### PR TITLE
tsweb: mark AccessLogRecord fields as omitempty

### DIFF
--- a/tsweb/log.go
+++ b/tsweb/log.go
@@ -18,34 +18,34 @@ type AccessLogRecord struct {
 	// include the entire lifetime of the underlying connection in
 	// cases like connection hijacking, only the lifetime of the HTTP
 	// request handler.
-	Seconds float64 `json:"duration"`
+	Seconds float64 `json:"duration,omitempty"`
 
 	// The client's ip:port.
-	RemoteAddr string `json:"remote_addr"`
+	RemoteAddr string `json:"remote_addr,omitempty"`
 	// The HTTP protocol version, usually "HTTP/1.1 or HTTP/2".
-	Proto string `json:"proto"`
+	Proto string `json:"proto,omitempty"`
 	// Whether the request was received over TLS.
-	TLS bool `json:"tls"`
+	TLS bool `json:"tls,omitempty"`
 	// The target hostname in the request.
-	Host string `json:"host"`
+	Host string `json:"host,omitempty"`
 	// The HTTP method invoked.
-	Method string `json:"method"`
+	Method string `json:"method,omitempty"`
 	// The unescaped request URI, including query parameters.
-	RequestURI string `json:"request_uri"`
+	RequestURI string `json:"request_uri,omitempty"`
 
 	// The client's user-agent
-	UserAgent string `json:"user_agent"`
+	UserAgent string `json:"user_agent,omitempty"`
 	// Where the client was before making this request.
-	Referer string `json:"referer"`
+	Referer string `json:"referer,omitempty"`
 
 	// The HTTP response code sent to the client.
-	Code int `json:"code"`
+	Code int `json:"code,omitempty"`
 	// Number of bytes sent in response body to client. If the request
 	// was hijacked, only includes bytes sent up to the point of
 	// hijacking.
-	Bytes int `json:"bytes"`
+	Bytes int `json:"bytes,omitempty"`
 	// Error encountered during request processing.
-	Err string `json:"err"`
+	Err string `json:"err,omitempty"`
 }
 
 // String returns m as a JSON string.


### PR DESCRIPTION
If the field is the zero value, then avoid serializing the field.
This reduces verbosity in server logs.

Signed-off-by: Joe Tsai <joetsai@digital-static.net>