### PR TITLE
tstime/mono: make json.Unmarshal of a zero time.Time yield a zero Time

### DIFF
--- a/tstime/mono/mono.go
+++ b/tstime/mono/mono.go
@@ -121,6 +121,10 @@ func (t *Time) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
+	if tt.IsZero() {
+		*t = 0
+		return nil
+	}
 	*t = Now().Add(-time.Since(tt))
 	return nil
 }

--- a/tstime/mono/mono_test.go
+++ b/tstime/mono/mono_test.go
@@ -5,6 +5,7 @@
 package mono
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -14,6 +15,22 @@ func TestNow(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	if elapsed := Since(start); elapsed < 100*time.Millisecond {
 		t.Errorf("short sleep: %v elapsed, want min %v", elapsed, 100*time.Millisecond)
+	}
+}
+
+func TestUnmarshalZero(t *testing.T) {
+	var tt time.Time
+	buf, err := json.Marshal(tt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m Time
+	err = json.Unmarshal(buf, &m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !m.IsZero() {
+		t.Errorf("expected unmarshal of zero time to be 0, got %d (~=%v)", m, m)
 	}
 }
 


### PR DESCRIPTION
This was the proximate cause of #2579.
#2582 is a deeper fix, but this will remain
as a footgun, so may as well fix it too.

Signed-off-by: Josh Bleecher Snyder <josh@tailscale.com>
