### PR TITLE
Fix truncated "g" with GitHub login in web controller

### DIFF
--- a/cmd/tailscale/cli/web.html
+++ b/cmd/tailscale/cli/web.html
@@ -28,7 +28,7 @@
 		<div class="flex items-center justify-end space-x-2 w-2/3">
 			{{ with .Profile.LoginName }}
 			<div class="text-right truncate leading-4">
-				<h4 class="truncate">{{.}}</h4>
+				<h4 class="truncate leading-normal">{{.}}</h4>
 				<a href="#" class="text-xs text-gray-500 hover:text-gray-700 js-loginButton">Switch account</a>
 			</div>
 			{{ end }}


### PR DESCRIPTION
This is a bit pedantic, but the "g" in GitHub gets clipped when using the `tailscale web` command-line tool.

Before:

<img width="557" alt="image" src="https://user-images.githubusercontent.com/20569/131185905-919fe97d-882e-4a55-9620-db585506e3b0.png">

After:

<img width="537" alt="image" src="https://user-images.githubusercontent.com/20569/131185783-71beca48-8347-466b-8ea3-36e490621046.png">
