### PR TITLE
ipn/ipnlocal: log most of Hostinfo once non-verbose at start-up

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -170,6 +170,9 @@ func NewLocalBackend(logf logger.Logf, logid string, store ipn.StateStore, diale
 	if e == nil {
 		panic("ipn.NewLocalBackend: engine must not be nil")
 	}
+
+	hi := hostinfo.New()
+	logf("Host: %s/%s, %s", hi.OS, hi.GoArch, hi.OSVersion)
 	envknob.LogCurrent(logf)
 	if dialer == nil {
 		dialer = new(tsdial.Dialer)


### PR DESCRIPTION
Our previous Hostinfo logging was all as a side effect of telling
control. And it got marked as verbose (as it was)

This adds a one-time Hostinfo logging that's not verbose, early in
start-up.
