### PR TITLE
wgengine/magicsock: don't Rebind after STUN error if closed.

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -616,8 +616,13 @@ func (c *Conn) updateEndpoints(why string) {
 	}()
 	c.logf("[v1] magicsock: starting endpoint update (%s)", why)
 	if c.noV4Send.Get() {
-		c.logf("magicsock: last netcheck reported send error. Rebinding.")
-		c.Rebind()
+		c.mu.Lock()
+		closed := c.closed
+		c.mu.Unlock()
+		if !closed {
+			c.logf("magicsock: last netcheck reported send error. Rebinding.")
+			c.Rebind()
+		}
 	}
 
 	endpoints, err := c.determineEndpoints(c.connCtx)


### PR DESCRIPTION
https://github.com/tailscale/tailscale/pull/3014 added a
rebind on STUN failure, which means there can now be a
tailscale.com/wgengine/magicsock.(*RebindingUDPConn).ReadFromNetaddr
in progress at the end of the test waiting for a STUN
response which will never arrive.

This causes a test flake due to the resource leak in those
cases where the Conn decided to rebind. For whatever reason,
it mostly flakes with Windows.

If the Conn is closed, don't Rebind after a send error.