### PR TITLE
Remove unused .gitignore lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,6 @@
 *.so
 *.dylib
 
-cmd/relaynode/relaynode
-cmd/taillogin/taillogin
 cmd/tailscale/tailscale
 cmd/tailscaled/tailscaled
 


### PR DESCRIPTION
These removed lines ignore built files that don't exist anymore, and just serve to clutter up the `.gitignore` file. (I was initially confused when I saw those lines, since I (correctly) thought that the only Tailscale binaries were `tailscale` and `tailscaled`):
- `taillogin` was removed in d052586
- `relaynode` was removed in a56e853