### PR TITLE
Support subnet routes in userspace networking mode

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1781,6 +1781,7 @@ func (b *LocalBackend) authReconfig() {
 	if err == wgengine.ErrNoChanges {
 		return
 	}
+	b.e.NotifyPrefs(prefs)
 	b.logf("[v1] authReconfig: ra=%v dns=%v 0x%02x: %v", prefs.RouteAll, prefs.CorpDNS, flags, err)
 
 	b.initPeerAPIListener()

--- a/net/socks5/tssocks/tssocks.go
+++ b/net/socks5/tssocks/tssocks.go
@@ -94,8 +94,6 @@ func (d *dialer) useNetstackForIP(ip netaddr.IP) bool {
 	if d.ns == nil {
 		return false
 	}
-	// TODO(bradfitz): this isn't exactly right.
-	// We should check the RouteAll pref
 	return tsaddr.IsTailscaleIP(ip) || d.isAllowedIP(ip)
 }
 

--- a/wgengine/watchdog.go
+++ b/wgengine/watchdog.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"inet.af/netaddr"
+	"tailscale.com/ipn"
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/net/dns"
 	"tailscale.com/net/tstun"
@@ -111,6 +112,14 @@ func (e *watchdogEngine) AddNetworkMapCallback(callback NetworkMapCallback) func
 	var fn func()
 	e.watchdog("AddNetworkMapCallback", func() { fn = e.wrap.AddNetworkMapCallback(callback) })
 	return func() { e.watchdog("RemoveNetworkMapCallback", fn) }
+}
+func (e *watchdogEngine) NotifyPrefs(prefs *ipn.Prefs) {
+	e.watchdog("NotifyPrefs", func() { e.wrap.NotifyPrefs(prefs) })
+}
+func (e *watchdogEngine) AddPrefsCallback(callback PrefsCallback) (removeCallback func()) {
+	var fn func()
+	e.watchdog("AddPrefsCallback", func() { fn = e.wrap.AddPrefsCallback(callback) })
+	return func() { e.watchdog("RemovePrefsCallback", fn) }
 }
 func (e *watchdogEngine) DiscoPublicKey() (k tailcfg.DiscoKey) {
 	e.watchdog("DiscoPublicKey", func() { k = e.wrap.DiscoPublicKey() })

--- a/wgengine/wgengine.go
+++ b/wgengine/wgengine.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 
 	"inet.af/netaddr"
+	"tailscale.com/ipn"
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/net/dns"
 	"tailscale.com/tailcfg"
@@ -39,6 +40,8 @@ type NetInfoCallback func(*tailcfg.NetInfo)
 // NetworkMapCallback is the type used by callbacks that hook
 // into network map updates.
 type NetworkMapCallback func(*netmap.NetworkMap)
+
+type PrefsCallback func(prefs *ipn.Prefs)
 
 // someHandle is allocated so its pointer address acts as a unique
 // map key handle. (It needs to have non-zero size for Go to guarantee
@@ -120,6 +123,17 @@ type Engine interface {
 	// function that when called would remove the function from the
 	// list of callbacks.
 	AddNetworkMapCallback(NetworkMapCallback) (removeCallback func())
+
+	// NotifyPrefs informs the engine of the latest ipn prefs
+	// changes.
+	// The prefs should only be read from.
+	NotifyPrefs(prefs *ipn.Prefs)
+
+	// AddPrefsCallback adds a function to a list of callbacks that
+	// are called when ipn prefs change. It returns a function that
+	// when called would remove the function from the list of
+	// callbacks.
+	AddPrefsCallback(PrefsCallback) (removeCallback func())
 
 	// SetNetInfoCallback sets the function to call when a
 	// new NetInfo summary is available.

--- a/wgengine/wgengine.go
+++ b/wgengine/wgengine.go
@@ -41,6 +41,8 @@ type NetInfoCallback func(*tailcfg.NetInfo)
 // into network map updates.
 type NetworkMapCallback func(*netmap.NetworkMap)
 
+// PrefsCallback is the type used by callbacks that hook
+// into ipn prefs updates.
 type PrefsCallback func(prefs *ipn.Prefs)
 
 // someHandle is allocated so its pointer address acts as a unique


### PR DESCRIPTION
Adds support for accepted subnet routes when running in userspace networking mode with a SOCKS5 proxy.

Fixes https://github.com/tailscale/tailscale/issues/2264.

This does not check the RouteAll pref, so the SOCKS proxy will use the Netstack dialer for all advertised routes regardless of prefs.  I could not find a straight-forward way of determining the state of the RouteAll flag within the SOCKS proxy.   