### PR TITLE
wgengine/magicsock: fix Conn docs type reference

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -46,7 +46,7 @@ import (
 )
 
 // A Conn routes UDP packets and actively manages a list of its endpoints.
-// It implements wireguard/device.Bind.
+// It implements wireguard/conn.Bind.
 type Conn struct {
 	pconnPort    uint16 // the preferred port from opts.Port; 0 means auto
 	pconn4       *RebindingUDPConn
@@ -1514,7 +1514,7 @@ type AddrSet struct {
 	// stopSpray is the time after which we stop spraying packets.
 	stopSpray time.Time
 
-	// lastSpray is the lsat time we sprayed a packet.
+	// lastSpray is the last time we sprayed a packet.
 	lastSpray time.Time
 }
 


### PR DESCRIPTION
While skimming the magicsock code, I noticed a tiny doc issue and figured I'd send a fix. The docs on `magicsock.Conn` currently state that they implement the `wireguard/device.Bind` interface, yet this type does not exist. It appears that the `Conn` type actually implements the [`wireguard/conn.Bind`](https://pkg.go.dev/github.com/tailscale/wireguard-go@v0.0.0-20200325185614-bd634ffe2ded/conn?tab=doc#Bind) interface, so I tweaked the docs to reflect this.

I also fixed a small typo in the same file. :v:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/266)
<!-- Reviewable:end -->
