### PR TITLE
types/views: add package level Range

### DIFF
--- a/types/views/views.go
+++ b/types/views/views.go
@@ -298,3 +298,21 @@ func (m MapFn[K, T, V]) Range(f MapRangeFn[K, V]) {
 		}
 	}
 }
+
+type Ranger[K comparable, V any] interface {
+	Range(f MapRangeFn[K, V])
+}
+
+// Range is like Map.Range but it takes a func that breaks the range if it
+// returns an error.  It returns the error returned by f, if any.
+//
+// It is used to where errors may occur while ranging over maps and shadowing
+// errors gets tricky without it.
+func Range[R Ranger[K, V], K comparable, V any](r R, f func(k K, v V) error) error {
+	var err error
+	r.Range(func(k K, v V) bool {
+		err = f(k, v)
+		return err == nil
+	})
+	return err
+}

--- a/types/views/views_test.go
+++ b/types/views/views_test.go
@@ -7,6 +7,7 @@ package views
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -71,5 +72,24 @@ func TestViewsJSON(t *testing.T) {
 		if !reflect.DeepEqual(got, tc.in) {
 			t.Fatalf("unmarshal resulted in different output: %+v; want %+v", got, tc.in)
 		}
+	}
+}
+
+func TestRange(t *testing.T) {
+	m := MapOf(map[string]int{
+		"a":    1,
+		"boom": 2,
+		"c":    3,
+	})
+
+	want := errors.New("boom")
+	got := Range(m, func(k string, v int) error {
+		if k == "boom" {
+			return want
+		}
+		return nil
+	})
+	if got != want {
+		t.Errorf("got = %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
While using `cmd/viewer` and the `views` package (which are super nice!), I found that when errors can happen while ranging over maps, preventing err shadowing gets tricky, and the the desire to "just return an error" creeps up, so I wrote a little helper and thought it might be nice if it could have a home here since it's pretty generic.

An example of easy mistake before Range:

```
mv := views.MapOf(map[int]bool{...})

var err error
mv.Range(func(k, v string) bool {
       _, err = db.Exec(...)
       if err != nil {
           // maybe sets error to non-nil
           return false
       }
       _, err := db.Exec(...)
       if err != nil {
          // maybe sets shadowed err to non-nil, but outer err is still nil.
          return false
       }
       return true
})
if err != nil {
   // ... if the first db.Exec returns a nil error; but the second does not, this err is still nil
}
```

After:

```
err := views.Range(mv, func(k, v string) error {
      _, err := db.Exec(...)
     if err != nil {
         return err
     }
     _, err = db.Exec(...)
     return err
})
```

One could also argue it aids in clarity.

I hope this is helpful and makes it in!

Also: I'm sure my docs here could be better. Feedback there would very much be appreciated.