### PR TITLE
net/peers: helpers for peer lookups

### DIFF
--- a/net/peers/peer.go
+++ b/net/peers/peer.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package peers contains helpers for looking up peers on a Tailscale network.
+package peers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os/exec"
+)
+
+// A Peer is another machine connected on a users network.
+type Peer struct {
+	Hostname string `json:"Hostname"`
+	TailAddr net.IP `json:"TailAddr"`
+}
+
+// A Queryer can be used to query for peers.
+type Queryer interface {
+	Query() ([]Peer, error)
+}
+
+// NewQueryer creates a new queryer object.
+func NewQueryer() Queryer {
+	return &queryer{}
+}
+
+type queryer struct{}
+
+func parseCmdOutput(output []byte) ([]Peer, error) {
+	var buf struct {
+		Peers map[string]Peer `json:"Peer"`
+	}
+	if err := json.Unmarshal(output, &buf); err != nil {
+		return nil, fmt.Errorf("peers: failed to parse command output: %v", err)
+	}
+	peers := make([]Peer, 0, len(buf.Peers))
+	for _, p := range buf.Peers {
+		peers = append(peers, p)
+	}
+	return peers, nil
+}
+
+func (q *queryer) Query() ([]Peer, error) {
+	out, err := exec.Command("tailscale", "status", "--json").Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseCmdOutput(out)
+}

--- a/net/peers/peer_test.go
+++ b/net/peers/peer_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package peers
+
+import (
+	"net"
+	"reflect"
+	"testing"
+)
+
+func TestParseCmdOutput(t *testing.T) {
+	tests := []struct {
+		desc   string
+		input  string
+		peers  []Peer
+		nilErr bool
+	}{
+		{
+			desc: "valid input",
+			input: `{
+  "BackendState": "",
+  "Peer": {
+    "peer1publickeyhere": {
+      "PublicKey": "peer1publickeyhere",
+      "HostName": "mgphone",
+      "OS": "iOS",
+      "UserID": 33022,
+      "TailAddr": "100.94.00.000",
+      "Addrs": [
+        "derp-1",
+        "192.168.68.148:57619"
+      ],
+      "CurAddr": "",
+      "RxBytes": 0,
+      "TxBytes": 0,
+      "Created": "2020-03-26T22:14:53.678505853Z",
+      "LastSeen": "2020-04-13T23:00:00.000000001Z",
+      "LastHandshake": "0001-01-01T00:00:00Z",
+      "KeepAlive": false,
+      "InNetworkMap": true,
+      "InMagicSock": true,
+      "InEngine": true
+    },
+    "peer2publickeyhere": {
+      "PublicKey": "peer2publickeyhere",
+      "HostName": "mgmbp",
+      "OS": "macOS",
+      "UserID": 33022,
+      "TailAddr": "100.69.00.000",
+      "Addrs": [
+        "derp-1",
+        "192.168.68.147:53745"
+      ],
+      "RxBytes": 3370,
+      "TxBytes": 53601,
+      "Created": "2020-02-27T19:46:18.508990755Z",
+      "LastSeen": "2020-04-13T23:00:00.000000001Z",
+      "LastHandshake": "2020-04-13T22:54:56.258398104Z",
+      "KeepAlive": true,
+      "InNetworkMap": true,
+      "InMagicSock": true,
+      "InEngine": true
+    }
+  },
+  "User": {
+    "1234": {
+      "ID": 1234,
+      "LoginName": "morgan@morgangallant.com",
+      "DisplayName": "Morgan Gallant",
+      "ProfilePicURL": "https://lh3.googleusercontent.com/a-/AAuE7mDYhTrqpPI8wqwEBI5fJlz0dR4xdwckeugkVUcI",
+      "Roles": [
+        42424242
+      ]
+    }
+  }
+}`,
+			peers: []Peer{
+				{
+					Hostname: "mgphone",
+					TailAddr: net.ParseIP("100.94.00.000"),
+				},
+				{
+					Hostname: "mgmbp",
+					TailAddr: net.ParseIP("100.69.00.000"),
+				},
+			},
+			nilErr: true,
+		},
+		{
+			desc: "valid, but empty input",
+			input: `{
+  "BackendState": "",
+  "Peer": {},
+  "User": {
+    "1234": {
+      "ID": 1234,
+      "LoginName": "morgan@morgangallant.com",
+      "DisplayName": "Morgan Gallant",
+      "ProfilePicURL": "https://lh3.googleusercontent.com/a-/AAuE7mDYhTrqpPI8wqwEBI5fJlz0dR4xdwckeugkVUcI",
+      "Roles": [
+        42424242
+      ]
+    }
+  }
+}`,
+			peers:  []Peer{},
+			nilErr: true,
+		},
+		{
+			desc:   "error connecting to tailscaled",
+			input:  "2020/04/13 23:30:04 Failed to connect to tailscaled. (safesocket.Connect: dial unix /var/run/tailscale/tailscaled.sock: connect: no such file or directory)",
+			peers:  nil,
+			nilErr: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			peers, err := parseCmdOutput([]byte(test.input))
+			if test.nilErr && err != nil {
+				t.Errorf("expecting nil error, got %v", err)
+			} else if !test.nilErr && err == nil {
+				t.Errorf("expecting non-nil error, got nil error")
+			}
+			if !reflect.DeepEqual(peers, test.peers) {
+				t.Errorf("expecting peer list %v, got %v", test.peers, peers)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Small utility package which allows users to query for other machines on their Tailscale network. Mainly used for distributed systems applications (peer discovery) in addition to exposing secure endpoints only accessible over a Tailscale network (see #259).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/296)
<!-- Reviewable:end -->

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1171685499906294/1171686497473498) by [Unito](https://www.unito.io/learn-more)
