### PR TITLE
cmd/tailscale: move call to cli.CleanUpArgs() from main() into cli.Run()

### DIFF
--- a/cmd/tailscale/cli/cli.go
+++ b/cmd/tailscale/cli/cli.go
@@ -129,6 +129,8 @@ var localClient tailscale.LocalClient
 
 // Run runs the CLI. The args do not include the binary name.
 func Run(args []string) (err error) {
+	args = CleanUpArgs(args)
+
 	if len(args) == 1 && (args[0] == "-V" || args[0] == "--version") {
 		args = []string{"version"}
 	}

--- a/cmd/tailscale/tailscale.go
+++ b/cmd/tailscale/tailscale.go
@@ -17,7 +17,6 @@ import (
 
 func main() {
 	args := os.Args[1:]
-	args = cli.CleanUpArgs(args)
 	if name, _ := os.Executable(); strings.HasSuffix(filepath.Base(name), ".cgi") {
 		args = []string{"web", "-cgi"}
 	}


### PR DESCRIPTION
Not all distributions build from package main.

Signed-off-by: Jordan Whited <jordan@tailscale.com>