### PR TITLE
control/controlclient: remove dummy endpoint in endpoint stripping mode

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -825,10 +825,7 @@ func (c *Direct) sendMapRequest(ctx context.Context, maxPolls int, cb func(*netm
 
 		if Debug.StripEndpoints {
 			for _, p := range resp.Peers {
-				// We need at least one endpoint here for now else
-				// other code doesn't even create the discoEndpoint.
-				// TODO(bradfitz): fix that and then just nil this out.
-				p.Endpoints = []string{"127.9.9.9:456"}
+				p.Endpoints = nil
 			}
 		}
 		if Debug.StripCaps {


### PR DESCRIPTION
The TODO is done. Magicsock doesn't require any endpoints to create an
*endpoint now.  Verified both in code and empirically: I can use the
env knob and access everything.
