### PR TITLE
add support for native Apple M1 binaries

### DIFF
--- a/portlist/netstat.go
+++ b/portlist/netstat.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !ios !arm64
+// +build go1.16,!ios !go1.16,!darwin !go1.16,!arm64
 
 package portlist
 

--- a/portlist/netstat.go
+++ b/portlist/netstat.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !darwin !arm64
+// +build !ios !arm64
 
 package portlist
 

--- a/portlist/netstat_exec.go
+++ b/portlist/netstat_exec.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build windows freebsd openbsd darwin,amd64 darwin,arm64
+// +build windows freebsd openbsd darwin,amd64 go1.16,darwin,arm64
 
 package portlist
 

--- a/portlist/netstat_exec.go
+++ b/portlist/netstat_exec.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build windows freebsd openbsd darwin,amd64
+// +build windows freebsd openbsd darwin,amd64 darwin,arm64
 
 package portlist
 

--- a/portlist/portlist_ios.go
+++ b/portlist/portlist_ios.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build ios,!amd64
+// +build go1.16,ios !go1.16,darwin,!amd64
 
 package portlist
 

--- a/portlist/portlist_ios.go
+++ b/portlist/portlist_ios.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin,!amd64
+// +build ios,!amd64
 
 package portlist
 

--- a/portlist/portlist_macos.go
+++ b/portlist/portlist_macos.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin,amd64 darwin,arm64
+// +build darwin,amd64 go1.16,darwin,arm64
 
 package portlist
 

--- a/portlist/portlist_macos.go
+++ b/portlist/portlist_macos.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin,amd64
+// +build darwin,amd64 darwin,arm64
 
 package portlist
 

--- a/version/cmdname.go
+++ b/version/cmdname.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !ios !arm64
+// +build go1.16,!ios !go1.16,!darwin !go1.16,!arm64
 
 package version
 

--- a/version/cmdname.go
+++ b/version/cmdname.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !darwin !arm64
+// +build !ios !arm64
 
 package version
 

--- a/version/cmdname_ios.go
+++ b/version/cmdname_ios.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build ios,arm64
+// +build go1.16,ios !go1.16,darwin,arm64
 
 package version
 

--- a/version/cmdname_ios.go
+++ b/version/cmdname_ios.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin,arm64
+// +build ios,arm64
 
 package version
 


### PR DESCRIPTION

I understand that, since go 1.16 is still in beta, it is a bit too soon for this PR, but I thought it might be useful in the future. 

-- 

Build tags have been updated to build native Apple M1 binaries, existing build
tags for ios have been changed from darwin,arm64 to ios,arm64.

With this change, running go build cmd/tailscale{,d}/tailscale{,d}.go on an Apple
machine with the new processor works and resulting binaries show the expected
architecture, e.g. tailscale: Mach-O 64-bit executable arm64.

Tested using go version go1.16beta1 darwin/arm64.