### PR TITLE
net/dnscache: do not call LookupIPFallback if the context was canceled.

### DIFF
--- a/net/dnscache/dnscache.go
+++ b/net/dnscache/dnscache.go
@@ -312,7 +312,7 @@ func (d *dialer) DialContext(ctx context.Context, network, address string) (retC
 	defer func() {
 		// On failure, consider that our DNS might be wrong and ask the DNS fallback mechanism for
 		// some other IPs to try.
-		if ret == nil || d.dnsCache.LookupIPFallback == nil || dc.dnsWasTrustworthy() {
+		if ret == nil || ctx.Err() != nil || d.dnsCache.LookupIPFallback == nil || dc.dnsWasTrustworthy() {
 			return
 		}
 		ips, err := d.dnsCache.LookupIPFallback(ctx, host)

--- a/net/dnsfallback/dnsfallback.go
+++ b/net/dnsfallback/dnsfallback.go
@@ -27,6 +27,10 @@ import (
 )
 
 func Lookup(ctx context.Context, host string) ([]netaddr.IP, error) {
+	if ip, err := netaddr.ParseIP(host); err == nil && !ip.IsZero() {
+		return []netaddr.IP{ip}, nil
+	}
+
 	type nameIP struct {
 		dnsName string
 		ip      netaddr.IP


### PR DESCRIPTION
Two changes
```
net/dnsfallback: do not attempt lookups of IPs.

When the context is canceled, dc.dialOne returns an error from line 345.
This causes the defer on line 312 to try to resolve the host again, which
triggers a dns lookup of "127.0.0.1" from derp.
```

```
net/dnscache: do not call LookupIPFallback if the context was canceled.

Currently if the passed in host is an IP, Lookup still attempts to
resolve it with a dns server. This makes it just return the IP directly.
```

Updates tailscale/corp#4475

Signed-off-by: Maisem Ali <maisem@tailscale.com>