### PR TITLE
util/must: new package

### DIFF
--- a/util/must/must.go
+++ b/util/must/must.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package must assists in calling functions that must succeed.
+//
+// Example usage:
+//	var target = must.Do(url.Parse(...))
+package must
+
+// Do returns v as is. It panics if err is non-nil.
+func Do[T any](v T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}


### PR DESCRIPTION
The Do function assists in calling of functions that must succeed.
It only interacts well with functions that return (T, err).
Signatures with more return arguments are not supported.

Signed-off-by: Joe Tsai <joetsai@digital-static.net>