### PR TITLE
tsdns: delegate asynchronously

### DIFF
--- a/wgengine/tsdns/forwarder.go
+++ b/wgengine/tsdns/forwarder.go
@@ -1,0 +1,325 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tsdns
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"hash/crc32"
+	"math/rand"
+	"net"
+	"os"
+	"sync"
+	"time"
+
+	"inet.af/netaddr"
+	"tailscale.com/types/logger"
+)
+
+// headerBytes is the number of bytes in a DNS message header.
+const headerBytes = 12
+
+// forwardQueueSize is the maximal number of requests that can be pending delegation.
+// Note that this is distinct from the number of requests that are pending a response,
+// which is not limited (except by txid collisions).
+const forwardQueueSize = 64
+
+// connCount is the number of UDP connections to use for forwarding.
+const connCount = 32
+
+const (
+	// cleanupInterval is the interval between purged of timed-out entries from txMap.
+	cleanupInterval = 30 * time.Second
+	// responseTimeout is the maximal amount of time to wait for a DNS response.
+	responseTimeout = 5 * time.Second
+)
+
+var errNoUpstreams = errors.New("upstream nameservers not set")
+
+var aLongTimeAgo = time.Unix(0, 1)
+
+type forwardedPacket struct {
+	payload []byte
+	dst     net.Addr
+}
+
+type forwardingRecord struct {
+	src       netaddr.IPPort
+	createdAt time.Time
+}
+
+// txid identifies a DNS transaction.
+//
+// As the standard DNS Request ID is only 16 bits, we extend it:
+// the lower 32 bits are the zero-extended bits of the DNS Request ID;
+// the upper 32 bits are the CRC32 checksum of the first question in the request.
+// This makes probability of txid collision negligible.
+type txid uint64
+
+// getTxID computes the txid of the given DNS packet.
+func getTxID(packet []byte) txid {
+	if len(packet) < headerBytes {
+		return 0
+	}
+
+	dnsid := binary.BigEndian.Uint16(packet[0:2])
+	qcount := binary.BigEndian.Uint16(packet[4:6])
+	if qcount == 0 {
+		return txid(dnsid)
+	}
+
+	offset := headerBytes
+	for i := uint16(0); i < qcount; i++ {
+		// Note: this relies on the fact that names are not compressed in questions,
+		// so they are guaranteed to end with a NUL byte.
+		//
+		// Justification:
+		// RFC 1035 doesn't seem to explicitly prohibit compressing names in questions,
+		// but this is exceedingly unlikely to be done in practice. A DNS request
+		// with multiple questions is ill-defined (which questions do the header flags apply to?)
+		// and a single question would have to contain a pointer to an *answer*,
+		// which would be excessively smart, pointless (an answer can just as well refer to the question)
+		// and perhaps even prohibited: a draft RFC (draft-ietf-dnsind-local-compression-05) states:
+		//
+		// > It is important that these pointers always point backwards.
+		//
+		// This is said in summarizing RFC 1035, although that phrase does not appear in the original RFC.
+		// Additionally, (https://cr.yp.to/djbdns/notes.html) states:
+		//
+		// > The precise rule is that a name can be compressed if it is a response owner name,
+		// > the name in NS data, the name in CNAME data, the name in PTR data, the name in MX data,
+		// > or one of the names in SOA data.
+		namebytes := bytes.IndexByte(packet[offset:], 0)
+		// ... | name | NUL | type | class
+		//        ??     1      2      2
+		offset = offset + namebytes + 5
+		if len(packet) < offset {
+			// Corrupt packet; don't crash.
+			return txid(dnsid)
+		}
+	}
+
+	hash := crc32.ChecksumIEEE(packet[headerBytes:offset])
+	return (txid(hash) << 32) | txid(dnsid)
+}
+
+// forwarder forwards DNS packets to a number of upstream nameservers.
+type forwarder struct {
+	logf logger.Logf
+
+	// queue is the queue for delegated packets.
+	queue chan forwardedPacket
+	// responses is a channel by which responses are returned.
+	responses chan Packet
+	// closed signals all goroutines to stop.
+	closed chan struct{}
+	// wg signals when all goroutines have stopped.
+	wg sync.WaitGroup
+
+	// conns are the UDP connections used for forwarding.
+	// A random one is selected for each request, regardless of the target upstream.
+	conns []*net.UDPConn
+
+	mu sync.Mutex
+	// upstreams are the nameserver addresses that should be used for forwarding.
+	upstreams []net.Addr
+	// txMap maps DNS txids to active forwarding records.
+	txMap map[txid]forwardingRecord
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func newForwarder(logf logger.Logf, responses chan Packet) *forwarder {
+	return &forwarder{
+		logf:      logger.WithPrefix(logf, "forward: "),
+		responses: responses,
+		queue:     make(chan forwardedPacket, forwardQueueSize),
+		closed:    make(chan struct{}),
+		conns:     make([]*net.UDPConn, connCount),
+		txMap:     make(map[txid]forwardingRecord),
+	}
+}
+
+func (f *forwarder) Start() error {
+	var err error
+
+	for i := range f.conns {
+		f.conns[i], err = net.ListenUDP("udp", nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	f.wg.Add(connCount + 2)
+	for idx, conn := range f.conns {
+		go f.recv(uint16(idx), conn)
+	}
+	go f.send()
+	go f.cleanMap()
+
+	return nil
+}
+
+func (f *forwarder) Close() {
+	select {
+	case <-f.closed:
+		return
+	default:
+		// continue
+	}
+	close(f.closed)
+
+	for _, conn := range f.conns {
+		conn.SetDeadline(aLongTimeAgo)
+	}
+
+	f.wg.Wait()
+
+	for _, conn := range f.conns {
+		conn.Close()
+	}
+}
+
+func (f *forwarder) setUpstreams(upstreams []net.Addr) {
+	f.mu.Lock()
+	f.upstreams = upstreams
+	f.mu.Unlock()
+}
+
+func (f *forwarder) send() {
+	defer f.wg.Done()
+
+	var packet forwardedPacket
+	for {
+		select {
+		case <-f.closed:
+			return
+		case packet = <-f.queue:
+			// continue
+		}
+
+		connIdx := rand.Intn(connCount)
+		conn := f.conns[connIdx]
+		_, err := conn.WriteTo(packet.payload, packet.dst)
+		if err != nil {
+			// Do not log errors due to expired deadline.
+			if !errors.Is(err, os.ErrDeadlineExceeded) {
+				f.logf("send: %v", err)
+			}
+			return
+		}
+	}
+}
+
+func (f *forwarder) recv(connIdx uint16, conn *net.UDPConn) {
+	defer f.wg.Done()
+
+	for {
+		out := make([]byte, maxResponseBytes)
+		n, err := conn.Read(out)
+
+		if err != nil {
+			// Do not log errors due to expired deadline.
+			if !errors.Is(err, os.ErrDeadlineExceeded) {
+				f.logf("recv: %v", err)
+			}
+			return
+		}
+
+		if n < headerBytes {
+			f.logf("recv: packet too small (%d bytes)", n)
+		}
+
+		out = out[:n]
+		txid := getTxID(out)
+
+		f.mu.Lock()
+
+		record, found := f.txMap[txid]
+		// At most one nameserver will return a response:
+		// the first one to do so will delete txid from the map.
+		if !found {
+			f.mu.Unlock()
+			continue
+		}
+		delete(f.txMap, txid)
+
+		f.mu.Unlock()
+
+		packet := Packet{
+			Payload: out,
+			Addr:    record.src,
+		}
+		select {
+		case <-f.closed:
+			return
+		case f.responses <- packet:
+			// continue
+		}
+	}
+}
+
+// cleanMap periodically deletes timed-out forwarding records from f.txMap to bound growth.
+func (f *forwarder) cleanMap() {
+	defer f.wg.Done()
+
+	t := time.NewTicker(cleanupInterval)
+	defer t.Stop()
+
+	var now time.Time
+	for {
+		select {
+		case <-f.closed:
+			return
+		case now = <-t.C:
+			// continue
+		}
+
+		f.mu.Lock()
+		for k, v := range f.txMap {
+			if now.Sub(v.createdAt) > responseTimeout {
+				delete(f.txMap, k)
+			}
+		}
+		f.mu.Unlock()
+	}
+}
+
+// forward forwards the query to all upstream nameservers and returns the first response.
+func (f *forwarder) forward(query Packet) error {
+	txid := getTxID(query.Payload)
+
+	f.mu.Lock()
+
+	upstreams := f.upstreams
+	if len(upstreams) == 0 {
+		f.mu.Unlock()
+		return errNoUpstreams
+	}
+	f.txMap[txid] = forwardingRecord{
+		src:       query.Addr,
+		createdAt: time.Now(),
+	}
+
+	f.mu.Unlock()
+
+	packet := forwardedPacket{
+		payload: query.Payload,
+	}
+	for _, upstream := range upstreams {
+		packet.dst = upstream
+		select {
+		case <-f.closed:
+			return ErrClosed
+		case f.queue <- packet:
+			// continue
+		}
+	}
+
+	return nil
+}

--- a/wgengine/tsdns/tsdns.go
+++ b/wgengine/tsdns/tsdns.go
@@ -8,33 +8,24 @@ package tsdns
 
 import (
 	"bytes"
-	"context"
-	"encoding/binary"
 	"encoding/hex"
 	"errors"
-	"io"
 	"net"
 	"sync"
 	"time"
 
 	dns "golang.org/x/net/dns/dnsmessage"
 	"inet.af/netaddr"
-	"tailscale.com/net/netns"
 	"tailscale.com/types/logger"
 )
 
-// maxResponseSize is the maximum size of a response from a Resolver.
-const maxResponseSize = 512
+// maxResponseBytes is the maximum size of a response from a Resolver.
+const maxResponseBytes = 512
 
 // pendingQueueSize is the maximal number of DNS requests that can await polling.
 // If EnqueueRequest is called when this many requests are already pending,
 // the request will be dropped to avoid blocking the caller.
 const pendingQueueSize = 64
-
-// upstreamQueueSize is the maximal number of request that can be pending a send to an upstream.
-// Note that this is distinct from the number of requests that may be pending a response,
-// which is not limited (except by txid collisions).
-const upstreamQueueSize = 64
 
 // defaultTTL is the TTL of all responses from Resolver.
 const defaultTTL = 600 * time.Second
@@ -45,7 +36,7 @@ var ErrClosed = errors.New("closed")
 var (
 	errFullQueue      = errors.New("request queue full")
 	errMapNotSet      = errors.New("domain map not set")
-	errNoNameservers  = errors.New("fallback nameservers not set")
+	errNotForwarding  = errors.New("forwarding disabled")
 	errNotImplemented = errors.New("query type not implemented")
 	errNotQuery       = errors.New("not a DNS query")
 	errNotOurName     = errors.New("not a Tailscale DNS name")
@@ -67,70 +58,69 @@ type Packet struct {
 // it delegates to upstream nameservers if any are set.
 type Resolver struct {
 	logf logger.Logf
-
-	// The asynchronous interface is due to the fact that resolution may potentially
-	// block for a long time (if the upstream nameserver is slow to reach).
+	// rootDomain is <root> in <mynode>.<mydomain>.<root>.
+	rootDomain []byte
+	// forwarder is
+	forwarder *forwarder
 
 	// queue is a buffered channel holding DNS requests queued for resolution.
 	queue chan Packet
-	// responses is an unbuffered channel to which responses are sent.
+	// responses is an unbuffered channel to which responses are returned.
 	responses chan Packet
-	// errors is an unbuffered channel to which errors are sent.
+	// errors is an unbuffered channel to which errors are returned.
 	errors chan error
 	// closed signals all goroutines to stop.
 	closed chan struct{}
-
-	// recvWg signals when all delegateRecv goroutines have stopped.
-	recvWg sync.WaitGroup
-	// sendWg signals when all delegateSend goroutines have stopped.
-	sendWg sync.WaitGroup
-	// pollWg signals when all poll goroutines have stopped.
-	pollWg sync.WaitGroup
-	// updateWg signals when all updateNameservers goroutines have stopped.
-	updateWg sync.WaitGroup
-
-	// rootDomain is <root> in <mynode>.<mydomain>.<root>.
-	rootDomain []byte
-
-	// dialer is the netns.Dialer used for delegation.
-	dialer netns.Dialer
+	// wg signals when all goroutines have stopped.
+	wg sync.WaitGroup
 
 	// mu guards the following fields from being updated while used.
 	mu sync.Mutex
 	// dnsMap is the map most recently received from the control server.
 	dnsMap *Map
-	// nameservers is the list of nameserver addresses that should be used
-	// if the received query is not for a Tailscale node.
-	// The addresses are strings of the form ip:port, as expected by Dial.
-	nameservers []string
-	// nameserverConns are the per-nameserver UDP connections.
-	nameserverConns []net.Conn
-	// nameserverQueues are the per-nameserver packet delegation queues.
-	nameserverQueues []chan []byte
-	// txToAddr maps DNS transaction IDs to addresses from which the respective packets originate.
-	txToAddr map[uint16]netaddr.IPPort
+}
+
+// ResolverConfig is the set of configuration options for a Resolver.
+type ResolverConfig struct {
+	// Logf is the logger to use throughout the Resolver.
+	Logf logger.Logf
+	// RootDomain is the domain whose subdomains will be resolved locally as Tailscale nodes.
+	RootDomain string
+	// Forward determines whether the resolver will forward packets to
+	// nameservers set with SetUpstreams if the domain name is not of a Tailscale node.
+	Forward bool
 }
 
 // NewResolver constructs a resolver associated with the given root domain.
 // The root domain must be in canonical form (with a trailing period).
-func NewResolver(logf logger.Logf, rootDomain string) *Resolver {
+func NewResolver(config ResolverConfig) *Resolver {
 	r := &Resolver{
-		logf:       logger.WithPrefix(logf, "tsdns: "),
+		logf:       logger.WithPrefix(config.Logf, "tsdns: "),
 		queue:      make(chan Packet, pendingQueueSize),
 		responses:  make(chan Packet),
 		errors:     make(chan error),
 		closed:     make(chan struct{}),
-		rootDomain: []byte(rootDomain),
-		dialer:     netns.NewDialer(),
-		txToAddr:   make(map[uint16]netaddr.IPPort),
+		rootDomain: []byte(config.RootDomain),
+	}
+
+	if config.Forward {
+		r.forwarder = newForwarder(r.logf, r.responses)
 	}
 
 	return r
 }
 
-func (r *Resolver) Start() {
-	r.pollWg.Add(1)
+func (r *Resolver) Start() error {
+	if r.forwarder != nil {
+		if err := r.forwarder.Start(); err != nil {
+			return err
+		}
+	}
+
+	r.wg.Add(1)
 	go r.poll()
+
+	return nil
 }
 
 // Close shuts down the resolver and ensures poll goroutines have exited.
@@ -144,9 +134,11 @@ func (r *Resolver) Close() {
 	}
 	close(r.closed)
 
-	r.updateWg.Wait()
-	r.cleanupNameservers()
-	r.pollWg.Wait()
+	if r.forwarder != nil {
+		r.forwarder.Close()
+	}
+
+	r.wg.Wait()
 }
 
 // SetMap sets the resolver's DNS map, taking ownership of it.
@@ -158,102 +150,11 @@ func (r *Resolver) SetMap(m *Map) {
 	r.logf("map diff:\n%s", m.PrettyDiffFrom(oldMap))
 }
 
-func (r *Resolver) cleanupNameservers() {
-	r.mu.Lock()
-	conns := r.nameserverConns
-	queues := r.nameserverQueues
-	r.mu.Unlock()
-
-	for _, queue := range queues {
-		close(queue)
-	}
-	// Let outstanding requests drain.
-	for _, conn := range conns {
-		conn.SetDeadline(time.Now().Add(time.Second))
-	}
-	r.sendWg.Wait()
-	r.recvWg.Wait()
-	for _, conn := range conns {
-		conn.Close()
-	}
-}
-
-func (r *Resolver) updateNameservers(nameservers []string) {
-	defer r.updateWg.Done()
-
-	newConns := make([]net.Conn, len(nameservers))
-	for i := range newConns {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-
-		conn, err := r.dialer.DialContext(ctx, "udp", nameservers[i])
-		if err != nil {
-			r.logf("[unexpected] %v", err)
-		} else {
-			newConns[i] = conn
-		}
-
-		cancel()
-	}
-
-	newQueues := make([]chan []byte, len(nameservers))
-	for i := range newQueues {
-		newQueues[i] = make(chan []byte, upstreamQueueSize)
-	}
-
-	r.mu.Lock()
-
-	oldConns := r.nameserverConns
-	oldQueues := r.nameserverQueues
-
-	r.nameserverConns = newConns
-	r.nameserverQueues = newQueues
-
-	r.mu.Unlock()
-
-	for _, queue := range oldQueues {
-		close(queue)
-	}
-	// Let outstanding requests drain.
-	for _, conn := range oldConns {
-		conn.SetDeadline(time.Now().Add(time.Second))
-	}
-	r.sendWg.Wait()
-	r.recvWg.Wait()
-	for _, conn := range oldConns {
-		conn.Close()
-	}
-
-	r.recvWg.Add(len(nameservers))
-	r.sendWg.Add(len(nameservers))
-	for i := range nameservers {
-		go r.delegateRecv(newConns[i])
-		go r.delegateSend(newConns[i], newQueues[i])
-	}
-}
-
-// SetUpstreamNameservers sets the addresses of the resolver's
+// SetUpstreams sets the addresses of the resolver's
 // upstream nameservers, taking ownership of the argument.
-// The addresses should be strings of the form ip:port,
-// matching what Dial("udp", addr) expects as addr.
-func (r *Resolver) SetNameservers(newNameservers []string) {
-	r.mu.Lock()
-	oldNameservers := r.nameservers
-	r.nameservers = newNameservers
-	r.mu.Unlock()
-
-	equal := len(oldNameservers) == len(newNameservers)
-	if equal {
-		for i, oldServer := range oldNameservers {
-			if newNameservers[i] != oldServer {
-				equal = false
-				break
-			}
-		}
-	}
-
-	if !equal {
-		r.updateWg.Add(1)
-		go r.updateNameservers(newNameservers)
+func (r *Resolver) SetUpstreams(upstreams []net.Addr) {
+	if r.forwarder != nil {
+		r.forwarder.setUpstreams(upstreams)
 	}
 }
 
@@ -262,6 +163,8 @@ func (r *Resolver) SetNameservers(newNameservers []string) {
 // If the queue is full, the request will be dropped and an error will be returned.
 func (r *Resolver) EnqueueRequest(request Packet) error {
 	select {
+	case <-r.closed:
+		return ErrClosed
 	case r.queue <- request:
 		return nil
 	default:
@@ -273,12 +176,12 @@ func (r *Resolver) EnqueueRequest(request Packet) error {
 // It blocks until a response is available and gives up ownership of the response payload.
 func (r *Resolver) NextResponse() (Packet, error) {
 	select {
+	case <-r.closed:
+		return Packet{}, ErrClosed
 	case resp := <-r.responses:
 		return resp, nil
 	case err := <-r.errors:
 		return Packet{}, err
-	case <-r.closed:
-		return Packet{}, ErrClosed
 	}
 }
 
@@ -318,139 +221,46 @@ func (r *Resolver) ResolveReverse(ip netaddr.IP) (string, dns.RCode, error) {
 }
 
 func (r *Resolver) poll() {
-	defer r.pollWg.Done()
+	defer r.wg.Done()
 
 	var packet Packet
 	for {
 		select {
-		case packet = <-r.queue:
-			// continue
 		case <-r.closed:
 			return
+		case packet = <-r.queue:
+			// continue
 		}
 
 		out, err := r.respond(packet.Payload)
 
-		switch err {
-		case errNotOurName:
-			r.delegate(packet)
-		case nil:
-			packet.Payload = out
+		if err == errNotOurName {
+			if r.forwarder != nil {
+				err = r.forwarder.forward(packet)
+				if err == nil {
+					// forward will send response into r.responses, nothing to do.
+					continue
+				}
+			} else {
+				err = errNotForwarding
+			}
+		}
+
+		if err != nil {
 			select {
-			case r.responses <- packet:
-				// continue
 			case <-r.closed:
 				return
-			}
-		default:
-			select {
 			case r.errors <- err:
 				// continue
+			}
+		} else {
+			packet.Payload = out
+			select {
 			case <-r.closed:
 				return
+			case r.responses <- packet:
+				// continue
 			}
-		}
-	}
-}
-
-func (r *Resolver) delegateSend(conn net.Conn, datach chan []byte) {
-	defer r.sendWg.Done()
-
-	for packet := range datach {
-		_, err := conn.Write(packet)
-		if err != nil {
-			if err == io.EOF {
-				return
-			}
-			// TODO(dmytro): switch to ErrDeadlineExceeded when on 1.15.
-			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-				return
-			}
-			r.logf("send: %v", err)
-		}
-	}
-}
-
-func (r *Resolver) delegateRecv(conn net.Conn) {
-	defer r.recvWg.Done()
-
-	for {
-		out := make([]byte, maxResponseSize)
-		n, err := conn.Read(out)
-
-		if err != nil {
-			if err == io.EOF {
-				return
-			}
-			// TODO(dmytro): switch to ErrDeadlineExceeded when on 1.15.
-			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-				return
-			}
-			r.logf("recv: %v", err)
-			continue
-		}
-
-		// Sanity check.
-		if n < 20 {
-			r.logf("recv: packet too small (%d bytes)", n)
-		}
-
-		txID := binary.BigEndian.Uint16(out[0:2])
-		r.mu.Lock()
-		addr, found := r.txToAddr[txID]
-		delete(r.txToAddr, txID)
-		r.mu.Unlock()
-
-		// At most one nameserver will return a response:
-		// the first one to do so will delete txID from the map.
-		if !found {
-			return
-		}
-
-		packet := Packet{
-			Payload: out[:n],
-			Addr:    addr,
-		}
-		select {
-		case r.responses <- packet:
-			// continue
-		case <-r.closed:
-			return
-		}
-	}
-}
-
-// delegate forwards the query to all upstream nameservers and returns the first response.
-func (r *Resolver) delegate(query Packet) {
-	r.updateWg.Wait()
-
-	txID := binary.BigEndian.Uint16(query.Payload[0:2])
-
-	r.mu.Lock()
-	nameservers := r.nameservers
-	queues := r.nameserverQueues
-	r.txToAddr[txID] = query.Addr
-	r.mu.Unlock()
-
-	if len(nameservers) == 0 {
-		r.mu.Lock()
-		delete(r.txToAddr, txID)
-		r.mu.Unlock()
-
-		select {
-		case r.errors <- errNoNameservers:
-			return
-		case <-r.closed:
-			return
-		}
-	}
-
-	for _, queue := range queues {
-		select {
-		case <-r.closed:
-			return
-		case queue <- query.Payload:
-			// continue
 		}
 	}
 }

--- a/wgengine/tsdns/tsdns_test.go
+++ b/wgengine/tsdns/tsdns_test.go
@@ -289,6 +289,11 @@ func TestDelegate(t *testing.T) {
 		{"nxdomain", dnspacket("nxdomain.site.", dns.TypeA), netaddr.IP{}, dns.RCodeNameError},
 	}
 
+	for i, tt := range tests {
+		// Delegation relies on txids being distinct.
+		tt.query[1] ^= byte(i)
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resp, err := syncRespond(r, tt.query)

--- a/wgengine/tsdns/tsdns_test.go
+++ b/wgengine/tsdns/tsdns_test.go
@@ -7,11 +7,13 @@ package tsdns
 import (
 	"bytes"
 	"errors"
+	"net"
 	"sync"
 	"testing"
 
 	dns "golang.org/x/net/dns/dnsmessage"
 	"inet.af/netaddr"
+	"tailscale.com/tstest"
 )
 
 var testipv4 = netaddr.IPv4(1, 2, 3, 4)
@@ -178,9 +180,13 @@ func TestRDNSNameToIPv6(t *testing.T) {
 }
 
 func TestResolve(t *testing.T) {
-	r := NewResolver(t.Logf, "ipn.dev")
+	r := NewResolver(ResolverConfig{Logf: t.Logf, RootDomain: "ipn.dev.", Forward: false})
 	r.SetMap(dnsMap)
-	r.Start()
+
+	if err := r.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer r.Close()
 
 	tests := []struct {
 		name   string
@@ -212,9 +218,13 @@ func TestResolve(t *testing.T) {
 }
 
 func TestResolveReverse(t *testing.T) {
-	r := NewResolver(t.Logf, "ipn.dev")
+	r := NewResolver(ResolverConfig{Logf: t.Logf, RootDomain: "ipn.dev.", Forward: false})
 	r.SetMap(dnsMap)
-	r.Start()
+
+	if err := r.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer r.Close()
 
 	tests := []struct {
 		name string
@@ -244,6 +254,9 @@ func TestResolveReverse(t *testing.T) {
 }
 
 func TestDelegate(t *testing.T) {
+	rc := tstest.NewResourceCheck()
+	defer rc.Assert(t)
+
 	dnsHandleFunc("test.site.", resolveToIP(testipv4, testipv6))
 	dnsHandleFunc("nxdomain.site.", resolveToNXDOMAIN)
 
@@ -271,12 +284,16 @@ func TestDelegate(t *testing.T) {
 		return
 	}
 
-	r := NewResolver(t.Logf, "ipn.dev")
-	r.SetNameservers([]string{
-		v4server.PacketConn.LocalAddr().String(),
-		v6server.PacketConn.LocalAddr().String(),
+	r := NewResolver(ResolverConfig{Logf: t.Logf, RootDomain: "ipn.dev.", Forward: true})
+	r.SetUpstreams([]net.Addr{
+		v4server.PacketConn.LocalAddr(),
+		v6server.PacketConn.LocalAddr(),
 	})
-	r.Start()
+
+	if err := r.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer r.Close()
 
 	tests := []struct {
 		name  string
@@ -287,11 +304,6 @@ func TestDelegate(t *testing.T) {
 		{"ipv4", dnspacket("test.site.", dns.TypeA), testipv4, dns.RCodeSuccess},
 		{"ipv6", dnspacket("test.site.", dns.TypeAAAA), testipv6, dns.RCodeSuccess},
 		{"nxdomain", dnspacket("nxdomain.site.", dns.TypeA), netaddr.IP{}, dns.RCodeNameError},
-	}
-
-	for i, tt := range tests {
-		// Delegation relies on txids being distinct.
-		tt.query[1] ^= byte(i)
 	}
 
 	for _, tt := range tests {
@@ -316,9 +328,92 @@ func TestDelegate(t *testing.T) {
 	}
 }
 
+func TestDelegateCollision(t *testing.T) {
+	dnsHandleFunc("test.site.", resolveToIP(testipv4, testipv6))
+
+	server, errch := serveDNS("127.0.0.1:0")
+	defer func() {
+		if err := <-errch; err != nil {
+			t.Errorf("server error: %v", err)
+		}
+	}()
+
+	if server == nil {
+		return
+	}
+	defer server.Shutdown()
+
+	r := NewResolver(ResolverConfig{Logf: t.Logf, RootDomain: "ipn.dev.", Forward: true})
+	r.SetUpstreams([]net.Addr{server.PacketConn.LocalAddr()})
+
+	if err := r.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer r.Close()
+
+	packets := []struct {
+		qname string
+		qtype dns.Type
+		addr  netaddr.IPPort
+	}{
+		{"test.site.", dns.TypeA, netaddr.IPPort{IP: netaddr.IPv4(1, 1, 1, 1), Port: 1001}},
+		{"test.site.", dns.TypeAAAA, netaddr.IPPort{IP: netaddr.IPv4(1, 1, 1, 1), Port: 1002}},
+	}
+
+	// packets will have the same dns txid.
+	for _, p := range packets {
+		payload := dnspacket(p.qname, p.qtype)
+		req := Packet{Payload: payload, Addr: p.addr}
+		err := r.EnqueueRequest(req)
+		if err != nil {
+			t.Error(err)
+		}
+	}
+
+	// Despite the txid collision, the answer(s) should still match the query.
+	resp, err := r.NextResponse()
+	if err != nil {
+		t.Error(err)
+	}
+
+	var p dns.Parser
+	_, err = p.Start(resp.Payload)
+	if err != nil {
+		t.Error(err)
+	}
+	err = p.SkipAllQuestions()
+	if err != nil {
+		t.Error(err)
+	}
+	ans, err := p.AllAnswers()
+	if err != nil {
+		t.Error(err)
+	}
+
+	var wantType dns.Type
+	switch ans[0].Body.(type) {
+	case *dns.AResource:
+		wantType = dns.TypeA
+	case *dns.AAAAResource:
+		wantType = dns.TypeAAAA
+	default:
+		t.Errorf("unexpected answer type: %T", ans[0].Body)
+	}
+
+	for _, p := range packets {
+		if p.qtype == wantType && p.addr != resp.Addr {
+			t.Errorf("addr = %v; want %v", resp.Addr, p.addr)
+		}
+	}
+}
+
 func TestConcurrentSetMap(t *testing.T) {
-	r := NewResolver(t.Logf, "ipn.dev.")
-	r.Start()
+	r := NewResolver(ResolverConfig{Logf: t.Logf, RootDomain: "ipn.dev.", Forward: false})
+
+	if err := r.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer r.Close()
 
 	// This is purely to ensure that Resolve does not race with SetMap.
 	var wg sync.WaitGroup
@@ -334,17 +429,36 @@ func TestConcurrentSetMap(t *testing.T) {
 	wg.Wait()
 }
 
-func TestConcurrentSetNameservers(t *testing.T) {
-	r := NewResolver(t.Logf, "ipn.dev.")
-	r.Start()
-	packet := dnspacket("google.com.", dns.TypeA)
+func TestConcurrentSetUpstreams(t *testing.T) {
+	dnsHandleFunc("test.site.", resolveToIP(testipv4, testipv6))
 
-	// This is purely to ensure that delegation does not race with SetNameservers.
+	server, errch := serveDNS("127.0.0.1:0")
+	defer func() {
+		if err := <-errch; err != nil {
+			t.Errorf("server error: %v", err)
+		}
+	}()
+
+	if server == nil {
+		return
+	}
+	defer server.Shutdown()
+
+	r := NewResolver(ResolverConfig{Logf: t.Logf, RootDomain: "ipn.dev.", Forward: true})
+	r.SetMap(dnsMap)
+
+	if err := r.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer r.Close()
+
+	packet := dnspacket("test.site.", dns.TypeA)
+	// This is purely to ensure that delegation does not race with SetUpstreams.
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		r.SetNameservers([]string{"9.9.9.9:53"})
+		r.SetUpstreams([]net.Addr{server.PacketConn.LocalAddr()})
 	}()
 	go func() {
 		defer wg.Done()
@@ -420,9 +534,13 @@ var nxdomainResponse = []byte{
 }
 
 func TestFull(t *testing.T) {
-	r := NewResolver(t.Logf, "ipn.dev.")
+	r := NewResolver(ResolverConfig{Logf: t.Logf, RootDomain: "ipn.dev.", Forward: false})
 	r.SetMap(dnsMap)
-	r.Start()
+
+	if err := r.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer r.Close()
 
 	// One full packet and one error packet
 	tests := []struct {
@@ -450,9 +568,13 @@ func TestFull(t *testing.T) {
 }
 
 func TestAllocs(t *testing.T) {
-	r := NewResolver(t.Logf, "ipn.dev.")
+	r := NewResolver(ResolverConfig{Logf: t.Logf, RootDomain: "ipn.dev.", Forward: false})
 	r.SetMap(dnsMap)
-	r.Start()
+
+	if err := r.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer r.Close()
 
 	// It is seemingly pointless to test allocs in the delegate path,
 	// as dialer.Dial -> Read -> Write alone comprise 12 allocs.
@@ -478,9 +600,28 @@ func TestAllocs(t *testing.T) {
 }
 
 func BenchmarkFull(b *testing.B) {
-	r := NewResolver(b.Logf, "ipn.dev.")
+	dnsHandleFunc("test.site.", resolveToIP(testipv4, testipv6))
+
+	server, errch := serveDNS("127.0.0.1:0")
+	defer func() {
+		if err := <-errch; err != nil {
+			b.Errorf("server error: %v", err)
+		}
+	}()
+
+	if server == nil {
+		return
+	}
+	defer server.Shutdown()
+
+	r := NewResolver(ResolverConfig{Logf: b.Logf, RootDomain: "ipn.dev.", Forward: true})
 	r.SetMap(dnsMap)
-	r.Start()
+	r.SetUpstreams([]net.Addr{server.PacketConn.LocalAddr()})
+
+	if err := r.Start(); err != nil {
+		b.Fatalf("start: %v", err)
+	}
+	defer r.Close()
 
 	tests := []struct {
 		name    string
@@ -488,7 +629,7 @@ func BenchmarkFull(b *testing.B) {
 	}{
 		{"forward", dnspacket("test1.ipn.dev.", dns.TypeA)},
 		{"reverse", dnspacket("4.3.2.1.in-addr.arpa.", dns.TypePTR)},
-		{"nxdomain", dnspacket("test3.ipn.dev.", dns.TypeA)},
+		{"delegated", dnspacket("test.site.", dns.TypeA)},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
As per earlier discussion (synchronous delegation is too slow and its queue is too shallow). The two commits implement different approaches; I much prefer the second one, but it makes a certain assumption.
- first commit (d66d600) implements the "goroutine per request" approach. This uses more memory than necessary and has tricky synchronization.
- second commit (08775a7) changes this to a map keyed on DNS Transaction ID and a (spcket, 2 goroutines) per nameserver, which is leaner and more elegant. The downside is that this assumes Transaction IDs don't collide in a short enough period of time, which is questionable, as normally distinctness of ports makes makes it less relevant. A way to mitigate this this would be to have more sockets per nameserver and additionally key on the socket index.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/687)
<!-- Reviewable:end -->
