### PR TITLE
tailscaled.service: Harden systemd unit somewhat

### DIFF
--- a/cmd/tailscaled/tailscaled.service
+++ b/cmd/tailscaled/tailscaled.service
@@ -20,5 +20,16 @@ CacheDirectory=tailscale
 CacheDirectoryMode=0750
 Type=notify
 
+LockPersonality=true
+MemoryDenyWriteExecute=true
+PrivateTmp=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectProc=invisible
+ProtectSystem=strict
+RestrictSUIDSGID=true
+SystemCallArchitectures=native
+
 [Install]
 WantedBy=multi-user.target

--- a/cmd/tailscaled/tailscaled.service
+++ b/cmd/tailscaled/tailscaled.service
@@ -28,6 +28,7 @@ ProtectHome=true
 ProtectKernelTunables=true
 ProtectProc=invisible
 ProtectSystem=strict
+ReadWritePaths=/etc/
 RestrictSUIDSGID=true
 SystemCallArchitectures=native
 

--- a/cmd/tailscaled/tailscaled.service
+++ b/cmd/tailscaled/tailscaled.service
@@ -26,7 +26,6 @@ PrivateTmp=true
 ProtectControlGroups=true
 ProtectHome=true
 ProtectKernelTunables=true
-ProtectProc=invisible
 ProtectSystem=strict
 ReadWritePaths=/etc/
 RestrictSUIDSGID=true


### PR DESCRIPTION
While not a full capability lockdown of the systemd unit, this still improves sandboxing and security of the running process a good deal.

I also tried to add `ProtectClock` (since I don’t see how or why Tailscale should/would ever need to alter the clock…), but for some reason, Tailscale refused to start up with that. (Which I should probably open its own, separate issue for.)

Related issue: https://github.com/tailscale/tailscale/issues/77 (though not fully the same)