### PR TITLE
tsweb: add case for f64 in logging

### DIFF
--- a/tsweb/tsweb.go
+++ b/tsweb/tsweb.go
@@ -409,7 +409,7 @@ func VarzHandler(w http.ResponseWriter, r *http.Request) {
 		case expvar.Func:
 			val := v()
 			switch val.(type) {
-			case int64, int:
+			case float64, int64, int:
 				fmt.Fprintf(w, "# TYPE %s %s\n%s %v\n", name, typ, name, val)
 			default:
 				fmt.Fprintf(w, "# skipping expvar func %q returning unknown type %T\n", name, val)


### PR DESCRIPTION
A previously added metric which was float64 was being ignored in tsweb, because it previously
only accepted int64 and ints. It can be handled in the same way as ints.

Fixes: #2506