### PR TITLE
net/netns: don't bind to device for :0 address

### DIFF
--- a/net/netns/netns_windows.go
+++ b/net/netns/netns_windows.go
@@ -29,11 +29,13 @@ func interfaceIndex(iface *winipcfg.IPAdapterAddresses) uint32 {
 // control binds c to the Windows interface that holds a default
 // route, and is not the Tailscale WinTun interface.
 func control(network, address string, c syscall.RawConn) error {
-	if strings.HasPrefix(address, "127.") {
+	if strings.HasPrefix(address, "127.") || address == ":0" {
 		// Don't bind to an interface for localhost connections,
 		// otherwise we get:
 		//   connectex: The requested address is not valid in its context
-		// (The derphttp tests were failing)
+		// and
+		//   wsasendto: The requested address is not valid in its context.
+		// (The derphttp or netcheck tests were failing)
 		return nil
 	}
 	canV4, canV6 := false, false


### PR DESCRIPTION
This change adds to what commit 551e1e9 started.

Fixes netcheck test failures on Windows (for #50).

Signed-off-by: Alex Brainman <alex.brainman@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/827)
<!-- Reviewable:end -->
