### PR TITLE
client/tailscale, cmd/tailscale/cli: plumb --socket through

### DIFF
--- a/cmd/tailscale/cli/cli.go
+++ b/cmd/tailscale/cli/cli.go
@@ -20,6 +20,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/peterbourgon/ff/v2/ffcli"
+	"tailscale.com/client/tailscale"
 	"tailscale.com/ipn"
 	"tailscale.com/paths"
 	"tailscale.com/safesocket"
@@ -87,6 +88,8 @@ change in the future.
 	if err := rootCmd.Parse(args); err != nil {
 		return err
 	}
+
+	tailscale.TailscaledSocket = rootArgs.socket
 
 	err := rootCmd.Run(context.Background())
 	if err == flag.ErrHelp {

--- a/safesocket/safesocket.go
+++ b/safesocket/safesocket.go
@@ -10,8 +10,6 @@ import (
 	"errors"
 	"net"
 	"runtime"
-
-	"tailscale.com/paths"
 )
 
 type closeable interface {
@@ -29,11 +27,6 @@ func ConnCloseRead(c net.Conn) error {
 // either a UnixConn or TCPConn as returned from this package.
 func ConnCloseWrite(c net.Conn) error {
 	return c.(closeable).CloseWrite()
-}
-
-// ConnectDefault connects to the local Tailscale daemon.
-func ConnectDefault() (net.Conn, error) {
-	return Connect(paths.DefaultTailscaledSocket(), 41112)
 }
 
 // Connect connects to either path (on Unix) or the provided localhost port (on Windows).


### PR DESCRIPTION
Without this, `tailscale status` ignores the --socket flag on macOS and
always talks to the IPNExtension, even if you wanted it to inspect a
userspace tailscaled.

Signed-off-by: David Crawshaw <crawshaw@tailscale.com>