### PR TITLE
wgengine/wglog: allow wireguard-go receive routines to log

### DIFF
--- a/wgengine/wglog/wglog.go
+++ b/wgengine/wglog/wglog.go
@@ -31,7 +31,7 @@ func NewLogger(logf logger.Logf) *Logger {
 
 	wrapper := func(format string, args ...interface{}) {
 		msg := fmt.Sprintf(format, args...)
-		if strings.Contains(msg, "Routine:") {
+		if strings.Contains(msg, "Routine:") && !strings.Contains(msg, "receive incoming") {
 			// wireguard-go logs as it starts and stops routines.
 			// Drop those; there are a lot of them, and they're just noise.
 			return


### PR DESCRIPTION
I've spent two days searching for a theoretical wireguard-go bug
around receive functions exiting early.

I've found many bugs, but none of the flavor we're looking for.

Restore wireguard-go's logging around starting and stopping receive functions,
so that we can definitively rule in or out this particular theory.
