### PR TITLE
util/winutil: fix build

### DIFF
--- a/util/winutil/winutil_notwindows.go
+++ b/util/winutil/winutil_notwindows.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !windows
+// +build !windows
+
 package winutil
 
 const regBase = ``


### PR DESCRIPTION
It was broken on Windows:

```
Error: util\winutil\winutil_windows.go:15:7: regBase redeclared in this block
Error:                                       D:\a\tailscale\tailscale\util\winutil\winutil_notwindows.go:7:17: previous declaration
Error: util\winutil\winutil_windows.go:29:6: getRegString redeclared in this block
Error:                                       D:\a\tailscale\tailscale\util\winutil\winutil_notwindows.go:9:40: previous declaration
Error: util\winutil\winutil_windows.go:47:6: getRegInteger redeclared in this block
Error:                                       D:\a\tailscale\tailscale\util\winutil\winutil_notwindows.go:11:48: previous declaration
Error: util\winutil\winutil_windows.go:77:6: isSIDValidPrincipal redeclared in this block
Error:                                       D:\a\tailscale\tailscale\util\winutil\winutil_notwindows.go:13:38: previous declaration
```
