### PR TITLE
.github: attempt to fix staticcheck builder

### DIFF
--- a/.github/workflows/staticcheck.yml
+++ b/.github/workflows/staticcheck.yml
@@ -28,7 +28,7 @@ jobs:
       run: go run honnef.co/go/tools/cmd/staticcheck -version
 
     - name: Run staticcheck
-      run: "go run honnef.co/go/tools/cmd/staticcheck -- $(go list ./... | grep -v tempfork)"
+      run: go run honnef.co/go/tools/cmd/staticcheck $(go list tailscale.com/... | grep -v tempfork)
 
     - uses: k0kubun/action-slack@v2.0.0
       with:


### PR DESCRIPTION
The build should be failing, because staticcheck does not pass
at HEAD:

	go run honnef.co/go/tools/cmd/staticcheck -- (go list ./... | grep -v tempfork)
	wgengine/router/dns/manager.go:18:7: const reconfigTimeout is unused (U1000)
	exit status 1

But instead the staticcheck builder shows no output and success.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/753)
<!-- Reviewable:end -->
