### PR TITLE
all: migrate code from netaddr.FromStdAddr to Go 1.18

### DIFF
--- a/ipn/ipnlocal/peerapi.go
+++ b/ipn/ipnlocal/peerapi.go
@@ -493,8 +493,8 @@ func (pln *peerAPIListener) serve() {
 			logf("peerapi: unexpected RemoteAddr %#v", c.RemoteAddr())
 			continue
 		}
-		ipp, ok := netaddr.FromStdAddr(ta.IP, ta.Port, "")
-		if !ok {
+		ipp := netaddr.Unmap(ta.AddrPort())
+		if !ipp.IsValid() {
 			logf("peerapi: bogus TCPAddr %#v", ta)
 			c.Close()
 			continue

--- a/net/netaddr/netaddr.go
+++ b/net/netaddr/netaddr.go
@@ -10,7 +10,6 @@
 package netaddr
 
 import (
-	"math"
 	"net"
 	"net/netip"
 )
@@ -18,6 +17,13 @@ import (
 // IPv4 returns the IP of the IPv4 address a.b.c.d.
 func IPv4(a, b, c, d uint8) netip.Addr {
 	return netip.AddrFrom4([4]byte{a, b, c, d})
+}
+
+// Unmap returns the provided AddrPort with its Addr IP component Unmap'ed.
+//
+// See https://github.com/golang/go/issues/53607#issuecomment-1203466984
+func Unmap(ap netip.AddrPort) netip.AddrPort {
+	return netip.AddrPortFrom(ap.Addr().Unmap(), ap.Port())
 }
 
 // FromStdIPNet returns an IPPrefix from the standard library's IPNet type.
@@ -41,22 +47,4 @@ func FromStdIPNet(std *net.IPNet) (prefix netip.Prefix, ok bool) {
 	}
 
 	return netip.PrefixFrom(ip, ones), true
-}
-
-// FromStdAddr maps the components of a standard library TCPAddr or
-// UDPAddr into an IPPort.
-func FromStdAddr(stdIP net.IP, port int, zone string) (_ netip.AddrPort, ok bool) {
-	ip, ok := netip.AddrFromSlice(stdIP)
-	if !ok || port < 0 || port > math.MaxUint16 {
-		return
-	}
-	ip = ip.Unmap()
-	if zone != "" {
-		if ip.Is4() {
-			ok = false
-			return
-		}
-		ip = ip.WithZone(zone)
-	}
-	return netip.AddrPortFrom(ip, uint16(port)), true
 }

--- a/net/netcheck/netcheck.go
+++ b/net/netcheck/netcheck.go
@@ -273,7 +273,8 @@ func (c *Client) ReceiveSTUNPacket(pkt []byte, src netip.AddrPort) {
 	}
 	rs.mu.Unlock()
 	if ok {
-		if ipp, ok := netaddr.FromStdAddr(addr, int(port), ""); ok {
+		ta := net.TCPAddr{IP: addr, Port: int(port)}
+		if ipp := netaddr.Unmap(ta.AddrPort()); ipp.IsValid() {
 			onDone(ipp)
 		}
 	}
@@ -516,8 +517,8 @@ func (c *Client) readPackets(ctx context.Context, pc net.PacketConn) {
 		if !stun.Is(pkt) {
 			continue
 		}
-		if ipp, ok := netaddr.FromStdAddr(ua.IP, ua.Port, ua.Zone); ok {
-			c.ReceiveSTUNPacket(pkt, ipp)
+		if ap := netaddr.Unmap(ua.AddrPort()); ap.IsValid() {
+			c.ReceiveSTUNPacket(pkt, ap)
 		}
 	}
 }

--- a/net/portmapper/igd_test.go
+++ b/net/portmapper/igd_test.go
@@ -167,9 +167,8 @@ func (d *TestIGD) servePxP() {
 			}
 			return
 		}
-		ua := a.(*net.UDPAddr)
-		src, ok := netaddr.FromStdAddr(ua.IP, ua.Port, ua.Zone)
-		if !ok {
+		src := netaddr.Unmap(a.(*net.UDPAddr).AddrPort())
+		if !src.IsValid() {
 			panic("bogus addr")
 		}
 		pkt := buf[:n]

--- a/net/portmapper/portmapper.go
+++ b/net/portmapper/portmapper.go
@@ -531,8 +531,8 @@ func (c *Client) createOrGetMapping(ctx context.Context) (external netip.AddrPor
 			return netip.AddrPort{}, NoMappingError{ErrNoPortMappingServices}
 		}
 		srcu := srci.(*net.UDPAddr)
-		src, ok := netaddr.FromStdAddr(srcu.IP, srcu.Port, srcu.Zone)
-		if !ok {
+		src := netaddr.Unmap(srcu.AddrPort())
+		if !src.IsValid() {
 			continue
 		}
 		if src == pxpAddr {

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -3037,8 +3037,8 @@ func (c *RebindingUDPConn) ReadFromNetaddr(b []byte) (n int, ipp netip.AddrPort,
 				return 0, netip.AddrPort{}, fmt.Errorf("RebindingUDPConn.ReadFromNetaddr: underlying connection returned address of type %T, want *netaddr.UDPAddr", addr)
 			}
 			if pAddr != nil {
-				ipp, ok = netaddr.FromStdAddr(pAddr.IP, pAddr.Port, pAddr.Zone)
-				if !ok {
+				ipp = netaddr.Unmap(pAddr.AddrPort())
+				if !ipp.IsValid() {
 					return 0, netip.AddrPort{}, errors.New("netaddr.FromStdAddr failed")
 				}
 			}


### PR DESCRIPTION
With caveat https://github.com/golang/go/issues/53607#issuecomment-1203466984
that then requires a new wrapper. But a simpler one at least.

Updates #5162
