### PR TITLE
ipnlocal, net/{dns,tsaddr,tstun}, wgengine: support MagicDNS on IPv6

### DIFF
--- a/ipn/ipnlocal/dnsconfig_test.go
+++ b/ipn/ipnlocal/dnsconfig_test.go
@@ -111,7 +111,8 @@ func TestDNSConfigForNetmap(t *testing.T) {
 			},
 			prefs: &ipn.Prefs{},
 			want: &dns.Config{
-				Routes: map[dnsname.FQDN][]dnstype.Resolver{},
+				OnlyIPv6: true,
+				Routes:   map[dnsname.FQDN][]dnstype.Resolver{},
 				Hosts: map[dnsname.FQDN][]netaddr.IP{
 					"b.net.":       ips("fe75::2"),
 					"myname.net.":  ips("fe75::1"),

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1951,6 +1951,7 @@ func dnsConfigForNetmap(nm *netmap.NetworkMap, prefs *ipn.Prefs, logf logger.Log
 	// selfV6Only is whether we only have IPv6 addresses ourselves.
 	selfV6Only := tsaddr.PrefixesContainsFunc(nm.Addresses, tsaddr.PrefixIs6) &&
 		!tsaddr.PrefixesContainsFunc(nm.Addresses, tsaddr.PrefixIs4)
+	dcfg.OnlyIPv6 = selfV6Only
 
 	// Populate MagicDNS records. We do this unconditionally so that
 	// quad-100 can always respond to MagicDNS queries, even if the OS
@@ -2382,7 +2383,9 @@ func (b *LocalBackend) routerConfig(cfg *wgcfg.Config, prefs *ipn.Prefs) *router
 		}
 	}
 
-	rs.Routes = append(rs.Routes, netaddr.IPPrefixFrom(tsaddr.TailscaleServiceIP(), 32))
+	if tsaddr.PrefixesContainsFunc(rs.LocalAddrs, tsaddr.PrefixIs4) {
+		rs.Routes = append(rs.Routes, netaddr.IPPrefixFrom(tsaddr.TailscaleServiceIP(), 32))
+	}
 
 	return rs
 }

--- a/net/dns/config.go
+++ b/net/dns/config.go
@@ -11,6 +11,7 @@ import (
 
 	"inet.af/netaddr"
 	"tailscale.com/net/dns/resolver"
+	"tailscale.com/net/tsaddr"
 	"tailscale.com/types/dnstype"
 	"tailscale.com/util/dnsname"
 )
@@ -40,6 +41,16 @@ type Config struct {
 	// it to resolve, you also need to add appropriate routes to
 	// Routes.
 	Hosts map[dnsname.FQDN][]netaddr.IP
+	// OnlyIPv6, if true, uses the IPv6 service IP (for MagicDNS)
+	// instead of the IPv4 version (100.100.100.100).
+	OnlyIPv6 bool
+}
+
+func (c *Config) serviceIP() netaddr.IP {
+	if c.OnlyIPv6 {
+		return tsaddr.TailscaleServiceIPv6()
+	}
+	return tsaddr.TailscaleServiceIP()
 }
 
 // WriteToBufioWriter write a debug version of c for logs to w, omitting

--- a/net/dns/manager.go
+++ b/net/dns/manager.go
@@ -12,7 +12,6 @@ import (
 	"inet.af/netaddr"
 	"tailscale.com/health"
 	"tailscale.com/net/dns/resolver"
-	"tailscale.com/net/tsaddr"
 	"tailscale.com/net/tsdial"
 	"tailscale.com/types/dnstype"
 	"tailscale.com/types/logger"
@@ -122,7 +121,7 @@ func (m *Manager) compileConfig(cfg Config) (rcfg resolver.Config, ocfg OSConfig
 		// through quad-100.
 		rcfg.Routes = routes
 		rcfg.Routes["."] = cfg.DefaultResolvers
-		ocfg.Nameservers = []netaddr.IP{tsaddr.TailscaleServiceIP()}
+		ocfg.Nameservers = []netaddr.IP{cfg.serviceIP()}
 		return rcfg, ocfg, nil
 	}
 
@@ -159,7 +158,7 @@ func (m *Manager) compileConfig(cfg Config) (rcfg resolver.Config, ocfg OSConfig
 	// or routes + MagicDNS, or just MagicDNS, or on an OS that cannot
 	// split-DNS. Install a split config pointing at quad-100.
 	rcfg.Routes = routes
-	ocfg.Nameservers = []netaddr.IP{tsaddr.TailscaleServiceIP()}
+	ocfg.Nameservers = []netaddr.IP{cfg.serviceIP()}
 
 	// If the OS can't do native split-dns, read out the underlying
 	// resolver config and blend it into our config.

--- a/net/dns/resolver/tsdns.go
+++ b/net/dns/resolver/tsdns.go
@@ -377,7 +377,7 @@ func (r *Resolver) HandleExitNodeDNSQuery(ctx context.Context, q []byte, from ne
 		// TODO: more than 1 resolver from /etc/resolv.conf?
 
 		var resolvers []resolverAndDelay
-		if nameserver == tsaddr.TailscaleServiceIP() {
+		if nameserver == tsaddr.TailscaleServiceIP() || nameserver == tsaddr.TailscaleServiceIPv6() {
 			// If resolv.conf says 100.100.100.100, it's coming right back to us anyway
 			// so avoid the loop through the kernel and just do what we
 			// would've done anyway. By not passing any resolvers, the forwarder

--- a/net/tsaddr/tsaddr.go
+++ b/net/tsaddr/tsaddr.go
@@ -36,12 +36,24 @@ var (
 	tsUlaRange   oncePrefix
 	ula4To6Range oncePrefix
 	ulaEph6Range oncePrefix
+	serviceIPv6  oncePrefix
 )
 
-// TailscaleServiceIP returns the listen address of services
+// TailscaleServiceIP returns the IPv4 listen address of services
 // provided by Tailscale itself such as the MagicDNS proxy.
+//
+// For IPv6, use TailscaleServiceIPv6.
 func TailscaleServiceIP() netaddr.IP {
 	return netaddr.IPv4(100, 100, 100, 100) // "100.100.100.100" for those grepping
+}
+
+// TailscaleServiceIPv6 returns the IPv6 listen address of the services
+// provided by Tailscale itself such as the MagicDNS proxy.
+//
+// For IPv4, use TailscaleServiceIP.
+func TailscaleServiceIPv6() netaddr.IP {
+	serviceIPv6.Do(func() { mustPrefix(&serviceIPv6.v, "fd7a:115c:a1e0::53/128") })
+	return serviceIPv6.v.IP()
 }
 
 // IsTailscaleIP reports whether ip is an IP address in a range that

--- a/net/tsaddr/tsaddr_test.go
+++ b/net/tsaddr/tsaddr_test.go
@@ -31,6 +31,14 @@ func TestInCrostiniRange(t *testing.T) {
 	}
 }
 
+func TestTailscaleServiceIPv6(t *testing.T) {
+	got := TailscaleServiceIPv6().String()
+	want := "fd7a:115c:a1e0::53"
+	if got != want {
+		t.Errorf("got %q; want %q", got, want)
+	}
+}
+
 func TestChromeOSVMRange(t *testing.T) {
 	if got, want := ChromeOSVMRange().String(), "100.115.92.0/23"; got != want {
 		t.Errorf("got %q; want %q", got, want)


### PR DESCRIPTION
Fixes #3660

RELNOTE=MagicDNS now works over IPv6 when CGNAT IPv4 is disabled.
