### PR TITLE
types/views: add generic Slice[T] and remove StringSlice

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -444,10 +444,10 @@ func (b *LocalBackend) populatePeerStatusLocked(sb *ipnstate.StatusBuilder) {
 		exitNodeOption := tsaddr.PrefixesContainsFunc(p.AllowedIPs, func(r netaddr.IPPrefix) bool {
 			return r.Bits() == 0
 		})
-		var tags *views.StringSlice
+		var tags *views.Slice[string]
 		var primaryRoutes *views.IPPrefixSlice
 		if p.Tags != nil {
-			v := views.StringSliceOf(p.Tags)
+			v := views.SliceOf(p.Tags)
 			tags = &v
 		}
 		if p.PrimaryRoutes != nil {

--- a/ipn/ipnstate/ipnstate.go
+++ b/ipn/ipnstate/ipnstate.go
@@ -112,7 +112,7 @@ type PeerStatus struct {
 
 	// Tags are the list of ACL tags applied to this node.
 	// See tailscale.com/tailcfg#Node.Tags for more information.
-	Tags *views.StringSlice `json:",omitempty"`
+	Tags *views.Slice[string] `json:",omitempty"`
 
 	// PrimaryRoutes are the routes this node is currently the primary
 	// subnet router for, as determined by the control plane. It does

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -527,12 +527,12 @@ func (v HostinfoView) RoutableIPs() views.IPPrefixSlice {
 	return views.IPPrefixSliceOf(v.ж.RoutableIPs)
 }
 
-func (v HostinfoView) RequestTags() views.StringSlice {
-	return views.StringSliceOf(v.ж.RequestTags)
+func (v HostinfoView) RequestTags() views.Slice[string] {
+	return views.SliceOf(v.ж.RequestTags)
 }
 
-func (v HostinfoView) SSH_HostKeys() views.StringSlice {
-	return views.StringSliceOf(v.ж.SSH_HostKeys)
+func (v HostinfoView) SSH_HostKeys() views.Slice[string] {
+	return views.SliceOf(v.ж.SSH_HostKeys)
 }
 
 func (v HostinfoView) Services() ServiceSlice {

--- a/types/views/views_test.go
+++ b/types/views/views_test.go
@@ -23,10 +23,12 @@ func TestViewsJSON(t *testing.T) {
 	}
 	type viewStruct struct {
 		Addrs      IPPrefixSlice
-		Strings    StringSlice
+		Strings    Slice[string]
 		AddrsPtr   *IPPrefixSlice `json:",omitempty"`
-		StringsPtr *StringSlice   `json:",omitempty"`
+		StringsPtr *Slice[string] `json:",omitempty"`
 	}
+	ipp := IPPrefixSliceOf(mustCIDR("192.168.0.0/24"))
+	ss := SliceOf([]string{"bar"})
 	tests := []struct {
 		name     string
 		in       viewStruct
@@ -40,12 +42,12 @@ func TestViewsJSON(t *testing.T) {
 		{
 			name: "everything",
 			in: viewStruct{
-				Addrs:      IPPrefixSliceOf(mustCIDR("192.168.0.0/24")),
-				AddrsPtr:   &IPPrefixSlice{mustCIDR("192.168.0.0/24")},
-				StringsPtr: &StringSlice{[]string{"foo"}},
-				Strings:    StringSlice{[]string{"bar"}},
+				Addrs:      ipp,
+				AddrsPtr:   &ipp,
+				StringsPtr: &ss,
+				Strings:    ss,
 			},
-			wantJSON: `{"Addrs":["192.168.0.0/24"],"Strings":["bar"],"AddrsPtr":["192.168.0.0/24"],"StringsPtr":["foo"]}`,
+			wantJSON: `{"Addrs":["192.168.0.0/24"],"Strings":["bar"],"AddrsPtr":["192.168.0.0/24"],"StringsPtr":["bar"]}`,
 		},
 	}
 


### PR DESCRIPTION
Also make IPPrefixSliceOf use Slice[netaddr.IPPrefix] as it also
provides additional functions besides the standard ones provided by
Slice[T].

I considered making `type StringSlice = Slice[string]` but decided against it.

Signed-off-by: Maisem Ali <maisem@tailscale.com>