### PR TITLE
cmd/tailscaled: don't require root for --cleanup

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -142,7 +142,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	if runtime.GOOS == "darwin" && os.Getuid() != 0 && !strings.Contains(args.tunname, "userspace-networking") {
+	if runtime.GOOS == "darwin" && os.Getuid() != 0 && !strings.Contains(args.tunname, "userspace-networking") && !args.cleanup {
 		log.SetFlags(0)
 		log.Fatalf("tailscaled requires root; use sudo tailscaled (or use --tun=userspace-networking)")
 	}


### PR DESCRIPTION
Without this, the integration tests fail locally for me:

```
--- FAIL: TestCollectPanic (7.61s)
    integration.go:74: built [tailscale.com/cmd/tailscaled tailscale.com/cmd/tailscale] in 1.59s
    integration_test.go:102: initial run: tailscaled requires root; use sudo tailscaled (or use --tun=userspace-networking)
    integration_test.go:108: cleanup failed: exit status 1: "tailscaled requires root; use sudo tailscaled (or use --tun=userspace-networking)\n"
    stuntest.go:64: STUN server shutdown
FAIL
FAIL	tailscale.com/tstest/integration	9.678s
FAIL
```