### PR TITLE
ipn: replace SetWantRunning(bool) with EditPrefs(MaskedPrefs)

### DIFF
--- a/cmd/tailscale/cli/down.go
+++ b/cmd/tailscale/cli/down.go
@@ -59,7 +59,12 @@ func runDown(ctx context.Context, args []string) error {
 		}
 	})
 
-	bc.SetWantRunning(false)
+	bc.EditPrefs(&ipn.MaskedPrefs{
+		Prefs: ipn.Prefs{
+			WantRunning: false,
+		},
+		WantRunningSet: true,
+	})
 	pump(ctx, bc, c)
 
 	return nil

--- a/ipn/backend.go
+++ b/ipn/backend.go
@@ -151,9 +151,8 @@ type Backend interface {
 	// WantRunning. This may cause the wireguard engine to
 	// reconfigure or stop.
 	SetPrefs(*Prefs)
-	// SetWantRunning is like SetPrefs but sets only the
-	// WantRunning field.
-	SetWantRunning(wantRunning bool)
+	// EditPrefs is like SetPrefs but only sets the specified fields.
+	EditPrefs(*MaskedPrefs)
 	// RequestEngineStatus polls for an update from the wireguard
 	// engine. Only needed if you want to display byte
 	// counts. Connection events are emitted automatically without

--- a/ipn/fake_test.go
+++ b/ipn/fake_test.go
@@ -79,8 +79,11 @@ func (b *FakeBackend) SetPrefs(new *Prefs) {
 	}
 }
 
-func (b *FakeBackend) SetWantRunning(v bool) {
-	b.SetPrefs(&Prefs{WantRunning: v})
+func (b *FakeBackend) EditPrefs(mp *MaskedPrefs) {
+	// This fake implementation only cares about this one pref.
+	if mp.WantRunningSet {
+		b.SetPrefs(&mp.Prefs)
+	}
 }
 
 func (b *FakeBackend) RequestEngineStatus() {

--- a/ipn/message.go
+++ b/ipn/message.go
@@ -80,7 +80,7 @@ type Command struct {
 	Login                 *tailcfg.Oauth2Token
 	Logout                *NoArgs
 	SetPrefs              *SetPrefsArgs
-	SetWantRunning        *bool
+	EditPrefs             *MaskedPrefs
 	RequestEngineStatus   *NoArgs
 	RequestStatus         *NoArgs
 	FakeExpireAfter       *FakeExpireAfterArgs
@@ -204,8 +204,8 @@ func (bs *BackendServer) GotCommand(ctx context.Context, cmd *Command) error {
 	} else if c := cmd.SetPrefs; c != nil {
 		bs.b.SetPrefs(c.New)
 		return nil
-	} else if c := cmd.SetWantRunning; c != nil {
-		bs.b.SetWantRunning(*c)
+	} else if c := cmd.EditPrefs; c != nil {
+		bs.b.EditPrefs(c)
 		return nil
 	} else if c := cmd.FakeExpireAfter; c != nil {
 		bs.b.FakeExpireAfter(c.Duration)
@@ -309,6 +309,10 @@ func (bc *BackendClient) SetPrefs(new *Prefs) {
 	bc.send(Command{SetPrefs: &SetPrefsArgs{New: new}})
 }
 
+func (bc *BackendClient) EditPrefs(mp *MaskedPrefs) {
+	bc.send(Command{EditPrefs: mp})
+}
+
 func (bc *BackendClient) RequestEngineStatus() {
 	bc.send(Command{RequestEngineStatus: &NoArgs{}})
 }
@@ -326,10 +330,6 @@ func (bc *BackendClient) Ping(ip string, useTSMP bool) {
 		IP:      ip,
 		UseTSMP: useTSMP,
 	}})
-}
-
-func (bc *BackendClient) SetWantRunning(v bool) {
-	bc.send(Command{SetWantRunning: &v})
 }
 
 // MaxMessageSize is the maximum message size, in bytes.


### PR DESCRIPTION
This adds a new ipn.MaskedPrefs embedding a ipn.Prefs, along with a
bunch of "has bits", kept in sync with tests & reflect.

Then it adds a Prefs.ApplyEdits(MaskedPrefs) method.

Then the ipn.Backend interface loses its weirdo SetWantRunning(bool)
method (that I added in 483141094c for "tailscale down")
and replaces it with EditPrefs (alongside the existing SetPrefs for now).

Then updates 'tailscale down' to use EditPrefs instead of SetWantRunning.

In the future, we can use this to do more interesting things with the
CLI, reconfiguring only certain properties without the reset-the-world
"tailscale up".

Updates #1436
