### PR TITLE
wgengine/magicsock: don't unconditionally close DERP connections on rebind

### DIFF
--- a/derp/derphttp/derphttp_client.go
+++ b/derp/derphttp/derphttp_client.go
@@ -774,6 +774,21 @@ func (c *Client) SendPing(data [8]byte) error {
 	return client.SendPing(data)
 }
 
+// LocalAddr reports c's local TCP address, without any implicit
+// connect or reconnect.
+func (c *Client) LocalAddr() (netaddr.IPPort, error) {
+	c.mu.Lock()
+	closed, client := c.closed, c.client
+	c.mu.Unlock()
+	if closed {
+		return netaddr.IPPort{}, ErrClientClosed
+	}
+	if client == nil {
+		return netaddr.IPPort{}, errors.New("client not connected")
+	}
+	return client.LocalAddr()
+}
+
 func (c *Client) ForwardPacket(from, to key.NodePublic, b []byte) error {
 	client, _, err := c.connect(context.TODO(), "derphttp.Client.ForwardPacket")
 	if err != nil {

--- a/net/tsaddr/tsaddr.go
+++ b/net/tsaddr/tsaddr.go
@@ -176,6 +176,16 @@ func PrefixesContainsFunc(ipp []netaddr.IPPrefix, f func(netaddr.IPPrefix) bool)
 	return false
 }
 
+// PrefixesContainsIP reports whether any prefix in ipp contains ip.
+func PrefixesContainsIP(ipp []netaddr.IPPrefix, ip netaddr.IP) bool {
+	for _, r := range ipp {
+		if r.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
 // IPsContainsFunc reports whether f is true for any IP in ips.
 func IPsContainsFunc(ips []netaddr.IP, f func(netaddr.IP) bool) bool {
 	for _, v := range ips {


### PR DESCRIPTION
Only if the source address isn't on the currently active interface or
a ping of the DERP server fails.

Updates #3619
