### PR TITLE
Patch Dockerfile to use valid Go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@
 #     $ docker exec tailscaled tailscale status
 
 
-FROM golang:1.14-alpine AS build-env
+FROM golang:1.15-alpine AS build-env
 
 WORKDIR /go/src/tailscale
 


### PR DESCRIPTION
As documented in the README, tailscale only build with the latest Go
version (Go 1.15).  As a result, a handful of undefined errors would pop
up using an older verison.

This patch updates the base image to 1.15, allowing "docker build"
to function correctly once more.