### PR TITLE
all: fix log test failures with -race after wireguard-go rebase

### DIFF
--- a/ipn/loglines_test.go
+++ b/ipn/loglines_test.go
@@ -26,6 +26,7 @@ func TestLocalLogLines(t *testing.T) {
 		"[v1] peer keys: %s",
 		"[v1] v%v peers: %v",
 	})
+	defer logListen.Close()
 
 	logid := func(hex byte) logtail.PublicID {
 		var ret logtail.PublicID

--- a/types/logger/logger.go
+++ b/types/logger/logger.go
@@ -179,3 +179,16 @@ func (fn ArgWriter) Format(f fmt.State, _ rune) {
 }
 
 var argBufioPool = &sync.Pool{New: func() interface{} { return bufio.NewWriterSize(ioutil.Discard, 1024) }}
+
+// Filtered returns a Logf that silently swallows some log lines.
+// Each inbound format and args is evaluated and printed to a string s.
+// The original format and args are passed to logf if and only if allow(s) returns true.
+func Filtered(logf Logf, allow func(s string) bool) Logf {
+	return func(format string, args ...interface{}) {
+		msg := fmt.Sprintf(format, args...)
+		if !allow(msg) {
+			return
+		}
+		logf(format, args...)
+	}
+}

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -247,9 +247,15 @@ func newUserspaceEngineAdvanced(conf EngineConfig) (_ Engine, reterr error) {
 	}
 	e.magicConn.SetNetworkUp(e.linkState.AnyInterfaceUp())
 
+	// wireguard-go logs as it starts and stops routines.
+	// Silence those; there are a lot of them, and they're just noise.
+	allowLogf := func(s string) bool {
+		return !strings.HasPrefix(s, "Routine:")
+	}
+	filtered := logger.Filtered(logf, allowLogf)
 	// flags==0 because logf is already nested in another logger.
 	// The outer one can display the preferred log prefixes, etc.
-	dlog := logger.StdLogger(logf)
+	dlog := logger.StdLogger(filtered)
 	logger := device.Logger{
 		Debug: dlog,
 		Info:  dlog,


### PR DESCRIPTION
The wireguard-go rebase restored the original wireguard-go logging. That logging occurs late during device shutdown, in a separate goroutine. This late logging caused test failures in one of our logging tests.

This PR fixes it two different ways: By suppressing some of the wireguard-go logging, and by making the log test robust to delayed logging.
