### PR TITLE
github/windows: improve caching in -race builder

### DIFF
--- a/.github/workflows/windows-race.yml
+++ b/.github/workflows/windows-race.yml
@@ -27,10 +27,21 @@ jobs:
     - name: Restore Cache
       uses: actions/cache@v2
       with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+        # Note: unlike some other setups, this is only grabbing the mod download
+        # cache, rather than the whole mod directory, as the download cache
+        # contains zips that can be unpacked in parallel faster than they can be
+        # fetched and extracted by tar
+        path: |
+          ~/go/pkg/mod/cache
+          ~\AppData\Local\go-build
+
+        # The -2- here should be incremented when the scheme of data to be
+        # cached changes (e.g. path above changes).
+        # The -race- here ensures that non-race builds and race builds do not
+        # overwrite each others cache, as while they share some files, they
+        # differ in most by volume (build cache).
+        # TODO(raggi): add a go version here.
+        key: ${{ runner.os }}-go-2-race-${{ hashFiles('**/go.sum') }}
 
     - name: Test with -race flag
       # Don't use -bench=. -benchtime=1x.


### PR DESCRIPTION
Applying the same logic as for the non-race builder, using a dedicated cache key to avoid build cache trees from stomping each other.