### PR TITLE
ipn: fix incorrect handling of packet filter changes

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -148,11 +148,10 @@ func run() error {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	// Exit gracefully by cancelling the ipnserver context in most common cases:
-	// interrupted from the TTY (including when output is piped into e.g. grep)
-	// or killed by a service manager.
+	// interrupted from the TTY or killed by a service manager.
 	go func() {
 		interrupt := make(chan os.Signal, 1)
-		signal.Notify(interrupt, syscall.SIGINT, syscall.SIGPIPE, syscall.SIGTERM)
+		signal.Notify(interrupt, syscall.SIGINT, syscall.SIGTERM)
 		select {
 		case s := <-interrupt:
 			logf("tailscaled got signal %v; shutting down", s)

--- a/ipn/local.go
+++ b/ipn/local.go
@@ -464,17 +464,19 @@ func (b *LocalBackend) updateFilter(netMap *controlclient.NetworkMap, prefs *Pre
 		return
 	}
 
-	localNets := wgCIDRsToFilter(netMap.Addresses, advRoutes)
-
-	switch {
-	case !haveNetmap:
+	if !haveNetmap {
 		b.logf("netmap packet filter: (not ready yet)")
 		b.e.SetFilter(filter.NewAllowNone(b.logf))
-	case shieldsUp:
+		return
+	}
+
+	localNets := wgCIDRsToFilter(netMap.Addresses, advRoutes)
+
+	if shieldsUp {
 		b.logf("netmap packet filter: (shields up)")
 		var prevFilter *filter.Filter // don't reuse old filter state
 		b.e.SetFilter(filter.New(filter.Matches{}, localNets, prevFilter, b.logf))
-	default:
+	} else {
 		b.logf("netmap packet filter: %v", packetFilter)
 		b.e.SetFilter(filter.New(packetFilter, localNets, b.e.GetFilter(), b.logf))
 	}


### PR DESCRIPTION
Fixes a race condition where the packet filter may reject all traffic
to a device's Tailscale IP.

Signed-off-by: David Anderson <danderson@tailscale.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/630)
<!-- Reviewable:end -->
