### PR TITLE
wgengine/router: also accept exit code 254 from `ip rule del`.

### DIFF
--- a/wgengine/router/router_linux.go
+++ b/wgengine/router/router_linux.go
@@ -519,7 +519,7 @@ func (r *linuxRouter) addIPRules() error {
 		return err
 	}
 
-	rg := newRunGroup(0, r.cmd)
+	rg := newRunGroup(nil, r.cmd)
 
 	// NOTE(apenwarr): We leave spaces between each pref number.
 	// This is so the sysadmin can override by inserting rules in
@@ -588,7 +588,10 @@ func (r *linuxRouter) delIPRules() error {
 	// Error codes: 'ip rule' returns error code 2 if the rule is a
 	// duplicate (add) or not found (del). It returns a different code
 	// for syntax errors. This is also true of busybox.
-	rg := newRunGroup(2, r.cmd)
+	//
+	// Some older versions of iproute2 also return error code 254 for
+	// unknown rules during deletion.
+	rg := newRunGroup([]int{2, 254}, r.cmd)
 
 	// When deleting rules, we want to be a bit specific (mention which
 	// table we were routing to) but not *too* specific (fwmarks, etc).


### PR DESCRIPTION
iproute2 3.16.0-2 from Debian Jessie (oldoldstable) doesn't return
exit code 2 when deleting a non-existent IP rule.

Fixes #434

Signed-off-by: David Anderson <danderson@tailscale.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/435)
<!-- Reviewable:end -->
