### PR TITLE
net/dns/resolver: don't forward DNS-SD on all platforms

### DIFF
--- a/net/dns/resolver/forwarder.go
+++ b/net/dns/resolver/forwarder.go
@@ -519,18 +519,12 @@ func (f *forwarder) forward(query packet) error {
 	}
 
 	// Drop DNS service discovery spam, primarily for battery life
-	// on mobile.  This is scoped to only Apple platforms, as
-	// that's where we see it.  Things like Spotify on iOS
-	// generate this traffic, when browsing for LAN devices.  But
-	// even when filtering this out, playing on Sonos still works.
-	//
-	// TODO(bradfitz): maybe after 1.16 is out, do it more broadly?
-	switch runtime.GOOS {
-	case "ios", "darwin":
-		if hasRDNSBonjourPrefix(domain) {
-			f.logf("[v1] dropping %q", domain)
-			return nil
-		}
+	// on mobile.  Things like Spotify on iOS generate this traffic,
+	// when browsing for LAN devices.  But even when filtering this
+	// out, playing on Sonos still works.
+	if hasRDNSBonjourPrefix(domain) {
+		f.logf("[v1] dropping %q", domain)
+		return nil
 	}
 
 	clampEDNSSize(query.bs, maxResponseBytes)


### PR DESCRIPTION
We added the initial handling only for macOS and iOS.
With 1.16.0 now released, suppress forwarding DNS-SD
on all platforms to test it through the 1.17.x cycle.

Updates #2442

Signed-off-by: Denton Gentry <dgentry@tailscale.com>