### PR TITLE
net/dns: fix systemd-resolved detection race at boot

### DIFF
--- a/net/dns/manager_linux.go
+++ b/net/dns/manager_linux.go
@@ -321,14 +321,14 @@ func resolvedIsActuallyResolver(bs []byte) error {
 }
 
 func dbusPing(name, objectPath string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-
 	conn, err := dbus.SystemBus()
 	if err != nil {
 		// DBus probably not running.
 		return err
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
 
 	obj := conn.Object(name, dbus.ObjectPath(objectPath))
 	call := obj.CallWithContext(ctx, "org.freedesktop.DBus.Peer.Ping", 0)


### PR DESCRIPTION
If systemd-resolved is enabled but not running (or not yet running,
such as early boot) and resolv.conf is old/dangling, we weren't
detecting systemd-resolved.

This moves its ping earlier, which will trigger it to start up and
write its file.

Fixes #3362
Fixes #3531
