### PR TITLE
Add multi-arch image make target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,9 @@ ARG VERSION_SHORT=""
 ENV VERSION_SHORT=$VERSION_SHORT
 ARG VERSION_GIT_HASH=""
 ENV VERSION_GIT_HASH=$VERSION_GIT_HASH
+ARG TARGETARCH
 
-RUN go install -tags=xversion -ldflags="\
+RUN GOARCH=$TARGETARCH go install -tags=xversion -ldflags="\
       -X tailscale.com/version.Long=$VERSION_LONG \
       -X tailscale.com/version.Short=$VERSION_SHORT \
       -X tailscale.com/version.GitCommit=$VERSION_GIT_HASH" \

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+IMAGE_REPO ?= tailscale/tailscale
+
 usage:
 	echo "See Makefile"
 
@@ -20,6 +22,10 @@ build386:
 
 buildlinuxarm:
 	GOOS=linux GOARCH=arm go install tailscale.com/cmd/tailscale tailscale.com/cmd/tailscaled
+
+
+buildmultiarchimage:
+	docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t ${IMAGE_REPO}:latest --push -f Dockerfile .
 
 check: staticcheck vet depaware buildwindows build386 buildlinuxarm
 


### PR DESCRIPTION
Add multi-arch image build target. 
It uses docker buildx capability to build a single image for multi-arch image support. 

We are developing native tailscale support for our project (https://synpse.net) and would be good to have something like this in master branch :)