### PR TITLE
wgengine/magicsock: turn down timeouts in tests

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -3151,16 +3151,6 @@ const (
 	// are sent.
 	heartbeatInterval = 2 * time.Second
 
-	// discoPingInterval is the minimum time between pings
-	// to an endpoint. (Except in the case of CallMeMaybe frames
-	// resetting the counter, as the first pings likely didn't through
-	// the firewall)
-	discoPingInterval = 5 * time.Second
-
-	// pingTimeoutDuration is how long we wait for a pong reply before
-	// assuming it's never coming.
-	pingTimeoutDuration = 5 * time.Second
-
 	// trustUDPAddrDuration is how long we trust a UDP address as the exclusive
 	// path (without using DERP) without having heard a Pong reply.
 	trustUDPAddrDuration = 5 * time.Second
@@ -3181,6 +3171,19 @@ const (
 	// STUN-derived endpoint valid for. UDP NAT mappings typically
 	// expire at 30 seconds, so this is a few seconds shy of that.
 	endpointsFreshEnoughDuration = 27 * time.Second
+)
+
+// Constants that are variable for testing.
+var (
+	// pingTimeoutDuration is how long we wait for a pong reply before
+	// assuming it's never coming.
+	pingTimeoutDuration = 5 * time.Second
+
+	// discoPingInterval is the minimum time between pings
+	// to an endpoint. (Except in the case of CallMeMaybe frames
+	// resetting the counter, as the first pings likely didn't through
+	// the firewall)
+	discoPingInterval = 5 * time.Second
 )
 
 // endpointState is some state and history for a specific endpoint of

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -743,6 +743,18 @@ func TestActiveDiscovery(t *testing.T) {
 		testActiveDiscovery(t, n)
 	})
 
+	// The following tests lose a disco pong before establishing a
+	// direct connection, so instead of waiting 5 seconds in the
+	// test, reduce the wait period.
+	origPingTimeoutDuration := pingTimeoutDuration
+	origDiscoPingInterval := discoPingInterval
+	discoPingInterval = 100 * time.Millisecond
+	pingTimeoutDuration = 100 * time.Millisecond
+	defer func() {
+		pingTimeoutDuration = origPingTimeoutDuration
+		discoPingInterval = origDiscoPingInterval
+	}()
+
 	t.Run("facing_easy_firewalls", func(t *testing.T) {
 		mstun := &natlab.Machine{Name: "stun"}
 		m1 := &natlab.Machine{


### PR DESCRIPTION
Before:

	--- PASS: TestActiveDiscovery (11.78s)
	    --- PASS: TestActiveDiscovery/facing_easy_firewalls (5.89s)
	    --- PASS: TestActiveDiscovery/facing_nats (5.89s)
	    --- PASS: TestActiveDiscovery/simple_internet (0.89s)

After:

	--- PASS: TestActiveDiscovery (1.98s)
	    --- PASS: TestActiveDiscovery/facing_easy_firewalls (0.99s)
	    --- PASS: TestActiveDiscovery/facing_nats (0.99s)
	    --- PASS: TestActiveDiscovery/simple_internet (0.89s)

Signed-off-by: David Crawshaw <crawshaw@tailscale.com>