### PR TITLE
wgengine: don't leak TUN device in NewUserspaceEngine error path

### DIFF
--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -194,6 +194,7 @@ func NewUserspaceEngine(logf logger.Logf, tunname string, listenPort uint16) (En
 
 	e, err := NewUserspaceEngineAdvanced(conf)
 	if err != nil {
+		tun.Close()
 		return nil, err
 	}
 	return e, err


### PR DESCRIPTION
Updates #1187

Signed-off-by: Brad Fitzpatrick <bradfitz@tailscale.com>