### PR TITLE
cmd/tsconnect: add basic panic handling

### DIFF
--- a/cmd/tsconnect/src/index.ts
+++ b/cmd/tsconnect/src/index.ts
@@ -12,7 +12,8 @@ WebAssembly.instantiateStreaming(
   fetch(`./dist/${wasmUrl}`),
   go.importObject
 ).then((result) => {
-  go.run(result.instance)
+  // The Go process should never exit, if it does then it's an unhandled panic.
+  go.run(result.instance).then(() => handleGoPanic())
   const ipn = newIPN({
     // Persist IPN state in sessionStorage in development, so that we don't need
     // to re-authorize every time we reload the page.
@@ -22,5 +23,32 @@ WebAssembly.instantiateStreaming(
     notifyState: notifyState.bind(null, ipn),
     notifyNetMap: notifyNetMap.bind(null, ipn),
     notifyBrowseToURL: notifyBrowseToURL.bind(null, ipn),
+    notifyPanicRecover: handleGoPanic,
   })
 })
+
+function handleGoPanic(err?: string) {
+  if (DEBUG && err) {
+    console.error("Go panic", err)
+  }
+  if (panicNode) {
+    panicNode.remove()
+  }
+  panicNode = document.createElement("div")
+  panicNode.className =
+    "rounded bg-red-500 p-2 absolute top-2 right-2 text-white font-bold text-right cursor-pointer"
+  panicNode.textContent = "Tailscale has encountered an error."
+  const panicDetailNode = document.createElement("div")
+  panicDetailNode.className = "text-sm font-normal"
+  panicDetailNode.textContent = "Click to reload"
+  panicNode.appendChild(panicDetailNode)
+  panicNode.addEventListener("click", () => location.reload(), {
+    once: true,
+  })
+  document.body.appendChild(panicNode)
+  setTimeout(() => {
+    panicNode!.remove()
+  }, 10000)
+}
+
+let panicNode: HTMLDivElement | undefined

--- a/cmd/tsconnect/src/wasm_js.ts
+++ b/cmd/tsconnect/src/wasm_js.ts
@@ -38,6 +38,7 @@ declare global {
     notifyState: (state: IPNState) => void
     notifyNetMap: (netMapStr: string) => void
     notifyBrowseToURL: (url: string) => void
+    notifyPanicRecover: (err: string) => void
   }
 
   type IPNNetMap = {
@@ -57,7 +58,7 @@ declare global {
   }
 
   type IPNNetMapPeerNode = IPNNetMapNode & {
-    online: boolean
+    online?: boolean
     tailscaleSSHEnabled: boolean
   }
 }


### PR DESCRIPTION
The go wasm process exiting is a sign of an unhandled panic. Also
add a explicit recover() call in the notify callback, that's where most
logic bugs are likely to happen (and they may not be fatal).

Also fixes the one panic that was encountered (nill pointer dereference
when generating the JS view of the netmap).

Fixes #5132

Signed-off-by: Mihai Parparita <mihai@tailscale.com>