### PR TITLE
vms: make ssh-keygen quiet by default

### DIFF
--- a/tstest/integration/vms/harness_test.go
+++ b/tstest/integration/vms/harness_test.go
@@ -96,7 +96,11 @@ func newHarness(t *testing.T) *Harness {
 	hs := &http.Server{Handler: mux}
 	go hs.Serve(ln)
 
-	run(t, dir, "ssh-keygen", "-t", "ed25519", "-f", "machinekey", "-N", ``)
+	cmd := exec.Command("ssh-keygen", "-t", "ed25519", "-f", "machinekey", "-N", "")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("ssh-keygen: %v, %s", err, out)
+	}
 	pubkey, err := os.ReadFile(filepath.Join(dir, "machinekey.pub"))
 	if err != nil {
 		t.Fatalf("can't read ssh key: %v", err)


### PR DESCRIPTION
Always succeeds. Its output clutters the log.

Signed-off-by: David Crawshaw <crawshaw@tailscale.com>