### PR TITLE
cmd/tailscale/cli: add "debug metrics" subcommand

### DIFF
--- a/client/tailscale/tailscale.go
+++ b/client/tailscale/tailscale.go
@@ -196,6 +196,12 @@ func Goroutines(ctx context.Context) ([]byte, error) {
 	return get200(ctx, "/localapi/v0/goroutines")
 }
 
+// DaemonMetrics returns the Tailscale daemon's metrics in
+// the Prometheus text exposition format.
+func DaemonMetrics(ctx context.Context) ([]byte, error) {
+	return get200(ctx, "/localapi/v0/metrics")
+}
+
 // Profile returns a pprof profile of the Tailscale daemon.
 func Profile(ctx context.Context, pprofType string, sec int) ([]byte, error) {
 	var secArg string

--- a/cmd/tailscale/cli/debug.go
+++ b/cmd/tailscale/cli/debug.go
@@ -46,17 +46,22 @@ var debugCmd = &ffcli.Command{
 			Exec:      runDaemonGoroutines,
 			ShortHelp: "print tailscaled's goroutines",
 		},
-		&ffcli.Command{
+		{
+			Name:      "metrics",
+			Exec:      runDaemonMetrics,
+			ShortHelp: "print tailscaled's metrics",
+		},
+		{
 			Name:      "env",
 			Exec:      runEnv,
 			ShortHelp: "print cmd/tailscale environment",
 		},
-		&ffcli.Command{
+		{
 			Name:      "local-creds",
 			Exec:      runLocalCreds,
 			ShortHelp: "print how to access Tailscale local API",
 		},
-		&ffcli.Command{
+		{
 			Name:      "prefs",
 			Exec:      runPrefs,
 			ShortHelp: "print prefs",
@@ -66,7 +71,7 @@ var debugCmd = &ffcli.Command{
 				return fs
 			})(),
 		},
-		&ffcli.Command{
+		{
 			Name:      "watch-ipn",
 			Exec:      runWatchIPN,
 			ShortHelp: "subscribe to IPN message bus",
@@ -243,5 +248,14 @@ func runDaemonGoroutines(ctx context.Context, args []string) error {
 		return err
 	}
 	Stdout.Write(goroutines)
+	return nil
+}
+
+func runDaemonMetrics(ctx context.Context, args []string) error {
+	out, err := tailscale.DaemonMetrics(ctx)
+	if err != nil {
+		return err
+	}
+	Stdout.Write(out)
 	return nil
 }


### PR DESCRIPTION
To let users inspect the tailscaled metrics easily.

Updates #3307
