### PR TITLE
tailcfg: Add user derps field to derpmap

### DIFF
--- a/tailcfg/derpmap.go
+++ b/tailcfg/derpmap.go
@@ -14,6 +14,9 @@ type DERPMap struct {
 	//
 	// The numbers are not necessarily contiguous.
 	Regions map[int]*DERPRegion
+
+	// UserSpecified is the set of user run DERP nodes specific to this tailnet.
+	UserSpecified []*DERPNode
 }
 
 /// RegionIDs returns the sorted region IDs.


### PR DESCRIPTION
Adds a field to derpmaps which will allow for users to specify their own DERP nodes outside of
those specified by tailscale's regions. Currently this field doesn't do anything, but will be populated later.

Signed-off-by: julianknodt <julianknodt@gmail.com>