### PR TITLE
net/tsdial: give netstack a Dialer, start refactoring name resolution

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -317,7 +317,7 @@ func run() error {
 		panic("internal error: exit node resolver not wired up")
 	}
 
-	ns, err := newNetstack(logf, e)
+	ns, err := newNetstack(logf, dialer, e)
 	if err != nil {
 		return fmt.Errorf("newNetstack: %w", err)
 	}
@@ -525,12 +525,12 @@ func runDebugServer(mux *http.ServeMux, addr string) {
 	}
 }
 
-func newNetstack(logf logger.Logf, e wgengine.Engine) (*netstack.Impl, error) {
+func newNetstack(logf logger.Logf, dialer *tsdial.Dialer, e wgengine.Engine) (*netstack.Impl, error) {
 	tunDev, magicConn, ok := e.(wgengine.InternalsGetter).GetInternals()
 	if !ok {
 		return nil, fmt.Errorf("%T is not a wgengine.InternalsGetter", e)
 	}
-	return netstack.Create(logf, tunDev, e, magicConn)
+	return netstack.Create(logf, tunDev, e, magicConn, dialer)
 }
 
 // mustStartProxyListeners creates listeners for local SOCKS and HTTP

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -165,9 +165,6 @@ func NewLocalBackend(logf logger.Logf, logid string, store ipn.StateStore, diale
 	if dialer == nil {
 		dialer = new(tsdial.Dialer)
 	}
-	e.AddNetworkMapCallback(func(nm *netmap.NetworkMap) {
-		dialer.SetDNSMap(tsdial.DNSMapFromNetworkMap(nm))
-	})
 
 	osshare.SetFileSharingEnabled(false, logf)
 
@@ -2679,6 +2676,7 @@ func hasCapability(nm *netmap.NetworkMap, cap string) bool {
 }
 
 func (b *LocalBackend) setNetMapLocked(nm *netmap.NetworkMap) {
+	b.dialer.SetNetMap(nm)
 	var login string
 	if nm != nil {
 		login = nm.UserProfiles[nm.User].LoginName

--- a/ipn/ipnserver/server_test.go
+++ b/ipn/ipnserver/server_test.go
@@ -13,6 +13,7 @@ import (
 
 	"tailscale.com/ipn"
 	"tailscale.com/ipn/ipnserver"
+	"tailscale.com/net/tsdial"
 	"tailscale.com/safesocket"
 	"tailscale.com/wgengine"
 )
@@ -72,6 +73,6 @@ func TestRunMultipleAccepts(t *testing.T) {
 	}
 	defer ln.Close()
 
-	err = ipnserver.Run(ctx, logTriggerTestf, ln, store, nil /* mon */, "dummy_logid", ipnserver.FixedEngine(eng), opts)
+	err = ipnserver.Run(ctx, logTriggerTestf, ln, store, nil /* mon */, new(tsdial.Dialer), "dummy_logid", ipnserver.FixedEngine(eng), opts)
 	t.Logf("ipnserver.Run = %v", err)
 }

--- a/net/tsdial/dnsmap_test.go
+++ b/net/tsdial/dnsmap_test.go
@@ -19,7 +19,7 @@ func TestDNSMapFromNetworkMap(t *testing.T) {
 	tests := []struct {
 		name string
 		nm   *netmap.NetworkMap
-		want DNSMap
+		want dnsMap
 	}{
 		{
 			name: "self",
@@ -30,7 +30,7 @@ func TestDNSMapFromNetworkMap(t *testing.T) {
 					pfx("100::123/128"),
 				},
 			},
-			want: DNSMap{
+			want: dnsMap{
 				"foo":         ip("100.102.103.104"),
 				"foo.tailnet": ip("100.102.103.104"),
 			},
@@ -59,7 +59,7 @@ func TestDNSMapFromNetworkMap(t *testing.T) {
 					},
 				},
 			},
-			want: DNSMap{
+			want: dnsMap{
 				"foo":         ip("100.102.103.104"),
 				"foo.tailnet": ip("100.102.103.104"),
 				"a":           ip("100.0.0.201"),
@@ -91,7 +91,7 @@ func TestDNSMapFromNetworkMap(t *testing.T) {
 					},
 				},
 			},
-			want: DNSMap{
+			want: dnsMap{
 				"foo":         ip("100::123"),
 				"foo.tailnet": ip("100::123"),
 				"a":           ip("100::201"),
@@ -103,7 +103,7 @@ func TestDNSMapFromNetworkMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := DNSMapFromNetworkMap(tt.nm)
+			got := dnsMapFromNetworkMap(tt.nm)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("mismatch:\n got %v\nwant %v\n", got, tt.want)
 			}

--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -132,7 +132,7 @@ func (s *Server) start() error {
 		return fmt.Errorf("%T is not a wgengine.InternalsGetter", eng)
 	}
 
-	ns, err := netstack.Create(logf, tunDev, eng, magicConn)
+	ns, err := netstack.Create(logf, tunDev, eng, magicConn, dialer)
 	if err != nil {
 		return fmt.Errorf("netstack.Create: %w", err)
 	}


### PR DESCRIPTION
This starts to refactor tsdial.Dialer's name resolution to have
different stages: in-memory MagicDNS vs system resolution. A future
change will plug in ExitDNS resolution.

This also plumbs a Dialer into netstack and unexports the dnsMap
internals.

And it removes some of the async AddNetworkMapCallback usage and
replaces it with synchronous updates of the Dialer's netmap
from LocalBackend, since the LocalBackend has the Dialer too.

Updates #3475
