### PR TITLE
ipn: make LoadPrefs return os.ErrNotExist when reading corrupted files

### DIFF
--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -5,6 +5,7 @@
 package ipn
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -275,6 +276,9 @@ func LoadPrefs(filename string) (*Prefs, error) {
 	data, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("LoadPrefs open: %w", err) // err includes path
+	}
+	if bytes.Contains(data, jsonEscapedZero) {
+		return nil, os.ErrNotExist
 	}
 	p, err := PrefsFromBytes(data, false)
 	if err != nil {


### PR DESCRIPTION
It appears some users have corrupted pref.conf files. Have LoadPrefs
treat these files as non-existent. This way tailscale will make user
login, and not crash.

Fixes #954

Signed-off-by: Alex Brainman <alex.brainman@gmail.com>