### PR TITLE
ipn: handle advertised routes provided by frontend.

### DIFF
--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -5,15 +5,14 @@
 package ipn
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
-	"net"
 	"os"
 	"path/filepath"
 
+	"github.com/tailscale/wireguard-go/wgcfg"
 	"tailscale.com/atomicfile"
 	"tailscale.com/control/controlclient"
 )
@@ -44,7 +43,7 @@ type Prefs struct {
 	UsePacketFilter bool
 	// AdvertiseRoutes specifies CIDR prefixes to advertise into the
 	// Tailscale network as reachable through the current node.
-	AdvertiseRoutes []*net.IPNet
+	AdvertiseRoutes []wgcfg.CIDR
 
 	// NotepadURLs is a debugging setting that opens OAuth URLs in
 	// notepad.exe on Windows, rather than loading them in a browser.
@@ -102,12 +101,12 @@ func (p *Prefs) Equals(p2 *Prefs) bool {
 		p.Persist.Equals(p2.Persist)
 }
 
-func compareIPNets(a, b []*net.IPNet) bool {
+func compareIPNets(a, b []wgcfg.CIDR) bool {
 	if len(a) != len(b) {
 		return false
 	}
 	for i := range a {
-		if !a[i].IP.Equal(b[i].IP) || !bytes.Equal(a[i].Mask, b[i].Mask) {
+		if !a[i].IP.Equal(&b[i].IP) || a[i].Mask != b[i].Mask {
 			return false
 		}
 	}

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -5,10 +5,10 @@
 package ipn
 
 import (
-	"net"
 	"reflect"
 	"testing"
 
+	"github.com/tailscale/wireguard-go/wgcfg"
 	"tailscale.com/control/controlclient"
 )
 
@@ -26,13 +26,13 @@ func TestPrefsEqual(t *testing.T) {
 			have, prefsHandles)
 	}
 
-	nets := func(strs ...string) (ns []*net.IPNet) {
+	nets := func(strs ...string) (ns []wgcfg.CIDR) {
 		for _, s := range strs {
-			_, n, err := net.ParseCIDR(s)
+			n, err := wgcfg.ParseCIDR(s)
 			if err != nil {
 				panic(err)
 			}
-			ns = append(ns, n)
+			ns = append(ns, *n)
 		}
 		return ns
 	}
@@ -124,12 +124,12 @@ func TestPrefsEqual(t *testing.T) {
 
 		{
 			&Prefs{AdvertiseRoutes: nil},
-			&Prefs{AdvertiseRoutes: []*net.IPNet{}},
+			&Prefs{AdvertiseRoutes: []wgcfg.CIDR{}},
 			true,
 		},
 		{
-			&Prefs{AdvertiseRoutes: []*net.IPNet{}},
-			&Prefs{AdvertiseRoutes: []*net.IPNet{}},
+			&Prefs{AdvertiseRoutes: []wgcfg.CIDR{}},
+			&Prefs{AdvertiseRoutes: []wgcfg.CIDR{}},
 			true,
 		},
 		{

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -220,7 +220,7 @@ type Hostinfo struct {
 	Services      []Service    `json:",omitempty"` // services advertised by this machine
 
 	// NOTE: any new fields containing pointers in this type
-	//       require changes to Hostinfo.Copy.
+	//       require changes to Hostinfo.Copy and Hostinfo.Equal.
 }
 
 // Copy makes a deep copy of Hostinfo.
@@ -232,6 +232,11 @@ func (hinfo *Hostinfo) Copy() (res *Hostinfo) {
 	res.RoutableIPs = append([]wgcfg.CIDR{}, res.RoutableIPs...)
 	res.Services = append([]Service{}, res.Services...)
 	return res
+}
+
+// Equal reports whether h and h2 are equal.
+func (h *Hostinfo) Equal(h2 *Hostinfo) bool {
+	return reflect.DeepEqual(h, h2)
 }
 
 type RegisterRequest struct {


### PR DESCRIPTION
With this change, you can advertise routes to the Tailscale network with tailscaled, feature parity with relaynode \o/

The CLI is still super janky. You have to provide the exact non-default settings you want on the CLI every time you invoke it, or it'll undo changes you cared about. It's okay as a one-off-and-never-touch-again configuration tool, but nothing more.