### PR TITLE
util/codegen: format generated code with goimports, not gofmt

### DIFF
--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -8,12 +8,13 @@
 package tailcfg
 
 import (
+	"time"
+
 	"inet.af/netaddr"
 	"tailscale.com/types/dnstype"
 	"tailscale.com/types/key"
 	"tailscale.com/types/opt"
 	"tailscale.com/types/structs"
-	"time"
 )
 
 // Clone makes a deep copy of User.

--- a/util/codegen/codegen.go
+++ b/util/codegen/codegen.go
@@ -9,12 +9,12 @@ import (
 	"bytes"
 	"fmt"
 	"go/ast"
-	"go/format"
 	"go/token"
 	"go/types"
 	"os"
 
 	"golang.org/x/tools/go/packages"
+	"golang.org/x/tools/imports"
 )
 
 // WriteFormatted writes code to path.
@@ -29,7 +29,12 @@ import (
 // It is also easier to interpret gofmt errors
 // with an editor providing file and line numbers.
 func WriteFormatted(code []byte, path string) error {
-	out, fmterr := format.Source(code)
+	out, fmterr := imports.Process(path, code, &imports.Options{
+		Comments:   true,
+		TabIndent:  true,
+		TabWidth:   8,
+		FormatOnly: true, // fancy gofmt only
+	})
 	if fmterr != nil {
 		out = code
 	}


### PR DESCRIPTION
goimports is a superset of gofmt that also groups imports.
(the goimports tool also adds/removes imports as needed, but that
part is disabled here)
