### PR TITLE
.github/workflows: upgrade to setup-go@v2

### DIFF
--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2.1.4
         with:
           go-version: 1.17
         id: go


### PR DESCRIPTION
The rest of our workflows use v2.1.4.
