### PR TITLE
net/tshttpproxy: use http as the scheme for proxies

### DIFF
--- a/net/tshttpproxy/tshttpproxy_synology.go
+++ b/net/tshttpproxy/tshttpproxy_synology.go
@@ -96,15 +96,15 @@ func parseSynologyConfig(r io.Reader) (*url.URL, error) {
 		return nil, nil
 	}
 
-	proxyURL := new(url.URL)
+	proxyURL := &url.URL{
+		Scheme: "http", // regardless of proxy type
+	}
 	if cfg["auth_enabled"] == "yes" {
 		proxyURL.User = url.UserPassword(cfg["proxy_user"], cfg["proxy_pwd"])
 	}
 
-	proxyURL.Scheme = "https"
 	host, port := cfg["https_host"], cfg["https_port"]
 	if host == "" {
-		proxyURL.Scheme = "http"
 		host, port = cfg["http_host"], cfg["http_port"]
 	}
 

--- a/net/tshttpproxy/tshttpproxy_synology_test.go
+++ b/net/tshttpproxy/tshttpproxy_synology_test.go
@@ -131,7 +131,7 @@ http_port=80
 			t.Fatalf("got %s, want %s", got, want)
 		}
 
-		if got, want := proxyURL, urlMustParse("https://foo:bar@10.0.0.66:8443"); got.String() != want.String() {
+		if got, want := proxyURL, urlMustParse("http://foo:bar@10.0.0.66:8443"); got.String() != want.String() {
 			t.Fatalf("got %s, want %s", got, want)
 		}
 
@@ -184,7 +184,7 @@ https_port=8443
 http_host=10.0.0.55
 http_port=80
 `,
-			url: urlMustParse("https://foo:bar@10.0.0.66:8443"),
+			url: urlMustParse("http://foo:bar@10.0.0.66:8443"),
 			err: nil,
 		},
 		"no-auth": {
@@ -200,7 +200,7 @@ https_port=8443
 http_host=10.0.0.55
 http_port=80
 `,
-			url: urlMustParse("https://10.0.0.66:8443"),
+			url: urlMustParse("http://10.0.0.66:8443"),
 			err: nil,
 		},
 		"http": {
@@ -257,7 +257,7 @@ http_port=
 				}
 			}
 
-			if got, want := example.url.String(), url.String(); got != want {
+			if got, want := url.String(), example.url.String(); got != want {
 				t.Fatalf("got %s, want %s", got, want)
 			}
 		})


### PR DESCRIPTION
Currently we try to use `https://` when we see `https_host`, however
that doesn't work and results in errors like `Received error: fetch
control key: Get "https://controlplane.tailscale.com/key?v=32":
proxyconnect tcp: tls: first record does not look like a TLS handshake`

This indiciates that we are trying to do a HTTPS request to a HTTP
server. Googling suggests that the standard is to use `http` regardless
of `https` or `http` proxy

Updates #4395, #2605

Signed-off-by: Maisem Ali <maisem@tailscale.com>