### PR TITLE
wgengine/monitor: use RTMGRP_* consts from x/sys/unix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/tailscale/wireguard-go v0.0.0-20200213180345-a7c4b7719b1d
 	golang.org/x/crypto v0.0.0-20200210222208-86ce3cb69678
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
-	golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4
+	golang.org/x/sys v0.0.0-20200217220822-9197077df867
 	gortc.io/stun v1.22.1
 	honnef.co/go/tools v0.0.1-2019.2.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 h1:LfCXLvNmTYH9kEmVgqbnsWfru
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4 h1:sfkvUWPNGwSV+8/fNqctR5lS2AqCSqYwXdrjCxp/dXo=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200217220822-9197077df867 h1:JoRuNIf+rpHl+VhScRQQvzbHed86tKkqwPMV34T8myw=
+golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/wgengine/monitor/monitor_linux.go
+++ b/wgengine/monitor/monitor_linux.go
@@ -12,11 +12,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const (
-	_RTMGRP_IPV4_IFADDR = 0x10
-	_RTMGRP_IPV4_ROUTE  = 0x40
-)
-
 // nlConn wraps a *netlink.Conn and returns a monitor.Message
 // instead of a netlink.Message. Currently, messages are discarded,
 // but down the line, when messages trigger different logic depending
@@ -33,11 +28,7 @@ func newOSMon() (osMon, error) {
 		// things like DHCP deciding to give us a new address upon
 		// renewal - routing wouldn't change, but all reachability
 		// would.
-		//
-		// Why magic numbers? These aren't exposed in x/sys/unix
-		// yet. The values come from rtnetlink.h, RTMGRP_IPV4_IFADDR
-		// and RTMGRP_IPV4_ROUTE.
-		Groups: _RTMGRP_IPV4_IFADDR | _RTMGRP_IPV4_ROUTE,
+		Groups: unix.RTMGRP_IPV4_IFADDR | unix.RTMGRP_IPV4_ROUTE,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("dialing netlink socket: %v", err)


### PR DESCRIPTION
Bump golang.org/x/sys/unix to get the RTMGRP_* consts and use them.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>