### PR TITLE
tstest/integration: fix tests on darwin

### DIFF
--- a/safesocket/safesocket_darwin.go
+++ b/safesocket/safesocket_darwin.go
@@ -53,15 +53,16 @@ func localTCPPortAndTokenDarwin() (port int, token string, err error) {
 	// The current process is running outside the sandbox, so use
 	// lsof to find the IPNExtension:
 
-	out, err := exec.Command("lsof",
+	cmd := exec.Command("lsof",
 		"-n",                             // numeric sockets; don't do DNS lookups, etc
 		"-a",                             // logical AND remaining options
 		fmt.Sprintf("-u%d", os.Getuid()), // process of same user only
 		"-c", "IPNExtension",             // starting with IPNExtension
 		"-F", // machine-readable output
-	).Output()
+	)
+	out, err := cmd.Output()
 	if err != nil {
-		return 0, "", fmt.Errorf("failed to run lsof looking for IPNExtension: %w", err)
+		return 0, "", fmt.Errorf("failed to run '%s' looking for IPNExtension: %w", cmd, err)
 	}
 	bs := bufio.NewScanner(bytes.NewReader(out))
 	subStr := []byte(".tailscale.ipn.macos/sameuserproof-")

--- a/safesocket/unixsocket.go
+++ b/safesocket/unixsocket.go
@@ -28,16 +28,15 @@ func connect(path string, port uint16) (net.Conn, error) {
 	pipe, err := net.Dial("unix", path)
 	if err != nil {
 		if runtime.GOOS == "darwin" {
-			extConn, err := connectMacOSAppSandbox()
-			if err != nil {
-				log.Printf("safesocket: failed to connect to Tailscale IPNExtension: %v", err)
-			} else {
-				return extConn, nil
+			extConn, extErr := connectMacOSAppSandbox()
+			if extErr != nil {
+				return nil, fmt.Errorf("safesocket: failed to connect to %v: %v; failed to connect to Tailscale IPNExtension: %v", path, err, extErr)
 			}
+			return extConn, nil
 		}
 		return nil, err
 	}
-	return pipe, err
+	return pipe, nil
 }
 
 // TODO(apenwarr): handle magic cookie auth

--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -314,7 +314,7 @@ func TestAddPingRequest(t *testing.T) {
 
 // Issue 2434: when "down" (WantRunning false), tailscaled shouldn't
 // be connected to control.
-func TestNoControlConnectionWhenDown(t *testing.T) {
+func TestNoControlConnWhenDown(t *testing.T) {
 	t.Parallel()
 	bins := BuildTestBinaries(t)
 
@@ -361,7 +361,7 @@ func TestNoControlConnectionWhenDown(t *testing.T) {
 
 // Issue 2137: make sure Windows tailscaled works with the CLI alone,
 // without the GUI to kick off a Start.
-func TestOneNodeUp_WindowsStyle(t *testing.T) {
+func TestOneNodeUpWindowsStyle(t *testing.T) {
 	t.Parallel()
 	bins := BuildTestBinaries(t)
 
@@ -471,10 +471,14 @@ type testNode struct {
 // The node is not started automatically.
 func newTestNode(t *testing.T, env *testEnv) *testNode {
 	dir := t.TempDir()
+	sockFile := filepath.Join(dir, "tailscale.sock")
+	if len(sockFile) >= 104 {
+		t.Fatalf("sockFile path %q (len %v) is too long, must be < 104", sockFile, len(sockFile))
+	}
 	return &testNode{
 		env:       env,
 		dir:       dir,
-		sockFile:  filepath.Join(dir, "tailscale.sock"),
+		sockFile:  sockFile,
 		stateFile: filepath.Join(dir, "tailscale.state"),
 	}
 }


### PR DESCRIPTION
- tstest/integration: shorten test names
- safesocket: reduce log spam while running integration tests
- safesocket: print full lsof command on failure
