### PR TITLE
logtail: do not panic in PrivateID.PublicID

### DIFF
--- a/logtail/id.go
+++ b/logtail/id.go
@@ -80,10 +80,6 @@ func (id PrivateID) String() string {
 }
 
 func (id PrivateID) Public() (pub PublicID) {
-	var emptyID PrivateID
-	if id == emptyID {
-		panic("invalid logtail.Public() on an empty private ID")
-	}
 	h := sha256.New()
 	h.Write(id[:])
 	if n := copy(pub[:], h.Sum(pub[:0])); n != len(pub) {


### PR DESCRIPTION
It is not idiomatic for Go code to panic for situations that
can be normal. For example, if a server receives PrivateID
from a client, it is normal for the server to call
PrivateID.PublicID to validate that the PublicID matches.
However, doing so would panic prior to this change.

Signed-off-by: Joe Tsai <joetsai@digital-static.net>