### PR TITLE
cmd/tailscale: log web listen addr

### DIFF
--- a/cmd/tailscale/cli/web.go
+++ b/cmd/tailscale/cli/web.go
@@ -15,6 +15,7 @@ import (
 	"html/template"
 	"io/ioutil"
 	"log"
+	"net"
 	"net/http"
 	"net/http/cgi"
 	"net/url"
@@ -94,8 +95,18 @@ func runWeb(ctx context.Context, args []string) error {
 		}
 		return nil
 	}
-	log.Printf("web server running on: %s\n", webArgs.listen)
+
+	log.Printf("web server running on: %s", urlOfListenAddr(webArgs.listen))
 	return http.ListenAndServe(webArgs.listen, http.HandlerFunc(webHandler))
+}
+
+// urlOfListenAddr parses a given listen address into a formatted URL
+func urlOfListenAddr(addr string) string {
+	host, port, _ := net.SplitHostPort(addr)
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	return fmt.Sprintf("http://%s", net.JoinHostPort(host, port))
 }
 
 // authorize returns the name of the user accessing the web UI after verifying

--- a/cmd/tailscale/cli/web.go
+++ b/cmd/tailscale/cli/web.go
@@ -94,6 +94,7 @@ func runWeb(ctx context.Context, args []string) error {
 		}
 		return nil
 	}
+	log.Printf("web server running on: %s\n", webArgs.listen)
 	return http.ListenAndServe(webArgs.listen, http.HandlerFunc(webHandler))
 }
 

--- a/cmd/tailscale/cli/web_test.go
+++ b/cmd/tailscale/cli/web_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cli
+
+import "testing"
+
+func TestUrlOfListenAddr(t *testing.T) {
+	t.Parallel()
+
+	testTable := map[string]struct {
+		addr     string
+		expected string
+	}{
+		"TestLocalhost": {
+			addr:     "localhost:8088",
+			expected: "http://localhost:8088",
+		},
+		"TestNoHost": {
+			addr:     ":8088",
+			expected: "http://127.0.0.1:8088",
+		},
+		"TestExplicitHost": {
+			addr:     "127.0.0.2:8088",
+			expected: "http://127.0.0.2:8088",
+		},
+		"TestIPv6": {
+			addr:     "[::1]:8088",
+			expected: "http://[::1]:8088",
+		},
+	}
+
+	for name, test := range testTable {
+		t.Run(name, func(t *testing.T) {
+			url := urlOfListenAddr(test.addr)
+			if url != test.expected {
+				t.Errorf("expected url: '%s', got: '%s'", test.expected, url)
+			}
+		})
+	}
+}

--- a/cmd/tailscale/cli/web_test.go
+++ b/cmd/tailscale/cli/web_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmd/tailscale/cli/web_test.go
+++ b/cmd/tailscale/cli/web_test.go
@@ -7,35 +7,37 @@ package cli
 import "testing"
 
 func TestUrlOfListenAddr(t *testing.T) {
-	t.Parallel()
-
-	testTable := map[string]struct {
-		addr     string
-		expected string
+	tests := []struct {
+		name     string
+		in, want string
 	}{
-		"TestLocalhost": {
-			addr:     "localhost:8088",
-			expected: "http://localhost:8088",
+		{
+			name: "TestLocalhost",
+			in:   "localhost:8088",
+			want: "http://localhost:8088",
 		},
-		"TestNoHost": {
-			addr:     ":8088",
-			expected: "http://127.0.0.1:8088",
+		{
+			name: "TestNoHost",
+			in:   ":8088",
+			want: "http://127.0.0.1:8088",
 		},
-		"TestExplicitHost": {
-			addr:     "127.0.0.2:8088",
-			expected: "http://127.0.0.2:8088",
+		{
+			name: "TestExplicitHost",
+			in:   "127.0.0.2:8088",
+			want: "http://127.0.0.2:8088",
 		},
-		"TestIPv6": {
-			addr:     "[::1]:8088",
-			expected: "http://[::1]:8088",
+		{
+			name: "TestIPv6",
+			in:   "[::1]:8088",
+			want: "http://[::1]:8088",
 		},
 	}
 
-	for name, test := range testTable {
-		t.Run(name, func(t *testing.T) {
-			url := urlOfListenAddr(test.addr)
-			if url != test.expected {
-				t.Errorf("expected url: '%s', got: '%s'", test.expected, url)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := urlOfListenAddr(tt.in)
+			if url != tt.want {
+				t.Errorf("expected url: %q, got: %q", tt.want, url)
 			}
 		})
 	}


### PR DESCRIPTION
When running `tailscale web` I saw no output and was unsure which address the server was listening on, so I added a log to display this.

Signed-off-by: Dan Bond <danbond@protonmail.com>