### PR TITLE
tsconnect: add flag to specify control server

### DIFF
--- a/cmd/tsconnect/common.go
+++ b/cmd/tsconnect/common.go
@@ -88,9 +88,14 @@ func buildWasm(dev bool) error {
 	log.Printf("Building wasm...\n")
 	args := []string{"build", "-tags", "tailscale_go,osusergo,netgo,nethttpomithttp2,omitidna,omitpemdecrypt"}
 	if !dev {
+		if *devControl != "" {
+			return fmt.Errorf("Development control URL can only be used in dev mode.")
+		}
 		// Omit long paths and debug symbols in release builds, to reduce the
 		// generated WASM binary size.
 		args = append(args, "-trimpath", "-ldflags", "-s -w")
+	} else if *devControl != "" {
+		args = append(args, "-ldflags", fmt.Sprintf("-X 'main.ControlURL=%v'", *devControl))
 	}
 	args = append(args, "-o", "src/main.wasm", "./wasm")
 	cmd := exec.Command(filepath.Join(runtime.GOROOT(), "bin", "go"), args...)

--- a/cmd/tsconnect/tsconnect.go
+++ b/cmd/tsconnect/tsconnect.go
@@ -22,6 +22,7 @@ var (
 	distDir         = flag.String("distdir", "./dist", "path of directory to place build output in")
 	yarnPath        = flag.String("yarnpath", "../../tool/yarn", "path yarn executable used to install JavaScript dependencies")
 	fastCompression = flag.Bool("fast-compression", false, "Use faster compression when building, to speed up build time. Meant to iterative/debugging use only.")
+	devControl      = flag.String("dev-control", "", "URL of a development control server to be used with dev. If provided without specifying dev, an error will be returned.")
 )
 
 func main() {

--- a/cmd/tsconnect/wasm/wasm_js.go
+++ b/cmd/tsconnect/wasm/wasm_js.go
@@ -41,6 +41,9 @@ import (
 	"tailscale.com/words"
 )
 
+// ControlURL defines the URL to be used for connection to Control.
+var ControlURL = ipn.DefaultControlURL
+
 func main() {
 	js.Global().Set("newIPN", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
 		if len(args) != 1 {
@@ -232,7 +235,7 @@ func (i *jsIPN) run(jsCallbacks js.Value) {
 		err := i.lb.Start(ipn.Options{
 			StateKey: "wasm",
 			UpdatePrefs: &ipn.Prefs{
-				ControlURL:       ipn.DefaultControlURL,
+				ControlURL:       ControlURL,
 				RouteAll:         false,
 				AllowSingleHosts: true,
 				WantRunning:      true,


### PR DESCRIPTION
To improve the local development experience, this change allows a
control url to be passed in with the `--control-url=` flag.

If no flag is passed, the default remains the Tailscale controlled
control server set by `ipn.DefaultControlURL`.

Co-authored-by: Maisem Ali <maisem@tailscale.com>
Signed-off-by: Charlotte Brandhorst-Satzkorn <charlotte@tailscale.com>