### PR TITLE
.github: revert dependabot change for vm builder

### DIFF
--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2.1.4
+        uses: actions/setup-go@v1
         with:
           go-version: 1.17
         id: go


### PR DESCRIPTION
In a56520c3c7f12c2d060f7ce9b561142af1dbc5c4 dependabot attempted to bump
the setup-go action version. It appears to work for most builders, but
not the self-hosted VM builder. Revert for now.

Signed-off-by: David Crawshaw <crawshaw@tailscale.com>