### PR TITLE
net/interfaces: make syscall and netstat agree when multiple gateways are present

### DIFF
--- a/net/interfaces/interfaces_darwin.go
+++ b/net/interfaces/interfaces_darwin.go
@@ -5,6 +5,7 @@
 package interfaces
 
 import (
+	"errors"
 	"os/exec"
 
 	"go4.org/mem"
@@ -62,8 +63,12 @@ func likelyHomeRouterIPDarwinExec() (ret netaddr.IP, ok bool) {
 		ip, err := netaddr.ParseIP(string(mem.Append(nil, ipm)))
 		if err == nil && isPrivateIP(ip) {
 			ret = ip
+			// We've found what we're looking for.
+			return stopReadingNetstatTable
 		}
 		return nil
 	})
 	return ret, !ret.IsZero()
 }
+
+var stopReadingNetstatTable = errors.New("found private gateway")

--- a/util/lineread/lineread.go
+++ b/util/lineread/lineread.go
@@ -22,6 +22,11 @@ func File(name string, fn func(line []byte) error) error {
 	return Reader(f, fn)
 }
 
+// Reader calls fn for each line.
+// If fn returns an error, Reader stops reading and returns that error.
+// Reader may also return errors encountered reading and parsing from r.
+// To stop reading early, use a sentinel "stop" error value and ignore
+// it when returned from Reader.
 func Reader(r io.Reader, fn func(line []byte) error) error {
 	bs := bufio.NewScanner(r)
 	for bs.Scan() {


### PR DESCRIPTION
likelyHomeRouterIPDarwinSyscall iterates through the list of routes,
looking for a private gateway, returning the first one it finds.

likelyHomeRouterIPDarwinExec does the same thing,
except that it returns the last one it finds.

As a result, when there are multiple gateways,
TestLikelyHomeRouterIPSyscallExec fails.
(At least, I think that that is what is happening;
I am going inferring from observed behavior.)

This implementation is slightly wasteful:
It always reads all lines from netstat,
even when we know we don't need them.
That's a consequence of the util/lineread API.
It's not worth fixing now.


Signed-off-by: Josh Bleecher Snyder <josh@tailscale.com>