### PR TITLE
QNAP: buffer logs & disable SSH

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1877,6 +1877,9 @@ func (b *LocalBackend) checkSSHPrefsLocked(p *ipn.Prefs) error {
 		if distro.Get() == distro.Synology && !envknob.UseWIPCode() {
 			return errors.New("The Tailscale SSH server does not run on Synology.")
 		}
+		if distro.Get() == distro.QNAP && !envknob.UseWIPCode() {
+			return errors.New("The Tailscale SSH server does not run on QNAP.")
+		}
 		// otherwise okay
 	case "darwin":
 		// okay only in tailscaled mode for now.

--- a/logpolicy/logpolicy.go
+++ b/logpolicy/logpolicy.go
@@ -551,12 +551,12 @@ func New(collection string) *Policy {
 	}
 	filchPrefix := filepath.Join(dir, cmdName)
 
-	// Synology disks cannot hibernate if we're writing logs to them all the time.
+	// NAS disks cannot hibernate if we're writing logs to them all the time.
 	// https://github.com/tailscale/tailscale/issues/3551
-	if runtime.GOOS == "linux" && distro.Get() == distro.Synology {
-		synologyTmpfsLogs := "/tmp/tailscale-logs"
-		if err := os.MkdirAll(synologyTmpfsLogs, 0755); err == nil {
-			filchPrefix = filepath.Join(synologyTmpfsLogs, cmdName)
+	if runtime.GOOS == "linux" && (distro.Get() == distro.Synology || distro.Get() == distro.QNAP) {
+		tmpfsLogs := "/tmp/tailscale-logs"
+		if err := os.MkdirAll(tmpfsLogs, 0755); err == nil {
+			filchPrefix = filepath.Join(tmpfsLogs, cmdName)
 			filchOptions.MaxFileSize = 1 << 20
 		} else {
 			// not a fatal error, we can leave the log files on the spinning disk


### PR DESCRIPTION
Two commits in this PR:
----
    logpolicy: put QNAP logs buffer in /tmp

    Ongoing log writing keeps the spinning disks from hibernating.
    Extends earlier implementation for Synology to also handle QNAP.

    Signed-off-by: Denton Gentry <dgentry@tailscale.com>
----
    ipn/ipnlocal: prevent attempting to run SSH on QNAP for now

    tailscaled runs as a non-root user, SSH is not immediately working.

    Signed-off-by: Denton Gentry <dgentry@tailscale.com>