### PR TITLE
scripts/installer.sh: add Xen Enterprise

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -161,6 +161,11 @@ main() {
 				VERSION="$VERSION_ID"
 				PACKAGETYPE="yum"
 				;;
+			xenenterprise)
+				OS="centos"
+				VERSION="$(echo "$VERSION_ID" | cut -f1 -d.)"
+				PACKAGETYPE="yum"
+				;;
 			opensuse-leap)
 				OS="opensuse"
 				VERSION="leap/$VERSION_ID"


### PR DESCRIPTION
https://xcp-ng.org/
Fixes https://github.com/tailscale/tailscale/issues/4655

Tested on a VM running Xen Enterprise 8.2.1

Signed-off-by: Denton Gentry <dgentry@tailscale.com>