### PR TITLE
ipn/policy: treat DNS service as interesting so it's not filtered out

### DIFF
--- a/ipn/policy/policy.go
+++ b/ipn/policy/policy.go
@@ -14,7 +14,8 @@ import (
 // system (a version.OS value) is an interesting enough port to report
 // to our peer nodes for discovery purposes.
 func IsInterestingService(s tailcfg.Service, os string) bool {
-	if s.Proto == "peerapi4" || s.Proto == "peerapi6" {
+	switch s.Proto {
+	case tailcfg.PeerAPI4, tailcfg.PeerAPI6, tailcfg.PeerAPIDNS:
 		return true
 	}
 	if s.Proto != tailcfg.TCP {


### PR DESCRIPTION
The control plane is currently still eating it.

Updates #1713
