### PR TITLE
Provide example when format string is rate limited

### DIFF
--- a/types/logger/logger.go
+++ b/types/logger/logger.go
@@ -132,7 +132,7 @@ func RateLimitedFn(logf Logf, f time.Duration, burst int, maxCache int) Logf {
 			logf(format, args...)
 		case warn:
 			// For the warning, log the specific format string
-			logf("[RATE LIMITED] format string \"%s\"", format)
+			logf("[RATE LIMITED] format string \"%s\" (example: \"%s\")", format, fmt.Sprintf(format, args...))
 		}
 	}
 }

--- a/types/logger/logger_test.go
+++ b/types/logger/logger_test.go
@@ -45,8 +45,8 @@ func TestRateLimiter(t *testing.T) {
 		"templated format string no. 0",
 		"boring string with constant formatting (constant)",
 		"templated format string no. 1",
-		"[RATE LIMITED] format string \"boring string with constant formatting %s\"",
-		"[RATE LIMITED] format string \"templated format string no. %d\"",
+		"[RATE LIMITED] format string \"boring string with constant formatting %s\" (example: \"boring string with constant formatting (constant)\")",
+		"[RATE LIMITED] format string \"templated format string no. %d\" (example: \"templated format string no. 2\")",
 		"Make sure this string makes it through the rest (that are blocked) 4",
 		"4 shouldn't get filtered.",
 	}


### PR DESCRIPTION
Here's an example log line in the new format:
```
[RATE LIMITED] format string "open-conn-track: timeout opening %v; no associated peer node" (example: "open-conn-track: timeout opening ([ip] => [ip]); no associated peer node")
```
This should make debugging logging issues a bit easier, and give more context as to why something was rate limited. Including an example was first mentioned at https://github.com/tailscale/tailscale/issues/1110#issuecomment-759073284.

edit: updated example