### PR TITLE
tailcfg: add omitempty to FilterRule.SrcBits

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -565,7 +565,7 @@ type FilterRule struct {
 	// position is 32, as if the SrcIPs above were a /32 mask. For
 	// a "*" SrcIPs value, the corresponding SrcBits value is
 	// ignored.
-	SrcBits []int
+	SrcBits []int `json:",omitempty"`
 
 	// DstPorts are the port ranges to allow once a source IP
 	// matches (is in the CIDR described by SrcIPs & SrcBits).


### PR DESCRIPTION
It's not used by recent clients, so even more reason to omit it.

Signed-off-by: Brad Fitzpatrick <bradfitz@tailscale.com>