### PR TITLE
tstest/integration/testcontrol: sort peers in map response

### DIFF
--- a/tstest/integration/testcontrol/testcontrol.go
+++ b/tstest/integration/testcontrol/testcontrol.go
@@ -661,6 +661,9 @@ func (s *Server) MapResponse(req *tailcfg.MapRequest) (res *tailcfg.MapResponse,
 			res.Peers = append(res.Peers, p)
 		}
 	}
+	sort.Slice(res.Peers, func(i, j int) bool {
+		return res.Peers[i].ID < res.Peers[j].ID
+	})
 
 	v4Prefix := netaddr.IPPrefixFrom(netaddr.IPv4(100, 64, uint8(tailcfg.NodeID(user.ID)>>8), uint8(tailcfg.NodeID(user.ID))), 32)
 	v6Prefix := netaddr.IPPrefixFrom(tsaddr.Tailscale4To6(v4Prefix.IP()), 128)


### PR DESCRIPTION
This is part of the control protocol.

Signed-off-by: Josh Bleecher Snyder <josh@tailscale.com>
