### PR TITLE
scripts/installer: fix elementaryOS

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -41,11 +41,16 @@ main() {
 		#  - ID: the short name of the OS (e.g. "debian", "freebsd")
 		#  - VERSION_ID: the numeric release version for the OS, if any (e.g. "18.04")
 		#  - VERSION_CODENAME: the codename of the OS release, if any (e.g. "buster")
+		#  - UBUNTU_CODENAME: if it exists, use instead of VERSION_CODENAME
 		. /etc/os-release
 		case "$ID" in
-			ubuntu|pop|neon|zorin|elementary)
+			ubuntu|pop|neon|zorin)
 				OS="ubuntu"
-				VERSION="$VERSION_CODENAME"
+				if [ "${UBUNTU_CODENAME:-}" != "" ]; then
+				    VERSION="$UBUNTU_CODENAME"
+				else
+				    VERSION="$VERSION_CODENAME"
+				fi
 				PACKAGETYPE="apt"
 				# Third-party keyrings became the preferred method of
 				# installation in Ubuntu 20.04.
@@ -80,6 +85,16 @@ main() {
 				fi
 				PACKAGETYPE="apt"
 				if [ "$VERSION_ID" -lt 5 ]; then
+					APT_KEY_TYPE="legacy"
+				else
+					APT_KEY_TYPE="keyring"
+				fi
+				;;
+			elementary)
+				OS="ubuntu"
+				VERSION="$UBUNTU_CODENAME"
+				PACKAGETYPE="apt"
+				if [ "$VERSION_ID" -lt 6 ]; then
 					APT_KEY_TYPE="legacy"
 				else
 					APT_KEY_TYPE="keyring"


### PR DESCRIPTION
c2b907c965d18eeacff3d7796f486b45f7fb662b moved UBUNTU_VERSION out
of the ubuntu case and into linuxmint, but linuxmint wasn't the
only Ubuntu-based system which needed it. Restore UBUNTU_VERSION
handling in the ubuntu case.

Break elementaryOS out into its own handling so we can get the
version number handling correct for keyring support.
Tested on an elementaryOS 6.1 VM.

Signed-off-by: Denton Gentry <dgentry@tailscale.com>