### PR TITLE
Add env vars for enabling socks5 and http proxies

### DIFF
--- a/docs/k8s/run.sh
+++ b/docs/k8s/run.sh
@@ -14,6 +14,9 @@ TS_USERSPACE="${TS_USERSPACE:-true}"
 TS_STATE_DIR="${TS_STATE_DIR:-}"
 TS_ACCEPT_DNS="${TS_ACCEPT_DNS:-false}"
 TS_KUBE_SECRET="${TS_KUBE_SECRET:-tailscale}"
+TS_SOCKS5_SERVER="${TS_SOCKS5_SERVER:-}"
+TS_OUTBOUND_HTTP_PROXY_LISTEN="${TS_OUTBOUND_HTTP_PROXY_LISTEN:-}"
+TS_TAILSCALED_EXTRA_ARGS="${TS_TAILSCALED_EXTRA_ARGS:-}"
 
 set -e
 
@@ -41,6 +44,18 @@ else
   if [[ ! -c /dev/net/tun ]]; then
     mknod /dev/net/tun c 10 200
   fi
+fi
+
+if [[ ! -z "${TS_SOCKS5_SERVER}" ]]; then
+  TAILSCALED_ARGS="${TAILSCALED_ARGS} --socks5-server ${TS_SOCKS5_SERVER}"
+fi
+
+if [[ ! -z "${TS_OUTBOUND_HTTP_PROXY_LISTEN}" ]]; then
+  TAILSCALED_ARGS="${TAILSCALED_ARGS} --outbound-http-proxy-listen ${TS_OUTBOUND_HTTP_PROXY_LISTEN}"
+fi
+
+if [[ ! -z "${TS_TAILSCALED_EXTRA_ARGS}" ]]; then
+  TAILSCALED_ARGS="${TAILSCALED_ARGS} ${TS_TAILSCALED_EXTRA_ARGS}"
 fi
 
 echo "Starting tailscaled"


### PR DESCRIPTION
- TSD_SOCKS5_SERVER, argument passed to tailscaled --socks5-server
- TSD_HTTP_PROXY, argument passed to tailscaled -outbound-http-proxy-listen
- TSD_EXTRA_ARGS extra arguments passed to tailscaled

Fixes #4985

Signed-off-by: Craig Rodrigues <rodrigc@crodrigues.org>