### PR TITLE
wgengine/monitor: ignore adding/removing uninteresting IPs

### DIFF
--- a/wgengine/monitor/monitor.go
+++ b/wgengine/monitor/monitor.go
@@ -310,7 +310,7 @@ func (m *Mon) debounce() {
 			}
 
 			oldState := m.ifState
-			ifChanged := !curState.EqualFiltered(oldState, interfaces.FilterInteresting)
+			ifChanged := !curState.EqualFiltered(oldState, interfaces.UseInterestingInterfaces, interfaces.UseInterestingIPs)
 			if ifChanged {
 				m.gwValid = false
 				m.ifState = curState

--- a/wgengine/monitor/polling.go
+++ b/wgengine/monitor/polling.go
@@ -77,7 +77,7 @@ func (pm *pollingMon) Receive() (message, error) {
 	defer ticker.Stop()
 	base := pm.m.InterfaceState()
 	for {
-		if cur, err := pm.m.interfaceStateUncached(); err == nil && !cur.EqualFiltered(base, interfaces.FilterInteresting) {
+		if cur, err := pm.m.interfaceStateUncached(); err == nil && !cur.EqualFiltered(base, interfaces.UseInterestingInterfaces, interfaces.UseInterestingIPs) {
 			return unspecifiedMessage{}, nil
 		}
 		select {


### PR DESCRIPTION
One of the most common "unexpected" log lines is:

"network state changed, but stringification didn't"

One way that this can occur is if an interesting interface
(non-Tailscale, has interesting IP address)
gains or loses an uninteresting IP address (link local or loopback).

The fact that the interface is interesting is enough for EqualFiltered
to inspect it. The fact that an IP address changed is enough for
EqualFiltered to declare that the interfaces are not equal.

But the State.String method reasonably declines to print any
uninteresting IP addresses. As a result, the network state appears
to have changed, but the stringification did not.

The String method is correct; nothing interesting happened.

This change fixes this by adding an IP address filter to EqualFiltered
in addition to the interface filter. This lets the network monitor
ignore the addition/removal of uninteresting IP addresses.

Signed-off-by: Josh Bleecher Snyder <josh@tailscale.com>
