### PR TITLE
wgengine: properly clean up freebsd routes and interfaces on close

### DIFF
--- a/wgengine/faketun.go
+++ b/wgengine/faketun.go
@@ -35,6 +35,7 @@ func (t *fakeTun) File() *os.File {
 func (t *fakeTun) Close() error {
 	close(t.closechan)
 	close(t.datachan)
+	close(t.evchan)
 	return nil
 }
 

--- a/wgengine/router_freebsd.go
+++ b/wgengine/router_freebsd.go
@@ -55,6 +55,10 @@ func (r *freebsdRouter) Up() error {
 }
 
 func (r *freebsdRouter) SetRoutes(rs RouteSettings) error {
+	if rs.LocalAddr == (wgcfg.CIDR{}) {
+		return nil
+	}
+
 	var errq error
 
 	// Update the address.
@@ -139,15 +143,6 @@ func (r *freebsdRouter) SetRoutes(rs RouteSettings) error {
 }
 
 func (r *freebsdRouter) Close() error {
-	out, err := cmd("ifconfig", r.tunname, "down").CombinedOutput()
-	if err != nil {
-		r.logf("running ifconfig failed: %v\n%s", err, out)
-	}
-
-	if err := r.restoreResolvConf(); err != nil {
-		r.logf("failed to restore system resolv.conf: %v", err)
-	}
-
 	return nil
 }
 

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -461,6 +461,7 @@ func (e *userspaceEngine) Close() {
 	e.Reconfig(&wgcfg.Config{}, nil)
 	e.linkMon.Close()
 	e.router.Close()
+	e.wgdev.Close()
 	e.magicConn.Close()
 	close(e.waitCh)
 }


### PR DESCRIPTION
The routes and interfaces will get cleaned up on close, so there's no need to try updating interfaces and routes with empty addresses.  device.Close() will properly close and clean up the device.

this resolves #72