### PR TITLE
cmd/tailscale: fix capitalization

### DIFF
--- a/cmd/tailscale/cli/logout.go
+++ b/cmd/tailscale/cli/logout.go
@@ -16,7 +16,7 @@ import (
 var logoutCmd = &ffcli.Command{
 	Name:       "logout",
 	ShortUsage: "logout [flags]",
-	ShortHelp:  "down + expire current node key",
+	ShortHelp:  "Disconnect from Tailscale and expire current node key",
 
 	LongHelp: strings.TrimSpace(`
 "tailscale logout" brings the network down and invalidates

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -30,7 +30,7 @@ import (
 var upCmd = &ffcli.Command{
 	Name:       "up",
 	ShortUsage: "up [flags]",
-	ShortHelp:  "Connect to your Tailscale network",
+	ShortHelp:  "Connect to Tailscale, logging in if needed",
 
 	LongHelp: strings.TrimSpace(`
 "tailscale up" connects this machine to your Tailscale network,


### PR DESCRIPTION
Fixes the capitalization of a command so it's consistent with the rest:

```diff
  SUBCOMMANDS
    up         Connect to your Tailscale network
    down       Disconnect from Tailscale
-   logout     down + expire current node key
+   logout     Down and expire current node key
    netcheck   Print an analysis of local network conditions
    ip         Show current Tailscale IP address(es)
    status     Show state of tailscaled and its connections
    ping       Ping a host at the Tailscale layer, see how it routed
    version    Print Tailscale version
    web        Run a web server for controlling Tailscale
    push       Push a file to a host
    bugreport  Print a shareable identifier to help diagnose issues
```