### PR TITLE
ipn/ipnlocal, health: populate self node's Online bit in tailscale status

### DIFF
--- a/health/health.go
+++ b/health/health.go
@@ -168,7 +168,8 @@ func GotStreamedMapResponse() {
 	selfCheckLocked()
 }
 
-// SetInPollNetMap records that we're in
+// SetInPollNetMap records whether the client has an open
+// HTTP long poll open to the control plane.
 func SetInPollNetMap(v bool) {
 	mu.Lock()
 	defer mu.Unlock()
@@ -181,6 +182,14 @@ func SetInPollNetMap(v bool) {
 	} else {
 		lastMapPollEndedAt = time.Now()
 	}
+}
+
+// GetInPollNetMap reports whether the client has an open
+// HTTP long poll open to the control plane.
+func GetInPollNetMap() bool {
+	mu.Lock()
+	defer mu.Unlock()
+	return inMapPoll
 }
 
 // SetMagicSockDERPHome notes what magicsock's view of its home DERP is.

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -380,6 +380,7 @@ func (b *LocalBackend) updateStatus(sb *ipnstate.StatusBuilder, extraLocked func
 		}
 	})
 	sb.MutateSelfStatus(func(ss *ipnstate.PeerStatus) {
+		ss.Online = health.GetInPollNetMap()
 		if b.netMap != nil {
 			ss.HostName = b.netMap.Hostinfo.Hostname
 			ss.DNSName = b.netMap.Name


### PR DESCRIPTION
One option was to just hide "offline" in the text output, but that
doesn't fix the JSON output.

The next option was to lie and say it's online in the JSON (which then
fixes the "offline" in the text output).

But instead, this sets the self node's "Online" to whether we're in an
active map poll.

Fixes #3564
