### PR TITLE
internal/deephash: hash maps without sorting in the acyclic common case

### DIFF
--- a/internal/deephash/deephash.go
+++ b/internal/deephash/deephash.go
@@ -19,18 +19,18 @@ import (
 	"tailscale.com/types/wgkey"
 )
 
-func Hash(v ...interface{}) string {
+func calcHash(v interface{}) string {
 	h := sha256.New()
 	// 64 matches the chunk size in crypto/sha256/sha256.go
 	b := bufio.NewWriterSize(h, 64)
-	Print(b, v)
+	printTo(b, v)
 	b.Flush()
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
 // UpdateHash sets last to the hash of v and reports whether its value changed.
 func UpdateHash(last *string, v ...interface{}) (changed bool) {
-	sig := Hash(v)
+	sig := calcHash(v)
 	if *last != sig {
 		*last = sig
 		return true
@@ -38,7 +38,7 @@ func UpdateHash(last *string, v ...interface{}) (changed bool) {
 	return false
 }
 
-func Print(w *bufio.Writer, v ...interface{}) {
+func printTo(w *bufio.Writer, v interface{}) {
 	print(w, reflect.ValueOf(v), make(map[uintptr]bool))
 }
 

--- a/internal/deephash/deephash.go
+++ b/internal/deephash/deephash.go
@@ -114,7 +114,7 @@ func print(w *bufio.Writer, v reflect.Value, visited map[uintptr]bool) (acyclic 
 				x := v.Interface().(tailcfg.DiscoKey)
 				w.Write(x[:])
 			}
-			return
+			return true
 		}
 	}
 

--- a/internal/deephash/deephash.go
+++ b/internal/deephash/deephash.go
@@ -23,8 +23,7 @@ import (
 
 func calcHash(v interface{}) string {
 	h := sha256.New()
-	// 64 matches the chunk size in crypto/sha256/sha256.go
-	b := bufio.NewWriterSize(h, 64)
+	b := bufio.NewWriterSize(h, h.BlockSize())
 	scratch := make([]byte, 0, 64)
 	printTo(b, v, scratch)
 	b.Flush()

--- a/internal/deephash/deephash.go
+++ b/internal/deephash/deephash.go
@@ -240,12 +240,16 @@ func hashMapAcyclic(w *bufio.Writer, v reflect.Value, visited map[uintptr]bool) 
 	defer mapHasherPool.Put(mh)
 	mh.Reset()
 	iter := v.MapRange()
+	k := reflect.New(v.Type().Key()).Elem()
+	e := reflect.New(v.Type().Elem()).Elem()
 	for iter.Next() {
+		key := iterKey(iter, k)
+		val := iterVal(iter, e)
 		mh.startEntry()
-		if !print(mh.bw, iter.Key(), visited) {
+		if !print(mh.bw, key, visited) {
 			return false
 		}
-		if !print(mh.bw, iter.Value(), visited) {
+		if !print(mh.bw, val, visited) {
 			return false
 		}
 		mh.endEntry()

--- a/internal/deephash/deephash.go
+++ b/internal/deephash/deephash.go
@@ -45,6 +45,7 @@ func Print(w *bufio.Writer, v ...interface{}) {
 var (
 	netaddrIPType       = reflect.TypeOf(netaddr.IP{})
 	netaddrIPPrefix     = reflect.TypeOf(netaddr.IPPrefix{})
+	netaddrIPPort       = reflect.TypeOf(netaddr.IPPort{})
 	wgkeyKeyType        = reflect.TypeOf(wgkey.Key{})
 	wgkeyPrivateType    = reflect.TypeOf(wgkey.Private{})
 	tailcfgDiscoKeyType = reflect.TypeOf(tailcfg.DiscoKey{})
@@ -82,6 +83,20 @@ func print(w *bufio.Writer, v reflect.Value, visited map[uintptr]bool) (acyclic 
 				b, err = x.MarshalText()
 			} else {
 				x := v.Interface().(netaddr.IPPrefix)
+				b, err = x.MarshalText()
+			}
+			if err == nil {
+				w.Write(b)
+				return true
+			}
+		case netaddrIPPort:
+			var b []byte
+			var err error
+			if v.CanAddr() {
+				x := v.Addr().Interface().(*netaddr.IPPort)
+				b, err = x.MarshalText()
+			} else {
+				x := v.Interface().(netaddr.IPPort)
 				b, err = x.MarshalText()
 			}
 			if err == nil {

--- a/internal/deephash/deephash_test.go
+++ b/internal/deephash/deephash_test.go
@@ -96,10 +96,11 @@ func TestHashMapAcyclic(t *testing.T) {
 
 	for i := 0; i < 20; i++ {
 		visited := map[uintptr]bool{}
+		scratch := make([]byte, 0, 64)
 		v := reflect.ValueOf(m)
 		buf.Reset()
 		bw.Reset(&buf)
-		if !hashMapAcyclic(bw, v, visited) {
+		if !hashMapAcyclic(bw, v, visited, scratch) {
 			t.Fatal("returned false")
 		}
 		if got[string(buf.Bytes())] {
@@ -122,12 +123,13 @@ func BenchmarkHashMapAcyclic(b *testing.B) {
 	var buf bytes.Buffer
 	bw := bufio.NewWriter(&buf)
 	visited := map[uintptr]bool{}
+	scratch := make([]byte, 0, 64)
 	v := reflect.ValueOf(m)
 
 	for i := 0; i < b.N; i++ {
 		buf.Reset()
 		bw.Reset(&buf)
-		if !hashMapAcyclic(bw, v, visited) {
+		if !hashMapAcyclic(bw, v, visited, scratch) {
 			b.Fatal("returned false")
 		}
 	}

--- a/internal/deephash/deephash_test.go
+++ b/internal/deephash/deephash_test.go
@@ -18,15 +18,15 @@ import (
 	"tailscale.com/wgengine/wgcfg"
 )
 
-func TestDeepPrint(t *testing.T) {
+func TestDeepHash(t *testing.T) {
 	// v contains the types of values we care about for our current callers.
 	// Mostly we're just testing that we don't panic on handled types.
 	v := getVal()
 
-	hash1 := Hash(v)
+	hash1 := calcHash(v)
 	t.Logf("hash: %v", hash1)
 	for i := 0; i < 20; i++ {
-		hash2 := Hash(getVal())
+		hash2 := calcHash(getVal())
 		if hash1 != hash2 {
 			t.Error("second hash didn't match")
 		}
@@ -80,7 +80,7 @@ func BenchmarkHash(b *testing.B) {
 	b.ReportAllocs()
 	v := getVal()
 	for i := 0; i < b.N; i++ {
-		Hash(v)
+		calcHash(v)
 	}
 }
 

--- a/internal/deephash/mapiter.go
+++ b/internal/deephash/mapiter.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !tailscale_go
+
+package deephash
+
+import "reflect"
+
+func iterKey(iter *reflect.MapIter, scratch reflect.Value) reflect.Value {
+	return iter.Key()
+}
+
+func iterVal(iter *reflect.MapIter, scratch reflect.Value) reflect.Value {
+	return iter.Value()
+}

--- a/internal/deephash/mapiter_future.go
+++ b/internal/deephash/mapiter_future.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build tailscale_go
+
+package deephash
+
+import "reflect"
+
+func iterKey(iter *reflect.MapIter, scratch reflect.Value) reflect.Value {
+	iter.SetKey(scratch)
+	return scratch
+}
+
+func iterVal(iter *reflect.MapIter, scratch reflect.Value) reflect.Value {
+	iter.SetValue(scratch)
+	return scratch
+}

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -633,7 +633,7 @@ func (e *userspaceEngine) maybeReconfigWireguardLocked(discoChanged map[key.Publ
 		}
 	}
 
-	if !deephash.UpdateHash(&e.lastEngineSigTrim, min, trimmedDisco, trackDisco, trackIPs) {
+	if !deephash.UpdateHash(&e.lastEngineSigTrim, &min, trimmedDisco, trackDisco, trackIPs) {
 		// No changes
 		return nil
 	}


### PR DESCRIPTION
Hash and xor each entry instead, then write final xor'ed result.

```
name    old time/op    new time/op    delta
Hash-4    33.6µs ± 4%    34.6µs ± 3%  +3.03%  (p=0.013 n=10+9)

name    old alloc/op   new alloc/op   delta
Hash-4    1.86kB ± 0%    1.77kB ± 0%  -5.10%  (p=0.000 n=10+9)

name    old allocs/op  new allocs/op  delta
Hash-4      51.0 ± 0%      49.0 ± 0%  -3.92%  (p=0.000 n=10+10)
```