### PR TITLE
ipn/ipnlocal: prevent attempting to run SSH on Synology for now

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1833,7 +1833,10 @@ func (b *LocalBackend) checkPrefsLocked(p *ipn.Prefs) error {
 	if p.RunSSH {
 		switch runtime.GOOS {
 		case "linux":
-			// okay
+			if distro.Get() == distro.Synology && !envknob.UseWIPCode() {
+				return errors.New("The Tailscale SSH server does not run on Synology.")
+			}
+			// otherwise okay
 		case "darwin":
 			// okay only in tailscaled mode for now.
 			if version.IsSandboxedMacOS() {


### PR DESCRIPTION
On DSM7 as a non-root user it'll run into problems.

And we haven't tested on DSM6, even though it might work, but I doubt
it.

Updates #3802
Updates tailscale/corp#5468
