### PR TITLE
tailcfg: add HTTPForTests to enable non-TLS servers in testing

### DIFF
--- a/derp/derphttp/derphttp_client.go
+++ b/derp/derphttp/derphttp_client.go
@@ -178,7 +178,10 @@ func (c *Client) targetString(reg *tailcfg.DERPRegion) string {
 	return fmt.Sprintf("region %d (%v)", reg.RegionID, reg.RegionCode)
 }
 
-func (c *Client) useHTTPS() bool {
+func (c *Client) useHTTPS(node *tailcfg.DERPNode) bool {
+	if node.HTTPForTests {
+		return false
+	}
 	if c.url != nil && c.url.Scheme == "http" {
 		return false
 	}
@@ -364,7 +367,7 @@ func (c *Client) connect(ctx context.Context, caller string) (client *derp.Clien
 	var serverPub key.NodePublic // or zero if unknown (if not using TLS or TLS middlebox eats it)
 	var serverProtoVersion int
 	var tlsState *tls.ConnectionState
-	if c.useHTTPS() {
+	if c.useHTTPS(node) {
 		tlsConn := c.tlsClient(tcpConn, node)
 		httpConn = tlsConn
 

--- a/tailcfg/derpmap.go
+++ b/tailcfg/derpmap.go
@@ -140,6 +140,10 @@ type DERPNode struct {
 	// It should not be set by users.
 	InsecureForTests bool `json:",omitempty"`
 
+	// HTTPForTests is used by unit tests to force HTTP.
+	// It should not be set by users.
+	HTTPForTests bool `json:",omitempty"`
+
 	// STUNTestIP is used in tests to override the STUN server's IP.
 	// If empty, it's assumed to be the same as the DERP server.
 	STUNTestIP string `json:",omitempty"`

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -321,6 +321,7 @@ var _DERPNodeCloneNeedsRegeneration = DERPNode(struct {
 	STUNOnly         bool
 	DERPPort         int
 	InsecureForTests bool
+	HTTPForTests     bool
 	STUNTestIP       string
 }{})
 

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -743,6 +743,7 @@ func (v DERPNodeView) STUNPort() int          { return v.ж.STUNPort }
 func (v DERPNodeView) STUNOnly() bool         { return v.ж.STUNOnly }
 func (v DERPNodeView) DERPPort() int          { return v.ж.DERPPort }
 func (v DERPNodeView) InsecureForTests() bool { return v.ж.InsecureForTests }
+func (v DERPNodeView) HTTPForTests() bool     { return v.ж.HTTPForTests}
 func (v DERPNodeView) STUNTestIP() string     { return v.ж.STUNTestIP }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
@@ -757,5 +758,6 @@ var _DERPNodeViewNeedsRegeneration = DERPNode(struct {
 	STUNOnly         bool
 	DERPPort         int
 	InsecureForTests bool
+	HTTPForTests     bool
 	STUNTestIP       string
 }{})


### PR DESCRIPTION
DERP currently requires HTTPS for tests with derphttp.NewRegionClient, as
there is no way to force HTTP. This adds a new HTTPForTests property to
DERPNode to force HTTP.

It seems potentially excessive to add an option to tailcfg.DERPMap for this case,
as NewClient consumes a URL that would determine whether HTTPS is used. I'm
very open to feedback on this approach, and happy to entirely change it!