### PR TITLE
wgengine/filter: use netaddr types in public API.

### DIFF
--- a/control/controlclient/filter.go
+++ b/control/controlclient/filter.go
@@ -9,9 +9,9 @@ import (
 	"tailscale.com/wgengine/filter"
 )
 
-// Parse a backward-compatible FilterRule used by control's wire format,
-// producing the most current filter.Matches format.
-func (c *Direct) parsePacketFilter(pf []tailcfg.FilterRule) filter.Matches {
+// Parse a backward-compatible FilterRule used by control's wire
+// format, producing the most current filter format.
+func (c *Direct) parsePacketFilter(pf []tailcfg.FilterRule) []filter.Match {
 	mm, err := filter.MatchesFromFilterRules(pf)
 	if err != nil {
 		c.logf("parsePacketFilter: %s\n", err)

--- a/control/controlclient/netmap.go
+++ b/control/controlclient/netmap.go
@@ -34,7 +34,7 @@ type NetworkMap struct {
 	Peers         []*tailcfg.Node // sorted by Node.ID
 	DNS           tailcfg.DNSConfig
 	Hostinfo      tailcfg.Hostinfo
-	PacketFilter  filter.Matches
+	PacketFilter  []filter.Match
 
 	// DERPMap is the last DERP server map received. It's reused
 	// between updates and should not be modified.

--- a/ipn/local.go
+++ b/ipn/local.go
@@ -523,7 +523,7 @@ func (b *LocalBackend) updateFilter(netMap *controlclient.NetworkMap, prefs *Pre
 	var (
 		haveNetmap   = netMap != nil
 		addrs        []wgcfg.CIDR
-		packetFilter filter.Matches
+		packetFilter []filter.Match
 		advRoutes    []wgcfg.CIDR
 		shieldsUp    = prefs == nil || prefs.ShieldsUp // Be conservative when not ready
 	)
@@ -551,7 +551,7 @@ func (b *LocalBackend) updateFilter(netMap *controlclient.NetworkMap, prefs *Pre
 	if shieldsUp {
 		b.logf("netmap packet filter: (shields up)")
 		var prevFilter *filter.Filter // don't reuse old filter state
-		b.e.SetFilter(filter.New(filter.Matches{}, localNets, prevFilter, b.logf))
+		b.e.SetFilter(filter.New(nil, localNets, prevFilter, b.logf))
 	} else {
 		b.logf("netmap packet filter: %v", packetFilter)
 		b.e.SetFilter(filter.New(packetFilter, localNets, b.e.GetFilter(), b.logf))

--- a/wgengine/filter/filter.go
+++ b/wgengine/filter/filter.go
@@ -92,7 +92,7 @@ const (
 // NewAllowAll returns a packet filter that accepts everything to and
 // from localNets.
 func NewAllowAll(localNets []netaddr.IPPrefix, logf logger.Logf) *Filter {
-	return New(Matches{Match{NetPortRangeAny, NetAny}}, localNets, nil, logf)
+	return New([]Match{Match{NetPortRangeAny, NetAny}}, localNets, nil, logf)
 }
 
 // NewAllowNone returns a packet filter that rejects everything.
@@ -105,7 +105,7 @@ func NewAllowNone(logf logger.Logf) *Filter {
 // by matches. If shareStateWith is non-nil, the returned filter
 // shares state with the previous one, to enable changing rules at
 // runtime without breaking existing stateful flows.
-func New(matches Matches, localNets []netaddr.IPPrefix, shareStateWith *Filter, logf logger.Logf) *Filter {
+func New(matches []Match, localNets []netaddr.IPPrefix, shareStateWith *Filter, logf logger.Logf) *Filter {
 	var state *filterState
 	if shareStateWith != nil {
 		state = shareStateWith.state

--- a/wgengine/filter/filter_test.go
+++ b/wgengine/filter/filter_test.go
@@ -97,7 +97,7 @@ func netports(netPorts ...string) (ret []NetPortRange) {
 	return ret
 }
 
-var matches = Matches{
+var matches = []Match{
 	{Srcs: nets("8.1.1.1", "8.2.2.2"), Dsts: netports("1.2.3.4:22", "5.6.7.8:23-24")},
 	{Srcs: nets("8.1.1.1", "8.2.2.2"), Dsts: netports("5.6.7.8:27-28")},
 	{Srcs: nets("2.2.2.2"), Dsts: netports("8.1.1.1:22")},
@@ -115,13 +115,13 @@ func newFilter(logf logger.Logf) *Filter {
 }
 
 func TestMarshal(t *testing.T) {
-	for _, ent := range []Matches{Matches{matches[0]}, matches} {
+	for _, ent := range [][]Match{[]Match{matches[0]}, matches} {
 		b, err := json.Marshal(ent)
 		if err != nil {
 			t.Fatalf("marshal: %v", err)
 		}
 
-		mm2 := Matches{}
+		mm2 := []Match{}
 		if err := json.Unmarshal(b, &mm2); err != nil {
 			t.Fatalf("unmarshal: %v (%v)", err, string(b))
 		}

--- a/wgengine/filter/match.go
+++ b/wgengine/filter/match.go
@@ -29,6 +29,7 @@ func (pr PortRange) String() string {
 	}
 }
 
+// contains returns whether port is in pr.
 func (pr PortRange) contains(port uint16) bool {
 	return port >= pr.First && port <= pr.Last
 }
@@ -47,6 +48,7 @@ func (npr NetPortRange) String() string {
 	return fmt.Sprintf("%v:%v", npr.Net, npr.Ports)
 }
 
+// NetPortRangeAny matches any IP and port.
 var NetPortRangeAny = []NetPortRange{{Net: NetAny[0], Ports: PortRangeAny}}
 
 // Match matches packets from any IP address in Srcs to any ip:port in

--- a/wgengine/filter/match.go
+++ b/wgengine/filter/match.go
@@ -56,17 +56,6 @@ type Match struct {
 	Srcs []netaddr.IPPrefix
 }
 
-// Clone returns a deep copy of m.
-func (m Match) Clone() (res Match) {
-	if m.Dsts != nil {
-		res.Dsts = append([]NetPortRange{}, m.Dsts...)
-	}
-	if m.Srcs != nil {
-		res.Srcs = append([]netaddr.IPPrefix{}, m.Srcs...)
-	}
-	return res
-}
-
 func (m Match) String() string {
 	srcs := []string{}
 	for _, src := range m.Srcs {
@@ -93,11 +82,3 @@ func (m Match) String() string {
 
 // Matches is a list of packet matchers.
 type Matches []Match
-
-// Clone returns a deep copy of ms.
-func (ms Matches) Clone() (res Matches) {
-	for _, match := range ms {
-		res = append(res, match.Clone())
-	}
-	return res
-}

--- a/wgengine/filter/match.go
+++ b/wgengine/filter/match.go
@@ -81,6 +81,3 @@ func (m Match) String() string {
 	}
 	return fmt.Sprintf("%v=>%v", ss, ds)
 }
-
-// Matches is a list of packet matchers.
-type Matches []Match

--- a/wgengine/filter/match4.go
+++ b/wgengine/filter/match4.go
@@ -80,7 +80,7 @@ func (ms matches4) String() string {
 	return b.String()
 }
 
-func newMatches4(ms Matches) (ret matches4) {
+func newMatches4(ms []Match) (ret matches4) {
 	for _, m := range ms {
 		var m4 match4
 		for _, src := range m.Srcs {

--- a/wgengine/filter/match4.go
+++ b/wgengine/filter/match4.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package filter
+
+import (
+	"fmt"
+	"math/bits"
+	"strings"
+
+	"inet.af/netaddr"
+	"tailscale.com/net/packet"
+)
+
+type net4 struct {
+	ip   packet.IP4
+	mask packet.IP4
+}
+
+func net4FromIPPrefix(pfx netaddr.IPPrefix) net4 {
+	if !pfx.IP.Is4() {
+		panic("net4FromIPPrefix given non-ipv4 prefix")
+	}
+	return net4{
+		ip:   packet.IP4FromNetaddr(pfx.IP),
+		mask: netmask4(pfx.Bits),
+	}
+}
+
+func nets4FromIPPrefixes(pfxs []netaddr.IPPrefix) (ret []net4) {
+	for _, pfx := range pfxs {
+		if pfx.IP.Is4() {
+			ret = append(ret, net4FromIPPrefix(pfx))
+		}
+	}
+	return ret
+}
+
+func (n net4) Contains(ip packet.IP4) bool {
+	return (n.ip & n.mask) == (ip & n.mask)
+}
+
+func (n net4) Bits() int {
+	return 32 - bits.TrailingZeros32(uint32(n.mask))
+}
+
+func (n net4) String() string {
+	b := n.Bits()
+	if b == 32 {
+		return n.ip.String()
+	} else if b == 0 {
+		return "*"
+	} else {
+		return fmt.Sprintf("%s/%d", n.ip, b)
+	}
+}
+
+type npr4 struct {
+	net   net4
+	ports PortRange
+}
+
+func (npr npr4) String() string {
+	return fmt.Sprintf("%s:%s", npr.net, npr.ports)
+}
+
+type match4 struct {
+	dsts []npr4
+	srcs []net4
+}
+
+type matches4 []match4
+
+func (ms matches4) String() string {
+	var b strings.Builder
+	for _, m := range ms {
+		fmt.Fprintf(&b, "%s => %s\n", m.srcs, m.dsts)
+	}
+	return b.String()
+}
+
+func newMatches4(ms Matches) (ret matches4) {
+	for _, m := range ms {
+		var m4 match4
+		for _, src := range m.Srcs {
+			if src.IP.Is4() {
+				m4.srcs = append(m4.srcs, net4FromIPPrefix(src))
+			}
+		}
+		for _, dst := range m.Dsts {
+			if dst.Net.IP.Is4() {
+				m4.dsts = append(m4.dsts, npr4{net4FromIPPrefix(dst.Net), dst.Ports})
+			}
+		}
+		if len(m4.srcs) > 0 && len(m4.dsts) > 0 {
+			ret = append(ret, m4)
+		}
+	}
+	return ret
+}
+
+// match returns whether q's source IP and destination IP:port match
+// any of ms.
+func (ms matches4) match(q *packet.ParsedPacket) bool {
+	for _, m := range ms {
+		if !ip4InList(q.SrcIP, m.srcs) {
+			continue
+		}
+		for _, dst := range m.dsts {
+			if !dst.net.Contains(q.DstIP) {
+				continue
+			}
+			if !dst.ports.contains(q.DstPort) {
+				continue
+			}
+			return true
+		}
+	}
+	return false
+}
+
+// matchIPsOnly returns whether q's source and destination IP match
+// any of ms.
+func (ms matches4) matchIPsOnly(q *packet.ParsedPacket) bool {
+	for _, m := range ms {
+		if !ip4InList(q.SrcIP, m.srcs) {
+			continue
+		}
+		for _, dst := range m.dsts {
+			if dst.net.Contains(q.DstIP) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func netmask4(bits uint8) packet.IP4 {
+	b := ^uint32((1 << (32 - bits)) - 1)
+	return packet.IP4(b)
+}
+
+func ip4InList(ip packet.IP4, netlist []net4) bool {
+	for _, net := range netlist {
+		if net.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/wgengine/filter/tailcfg.go
+++ b/wgengine/filter/tailcfg.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package filter
+
+import (
+	"fmt"
+
+	"inet.af/netaddr"
+	"tailscale.com/tailcfg"
+)
+
+// MatchesFromFilterRules converts tailcfg FilterRules into Matches.
+// If an error is returned, the Matches result is still valid,
+// containing the rules that were successfully converted.
+func MatchesFromFilterRules(pf []tailcfg.FilterRule) (Matches, error) {
+	mm := make([]Match, 0, len(pf))
+	var erracc error
+
+	for _, r := range pf {
+		m := Match{}
+
+		for i, s := range r.SrcIPs {
+			bits := 32
+			if len(r.SrcBits) > i {
+				bits = r.SrcBits[i]
+			}
+			net, err := parseIP(s, bits)
+			if err != nil && erracc == nil {
+				erracc = err
+				continue
+			}
+			m.Srcs = append(m.Srcs, net)
+		}
+
+		for _, d := range r.DstPorts {
+			bits := 32
+			if d.Bits != nil {
+				bits = *d.Bits
+			}
+			net, err := parseIP(d.IP, bits)
+			if err != nil && erracc == nil {
+				erracc = err
+				continue
+			}
+			m.Dsts = append(m.Dsts, NetPortRange{
+				Net: net,
+				Ports: PortRange{
+					First: d.Ports.First,
+					Last:  d.Ports.Last,
+				},
+			})
+		}
+
+		mm = append(mm, m)
+	}
+	return mm, erracc
+}
+
+func parseIP(host string, defaultBits int) (netaddr.IPPrefix, error) {
+	if host == "*" {
+		// User explicitly requested wildcard dst ip.
+		// TODO: ipv6
+		return netaddr.IPPrefix{IP: netaddr.IPv4(0, 0, 0, 0), Bits: 0}, nil
+	}
+
+	ip, err := netaddr.ParseIP(host)
+	if err != nil {
+		return netaddr.IPPrefix{}, fmt.Errorf("ports=%#v: invalid IP address", host)
+	}
+	if ip == netaddr.IPv4(0, 0, 0, 0) {
+		// For clarity, reject 0.0.0.0 as an input
+		return netaddr.IPPrefix{}, fmt.Errorf("ports=%#v: to allow all IP addresses, use *:port, not 0.0.0.0:port", host)
+	}
+	if !ip.Is4() {
+		// TODO: ipv6
+		return netaddr.IPPrefix{}, fmt.Errorf("ports=%#v: invalid IPv4 address", host)
+	}
+	if defaultBits < 0 || defaultBits > 32 {
+		return netaddr.IPPrefix{}, fmt.Errorf("invalid CIDR size %d for host %q", defaultBits, host)
+	}
+	return netaddr.IPPrefix{
+		IP:   ip,
+		Bits: uint8(defaultBits),
+	}, nil
+}

--- a/wgengine/filter/tailcfg.go
+++ b/wgengine/filter/tailcfg.go
@@ -14,7 +14,7 @@ import (
 // MatchesFromFilterRules converts tailcfg FilterRules into Matches.
 // If an error is returned, the Matches result is still valid,
 // containing the rules that were successfully converted.
-func MatchesFromFilterRules(pf []tailcfg.FilterRule) (Matches, error) {
+func MatchesFromFilterRules(pf []tailcfg.FilterRule) ([]Match, error) {
 	mm := make([]Match, 0, len(pf))
 	var erracc error
 

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -158,7 +158,7 @@ func newMagicStack(t *testing.T, logf logger.Logf, l nettype.PacketListener, der
 
 	tun := tuntest.NewChannelTUN()
 	tsTun := tstun.WrapTUN(logf, tun.TUN())
-	tsTun.SetFilter(filter.NewAllowAll([]filter.Net{filter.NetAny}, logf))
+	tsTun.SetFilter(filter.NewAllowAll(filter.NetAny, logf))
 
 	dev := device.NewDevice(tsTun, &device.DeviceOptions{
 		Logger: &device.Logger{

--- a/wgengine/tstun/tun_test.go
+++ b/wgengine/tstun/tun_test.go
@@ -6,11 +6,15 @@ package tstun
 
 import (
 	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"unsafe"
 
 	"github.com/tailscale/wireguard-go/tun/tuntest"
+	"inet.af/netaddr"
 	"tailscale.com/net/packet"
 	"tailscale.com/types/logger"
 	"tailscale.com/wgengine/filter"
@@ -29,35 +33,76 @@ func udp(src, dst packet.IP4, sport, dport uint16) []byte {
 	return packet.Generate(header, []byte("udp_payload"))
 }
 
-func filterNet(ip, mask packet.IP4) filter.Net {
-	return filter.Net{IP: ip, Mask: mask}
+func nets(nets ...string) (ret []netaddr.IPPrefix) {
+	for _, s := range nets {
+		if i := strings.IndexByte(s, '/'); i == -1 {
+			ip, err := netaddr.ParseIP(s)
+			if err != nil {
+				panic(err)
+			}
+			bits := uint8(32)
+			if ip.Is6() {
+				bits = 128
+			}
+			ret = append(ret, netaddr.IPPrefix{IP: ip, Bits: bits})
+		} else {
+			pfx, err := netaddr.ParseIPPrefix(s)
+			if err != nil {
+				panic(err)
+			}
+			ret = append(ret, pfx)
+		}
+	}
+	return ret
 }
 
-func nets(ips []packet.IP4) []filter.Net {
-	out := make([]filter.Net, 0, len(ips))
-	for _, ip := range ips {
-		out = append(out, filterNet(ip, filter.Netmask(32)))
+func ports(s string) filter.PortRange {
+	if s == "*" {
+		return filter.PortRangeAny
 	}
-	return out
+
+	var fs, ls string
+	i := strings.IndexByte(s, '-')
+	if i == -1 {
+		fs = s
+		ls = fs
+	} else {
+		fs = s[:i]
+		ls = s[i+1:]
+	}
+	first, err := strconv.ParseInt(fs, 10, 16)
+	if err != nil {
+		panic(fmt.Sprintf("invalid NetPortRange %q", s))
+	}
+	last, err := strconv.ParseInt(ls, 10, 16)
+	if err != nil {
+		panic(fmt.Sprintf("invalid NetPortRange %q", s))
+	}
+	return filter.PortRange{First: uint16(first), Last: uint16(last)}
 }
 
-func ippr(ip packet.IP4, start, end uint16) []filter.NetPortRange {
-	return []filter.NetPortRange{
-		filter.NetPortRange{
-			Net:   filterNet(ip, filter.Netmask(32)),
-			Ports: filter.PortRange{First: start, Last: end},
-		},
+func netports(netPorts ...string) (ret []filter.NetPortRange) {
+	for _, s := range netPorts {
+		i := strings.LastIndexByte(s, ':')
+		if i == -1 {
+			panic(fmt.Sprintf("invalid NetPortRange %q", s))
+		}
+
+		npr := filter.NetPortRange{
+			Net:   nets(s[:i])[0],
+			Ports: ports(s[i+1:]),
+		}
+		ret = append(ret, npr)
 	}
+	return ret
 }
 
 func setfilter(logf logger.Logf, tun *TUN) {
 	matches := filter.Matches{
-		{Srcs: nets([]packet.IP4{0x05060708}), Dsts: ippr(0x01020304, 89, 90)},
-		{Srcs: nets([]packet.IP4{0x01020304}), Dsts: ippr(0x05060708, 98, 98)},
+		{Srcs: nets("5.6.7.8"), Dsts: netports("1.2.3.4:89-90")},
+		{Srcs: nets("1.2.3.4"), Dsts: netports("5.6.7.8:98")},
 	}
-	localNets := []filter.Net{
-		filterNet(packet.IP4(0x01020304), filter.Netmask(16)),
-	}
+	localNets := nets("1.2.0.0/16")
 	tun.SetFilter(filter.New(matches, localNets, nil, logf))
 }
 

--- a/wgengine/tstun/tun_test.go
+++ b/wgengine/tstun/tun_test.go
@@ -98,7 +98,7 @@ func netports(netPorts ...string) (ret []filter.NetPortRange) {
 }
 
 func setfilter(logf logger.Logf, tun *TUN) {
-	matches := filter.Matches{
+	matches := []filter.Match{
 		{Srcs: nets("5.6.7.8"), Dsts: netports("1.2.3.4:89-90")},
 		{Srcs: nets("1.2.3.4"), Dsts: netports("5.6.7.8:98")},
 	}


### PR DESCRIPTION
We still use the packet.* alloc-free types in the data path, but
the compilation from netaddr to packet happens within the filter
package.

Signed-off-by: David Anderson <danderson@tailscale.com>