### PR TITLE
tstest/integration/vms: regex-match distros using a flag

### DIFF
--- a/tstest/integration/vms/regex_flag.go
+++ b/tstest/integration/vms/regex_flag.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vms
+
+import "regexp"
+
+type regexValue struct {
+	r *regexp.Regexp
+}
+
+func (r *regexValue) String() string {
+	if r.r == nil {
+		return ""
+	}
+
+	return r.r.String()
+}
+
+func (r *regexValue) Set(val string) error {
+	if rex, err := regexp.Compile(val); err != nil {
+		return err
+	} else {
+		r.r = rex
+		return nil
+	}
+}
+
+func (r regexValue) Unwrap() *regexp.Regexp { return r.r }

--- a/tstest/integration/vms/regex_flag_test.go
+++ b/tstest/integration/vms/regex_flag_test.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vms
+
+import (
+	"flag"
+	"testing"
+)
+
+func TestRegexFlag(t *testing.T) {
+	var v regexValue
+	fs := flag.NewFlagSet(t.Name(), flag.PanicOnError)
+	fs.Var(&v, "regex", "regex to parse")
+
+	const want = `.*`
+	fs.Parse([]string{"-regex", want})
+	if v.Unwrap().String() != want {
+		t.Fatalf("got wrong regex: %q, wanted: %q", v.Unwrap().String(), want)
+	}
+}


### PR DESCRIPTION
If you set `-distro-regex` to match a subset of distros, only those
distros will be tested. Ex:

    $ go test -run-vm-tests -distro-regex='opensuse'

Signed-off-by: Christine Dodrill <xe@tailscale.com>