### PR TITLE
cmd/proxy-to-grafana: prevent premature termination

### DIFF
--- a/cmd/proxy-to-grafana/proxy-to-grafana.go
+++ b/cmd/proxy-to-grafana/proxy-to-grafana.go
@@ -86,11 +86,12 @@ func main() {
 			for i := 0; i < 60; i++ {
 				st, err := tailscale.Status(context.Background())
 				if err != nil {
-					log.Fatal(err)
-				}
-				log.Printf("tailscale status: %v", st.BackendState)
-				if st.BackendState == "Running" {
-					break
+					log.Printf("error retrieving tailscale status; retrying: %v", err)
+				} else {
+					log.Printf("tailscale status: %v", st.BackendState)
+					if st.BackendState == "Running" {
+						break
+					}
 				}
 				time.Sleep(time.Second)
 			}


### PR DESCRIPTION
This commit changes proxy-to-grafana to report errors while polling for
tailscaled status instead of terminating at the first sign of an error.
This allows tailscale some time to come up before the proxy decides to
give up.