### PR TITLE
.github/workflows: update module that we try to build in cross-wasm

### DIFF
--- a/.github/workflows/cross-wasm.yml
+++ b/.github/workflows/cross-wasm.yml
@@ -25,11 +25,11 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
 
-    - name: Wasm build CLI and client modules
+    - name: Wasm client build
       env:
         GOOS: js
         GOARCH: wasm
-      run: go build ./cmd/tailscale/cli ./ipn/... ./net/... ./safesocket ./types/... ./wgengine/...
+      run: go build ./cmd/tsconnect/wasm
 
     - uses: k0kubun/action-slack@v2.0.0
       with:

--- a/tstest/jsdeps/jsdeps.go
+++ b/tstest/jsdeps/jsdeps.go
@@ -4,8 +4,8 @@
 
 // Package jsdeps is a just a list of the packages we import in the
 // JavaScript/WASM build, to let us test that our transitive closure of
-// dependencies on iOS doesn't accidentally grow too large, since binary size
-// is more of a concern there.
+// dependencies doesn't accidentally grow too large, since binary size
+// is more of a concern.
 package jsdeps
 
 import (


### PR DESCRIPTION
We now have the actual module that we need to build, so switch to
building it directly instead of its (expected) dependencies.

Also fix a copy/paste error in a jsdeps comment.

Signed-off-by: Mihai Parparita <mihai@tailscale.com>