### PR TITLE
cmd/tailscale: use html/template for synoTokenRedirect

### DIFF
--- a/cmd/tailscale/cli/web.go
+++ b/cmd/tailscale/cli/web.go
@@ -270,14 +270,14 @@ func synoTokenRedirect(w http.ResponseWriter, r *http.Request) bool {
 	// We need a SynoToken for authenticate.cgi.
 	// So we tell the client to get one.
 	serverURL := r.URL.Scheme + "://" + r.URL.Host
-	fmt.Fprintf(w, synoTokenRedirectHTML, serverURL)
+	synoTokenRedirectHTML.Execute(w, serverURL)
 	return true
 }
 
-const synoTokenRedirectHTML = `<html><body>
+var synoTokenRedirectHTML = template.Must(template.New("redirect").Parse(`<html><body>
 Redirecting with session token...
 <script>
-var serverURL = %q;
+var serverURL = {{ . }};
 var req = new XMLHttpRequest();
 req.overrideMimeType("application/json");
 req.open("GET", serverURL + "/webman/login.cgi", true);
@@ -289,7 +289,7 @@ req.onload = function() {
 req.send(null);
 </script>
 </body></html>
-`
+`))
 
 func webHandler(w http.ResponseWriter, r *http.Request) {
 	if authRedirect(w, r) {


### PR DESCRIPTION
The GitHub code scanner flagged this as a security vulnerability.
I don't believe it was, but I couldn't convince myself of it 100%.
Err on the safe side and use html/template to generate the HTML,
with all necessary escaping.

Signed-off-by: Josh Bleecher Snyder <josh@tailscale.com>
