### PR TITLE
ipn: add Hostname override to Options

### DIFF
--- a/ipn/local.go
+++ b/ipn/local.go
@@ -654,6 +654,9 @@ func (b *LocalBackend) SetPrefs(new *Prefs) {
 	oldHi := b.hiCache
 	newHi := oldHi.Clone()
 	newHi.RoutableIPs = append([]wgcfg.CIDR(nil), b.prefs.AdvertiseRoutes...)
+	if h := new.Hostname; h != "" {
+		newHi.Hostname = h
+	}
 	b.hiCache = newHi
 	b.mu.Unlock()
 

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -51,6 +51,9 @@ type Prefs struct {
 	// the control server will allow you to take on the rights for that
 	// tag.
 	AdvertiseTags []string
+	// Hostname is the hostname to use for identifying the node. If
+	// not set, os.Hostname is used.
+	Hostname string
 
 	// NotepadURLs is a debugging setting that opens OAuth URLs in
 	// notepad.exe on Windows, rather than loading them in a browser.
@@ -134,6 +137,7 @@ func (p *Prefs) Equals(p2 *Prefs) bool {
 		p.ShieldsUp == p2.ShieldsUp &&
 		p.NoSNAT == p2.NoSNAT &&
 		p.NetfilterMode == p2.NetfilterMode &&
+		p.Hostname == p2.Hostname &&
 		compareIPNets(p.AdvertiseRoutes, p2.AdvertiseRoutes) &&
 		compareStrings(p.AdvertiseTags, p2.AdvertiseTags) &&
 		p.Persist.Equals(p2.Persist)

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -24,7 +24,7 @@ func fieldsOf(t reflect.Type) (fields []string) {
 func TestPrefsEqual(t *testing.T) {
 	tstest.PanicOnLog()
 
-	prefsHandles := []string{"ControlURL", "RouteAll", "AllowSingleHosts", "CorpDNS", "WantRunning", "ShieldsUp", "AdvertiseTags", "NotepadURLs", "DisableDERP", "AdvertiseRoutes", "NoSNAT", "NetfilterMode", "Persist"}
+	prefsHandles := []string{"ControlURL", "RouteAll", "AllowSingleHosts", "CorpDNS", "WantRunning", "ShieldsUp", "AdvertiseTags", "Hostname", "NotepadURLs", "DisableDERP", "AdvertiseRoutes", "NoSNAT", "NetfilterMode", "Persist"}
 	if have := fieldsOf(reflect.TypeOf(Prefs{})); !reflect.DeepEqual(have, prefsHandles) {
 		t.Errorf("Prefs.Equal check might be out of sync\nfields: %q\nhandled: %q\n",
 			have, prefsHandles)
@@ -123,6 +123,17 @@ func TestPrefsEqual(t *testing.T) {
 		{
 			&Prefs{NoSNAT: true},
 			&Prefs{NoSNAT: true},
+			true,
+		},
+
+		{
+			&Prefs{Hostname: "android-host01"},
+			&Prefs{Hostname: "android-host02"},
+			false,
+		},
+		{
+			&Prefs{Hostname: ""},
+			&Prefs{Hostname: ""},
 			true,
 		},
 


### PR DESCRIPTION
Overriding the hostname is required for Android, where os.Hostname
is often just "localhost".

Signed-off-by: Elias Naur <mail@eliasnaur.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/429)
<!-- Reviewable:end -->
