### PR TITLE
wgengine/magicsock: make debugUseDerpRoute an opt.Bool.

### DIFF
--- a/wgengine/magicsock/debugknobs_ios.go
+++ b/wgengine/magicsock/debugknobs_ios.go
@@ -4,16 +4,18 @@
 
 package magicsock
 
+import "tailscale.com/types/opt"
+
 // All knobs are disabled on iOS.
 // Further, they're const, so the toolchain can produce smaller binaries.
 const (
-	debugDisco              = false
-	debugOmitLocalAddresses = false
-	debugUseDerpRouteEnv    = ""
-	debugUseDerpRoute       = false
-	logDerpVerbose          = false
-	debugReSTUNStopOnIdle   = false
-	debugAlwaysDERP         = false
+	debugDisco                       = false
+	debugOmitLocalAddresses          = false
+	debugUseDerpRouteEnv             = ""
+	debugUseDerpRoute       opt.Bool = ""
+	logDerpVerbose                   = false
+	debugReSTUNStopOnIdle            = false
+	debugAlwaysDERP                  = false
 )
 
 func inTest() bool { return false }


### PR DESCRIPTION
Can still be constant, just needs the extra methods.

Fixes #3812

Signed-off-by: David Anderson <danderson@tailscale.com>