### PR TITLE
wgengine/router: do not call ifconfig up if SetRoutesFunc is set

### DIFF
--- a/wgengine/router/router_darwin.go
+++ b/wgengine/router/router_darwin.go
@@ -45,3 +45,10 @@ func (r *darwinRouter) Set(cfg *Config) error {
 
 	return r.Router.Set(cfg)
 }
+
+func (r *darwinRouter) Up() error {
+	if SetRoutesFunc != nil {
+		return nil // bringing up the tunnel is handled externally
+	}
+	return r.Router.Up()
+}


### PR DESCRIPTION
The NetworkExtension brings up the interface itself and does not have
access to `ifconfig`, which the underlying BSD userspace router attempts
to use when Up is called.

Signed-off-by: David Crawshaw <crawshaw@tailscale.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/512)
<!-- Reviewable:end -->
