### PR TITLE
portlist: stop logging stray UDP ports

### DIFF
--- a/portlist/portlist_macos.go
+++ b/portlist/portlist_macos.go
@@ -12,7 +12,6 @@ import (
 	"bytes"
 	"fmt"
 	"log"
-	"os"
 	"os/exec"
 	"strings"
 	"sync/atomic"
@@ -99,10 +98,8 @@ func addProcesses(pl []Port) ([]Port, error) {
 				switch {
 				case p != nil:
 					p.Process = cmd
-				case isLoopbackAddr(val):
-					// ignore
 				default:
-					fmt.Fprintf(os.Stderr, "weird: missing %v\n", pp)
+					// ignore: processes and ports come and go
 				}
 			}
 		}


### PR DESCRIPTION
These "weird" port lines show up in logs frequently.
They're the result of uninteresting races,
and they're not actionable. Remove the noise.

Signed-off-by: Josh Bleecher Snyder <josh@tailscale.com>
