### PR TITLE
util/codegen, cmd/cloner: organize and simplify cloner

### DIFF
--- a/cmd/cloner/cloner.go
+++ b/cmd/cloner/cloner.go
@@ -18,15 +18,14 @@ import (
 	"flag"
 	"fmt"
 	"go/ast"
-	"go/format"
 	"go/token"
 	"go/types"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
 
 	"golang.org/x/tools/go/packages"
+	"tailscale.com/util/codegen"
 )
 
 var (
@@ -130,17 +129,12 @@ func main() {
 	fmt.Fprintf(contents, ")\n\n")
 	contents.Write(buf.Bytes())
 
-	out, err := format.Source(contents.Bytes())
-	if err != nil {
-		log.Fatalf("%s, in source:\n%s", err, contents.Bytes())
-	}
-
 	output := *flagOutput
 	if output == "" {
 		flag.Usage()
 		os.Exit(2)
 	}
-	if err := ioutil.WriteFile(output, out, 0644); err != nil {
+	if err := codegen.WriteFormatted(contents.Bytes(), output); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/cloner/cloner.go
+++ b/cmd/cloner/cloner.go
@@ -85,7 +85,7 @@ func main() {
 						continue
 					}
 					pkg := typeNameObj.Pkg()
-					gen(buf, imports, typeName, typ, pkg)
+					gen(buf, imports, typ, pkg)
 					found = true
 				}
 			}
@@ -150,7 +150,7 @@ package %s
 
 `
 
-func gen(buf *bytes.Buffer, imports map[string]struct{}, name string, typ *types.Named, thisPkg *types.Package) {
+func gen(buf *bytes.Buffer, imports map[string]struct{}, typ *types.Named, thisPkg *types.Package) {
 	pkgQual := func(pkg *types.Package) string {
 		if thisPkg == pkg {
 			return ""
@@ -162,89 +162,91 @@ func gen(buf *bytes.Buffer, imports map[string]struct{}, name string, typ *types
 		return types.TypeString(t, pkgQual)
 	}
 
-	switch t := typ.Underlying().(type) {
-	case *types.Struct:
-		name := typ.Obj().Name()
-		fmt.Fprintf(buf, "// Clone makes a deep copy of %s.\n", name)
-		fmt.Fprintf(buf, "// The result aliases no memory with the original.\n")
-		fmt.Fprintf(buf, "func (src *%s) Clone() *%s {\n", name, name)
-		writef := func(format string, args ...interface{}) {
-			fmt.Fprintf(buf, "\t"+format+"\n", args...)
-		}
-		writef("if src == nil {")
-		writef("\treturn nil")
-		writef("}")
-		writef("dst := new(%s)", name)
-		writef("*dst = *src")
-		for i := 0; i < t.NumFields(); i++ {
-			fname := t.Field(i).Name()
-			ft := t.Field(i).Type()
-			if !containsPointers(ft) {
-				continue
-			}
-			if named, _ := ft.(*types.Named); named != nil && !hasBasicUnderlying(ft) {
-				writef("dst.%s = *src.%s.Clone()", fname, fname)
-				continue
-			}
-			switch ft := ft.Underlying().(type) {
-			case *types.Slice:
-				if containsPointers(ft.Elem()) {
-					n := importedName(ft.Elem())
-					writef("dst.%s = make([]%s, len(src.%s))", fname, n, fname)
-					writef("for i := range dst.%s {", fname)
-					if _, isPtr := ft.Elem().(*types.Pointer); isPtr {
-						writef("\tdst.%s[i] = src.%s[i].Clone()", fname, fname)
-					} else {
-						writef("\tdst.%s[i] = *src.%s[i].Clone()", fname, fname)
-					}
-					writef("}")
-				} else {
-					writef("dst.%s = append(src.%s[:0:0], src.%s...)", fname, fname, fname)
-				}
-			case *types.Pointer:
-				if named, _ := ft.Elem().(*types.Named); named != nil && containsPointers(ft.Elem()) {
-					writef("dst.%s = src.%s.Clone()", fname, fname)
-					continue
-				}
-				n := importedName(ft.Elem())
-				writef("if dst.%s != nil {", fname)
-				writef("\tdst.%s = new(%s)", fname, n)
-				writef("\t*dst.%s = *src.%s", fname, fname)
-				if containsPointers(ft.Elem()) {
-					writef("\t" + `panic("TODO pointers in pointers")`)
-				}
-				writef("}")
-			case *types.Map:
-				writef("if dst.%s != nil {", fname)
-				writef("\tdst.%s = map[%s]%s{}", fname, importedName(ft.Key()), importedName(ft.Elem()))
-				if sliceType, isSlice := ft.Elem().(*types.Slice); isSlice {
-					n := importedName(sliceType.Elem())
-					writef("\tfor k := range src.%s {", fname)
-					// use zero-length slice instead of nil to ensure
-					// the key is always copied.
-					writef("\t\tdst.%s[k] = append([]%s{}, src.%s[k]...)", fname, n, fname)
-					writef("\t}")
-				} else if containsPointers(ft.Elem()) {
-					writef("\tfor k, v := range src.%s {", fname)
-					writef("\t\tdst.%s[k] = v.Clone()", fname)
-					writef("\t}")
-				} else {
-					writef("\tfor k, v := range src.%s {", fname)
-					writef("\t\tdst.%s[k] = v", fname)
-					writef("\t}")
-				}
-				writef("}")
-			case *types.Struct:
-				writef(`panic("TODO struct %s")`, fname)
-			default:
-				writef(`panic(fmt.Sprintf("TODO: %T", ft))`)
-			}
-		}
-		writef("return dst")
-		fmt.Fprintf(buf, "}\n\n")
-
-		buf.Write(codegen.AssertStructUnchanged(t, name, "Clone", thisPkg, imports))
+	t, ok := typ.Underlying().(*types.Struct)
+	if !ok {
+		return
 	}
+
+	name := typ.Obj().Name()
+	fmt.Fprintf(buf, "// Clone makes a deep copy of %s.\n", name)
+	fmt.Fprintf(buf, "// The result aliases no memory with the original.\n")
+	fmt.Fprintf(buf, "func (src *%s) Clone() *%s {\n", name, name)
+	writef := func(format string, args ...interface{}) {
+		fmt.Fprintf(buf, "\t"+format+"\n", args...)
+	}
+	writef("if src == nil {")
+	writef("\treturn nil")
+	writef("}")
+	writef("dst := new(%s)", name)
+	writef("*dst = *src")
+	for i := 0; i < t.NumFields(); i++ {
+		fname := t.Field(i).Name()
+		ft := t.Field(i).Type()
+		if !containsPointers(ft) {
+			continue
+		}
+		if named, _ := ft.(*types.Named); named != nil && !hasBasicUnderlying(ft) {
+			writef("dst.%s = *src.%s.Clone()", fname, fname)
+			continue
+		}
+		switch ft := ft.Underlying().(type) {
+		case *types.Slice:
+			if containsPointers(ft.Elem()) {
+				n := importedName(ft.Elem())
+				writef("dst.%s = make([]%s, len(src.%s))", fname, n, fname)
+				writef("for i := range dst.%s {", fname)
+				if _, isPtr := ft.Elem().(*types.Pointer); isPtr {
+					writef("\tdst.%s[i] = src.%s[i].Clone()", fname, fname)
+				} else {
+					writef("\tdst.%s[i] = *src.%s[i].Clone()", fname, fname)
+				}
+				writef("}")
+			} else {
+				writef("dst.%s = append(src.%s[:0:0], src.%s...)", fname, fname, fname)
+			}
+		case *types.Pointer:
+			if named, _ := ft.Elem().(*types.Named); named != nil && containsPointers(ft.Elem()) {
+				writef("dst.%s = src.%s.Clone()", fname, fname)
+				continue
+			}
+			n := importedName(ft.Elem())
+			writef("if dst.%s != nil {", fname)
+			writef("\tdst.%s = new(%s)", fname, n)
+			writef("\t*dst.%s = *src.%s", fname, fname)
+			if containsPointers(ft.Elem()) {
+				writef("\t" + `panic("TODO pointers in pointers")`)
+			}
+			writef("}")
+		case *types.Map:
+			writef("if dst.%s != nil {", fname)
+			writef("\tdst.%s = map[%s]%s{}", fname, importedName(ft.Key()), importedName(ft.Elem()))
+			if sliceType, isSlice := ft.Elem().(*types.Slice); isSlice {
+				n := importedName(sliceType.Elem())
+				writef("\tfor k := range src.%s {", fname)
+				// use zero-length slice instead of nil to ensure
+				// the key is always copied.
+				writef("\t\tdst.%s[k] = append([]%s{}, src.%s[k]...)", fname, n, fname)
+				writef("\t}")
+			} else if containsPointers(ft.Elem()) {
+				writef("\tfor k, v := range src.%s {", fname)
+				writef("\t\tdst.%s[k] = v.Clone()", fname)
+				writef("\t}")
+			} else {
+				writef("\tfor k, v := range src.%s {", fname)
+				writef("\t\tdst.%s[k] = v", fname)
+				writef("\t}")
+			}
+			writef("}")
+		case *types.Struct:
+			writef(`panic("TODO struct %s")`, fname)
+		default:
+			writef(`panic(fmt.Sprintf("TODO: %T", ft))`)
+		}
+	}
+	writef("return dst")
+	fmt.Fprintf(buf, "}\n\n")
+
+	buf.Write(codegen.AssertStructUnchanged(t, name, "Clone", thisPkg, imports))
 }
 
 func hasBasicUnderlying(typ types.Type) bool {

--- a/cmd/cloner/cloner.go
+++ b/cmd/cloner/cloner.go
@@ -218,7 +218,7 @@ func gen(buf *bytes.Buffer, imports map[string]struct{}, typ *types.Named, thisP
 	writef("return dst")
 	fmt.Fprintf(buf, "}\n\n")
 
-	buf.Write(codegen.AssertStructUnchanged(t, name, "Clone", thisPkg, imports))
+	buf.Write(codegen.AssertStructUnchanged(t, thisPkg, name, "Clone", imports))
 }
 
 func hasBasicUnderlying(typ types.Type) bool {

--- a/cmd/cloner/cloner.go
+++ b/cmd/cloner/cloner.go
@@ -211,10 +211,8 @@ func gen(buf *bytes.Buffer, imports map[string]struct{}, typ *types.Named, thisP
 				writef("\t}")
 			}
 			writef("}")
-		case *types.Struct:
-			writef(`panic("TODO struct %s")`, fname)
 		default:
-			writef(`panic(fmt.Sprintf("TODO: %T", ft))`)
+			writef(`panic("TODO: %s (%T)")`, fname, ft)
 		}
 	}
 	writef("return dst")

--- a/cmd/cloner/cloner.go
+++ b/cmd/cloner/cloner.go
@@ -243,7 +243,7 @@ func gen(buf *bytes.Buffer, imports map[string]struct{}, name string, typ *types
 		writef("return dst")
 		fmt.Fprintf(buf, "}\n\n")
 
-		buf.Write(codegen.AssertStructUnchanged(t, name, "", thisPkg, imports))
+		buf.Write(codegen.AssertStructUnchanged(t, name, "Clone", thisPkg, imports))
 	}
 }
 

--- a/cmd/cloner/cloner.go
+++ b/cmd/cloner/cloner.go
@@ -65,10 +65,6 @@ func main() {
 	for _, typeName := range typeNames {
 		found := false
 		for _, file := range pkg.Syntax {
-			//var fbuf bytes.Buffer
-			//ast.Fprint(&fbuf, pkg.Fset, file, nil)
-			//fmt.Println(fbuf.String())
-
 			for _, d := range file.Decls {
 				decl, ok := d.(*ast.GenDecl)
 				if !ok || decl.Tok != token.TYPE {

--- a/ipn/prefs_clone.go
+++ b/ipn/prefs_clone.go
@@ -32,7 +32,7 @@ func (src *Prefs) Clone() *Prefs {
 }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
-var _PrefsNeedsRegeneration = Prefs(struct {
+var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	ControlURL             string
 	RouteAll               bool
 	AllowSingleHosts       bool

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -29,7 +29,7 @@ func (src *User) Clone() *User {
 }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
-var _UserNeedsRegeneration = User(struct {
+var _UserCloneNeedsRegeneration = User(struct {
 	ID            UserID
 	LoginName     string
 	DisplayName   string
@@ -65,7 +65,7 @@ func (src *Node) Clone() *Node {
 }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
-var _NodeNeedsRegeneration = Node(struct {
+var _NodeCloneNeedsRegeneration = Node(struct {
 	ID                      NodeID
 	StableID                StableNodeID
 	Name                    string
@@ -108,7 +108,7 @@ func (src *Hostinfo) Clone() *Hostinfo {
 }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
-var _HostinfoNeedsRegeneration = Hostinfo(struct {
+var _HostinfoCloneNeedsRegeneration = Hostinfo(struct {
 	IPNVersion    string
 	FrontendLogID string
 	BackendLogID  string
@@ -144,7 +144,7 @@ func (src *NetInfo) Clone() *NetInfo {
 }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
-var _NetInfoNeedsRegeneration = NetInfo(struct {
+var _NetInfoCloneNeedsRegeneration = NetInfo(struct {
 	MappingVariesByDestIP opt.Bool
 	HairPinning           opt.Bool
 	WorkingIPv6           opt.Bool
@@ -170,7 +170,7 @@ func (src *Login) Clone() *Login {
 }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
-var _LoginNeedsRegeneration = Login(struct {
+var _LoginCloneNeedsRegeneration = Login(struct {
 	_             structs.Incomparable
 	ID            LoginID
 	Provider      string
@@ -210,7 +210,7 @@ func (src *DNSConfig) Clone() *DNSConfig {
 }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
-var _DNSConfigNeedsRegeneration = DNSConfig(struct {
+var _DNSConfigCloneNeedsRegeneration = DNSConfig(struct {
 	Resolvers         []dnstype.Resolver
 	Routes            map[string][]dnstype.Resolver
 	FallbackResolvers []dnstype.Resolver
@@ -235,7 +235,7 @@ func (src *RegisterResponse) Clone() *RegisterResponse {
 }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
-var _RegisterResponseNeedsRegeneration = RegisterResponse(struct {
+var _RegisterResponseCloneNeedsRegeneration = RegisterResponse(struct {
 	User              User
 	Login             Login
 	NodeKeyExpired    bool
@@ -259,7 +259,7 @@ func (src *DERPRegion) Clone() *DERPRegion {
 }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
-var _DERPRegionNeedsRegeneration = DERPRegion(struct {
+var _DERPRegionCloneNeedsRegeneration = DERPRegion(struct {
 	RegionID   int
 	RegionCode string
 	RegionName string
@@ -285,7 +285,7 @@ func (src *DERPMap) Clone() *DERPMap {
 }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
-var _DERPMapNeedsRegeneration = DERPMap(struct {
+var _DERPMapCloneNeedsRegeneration = DERPMap(struct {
 	Regions            map[int]*DERPRegion
 	OmitDefaultRegions bool
 }{})
@@ -302,7 +302,7 @@ func (src *DERPNode) Clone() *DERPNode {
 }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
-var _DERPNodeNeedsRegeneration = DERPNode(struct {
+var _DERPNodeCloneNeedsRegeneration = DERPNode(struct {
 	Name             string
 	RegionID         int
 	HostName         string

--- a/types/dnstype/dnstype_clone.go
+++ b/types/dnstype/dnstype_clone.go
@@ -24,7 +24,7 @@ func (src *Resolver) Clone() *Resolver {
 }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
-var _ResolverNeedsRegeneration = Resolver(struct {
+var _ResolverCloneNeedsRegeneration = Resolver(struct {
 	Addr                string
 	BootstrapResolution []netaddr.IP
 }{})

--- a/types/persist/persist_clone.go
+++ b/types/persist/persist_clone.go
@@ -25,7 +25,7 @@ func (src *Persist) Clone() *Persist {
 }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
-var _PersistNeedsRegeneration = Persist(struct {
+var _PersistCloneNeedsRegeneration = Persist(struct {
 	_                               structs.Incomparable
 	LegacyFrontendPrivateMachineKey key.MachinePrivate
 	PrivateNodeKey                  wgkey.Private

--- a/util/codegen/codegen.go
+++ b/util/codegen/codegen.go
@@ -72,12 +72,12 @@ func NamedTypes(pkg *packages.Package) map[string]*types.Named {
 }
 
 // AssertStructUnchanged generates code that asserts at compile time that type t is unchanged.
+// thisPkg is the package containing t.
 // tname is the named type corresponding to t.
 // ctx is a single-word context for this assertion, such as "Clone".
-// thisPkg is the package containing t.
 // If non-nil, AssertStructUnchanged will add elements to imports
 // for each package path that the caller must import for the returned code to compile.
-func AssertStructUnchanged(t *types.Struct, tname, ctx string, thisPkg *types.Package, imports map[string]struct{}) []byte {
+func AssertStructUnchanged(t *types.Struct, thisPkg *types.Package, tname, ctx string, imports map[string]struct{}) []byte {
 	buf := new(bytes.Buffer)
 	w := func(format string, args ...interface{}) {
 		fmt.Fprintf(buf, format+"\n", args...)

--- a/util/codegen/codegen.go
+++ b/util/codegen/codegen.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package codegen contains shared utilities for generating code.
+package codegen
+
+import (
+	"fmt"
+	"go/format"
+	"os"
+)
+
+// WriteFormatted writes code to path.
+// It runs gofmt on it before writing;
+// if gofmt fails, it writes code unchanged.
+// Errors can include I/O errors and gofmt errors.
+//
+// The advantage of always writing code to path,
+// even if gofmt fails, is that it makes debugging easier.
+// The code can be long, but you need it in order to debug.
+// It is nicer to work with it in a file than a terminal.
+// It is also easier to interpret gofmt errors
+// with an editor providing file and line numbers.
+func WriteFormatted(code []byte, path string) error {
+	out, fmterr := format.Source(code)
+	if fmterr != nil {
+		out = code
+	}
+	ioerr := os.WriteFile(path, out, 0644)
+	// Prefer I/O errors. They're usually easier to fix,
+	// and until they're fixed you can't do much else.
+	if ioerr != nil {
+		return ioerr
+	}
+	if fmterr != nil {
+		return fmt.Errorf("%s:%v", path, fmterr)
+	}
+	return nil
+}

--- a/util/codegen/codegen.go
+++ b/util/codegen/codegen.go
@@ -6,8 +6,10 @@
 package codegen
 
 import (
+	"bytes"
 	"fmt"
 	"go/format"
+	"go/types"
 	"os"
 )
 
@@ -37,4 +39,43 @@ func WriteFormatted(code []byte, path string) error {
 		return fmt.Errorf("%s:%v", path, fmterr)
 	}
 	return nil
+}
+
+// AssertStructUnchanged generates code that asserts at compile time that type t is unchanged.
+// tname is the named type corresponding to t.
+// ctx is a single-word context for this assertion, such as "Clone".
+// thisPkg is the package containing t.
+// If non-nil, AssertStructUnchanged will add elements to imports
+// for each package path that the caller must import for the returned code to compile.
+func AssertStructUnchanged(t *types.Struct, tname, ctx string, thisPkg *types.Package, imports map[string]struct{}) []byte {
+	buf := new(bytes.Buffer)
+	w := func(format string, args ...interface{}) {
+		fmt.Fprintf(buf, format+"\n", args...)
+	}
+	w("// A compilation failure here means this code must be regenerated, with the command at the top of this file.")
+	w("var _%s%sNeedsRegeneration = %s(struct {", tname, ctx, tname)
+
+	for i := 0; i < t.NumFields(); i++ {
+		fname := t.Field(i).Name()
+		ft := t.Field(i).Type()
+		qname, imppath := importedName(ft, thisPkg)
+		if imppath != "" && imports != nil {
+			imports[imppath] = struct{}{}
+		}
+		w("\t%s %s", fname, qname)
+	}
+
+	w("}{})\n")
+	return buf.Bytes()
+}
+
+func importedName(t types.Type, thisPkg *types.Package) (qualifiedName, importPkg string) {
+	qual := func(pkg *types.Package) string {
+		if thisPkg == pkg {
+			return ""
+		}
+		importPkg = pkg.Path()
+		return pkg.Name()
+	}
+	return types.TypeString(t, qual), importPkg
 }

--- a/wgengine/filter/match_clone.go
+++ b/wgengine/filter/match_clone.go
@@ -27,7 +27,7 @@ func (src *Match) Clone() *Match {
 }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
-var _MatchNeedsRegeneration = Match(struct {
+var _MatchCloneNeedsRegeneration = Match(struct {
 	IPProto []ipproto.Proto
 	Dsts    []NetPortRange
 	Srcs    []netaddr.IPPrefix

--- a/wgengine/wgcfg/clone.go
+++ b/wgengine/wgcfg/clone.go
@@ -31,7 +31,7 @@ func (src *Config) Clone() *Config {
 }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
-var _ConfigNeedsRegeneration = Config(struct {
+var _ConfigCloneNeedsRegeneration = Config(struct {
 	Name       string
 	PrivateKey wgkey.Private
 	Addresses  []netaddr.IPPrefix
@@ -53,7 +53,7 @@ func (src *Peer) Clone() *Peer {
 }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
-var _PeerNeedsRegeneration = Peer(struct {
+var _PeerCloneNeedsRegeneration = Peer(struct {
 	PublicKey           wgkey.Key
 	DiscoKey            tailcfg.DiscoKey
 	AllowedIPs          []netaddr.IPPrefix


### PR DESCRIPTION
- util/codegen: add package
- util/codegen: add AssertStructUnchanged
- cmd/cloner: add Clone context to regen struct assignments
- cmd/cloner: simplify code
- cmd/cloner: delete some debug code
- util/codegen: add NamedTypes
- cmd/cloner: unify switch cases
- util/codegen: add ContainsPointers
