### PR TITLE
tsweb: refactor JSONHandler to take status code from error if it is present

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,7 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/rpmpack v0.0.0-20191226140753-aa36bfddb3a0 h1:BW6OvS3kpT5UEPbCZ+KyX/OB4Ks9/MNMhWjqPPkZxsE=
 github.com/google/rpmpack v0.0.0-20191226140753-aa36bfddb3a0/go.mod h1:RaTPr0KUf2K7fnZYLNDrr8rxAamWs3iNywJLtQ2AzBg=

--- a/tsweb/jsonhandler_test.go
+++ b/tsweb/jsonhandler_test.go
@@ -40,11 +40,11 @@ func TestNewJSONHandler(t *testing.T) {
 		if d.Status == status {
 			t.Logf("ok: %s", d.Status)
 		} else {
-			t.Fatalf("wrong status: %s %s", d.Status, status)
+			t.Fatalf("wrong status: got: %s, want: %s", d.Status, status)
 		}
 
 		if w.Code != code {
-			t.Fatalf("wrong status code: %d %d", w.Code, code)
+			t.Fatalf("wrong status code: got: %d, want: %d", w.Code, code)
 		}
 
 		if w.Header().Get("Content-Type") != "application/json" {
@@ -67,7 +67,7 @@ func TestNewJSONHandler(t *testing.T) {
 
 	t.Run("403 HTTPError", func(t *testing.T) {
 		h := JSONHandlerFunc(func(r *http.Request) (int, interface{}, error) {
-			return http.StatusForbidden, nil, fmt.Errorf("forbidden")
+			return 0, nil, Error(http.StatusForbidden, "forbidden", nil)
 		})
 
 		w := httptest.NewRecorder()
@@ -90,11 +90,11 @@ func TestNewJSONHandler(t *testing.T) {
 	h31 := JSONHandlerFunc(func(r *http.Request) (int, interface{}, error) {
 		body := new(Data)
 		if err := json.NewDecoder(r.Body).Decode(body); err != nil {
-			return http.StatusBadRequest, nil, err
+			return 0, nil, Error(http.StatusBadRequest, err.Error(), err)
 		}
 
 		if body.Name == "" {
-			return http.StatusBadRequest, nil, Error(http.StatusBadGateway, "name is empty", nil)
+			return 0, nil, Error(http.StatusBadRequest, "name is empty", nil)
 		}
 
 		return http.StatusOK, nil, nil
@@ -126,13 +126,13 @@ func TestNewJSONHandler(t *testing.T) {
 	h32 := JSONHandlerFunc(func(r *http.Request) (int, interface{}, error) {
 		body := new(Data)
 		if err := json.NewDecoder(r.Body).Decode(body); err != nil {
-			return http.StatusBadRequest, nil, err
+			return 0, nil, Error(http.StatusBadRequest, err.Error(), err)
 		}
 		if body.Name == "root" {
-			return http.StatusInternalServerError, nil, fmt.Errorf("invalid name")
+			return 0, nil, fmt.Errorf("invalid name")
 		}
 		if body.Price == 0 {
-			return http.StatusBadRequest, nil, Error(http.StatusBadGateway, "price is empty", nil)
+			return 0, nil, Error(http.StatusBadRequest, "price is empty", nil)
 		}
 
 		return http.StatusOK, &Data{Price: body.Price * 2}, nil
@@ -159,7 +159,7 @@ func TestNewJSONHandler(t *testing.T) {
 		}
 	})
 
-	t.Run("500 internal server error", func(t *testing.T) {
+	t.Run("500 internal server error (unspecified error, not of type HTTPError)", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest("POST", "/", strings.NewReader(`{"Name": "root"}`))
 		h32.ServeHTTPReturn(w, r)


### PR DESCRIPTION
This PR refactors JSONHandler to handle errors more intuitively. If the handler function returns an error and it can be asserted to be of type tsweb.HTTPError, use the status code on that error type, rather than the status returned by the handler function. This encourages the error to be handled only by the original implementator of the error. 
