### PR TITLE
tstest/integration/testcontrol: add ipv6 support

### DIFF
--- a/tstest/integration/testcontrol/testcontrol.go
+++ b/tstest/integration/testcontrol/testcontrol.go
@@ -28,6 +28,7 @@ import (
 	"github.com/klauspost/compress/zstd"
 	"golang.org/x/crypto/nacl/box"
 	"inet.af/netaddr"
+	"tailscale.com/net/tsaddr"
 	"tailscale.com/smallzstd"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/logger"
@@ -406,8 +407,12 @@ func (s *Server) serveRegister(w http.ResponseWriter, r *http.Request, mkey tail
 
 	machineAuthorized := true // TODO: add Server.RequireMachineAuth
 
+	v4Prefix := netaddr.IPPrefixFrom(netaddr.IPv4(100, 64, uint8(tailcfg.NodeID(user.ID)>>8), uint8(tailcfg.NodeID(user.ID))), 32)
+	v6Prefix := netaddr.IPPrefixFrom(tsaddr.Tailscale4To6(v4Prefix.IP()), 128)
+
 	allowedIPs := []netaddr.IPPrefix{
-		netaddr.MustParseIPPrefix(fmt.Sprintf("100.64.%d.%d/32", uint8(tailcfg.NodeID(user.ID)>>8), uint8(tailcfg.NodeID(user.ID)))),
+		v4Prefix,
+		v6Prefix,
 	}
 
 	s.nodes[req.NodeKey] = &tailcfg.Node{
@@ -638,8 +643,12 @@ func (s *Server) MapResponse(req *tailcfg.MapRequest) (res *tailcfg.MapResponse,
 		}
 	}
 
+	v4Prefix := netaddr.IPPrefixFrom(netaddr.IPv4(100, 64, uint8(tailcfg.NodeID(user.ID)>>8), uint8(tailcfg.NodeID(user.ID))), 32)
+	v6Prefix := netaddr.IPPrefixFrom(tsaddr.Tailscale4To6(v4Prefix.IP()), 128)
+
 	res.Node.Addresses = []netaddr.IPPrefix{
-		netaddr.MustParseIPPrefix(fmt.Sprintf("100.64.%d.%d/32", uint8(node.ID>>8), uint8(node.ID))),
+		v4Prefix,
+		v6Prefix,
 	}
 	res.Node.AllowedIPs = res.Node.Addresses
 

--- a/tstest/integration/vms/vms_test.go
+++ b/tstest/integration/vms/vms_test.go
@@ -966,6 +966,26 @@ func (h Harness) testDistro(t *testing.T, d Distro, ipm ipMapping) {
 			t.Fatalf("wanted %q from vm, got: %q", securePassword, msg)
 		}
 	})
+
+	t.Run("ipv6-addr", func(t *testing.T) {
+		sess, err := cli.NewSession()
+		if err != nil {
+			t.Fatalf("can't make incoming session: %v", err)
+		}
+		defer sess.Close()
+
+		outp, err := sess.CombinedOutput("tailscale ip -6")
+		if err != nil {
+			t.Log(string(outp))
+			t.Fatalf("can't get ipv6 address: %v", err)
+		}
+
+		_, err = netaddr.ParseIP(string(bytes.TrimSpace(outp)))
+		if err != nil {
+			t.Log(string(outp))
+			t.Fatalf("can't parse IP: %v", err)
+		}
+	})
 }
 
 func runTestCommands(t *testing.T, timeout time.Duration, cli *ssh.Client, batch []expect.Batcher) {


### PR DESCRIPTION
Split from https://github.com/tailscale/tailscale/pull/2376

This adds IPv6 support to testcontrol so each member of the tailscale
network gets an IPv6 address too.

Signed-off-by: Christine Dodrill <xe@tailscale.com>