### PR TITLE
util/deephash: simplify hex encode

### DIFF
--- a/util/deephash/deephash.go
+++ b/util/deephash/deephash.go
@@ -26,13 +26,7 @@ func calcHash(v interface{}) string {
 	scratch := make([]byte, 0, 128)
 	printTo(b, v, scratch)
 	b.Flush()
-	scratch = h.Sum(scratch[:0])
-	// The first sha256.Size bytes contain the hash.
-	// Hex-encode that into the next sha256.Size*2 bytes.
-	src := scratch[:sha256.Size]
-	dst := scratch[sha256.Size:cap(scratch)]
-	n := hex.Encode(dst, src)
-	return string(dst[:n])
+	return hex.EncodeToString(h.Sum(scratch[:0]))
 }
 
 // UpdateHash sets last to the hash of v and reports whether its value changed.


### PR DESCRIPTION
With https://go-review.googlesource.com/c/go/+/332689,

Before:
	BenchmarkHash-24                   62504             19250 ns/op            2297 B/op         58 allocs/op
	BenchmarkHashMapAcyclic-24         39852             30119 ns/op            2532 B/op        202 allocs/op

After:
	BenchmarkHash-24                   62440             19271 ns/op            2298 B/op         58 allocs/op
	BenchmarkHashMapAcyclic-24         39592             30307 ns/op            2532 B/op        202 allocs/op