### PR TITLE
cmd/tailscale: let 'tailscale up --reset' do a pref edit

### DIFF
--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -787,6 +787,16 @@ func TestUpdatePrefs(t *testing.T) {
 			wantJustEditMP: &ipn.MaskedPrefs{WantRunningSet: true},
 		},
 		{
+			name:  "just_edit_reset",
+			flags: []string{"--reset"},
+			curPrefs: &ipn.Prefs{
+				ControlURL: ipn.DefaultControlURL,
+				Persist:    &persist.Persist{LoginName: "crawshaw.github"},
+			},
+			env:            upCheckEnv{backendState: "Running"},
+			wantJustEditMP: &ipn.MaskedPrefs{WantRunningSet: true},
+		},
+		{
 			name:  "control_synonym",
 			flags: []string{},
 			curPrefs: &ipn.Prefs{

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -413,7 +413,6 @@ func updatePrefs(prefs, curPrefs *ipn.Prefs, env upCheckEnv) (simpleUp bool, jus
 
 	justEdit := env.backendState == ipn.Running.String() &&
 		!env.upArgs.forceReauth &&
-		!env.upArgs.reset &&
 		env.upArgs.authKeyOrFile == "" &&
 		!controlURLChanged &&
 		!tagsChanged


### PR DESCRIPTION
The --reset shouldn't imply that a Start is necessary.

Fixes #3702
