### PR TITLE
prober: support adding key/value labels to probes.

### DIFF
--- a/prober/prober.go
+++ b/prober/prober.go
@@ -9,13 +9,15 @@ package prober
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"expvar"
 	"fmt"
+	"io"
 	"log"
+	"sort"
 	"sync"
 	"time"
-
-	"tailscale.com/metrics"
 )
 
 // ProbeFunc is a function that probes something and reports whether
@@ -29,33 +31,6 @@ type Prober struct {
 	now       func() time.Time
 	newTicker func(time.Duration) ticker
 
-	// lastStart is the time, in seconds since epoch, of the last time
-	// each probe started a probe cycle.
-	lastStart metrics.LabelMap
-	// lastEnd is the time, in seconds since epoch, of the last time
-	// each probe finished a probe cycle.
-	lastEnd metrics.LabelMap
-	// lastResult records whether probes succeeded. A successful probe
-	// is recorded as 1, a failure as 0.
-	lastResult metrics.LabelMap
-	// lastLatency records how long the last probe cycle took for each
-	// probe, in milliseconds.
-	lastLatency metrics.LabelMap
-	// probeInterval records the time in seconds between successive
-	// runs of each probe.
-	//
-	// This is to help Prometheus figure out how long a probe should
-	// be failing before it fires an alert for it. To avoid random
-	// background noise, you want it to wait for more than 1
-	// datapoint, but you also can't use a fixed interval because some
-	// probes might run every few seconds, while e.g. TLS certificate
-	// expiry might only run once a day.
-	//
-	// So, for each probe, the prober tells Prometheus how often it
-	// runs, so that the alert can autotune itself to eliminate noise
-	// without being excessively delayed.
-	probeInterval metrics.LabelMap
-
 	mu     sync.Mutex // protects all following fields
 	probes map[string]*Probe
 }
@@ -67,26 +42,15 @@ func New() *Prober {
 
 func newForTest(now func() time.Time, newTicker func(time.Duration) ticker) *Prober {
 	return &Prober{
-		now:           now,
-		newTicker:     newTicker,
-		lastStart:     metrics.LabelMap{Label: "probe"},
-		lastEnd:       metrics.LabelMap{Label: "probe"},
-		lastResult:    metrics.LabelMap{Label: "probe"},
-		lastLatency:   metrics.LabelMap{Label: "probe"},
-		probeInterval: metrics.LabelMap{Label: "probe"},
-		probes:        map[string]*Probe{},
+		now:       now,
+		newTicker: newTicker,
+		probes:    map[string]*Probe{},
 	}
 }
 
 // Expvar returns the metrics for running probes.
-func (p *Prober) Expvar() *metrics.Set {
-	ret := new(metrics.Set)
-	ret.Set("start_secs", &p.lastStart)
-	ret.Set("end_secs", &p.lastEnd)
-	ret.Set("result", &p.lastResult)
-	ret.Set("latency_millis", &p.lastLatency)
-	ret.Set("interval_secs", &p.probeInterval)
-	return ret
+func (p *Prober) Expvar() expvar.Var {
+	return varExporter{p}
 }
 
 // Run executes fun every interval, and exports probe results under probeName.
@@ -113,7 +77,6 @@ func (p *Prober) Run(name string, interval time.Duration, fun ProbeFunc) *Probe 
 		tick:     ticker,
 	}
 	p.probes[name] = probe
-	p.probeInterval.Get(name).Set(int64(interval.Seconds()))
 	go probe.loop()
 	return probe
 }
@@ -123,11 +86,6 @@ func (p *Prober) unregister(probe *Probe) {
 	defer p.mu.Unlock()
 	name := probe.name
 	delete(p.probes, name)
-	p.lastStart.Delete(name)
-	p.lastEnd.Delete(name)
-	p.lastResult.Delete(name)
-	p.lastLatency.Delete(name)
-	p.probeInterval.Delete(name)
 }
 
 // Reports the number of registered probes. For tests only.
@@ -149,6 +107,11 @@ type Probe struct {
 	doProbe  ProbeFunc
 	interval time.Duration
 	tick     ticker
+
+	mu     sync.Mutex
+	start  time.Time
+	end    time.Time
+	result bool
 }
 
 // Close shuts down the Probe and unregisters it from its Prober.
@@ -183,7 +146,7 @@ func (p *Probe) loop() {
 // the probe either succeeds or fails before the next cycle is
 // scheduled to start.
 func (p *Probe) run() {
-	start := p.start()
+	start := p.recordStart()
 	defer func() {
 		// Prevent a panic within one probe function from killing the
 		// entire prober, so that a single buggy probe doesn't destroy
@@ -192,7 +155,7 @@ func (p *Probe) run() {
 		// alert for debugging.
 		if r := recover(); r != nil {
 			log.Printf("probe %s panicked: %v", p.name, r)
-			p.end(start, errors.New("panic"))
+			p.recordEnd(start, errors.New("panic"))
 		}
 	}()
 	timeout := time.Duration(float64(p.interval) * 0.8)
@@ -200,27 +163,98 @@ func (p *Probe) run() {
 	defer cancel()
 
 	err := p.doProbe(ctx)
-	p.end(start, err)
+	p.recordEnd(start, err)
 	if err != nil {
 		log.Printf("probe %s: %v", p.name, err)
 	}
 }
 
-func (p *Probe) start() time.Time {
+func (p *Probe) recordStart() time.Time {
 	st := p.prober.now()
-	p.prober.lastStart.Get(p.name).Set(st.Unix())
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.start = st
 	return st
 }
 
-func (p *Probe) end(start time.Time, err error) {
+func (p *Probe) recordEnd(start time.Time, err error) {
 	end := p.prober.now()
-	p.prober.lastEnd.Get(p.name).Set(end.Unix())
-	p.prober.lastLatency.Get(p.name).Set(end.Sub(start).Milliseconds())
-	v := int64(1)
-	if err != nil {
-		v = 0
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.end = end
+	p.result = err == nil
+}
+
+type varExporter struct {
+	p *Prober
+}
+
+func (v varExporter) String() string {
+	type probeInfo struct {
+		Start   time.Time
+		End     time.Time
+		Latency string
+		Result  bool
 	}
-	p.prober.lastResult.Get(p.name).Set(v)
+	out := map[string]probeInfo{}
+
+	v.p.mu.Lock()
+	probes := make([]*Probe, 0, len(v.p.probes))
+	for _, probe := range v.p.probes {
+		probes = append(probes, probe)
+	}
+	v.p.mu.Unlock()
+
+	for _, probe := range probes {
+		probe.mu.Lock()
+		inf := probeInfo{
+			Start:  probe.start,
+			End:    probe.end,
+			Result: probe.result,
+		}
+		if probe.end.After(probe.start) {
+			inf.Latency = probe.end.Sub(probe.start).String()
+		}
+		out[probe.name] = inf
+		probe.mu.Unlock()
+	}
+
+	bs, err := json.Marshal(out)
+	if err != nil {
+		return fmt.Sprintf(`{"error": %q}`, err)
+	}
+	return string(bs)
+}
+
+func (v varExporter) WritePrometheus(w io.Writer, prefix string) {
+	v.p.mu.Lock()
+	probes := make([]*Probe, 0, len(v.p.probes))
+	for _, probe := range v.p.probes {
+		probes = append(probes, probe)
+	}
+	v.p.mu.Unlock()
+
+	sort.Slice(probes, func(i, j int) bool {
+		return probes[i].name < probes[j].name
+	})
+	for _, probe := range probes {
+		probe.mu.Lock()
+		fmt.Fprintf(w, "%s_interval_secs{probe=%q} %f\n", prefix, probe.name, probe.interval.Seconds())
+		if !probe.start.IsZero() {
+			fmt.Fprintf(w, "%s_start_secs{probe=%q} %d\n", prefix, probe.name, probe.start.Unix())
+		}
+		if !probe.end.IsZero() {
+			fmt.Fprintf(w, "%s_end_secs{probe=%q} %d\n", prefix, probe.name, probe.end.Unix())
+			// Start is always present if end is.
+			fmt.Fprintf(w, "%s_latency_millis{probe=%q} %d\n", prefix, probe.name, probe.end.Sub(probe.start).Milliseconds())
+			if probe.result {
+				fmt.Fprintf(w, "%s_result{probe=%q} 1\n", prefix, probe.name)
+			} else {
+				fmt.Fprintf(w, "%s_result{probe=%q} 0\n", prefix, probe.name)
+			}
+		}
+		probe.mu.Unlock()
+	}
 }
 
 // ticker wraps a time.Ticker in a way that can be faked for tests.


### PR DESCRIPTION
This lets especially dynamically-registered probes export their results with a bunch more dimensions to slice by in dashboards, so you can e.g. show "only probes for DERP in Singapore", or "only production backup checks".

The labels are still static after probe creation, because prometheus doesn't deal well with per-datapoint cardinality explosion. This API forces you to think a little bit about adding labels that are about the probe, not about a particular probing event.

Two commits. First one is a pure refactor that uses PrometheusVar for exporting probe results, without altering the exported data. The second commit alters the probe export to include custom labels.