### PR TITLE
net/packet: add some more TSMP packet reject reasons

### DIFF
--- a/net/packet/tsmp_test.go
+++ b/net/packet/tsmp_test.go
@@ -37,6 +37,18 @@ func TestTailscaleRejectedHeader(t *testing.T) {
 			},
 			wantStr: "TSMP-reject-flow{UDP [1::1]:567 > [2::2]:443}: shields",
 		},
+		{
+			h: TailscaleRejectedHeader{
+				IPSrc:       netaddr.MustParseIP("2::2"),
+				IPDst:       netaddr.MustParseIP("1::1"),
+				Src:         netaddr.MustParseIPPort("[1::1]:567"),
+				Dst:         netaddr.MustParseIPPort("[2::2]:443"),
+				Proto:       UDP,
+				Reason:      RejectedDueToIPForwarding,
+				MaybeBroken: true,
+			},
+			wantStr: "TSMP-reject-flow{UDP [1::1]:567 > [2::2]:443}: host-ip-forwarding-unavailable",
+		},
 	}
 	for i, tt := range tests {
 		gotStr := tt.h.String()


### PR DESCRIPTION
Unused for now, but I want to backport this commit to 1.4 so 1.6 can
start sending these and then at least 1.4 logs will stringify nicely.
