### PR TITLE
wgengine/magicsock: increase legacy ping timeout again

### DIFF
--- a/util/cibuild/cibuild.go
+++ b/util/cibuild/cibuild.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package cibuild reports runtime CI information.
+package cibuild
+
+import "os"
+
+// On reports whether the current binary is executing on a CI system.
+func On() bool {
+	return os.Getenv("GITHUB_ACTIONS") != ""
+}


### PR DESCRIPTION
I based my estimation of the required timeout based on locally
observed behavior. But CI machines are worse than my local machine.
16s was enough to reduce flakiness but not eliminate it. Bump it up again.
