### PR TITLE
Adding the command to run tailscaled on start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,3 +17,8 @@ RUN go install -v ./cmd/...
 FROM alpine:3.11
 RUN apk add --no-cache ca-certificates iptables
 COPY --from=build-env /go/bin/* /usr/local/bin/
+
+CMD ["/usr/local/bin/tailscaled", "--state=/var/lib/tailscale/tailscaled.state", "--socket=/var/run/tailscale/tailscaled.sock", "--port=41641"]
+
+
+# docker run --network=host  --cap-add=NET_ADMIN --device /dev/net/tun:/dev/net/tun myusuf3/tailscale


### PR DESCRIPTION
working to see if this is something that could be supported with docker within unraid. 


need to figure out how to persist keys between launches.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/236)
<!-- Reviewable:end -->
