### PR TITLE
net/interfaces: add debugging code for crawshaw

### DIFF
--- a/net/interfaces/interfaces_darwin.go
+++ b/net/interfaces/interfaces_darwin.go
@@ -6,6 +6,9 @@ package interfaces
 
 import (
 	"errors"
+	"fmt"
+	"io"
+	"os"
 	"os/exec"
 
 	"go4.org/mem"
@@ -46,8 +49,10 @@ func likelyHomeRouterIPDarwinExec() (ret netaddr.IP, ok bool) {
 	}
 	defer cmd.Wait()
 
+	fmt.Println("netstat output:")
+	tee := io.TeeReader(stdout, os.Stdout)
 	var f []mem.RO
-	lineread.Reader(stdout, func(lineb []byte) error {
+	lineread.Reader(tee, func(lineb []byte) error {
 		line := mem.B(lineb)
 		if !mem.Contains(line, mem.S("default")) {
 			return nil

--- a/net/interfaces/interfaces_darwin_cgo.go
+++ b/net/interfaces/interfaces_darwin_cgo.go
@@ -105,6 +105,7 @@ import "C"
 
 import (
 	"encoding/binary"
+	"fmt"
 
 	"inet.af/netaddr"
 )
@@ -116,6 +117,7 @@ func init() {
 func likelyHomeRouterIPDarwinSyscall() (ret netaddr.IP, ok bool) {
 	ip := C.privateGatewayIP()
 	if ip < 255 {
+		fmt.Println("privateGatewayIP failure:", ip)
 		return netaddr.IP{}, false
 	}
 	var q [4]byte


### PR DESCRIPTION
At your leisure, where this test is failing for you, please do

gh pr checkout 1136
go test -run=TestLikelyHomeRouterIPSyscallExec -v ./net/interfaces

and share the output. Thanks!

(Oh, and do not merge this PR. Thanks.)