### PR TITLE
docs/k8s: use job control in run.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,3 +72,4 @@ FROM alpine:3.16
 RUN apk add --no-cache ca-certificates iptables iproute2 ip6tables
 
 COPY --from=build-env /go/bin/* /usr/local/bin/
+COPY --from=build-env /go/src/tailscale/docs/k8s/run.sh /usr/local/bin/

--- a/docs/k8s/run.sh
+++ b/docs/k8s/run.sh
@@ -4,6 +4,8 @@
 
 #! /bin/sh
 
+set -m # enable job control
+
 export PATH=$PATH:/tailscale/bin
 
 TS_AUTH_KEY="${TS_AUTH_KEY:-}"
@@ -60,7 +62,6 @@ fi
 
 echo "Starting tailscaled"
 tailscaled ${TAILSCALED_ARGS} &
-PID=$!
 
 UP_ARGS="--accept-dns=${TS_ACCEPT_DNS}"
 if [[ ! -z "${TS_ROUTES}" ]]; then
@@ -81,4 +82,4 @@ if [[ ! -z "${TS_DEST_IP}" ]]; then
   iptables -t nat -I PREROUTING -d "$(tailscale --socket=/tmp/tailscaled.sock ip -4)" -j DNAT --to-destination "${TS_DEST_IP}"
 fi
 
-wait ${PID}
+fg


### PR DESCRIPTION
This has the benefit of propagating SIGINT to tailscaled, which in turn
can react to the event and logout in case of an ephemeral node.

Also fix missing run.sh in Dockerfile.

Signed-off-by: Maisem Ali <maisem@tailscale.com>