### PR TITLE
net/dns: add GetBaseConfig to CallbackRouter.

### DIFF
--- a/ipn/ipnlocal/dnsconfig_test.go
+++ b/ipn/ipnlocal/dnsconfig_test.go
@@ -232,32 +232,11 @@ func TestDNSConfigForNetmap(t *testing.T) {
 			},
 		},
 		{
-			name: "android_does_need_fallbacks",
-			os:   "android",
-			nm: &netmap.NetworkMap{
-				DNS: tailcfg.DNSConfig{
-					FallbackResolvers: []dnstype.Resolver{
-						{Addr: "8.8.4.4"},
-					},
-					Routes: map[string][]dnstype.Resolver{
-						"foo.com.": {{Addr: "1.2.3.4"}},
-					},
-				},
-			},
-			prefs: &ipn.Prefs{
-				CorpDNS: true,
-			},
-			want: &dns.Config{
-				Hosts: map[dnsname.FQDN][]netaddr.IP{},
-				DefaultResolvers: []dnstype.Resolver{
-					{Addr: "8.8.4.4:53"},
-				},
-				Routes: map[dnsname.FQDN][]dnstype.Resolver{
-					"foo.com.": {{Addr: "1.2.3.4:53"}},
-				},
-			},
-		},
-		{
+			// Prior to fixing https://github.com/tailscale/tailscale/issues/2116,
+			// Android had cases where it needed FallbackResolvers. This was the
+			// negative test for the case where Override-local-DNS was set, so the
+			// fallback resolvers did not need to be used. This test is still valid
+			// so we keep it, but the fallback test has been removed.
 			name: "android_does_NOT_need_fallbacks",
 			os:   "android",
 			nm: &netmap.NetworkMap{

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -2075,9 +2075,6 @@ func dnsConfigForNetmap(nm *netmap.NetworkMap, prefs *ipn.Prefs, logf logger.Log
 		addDefault(nm.DNS.FallbackResolvers)
 	case len(dcfg.Routes) == 0:
 		// No settings requiring split DNS, no problem.
-	case versionOS == "android":
-		// We don't support split DNS at all on Android yet.
-		addDefault(nm.DNS.FallbackResolvers)
 	}
 
 	return dcfg

--- a/wgengine/router/callback.go
+++ b/wgengine/router/callback.go
@@ -18,6 +18,13 @@ type CallbackRouter struct {
 	SetBoth  func(rcfg *Config, dcfg *dns.OSConfig) error
 	SplitDNS bool
 
+	// GetBaseConfigFunc optionally specifies a function to return the current DNS
+	// config in response to GetBaseConfig.
+	//
+	// If nil, reading the current config isn't supported and GetBaseConfig()
+	// will return ErrGetBaseConfigNotSupported.
+	GetBaseConfigFunc func() (dns.OSConfig, error)
+
 	mu   sync.Mutex    // protects all the following
 	rcfg *Config       // last applied router config
 	dcfg *dns.OSConfig // last applied DNS config
@@ -50,7 +57,10 @@ func (r *CallbackRouter) SupportsSplitDNS() bool {
 }
 
 func (r *CallbackRouter) GetBaseConfig() (dns.OSConfig, error) {
-	return dns.OSConfig{}, dns.ErrGetBaseConfigNotSupported
+	if r.GetBaseConfigFunc == nil {
+		return dns.OSConfig{}, dns.ErrGetBaseConfigNotSupported
+	}
+	return r.GetBaseConfigFunc()
 }
 
 func (r *CallbackRouter) Close() error {

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -1199,7 +1199,7 @@ func (e *userspaceEngine) linkChange(changed bool, cur *interfaces.State) {
 	// suspend/resume or whenever NetworkManager is started, it
 	// nukes all systemd-resolved configs. So reapply our DNS
 	// config on major link change.
-	if runtime.GOOS == "linux" && changed {
+	if (runtime.GOOS == "linux" || runtime.GOOS == "android") && changed {
 		e.wgLock.Lock()
 		dnsCfg := e.lastDNSConfig
 		e.wgLock.Unlock()


### PR DESCRIPTION
Allow users of CallbackRouter to supply a GetBaseConfig
implementation. This is expected to be used on Android,
which currently lacks both a) platform support for
Split-DNS and b) a way to retrieve the current DNS
servers.

iOS/macOS also use the CallbackRouter but have platform
support for SplitDNS, so don't need getBaseConfig.

Updates https://github.com/tailscale/tailscale/issues/2116
Updates https://github.com/tailscale/tailscale/issues/988

Signed-off-by: Denton Gentry <dgentry@tailscale.com>