### PR TITLE
wgengine/netstack: avoid delivering incoming packets to both netstack + host

### DIFF
--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -410,7 +410,14 @@ func (ns *Impl) injectInbound(p *packet.Parsed, t *tstun.Wrapper) filter.Respons
 		Data: vv,
 	})
 	ns.linkEP.InjectInbound(pn, packetBuf)
-	return filter.Accept
+
+	// We've now delivered this to netstack, so we're done.
+	// Instead of returning a filter.Accept here (which would also
+	// potentially deliver it to the host OS), and instead of
+	// filter.Drop (which would log about rejected traffic),
+	// instead return filter.DropSilently which just quietly stops
+	// processing it in the tstun TUN wrapper.
+	return filter.DropSilently
 }
 
 func (ns *Impl) acceptTCP(r *tcp.ForwarderRequest) {


### PR DESCRIPTION
The earlier eb06ec172f1d984bb87c589da1dd2d3f15dc6d82 fixed
the flaky SSH issue (tailscale/corp#1725) by making sure that packets
addressed to Tailscale IPs in hybrid netstack mode weren't delivered
to netstack, but another issue remained:

All traffic handled by netstack was also potentially being handled by
the host networking stack, as the filter hook returned "Accept", which
made it keep processing. This could lead to various random racey chaos
as a function of OS/firewalls/routes/etc.

Instead, once we inject into netstack, stop our caller's packet
processing.