### PR TITLE
tsconnect: pass in authkey in dev mode

### DIFF
--- a/cmd/tsconnect/src/index.ts
+++ b/cmd/tsconnect/src/index.ts
@@ -18,10 +18,18 @@ async function main() {
   go.run(wasmInstance.instance).then(() =>
     app.handleGoPanic("Unexpected shutdown")
   )
+
+  const params = new URLSearchParams(window.location.search)
+  const authKey = params.get("authkey") ?? undefined
+
   const ipn = newIPN({
     // Persist IPN state in sessionStorage in development, so that we don't need
     // to re-authorize every time we reload the page.
     stateStorage: DEBUG ? sessionStateStorage : undefined,
+    // authKey allows for an auth key to be
+    // specified as a url param which automatically
+    // authorizes the client for use.
+    authKey: DEBUG ? authKey : undefined,
   })
   app.runWithIPN(ipn)
 }

--- a/cmd/tsconnect/src/wasm_js.ts
+++ b/cmd/tsconnect/src/wasm_js.ts
@@ -47,6 +47,7 @@ declare global {
 
   type IPNConfig = {
     stateStorage?: IPNStateStorage
+    authKey?: string
   }
 
   type IPNCallbacks = {


### PR DESCRIPTION
This change allows for an auth key to be specified as a url query param
for use in development mode. If an auth key is specified and valid, it
will authorize the client for use immediately.

Updates #5144

Signed-off-by: Charlotte Brandhorst-Satzkorn <charlotte@tailscale.com>