### PR TITLE
net/dns: handle comments in resolv.conf

### DIFF
--- a/net/dns/direct.go
+++ b/net/dns/direct.go
@@ -56,8 +56,11 @@ func readResolv(r io.Reader) (config OSConfig, err error) {
 		}
 
 		if strings.HasPrefix(line, "nameserver") {
-			nameserver := strings.TrimPrefix(line, "nameserver")
-			nameserver = strings.TrimSpace(nameserver)
+			s := strings.TrimPrefix(line, "nameserver")
+			nameserver := strings.TrimSpace(s)
+			if len(nameserver) == len(s) {
+				return OSConfig{}, fmt.Errorf("missing space after \"nameserver\" in %q", line)
+			}
 			ip, err := netaddr.ParseIP(nameserver)
 			if err != nil {
 				return OSConfig{}, err
@@ -67,8 +70,12 @@ func readResolv(r io.Reader) (config OSConfig, err error) {
 		}
 
 		if strings.HasPrefix(line, "search") {
-			domain := strings.TrimPrefix(line, "search")
-			domain = strings.TrimSpace(domain)
+			s := strings.TrimPrefix(line, "search")
+			domain := strings.TrimSpace(s)
+			if len(domain) == len(s) {
+				// No leading space?!
+				return OSConfig{}, fmt.Errorf("missing space after \"domain\" in %q", line)
+			}
 			fqdn, err := dnsname.ToFQDN(domain)
 			if err != nil {
 				return OSConfig{}, fmt.Errorf("parsing search domains %q: %w", line, err)

--- a/net/dns/direct.go
+++ b/net/dns/direct.go
@@ -50,6 +50,10 @@ func readResolv(r io.Reader) (config OSConfig, err error) {
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
+		i := strings.IndexByte(line, '#')
+		if i >= 0 {
+			line = line[:i]
+		}
 
 		if strings.HasPrefix(line, "nameserver") {
 			nameserver := strings.TrimPrefix(line, "nameserver")

--- a/net/dns/direct_test.go
+++ b/net/dns/direct_test.go
@@ -169,7 +169,22 @@ func TestReadResolve(t *testing.T) {
 			},
 		},
 		{in: `nameserver #192.168.0.100`, wantErr: true},
+		{in: `nameserver`, wantErr: true},
 		{in: `# nameserver 192.168.0.100`, want: OSConfig{}},
+		{in: `nameserver192.168.0.100`, wantErr: true},
+
+		{in: `search tailsacle.com`,
+			want: OSConfig{
+				SearchDomains: []dnsname.FQDN{"tailsacle.com."},
+			},
+		},
+		{in: `search tailsacle.com # typo`,
+			want: OSConfig{
+				SearchDomains: []dnsname.FQDN{"tailsacle.com."},
+			},
+		},
+		{in: `searchtailsacle.com`, wantErr: true},
+		{in: `search`, wantErr: true},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Currently, comments in resolv.conf cause our parser to fail,
with error messages like:

ParseIP("192.168.0.100 # comment"): unexpected character (at " # comment")

Fix that.

Noticed while looking through logs.

Signed-off-by: Josh Bleecher Snyder <josh@tailscale.com>
