### PR TITLE
tstest/integration/vms: change build tag restriction

### DIFF
--- a/tstest/integration/vms/derive_bindhost_test.go
+++ b/tstest/integration/vms/derive_bindhost_test.go
@@ -2,13 +2,11 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux
-// +build linux
-
 package vms
 
 import (
 	"io"
+	"runtime"
 	"testing"
 
 	"inet.af/netaddr"
@@ -41,6 +39,9 @@ func deriveBindhost(t *testing.T) string {
 }
 
 func TestDeriveBindhost(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("requires GOOS=linux")
+	}
 	t.Log(deriveBindhost(t))
 }
 

--- a/tstest/integration/vms/distros_test.go
+++ b/tstest/integration/vms/distros_test.go
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux
-// +build linux
-
 package vms
 
 import (

--- a/tstest/integration/vms/harness_test.go
+++ b/tstest/integration/vms/harness_test.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux
-// +build linux
+//go:build !windows
+// +build !windows
 
 package vms
 

--- a/tstest/integration/vms/nixos_test.go
+++ b/tstest/integration/vms/nixos_test.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux
-// +build linux
+//go:build !windows
+// +build !windows
 
 package vms
 

--- a/tstest/integration/vms/opensuse_leap_15_1_test.go
+++ b/tstest/integration/vms/opensuse_leap_15_1_test.go
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux
-// +build linux
-
 package vms
 
 import (

--- a/tstest/integration/vms/top_level_test.go
+++ b/tstest/integration/vms/top_level_test.go
@@ -2,20 +2,19 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux
-// +build linux
+//go:build !windows
+// +build !windows
 
 package vms
 
 import "testing"
 
 func TestRunUbuntu1804(t *testing.T) {
-	t.Parallel()
 	setupTests(t)
 	testOneDistribution(t, 0, Distros[0])
 }
+
 func TestRunUbuntu2004(t *testing.T) {
-	t.Parallel()
 	setupTests(t)
 	testOneDistribution(t, 1, Distros[1])
 }

--- a/tstest/integration/vms/vm_setup_test.go
+++ b/tstest/integration/vms/vm_setup_test.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux
-// +build linux
+//go:build !windows
+// +build !windows
 
 package vms
 

--- a/tstest/integration/vms/vms_steps_test.go
+++ b/tstest/integration/vms/vms_steps_test.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux
-// +build linux
+//go:build !windows
+// +build !windows
 
 package vms
 

--- a/tstest/integration/vms/vms_test.go
+++ b/tstest/integration/vms/vms_test.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux
-// +build linux
+//go:build !windows
+// +build !windows
 
 package vms
 


### PR DESCRIPTION
The tests build fine off linux, they just can't run on other OSs.
But there is already a t.Skip by default, so `go test` ends up
working fine elsewhere and checks the code compiles.

Signed-off-by: David Crawshaw <crawshaw@tailscale.com>