### PR TITLE
wgengine: eliminate deadlock in Close

### DIFF
--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -759,10 +759,10 @@ func (e *userspaceEngine) Close() {
 
 	r := bufio.NewReader(strings.NewReader(""))
 	e.wgdev.IpcSetOperation(r)
-	e.wgdev.Close()
+	e.magicConn.Close()
 	e.linkMon.Close()
 	e.router.Close()
-	e.magicConn.Close()
+	e.wgdev.Close()
 
 	// Shut down pingers after tundev is closed (by e.wgdev.Close) so the
 	// synchronous close does not get stuck on InjectOutbound.

--- a/wgengine/watchdog_test.go
+++ b/wgengine/watchdog_test.go
@@ -24,6 +24,8 @@ func TestWatchdog(t *testing.T) {
 
 		e = NewWatchdog(e)
 		e.(*watchdogEngine).maxWait = 150 * time.Millisecond
+		e.(*watchdogEngine).logf = t.Logf
+		e.(*watchdogEngine).fatalf = t.Fatalf
 
 		e.RequestStatus()
 		e.RequestStatus()
@@ -65,5 +67,9 @@ func TestWatchdog(t *testing.T) {
 		case <-time.After(3 * time.Second):
 			t.Fatalf("watchdog failed to fire")
 		}
+
+		usEngine.wgLock.Unlock()
+		wdEngine.fatalf = t.Fatalf
+		wdEngine.Close()
 	})
 }


### PR DESCRIPTION
This gets `userspaceEngine.Close` to close components in reverse order of bringup, which eliminates a deadlock that occasionally surfaces under the race detector. Also, an unrelated log-after-exit issue is fixed in `watchdog_test` by closing the engine before leaving.

This may seem like merely "masking the problem", but relying on the Wireguard device being around at Close time seems reasonable. In fact, this fix has to be done anyway for graceful shutdown (it is included in #514), since the router already doesn't like the interface disappearing from underneath it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/520)
<!-- Reviewable:end -->
