### PR TITLE
derp: prevent readFrame() from reading more than len(b) bytes

### DIFF
--- a/derp/derp.go
+++ b/derp/derp.go
@@ -138,7 +138,8 @@ func readFrame(br *bufio.Reader, maxSize uint32, b []byte) (t frameType, frameLe
 	if frameLen > maxSize {
 		return 0, 0, fmt.Errorf("frame header size %d exceeds reader limit of %d", frameLen, maxSize)
 	}
-	n, err := io.ReadFull(br, b[:frameLen])
+
+	n, err := io.ReadFull(br, b[:minUint32(frameLen, uint32(len(b)))])
 	if err != nil {
 		return 0, 0, err
 	}
@@ -174,6 +175,13 @@ func writeFrame(bw *bufio.Writer, t frameType, b []byte) error {
 }
 
 func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func minUint32(a, b uint32) uint32 {
 	if a < b {
 		return a
 	}


### PR DESCRIPTION
Comments already suggest that it should do this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/271)
<!-- Reviewable:end -->
