### PR TITLE
tailcfg: make MapResponse.ControlTime a pointer

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -772,7 +772,7 @@ func (c *Direct) sendMapRequest(ctx context.Context, maxPolls int, cb func(*netm
 			go answerPing(c.logf, c.httpc, pr)
 		}
 
-		if !resp.ControlTime.IsZero() {
+		if resp.ControlTime != nil && !resp.ControlTime.IsZero() {
 			c.logf("netmap: control time is %v", resp.ControlTime.UTC().Format(time.RFC3339Nano))
 		}
 		if resp.KeepAlive {

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -1292,7 +1292,7 @@ type MapResponse struct {
 	SSHPolicy *SSHPolicy `json:",omitempty"`
 
 	// ControlTime, if non-zero, is the current timestamp according to the control server.
-	ControlTime time.Time `json:",omitempty"`
+	ControlTime *time.Time `json:",omitempty"`
 
 	// Debug is normally nil, except for when the control server
 	// is setting debug settings on a node.

--- a/tstest/integration/testcontrol/testcontrol.go
+++ b/tstest/integration/testcontrol/testcontrol.go
@@ -721,6 +721,7 @@ func (s *Server) MapResponse(req *tailcfg.MapRequest) (res *tailcfg.MapResponse,
 		return nil, nil
 	}
 	user, _ := s.getUser(nk)
+	t := time.Date(2020, 8, 3, 0, 0, 0, 1, time.UTC)
 	res = &tailcfg.MapResponse{
 		Node:            node,
 		DERPMap:         s.DERPMap,
@@ -731,7 +732,7 @@ func (s *Server) MapResponse(req *tailcfg.MapRequest) (res *tailcfg.MapResponse,
 			DisableUPnP: "true",
 		},
 		DNSConfig:   s.DNSConfig,
-		ControlTime: time.Date(2020, 8, 3, 0, 0, 0, 1, time.UTC),
+		ControlTime: &t,
 	}
 	for _, p := range s.AllNodes() {
 		if p.StableID != node.StableID {


### PR DESCRIPTION
Otherwise omitempty doesn't work.

This is wire-compatible with a non-pointer type, so switching
is safe, now and in the future.

Signed-off-by: Josh Bleecher Snyder <josh@tailscale.com>
