### PR TITLE
words: more hamsters, less hampsters

### DIFF
--- a/words/tails.txt
+++ b/words/tails.txt
@@ -132,7 +132,7 @@ feist
 spitz
 squirrel
 gerbil
-hampster
+hamster
 panda
 gibbon
 flyingfox
@@ -211,3 +211,4 @@ velociraptor
 siren
 mudpuppy
 ferret
+roborovski


### PR DESCRIPTION
Spell hamster correctly, and add the name of a teeny tiny type of
hamster, the Roborovski dwarf hamster.

Signed-off-by: Charlotte Brandhorst-Satzkorn <charlotte@tailscale.com>