### PR TITLE
.github: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,78 @@
 ---
 name: Bug report
-about: Create a bug report
-title: ''
-labels: 'needs-triage'
-assignees: ''
-
+about: File a bug report
+title: "[Bug]: "
+labels: ["needs-triage","bug"]
+assignees: ""
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please check if your bug is [already filed](https://github.com/tailscale/tailscale/issues).
+        Have an urgent issue? Let us know by emailing us at <support@tailscale.com>.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What is the issue?
+      description: What happened? What did you expect to happen?
+      placeholder: oh no
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: What are the steps you took that hit this issue?
+    validations:
+      required: false
+  - type: textarea
+    id: changes
+    attributes:
+      label: Are there any recent changes that introduced the issue?
+      description: If so, what are those changes?
+    validations:
+      required: false
+  - type: checkboxes
+    id: os
+    attributes:
+      label: OS
+      description: What OS are you using?
+      multiple: true
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - iOS
+        - Android
+        - Other
+    validations:
+      required: false
+  - type: input
+    id: os-version
+    attributes:
+      label: OS version
+      description: What OS version are you using?
+      placeholder: e.g., Debian 11.0, macOS Big Sur 11.6
+    validations:
+      required: false
+  - type: input
+    id: ts-version
+    attributes:
+      label: Tailscale version
+      description: What Tailscale version are you using?
+      placeholder: e.g., 1.14.4
+    validations:
+      required: false
+  - type: input
+    id: bug-report
+    attributes:
+      label: Bug report
+      description: Please run [`tailscale bugreport`](https://tailscale.com/kb/1080/cli/?q=Cli#bugreport) and share the bug identifier. The identifier is a random string which allows Tailscale support to locate your account and gives a point to focus on when looking for errors.
+      placeholder: e.g., BUG-1b7641a16971a9cd75822c0ed8043fee70ae88cf05c52981dc220eb96a5c49a8-20210427151443Z-fbcd4fd3a4b7ad94
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug report!
 ---

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Support and Product Questions
+  - name: Support requests and Troubleshooting
     url: https://tailscale.com/kb/1023/troubleshooting
-    about: Please send support questions and questions about the Tailscale product to support@tailscale.com
+    about: Troubleshoot common issues. Contact us by email at support@tailscale.com.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,52 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
-title: ''
-labels: 'needs-triage'
-assignees: ''
+about: Propose a new feature
+title: "[FR]: "
+labels: ["needs-triage","fr"]
+assignees: ""
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please check if your feature request is [already filed](https://github.com/tailscale/tailscale/issues).
+  - type: input
+    id: request
+    attributes:
+      label: Tell us about your idea!
+      description: What is your feature request?
+      placeholder: e.g., A pet pangolin
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do?
+      description: Tell us about the problem you're trying to solve.
+    validations:
+      required: false
+  - type: textarea
+    id: solution
+    attributes:
+      label: How should we solve this?
+      description: If you have an idea of how you'd like to see this feature work, let us know.
+    validations:
+      required: false
+  - type: textarea
+    id: alternative
+    attributes:
+      label: What is the impact of not solving this?
+      description: (How) Are you currently working around the issue?
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything else?
+      description: Any additional context to share, e.g., links
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a feature request!
 ---


### PR DESCRIPTION
Update issue templates for bugs and FRs, adding tags for those as well.
Note that I didn't add an issue type to email support, since that isn't supported (only URLs). Once we have a "contact Support" page, we can add this.