### PR TITLE
tailcfg, tsdns: derive root domains from list of nodes

### DIFF
--- a/ipn/local.go
+++ b/ipn/local.go
@@ -550,7 +550,7 @@ func (b *LocalBackend) updateDNSMap(netMap *controlclient.NetworkMap) {
 	}
 	set(netMap.Name, netMap.Addresses)
 
-	dnsMap := tsdns.NewMap(nameToIP)
+	dnsMap := tsdns.NewMap(nameToIP, domainsForProxying(netMap))
 	// map diff will be logged in tsdns.Resolver.SetMap.
 	b.e.SetDNSMap(dnsMap)
 }

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -496,10 +496,18 @@ var FilterAllowAll = []FilterRule{
 
 // DNSConfig is the DNS configuration.
 type DNSConfig struct {
+	// Nameservers are the IP addresses of the nameservers to use.
 	Nameservers []netaddr.IP `json:",omitempty"`
-	Domains     []string     `json:",omitempty"`
-	PerDomain   bool
-	Proxied     bool
+	// Domains are the search domains to use.
+	Domains []string `json:",omitempty"`
+	// PerDomain indicates whether it is preferred to use Nameservers
+	// only for DNS queries for subdomains of Domains.
+	// Some OSes and OS configurations don't support per-domain DNS configuration,
+	// in which case Nameservers applies to all DNS requests regardless of PerDomain's value.
+	PerDomain bool
+	// Proxied indicates whether DNS requests are proxied through a tsdns.Resolver.
+	// This enables Magic DNS. It is togglable independently of PerDomain.
+	Proxied bool
 }
 
 type MapResponse struct {

--- a/wgengine/router/dns/config.go
+++ b/wgengine/router/dns/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	// if the manager does not support per-domain settings.
 	PerDomain bool
 	// Proxied indicates whether DNS requests are proxied through a tsdns.Resolver.
+	// This enables Magic DNS.
 	Proxied bool
 }
 

--- a/wgengine/tsdns/map_test.go
+++ b/wgengine/tsdns/map_test.go
@@ -16,12 +16,12 @@ func TestPretty(t *testing.T) {
 		dmap *Map
 		want string
 	}{
-		{"empty", NewMap(nil), ""},
+		{"empty", NewMap(nil, nil), ""},
 		{
 			"single",
 			NewMap(map[string]netaddr.IP{
 				"hello.ipn.dev.": netaddr.IPv4(100, 101, 102, 103),
-			}),
+			}, nil),
 			"hello.ipn.dev.\t100.101.102.103\n",
 		},
 		{
@@ -29,7 +29,7 @@ func TestPretty(t *testing.T) {
 			NewMap(map[string]netaddr.IP{
 				"test1.domain.":     netaddr.IPv4(100, 101, 102, 103),
 				"test2.sub.domain.": netaddr.IPv4(100, 99, 9, 1),
-			}),
+			}, nil),
 			"test1.domain.\t100.101.102.103\ntest2.sub.domain.\t100.99.9.1\n",
 		},
 	}
@@ -57,7 +57,7 @@ func TestPrettyDiffFrom(t *testing.T) {
 			NewMap(map[string]netaddr.IP{
 				"test1.ipn.dev.": netaddr.IPv4(100, 101, 102, 103),
 				"test2.ipn.dev.": netaddr.IPv4(100, 103, 102, 101),
-			}),
+			}, nil),
 			"+test1.ipn.dev.\t100.101.102.103\n+test2.ipn.dev.\t100.103.102.101\n",
 		},
 		{
@@ -65,11 +65,11 @@ func TestPrettyDiffFrom(t *testing.T) {
 			NewMap(map[string]netaddr.IP{
 				"test1.ipn.dev.": netaddr.IPv4(100, 101, 102, 103),
 				"test2.ipn.dev.": netaddr.IPv4(100, 103, 102, 101),
-			}),
+			}, nil),
 			NewMap(map[string]netaddr.IP{
 				"test2.ipn.dev.": netaddr.IPv4(100, 103, 102, 101),
 				"test1.ipn.dev.": netaddr.IPv4(100, 101, 102, 103),
-			}),
+			}, nil),
 			"",
 		},
 		{
@@ -77,11 +77,11 @@ func TestPrettyDiffFrom(t *testing.T) {
 			NewMap(map[string]netaddr.IP{
 				"test1.ipn.dev.": netaddr.IPv4(100, 101, 102, 103),
 				"test2.ipn.dev.": netaddr.IPv4(100, 103, 102, 101),
-			}),
+			}, nil),
 			NewMap(map[string]netaddr.IP{
 				"test2.ipn.dev.": netaddr.IPv4(100, 104, 102, 101),
 				"test1.ipn.dev.": netaddr.IPv4(100, 101, 102, 103),
-			}),
+			}, nil),
 			"-test2.ipn.dev.\t100.103.102.101\n+test2.ipn.dev.\t100.104.102.101\n",
 		},
 		{
@@ -89,12 +89,12 @@ func TestPrettyDiffFrom(t *testing.T) {
 			NewMap(map[string]netaddr.IP{
 				"test1.ipn.dev.": netaddr.IPv4(100, 101, 102, 103),
 				"test2.ipn.dev.": netaddr.IPv4(100, 103, 102, 101),
-			}),
+			}, nil),
 			NewMap(map[string]netaddr.IP{
 				"test3.ipn.dev.": netaddr.IPv4(100, 105, 106, 107),
 				"test2.ipn.dev.": netaddr.IPv4(100, 103, 102, 101),
 				"test1.ipn.dev.": netaddr.IPv4(100, 101, 102, 103),
-			}),
+			}, nil),
 			"+test3.ipn.dev.\t100.105.106.107\n",
 		},
 		{
@@ -102,10 +102,10 @@ func TestPrettyDiffFrom(t *testing.T) {
 			NewMap(map[string]netaddr.IP{
 				"test1.ipn.dev.": netaddr.IPv4(100, 101, 102, 103),
 				"test2.ipn.dev.": netaddr.IPv4(100, 103, 102, 101),
-			}),
+			}, nil),
 			NewMap(map[string]netaddr.IP{
 				"test1.ipn.dev.": netaddr.IPv4(100, 101, 102, 103),
-			}),
+			}, nil),
 			"-test2.ipn.dev.\t100.103.102.101\n",
 		},
 		{
@@ -115,12 +115,12 @@ func TestPrettyDiffFrom(t *testing.T) {
 				"test4.ipn.dev.": netaddr.IPv4(100, 107, 106, 105),
 				"test5.ipn.dev.": netaddr.IPv4(100, 64, 1, 1),
 				"test2.ipn.dev.": netaddr.IPv4(100, 103, 102, 101),
-			}),
+			}, nil),
 			NewMap(map[string]netaddr.IP{
 				"test2.ipn.dev.": netaddr.IPv4(100, 104, 102, 101),
 				"test1.ipn.dev.": netaddr.IPv4(100, 100, 101, 102),
 				"test3.ipn.dev.": netaddr.IPv4(100, 64, 1, 1),
-			}),
+			}, nil),
 			"-test1.ipn.dev.\t100.101.102.103\n+test1.ipn.dev.\t100.100.101.102\n" +
 				"-test2.ipn.dev.\t100.103.102.101\n+test2.ipn.dev.\t100.104.102.101\n" +
 				"+test3.ipn.dev.\t100.64.1.1\n-test4.ipn.dev.\t100.107.106.105\n-test5.ipn.dev.\t100.64.1.1\n",

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -61,9 +61,6 @@ const (
 	magicDNSPort = 53
 )
 
-// magicDNSDomain is the parent domain for Tailscale nodes.
-const magicDNSDomain = "b.tailscale.net."
-
 // Lazy wireguard-go configuration parameters.
 const (
 	// lazyPeerIdleThreshold is the idle duration after
@@ -202,9 +199,8 @@ func newUserspaceEngineAdvanced(conf EngineConfig) (_ Engine, reterr error) {
 	logf := conf.Logf
 
 	rconf := tsdns.ResolverConfig{
-		Logf:       conf.Logf,
-		RootDomain: magicDNSDomain,
-		Forward:    true,
+		Logf:    conf.Logf,
+		Forward: true,
 	}
 	e := &userspaceEngine{
 		timeNow:  time.Now,


### PR DESCRIPTION
This is important for future extensibility: client code should not hard-code the root domains.

An alternative to this would involve sending domains down from control, but this seems simpler, even if the resultant list is longer (usually `[]{"$workgroup.beta.tailscale.net.", "tailscale.com.beta.tailscale.net."}` instead of just `[]{"beta.tailscale.net."}`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/708)
<!-- Reviewable:end -->
