### PR TITLE
Fix installer script on Oracle Linux

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -46,13 +46,18 @@ main() {
 				VERSION="$VERSION_CODENAME"
 				PACKAGETYPE="apt"
 				;;
-			centos|ol)
+			centos)
 				OS="$ID"
 				VERSION="$VERSION_ID"
 				PACKAGETYPE="dnf"
-				if [ "$VERSION" =~ ^7 ]; then
+				if [ "$VERSION" = ^7 ]; then
 					PACKAGETYPE="yum"
 				fi
+				;;
+			ol)
+				OS="oracle"
+				VERSION="$(echo "$VERSION_ID" | cut -f1 -d.)"
+				PACKAGETYPE="yum"
 				;;
 			rhel)
 				OS="$ID"
@@ -182,7 +187,7 @@ main() {
 				OS_UNSUPPORTED=1
 			fi
 		;;
-		centos)
+		centos|oracle)
 			if [ "$VERSION" != "7" ] && \
 			   [ "$VERSION" != "8" ]
 			then


### PR DESCRIPTION
Reverts updates in #2604 as they did not fully work.

Fixes this error: `environment: line 52: [: =~: binary operator expected` (see https://github.com/koalaman/shellcheck/wiki/SC3015)

Fixes this error: `ol 8.4 isn't supported by this script yet.`

@Xe and @bradfitz 