### PR TITLE
tsweb: add PrometheusVar, for vars that want to output varz themselves.

### DIFF
--- a/tsweb/tsweb_test.go
+++ b/tsweb/tsweb_test.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"errors"
 	"expvar"
+	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -469,6 +471,12 @@ foo_AUint16 65535
 			expvar.Func(func() any { return 123 }),
 			"num_goroutines 123\n",
 		},
+		{
+			"var_that_exports_itself",
+			"custom_var",
+			promWriter{},
+			"custom_var_value 42\n",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -533,4 +541,14 @@ func (expvarAdapter) String() string { return "{}" } // expvar JSON; unused in t
 
 func (a expvarAdapter) PrometheusMetricsReflectRoot() any {
 	return a.st
+}
+
+type promWriter struct{}
+
+func (promWriter) WritePrometheus(w io.Writer, prefix string) {
+	fmt.Fprintf(w, "%s_value 42\n", prefix)
+}
+
+func (promWriter) String() string {
+	return ""
 }


### PR DESCRIPTION
This enables the infrequent use of more complex Prometheus types, such as
timeseries with high/irregular label cardinality, without needing to
discover and implement generic abstracted type like LabelMap for each one.

Signed-off-by: David Anderson <danderson@tailscale.com>