### PR TITLE
cmd/tailscale: add corpDNS flag

### DIFF
--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -54,6 +54,7 @@ specify any flags, options are reset to their default.
 		upf.StringVar(&upArgs.authKey, "authkey", "", "node authorization key")
 		upf.StringVar(&upArgs.hostname, "hostname", "", "hostname to use instead of the one provided by the OS")
 		upf.BoolVar(&upArgs.enableDERP, "enable-derp", true, "enable the use of DERP servers")
+		upf.BoolVar(&upArgs.useDNS, "use-dns", true, "use DNS configuration from the admin panel")
 		if runtime.GOOS == "linux" || isBSD(runtime.GOOS) {
 			upf.StringVar(&upArgs.advertiseRoutes, "advertise-routes", "", "routes to advertise to other nodes (comma-separated, e.g. 10.0.0.0/8,192.168.0.0/24)")
 		}
@@ -74,6 +75,7 @@ var upArgs struct {
 	advertiseRoutes string
 	advertiseTags   string
 	enableDERP      bool
+	useDNS          bool
 	snat            bool
 	netfilterMode   string
 	authKey         string
@@ -184,6 +186,7 @@ func runUp(ctx context.Context, args []string) error {
 	prefs.AdvertiseTags = tags
 	prefs.NoSNAT = !upArgs.snat
 	prefs.DisableDERP = !upArgs.enableDERP
+	prefs.CorpDNS = upArgs.useDNS
 	prefs.Hostname = upArgs.hostname
 	if runtime.GOOS == "linux" {
 		switch upArgs.netfilterMode {


### PR DESCRIPTION
As it turned out in #589, this is currently missing.

I'm not sure that `--corp-dns` is the best name for it, given that it is more of a toggle for _all_ DNS settings and not just corporate DNS servers specifically, which will become a useful distinction soon, but that's what it is in prefs and on other platforms, so it seems reasonable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/593)
<!-- Reviewable:end -->
