### PR TITLE
words: after a Series of discussions, Bees should be included

### DIFF
--- a/words/scales.txt
+++ b/words/scales.txt
@@ -154,3 +154,4 @@ tet
 tone
 tritone
 yo
+bee

--- a/words/tails.txt
+++ b/words/tails.txt
@@ -212,3 +212,4 @@ siren
 mudpuppy
 ferret
 roborovski
+bee


### PR DESCRIPTION
There has been a lot of talk about Bees at Tailscale recently, and
naturally, with it being Tailscale, we thought to ourselves:

Do Bees have a tail and/or scales?

Tailscale has a long track record of [scientific](https://github.com/tailscale/tailscale/pull/3777) [rigor](https://github.com/tailscale/tailscale/pull/3778) around the
validity of the inclusions on the tails and scales list, and this time
will be no exception.

Our research has found that Bees, in particular the Honey Bee, produces
[wax scales](https://bee-health.extension.org/abdomen-of-the-honey-bee/#Wax_Scales) on their abdomens and thus should be included. As for tails;

'Stabby-tails' - Tailscale Employee, 2022

No further justification needed, it will be included.

This change includes Bee in both tails.txt and scales.txt.

Signed-off-by: Charlotte Brandhorst-Satzkorn <charlotte@tailscale.com>