### PR TITLE
cmd/tsconnect: make logtail uploading work

### DIFF
--- a/logtail/filch/filch_js.go
+++ b/logtail/filch/filch_js.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package filch
+
+import (
+	"os"
+)
+
+func saveStderr() (*os.File, error) {
+	return os.Stderr, nil
+}
+
+func unsaveStderr(f *os.File) error {
+	os.Stderr = f
+	return nil
+}
+
+func dup2Stderr(f *os.File) error {
+	return nil
+}

--- a/logtail/filch/filch_unix.go
+++ b/logtail/filch/filch_unix.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !windows
-// +build !windows
+//go:build !windows && !js
+// +build !windows,!js
 
 package filch
 


### PR DESCRIPTION
Initialize logtail and provide an uploader that works in the
browser (we make a no-cors cross-origin request to avoid having to
open up the logcatcher servers to CORS).

Fixes #5147

Signed-off-by: Mihai Parparita <mihai@tailscale.com>