### PR TITLE
ipn/ipnlocal: be authoritative for the entire MagicDNS record tree.

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1881,6 +1881,12 @@ func magicDNSRootDomains(nm *netmap.NetworkMap) []dnsname.FQDN {
 			// TODO: propagate error
 			return nil
 		}
+		if strings.HasSuffix(fqdn.WithoutTrailingDot(), ".beta.tailscale.net") {
+			// When using our standard MagicDNS suffix, make ourselves
+			// authoritative for all of tailscale.net, so that we
+			// become the resolver for shared nodes as well.
+			fqdn = dnsname.FQDN("tailscale.net.")
+		}
 		ret := []dnsname.FQDN{
 			fqdn,
 			dnsname.FQDN("0.e.1.a.c.5.1.1.a.7.d.f.ip6.arpa."),


### PR DESCRIPTION
With this change, shared node names resolve correctly on split DNS-supporting
operating systems.

Fixes tailscale/corp#1706

Signed-off-by: David Anderson <danderson@tailscale.com>