### PR TITLE
cmd/tailscale: expose --enable-derp

### DIFF
--- a/cmd/tailscale/tailscale.go
+++ b/cmd/tailscale/tailscale.go
@@ -57,6 +57,7 @@ func main() {
 	upf.BoolVar(&upArgs.shieldsUp, "shields-up", false, "don't allow incoming connections")
 	upf.StringVar(&upArgs.advertiseTags, "advertise-tags", "", "ACL tags to request (comma-separated, e.g. eng,montreal,ssh)")
 	upf.StringVar(&upArgs.authKey, "authkey", "", "node authorization key")
+	upf.BoolVar(&upArgs.enableDERP, "enable-derp", true, "enable the use of DERP servers")
 	if runtime.GOOS == "linux" {
 		upf.StringVar(&upArgs.advertiseRoutes, "advertise-routes", "", "routes to advertise to other nodes (comma-separated, e.g. 10.0.0.0/8,192.168.0.0/24)")
 		upf.BoolVar(&upArgs.noSNAT, "no-snat", false, "disable SNAT of traffic to local routes advertised with -advertise-routes")
@@ -110,6 +111,7 @@ var upArgs struct {
 	shieldsUp       bool
 	advertiseRoutes string
 	advertiseTags   string
+	enableDERP      bool
 	noSNAT          bool
 	netfilterMode   string
 	authKey         string
@@ -203,6 +205,7 @@ func runUp(ctx context.Context, args []string) error {
 	prefs.AdvertiseRoutes = routes
 	prefs.AdvertiseTags = tags
 	prefs.NoSNAT = upArgs.noSNAT
+	prefs.DisableDERP = !upArgs.enableDERP
 	if runtime.GOOS == "linux" {
 		switch upArgs.netfilterMode {
 		case "on":


### PR DESCRIPTION
This is a really trivial change that just exposes in the tailscale CLI a flag already present in prefs. As far as I know, this setting is togglable at least on Windows, so I presume we intend to support it. I named the CLI flag consistently with `--no-snat`, even though the pref name is different. Renaming the pref would have to work around existing clients, I imagine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/385)
<!-- Reviewable:end -->
