### PR TITLE
logtail: don't send a User-Agent

### DIFF
--- a/logtail/logtail.go
+++ b/logtail/logtail.go
@@ -295,6 +295,7 @@ func (l *logger) upload(ctx context.Context, body []byte) (uploaded bool, err er
 	if l.zstdEncoder != nil {
 		req.Header.Add("Content-Encoding", "zstd")
 	}
+	req.Header["User-Agent"] = nil // not worth writing one; save some bytes
 
 	maxUploadTime := 45 * time.Second
 	ctx, cancel := context.WithTimeout(ctx, maxUploadTime)


### PR DESCRIPTION
Just useless bytes on the wire. Especially with HTTP/1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/257)
<!-- Reviewable:end -->
