### PR TITLE
wgengine/magicsock: fix latent data race in test

### DIFF
--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -1430,8 +1430,13 @@ func BenchmarkReceiveFrom_Native(b *testing.B) {
 	}
 }
 
+// logBufWriterMu serializes writes made by logBufWriter.
+var logBufWriterMu sync.Mutex
+
 func logBufWriter(buf *bytes.Buffer) logger.Logf {
 	return func(format string, a ...interface{}) {
+		logBufWriterMu.Lock()
+		defer logBufWriterMu.Unlock()
 		fmt.Fprintf(buf, format, a...)
 		if !bytes.HasSuffix(buf.Bytes(), []byte("\n")) {
 			buf.WriteByte('\n')


### PR DESCRIPTION
logBufWriter had no serialization.
It just so happens that none of its users currently ever log concurrently.
Make it safe for concurrent use.

Signed-off-by: Josh Bleecher Snyder <josh@tailscale.com>
