### PR TITLE
wgengine/magicsock: simplify and remove an alloc on receive

### DIFF
--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -1552,6 +1552,7 @@ func addTestEndpoint(conn *Conn, sendConn net.PacketConn) (tailcfg.NodeKey, tail
 func BenchmarkReceiveFrom(b *testing.B) {
 	conn := newNonLegacyTestConn(b)
 	defer conn.Close()
+	conn.logf = logger.Discard
 
 	sendConn, err := net.ListenPacket("udp4", "127.0.0.1:0")
 	if err != nil {


### PR DESCRIPTION
This is part cleanup and part optimization.

See each commit message for details.

The optimization won't really kick in until we pull in our upstream standard library optimization, but it doesn't do any harm in the meanwhile either.

Paired with @soniaappasamy.
