### PR TITLE
Added new Addresses / AllowedIPs fields to testcontrol when creating tailcfg.Node

### DIFF
--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -196,6 +196,37 @@ func TestTwoNodes(t *testing.T) {
 	d2.MustCleanShutdown(t)
 }
 
+func TestNodeAddressIPFields(t *testing.T) {
+	t.Parallel()
+	bins := buildTestBinaries(t)
+
+	env := newTestEnv(t, bins)
+	defer env.Close()
+
+	n1 := newTestNode(t, env)
+	d1 := n1.StartDaemon(t)
+	defer d1.Kill()
+
+	n1.AwaitListening(t)
+	n1.MustUp()
+	n1.AwaitRunning(t)
+
+	testNodes := env.Control.AllNodes()
+
+	if len(testNodes) != 1 {
+		t.Errorf("Expected %d nodes, got %d", 1, len(testNodes))
+	}
+	node := testNodes[0]
+	if len(node.Addresses) == 0 {
+		t.Errorf("Empty Addresses field in node")
+	}
+	if len(node.AllowedIPs) == 0 {
+		t.Errorf("Empty AllowedIPs field in node")
+	}
+
+	d1.MustCleanShutdown(t)
+}
+
 // testBinaries are the paths to a tailscaled and tailscale binary.
 // These can be shared by multiple nodes.
 type testBinaries struct {

--- a/tstest/integration/testcontrol/testcontrol.go
+++ b/tstest/integration/testcontrol/testcontrol.go
@@ -307,6 +307,10 @@ func (s *Server) serveRegister(w http.ResponseWriter, r *http.Request, mkey tail
 
 	machineAuthorized := true // TODO: add Server.RequireMachineAuth
 
+	allowedIPs := []netaddr.IPPrefix{
+		netaddr.MustParseIPPrefix(fmt.Sprintf("100.64.%d.%d/32", uint8(tailcfg.NodeID(user.ID)>>8), uint8(tailcfg.NodeID(user.ID)))),
+	}
+
 	s.nodes[req.NodeKey] = &tailcfg.Node{
 		ID:                tailcfg.NodeID(user.ID),
 		StableID:          tailcfg.StableNodeID(fmt.Sprintf("TESTCTRL%08x", int(user.ID))),
@@ -314,6 +318,8 @@ func (s *Server) serveRegister(w http.ResponseWriter, r *http.Request, mkey tail
 		Machine:           mkey,
 		Key:               req.NodeKey,
 		MachineAuthorized: machineAuthorized,
+		Addresses:         allowedIPs,
+		AllowedIPs:        allowedIPs,
 	}
 	requireAuth := s.RequireAuth
 	if requireAuth && s.nodeKeyAuthed[req.NodeKey] {


### PR DESCRIPTION
Adds the fields such that when running Ping(ip netaddr.IP, useTSMP bool, cb func(*ipnstate.PingResult)), it calls peerForIP inside of userspace.go, inside that function it checks
```go
for _, p := range nm.Peers {
	for _, a := range p.Addresses {
		if a.IP() == ip && a.IsSingleIP() && tsaddr.IsTailscaleIP(ip) {
			return p, nil
		}
	}
	for _, cidr := range p.AllowedIPs {
		if !cidr.Contains(ip) {
			continue
		}
		if bestInNMPrefix.IsZero() || cidr.Bits() > bestInNMPrefix.Bits() {
			bestInNMPrefix = cidr
			bestInNM = p
		}
	}
}
```
but peers the Addresses, and AllowedIPs fields are nil, so these checks for bestInNM are not reached.