### PR TITLE
ipn/ipnlocal: clear magicsock's netmap on logout

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -536,6 +536,7 @@ func (b *LocalBackend) setClientStatus(st controlclient.Status) {
 		// Since st.NetMap==nil means "netmap is unchanged", there is
 		// no other way to represent this change.
 		b.setNetMapLocked(nil)
+		b.e.SetNetworkMap(new(netmap.NetworkMap))
 	}
 
 	prefs := b.prefs

--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -655,6 +655,9 @@ func (n *testNode) StartDaemonAsIPNGOOS(t testing.TB, ipnGOOS string) *Daemon {
 		"--socket="+n.sockFile,
 		"--socks5-server=localhost:0",
 	)
+	if *verboseTailscaled {
+		cmd.Args = append(cmd.Args, "-verbose=2")
+	}
 	cmd.Env = append(os.Environ(),
 		"TS_LOG_TARGET="+n.env.LogCatcherServer.URL,
 		"HTTP_PROXY="+n.env.TrafficTrapServer.URL,

--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -239,13 +239,15 @@ func (ns *Impl) updateIPs(nm *netmap.NetworkMap) {
 	newIPs := make(map[tcpip.AddressWithPrefix]bool)
 
 	isAddr := map[netaddr.IPPrefix]bool{}
-	for _, ipp := range nm.SelfNode.Addresses {
-		isAddr[ipp] = true
-	}
-	for _, ipp := range nm.SelfNode.AllowedIPs {
-		local := isAddr[ipp]
-		if local && ns.ProcessLocalIPs || !local && ns.ProcessSubnets {
-			newIPs[ipPrefixToAddressWithPrefix(ipp)] = true
+	if nm.SelfNode != nil {
+		for _, ipp := range nm.SelfNode.Addresses {
+			isAddr[ipp] = true
+		}
+		for _, ipp := range nm.SelfNode.AllowedIPs {
+			local := isAddr[ipp]
+			if local && ns.ProcessLocalIPs || !local && ns.ProcessSubnets {
+				newIPs[ipPrefixToAddressWithPrefix(ipp)] = true
+			}
 		}
 	}
 


### PR DESCRIPTION
- tstest/integration: make -verbose-tailscaled pass -verbose=2 to tailscaled
- ipn/ipnlocal: clear magicsock's netmap on logout
