### PR TITLE
wgengine/router{win}: ignore broadcast routes added by Windows when removing routes.

### DIFF
--- a/wgengine/router/router_linux_test.go
+++ b/wgengine/router/router_linux_test.go
@@ -20,22 +20,6 @@ import (
 	"inet.af/netaddr"
 )
 
-func mustCIDR(s string) netaddr.IPPrefix {
-	pfx, err := netaddr.ParseIPPrefix(s)
-	if err != nil {
-		panic(err)
-	}
-	return pfx
-}
-
-func mustCIDRs(ss ...string) []netaddr.IPPrefix {
-	var ret []netaddr.IPPrefix
-	for _, s := range ss {
-		ret = append(ret, mustCIDR(s))
-	}
-	return ret
-}
-
 func TestRouterStates(t *testing.T) {
 	basic := `
 ip rule add -4 pref 5210 fwmark 0x80000 table main

--- a/wgengine/router/router_test.go
+++ b/wgengine/router/router_test.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package router
+
+import "inet.af/netaddr"
+
+func mustCIDRs(ss ...string) []netaddr.IPPrefix {
+	var ret []netaddr.IPPrefix
+	for _, s := range ss {
+		ret = append(ret, netaddr.MustParseIPPrefix(s))
+	}
+	return ret
+}


### PR DESCRIPTION

Signed-off-by: Maisem Ali <maisem@tailscale.com>