### PR TITLE
magicsock: skip TestConnClosed().

### DIFF
--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -629,6 +629,8 @@ func TestConnClosing(t *testing.T) {
 
 // Exercise a code path in sendDiscoMessage if the connection has been closed.
 func TestConnClosed(t *testing.T) {
+	t.Skip() // https://github.com/tailscale/tailscale/pull/1135 is an attempt to fix this.
+
 	mstun := &natlab.Machine{Name: "stun"}
 	m1 := &natlab.Machine{Name: "m1"}
 	m2 := &natlab.Machine{Name: "m2"}


### PR DESCRIPTION
A number of PRs are failing with "panic: Log in goroutine after
TestConnClosed has completed." This is a new test and has not been
in the tree for long.

Disable the test for now, to not impact the work of others while
debugging.