### PR TITLE
wgengine/magicsock: never set a DERP server as a roamAddr.

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -1098,6 +1098,11 @@ func (a *AddrSet) UpdateDst(new *net.UDPAddr) error {
 		// Packet from current-priority address, no logging.
 		// This is a hot path for established connections.
 		return nil
+	} else if new.IP.Equal(derpMagicIP) {
+		// Never pick DERP addresses as a roaming addr. DERP obeys its
+		// own endpoint selection logic.
+		// This is a hot path for established connections.
+		return nil
 	}
 
 	index := -1


### PR DESCRIPTION
Signed-Off-By: David Anderson <danderson@tailscale.com>