### PR TITLE
wasm: drop pprof dependency

### DIFF
--- a/log/logheap/logheap.go
+++ b/log/logheap/logheap.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !js
+// +build !js
+
 // Package logheap logs a heap pprof profile.
 package logheap
 

--- a/log/logheap/logheap_js.go
+++ b/log/logheap/logheap_js.go
@@ -1,0 +1,8 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package logheap
+
+func LogHeap(postURL string) {
+}

--- a/wgengine/watchdog.go
+++ b/wgengine/watchdog.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !js
+// +build !js
+
 package wgengine
 
 import (

--- a/wgengine/watchdog_js.go
+++ b/wgengine/watchdog_js.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build js
+
+package wgengine
+
+import "tailscale.com/net/dns/resolver"
+
+type watchdogEngine struct {
+	Engine
+	wrap Engine
+}
+
+func (e *watchdogEngine) GetResolver() (r *resolver.Resolver, ok bool) {
+	return nil, false
+}


### PR DESCRIPTION
We can use the browser tools to profile, pprof adds 200K to the binary size.

Updates #3157

Signed-off-by: Mihai Parparita <mihai@tailscale.com>