### PR TITLE
support running in a FreeBSD jail

### DIFF
--- a/wgengine/monitor/monitor_freebsd.go
+++ b/wgengine/monitor/monitor_freebsd.go
@@ -25,10 +25,11 @@ type devdConn struct {
 	conn net.Conn
 }
 
-func newOSMon(logf logger.Logf, _ *Mon) (osMon, error) {
+func newOSMon(logf logger.Logf, m *Mon) (osMon, error) {
 	conn, err := net.Dial("unixpacket", "/var/run/devd.seqpacket.pipe")
 	if err != nil {
-		return nil, fmt.Errorf("devd dial error: %v", err)
+		logf("devd dial error: %v, falling back to polling method", err)
+		return newPollingMon(logf, m)
 	}
 	return &devdConn{conn}, nil
 }

--- a/wgengine/monitor/polling.go
+++ b/wgengine/monitor/polling.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !freebsd && !windows && !darwin
-// +build !freebsd,!windows,!darwin
+//go:build !windows && !darwin
+// +build !windows,!darwin
 
 package monitor
 


### PR DESCRIPTION
Since devd apparently can't be made to work in a FreeBSD jail
fall back to polling.

Fixes tailscale#2858