### PR TITLE
Dockerfile: use alpine:latest.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,6 @@ RUN go install -tags=xversion -ldflags="\
       -X tailscale.com/version.GitCommit=$VERSION_GIT_HASH" \
       -v ./cmd/...
 
-FROM alpine:3.11
+FROM alpine:3.14
 RUN apk add --no-cache ca-certificates iptables iproute2
 COPY --from=build-env /go/bin/* /usr/local/bin/


### PR DESCRIPTION
golang:1.16-alpine is kept updates as Alpine versions
advance, we can't specify an older release without having
it break at some point due to incompatibility.

Reported by @kubeworm
https://twitter.com/kubeworm/status/1426751941519020033

Signed-off-by: Denton Gentry <dgentry@tailscale.com>