### PR TITLE
net/tstun: de-select Wrapper

### DIFF
--- a/net/tstun/wrap.go
+++ b/net/tstun/wrap.go
@@ -357,13 +357,8 @@ func (t *Wrapper) Read(buf []byte, offset int) (int, error) {
 		}
 	}
 
-	// For injected packets, we return early to bypass filtering.
-	if wasInjectedPacket {
-		t.noteActivity()
-		return n, nil
-	}
-
-	if !t.disableFilter {
+	// Do not filter injected packets.
+	if !wasInjectedPacket && !t.disableFilter {
 		response := t.filterOut(p)
 		if response != filter.Accept {
 			// Wireguard considers read errors fatal; pretend nothing was read

--- a/net/tstun/wrap_test.go
+++ b/net/tstun/wrap_test.go
@@ -309,7 +309,7 @@ func TestFilter(t *testing.T) {
 		var recvbuf []byte
 		for {
 			select {
-			case <-tun.closed:
+			case <-tun.done:
 				return
 			case recvbuf = <-chtun.Inbound:
 				// continue


### PR DESCRIPTION
Every TUN Read went through several multi-case selects.
We know from past experience with wireguard-go that these are slow
and cause scheduler churn.

This PR removes multi-case selects from hot code.

There are two commits; the first is trivial.

This is an intricate and dangerous change.
I would be happy to co-review it live,
if that is helpful.
