### PR TITLE
wgengine/router: add debug knob to resort to Linux "ip" command usage

### DIFF
--- a/wgengine/router/router_linux.go
+++ b/wgengine/router/router_linux.go
@@ -183,11 +183,16 @@ func useAmbientCaps() bool {
 	return v >= 7
 }
 
+var forceIPCommand, _ = strconv.ParseBool(os.Getenv("TS_DEBUG_USE_IP_COMMAND"))
+
 // useIPCommand reports whether r should use the "ip" command (or its
 // fake commandRunner for tests) instead of netlink.
 func (r *linuxRouter) useIPCommand() bool {
 	if r.cmd == nil {
 		panic("invalid init")
+	}
+	if forceIPCommand {
+		return true
 	}
 	// In the future we might need to fall back to using the "ip"
 	// command if, say, netlink is blocked somewhere but the ip


### PR DESCRIPTION
Tailscale 1.18 uses netlink instead of the "ip" command to program the
Linux kernel.

The old way was kept primarily for tests, but this also adds a
TS_DEBUG_USE_IP_COMMAND environment knob to force the old way
temporarily for debugging anybody who might have problems with the
new way in 1.18.

Updates #391
