### PR TITLE
hostinfo, tailcfg: add desktop environment to hostinfo

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -460,6 +460,7 @@ type Hostinfo struct {
 	BackendLogID  string             `json:",omitempty"` // logtail ID of backend instance
 	OS            string             `json:",omitempty"` // operating system the client runs on (a version.OS value)
 	OSVersion     string             `json:",omitempty"` // operating system version, with optional distro prefix ("Debian 10.4", "Windows 10 Pro 10.0.19041")
+	Desktop       opt.Bool           `json:",omitempty"` // if a desktop was detected on Linux
 	Package       string             `json:",omitempty"` // Tailscale package to disambiguate ("choco", "appstore", etc; "" for unknown)
 	DeviceModel   string             `json:",omitempty"` // mobile phone model ("Pixel 3a", "iPhone12,3")
 	Hostname      string             `json:",omitempty"` // name of the host the client runs on

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -117,6 +117,7 @@ var _HostinfoCloneNeedsRegeneration = Hostinfo(struct {
 	BackendLogID  string
 	OS            string
 	OSVersion     string
+	Desktop       opt.Bool
 	Package       string
 	DeviceModel   string
 	Hostname      string

--- a/tailcfg/tailcfg_test.go
+++ b/tailcfg/tailcfg_test.go
@@ -28,7 +28,7 @@ func fieldsOf(t reflect.Type) (fields []string) {
 func TestHostinfoEqual(t *testing.T) {
 	hiHandles := []string{
 		"IPNVersion", "FrontendLogID", "BackendLogID",
-		"OS", "OSVersion", "Package", "DeviceModel", "Hostname",
+		"OS", "OSVersion", "Desktop", "Package", "DeviceModel", "Hostname",
 		"ShieldsUp", "ShareeNode",
 		"GoArch",
 		"RoutableIPs", "RequestTags",


### PR DESCRIPTION
From the machines tab its hard to differenciate desktop Linux installs from server Linux installs. Transmitting this information should make this determination a lot easier.

Due to the reality that tailscaled is likely a system process, the standard checks based on XDG_SESSION_TYPE or DISPLAY environment variables are not possible (those variables won't be set). Instead, we look for listening unix sockets that are typical of desktop installs.