### PR TITLE
wf: loopback condition should use MatchTypeFlagsAllSet.

### DIFF
--- a/wf/firewall.go
+++ b/wf/firewall.go
@@ -152,7 +152,7 @@ func (f *Firewall) enable() error {
 		return fmt.Errorf("permitDNS failed: %w", err)
 	}
 
-	if err := f.permitLoopback(weightKnownTraffic); err != nil {
+	if err := f.permitLoopback(weightTailscaleTraffic); err != nil {
 		return fmt.Errorf("permitLoopback failed: %w", err)
 	}
 
@@ -457,7 +457,7 @@ func (f *Firewall) permitLoopback(w weight) error {
 	condition := []*wf.Match{
 		{
 			Field: wf.FieldFlags,
-			Op:    wf.MatchTypeEqual,
+			Op:    wf.MatchTypeFlagsAllSet,
 			Value: wf.ConditionFlagIsLoopback,
 		},
 	}


### PR DESCRIPTION
I overlooked this when doing the initial implementation.
This is now the same as https://github.com/tailscale/tailscale/blob/main/tempfork/wireguard-windows/firewall/rules.go#L242.

I verified that all other MatchTypes are set correctly.

Fixes #2133, #2106, #2105

Signed-off-by: Maisem Ali <maisem@tailscale.com>