### PR TITLE
net/socks5: use new Go 1.19 binary.AppendByteOrder.AppendUintX

### DIFF
--- a/net/socks5/socks5.go
+++ b/net/socks5/socks5.go
@@ -363,9 +363,7 @@ func (res *response) marshal() ([]byte, error) {
 	}
 
 	pkt = append(pkt, addr...)
-	port := make([]byte, 2)
-	binary.BigEndian.PutUint16(port, uint16(res.bindPort))
-	pkt = append(pkt, port...)
+	pkt = binary.BigEndian.AppendUint16(pkt, uint16(res.bindPort))
 
 	return pkt, nil
 }


### PR DESCRIPTION
Updates #4872
