### PR TITLE
.github/workflows: downgrade MinGW to work around windows-race failures

### DIFF
--- a/.github/workflows/windows-race.yml
+++ b/.github/workflows/windows-race.yml
@@ -46,6 +46,14 @@ jobs:
     - name: Print toolchain details
       run: gcc -v
 
+    # There is currently an issue in the race detector in Go on Windows when
+    # used with a newer version of GCC.
+    # See https://github.com/tailscale/tailscale/issues/4926.
+    - name: Downgrade MinGW
+      shell: bash
+      run: |
+        choco install mingw --version 10.2.0 --allow-downgrade
+
     - name: Test with -race flag
       # Don't use -bench=. -benchtime=1x.
       # Somewhere in the layers (powershell?)


### PR DESCRIPTION
Updates #4926

Signed-off-by: Mihai Parparita <mihai@tailscale.com>