### PR TITLE
ipn: remove enforceDefaults option from PrefsFromBytes

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1617,7 +1617,7 @@ func (b *LocalBackend) loadStateLocked(key ipn.StateKey, prefs *ipn.Prefs) (err 
 	case err != nil:
 		return fmt.Errorf("backend prefs: store.ReadState(%q): %v", key, err)
 	}
-	b.prefs, err = ipn.PrefsFromBytes(bs, false)
+	b.prefs, err = ipn.PrefsFromBytes(bs)
 	if err != nil {
 		b.logf("using backend prefs for %q", key)
 		return fmt.Errorf("PrefsFromBytes: %v", err)

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -584,10 +584,8 @@ func (p *Prefs) SetExitNodeIP(s string, st *ipnstate.Status) error {
 	return err
 }
 
-// PrefsFromBytes deserializes Prefs from a JSON blob. If
-// enforceDefaults is true, Prefs.RouteAll and Prefs.AllowSingleHosts
-// are forced on.
-func PrefsFromBytes(b []byte, enforceDefaults bool) (*Prefs, error) {
+// PrefsFromBytes deserializes Prefs from a JSON blob.
+func PrefsFromBytes(b []byte) (*Prefs, error) {
 	p := NewPrefs()
 	if len(b) == 0 {
 		return p, nil
@@ -602,10 +600,6 @@ func PrefsFromBytes(b []byte, enforceDefaults bool) (*Prefs, error) {
 		if err != nil {
 			log.Printf("Prefs parse: %v: %v\n", err, b)
 		}
-	}
-	if enforceDefaults {
-		p.RouteAll = true
-		p.AllowSingleHosts = true
 	}
 	return p, err
 }
@@ -625,7 +619,7 @@ func LoadPrefs(filename string) (*Prefs, error) {
 		// to log in again. (better than crashing)
 		return nil, os.ErrNotExist
 	}
-	p, err := PrefsFromBytes(data, false)
+	p, err := PrefsFromBytes(data)
 	if err != nil {
 		return nil, fmt.Errorf("LoadPrefs(%q) decode: %w", filename, err)
 	}

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -302,7 +302,7 @@ func checkPrefs(t *testing.T, p Prefs) {
 	if p.Equals(p2) {
 		t.Fatalf("p == p2\n")
 	}
-	p2b, err = PrefsFromBytes(p2.ToBytes(), false)
+	p2b, err = PrefsFromBytes(p2.ToBytes())
 	if err != nil {
 		t.Fatalf("PrefsFromBytes(p2) failed\n")
 	}


### PR DESCRIPTION
The Mac client was using it, but it had the effect of the `RouteAll`
("Use Tailscale subnets") pref always being enabled at startup,
regardless of the persisted value.

enforceDefaults was added to handle cases from ~2 years ago where
we ended up with persisted `"RouteAll": false` values in the keychain,
but that should no longer be a concern. New users will get the default
of it being enabled via `NewPrefs`.

There will be a corresponding Mac client change to stop passing in
enforceDefaults.

For #3962

Signed-off-by: Mihai Parparita <mihai@tailscale.com>