### PR TITLE
Support state storage in the backend.

### DIFF
--- a/cmd/tailscale/ipn.go
+++ b/cmd/tailscale/ipn.go
@@ -44,15 +44,14 @@ func main() {
 		log.Printf("fixConsoleOutput: %v\n", err)
 	}
 	config := getopt.StringLong("config", 'f', "", "path to config file")
-	statekey := getopt.StringLong("statekey", 0, "", "state key for daemon-side config")
 	server := getopt.StringLong("server", 's', "https://login.tailscale.com", "URL to tailcontrol server")
 	nuroutes := getopt.BoolLong("no-single-routes", 'N', "disallow (non-subnet) routes to single nodes")
 	rroutes := getopt.BoolLong("remote-routes", 'R', "allow routing subnets to remote nodes")
 	droutes := getopt.BoolLong("default-routes", 'D', "allow default route on remote node")
 	getopt.Parse()
-	if *config == "" && *statekey == "" {
+	if *config == "" {
 		logpolicy.New("tailnode.log.tailscale.io", "tailscale")
-		log.Fatal("no --config or --statekey provided")
+		log.Fatal("no --config provided")
 	}
 	if len(getopt.Args()) > 0 {
 		log.Fatalf("too many non-flag arguments: %#v", getopt.Args()[0])
@@ -61,20 +60,17 @@ func main() {
 	pol := logpolicy.New("tailnode.log.tailscale.io", *config)
 	defer pol.Close()
 
-	var prefs *ipn.Prefs
-	if *config != "" {
-		localCfg, err := loadConfig(*config)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		// TODO(apenwarr): fix different semantics between prefs and uflags
-		// TODO(apenwarr): allow setting/using CorpDNS
-		prefs = &localCfg
-		prefs.WantRunning = true
-		prefs.RouteAll = *rroutes || *droutes
-		prefs.AllowSingleHosts = !*nuroutes
+	localCfg, err := loadConfig(*config)
+	if err != nil {
+		log.Fatal(err)
 	}
+
+	// TODO(apenwarr): fix different semantics between prefs and uflags
+	// TODO(apenwarr): allow setting/using CorpDNS
+	prefs := &localCfg
+	prefs.WantRunning = true
+	prefs.RouteAll = *rroutes || *droutes
+	prefs.AllowSingleHosts = !*nuroutes
 
 	c, err := safesocket.Connect("", "Tailscale", "tailscaled", 41112)
 	if err != nil {
@@ -95,7 +91,6 @@ func main() {
 
 	bc := ipn.NewBackendClient(log.Printf, clientToServer)
 	opts := ipn.Options{
-		StateKey:  ipn.StateKey(*statekey),
 		Prefs:     prefs,
 		ServerURL: *server,
 		Notify: func(n ipn.Notify) {

--- a/cmd/tailscale/ipn.go
+++ b/cmd/tailscale/ipn.go
@@ -90,7 +90,7 @@ func main() {
 
 	bc := ipn.NewBackendClient(log.Printf, clientToServer)
 	opts := ipn.Options{
-		Prefs:     prefs,
+		Prefs:     &prefs,
 		ServerURL: *server,
 		Notify: func(n ipn.Notify) {
 			log.Printf("Notify: %v\n", n)

--- a/cmd/tailscaled/ipnd.go
+++ b/cmd/tailscaled/ipnd.go
@@ -28,6 +28,7 @@ func main() {
 	debug := getopt.StringLong("debug", 0, "", "Address of debug server")
 	tunname := getopt.StringLong("tun", 0, "ts0", "tunnel interface name")
 	listenport := getopt.Uint16Long("port", 'p', magicsock.DefaultPort, "WireGuard port (0=autoselect)")
+	statepath := getopt.StringLong("state", 0, "", "Path of state file")
 
 	logf := wgengine.RusagePrefixLog(log.Printf)
 
@@ -58,6 +59,7 @@ func main() {
 	e = wgengine.NewWatchdog(e)
 
 	opts := ipnserver.Options{
+		StatePath:          *statepath,
 		SurviveDisconnects: true,
 		AllowQuit:          false,
 	}

--- a/ipn/backend.go
+++ b/ipn/backend.go
@@ -66,15 +66,13 @@ type Notify struct {
 // to the backend. That way, while we can't identify an OS user by
 // name, we can tell two different users apart, because they'll have
 // different opaque state keys (and no access to each others's keys).
-//
-// It would be much nicer if we could just figure out the OS user that
-// owns the connected frontend, but here we are.
 type StateKey string
 
 type Options struct {
 	// FrontendLogID is the public logtail id used by the frontend.
 	FrontendLogID string
-	// ServerURL is the base URL of the tailcontrol server to talk to.
+	// ServerURL is the base URL of the tailcontrol server to talk
+	// to. Required.
 	ServerURL string
 	// StateKey and Prefs together define the state the backend should
 	// use:

--- a/ipn/backend.go
+++ b/ipn/backend.go
@@ -53,7 +53,7 @@ type Notify struct {
 type Options struct {
 	FrontendLogID string // public logtail id used by frontend
 	ServerURL     string
-	Prefs         Prefs
+	Prefs         *Prefs
 	Notify        func(n Notify) `json:"-"`
 }
 

--- a/ipn/backend.go
+++ b/ipn/backend.go
@@ -72,9 +72,9 @@ type Notify struct {
 type StateKey string
 
 type Options struct {
-	// Public logtail id used by frontend.
+	// FrontendLogID is the public logtail id used by the frontend.
 	FrontendLogID string
-	// Base URL for the tailcontrol server to talk to.
+	// ServerURL is the base URL of the tailcontrol server to talk to.
 	ServerURL string
 	// StateKey and Prefs together define the state the backend should
 	// use:
@@ -86,27 +86,32 @@ type Options struct {
 	//    an initial overwrite of backend state with Prefs.
 	StateKey StateKey
 	Prefs    *Prefs
-	// Callback for backend events.
+	// Notify is called when backend events happen.
 	Notify func(Notify) `json:"-"`
 }
 
 type Backend interface {
 	// Start or restart the backend, because a new Handle has connected.
 	Start(opts Options) error
-	// Start a new interactive login. This should trigger a new
-	// BrowseToURL notification eventually.
+	// StartLoginInteractive requests to start a new interactive login
+	// flow. This should trigger a new BrowseToURL notification
+	// eventually.
 	StartLoginInteractive()
-	// Terminate the current login session and stop the wireguard engine.
+	// Logout terminates the current login session and stop the
+	// wireguard engine.
 	Logout()
-	// Install a new set of user preferences, including WantRunning.
-	// This may cause the wireguard engine to reconfigure or stop.
+	// SetPrefs install a new set of user preferences, including
+	// WantRunning.  This may cause the wireguard engine to
+	// reconfigure or stop.
 	SetPrefs(new Prefs)
-	// Poll for an update from the wireguard engine. Only needed if
-	// you want to display byte counts. Connection events are emitted
-	// automatically without polling.
+	// RequestEngineStatus polls for an update from the wireguard
+	// engine. Only needed if you want to display byte
+	// counts. Connection events are emitted automatically without
+	// polling.
 	RequestEngineStatus()
-	// Pretend the current key is going to expire after duration x.
-	// This is useful for testing GUIs to make sure they react properly
-	// with keys that are going to expire.
+	// FakeExpireAfter pretends that the current key is going to
+	// expire after duration x. This is useful for testing GUIs to
+	// make sure they react properly with keys that are going to
+	// expire.
 	FakeExpireAfter(x time.Duration)
 }

--- a/ipn/backend.go
+++ b/ipn/backend.go
@@ -5,10 +5,11 @@
 package ipn
 
 import (
+	"time"
+
 	"tailscale.com/control/controlclient"
 	"tailscale.com/tailcfg"
 	"tailscale.com/wgengine"
-	"time"
 )
 
 type State int
@@ -53,7 +54,6 @@ type Options struct {
 	FrontendLogID string // public logtail id used by frontend
 	ServerURL     string
 	Prefs         Prefs
-	LoginFlags    controlclient.LoginFlags
 	Notify        func(n Notify) `json:"-"`
 }
 

--- a/ipn/e2e_test.go
+++ b/ipn/e2e_test.go
@@ -170,7 +170,7 @@ func newNode(t *testing.T, prefix string, https *httptest.Server) testNode {
 	n.Start(Options{
 		FrontendLogID: prefix + "-f",
 		ServerURL:     https.URL,
-		Prefs: Prefs{
+		Prefs: &Prefs{
 			RouteAll:         true,
 			AllowSingleHosts: true,
 			CorpDNS:          true,

--- a/ipn/e2e_test.go
+++ b/ipn/e2e_test.go
@@ -177,7 +177,6 @@ func newNode(t *testing.T, prefix string, https *httptest.Server) testNode {
 			WantRunning:      true,
 			Persist:          &c,
 		},
-		LoginFlags: controlclient.LoginDefault,
 		Notify: func(n Notify) {
 			// Automatically visit auth URLs
 			if n.BrowseToURL != nil {

--- a/ipn/e2e_test.go
+++ b/ipn/e2e_test.go
@@ -158,7 +158,7 @@ func newNode(t *testing.T, prefix string, https *httptest.Server) testNode {
 	if err != nil {
 		t.Fatalf("NewFakeEngine: %v\n", err)
 	}
-	n, err := NewLocalBackend(logf, prefix, e1)
+	n, err := NewLocalBackend(logf, prefix, &MemoryStore{}, e1)
 	if err != nil {
 		t.Fatalf("NewLocalBackend: %v\n", err)
 	}

--- a/ipn/fake.go
+++ b/ipn/fake.go
@@ -21,7 +21,7 @@ func (b *FakeBackend) Start(opts Options) error {
 		log.Fatalf("FakeBackend.Start: opts.Notify is nil\n")
 	}
 	b.notify = opts.Notify
-	b.notify(Notify{Prefs: &opts.Prefs})
+	b.notify(Notify{Prefs: opts.Prefs})
 	nl := NeedsLogin
 	b.notify(Notify{State: &nl})
 	return nil

--- a/ipn/handle.go
+++ b/ipn/handle.go
@@ -49,7 +49,9 @@ func (h *Handle) Start(opts Options) error {
 	h.netmapCache = nil
 	h.engineStatusCache = EngineStatus{}
 	h.stateCache = NoState
-	h.prefsCache = opts.Prefs
+	if opts.Prefs != nil {
+		h.prefsCache = *opts.Prefs
+	}
 	xopts := opts
 	xopts.Notify = h.notify
 	return h.b.Start(xopts)

--- a/ipn/ipnserver/server.go
+++ b/ipn/ipnserver/server.go
@@ -29,6 +29,7 @@ import (
 )
 
 type Options struct {
+	StatePath          string
 	SurviveDisconnects bool
 	AllowQuit          bool
 }
@@ -58,7 +59,17 @@ func Run(rctx context.Context, logf logger.Logf, logid string, opts Options, e w
 		return fmt.Errorf("safesocket.Listen: %v", err)
 	}
 
-	b, err := ipn.NewLocalBackend(logf, logid, e)
+	var store ipn.StateStore
+	if opts.StatePath != "" {
+		store, err = ipn.NewFileStore(opts.StatePath)
+		if err != nil {
+			return fmt.Errorf("ipn.NewFileStore(%q): %v", opts.StatePath, err)
+		}
+	} else {
+		store = &ipn.MemoryStore{}
+	}
+
+	b, err := ipn.NewLocalBackend(logf, logid, store, e)
 	if err != nil {
 		return fmt.Errorf("NewLocalBackend: %v", err)
 	}

--- a/ipn/local.go
+++ b/ipn/local.go
@@ -253,7 +253,7 @@ func (b *LocalBackend) Start(opts Options) error {
 	b.logf("Backend: logs: be:%v fe:%v\n", blid, opts.FrontendLogID)
 	b.send(Notify{BackendLogID: &blid})
 
-	cli.Login(nil, opts.LoginFlags)
+	cli.Login(nil, controlclient.LoginDefault)
 	return nil
 }
 

--- a/ipn/local.go
+++ b/ipn/local.go
@@ -53,7 +53,6 @@ type LocalBackend struct {
 }
 
 func NewLocalBackend(logf logger.Logf, logid string, e wgengine.Engine) (*LocalBackend, error) {
-
 	if e == nil {
 		panic("ipn.NewLocalBackend: wgengine must not be nil")
 	}
@@ -114,6 +113,10 @@ func (b *LocalBackend) SetCmpDiff(cmpDiff func(x, y interface{}) string) {
 }
 
 func (b *LocalBackend) Start(opts Options) error {
+	if opts.Prefs == nil {
+		panic("Prefs can't be nil yet")
+	}
+
 	if b.c != nil {
 		// TODO(apenwarr): avoid the need to reinit controlclient.
 		// This will trigger a full relogin/reconfigure cycle every
@@ -136,7 +139,9 @@ func (b *LocalBackend) Start(opts Options) error {
 	b.hiCache = hi
 	b.state = NoState
 	b.serverURL = opts.ServerURL
-	b.prefs = opts.Prefs
+	if opts.Prefs != nil {
+		b.prefs = *opts.Prefs
+	}
 	b.notify = opts.Notify
 	b.netMapCache = nil
 	b.mu.Unlock()

--- a/ipn/message_test.go
+++ b/ipn/message_test.go
@@ -96,6 +96,7 @@ func TestClientServer(t *testing.T) {
 	ch := make(chan Notify, 256)
 	h, err := NewHandle(bc, clogf, Options{
 		ServerURL: "http://example.com/fake",
+		Prefs:     &Prefs{},
 		Notify: func(n Notify) {
 			ch <- n
 		},

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -103,7 +103,7 @@ func (uc *Prefs) Copy() *Prefs {
 	return &uc2
 }
 
-func LoadPrefs(filename string, enforceDefaults bool) Prefs {
+func LoadPrefs(filename string, enforceDefaults bool) *Prefs {
 	log.Printf("Loading prefs %v\n", filename)
 	data, err := ioutil.ReadFile(filename)
 	uc := NewPrefs()
@@ -136,7 +136,7 @@ post:
 		uc.WantRunning = true
 	}
 	log.Printf("Loaded prefs %v %v\n", filename, uc.Pretty())
-	return uc
+	return &uc
 }
 
 func SavePrefs(filename string, uc *Prefs) {

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -33,6 +33,9 @@ type Prefs struct {
 	Persist *controlclient.Persist `json:"Config"`
 }
 
+// IsEmpty reports whether p is nil or pointing to a Prefs zero value.
+func (uc *Prefs) IsEmpty() bool { return uc == nil || *uc == Prefs{} }
+
 func (uc *Prefs) Pretty() string {
 	var ucp string
 	if uc.Persist != nil {

--- a/ipn/store.go
+++ b/ipn/store.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ipn
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"os"
+	"sync"
+
+	"tailscale.com/atomicfile"
+)
+
+// ErrStateNotExist is returned by StateStore.ReadState when the
+// requested state id doesn't exist.
+var ErrStateNotExist = errors.New("no state with given id")
+
+// StateStore persists state, and produces it back on request.
+type StateStore interface {
+	// ReadState returns the bytes associated with id. Returns (nil,
+	// ErrStateNotExist) if the id doesn't have associated state.
+	ReadState(id StateKey) ([]byte, error)
+	// WriteState saves bs as the state associated with id.
+	WriteState(id StateKey, bs []byte) error
+}
+
+// MemoryStore is a store that keeps state in memory only.
+type MemoryStore struct {
+	mu    sync.Mutex
+	cache map[StateKey][]byte
+}
+
+func (s *MemoryStore) ReadState(id StateKey) ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.cache == nil {
+		s.cache = map[StateKey][]byte{}
+	}
+	bs, ok := s.cache[id]
+	if !ok {
+		return nil, ErrStateNotExist
+	}
+	return bs, nil
+}
+
+func (s *MemoryStore) WriteState(id StateKey, bs []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.cache == nil {
+		s.cache = map[StateKey][]byte{}
+	}
+	s.cache[id] = append([]byte(nil), bs...)
+	return nil
+}
+
+// FileStore is a StateStore that uses a JSON file for persistence.
+type FileStore struct {
+	path string
+
+	mu    sync.RWMutex
+	cache map[StateKey][]byte
+}
+
+// NewFileStore returns a new file store that persists to path.
+func NewFileStore(path string) (*FileStore, error) {
+	bs, err := ioutil.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Write out an initial file, to verify that we can write
+			// to the path.
+			if err = atomicfile.WriteFile(path, []byte("{}"), 0600); err != nil {
+				return nil, err
+			}
+			return &FileStore{
+				path:  path,
+				cache: map[StateKey][]byte{},
+			}, nil
+		}
+		return nil, err
+	}
+
+	ret := &FileStore{
+		path:  path,
+		cache: map[StateKey][]byte{},
+	}
+	if err := json.Unmarshal(bs, &ret.cache); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// ReadState returns the bytes persisted for id, if any.
+func (s *FileStore) ReadState(id StateKey) ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	bs, ok := s.cache[id]
+	if !ok {
+		return nil, ErrStateNotExist
+	}
+	return bs, nil
+}
+
+// WriteState persists bs under the key id.
+func (s *FileStore) WriteState(id StateKey, bs []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cache[id] = append([]byte(nil), bs...)
+	bs, err := json.MarshalIndent(s.cache, "", "  ")
+	if err != nil {
+		return err
+	}
+	return atomicfile.WriteFile(s.path, bs, 0600)
+}

--- a/ipn/store.go
+++ b/ipn/store.go
@@ -15,15 +15,15 @@ import (
 )
 
 // ErrStateNotExist is returned by StateStore.ReadState when the
-// requested state id doesn't exist.
-var ErrStateNotExist = errors.New("no state with given id")
+// requested state ID doesn't exist.
+var ErrStateNotExist = errors.New("no state with given ID")
 
 // StateStore persists state, and produces it back on request.
 type StateStore interface {
-	// ReadState returns the bytes associated with id. Returns (nil,
-	// ErrStateNotExist) if the id doesn't have associated state.
+	// ReadState returns the bytes associated with ID. Returns (nil,
+	// ErrStateNotExist) if the ID doesn't have associated state.
 	ReadState(id StateKey) ([]byte, error)
-	// WriteState saves bs as the state associated with id.
+	// WriteState saves bs as the state associated with ID.
 	WriteState(id StateKey, bs []byte) error
 }
 
@@ -33,6 +33,7 @@ type MemoryStore struct {
 	cache map[StateKey][]byte
 }
 
+// ReadState implements the StateStore interface.
 func (s *MemoryStore) ReadState(id StateKey) ([]byte, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -46,6 +47,7 @@ func (s *MemoryStore) ReadState(id StateKey) ([]byte, error) {
 	return bs, nil
 }
 
+// WriteState implements the StateStore interface.
 func (s *MemoryStore) WriteState(id StateKey, bs []byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -93,7 +95,7 @@ func NewFileStore(path string) (*FileStore, error) {
 	return ret, nil
 }
 
-// ReadState returns the bytes persisted for id, if any.
+// ReadState implements the StateStore interface.
 func (s *FileStore) ReadState(id StateKey) ([]byte, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -104,7 +106,7 @@ func (s *FileStore) ReadState(id StateKey) ([]byte, error) {
 	return bs, nil
 }
 
-// WriteState persists bs under the key id.
+// WriteState implements the StateStore interface.
 func (s *FileStore) WriteState(id StateKey, bs []byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/ipn/store_test.go
+++ b/ipn/store_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ipn
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func testStoreSemantics(t *testing.T, store StateStore) {
+	t.Helper()
+
+	tests := []struct {
+		// if true, data is data to write. If false, data is expected
+		// output of read.
+		write bool
+		id    StateKey
+		data  string
+		// If write=false, true if we expect a not-exist error.
+		notExists bool
+	}{
+		{
+			id:        "foo",
+			notExists: true,
+		},
+		{
+			write: true,
+			id:    "foo",
+			data:  "bar",
+		},
+		{
+			id:   "foo",
+			data: "bar",
+		},
+		{
+			id:        "baz",
+			notExists: true,
+		},
+		{
+			write: true,
+			id:    "baz",
+			data:  "quux",
+		},
+		{
+			id:   "foo",
+			data: "bar",
+		},
+		{
+			id:   "baz",
+			data: "quux",
+		},
+	}
+
+	for _, test := range tests {
+		if test.write {
+			if err := store.WriteState(test.id, []byte(test.data)); err != nil {
+				t.Errorf("writing %q to %q: %v", test.data, test.id, err)
+			}
+		} else {
+			bs, err := store.ReadState(test.id)
+			if err != nil {
+				if test.notExists && err == ErrStateNotExist {
+					continue
+				}
+				t.Errorf("reading %q: %v", test.id, err)
+				continue
+			}
+			if string(bs) != test.data {
+				t.Errorf("reading %q: got %q, want %q", test.id, string(bs), test.data)
+			}
+		}
+	}
+}
+
+func TestMemoryStore(t *testing.T) {
+	store := &MemoryStore{}
+	testStoreSemantics(t, store)
+}
+
+func TestFileStore(t *testing.T) {
+	f, err := ioutil.TempFile("", "test_ipn_store")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := f.Name()
+	f.Close()
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := NewFileStore(path)
+	if err != nil {
+		t.Fatalf("creating file store failed: %v", err)
+	}
+
+	testStoreSemantics(t, store)
+
+	// Build a brand new file store and check that both IDs written
+	// above are still there.
+	store, err = NewFileStore(path)
+	if err != nil {
+		t.Fatalf("creating second file store failed: %v", err)
+	}
+
+	expected := map[StateKey]string{
+		"foo": "bar",
+		"baz": "quux",
+	}
+	for id, want := range expected {
+		bs, err := store.ReadState(id)
+		if err != nil {
+			t.Errorf("reading %q (2nd store): %v", id, err)
+		}
+		if string(bs) != want {
+			t.Errorf("reading %q (2nd store): got %q, want %q", id, string(bs), want)
+		}
+	}
+}


### PR DESCRIPTION
In our current codebase, the agent frontend (e.g. CLI, windows UI) owns a user's state and passes it in on startup. There were good reasons for that on Windows, due to limitations of the OS's IPC mechanisms. However, we've decided we need to move the state into the backend.

This change adds support for owned state in LocalBackend, as well as a file-based implementation that `tailscaled` can use. Frontends can choose whether LocalBackend will use purely frontend state, purely backend state, or import frontend state into the backend before use (as a migration path for existing machine keys).

Other existing frontends (Windows, MacOS, iOS UIs) are unchanged for the moment, and continue to pass in state owned by the frontend.