### PR TITLE
cmd/tailscale/cli: don't force an interactive login on --reset.

### DIFF
--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -435,7 +435,9 @@ func runUp(ctx context.Context, args []string) error {
 		}
 
 		bc.Start(opts)
-		startLoginInteractive()
+		if upArgs.forceReauth {
+			startLoginInteractive()
+		}
 	}
 
 	select {


### PR DESCRIPTION
Fixes #1778

Signed-off-by: David Anderson <danderson@tailscale.com>