### PR TITLE
ipn: remove unused Prefs.OSVersion and Prefs.DeviceModel

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -2275,12 +2275,6 @@ func applyPrefsToHostinfo(hi *tailcfg.Hostinfo, prefs *ipn.Prefs) {
 	if h := prefs.Hostname; h != "" {
 		hi.Hostname = h
 	}
-	if v := prefs.OSVersion; v != "" && hi.OSVersion == "" {
-		hi.OSVersion = v
-	}
-	if m := prefs.DeviceModel; m != "" && hi.DeviceModel == "" {
-		hi.DeviceModel = m
-	}
 	hi.RoutableIPs = append(prefs.AdvertiseRoutes[:0:0], prefs.AdvertiseRoutes...)
 	hi.RequestTags = append(prefs.AdvertiseTags[:0:0], prefs.AdvertiseTags...)
 	hi.ShieldsUp = prefs.ShieldsUp

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -127,18 +127,6 @@ type Prefs struct {
 	// not set, os.Hostname is used.
 	Hostname string
 
-	// OSVersion overrides tailcfg.Hostinfo's OSVersion.
-	//
-	// Deprecated: we're in the process of deleting this and using
-	// hostinfo.SetFoo methods instead.
-	OSVersion string
-
-	// DeviceModel overrides tailcfg.Hostinfo's DeviceModel.
-	//
-	// Deprecated: we're in the process of deleting this and using
-	// hostinfo.SetFoo methods instead.
-	DeviceModel string
-
 	// NotepadURLs is a debugging setting that opens OAuth URLs in
 	// notepad.exe on Windows, rather than loading them in a browser.
 	//
@@ -210,8 +198,6 @@ type MaskedPrefs struct {
 	ShieldsUpSet              bool `json:",omitempty"`
 	AdvertiseTagsSet          bool `json:",omitempty"`
 	HostnameSet               bool `json:",omitempty"`
-	OSVersionSet              bool `json:",omitempty"`
-	DeviceModelSet            bool `json:",omitempty"`
 	NotepadURLsSet            bool `json:",omitempty"`
 	ForceDaemonSet            bool `json:",omitempty"`
 	AdvertiseRoutesSet        bool `json:",omitempty"`
@@ -355,8 +341,6 @@ func (p *Prefs) Equals(p2 *Prefs) bool {
 		p.NetfilterMode == p2.NetfilterMode &&
 		p.OperatorUser == p2.OperatorUser &&
 		p.Hostname == p2.Hostname &&
-		p.OSVersion == p2.OSVersion &&
-		p.DeviceModel == p2.DeviceModel &&
 		p.ForceDaemon == p2.ForceDaemon &&
 		compareIPNets(p.AdvertiseRoutes, p2.AdvertiseRoutes) &&
 		compareStrings(p.AdvertiseTags, p2.AdvertiseTags) &&

--- a/ipn/prefs_clone.go
+++ b/ipn/prefs_clone.go
@@ -45,8 +45,6 @@ var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	ShieldsUp              bool
 	AdvertiseTags          []string
 	Hostname               string
-	OSVersion              string
-	DeviceModel            string
 	NotepadURLs            bool
 	ForceDaemon            bool
 	AdvertiseRoutes        []netaddr.IPPrefix

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -46,8 +46,6 @@ func TestPrefsEqual(t *testing.T) {
 		"ShieldsUp",
 		"AdvertiseTags",
 		"Hostname",
-		"OSVersion",
-		"DeviceModel",
 		"NotepadURLs",
 		"ForceDaemon",
 		"AdvertiseRoutes",
@@ -562,8 +560,8 @@ func TestPrefsApplyEdits(t *testing.T) {
 			},
 			edit: &MaskedPrefs{
 				Prefs: Prefs{
-					Hostname:    "bar",
-					DeviceModel: "ignore-this", // not set
+					Hostname:     "bar",
+					OperatorUser: "ignore-this", // not set
 				},
 				HostnameSet: true,
 			},
@@ -576,15 +574,15 @@ func TestPrefsApplyEdits(t *testing.T) {
 			prefs: &Prefs{},
 			edit: &MaskedPrefs{
 				Prefs: Prefs{
-					Hostname:    "bar",
-					DeviceModel: "galaxybrain",
+					Hostname:     "bar",
+					OperatorUser: "galaxybrain",
 				},
-				HostnameSet:    true,
-				DeviceModelSet: true,
+				HostnameSet:     true,
+				OperatorUserSet: true,
 			},
 			want: &Prefs{
-				Hostname:    "bar",
-				DeviceModel: "galaxybrain",
+				Hostname:     "bar",
+				OperatorUser: "galaxybrain",
 			},
 		},
 	}
@@ -614,15 +612,15 @@ func TestMaskedPrefsPretty(t *testing.T) {
 			m: &MaskedPrefs{
 				Prefs: Prefs{
 					Hostname:         "bar",
-					DeviceModel:      "galaxybrain",
+					OperatorUser:     "galaxybrain",
 					AllowSingleHosts: true,
 					RouteAll:         false,
 				},
-				RouteAllSet:    true,
-				HostnameSet:    true,
-				DeviceModelSet: true,
+				RouteAllSet:     true,
+				HostnameSet:     true,
+				OperatorUserSet: true,
 			},
-			want: `MaskedPrefs{RouteAll=false Hostname="bar" DeviceModel="galaxybrain"}`,
+			want: `MaskedPrefs{RouteAll=false Hostname="bar" OperatorUser="galaxybrain"}`,
 		},
 	}
 	for i, tt := range tests {


### PR DESCRIPTION
iOS and Android no longer use these. They both now (as of today)
use the hostinfo.SetFoo setters instead.
