### PR TITLE
User bigger line length when parsing IpcGetOperation

### DIFF
--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -1063,7 +1063,7 @@ func (e *userspaceEngine) getStatus() (*Status, error) {
 
 	// lineLen is the max UAPI line we expect. The longest I see is
 	// len("preshared_key=")+64 hex+"\n" == 79. Add some slop.
-	const lineLen = 100
+	const lineLen = 256
 
 	pr, pw := io.Pipe()
 	errc := make(chan error, 1)
@@ -1094,6 +1094,9 @@ func (e *userspaceEngine) getStatus() (*Status, error) {
 	bs.Buffer(make([]byte, lineLen), lineLen)
 	for bs.Scan() {
 		line := bs.Bytes()
+		if len(line) > lineLen/2 {
+			log.Printf("wgengine: IpcGetOperation: line too long (%d): %s", len(line), line)
+		}
 		k := line
 		var v mem.RO
 		if i := bytes.IndexByte(line, '='); i != -1 {


### PR DESCRIPTION
Dual stack line is longer (106) than the used 100.
Raise it to 256 and log when it's longer than 128.

Fixes #1024.