### PR TITLE
derp: add one send queue per client, queue packets from receivers.

### DIFF
--- a/cmd/derper/derper.go
+++ b/cmd/derper/derper.go
@@ -40,7 +40,6 @@ var (
 	configPath    = flag.String("c", "", "config file path")
 	certDir       = flag.String("certdir", tsweb.DefaultCertDir("derper-certs"), "directory to store LetsEncrypt certs, if addr's port is :443")
 	hostname      = flag.String("hostname", "derp.tailscale.com", "LetsEncrypt host name, if addr's port is :443")
-	mbps          = flag.Int("mbps", 5, "Mbps (mebibit/s) per-client rate limit; 0 means unlimited")
 	logCollection = flag.String("logcollection", "", "If non-empty, logtail collection to log to")
 	runSTUN       = flag.Bool("stun", false, "also run a STUN server")
 )
@@ -120,9 +119,6 @@ func main() {
 
 	s := derp.NewServer(key.Private(cfg.PrivateKey), log.Printf)
 	s.WriteTimeout = 2 * time.Second
-	if *mbps != 0 {
-		s.BytesPerSecond = (*mbps << 20) / 8
-	}
 	expvar.Publish("derp", s.ExpVar())
 
 	// Create our own mux so we don't expose /debug/ stuff to the world.
@@ -196,7 +192,6 @@ func debugHandler(s *derp.Server) http.Handler {
 <ul>
 `)
 		f("<li><b>Hostname:</b> %v</li>\n", *hostname)
-		f("<li><b>Rate Limit:</b> %v Mbps</li>\n", *mbps)
 		f("<li><b>Uptime:</b> %v</li>\n", tsweb.Uptime())
 
 		f(`<li><a href="/debug/vars">/debug/vars</a> (Go)</li>

--- a/cmd/derper/derper.go
+++ b/cmd/derper/derper.go
@@ -118,7 +118,6 @@ func main() {
 	letsEncrypt := tsweb.IsProd443(*addr)
 
 	s := derp.NewServer(key.Private(cfg.PrivateKey), log.Printf)
-	s.WriteTimeout = 2 * time.Second
 	expvar.Publish("derp", s.ExpVar())
 
 	// Create our own mux so we don't expose /debug/ stuff to the world.


### PR DESCRIPTION
Related changes:
 - Remove per-node rate limiter, rely entirely on kernel fair queuing+limiting for now.
 - Fix server->client keepalives. Code used to send 1 keepalive and then stop.
 - Packet drop counters broken down by drop reason.

Missing:
 - New test that overloads queues & verifies receivers don't block. Working on that after zzz, but code is good for review meanwhile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/200)
<!-- Reviewable:end -->
