### PR TITLE
Bug template: remove "[Bug]: " prefix for the common case.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: File a bug report
-title: "[Bug]: "
+title: ""
 labels: [needs-triage, bug]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Propose a new feature
-title: "[FR]: "
+title: "FR: "
 labels: [needs-triage, fr]
 body:
   - type: markdown


### PR DESCRIPTION
Also shorten "[FR]:" to "FR:" to save precious subject line space.

I don't mind a prefix to distinguish feature requests, but the majority
of cases are bugs. Let's preserve as many chars as possible for the
specific topic when looking at subject lines in gmail.

(Now, if only it wouldn't include [tailscale/tailscale] on every
message...)

Signed-off-by: Avery Pennarun <apenwarr@tailscale.com>