### PR TITLE
ipn: on transition to Stopped state, stop some network activity

### DIFF
--- a/ipn/local.go
+++ b/ipn/local.go
@@ -698,6 +698,7 @@ func (b *LocalBackend) enterState(newState State) {
 	state := b.state
 	prefs := b.prefs
 	notify := b.notify
+	c := b.c
 	b.mu.Unlock()
 
 	if state == newState {
@@ -718,6 +719,9 @@ func (b *LocalBackend) enterState(newState State) {
 		err := b.e.Reconfig(&wgcfg.Config{}, nil)
 		if err != nil {
 			b.logf("Reconfig(down): %v\n", err)
+		}
+		if c != nil {
+			c.Shutdown()
 		}
 	case Starting, NeedsMachineAuth:
 		b.authReconfig()


### PR DESCRIPTION
@crawshaw, I have no clue whether this is right or not. I just wanted the IPNExtension to be less active when toggling Active/Stopped in the iOS Tailscale app.

The ipn/local.go state machine still scares me. I'm afraid of breaking misc frontends. How's the test coverage? 😨 

Thoughts?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/288)
<!-- Reviewable:end -->

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1171685499906294/1171686505537492) by [Unito](https://www.unito.io/learn-more)
