### PR TITLE
tailcfg, logtail: provide Debug bit to disable logtail

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -34,6 +34,7 @@ import (
 	"tailscale.com/hostinfo"
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/log/logheap"
+	"tailscale.com/logtail"
 	"tailscale.com/net/dnscache"
 	"tailscale.com/net/dnsfallback"
 	"tailscale.com/net/interfaces"
@@ -894,6 +895,9 @@ func (c *Direct) sendMapRequest(ctx context.Context, maxPolls int, cb func(*netm
 			if code := resp.Debug.Exit; code != nil {
 				c.logf("exiting process with status %v per controlplane", *code)
 				os.Exit(*code)
+			}
+			if resp.Debug.DisableLogTail {
+				logtail.Disable()
 			}
 			if resp.Debug.LogHeapPprof {
 				go logheap.LogHeap(resp.Debug.LogHeapURL)

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -1458,6 +1458,10 @@ type Debug struct {
 	// new attempts at UPnP connections.
 	DisableUPnP opt.Bool `json:",omitempty"`
 
+	// DisableLogTail disables the logtail package. Once disabled it can't be
+	// re-enabled for the lifetime of the process.
+	DisableLogTail bool `json:",omitempty"`
+
 	// Exit optionally specifies that the client should os.Exit
 	// with this code.
 	Exit *int `json:",omitempty"`


### PR DESCRIPTION
For people running self-hosted control planes who want a global
opt-out knob instead of running their own logcatcher.
