### PR TITLE
derp: deflake TestSendFreeze

### DIFF
--- a/derp/derp_test.go
+++ b/derp/derp_test.go
@@ -403,8 +403,11 @@ func TestSendFreeze(t *testing.T) {
 	t.Logf("TEST COMPLETE, cancelling sender")
 	cancel()
 	t.Logf("closing connections")
-	aliceConn.Close()
+	// Close bob before alice.
+	// Starting with alice can cause a PeerGoneMessage to reach
+	// bob before bob is closed, causing a test flake (issue 2668).
 	bobConn.Close()
+	aliceConn.Close()
 	cathyConn.Close()
 
 	for i := 0; i < cap(errCh); i++ {


### PR DESCRIPTION
On about 1 out of 500 runs, TestSendFreeze failed:

    derp_test.go:416: bob: unexpected message type derp.PeerGoneMessage

Closing alice before bob created a race.
If bob closed promptly, the test passed.
If bob closed slowly, and alice's disappearance caused
bob to receive a PeerGoneMessage before closing, the test failed.

Deflake the test by closing bob first.
With this fix, the test passed 12,000 times locally.

Fixes #2668

Signed-off-by: Josh Bleecher Snyder <josh@tailscale.com>