### PR TITLE
wgengine/monitor: ignore OS-specific uninteresting interfaces

### DIFF
--- a/wgengine/monitor/monitor.go
+++ b/wgengine/monitor/monitor.go
@@ -316,8 +316,9 @@ func (m *Mon) debounce() {
 				m.ifState = curState
 
 				if s1, s2 := oldState.String(), curState.String(); s1 == s2 {
-					m.logf("[unexpected] network state changed, but stringification didn't: %v\nold: %s\nnew: %s\n", s1,
-						jsonSummary(oldState), jsonSummary(curState))
+					m.logf("[unexpected] network state changed, but stringification didn't: %v", s1)
+					m.logf("[unexpected] old: %s", jsonSummary(oldState))
+					m.logf("[unexpected] new: %s", jsonSummary(curState))
 				}
 			}
 			// See if we have a queued or new time jump signal.

--- a/wgengine/monitor/monitor_darwin.go
+++ b/wgengine/monitor/monitor_darwin.go
@@ -112,11 +112,18 @@ func addrType(addrs []route.Addr, rtaxType int) route.Addr {
 	return nil
 }
 
+func (m *darwinRouteMon) IsInterestingInterface(iface string) bool {
+	baseName := strings.TrimRight(iface, "0123456789")
+	switch baseName {
+	case "llw", "awdl", "pdp_ip", "ipsec":
+		return false
+	}
+	return true
+}
+
 func (m *darwinRouteMon) skipInterfaceAddrMessage(msg *route.InterfaceAddrMessage) bool {
 	if la, ok := addrType(msg.Addrs, unix.RTAX_IFP).(*route.LinkAddr); ok {
-		baseName := strings.TrimRight(la.Name, "0123456789")
-		switch baseName {
-		case "llw", "awdl", "pdp_ip", "ipsec":
+		if !m.IsInterestingInterface(la.Name) {
 			return true
 		}
 	}

--- a/wgengine/monitor/monitor_freebsd.go
+++ b/wgengine/monitor/monitor_freebsd.go
@@ -34,6 +34,8 @@ func newOSMon(logf logger.Logf, m *Mon) (osMon, error) {
 	return &devdConn{conn}, nil
 }
 
+func (c *devdConn) IsInterestingInterface(iface string) bool { return true }
+
 func (c *devdConn) Close() error {
 	return c.conn.Close()
 }

--- a/wgengine/monitor/monitor_linux.go
+++ b/wgengine/monitor/monitor_linux.go
@@ -64,6 +64,8 @@ func newOSMon(logf logger.Logf, m *Mon) (osMon, error) {
 	return &nlConn{logf: logf, conn: conn, addrCache: make(map[uint32]map[netaddr.IP]bool)}, nil
 }
 
+func (c *nlConn) IsInterestingInterface(iface string) bool { return true }
+
 func (c *nlConn) Close() error { return c.conn.Close() }
 
 func (c *nlConn) Receive() (message, error) {

--- a/wgengine/monitor/monitor_windows.go
+++ b/wgengine/monitor/monitor_windows.go
@@ -72,6 +72,8 @@ func newOSMon(logf logger.Logf, _ *Mon) (osMon, error) {
 	return m, nil
 }
 
+func (m *winMon) IsInterestingInterface(iface string) bool { return true }
+
 func (m *winMon) Close() (ret error) {
 	m.cancel()
 	m.noDeadlockTicker.Stop()

--- a/wgengine/monitor/polling.go
+++ b/wgengine/monitor/polling.go
@@ -38,6 +38,10 @@ type pollingMon struct {
 	stop      chan struct{}
 }
 
+func (pm *pollingMon) IsInterestingInterface(iface string) bool {
+	return true
+}
+
 func (pm *pollingMon) Close() error {
 	pm.closeOnce.Do(func() {
 		close(pm.stop)


### PR DESCRIPTION
Currently we ignore these interfaces in the darwin osMon but then would consider it
interesting when checking if anything had changed.

Signed-off-by: Maisem Ali <maisem@tailscale.com>