### PR TITLE
version: fix CmdName on the tailscale-ipn.exe binary

### DIFF
--- a/version/cmdname.go
+++ b/version/cmdname.go
@@ -26,13 +26,16 @@ func CmdName() string {
 	if err != nil {
 		return "cmd"
 	}
+	return cmdName(e)
+}
 
+func cmdName(exe string) string {
 	// fallbackName, the lowercase basename of the executable, is what we return if
 	// we can't find the Go module metadata embedded in the file.
-	fallbackName := filepath.Base(strings.TrimSuffix(strings.ToLower(e), ".exe"))
+	fallbackName := filepath.Base(strings.TrimSuffix(strings.ToLower(exe), ".exe"))
 
 	var ret string
-	info, err := findModuleInfo(e)
+	info, err := findModuleInfo(exe)
 	if err != nil {
 		return fallbackName
 	}
@@ -44,6 +47,12 @@ func CmdName() string {
 			ret = path.Base(goPkg)                      // goPkg is always forward slashes; use path, not filepath
 			break
 		}
+	}
+	if strings.HasPrefix(ret, "wg") && fallbackName == "tailscale-ipn" {
+		// The tailscale-ipn.exe binary for internal build system packaging reasons
+		// has a path of "tailscale.io/win/wg64", "tailscale.io/win/wg32", etc.
+		// Ignore that name and use "tailscale-ipn" instead.
+		return fallbackName
 	}
 	if ret == "" {
 		return fallbackName

--- a/version/modinfo_test.go
+++ b/version/modinfo_test.go
@@ -5,6 +5,7 @@
 package version
 
 import (
+	"flag"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -35,4 +36,19 @@ func exe() string {
 		return ".exe"
 	}
 	return ""
+}
+
+var findModuleInfoName = flag.String("module-info-file", "", "if non-empty, test findModuleInfo against this filename")
+
+func TestFindModuleInfoManual(t *testing.T) {
+	exe := *findModuleInfoName
+	if exe == "" {
+		t.Skip("skipping without --module-info-file filename")
+	}
+	cmd := cmdName(exe)
+	mod, err := findModuleInfo(exe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Got %q from: %s", cmd, mod)
 }


### PR DESCRIPTION
Don't return "wg64", "wg32", etc.
