### PR TITLE
portmap: remove "saw UPnP type ..." log message

### DIFF
--- a/net/portmapper/upnp.go
+++ b/net/portmapper/upnp.go
@@ -17,7 +17,6 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/tailscale/goupnp"
@@ -191,15 +190,6 @@ func getUPnPClient(ctx context.Context, logf logger.Logf, gw netaddr.IP, meta uP
 	if err != nil {
 		return nil, err
 	}
-
-	defer func() {
-		if client == nil {
-			return
-		}
-		logf("saw UPnP type %v at %v; %v (%v)",
-			strings.TrimPrefix(fmt.Sprintf("%T", client), "*internetgateway2."),
-			meta.Location, root.Device.FriendlyName, root.Device.Manufacturer)
-	}()
 
 	// These parts don't do a network fetch.
 	// Pick the best service type available.


### PR DESCRIPTION
Not really useful now, portmap result is included in
`netcheck: report: udp=true... portmap=U` line.

Fixes https://github.com/tailscale/tailscale/issues/3425

Signed-off-by: Denton Gentry <dgentry@tailscale.com>