### PR TITLE
control/controlclient: start simplifying netmap fetch APIs

### DIFF
--- a/control/controlclient/auto.go
+++ b/control/controlclient/auto.go
@@ -41,6 +41,8 @@ func (g *LoginGoal) sendLogoutError(err error) {
 	}
 }
 
+var _ Client = (*Auto)(nil)
+
 // Auto connects to a tailcontrol server for a node.
 // It's a concrete implementation of the Client interface.
 type Auto struct {
@@ -462,7 +464,7 @@ func (c *Auto) mapRoutine() {
 			c.mu.Unlock()
 			health.SetInPollNetMap(false)
 
-			err := c.direct.PollNetMap(ctx, -1, func(nm *netmap.NetworkMap) {
+			err := c.direct.PollNetMap(ctx, func(nm *netmap.NetworkMap) {
 				health.SetInPollNetMap(true)
 				c.mu.Lock()
 


### PR DESCRIPTION
Step 1 of many, cleaning up the direct/auto client & restarting map
requests that leads to all the unnecessary map requests.

Updates tailscale/corp#5761