### PR TITLE
wgengine: allow both fixed and random port

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -1051,6 +1051,10 @@ type Debug struct {
 	// fixed port.
 	RandomizeClientPort bool `json:",omitempty"`
 
+	// RandomAndFixedPort is whether magicsock should UDP bind to
+	// :0 to get a random local port AND use the fixed configured provided port.
+	RandomAndFixedPort bool `json:",omitempty"`
+
 	/// DisableUPnP is whether the client will attempt to perform a UPnP portmapping.
 	// By default, we want to enable it to see if it works on more clients.
 	//

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -2111,17 +2111,18 @@ func (c *Conn) SetNetworkUp(up bool) {
 }
 
 // SetPreferredPort sets the connection's preferred local port.
-func (c *Conn) SetPreferredPort(port uint16) {
+func (c *Conn) SetPreferredPort(port uint16) (ok bool) {
 	if uint16(c.port.Get()) == port {
-		return
+		return true
 	}
 	c.port.Set(uint32(port))
 
 	if err := c.rebind(dropCurrentPort); err != nil {
 		c.logf("%w", err)
-		return
+		return false
 	}
 	c.resetEndpointStates()
+	return true
 }
 
 // SetPrivateKey sets the connection's private key.

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -830,7 +830,14 @@ func (e *userspaceEngine) Reconfig(cfg *wgcfg.Config, routerCfg *router.Config, 
 		e.logf("wgengine: Reconfig: SetPrivateKey: %v", err)
 	}
 	e.magicConn.UpdatePeers(peerSet)
-	e.magicConn.SetPreferredPort(listenPort)
+	ok := e.magicConn.SetPreferredPort(listenPort)
+	if !ok /*&& debug != nil && debug.RandomAndFixedPort */ {
+		if listenPort == 0 {
+			e.magicConn.SetPreferredPort(e.confListenPort)
+		} else {
+			e.magicConn.SetPreferredPort(0)
+		}
+	}
 
 	if err := e.maybeReconfigWireguardLocked(discoChanged); err != nil {
 		return err

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -784,7 +784,8 @@ func (e *userspaceEngine) Reconfig(cfg *wgcfg.Config, routerCfg *router.Config, 
 
 	engineChanged := deephash.Update(&e.lastEngineSigFull, cfg)
 	routerChanged := deephash.Update(&e.lastRouterSig, routerCfg, dnsCfg)
-	if !engineChanged && !routerChanged && listenPort == e.magicConn.LocalPort() {
+	attemptRand := debug != nil && debug.RandomAndFixedPort
+	if !engineChanged && !routerChanged && listenPort == e.magicConn.LocalPort() && !attemptRand {
 		return ErrNoChanges
 	}
 
@@ -831,7 +832,7 @@ func (e *userspaceEngine) Reconfig(cfg *wgcfg.Config, routerCfg *router.Config, 
 	}
 	e.magicConn.UpdatePeers(peerSet)
 	ok := e.magicConn.SetPreferredPort(listenPort)
-	if !ok /*&& debug != nil && debug.RandomAndFixedPort */ {
+	if !ok && debug != nil && debug.RandomAndFixedPort {
 		if listenPort == 0 {
 			e.magicConn.SetPreferredPort(e.confListenPort)
 		} else {


### PR DESCRIPTION
Previously, we only attempted either a fixed port xor a random port. Instead, we would like to
try both (sequentially), which should provide a higher rate of success.

Context:
@DentonGentry suggested that currently we only do one of either random ports or fixed ports  Ideally, we would like to try both out, instead of having the user manually select one or the other, and then picking the best of both.

Testing this out on CI to get the integration tests.

Signed-off-by: julianknodt <julianknodt@gmail.com>