### PR TITLE
ipn/ipnlocal: add capability for debugging peers over peerapi

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -1587,6 +1587,9 @@ const (
 	// CapabilityFileSharingSend grants the ability to receive files from a
 	// node that's owned by a different user.
 	CapabilityFileSharingSend = "https://tailscale.com/cap/file-send"
+	// CapabilityDebugPeer grants the ability for a peer to read this node's
+	// goroutines, metrics, magicsock internal state, etc.
+	CapabilityDebugPeer = "https://tailscale.com/cap/debug-peer"
 )
 
 // SetDNSRequest is a request to add a DNS record.


### PR DESCRIPTION
The default is still users can debug their own nodes. But like
cd916b728b did, this adds support for admins to grant additional
capabilities with the new tailcfg.CapabilityDebugPeer cap.

Updates #4217
