### PR TITLE
net/netns: add package for start of network namespace support

### DIFF
--- a/net/netcheck/netcheck.go
+++ b/net/netcheck/netcheck.go
@@ -23,6 +23,7 @@ import (
 	"inet.af/netaddr"
 	"tailscale.com/net/dnscache"
 	"tailscale.com/net/interfaces"
+	"tailscale.com/net/netns"
 	"tailscale.com/net/stun"
 	"tailscale.com/syncs"
 	"tailscale.com/tailcfg"
@@ -656,7 +657,7 @@ func (c *Client) GetReport(ctx context.Context, dm *tailcfg.DERPMap) (*Report, e
 	}
 
 	// Create a UDP4 socket used for sending to our discovered IPv4 address.
-	rs.pc4Hair, err = net.ListenPacket("udp4", ":0")
+	rs.pc4Hair, err = netns.Listener().ListenPacket(ctx, "udp4", ":0")
 	if err != nil {
 		c.logf("udp4: %v", err)
 		return nil, err
@@ -666,7 +667,7 @@ func (c *Client) GetReport(ctx context.Context, dm *tailcfg.DERPMap) (*Report, e
 	if f := c.GetSTUNConn4; f != nil {
 		rs.pc4 = f()
 	} else {
-		u4, err := net.ListenPacket("udp4", ":0")
+		u4, err := netns.Listener().ListenPacket(ctx, "udp4", ":0")
 		if err != nil {
 			c.logf("udp4: %v", err)
 			return nil, err
@@ -679,7 +680,7 @@ func (c *Client) GetReport(ctx context.Context, dm *tailcfg.DERPMap) (*Report, e
 		if f := c.GetSTUNConn6; f != nil {
 			rs.pc6 = f()
 		} else {
-			u6, err := net.ListenPacket("udp6", ":0")
+			u6, err := netns.Listener().ListenPacket(ctx, "udp6", ":0")
 			if err != nil {
 				c.logf("udp6: %v", err)
 			} else {

--- a/net/netns/netns.go
+++ b/net/netns/netns.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package netns contains the common code for using the Go net package
+// in a logical "network namespace" to avoid routing loops where
+// Tailscale-created packets would otherwise loop back through
+// Tailscale routes.
+//
+// Despite the name netns, the exact mechanism used differs by
+// operating system, and perhaps even by version of the OS.
+package netns
+
+import (
+	"net"
+	"syscall"
+)
+
+// Listener returns a new net.Listener with its Control hook func
+// initialized as necessary to run in logical network namespace that
+// doesn't route back into Tailscale.
+func Listener() *net.ListenConfig {
+	return &net.ListenConfig{Control: control}
+}
+
+// control marks c as necessary to dial in a separate network namespace.
+//
+// It's intentionally the same signature as net.Dialer.Control
+// and net.ListenConfig.Control.
+func control(network, address string, c syscall.RawConn) error {
+	// TODO: implement
+	return nil
+}


### PR DESCRIPTION
net/netns: add package for start of network namespace support

And plumb in netcheck STUN packets.

TODO: derphttp, logs, control.

Updates #144

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/422)
<!-- Reviewable:end -->
