### PR TITLE
cmd/tailscaled: make build fail nicely on older Go versions

### DIFF
--- a/client/tailscale/required_version.go
+++ b/client/tailscale/required_version.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !go1.18
+// +build !go1.18
+
+package tailscale
+
+func init() {
+	you_need_Go_1_18_to_compile_Tailscale()
+}

--- a/client/tailscale/tailscale.go
+++ b/client/tailscale/tailscale.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build go1.18
+// +build go1.18
+
 // Package tailscale contains Tailscale client code.
 package tailscale
 

--- a/cmd/tailscaled/debug.go
+++ b/cmd/tailscaled/debug.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build go1.18
+// +build go1.18
+
 package main
 
 import (

--- a/cmd/tailscaled/install_darwin.go
+++ b/cmd/tailscaled/install_darwin.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build go1.18
+// +build go1.18
+
 package main
 
 import (

--- a/cmd/tailscaled/install_windows.go
+++ b/cmd/tailscaled/install_windows.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build go1.18
+// +build go1.18
+
 package main
 
 import (

--- a/cmd/tailscaled/proxy.go
+++ b/cmd/tailscaled/proxy.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build go1.18
+// +build go1.18
+
 // HTTP proxy code
 
 package main

--- a/cmd/tailscaled/required_version.go
+++ b/cmd/tailscaled/required_version.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !go1.18
+// +build !go1.18
+
+package main
+
+func init() {
+	you_need_Go_1_18_to_compile_Tailscale()
+}

--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build go1.18
+// +build go1.18
+
 // The tailscaled program is the Tailscale client daemon. It's configured
 // and controlled via the tailscale CLI program.
 //

--- a/cmd/tailscaled/tailscaled_bird.go
+++ b/cmd/tailscaled/tailscaled_bird.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux || darwin || freebsd || openbsd
+//go:build go1.18 && (linux || darwin || freebsd || openbsd)
+// +build go1.18
 // +build linux darwin freebsd openbsd
 
 package main

--- a/cmd/tailscaled/tailscaled_notwindows.go
+++ b/cmd/tailscaled/tailscaled_notwindows.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !windows
-// +build !windows
+//go:build !windows && go1.18
+// +build !windows,go1.18
 
 package main // import "tailscale.com/cmd/tailscaled"
 

--- a/cmd/tailscaled/tailscaled_windows.go
+++ b/cmd/tailscaled/tailscaled_windows.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build go1.18
+// +build go1.18
+
 package main // import "tailscale.com/cmd/tailscaled"
 
 // TODO: check if administrator, like tswin does.


### PR DESCRIPTION
Due to a bug in Go (golang/go#51778), cmd/go doesn't warn about your
Go version being older than the go.mod's declared Go version in that
case that package loading fails before the build starts, such as when
you use packages that are only in the current version of Go, like our
use of net/netip.

This change works around that Go bug by adding build tags and a
pre-Go1.18-only file that will cause Go 1.17 and earlier to fail like:

    $ ~/sdk/go1.17/bin/go install ./cmd/tailscaled
    # tailscale.com/cmd/tailscaled
    ./required_version.go:11:2: undefined: you_need_Go_1_18_to_compile_Tailscale
    note: module requires Go 1.18
