### PR TITLE
paths: use /var/db for state on BSDs, and /var/run for sockets.

### DIFF
--- a/paths/paths.go
+++ b/paths/paths.go
@@ -21,8 +21,8 @@ func DefaultTailscaledSocket() string {
 	if runtime.GOOS == "windows" {
 		return ""
 	}
-	if fi, err := os.Stat("/run"); err == nil && fi.IsDir() {
-		return "/run/tailscale/tailscaled.sock"
+	if fi, err := os.Stat("/var/run"); err == nil && fi.IsDir() {
+		return "/var/run/tailscale/tailscaled.sock"
 	}
 	return "tailscaled.sock"
 }


### PR DESCRIPTION
On BSD, /var/db is what linux calls /var/lib.

On modern linux, /run and /var/run are the same directory, but
on BSD the correct path is /var/run, so use that.

Fixes #79