### PR TITLE
util/hujson: initial commit a HuJSON AST parser and packer

### DIFF
--- a/util/hujson/fuzz_test.go
+++ b/util/hujson/fuzz_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//+build dev.fuzz
+
+package hujson
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func Fuzz(f *testing.F) {
+	f.Fuzz(func(t *testing.T, b []byte) {
+		if len(b) > 1<<12 {
+			t.Skip("input too large")
+		}
+
+		// Parse for valid HuJSON input.
+		v, err := Parse(b)
+		if err != nil {
+			t.Skipf("input %q: Parse error: %v", b, err)
+		}
+
+		// Pack should preserve the original input exactly.
+		if b2 := v.Pack(); !bytes.Equal(b, b2) {
+			t.Fatalf("input %q: Pack mismatch: %s", b, cmp.Diff(b, b2))
+		}
+
+		// Standardize should produce valid JSON.
+		v2 := v.Clone()
+		v2.Standardize()
+		b2 := v2.Pack()
+		if !json.Valid(b2) {
+			t.Fatalf("input %q: Standardize failure", b)
+		}
+	})
+}

--- a/util/hujson/json_test.go
+++ b/util/hujson/json_test.go
@@ -1,0 +1,302 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package hujson
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func Test(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    Value
+		wantErr error
+
+		wantMin string
+		wantStd string
+	}{{
+		in: ` null `,
+		want: Value{
+			BeforeExtra: Extra(" "),
+			StartOffset: 1,
+			Value:       Literal("null"),
+			EndOffset:   5,
+			AfterExtra:  Extra(" "),
+		},
+		wantMin: `null`,
+		wantStd: ` null `,
+	}, {
+		in: ` null,`,
+		want: Value{
+			BeforeExtra: Extra(" "),
+			StartOffset: 1,
+			Value:       Literal("null"),
+			EndOffset:   5,
+		},
+		wantErr: fmt.Errorf("hujson: line 1, column 6: %w", errors.New("invalid character ',' after top-level value")),
+	}, {
+		in: "//😊 \r\t\n/*\r\t\n*/null//😊 \r\t\n/*\r\t\n*/",
+		want: Value{
+			BeforeExtra: Extra("//😊 \r\t\n/*\r\t\n*/"),
+			StartOffset: 17,
+			Value:       Literal("null"),
+			EndOffset:   21,
+			AfterExtra:  Extra("//😊 \r\t\n/*\r\t\n*/"),
+		},
+		wantMin: "null",
+		wantStd: "       \r\t\n  \r\t\n  null       \r\t\n  \r\t\n  ",
+	}, {
+		in:      "/?",
+		wantErr: fmt.Errorf("hujson: line 1, column 1: %w", errors.New("invalid character '/' at start of value")),
+	}, {
+		in:      "//\xde\xad\xbe\xef\nnull",
+		wantErr: fmt.Errorf("hujson: line 1, column 1: %w", errors.New("invalid UTF-8 in comment")),
+	}, {
+		in: "null//",
+		want: Value{
+			Value:     Literal("null"),
+			EndOffset: 4,
+		},
+		wantErr: fmt.Errorf("hujson: line 1, column 5: %w", fmt.Errorf("parsing comment: %w", io.ErrUnexpectedEOF)),
+	}, {
+		in: "null//\n",
+		want: Value{
+			Value:      Literal("null"),
+			EndOffset:  4,
+			AfterExtra: Extra("//\n"),
+		},
+		wantMin: "null",
+		wantStd: "null  \n",
+	}, {
+		in:      `"\"\\\u0022😊`,
+		wantErr: fmt.Errorf("hujson: line 1, column 16: %w", fmt.Errorf("parsing string: %w", io.ErrUnexpectedEOF)),
+	}, {
+		in:      `"\xff"`,
+		wantErr: fmt.Errorf("hujson: line 1, column 1: %w", errors.New("invalid literal: \"\\xff\"")),
+	}, {
+		in:      `"\"\\\u0022😊"`,
+		want:    Value{Value: Literal(`"\"\\\u0022😊"`), EndOffset: 16},
+		wantMin: `"\"\\\u0022😊"`,
+		wantStd: `"\"\\\u0022😊"`,
+	}, {
+		in:      `3.14159E+435`,
+		want:    Value{Value: Literal(`3.14159E+435`), EndOffset: 12},
+		wantMin: `3.14159E+435`,
+		wantStd: `3.14159E+435`,
+	}, {
+		in:      `+1000`,
+		wantErr: fmt.Errorf("hujson: line 1, column 1: %w", errors.New("invalid literal: +1000")),
+	}, {
+		in:      "{",
+		want:    Value{Value: &Object{}},
+		wantErr: fmt.Errorf("hujson: line 1, column 2: %w", fmt.Errorf("parsing value: %w", io.ErrUnexpectedEOF)),
+	}, {
+		in:      "{,}",
+		want:    Value{Value: &Object{}},
+		wantErr: fmt.Errorf("hujson: line 1, column 2: %w", errors.New("invalid character ',' at start of value")),
+	}, {
+		in:      `{null:"v"`,
+		want:    Value{Value: &Object{}},
+		wantErr: fmt.Errorf("hujson: line 1, column 2: %w", errors.New("invalid character 'n' at start of object name")),
+	}, {
+		in:      `{"k"`,
+		want:    Value{Value: &Object{}},
+		wantErr: fmt.Errorf("hujson: line 1, column 5: %w", fmt.Errorf("parsing object after name: %w", io.ErrUnexpectedEOF)),
+	}, {
+		in:      `{"k";`,
+		want:    Value{Value: &Object{}},
+		wantErr: fmt.Errorf("hujson: line 1, column 5: %w", errors.New("invalid character ';' after object name")),
+	}, {
+		in:      `{"k":}`,
+		want:    Value{Value: &Object{}},
+		wantErr: fmt.Errorf("hujson: line 1, column 6: %w", errors.New("invalid character '}' at start of value")),
+	}, {
+		in: `{"k":"v"`,
+		want: Value{Value: &Object{
+			Members: []ObjectMember{{
+				Value{StartOffset: 1, Value: Literal(`"k"`), EndOffset: 4},
+				Value{StartOffset: 5, Value: Literal(`"v"`), EndOffset: 8},
+			}},
+		}},
+		wantErr: fmt.Errorf("hujson: line 1, column 9: %w", fmt.Errorf("parsing object after value: %w", io.ErrUnexpectedEOF)),
+	}, {
+		in: `{"k":"v"]`,
+		want: Value{Value: &Object{
+			Members: []ObjectMember{{
+				Value{StartOffset: 1, Value: Literal(`"k"`), EndOffset: 4},
+				Value{StartOffset: 5, Value: Literal(`"v"`), EndOffset: 8},
+			}},
+		}},
+		wantErr: fmt.Errorf("hujson: line 1, column 9: %w", errors.New("invalid character ']' after object value (expecting ',' or '}')")),
+	}, {
+		in: ` { "k" : "v" } `,
+		want: Value{
+			BeforeExtra: Extra(" "),
+			StartOffset: 1,
+			Value: &Object{
+				Members: []ObjectMember{{
+					Value{BeforeExtra: Extra(" "), StartOffset: 3, Value: Literal(`"k"`), EndOffset: 6, AfterExtra: Extra(" ")},
+					Value{BeforeExtra: Extra(" "), StartOffset: 9, Value: Literal(`"v"`), EndOffset: 12},
+				}},
+				AfterExtra: Extra(" "),
+			},
+			EndOffset:  14,
+			AfterExtra: Extra(" "),
+		},
+		wantMin: `{"k":"v"}`,
+		wantStd: ` { "k" : "v" } `,
+	}, {
+		in: ` { "k" : "v" , } `,
+		want: Value{
+			BeforeExtra: Extra(" "),
+			StartOffset: 1,
+			Value: &Object{
+				Members: []ObjectMember{{
+					Value{BeforeExtra: Extra(" "), StartOffset: 3, Value: Literal(`"k"`), EndOffset: 6, AfterExtra: Extra(" ")},
+					Value{BeforeExtra: Extra(" "), StartOffset: 9, Value: Literal(`"v"`), EndOffset: 12, AfterExtra: Extra(" ")},
+				}},
+				AfterExtra: Extra(" "),
+			},
+			EndOffset:  16,
+			AfterExtra: Extra(" "),
+		},
+		wantMin: `{"k":"v"}`,
+		wantStd: ` { "k" : "v"   } `,
+	}, {
+		in:      "[",
+		want:    Value{Value: &Array{}},
+		wantErr: fmt.Errorf("hujson: line 1, column 2: %w", fmt.Errorf("parsing value: %w", io.ErrUnexpectedEOF)),
+	}, {
+		in:      "[,]",
+		want:    Value{Value: &Array{}},
+		wantErr: fmt.Errorf("hujson: line 1, column 2: %w", errors.New("invalid character ',' at start of value")),
+	}, {
+		in: `["s"`,
+		want: Value{Value: &Array{
+			Elements: []Value{{StartOffset: 1, Value: Literal(`"s"`), EndOffset: 4}},
+		}},
+		wantErr: fmt.Errorf("hujson: line 1, column 5: %w", fmt.Errorf("parsing array after value: %w", io.ErrUnexpectedEOF)),
+	}, {
+		in: `["s"}`,
+		want: Value{Value: &Array{
+			Elements: []Value{{StartOffset: 1, Value: Literal(`"s"`), EndOffset: 4}},
+		}},
+		wantErr: fmt.Errorf("hujson: line 1, column 5: %w", errors.New("invalid character '}' after array value (expecting ',' or ']')")),
+	}, {
+		in: ` [ "s" ] `,
+		want: Value{
+			BeforeExtra: Extra(" "),
+			StartOffset: 1,
+			Value: &Array{
+				Elements:   []Value{{BeforeExtra: Extra(" "), StartOffset: 3, Value: Literal(`"s"`), EndOffset: 6}},
+				AfterExtra: Extra(" "),
+			},
+			EndOffset:  8,
+			AfterExtra: Extra(" "),
+		},
+		wantMin: `["s"]`,
+		wantStd: ` [ "s" ] `,
+	}, {
+		in: ` [ "s" , ] `,
+		want: Value{
+			BeforeExtra: Extra(" "),
+			StartOffset: 1,
+			Value: &Array{
+				Elements:   []Value{{BeforeExtra: Extra(" "), StartOffset: 3, Value: Literal(`"s"`), EndOffset: 6, AfterExtra: Extra(" ")}},
+				AfterExtra: Extra(" "),
+			},
+			EndOffset:  10,
+			AfterExtra: Extra(" "),
+		},
+		wantMin: `["s"]`,
+		wantStd: ` [ "s"   ] `,
+	}, {
+		in: ` /**/ [ /**/ null /**/ , /**/ false /**/ , /**/ true /**/ , /**/ "string" /**/ , /**/ 0 /**/ , /**/ {} /**/ , /**/ [] /**/ ] /**/ `,
+		want: Value{
+			BeforeExtra: Extra(" /**/ "),
+			StartOffset: 6,
+			Value: &Array{
+				Elements: []Value{
+					{BeforeExtra: Extra(" /**/ "), StartOffset: 13, Value: Literal("null"), EndOffset: 17, AfterExtra: Extra(" /**/ ")},
+					{BeforeExtra: Extra(" /**/ "), StartOffset: 30, Value: Literal("false"), EndOffset: 35, AfterExtra: Extra(" /**/ ")},
+					{BeforeExtra: Extra(" /**/ "), StartOffset: 48, Value: Literal("true"), EndOffset: 52, AfterExtra: Extra(" /**/ ")},
+					{BeforeExtra: Extra(" /**/ "), StartOffset: 65, Value: Literal(`"string"`), EndOffset: 73, AfterExtra: Extra(" /**/ ")},
+					{BeforeExtra: Extra(" /**/ "), StartOffset: 86, Value: Literal("0"), EndOffset: 87, AfterExtra: Extra(" /**/ ")},
+					{BeforeExtra: Extra(" /**/ "), StartOffset: 100, Value: &Object{}, EndOffset: 102, AfterExtra: Extra(" /**/ ")},
+					{BeforeExtra: Extra(" /**/ "), StartOffset: 115, Value: &Array{}, EndOffset: 117},
+				},
+				AfterExtra: Extra(" /**/ "),
+			},
+			EndOffset:  124,
+			AfterExtra: Extra(" /**/ "),
+		},
+		wantMin: `[null,false,true,"string",0,{},[]]`,
+		wantStd: `      [      null      ,      false      ,      true      ,      "string"      ,      0      ,      {}      ,      []      ]      `,
+	}}
+
+	for _, tt := range tests {
+		gotVal, gotErr := Parse([]byte(tt.in))
+		if diff := cmp.Diff(tt.want, gotVal, cmpopts.EquateEmpty()); diff != "" {
+			t.Errorf("Parse mismatch (-want +got):\n%s", diff)
+		}
+		if !reflect.DeepEqual(gotErr, tt.wantErr) {
+			t.Errorf("Parse error mismatch:\ngot  %v\nwant %v", gotErr, tt.wantErr)
+		}
+
+		if gotErr == nil {
+			gotIsStd := gotVal.IsStandard()
+			wantIsStd := tt.in == tt.wantStd
+			if gotIsStd != wantIsStd {
+				fmt.Printf("%q\n", string(tt.in))
+				fmt.Printf("%q\n", string(tt.wantStd))
+				t.Errorf("IsStandard() = %v, want %v", gotIsStd, wantIsStd)
+			}
+
+			gotBuf := string(gotVal.Pack())
+			if diff := cmp.Diff(gotBuf, tt.in); diff != "" {
+				t.Errorf("Pack mismatch (-want +got):\n%s", diff)
+			}
+
+			if tt.wantMin != "" {
+				gotMinVal := gotVal.Clone()
+				gotMinVal.Minimize()
+				gotMinBuf := string(gotMinVal.Pack())
+				wantMinVal, _ := Parse([]byte(tt.wantMin))
+				if diff := cmp.Diff(wantMinVal, gotMinVal, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("Minimize Value mismatch (-want +got):\n%s", diff)
+				}
+				if diff := cmp.Diff(tt.wantMin, gotMinBuf); diff != "" {
+					t.Errorf("Minimize buffer mismatch (-want +got):\n%s", diff)
+				}
+				if !gotMinVal.IsStandard() {
+					t.Errorf("IsStandard() = false, want true")
+				}
+			}
+
+			if tt.wantStd != "" {
+				gotStdVal := gotVal.Clone()
+				gotStdVal.Standardize()
+				gotStdBuf := string(gotStdVal.Pack())
+				wantStdVal, _ := Parse([]byte(tt.wantStd))
+				if diff := cmp.Diff(wantStdVal, gotStdVal, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("Standardize Value mismatch (-want +got):\n%s", diff)
+				}
+				if diff := cmp.Diff(tt.wantStd, gotStdBuf); diff != "" {
+					t.Errorf("Standardize buffer mismatch (-want +got):\n%s", diff)
+				}
+				if !gotStdVal.IsStandard() {
+					t.Errorf("IsStandard() = false, want true")
+				}
+			}
+		}
+	}
+}

--- a/util/hujson/pack.go
+++ b/util/hujson/pack.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package hujson
+
+// UpdateOffsets iterates through v and updates all
+// Value.StartOffset and Value.EndOffset fields so that they are accurate.
+func (v *Value) UpdateOffsets() {
+	v.updateOffsets(0)
+}
+func (v *Value) updateOffsets(n int) int {
+	n += len(v.BeforeExtra)
+	v.StartOffset = n
+	switch v2 := v.Value.(type) {
+	case Literal:
+		n += len(v2)
+	case *Object:
+		n += len("{")
+		for i := range v2.Members {
+			n = v2.Members[i].Name.updateOffsets(n)
+			n += len(":")
+			n = v2.Members[i].Value.updateOffsets(n)
+			n += len(",")
+		}
+		if v2.length() > 0 && !hasTrailingComma(v2) {
+			n -= len(",")
+		}
+		n += len(v2.AfterExtra)
+		n += len("}")
+	case *Array:
+		n += len("[")
+		for i := range v2.Elements {
+			n = v2.Elements[i].updateOffsets(n)
+			n += len(",")
+		}
+		if v2.length() > 0 && !hasTrailingComma(v2) {
+			n -= len(",")
+		}
+		n += len(v2.AfterExtra)
+		n += len("]")
+	}
+	v.EndOffset = n
+	n += len(v.AfterExtra)
+	return n
+}
+
+// Pack serializes the value as HuJSON.
+// The output is valid so long as every Extra and Literal in the Value is valid.
+// The output does not alias the memory of any buffers referenced by v.
+func (v Value) Pack() []byte {
+	return v.append(nil)
+}
+
+// String is a string representation of v.
+func (v Value) String() string {
+	return string(v.append(nil))
+}
+
+func (v Value) append(b []byte) []byte {
+	b = append(b, v.BeforeExtra...)
+	switch v2 := v.Value.(type) {
+	case Literal:
+		b = append(b, v2...)
+	case *Object:
+		b = append(b, '{')
+		for _, m := range v2.Members {
+			b = m.Name.append(b)
+			b = append(b, ':')
+			b = m.Value.append(b)
+			b = append(b, ',')
+		}
+		if v2.length() > 0 && !hasTrailingComma(v2) {
+			b = b[:len(b)-1]
+		}
+		b = append(b, v2.AfterExtra...)
+		b = append(b, '}')
+	case *Array:
+		b = append(b, '[')
+		for _, e := range v2.Elements {
+			b = e.append(b)
+			b = append(b, ',')
+		}
+		if v2.length() > 0 && !hasTrailingComma(v2) {
+			b = b[:len(b)-1]
+		}
+		b = append(b, v2.AfterExtra...)
+		b = append(b, ']')
+	}
+	b = append(b, v.AfterExtra...)
+	return b
+}

--- a/util/hujson/parse.go
+++ b/util/hujson/parse.go
@@ -1,0 +1,253 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package hujson
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"unicode/utf8"
+)
+
+func lineColumn(b []byte, n int) (line, column int) {
+	line = 1 + bytes.Count(b[:n], []byte("\n"))
+	column = 1 + n - (bytes.LastIndexByte(b[:n], '\n') + len("\n"))
+	return line, column
+}
+
+// Parse parses a HuJSON value as a Value.
+// Extra and Literal values in v will alias the provided input buffer.
+func Parse(b []byte) (Value, error) {
+	v, n, err := parseNext(0, b)
+	if err == nil && n < len(b) {
+		err = fmt.Errorf("invalid character %q after top-level value", b[n])
+	}
+	if err != nil {
+		line, column := lineColumn(b, n)
+		err = fmt.Errorf("hujson: line %d, column %d: %w", line, column, err)
+		return v, err
+	}
+	return v, nil
+}
+
+// parseNext parses the next value with surrounding whitespace and comments.
+func parseNext(n int, b []byte) (v Value, _ int, err error) {
+	n0 := n
+
+	// Consume leading whitespace and comments.
+	if n, err = consumeExtra(n, b); err != nil {
+		return v, n, err
+	}
+	if n > n0 {
+		v.BeforeExtra = b[n0:n:n]
+	}
+
+	// Parse the next value.
+	v.StartOffset = n
+	if v.Value, n, err = parseNextTrimmed(n, b); err != nil {
+		return v, n, err
+	}
+	v.EndOffset = n
+
+	// Consume trailing whitespace and comments.
+	if n, err = consumeExtra(n, b); err != nil {
+		return v, n, err
+	}
+	if n > v.EndOffset {
+		v.AfterExtra = b[v.EndOffset:n:n]
+	}
+
+	return v, n, nil
+}
+
+var (
+	errInvalidObjectEnd = errors.New("invalid character '}' at start of value")
+	errInvalidArrayEnd  = errors.New("invalid character ']' at start of value")
+)
+
+// parseNextTrimmed parses the next value without surrounding whitespace and comments.
+func parseNextTrimmed(n int, b []byte) (ValueTrimmed, int, error) {
+	if len(b) == n {
+		return nil, n, fmt.Errorf("parsing value: %w", io.ErrUnexpectedEOF)
+	}
+	switch b[n] {
+	// Parse objects.
+	case '{':
+		n++
+		var obj Object
+		for {
+			var vk, vv Value
+			var err error
+
+			// Parse the name.
+			if vk, n, err = parseNext(n, b); err != nil {
+				if err == errInvalidObjectEnd && vk.Value == nil {
+					setTrailingComma(&obj, len(obj.Members) > 0)
+					obj.AfterExtra = vk.BeforeExtra
+					return &obj, n + len(`}`), nil
+				}
+				return &obj, n, err
+			}
+			if vk.Value.Kind() != '"' {
+				return &obj, vk.StartOffset, fmt.Errorf("invalid character %q at start of object name", b[vk.StartOffset])
+			}
+
+			// Parse the colon.
+			switch {
+			case len(b) == n:
+				return &obj, n, fmt.Errorf("parsing object after name: %w", io.ErrUnexpectedEOF)
+			case b[n] != ':':
+				return &obj, n, fmt.Errorf("invalid character %q after object name", b[n])
+			}
+			n++
+
+			// Parse the value.
+			if vv, n, err = parseNext(n, b); err != nil {
+				return &obj, n, err
+			}
+
+			obj.Members = append(obj.Members, ObjectMember{vk, vv})
+			switch {
+			case len(b) == n:
+				return &obj, n, fmt.Errorf("parsing object after value: %w", io.ErrUnexpectedEOF)
+			case b[n] == ',':
+				n++
+			case b[n] == '}':
+				// Move AfterExtra from last value to AfterExtra of the object.
+				obj.AfterExtra = obj.Members[len(obj.Members)-1].Value.AfterExtra
+				obj.Members[len(obj.Members)-1].Value.AfterExtra = nil
+				return &obj, n + len(`}`), nil
+			default:
+				return &obj, n, fmt.Errorf("invalid character %q after object value (expecting ',' or '}')", b[n])
+			}
+		}
+	case '}':
+		return nil, n, errInvalidObjectEnd
+
+	// Parse arrays.
+	case '[':
+		n++
+		var arr Array
+		for {
+			var v Value
+			var err error
+			if v, n, err = parseNext(n, b); err != nil {
+				if err == errInvalidArrayEnd && v.Value == nil {
+					setTrailingComma(&arr, len(arr.Elements) > 0)
+					arr.AfterExtra = v.BeforeExtra
+					return &arr, n + len(`]`), nil
+				}
+				return &arr, n, err
+			}
+			arr.Elements = append(arr.Elements, v)
+			switch {
+			case len(b) == n:
+				return &arr, n, fmt.Errorf("parsing array after value: %w", io.ErrUnexpectedEOF)
+			case b[n] == ',':
+				n++
+			case b[n] == ']':
+				// Move AfterExtra from last value to AfterExtra of the array.
+				arr.AfterExtra = arr.Elements[len(arr.Elements)-1].AfterExtra
+				arr.Elements[len(arr.Elements)-1].AfterExtra = nil
+				return &arr, n + len(`]`), nil
+			default:
+				return &arr, n, fmt.Errorf("invalid character %q after array value (expecting ',' or ']')", b[n])
+			}
+		}
+	case ']':
+		return nil, n, errInvalidArrayEnd
+
+	// Parse strings.
+	case '"':
+		n0 := n
+		n++
+		var inEscape bool
+		for {
+			switch {
+			case len(b) == n:
+				return nil, n, fmt.Errorf("parsing string: %w", io.ErrUnexpectedEOF)
+			case inEscape:
+				inEscape = false
+			case b[n] == '\\':
+				inEscape = true
+			case b[n] == '"':
+				n++
+				lit := Literal(b[n0:n:n])
+				if !lit.IsValid() {
+					return nil, n0, fmt.Errorf("invalid literal: %s", lit)
+				}
+				return lit, n, nil
+			}
+			n++
+		}
+
+	// Parse null, booleans, and numbers.
+	default:
+		n0 := n
+		for len(b) > n && (b[n] == '-' || b[n] == '+' || b[n] == '.' ||
+			('a' <= b[n] && b[n] <= 'z') ||
+			('A' <= b[n] && b[n] <= 'Z') ||
+			('0' <= b[n] && b[n] <= '9')) {
+			n++
+		}
+		switch lit := Literal(b[n0:n]); {
+		case len(lit) == 0:
+			return nil, n0, fmt.Errorf("invalid character %q at start of value", b[n0])
+		case !lit.IsValid():
+			return nil, n0, fmt.Errorf("invalid literal: %s", lit)
+		default:
+			return lit, n, nil
+		}
+	}
+}
+
+var (
+	lineCommentStart  = []byte("//")
+	lineCommentEnd    = []byte("\n")
+	blockCommentStart = []byte("/*")
+	blockCommentEnd   = []byte("*/")
+)
+
+// consumeExtra consumes leading whitespace and comments.
+func consumeExtra(n int, b []byte) (int, error) {
+	for len(b) > n {
+		switch b[n] {
+		// Skip past whitespace.
+		case ' ', '\t', '\r', '\n':
+			n += consumeWhitespace(b[n:])
+		// Skip past comments.
+		case '/':
+			var start, end []byte
+			switch {
+			case bytes.HasPrefix(b[n:], lineCommentStart):
+				start, end = lineCommentStart, lineCommentEnd
+			case bytes.HasPrefix(b[n:], blockCommentStart):
+				start, end = blockCommentStart, blockCommentEnd
+			default:
+				return n, nil
+			}
+			n += len(start)
+			i := bytes.Index(b[n:], end)
+			switch {
+			case i < 0:
+				return n - len(start), fmt.Errorf("parsing comment: %w", io.ErrUnexpectedEOF)
+			case !utf8.Valid(b[n : n+i]):
+				return n - len(start), fmt.Errorf("invalid UTF-8 in comment")
+			}
+			n += i + len(end)
+		default:
+			return n, nil
+		}
+	}
+	return n, nil
+}
+
+func consumeWhitespace(b []byte) (n int) {
+	for len(b) > n && (b[n] == ' ' || b[n] == '\t' || b[n] == '\r' || b[n] == '\n') {
+		n++
+	}
+	return n
+}

--- a/util/hujson/standard.go
+++ b/util/hujson/standard.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package hujson
+
+// IsStandard reports whether this is standard JSON. It checks whether
+// Extra only contains whitespace and that there are no trailing commas.
+func (v *Value) IsStandard() bool {
+	if !v.BeforeExtra.IsStandard() {
+		return false
+	}
+	if comp, ok := v.Value.(composite); ok {
+		if !comp.rangeValues(func(v *Value) bool { return v.IsStandard() }) {
+			return false
+		}
+		if hasTrailingComma(comp) || !comp.afterExtra().IsStandard() {
+			return false
+		}
+	}
+	if !v.AfterExtra.IsStandard() {
+		return false
+	}
+	return true
+}
+
+// IsStandard reports whether this is standard JSON whitespace.
+func (b Extra) IsStandard() bool {
+	return consumeWhitespace(b) == len(b)
+}
+
+// Minimize removes all whitespace, comments, and trailing commas from v,
+// making it compliant with standard JSON per RFC 8259.
+func (v *Value) Minimize() {
+	v.minimize()
+	v.UpdateOffsets()
+}
+func (v *Value) minimize() {
+	v.BeforeExtra = nil
+	if v2, ok := v.Value.(composite); ok {
+		v2.rangeValues(func(v *Value) bool {
+			v.minimize()
+			return true
+		})
+		setTrailingComma(v2, false)
+		*v2.afterExtra() = nil
+	}
+	v.AfterExtra = nil
+}
+
+// Standardize strips any features specific to HuJSON from v,
+// making it compliant with standard JSON per RFC 8259.
+// All comments and trailing commas are replaced with a space character
+// in order to preserve the original line numbers and byte offsets.
+func (v *Value) Standardize() {
+	v.standardize()
+	v.UpdateOffsets() // should be noop if offsets are already correct
+}
+func (v *Value) standardize() {
+	v.BeforeExtra.standardize()
+	if comp, ok := v.Value.(composite); ok {
+		comp.rangeValues(func(v *Value) bool {
+			v.standardize()
+			return true
+		})
+		if last := comp.lastValue(); last != nil && last.AfterExtra != nil {
+			*comp.afterExtra() = append(append(last.AfterExtra, ' '), *comp.afterExtra()...)
+			last.AfterExtra = nil
+		}
+		comp.afterExtra().standardize()
+	}
+	v.AfterExtra.standardize()
+}
+func (b *Extra) standardize() {
+	for i, c := range *b {
+		switch c {
+		case ' ', '\t', '\r', '\n':
+			// NOTE: Avoid changing '\n' to keep line numbers the same.
+		default:
+			(*b)[i] = ' '
+		}
+	}
+}

--- a/util/hujson/types.go
+++ b/util/hujson/types.go
@@ -1,0 +1,450 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package hujson contains a parser and packer for the HuJSON format.
+//
+// HuJSON is an extension of standard JSON (as defined in RFC 8259) in order to
+// make it more suitable for humans and configuration files. In particular,
+// it supports line comments (e.g., //...), block comments (e.g., /*...*/), and
+// trailing commas after the last member or element in a JSON object or array.
+//
+//
+// Functionality
+//
+// The Parse function parses HuJSON input as a Value,
+// which is a syntax tree exactly representing the input.
+// Comments and whitespace are represented using the Extra type.
+// Composite types in JSON are represented using the Object and Array types.
+// Primitive types in JSON are represented using the Literal type.
+// The Value.Pack method serializes the syntax tree as raw output,
+// which is byte-for-byte identical to the input if no transformations
+// were performed on the value.
+//
+// A HuJSON value can be transformed using the Minimize, Standardize,
+// NormalizeNames, and Reformat methods. Each of these methods mutate the value
+// in place. Call the Clone method in order to preserve the original value.
+// The Minimize and Standardize methods coerces HuJSON into valid standard JSON.
+// The Reformat method formats the value; it is similar to `go fmt`,
+// but instead for the HuJSON and standard JSON format.
+//
+//
+// Grammar
+//
+// The changes to the JSON grammar are:
+//
+//	--- grammar.json
+//	+++ grammar.hujson
+//	@@ -1,13 +1,31 @@
+//	 members
+//	 	member
+//	+	member ',' ws
+//	 	member ',' members
+//
+//	 elements
+//	 	element
+//	+	element ',' ws
+//	 	element ',' elements
+//
+//	+comments
+//	+	"*/"
+//	+	comment comments
+//	+
+//	+comment
+//	+	'0000' . '10FFFF'
+//	+
+//	+linecomments
+//	+	'\n'
+//	+	linecomment
+//	+
+//	+linecomment
+//	+	'0000' . '10FFFF' - '\n'
+//	+
+//	 ws
+//	 	""
+//	+	"/*" comments
+//	+	"//" linecomments
+//	 	'0020' ws
+//	 	'000A' ws
+//	 	'000D' ws
+//
+package hujson
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"unicode/utf8"
+)
+
+// Value is an exact syntactic representation of a JSON value.
+// The starting and ending byte offsets are populated when parsing,
+// but are otherwise ignored when packing.
+type Value struct {
+	// BeforeExtra are the comments and whitespace before Value.
+	// This is the extra after the preceding open brace, open bracket,
+	// colon, comma, or start of input.
+	BeforeExtra Extra
+	// StartOffset is the offset of the first byte in Value.
+	StartOffset int
+	// Value is the JSON value itself without surround extra.
+	Value ValueTrimmed
+	// EndOffset is the offset of the next byte after Value.
+	EndOffset int
+	// AfterExtra are the comments and whitespace after Value.
+	// This is the extra before the succeeding colon, comma, or end of input.
+	AfterExtra Extra
+}
+
+// Clone returns a deep copy of the value.
+func (v Value) Clone() Value {
+	v.BeforeExtra = copyBytes(v.BeforeExtra)
+	v.Value = v.Value.Clone()
+	v.AfterExtra = copyBytes(v.AfterExtra)
+	return v
+}
+
+// ValueTrimmed is a JSON value without surround whitespace or comments.
+// This is a sum type consisting of Literal, *Object, or *Array.
+type ValueTrimmed interface {
+	// Clone returns a deep copy of the value.
+	Clone() ValueTrimmed
+
+	// Kind reports the kind of the JSON value.
+	// It is the first byte of the grammar for that JSON value,
+	// with the exception that JSON numbers are represented as a '0'.
+	//
+	//	'n': null
+	//	'f': false
+	//	't': true
+	//	'"': string
+	//	'0': number
+	//	'{': object
+	//	'[': array
+	//
+	Kind() byte
+}
+
+// Literal is the raw bytes for a JSON null, boolean, string, or number.
+// It contains no surrounding whitespace or comments.
+type Literal []byte // null, false, true, "string", 3.14159
+
+// Bool constructs a JSON literal for a boolean.
+func Bool(v bool) Literal {
+	if v {
+		return Literal("true")
+	} else {
+		return Literal("false")
+	}
+}
+
+// String constructs a JSON literal for string.
+// Invalid UTF-8 is mangled with the Unicode replacement character.
+func String(v string) Literal {
+	// Format according to RFC 8785, section 3.2.2.2.
+	b := make([]byte, 0, len(`"`)+len(v)+len(`"`))
+	b = append(b, '"')
+	var arr [utf8.UTFMax]byte
+	for _, r := range v {
+		switch {
+		case r < ' ' || r == '\\' || r == '"':
+			switch r {
+			case '\b':
+				b = append(b, `\b`...)
+			case '\t':
+				b = append(b, `\t`...)
+			case '\n':
+				b = append(b, `\n`...)
+			case '\f':
+				b = append(b, `\f`...)
+			case '\r':
+				b = append(b, `\r`...)
+			case '\\':
+				b = append(b, `\\`...)
+			case '"':
+				b = append(b, `\"`...)
+			default:
+				b = append(b, fmt.Sprintf(`\u%04x`, r)...)
+			}
+		default:
+			b = append(b, arr[:utf8.EncodeRune(arr[:], r)]...)
+		}
+	}
+	b = append(b, '"')
+	return Literal(b)
+}
+
+// Int construct a JSON literal for a signed integer.
+func Int(v int64) Literal {
+	return Literal(strconv.AppendInt(nil, v, 10))
+}
+
+// Uint construct a JSON literal for an unsigned integer.
+func Uint(v uint64) Literal {
+	return Literal(strconv.AppendUint(nil, v, 10))
+}
+
+// Float construct a JSON literal for a floating-point number.
+// The values NaN, +Inf, and -Inf will be represented as a JSON string
+// with the values "NaN", "Infinity", and "-Infinity".
+func Float(v float64) Literal {
+	switch {
+	case math.IsNaN(v):
+		return Literal(`"NaN"`)
+	case math.IsInf(v, +1):
+		return Literal(`"Infinity"`)
+	case math.IsInf(v, -1):
+		return Literal(`"-Infinity"`)
+	default:
+		b, _ := json.Marshal(v)
+		return Literal(b)
+	}
+}
+
+// Clone makes a new copy of the literal.
+func (b Literal) Clone() ValueTrimmed {
+	return Literal(copyBytes(b))
+}
+
+// Kind represents each possible JSON literal kind with a single byte,
+// which is conveniently the first byte of that kind's grammar
+// with the restriction that numbers always be represented with '0'.
+func (b Literal) Kind() byte {
+	if len(b) == 0 {
+		return 0
+	}
+	switch k := b[0]; k {
+	case 'n', 'f', 't', '"':
+		return k
+	case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		return '0'
+	default:
+		return 0
+	}
+}
+
+// IsValid reports whether b is a valid JSON null, boolean, string, or number.
+// The literal must not have surrounding whitespace.
+func (b Literal) IsValid() bool {
+	// NOTE: The v1 json package is non-compliant with RFC 8259, section 8.1
+	// in that it does not enforce the use of valid UTF-8.
+	return json.Valid(b) && len(b) == len(bytes.TrimSpace(b))
+}
+
+// Bool returns the value for a JSON boolean.
+// It returns false if the literal is not a JSON boolean.
+func (b Literal) Bool() bool {
+	return string(b) == "true"
+}
+
+// String returns the unescaped string value for a JSON string.
+// For other JSON kinds, this returns the raw JSON represention.
+func (b Literal) String() (s string) {
+	if b.Kind() == '"' && json.Unmarshal(b, &s) == nil {
+		return s
+	}
+	return string(b)
+}
+
+// Int returns the signed integer value for a JSON number.
+// It returns 0 if the literal is not a signed integer.
+func (b Literal) Int() (n int64) {
+	if b.Kind() == '0' && json.Unmarshal(b, &n) == nil {
+		return n
+	}
+	return 0
+}
+
+// Uin returns the unsigned integer value for a JSON number.
+// It returns 0 if the literal is not an unsigned integer.
+func (b Literal) Uint() (n uint64) {
+	if b.Kind() == '0' && json.Unmarshal(b, &n) == nil {
+		return n
+	}
+	return 0
+}
+
+// Float returns the floating-point value for a JSON number.
+// It returns a NaN, +Inf, or -Inf value for any JSON string with the values
+// "NaN", "Infinity", or "-Infinity".
+// It returns 0 for all other cases.
+func (b Literal) Float() (n float64) {
+	if b.Kind() == '0' && json.Unmarshal(b, &n) == nil {
+		return n
+	}
+	if b.Kind() == '"' {
+		switch b.String() {
+		case "NaN":
+			return math.NaN()
+		case "Infinity":
+			return math.Inf(+1)
+		case "-Infinity":
+			return math.Inf(-1)
+		}
+	}
+	return 0
+}
+
+// Object is an exact syntactic representation of a JSON object.
+type Object struct {
+	// Members are the members of a JSON object.
+	// A trailing comma is emitted only if the Value.AfterExtra
+	// on the last value is non-nil. Otherwise it is omitted.
+	Members []ObjectMember
+	// AfterExtra are the comments and whitespace before the closing '}'.
+	AfterExtra Extra
+}
+
+type ObjectMember struct {
+	Name, Value Value
+}
+
+func (obj Object) length() int {
+	return len(obj.Members)
+}
+func (obj Object) firstValue() *Value {
+	if len(obj.Members) > 0 {
+		return &obj.Members[0].Name
+	}
+	return nil
+}
+func (obj Object) rangeValues(f func(*Value) bool) bool {
+	for i := range obj.Members {
+		if !f(&obj.Members[i].Name) {
+			return false
+		}
+		if !f(&obj.Members[i].Value) {
+			return false
+		}
+	}
+	return true
+}
+func (obj Object) lastValue() *Value {
+	if len(obj.Members) > 0 {
+		return &obj.Members[len(obj.Members)-1].Value
+	}
+	return nil
+}
+func (obj *Object) afterExtra() *Extra {
+	return &obj.AfterExtra
+}
+
+func (obj Object) Clone() ValueTrimmed {
+	if obj.Members != nil {
+		obj.Members = append([]ObjectMember(nil), obj.Members...)
+		for i := range obj.Members {
+			obj.Members[i].Name = obj.Members[i].Name.Clone()
+			obj.Members[i].Value = obj.Members[i].Value.Clone()
+		}
+	}
+	obj.AfterExtra = copyBytes(obj.AfterExtra)
+	return &obj
+}
+
+func (*Object) Kind() byte { return '{' }
+
+// Array is an exact syntactic representation of a JSON array.
+type Array struct {
+	// Elements are the elements of a JSON array.
+	// A trailing comma is emitted only if the Value.AfterExtra
+	// on the last value is non-nil. Otherwise it is omitted.
+	Elements []Value
+	// AfterExtra are the comments and whitespace before the closing ']'.
+	AfterExtra Extra
+}
+
+func (arr Array) length() int {
+	return len(arr.Elements)
+}
+func (arr Array) firstValue() *Value {
+	if len(arr.Elements) > 0 {
+		return &arr.Elements[0]
+	}
+	return nil
+}
+func (arr Array) rangeValues(f func(*Value) bool) bool {
+	for i := range arr.Elements {
+		if !f(&arr.Elements[i]) {
+			return false
+		}
+	}
+	return true
+}
+func (arr Array) lastValue() *Value {
+	if len(arr.Elements) > 0 {
+		return &arr.Elements[len(arr.Elements)-1]
+	}
+	return nil
+}
+func (arr *Array) afterExtra() *Extra {
+	return &arr.AfterExtra
+}
+
+func (arr Array) Clone() ValueTrimmed {
+	if arr.Elements != nil {
+		arr.Elements = append([]Value(nil), arr.Elements...)
+		for i := range arr.Elements {
+			arr.Elements[i] = arr.Elements[i].Clone()
+		}
+	}
+	arr.AfterExtra = copyBytes(arr.AfterExtra)
+	return &arr
+}
+
+func (*Array) Kind() byte { return '[' }
+
+// composite are the common methods of Object and Array.
+type composite interface {
+	length() int
+
+	firstValue() *Value
+	rangeValues(func(*Value) bool) bool
+	lastValue() *Value
+
+	afterExtra() *Extra
+}
+
+func hasTrailingComma(comp composite) bool {
+	if last := comp.lastValue(); last != nil && last.AfterExtra != nil {
+		return true
+	}
+	return false
+}
+func setTrailingComma(comp composite, v bool) {
+	if last := comp.lastValue(); last != nil {
+		switch {
+		case v && last.AfterExtra == nil:
+			last.AfterExtra = []byte{}
+		case !v && last.AfterExtra != nil:
+			*comp.afterExtra() = append(last.AfterExtra, *comp.afterExtra()...)
+			last.AfterExtra = nil
+		}
+	}
+}
+
+var (
+	_ composite = (*Object)(nil)
+	_ composite = (*Array)(nil)
+)
+
+// Extra is the raw bytes for whitespace and comments.
+// Whitespace per RFC 8259, section 2 are permitted.
+// Line comments that start with "//" and end with "\n" are permitted.
+// Block comments that start with "/*" and end with "*/" are permitted.
+type Extra []byte
+
+// IsValid reports whether the whitespace and comments are valid
+// according to the HuJSON grammar.
+func (b Extra) IsValid() bool {
+	n, err := consumeExtra(0, b)
+	return n == len(b) && err == nil
+}
+
+func copyBytes(b []byte) []byte {
+	if b == nil {
+		return nil
+	}
+	return append([]byte(nil), b...)
+}


### PR DESCRIPTION
This package provides a HuJSON parser into an AST represented by the following Go types:
* Value: A JSON literal, object, or array with surrounding whitespace/comments.
* Extra: Raw bytes of whitespace and comments.
* Literal: Raw bytes of a JSON literal (i.e., null, boolean, string, or number).
* Object: A JSON object.
* Array: A JSON array.

The Parse function parses raw HuJSON input as a Value.
The Value.Pack method serializes the AST as raw HuJSON output.