### PR TITLE
ipn/ipnlocal: blend existing host SSH keys + newly-generated types as needed

### DIFF
--- a/ipn/ipnlocal/ssh_test.go
+++ b/ipn/ipnlocal/ssh_test.go
@@ -15,7 +15,7 @@ import (
 func TestSSHKeyGen(t *testing.T) {
 	dir := t.TempDir()
 	lb := &LocalBackend{varRoot: dir}
-	keys, err := lb.getTailscaleSSH_HostKeys()
+	keys, err := lb.getTailscaleSSH_HostKeys(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +32,7 @@ func TestSSHKeyGen(t *testing.T) {
 		t.Fatalf("keys = %v; want %v", got, want)
 	}
 
-	keys2, err := lb.getTailscaleSSH_HostKeys()
+	keys2, err := lb.getTailscaleSSH_HostKeys(nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
If the host only has RSA, use its RSA + generate ecdsa + ed25519, etc.

Perhaps fixes https://twitter.com/colek42c/status/1550554439299244032 and something else that was reported.
