### PR TITLE
ipn/ipnlocal: add missing place where we set the SSH atomic

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -955,6 +955,7 @@ func (b *LocalBackend) Start(opts ipn.Options) error {
 				b.logf("failed to save UpdatePrefs state: %v", err)
 			}
 		}
+		b.setAtomicValuesFromPrefs(b.prefs)
 	}
 
 	wantRunning := b.prefs.WantRunning


### PR DESCRIPTION
This fixes the "tailscale up --authkey=... --ssh" path which wasn't setting the bit.

Updates #3802
