### PR TITLE
Fix non-deterministic code coverage, part 1.

### DIFF
--- a/logtail/logtail_test.go
+++ b/logtail/logtail_test.go
@@ -16,8 +16,12 @@ func TestFastShutdown(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
+	testServ := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {}))
+	defer testServ.Close()
+
 	l := NewLogger(Config{
-		BaseURL: "http://localhost:1234",
+		BaseURL: testServ.URL,
 	}, t.Logf)
 	l.Shutdown(ctx)
 }
@@ -30,6 +34,7 @@ func TestUploadMessages(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json; charset=utf-8")
 			uploads += 1
 		}))
+	defer testServ.Close()
 
 	l := NewLogger(Config{BaseURL: testServ.URL}, t.Logf)
 	for i := 1; i < 10; i++ {

--- a/net/netcheck/netcheck_test.go
+++ b/net/netcheck/netcheck_test.go
@@ -560,3 +560,39 @@ func TestLogConciseReport(t *testing.T) {
 		})
 	}
 }
+
+func TestSortRegions(t *testing.T) {
+	unsortedMap := &tailcfg.DERPMap{
+		Regions: map[int]*tailcfg.DERPRegion{},
+	}
+	for rid := 1; rid <= 5; rid++ {
+		var nodes []*tailcfg.DERPNode
+		nodes = append(nodes, &tailcfg.DERPNode{
+			Name:     fmt.Sprintf("%da", rid),
+			RegionID: rid,
+			HostName: fmt.Sprintf("derp%d-1", rid),
+			IPv4:     fmt.Sprintf("%d.0.0.1", rid),
+			IPv6:     fmt.Sprintf("%d::1", rid),
+		})
+		unsortedMap.Regions[rid] = &tailcfg.DERPRegion{
+			RegionID: rid,
+			Nodes:    nodes,
+		}
+	}
+	report := newReport()
+	report.RegionLatency[1] = time.Second * time.Duration(5)
+	report.RegionLatency[2] = time.Second * time.Duration(3)
+	report.RegionLatency[3] = time.Second * time.Duration(6)
+	report.RegionLatency[4] = time.Second * time.Duration(0)
+	report.RegionLatency[5] = time.Second * time.Duration(2)
+	got := sortRegions(unsortedMap, report)
+
+	// Sorting by latency this should result in rid: 5, 2, 1, 3
+	// rid 4 with latency 0 should be at the end
+	expected := []int{5, 2, 1, 3, 4}
+	for idx, want := range expected {
+		if got[idx].RegionID != want {
+			t.Errorf("idx:%v got:%v want:%v\n", idx, got[idx].RegionID, want)
+		}
+	}
+}

--- a/net/netcheck/netcheck_test.go
+++ b/net/netcheck/netcheck_test.go
@@ -585,14 +585,16 @@ func TestSortRegions(t *testing.T) {
 	report.RegionLatency[3] = time.Second * time.Duration(6)
 	report.RegionLatency[4] = time.Second * time.Duration(0)
 	report.RegionLatency[5] = time.Second * time.Duration(2)
-	got := sortRegions(unsortedMap, report)
+	sortedMap := sortRegions(unsortedMap, report)
 
 	// Sorting by latency this should result in rid: 5, 2, 1, 3
 	// rid 4 with latency 0 should be at the end
-	expected := []int{5, 2, 1, 3, 4}
-	for idx, want := range expected {
-		if got[idx].RegionID != want {
-			t.Errorf("idx:%v got:%v want:%v\n", idx, got[idx].RegionID, want)
-		}
+	want := []int{5, 2, 1, 3, 4}
+	got := make([]int, len(sortedMap))
+	for i, r := range sortedMap {
+		got[i] = r.RegionID
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v; want %v", got, want)
 	}
 }

--- a/portlist/portlist_test.go
+++ b/portlist/portlist_test.go
@@ -47,6 +47,100 @@ func TestIgnoreLocallyBoundPorts(t *testing.T) {
 	}
 }
 
+func TestLessThan(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b Port
+		want bool
+	}{
+		{
+			"Port a < b",
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			Port{Proto: "tcp", Port: 101, Process: "proc1", inode: "inode1"},
+			true,
+		},
+		{
+			"Port a > b",
+			Port{Proto: "tcp", Port: 101, Process: "proc1", inode: "inode1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			false,
+		},
+		{
+			"Proto a < b",
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			Port{Proto: "udp", Port: 100, Process: "proc1", inode: "inode1"},
+			true,
+		},
+		{
+			"Proto a < b",
+			Port{Proto: "udp", Port: 100, Process: "proc1", inode: "inode1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			false,
+		},
+		{
+			"inode a < b",
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode2"},
+			true,
+		},
+		{
+			"inode a > b",
+			Port{Proto: "tcp", Port: 100, Process: "proc2", inode: "inode2"},
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			false,
+		},
+		{
+			"Process a < b",
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc2", inode: "inode1"},
+			true,
+		},
+		{
+			"Process a > b",
+			Port{Proto: "tcp", Port: 100, Process: "proc2", inode: "inode1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			false,
+		},
+		{
+			"Port evaluated first",
+			Port{Proto: "udp", Port: 100, Process: "proc2", inode: "inode2"},
+			Port{Proto: "tcp", Port: 101, Process: "proc1", inode: "inode1"},
+			true,
+		},
+		{
+			"Proto evaluated second",
+			Port{Proto: "tcp", Port: 100, Process: "proc2", inode: "inode2"},
+			Port{Proto: "udp", Port: 100, Process: "proc1", inode: "inode1"},
+			true,
+		},
+		{
+			"inode evaluated third",
+			Port{Proto: "tcp", Port: 100, Process: "proc2", inode: "inode1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode2"},
+			true,
+		},
+		{
+			"Process evaluated fourth",
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc2", inode: "inode1"},
+			true,
+		},
+		{
+			"equal",
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		got := tt.a.lessThan(&tt.b)
+		if got != tt.want {
+			t.Errorf("%s: Equal = %v; want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
 func BenchmarkGetList(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {

--- a/portlist/portlist_test.go
+++ b/portlist/portlist_test.go
@@ -141,6 +141,59 @@ func TestLessThan(t *testing.T) {
 	}
 }
 
+func TestSameInodes(t *testing.T) {
+	port1 := Port{Proto: "tcp", Port: 100, Process: "proc", inode: "inode1"}
+	port2 := Port{Proto: "tcp", Port: 100, Process: "proc", inode: "inode1"}
+	portProto := Port{Proto: "udp", Port: 100, Process: "proc", inode: "inode1"}
+	portPort := Port{Proto: "tcp", Port: 101, Process: "proc", inode: "inode1"}
+	portInode := Port{Proto: "tcp", Port: 100, Process: "proc", inode: "inode2"}
+	portProcess := Port{Proto: "tcp", Port: 100, Process: "other", inode: "inode1"}
+
+	tests := []struct {
+		name string
+		a, b List
+		want bool
+	}{
+		{
+			"identical",
+			List{port1, port1},
+			List{port2, port2},
+			true,
+		},
+		{
+			"proto differs",
+			List{port1, port1},
+			List{port2, portProto},
+			false,
+		},
+		{
+			"port differs",
+			List{port1, port1},
+			List{port2, portPort},
+			false,
+		},
+		{
+			"inode differs",
+			List{port1, port1},
+			List{port2, portInode},
+			false,
+		},
+		{
+			// SameInodes does not check the Process field
+			"Process differs",
+			List{port1, port1},
+			List{port2, portProcess},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		got := tt.a.SameInodes(tt.b)
+		if got != tt.want {
+			t.Errorf("%s: Equal = %v; want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
 func BenchmarkGetList(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -1139,7 +1139,7 @@ func (c *Conn) derpWriteChanOfAddr(addr netaddr.IPPort, peer key.Public) chan<- 
 		return nil
 	}
 
-	// Note that derphttp.NewClient does not dial the server
+	// Note that derphttp.NewRegionClient does not dial the server
 	// so it is safe to do under the mu lock.
 	dc := derphttp.NewRegionClient(c.privateKey, c.logf, func() *tailcfg.DERPRegion {
 		if c.connCtx.Err() != nil {

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/tls"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -540,6 +541,88 @@ func TestDeviceStartStop(t *testing.T) {
 	})
 	dev.Up()
 	dev.Close()
+}
+
+type testConnClosingContext struct {
+	parent context.Context
+	mu     *sync.Mutex
+}
+
+func (c *testConnClosingContext) Deadline() (deadline time.Time, ok bool) {
+	d, o := c.parent.Deadline()
+	return d, o
+}
+func (c *testConnClosingContext) Done() <-chan struct{} {
+	return c.parent.Done()
+}
+func (c *testConnClosingContext) Err() error {
+	// Deliberately deadlock if anything grabs the lock after checking Err()
+	c.mu.Lock()
+	return errors.New("testConnClosingContext error")
+}
+func (c *testConnClosingContext) Value(key interface{}) interface{} {
+	return c.parent.Value(key)
+}
+func (*testConnClosingContext) String() string {
+	return "testConnClosingContext"
+}
+
+func TestConnClosing(t *testing.T) {
+	privateKey, err := wgkey.NewPrivate()
+	if err != nil {
+		t.Fatalf("generating private key: %v", err)
+	}
+
+	epCh := make(chan []string, 100)
+	conn, err := NewConn(Options{
+		Logf:           t.Logf,
+		PacketListener: nettype.Std{},
+		EndpointsFunc: func(eps []string) {
+			epCh <- eps
+		},
+		SimulatedNetwork: false,
+	})
+	if err != nil {
+		t.Fatalf("constructing magicsock: %v", err)
+	}
+
+	derpMap, cleanup := runDERPAndStun(t, t.Logf, nettype.Std{}, netaddr.IPv4(127, 0, 3, 1))
+	defer cleanup()
+
+	// The point of this test case is to exercise handling in derpWriteChanOfAddr() which
+	// returns early if connCtx.Err() returns non-nil, to avoid a deadlock on conn.mu.
+	// We swap in a context which always returns an error, and deliberately grabs the lock
+	// to cause a deadlock if magicsock.go tries to acquire the lock after calling Err().
+	closingCtx := testConnClosingContext{parent: conn.connCtx, mu: &conn.mu}
+	conn.connCtx = &closingCtx
+	conn.Start()
+
+	conn.SetDERPMap(derpMap)
+	if err := conn.SetPrivateKey(privateKey); err != nil {
+		t.Fatalf("setting private key in magicsock: %v", err)
+	}
+
+	tun := tuntest.NewChannelTUN()
+	tsTun := tstun.WrapTUN(t.Logf, tun.TUN())
+	tsTun.SetFilter(filter.NewAllowAllForTest(t.Logf))
+
+	dev := device.NewDevice(tsTun, &device.DeviceOptions{
+		Logger: &device.Logger{
+			Debug: logger.StdLogger(t.Logf),
+			Info:  logger.StdLogger(t.Logf),
+			Error: logger.StdLogger(t.Logf),
+		},
+		CreateEndpoint: conn.CreateEndpoint,
+		CreateBind:     conn.CreateBind,
+		SkipBindUpdate: true,
+	})
+
+	dev.Up()
+	conn.WaitReady(t)
+
+	// We don't assert any failures within the test itself. If derpWriteChanOfAddr tries to
+	// grab the lock it will deadlock, and conn.WaitReady(t) will call t.Fatal() after timeout.
+	// (verified by deliberately breaking derpWriteChanOfAddr)
 }
 
 func makeNestable(t *testing.T) (logf logger.Logf, setT func(t *testing.T)) {

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -543,6 +543,11 @@ func TestDeviceStartStop(t *testing.T) {
 	dev.Close()
 }
 
+// A context used in TestConnClosing() which seeks to test that code which calls
+// Err() to see if a connection is already being closed does not then proceed to
+// try to acquire the mutex, as this would lead to deadlock. When Err() is called
+// this context acquires the lock itself, in order to force a deadlock (and test
+// failure on timeout).
 type testConnClosingContext struct {
 	parent context.Context
 	mu     *sync.Mutex


### PR DESCRIPTION
The changes in this PR address most of the cases of non-deterministic code coverage which caused lines of code to be alternately added and removed from coverage reports. It does so by expressly testing the functionality in question. After this PR there may be one function in DERP left which is non-deterministically covered, plus any more which we notice over time. I'd expect to address all such areas similarly, by adding specific tests.