### PR TITLE
bencher: add config to suppress failures on benchmark regressions.

### DIFF
--- a/.bencher/config.yaml
+++ b/.bencher/config.yaml
@@ -1,0 +1,1 @@
+suppress_failure_on_regression: true


### PR DESCRIPTION
This config update will let tailscale use bencher without worrying about the bencher check appearing as failed due to a benchmark regressing.

Updates #2938

Signed-off-by: Nathan Dias <nathan@orijtech.com>
