### PR TITLE
tstest/integration/vms: fix OpenSUSE Leap 15.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/godbus/dbus/v5 v5.0.4
 	github.com/google/go-cmp v0.5.5
 	github.com/google/goexpect v0.0.0-20210430020637-ab937bf7fd6f
+	github.com/google/uuid v1.1.2 // indirect
 	github.com/goreleaser/nfpm v1.10.3
 	github.com/jsimonetti/rtnetlink v0.0.0-20210409061457-9561dc9288a7
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51

--- a/tstest/integration/vms/opensuse_leap_15_1_test.go
+++ b/tstest/integration/vms/opensuse_leap_15_1_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux
+
+package vms
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+/*
+   The images that we use for OpenSUSE Leap 15.1 have an issue that makes the
+   nocloud backend[1] for cloud-init just not work. As a distro-specific
+   workaround, we're gonna pretend to be OpenStack.
+
+   TODO(Xe): delete once we no longer need to support OpenSUSE Leap 15.1.
+
+   [1]: https://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html
+*/
+
+type openSUSELeap151MetaData struct {
+	Zone        string                      `json:"availability_zone"` // nova
+	Hostname    string                      `json:"hostname"`          // opensuse-leap-15-1
+	LaunchIndex string                      `json:"launch_index"`      // 0
+	Meta        openSUSELeap151MetaDataMeta `json:"meta"`              // some openstack metadata we don't need to care about
+	Name        string                      `json:"name"`              // opensuse-leap-15-1
+	UUID        string                      `json:"uuid"`              // e9c664cd-b116-433b-aa61-7ff420163dcd
+}
+
+type openSUSELeap151MetaDataMeta struct {
+	Role      string `json:"role"`      // server
+	DSMode    string `json:"dsmode"`    // local
+	Essential string `json:"essential"` // essential
+}
+
+func hackOpenSUSE151UserData(t *testing.T, d Distro, dir string) bool {
+	if d.name != "opensuse-leap-15-1" {
+		return false
+	}
+
+	t.Log("doing OpenSUSE Leap 15.1 hack")
+	osDir := filepath.Join(dir, "openstack", "latest")
+	err := os.MkdirAll(osDir, 0755)
+	if err != nil {
+		t.Fatalf("can't make metadata home: %v", err)
+	}
+
+	metadata, err := json.Marshal(openSUSELeap151MetaData{
+		Zone:        "nova",
+		Hostname:    d.name,
+		LaunchIndex: "0",
+		Meta: openSUSELeap151MetaDataMeta{
+			Role:      "server",
+			DSMode:    "local",
+			Essential: "false",
+		},
+		Name: d.name,
+		UUID: uuid.New().String(),
+	})
+	if err != nil {
+		t.Fatalf("can't encode metadata: %v", err)
+	}
+	err = os.WriteFile(filepath.Join(osDir, "meta_data.json"), metadata, 0666)
+	if err != nil {
+		t.Fatalf("can't write to meta_data.json: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "user-data"))
+	if err != nil {
+		t.Fatalf("can't read user_data: %v", err)
+	}
+
+	err = os.WriteFile(filepath.Join(osDir, "user_data"), data, 0666)
+	if err != nil {
+		t.Fatalf("can't create output user_data: %v", err)
+	}
+
+	return true
+}

--- a/tstest/integration/vms/vms_test.go
+++ b/tstest/integration/vms/vms_test.go
@@ -244,12 +244,18 @@ func mkSeed(t *testing.T, d Distro, sshKey, hostURL, tdir string, port int) {
 		}
 	}
 
-	run(t, tdir, "genisoimage",
+	args := []string{
 		"-output", filepath.Join(dir, "seed.iso"),
 		"-volid", "cidata", "-joliet", "-rock",
 		filepath.Join(dir, "meta-data"),
 		filepath.Join(dir, "user-data"),
-	)
+	}
+
+	if hackOpenSUSE151UserData(t, d, dir) {
+		args = append(args, filepath.Join(dir, "openstack"))
+	}
+
+	run(t, tdir, "genisoimage", args...)
 }
 
 // mkVM makes a KVM-accelerated virtual machine and prepares it for introduction
@@ -446,10 +452,6 @@ func TestVMIntegrationEndToEnd(t *testing.T) {
 			t.Run(distro.name, func(t *testing.T) {
 				ctx, done := context.WithCancel(context.Background())
 				defer done()
-
-				if distro.name == "opensuse-leap-15-1" {
-					t.Skip("OpenSUSE Leap 15.1's cloud-init image just doesn't work for some reason, see https://github.com/tailscale/tailscale/issues/1988")
-				}
 
 				t.Parallel()
 


### PR DESCRIPTION
The OpenSUSE 15.1 image we are using (and conseqentially the only one
that is really available easily given it is EOL) has cloud-init
hardcoded to use the OpenStack metadata thingy. Other OpenSUSE Leap
images function fine with the NoCloud backend, but this one seems to
just not work with it. No bother, we can just pretend to be OpenStack.

Thanks to Okami for giving me an example OpenStack configuration seed
image.

Updates #1988

Signed-off-by: Christine Dodrill <xe@tailscale.com>