### PR TITLE
Added 2 fuzzers

### DIFF
--- a/disco/disco_fuzzer.go
+++ b/disco/disco_fuzzer.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// +build gofuzz
+
+package disco
+
+func Fuzz(data []byte) int {
+	m, _ := Parse(data)
+
+	newBytes := m.AppendMarshal(data)
+	parsedMarshall, _ := Parse(newBytes)
+
+	if m != parsedMarshall {
+		panic("Parsing error")
+	}
+	return 1
+}

--- a/net/stun/stun_fuzzer.go
+++ b/net/stun/stun_fuzzer.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// +build gofuzz
+
+package stun
+
+func FuzzStunParser(data []byte) int {
+	_, _, _, _ := ParseResponse(data)
+
+	_, _ = ParseBindingRequest(data)
+	return 1
+}


### PR DESCRIPTION
Hello

I saw in the code that a fuzzing was on the to-do list:
https://github.com/tailscale/tailscale/blob/e4f53e9b6f1a4d3d6f00091ddef617989b1ea3e4/net/stun/stun_test.go#L16

I have run these on OSS-fuzz's infrastructure as well and would be happy to set up an integration application so they can run continuously free of charge by OSS-fuzz. 

Tagging @bradfitz since you were mentioned in the comment.

Signed-off-by: AdamKorcz <adam@adalogics.com>