### PR TITLE
cmd/tsconnect: prefetch main.wasm when serving

### DIFF
--- a/.github/workflows/cross-wasm.yml
+++ b/.github/workflows/cross-wasm.yml
@@ -34,7 +34,7 @@ jobs:
     - name: tsconnect static build
       # Use our custom Go toolchain, we set build tags (to control binary size)
       # that depend on it.
-      run: ./tool/go run ./cmd/tsconnect build
+      run: ./tool/go run ./cmd/tsconnect --fast-compression build
 
     - uses: k0kubun/action-slack@v2.0.0
       with:

--- a/cmd/tsconnect/common.go
+++ b/cmd/tsconnect/common.go
@@ -119,6 +119,9 @@ func runYarn(args ...string) error {
 // from entry points to hashed file names.
 type EsbuildMetadata struct {
 	Outputs map[string]struct {
+		Inputs map[string]struct {
+			BytesInOutput int64 `json:"bytesInOutput"`
+		} `json:"inputs,omitempty"`
 		EntryPoint string `json:"entryPoint,omitempty"`
 	} `json:"outputs,omitempty"`
 }

--- a/cmd/tsconnect/index.html
+++ b/cmd/tsconnect/index.html
@@ -3,7 +3,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tailscale Connect</title>
     <link rel="stylesheet" type="text/css" href="dist/index.css" />
+    <script src="dist/index.js" defer></script>
   </head>
   <body class="flex flex-col min-h-screen">
     <div class="bg-gray-100 border-b border-gray-200 pt-4 pb-2 mb-6">
@@ -33,6 +35,5 @@
       >
       enabled. Give it a try!
     </div>
-    <script src="dist/index.js"></script>
   </body>
 </html>

--- a/cmd/tsconnect/tsconnect.go
+++ b/cmd/tsconnect/tsconnect.go
@@ -18,9 +18,10 @@ import (
 )
 
 var (
-	addr     = flag.String("addr", ":9090", "address to listen on")
-	distDir  = flag.String("distdir", "./dist", "path of directory to place build output in")
-	yarnPath = flag.String("yarnpath", "../../tool/yarn", "path yarn executable used to install JavaScript dependencies")
+	addr            = flag.String("addr", ":9090", "address to listen on")
+	distDir         = flag.String("distdir", "./dist", "path of directory to place build output in")
+	yarnPath        = flag.String("yarnpath", "../../tool/yarn", "path yarn executable used to install JavaScript dependencies")
+	fastCompression = flag.Bool("fast-compression", false, "Use faster compression when building, to speed up build time. Meant to iterative/debugging use only.")
 )
 
 func main() {


### PR DESCRIPTION
Avoids waterfalling of requests from the file (its load is triggered
from JavaScript).

Also has other cleanups to index.html, adding a <title> and moving the
<script> to being loaded sooner (but still not delaying page rendering
by using the defer attribute).

Also includes a `-fast-compression` flag when building that was useful in
speeding up the iteration loop when working on this.