### PR TITLE
tstest/integration/vms: use one testcontrol instance per VM

### DIFF
--- a/tstest/integration/vms/nixos_test.go
+++ b/tstest/integration/vms/nixos_test.go
@@ -166,7 +166,7 @@ func copyUnit(t *testing.T, bins *integration.Binaries) {
 	}
 }
 
-func (h Harness) makeNixOSImage(t *testing.T, d Distro, cdir string) string {
+func (h *Harness) makeNixOSImage(t *testing.T, d Distro, cdir string) string {
 	copyUnit(t, h.bins)
 	dir := t.TempDir()
 	fname := filepath.Join(dir, d.name+".nix")

--- a/tstest/integration/vms/vm_setup_test.go
+++ b/tstest/integration/vms/vm_setup_test.go
@@ -35,7 +35,7 @@ import (
 // mkVM makes a KVM-accelerated virtual machine and prepares it for introduction
 // to the testcontrol server. The function it returns is for killing the virtual
 // machine when it is time for it to die.
-func (h Harness) mkVM(t *testing.T, n int, d Distro, sshKey, hostURL, tdir string) {
+func (h *Harness) mkVM(t *testing.T, n int, d Distro, sshKey, hostURL, tdir string) {
 	t.Helper()
 
 	cdir, err := os.UserCacheDir()
@@ -160,7 +160,7 @@ func fetchFromS3(t *testing.T, fout *os.File, d Distro) bool {
 
 // fetchDistro fetches a distribution from the internet if it doesn't already exist locally. It
 // also validates the sha256 sum from a known good hash.
-func (h Harness) fetchDistro(t *testing.T, resultDistro Distro) string {
+func (h *Harness) fetchDistro(t *testing.T, resultDistro Distro) string {
 	t.Helper()
 
 	cdir, err := os.UserCacheDir()
@@ -253,7 +253,7 @@ func checkCachedImageHash(t *testing.T, d Distro, cacheDir string) (gotHash stri
 	return
 }
 
-func (h Harness) copyBinaries(t *testing.T, d Distro, conn *ssh.Client) {
+func (h *Harness) copyBinaries(t *testing.T, d Distro, conn *ssh.Client) {
 	bins := h.bins
 	if strings.HasPrefix(d.name, "nixos") {
 		return

--- a/tstest/integration/vms/vms_steps_test.go
+++ b/tstest/integration/vms/vms_steps_test.go
@@ -39,7 +39,7 @@ func retry(t *testing.T, fn func() error) {
 	t.Fatalf("tried %d times, got: %v", tries, err)
 }
 
-func (h Harness) testPing(t *testing.T, ipAddr netaddr.IP, cli *ssh.Client) {
+func (h *Harness) testPing(t *testing.T, ipAddr netaddr.IP, cli *ssh.Client) {
 	var outp []byte
 	var err error
 	retry(t, func() error {
@@ -83,7 +83,7 @@ func getSession(t *testing.T, cli *ssh.Client) *ssh.Session {
 	return sess
 }
 
-func (h Harness) testOutgoingTCP(t *testing.T, ipAddr netaddr.IP, cli *ssh.Client) {
+func (h *Harness) testOutgoingTCP(t *testing.T, ipAddr netaddr.IP, cli *ssh.Client) {
 	const sendmsg = "this is a message that curl won't print"
 	ctx, cancel := context.WithCancel(context.Background())
 	s := &http.Server{


### PR DESCRIPTION
This paves the way for future MagicDNS tests.

Signed-off-by: Christine Dodrill <xe@tailscale.com>