### PR TITLE
util/clientmetric: add ResetLastDeltaForTest function

### DIFF
--- a/util/clientmetric/clientmetric.go
+++ b/util/clientmetric/clientmetric.go
@@ -255,6 +255,10 @@ func EncodeLogTailMetricsDelta() string {
 	return enc.buf.String()
 }
 
+func ResetLastDeltaForTest() {
+	lastDelta = time.Time{}
+}
+
 var deltaPool = &sync.Pool{
 	New: func() any {
 		return new(deltaEncBuf)


### PR DESCRIPTION
Necessary to force flushing of client metrics more aggressively in
dev/test mode.

Signed-off-by: Mihai Parparita <mihai@tailscale.com>