### PR TITLE
net/dns/resolver: add unsecured Quad9 resolvers

### DIFF
--- a/net/dns/resolver/forwarder.go
+++ b/net/dns/resolver/forwarder.go
@@ -712,4 +712,10 @@ func init() {
 	addDoH("149.112.112.112", "https://dns.quad9.net/dns-query")
 	addDoH("2620:fe::fe", "https://dns.quad9.net/dns-query")
 	addDoH("2620:fe::fe:9", "https://dns.quad9.net/dns-query")
+	
+	// Quad9 -DNSSEC
+	addDoH("9.9.9.10", "https://dns10.quad9.net/dns-query")
+	addDoH("149.112.112.10", "https://dns10.quad9.net/dns-query")
+	addDoH("2620:fe::10", "https://dns10.quad9.net/dns-query")
+	addDoH("2620:fe::fe:10", "https://dns10.quad9.net/dns-query")
 }


### PR DESCRIPTION
DNSSEC is an availability issue, as recently demonstrated by the
Slack issue, with limited security advantage. DoH on the other hand
is a critical security upgrade. This change adds DoH support for the
non-DNSSEC endpoints of Quad9.

https://www.quad9.net/service/service-addresses-and-features#unsec