### PR TITLE
ipn/ipnlocal: close peerapi listeners on LocalBackend.Shutdown

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -344,6 +344,7 @@ func (b *LocalBackend) onHealthChange(sys health.Subsystem, err error) {
 func (b *LocalBackend) Shutdown() {
 	b.mu.Lock()
 	cc := b.cc
+	b.closePeerAPIListenersLocked()
 	b.mu.Unlock()
 
 	b.unregisterLinkMon()


### PR DESCRIPTION
For tests.

Now that we can always listen (whereas we used to fail prior to
a2c330c4961aea883a674aa530cc40bf74047bac), some goroutine leak
checks were failing in tests in another repo after that change.
