### PR TITLE
tailcfg & controlclient: add caching for Node

### DIFF
--- a/control/controlclient/map.go
+++ b/control/controlclient/map.go
@@ -123,7 +123,12 @@ func (ms *mapSession) netmapForResponse(resp *tailcfg.MapResponse) *netmap.Netwo
 	if resp.Node != nil {
 		ms.lastNode = resp.Node
 	}
-	if node := ms.lastNode.Clone(); node != nil {
+	if ms.lastNode != nil {
+		node := nm.SelfNode
+		if node == nil {
+			node = &tailcfg.Node{}
+		}
+		node = node.CloneFrom(ms.lastNode)
 		nm.SelfNode = node
 		nm.Expiry = node.KeyExpiry
 		nm.Name = node.Name
@@ -279,7 +284,7 @@ func cloneNodes(v1 []*tailcfg.Node) []*tailcfg.Node {
 	}
 	v2 := make([]*tailcfg.Node, len(v1))
 	for i, n := range v1 {
-		v2[i] = n.Clone()
+		v2[i] = v2[i].CloneFrom(n)
 	}
 	return v2
 }

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -224,6 +224,60 @@ func (n *Node) DisplayName(forOwner bool) string {
 	return n.ComputedName
 }
 
+// CloneFrom
+func (dst *Node) CloneFrom(src *Node) *Node {
+	if src == nil {
+		*dst = Node{}
+		return dst
+	}
+	if dst == nil {
+		dst = &Node{}
+	}
+	dst.ID = src.ID
+	dst.StableID = src.StableID
+	dst.Name = src.Name
+	dst.User = src.User
+	dst.Sharer = src.Sharer
+	dst.Key = src.Key
+	dst.KeyExpiry = src.KeyExpiry
+	dst.Machine = src.Machine
+	dst.DiscoKey = src.DiscoKey
+	dst.Hostinfo = *src.Hostinfo.Clone()
+	dst.DERP = src.DERP
+	dst.Created = src.Created
+
+	dst.Addresses = append(dst.Addresses[:0], src.Addresses...)
+	dst.Endpoints = append(dst.Endpoints[:0], src.Endpoints...)
+	dst.AllowedIPs = append(dst.AllowedIPs[:0], src.AllowedIPs...)
+	dst.PrimaryRoutes = append(dst.PrimaryRoutes[:0], src.PrimaryRoutes...)
+
+	if src.LastSeen == nil {
+		dst.LastSeen = nil
+	} else {
+		if dst.LastSeen == nil {
+			dst.LastSeen = new(time.Time)
+		}
+		*dst.LastSeen = *src.LastSeen
+	}
+
+	if src.Online == nil {
+		dst.Online = nil
+	} else {
+		if dst.Online == nil {
+			dst.Online = new(bool)
+		}
+		*dst.Online = *src.Online
+	}
+
+	dst.KeepAlive = src.KeepAlive
+
+	dst.MachineAuthorized = src.MachineAuthorized
+	dst.ComputedName = src.ComputedName
+	dst.computedHostIfDifferent = src.computedHostIfDifferent
+	dst.ComputedNameWithHost = src.ComputedNameWithHost
+	return dst
+}
+
 // DisplayName returns the decomposed user-facing name for a node.
 //
 // Parameter forOwner specifies whether the name is requested by


### PR DESCRIPTION
This adds a sync.Pool for tailcfg.Node so that they are not allocated on every iteration. It
seems this is the only place that Nodes are being cloned, so we can hopefully save most of the
cost of cloning them all the time.

Updates tailscale/corp#2405

Signed-off-by: julianknodt <julianknodt@gmail.com>