### PR TITLE
cmd/tailscale: make web mode preserve URL scheme in Synology redirect

### DIFF
--- a/cmd/tailscale/cli/web.go
+++ b/cmd/tailscale/cli/web.go
@@ -269,15 +269,14 @@ func synoTokenRedirect(w http.ResponseWriter, r *http.Request) bool {
 	}
 	// We need a SynoToken for authenticate.cgi.
 	// So we tell the client to get one.
-	serverURL := r.URL.Scheme + "://" + r.URL.Host
-	synoTokenRedirectHTML.Execute(w, serverURL)
+	_, _ = fmt.Fprint(w, synoTokenRedirectHTML)
 	return true
 }
 
-var synoTokenRedirectHTML = template.Must(template.New("redirect").Parse(`<html><body>
+const synoTokenRedirectHTML = `<html><body>
 Redirecting with session token...
 <script>
-var serverURL = {{ . }};
+var serverURL = window.location.protocol + "//" + window.location.host;
 var req = new XMLHttpRequest();
 req.overrideMimeType("application/json");
 req.open("GET", serverURL + "/webman/login.cgi", true);
@@ -289,7 +288,7 @@ req.onload = function() {
 req.send(null);
 </script>
 </body></html>
-`))
+`
 
 func webHandler(w http.ResponseWriter, r *http.Request) {
 	if authRedirect(w, r) {


### PR DESCRIPTION
Error message:
```js
(index):13 Mixed Content: The page at 'https://dsm.example.local/webman/3rdparty/Tailscale/' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://dsm.example.local/webman/login.cgi'. This request has been blocked; the content must be served over HTTPS.
```