### PR TITLE
ipn, ipnserver: only require sudo on Linux for mutable CLI actions

### DIFF
--- a/ipn/ipnserver/conn_linux.go
+++ b/ipn/ipnserver/conn_linux.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux
+
+package ipnserver
+
+import (
+	"net"
+
+	"golang.org/x/sys/unix"
+	"tailscale.com/types/logger"
+)
+
+func isReadonlyConn(c net.Conn, logf logger.Logf) (ro bool) {
+	ro = true // conservative default for naked returns below
+	uc, ok := c.(*net.UnixConn)
+	if !ok {
+		logf("unexpected connection type %T", c)
+		return
+	}
+	raw, err := uc.SyscallConn()
+	if err != nil {
+		logf("SyscallConn: %v", err)
+		return
+	}
+
+	var cred *unix.Ucred
+	cerr := raw.Control(func(fd uintptr) {
+		cred, err = unix.GetsockoptUcred(int(fd),
+			unix.SOL_SOCKET,
+			unix.SO_PEERCRED)
+	})
+	if cerr != nil {
+		logf("raw.Control: %v", err)
+		return
+	}
+	if err != nil {
+		logf("raw.Control: %v", err)
+		return
+	}
+	if cred.Uid == 0 {
+		// root is not read-only.
+		return false
+	}
+	logf("non-root connection from %v (read-only)", cred.Uid)
+	return true
+}

--- a/ipn/ipnserver/conn_no_ucred.go
+++ b/ipn/ipnserver/conn_no_ucred.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !linux
+
+package ipnserver
+
+import (
+	"net"
+
+	"tailscale.com/types/logger"
+)
+
+func isReadonlyConn(c net.Conn, logf logger.Logf) bool {
+	// Windows doesn't need/use this mechanism, at least yet. It
+	// has a different last-user-wins auth model.
+
+	// And on Darwin, we're not using it yet, as the Darwin
+	// tailscaled port isn't yet done, and unix.Ucred and
+	// unix.GetsockoptUcred aren't in x/sys/unix.
+
+	// TODO(bradfitz): OpenBSD and FreeBSD should implement this too.
+	// But their x/sys/unix package is different than Linux, so
+	// I didn't include it for now.
+	return false
+}

--- a/ipn/message_test.go
+++ b/ipn/message_test.go
@@ -6,6 +6,7 @@ package ipn
 
 import (
 	"bytes"
+	"context"
 	"testing"
 	"time"
 
@@ -81,7 +82,7 @@ func TestClientServer(t *testing.T) {
 		serverToClientCh <- append([]byte{}, b...)
 	}
 	clientToServer := func(b []byte) {
-		bs.GotCommandMsg(b)
+		bs.GotCommandMsg(context.TODO(), b)
 	}
 	slogf := func(fmt string, args ...interface{}) {
 		t.Logf("s: "+fmt, args...)


### PR DESCRIPTION
This partially reverts d6e9fb1df0fd6, which modified the permissions
on the tailscaled Unix socket and thus required "sudo tailscale" even
for "tailscale status".

Instead, open the permissions back up but have the server look at the
peer creds and only permit read-only actions unless you're root.

In the future we'll also have a group that can do mutable actions.