### PR TITLE
Revert "wgengine: actively log FlushDNS."

### DIFF
--- a/wgengine/router/router_windows.go
+++ b/wgengine/router/router_windows.go
@@ -86,7 +86,6 @@ func (r *winRouter) Set(cfg *Config) error {
 	}
 
 	// Flush DNS on router config change to clear cached DNS entries (solves #1430)
-	r.logf("router_windows.go:Set calling ipconfig /flushdns")
 	if err := dns.Flush(); err != nil {
 		r.logf("flushdns error: %v", err)
 	}


### PR DESCRIPTION
This log is quite verbose, it was only to be left in for one
unstable build to help debug a user issue.

This reverts commit 1dd25520326f0adc1d37c12710c9f33c830a7ef5.

Signed-off-by: Denton Gentry <dgentry@tailscale.com>