### PR TITLE
net/uring: add probing capability

### DIFF
--- a/net/uring/capability_linux.go
+++ b/net/uring/capability_linux.go
@@ -1,0 +1,20 @@
+package uring
+
+// #cgo CFLAGS: -I${SRCDIR}/liburing/src/include
+// #cgo LDFLAGS: -L${SRCDIR}/liburing/src/ -luring
+// #include "io_uring.c"
+import "C"
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// hasUring reports whether it is possible to use io_uring syscalls on the system.
+func uringSupported() bool {
+	probe, err := C.io_uring_get_probe()
+	if err == nil && probe != nil {
+		C.free(unsafe.Pointer(probe))
+	}
+	return err != syscall.ENOSYS
+}

--- a/net/uring/io_uring_test.go
+++ b/net/uring/io_uring_test.go
@@ -1,0 +1,11 @@
+// +build linux
+
+package uring
+
+import (
+	"testing"
+)
+
+func TestUringAvailable(t *testing.T) {
+	uringSupported()
+}


### PR DESCRIPTION
Adds the ability to probe for various capabilities. It will not call into C unless
necessary. It also allocates one probe per call to new capability, which may be expensive, so in
theory they could be reused instead.

Re-opened version of https://github.com/tailscale/tailscale/pull/2366
onto different branch