### PR TITLE
wgengine: extend TestWatchdog timeout on macOS

### DIFF
--- a/wgengine/watchdog_test.go
+++ b/wgengine/watchdog_test.go
@@ -7,6 +7,7 @@ package wgengine
 import (
 	"bytes"
 	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -14,6 +15,13 @@ import (
 
 func TestWatchdog(t *testing.T) {
 	t.Parallel()
+
+	var maxWaitMultiple time.Duration = 1
+	if runtime.GOOS == "darwin" {
+		// Work around slow close syscalls on Big Sur with content filter Network Extensions installed.
+		// See https://github.com/tailscale/tailscale/issues/1598.
+		maxWaitMultiple = 15
+	}
 
 	t.Run("default watchdog does not fire", func(t *testing.T) {
 		t.Parallel()
@@ -23,7 +31,7 @@ func TestWatchdog(t *testing.T) {
 		}
 
 		e = NewWatchdog(e)
-		e.(*watchdogEngine).maxWait = 150 * time.Millisecond
+		e.(*watchdogEngine).maxWait = maxWaitMultiple * 150 * time.Millisecond
 		e.(*watchdogEngine).logf = t.Logf
 		e.(*watchdogEngine).fatalf = t.Fatalf
 
@@ -42,7 +50,7 @@ func TestWatchdog(t *testing.T) {
 		usEngine := e.(*userspaceEngine)
 		e = NewWatchdog(e)
 		wdEngine := e.(*watchdogEngine)
-		wdEngine.maxWait = 100 * time.Millisecond
+		wdEngine.maxWait = maxWaitMultiple * 100 * time.Millisecond
 
 		logBuf := new(bytes.Buffer)
 		fatalCalled := make(chan struct{})


### PR DESCRIPTION
This works around the close syscall being slow.
We can revert this if we find a fix or if Apple makes close fast again.
