### PR TITLE
tstest/integration: allow tests to pass on machines also running the macOS GUI

### DIFF
--- a/ipn/ipnserver/server_test.go
+++ b/ipn/ipnserver/server_test.go
@@ -33,10 +33,11 @@ func TestRunMultipleAccepts(t *testing.T) {
 		t.Logf(format, args...)
 	}
 
+	s := safesocket.DefaultConnectionStrategy(socketPath)
 	connect := func() {
 		for i := 1; i <= 2; i++ {
 			logf("connect %d ...", i)
-			c, err := safesocket.Connect(socketPath, 0)
+			c, err := safesocket.Connect(s)
 			if err != nil {
 				t.Fatalf("safesocket.Connect: %v\n", err)
 			}

--- a/safesocket/basic_test.go
+++ b/safesocket/basic_test.go
@@ -48,7 +48,9 @@ func TestBasics(t *testing.T) {
 	}()
 
 	go func() {
-		c, err := Connect(sock, port)
+		s := DefaultConnectionStrategy(sock)
+		s.UsePort(port)
+		c, err := Connect(s)
 		if err != nil {
 			errs <- err
 			return

--- a/safesocket/pipe_windows.go
+++ b/safesocket/pipe_windows.go
@@ -11,8 +11,8 @@ import (
 	"syscall"
 )
 
-func connect(path string, port uint16) (net.Conn, error) {
-	pipe, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+func connect(s *ConnectionStrategy) (net.Conn, error) {
+	pipe, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", s.port))
 	if err != nil {
 		return nil, err
 	}

--- a/safesocket/safesocket_js.go
+++ b/safesocket/safesocket_js.go
@@ -17,6 +17,6 @@ func listen(path string, port uint16) (_ net.Listener, gotPort uint16, _ error) 
 	return ln, 1, err
 }
 
-func connect(path string, port uint16) (net.Conn, error) {
+func connect(_ *ConnectionStrategy) (net.Conn, error) {
 	return memconn.Dial("memu", memName)
 }

--- a/safesocket/safesocket_ps.go
+++ b/safesocket/safesocket_ps.go
@@ -32,6 +32,5 @@ func init() {
 			}
 		}
 		return false
-
 	}
 }

--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -62,7 +62,7 @@ func TestMain(m *testing.M) {
 	os.Exit(0)
 }
 
-func TestOneNodeUp_NoAuth(t *testing.T) {
+func TestOneNodeUpNoAuth(t *testing.T) {
 	t.Parallel()
 	bins := BuildTestBinaries(t)
 
@@ -190,7 +190,7 @@ func TestStateSavedOnStart(t *testing.T) {
 	d1.MustCleanShutdown(t)
 }
 
-func TestOneNodeUp_Auth(t *testing.T) {
+func TestOneNodeUpAuth(t *testing.T) {
 	t.Parallel()
 	bins := BuildTestBinaries(t)
 

--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -720,8 +720,10 @@ func (n *testNode) MustDown() {
 // AwaitListening waits for the tailscaled to be serving local clients
 // over its localhost IPC mechanism. (Unix socket, etc)
 func (n *testNode) AwaitListening(t testing.TB) {
+	s := safesocket.DefaultConnectionStrategy(n.sockFile)
+	s.UseFallback(false) // connect only to the tailscaled that we started
 	if err := tstest.WaitFor(20*time.Second, func() (err error) {
-		c, err := safesocket.Connect(n.sockFile, safesocket.WindowsLocalPort)
+		c, err := safesocket.Connect(s)
 		if err != nil {
 			return err
 		}

--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -700,8 +700,11 @@ func (n *testNode) MustUp(extraArgs ...string) {
 		"--login-server=" + n.env.ControlServer.URL,
 	}
 	args = append(args, extraArgs...)
-	t.Logf("Running %v ...", args)
-	if b, err := n.Tailscale(args...).CombinedOutput(); err != nil {
+	cmd := n.Tailscale(args...)
+	t.Logf("Running %v ...", cmd)
+	cmd.Stdout = nil // in case --verbose-tailscale was set
+	cmd.Stderr = nil // in case --verbose-tailscale was set
+	if b, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("up: %v, %v", string(b), err)
 	}
 }


### PR DESCRIPTION
- all: minor code cleanup
- tstest/integration: fix running with -verbose-tailscale
- safesocket: let callers control whether to dial IPNExtension as a fallback
