### PR TITLE
tsshd: fix double exit with different exit codes

### DIFF
--- a/cmd/tsshd/tsshd.go
+++ b/cmd/tsshd/tsshd.go
@@ -157,8 +157,9 @@ func handleSSH(s ssh.Session) {
 		cmd.Process.Kill()
 		if err := cmd.Wait(); err != nil {
 			s.Exit(1)
+		} else {
+			s.Exit(0)
 		}
-		s.Exit(0)
 		return
 	}
 


### PR DESCRIPTION
There was a bug where the code ended up doing:

```go
s.Exit(1)
s.Exit(0)
```
(SSH session `Exit()` is not same as `os.Exit()` which would not continue running the code)