### PR TITLE
ipn: add `CurrentTailnet` info to `tailscale status --json`

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -379,9 +379,14 @@ func (b *LocalBackend) updateStatus(sb *ipnstate.StatusBuilder, extraLocked func
 			}
 		}
 		if b.netMap != nil {
-			s.MagicDNSSuffix = b.netMap.MagicDNSSuffix()
 			s.CertDomains = append([]string(nil), b.netMap.DNS.CertDomains...)
-			s.TailnetName = b.netMap.Domain
+			s.MagicDNSSuffix = b.netMap.MagicDNSSuffix()
+			if s.CurrentTailnet == nil {
+				s.CurrentTailnet = &ipnstate.TailnetStatus{}
+			}
+			s.CurrentTailnet.MagicDNSSuffix = b.netMap.MagicDNSSuffix()
+			s.CurrentTailnet.MagicDNSEnabled = b.netMap.DNS.Proxied
+			s.CurrentTailnet.Name = b.netMap.Domain
 		}
 	})
 	sb.MutateSelfStatus(func(ss *ipnstate.PeerStatus) {

--- a/ipn/ipnstate/ipnstate.go
+++ b/ipn/ipnstate/ipnstate.go
@@ -33,10 +33,6 @@ type Status struct {
 	//  "Starting", "Running".
 	BackendState string
 
-	// TailnetName is the name of the network that's currently in
-	// use.
-	TailnetName string
-
 	AuthURL      string       // current URL provided by control to authorize client
 	TailscaleIPs []netaddr.IP // Tailscale IP(s) assigned to this node
 	Self         *PeerStatus
@@ -46,12 +42,14 @@ type Status struct {
 	// problems are detected)
 	Health []string
 
-	// MagicDNSSuffix is the network's MagicDNS suffix for nodes
-	// in the network such as "userfoo.tailscale.net".
-	// There are no surrounding dots.
-	// MagicDNSSuffix should be populated regardless of whether a domain
-	// has MagicDNS enabled.
+	// This field is the legacy name of CurrentTailnet.MagicDNSSuffix.
+	//
+	// Deprecated: use CurrentTailnet.MagicDNSSuffix instead.
 	MagicDNSSuffix string
+
+	// CurrentTailnet is information about the tailnet that the node
+	// is currently connected to. When not connected, this field is nil.
+	CurrentTailnet *TailnetStatus
 
 	// CertDomains are the set of DNS names for which the control
 	// plane server will assist with provisioning TLS
@@ -62,6 +60,24 @@ type Status struct {
 
 	Peer map[key.NodePublic]*PeerStatus
 	User map[tailcfg.UserID]tailcfg.UserProfile
+}
+
+// TailnetStatus is information about a Tailscale network ("tailnet").
+type TailnetStatus struct {
+	// Name is the name of the network that's currently in use.
+	Name string
+
+	// MagicDNSSuffix is the network's MagicDNS suffix for nodes
+	// in the network such as "userfoo.tailscale.net".
+	// There are no surrounding dots.
+	// MagicDNSSuffix should be populated regardless of whether a domain
+	// has MagicDNS enabled.
+	MagicDNSSuffix string
+
+	// MagicDNSEnabled is whether or not the network has MagicDNS enabled.
+	// Note that the current device may still not support MagicDNS if
+	// `--accept-dns=false` was used.
+	MagicDNSEnabled bool
 }
 
 func (s *Status) Peers() []key.NodePublic {


### PR DESCRIPTION
We need this for some Docker-related features. There's currently no way to detect the MagicDNS status from the `status --json` output, so this commit adds it.

Fixes tailscale/corp#3670

Signed-off-by: Ross Zurowski <ross@rosszurowski.com>