### PR TITLE
client/tailscale: move/copy all package funcs to new LocalClient type

### DIFF
--- a/cmd/tailscale/cli/bugreport.go
+++ b/cmd/tailscale/cli/bugreport.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
-	"tailscale.com/client/tailscale"
 )
 
 var bugReportCmd = &ffcli.Command{
@@ -28,7 +27,7 @@ func runBugReport(ctx context.Context, args []string) error {
 	default:
 		return errors.New("unknown argumets")
 	}
-	logMarker, err := tailscale.BugReport(ctx, note)
+	logMarker, err := localClient.BugReport(ctx, note)
 	if err != nil {
 		return err
 	}

--- a/cmd/tailscale/cli/cert.go
+++ b/cmd/tailscale/cli/cert.go
@@ -50,7 +50,7 @@ func runCert(ctx context.Context, args []string) error {
 			},
 			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.TLS != nil && !strings.Contains(r.Host, ".") && r.Method == "GET" {
-					if v, ok := tailscale.ExpandSNIName(r.Context(), r.Host); ok {
+					if v, ok := localClient.ExpandSNIName(r.Context(), r.Host); ok {
 						http.Redirect(w, r, "https://"+v+r.URL.Path, http.StatusTemporaryRedirect)
 						return
 					}
@@ -64,7 +64,7 @@ func runCert(ctx context.Context, args []string) error {
 
 	if len(args) != 1 {
 		var hint bytes.Buffer
-		if st, err := tailscale.Status(ctx); err == nil {
+		if st, err := localClient.Status(ctx); err == nil {
 			if st.BackendState != ipn.Running.String() {
 				fmt.Fprintf(&hint, "\nTailscale is not running.\n")
 			} else if len(st.CertDomains) == 0 {

--- a/cmd/tailscale/cli/cli.go
+++ b/cmd/tailscale/cli/cli.go
@@ -125,6 +125,8 @@ func CleanUpArgs(args []string) []string {
 	return out
 }
 
+var localClient tailscale.LocalClient
+
 // Run runs the CLI. The args do not include the binary name.
 func Run(args []string) (err error) {
 	if len(args) == 1 && (args[0] == "-V" || args[0] == "--version") {
@@ -193,10 +195,10 @@ change in the future.
 		return err
 	}
 
-	tailscale.TailscaledSocket = rootArgs.socket
+	localClient.Socket = rootArgs.socket
 	rootfs.Visit(func(f *flag.Flag) {
 		if f.Name == "socket" {
-			tailscale.TailscaledSocketSetExplicitly = true
+			localClient.UseSocketOnly = true
 		}
 	})
 

--- a/cmd/tailscale/cli/down.go
+++ b/cmd/tailscale/cli/down.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
-	"tailscale.com/client/tailscale"
 	"tailscale.com/ipn"
 )
 
@@ -26,7 +25,7 @@ func runDown(ctx context.Context, args []string) error {
 		return fmt.Errorf("too many non-flag arguments: %q", args)
 	}
 
-	st, err := tailscale.Status(ctx)
+	st, err := localClient.Status(ctx)
 	if err != nil {
 		return fmt.Errorf("error fetching current status: %w", err)
 	}
@@ -34,7 +33,7 @@ func runDown(ctx context.Context, args []string) error {
 		fmt.Fprintf(Stderr, "Tailscale was already stopped.\n")
 		return nil
 	}
-	_, err = tailscale.EditPrefs(ctx, &ipn.MaskedPrefs{
+	_, err = localClient.EditPrefs(ctx, &ipn.MaskedPrefs{
 		Prefs: ipn.Prefs{
 			WantRunning: false,
 		},

--- a/cmd/tailscale/cli/id-token.go
+++ b/cmd/tailscale/cli/id-token.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
-	"tailscale.com/client/tailscale"
 )
 
 var idTokenCmd = &ffcli.Command{
@@ -25,7 +24,7 @@ func runIDToken(ctx context.Context, args []string) error {
 		return errors.New("usage: id-token <aud>")
 	}
 
-	tr, err := tailscale.IDToken(ctx, args[0])
+	tr, err := localClient.IDToken(ctx, args[0])
 	if err != nil {
 		return err
 	}

--- a/cmd/tailscale/cli/ip.go
+++ b/cmd/tailscale/cli/ip.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"inet.af/netaddr"
-	"tailscale.com/client/tailscale"
 	"tailscale.com/ipn/ipnstate"
 )
 
@@ -59,7 +58,7 @@ func runIP(ctx context.Context, args []string) error {
 	if !v4 && !v6 {
 		v4, v6 = true, true
 	}
-	st, err := tailscale.Status(ctx)
+	st, err := localClient.Status(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/tailscale/cli/logout.go
+++ b/cmd/tailscale/cli/logout.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
-	"tailscale.com/client/tailscale"
 )
 
 var logoutCmd = &ffcli.Command{
@@ -30,5 +29,5 @@ func runLogout(ctx context.Context, args []string) error {
 	if len(args) > 0 {
 		return fmt.Errorf("too many non-flag arguments: %q", args)
 	}
-	return tailscale.Logout(ctx)
+	return localClient.Logout(ctx)
 }

--- a/cmd/tailscale/cli/nc.go
+++ b/cmd/tailscale/cli/nc.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
-	"tailscale.com/client/tailscale"
 )
 
 var ncCmd = &ffcli.Command{
@@ -24,7 +23,7 @@ var ncCmd = &ffcli.Command{
 }
 
 func runNC(ctx context.Context, args []string) error {
-	st, err := tailscale.Status(ctx)
+	st, err := localClient.Status(ctx)
 	if err != nil {
 		return fixTailscaledConnectError(err)
 	}
@@ -45,7 +44,7 @@ func runNC(ctx context.Context, args []string) error {
 	}
 
 	// TODO(bradfitz): also add UDP too, via flag?
-	c, err := tailscale.DialTCP(ctx, hostOrIP, uint16(port))
+	c, err := localClient.DialTCP(ctx, hostOrIP, uint16(port))
 	if err != nil {
 		return fmt.Errorf("Dial(%q, %v): %w", hostOrIP, port, err)
 	}

--- a/cmd/tailscale/cli/netcheck.go
+++ b/cmd/tailscale/cli/netcheck.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
-	"tailscale.com/client/tailscale"
 	"tailscale.com/envknob"
 	"tailscale.com/ipn"
 	"tailscale.com/net/netcheck"
@@ -63,7 +62,7 @@ func runNetcheck(ctx context.Context, args []string) error {
 		fmt.Fprintln(Stderr, "# Warning: this JSON format is not yet considered a stable interface")
 	}
 
-	dm, err := tailscale.CurrentDERPMap(ctx)
+	dm, err := localClient.CurrentDERPMap(ctx)
 	noRegions := dm != nil && len(dm.Regions) == 0
 	if noRegions {
 		log.Printf("No DERP map from tailscaled; using default.")

--- a/cmd/tailscale/cli/ping.go
+++ b/cmd/tailscale/cli/ping.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
-	"tailscale.com/client/tailscale"
 	"tailscale.com/ipn"
 	"tailscale.com/ipn/ipnstate"
 )
@@ -65,7 +64,7 @@ var pingArgs struct {
 }
 
 func runPing(ctx context.Context, args []string) error {
-	st, err := tailscale.Status(ctx)
+	st, err := localClient.Status(ctx)
 	if err != nil {
 		return fixTailscaledConnectError(err)
 	}
@@ -173,7 +172,7 @@ func tailscaleIPFromArg(ctx context.Context, hostOrIP string) (ip string, self b
 	}
 
 	// Otherwise, try to resolve it first from the network peer list.
-	st, err := tailscale.Status(ctx)
+	st, err := localClient.Status(ctx)
 	if err != nil {
 		return "", false, err
 	}

--- a/cmd/tailscale/cli/ssh.go
+++ b/cmd/tailscale/cli/ssh.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"inet.af/netaddr"
-	"tailscale.com/client/tailscale"
 	"tailscale.com/envknob"
 	"tailscale.com/ipn/ipnstate"
 )
@@ -47,7 +46,7 @@ func runSSH(ctx context.Context, args []string) error {
 		username = lu.Username
 	}
 
-	st, err := tailscale.Status(ctx)
+	st, err := localClient.Status(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/tailscale/cli/status.go
+++ b/cmd/tailscale/cli/status.go
@@ -19,7 +19,6 @@ import (
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"github.com/toqueteos/webbrowser"
 	"inet.af/netaddr"
-	"tailscale.com/client/tailscale"
 	"tailscale.com/ipn"
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/net/interfaces"
@@ -73,9 +72,9 @@ func runStatus(ctx context.Context, args []string) error {
 	if len(args) > 0 {
 		return errors.New("unexpected non-flag arguments to 'tailscale status'")
 	}
-	getStatus := tailscale.Status
+	getStatus := localClient.Status
 	if !statusArgs.peers {
-		getStatus = tailscale.StatusWithoutPeers
+		getStatus = localClient.StatusWithoutPeers
 	}
 	st, err := getStatus(ctx)
 	if err != nil {
@@ -115,7 +114,7 @@ func runStatus(ctx context.Context, args []string) error {
 				http.NotFound(w, r)
 				return
 			}
-			st, err := tailscale.Status(ctx)
+			st, err := localClient.Status(ctx)
 			if err != nil {
 				http.Error(w, err.Error(), 500)
 				return

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -24,7 +24,6 @@ import (
 	"github.com/peterbourgon/ff/v3/ffcli"
 	qrcode "github.com/skip2/go-qrcode"
 	"inet.af/netaddr"
-	"tailscale.com/client/tailscale"
 	"tailscale.com/ipn"
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/net/tsaddr"
@@ -406,7 +405,7 @@ func runUp(ctx context.Context, args []string) error {
 		fatalf("too many non-flag arguments: %q", args)
 	}
 
-	st, err := tailscale.Status(ctx)
+	st, err := localClient.Status(ctx)
 	if err != nil {
 		return fixTailscaledConnectError(err)
 	}
@@ -447,12 +446,12 @@ func runUp(ctx context.Context, args []string) error {
 	}
 
 	if len(prefs.AdvertiseRoutes) > 0 {
-		if err := tailscale.CheckIPForwarding(context.Background()); err != nil {
+		if err := localClient.CheckIPForwarding(context.Background()); err != nil {
 			warnf("%v", err)
 		}
 	}
 
-	curPrefs, err := tailscale.GetPrefs(ctx)
+	curPrefs, err := localClient.GetPrefs(ctx)
 	if err != nil {
 		return err
 	}
@@ -471,7 +470,7 @@ func runUp(ctx context.Context, args []string) error {
 		fatalf("%s", err)
 	}
 	if justEditMP != nil {
-		_, err := tailscale.EditPrefs(ctx, justEditMP)
+		_, err := localClient.EditPrefs(ctx, justEditMP)
 		return err
 	}
 
@@ -582,7 +581,7 @@ func runUp(ctx context.Context, args []string) error {
 	// Special case: bare "tailscale up" means to just start
 	// running, if there's ever been a login.
 	if simpleUp {
-		_, err := tailscale.EditPrefs(ctx, &ipn.MaskedPrefs{
+		_, err := localClient.EditPrefs(ctx, &ipn.MaskedPrefs{
 			Prefs: ipn.Prefs{
 				WantRunning: true,
 			},
@@ -592,7 +591,7 @@ func runUp(ctx context.Context, args []string) error {
 			return err
 		}
 	} else {
-		if err := tailscale.CheckPrefs(ctx, prefs); err != nil {
+		if err := localClient.CheckPrefs(ctx, prefs); err != nil {
 			return err
 		}
 

--- a/cmd/tailscale/cli/version.go
+++ b/cmd/tailscale/cli/version.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
-	"tailscale.com/client/tailscale"
 	"tailscale.com/version"
 )
 
@@ -41,7 +40,7 @@ func runVersion(ctx context.Context, args []string) error {
 
 	printf("Client: %s\n", version.String())
 
-	st, err := tailscale.StatusWithoutPeers(ctx)
+	st, err := localClient.StatusWithoutPeers(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/tailscale/cli/web.go
+++ b/cmd/tailscale/cli/web.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"inet.af/netaddr"
-	"tailscale.com/client/tailscale"
 	"tailscale.com/ipn"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/preftype"
@@ -318,7 +317,7 @@ func webHandler(w http.ResponseWriter, r *http.Request) {
 			json.NewEncoder(w).Encode(mi{"error": err.Error()})
 			return
 		}
-		prefs, err := tailscale.GetPrefs(r.Context())
+		prefs, err := localClient.GetPrefs(r.Context())
 		if err != nil && !postData.Reauthenticate {
 			w.WriteHeader(http.StatusInternalServerError)
 			json.NewEncoder(w).Encode(mi{"error": err.Error()})
@@ -348,12 +347,12 @@ func webHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	st, err := tailscale.Status(r.Context())
+	st, err := localClient.Status(r.Context())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	prefs, err := tailscale.GetPrefs(r.Context())
+	prefs, err := localClient.GetPrefs(r.Context())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -406,7 +405,7 @@ func tailscaleUp(ctx context.Context, prefs *ipn.Prefs, forceReauth bool) (authU
 		prefs.NetfilterMode = preftype.NetfilterOff
 	}
 
-	st, err := tailscale.Status(ctx)
+	st, err := localClient.Status(ctx)
 	if err != nil {
 		return "", fmt.Errorf("can't fetch status: %v", err)
 	}


### PR DESCRIPTION
Remove all global variables, and clean up tsnet and cmd/tailscale's usage.

This is in prep for using this package for the web API too (it has the
best package name).
