### PR TITLE
Use hybrid netstack mode for FreeBSD

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -335,9 +335,9 @@ func shouldWrapNetstack() bool {
 		return true
 	}
 	switch runtime.GOOS {
-	case "windows", "darwin":
+	case "windows", "darwin", "freebsd":
 		// Enable on Windows and tailscaled-on-macOS (this doesn't
-		// affect the GUI clients).
+		// affect the GUI clients), and on FreeBSD.
 		return true
 	}
 	return false


### PR DESCRIPTION
Allows FreeBSD to function as an exit node in the same way
that Windows and Tailscaled-on-MacOS do.

Updates https://github.com/tailscale/tailscale/issues/2498

Signed-off-by: Denton Gentry <dgentry@tailscale.com>