### PR TITLE
Use LittleEndian for correct byte order on DNS IPs

### DIFF
--- a/wgengine/router/dns_networkmanager.go
+++ b/wgengine/router/dns_networkmanager.go
@@ -143,7 +143,7 @@ func dnsNetworkManagerUp(config DNSConfig, interfaceName string) error {
 	for _, ip := range config.Nameservers {
 		b := ip.As16()
 		if ip.Is4() {
-			dnsv4 = append(dnsv4, binary.BigEndian.Uint32(b[12:]))
+			dnsv4 = append(dnsv4, binary.LittleEndian.Uint32(b[12:]))
 		} else {
 			dnsv6 = append(dnsv6, b[:])
 		}


### PR DESCRIPTION
Nameserver IP 10.11.12.13 would otherwise get written to resolv.conf as 13.12.11.10, as was happening on my client.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/566)
<!-- Reviewable:end -->
