### PR TITLE
net/dns: teach OpenBSD's manager to talk to resolvd(8).

### DIFF
--- a/net/dns/manager_openbsd.go
+++ b/net/dns/manager_openbsd.go
@@ -31,7 +31,7 @@ func NewOSConfigurator(logf logger.Logf, interfaceName string) (OSConfigurator, 
 // newOSConfigEnv are the funcs newOSConfigurator needs, pulled out for testing.
 type newOSConfigEnv struct {
 	fs          wholeFileFS
-	rcIsResolvd func(resolvConfContents []byte) string
+	rcIsResolvd func(resolvConfContents []byte) bool
 }
 
 func newOSConfigurator(logf logger.Logf, interfaceName string, env newOSConfigEnv) (ret OSConfigurator, err error) {
@@ -70,5 +70,5 @@ func rcIsResolvd(resolvConfContents []byte) bool {
 	if bytes.Contains(resolvConfContents, []byte("# resolvd:")) {
 		return true
 	}
-	return fase
+	return false
 }

--- a/net/dns/manager_openbsd.go
+++ b/net/dns/manager_openbsd.go
@@ -61,7 +61,7 @@ func newOSConfigurator(logf logger.Logf, interfaceName string, env newOSConfigEn
 	}
 
 	dbg("resolvd", "missing")
-	return newDirectManager(), nil
+	return newDirectManager(logf), nil
 }
 
 func rcIsResolvd(resolvConfContents []byte) bool {

--- a/net/dns/manager_openbsd.go
+++ b/net/dns/manager_openbsd.go
@@ -4,8 +4,72 @@
 
 package dns
 
-import "tailscale.com/types/logger"
+import (
+	"bytes"
+	"fmt"
+	"os"
 
-func NewOSConfigurator(logf logger.Logf, _ string) (OSConfigurator, error) {
-	return newDirectManager(logf), nil
+	"tailscale.com/types/logger"
+)
+
+type kv struct {
+	k, v string
+}
+
+func (kv kv) String() string {
+	return fmt.Sprintf("%s=%s", kv.k, kv.v)
+}
+
+func NewOSConfigurator(logf logger.Logf, interfaceName string) (OSConfigurator, error) {
+	return newOSConfigurator(logf, interfaceName,
+		newOSConfigEnv{
+			rcIsResolvd: rcIsResolvd,
+			fs:          directFS{},
+		})
+}
+
+// newOSConfigEnv
+type newOSConfigEnv struct {
+	fs          wholeFileFS
+	rcIsResolvd func(resolvConfContents []byte) string
+}
+
+func newOSConfigurator(logf logger.Logf, interfaceName string, env newOSConfigEnv) (ret OSConfigurator, err error) {
+	var debug []kv
+	dbg := func(k, v string) {
+		debug = append(debug, kv{k, v})
+	}
+	defer func() {
+		if ret != nil {
+			dbg("ret", fmt.Sprintf("%T", ret))
+		}
+		logf("dns: %v", debug)
+	}()
+
+	bs, err := env.fs.ReadFile(resolvConf)
+	if os.IsNotExist(err) {
+		dbg("rc", "missing")
+		return newDirectManager(logf), nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading /etc/resolv.conf: %w", err)
+	}
+
+	switch env.rcIsResolvd(bs) {
+	case "resolvd":
+		dbg("resolvd", "yes")
+		return newResolvdManager(logf, interfaceName)
+	default:
+		dbg("resolvd", "missing")
+		return newDirectManager(logf), nil
+	}
+}
+
+func rcIsResolvd(resolvConfContents []byte) string {
+	// If we have the string "# resolvd:" in resolv.conf resolvd(8) is
+	// managing things.
+	if bytes.Contains(resolvConfContents, []byte("# resolvd:")) {
+		return "resolvd"
+	}
+	return ""
 }

--- a/net/dns/manager_openbsd.go
+++ b/net/dns/manager_openbsd.go
@@ -28,7 +28,7 @@ func NewOSConfigurator(logf logger.Logf, interfaceName string) (OSConfigurator, 
 		})
 }
 
-// newOSConfigEnv
+// newOSConfigEnv are the funcs newOSConfigurator needs, pulled out for testing.
 type newOSConfigEnv struct {
 	fs          wholeFileFS
 	rcIsResolvd func(resolvConfContents []byte) string

--- a/net/dns/manager_openbsd.go
+++ b/net/dns/manager_openbsd.go
@@ -30,7 +30,7 @@ func NewOSConfigurator(logf logger.Logf, interfaceName string) (OSConfigurator, 
 
 // newOSConfigEnv are the funcs newOSConfigurator needs, pulled out for testing.
 type newOSConfigEnv struct {
-	fs          wholeFileFS
+	fs          directFS
 	rcIsResolvd func(resolvConfContents []byte) bool
 }
 

--- a/net/dns/manager_openbsd.go
+++ b/net/dns/manager_openbsd.go
@@ -55,21 +55,20 @@ func newOSConfigurator(logf logger.Logf, interfaceName string, env newOSConfigEn
 		return nil, fmt.Errorf("reading /etc/resolv.conf: %w", err)
 	}
 
-	switch env.rcIsResolvd(bs) {
-	case "resolvd":
+	if env.rcIsResolvd(bs) {
 		dbg("resolvd", "yes")
 		return newResolvdManager(logf, interfaceName)
-	default:
-		dbg("resolvd", "missing")
-		return newDirectManager(logf), nil
 	}
+
+	dbg("resolvd", "missing")
+	return newDirectManager(), nil
 }
 
-func rcIsResolvd(resolvConfContents []byte) string {
+func rcIsResolvd(resolvConfContents []byte) bool {
 	// If we have the string "# resolvd:" in resolv.conf resolvd(8) is
 	// managing things.
 	if bytes.Contains(resolvConfContents, []byte("# resolvd:")) {
-		return "resolvd"
+		return true
 	}
-	return ""
+	return fase
 }

--- a/net/dns/resolvd.go
+++ b/net/dns/resolvd.go
@@ -41,7 +41,7 @@ func (m *resolvdManager) SetDNS(config OSConfig) error {
 	return cmd.Run()
 }
 func (m *resolvdManager) SupportsSplitDNS() bool {
-	return true
+	return false
 }
 
 func (m *resolvdManager) GetBaseConfig() (OSConfig, error) {

--- a/net/dns/resolvd.go
+++ b/net/dns/resolvd.go
@@ -8,15 +8,23 @@
 package dns
 
 import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
 	"os/exec"
+	"regexp"
+	"strings"
 
 	"tailscale.com/types/logger"
+	"tailscale.com/util/dnsname"
 )
 
 func newResolvdManager(logf logger.Logf, interfaceName string) (*resolvdManager, error) {
 	return &resolvdManager{
 		logf:   logf,
 		ifName: interfaceName,
+		fs:     directFS{},
 	}, nil
 }
 
@@ -25,6 +33,7 @@ func newResolvdManager(logf logger.Logf, interfaceName string) (*resolvdManager,
 type resolvdManager struct {
 	logf   logger.Logf
 	ifName string
+	fs     directFS
 }
 
 func (m *resolvdManager) SetDNS(config OSConfig) error {
@@ -33,22 +42,100 @@ func (m *resolvdManager) SetDNS(config OSConfig) error {
 		m.ifName,
 	}
 
-	for _, s := range config.Nameservers {
-		args = append(args, s.String())
+	origResolv, err := m.readAndCopy(resolvConf, backupConf, 0644)
+	if err != nil {
+		return err
+	}
+	newResolvConf := removeSearchLines(origResolv)
+
+	for _, ns := range config.Nameservers {
+		args = append(args, ns.String())
+	}
+
+	var newSearch = []string{
+		"search",
+	}
+	for _, s := range config.SearchDomains {
+		newSearch = append(newSearch, s.WithoutTrailingDot())
+	}
+
+	newResolvConf = append(newResolvConf, []byte(strings.Join(newSearch, " "))...)
+
+	err = m.fs.WriteFile(resolvConf, newResolvConf, 0644)
+	if err != nil {
+		return err
 	}
 
 	cmd := exec.Command("/sbin/route", args...)
 	return cmd.Run()
 }
+
 func (m *resolvdManager) SupportsSplitDNS() bool {
 	return false
 }
 
 func (m *resolvdManager) GetBaseConfig() (OSConfig, error) {
-	return OSConfig{}, ErrGetBaseConfigNotSupported
+	cfg, err := m.readResolvConf()
+	if err != nil {
+		return OSConfig{}, err
+	}
+
+	return cfg, nil
 }
 
 func (m *resolvdManager) Close() error {
-	// resolvd handles teardown of everything
-	return nil
+	// resolvd handles teardown of nameservers so we only need to write back the original
+	// config and be done.
+
+	_, err := m.readAndCopy(backupConf, resolvConf, 0644)
+	if err != nil {
+		return err
+	}
+
+	return m.fs.Remove(backupConf)
+}
+
+func (m *resolvdManager) readAndCopy(a, b string, mode os.FileMode) ([]byte, error) {
+	orig, err := m.fs.ReadFile(a)
+	if err != nil {
+		return nil, err
+	}
+	err = m.fs.WriteFile(b, orig, mode)
+	if err != nil {
+		return nil, err
+	}
+
+	return orig, nil
+}
+
+func (m resolvdManager) readResolvConf() (config OSConfig, err error) {
+	b, err := m.fs.ReadFile(resolvConf)
+	if err != nil {
+		return OSConfig{}, err
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(b))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		// resolvd manages "nameserver" lines, we only need to handle
+		// "search".
+		if strings.HasPrefix(line, "search") {
+			domain := strings.TrimPrefix(line, "search")
+			domain = strings.TrimSpace(domain)
+			fqdn, err := dnsname.ToFQDN(domain)
+			if err != nil {
+				return OSConfig{}, fmt.Errorf("parsing search domains %q: %w", line, err)
+			}
+			config.SearchDomains = append(config.SearchDomains, fqdn)
+			continue
+		}
+	}
+
+	return config, nil
+}
+
+func removeSearchLines(orig []byte) []byte {
+	re := regexp.MustCompile(`(?m)^search\s+.+$`)
+	return re.ReplaceAll(orig, []byte(""))
 }

--- a/net/dns/resolvd.go
+++ b/net/dns/resolvd.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build openbsd
+// +build openbsd
+
+package dns
+
+import (
+	"os/exec"
+
+	"tailscale.com/types/logger"
+)
+
+func newResolvdManager(logf logger.Logf, interfaceName string) (*resolvdManager, error) {
+	return &resolvdManager{
+		logf:   logf,
+		ifName: interfaceName,
+	}, nil
+}
+
+// resolvdManager is an OSConfigurator which uses route(1) to teach OpenBSD's
+// resolvd(8) about DNS servers.
+type resolvdManager struct {
+	logf   logger.Logf
+	ifName string
+}
+
+func (m *resolvdManager) SetDNS(config OSConfig) error {
+	args := []string{
+		"nameserver",
+		m.ifName,
+	}
+
+	for _, s := range config.Nameservers {
+		args = append(args, s.String())
+	}
+
+	cmd := exec.Command("/sbin/route", args...)
+	return cmd.Run()
+}
+func (m *resolvdManager) SupportsSplitDNS() bool {
+	return true
+}
+
+func (m *resolvdManager) GetBaseConfig() (OSConfig, error) {
+	return OSConfig{}, ErrGetBaseConfigNotSupported
+}
+
+func (m *resolvdManager) Close() error {
+	return nil
+}

--- a/net/dns/resolvd.go
+++ b/net/dns/resolvd.go
@@ -49,5 +49,6 @@ func (m *resolvdManager) GetBaseConfig() (OSConfig, error) {
 }
 
 func (m *resolvdManager) Close() error {
+	// resolvd handles teardown of everything
 	return nil
 }


### PR DESCRIPTION
OpenBSD 6.9 and up has a daemon which handles nameserver configuration. This MR
teaches the OpenBSD dns manager to check if resolvd is being used. If it is, it
will use the route(8) command to tell resolvd to add the Tailscale dns entries
to resolv.conf

Signed-off-by: Aaron Bieber <aaron@bolddaemon.com>