### PR TITLE
cmd/tailscale/cli: add new flag --force-reauth to up subcommand

### DIFF
--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -53,6 +53,7 @@ specify any flags, options are reset to their default.
 		upf.BoolVar(&upArgs.acceptDNS, "accept-dns", true, "accept DNS configuration from the admin panel")
 		upf.BoolVar(&upArgs.singleRoutes, "host-routes", true, "install host routes to other Tailscale nodes")
 		upf.BoolVar(&upArgs.shieldsUp, "shields-up", false, "don't allow incoming connections")
+		upf.BoolVar(&upArgs.forceReauth, "force-reauth", false, "force reauthentication")
 		upf.StringVar(&upArgs.advertiseTags, "advertise-tags", "", "ACL tags to request (comma-separated, e.g. eng,montreal,ssh)")
 		upf.StringVar(&upArgs.authKey, "authkey", "", "node authorization key")
 		upf.StringVar(&upArgs.hostname, "hostname", "", "hostname to use instead of the one provided by the OS")
@@ -75,6 +76,7 @@ var upArgs struct {
 	acceptDNS       bool
 	singleRoutes    bool
 	shieldsUp       bool
+	forceReauth     bool
 	advertiseRoutes string
 	advertiseTags   string
 	enableDERP      bool
@@ -212,6 +214,7 @@ func runUp(ctx context.Context, args []string) error {
 	defer cancel()
 
 	var printed bool
+	var loginStarted bool
 
 	bc.SetPrefs(prefs)
 	opts := ipn.Options{
@@ -224,6 +227,10 @@ func runUp(ctx context.Context, args []string) error {
 			if s := n.State; s != nil {
 				switch *s {
 				case ipn.NeedsLogin:
+					if loginStarted {
+						break
+					}
+					loginStarted = true
 					printed = true
 					bc.StartLoginInteractive()
 				case ipn.NeedsMachineAuth:
@@ -251,6 +258,11 @@ func runUp(ctx context.Context, args []string) error {
 	// ephemeral frontends that read/modify/write state, once
 	// Windows/Mac state is moved into backend.
 	bc.Start(opts)
+	if upArgs.forceReauth && !loginStarted {
+		loginStarted = true
+		printed = true
+		bc.StartLoginInteractive()
+	}
 	pump(ctx, bc, c)
 
 	return nil


### PR DESCRIPTION
Add a new flag `--force-reauth` to `tailscale up`. It can start the login process even the user is already logged in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/717)
<!-- Reviewable:end -->
