### PR TITLE
ipn/ipnserver: fix Windows connection auth regression

### DIFF
--- a/ipn/ipnserver/server.go
+++ b/ipn/ipnserver/server.go
@@ -312,6 +312,11 @@ func (s *server) serveConn(ctx context.Context, c net.Conn, logf logger.Logf) {
 }
 
 func isReadonlyConn(c net.Conn, logf logger.Logf) bool {
+	if runtime.GOOS == "windows" {
+		// Windows doesn't need/use this mechanism, at least yet. It
+		// has a different last-user-wins auth model.
+		return false
+	}
 	const ro = true
 	const rw = false
 	creds, err := peercred.Get(c)


### PR DESCRIPTION
Regression from code movement in d3efe8caf636aaa9a8e02b65877878954ea980b7

Signed-off-by: Brad Fitzpatrick <bradfitz@tailscale.com>