### PR TITLE
wgengine: pass logger as a separate arg to device.NewDevice

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/peterbourgon/ff/v2 v2.0.0
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/tailscale/depaware v0.0.0-20201214215404-77d1e9757027
-	github.com/tailscale/wireguard-go v0.0.0-20210210202228-3cc76ed5f222
+	github.com/tailscale/wireguard-go v0.0.0-20210324165952-2963b66bc23a
 	github.com/tcnksm/go-httpstat v0.2.0
 	github.com/toqueteos/webbrowser v1.2.0
 	go4.org/mem v0.0.0-20201119185036-c04c5a6ff174

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/tailscale/depaware v0.0.0-20201214215404-77d1e9757027 h1:lK99QQdH3yBW
 github.com/tailscale/depaware v0.0.0-20201214215404-77d1e9757027/go.mod h1:p9lPsd+cx33L3H9nNoecRRxPssFKUwwI50I3pZ0yT+8=
 github.com/tailscale/wireguard-go v0.0.0-20210210202228-3cc76ed5f222 h1:VzTS7LIwCH8jlxwrZguU0TsCLV/MDOunoNIDJdFajyM=
 github.com/tailscale/wireguard-go v0.0.0-20210210202228-3cc76ed5f222/go.mod h1:6t0OVdJwFOKFnvaHaVMKG6GznWaHqkmiR2n3kH0t924=
+github.com/tailscale/wireguard-go v0.0.0-20210324165952-2963b66bc23a h1:tQ7Y0ALSe5109GMFB7TVtfNBsVcAuM422hVSJrXWMTE=
+github.com/tailscale/wireguard-go v0.0.0-20210324165952-2963b66bc23a/go.mod h1:6t0OVdJwFOKFnvaHaVMKG6GznWaHqkmiR2n3kH0t924=
 github.com/tcnksm/go-httpstat v0.2.0 h1:rP7T5e5U2HfmOBmZzGgGZjBQ5/GluWUylujl0tJ04I0=
 github.com/tcnksm/go-httpstat v0.2.0/go.mod h1:s3JVJFtQxtBEBC9dwcdTTXS9xFnM3SXAZwPG41aurT8=
 github.com/toqueteos/webbrowser v1.2.0 h1:tVP/gpK69Fx+qMJKsLE7TD8LuGWPnEV71wBN9rrstGQ=

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -170,12 +170,12 @@ func newMagicStack(t testing.TB, logf logger.Logf, l nettype.PacketListener, der
 	tsTun.SetFilter(filter.NewAllowAllForTest(logf))
 
 	wgLogger := wglog.NewLogger(logf)
-	dev := device.NewDevice(tsTun, &device.DeviceOptions{
-		Logger:         wgLogger.DeviceLogger,
+	opts := &device.DeviceOptions{
 		CreateEndpoint: conn.CreateEndpoint,
 		CreateBind:     conn.CreateBind,
 		SkipBindUpdate: true,
-	})
+	}
+	dev := device.NewDevice(tsTun, wgLogger.DeviceLogger, opts)
 	dev.Up()
 
 	// Wait for magicsock to connect up to DERP.
@@ -522,12 +522,13 @@ func TestDeviceStartStop(t *testing.T) {
 	defer conn.Close()
 
 	tun := tuntest.NewChannelTUN()
-	dev := device.NewDevice(tun.TUN(), &device.DeviceOptions{
-		Logger:         wglog.NewLogger(t.Logf).DeviceLogger,
+	wgLogger := wglog.NewLogger(t.Logf)
+	opts := &device.DeviceOptions{
 		CreateEndpoint: conn.CreateEndpoint,
 		CreateBind:     conn.CreateBind,
 		SkipBindUpdate: true,
-	})
+	}
+	dev := device.NewDevice(tun.TUN(), wgLogger.DeviceLogger, opts)
 	dev.Up()
 	dev.Close()
 }

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -304,7 +304,6 @@ func newUserspaceEngine(logf logger.Logf, rawTUNDev tun.Device, conf Config) (_ 
 
 	e.wgLogger = wglog.NewLogger(logf)
 	opts := &device.DeviceOptions{
-		Logger: e.wgLogger.DeviceLogger,
 		HandshakeDone: func(peerKey device.NoisePublicKey, peer *device.Peer, deviceAllowedIPs *device.AllowedIPs) {
 			// Send an unsolicited status event every time a
 			// handshake completes. This makes sure our UI can
@@ -365,7 +364,7 @@ func newUserspaceEngine(logf logger.Logf, rawTUNDev tun.Device, conf Config) (_ 
 
 	// wgdev takes ownership of tundev, will close it when closed.
 	e.logf("Creating wireguard device...")
-	e.wgdev = device.NewDevice(e.tundev, opts)
+	e.wgdev = device.NewDevice(e.tundev, e.wgLogger.DeviceLogger, opts)
 	closePool.addFunc(e.wgdev.Close)
 
 	// Pass the underlying tun.(*NativeDevice) to the router:

--- a/wgengine/wgcfg/device_test.go
+++ b/wgengine/wgcfg/device_test.go
@@ -55,12 +55,8 @@ func TestDeviceConfig(t *testing.T) {
 		}},
 	}
 
-	device1 := device.NewDevice(newNilTun(), &device.DeviceOptions{
-		Logger: device.NewLogger(device.LogLevelError, "device1"),
-	})
-	device2 := device.NewDevice(newNilTun(), &device.DeviceOptions{
-		Logger: device.NewLogger(device.LogLevelError, "device2"),
-	})
+	device1 := device.NewDevice(newNilTun(), device.NewLogger(device.LogLevelError, "device1"))
+	device2 := device.NewDevice(newNilTun(), device.NewLogger(device.LogLevelError, "device2"))
 	defer device1.Close()
 	defer device2.Close()
 


### PR DESCRIPTION
Adapt to minor API changes in wireguard-go.
And factor out device.DeviceOptions variables.
