### PR TITLE
ipn: don't temporarilySetMachineKeyInPersist for Android clients

### DIFF
--- a/ipn/local.go
+++ b/ipn/local.go
@@ -1540,8 +1540,8 @@ func (b *LocalBackend) TestOnlyPublicKeys() (machineKey tailcfg.MachineKey, node
 // clients. We can't do that until 1.0.x is no longer supported.
 func temporarilySetMachineKeyInPersist() bool {
 	//lint:ignore S1008 for comments
-	if runtime.GOOS == "darwin" {
-		// iOS and macOS users can't downgrade anyway.
+	if runtime.GOOS == "darwin" || runtime.GOOS == "android" {
+		// iOS, macOS, Android users can't downgrade anyway.
 		return false
 	}
 	return true


### PR DESCRIPTION
Without this change, newly installed Android clients crash on startup
with

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x9881b9f8]

goroutine 29 [running]:
tailscale.com/ipn.(*LocalBackend).initMachineKeyLocked.func1(0x50cb1b9c, 0x503c9a00)
	/home/elias/proj/tailscale/ipn/local.go:711 +0x2c
tailscale.com/ipn.(*LocalBackend).initMachineKeyLocked(0x503c9a00, 0x0, 0x0)
	/home/elias/proj/tailscale/ipn/local.go:736 +0x728
tailscale.com/ipn.(*LocalBackend).loadStateLocked(0x503c9a00, 0x988be40e, 0xb, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/elias/proj/tailscale/ipn/local.go:817 +0x1e8
tailscale.com/ipn.(*LocalBackend).Start(0x503c9a00, 0x0, 0x0, 0x988be40e, 0xb, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/elias/proj/tailscale/ipn/local.go:412 +0x200
main.(*backend).Start(...)
	/home/elias/proj/tailscale-android/cmd/tailscale/backend.go:116
main.(*App).runBackend.func3(0x50106340, 0x5000c060, 0x50d9a280)
	/home/elias/proj/tailscale-android/cmd/tailscale/main.go:169 +0x90
created by main.(*App).runBackend
	/home/elias/proj/tailscale-android/cmd/tailscale/main.go:168 +0x27c

Signed-off-by: Elias Naur <mail@eliasnaur.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/tailscale/881)
<!-- Reviewable:end -->
