### PR TITLE
util/deephash: disambiguate hashing of AppendTo

### DIFF
--- a/util/deephash/deephash.go
+++ b/util/deephash/deephash.go
@@ -147,8 +147,10 @@ func (h *hasher) print(v reflect.Value) (acyclic bool) {
 		// Use AppendTo methods, if available and cheap.
 		if v.CanAddr() && v.Type().Implements(appenderToType) {
 			a := v.Addr().Interface().(appenderTo)
-			scratch := a.AppendTo(h.scratch[:0])
-			w.Write(scratch)
+			size := h.scratch[:8]
+			record := a.AppendTo(size)
+			binary.LittleEndian.PutUint64(record, uint64(len(record)-len(size)))
+			w.Write(record)
 			return true
 		}
 	}

--- a/util/deephash/deephash_test.go
+++ b/util/deephash/deephash_test.go
@@ -22,6 +22,12 @@ import (
 	"tailscale.com/wgengine/wgcfg"
 )
 
+type appendBytes []byte
+
+func (p appendBytes) AppendTo(b []byte) []byte {
+	return append(b, p...)
+}
+
 func TestHash(t *testing.T) {
 	type tuple [2]interface{}
 	type iface struct{ X interface{} }
@@ -31,6 +37,8 @@ func TestHash(t *testing.T) {
 		in     tuple
 		wantEq bool
 	}{
+		{in: tuple{[]appendBytes{{}, {0, 0, 0, 0, 0, 0, 0, 1}}, []appendBytes{{}, {0, 0, 0, 0, 0, 0, 0, 1}}}, wantEq: true},
+		{in: tuple{[]appendBytes{{}, {0, 0, 0, 0, 0, 0, 0, 1}}, []appendBytes{{0, 0, 0, 0, 0, 0, 0, 1}, {}}}, wantEq: false},
 		{in: tuple{iface{MyBool(true)}, iface{MyBool(true)}}, wantEq: true},
 		{in: tuple{iface{true}, iface{MyBool(true)}}, wantEq: false},
 		{in: tuple{iface{MyHeader{}}, iface{MyHeader{}}}, wantEq: true},


### PR DESCRIPTION
Prepend size to AppendTo output.

Fixes #2443

Signed-off-by: Joe Tsai <joetsai@digital-static.net>