### PR TITLE
net/packet, wgengine, tstun: communicate SYN failure reason between nodes

### DIFF
--- a/ipn/local.go
+++ b/ipn/local.go
@@ -564,8 +564,7 @@ func (b *LocalBackend) updateFilter(netMap *controlclient.NetworkMap, prefs *Pre
 
 	if shieldsUp {
 		b.logf("netmap packet filter: (shields up)")
-		var prevFilter *filter.Filter // don't reuse old filter state
-		b.e.SetFilter(filter.New(nil, localNets, prevFilter, b.logf))
+		b.e.SetFilter(filter.NewShieldsUpFilter(b.logf))
 	} else {
 		b.logf("netmap packet filter: %v", packetFilter)
 		b.e.SetFilter(filter.New(packetFilter, localNets, b.e.GetFilter(), b.logf))

--- a/net/packet/header.go
+++ b/net/packet/header.go
@@ -36,9 +36,6 @@ type Header interface {
 	// purpose of computing length and checksum fields. Marshal
 	// implementations must not allocate memory.
 	Marshal(buf []byte) error
-	// ToResponse transforms the header into one for a response packet.
-	// For instance, this swaps the source and destination IPs.
-	ToResponse()
 }
 
 // Generate generates a new packet with the given Header and

--- a/net/packet/ip.go
+++ b/net/packet/ip.go
@@ -24,6 +24,17 @@ const (
 	TCP    IPProto = 0x06
 	UDP    IPProto = 0x11
 
+	// TSMP is the Tailscale Message Protocol (our ICMP-ish
+	// thing), an IP protocol used only between Tailscale nodes
+	// (still encrypted by WireGuard) that communicates why things
+	// failed, etc.
+	//
+	// Proto number 99 is reserved for "any private encryption
+	// scheme". We never accept these from the host OS stack nor
+	// send them to the host network stack. It's only used between
+	// nodes.
+	TSMP IPProto = 99
+
 	// Fragment represents any non-first IP fragment, for which we
 	// don't have the sub-protocol header (and therefore can't
 	// figure out what the sub-protocol is).
@@ -47,6 +58,8 @@ func (p IPProto) String() string {
 		return "UDP"
 	case TCP:
 		return "TCP"
+	case TSMP:
+		return "TSMP"
 	default:
 		return "Unknown"
 	}

--- a/net/packet/packet.go
+++ b/net/packet/packet.go
@@ -204,6 +204,10 @@ func (q *Parsed) decode4(b []byte) {
 			q.Dst.Port = binary.BigEndian.Uint16(sub[2:4])
 			q.dataofs = q.subofs + udpHeaderLength
 			return
+		case TSMP:
+			// Inter-tailscale messages.
+			q.dataofs = q.subofs
+			return
 		default:
 			q.IPProto = Unknown
 			return
@@ -291,6 +295,10 @@ func (q *Parsed) decode6(b []byte) {
 		q.Src.Port = binary.BigEndian.Uint16(sub[0:2])
 		q.Dst.Port = binary.BigEndian.Uint16(sub[2:4])
 		q.dataofs = q.subofs + udpHeaderLength
+	case TSMP:
+		// Inter-tailscale messages.
+		q.dataofs = q.subofs
+		return
 	default:
 		q.IPProto = Unknown
 		return

--- a/net/packet/tsmp.go
+++ b/net/packet/tsmp.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// TSMP is our ICMP-like "Tailscale Message Protocol" for signaling
+// Tailscale-specific messages between nodes. It uses IP protocol 99
+// (reserved for "any private encryption scheme") within
+// Wireguard's normal encryption between peers and never hits the host
+// network stack.
+
+package packet
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"inet.af/netaddr"
+	"tailscale.com/net/flowtrack"
+)
+
+// TailscaleRejectedHeader is a TSMP message that says that one
+// Tailscale node has rejected the connection from another. Unlike a
+// TCP RST, this includes a reason.
+//
+// On the wire, after the IP header, it's currently 7 bytes:
+//     * '!'
+//     * IPProto byte (IANA protocol number: TCP or UDP)
+//     * 'A' or 'S' (RejectedDueToACLs, RejectedDueToShieldsUp)
+//     * srcPort big endian uint16
+//     * dstPort big endian uint16
+//
+// In the future it might also accept 16 byte IP flow src/dst IPs
+// after the header, if they're different than the IP-level ones.
+type TailscaleRejectedHeader struct {
+	IPSrc  netaddr.IP            // IPv4 or IPv6 header's src IP
+	IPDst  netaddr.IP            // IPv4 or IPv6 header's dst IP
+	Src    netaddr.IPPort        // rejected flow's src
+	Dst    netaddr.IPPort        // rejected flow's dst
+	Proto  IPProto               // proto that was rejected (TCP or UDP)
+	Reason TailscaleRejectReason // why the connection was rejected
+}
+
+func (rh TailscaleRejectedHeader) Flow() flowtrack.Tuple {
+	return flowtrack.Tuple{Src: rh.Src, Dst: rh.Dst}
+}
+
+func (rh TailscaleRejectedHeader) String() string {
+	return fmt.Sprintf("TSMP-reject-flow{%s %s > %s}: %s", rh.Proto, rh.Src, rh.Dst, rh.Reason)
+}
+
+type TSMPType uint8
+
+const (
+	TSMPTypeRejectedConn TSMPType = '!'
+)
+
+type TailscaleRejectReason byte
+
+const (
+	RejectedDueToACLs      TailscaleRejectReason = 'A'
+	RejectedDueToShieldsUp TailscaleRejectReason = 'S'
+)
+
+func (r TailscaleRejectReason) String() string {
+	switch r {
+	case RejectedDueToACLs:
+		return "acl"
+	case RejectedDueToShieldsUp:
+		return "shields"
+	}
+	return fmt.Sprintf("0x%02x", byte(r))
+}
+
+func (h TailscaleRejectedHeader) Len() int {
+	var ipHeaderLen int
+	if h.IPSrc.Is4() {
+		ipHeaderLen = ip4HeaderLength
+	} else if h.IPSrc.Is6() {
+		ipHeaderLen = ip6HeaderLength
+	}
+	return ipHeaderLen +
+		1 + // TSMPType byte
+		1 + // IPProto byte
+		1 + // TailscaleRejectReason byte
+		2*2 // 2 uint16 ports
+}
+
+func (h TailscaleRejectedHeader) Marshal(buf []byte) error {
+	if len(buf) < h.Len() {
+		return errSmallBuffer
+	}
+	if len(buf) > maxPacketLength {
+		return errLargePacket
+	}
+	if h.Src.IP.Is4() {
+		iph := IP4Header{
+			IPProto: TSMP,
+			Src:     h.IPSrc,
+			Dst:     h.IPDst,
+		}
+		iph.Marshal(buf)
+		buf = buf[ip4HeaderLength:]
+	} else if h.Src.IP.Is6() {
+		iph := IP6Header{
+			IPProto: TSMP,
+			Src:     h.IPSrc,
+			Dst:     h.IPDst,
+		}
+		iph.Marshal(buf)
+		buf = buf[ip6HeaderLength:]
+	} else {
+		return errors.New("bogus src IP")
+	}
+	buf[0] = byte(TSMPTypeRejectedConn)
+	buf[1] = byte(h.Proto)
+	buf[2] = byte(h.Reason)
+	binary.BigEndian.PutUint16(buf[3:5], h.Src.Port)
+	binary.BigEndian.PutUint16(buf[5:7], h.Dst.Port)
+	return nil
+}
+
+// AsTailscaleRejectedHeader parses pp as an incoming rejection
+// connection TSMP message.
+//
+// ok reports whether pp was a valid TSMP rejection packet.
+func (pp *Parsed) AsTailscaleRejectedHeader() (h TailscaleRejectedHeader, ok bool) {
+	p := pp.Payload()
+	if len(p) < 7 || p[0] != byte(TSMPTypeRejectedConn) {
+		return
+	}
+	return TailscaleRejectedHeader{
+		Proto:  IPProto(p[1]),
+		Reason: TailscaleRejectReason(p[2]),
+		IPSrc:  pp.Src.IP,
+		IPDst:  pp.Dst.IP,
+		Src:    netaddr.IPPort{IP: pp.Dst.IP, Port: binary.BigEndian.Uint16(p[3:5])},
+		Dst:    netaddr.IPPort{IP: pp.Src.IP, Port: binary.BigEndian.Uint16(p[5:7])},
+	}, true
+}

--- a/net/packet/tsmp_test.go
+++ b/net/packet/tsmp_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package packet
+
+import (
+	"testing"
+
+	"inet.af/netaddr"
+)
+
+func TestTailscaleRejectedHeader(t *testing.T) {
+	tests := []struct {
+		h       TailscaleRejectedHeader
+		wantStr string
+	}{
+		{
+			h: TailscaleRejectedHeader{
+				IPSrc:  netaddr.MustParseIP("5.5.5.5"),
+				IPDst:  netaddr.MustParseIP("1.2.3.4"),
+				Src:    netaddr.MustParseIPPort("1.2.3.4:567"),
+				Dst:    netaddr.MustParseIPPort("5.5.5.5:443"),
+				Proto:  TCP,
+				Reason: RejectedDueToACLs,
+			},
+			wantStr: "TSMP-reject-flow{TCP 1.2.3.4:567 > 5.5.5.5:443}: acl",
+		},
+		{
+			h: TailscaleRejectedHeader{
+				IPSrc:  netaddr.MustParseIP("2::2"),
+				IPDst:  netaddr.MustParseIP("1::1"),
+				Src:    netaddr.MustParseIPPort("[1::1]:567"),
+				Dst:    netaddr.MustParseIPPort("[2::2]:443"),
+				Proto:  UDP,
+				Reason: RejectedDueToShieldsUp,
+			},
+			wantStr: "TSMP-reject-flow{UDP [1::1]:567 > [2::2]:443}: shields",
+		},
+	}
+	for i, tt := range tests {
+		gotStr := tt.h.String()
+		if gotStr != tt.wantStr {
+			t.Errorf("%v. String = %q; want %q", i, gotStr, tt.wantStr)
+			continue
+		}
+		pkt := make([]byte, tt.h.Len())
+		tt.h.Marshal(pkt)
+
+		var p Parsed
+		p.Decode(pkt)
+		t.Logf("Parsed: %+v", p)
+		t.Logf("Parsed: %s", p.String())
+		back, ok := p.AsTailscaleRejectedHeader()
+		if !ok {
+			t.Errorf("%v. %q (%02x) didn't parse back", i, gotStr, pkt)
+			continue
+		}
+		if back != tt.h {
+			t.Errorf("%v. %q parsed back as %q", i, tt.h, back)
+		}
+	}
+}

--- a/wgengine/filter/filter.go
+++ b/wgengine/filter/filter.go
@@ -39,6 +39,8 @@ type Filter struct {
 	// to an outbound connection that this node made, even if those
 	// incoming packets don't get accepted by matches above.
 	state *filterState
+
+	shieldsUp bool
 }
 
 // filterState is a state cache of past seen packets.
@@ -54,15 +56,18 @@ const lruMax = 512
 type Response int
 
 const (
-	Drop      Response = iota // do not continue processing packet.
-	Accept                    // continue processing packet.
-	noVerdict                 // no verdict yet, continue running filter
+	Drop         Response = iota // do not continue processing packet.
+	DropSilently                 // do not continue processing packet, but also don't log
+	Accept                       // continue processing packet.
+	noVerdict                    // no verdict yet, continue running filter
 )
 
 func (r Response) String() string {
 	switch r {
 	case Drop:
 		return "Drop"
+	case DropSilently:
+		return "DropSilently"
 	case Accept:
 		return "Accept"
 	case noVerdict:
@@ -70,6 +75,10 @@ func (r Response) String() string {
 	default:
 		return "???"
 	}
+}
+
+func (r Response) IsDrop() bool {
+	return r == Drop || r == DropSilently
 }
 
 // RunFlags controls the filter's debug log verbosity at runtime.
@@ -121,6 +130,12 @@ func NewAllowAllForTest(logf logger.Logf) *Filter {
 // NewAllowNone returns a packet filter that rejects everything.
 func NewAllowNone(logf logger.Logf) *Filter {
 	return New(nil, nil, nil, logf)
+}
+
+func NewShieldsUpFilter(logf logger.Logf) *Filter {
+	f := New(nil, nil, nil, logf)
+	f.shieldsUp = true
+	return f
 }
 
 // New creates a new packet filter. The filter enforces that incoming
@@ -253,6 +268,10 @@ func (f *Filter) CheckTCP(srcIP, dstIP netaddr.IP, dstPort uint16) Response {
 	return f.RunIn(pkt, 0)
 }
 
+// ShieldsUp reports whether this is a "shields up" (block everything
+// incoming) filter.
+func (f *Filter) ShieldsUp() bool { return f.shieldsUp }
+
 // RunIn determines whether this node is allowed to receive q from a
 // Tailscale peer.
 func (f *Filter) RunIn(q *packet.Parsed, rf RunFlags) Response {
@@ -339,6 +358,8 @@ func (f *Filter) runIn4(q *packet.Parsed) (r Response, why string) {
 		if f.matches4.match(q) {
 			return Accept, "udp ok"
 		}
+	case packet.TSMP:
+		return Accept, "tsmp ok"
 	default:
 		return Drop, "Unknown proto"
 	}


### PR DESCRIPTION
This adds a new "TSMP" IP Protocol type (99) for sending inter-tailscale
messages over WireGuard, currently just for why a peer rejects TCP
SYNs (ACL rejection, shields up, nothing listening, something listening on that port but wrong interface, etc)

Updates #1094