### PR TITLE
control/controlclient, ipn/ipnlocal: remove Client.SetExpirySooner, fix race

### DIFF
--- a/control/controlclient/client.go
+++ b/control/controlclient/client.go
@@ -11,7 +11,6 @@ package controlclient
 
 import (
 	"context"
-	"time"
 
 	"tailscale.com/tailcfg"
 )
@@ -43,9 +42,6 @@ type Client interface {
 	// Logout starts a synchronous logout process. It doesn't return
 	// until the logout operation has been completed.
 	Logout(context.Context) error
-	// SetExpirySooner sets the node's expiry time via the controlclient,
-	// as long as it's shorter than the current expiry time.
-	SetExpirySooner(context.Context, time.Time) error
 	// SetPaused pauses or unpauses the controlclient activity as much
 	// as possible, without losing its internal state, to minimize
 	// unnecessary network activity.

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3369,7 +3369,13 @@ func (b *LocalBackend) allowExitNodeDNSProxyToServeName(name string) bool {
 // If t is in the past, the key is expired immediately.
 // If t is after the current expiry, an error is returned.
 func (b *LocalBackend) SetExpirySooner(ctx context.Context, expiry time.Time) error {
-	return b.cc.SetExpirySooner(ctx, expiry)
+	b.mu.Lock()
+	cc := b.ccAuto
+	b.mu.Unlock()
+	if cc == nil {
+		return errors.New("not running")
+	}
+	return cc.SetExpirySooner(ctx, expiry)
 }
 
 // exitNodeCanProxyDNS reports the DoH base URL ("http://foo/dns-query") without query parameters

--- a/ipn/ipnlocal/state_test.go
+++ b/ipn/ipnlocal/state_test.go
@@ -220,12 +220,6 @@ func (cc *mockControl) Logout(ctx context.Context) error {
 	return nil
 }
 
-func (cc *mockControl) SetExpirySooner(context.Context, time.Time) error {
-	cc.logf("SetExpirySooner")
-	cc.called("SetExpirySooner")
-	return nil
-}
-
 func (cc *mockControl) SetPaused(paused bool) {
 	cc.logf("SetPaused=%v", paused)
 	if paused {


### PR DESCRIPTION
Client.SetExpirySooner isn't part of the state machine. Remove it from
the Client interface.

And fix a use of LocalBackend.cc without acquiring the lock that
guards that field.
