### PR TITLE
wgengine/router: fix checkIPRuleSupportsV6 to actually use IPv6

### DIFF
--- a/wgengine/router/router_linux_test.go
+++ b/wgengine/router/router_linux_test.go
@@ -803,7 +803,7 @@ func TestDebugListRules(t *testing.T) {
 }
 
 func TestCheckIPRuleSupportsV6(t *testing.T) {
-	err := checkIPRuleSupportsV6()
+	err := checkIPRuleSupportsV6(t.Logf)
 	if err != nil && os.Getuid() != 0 {
 		t.Skipf("skipping, error when not root: %v", err)
 	}


### PR DESCRIPTION
Updates #3358 (should fix it)
Updates #391
