### PR TITLE
tailcfg: rename map request version to "capability version"

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -368,7 +368,7 @@ func (c *Direct) doLogin(ctx context.Context, opt loginOpt) (mustRegen bool, new
 	}
 	now := time.Now().Round(time.Second)
 	request := tailcfg.RegisterRequest{
-		Version:    1,
+		Version:    1, // TODO(bradfitz): use tailcfg.CurrentCapabilityVersion when over Noise
 		OldNodeKey: oldNodeKey,
 		NodeKey:    tryingNewKey.Public(),
 		Hostinfo:   hi,
@@ -614,7 +614,7 @@ func (c *Direct) sendMapRequest(ctx context.Context, maxPolls int, cb func(*netm
 	}
 
 	request := &tailcfg.MapRequest{
-		Version:       tailcfg.CurrentMapRequestVersion,
+		Version:       tailcfg.CurrentCapabilityVersion,
 		KeepAlive:     c.keepAlive,
 		NodeKey:       persist.PrivateNodeKey.Public(),
 		DiscoKey:      c.discoPubKey,

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -2930,7 +2930,7 @@ func (b *LocalBackend) FileTargets() ([]*apitype.FileTarget, error) {
 // friendly options to get HTTPS certs.
 func (b *LocalBackend) SetDNS(ctx context.Context, name, value string) error {
 	req := &tailcfg.SetDNSRequest{
-		Version: 1,
+		Version: 1, // TODO(bradfitz,maisem): use tailcfg.CurrentCapabilityVersion when using the Noise transport
 		Type:    "TXT",
 		Name:    name,
 		Value:   value,

--- a/tstest/integration/testcontrol/testcontrol.go
+++ b/tstest/integration/testcontrol/testcontrol.go
@@ -408,19 +408,18 @@ func (s *Server) CompleteAuth(authPathOrURL string) bool {
 
 func (s *Server) serveRegister(w http.ResponseWriter, r *http.Request, mkey key.MachinePublic) {
 	msg, err := ioutil.ReadAll(io.LimitReader(r.Body, msgLimit))
+	r.Body.Close()
 	if err != nil {
-		r.Body.Close()
 		http.Error(w, fmt.Sprintf("bad map request read: %v", err), 400)
 		return
 	}
-	r.Body.Close()
 
 	var req tailcfg.RegisterRequest
 	if err := s.decode(mkey, msg, &req); err != nil {
 		go panic(fmt.Sprintf("serveRegister: decode: %v", err))
 	}
-	if req.Version != 1 {
-		go panic(fmt.Sprintf("serveRegister: unsupported version: %d", req.Version))
+	if req.Version == 0 {
+		panic("serveRegister: zero Version")
 	}
 	if req.NodeKey.IsZero() {
 		go panic("serveRegister: request has zero node key")


### PR DESCRIPTION
And add a CapabilityVersion type, primarily for documentation.

This makes MapRequest.Version, RegisterRequest.Version, and
SetDNSRequest.Version all use the same version, which will avoid
confusing in the future if Register or SetDNS ever changed their
semantics on Version change. (Currently they're both always 1)

This will requre a control server change to allow a
SetDNSRequest.Version value other than 1 to be deployed first.
