### PR TITLE
wgengine: fix macos staticcheck errors

### DIFF
--- a/wgengine/monitor/monitor.go
+++ b/wgengine/monitor/monitor.go
@@ -20,13 +20,6 @@ type message interface {
 	ignore() bool
 }
 
-// unspecifiedMessage is a minimal message implementation that should not
-// be ignored. In general, OS-specific implementations should use better
-// types and avoid this if they can.
-type unspecifiedMessage struct{}
-
-func (unspecifiedMessage) ignore() bool { return false }
-
 // osMon is the interface that each operating system-specific
 // implementation of the link monitor must implement.
 type osMon interface {

--- a/wgengine/monitor/monitor_freebsd.go
+++ b/wgengine/monitor/monitor_freebsd.go
@@ -13,6 +13,13 @@ import (
 	"tailscale.com/types/logger"
 )
 
+// unspecifiedMessage is a minimal message implementation that should not
+// be ignored. In general, OS-specific implementations should use better
+// types and avoid this if they can.
+type unspecifiedMessage struct{}
+
+func (unspecifiedMessage) ignore() bool { return false }
+
 // devdConn implements osMon using devd(8).
 type devdConn struct {
 	conn net.Conn

--- a/wgengine/monitor/monitor_linux.go
+++ b/wgengine/monitor/monitor_linux.go
@@ -19,6 +19,13 @@ import (
 	"tailscale.com/types/logger"
 )
 
+// unspecifiedMessage is a minimal message implementation that should not
+// be ignored. In general, OS-specific implementations should use better
+// types and avoid this if they can.
+type unspecifiedMessage struct{}
+
+func (unspecifiedMessage) ignore() bool { return false }
+
 // nlConn wraps a *netlink.Conn and returns a monitor.Message
 // instead of a netlink.Message. Currently, messages are discarded,
 // but down the line, when messages trigger different logic depending

--- a/wgengine/router/dns.go
+++ b/wgengine/router/dns.go
@@ -5,8 +5,6 @@
 package router
 
 import (
-	"time"
-
 	"inet.af/netaddr"
 )
 
@@ -45,13 +43,6 @@ func (lhs DNSConfig) EquivalentTo(rhs DNSConfig) bool {
 
 	return true
 }
-
-// dnsReconfigTimeout is the timeout for DNS reconfiguration.
-//
-// This is useful because certain conditions can cause indefinite hangs
-// (such as improper dbus auth followed by contextless dbus.Object.Call).
-// Such operations should be wrapped in a timeout context.
-const dnsReconfigTimeout = time.Second
 
 // dnsMode determines how DNS settings are managed.
 type dnsMode uint8

--- a/wgengine/router/dns_resolved.go
+++ b/wgengine/router/dns_resolved.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"time"
 
 	"github.com/godbus/dbus/v5"
 	"golang.org/x/sys/unix"
@@ -34,6 +35,13 @@ import (
 // While it may seem that we need to read a config option to get at this,
 // this address is, in fact, hard-coded into resolved.
 var resolvedListenAddr = netaddr.IPv4(127, 0, 0, 53)
+
+// dnsReconfigTimeout is the timeout for DNS reconfiguration.
+//
+// This is useful because certain conditions can cause indefinite hangs
+// (such as improper dbus auth followed by contextless dbus.Object.Call).
+// Such operations should be wrapped in a timeout context.
+const dnsReconfigTimeout = time.Second
 
 var errNotReady = errors.New("interface not ready")
 


### PR DESCRIPTION
Fixing a few static check errors that popped up on Mac (due to things that are only built on Linux), namely: 
```
oss/wgengine/monitor/monitor.go:26:6: type unspecifiedMessage is unused (U1000)
oss/wgengine/router/dns.go:54:7: const dnsReconfigTimeout is unused (U1000)
```
I just moved a few things to be declared in the files built on Linux, but let me know if you'd want to organize it differently :)

Signed-off-by: Wendi Yu <wendi@tailscale.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/557)
<!-- Reviewable:end -->
