### PR TITLE
net/ping, control/controlclient: add ICMP pings

### DIFF
--- a/cmd/tailscale/cli/ping.go
+++ b/cmd/tailscale/cli/ping.go
@@ -18,6 +18,7 @@ import (
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"tailscale.com/ipn"
 	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/tailcfg"
 )
 
 var pingCmd = &ffcli.Command{
@@ -26,7 +27,7 @@ var pingCmd = &ffcli.Command{
 	ShortHelp:  "Ping a host at the Tailscale layer, see how it routed",
 	LongHelp: strings.TrimSpace(`
 
-The 'tailscale ping' command pings a peer node at the Tailscale layer
+The 'tailscale ping' command pings a peer node from the Tailscale layer
 and reports which route it took for each response. The first ping or
 so will likely go over DERP (Tailscale's TCP relay protocol) while NAT
 traversal finds a direct path through.
@@ -48,7 +49,8 @@ relay node.
 		fs := newFlagSet("ping")
 		fs.BoolVar(&pingArgs.verbose, "verbose", false, "verbose output")
 		fs.BoolVar(&pingArgs.untilDirect, "until-direct", true, "stop once a direct path is established")
-		fs.BoolVar(&pingArgs.tsmp, "tsmp", false, "do a TSMP-level ping (through IP + wireguard, but not involving host OS stack)")
+		fs.BoolVar(&pingArgs.tsmp, "tsmp", false, "do a TSMP-level ping (through wireguard, but not either host OS stack)")
+		fs.BoolVar(&pingArgs.icmp, "icmp", false, "do a ICMP-level ping (through wireguard, but not the local host OS stack)")
 		fs.IntVar(&pingArgs.num, "c", 10, "max number of pings to send")
 		fs.DurationVar(&pingArgs.timeout, "timeout", 5*time.Second, "timeout before giving up on a ping")
 		return fs
@@ -60,7 +62,18 @@ var pingArgs struct {
 	untilDirect bool
 	verbose     bool
 	tsmp        bool
+	icmp        bool
 	timeout     time.Duration
+}
+
+func pingType() tailcfg.PingType {
+	if pingArgs.tsmp {
+		return tailcfg.PingTSMP
+	}
+	if pingArgs.icmp {
+		return tailcfg.PingICMP
+	}
+	return tailcfg.PingDisco
 }
 
 func runPing(ctx context.Context, args []string) error {
@@ -111,7 +124,7 @@ func runPing(ctx context.Context, args []string) error {
 	anyPong := false
 	for {
 		n++
-		bc.Ping(ip, pingArgs.tsmp)
+		bc.Ping(ip, pingType())
 		timer := time.NewTimer(pingArgs.timeout)
 		select {
 		case <-timer.C:
@@ -132,10 +145,10 @@ func runPing(ctx context.Context, args []string) error {
 			if pr.DERPRegionID != 0 {
 				via = fmt.Sprintf("DERP(%s)", pr.DERPRegionCode)
 			}
-			if pingArgs.tsmp {
+			if via == "" {
 				// TODO(bradfitz): populate the rest of ipnstate.PingResult for TSMP queries?
-				// For now just say it came via TSMP.
-				via = "TSMP"
+				// For now just say which protocol it used.
+				via = string(pingType())
 			}
 			anyPong = true
 			extra := ""
@@ -143,7 +156,7 @@ func runPing(ctx context.Context, args []string) error {
 				extra = fmt.Sprintf(", %d", pr.PeerAPIPort)
 			}
 			printf("pong from %s (%s%s) via %v in %v\n", pr.NodeName, pr.NodeIP, extra, via, latency)
-			if pingArgs.tsmp {
+			if pingArgs.tsmp || pingArgs.icmp {
 				return nil
 			}
 			if pr.Endpoint != "" && pingArgs.untilDirect {

--- a/ipn/backend.go
+++ b/ipn/backend.go
@@ -248,5 +248,5 @@ type Backend interface {
 	// Ping attempts to start connecting to the given IP and sends a Notify
 	// with its PingResult. If the host is down, there might never
 	// be a PingResult sent. The cmd/tailscale CLI client adds a timeout.
-	Ping(ip string, useTSMP bool)
+	Ping(ip string, pingType tailcfg.PingType)
 }

--- a/ipn/fake_test.go
+++ b/ipn/fake_test.go
@@ -100,7 +100,7 @@ func (b *FakeBackend) RequestEngineStatus() {
 	}
 }
 
-func (b *FakeBackend) Ping(ip string, useTSMP bool) {
+func (b *FakeBackend) Ping(ip string, pingType tailcfg.PingType) {
 	if b.notify != nil {
 		b.notify(Notify{PingResult: &ipnstate.PingResult{}})
 	}

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1699,13 +1699,13 @@ func (b *LocalBackend) StartLoginInteractive() {
 	}
 }
 
-func (b *LocalBackend) Ping(ipStr string, useTSMP bool) {
+func (b *LocalBackend) Ping(ipStr string, pingType tailcfg.PingType) {
 	ip, err := netaddr.ParseIP(ipStr)
 	if err != nil {
 		b.logf("ignoring Ping request to invalid IP %q", ipStr)
 		return
 	}
-	b.e.Ping(ip, useTSMP, func(pr *ipnstate.PingResult) {
+	b.e.Ping(ip, pingType, func(pr *ipnstate.PingResult) {
 		b.send(ipn.Notify{PingResult: pr})
 	})
 }

--- a/ipn/ipnstate/ipnstate.go
+++ b/ipn/ipnstate/ipnstate.go
@@ -515,7 +515,7 @@ type PingResult struct {
 	// TODO(bradfitz): details like whether port mapping was used on either side? (Once supported)
 }
 
-func (pr *PingResult) ToPingResponse(pingType string) *tailcfg.PingResponse {
+func (pr *PingResult) ToPingResponse(pingType tailcfg.PingType) *tailcfg.PingResponse {
 	return &tailcfg.PingResponse{
 		Type:           pingType,
 		IP:             pr.IP,

--- a/ipn/message.go
+++ b/ipn/message.go
@@ -52,8 +52,8 @@ type SetPrefsArgs struct {
 }
 
 type PingArgs struct {
-	IP      string
-	UseTSMP bool
+	IP   string
+	Type tailcfg.PingType
 }
 
 // Command is a command message that is JSON encoded and sent by a
@@ -171,7 +171,7 @@ func (bs *BackendServer) GotCommand(ctx context.Context, cmd *Command) error {
 		bs.b.RequestEngineStatus()
 		return nil
 	} else if c := cmd.Ping; c != nil {
-		bs.b.Ping(c.IP, c.UseTSMP)
+		bs.b.Ping(c.IP, tailcfg.PingType(c.Type))
 		return nil
 	}
 
@@ -311,10 +311,10 @@ func (bc *BackendClient) RequestStatus() {
 	bc.send(Command{AllowVersionSkew: true, RequestStatus: &NoArgs{}})
 }
 
-func (bc *BackendClient) Ping(ip string, useTSMP bool) {
+func (bc *BackendClient) Ping(ip string, pingType tailcfg.PingType) {
 	bc.send(Command{Ping: &PingArgs{
-		IP:      ip,
-		UseTSMP: useTSMP,
+		IP:   ip,
+		Type: pingType,
 	}})
 }
 

--- a/net/packet/icmp.go
+++ b/net/packet/icmp.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package packet
+
+import (
+	crand "crypto/rand"
+
+	"encoding/binary"
+)
+
+// ICMPEchoPayload generates a new random ID/Sequence pair, and returns a uint32
+// derived from them, along with the id, sequence and given payload in a buffer.
+// It returns an error if the random source could not be read.
+func ICMPEchoPayload(payload []byte) (idSeq uint32, buf []byte) {
+	buf = make([]byte, len(payload)+4)
+
+	// make a completely random id/sequence combo, which is very unlikely to
+	// collide with a running ping sequence on the host system. Errors are
+	// ignored, that would result in collisions, but errors reading from the
+	// random device are rare, and will cause this process universe to soon end.
+	crand.Read(buf[:4])
+
+	idSeq = binary.LittleEndian.Uint32(buf)
+	copy(buf[4:], payload)
+
+	return
+}

--- a/net/packet/packet.go
+++ b/net/packet/packet.go
@@ -434,6 +434,29 @@ func (q *Parsed) IsEchoResponse() bool {
 	}
 }
 
+// EchoIDSeq extracts the identifier/sequence bytes from an ICMP Echo response,
+// and returns them as a uint32, used to lookup internally routed ICMP echo
+// responses. This function is intentionally lightweight as it is called on
+// every incoming ICMP packet.
+func (q *Parsed) EchoIDSeq() uint32 {
+	switch q.IPProto {
+	case ipproto.ICMPv4:
+		offset := ip4HeaderLength + icmp4HeaderLength
+		if len(q.b) < offset+4 {
+			return 0
+		}
+		return binary.LittleEndian.Uint32(q.b[offset:])
+	case ipproto.ICMPv6:
+		offset := ip6HeaderLength + icmp6HeaderLength
+		if len(q.b) < offset+4 {
+			return 0
+		}
+		return binary.LittleEndian.Uint32(q.b[offset:])
+	default:
+		return 0
+	}
+}
+
 func Hexdump(b []byte) string {
 	out := new(strings.Builder)
 	for i := 0; i < len(b); i += 16 {

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -1217,6 +1217,19 @@ type DNSRecord struct {
 	Value string
 }
 
+// PingType is a string representing the kind of ping to perform.
+type PingType string
+
+const (
+	// PingDisco performs a ping, without involving IP at either end.
+	PingDisco PingType = "disco"
+	// PingTSMP performs a ping, using the IP layer, but avoiding the OS IP stack.
+	PingTSMP PingType = "TSMP"
+	// PingICMP performs a ping between two tailscale nodes using ICMP that is
+	// received by the target systems IP stack.
+	PingICMP PingType = "ICMP"
+)
+
 // PingRequest with no IP and Types is a request to send an HTTP request to prove the
 // long-polling client is still connected.
 // PingRequest with Types and IP, will send a ping to the IP and send a POST
@@ -1234,8 +1247,8 @@ type PingRequest struct {
 	// For failure cases, the client will log regardless.
 	Log bool `json:",omitempty"`
 
-	// Types is the types of ping that is initiated. Can be TSMP, ICMP or disco.
-	// Types will be comma separated, such as TSMP,disco.
+	// Types is the types of ping that are initiated. Can be any PingType, comma
+	// separated, e.g. "disco,TSMP"
 	Types string
 
 	// IP is the ping target.
@@ -1246,7 +1259,7 @@ type PingRequest struct {
 // PingResponse provides result information for a TSMP or Disco PingRequest.
 // Typically populated from an ipnstate.PingResult used in `tailscale ping`.
 type PingResponse struct {
-	Type string // ping type, such as TSMP or disco.
+	Type PingType // ping type, such as TSMP or disco.
 
 	IP       string `json:",omitempty"` // ping destination
 	NodeIP   string `json:",omitempty"` // Tailscale IP of node handling IP (different for subnet routers)

--- a/wgengine/watchdog.go
+++ b/wgengine/watchdog.go
@@ -117,8 +117,8 @@ func (e *watchdogEngine) DiscoPublicKey() (k key.DiscoPublic) {
 	e.watchdog("DiscoPublicKey", func() { k = e.wrap.DiscoPublicKey() })
 	return k
 }
-func (e *watchdogEngine) Ping(ip netaddr.IP, useTSMP bool, cb func(*ipnstate.PingResult)) {
-	e.watchdog("Ping", func() { e.wrap.Ping(ip, useTSMP, cb) })
+func (e *watchdogEngine) Ping(ip netaddr.IP, pingType tailcfg.PingType, cb func(*ipnstate.PingResult)) {
+	e.watchdog("Ping", func() { e.wrap.Ping(ip, pingType, cb) })
 }
 func (e *watchdogEngine) RegisterIPPortIdentity(ipp netaddr.IPPort, tsIP netaddr.IP) {
 	e.watchdog("RegisterIPPortIdentity", func() { e.wrap.RegisterIPPortIdentity(ipp, tsIP) })

--- a/wgengine/wgengine.go
+++ b/wgengine/wgengine.go
@@ -154,9 +154,9 @@ type Engine interface {
 	// status builder.
 	UpdateStatus(*ipnstate.StatusBuilder)
 
-	// Ping is a request to start a discovery ping with the peer handling
-	// the given IP and then call cb with its ping latency & method.
-	Ping(ip netaddr.IP, useTSMP bool, cb func(*ipnstate.PingResult))
+	// Ping is a request to start a ping with the peer handling the given IP and
+	// then call cb with its ping latency & method.
+	Ping(ip netaddr.IP, pingType tailcfg.PingType, cb func(*ipnstate.PingResult))
 
 	// RegisterIPPortIdentity registers a given node (identified by its
 	// Tailscale IP) as temporarily having the given IP:port for whois lookups.


### PR DESCRIPTION
```
control: ping to 8.8.8.8 completed in 0.0129. pinger.Ping took 17.361535ms seconds
control: postPingResult: sending ping results to http://localhost:31544/pong/a42f028ba0636fea63d348a80bb6b185 ...
control: postPingResult complete to http://localhost:31544/pong/a42f028ba0636fea63d348a80bb6b185 (after 1ms)```