### PR TITLE
ipn/ipnlocal: make sure mobile clients don't use the old control server URL

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1419,6 +1419,26 @@ func (b *LocalBackend) loadStateLocked(key ipn.StateKey, prefs *ipn.Prefs) (err 
 	if err != nil {
 		return fmt.Errorf("PrefsFromBytes: %v", err)
 	}
+
+	// On mobile platforms, ignore any old stored preferences for
+	// https://login.tailscale.com as the control server that
+	// would override the new default of controlplane.tailscale.com.
+	// This makes sure that mobile clients go through the new
+	// frontends where we're (2021-10-02) doing battery
+	// optimization work ahead of turning down the old backends.
+	// TODO(bradfitz): make this the default for all platforms
+	// later. But mobile is a relatively small chunk (compared to
+	// Linux, Windows, macOS) and moving mobile early for battery
+	// gains is nice.
+	switch runtime.GOOS {
+	case "android", "ios":
+		if b.prefs != nil && b.prefs.ControlURL != "" &&
+			b.prefs.ControlURL != ipn.DefaultControlURL &&
+			ipn.IsLoginServerSynonym(b.prefs.ControlURL) {
+			b.prefs.ControlURL = ""
+		}
+	}
+
 	b.logf("backend prefs for %q: %s", key, b.prefs.Pretty())
 	return nil
 }


### PR DESCRIPTION
The new frontends are better for battery.

Updates #2442
Updates tailscale/corp#2750
