### PR TITLE
debian: fix changelog generation.

### DIFF
--- a/cmd/relaynode/debian/gen-changelog
+++ b/cmd/relaynode/debian/gen-changelog
@@ -18,7 +18,7 @@ def Describe(g):
     first = False
   else:
     sha = g.group(1)
-    s = subprocess.check_output(["git", "describe", "--", sha]).strip().decode("utf-8")
+    s = subprocess.check_output(["git", "describe", "--always", "--", sha]).strip().decode("utf-8")
   return re.sub(r"^\D*", "", s)
 
 print(re.sub(r"SHA:([0-9a-f]+)", Describe, sys.stdin.read()))


### PR DESCRIPTION
It seems changelog generation got broken by moving the code between
corp and OSS repos, because one of the commit SHAs doesn't have an
associated tag.

In the interest of fixing the build, and because we're not yet trying
to upstream the debian package, I fixed this by allowing hash-based
versions to show up in the changelog. This maybe wrong from a
debian standards perspective, but for our current point in life
it'll work until we learn to do it better.