### PR TITLE
.github/workflows: check that repo is clean after build and test

### DIFF
--- a/.github/workflows/linux-race.yml
+++ b/.github/workflows/linux-race.yml
@@ -31,6 +31,21 @@ jobs:
     - name: Run tests and benchmarks with -race flag on linux
       run: go test -race -bench=. -benchtime=1x ./...
 
+    - name: Check that no tracked files in the repo have been modified
+      run: git diff --no-ext-diff --name-only --exit-code || (echo "Build/test modified the files above."; exit 1)
+
+    - name: Check that no files have been added to the repo
+      run: |
+        # Note: The "error: pathspec..." you see below is normal!
+        # In the success case in which there are no new untracked files,
+        # git ls-files complains about the pathspec not matching anything.
+        # That's OK. It's not worth the effort to suppress. Please ignore it.
+        if git ls-files --others --exclude-standard --directory --no-empty-directory --error-unmatch -- ':/*'
+        then
+          echo "Build/test created untracked files in the repo (file names above)."
+          exit 1
+        fi
+
     - uses: k0kubun/action-slack@v2.0.0
       with:
         payload: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -40,6 +40,21 @@ jobs:
     - name: Run tests on linux
       run: go test -bench=. -benchtime=1x ./...
 
+    - name: Check that no tracked files in the repo have been modified
+      run: git diff --no-ext-diff --name-only --exit-code || (echo "Build/test modified the files above."; exit 1)
+
+    - name: Check that no files have been added to the repo
+      run: |
+        # Note: The "error: pathspec..." you see below is normal!
+        # In the success case in which there are no new untracked files,
+        # git ls-files complains about the pathspec not matching anything.
+        # That's OK. It's not worth the effort to suppress. Please ignore it.
+        if git ls-files --others --exclude-standard --directory --no-empty-directory --error-unmatch -- ':/*'
+        then
+          echo "Build/test created untracked files in the repo (file names above)."
+          exit 1
+        fi
+
     - uses: k0kubun/action-slack@v2.0.0
       with:
         payload: |

--- a/.github/workflows/linux32.yml
+++ b/.github/workflows/linux32.yml
@@ -31,6 +31,21 @@ jobs:
     - name: Run tests on linux
       run: GOARCH=386 go test -bench=. -benchtime=1x ./...
 
+    - name: Check that no tracked files in the repo have been modified
+      run: git diff --no-ext-diff --name-only --exit-code || (echo "Build/test modified the files above."; exit 1)
+
+    - name: Check that no files have been added to the repo
+      run: |
+        # Note: The "error: pathspec..." you see below is normal!
+        # In the success case in which there are no new untracked files,
+        # git ls-files complains about the pathspec not matching anything.
+        # That's OK. It's not worth the effort to suppress. Please ignore it.
+        if git ls-files --others --exclude-standard --directory --no-empty-directory --error-unmatch -- ':/*'
+        then
+          echo "Build/test created untracked files in the repo (file names above)."
+          exit 1
+        fi
+
     - uses: k0kubun/action-slack@v2.0.0
       with:
         payload: |


### PR DESCRIPTION
Linux-only for now, to avoid having to figure out why
powershell doesn't like my shell scripting. (Not that I blame it.)
That'll be enough to catch most regressions.

Fixes #1083

Co-authored-by: Aaron Klotz <aaron@tailscale.com>
Signed-off-by: Josh Bleecher Snyder <josh@tailscale.com>
