### PR TITLE
github/windows: attempt to improve cache performance

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,10 +27,18 @@ jobs:
     - name: Restore Cache
       uses: actions/cache@v2
       with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+        # Note: unlike some other setups, this is only grabbing the mod download
+        # cache, rather than the whole mod directory, as the download cache
+        # contains zips that can be unpacked in parallel faster than they can be
+        # fetched and extracted by tar
+        path: |
+          ~/go/pkg/mod/cache
+          ~\AppData\Local\go-build
+
+        # The -2- here should be incremented when the scheme of data to be
+        # cached changes (e.g. path above changes).
+        # TODO(raggi): add a go version here.
+        key: ${{ runner.os }}-go-2-${{ hashFiles('**/go.sum') }}
 
     - name: Test
       # Don't use -bench=. -benchtime=1x.


### PR DESCRIPTION
- Remove the expanded module files, as Go can likely expand the zips
  faster than tar can expand the extra copies.
- Add the go-build cache.