### PR TITLE
[WIP] magicsock: Rebind() on Open().

### DIFF
--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -1224,6 +1224,8 @@ func (e *userspaceEngine) RequestStatus() {
 func (e *userspaceEngine) Close() {
 	var pingers []*pinger
 
+	e.logf("engine close requested")
+
 	e.mu.Lock()
 	if e.closing {
 		e.mu.Unlock()


### PR DESCRIPTION
This adds a bunch of temporary trace log messages to show that
wireguard is calling Close(); Open(); Close(); Open(); receiveIPv4()
(although sometimes receiveIPv4 happens earlier in the sequence from
another thread, I think) during rebinding.

It turns out that:
1. Open() did not actually reopen the sockets closed by Close()
2. Close() did not actually close the sockets unless you called Open()
first, which hides (1) in most cases right after startup, but would
have broken UDP sometime later, next time wireguard decides to rebind.
3. Rebind() does not actually rebind IPv6, so in any case, IPv6 could
end up broken.

This draft is not a real fix, because there's something convoluted
about the locking between Open() and Rebind(). I don't even understand
where Rebind() would normally have been called from. I didn't try to
fix the IPv6 binding problem. And I think there are still races that
would allow receiveIPv4 (or v6) to be called between Close() and Open()
operations.

Maybe a proper fix would be to have wireguard call something like
Rebind() instead of successively Close() and Open(). It doesn't
actually want our binding to close, it wants it to rebind, and it
should say so.

Updates #1790

Signed-off-by: Avery Pennarun <apenwarr@tailscale.com>