### PR TITLE
ipn{,/ipnlocal}, cmd/tailscale/cli: don't check pref reverts on initial up

### DIFF
--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -499,6 +499,10 @@ func checkForAccidentalSettingReverts(flagSet map[string]bool, curPrefs *ipn.Pre
 		// mean bringing the network up without any changes.
 		return nil
 	}
+	if curPrefs.ControlURL == "" {
+		// Don't validate things on initial "up" before a control URL has been set.
+		return nil
+	}
 	curWithExplicitEdits := curPrefs.Clone()
 	curWithExplicitEdits.ApplyEdits(mp)
 

--- a/ipn/fake_test.go
+++ b/ipn/fake_test.go
@@ -19,7 +19,7 @@ type FakeBackend struct {
 }
 
 func (b *FakeBackend) Start(opts Options) error {
-	b.serverURL = opts.Prefs.ControlURL
+	b.serverURL = opts.Prefs.ControlURLOrDefault()
 	if b.notify == nil {
 		panic("FakeBackend.Start: SetNotifyCallback not called")
 	}

--- a/ipn/handle.go
+++ b/ipn/handle.go
@@ -156,7 +156,7 @@ func (h *Handle) Expiry() time.Time {
 }
 
 func (h *Handle) AdminPageURL() string {
-	return h.prefsCache.ControlURL + "/admin/machines"
+	return h.prefsCache.ControlURLOrDefault() + "/admin/machines"
 }
 
 func (h *Handle) StartLoginInteractive() {

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -436,6 +436,15 @@ func (b *LocalBackend) setClientStatus(st controlclient.Status) {
 	netMap := b.netMap
 	interact := b.interact
 
+	if prefs.ControlURL == "" {
+		// Once we get a message from the control plane, set
+		// our ControlURL pref explicitly. This causes a
+		// future "tailscale up" to start checking for
+		// implicit setting reverts, which it doesn't do when
+		// ControlURL is blank.
+		prefs.ControlURL = prefs.ControlURLOrDefault()
+		prefsChanged = true
+	}
 	if st.Persist != nil {
 		if !b.prefs.Persist.Equals(st.Persist) {
 			prefsChanged = true
@@ -637,7 +646,7 @@ func (b *LocalBackend) Start(opts ipn.Options) error {
 	}
 
 	b.inServerMode = b.prefs.ForceDaemon
-	b.serverURL = b.prefs.ControlURL
+	b.serverURL = b.prefs.ControlURLOrDefault()
 	hostinfo.RoutableIPs = append(hostinfo.RoutableIPs, b.prefs.AdvertiseRoutes...)
 	hostinfo.RequestTags = append(hostinfo.RequestTags, b.prefs.AdvertiseTags...)
 	if b.inServerMode || runtime.GOOS == "windows" {


### PR DESCRIPTION
The ipn.NewPrefs func returns a populated ipn.Prefs for historical
reasons. It's not used or as important as it once was, but it hasn't
yet been removed. Meanwhile, it contains some default values that are
used on some platforms. Notably, for this bug (#1725), Windows/Mac use
its Prefs.RouteAll true value (to accept subnets), but Linux users
have always gotten a "false" value for that, because that's what
cmd/tailscale's CLI default flag is _for all operating systems_.  That
meant that "tailscale up" was rightfully reporting that the user was
changing an implicit setting: RouteAll was changing from true with
false with the user explicitly saying so.

An obvious fix might be to change ipn.NewPrefs to return
Prefs.RouteAll == false on some platforms, but the logic is
complicated by darwin: we want RouteAll true on windows, android, ios,
and the GUI mac app, but not the CLI mac app. But even if we used
build tags (e.g. the "redo" build tag) to determine what the default
is, that then means we have duplicated and differing "defaults" between
both the CLI up flags and ipn.NewPrefs. Furthering that complication
didn't seem like a good idea.

So, changing the NewPrefs defaults is too invasive at this stage of
the release, as is removing the NewPrefs func entirely.

Instead, tweak slightly the semantics of the ipn.Prefs.ControlURL
field.  This now defines that a ControlURL of the empty string means
both "we're uninitialized" and also "just use the default". A new
constant then replies a handful of repeated
"https://login.tailscale.com/" literals.

Then, once we have the "empty-string-means-unintialized" semantics,
use that to suppress "tailscale up"'s recent implicit-setting-revert
checking safety net, if we've never initialized Tailscale yet.

And update/add tests.

Fixes #1725