### PR TITLE
ipn/ipnlocal: ignore NetfilterMode pref on Synology

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -44,11 +44,13 @@ import (
 	"tailscale.com/types/logger"
 	"tailscale.com/types/netmap"
 	"tailscale.com/types/persist"
+	"tailscale.com/types/preftype"
 	"tailscale.com/types/wgkey"
 	"tailscale.com/util/dnsname"
 	"tailscale.com/util/osshare"
 	"tailscale.com/util/systemd"
 	"tailscale.com/version"
+	"tailscale.com/version/distro"
 	"tailscale.com/wgengine"
 	"tailscale.com/wgengine/filter"
 	"tailscale.com/wgengine/router"
@@ -2024,6 +2026,11 @@ func (b *LocalBackend) routerConfig(cfg *wgcfg.Config, prefs *ipn.Prefs) *router
 		SNATSubnetRoutes: !prefs.NoSNAT,
 		NetfilterMode:    prefs.NetfilterMode,
 		Routes:           peerRoutes(cfg.Peers, 10_000),
+	}
+
+	if distro.Get() == distro.Synology {
+		// Issue 1995: we don't use iptables on Synology.
+		rs.NetfilterMode = preftype.NetfilterOff
 	}
 
 	// Sanity check: we expect the control server to program both a v4


### PR DESCRIPTION
On clean installs we didn't set use iptables, but during upgrades it
looks like we could use old prefs that directed us to go into the iptables
paths that might fail on Synology.

Updates #1995
Fixes tailscale/tailscale-synology#57 (I think)