### PR TITLE
tstime/rate: deflake TestLongRunningQPS

### DIFF
--- a/tstime/rate/rate_test.go
+++ b/tstime/rate/rate_test.go
@@ -185,7 +185,7 @@ func TestLongRunningQPS(t *testing.T) {
 	// This will still offer ~500 requests per second,
 	// but won't consume outrageous amount of CPU.
 	start := time.Now()
-	end := start.Add(5 * time.Second)
+	end := start.Add(1 * time.Second)
 	ticker := time.NewTicker(2 * time.Millisecond)
 	defer ticker.Stop()
 	for now := range ticker.C {
@@ -203,8 +203,9 @@ func TestLongRunningQPS(t *testing.T) {
 	if want := int32(ideal + 1); numOK > want {
 		t.Errorf("numOK = %d, want %d (ideal %f)", numOK, want, ideal)
 	}
-	// We should get very close to the number of requests allowed.
-	if want := int32(0.995 * ideal); numOK < want {
+	// We should get close-ish to the number of requests allowed.
+	// Trying to get too close causes flakes. Treat this as a sanity check.
+	if want := int32(0.9 * ideal); numOK < want {
 		t.Errorf("numOK = %d, want %d (ideal %f)", numOK, want, ideal)
 	}
 }


### PR DESCRIPTION
This test set the bar too high.
Just a couple of missed timers was enough to fail.
Change the test to more of a sanity check.
While we're here, run it for just 1s instead of 5s.

Prior to this change, on a 13" M1 MPB, with

stress -p 512 ./rate.test -test.run=QPS

I saw 90%+ failures.

After this change, I'm at 30k runs with no failures yet.

Fixes #3733

Signed-off-by: Josh Bleecher Snyder <josh@tailscale.com>
