### PR TITLE
net/tshttpproxy: call winhttp calls from a fixed OS thread

### DIFF
--- a/net/tshttpproxy/tshttpproxy_windows.go
+++ b/net/tshttpproxy/tshttpproxy_windows.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -109,6 +110,9 @@ func proxyFromWinHTTPOrCache(req *http.Request) (*url.URL, error) {
 }
 
 func proxyFromWinHTTP(ctx context.Context, urlStr string) (proxy *url.URL, err error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	whi, err := winHTTPOpen()
 	if err != nil {
 		proxyErrorf("winhttp: Open: %v", err)


### PR DESCRIPTION
We often see things in logs like:

```
2021-03-02 17:52:45.2456258 +0800 +0800: winhttp: Open: The parameter is incorrect.
2021-03-02 17:52:45.2506261 +0800 +0800: tshttpproxy: winhttp: GetProxyForURL("https://log.tailscale.io/c/tailnode.log.tailscale.io/5037bb42f4bc330e2d6143e191a7ff7e837c6be538139231de69a439536e0d68"): ERROR_INVALID_PARAMETER [unexpected]
```

I have a hunch that WinHTTP has thread-local state. If so, this would fix it.
If not, this is pretty harmless.
