### PR TITLE
internal/deephash: 8 bits of output is not enough

### DIFF
--- a/internal/deephash/deephash.go
+++ b/internal/deephash/deephash.go
@@ -24,8 +24,12 @@ func calcHash(v interface{}) string {
 	printTo(b, v, scratch)
 	b.Flush()
 	scratch = h.Sum(scratch[:0])
-	hex.Encode(scratch[:cap(scratch)], scratch[:sha256.Size])
-	return string(scratch[:sha256.Size*2])
+	// The first sha256.Size bytes contain the hash.
+	// Hex-encode that into the next sha256.Size*2 bytes.
+	src := scratch[:sha256.Size]
+	dst := scratch[sha256.Size:cap(scratch)]
+	n := hex.Encode(dst, src)
+	return string(dst[:n])
 }
 
 // UpdateHash sets last to the hash of v and reports whether its value changed.

--- a/internal/deephash/deephash_test.go
+++ b/internal/deephash/deephash_test.go
@@ -134,3 +134,14 @@ func BenchmarkHashMapAcyclic(b *testing.B) {
 		}
 	}
 }
+
+func TestExhaustive(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < 100000; i++ {
+		s := calcHash(i)
+		if seen[s] {
+			t.Fatalf("hash collision %v", i)
+		}
+		seen[s] = true
+	}
+}


### PR DESCRIPTION
Running hex.Encode(b, b) is a bad idea.
The first byte of input will overwrite the first two bytes of output.
Subsequent bytes have no impact on the output.

Wh::ps.

This caused us to spuriously ignore some wireguard config updates.

Signed-off-by: Josh Bleecher Snyder <josh@tailscale.com>
