### PR TITLE
util/clientmetric: switch to TestHooks struct for test-only functions

### DIFF
--- a/util/clientmetric/clientmetric.go
+++ b/util/clientmetric/clientmetric.go
@@ -255,10 +255,6 @@ func EncodeLogTailMetricsDelta() string {
 	return enc.buf.String()
 }
 
-func ResetLastDeltaForTest() {
-	lastDelta = time.Time{}
-}
-
 var deltaPool = &sync.Pool{
 	New: func() any {
 		return new(deltaEncBuf)
@@ -307,4 +303,12 @@ func (b *deltaEncBuf) writeHexVarint(v int64) {
 	hexBuf := b.buf.Bytes()[oldLen : oldLen+hexLen]
 	hex.Encode(hexBuf, b.scratch[:n])
 	b.buf.Write(hexBuf)
+}
+
+var TestHooks testHooks
+
+type testHooks struct{}
+
+func (testHooks) ResetLastDelta() {
+	lastDelta = time.Time{}
 }


### PR DESCRIPTION
Followup to 7966aed1e008936ea0fad6c63bd72461cdc55648 to pick up
review feedback that was accidentally left out.

Signed-off-by: Mihai Parparita <mihai@tailscale.com>