### PR TITLE
net/dns, net/dns/resolver, wgengine: refactor DNS request path

### DIFF
--- a/net/dns/manager.go
+++ b/net/dns/manager.go
@@ -14,6 +14,7 @@ import (
 	"tailscale.com/net/dns/resolver"
 	"tailscale.com/net/tsdial"
 	"tailscale.com/types/dnstype"
+	"tailscale.com/types/ipproto"
 	"tailscale.com/types/logger"
 	"tailscale.com/util/dnsname"
 	"tailscale.com/wgengine/monitor"
@@ -204,12 +205,12 @@ func toIPPorts(ips []netaddr.IP) (ret []netaddr.IPPort) {
 	return ret
 }
 
-func (m *Manager) EnqueueRequest(bs []byte, from netaddr.IPPort) error {
-	return m.resolver.EnqueueRequest(bs, from)
+func (m *Manager) EnqueuePacket(bs []byte, proto ipproto.Proto, from, to netaddr.IPPort) error {
+	return m.resolver.EnqueuePacket(bs, proto, from, to)
 }
 
-func (m *Manager) NextResponse() ([]byte, netaddr.IPPort, error) {
-	return m.resolver.NextResponse()
+func (m *Manager) NextPacket() ([]byte, error) {
+	return m.resolver.NextPacket()
 }
 
 func (m *Manager) Down() error {

--- a/net/dns/resolver/tsdns_test.go
+++ b/net/dns/resolver/tsdns_test.go
@@ -39,7 +39,7 @@ var (
 	testipv4Arpa = dnsname.FQDN("4.3.2.1.in-addr.arpa.")
 	testipv6Arpa = dnsname.FQDN("f.0.e.0.d.0.c.0.b.0.a.0.9.0.8.0.7.0.6.0.5.0.4.0.3.0.2.0.1.0.0.0.ip6.arpa.")
 
-	magicdnsDstUdp = netaddr.MustParseIPPort("100.100.100.100:53")
+	magicDNSv4Port = netaddr.MustParseIPPort("100.100.100.100:53")
 )
 
 var dnsCfg = Config{
@@ -234,7 +234,7 @@ func unpackResponse(payload []byte) (dnsResponse, error) {
 }
 
 func syncRespond(r *Resolver, query []byte) ([]byte, error) {
-	if err := r.enqueueRequest(query, ipproto.UDP, netaddr.IPPort{}, magicdnsDstUdp); err != nil {
+	if err := r.enqueueRequest(query, ipproto.UDP, netaddr.IPPort{}, magicDNSv4Port); err != nil {
 		return nil, fmt.Errorf("enqueueRequest: %w", err)
 	}
 	payload, _, err := r.nextResponse()
@@ -730,7 +730,7 @@ func TestDelegateCollision(t *testing.T) {
 	// packets will have the same dns txid.
 	for _, p := range packets {
 		payload := dnspacket(p.qname, p.qtype, noEdns)
-		err := r.enqueueRequest(payload, ipproto.UDP, p.addr, magicdnsDstUdp)
+		err := r.enqueueRequest(payload, ipproto.UDP, p.addr, magicDNSv4Port)
 		if err != nil {
 			t.Error(err)
 		}

--- a/net/dns/resolver/tsdns_test.go
+++ b/net/dns/resolver/tsdns_test.go
@@ -27,6 +27,7 @@ import (
 	"tailscale.com/net/tsdial"
 	"tailscale.com/tstest"
 	"tailscale.com/types/dnstype"
+	"tailscale.com/types/ipproto"
 	"tailscale.com/util/dnsname"
 	"tailscale.com/wgengine/monitor"
 )
@@ -37,6 +38,8 @@ var (
 
 	testipv4Arpa = dnsname.FQDN("4.3.2.1.in-addr.arpa.")
 	testipv6Arpa = dnsname.FQDN("f.0.e.0.d.0.c.0.b.0.a.0.9.0.8.0.7.0.6.0.5.0.4.0.3.0.2.0.1.0.0.0.ip6.arpa.")
+
+	magicdnsDstUdp = netaddr.MustParseIPPort("100.100.100.100:53")
 )
 
 var dnsCfg = Config{
@@ -231,10 +234,10 @@ func unpackResponse(payload []byte) (dnsResponse, error) {
 }
 
 func syncRespond(r *Resolver, query []byte) ([]byte, error) {
-	if err := r.EnqueueRequest(query, netaddr.IPPort{}); err != nil {
-		return nil, fmt.Errorf("EnqueueRequest: %w", err)
+	if err := r.enqueueRequest(query, ipproto.UDP, netaddr.IPPort{}, magicdnsDstUdp); err != nil {
+		return nil, fmt.Errorf("enqueueRequest: %w", err)
 	}
-	payload, _, err := r.NextResponse()
+	payload, _, err := r.nextResponse()
 	return payload, err
 }
 
@@ -727,14 +730,14 @@ func TestDelegateCollision(t *testing.T) {
 	// packets will have the same dns txid.
 	for _, p := range packets {
 		payload := dnspacket(p.qname, p.qtype, noEdns)
-		err := r.EnqueueRequest(payload, p.addr)
+		err := r.enqueueRequest(payload, ipproto.UDP, p.addr, magicdnsDstUdp)
 		if err != nil {
 			t.Error(err)
 		}
 	}
 
 	// Despite the txid collision, the answer(s) should still match the query.
-	resp, addr, err := r.NextResponse()
+	resp, addr, err := r.nextResponse()
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Previously, method calls into the DNS manager/resolver types handled DNS requests rather than DNS packets. This is fine for UDP as one packet corresponds to one request or response, however will not suit an implementation that supports DNS over TCP.

To support PRs implementing this in the future, wgengine delegates all handling/construction of packets to the magic DNS endpoint, to the DNS types themselves. Handling IP packets at this level enables future support for both UDP and TCP.