### PR TITLE
hostinfo: add FreeBSD support.

### DIFF
--- a/hostinfo/hostinfo_freebsd.go
+++ b/hostinfo/hostinfo_freebsd.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build freebsd
+// +build freebsd
+
+package hostinfo
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"golang.org/x/sys/unix"
+	"tailscale.com/version/distro"
+)
+
+func init() {
+	osVersion = osVersionFreebsd
+}
+
+func osVersionFreebsd() string {
+	un := unix.Utsname{}
+	unix.Uname(&un)
+
+	var attrBuf strings.Builder
+	attrBuf.WriteString("; version=")
+	for _, b := range un.Release {
+		if b == 0 {
+			break
+		}
+		attrBuf.WriteByte(byte(b))
+	}
+	attr := attrBuf.String()
+
+	version := "FreeBSD"
+	switch distro.Get() {
+	case distro.Pfsense:
+		b, _ := os.ReadFile("/etc/version")
+		version = fmt.Sprintf("pfSense %s", b)
+	case distro.OPNsense:
+		b, err := exec.Command("opnsense-version").Output()
+		if err == nil {
+			version = string(b)
+		} else {
+			version = "OPNsense"
+		}
+	case distro.TrueNAS:
+		b, err := os.ReadFile("/etc/version")
+		if err == nil {
+			version = string(b)
+		} else {
+			version = "TrueNAS"
+		}
+	}
+	// the /etc/version files end in a newline
+	return fmt.Sprintf("%s%s", strings.TrimSuffix(version, "\n"), attr)
+}

--- a/version/distro/distro.go
+++ b/version/distro/distro.go
@@ -19,12 +19,18 @@ const (
 	OpenWrt  = Distro("openwrt")
 	NixOS    = Distro("nixos")
 	QNAP     = Distro("qnap")
+	Pfsense  = Distro("pfsense")
+	OPNsense = Distro("opnsense")
+	TrueNAS  = Distro("truenas")
 )
 
 // Get returns the current distro, or the empty string if unknown.
 func Get() Distro {
 	if runtime.GOOS == "linux" {
 		return linuxDistro()
+	}
+	if runtime.GOOS == "freebsd" {
+		return freebsdDistro()
 	}
 	return ""
 }
@@ -53,6 +59,18 @@ func linuxDistro() Distro {
 		return NixOS
 	case have("/etc/config/uLinux.conf"):
 		return QNAP
+	}
+	return ""
+}
+
+func freebsdDistro() Distro {
+	switch {
+	case have("/etc/pfSense-rc"):
+		return Pfsense
+	case have("/usr/local/sbin/opnsense-shell"):
+		return OPNsense
+	case have("/usr/local/bin/freenas-debug"):
+		return TrueNAS
 	}
 	return ""
 }


### PR DESCRIPTION
Add specific handling for common appliances based on FreeBSD:
- pfSense
    HostInfo: {"OS":"freebsd","OSVersion":"pfSense 2.5.2-RELEASE; version=12.2-STABLE"
- OPNsense
    HostInfo: {"OS":"freebsd","OSVersion":"OPNsense 21.7.1 (amd64/OpenSSL); version=12.1-RELEASE-p19-HBSD"
- TrueNAS
    HostInfo: {"OS":"freebsd","OSVersion":"TrueNAS-12.0-U5.1 (6c639bd48a); version=12.2-RELEASE-p9"
- FreeNAS
    HostInfo: {"OS":"freebsd","OSVersion":"FreeNAS-11.3-U5 (2e4ded5a0a); version=11.3-RELEASE-p14",

- regular FreeBSD
    HostInfo: {"OS":"freebsd","OSVersion":"FreeBSD; version=12.2-RELEASE"