### PR TITLE
control/controlbase: make the protocol version number selectable.

### DIFF
--- a/control/controlbase/conn_test.go
+++ b/control/controlbase/conn_test.go
@@ -26,6 +26,8 @@ import (
 	"tailscale.com/types/key"
 )
 
+const testProtocolVersion = 1
+
 func TestMessageSize(t *testing.T) {
 	// This test is a regression guard against someone looking at
 	// maxCiphertextSize, going "huh, we could be more efficient if it
@@ -204,10 +206,10 @@ func TestConnStd(t *testing.T) {
 		serverErr := make(chan error, 1)
 		go func() {
 			var err error
-			c2, err = Server(context.Background(), s2, controlKey, nil)
+			c2, err = Server(context.Background(), s2, controlKey, testProtocolVersion, nil)
 			serverErr <- err
 		}()
-		c1, err = Client(context.Background(), s1, machineKey, controlKey.Public())
+		c1, err = Client(context.Background(), s1, machineKey, controlKey.Public(), testProtocolVersion)
 		if err != nil {
 			s1.Close()
 			s2.Close()
@@ -396,11 +398,11 @@ func pairWithConns(t *testing.T, clientConn, serverConn net.Conn) (*Conn, *Conn)
 	)
 	go func() {
 		var err error
-		server, err = Server(context.Background(), serverConn, controlKey, nil)
+		server, err = Server(context.Background(), serverConn, controlKey, testProtocolVersion, nil)
 		serverErr <- err
 	}()
 
-	client, err := Client(context.Background(), clientConn, machineKey, controlKey.Public())
+	client, err := Client(context.Background(), clientConn, machineKey, controlKey.Public(), testProtocolVersion)
 	if err != nil {
 		t.Fatalf("client connection failed: %v", err)
 	}

--- a/control/controlbase/handshake_test.go
+++ b/control/controlbase/handshake_test.go
@@ -26,11 +26,11 @@ func TestHandshake(t *testing.T) {
 	)
 	go func() {
 		var err error
-		server, err = Server(context.Background(), serverConn, serverKey, nil)
+		server, err = Server(context.Background(), serverConn, serverKey, testProtocolVersion, nil)
 		serverErr <- err
 	}()
 
-	client, err := Client(context.Background(), clientConn, clientKey, serverKey.Public())
+	client, err := Client(context.Background(), clientConn, clientKey, serverKey.Public(), testProtocolVersion)
 	if err != nil {
 		t.Fatalf("client connection failed: %v", err)
 	}
@@ -42,8 +42,8 @@ func TestHandshake(t *testing.T) {
 		t.Fatal("client and server disagree on handshake hash")
 	}
 
-	if client.ProtocolVersion() != int(protocolVersion) {
-		t.Fatalf("client reporting wrong protocol version %d, want %d", client.ProtocolVersion(), protocolVersion)
+	if client.ProtocolVersion() != int(testProtocolVersion) {
+		t.Fatalf("client reporting wrong protocol version %d, want %d", client.ProtocolVersion(), testProtocolVersion)
 	}
 	if client.ProtocolVersion() != server.ProtocolVersion() {
 		t.Fatalf("peers disagree on protocol version, client=%d server=%d", client.ProtocolVersion(), server.ProtocolVersion())
@@ -78,11 +78,11 @@ func TestNoReuse(t *testing.T) {
 		)
 		go func() {
 			var err error
-			server, err = Server(context.Background(), serverConn, serverKey, nil)
+			server, err = Server(context.Background(), serverConn, serverKey, testProtocolVersion, nil)
 			serverErr <- err
 		}()
 
-		client, err := Client(context.Background(), clientConn, clientKey, serverKey.Public())
+		client, err := Client(context.Background(), clientConn, clientKey, serverKey.Public(), testProtocolVersion)
 		if err != nil {
 			t.Fatalf("client connection failed: %v", err)
 		}
@@ -172,7 +172,7 @@ func TestTampering(t *testing.T) {
 			serverErr             = make(chan error, 1)
 		)
 		go func() {
-			_, err := Server(context.Background(), serverConn, serverKey, nil)
+			_, err := Server(context.Background(), serverConn, serverKey, testProtocolVersion, nil)
 			// If the server failed, we have to close the Conn to
 			// unblock the client.
 			if err != nil {
@@ -181,7 +181,7 @@ func TestTampering(t *testing.T) {
 			serverErr <- err
 		}()
 
-		_, err := Client(context.Background(), clientConn, clientKey, serverKey.Public())
+		_, err := Client(context.Background(), clientConn, clientKey, serverKey.Public(), testProtocolVersion)
 		if err == nil {
 			t.Fatal("client connection succeeded despite tampering")
 		}
@@ -200,11 +200,11 @@ func TestTampering(t *testing.T) {
 			serverErr             = make(chan error, 1)
 		)
 		go func() {
-			_, err := Server(context.Background(), serverConn, serverKey, nil)
+			_, err := Server(context.Background(), serverConn, serverKey, testProtocolVersion, nil)
 			serverErr <- err
 		}()
 
-		_, err := Client(context.Background(), clientConn, clientKey, serverKey.Public())
+		_, err := Client(context.Background(), clientConn, clientKey, serverKey.Public(), testProtocolVersion)
 		if err == nil {
 			t.Fatal("client connection succeeded despite tampering")
 		}
@@ -225,13 +225,13 @@ func TestTampering(t *testing.T) {
 			serverErr             = make(chan error, 1)
 		)
 		go func() {
-			server, err := Server(context.Background(), serverConn, serverKey, nil)
+			server, err := Server(context.Background(), serverConn, serverKey, testProtocolVersion, nil)
 			serverErr <- err
 			_, err = io.WriteString(server, strings.Repeat("a", 14))
 			serverErr <- err
 		}()
 
-		client, err := Client(context.Background(), clientConn, clientKey, serverKey.Public())
+		client, err := Client(context.Background(), clientConn, clientKey, serverKey.Public(), testProtocolVersion)
 		if err != nil {
 			t.Fatalf("client handshake failed: %v", err)
 		}
@@ -266,7 +266,7 @@ func TestTampering(t *testing.T) {
 			serverErr             = make(chan error, 1)
 		)
 		go func() {
-			server, err := Server(context.Background(), serverConn, serverKey, nil)
+			server, err := Server(context.Background(), serverConn, serverKey, testProtocolVersion, nil)
 			serverErr <- err
 			var bs [100]byte
 			// The server needs a timeout if the tampering is hitting the length header.
@@ -281,7 +281,7 @@ func TestTampering(t *testing.T) {
 			}
 		}()
 
-		client, err := Client(context.Background(), clientConn, clientKey, serverKey.Public())
+		client, err := Client(context.Background(), clientConn, clientKey, serverKey.Public(), testProtocolVersion)
 		if err != nil {
 			t.Fatalf("client handshake failed: %v", err)
 		}

--- a/control/controlbase/interop_test.go
+++ b/control/controlbase/interop_test.go
@@ -29,7 +29,7 @@ func TestInteropClient(t *testing.T) {
 	)
 
 	go func() {
-		server, err := Server(context.Background(), s2, controlKey, nil)
+		server, err := Server(context.Background(), s2, controlKey, testProtocolVersion, nil)
 		serverErr <- err
 		if err != nil {
 			return
@@ -77,7 +77,7 @@ func TestInteropServer(t *testing.T) {
 	)
 
 	go func() {
-		client, err := Client(context.Background(), s1, machineKey, controlKey.Public())
+		client, err := Client(context.Background(), s1, machineKey, controlKey.Public(), testProtocolVersion)
 		clientErr <- err
 		if err != nil {
 			return
@@ -121,11 +121,11 @@ func noiseExplorerClient(conn net.Conn, controlKey key.MachinePublic, machineKey
 	copy(mk.public_key[:], machineKey.Public().UntypedBytes())
 	var peerKey [32]byte
 	copy(peerKey[:], controlKey.UntypedBytes())
-	session := InitSession(true, protocolVersionPrologue(protocolVersion), mk, peerKey)
+	session := InitSession(true, protocolVersionPrologue(testProtocolVersion), mk, peerKey)
 
 	_, msg1 := SendMessage(&session, nil)
 	var hdr [initiationHeaderLen]byte
-	binary.BigEndian.PutUint16(hdr[:2], protocolVersion)
+	binary.BigEndian.PutUint16(hdr[:2], testProtocolVersion)
 	hdr[2] = msgTypeInitiation
 	binary.BigEndian.PutUint16(hdr[3:5], 96)
 	if _, err := conn.Write(hdr[:]); err != nil {
@@ -193,7 +193,7 @@ func noiseExplorerServer(conn net.Conn, controlKey key.MachinePrivate, wantMachi
 	var mk keypair
 	copy(mk.private_key[:], controlKey.UntypedBytes())
 	copy(mk.public_key[:], controlKey.Public().UntypedBytes())
-	session := InitSession(false, protocolVersionPrologue(protocolVersion), mk, [32]byte{})
+	session := InitSession(false, protocolVersionPrologue(testProtocolVersion), mk, [32]byte{})
 
 	var buf [1024]byte
 	if _, err := io.ReadFull(conn, buf[:101]); err != nil {

--- a/control/controlbase/messages.go
+++ b/control/controlbase/messages.go
@@ -39,9 +39,9 @@ const (
 // 16b: message tag (authenticates the whole message)
 type initiationMessage [101]byte
 
-func mkInitiationMessage() initiationMessage {
+func mkInitiationMessage(protocolVersion uint16) initiationMessage {
 	var ret initiationMessage
-	binary.BigEndian.PutUint16(ret[:2], uint16(protocolVersion))
+	binary.BigEndian.PutUint16(ret[:2], protocolVersion)
 	ret[2] = msgTypeInitiation
 	binary.BigEndian.PutUint16(ret[3:5], uint16(len(ret.Payload())))
 	return ret

--- a/control/controlclient/noise_test.go
+++ b/control/controlclient/noise_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package controlclient
+
+import (
+	"math"
+	"testing"
+
+	"tailscale.com/tailcfg"
+)
+
+// maxAllowedNoiseVersion is the highest we expect the Tailscale
+// capability version to ever get. It's a value close to 2^16, but
+// with enough leeway that we get a very early warning that it's time
+// to rework the wire protocol to allow larger versions, while still
+// giving us headroom to bump this test and fix the build.
+//
+// Code elsewhere in the client will panic() if the tailcfg capability
+// version exceeds 16 bits, so take a failure of this test seriously.
+const maxAllowedNoiseVersion = math.MaxUint16 - 5000
+
+func TestNoiseVersion(t *testing.T) {
+	if tailcfg.CurrentCapabilityVersion > maxAllowedNoiseVersion {
+		t.Fatalf("tailcfg.CurrentCapabilityVersion is %d, want <=%d", tailcfg.CurrentCapabilityVersion, maxAllowedNoiseVersion)
+	}
+}

--- a/control/controlhttp/http_test.go
+++ b/control/controlhttp/http_test.go
@@ -104,9 +104,10 @@ func TestControlHTTP(t *testing.T) {
 func testControlHTTP(t *testing.T, proxy proxy) {
 	client, server := key.NewMachine(), key.NewMachine()
 
+	const testProtocolVersion = 1
 	sch := make(chan serverResult, 1)
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := AcceptHTTP(context.Background(), w, r, server)
+		conn, err := AcceptHTTP(context.Background(), w, r, server, testProtocolVersion)
 		if err != nil {
 			log.Print(err)
 		}
@@ -152,6 +153,7 @@ func testControlHTTP(t *testing.T, proxy proxy) {
 		httpsPort:   strconv.Itoa(httpsLn.Addr().(*net.TCPAddr).Port),
 		machineKey:  client,
 		controlKey:  server.Public(),
+		version:     testProtocolVersion,
 		insecureTLS: true,
 	}
 

--- a/control/controlhttp/server.go
+++ b/control/controlhttp/server.go
@@ -21,7 +21,7 @@ import (
 //
 // AcceptHTTP always writes an HTTP response to w. The caller must not
 // attempt their own response after calling AcceptHTTP.
-func AcceptHTTP(ctx context.Context, w http.ResponseWriter, r *http.Request, private key.MachinePrivate) (*controlbase.Conn, error) {
+func AcceptHTTP(ctx context.Context, w http.ResponseWriter, r *http.Request, private key.MachinePrivate, maxSupportedVersion uint16) (*controlbase.Conn, error) {
 	next := r.Header.Get("Upgrade")
 	if next == "" {
 		http.Error(w, "missing next protocol", http.StatusBadRequest)
@@ -63,7 +63,7 @@ func AcceptHTTP(ctx context.Context, w http.ResponseWriter, r *http.Request, pri
 	}
 	conn = netutil.NewDrainBufConn(conn, brw.Reader)
 
-	nc, err := controlbase.Server(ctx, conn, private, init)
+	nc, err := controlbase.Server(ctx, conn, private, maxSupportedVersion, init)
 	if err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("noise handshake failed: %w", err)


### PR DESCRIPTION
This is so that we can plumb our client capability version through
the protocol as the Noise version. The capability version increments
more frequently than strictly required (the Noise version only needs
to change when cryptographically-significant changes are made to
the protocol, whereas the capability version also indicates changes
in non-cryptographically-significant parts of the protocol), but this
gives us a safe pre-auth way to determine if the client supports
future protocol features, while still relying on Noise's strong
assurance that the client and server have agreed on the same version.

Currently, the server executes the same protocol regardless of the
version number, and just presents the version to the caller so they
can do capability-based things in the upper RPC protocol. In future,
we may add a ratchet to disallow obsolete protocols, or vary the
Noise handshake behavior based on requested version.

Signed-off-by: David Anderson <danderson@tailscale.com>