### PR TITLE
tailcfg, control/controlclient: accept nil MapResponse.Node (mapver 18)

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -798,6 +798,10 @@ func (c *Direct) sendMapRequest(ctx context.Context, maxPolls int, cb func(*netm
 		}
 
 		nm := sess.netmapForResponse(&resp)
+		if nm.SelfNode == nil {
+			c.logf("MapResponse lacked node")
+			return errors.New("MapResponse lacked node")
+		}
 
 		// Temporarily (2020-06-29) support removing all but
 		// discovery-supporting nodes during development, for

--- a/control/controlclient/map_test.go
+++ b/control/controlclient/map_test.go
@@ -5,6 +5,7 @@
 package controlclient
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -275,5 +276,36 @@ func TestNetmapForResponse(t *testing.T) {
 			Node: new(tailcfg.Node),
 		})
 		want("foo.com")
+	})
+	t.Run("implicit_node", func(t *testing.T) {
+		someNode := &tailcfg.Node{
+			Name: "foo",
+		}
+		wantNode := &tailcfg.Node{
+			Name:                 "foo",
+			ComputedName:         "foo",
+			ComputedNameWithHost: "foo",
+		}
+		ms := newTestMapSession(t)
+
+		nm1 := ms.netmapForResponse(&tailcfg.MapResponse{
+			Node: someNode,
+		})
+		if nm1.SelfNode == nil {
+			t.Fatal("nil Node in 1st netmap")
+		}
+		if !reflect.DeepEqual(nm1.SelfNode, wantNode) {
+			j, _ := json.Marshal(nm1.SelfNode)
+			t.Errorf("Node mismatch in 1st netmap; got: %s", j)
+		}
+
+		nm2 := ms.netmapForResponse(&tailcfg.MapResponse{})
+		if nm2.SelfNode == nil {
+			t.Fatal("nil Node in 1st netmap")
+		}
+		if !reflect.DeepEqual(nm2.SelfNode, wantNode) {
+			j, _ := json.Marshal(nm2.SelfNode)
+			t.Errorf("Node mismatch in 2nd netmap; got: %s", j)
+		}
 	})
 }

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -40,7 +40,8 @@ import (
 //    15: 2021-04-12: client treats nil MapResponse.DNSConfig as meaning unchanged
 //    16: 2021-04-15: client understands Node.Online, MapResponse.OnlineChange
 //    17: 2021-04-18: MapResponse.Domain empty means unchanged
-const CurrentMapRequestVersion = 17
+//    18: 2021-04-19: MapResponse.Node nil means unchanged (all fields now omitempty)
+const CurrentMapRequestVersion = 18
 
 type StableID string
 
@@ -895,8 +896,14 @@ type MapResponse struct {
 	PingRequest *PingRequest `json:",omitempty"`
 
 	// Networking
-	Node    *Node
-	DERPMap *DERPMap `json:",omitempty"` // if non-empty, a change in the DERP map.
+
+	// Node describes the node making the map request.
+	// Starting with MapRequest.Version 18, nil means unchanged.
+	Node *Node `json:",omitempty"`
+
+	// DERPMap describe the set of DERP servers available.
+	// A nil value means unchanged.
+	DERPMap *DERPMap `json:",omitempty"`
 
 	// Peers, if non-empty, is the complete list of peers.
 	// It will be set in the first MapResponse for a long-polled request/response.
@@ -955,9 +962,12 @@ type MapResponse struct {
 	// previously streamed non-nil MapResponse.PacketFilter within
 	// the same HTTP response. A non-nil but empty list always means
 	// no PacketFilter (that is, to block everything).
-	PacketFilter []FilterRule
+	PacketFilter []FilterRule `json:",omitempty"`
 
-	UserProfiles []UserProfile // as of 1.1.541 (mapver 5): may be new or updated user profiles only
+	// UserProfiles are the user profiles of nodes in the network.
+	// As as of 1.1.541 (mapver 5), this contains new or updated
+	// user profiles only.
+	UserProfiles []UserProfile `json:",omitempty"`
 
 	// Debug is normally nil, except for when the control server
 	// is setting debug settings on a node.


### PR DESCRIPTION
All MapResponse fields can not be omitted and are tagged "omitempty".
