### PR TITLE
net/dns/resolver: make DoH dialer use existing dnscache happy eyeball dialer

### DIFF
--- a/net/dns/resolver/forwarder_test.go
+++ b/net/dns/resolver/forwarder_test.go
@@ -5,6 +5,7 @@
 package resolver
 
 import (
+	"flag"
 	"fmt"
 	"net"
 	"reflect"
@@ -167,6 +168,25 @@ func TestMaxDoHInFlight(t *testing.T) {
 			}
 		})
 	}
+}
+
+var testDNS = flag.Bool("test-dns", false, "run tests that require a working DNS server")
+
+func TestGetKnownDoHClientForProvider(t *testing.T) {
+	var fwd forwarder
+	c, ok := fwd.getKnownDoHClientForProvider("https://dns.google/dns-query")
+	if !ok {
+		t.Fatal("not found")
+	}
+	if !*testDNS {
+		t.Skip("skipping without --test-dns")
+	}
+	res, err := c.Head("https://dns.google/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	t.Logf("Got: %+v", res)
 }
 
 func BenchmarkNameFromQuery(b *testing.B) {

--- a/net/dnscache/dnscache.go
+++ b/net/dnscache/dnscache.go
@@ -72,6 +72,15 @@ type Resolver struct {
 	// if a refresh fails.
 	UseLastGood bool
 
+	// SingleHostStaticResult, if non-nil, is the static result of IPs that is returned
+	// by Resolver.LookupIP for any hostname. When non-nil, SingleHost must also be
+	// set with the expected name.
+	SingleHostStaticResult []netaddr.IP
+
+	// SingleHost is the hostname that SingleHostStaticResult is for.
+	// It is required when SingleHostStaticResult is present.
+	SingleHost string
+
 	sf singleflight.Group
 
 	mu      sync.Mutex
@@ -108,6 +117,22 @@ var debug = envknob.Bool("TS_DEBUG_DNS_CACHE")
 // If err is nil, ip will be non-nil. The v6 address may be nil even
 // with a nil error.
 func (r *Resolver) LookupIP(ctx context.Context, host string) (ip, v6 net.IP, allIPs []net.IPAddr, err error) {
+	if r.SingleHostStaticResult != nil {
+		if r.SingleHost != host {
+			return nil, nil, nil, fmt.Errorf("dnscache: unexpected hostname %q doesn't match expected %q", host, r.SingleHost)
+		}
+		for _, naIP := range r.SingleHostStaticResult {
+			ipa := naIP.IPAddr()
+			if ip == nil && naIP.Is4() {
+				ip = ipa.IP
+			}
+			if v6 == nil && naIP.Is6() {
+				v6 = ipa.IP
+			}
+			allIPs = append(allIPs, *ipa)
+		}
+		return
+	}
 	if ip := net.ParseIP(host); ip != nil {
 		if ip4 := ip.To4(); ip4 != nil {
 			return ip4, nil, []net.IPAddr{{IP: ip4}}, nil


### PR DESCRIPTION
Simplify the ability to reason about the DoH dialing code by reusing the
dnscache's dialer we already have.

Also, reduce the scope of the "ip" variable we don't want to close over.

This necessarily adds a new field to dnscache.Resolver:
SingleHostStaticResult, for when the caller already knows the IPs to be
returned.
