### PR TITLE
all: add side-channel logf communication via magic args

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -133,6 +133,7 @@ func run() error {
 	if v, _ := strconv.ParseBool(os.Getenv("TS_DEBUG_MEMORY")); v {
 		logf = logger.RusagePrefixLog(logf)
 	}
+	logf = logger.ApplyPostProcess(logf)
 	logf = logger.RateLimitedFn(logf, 5*time.Second, 5, 100)
 
 	if args.cleanup {

--- a/ipn/ipnserver/server.go
+++ b/ipn/ipnserver/server.go
@@ -258,7 +258,7 @@ func (s *server) serveConn(ctx context.Context, c net.Conn, logf logger.Logf) {
 			// minutes. 5 seconds is enough to let browser hit
 			// favicon.ico and such.
 			IdleTimeout: 5 * time.Second,
-			ErrorLog:    logger.StdLogger(logf),
+			ErrorLog:    logger.StdLogger(logger.RateLimitContext(logf, "ipn-server")),
 			Handler:     s.localhostHandler(ci),
 		}
 		httpServer.Serve(&oneConnListener{&protoSwitchConn{s: s, br: br, Conn: c}})

--- a/types/logger/logger.go
+++ b/types/logger/logger.go
@@ -120,7 +120,6 @@ func RateLimitedFn(logf Logf, f time.Duration, burst int, maxCache int) Logf {
 			}
 		}
 
-		format = noopFormatRemover.Replace(format)
 		if len(contexts) > 0 {
 			format += " (rate-limit-context:" + strings.Join(contexts, ",") + ")"
 		}
@@ -147,6 +146,7 @@ func RateLimitedFn(logf Logf, f time.Duration, burst int, maxCache int) Logf {
 		}
 		if !rl.msgBlocked {
 			rl.msgBlocked = true
+			format = noopFormatRemover.Replace(format)
 			return warn, format
 		}
 		return block, ""

--- a/types/logger/logger_test.go
+++ b/types/logger/logger_test.go
@@ -67,7 +67,30 @@ func TestRateLimiter(t *testing.T) {
 	if testsRun < len(want) {
 		t.Fatalf("Tests after %s weren't logged.", want[testsRun])
 	}
+}
 
+func TestNoRateLimit(t *testing.T) {
+	want := []string{
+		"not rate limited",
+		"rate limited",
+		"not rate limited",
+		"[RATE LIMITED] format string \"rate limited\" (example: \"rate limited\")",
+		"not rate limited",
+		"not rate limited",
+		"not rate limited",
+	}
+
+	testsRun := 0
+	lgtest := logTester(want, t, &testsRun)
+	rl := RateLimitedFn(lgtest, 1*time.Minute, 1, 1)
+	lg := NoRateLimit(rl)
+	for i := 0; i < 5; i++ {
+		lg("not rate limited")
+		rl("rate limited")
+	}
+	if testsRun < len(want) {
+		t.Fatalf("tests after %s weren't logged.", want[testsRun])
+	}
 }
 
 func testTimer(d time.Duration) func() time.Time {

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -81,7 +81,7 @@ func runDERPAndStun(t *testing.T, logf logger.Logf, l nettype.PacketListener, st
 	d := derp.NewServer(serverPrivateKey, logf)
 
 	httpsrv := httptest.NewUnstartedServer(derphttp.Handler(d))
-	httpsrv.Config.ErrorLog = logger.StdLogger(logf)
+	httpsrv.Config.ErrorLog = logger.StdLogger(logger.RateLimitContext(logf, "run-DERP-and-stun"))
 	httpsrv.Config.TLSNextProto = make(map[string]func(*http.Server, *tls.Conn, http.Handler))
 	httpsrv.StartTLS()
 

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -165,6 +165,7 @@ func newMagicStack(t testing.TB, logf logger.Logf, l nettype.PacketListener, der
 	tsTun := tstun.WrapTUN(logf, tun.TUN())
 	tsTun.SetFilter(filter.NewAllowAllForTest(logf))
 
+	logf = logger.ApplyPostProcess(logf)
 	wgLogger := wglog.NewLogger(logf)
 	dev := device.NewDevice(tsTun, &device.DeviceOptions{
 		Logger:         wgLogger.DeviceLogger,

--- a/wgengine/wglog/wglog.go
+++ b/wgengine/wglog/wglog.go
@@ -29,6 +29,7 @@ type Logger struct {
 func NewLogger(logf logger.Logf) *Logger {
 	ret := new(Logger)
 
+	logf = logger.RateLimitContext(logf, "wireguard-go")
 	wrapper := func(format string, args ...interface{}) {
 		msg := fmt.Sprintf(format, args...)
 		if strings.Contains(msg, "Routine:") {
@@ -53,6 +54,10 @@ func NewLogger(logf logger.Logf) *Logger {
 		// This changes the format string,
 		// which is somewhat unfortunate as it impacts rate limiting,
 		// but there's not much we can do about that.
+		// At the moment, that doesn't matter, becuase logger.StdLogger
+		// already always uses %s, but it'd be nice to change that.
+		// The use of RateLimitContext at least ensures we won't
+		// interact with other loggers using %s.
 		logf("%s", new)
 	}
 	std := logger.StdLogger(wrapper)

--- a/wgengine/wglog/wglog_test.go
+++ b/wgengine/wglog/wglog_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/tailscale/wireguard-go/wgcfg"
+	"tailscale.com/types/logger"
 	"tailscale.com/wgengine/wglog"
 )
 
@@ -32,7 +33,7 @@ func TestLogger(t *testing.T) {
 			t.Errorf("wrote %q, but shouldn't have", s)
 		}
 	}
-
+	logf = logger.ApplyPostProcess(logf)
 	x := wglog.NewLogger(logf)
 	key, err := wgcfg.ParseHexKey("20c4c1ae54e1fd37cab6e9a532ca20646aff496796cc41d4519560e5e82bee53")
 	if err != nil {


### PR DESCRIPTION
I suggest reviewing this commit by commit.

This is perhaps both too cute and too clever, but:

* it is a clear, extensible, re-usable approach to the problem of cross-layer logf communication
* I've not come up with any alternatives that aren't abysmal

If we decide to move forward with this, the next steps are:

* see about eliminating logger.StdLogger wherever possible
* consider using logger.NoRateLimit instead of the magic prefixes
* consider applying logger.RateLimitContext to places where we have very plain format strings
* consider whether to use this approach for other things, like verbosity

