### PR TITLE
disco, wgengine/magicsock: send self node key in disco pings

### DIFF
--- a/disco/disco_test.go
+++ b/disco/disco_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"inet.af/netaddr"
+	"tailscale.com/tailcfg"
 )
 
 func TestMarshalAndParse(t *testing.T) {
@@ -25,6 +26,19 @@ func TestMarshalAndParse(t *testing.T) {
 				TxID: [12]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
 			},
 			want: "01 00 01 02 03 04 05 06 07 08 09 0a 0b 0c",
+		},
+		{
+			name: "ping_with_nodekey_src",
+			m: &Ping{
+				TxID: [12]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+				NodeKey: tailcfg.NodeKey{
+					1:  1,
+					2:  2,
+					30: 30,
+					31: 31,
+				},
+			},
+			want: "01 00 01 02 03 04 05 06 07 08 09 0a 0b 0c 00 01 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 1e 1f",
 		},
 		{
 			name: "pong",


### PR DESCRIPTION
This lets clients quickly (sub-millisecond within a local LAN) map
from an ambiguous disco key to a node key without waiting for a
CallMeMaybe (over relatively high latency DERP).

Updates #3088
