### PR TITLE
wgengine/magicsock: start removing endpointForDiscoKey

### DIFF
--- a/wgengine/pendopen.go
+++ b/wgengine/pendopen.go
@@ -231,7 +231,7 @@ func (e *userspaceEngine) onOpenTimeout(flow flowtrack.Tuple) {
 	e.logf("open-conn-track: timeout opening %v to node %v; online=%v, lastRecv=%v",
 		flow, n.Key.ShortString(),
 		online,
-		e.magicConn.LastRecvActivityOfDisco(n.DiscoKey))
+		e.magicConn.LastRecvActivityOfNodeKey(n.Key))
 }
 
 func durFmt(t time.Time) string {


### PR DESCRIPTION
It's not valid to assume that a discokey is globally unique.

This removes the first two of the four callers.

Updates #3088
