### PR TITLE
ssh/tailssh: fix double SSH-2.0- prefix in greeting banner

### DIFF
--- a/ssh/tailssh/tailssh.go
+++ b/ssh/tailssh/tailssh.go
@@ -221,7 +221,7 @@ func (c *conn) ServerConfig(ctx ssh.Context) *gossh.ServerConfig {
 func (srv *server) newConn() (*conn, error) {
 	c := &conn{srv: srv, now: srv.now()}
 	c.Server = &ssh.Server{
-		Version:           "SSH-2.0-Tailscale",
+		Version:           "Tailscale",
 		Handler:           c.handleConnPostSSHAuth,
 		RequestHandlers:   map[string]ssh.RequestHandler{},
 		SubsystemHandlers: map[string]ssh.SubsystemHandler{},


### PR DESCRIPTION
gliderlabs/ssh was already adding the "SSH-2.0-" prefix.

Updates #3802
