### PR TITLE
wgengine/router/dns: reduce windows registry key open timeout

### DIFF
--- a/wgengine/router/dns/manager_windows.go
+++ b/wgengine/router/dns/manager_windows.go
@@ -37,7 +37,7 @@ func newManager(mconfig ManagerConfig) managerImpl {
 // appear. For some reason, registry keys tied to ephemeral interfaces
 // can take a long while to appear after interface creation, and we
 // can end up racing with that.
-const keyOpenTimeout = time.Minute
+const keyOpenTimeout = 20 * time.Second
 
 func setRegistryString(path, name, value string) error {
 	key, err := openKeyWait(registry.LOCAL_MACHINE, path, registry.SET_VALUE, keyOpenTimeout)


### PR DESCRIPTION
The windows key timeout is longer than the wgengine watchdog timeout,
which means we never reach the timeout, instead the process exits.
Reduce the timeout so if we do hit it, at least the process continues.

Signed-off-by: David Crawshaw <crawshaw@tailscale.com>