### PR TITLE
tailcfg, hostinfo: put envtype in Hostinfo

### DIFF
--- a/hostinfo/hostinfo.go
+++ b/hostinfo/hostinfo.go
@@ -35,6 +35,7 @@ func New() *tailcfg.Hostinfo {
 		Package:     packageType(),
 		GoArch:      runtime.GOARCH,
 		DeviceModel: deviceModel(),
+		EnvType:     GetEnvType(),
 	}
 }
 
@@ -75,25 +76,10 @@ func packageType() string {
 	return ""
 }
 
-// EnvType represents a known environment type.
-// The empty string, the default, means unknown.
-type EnvType string
+var envType atomic.Value // of tailcfg.EnvType
 
-const (
-	KNative         = EnvType("kn")
-	AWSLambda       = EnvType("lm")
-	Heroku          = EnvType("hr")
-	AzureAppService = EnvType("az")
-	AWSFargate      = EnvType("fg")
-	FlyDotIo        = EnvType("fly")
-	Kubernetes      = EnvType("k8s")
-	DockerDesktop   = EnvType("dde")
-)
-
-var envType atomic.Value // of EnvType
-
-func GetEnvType() EnvType {
-	if e, ok := envType.Load().(EnvType); ok {
+func GetEnvType() tailcfg.EnvType {
+	if e, ok := envType.Load().(tailcfg.EnvType); ok {
 		return e
 	}
 	e := getEnvType()
@@ -123,30 +109,30 @@ func deviceModel() string {
 	return s
 }
 
-func getEnvType() EnvType {
+func getEnvType() tailcfg.EnvType {
 	if inKnative() {
-		return KNative
+		return tailcfg.KNative
 	}
 	if inAWSLambda() {
-		return AWSLambda
+		return tailcfg.AWSLambda
 	}
 	if inHerokuDyno() {
-		return Heroku
+		return tailcfg.Heroku
 	}
 	if inAzureAppService() {
-		return AzureAppService
+		return tailcfg.AzureAppService
 	}
 	if inAWSFargate() {
-		return AWSFargate
+		return tailcfg.AWSFargate
 	}
 	if inFlyDotIo() {
-		return FlyDotIo
+		return tailcfg.FlyDotIo
 	}
 	if inKubernetes() {
-		return Kubernetes
+		return tailcfg.Kubernetes
 	}
 	if inDockerDesktop() {
-		return DockerDesktop
+		return tailcfg.DockerDesktop
 	}
 	return ""
 }

--- a/net/interfaces/interfaces.go
+++ b/net/interfaces/interfaces.go
@@ -18,6 +18,7 @@ import (
 	"tailscale.com/hostinfo"
 	"tailscale.com/net/tsaddr"
 	"tailscale.com/net/tshttpproxy"
+	"tailscale.com/tailcfg"
 )
 
 // LoginEndpointForProxyDetermination is the URL used for testing
@@ -153,7 +154,7 @@ func LocalAddresses() (regular, loopback []netaddr.IP, err error) {
 		// addresses we otherwise wouldn't, like:
 		//   + 169.254.x.x (AWS Lambda uses NAT with these)
 		//   + IPv6 ULA (Google Cloud Run uses these with address translation)
-		if hostinfo.GetEnvType() == hostinfo.AWSLambda {
+		if hostinfo.GetEnvType() == tailcfg.AWSLambda {
 			regular4 = linklocal4
 		}
 		regular6 = ula6
@@ -615,7 +616,7 @@ func isUsableV4(ip netaddr.IP) bool {
 		return false
 	}
 	if ip.IsLinkLocalUnicast() {
-		return hostinfo.GetEnvType() == hostinfo.AWSLambda
+		return hostinfo.GetEnvType() == tailcfg.AWSLambda
 	}
 	return true
 }

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -445,6 +445,7 @@ type Hostinfo struct {
 	ShieldsUp     bool               `json:",omitempty"` // indicates whether the host is blocking incoming connections
 	ShareeNode    bool               `json:",omitempty"` // indicates this node exists in netmap because it's owned by a shared-to user
 	GoArch        string             `json:",omitempty"` // the host's GOARCH value (of the running binary)
+	EnvType       EnvType            `json:",omitempty"` // the host's environment type, if known
 	RoutableIPs   []netaddr.IPPrefix `json:",omitempty"` // set of IP ranges this client can route
 	RequestTags   []string           `json:",omitempty"` // set of ACL tags this node wants to claim
 	Services      []Service          `json:",omitempty"` // services advertised by this machine
@@ -1369,3 +1370,18 @@ type SetDNSRequest struct {
 	// Value is the value to add.
 	Value string
 }
+
+// EnvType represents a known environment type.
+// The empty string, the default, means unknown.
+type EnvType string
+
+const (
+	KNative         = EnvType("kn")
+	AWSLambda       = EnvType("lm")
+	Heroku          = EnvType("hr")
+	AzureAppService = EnvType("az")
+	AWSFargate      = EnvType("fg")
+	FlyDotIo        = EnvType("fly")
+	Kubernetes      = EnvType("k8s")
+	DockerDesktop   = EnvType("dde")
+)

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -122,6 +122,7 @@ var _HostinfoCloneNeedsRegeneration = Hostinfo(struct {
 	ShieldsUp     bool
 	ShareeNode    bool
 	GoArch        string
+	EnvType       EnvType
 	RoutableIPs   []netaddr.IPPrefix
 	RequestTags   []string
 	Services      []Service

--- a/tailcfg/tailcfg_test.go
+++ b/tailcfg/tailcfg_test.go
@@ -30,7 +30,7 @@ func TestHostinfoEqual(t *testing.T) {
 		"IPNVersion", "FrontendLogID", "BackendLogID",
 		"OS", "OSVersion", "Package", "DeviceModel", "Hostname",
 		"ShieldsUp", "ShareeNode",
-		"GoArch",
+		"GoArch", "EnvType",
 		"RoutableIPs", "RequestTags",
 		"Services", "NetInfo",
 	}


### PR DESCRIPTION
Maybe this is unnecessary? Is this information somewhere else?