### PR TITLE
Update docs/k8s dockerfile to allow running the run.sh

### DIFF
--- a/docs/k8s/Dockerfile
+++ b/docs/k8s/Dockerfile
@@ -4,4 +4,5 @@
 
 FROM ghcr.io/tailscale/tailscale:latest
 COPY run.sh /run.sh
+RUN chmod +x /run.sh
 CMD "/run.sh"


### PR DESCRIPTION
The dockerfile as is does not work since you can not run the run.sh. 

This makes it a bit easier for other people to use this.