### PR TITLE
wgengine/netstack: use tailscale IPs instead of a hardcoded one

### DIFF
--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -28,6 +28,7 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip/transport/udp"
 	"gvisor.dev/gvisor/pkg/waiter"
 	"inet.af/netaddr"
+	"tailscale.com/control/controlclient"
 	"tailscale.com/net/packet"
 	"tailscale.com/types/logger"
 	"tailscale.com/wgengine"
@@ -62,7 +63,46 @@ func Impl(logf logger.Logf, tundev *tstun.TUN, e wgengine.Engine, mc *magicsock.
 		log.Fatal(err)
 	}
 
-	ipstack.AddAddress(nicID, ipv4.ProtocolNumber, tcpip.Address(net.ParseIP("100.96.188.101").To4()))
+	e.AddNetworkMapCallback(func(nm *controlclient.NetworkMap) {
+		oldIPs := make(map[tcpip.Address]bool)
+		for _, ip := range ipstack.AllAddresses()[nicID] {
+			oldIPs[ip.AddressWithPrefix.Address] = true
+		}
+		newIPs := make(map[tcpip.Address]bool)
+		for _, ip := range nm.Addresses {
+			newIPs[tcpip.Address(ip.IPNet().IP)] = true
+		}
+
+		ipsToBeAdded := make(map[tcpip.Address]bool)
+		for ip := range newIPs {
+			if !oldIPs[ip] {
+				ipsToBeAdded[ip] = true
+			}
+		}
+		ipsToBeRemoved := make(map[tcpip.Address]bool)
+		for ip := range oldIPs {
+			if !newIPs[ip] {
+				ipsToBeRemoved[ip] = true
+			}
+		}
+
+		for ip := range ipsToBeRemoved {
+			err := ipstack.RemoveAddress(nicID, ip)
+			if err != nil {
+				logf("netstack: could not deregister IP %v: %v", ip.String(), err)
+			} else {
+				logf("netstack: deregistered IP %v", ip.String())
+			}
+		}
+		for ip := range ipsToBeAdded {
+			err := ipstack.AddAddress(nicID, ipv4.ProtocolNumber, ip)
+			if err != nil {
+				logf("netstack: could not register IP %v: %v", ip.String(), err)
+			} else {
+				logf("netstack: registered IP %v", ip.String())
+			}
+		}
+	})
 
 	// Add 0.0.0.0/0 default route.
 	subnet, _ := tcpip.NewSubnet(tcpip.Address(strings.Repeat("\x00", 4)), tcpip.AddressMask(strings.Repeat("\x00", 4)))

--- a/wgengine/watchdog.go
+++ b/wgengine/watchdog.go
@@ -110,6 +110,11 @@ func (e *watchdogEngine) SetDERPMap(m *tailcfg.DERPMap) {
 func (e *watchdogEngine) SetNetworkMap(nm *controlclient.NetworkMap) {
 	e.watchdog("SetNetworkMap", func() { e.wrap.SetNetworkMap(nm) })
 }
+func (e *watchdogEngine) AddNetworkMapCallback(callback NetworkMapCallback) func() {
+	var fn func()
+	e.watchdog("AddNetworkMapCallback", func() { fn = e.wrap.AddNetworkMapCallback(callback) })
+	return func() { e.watchdog("RemoveNetworkMapCallback", fn) }
+}
 func (e *watchdogEngine) DiscoPublicKey() (k tailcfg.DiscoKey) {
 	e.watchdog("DiscoPublicKey", func() { k = e.wrap.DiscoPublicKey() })
 	return k

--- a/wgengine/wgengine.go
+++ b/wgengine/wgengine.go
@@ -49,6 +49,11 @@ type StatusCallback func(*Status, error)
 // NetInfoCallback is the type used by Engine.SetNetInfoCallback.
 type NetInfoCallback func(*tailcfg.NetInfo)
 
+// NetworkMapCallback is the type used by callbacks that hook
+// into network map updates.
+type NetworkMapCallback func(*controlclient.NetworkMap)
+type networkMapCallbackHandle struct{ _ byte }
+
 // ErrNoChanges is returned by Engine.Reconfig if no changes were made.
 var ErrNoChanges = errors.New("no changes made to Engine config")
 
@@ -113,6 +118,12 @@ type Engine interface {
 	// instead.
 	// The network map should only be read from.
 	SetNetworkMap(*controlclient.NetworkMap)
+
+	// AddNetworkMapCallback adds a function to a list of callbacks
+	// that are called when the network map updates. It returns a
+	// function that when called would remove the function from the
+	// list of callbacks.
+	AddNetworkMapCallback(NetworkMapCallback) func()
 
 	// SetNetInfoCallback sets the function to call when a
 	// new NetInfo summary is available.


### PR DESCRIPTION
Rather than hardcoding your Tailscale IP in netstack.go, pull the current ones in from the netmap, and listen for any future changes to the netmap IPs as well.