### PR TITLE
.github/workflows: put back CLI in cross-wasm GitHub action

### DIFF
--- a/.github/workflows/cross-wasm.yml
+++ b/.github/workflows/cross-wasm.yml
@@ -29,7 +29,7 @@ jobs:
       env:
         GOOS: js
         GOARCH: wasm
-      run: go build ./cmd/tsconnect/wasm
+      run: go build ./cmd/tsconnect/wasm ./cmd/tailscale/cli
 
     - name: tsconnect static build
       # Use our custom Go toolchain, we set build tags (to control binary size)


### PR DESCRIPTION
Since we're keeping the JS support in the CLI (see https://github.com/tailscale/tailscale/pull/5265#issuecomment-1203078243),
make sure it keeps building.

Signed-off-by: Mihai Parparita <mihai@tailscale.com>