### PR TITLE
Fix macOS build

### DIFF
--- a/portlist/portlist.go
+++ b/portlist/portlist.go
@@ -21,8 +21,6 @@ type Port struct {
 // List is a list of Ports.
 type List []Port
 
-var protos = []string{"tcp", "udp"}
-
 func (a *Port) lessThan(b *Port) bool {
 	if a.Port < b.Port {
 		return true

--- a/portlist/portlist_linux.go
+++ b/portlist/portlist_linux.go
@@ -24,6 +24,7 @@ const pollInterval = 1 * time.Second
 // TODO(apenwarr): Include IPv6 ports eventually.
 // Right now we don't route IPv6 anyway so it's better to exclude them.
 var sockfiles = []string{"/proc/net/tcp", "/proc/net/udp"}
+var protos = []string{"tcp", "udp"}
 
 func listPorts() (List, error) {
 	l := []Port{}


### PR DESCRIPTION
staticcheck (called by `redo pr`) used to fail on macOS (and presumably 
windows) due to a variable declared in a common package that was only used
by the Linux build, which would prevent `redo pr` from passing on Mac. 
Moved variable declaration from the common file to the Linux-specific one 
to resolve the compiler complaint.

Signed-off-by: Wendi Yu <wendi.yu@yahoo.ca>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/364)
<!-- Reviewable:end -->
