### PR TITLE
all: gofmt with Go 1.17

### DIFF
--- a/cmd/tailscale/cli/diag.go
+++ b/cmd/tailscale/cli/diag.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux || windows || darwin
 // +build linux windows darwin
 
 package cli

--- a/cmd/tailscale/cli/diag_other.go
+++ b/cmd/tailscale/cli/diag_other.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !linux && !windows && !darwin
 // +build !linux,!windows,!darwin
 
 package cli

--- a/cmd/tailscaled/tailscaled_notwindows.go
+++ b/cmd/tailscaled/tailscaled_notwindows.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !windows
 // +build !windows
 
 package main // import "tailscale.com/cmd/tailscaled"

--- a/cmd/tsshd/tsshd.go
+++ b/cmd/tsshd/tsshd.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !windows
 // +build !windows
 
 // The tsshd binary is an SSH server that accepts connections

--- a/cmd/tsshd/tsshd_windows.go
+++ b/cmd/tsshd/tsshd_windows.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package main

--- a/control/controlclient/hostinfo_linux.go
+++ b/control/controlclient/hostinfo_linux.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux && !android
 // +build linux,!android
 
 package controlclient

--- a/control/controlclient/sign_supported.go
+++ b/control/controlclient/sign_supported.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows && cgo
 // +build windows,cgo
 
 // darwin,cgo is also supported by certstore but machineCertificateSubject will

--- a/control/controlclient/sign_unsupported.go
+++ b/control/controlclient/sign_unsupported.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !windows || !cgo
 // +build !windows !cgo
 
 package controlclient

--- a/disco/disco_fuzzer.go
+++ b/disco/disco_fuzzer.go
@@ -1,6 +1,7 @@
 // Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+//go:build gofuzz
 // +build gofuzz
 
 package disco

--- a/ipn/ipnlocal/peerapi_macios_ext.go
+++ b/ipn/ipnlocal/peerapi_macios_ext.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build (darwin && ts_macext) || (ios && ts_macext)
 // +build darwin,ts_macext ios,ts_macext
 
 package ipnlocal

--- a/logtail/filch/filch_unix.go
+++ b/logtail/filch/filch_unix.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !windows
+//go:build !windows
+// +build !windows
 
 package filch
 

--- a/net/dns/debian_resolvconf.go
+++ b/net/dns/debian_resolvconf.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux || freebsd || openbsd
 // +build linux freebsd openbsd
 
 package dns

--- a/net/dns/ini.go
+++ b/net/dns/ini.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package dns

--- a/net/dns/ini_test.go
+++ b/net/dns/ini_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package dns

--- a/net/dns/manager_default.go
+++ b/net/dns/manager_default.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !linux && !freebsd && !openbsd && !windows
 // +build !linux,!freebsd,!openbsd,!windows
 
 package dns

--- a/net/dns/nm.go
+++ b/net/dns/nm.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux
 // +build linux
 
 package dns

--- a/net/dns/openresolv.go
+++ b/net/dns/openresolv.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux || freebsd || openbsd
 // +build linux freebsd openbsd
 
 package dns

--- a/net/dns/resolvconf.go
+++ b/net/dns/resolvconf.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux || freebsd || openbsd
 // +build linux freebsd openbsd
 
 package dns

--- a/net/dns/resolved.go
+++ b/net/dns/resolved.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux
 // +build linux
 
 package dns

--- a/net/dns/resolver/macios_ext.go
+++ b/net/dns/resolver/macios_ext.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build (darwin && ts_macext) || (ios && ts_macext)
 // +build darwin,ts_macext ios,ts_macext
 
 package resolver

--- a/net/dns/resolver/neterr_other.go
+++ b/net/dns/resolver/neterr_other.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !darwin && !windows
 // +build !darwin,!windows
 
 package resolver

--- a/net/dnsfallback/update-dns-fallbacks.go
+++ b/net/dnsfallback/update-dns-fallbacks.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build ignore
 // +build ignore
 
 package main

--- a/net/interfaces/interfaces_default_route_test.go
+++ b/net/interfaces/interfaces_default_route_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux || (darwin && !ts_macext)
 // +build linux darwin,!ts_macext
 
 package interfaces

--- a/net/interfaces/interfaces_defaultrouteif_todo.go
+++ b/net/interfaces/interfaces_defaultrouteif_todo.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !linux && !windows && !darwin
 // +build !linux,!windows,!darwin
 
 package interfaces

--- a/net/netns/netns_android.go
+++ b/net/netns/netns_android.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build android
 // +build android
 
 package netns

--- a/net/netns/netns_darwin_tailscaled.go
+++ b/net/netns/netns_darwin_tailscaled.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build darwin && !ts_macext
 // +build darwin,!ts_macext
 
 package netns

--- a/net/netns/netns_default.go
+++ b/net/netns/netns_default.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build (!linux && !windows && !darwin) || (darwin && ts_macext)
 // +build !linux,!windows,!darwin darwin,ts_macext
 
 package netns

--- a/net/netns/netns_linux.go
+++ b/net/netns/netns_linux.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux && !android
 // +build linux,!android
 
 package netns

--- a/net/netns/netns_macios.go
+++ b/net/netns/netns_macios.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build darwin || ios
 // +build darwin ios
 
 package netns

--- a/net/netns/socks.go
+++ b/net/netns/socks.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !ios
 // +build !ios
 
 package netns

--- a/net/netstat/netstat_noimpl.go
+++ b/net/netstat/netstat_noimpl.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !windows
 // +build !windows
 
 package netstat

--- a/net/portmapper/disabled_stubs.go
+++ b/net/portmapper/disabled_stubs.go
@@ -2,7 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build ios
 // +build ios
+
 // (https://github.com/tailscale/tailscale/issues/2495)
 
 package portmapper

--- a/net/portmapper/upnp.go
+++ b/net/portmapper/upnp.go
@@ -2,7 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !ios
 // +build !ios
+
 // (https://github.com/tailscale/tailscale/issues/2495)
 
 package portmapper

--- a/net/stun/stun_fuzzer.go
+++ b/net/stun/stun_fuzzer.go
@@ -1,6 +1,7 @@
 // Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+//go:build gofuzz
 // +build gofuzz
 
 package stun

--- a/net/tshttpproxy/tshttpproxy_future.go
+++ b/net/tshttpproxy/tshttpproxy_future.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build tailscale_go
 // +build tailscale_go
 
 // We want to use https://github.com/golang/go/issues/41048 but it's only in the

--- a/net/tstun/ifstatus_noop.go
+++ b/net/tstun/ifstatus_noop.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !windows
 // +build !windows
 
 package tstun

--- a/net/tstun/tap_unsupported.go
+++ b/net/tstun/tap_unsupported.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !linux
 // +build !linux
 
 package tstun

--- a/net/tstun/tun_notwindows.go
+++ b/net/tstun/tun_notwindows.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !windows
 // +build !windows
 
 package tstun

--- a/paths/paths_unix.go
+++ b/paths/paths_unix.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !windows
 // +build !windows
 
 package paths

--- a/portlist/netstat.go
+++ b/portlist/netstat.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build (go1.16 && !ios) || (!go1.16 && !darwin) || (!go1.16 && !arm64)
 // +build go1.16,!ios !go1.16,!darwin !go1.16,!arm64
 
 package portlist

--- a/portlist/netstat_exec.go
+++ b/portlist/netstat_exec.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build (windows || freebsd || openbsd || (darwin && go1.16) || (darwin && !go1.16 && !arm64)) && !ios
 // +build windows freebsd openbsd darwin,go1.16 darwin,!go1.16,!arm64
 // +build !ios
 

--- a/portlist/portlist_ios.go
+++ b/portlist/portlist_ios.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build (go1.16 && ios) || (!go1.16 && darwin && !amd64)
 // +build go1.16,ios !go1.16,darwin,!amd64
 
 package portlist

--- a/portlist/portlist_macos.go
+++ b/portlist/portlist_macos.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build ((darwin && amd64 && !go1.16) || (darwin && go1.16)) && !ios
 // +build darwin,amd64,!go1.16 darwin,go1.16
 // +build !ios
 

--- a/portlist/portlist_other.go
+++ b/portlist/portlist_other.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !linux && !windows && !darwin
 // +build !linux,!windows,!darwin
 
 package portlist

--- a/safesocket/unixsocket.go
+++ b/safesocket/unixsocket.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !windows
 // +build !windows
 
 package safesocket

--- a/syncs/locked.go
+++ b/syncs/locked.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build go1.13 && !go1.16
 // +build go1.13,!go1.16
 
 // This file makes assumptions about the inner workings of sync.Mutex and sync.RWMutex.

--- a/syncs/locked_test.go
+++ b/syncs/locked_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build go1.13 && !go1.16
 // +build go1.13,!go1.16
 
 package syncs

--- a/tempfork/wireguard-windows/firewall/blocker.go
+++ b/tempfork/wireguard-windows/firewall/blocker.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /* SPDX-License-Identifier: MIT

--- a/tempfork/wireguard-windows/firewall/helpers.go
+++ b/tempfork/wireguard-windows/firewall/helpers.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /* SPDX-License-Identifier: MIT

--- a/tempfork/wireguard-windows/firewall/rules.go
+++ b/tempfork/wireguard-windows/firewall/rules.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /* SPDX-License-Identifier: MIT

--- a/tempfork/wireguard-windows/firewall/types_windows.go
+++ b/tempfork/wireguard-windows/firewall/types_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /* SPDX-License-Identifier: MIT

--- a/tempfork/wireguard-windows/firewall/types_windows_32.go
+++ b/tempfork/wireguard-windows/firewall/types_windows_32.go
@@ -1,3 +1,4 @@
+//go:build (windows && 386) || (windows && arm)
 // +build windows,386 windows,arm
 
 /* SPDX-License-Identifier: MIT

--- a/tempfork/wireguard-windows/firewall/types_windows_64.go
+++ b/tempfork/wireguard-windows/firewall/types_windows_64.go
@@ -1,3 +1,4 @@
+//go:build (windows && amd64) || (windows && arm64)
 // +build windows,amd64 windows,arm64
 
 /* SPDX-License-Identifier: MIT

--- a/tempfork/wireguard-windows/firewall/types_windows_test.go
+++ b/tempfork/wireguard-windows/firewall/types_windows_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /* SPDX-License-Identifier: MIT

--- a/tstest/integration/gen_deps.go
+++ b/tstest/integration/gen_deps.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build ignore
 // +build ignore
 
 package main

--- a/tstest/integration/vms/derive_bindhost_test.go
+++ b/tstest/integration/vms/derive_bindhost_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux
 // +build linux
 
 package vms

--- a/tstest/integration/vms/distros_test.go
+++ b/tstest/integration/vms/distros_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux
 // +build linux
 
 package vms

--- a/tstest/integration/vms/harness_test.go
+++ b/tstest/integration/vms/harness_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux
 // +build linux
 
 package vms

--- a/tstest/integration/vms/nixos_test.go
+++ b/tstest/integration/vms/nixos_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux
 // +build linux
 
 package vms

--- a/tstest/integration/vms/opensuse_leap_15_1_test.go
+++ b/tstest/integration/vms/opensuse_leap_15_1_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux
 // +build linux
 
 package vms

--- a/tstest/integration/vms/top_level_test.go
+++ b/tstest/integration/vms/top_level_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux
 // +build linux
 
 package vms

--- a/tstest/integration/vms/udp_tester.go
+++ b/tstest/integration/vms/udp_tester.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build ignore
 // +build ignore
 
 // Command udp_tester exists because all of these distros being tested don't

--- a/tstest/integration/vms/vm_setup_test.go
+++ b/tstest/integration/vms/vm_setup_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux
 // +build linux
 
 package vms

--- a/tstest/integration/vms/vms_steps_test.go
+++ b/tstest/integration/vms/vms_steps_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux
 // +build linux
 
 package vms

--- a/tstest/integration/vms/vms_test.go
+++ b/tstest/integration/vms/vms_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux
 // +build linux
 
 package vms

--- a/types/logger/rusage_nowindows.go
+++ b/types/logger/rusage_nowindows.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !windows
 // +build !windows
 
 package logger

--- a/util/deephash/mapiter.go
+++ b/util/deephash/mapiter.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !tailscale_go
 // +build !tailscale_go
 
 package deephash

--- a/util/deephash/mapiter_future.go
+++ b/util/deephash/mapiter_future.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build tailscale_go
 // +build tailscale_go
 
 package deephash

--- a/util/endian/big.go
+++ b/util/endian/big.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build mips || mips64 || ppc64 || s390x
 // +build mips mips64 ppc64 s390x
 
 package endian

--- a/util/endian/little.go
+++ b/util/endian/little.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build 386 || amd64 || arm || arm64 || mips64le || mipsle || ppc64le || riscv64 || wasm
 // +build 386 amd64 arm arm64 mips64le mipsle ppc64le riscv64 wasm
 
 package endian

--- a/util/groupmember/groupmember_cgo.go
+++ b/util/groupmember/groupmember_cgo.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build cgo
 // +build cgo
 
 package groupmember

--- a/util/groupmember/groupmember_noimpl.go
+++ b/util/groupmember/groupmember_noimpl.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !cgo && !linux && !darwin
 // +build !cgo,!linux,!darwin
 
 package groupmember

--- a/util/groupmember/groupmember_notcgo.go
+++ b/util/groupmember/groupmember_notcgo.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !cgo && (linux || darwin)
 // +build !cgo
 // +build linux darwin
 

--- a/util/osshare/filesharingstatus_noop.go
+++ b/util/osshare/filesharingstatus_noop.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !windows
 // +build !windows
 
 package osshare

--- a/util/osshare/filesharingstatus_windows.go
+++ b/util/osshare/filesharingstatus_windows.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package osshare

--- a/util/pidowner/pidowner_noimpl.go
+++ b/util/pidowner/pidowner_noimpl.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !windows && !linux
 // +build !windows,!linux
 
 package pidowner

--- a/util/racebuild/off.go
+++ b/util/racebuild/off.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !race
 // +build !race
 
 package racebuild

--- a/util/racebuild/on.go
+++ b/util/racebuild/on.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build race
 // +build race
 
 package racebuild

--- a/util/systemd/systemd_linux.go
+++ b/util/systemd/systemd_linux.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux
 // +build linux
 
 package systemd

--- a/util/systemd/systemd_nonlinux.go
+++ b/util/systemd/systemd_nonlinux.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !linux
 // +build !linux
 
 package systemd

--- a/util/winutil/winutil.go
+++ b/util/winutil/winutil.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 // Package winuntil contains misc Windows/win32 helper functions.

--- a/util/winutil/winutil_notwindows.go
+++ b/util/winutil/winutil_notwindows.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !windows
 // +build !windows
 
 package winutil

--- a/version/cmdname.go
+++ b/version/cmdname.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build (go1.16 && !ios) || (!go1.16 && !darwin) || (!go1.16 && !arm64)
 // +build go1.16,!ios !go1.16,!darwin !go1.16,!arm64
 
 package version

--- a/version/cmdname_ios.go
+++ b/version/cmdname_ios.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build (go1.16 && ios) || (!go1.16 && darwin && arm64)
 // +build go1.16,ios !go1.16,darwin,arm64
 
 package version

--- a/version/race.go
+++ b/version/race.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build race
 // +build race
 
 package version

--- a/version/race_off.go
+++ b/version/race_off.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !race
 // +build !race
 
 package version

--- a/wgengine/monitor/monitor_linux.go
+++ b/wgengine/monitor/monitor_linux.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !android
 // +build !android
 
 package monitor

--- a/wgengine/monitor/monitor_polling.go
+++ b/wgengine/monitor/monitor_polling.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build (!linux && !freebsd && !windows && !darwin) || android
 // +build !linux,!freebsd,!windows,!darwin android
 
 package monitor

--- a/wgengine/monitor/polling.go
+++ b/wgengine/monitor/polling.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//  +build !freebsd,!windows,!darwin
+//go:build !freebsd && !windows && !darwin
+// +build !freebsd,!windows,!darwin
 
 package monitor
 

--- a/wgengine/router/router_default.go
+++ b/wgengine/router/router_default.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !windows && !linux && !darwin && !openbsd && !freebsd
 // +build !windows,!linux,!darwin,!openbsd,!freebsd
 
 package router

--- a/wgengine/router/router_test.go
+++ b/wgengine/router/router_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux || windows
 // +build linux windows
 
 package router

--- a/wgengine/router/router_userspace_bsd.go
+++ b/wgengine/router/router_userspace_bsd.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build darwin || freebsd
 // +build darwin freebsd
 
 package router

--- a/wgengine/router/runner.go
+++ b/wgengine/router/runner.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux
 // +build linux
 
 package router


### PR DESCRIPTION
This adds `//go:build` lines and tidies up existing `// +build` lines.
