### PR TITLE
net/nettest: deflake TestPipeTimeout

### DIFF
--- a/net/nettest/pipe.go
+++ b/net/nettest/pipe.go
@@ -76,7 +76,7 @@ func (p *Pipe) Read(b []byte) (n int, err error) {
 	if debugPipe {
 		orig := b
 		defer func() {
-			log.Printf("Pipe(%q).Read( %q) n=%d, err=%v", p.name, string(orig[:n]), n, err)
+			log.Printf("Pipe(%q).Read(%q) n=%d, err=%v", p.name, string(orig[:n]), n, err)
 		}()
 	}
 	for n == 0 {

--- a/net/nettest/pipe_test.go
+++ b/net/nettest/pipe_test.go
@@ -60,9 +60,6 @@ func TestPipeTimeout(t *testing.T) {
 	t.Run("block-write", func(t *testing.T) {
 		p := NewPipe("p1", 1<<16)
 		p.SetWriteDeadline(time.Now().Add(10 * time.Millisecond))
-		if _, err := p.Write([]byte{'h'}); err != nil {
-			t.Fatal(err)
-		}
 		if err := p.Block(); err != nil {
 			t.Fatal(err)
 		}
@@ -75,9 +72,6 @@ func TestPipeTimeout(t *testing.T) {
 		p.Write([]byte{'h', 'i'})
 		p.SetReadDeadline(time.Now().Add(10 * time.Millisecond))
 		b := make([]byte, 1)
-		if _, err := p.Read(b); err != nil {
-			t.Fatal(err)
-		}
 		if err := p.Block(); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
The block-write and block-read tests are both flaky,
because each assumes it can get a normal read/write
completed within 10ms. This isn’t always true.

We can’t increase the timeouts, because that slows down the test.
However, we don’t need to issue a regular read/write for this test.
The immediately preceding tests already test this code,
using a far more generous timeout.

Remove the extraneous read/write.

This drops the failure rate from 1 per 20,000 to undetectable
on my machine.

While we’re here, fix a typo in a debug print statement.

Signed-off-by: Josh Bleecher Snyder <josh@tailscale.com>
