### PR TITLE
tstest/integration/testcontrol: fix data race

### DIFF
--- a/tstest/integration/testcontrol/testcontrol.go
+++ b/tstest/integration/testcontrol/testcontrol.go
@@ -157,10 +157,11 @@ func (s *Server) AddPingRequest(nodeKeyDst key.NodePublic, pr *tailcfg.PingReque
 // Mark the Node key of every node as expired
 func (s *Server) SetExpireAllNodes(expired bool) {
 	s.mu.Lock()
-	s.allExpired = expired
-	s.mu.Unlock()
+	defer s.mu.Unlock()
 
-	for _, node := range s.AllNodes() {
+	s.allExpired = expired
+
+	for _, node := range s.nodes {
 		sendUpdate(s.updates[node.ID], updateSelfChanged)
 	}
 }


### PR DESCRIPTION
Fix race from 1ec99e99f4e701fa1b9edef9eb0fbe022c5efebd

Fixes #3289
