### PR TITLE
cmd/tailscale/cli: add ping subcommand

### DIFF
--- a/cmd/tailscale/cli/cli.go
+++ b/cmd/tailscale/cli/cli.go
@@ -31,7 +31,7 @@ func ActLikeCLI() bool {
 		return false
 	}
 	switch os.Args[1] {
-	case "up", "status", "netcheck", "version",
+	case "up", "status", "netcheck", "ping", "version",
 		"-V", "--version", "-h", "--help":
 		return true
 	}
@@ -59,6 +59,7 @@ change in the future.
 			upCmd,
 			netcheckCmd,
 			statusCmd,
+			pingCmd,
 			versionCmd,
 		},
 		FlagSet: rootfs,

--- a/cmd/tailscale/cli/ping.go
+++ b/cmd/tailscale/cli/ping.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/peterbourgon/ff/v2/ffcli"
+	"tailscale.com/ipn"
+	"tailscale.com/ipn/ipnstate"
+)
+
+var pingCmd = &ffcli.Command{
+	Name:       "ping",
+	ShortUsage: "ping <hostname-or-IP>",
+	ShortHelp:  "Ping a host at the Tailscale layer, see how it routed",
+	LongHelp: strings.TrimSpace(`
+
+The 'tailscale ping' command pings a peer node at the Tailscale layer
+and reports which route it took for each response. The first ping or
+so will likely go over DERP (Tailscale's TCP relay protocol) while NAT
+traversal finds a direct path through.
+
+If 'tailscale ping' works but a normal ping does not, that means one
+side's operating system firewall is blocking packets; 'tailscale ping'
+does not inject packets into either side's TUN devices.
+
+By default, 'tailscale ping' stops after 10 pings or once a direct
+(non-DERP) path has been established, whichever comes first.
+
+The provided hostname must resolve to or be a Tailscale IP
+(e.g. 100.x.y.z) or a subnet IP advertised by a Tailscale
+relay node.
+
+`),
+	Exec: runPing,
+	FlagSet: (func() *flag.FlagSet {
+		fs := flag.NewFlagSet("ping", flag.ExitOnError)
+		fs.BoolVar(&pingArgs.verbose, "verbose", false, "verbose output")
+		fs.BoolVar(&pingArgs.untilDirect, "until-direct", true, "stop once a direct path is established")
+		fs.IntVar(&pingArgs.num, "c", 10, "max number of pings to send")
+		fs.DurationVar(&pingArgs.timeout, "timeout", 5*time.Second, "timeout before giving up on a ping")
+		return fs
+	})(),
+}
+
+var pingArgs struct {
+	num         int
+	untilDirect bool
+	verbose     bool
+	timeout     time.Duration
+}
+
+func runPing(ctx context.Context, args []string) error {
+	c, bc, ctx, cancel := connect(ctx)
+	defer cancel()
+
+	if len(args) != 1 {
+		return errors.New("usage: ping <hostname-or-IP>")
+	}
+	hostOrIP := args[0]
+	var ip string
+	var res net.Resolver
+	if addrs, err := res.LookupHost(ctx, hostOrIP); err != nil {
+		return fmt.Errorf("error looking up IP of %q: %v", hostOrIP, err)
+	} else if len(addrs) == 0 {
+		return fmt.Errorf("no IPs found for %q", hostOrIP)
+	} else {
+		ip = addrs[0]
+	}
+	if pingArgs.verbose && ip != hostOrIP {
+		log.Printf("lookup %q => %q", hostOrIP, ip)
+	}
+
+	ch := make(chan *ipnstate.PingResult, 1)
+	bc.SetNotifyCallback(func(n ipn.Notify) {
+		if n.ErrMessage != nil {
+			log.Fatal(*n.ErrMessage)
+		}
+		if pr := n.PingResult; pr != nil && pr.IP == ip {
+			ch <- pr
+		}
+	})
+	go pump(ctx, bc, c)
+
+	n := 0
+	anyPong := false
+	for {
+		n++
+		bc.Ping(ip)
+		timer := time.NewTimer(pingArgs.timeout)
+		select {
+		case <-timer.C:
+			fmt.Printf("timeout waiting for ping reply\n")
+		case pr := <-ch:
+			timer.Stop()
+			if pr.Err != "" {
+				return errors.New(pr.Err)
+			}
+			latency := time.Duration(pr.LatencySeconds * float64(time.Second)).Round(time.Millisecond)
+			via := pr.Endpoint
+			if pr.DERPRegionID != 0 {
+				via = fmt.Sprintf("DERP(%s)", pr.DERPRegionCode)
+			}
+			anyPong = true
+			fmt.Printf("pong from %s (%s) via %v in %v\n", pr.NodeName, pr.NodeIP, via, latency)
+			if pr.Endpoint != "" && pingArgs.untilDirect {
+				return nil
+			}
+			time.Sleep(time.Second)
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		if n == pingArgs.num {
+			if !anyPong {
+				return errors.New("no reply")
+			}
+			return nil
+		}
+	}
+}

--- a/ipn/backend.go
+++ b/ipn/backend.go
@@ -62,6 +62,7 @@ type Notify struct {
 	Status        *ipnstate.Status          // full status
 	BrowseToURL   *string                   // UI should open a browser right now
 	BackendLogID  *string                   // public logtail id used by backend
+	PingResult    *ipnstate.PingResult
 
 	// LocalTCPPort, if non-nil, informs the UI frontend which
 	// (non-zero) localhost TCP port it's listening on.
@@ -156,4 +157,8 @@ type Backend interface {
 	// make sure they react properly with keys that are going to
 	// expire.
 	FakeExpireAfter(x time.Duration)
+	// Ping attempts to start connecting to the given IP and sends a Notify
+	// with its PingResult. If the host is down, there might never
+	// be a PingResult sent. The cmd/tailscale CLI client adds a timeout.
+	Ping(ip string)
 }

--- a/ipn/fake_test.go
+++ b/ipn/fake_test.go
@@ -90,3 +90,7 @@ func (b *FakeBackend) RequestStatus() {
 func (b *FakeBackend) FakeExpireAfter(x time.Duration) {
 	b.notify(Notify{NetMap: &controlclient.NetworkMap{}})
 }
+
+func (b *FakeBackend) Ping(ip string) {
+	b.notify(Notify{PingResult: &ipnstate.PingResult{}})
+}

--- a/ipn/ipnstate/ipnstate.go
+++ b/ipn/ipnstate/ipnstate.go
@@ -322,3 +322,21 @@ func osEmoji(os string) string {
 	}
 	return "👽"
 }
+
+// PingResult contains response information for the "tailscale ping" subcommand,
+// saying how Tailscale can reach a Tailscale IP or subnet-routed IP.
+type PingResult struct {
+	IP       string // ping destination
+	NodeIP   string // Tailscale IP of node handling IP (different for subnet routers)
+	NodeName string // DNS name base or (possibly not unique) hostname
+
+	Err            string
+	LatencySeconds float64
+
+	Endpoint string // ip:port if direct UDP was used
+
+	DERPRegionID   int    // non-zero if DERP was used
+	DERPRegionCode string // three-letter airport/region code if DERP was used
+
+	// TODO(bradfitz): details like whether port mapping was used on either side? (Once supported)
+}

--- a/ipn/local.go
+++ b/ipn/local.go
@@ -745,6 +745,17 @@ func (b *LocalBackend) FakeExpireAfter(x time.Duration) {
 	b.send(Notify{NetMap: b.netMap})
 }
 
+func (b *LocalBackend) Ping(ipStr string) {
+	ip, err := netaddr.ParseIP(ipStr)
+	if err != nil {
+		b.logf("ignoring Ping request to invalid IP %q", ipStr)
+		return
+	}
+	b.e.Ping(ip, func(pr *ipnstate.PingResult) {
+		b.send(Notify{PingResult: pr})
+	})
+}
+
 func (b *LocalBackend) parseWgStatus(s *wgengine.Status) (ret EngineStatus) {
 	var (
 		peerStats []string

--- a/ipn/message.go
+++ b/ipn/message.go
@@ -33,6 +33,10 @@ type FakeExpireAfterArgs struct {
 	Duration time.Duration
 }
 
+type PingArgs struct {
+	IP string
+}
+
 // Command is a command message that is JSON encoded and sent by a
 // frontend to a backend.
 type Command struct {
@@ -56,6 +60,7 @@ type Command struct {
 	RequestEngineStatus   *NoArgs
 	RequestStatus         *NoArgs
 	FakeExpireAfter       *FakeExpireAfterArgs
+	Ping                  *PingArgs
 }
 
 type BackendServer struct {
@@ -147,6 +152,9 @@ func (bs *BackendServer) GotCommand(cmd *Command) error {
 		return nil
 	} else if c := cmd.FakeExpireAfter; c != nil {
 		bs.b.FakeExpireAfter(c.Duration)
+		return nil
+	} else if c := cmd.Ping; c != nil {
+		bs.b.Ping(c.IP)
 		return nil
 	} else {
 		return fmt.Errorf("BackendServer.Do: no command specified")
@@ -252,6 +260,10 @@ func (bc *BackendClient) RequestStatus() {
 
 func (bc *BackendClient) FakeExpireAfter(x time.Duration) {
 	bc.send(Command{FakeExpireAfter: &FakeExpireAfterArgs{Duration: x}})
+}
+
+func (bc *BackendClient) Ping(ip string) {
+	bc.send(Command{Ping: &PingArgs{IP: ip}})
 }
 
 // MaxMessageSize is the maximum message size, in bytes.

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -1157,6 +1157,10 @@ func (e *userspaceEngine) UpdateStatus(sb *ipnstate.StatusBuilder) {
 	e.magicConn.UpdateStatus(sb)
 }
 
+func (e *userspaceEngine) Ping(ip netaddr.IP, cb func(*ipnstate.PingResult)) {
+	e.magicConn.Ping(ip, cb)
+}
+
 // diagnoseTUNFailure is called if tun.CreateTUN fails, to poke around
 // the system and log some diagnostic info that might help debug why
 // TUN failed. Because TUN's already failed and things the program's

--- a/wgengine/watchdog.go
+++ b/wgengine/watchdog.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/tailscale/wireguard-go/wgcfg"
+	"inet.af/netaddr"
 	"tailscale.com/control/controlclient"
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/tailcfg"
@@ -108,6 +109,9 @@ func (e *watchdogEngine) SetNetworkMap(nm *controlclient.NetworkMap) {
 func (e *watchdogEngine) DiscoPublicKey() (k tailcfg.DiscoKey) {
 	e.watchdog("DiscoPublicKey", func() { k = e.wrap.DiscoPublicKey() })
 	return k
+}
+func (e *watchdogEngine) Ping(ip netaddr.IP, cb func(*ipnstate.PingResult)) {
+	e.watchdog("Ping", func() { e.wrap.Ping(ip, cb) })
 }
 func (e *watchdogEngine) Close() {
 	e.watchdog("Close", e.wrap.Close)

--- a/wgengine/wgengine.go
+++ b/wgengine/wgengine.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/tailscale/wireguard-go/wgcfg"
+	"inet.af/netaddr"
 	"tailscale.com/control/controlclient"
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/tailcfg"
@@ -123,4 +124,8 @@ type Engine interface {
 	// UpdateStatus populates the network state using the provided
 	// status builder.
 	UpdateStatus(*ipnstate.StatusBuilder)
+
+	// Ping is a request to start a discovery ping with the peer handling
+	// the given IP and then call cb with its ping latency & method.
+	Ping(ip netaddr.IP, cb func(*ipnstate.PingResult))
 }


### PR DESCRIPTION
For example:

```
$ tailscale ping -h
USAGE
  ping <hostname-or-IP>

FLAGS
  -c 10                   max number of pings to send
  -stop-once-direct true  stop once a direct path is established
  -verbose false          verbose output

$ tailscale ping mon.ts.tailscale.com
pong from monitoring (100.88.178.64) via DERP(sfo) in 65ms
pong from monitoring (100.88.178.64) via DERP(sfo) in 252ms
pong from monitoring (100.88.178.64) via [2604:a880:2:d1::36:d001]:41641 in 33ms
```

Fixes #661

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/663)
<!-- Reviewable:end -->
