### PR TITLE
net/interfaces: sort returned addresses from LocalAddresses

### DIFF
--- a/net/interfaces/interfaces.go
+++ b/net/interfaces/interfaces.go
@@ -78,7 +78,7 @@ func isProblematicInterface(nif *net.Interface) bool {
 
 // LocalAddresses returns the machine's IP addresses, separated by
 // whether they're loopback addresses.
-func LocalAddresses() (regular, loopback []string, err error) {
+func LocalAddresses() (regular, loopback []netaddr.IP, err error) {
 	// TODO(crawshaw): don't serve interface addresses that we are routing
 	ifaces, err := net.Interfaces()
 	if err != nil {
@@ -117,14 +117,20 @@ func LocalAddresses() (regular, loopback []string, err error) {
 					continue
 				}
 				if ip.IsLoopback() || ifcIsLoopback {
-					loopback = append(loopback, ip.String())
+					loopback = append(loopback, ip)
 				} else {
-					regular = append(regular, ip.String())
+					regular = append(regular, ip)
 				}
 			}
 		}
 	}
+	sortIPs(regular)
+	sortIPs(loopback)
 	return regular, loopback, nil
+}
+
+func sortIPs(s []netaddr.IP) {
+	sort.Slice(s, func(i, j int) bool { return s[i].Less(s[j]) })
 }
 
 // Interface is a wrapper around Go's net.Interface with some extra methods.

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -1055,8 +1055,8 @@ func (c *Conn) determineEndpoints(ctx context.Context) (ipPorts []string, reason
 			ips = loopback
 			reason = "loopback"
 		}
-		for _, ipStr := range ips {
-			addAddr(net.JoinHostPort(ipStr, fmt.Sprint(localAddr.Port)), reason)
+		for _, ip := range ips {
+			addAddr(netaddr.IPPort{IP: ip, Port: uint16(localAddr.Port)}.String(), reason)
 		}
 	} else {
 		// Our local endpoint is bound to a particular address.


### PR DESCRIPTION
Also change the type to netaddr.IP while here, because it made sorting
easier.

Updates tailscale/corp#1397
