### PR TITLE
go.toolchain.rev: add update script

### DIFF
--- a/go.toolchain.branch
+++ b/go.toolchain.branch
@@ -1,0 +1,1 @@
+tailscale.go1.17

--- a/pull-toolchain.sh
+++ b/pull-toolchain.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Retrieve the latest Go toolchain.
+#
+set -eu
+cd "$(dirname "$0")"
+
+read -r go_branch <go.toolchain.branch
+upstream=$(git ls-remote https://github.com/tailscale/go "$go_branch" | awk '{print $1}')
+current=$(cat go.toolchain.rev)
+if [ "$upstream" != "$current" ]; then
+	echo "$upstream" >go.toolchain.rev
+fi
+
+if [ -n "$(git diff-index --name-only HEAD -- go.toolchain.rev)" ]; then
+    echo "pull-toolchain.sh: changes imported. Use git commit to make them permanent." >&2
+fi


### PR DESCRIPTION
Also go.toolchain.branch.

Both migrated from the corp repo.
