### PR TITLE
Support "Taildrop" on TrueNAS

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -142,11 +142,11 @@ type LocalBackend struct {
 	// same as the Network Extension lifetime and we can thus avoid
 	// double-copying files by writing them to the right location
 	// immediately.
-	// It's also used on Synology, but in that case DoFinalRename is
-	// also set true, which moves the *.partial file to its final
+	// It's also used on Synology & TrueNAS, but in that case DoFinalRename
+	// is also set true, which moves the *.partial file to its final
 	// name on completion.
 	directFileRoot          string
-	directFileDoFinalRename bool // false on macOS, true on Synology
+	directFileDoFinalRename bool // false on macOS, true on Synology & TrueNAS
 
 	// statusLock must be held before calling statusChanged.Wait() or
 	// statusChanged.Broadcast().

--- a/version/distro/distro.go
+++ b/version/distro/distro.go
@@ -49,6 +49,9 @@ func linuxDistro() Distro {
 	switch {
 	case haveDir("/usr/syno"):
 		return Synology
+	case have("/usr/local/bin/freenas-debug"):
+		// TrueNAS Scale runs on debian
+		return TrueNAS
 	case have("/etc/debian_version"):
 		return Debian
 	case have("/etc/arch-release"):
@@ -70,6 +73,7 @@ func freebsdDistro() Distro {
 	case have("/usr/local/sbin/opnsense-shell"):
 		return OPNsense
 	case have("/usr/local/bin/freenas-debug"):
+		// TrueNAS Core runs on FreeBSD
 		return TrueNAS
 	}
 	return ""


### PR DESCRIPTION
I was experimenting with TrueNAS for another reason and happened to see Brad's change to add this support for dropping files directly to Synology store.  This implements the same feature for TrueNAS.  I don't feel strongly about it and may not be using TrueNAS much in the future, but figured I'd mail the change in case it was wanted.  This was tested on both FreeBSD TrueNAS Core and Debian/Linux TrueNAS Scale.