### PR TITLE
net/tstun, wgengine: use correct type for counter metrics

### DIFF
--- a/net/tstun/wrap.go
+++ b/net/tstun/wrap.go
@@ -831,13 +831,13 @@ func (t *Wrapper) Unwrap() tun.Device {
 }
 
 var (
-	metricPacketIn              = clientmetric.NewGauge("tstun_in_from_wg")
-	metricPacketInDrop          = clientmetric.NewGauge("tstun_in_from_wg_drop")
-	metricPacketInDropFilter    = clientmetric.NewGauge("tstun_in_from_wg_drop_filter")
-	metricPacketInDropSelfDisco = clientmetric.NewGauge("tstun_in_from_wg_drop_self_disco")
+	metricPacketIn              = clientmetric.NewCounter("tstun_in_from_wg")
+	metricPacketInDrop          = clientmetric.NewCounter("tstun_in_from_wg_drop")
+	metricPacketInDropFilter    = clientmetric.NewCounter("tstun_in_from_wg_drop_filter")
+	metricPacketInDropSelfDisco = clientmetric.NewCounter("tstun_in_from_wg_drop_self_disco")
 
-	metricPacketOut              = clientmetric.NewGauge("tstun_out_to_wg")
-	metricPacketOutDrop          = clientmetric.NewGauge("tstun_out_to_wg_drop")
-	metricPacketOutDropFilter    = clientmetric.NewGauge("tstun_out_to_wg_drop_filter")
-	metricPacketOutDropSelfDisco = clientmetric.NewGauge("tstun_out_to_wg_drop_self_disco")
+	metricPacketOut              = clientmetric.NewCounter("tstun_out_to_wg")
+	metricPacketOutDrop          = clientmetric.NewCounter("tstun_out_to_wg_drop")
+	metricPacketOutDropFilter    = clientmetric.NewCounter("tstun_out_to_wg_drop_filter")
+	metricPacketOutDropSelfDisco = clientmetric.NewCounter("tstun_out_to_wg_drop_self_disco")
 )

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -1629,8 +1629,8 @@ func (ls fwdDNSLinkSelector) PickLink(ip netaddr.IP) (linkName string) {
 }
 
 var (
-	metricMagicDNSPacketIn = clientmetric.NewGauge("magicdns_packet_in") // for 100.100.100.100
-	metricReflectToOS      = clientmetric.NewGauge("packet_reflect_to_os")
+	metricMagicDNSPacketIn = clientmetric.NewCounter("magicdns_packet_in") // for 100.100.100.100
+	metricReflectToOS      = clientmetric.NewCounter("packet_reflect_to_os")
 
 	metricNumMajorChanges = clientmetric.NewCounter("wgengine_major_changes")
 	metricNumMinorChanges = clientmetric.NewCounter("wgengine_minor_changes")


### PR DESCRIPTION
We were marking them as gauges, but they are only ever incremented,
thus counter is more appropriate.

Signed-off-by: Mihai Parparita <mihai@tailscale.com>