### PR TITLE
tailcfg: remove old DNS fields

### DIFF
--- a/control/controlclient/map.go
+++ b/control/controlclient/map.go
@@ -165,12 +165,6 @@ func (ms *mapSession) netmapForResponse(resp *tailcfg.MapResponse) *netmap.Netwo
 		}
 		ms.addUserProfile(peer.User)
 	}
-	if len(resp.DNS) > 0 {
-		nm.DNS.Nameservers = resp.DNS
-	}
-	if len(resp.SearchPaths) > 0 {
-		nm.DNS.Domains = resp.SearchPaths
-	}
 	if Debug.ProxyDNS {
 		nm.DNS.Proxied = true
 	}

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -1245,14 +1245,6 @@ type MapResponse struct {
 	// OnlineChange changes the value of a Peer Node.Online value.
 	OnlineChange map[NodeID]bool `json:",omitempty"`
 
-	// DNS is the same as DNSConfig.Nameservers.
-	// Only populated if MapRequest.Version < 9.
-	DNS []netaddr.IP `json:",omitempty"`
-
-	// SearchPaths is the old way to specify DNS search domains.
-	// Only populated if MapRequest.Version < 9.
-	SearchPaths []string `json:",omitempty"`
-
 	// DNSConfig contains the DNS settings for the client to use.
 	// A nil value means no change from an earlier non-nil value.
 	DNSConfig *DNSConfig `json:",omitempty"`


### PR DESCRIPTION
The control plane server doesn't send these to modern clients so we
don't need them in the tree. The server has its own serialization code
to generate legacy MapResponses when needed.
