### PR TITLE
net/netns: don't bind to non-existent device on Android

### DIFF
--- a/net/netns/netns_linux.go
+++ b/net/netns/netns_linux.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -135,6 +136,11 @@ func setBypassMark(fd uintptr) error {
 func bindToDevice(fd uintptr) error {
 	ifc, err := defaultRouteInterface()
 	if err != nil {
+		if runtime.GOOS == "android" {
+			// Some Android devices do not tolerate binding to "lo",
+			// leading to issue #645.
+			return err
+		}
 		// Make sure we bind to *some* interface,
 		// or we could get a routing loop.
 		// "lo" is always wrong, but if we don't have


### PR DESCRIPTION
Straw man fix for #471: calling

`unix.SetsockoptString(int(fd), unix.SOL_SOCKET, unix.SO_BINDTODEVICE, "lo")`

on Huawei devices result in dials timing out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/666)
<!-- Reviewable:end -->
