### PR TITLE
control/controlclient: synchronize hostinfo test.

### DIFF
--- a/control/controlclient/auto_test.go
+++ b/control/controlclient/auto_test.go
@@ -354,13 +354,14 @@ func TestControl(t *testing.T) {
 			t.Errorf("peer KeepAlive=false, want true")
 		}
 		if peer.Hostinfo.OS != "linux" {
-			t.Errorf("peer hostinfo does not have OS: %v", peer.Hostinfo)
+			t.Errorf("peer OS is not linux: %v", peer.Hostinfo)
 		}
 
 		c4.SetHostinfo(&tailcfg.Hostinfo{
 			BackendLogID: "set-hostinfo-test",
 			OS:           "iOS",
 		})
+		c4.waitStatus(t, stateSynchronized)
 		c3NetMap := c3.status(t).New.NetMap
 		c4NetMap = c4.status(t).New.NetMap
 		if len(c3NetMap.Peers) != 1 {
@@ -374,14 +375,14 @@ func TestControl(t *testing.T) {
 			t.Errorf("peer KeepAlive=true, want false")
 		}
 		if peer.Hostinfo.OS != "iOS" {
-			t.Errorf("peer hostinfo does not have OS: %v", peer.Hostinfo)
+			t.Errorf("peer OS is not iOS: %v", peer.Hostinfo)
 		}
 		peer = c4NetMap.Peers[0]
 		if peer.KeepAlive {
 			t.Errorf("peer KeepAlive=true, want false")
 		}
 		if peer.Hostinfo.OS != "linux" {
-			t.Errorf("peer hostinfo does not have OS: %v", peer.Hostinfo)
+			t.Errorf("peer OS is not linux: %v", peer.Hostinfo)
 		}
 
 	})


### PR DESCRIPTION
I believe this is the issue behind the most recent test flake. The second half of the hostinfo test lacked synchronization, so it was possible to see `peer.Hostinfo.OS` with its old value (`macOS`) instead of `iOS` as expected. The error message message arising from this, `peer hostinfo does not have OS`, was eminently confusing, so I changed it as well.