### PR TITLE
cmd/tailscale/cli: use printf and outln consistently

### DIFF
--- a/cmd/tailscale/cli/configure-host.go
+++ b/cmd/tailscale/cli/configure-host.go
@@ -66,7 +66,7 @@ func runConfigureHost(ctx context.Context, args []string) error {
 		return err
 	}
 	if isDSM6 {
-		fmt.Printf("/dev/net/tun exists and has permissions 0666. Skipping setcap on DSM6.\n")
+		printf("/dev/net/tun exists and has permissions 0666. Skipping setcap on DSM6.\n")
 		return nil
 	}
 
@@ -80,6 +80,6 @@ func runConfigureHost(ctx context.Context, args []string) error {
 	if out, err := exec.Command("/bin/setcap", "cap_net_admin,cap_net_raw+eip", daemonBin).CombinedOutput(); err != nil {
 		return fmt.Errorf("setcap: %v, %s", err, out)
 	}
-	fmt.Printf("Done. To restart Tailscale to use the new permissions, run:\n\n  sudo synosystemctl restart pkgctl-Tailscale.service\n\n")
+	printf("Done. To restart Tailscale to use the new permissions, run:\n\n  sudo synosystemctl restart pkgctl-Tailscale.service\n\n")
 	return nil
 }

--- a/cmd/tailscale/cli/debug.go
+++ b/cmd/tailscale/cli/debug.go
@@ -308,18 +308,18 @@ func runStat(ctx context.Context, args []string) error {
 	for _, a := range args {
 		fi, err := os.Lstat(a)
 		if err != nil {
-			fmt.Printf("%s: %v\n", a, err)
+			printf("%s: %v\n", a, err)
 			continue
 		}
-		fmt.Printf("%s: %v, %v\n", a, fi.Mode(), fi.Size())
+		printf("%s: %v, %v\n", a, fi.Mode(), fi.Size())
 		if fi.IsDir() {
 			ents, _ := os.ReadDir(a)
 			for i, ent := range ents {
 				if i == 25 {
-					fmt.Printf("  ...\n")
+					printf("  ...\n")
 					break
 				}
-				fmt.Printf("  - %s\n", ent.Name())
+				printf("  - %s\n", ent.Name())
 			}
 		}
 	}
@@ -420,7 +420,7 @@ func runVia(ctx context.Context, args []string) error {
 		v4 := tsaddr.UnmapVia(ipp.Addr())
 		a := ipp.Addr().As16()
 		siteID := binary.BigEndian.Uint32(a[8:12])
-		fmt.Printf("site %v (0x%x), %v\n", siteID, siteID, netip.PrefixFrom(v4, ipp.Bits()-96))
+		printf("site %v (0x%x), %v\n", siteID, siteID, netip.PrefixFrom(v4, ipp.Bits()-96))
 	case 2:
 		siteID, err := strconv.ParseUint(args[0], 0, 32)
 		if err != nil {
@@ -437,7 +437,7 @@ func runVia(ctx context.Context, args []string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Println(via)
+		outln(via)
 	}
 	return nil
 }

--- a/cmd/tailscale/cli/id-token.go
+++ b/cmd/tailscale/cli/id-token.go
@@ -7,7 +7,6 @@ package cli
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 )
@@ -29,6 +28,6 @@ func runIDToken(ctx context.Context, args []string) error {
 		return err
 	}
 
-	fmt.Println(tr.IDToken)
+	outln(tr.IDToken)
 	return nil
 }

--- a/cmd/tailscale/cli/risks.go
+++ b/cmd/tailscale/cli/risks.go
@@ -55,8 +55,8 @@ func presentRiskToUser(riskType, riskMessage string) error {
 	if riskAccepted(riskType) {
 		return nil
 	}
-	fmt.Println(riskMessage)
-	fmt.Printf("To skip this warning, use --accept-risk=%s\n", riskType)
+	outln(riskMessage)
+	printf("To skip this warning, use --accept-risk=%s\n", riskType)
 
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, syscall.SIGINT)
@@ -64,15 +64,15 @@ func presentRiskToUser(riskType, riskMessage string) error {
 	for left := riskAbortTimeSeconds; left > 0; left-- {
 		msg := fmt.Sprintf("\rContinuing in %d seconds...", left)
 		msgLen = len(msg)
-		fmt.Print(msg)
+		printf(msg)
 		select {
 		case <-interrupt:
-			fmt.Printf("\r%s\r", strings.Repeat(" ", msgLen+1))
+			printf("\r%s\r", strings.Repeat("x", msgLen+1))
 			return errAborted
 		case <-time.After(time.Second):
 			continue
 		}
 	}
-	fmt.Printf("\r%s\r", strings.Repeat(" ", msgLen))
+	printf("\r%s\r", strings.Repeat(" ", msgLen))
 	return errAborted
 }

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -571,9 +571,9 @@ func runUp(ctx context.Context, args []string) (retErr error) {
 
 				data, err := json.MarshalIndent(js, "", "\t")
 				if err != nil {
-					log.Printf("upOutputJSON marshalling error: %v", err)
+					printf("upOutputJSON marshalling error: %v", err)
 				} else {
-					fmt.Println(string(data))
+					outln(string(data))
 				}
 			} else {
 				fmt.Fprintf(Stderr, "\nTo authenticate, visit:\n\n\t%s\n\n", *url)
@@ -711,7 +711,7 @@ func printUpDoneJSON(state ipn.State, errorString string) {
 	if err != nil {
 		log.Printf("printUpDoneJSON marshalling error: %v", err)
 	} else {
-		fmt.Println(string(data))
+		outln(string(data))
 	}
 }
 


### PR DESCRIPTION
Fix some fmt.Println and fmt.Printf calls that crept in since
5df7ac70d6a942d1bd4cb5b388aecbe161a1a0d1.

Signed-off-by: Mihai Parparita <mihai@tailscale.com>