### PR TITLE
cmd/tailscale: allow overriding hostname in tailscale up

### DIFF
--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -80,12 +80,13 @@ var upArgs struct {
 	hostname        string
 }
 
-// validateHostname checks that name is a valid non-empty domain name label
+// validateHostname checks that name is a valid domain name label
 // pursuant to https://tools.ietf.org/html/rfc1034#section-3.1.
 func validateHostname(name string) error {
 	switch {
+	// Empty string is treated as missing hostname and replaced downstream.
 	case len(name) == 0:
-		return fmt.Errorf("empty")
+		return nil
 	case len(name) > 63:
 		return fmt.Errorf("longer than 63 characters")
 	}


### PR DESCRIPTION
Following discussion with @apenwarr, this appears to be a common customer request and easy to implement. 

One considerations: should we also normalize existing hostnames / newly acquired ones from `os.Hostname` to satisfy `validateHostname`? This seems like a useful invariant, since such names can be used in a domain name without additional sanitization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/560)
<!-- Reviewable:end -->
