### PR TITLE
cli: properly document expected tag format for advertise-tag flag

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -210,6 +210,8 @@ func (m MachineStatus) String() string {
 	}
 }
 
+const TagPrefix = "tag:"
+
 func isNum(b byte) bool {
 	return b >= '0' && b <= '9'
 }
@@ -228,15 +230,15 @@ func isAlpha(b byte) bool {
 //
 // We might relax these rules later.
 func CheckTag(tag string) error {
-	if !strings.HasPrefix(tag, "tag:") {
-		return errors.New("tags must start with 'tag:'")
+	if !strings.HasPrefix(tag, TagPrefix) {
+		return errors.New("tags must start with '" + TagPrefix + "'")
 	}
 	tag = tag[4:]
 	if tag == "" {
 		return errors.New("tag names must not be empty")
 	}
 	if !isAlpha(tag[0]) {
-		return errors.New("tag names must start with a letter, after 'tag:'")
+		return errors.New("tag names must start with a letter, after '" + TagPrefix + "'")
 	}
 
 	for _, b := range []byte(tag) {


### PR DESCRIPTION
Resolves https://github.com/tailscale/tailscale/issues/861

The previous description's example was misleading, the tags did not have the required prefix. There's now an explicit mention of the required prefix for each tag ('tag:') and the example has been updated with each tag having the prefix.

Signed-off-by: Kumbirai Tanekha <kumbirai.tanekha@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/862)
<!-- Reviewable:end -->
