### PR TITLE
scripts/installer: automagically run apt update

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -407,7 +407,8 @@ main() {
 			fi
 			export DEBIAN_FRONTEND=noninteractive
 			if ! type gpg >/dev/null; then
-				apt-get install -y gnupg
+				$SUDO apt-get update
+				$SUDO apt-get install -y gnupg
 			fi
 
 			set -x


### PR DESCRIPTION
When running this script against a totally fresh out of the box Debian
11 image, sometimes it will fail to run because it doesn't have a
package list cached. This patch adds an `apt-get update` to ensure that
the local package cache is up to date.

Signed-off-by: Xe Iaso <xe@tailscale.com>