### PR TITLE
Return NOERROR instead of NOTIMP for most records

### DIFF
--- a/wgengine/tsdns/tsdns.go
+++ b/wgengine/tsdns/tsdns.go
@@ -228,8 +228,22 @@ func (r *Resolver) Resolve(domain string, tp dns.Type) (netaddr.IP, dns.RCode, e
 		// It could be IPv4, IPv6, or a zero addr.
 		// TODO: Return all available resolutions (A and AAAA, if we have them).
 		return addr, dns.RCodeSuccess, nil
-	default:
+
+	// Leave some some record types explicitly unimplemented.
+	// These types relate to recursive resolution or special
+	// DNS sematics and might be implemented in the future.
+	case dns.TypeNS, dns.TypeSOA, dns.TypeAXFR, dns.TypeHINFO:
 		return netaddr.IP{}, dns.RCodeNotImplemented, errNotImplemented
+
+	// For everything except for the few types above that are explictly not implemented, return no records.
+	// This is what other DNS systems do: always return NOERROR
+	// without any records whenever the requested record type is unknown.
+	// You can try this with:
+	//   dig -t TYPE9824 example.com
+	// and note that NOERROR is returned, despite that record type being made up.
+	default:
+		// no records exist of this type
+		return netaddr.IP{}, dns.RCodeSuccess, nil
 	}
 }
 

--- a/wgengine/tsdns/tsdns_test.go
+++ b/wgengine/tsdns/tsdns_test.go
@@ -215,6 +215,10 @@ func TestResolve(t *testing.T) {
 		{"nxdomain", "test3.ipn.dev.", dns.TypeA, netaddr.IP{}, dns.RCodeNameError},
 		{"foreign domain", "google.com.", dns.TypeA, netaddr.IP{}, dns.RCodeRefused},
 		{"all", "test1.ipn.dev.", dns.TypeA, testipv4, dns.RCodeSuccess},
+		{"mx-ipv4", "test1.ipn.dev.", dns.TypeMX, netaddr.IP{}, dns.RCodeSuccess},
+		{"mx-ipv6", "test2.ipn.dev.", dns.TypeMX, netaddr.IP{}, dns.RCodeSuccess},
+		{"mx-nxdomain", "test3.ipn.dev.", dns.TypeMX, netaddr.IP{}, dns.RCodeNameError},
+		{"ns-nxdomain", "test3.ipn.dev.", dns.TypeNS, netaddr.IP{}, dns.RCodeNameError},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This is what every other DNS resolver I could find does, so `tsdns` should do it as well. This also helps avoid weird error messages about records don't exist being unimplemented, and thus fixes #848.

notes:
- `go fmt` makes the indentation on lines 218/219 look wrong, but AFAIK there's no way to make `go fmt` handle it right.
- `go.sum` wasn't correctly regenerated after 14af6773324c95488f9f0a68704e637c7d642e70, but I didn't include the updated version in this PR to avoid merge conflicts.