### PR TITLE
net/socks5: verify that the requested port is a uint16.

### DIFF
--- a/net/socks5/socks5.go
+++ b/net/socks5/socks5.go
@@ -178,7 +178,10 @@ func (c *Conn) handleRequest() error {
 	if err != nil {
 		return err
 	}
-	serverPort, _ := strconv.Atoi(serverPortStr)
+	serverPort, err := strconv.ParseUint(serverPortStr, 10, 16)
+	if err != nil {
+		return err
+	}
 
 	var bindAddrType addrType
 	if ip := net.ParseIP(serverAddr); ip != nil {


### PR DESCRIPTION
Signed-off-by: David Anderson <danderson@tailscale.com>