### PR TITLE
logpolicy: automatically figure out storage paths.

### DIFF
--- a/cmd/relaynode/relaynode.go
+++ b/cmd/relaynode/relaynode.go
@@ -66,7 +66,7 @@ func main() {
 		log.Printf("Warning: no --tun device specified; routing disabled.\n")
 	}
 
-	pol := logpolicy.New("tailnode.log.tailscale.io", *config)
+	pol := logpolicy.New("tailnode.log.tailscale.io")
 
 	logf := wgengine.RusagePrefixLog(log.Printf)
 

--- a/cmd/taillogin/taillogin.go
+++ b/cmd/taillogin/taillogin.go
@@ -31,7 +31,7 @@ func main() {
 	if *config == "" {
 		log.Fatal("no --config file specified")
 	}
-	pol := logpolicy.New("tailnode.log.tailscale.io", *config)
+	pol := logpolicy.New("tailnode.log.tailscale.io")
 	defer pol.Close()
 
 	cfg, err := loadConfig(*config)

--- a/cmd/tailscale/tailscale.go
+++ b/cmd/tailscale/tailscale.go
@@ -59,7 +59,7 @@ func main() {
 	nopf := getopt.BoolLong("no-packet-filter", 'F', "disable packet filter")
 	advroutes := getopt.ListLong("routes", 'r', "routes to advertise to other nodes (comma-separated, e.g. 10.0.0.0/8,192.168.1.0/24)")
 	getopt.Parse()
-	pol := logpolicy.New("tailnode.log.tailscale.io", "tailscale")
+	pol := logpolicy.New("tailnode.log.tailscale.io")
 	if len(getopt.Args()) > 0 {
 		log.Fatalf("too many non-flag arguments: %#v", getopt.Args()[0])
 	}

--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -46,7 +46,7 @@ func main() {
 	if err != nil {
 		logf("fixConsoleOutput: %v\n", err)
 	}
-	pol := logpolicy.New("tailnode.log.tailscale.io", "tailscaled")
+	pol := logpolicy.New("tailnode.log.tailscale.io")
 
 	getopt.Parse()
 	if len(getopt.Args()) > 0 {


### PR DESCRIPTION
We want the config to persist, but logs should live in logs-ey
places.

Signed-off-by: David Anderson <dave@natulte.net>