### PR TITLE
wgengine/netstack: close ipstack when netstack.Impl is closed

### DIFF
--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -201,6 +201,7 @@ func Create(logf logger.Logf, tundev *tstun.Wrapper, e wgengine.Engine, mc *magi
 
 func (ns *Impl) Close() error {
 	ns.ctxCancel()
+	ns.ipstack.Close()
 	return nil
 }
 


### PR DESCRIPTION
Fixes netstack.Impl leaking goroutines after shutdown.