### PR TITLE
portlist: reuse bufio.Reader between files

### DIFF
--- a/portlist/portlist_linux_test.go
+++ b/portlist/portlist_linux_test.go
@@ -129,3 +129,13 @@ func BenchmarkParsePorts(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkListPorts(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := listPorts()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
```
name         old time/op    new time/op    delta
ListPorts-6    1.18ms ± 5%    1.16ms ± 5%     ~     (p=0.075 n=10+10)

name         old alloc/op   new alloc/op   delta
ListPorts-6    27.2kB ± 0%    14.9kB ± 0%  -45.14%  (p=0.001 n=8+9)

name         old allocs/op  new allocs/op  delta
ListPorts-6      90.0 ± 0%      84.0 ± 0%   -6.67%  (p=0.000 n=10+10)
```

Updates tailscale/corp#2566
