### PR TITLE
wgengine/filter: only log packets to/from non-default routes.

### DIFF
--- a/net/packet/packet.go
+++ b/net/packet/packet.go
@@ -116,6 +116,12 @@ func (q *Parsed) Decode(b []byte) {
 	}
 }
 
+// StuffForTesting makes Parsed contain a len-bytes buffer. Used in
+// tests to build up a synthetic parse result with a non-zero buffer.
+func (q *Parsed) StuffForTesting(len int) {
+	q.b = make([]byte, len)
+}
+
 func (q *Parsed) decode4(b []byte) {
 	if len(b) < ip4HeaderLength {
 		q.IPVersion = 0

--- a/wgengine/tstun/tun_test.go
+++ b/wgengine/tstun/tun_test.go
@@ -112,7 +112,7 @@ func setfilter(logf logger.Logf, tun *TUN) {
 	}
 	var sb netaddr.IPSetBuilder
 	sb.AddPrefix(netaddr.MustParseIPPrefix("1.2.0.0/16"))
-	tun.SetFilter(filter.New(matches, sb.IPSet(), nil, logf))
+	tun.SetFilter(filter.New(matches, sb.IPSet(), sb.IPSet(), nil, logf))
 }
 
 func newChannelTUN(logf logger.Logf, secure bool) (*tuntest.ChannelTUN, *TUN) {


### PR DESCRIPTION
Fixes tailscale/corp#1429.

Signed-off-by: David Anderson <danderson@tailscale.com>