### PR TITLE
Recognize utun addresses as a possible Tailscale interface name prefix

### DIFF
--- a/interfaces/interfaces.go
+++ b/interfaces/interfaces.go
@@ -76,7 +76,8 @@ func isLoopbackInterfaceName(s string) bool {
 func maybeTailscaleInterfaceName(s string) bool {
 	return strings.HasPrefix(s, "wg") ||
 		strings.HasPrefix(s, "ts") ||
-		strings.HasPrefix(s, "tailscale")
+		strings.HasPrefix(s, "tailscale") ||
+		strings.HasPrefix(s, "utun")
 }
 
 // IsTailscaleIP reports whether ip is an IP in a range used by


### PR DESCRIPTION
When running `tsshd` on macOS, I found that no Tailscale interfaces are found because the interfaces code does not look for `utun` addresses. This small change enabled it and I was happily sshing around my network :smile:.