### PR TITLE
tstest/natlab: use net.ErrClosed instead of a new error

### DIFF
--- a/net/stun/stuntest/stuntest.go
+++ b/net/stun/stuntest/stuntest.go
@@ -59,6 +59,7 @@ func runSTUN(t *testing.T, pc net.PacketConn, stats *stunStats, done chan<- stru
 	for {
 		n, addr, err := pc.ReadFrom(buf[:])
 		if err != nil {
+			// TODO: when we switch to Go 1.16, replace this with errors.Is(err, net.ErrClosed)
 			if strings.Contains(err.Error(), "closed network connection") {
 				t.Logf("STUN server shutdown")
 				return

--- a/tstest/natlab/natlab.go
+++ b/tstest/natlab/natlab.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"time"
 
+	wgconn "github.com/tailscale/wireguard-go/conn"
 	"inet.af/netaddr"
 )
 
@@ -758,7 +759,8 @@ func (c *conn) canRead() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.closed {
-		return errors.New("closed network connection") // sadface: magic string used by other; don't change
+		// TODO: when we switch to Go 1.16, replace this with net.ErrClosed
+		return wgconn.NetErrClosed
 	}
 	if !c.readDeadline.IsZero() && c.readDeadline.Before(time.Now()) {
 		return errors.New("read deadline exceeded")


### PR DESCRIPTION
Upstream wireguard-go decided to use errors.Is(err, net.ErrClosed)
instead of checking the error string.

It also provided an unsafe linknamed version of net.ErrClosed
for clients running Go 1.15. Switch to that.

This reduces the time required for the wgengine/magicsock tests
on my machine from ~35s back to the ~13s it was before
456cf8a3765948d6f1992162993eaf3844371592.
