### PR TITLE
tailcfg: add RegisterRequest.Ephemeral to request new ephemeral node

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -642,6 +642,11 @@ type RegisterRequest struct {
 	Followup string // response waits until AuthURL is visited
 	Hostinfo *Hostinfo
 
+	// Ephemeral is whether the client is requesting that this
+	// node be considered ephemeral and be automatically deleted
+	// when it stops being active.
+	Ephemeral bool `json:",omitempty"`
+
 	// The following fields are not used for SignatureNone and are required for
 	// SignatureV1:
 	SignatureType SignatureType `json:",omitempty"`


### PR DESCRIPTION
So js/wasm clients can log in for a bit using regular Gmail/GitHub auth
without using an ephemeral key but still have their node cleaned up
when they're done.

Updates #3157
