### PR TITLE
surface authentication errors via status.Health

### DIFF
--- a/cmd/tailscale/cli/status.go
+++ b/cmd/tailscale/cli/status.go
@@ -128,18 +128,20 @@ func runStatus(ctx context.Context, args []string) error {
 		return err
 	}
 
-	description, ok := isRunningOrStarting(st)
-	if !ok {
-		outln(description)
-		os.Exit(1)
-	}
-
+	// print health check information prior to checking LocalBackend state as
+	// it may provide an explanation to the user if we choose to exit early
 	if len(st.Health) > 0 {
 		printf("# Health check:\n")
 		for _, m := range st.Health {
 			printf("#     - %s\n", m)
 		}
 		outln()
+	}
+
+	description, ok := isRunningOrStarting(st)
+	if !ok {
+		outln(description)
+		os.Exit(1)
 	}
 
 	var buf bytes.Buffer

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	shellquote "github.com/kballard/go-shellquote"
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -114,7 +115,7 @@ func newUpFlagSet(goos string, upArgs *upArgsT) *flag.FlagSet {
 	case "windows":
 		upf.BoolVar(&upArgs.forceDaemon, "unattended", false, "run in \"Unattended Mode\" where Tailscale keeps running even after the current GUI user logs out (Windows-only)")
 	}
-
+	upf.DurationVar(&upArgs.timeout, "timeout", 0, "maximum amount of time to wait for tailscaled to enter a Running state; default (0s) blocks forever")
 	registerAcceptRiskFlag(upf)
 	return upf
 }
@@ -148,6 +149,7 @@ type upArgsT struct {
 	hostname               string
 	opUser                 string
 	json                   bool
+	timeout                time.Duration
 }
 
 func (a upArgsT) getAuthKey() (string, error) {
@@ -646,6 +648,12 @@ func runUp(ctx context.Context, args []string) error {
 	// need to prioritize reads from 'running' if it's
 	// readable; its send does happen before the pump mechanism
 	// shuts down. (Issue 2333)
+	var timeoutCh <-chan time.Time
+	if upArgs.timeout > 0 {
+		timeoutTimer := time.NewTimer(upArgs.timeout)
+		defer timeoutTimer.Stop()
+		timeoutCh = timeoutTimer.C
+	}
 	select {
 	case <-running:
 		return nil
@@ -663,6 +671,8 @@ func runUp(ctx context.Context, args []string) error {
 		default:
 		}
 		return err
+	case <-timeoutCh:
+		return errors.New(`timeout waiting for Tailscale service to enter a Running state; check health with "tailscale status"`)
 	}
 }
 
@@ -719,7 +729,7 @@ func addPrefFlagMapping(flagName string, prefNames ...string) {
 // correspond to an ipn.Pref.
 func preflessFlag(flagName string) bool {
 	switch flagName {
-	case "auth-key", "force-reauth", "reset", "qr", "json", "accept-risk":
+	case "auth-key", "force-reauth", "reset", "qr", "json", "timeout", "accept-risk":
 		return true
 	}
 	return false

--- a/control/controlclient/auto.go
+++ b/control/controlclient/auto.go
@@ -289,6 +289,7 @@ func (c *Auto) authRoutine() {
 		}
 
 		if goal == nil {
+			health.SetAuthRoutineInError(nil)
 			// Wait for user to Login or Logout.
 			<-ctx.Done()
 			c.logf("[v1] authRoutine: context done.")
@@ -296,6 +297,7 @@ func (c *Auto) authRoutine() {
 		}
 
 		if !goal.wantLoggedIn {
+			health.SetAuthRoutineInError(nil)
 			err := c.direct.TryLogout(ctx)
 			goal.sendLogoutError(err)
 			if err != nil {
@@ -334,6 +336,7 @@ func (c *Auto) authRoutine() {
 				f = "TryLogin"
 			}
 			if err != nil {
+				health.SetAuthRoutineInError(err)
 				report(err, f)
 				bo.BackOff(ctx, err)
 				continue
@@ -358,6 +361,7 @@ func (c *Auto) authRoutine() {
 			}
 
 			// success
+			health.SetAuthRoutineInError(nil)
 			c.mu.Lock()
 			c.loggedIn = true
 			c.loginGoal = nil

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -2680,12 +2680,14 @@ func (b *LocalBackend) enterState(newState ipn.State) {
 	b.maybePauseControlClientLocked()
 	b.mu.Unlock()
 
+	// prefs may change irrespective of state; WantRunning should be explicitly
+	// set before potential early return even if the state is unchanged.
+	health.SetIPNState(newState.String(), prefs.WantRunning)
 	if oldState == newState {
 		return
 	}
 	b.logf("Switching ipn state %v -> %v (WantRunning=%v, nm=%v)",
 		oldState, newState, prefs.WantRunning, netMap != nil)
-	health.SetIPNState(newState.String(), prefs.WantRunning)
 	b.send(ipn.Notify{State: &newState})
 
 	switch newState {


### PR DESCRIPTION
This PR does two things:

1) It adds a `timeout` flag to `tailscale up`.
> maximum amount of time (in seconds) to wait for tailscaled to enter a Running state; default (0) blocks forever

2) It augments the `health` package with authentication routine error state. If authentication with coordination is desired and failing, the last error encountered will be surfaced via the `Health` field in localapi's status response.

Both of these changes are in response to #3713 where `tailscale up` was blocked indefinitely as coordination TLS cert validation failed due to a drifted clock. This can also happen when coordination is simply unreachable/firewalled from `tailscaled`, and in such a case the error will also be available via `tailscale status`.

Example:

start `tailscaled`:
```
% go run . --socket=/tmp/tailscale1.sock --statedir=/tmp/tailscaled1 --tun=userspace-networking
logtail started
Program starting: v1.25.0-dev-t, Go 1.18.2: []string{"/var/folders/1l/ndwb1lcx4099_7bc3ncndcy40000gn/T/go-build3380658850/b001/exe/tailscaled", "--socket=/tmp/tailscale1.sock", "--statedir=/tmp/tailscaled1", "--tun=userspace-networking"}
[...]
```

`tailscale up`:
```
% go run cmd/tailscale/tailscale.go --socket=/tmp/tailscale1.sock up --login-server=http://localhost:31544 --hostname=tailscale1 --timeout=5
timeout waiting for Tailscale service to enter a Running state; check health with "tailscale status"
exit status 1
```

`tailscaled` login failures:
```
StartLoginInteractive: url=false
control: client.Login(false, 2)
control: LoginInteractive -> regen=true
control: doLogin(regen=true, hasUrl=false)
trying bootstrapDNS("derp9b.tailscale.com", "144.202.67.195") for "localhost" ...
trying bootstrapDNS("derp3.tailscale.com", "2400:6180:0:d1::67d:8001") for "localhost" ...
trying bootstrapDNS("derp4d.tailscale.com", "134.122.94.167") for "localhost" ...
trying bootstrapDNS("derp1d.tailscale.com", "2604:a880:800:10::7fe:f001") for "localhost" ...
trying bootstrapDNS("derp9.tailscale.com", "207.148.3.137") for "localhost" ...
trying bootstrapDNS("derp1e.tailscale.com", "2604:a880:800:10::873:4001") for "localhost" ...
Received error: fetch control key: Get "http://localhost:31544/key?v=32": dial tcp [::1]:31544: connect: connection refused
```

`tailscale status`:
```
% go run cmd/tailscale/tailscale.go --socket=/tmp/tailscale1.sock status
# Health check:
#     - not logged in, last login error=fetch control key: Get "http://localhost:31544/key?v=32": dial tcp [::1]:31544: connect: connection refused
Logged out.
exit status 1
```