### PR TITLE
ipnlocal: fix sync.Cond-related test flakiness

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -601,12 +601,18 @@ func (b *LocalBackend) findExitNodeIDLocked(nm *netmap.NetworkMap) (prefsChanged
 func (b *LocalBackend) setWgengineStatus(s *wgengine.Status, err error) {
 	if err != nil {
 		b.logf("wgengine status error: %v", err)
+
+		b.statusLock.Lock()
 		b.statusChanged.Broadcast()
+		b.statusLock.Unlock()
 		return
 	}
 	if s == nil {
 		b.logf("[unexpected] non-error wgengine update with status=nil: %v", s)
+
+		b.statusLock.Lock()
 		b.statusChanged.Broadcast()
+		b.statusLock.Unlock()
 		return
 	}
 
@@ -626,7 +632,11 @@ func (b *LocalBackend) setWgengineStatus(s *wgengine.Status, err error) {
 		}
 		b.stateMachine()
 	}
+
+	b.statusLock.Lock()
 	b.statusChanged.Broadcast()
+	b.statusLock.Unlock()
+
 	b.send(ipn.Notify{Engine: &es})
 }
 


### PR DESCRIPTION
- Revert "ipn/ipnlocal: remove locks around sync.Cond.Broadcast call"
- ipn/ipnlocal: add LocalBackend.broadcastStatusChanged
