### PR TITLE
wgengine/{monitor,router}: restore Linux ip rules when systemd deletes them

### DIFF
--- a/syncs/syncs.go
+++ b/syncs/syncs.go
@@ -79,6 +79,16 @@ func (b *AtomicBool) Set(v bool) {
 	atomic.StoreInt32((*int32)(b), n)
 }
 
+// Swap sets b to v and reports whether it changed.
+func (b *AtomicBool) Swap(v bool) (changed bool) {
+	var n int32
+	if v {
+		n = 1
+	}
+	old := atomic.SwapInt32((*int32)(b), n)
+	return old != n
+}
+
 func (b *AtomicBool) Get() bool {
 	return atomic.LoadInt32((*int32)(b)) != 0
 }

--- a/wgengine/monitor/monitor.go
+++ b/wgengine/monitor/monitor.go
@@ -62,6 +62,7 @@ type Mon struct {
 
 	mu         sync.Mutex // guards all following fields
 	cbs        map[*callbackHandle]ChangeFunc
+	ruleDelCB  map[*callbackHandle]RuleDeleteCallback
 	ifState    *interfaces.State
 	gwValid    bool       // whether gw and gwSelfIP are valid
 	gw         netaddr.IP // our gateway's IP
@@ -145,6 +146,30 @@ func (m *Mon) RegisterChangeCallback(callback ChangeFunc) (unregister func()) {
 		m.mu.Lock()
 		defer m.mu.Unlock()
 		delete(m.cbs, handle)
+	}
+}
+
+// RuleDeleteCallback is a callback when a Linux IP policy routing
+// rule is deleted. The table is the table number (52, 253, 354) and
+// priority is the priority order number (for Tailscale rules
+// currently: 5210, 5230, 5250, 5270)
+type RuleDeleteCallback func(table uint8, priority uint32)
+
+// RegisterRuleDeleteCallback adds callback to the set of parties to be
+// notified (in their own goroutine) when a Linux ip rule is deleted.
+// To remove this callback, call unregister (or close the monitor).
+func (m *Mon) RegisterRuleDeleteCallback(callback RuleDeleteCallback) (unregister func()) {
+	handle := new(callbackHandle)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.ruleDelCB == nil {
+		m.ruleDelCB = map[*callbackHandle]RuleDeleteCallback{}
+	}
+	m.ruleDelCB[handle] = callback
+	return func() {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		delete(m.ruleDelCB, handle)
 	}
 }
 
@@ -242,10 +267,22 @@ func (m *Mon) pump() {
 			time.Sleep(time.Second)
 			continue
 		}
+		if rdm, ok := msg.(ipRuleDeletedMessage); ok {
+			m.notifyRuleDeleted(rdm)
+			continue
+		}
 		if msg.ignore() {
 			continue
 		}
 		m.InjectEvent()
+	}
+}
+
+func (m *Mon) notifyRuleDeleted(rdm ipRuleDeletedMessage) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, cb := range m.ruleDelCB {
+		go cb(rdm.table, rdm.priority)
 	}
 }
 
@@ -338,3 +375,10 @@ func (m *Mon) checkWallTimeAdvanceLocked() {
 	}
 	m.lastWall = now
 }
+
+type ipRuleDeletedMessage struct {
+	table    uint8
+	priority uint32
+}
+
+func (ipRuleDeletedMessage) ignore() bool { return true }

--- a/wgengine/monitor/monitor_linux.go
+++ b/wgengine/monitor/monitor_linux.go
@@ -134,7 +134,10 @@ func (c *nlConn) Receive() (message, error) {
 			// On `ip -4 rule del pref 5210 table main`, logs:
 			// monitor: ip rule deleted: {Family:2 DstLength:0 SrcLength:0 Tos:0 Table:254 Protocol:0 Scope:0 Type:1 Flags:0 Attributes:{Dst:<nil> Src:<nil> Gateway:<nil> OutIface:0 Priority:5210 Table:254 Mark:4294967295 Expires:<nil> Metrics:<nil> Multipath:[]}}
 		}
-		return ipRuleDeletedMessage{}, nil
+		return ipRuleDeletedMessage{
+			table:    rmsg.Table,
+			priority: rmsg.Attributes.Priority,
+		}, nil
 	default:
 		c.logf("unhandled netlink msg type %+v, %q", msg.Header, msg.Data)
 		return unspecifiedMessage{}, nil
@@ -192,7 +195,3 @@ func (m *newAddrMessage) ignore() bool {
 type ignoreMessage struct{}
 
 func (ignoreMessage) ignore() bool { return true }
-
-type ipRuleDeletedMessage struct{}
-
-func (ipRuleDeletedMessage) ignore() bool { return false }


### PR DESCRIPTION
Thanks.

Fixes #1591