### PR TITLE
cmd/tailscale: make up respect explicitly empty --operator= value

### DIFF
--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -493,14 +493,16 @@ func TestCheckForAccidentalSettingReverts(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			applyImplicitPrefs(newPrefs, tt.curPrefs, tt.curUser)
-			var got string
-			if err := checkForAccidentalSettingReverts(newPrefs, tt.curPrefs, upCheckEnv{
+			upEnv := upCheckEnv{
 				goos:          goos,
 				flagSet:       flagSet,
 				curExitNodeIP: tt.curExitNodeIP,
 				distro:        tt.distro,
-			}); err != nil {
+				user:          tt.curUser,
+			}
+			applyImplicitPrefs(newPrefs, tt.curPrefs, upEnv)
+			var got string
+			if err := checkForAccidentalSettingReverts(newPrefs, tt.curPrefs, upEnv); err != nil {
 				got = err.Error()
 			}
 			if strings.TrimSpace(got) != tt.want {
@@ -784,6 +786,10 @@ func TestUpdatePrefs(t *testing.T) {
 		curPrefs *ipn.Prefs
 		env      upCheckEnv // empty goos means "linux"
 
+		// checkUpdatePrefsMutations, if non-nil, is run with the new prefs after
+		// updatePrefs might've mutated them (from applyImplicitPrefs).
+		checkUpdatePrefsMutations func(t *testing.T, newPrefs *ipn.Prefs)
+
 		wantSimpleUp   bool
 		wantJustEditMP *ipn.MaskedPrefs
 		wantErrSubtr   string
@@ -885,6 +891,28 @@ func TestUpdatePrefs(t *testing.T) {
 			},
 			env: upCheckEnv{backendState: "Running"},
 		},
+		{
+			// Issue 3808: explicitly empty --operator= should clear value.
+			name:  "explicit_empty_operator",
+			flags: []string{"--operator="},
+			curPrefs: &ipn.Prefs{
+				ControlURL:       "https://login.tailscale.com",
+				CorpDNS:          true,
+				AllowSingleHosts: true,
+				NetfilterMode:    preftype.NetfilterOn,
+				OperatorUser:     "somebody",
+			},
+			env: upCheckEnv{user: "somebody", backendState: "Running"},
+			wantJustEditMP: &ipn.MaskedPrefs{
+				OperatorUserSet: true,
+				WantRunningSet:  true,
+			},
+			checkUpdatePrefsMutations: func(t *testing.T, prefs *ipn.Prefs) {
+				if prefs.OperatorUser != "" {
+					t.Errorf("operator sent to backend should be empty; got %q", prefs.OperatorUser)
+				}
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -908,6 +936,9 @@ func TestUpdatePrefs(t *testing.T) {
 					return
 				}
 				t.Fatal(err)
+			}
+			if tt.checkUpdatePrefsMutations != nil {
+				tt.checkUpdatePrefsMutations(t, newPrefs)
 			}
 			if simpleUp != tt.wantSimpleUp {
 				t.Fatalf("simpleUp=%v, want %v", simpleUp, tt.wantSimpleUp)


### PR DESCRIPTION
Fixes: #3808 

change the implicit fields checks on the `--operator` flag to allow it to be explicitly set to an empty string

Signed-off-by: soypete <miriah@tailscale.com>

