### PR TITLE
tstest/integration/vms: disable rDNS for sshd on centos

### DIFF
--- a/tstest/integration/vms/distros.go
+++ b/tstest/integration/vms/distros.go
@@ -26,7 +26,9 @@ func (d *Distro) InstallPre() string {
 	switch d.PackageManager {
 	case "yum":
 		return ` - [ yum, update, gnupg2 ]
- - [ yum, "-y", install, iptables ]`
+ - [ yum, "-y", install, iptables ]
+ - [ sh, "-c", "printf '\n\nUseDNS no\n\n' | tee -a /etc/ssh/sshd_config" ]
+ - [ systemctl, restart, "sshd.service" ]`
 	case "zypper":
 		return ` - [ zypper, in, "-y", iptables ]`
 


### PR DESCRIPTION
This prevents centos tests from timing out because sshd does reverse dns
lookups on every session being established instead of doing it once on
the acutal ssh connection being established. This is odd. Appending this
to the sshd config and restarting it seems to fix it though.

Signed-off-by: Christine Dodrill <xe@tailscale.com>

Depends on #2491 