### PR TITLE
ipn: cc.Login(noninteractive) at start even if WantRunning=false.

### DIFF
--- a/ipn/backend.go
+++ b/ipn/backend.go
@@ -17,13 +17,13 @@ import (
 type State int
 
 const (
-	NoState = State(iota)
-	InUseOtherUser
-	NeedsLogin
-	NeedsMachineAuth
-	Stopped
-	Starting
-	Running
+	NoState          = State(iota)
+	InUseOtherUser   // backend is in use by another user
+	NeedsLogin       // an *interactive* user login is required; URL available
+	NeedsMachineAuth // logged in, but machine key needs approval
+	Stopped          // user requested WantRunning=false
+	Starting         // in transition from stopped to running
+	Running          // network is connected
 )
 
 // GoogleIDToken Type is the tailcfg.Oauth2Token.TokenType for the Google

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -5,20 +5,15 @@
 package ipnlocal
 
 import (
-	"bytes"
-	"fmt"
 	"net/http"
 	"reflect"
-	"sync"
 	"testing"
 
 	"inet.af/netaddr"
-	"tailscale.com/ipn"
 	"tailscale.com/net/interfaces"
 	"tailscale.com/net/tsaddr"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/netmap"
-	"tailscale.com/wgengine"
 	"tailscale.com/wgengine/wgcfg"
 )
 
@@ -433,40 +428,3 @@ func (panicOnUseTransport) RoundTrip(*http.Request) (*http.Response, error) {
 }
 
 var nl = []byte("\n")
-
-func TestStartsInNeedsLoginState(t *testing.T) {
-	var (
-		mu     sync.Mutex
-		logBuf bytes.Buffer
-	)
-	logf := func(format string, a ...interface{}) {
-		mu.Lock()
-		defer mu.Unlock()
-		fmt.Fprintf(&logBuf, format, a...)
-		if !bytes.HasSuffix(logBuf.Bytes(), nl) {
-			logBuf.Write(nl)
-		}
-	}
-	store := new(ipn.MemoryStore)
-	eng, err := wgengine.NewFakeUserspaceEngine(logf, 0)
-	if err != nil {
-		t.Fatalf("NewFakeUserspaceEngine: %v", err)
-	}
-	lb, err := NewLocalBackend(logf, "logid", store, eng)
-	if err != nil {
-		t.Fatalf("NewLocalBackend: %v", err)
-	}
-
-	lb.SetHTTPTestClient(&http.Client{
-		Transport: panicOnUseTransport{}, // validate we don't send HTTP requests
-	})
-
-	if err := lb.Start(ipn.Options{
-		StateKey: ipn.GlobalDaemonStateKey,
-	}); err != nil {
-		t.Fatalf("Start: %v", err)
-	}
-	if st := lb.State(); st != ipn.NeedsLogin {
-		t.Errorf("State = %v; want NeedsLogin", st)
-	}
-}


### PR DESCRIPTION
We were not properly initializing controlclient at startup, if
Prefs.WantRunning was initially false. This originally would cause the
state machine to get stuck in NewState, but an earlier erroneous change
tried to make it get stuck in NeedsLogin instead, which is incorrect;
NeedsLogin means we need *interactive* login, which is not true. The
correct fix is to not get it stuck.

While we're here:
- Add a bunch of comments to explain how these work.
- Unexport the Status.state var from controlclient. There has not been
  any need for outsiders to inspect it for a long time; it's needed
  only by unit tests.
- Remove a very suspicious check from AuthCantContinue that its self
  pointer != nil.
- Remove an extremely suspicious "defer b.stateMachine()" from Start().
  There is no need to run the state machine when nothing has happened
  yet; any apparent need for this is a sign of some other bug.

Fixes tailscale/corp#1660 (iOS app startup bug)

Signed-off-by: Avery Pennarun <apenwarr@tailscale.com>