### PR TITLE
wgengine/netstack: stop re-adding IPs registered by active TCP connections

### DIFF
--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -242,7 +242,6 @@ func (ns *Impl) updateIPs(nm *netmap.NetworkMap) {
 	ns.mu.Lock()
 	for ip := range ns.connsOpenBySubnetIP {
 		ipp := tcpip.Address(ip.IPAddr().IP).WithPrefix()
-		ipsToBeAdded[ipp] = true
 		delete(ipsToBeRemoved, ipp)
 	}
 	ns.mu.Unlock()


### PR DESCRIPTION
Signed-off-by: Naman Sood <mail@nsood.in>