### PR TITLE
Error handling after OLE calls

### DIFF
--- a/wgengine/ifconfig_windows.go
+++ b/wgengine/ifconfig_windows.go
@@ -184,26 +184,26 @@ func setFirewall(ifcGUID *windows.GUID) (bool, error) {
 	c := ole.Connection{}
 	err := c.Initialize()
 	if err != nil {
-		panic(err)
+		return false, fmt.Errorf("c.Initialize: %v", err)
 	}
 	defer c.Uninitialize()
 
 	m, err := winnet.NewNetworkListManager(&c)
 	if err != nil {
-		panic(err)
+		return false, fmt.Errorf("winnet.NewNetworkListManager: %v", err)
 	}
 	defer m.Release()
 
 	cl, err := m.GetNetworkConnections()
 	if err != nil {
-		panic(err)
+		return false, fmt.Errorf("m.GetNetworkConnections: %v", err)
 	}
 	defer cl.Release()
 
 	for _, nco := range cl {
 		aid, err := nco.GetAdapterId()
 		if err != nil {
-			panic(err)
+			return false, fmt.Errorf("nco.GetAdapterId: %v", err)
 		}
 		if aid != ifcGUID.String() {
 			log.Printf("skipping adapter id: %v\n", aid)


### PR DESCRIPTION
OLE calls sometimes unexpectedly fail, but retries can succeed. Instead of calls to panic(), return errors. This way ConfigureInterface() retries can succeed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/90)
<!-- Reviewable:end -->

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1171685499906294/1171687648683959) by [Unito](https://www.unito.io/learn-more)
