### PR TITLE
Support multiple hostnames for a peer

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1748,6 +1748,9 @@ func (b *LocalBackend) authReconfig() {
 	set(nm.Name, nm.Addresses)
 	for _, peer := range nm.Peers {
 		set(peer.Name, peer.Addresses)
+		for _, n := range peer.OtherNames {
+			set(n, peer.Addresses)
+		}
 	}
 
 	if uc.CorpDNS {

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -138,9 +138,10 @@ func (emptyStructJSONSlice) MarshalJSON() ([]byte, error) {
 func (emptyStructJSONSlice) UnmarshalJSON([]byte) error { return nil }
 
 type Node struct {
-	ID       NodeID
-	StableID StableNodeID
-	Name     string // DNS
+	ID         NodeID
+	StableID   StableNodeID
+	Name       string   // DNS
+	OtherNames []string // extra DNS names
 
 	// User is the user who created the node. If ACL tags are in
 	// use for the node then it doesn't reflect the ACL identity
@@ -1085,6 +1086,7 @@ func (n *Node) Equal(n2 *Node) bool {
 		n.ID == n2.ID &&
 		n.StableID == n2.StableID &&
 		n.Name == n2.Name &&
+		eqStrings(n.OtherNames, n2.OtherNames) &&
 		n.User == n2.User &&
 		n.Sharer == n2.Sharer &&
 		n.Key == n2.Key &&

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -45,6 +45,7 @@ func (src *Node) Clone() *Node {
 	}
 	dst := new(Node)
 	*dst = *src
+	dst.OtherNames = append(src.OtherNames[:0:0], src.OtherNames...)
 	dst.Addresses = append(src.Addresses[:0:0], src.Addresses...)
 	dst.AllowedIPs = append(src.AllowedIPs[:0:0], src.AllowedIPs...)
 	dst.Endpoints = append(src.Endpoints[:0:0], src.Endpoints...)
@@ -67,6 +68,7 @@ var _NodeNeedsRegeneration = Node(struct {
 	ID                      NodeID
 	StableID                StableNodeID
 	Name                    string
+	OtherNames              []string
 	User                    UserID
 	Sharer                  UserID
 	Key                     NodeKey

--- a/tailcfg/tailcfg_test.go
+++ b/tailcfg/tailcfg_test.go
@@ -191,7 +191,7 @@ func TestHostinfoEqual(t *testing.T) {
 
 func TestNodeEqual(t *testing.T) {
 	nodeHandles := []string{
-		"ID", "StableID", "Name", "User", "Sharer",
+		"ID", "StableID", "Name", "OtherNames", "User", "Sharer",
 		"Key", "KeyExpiry", "Machine", "DiscoKey",
 		"Addresses", "AllowedIPs", "Endpoints", "DERP", "Hostinfo",
 		"Created", "LastSeen", "Online", "KeepAlive", "MachineAuthorized",


### PR DESCRIPTION
Suggested by mcmillen on twitter: in the admin panel, we could allow comma-separated hostnames when editing machine name, and pass those down as a quick form of virtual hosting. AFAICT, this is the only required change for the wire protocol and client, the rest is database stuff in control. WDYT?