### PR TITLE
control/controlclient: add call to tsmpPing

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -787,6 +787,7 @@ func (c *Direct) sendMapRequest(ctx context.Context, maxPolls int, cb func(*netm
 
 		if pr := resp.PingRequest; pr != nil && c.isUniquePingRequest(pr) {
 			go answerPing(c.logf, c.httpc, pr)
+			go tsmpPing(c.logf, c.httpc, pr, c.pinger)
 		}
 
 		if resp.KeepAlive {


### PR DESCRIPTION
Held back on spinning up the new goroutine to call the tsmpPing. This PR enables clients to respond with the PingResults via POST request. 

This should be merged after the 1.14 release