### PR TITLE
cmd/derper: fix regression from bootstrap DNS optimization

### DIFF
--- a/cmd/derper/bootstrap_dns.go
+++ b/cmd/derper/bootstrap_dns.go
@@ -47,7 +47,7 @@ func refreshBootstrapDNS() {
 		}
 		dnsEntries[name] = addrs
 	}
-	j, err := json.MarshalIndent(dnsCache, "", "\t")
+	j, err := json.MarshalIndent(dnsEntries, "", "\t")
 	if err != nil {
 		// leave the old values in place
 		return


### PR DESCRIPTION
The commit b9c92b90db08bbcb7c726c307d2c7b2590278953 earlier today
caused a regression of serving an empty map always, as it was
JSON marshalling an atomic.Value instead of the DNS entries map
it just built.
