### PR TITLE
all: prevent common large log lines

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -872,15 +872,14 @@ func (c *Direct) sendMapRequest(ctx context.Context, maxPolls int, cb func(*netm
 		nm.LocalPort = c.localPort
 		c.mu.Unlock()
 
-		// Printing the netmap can be extremely verbose, but is very
-		// handy for debugging. Let's limit how often we do it.
-		// Code elsewhere prints netmap diffs every time, so this
-		// occasional full dump, plus incremental diffs, should do
-		// the job.
+		// Occasionally print the netmap header.
+		// This is handy for debugging, and our logs processing
+		// pipeline depends on it. (TODO: Remove this dependency.)
+		// Code elsewhere prints netmap diffs every time they are received.
 		now := c.timeNow()
 		if now.Sub(c.lastPrintMap) >= 5*time.Minute {
 			c.lastPrintMap = now
-			c.logf("[v1] new network map[%d]:\n%s", i, nm.Concise())
+			c.logf("[v1] new network map[%d]:\n%s", i, nm.VeryConcise())
 		}
 
 		c.mu.Lock()

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -961,7 +961,7 @@ func (b *LocalBackend) updateFilter(netMap *netmap.NetworkMap, prefs *ipn.Prefs)
 		b.logf("netmap packet filter: (shields up)")
 		b.e.SetFilter(filter.NewShieldsUpFilter(localNets, logNets, oldFilter, b.logf))
 	} else {
-		b.logf("netmap packet filter: %v", packetFilter)
+		b.logf("netmap packet filter: %v filters", len(packetFilter))
 		b.e.SetFilter(filter.New(packetFilter, localNets, logNets, oldFilter, b.logf))
 	}
 }

--- a/types/netmap/netmap.go
+++ b/types/netmap/netmap.go
@@ -87,6 +87,12 @@ func (nm *NetworkMap) Concise() string {
 	return buf.String()
 }
 
+func (nm *NetworkMap) VeryConcise() string {
+	buf := new(strings.Builder)
+	nm.printConciseHeader(buf)
+	return buf.String()
+}
+
 // printConciseHeader prints a concise header line representing nm to buf.
 //
 // If this function is changed to access different fields of nm, keep
@@ -132,7 +138,7 @@ func (a *NetworkMap) equalConciseHeader(b *NetworkMap) bool {
 	return (a.Debug == nil && b.Debug == nil) || reflect.DeepEqual(a.Debug, b.Debug)
 }
 
-// printPeerConcise appends to buf a line repsenting the peer p.
+// printPeerConcise appends to buf a line representing the peer p.
 //
 // If this function is changed to access different fields of p, keep
 // in nodeConciseEqual in sync.


### PR DESCRIPTION
- control/controlclient: do not periodically print full netmap
- ipn/ipnlocal: log number of packet filters rather than entire filter
