### PR TITLE
words: fallout from mudpuppy-gate.

### DIFF
--- a/words/scales.txt
+++ b/words/scales.txt
@@ -102,7 +102,6 @@ coho
 lake
 arctic
 pumpkinseed
-salamander
 gopher
 chickadee
 toad


### PR DESCRIPTION
Salamanders also have no scales. I checked the interweb, and there
doesn't seem to be any subspecies that would let us claim that
*some* salamanders are scaley.

But they are tailey, for sure.

Signed-off-by: David Anderson <danderson@tailscale.com>