### PR TITLE
net/netutil: fix regression where peerapi would get closed after 1st req

### DIFF
--- a/ipn/ipnlocal/peerapi.go
+++ b/ipn/ipnlocal/peerapi.go
@@ -411,7 +411,7 @@ func (s *peerAPIServer) listen(ip netaddr.IP, ifState *interfaces.State) (ln net
 	}
 
 	// Make a best effort to pick a deterministic port number for
-	// the ip The lower three bytes are the same for IPv4 and IPv6
+	// the ip. The lower three bytes are the same for IPv4 and IPv6
 	// Tailscale addresses (at least currently), so we'll usually
 	// get the same port number on both address families for
 	// dev/debugging purposes, which is nice. But it's not so
@@ -507,7 +507,7 @@ func (pln *peerAPIListener) ServeConn(src netaddr.IPPort, c net.Conn) {
 	if addH2C != nil {
 		addH2C(httpServer)
 	}
-	go httpServer.Serve(netutil.NewOneConnListenerFrom(c, pln.ln))
+	go httpServer.Serve(netutil.NewOneConnListener(c, pln.ln.Addr()))
 }
 
 // peerAPIHandler serves the Peer API for a source specific client.

--- a/ipn/ipnserver/server.go
+++ b/ipn/ipnserver/server.go
@@ -312,7 +312,7 @@ func (s *Server) serveConn(ctx context.Context, c net.Conn, logf logger.Logf) {
 			ErrorLog:    logger.StdLogger(logf),
 			Handler:     s.localhostHandler(ci),
 		}
-		httpServer.Serve(netutil.NewOneConnListener(&protoSwitchConn{s: s, br: br, Conn: c}))
+		httpServer.Serve(netutil.NewOneConnListener(&protoSwitchConn{s: s, br: br, Conn: c}, nil))
 		return
 	}
 

--- a/net/netutil/netutil_test.go
+++ b/net/netutil/netutil_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package netutil
+
+import (
+	"io"
+	"net"
+	"testing"
+)
+
+type conn struct {
+	net.Conn
+}
+
+func TestOneConnListener(t *testing.T) {
+	c1 := new(conn)
+	a1 := dummyAddr("a1")
+
+	// Two Accepts
+	ln := NewOneConnListener(c1, a1)
+	if got := ln.Addr(); got != a1 {
+		t.Errorf("Addr = %#v; want %#v", got, a1)
+	}
+	c, err := ln.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c != c1 {
+		t.Fatalf("didn't get c1; got %p", c)
+	}
+	c, err = ln.Accept()
+	if err != io.EOF {
+		t.Errorf("got %v; want EOF", err)
+	}
+	if c != nil {
+		t.Errorf("unexpected non-nil Conn")
+	}
+
+	// Close before Accept
+	ln = NewOneConnListener(c1, a1)
+	ln.Close()
+	_, err = ln.Accept()
+	if err != io.EOF {
+		t.Fatalf("got %v; want EOF", err)
+	}
+
+	// Implicit addr
+	ln = NewOneConnListener(c1, nil)
+	if ln.Addr() == nil {
+		t.Errorf("nil Addr")
+	}
+}


### PR DESCRIPTION
I introduced a bug in 8fe503057da26 when unifying oneConnListener
implementations.

The NewOneConnListenerFrom API was easy to misuse (its Close method
closes the underlying Listener), and we did (via http.Serve, which
closes the listener after use, which meant we were close the peerapi's
listener, even though we only wanted its Addr)

Instead, combine those two constructors into one and pass in the Addr
explicitly, without delegating through to any Listener.
