### PR TITLE
all: make staticcheck happy on windows

### DIFF
--- a/cmd/tailscaled/tailscaled_windows.go
+++ b/cmd/tailscaled/tailscaled_windows.go
@@ -168,7 +168,7 @@ func startIPNServer(ctx context.Context, logid string) error {
 		r, err := router.New(logf, dev)
 		if err != nil {
 			dev.Close()
-			return nil, fmt.Errorf("Router: %w", err)
+			return nil, fmt.Errorf("router: %w", err)
 		}
 		if wrapNetstack {
 			r = netstack.NewSubnetRouterWrapper(r)
@@ -188,7 +188,7 @@ func startIPNServer(ctx context.Context, logid string) error {
 		if err != nil {
 			r.Close()
 			dev.Close()
-			return nil, fmt.Errorf("Engine: %w", err)
+			return nil, fmt.Errorf("engine: %w", err)
 		}
 		onlySubnets := true
 		if wrapNetstack {

--- a/logtail/filch/filch.go
+++ b/logtail/filch/filch.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 )
 
+//lint:ignore U1000 work around false positive: https://github.com/dominikh/go-tools/issues/983
 var stderrFD = 2 // a variable for testing
 
 type Options struct {

--- a/net/tstun/ifstatus_windows.go
+++ b/net/tstun/ifstatus_windows.go
@@ -93,7 +93,6 @@ func waitInterfaceUp(iface tun.Device, timeout time.Duration, logf logger.Logf) 
 			iw.logf("TUN interface is up after %v", time.Since(t0))
 			return nil
 		case <-ticker.C:
-			break
 		}
 
 		if iw.isUp() {

--- a/portlist/portlist_windows.go
+++ b/portlist/portlist_windows.go
@@ -23,7 +23,7 @@ func listPorts() (List, error) {
 }
 
 func addProcesses(pl []Port) ([]Port, error) {
-	// OpenCurrentProcessToken instead of GetCurrentProcessToken,
+	//lint:ignore SA1019 OpenCurrentProcessToken instead of GetCurrentProcessToken,
 	// as GetCurrentProcessToken only works on Windows 8+.
 	tok, err := windows.OpenCurrentProcessToken()
 	if err != nil {

--- a/safesocket/pipe_windows.go
+++ b/safesocket/pipe_windows.go
@@ -11,10 +11,6 @@ import (
 	"syscall"
 )
 
-func path(vendor, name string, port uint16) string {
-	return fmt.Sprintf("127.0.0.1:%v", port)
-}
-
 func connect(path string, port uint16) (net.Conn, error) {
 	pipe, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	if err != nil {

--- a/wgengine/router/ifconfig_windows.go
+++ b/wgengine/router/ifconfig_windows.go
@@ -377,7 +377,7 @@ func configureInterface(cfg *Config, tun *tun.NativeTun) (retErr error) {
 			NextHop: gateway,
 			Metric:  0,
 		}
-		if bytes.Compare(r.Destination.IP, gateway) == 0 {
+		if net.IP.Equal(r.Destination.IP, gateway) {
 			// no need to add a route for the interface's
 			// own IP. The kernel does that for us.
 			// If we try to replace it, we'll fail to
@@ -411,7 +411,7 @@ func configureInterface(cfg *Config, tun *tun.NativeTun) (retErr error) {
 		// There's only one way to get to a given IP+Mask, so delete
 		// all matches after the first.
 		if i > 0 &&
-			bytes.Equal(routes[i].Destination.IP, routes[i-1].Destination.IP) &&
+			net.IP.Equal(routes[i].Destination.IP, routes[i-1].Destination.IP) &&
 			bytes.Equal(routes[i].Destination.Mask, routes[i-1].Destination.Mask) {
 			continue
 		}

--- a/wgengine/router/ifconfig_windows.go
+++ b/wgengine/router/ifconfig_windows.go
@@ -359,7 +359,7 @@ func configureInterface(cfg *Config, tun *tun.NativeTun) (retErr error) {
 			firstGateway6 = &ipnet.IP
 		} else if route.IP.Is4() && firstGateway4 == nil {
 			// TODO: do same dummy behavior as v6?
-			return errors.New("Due to a Windows limitation, one cannot have interface routes without an interface address")
+			return errors.New("due to a Windows limitation, one cannot have interface routes without an interface address")
 		}
 
 		ipn := route.IPNet()

--- a/wgengine/router/router_windows.go
+++ b/wgengine/router/router_windows.go
@@ -30,15 +30,6 @@ type winRouter struct {
 	nativeTun           *tun.NativeTun
 	routeChangeCallback *winipcfg.RouteChangeCallback
 	firewall            *firewallTweaker
-
-	// firewallSubproc is a subprocess that runs a tweaked version of
-	// wireguard-windows's "default route killswitch" code. We run it
-	// as a subprocess because it does unsafe callouts to the WFP API,
-	// and we want to defend against memory corruption in our main
-	// process. Owned and mutated only by Set, and doesn't need a lock
-	// because Set is only called with wgengine's lock held,
-	// preventing concurrent reconfigs.
-	firewallSubproc *exec.Cmd
 }
 
 func newUserspaceRouter(logf logger.Logf, tundev tun.Device) (Router, error) {


### PR DESCRIPTION
We weren't running staticcheck with GOOS=windows.
Preditably, there were lots of failures.
Fix or suppress a bunch of little staticcheck complaints,
so that we can add windows staticcheck to CI.
