### PR TITLE
Resolves docker-proxy containers name on the admin panel

### DIFF
--- a/net/tsaddr/tsaddr.go
+++ b/net/tsaddr/tsaddr.go
@@ -41,11 +41,8 @@ var (
 // TailscaleServiceIP returns the listen address of services
 // provided by Tailscale itself such as the MagicDNS proxy.
 func TailscaleServiceIP() netaddr.IP {
-	serviceIP.Do(func() { mustIP(&serviceIP.v, "100.100.100.100") })
-	return serviceIP.v
+	return netaddr.IPv4(100, 100, 100, 100) // "100.100.100.100" for those grepping
 }
-
-var serviceIP onceIP
 
 // IsTailscaleIP reports whether ip is an IP address in a range that
 // Tailscale assigns from.
@@ -124,19 +121,6 @@ func mustPrefix(v *netaddr.IPPrefix, prefix string) {
 type oncePrefix struct {
 	sync.Once
 	v netaddr.IPPrefix
-}
-
-func mustIP(v *netaddr.IP, ip string) {
-	var err error
-	*v, err = netaddr.ParseIP(ip)
-	if err != nil {
-		panic(err)
-	}
-}
-
-type onceIP struct {
-	sync.Once
-	v netaddr.IP
 }
 
 // NewContainsIPFunc returns a func that reports whether ip is in addrs.

--- a/net/tsaddr/tsaddr_test.go
+++ b/net/tsaddr/tsaddr_test.go
@@ -93,3 +93,11 @@ func TestNewContainsIPFunc(t *testing.T) {
 		t.Fatal("bad")
 	}
 }
+
+var sinkIP netaddr.IP
+
+func BenchmarkTailscaleServiceAddr(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		sinkIP = TailscaleServiceIP()
+	}
+}

--- a/tstest/integration/vms/vms_test.go
+++ b/tstest/integration/vms/vms_test.go
@@ -496,6 +496,7 @@ func deriveBindhost(t *testing.T) string {
 }
 
 func TestDeriveBindhost(t *testing.T) {
+	t.Skip("broken on some machines; https://github.com/tailscale/tailscale/issues/2011")
 	t.Log(deriveBindhost(t))
 }
 

--- a/util/rproxy/resolver.go
+++ b/util/rproxy/resolver.go
@@ -1,0 +1,86 @@
+// resolver for docker-proxy
+package rproxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+)
+
+// docker Engine API addresses
+const (
+	sockAddr = "/var/run/docker.sock"
+	endpoint = "/containers/json"
+)
+
+type Port struct {
+	PrivatePort int
+	PublicPort  int
+	Type        string // "tcp" or "udp"
+}
+
+// Resolver A struct that stores list of running docker containers
+type Resolver struct {
+	containers []container
+}
+
+func (r *Resolver) init() error {
+	c, err := getDockerContainers()
+	r.containers = c
+	return err
+}
+
+// returns containers name, if such a conteiner exist with given ports
+func (r *Resolver) Resolve(p Port) (name string, err error) {
+
+	if r.containers == nil {
+		if err := r.init(); err != nil {
+			return name, fmt.Errorf("docker-proxy resolver cannot be initialized %v", err)
+		}
+	}
+
+	for _, c := range r.containers {
+		// compare to container ports
+		for _, cp := range c.Ports {
+			if p.PrivatePort == cp.PrivatePort && p.PublicPort == cp.PublicPort && p.Type == cp.Type {
+				return c.Names[0], nil
+			}
+		}
+	}
+
+	return name, fmt.Errorf("given Port cannot be found in docker API")
+}
+
+// json response to containers call
+type container struct {
+	Names []string
+	Ports []Port
+}
+
+// calls docker api via unix sockets
+// GET containers/json
+// see: https://docs.docker.com/engine/api/v1.24/
+func getDockerContainers() ([]container, error) {
+
+	httpc := http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", sockAddr)
+			},
+		},
+	}
+
+	r, err := httpc.Get("http://unix" + endpoint)
+	var c []container
+
+	// Try to decode the request body into the struct. If there is an error,
+	// respond to the client with the error message and a 400 status code.
+	err = json.NewDecoder(r.Body).Decode(&c)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, err
+}


### PR DESCRIPTION
This PR addresses the issue: #1361

adds util/rproxy package, "resolve-proxy"

Gets list of the containers via Docker Engine API socket `/var/run/docker.sock`,
then tries to resolve container's name who has docker-resolve as the description. 

If so sends `docker container: [container-name]` to IPN. 

for example here: 

![image](https://user-images.githubusercontent.com/6696695/120114505-1eb7b100-c188-11eb-8b0e-b41ed7142d56.png)

