### PR TITLE
wgengine/magicsock, derp, derp/derphttp: respond to DERP server->client pings

### DIFF
--- a/derp/derp.go
+++ b/derp/derp.go
@@ -59,7 +59,8 @@ Login:
 * server sends frameServerInfo
 
 Steady state:
-* server occasionally sends frameKeepAlive
+* server occasionally sends frameKeepAlive (or framePing)
+* client responds to any framePing with a framePong
 * client sends frameSendPacket
 * server then sends frameRecvPacket to recipient
 */
@@ -97,6 +98,9 @@ const (
 	// connection. (To be used for cluster load balancing
 	// purposes, when clients end up on a non-ideal node)
 	frameClosePeer = frameType(0x11) // 32B pub key of peer to close.
+
+	framePing = frameType(0x12) // 8 byte ping payload, to be echoed back in framePong
+	framePong = frameType(0x13) // 8 byte payload, the contents of the ping being replied to
 )
 
 var bin = binary.BigEndian

--- a/derp/derphttp/derphttp_client.go
+++ b/derp/derphttp/derphttp_client.go
@@ -642,6 +642,29 @@ func (c *Client) ForwardPacket(from, to key.Public, b []byte) error {
 	return err
 }
 
+// SendPong sends a reply to a ping, with the ping's provided
+// challenge/identifier data.
+//
+// Unlike other send methods, SendPong makes no attempt to connect or
+// reconnect to the peer. It's best effort. If there's a connection
+// problem, the server will choose to hang up on us if we're not
+// replying.
+func (c *Client) SendPong(data [8]byte) error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return ErrClientClosed
+	}
+	if c.client == nil {
+		c.mu.Unlock()
+		return errors.New("not connected")
+	}
+	dc := c.client
+	c.mu.Unlock()
+
+	return dc.SendPong(data)
+}
+
 // NotePreferred notes whether this Client is the caller's preferred
 // (home) DERP node. It's only used for stats.
 func (c *Client) NotePreferred(v bool) {

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -1465,6 +1465,15 @@ func (c *Conn) runDerpReader(ctx context.Context, derpFakeAddr netaddr.IPPort, d
 				peerPresent[m.Source] = true
 				c.addDerpPeerRoute(m.Source, regionID, dc)
 			}
+		case derp.PingMessage:
+			// Best effort reply to the ping.
+			pingData := [8]byte(m)
+			go func() {
+				if err := dc.SendPong(pingData); err != nil {
+					c.logf("magicsock: derp-%d SendPong error: %v", regionID, err)
+				}
+			}()
+			continue
 		default:
 			// Ignore.
 			continue


### PR DESCRIPTION
No server support yet, but we want Tailscale 1.6 clients to be able to respond
to them when the server can do it.

Updates #1310