### PR TITLE
ipn/ipnlocal: minor cleanup

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -871,7 +871,7 @@ func (b *LocalBackend) Start(opts ipn.Options) error {
 		LinkMonitor:          b.e.GetLinkMonitor(),
 		Pinger:               b.e,
 
-		// Don't warn about broken Linux IP forwading when
+		// Don't warn about broken Linux IP forwarding when
 		// netstack is being used.
 		SkipIPForwardingCheck: isNetstack,
 	})

--- a/ipn/ipnlocal/state_test.go
+++ b/ipn/ipnlocal/state_test.go
@@ -645,16 +645,6 @@ func TestStateMachine(t *testing.T) {
 		c.Assert(ipn.NeedsLogin, qt.Equals, b.State())
 	}
 
-	// Shut down the backend.
-	t.Logf("\n\nShutdown")
-	notifies.expect(0)
-	b.Shutdown()
-	{
-		notifies.drain(0)
-		// BUG: I expect a transition to ipn.NoState here.
-		cc.assertCalls("Shutdown")
-	}
-
 	// Oh, you thought we were done? Ha! Now we have to test what
 	// happens if the user exits and restarts while logged out.
 	// Note that it's explicitly okay to call b.Start() over and over
@@ -694,7 +684,7 @@ func TestStateMachine(t *testing.T) {
 	})
 	{
 		nn := notifies.drain(3)
-		cc.assertCalls("unpause", "unpause")
+		cc.assertCalls("unpause", "unpause", "unpause")
 		c.Assert(nn[0].LoginFinished, qt.IsNotNil)
 		c.Assert(nn[1].Prefs, qt.IsNotNil)
 		c.Assert(nn[2].State, qt.IsNotNil)
@@ -771,7 +761,7 @@ func TestStateMachine(t *testing.T) {
 	})
 	{
 		nn := notifies.drain(2)
-		cc.assertCalls("Login", "unpause")
+		cc.assertCalls("Login", "unpause", "unpause")
 		// BUG: I would expect Prefs to change first, and state after.
 		c.Assert(nn[0].State, qt.IsNotNil)
 		c.Assert(nn[1].Prefs, qt.IsNotNil)
@@ -810,7 +800,7 @@ func TestStateMachine(t *testing.T) {
 		//
 		// Because the login hasn't yet completed, the old login
 		// is still valid, so it's correct that we stay paused.
-		cc.assertCalls("Login", "pause")
+		cc.assertCalls("Login", "pause", "pause")
 		c.Assert(nn[0].BrowseToURL, qt.IsNotNil)
 		c.Assert(*nn[0].BrowseToURL, qt.Equals, url3)
 	}
@@ -832,7 +822,7 @@ func TestStateMachine(t *testing.T) {
 		//  and !WantRunning. But since it's a fresh and successful
 		//  new login, WantRunning is true, so there was never a
 		//  reason to pause().
-		cc.assertCalls("pause", "unpause")
+		cc.assertCalls("pause", "unpause", "unpause")
 		c.Assert(nn[0].LoginFinished, qt.IsNotNil)
 		c.Assert(nn[1].Prefs, qt.IsNotNil)
 		c.Assert(nn[2].State, qt.IsNotNil)
@@ -870,7 +860,7 @@ func TestStateMachine(t *testing.T) {
 	})
 	{
 		nn := notifies.drain(1)
-		cc.assertCalls("unpause", "unpause")
+		cc.assertCalls("unpause", "unpause", "unpause")
 		// NOTE: No LoginFinished message since no interactive
 		// login was needed.
 		c.Assert(nn[0].State, qt.IsNotNil)

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -42,6 +42,7 @@ import (
 	"tailscale.com/types/nettype"
 	"tailscale.com/types/wgkey"
 	"tailscale.com/util/cibuild"
+	"tailscale.com/util/racebuild"
 	"tailscale.com/wgengine/filter"
 	"tailscale.com/wgengine/wgcfg"
 	"tailscale.com/wgengine/wgcfg/nmcfg"
@@ -1261,6 +1262,9 @@ func TestGoMajorVersion(t *testing.T) {
 }
 
 func TestReceiveFromAllocs(t *testing.T) {
+	if racebuild.On {
+		t.Skip("alloc tests are unreliable with -race")
+	}
 	// Go 1.16 and before: allow 3 allocs.
 	// Go Tailscale fork, Go 1.17+: only allow 2 allocs.
 	major, ts := goMajorVersion(runtime.Version())


### PR DESCRIPTION
- ipn/ipnlocal: reduce line noise in tests
- ipn/ipnlocal: fix minor typo in comment
- ipn/ipnlocal: do not shut down the backend halfway through TestStateMachine
- wgengine/magicsock: skip alloc test with -race
