### PR TITLE
wgengine: flush DNS cache after major link change.

### DIFF
--- a/net/dns/flush_default.go
+++ b/net/dns/flush_default.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !windows
+// +build !windows
+
+package dns
+
+func flushCaches() error {
+	return nil
+}

--- a/net/dns/flush_windows.go
+++ b/net/dns/flush_windows.go
@@ -9,11 +9,20 @@ import (
 	"os/exec"
 )
 
-// Flush clears the local resolver cache.
-func Flush() error {
+func flushCaches() error {
 	out, err := exec.Command("ipconfig", "/flushdns").CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%v (output: %s)", err, out)
 	}
 	return nil
+}
+
+// Flush clears the local resolver cache.
+//
+// Only Windows has a public dns.Flush, needed in router_windows.go. Other
+// platforms like Linux need a different flush implementation depending on
+// the DNS manager. There is a FlushCaches method on the manager which
+// can be used on all platforms.
+func Flush() error {
+	return flushCaches()
 }

--- a/net/dns/manager.go
+++ b/net/dns/manager.go
@@ -212,6 +212,10 @@ func (m *Manager) Down() error {
 	return nil
 }
 
+func (m *Manager) FlushCaches() error {
+	return flushCaches()
+}
+
 // Cleanup restores the system DNS configuration to its original state
 // in case the Tailscale daemon terminated without closing the router.
 // No other state needs to be instantiated before this runs.

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -1160,6 +1160,11 @@ func (e *userspaceEngine) linkChange(changed bool, cur *interfaces.State) {
 
 	health.SetAnyInterfaceUp(up)
 	e.magicConn.SetNetworkUp(up)
+	if !up || changed {
+		if err := e.dns.FlushCaches(); err != nil {
+			e.logf("wgengine: dns flush failed after major link change: %v", err)
+		}
+	}
 
 	// Hacky workaround for Linux DNS issue 2458: on
 	// suspend/resume or whenever NetworkManager is started, it


### PR DESCRIPTION
Fixes https://github.com/tailscale/tailscale/issues/2132

Signed-off-by: Denton Gentry <dgentry@tailscale.com>