### PR TITLE
Revert "cmd/tailscale/cli: disallow --ssh on Synology"

### DIFF
--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -440,10 +440,7 @@ func runUp(ctx context.Context, args []string) error {
 			return errors.New("--exit-node is " + notSupported)
 		}
 		if upArgs.netfilterMode != "off" {
-			return errors.New("--netfilter-mode values besides \"off\" are " + notSupported)
-		}
-		if upArgs.runSSH {
-			return errors.New("--ssh is " + notSupported)
+			return errors.New("--netfilter-mode values besides \"off\" " + notSupported)
 		}
 	}
 


### PR DESCRIPTION
This reverts commit 03e3e6abcd39239eca710144e329d5e8ef935a2d
in favor of #4785.