### PR TITLE
tailcfg: add TailscaleSSHEnabled helper check

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -475,6 +475,14 @@ type Hostinfo struct {
 	//       require changes to Hostinfo.Equal.
 }
 
+// TailscaleSSHEnabled reports whether or not this node is acting as a
+// Tailscale SSH server.
+func (hi *Hostinfo) TailscaleSSHEnabled() bool {
+	// Currently, we use `SSH_HostKeys` as a proxy for this. However, we may later
+	// include non-Tailscale host keys, and will add a separate flag to rely on.
+	return hi != nil && len(hi.SSH_HostKeys) > 0
+}
+
 // NetInfo contains information about the host's network state.
 type NetInfo struct {
 	// MappingVariesByDestIP says whether the host's NAT mappings

--- a/tailcfg/tailcfg_test.go
+++ b/tailcfg/tailcfg_test.go
@@ -271,6 +271,33 @@ func TestHostinfoHowEqual(t *testing.T) {
 	}
 }
 
+func TestHostinfoTailscaleSSHEnabled(t *testing.T) {
+	tests := []struct {
+		hi   *Hostinfo
+		want bool
+	}{
+		{
+			nil,
+			false,
+		},
+		{
+			&Hostinfo{},
+			false,
+		},
+		{
+			&Hostinfo{SSH_HostKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO.... root@bar"}},
+			true,
+		},
+	}
+
+	for i, tt := range tests {
+		got := tt.hi.TailscaleSSHEnabled()
+		if got != tt.want {
+			t.Errorf("%d. got %v; want %v", i, got, tt.want)
+		}
+	}
+}
+
 func TestNodeEqual(t *testing.T) {
 	nodeHandles := []string{
 		"ID", "StableID", "Name", "User", "Sharer",


### PR DESCRIPTION
This commit adds a helper to check if SSH is enabled. We're currently checking the SSH_HostKeys field in a few places, but later plan to add an explicit bool. This helper makes the check and any future changes easier.

Signed-off-by: Ross Zurowski <ross@rosszurowski.com>