### PR TITLE
util/cloudenv: avoid goroutine leak from gcpmetadata.OnGCE()

### DIFF
--- a/util/cloudenv/cloudenv.go
+++ b/util/cloudenv/cloudenv.go
@@ -6,6 +6,7 @@
 package cloudenv
 
 import (
+	"flag"
 	"os"
 	"runtime"
 	"strings"
@@ -77,9 +78,13 @@ func getCloud() Cloud {
 			return AWS
 		}
 	}
-	if gcpmetadata.OnGCE() {
+	// gcpmetadata.OnGCE leaks goroutines, avoid calling it in tests (which
+	// never run on GCP).
+	if !inTest() && gcpmetadata.OnGCE() {
 		return GCP
 	}
 	// TODO: more, as needed.
 	return ""
 }
+
+func inTest() bool { return flag.Lookup("test.v") != nil }


### PR DESCRIPTION
gcpmetadata.OnGCE() races multiple goroutines to determine if we're on
GCP, which trips up E2E tests in corp. For now avoid calling it
altogether under tests.

Signed-off-by: Mihai Parparita <mihai@tailscale.com>