### PR TITLE
wgengine/router/dns: remove unused code

### DIFF
--- a/wgengine/router/dns/manager_windows.go
+++ b/wgengine/router/dns/manager_windows.go
@@ -18,7 +18,6 @@ import (
 const (
 	ipv4RegBase = `SYSTEM\CurrentControlSet\Services\Tcpip\Parameters`
 	ipv6RegBase = `SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters`
-	tsRegBase   = `SOFTWARE\Tailscale IPN`
 )
 
 type windowsManager struct {
@@ -88,11 +87,6 @@ func (m windowsManager) Up(config Config) error {
 		return err
 	}
 	if err := m.setDomains(ipv6RegBase, config.Domains); err != nil {
-		return err
-	}
-
-	newSearchList := strings.Join(config.Domains, ",")
-	if err := setRegistryString(tsRegBase, "SearchList", newSearchList); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Commit 68ddf1 removed code that reads
`SOFTWARE\Tailscale IPN\SearchList` registry value. But the commit
left code that writes that value.

So now this package writes and never reads the value.

Remove the code to stop pointless work.

Updates #853

Signed-off-by: Alex Brainman <alex.brainman@gmail.com>