### PR TITLE
derp: set Basic Constraints on metacert

### DIFF
--- a/derp/derp_server.go
+++ b/derp/derp_server.go
@@ -453,6 +453,9 @@ func (s *Server) initMetacert() {
 		// Windows requires NotAfter and NotBefore set:
 		NotAfter:  time.Now().Add(30 * 24 * time.Hour),
 		NotBefore: time.Now().Add(-30 * 24 * time.Hour),
+		// Per https://github.com/golang/go/issues/51759#issuecomment-1071147836,
+		// macOS requires BasicConstraints when subject == issuer:
+		BasicConstraintsValid: true,
 	}
 	cert, err := x509.CreateCertificate(crand.Reader, tmpl, tmpl, pub, priv)
 	if err != nil {

--- a/derp/derp_test.go
+++ b/derp/derp_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/x509"
+	"encoding/asn1"
 	"encoding/json"
 	"errors"
 	"expvar"
@@ -789,6 +790,17 @@ func TestMetaCert(t *testing.T) {
 	}
 	if g, w := cert.Subject.CommonName, fmt.Sprintf("derpkey%s", pub.UntypedHexString()); g != w {
 		t.Errorf("CommonName = %q; want %q", g, w)
+	}
+	if n := len(cert.Extensions); n != 1 {
+		t.Fatalf("got %d extensions; want 1", n)
+	}
+
+	// oidExtensionBasicConstraints is the Basic Constraints ID copied
+	// from the x509 package.
+	oidExtensionBasicConstraints := asn1.ObjectIdentifier{2, 5, 29, 19}
+
+	if id := cert.Extensions[0].Id; !id.Equal(oidExtensionBasicConstraints) {
+		t.Errorf("extension ID = %v; want %v", id, oidExtensionBasicConstraints)
 	}
 }
 


### PR DESCRIPTION
See https://github.com/golang/go/issues/51759#issuecomment-1071147836

Once we deploy this, tailscaled should work again for macOS users with
Go 1.18.

Updates golang/go#51759
