### PR TITLE
control/controlclient: turn off Go's implicit compression

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -168,6 +168,10 @@ func NewDirect(opts Options) (*Direct, error) {
 		tr.DialContext = dnscache.Dialer(dialer.DialContext, dnsCache)
 		tr.DialTLSContext = dnscache.TLSDialer(dialer.DialContext, dnsCache, tr.TLSClientConfig)
 		tr.ForceAttemptHTTP2 = true
+		// Disable implicit gzip compression; the various
+		// handlers (register, map, set-dns, etc) do their own
+		// zstd compression per naclbox.
+		tr.DisableCompression = true
 		httpc = &http.Client{Transport: tr}
 	}
 


### PR DESCRIPTION
We don't use it anyway, so be explicit that we're not using it.
