### PR TITLE
control/controlclient: store netinfo and hostinfo separately

### DIFF
--- a/control/controlclient/auto.go
+++ b/control/controlclient/auto.go
@@ -61,10 +61,9 @@ type Auto struct {
 	loggedIn        bool       // true if currently logged in
 	loginGoal       *LoginGoal // non-nil if some login activity is desired
 	synced          bool       // true if our netmap is up-to-date
-	hostinfo        *tailcfg.Hostinfo
-	inPollNetMap    bool // true if currently running a PollNetMap
-	inLiteMapUpdate bool // true if a lite (non-streaming) map request is outstanding
-	inSendStatus    int  // number of sendStatus calls currently in progress
+	inPollNetMap    bool       // true if currently running a PollNetMap
+	inLiteMapUpdate bool       // true if a lite (non-streaming) map request is outstanding
+	inSendStatus    int        // number of sendStatus calls currently in progress
 	state           State
 
 	authCtx    context.Context // context used for auth requests
@@ -555,9 +554,8 @@ func (c *Auto) SetNetInfo(ni *tailcfg.NetInfo) {
 	if !c.direct.SetNetInfo(ni) {
 		return
 	}
-	c.logf("NetInfo: %v", ni)
 
-	// Send new Hostinfo (which includes NetInfo) to server
+	// Send new NetInfo to server
 	c.sendNewMapRequest()
 }
 
@@ -567,7 +565,6 @@ func (c *Auto) sendStatus(who string, err error, url string, nm *netmap.NetworkM
 	loggedIn := c.loggedIn
 	synced := c.synced
 	statusFunc := c.statusFunc
-	hi := c.hostinfo
 	c.inSendStatus++
 	c.mu.Unlock()
 
@@ -595,7 +592,6 @@ func (c *Auto) sendStatus(who string, err error, url string, nm *netmap.NetworkM
 		URL:            url,
 		Persist:        p,
 		NetMap:         nm,
-		Hostinfo:       hi,
 		State:          state,
 		Err:            err,
 	}

--- a/control/controlclient/controlclient_test.go
+++ b/control/controlclient/controlclient_test.go
@@ -22,7 +22,7 @@ func fieldsOf(t reflect.Type) (fields []string) {
 
 func TestStatusEqual(t *testing.T) {
 	// Verify that the Equal method stays in sync with reality
-	equalHandles := []string{"LoginFinished", "LogoutFinished", "Err", "URL", "NetMap", "State", "Persist", "Hostinfo"}
+	equalHandles := []string{"LoginFinished", "LogoutFinished", "Err", "URL", "NetMap", "State", "Persist"}
 	if have := fieldsOf(reflect.TypeOf(Status{})); !reflect.DeepEqual(have, equalHandles) {
 		t.Errorf("Status.Equal check might be out of sync\nfields: %q\nhandled: %q\n",
 			have, equalHandles)

--- a/control/controlclient/status.go
+++ b/control/controlclient/status.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"tailscale.com/tailcfg"
 	"tailscale.com/types/empty"
 	"tailscale.com/types/netmap"
 	"tailscale.com/types/persist"
@@ -75,9 +74,8 @@ type Status struct {
 	// package, but we have some automated tests elsewhere that need to
 	// use them. Please don't use these fields.
 	// TODO(apenwarr): Unexport or remove these.
-	State    State
-	Persist  *persist.Persist  // locally persisted configuration
-	Hostinfo *tailcfg.Hostinfo // current Hostinfo data
+	State   State
+	Persist *persist.Persist // locally persisted configuration
 }
 
 // Equal reports whether s and s2 are equal.
@@ -92,7 +90,6 @@ func (s *Status) Equal(s2 *Status) bool {
 		s.URL == s2.URL &&
 		reflect.DeepEqual(s.Persist, s2.Persist) &&
 		reflect.DeepEqual(s.NetMap, s2.NetMap) &&
-		reflect.DeepEqual(s.Hostinfo, s2.Hostinfo) &&
 		s.State == s2.State
 }
 

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -935,8 +935,7 @@ func (b *LocalBackend) Start(opts ipn.Options) error {
 	httpTestClient := b.httpTestClient
 
 	if b.hostinfo != nil {
-		hostinfo.Services = b.hostinfo.Services // keep any previous session and netinfo
-		hostinfo.NetInfo = b.hostinfo.NetInfo
+		hostinfo.Services = b.hostinfo.Services // keep any previous services
 	}
 	b.hostinfo = hostinfo
 	b.state = ipn.NoState
@@ -2870,9 +2869,6 @@ func (b *LocalBackend) assertClientLocked() {
 func (b *LocalBackend) setNetInfo(ni *tailcfg.NetInfo) {
 	b.mu.Lock()
 	cc := b.cc
-	if b.hostinfo != nil {
-		b.hostinfo.NetInfo = ni.Clone()
-	}
 	b.mu.Unlock()
 
 	if cc == nil {


### PR DESCRIPTION
Currently, when SetNetInfo is called it sets the value on
hostinfo.NetInfo. However, when SetHostInfo is called it overrides all
of the hostinfo object which may race with SetNetInfo.
Instead of trying to solve that race, store NetInfo separately and combine when needed.

Updates #tailscale/corp#4824 (maybe fixes)

Signed-off-by: Maisem Ali <maisem@tailscale.com>