### PR TITLE
net/dns: make WSL network configuration opt-in for now

### DIFF
--- a/net/dns/manager_windows.go
+++ b/net/dns/manager_windows.go
@@ -7,8 +7,10 @@ package dns
 import (
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -33,6 +35,8 @@ const (
 
 	versionKey = `SOFTWARE\Microsoft\Windows NT\CurrentVersion`
 )
+
+var configureWSL, _ = strconv.ParseBool(os.Getenv("TS_DEBUG_CONFIGURE_WSL"))
 
 type windowsManager struct {
 	logf       logger.Logf
@@ -307,13 +311,15 @@ func (m windowsManager) SetDNS(cfg OSConfig) error {
 
 	// On initial setup of WSL, the restart caused by --shutdown is slow,
 	// so we do it out-of-line.
-	go func() {
-		if err := m.wslManager.SetDNS(cfg); err != nil {
-			m.logf("WSL SetDNS: %v", err) // continue
-		} else {
-			m.logf("WSL SetDNS: success")
-		}
-	}()
+	if configureWSL {
+		go func() {
+			if err := m.wslManager.SetDNS(cfg); err != nil {
+				m.logf("WSL SetDNS: %v", err) // continue
+			} else {
+				m.logf("WSL SetDNS: success")
+			}
+		}()
+	}
 
 	return nil
 }


### PR DESCRIPTION
Tailscale seems to be breaking WSL configurations lately.  Until we
understand what changed, turn off Tailscale's involvement by default
and make it opt-in.

Updates #2815
