### PR TITLE
net/dns/resolver: add metric for number of truncated dns packets

### DIFF
--- a/net/dns/resolver/tsdns.go
+++ b/net/dns/resolver/tsdns.go
@@ -1340,6 +1340,7 @@ var (
 
 	metricDNSFwdErrorType      = clientmetric.NewCounter("dns_query_fwd_error_type")
 	metricDNSFwdErrorParseAddr = clientmetric.NewCounter("dns_query_fwd_error_parse_addr")
+	metricDNSFwdTruncated      = clientmetric.NewCounter("dns_query_fwd_truncated")
 
 	metricDNSFwdUDP            = clientmetric.NewCounter("dns_query_fwd_udp")       // on entry
 	metricDNSFwdUDPWrote       = clientmetric.NewCounter("dns_query_fwd_udp_wrote") // sent UDP packet


### PR DESCRIPTION
Updates #2067

This should help us determine if more robust control of edns parameters & implementing answer truncation is warranted, given its likely complexity.
