### PR TITLE
tsnet: add AuthKey support.

### DIFF
--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -177,11 +177,12 @@ func (s *Server) start() error {
 	err = lb.Start(ipn.Options{
 		StateKey:    ipn.GlobalDaemonStateKey,
 		UpdatePrefs: prefs,
+		AuthKey:     os.Getenv("TS_AUTHKEY"),
 	})
 	if err != nil {
 		return fmt.Errorf("starting backend: %w", err)
 	}
-	if os.Getenv("TS_LOGIN") == "1" {
+	if os.Getenv("TS_LOGIN") == "1" || os.Getenv("TS_AUTHKEY") != "" {
 		s.lb.StartLoginInteractive()
 	}
 	return nil


### PR DESCRIPTION
Set a TS_AUTHKEY environment variable to "tskey-01234..."

Signed-off-by: Denton Gentry <dgentry@tailscale.com>