### PR TITLE
cmd/tailscaled: disable netns earlier in userspace-networking mode

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -297,9 +297,6 @@ func run() error {
 		logf("wgengine.New: %v", err)
 		return err
 	}
-	if useNetstack {
-		netns.Disable()
-	}
 
 	var ns *netstack.Impl
 	if useNetstack || wrapNetstack {
@@ -391,6 +388,10 @@ func tryEngine(logf logger.Logf, linkMon *monitor.Mon, name string) (e wgengine.
 		ListenPort:  args.port,
 		LinkMonitor: linkMon,
 	}
+
+	useNetstack = name == "userspace-networking"
+	netns.SetEnabled(!useNetstack)
+
 	if args.birdSocketPath != "" && createBIRDClient != nil {
 		log.Printf("Connecting to BIRD at %s ...", args.birdSocketPath)
 		conf.BIRDClient, err = createBIRDClient(args.birdSocketPath)
@@ -398,7 +399,6 @@ func tryEngine(logf logger.Logf, linkMon *monitor.Mon, name string) (e wgengine.
 			return nil, false, err
 		}
 	}
-	useNetstack = name == "userspace-networking"
 	if !useNetstack {
 		dev, devName, err := tstun.New(logf, name)
 		if err != nil {

--- a/net/netns/netns.go
+++ b/net/netns/netns.go
@@ -24,9 +24,10 @@ import (
 
 var disabled syncs.AtomicBool
 
-// Disable disables netns for the process.
-func Disable() {
-	disabled.Set(true)
+// SetEnabled enables or disables netns for the process.
+// It defaults to being enabled.
+func SetEnabled(on bool) {
+	disabled.Set(!on)
 }
 
 // Listener returns a new net.Listener with its Control hook func


### PR DESCRIPTION
The earlier 382b349c54ed38bbc4d2936a8c9de6cc2f905eb8 was too late,
as engine creation itself needed to listen on things.

Fixes #2827
Updates #2822