### PR TITLE
logtail: add instance metadata to the entry logtail

### DIFF
--- a/logpolicy/logpolicy.go
+++ b/logpolicy/logpolicy.go
@@ -519,6 +519,8 @@ func New(collection string) *Policy {
 	}
 	if collection == logtail.CollectionNode {
 		c.MetricsDelta = clientmetric.EncodeLogTailMetricsDelta
+		c.IncludeProcID = true
+		c.IncludeProcSequence = true
 	}
 
 	if val := getLogTarget(); val != "" {


### PR DESCRIPTION
Allows instances that are running with the same machine ID (due to
cloning) to be distinguished.

For tailscale/corp#5244

Signed-off-by: Mihai Parparita <mihai@tailscale.com>