### PR TITLE
wgengine/tstun: tolerate 0-reads

### DIFF
--- a/wgengine/tstun/tun.go
+++ b/wgengine/tstun/tun.go
@@ -180,7 +180,7 @@ func (t *TUN) Read(buf []byte, offset int) (int, error) {
 		n = copy(buf[offset:], packet)
 		// t.buffer has a fixed location in memory,
 		// so this is the easiest way to tell when it has been consumed.
-		if &packet[0] == &t.buffer[readOffset] {
+		if len(packet) == 0 || &packet[0] == &t.buffer[readOffset] {
 			t.bufferConsumed <- struct{}{}
 		}
 	}


### PR DESCRIPTION
0-reads may happen on Android during VPN device handover.

Signed-off-by: Elias Naur <mail@eliasnaur.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/404)
<!-- Reviewable:end -->
