### PR TITLE
control/controlclient: avoid crash sending map request with zero node key

### DIFF
--- a/control/controlclient/auto.go
+++ b/control/controlclient/auto.go
@@ -213,7 +213,7 @@ func (c *Client) sendNewMapRequest() {
 	// If we're not already streaming a netmap, or if we're already stuck
 	// in a lite update, then tear down everything and start a new stream
 	// (which starts by sending a new map request)
-	if !c.inPollNetMap || c.inLiteMapUpdate {
+	if !c.inPollNetMap || c.inLiteMapUpdate || !c.loggedIn {
 		c.mu.Unlock()
 		c.cancelMapSafely()
 		return

--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -550,6 +550,9 @@ func (c *Direct) sendMapRequest(ctx context.Context, maxPolls int, cb func(*Netw
 	everEndpoints := c.everEndpoints
 	c.mu.Unlock()
 
+	if persist.PrivateNodeKey.IsZero() {
+		return errors.New("privateNodeKey is zero")
+	}
 	if backendLogID == "" {
 		return errors.New("hostinfo: BackendLogID missing")
 	}


### PR DESCRIPTION
Fixes #1271
