### PR TITLE
net/portmapper: Add discovery to upnp

### DIFF
--- a/net/portmapper/portmapper_test.go
+++ b/net/portmapper/portmapper_test.go
@@ -34,7 +34,7 @@ func TestClientProbe(t *testing.T) {
 	}
 	c := NewClient(t.Logf, nil)
 	defer c.Close()
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 10; i++ {
 		if i > 0 {
 			time.Sleep(100 * time.Millisecond)
 		}

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -33,6 +33,7 @@ import (
 	"tailscale.com/derp"
 	"tailscale.com/derp/derphttp"
 	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/net/portmapper"
 	"tailscale.com/net/stun/stuntest"
 	"tailscale.com/net/tstun"
 	"tailscale.com/tailcfg"
@@ -326,6 +327,7 @@ func meshStacks(logf logger.Logf, ms []*magicStack) (cleanup func()) {
 }
 
 func TestNewConn(t *testing.T) {
+	portmapper.DisableDiscovery()
 	tstest.PanicOnLog()
 	tstest.ResourceCheck(t)
 


### PR DESCRIPTION
Previously, it was just a brittle check for a specific port on my own network.
It seems that routers are free to pick whatever port they'd like, so if we'd really like to
support any router it's necessary to have discovery. This is the smallest possible change
to add it in.

This makes upnp work on Denton's box, so hopefully it should enable more uses.