### PR TITLE
tstest/natlab: refactor PacketHandler into a larger interface.

### DIFF
--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -371,15 +371,13 @@ func TestTwoDevicePing(t *testing.T) {
 
 		t.Run("facing firewalls", func(t *testing.T) {
 			mstun := &natlab.Machine{Name: "stun"}
-			f1 := &natlab.Firewall{}
-			f2 := &natlab.Firewall{}
 			m1 := &natlab.Machine{
-				Name:         "m1",
-				HandlePacket: f1.HandlePacket,
+				Name:          "m1",
+				PacketHandler: &natlab.Firewall{},
 			}
 			m2 := &natlab.Machine{
-				Name:         "m2",
-				HandlePacket: f2.HandlePacket,
+				Name:          "m2",
+				PacketHandler: &natlab.Firewall{},
 			}
 			inet := natlab.NewInternet()
 			sif := mstun.Attach("eth0", inet)


### PR DESCRIPTION
The new interface lets implementors more precisely distinguish
local traffic from forwarded traffic, and applies different
forwarding logic within Machines for each type. This allows
Machines to be packet forwarders, which didn't quite work
with the implementation of Inject.

Signed-off-by: David Anderson <danderson@tailscale.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/556)
<!-- Reviewable:end -->
