### PR TITLE
version: explicitly use 9 hex digits in git describe version number

### DIFF
--- a/version/describe.txt.do
+++ b/version/describe.txt.do
@@ -1,4 +1,4 @@
-describe=$(cd ../.. && git describe --long)
+describe=$(cd ../.. && git describe --long --abbrev=9)
 echo "$describe" >$3
 redo-always
 redo-stamp <$3


### PR DESCRIPTION
So it doesn't vary based on who's doing the release with which version
of git.

Fixes tailscale/corp#419

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/522)
<!-- Reviewable:end -->
