### PR TITLE
cmd/tailscaled: add a no-op test for profiling init-time memory allocs

### DIFF
--- a/cmd/tailscaled/tailscaled_test.go
+++ b/cmd/tailscaled/tailscaled_test.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main // import "tailscale.com/cmd/tailscaled"
+
+import "testing"
+
+func TestNothing(t *testing.T) {
+	// This test does nothing on purpose, so we can run
+	// GODEBUG=memprofilerate=1 go test -v -run=Nothing -memprofile=prof.mem
+	// without any errors about no matching tests.
+}


### PR DESCRIPTION
Turns out we're pretty good already at init-time work in tailscaled.
The regexp/syntax shows up but it's hard to get rid of that; zstd even
uses regexp. *shrug*
