### PR TITLE
wgengine: pass tun.NativeDevice to router

### DIFF
--- a/wgengine/tstun/tun.go
+++ b/wgengine/tstun/tun.go
@@ -262,3 +262,8 @@ func (t *TUN) InjectOutbound(packet []byte) error {
 		return nil
 	}
 }
+
+// Unwrap returns the underlying TUN device.
+func (t *TUN) Unwrap() tun.Device {
+	return t.tdev
+}

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -206,7 +206,9 @@ func newUserspaceEngineAdvanced(logf logger.Logf, tundev *tstun.TUN, routerGen R
 		}
 	}()
 
-	e.router, err = routerGen(logf, e.wgdev, e.tundev)
+	// Pass the underlying tun.(*NativeDevice) to the router:
+	// routers do not Read or Write, but do access native interfaces.
+	e.router, err = routerGen(logf, e.wgdev, e.tundev.Unwrap())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Unfortunately, in my tstun patch I overlooked that `router_windows.go` asserts that the `tun.Device` it receives is a `tun.(*NativeDevice)`. I hoped to avoid providing `Unwrap()`, but it seems like the best solution. If I change the interface of `newUserspaceEngineAdvanced` back to receiving a `tun.Device` and wrapping it inside, then callers cannot get at the wrapped TUN without `userspaceEngine` exposing it. I'm not sure that that would be cleaner.

I have verified that both native and fake modes start without issues on Linux and Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/390)
<!-- Reviewable:end -->
