### PR TITLE
tstest/integration/vms: unbreak nixos builds

### DIFF
--- a/tstest/integration/vms/nixos_test.go
+++ b/tstest/integration/vms/nixos_test.go
@@ -121,7 +121,10 @@ in {
   boot.extraModulePackages = [ ];
 
   # Curl is needed for one of the steps in cloud-final
-  systemd.services.cloud-final.path = [ pkgs.curl ];
+  systemd.services.cloud-final.path = with pkgs; [ curl ];
+
+  # Curl is needed for one of the integration tests
+  environment.systemPackages = with pkgs; [ curl ];
 
   # yolo, this vm can sudo freely.
   security.sudo.wheelNeedsPassword = false;

--- a/tstest/integration/vms/vms_test.go
+++ b/tstest/integration/vms/vms_test.go
@@ -252,11 +252,7 @@ func (h Harness) fetchDistro(t *testing.T, resultDistro Distro) string {
 	cdir = filepath.Join(cdir, "tailscale", "vm-test")
 
 	if strings.HasPrefix(resultDistro.name, "nixos") {
-		var imagePath string
-		t.Run("nix-build", func(t *testing.T) {
-			imagePath = h.makeNixOSImage(t, resultDistro, cdir)
-		})
-		return imagePath
+		return h.makeNixOSImage(t, resultDistro, cdir)
 	}
 
 	qcowPath := filepath.Join(cdir, "qcow2", resultDistro.sha256sum)


### PR DESCRIPTION
To avoid the generated nixos disk images from becoming immune from the
GC, I delete the symlink to the nix store at the end of tests.
`t.Cleanup` runs at the end of a test. I changed this part of the code
to have a separate timer for how long it takes to run NixOS builds, but
I did that by using a subtest. This means that it was creating the NixOS
image, deleting its symlink and then trying to use that symlink to find
the resulting disk image, making the whole thing ineffectual.

This was a mistake. I am reverting this change made in
https://github.com/tailscale/tailscale/pull/2360 to remove this layer of
subtesting.

Signed-off-by: Christine Dodrill <xe@tailscale.com>