### PR TITLE
tailcfg: include ShieldsUp in HostInfo

### DIFF
--- a/ipn/local.go
+++ b/ipn/local.go
@@ -1303,6 +1303,7 @@ func applyPrefsToHostinfo(hi *tailcfg.Hostinfo, prefs *Prefs) {
 	if m := prefs.DeviceModel; m != "" {
 		hi.DeviceModel = m
 	}
+	hi.ShieldsUp = prefs.ShieldsUp
 }
 
 // enterState transitions the backend into newState, updating internal

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -54,7 +54,7 @@ type Prefs struct {
 	// ShieldsUp indicates whether to block all incoming connections,
 	// regardless of the control-provided packet filter. If false, we
 	// use the packet filter as provided. If true, we block incoming
-	// connections.
+	// connections. This overrides tailcfg.Hostinfo's ShieldsUp.
 	ShieldsUp bool
 
 	// AdvertiseTags specifies groups that this node wants to join, for

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -294,6 +294,7 @@ type Hostinfo struct {
 	OSVersion     string       `json:",omitempty"` // operating system version, with optional distro prefix ("Debian 10.4", "Windows 10 Pro 10.0.19041")
 	DeviceModel   string       `json:",omitempty"` // mobile phone model ("Pixel 3a", "iPhone 11 Pro")
 	Hostname      string       // name of the host the client runs on
+	ShieldsUp     bool         `json:",omitempty`  // indicates whether the host is blocking incoming connections
 	GoArch        string       `json:",omitempty"` // the host's GOARCH value (of the running binary)
 	RoutableIPs   []wgcfg.CIDR `json:",omitempty"` // set of IP ranges this client can route
 	RequestTags   []string     `json:",omitempty"` // set of ACL tags this node wants to claim

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -294,7 +294,7 @@ type Hostinfo struct {
 	OSVersion     string       `json:",omitempty"` // operating system version, with optional distro prefix ("Debian 10.4", "Windows 10 Pro 10.0.19041")
 	DeviceModel   string       `json:",omitempty"` // mobile phone model ("Pixel 3a", "iPhone 11 Pro")
 	Hostname      string       // name of the host the client runs on
-	ShieldsUp     bool         `json:",omitempty`  // indicates whether the host is blocking incoming connections
+	ShieldsUp     bool         `json:",omitempty"` // indicates whether the host is blocking incoming connections
 	GoArch        string       `json:",omitempty"` // the host's GOARCH value (of the running binary)
 	RoutableIPs   []wgcfg.CIDR `json:",omitempty"` // set of IP ranges this client can route
 	RequestTags   []string     `json:",omitempty"` // set of ACL tags this node wants to claim

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -105,6 +105,7 @@ var _HostinfoNeedsRegeneration = Hostinfo(struct {
 	OSVersion     string
 	DeviceModel   string
 	Hostname      string
+	ShieldsUp     bool
 	GoArch        string
 	RoutableIPs   []wgcfg.CIDR
 	RequestTags   []string

--- a/tailcfg/tailcfg_test.go
+++ b/tailcfg/tailcfg_test.go
@@ -24,8 +24,8 @@ func fieldsOf(t reflect.Type) (fields []string) {
 func TestHostinfoEqual(t *testing.T) {
 	hiHandles := []string{
 		"IPNVersion", "FrontendLogID", "BackendLogID", "OS", "OSVersion",
-		"DeviceModel", "Hostname", "GoArch", "RoutableIPs", "RequestTags", "Services",
-		"NetInfo",
+		"DeviceModel", "Hostname", "ShieldsUp", "GoArch", "RoutableIPs",
+		"RequestTags", "Services", "NetInfo",
 	}
 	if have := fieldsOf(reflect.TypeOf(Hostinfo{})); !reflect.DeepEqual(have, hiHandles) {
 		t.Errorf("Hostinfo.Equal check might be out of sync\nfields: %q\nhandled: %q\n",


### PR DESCRIPTION
Signed-off-by: Sonia Appasamy <sonia@tailscale.com>

Including ShieldsUp in HostInfo with the goal of eventually being able to port this information through to the admin panel.