### PR TITLE
build_docker.sh: use build_dist.sh to inject version information

### DIFF
--- a/build_docker.sh
+++ b/build_docker.sh
@@ -25,7 +25,7 @@
 
 set -eu
 
-eval $(./version/version.sh)
+eval $(./build_dist.sh shellvars)
 
 docker build \
   --build-arg VERSION_LONG=$VERSION_LONG \


### PR DESCRIPTION
`version/version.sh` was removed in commit 5088af68. Use `build_dist.sh shellvars` to provide version information instead.