### PR TITLE
hostinfo,distro: Identify Western Digital MyCloud devices.

### DIFF
--- a/hostinfo/hostinfo_linux.go
+++ b/hostinfo/hostinfo_linux.go
@@ -37,6 +37,7 @@ func linuxDeviceModel() string {
 		// Otherwise, try the Devicetree model, usually set on
 		// ARM SBCs, etc.
 		// Example: "Raspberry Pi 4 Model B Rev 1.2"
+		// Example: "WD My Cloud Gen2: Marvell Armada 375"
 		"/sys/firmware/devicetree/base/model", // Raspberry Pi 4 Model B Rev 1.2"
 	} {
 		b, _ := os.ReadFile(path)
@@ -55,6 +56,9 @@ func osVersionLinux() string {
 		propFile = "/etc.defaults/VERSION"
 	case distro.OpenWrt:
 		propFile = "/etc/openwrt_release"
+	case distro.WDMyCloud:
+		slurp, _ := ioutil.ReadFile("/etc/version")
+		return fmt.Sprintf("%s", string(bytes.TrimSpace(slurp)))
 	}
 
 	m := map[string]string{}

--- a/version/distro/distro.go
+++ b/version/distro/distro.go
@@ -14,16 +14,17 @@ import (
 type Distro string
 
 const (
-	Debian   = Distro("debian")
-	Arch     = Distro("arch")
-	Synology = Distro("synology")
-	OpenWrt  = Distro("openwrt")
-	NixOS    = Distro("nixos")
-	QNAP     = Distro("qnap")
-	Pfsense  = Distro("pfsense")
-	OPNsense = Distro("opnsense")
-	TrueNAS  = Distro("truenas")
-	Gokrazy  = Distro("gokrazy")
+	Debian    = Distro("debian")
+	Arch      = Distro("arch")
+	Synology  = Distro("synology")
+	OpenWrt   = Distro("openwrt")
+	NixOS     = Distro("nixos")
+	QNAP      = Distro("qnap")
+	Pfsense   = Distro("pfsense")
+	OPNsense  = Distro("opnsense")
+	TrueNAS   = Distro("truenas")
+	Gokrazy   = Distro("gokrazy")
+	WDMyCloud = Distro("wdmycloud")
 )
 
 var distroAtomic atomic.Value // of Distro
@@ -73,6 +74,10 @@ func linuxDistro() Distro {
 		return QNAP
 	case haveDir("/gokrazy"):
 		return Gokrazy
+	case have("/usr/local/wdmcserver/bin/wdmc.xml"): // Western Digital MyCloud OS3
+		return WDMyCloud
+	case have("/usr/sbin/wd_crontab.sh"): // Western Digital MyCloud OS5
+		return WDMyCloud
 	}
 	return ""
 }


### PR DESCRIPTION
```
root@WDMyCloud HD_a2 # ./tailscale debug hostinfo
{
  "IPNVersion": "1.25.0-dev20220605-t7fea52e02",
  "OS": "linux",
  "OSVersion": "5.22.113",
  "Desktop": false,
  "DeviceModel": "WD My Cloud Gen2: Marvell Armada 375",
  "Hostname": "WDMyCloud",
  "GoArch": "arm"
}
```

Updates https://github.com/tailscale/tailscale/issues/4622

Signed-off-by: Denton Gentry <dgentry@tailscale.com>