### PR TITLE
/usr/bin/login on Mac requires different argument ordering

### DIFF
--- a/ssh/tailssh/incubator.go
+++ b/ssh/tailssh/incubator.go
@@ -225,7 +225,8 @@ func beIncubator(args []string) error {
 		}
 		groupIDs = append(groupIDs, int(gid))
 	}
-	if err := syscall.Setgroups(groupIDs); err != nil {
+
+	if err := setGroups(groupIDs); err != nil {
 		return err
 	}
 	if egid := os.Getegid(); egid != ia.gid {

--- a/ssh/tailssh/incubator.go
+++ b/ssh/tailssh/incubator.go
@@ -206,7 +206,7 @@ func beIncubator(args []string) error {
 		// If we are trying to launch a login shell, just exec into login
 		// instead. We can only do this if a TTY was requested, otherwise login
 		// exits immediately, which breaks things likes mosh and VSCode.
-		return unix.Exec(ia.loginCmdPath, []string{ia.loginCmdPath, "-f", ia.localUser, "-h", ia.remoteIP, "-p"}, os.Environ())
+		return unix.Exec(ia.loginCmdPath, ia.loginArgs(), os.Environ())
 	}
 
 	// Inform the system that we are about to log someone in.

--- a/ssh/tailssh/incubator_darwin.go
+++ b/ssh/tailssh/incubator_darwin.go
@@ -4,6 +4,18 @@
 
 package tailssh
 
+import "syscall"
+
 func (ia *incubatorArgs) loginArgs() []string {
 	return []string{ia.loginCmdPath, "-fp", "-h", ia.remoteIP, ia.localUser}
+}
+
+func setGroups(groupIDs []int) error {
+	// darwin returns "invalid argument" if more than 16 groups are passed to syscall.Setgroups
+	// some info can be found here:
+	// https://opensource.apple.com/source/samba/samba-187.8/patches/support-darwin-initgroups-syscall.auto.html
+	// this fix isn't great, as anyone reading this has probably just wasted hours figuring out why
+	// some permissions thing isn't working, due to some arbitrary group ordering, but it at least allows
+	// this to work for more things than it previously did.
+	return syscall.Setgroups(groupIDs[:16])
 }

--- a/ssh/tailssh/incubator_darwin.go
+++ b/ssh/tailssh/incubator_darwin.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tailssh
+
+func (ia *incubatorArgs) loginArgs() []string {
+	return []string{ia.loginCmdPath, "-fp", "-h", ia.remoteIP, ia.localUser}
+}

--- a/ssh/tailssh/incubator_linux.go
+++ b/ssh/tailssh/incubator_linux.go
@@ -177,3 +177,7 @@ func maybeStartLoginSessionLinux(logf logger.Logf, ia incubatorArgs) (func() err
 func (ia *incubatorArgs) loginArgs() []string {
 	return []string{ia.loginCmdPath, "-f", ia.localUser, "-h", ia.remoteIP, "-p"}
 }
+
+func setGroups(groupIDs []int) error {
+	return syscall.Setgroups(groupIDs)
+}

--- a/ssh/tailssh/incubator_linux.go
+++ b/ssh/tailssh/incubator_linux.go
@@ -173,3 +173,7 @@ func maybeStartLoginSessionLinux(logf logger.Logf, ia incubatorArgs) (func() err
 	}
 	return nil, nil
 }
+
+func (ia *incubatorArgs) loginArgs() []string {
+	return []string{ia.loginCmdPath, "-f", ia.localUser, "-h", ia.remoteIP, "-p"}
+}


### PR DESCRIPTION
Fixes #4931 - well seems to - with this change I am able to `ssh` in successfully.

I don't know if other versions of MacOS would be different, and I'm not sure the best way to make this conditional in the code, but thought I'd contribute this as a step in the direction of solving.

