### PR TITLE
wgengine/wglog: fix wireguard-go logging rate limiting

### DIFF
--- a/wgengine/wglog/wglog.go
+++ b/wgengine/wglog/wglog.go
@@ -28,23 +28,22 @@ type Logger struct {
 // and rewrites peer keys from wireguard-go into Tailscale format.
 func NewLogger(logf logger.Logf) *Logger {
 	ret := new(Logger)
-
 	wrapper := func(format string, args ...interface{}) {
-		msg := fmt.Sprintf(format, args...)
-		if strings.Contains(msg, "Routine:") && !strings.Contains(msg, "receive incoming") {
+		if strings.Contains(format, "Routine:") && !strings.Contains(format, "receive incoming") {
 			// wireguard-go logs as it starts and stops routines.
 			// Drop those; there are a lot of them, and they're just noise.
 			return
 		}
-		if strings.Contains(msg, "Failed to send data packet") {
+		if strings.Contains(format, "Failed to send data packet") {
 			// Drop. See https://github.com/tailscale/tailscale/issues/1239.
 			return
 		}
-		if strings.Contains(msg, "Interface up requested") || strings.Contains(msg, "Interface down requested") {
+		if strings.Contains(format, "Interface up requested") || strings.Contains(format, "Interface down requested") {
 			// Drop. Logs 1/s constantly while the tun device is open.
 			// See https://github.com/tailscale/tailscale/issues/1388.
 			return
 		}
+		msg := fmt.Sprintf(format, args...)
 		r := ret.replacer.Load()
 		if r == nil {
 			// No replacements specified; log as originally planned.

--- a/wgengine/wglog/wglog.go
+++ b/wgengine/wglog/wglog.go
@@ -20,7 +20,7 @@ import (
 // It can be modified at run time to adjust to new wireguard-go configurations.
 type Logger struct {
 	DeviceLogger *device.Logger
-	replacer     atomic.Value // of *strings.Replacer
+	replace      atomic.Value // of map[string]string
 }
 
 // NewLogger creates a new logger for use with wireguard-go.
@@ -43,25 +43,33 @@ func NewLogger(logf logger.Logf) *Logger {
 			// See https://github.com/tailscale/tailscale/issues/1388.
 			return
 		}
-		msg := fmt.Sprintf(format, args...)
-		r := ret.replacer.Load()
-		if r == nil {
+		replace, _ := ret.replace.Load().(map[string]string)
+		if replace == nil {
 			// No replacements specified; log as originally planned.
 			logf(format, args...)
 			return
 		}
-		// Do the replacements.
-		new := r.(*strings.Replacer).Replace(msg)
-		if new == msg {
-			// No replacements. Log as originally planned.
-			logf(format, args...)
-			return
+		// Duplicate the args slice so that we can modify it.
+		// This is not always required, but the code required to avoid it is not worth the complexity.
+		newargs := make([]interface{}, len(args))
+		copy(newargs, args)
+		for i, arg := range newargs {
+			// We want to replace *device.Peer args with the Tailscale-formatted version of themselves.
+			// Using *device.Peer directly makes this hard to test, so we string any fmt.Stringers,
+			// and if the string ends up looking exactly like a known Peer, we replace it.
+			// This is slightly imprecise, in that we don't check the formatting verb. Oh well.
+			s, ok := arg.(fmt.Stringer)
+			if !ok {
+				continue
+			}
+			wgStr := s.String()
+			tsStr, ok := replace[wgStr]
+			if !ok {
+				continue
+			}
+			newargs[i] = tsStr
 		}
-		// We made some replacements. Log the new version.
-		// This changes the format string,
-		// which is somewhat unfortunate as it impacts rate limiting,
-		// but there's not much we can do about that.
-		logf("%s", new)
+		logf(format, newargs...)
 	}
 	ret.DeviceLogger = &device.Logger{
 		Verbosef: logger.WithPrefix(wrapper, "[v2] "),
@@ -74,14 +82,13 @@ func NewLogger(logf logger.Logf) *Logger {
 // SetPeers is safe for concurrent use.
 func (x *Logger) SetPeers(peers []wgcfg.Peer) {
 	// Construct a new peer public key log rewriter.
-	var replace []string
+	replace := make(map[string]string)
 	for _, peer := range peers {
 		old := "peer(" + wireguardGoString(peer.PublicKey) + ")"
 		new := peer.PublicKey.ShortString()
-		replace = append(replace, old, new)
+		replace[old] = new
 	}
-	r := strings.NewReplacer(replace...)
-	x.replacer.Store(r)
+	x.replace.Store(replace)
 }
 
 // wireguardGoString prints p in the same format used by wireguard-go.

--- a/wgengine/wglog/wglog_test.go
+++ b/wgengine/wglog/wglog_test.go
@@ -14,22 +14,27 @@ import (
 
 func TestLogger(t *testing.T) {
 	tests := []struct {
-		in   string
-		want string
-		omit bool
+		format string
+		args   []interface{}
+		want   string
+		omit   bool
 	}{
-		{"hi", "hi", false},
-		{"Routine: starting", "", true},
-		{"peer(IMTB…r7lM) says it misses you", "[IMTBr] says it misses you", false},
+		{"hi", nil, "hi", false},
+		{"Routine: starting", nil, "", true},
+		{"%v says it misses you", []interface{}{stringer("peer(IMTB…r7lM)")}, "[IMTBr] says it misses you", false},
 	}
 
-	c := make(chan string, 1)
+	type log struct {
+		format string
+		args   []interface{}
+	}
+
+	c := make(chan log, 1)
 	logf := func(format string, args ...interface{}) {
-		s := fmt.Sprintf(format, args...)
 		select {
-		case c <- s:
+		case c <- log{format, args}:
 		default:
-			t.Errorf("wrote %q, but shouldn't have", s)
+			t.Errorf("wrote %q, but shouldn't have", fmt.Sprintf(format, args...))
 		}
 	}
 
@@ -44,15 +49,23 @@ func TestLogger(t *testing.T) {
 		if tt.omit {
 			// Write a message ourselves into the channel.
 			// Then if logf also attempts to write into the channel, it'll fail.
-			c <- ""
+			c <- log{}
 		}
-		x.DeviceLogger.Errorf(tt.in)
-		got := <-c
+		x.DeviceLogger.Errorf(tt.format, tt.args...)
+		gotLog := <-c
 		if tt.omit {
 			continue
 		}
-		if got != tt.want {
-			t.Errorf("Println(%q) = %q want %q", tt.in, got, tt.want)
+		if got := fmt.Sprintf(gotLog.format, gotLog.args...); got != tt.want {
+			t.Errorf("Printf(%q, %v) = %q want %q", tt.format, tt.args, got, tt.want)
 		}
 	}
 }
+
+func stringer(s string) stringerString {
+	return stringerString(s)
+}
+
+type stringerString string
+
+func (s stringerString) String() string { return string(s) }


### PR DESCRIPTION
Two commits; review one at a time.
