### PR TITLE
wgengine/monitor: skip some macOS route updates, fix debounce regression

### DIFF
--- a/wgengine/monitor/monitor_test.go
+++ b/wgengine/monitor/monitor_test.go
@@ -5,7 +5,10 @@
 package monitor
 
 import (
+	"flag"
 	"testing"
+
+	"tailscale.com/net/interfaces"
 )
 
 func TestMonitorStartClose(t *testing.T) {
@@ -26,5 +29,37 @@ func TestMonitorJustClose(t *testing.T) {
 	}
 	if err := mon.Close(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+var monitor = flag.String("monitor", "", `go into monitor mode like 'route monitor'; test never terminates. Value can be either "raw" or "callback"`)
+
+func TestMonitorMode(t *testing.T) {
+	switch *monitor {
+	case "":
+		t.Skip("skipping non-test without --monitor")
+	case "raw", "callback":
+	default:
+		t.Skipf(`invalid --monitor value: must be "raw" or "callback"`)
+	}
+	mon, err := New(t.Logf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	switch *monitor {
+	case "raw":
+		for {
+			msg, err := mon.om.Receive()
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("msg: %#v", msg)
+		}
+	case "callback":
+		mon.RegisterChangeCallback(func(changed bool, st *interfaces.State) {
+			t.Logf("cb: changed=%v, ifSt=%v", changed, st)
+		})
+		mon.Start()
+		select {}
 	}
 }


### PR DESCRIPTION
Turning my wifi on & off now in the new debug mode, I see the output below.

Notably, note the:

```
    logger.go:33: monitor: coalesced 33 changes
...
    logger.go:33: monitor: coalesced 18 changes

=== RUN   TestMonitorMode
    logger.go:33: monitor: read 140 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 96 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: coalesced 2 changes
    monitor_test.go:60: cb: changed=true, ifSt=interfaces.State{defaultRoute=en0 ifs={en0:[10.0.0.85/16 2602:d1:b4cf:c100:1438:63ab:fe13:8130/64 2602:d1:b4cf:c100:21a5:9f19:ea0a:9f0a/64] en1:[10.0.0.86/16 2602:d1:b4cf:c100:44f:9bf7:1c78:4a4b/64 2602:d1:b4cf:c100:4cb8:5e95:9425:93d9/64]} v4=true v6global=true}
    logger.go:33: monitor: read 140 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 96 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 112 bytes with no messages (70 00 05 0e 00 00 00 00 02 88 00 00 09 00 00 00 06 00 00 06 0e 00 00 00 00 09 00 00 00 00 00 00 80 96 98 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 c8 66 30 60 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00)
    logger.go:33: monitor: read 112 bytes with no messages (70 00 05 0e 00 00 00 00 02 89 00 00 0a 00 00 00 06 00 00 06 0e 00 00 00 cc 05 00 00 00 00 00 00 80 96 98 00 85 2b 00 00 00 00 00 00 68 19 00 00 00 00 00 00 00 00 00 00 dd 3f 33 00 a1 ad 2f 00 f7 13 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 c8 66 30 60 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 140 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 96 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 140 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 96 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 140 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 96 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 172 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 172 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 172 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 172 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 172 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 172 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: coalesced 33 changes
    monitor_test.go:60: cb: changed=true, ifSt=interfaces.State{defaultRoute=en0 ifs={en0:[10.0.0.85/16 2602:d1:b4cf:c100:1438:63ab:fe13:8130/64 2602:d1:b4cf:c100:21a5:9f19:ea0a:9f0a/64]} v4=true v6global=true}
    logger.go:33: monitor: read 112 bytes with no messages (70 00 05 0e 00 00 00 00 03 88 00 00 09 00 00 00 06 00 00 06 0e 00 00 00 00 09 00 00 00 00 00 00 80 96 98 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 de 66 30 60 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00)
    logger.go:33: monitor: read 112 bytes with no messages (70 00 05 0e 00 00 00 00 03 89 00 00 0a 00 00 00 06 00 00 06 0e 00 00 00 cc 05 00 00 00 00 00 00 80 96 98 00 85 2b 00 00 00 00 00 00 68 19 00 00 00 00 00 00 00 00 00 00 dd 3f 33 00 a1 ad 2f 00 f7 13 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 de 66 30 60 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00)
    logger.go:33: monitor: read 96 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 140 bytes, 1 messages (0 skipped)
    monitor_test.go:60: cb: changed=true, ifSt=interfaces.State{defaultRoute=en0 ifs={en0:[10.0.0.85/16 2602:d1:b4cf:c100:1438:63ab:fe13:8130/64 2602:d1:b4cf:c100:21a5:9f19:ea0a:9f0a/64]} v4=true v6global=true}
    logger.go:33: monitor: read 96 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 140 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: coalesced 3 changes
    monitor_test.go:60: cb: changed=true, ifSt=interfaces.State{defaultRoute=en0 ifs={en0:[10.0.0.85/16 2602:d1:b4cf:c100:1438:63ab:fe13:8130/64 2602:d1:b4cf:c100:21a5:9f19:ea0a:9f0a/64]} v4=true v6global=true}
    logger.go:33: monitor: read 96 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 140 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: coalesced 2 changes
    monitor_test.go:60: cb: changed=true, ifSt=interfaces.State{defaultRoute=en0 ifs={en0:[10.0.0.85/16 2602:d1:b4cf:c100:1438:63ab:fe13:8130/64 2602:d1:b4cf:c100:21a5:9f19:ea0a:9f0a/64]} v4=true v6global=true}
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 180 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 176 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 180 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 180 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 180 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 180 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 180 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 96 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 140 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 96 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 140 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: coalesced 18 changes
    monitor_test.go:60: cb: changed=true, ifSt=interfaces.State{defaultRoute=en0 ifs={en0:[10.0.0.85/16 2602:d1:b4cf:c100:1438:63ab:fe13:8130/64 2602:d1:b4cf:c100:21a5:9f19:ea0a:9f0a/64] en1:[10.0.0.86/16 2602:d1:b4cf:c100:44f:9bf7:1c78:4a4b/64 2602:d1:b4cf:c100:4c11:5da8:c75e:d26e/64]} v4=true v6global=true}
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: read 164 bytes, 1 messages (0 skipped)
    logger.go:33: monitor: coalesced 2 changes
    monitor_test.go:60: cb: changed=false, ifSt=interfaces.State{defaultRoute=en0 ifs={en0:[10.0.0.85/16 2602:d1:b4cf:c100:1438:63ab:fe13:8130/64 2602:d1:b4cf:c100:21a5:9f19:ea0a:9f0a/64] en1:[10.0.0.86/16 2602:d1:b4cf:c100:44f:9bf7:1c78:4a4b/64 2602:d1:b4cf:c100:4c11:5da8:c75e:d26e/64]} v4=true v6global=true}
```