### PR TITLE
wgengine/netstack: switch injectOutbound to full-duplex pipes

### DIFF
--- a/.github/workflows/repr-template.md
+++ b/.github/workflows/repr-template.md
@@ -1,0 +1,8 @@
+### checkout this branch
+```
+mkdir -p $HOME/tailscale/{branch_name} && cd $HOME/tailscale/{branch_name}
+git init && git remote add origin https://github.com/tailscale/tailscale.git
+git fetch origin --tags && git fetch origin pull/{pull_id}/head:{branch_name}
+git checkout {branch_name}
+``` 
+

--- a/.github/workflows/repr.yml
+++ b/.github/workflows/repr.yml
@@ -1,0 +1,24 @@
+
+name: repr
+on: 
+  pull_request:
+    types: [ opened, reopened ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: repr
+        run: |
+          outfile=".github/workflows/repr.md"
+          templateFile=".github/workflows/repr-template.md"
+          cat $templateFile >> $outfile
+      - name: comment
+        uses: harupy/comment-on-pr@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: "repr.md"


### PR DESCRIPTION
Thought I'd take a quick crack at #2741

I use a pipe (two synchronous, full-duplex *net.Conn ) that gets allocated once per call to injectUnbound(). 

The tests never failed while writing this; so I'm somewhat sus about it. 

I added a deadline just out of habit; 30 seconds is completely arbitrary, likely needs changing.
```go
// Deadline is optional - thoughts?
d, n := time.Second*30, time.Now()
r, w := net.Pipe()
r.SetDeadline(n.Add(d))
w.SetDeadline(n.Add(d))
```

I left the buffer allocation for the full packet.
```go
full := make([]byte, 0, pkt.Size())
```

But instead of performing appends to full we write to the raw conn `w` in a new go routine.
```go
go func() {
	w.Write(pkt.Data().AsRange().AsView())
	w.Write(pkt.NetworkHeader().View())
	w.Write(pkt.TransportHeader().View())
}()

```

The successive read from the `r` conn will block until all writes have been consumed.
```go
if wrote, err := r.Read(full); debugNetstack {
        ...
}
```

BTW how do you generally benchmark the netstack package? 

I'm not saying this is better (haven't benched it) - but the heavy use of `append` as you said is "get-it-working code" so I'd wager most implementations that use reader/writer or `copy` should be an improvement.