### PR TITLE
version: skip TestMkversion on windows

### DIFF
--- a/net/netns/netns_windows.go
+++ b/net/netns/netns_windows.go
@@ -29,11 +29,13 @@ func interfaceIndex(iface *winipcfg.IPAdapterAddresses) uint32 {
 // control binds c to the Windows interface that holds a default
 // route, and is not the Tailscale WinTun interface.
 func control(network, address string, c syscall.RawConn) error {
-	if strings.HasPrefix(address, "127.") {
+	if strings.HasPrefix(address, "127.") || address == ":0" {
 		// Don't bind to an interface for localhost connections,
 		// otherwise we get:
 		//   connectex: The requested address is not valid in its context
-		// (The derphttp tests were failing)
+		// and
+		//   wsasendto: The requested address is not valid in its context.
+		// (The derphttp or netcheck tests were failing)
 		return nil
 	}
 	canV4, canV6 := false, false

--- a/version/mkversion_test.go
+++ b/version/mkversion_test.go
@@ -7,6 +7,7 @@ package version
 import (
 	"fmt"
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -26,6 +27,9 @@ func mkversion(t *testing.T, mode, in string) (string, bool) {
 }
 
 func TestMkversion(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skip test on Windows, because there is no shell to execute mkversion.sh.")
+	}
 	tests := []struct {
 		in    string
 		ok    bool


### PR DESCRIPTION
TestMkversion requires UNIX shell to run mkversion.sh. No such shell
is present on Windows. Just skip the test.

Updates #50

Signed-off-by: Alex Brainman <alex.brainman@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/828)
<!-- Reviewable:end -->
