### PR TITLE
ipn: don't log IPN messages that may contain an authkey.

### DIFF
--- a/ipn/message.go
+++ b/ipn/message.go
@@ -260,10 +260,10 @@ func (bc *BackendClient) send(cmd Command) {
 	cmd.Version = version.Long
 	b, err := json.Marshal(cmd)
 	if err != nil {
-		log.Fatalf("Failed json.Marshal(cmd): %v\n%#v\n", err, cmd)
+		log.Fatalf("Failed json.Marshal(cmd): %v\n", err)
 	}
 	if bytes.Contains(b, jsonEscapedZero) {
-		log.Printf("[unexpected] zero byte in BackendClient.send command: %q", b)
+		log.Printf("[unexpected] zero byte in BackendClient.send command")
 	}
 	bc.sendCommandMsg(b)
 }


### PR DESCRIPTION
I believe this check was added when we were debugging the zero-bytes corruption on Windows, so I don't expect it to trigger again. I could also remove the 0b checks altogether?