### PR TITLE
wasm: exclude code that's not used on iOS for Wasm too

### DIFF
--- a/ipn/ipnlocal/peerapi_h2c.go
+++ b/ipn/ipnlocal/peerapi_h2c.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !ios && !android
-// +build !ios,!android
+//go:build !ios && !android && !js
+// +build !ios,!android,!js
 
 package ipnlocal
 

--- a/ipn/localapi/cert.go
+++ b/ipn/localapi/cert.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !ios && !android
-// +build !ios,!android
+//go:build !ios && !android && !js
+// +build !ios,!android,!js
 
 package localapi
 

--- a/ipn/localapi/disabled_stubs.go
+++ b/ipn/localapi/disabled_stubs.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build ios || android
-// +build ios android
+//go:build ios || android || js
+// +build ios android js
 
 package localapi
 

--- a/ipn/localapi/profile.go
+++ b/ipn/localapi/profile.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !ios && !android
-// +build !ios,!android
+//go:build !ios && !android && !js
+// +build !ios,!android,!js
 
 // We don't include it on mobile where we're more memory constrained and
 // there's no CLI to get at the results anyway.

--- a/net/netns/socks.go
+++ b/net/netns/socks.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !ios
-// +build !ios
+//go:build !ios && !js
+// +build !ios,!js
 
 package netns
 

--- a/net/portmapper/disabled_stubs.go
+++ b/net/portmapper/disabled_stubs.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build ios
-// +build ios
+//go:build ios || js
+// +build ios js
 
 // (https://github.com/tailscale/tailscale/issues/2495)
 

--- a/net/portmapper/upnp.go
+++ b/net/portmapper/upnp.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !ios
-// +build !ios
+//go:build !ios && !js
+// +build !ios,!js
 
 // (https://github.com/tailscale/tailscale/issues/2495)
 

--- a/portlist/netstat.go
+++ b/portlist/netstat.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !ios
-// +build !ios
+//go:build !ios && !js
+// +build !ios,!js
 
 package portlist
 

--- a/portlist/netstat_exec.go
+++ b/portlist/netstat_exec.go
@@ -2,9 +2,10 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build (windows || freebsd || openbsd || darwin) && !ios
+//go:build (windows || freebsd || openbsd || darwin) && !ios && !js
 // +build windows freebsd openbsd darwin
 // +build !ios
+// +build !js
 
 package portlist
 

--- a/wgengine/magicsock/debugknobs.go
+++ b/wgengine/magicsock/debugknobs.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !ios
-// +build !ios
+//go:build !ios && !js
+// +build !ios,!js
 
 package magicsock
 

--- a/wgengine/magicsock/debugknobs_stubs.go
+++ b/wgengine/magicsock/debugknobs_stubs.go
@@ -2,11 +2,13 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build ios || js
+
 package magicsock
 
 import "tailscale.com/types/opt"
 
-// All knobs are disabled on iOS.
+// All knobs are disabled on iOS and Wasm.
 // Further, they're const, so the toolchain can produce smaller binaries.
 const (
 	debugDisco                       = false

--- a/wgengine/magicsock/debugknobs_stubs.go
+++ b/wgengine/magicsock/debugknobs_stubs.go
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 //go:build ios || js
+// +build ios js
 
 package magicsock
 


### PR DESCRIPTION
It has similar size constraints. Saves ~1.9MB from the Wasm build.

Updates #3157

Signed-off-by: Mihai Parparita <mihai@tailscale.com>