### PR TITLE
cmd/tailscale/cli, ipn: move exit node IP parsing and validation from…

### DIFF
--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -19,7 +19,6 @@ import (
 	"tailscale.com/ipn"
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/tstest"
-	"tailscale.com/types/key"
 	"tailscale.com/types/persist"
 	"tailscale.com/types/preftype"
 	"tailscale.com/version/distro"
@@ -632,7 +631,7 @@ func TestPrefsFromUpArgs(t *testing.T) {
 			st: &ipnstate.Status{
 				TailscaleIPs: []netaddr.IP{netaddr.MustParseIP("100.105.106.107")},
 			},
-			wantErr: `cannot use 100.105.106.107 as the exit node as it is a local IP address to this machine, did you mean --advertise-exit-node?`,
+			wantErr: `cannot use 100.105.106.107 as an exit node as it is a local IP address to this machine; did you mean --advertise-exit-node?`,
 		},
 		{
 			name: "warn_linux_netfilter_nodivert",
@@ -896,136 +895,6 @@ func TestUpdatePrefs(t *testing.T) {
 var cmpIP = cmp.Comparer(func(a, b netaddr.IP) bool {
 	return a == b
 })
-
-func TestExitNodeIPOfArg(t *testing.T) {
-	mustIP := netaddr.MustParseIP
-	tests := []struct {
-		name    string
-		arg     string
-		st      *ipnstate.Status
-		want    netaddr.IP
-		wantErr string
-	}{
-		{
-			name: "ip_while_stopped_okay",
-			arg:  "1.2.3.4",
-			st: &ipnstate.Status{
-				BackendState: "Stopped",
-			},
-			want: mustIP("1.2.3.4"),
-		},
-		{
-			name: "ip_not_found",
-			arg:  "1.2.3.4",
-			st: &ipnstate.Status{
-				BackendState: "Running",
-			},
-			wantErr: `no node found in netmap with IP 1.2.3.4`,
-		},
-		{
-			name: "ip_not_exit",
-			arg:  "1.2.3.4",
-			st: &ipnstate.Status{
-				BackendState: "Running",
-				Peer: map[key.NodePublic]*ipnstate.PeerStatus{
-					key.NewNode().Public(): {
-						TailscaleIPs: []netaddr.IP{mustIP("1.2.3.4")},
-					},
-				},
-			},
-			wantErr: `node 1.2.3.4 is not advertising an exit node`,
-		},
-		{
-			name: "ip",
-			arg:  "1.2.3.4",
-			st: &ipnstate.Status{
-				BackendState: "Running",
-				Peer: map[key.NodePublic]*ipnstate.PeerStatus{
-					key.NewNode().Public(): {
-						TailscaleIPs:   []netaddr.IP{mustIP("1.2.3.4")},
-						ExitNodeOption: true,
-					},
-				},
-			},
-			want: mustIP("1.2.3.4"),
-		},
-		{
-			name:    "no_match",
-			arg:     "unknown",
-			st:      &ipnstate.Status{MagicDNSSuffix: ".foo"},
-			wantErr: `invalid value "unknown" for --exit-node; must be IP or unique node name`,
-		},
-		{
-			name: "name",
-			arg:  "skippy",
-			st: &ipnstate.Status{
-				MagicDNSSuffix: ".foo",
-				Peer: map[key.NodePublic]*ipnstate.PeerStatus{
-					key.NewNode().Public(): {
-						DNSName:        "skippy.foo.",
-						TailscaleIPs:   []netaddr.IP{mustIP("1.0.0.2")},
-						ExitNodeOption: true,
-					},
-				},
-			},
-			want: mustIP("1.0.0.2"),
-		},
-		{
-			name: "name_not_exit",
-			arg:  "skippy",
-			st: &ipnstate.Status{
-				MagicDNSSuffix: ".foo",
-				Peer: map[key.NodePublic]*ipnstate.PeerStatus{
-					key.NewNode().Public(): {
-						DNSName:      "skippy.foo.",
-						TailscaleIPs: []netaddr.IP{mustIP("1.0.0.2")},
-					},
-				},
-			},
-			wantErr: `node "skippy" is not advertising an exit node`,
-		},
-		{
-			name: "ambiguous",
-			arg:  "skippy",
-			st: &ipnstate.Status{
-				MagicDNSSuffix: ".foo",
-				Peer: map[key.NodePublic]*ipnstate.PeerStatus{
-					key.NewNode().Public(): {
-						DNSName:        "skippy.foo.",
-						TailscaleIPs:   []netaddr.IP{mustIP("1.0.0.2")},
-						ExitNodeOption: true,
-					},
-					key.NewNode().Public(): {
-						DNSName:        "SKIPPY.foo.",
-						TailscaleIPs:   []netaddr.IP{mustIP("1.0.0.2")},
-						ExitNodeOption: true,
-					},
-				},
-			},
-			wantErr: `ambiguous exit node name "skippy"`,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := exitNodeIPOfArg(tt.arg, tt.st)
-			if err != nil {
-				if err.Error() == tt.wantErr {
-					return
-				}
-				if tt.wantErr == "" {
-					t.Fatal(err)
-				}
-				t.Fatalf("error = %#q; want %#q", err, tt.wantErr)
-			}
-			if tt.wantErr != "" {
-				t.Fatalf("got %v; want error %#q", got, tt.wantErr)
-			}
-			if got != tt.want {
-				t.Fatalf("got %v; want %v", got, tt.want)
-			}
-		})
-	}
-}
 
 func TestCleanUpArgs(t *testing.T) {
 	c := qt.New(t)

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -17,6 +17,7 @@ import (
 
 	"go4.org/mem"
 	"inet.af/netaddr"
+	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/tailcfg"
 	"tailscale.com/tstest"
 	"tailscale.com/types/key"
@@ -677,5 +678,135 @@ func TestPrefsExitNode(t *testing.T) {
 	}
 	if got, want := len(p.AdvertiseRoutes), 1; got != want {
 		t.Errorf("routes = %d; want %d", got, want)
+	}
+}
+
+func TestExitNodeIPOfArg(t *testing.T) {
+	mustIP := netaddr.MustParseIP
+	tests := []struct {
+		name    string
+		arg     string
+		st      *ipnstate.Status
+		want    netaddr.IP
+		wantErr string
+	}{
+		{
+			name: "ip_while_stopped_okay",
+			arg:  "1.2.3.4",
+			st: &ipnstate.Status{
+				BackendState: "Stopped",
+			},
+			want: mustIP("1.2.3.4"),
+		},
+		{
+			name: "ip_not_found",
+			arg:  "1.2.3.4",
+			st: &ipnstate.Status{
+				BackendState: "Running",
+			},
+			wantErr: `no node found in netmap with IP 1.2.3.4`,
+		},
+		{
+			name: "ip_not_exit",
+			arg:  "1.2.3.4",
+			st: &ipnstate.Status{
+				BackendState: "Running",
+				Peer: map[key.NodePublic]*ipnstate.PeerStatus{
+					key.NewNode().Public(): {
+						TailscaleIPs: []netaddr.IP{mustIP("1.2.3.4")},
+					},
+				},
+			},
+			wantErr: `node 1.2.3.4 is not advertising an exit node`,
+		},
+		{
+			name: "ip",
+			arg:  "1.2.3.4",
+			st: &ipnstate.Status{
+				BackendState: "Running",
+				Peer: map[key.NodePublic]*ipnstate.PeerStatus{
+					key.NewNode().Public(): {
+						TailscaleIPs:   []netaddr.IP{mustIP("1.2.3.4")},
+						ExitNodeOption: true,
+					},
+				},
+			},
+			want: mustIP("1.2.3.4"),
+		},
+		{
+			name:    "no_match",
+			arg:     "unknown",
+			st:      &ipnstate.Status{MagicDNSSuffix: ".foo"},
+			wantErr: `invalid value "unknown" for --exit-node; must be IP or unique node name`,
+		},
+		{
+			name: "name",
+			arg:  "skippy",
+			st: &ipnstate.Status{
+				MagicDNSSuffix: ".foo",
+				Peer: map[key.NodePublic]*ipnstate.PeerStatus{
+					key.NewNode().Public(): {
+						DNSName:        "skippy.foo.",
+						TailscaleIPs:   []netaddr.IP{mustIP("1.0.0.2")},
+						ExitNodeOption: true,
+					},
+				},
+			},
+			want: mustIP("1.0.0.2"),
+		},
+		{
+			name: "name_not_exit",
+			arg:  "skippy",
+			st: &ipnstate.Status{
+				MagicDNSSuffix: ".foo",
+				Peer: map[key.NodePublic]*ipnstate.PeerStatus{
+					key.NewNode().Public(): {
+						DNSName:      "skippy.foo.",
+						TailscaleIPs: []netaddr.IP{mustIP("1.0.0.2")},
+					},
+				},
+			},
+			wantErr: `node "skippy" is not advertising an exit node`,
+		},
+		{
+			name: "ambiguous",
+			arg:  "skippy",
+			st: &ipnstate.Status{
+				MagicDNSSuffix: ".foo",
+				Peer: map[key.NodePublic]*ipnstate.PeerStatus{
+					key.NewNode().Public(): {
+						DNSName:        "skippy.foo.",
+						TailscaleIPs:   []netaddr.IP{mustIP("1.0.0.2")},
+						ExitNodeOption: true,
+					},
+					key.NewNode().Public(): {
+						DNSName:        "SKIPPY.foo.",
+						TailscaleIPs:   []netaddr.IP{mustIP("1.0.0.2")},
+						ExitNodeOption: true,
+					},
+				},
+			},
+			wantErr: `ambiguous exit node name "skippy"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := exitNodeIPOfArg(tt.arg, tt.st)
+			if err != nil {
+				if err.Error() == tt.wantErr {
+					return
+				}
+				if tt.wantErr == "" {
+					t.Fatal(err)
+				}
+				t.Fatalf("error = %#q; want %#q", err, tt.wantErr)
+			}
+			if tt.wantErr != "" {
+				t.Fatalf("got %v; want error %#q", got, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("got %v; want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
… cli into prefs.

We need to be able to provide the ability for the GUI clients to resolve and set
the exit node IP from an untrusted string, thus enabling the ability to specify
that information via enterprise policy.

This patch moves the relevant code out of the handler for `tailscale up`,
into a method on `Prefs` that may then be called by GUI clients.

Signed-off-by: Aaron Klotz <aaron@tailscale.com>