### PR TITLE
control/controlclient: revert extreneous synchronization.

### DIFF
--- a/control/controlclient/auto_test.go
+++ b/control/controlclient/auto_test.go
@@ -361,7 +361,6 @@ func TestControl(t *testing.T) {
 			BackendLogID: "set-hostinfo-test",
 			OS:           "iOS",
 		})
-		c4.waitStatus(t, stateSynchronized)
 		c3NetMap := c3.status(t).New.NetMap
 		c4NetMap = c4.status(t).New.NetMap
 		if len(c3NetMap.Peers) != 1 {


### PR DESCRIPTION
I apologize: in tailscale/tailscale#352, I wrongly assumed that simply running `go test ./...` in this repo is enough to ensure that tests pass. In fact, this is wrong (I believe due to `auto_test.go` having `// +build depends_on_currently_unreleased`), and the newly added synchronization actually breaks the previously flaky test reliably.

This does not quite revert that PR, as I think that the improved error logging is still helpful. However, this line does need to be reverted to prevent an impending test breakage. I will investigate the issue further, this time running the tests properly.