### PR TITLE
tstest/integration: disable TestAddPingRequest

### DIFF
--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -230,6 +230,7 @@ func TestNodeAddressIPFields(t *testing.T) {
 }
 
 func TestAddPingRequest(t *testing.T) {
+	t.Skip("flaky in CI, tailscale/issues/2079")
 	t.Parallel()
 	bins := BuildTestBinaries(t)
 


### PR DESCRIPTION
Failing often now, we don't want people to get used to
routinely ignoring test failures.

Can be re-enabled when
https://github.com/tailscale/tailscale/issues/2079
is resolved.

Signed-off-by: Denton Gentry <dgentry@tailscale.com>