### PR TITLE
tstest/integration/vms: test on stable nixos (21.11)

### DIFF
--- a/tstest/integration/vms/README.md
+++ b/tstest/integration/vms/README.md
@@ -35,7 +35,7 @@ If you are using [Nix](https://nixos.org), you can run all of the tests with the
 correct command line tools using this command:
 
 ```console
-$ nix-shell -p openssh -p go -p qemu -p cdrkit --run "go test . --run-vm-tests --v --timeout 30m --no-s3"
+$ nix-shell -p nixos-generators -p openssh -p go -p qemu -p cdrkit --run "go test . --run-vm-tests --v --timeout 30m --no-s3"
 ```
 
 Keep the timeout high for the first run, especially if you are not downloading

--- a/tstest/integration/vms/distros.go
+++ b/tstest/integration/vms/distros.go
@@ -20,6 +20,7 @@ type Distro struct {
 	MemoryMegs     int    // VM memory in megabytes
 	PackageManager string // yum/apt/dnf/zypper
 	InitSystem     string // systemd/openrc
+	HostGenerated  bool   // generated image rather than downloaded
 }
 
 func (d *Distro) InstallPre() string {

--- a/tstest/integration/vms/distros.hujson
+++ b/tstest/integration/vms/distros.hujson
@@ -27,4 +27,13 @@
         "PackageManager": "apt",
         "InitSystem": "systemd"
     },
+    {
+        "Name": "nixos-21-11",
+        "URL": "channel:nixos-21.11",
+        "SHA256Sum": "lolfakesha",
+        "MemoryMegs": 512,
+        "PackageManager": "nix",
+        "InitSystem": "systemd",
+        "HostGenerated": true
+    },
 ]

--- a/tstest/integration/vms/top_level_test.go
+++ b/tstest/integration/vms/top_level_test.go
@@ -18,3 +18,9 @@ func TestRunUbuntu2004(t *testing.T) {
 	setupTests(t)
 	testOneDistribution(t, 1, Distros[1])
 }
+
+func TestRunNixos2111(t *testing.T) {
+	t.Parallel()
+	setupTests(t)
+	testOneDistribution(t, 2, Distros[2])
+}


### PR DESCRIPTION
I would like to do some more customized integration tests in the future, (specifically, bringing up a mitm proxy and testing tailscaled through that) so hoping to bring back the nixos wiring to support that.
