### PR TITLE
Revert "api: document preauthorized auth keys"

### DIFF
--- a/api.md
+++ b/api.md
@@ -317,14 +317,9 @@ Allows for updating properties on the device key.
 - Provide `false` to enable the device's key expiry. Sets the key to expire at the original expiry time prior to disabling. The key may already have expired. In that case, the device must be re-authenticated.
 - Empty value will not change the key expiry.
 
-`preauthorized`
-
-- If `true`, don't require machine authorization (if enabled on the tailnet)
-
 ```
 {
-  "keyExpiryDisabled": true,
-  "preauthorized": true
+  "keyExpiryDisabled": true
 }
 ```
 


### PR DESCRIPTION
This reverts commit dd6472d4e87f823cb14a611a582afc25827cc46b.

Reason: it appears I was just really really wrong or confused.

We added it to the old internal API used by the website instead,
not to the "v2" API.

Updates #2120
Updates #4571