### PR TITLE
cmd/tailscale: s/-authkey/-auth-key/ in help text

### DIFF
--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -52,7 +52,7 @@ down").
 If flags are specified, the flags must be the complete set of desired
 settings. An error is returned if any setting would be changed as a
 result of an unspecified flag's default value, unless the --reset flag
-is also used. (The flags --authkey, --force-reauth, and --qr are not
+is also used. (The flags --auth-key, --force-reauth, and --qr are not
 considered settings that need to be re-specified when modifying
 settings.)
 `),


### PR DESCRIPTION
Looks like we accept both via CleanupArgs, but the other help output lists it as `auth-key` so this just makes that consistent.