### PR TITLE
Adding TestTwoNodeConnectivity, tests connections between two nodes using SOCKS5 proxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,3 +47,5 @@ require (
 	inet.af/wf v0.0.0-20210516214145-a5343001b756
 	rsc.io/goversion v1.2.0
 )
+
+replace golang.zx2c4.com/wireguard => /home/simenghe/gohack/golang.zx2c4.com/wireguard

--- a/net/socks5/socks5.go
+++ b/net/socks5/socks5.go
@@ -160,7 +160,7 @@ func (c *Conn) handleRequest() error {
 	}
 	c.request = req
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 	srv, err := c.srv.dial(
 		ctx,

--- a/net/tstun/fake.go
+++ b/net/tstun/fake.go
@@ -6,6 +6,7 @@ package tstun
 
 import (
 	"io"
+	"log"
 	"os"
 
 	"golang.zx2c4.com/wireguard/tun"
@@ -35,11 +36,13 @@ func (t *fakeTUN) Close() error {
 }
 
 func (t *fakeTUN) Read(out []byte, offset int) (int, error) {
+	log.Println("TSTUN : FAKE")
 	<-t.closechan
 	return 0, io.EOF
 }
 
 func (t *fakeTUN) Write(b []byte, n int) (int, error) {
+	log.Println("FAKE : Write Called")
 	select {
 	case <-t.closechan:
 		return 0, ErrClosed

--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -393,55 +393,6 @@ func TestTwoNodeConnectivity(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// // Try communicating with the two addresss.
-	// l, err := net.Listen("tcp", "localhost:0")
-	// if err != nil {
-	// 	t.Fatal(err)
-	// }
-
-	// // Dial this conn.addr
-	// go func() {
-	// 	conn, err := l.Accept()
-	// 	if err != nil {
-	// 		t.Error(err)
-	// 	}
-	// 	defer conn.Close()
-	// 	_, err = conn.Write([]byte("TestString"))
-	// 	if err != nil {
-	// 		t.Error(err)
-	// 	}
-	// }()
-
-	// dialer, err := proxy.SOCKS5("tcp", n1Socks, nil, proxy.Direct)
-	// if err != nil {
-	// 	t.Error(err)
-	// }
-	// t.Log(dialer)
-
-	// port := l.Addr().(*net.TCPAddr)
-	// t.Log(port)
-
-	// testIP := strings.ReplaceAll(net.JoinHostPort(n2IP, strconv.Itoa(port.Port)), "\n", "")
-	// t.Log("Dialing : ", testIP)
-
-	// dialerConn, err := dialer.Dial("tcp", testIP)
-	// if err != nil {
-	// 	t.Fatal(err)
-	// }
-	// defer dialerConn.Close()
-
-	// t.Logf("Dialer Connection Established at %v", dialerConn.LocalAddr())
-	// _, err = dialerConn.Write([]byte("TestTest"))
-	// if err != nil {
-	// 	t.Error(err)
-	// }
-
-	// // Read the bytes in
-	// p := make([]byte, 1024)
-	// _, err = dialerConn.Read(p)
-	// if err != nil {
-	// 	t.Error(err)
-	// }
 }
 
 // testEnv contains the test environment (set of servers) used by one

--- a/wgengine/magicsock/legacy.go
+++ b/wgengine/magicsock/legacy.go
@@ -11,6 +11,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"hash"
+	"log"
 	"net"
 	"strings"
 	"sync"
@@ -144,6 +145,7 @@ func (c *Conn) resetAddrSetStatesLocked() {
 }
 
 func (c *Conn) sendAddrSet(b []byte, as *addrSet) error {
+	log.Println("sendAddrSet")
 	if c.disableLegacy {
 		return errDisabled
 	}

--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -399,6 +399,7 @@ func (ns *Impl) DialContextUDP(ctx context.Context, addr string) (*gonet.UDPConn
 }
 
 func (ns *Impl) injectOutbound() {
+	log.Println("NETSTACK Inject outbound")
 	for {
 		packetInfo, ok := ns.linkEP.ReadContext(context.Background())
 		if !ok {
@@ -431,6 +432,7 @@ func (ns *Impl) isLocalIP(ip netaddr.IP) bool {
 }
 
 func (ns *Impl) injectInbound(p *packet.Parsed, t *tstun.Wrapper) filter.Response {
+	log.Println("NETSTACK: injectInbound")
 	if ns.onlySubnets && ns.isLocalIP(p.Dst.IP()) {
 		// In hybrid ("only subnets") mode, bail out early if
 		// the traffic is destined for an actual Tailscale


### PR DESCRIPTION
Added test that starts up two nodes, which will also start up a tcp listener using `--socks5-server=localhost:0` for each tailscaled.
Test tries to parse the two addresses from the logs, and test communicating between the two listeners.