### PR TITLE
tsnet: use proper log ID

### DIFF
--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -10,6 +10,7 @@ package tsnet
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -29,6 +30,9 @@ import (
 	"tailscale.com/ipn/localapi"
 	"tailscale.com/ipn/store"
 	"tailscale.com/ipn/store/mem"
+	"tailscale.com/logpolicy"
+	"tailscale.com/logtail"
+	"tailscale.com/logtail/filch"
 	"tailscale.com/net/nettest"
 	"tailscale.com/net/tsdial"
 	"tailscale.com/smallzstd"
@@ -76,6 +80,7 @@ type Server struct {
 	shutdownCtx      context.Context
 	shutdownCancel   context.CancelFunc
 	localClient      *tailscale.LocalClient
+	logtail          *logtail.Logger
 
 	mu        sync.Mutex
 	listeners map[listenKey]*listener
@@ -126,6 +131,11 @@ func (s *Server) Close() error {
 		ln.Close()
 	}
 	s.listeners = nil
+
+	// Perform a best-effort final flush.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	s.logtail.Shutdown(ctx)
 
 	return nil
 }
@@ -178,8 +188,35 @@ func (s *Server) start() error {
 		return fmt.Errorf("%v is not a directory", s.rootPath)
 	}
 
-	// TODO(bradfitz): start logtail? don't use filch, perhaps?
-	// only upload plumbed Logf?
+	cfgPath := filepath.Join(s.rootPath, "tailscaled.log.conf")
+
+	lpc, err := logpolicy.ConfigFromFile(cfgPath)
+	switch {
+	case os.IsNotExist(err):
+		lpc.Initialize(logtail.CollectionNode)
+		if err := lpc.Save(cfgPath); err != nil {
+			return fmt.Errorf("logpolicy.Config.Save for %v: %w", cfgPath, err)
+		}
+	case err != nil:
+		return fmt.Errorf("logpolicy.LoadConfig for %v: %w", cfgPath, err)
+	}
+	if err := lpc.Validate(logtail.CollectionNode); err != nil {
+		return fmt.Errorf("logpolicy.Config.Validate for %v: %w", cfgPath, err)
+	}
+	logid := lpc.PublicID.String()
+
+	f, err := filch.New(filepath.Join(s.rootPath, "tailscaled"), filch.Options{ReplaceStderr: false})
+	if err != nil {
+		return fmt.Errorf("error creating filch: %w", err)
+	}
+	c := logtail.Config{
+		Collection: lpc.Collection,
+		PrivateID:  lpc.PrivateID,
+		Stderr:     ioutil.Discard, // log everything to Buffer
+		Buffer:     f,
+		// TODO: consider adding compression. Look at logpolicy.go
+	}
+	s.logtail = logtail.NewLogger(c, logf)
 
 	s.linkMon, err = monitor.New(logf)
 	if err != nil {
@@ -226,7 +263,6 @@ func (s *Server) start() error {
 			return err
 		}
 	}
-	logid := "tsnet-TODO" // https://github.com/tailscale/tailscale/issues/3866
 
 	loginFlags := controlclient.LoginDefault
 	if s.Ephemeral {
@@ -283,6 +319,9 @@ func (s *Server) start() error {
 }
 
 func (s *Server) logf(format string, a ...interface{}) {
+	if s.logtail != nil {
+		s.logtail.Logf(format, a...)
+	}
 	if s.Logf != nil {
 		s.Logf(format, a...)
 		return


### PR DESCRIPTION
refactor logpolicy config loading to make it easier to reuse from outside the package.  Within tsnet, setup a basic logtail config.

Fixes #3866