### PR TITLE
wgengine/router_windows: support toggling local lan access when using exit nodes.

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -2089,7 +2089,7 @@ func (b *LocalBackend) routerConfig(cfg *wgcfg.Config, prefs *ipn.Prefs) *router
 		if !default6 {
 			rs.Routes = append(rs.Routes, ipv6Default)
 		}
-		if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
+		if runtime.GOOS == "linux" || runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
 			// Only allow local lan access on linux machines for now.
 			ips, _, err := interfaceRoutes()
 			if err != nil {


### PR DESCRIPTION
Note: This requires reconfiguring the firewall while it's enabled to allow the local routes through, the way we do this is by passing in a json encoded list of routes to the firewall process via stdin.

Updates #1527

Signed-off-by: Maisem Ali <maisem@tailscale.com>