### PR TITLE
tsweb: rename Handler to ReturnHandler

### DIFF
--- a/cmd/microproxy/microproxy.go
+++ b/cmd/microproxy/microproxy.go
@@ -95,7 +95,7 @@ func promPrint(w io.Writer, prefix string, obj map[string]interface{}) {
 	}
 }
 
-func (h *goVarsHandler) ServeHTTPErr(w http.ResponseWriter, r *http.Request) error {
+func (h *goVarsHandler) ServeHTTPReturn(w http.ResponseWriter, r *http.Request) error {
 	resp, err := http.Get(h.url)
 	if err != nil {
 		return tsweb.Error(http.StatusInternalServerError, "fetch failed", err)

--- a/tsweb/tsweb_test.go
+++ b/tsweb/tsweb_test.go
@@ -269,3 +269,35 @@ func TestStdHandler(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkLogNot200(b *testing.B) {
+	b.ReportAllocs()
+	rh := handlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		// Implicit 200 OK.
+		return nil
+	})
+	discardLogger := func(string, ...interface{}) {}
+	h := StdHandlerNo200s(rh, discardLogger)
+	req := httptest.NewRequest("GET", "/", nil)
+	rw := new(httptest.ResponseRecorder)
+	for i := 0; i < b.N; i++ {
+		*rw = httptest.ResponseRecorder{}
+		h.ServeHTTP(rw, req)
+	}
+}
+
+func BenchmarkLog(b *testing.B) {
+	b.ReportAllocs()
+	rh := handlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		// Implicit 200 OK.
+		return nil
+	})
+	discardLogger := func(string, ...interface{}) {}
+	h := StdHandler(rh, discardLogger)
+	req := httptest.NewRequest("GET", "/", nil)
+	rw := new(httptest.ResponseRecorder)
+	for i := 0; i < b.N; i++ {
+		*rw = httptest.ResponseRecorder{}
+		h.ServeHTTP(rw, req)
+	}
+}


### PR DESCRIPTION
The name's been bugging me for a long time.

I liked neither the overlap between tsweb.Handler and http.Handler,
nor the name "ServeHTTPErr" which sounds like it's an error being
returned, like it's an error handler and not sometimes a happy path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/258)
<!-- Reviewable:end -->
