### PR TITLE
add nix-shell boilerplate

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+eval "$(lorri direnv)"

--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-eval "$(lorri direnv)"

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ cmd/tailscaled/tailscaled
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# direnv config, this may be different for other people so it's probably safer
+# to make this nonspecific.
+.envrc

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,23 @@
+# This is a shell.nix file used to describe the environment that tailscale needs
+# for development. This includes a lot of the basic tools that you need in order
+# to get started. We hope this file will be useful for users of Nix on macOS or
+# Linux.
+#
+# For more information about this and why this file is useful, see here:
+# https://nixos.org/guides/nix-pills/developing-with-nix-shell.html
+#
+# Also look into direnv: https://direnv.net/, this can make it so that you can
+# automatically get your environment set up when you change folders into the
+# project.
 { pkgs ? import <nixpkgs> {} }:
 
 pkgs.mkShell {
+  # This specifies the tools that are needed for people to get started with
+  # development. These tools include:
+  #  - The Go compiler toolchain (and all additional tooling with it)
+  #  - goimports, a robust formatting tool for Go source code
+  #  - gopls, the language server for Go to increase editor integration
+  #  - git, the version control program (used in some scripts)
   buildInputs = with pkgs; [
     go goimports gopls git
   ];

--- a/shell.nix
+++ b/shell.nix
@@ -2,9 +2,6 @@
 
 pkgs.mkShell {
   buildInputs = with pkgs; [
-    go goimports gopls
-
-    # keep this line if you use bash
-    pkgs.bashInteractive
+    go goimports gopls git
   ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    go goimports gopls
+
+    # keep this line if you use bash
+    pkgs.bashInteractive
+  ];
+}


### PR DESCRIPTION
This enables users of nix-shell and lorri to automagically have the correct development environment by simply changing directory into a checkout of this repo. For more information on this see the following links:

- https://christine.website/blog/how-i-start-nix-2020-03-08
- https://direnv.net/
- https://www.tweag.io/blog/2019-03-28-introducing-lorri/

Signed-off-by: Christine Dodrill <xe@tailscale.com>