### PR TITLE
wgengine/router{windows}: return the output from the firewallTweaker on error

### DIFF
--- a/wgengine/router/router_windows.go
+++ b/wgengine/router/router_windows.go
@@ -183,7 +183,10 @@ func (ft *firewallTweaker) runFirewall(args ...string) (time.Duration, error) {
 	args = append([]string{"advfirewall", "firewall"}, args...)
 	cmd := exec.Command("netsh", args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
-	err := cmd.Run()
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		err = fmt.Errorf("%w: %v", err, string(b))
+	}
 	return time.Since(t0).Round(time.Millisecond), err
 }
 


### PR DESCRIPTION
While debugging a customer issue where the firewallTweaker was failing
the only message we have is `router: firewall: error adding
Tailscale-Process rule: exit status 1` which is not really helpful.
This will hopefully help diagnose the failure.

Signed-off-by: Maisem Ali <maisem@tailscale.com>

<img src="https://frontapp.com/assets/img/favicons/favicon-32x32.png" height="16" width="16" alt="Front logo" /> [Front conversations](https://app.frontapp.com/open/top_40aoh)