### PR TITLE
cmd/tsconnect: allow SSH username to be specified

### DIFF
--- a/cmd/tsconnect/index.html
+++ b/cmd/tsconnect/index.html
@@ -12,7 +12,27 @@
         <div class="text-gray-600" id="state">Loading…</div>
       </header>
     </div>
-    <div id="peers" class="container mx-auto px-4"></div>
+    <form
+      id="ssh-form"
+      class="container mx-auto px-4 hidden flex justify-center"
+    >
+      <input type="text" class="input username" placeholder="Username" />
+      <div class="select-with-arrow mx-2">
+        <select class="select"></select>
+      </div>
+      <input
+        type="submit"
+        class="button bg-green-500 border-green-500 text-white hover:bg-green-600 hover:border-green-600"
+        value="SSH"
+      />
+    </form>
+    <div id="no-ssh" class="container mx-auto px-4 hidden text-center">
+      None of your machines have
+      <a href="https://tailscale.com/kb/1193/tailscale-ssh/" class="link"
+        >Tailscale SSH</a
+      >
+      enabled. Give it a try!
+    </div>
     <script src="dist/index.js"></script>
   </body>
 </html>

--- a/cmd/tsconnect/src/index.css
+++ b/cmd/tsconnect/src/index.css
@@ -7,3 +7,69 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.link {
+  @apply text-blue-600;
+}
+
+.link:hover {
+  @apply underline;
+}
+
+.button {
+  @apply font-medium py-1 px-2 rounded-md border border-transparent text-center cursor-pointer;
+  transition-property: background-color, border-color, color, box-shadow;
+  transition-duration: 120ms;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+  min-width: 80px;
+}
+.button:focus {
+  @apply outline-none ring;
+}
+.button:disabled {
+  @apply pointer-events-none select-none;
+}
+
+.input {
+  @apply appearance-none leading-tight rounded-md bg-white border border-gray-300 hover:border-gray-400 transition-colors px-3;
+  height: 2.375rem;
+}
+
+.input::placeholder {
+  @apply text-gray-400;
+}
+
+.input:disabled {
+  @apply border-gray-200;
+  @apply bg-gray-50;
+  @apply cursor-not-allowed;
+}
+
+.input:focus {
+  @apply outline-none ring border-transparent;
+}
+
+.select {
+  @apply appearance-none py-2 px-3 leading-tight rounded-md bg-white border border-gray-300;
+}
+
+.select-with-arrow {
+  @apply relative;
+}
+
+.select-with-arrow .select {
+  width: 100%;
+}
+
+.select-with-arrow::after {
+  @apply absolute;
+  content: "";
+  top: 50%;
+  right: 0.5rem;
+  transform: translate(-0.3em, -0.15em);
+  width: 0.6em;
+  height: 0.4em;
+  opacity: 0.6;
+  background-color: currentColor;
+  clip-path: polygon(100% 0%, 0 0%, 50% 100%);
+}

--- a/cmd/tsconnect/src/login.ts
+++ b/cmd/tsconnect/src/login.ts
@@ -11,7 +11,7 @@ export async function showLoginURL(url: string) {
   loginNode = document.createElement("div")
   loginNode.className = "flex flex-col items-center justify-items-center"
   const linkNode = document.createElement("a")
-  linkNode.className = "text-blue-600 hover:underline"
+  linkNode.className = "link"
   linkNode.href = url
   linkNode.target = "_blank"
   loginNode.appendChild(linkNode)
@@ -49,7 +49,7 @@ export function showLogoutButton(ipn: IPN) {
   }
   logoutButtonNode = document.createElement("button")
   logoutButtonNode.className =
-    "py-1 px-2 rounded bg-gray-500 border-gray-500 text-white hover:bg-gray-600 hover:border-gray-600 ml-2 font-bold"
+    "button bg-gray-500 border-gray-500 text-white hover:bg-gray-600 hover:border-gray-600 ml-2 font-bold"
   logoutButtonNode.textContent = "Logout"
   logoutButtonNode.addEventListener(
     "click",

--- a/cmd/tsconnect/src/notifier.ts
+++ b/cmd/tsconnect/src/notifier.ts
@@ -8,7 +8,7 @@ import {
   showLogoutButton,
   hideLogoutButton,
 } from "./login"
-import { showSSHPeers, hideSSHPeers } from "./ssh"
+import { showSSHForm, hideSSHForm } from "./ssh"
 import { IPNState } from "./wasm_js"
 
 /**
@@ -27,7 +27,7 @@ export function notifyState(ipn: IPN, state: IPNState) {
     case IPNState.NeedsLogin:
       stateLabel = "Needs Login"
       hideLogoutButton()
-      hideSSHPeers()
+      hideSSHForm()
       ipn.login()
       break
     case IPNState.NeedsMachineAuth:
@@ -36,7 +36,7 @@ export function notifyState(ipn: IPN, state: IPNState) {
     case IPNState.Stopped:
       stateLabel = "Stopped"
       hideLogoutButton()
-      hideSSHPeers()
+      hideSSHForm()
       break
     case IPNState.Starting:
       stateLabel = "Starting…"
@@ -57,7 +57,7 @@ export function notifyNetMap(ipn: IPN, netMapStr: string) {
     console.log("Received net map: " + JSON.stringify(netMap, null, 2))
   }
 
-  showSSHPeers(netMap.peers, ipn)
+  showSSHForm(netMap.peers, ipn)
 }
 
 export function notifyBrowseToURL(ipn: IPN, url: string) {

--- a/cmd/tsconnect/src/wasm_js.ts
+++ b/cmd/tsconnect/src/wasm_js.ts
@@ -17,11 +17,14 @@ declare global {
     logout(): void
     ssh(
       host: string,
-      writeFn: (data: string) => void,
-      setReadFn: (readFn: (data: string) => void) => void,
-      rows: number,
-      cols: number,
-      onDone: () => void
+      username: string,
+      termConfig: {
+        writeFn: (data: string) => void
+        setReadFn: (readFn: (data: string) => void) => void
+        rows: number
+        cols: number
+        onDone: () => void
+      }
     ): void
   }
 


### PR DESCRIPTION
Redoes the UI to be a form, with a username field and a host drop-down
(we also show non-Tailscale SSH hosts now, in a separate section)

Fixes #5139

Signed-off-by: Mihai Parparita <mihai@tailscale.com>