### PR TITLE
net/tstun: remove TODO that's done

### DIFF
--- a/net/tstun/wrap.go
+++ b/net/tstun/wrap.go
@@ -431,7 +431,6 @@ func (t *Wrapper) filterOut(p *packet.Parsed) filter.Response {
 			return filter.DropSilently // don't pass on to OS; already handled
 		}
 	}
-	// TODO(bradfitz): support pinging TailscaleServiceIPv6 too.
 
 	// Issue 1526 workaround: if we sent disco packets over
 	// Tailscale from ourselves, then drop them, as that shouldn't


### PR DESCRIPTION
This TODO was both added and fixed in 506c727e3.

As I recall, I wasn't originally going to do it because it seemed
annoying, so I wrote the TODO, but then I felt bad about it and just
did it, but forgot to remove the TODO.
