### PR TITLE
wgengine: remove IpcSetOperation on LinkChange

### DIFF
--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -651,26 +651,6 @@ func (e *userspaceEngine) LinkChange(isExpensive bool) {
 		e.magicConn.Rebind()
 	}
 	e.magicConn.ReSTUN(why)
-	if !needRebind {
-		return
-	}
-
-	e.wgLock.Lock()
-	defer e.wgLock.Unlock()
-
-	// TODO(crawshaw): use isExpensive=true to switch into "client mode" on macOS?
-
-	// TODO(crawshaw): when we have an incremental notion of reconfig,
-	// be gentler here. No need to smash in-progress connections,
-	// we just need to handshake again.
-	if e.lastReconfig == "" {
-		return
-	}
-	uapi := e.lastReconfig[:strings.Index(e.lastReconfig, "\x00")]
-	r := bufio.NewReader(strings.NewReader(uapi))
-	if err := e.wgdev.IpcSetOperation(r); err != nil {
-		e.logf("IpcSetOperation: %v\n", err)
-	}
 }
 
 func getLinkState() (*interfaces.State, error) {


### PR DESCRIPTION
This was only done occasionally, but was extremely disruptive
when done and is no longer necessary.

It used to be that when switching links, we had to immediately
generate handshakes to everyone we were communicating with to
punch a hole in any NAT we were talking through. (This ended up
not really working, because in the process we got rid of our
session keys and ended up having a futile conversation for many
seconds.)

Now we have DERP, our link change propogates to the other side
as a new list of endpoints, so they start spraying packets.
We will definitely get one thanks to DERP, which will cause us
to spray, opening any NAT we are behind.

The result is that for good connections, we don't trash session
keys and cause an interruption.

Signed-off-by: David Crawshaw <crawshaw@tailscale.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/279)
<!-- Reviewable:end -->
