### PR TITLE
cmd/mkpkg: add name argument

### DIFF
--- a/cmd/mkpkg/main.go
+++ b/cmd/mkpkg/main.go
@@ -45,6 +45,8 @@ func parseEmptyDirs(s string) []string {
 
 func main() {
 	out := getopt.StringLong("out", 'o', "", "output file to write")
+	name := getopt.StringLong("name", 'n', "tailscale", "package name")
+	description := getopt.StringLong("description", 'd', "The easiest, most secure, cross platform way to use WireGuard + oauth2 + 2FA/SSO", "package description")
 	goarch := getopt.StringLong("arch", 'a', "amd64", "GOARCH this package is for")
 	pkgType := getopt.StringLong("type", 't', "deb", "type of package to build (deb or rpm)")
 	files := getopt.StringLong("files", 'F', "", "comma-separated list of files in src:dst form")
@@ -68,12 +70,12 @@ func main() {
 	}
 	emptyDirList := parseEmptyDirs(*emptyDirs)
 	info := nfpm.WithDefaults(&nfpm.Info{
-		Name:        "tailscale",
+		Name:        *name,
 		Arch:        *goarch,
 		Platform:    "linux",
 		Version:     *version,
 		Maintainer:  "Tailscale Inc <info@tailscale.com>",
-		Description: "The easiest, most secure, cross platform way to use WireGuard + oauth2 + 2FA/SSO",
+		Description: *description,
 		Homepage:    "https://www.tailscale.com",
 		License:     "MIT",
 		Overridables: nfpm.Overridables{

--- a/shell.nix
+++ b/shell.nix
@@ -15,10 +15,10 @@ pkgs.mkShell {
   # This specifies the tools that are needed for people to get started with
   # development. These tools include:
   #  - The Go compiler toolchain (and all additional tooling with it)
-  #  - goimports, a robust formatting tool for Go source code
+  #  - gotools for goimports, a robust formatting tool for Go source code
   #  - gopls, the language server for Go to increase editor integration
   #  - git, the version control program (used in some scripts)
   buildInputs = with pkgs; [
-    go goimports gopls git
+    go gotools gopls git
   ];
 }


### PR DESCRIPTION
I would like to package proxy-to-grafana and similar tools in .deb/.rpm packages. As a first step to that, I want to be able to pass a package name and description to the `mkpkg` tool.

Also included is a patch to `shell.nix` to make it track recent changes in how `goimports` is referenced.