### PR TITLE
hostinfo: capitalization of AWS

### DIFF
--- a/control/controlclient/hostinfo_linux.go
+++ b/control/controlclient/hostinfo_linux.go
@@ -62,7 +62,7 @@ func osVersionLinux() string {
 	if inKnative() {
 		attrBuf.WriteString("; env=kn")
 	}
-	if inAwsLambda() {
+	if inAWSLambda() {
 		attrBuf.WriteString("; env=lm")
 	}
 	if inHerokuDyno() {
@@ -131,7 +131,7 @@ func inKnative() bool {
 	return false
 }
 
-func inAwsLambda() bool {
+func inAWSLambda() bool {
 	// https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html
 	if os.Getenv("AWS_LAMBDA_FUNCTION_NAME") != "" &&
 		os.Getenv("AWS_LAMBDA_FUNCTION_VERSION") != "" &&


### PR DESCRIPTION
Missed one comment from https://github.com/tailscale/tailscale/pull/1868
should be isAWSLambda not isAwsLambda

Signed-off-by: Denton Gentry <dgentry@tailscale.com>