### PR TITLE
Bug report template: remove empty 'title' field.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: Bug report
 description: File a bug report
-title: ""
 labels: [needs-triage, bug]
 body:
   - type: markdown


### PR DESCRIPTION
Mysteriously, GitHub can't parse it if it's an empty string rather than just missing.