### PR TITLE
cmd/tsconnect: fix xterm CSS not being imported

### DIFF
--- a/cmd/tsconnect/src/index.css
+++ b/cmd/tsconnect/src/index.css
@@ -2,8 +2,8 @@
 /* Use of this source code is governed by a BSD-style */
 /* license that can be found in the LICENSE file. */
 
+@import "xterm/css/xterm.css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import "xterm/css/xterm.css";


### PR DESCRIPTION
@import rules need to come first, they are (silently) ignored otherwise.

Signed-off-by: Mihai Parparita <mihai@tailscale.com>