### PR TITLE
ipn/ipnstate: use key.NodePublic instead of the generic key.Public.

### DIFF
--- a/derp/derp_server.go
+++ b/derp/derp_server.go
@@ -1006,10 +1006,10 @@ func (s *Server) verifyClient(clientKey key.NodePublic, info *clientInfo) error 
 	if err != nil {
 		return fmt.Errorf("failed to query local tailscaled status: %w", err)
 	}
-	if clientKey == key.NodePublicFromRaw32(mem.B(status.Self.PublicKey[:])) {
+	if clientKey == status.Self.PublicKey {
 		return nil
 	}
-	if _, exists := status.Peer[clientKey.AsPublic()]; !exists {
+	if _, exists := status.Peer[clientKey]; !exists {
 		return fmt.Errorf("client %v not in set of peers", clientKey)
 	}
 	// TODO(bradfitz): add policy for configurable bandwidth rate per client?

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/go-multierror/multierror"
+	"go4.org/mem"
 	"inet.af/netaddr"
 	"tailscale.com/client/tailscale/apitype"
 	"tailscale.com/control/controlclient"
@@ -388,7 +389,7 @@ func (b *LocalBackend) populatePeerStatusLocked(sb *ipnstate.StatusBuilder) {
 				tailscaleIPs = append(tailscaleIPs, addr.IP())
 			}
 		}
-		sb.AddPeer(key.Public(p.Key), &ipnstate.PeerStatus{
+		sb.AddPeer(key.NodePublicFromRaw32(mem.B(p.Key[:])), &ipnstate.PeerStatus{
 			InNetworkMap:       true,
 			ID:                 p.StableID,
 			UserID:             p.User,

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -3081,7 +3081,11 @@ func (c *Conn) UpdateStatus(sb *ipnstate.StatusBuilder) {
 	}
 
 	sb.MutateSelfStatus(func(ss *ipnstate.PeerStatus) {
-		ss.PublicKey = c.privateKey.Public()
+		if !c.privateKey.IsZero() {
+			ss.PublicKey = key.NodePrivateFromRaw32(mem.B(c.privateKey[:])).Public()
+		} else {
+			ss.PublicKey = key.NodePublic{}
+		}
 		ss.Addrs = make([]string, 0, len(c.lastEndpoints))
 		for _, ep := range c.lastEndpoints {
 			ss.Addrs = append(ss.Addrs, ep.Addr.String())
@@ -3113,7 +3117,7 @@ func (c *Conn) UpdateStatus(sb *ipnstate.StatusBuilder) {
 		ps := &ipnstate.PeerStatus{InMagicSock: true}
 		//ps.Addrs = append(ps.Addrs, n.Endpoints...)
 		ep.populatePeerStatus(ps)
-		sb.AddPeer(key.Public(ep.publicKey), ps)
+		sb.AddPeer(key.NodePublicFromRaw32(mem.B(ep.publicKey[:])), ps)
 	})
 
 	c.foreachActiveDerpSortedLocked(func(node int, ad activeDerp) {

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -205,8 +205,8 @@ func (s *magicStack) Close() {
 	s.conn.Close()
 }
 
-func (s *magicStack) Public() key.Public {
-	return s.privateKey.Public().AsPublic()
+func (s *magicStack) Public() key.NodePublic {
+	return s.privateKey.Public()
 }
 
 func (s *magicStack) Status() *ipnstate.Status {
@@ -995,10 +995,10 @@ func testTwoDevicePing(t *testing.T, d *devices) {
 
 	// Wait for magicsock to be told about peers from meshStacks.
 	tstest.WaitFor(10*time.Second, func() error {
-		if p := m1.Status().Peer[m2.privateKey.Public().AsPublic()]; p == nil || !p.InMagicSock {
+		if p := m1.Status().Peer[m2.Public()]; p == nil || !p.InMagicSock {
 			return errors.New("m1 not ready")
 		}
-		if p := m2.Status().Peer[m1.privateKey.Public().AsPublic()]; p == nil || !p.InMagicSock {
+		if p := m2.Status().Peer[m1.Public()]; p == nil || !p.InMagicSock {
 			return errors.New("m2 not ready")
 		}
 		return nil

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -1242,7 +1242,7 @@ func (e *userspaceEngine) UpdateStatus(sb *ipnstate.StatusBuilder) {
 		return
 	}
 	for _, ps := range st.Peers {
-		sb.AddPeer(key.Public(ps.NodeKey), &ipnstate.PeerStatus{
+		sb.AddPeer(key.NodePublicFromRaw32(mem.B(ps.NodeKey[:])), &ipnstate.PeerStatus{
 			RxBytes:       int64(ps.RxBytes),
 			TxBytes:       int64(ps.TxBytes),
 			LastHandshake: ps.LastHandshake,


### PR DESCRIPTION
This is a mechanical no-op change, except one thing: when ipnstate.Status is serialized to json, node keys which used to be base64-stringified are now stringified to their "typed hex" form, e.g.:

```
"PublicKey": "UHKhXe+c8o53n6tis65+I5jcuhyMgVgIoeSkLl+we38=",
```

Becomes

```
"PublicKey": "nodekey:c6cc72173c28f67e33c6514ca1c036ae62cd87b983088ab7d69fca98531eb86a",
```

This matters because this struct is exposed over the localapi, so the output format of `tailscale status --json` changes, as does anyone programmatically accessing it not using the right version of tailscale.com/client/tailscale.

WDYT? Worth doing some MarhsalJSON tedium to preserve the B64 encoding in this one place?