### PR TITLE
build_docker.sh: use `github.com/tailscale/mkctr` instead of docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,5 @@ RUN GOARCH=$TARGETARCH go install -tags=xversion -ldflags="\
       -X tailscale.com/version.GitCommit=$VERSION_GIT_HASH" \
       -v ./cmd/tailscale ./cmd/tailscaled
 
-FROM alpine:3.14
-RUN apk add --no-cache ca-certificates iptables iproute2 ip6tables
+FROM ghcr.io/tailscale/alpine-base:3.14
 COPY --from=build-env /go/bin/* /usr/local/bin/

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,6 @@
+# Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+FROM alpine:3.14
+RUN apk add --no-cache ca-certificates iptables iproute2 ip6tables

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,8 @@ build386:
 buildlinuxarm:
 	GOOS=linux GOARCH=arm go install tailscale.com/cmd/tailscale tailscale.com/cmd/tailscaled
 
-
 buildmultiarchimage:
-	docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t ${IMAGE_REPO}:latest --push -f Dockerfile .
+	./build_docker.sh
 
 check: staticcheck vet depaware buildwindows build386 buildlinuxarm
 

--- a/build_dist.sh
+++ b/build_dist.sh
@@ -30,12 +30,14 @@ else
 fi
 
 long_suffix="$change_suffix-t$short_hash"
-SHORT="$major.$minor.$patch"
+MINOR="$major.$minor"
+SHORT="$MINOR.$patch"
 LONG="${SHORT}$long_suffix"
 GIT_HASH="$git_hash"
 
 if [ "$1" = "shellvars" ]; then
 	cat <<EOF
+VERSION_MINOR="$MINOR"
 VERSION_SHORT="$SHORT"
 VERSION_LONG="$LONG"
 VERSION_GIT_HASH="$GIT_HASH"

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -21,8 +21,15 @@ set -eu
 
 eval $(./build_dist.sh shellvars)
 
-docker build \
-  --build-arg VERSION_LONG=$VERSION_LONG \
-  --build-arg VERSION_SHORT=$VERSION_SHORT \
-  --build-arg VERSION_GIT_HASH=$VERSION_GIT_HASH \
-  -t tailscale:$VERSION_SHORT -t tailscale:latest .
+go run github.com/tailscale/mkctr@latest \
+  --base="ghcr.io/tailscale/alpine-base:3.14" \
+  --gopaths="\
+    tailscale.com/cmd/tailscale:/usr/local/bin/tailscale, \
+    tailscale.com/cmd/tailscaled:/usr/local/bin/tailscaled" \
+  --ldflags="\
+    -X tailscale.com/version.Long=${VERSION_LONG} \
+    -X tailscale.com/version.Short=${VERSION_SHORT} \
+    -X tailscale.com/version.GitCommit=${VERSION_GIT_HASH}" \
+  --tags="${VERSION_SHORT},${VERSION_MINOR}" \
+  --repos="tailscale/tailscale,ghcr.io/tailscale/tailscale" \
+  --push


### PR DESCRIPTION
We recently added support for building cross platform docker containers using `docker buildx`. However, docker does cross platform builds by emulating the target arch using qemu. That is obviously very slow to build and consumes 100% of the cpu, and when run on `arm64` machines has a tendency to fail completely.

This in contrast, is a small go binary which uses `GOOS= GOARCH= go build` directly to compile the binaries and then uses [google/go-containerregistry](https://github.com/google/go-containerregistry) to create and publish the new containers based on the desired platform.

This does introduce an extra step to generate a base alpine image, however the base image is going to change less frequently than our code so I think the extra step is ok.

Signed-off-by: Maisem Ali <maisem@tailscale.com>