### PR TITLE
cmd/tailscale: make cert subcommand give hints on access denied

### DIFF
--- a/client/tailscale/tailscale.go
+++ b/client/tailscale/tailscale.go
@@ -77,6 +77,20 @@ type errorJSON struct {
 	Error string
 }
 
+// AccessDeniedError is an error due to permissions.
+type AccessDeniedError struct {
+	err error
+}
+
+func (e *AccessDeniedError) Error() string { return fmt.Sprintf("Access denied: %v", e.err) }
+func (e *AccessDeniedError) Unwrap() error { return e.err }
+
+// IsAccessDeniedError reports whether err is or wraps an AccessDeniedError.
+func IsAccessDeniedError(err error) bool {
+	var ae *AccessDeniedError
+	return errors.As(err, &ae)
+}
+
 // bestError returns either err, or if body contains a valid JSON
 // object of type errorJSON, its non-empty error body.
 func bestError(err error, body []byte) error {
@@ -85,6 +99,14 @@ func bestError(err error, body []byte) error {
 		return errors.New(j.Error)
 	}
 	return err
+}
+
+func errorMessageFromBody(body []byte) string {
+	var j errorJSON
+	if err := json.Unmarshal(body, &j); err == nil && j.Error != "" {
+		return j.Error
+	}
+	return strings.TrimSpace(string(body))
 }
 
 var onVersionMismatch func(clientVer, serverVer string)
@@ -123,6 +145,9 @@ func send(ctx context.Context, method, path string, wantStatus int, body io.Read
 		return nil, err
 	}
 	if res.StatusCode != wantStatus {
+		if res.StatusCode == 403 {
+			return nil, &AccessDeniedError{errors.New(errorMessageFromBody(slurp))}
+		}
 		err := fmt.Errorf("HTTP %s: %s (expected %v)", res.Status, slurp, wantStatus)
 		return nil, bestError(err, slurp)
 	}

--- a/cmd/tailscale/cli/cert.go
+++ b/cmd/tailscale/cli/cert.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -85,6 +86,9 @@ func runCert(ctx context.Context, args []string) error {
 		certArgs.keyFile = domain + ".key"
 	}
 	certPEM, keyPEM, err := tailscale.CertPair(ctx, domain)
+	if tailscale.IsAccessDeniedError(err) && os.Getuid() != 0 && runtime.GOOS != "windows" {
+		return fmt.Errorf("%v\n\nUse 'sudo tailscale cert' or 'tailscale up --operator=$USER' to not require root.", err)
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Lot of people have been hitting this.

Now it says:

    $ tailscale cert tsdev.corp.ts.net
    Access denied: cert access denied

    Use 'sudo tailscale cert' or 'tailscale up --operator=$USER' to not require root.

