### PR TITLE
net/portmapper: add pcp portmapping

### DIFF
--- a/net/portmapper/pcp.go
+++ b/net/portmapper/pcp.go
@@ -5,10 +5,14 @@
 package portmapper
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/binary"
+	"fmt"
+	"time"
 
 	"inet.af/netaddr"
+	"tailscale.com/net/netns"
 )
 
 // References:
@@ -34,41 +38,92 @@ const (
 	pcpTCPMapping = 6  // portmap TCP
 )
 
-// pcpMapRequest generates a PCP packet with a MAP opcode.
-func pcpMapRequest(myIP netaddr.IP, mapToLocalPort int, delete bool) []byte {
-	const udpProtoNumber = 17
-	lifetimeSeconds := uint32(1)
-	if delete {
-		lifetimeSeconds = 0
+type pcpMapping struct {
+	gw       netaddr.IP
+	internal netaddr.IPPort
+	external netaddr.IPPort
+
+	renewAfter time.Time
+	goodUntil  time.Time
+}
+
+func (p *pcpMapping) GoodUntil() time.Time     { return p.goodUntil }
+func (p *pcpMapping) RenewAfter() time.Time    { return p.renewAfter }
+func (p *pcpMapping) External() netaddr.IPPort { return p.external }
+func (p *pcpMapping) Release(ctx context.Context) {
+	uc, err := netns.Listener().ListenPacket(ctx, "udp4", ":0")
+	if err != nil {
+		return
 	}
-	const opMap = 1
+	defer uc.Close()
+	pkt := buildPCPRequestMappingPacket(p.internal.IP(), p.internal.Port(), p.external.Port(), 0)
+	uc.WriteTo(pkt, netaddr.IPPortFrom(p.gw, pcpPort).UDPAddr())
+}
 
-	// 24 byte header + 36 byte map opcode
-	pkt := make([]byte, (32+32+128)/8+(96+8+24+16+16+128)/8)
+// buildPCPRequestMappingPacket generates a PCP packet with a MAP opcode.
+// To create a packet which deletes a mapping, lifetimeSec should be set to 0.
+// If prevPort is not known, it should be set to 0.
+func buildPCPRequestMappingPacket(myIP netaddr.IP, localPort, prevPort uint16, lifetimeSec uint32) (pkt []byte) {
+	// note: lifetimeSec = 0 implies delete the mapping, should that be special-cased here?
 
-	// The header (https://tools.ietf.org/html/rfc6887#section-7.1)
-	pkt[0] = 2 // version
-	pkt[1] = opMap
-	binary.BigEndian.PutUint32(pkt[4:8], lifetimeSeconds)
+	// 24 byte common PCP header + 36 bytes of MAP-specific fields
+	pkt = make([]byte, 24+36)
+	pkt[0] = pcpVersion
+	pkt[1] = pcpOpMap
+	binary.BigEndian.PutUint32(pkt[4:8], lifetimeSec)
 	myIP16 := myIP.As16()
-	copy(pkt[8:], myIP16[:])
+	copy(pkt[8:24], myIP16[:])
 
-	// The map opcode body (https://tools.ietf.org/html/rfc6887#section-11.1)
 	mapOp := pkt[24:]
-	rand.Read(mapOp[:12]) // 96 bit mappping nonce
-	mapOp[12] = udpProtoNumber
-	binary.BigEndian.PutUint16(mapOp[16:], uint16(mapToLocalPort))
+	rand.Read(mapOp[:12]) // 96 bit mapping nonce
+
+	// TODO should this be a UDP mapping? It looks like it supports "all protocols" with 0, but
+	// also doesn't support a local port then.
+	mapOp[12] = pcpUDPMapping
+	binary.BigEndian.PutUint16(mapOp[16:18], localPort)
+	binary.BigEndian.PutUint16(mapOp[18:20], prevPort)
+
 	v4unspec := netaddr.MustParseIP("0.0.0.0")
 	v4unspec16 := v4unspec.As16()
 	copy(mapOp[20:], v4unspec16[:])
 	return pkt
 }
 
+func parsePCPMapResponse(resp []byte) (*pcpMapping, error) {
+	if len(resp) < 60 {
+		return nil, fmt.Errorf("Does not appear to be PCP MAP response")
+	}
+	res, ok := parsePCPResponse(resp[:24])
+	if !ok {
+		return nil, fmt.Errorf("Invalid PCP common header")
+	}
+	if res.ResultCode != pcpCodeOK {
+		return nil, fmt.Errorf("PCP response not ok, code %d", res.ResultCode)
+	}
+	// TODO don't ignore the nonce and make sure it's the same?
+	externalPort := binary.BigEndian.Uint16(resp[42:44])
+	externalIPBytes := [16]byte{}
+	copy(externalIPBytes[:], resp[44:])
+	externalIP := netaddr.IPFrom16(externalIPBytes)
+
+	external := netaddr.IPPortFrom(externalIP, externalPort)
+
+	lifetime := time.Second * time.Duration(res.Lifetime)
+	now := time.Now()
+	mapping := &pcpMapping{
+		external:   external,
+		renewAfter: now.Add(lifetime / 2),
+		goodUntil:  now.Add(lifetime),
+	}
+
+	return mapping, nil
+}
+
 // pcpAnnounceRequest generates a PCP packet with an ANNOUNCE opcode.
 func pcpAnnounceRequest(myIP netaddr.IP) []byte {
 	// See https://tools.ietf.org/html/rfc6887#section-7.1
 	pkt := make([]byte, 24)
-	pkt[0] = pcpVersion // version
+	pkt[0] = pcpVersion
 	pkt[1] = pcpOpAnnounce
 	myIP16 := myIP.As16()
 	copy(pkt[8:], myIP16[:])

--- a/net/portmapper/pcp.go
+++ b/net/portmapper/pcp.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package portmapper
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+
+	"inet.af/netaddr"
+)
+
+// References:
+//
+// https://www.rfc-editor.org/rfc/pdfrfc/rfc6887.txt.pdf
+// https://tools.ietf.org/html/rfc6887
+
+// PCP constants
+const (
+	pcpVersion = 2
+	pcpPort    = 5351
+
+	pcpMapLifetimeSec = 7200 // TODO does the RFC recommend anything? This is taken from PMP.
+
+	pcpCodeOK            = 0
+	pcpCodeNotAuthorized = 2
+
+	pcpOpReply    = 0x80 // OR'd into request's op code on response
+	pcpOpAnnounce = 0
+	pcpOpMap      = 1
+
+	pcpUDPMapping = 17 // portmap UDP
+	pcpTCPMapping = 6  // portmap TCP
+)
+
+// pcpMapRequest generates a PCP packet with a MAP opcode.
+func pcpMapRequest(myIP netaddr.IP, mapToLocalPort int, delete bool) []byte {
+	const udpProtoNumber = 17
+	lifetimeSeconds := uint32(1)
+	if delete {
+		lifetimeSeconds = 0
+	}
+	const opMap = 1
+
+	// 24 byte header + 36 byte map opcode
+	pkt := make([]byte, (32+32+128)/8+(96+8+24+16+16+128)/8)
+
+	// The header (https://tools.ietf.org/html/rfc6887#section-7.1)
+	pkt[0] = 2 // version
+	pkt[1] = opMap
+	binary.BigEndian.PutUint32(pkt[4:8], lifetimeSeconds)
+	myIP16 := myIP.As16()
+	copy(pkt[8:], myIP16[:])
+
+	// The map opcode body (https://tools.ietf.org/html/rfc6887#section-11.1)
+	mapOp := pkt[24:]
+	rand.Read(mapOp[:12]) // 96 bit mappping nonce
+	mapOp[12] = udpProtoNumber
+	binary.BigEndian.PutUint16(mapOp[16:], uint16(mapToLocalPort))
+	v4unspec := netaddr.MustParseIP("0.0.0.0")
+	v4unspec16 := v4unspec.As16()
+	copy(mapOp[20:], v4unspec16[:])
+	return pkt
+}
+
+// pcpAnnounceRequest generates a PCP packet with an ANNOUNCE opcode.
+func pcpAnnounceRequest(myIP netaddr.IP) []byte {
+	// See https://tools.ietf.org/html/rfc6887#section-7.1
+	pkt := make([]byte, 24)
+	pkt[0] = pcpVersion // version
+	pkt[1] = pcpOpAnnounce
+	myIP16 := myIP.As16()
+	copy(pkt[8:], myIP16[:])
+	return pkt
+}
+
+type pcpResponse struct {
+	OpCode     uint8
+	ResultCode uint8
+	Lifetime   uint32
+	Epoch      uint32
+}
+
+func parsePCPResponse(b []byte) (res pcpResponse, ok bool) {
+	if len(b) < 24 || b[0] != pcpVersion {
+		return
+	}
+	res.OpCode = b[1]
+	res.ResultCode = b[3]
+	res.Lifetime = binary.BigEndian.Uint32(b[4:])
+	res.Epoch = binary.BigEndian.Uint32(b[8:])
+	return res, true
+}

--- a/net/portmapper/pcp_test.go
+++ b/net/portmapper/pcp_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package portmapper
+
+import (
+	"testing"
+
+	"inet.af/netaddr"
+)
+
+var examplePCPMapResponse = []byte{2, 129, 0, 0, 0, 0, 28, 32, 0, 2, 155, 237, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 129, 112, 9, 24, 241, 208, 251, 45, 157, 76, 10, 188, 17, 0, 0, 0, 4, 210, 4, 210, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 135, 180, 175, 246}
+
+func TestParsePCPMapResponse(t *testing.T) {
+	mapping, err := parsePCPMapResponse(examplePCPMapResponse)
+	if err != nil {
+		t.Fatalf("failed to parse PCP Map Response: %v", err)
+	}
+	if mapping == nil {
+		t.Fatalf("got nil mapping when expected non-nil")
+	}
+	expectedAddr := netaddr.MustParseIPPort("135.180.175.246:1234")
+	if mapping.external != expectedAddr {
+		t.Errorf("mismatched external address, got: %v, want: %v", mapping.external, expectedAddr)
+	}
+}

--- a/net/portmapper/upnp.go
+++ b/net/portmapper/upnp.go
@@ -152,7 +152,7 @@ func addAnyPortMapping(
 // The provided ctx is not retained in the returned upnpClient, but
 // its associated HTTP client is (if set via goupnp.WithHTTPClient).
 func getUPnPClient(ctx context.Context, logf logger.Logf, gw netaddr.IP, meta uPnPDiscoResponse) (client upnpClient, err error) {
-	if controlknobs.DisableUPnP() {
+	if controlknobs.DisableUPnP() || DisableUPnP {
 		return nil, nil
 	}
 
@@ -234,7 +234,7 @@ func (c *Client) getUPnPPortMapping(
 	internal netaddr.IPPort,
 	prevPort uint16,
 ) (external netaddr.IPPort, ok bool) {
-	if controlknobs.DisableUPnP() {
+	if controlknobs.DisableUPnP() || DisableUPnP {
 		return netaddr.IPPort{}, false
 	}
 	now := time.Now()


### PR DESCRIPTION
This adds PCP portmapping, moving all existing PCP content into a separate file, and parsing the
response from PCP portmapping requests. It hooks into the existing way we handle PMP mapping.

Tested this out on Denton's router, and seems to work fine, but would appreciate others also checking it out.
Also seems to work on pfSense on Brad's DO instance.

Updates #2563