### PR TITLE
ssh/tailssh,ipn/ipnlocal: terminate any active sessions on `up --ssh=false`

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1934,6 +1934,10 @@ func (b *LocalBackend) setPrefsLockedOnEntry(caller string, newp *ipn.Prefs) {
 		b.authReconfig()
 	}
 
+	if oldp.RunSSH && !newp.RunSSH && b.sshServer != nil {
+		go b.sshServer.OnPolicyChange()
+	}
+
 	b.send(ipn.Notify{Prefs: newp})
 }
 

--- a/ssh/tailssh/tailssh.go
+++ b/ssh/tailssh/tailssh.go
@@ -307,6 +307,9 @@ func (c *conn) havePubKeyPolicy(ci *sshConnInfo) bool {
 // if one is defined.
 func (c *conn) sshPolicy() (_ *tailcfg.SSHPolicy, ok bool) {
 	lb := c.srv.lb
+	if !lb.ShouldRunSSH() {
+		return nil, false
+	}
 	nm := lb.NetMap()
 	if nm == nil {
 		return nil, false


### PR DESCRIPTION
Currently the ssh session isn't terminated cleanly, instead the packets
are just are no longer routed to the in-proc SSH server. This makes it
so that clients get a disconnection when the `RunSSH` pref changes to
`false`.

Updates #3802

Signed-off-by: Maisem Ali <maisem@tailscale.com>