### PR TITLE
ipn/{ipnlocal,localapi}, cmd/tailscale: add logout command

### DIFF
--- a/client/tailscale/tailscale.go
+++ b/client/tailscale/tailscale.go
@@ -212,3 +212,8 @@ func GetPrefs(ctx context.Context) (*ipn.Prefs, error) {
 	}
 	return &p, nil
 }
+
+func Logout(ctx context.Context) error {
+	_, err := send(ctx, "POST", "/localapi/v0/logout", http.StatusNoContent, nil)
+	return err
+}

--- a/cmd/tailscale/cli/cli.go
+++ b/cmd/tailscale/cli/cli.go
@@ -64,6 +64,7 @@ change in the future.
 		Subcommands: []*ffcli.Command{
 			upCmd,
 			downCmd,
+			logoutCmd,
 			netcheckCmd,
 			ipCmd,
 			statusCmd,

--- a/cmd/tailscale/cli/logout.go
+++ b/cmd/tailscale/cli/logout.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cli
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/peterbourgon/ff/v2/ffcli"
+	"tailscale.com/client/tailscale"
+)
+
+var logoutCmd = &ffcli.Command{
+	Name:       "logout",
+	ShortUsage: "logout [flags]",
+	ShortHelp:  "down + expire current node key",
+
+	LongHelp: strings.TrimSpace(`
+"tailscale logout" brings the network down and invalidates
+the current node key, forcing a future use of it to cause
+a reauthentication.
+`),
+	Exec: runLogout,
+}
+
+func runLogout(ctx context.Context, args []string) error {
+	if len(args) > 0 {
+		log.Fatalf("too many non-flag arguments: %q", args)
+	}
+	return tailscale.Logout(ctx)
+}

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1935,18 +1935,27 @@ func (b *LocalBackend) requestEngineStatusAndWait() {
 // transitions the local engine to the logged-out state without
 // waiting for controlclient to be in that state.
 //
-// TODO(danderson): controlclient Logout does nothing useful, and we
-// shouldn't be transitioning to a state based on what we believe
-// controlclient may have done.
-//
 // NOTE(apenwarr): No easy way to persist logged-out status.
 //  Maybe that's for the better; if someone logs out accidentally,
 //  rebooting will fix it.
 func (b *LocalBackend) Logout() {
+	b.logout(context.Background(), false)
+}
+
+func (b *LocalBackend) LogoutSync(ctx context.Context) error {
+	return b.logout(ctx, true)
+}
+
+func (b *LocalBackend) logout(ctx context.Context, sync bool) error {
 	b.mu.Lock()
 	cc := b.cc
 	b.setNetMapLocked(nil)
 	b.mu.Unlock()
+
+	b.EditPrefs(&ipn.MaskedPrefs{
+		WantRunningSet: true,
+		Prefs:          ipn.Prefs{WantRunning: true},
+	})
 
 	if cc == nil {
 		// Double Logout can happen via repeated IPN
@@ -1956,16 +1965,22 @@ func (b *LocalBackend) Logout() {
 		// on the transition to zero.
 		// Previously this crashed when we asserted that c was non-nil
 		// here.
-		return
+		return errors.New("no controlclient")
 	}
 
-	cc.Logout()
+	var err error
+	if sync {
+		err = cc.Logout(ctx)
+	} else {
+		cc.StartLogout()
+	}
 
 	b.mu.Lock()
 	b.setNetMapLocked(nil)
 	b.mu.Unlock()
 
 	b.stateMachine()
+	return err
 }
 
 // assertClientLocked crashes if there is no controlclient in this backend.

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -87,6 +87,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.serveGoroutines(w, r)
 	case "/localapi/v0/status":
 		h.serveStatus(w, r)
+	case "/localapi/v0/logout":
+		h.serveLogout(w, r)
 	case "/localapi/v0/prefs":
 		h.servePrefs(w, r)
 	case "/localapi/v0/check-ip-forwarding":
@@ -198,6 +200,23 @@ func (h *Handler) serveStatus(w http.ResponseWriter, r *http.Request) {
 	e := json.NewEncoder(w)
 	e.SetIndent("", "\t")
 	e.Encode(st)
+}
+
+func (h *Handler) serveLogout(w http.ResponseWriter, r *http.Request) {
+	if !h.PermitWrite {
+		http.Error(w, "logout access denied", http.StatusForbidden)
+		return
+	}
+	if r.Method != "POST" {
+		http.Error(w, "want POST", 400)
+		return
+	}
+	err := h.b.LogoutSync(r.Context())
+	if err == nil {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	http.Error(w, err.Error(), 500)
 }
 
 func (h *Handler) servePrefs(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Adds `tailscale logout` and makes "Log out" from GUIs actually log out, telling the server that the node key should be immediately expired.
