### PR TITLE
Add new DNS config struct, and start plumbing it into wgengine and ipn.

### DIFF
--- a/internal/deepprint/deepprint_test.go
+++ b/internal/deepprint/deepprint_test.go
@@ -46,7 +46,7 @@ func getVal() []interface{} {
 			},
 		},
 		&router.Config{
-			DNS: dns.Config{
+			DNS: dns.OSConfig{
 				Nameservers: []netaddr.IP{netaddr.IPv4(8, 8, 8, 8)},
 				Domains:     []string{"tailscale.net"},
 			},

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1449,7 +1449,7 @@ func (b *LocalBackend) authReconfig() {
 			b.logf("[unexpected] dns proxied but no nameservers")
 			proxied = false
 		}
-		rcfg.DNS = dns.Config{
+		rcfg.DNS = dns.OSConfig{
 			Nameservers: nm.DNS.Nameservers,
 			Domains:     nm.DNS.Domains,
 			Proxied:     proxied,

--- a/net/dns/config.go
+++ b/net/dns/config.go
@@ -8,6 +8,34 @@ import (
 	"inet.af/netaddr"
 )
 
+// Config is a DNS configuration.
+type Config struct {
+	// DefaultResolvers are the DNS resolvers to use for DNS names
+	// which aren't covered by more specific per-domain routes below.
+	// If empty, the OS's default resolvers (the ones that predate
+	// Tailscale altering the configuration) are used.
+	DefaultResolvers []netaddr.IPPort
+	// Routes maps a DNS suffix to the resolvers that should be used
+	// for queries that fall within that suffix.
+	// If a query doesn't match any entry in Routes, the
+	// DefaultResolvers are used.
+	Routes map[string][]netaddr.IPPort
+	// SearchDomains are DNS suffixes to try when expanding
+	// single-label queries.
+	SearchDomains []string
+	// Hosts maps DNS FQDNs to their IPs, which can be a mix of IPv4
+	// and IPv6.
+	// Queries matching entries in Hosts are resolved locally without
+	// recursing off-machine.
+	Hosts map[string][]netaddr.IP
+	// AuthoritativeSuffixes is a list of fully-qualified DNS suffixes
+	// for which the in-process Tailscale resolver is authoritative.
+	// Queries for names within AuthoritativeSuffixes can only be
+	// fulfilled by entries in Hosts. Queries with no match in Hosts
+	// return NXDOMAIN.
+	AuthoritativeSuffixes []string
+}
+
 // OSConfig is an OS DNS configuration.
 type OSConfig struct {
 	// Nameservers are the IP addresses of the nameservers to use.

--- a/net/dns/config.go
+++ b/net/dns/config.go
@@ -42,18 +42,11 @@ type OSConfig struct {
 	Nameservers []netaddr.IP
 	// Domains are the search domains to use.
 	Domains []string
-	// Proxied indicates whether DNS requests are proxied through a dns.Resolver.
-	// This enables MagicDNS.
-	Proxied bool
 }
 
 // Equal determines whether its argument and receiver
 // represent equivalent DNS configurations (then DNS reconfig is a no-op).
 func (lhs OSConfig) Equal(rhs OSConfig) bool {
-	if lhs.Proxied != rhs.Proxied {
-		return false
-	}
-
 	if len(lhs.Nameservers) != len(rhs.Nameservers) {
 		return false
 	}

--- a/net/dns/config.go
+++ b/net/dns/config.go
@@ -8,9 +8,8 @@ import (
 	"inet.af/netaddr"
 )
 
-// Config is the set of parameters that uniquely determine
-// the state to which a manager should bring system DNS settings.
-type Config struct {
+// OSConfig is an OS DNS configuration.
+type OSConfig struct {
 	// Nameservers are the IP addresses of the nameservers to use.
 	Nameservers []netaddr.IP
 	// Domains are the search domains to use.
@@ -22,7 +21,7 @@ type Config struct {
 
 // Equal determines whether its argument and receiver
 // represent equivalent DNS configurations (then DNS reconfig is a no-op).
-func (lhs Config) Equal(rhs Config) bool {
+func (lhs OSConfig) Equal(rhs OSConfig) bool {
 	if lhs.Proxied != rhs.Proxied {
 		return false
 	}

--- a/net/dns/direct.go
+++ b/net/dns/direct.go
@@ -48,8 +48,8 @@ func writeResolvConf(w io.Writer, servers []netaddr.IP, domains []string) {
 }
 
 // readResolvConf reads DNS configuration from /etc/resolv.conf.
-func readResolvConf() (Config, error) {
-	var config Config
+func readResolvConf() (OSConfig, error) {
+	var config OSConfig
 
 	f, err := os.Open("/etc/resolv.conf")
 	if err != nil {
@@ -115,7 +115,7 @@ func newDirectManager() managerImpl {
 }
 
 // Up implements managerImpl.
-func (m directManager) Up(config Config) error {
+func (m directManager) Up(config OSConfig) error {
 	// Write the tsConf file.
 	buf := new(bytes.Buffer)
 	writeResolvConf(buf, config.Nameservers, config.Domains)

--- a/net/dns/manager.go
+++ b/net/dns/manager.go
@@ -25,7 +25,7 @@ const reconfigTimeout = time.Second
 
 type managerImpl interface {
 	// Up updates system DNS settings to match the given configuration.
-	Up(Config) error
+	Up(OSConfig) error
 	// Down undoes the effects of Up.
 	// It is idempotent and performs no action if Up has never been called.
 	Down() error
@@ -37,7 +37,7 @@ type Manager struct {
 
 	impl managerImpl
 
-	config Config
+	config OSConfig
 }
 
 // NewManagers created a new manager from the given config.
@@ -52,7 +52,7 @@ func NewManager(logf logger.Logf, interfaceName string) *Manager {
 	return m
 }
 
-func (m *Manager) Set(config Config) error {
+func (m *Manager) Set(config OSConfig) error {
 	if config.Equal(m.config) {
 		return nil
 	}

--- a/net/dns/manager_windows.go
+++ b/net/dns/manager_windows.go
@@ -64,7 +64,7 @@ func (m windowsManager) setDomains(basePath string, domains []string) error {
 	return setRegistryString(path, "SearchList", value)
 }
 
-func (m windowsManager) Up(config Config) error {
+func (m windowsManager) Up(config OSConfig) error {
 	var ipsv4 []string
 	var ipsv6 []string
 
@@ -114,5 +114,5 @@ func (m windowsManager) Up(config Config) error {
 }
 
 func (m windowsManager) Down() error {
-	return m.Up(Config{Nameservers: nil, Domains: nil})
+	return m.Up(OSConfig{Nameservers: nil, Domains: nil})
 }

--- a/net/dns/nm.go
+++ b/net/dns/nm.go
@@ -62,7 +62,7 @@ func newNMManager(interfaceName string) managerImpl {
 type nmConnectionSettings map[string]map[string]dbus.Variant
 
 // Up implements managerImpl.
-func (m nmManager) Up(config Config) error {
+func (m nmManager) Up(config OSConfig) error {
 	ctx, cancel := context.WithTimeout(context.Background(), reconfigTimeout)
 	defer cancel()
 
@@ -201,5 +201,5 @@ func (m nmManager) Up(config Config) error {
 
 // Down implements managerImpl.
 func (m nmManager) Down() error {
-	return m.Up(Config{Nameservers: nil, Domains: nil})
+	return m.Up(OSConfig{Nameservers: nil, Domains: nil})
 }

--- a/net/dns/noop.go
+++ b/net/dns/noop.go
@@ -9,7 +9,7 @@ package dns
 type noopManager struct{}
 
 // Up implements managerImpl.
-func (m noopManager) Up(Config) error { return nil }
+func (m noopManager) Up(OSConfig) error { return nil }
 
 // Down implements managerImpl.
 func (m noopManager) Down() error { return nil }

--- a/net/dns/resolvconf.go
+++ b/net/dns/resolvconf.go
@@ -116,7 +116,7 @@ func newResolvconfManager(logf logger.Logf) managerImpl {
 const resolvconfConfigName = "tun-tailscale.inet"
 
 // Up implements managerImpl.
-func (m resolvconfManager) Up(config Config) error {
+func (m resolvconfManager) Up(config OSConfig) error {
 	stdin := new(bytes.Buffer)
 	writeResolvConf(stdin, config.Nameservers, config.Domains) // dns_direct.go
 

--- a/net/dns/resolved.go
+++ b/net/dns/resolved.go
@@ -82,7 +82,7 @@ func newResolvedManager() managerImpl {
 }
 
 // Up implements managerImpl.
-func (m resolvedManager) Up(config Config) error {
+func (m resolvedManager) Up(config OSConfig) error {
 	ctx, cancel := context.WithTimeout(context.Background(), reconfigTimeout)
 	defer cancel()
 

--- a/wgengine/router/router.go
+++ b/wgengine/router/router.go
@@ -58,7 +58,7 @@ type Config struct {
 	// this node has chosen to use.
 	Routes []netaddr.IPPrefix
 
-	DNS dns.Config
+	DNS dns.OSConfig
 
 	// Linux-only things below, ignored on other platforms.
 

--- a/wgengine/router/router.go
+++ b/wgengine/router/router.go
@@ -58,6 +58,7 @@ type Config struct {
 	// this node has chosen to use.
 	Routes []netaddr.IPPrefix
 
+	// Set internally by wgengine, must not be set elsewhere.
 	DNS dns.OSConfig
 
 	// Linux-only things below, ignored on other platforms.

--- a/wgengine/userspace_test.go
+++ b/wgengine/userspace_test.go
@@ -13,6 +13,7 @@ import (
 
 	"go4.org/mem"
 	"inet.af/netaddr"
+	"tailscale.com/net/dns"
 	"tailscale.com/net/tstun"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/key"
@@ -108,7 +109,7 @@ func TestUserspaceEngineReconfig(t *testing.T) {
 			},
 		}
 
-		err = e.Reconfig(cfg, routerCfg, nil, nil)
+		err = e.Reconfig(cfg, routerCfg, &dns.Config{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/wgengine/watchdog.go
+++ b/wgengine/watchdog.go
@@ -14,6 +14,7 @@ import (
 
 	"inet.af/netaddr"
 	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/net/dns"
 	"tailscale.com/net/tstun"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/netmap"
@@ -73,8 +74,8 @@ func (e *watchdogEngine) watchdog(name string, fn func()) {
 	})
 }
 
-func (e *watchdogEngine) Reconfig(cfg *wgcfg.Config, routerCfg *router.Config, hosts map[string][]netaddr.IP, localDomains []string) error {
-	return e.watchdogErr("Reconfig", func() error { return e.wrap.Reconfig(cfg, routerCfg, hosts, localDomains) })
+func (e *watchdogEngine) Reconfig(cfg *wgcfg.Config, routerCfg *router.Config, dnsCfg *dns.Config) error {
+	return e.watchdogErr("Reconfig", func() error { return e.wrap.Reconfig(cfg, routerCfg, dnsCfg) })
 }
 func (e *watchdogEngine) GetLinkMonitor() *monitor.Mon {
 	return e.wrap.GetLinkMonitor()

--- a/wgengine/wgengine.go
+++ b/wgengine/wgengine.go
@@ -9,6 +9,7 @@ import (
 
 	"inet.af/netaddr"
 	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/net/dns"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/netmap"
 	"tailscale.com/wgengine/filter"
@@ -56,7 +57,7 @@ type Engine interface {
 	// sends an updated network map.
 	//
 	// The returned error is ErrNoChanges if no changes were made.
-	Reconfig(*wgcfg.Config, *router.Config, map[string][]netaddr.IP, []string) error
+	Reconfig(*wgcfg.Config, *router.Config, *dns.Config) error
 
 	// GetFilter returns the current packet filter, if any.
 	GetFilter() *filter.Filter


### PR DESCRIPTION
The code flow is still a bit of a mess, and wgengine ends up splitting dns.Config into resolver.Config and dns.OSConfig internally. But wgengine's APIs handle the right configs now, another step of the refactor.

Opening PR mostly for a review of the docs and semantics of the dns.Config struct, the rest is a lot of mechanical moving around that amounts to a behavioral no-op.

Also submitting eagerly, so I can continue with the refactor, but would still like feedback.