### PR TITLE
WireGuard

### DIFF
--- a/cmd/tailscale/cli/ping.go
+++ b/cmd/tailscale/cli/ping.go
@@ -49,8 +49,8 @@ relay node.
 		fs := newFlagSet("ping")
 		fs.BoolVar(&pingArgs.verbose, "verbose", false, "verbose output")
 		fs.BoolVar(&pingArgs.untilDirect, "until-direct", true, "stop once a direct path is established")
-		fs.BoolVar(&pingArgs.tsmp, "tsmp", false, "do a TSMP-level ping (through wireguard, but not either host OS stack)")
-		fs.BoolVar(&pingArgs.icmp, "icmp", false, "do a ICMP-level ping (through wireguard, but not the local host OS stack)")
+		fs.BoolVar(&pingArgs.tsmp, "tsmp", false, "do a TSMP-level ping (through WireGuard, but not either host OS stack)")
+		fs.BoolVar(&pingArgs.icmp, "icmp", false, "do a ICMP-level ping (through WireGuard, but not the local host OS stack)")
 		fs.IntVar(&pingArgs.num, "c", 10, "max number of pings to send")
 		fs.DurationVar(&pingArgs.timeout, "timeout", 5*time.Second, "timeout before giving up on a ping")
 		return fs

--- a/derp/derp_client.go
+++ b/derp/derp_client.go
@@ -485,7 +485,7 @@ func (c *Client) recvTimeout(timeout time.Duration) (m ReceivedMessage, err erro
 			c.peeked = int(n)
 		} else {
 			// But if for some reason we read a large DERP message (which isn't necessarily
-			// a Wireguard packet), then just allocate memory for it.
+			// a WireGuard packet), then just allocate memory for it.
 			// TODO(bradfitz): use a pool if large frames ever happen in practice.
 			b = make([]byte, n)
 			_, err = io.ReadFull(c.br, b)

--- a/net/packet/tsmp.go
+++ b/net/packet/tsmp.go
@@ -5,7 +5,7 @@
 // TSMP is our ICMP-like "Tailscale Message Protocol" for signaling
 // Tailscale-specific messages between nodes. It uses IP protocol 99
 // (reserved for "any private encryption scheme") within
-// Wireguard's normal encryption between peers and never hits the host
+// WireGuard's normal encryption between peers and never hits the host
 // network stack.
 
 package packet

--- a/net/tstun/wrap.go
+++ b/net/tstun/wrap.go
@@ -110,9 +110,9 @@ type Wrapper struct {
 	// inbound packets arrive via UDP and are written into the TUN device;
 	// outbound packets are read from the TUN device and sent out via UDP.
 	// This queue is needed because although inbound writes are synchronous,
-	// the other direction must wait on a Wireguard goroutine to poll it.
+	// the other direction must wait on a WireGuard goroutine to poll it.
 	//
-	// Empty reads are skipped by Wireguard, so it is always legal
+	// Empty reads are skipped by WireGuard, so it is always legal
 	// to discard an empty packet instead of sending it through t.outbound.
 	//
 	// Close closes outbound. There may be outstanding sends to outbound
@@ -554,7 +554,7 @@ func (t *Wrapper) Read(buf []byte, offset int) (int, error) {
 		response := t.filterOut(p)
 		if response != filter.Accept {
 			metricPacketOutDrop.Add(1)
-			// Wireguard considers read errors fatal; pretend nothing was read
+			// WireGuard considers read errors fatal; pretend nothing was read
 			return 0, nil
 		}
 	}
@@ -713,7 +713,7 @@ func (t *Wrapper) SetFilter(filt *filter.Filter) {
 // This path is typically used to deliver synthesized packets to the
 // host networking stack.
 func (t *Wrapper) InjectInboundPacketBuffer(pkt *stack.PacketBuffer) error {
-	buf := make([]byte, PacketStartOffset + pkt.Size())
+	buf := make([]byte, PacketStartOffset+pkt.Size())
 
 	n := copy(buf[PacketStartOffset:], pkt.NetworkHeader().View())
 	n += copy(buf[PacketStartOffset+n:], pkt.TransportHeader().View())
@@ -733,7 +733,7 @@ func (t *Wrapper) InjectInboundPacketBuffer(pkt *stack.PacketBuffer) error {
 //
 // The packet contents are to start at &buf[offset].
 // offset must be greater or equal to PacketStartOffset.
-// The space before &buf[offset] will be used by Wireguard.
+// The space before &buf[offset] will be used by WireGuard.
 func (t *Wrapper) InjectInboundDirect(buf []byte, offset int) error {
 	if len(buf) > MaxPacketSize {
 		return errPacketTooBig

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -493,7 +493,7 @@ type Options struct {
 	// whenever it receives a packet from a a peer if it's been more
 	// than ~10 seconds since the last one. (10 seconds is somewhat
 	// arbitrary; the sole user just doesn't need or want it called on
-	// every packet, just every minute or two for Wireguard timeouts,
+	// every packet, just every minute or two for WireGuard timeouts,
 	// and 10 seconds seems like a good trade-off between often enough
 	// and not too often.)
 	// The provided func is likely to call back into
@@ -1864,7 +1864,7 @@ func (c *Conn) handleDiscoMessage(msg []byte, src netaddr.IPPort, derpNodeSrc ke
 	}
 
 	// If the first four parts are the prefix of disco.Magic
-	// (0x5453f09f) then it's definitely not a valid Wireguard
+	// (0x5453f09f) then it's definitely not a valid WireGuard
 	// packet (which starts with little-endian uint32 1, 2, 3, 4).
 	// Use naked returns for all following paths.
 	isDiscoMsg = true

--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -162,7 +162,7 @@ func Create(logf logger.Logf, tundev *tstun.Wrapper, e wgengine.Engine, mc *magi
 	// registered to it. Since in some cases we dynamically register IPs
 	// based on the packets that arrive, the NIC needs to accept all
 	// incoming packets. The NIC won't receive anything it isn't meant to
-	// since Wireguard will only send us packets that are meant for us.
+	// since WireGuard will only send us packets that are meant for us.
 	ipstack.SetPromiscuousMode(nicID, true)
 	// Add IPv4 and IPv6 default routes, so all incoming packets from the Tailscale side
 	// are handled by the one fake NIC we use.

--- a/wgengine/pendopen.go
+++ b/wgengine/pendopen.go
@@ -189,7 +189,7 @@ func (e *userspaceEngine) onOpenTimeout(flow flowtrack.Tuple) {
 			// node.
 			return
 		}
-		e.logf("open-conn-track: timeout opening %v; target node %v in netmap but unknown to wireguard", flow, n.Key.ShortString())
+		e.logf("open-conn-track: timeout opening %v; target node %v in netmap but unknown to WireGuard", flow, n.Key.ShortString())
 		return
 	}
 

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -77,7 +77,7 @@ const (
 	// packetSendRecheckWireguardThreshold controls how long we can go
 	// between packet sends to an IP before checking to see
 	// whether this IP address needs to be added back to the
-	// Wireguard peer oconfig.
+	// WireGuard peer oconfig.
 	packetSendRecheckWireguardThreshold = 1 * time.Minute
 )
 
@@ -221,7 +221,7 @@ type Config struct {
 }
 
 func NewFakeUserspaceEngine(logf logger.Logf, listenPort uint16) (Engine, error) {
-	logf("Starting userspace wireguard engine (with fake TUN device)")
+	logf("Starting userspace WireGuard engine (with fake TUN device)")
 	return NewUserspaceEngine(logf, Config{
 		ListenPort:    listenPort,
 		RespondToPing: true,
@@ -410,7 +410,7 @@ func NewUserspaceEngine(logf logger.Logf, conf Config) (_ Engine, reterr error) 
 	}
 
 	// wgdev takes ownership of tundev, will close it when closed.
-	e.logf("Creating wireguard device...")
+	e.logf("Creating WireGuard device...")
 	e.wgdev = wgcfg.NewDevice(e.tundev, e.magicConn.Bind(), e.wgLogger.DeviceLogger)
 	closePool.addFunc(e.wgdev.Close)
 	closePool.addFunc(func() {
@@ -435,7 +435,7 @@ func NewUserspaceEngine(logf logger.Logf, conf Config) (_ Engine, reterr error) 
 		}
 	}()
 
-	e.logf("Bringing wireguard device up...")
+	e.logf("Bringing WireGuard device up...")
 	if err := e.wgdev.Up(); err != nil {
 		return nil, fmt.Errorf("wgdev.Up: %w", err)
 	}
@@ -614,12 +614,12 @@ func (e *userspaceEngine) noteRecvActivity(nk key.NodePublic) {
 
 	// If the last activity time jumped a bunch (say, at least
 	// half the idle timeout) then see if we need to reprogram
-	// Wireguard. This could probably be just
+	// WireGuard. This could probably be just
 	// lazyPeerIdleThreshold without the divide by 2, but
 	// maybeReconfigWireguardLocked is cheap enough to call every
 	// couple minutes (just not on every packet).
 	if e.trimmedNodes[nk] {
-		e.logf("wgengine: idle peer %v now active, reconfiguring wireguard", nk.ShortString())
+		e.logf("wgengine: idle peer %v now active, reconfiguring WireGuard", nk.ShortString())
 		e.maybeReconfigWireguardLocked(nil)
 	}
 }
@@ -733,7 +733,7 @@ func (e *userspaceEngine) maybeReconfigWireguardLocked(discoChanged map[key.Node
 		}
 	}
 
-	e.logf("wgengine: Reconfig: configuring userspace wireguard config (with %d/%d peers)", len(min.Peers), len(full.Peers))
+	e.logf("wgengine: Reconfig: configuring userspace WireGuard config (with %d/%d peers)", len(min.Peers), len(full.Peers))
 	if err := wgcfg.ReconfigDevice(e.wgdev, &min, e.logf); err != nil {
 		e.logf("wgdev.Reconfig: %v", err)
 		return err

--- a/wgengine/wgcfg/nmcfg/nmcfg.go
+++ b/wgengine/wgcfg/nmcfg/nmcfg.go
@@ -49,7 +49,7 @@ func cidrIsSubnet(node *tailcfg.Node, cidr netaddr.IPPrefix) bool {
 	return true
 }
 
-// WGCfg returns the NetworkMaps's Wireguard configuration.
+// WGCfg returns the NetworkMaps's WireGuard configuration.
 func WGCfg(nm *netmap.NetworkMap, logf logger.Logf, flags netmap.WGConfigFlags, exitNode tailcfg.StableNodeID) (*wgcfg.Config, error) {
 	cfg := &wgcfg.Config{
 		Name:       "tailscale",


### PR DESCRIPTION
This updates the places where we log the noun, or have the noun incorrectly capitalized.

Lowercase docstrings are left alone for now.