### PR TITLE
derp: advertise server public key following ServerHello

### DIFF
--- a/derp/derp.go
+++ b/derp/derp.go
@@ -39,10 +39,10 @@ const (
 	keepAlive      = 60 * time.Second
 )
 
-// protocolVersion is bumped whenever there's a wire-incompatible change.
+// ProtocolVersion is bumped whenever there's a wire-incompatible change.
 //   * version 1 (zero on wire): consistent box headers, in use by employee dev nodes a bit
 //   * version 2: received packets have src addrs in frameRecvPacket at beginning
-const protocolVersion = 2
+const ProtocolVersion = 2
 
 // frameType is the one byte frame type at the beginning of the frame
 // header.  The second field is a big-endian uint32 describing the

--- a/derp/derphttp/derphttp_server.go
+++ b/derp/derphttp/derphttp_server.go
@@ -5,11 +5,18 @@
 package derphttp
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 
 	"tailscale.com/derp"
 )
+
+// fastStartHeader is the header (with value "1") that signals to the HTTP
+// server that the DERP HTTP client does not want the HTTP 101 response
+// headers and it will begin writing & reading the DERP protocol immediately
+// following its HTTP request.
+const fastStartHeader = "Derp-Fast-Start"
 
 func Handler(s *derp.Server) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -17,21 +24,32 @@ func Handler(s *derp.Server) http.Handler {
 			http.Error(w, "DERP requires connection upgrade", http.StatusUpgradeRequired)
 			return
 		}
-		w.Header().Set("Upgrade", "DERP")
-		w.Header().Set("Connection", "Upgrade")
-		w.WriteHeader(http.StatusSwitchingProtocols)
+		fastStart := r.Header.Get(fastStartHeader) == "1"
 
 		h, ok := w.(http.Hijacker)
 		if !ok {
 			http.Error(w, "HTTP does not support general TCP support", 500)
 			return
 		}
+
 		netConn, conn, err := h.Hijack()
 		if err != nil {
 			log.Printf("Hijack failed: %v", err)
 			http.Error(w, "HTTP does not support general TCP support", 500)
 			return
 		}
+
+		if !fastStart {
+			pubKey := s.PublicKey()
+			fmt.Fprintf(conn, "HTTP/1.1 101 Switching Protocols\r\n"+
+				"Upgrade: DERP\r\n"+
+				"Connection: Upgrade\r\n"+
+				"Derp-Version: %v\r\n"+
+				"Derp-Public-Key: %x\r\n\r\n",
+				derp.ProtocolVersion,
+				pubKey[:])
+		}
+
 		s.Accept(netConn, conn, netConn.RemoteAddr().String())
 	})
 }


### PR DESCRIPTION
```
* advertise server's DERP public key following ServerHello
* have client look for that DEPR public key in the response
  PeerCertificates
* let client advertise it's going into a "fast start" mode
  if it finds it
* modify server to support that fast start mode, just not
  sending the HTTP response header

Cuts down another round trip, bringing the latency of being able to
write our first DERP frame from SF to Bangalore from ~725ms
(3 RTT) to ~481ms (2 RTT: TCP and TLS).
```

Fixes #693

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/695)
<!-- Reviewable:end -->
