### PR TITLE
ipn: always treat login.tailscale.com as controlplane.tailscale.com

### DIFF
--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -428,9 +428,14 @@ func NewPrefs() *Prefs {
 }
 
 // ControlURLOrDefault returns the coordination server's URL base.
-// If not configured, DefaultControlURL is returned instead.
+//
+// If not configured, or if the configured value is a legacy name equivalent to
+// the default, then DefaultControlURL is returned instead.
 func (p *Prefs) ControlURLOrDefault() string {
 	if p.ControlURL != "" {
+		if p.ControlURL != DefaultControlURL && IsLoginServerSynonym(p.ControlURL) {
+			return DefaultControlURL
+		}
 		return p.ControlURL
 	}
 	return DefaultControlURL

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -810,3 +810,18 @@ func TestExitNodeIPOfArg(t *testing.T) {
 		})
 	}
 }
+
+func TestControlURLOrDefault(t *testing.T) {
+	var p Prefs
+	if got, want := p.ControlURLOrDefault(), DefaultControlURL; got != want {
+		t.Errorf("got %q; want %q", got, want)
+	}
+	p.ControlURL = "http://foo.bar"
+	if got, want := p.ControlURLOrDefault(), "http://foo.bar"; got != want {
+		t.Errorf("got %q; want %q", got, want)
+	}
+	p.ControlURL = "https://login.tailscale.com"
+	if got, want := p.ControlURLOrDefault(), DefaultControlURL; got != want {
+		t.Errorf("got %q; want %q", got, want)
+	}
+}


### PR DESCRIPTION
Like 888e50e1, but more aggressive.

Updates #4538 (likely fixes)
Updates #3488
