### PR TITLE
cmd/tailscale/cli: fix running from Xcode

### DIFF
--- a/cmd/tailscale/cli/cli.go
+++ b/cmd/tailscale/cli/cli.go
@@ -51,6 +51,14 @@ func ActLikeCLI() bool {
 		return false
 	}
 
+	// Xcode adds the -NSDocumentRevisionsDebugMode flag on execution.
+	// If present, we are almost certainly being run as a GUI.
+	for _, arg := range os.Args {
+		if arg == "-NSDocumentRevisionsDebugMode" {
+			return false
+		}
+	}
+
 	// Looking at the environment of the GUI Tailscale app (ps eww
 	// $PID), empirically none of these environment variables are
 	// present. But all or some of these should be present with


### PR DESCRIPTION
We were over-eager in running tailscale in GUI mode.
f42ded7acf63e2f3711f6512b701ddeac0e2d7a6 fixed that by
checking for a variety of shell-ish env vars and using those
to force us into CLI mode.

However, for reasons I don't understand, those shell env vars
are present when Xcode runs Tailscale.app on my machine.
(I've changed no configs, modified nothing on a brand new machine.)
Work around that by adding an additional "only in GUI mode" check.
