### PR TITLE
wgengine/router/router_userspace_bsd: on Mac the route program syntax…

### DIFF
--- a/wgengine/router/router_userspace_bsd.go
+++ b/wgengine/router/router_userspace_bsd.go
@@ -16,6 +16,7 @@ import (
 	"github.com/tailscale/wireguard-go/tun"
 	"inet.af/netaddr"
 	"tailscale.com/types/logger"
+	"tailscale.com/version"
 	"tailscale.com/wgengine/router/dns"
 )
 
@@ -114,8 +115,12 @@ func (r *userspaceBSDRouter) Set(cfg *Config) error {
 			net := route.IPNet()
 			nip := net.IP.Mask(net.Mask)
 			nstr := fmt.Sprintf("%v/%d", nip, route.Bits)
+			del := "del"
+			if version.OS() == "macOS" {
+				del = "delete"
+			}
 			routedel := []string{"route", "-q", "-n",
-				"del", "-inet", nstr,
+				del, "-inet", nstr,
 				"-iface", r.tunname}
 			out, err := cmd(routedel...).CombinedOutput()
 			if err != nil {


### PR DESCRIPTION
… expects delete not del -- this had caused router reconfig to fail in some cases. Fixes #673

Signed-off-by: Mike Kramlich <groglogic@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/674)
<!-- Reviewable:end -->
