### PR TITLE
derpmap: add full region name

### DIFF
--- a/derp/derpmap/derpmap.go
+++ b/derp/derpmap/derpmap.go
@@ -21,9 +21,10 @@ func derpNode(suffix, v4, v6 string) *tailcfg.DERPNode {
 	}
 }
 
-func derpRegion(id int, code string, nodes ...*tailcfg.DERPNode) *tailcfg.DERPRegion {
+func derpRegion(id int, name string, code string, nodes ...*tailcfg.DERPNode) *tailcfg.DERPRegion {
 	region := &tailcfg.DERPRegion{
 		RegionID:   id,
+		RegionName: name,
 		RegionCode: code,
 		Nodes:      nodes,
 	}
@@ -45,19 +46,19 @@ func derpRegion(id int, code string, nodes ...*tailcfg.DERPNode) *tailcfg.DERPRe
 func Prod() *tailcfg.DERPMap {
 	return &tailcfg.DERPMap{
 		Regions: map[int]*tailcfg.DERPRegion{
-			1: derpRegion(1, "nyc",
+			1: derpRegion(1, "nyc", "New York City",
 				derpNode("a", "159.89.225.99", "2604:a880:400:d1::828:b001"),
 			),
-			2: derpRegion(2, "sfo",
+			2: derpRegion(2, "sfo", "San Francisco",
 				derpNode("a", "167.172.206.31", "2604:a880:2:d1::c5:7001"),
 			),
-			3: derpRegion(3, "sin",
+			3: derpRegion(3, "sin", "Singapore",
 				derpNode("a", "68.183.179.66", "2400:6180:0:d1::67d:8001"),
 			),
-			4: derpRegion(4, "fra",
+			4: derpRegion(4, "fra", "Frankfurt",
 				derpNode("a", "167.172.182.26", "2a03:b0c0:3:e0::36e:9001"),
 			),
-			5: derpRegion(5, "syd",
+			5: derpRegion(5, "syd", "Sydney",
 				derpNode("a", "103.43.75.49", "2001:19f0:5801:10b7:5400:2ff:feaa:284c"),
 			),
 		},

--- a/tailcfg/derpmap.go
+++ b/tailcfg/derpmap.go
@@ -51,6 +51,10 @@ type DERPRegion struct {
 	// "fra", etc.
 	RegionCode string
 
+	// RegionName is a long English name for the region: "New York City",
+	// "San Francisco", "Singapore", "Frankfurt", etc.
+	RegionName string
+
 	// Nodes are the DERP nodes running in this region, in
 	// priority order for the current client. Client TLS
 	// connections should ideally only go to the first entry


### PR DESCRIPTION
We're beginning to reference DERP region names in the admin UI, so it's best to consolidate this information in our DERP map.

There are a few other references to `tailcfg.DERPRegion` unchanged by this PR (netcheck_test.go, stuntest.go, magicsock_test.go), but since this new field isn't relied on anywhere, it seems fine to leave as an empty string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/686)
<!-- Reviewable:end -->
