### PR TITLE
cmd/tailscale: improve ping error message when logged out

### DIFF
--- a/cmd/tailscale/cli/ping.go
+++ b/cmd/tailscale/cli/ping.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"os"
 	"strings"
 	"time"
 
@@ -64,6 +65,16 @@ var pingArgs struct {
 }
 
 func runPing(ctx context.Context, args []string) error {
+	st, err := tailscale.Status(ctx)
+	if err != nil {
+		return fixTailscaledConnectError(err)
+	}
+	description, ok := isRunningOrStarting(st)
+	if !ok {
+		printf("%s\n", description)
+		os.Exit(1)
+	}
+
 	c, bc, ctx, cancel := connect(ctx)
 	defer cancel()
 


### PR DESCRIPTION
Refactor out the pretty status printing code from status, use it in ping.

Fixes #3549

Signed-off-by: Josh Bleecher Snyder <josh@tailscale.com>
