### PR TITLE
wgengine: optimize isLocalAddr a bit

### DIFF
--- a/wgengine/userspace_test.go
+++ b/wgengine/userspace_test.go
@@ -139,3 +139,50 @@ func dkFromHex(hex string) tailcfg.DiscoKey {
 	}
 	return tailcfg.DiscoKey(k)
 }
+
+// an experiment to see if genLocalAddrFunc was worth it. As of Go
+// 1.16, it still very much is. (30-40x faster)
+func BenchmarkGenLocalAddrFunc(b *testing.B) {
+	la1 := netaddr.MustParseIP("1.2.3.4")
+	la2 := netaddr.MustParseIP("::4")
+	lanot := netaddr.MustParseIP("5.5.5.5")
+	var x bool
+	b.Run("map1", func(b *testing.B) {
+		m := map[netaddr.IP]bool{
+			la1: true,
+		}
+		for i := 0; i < b.N; i++ {
+			x = m[la1]
+			x = m[lanot]
+		}
+	})
+	b.Run("map2", func(b *testing.B) {
+		m := map[netaddr.IP]bool{
+			la1: true,
+			la2: true,
+		}
+		for i := 0; i < b.N; i++ {
+			x = m[la1]
+			x = m[lanot]
+		}
+	})
+	b.Run("or1", func(b *testing.B) {
+		f := func(t netaddr.IP) bool {
+			return t == la1
+		}
+		for i := 0; i < b.N; i++ {
+			x = f(la1)
+			x = f(lanot)
+		}
+	})
+	b.Run("or2", func(b *testing.B) {
+		f := func(t netaddr.IP) bool {
+			return t == la1 || t == la2
+		}
+		for i := 0; i < b.N; i++ {
+			x = f(la1)
+			x = f(lanot)
+		}
+	})
+	b.Logf("x = %v", x)
+}


### PR DESCRIPTION
On macOS/iOS, this removes a map lookup per outgoing packet.

Noticed it while reading code, not from profiles, but can't hurt.

```
BenchmarkGenLocalAddrFunc
BenchmarkGenLocalAddrFunc/map1
BenchmarkGenLocalAddrFunc/map1-4                16184868                69.78 ns/op
BenchmarkGenLocalAddrFunc/map2
BenchmarkGenLocalAddrFunc/map2-4                16878140                70.73 ns/op
BenchmarkGenLocalAddrFunc/or1
BenchmarkGenLocalAddrFunc/or1-4                 623055721                1.950 ns/op
BenchmarkGenLocalAddrFunc/or2
BenchmarkGenLocalAddrFunc/or2-4                 472493098                2.589 ns/op
```
