### PR TITLE
net/dnscache: don't cancel the TLS context before writing to the result channel.

### DIFF
--- a/net/dnscache/dnscache.go
+++ b/net/dnscache/dnscache.go
@@ -457,9 +457,7 @@ func TLSDialer(fwd DialContextFunc, dnsCache *Resolver, tlsConfigBase *tls.Confi
 			}
 		}()
 		go func() {
-			err := tlsConn.Handshake()
-			handshakeTimeoutCancel()
-			errc <- err
+			errc <- tlsConn.Handshake()
 		}()
 		if err := <-errc; err != nil {
 			tcpConn.Close()


### PR DESCRIPTION
Cancelling the context makes the timeout goroutine race with the write that
reports a successful TLS handshake, so you can end up with a successful TLS
handshake that mysteriously reports that it timed out after ~0s in flight.

The context is always canceled and cleaned up as the function exits, which
happens mere microseconds later, so just let function exit clean up and
thereby avoid races.

Signed-off-by: David Anderson <danderson@tailscale.com>