### PR TITLE
Add an environment variable to enable customizing the log target

### DIFF
--- a/logpolicy/logpolicy.go
+++ b/logpolicy/logpolicy.go
@@ -388,7 +388,7 @@ func New(collection string) *Policy {
 		HTTPC: &http.Client{Transport: newLogtailTransport(logtail.DefaultHost)},
 	}
 
-	if val, ok := os.LookupEnv("TAILSCALE_LOG_TARGET_DO_NOT_SET_UNLESS_TOLD_TO"); ok {
+	if val, ok := os.LookupEnv("TAILSCALE_LOG_TARGET"); ok {
 		log.Println("You have enabled a non-default log target. Doing without being told to by Tailscale staff or your network administrator will make getting support difficult.")
 		c.BaseURL = val
 		u, _ := url.Parse(val)

--- a/logpolicy/logpolicy.go
+++ b/logpolicy/logpolicy.go
@@ -17,6 +17,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -390,6 +391,8 @@ func New(collection string) *Policy {
 	if val, ok := os.LookupEnv("TAILSCALE_LOG_TARGET_DO_NOT_SET_UNLESS_TOLD_TO"); ok {
 		log.Println("You have enabled a non-default log target. Doing without being told to by Tailscale staff or your network administrator will make getting support difficult.")
 		c.BaseURL = val
+		u, _ := url.Parse(val)
+		c.HTTPC = &http.Client{Transport: newLogtailTransport(u.Host)}
 	}
 
 	filchBuf, filchErr := filch.New(filepath.Join(dir, cmdName), filch.Options{})

--- a/logpolicy/logpolicy.go
+++ b/logpolicy/logpolicy.go
@@ -387,6 +387,11 @@ func New(collection string) *Policy {
 		HTTPC: &http.Client{Transport: newLogtailTransport(logtail.DefaultHost)},
 	}
 
+	if val, ok := os.LookupEnv("TAILSCALE_LOG_TARGET_DO_NOT_SET_UNLESS_TOLD_TO"); ok {
+		log.Println("You have enabled a non-default log target. Doing without being told to by Tailscale staff or your network administrator will make getting support difficult.")
+		c.BaseURL = val
+	}
+
 	filchBuf, filchErr := filch.New(filepath.Join(dir, cmdName), filch.Options{})
 	if filchBuf != nil {
 		c.Buffer = filchBuf

--- a/logtail/logtail.go
+++ b/logtail/logtail.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"os"
 	"strconv"
@@ -52,7 +51,6 @@ type Config struct {
 func NewLogger(cfg Config, logf tslogger.Logf) *Logger {
 	if cfg.BaseURL == "" {
 		cfg.BaseURL = "https://" + DefaultHost
-		log.Println("XXX(Xe): set default host")
 	}
 	if cfg.HTTPC == nil {
 		cfg.HTTPC = http.DefaultClient

--- a/logtail/logtail.go
+++ b/logtail/logtail.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"strconv"
@@ -51,6 +52,7 @@ type Config struct {
 func NewLogger(cfg Config, logf tslogger.Logf) *Logger {
 	if cfg.BaseURL == "" {
 		cfg.BaseURL = "https://" + DefaultHost
+		log.Println("XXX(Xe): set default host")
 	}
 	if cfg.HTTPC == nil {
 		cfg.HTTPC = http.DefaultClient


### PR DESCRIPTION
This will enable the log server target to be chosen by end users to point to an arbitrary server. This is intended to be used with corporate/onprem deployments of Tailscale, and should NOT be used by end users unless you want to make getting support difficult.

- [x] test with mincatcher