### PR TITLE
magicsock: if STUN failed to send before, rebind before STUNning again.

### DIFF
--- a/net/netcheck/netcheck_test.go
+++ b/net/netcheck/netcheck_test.go
@@ -100,10 +100,17 @@ func TestWorksWhenUDPBlocked(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := newReport()
 	r.UPnP = ""
 	r.PMP = ""
 	r.PCP = ""
+
+	want := newReport()
+
+	// The IPv4CanSend flag gets set differently across platforms.
+	// On Windows this test detects false, while on Linux detects true.
+	// That's not relevant to this test, so just accept what we're
+	// given.
+	want.IPv4CanSend = r.IPv4CanSend
 
 	if !reflect.DeepEqual(r, want) {
 		t.Errorf("mismatch\n got: %+v\nwant: %+v\n", r, want)

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -1143,7 +1143,8 @@ func (e *userspaceEngine) GetLinkMonitor() *monitor.Mon {
 }
 
 // LinkChange signals a network change event. It's currently
-// (2021-03-03) only called on Android.
+// (2021-03-03) only called on Android. On other platforms, linkMon
+// generates link change events for us.
 func (e *userspaceEngine) LinkChange(_ bool) {
 	e.linkMon.InjectEvent()
 }


### PR DESCRIPTION
On iOS (and possibly other platforms), sometimes our UDP socket would
get stuck in a state where it was bound to an invalid interface (or no
interface) after a network reconfiguration. We can detect this by
actually checking the error codes from sending our STUN packets.

If we completely fail to send any STUN packets, we know something is
very broken. So on the next STUN attempt, let's rebind the UDP socket
to try to correct any problems.

This fixes a problem where iOS would sometimes get stuck using DERP
instead of direct connections until the backend was restarted.

Fixes #2994

Signed-off-by: Avery Pennarun <apenwarr@tailscale.com>