### PR TITLE
ipn: treat all errors from ReadState as ErrStateNotExist

### DIFF
--- a/ipn/local.go
+++ b/ipn/local.go
@@ -665,23 +665,20 @@ func (b *LocalBackend) loadStateLocked(key StateKey, prefs *Prefs, legacyPath st
 	b.logf("Using backend prefs")
 	bs, err := b.store.ReadState(key)
 	if err != nil {
-		if errors.Is(err, ErrStateNotExist) {
-			if legacyPath != "" {
-				b.prefs, err = LoadPrefs(legacyPath)
-				if err != nil {
-					b.logf("Failed to load legacy prefs: %v", err)
-					b.prefs = NewPrefs()
-				} else {
-					b.logf("Imported state from relaynode for %q", key)
-				}
-			} else {
+		if legacyPath != "" {
+			b.prefs, err = LoadPrefs(legacyPath)
+			if err != nil {
+				b.logf("Failed to load legacy prefs: %v", err)
 				b.prefs = NewPrefs()
-				b.logf("Created empty state for %q", key)
+			} else {
+				b.logf("Imported state from relaynode for %q", key)
 			}
-			b.stateKey = key
-			return nil
+		} else {
+			b.prefs = NewPrefs()
+			b.logf("Created empty state for %q", key)
 		}
-		return fmt.Errorf("store.ReadState(%q): %v", key, err)
+		b.stateKey = key
+		return nil
 	}
 	b.prefs, err = PrefsFromBytes(bs, false)
 	if err != nil {


### PR DESCRIPTION
The Android app encrypts the state with the hardware device key. After
transferring app data to a new device, the state is effectively corrupted
by the changed hardware key.

Mapping just that particular kind of corruption errors to ErrStateNotExist is
brittle, so change loadStateLocked to treat all ReadState errors the same
(empty state).

Fixes tailscale/tailscale#732

Signed-off-by: Elias Naur <mail@eliasnaur.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/734)
<!-- Reviewable:end -->
