### PR TITLE
wgengine/magicsock: reduce log spam during tests

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -2775,10 +2775,11 @@ func (c *RebindingUDPConn) ReadFromNetaddr(b []byte) (n int, ipp netaddr.IPPort,
 		} else {
 			var addr net.Addr
 			n, addr, err = pconn.ReadFrom(b)
-			var ok2 bool
-			pAddr, ok2 = addr.(*net.UDPAddr)
-			if !ok2 {
-				return 0, netaddr.IPPort{}, fmt.Errorf("RebindingUDPConn.ReadFromNetaddr: underlying connection returned address of type %T, want *netaddr.UDPAddr", addr)
+			if addr != nil {
+				pAddr, ok = addr.(*net.UDPAddr)
+				if !ok {
+					return 0, netaddr.IPPort{}, fmt.Errorf("RebindingUDPConn.ReadFromNetaddr: underlying connection returned address of type %T, want *netaddr.UDPAddr", addr)
+				}
 			}
 		}
 


### PR DESCRIPTION
Only do the type assertion to *net.UDPAddr when addr is non-nil.
This prevents a bunch of log spam during tests.