### PR TITLE
cmd/tailscaled util/winutil: make tailscaled aware of SessionChange e…

### DIFF
--- a/tstest/integration/tailscaled_deps_test_windows.go
+++ b/tstest/integration/tailscaled_deps_test_windows.go
@@ -57,6 +57,7 @@ import (
 	_ "tailscale.com/types/key"
 	_ "tailscale.com/types/logger"
 	_ "tailscale.com/util/osshare"
+	_ "tailscale.com/util/winutil"
 	_ "tailscale.com/version"
 	_ "tailscale.com/version/distro"
 	_ "tailscale.com/wf"

--- a/util/winutil/winutil.go
+++ b/util/winutil/winutil.go
@@ -53,6 +53,29 @@ func GetRegString(name, defval string) string {
 	return val
 }
 
+// GetRegInteger looks up a registry path in our local machine path, or returns
+// the given default if it can't.
+//
+// This function will only work on GOOS=windows. Trying to run it on any other
+// OS will always return the default value.
+func GetRegInteger(name string, defval uint64) uint64 {
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, RegBase, registry.READ)
+	if err != nil {
+		log.Printf("registry.OpenKey(%v): %v", RegBase, err)
+		return defval
+	}
+	defer key.Close()
+
+	val, _, err := key.GetIntegerValue(name)
+	if err != nil {
+		if err != registry.ErrNotExist {
+			log.Printf("registry.GetIntegerValue(%v): %v", name, err)
+		}
+		return defval
+	}
+	return val
+}
+
 var (
 	kernel32                         = syscall.NewLazyDLL("kernel32.dll")
 	procWTSGetActiveConsoleSessionId = kernel32.NewProc("WTSGetActiveConsoleSessionId")

--- a/util/winutil/winutil_notwindows.go
+++ b/util/winutil/winutil_notwindows.go
@@ -15,3 +15,10 @@ const RegBase = ``
 // This function will only work on GOOS=windows. Trying to run it on any other
 // OS will always return the default value.
 func GetRegString(name, defval string) string { return defval }
+
+// GetRegInteger looks up a registry path in our local machine path, or returns
+// the given default if it can't.
+//
+// This function will only work on GOOS=windows. Trying to run it on any other
+// OS will always return the default value.
+func GetRegInteger(name string, defval uint64) uint64 { return defval }


### PR DESCRIPTION
…vents, and when enabled, flush the dns cache upon session unlock

For the service, all we need to do is handle the `svc.SessionChange` command.
Upon receipt of a `windows.WTS_SESSION_UNLOCK` event, we fire off a goroutine to flush the DNS cache.
(Windows expects responses to service requests to be quick, so we don't want to do that synchronously.)

This is gated on an integral registry value named `FlushDnsOnSessionUnlock`,
whose value we obtain during service initialization. We add `winutil.GetRegInteger`
to support this.

(See [this link](https://docs.microsoft.com/en-us/windows/win32/api/winsvc/nc-winsvc-lphandler_function_ex)
for information re: handling `SERVICE_CONTROL_SESSIONCHANGE`.)

Fixes #2956

Signed-off-by: Aaron Klotz <aaron@tailscale.com>