### PR TITLE
derp: fix traffic handler peer addresses

### DIFF
--- a/derp/derp_server.go
+++ b/derp/derp_server.go
@@ -1435,17 +1435,10 @@ func parseSSOutput(raw string) map[netaddr.IPPort]BytesSentRecv {
 		if len(ipInfo) < 5 {
 			continue
 		}
-		src, err := netaddr.ParseIPPort(ipInfo[3])
+		src, err := netaddr.ParseIPPort(ipInfo[4])
 		if err != nil {
 			continue
 		}
-		/*
-		   TODO(jknodt) do we care about the full route or just the src?
-		   dst, err := netaddr.ParseIPPort(string(ipInfo[4]))
-		   if err != nil {
-		     continue
-		   }
-		*/
 		stats := strings.Fields(strings.TrimSpace(lines[i+1]))
 		stat := BytesSentRecv{}
 		for _, s := range stats {


### PR DESCRIPTION
Before it was using the local address and port, so fix that.
The fields in the response from `ss` are:

State, Recv-Q, Send-Q, Local Address:Port, Peer Address:Port, Process