### PR TITLE
Start of netcheck package & including network state in Hostinfo.

### DIFF
--- a/cmd/tailscale/netcheck.go
+++ b/cmd/tailscale/netcheck.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main // import "tailscale.com/cmd/tailscale"
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sort"
+	"time"
+
+	"github.com/pborman/getopt/v2"
+	"tailscale.com/netcheck"
+)
+
+func isSubcommand(cmd string) bool {
+	return len(getopt.Args()) == 1 && getopt.Args()[0] == cmd
+}
+
+func netcheckCmd() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	report, err := netcheck.GetReport(ctx, log.Printf)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("\nReport:\n")
+	fmt.Printf("\t* UDP: %v\n", report.UDP)
+	fmt.Printf("\t* IPv6: %v\n", report.IPv6)
+	fmt.Printf("\t* MappingVariesByDestIP: %v\n", report.MappingVariesByDestIP)
+	fmt.Printf("\t* DERP latency:\n")
+	var ss []string
+	for s := range report.DERPLatency {
+		ss = append(ss, s)
+	}
+	sort.Strings(ss)
+	for _, s := range ss {
+		fmt.Printf("\t\t- %s = %v\n", s, report.DERPLatency[s])
+	}
+}

--- a/cmd/tailscale/tailscale.go
+++ b/cmd/tailscale/tailscale.go
@@ -59,6 +59,11 @@ func main() {
 	nopf := getopt.BoolLong("no-packet-filter", 'F', "disable packet filter")
 	advroutes := getopt.ListLong("routes", 'r', "routes to advertise to other nodes (comma-separated, e.g. 10.0.0.0/8,192.168.1.0/24)")
 	getopt.Parse()
+	// TODO(bradfitz): move this into a proper subcommand system when we have that.
+	if isSubcommand("netcheck") {
+		netcheckCmd()
+		return
+	}
 	pol := logpolicy.New("tailnode.log.tailscale.io")
 	if len(getopt.Args()) > 0 {
 		log.Fatalf("too many non-flag arguments: %#v", getopt.Args()[0])

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/tailscale/wireguard-go v0.0.0-20200225215529-3ec48fad1002
 	golang.org/x/crypto v0.0.0-20200210222208-86ce3cb69678
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20200217220822-9197077df867
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	gortc.io/stun v1.22.1

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,8 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FY
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190310054646-10058d7d4faa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/ipn/local_test.go
+++ b/ipn/local_test.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ipn
+
+import (
+	"flag"
+	"testing"
+
+	"tailscale.com/tailcfg"
+)
+
+var external = flag.Bool("external", false, "run external network tests")
+
+func TestPopulateNetworkConditions(t *testing.T) {
+	if !*external {
+		t.Skip("skipping network test without -external flag")
+	}
+	b := &LocalBackend{logf: t.Logf}
+	hi := new(tailcfg.Hostinfo)
+	b.populateNetworkConditions(hi)
+	t.Logf("Got: %+v", hi)
+
+}

--- a/netcheck/netcheck.go
+++ b/netcheck/netcheck.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package netcheck checks the network conditions from the current host.
+package netcheck
+
+import (
+	"context"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+	"tailscale.com/interfaces"
+	"tailscale.com/stunner"
+	"tailscale.com/types/logger"
+	"tailscale.com/types/opt"
+)
+
+type Report struct {
+	UDP                   bool                     // UDP works
+	IPv6                  bool                     // IPv6 works
+	MappingVariesByDestIP opt.Bool                 // for IPv4
+	DERPLatency           map[string]time.Duration // keyed by STUN host:port
+}
+
+func GetReport(ctx context.Context, logf logger.Logf) (*Report, error) {
+	closeOnCtx := func(c io.Closer) {
+		<-ctx.Done()
+		c.Close()
+	}
+
+	v6, err := interfaces.HaveIPv6GlobalAddress()
+	if err != nil {
+		logf("interfaces: %v", err)
+	}
+	var (
+		mu  sync.Mutex
+		ret = &Report{
+			DERPLatency: map[string]time.Duration{},
+		}
+		gotIP = map[string]string{} // server -> IP
+	)
+	add := func(server, ip string, d time.Duration) {
+		logf("%s says we are %s (in %v)", server, ip, d)
+
+		mu.Lock()
+		defer mu.Unlock()
+		ret.UDP = true
+		ret.DERPLatency[server] = d
+		if strings.Contains(server, "-v6") {
+			ret.IPv6 = true
+		}
+		gotIP[server] = ip
+	}
+
+	var pc4, pc6 net.PacketConn
+
+	pc4, err = net.ListenPacket("udp4", ":0")
+	if err != nil {
+		logf("udp4: %v", err)
+		return nil, err
+	}
+	go closeOnCtx(pc4)
+	if v6 {
+		pc6, err = net.ListenPacket("udp6", ":0")
+		if err != nil {
+			logf("udp6: %v", err)
+			v6 = false
+		} else {
+			go closeOnCtx(pc6)
+		}
+	}
+
+	reader := func(s *stunner.Stunner, pc net.PacketConn) {
+		var buf [64 << 10]byte
+		for {
+			n, addr, err := pc.ReadFrom(buf[:])
+			if err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				logf("ReadFrom: %v", err)
+				return
+			}
+			ua, ok := addr.(*net.UDPAddr)
+			if !ok {
+				logf("ReadFrom: unexpected addr %T", addr)
+				continue
+			}
+			logf("Packet from %v: %q", ua, buf[:n])
+			s.Receive(buf[:n], ua)
+		}
+
+	}
+
+	var grp errgroup.Group
+	s4 := &stunner.Stunner{
+		Send:     pc4.WriteTo,
+		Endpoint: add,
+		Servers:  []string{"derp1.tailscale.com:3478", "derp2.tailscale.com:3478"},
+		Logf:     logf,
+	}
+	grp.Go(func() error { return s4.Run(ctx) })
+	go reader(s4, pc4)
+
+	if v6 {
+		s6 := &stunner.Stunner{
+			Endpoint: add,
+			Send:     pc6.WriteTo,
+			Servers:  []string{"derp1-v6.tailscale.com:3478", "derp2-v6.tailscale.com:3478"},
+			Logf:     logf,
+			OnlyIPv6: true,
+		}
+		grp.Go(func() error { return s6.Run(ctx) })
+		go reader(s6, pc6)
+	}
+
+	err = grp.Wait()
+	logf("stunner.Run: %v", err)
+
+	mu.Lock()
+	defer mu.Unlock() // unnecessary, but feels weird without
+
+	// TODO: generalize this to find at least two out of N DERP
+	// servers (where N will be 5+).
+	ip1 := gotIP["derp1.tailscale.com:3478"]
+	ip2 := gotIP["derp2.tailscale.com:3478"]
+	if ip1 != "" && ip2 != "" {
+		ret.MappingVariesByDestIP.Set(ip1 != ip2)
+	}
+
+	return ret, nil
+}

--- a/tailcfg/tailcfg_test.go
+++ b/tailcfg/tailcfg_test.go
@@ -20,7 +20,10 @@ func fieldsOf(t reflect.Type) (fields []string) {
 }
 
 func TestHostinfoEqual(t *testing.T) {
-	hiHandles := []string{"IPNVersion", "FrontendLogID", "BackendLogID", "OS", "Hostname", "RoutableIPs", "Services"}
+	hiHandles := []string{
+		"IPNVersion", "FrontendLogID", "BackendLogID", "OS", "Hostname", "RoutableIPs", "Services",
+		"NetInfo",
+	}
 	if have := fieldsOf(reflect.TypeOf(Hostinfo{})); !reflect.DeepEqual(have, hiHandles) {
 		t.Errorf("Hostinfo.Equal check might be out of sync\nfields: %q\nhandled: %q\n",
 			have, hiHandles)


### PR DESCRIPTION
* adds new packet "netcheck" to do the checking of UDP, IPv6, and
  nearest DERP server, and the Report type for all that (and more
  in the future, probably pulling in danderson's natprobe)
* cmd/tailscale netcheck subcommand (tentative name, likely to
  change/move) to print out the netcheck.Report.