### PR TITLE
version: relax git detection logic (again)

### DIFF
--- a/version/version.sh
+++ b/version/version.sh
@@ -31,7 +31,7 @@ case $# in
         if [ -z "$extra_hash_or_dir" ]; then
             # Nothing, empty extra hash is fine.
             extra_hash=""
-        elif [ -d "$extra_hash_or_dir/.git" ]; then
+        elif [ -e "$extra_hash_or_dir/.git" ]; then
             extra_hash=$(git_hash_dirty "$extra_hash_or_dir" HEAD)
         elif ! expr "$extra_hash_or_dir" : "^[0-9a-f]*$"; then
             echo "Invalid extra hash '$extra_hash_or_dir', must be a git commit or path to a git repo" >&2


### PR DESCRIPTION
This is a repeat of commit 3aa68cd3978b880b451cd41ac4f4ee4ff5c4cb2f
which was lost in a rework of version.sh.

git worktrees have a .git file rather than a .git directory, so building
in a worktree caused version.sh to generate an error.

Signed-off-by: Adrian Dewhurst <adrian@tailscale.com>