### PR TITLE
ipn/ipnlocal: shutdown sshServer on tailscale down

### DIFF
--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -584,6 +584,12 @@ func (p *Prefs) SetExitNodeIP(s string, st *ipnstate.Status) error {
 	return err
 }
 
+// ShouldSSHBeRunning reports whether the SSH server should be running based on
+// the prefs.
+func (p *Prefs) ShouldSSHBeRunning() bool {
+	return p.WantRunning && p.RunSSH
+}
+
 // PrefsFromBytes deserializes Prefs from a JSON blob.
 func PrefsFromBytes(b []byte) (*Prefs, error) {
 	p := NewPrefs()

--- a/ssh/tailssh/tailssh.go
+++ b/ssh/tailssh/tailssh.go
@@ -110,7 +110,7 @@ func (srv *server) Shutdown() {
 	srv.shutdownCalled = true
 	for _, s := range srv.activeSessionByH {
 		s.ctx.CloseWithError(userVisibleError{
-			fmt.Sprintf("Tailscale shutting down.\r\n"),
+			fmt.Sprintf("Tailscale SSH is shutting down.\r\n"),
 			context.Canceled,
 		})
 	}
@@ -876,7 +876,7 @@ func (ss *sshSession) run() {
 	if srv.shutdownCalled {
 		srv.mu.Unlock()
 		// Do not start any new sessions.
-		fmt.Fprintf(ss, "Tailscale is shutting down\r\n")
+		fmt.Fprintf(ss, "Tailscale SSH is shutting down\r\n")
 		ss.Exit(1)
 		return
 	}


### PR DESCRIPTION
Also lazify SSHServer initialization to allow restarting the server on a
subsequent `tailscale up`

Signed-off-by: Maisem Ali <maisem@tailscale.com>