### PR TITLE
cmd/tailscaled: add `-state=mem:` to support creation of an ephemeral node

### DIFF
--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -463,7 +463,7 @@ func TestLazyMachineKeyGeneration(t *testing.T) {
 		t.Fatalf("NewFakeUserspaceEngine: %v", err)
 	}
 	t.Cleanup(eng.Close)
-	lb, err := NewLocalBackend(logf, "logid", store, nil, eng)
+	lb, err := NewLocalBackend(logf, "logid", store, nil, eng, 0)
 	if err != nil {
 		t.Fatalf("NewLocalBackend: %v", err)
 	}

--- a/ipn/ipnlocal/loglines_test.go
+++ b/ipn/ipnlocal/loglines_test.go
@@ -54,7 +54,7 @@ func TestLocalLogLines(t *testing.T) {
 	}
 	t.Cleanup(e.Close)
 
-	lb, err := NewLocalBackend(logf, idA.String(), store, nil, e)
+	lb, err := NewLocalBackend(logf, idA.String(), store, nil, e, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ipn/ipnlocal/state_test.go
+++ b/ipn/ipnlocal/state_test.go
@@ -293,7 +293,7 @@ func TestStateMachine(t *testing.T) {
 
 	cc := newMockControl(t)
 	t.Cleanup(func() { cc.preventLog.Set(true) }) // hacky way to pacify issue 3020
-	b, err := NewLocalBackend(logf, "logid", store, nil, e)
+	b, err := NewLocalBackend(logf, "logid", store, nil, e, 0)
 	if err != nil {
 		t.Fatalf("NewLocalBackend: %v", err)
 	}
@@ -954,7 +954,7 @@ func TestWGEngineStatusRace(t *testing.T) {
 	eng, err := wgengine.NewFakeUserspaceEngine(logf, 0)
 	c.Assert(err, qt.IsNil)
 	t.Cleanup(eng.Close)
-	b, err := NewLocalBackend(logf, "logid", new(ipn.MemoryStore), nil, eng)
+	b, err := NewLocalBackend(logf, "logid", new(ipn.MemoryStore), nil, eng, 0)
 	c.Assert(err, qt.IsNil)
 
 	cc := newMockControl(t)

--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -54,6 +54,10 @@ type Server struct {
 	// log.Printf is used.
 	Logf logger.Logf
 
+	// Ephemeral, if true, specifies that the instance should register
+	// as an Ephemeral node (https://tailscale.com/kb/1111/ephemeral-nodes/).
+	Emphemeral bool
+
 	initOnce sync.Once
 	initErr  error
 	lb       *ipnlocal.LocalBackend
@@ -173,7 +177,11 @@ func (s *Server) start() error {
 	}
 	logid := "tslib-TODO"
 
-	lb, err := ipnlocal.NewLocalBackend(logf, logid, store, s.dialer, eng)
+	loginFlags := controlclient.LoginDefault
+	if s.Emphemeral {
+		loginFlags = controlclient.LoginEphemeral
+	}
+	lb, err := ipnlocal.NewLocalBackend(logf, logid, store, s.dialer, eng, loginFlags)
 	if err != nil {
 		return fmt.Errorf("NewLocalBackend: %v", err)
 	}

--- a/tstest/integration/tailscaled_deps_test_darwin.go
+++ b/tstest/integration/tailscaled_deps_test_darwin.go
@@ -13,6 +13,7 @@ import (
 	// process and can cache a prior success when a dependency changes.
 	_ "inet.af/netaddr"
 	_ "tailscale.com/chirp"
+	_ "tailscale.com/control/controlclient"
 	_ "tailscale.com/derp/derphttp"
 	_ "tailscale.com/envknob"
 	_ "tailscale.com/ipn"

--- a/tstest/integration/tailscaled_deps_test_freebsd.go
+++ b/tstest/integration/tailscaled_deps_test_freebsd.go
@@ -13,6 +13,7 @@ import (
 	// process and can cache a prior success when a dependency changes.
 	_ "inet.af/netaddr"
 	_ "tailscale.com/chirp"
+	_ "tailscale.com/control/controlclient"
 	_ "tailscale.com/derp/derphttp"
 	_ "tailscale.com/envknob"
 	_ "tailscale.com/ipn"

--- a/tstest/integration/tailscaled_deps_test_linux.go
+++ b/tstest/integration/tailscaled_deps_test_linux.go
@@ -13,6 +13,7 @@ import (
 	// process and can cache a prior success when a dependency changes.
 	_ "inet.af/netaddr"
 	_ "tailscale.com/chirp"
+	_ "tailscale.com/control/controlclient"
 	_ "tailscale.com/derp/derphttp"
 	_ "tailscale.com/envknob"
 	_ "tailscale.com/ipn"

--- a/tstest/integration/tailscaled_deps_test_openbsd.go
+++ b/tstest/integration/tailscaled_deps_test_openbsd.go
@@ -13,6 +13,7 @@ import (
 	// process and can cache a prior success when a dependency changes.
 	_ "inet.af/netaddr"
 	_ "tailscale.com/chirp"
+	_ "tailscale.com/control/controlclient"
 	_ "tailscale.com/derp/derphttp"
 	_ "tailscale.com/envknob"
 	_ "tailscale.com/ipn"

--- a/tstest/integration/tailscaled_deps_test_windows.go
+++ b/tstest/integration/tailscaled_deps_test_windows.go
@@ -16,6 +16,7 @@ import (
 	_ "golang.org/x/sys/windows/svc/mgr"
 	_ "golang.zx2c4.com/wireguard/windows/tunnel/winipcfg"
 	_ "inet.af/netaddr"
+	_ "tailscale.com/control/controlclient"
 	_ "tailscale.com/derp/derphttp"
 	_ "tailscale.com/envknob"
 	_ "tailscale.com/ipn"


### PR DESCRIPTION
RELNOTE=`tailscaled --state=mem:` registers as an ephemeral node and
does not store state to disk.

Signed-off-by: Maisem Ali <maisem@tailscale.com>
