### PR TITLE
WIP: tolerate ip6tables failures.

### DIFF
--- a/wgengine/router/router_linux.go
+++ b/wgengine/router/router_linux.go
@@ -1081,7 +1081,14 @@ func (r *linuxRouter) addNetfilterChains() error {
 
 	for _, ipt := range r.netfilterFamilies() {
 		if err := create(ipt, "filter", "ts-input"); err != nil {
-			return err
+			if ipt == r.ipt6 {
+				r.v6Available = false
+				r.v6NATAvailable = false
+				r.logf("addNetfilterChains ipt6 failed, disabling IPv6 and continuing. Error was: %v", err)
+				continue
+			} else {
+				return err
+			}
 		}
 		if err := create(ipt, "filter", "ts-forward"); err != nil {
 			return err
@@ -1106,7 +1113,8 @@ func (r *linuxRouter) addNetfilterBase() error {
 	}
 	if r.v6Available {
 		if err := r.addNetfilterBase6(); err != nil {
-			return err
+			r.v6Available = false
+			r.logf("addNetfilterBase6 failed, disabling IPv6 and continuing. Error was: %v", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
It comes up reasonably often that a host has IPv6 configured
but broken or non-functional in some way. One recent example is
https://github.com/gitpod-io/gitpod/issues/8049 where the sypmtoms
were:
1. an error message and health check failure about ip6tables
2. MagicDNS didn't work, even for IPv4

MagicDNS is broken because the failure to initialize IPv6 returns
an error which stops the rest of the initialization. I think we
have another case where IPv6 failing results in not acceping IPv4
subnet routes. Clearly we'd prefer not to have subsets of
functionality be mysteriously broken.

This PR is not the right way to do it, but serves as a proof of concept
that tolerating IPv6 failures results in fixing https://github.com/gitpod-io/gitpod/issues/8049
without needing the workaround which gitpod put together.