### PR TITLE
tailscaled.service: Lock down clock and /dev

### DIFF
--- a/cmd/tailscaled/tailscaled.service
+++ b/cmd/tailscaled/tailscaled.service
@@ -20,9 +20,15 @@ CacheDirectory=tailscale
 CacheDirectoryMode=0750
 Type=notify
 
+DeviceAllow=/dev/net/tun
+DeviceAllow=/dev/null
+DeviceAllow=/dev/random
+DeviceAllow=/dev/urandom
+DevicePolicy=strict
 LockPersonality=true
 MemoryDenyWriteExecute=true
 PrivateTmp=true
+ProtectClock=true
 ProtectControlGroups=true
 ProtectHome=true
 ProtectKernelTunables=true


### PR DESCRIPTION
Research in issue https://github.com/tailscale/tailscale/issues/1063 uncovered why tailscaled would fail with ProtectClock enabled (it implicitly enabled DevicePolicy=closed).

This knowledge in turn also opens the door for locking down /dev further, e.g. explicitly setting DevicePolicy=strict (instead of closed), and making /dev private for the unit.