### PR TITLE
cmd/tailscaled: default to userspace-networking mode on gokrazy, set paths

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -70,11 +70,27 @@ func defaultTunName() string {
 		// as a magic value that uses/creates any free number.
 		return "utun"
 	case "linux":
-		if distro.Get() == distro.Synology {
+		switch distro.Get() {
+		case distro.Synology:
 			// Try TUN, but fall back to userspace networking if needed.
 			// See https://github.com/tailscale/tailscale-synology/issues/35
 			return "tailscale0,userspace-networking"
+		case distro.Gokrazy:
+			// Gokrazy doesn't yet work in tun mode because the whole
+			// Gokrazy thing is no C code, and Tailscale currently
+			// depends on the iptables binary for Linux's
+			// wgengine/router.
+			// But on Gokrazy there's no legacy iptables, so we could use netlink
+			// to program nft-iptables directly. It just isn't done yet;
+			// see https://github.com/tailscale/tailscale/issues/391
+			//
+			// But Gokrazy does have the tun module built-in, so users
+			// can stil run --tun=tailscale0 if they wish, if they
+			// arrange for iptables to be present or run in "tailscale
+			// up --netfilter-mode=off" mode, perhaps. Untested.
+			return "userspace-networking"
 		}
+
 	}
 	return "tailscale0"
 }

--- a/paths/paths.go
+++ b/paths/paths.go
@@ -28,7 +28,8 @@ func DefaultTailscaledSocket() string {
 	if runtime.GOOS == "darwin" {
 		return "/var/run/tailscaled.socket"
 	}
-	if distro.Get() == distro.Synology {
+	switch distro.Get() {
+	case distro.Synology:
 		// TODO(maisem): be smarter about this. We can parse /etc/VERSION.
 		const dsm6Sock = "/var/packages/Tailscale/etc/tailscaled.sock"
 		const dsm7Sock = "/var/packages/Tailscale/var/tailscaled.sock"
@@ -38,6 +39,8 @@ func DefaultTailscaledSocket() string {
 		if fi, err := os.Stat(dsm7Sock); err == nil && !fi.IsDir() {
 			return dsm7Sock
 		}
+	case distro.Gokrazy:
+		return "/perm/tailscaled/tailscaled.sock"
 	}
 	if fi, err := os.Stat("/var/run"); err == nil && fi.IsDir() {
 		return "/var/run/tailscale/tailscaled.sock"

--- a/paths/paths_unix.go
+++ b/paths/paths_unix.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 
 	"golang.org/x/sys/unix"
+	"tailscale.com/version/distro"
 )
 
 func init() {
@@ -34,6 +35,9 @@ func statePath() string {
 }
 
 func stateFileUnix() string {
+	if distro.Get() == distro.Gokrazy {
+		return "/perm/tailscaled/tailscaled.state"
+	}
 	path := statePath()
 	if path == "" {
 		return ""


### PR DESCRIPTION
One of the current few steps to run Tailscale on gokrazy is to
specify the --tun=userspace-networking flag:

https://gokrazy.org/userguide/install/tailscale/

Instead, make it the default for now. Later we can change the
default to kernel mode if available and fall back to userspace
mode like Synology, once #391 is done.

Likewise, set default paths for Gokrazy, as its filesystem hierarchy
is not the Linux standard one. Instead, use the conventional paths as
documented at https://gokrazy.org/userguide/install/tailscale/.

Updates #1866

RELNOTE=default to userspace-networking mode on gokrazy

/cc @stapelberg 