### PR TITLE
wgengine/router: remove unused wireguard *Device argument.

### DIFF
--- a/wgengine/router/router.go
+++ b/wgengine/router/router.go
@@ -7,7 +7,6 @@
 package router
 
 import (
-	"github.com/tailscale/wireguard-go/device"
 	"github.com/tailscale/wireguard-go/tun"
 	"inet.af/netaddr"
 	"tailscale.com/net/dns"
@@ -33,9 +32,9 @@ type Router interface {
 
 // New returns a new Router for the current platform, using the
 // provided tun device.
-func New(logf logger.Logf, wgdev *device.Device, tundev tun.Device) (Router, error) {
+func New(logf logger.Logf, tundev tun.Device) (Router, error) {
 	logf = logger.WithPrefix(logf, "router: ")
-	return newUserspaceRouter(logf, wgdev, tundev)
+	return newUserspaceRouter(logf, tundev)
 }
 
 // Cleanup restores the system network configuration to its original state

--- a/wgengine/router/router_darwin.go
+++ b/wgengine/router/router_darwin.go
@@ -5,13 +5,12 @@
 package router
 
 import (
-	"github.com/tailscale/wireguard-go/device"
 	"github.com/tailscale/wireguard-go/tun"
 	"tailscale.com/types/logger"
 )
 
-func newUserspaceRouter(logf logger.Logf, wgdev *device.Device, tundev tun.Device) (Router, error) {
-	return newUserspaceBSDRouter(logf, wgdev, tundev)
+func newUserspaceRouter(logf logger.Logf, tundev tun.Device) (Router, error) {
+	return newUserspaceBSDRouter(logf, tundev)
 }
 
 func cleanup(logger.Logf, string) {

--- a/wgengine/router/router_default.go
+++ b/wgengine/router/router_default.go
@@ -7,13 +7,12 @@
 package router
 
 import (
-	"github.com/tailscale/wireguard-go/device"
 	"github.com/tailscale/wireguard-go/tun"
 	"tailscale.com/types/logger"
 )
 
-func newUserspaceRouter(logf logger.Logf, tunname string, dev *device.Device, tunDev tun.Device, netChanged func()) Router {
-	return NewFakeRouter(logf, tunname, dev, tunDev, netChanged)
+func newUserspaceRouter(logf logger.Logf, tunname string, tunDev tun.Device, netChanged func()) Router {
+	return NewFakeRouter(logf, tunname, tunDev, netChanged)
 }
 
 func cleanup(logf logger.Logf, interfaceName string) {

--- a/wgengine/router/router_fake.go
+++ b/wgengine/router/router_fake.go
@@ -5,14 +5,13 @@
 package router
 
 import (
-	"github.com/tailscale/wireguard-go/device"
 	"github.com/tailscale/wireguard-go/tun"
 	"tailscale.com/types/logger"
 )
 
 // NewFakeRouter returns a Router that does nothing when called and
 // always returns nil errors.
-func NewFake(logf logger.Logf, _ *device.Device, _ tun.Device) (Router, error) {
+func NewFake(logf logger.Logf, _ tun.Device) (Router, error) {
 	return fakeRouter{logf: logf}, nil
 }
 

--- a/wgengine/router/router_freebsd.go
+++ b/wgengine/router/router_freebsd.go
@@ -5,7 +5,6 @@
 package router
 
 import (
-	"github.com/tailscale/wireguard-go/device"
 	"github.com/tailscale/wireguard-go/tun"
 	"tailscale.com/types/logger"
 )
@@ -15,8 +14,8 @@ import (
 // Work is currently underway for an in-kernel FreeBSD implementation of wireguard
 // https://svnweb.freebsd.org/base?view=revision&revision=357986
 
-func newUserspaceRouter(logf logger.Logf, _ *device.Device, tundev tun.Device) (Router, error) {
-	return newUserspaceBSDRouter(logf, nil, tundev)
+func newUserspaceRouter(logf logger.Logf, tundev tun.Device) (Router, error) {
+	return newUserspaceBSDRouter(logf, tundev)
 }
 
 func cleanup(logf logger.Logf, interfaceName string) {

--- a/wgengine/router/router_linux.go
+++ b/wgengine/router/router_linux.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/go-multierror/multierror"
-	"github.com/tailscale/wireguard-go/device"
 	"github.com/tailscale/wireguard-go/tun"
 	"inet.af/netaddr"
 	"tailscale.com/net/dns"
@@ -110,7 +109,7 @@ type linuxRouter struct {
 	cmd  commandRunner
 }
 
-func newUserspaceRouter(logf logger.Logf, _ *device.Device, tunDev tun.Device) (Router, error) {
+func newUserspaceRouter(logf logger.Logf, tunDev tun.Device) (Router, error) {
 	tunname, err := tunDev.Name()
 	if err != nil {
 		return nil, err

--- a/wgengine/router/router_linux_test.go
+++ b/wgengine/router/router_linux_test.go
@@ -627,7 +627,7 @@ func TestDelRouteIdempotent(t *testing.T) {
 		}
 	}
 
-	r, err := newUserspaceRouter(logf, nil, tun)
+	r, err := newUserspaceRouter(logf, tun)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/wgengine/router/router_openbsd.go
+++ b/wgengine/router/router_openbsd.go
@@ -10,7 +10,6 @@ import (
 	"log"
 	"os/exec"
 
-	"github.com/tailscale/wireguard-go/device"
 	"github.com/tailscale/wireguard-go/tun"
 	"inet.af/netaddr"
 	"tailscale.com/net/dns"
@@ -31,7 +30,7 @@ type openbsdRouter struct {
 	dns *dns.Manager
 }
 
-func newUserspaceRouter(logf logger.Logf, _ *device.Device, tundev tun.Device) (Router, error) {
+func newUserspaceRouter(logf logger.Logf, tundev tun.Device) (Router, error) {
 	tunname, err := tundev.Name()
 	if err != nil {
 		return nil, err

--- a/wgengine/router/router_userspace_bsd.go
+++ b/wgengine/router/router_userspace_bsd.go
@@ -12,7 +12,6 @@ import (
 	"os/exec"
 	"runtime"
 
-	"github.com/tailscale/wireguard-go/device"
 	"github.com/tailscale/wireguard-go/tun"
 	"inet.af/netaddr"
 	"tailscale.com/net/dns"
@@ -29,7 +28,7 @@ type userspaceBSDRouter struct {
 	dns *dns.Manager
 }
 
-func newUserspaceBSDRouter(logf logger.Logf, _ *device.Device, tundev tun.Device) (Router, error) {
+func newUserspaceBSDRouter(logf logger.Logf, tundev tun.Device) (Router, error) {
 	tunname, err := tundev.Name()
 	if err != nil {
 		return nil, err

--- a/wgengine/router/router_windows.go
+++ b/wgengine/router/router_windows.go
@@ -16,7 +16,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/tailscale/wireguard-go/device"
 	"github.com/tailscale/wireguard-go/tun"
 	"golang.org/x/sys/windows"
 	"golang.zx2c4.com/wireguard/windows/tunnel/winipcfg"
@@ -30,7 +29,6 @@ type winRouter struct {
 	logf                func(fmt string, args ...interface{})
 	tunname             string
 	nativeTun           *tun.NativeTun
-	wgdev               *device.Device
 	routeChangeCallback *winipcfg.RouteChangeCallback
 	dns                 *dns.Manager
 	firewall            *firewallTweaker
@@ -45,7 +43,7 @@ type winRouter struct {
 	firewallSubproc *exec.Cmd
 }
 
-func newUserspaceRouter(logf logger.Logf, wgdev *device.Device, tundev tun.Device) (Router, error) {
+func newUserspaceRouter(logf logger.Logf, tundev tun.Device) (Router, error) {
 	tunname, err := tundev.Name()
 	if err != nil {
 		return nil, err
@@ -65,7 +63,6 @@ func newUserspaceRouter(logf logger.Logf, wgdev *device.Device, tundev tun.Devic
 
 	return &winRouter{
 		logf:      logf,
-		wgdev:     wgdev,
 		tunname:   tunname,
 		nativeTun: nativeTun,
 		dns:       dns.NewManager(mconfig),

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -145,7 +145,7 @@ func (e *userspaceEngine) GetInternals() (*tstun.TUN, *magicsock.Conn) {
 
 // RouterGen is the signature for a function that creates a
 // router.Router.
-type RouterGen func(logf logger.Logf, wgdev *device.Device, tundev tun.Device) (router.Router, error)
+type RouterGen func(logf logger.Logf, tundev tun.Device) (router.Router, error)
 
 // Config is the engine configuration.
 type Config struct {
@@ -370,7 +370,7 @@ func newUserspaceEngine(logf logger.Logf, rawTUNDev tun.Device, conf Config) (_ 
 	// Pass the underlying tun.(*NativeDevice) to the router:
 	// routers do not Read or Write, but do access native interfaces.
 	e.logf("Creating router...")
-	e.router, err = conf.RouterGen(logf, e.wgdev, e.tundev.Unwrap())
+	e.router, err = conf.RouterGen(logf, e.tundev.Unwrap())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: David Anderson <danderson@tailscale.com>