### PR TITLE
logtail/filch: use bufio.ScanLines

### DIFF
--- a/logtail/filch/filch.go
+++ b/logtail/filch/filch.go
@@ -8,7 +8,6 @@ package filch
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -53,7 +52,6 @@ func (f *Filch) TryReadLine() ([]byte, error) {
 		return nil, err
 	}
 	f.altscan = bufio.NewScanner(f.alt)
-	f.altscan.Split(splitLines)
 	return f.scan()
 }
 
@@ -188,7 +186,6 @@ func New(filePrefix string, opts Options) (f *Filch, err error) {
 	}
 	if f.recovered > 0 {
 		f.altscan = bufio.NewScanner(f.alt)
-		f.altscan.Split(splitLines)
 	}
 
 	f.OrigStderr = nil
@@ -227,17 +224,4 @@ func moveContents(dst, src *os.File) (err error) {
 		return err
 	}
 	return nil
-}
-
-func splitLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
-	if atEOF && len(data) == 0 {
-		return 0, nil, nil
-	}
-	if i := bytes.IndexByte(data, '\n'); i >= 0 {
-		return i + 1, data[0 : i+1], nil
-	}
-	if atEOF {
-		return len(data), data, nil
-	}
-	return 0, nil, nil
 }


### PR DESCRIPTION
splitLines here is identical to bufio.ScanLines, except that bufio.ScanLines removes \r in addition to \n.
Trailing carriage returns shouldn't matter for our uses.
Since bufio.ScanLines is the default for a new bufio.Scanner, we can delete the calls to Split too.

If I'm wrong about that, I'm very curious to hear the details!
