### PR TITLE
use C:\Windows\System32\OpenSSH\ssh.exe

### DIFF
--- a/cmd/tailscale/cli/ssh.go
+++ b/cmd/tailscale/cli/ssh.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"os/user"
 	"path/filepath"
 	"runtime"
@@ -63,7 +62,7 @@ func runSSH(ctx context.Context, args []string) error {
 		hostForSSH = v
 	}
 
-	ssh, err := exec.LookPath("ssh")
+	ssh, err := findSSH()
 	if err != nil {
 		// TODO(bradfitz): use Go's crypto/ssh client instead
 		// of failing. But for now:

--- a/cmd/tailscale/cli/ssh_exec.go
+++ b/cmd/tailscale/cli/ssh_exec.go
@@ -10,8 +10,13 @@ package cli
 import (
 	"errors"
 	"os"
+	"os/exec"
 	"syscall"
 )
+
+func findSSH() (string, error) {
+	return exec.LookPath("ssh")
+}
 
 func execSSH(ssh string, argv []string) error {
 	if err := syscall.Exec(ssh, argv, os.Environ()); err != nil {

--- a/cmd/tailscale/cli/ssh_exec_js.go
+++ b/cmd/tailscale/cli/ssh_exec_js.go
@@ -8,6 +8,10 @@ import (
 	"errors"
 )
 
+func findSSH() (string, error) {
+	return "", errors.New("Not implemented")
+}
+
 func execSSH(ssh string, argv []string) error {
 	return errors.New("Not implemented")
 }

--- a/cmd/tailscale/cli/ssh_exec_windows.go
+++ b/cmd/tailscale/cli/ssh_exec_windows.go
@@ -12,6 +12,8 @@ import (
 )
 
 func findSSH() (string, error) {
+	// use C:\Windows\System32\OpenSSH\ssh.exe since unexpected behavior
+	// occured with ssh.exe provided by msys2/cygwin and other environments.
 	if systemRoot := os.Getenv("SystemRoot"); systemRoot != "" {
 		exe := filepath.Join(systemRoot, "System32", "OpenSSH", "ssh.exe")
 		if st, err := os.Stat(exe); err == nil && !st.IsDir() {

--- a/cmd/tailscale/cli/ssh_exec_windows.go
+++ b/cmd/tailscale/cli/ssh_exec_windows.go
@@ -8,7 +8,18 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"path/filepath"
 )
+
+func findSSH() (string, error) {
+	if systemRoot := os.Getenv("SystemRoot"); systemRoot != "" {
+		exe := filepath.Join(systemRoot, "System32", "OpenSSH", "ssh.exe")
+		if st, err := os.Stat(exe); err == nil && !st.IsDir() {
+			return exe, nil
+		}
+	}
+	return exec.LookPath("ssh")
+}
 
 func execSSH(ssh string, argv []string) error {
 	// Don't use syscall.Exec on Windows, it's not fully implemented.


### PR DESCRIPTION
I got problem with using msys2's ssh.exe via tailscale.exe. If typing CTRL-C, the ssh.exe is always stopped. To avoid this, I tried to add some hack for handling os.Interrupt but it seems not working with msys2 runtime. However C:\Windows\System32\OpenSSH\ssh.exe works good. Then I added code to use C:\Windows\System32\OpenSSH\ssh.exe always on Windows.