### PR TITLE
net/dns/publicdns: add missing call to sync.Once.Do

### DIFF
--- a/net/dns/publicdns/publicdns.go
+++ b/net/dns/publicdns/publicdns.go
@@ -33,6 +33,7 @@ func DoHIPsOfBase() map[string][]netaddr.IP {
 // DoHV6 returns the first IPv6 DNS address from a given public DNS provider
 // if found, along with a boolean indicating success.
 func DoHV6(base string) (ip netaddr.IP, ok bool) {
+	populateOnce.Do(populate)
 	for _, ip := range dohIPsOfBase[base] {
 		if ip.Is6() {
 			return ip, true


### PR DESCRIPTION
Signed-off-by: Jenny Zhang <jz@tailscale.com>