### PR TITLE
tsweb: add Float expvar support in varz

### DIFF
--- a/tsweb/tsweb.go
+++ b/tsweb/tsweb.go
@@ -466,6 +466,12 @@ func writePromExpVar(w io.Writer, prefix string, kv expvar.KeyValue) {
 		}
 		fmt.Fprintf(w, "# TYPE %s %s\n%s %v\n", name, typ, name, v.Value())
 		return
+	case *expvar.Float:
+		if typ == "" {
+			typ = "gauge"
+		}
+		fmt.Fprintf(w, "# TYPE %s %s\n%s %v\n", name, typ, name, v.Value())
+		return
 	case *metrics.Set:
 		v.Do(func(kv expvar.KeyValue) {
 			writePromExpVar(w, name+"_", kv)

--- a/tsweb/tsweb_test.go
+++ b/tsweb/tsweb_test.go
@@ -334,6 +334,9 @@ func TestVarzHandler(t *testing.T) {
 		t.Logf("Got: %s", rec.Body.Bytes())
 	})
 
+	half := new(expvar.Float)
+	half.Set(0.5)
+
 	tests := []struct {
 		name string
 		k    string // key name
@@ -357,6 +360,31 @@ func TestVarzHandler(t *testing.T) {
 			"gauge_foo",
 			new(expvar.Int),
 			"# TYPE foo gauge\nfoo 0\n",
+		},
+		{
+			// For a float = 0.0, Prometheus client_golang outputs "0"
+			"float_zero",
+			"foo",
+			new(expvar.Float),
+			"# TYPE foo gauge\nfoo 0\n",
+		},
+		{
+			"float_point_5",
+			"foo",
+			half,
+			"# TYPE foo gauge\nfoo 0.5\n",
+		},
+		{
+			"float_with_type_counter",
+			"counter_foo",
+			half,
+			"# TYPE foo counter\nfoo 0.5\n",
+		},
+		{
+			"float_with_type_gauge",
+			"gauge_foo",
+			half,
+			"# TYPE foo gauge\nfoo 0.5\n",
 		},
 		{
 			"metrics_set",


### PR DESCRIPTION
We make assertions about stringification of 0.5. IEEE floating point and
all reasonable proprietary floating point can exactly represent 0.5.
We don't make assertions about other floating point values, too brittle
in tests.

Signed-off-by: Denton Gentry <dgentry@tailscale.com>