### PR TITLE
ipn: call SetNetInfoCallback later, in Start

### DIFF
--- a/ipn/local.go
+++ b/ipn/local.go
@@ -87,8 +87,6 @@ func NewLocalBackend(logf logger.Logf, logid string, store StateStore, e wgengin
 	}
 	b.statusChanged = sync.NewCond(&b.statusLock)
 
-	e.SetNetInfoCallback(b.SetNetInfo)
-
 	if b.portpoll != nil {
 		go b.portpoll.Run(ctx)
 		go b.runPoller()
@@ -289,6 +287,8 @@ func (b *LocalBackend) Start(opts Options) error {
 
 		b.send(Notify{Engine: &es})
 	})
+
+	b.e.SetNetInfoCallback(b.SetNetInfo)
 
 	b.mu.Lock()
 	prefs := b.prefs.Clone()


### PR DESCRIPTION
It was being called back into ultimately from magicsock before there
was a control client.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/210)
<!-- Reviewable:end -->
