### PR TITLE
ipn/localapi: add API for uploading client metrics

### DIFF
--- a/util/clientmetric/clientmetric.go
+++ b/util/clientmetric/clientmetric.go
@@ -136,6 +136,15 @@ func Metrics() []*Metric {
 	return sorted
 }
 
+// HasPublished reports whether a metric with the given name has already been
+// published.
+func HasPublished(name string) bool {
+	mu.Lock()
+	defer mu.Unlock()
+	_, ok := metrics[name]
+	return ok
+}
+
 // NewUnpublished initializes a new Metric without calling Publish on
 // it.
 func NewUnpublished(name string, typ Type) *Metric {


### PR DESCRIPTION
Clients may have platform-specific metrics they would like uploaded
(e.g. extracted from MetricKit on iOS). Add a new local API endpoint
that allows metrics to be updated by a simple name/value JSON-encoded
struct.

Signed-off-by: Mihai Parparita <mihai@tailscale.com>