### PR TITLE
cmd/tailscaled, util/winutil: add accessor functions for Windows syst…

### DIFF
--- a/cmd/tailscaled/tailscaled_windows.go
+++ b/cmd/tailscaled/tailscaled_windows.go
@@ -74,7 +74,7 @@ func (service *ipnService) Execute(args []string, r <-chan svc.ChangeRequest, ch
 	changes <- svc.Status{State: svc.StartPending}
 
 	svcAccepts := svc.AcceptStop
-	if winutil.GetRegInteger("FlushDNSOnSessionUnlock", 0) != 0 {
+	if winutil.GetPolicyInteger("FlushDNSOnSessionUnlock", 0) != 0 {
 		svcAccepts |= svc.AcceptSessionChange
 	}
 

--- a/util/winutil/winutil.go
+++ b/util/winutil/winutil.go
@@ -9,7 +9,31 @@ package winutil
 // are stored. This constant is a non-empty string only when GOOS=windows.
 const RegBase = regBase
 
-// GetRegString looks up a registry path in our local machine path, or returns
+// GetPolicyString looks up a registry value in the local machine's path for
+// system policies, or returns the given default if it can't.
+// Use this function to read values that may be set by sysadmins via the MSI
+// installer or via GPO. For registry settings that you do *not* want to be
+// visible to sysadmin tools, use GetRegString instead.
+//
+// This function will only work on GOOS=windows. Trying to run it on any other
+// OS will always return the default value.
+func GetPolicyString(name, defval string) string {
+	return getPolicyString(name, defval)
+}
+
+// GetPolicyInteger looks up a registry value in the local machine's path for
+// system policies, or returns the given default if it can't.
+// Use this function to read values that may be set by sysadmins via the MSI
+// installer or via GPO. For registry settings that you do *not* want to be
+// visible to sysadmin tools, use GetRegInteger instead.
+//
+// This function will only work on GOOS=windows. Trying to run it on any other
+// OS will always return the default value.
+func GetPolicyInteger(name string, defval uint64) uint64 {
+	return getPolicyInteger(name, defval)
+}
+
+// GetRegString looks up a registry path in the local machine path, or returns
 // the given default if it can't.
 //
 // This function will only work on GOOS=windows. Trying to run it on any other
@@ -18,7 +42,7 @@ func GetRegString(name, defval string) string {
 	return getRegString(name, defval)
 }
 
-// GetRegInteger looks up a registry path in our local machine path, or returns
+// GetRegInteger looks up a registry path in the local machine path, or returns
 // the given default if it can't.
 //
 // This function will only work on GOOS=windows. Trying to run it on any other

--- a/util/winutil/winutil_notwindows.go
+++ b/util/winutil/winutil_notwindows.go
@@ -9,6 +9,10 @@ package winutil
 
 const regBase = ``
 
+func getPolicyString(name, defval string) string { return defval }
+
+func getPolicyInteger(name string, defval uint64) uint64 { return defval }
+
 func getRegString(name, defval string) string { return defval }
 
 func getRegInteger(name string, defval uint64) uint64 { return defval }


### PR DESCRIPTION
…em policies

This patch adds new functions to be used when accessing system policies,
and revises callers to use the new functions. They first attempt the new
registry path for policies, and if that fails, attempt to fall back to the
legacy path.

The remaining changes will be done in corp.

Updates https://github.com/tailscale/tailscale/issues/3584

Signed-off-by: Aaron Klotz <aaron@tailscale.com>