### PR TITLE
all: remove "no 1.18 support" failures

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -181,9 +181,6 @@ func main() {
 		os.Exit(0)
 	}
 
-	if runtime.GOOS == "darwin" && runtime.Version() == "go1.18" {
-		log.Fatalf("tailscaled is broken on macOS with go1.18 due to upstream bug https://github.com/golang/go/issues/51759; use 1.18.1+ or Tailscale's Go fork")
-	}
 	if runtime.GOOS == "darwin" && os.Getuid() != 0 && !strings.Contains(args.tunname, "userspace-networking") && !args.cleanup {
 		log.SetFlags(0)
 		log.Fatalf("tailscaled requires root; use sudo tailscaled (or use --tun=userspace-networking)")

--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -15,7 +15,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -93,9 +92,6 @@ func (s *Server) Dial(ctx context.Context, network, address string) (net.Conn, e
 // Start connects the server to the tailnet.
 // Optional: any calls to Dial/Listen will also call Start.
 func (s *Server) Start() error {
-	if runtime.GOOS == "darwin" && runtime.Version() == "go1.18" {
-		log.Fatalf("Tailscale is broken on macOS with go1.18 due to upstream bug https://github.com/golang/go/issues/51759; use 1.18.1+ or Tailscale's Go fork")
-	}
 	s.initOnce.Do(s.doInit)
 	return s.initErr
 }


### PR DESCRIPTION
We have worked around the issue in DERP,
so the vanilla Go 1.18 toolchain now works.

Signed-off-by: Josh Bleecher Snyder <josh@tailscale.com>
