### PR TITLE
net/portmapper: ignore IGD SSDP responses from !defaultgw

### DIFF
--- a/net/portmapper/portmapper.go
+++ b/net/portmapper/portmapper.go
@@ -752,10 +752,14 @@ func (c *Client) Probe(ctx context.Context) (res ProbeResult, err error) {
 			}
 			return res, err
 		}
+		ip, ok := netaddr.FromStdIP(addr.(*net.UDPAddr).IP)
+		if !ok {
+			continue
+		}
 		port := uint16(addr.(*net.UDPAddr).Port)
 		switch port {
 		case c.upnpPort():
-			if mem.Contains(mem.B(buf[:n]), mem.S(":InternetGatewayDevice:")) {
+			if ip == gw && mem.Contains(mem.B(buf[:n]), mem.S(":InternetGatewayDevice:")) {
 				meta, err := parseUPnPDiscoResponse(buf[:n])
 				if err != nil {
 					c.logf("unrecognized UPnP discovery response; ignoring")


### PR DESCRIPTION
Now that we multicast the SSDP query, we can get IGD offers from
devices other than the current device's default gateway. We don't want
to accidentally bind ourselves to those.

Updates #3197

Signed-off-by: David Anderson <danderson@tailscale.com>