### PR TITLE
cmd/{cloner,viewer}: add support for map of structs without pointers

### DIFF
--- a/cmd/viewer/tests/tests.go
+++ b/cmd/viewer/tests/tests.go
@@ -32,6 +32,7 @@ type Map struct {
 	SliceIntPtr      map[string][]*int
 	PointerKey       map[*string]int        `json:"-"`
 	StructWithPtrKey map[StructWithPtrs]int `json:"-"`
+	StructWithPtr    map[string]StructWithPtrs
 }
 
 type StructWithPtrs struct {

--- a/cmd/viewer/tests/tests.go
+++ b/cmd/viewer/tests/tests.go
@@ -21,13 +21,14 @@ type StructWithoutPtrs struct {
 type Map struct {
 	Int                 map[string]int
 	SliceInt            map[string][]int
-	StructWithPtr       map[string]*StructWithPtrs
-	StructWithoutPtr    map[string]*StructWithoutPtrs
+	StructPtrWithPtr    map[string]*StructWithPtrs
+	StructPtrWithoutPtr map[string]*StructWithoutPtrs
+	StructWithoutPtr    map[string]StructWithoutPtrs
 	SlicesWithPtrs      map[string][]*StructWithPtrs
 	SlicesWithoutPtrs   map[string][]*StructWithoutPtrs
 	StructWithoutPtrKey map[StructWithoutPtrs]int `json:"-"`
 
-	// Unsupported.
+	// Unsupported views.
 	SliceIntPtr      map[string][]*int
 	PointerKey       map[*string]int        `json:"-"`
 	StructWithPtrKey map[StructWithPtrs]int `json:"-"`

--- a/cmd/viewer/tests/tests_clone.go
+++ b/cmd/viewer/tests/tests_clone.go
@@ -73,16 +73,22 @@ func (src *Map) Clone() *Map {
 			dst.SliceInt[k] = append([]int{}, src.SliceInt[k]...)
 		}
 	}
-	if dst.StructWithPtr != nil {
-		dst.StructWithPtr = map[string]*StructWithPtrs{}
-		for k, v := range src.StructWithPtr {
-			dst.StructWithPtr[k] = v.Clone()
+	if dst.StructPtrWithPtr != nil {
+		dst.StructPtrWithPtr = map[string]*StructWithPtrs{}
+		for k, v := range src.StructPtrWithPtr {
+			dst.StructPtrWithPtr[k] = v.Clone()
+		}
+	}
+	if dst.StructPtrWithoutPtr != nil {
+		dst.StructPtrWithoutPtr = map[string]*StructWithoutPtrs{}
+		for k, v := range src.StructPtrWithoutPtr {
+			dst.StructPtrWithoutPtr[k] = v.Clone()
 		}
 	}
 	if dst.StructWithoutPtr != nil {
-		dst.StructWithoutPtr = map[string]*StructWithoutPtrs{}
+		dst.StructWithoutPtr = map[string]StructWithoutPtrs{}
 		for k, v := range src.StructWithoutPtr {
-			dst.StructWithoutPtr[k] = v.Clone()
+			dst.StructWithoutPtr[k] = v
 		}
 	}
 	if dst.SlicesWithPtrs != nil {
@@ -128,8 +134,9 @@ func (src *Map) Clone() *Map {
 var _MapCloneNeedsRegeneration = Map(struct {
 	Int                 map[string]int
 	SliceInt            map[string][]int
-	StructWithPtr       map[string]*StructWithPtrs
-	StructWithoutPtr    map[string]*StructWithoutPtrs
+	StructPtrWithPtr    map[string]*StructWithPtrs
+	StructPtrWithoutPtr map[string]*StructWithoutPtrs
+	StructWithoutPtr    map[string]StructWithoutPtrs
 	SlicesWithPtrs      map[string][]*StructWithPtrs
 	SlicesWithoutPtrs   map[string][]*StructWithoutPtrs
 	StructWithoutPtrKey map[StructWithoutPtrs]int

--- a/cmd/viewer/tests/tests_clone.go
+++ b/cmd/viewer/tests/tests_clone.go
@@ -127,6 +127,13 @@ func (src *Map) Clone() *Map {
 			dst.StructWithPtrKey[k] = v
 		}
 	}
+	if dst.StructWithPtr != nil {
+		dst.StructWithPtr = map[string]StructWithPtrs{}
+		for k, v := range src.StructWithPtr {
+			v2 := v.Clone()
+			dst.StructWithPtr[k] = *v2
+		}
+	}
 	return dst
 }
 
@@ -143,6 +150,7 @@ var _MapCloneNeedsRegeneration = Map(struct {
 	SliceIntPtr         map[string][]*int
 	PointerKey          map[*string]int
 	StructWithPtrKey    map[StructWithPtrs]int
+	StructWithPtr       map[string]StructWithPtrs
 }{})
 
 // Clone makes a deep copy of StructWithSlices.

--- a/cmd/viewer/tests/tests_view.go
+++ b/cmd/viewer/tests/tests_view.go
@@ -231,6 +231,12 @@ func (v MapView) SliceIntPtr() map[string][]*int           { panic("unsupported"
 func (v MapView) PointerKey() map[*string]int              { panic("unsupported") }
 func (v MapView) StructWithPtrKey() map[StructWithPtrs]int { panic("unsupported") }
 
+func (v MapView) StructWithPtr() views.MapFn[string, StructWithPtrs, StructWithPtrsView] {
+	return views.MapFnOf(v.ж.StructWithPtr, func(t StructWithPtrs) StructWithPtrsView {
+		return t.View()
+	})
+}
+
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _MapViewNeedsRegeneration = Map(struct {
 	Int                 map[string]int
@@ -244,6 +250,7 @@ var _MapViewNeedsRegeneration = Map(struct {
 	SliceIntPtr         map[string][]*int
 	PointerKey          map[*string]int
 	StructWithPtrKey    map[StructWithPtrs]int
+	StructWithPtr       map[string]StructWithPtrs
 }{})
 
 // View returns a readonly view of StructWithSlices.

--- a/cmd/viewer/tests/tests_view.go
+++ b/cmd/viewer/tests/tests_view.go
@@ -196,16 +196,20 @@ func (v MapView) SliceInt() views.MapFn[string, []int, views.Slice[int]] {
 	})
 }
 
-func (v MapView) StructWithPtr() views.MapFn[string, *StructWithPtrs, StructWithPtrsView] {
-	return views.MapFnOf(v.ж.StructWithPtr, func(t *StructWithPtrs) StructWithPtrsView {
+func (v MapView) StructPtrWithPtr() views.MapFn[string, *StructWithPtrs, StructWithPtrsView] {
+	return views.MapFnOf(v.ж.StructPtrWithPtr, func(t *StructWithPtrs) StructWithPtrsView {
 		return t.View()
 	})
 }
 
-func (v MapView) StructWithoutPtr() views.MapFn[string, *StructWithoutPtrs, StructWithoutPtrsView] {
-	return views.MapFnOf(v.ж.StructWithoutPtr, func(t *StructWithoutPtrs) StructWithoutPtrsView {
+func (v MapView) StructPtrWithoutPtr() views.MapFn[string, *StructWithoutPtrs, StructWithoutPtrsView] {
+	return views.MapFnOf(v.ж.StructPtrWithoutPtr, func(t *StructWithoutPtrs) StructWithoutPtrsView {
 		return t.View()
 	})
+}
+
+func (v MapView) StructWithoutPtr() views.Map[string, StructWithoutPtrs] {
+	return views.MapOf(v.ж.StructWithoutPtr)
 }
 
 func (v MapView) SlicesWithPtrs() views.MapFn[string, []*StructWithPtrs, views.SliceView[*StructWithPtrs, StructWithPtrsView]] {
@@ -231,8 +235,9 @@ func (v MapView) StructWithPtrKey() map[StructWithPtrs]int { panic("unsupported"
 var _MapViewNeedsRegeneration = Map(struct {
 	Int                 map[string]int
 	SliceInt            map[string][]int
-	StructWithPtr       map[string]*StructWithPtrs
-	StructWithoutPtr    map[string]*StructWithoutPtrs
+	StructPtrWithPtr    map[string]*StructWithPtrs
+	StructPtrWithoutPtr map[string]*StructWithoutPtrs
+	StructWithoutPtr    map[string]StructWithoutPtrs
 	SlicesWithPtrs      map[string][]*StructWithPtrs
 	SlicesWithoutPtrs   map[string][]*StructWithoutPtrs
 	StructWithoutPtrKey map[StructWithoutPtrs]int

--- a/cmd/viewer/viewer.go
+++ b/cmd/viewer/viewer.go
@@ -224,6 +224,15 @@ func genView(buf *bytes.Buffer, it *codegen.ImportTracker, typ *types.Named, thi
 			mElem := m.Elem()
 			var template string
 			switch u := mElem.(type) {
+			case *types.Struct, *types.Named:
+				strucT := u
+				args.FieldType = it.QualifiedName(fieldType)
+				if codegen.ContainsPointers(strucT) {
+					writeTemplate("unsupportedField")
+					continue
+				}
+				template = "mapField"
+				args.MapValueType = it.QualifiedName(mElem)
 			case *types.Basic:
 				template = "mapField"
 				args.MapValueType = it.QualifiedName(mElem)

--- a/cmd/viewer/viewer.go
+++ b/cmd/viewer/viewer.go
@@ -228,11 +228,14 @@ func genView(buf *bytes.Buffer, it *codegen.ImportTracker, typ *types.Named, thi
 				strucT := u
 				args.FieldType = it.QualifiedName(fieldType)
 				if codegen.ContainsPointers(strucT) {
-					writeTemplate("unsupportedField")
-					continue
+					args.MapFn = "t.View()"
+					template = "mapFnField"
+					args.MapValueType = it.QualifiedName(mElem)
+					args.MapValueView = args.MapValueType + "View"
+				} else {
+					template = "mapField"
+					args.MapValueType = it.QualifiedName(mElem)
 				}
-				template = "mapField"
-				args.MapValueType = it.QualifiedName(mElem)
 			case *types.Basic:
 				template = "mapField"
 				args.MapValueType = it.QualifiedName(mElem)


### PR DESCRIPTION
This adds support for fields like `map[string]netaddr.IPPrefix`.

Signed-off-by: Maisem Ali <maisem@tailscale.com>