### PR TITLE
wgengine/monitor: fix docs on Mon.InterfaceState

### DIFF
--- a/wgengine/monitor/monitor.go
+++ b/wgengine/monitor/monitor.go
@@ -104,8 +104,10 @@ func New(logf logger.Logf) (*Mon, error) {
 	return m, nil
 }
 
-// InterfaceState returns the state of the machine's network interfaces,
-// without any Tailscale ones.
+// InterfaceState returns the latest snapshot of the machine's network
+// interfaces.
+//
+// The returned value is owned by Mon; it must not be modified.
 func (m *Mon) InterfaceState() *interfaces.State {
 	m.mu.Lock()
 	defer m.mu.Unlock()


### PR DESCRIPTION
The behavior was changed in March (in 7f174e84e627dc04bc91352e9897f22cf4724191)
but that change forgot to update these docs.
