### PR TITLE
net/dns/resolver: respond with SERVFAIL if all upstreams fail

### DIFF
--- a/net/dns/resolver/forwarder.go
+++ b/net/dns/resolver/forwarder.go
@@ -472,6 +472,8 @@ func (f *forwarder) send(ctx context.Context, fq *forwardQuery, rr resolverAndDe
 	return f.sendUDP(ctx, fq, rr)
 }
 
+var errServerFailure = errors.New("response code indicates server issue")
+
 func (f *forwarder) sendUDP(ctx context.Context, fq *forwardQuery, rr resolverAndDelay) (ret []byte, err error) {
 	ipp, ok := rr.name.IPPort()
 	if !ok {
@@ -535,7 +537,7 @@ func (f *forwarder) sendUDP(ctx context.Context, fq *forwardQuery, rr resolverAn
 	if rcode == dns.RCodeServerFailure {
 		f.logf("recv: response code indicating server failure: %d", rcode)
 		metricDNSFwdUDPErrorServer.Add(1)
-		return nil, errors.New("response code indicates server issue")
+		return nil, errServerFailure
 	}
 
 	if truncated {
@@ -704,6 +706,18 @@ func (f *forwarder) forwardWithDestChan(ctx context.Context, query packet, respo
 			}
 			numErr++
 			if numErr == len(resolvers) {
+				res, err := servfailResponse(query)
+				if err != nil {
+					f.logf("building servfail response: %v", err)
+					return firstErr
+				}
+
+				select {
+				case <-ctx.Done():
+					metricDNSFwdErrorContext.Add(1)
+					metricDNSFwdErrorContextGotError.Add(1)
+				case responseChan <- res:
+				}
 				return firstErr
 			}
 		case <-ctx.Done():
@@ -757,6 +771,27 @@ func nxDomainResponse(req packet) (res packet, err error) {
 	// TODO(bradfitz): should we add an SOA record in the Authority
 	// section too? (for the nxdomain negative caching TTL)
 	// For which zone? Does iOS care?
+	res.bs, err = b.Finish()
+	res.addr = req.addr
+	return res, err
+}
+
+// servfailResponse returns a SERVFAIL error reply for the provided request.
+func servfailResponse(req packet) (res packet, err error) {
+	p := dnsParserPool.Get().(*dnsParser)
+	defer dnsParserPool.Put(p)
+
+	if err := p.parseQuery(req.bs); err != nil {
+		return packet{}, err
+	}
+
+	h := p.Header
+	h.Response = true
+	h.Authoritative = true
+	h.RCode = dns.RCodeServerFailure
+	b := dns.NewBuilder(nil, h)
+	b.StartQuestions()
+	b.Question(p.Question)
 	res.bs, err = b.Finish()
 	res.addr = req.addr
 	return res, err

--- a/net/dns/resolver/tsdns.go
+++ b/net/dns/resolver/tsdns.go
@@ -278,7 +278,12 @@ func (r *Resolver) Query(ctx context.Context, bs []byte, from netaddr.IPPort) ([
 		defer cancel()
 		err = r.forwarder.forwardWithDestChan(ctx, packet{bs, from}, responses)
 		if err != nil {
-			return nil, err
+			select {
+			case resp := <-responses:
+				return resp.bs, err
+			default:
+				return nil, err
+			}
 		}
 		return (<-responses).bs, nil
 	}

--- a/net/dns/resolver/tsdns_test.go
+++ b/net/dns/resolver/tsdns_test.go
@@ -1417,3 +1417,41 @@ func TestUnARPA(t *testing.T) {
 		}
 	}
 }
+
+func TestServfail(t *testing.T) {
+	server := serveDNS(t, "127.0.0.1:0", "test.site.", miekdns.HandlerFunc(func(w miekdns.ResponseWriter, req *miekdns.Msg) {
+		m := new(miekdns.Msg)
+		m.Rcode = miekdns.RcodeServerFailure
+		w.WriteMsg(m)
+	}))
+	defer server.Shutdown()
+
+	r := newResolver(t)
+	defer r.Close()
+
+	cfg := dnsCfg
+	cfg.Routes = map[dnsname.FQDN][]*dnstype.Resolver{
+		".": {{Addr: server.PacketConn.LocalAddr().String()}},
+	}
+	r.SetConfig(cfg)
+
+	pkt, err := syncRespond(r, dnspacket("test.site.", dns.TypeA, noEdns))
+	if err != errServerFailure {
+		t.Errorf("err = %v, want %v", err, errServerFailure)
+	}
+
+	wantPkt := []byte{
+		0x00, 0x00, // transaction id: 0
+		0x84, 0x02, // flags: response, authoritative, error: servfail
+		0x00, 0x01, // one question
+		0x00, 0x00, // no answers
+		0x00, 0x00, 0x00, 0x00, // no authority or additional RRs
+		// Question:
+		0x04, 0x74, 0x65, 0x73, 0x74, 0x04, 0x73, 0x69, 0x74, 0x65, 0x00, // name
+		0x00, 0x01, 0x00, 0x01, // type A, class IN
+	}
+
+	if !bytes.Equal(pkt, wantPkt) {
+		t.Errorf("response was %X, want %X", pkt, wantPkt)
+	}
+}


### PR DESCRIPTION
Fixes #4722

This represents a fairly big change from being silent, so will need a lot of testing just in case there are side effects.