### PR TITLE
tsweb: fix Port80Handler redirect to https with FQDN unset

### DIFF
--- a/tsweb/tsweb.go
+++ b/tsweb/tsweb.go
@@ -162,7 +162,7 @@ func (h Port80Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	host := h.FQDN
 	if host == "" {
-		host = r.URL.Hostname()
+		host = r.Host
 	}
 	target := "https://" + host + path
 	http.Redirect(w, r, target, http.StatusFound)


### PR DESCRIPTION
Fixes the current http://pkgs.tailscale.com/ redirect to https:///
as that server doesn't configure the Port80Handler.FQDN field.
