### PR TITLE
wgengine/magicsock: adapt CreateEndpoint signature to match wireguard-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/peterbourgon/ff/v2 v2.0.0
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/tailscale/depaware v0.0.0-20201214215404-77d1e9757027
-	github.com/tailscale/wireguard-go v0.0.0-20210330200845-4914b4a944c4
+	github.com/tailscale/wireguard-go v0.0.0-20210401164443-2d6878b6b30d
 	github.com/tcnksm/go-httpstat v0.2.0
 	github.com/toqueteos/webbrowser v1.2.0
 	go4.org/mem v0.0.0-20201119185036-c04c5a6ff174

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ github.com/tailscale/wireguard-go v0.0.0-20210330185929-1689f2635004 h1:GNEPNdNH
 github.com/tailscale/wireguard-go v0.0.0-20210330185929-1689f2635004/go.mod h1:6t0OVdJwFOKFnvaHaVMKG6GznWaHqkmiR2n3kH0t924=
 github.com/tailscale/wireguard-go v0.0.0-20210330200845-4914b4a944c4 h1:7Y0H5NzrV3fwHeDrUXDFcTy8QNbAEDwr+qHyOfX4VyE=
 github.com/tailscale/wireguard-go v0.0.0-20210330200845-4914b4a944c4/go.mod h1:6t0OVdJwFOKFnvaHaVMKG6GznWaHqkmiR2n3kH0t924=
+github.com/tailscale/wireguard-go v0.0.0-20210401164443-2d6878b6b30d h1:zbDBqtYvc492gcRL5BB7AO5Aed+aVht2jbYg8SKoMYs=
+github.com/tailscale/wireguard-go v0.0.0-20210401164443-2d6878b6b30d/go.mod h1:6t0OVdJwFOKFnvaHaVMKG6GznWaHqkmiR2n3kH0t924=
 github.com/tcnksm/go-httpstat v0.2.0 h1:rP7T5e5U2HfmOBmZzGgGZjBQ5/GluWUylujl0tJ04I0=
 github.com/tcnksm/go-httpstat v0.2.0/go.mod h1:s3JVJFtQxtBEBC9dwcdTTXS9xFnM3SXAZwPG41aurT8=
 github.com/toqueteos/webbrowser v1.2.0 h1:tVP/gpK69Fx+qMJKsLE7TD8LuGWPnEV71wBN9rrstGQ=

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -173,7 +173,6 @@ func newMagicStack(t testing.TB, logf logger.Logf, l nettype.PacketListener, der
 	opts := &device.DeviceOptions{
 		CreateEndpoint: conn.CreateEndpoint,
 		CreateBind:     conn.CreateBind,
-		SkipBindUpdate: true,
 	}
 	dev := device.NewDevice(tsTun, wgLogger.DeviceLogger, opts)
 	dev.Up()
@@ -525,7 +524,6 @@ func TestDeviceStartStop(t *testing.T) {
 	opts := &device.DeviceOptions{
 		CreateEndpoint: conn.CreateEndpoint,
 		CreateBind:     conn.CreateBind,
-		SkipBindUpdate: true,
 	}
 	dev := device.NewDevice(tun.TUN(), wgLogger.DeviceLogger, opts)
 	dev.Up()
@@ -1525,7 +1523,7 @@ func addTestEndpoint(tb testing.TB, conn *Conn, sendConn net.PacketConn) (tailcf
 		},
 	})
 	conn.SetPrivateKey(wgkey.Private{0: 1})
-	_, err := conn.CreateEndpoint([32]byte(nodeKey), "0000000000000000000000000000000000000000000000000000000000000001.disco.tailscale:12345")
+	_, err := conn.CreateEndpoint(string(nodeKey[:]) + "0000000000000000000000000000000000000000000000000000000000000001.disco.tailscale:12345")
 	if err != nil {
 		tb.Fatal(err)
 	}
@@ -1699,7 +1697,7 @@ func TestSetNetworkMapChangingNodeKey(t *testing.T) {
 			},
 		},
 	})
-	_, err := conn.CreateEndpoint([32]byte(nodeKey1), "0000000000000000000000000000000000000000000000000000000000000001.disco.tailscale:12345")
+	_, err := conn.CreateEndpoint(string(nodeKey1[:]) + "0000000000000000000000000000000000000000000000000000000000000001.disco.tailscale:12345")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -321,7 +321,6 @@ func NewUserspaceEngine(logf logger.Logf, conf Config) (_ Engine, reterr error) 
 		},
 		CreateBind:     e.magicConn.CreateBind,
 		CreateEndpoint: e.magicConn.CreateEndpoint,
-		SkipBindUpdate: true,
 	}
 
 	e.tundev.OnTSMPPongReceived = func(pong packet.TSMPPongReply) {


### PR DESCRIPTION
Part of a temporary change to make merging wireguard-go easier.
See https://github.com/tailscale/wireguard-go/pull/45.
