### PR TITLE
cmd/derper: support customized server certificate

### DIFF
--- a/cmd/derper/cert.go
+++ b/cmd/derper/cert.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2020 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"regexp"
+
+	"golang.org/x/crypto/acme/autocert"
+)
+
+var unsafeHostnameCharacters = regexp.MustCompile(`[^a-zA-Z0-9-\.]`)
+
+type certProvider interface {
+	// TLSConfig creates a new TLS config suitable for net/http.Server servers.
+	TLSConfig() *tls.Config
+	// HTTPHandler handle ACME related request, if any.
+	HTTPHandler(fallback http.Handler) http.Handler
+}
+
+func certProviderByCertMode(mode, dir string) (certProvider, error) {
+	if dir == "" {
+		return nil, errors.New("missing required --certdir flag")
+	}
+	switch mode {
+	case "letsencrypt":
+		certManager := &autocert.Manager{
+			Prompt:     autocert.AcceptTOS,
+			HostPolicy: autocert.HostWhitelist(*hostname),
+			Cache:      autocert.DirCache(dir),
+		}
+		if *hostname == "derp.tailscale.com" {
+			certManager.HostPolicy = prodAutocertHostPolicy
+			certManager.Email = "security@tailscale.com"
+		}
+		return certManager, nil
+	case "manual":
+		return &manualCertManager{
+			certdir: dir,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupport cert mode: %q", mode)
+	}
+}
+
+type manualCertManager struct {
+	certdir string
+}
+
+func (m *manualCertManager) TLSConfig() *tls.Config {
+	return &tls.Config{
+		Certificates: nil,
+		NextProtos: []string{
+			"h2", "http/1.1", // enable HTTP/2
+		},
+		GetCertificate: m.getCertificate,
+	}
+}
+
+func (m *manualCertManager) getCertificate(hi *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	// If server name is provided (which means SNI), search for the file.
+	// Or, use local IP as cert name.
+	keyname := hi.ServerName
+	if keyname == "" {
+		keyname = hi.Conn.LocalAddr().String()
+	}
+	// RFC basically only allow [0-9a-zA-Z\.-] in SNI, so
+	// We will follow it for security purpose.
+	// Also, unnecessary to check concated string.
+	keyname = unsafeHostnameCharacters.ReplaceAllString(keyname, "")
+	crtPath := filepath.Join(m.certdir, keyname+".crt")
+	keyPath := filepath.Join(m.certdir, keyname+".key")
+	cert, err := tls.LoadX509KeyPair(crtPath, keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("can not load x509 key pair for hostname %q: %w", keyname, err)
+	}
+	return &cert, err
+}
+
+func (m *manualCertManager) HTTPHandler(fallback http.Handler) http.Handler {
+	return fallback
+}

--- a/cmd/derper/derper.go
+++ b/cmd/derper/derper.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/crypto/acme/autocert"
 	"tailscale.com/atomicfile"
 	"tailscale.com/derp"
 	"tailscale.com/derp/derphttp"
@@ -39,6 +38,7 @@ var (
 	dev           = flag.Bool("dev", false, "run in localhost development mode")
 	addr          = flag.String("a", ":443", "server address")
 	configPath    = flag.String("c", "", "config file path")
+	certMode      = flag.String("certmode", "letsencrypt", "mode for getting a cert. possible options: manual, letsencrypt")
 	certDir       = flag.String("certdir", tsweb.DefaultCertDir("derper-certs"), "directory to store LetsEncrypt certs, if addr's port is :443")
 	hostname      = flag.String("hostname", "derp.tailscale.com", "LetsEncrypt host name, if addr's port is :443")
 	logCollection = flag.String("logcollection", "", "If non-empty, logtail collection to log to")
@@ -130,7 +130,7 @@ func main() {
 
 	cfg := loadConfig()
 
-	letsEncrypt := tsweb.IsProd443(*addr)
+	serveTLS := tsweb.IsProd443(*addr)
 
 	s := derp.NewServer(key.Private(cfg.PrivateKey), log.Printf)
 	s.SetVerifyClient(*verifyClients)
@@ -204,24 +204,16 @@ func main() {
 		WriteTimeout: 30 * time.Second,
 	}
 
-	if letsEncrypt {
-		if *certDir == "" {
-			log.Fatalf("missing required --certdir flag")
-		}
+	if serveTLS {
 		log.Printf("derper: serving on %s with TLS", *addr)
-		certManager := &autocert.Manager{
-			Prompt:     autocert.AcceptTOS,
-			HostPolicy: autocert.HostWhitelist(*hostname),
-			Cache:      autocert.DirCache(*certDir),
-		}
-		if *hostname == "derp.tailscale.com" {
-			certManager.HostPolicy = prodAutocertHostPolicy
-			certManager.Email = "security@tailscale.com"
+		certManager, err := certProviderByCertMode(*certMode, *certDir)
+		if err != nil {
+			log.Fatalf("derper: can not start cert provider: %v", err)
 		}
 		httpsrv.TLSConfig = certManager.TLSConfig()
-		letsEncryptGetCert := httpsrv.TLSConfig.GetCertificate
+		getCert := httpsrv.TLSConfig.GetCertificate
 		httpsrv.TLSConfig.GetCertificate = func(hi *tls.ClientHelloInfo) (*tls.Certificate, error) {
-			cert, err := letsEncryptGetCert(hi)
+			cert, err := getCert(hi)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/derper/derper.go
+++ b/cmd/derper/derper.go
@@ -206,7 +206,7 @@ func main() {
 
 	if serveTLS {
 		log.Printf("derper: serving on %s with TLS", *addr)
-		certManager, err := certProviderByCertMode(*certMode, *certDir)
+		certManager, err := certProviderByCertMode(*certMode, *certDir, *hostname)
 		if err != nil {
 			log.Fatalf("derper: can not start cert provider: %v", err)
 		}


### PR DESCRIPTION
In #2619, @hronro asked if users could provide an certificate by themself, instead of using the automatically retrieved one via Let's Encrypt.

This pull request adds a new "-certmode" argument for control certificate source. Default argument "letsencrypt" would keep the old behaviour. 

In "manual" mode, certs are searched in given "-certdir" argument. The filename being searched is decided by HTTPS request's SNI field, and in format `${certdir}/${hostname}.{crt/key}`. If cert can not be loaded on start, error is thrown.

Solves #2619 and #2794

Signed-off-by: SilverBut <SilverBut@users.noreply.github.com>