### PR TITLE
wgengine/magicsock: fix watchdog timeout on Close when IPv6 not available

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -3121,6 +3121,7 @@ func (c *blockForeverConn) Close() error {
 		return net.ErrClosed
 	}
 	c.closed = true
+	c.cond.Broadcast()
 	return nil
 }
 


### PR DESCRIPTION
The blockForeverConn was only using its sync.Cond one side. Looks like it
was just forgotten.

Fixes #3671
