### PR TITLE
ipn/ipnserver: add TS_PERMIT_CERT_UID envknob to give webservers cert access

### DIFF
--- a/ipn/localapi/cert.go
+++ b/ipn/localapi/cert.go
@@ -66,7 +66,7 @@ func (h *Handler) certDir() (string, error) {
 var acmeDebug = envknob.Bool("TS_DEBUG_ACME")
 
 func (h *Handler) serveCert(w http.ResponseWriter, r *http.Request) {
-	if !h.PermitWrite {
+	if !h.PermitWrite && !h.PermitCert {
 		http.Error(w, "cert access denied", http.StatusForbidden)
 		return
 	}

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -52,7 +52,14 @@ type Handler struct {
 	PermitRead bool
 
 	// PermitWrite is whether mutating HTTP handlers are allowed.
+	// If PermitWrite is true, everything is allowed.
+	// It effectively means that the user is root or the admin
+	// (operator user).
 	PermitWrite bool
+
+	// PermitCert is whether the client is additionally granted
+	// cert fetching access.
+	PermitCert bool
 
 	b            *ipnlocal.LocalBackend
 	logf         logger.Logf


### PR DESCRIPTION
So you can run Caddy etc as a non-root user and let it have access to
get certs.

Updates caddyserver/caddy#4541
