### PR TITLE
tailcfg: add a DebugFlags field for experiments and debugging.

### DIFF
--- a/ipn/local.go
+++ b/ipn/local.go
@@ -36,6 +36,10 @@ import (
 	"tailscale.com/wgengine/tsdns"
 )
 
+var (
+	controlDebugFlags = strings.Split(os.Getenv("TS_DEBUG_CONTROL_FLAGS"), ",")
+)
+
 // LocalBackend is the glue between the major pieces of the Tailscale
 // network software: the cloud control plane (via controlclient), the
 // network data plane (via wgengine), and the user-facing UIs and CLIs
@@ -451,6 +455,7 @@ func (b *LocalBackend) Start(opts Options) error {
 		NewDecompressor:   b.newDecompressor,
 		HTTPTestClient:    opts.HTTPTestClient,
 		DiscoPublicKey:    discoPublic,
+		DebugFlags:        controlDebugFlags,
 	})
 	if err != nil {
 		return err

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -486,6 +486,14 @@ type MapRequest struct {
 	// being omitted in the response. (For example, a client on
 	// start up using ReadOnly to get the DERP map.)
 	OmitPeers bool `json:",omitempty"`
+
+	// DebugFlags is a list of strings specifying debugging and
+	// development features to enable in handling this map
+	// request. The values are deliberately unspecified, as they get
+	// added and removed all the time during development, and offer no
+	// compatibility promise. To roll out semantic changes, bump
+	// Version instead.
+	DebugFlags []string `json:",omitempty"`
 }
 
 // PortRange represents a range of UDP or TCP port numbers.


### PR DESCRIPTION
Also replaces the IPv6Overlay bool with use of DebugFlags, since
it's currently an experimental configuration.

Signed-off-by: David Anderson <danderson@tailscale.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/837)
<!-- Reviewable:end -->
