### PR TITLE
cmd/tailscale/cli/web: fix typo where the html template data was being replaced instead of being appended to.

### DIFF
--- a/cmd/tailscale/cli/web.go
+++ b/cmd/tailscale/cli/web.go
@@ -375,7 +375,7 @@ func webHandler(w http.ResponseWriter, r *http.Request) {
 			data.AdvertiseExitNode = true
 		} else {
 			if data.AdvertiseRoutes != "" {
-				data.AdvertiseRoutes = ","
+				data.AdvertiseRoutes += ","
 			}
 			data.AdvertiseRoutes += r.String()
 		}


### PR DESCRIPTION
This caused the exit node toggle to stop working as ",10.0.6.1/32" is invalid.

Signed-off-by: Maisem Ali <maisem@tailscale.com>