### PR TITLE
tsweb: use ResponseWriter wrapper to log better.

### DIFF
--- a/testy/clock.go
+++ b/testy/clock.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testy
+
+import "time"
+
+// Clock is a testing clock that advances every time its Now method is
+// called, beginning at Start.
+//
+// The zero value starts virtual time at an arbitrary value recorded
+// in Start on the first call to Now, and increments by one second
+// between calls to Now.
+type Clock struct {
+	// Start is the first value returned by Now.
+	Start time.Time
+	// Step is how much to advance with each Now call.
+	// Zero means 1 second.
+	Step time.Duration
+	// Present is the time that the next Now call will receive.
+	Present time.Time
+}
+
+// Now returns the virtual clock's current time, and avances it
+// according to its step configuration.
+func (c *Clock) Now() time.Time {
+	if c.Start.IsZero() {
+		c.Start = time.Now()
+		c.Present = c.Start
+	}
+	step := c.Step
+	if step == 0 {
+		step = time.Second
+	}
+	ret := c.Present
+	c.Present = c.Present.Add(step)
+	return ret
+}
+
+// Reset rewinds the virtual clock to its start time.
+func (c *Clock) Reset() {
+	c.Present = c.Start
+}

--- a/testy/doc.go
+++ b/testy/doc.go
@@ -1,0 +1,6 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package testy provides utilities for use in unit tests.
+package testy

--- a/tsweb/log.go
+++ b/tsweb/log.go
@@ -10,30 +10,46 @@ import (
 	"time"
 )
 
-// Msg is a structured event log entry.
-type Msg struct {
-	Where    string        `json:"where"`
-	When     time.Time     `json:"when"`
-	Duration time.Duration `json:"duration,omitempty"`
-	Domain   string        `json:"domain,omitempty"`
-	Msg      string        `json:"msg,omitempty"`
-	Err      error         `json:"err,omitempty"`
-	HTTP     *MsgHTTP      `json:"http,omitempty"`
-	Data     interface{}   `json:"data,omitempty"`
-}
+// AccessLogRecord is a record of one HTTP request served.
+type AccessLogRecord struct {
+	// Timestamp at which request processing started.
+	When time.Time `json:"when"`
+	// Time it took to finish processing the request. It does not
+	// include the entire lifetime of the underlying connection in
+	// cases like connection hijacking, only the lifetime of the HTTP
+	// request handler.
+	Seconds float64 `json:"duration"`
 
-// MsgHTTP contains information about the processing of one HTTP
-// request.
-type MsgHTTP struct {
-	Code       int    `json:"code"`
-	Path       string `json:"path"`
+	// The client's ip:port.
 	RemoteAddr string `json:"remote_addr"`
-	UserAgent  string `json:"user_agent"`
-	Referer    string `json:"referer"`
+	// The HTTP protocol version, usually "HTTP/1.1 or HTTP/2".
+	Proto string `json:"proto"`
+	// Whether the request was received over TLS.
+	TLS bool `json:"tls"`
+	// The target hostname in the request.
+	Host string `json:"host"`
+	// The HTTP method invoked.
+	Method string `json:"method"`
+	// The unescaped request URI, including query parameters.
+	RequestURI string `json:"request_uri"`
+
+	// The client's user-agent
+	UserAgent string `json:"user_agent"`
+	// Where the client was before making this request.
+	Referer string `json:"referer"`
+
+	// The HTTP response code sent to the client.
+	Code int `json:"code"`
+	// Number of bytes sent in response body to client. If the request
+	// was hijacked, only includes bytes sent up to the point of
+	// hijacking.
+	Bytes int `json:"bytes"`
+	// Error encountered during request processing.
+	Err string `json:"err"`
 }
 
 // String returns m as a JSON string.
-func (m Msg) String() string {
+func (m AccessLogRecord) String() string {
 	if m.When.IsZero() {
 		m.When = time.Now()
 	}

--- a/tsweb/tsweb_test.go
+++ b/tsweb/tsweb_test.go
@@ -1,0 +1,254 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tsweb
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"tailscale.com/testy"
+)
+
+type noopHijacker struct {
+	*httptest.ResponseRecorder
+	hijacked bool
+}
+
+func (h *noopHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	// Hijack "successfully" but don't bother returning a conn.
+	h.hijacked = true
+	return nil, nil, nil
+}
+
+func TestStdHandler(t *testing.T) {
+	var (
+		handlerCode = func(code int) Handler {
+			return HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+				w.WriteHeader(code)
+				return nil
+			})
+		}
+		handlerErr = func(code int, err error) Handler {
+			return HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+				if code != 0 {
+					w.WriteHeader(code)
+				}
+				return err
+			})
+		}
+
+		req = func(ctx context.Context, url string) *http.Request {
+			ret, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+			if err != nil {
+				panic(err)
+			}
+			return ret
+		}
+
+		testErr = errors.New("test error")
+		bgCtx   = context.Background()
+		// canceledCtx, cancel = context.WithCancel(bgCtx)
+		clock = testy.Clock{
+			Start: time.Now(),
+			Step:  time.Second,
+		}
+	)
+	// cancel()
+
+	tests := []struct {
+		name     string
+		h        Handler
+		r        *http.Request
+		wantCode int
+		wantLog  AccessLogRecord
+	}{
+		{
+			name:     "handler returns 200",
+			h:        handlerCode(200),
+			r:        req(bgCtx, "http://example.com/"),
+			wantCode: 200,
+			wantLog: AccessLogRecord{
+				When:       clock.Start,
+				Seconds:    1.0,
+				Proto:      "HTTP/1.1",
+				TLS:        false,
+				Host:       "example.com",
+				Method:     "GET",
+				Code:       200,
+				RequestURI: "/",
+			},
+		},
+
+		{
+			name:     "handler returns 404",
+			h:        handlerCode(404),
+			r:        req(bgCtx, "http://example.com/foo"),
+			wantCode: 404,
+			wantLog: AccessLogRecord{
+				When:       clock.Start,
+				Seconds:    1.0,
+				Proto:      "HTTP/1.1",
+				Host:       "example.com",
+				Method:     "GET",
+				RequestURI: "/foo",
+				Code:       404,
+			},
+		},
+
+		{
+			name:     "handler returns 404 via HTTPError",
+			h:        handlerErr(0, Error(404, "not found", testErr)),
+			r:        req(bgCtx, "http://example.com/foo"),
+			wantCode: 404,
+			wantLog: AccessLogRecord{
+				When:       clock.Start,
+				Seconds:    1.0,
+				Proto:      "HTTP/1.1",
+				Host:       "example.com",
+				Method:     "GET",
+				RequestURI: "/foo",
+				Err:        testErr.Error(),
+				Code:       404,
+			},
+		},
+
+		{
+			name:     "handler returns generic error",
+			h:        handlerErr(0, testErr),
+			r:        req(bgCtx, "http://example.com/foo"),
+			wantCode: 500,
+			wantLog: AccessLogRecord{
+				When:       clock.Start,
+				Seconds:    1.0,
+				Proto:      "HTTP/1.1",
+				Host:       "example.com",
+				Method:     "GET",
+				RequestURI: "/foo",
+				Err:        testErr.Error(),
+				Code:       500,
+			},
+		},
+
+		{
+			name:     "handler returns error after writing response",
+			h:        handlerErr(200, testErr),
+			r:        req(bgCtx, "http://example.com/foo"),
+			wantCode: 200,
+			wantLog: AccessLogRecord{
+				When:       clock.Start,
+				Seconds:    1.0,
+				Proto:      "HTTP/1.1",
+				Host:       "example.com",
+				Method:     "GET",
+				RequestURI: "/foo",
+				Err:        testErr.Error(),
+				Code:       200,
+			},
+		},
+
+		{
+			name:     "handler returns HTTPError after writing response",
+			h:        handlerErr(200, Error(404, "not found", testErr)),
+			r:        req(bgCtx, "http://example.com/foo"),
+			wantCode: 200,
+			wantLog: AccessLogRecord{
+				When:       clock.Start,
+				Seconds:    1.0,
+				Proto:      "HTTP/1.1",
+				Host:       "example.com",
+				Method:     "GET",
+				RequestURI: "/foo",
+				Err:        testErr.Error(),
+				Code:       200,
+			},
+		},
+
+		{
+			name:     "handler does nothing",
+			h:        HandlerFunc(func(http.ResponseWriter, *http.Request) error { return nil }),
+			r:        req(bgCtx, "http://example.com/foo"),
+			wantCode: 500,
+			wantLog: AccessLogRecord{
+				When:       clock.Start,
+				Seconds:    1.0,
+				Proto:      "HTTP/1.1",
+				Host:       "example.com",
+				Method:     "GET",
+				RequestURI: "/foo",
+				Code:       500,
+				Err:        "[unexpected] handler did not respond to the client",
+			},
+		},
+
+		{
+			name: "handler hijacks conn",
+			h: HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+				_, _, err := w.(http.Hijacker).Hijack()
+				if err != nil {
+					t.Errorf("couldn't hijack: %v", err)
+				}
+				return err
+			}),
+			r:        req(bgCtx, "http://example.com/foo"),
+			wantCode: 0,
+			wantLog: AccessLogRecord{
+				When:    clock.Start,
+				Seconds: 1.0,
+
+				Proto:      "HTTP/1.1",
+				Host:       "example.com",
+				Method:     "GET",
+				RequestURI: "/foo",
+				Code:       101,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var logs []AccessLogRecord
+			logf := func(fmt string, args ...interface{}) {
+				if fmt == "%s" {
+					logs = append(logs, args[0].(AccessLogRecord))
+				}
+				t.Logf(fmt, args...)
+			}
+
+			clock.Reset()
+
+			rec := noopHijacker{httptest.NewRecorder(), false}
+			// ResponseRecorder defaults Code to 200, grump.
+			rec.Code = 0
+			h := stdHandler(test.h, logf, clock.Now)
+			h.ServeHTTP(&rec, test.r)
+			if rec.Code != test.wantCode {
+				t.Errorf("HTTP code = %v, want %v", rec.Code, test.wantCode)
+			}
+			if !rec.hijacked && !rec.Flushed {
+				t.Errorf("handler didn't flush")
+			}
+			if len(logs) != 1 {
+				t.Errorf("handler didn't write a request log")
+				return
+			}
+			errTransform := cmp.Transformer("err", func(e error) string {
+				if e == nil {
+					return ""
+				}
+				return e.Error()
+			})
+			if diff := cmp.Diff(logs[0], test.wantLog, errTransform); diff != "" {
+				t.Errorf("handler wrote incorrect request log (-got+want):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Also adds tests for StdHandler, because it's getting a bit complex. And a virtual clock type, so as to not have to implement the arrow of time again.

StdHandler has to pass through `http.Handler`, `http.Flusher` and `http.Hijacker` in order to support all our HTTP servers. This leads to a small menagerie of wrappers, in order to correctly handle cases where the underlying ResponseWriter doesn't implement some of the optionals (which can happen in our servers). I believe the wrapper logic works correctly regardless of which underlying interfaces are provided vs. used. Please check carefully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/194)
<!-- Reviewable:end -->
