### PR TITLE
cmd/tsconnect: make PeerAPI work

### DIFF
--- a/cmd/tsconnect/src/wasm_js.ts
+++ b/cmd/tsconnect/src/wasm_js.ts
@@ -26,6 +26,13 @@ declare global {
         onDone: () => void
       }
     ): IPNSSHSession
+    fetch(
+      url: string
+    ): Promise<{
+      status: number
+      statusText: string
+      text: () => Promise<string>
+    }>
   }
 
   interface IPNSSHSession {


### PR DESCRIPTION
JS -> native nodes worked already, tested by exposing a fetch() method
to JS (it's Promise-based to be consistent with the native fetch() API).

Native nodes -> JS almost worked, we just needed to set the LocalBackend
on the user-space netstack.

Fixes #5130

Signed-off-by: Mihai Parparita <mihai@tailscale.com>