### PR TITLE
ipn/ipnlocal: fix cert fetching on macOS GUI platforms

### DIFF
--- a/cmd/tailscale/cli/cert.go
+++ b/cmd/tailscale/cli/cert.go
@@ -108,7 +108,7 @@ func runCert(ctx context.Context, args []string) error {
 		if version.IsMacSysExt() {
 			dir = "io.tailscale.ipn.macsys"
 		}
-		printf("Warning: the macOS CLI runs in a sandbox; this binary's filesystem writes go to $HOME/Library/Containers/%s\n", dir)
+		printf("Warning: the macOS CLI runs in a sandbox; this binary's filesystem writes go to $HOME/Library/Containers/%s/Data\n", dir)
 	}
 	if certArgs.certFile != "" {
 		certChanged, err := writeIfChanged(certArgs.certFile, certPEM, 0644)

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -2121,7 +2121,7 @@ func (b *LocalBackend) TailscaleVarRoot() string {
 		return b.varRoot
 	}
 	switch runtime.GOOS {
-	case "ios", "android":
+	case "ios", "android", "darwin":
 		dir, _ := paths.AppSharedDir.Load().(string)
 		return dir
 	}


### PR DESCRIPTION
And clarify the directory they get written to when under the sandbox.

Fixes #3667