### PR TITLE
net/dnscache: don't use the Go resolver on Android

### DIFF
--- a/net/dnscache/dnscache.go
+++ b/net/dnscache/dnscache.go
@@ -31,6 +31,11 @@ func preferGoResolver() bool {
 		return false
 	}
 
+	// The local resolver is not available on Android.
+	if runtime.GOOS == "android" {
+		return false
+	}
+
 	// Otherwise, the Go resolver is fine and slightly preferred
 	// since it's lighter, not using cgo calls & threads.
 	return true


### PR DESCRIPTION
Just like on iOS, there is no local resolver on Android.

Signed-off-by: Elias Naur <mail@eliasnaur.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/331)
<!-- Reviewable:end -->
