### PR TITLE
cmd/tailscaled: add opt-in support for linking CLI into daemon

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -128,6 +128,8 @@ var subCommands = map[string]*func([]string) error{
 	"be-child":                &beChildFunc,
 }
 
+var beCLI func() // non-nil if CLI is linked in
+
 func main() {
 	printVersion := false
 	flag.IntVar(&args.verbose, "verbose", 0, "log verbosity level; 0 is default, 1 or higher are increasingly verbose")
@@ -142,6 +144,11 @@ func main() {
 	flag.StringVar(&args.socketpath, "socket", paths.DefaultTailscaledSocket(), "path of the service unix socket")
 	flag.StringVar(&args.birdSocketPath, "bird-socket", "", "path of the bird unix socket")
 	flag.BoolVar(&printVersion, "version", false, "print version information and exit")
+
+	if len(os.Args) > 0 && filepath.Base(os.Args[0]) == "tailscale" && beCLI != nil {
+		beCLI()
+		return
+	}
 
 	if len(os.Args) > 1 {
 		sub := os.Args[1]

--- a/cmd/tailscaled/with_cli.go
+++ b/cmd/tailscaled/with_cli.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build ts_include_cli
+// +build ts_include_cli
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"tailscale.com/cmd/tailscale/cli"
+)
+
+func init() {
+	beCLI = func() {
+		args := os.Args[1:]
+		if err := cli.Run(args); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+}


### PR DESCRIPTION
Doesn't help much, though.

    $ go install --tags=ts_include_cli ./cmd/tailscaled/
    $ ls -lh ~/go/bin/tailscaled
    -rwxr-xr-x 2 bradfitz bradfitz 34M Jul 27 11:00 /home/bradfitz/go/bin/tailscaled
    $ go install --tags= ./cmd/tailscaled/
    $ ls -lh ~/go/bin/tailscaled
    -rwxr-xr-x 1 bradfitz bradfitz 23M Jul 27 11:00 /home/bradfitz/go/bin/tailscaled
    $ ls -lh ~/go/bin/tailscale
    -rwxr-xr-x 1 bradfitz bradfitz 13M Jul 25 21:30 /home/bradfitz/go/bin/tailscale

Fixes #2233
