### PR TITLE
tsnet: use tailscaled as prefix for state file names

### DIFF
--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -56,6 +56,10 @@ type Server struct {
 	//
 	// If nil, a new FileStore is initialized at `Dir/tailscaled.state`.
 	// See tailscale.com/ipn/store for supported stores.
+	//
+	// Logs will automatically be uploaded to uploaded to log.tailscale.io,
+	// where the configuration file for logging will be saved at
+	// `Dir/tailscaled.log.conf`.
 	Store ipn.StateStore
 
 	// Hostname is the hostname to present to the control server.
@@ -188,7 +192,7 @@ func (s *Server) start() error {
 		return fmt.Errorf("%v is not a directory", s.rootPath)
 	}
 
-	cfgPath := filepath.Join(s.rootPath, "tsnet.log.conf")
+	cfgPath := filepath.Join(s.rootPath, "tailscaled.log.conf")
 
 	lpc, err := logpolicy.ConfigFromFile(cfgPath)
 	switch {
@@ -205,7 +209,7 @@ func (s *Server) start() error {
 	}
 	logid := lpc.PublicID.String()
 
-	f, err := filch.New(filepath.Join(s.rootPath, "tsnet"), filch.Options{ReplaceStderr: false})
+	f, err := filch.New(filepath.Join(s.rootPath, "tailscaled"), filch.Options{ReplaceStderr: false})
 	if err != nil {
 		return fmt.Errorf("error creating filch: %w", err)
 	}


### PR DESCRIPTION
Use the "tailscaled" prefix instead of "tsnet" for state file names:
1. It is consistent with the pre-existing `{{Dir}}/tailscaled.state` file.
2. It makes the file layout of `tsnet` and `tailscaled` identical,
   so that they are compatible with each other.

Signed-off-by: Joe Tsai <joetsai@digital-static.net>