### PR TITLE
net/portmapper: only print PCP/PMP if VerboseLogs

### DIFF
--- a/net/portmapper/portmapper.go
+++ b/net/portmapper/portmapper.go
@@ -719,9 +719,7 @@ func (c *Client) Probe(ctx context.Context) (res ProbeResult, err error) {
 				if err != nil {
 					c.logf("unrecognized UPnP discovery response; ignoring")
 				}
-				if VerboseLogs {
-					c.logf("UPnP reply %+v, %q", meta, buf[:n])
-				}
+				c.logf("[v1] UPnP reply %+v, %q", meta, buf[:n])
 				res.UPnP = true
 				c.mu.Lock()
 				c.uPnPSawTime = time.Now()
@@ -740,7 +738,7 @@ func (c *Client) Probe(ctx context.Context) (res ProbeResult, err error) {
 					c.mu.Unlock()
 					switch pres.ResultCode {
 					case pcpCodeOK:
-						c.logf("Got PCP response: epoch: %v", pres.Epoch)
+						c.logf("[v1] Got PCP response: epoch: %v", pres.Epoch)
 						res.PCP = true
 						continue
 					case pcpCodeNotAuthorized:
@@ -756,7 +754,7 @@ func (c *Client) Probe(ctx context.Context) (res ProbeResult, err error) {
 			}
 			if pres, ok := parsePMPResponse(buf[:n]); ok {
 				if pres.OpCode == pmpOpReply|pmpOpMapPublicAddr && pres.ResultCode == pmpCodeOK {
-					c.logf("Got PMP response; IP: %v, epoch: %v", pres.PublicAddr, pres.SecondsSinceEpoch)
+					c.logf("[v1] Got PMP response; IP: %v, epoch: %v", pres.PublicAddr, pres.SecondsSinceEpoch)
 					res.PMP = true
 					c.mu.Lock()
 					c.pmpPubIP = pres.PublicAddr


### PR DESCRIPTION
Make UPnP, NAT-PMP, and PCP packet reception logs be [v1] so
they will never appear on stdout and instead only go to logtail.

```
$ tailscale netcheck
2021/10/15 22:50:31 portmap: Got PMP response; IP: w.x.y.z, epoch: 1012707
2021/10/15 22:50:31 portmap: Got PCP response: epoch: 1012707

Report:
        * UDP: true
        * IPv4: yes, w.x.y.z:1511
        * IPv6: no
        * MappingVariesByDestIP: true
        * HairPinning: false
        * PortMapping: NAT-PMP, PCP
        * Nearest DERP: San Francisco
        * DERP latency:
                - sfo: 5.9ms   (San Francisco)
                - sea: 24ms    (Seattle)
                - dfw: 45ms    (Dallas)
                - ord: 53.7ms  (Chicago)
                - nyc: 74.1ms  (New York City)
                - tok: 111.1ms (Tokyo)
                - lhr: 139.4ms (London)
                - syd: 152.7ms (Sydney)
                - fra: 153.1ms (Frankfurt)
                - sin: 182.1ms (Singapore)
                - sao: 190.1ms (S_o Paulo)
                - blr: 218.6ms (Bangalore)
```

Signed-off-by: Denton Gentry <dgentry@tailscale.com>