### PR TITLE
wgengine/magicsock: fix BenchmarkReceiveFrom.

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -119,6 +119,7 @@ type Conn struct {
 	packetListener   nettype.PacketListener
 	noteRecvActivity func(tailcfg.DiscoKey) // or nil, see Options.NoteRecvActivity
 	simulatedNetwork bool
+	disableLegacy    bool
 
 	// ================================================================
 	// No locking required to access these fields, either because
@@ -382,6 +383,11 @@ type Options struct {
 	// triggering macOS and Windows firwall dialog boxes during
 	// "go test").
 	SimulatedNetwork bool
+
+	// DisableLegacyNetworking disables legacy peer handling. When
+	// enabled, only active discovery-aware nodes will be able to
+	// communicate with Conn.
+	DisableLegacyNetworking bool
 }
 
 func (o *Options) logf() logger.Logf {
@@ -1600,7 +1606,9 @@ Top:
 				c.logf("magicsock: DERP packet received from idle peer %v; created=%v", dm.src.ShortString(), ep != nil)
 			}
 		}
-		asEp = c.addrsByKey[dm.src]
+		if !c.disableLegacy {
+			asEp = c.addrsByKey[dm.src]
+		}
 		c.mu.Unlock()
 
 		if discoEp != nil {

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -681,6 +681,16 @@ func (c *Conn) callNetInfoCallback(ni *tailcfg.NetInfo) {
 	}
 }
 
+// addValidDiscoPathForTest makes addr a validated disco address for
+// discoKey. It's used in tests to enable receiving of packets from
+// addr without having to spin up the entire active discovery
+// machinery.
+func (c *Conn) addValidDiscoPathForTest(discoKey tailcfg.DiscoKey, addr netaddr.IPPort) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.discoOfAddr[addr] = discoKey
+}
+
 func (c *Conn) SetNetInfoCallback(fn func(*tailcfg.NetInfo)) {
 	if fn == nil {
 		panic("nil NetInfoCallback")
@@ -2147,7 +2157,6 @@ func (c *Conn) SetNetworkMap(nm *controlclient.NetworkMap) {
 			delete(c.sharedDiscoKey, dk)
 		}
 	}
-
 }
 
 func (c *Conn) wantDerpLocked() bool { return c.derpMap != nil }

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -1491,6 +1491,7 @@ func BenchmarkReceiveFrom(b *testing.B) {
 		EndpointsFunc: func(eps []string) {
 			b.Logf("endpoints: %q", eps)
 		},
+		DisableLegacyNetworking: true,
 	})
 	if err != nil {
 		b.Fatal(err)

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -1503,6 +1503,21 @@ func BenchmarkReceiveFrom(b *testing.B) {
 	}
 	defer sendConn.Close()
 
+	// Give conn just enough state that it'll recognize sendConn as a
+	// valid peer and not fall through to the legacy magicsock
+	// codepath.
+	discoKey := tailcfg.DiscoKey{31: 1}
+	conn.SetNetworkMap(&controlclient.NetworkMap{
+		Peers: []*tailcfg.Node{
+			{
+				DiscoKey:  discoKey,
+				Endpoints: []string{sendConn.LocalAddr().String()},
+			},
+		},
+	})
+	conn.CreateEndpoint([32]byte{1: 1}, "0000000000000000000000000000000000000000000000000000000000000001.disco.tailscale:12345")
+	conn.addValidDiscoPathForTest(discoKey, netaddr.MustParseIPPort(sendConn.LocalAddr().String()))
+
 	var dstAddr net.Addr = conn.pconn4.LocalAddr()
 	sendBuf := make([]byte, 1<<10)
 	for i := range sendBuf {


### PR DESCRIPTION
Previously, this benchmark relied on behavior of the legacy
receive codepath, which I changed in 22507adf. With this
change, the benchmark instead relies on the new active discovery
path.

Signed-off-by: David Anderson <danderson@tailscale.com>