### PR TITLE
scripts/installer: work on Oracle Linux

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -46,11 +46,11 @@ main() {
 				VERSION="$VERSION_CODENAME"
 				PACKAGETYPE="apt"
 				;;
-			centos)
+			centos|ol)
 				OS="$ID"
 				VERSION="$VERSION_ID"
 				PACKAGETYPE="dnf"
-				if [ "$VERSION" = "7" ]; then
+				if [ "$VERSION" =~ ^7 ]; then
 					PACKAGETYPE="yum"
 				fi
 				;;


### PR DESCRIPTION
Before we didn't detect it properly. Since Oracle Linux is diet centos,
we can just make the centos logic detect Oracle linux and everything
should be fine.

Signed-off-by: Christine Dodrill <xe@tailscale.com>