### PR TITLE
Fix typo in cmd/tailscale/cli/cli.go

### DIFF
--- a/cmd/tailscale/cli/cli.go
+++ b/cmd/tailscale/cli/cli.go
@@ -99,7 +99,7 @@ func connect(ctx context.Context) (net.Conn, *ipn.BackendClient, context.Context
 		if runtime.GOOS != "windows" && rootArgs.socket == "" {
 			fatalf("--socket cannot be empty")
 		}
-		fatalf("Failed to connect to connect to tailscaled. (safesocket.Connect: %v)\n", err)
+		fatalf("Failed to connect to tailscaled. (safesocket.Connect: %v)\n", err)
 	}
 	clientToServer := func(b []byte) {
 		ipn.WriteMsg(c, b)


### PR DESCRIPTION
Remove duplicate 'to connect' in error message.

Fixes #1068