### PR TITLE
ipn: delete domainsForProxying, require explicit DNS search domains (mapver 9)

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -547,7 +547,7 @@ func (c *Direct) PollNetMap(ctx context.Context, maxPolls int, cb func(*NetworkM
 	}
 
 	request := tailcfg.MapRequest{
-		Version:    8,
+		Version:    tailcfg.CurrentMapRequestVersion,
 		KeepAlive:  c.keepAlive,
 		NodeKey:    tailcfg.NodeKey(persist.PrivateNodeKey.Public()),
 		DiscoKey:   c.discoPubKey,

--- a/wgengine/tsdns/map.go
+++ b/wgengine/tsdns/map.go
@@ -26,6 +26,10 @@ type Map struct {
 }
 
 // NewMap returns a new Map with name to address mapping given by nameToIP.
+//
+// rootDomains are the domains whose subdomains should always be
+// resolved locally to prevent leakage of sensitive names. They should
+// end in a period ("user-foo.tailscale.net.").
 func NewMap(initNameToIP map[string]netaddr.IP, rootDomains []string) *Map {
 	// TODO(dmytro): we have to allocate names and ipToName, but nameToIP can be avoided.
 	// It is here because control sends us names not in canonical form. Change this.

--- a/wgengine/tsdns/tsdns.go
+++ b/wgengine/tsdns/tsdns.go
@@ -194,8 +194,8 @@ func (r *Resolver) Resolve(domain string, tp dns.Type) (netaddr.IP, dns.RCode, e
 	}
 
 	anyHasSuffix := false
-	for _, rootDomain := range dnsMap.rootDomains {
-		if strings.HasSuffix(domain, rootDomain) {
+	for _, suffix := range dnsMap.rootDomains {
+		if NameHasSuffix(domain, suffix) {
 			anyHasSuffix = true
 			break
 		}
@@ -610,4 +610,13 @@ func (r *Resolver) respond(query []byte) ([]byte, error) {
 	}
 
 	return marshalResponse(resp)
+}
+
+// NameHasSuffix reports whether the provided DNS name ends with the
+// component(s) in suffix, ignoring any trailing dots.
+func NameHasSuffix(name, suffix string) bool {
+	name = strings.TrimSuffix(name, ".")
+	suffix = strings.TrimSuffix(suffix, ".")
+	nameBase := strings.TrimSuffix(name, suffix)
+	return len(nameBase) < len(name) && strings.HasSuffix(nameBase, ".")
 }

--- a/wgengine/tsdns/tsdns_test.go
+++ b/wgengine/tsdns/tsdns_test.go
@@ -758,3 +758,24 @@ func TestMarshalResponseFormatError(t *testing.T) {
 	}
 	t.Logf("response: %q", v)
 }
+
+func TestNameHasSuffix(t *testing.T) {
+	tests := []struct {
+		name, suffix string
+		want         bool
+	}{
+		{"foo.com", "com", true},
+		{"foo.com.", "com", true},
+		{"foo.com.", "com.", true},
+
+		{"", "", false},
+		{"foo.com.", "", false},
+		{"foo.com.", "o.com", false},
+	}
+	for _, tt := range tests {
+		got := NameHasSuffix(tt.name, tt.suffix)
+		if got != tt.want {
+			t.Errorf("NameHasSuffix(%q, %q) = %v; want %v", tt.name, tt.suffix, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Previously the client had heuristics to calculate which DNS search domains
to set, based on the peers' names. Unfortunately that prevented us from
doing some things we wanted to do server-side related to node sharing.

So, bump MapRequest.Version to 9 to signal that the client only uses the
explicitly configured DNS search domains and doesn't augment it with its own
list.

Updates tailscale/corp#1026