### PR TITLE
wgengine/router: split out from wgengine.

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -14,6 +14,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/pprof"
+	"runtime"
 
 	"github.com/apenwarr/fixconsole"
 	"github.com/pborman/getopt/v2"
@@ -33,10 +34,18 @@ import (
 // later, the global state key doesn't look like a username.
 const globalStateKey = "_daemon"
 
+var defaultTunName = "tailscale0"
+
+func init() {
+	if runtime.GOOS == "openbsd" {
+		defaultTunName = "tun"
+	}
+}
+
 func main() {
 	fake := getopt.BoolLong("fake", 0, "fake tunnel+routing instead of tuntap")
 	debug := getopt.StringLong("debug", 0, "", "Address of debug server")
-	tunname := getopt.StringLong("tun", 0, wgengine.DefaultTunName, "tunnel interface name")
+	tunname := getopt.StringLong("tun", 0, defaultTunName, "tunnel interface name")
 	listenport := getopt.Uint16Long("port", 'p', magicsock.DefaultPort, "WireGuard port (0=autoselect)")
 	statepath := getopt.StringLong("state", 0, paths.DefaultTailscaledStateFile(), "Path of state file")
 	socketpath := getopt.StringLong("socket", 's', paths.DefaultTailscaledSocket(), "Path of the service unix socket")

--- a/ipn/e2e_test.go
+++ b/ipn/e2e_test.go
@@ -24,6 +24,7 @@ import (
 	"tailscale.com/tstest"
 	"tailscale.com/wgengine"
 	"tailscale.com/wgengine/magicsock"
+	"tailscale.com/wgengine/router"
 	"tailscale.io/control" // not yet released
 )
 
@@ -196,7 +197,7 @@ func newNode(t *testing.T, prefix string, https *httptest.Server) testNode {
 	}
 
 	tun := tuntest.NewChannelTUN()
-	e1, err := wgengine.NewUserspaceEngineAdvanced(logfe, tun.TUN(), wgengine.NewFakeRouter, 0)
+	e1, err := wgengine.NewUserspaceEngineAdvanced(logfe, tun.TUN(), router.NewFake, 0)
 	if err != nil {
 		t.Fatalf("NewFakeEngine: %v\n", err)
 	}

--- a/scripts/check_license_headers.sh
+++ b/scripts/check_license_headers.sh
@@ -35,7 +35,7 @@ for file in $(find $1 -name '*.go'); do
         $1/tempfork/*)
             # Skip, tempfork of third-party code
         ;;
-        $1/wgengine/ifconfig_windows.go)
+        $1/wgengine/router/ifconfig_windows.go)
             # WireGuard copyright.
             ;;
         *)

--- a/wgengine/router/ifconfig_windows.go
+++ b/wgengine/router/ifconfig_windows.go
@@ -3,7 +3,7 @@
  * Copyright (C) 2019 WireGuard LLC. All Rights Reserved.
  */
 
-package wgengine
+package router
 
 import (
 	"bytes"

--- a/wgengine/router/router.go
+++ b/wgengine/router/router.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package router presents an interface to manipulate the host network
+// stack's state.
+package router
+
+import (
+	"fmt"
+
+	"github.com/tailscale/wireguard-go/device"
+	"github.com/tailscale/wireguard-go/tun"
+	"github.com/tailscale/wireguard-go/wgcfg"
+	"tailscale.com/types/logger"
+)
+
+// Router is responsible for managing the system network stack.
+//
+// There is typically only one instance of this interface per process.
+type Router interface {
+	// Up brings the router up.
+	Up() error
+
+	// SetRoutes is called regularly on network map updates.
+	// It's how you kernel route table entries are populated for
+	// each peer.
+	SetRoutes(RouteSettings) error
+
+	// Close closes the router.
+	Close() error
+}
+
+// NewUserspaceRouter returns a new Router for the current platform, using the provided tun device.
+func New(logf logger.Logf, wgdev *device.Device, tundev tun.Device) (Router, error) {
+	return newUserspaceRouter(logf, wgdev, tundev)
+}
+
+// RouteSettings is the full WireGuard config data (set of peers keys,
+// IP, etc in wgcfg.Config) plus the things that WireGuard doesn't do
+// itself, like DNS stuff.
+type RouteSettings struct {
+	LocalAddr  wgcfg.CIDR // TODO: why is this here? how does it differ from wgcfg.Config's info?
+	DNS        []wgcfg.IP
+	DNSDomains []string
+	Cfg        *wgcfg.Config
+}
+
+// OnlyRelevantParts returns a string minimally describing the route settings.
+func (rs *RouteSettings) OnlyRelevantParts() string {
+	var peers [][]wgcfg.CIDR
+	for _, p := range rs.Cfg.Peers {
+		peers = append(peers, p.AllowedIPs)
+	}
+	return fmt.Sprintf("%v %v %v %v",
+		rs.LocalAddr, rs.DNS, rs.DNSDomains, peers)
+}

--- a/wgengine/router/router_darwin.go
+++ b/wgengine/router/router_darwin.go
@@ -2,15 +2,13 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package wgengine
+package router
 
 import (
 	"github.com/tailscale/wireguard-go/device"
 	"github.com/tailscale/wireguard-go/tun"
 	"tailscale.com/types/logger"
 )
-
-const DefaultTunName = "tailscale0"
 
 type darwinRouter struct {
 	tunname string

--- a/wgengine/router/router_darwin_support.go
+++ b/wgengine/router/router_darwin_support.go
@@ -4,7 +4,7 @@
 
 // +build linux darwin
 
-package wgengine
+package router
 
 // SetRoutesFunc applies the given route settings to the OS network
 // stack.

--- a/wgengine/router/router_default.go
+++ b/wgengine/router/router_default.go
@@ -4,15 +4,13 @@
 
 // +build !windows,!linux,!darwin,!openbsd,!freebsd
 
-package wgengine
+package router
 
 import (
 	"github.com/tailscale/wireguard-go/device"
 	"github.com/tailscale/wireguard-go/tun"
 	"tailscale.com/types/logger"
 )
-
-const DefaultTunName = "tailscale0"
 
 func newUserspaceRouter(logf logger.Logf, tunname string, dev *device.Device, tuntap tun.Device, netChanged func()) Router {
 	return NewFakeRouter(logf, tunname, dev, tuntap, netChanged)

--- a/wgengine/router/router_fake.go
+++ b/wgengine/router/router_fake.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package wgengine
+package router
 
 import (
 	"github.com/tailscale/wireguard-go/device"
@@ -10,9 +10,9 @@ import (
 	"tailscale.com/types/logger"
 )
 
-// NewFakeRouter returns a new fake Router implementation whose
-// implementation does nothing and always returns nil errors.
-func NewFakeRouter(logf logger.Logf, _ *device.Device, _ tun.Device) (Router, error) {
+// NewFakeRouter returns a Router that does nothing when called and
+// always returns nil errors.
+func NewFake(logf logger.Logf, _ *device.Device, _ tun.Device) (Router, error) {
 	return fakeRouter{logf: logf}, nil
 }
 

--- a/wgengine/router/router_freebsd.go
+++ b/wgengine/router/router_freebsd.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package wgengine
+package router
 
 import (
 	"fmt"
@@ -19,8 +19,6 @@ import (
 //
 // Work is currently underway for an in-kernel FreeBSD implementation of wireguard
 // https://svnweb.freebsd.org/base?view=revision&revision=357986
-
-const DefaultTunName = "tailscale0"
 
 type freebsdRouter struct {
 	logf    logger.Logf

--- a/wgengine/router/router_linux.go
+++ b/wgengine/router/router_linux.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package wgengine
+package router
 
 import (
 	"bytes"
@@ -21,8 +21,6 @@ import (
 	"tailscale.com/atomicfile"
 	"tailscale.com/types/logger"
 )
-
-const DefaultTunName = "tailscale0"
 
 type linuxRouter struct {
 	logf    func(fmt string, args ...interface{})

--- a/wgengine/router/router_openbsd.go
+++ b/wgengine/router/router_openbsd.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package wgengine
+package router
 
 import (
 	"bytes"
@@ -24,8 +24,6 @@ import (
 // For now this router only supports the WireGuard userspace implementation.
 // There is an experimental kernel version in the works for OpenBSD:
 // https://git.zx2c4.com/wireguard-openbsd.
-
-const DefaultTunName = "tun"
 
 type openbsdRouter struct {
 	logf    logger.Logf

--- a/wgengine/router/router_windows.go
+++ b/wgengine/router/router_windows.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package wgengine
+package router
 
 import (
 	"log"
@@ -12,8 +12,6 @@ import (
 	"github.com/tailscale/wireguard-go/tun"
 	"tailscale.com/types/logger"
 )
-
-const DefaultTunName = "tailscale0"
 
 type winRouter struct {
 	logf                func(fmt string, args ...interface{})

--- a/wgengine/watchdog_test.go
+++ b/wgengine/watchdog_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"tailscale.com/wgengine/router"
 )
 
 func TestWatchdog(t *testing.T) {
@@ -18,7 +20,7 @@ func TestWatchdog(t *testing.T) {
 	t.Run("default watchdog does not fire", func(t *testing.T) {
 		t.Parallel()
 		tun := NewFakeTun()
-		e, err := NewUserspaceEngineAdvanced(t.Logf, tun, NewFakeRouter, 0)
+		e, err := NewUserspaceEngineAdvanced(t.Logf, tun, router.NewFake, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -35,7 +37,7 @@ func TestWatchdog(t *testing.T) {
 	t.Run("watchdog fires on blocked getStatus", func(t *testing.T) {
 		t.Parallel()
 		tun := NewFakeTun()
-		e, err := NewUserspaceEngineAdvanced(t.Logf, tun, NewFakeRouter, 0)
+		e, err := NewUserspaceEngineAdvanced(t.Logf, tun, router.NewFake, 0)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
The router implementations are logically separate, with their own API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/342)
<!-- Reviewable:end -->
