### PR TITLE
go.mod,go.sum: bump golang.org/x/sys for the Android dup2 fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
-	golang.org/x/sys v0.0.0-20200317113312-5766fd39f98d
+	golang.org/x/sys v0.0.0-20200501052902-10377860bb8e
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	gortc.io/stun v1.22.1
 	inet.af/netaddr v0.0.0-20200417213433-f9e5bcc2d6ea

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,8 @@ golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 h1:LfCXLvNmTYH9kEmVgqbnsWfru
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200317113312-5766fd39f98d h1:62ap6LNOjDU6uGmKXHJbSfciMoV+FeI1sRXx/pLDL44=
 golang.org/x/sys v0.0.0-20200317113312-5766fd39f98d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200501052902-10377860bb8e h1:hq86ru83GdWTlfQFZGO4nZJTU4Bs2wfHl8oFHRaXsfc=
+golang.org/x/sys v0.0.0-20200501052902-10377860bb8e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=


### PR DESCRIPTION
No tidy, because it doesn't work for me:

$ go mod tidy
go: finding module for package tailscale.io/control
go: finding module for package tailscale.io/control/cfgdb
tailscale.com/control/controlclient tested by
	tailscale.com/control/controlclient.test imports
	tailscale.io/control: cannot find module providing package tailscale.io/control: unrecognized import path "tailscale.io/control": parse https://tailscale.io/control?go-get=1: no go-import meta tags (meta tag tailscale.com did not match import path tailscale.io/control)
tailscale.com/control/controlclient tested by
	tailscale.com/control/controlclient.test imports
	tailscale.io/control/cfgdb: cannot find module providing package tailscale.io/control/cfgdb: unrecognized import path "tailscale.io/control/cfgdb": parse https://tailscale.io/control/cfgdb?go-get=1: no go-import meta tags (meta tag tailscale.com did not match import path tailscale.io/control/cfgdb)

Signed-off-by: Elias Naur <mail@eliasnaur.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/343)
<!-- Reviewable:end -->
