### PR TITLE
tailscaled: reduce gc churn

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -25,7 +25,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
-	"runtime/debug"
 	"strings"
 	"syscall"
 	"time"
@@ -130,14 +129,6 @@ var subCommands = map[string]*func([]string) error{
 }
 
 func main() {
-	// We aren't very performance sensitive, and the parts that are
-	// performance sensitive (wireguard) try hard not to do any memory
-	// allocations. So let's be aggressive about garbage collection,
-	// unless the user specifically overrides it in the usual way.
-	if _, ok := os.LookupEnv("GOGC"); !ok {
-		debug.SetGCPercent(10)
-	}
-
 	printVersion := false
 	flag.IntVar(&args.verbose, "verbose", 0, "log verbosity level; 0 is default, 1 or higher are increasingly verbose")
 	flag.BoolVar(&args.cleanup, "cleanup", false, "clean up system state and exit")


### PR DESCRIPTION
Usage of userspace-networking is increasing, and the aggressive GC
tuning causes a significant reduction in performance in that mode.

---

I was debugging a different issue and noticed that the GC frequency under moderate throughput (100mbit) in userspace mode was very high - multiple times per second.

The default tuning seems more suitable when running in userspace mode.

Observed metrics from the change tested against a 2015 macbook pro over wifi (not great test):

100mbit sustained UDP:
GOGC=10: dropping ~15% of packets
GOGC=100: dropping 0%

TCP throughput test:
GOGC=10:   100mbit
GOGC=100:  350mbit

Throughput wise for this scenario, the new tuning causes userspace mode and normal mode to perform the same.