### PR TITLE
Move magicDNS to netstack instead of handcrafted UDP

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -342,7 +342,7 @@ func run() error {
 	}
 	if debugMux != nil {
 		if ig, ok := e.(wgengine.InternalsGetter); ok {
-			if _, mc, ok := ig.GetInternals(); ok {
+			if _, mc, _, ok := ig.GetInternals(); ok {
 				debugMux.HandleFunc("/debug/magicsock", mc.ServeHTTPDebug)
 			}
 		}
@@ -566,11 +566,11 @@ func runDebugServer(mux *http.ServeMux, addr string) {
 }
 
 func newNetstack(logf logger.Logf, dialer *tsdial.Dialer, e wgengine.Engine) (*netstack.Impl, error) {
-	tunDev, magicConn, ok := e.(wgengine.InternalsGetter).GetInternals()
+	tunDev, magicConn, dns, ok := e.(wgengine.InternalsGetter).GetInternals()
 	if !ok {
 		return nil, fmt.Errorf("%T is not a wgengine.InternalsGetter", e)
 	}
-	return netstack.Create(logf, tunDev, e, magicConn, dialer)
+	return netstack.Create(logf, tunDev, e, magicConn, dialer, dns)
 }
 
 // mustStartProxyListeners creates listeners for local SOCKS and HTTP

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -249,7 +249,7 @@ func NewLocalBackend(logf logger.Logf, logid string, store ipn.StateStore, diale
 
 	wiredPeerAPIPort := false
 	if ig, ok := e.(wgengine.InternalsGetter); ok {
-		if tunWrap, _, ok := ig.GetInternals(); ok {
+		if tunWrap, _, _, ok := ig.GetInternals(); ok {
 			tunWrap.PeerAPIPort = b.GetPeerAPIPort
 			wiredPeerAPIPort = true
 		}
@@ -3287,7 +3287,7 @@ func (b *LocalBackend) magicConn() (*magicsock.Conn, error) {
 	if !ok {
 		return nil, errors.New("engine isn't InternalsGetter")
 	}
-	_, mc, ok := ig.GetInternals()
+	_, mc, _, ok := ig.GetInternals()
 	if !ok {
 		return nil, errors.New("failed to get internals")
 	}

--- a/ipn/ipnlocal/peerapi.go
+++ b/ipn/ipnlocal/peerapi.go
@@ -864,7 +864,7 @@ func (h *peerAPIHandler) handleServeMagicsock(w http.ResponseWriter, r *http.Req
 	}
 	eng := h.ps.b.e
 	if ig, ok := eng.(wgengine.InternalsGetter); ok {
-		if _, mc, ok := ig.GetInternals(); ok {
+		if _, mc, _, ok := ig.GetInternals(); ok {
 			mc.ServeHTTPDebug(w, r)
 			return
 		}

--- a/net/tstun/wrap.go
+++ b/net/tstun/wrap.go
@@ -135,9 +135,16 @@ type Wrapper struct {
 	PreFilterIn FilterFunc
 	// PostFilterIn is the inbound filter function that runs after the main filter.
 	PostFilterIn FilterFunc
-	// PreFilterOut is the outbound filter function that runs before the main filter
-	// and therefore sees the packets that may be later dropped by it.
-	PreFilterOut FilterFunc
+	// PreFilterFromTunToNetstack is a filter function that runs before the main filter
+	// for packets from the local system. This filter is populated by netstack to hook
+	// packets that should be handled by netstack. If set, this filter runs before
+	// PreFilterFromTunToEngine.
+	PreFilterFromTunToNetstack FilterFunc
+	// PreFilterFromTunToEngine is a filter function that runs before the main filter
+	// for packets from the local system. This filter is populated by wgengine to hook
+	// packets which it handles internally. If both this and PreFilterFromTunToNetstack
+	// filter functions are non-nil, this filter runs second.
+	PreFilterFromTunToEngine FilterFunc
 	// PostFilterOut is the outbound filter function that runs after the main filter.
 	PostFilterOut FilterFunc
 
@@ -451,9 +458,16 @@ func (t *Wrapper) filterOut(p *packet.Parsed) filter.Response {
 		return filter.DropSilently
 	}
 
-	if t.PreFilterOut != nil {
-		if res := t.PreFilterOut(p, t); res.IsDrop() {
-			// Handled by userspaceEngine.handleLocalPackets (quad-100 DNS primarily).
+	if t.PreFilterFromTunToNetstack != nil {
+		if res := t.PreFilterFromTunToNetstack(p, t); res.IsDrop() {
+			// Handled by netstack.Impl.handleLocalPackets (quad-100 DNS primarily)
+			return res
+		}
+	}
+	if t.PreFilterFromTunToEngine != nil {
+		if res := t.PreFilterFromTunToEngine(p, t); res.IsDrop() {
+			// Handled by userspaceEngine.handleLocalPackets (primarily handles
+			// quad-100 if netstack is not installed).
 			return res
 		}
 	}

--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -196,12 +196,12 @@ func (s *Server) start() error {
 		return err
 	}
 
-	tunDev, magicConn, ok := eng.(wgengine.InternalsGetter).GetInternals()
+	tunDev, magicConn, d, ok := eng.(wgengine.InternalsGetter).GetInternals()
 	if !ok {
 		return fmt.Errorf("%T is not a wgengine.InternalsGetter", eng)
 	}
 
-	ns, err := netstack.Create(logf, tunDev, eng, magicConn, s.dialer)
+	ns, err := netstack.Create(logf, tunDev, eng, magicConn, s.dialer, d)
 	if err != nil {
 		return fmt.Errorf("netstack.Create: %w", err)
 	}

--- a/wgengine/netstack/netstack_test.go
+++ b/wgengine/netstack/netstack_test.go
@@ -39,12 +39,12 @@ func TestInjectInboundLeak(t *testing.T) {
 	if !ok {
 		t.Fatal("not an InternalsGetter")
 	}
-	tunWrap, magicSock, ok := ig.GetInternals()
+	tunWrap, magicSock, d, ok := ig.GetInternals()
 	if !ok {
 		t.Fatal("failed to get internals")
 	}
 
-	ns, err := Create(logf, tunWrap, eng, magicSock, dialer)
+	ns, err := Create(logf, tunWrap, eng, magicSock, dialer, d)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -142,11 +142,11 @@ type userspaceEngine struct {
 
 // InternalsGetter is implemented by Engines that can export their internals.
 type InternalsGetter interface {
-	GetInternals() (_ *tstun.Wrapper, _ *magicsock.Conn, ok bool)
+	GetInternals() (_ *tstun.Wrapper, _ *magicsock.Conn, _ *dns.Manager, ok bool)
 }
 
-func (e *userspaceEngine) GetInternals() (_ *tstun.Wrapper, _ *magicsock.Conn, ok bool) {
-	return e.tundev, e.magicConn, true
+func (e *userspaceEngine) GetInternals() (_ *tstun.Wrapper, _ *magicsock.Conn, _ *dns.Manager, ok bool) {
+	return e.tundev, e.magicConn, e.dns, true
 }
 
 // ResolvingEngine is implemented by Engines that have DNS resolvers.
@@ -244,7 +244,7 @@ func IsNetstack(e Engine) bool {
 	if !ok {
 		return false
 	}
-	tw, _, ok := ig.GetInternals()
+	tw, _, _, ok := ig.GetInternals()
 	if !ok {
 		return false
 	}

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -362,7 +362,7 @@ func NewUserspaceEngine(logf logger.Logf, conf Config) (_ Engine, reterr error) 
 	if conf.RespondToPing {
 		e.tundev.PostFilterIn = echoRespondToAll
 	}
-	e.tundev.PreFilterOut = e.handleLocalPackets
+	e.tundev.PreFilterFromTunToEngine = e.handleLocalPackets
 
 	if envknob.BoolDefaultTrue("TS_DEBUG_CONNECT_FAILURES") {
 		if e.tundev.PreFilterIn != nil {

--- a/wgengine/watchdog.go
+++ b/wgengine/watchdog.go
@@ -133,7 +133,7 @@ func (e *watchdogEngine) WhoIsIPPort(ipp netaddr.IPPort) (tsIP netaddr.IP, ok bo
 func (e *watchdogEngine) Close() {
 	e.watchdog("Close", e.wrap.Close)
 }
-func (e *watchdogEngine) GetInternals() (tw *tstun.Wrapper, c *magicsock.Conn, ok bool) {
+func (e *watchdogEngine) GetInternals() (tw *tstun.Wrapper, c *magicsock.Conn, d *dns.Manager, ok bool) {
 	if ig, ok := e.wrap.(InternalsGetter); ok {
 		return ig.GetInternals()
 	}


### PR DESCRIPTION
 - [x] Moves magicDNS-specific handling out of `resolver.Resolver` & into `dns.Manager`. This greatly simplifies the Resolver to solely issuing queries and returning responses, without channels.
 - [x] Pass `*dns.Manager` in initialization of `netstack.Impl` so it can service DNS
 - [x] Hook _From Host_ (traffic received from the TUN) traffic in `netstack.Impl` so netstack can handle MagicDNS
 - [x] Implement shim in `netstack.Impl.acceptUDP` to handle MagicDNS requests
 - [x] ~Implement shim in `netstack.Impl.acceptTCP` to handle MagicDNS requests~ For a future PR, this is big enough already.

Note to reviewers: This change was not conducive to being split into multiple atomic PRs. Instead, I've split it into multiple commits that can be reviewed in progression.