### PR TITLE
logpolicy: fix config initialization bug

### DIFF
--- a/logpolicy/logpolicy.go
+++ b/logpolicy/logpolicy.go
@@ -112,6 +112,8 @@ func NewConfig(collection string) *Config {
 // and that the PrivateID and PublicID pair are sensible.
 func (c *Config) Validate(collection string) error {
 	switch {
+	case c == nil:
+		return errors.New("config is nil")
 	case c.Collection != collection:
 		return fmt.Errorf("config collection %q does not match %q", c.Collection, collection)
 	case c.PrivateID.IsZero():
@@ -509,11 +511,10 @@ func New(collection string) *Policy {
 	newc, err := ConfigFromFile(cfgPath)
 	if err != nil {
 		earlyLogf("logpolicy.ConfigFromFile %v: %v", cfgPath, err)
-		newc = NewConfig(collection)
 	}
 	if err := newc.Validate(collection); err != nil {
-		earlyLogf("logpolicy.Config.Validate for %q: %v", cfgPath, err)
-		newc := NewConfig(collection)
+		earlyLogf("logpolicy.Config.Validate for %v: %v", cfgPath, err)
+		newc = NewConfig(collection)
 		if err := newc.Save(cfgPath); err != nil {
 			earlyLogf("logpolicy.Config.Save for %v: %v", cfgPath, err)
 		}


### PR DESCRIPTION
If ConfigFromFile cannot find the configuration file,
we must not initialize it with NewConfig.
Instead, we need it to fail validation so that it eventually writes
a newly constructed configuration file.
Otherwise, new tailscale instances will never be able store a persistent
log config and start with a new config file upon every bootup.

Signed-off-by: Joe Tsai <joetsai@digital-static.net>