### PR TITLE
net/dns/resolvd: properly handle not having "search" entries

### DIFF
--- a/net/dns/resolvd.go
+++ b/net/dns/resolvd.go
@@ -60,7 +60,9 @@ func (m *resolvdManager) SetDNS(config OSConfig) error {
 		newSearch = append(newSearch, s.WithoutTrailingDot())
 	}
 
-	newResolvConf = append(newResolvConf, []byte(strings.Join(newSearch, " "))...)
+	if len(newSearch) > 1 {
+		newResolvConf = append(newResolvConf, []byte(strings.Join(newSearch, " "))...)
+	}
 
 	err = m.fs.WriteFile(resolvConf, newResolvConf, 0644)
 	if err != nil {


### PR DESCRIPTION
This prevents adding an empty "search" line when no search domains are set.

Signed-off-by: Aaron Bieber <aaron@bolddaemon.com>