### PR TITLE
wgengine/router: disable IPv6 if v6 policy routing is unavailable.

### DIFF
--- a/wgengine/router/router_linux.go
+++ b/wgengine/router/router_linux.go
@@ -1023,6 +1023,20 @@ func supportsV6() bool {
 		return false
 	}
 
+	// Older kernels don't support IPv6 policy routing.
+	bs, err = ioutil.ReadFile("/proc/sys/net/ipv6/conf/all/disable_policy")
+	if err != nil {
+		// Absent knob means policy routing is unsupported.
+		return false
+	}
+	disabled, err = strconv.ParseBool(strings.TrimSpace(string(bs)))
+	if err != nil {
+		return false
+	}
+	if disabled {
+		return false
+	}
+
 	// Some distros ship ip6tables separately from iptables.
 	if _, err := exec.LookPath("ip6tables"); err != nil {
 		return false


### PR DESCRIPTION
Fixes #895.

Signed-off-by: David Anderson <danderson@tailscale.com>