### PR TITLE
cmd/tailscale/cli: fix ssh CLI command breaking the Wasm build

### DIFF
--- a/cmd/tailscale/cli/ssh.go
+++ b/cmd/tailscale/cli/ssh.go
@@ -16,7 +16,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"syscall"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"inet.af/netaddr"
@@ -116,24 +115,7 @@ func runSSH(ctx context.Context, args []string) error {
 		log.Printf("Running: %q, %q ...", ssh, argv)
 	}
 
-	if runtime.GOOS == "windows" {
-		// Don't use syscall.Exec on Windows.
-		cmd := exec.Command(ssh, argv[1:]...)
-		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		var ee *exec.ExitError
-		err := cmd.Run()
-		if errors.As(err, &ee) {
-			os.Exit(ee.ExitCode())
-		}
-		return err
-	}
-
-	if err := syscall.Exec(ssh, argv, os.Environ()); err != nil {
-		return err
-	}
-	return errors.New("unreachable")
+	return execSSH(ssh, argv)
 }
 
 func writeKnownHosts(st *ipnstate.Status) (knownHostsFile string, err error) {

--- a/cmd/tailscale/cli/ssh_exec.go
+++ b/cmd/tailscale/cli/ssh_exec.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !js && !windows
+// +build !js,!windows
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+func execSSH(ssh string, argv []string) error {
+	if err := syscall.Exec(ssh, argv, os.Environ()); err != nil {
+		return err
+	}
+	return errors.New("unreachable")
+}

--- a/cmd/tailscale/cli/ssh_exec_js.go
+++ b/cmd/tailscale/cli/ssh_exec_js.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cli
+
+import (
+	"errors"
+)
+
+func execSSH(ssh string, argv []string) error {
+	return errors.New("Not implemented")
+}

--- a/cmd/tailscale/cli/ssh_exec_windows.go
+++ b/cmd/tailscale/cli/ssh_exec_windows.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+)
+
+func execSSH(ssh string, argv []string) error {
+	// Don't use syscall.Exec on Windows, it's not fully implemented.
+	cmd := exec.Command(ssh, argv[1:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	var ee *exec.ExitError
+	err := cmd.Run()
+	if errors.As(err, &ee) {
+		os.Exit(ee.ExitCode())
+	}
+	return err
+}


### PR DESCRIPTION
Adds a stub for syscall.Exec when GOOS=js. We also had a separate branch
for Windows, might as well use the same mechanism there too.

For #3157

Signed-off-by: Mihai Parparita <mihai@tailscale.com>