### PR TITLE
net/dns: avoid running wsl.exe as LocalSystem

### DIFF
--- a/util/winutil/winutil.go
+++ b/util/winutil/winutil.go
@@ -9,6 +9,7 @@ package winutil
 
 import (
 	"log"
+	"syscall"
 
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
@@ -49,4 +50,16 @@ func GetRegString(name, defval string) string {
 		return defval
 	}
 	return val
+}
+
+var (
+	kernel32                         = syscall.NewLazyDLL("kernel32.dll")
+	procWTSGetActiveConsoleSessionId = kernel32.NewProc("WTSGetActiveConsoleSessionId")
+)
+
+// TODO(crawshaw): replace with x/sys/windows... one day.
+// https://go-review.googlesource.com/c/sys/+/331909
+func WTSGetActiveConsoleSessionId() uint32 {
+	r1, _, _ := procWTSGetActiveConsoleSessionId.Call()
+	return uint32(r1)
 }


### PR DESCRIPTION
It doesn't work. It needs to run as the user.

	https://github.com/microsoft/WSL/issues/4803

The mechanism for doing this was extracted from:

	https://web.archive.org/web/20101009012531/http://blogs.msdn.com/b/winsdk/archive/2009/07/14/launching-an-interactive-process-from-windows-service-in-windows-vista-and-later.aspx

Signed-off-by: David Crawshaw <crawshaw@tailscale.com>