### PR TITLE
types/logger: fix go test vet error

### DIFF
--- a/types/logger/logger_test.go
+++ b/types/logger/logger_test.go
@@ -60,7 +60,7 @@ func TestRateLimiter(t *testing.T) {
 		lg("templated format string no. %d", i)
 		if i == 4 {
 			lg("Make sure this string makes it through the rest (that are blocked) %d", i)
-			prefixed = WithPrefix(lg, string('0'+i))
+			prefixed = WithPrefix(lg, string(rune('0'+i)))
 			prefixed(" shouldn't get filtered.")
 		}
 	}


### PR DESCRIPTION
Silences

types/logger/logger_test.go:63:30: conversion from int to string yields a string of one rune

Signed-off-by: Elias Naur <mail@eliasnaur.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/549)
<!-- Reviewable:end -->
