### PR TITLE
wgengine{,/monitor}: restore Engine.LinkChange, add Mon.InjectEvent

### DIFF
--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -1251,6 +1251,12 @@ func (e *userspaceEngine) GetLinkMonitor() *monitor.Mon {
 	return e.linkMon
 }
 
+// LinkChange signals a network change event. It's currently
+// (2021-03-03) only called on Android.
+func (e *userspaceEngine) LinkChange(_ bool) {
+	e.linkMon.InjectEvent()
+}
+
 func (e *userspaceEngine) linkChange(changed bool, cur *interfaces.State) {
 	up := cur.AnyInterfaceUp()
 	if !up {

--- a/wgengine/watchdog.go
+++ b/wgengine/watchdog.go
@@ -99,6 +99,9 @@ func (e *watchdogEngine) SetNetInfoCallback(cb NetInfoCallback) {
 func (e *watchdogEngine) RequestStatus() {
 	e.watchdog("RequestStatus", func() { e.wrap.RequestStatus() })
 }
+func (e *watchdogEngine) LinkChange(isExpensive bool) {
+	e.watchdog("LinkChange", func() { e.wrap.LinkChange(isExpensive) })
+}
 func (e *watchdogEngine) SetDERPMap(m *tailcfg.DERPMap) {
 	e.watchdog("SetDERPMap", func() { e.wrap.SetDERPMap(m) })
 }

--- a/wgengine/wgengine.go
+++ b/wgengine/wgengine.go
@@ -89,6 +89,21 @@ type Engine interface {
 	// TODO: return an error?
 	Wait()
 
+	// LinkChange informs the engine that the system network
+	// link has changed.
+	//
+	// The isExpensive parameter is not used.
+	//
+	// LinkChange should be called whenever something changed with
+	// the network, no matter how minor.
+	//
+	// Deprecated: don't use this method. It was removed shortly
+	// before the Tailscale 1.6 release when we remembered that
+	// Android doesn't use the Linux-based link monitor and has
+	// its own mechanism that uses LinkChange. Android is the only
+	// caller of this method now. Don't add more.
+	LinkChange(isExpensive bool)
+
 	// SetDERPMap controls which (if any) DERP servers are used.
 	// If nil, DERP is disabled. It starts disabled until a DERP map
 	// is configured.


### PR DESCRIPTION
Rather than do some last minute rearchitecting of link state on
Android, just restore the old Engine.LinkChange hook (so the Android
client doesn't need any changes), but change how it's implemented to
instead inject an event into the link monitor.

Fixes #1427
