### PR TITLE
net/dns/resolver: make hasRDNSBonjourPrefix match shorter queries too

### DIFF
--- a/net/dns/resolver/tsdns.go
+++ b/net/dns/resolver/tsdns.go
@@ -598,11 +598,6 @@ const (
 //  dr._dns-sd._udp.<domain>.
 //  lb._dns-sd._udp.<domain>.
 func hasRDNSBonjourPrefix(name dnsname.FQDN) bool {
-	// Even the shortest name containing a Bonjour prefix is long,
-	// so check length (cheap) and bail early if possible.
-	if len(name) < len("*._dns-sd._udp.0.0.0.0.in-addr.arpa.") {
-		return false
-	}
 	s := name.WithTrailingDot()
 	dot := strings.IndexByte(s, '.')
 	if dot == -1 {

--- a/net/dns/resolver/tsdns_test.go
+++ b/net/dns/resolver/tsdns_test.go
@@ -985,6 +985,7 @@ func TestTrimRDNSBonjourPrefix(t *testing.T) {
 		{"lb._dns-sd._udp.0.10.20.172.in-addr.arpa.", true},
 		{"qq._dns-sd._udp.0.10.20.172.in-addr.arpa.", false},
 		{"0.10.20.172.in-addr.arpa.", false},
+		{"lb._dns-sd._udp.ts-dns.test.", true},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes tailscale/corp#2886
Updates tailscale/corp#2820
Updates #2442
