### PR TITLE
net/portmapper: enable for iOS

### DIFF
--- a/net/portmapper/disabled_stubs.go
+++ b/net/portmapper/disabled_stubs.go
@@ -2,10 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build ios || js
-// +build ios js
-
-// (https://github.com/tailscale/tailscale/issues/2495)
+//go:build js
+// +build js
 
 package portmapper
 

--- a/net/portmapper/upnp.go
+++ b/net/portmapper/upnp.go
@@ -2,10 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !ios && !js
-// +build !ios,!js
-
-// (https://github.com/tailscale/tailscale/issues/2495)
+//go:build !js
+// +build !js
+// (no raw sockets in JS/WASM)
 
 package portmapper
 

--- a/tstest/iosdeps/iosdeps_test.go
+++ b/tstest/iosdeps/iosdeps_test.go
@@ -34,7 +34,7 @@ func TestDeps(t *testing.T) {
 	}
 	for _, dep := range res.Deps {
 		switch dep {
-		case "regexp", "regexp/syntax", "text/template", "html/template":
+		case "text/template", "html/template":
 			t.Errorf("package %q is not allowed as a dependency on iOS", dep)
 		}
 	}


### PR DESCRIPTION
In the 1.27 unstable releases we set the min-version to iOS15,
which means we have 50 MBytes of RAM in the Network Extension.
https://tailscale.com/blog/go-linker/

Include the UPnP/NAT-PMP/PCP portmapper support now that there
is room for it.

Fixes https://github.com/tailscale/tailscale/issues/2495
Signed-off-by: Denton Gentry <dgentry@tailscale.com>