### PR TITLE
ipn/ipnlocal: add start of inter-user Taildrop

### DIFF
--- a/ipn/ipnlocal/peerapi_test.go
+++ b/ipn/ipnlocal/peerapi_test.go
@@ -158,7 +158,7 @@ func TestHandlePeerAPI(t *testing.T) {
 			req:        httptest.NewRequest("PUT", "/v0/put/foo", nil),
 			checks: checks(
 				httpStatus(http.StatusForbidden),
-				bodyContains("not owner"),
+				bodyContains("Taildrop access denied"),
 			),
 		},
 		{

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -1577,8 +1577,16 @@ type Oauth2Token struct {
 }
 
 const (
+	// MapResponse.Node self capabilities.
+
 	CapabilityFileSharing = "https://tailscale.com/cap/file-sharing"
 	CapabilityAdmin       = "https://tailscale.com/cap/is-admin"
+
+	// Inter-node capabilities.
+
+	// CapabilityFileSharingSend grants the ability to receive files from a
+	// node that's owned by a different user.
+	CapabilityFileSharingSend = "https://tailscale.com/cap/file-send"
 )
 
 // SetDNSRequest is a request to add a DNS record.


### PR DESCRIPTION
Controlled by server-sent capability policy.

To be initially used for SSH servers to record sessions to other
nodes. Not yet productized into something user-accessible. (Notably,
the list of Taildrop targets from the sender side isn't augmented
yet.) This purely permits expanding the set of expands a node will
accept a drop from.

Updates #3802
Updates #4217
