### PR TITLE
Implement rate limiting on log messages

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -51,8 +51,8 @@ func main() {
 	statepath := getopt.StringLong("state", 0, paths.DefaultTailscaledStateFile(), "Path of state file")
 	socketpath := getopt.StringLong("socket", 's', paths.DefaultTailscaledSocket(), "Path of the service unix socket")
 
-	rlPrint := logger.RateLimitedFn(log.Printf, 1, 1)
-	logf := wgengine.RusagePrefixLog(rlPrint)
+	logf := wgengine.RusagePrefixLog(log.Printf)
+	logf = logger.RateLimitedFn(logf, 1, 1, 100)
 
 	err := fixconsole.FixConsoleIfNeeded()
 	if err != nil {

--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -21,6 +21,7 @@ import (
 	"tailscale.com/ipn/ipnserver"
 	"tailscale.com/logpolicy"
 	"tailscale.com/paths"
+	"tailscale.com/types/logger"
 	"tailscale.com/wgengine"
 	"tailscale.com/wgengine/magicsock"
 )
@@ -50,7 +51,8 @@ func main() {
 	statepath := getopt.StringLong("state", 0, paths.DefaultTailscaledStateFile(), "Path of state file")
 	socketpath := getopt.StringLong("socket", 's', paths.DefaultTailscaledSocket(), "Path of the service unix socket")
 
-	logf := wgengine.RusagePrefixLog(log.Printf)
+	rlPrint := logger.RateLimitedFn(log.Printf, 1, 1)
+	logf := wgengine.RusagePrefixLog(rlPrint)
 
 	err := fixconsole.FixConsoleIfNeeded()
 	if err != nil {

--- a/ipn/e2e_test.go
+++ b/ipn/e2e_test.go
@@ -23,6 +23,7 @@ import (
 	"tailscale.com/control/controlclient"
 	"tailscale.com/tailcfg"
 	"tailscale.com/tstest"
+	"tailscale.com/types/logger"
 	"tailscale.com/wgengine"
 	"tailscale.com/wgengine/magicsock"
 	"tailscale.com/wgengine/router"
@@ -191,12 +192,16 @@ type testNode struct {
 // Create a new IPN node.
 func newNode(t *testing.T, prefix string, https *httptest.Server, weirdPrefs bool) testNode {
 	t.Helper()
-	logfe := func(fmt string, args ...interface{}) {
+
+	ulogfe := func(fmt string, args ...interface{}) {
 		t.Logf(prefix+".e: "+fmt, args...)
 	}
-	logf := func(fmt string, args ...interface{}) {
+	logfe := logger.RateLimitedFn(ulogfe, 1, 1)
+
+	ulogf := func(fmt string, args ...interface{}) {
 		t.Logf(prefix+": "+fmt, args...)
 	}
+	logf := logger.RateLimitedFn(ulogf, 1, 1)
 
 	var err error
 	httpc := https.Client()

--- a/ipn/e2e_test.go
+++ b/ipn/e2e_test.go
@@ -196,12 +196,12 @@ func newNode(t *testing.T, prefix string, https *httptest.Server, weirdPrefs boo
 	logfe := func(fmt string, args ...interface{}) {
 		t.Logf(prefix+".e: "+fmt, args...)
 	}
-	logfe := logger.RateLimitedFn(logfe, 1, 1)
+	logfe = logger.RateLimitedFn(logfe, 1, 1, 100)
 
 	logf := func(fmt string, args ...interface{}) {
 		t.Logf(prefix+": "+fmt, args...)
 	}
-	logf := logger.RateLimitedFn(logf, 1, 1, 100)
+	logf = logger.RateLimitedFn(logf, 1, 1, 100)
 
 	var err error
 	httpc := https.Client()

--- a/ipn/e2e_test.go
+++ b/ipn/e2e_test.go
@@ -193,15 +193,9 @@ type testNode struct {
 func newNode(t *testing.T, prefix string, https *httptest.Server, weirdPrefs bool) testNode {
 	t.Helper()
 
-	logfe := func(fmt string, args ...interface{}) {
-		t.Logf(prefix+".e: "+fmt, args...)
-	}
-	logfe = logger.RateLimitedFn(logfe, 1, 1, 100)
+	logfe := logger.RateLimitedFn(logger.WithPrefix(t.Logf, prefix+"e: "), 1, 1, 100)
 
-	logf := func(fmt string, args ...interface{}) {
-		t.Logf(prefix+": "+fmt, args...)
-	}
-	logf = logger.RateLimitedFn(logf, 1, 1, 100)
+	logf := logger.RateLimitedFn(logger.WithPrefix(t.Logf, prefix+": "), 1, 1, 100)
 
 	var err error
 	httpc := https.Client()

--- a/ipn/e2e_test.go
+++ b/ipn/e2e_test.go
@@ -193,15 +193,15 @@ type testNode struct {
 func newNode(t *testing.T, prefix string, https *httptest.Server, weirdPrefs bool) testNode {
 	t.Helper()
 
-	ulogfe := func(fmt string, args ...interface{}) {
+	logfe := func(fmt string, args ...interface{}) {
 		t.Logf(prefix+".e: "+fmt, args...)
 	}
-	logfe := logger.RateLimitedFn(ulogfe, 1, 1)
+	logfe := logger.RateLimitedFn(logfe, 1, 1)
 
-	ulogf := func(fmt string, args ...interface{}) {
+	logf := func(fmt string, args ...interface{}) {
 		t.Logf(prefix+": "+fmt, args...)
 	}
-	logf := logger.RateLimitedFn(ulogf, 1, 1)
+	logf := logger.RateLimitedFn(logf, 1, 1, 100)
 
 	var err error
 	httpc := https.Client()

--- a/ipn/e2e_test.go
+++ b/ipn/e2e_test.go
@@ -193,9 +193,9 @@ type testNode struct {
 func newNode(t *testing.T, prefix string, https *httptest.Server, weirdPrefs bool) testNode {
 	t.Helper()
 
-	logfe := logger.RateLimitedFn(logger.WithPrefix(t.Logf, prefix+"e: "), 1, 1, 100)
+	logfe := logger.WithPrefix(t.Logf, prefix+"e: ")
 
-	logf := logger.RateLimitedFn(logger.WithPrefix(t.Logf, prefix+": "), 1, 1, 100)
+	logf := logger.WithPrefix(t.Logf, prefix+": ")
 
 	var err error
 	httpc := https.Client()

--- a/ipn/ipnserver/server_test.go
+++ b/ipn/ipnserver/server_test.go
@@ -40,7 +40,7 @@ func TestRunMultipleAccepts(t *testing.T) {
 		t.Logf(format, args...)
 	}
 
-	logf := logger.RateLimitedFn(ulogf, 1, 1)
+	logf := logger.RateLimitedFn(ulogf, 1, 1, 100)
 
 	connect := func() {
 		for i := 1; i <= 2; i++ {

--- a/ipn/ipnserver/server_test.go
+++ b/ipn/ipnserver/server_test.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"testing"
 
+	"tailscale.com/types/logger"
+
 	"tailscale.com/ipn"
 	"tailscale.com/ipn/ipnserver"
 	"tailscale.com/safesocket"
@@ -32,11 +34,13 @@ func TestRunMultipleAccepts(t *testing.T) {
 	defer os.RemoveAll(td)
 	socketPath := filepath.Join(td, "tailscale.sock")
 
-	logf := func(format string, args ...interface{}) {
+	ulogf := func(format string, args ...interface{}) {
 		format = strings.TrimRight(format, "\n")
 		println(fmt.Sprintf(format, args...))
 		t.Logf(format, args...)
 	}
+
+	logf := logger.RateLimitedFn(ulogf, 1, 1)
 
 	connect := func() {
 		for i := 1; i <= 2; i++ {

--- a/types/logger/logger.go
+++ b/types/logger/logger.go
@@ -95,19 +95,8 @@ func RateLimitedFn(logf Logf, f float64, b int, m int) Logf {
 
 		mu.Lock()
 		if msgCache.Len() > m {
+			delete(msgLim, msgCache.Back().Value.(string))
 			msgCache.Remove(msgCache.Back())
-		}
-
-		// Purge msgLim of outdated keys to reduce overhead. Must be done by copying
-		// over to a new map and allowing the garbage collector to eat the entire old one,
-		// since deleting keys in maps is done through a "zombie flag" on the data rather than
-		// actually clearing it from memory. See https://github.com/golang/go/issues/20135
-		if len(msgLim)-msgCache.Len() > 100 {
-			newList := make(map[string]*limitData)
-			for e := msgCache.Front(); e != nil; e = e.Next() {
-				newList[e.Value.(string)] = msgLim[e.Value.(string)]
-			}
-			msgLim = newList
 		}
 		mu.Unlock()
 	}

--- a/types/logger/logger_test.go
+++ b/types/logger/logger_test.go
@@ -7,6 +7,7 @@ package logger
 import (
 	"log"
 	"testing"
+	"time"
 )
 
 func TestFuncWriter(t *testing.T) {
@@ -18,4 +19,20 @@ func TestFuncWriter(t *testing.T) {
 func TestStdLogger(t *testing.T) {
 	lg := StdLogger(t.Logf)
 	lg.Printf("plumbed through")
+}
+
+func TestRateLimiter(t *testing.T) {
+	lg := RateLimitedFn(t.Logf, 1, 1)
+	var prefixed Logf
+	for i := 0; i < 10; i++ {
+		lg("boring string with no formatting")
+		lg("templated format string no. %d", i)
+		if i == 4 {
+			lg("Make sure this string makes it through the rest (that are blocked) %d", i)
+		}
+		prefixed = WithPrefix(lg, string('0'+i))
+		prefixed(" shouldn't get filtered.")
+		time.Sleep(200 * time.Millisecond)
+	}
+
 }

--- a/types/logger/logger_test.go
+++ b/types/logger/logger_test.go
@@ -5,9 +5,9 @@
 package logger
 
 import (
+	"fmt"
 	"log"
 	"testing"
-	"time"
 )
 
 func TestFuncWriter(t *testing.T) {
@@ -22,17 +22,41 @@ func TestStdLogger(t *testing.T) {
 }
 
 func TestRateLimiter(t *testing.T) {
-	lg := RateLimitedFn(t.Logf, 1, 1)
+
+	// Testing function. args[0] should indicate what should
+	logTester := func(want []string) Logf {
+		i := 0
+		return func(format string, args ...interface{}) {
+			got := fmt.Sprintf(format, args...)
+			if i >= len(want) {
+				t.Fatalf("Logging continued past end of expected input: %s", got)
+			}
+			if got != want[i] {
+				t.Fatalf("wanted: %s \n got: %s", want[i], got)
+			}
+			i++
+		}
+	}
+
+	want := []string{
+		"boring string with constant formatting (constant)",
+		"templated format string no. 0",
+		"Repeated messages were suppressed by rate limiting. Original message: boring string with constant formatting (constant)",
+		"Repeated messages were suppressed by rate limiting. Original message: templated format string no. 1",
+		"Make sure this string makes it through the rest (that are blocked) 4",
+		"4 shouldn't get filtered.",
+	}
+
+	lg := RateLimitedFn(logTester(want), 1, 1, 50)
 	var prefixed Logf
 	for i := 0; i < 10; i++ {
-		lg("boring string with no formatting")
+		lg("boring string with constant formatting %s", "(constant)")
 		lg("templated format string no. %d", i)
 		if i == 4 {
 			lg("Make sure this string makes it through the rest (that are blocked) %d", i)
+			prefixed = WithPrefix(lg, string('0'+i))
+			prefixed(" shouldn't get filtered.")
 		}
-		prefixed = WithPrefix(lg, string('0'+i))
-		prefixed(" shouldn't get filtered.")
-		time.Sleep(200 * time.Millisecond)
 	}
 
 }


### PR DESCRIPTION
Addresses issue #317, where logs can get spammed with the same message
nonstop. Created a rate limiting closure on logging functions, which
limits the number of messages being logged per second based on format
string.

Signed-off-by: Wendi Yu <wendi@tailscale.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/356)
<!-- Reviewable:end -->
