### PR TITLE
wgengine/router: remove wireguard-go config from settings.

### DIFF
--- a/wgengine/router/router_darwin.go
+++ b/wgengine/router/router_darwin.go
@@ -26,7 +26,7 @@ func (r *darwinRouter) Up() error {
 	return nil
 }
 
-func (r *darwinRouter) SetRoutes(rs RouteSettings) error {
+func (r *darwinRouter) Set(rs Settings) error {
 	if SetRoutesFunc != nil {
 		return SetRoutesFunc(rs)
 	}

--- a/wgengine/router/router_darwin_support.go
+++ b/wgengine/router/router_darwin_support.go
@@ -6,7 +6,7 @@
 
 package router
 
-// SetRoutesFunc applies the given route settings to the OS network
+// SetRoutesFunc applies the given router settings to the OS network
 // stack.
 //
 // This is logically part of the router_darwin.go implementation, and
@@ -22,4 +22,4 @@ package router
 // as MacOS, so that we don't have to wait until the Mac CI to
 // discover that we broke it. So this one definition needs to exist in
 // both the darwin and linux builds. Hence this file and build tag.
-var SetRoutesFunc func(rs RouteSettings) error
+var SetRoutesFunc func(rs Settings) error

--- a/wgengine/router/router_fake.go
+++ b/wgengine/router/router_fake.go
@@ -25,8 +25,8 @@ func (r fakeRouter) Up() error {
 	return nil
 }
 
-func (r fakeRouter) SetRoutes(rs RouteSettings) error {
-	r.logf("Warning: fakeRouter.SetRoutes: not implemented.")
+func (r fakeRouter) Set(rs Settings) error {
+	r.logf("Warning: fakeRouter.Set: not implemented.")
 	return nil
 }
 

--- a/wgengine/router/router_freebsd.go
+++ b/wgengine/router/router_freebsd.go
@@ -55,7 +55,7 @@ func (r *freebsdRouter) Up() error {
 	return nil
 }
 
-func (r *freebsdRouter) SetRoutes(rs RouteSettings) error {
+func (r *freebsdRouter) Set(rs Settings) error {
 	if len(rs.LocalAddrs) == 0 {
 		return nil
 	}
@@ -95,10 +95,8 @@ func (r *freebsdRouter) SetRoutes(rs RouteSettings) error {
 	}
 
 	newRoutes := make(map[wgcfg.CIDR]struct{})
-	for _, peer := range rs.Cfg.Peers {
-		for _, route := range peer.AllowedIPs {
-			newRoutes[route] = struct{}{}
-		}
+	for _, route := range rs.Routes {
+		newRoutes[route] = struct{}{}
 	}
 	// Delete any pre-existing routes.
 	for route := range r.routes {

--- a/wgengine/router/router_openbsd.go
+++ b/wgengine/router/router_openbsd.go
@@ -60,7 +60,7 @@ func (r *openbsdRouter) Up() error {
 	return nil
 }
 
-func (r *openbsdRouter) SetRoutes(rs RouteSettings) error {
+func (r *openbsdRouter) Set(rs Settings) error {
 	// TODO: support configuring multiple local addrs on interface.
 	if len(rs.LocalAddrs) != 1 {
 		return errors.New("freebsd doesn't support setting multiple local addrs yet")
@@ -114,10 +114,8 @@ func (r *openbsdRouter) SetRoutes(rs RouteSettings) error {
 	}
 
 	newRoutes := make(map[wgcfg.CIDR]struct{})
-	for _, peer := range rs.Cfg.Peers {
-		for _, route := range peer.AllowedIPs {
-			newRoutes[route] = struct{}{}
-		}
+	for _, route := range rs.Routes {
+		newRoutes[route] = struct{}{}
 	}
 	for route := range r.routes {
 		if _, keep := newRoutes[route]; !keep {

--- a/wgengine/router/router_windows.go
+++ b/wgengine/router/router_windows.go
@@ -45,8 +45,8 @@ func (r *winRouter) Up() error {
 	return nil
 }
 
-func (r *winRouter) SetRoutes(rs RouteSettings) error {
-	err := configureInterface(rs.Cfg, r.nativeTun, rs.DNS, rs.DNSDomains)
+func (r *winRouter) Set(rs Settings) error {
+	err := configureInterface(rs, r.nativeTun)
 	if err != nil {
 		r.logf("ConfigureInterface: %v\n", err)
 		return err


### PR DESCRIPTION
Instead, pass in only exactly the relevant configuration pieces
that the OS network stack cares about.

Signed-off-by: David Anderson <danderson@tailscale.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/361)
<!-- Reviewable:end -->
