### PR TITLE
net/dns: Implement resolver vs. OS config splitting

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1602,10 +1602,9 @@ func (b *LocalBackend) initPeerAPIListener() {
 }
 
 // magicDNSRootDomains returns the subset of nm.DNS.Domains that are the search domains for MagicDNS.
-// Each entry has a trailing period.
 func magicDNSRootDomains(nm *netmap.NetworkMap) []string {
 	if v := nm.MagicDNSSuffix(); v != "" {
-		return []string{strings.Trim(v, ".") + "."}
+		return []string{strings.Trim(v, ".")}
 	}
 	return nil
 }

--- a/net/dns/config.go
+++ b/net/dns/config.go
@@ -5,6 +5,8 @@
 package dns
 
 import (
+	"sort"
+
 	"inet.af/netaddr"
 )
 
@@ -99,6 +101,7 @@ func (c Config) matchDomains() []string {
 		ret = append(ret, suffix)
 		seen[suffix] = true
 	}
+	sort.Strings(ret)
 	return ret
 }
 

--- a/net/dns/direct.go
+++ b/net/dns/direct.go
@@ -163,6 +163,11 @@ func (m directManager) SupportsSplitDNS() bool {
 	return false
 }
 
+func (m directManager) GetBaseConfig() (OSConfig, error) {
+	// TODO
+	return OSConfig{}, nil
+}
+
 func (m directManager) Close() error {
 	if _, err := os.Stat(backupConf); err != nil {
 		// If the backup file does not exist, then Up never ran successfully.

--- a/net/dns/direct.go
+++ b/net/dns/direct.go
@@ -164,8 +164,7 @@ func (m directManager) SupportsSplitDNS() bool {
 }
 
 func (m directManager) GetBaseConfig() (OSConfig, error) {
-	// TODO
-	return OSConfig{}, nil
+	return OSConfig{}, ErrGetBaseConfigNotSupported
 }
 
 func (m directManager) Close() error {

--- a/net/dns/manager.go
+++ b/net/dns/manager.go
@@ -5,6 +5,7 @@
 package dns
 
 import (
+	"strings"
 	"time"
 
 	"inet.af/netaddr"
@@ -50,47 +51,149 @@ func NewManager(logf logger.Logf, oscfg OSConfigurator, linkMon *monitor.Mon) *M
 	return m
 }
 
+// forceSplitDNSForTesting alters cfg to be a split DNS configuration
+// that only captures search paths. It's intended for testing split
+// DNS until the functionality is linked up in the admin panel.
+func forceSplitDNSForTesting(cfg *Config) {
+	if len(cfg.DefaultResolvers) == 0 {
+		return
+	}
+
+	if cfg.Routes == nil {
+		cfg.Routes = map[string][]netaddr.IPPort{}
+	}
+	for _, search := range cfg.SearchDomains {
+		cfg.Routes[search] = cfg.DefaultResolvers
+	}
+	cfg.DefaultResolvers = nil
+}
+
 func (m *Manager) Set(cfg Config) error {
 	m.logf("Set: %+v", cfg)
 
-	if len(cfg.DefaultResolvers) == 0 {
-		// TODO: make other settings work even if you didn't set a
-		// default resolver. For now, no default resolvers == no
-		// managed DNS config.
-		cfg = Config{}
+	if false {
+		// Temporary, for danderson to test things.
+		forceSplitDNSForTesting(&cfg)
 	}
 
-	resolverCfg := resolver.Config{
-		Hosts:        cfg.Hosts,
-		LocalDomains: cfg.AuthoritativeSuffixes,
-		Routes:       map[string][]netaddr.IPPort{},
-	}
-	osCfg := OSConfig{
-		SearchDomains: cfg.SearchDomains,
-	}
-	// We must proxy through quad-100 if MagicDNS hosts are in
-	// use, or there are any per-domain routes.
-	mustProxy := len(cfg.Hosts) > 0 || len(cfg.Routes) > 0
-	if mustProxy {
-		osCfg.Nameservers = []netaddr.IP{tsaddr.TailscaleServiceIP()}
-		resolverCfg.Routes["."] = cfg.DefaultResolvers
-		for suffix, resolvers := range cfg.Routes {
-			resolverCfg.Routes[suffix] = resolvers
-		}
-	} else {
-		for _, resolver := range cfg.DefaultResolvers {
-			osCfg.Nameservers = append(osCfg.Nameservers, resolver.IP)
-		}
-	}
+	rcfg, ocfg := m.compileConfig(cfg)
 
-	if err := m.resolver.SetConfig(resolverCfg); err != nil {
+	m.logf("Resolvercfg: %+v", rcfg)
+	m.logf("OScfg: %+v", ocfg)
+
+	if err := m.resolver.SetConfig(rcfg); err != nil {
 		return err
 	}
-	if err := m.os.SetDNS(osCfg); err != nil {
+	if err := m.os.SetDNS(ocfg); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// compileConfig converts cfg into a quad-100 resolver configuration
+// and an OS-level configuration.
+func (m *Manager) compileConfig(cfg Config) (resolver.Config, OSConfig) {
+	// Deal with trivial configs first.
+	switch {
+	case !cfg.needsOSResolver():
+		// Set search domains, but nothing else. This also covers the
+		// case where cfg is entirely zero, in which case these
+		// configs clear all Tailscale DNS settings.
+		return resolver.Config{}, OSConfig{
+			SearchDomains: cfg.SearchDomains,
+		}
+	case cfg.hasDefaultResolversOnly():
+		// Trivial CorpDNS configuration, just override the OS
+		// resolver.
+		return resolver.Config{}, OSConfig{
+			Nameservers:   toIPsOnly(cfg.DefaultResolvers),
+			SearchDomains: cfg.SearchDomains,
+		}
+	case cfg.hasDefaultResolvers():
+		// Default resolvers plus other stuff always ends up proxying
+		// through quad-100.
+		rcfg := resolver.Config{
+			Routes: map[string][]netaddr.IPPort{
+				".": cfg.DefaultResolvers,
+			},
+			Hosts:        cfg.Hosts,
+			LocalDomains: addFQDNDots(cfg.AuthoritativeSuffixes),
+		}
+		for suffix, resolvers := range cfg.Routes {
+			rcfg.Routes[suffix+"."] = resolvers
+		}
+		ocfg := OSConfig{
+			Nameservers:   []netaddr.IP{tsaddr.TailscaleServiceIP()},
+			SearchDomains: cfg.SearchDomains,
+		}
+		return rcfg, ocfg
+	}
+
+	// From this point on, we're figuring out split DNS
+	// configurations. The possible cases don't return directly any
+	// more, because as a final step we have to handle the case where
+	// the OS can't do split DNS.
+	var rcfg resolver.Config
+	var ocfg OSConfig
+
+	if !cfg.hasHosts() && cfg.singleResolverSet() != nil && m.os.SupportsSplitDNS() {
+		// Split DNS configuration requested, where all split domains
+		// go to the same resolvers. We can let the OS do it.
+		return resolver.Config{}, OSConfig{
+			Nameservers:   toIPsOnly(cfg.singleResolverSet()),
+			SearchDomains: cfg.SearchDomains,
+			MatchDomains:  cfg.matchDomains(),
+		}
+	}
+
+	// Split DNS configuration with either multiple upstream routes,
+	// or routes + MagicDNS, or just MagicDNS, or on an OS that cannot
+	// split-DNS. Install a split config pointing at quad-100.
+	rcfg = resolver.Config{
+		Routes:       map[string][]netaddr.IPPort{},
+		Hosts:        cfg.Hosts,
+		LocalDomains: addFQDNDots(cfg.AuthoritativeSuffixes),
+	}
+	for suffix, resolvers := range cfg.Routes {
+		rcfg.Routes[suffix+"."] = resolvers
+	}
+	ocfg = OSConfig{
+		Nameservers:   []netaddr.IP{tsaddr.TailscaleServiceIP()},
+		SearchDomains: cfg.SearchDomains,
+	}
+
+	// If the OS can't do native split-dns, read out the underlying
+	// resolver config and blend it into our config.
+	// TODO: for now, use quad-8 as the upstream until more plumbing
+	// is done.
+	if m.os.SupportsSplitDNS() {
+		ocfg.MatchDomains = cfg.matchDomains()
+	} else {
+		rcfg.Routes["."] = []netaddr.IPPort{netaddr.MustParseIPPort("8.8.8.8:53")}
+	}
+
+	return rcfg, ocfg
+}
+
+func addFQDNDots(domains []string) []string {
+	ret := make([]string, 0, len(domains))
+	for _, dom := range domains {
+		ret = append(ret, strings.TrimSuffix(dom, ".")+".")
+	}
+	return ret
+}
+
+// toIPsOnly returns only the IP portion of ipps.
+// TODO: this discards port information on the assumption that we're
+// always pointing at port 53.
+// https://github.com/tailscale/tailscale/issues/1666 tracks making
+// that not true, if we ever want to.
+func toIPsOnly(ipps []netaddr.IPPort) (ret []netaddr.IP) {
+	for _, ipp := range ipps {
+		ret = append(ret, ipp.IP)
+	}
+	return ret
 }
 
 func (m *Manager) EnqueueRequest(bs []byte, from netaddr.IPPort) error {

--- a/net/dns/manager_test.go
+++ b/net/dns/manager_test.go
@@ -1,0 +1,397 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package dns
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"inet.af/netaddr"
+	"tailscale.com/net/dns/resolver"
+)
+
+type fakeOSConfigurator struct {
+	SplitDNS bool
+
+	OSConfig       OSConfig
+	ResolverConfig resolver.Config
+}
+
+func (c *fakeOSConfigurator) SetDNS(cfg OSConfig) error {
+	if !c.SplitDNS && len(cfg.MatchDomains) > 0 {
+		panic("split DNS config passed to non-split OSConfigurator")
+	}
+	c.OSConfig = cfg
+	return nil
+}
+
+func (c *fakeOSConfigurator) SetResolver(cfg resolver.Config) {
+	c.ResolverConfig = cfg
+}
+
+func (c *fakeOSConfigurator) SupportsSplitDNS() bool {
+	return c.SplitDNS
+}
+
+func (c *fakeOSConfigurator) Close() error { return nil }
+
+func TestManager(t *testing.T) {
+	// Note: these tests assume that it's safe to switch the
+	// OSConfigurator's split-dns support on and off between Set
+	// calls. Empirically this is currently true, because we reprobe
+	// the support every time we generate configs. It would be
+	// reasonable to make this unsupported as well, in which case
+	// these tests will need tweaking.
+	tests := []struct {
+		name  string
+		in    Config
+		split bool
+		os    OSConfig
+		rs    resolver.Config
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name: "search-only",
+			in: Config{
+				SearchDomains: strs("tailscale.com", "universe.tf"),
+			},
+			os: OSConfig{
+				SearchDomains: strs("tailscale.com", "universe.tf"),
+			},
+		},
+		{
+			name: "corp",
+			in: Config{
+				DefaultResolvers: mustIPPs("1.1.1.1:53", "9.9.9.9:53"),
+				SearchDomains:    strs("tailscale.com", "universe.tf"),
+			},
+			os: OSConfig{
+				Nameservers:   mustIPs("1.1.1.1", "9.9.9.9"),
+				SearchDomains: strs("tailscale.com", "universe.tf"),
+			},
+		},
+		{
+			name: "corp-split",
+			in: Config{
+				DefaultResolvers: mustIPPs("1.1.1.1:53", "9.9.9.9:53"),
+				SearchDomains:    strs("tailscale.com", "universe.tf"),
+			},
+			split: true,
+			os: OSConfig{
+				Nameservers:   mustIPs("1.1.1.1", "9.9.9.9"),
+				SearchDomains: strs("tailscale.com", "universe.tf"),
+			},
+		},
+		{
+			name: "corp-magic",
+			in: Config{
+				DefaultResolvers: mustIPPs("1.1.1.1:53", "9.9.9.9:53"),
+				SearchDomains:    strs("tailscale.com", "universe.tf"),
+				Hosts: hosts(
+					"dave.ts.com.", "1.2.3.4",
+					"bradfitz.ts.com.", "2.3.4.5"),
+				AuthoritativeSuffixes: strs("ts.com"),
+			},
+			os: OSConfig{
+				Nameservers:   mustIPs("100.100.100.100"),
+				SearchDomains: strs("tailscale.com", "universe.tf"),
+			},
+			rs: resolver.Config{
+				Routes: upstreams(".", "1.1.1.1:53", "9.9.9.9:53"),
+				Hosts: hosts(
+					"dave.ts.com.", "1.2.3.4",
+					"bradfitz.ts.com.", "2.3.4.5"),
+				LocalDomains: strs("ts.com."),
+			},
+		},
+		{
+			name: "corp-magic-split",
+			in: Config{
+				DefaultResolvers: mustIPPs("1.1.1.1:53", "9.9.9.9:53"),
+				SearchDomains:    strs("tailscale.com", "universe.tf"),
+				Hosts: hosts(
+					"dave.ts.com.", "1.2.3.4",
+					"bradfitz.ts.com.", "2.3.4.5"),
+				AuthoritativeSuffixes: strs("ts.com"),
+			},
+			split: true,
+			os: OSConfig{
+				Nameservers:   mustIPs("100.100.100.100"),
+				SearchDomains: strs("tailscale.com", "universe.tf"),
+			},
+			rs: resolver.Config{
+				Routes: upstreams(".", "1.1.1.1:53", "9.9.9.9:53"),
+				Hosts: hosts(
+					"dave.ts.com.", "1.2.3.4",
+					"bradfitz.ts.com.", "2.3.4.5"),
+				LocalDomains: strs("ts.com."),
+			},
+		},
+		{
+			name: "corp-routes",
+			in: Config{
+				DefaultResolvers: mustIPPs("1.1.1.1:53", "9.9.9.9:53"),
+				Routes:           upstreams("corp.com", "2.2.2.2:53"),
+				SearchDomains:    strs("tailscale.com", "universe.tf"),
+			},
+			os: OSConfig{
+				Nameservers:   mustIPs("100.100.100.100"),
+				SearchDomains: strs("tailscale.com", "universe.tf"),
+			},
+			rs: resolver.Config{
+				Routes: upstreams(
+					".", "1.1.1.1:53", "9.9.9.9:53",
+					"corp.com.", "2.2.2.2:53"),
+			},
+		},
+		{
+			name: "corp-routes-split",
+			in: Config{
+				DefaultResolvers: mustIPPs("1.1.1.1:53", "9.9.9.9:53"),
+				Routes:           upstreams("corp.com", "2.2.2.2:53"),
+				SearchDomains:    strs("tailscale.com", "universe.tf"),
+			},
+			split: true,
+			os: OSConfig{
+				Nameservers:   mustIPs("100.100.100.100"),
+				SearchDomains: strs("tailscale.com", "universe.tf"),
+			},
+			rs: resolver.Config{
+				Routes: upstreams(
+					".", "1.1.1.1:53", "9.9.9.9:53",
+					"corp.com.", "2.2.2.2:53"),
+			},
+		},
+		{
+			name: "routes",
+			in: Config{
+				Routes:        upstreams("corp.com", "2.2.2.2:53"),
+				SearchDomains: strs("tailscale.com", "universe.tf"),
+			},
+			os: OSConfig{
+				Nameservers:   mustIPs("100.100.100.100"),
+				SearchDomains: strs("tailscale.com", "universe.tf"),
+			},
+			rs: resolver.Config{
+				Routes: upstreams(
+					".", "8.8.8.8:53",
+					"corp.com.", "2.2.2.2:53"),
+			},
+		},
+		{
+			name: "routes-split",
+			in: Config{
+				Routes:        upstreams("corp.com", "2.2.2.2:53"),
+				SearchDomains: strs("tailscale.com", "universe.tf"),
+			},
+			split: true,
+			os: OSConfig{
+				Nameservers:   mustIPs("2.2.2.2"),
+				SearchDomains: strs("tailscale.com", "universe.tf"),
+				MatchDomains:  strs("corp.com"),
+			},
+		},
+		{
+			name: "routes-multi",
+			in: Config{
+				Routes: upstreams(
+					"corp.com", "2.2.2.2:53",
+					"bigco.net", "3.3.3.3:53"),
+				SearchDomains: strs("tailscale.com", "universe.tf"),
+			},
+			os: OSConfig{
+				Nameservers:   mustIPs("100.100.100.100"),
+				SearchDomains: strs("tailscale.com", "universe.tf"),
+			},
+			rs: resolver.Config{
+				Routes: upstreams(
+					".", "8.8.8.8:53",
+					"corp.com.", "2.2.2.2:53",
+					"bigco.net.", "3.3.3.3:53"),
+			},
+		},
+		{
+			name: "routes-multi-split",
+			in: Config{
+				Routes: upstreams(
+					"corp.com", "2.2.2.2:53",
+					"bigco.net", "3.3.3.3:53"),
+				SearchDomains: strs("tailscale.com", "universe.tf"),
+			},
+			split: true,
+			os: OSConfig{
+				Nameservers:   mustIPs("100.100.100.100"),
+				SearchDomains: strs("tailscale.com", "universe.tf"),
+				MatchDomains:  strs("corp.com", "bigco.net"),
+			},
+			rs: resolver.Config{
+				Routes: upstreams(
+					"corp.com.", "2.2.2.2:53",
+					"bigco.net.", "3.3.3.3:53"),
+			},
+		},
+		{
+			name: "magic",
+			in: Config{
+				Hosts: hosts(
+					"dave.ts.com.", "1.2.3.4",
+					"bradfitz.ts.com.", "2.3.4.5"),
+				AuthoritativeSuffixes: strs("ts.com"),
+				SearchDomains:         strs("tailscale.com", "universe.tf"),
+			},
+			os: OSConfig{
+				Nameservers:   mustIPs("100.100.100.100"),
+				SearchDomains: strs("tailscale.com", "universe.tf"),
+			},
+			rs: resolver.Config{
+				Routes: upstreams(".", "8.8.8.8:53"),
+				Hosts: hosts(
+					"dave.ts.com.", "1.2.3.4",
+					"bradfitz.ts.com.", "2.3.4.5"),
+				LocalDomains: strs("ts.com."),
+			},
+		},
+		{
+			name: "magic-split",
+			in: Config{
+				Hosts: hosts(
+					"dave.ts.com.", "1.2.3.4",
+					"bradfitz.ts.com.", "2.3.4.5"),
+				AuthoritativeSuffixes: strs("ts.com"),
+				SearchDomains:         strs("tailscale.com", "universe.tf"),
+			},
+			split: true,
+			os: OSConfig{
+				Nameservers:   mustIPs("100.100.100.100"),
+				SearchDomains: strs("tailscale.com", "universe.tf"),
+				MatchDomains:  strs("ts.com"),
+			},
+			rs: resolver.Config{
+				Hosts: hosts(
+					"dave.ts.com.", "1.2.3.4",
+					"bradfitz.ts.com.", "2.3.4.5"),
+				LocalDomains: strs("ts.com."),
+			},
+		},
+		{
+			name: "routes-magic",
+			in: Config{
+				Routes: upstreams("corp.com", "2.2.2.2:53"),
+				Hosts: hosts(
+					"dave.ts.com.", "1.2.3.4",
+					"bradfitz.ts.com.", "2.3.4.5"),
+				AuthoritativeSuffixes: strs("ts.com"),
+				SearchDomains:         strs("tailscale.com", "universe.tf"),
+			},
+			os: OSConfig{
+				Nameservers:   mustIPs("100.100.100.100"),
+				SearchDomains: strs("tailscale.com", "universe.tf"),
+			},
+			rs: resolver.Config{
+				Routes: upstreams(
+					"corp.com.", "2.2.2.2:53",
+					".", "8.8.8.8:53"),
+				Hosts: hosts(
+					"dave.ts.com.", "1.2.3.4",
+					"bradfitz.ts.com.", "2.3.4.5"),
+				LocalDomains: strs("ts.com."),
+			},
+		},
+		{
+			name: "routes-magic-split",
+			in: Config{
+				Routes: upstreams("corp.com", "2.2.2.2:53"),
+				Hosts: hosts(
+					"dave.ts.com.", "1.2.3.4",
+					"bradfitz.ts.com.", "2.3.4.5"),
+				AuthoritativeSuffixes: strs("ts.com"),
+				SearchDomains:         strs("tailscale.com", "universe.tf"),
+			},
+			split: true,
+			os: OSConfig{
+				Nameservers:   mustIPs("100.100.100.100"),
+				SearchDomains: strs("tailscale.com", "universe.tf"),
+				MatchDomains:  strs("ts.com", "corp.com"),
+			},
+			rs: resolver.Config{
+				Routes: upstreams("corp.com.", "2.2.2.2:53"),
+				Hosts: hosts(
+					"dave.ts.com.", "1.2.3.4",
+					"bradfitz.ts.com.", "2.3.4.5"),
+				LocalDomains: strs("ts.com."),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := fakeOSConfigurator{SplitDNS: test.split}
+			m := NewManager(t.Logf, &f, nil)
+			m.resolver.TestOnlySetHook(f.SetResolver)
+
+			if err := m.Set(test.in); err != nil {
+				t.Fatalf("m.Set: %v", err)
+			}
+			tr := cmp.Transformer("ipStr", func(ip netaddr.IP) string { return ip.String() })
+			if diff := cmp.Diff(f.OSConfig, test.os, tr, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("wrong OSConfig (-got+want)\n%s", diff)
+			}
+			if diff := cmp.Diff(f.ResolverConfig, test.rs, tr, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("wrong resolver.Config (-got+want)\n%s", diff)
+			}
+		})
+	}
+}
+
+func mustIPs(strs ...string) (ret []netaddr.IP) {
+	for _, s := range strs {
+		ret = append(ret, netaddr.MustParseIP(s))
+	}
+	return ret
+}
+
+func mustIPPs(strs ...string) (ret []netaddr.IPPort) {
+	for _, s := range strs {
+		ret = append(ret, netaddr.MustParseIPPort(s))
+	}
+	return ret
+}
+
+func strs(strs ...string) []string { return strs }
+
+func hosts(strs ...string) (ret map[string][]netaddr.IP) {
+	var key string
+	ret = map[string][]netaddr.IP{}
+	for _, s := range strs {
+		if ip, err := netaddr.ParseIP(s); err == nil {
+			if key == "" {
+				panic("IP provided before name")
+			}
+			ret[key] = append(ret[key], ip)
+		} else {
+			key = s
+		}
+	}
+	return ret
+}
+
+func upstreams(strs ...string) (ret map[string][]netaddr.IPPort) {
+	var key string
+	ret = map[string][]netaddr.IPPort{}
+	for _, s := range strs {
+		if ipp, err := netaddr.ParseIPPort(s); err == nil {
+			if key == "" {
+				panic("IPPort provided before suffix")
+			}
+			ret[key] = append(ret[key], ipp)
+		} else {
+			key = s
+		}
+	}
+	return ret
+}

--- a/net/dns/manager_test.go
+++ b/net/dns/manager_test.go
@@ -36,6 +36,11 @@ func (c *fakeOSConfigurator) SupportsSplitDNS() bool {
 	return c.SplitDNS
 }
 
+func (c *fakeOSConfigurator) GetBaseConfig() (OSConfig, error) {
+	// TODO
+	return OSConfig{}, nil
+}
+
 func (c *fakeOSConfigurator) Close() error { return nil }
 
 func TestManager(t *testing.T) {

--- a/net/dns/manager_windows.go
+++ b/net/dns/manager_windows.go
@@ -300,6 +300,23 @@ func (m windowsManager) Close() error {
 	return m.SetDNS(OSConfig{})
 }
 
+func (m windowsManager) GetBaseConfig() (OSConfig, error) {
+	if m.nrptWorks {
+		return OSConfig{}, errors.New("GetBaseConfig not supported")
+	}
+	resolvers, err := m.getBasePrimaryResolver()
+	if err != nil {
+		return OSConfig{}, err
+	}
+	return OSConfig{
+		Nameservers: resolvers,
+		// Don't return any search domains here, because even Windows
+		// 7 correctly handles blending search domains from multiple
+		// sources, and any search domains we add here will get tacked
+		// onto the Tailscale config unnecessarily.
+	}, nil
+}
+
 // getBasePrimaryResolver returns a guess of the non-Tailscale primary
 // resolver on the system.
 // It's used on Windows 7 to emulate split DNS by trying to figure out

--- a/net/dns/manager_windows.go
+++ b/net/dns/manager_windows.go
@@ -301,9 +301,6 @@ func (m windowsManager) Close() error {
 }
 
 func (m windowsManager) GetBaseConfig() (OSConfig, error) {
-	if m.nrptWorks {
-		return OSConfig{}, errors.New("GetBaseConfig not supported")
-	}
 	resolvers, err := m.getBasePrimaryResolver()
 	if err != nil {
 		return OSConfig{}, err

--- a/net/dns/nm.go
+++ b/net/dns/nm.go
@@ -202,6 +202,11 @@ func (m nmManager) SetDNS(config OSConfig) error {
 
 func (m nmManager) SupportsSplitDNS() bool { return false }
 
+func (m nmManager) GetBaseConfig() (OSConfig, error) {
+	// TODO
+	return OSConfig{}, nil
+}
+
 func (m nmManager) Close() error {
 	return m.SetDNS(OSConfig{})
 }

--- a/net/dns/nm.go
+++ b/net/dns/nm.go
@@ -203,8 +203,7 @@ func (m nmManager) SetDNS(config OSConfig) error {
 func (m nmManager) SupportsSplitDNS() bool { return false }
 
 func (m nmManager) GetBaseConfig() (OSConfig, error) {
-	// TODO
-	return OSConfig{}, nil
+	return OSConfig{}, ErrGetBaseConfigNotSupported
 }
 
 func (m nmManager) Close() error {

--- a/net/dns/noop.go
+++ b/net/dns/noop.go
@@ -6,9 +6,10 @@ package dns
 
 type noopManager struct{}
 
-func (m noopManager) SetDNS(OSConfig) error  { return nil }
-func (m noopManager) SupportsSplitDNS() bool { return false }
-func (m noopManager) Close() error           { return nil }
+func (m noopManager) SetDNS(OSConfig) error            { return nil }
+func (m noopManager) SupportsSplitDNS() bool           { return false }
+func (m noopManager) Close() error                     { return nil }
+func (m noopManager) GetBaseConfig() (OSConfig, error) { return OSConfig{}, nil }
 
 func NewNoopManager() noopManager {
 	return noopManager{}

--- a/net/dns/noop.go
+++ b/net/dns/noop.go
@@ -6,10 +6,12 @@ package dns
 
 type noopManager struct{}
 
-func (m noopManager) SetDNS(OSConfig) error            { return nil }
-func (m noopManager) SupportsSplitDNS() bool           { return false }
-func (m noopManager) Close() error                     { return nil }
-func (m noopManager) GetBaseConfig() (OSConfig, error) { return OSConfig{}, nil }
+func (m noopManager) SetDNS(OSConfig) error  { return nil }
+func (m noopManager) SupportsSplitDNS() bool { return false }
+func (m noopManager) Close() error           { return nil }
+func (m noopManager) GetBaseConfig() (OSConfig, error) {
+	return OSConfig{}, ErrGetBaseConfigNotSupported
+}
 
 func NewNoopManager() noopManager {
 	return noopManager{}

--- a/net/dns/osconfig.go
+++ b/net/dns/osconfig.go
@@ -4,7 +4,11 @@
 
 package dns
 
-import "inet.af/netaddr"
+import (
+	"errors"
+
+	"inet.af/netaddr"
+)
 
 // An OSConfigurator applies DNS settings to the operating system.
 type OSConfigurator interface {
@@ -23,6 +27,9 @@ type OSConfigurator interface {
 	// GetBaseConfig must return the tailscale-free base config even
 	// after SetDNS has been called to set a Tailscale configuration.
 	// Only works when SupportsSplitDNS=false.
+
+	// Implementations that don't support getting the base config must
+	// return ErrGetBaseConfigNotSupported.
 	GetBaseConfig() (OSConfig, error)
 	// Close removes Tailscale-related DNS configuration from the OS.
 	Close() error
@@ -43,3 +50,8 @@ type OSConfig struct {
 	// report SupportsSplitDNS()=true.
 	MatchDomains []string
 }
+
+// ErrGetBaseConfigNotSupported is the error
+// OSConfigurator.GetBaseConfig returns when the OSConfigurator
+// doesn't support reading the underlying configuration out of the OS.
+var ErrGetBaseConfigNotSupported = errors.New("getting OS base config is not supported")

--- a/net/dns/osconfig.go
+++ b/net/dns/osconfig.go
@@ -17,6 +17,13 @@ type OSConfigurator interface {
 	// installing a resolver only for specific DNS suffixes. If false,
 	// the configurator can only set a global resolver.
 	SupportsSplitDNS() bool
+	// GetBaseConfig returns the OS's "base" configuration, i.e. the
+	// resolver settings the OS would use without Tailscale
+	// contributing any configuration.
+	// GetBaseConfig must return the tailscale-free base config even
+	// after SetDNS has been called to set a Tailscale configuration.
+	// Only works when SupportsSplitDNS=false.
+	GetBaseConfig() (OSConfig, error)
 	// Close removes Tailscale-related DNS configuration from the OS.
 	Close() error
 }

--- a/net/dns/resolvconf.go
+++ b/net/dns/resolvconf.go
@@ -143,8 +143,7 @@ func (m resolvconfManager) SupportsSplitDNS() bool {
 }
 
 func (m resolvconfManager) GetBaseConfig() (OSConfig, error) {
-	// TODO
-	return OSConfig{}, nil
+	return OSConfig{}, ErrGetBaseConfigNotSupported
 }
 
 func (m resolvconfManager) Close() error {

--- a/net/dns/resolvconf.go
+++ b/net/dns/resolvconf.go
@@ -142,6 +142,11 @@ func (m resolvconfManager) SupportsSplitDNS() bool {
 	return false
 }
 
+func (m resolvconfManager) GetBaseConfig() (OSConfig, error) {
+	// TODO
+	return OSConfig{}, nil
+}
+
 func (m resolvconfManager) Close() error {
 	var cmd *exec.Cmd
 	switch m.impl {

--- a/net/dns/resolved.go
+++ b/net/dns/resolved.go
@@ -158,8 +158,7 @@ func (m resolvedManager) SupportsSplitDNS() bool {
 }
 
 func (m resolvedManager) GetBaseConfig() (OSConfig, error) {
-	// TODO
-	return OSConfig{}, nil
+	return OSConfig{}, ErrGetBaseConfigNotSupported
 }
 
 func (m resolvedManager) Close() error {

--- a/net/dns/resolved.go
+++ b/net/dns/resolved.go
@@ -157,6 +157,11 @@ func (m resolvedManager) SupportsSplitDNS() bool {
 	return false
 }
 
+func (m resolvedManager) GetBaseConfig() (OSConfig, error) {
+	// TODO
+	return OSConfig{}, nil
+}
+
 func (m resolvedManager) Close() error {
 	ctx, cancel := context.WithTimeout(context.Background(), reconfigTimeout)
 	defer cancel()

--- a/wgengine/router/callback.go
+++ b/wgengine/router/callback.go
@@ -49,6 +49,11 @@ func (r *CallbackRouter) SupportsSplitDNS() bool {
 	return r.SplitDNS
 }
 
+func (r *CallbackRouter) GetBaseConfig() (dns.OSConfig, error) {
+	// TODO
+	return dns.OSConfig{}, nil
+}
+
 func (r *CallbackRouter) Close() error {
 	return r.SetBoth(nil, nil) // TODO: check if makes sense
 }

--- a/wgengine/router/callback.go
+++ b/wgengine/router/callback.go
@@ -50,8 +50,7 @@ func (r *CallbackRouter) SupportsSplitDNS() bool {
 }
 
 func (r *CallbackRouter) GetBaseConfig() (dns.OSConfig, error) {
-	// TODO
-	return dns.OSConfig{}, nil
+	return dns.OSConfig{}, dns.ErrGetBaseConfigNotSupported
 }
 
 func (r *CallbackRouter) Close() error {


### PR DESCRIPTION
With this, and split DNS forced on in net/dns (not plumbed through tailcfg yet), split DNS works on Windows 7 through 10. Other DNS managers still need to implement the couple of API calls to make it go, but this is the meaty core of "figure out how to implement a requested DNS config based on what the OS can do".

Also includes exhaustive tests covering the possible configurations stemming from the high-level intent.