### PR TITLE
log/logheap: properly document LogHeap as performing HTTP upload

### DIFF
--- a/log/logheap/logheap.go
+++ b/log/logheap/logheap.go
@@ -15,15 +15,18 @@ import (
 	"time"
 )
 
-// LogHeap writes a JSON logtail record with the base64 heap pprof to
-// os.Stderr.
+// LogHeap uploads a JSON logtail record with the base64 heap pprof by means
+// of an HTTP POST request to the endpoint referred to in postURL.
 func LogHeap(postURL string) {
 	if postURL == "" {
 		return
 	}
 	runtime.GC()
 	buf := new(bytes.Buffer)
-	pprof.WriteHeapProfile(buf)
+	if err := pprof.WriteHeapProfile(buf); err != nil {
+		log.Printf("LogHeap: %v", err)
+		return
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()


### PR DESCRIPTION
LogHeap no longer logs to os.Stderr and instead uploads
the heap profile by means of an HTTP POST request to the
target URL endpoint.

While here, also ensured that an error from pprof.WriteHeapProfile
isn't ignored and will prevent the HTTP request from being made
if non-nil.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/741)
<!-- Reviewable:end -->
