### PR TITLE
Clarify that raw format strings are intentional

### DIFF
--- a/types/logger/logger.go
+++ b/types/logger/logger.go
@@ -132,7 +132,7 @@ func RateLimitedFn(logf Logf, f time.Duration, burst int, maxCache int) Logf {
 			logf(format, args...)
 		case warn:
 			// For the warning, log the specific format string
-			logf("[RATE LIMITED] %s", format)
+			logf("[RATE LIMITED] format string \"%s\"", format)
 		}
 	}
 }

--- a/types/logger/logger_test.go
+++ b/types/logger/logger_test.go
@@ -45,8 +45,8 @@ func TestRateLimiter(t *testing.T) {
 		"templated format string no. 0",
 		"boring string with constant formatting (constant)",
 		"templated format string no. 1",
-		"[RATE LIMITED] boring string with constant formatting %s",
-		"[RATE LIMITED] templated format string no. %d",
+		"[RATE LIMITED] format string \"boring string with constant formatting %s\"",
+		"[RATE LIMITED] format string \"templated format string no. %d\"",
 		"Make sure this string makes it through the rest (that are blocked) 4",
 		"4 shouldn't get filtered.",
 	}


### PR DESCRIPTION
This caused some confusion in issue #460, since usually raw format strings aren't printed directly. Hopefully by directly logging that they are intended to be raw format strings, this will be more clear. Rate limited format strings now look like

```
[RATE LIMITED] format string "control: sendStatus: %s: %v"
```

Closes #460.