### PR TITLE
net/tsdial: add SystemDial as a wrapper on netns.Dial

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -332,6 +332,7 @@ func run() error {
 	socksListener, httpProxyListener := mustStartProxyListeners(args.socksAddr, args.httpProxyAddr)
 
 	dialer := new(tsdial.Dialer) // mutated below (before used)
+	dialer.Logf = logf
 	e, useNetstack, err := createEngine(logf, linkMon, dialer)
 	if err != nil {
 		return fmt.Errorf("createEngine: %w", err)
@@ -394,6 +395,7 @@ func run() error {
 	// want to keep running.
 	signal.Ignore(syscall.SIGPIPE)
 	go func() {
+		defer dialer.Close()
 		select {
 		case s := <-interrupt:
 			logf("tailscaled got signal %v; shutting down", s)

--- a/control/controlclient/direct_test.go
+++ b/control/controlclient/direct_test.go
@@ -14,6 +14,7 @@ import (
 	"inet.af/netaddr"
 	"tailscale.com/hostinfo"
 	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/net/tsdial"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/key"
 )
@@ -30,6 +31,7 @@ func TestNewDirect(t *testing.T) {
 		GetMachinePrivateKey: func() (key.MachinePrivate, error) {
 			return k, nil
 		},
+		Dialer: new(tsdial.Dialer),
 	}
 	c, err := NewDirect(opts)
 	if err != nil {
@@ -106,6 +108,7 @@ func TestTsmpPing(t *testing.T) {
 		GetMachinePrivateKey: func() (key.MachinePrivate, error) {
 			return k, nil
 		},
+		Dialer: new(tsdial.Dialer),
 	}
 
 	c, err := NewDirect(opts)

--- a/control/controlclient/noise.go
+++ b/control/controlclient/noise.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/net/http2"
 	"tailscale.com/control/controlbase"
 	"tailscale.com/control/controlhttp"
+	"tailscale.com/net/tsdial"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/key"
 	"tailscale.com/util/mak"
@@ -46,6 +47,7 @@ func (c *noiseConn) Close() error {
 // the ts2021 protocol.
 type noiseClient struct {
 	*http.Client // HTTP client used to talk to tailcontrol
+	dialer       *tsdial.Dialer
 	privKey      key.MachinePrivate
 	serverPubKey key.MachinePublic
 	serverHost   string // the host:port part of serverURL
@@ -58,7 +60,7 @@ type noiseClient struct {
 
 // newNoiseClient returns a new noiseClient for the provided server and machine key.
 // serverURL is of the form https://<host>:<port> (no trailing slash).
-func newNoiseClient(priKey key.MachinePrivate, serverPubKey key.MachinePublic, serverURL string) (*noiseClient, error) {
+func newNoiseClient(priKey key.MachinePrivate, serverPubKey key.MachinePublic, serverURL string, dialer *tsdial.Dialer) (*noiseClient, error) {
 	u, err := url.Parse(serverURL)
 	if err != nil {
 		return nil, err
@@ -75,6 +77,7 @@ func newNoiseClient(priKey key.MachinePrivate, serverPubKey key.MachinePublic, s
 		serverPubKey: serverPubKey,
 		privKey:      priKey,
 		serverHost:   host,
+		dialer:       dialer,
 	}
 
 	// Create the HTTP/2 Transport using a net/http.Transport
@@ -151,7 +154,7 @@ func (nc *noiseClient) dial(_, _ string, _ *tls.Config) (net.Conn, error) {
 		// thousand version numbers before getting to this point.
 		panic("capability version is too high to fit in the wire protocol")
 	}
-	conn, err := controlhttp.Dial(ctx, nc.serverHost, nc.privKey, nc.serverPubKey, uint16(tailcfg.CurrentCapabilityVersion))
+	conn, err := controlhttp.Dial(ctx, nc.serverHost, nc.privKey, nc.serverPubKey, uint16(tailcfg.CurrentCapabilityVersion), nc.dialer.SystemDial)
 	if err != nil {
 		return nil, err
 	}

--- a/control/controlhttp/client.go
+++ b/control/controlhttp/client.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"net/http"
 	"net/http/httptrace"
@@ -34,7 +33,6 @@ import (
 	"tailscale.com/control/controlbase"
 	"tailscale.com/net/dnscache"
 	"tailscale.com/net/dnsfallback"
-	"tailscale.com/net/netns"
 	"tailscale.com/net/netutil"
 	"tailscale.com/net/tlsdial"
 	"tailscale.com/net/tshttpproxy"
@@ -65,7 +63,7 @@ const (
 //
 // The provided ctx is only used for the initial connection, until
 // Dial returns. It does not affect the connection once established.
-func Dial(ctx context.Context, addr string, machineKey key.MachinePrivate, controlKey key.MachinePublic, protocolVersion uint16) (*controlbase.Conn, error) {
+func Dial(ctx context.Context, addr string, machineKey key.MachinePrivate, controlKey key.MachinePublic, protocolVersion uint16, dialer dnscache.DialContextFunc) (*controlbase.Conn, error) {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		return nil, err
@@ -79,6 +77,7 @@ func Dial(ctx context.Context, addr string, machineKey key.MachinePrivate, contr
 		controlKey: controlKey,
 		version:    protocolVersion,
 		proxyFunc:  tshttpproxy.ProxyFromEnvironment,
+		dialer:     dialer,
 	}
 	return a.dial()
 }
@@ -92,6 +91,7 @@ type dialParams struct {
 	controlKey key.MachinePublic
 	version    uint16
 	proxyFunc  func(*http.Request) (*url.URL, error) // or nil
+	dialer     dnscache.DialContextFunc
 
 	// For tests only
 	insecureTLS bool
@@ -145,12 +145,11 @@ func (a *dialParams) tryURL(u *url.URL, init []byte) (net.Conn, error) {
 		LookupIPFallback: dnsfallback.Lookup,
 		UseLastGood:      true,
 	}
-	dialer := netns.NewDialer(log.Printf)
 	tr := http.DefaultTransport.(*http.Transport).Clone()
 	defer tr.CloseIdleConnections()
 	tr.Proxy = a.proxyFunc
 	tshttpproxy.SetTransportGetProxyConnectHeader(tr)
-	tr.DialContext = dnscache.Dialer(dialer.DialContext, dns)
+	tr.DialContext = dnscache.Dialer(a.dialer, dns)
 	// Disable HTTP2, since h2 can't do protocol switching.
 	tr.TLSClientConfig.NextProtos = []string{}
 	tr.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
@@ -159,7 +158,7 @@ func (a *dialParams) tryURL(u *url.URL, init []byte) (net.Conn, error) {
 		tr.TLSClientConfig.InsecureSkipVerify = true
 		tr.TLSClientConfig.VerifyConnection = nil
 	}
-	tr.DialTLSContext = dnscache.TLSDialer(dialer.DialContext, dns, tr.TLSClientConfig)
+	tr.DialTLSContext = dnscache.TLSDialer(a.dialer, dns, tr.TLSClientConfig)
 	tr.DisableCompression = true
 
 	// (mis)use httptrace to extract the underlying net.Conn from the

--- a/control/controlhttp/http_test.go
+++ b/control/controlhttp/http_test.go
@@ -20,6 +20,7 @@ import (
 
 	"tailscale.com/control/controlbase"
 	"tailscale.com/net/socks5"
+	"tailscale.com/net/tsdial"
 	"tailscale.com/types/key"
 )
 
@@ -155,6 +156,7 @@ func testControlHTTP(t *testing.T, proxy proxy) {
 		controlKey:  server.Public(),
 		version:     testProtocolVersion,
 		insecureTLS: true,
+		dialer:      new(tsdial.Dialer).SystemDial,
 	}
 
 	if proxy != nil {

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1036,6 +1036,7 @@ func (b *LocalBackend) Start(opts ipn.Options) error {
 		LinkMonitor:          b.e.GetLinkMonitor(),
 		Pinger:               b.e,
 		PopBrowserURL:        b.tellClientToBrowseToURL,
+		Dialer:               b.Dialer(),
 
 		// Don't warn about broken Linux IP forwarding when
 		// netstack is being used.

--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -105,6 +105,7 @@ func (s *Server) Close() error {
 	s.shutdownCancel()
 	s.lb.Shutdown()
 	s.linkMon.Close()
+	s.dialer.Close()
 	s.localAPIListener.Close()
 
 	s.mu.Lock()


### PR DESCRIPTION
The connections returned from SystemDial are automatically closed when
there is a major link change.

Also plumb through the dialer to the noise client so that connections
are auto-reset when moving from cellular to WiFi etc.

Updates #3363

Signed-off-by: Maisem Ali <maisem@tailscale.com>