### PR TITLE
net/dns: resolveConfExists reading the wrong error

### DIFF
--- a/net/dns/direct.go
+++ b/net/dns/direct.go
@@ -216,7 +216,8 @@ func (m directManager) restoreBackup() error {
 	if err != nil {
 		return err
 	}
-	if _, err := m.fs.Stat(resolvConf); err != nil && !os.IsNotExist(err) {
+	_, err = m.fs.Stat(resolvConf)
+	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
 	resolvConfExists := !os.IsNotExist(err)


### PR DESCRIPTION
noideadog.gif

I don't know if this is right, but I think the wrong err was being read before.

I am also unsure how to test this in its current state, but I'm working on that separately!