### PR TITLE
wgengine/router/router_linux.go: fixed " route del failed" error 

### DIFF
--- a/wgengine/router/router_linux.go
+++ b/wgengine/router/router_linux.go
@@ -163,10 +163,17 @@ func (r *linuxRouter) Close() error {
 }
 
 // Set implements the Router interface.
-func (r *linuxRouter) Set(cfg *Config) error {
+func (r *linuxRouter) Set(cfg *Config) (err error) {
 	if cfg == nil {
 		cfg = &shutdownConfig
 	}
+
+	defer func() {
+		if err != nil {
+			// restore /etc/resolv.conf to its original state.
+			r.dns.Set(dns.Config{})
+		}
+	}()
 
 	if err := r.setNetfilterMode(cfg.NetfilterMode); err != nil {
 		return err

--- a/wgengine/router/router_linux.go
+++ b/wgengine/router/router_linux.go
@@ -163,33 +163,26 @@ func (r *linuxRouter) Close() error {
 }
 
 // Set implements the Router interface.
-func (r *linuxRouter) Set(cfg *Config) (err error) {
+func (r *linuxRouter) Set(cfg *Config) error {
 	if cfg == nil {
 		cfg = &shutdownConfig
 	}
 
-	defer func() {
-		if err != nil {
-			// restore /etc/resolv.conf to its original state.
-			r.dns.Set(dns.Config{})
-		}
-	}()
-
 	if err := r.setNetfilterMode(cfg.NetfilterMode); err != nil {
 		return err
 	}
-
-	newAddrs, err := cidrDiff("addr", r.addrs, cfg.LocalAddrs, r.addAddress, r.delAddress, r.logf)
-	if err != nil {
-		return err
-	}
-	r.addrs = newAddrs
 
 	newRoutes, err := cidrDiff("route", r.routes, cfg.Routes, r.addRoute, r.delRoute, r.logf)
 	if err != nil {
 		return err
 	}
 	r.routes = newRoutes
+
+	newAddrs, err := cidrDiff("addr", r.addrs, cfg.LocalAddrs, r.addAddress, r.delAddress, r.logf)
+	if err != nil {
+		return err
+	}
+	r.addrs = newAddrs
 
 	switch {
 	case cfg.SNATSubnetRoutes == r.snatSubnetRoutes:


### PR DESCRIPTION
`6.4M/24.1M router: route del failed: running “ip route del 100.100.100.100/32 dev tailscale0 table 52” failed: exit status 2` 

`ip addr del` is called before `ip route del` leading to error above. Switching order of `cidrDiff("addr")` and `cidrDiff("route")` to avoid error message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/756)
<!-- Reviewable:end -->
