### PR TITLE
wgengine/router: use inet.af/netaddr, not wgcfg.CIDR.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,6 @@ require (
 	golang.org/x/sys v0.0.0-20200501052902-10377860bb8e
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	gortc.io/stun v1.22.1
-	inet.af/netaddr v0.0.0-20200417213433-f9e5bcc2d6ea
+	inet.af/netaddr v0.0.0-20200430175045-5aaf2097c7fc
 	rsc.io/goversion v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -146,5 +146,7 @@ gortc.io/stun v1.22.1 h1:96mOdDATYRqhYB+TZdenWBg4CzL2Ye5kPyBXQ8KAB+8=
 gortc.io/stun v1.22.1/go.mod h1:XD5lpONVyjvV3BgOyJFNo0iv6R2oZB4L+weMqxts+zg=
 inet.af/netaddr v0.0.0-20200417213433-f9e5bcc2d6ea h1:DpXewrGVf9+vvYQFrNGj9v34bXMuTVQv+2wuULTNV8I=
 inet.af/netaddr v0.0.0-20200417213433-f9e5bcc2d6ea/go.mod h1:qqYzz/2whtrbWJvt+DNWQyvekNN4ePQZcg2xc2/Yjww=
+inet.af/netaddr v0.0.0-20200430175045-5aaf2097c7fc h1:We3b/z+7i9LV4Ls0yWve5vYIlnAPSPeqxKVgZseRDBs=
+inet.af/netaddr v0.0.0-20200430175045-5aaf2097c7fc/go.mod h1:qqYzz/2whtrbWJvt+DNWQyvekNN4ePQZcg2xc2/Yjww=
 rsc.io/goversion v1.2.0 h1:SPn+NLTiAG7w30IRK/DKp1BjvpWabYgxlLp/+kx5J8w=
 rsc.io/goversion v1.2.0/go.mod h1:Eih9y/uIBS3ulggl7KNJ09xGSLcuNaLgmvvqa07sgfo=

--- a/wgengine/router/ifconfig_windows.go
+++ b/wgengine/router/ifconfig_windows.go
@@ -310,12 +310,12 @@ func configureInterface(rs Settings, tun *tun.NativeTun) error {
 			continue
 		}
 		if route.IP.Is4() {
-			if route.Mask == 0 {
+			if route.Bits == 0 {
 				foundDefault4 = true
 			}
 			r.NextHop = *firstGateway4
 		} else if route.IP.Is6() {
-			if route.Mask == 0 {
+			if route.Bits == 0 {
 				foundDefault6 = true
 			}
 			r.NextHop = *firstGateway6
@@ -360,7 +360,7 @@ func configureInterface(rs Settings, tun *tun.NativeTun) error {
 
 	var dnsIPs []net.IP
 	for _, ip := range rs.DNS {
-		dnsIPs = append(dnsIPs, ip.IP())
+		dnsIPs = append(dnsIPs, ip.IPAddr().IP)
 	}
 	err = iface.SetDNS(dnsIPs)
 	if err != nil && errAcc == nil {

--- a/wgengine/router/router.go
+++ b/wgengine/router/router.go
@@ -9,7 +9,7 @@ package router
 import (
 	"github.com/tailscale/wireguard-go/device"
 	"github.com/tailscale/wireguard-go/tun"
-	"github.com/tailscale/wireguard-go/wgcfg"
+	"inet.af/netaddr"
 	"tailscale.com/types/logger"
 )
 
@@ -38,9 +38,9 @@ func New(logf logger.Logf, wgdev *device.Device, tundev tun.Device) (Router, err
 // Settings is the subset of Tailscale configuration that is relevant
 // to the OS's network stack.
 type Settings struct {
-	LocalAddrs   []wgcfg.CIDR
-	DNS          []wgcfg.IP
+	LocalAddrs   []netaddr.IPPrefix
+	DNS          []netaddr.IP
 	DNSDomains   []string
-	Routes       []wgcfg.CIDR // routes to point into the Tailscale interface
-	SubnetRoutes []wgcfg.CIDR // subnets being advertised to other Tailscale nodes
+	Routes       []netaddr.IPPrefix // routes to point into the Tailscale interface
+	SubnetRoutes []netaddr.IPPrefix // subnets being advertised to other Tailscale nodes
 }


### PR DESCRIPTION
For your consideration. I'm neutral on this change, but I'm thinking of moving router out to be a sibling, rather than a child, of wgengine, with glue logic in the ipn package. With that in mind, it makes some sense to cut out wireguard-go entirely from this package. WDYT?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/362)
<!-- Reviewable:end -->
