### PR TITLE
wgengine: actively log FlushDNS.

### DIFF
--- a/wgengine/router/router_windows.go
+++ b/wgengine/router/router_windows.go
@@ -86,6 +86,7 @@ func (r *winRouter) Set(cfg *Config) error {
 	}
 
 	// Flush DNS on router config change to clear cached DNS entries (solves #1430)
+	r.logf("router_windows.go:Set calling ipconfig /flushdns")
 	if err := dns.Flush(); err != nil {
 		r.logf("flushdns error: %v", err)
 	}


### PR DESCRIPTION
Intended to help in resolving customer issue with
DNS caching.

We currently exec `ipconfig /flushdns` from two
places:
- SetDNS(), which logs before invoking
- here in router_windows, which doesn't

We'd like to see a positive indication in logs that flushdns
is being run.

As this log is expected to be spammy, it is proposed to
leave this in just long enough to do an unstable 1.13.x build
and then revert it. They won't run an unsigned image that
I build.

Signed-off-by: Denton Gentry <dgentry@tailscale.com>