### PR TITLE
net/socks5: always close client connections after serving

### DIFF
--- a/net/socks5/socks5.go
+++ b/net/socks5/socks5.go
@@ -112,11 +112,11 @@ func (s *Server) Serve(l net.Listener) error {
 			return err
 		}
 		go func() {
+			defer c.Close()
 			conn := &Conn{clientConn: c, srv: s}
 			err := conn.Run()
 			if err != nil {
 				s.logf("client connection failed: %v", err)
-				conn.clientConn.Close()
 			}
 		}()
 	}


### PR DESCRIPTION
Customer reported an issue where the connections were not closing, and
would instead just stay open. This commit makes it so that we close out
the connection regardless of what error we see. I've verified locally
that it fixes the issue, we should add a test for this.

Signed-off-by: Maisem Ali <maisem@tailscale.com>