### PR TITLE
ipn/ipnlocal: add failing test, reduce UpdateEndpoints calls, start concurrency work

### DIFF
--- a/control/controlclient/client.go
+++ b/control/controlclient/client.go
@@ -69,7 +69,7 @@ type Client interface {
 	SetNetInfo(*tailcfg.NetInfo)
 	// UpdateEndpoints changes the Endpoint structure that will be sent
 	// in subsequent node registration requests.
-	// TODO: localPort seems to be obsolete, remove it.
+	// The localPort field is unused except for integration tests in another repo.
 	// TODO: a server-side change would let us simply upload this
 	// in a separate http request. It has nothing to do with the rest of
 	// the state machine.

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -2357,22 +2357,22 @@ func (b *LocalBackend) nextState() ipn.State {
 			// Auth was interrupted or waiting for URL visit,
 			// so it won't proceed without human help.
 			return ipn.NeedsLogin
-		} else if state == ipn.Stopped {
+		}
+		switch state {
+		case ipn.Stopped:
 			// If we were already in the Stopped state, then
 			// we can assume auth is in good shape (or we would
 			// have been in NeedsLogin), so transition to Starting
 			// right away.
 			return ipn.Starting
-		} else if state == ipn.NoState {
+		case ipn.NoState:
 			// Our first time connecting to control, and we
 			// don't know if we'll NeedsLogin or not yet.
 			// UIs should print "Loading..." in this state.
 			return ipn.NoState
-		} else if state == ipn.Starting ||
-			state == ipn.Running ||
-			state == ipn.NeedsLogin {
+		case ipn.Starting, ipn.Running, ipn.NeedsLogin:
 			return state
-		} else {
+		default:
 			b.logf("unexpected no-netmap state transition for %v", state)
 			return state
 		}

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1437,16 +1437,6 @@ func (b *LocalBackend) InServerMode() bool {
 	return b.inServerMode
 }
 
-// getEngineStatus returns a copy of b.engineStatus.
-//
-// TODO(bradfitz): remove this and use Status() throughout.
-func (b *LocalBackend) getEngineStatus() ipn.EngineStatus {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	return b.engineStatus
-}
-
 // Login implements Backend.
 func (b *LocalBackend) Login(token *tailcfg.Oauth2Token) {
 	b.mu.Lock()
@@ -2346,6 +2336,7 @@ func (b *LocalBackend) nextState() ipn.State {
 		blocked     = b.blocked
 		wantRunning = b.prefs.WantRunning
 		loggedOut   = b.prefs.LoggedOut
+		st          = b.engineStatus
 	)
 	b.mu.Unlock()
 
@@ -2387,7 +2378,7 @@ func (b *LocalBackend) nextState() ipn.State {
 		// (if we get here, we know MachineAuthorized == true)
 		return ipn.Starting
 	case state == ipn.Starting:
-		if st := b.getEngineStatus(); st.NumLive > 0 || st.LiveDERPs > 0 {
+		if st.NumLive > 0 || st.LiveDERPs > 0 {
 			return ipn.Running
 		} else {
 			return state

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -601,18 +601,12 @@ func (b *LocalBackend) findExitNodeIDLocked(nm *netmap.NetworkMap) (prefsChanged
 func (b *LocalBackend) setWgengineStatus(s *wgengine.Status, err error) {
 	if err != nil {
 		b.logf("wgengine status error: %v", err)
-
-		b.statusLock.Lock()
 		b.statusChanged.Broadcast()
-		b.statusLock.Unlock()
 		return
 	}
 	if s == nil {
 		b.logf("[unexpected] non-error wgengine update with status=nil: %v", s)
-
-		b.statusLock.Lock()
 		b.statusChanged.Broadcast()
-		b.statusLock.Unlock()
 		return
 	}
 
@@ -632,11 +626,7 @@ func (b *LocalBackend) setWgengineStatus(s *wgengine.Status, err error) {
 		}
 		b.stateMachine()
 	}
-
-	b.statusLock.Lock()
 	b.statusChanged.Broadcast()
-	b.statusLock.Unlock()
-
 	b.send(ipn.Notify{Engine: &es})
 }
 

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -443,6 +443,7 @@ func TestLazyMachineKeyGeneration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewFakeUserspaceEngine: %v", err)
 	}
+	t.Cleanup(eng.Close)
 	lb, err := NewLocalBackend(logf, "logid", store, eng)
 	if err != nil {
 		t.Fatalf("NewLocalBackend: %v", err)

--- a/ipn/ipnlocal/loglines_test.go
+++ b/ipn/ipnlocal/loglines_test.go
@@ -52,6 +52,7 @@ func TestLocalLogLines(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(e.Close)
 
 	lb, err := NewLocalBackend(logf, idA.String(), store, e)
 	if err != nil {

--- a/ipn/ipnlocal/state_test.go
+++ b/ipn/ipnlocal/state_test.go
@@ -284,6 +284,7 @@ func TestStateMachine(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewFakeUserspaceEngine: %v", err)
 	}
+	t.Cleanup(e.Close)
 
 	cc := newMockControl()
 	b, err := NewLocalBackend(logf, "logid", store, e)

--- a/ipn/ipnlocal/state_test.go
+++ b/ipn/ipnlocal/state_test.go
@@ -335,8 +335,8 @@ func TestStateMachine(t *testing.T) {
 
 		nn := notifies.drain(2)
 		c.Assert(cc.getCalls(), qt.HasLen, 0)
-		c.Assert(nn[0].Prefs, qt.Not(qt.IsNil))
-		c.Assert(nn[1].State, qt.Not(qt.IsNil))
+		c.Assert(nn[0].Prefs, qt.IsNotNil)
+		c.Assert(nn[1].State, qt.IsNotNil)
 		prefs := *nn[0].Prefs
 		// Note: a totally fresh system has Prefs.LoggedOut=false by
 		// default. We are logged out, but not because the user asked
@@ -360,8 +360,8 @@ func TestStateMachine(t *testing.T) {
 
 		nn := notifies.drain(2)
 		c.Assert(cc.getCalls(), qt.HasLen, 0)
-		c.Assert(nn[0].Prefs, qt.Not(qt.IsNil))
-		c.Assert(nn[1].State, qt.Not(qt.IsNil))
+		c.Assert(nn[0].Prefs, qt.IsNotNil)
+		c.Assert(nn[1].State, qt.IsNotNil)
 		c.Assert(nn[0].Prefs.LoggedOut, qt.IsFalse)
 		c.Assert(nn[0].Prefs.WantRunning, qt.IsFalse)
 		c.Assert(ipn.NeedsLogin, qt.Equals, *nn[1].State)
@@ -398,7 +398,7 @@ func TestStateMachine(t *testing.T) {
 		// we're already in NeedsLogin state.
 		nn := notifies.drain(1)
 
-		c.Assert(nn[0].Prefs, qt.Not(qt.IsNil))
+		c.Assert(nn[0].Prefs, qt.IsNotNil)
 		c.Assert(nn[0].Prefs.LoggedOut, qt.IsFalse)
 		c.Assert(nn[0].Prefs.WantRunning, qt.IsFalse)
 	}
@@ -413,7 +413,7 @@ func TestStateMachine(t *testing.T) {
 	{
 		nn := notifies.drain(1)
 		c.Assert([]string{"unpause"}, qt.DeepEquals, cc.getCalls())
-		c.Assert(nn[0].BrowseToURL, qt.Not(qt.IsNil))
+		c.Assert(nn[0].BrowseToURL, qt.IsNotNil)
 		c.Assert(url1, qt.Equals, *nn[0].BrowseToURL)
 	}
 
@@ -442,7 +442,7 @@ func TestStateMachine(t *testing.T) {
 		// This time, backend should emit it to the UI right away,
 		// because the UI is anxiously awaiting a new URL to visit.
 		nn := notifies.drain(1)
-		c.Assert(nn[0].BrowseToURL, qt.Not(qt.IsNil))
+		c.Assert(nn[0].BrowseToURL, qt.IsNotNil)
 		c.Assert(url2, qt.Equals, *nn[0].BrowseToURL)
 	}
 
@@ -466,9 +466,9 @@ func TestStateMachine(t *testing.T) {
 		// TODO: (Currently this test doesn't detect that bug, but
 		// it's visible in the logs)
 		c.Assert([]string{"unpause", "unpause", "unpause"}, qt.DeepEquals, cc.getCalls())
-		c.Assert(nn[0].LoginFinished, qt.Not(qt.IsNil))
-		c.Assert(nn[1].Prefs, qt.Not(qt.IsNil))
-		c.Assert(nn[2].State, qt.Not(qt.IsNil))
+		c.Assert(nn[0].LoginFinished, qt.IsNotNil)
+		c.Assert(nn[1].Prefs, qt.IsNotNil)
+		c.Assert(nn[2].State, qt.IsNotNil)
 		c.Assert(nn[1].Prefs.Persist.LoginName, qt.Equals, "user1")
 		c.Assert(ipn.NeedsMachineAuth, qt.Equals, *nn[2].State)
 	}
@@ -488,7 +488,7 @@ func TestStateMachine(t *testing.T) {
 	{
 		nn := notifies.drain(1)
 		c.Assert([]string{"unpause", "unpause", "unpause"}, qt.DeepEquals, cc.getCalls())
-		c.Assert(nn[0].State, qt.Not(qt.IsNil))
+		c.Assert(nn[0].State, qt.IsNotNil)
 		c.Assert(ipn.Starting, qt.Equals, *nn[0].State)
 	}
 
@@ -512,8 +512,8 @@ func TestStateMachine(t *testing.T) {
 		nn := notifies.drain(2)
 		c.Assert([]string{"pause"}, qt.DeepEquals, cc.getCalls())
 		// BUG: I would expect Prefs to change first, and state after.
-		c.Assert(nn[0].State, qt.Not(qt.IsNil))
-		c.Assert(nn[1].Prefs, qt.Not(qt.IsNil))
+		c.Assert(nn[0].State, qt.IsNotNil)
+		c.Assert(nn[1].Prefs, qt.IsNotNil)
 		c.Assert(ipn.Stopped, qt.Equals, *nn[0].State)
 	}
 
@@ -530,8 +530,8 @@ func TestStateMachine(t *testing.T) {
 		// BUG: Login isn't needed here. We never logged out.
 		c.Assert([]string{"Login", "unpause", "unpause"}, qt.DeepEquals, cc.getCalls())
 		// BUG: I would expect Prefs to change first, and state after.
-		c.Assert(nn[0].State, qt.Not(qt.IsNil))
-		c.Assert(nn[1].Prefs, qt.Not(qt.IsNil))
+		c.Assert(nn[0].State, qt.IsNotNil)
+		c.Assert(nn[1].Prefs, qt.IsNotNil)
 		c.Assert(ipn.Starting, qt.Equals, *nn[0].State)
 		c.Assert(store.sawWrite(), qt.IsTrue)
 	}
@@ -549,10 +549,10 @@ func TestStateMachine(t *testing.T) {
 	{
 		nn := notifies.drain(1)
 		c.Assert(cc.getCalls(), qt.HasLen, 0)
-		c.Assert(nn[0].State, qt.Not(qt.IsNil))
-		c.Assert(nn[0].LoginFinished, qt.Not(qt.IsNil))
-		c.Assert(nn[0].NetMap, qt.Not(qt.IsNil))
-		c.Assert(nn[0].Prefs, qt.Not(qt.IsNil))
+		c.Assert(nn[0].State, qt.IsNotNil)
+		c.Assert(nn[0].LoginFinished, qt.IsNotNil)
+		c.Assert(nn[0].NetMap, qt.IsNotNil)
+		c.Assert(nn[0].Prefs, qt.IsNotNil)
 	}
 
 	// undo the state hack above.
@@ -566,8 +566,8 @@ func TestStateMachine(t *testing.T) {
 	{
 		nn := notifies.drain(2)
 		c.Assert([]string{"pause", "StartLogout", "pause"}, qt.DeepEquals, cc.getCalls())
-		c.Assert(nn[0].State, qt.Not(qt.IsNil))
-		c.Assert(nn[1].Prefs, qt.Not(qt.IsNil))
+		c.Assert(nn[0].State, qt.IsNotNil)
+		c.Assert(nn[1].Prefs, qt.IsNotNil)
 		c.Assert(ipn.Stopped, qt.Equals, *nn[0].State)
 		c.Assert(nn[1].Prefs.LoggedOut, qt.IsTrue)
 		c.Assert(nn[1].Prefs.WantRunning, qt.IsFalse)
@@ -583,7 +583,7 @@ func TestStateMachine(t *testing.T) {
 	{
 		nn := notifies.drain(1)
 		c.Assert([]string{"unpause", "unpause"}, qt.DeepEquals, cc.getCalls())
-		c.Assert(nn[0].State, qt.Not(qt.IsNil))
+		c.Assert(nn[0].State, qt.IsNotNil)
 		c.Assert(ipn.NeedsLogin, qt.Equals, *nn[0].State)
 		c.Assert(b.Prefs().LoggedOut, qt.IsTrue)
 		c.Assert(b.Prefs().WantRunning, qt.IsFalse)
@@ -674,8 +674,8 @@ func TestStateMachine(t *testing.T) {
 
 		nn := notifies.drain(2)
 		c.Assert(cc.getCalls(), qt.HasLen, 0)
-		c.Assert(nn[0].Prefs, qt.Not(qt.IsNil))
-		c.Assert(nn[1].State, qt.Not(qt.IsNil))
+		c.Assert(nn[0].Prefs, qt.IsNotNil)
+		c.Assert(nn[1].State, qt.IsNotNil)
 		c.Assert(nn[0].Prefs.LoggedOut, qt.IsTrue)
 		c.Assert(nn[0].Prefs.WantRunning, qt.IsFalse)
 		c.Assert(ipn.NeedsLogin, qt.Equals, *nn[1].State)
@@ -696,9 +696,9 @@ func TestStateMachine(t *testing.T) {
 	{
 		nn := notifies.drain(3)
 		c.Assert([]string{"unpause", "unpause"}, qt.DeepEquals, cc.getCalls())
-		c.Assert(nn[0].LoginFinished, qt.Not(qt.IsNil))
-		c.Assert(nn[1].Prefs, qt.Not(qt.IsNil))
-		c.Assert(nn[2].State, qt.Not(qt.IsNil))
+		c.Assert(nn[0].LoginFinished, qt.IsNotNil)
+		c.Assert(nn[1].Prefs, qt.IsNotNil)
+		c.Assert(nn[2].State, qt.IsNotNil)
 		// Prefs after finishing the login, so LoginName updated.
 		c.Assert(nn[1].Prefs.Persist.LoginName, qt.Equals, "user2")
 		c.Assert(nn[1].Prefs.LoggedOut, qt.IsFalse)
@@ -717,8 +717,8 @@ func TestStateMachine(t *testing.T) {
 		nn := notifies.drain(2)
 		c.Assert([]string{"pause"}, qt.DeepEquals, cc.getCalls())
 		// BUG: I would expect Prefs to change first, and state after.
-		c.Assert(nn[0].State, qt.Not(qt.IsNil))
-		c.Assert(nn[1].Prefs, qt.Not(qt.IsNil))
+		c.Assert(nn[0].State, qt.IsNotNil)
+		c.Assert(nn[1].Prefs, qt.IsNotNil)
 		c.Assert(ipn.Stopped, qt.Equals, *nn[0].State)
 		c.Assert(nn[1].Prefs.LoggedOut, qt.IsFalse)
 	}
@@ -737,8 +737,8 @@ func TestStateMachine(t *testing.T) {
 		nn := notifies.drain(2)
 		c.Assert([]string{"Shutdown", "unpause", "New", "Login", "unpause"}, qt.DeepEquals, cc.getCalls())
 		c.Assert(cc.getCalls(), qt.HasLen, 0)
-		c.Assert(nn[0].Prefs, qt.Not(qt.IsNil))
-		c.Assert(nn[1].State, qt.Not(qt.IsNil))
+		c.Assert(nn[0].Prefs, qt.IsNotNil)
+		c.Assert(nn[1].State, qt.IsNotNil)
 		c.Assert(nn[0].Prefs.WantRunning, qt.IsFalse)
 		c.Assert(nn[0].Prefs.LoggedOut, qt.IsFalse)
 		c.Assert(ipn.Stopped, qt.Equals, *nn[1].State)
@@ -775,8 +775,8 @@ func TestStateMachine(t *testing.T) {
 		nn := notifies.drain(2)
 		c.Assert([]string{"Login", "unpause"}, qt.DeepEquals, cc.getCalls())
 		// BUG: I would expect Prefs to change first, and state after.
-		c.Assert(nn[0].State, qt.Not(qt.IsNil))
-		c.Assert(nn[1].Prefs, qt.Not(qt.IsNil))
+		c.Assert(nn[0].State, qt.IsNotNil)
+		c.Assert(nn[1].Prefs, qt.IsNotNil)
 		c.Assert(ipn.Starting, qt.Equals, *nn[0].State)
 	}
 
@@ -791,8 +791,8 @@ func TestStateMachine(t *testing.T) {
 		nn := notifies.drain(2)
 		c.Assert([]string{"pause"}, qt.DeepEquals, cc.getCalls())
 		// BUG: I would expect Prefs to change first, and state after.
-		c.Assert(nn[0].State, qt.Not(qt.IsNil))
-		c.Assert(nn[1].Prefs, qt.Not(qt.IsNil))
+		c.Assert(nn[0].State, qt.IsNotNil)
+		c.Assert(nn[1].Prefs, qt.IsNotNil)
 		c.Assert(ipn.Stopped, qt.Equals, *nn[0].State)
 	}
 
@@ -813,7 +813,7 @@ func TestStateMachine(t *testing.T) {
 		// Because the login hasn't yet completed, the old login
 		// is still valid, so it's correct that we stay paused.
 		c.Assert([]string{"Login", "pause"}, qt.DeepEquals, cc.getCalls())
-		c.Assert(nn[0].BrowseToURL, qt.Not(qt.IsNil))
+		c.Assert(nn[0].BrowseToURL, qt.IsNotNil)
 		c.Assert(*nn[0].BrowseToURL, qt.Equals, url3)
 	}
 
@@ -835,9 +835,9 @@ func TestStateMachine(t *testing.T) {
 		//  new login, WantRunning is true, so there was never a
 		//  reason to pause().
 		c.Assert([]string{"pause", "unpause"}, qt.DeepEquals, cc.getCalls())
-		c.Assert(nn[0].LoginFinished, qt.Not(qt.IsNil))
-		c.Assert(nn[1].Prefs, qt.Not(qt.IsNil))
-		c.Assert(nn[2].State, qt.Not(qt.IsNil))
+		c.Assert(nn[0].LoginFinished, qt.IsNotNil)
+		c.Assert(nn[1].Prefs, qt.IsNotNil)
+		c.Assert(nn[2].State, qt.IsNotNil)
 		// Prefs after finishing the login, so LoginName updated.
 		c.Assert(nn[1].Prefs.Persist.LoginName, qt.Equals, "user3")
 		c.Assert(nn[1].Prefs.LoggedOut, qt.IsFalse)
@@ -857,7 +857,7 @@ func TestStateMachine(t *testing.T) {
 
 		nn := notifies.drain(1)
 		c.Assert(cc.getCalls(), qt.HasLen, 0)
-		c.Assert(nn[0].Prefs, qt.Not(qt.IsNil))
+		c.Assert(nn[0].Prefs, qt.IsNotNil)
 		c.Assert(nn[0].Prefs.LoggedOut, qt.IsFalse)
 		c.Assert(nn[0].Prefs.WantRunning, qt.IsTrue)
 		c.Assert(ipn.NoState, qt.Equals, b.State())
@@ -875,7 +875,7 @@ func TestStateMachine(t *testing.T) {
 		c.Assert([]string{"unpause", "unpause"}, qt.DeepEquals, cc.getCalls())
 		// NOTE: No LoginFinished message since no interactive
 		// login was needed.
-		c.Assert(nn[0].State, qt.Not(qt.IsNil))
+		c.Assert(nn[0].State, qt.IsNotNil)
 		c.Assert(ipn.Starting, qt.Equals, *nn[0].State)
 		// NOTE: No prefs change this time. WantRunning stays true.
 		// We were in Starting in the first place, so that doesn't

--- a/ipn/ipnserver/server_test.go
+++ b/ipn/ipnserver/server_test.go
@@ -60,7 +60,7 @@ func TestRunMultipleAccepts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer eng.Close()
+	t.Cleanup(eng.Close)
 
 	opts := ipnserver.Options{
 		SocketPath: socketPath,

--- a/wgengine/userspace_test.go
+++ b/wgengine/userspace_test.go
@@ -89,7 +89,7 @@ func TestUserspaceEngineReconfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer e.Close()
+	t.Cleanup(e.Close)
 	ue := e.(*userspaceEngine)
 
 	routerCfg := &router.Config{}
@@ -158,7 +158,7 @@ func TestUserspaceEnginePortReconfig(t *testing.T) {
 	if ue == nil {
 		t.Fatal("could not create a wgengine with a specific port")
 	}
-	defer ue.Close()
+	t.Cleanup(ue.Close)
 
 	startingPort := ue.magicConn.LocalPort()
 	nodeKey := nkFromHex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")

--- a/wgengine/watchdog_test.go
+++ b/wgengine/watchdog_test.go
@@ -48,6 +48,7 @@ func TestWatchdog(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		t.Cleanup(e.Close)
 		usEngine := e.(*userspaceEngine)
 		e = NewWatchdog(e)
 		wdEngine := e.(*watchdogEngine)


### PR DESCRIPTION
- all: close fake userspace engines when tests complete
- ipn/ipnlocal: add failing test
- control/controlclient: replace TODO with explanation
- ipn/ipnlocal: only call UpdateEndpoints when the endpoints change
- ipn/ipnlocal: use a switch statement instead of an else-if chain
- ipn/ipnlocal: inline LocalBackend.getEngineStatus
- ipn/ipnlocal: add LocalBackend.broadcastStatusChanged
