### PR TITLE
ssh/tailssh: try launching commands with /usr/bin/login on macOS

### DIFF
--- a/ssh/tailssh/incubator.go
+++ b/ssh/tailssh/incubator.go
@@ -55,6 +55,12 @@ var maybeStartLoginSession = func(logf logger.Logf, ia incubatorArgs) (close fun
 	return nil, nil
 }
 
+// on some systems, we may be able to run the coomand with login easily
+// return true if is handled. err is ignored if false is returned.
+var maybeRunCommandWithLogin = func(logf logger.Logf, ia incubatorArgs) (bool, error) {
+	return false, nil
+}
+
 // newIncubatorCommand returns a new exec.Cmd configured with
 // `tailscaled be-child ssh` as the entrypoint.
 //
@@ -111,10 +117,9 @@ func (ss *sshSession) newIncubatorCommand() *exec.Cmd {
 	} else {
 		if isShell {
 			incubatorArgs = append(incubatorArgs, "--shell")
-			// Currently (2022-05-09) `login` is only used for shells
-			if lp, err := exec.LookPath("login"); err == nil {
-				incubatorArgs = append(incubatorArgs, "--login-cmd="+lp)
-			}
+		}
+		if lp, err := exec.LookPath("login"); err == nil {
+			incubatorArgs = append(incubatorArgs, "--login-cmd="+lp)
 		}
 		incubatorArgs = append(incubatorArgs, "--cmd="+name)
 		if len(args) > 0 {
@@ -207,6 +212,13 @@ func beIncubator(args []string) error {
 		// instead. We can only do this if a TTY was requested, otherwise login
 		// exits immediately, which breaks things likes mosh and VSCode.
 		return unix.Exec(ia.loginCmdPath, ia.loginArgs(), os.Environ())
+	}
+
+	if runningAsRoot {
+		handled, err := maybeRunCommandWithLogin(logf, ia)
+		if handled {
+			return err
+		}
 	}
 
 	// Inform the system that we are about to log someone in.


### PR DESCRIPTION
Perhaps fixes some aspects of #4939 by avoiding that portion of code.
 
I really don't know if this is a good solution or not - I'm not that familiar with the internals of what happens when someone tries to login to a system. I just noticed that `/usr/bin/login` on Mac had the ability to accept program name and args, and noted this happened to fix the issue I was seeing (details in #4939).

Signed-off-by: Adam Eijdenberg <adam@continusec.com>