### PR TITLE
wgengine/router/dns: use the correct interface GUID

### DIFF
--- a/wgengine/router/dns/manager_windows.go
+++ b/wgengine/router/dns/manager_windows.go
@@ -11,7 +11,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/tailscale/wireguard-go/tun"
 	"golang.org/x/sys/windows/registry"
 	"tailscale.com/types/logger"
 )
@@ -30,7 +29,7 @@ type windowsManager struct {
 func newManager(mconfig ManagerConfig) managerImpl {
 	return windowsManager{
 		logf: mconfig.Logf,
-		guid: tun.WintunGUID,
+		guid: mconfig.InterfaceName,
 	}
 }
 


### PR DESCRIPTION
On Win10, there's a hardcoded GUID and this works.
On Win7, this GUID changes and we need to ask the tun for its
LUID and convert that from the GUID.

This commit uses the computed GUID that is placed in InterfaceName.

Diagnosed by Jason Donnenfeld. (Thanks!)