### PR TITLE
stunner: re-do how Stunner works

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -185,6 +185,7 @@ golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac h1:MQEvx39qSf8vyrx3XRaOe+j1UDIzKwkYOVObRgGPVqI=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d h1:/iIZNFGxc/a7C3yWjGcnboV+Tkc7mxr+p6fDztwoxuM=
 golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/netcheck/netcheck_test.go
+++ b/netcheck/netcheck_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package netcheck
+
+import (
+	"net"
+	"testing"
+
+	"tailscale.com/stun"
+)
+
+func TestHairpinSTUN(t *testing.T) {
+	c := &Client{
+		hairTX:      stun.NewTxID(),
+		gotHairSTUN: make(chan *net.UDPAddr, 1),
+	}
+	req := stun.Request(c.hairTX)
+	if !stun.Is(req) {
+		t.Fatal("expected STUN message")
+	}
+	if !c.handleHairSTUN(req, nil) {
+		t.Fatal("expected true")
+	}
+	select {
+	case <-c.gotHairSTUN:
+	default:
+		t.Fatal("expected value")
+	}
+}

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -138,9 +138,8 @@ type Options struct {
 	// Zero means to pick one automatically.
 	Port uint16
 
-	// STUN, if non-empty, specifies alternate STUN servers for testing.
-	// If empty, the production DERP servers are used.
-	STUN []string
+	// DERPs, if non-nil, is used instead of derpmap.Prod.
+	DERPs *derpmap.World
 
 	// EndpointsFunc optionally provides a func to be called when
 	// endpoints change. The called func does not own the slice.
@@ -202,11 +201,11 @@ func Listen(opts Options) (*Conn, error) {
 		derpRecvCh:    make(chan derpReadResult),
 		udpRecvCh:     make(chan udpReadResult),
 		derpTLSConfig: opts.derpTLSConfig,
-		derps:         derpmap.Prod(),
+		derps:         opts.DERPs,
 	}
 	c.linkState, _ = getLinkState()
-	if len(opts.STUN) > 0 {
-		c.derps = derpmap.NewTestWorld(opts.STUN...)
+	if c.derps == nil {
+		c.derps = derpmap.Prod()
 	}
 	c.netChecker = &netcheck.Client{
 		DERP:         c.derps,

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -32,7 +32,6 @@ import (
 )
 
 func TestListen(t *testing.T) {
-	// TODO(crawshaw): when offline this test spends a while trying to connect to real derp servers.
 
 	epCh := make(chan string, 16)
 	epFunc := func(endpoints []string) {
@@ -47,7 +46,7 @@ func TestListen(t *testing.T) {
 	port := pickPort(t)
 	conn, err := Listen(Options{
 		Port:          port,
-		STUN:          []string{stunAddr},
+		DERPs:         derpmap.NewTestWorld(stunAddr),
 		EndpointsFunc: epFunc,
 		Logf:          t.Logf,
 	})
@@ -157,7 +156,7 @@ func serveSTUN(t *testing.T) (addr string, cleanupFn func()) {
 	}
 
 	stunAddr := pc.LocalAddr().String()
-	stunAddr = strings.Replace(stunAddr, "0.0.0.0:", "localhost:", 1)
+	stunAddr = strings.Replace(stunAddr, "0.0.0.0:", "127.0.0.1:", 1)
 
 	go runSTUN(t, pc, &stats)
 	return stunAddr, func() { pc.Close() }
@@ -335,8 +334,8 @@ func TestTwoDevicePing(t *testing.T) {
 
 	epCh1 := make(chan []string, 16)
 	conn1, err := Listen(Options{
-		Logf: logger.WithPrefix(t.Logf, "conn1: "),
-		STUN: []string{stunAddr},
+		Logf:  logger.WithPrefix(t.Logf, "conn1: "),
+		DERPs: derps,
 		EndpointsFunc: func(eps []string) {
 			epCh1 <- eps
 		},
@@ -345,13 +344,12 @@ func TestTwoDevicePing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	conn1.derps = derps
 	defer conn1.Close()
 
 	epCh2 := make(chan []string, 16)
 	conn2, err := Listen(Options{
-		Logf: logger.WithPrefix(t.Logf, "conn2: "),
-		STUN: []string{stunAddr},
+		Logf:  logger.WithPrefix(t.Logf, "conn2: "),
+		DERPs: derps,
 		EndpointsFunc: func(eps []string) {
 			epCh2 <- eps
 		},
@@ -360,7 +358,6 @@ func TestTwoDevicePing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	conn2.derps = derps
 	defer conn2.Close()
 
 	ports := []uint16{conn1.LocalPort(), conn2.LocalPort()}


### PR DESCRIPTION
It used to make assumptions based on having Anycast IPs that are super
near. Now we're intentionally going to a bunch of different distant
IPs to measure latency.

Also, optimize how the hairpin detection works. No need to STUN on
that socket. Just use that separate socket for sending, once we know
the other UDP4 socket's endpoint. The trick is: make our test probe
also a STUN packet, so it fits through magicsock's existing STUN
routing.

This drops netcheck from ~5 seconds to ~250-500ms.

Signed-off-by: Brad Fitzpatrick <bradfitz@tailscale.com>