### PR TITLE
ipn: filter portlist to a short list of "interesting" ports.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,3 +32,4 @@ require (
 	honnef.co/go/tools v0.0.1-2020.1.3 // indirect
 	rsc.io/goversion v1.2.0
 )
+

--- a/ipn/local.go
+++ b/ipn/local.go
@@ -369,6 +369,8 @@ func (b *LocalBackend) updateFilter(netMap *controlclient.NetworkMap) {
 	}
 }
 
+var wantPorts = []uint16{22, 80, 443, 3389, 5900, 8000, 8080, 8443, 8888}
+
 func (b *LocalBackend) runPoller() {
 	for {
 		ports, ok := <-b.portpoll.C
@@ -381,15 +383,17 @@ func (b *LocalBackend) runPoller() {
 			if p.Proto == "tcp" {
 				proto = tailcfg.TCP
 			} else if p.Proto == "udp" {
-				proto = tailcfg.UDP
-			}
-			if p.Port == 53 || p.Port == 68 ||
-				p.Port == 5353 || p.Port == 5355 {
-				// uninteresting system services
+				// TODO(apenwarr): no UDP ports worth advertising
+				// proto = tailcfg.UDP
 				continue
 			}
-			if p.Proto == "udp" && strings.EqualFold(p.Process, "tailscaled") {
-				//  Skip our own.
+			found := false
+			for _, i := range wantPorts {
+				if p.Port == i {
+					found = true
+				}
+			}
+			if !found {
 				continue
 			}
 			s := tailcfg.Service{


### PR DESCRIPTION
Uploading a list of all listeners turned out to be hopelessly naive.
Windows has zillions of them under normal use (yikes, but that's
another story), and Chrome creates and destroys them constantly,
possibly related to webrtc.

Instead, we'll only return a list of the ports that we expect to expose
in the UI within the near future.

Signed-off-by: Avery Pennarun <apenwarr@tailscale.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/239)
<!-- Reviewable:end -->
