### PR TITLE
ssh/tailssh: always use current time for policy evaluation

### DIFF
--- a/ssh/tailssh/tailssh_test.go
+++ b/ssh/tailssh/tailssh_test.go
@@ -179,7 +179,6 @@ func TestMatchRule(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &conn{
-				now:  time.Unix(200, 0),
 				info: tt.ci,
 			}
 			got, gotUser, err := c.matchRule(tt.rule, nil)


### PR DESCRIPTION
Whenever the SSH policy changes we revaluate all open connections to
make sure they still have access. This check was using the wrong
timestamp and would match against expired policies, however this really
isn't a problem today as we don't have policy that would be impacted by
this check. Fixing it for future use.

Signed-off-by: Maisem Ali <maisem@tailscale.com>