### PR TITLE
ssh/tailssh: avoid user ssh configuration in tests

### DIFF
--- a/ssh/tailssh/tailssh_test.go
+++ b/ssh/tailssh/tailssh_test.go
@@ -265,6 +265,8 @@ func TestSSH(t *testing.T) {
 
 	execSSH := func(args ...string) *exec.Cmd {
 		cmd := exec.Command("ssh",
+			"-F",
+			"none",
 			"-v",
 			"-p", fmt.Sprint(port),
 			"-o", "StrictHostKeyChecking=no",


### PR DESCRIPTION
The tests were hanging for me, probably waiting for `ssh` to exit, but it may not under some conditions, such as if it's matched my broad ControlMaster config. Avoiding the user config will avoid any such test unpredictability.