### PR TITLE
wgengine/netstack: log error when acceptUDP fails

### DIFF
--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -476,7 +476,7 @@ func (ns *Impl) acceptUDP(r *udp.ForwarderRequest) {
 	var wq waiter.Queue
 	ep, err := r.CreateEndpoint(&wq)
 	if err != nil {
-		ns.logf("Could not create endpoint, exiting")
+		ns.logf("acceptUDP: could not create endpoint: %v", err)
 		return
 	}
 	localAddr, err := ep.GetLocalAddress()


### PR DESCRIPTION
I see a bunch of these in some logs I'm looking at,
separated only by a few seconds.
Log the error so we can tell what's going on here.
