### PR TITLE
Updating error msg for no discovery key for peer

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -648,8 +648,8 @@ func (c *Conn) Ping(ip netaddr.IP, cb func(*ipnstate.PingResult)) {
 	}
 
 	dk, ok := c.discoOfNode[peer.Key]
-	if !ok {
-		res.Err = "no discovery key for peer (old Tailscale version?). Try: ping 100.x.y.z"
+	if !ok { // peer is using outdated Tailscale version (pre-0.100)
+		res.Err = "no discovery key for peer (pre Tailscale 0.100 version?). Try: ping 100.x.y.z"
 		cb(res)
 		return
 	}

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -649,7 +649,7 @@ func (c *Conn) Ping(ip netaddr.IP, cb func(*ipnstate.PingResult)) {
 
 	dk, ok := c.discoOfNode[peer.Key]
 	if !ok {
-		res.Err = "no discovery key for peer (pre 0.100?)"
+		res.Err = "no discovery key for peer (old Tailscale version?). Try: ping 100.x.y.z"
 		cb(res)
 		return
 	}


### PR DESCRIPTION
Changed error message from "no discovery key for peer (pre 0.100?)" to "no discovery key for peer (old Tailscale version?)"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/746)
<!-- Reviewable:end -->
