### PR TITLE
fix unkeyed fields in cmd/derper.go and wgengine/magicsock.go

### DIFF
--- a/cmd/derper/derper.go
+++ b/cmd/derper/derper.go
@@ -166,7 +166,7 @@ func main() {
 		}
 		httpsrv.TLSConfig = certManager.TLSConfig()
 		go func() {
-			err := http.ListenAndServe(":80", certManager.HTTPHandler(tsweb.Port80Handler{mux}))
+			err := http.ListenAndServe(":80", certManager.HTTPHandler(tsweb.Port80Handler{Main: mux}))
 			if err != nil {
 				if err != http.ErrServerClosed {
 					log.Fatal(err)

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -1064,7 +1064,7 @@ func (c *Conn) findAddrSet(addr *net.UDPAddr) *AddrSet {
 	if !ok {
 		return nil
 	}
-	ipp := netaddr.IPPort{ip, uint16(addr.Port)}
+	ipp := netaddr.IPPort{IP: ip, Port: uint16(addr.Port)}
 
 	c.mu.Lock()
 	defer c.mu.Unlock()


### PR DESCRIPTION
Unkeyed fields reduce the readability of the code. Let's avoid that.