### PR TITLE
logpolicy: don't use C:\ProgramData use for tailscale-ipn GUI's log dir

### DIFF
--- a/ipn/ipnserver/server.go
+++ b/ipn/ipnserver/server.go
@@ -595,14 +595,14 @@ func (s *server) writeToClients(n ipn.Notify) {
 // Returns a string of the path to use for the state file.
 // This will be a fallback %LocalAppData% path if migration fails,
 // a %ProgramData% path otherwise.
-func tryWindowsAppDataMigration(path string) string {
+func tryWindowsAppDataMigration(logf logger.Logf, path string) string {
 	if path != paths.DefaultTailscaledStateFile() {
 		// If they're specifying a non-default path, just trust that they know
 		// what they are doing.
 		return path
 	}
 	oldFile := filepath.Join(os.Getenv("LocalAppData"), "Tailscale", "server-state.conf")
-	return paths.TryConfigFileMigration(oldFile, path)
+	return paths.TryConfigFileMigration(logf, oldFile, path)
 }
 
 // Run runs a Tailscale backend service.
@@ -648,7 +648,7 @@ func Run(ctx context.Context, logf logger.Logf, logid string, getEngine func() (
 			}
 		default:
 			if runtime.GOOS == "windows" {
-				path = tryWindowsAppDataMigration(path)
+				path = tryWindowsAppDataMigration(logf, path)
 			}
 			store, err = ipn.NewFileStore(path)
 			if err != nil {

--- a/paths/migrate.go
+++ b/paths/migrate.go
@@ -5,9 +5,10 @@
 package paths
 
 import (
-	"log"
 	"os"
 	"path/filepath"
+
+	"tailscale.com/types/logger"
 )
 
 // TryConfigFileMigration carefully copies the contents of oldFile to
@@ -17,14 +18,14 @@ import (
 //   default config to be written to.
 // - if oldFile exists but copying to newFile fails, return oldFile so
 //   there will at least be some config to work with.
-func TryConfigFileMigration(oldFile, newFile string) string {
+func TryConfigFileMigration(logf logger.Logf, oldFile, newFile string) string {
 	_, err := os.Stat(newFile)
 	if err == nil {
 		// Common case for a system which has already been migrated.
 		return newFile
 	}
 	if !os.IsNotExist(err) {
-		log.Printf("TryConfigFileMigration failed; new file: %v", err)
+		logf("TryConfigFileMigration failed; new file: %v", err)
 		return newFile
 	}
 
@@ -39,15 +40,15 @@ func TryConfigFileMigration(oldFile, newFile string) string {
 	if err != nil {
 		removeErr := os.Remove(newFile)
 		if removeErr != nil {
-			log.Printf("TryConfigFileMigration failed; write newFile no cleanup: %v, remove err: %v",
+			logf("TryConfigFileMigration failed; write newFile no cleanup: %v, remove err: %v",
 				err, removeErr)
 			return oldFile
 		}
-		log.Printf("TryConfigFileMigration failed; write newFile: %v", err)
+		logf("TryConfigFileMigration failed; write newFile: %v", err)
 		return oldFile
 	}
 
-	log.Printf("TryConfigFileMigration: successfully migrated: from %v to %v",
+	logf("TryConfigFileMigration: successfully migrated: from %v to %v",
 		oldFile, newFile)
 
 	return newFile


### PR DESCRIPTION
tailscale-ipn.exe (the GUI) shouldn't use C:\ProgramData.

Also, migrate the earlier misnamed wg32/wg64 conf files if they're present.
(That was stopped in 2db877caa332c8968ee1b1eb08ef40a219ff3eec, but the
files exist from fresh 1.14 installs)

Updates #2856