### PR TITLE
Dockerfile: narrow host's mount directory scope

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@
 #
 # To run the tailscaled agent:
 #
-#     $ docker run -d --name=tailscaled -v /var/lib:/var/lib -v /dev/net/tun:/dev/net/tun --network=host --privileged tailscale/tailscale tailscaled
+#     $ docker run -d --name=tailscaled -v /var/lib/tailscale/:/var/lib/tailscale/ -v /dev/net/tun:/dev/net/tun --network=host --privileged tailscale/tailscale tailscaled
 #
 # To then log in:
 #


### PR DESCRIPTION
Recommend a narrowly defined directory access scope to confine tailscale container, for security reasons.