### PR TITLE
types/logger, logtail: add mechanism to do structured JSON logs

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -172,7 +172,7 @@ func NewLocalBackend(logf logger.Logf, logid string, store ipn.StateStore, diale
 	}
 
 	hi := hostinfo.New()
-	logf("Host: %s/%s, %s", hi.OS, hi.GoArch, hi.OSVersion)
+	logf.JSON(1, "Hostinfo", hi)
 	envknob.LogCurrent(logf)
 	if dialer == nil {
 		dialer = new(tsdial.Dialer)

--- a/logtail/logtail_test.go
+++ b/logtail/logtail_test.go
@@ -275,6 +275,11 @@ func TestParseAndRemoveLogLevel(t *testing.T) {
 			0,
 			"[v3] no level 3",
 		},
+		{
+			"some ignored text then [v\x00JSON]5{\"foo\":1234}",
+			5,
+			`{"foo":1234}`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -367,6 +372,14 @@ func TestEncode(t *testing.T) {
 		{
 			`{"foo":"bar"}`,
 			`{"foo":"bar","logtail":{"client_time":"1970-01-01T00:02:03.000000456Z"}}` + "\n",
+		},
+		{
+			"foo: [v\x00JSON]0{\"foo\":1}",
+			"{\"foo\":1,\"logtail\":{\"client_time\":\"1970-01-01T00:02:03.000000456Z\"}}\n",
+		},
+		{
+			"foo: [v\x00JSON]2{\"foo\":1}",
+			"{\"foo\":1,\"logtail\":{\"client_time\":\"1970-01-01T00:02:03.000000456Z\"},\"v\":2}\n",
 		},
 	}
 	for _, tt := range tests {

--- a/types/logger/logger_test.go
+++ b/types/logger/logger_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	qt "github.com/frankban/quicktest"
+	"tailscale.com/tailcfg"
 )
 
 func TestFuncWriter(t *testing.T) {
@@ -210,4 +211,14 @@ func TestContext(t *testing.T) {
 	logf = FromContext(ctx)
 	logf("a")
 	c.Assert(called, qt.IsTrue)
+}
+
+func TestJSON(t *testing.T) {
+	var buf bytes.Buffer
+	var logf Logf = func(f string, a ...interface{}) { fmt.Fprintf(&buf, f, a...) }
+	logf.JSON(1, "foo", &tailcfg.Hostinfo{})
+	want := "[v\x00JSON]1" + `{"foo":{"OS":"","Hostname":""}}`
+	if got := buf.String(); got != want {
+		t.Errorf("mismatch\n got: %q\nwant: %q\n", got, want)
+	}
 }


### PR DESCRIPTION
e.g. the change to ipnlocal in this commit ultimately logs out:

```
{"logtail":{"client_time":"2022-02-17T20:40:30.511381153-08:00","server_time":"2022-02-18T04:40:31.057771504Z"},"type":"Hostinfo","val":{"GoArch":"amd64","Hostname":"tsdev","IPNVersion":"1.21.0-date.20220107","OS":"linux","OSVersion":"Debian 11.2 (bullseye); kernel=5.10.0-10-amd64"}}
```
