### PR TITLE
wgengine/router: demote TestDebugListRules fail to skip

### DIFF
--- a/wgengine/router/router_linux_test.go
+++ b/wgengine/router/router_linux_test.go
@@ -793,7 +793,7 @@ func TestDebugListRules(t *testing.T) {
 		t.Run(famName[fam], func(t *testing.T) {
 			rules, err := netlink.RuleList(fam)
 			if err != nil {
-				t.Fatal(err)
+				t.Skipf("skip; RuleList fails with: %v", err)
 			}
 			for _, r := range rules {
 				t.Logf("Rule: %+v", r)


### PR DESCRIPTION
Updates #3360
