### PR TITLE
ipn: add AdvertiseRoutes to Prefs.

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -39,6 +39,21 @@ type Persist struct {
 	LoginName         string
 }
 
+func (p *Persist) Equals(p2 *Persist) bool {
+	if p == nil && p2 == nil {
+		return true
+	}
+	if p == nil || p2 == nil {
+		return false
+	}
+
+	return p.PrivateMachineKey.Equal(p2.PrivateMachineKey) &&
+		p.PrivateNodeKey.Equal(p2.PrivateNodeKey) &&
+		p.OldPrivateNodeKey.Equal(p2.OldPrivateNodeKey) &&
+		p.Provider == p2.Provider &&
+		p.LoginName == p2.LoginName
+}
+
 func (p *Persist) Pretty() string {
 	var mk, ok, nk wgcfg.Key
 	if !p.PrivateMachineKey.IsZero() {

--- a/control/controlclient/persist_test.go
+++ b/control/controlclient/persist_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package controlclient
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/tailscale/wireguard-go/wgcfg"
+)
+
+func TestPersistEqual(t *testing.T) {
+	persistHandles := []string{"PrivateMachineKey", "PrivateNodeKey", "OldPrivateNodeKey", "Provider", "LoginName"}
+	if have := fieldsOf(reflect.TypeOf(Persist{})); !reflect.DeepEqual(have, persistHandles) {
+		t.Errorf("Persist.Equal check might be out of sync\nfields: %q\nhandled: %q\n",
+			have, persistHandles)
+	}
+
+	newPrivate := func() wgcfg.PrivateKey {
+		k, err := wgcfg.NewPrivateKey()
+		if err != nil {
+			panic(err)
+		}
+		return k
+	}
+	k1 := newPrivate()
+	tests := []struct {
+		a, b *Persist
+		want bool
+	}{
+		{nil, nil, true},
+		{nil, &Persist{}, false},
+		{&Persist{}, nil, false},
+		{&Persist{}, &Persist{}, true},
+
+		{
+			&Persist{PrivateMachineKey: k1},
+			&Persist{PrivateMachineKey: newPrivate()},
+			false,
+		},
+		{
+			&Persist{PrivateMachineKey: k1},
+			&Persist{PrivateMachineKey: k1},
+			true,
+		},
+
+		{
+			&Persist{PrivateNodeKey: k1},
+			&Persist{PrivateNodeKey: newPrivate()},
+			false,
+		},
+		{
+			&Persist{PrivateNodeKey: k1},
+			&Persist{PrivateNodeKey: k1},
+			true,
+		},
+
+		{
+			&Persist{OldPrivateNodeKey: k1},
+			&Persist{OldPrivateNodeKey: newPrivate()},
+			false,
+		},
+		{
+			&Persist{OldPrivateNodeKey: k1},
+			&Persist{OldPrivateNodeKey: k1},
+			true,
+		},
+
+		{
+			&Persist{Provider: "google"},
+			&Persist{Provider: "o365"},
+			false,
+		},
+		{
+			&Persist{Provider: "google"},
+			&Persist{Provider: "google"},
+			true,
+		},
+
+		{
+			&Persist{LoginName: "foo@tailscale.com"},
+			&Persist{LoginName: "bar@tailscale.com"},
+			false,
+		},
+		{
+			&Persist{LoginName: "foo@tailscale.com"},
+			&Persist{LoginName: "foo@tailscale.com"},
+			true,
+		},
+	}
+	for i, test := range tests {
+		if got := test.a.Equals(test.b); got != test.want {
+			t.Errorf("%d. Equals = %v; want %v", i, got, test.want)
+		}
+	}
+}

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net"
 	"os"
 	"path/filepath"
 
@@ -24,6 +25,7 @@ type Prefs struct {
 	WantRunning      bool
 	NotepadURLs      bool
 	UsePacketFilter  bool
+	AdvertiseRoutes  []*net.IPNet
 
 	// The Persist field is named 'Config' in the file for backward
 	// compatibility with earlier versions.
@@ -34,7 +36,7 @@ type Prefs struct {
 }
 
 // IsEmpty reports whether p is nil or pointing to a Prefs zero value.
-func (uc *Prefs) IsEmpty() bool { return uc == nil || *uc == Prefs{} }
+func (uc *Prefs) IsEmpty() bool { return uc == nil || uc.Equals(&Prefs{}) }
 
 func (uc *Prefs) Pretty() string {
 	var ucp string
@@ -43,9 +45,9 @@ func (uc *Prefs) Pretty() string {
 	} else {
 		ucp = "Persist=nil"
 	}
-	return fmt.Sprintf("Prefs{ra=%v mesh=%v dns=%v want=%v notepad=%v pf=%v %v}",
+	return fmt.Sprintf("Prefs{ra=%v mesh=%v dns=%v want=%v notepad=%v pf=%v routes=%v %v}",
 		uc.RouteAll, uc.AllowSingleHosts, uc.CorpDNS, uc.WantRunning,
-		uc.NotepadURLs, uc.UsePacketFilter, ucp)
+		uc.NotepadURLs, uc.UsePacketFilter, uc.AdvertiseRoutes, ucp)
 }
 
 func (uc *Prefs) ToBytes() []byte {

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -18,14 +18,39 @@ import (
 	"tailscale.com/control/controlclient"
 )
 
+// Prefs are the user modifiable settings of the Tailscale node agent.
 type Prefs struct {
-	RouteAll         bool
+	// RouteAll specifies whether to accept subnet and default routes
+	// advertised by other nodes on the Tailscale network.
+	RouteAll bool
+	// AllowSingleHosts specifies whether to install routes for each
+	// node IP on the tailscale network, in addition to a route for
+	// the whole network.
+	//
+	// TODO(danderson): why do we have this? It dumps a lot of stuff
+	// into the routing table, and a single network route _should_ be
+	// all that we need. But when I turn this off in my tailscaled,
+	// packets stop flowing. What's up with that?
 	AllowSingleHosts bool
-	CorpDNS          bool
-	WantRunning      bool
-	NotepadURLs      bool
-	UsePacketFilter  bool
-	AdvertiseRoutes  []*net.IPNet
+	// CorpDNS specifies whether to install the Tailscale network's
+	// DNS configuration, if it exists.
+	CorpDNS bool
+	// WantRunning indicates whether networking should be active on
+	// this node.
+	WantRunning bool
+	// UsePacketFilter indicates whether to enforce centralized ACLs
+	// on this node. If false, all traffic in and out of this node is
+	// allowed.
+	UsePacketFilter bool
+	// AdvertiseRoutes specifies CIDR prefixes to advertise into the
+	// Tailscale network as reachable through the current node.
+	AdvertiseRoutes []*net.IPNet
+
+	// NotepadURLs is a debugging setting that opens OAuth URLs in
+	// notepad.exe on Windows, rather than loading them in a browser.
+	//
+	// TODO(danderson): remove?
+	NotepadURLs bool
 
 	// The Persist field is named 'Config' in the file for backward
 	// compatibility with earlier versions.

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -20,7 +20,7 @@ func fieldsOf(t reflect.Type) (fields []string) {
 }
 
 func TestPrefsEqual(t *testing.T) {
-	prefsHandles := []string{"RouteAll", "AllowSingleHosts", "CorpDNS", "WantRunning", "NotepadURLs", "UsePacketFilter", "AdvertiseRoutes", "Persist"}
+	prefsHandles := []string{"RouteAll", "AllowSingleHosts", "CorpDNS", "WantRunning", "UsePacketFilter", "AdvertiseRoutes", "NotepadURLs", "Persist"}
 	if have := fieldsOf(reflect.TypeOf(Prefs{})); !reflect.DeepEqual(have, prefsHandles) {
 		t.Errorf("Prefs.Equal check might be out of sync\nfields: %q\nhandled: %q\n",
 			have, prefsHandles)

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -29,7 +29,7 @@ func checkPrefs(t *testing.T, p Prefs) {
 	}
 	p2 = p
 	p2.RouteAll = true
-	if p == p2 {
+	if p.Equals(&p2) {
 		t.Fatalf("p == p2\n")
 	}
 	p2b, err = PrefsFromBytes(p2.ToBytes(), false)

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -5,10 +5,167 @@
 package ipn
 
 import (
+	"net"
+	"reflect"
 	"testing"
 
 	"tailscale.com/control/controlclient"
 )
+
+func fieldsOf(t reflect.Type) (fields []string) {
+	for i := 0; i < t.NumField(); i++ {
+		fields = append(fields, t.Field(i).Name)
+	}
+	return
+}
+
+func TestPrefsEqual(t *testing.T) {
+	prefsHandles := []string{"RouteAll", "AllowSingleHosts", "CorpDNS", "WantRunning", "NotepadURLs", "UsePacketFilter", "AdvertiseRoutes", "Persist"}
+	if have := fieldsOf(reflect.TypeOf(Prefs{})); !reflect.DeepEqual(have, prefsHandles) {
+		t.Errorf("Prefs.Equal check might be out of sync\nfields: %q\nhandled: %q\n",
+			have, prefsHandles)
+	}
+
+	nets := func(strs ...string) (ns []*net.IPNet) {
+		for _, s := range strs {
+			_, n, err := net.ParseCIDR(s)
+			if err != nil {
+				panic(err)
+			}
+			ns = append(ns, n)
+		}
+		return ns
+	}
+	tests := []struct {
+		a, b *Prefs
+		want bool
+	}{
+		{
+			&Prefs{},
+			nil,
+			false,
+		},
+		{
+			nil,
+			&Prefs{},
+			false,
+		},
+		{
+			&Prefs{},
+			&Prefs{},
+			true,
+		},
+
+		{
+			&Prefs{RouteAll: true},
+			&Prefs{RouteAll: false},
+			false,
+		},
+		{
+			&Prefs{RouteAll: true},
+			&Prefs{RouteAll: true},
+			true,
+		},
+
+		{
+			&Prefs{AllowSingleHosts: true},
+			&Prefs{AllowSingleHosts: false},
+			false,
+		},
+		{
+			&Prefs{AllowSingleHosts: true},
+			&Prefs{AllowSingleHosts: true},
+			true,
+		},
+
+		{
+			&Prefs{CorpDNS: true},
+			&Prefs{CorpDNS: false},
+			false,
+		},
+		{
+			&Prefs{CorpDNS: true},
+			&Prefs{CorpDNS: true},
+			true,
+		},
+
+		{
+			&Prefs{WantRunning: true},
+			&Prefs{WantRunning: false},
+			false,
+		},
+		{
+			&Prefs{WantRunning: true},
+			&Prefs{WantRunning: true},
+			true,
+		},
+
+		{
+			&Prefs{NotepadURLs: true},
+			&Prefs{NotepadURLs: false},
+			false,
+		},
+		{
+			&Prefs{NotepadURLs: true},
+			&Prefs{NotepadURLs: true},
+			true,
+		},
+
+		{
+			&Prefs{UsePacketFilter: true},
+			&Prefs{UsePacketFilter: false},
+			false,
+		},
+		{
+			&Prefs{UsePacketFilter: true},
+			&Prefs{UsePacketFilter: true},
+			true,
+		},
+
+		{
+			&Prefs{AdvertiseRoutes: nil},
+			&Prefs{AdvertiseRoutes: []*net.IPNet{}},
+			true,
+		},
+		{
+			&Prefs{AdvertiseRoutes: []*net.IPNet{}},
+			&Prefs{AdvertiseRoutes: []*net.IPNet{}},
+			true,
+		},
+		{
+			&Prefs{AdvertiseRoutes: nets("192.168.0.0/24", "10.1.0.0/16")},
+			&Prefs{AdvertiseRoutes: nets("192.168.1.0/24", "10.2.0.0/16")},
+			false,
+		},
+		{
+			&Prefs{AdvertiseRoutes: nets("192.168.0.0/24", "10.1.0.0/16")},
+			&Prefs{AdvertiseRoutes: nets("192.168.0.0/24", "10.2.0.0/16")},
+			false,
+		},
+		{
+			&Prefs{AdvertiseRoutes: nets("192.168.0.0/24", "10.1.0.0/16")},
+			&Prefs{AdvertiseRoutes: nets("192.168.0.0/24", "10.1.0.0/16")},
+			true,
+		},
+
+		{
+			&Prefs{Persist: &controlclient.Persist{}},
+			&Prefs{Persist: &controlclient.Persist{LoginName: "dave"}},
+			false,
+		},
+		{
+			&Prefs{Persist: &controlclient.Persist{LoginName: "dave"}},
+			&Prefs{Persist: &controlclient.Persist{LoginName: "dave"}},
+			true,
+		},
+	}
+	for i, tt := range tests {
+		got := tt.a.Equals(tt.b)
+		if got != tt.want {
+			t.Errorf("%d. Equal = %v; want %v", i, got, tt.want)
+		}
+	}
+}
 
 func checkPrefs(t *testing.T, p Prefs) {
 	var err error


### PR DESCRIPTION
This is a prelude to supporting relaynode's --routes in
tailscaled. The daemon needs to remembers routes to
advertise, and the CLI needs to be able to change the
set of advertised routes. Prefs is the thing used for
both of these.

Signed-off-by: David Anderson <dave@natulte.net>