### PR TITLE
net/interfaces: bound Linux /proc/net/route parsing

### DIFF
--- a/net/interfaces/interfaces_linux_test.go
+++ b/net/interfaces/interfaces_linux_test.go
@@ -51,7 +51,7 @@ func TestExtremelyLongProcNetRoute(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for n := 0; n <= 1000; n++ {
+	for n := 0; n <= 900; n++ {
 		line := fmt.Sprintf("eth%d\t8008FEA9\t00000000\t0001\t0\t0\t0\t01FFFFFF\t0\t0\t0\n", n)
 		_, err := f.Write([]byte(line))
 		if err != nil {


### PR DESCRIPTION
tailscaled was using 100% CPU on a machine with ~1M lines, 100MB+
of /proc/net/route data.

Two problems: in likelyHomeRouterIPLinux, we didn't stop reading the
file once we found the default route (which is on the first non-header
line when present). Which meant it was finding the answer and then
parsing 100MB over 1M lines unnecessarily. Second was that if the
default route isn't present, it'd read to the end of the file looking
for it. If it's not in the first 1,000 lines, it ain't coming, or at
least isn't worth having. (it's only used for discovering a potential
UPnP/PMP/PCP server, which is very unlikely to be present in the
environment of a machine with a ton of routes)
