### PR TITLE
 hostinfo: use ByteSliceToString from golang.org/x/sys/unix

### DIFF
--- a/hostinfo/hostinfo_freebsd.go
+++ b/hostinfo/hostinfo_freebsd.go
@@ -27,12 +27,7 @@ func osVersionFreebsd() string {
 
 	var attrBuf strings.Builder
 	attrBuf.WriteString("; version=")
-	for _, b := range un.Release {
-		if b == 0 {
-			break
-		}
-		attrBuf.WriteByte(byte(b))
-	}
+	attrBuf.WriteString(unix.ByteSliceToString(un.Release[:]))
 	attr := attrBuf.String()
 
 	version := "FreeBSD"

--- a/hostinfo/hostinfo_linux.go
+++ b/hostinfo/hostinfo_linux.go
@@ -13,7 +13,6 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
-	"syscall"
 
 	"tailscale.com/util/lineread"
 	"tailscale.com/version/distro"
@@ -68,8 +67,8 @@ func osVersionLinux() string {
 		return nil
 	})
 
-	var un syscall.Utsname
-	syscall.Uname(&un)
+	var un unix.Utsname
+	unix.Uname(&un)
 
 	var attrBuf strings.Builder
 	attrBuf.WriteString("; kernel=")

--- a/hostinfo/hostinfo_linux.go
+++ b/hostinfo/hostinfo_linux.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"strings"
 
+	"golang.org/x/sys/unix"
 	"tailscale.com/util/lineread"
 	"tailscale.com/version/distro"
 )
@@ -72,12 +73,7 @@ func osVersionLinux() string {
 
 	var attrBuf strings.Builder
 	attrBuf.WriteString("; kernel=")
-	for _, b := range un.Release {
-		if b == 0 {
-			break
-		}
-		attrBuf.WriteByte(byte(b))
-	}
+	attrBuf.WriteString(unix.ByteSliceToString(un.Release[:]))
 	if inContainer() {
 		attrBuf.WriteString("; container")
 	}


### PR DESCRIPTION
Use `unix.ByteSliceToString` in `osVersionFreebsd` and `osVersionLinux` to
convert the `Utsname.Release` `[]byte` field to `string`.
