### PR TITLE
net/netcheck: implement netcheck for js/wasm clients

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -3578,6 +3578,9 @@ func (de *endpoint) sendPingsLocked(now mono.Time, sendCallMeMaybe bool) {
 			de.deleteEndpointLocked(ep)
 			continue
 		}
+		if runtime.GOOS == "js" {
+			continue
+		}
 		if !st.lastPing.IsZero() && now.Sub(st.lastPing) < discoPingInterval {
 			continue
 		}


### PR DESCRIPTION
And the derper change to add a CORS endpoint for latency measurement.

And a little magicsock change to cut down some log spam on js/wasm.

Updates #3157
