### PR TITLE
scripts/installer.sh: use expr for regex matches.

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -38,7 +38,7 @@ main() {
 				PACKAGETYPE="apt"
 				# Third-party keyrings became the preferred method of
 				# installation in Ubuntu 20.04.
-				if [ "$VERSION_ID" =~ ^2 ]; then
+				if expr "$VERSION_ID" : "2.*" >/dev/null; then
 					APT_KEY_TYPE="keyring"
 				else
 					APT_KEY_TYPE="legacy"
@@ -72,7 +72,7 @@ main() {
 				OS="$ID"
 				VERSION="$VERSION_ID"
 				PACKAGETYPE="dnf"
-				if [ "$VERSION" =~ ^7 ]; then
+				if expr "$VERSION" : "7.*" >/dev/null; then
 					PACKAGETYPE="yum"
 				fi
 				;;


### PR DESCRIPTION
=~ doesn't work in posix shell, only in bash, and we don't use bash.

Signed-off-by: David Anderson <danderson@tailscale.com>