### PR TITLE
tool/go: accept a marker file with no line terminator

### DIFF
--- a/tool/go
+++ b/tool/go
@@ -45,7 +45,9 @@ get_cached() {
     archive="$TOOLCHAIN-$REV.tar.gz"
     mark="$TOOLCHAIN.extracted"
     extracted=
-    [ ! -e "$mark" ] || read -r extracted junk <$mark
+
+    # Ignore the error from read, which may error if the mark file does not contain a line end.
+    read -r extracted < "$mark" || true
 
     if [ "$extracted" = "$REV" ] && [ -e "${TOOLCHAIN_GO}" ]; then
         # already ok


### PR DESCRIPTION
Somewhere my local configuration or program versions are producing
marker files earlier in the process that lack a line terminator. This
doesn't need to cause an exit via set -e, we can just continue the
process. $extracted matches $REV anyway, so the process works.

Signed-off-by: James Tucker <james@tailscale.com>