### PR TITLE
cmd/tailscaled: fix Windows "Allow local LAN access" regression

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -161,7 +161,7 @@ func main() {
 	flag.Parse()
 	if flag.NArg() > 0 {
 		// Windows subprocess is spawned with /subprocess, so we need to avoid this check there.
-		if runtime.GOOS != "windows" || flag.Arg(0) != "/subproc" {
+		if runtime.GOOS != "windows" || (flag.Arg(0) != "/subproc" && flag.Arg(0) != "/firewall") {
 			log.Fatalf("tailscaled does not take non-flag arguments: %q", flag.Args())
 		}
 	}


### PR DESCRIPTION
3f686688a6cff regressed the Windows beFirewallKillswitch code,
preventing the /firewall subprocess from running.

Fixes tailscale/corp#6063
