### PR TITLE
cmd/tsconnect: lint during build step

### DIFF
--- a/cmd/tsconnect/build.go
+++ b/cmd/tsconnect/build.go
@@ -28,6 +28,11 @@ func runBuild() {
 		log.Fatalf("Cannot setup: %v", err)
 	}
 
+	log.Printf("Linting...\n")
+	if err := runYarn("lint"); err != nil {
+		log.Fatalf("Linting failed: %v", err)
+	}
+
 	if err := cleanDist(); err != nil {
 		log.Fatalf("Cannot clean %s: %v", *distDir, err)
 	}

--- a/cmd/tsconnect/common.go
+++ b/cmd/tsconnect/common.go
@@ -104,7 +104,11 @@ func buildWasm(dev bool) error {
 // installJSDeps installs the JavaScript dependencies specified by package.json
 func installJSDeps() error {
 	log.Printf("Installing JS deps...\n")
-	cmd := exec.Command(*yarnPath)
+	return runYarn()
+}
+
+func runYarn(args ...string) error {
+	cmd := exec.Command(*yarnPath, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()


### PR DESCRIPTION
Ensures that TypeScript checks pass before we deploy.

Signed-off-by: Mihai Parparita <mihai@tailscale.com>