### PR TITLE
tstest: do not error if the there are fewer goroutines than at start

### DIFF
--- a/tstest/resource.go
+++ b/tstest/resource.go
@@ -30,6 +30,9 @@ func ResourceCheck(tb testing.TB) {
 			time.Sleep(5 * time.Millisecond)
 		}
 		endN, endStacks := goroutines()
+		if endN <= startN {
+			return
+		}
 		tb.Logf("goroutine diff:\n%v\n", cmp.Diff(startStacks, endStacks))
 		tb.Fatalf("goroutine count: expected %d, got %d\n", startN, endN)
 	})


### PR DESCRIPTION
This fixes test failures like:
```
    resource.go:34: goroutine count: expected 3, got 2
```

Signed-off-by: Maisem Ali <maisem@tailscale.com>