### PR TITLE
tstest/integration/vms: use dynamically discovered bindhost

### DIFF
--- a/tstest/integration/vms/vms_test.go
+++ b/tstest/integration/vms/vms_test.go
@@ -28,6 +28,7 @@ import (
 
 	expect "github.com/google/goexpect"
 	"golang.org/x/crypto/ssh"
+	"inet.af/netaddr"
 	"tailscale.com/tstest/integration/testcontrol"
 )
 
@@ -35,7 +36,6 @@ var runVMTests = flag.Bool("run-vm-tests", false, "if set, run expensive (10G+ r
 
 type Distro struct {
 	name           string // amazon-linux
-	size           string // 5
 	url            string // URL to a qcow2 image
 	sha256sum      string // hex-encoded sha256 sum
 	mem            int    // VM memory in megabytes
@@ -285,25 +285,25 @@ func TestVMIntegrationEndToEnd(t *testing.T) {
 	}
 
 	distros := []Distro{
-		{"amazon-linux", "25", "https://cdn.amazonlinux.com/os-images/2.0.20210427.0/kvm/amzn2-kvm-2.0.20210427.0-x86_64.xfs.gpt.qcow2", "6ef9daef32cec69b2d0088626ec96410cd24afc504d57278bbf2f2ba2b7e529b", 512, "yum"},
-		{"centos-7", "8", "https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2", "1db30c9c272fb37b00111b93dcebff16c278384755bdbe158559e9c240b73b80", 512, "yum"},
-		{"centos-8", "10", "https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.3.2011-20201204.2.x86_64.qcow2", "7ec97062618dc0a7ebf211864abf63629da1f325578868579ee70c495bed3ba0", 768, "dnf"},
-		{"debian-9", "5", "https://cdimage.debian.org/cdimage/openstack/9.13.21-20210511/debian-9.13.21-20210511-openstack-amd64.qcow2", "0667a08e2d947b331aee068db4bbf3a703e03edaf5afa52e23d534adff44b62a", 512, "apt"},
-		{"debian-10", "5", "https://cdimage.debian.org/images/cloud/buster/20210329-591/debian-10-generic-amd64-20210329-591.qcow2", "70c61956095870c4082103d1a7a1cb5925293f8405fc6cb348588ec97e8611b0", 768, "apt"},
-		{"fedora-34", "5", "https://download.fedoraproject.org/pub/fedora/linux/releases/34/Cloud/x86_64/images/Fedora-Cloud-Base-34-1.2.x86_64.qcow2", "b9b621b26725ba95442d9a56cbaa054784e0779a9522ec6eafff07c6e6f717ea", 768, "dnf"},
-		{"opensuse-leap-15.1", "10", "https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.1/images/openSUSE-Leap-15.1-OpenStack.x86_64.qcow2", "3203e256dab5981ca3301408574b63bc522a69972fbe9850b65b54ff44a96e0a", 512, "zypper"},
-		{"opensuse-leap-15.2", "10", "https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.2/images/openSUSE-Leap-15.2-OpenStack.x86_64.qcow2", "4df9cee9281d1f57d20f79dc65d76e255592b904760e73c0dd44ac753a54330f", 512, "zypper"},
-		{"opensuse-tumbleweed", "5", "https://download.opensuse.org/tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-OpenStack-Cloud.qcow2", "f5a40c693187dddc524b0877b0aba31cdb6f2e78f12acce0bbb2975ec120dfc0", 512, "zypper"},
-		{"ubuntu-16-04", "5", "https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img", "50a21bc067c05e0c73bf5d8727ab61152340d93073b3dc32eff18b626f7d813b", 512, "apt"},
-		{"ubuntu-18-04", "5", "https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img", "78f09b6086367914d23f26e38c3cd88a2aaf1a6a4500ebd46c74ad60c56c1585", 512, "apt"},
-		{"ubuntu-20-04", "5", "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img", "513158b22ff0f08d0a078d8d60293bcddffdb17094a7809c76c52aba415ecc54", 512, "apt"},
-		{"ubuntu-20-10", "5", "https://cloud-images.ubuntu.com/groovy/current/groovy-server-cloudimg-amd64.img", "c1332c24557389a129ff98fa169e34cb53c02555ed702a235e26b8978dd004c3", 512, "apt"},
-		{"ubuntu-21-04", "5", "https://cloud-images.ubuntu.com/hirsute/current/hirsute-server-cloudimg-amd64.img", "2f8a562637340a026f712594f1257673543d74725d8e3daf88d533d7b8bf448f", 512, "apt"},
+		{"amazon-linux", "https://cdn.amazonlinux.com/os-images/2.0.20210427.0/kvm/amzn2-kvm-2.0.20210427.0-x86_64.xfs.gpt.qcow2", "6ef9daef32cec69b2d0088626ec96410cd24afc504d57278bbf2f2ba2b7e529b", 512, "yum"},
+		{"centos-7", "https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2", "1db30c9c272fb37b00111b93dcebff16c278384755bdbe158559e9c240b73b80", 512, "yum"},
+		{"centos-8", "https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.3.2011-20201204.2.x86_64.qcow2", "7ec97062618dc0a7ebf211864abf63629da1f325578868579ee70c495bed3ba0", 768, "dnf"},
+		{"debian-9", "https://cdimage.debian.org/cdimage/openstack/9.13.21-20210511/debian-9.13.21-20210511-openstack-amd64.qcow2", "0667a08e2d947b331aee068db4bbf3a703e03edaf5afa52e23d534adff44b62a", 512, "apt"},
+		{"debian-10", "https://cdimage.debian.org/images/cloud/buster/20210329-591/debian-10-generic-amd64-20210329-591.qcow2", "70c61956095870c4082103d1a7a1cb5925293f8405fc6cb348588ec97e8611b0", 768, "apt"},
+		{"fedora-34", "https://download.fedoraproject.org/pub/fedora/linux/releases/34/Cloud/x86_64/images/Fedora-Cloud-Base-34-1.2.x86_64.qcow2", "b9b621b26725ba95442d9a56cbaa054784e0779a9522ec6eafff07c6e6f717ea", 768, "dnf"},
+		{"opensuse-leap-15.1", "https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.1/images/openSUSE-Leap-15.1-OpenStack.x86_64.qcow2", "3203e256dab5981ca3301408574b63bc522a69972fbe9850b65b54ff44a96e0a", 512, "zypper"},
+		{"opensuse-leap-15.2", "https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.2/images/openSUSE-Leap-15.2-OpenStack.x86_64.qcow2", "4df9cee9281d1f57d20f79dc65d76e255592b904760e73c0dd44ac753a54330f", 512, "zypper"},
+		{"opensuse-tumbleweed", "https://download.opensuse.org/tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-OpenStack-Cloud.qcow2", "ba3ecd281045b5019f0fb11378329a644a41870b77631ea647b128cd07eb804b", 512, "zypper"},
+		{"ubuntu-16-04", "https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img", "50a21bc067c05e0c73bf5d8727ab61152340d93073b3dc32eff18b626f7d813b", 512, "apt"},
+		{"ubuntu-18-04", "https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img", "08396cf95c18534a2e3f88289bd92d18eee76f0e75813636b3ab9f1e603816d7", 512, "apt"},
+		{"ubuntu-20-04", "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img", "513158b22ff0f08d0a078d8d60293bcddffdb17094a7809c76c52aba415ecc54", 512, "apt"},
+		{"ubuntu-20-10", "https://cloud-images.ubuntu.com/groovy/current/groovy-server-cloudimg-amd64.img", "e470df72fce4fb8d0ee4ef8af8eed740ee3bf51290515eb42e5c747725e98b6d", 512, "apt"},
+		{"ubuntu-21-04", "https://cloud-images.ubuntu.com/hirsute/current/hirsute-server-cloudimg-amd64.img", "7fab8eda0bcf6f8f6e63845ccf1e29de4706e3359c82d3888835093020fe6f05", 512, "apt"},
 	}
 
 	dir := t.TempDir()
 
-	ln, err := net.Listen("tcp", "192.168.122.1:0")
+	ln, err := net.Listen("tcp", deriveBindhost(t)+":0")
 	if err != nil {
 		t.Fatalf("can't make TCP listener: %v", err)
 	}
@@ -354,6 +354,7 @@ func TestVMIntegrationEndToEnd(t *testing.T) {
 	}
 
 	loginServer := fmt.Sprintf("http://%s", ln.Addr())
+	t.Logf("loginServer: %s", loginServer)
 
 	cancels := make(chan func(), len(distros))
 
@@ -450,6 +451,42 @@ func TestVMIntegrationEndToEnd(t *testing.T) {
 	if numNodes := cs.NumNodes(); numNodes != len(ipMap) {
 		t.Errorf("wanted %d nodes, got: %d", len(ipMap), numNodes)
 	}
+}
+
+func deriveBindhost(t *testing.T) string {
+	t.Helper()
+
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rex := regexp.MustCompile(`^(eth|enp|wlp|wlan)`)
+
+	for _, iface := range ifaces {
+		t.Logf("found interface %s: %d", iface.Name, iface.Flags&net.FlagUp)
+		if (iface.Flags & net.FlagUp) == 0 {
+			continue
+		}
+
+		if rex.MatchString(iface.Name) {
+			addrs, err := iface.Addrs()
+			if err != nil {
+				t.Fatalf("can't get address for %s: %v", iface.Name, err)
+			}
+
+			for _, addr := range addrs {
+				return netaddr.MustParseIPPrefix(addr.String()).IP().String()
+			}
+		}
+	}
+
+	t.Fatal("can't find a bindhost")
+	return "invalid"
+}
+
+func TestDeriveBindhost(t *testing.T) {
+	t.Log(deriveBindhost(t))
 }
 
 const metaDataTemplate = `instance-id: {{.ID}}


### PR DESCRIPTION
Instead of relying on a libvirtd bridge address that you probably won't have on your system.

Updates #1988 

Signed-off-by: Christine Dodrill <xe@tailscale.com>