### PR TITLE
version, hostinfo: recognize gokrazy as a distro

### DIFF
--- a/hostinfo/hostinfo_linux.go
+++ b/hostinfo/hostinfo_linux.go
@@ -113,6 +113,8 @@ func osVersionLinux() string {
 		return fmt.Sprintf("Synology %s%s", m["productversion"], attr)
 	case distro.OpenWrt:
 		return fmt.Sprintf("OpenWrt %s%s", m["DISTRIB_RELEASE"], attr)
+	case distro.Gokrazy:
+		return fmt.Sprintf("Gokrazy%s", attr)
 	}
 	return fmt.Sprintf("Other%s", attr)
 }

--- a/version/distro/distro_test.go
+++ b/version/distro/distro_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package distro
+
+import "testing"
+
+func BenchmarkGet(b *testing.B) {
+	b.ReportAllocs()
+	var d Distro
+	for i := 0; i < b.N; i++ {
+		d = Get()
+	}
+	_ = d
+}


### PR DESCRIPTION
Now:

```
/tmp/breakglass3929186798 # /user/tailscale debug hostinfo
{
  "IPNVersion": "1.23.0-date.20220107",
  "OS": "linux",
  "OSVersion": "Gokrazy; kernel=5.16.11",
  "DeviceModel": "Raspberry Pi 4 Model B Rev 1.2",
  "Hostname": "gokrazy",
  "GoArch": "arm64"
}
```

Also, cache the distro lookup. It doesn't change while the program is
running:

```
name   old time/op    new time/op    delta
Get-6    5.21µs ± 5%    0.00µs ± 3%   -99.91%  (p=0.008 n=5+5)

name   old alloc/op   new alloc/op   delta
Get-6      792B ± 0%        0B       -100.00%  (p=0.008 n=5+5)

name   old allocs/op  new allocs/op  delta
Get-6      8.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
```

Updates #1866

/cc @stapelberg 