### PR TITLE
Fix non-deterministic code coverage

### DIFF
--- a/portlist/portlist_test.go
+++ b/portlist/portlist_test.go
@@ -47,6 +47,100 @@ func TestIgnoreLocallyBoundPorts(t *testing.T) {
 	}
 }
 
+func TestLessThan(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b Port
+		want bool
+	}{
+		{
+			"Port a < b",
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			Port{Proto: "tcp", Port: 101, Process: "proc1", inode: "inode1"},
+			true,
+		},
+		{
+			"Port a > b",
+			Port{Proto: "tcp", Port: 101, Process: "proc1", inode: "inode1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			false,
+		},
+		{
+			"Proto a < b",
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			Port{Proto: "udp", Port: 100, Process: "proc1", inode: "inode1"},
+			true,
+		},
+		{
+			"Proto a < b",
+			Port{Proto: "udp", Port: 100, Process: "proc1", inode: "inode1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			false,
+		},
+		{
+			"inode a < b",
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode2"},
+			true,
+		},
+		{
+			"inode a > b",
+			Port{Proto: "tcp", Port: 100, Process: "proc2", inode: "inode2"},
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			false,
+		},
+		{
+			"Process a < b",
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc2", inode: "inode1"},
+			true,
+		},
+		{
+			"Process a > b",
+			Port{Proto: "tcp", Port: 100, Process: "proc2", inode: "inode1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			false,
+		},
+		{
+			"Port evaluated first",
+			Port{Proto: "udp", Port: 100, Process: "proc2", inode: "inode2"},
+			Port{Proto: "tcp", Port: 101, Process: "proc1", inode: "inode1"},
+			true,
+		},
+		{
+			"Proto evaluated second",
+			Port{Proto: "tcp", Port: 100, Process: "proc2", inode: "inode2"},
+			Port{Proto: "udp", Port: 100, Process: "proc1", inode: "inode1"},
+			true,
+		},
+		{
+			"inode evaluated third",
+			Port{Proto: "tcp", Port: 100, Process: "proc2", inode: "inode1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode2"},
+			true,
+		},
+		{
+			"Process evaluated fourth",
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc2", inode: "inode1"},
+			true,
+		},
+		{
+			"equal",
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		got := tt.a.lessThan(&tt.b)
+		if got != tt.want {
+			t.Errorf("%s: Equal = %v; want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
 func BenchmarkGetList(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {

--- a/portlist/portlist_test.go
+++ b/portlist/portlist_test.go
@@ -141,6 +141,59 @@ func TestLessThan(t *testing.T) {
 	}
 }
 
+func TestSameInodes(t *testing.T) {
+	port1 := Port{Proto: "tcp", Port: 100, Process: "proc", inode: "inode1"}
+	port2 := Port{Proto: "tcp", Port: 100, Process: "proc", inode: "inode1"}
+	portProto := Port{Proto: "udp", Port: 100, Process: "proc", inode: "inode1"}
+	portPort := Port{Proto: "tcp", Port: 101, Process: "proc", inode: "inode1"}
+	portInode := Port{Proto: "tcp", Port: 100, Process: "proc", inode: "inode2"}
+	portProcess := Port{Proto: "tcp", Port: 100, Process: "other", inode: "inode1"}
+
+	tests := []struct {
+		name string
+		a, b List
+		want bool
+	}{
+		{
+			"identical",
+			List{port1, port1},
+			List{port2, port2},
+			true,
+		},
+		{
+			"proto differs",
+			List{port1, port1},
+			List{port2, portProto},
+			false,
+		},
+		{
+			"port differs",
+			List{port1, port1},
+			List{port2, portPort},
+			false,
+		},
+		{
+			"inode differs",
+			List{port1, port1},
+			List{port2, portInode},
+			false,
+		},
+		{
+			// SameInodes does not check the Process field
+			"Process differs",
+			List{port1, port1},
+			List{port2, portProcess},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		got := tt.a.SameInodes(tt.b)
+		if got != tt.want {
+			t.Errorf("%s: Equal = %v; want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
 func BenchmarkGetList(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -1139,7 +1139,7 @@ func (c *Conn) derpWriteChanOfAddr(addr netaddr.IPPort, peer key.Public) chan<- 
 		return nil
 	}
 
-	// Note that derphttp.NewClient does not dial the server
+	// Note that derphttp.NewRegionClient does not dial the server
 	// so it is safe to do under the mu lock.
 	dc := derphttp.NewRegionClient(c.privateKey, c.logf, func() *tailcfg.DERPRegion {
 		if c.connCtx.Err() != nil {

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -625,6 +625,58 @@ func TestConnClosing(t *testing.T) {
 	// (verified by deliberately breaking derpWriteChanOfAddr)
 }
 
+// Exercise a code path in sendDiscoMessage if the connection has been closed.
+func TestConnClosed(t *testing.T) {
+	mstun := &natlab.Machine{Name: "stun"}
+	m1 := &natlab.Machine{Name: "m1"}
+	m2 := &natlab.Machine{Name: "m2"}
+	inet := natlab.NewInternet()
+	sif := mstun.Attach("eth0", inet)
+	m1if := m1.Attach("eth0", inet)
+	m2if := m2.Attach("eth0", inet)
+
+	d := &devices{
+		m1:     m1,
+		m1IP:   m1if.V4(),
+		m2:     m2,
+		m2IP:   m2if.V4(),
+		stun:   mstun,
+		stunIP: sif.V4(),
+	}
+
+	derpMap, cleanup := runDERPAndStun(t, t.Logf, d.stun, d.stunIP)
+	defer cleanup()
+
+	ms1 := newMagicStack(t, logger.WithPrefix(t.Logf, "conn1: "), d.m1, derpMap)
+	defer ms1.Close()
+	ms2 := newMagicStack(t, logger.WithPrefix(t.Logf, "conn2: "), d.m2, derpMap)
+	defer ms2.Close()
+
+	cleanup = meshStacks(t.Logf, []*magicStack{ms1, ms2})
+	defer cleanup()
+
+	pkt := tuntest.Ping(ms2.IP(t).IPAddr().IP, ms1.IP(t).IPAddr().IP)
+
+	if len(ms1.conn.activeDerp) == 0 {
+		t.Errorf("unexpected DERP empty want: >0 got:%v", len(ms1.conn.activeDerp))
+	}
+
+	ms1.conn.Close()
+	ms2.conn.Close()
+
+	// This should hit a c.closed conditional in sendDiscoMessage() and return immediately.
+	ms1.tun.Outbound <- pkt
+	select {
+	case <-ms2.tun.Inbound:
+		t.Error("Unexpected response with connection closed")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	if len(ms1.conn.activeDerp) > 0 {
+		t.Errorf("unexpected DERP active want:0 got:%v", len(ms1.conn.activeDerp))
+	}
+}
+
 func makeNestable(t *testing.T) (logf logger.Logf, setT func(t *testing.T)) {
 	var mu sync.RWMutex
 	cur := t

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/tls"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -540,6 +541,88 @@ func TestDeviceStartStop(t *testing.T) {
 	})
 	dev.Up()
 	dev.Close()
+}
+
+type testConnClosingContext struct {
+	parent context.Context
+	mu     *sync.Mutex
+}
+
+func (c *testConnClosingContext) Deadline() (deadline time.Time, ok bool) {
+	d, o := c.parent.Deadline()
+	return d, o
+}
+func (c *testConnClosingContext) Done() <-chan struct{} {
+	return c.parent.Done()
+}
+func (c *testConnClosingContext) Err() error {
+	// Deliberately deadlock if anything grabs the lock after checking Err()
+	c.mu.Lock()
+	return errors.New("testConnClosingContext error")
+}
+func (c *testConnClosingContext) Value(key interface{}) interface{} {
+	return c.parent.Value(key)
+}
+func (*testConnClosingContext) String() string {
+	return "testConnClosingContext"
+}
+
+func TestConnClosing(t *testing.T) {
+	privateKey, err := wgkey.NewPrivate()
+	if err != nil {
+		t.Fatalf("generating private key: %v", err)
+	}
+
+	epCh := make(chan []string, 100)
+	conn, err := NewConn(Options{
+		Logf:           t.Logf,
+		PacketListener: nettype.Std{},
+		EndpointsFunc: func(eps []string) {
+			epCh <- eps
+		},
+		SimulatedNetwork: false,
+	})
+	if err != nil {
+		t.Fatalf("constructing magicsock: %v", err)
+	}
+
+	derpMap, cleanup := runDERPAndStun(t, t.Logf, nettype.Std{}, netaddr.IPv4(127, 0, 3, 1))
+	defer cleanup()
+	conn.Start()
+	conn.SetDERPMap(derpMap)
+	if err := conn.SetPrivateKey(privateKey); err != nil {
+		t.Fatalf("setting private key in magicsock: %v", err)
+	}
+
+	tun := tuntest.NewChannelTUN()
+	tsTun := tstun.WrapTUN(t.Logf, tun.TUN())
+	tsTun.SetFilter(filter.NewAllowAllForTest(t.Logf))
+
+	dev := device.NewDevice(tsTun, &device.DeviceOptions{
+		Logger: &device.Logger{
+			Debug: logger.StdLogger(t.Logf),
+			Info:  logger.StdLogger(t.Logf),
+			Error: logger.StdLogger(t.Logf),
+		},
+		CreateEndpoint: conn.CreateEndpoint,
+		CreateBind:     conn.CreateBind,
+		SkipBindUpdate: true,
+	})
+
+	// The point of this test case is to exercise handling in derpWriteChanOfAddr() which
+	// returns early if connCtx.Err() returns non-nil, to avoid a deadlock on conn.mu.
+	// We swap in a context which always returns an error, and deliberately grabs the lock
+	// to cause a deadlock.
+
+	closingCtx := testConnClosingContext{parent: conn.connCtx, mu: &conn.mu}
+	conn.connCtx = &closingCtx
+
+	dev.Up()
+	conn.WaitReady(t)
+
+	// We don't assert any failures within the test itself. If derpWriteChanOfAddr tries to
+	// grab the lock it will deadlock, and conn.WaitReady(t) will call t.Fatal() after timeout.
+	// (verified by deliberately breaking derpWriteChanOfAddr)
 }
 
 func makeNestable(t *testing.T) (logf logger.Logf, setT func(t *testing.T)) {


### PR DESCRIPTION
The changes in this PR address almost all of the cases of non-deterministic code coverage which caused lines of code to be alternately added and removed from coverage reports. It does so by expressly testing the functionality in question. After this PR there may be one function in DERP left which is non-deterministically covered, plus any more which we notice over time. I'd expect to address all such areas similarly, by adding specific tests.