### PR TITLE
cmd/tailscale/cli: display currently active exit node in `tailscale status`.

### DIFF
--- a/cmd/tailscale/cli/status.go
+++ b/cmd/tailscale/cli/status.go
@@ -159,13 +159,18 @@ func runStatus(ctx context.Context, args []string) error {
 		relay := ps.Relay
 		anyTraffic := ps.TxBytes != 0 || ps.RxBytes != 0
 		if !active {
-			if anyTraffic {
+			if ps.ExitNode {
+				f("idle; exit node")
+			} else if anyTraffic {
 				f("idle")
 			} else {
 				f("-")
 			}
 		} else {
 			f("active; ")
+			if ps.ExitNode {
+				f("exit node; ")
+			}
 			if relay != "" && ps.CurAddr == "" {
 				f("relay %q", relay)
 			} else if ps.CurAddr != "" {

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -233,6 +233,7 @@ func (b *LocalBackend) UpdateStatus(sb *ipnstate.StatusBuilder) {
 				Created:      p.Created,
 				LastSeen:     lastSeen,
 				ShareeNode:   p.Hostinfo.ShareeNode,
+				ExitNode:     p.StableID != "" && p.StableID == b.prefs.ExitNodeID,
 			})
 		}
 	}

--- a/ipn/ipnstate/ipnstate.go
+++ b/ipn/ipnstate/ipnstate.go
@@ -77,6 +77,7 @@ type PeerStatus struct {
 	LastSeen      time.Time // last seen to tailcontrol
 	LastHandshake time.Time // with local wireguard
 	KeepAlive     bool
+	ExitNode      bool // true if this is the currently selected exit node.
 
 	// ShareeNode indicates this node exists in the netmap because
 	// it's owned by a shared-to user and that node might connect
@@ -243,6 +244,9 @@ func (sb *StatusBuilder) AddPeer(peer key.Public, st *PeerStatus) {
 	}
 	if st.KeepAlive {
 		e.KeepAlive = true
+	}
+	if st.ExitNode {
+		e.ExitNode = true
 	}
 	if st.ShareeNode {
 		e.ShareeNode = true


### PR DESCRIPTION
Signed-off-by: David Anderson <danderson@tailscale.com>