### PR TITLE
wgengine: generate and plumb router.Settings in from ipn.

### DIFF
--- a/ipn/local.go
+++ b/ipn/local.go
@@ -709,16 +709,16 @@ func (b *LocalBackend) authReconfig() {
 		log.Fatalf("WGCfg: %v", err)
 	}
 
-	err = b.e.Reconfig(cfg, routerSettings(cfg, uc, dom))
+	err = b.e.Reconfig(cfg, routerConfig(cfg, uc, dom))
 	if err == wgengine.ErrNoChanges {
 		return
 	}
 	b.logf("authReconfig: ra=%v dns=%v 0x%02x: %v", uc.RouteAll, uc.CorpDNS, uflags, err)
 }
 
-// routerSettings produces a router.Settings from a wireguard config,
+// routerConfig produces a router.Config from a wireguard config,
 // IPN prefs, and the dnsDomains pulled from control's network map.
-func routerSettings(cfg *wgcfg.Config, prefs *Prefs, dnsDomains []string) router.Settings {
+func routerConfig(cfg *wgcfg.Config, prefs *Prefs, dnsDomains []string) *router.Config {
 	var addrs []wgcfg.CIDR
 	for _, addr := range cfg.Addresses {
 		addrs = append(addrs, wgcfg.CIDR{
@@ -731,7 +731,7 @@ func routerSettings(cfg *wgcfg.Config, prefs *Prefs, dnsDomains []string) router
 		})
 	}
 
-	rs := router.Settings{
+	rs := &router.Config{
 		LocalAddrs:   wgCIDRToNetaddr(addrs),
 		DNS:          wgIPToNetaddr(cfg.DNS),
 		DNSDomains:   dnsDomains,
@@ -791,7 +791,7 @@ func (b *LocalBackend) enterState(newState State) {
 		b.blockEngineUpdates(true)
 		fallthrough
 	case Stopped:
-		err := b.e.Reconfig(&wgcfg.Config{}, router.Settings{})
+		err := b.e.Reconfig(&wgcfg.Config{}, nil)
 		if err != nil {
 			b.logf("Reconfig(down): %v", err)
 		}
@@ -867,7 +867,7 @@ func (b *LocalBackend) stateMachine() {
 
 func (b *LocalBackend) stopEngineAndWait() {
 	b.logf("stopEngineAndWait...")
-	b.e.Reconfig(&wgcfg.Config{}, router.Settings{})
+	b.e.Reconfig(&wgcfg.Config{}, nil)
 	b.requestEngineStatusAndWait()
 	b.logf("stopEngineAndWait: done.")
 }

--- a/ipn/local.go
+++ b/ipn/local.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/tailscale/wireguard-go/wgcfg"
+	"inet.af/netaddr"
 	"tailscale.com/control/controlclient"
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/ipn/policy"
@@ -25,6 +26,7 @@ import (
 	"tailscale.com/version"
 	"tailscale.com/wgengine"
 	"tailscale.com/wgengine/filter"
+	"tailscale.com/wgengine/router"
 )
 
 // LocalBackend is the scaffolding between the Tailscale cloud control
@@ -707,11 +709,64 @@ func (b *LocalBackend) authReconfig() {
 		log.Fatalf("WGCfg: %v", err)
 	}
 
-	err = b.e.Reconfig(cfg, dom, uc.AdvertiseRoutes, uc.NoSNAT)
+	err = b.e.Reconfig(cfg, routerSettings(cfg, uc, dom))
 	if err == wgengine.ErrNoChanges {
 		return
 	}
 	b.logf("authReconfig: ra=%v dns=%v 0x%02x: %v", uc.RouteAll, uc.CorpDNS, uflags, err)
+}
+
+// routerSettings produces a router.Settings from a wireguard config,
+// IPN prefs, and the dnsDomains pulled from control's network map.
+func routerSettings(cfg *wgcfg.Config, prefs *Prefs, dnsDomains []string) router.Settings {
+	var addrs []wgcfg.CIDR
+	for _, addr := range cfg.Addresses {
+		addrs = append(addrs, wgcfg.CIDR{
+			IP: addr.IP,
+			// TODO(apenwarr): this shouldn't be hardcoded in the client
+			// TODO(danderson): fairly sure we can make this a /32 or
+			// /128 based on address family. Need to check behavior on
+			// !linux OSes.
+			Mask: 10,
+		})
+	}
+
+	rs := router.Settings{
+		LocalAddrs:   wgCIDRToNetaddr(addrs),
+		DNS:          wgIPToNetaddr(cfg.DNS),
+		DNSDomains:   dnsDomains,
+		SubnetRoutes: wgCIDRToNetaddr(prefs.AdvertiseRoutes),
+		NoSNAT:       prefs.NoSNAT,
+	}
+
+	for _, peer := range cfg.Peers {
+		rs.Routes = append(rs.Routes, wgCIDRToNetaddr(peer.AllowedIPs)...)
+	}
+
+	return rs
+}
+
+func wgIPToNetaddr(ips []wgcfg.IP) (ret []netaddr.IP) {
+	for _, ip := range ips {
+		nip, ok := netaddr.FromStdIP(ip.IP())
+		if !ok {
+			panic(fmt.Sprintf("conversion of %s from wgcfg to netaddr IP failed", ip))
+		}
+		ret = append(ret, nip.Unmap())
+	}
+	return ret
+}
+
+func wgCIDRToNetaddr(cidrs []wgcfg.CIDR) (ret []netaddr.IPPrefix) {
+	for _, cidr := range cidrs {
+		ncidr, ok := netaddr.FromStdIPNet(cidr.IPNet())
+		if !ok {
+			panic(fmt.Sprintf("conversion of %s from wgcfg to netaddr IPNet failed", cidr))
+		}
+		ncidr.IP = ncidr.IP.Unmap()
+		ret = append(ret, ncidr)
+	}
+	return ret
 }
 
 func (b *LocalBackend) enterState(newState State) {
@@ -736,7 +791,7 @@ func (b *LocalBackend) enterState(newState State) {
 		b.blockEngineUpdates(true)
 		fallthrough
 	case Stopped:
-		err := b.e.Reconfig(&wgcfg.Config{}, nil, nil, false)
+		err := b.e.Reconfig(&wgcfg.Config{}, router.Settings{})
 		if err != nil {
 			b.logf("Reconfig(down): %v", err)
 		}
@@ -812,7 +867,7 @@ func (b *LocalBackend) stateMachine() {
 
 func (b *LocalBackend) stopEngineAndWait() {
 	b.logf("stopEngineAndWait...")
-	b.e.Reconfig(&wgcfg.Config{}, nil, nil, false)
+	b.e.Reconfig(&wgcfg.Config{}, router.Settings{})
 	b.requestEngineStatusAndWait()
 	b.logf("stopEngineAndWait: done.")
 }

--- a/wgengine/router/ifconfig_windows.go
+++ b/wgengine/router/ifconfig_windows.go
@@ -236,7 +236,7 @@ func setFirewall(ifcGUID *windows.GUID) (bool, error) {
 	return false, nil
 }
 
-func configureInterface(rs Settings, tun *tun.NativeTun) error {
+func configureInterface(cfg *Config, tun *tun.NativeTun) error {
 	const mtu = 0
 	guid := tun.GUID()
 	log.Printf("wintun GUID is %v\n", guid)
@@ -262,13 +262,13 @@ func configureInterface(rs Settings, tun *tun.NativeTun) error {
 		}
 	}()
 
-	setDNSDomains(guid, rs.DNSDomains)
+	setDNSDomains(guid, cfg.DNSDomains)
 
 	routes := []winipcfg.RouteData{}
 	var firstGateway4 *net.IP
 	var firstGateway6 *net.IP
-	addresses := make([]*net.IPNet, len(rs.LocalAddrs))
-	for i, addr := range rs.LocalAddrs {
+	addresses := make([]*net.IPNet, len(cfg.LocalAddrs))
+	for i, addr := range cfg.LocalAddrs {
 		ipnet := addr.IPNet()
 		addresses[i] = ipnet
 		gateway := ipnet.IP
@@ -281,7 +281,7 @@ func configureInterface(rs Settings, tun *tun.NativeTun) error {
 
 	foundDefault4 := false
 	foundDefault6 := false
-	for _, route := range rs.Routes {
+	for _, route := range cfg.Routes {
 		if (route.IP.Is4() && firstGateway4 == nil) || (route.IP.Is6() && firstGateway6 == nil) {
 			return errors.New("Due to a Windows limitation, one cannot have interface routes without an interface address")
 		}
@@ -359,7 +359,7 @@ func configureInterface(rs Settings, tun *tun.NativeTun) error {
 	}
 
 	var dnsIPs []net.IP
-	for _, ip := range rs.DNS {
+	for _, ip := range cfg.DNS {
 		dnsIPs = append(dnsIPs, ip.IPAddr().IP)
 	}
 	err = iface.SetDNS(dnsIPs)

--- a/wgengine/router/router_darwin.go
+++ b/wgengine/router/router_darwin.go
@@ -26,11 +26,14 @@ func (r *darwinRouter) Up() error {
 	return nil
 }
 
-func (r *darwinRouter) Set(rs Settings) error {
-	if SetRoutesFunc != nil {
-		return SetRoutesFunc(rs)
+func (r *darwinRouter) Set(cfg *Config) error {
+	if SetRoutesFunc == nil {
+		return nil
 	}
-	return nil
+	if cfg == nil {
+		cfg = &shutdownConfig
+	}
+	return SetRoutesFunc(cfg)
 }
 
 func (r *darwinRouter) Close() error {

--- a/wgengine/router/router_darwin_support.go
+++ b/wgengine/router/router_darwin_support.go
@@ -7,7 +7,7 @@
 package router
 
 // SetRoutesFunc applies the given router settings to the OS network
-// stack.
+// stack. cfg is guaranteed to be non-nil.
 //
 // This is logically part of the router_darwin.go implementation, and
 // should not be used on other platforms.
@@ -22,4 +22,4 @@ package router
 // as MacOS, so that we don't have to wait until the Mac CI to
 // discover that we broke it. So this one definition needs to exist in
 // both the darwin and linux builds. Hence this file and build tag.
-var SetRoutesFunc func(rs Settings) error
+var SetRoutesFunc func(cfg *Config) error

--- a/wgengine/router/router_fake.go
+++ b/wgengine/router/router_fake.go
@@ -25,7 +25,7 @@ func (r fakeRouter) Up() error {
 	return nil
 }
 
-func (r fakeRouter) Set(rs Settings) error {
+func (r fakeRouter) Set(cfg *Config) error {
 	r.logf("Warning: fakeRouter.Set: not implemented.")
 	return nil
 }

--- a/wgengine/router/router_freebsd.go
+++ b/wgengine/router/router_freebsd.go
@@ -55,15 +55,18 @@ func (r *freebsdRouter) Up() error {
 	return nil
 }
 
-func (r *freebsdRouter) Set(rs Settings) error {
-	if len(rs.LocalAddrs) == 0 {
+func (r *freebsdRouter) Set(cfg *Config) error {
+	if cfg == nil {
+		cfg = &shutdownConfig
+	}
+	if len(cfg.LocalAddrs) == 0 {
 		return nil
 	}
 	// TODO: support configuring multiple local addrs on interface.
-	if len(rs.LocalAddrs) != 1 {
+	if len(cfg.LocalAddrs) != 1 {
 		return errors.New("freebsd doesn't support setting multiple local addrs yet")
 	}
-	localAddr := rs.LocalAddrs[0]
+	localAddr := cfg.LocalAddrs[0]
 
 	var errq error
 
@@ -95,7 +98,7 @@ func (r *freebsdRouter) Set(rs Settings) error {
 	}
 
 	newRoutes := make(map[netaddr.IPPrefix]struct{})
-	for _, route := range rs.Routes {
+	for _, route := range cfg.Routes {
 		newRoutes[route] = struct{}{}
 	}
 	// Delete any pre-existing routes.
@@ -139,7 +142,7 @@ func (r *freebsdRouter) Set(rs Settings) error {
 	r.local = localAddr
 	r.routes = newRoutes
 
-	if err := r.replaceResolvConf(rs.DNS, rs.DNSDomains); err != nil {
+	if err := r.replaceResolvConf(cfg.DNS, cfg.DNSDomains); err != nil {
 		errq = fmt.Errorf("replacing resolv.conf failed: %v", err)
 	}
 

--- a/wgengine/router/router_openbsd.go
+++ b/wgengine/router/router_openbsd.go
@@ -60,12 +60,16 @@ func (r *openbsdRouter) Up() error {
 	return nil
 }
 
-func (r *openbsdRouter) Set(rs Settings) error {
+func (r *openbsdRouter) Set(cfg *Config) error {
+	if cfg == nil {
+		cfg = &shutdownConfig
+	}
+
 	// TODO: support configuring multiple local addrs on interface.
-	if len(rs.LocalAddrs) != 1 {
+	if len(cfg.LocalAddrs) != 1 {
 		return errors.New("freebsd doesn't support setting multiple local addrs yet")
 	}
-	localAddr := rs.LocalAddrs[0]
+	localAddr := cfg.LocalAddrs[0]
 
 	var errq error
 
@@ -114,7 +118,7 @@ func (r *openbsdRouter) Set(rs Settings) error {
 	}
 
 	newRoutes := make(map[netaddr.IPPrefix]struct{})
-	for _, route := range rs.Routes {
+	for _, route := range cfg.Routes {
 		newRoutes[route] = struct{}{}
 	}
 	for route := range r.routes {
@@ -155,7 +159,7 @@ func (r *openbsdRouter) Set(rs Settings) error {
 	r.local = localAddr
 	r.routes = newRoutes
 
-	if err := r.replaceResolvConf(rs.DNS, rs.DNSDomains); err != nil {
+	if err := r.replaceResolvConf(cfg.DNS, cfg.DNSDomains); err != nil {
 		errq = fmt.Errorf("replacing resolv.conf failed: %v", err)
 	}
 

--- a/wgengine/router/router_windows.go
+++ b/wgengine/router/router_windows.go
@@ -45,8 +45,12 @@ func (r *winRouter) Up() error {
 	return nil
 }
 
-func (r *winRouter) Set(rs Settings) error {
-	err := configureInterface(rs, r.nativeTun)
+func (r *winRouter) Set(cfg *Config) error {
+	if cfg == nil {
+		cfg = &shutdownConfig
+	}
+
+	err := configureInterface(cfg, r.nativeTun)
 	if err != nil {
 		r.logf("ConfigureInterface: %v\n", err)
 		return err

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -243,7 +243,7 @@ func newUserspaceEngineAdvanced(logf logger.Logf, tundev tun.Device, routerGen R
 	}
 	// TODO(danderson): we should delete this. It's pointless to apply
 	// a no-op settings here.
-	if err := e.router.Set(router.Settings{}); err != nil {
+	if err := e.router.Set(nil); err != nil {
 		e.wgdev.Close()
 		return nil, err
 	}
@@ -326,7 +326,7 @@ func (e *userspaceEngine) pinger(peerKey wgcfg.Key, ips []wgcfg.IP) {
 	}
 }
 
-func configSignature(cfg *wgcfg.Config, routerCfg router.Settings) (string, error) {
+func configSignature(cfg *wgcfg.Config, routerCfg *router.Config) (string, error) {
 	// TODO(apenwarr): get rid of uapi stuff for in-process comms
 	uapi, err := cfg.ToUAPI()
 	if err != nil {
@@ -336,7 +336,7 @@ func configSignature(cfg *wgcfg.Config, routerCfg router.Settings) (string, erro
 	return fmt.Sprintf("%s %v", uapi, routerCfg), nil
 }
 
-func (e *userspaceEngine) Reconfig(cfg *wgcfg.Config, routerCfg router.Settings) error {
+func (e *userspaceEngine) Reconfig(cfg *wgcfg.Config, routerCfg *router.Config) error {
 	e.wgLock.Lock()
 	defer e.wgLock.Unlock()
 

--- a/wgengine/watchdog.go
+++ b/wgengine/watchdog.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tailscale/wireguard-go/wgcfg"
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/wgengine/filter"
+	"tailscale.com/wgengine/router"
 )
 
 // NewWatchdog wraps an Engine and makes sure that all methods complete
@@ -61,8 +62,8 @@ func (e *watchdogEngine) watchdog(name string, fn func()) {
 	})
 }
 
-func (e *watchdogEngine) Reconfig(cfg *wgcfg.Config, dnsDomains []string, localRoutes []wgcfg.CIDR, noSNAT bool) error {
-	return e.watchdogErr("Reconfig", func() error { return e.wrap.Reconfig(cfg, dnsDomains, localRoutes, noSNAT) })
+func (e *watchdogEngine) Reconfig(cfg *wgcfg.Config, routerCfg router.Settings) error {
+	return e.watchdogErr("Reconfig", func() error { return e.wrap.Reconfig(cfg, routerCfg) })
 }
 func (e *watchdogEngine) GetFilter() *filter.Filter {
 	var x *filter.Filter

--- a/wgengine/watchdog.go
+++ b/wgengine/watchdog.go
@@ -62,7 +62,7 @@ func (e *watchdogEngine) watchdog(name string, fn func()) {
 	})
 }
 
-func (e *watchdogEngine) Reconfig(cfg *wgcfg.Config, routerCfg router.Settings) error {
+func (e *watchdogEngine) Reconfig(cfg *wgcfg.Config, routerCfg *router.Config) error {
 	return e.watchdogErr("Reconfig", func() error { return e.wrap.Reconfig(cfg, routerCfg) })
 }
 func (e *watchdogEngine) GetFilter() *filter.Filter {

--- a/wgengine/wgengine.go
+++ b/wgengine/wgengine.go
@@ -12,6 +12,7 @@ import (
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/tailcfg"
 	"tailscale.com/wgengine/filter"
+	"tailscale.com/wgengine/router"
 )
 
 // ByteCount is the number of bytes that have been sent or received.
@@ -59,7 +60,7 @@ type Engine interface {
 	// sends an updated network map.
 	//
 	// The returned error is ErrNoChanges if no changes were made.
-	Reconfig(cfg *wgcfg.Config, dnsDomains []string, localSubnets []wgcfg.CIDR, noSNAT bool) error
+	Reconfig(cfg *wgcfg.Config, routerCfg router.Settings) error
 
 	// GetFilter returns the current packet filter, if any.
 	GetFilter() *filter.Filter

--- a/wgengine/wgengine.go
+++ b/wgengine/wgengine.go
@@ -53,14 +53,11 @@ type Engine interface {
 	// Reconfig reconfigures WireGuard and makes sure it's running.
 	// This also handles setting up any kernel routes.
 	//
-	// The provided DNS domains are not part of wgcfg.Config, as
-	// WireGuard itself doesn't care about such things.
-	//
 	// This is called whenever the tailcontrol (control plane)
 	// sends an updated network map.
 	//
 	// The returned error is ErrNoChanges if no changes were made.
-	Reconfig(cfg *wgcfg.Config, routerCfg router.Settings) error
+	Reconfig(*wgcfg.Config, *router.Config) error
 
 	// GetFilter returns the current packet filter, if any.
 	GetFilter() *filter.Filter


### PR DESCRIPTION
This saves a layer of translation, and saves us having to
pass in extra bits and pieces of the netmap and prefs to
wgengine. Now it gets one Wireguard config, and one OS
network stack config.

Signed-off-by: David Anderson <danderson@tailscale.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/373)
<!-- Reviewable:end -->
