### PR TITLE
version: don't have a third version number form for xcode

### DIFF
--- a/version/mkversion.sh
+++ b/version/mkversion.sh
@@ -61,6 +61,14 @@ xcode() {
     patch=$(echo "$ver" | cut -f3 -d.)
     changecount=$(echo "$ver" | cut -f4 -d.)
 
+    # name should be like git-describe, but without the git suffix or
+    # the leading v. For example, for git-describe of
+    # "v0.100.0-15-gce1b52bb7" we want:
+    #
+    #   VERSION_NAME = 0.100.0-15
+    #   VERSION_ID = 100.100.15
+    name=$(echo "$describe" | sed -e 's/^v//' | sed -e 's/-g.*//' | sed -e 's/-0$//')
+
     # Apple version numbers must be major.minor.patch. We have 4 fields
     # because we need major.minor.patch for go module compatibility, and
     # changecount for automatic version numbering of unstable builds. To
@@ -68,8 +76,8 @@ xcode() {
     patch=$((patch*10000 + changecount))
 
     # CFBundleShortVersionString: the "short name" used in the App Store.
-    # eg. 0.92.98
-    echo "VERSION_NAME = $major.$minor.$patch"
+    # e.g. 0.92.98
+    echo "VERSION_NAME = \"$name\""
     # CFBundleVersion: the build number. Needs to be 3 numeric sections
     # that increment for each release according to SemVer rules.
     #

--- a/version/mkversion_test.go
+++ b/version/mkversion_test.go
@@ -11,15 +11,15 @@ import (
 	"testing"
 )
 
-func xcode(short, long string) string {
-	return fmt.Sprintf("VERSION_NAME = %s\nVERSION_ID = %s", short, long)
+func xcode(name, semver string) string {
+	return fmt.Sprintf("VERSION_NAME = %q\nVERSION_ID = %s", name, semver)
 }
 
 func mkversion(t *testing.T, mode, in string) string {
 	t.Helper()
 	bs, err := exec.Command("./mkversion.sh", mode, in).CombinedOutput()
 	if err != nil {
-		t.Logf("mkversion.sh output: %s", string(bs))
+		t.Logf("mkversion.sh output: %s", bs)
 		t.Fatalf("mkversion.sh %s %s: %v", mode, in, err)
 	}
 	return strings.TrimSpace(string(bs))
@@ -32,12 +32,15 @@ func TestMkversion(t *testing.T) {
 		short string
 		xcode string
 	}{
-		{"v0.98-abcdef", "0.98.0-0-abcdef", "0.98.0-0", xcode("0.98.0", "100.98.0")},
-		{"v0.98-123-abcdef", "0.98.0-123-abcdef", "0.98.0-123", xcode("0.98.123", "100.98.123")},
-		{"v0.99.5-123-abcdef", "0.99.5-123-abcdef", "0.99.5-123", xcode("0.99.50123", "100.99.50123")},
-		{"v0.99.5-123-abcdef", "0.99.5-123-abcdef", "0.99.5-123", xcode("0.99.50123", "100.99.50123")},
-		{"v2.3-0-abcdef", "2.3.0-0-abcdef", "2.3.0-0", xcode("2.3.0", "102.3.0")},
-		{"1.2.3-4-abcdef", "1.2.3-4-abcdef", "1.2.3-4", xcode("1.2.30004", "101.2.30004")},
+		{"v0.98-gabcdef", "0.98.0-0-gabcdef", "0.98.0-0", xcode("0.98", "100.98.0")},
+		{"v0.98-123-gabcdef", "0.98.0-123-gabcdef", "0.98.0-123", xcode("0.98-123", "100.98.123")},
+		{"v0.99.5-123-gabcdef", "0.99.5-123-gabcdef", "0.99.5-123", xcode("0.99.5-123", "100.99.50123")},
+		{"v0.99.5-123-gabcdef", "0.99.5-123-gabcdef", "0.99.5-123", xcode("0.99.5-123", "100.99.50123")},
+		{"v0.100.0-gabcdef", "0.100.0-0-gabcdef", "0.100.0-0", xcode("0.100.0", "100.100.0")},
+		{"v0.100.0-1-gabcdef", "0.100.0-1-gabcdef", "0.100.0-1", xcode("0.100.0-1", "100.100.1")},
+		{"v0.100.1-2-gabcdef", "0.100.1-2-gabcdef", "0.100.1-2", xcode("0.100.1-2", "100.100.10002")},
+		{"v2.3-0-gabcdef", "2.3.0-0-gabcdef", "2.3.0-0", xcode("2.3", "102.3.0")},
+		{"1.2.3-4-gabcdef", "1.2.3-4-gabcdef", "1.2.3-4", xcode("1.2.3-4", "101.2.30004")},
 	}
 
 	for _, test := range tests {
@@ -51,7 +54,7 @@ func TestMkversion(t *testing.T) {
 			t.Errorf("mkversion.sh short %q: got %q, want %q", test.in, gotshort, test.short)
 		}
 		if gotxcode != test.xcode {
-			t.Errorf("mkversion.sh xcode %q: got %q, want %q", test.in, gotxcode, test.xcode)
+			t.Errorf("mkversion.sh xcode %q:\ngot:\n%q\nwant:\n%q", test.in, gotxcode, test.xcode)
 		}
 	}
 }


### PR DESCRIPTION
Our primary version format is git describe --long --abbrev=9.

Our Apple scheme is:
    (major+100).minor.(patch*10,000+gitDescribeCommits).

This CL gets rid of the third, which was:
    major.minor.(patch*10,000+gitDescribeCommits).

Now the "About" box in the macOS app shows the same version that we
show on pkgs.tailscale.com, userz, changelog, etc.

This will be more important once/if we get standalone DMG downloads
for macOS on pkgs.tailscale.com.

Fixes tailscale/corp#364

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/533)
<!-- Reviewable:end -->
