### PR TITLE
net/interfaces/windows: update Tailscale interface detection logic to account for new wintun naming.

### DIFF
--- a/net/interfaces/interfaces_windows.go
+++ b/net/interfaces/interfaces_windows.go
@@ -116,8 +116,12 @@ func notTailscaleInterface(iface *winipcfg.IPAdapterAddresses) bool {
 	// TODO(bradfitz): do this without the Description method's
 	// utf16-to-string allocation. But at least we only do it for
 	// the virtual interfaces, for which there won't be many.
-	return !(iface.IfType == winipcfg.IfTypePropVirtual &&
-		iface.Description() == tsconst.WintunInterfaceDesc)
+	if iface.IfType != winipcfg.IfTypePropVirtual {
+		return true
+	}
+	desc := iface.Description()
+	return !(strings.Contains(desc, tsconst.WintunInterfaceDesc) ||
+		strings.Contains(desc, tsconst.WintunInterfaceDesc0_14))
 }
 
 // NonTailscaleInterfaces returns a map of interface LUID to interface

--- a/tsconst/interface.go
+++ b/tsconst/interface.go
@@ -7,5 +7,6 @@
 package tsconst
 
 // WintunInterfaceDesc is the description attached to Tailscale
-// interfaces on Windows. This is set by our modified WinTun driver.
+// interfaces on Windows. This is set by the WinTun driver.
 const WintunInterfaceDesc = "Tailscale Tunnel"
+const WintunInterfaceDesc0_14 = "Wintun Userspace Tunnel"


### PR DESCRIPTION
With wintun 0.14, we end up binding to the wrong default interface. This is likely related to the new installation mechanism which probably also changed the naming of the tunnel. We are looking for `Tailscale Tunnel` in the description, but now it's `Wintun Userspace Tunnel #24`. 

Fixes #3260

Signed-off-by: Maisem Ali <maisem@tailscale.com>