### PR TITLE
ipn/store: [TestNewStore] do not use an empty file

### DIFF
--- a/ipn/store/stores.go
+++ b/ipn/store/stores.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -125,7 +124,7 @@ func (s *FileStore) Path() string { return s.path }
 func (s *FileStore) String() string { return fmt.Sprintf("FileStore(%q)", s.path) }
 
 // NewFileStore returns a new file store that persists to path.
-func NewFileStore(_ logger.Logf, path string) (ipn.StateStore, error) {
+func NewFileStore(logf logger.Logf, path string) (ipn.StateStore, error) {
 	// We unconditionally call this to ensure that our perms are correct
 	if err := paths.MkStateDir(filepath.Dir(path)); err != nil {
 		return nil, fmt.Errorf("creating state directory: %w", err)
@@ -136,7 +135,7 @@ func NewFileStore(_ logger.Logf, path string) (ipn.StateStore, error) {
 	// Treat an empty file as a missing file.
 	// (https://github.com/tailscale/tailscale/issues/895#issuecomment-723255589)
 	if err == nil && len(bs) == 0 {
-		log.Printf("ipn.NewFileStore(%q): file empty; treating it like a missing file [warning]", path)
+		logf("store.NewFileStore(%q): file empty; treating it like a missing file [warning]", path)
 		err = os.ErrNotExist
 	}
 

--- a/ipn/store/stores_test.go
+++ b/ipn/store/stores_test.go
@@ -5,7 +5,6 @@
 package store
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -63,18 +62,8 @@ func TestNewStore(t *testing.T) {
 	} else if _, ok := s.(*store2); !ok {
 		t.Fatalf("%q: got: %T, want: %T", path, s, new(store2))
 	}
-	f, err := os.CreateTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := f.Close(); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		os.Remove(f.Name())
-	})
 
-	path = f.Name()
+	path = filepath.Join(t.TempDir(), "state")
 	if s, err := New(t.Logf, path); err != nil {
 		t.Fatalf("%q: %v", path, err)
 	} else if _, ok := s.(*FileStore); !ok {


### PR DESCRIPTION
Otherwise it would log warnings about an empty file.
```
    stores.go:138: store.NewFileStore("/tmp/3777352782"): file empty; treating it like a missing file [warning]
```

Signed-off-by: Maisem Ali <maisem@tailscale.com>