### PR TITLE
tailcfg/derpmap: add flag to omit ts's derps

### DIFF
--- a/tailcfg/derpmap.go
+++ b/tailcfg/derpmap.go
@@ -14,6 +14,10 @@ type DERPMap struct {
 	//
 	// The numbers are not necessarily contiguous.
 	Regions map[int]*DERPRegion
+
+	// OmitDefaultRegions specifies to not use Tailscale's DERP servers, and only use those
+	// specified in this DERPMap. If there are none set outside of the defaults, this is a noop.
+	OmitDefaultRegions bool `json:"omitDefaultRegions,omitempty"`
 }
 
 /// RegionIDs returns the sorted region IDs.

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -309,7 +309,8 @@ func (src *DERPMap) Clone() *DERPMap {
 // A compilation failure here means this code must be regenerated, with command:
 //   tailscale.com/cmd/cloner -type User,Node,Hostinfo,NetInfo,Login,DNSConfig,DNSResolver,RegisterResponse,DERPRegion,DERPMap,DERPNode
 var _DERPMapNeedsRegeneration = DERPMap(struct {
-	Regions map[int]*DERPRegion
+	Regions            map[int]*DERPRegion
+	OmitDefaultRegions bool
 }{})
 
 // Clone makes a deep copy of DERPNode.


### PR DESCRIPTION
This adds a flag to derp maps which specifies that default Tailscale DERP servers should not be
used. If true and there are entries in this map, it indicates that the entries in this map
should take precedent and not hit any of tailscale's DERP servers.

This change is backwards compatible, as the default behavior should be false.

Updates #1264