### PR TITLE
cmd/derper: refactor STUN path for testing, add serverSTUN benchmark

### DIFF
--- a/cmd/derper/derper_test.go
+++ b/cmd/derper/derper_test.go
@@ -6,7 +6,10 @@ package main
 
 import (
 	"context"
+	"net"
 	"testing"
+
+	"tailscale.com/net/stun"
 )
 
 func TestProdAutocertHostPolicy(t *testing.T) {
@@ -29,6 +32,37 @@ func TestProdAutocertHostPolicy(t *testing.T) {
 		got := prodAutocertHostPolicy(context.Background(), tt.in) == nil
 		if got != tt.wantOK {
 			t.Errorf("f(%q) = %v; want %v", tt.in, got, tt.wantOK)
+		}
+	}
+}
+
+func BenchmarkServerSTUN(b *testing.B) {
+	b.ReportAllocs()
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer pc.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go serverSTUNListener(ctx, pc.(*net.UDPConn))
+	addr := pc.LocalAddr().(*net.UDPAddr)
+
+	var resBuf [1500]byte
+	cc, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1")})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	tx := stun.NewTxID()
+	req := stun.Request(tx)
+	for i := 0; i < b.N; i++ {
+		if _, err := cc.WriteToUDP(req, addr); err != nil {
+			b.Fatal(err)
+		}
+		_, _, err := cc.ReadFromUDP(resBuf[:])
+		if err != nil {
+			b.Fatal(err)
 		}
 	}
 


### PR DESCRIPTION
Real goal is to eliminate some allocs in the STUN path, but that requires
work in the standard library.

For now this just adds a benchmark.

