### PR TITLE
net/{interfaces,netns}: add some new tests, missed from prior commit

### DIFF
--- a/net/interfaces/interfaces_default_route_test.go
+++ b/net/interfaces/interfaces_default_route_test.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux darwin,!redo
+
+package interfaces
+
+import "testing"
+
+func TestDefaultRouteInterface(t *testing.T) {
+	v, err := DefaultRouteInterface()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("got %q", v)
+}

--- a/net/netns/netns_test.go
+++ b/net/netns/netns_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package netns contains the common code for using the Go net package
+// in a logical "network namespace" to avoid routing loops where
+// Tailscale-created packets would otherwise loop back through
+// Tailscale routes.
+//
+// Despite the name netns, the exact mechanism used differs by
+// operating system, and perhaps even by version of the OS.
+//
+// The netns package also handles connecting via SOCKS proxies when
+// configured by the environment.
+package netns
+
+import (
+	"flag"
+	"testing"
+)
+
+var extNetwork = flag.Bool("use-external-network", false, "use the external network in tests")
+
+func TestDial(t *testing.T) {
+	if !*extNetwork {
+		t.Skip("skipping test without --use-external-network")
+	}
+	d := NewDialer()
+	c, err := d.Dial("tcp", "google.com:80")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	t.Logf("got addr %v", c.RemoteAddr())
+
+	c, err = d.Dial("tcp4", "google.com:80")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	t.Logf("got addr %v", c.RemoteAddr())
+}


### PR DESCRIPTION
I meant for these to be part of 52e24aa966ffa.