### PR TITLE
Require at least Go 1.15 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module tailscale.com
 
-go 1.14
+go 1.15
 
 require (
 	github.com/alexbrainman/sspi v0.0.0-20180613141037-e580b900e9f5


### PR DESCRIPTION
This is actually already required, this just updates `go.mod` with that fact. If you try and fail to build Tailscale with an outdated Go version, an error like this is printed, which should hopefully make building Tailscale easier:
```
note: module requires Go 1.15
```