### PR TITLE
net/tsaddr, wgengine/netstack: add IPv6 range that forwards to site-relative IPv4

### DIFF
--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -659,6 +659,39 @@ func TestPrefsFromUpArgs(t *testing.T) {
 				NoSNAT:        true,
 			},
 		},
+		{
+			name: "via_route_good",
+			goos: "linux",
+			args: upArgsT{
+				advertiseRoutes: "fd7a:115c:a1e0:b1a::bb:10.0.0.0/112",
+				netfilterMode: "off",
+			},
+			want: &ipn.Prefs{
+				WantRunning:   true,
+				NoSNAT:        true,
+				AdvertiseRoutes: []netaddr.IPPrefix{
+					netaddr.MustParseIPPrefix("fd7a:115c:a1e0:b1a::bb:10.0.0.0/112"),
+				},
+			},
+		},
+		{
+			name: "via_route_short_prefix",
+			goos: "linux",
+			args: upArgsT{
+				advertiseRoutes: "fd7a:115c:a1e0:b1a::/64",
+				netfilterMode: "off",
+			},
+			wantErr: "fd7a:115c:a1e0:b1a::/64 4-in-6 prefix must be at least a /96",
+		},
+		{
+			name: "via_route_short_reserved_siteid",
+			goos: "linux",
+			args: upArgsT{
+				advertiseRoutes: "fd7a:115c:a1e0:b1a:1234:5678::/112",
+				netfilterMode: "off",
+			},
+			wantErr: "route fd7a:115c:a1e0:b1a:1234:5678::/112 contains invalid site ID 12345678; must be 0xff or less",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/net/tsaddr/tsaddr_test.go
+++ b/net/tsaddr/tsaddr_test.go
@@ -88,3 +88,19 @@ func BenchmarkTailscaleServiceAddr(b *testing.B) {
 		sinkIP = TailscaleServiceIP()
 	}
 }
+
+func TestUnmapVia(t *testing.T) {
+	tests := []struct {
+		ip   string
+		want string
+	}{
+		{"1.2.3.4", "1.2.3.4"}, // unchanged v4
+		{"fd7a:115c:a1e0:b1a::bb:10.2.1.3", "10.2.1.3"},
+		{"fd7a:115c:a1e0:b1b::bb:10.2.1.4", "fd7a:115c:a1e0:b1b:0:bb:a02:104"}, // "b1b",not "bia"
+	}
+	for _, tt := range tests {
+		if got := UnmapVia(netaddr.MustParseIP(tt.ip)).String(); got != tt.want {
+			t.Errorf("for %q: got %q, want %q", tt.ip, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
This defines a new magic IPv6 prefix, fd7a:115c:a1e0:b1a::/64, a subset of our
existing /48, where the final 32 bits are an IPv4 address, and the middle 32 bits are
a user-chosen "site ID".

e.g., I can say my home LAN's "site ID" is "bbbb:0000" and then
advertise its IPv4 via IPv6, like:

    tailscale up --advertise-routes=fd7a:115c:a1e0:b1a:bbbb::/80

Then people in my tailnet can:

     $ curl '[fd7a:115c:a1e0:b1a:bbbb::10.2.0.230]'
     <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" ....

Or if only want to export 10.2.0.0/16:

    tailscale up --advertise-routes=fd7a:115c:a1e0:b1a:bbbb::10.2.0.0/112

(112 being 128-16)

Updates #3616, etc
