### PR TITLE
portlist: document, clean up, fix an open fd spike, optimize a bit

### DIFF
--- a/portlist/netstat_test.go
+++ b/portlist/netstat_test.go
@@ -5,7 +5,6 @@
 package portlist
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -62,28 +61,26 @@ udp4       0      0  *.5553                 *.*
 `
 
 func TestParsePortsNetstat(t *testing.T) {
-	expect := List{
+	want := List{
 		Port{"tcp", 22, "", ""},
 		Port{"tcp", 23, "", ""},
 		Port{"tcp", 24, "", ""},
-		Port{"tcp", 32, "", "sshd"},
-		Port{"udp", 53, "", "chrome"},
-		Port{"udp", 53, "", "funball"},
-		Port{"udp", 5050, "", "CDPSvc"},
+		Port{"tcp", 32, "sshd", ""},
+		Port{"udp", 53, "chrome", ""},
+		Port{"udp", 53, "funball", ""},
+		Port{"udp", 5050, "CDPSvc", ""},
 		Port{"udp", 5353, "", ""},
 		Port{"udp", 5354, "", ""},
 		Port{"udp", 5453, "", ""},
 		Port{"udp", 5553, "", ""},
-		Port{"udp", 9353, "", "iTunes"},
+		Port{"udp", 9353, "iTunes", ""},
 	}
 
 	pl := parsePortsNetstat(netstat_output)
-	fmt.Printf("--- expect:\n%v\n", expect)
-	fmt.Printf("--- got:\n%v\n", pl)
 	for i := range pl {
-		if expect[i] != pl[i] {
-			t.Fatalf("row#%d\n expect=%v\n    got=%v\n",
-				i, expect[i], pl[i])
+		if pl[i] != want[i] {
+			t.Errorf("row#%d\n got: %#v\n\nwant: %#v\n",
+				i, pl[i], want[i])
 		}
 	}
 }

--- a/portlist/portlist.go
+++ b/portlist/portlist.go
@@ -9,13 +9,16 @@ import (
 	"strings"
 )
 
+// Port is a listening port on the machine.
 type Port struct {
-	Proto   string
-	Port    uint16
-	inode   string
-	Process string
+	Proto   string // "tcp" or "udp"
+	Port    uint16 // port number
+	Process string // optional process name, if found
+
+	inode string // OS-specific; "socket:[165614651]" on Linux
 }
 
+// List is a list of Ports.
 type List []Port
 
 var protos = []string{"tcp", "udp"}
@@ -62,12 +65,12 @@ func (a List) SameInodes(b List) bool {
 }
 
 func (pl List) String() string {
-	out := []string{}
+	var sb strings.Builder
 	for _, v := range pl {
-		out = append(out, fmt.Sprintf("%-3s %5d %-17s %#v",
-			v.Proto, v.Port, v.inode, v.Process))
+		fmt.Fprintf(&sb, "%-3s %5d %-17s %#v\n",
+			v.Proto, v.Port, v.inode, v.Process)
 	}
-	return strings.Join(out, "\n")
+	return strings.TrimRight(sb.String(), "\n")
 }
 
 func GetList(prev List) (List, error) {

--- a/portlist/portlist_darwin.go
+++ b/portlist/portlist_darwin.go
@@ -13,12 +13,13 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	exec "tailscale.com/tempfork/osexec"
 )
 
 // We have to run netstat, which is a bit expensive, so don't do it too often.
-const POLL_SECONDS = 5
+const pollInterval = 5 * time.Second
 
 func listPorts() (List, error) {
 	return listPortsNetstat("-na")

--- a/portlist/portlist_other.go
+++ b/portlist/portlist_other.go
@@ -6,8 +6,10 @@
 
 package portlist
 
+import "time"
+
 // We have to run netstat, which is a bit expensive, so don't do it too often.
-const POLL_SECONDS = 5
+const pollInterval = 5 * time.Second
 
 func listPorts() (List, error) {
 	return listPortsNetstat("-na")

--- a/portlist/portlist_test.go
+++ b/portlist/portlist_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package portlist
+
+import "testing"
+
+func TestGetList(t *testing.T) {
+	pl, err := GetList(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, p := range pl {
+		t.Logf("[%d] %+v", i, p)
+	}
+	t.Logf("As String: %v", pl.String())
+}
+
+func BenchmarkGetList(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := GetList(nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/portlist/portlist_windows.go
+++ b/portlist/portlist_windows.go
@@ -4,8 +4,10 @@
 
 package portlist
 
+import "time"
+
 // Forking on Windows is insanely expensive, so don't do it too often.
-const POLL_SECONDS = 5
+const pollInterval = 5 * time.Second
 
 func listPorts() (List, error) {
 	return listPortsNetstat("-na")


### PR DESCRIPTION
I noticed portlist when looking at some profiles and hadn't looked at
the code much before. This is a first pass over it. It allocates a
fair bit. More love remains, but this does a bit:

```
name       old time/op    new time/op    delta
GetList-8    9.92ms ± 8%    9.64ms ±12%     ~     (p=0.247 n=10+10)

name       old alloc/op   new alloc/op   delta
GetList-8     931kB ± 0%     869kB ± 0%   -6.70%  (p=0.000 n=10+10)

name       old allocs/op  new allocs/op  delta
GetList-8     4.59k ± 0%     3.69k ± 1%  -19.71%  (p=0.000 n=10+10)
```

Signed-off-by: Brad Fitzpatrick <bradfitz@tailscale.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/186)
<!-- Reviewable:end -->
