### PR TITLE
tailscaled.service: use default restart limiting

### DIFF
--- a/cmd/tailscaled/tailscaled.service
+++ b/cmd/tailscaled/tailscaled.service
@@ -3,8 +3,6 @@ Description=Tailscale node agent
 Documentation=https://tailscale.com/kb/
 Wants=network-pre.target
 After=network-pre.target
-StartLimitIntervalSec=0
-StartLimitBurst=0
 
 [Service]
 EnvironmentFile=/etc/default/tailscaled


### PR DESCRIPTION
It appears that systemd has sensible defaults for limiting
crash loops:

	DefaultStartLimitIntervalSec=10s
	DefaultStartLimitBurst=5

Remove our insta-restart configuration so that it works.

Signed-off-by: David Crawshaw <crawshaw@tailscale.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/626)
<!-- Reviewable:end -->
