### PR TITLE
derp/derp_server: fixed unbalanced {register,unregister}Client() calls.

### DIFF
--- a/derp/derp_server.go
+++ b/derp/derp_server.go
@@ -255,11 +255,12 @@ func (s *Server) accept(nc Conn, brw *bufio.ReadWriter, remoteAddr string, connN
 	}
 
 	s.registerClient(c)
+	defer s.unregisterClient(c)
+
 	err = s.sendServerInfo(bw, clientKey)
 	if err != nil {
 		return fmt.Errorf("send server info: %v", err)
 	}
-	defer s.unregisterClient(c)
 
 	return c.run(ctx)
 }


### PR DESCRIPTION
`unregisterClient()` isn't called if `sendServerInfo()` fails in `accept()`. Fixed this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/262)
<!-- Reviewable:end -->
