### PR TITLE
tailcfg: add MapRequest.ReadOnly and OmitPeers; remove DebugForceDisco

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -493,16 +493,15 @@ func (c *Direct) PollNetMap(ctx context.Context, maxPolls int, cb func(*NetworkM
 	}
 
 	request := tailcfg.MapRequest{
-		Version:         4,
-		IncludeIPv6:     true,
-		DeltaPeers:      true,
-		KeepAlive:       c.keepAlive,
-		NodeKey:         tailcfg.NodeKey(persist.PrivateNodeKey.Public()),
-		DiscoKey:        c.discoPubKey,
-		Endpoints:       ep,
-		Stream:          allowStream,
-		Hostinfo:        hostinfo,
-		DebugForceDisco: Debug.ForceDisco,
+		Version:     4,
+		IncludeIPv6: true,
+		DeltaPeers:  true,
+		KeepAlive:   c.keepAlive,
+		NodeKey:     tailcfg.NodeKey(persist.PrivateNodeKey.Public()),
+		DiscoKey:    c.discoPubKey,
+		Endpoints:   ep,
+		Stream:      allowStream,
+		Hostinfo:    hostinfo,
 	}
 	if c.newDecompressor != nil {
 		request.Compress = "zstd"
@@ -843,25 +842,20 @@ func wgIPToNetaddr(ips []wgcfg.IP) (ret []netaddr.IP) {
 var Debug = initDebug()
 
 type debug struct {
-	NetMap     bool
-	ProxyDNS   bool
-	OnlyDisco  bool
-	Disco      bool
-	ForceDisco bool // ask control server to not filter out our disco key
+	NetMap    bool
+	ProxyDNS  bool
+	OnlyDisco bool
+	Disco     bool
 }
 
 func initDebug() debug {
-	d := debug{
-		NetMap:     envBool("TS_DEBUG_NETMAP"),
-		ProxyDNS:   envBool("TS_DEBUG_PROXY_DNS"),
-		OnlyDisco:  os.Getenv("TS_DEBUG_USE_DISCO") == "only",
-		ForceDisco: os.Getenv("TS_DEBUG_USE_DISCO") == "only" || envBool("TS_DEBUG_USE_DISCO"),
+	use := os.Getenv("TS_DEBUG_USE_DISCO")
+	return debug{
+		NetMap:    envBool("TS_DEBUG_NETMAP"),
+		ProxyDNS:  envBool("TS_DEBUG_PROXY_DNS"),
+		OnlyDisco: use == "only",
+		Disco:     use == "only" || use == "" || envBool("TS_DEBUG_USE_DISCO"),
 	}
-	if d.ForceDisco || os.Getenv("TS_DEBUG_USE_DISCO") == "" {
-		// This is now defaults to on.
-		d.Disco = true
-	}
-	return d
 }
 
 func envBool(k string) bool {

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -452,11 +452,19 @@ type MapRequest struct {
 	Stream      bool     // if true, multiple MapResponse objects are returned
 	Hostinfo    *Hostinfo
 
-	// DebugForceDisco is a temporary flag during the deployment
-	// of magicsock active discovery. It says that that the client
-	// has environment variables explicitly turning discovery on,
-	// so control should not disable it.
-	DebugForceDisco bool `json:"debugForceDisco,omitempty"`
+	// ReadOnly is whether the client just wants to fetch the
+	// MapResponse, without updating their Endpoints. The
+	// Endpoints field will be ignored and LastSeen will not be
+	// updated and peers will not be notified of changes.
+	//
+	// The intended use if for clients to discover the DERP map at
+	// start-up before their first real endpoint update.
+	ReadOnly bool `json:",omitempty"`
+
+	// OmitPeers is whether the client is okay with the Peers list
+	// being omitted in the response. (For example, a client on
+	// start up using ReadOnly to get the DERP map.)
+	OmitPeers bool `json:",omitempty"`
 }
 
 // PortRange represents a range of UDP or TCP port numbers.


### PR DESCRIPTION
DebugForceDisco was a development & safety knob during the the transition
to discovery. It's no longer needed.

Add MapRequest.ReadOnly to prevent clients needing to do two
peer-spamming MapRequest at start-up.

This only adds the field, not the use of the field. (The control server
needs to support it first.)

Updates tailscale/corp#557

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/769)
<!-- Reviewable:end -->
