### PR TITLE
hostinfo: add SetOSVersion like SetDeviceModel, deprecate ipn.Prefs way

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -2275,7 +2275,7 @@ func applyPrefsToHostinfo(hi *tailcfg.Hostinfo, prefs *ipn.Prefs) {
 	if h := prefs.Hostname; h != "" {
 		hi.Hostname = h
 	}
-	if v := prefs.OSVersion; v != "" {
+	if v := prefs.OSVersion; v != "" && hi.OSVersion == "" {
 		hi.OSVersion = v
 
 		// The Android app annotates when Google Play Services

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -128,9 +128,15 @@ type Prefs struct {
 	Hostname string
 
 	// OSVersion overrides tailcfg.Hostinfo's OSVersion.
+	//
+	// Deprecated: we're in the process of deleting this and using
+	// hostinfo.SetFoo methods instead.
 	OSVersion string
 
 	// DeviceModel overrides tailcfg.Hostinfo's DeviceModel.
+	//
+	// Deprecated: we're in the process of deleting this and using
+	// hostinfo.SetFoo methods instead.
 	DeviceModel string
 
 	// NotepadURLs is a debugging setting that opens OAuth URLs in


### PR DESCRIPTION
Turns out the iOS client has been only sending the OS version it first
started at. This whole hostinfo-via-prefs mechanism was never a good idea.
Start removing it.