### PR TITLE
wgengine/router: delete hardcoded link-local address on Windows

### DIFF
--- a/wgengine/router/ifconfig_windows_test.go
+++ b/wgengine/router/ifconfig_windows_test.go
@@ -164,8 +164,9 @@ func TestDeltaNets(t *testing.T) {
 			wantDel: nets("fe80::99d0:ec2d:b2e7:536b/64"),
 		},
 		{
-			a: excludeIPv6LinkLocal(nets("100.84.36.11/32", "fe80::99d0:ec2d:b2e7:536b/64")),
-			b: nets("100.84.36.11/32"),
+			a:       excludeIPv6LinkLocal(nets("100.84.36.11/32", "fe80::99d0:ec2d:b2e7:536b/64")),
+			b:       nets("100.84.36.11/32"),
+			wantDel: nets("fe80::99d0:ec2d:b2e7:536b/64"),
 		},
 		{
 			a: []*net.IPNet{


### PR DESCRIPTION
Fixes #4647

It seems that Windows creates a link-local address for the TUN driver, seemingly based on the (fixed) adapter GUID. This results in a fixed MAC address, which for some reason doesn't handle loopback correctly. Given the derived link-local
address is preferred for lookups (thanks LLMNR), traffic which addresses the current node by hostname uses this broken address and never works.

To address this, we remove the broken link-local address from the wintun adapter.

@raggi IIRC you have a Windows machine? Are you able to test this live?
