### PR TITLE
make ip6tables ip6tables-nft

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,3 +58,4 @@ RUN GOARCH=$TARGETARCH go install -ldflags="\
 
 FROM ghcr.io/tailscale/alpine-base:3.14
 COPY --from=build-env /go/bin/* /usr/local/bin/
+RUN cp -v /sbin/ip6tables-nft /sbin/ip6tables


### PR DESCRIPTION
to avoid:
```
# Health check:
#     - router: setting up filter/ts-input: running [/sbin/ip6tables -t filter -N ts-input --wait]: exit status 3: modprobe: can't change directory to '/lib/modules': No such file or directory
ip6tables v1.8.7 (legacy): can't initialize ip6tables table `filter': Table does not exist (do you need to insmod?)
Perhaps ip6tables or your kernel needs to be upgraded.
```

Signed-off-by: Shun Li <riverscn@gmail.com>