### PR TITLE
control/controlclient, localapi: shorten expiry time via localapi

### DIFF
--- a/control/controlclient/auto.go
+++ b/control/controlclient/auto.go
@@ -657,6 +657,10 @@ func (c *Auto) Logout(ctx context.Context) error {
 	}
 }
 
+func (c *Auto) SetExpirySooner(ctx context.Context, expiry time.Time) error {
+	return c.direct.SetExpirySooner(ctx, expiry)
+}
+
 // UpdateEndpoints sets the client's discovered endpoints and sends
 // them to the control server if they've changed.
 //

--- a/control/controlclient/client.go
+++ b/control/controlclient/client.go
@@ -11,6 +11,7 @@ package controlclient
 
 import (
 	"context"
+	"time"
 
 	"tailscale.com/tailcfg"
 )
@@ -45,6 +46,9 @@ type Client interface {
 	// Logout starts a synchronous logout process. It doesn't return
 	// until the logout operation has been completed.
 	Logout(context.Context) error
+	// SetExpirySooner sets the node's expiry time via the controlclient,
+	// as long as it's shorter than the current expiry time.
+	SetExpirySooner(context.Context, time.Time) error
 	// SetPaused pauses or unpauses the controlclient activity as much
 	// as possible, without losing its internal state, to minimize
 	// unnecessary network activity.

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3187,6 +3187,15 @@ func (b *LocalBackend) allowExitNodeDNSProxyToServeName(name string) bool {
 	return true
 }
 
+// SetExpiry updates the expiry of the current node key to t, as long as it's
+// only sooner than the old expiry.
+//
+// If t is in the past, the key is expired immediately.
+// If t is after the current expiry, an error is returned.
+func (b *LocalBackend) SetExpirySooner(ctx context.Context, expiry time.Time) error {
+	return b.cc.SetExpirySooner(ctx, expiry)
+}
+
 // exitNodeCanProxyDNS reports the DoH base URL ("http://foo/dns-query") without query parameters
 // to exitNodeID's DoH service, if available.
 //

--- a/ipn/ipnlocal/state_test.go
+++ b/ipn/ipnlocal/state_test.go
@@ -223,6 +223,12 @@ func (cc *mockControl) Logout(ctx context.Context) error {
 	return nil
 }
 
+func (cc *mockControl) SetExpirySooner(context.Context, time.Time) error {
+	cc.logf("SetExpirySooner")
+	cc.called("SetExpirySooner")
+	return nil
+}
+
 func (cc *mockControl) SetPaused(paused bool) {
 	cc.logf("SetPaused=%v", paused)
 	if paused {


### PR DESCRIPTION
Builds on work in tailscale/corp#4205, which is where all the can't-extend-expiry logic is.

Usage like:
`curl -X POST http://foo/localapi/v0/shorten-expiry -d "expiry=1647242808"`