### PR TITLE
add in dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+*.md
+AUTHORS
+LICENSE
+PATENTS
+*.txt


### PR DESCRIPTION
extra files in the build container probably don't matter so much due to the multi-stage build, but if there are additional files that can be ignored, particularly tests or artefacts that don't need to be copied over, it would speed up the build, and there's no reason not to do it.

Signed-off-by: Adam Leskis <leskis@gmail.com>