### PR TITLE
.github: change templates to yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,9 +1,7 @@
----
 name: Bug report
-about: File a bug report
+description: File a bug report
 title: "[Bug]: "
-labels: ["needs-triage","bug"]
-assignees: ""
+labels: [needs-triage, bug]
 body:
   - type: markdown
     attributes:
@@ -75,4 +73,3 @@ body:
     attributes:
       value: |
         Thanks for filing a bug report!
----

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,9 +1,7 @@
----
 name: Feature request
-about: Propose a new feature
+description: Propose a new feature
 title: "[FR]: "
-labels: ["needs-triage","fr"]
-assignees: ""
+labels: [needs-triage, fr]
 body:
   - type: markdown
     attributes:
@@ -49,4 +47,3 @@ body:
     attributes:
       value: |
         Thanks for filing a feature request!
----


### PR DESCRIPTION
Changed to yml 🙄 and modified `about` to `description`. Basically followed https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#converting-a-markdown-issue-template-to-a-yaml-issue-form-template

Signed-off-by: Maya Kaczorowski <15946341+mayakacz@users.noreply.github.com>