### PR TITLE
wgengine/magicsock: use key.NodePublic instead of tailcfg.NodeKey.

### DIFF
--- a/wgengine/pendopen.go
+++ b/wgengine/pendopen.go
@@ -231,7 +231,7 @@ func (e *userspaceEngine) onOpenTimeout(flow flowtrack.Tuple) {
 	e.logf("open-conn-track: timeout opening %v to node %v; online=%v, lastRecv=%v",
 		flow, n.Key.ShortString(),
 		online,
-		e.magicConn.LastRecvActivityOfNodeKey(n.Key))
+		e.magicConn.LastRecvActivityOfNodeKey(n.Key.AsNodePublic()))
 }
 
 func durFmt(t time.Time) string {

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -554,7 +554,8 @@ func isTrimmablePeer(p *wgcfg.Peer, numPeers int) bool {
 // noteRecvActivity is called by magicsock when a packet has been
 // received for the peer with node key nk. Magicsock calls this no
 // more than every 10 seconds for a given peer.
-func (e *userspaceEngine) noteRecvActivity(nk tailcfg.NodeKey) {
+func (e *userspaceEngine) noteRecvActivity(k key.NodePublic) {
+	nk := k.AsNodeKey()
 	e.wgLock.Lock()
 	defer e.wgLock.Unlock()
 

--- a/wgengine/userspace_test.go
+++ b/wgengine/userspace_test.go
@@ -45,7 +45,8 @@ func TestNoteReceiveActivity(t *testing.T) {
 	}
 	ra := e.recvActivityAt
 
-	nk := key.NewNode().Public().AsNodeKey()
+	nk := key.NewNode().Public()
+	tnk := nk.AsNodeKey()
 
 	// Activity on an untracked key should do nothing.
 	e.noteRecvActivity(nk)
@@ -57,12 +58,12 @@ func TestNoteReceiveActivity(t *testing.T) {
 	}
 
 	// Now track it, but don't mark it trimmed, so shouldn't update.
-	ra[nk] = 0
+	ra[tnk] = 0
 	e.noteRecvActivity(nk)
 	if len(ra) != 1 {
 		t.Fatalf("unexpected growth in map: now has %d keys; want 1", len(ra))
 	}
-	if got := ra[nk]; got != now {
+	if got := ra[tnk]; got != now {
 		t.Fatalf("time in map = %v; want %v", got, now)
 	}
 	if gotConf() {
@@ -70,12 +71,12 @@ func TestNoteReceiveActivity(t *testing.T) {
 	}
 
 	// Now mark it trimmed and expect an update.
-	e.trimmedNodes[nk] = true
+	e.trimmedNodes[tnk] = true
 	e.noteRecvActivity(nk)
 	if len(ra) != 1 {
 		t.Fatalf("unexpected growth in map: now has %d keys; want 1", len(ra))
 	}
-	if got := ra[nk]; got != now {
+	if got := ra[tnk]; got != now {
 		t.Fatalf("time in map = %v; want %v", got, now)
 	}
 	if !gotConf() {


### PR DESCRIPTION
Signed-off-by: David Anderson <danderson@tailscale.com>