### PR TITLE
all: add (*testing.B).ReportAllocs() to every benchmark

### DIFF
--- a/net/dns/resolver/tsdns_test.go
+++ b/net/dns/resolver/tsdns_test.go
@@ -1015,6 +1015,7 @@ func BenchmarkFull(b *testing.B) {
 
 	for _, tt := range tests {
 		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
 				syncRespond(r, tt.request)
 			}

--- a/net/tsaddr/tsaddr_test.go
+++ b/net/tsaddr/tsaddr_test.go
@@ -75,6 +75,7 @@ func TestNewContainsIPFunc(t *testing.T) {
 var sinkIP netaddr.IP
 
 func BenchmarkTailscaleServiceAddr(b *testing.B) {
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		sinkIP = TailscaleServiceIP()
 	}

--- a/net/tstun/wrap_test.go
+++ b/net/tstun/wrap_test.go
@@ -397,6 +397,7 @@ func TestClose(t *testing.T) {
 }
 
 func BenchmarkWrite(b *testing.B) {
+	b.ReportAllocs()
 	ftun, tun := newFakeTUN(b.Logf, true)
 	defer tun.Close()
 

--- a/tstime/mono/mono_test.go
+++ b/tstime/mono/mono_test.go
@@ -35,12 +35,14 @@ func TestUnmarshalZero(t *testing.T) {
 }
 
 func BenchmarkMonoNow(b *testing.B) {
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		Now()
 	}
 }
 
 func BenchmarkTimeNow(b *testing.B) {
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		time.Now()
 	}

--- a/tstime/tstime_test.go
+++ b/tstime/tstime_test.go
@@ -152,7 +152,6 @@ func BenchmarkParse3339(b *testing.B) {
 	run := func(in string) func(*testing.B) {
 		return func(b *testing.B) {
 			b.ReportAllocs()
-
 			t, err := time.Parse(time.RFC3339Nano, in)
 			if err != nil {
 				b.Fatal(err)
@@ -182,6 +181,7 @@ func BenchmarkParse3339(b *testing.B) {
 }
 
 func BenchmarkParseInt(b *testing.B) {
+	b.ReportAllocs()
 	var out int
 	for i := 0; i < b.N; i++ {
 		parseInt(mem.S("148487491"), &out)

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -1194,6 +1194,10 @@ func addTestEndpoint(tb testing.TB, conn *Conn, sendConn net.PacketConn) (tailcf
 }
 
 func setUpReceiveFrom(tb testing.TB) (roundTrip func()) {
+	if b, ok := tb.(*testing.B); ok {
+		b.ReportAllocs()
+	}
+
 	conn := newTestConn(tb)
 	tb.Cleanup(func() { conn.Close() })
 	conn.logf = logger.Discard
@@ -1295,6 +1299,7 @@ func BenchmarkReceiveFrom(b *testing.B) {
 }
 
 func BenchmarkReceiveFrom_Native(b *testing.B) {
+	b.ReportAllocs()
 	recvConn, err := net.ListenPacket("udp4", "127.0.0.1:0")
 	if err != nil {
 		b.Fatal(err)

--- a/wgengine/userspace_test.go
+++ b/wgengine/userspace_test.go
@@ -214,6 +214,8 @@ func BenchmarkGenLocalAddrFunc(b *testing.B) {
 	lanot := netaddr.MustParseIP("5.5.5.5")
 	var x bool
 	b.Run("map1", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
 		m := map[netaddr.IP]bool{
 			la1: true,
 		}
@@ -223,6 +225,8 @@ func BenchmarkGenLocalAddrFunc(b *testing.B) {
 		}
 	})
 	b.Run("map2", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
 		m := map[netaddr.IP]bool{
 			la1: true,
 			la2: true,
@@ -233,6 +237,8 @@ func BenchmarkGenLocalAddrFunc(b *testing.B) {
 		}
 	})
 	b.Run("or1", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
 		f := func(t netaddr.IP) bool {
 			return t == la1
 		}
@@ -242,6 +248,8 @@ func BenchmarkGenLocalAddrFunc(b *testing.B) {
 		}
 	})
 	b.Run("or2", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
 		f := func(t netaddr.IP) bool {
 			return t == la1 || t == la2
 		}


### PR DESCRIPTION
This ensures that we can properly track and catch allocation
slippages that could otherwise have been missed.

Fixes #2748