### PR TITLE
ipn/ipnstate: remove old deprecated TailAddr IPv4-only field

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -417,16 +417,9 @@ func (b *LocalBackend) populatePeerStatusLocked(sb *ipnstate.StatusBuilder) {
 		if p.LastSeen != nil {
 			lastSeen = *p.LastSeen
 		}
-		var tailAddr4 string
 		var tailscaleIPs = make([]netaddr.IP, 0, len(p.Addresses))
 		for _, addr := range p.Addresses {
 			if addr.IsSingleIP() && tsaddr.IsTailscaleIP(addr.IP()) {
-				if addr.IP().Is4() && tailAddr4 == "" {
-					// The peer struct previously only allowed a single
-					// Tailscale IP address. For compatibility for a few releases starting
-					// with 1.8, keep it pulled out as IPv4-only for a bit.
-					tailAddr4 = addr.IP().String()
-				}
 				tailscaleIPs = append(tailscaleIPs, addr.IP())
 			}
 		}
@@ -434,21 +427,20 @@ func (b *LocalBackend) populatePeerStatusLocked(sb *ipnstate.StatusBuilder) {
 			return r.Bits() == 0
 		})
 		sb.AddPeer(p.Key, &ipnstate.PeerStatus{
-			InNetworkMap:       true,
-			ID:                 p.StableID,
-			UserID:             p.User,
-			TailAddrDeprecated: tailAddr4,
-			TailscaleIPs:       tailscaleIPs,
-			HostName:           p.Hostinfo.Hostname,
-			DNSName:            p.Name,
-			OS:                 p.Hostinfo.OS,
-			KeepAlive:          p.KeepAlive,
-			Created:            p.Created,
-			LastSeen:           lastSeen,
-			Online:             p.Online != nil && *p.Online,
-			ShareeNode:         p.Hostinfo.ShareeNode,
-			ExitNode:           p.StableID != "" && p.StableID == b.prefs.ExitNodeID,
-			ExitNodeOption:     exitNodeOption,
+			InNetworkMap:   true,
+			ID:             p.StableID,
+			UserID:         p.User,
+			TailscaleIPs:   tailscaleIPs,
+			HostName:       p.Hostinfo.Hostname,
+			DNSName:        p.Name,
+			OS:             p.Hostinfo.OS,
+			KeepAlive:      p.KeepAlive,
+			Created:        p.Created,
+			LastSeen:       lastSeen,
+			Online:         p.Online != nil && *p.Online,
+			ShareeNode:     p.Hostinfo.ShareeNode,
+			ExitNode:       p.StableID != "" && p.StableID == b.prefs.ExitNodeID,
+			ExitNodeOption: exitNodeOption,
 		})
 	}
 }

--- a/ipn/ipnstate/ipnstate.go
+++ b/ipn/ipnstate/ipnstate.go
@@ -88,8 +88,7 @@ type PeerStatus struct {
 	OS        string // HostInfo.OS
 	UserID    tailcfg.UserID
 
-	TailAddrDeprecated string       `json:"TailAddr"` // Tailscale IP
-	TailscaleIPs       []netaddr.IP // Tailscale IP(s) assigned to this node
+	TailscaleIPs []netaddr.IP // Tailscale IP(s) assigned to this node
 
 	// Endpoints:
 	Addrs   []string
@@ -243,9 +242,6 @@ func (sb *StatusBuilder) AddPeer(peer key.NodePublic, st *PeerStatus) {
 	}
 	if v := st.UserID; v != 0 {
 		e.UserID = v
-	}
-	if v := st.TailAddrDeprecated; v != "" {
-		e.TailAddrDeprecated = v
 	}
 	if v := st.TailscaleIPs; v != nil {
 		e.TailscaleIPs = v

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -3097,7 +3097,6 @@ func (c *Conn) UpdateStatus(sb *ipnstate.StatusBuilder) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	var tailAddr4 string
 	var tailscaleIPs []netaddr.IP
 	if c.netMap != nil {
 		tailscaleIPs = make([]netaddr.IP, 0, len(c.netMap.Addresses))
@@ -3106,13 +3105,6 @@ func (c *Conn) UpdateStatus(sb *ipnstate.StatusBuilder) {
 				continue
 			}
 			sb.AddTailscaleIP(addr.IP())
-			// TailAddr previously only allowed for a
-			// single Tailscale IP. For compatibility for
-			// a couple releases starting with 1.8, keep
-			// that field pulled out separately.
-			if addr.IP().Is4() {
-				tailAddr4 = addr.IP().String()
-			}
 			tailscaleIPs = append(tailscaleIPs, addr.IP())
 		}
 	}
@@ -3135,7 +3127,6 @@ func (c *Conn) UpdateStatus(sb *ipnstate.StatusBuilder) {
 			}
 		}
 		ss.TailscaleIPs = tailscaleIPs
-		ss.TailAddrDeprecated = tailAddr4
 	})
 
 	c.peerMap.forEachEndpoint(func(ep *endpoint) {


### PR DESCRIPTION
It's been a bunch of releases now since the TailscaleIPs slice
replacement was added.
