### PR TITLE
ipn: remove FakeExpireAfter Backend function

### DIFF
--- a/ipn/backend.go
+++ b/ipn/backend.go
@@ -245,11 +245,6 @@ type Backend interface {
 	// counts. Connection events are emitted automatically without
 	// polling.
 	RequestEngineStatus()
-	// FakeExpireAfter pretends that the current key is going to
-	// expire after duration x. This is useful for testing GUIs to
-	// make sure they react properly with keys that are going to
-	// expire.
-	FakeExpireAfter(x time.Duration)
 	// Ping attempts to start connecting to the given IP and sends a Notify
 	// with its PingResult. If the host is down, there might never
 	// be a PingResult sent. The cmd/tailscale CLI client adds a timeout.

--- a/ipn/fake_test.go
+++ b/ipn/fake_test.go
@@ -5,8 +5,6 @@
 package ipn
 
 import (
-	"time"
-
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/netmap"
@@ -99,12 +97,6 @@ func (b *FakeBackend) SetPrefs(new *Prefs) {
 func (b *FakeBackend) RequestEngineStatus() {
 	if b.notify != nil {
 		b.notify(Notify{Engine: &EngineStatus{}})
-	}
-}
-
-func (b *FakeBackend) FakeExpireAfter(x time.Duration) {
-	if b.notify != nil {
-		b.notify(Notify{NetMap: &netmap.NetworkMap{}})
 	}
 }
 

--- a/ipn/handle.go
+++ b/ipn/handle.go
@@ -174,7 +174,3 @@ func (h *Handle) Logout() {
 func (h *Handle) RequestEngineStatus() {
 	h.b.RequestEngineStatus()
 }
-
-func (h *Handle) FakeExpireAfter(x time.Duration) {
-	h.b.FakeExpireAfter(x)
-}

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1699,28 +1699,6 @@ func (b *LocalBackend) StartLoginInteractive() {
 	}
 }
 
-// FakeExpireAfter implements Backend.
-func (b *LocalBackend) FakeExpireAfter(x time.Duration) {
-	b.logf("FakeExpireAfter: %v", x)
-
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	if b.netMap == nil {
-		return
-	}
-
-	// This function is called very rarely,
-	// so we prefer to fully copy the netmap over introducing in-place modification here.
-	mapCopy := *b.netMap
-	e := mapCopy.Expiry
-	if e.IsZero() || time.Until(e) > x {
-		mapCopy.Expiry = time.Now().Add(x)
-	}
-	b.setNetMapLocked(&mapCopy)
-	b.send(ipn.Notify{NetMap: b.netMap})
-}
-
 func (b *LocalBackend) Ping(ipStr string, useTSMP bool) {
 	ip, err := netaddr.ParseIP(ipStr)
 	if err != nil {

--- a/ipn/message.go
+++ b/ipn/message.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"time"
 
 	"tailscale.com/envknob"
 	"tailscale.com/tailcfg"
@@ -52,10 +51,6 @@ type SetPrefsArgs struct {
 	New *Prefs
 }
 
-type FakeExpireAfterArgs struct {
-	Duration time.Duration
-}
-
 type PingArgs struct {
 	IP      string
 	UseTSMP bool
@@ -83,7 +78,6 @@ type Command struct {
 	SetPrefs              *SetPrefsArgs
 	RequestEngineStatus   *NoArgs
 	RequestStatus         *NoArgs
-	FakeExpireAfter       *FakeExpireAfterArgs
 	Ping                  *PingArgs
 }
 
@@ -205,9 +199,6 @@ func (bs *BackendServer) GotCommand(ctx context.Context, cmd *Command) error {
 	} else if c := cmd.SetPrefs; c != nil {
 		bs.b.SetPrefs(c.New)
 		return nil
-	} else if c := cmd.FakeExpireAfter; c != nil {
-		bs.b.FakeExpireAfter(c.Duration)
-		return nil
 	}
 	return fmt.Errorf("BackendServer.Do: no command specified")
 }
@@ -318,10 +309,6 @@ func (bc *BackendClient) RequestEngineStatus() {
 
 func (bc *BackendClient) RequestStatus() {
 	bc.send(Command{AllowVersionSkew: true, RequestStatus: &NoArgs{}})
-}
-
-func (bc *BackendClient) FakeExpireAfter(x time.Duration) {
-	bc.send(Command{FakeExpireAfter: &FakeExpireAfterArgs{Duration: x}})
 }
 
 func (bc *BackendClient) Ping(ip string, useTSMP bool) {


### PR DESCRIPTION
No callers remain (last one was removed with
tailscale/corp@1c095ae08fcc21362db65035a117672a71b4a081), and it's
pretty esoteric.

Signed-off-by: Mihai Parparita <mihai@tailscale.com>