### PR TITLE
scripts: update check_license_headers.sh to skip zsyscall_windows.go

### DIFF
--- a/scripts/check_license_headers.sh
+++ b/scripts/check_license_headers.sh
@@ -44,6 +44,9 @@ for file in $(find $1 -name '*.go' -not -path '*/.git/*'); do
 		$1/control/controlbase/noiseexplorer_test.go)
 			# Noiseexplorer.com copyright.
 		;;
+        */zsyscall_windows.go)
+            # Generated syscall wrappers
+        ;;
         *)
             header="$(head -3 $file)"
             if ! check_file "$header"; then


### PR DESCRIPTION
We need to skip those.

Signed-off-by: Aaron Klotz <aaron@tailscale.com>