### PR TITLE
wgengine: convert syscall to golang.org/x/sys when possible

### DIFF
--- a/wgengine/router/dns/manager_windows.go
+++ b/wgengine/router/dns/manager_windows.go
@@ -8,10 +8,10 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/tailscale/wireguard-go/tun"
+	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
 	"tailscale.com/types/logger"
 )
@@ -108,7 +108,7 @@ func (m windowsManager) Up(config Config) error {
 		t0 := time.Now()
 		m.logf("running ipconfig /registerdns ...")
 		cmd := exec.Command("ipconfig", "/registerdns")
-		cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+		cmd.SysProcAttr = &windows.SysProcAttr{HideWindow: true}
 		d := time.Since(t0).Round(time.Millisecond)
 		if err := cmd.Run(); err != nil {
 			m.logf("error running ipconfig /registerdns after %v: %v", d, err)

--- a/wgengine/router/router_windows.go
+++ b/wgengine/router/router_windows.go
@@ -9,11 +9,11 @@ import (
 	"fmt"
 	"os/exec"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/tailscale/wireguard-go/device"
 	"github.com/tailscale/wireguard-go/tun"
+	"golang.org/x/sys/windows"
 	"golang.zx2c4.com/wireguard/windows/tunnel/winipcfg"
 	"tailscale.com/logtail/backoff"
 	"tailscale.com/types/logger"
@@ -158,7 +158,7 @@ func (ft *firewallTweaker) runFirewall(args ...string) (time.Duration, error) {
 	t0 := time.Now()
 	args = append([]string{"advfirewall", "firewall"}, args...)
 	cmd := exec.Command("netsh", args...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	cmd.SysProcAttr = &windows.SysProcAttr{HideWindow: true}
 	err := cmd.Run()
 	return time.Since(t0).Round(time.Millisecond), err
 }

--- a/wgengine/tsdns/neterr_darwin.go
+++ b/wgengine/tsdns/neterr_darwin.go
@@ -6,14 +6,15 @@ package tsdns
 
 import (
 	"errors"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // Avoid allocation when calling errors.Is below
 // by converting syscall.Errno to error here.
 var (
-	networkDown        error = syscall.ENETDOWN
-	networkUnreachable error = syscall.ENETUNREACH
+	networkDown        error = unix.ENETDOWN
+	networkUnreachable error = unix.ENETUNREACH
 )
 
 func networkIsDown(err error) bool {


### PR DESCRIPTION
Two cases of syscall remain in wgengine/..., neither of which is too problematic:

* magicsock/magicsock.go is OS-independent but needs syscall.EAFNOSUPPORT
* winnet/winnet\_windows.go uses syscall.Syscall in a special way for which golang.org/x/sys/windows has no support

Updates: #1024
Signed-off-by: Timothy Gu <timothygu99@gmail.com>