### PR TITLE
control/noise: clean up resources in TestNoReuse

### DIFF
--- a/control/noise/handshake_test.go
+++ b/control/noise/handshake_test.go
@@ -139,6 +139,9 @@ func TestNoReuse(t *testing.T) {
 			t.Fatalf("server wire traffic seen twice")
 		}
 		packets[serverWire] = true
+
+		server.Close()
+		client.Close()
 	}
 }
 


### PR DESCRIPTION
Close the server and client.
Without this, we leak system threads.

Signed-off-by: Josh Bleecher Snyder <josh@tailscale.com>
