### PR TITLE
tailcfg, control/controlclient: add tailcfg.PeersChangedPatch [capver 33]

### DIFF
--- a/control/controlclient/map.go
+++ b/control/controlclient/map.go
@@ -5,6 +5,7 @@
 package controlclient
 
 import (
+	"fmt"
 	"log"
 	"sort"
 
@@ -238,7 +239,7 @@ func undeltaPeers(mapRes *tailcfg.MapResponse, prev []*tailcfg.Node) {
 		sortNodes(newFull)
 	}
 
-	if len(mapRes.PeerSeenChange) != 0 || len(mapRes.OnlineChange) != 0 {
+	if len(mapRes.PeerSeenChange) != 0 || len(mapRes.OnlineChange) != 0 || len(mapRes.PeersChangedPatch) != 0 {
 		peerByID := make(map[tailcfg.NodeID]*tailcfg.Node, len(newFull))
 		for _, n := range newFull {
 			peerByID[n.ID] = n
@@ -257,6 +258,16 @@ func undeltaPeers(mapRes *tailcfg.MapResponse, prev []*tailcfg.Node) {
 			if n, ok := peerByID[nodeID]; ok {
 				online := online
 				n.Online = &online
+			}
+		}
+		for _, ec := range mapRes.PeersChangedPatch {
+			if n, ok := peerByID[ec.NodeID]; ok {
+				if ec.DERPRegion != 0 {
+					n.DERP = fmt.Sprintf("%s:%v", tailcfg.DerpMagicIP, ec.DERPRegion)
+				}
+				if ec.Endpoints != nil {
+					n.Endpoints = ec.Endpoints
+				}
 			}
 		}
 	}

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -442,14 +442,7 @@ func (c *Conn) addDerpPeerRoute(peer key.NodePublic, derpID int, dc *derphttp.Cl
 	mak.Set(&c.derpRoute, peer, derpRoute{derpID, dc})
 }
 
-// DerpMagicIP is a fake WireGuard endpoint IP address that means
-// to use DERP. When used, the port number of the WireGuard endpoint
-// is the DERP server number to use.
-//
-// Mnemonic: 3.3.40 are numbers above the keys D, E, R, P.
-const DerpMagicIP = "127.3.3.40"
-
-var derpMagicIPAddr = netaddr.MustParseIP(DerpMagicIP)
+var derpMagicIPAddr = netaddr.MustParseIP(tailcfg.DerpMagicIP)
 
 // activeDerp contains fields for an active DERP connection.
 type activeDerp struct {


### PR DESCRIPTION
This adds a lighter mechanism for endpoint updates from control.
