### PR TITLE
net/tshttpproxy: use correct size for Windows BOOL argument

### DIFF
--- a/net/tshttpproxy/tshttpproxy_windows.go
+++ b/net/tshttpproxy/tshttpproxy_windows.go
@@ -190,7 +190,7 @@ type autoProxyOptions struct {
 	AutoConfigUrl          *uint16
 	_                      uintptr
 	_                      uint32
-	FAutoLogonIfChallenged bool
+	FAutoLogonIfChallenged int32 // BOOL
 }
 
 // WINHTTP_PROXY_INFO


### PR DESCRIPTION
The Windows BOOL type is an int32. We were using a bool,
which is a one byte wide. This could be responsible for the
ERROR_INVALID_PARAMETER errors we were seeing for calls to
WinHttpGetProxyForUrl.

We manually checked all other existing Windows syscalls
for similar mistakes and did not find any.

Updates #879

Co-authored-by: Aaron Klotz <aaron@tailscale.com>
Signed-off-by: Josh Bleecher Snyder <josh@tailscale.com>
