### PR TITLE
tsnet: fix mem.Store check for normal nodes

### DIFF
--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -137,8 +137,9 @@ func (s *Server) start() error {
 	}
 
 	s.rootPath = s.Dir
-	if s.Store != nil && !s.Ephemeral {
-		if _, ok := s.Store.(*mem.Store); !ok {
+	if s.Store != nil {
+		_, isMemStore := s.Store.(*mem.Store)
+		if isMemStore && !s.Ephemeral {
 			return fmt.Errorf("in-memory store is only supported for Ephemeral nodes")
 		}
 	}


### PR DESCRIPTION
There was a typo in the check it was doing `!ok` instead of `ok`, this
restructures it a bit to read better.

Fixes #4506

Signed-off-by: Maisem Ali <maisem@tailscale.com>