### PR TITLE
portlist/portlist_linux.go: resolve docker-proxy to container's name

### DIFF
--- a/portlist/portlist_linux.go
+++ b/portlist/portlist_linux.go
@@ -19,6 +19,7 @@ import (
 
 	"golang.org/x/sys/unix"
 	"tailscale.com/syncs"
+	"tailscale.com/util/rproxy"
 )
 
 // Reading the sockfiles on Linux is very fast, so we can do it often.
@@ -170,6 +171,8 @@ func addProcesses(pl []Port) ([]Port, error) {
 			if err != nil {
 				return fmt.Errorf("addProcesses.readDir: %w", err)
 			}
+
+			rp := rproxy.Resolver{}
 			for _, fd := range fds {
 				n, err := unix.Readlink(fmt.Sprintf("/proc/%s/fd/%s", pid, fd), targetBuf)
 				if err != nil {
@@ -189,6 +192,19 @@ func addProcesses(pl []Port) ([]Port, error) {
 
 					argv := strings.Split(strings.TrimSuffix(string(bs), "\x00"), "\x00")
 					pe.Process = argvSubject(argv...)
+
+					// if the process works under docker-proxy, try to resolve the container's name,
+					if pe.Process == "docker-proxy" {
+						// argv is in form /usr/libexec/docker/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 3308 -container-ip 172.18.0.2 -container-port 3306
+						pub, _ := strconv.Atoi(argv[6])
+						priv, _ := strconv.Atoi(argv[10])
+						proxyPort := rproxy.Port{PrivatePort: priv, PublicPort: pub, Type: argv[2]}
+						if n, perr := rp.Resolve(proxyPort); perr == nil {
+							pe.Process = fmt.Sprintf("docker container: %s", n)
+						}
+
+					}
+
 				}
 			}
 		}

--- a/util/rproxy/resolver.go
+++ b/util/rproxy/resolver.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// resolver for docker-proxy
+package rproxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+)
+
+// docker Engine API addresses
+const (
+	sockAddr = "/var/run/docker.sock"
+	endpoint = "/containers/json"
+)
+
+type Port struct {
+	PrivatePort int
+	PublicPort  int
+	Type        string // "tcp" or "udp"
+}
+
+// Resolver A struct that stores list of running docker containers
+type Resolver struct {
+	containers []container
+}
+
+func (r *Resolver) init() error {
+	c, err := getDockerContainers()
+	r.containers = c
+	return err
+}
+
+// returns containers name, if such a conteiner exist with given ports
+func (r *Resolver) Resolve(p Port) (name string, err error) {
+
+	if r.containers == nil {
+		if err := r.init(); err != nil {
+			return name, fmt.Errorf("docker-proxy resolver cannot be initialized %v", err)
+		}
+	}
+
+	for _, c := range r.containers {
+		// compare to container ports
+		for _, cp := range c.Ports {
+			if p.PrivatePort == cp.PrivatePort && p.PublicPort == cp.PublicPort && p.Type == cp.Type {
+				return c.Names[0], nil
+			}
+		}
+	}
+
+	return name, fmt.Errorf("given Port cannot be found in docker API")
+}
+
+// json response to containers call
+type container struct {
+	Names []string
+	Ports []Port
+}
+
+// calls docker api via unix sockets
+// GET containers/json
+// see: https://docs.docker.com/engine/api/v1.24/
+func getDockerContainers() ([]container, error) {
+
+	httpc := http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", sockAddr)
+			},
+		},
+	}
+
+	r, err := httpc.Get("http://unix" + endpoint)
+	var c []container
+
+	// Try to decode the request body into the struct. If there is an error,
+	// respond to the client with the error message and a 400 status code.
+	err = json.NewDecoder(r.Body).Decode(&c)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, err
+}


### PR DESCRIPTION
Modifies docker-proxy processes' descriptons, to send corresponding container's name to IPN

this commit solves: #1361

When a process description is `docker-proxy`, there is an attempt to resolve corresponding docker container's name:

![image](https://user-images.githubusercontent.com/79106885/120115909-66413b80-c18e-11eb-8da7-d41762051a74.png)


Signed-off-by: Selahaddin Harmankaya <mselahaddinh@gmail.com>