### PR TITLE
/derp: Add metric for recording use after N seconds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.dll
 *.so
 *.dylib
+*.swp
 
 cmd/tailscale/tailscale
 cmd/tailscaled/tailscaled


### PR DESCRIPTION
This adds a really simple metric for checking if a client is still using derp after 5/10 seconds, by seeing if they send a packet as a proxy. It might make sense to also check that if the between the current and previous packet and the start was greater than an hour, we treat it as a new session and increment the counter again.

asking for review from @bradfitz
cc @DentonGentry 