### PR TITLE
portlist: reduce log spam on macOS

### DIFF
--- a/portlist/netstat.go
+++ b/portlist/netstat.go
@@ -41,6 +41,10 @@ func parsePort(s string) int {
 	return int(port)
 }
 
+func isLoopbackAddr(s string) bool {
+	return strings.HasPrefix(s, "127.0.0.1:") || strings.HasPrefix(s, "127.0.0.1.")
+}
+
 type nothing struct{}
 
 // Lowest common denominator parser for "netstat -na" format.
@@ -74,7 +78,7 @@ func parsePortsNetstat(output string) List {
 				// not interested in non-listener sockets
 				continue
 			}
-			if strings.HasPrefix(laddr, "127.0.0.1:") || strings.HasPrefix(laddr, "127.0.0.1.") {
+			if isLoopbackAddr(laddr) {
 				// not interested in loopback-bound listeners
 				continue
 			}
@@ -85,7 +89,7 @@ func parsePortsNetstat(output string) List {
 			proto = "udp"
 			laddr = cols[len(cols)-2]
 			raddr = cols[len(cols)-1]
-			if strings.HasPrefix(laddr, "127.0.0.1:") || strings.HasPrefix(laddr, "127.0.0.1.") {
+			if isLoopbackAddr(laddr) {
 				// not interested in loopback-bound listeners
 				continue
 			}

--- a/portlist/portlist_macos.go
+++ b/portlist/portlist_macos.go
@@ -95,9 +95,12 @@ func addProcesses(pl []Port) ([]Port, error) {
 			if port > 0 {
 				pp := ProtoPort{proto, uint16(port)}
 				p := m[pp]
-				if p != nil {
+				switch {
+				case p != nil:
 					p.Process = cmd
-				} else {
+				case isLoopbackAddr(val):
+					// ignore
+				default:
 					fmt.Fprintf(os.Stderr, "weird: missing %v\n", pp)
 				}
 			}


### PR DESCRIPTION
Running tailscaled on my machine yields lots of entries like:

weird: missing {tcp 6060}

parsePortsNetstat is filtering out loopback addresses as uninteresting.
Then addProcesses is surprised to discover these listening ports,
which results in spurious logging.
Teach addProcesses to also ignore loopback addresses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/733)
<!-- Reviewable:end -->
