### PR TITLE
wgengine: move link monitor to be owned by the engine, not the router

### DIFF
--- a/wgengine/monitor/monitor.go
+++ b/wgengine/monitor/monitor.go
@@ -2,27 +2,33 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build linux freebsd
-
 // Package monitor provides facilities for monitoring network
 // interface changes.
 package monitor
 
 import (
+	"sync"
 	"time"
 
 	"tailscale.com/types/logger"
 )
 
-// Message represents a message returned from a connection.
-// TODO(]|[): currently messages are being discarded, so the
-// properties of the message haven't been defined.
-type Message interface{}
+// message represents a message returned from an osMon.
+//
+// TODO: currently messages are being discarded, so the properties of
+// the message haven't been defined.
+type message interface{}
 
-// Conn represents the connection that is being monitored.
-type Conn interface {
+// osMon is the interface that each operating system-specific
+// implementation of the link monitor must implement.
+type osMon interface {
 	Close() error
-	Receive() (Message, error)
+
+	// Receive returns a new network interface change message. It
+	// should block until there's either something to return, or
+	// until the osMon is closed. After a Close, the returned
+	// error is ignored.
+	Receive() (message, error)
 }
 
 // ChangeFunc is a callback function that's called when
@@ -33,41 +39,68 @@ type ChangeFunc func()
 type Mon struct {
 	logf   logger.Logf
 	cb     ChangeFunc
-	conn   Conn
+	om     osMon // nil means not supported on this platform
 	change chan struct{}
 	stop   chan struct{}
+
+	onceStart  sync.Once
+	started    bool
+	goroutines sync.WaitGroup
 }
 
 // New instantiates and starts a monitoring instance. Change notifications
 // are propagated to the callback function.
+// The returned monitor is inactive until it's started by the Start method.
 func New(logf logger.Logf, callback ChangeFunc) (*Mon, error) {
-	conn, err := NewConn()
+	om, err := newOSMon()
 	if err != nil {
 		return nil, err
 	}
-	ret := &Mon{
+	return &Mon{
 		logf:   logf,
 		cb:     callback,
-		conn:   conn,
+		om:     om,
 		change: make(chan struct{}, 1),
 		stop:   make(chan struct{}),
-	}
-	go ret.pump()
-	go ret.debounce()
-	return ret, nil
+	}, nil
 }
 
-// Close is used to close the underlying connection.
+// Start starts the monitor.
+// A monitor can only be started & closed once.
+func (m *Mon) Start() {
+	m.onceStart.Do(func() {
+		if m.om == nil {
+			return
+		}
+		m.started = true
+		m.goroutines.Add(2)
+		go m.pump()
+		go m.debounce()
+	})
+}
+
+// Close closes the monitor.
+// It may only be called once.
 func (m *Mon) Close() error {
 	close(m.stop)
-	return m.conn.Close()
+	var err error
+	if m.om != nil {
+		err = m.om.Close()
+	}
+	// If it was previously started, wait for those goroutines to finish.
+	m.onceStart.Do(func() {})
+	if m.started {
+		m.goroutines.Wait()
+	}
+	return err
 }
 
 // pump continuously retrieves messages from the connection, notifying
 // the change channel of changes, and stopping when a stop is issued.
 func (m *Mon) pump() {
+	defer m.goroutines.Done()
 	for {
-		_, err := m.conn.Receive()
+		_, err := m.om.Receive()
 		if err != nil {
 			select {
 			case <-m.stop:
@@ -90,6 +123,7 @@ func (m *Mon) pump() {
 // debounce calls the callback function with a delay between events
 // and exits when a stop is issued.
 func (m *Mon) debounce() {
+	defer m.goroutines.Done()
 	for {
 		select {
 		case <-m.stop:

--- a/wgengine/monitor/monitor_freebsd.go
+++ b/wgengine/monitor/monitor_freebsd.go
@@ -11,11 +11,12 @@ import (
 	"strings"
 )
 
+// devdConn implements osMon using devd(8).
 type devdConn struct {
 	conn net.Conn
 }
 
-func NewConn() (Conn, error) {
+func newOSMon() (osMon, error) {
 	conn, err := net.Dial("unixpacket", "/var/run/devd.seqpacket.pipe")
 	if err != nil {
 		return nil, fmt.Errorf("devd dial error: %v", err)
@@ -30,7 +31,7 @@ func (c *devdConn) Close() error {
 	return c.conn.Close()
 }
 
-func (c *devdConn) Receive() (Message, error) {
+func (c *devdConn) Receive() (message, error) {
 	for {
 		msg, err := bufio.NewReader(c.conn).ReadString('\n')
 		if err != nil {

--- a/wgengine/monitor/monitor_linux.go
+++ b/wgengine/monitor/monitor_linux.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	RTMGRP_IPV4_IFADDR = 0x10
-	RTMGRP_IPV4_ROUTE  = 0x40
+	_RTMGRP_IPV4_IFADDR = 0x10
+	_RTMGRP_IPV4_ROUTE  = 0x40
 )
 
 // nlConn wraps a *netlink.Conn and returns a monitor.Message
@@ -25,7 +25,7 @@ type nlConn struct {
 	conn *netlink.Conn
 }
 
-func NewConn() (Conn, error) {
+func newOSMon() (osMon, error) {
 	conn, err := netlink.Dial(unix.NETLINK_ROUTE, &netlink.Config{
 		// IPv4 address and route changes. Routes get us most of the
 		// events of interest, but we need address as well to cover
@@ -36,7 +36,7 @@ func NewConn() (Conn, error) {
 		// Why magic numbers? These aren't exposed in x/sys/unix
 		// yet. The values come from rtnetlink.h, RTMGRP_IPV4_IFADDR
 		// and RTMGRP_IPV4_ROUTE.
-		Groups: RTMGRP_IPV4_IFADDR | RTMGRP_IPV4_ROUTE,
+		Groups: _RTMGRP_IPV4_IFADDR | _RTMGRP_IPV4_ROUTE,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("dialing netlink socket: %v", err)
@@ -48,7 +48,7 @@ func (c *nlConn) Close() error {
 	return c.conn.Close()
 }
 
-func (c *nlConn) Receive() (Message, error) {
+func (c *nlConn) Receive() (message, error) {
 	// currently ignoring the message
 	_, err := c.conn.Receive()
 	if err != nil {

--- a/wgengine/monitor/monitor_unsupported.go
+++ b/wgengine/monitor/monitor_unsupported.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !linux,!freebsd
+
+package monitor
+
+func newOSMon() (osMon, error) { return nil, nil }

--- a/wgengine/router_bsd.go
+++ b/wgengine/router_bsd.go
@@ -34,7 +34,7 @@ type bsdRouter struct {
 	routes  map[wgcfg.CIDR]struct{}
 }
 
-func newUserspaceRouter(logf logger.Logf, _ *device.Device, tundev tun.Device, _ func()) (Router, error) {
+func newUserspaceRouter(logf logger.Logf, _ *device.Device, tundev tun.Device) (Router, error) {
 	tunname, err := tundev.Name()
 	if err != nil {
 		return nil, err

--- a/wgengine/router_darwin.go
+++ b/wgengine/router_darwin.go
@@ -14,7 +14,7 @@ type darwinRouter struct {
 	tunname string
 }
 
-func newUserspaceRouter(logf logger.Logf, _ *device.Device, tundev tun.Device, netChanged func()) (Router, error) {
+func newUserspaceRouter(logf logger.Logf, _ *device.Device, tundev tun.Device) (Router, error) {
 	tunname, err := tundev.Name()
 	if err != nil {
 		return nil, err

--- a/wgengine/router_fake.go
+++ b/wgengine/router_fake.go
@@ -12,7 +12,7 @@ import (
 
 // NewFakeRouter returns a new fake Router implementation whose
 // implementation does nothing and always returns nil errors.
-func NewFakeRouter(logf logger.Logf, _ *device.Device, _ tun.Device, netChanged func()) (Router, error) {
+func NewFakeRouter(logf logger.Logf, _ *device.Device, _ tun.Device) (Router, error) {
 	return fakeRouter{logf: logf}, nil
 }
 

--- a/wgengine/router_windows.go
+++ b/wgengine/router_windows.go
@@ -21,7 +21,7 @@ type winRouter struct {
 	routeChangeCallback *winipcfg.RouteChangeCallback
 }
 
-func newUserspaceRouter(logf logger.Logf, wgdev *device.Device, tundev tun.Device, netChanged func()) (Router, error) {
+func newUserspaceRouter(logf logger.Logf, wgdev *device.Device, tundev tun.Device) (Router, error) {
 	tunname, err := tundev.Name()
 	if err != nil {
 		return nil, err

--- a/wgengine/wgengine.go
+++ b/wgengine/wgengine.go
@@ -62,13 +62,13 @@ func (rs *RouteSettings) OnlyRelevantParts() string {
 }
 
 // NewUserspaceRouter returns a new Router for the current platform, using the provided tun device.
-func NewUserspaceRouter(logf logger.Logf, wgdev *device.Device, tundev tun.Device, netChanged func()) (Router, error) {
-	return newUserspaceRouter(logf, wgdev, tundev, netChanged)
+func NewUserspaceRouter(logf logger.Logf, wgdev *device.Device, tundev tun.Device) (Router, error) {
+	return newUserspaceRouter(logf, wgdev, tundev)
 }
 
 // RouterGen is the signature for the two funcs that create Router implementations:
 // NewUserspaceRouter (which varies by operating system) and NewFakeRouter.
-type RouterGen func(logf logger.Logf, wgdev *device.Device, tundev tun.Device, netStateChanged func()) (Router, error)
+type RouterGen func(logf logger.Logf, wgdev *device.Device, tundev tun.Device) (Router, error)
 
 // Router is responsible for managing the system route table.
 //


### PR DESCRIPTION
And make the monitor package portable with no-op implementations on
unsupported operating systems.