### PR TITLE
ipn/ipnserver, util/winutil: update workaround for os/user.LookupId f…

### DIFF
--- a/util/winutil/winutil_notwindows.go
+++ b/util/winutil/winutil_notwindows.go
@@ -2,23 +2,12 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !windows
-// +build !windows
-
 package winutil
 
-const RegBase = ``
+const regBase = ``
 
-// GetRegString looks up a registry path in our local machine path, or returns
-// the given default if it can't.
-//
-// This function will only work on GOOS=windows. Trying to run it on any other
-// OS will always return the default value.
-func GetRegString(name, defval string) string { return defval }
+func getRegString(name, defval string) string { return defval }
 
-// GetRegInteger looks up a registry path in our local machine path, or returns
-// the given default if it can't.
-//
-// This function will only work on GOOS=windows. Trying to run it on any other
-// OS will always return the default value.
-func GetRegInteger(name string, defval uint64) uint64 { return defval }
+func getRegInteger(name string, defval uint64) uint64 { return defval }
+
+func isSIDValidPrincipal(uid string) bool { return false }

--- a/util/winutil/winutil_windows.go
+++ b/util/winutil/winutil_windows.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package winutil
+
+import (
+	"log"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
+)
+
+const regBase = `SOFTWARE\Tailscale IPN`
+
+// GetDesktopPID searches the PID of the process that's running the
+// currently active desktop and whether it was found.
+// Usually the PID will be for explorer.exe.
+func GetDesktopPID() (pid uint32, ok bool) {
+	hwnd := windows.GetShellWindow()
+	if hwnd == 0 {
+		return 0, false
+	}
+	windows.GetWindowThreadProcessId(hwnd, &pid)
+	return pid, pid != 0
+}
+
+func getRegString(name, defval string) string {
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, RegBase, registry.READ)
+	if err != nil {
+		log.Printf("registry.OpenKey(%v): %v", RegBase, err)
+		return defval
+	}
+	defer key.Close()
+
+	val, _, err := key.GetStringValue(name)
+	if err != nil {
+		if err != registry.ErrNotExist {
+			log.Printf("registry.GetStringValue(%v): %v", name, err)
+		}
+		return defval
+	}
+	return val
+}
+
+func getRegInteger(name string, defval uint64) uint64 {
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, RegBase, registry.READ)
+	if err != nil {
+		log.Printf("registry.OpenKey(%v): %v", RegBase, err)
+		return defval
+	}
+	defer key.Close()
+
+	val, _, err := key.GetIntegerValue(name)
+	if err != nil {
+		if err != registry.ErrNotExist {
+			log.Printf("registry.GetIntegerValue(%v): %v", name, err)
+		}
+		return defval
+	}
+	return val
+}
+
+var (
+	kernel32                         = syscall.NewLazyDLL("kernel32.dll")
+	procWTSGetActiveConsoleSessionId = kernel32.NewProc("WTSGetActiveConsoleSessionId")
+)
+
+// TODO(crawshaw): replace with x/sys/windows... one day.
+// https://go-review.googlesource.com/c/sys/+/331909
+func WTSGetActiveConsoleSessionId() uint32 {
+	r1, _, _ := procWTSGetActiveConsoleSessionId.Call()
+	return uint32(r1)
+}
+
+func isSIDValidPrincipal(uid string) bool {
+	usid, err := syscall.StringToSid(uid)
+	if err != nil {
+		return false
+	}
+
+	_, _, accType, err := usid.LookupAccount("")
+	if err != nil {
+		return false
+	}
+
+	switch accType {
+	case syscall.SidTypeUser, syscall.SidTypeGroup, syscall.SidTypeDomain, syscall.SidTypeAlias, syscall.SidTypeWellKnownGroup, syscall.SidTypeComputer:
+		return true
+	default:
+		// Reject deleted users, invalid SIDs, unknown SIDs, mandatory label SIDs, etc.
+		return false
+	}
+}


### PR DESCRIPTION
…ailures on Windows to reject SIDs from deleted/invalid security principals

Our current workaround made the user check too lax, thus allowing deleted
users. This patch adds a helper function to winutil that checks that the
uid's SID represents a valid Windows security principal.

Now if `lookupUserFromID` determines that the SID is invalid, we simply
propagate the error.

Updates https://github.com/tailscale/tailscale/issues/869

Signed-off-by: Aaron Klotz <aaron@tailscale.com>