### PR TITLE
safesocket, ipn/ipnserver: unify peercred info, fix bug on FreeBSD etc

### DIFF
--- a/ipn/ipnserver/server.go
+++ b/ipn/ipnserver/server.go
@@ -319,6 +319,9 @@ func isReadonlyConn(c net.Conn, logf logger.Logf) bool {
 	}
 	const ro = true
 	const rw = false
+	if !safesocket.PlatformUsesPeerCreds() {
+		return rw
+	}
 	creds, err := peercred.Get(c)
 	if err != nil {
 		logf("connection from unknown peer; read-only")

--- a/safesocket/safesocket.go
+++ b/safesocket/safesocket.go
@@ -65,3 +65,13 @@ func LocalTCPPortAndToken() (port int, token string, err error) {
 	}
 	return localTCPPortAndToken()
 }
+
+// PlatformUsesPeerCreds reports whether the current platform uses peer credentials
+// to authenticate connections.
+func PlatformUsesPeerCreds() bool {
+	switch runtime.GOOS {
+	case "linux", "darwin":
+		return true
+	}
+	return false
+}

--- a/safesocket/unixsocket.go
+++ b/safesocket/unixsocket.go
@@ -103,21 +103,7 @@ func tailscaledRunningUnderLaunchd() bool {
 // socketPermissionsForOS returns the permissions to use for the
 // tailscaled.sock.
 func socketPermissionsForOS() os.FileMode {
-	switch runtime.GOOS {
-	case "linux", "darwin":
-		// On Linux and Darwin, the ipn/ipnserver package looks at the Unix peer creds
-		// and only permits read-only actions from non-root users, so we want
-		// this opened up wider.
-		//
-		// TODO(bradfitz): unify this all one in place probably, moving some
-		// of ipnserver (which does much of the "safe" bits) here. Maybe
-		// instead of net.Listener, we should return a type that returns
-		// an identity in addition to a net.Conn? (returning a wrapped net.Conn
-		// would surprise downstream callers probably)
-		//
-		// TODO(bradfitz): if OpenBSD and FreeBSD do the equivalent peercreds
-		// stuff that's in ipn/ipnserver/conn_ucred.go, they should also
-		// return 0666 here.
+	if PlatformUsesPeerCreds() {
 		return 0666
 	}
 	// Otherwise, root only.


### PR DESCRIPTION
FreeBSD wasn't able to run "tailscale up" since the recent peercred
refactoring.