### PR TITLE
net/portmapper: deflake TestPCPIntegration

### DIFF
--- a/net/portmapper/igd_test.go
+++ b/net/portmapper/igd_test.go
@@ -63,10 +63,17 @@ type igdCounters struct {
 
 func NewTestIGD(logf logger.Logf, t TestIGDOptions) (*TestIGD, error) {
 	d := &TestIGD{
-		logf:   logf,
 		doPMP:  t.PMP,
 		doPCP:  t.PCP,
 		doUPnP: t.UPnP,
+	}
+	d.logf = func(msg string, args ...interface{}) {
+		// Don't log after the device has closed;
+		// stray trailing logging angers testing.T.Logf.
+		if d.closed.Get() {
+			return
+		}
+		logf(msg, args...)
 	}
 	var err error
 	if d.upnpConn, err = testListenUDP(); err != nil {


### PR DESCRIPTION
Logging in goroutines after the test completed
caused data races and panics. Prevent that.

Signed-off-by: Josh Bleecher Snyder <josh@tailscale.com>
