### PR TITLE
net/tshttpproxy: support Basic auth

### DIFF
--- a/net/tshttpproxy/tshttpproxy.go
+++ b/net/tshttpproxy/tshttpproxy.go
@@ -74,6 +74,18 @@ func GetAuthHeader(u *url.URL) (string, error) {
 	if sysAuthHeader != nil {
 		return sysAuthHeader(u)
 	}
+
+	if user := u.User.Username(); user != "" {
+		pass, ok := u.User.Password()
+		if !ok {
+			return "", nil
+		}
+
+		req := &http.Request{Header: make(http.Header)}
+		req.SetBasicAuth(user, pass)
+		return req.Header.Get("Authorization"), nil
+	}
+
 	return "", nil
 }
 

--- a/net/tshttpproxy/tshttpproxy_test.go
+++ b/net/tshttpproxy/tshttpproxy_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !windows
+
+package tshttpproxy
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestGetAuthHeaderNoResult(t *testing.T) {
+	const proxyURL = `http://127.0.0.1:38274`
+
+	u, err := url.Parse(proxyURL)
+	if err != nil {
+		t.Fatalf("can't parse %q: %v", proxyURL, err)
+	}
+
+	ahval, err := GetAuthHeader(u)
+	if err != nil {
+		t.Fatalf("can't get auth header value: %v", err)
+	}
+
+	if ahval != "" {
+		t.Fatalf("wanted auth header value to be empty, got: %q", ahval)
+	}
+}
+
+func TestGetAuthHeaderBasicAuth(t *testing.T) {
+	const proxyURL = `http://user:password@127.0.0.1:38274`
+	const expect = `Basic dXNlcjpwYXNzd29yZA==`
+
+	u, err := url.Parse(proxyURL)
+	if err != nil {
+		t.Fatalf("can't parse %q: %v", proxyURL, err)
+	}
+
+	ahval, err := GetAuthHeader(u)
+	if err != nil {
+		t.Fatalf("can't get auth header value: %v", err)
+	}
+
+	if ahval != expect {
+		t.Fatalf("wrong auth header value: want: %q, got: %q", expect, ahval)
+	}
+}


### PR DESCRIPTION
This closes #1047.

- [x] Fix the panic
- [x] Fix the HTTP proxy connection issue
- [x] Add tests 

```
magicsock: [0xc0004f00c0] derp.Recv(derp-1): derphttp.Client.Recv connect to region 1 (nyc): invalid response status from HTTP proxy http://azurediamond:hunter2@192.168.122.154:38274 on CONNECT to derp1.tailscale.com:443: 407 Proxy Authentication Required
derp-1: backoff: 7131 msec
```

Signed-off-by: Christine Dodrill <xe@tailscale.com>