### PR TITLE
WIP: tstime: add an abstract Time interface, which can be real or virtual.

### DIFF
--- a/tstime/parse.go
+++ b/tstime/parse.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tstime
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// zoneOf returns the RFC3339 zone suffix (either "Z" or like
+// "+08:30"), or the empty string if it's invalid or not something we
+// want to cache.
+func zoneOf(s string) string {
+	if strings.HasSuffix(s, "Z") {
+		return "Z"
+	}
+	if len(s) < len("2020-04-05T15:56:00+08:00") {
+		// Too short, invalid? Let time.Parse fail on it.
+		return ""
+	}
+	zone := s[len(s)-len("+08:00"):]
+	if c := zone[0]; c == '+' || c == '-' {
+		min := zone[len("+08:"):]
+		switch min {
+		case "00", "15", "30":
+			return zone
+		}
+	}
+	return ""
+}
+
+// locCache maps from zone offset suffix string ("+08:00") =>
+// *time.Location (from FixedLocation).
+var locCache sync.Map
+
+func getLocation(zone, timeValue string) (*time.Location, error) {
+	if zone == "Z" {
+		return time.UTC, nil
+	}
+	if loci, ok := locCache.Load(zone); ok {
+		return loci.(*time.Location), nil
+	}
+	// TODO(bradfitz): just parse it and call time.FixedLocation.
+	// For now, just have time.Parse do it once:
+	t, err := time.Parse(time.RFC3339Nano, timeValue)
+	if err != nil {
+		return nil, err
+	}
+	loc := t.Location()
+	locCache.LoadOrStore(zone, loc)
+	return loc, nil
+
+}
+
+// Parse3339 is a wrapper around time.Parse(time.RFC3339Nano, s) that caches
+// timezone Locations for future parses.
+func Parse3339(s string) (time.Time, error) {
+	zone := zoneOf(s)
+	if zone == "" {
+		// Invalid or weird timezone offset. Use slow path,
+		// which'll probably return an error.
+		return time.Parse(time.RFC3339Nano, s)
+	}
+	loc, err := getLocation(zone, s)
+	if err != nil {
+		return time.Time{}, err
+	}
+	s = s[:len(s)-len(zone)] // remove zone suffix
+	var year, mon, day, hr, min, sec, nsec int
+	const baseLen = len("2020-04-05T15:56:00")
+	if len(s) < baseLen ||
+		!parseInt(s[:4], &year) ||
+		s[4] != '-' ||
+		!parseInt(s[5:7], &mon) ||
+		s[7] != '-' ||
+		!parseInt(s[8:10], &day) ||
+		s[10] != 'T' ||
+		!parseInt(s[11:13], &hr) ||
+		s[13] != ':' ||
+		!parseInt(s[14:16], &min) ||
+		s[16] != ':' ||
+		!parseInt(s[17:19], &sec) {
+		return time.Time{}, errors.New("invalid time")
+	}
+	nsStr := s[baseLen:]
+	if nsStr != "" {
+		if nsStr[0] != '.' {
+			return time.Time{}, errors.New("invalid optional nanosecond prefix")
+		}
+		if !parseInt(nsStr[1:], &nsec) {
+			return time.Time{}, fmt.Errorf("invalid optional nanosecond number %q", nsStr[1:])
+		}
+		for i := 0; i < len("999999999")-(len(nsStr)-1); i++ {
+			nsec *= 10
+		}
+	}
+	return time.Date(year, time.Month(mon), day, hr, min, sec, nsec, loc), nil
+}
+
+func parseInt(s string, dst *int) bool {
+	if len(s) == 0 || len(s) > len("999999999") {
+		*dst = 0
+		return false
+	}
+	n := 0
+	for i := 0; i < len(s); i++ {
+		d := s[i] - '0'
+		if d > 9 {
+			*dst = 0
+			return false
+		}
+		n = n*10 + int(d)
+	}
+	*dst = n
+	return true
+}

--- a/tstime/parse_test.go
+++ b/tstime/parse_test.go
@@ -1,0 +1,187 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tstime
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParse3339(t *testing.T) {
+	tests := []string{
+		"2020-04-05T15:56:00Z",
+		"2020-04-05T15:56:00.1234Z",
+		"2020-04-05T15:56:00+08:00",
+
+		"2020-04-05T15:56:00.1+08:00",
+		"2020-04-05T15:56:00.12+08:00",
+		"2020-04-05T15:56:00.012+08:00",
+		"2020-04-05T15:56:00.0012+08:00",
+		"2020-04-05T15:56:00.148487491+08:00",
+
+		"2020x04-05T15:56:00.1234+08:00",
+		"2020-04x05T15:56:00.1234+08:00",
+		"2020-04-05x15:56:00.1234+08:00",
+		"2020-04-05T15x56:00.1234+08:00",
+		"2020-04-05T15:56x00.1234+08:00",
+		"2020-04-05T15:56:00x1234+08:00",
+	}
+	for _, s := range tests {
+		t.Run(s, func(t *testing.T) {
+			goTime, goErr := time.Parse(time.RFC3339Nano, s)
+
+			Parse3339(s) // prime the tz cache so next parse use fast path
+			got, err := Parse3339(s)
+
+			if (err == nil) != (goErr == nil) {
+				t.Fatalf("for %q, go err = %v; our err = %v", s, goErr, err)
+			}
+			if err != nil {
+				return
+			}
+			if !goTime.Equal(got) {
+				t.Errorf("for %q, times not Equal: we got %v, want go's %v", s, got, goTime)
+			}
+			if goStr, ourStr := goTime.Format(time.RFC3339Nano), got.Format(time.RFC3339Nano); goStr != ourStr {
+				t.Errorf("for %q, strings not equal: we got %q, want go's %q", s, ourStr, goStr)
+			}
+
+		})
+	}
+
+}
+
+func TestZoneOf(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"2020-04-05T15:56:00+08:00", "+08:00"},
+		{"2020-04-05T15:56:00-08:00", "-08:00"},
+		{"2020-04-05T15:56:00.12345-08:00", "-08:00"},
+		{"2020-04-05T15:56:00.12345-08:00", "-08:00"},
+		{"2020-04-05T15:56:00.12345-08:30", "-08:30"},
+		{"2020-04-05T15:56:00.12345-08:15", "-08:15"},
+		{"2020-04-05T15:56:00.12345-08:17", ""}, // don't cache weird offsets
+		{"2020-04-05T15:56:00.12345Z", "Z"},
+		{"2020-04-05T15:56:00Z", "Z"},
+		{"123+08:00", ""}, // too short
+		{"+08:00", ""},    // too short
+	}
+	for _, tt := range tests {
+		if got := zoneOf(tt.in); got != tt.want {
+			t.Errorf("zoneOf(%q) = %q; want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestParseInt(t *testing.T) {
+	tests := []struct {
+		in   string
+		want int
+		ret  bool
+	}{
+		{"", 0, false},
+		{"1", 1, true},
+		{"999999999", 999999999, true},
+		{"123456789", 123456789, true},
+		{"000000", 0, true},
+		{"bork", 0, false},
+		{"123bork", 0, false},
+	}
+
+	for _, tt := range tests {
+		var got int
+		gotRet := parseInt(tt.in, &got)
+		if gotRet != tt.ret || got != tt.want {
+			t.Errorf("parseInt(%q) = %v, %d; want %v, %d", tt.in, gotRet, got, tt.ret, tt.want)
+		}
+	}
+}
+
+func BenchmarkGoParse3339(b *testing.B) {
+	run := func(in string) func(*testing.B) {
+		return func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, err := time.Parse(time.RFC3339Nano, in)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+	}
+	b.Run("Z", run("2020-04-05T15:56:00.148487491Z"))
+	b.Run("TZ", run("2020-04-05T15:56:00.148487491+08:00"))
+}
+
+func BenchmarkGoParse3339InLocation(b *testing.B) {
+	b.ReportAllocs()
+	const in = `2020-04-05T15:56:00.148487491+08:00`
+
+	t, err := time.Parse(time.RFC3339Nano, in)
+	if err != nil {
+		b.Fatal(err)
+	}
+	loc := t.Location()
+
+	t2, err := time.ParseInLocation(time.RFC3339Nano, in, loc)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if !t.Equal(t2) {
+		b.Fatal("not equal")
+	}
+	if s1, s2 := t.Format(time.RFC3339Nano), t2.Format(time.RFC3339Nano); s1 != s2 {
+		b.Fatalf("times don't stringify the same: %q vs %q", s1, s2)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := time.ParseInLocation(time.RFC3339Nano, in, loc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkParse3339(b *testing.B) {
+	run := func(in string) func(*testing.B) {
+		return func(b *testing.B) {
+			b.ReportAllocs()
+
+			t, err := time.Parse(time.RFC3339Nano, in)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			t2, err := Parse3339(in)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if !t.Equal(t2) {
+				b.Fatal("not equal")
+			}
+			if s1, s2 := t.Format(time.RFC3339Nano), t2.Format(time.RFC3339Nano); s1 != s2 {
+				b.Fatalf("times don't stringify the same: %q vs %q", s1, s2)
+			}
+
+			for i := 0; i < b.N; i++ {
+				_, err := Parse3339(in)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+	}
+	b.Run("Z", run("2020-04-05T15:56:00.148487491Z"))
+	b.Run("TZ", run("2020-04-05T15:56:00.148487491+08:00"))
+}
+
+func BenchmarkParseInt(b *testing.B) {
+	var out int
+	for i := 0; i < b.N; i++ {
+		parseInt("148487491", &out)
+	}
+}

--- a/tstime/tstime.go
+++ b/tstime/tstime.go
@@ -6,117 +6,234 @@
 package tstime
 
 import (
-	"errors"
-	"fmt"
-	"strings"
-	"sync"
+	"context"
+	"math/bits"
+	"sync/atomic"
 	"time"
 )
 
-// zoneOf returns the RFC3339 zone suffix (either "Z" or like
-// "+08:30"), or the empty string if it's invalid or not something we
-// want to cache.
-func zoneOf(s string) string {
-	if strings.HasSuffix(s, "Z") {
-		return "Z"
-	}
-	if len(s) < len("2020-04-05T15:56:00+08:00") {
-		// Too short, invalid? Let time.Parse fail on it.
-		return ""
-	}
-	zone := s[len(s)-len("+08:00"):]
-	if c := zone[0]; c == '+' || c == '-' {
-		min := zone[len("+08:"):]
-		switch min {
-		case "00", "15", "30":
-			return zone
-		}
-	}
-	return ""
+// Time is an interface to all things that deal with the current time,
+// and the passage of time. It's meant to be used as a replacement for
+// the functions of the same name in the `time` and `context`
+// packages, so that different implementations of time can be swapped
+// in.
+type Time interface {
+	// After is like time.After.
+	After(time.Duration) <-chan time.Time
+	// Sleep is like time.Sleep.
+	Sleep(time.Duration)
+
+	// Since is like time.Since.
+	Since(time.Time) time.Duration
+	// Until is like time.Until.
+	Until(time.Time) time.Duration
+
+	// Now is like time.Now.
+	Now() time.Time
+
+	// AfterFunc is like time.AfterFunc.
+	AfterFunc(time.Duration, func()) *Timer
+	// NewTimer is like time.NewTimer.
+	NewTimer(time.Duration) *Timer
+	// NewTicker is like time.NewTicker.
+	NewTicker(time.Duration) *time.Ticker
+
+	// WithTimeout is like context.WithTimeout.
+	ContextWithTimeout(context.Context, time.Duration) (context.Context, context.CancelFunc)
+	// WithDeadline is like context.WithDeadline.
+	ContextWithDeadline(context.Context, time.Time) (context.Context, context.CancelFunc)
 }
 
-// locCache maps from zone offset suffix string ("+08:00") =>
-// *time.Location (from FixedLocation).
-var locCache sync.Map
-
-func getLocation(zone, timeValue string) (*time.Location, error) {
-	if zone == "Z" {
-		return time.UTC, nil
-	}
-	if loci, ok := locCache.Load(zone); ok {
-		return loci.(*time.Location), nil
-	}
-	// TODO(bradfitz): just parse it and call time.FixedLocation.
-	// For now, just have time.Parse do it once:
-	t, err := time.Parse(time.RFC3339Nano, timeValue)
-	if err != nil {
-		return nil, err
-	}
-	loc := t.Location()
-	locCache.LoadOrStore(zone, loc)
-	return loc, nil
-
+// Timer wraps a time.Timer and makes its Reset function integrate
+// with a custom Time implementation, rather than hardcode stdlib's.
+type Timer struct {
+	timer  *time.Timer
+	adjust func(time.Duration) time.Duration
 }
 
-// Parse3339 is a wrapper around time.Parse(time.RFC3339Nano, s) that caches
-// timezone Locations for future parses.
-func Parse3339(s string) (time.Time, error) {
-	zone := zoneOf(s)
-	if zone == "" {
-		// Invalid or weird timezone offset. Use slow path,
-		// which'll probably return an error.
-		return time.Parse(time.RFC3339Nano, s)
-	}
-	loc, err := getLocation(zone, s)
-	if err != nil {
-		return time.Time{}, err
-	}
-	s = s[:len(s)-len(zone)] // remove zone suffix
-	var year, mon, day, hr, min, sec, nsec int
-	const baseLen = len("2020-04-05T15:56:00")
-	if len(s) < baseLen ||
-		!parseInt(s[:4], &year) ||
-		s[4] != '-' ||
-		!parseInt(s[5:7], &mon) ||
-		s[7] != '-' ||
-		!parseInt(s[8:10], &day) ||
-		s[10] != 'T' ||
-		!parseInt(s[11:13], &hr) ||
-		s[13] != ':' ||
-		!parseInt(s[14:16], &min) ||
-		s[16] != ':' ||
-		!parseInt(s[17:19], &sec) {
-		return time.Time{}, errors.New("invalid time")
-	}
-	nsStr := s[baseLen:]
-	if nsStr != "" {
-		if nsStr[0] != '.' {
-			return time.Time{}, errors.New("invalid optional nanosecond prefix")
-		}
-		if !parseInt(nsStr[1:], &nsec) {
-			return time.Time{}, fmt.Errorf("invalid optional nanosecond number %q", nsStr[1:])
-		}
-		for i := 0; i < len("999999999")-(len(nsStr)-1); i++ {
-			nsec *= 10
-		}
-	}
-	return time.Date(year, time.Month(mon), day, hr, min, sec, nsec, loc), nil
+func (t *Timer) Reset(d time.Duration) bool {
+	return t.timer.Reset(t.adjust(d))
 }
 
-func parseInt(s string, dst *int) bool {
-	if len(s) == 0 || len(s) > len("999999999") {
-		*dst = 0
-		return false
+func (t *Timer) Stop() bool {
+	return t.timer.Stop()
+}
+
+// Std is a Time implementation that uses standard library
+// functions. With this implementation, time works as you'd normally
+// expect.
+type Std struct{}
+
+// After is like time.After.
+func (Std) After(d time.Duration) <-chan time.Time { return time.After(d) }
+
+// After is like time.Sleep.
+func (Std) Sleep(d time.Duration) { time.Sleep(d) }
+
+// After is like time.Since.
+func (Std) Since(t time.Time) time.Duration { return time.Since(t) }
+
+// After is like time.Until.
+func (Std) Until(t time.Time) time.Duration { return time.Until(t) }
+
+// After is like time.NewTicker.
+func (Std) NewTicker(d time.Duration) *time.Ticker { return time.NewTicker(d) }
+
+// After is like time.Now.
+func (Std) Now() time.Time                           { return time.Now() }
+func durationIdentity(d time.Duration) time.Duration { return d }
+
+// After is like time.AfterFunc.
+func (s Std) AfterFunc(d time.Duration, f func()) *Timer {
+	return &Timer{time.AfterFunc(d, f), durationIdentity}
+}
+
+// After is like time.NewTimer.
+func (s Std) NewTimer(d time.Duration) *Timer { return &Timer{time.NewTimer(d), durationIdentity} }
+
+// ContextWithTimeout is like context.WithTimeout.
+func (Std) ContextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, d)
+}
+
+// ContextWithDeadline is like context.WithDeadline.
+func (Std) ContextWithDeadline(ctx context.Context, t time.Time) (context.Context, context.CancelFunc) {
+	return context.WithDeadline(ctx, t)
+}
+
+// Virtual is a Time implementation that runs faster or slower than
+// wall clock time, but keeps ratios the same.
+type Virtual struct {
+	// Second is how long a virtual second actually takes in wall
+	// clock time. That is, if you virtual.Sleep(time.Second), this is
+	// how long you'll actually sleep.
+	Second time.Duration
+
+	// first is the first value of time.Now seen by this virtual
+	// instance. It's used as the origin point for virtual time.Time
+	// values when scaling them to/from wall clock time.
+	first int64 // nanoseconds since Epoch, accessed atomically.
+}
+
+func (vt *Virtual) init() {
+	atomic.CompareAndSwapInt64(&vt.first, 0, time.Now().UnixNano())
+}
+
+// mulDiv implements v*mul/div using 128-bit integer math, to avoid
+// overflows and losses of precision.
+func mulDiv(v, mul, div time.Duration) time.Duration {
+	neg := v < 0
+	if neg {
+		v = -v
 	}
-	n := 0
-	for i := 0; i < len(s); i++ {
-		d := s[i] - '0'
-		if d > 9 {
-			*dst = 0
-			return false
-		}
-		n = n*10 + int(d)
+
+	hi, lo := bits.Mul64(uint64(v), uint64(mul))
+	quo, _ := bits.Div64(hi, lo, uint64(div))
+
+	ret := time.Duration(quo)
+	if neg {
+		ret = -ret
 	}
-	*dst = n
-	return true
+	return ret
+}
+
+// virtualToWallDuration converts a time.Duration from the virtual
+// reference frame to the wall clock reference frame. This is the
+// transform that takes place to convert
+// virtual.Sleep(virtualDuration) into time.Sleep(realDuration), for
+// example.
+func (vt *Virtual) virtualToWallDuration(d time.Duration) time.Duration {
+	return mulDiv(d, vt.Second, time.Second)
+}
+
+// wallToVirtualDuration converts a time.Duration from the wall clock
+// reference frame to the virtual reference frame.
+func (vt *Virtual) wallToVirtualDuration(d time.Duration) time.Duration {
+	return mulDiv(d, time.Second, vt.Second)
+}
+
+func (vt *Virtual) virtualToWallTime(t time.Time) time.Time {
+	vt.init()
+	wt := time.Unix(0, atomic.LoadInt64(&vt.first)).In(t.Location())
+	return wt.Add(vt.virtualToWallDuration(t.Sub(wt)))
+}
+func (vt *Virtual) wallToVirtualTime(t time.Time) time.Time {
+	vt.init()
+	ret := time.Unix(0, atomic.LoadInt64(&vt.first)).In(t.Location())
+	return ret.Add(vt.wallToVirtualDuration(t.Sub(ret)))
+}
+
+// After is like time.After.
+func (vt *Virtual) After(d time.Duration) <-chan time.Time {
+	return time.After(vt.virtualToWallDuration(d))
+}
+
+// Sleep is like time.Sleep.
+func (vt *Virtual) Sleep(d time.Duration) {
+	time.Sleep(vt.virtualToWallDuration(d))
+}
+
+// Since is like time.Since.
+func (vt *Virtual) Since(t time.Time) time.Duration {
+	return vt.wallToVirtualDuration(time.Since(vt.virtualToWallTime(t)))
+}
+
+// Until is like time.Until.
+func (vt *Virtual) Until(t time.Time) time.Duration {
+	return vt.wallToVirtualDuration(time.Until(vt.virtualToWallTime(t)))
+}
+
+// NewTicker is like time.NewTicker.
+func (vt *Virtual) NewTicker(d time.Duration) *time.Ticker {
+	return time.NewTicker(vt.virtualToWallDuration(d))
+}
+
+// Now is like time.Now.
+func (vt *Virtual) Now() time.Time {
+	vt.init() // to make realNow after the start of our universe
+	realNow := time.Now().Round(0)
+	return vt.wallToVirtualTime(realNow)
+}
+
+// AfterFunc is like time.AfterFunc.
+func (vt *Virtual) AfterFunc(d time.Duration, f func()) *Timer {
+	return &Timer{
+		timer:  time.AfterFunc(vt.virtualToWallDuration(d), f),
+		adjust: vt.virtualToWallDuration,
+	}
+}
+
+// NewTimer is like time.NewTimer.
+func (vt *Virtual) NewTimer(d time.Duration) *Timer {
+	return &Timer{
+		timer:  time.NewTimer(vt.virtualToWallDuration(d)),
+		adjust: vt.virtualToWallDuration,
+	}
+}
+
+// ContextWithTimeout is like context.WithTimeout.
+func (vt *Virtual) ContextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(ctx, vt.virtualToWallDuration(d))
+	return virtualContext{ctx, vt}, cancel
+}
+
+// ContextWithDeadline is like context.WithDeadline.
+func (vt *Virtual) ContextWithDeadline(ctx context.Context, t time.Time) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithDeadline(ctx, vt.virtualToWallTime(t))
+	return virtualContext{ctx, vt}, cancel
+}
+
+// virtualContext is a context.Context that presents the correct
+// virtual time in its Deadline() call.
+type virtualContext struct {
+	context.Context
+	vt *Virtual
+}
+
+// Deadline returns the time when work done on behalf of this context
+// should be canceled. Deadline returns ok==false when no deadline is
+// set. Successive calls to Deadline return the same results.
+func (dc virtualContext) Deadline() (time.Time, bool) {
+	t, ok := dc.Context.Deadline()
+	return dc.vt.wallToVirtualTime(t), ok
 }

--- a/tstime/tstime_test.go
+++ b/tstime/tstime_test.go
@@ -9,179 +9,42 @@ import (
 	"time"
 )
 
-func TestParse3339(t *testing.T) {
-	tests := []string{
-		"2020-04-05T15:56:00Z",
-		"2020-04-05T15:56:00.1234Z",
-		"2020-04-05T15:56:00+08:00",
-
-		"2020-04-05T15:56:00.1+08:00",
-		"2020-04-05T15:56:00.12+08:00",
-		"2020-04-05T15:56:00.012+08:00",
-		"2020-04-05T15:56:00.0012+08:00",
-		"2020-04-05T15:56:00.148487491+08:00",
-
-		"2020x04-05T15:56:00.1234+08:00",
-		"2020-04x05T15:56:00.1234+08:00",
-		"2020-04-05x15:56:00.1234+08:00",
-		"2020-04-05T15x56:00.1234+08:00",
-		"2020-04-05T15:56x00.1234+08:00",
-		"2020-04-05T15:56:00x1234+08:00",
-	}
-	for _, s := range tests {
-		t.Run(s, func(t *testing.T) {
-			goTime, goErr := time.Parse(time.RFC3339Nano, s)
-
-			Parse3339(s) // prime the tz cache so next parse use fast path
-			got, err := Parse3339(s)
-
-			if (err == nil) != (goErr == nil) {
-				t.Fatalf("for %q, go err = %v; our err = %v", s, goErr, err)
-			}
-			if err != nil {
-				return
-			}
-			if !goTime.Equal(got) {
-				t.Errorf("for %q, times not Equal: we got %v, want go's %v", s, got, goTime)
-			}
-			if goStr, ourStr := goTime.Format(time.RFC3339Nano), got.Format(time.RFC3339Nano); goStr != ourStr {
-				t.Errorf("for %q, strings not equal: we got %q, want go's %q", s, ourStr, goStr)
-			}
-
-		})
-	}
-
+type d struct {
+	wall    time.Duration
+	virtual time.Duration
 }
 
-func TestZoneOf(t *testing.T) {
-	tests := []struct {
-		in, want string
-	}{
-		{"2020-04-05T15:56:00+08:00", "+08:00"},
-		{"2020-04-05T15:56:00-08:00", "-08:00"},
-		{"2020-04-05T15:56:00.12345-08:00", "-08:00"},
-		{"2020-04-05T15:56:00.12345-08:00", "-08:00"},
-		{"2020-04-05T15:56:00.12345-08:30", "-08:30"},
-		{"2020-04-05T15:56:00.12345-08:15", "-08:15"},
-		{"2020-04-05T15:56:00.12345-08:17", ""}, // don't cache weird offsets
-		{"2020-04-05T15:56:00.12345Z", "Z"},
-		{"2020-04-05T15:56:00Z", "Z"},
-		{"123+08:00", ""}, // too short
-		{"+08:00", ""},    // too short
-	}
-	for _, tt := range tests {
-		if got := zoneOf(tt.in); got != tt.want {
-			t.Errorf("zoneOf(%q) = %q; want %q", tt.in, got, tt.want)
-		}
+type t struct {
+	wall    time.Time
+	virtual time.Time
+}
+
+func since(dt *Virtual, t t) d {
+	return d{
+		wall:    time.Since(t.wall),
+		virtual: dt.Since(t.virtual),
 	}
 }
 
-func TestParseInt(t *testing.T) {
-	tests := []struct {
-		in   string
-		want int
-		ret  bool
-	}{
-		{"", 0, false},
-		{"1", 1, true},
-		{"999999999", 999999999, true},
-		{"123456789", 123456789, true},
-		{"000000", 0, true},
-		{"bork", 0, false},
-		{"123bork", 0, false},
-	}
-
-	for _, tt := range tests {
-		var got int
-		gotRet := parseInt(tt.in, &got)
-		if gotRet != tt.ret || got != tt.want {
-			t.Errorf("parseInt(%q) = %v, %d; want %v, %d", tt.in, gotRet, got, tt.ret, tt.want)
-		}
+func now(d *Virtual) t {
+	return t{
+		wall:    time.Now(),
+		virtual: d.Now(),
 	}
 }
 
-func BenchmarkGoParse3339(b *testing.B) {
-	run := func(in string) func(*testing.B) {
-		return func(b *testing.B) {
-			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
-				_, err := time.Parse(time.RFC3339Nano, in)
-				if err != nil {
-					b.Fatal(err)
-				}
-			}
-		}
+func TestVirtual(t *testing.T) {
+	d := &Virtual{
+		Second: time.Millisecond,
 	}
-	b.Run("Z", run("2020-04-05T15:56:00.148487491Z"))
-	b.Run("TZ", run("2020-04-05T15:56:00.148487491+08:00"))
-}
-
-func BenchmarkGoParse3339InLocation(b *testing.B) {
-	b.ReportAllocs()
-	const in = `2020-04-05T15:56:00.148487491+08:00`
-
-	t, err := time.Parse(time.RFC3339Nano, in)
-	if err != nil {
-		b.Fatal(err)
+	start := now(d)
+	d.Sleep(time.Second)
+	took := since(d, start)
+	t.Logf("Slept %s in %s", took.virtual, took.wall)
+	if took.wall > 5*time.Millisecond { // generous margin to allow for loaded machine
+		t.Errorf("virtual time ran too slow")
 	}
-	loc := t.Location()
-
-	t2, err := time.ParseInLocation(time.RFC3339Nano, in, loc)
-	if err != nil {
-		b.Fatal(err)
-	}
-	if !t.Equal(t2) {
-		b.Fatal("not equal")
-	}
-	if s1, s2 := t.Format(time.RFC3339Nano), t2.Format(time.RFC3339Nano); s1 != s2 {
-		b.Fatalf("times don't stringify the same: %q vs %q", s1, s2)
-	}
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, err := time.ParseInLocation(time.RFC3339Nano, in, loc)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-func BenchmarkParse3339(b *testing.B) {
-	run := func(in string) func(*testing.B) {
-		return func(b *testing.B) {
-			b.ReportAllocs()
-
-			t, err := time.Parse(time.RFC3339Nano, in)
-			if err != nil {
-				b.Fatal(err)
-			}
-
-			t2, err := Parse3339(in)
-			if err != nil {
-				b.Fatal(err)
-			}
-			if !t.Equal(t2) {
-				b.Fatal("not equal")
-			}
-			if s1, s2 := t.Format(time.RFC3339Nano), t2.Format(time.RFC3339Nano); s1 != s2 {
-				b.Fatalf("times don't stringify the same: %q vs %q", s1, s2)
-			}
-
-			for i := 0; i < b.N; i++ {
-				_, err := Parse3339(in)
-				if err != nil {
-					b.Fatal(err)
-				}
-			}
-		}
-	}
-	b.Run("Z", run("2020-04-05T15:56:00.148487491Z"))
-	b.Run("TZ", run("2020-04-05T15:56:00.148487491+08:00"))
-}
-
-func BenchmarkParseInt(b *testing.B) {
-	var out int
-	for i := 0; i < b.N; i++ {
-		parseInt("148487491", &out)
+	if took.virtual < time.Second {
+		t.Errorf("virtual time didn't advance enough")
 	}
 }


### PR DESCRIPTION
The virtual implementation supports configurable "time dilation", to
make it run faster or slower than virtual time.

Signed-off-by: David Anderson <danderson@tailscale.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/603)
<!-- Reviewable:end -->
