### PR TITLE
cmd/tsconnect: make terminal resizable

### DIFF
--- a/cmd/tsconnect/index.html
+++ b/cmd/tsconnect/index.html
@@ -5,33 +5,38 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="dist/index.css" />
   </head>
-  <body class="flex flex-col min-h-screen">
-    <div class="bg-gray-100 border-b border-gray-200 pt-4 pb-2 mb-6">
+  <body class="flex flex-col h-screen overflow-hidden">
+    <div class="bg-gray-100 border-b border-gray-200 pt-4 pb-2">
       <header class="container mx-auto px-4 flex flex-row items-center">
         <h1 class="text-3xl font-bold grow">Tailscale Connect</h1>
         <div class="text-gray-600" id="state">Loading…</div>
       </header>
     </div>
-    <form
-      id="ssh-form"
-      class="container mx-auto px-4 hidden flex justify-center"
+    <div
+      id="content"
+      class="flex-grow flex flex-col justify-center overflow-hidden"
     >
-      <input type="text" class="input username" placeholder="Username" />
-      <div class="select-with-arrow mx-2">
-        <select class="select"></select>
-      </div>
-      <input
-        type="submit"
-        class="button bg-green-500 border-green-500 text-white hover:bg-green-600 hover:border-green-600"
-        value="SSH"
-      />
-    </form>
-    <div id="no-ssh" class="container mx-auto px-4 hidden text-center">
-      None of your machines have
-      <a href="https://tailscale.com/kb/1193/tailscale-ssh/" class="link"
-        >Tailscale SSH</a
+      <form
+        id="ssh-form"
+        class="container mx-auto px-4 hidden flex justify-center"
       >
-      enabled. Give it a try!
+        <input type="text" class="input username" placeholder="Username" />
+        <div class="select-with-arrow mx-2">
+          <select class="select"></select>
+        </div>
+        <input
+          type="submit"
+          class="button bg-green-500 border-green-500 text-white hover:bg-green-600 hover:border-green-600"
+          value="SSH"
+        />
+      </form>
+      <div id="no-ssh" class="container mx-auto px-4 hidden text-center">
+        None of your machines have
+        <a href="https://tailscale.com/kb/1193/tailscale-ssh/" class="link"
+          >Tailscale SSH</a
+        >
+        enabled. Give it a try!
+      </div>
     </div>
     <script src="dist/index.js"></script>
   </body>

--- a/cmd/tsconnect/package.json
+++ b/cmd/tsconnect/package.json
@@ -8,7 +8,8 @@
     "qrcode": "^1.5.0",
     "tailwindcss": "^3.1.6",
     "typescript": "^4.7.4",
-    "xterm": "^4.18.0"
+    "xterm": "^4.18.0",
+    "xterm-addon-fit": "^0.5.0"
   },
   "scripts": {
     "lint": "tsc --noEmit"

--- a/cmd/tsconnect/src/index.css
+++ b/cmd/tsconnect/src/index.css
@@ -73,3 +73,7 @@
   background-color: currentColor;
   clip-path: polygon(100% 0%, 0 0%, 50% 100%);
 }
+
+body.ssh-active #ssh-form {
+  @apply hidden;
+}

--- a/cmd/tsconnect/src/index.ts
+++ b/cmd/tsconnect/src/index.ts
@@ -52,3 +52,7 @@ function handleGoPanic(err?: string) {
 }
 
 let panicNode: HTMLDivElement | undefined
+
+export function getContentNode(): HTMLDivElement {
+  return document.querySelector("#content") as HTMLDivElement
+}

--- a/cmd/tsconnect/src/login.ts
+++ b/cmd/tsconnect/src/login.ts
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import * as qrcode from "qrcode"
+import { getContentNode } from "./index"
 
 export async function showLoginURL(url: string) {
   if (loginNode) {
@@ -30,7 +31,7 @@ export async function showLoginURL(url: string) {
 
   linkNode.appendChild(document.createTextNode(url))
 
-  document.body.appendChild(loginNode)
+  getContentNode().appendChild(loginNode)
 }
 
 export function hideLoginURL() {

--- a/cmd/tsconnect/src/notifier.ts
+++ b/cmd/tsconnect/src/notifier.ts
@@ -47,7 +47,7 @@ export function notifyState(ipn: IPN, state: IPNState) {
       showLogoutButton(ipn)
       break
   }
-  const stateNode = document.getElementById("state") as HTMLDivElement
+  const stateNode = document.querySelector("#state") as HTMLDivElement
   stateNode.textContent = stateLabel ?? ""
 }
 

--- a/cmd/tsconnect/src/wasm_js.ts
+++ b/cmd/tsconnect/src/wasm_js.ts
@@ -25,7 +25,12 @@ declare global {
         cols: number
         onDone: () => void
       }
-    ): void
+    ): IPNSSHSession
+  }
+
+  interface IPNSSHSession {
+    resize(rows: number, cols: number): boolean
+    close(): boolean
   }
 
   interface IPNStateStorage {

--- a/cmd/tsconnect/yarn.lock
+++ b/cmd/tsconnect/yarn.lock
@@ -603,6 +603,11 @@ xtend@^4.0.2:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
+xterm-addon-fit@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/xterm-addon-fit/-/xterm-addon-fit-0.5.0.tgz#2d51b983b786a97dcd6cde805e700c7f913bc596"
+  integrity sha512-DsS9fqhXHacEmsPxBJZvfj2la30Iz9xk+UKjhQgnYNkrUIN5CYLbw7WEfz117c7+S86S/tpHPfvNxJsF5/G8wQ==
+
 xterm@^4.18.0:
   version "4.18.0"
   resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.18.0.tgz#a1f6ab2c330c3918fb094ae5f4c2562987398ea1"


### PR DESCRIPTION
Makes the terminal container DOM node as large as the window (except for
the header) via flexbox. The xterm.js terminal is then sized to fit via
xterm-addon-fit. Once we have a computed rows/columns size, and we can
tell the SSH session of the computed size.

Required introducing an IPNSSHSession type to allow the JS to control
the SSH session once opened. That alse allows us to programatically
close it, which we do when the user closes the window with the session
still active.

I initially wanted to open the terminal in a new window instead (so that
it could be resizable independently of the main window), but xterm.js
does not appear to work well in that mode (possibly because it adds an
IntersectionObserver to pause rendering when the window is not visible,
and it ends up doing that when the parent window is hidden -- see
xtermjs/xterm.js@87dca56dee8018a17b5cb22ec844b7013629da63)

Fixes #5150

Signed-off-by: Mihai Parparita <mihai@tailscale.com>