### PR TITLE
wgengine: define default tunname for each platform

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -36,7 +36,7 @@ const globalStateKey = "_daemon"
 func main() {
 	fake := getopt.BoolLong("fake", 0, "fake tunnel+routing instead of tuntap")
 	debug := getopt.StringLong("debug", 0, "", "Address of debug server")
-	tunname := getopt.StringLong("tun", 0, "tailscale0", "tunnel interface name")
+	tunname := getopt.StringLong("tun", 0, wgengine.DefaultTunName, "tunnel interface name")
 	listenport := getopt.Uint16Long("port", 'p', magicsock.DefaultPort, "WireGuard port (0=autoselect)")
 	statepath := getopt.StringLong("state", 0, paths.DefaultTailscaledStateFile(), "Path of state file")
 	socketpath := getopt.StringLong("socket", 's', paths.DefaultTailscaledSocket(), "Path of the service unix socket")

--- a/wgengine/router_darwin.go
+++ b/wgengine/router_darwin.go
@@ -10,6 +10,8 @@ import (
 	"tailscale.com/types/logger"
 )
 
+const DefaultTunName = "tailscale0"
+
 type darwinRouter struct {
 	tunname string
 }

--- a/wgengine/router_default.go
+++ b/wgengine/router_default.go
@@ -12,6 +12,8 @@ import (
 	"tailscale.com/types/logger"
 )
 
+const DefaultTunName = "tailscale0"
+
 func newUserspaceRouter(logf logger.Logf, tunname string, dev *device.Device, tuntap tun.Device, netChanged func()) Router {
 	return NewFakeRouter(logf, tunname, dev, tuntap, netChanged)
 }

--- a/wgengine/router_freebsd.go
+++ b/wgengine/router_freebsd.go
@@ -20,6 +20,8 @@ import (
 // Work is currently underway for an in-kernel FreeBSD implementation of wireguard
 // https://svnweb.freebsd.org/base?view=revision&revision=357986
 
+const DefaultTunName = "tailscale0"
+
 type freebsdRouter struct {
 	logf    logger.Logf
 	tunname string

--- a/wgengine/router_linux.go
+++ b/wgengine/router_linux.go
@@ -22,6 +22,8 @@ import (
 	"tailscale.com/types/logger"
 )
 
+const DefaultTunName = "tailscale0"
+
 type linuxRouter struct {
 	logf    func(fmt string, args ...interface{})
 	tunname string

--- a/wgengine/router_openbsd.go
+++ b/wgengine/router_openbsd.go
@@ -25,6 +25,8 @@ import (
 // There is an experimental kernel version in the works for OpenBSD:
 // https://git.zx2c4.com/wireguard-openbsd.
 
+const DefaultTunName = "tun"
+
 type openbsdRouter struct {
 	logf    logger.Logf
 	tunname string

--- a/wgengine/router_windows.go
+++ b/wgengine/router_windows.go
@@ -13,6 +13,8 @@ import (
 	"tailscale.com/types/logger"
 )
 
+const DefaultTunName = "tailscale0"
+
 type winRouter struct {
 	logf                func(fmt string, args ...interface{})
 	tunname             string


### PR DESCRIPTION
The device name "tailscale0" will be used for all platforms except for OpenBSD where "tun" is enforced by the kernel. [CreateTUN](https://github.com/tailscale/wireguard-go/blob/master/tun/tun_openbsd.go#L127-L131) in `wireguard-go` will select the next available "tunX" device name on the OpenBSD system.

Aims to resolve: https://github.com/tailscale/tailscale/issues/38

Signed-off-by: Martin Baillie <martin@baillie.email>