### PR TITLE
scripts: install gnupg only when apt-key is needed

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -407,7 +407,7 @@ main() {
 				exit 1
 			fi
 			export DEBIAN_FRONTEND=noninteractive
-			if ! type gpg >/dev/null; then
+			if [ "$APT_KEY_TYPE" = "legacy" ] && ! type gpg >/dev/null; then
 				$SUDO apt-get update
 				$SUDO apt-get install -y gnupg
 			fi


### PR DESCRIPTION
apt-key depends on gnupg but apt-key itself if not used
on modern systems (APT_KEY_TYPE=keyring).

Signed-off-by: Simon Deziel <simon@sdeziel.info>