### PR TITLE
filter: prevent escape of QDecode to the heap

### DIFF
--- a/wgengine/filter/filter.go
+++ b/wgengine/filter/filter.go
@@ -138,16 +138,16 @@ var acceptBucket = rate.NewLimiter(rate.Every(10*time.Second), 3)
 var dropBucket = rate.NewLimiter(rate.Every(5*time.Second), 10)
 
 func (f *Filter) logRateLimit(runflags RunFlags, b []byte, q *packet.QDecode, r Response, why string) {
+	var qs string
+	if q == nil {
+		qs = fmt.Sprintf("(%d bytes)", len(b))
+	} else {
+		qs = q.String()
+	}
 	if r == Drop && (runflags&LogDrops) != 0 && dropBucket.Allow() {
-		var qs string
-		if q == nil {
-			qs = fmt.Sprintf("(%d bytes)", len(b))
-		} else {
-			qs = q.String()
-		}
 		f.logf("Drop: %v %v %s\n%s", qs, len(b), why, maybeHexdump(runflags&HexdumpDrops, b))
 	} else if r == Accept && (runflags&LogAccepts) != 0 && acceptBucket.Allow() {
-		f.logf("Accept: %v %v %s\n%s", q, len(b), why, maybeHexdump(runflags&HexdumpAccepts, b))
+		f.logf("Accept: %v %v %s\n%s", qs, len(b), why, maybeHexdump(runflags&HexdumpAccepts, b))
 	}
 }
 


### PR DESCRIPTION
Right now, `q` from `tstun` escapes to the heap, as reported by
```sh
go install --gcflags=tailscale.com/wgengine/...=-m ./wgengine/tstun
```
Namely, we have
```
wgengine/tstun/tun.go:179:6: moved to heap: q
```
in
```go
179	var q packet.QDecode
180	if filt.RunOut(buf, &q, t.filterFlags) == filter.Accept {
```
and
```
wgengine/tstun/tun.go:221:6: moved to heap: q
```
in
```go
221	var q packet.QDecode
222	if filt.RunIn(buf, &q, t.filterFlags) == filter.Accept {
```
In turns out that this is because `q` is directly passed to `logf` in one case, and `logf` is an interface, so escape is inevitable. This slight reordering fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/417)
<!-- Reviewable:end -->
