### PR TITLE
Fix shellcheck errors in k8s script

### DIFF
--- a/docs/k8s/run.sh
+++ b/docs/k8s/run.sh
@@ -4,7 +4,7 @@
 
 #! /bin/sh
 
-export PATH=$PATH:/tailscale/bin
+export PATH="$PATH:/tailscale/bin"
 
 AUTH_KEY="${AUTH_KEY:-}"
 ROUTES="${ROUTES:-}"
@@ -17,41 +17,41 @@ set -e
 
 TAILSCALED_ARGS="--state=kube:${KUBE_SECRET} --socket=/tmp/tailscaled.sock"
 
-if [[ "${USERSPACE}" == "true" ]]; then
-  if [[ ! -z "${DEST_IP}" ]]; then
+if [ "${USERSPACE}" = "true" ]; then
+  if [ -n "${DEST_IP}" ]; then
     echo "IP forwarding is not supported in userspace mode"
     exit 1
   fi
   TAILSCALED_ARGS="${TAILSCALED_ARGS} --tun=userspace-networking"
 else
-  if [[ ! -d /dev/net ]]; then
+  if [ ! -d /dev/net ]; then
     mkdir -p /dev/net
   fi
 
-  if [[ ! -c /dev/net/tun ]]; then
+  if [ ! -c /dev/net/tun ]; then
     mknod /dev/net/tun c 10 200
   fi
 fi
 
 echo "Starting tailscaled"
-tailscaled ${TAILSCALED_ARGS} &
+eval "tailscaled ${TAILSCALED_ARGS}" &
 PID=$!
 
 UP_ARGS="--accept-dns=false"
-if [[ ! -z "${ROUTES}" ]]; then
+if [ -n "${ROUTES}" ]; then
   UP_ARGS="--advertise-routes=${ROUTES} ${UP_ARGS}"
 fi
-if [[ ! -z "${AUTH_KEY}" ]]; then
+if [ -n "${AUTH_KEY}" ]; then
   UP_ARGS="--authkey=${AUTH_KEY} ${UP_ARGS}"
 fi
-if [[ ! -z "${EXTRA_ARGS}" ]]; then
+if [ -n "${EXTRA_ARGS}" ]; then
   UP_ARGS="${UP_ARGS} ${EXTRA_ARGS:-}"
 fi
 
 echo "Running tailscale up"
-tailscale --socket=/tmp/tailscaled.sock up ${UP_ARGS}
+eval "tailscale --socket=/tmp/tailscaled.sock up ${UP_ARGS}"
 
-if [[ ! -z "${DEST_IP}" ]]; then
+if [ -n "${DEST_IP}" ]; then
   echo "Adding iptables rule for DNAT"
   iptables -t nat -I PREROUTING -d "$(tailscale --socket=/tmp/tailscaled.sock ip -4)" -j DNAT --to-destination "${DEST_IP}"
 fi


### PR DESCRIPTION
Fixed all the warnings generated by spellcheck ([SC3010](https://github.com/koalaman/shellcheck/wiki/SC3010), [SC3014](https://github.com/koalaman/shellcheck/wiki/SC3014), [SC2236](https://github.com/koalaman/shellcheck/wiki/SC2236), [SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086)).

Signed-off-by: Pavel Popov <popoffpavel@yandex.ru>