### PR TITLE
wasm: add test for disallowed JS/WASM dependencies

### DIFF
--- a/tstest/jsdeps/jsdeps.go
+++ b/tstest/jsdeps/jsdeps.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package jsdeps is a just a list of the packages we import in the
+// JavaScript/WASM build, to let us test that our transitive closure of
+// dependencies on iOS doesn't accidentally grow too large, since binary size
+// is more of a concern there.
+package jsdeps
+
+import (
+	_ "bytes"
+	_ "context"
+	_ "encoding/hex"
+	_ "encoding/json"
+	_ "fmt"
+	_ "log"
+	_ "math/rand"
+	_ "net"
+	_ "strings"
+	_ "time"
+
+	_ "golang.org/x/crypto/ssh"
+	_ "inet.af/netaddr"
+	_ "tailscale.com/control/controlclient"
+	_ "tailscale.com/ipn"
+	_ "tailscale.com/ipn/ipnserver"
+	_ "tailscale.com/net/netns"
+	_ "tailscale.com/net/tsdial"
+	_ "tailscale.com/safesocket"
+	_ "tailscale.com/tailcfg"
+	_ "tailscale.com/types/logger"
+	_ "tailscale.com/wgengine"
+	_ "tailscale.com/wgengine/netstack"
+	_ "tailscale.com/words"
+)

--- a/tstest/jsdeps/jsdeps_test.go
+++ b/tstest/jsdeps/jsdeps_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// No need to run this on Windows where CI's slow enough. Then we don't need to
+// worry about "go.exe" etc.
+
+//go:build !windows
+// +build !windows
+
+package jsdeps
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestDeps(t *testing.T) {
+	cmd := exec.Command(filepath.Join(runtime.GOROOT(), "bin", "go"), "list", "-json", ".")
+	cmd.Env = append(os.Environ(), "GOOS=js", "GOARCH=wasm")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var res struct {
+		Deps []string
+	}
+	if err := json.Unmarshal(out, &res); err != nil {
+		t.Fatal(err)
+	}
+	for _, dep := range res.Deps {
+		switch dep {
+		case "runtime/pprof", "golang.org/x/net/http2/h2c", "net/http/pprof", "golang.org/x/net/proxy", "github.com/tailscale/goupnp":
+			t.Errorf("package %q is not allowed as a dependency on JS", dep)
+		}
+	}
+	t.Logf("got %d dependencies", len(res.Deps))
+}


### PR DESCRIPTION
Ensures that binary size gains like the ones from #4802 and #4813
don't regress.

Updates #3517

Signed-off-by: Mihai Parparita <mihai@tailscale.com>