### PR TITLE
fix(docs): pass TS_ROUTES correctly as make kwargs

### DIFF
--- a/docs/k8s/README.md
+++ b/docs/k8s/README.md
@@ -112,13 +112,12 @@ the entire Kubernetes cluster network (assuming NetworkPolicies allow) over Tail
    ```bash
    SERVICE_CIDR=10.20.0.0/16
    POD_CIDR=10.42.0.0/15
-   export TS_ROUTES=$SERVICE_CIDR,$POD_CIDR
    ```
 
 1. Deploy the subnet-router pod.
 
    ```bash
-   make subnet-router
+   make TS_ROUTES=$SERVICE_CIDR,$POD_CIDR subnet-router
    # If not using an auth key, authenticate by grabbing the Login URL here:
    kubectl logs subnet-router
    ```

--- a/net/socks5/socks5_test.go
+++ b/net/socks5/socks5_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package socks5
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"testing"
+
+	"golang.org/x/net/proxy"
+)
+
+func socks5Server(listener net.Listener) {
+	var server Server
+	err := server.Serve(listener)
+	if err != nil {
+		panic(err)
+	}
+        listener.Close()
+}
+
+func backendServer(listener net.Listener) {
+	conn, err := listener.Accept()
+	if err != nil {
+		panic(err)
+	}
+	conn.Write([]byte("Test"))
+	conn.Close()
+        listener.Close()
+}
+
+func TestRead(t *testing.T) {
+	// backend server which we'll use SOCKS5 to connect to
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	backendServerPort := listener.Addr().(*net.TCPAddr).Port
+	go backendServer(listener)
+
+	// SOCKS5 server
+	socks5, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	socks5Port := socks5.Addr().(*net.TCPAddr).Port
+	go socks5Server(socks5)
+
+	addr := fmt.Sprintf("localhost:%d", socks5Port)
+	socksDialer, err := proxy.SOCKS5("tcp", addr, nil, proxy.Direct)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	addr = fmt.Sprintf("localhost:%d", backendServerPort)
+	conn, err := socksDialer.Dial("tcp", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := make([]byte, 4)
+	_, err = io.ReadFull(conn, buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(buf) != "Test" {
+		t.Fatalf("got: %q want: Test", buf)
+	}
+
+	err = conn.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -888,13 +888,20 @@ type MapRequest struct {
 	// start-up before their first real endpoint update.
 	ReadOnly bool `json:",omitempty"`
 
-	// OmitPeers is whether the client is okay with the Peers list
-	// being omitted in the response. (For example, a client on
-	// start up using ReadOnly to get the DERP map.)
+	// OmitPeers is whether the client is okay with the Peers list being omitted
+	// in the response.
+	//
+	// The behavior of OmitPeers being true varies based on Stream and ReadOnly:
 	//
 	// If OmitPeers is true, Stream is false, and ReadOnly is false,
 	// then the server will let clients update their endpoints without
 	// breaking existing long-polling (Stream == true) connections.
+	// In this case, the server can omit the entire response; the client
+	// only checks the HTTP response status code.
+	//
+	// If OmitPeers is true, Stream is false, but ReadOnly is true,
+	// then all the response fields are included. (This is what the client does
+	// when initially fetching the DERP map.)
 	OmitPeers bool `json:",omitempty"`
 
 	// DebugFlags is a list of strings specifying debugging and

--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -56,6 +56,10 @@ type Server struct {
 	//
 	// If nil, a new FileStore is initialized at `Dir/tailscaled.state`.
 	// See tailscale.com/ipn/store for supported stores.
+	//
+	// Logs will automatically be uploaded to uploaded to log.tailscale.io,
+	// where the configuration file for logging will be saved at
+	// `Dir/tailscaled.log.conf`.
 	Store ipn.StateStore
 
 	// Hostname is the hostname to present to the control server.
@@ -188,7 +192,7 @@ func (s *Server) start() error {
 		return fmt.Errorf("%v is not a directory", s.rootPath)
 	}
 
-	cfgPath := filepath.Join(s.rootPath, "tsnet.log.conf")
+	cfgPath := filepath.Join(s.rootPath, "tailscaled.log.conf")
 
 	lpc, err := logpolicy.ConfigFromFile(cfgPath)
 	switch {
@@ -205,7 +209,7 @@ func (s *Server) start() error {
 	}
 	logid := lpc.PublicID.String()
 
-	f, err := filch.New(filepath.Join(s.rootPath, "tsnet"), filch.Options{ReplaceStderr: false})
+	f, err := filch.New(filepath.Join(s.rootPath, "tailscaled"), filch.Options{ReplaceStderr: false})
 	if err != nil {
 		return fmt.Errorf("error creating filch: %w", err)
 	}


### PR DESCRIPTION
# Problem

`make subnet-router` does not pick up `TS_ROUTES` set as shell env var.

# Solution

Update docs to reflect intended `make subnet-router` effects.

# Result

Able to deploy subnet-router with shell-specified subnet routes.