### PR TITLE
net/interfaces: define DefaultRouteInterface and State.DefaultRouteInterface

### DIFF
--- a/net/interfaces/interfaces_darwin.go
+++ b/net/interfaces/interfaces_darwin.go
@@ -16,16 +16,18 @@ import (
 	"inet.af/netaddr"
 )
 
-func DefaultRouteInterface() (string, error) {
+func defaultRoute() (d DefaultRouteDetails, err error) {
 	idx, err := DefaultRouteInterfaceIndex()
 	if err != nil {
-		return "", err
+		return d, err
 	}
 	iface, err := net.InterfaceByIndex(idx)
 	if err != nil {
-		return "", err
+		return d, err
 	}
-	return iface.Name, nil
+	d.InterfaceName = iface.Name
+	d.InterfaceIndex = idx
+	return d, nil
 }
 
 // fetchRoutingTable calls route.FetchRIB, fetching NET_RT_DUMP2.

--- a/net/interfaces/interfaces_defaultrouteif_todo.go
+++ b/net/interfaces/interfaces_defaultrouteif_todo.go
@@ -11,6 +11,6 @@ import "errors"
 
 var errTODO = errors.New("TODO")
 
-func DefaultRouteInterface() (string, error) {
-	return "TODO", errTODO
+func defaultRoute() (DefaultRouteDetails, error) {
+	return DefaultRouteDetails{}, errTODO
 }

--- a/net/interfaces/interfaces_linux.go
+++ b/net/interfaces/interfaces_linux.go
@@ -122,17 +122,18 @@ func likelyHomeRouterIPAndroid() (ret netaddr.IP, ok bool) {
 	return ret, !ret.IsZero()
 }
 
-// DefaultRouteInterface returns the name of the network interface that owns
-// the default route, not including any tailscale interfaces.
-func DefaultRouteInterface() (string, error) {
+func defaultRoute() (d DefaultRouteDetails, err error) {
 	v, err := defaultRouteInterfaceProcNet()
 	if err == nil {
-		return v, nil
+		d.InterfaceName = v
+		return d, nil
 	}
 	if runtime.GOOS == "android" {
-		return defaultRouteInterfaceAndroidIPRoute()
+		v, err = defaultRouteInterfaceAndroidIPRoute()
+		d.InterfaceName = v
+		return d, err
 	}
-	return v, err
+	return d, err
 }
 
 var zeroRouteBytes = []byte("00000000")

--- a/net/interfaces/interfaces_test.go
+++ b/net/interfaces/interfaces_test.go
@@ -104,3 +104,55 @@ func TestStateEqualFilteredIPFilter(t *testing.T) {
 		t.Errorf("%+v == %+v when restricting to interesting interfaces and IPs", s1, s2)
 	}
 }
+
+func TestStateString(t *testing.T) {
+	tests := []struct {
+		name string
+		s    *State
+		want string
+	}{
+		{
+			name: "typical_linux",
+			s: &State{
+				DefaultRouteInterface: "eth0",
+				Interface: map[string]Interface{
+					"eth0": {
+						Interface: &net.Interface{
+							Flags: net.FlagUp,
+						},
+					},
+					"wlan0": {
+						Interface: &net.Interface{},
+					},
+				},
+				InterfaceIPs: map[string][]netaddr.IPPrefix{
+					"eth0": []netaddr.IPPrefix{
+						netaddr.MustParseIPPrefix("10.0.0.2/8"),
+					},
+				},
+				HaveV4: true,
+			},
+			want: `interfaces.State{defaultRoute=eth0 ifs={eth0:[10.0.0.2/8]} v4=true v6=false}`,
+		},
+		{
+			name: "default_desc",
+			s: &State{
+				DefaultRouteInterface: "foo",
+				Interface: map[string]Interface{
+					"foo": {
+						Desc: "a foo thing",
+					},
+				},
+			},
+			want: `interfaces.State{defaultRoute=foo (a foo thing) ifs={} v4=false v6=false}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.s.String()
+			if got != tt.want {
+				t.Errorf("wrong\n got: %s\nwant: %s\n", got, tt.want)
+			}
+		})
+	}
+}

--- a/net/interfaces/interfaces_windows.go
+++ b/net/interfaces/interfaces_windows.go
@@ -5,7 +5,6 @@
 package interfaces
 
 import (
-	"fmt"
 	"log"
 	"net"
 	"net/url"
@@ -217,18 +216,20 @@ func GetWindowsDefault(family winipcfg.AddressFamily) (*winipcfg.IPAdapterAddres
 	return bestIface, nil
 }
 
-func DefaultRouteInterface() (string, error) {
+func defaultRoute() (d DefaultRouteDetails, err error) {
 	// We always return the IPv4 default route.
 	// TODO(bradfitz): adjust API if/when anything cares. They could in theory differ, though,
 	// in which case we might send traffic to the wrong interface.
 	iface, err := GetWindowsDefault(windows.AF_INET)
 	if err != nil {
-		return "", err
+		return d, err
 	}
-	if iface == nil {
-		return "(none)", nil
+	if iface != nil {
+		d.InterfaceName = iface.FriendlyName()
+		d.InterfaceDesc = iface.Description()
+		d.InterfaceIndex = int(iface.IfIndex)
 	}
-	return fmt.Sprintf("%s (%s)", iface.FriendlyName(), iface.Description()), nil
+	return d, nil
 }
 
 var (


### PR DESCRIPTION
It was pretty ill-defined before and mostly for logging. But I wanted
to start depending on it, so define what it is and make Windows match
the other operating systems, without losing the log output we had
before. (and add tests for that)
