### PR TITLE
util/deephash: make hash type opaque

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -95,7 +95,7 @@ type LocalBackend struct {
 	serverURL             string           // tailcontrol URL
 	newDecompressor       func() (controlclient.Decompressor, error)
 
-	filterHash string
+	filterHash deephash.Sum
 
 	// The mutex protects the following elements.
 	mu             sync.Mutex
@@ -944,7 +944,7 @@ func (b *LocalBackend) updateFilter(netMap *netmap.NetworkMap, prefs *ipn.Prefs)
 	localNets, _ := localNetsB.IPSet()
 	logNets, _ := logNetsB.IPSet()
 
-	changed := deephash.UpdateHash(&b.filterHash, haveNetmap, addrs, packetFilter, localNets.Ranges(), logNets.Ranges(), shieldsUp)
+	changed := deephash.Update(&b.filterHash, haveNetmap, addrs, packetFilter, localNets.Ranges(), logNets.Ranges(), shieldsUp)
 	if !changed {
 		return
 	}

--- a/util/deephash/deephash_test.go
+++ b/util/deephash/deephash_test.go
@@ -7,8 +7,6 @@ package deephash
 import (
 	"bufio"
 	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"reflect"
 	"testing"
@@ -233,26 +231,13 @@ func BenchmarkTailcfgNode(b *testing.B) {
 }
 
 func TestExhaustive(t *testing.T) {
-	seen := make(map[[sha256.Size]byte]bool)
+	seen := make(map[Sum]bool)
 	for i := 0; i < 100000; i++ {
 		s := Hash(i)
 		if seen[s] {
 			t.Fatalf("hash collision %v", i)
 		}
 		seen[s] = true
-	}
-}
-
-func TestSHA256EqualHex(t *testing.T) {
-	for i := 0; i < 1000; i++ {
-		sum := Hash(i)
-		hx := hex.EncodeToString(sum[:])
-		if !sha256EqualHex(sum, hx) {
-			t.Fatal("didn't match, should've")
-		}
-		if sha256EqualHex(sum, hx[:len(hx)-1]) {
-			t.Fatal("matched on wrong length")
-		}
 	}
 }
 


### PR DESCRIPTION
The fact that Hash returns a [sha256.Size]byte leaks details about
the underlying hash implementation. This could very well be any other
hashing algorithm with a possible different block size.

Abstract this implementation detail away by declaring an opaque type
that is comparable. While we are changing the signature of UpdateHash,
rename it to just Update to reduce stutter (e.g., deephash.Update).