### PR TITLE
wgengine/packet: add IPVersion field, don't use IPProto to note version

### DIFF
--- a/wgengine/packet/ip.go
+++ b/wgengine/packet/ip.go
@@ -47,12 +47,12 @@ const (
 	// Unknown represents an unknown or unsupported protocol; it's deliberately the zero value.
 	Unknown IPProto = 0x00
 	ICMP    IPProto = 0x01
+	ICMPv6  IPProto = 0x3a
 	TCP     IPProto = 0x06
 	UDP     IPProto = 0x11
-	// IPv6 and Fragment are special values. They're not really IPProto values
-	// so we're using the unassigned 0xFE and 0xFF values for them.
+	// Fragment is a special value. It's not really an IPProto value
+	// so we're using the unassigned 0xFF value.
 	// TODO(dmytro): special values should be taken out of here.
-	IPv6     IPProto = 0xFE
 	Fragment IPProto = 0xFF
 )
 
@@ -66,8 +66,6 @@ func (p IPProto) String() string {
 		return "UDP"
 	case TCP:
 		return "TCP"
-	case IPv6:
-		return "IPv6"
 	default:
 		return "Unknown"
 	}

--- a/wgengine/packet/packet_test.go
+++ b/wgengine/packet/packet_test.go
@@ -47,11 +47,12 @@ var icmpRequestDecode = ParsedPacket{
 	dataofs: 24,
 	length:  len(icmpRequestBuffer),
 
-	IPProto: ICMP,
-	SrcIP:   NewIP(net.ParseIP("1.2.3.4")),
-	DstIP:   NewIP(net.ParseIP("5.6.7.8")),
-	SrcPort: 0,
-	DstPort: 0,
+	IPVersion: 4,
+	IPProto:   ICMP,
+	SrcIP:     NewIP(net.ParseIP("1.2.3.4")),
+	DstIP:     NewIP(net.ParseIP("5.6.7.8")),
+	SrcPort:   0,
+	DstPort:   0,
 }
 
 var icmpReplyBuffer = []byte{
@@ -72,11 +73,12 @@ var icmpReplyDecode = ParsedPacket{
 	dataofs: 24,
 	length:  len(icmpReplyBuffer),
 
-	IPProto: ICMP,
-	SrcIP:   NewIP(net.ParseIP("1.2.3.4")),
-	DstIP:   NewIP(net.ParseIP("5.6.7.8")),
-	SrcPort: 0,
-	DstPort: 0,
+	IPVersion: 4,
+	IPProto:   ICMP,
+	SrcIP:     NewIP(net.ParseIP("1.2.3.4")),
+	DstIP:     NewIP(net.ParseIP("5.6.7.8")),
+	SrcPort:   0,
+	DstPort:   0,
 }
 
 // IPv6 Router Solicitation
@@ -90,8 +92,9 @@ var ipv6PacketBuffer = []byte{
 }
 
 var ipv6PacketDecode = ParsedPacket{
-	b:       ipv6PacketBuffer,
-	IPProto: IPv6,
+	b:         ipv6PacketBuffer,
+	IPVersion: 6,
+	IPProto:   ICMPv6,
 }
 
 // This is a malformed IPv4 packet.
@@ -101,8 +104,9 @@ var unknownPacketBuffer = []byte{
 }
 
 var unknownPacketDecode = ParsedPacket{
-	b:       unknownPacketBuffer,
-	IPProto: Unknown,
+	b:         unknownPacketBuffer,
+	IPVersion: 0,
+	IPProto:   Unknown,
 }
 
 var tcpPacketBuffer = []byte{
@@ -125,12 +129,13 @@ var tcpPacketDecode = ParsedPacket{
 	dataofs: 40,
 	length:  len(tcpPacketBuffer),
 
-	IPProto:  TCP,
-	SrcIP:    NewIP(net.ParseIP("1.2.3.4")),
-	DstIP:    NewIP(net.ParseIP("5.6.7.8")),
-	SrcPort:  123,
-	DstPort:  567,
-	TCPFlags: TCPSynAck,
+	IPVersion: 4,
+	IPProto:   TCP,
+	SrcIP:     NewIP(net.ParseIP("1.2.3.4")),
+	DstIP:     NewIP(net.ParseIP("5.6.7.8")),
+	SrcPort:   123,
+	DstPort:   567,
+	TCPFlags:  TCPSynAck,
 }
 
 var udpRequestBuffer = []byte{
@@ -152,11 +157,12 @@ var udpRequestDecode = ParsedPacket{
 	dataofs: 28,
 	length:  len(udpRequestBuffer),
 
-	IPProto: UDP,
-	SrcIP:   NewIP(net.ParseIP("1.2.3.4")),
-	DstIP:   NewIP(net.ParseIP("5.6.7.8")),
-	SrcPort: 123,
-	DstPort: 567,
+	IPVersion: 4,
+	IPProto:   UDP,
+	SrcIP:     NewIP(net.ParseIP("1.2.3.4")),
+	DstIP:     NewIP(net.ParseIP("5.6.7.8")),
+	SrcPort:   123,
+	DstPort:   567,
 }
 
 var udpReplyBuffer = []byte{
@@ -234,7 +240,7 @@ func TestDecode(t *testing.T) {
 			var got ParsedPacket
 			got.Decode(tt.buf)
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("got %v; want %v", got, tt.want)
+				t.Errorf("mismatch\n got: %#v\nwant: %#v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
As prep for IPv6 log spam fixes in a future change.

Signed-off-by: Brad Fitzpatrick <bradfitz@tailscale.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/612)
<!-- Reviewable:end -->
