### PR TITLE
ipn/localapi: implement LoginInteractive via localapi

### DIFF
--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -109,6 +109,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.serveStatus(w, r)
 	case "/localapi/v0/logout":
 		h.serveLogout(w, r)
+	case "/localapi/v0/login-interactive":
+		h.serveLoginInteractive(w, r)
 	case "/localapi/v0/prefs":
 		h.servePrefs(w, r)
 	case "/localapi/v0/ping":
@@ -341,6 +343,20 @@ func (h *Handler) serveStatus(w http.ResponseWriter, r *http.Request) {
 	e := json.NewEncoder(w)
 	e.SetIndent("", "\t")
 	e.Encode(st)
+}
+
+func (h *Handler) serveLoginInteractive(w http.ResponseWriter, r *http.Request) {
+	if !h.PermitWrite {
+		http.Error(w, "login access denied", http.StatusForbidden)
+		return
+	}
+	if r.Method != "POST" {
+		http.Error(w, "want POST", 400)
+		return
+	}
+	h.b.StartLoginInteractive()
+	w.WriteHeader(http.StatusNoContent)
+	return
 }
 
 func (h *Handler) serveLogout(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Updates: #4738

This is the server-side change for implementing an Interactive Login via the localapi.

I noticed that the function `StartLoginInteractive()` on `LocalBackend` has no error return type, so i'll be looking to the core maintainers/reviewers if this is acceptable for localapi. I think it would be beneficial to catch errors and return 500 just like the logout api but i'm leaving that open for review.