### PR TITLE
tstest/integration/vms: verbosify nixos logs to fs, disable unstable

### DIFF
--- a/tstest/integration/vms/nixos_test.go
+++ b/tstest/integration/vms/nixos_test.go
@@ -8,9 +8,11 @@ package vms
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"text/template"
 
@@ -190,7 +192,15 @@ func makeNixOSImage(t *testing.T, d Distro, cdir string, bins *integration.Binar
 		cmd.Stdout = logger.FuncWriter(t.Logf)
 		cmd.Stderr = logger.FuncWriter(t.Logf)
 	} else {
-		t.Log("building nixos image...")
+		fname := fmt.Sprintf("nix-build-%s-%s", os.Getenv("GITHUB_RUN_NUMBER"), strings.Replace(t.Name(), "/", "-", -1))
+		t.Logf("writing nix logs to %s", fname)
+		fout, err := os.Create(fname)
+		if err != nil {
+			t.Fatalf("can't make log file for nix build: %v", err)
+		}
+		cmd.Stdout = fout
+		cmd.Stderr = fout
+		defer fout.Close()
 	}
 	cmd.Env = append(os.Environ(), "NIX_PATH=nixpkgs="+d.url)
 	cmd.Dir = outpath

--- a/tstest/integration/vms/vms_test.go
+++ b/tstest/integration/vms/vms_test.go
@@ -170,8 +170,11 @@ var distros = []Distro{
 	// shasum is meaningless. This `channel:name` syntax is documented at [1].
 	//
 	// [1]: https://nixos.org/manual/nix/unstable/command-ref/env-common.html
-	{"nixos-unstable", "channel:nixos-unstable", "lolfakesha", 512, "nix", "systemd"},
 	{"nixos-21-05", "channel:nixos-21.05", "lolfakesha", 512, "nix", "systemd"},
+
+	// // NOTE(Xe): disabled until https://github.com/NixOS/nixpkgs/issues/128783
+	// // is fixed.
+	// {"nixos-unstable", "channel:nixos-unstable", "lolfakesha", 512, "nix", "systemd"},
 }
 
 // fetchFromS3 fetches a distribution image from Amazon S3 or reports whether


### PR DESCRIPTION
This puts nix build logs on the filesystem so that we can debug them
later. This also disables nixos unstable until
https://github.com/NixOS/nixpkgs/issues/128783 is fixed.

Signed-off-by: Christine Dodrill <xe@tailscale.com>