### PR TITLE
net/dns: add Windows group policy notifications to the NRPT rule manager

### DIFF
--- a/net/dns/manager.go
+++ b/net/dns/manager.go
@@ -370,8 +370,8 @@ type dnsTCPSession struct {
 	conn    net.Conn
 	srcAddr netaddr.IPPort
 
-	readClosing  chan struct{}
-	responses    chan []byte // DNS replies pending writing
+	readClosing chan struct{}
+	responses   chan []byte // DNS replies pending writing
 
 	ctx      context.Context
 	closeCtx context.CancelFunc
@@ -457,11 +457,11 @@ func (s *dnsTCPSession) handleReads() {
 // servicing DNS requests sent down it.
 func (m *Manager) HandleTCPConn(conn net.Conn, srcAddr netaddr.IPPort) {
 	s := dnsTCPSession{
-		m:            m,
-		conn:         conn,
-		srcAddr:      srcAddr,
-		responses:    make(chan []byte),
-		readClosing:  make(chan struct{}),
+		m:           m,
+		conn:        conn,
+		srcAddr:     srcAddr,
+		responses:   make(chan []byte),
+		readClosing: make(chan struct{}),
 	}
 	s.ctx, s.closeCtx = context.WithCancel(m.ctx)
 	go s.handleReads()

--- a/net/dns/manager_windows.go
+++ b/net/dns/manager_windows.go
@@ -297,7 +297,11 @@ func (m windowsManager) SupportsSplitDNS() bool {
 }
 
 func (m windowsManager) Close() error {
-	return m.SetDNS(OSConfig{})
+	err := m.SetDNS(OSConfig{})
+	if m.nrptDB != nil {
+		m.nrptDB.Close()
+	}
+	return err
 }
 
 // disableDynamicUpdates sets the appropriate registry values to prevent the


### PR DESCRIPTION
As discussed in previous PRs, we can register for notifications when group
policies are updated and act accordingly.

This patch changes nrptRuleDatabase to receive notifications that group policy
has changed and automatically move our NRPT rules between the local and
group policy subkeys as needed.