### PR TITLE
cmd/tailscale: Propagate tailscaled 403s as AccessDeniedErrors

### DIFF
--- a/cmd/tailscale/cli/cert.go
+++ b/cmd/tailscale/cli/cert.go
@@ -13,7 +13,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"runtime"
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -92,9 +91,6 @@ func runCert(ctx context.Context, args []string) error {
 		certArgs.keyFile = domain + ".key"
 	}
 	certPEM, keyPEM, err := tailscale.CertPair(ctx, domain)
-	if tailscale.IsAccessDeniedError(err) && os.Getuid() != 0 && runtime.GOOS != "windows" {
-		return fmt.Errorf("%v\n\nUse 'sudo tailscale cert' or 'tailscale up --operator=$USER' to not require root.", err)
-	}
 	if err != nil {
 		return err
 	}

--- a/cmd/tailscale/cli/cli.go
+++ b/cmd/tailscale/cli/cli.go
@@ -171,6 +171,9 @@ change in the future.
 	})
 
 	err := rootCmd.Run(context.Background())
+	if tailscale.IsAccessDeniedError(err) && os.Getuid() != 0 && runtime.GOOS != "windows" {
+		return fmt.Errorf("%v\n\nUse 'sudo tailscale %s' or 'tailscale up --operator=$USER' to not require root.", err, strings.Join(args, " "))
+	}
 	if errors.Is(err, flag.ErrHelp) {
 		return nil
 	}

--- a/cmd/tailscale/cli/file.go
+++ b/cmd/tailscale/cli/file.go
@@ -324,7 +324,7 @@ func runFileGet(ctx context.Context, args []string) error {
 	for {
 		wfs, err = tailscale.WaitingFiles(ctx)
 		if err != nil {
-			return fmt.Errorf("getting WaitingFiles: %v", err)
+			return err
 		}
 		if len(wfs) != 0 || !getArgs.wait {
 			break
@@ -379,7 +379,7 @@ func wipeInbox(ctx context.Context) error {
 	}
 	wfs, err := tailscale.WaitingFiles(ctx)
 	if err != nil {
-		return fmt.Errorf("getting WaitingFiles: %v", err)
+		return err
 	}
 	deleted := 0
 	for _, wf := range wfs {

--- a/cmd/tailscale/cli/file.go
+++ b/cmd/tailscale/cli/file.go
@@ -324,7 +324,7 @@ func runFileGet(ctx context.Context, args []string) error {
 	for {
 		wfs, err = tailscale.WaitingFiles(ctx)
 		if err != nil {
-			return err
+			return fmt.Errorf("getting WaitingFiles: %w", err)
 		}
 		if len(wfs) != 0 || !getArgs.wait {
 			break
@@ -379,7 +379,7 @@ func wipeInbox(ctx context.Context) error {
 	}
 	wfs, err := tailscale.WaitingFiles(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting WaitingFiles: %w", err)
 	}
 	deleted := 0
 	for _, wf := range wfs {


### PR DESCRIPTION
linux users get helpful advice to run tailscale with --operator=$USER
when they try to 'tailscale file {cp,get}' but are mysteriously forbidden.

Signed-off-by: David Eger <david.eger@gmail.com>