### PR TITLE
Allow any port for HTTPS when using Noise over TLS

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -1314,7 +1314,7 @@ func (c *Direct) setDNSNoise(ctx context.Context, req *tailcfg.SetDNSRequest) er
 	if err != nil {
 		return err
 	}
-	res, err := np.Post(fmt.Sprintf("https://%v/%v", np.serverHost, "machine/set-dns"), "application/json", bytes.NewReader(bodyData))
+	res, err := np.Post(fmt.Sprintf("https://%v/%v", np.host, "machine/set-dns"), "application/json", bytes.NewReader(bodyData))
 	if err != nil {
 		return err
 	}

--- a/control/controlhttp/client.go
+++ b/control/controlhttp/client.go
@@ -43,24 +43,20 @@ import (
 	"tailscale.com/types/key"
 )
 
-// Dial connects to the HTTP server at addr, requests to switch to the
+// Dial connects to the HTTP server at host:httpPort, requests to switch to the
 // Tailscale control protocol, and returns an established control
 // protocol connection.
 //
 // If Dial fails to connect using addr, it also tries to tunnel over
-// TLS to <addr's host>:443 as a compatibility fallback.
+// TLS to host:httpsPort as a compatibility fallback.
 //
 // The provided ctx is only used for the initial connection, until
 // Dial returns. It does not affect the connection once established.
-func Dial(ctx context.Context, addr string, machineKey key.MachinePrivate, controlKey key.MachinePublic, protocolVersion uint16, dialer dnscache.DialContextFunc) (*controlbase.Conn, error) {
-	host, port, err := net.SplitHostPort(addr)
-	if err != nil {
-		return nil, err
-	}
+func Dial(ctx context.Context, host string, httpPort string, httpsPort string, machineKey key.MachinePrivate, controlKey key.MachinePublic, protocolVersion uint16, dialer dnscache.DialContextFunc) (*controlbase.Conn, error) {
 	a := &dialParams{
 		host:       host,
-		httpPort:   port,
-		httpsPort:  "443",
+		httpPort:   httpPort,
+		httpsPort:  httpsPort,
 		machineKey: machineKey,
 		controlKey: controlKey,
 		version:    protocolVersion,


### PR DESCRIPTION
When connecting to `/ts2021` it is assumed that the control server is running in tcp/443 if using the fallback HTTPS method. This sometimes might not be the case :)

This PR allows to pass any addr to `controlhttp.Dial` - or if the addr does not include a port assume tcp/80 for http and tcp/443 for https.

Signed-off-by: Juan Font Alonso <juanfontalonso@gmail.com>