### PR TITLE
control/controlbase: make Conn.Write return consumed bytes

### DIFF
--- a/control/controlbase/conn.go
+++ b/control/controlbase/conn.go
@@ -267,18 +267,16 @@ func (c *Conn) Write(bs []byte) (n int, err error) {
 
 		ciphertext, err := c.encryptLocked(toSend)
 		if err != nil {
-			return 0, err
+			return sent, err
 		}
-
-		n, err := c.conn.Write(ciphertext)
-		sent += n
-		if err != nil {
+		if _, err := c.conn.Write(ciphertext); err != nil {
 			// Return the raw error on the Write that actually
 			// failed. For future writes, return that error wrapped in
 			// a desync error.
 			c.tx.err = errPartialWrite{err}
 			return sent, err
 		}
+		sent += len(toSend)
 	}
 	return sent, nil
 }


### PR DESCRIPTION
Currently `Write` returns the number of ciphertext bytes written.
According to the docs for io.Writer, Write should return the amount
of bytes consumed from the input.
```
// Write writes len(p) bytes from p to the underlying data stream.
// It returns the number of bytes written from p (0 <= n <= len(p))
// and any error encountered that caused the write to stop early.
// Write must return a non-nil error if it returns n < len(p).
// Write must not modify the slice data, even temporarily.
Write(p []byte) (n int, err error)
```

Fixes #4126

Signed-off-by: Maisem Ali <maisem@tailscale.com>