### PR TITLE
cmd/tailscaled: let SOCKS5 listen on a unix socket

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -598,9 +598,14 @@ func mustStartProxyListeners(socksAddr, httpAddr string) (socksListener, httpLis
 
 	var err error
 	if socksAddr != "" {
-		socksListener, err = net.Listen("tcp", socksAddr)
+		socksType := "tcp"
+		if strings.HasPrefix(socksAddr, "file:") {
+			socksType = "unix"
+			socksAddr = strings.TrimPrefix(socksAddr, "file:")
+		}
+		socksListener, err = net.Listen(socksType, socksAddr)
 		if err != nil {
-			log.Fatalf("SOCKS5 listener: %v", err)
+			log.Fatalf("SOCKS5 %s listener: %v", socksType, err)
 		}
 		if strings.HasSuffix(socksAddr, ":0") {
 			// Log kernel-selected port number so integration tests


### PR DESCRIPTION
Allows userspace networking without binding a port.

Uses the same `file:` syntax [already established](https://github.com/tailscale/tailscale/blob/87b44aa311aa535f243c11ff53e32f1b4217f9c2/cmd/tailscale/cli/up.go#L153) with the `tailscale --auth-key` arg:

```
tailscaled -tun="userspace-networking" -socks5-server="file:/example/proxy.sock"
```

Ideally, this patch would also clean up the file when tailscaled exits. If that's needed for this to merge, I was hoping a maintainer could add that or provide a suggestion.

Closes #4657