### PR TITLE
cmd/nginx-auth: allow use of shared nodes

### DIFF
--- a/cmd/nginx-auth/nginx-auth.go
+++ b/cmd/nginx-auth/nginx-auth.go
@@ -63,17 +63,24 @@ func main() {
 			return
 		}
 
-		_, tailnet, ok := strings.Cut(info.Node.Name, info.Node.ComputedName+".")
-		if !ok {
-			w.WriteHeader(http.StatusUnauthorized)
-			log.Printf("can't extract tailnet name from hostname %q", info.Node.Name)
-			return
-		}
-		tailnet, _, ok = strings.Cut(tailnet, ".beta.tailscale.net")
-		if !ok {
-			w.WriteHeader(http.StatusUnauthorized)
-			log.Printf("can't extract tailnet name from hostname %q", info.Node.Name)
-			return
+		// tailnet of connected node. When accessing shared nodes, this
+		// will be empty because the tailnet of the sharee is not exposed.
+		var tailnet string
+
+		if !info.Node.Hostinfo.ShareeNode() {
+			var ok bool
+			_, tailnet, ok = strings.Cut(info.Node.Name, info.Node.ComputedName+".")
+			if !ok {
+				w.WriteHeader(http.StatusUnauthorized)
+				log.Printf("can't extract tailnet name from hostname %q", info.Node.Name)
+				return
+			}
+			tailnet, _, ok = strings.Cut(tailnet, ".beta.tailscale.net")
+			if !ok {
+				w.WriteHeader(http.StatusUnauthorized)
+				log.Printf("can't extract tailnet name from hostname %q", info.Node.Name)
+				return
+			}
 		}
 
 		if expectedTailnet := r.Header.Get("Expected-Tailnet"); expectedTailnet != "" && expectedTailnet != tailnet {


### PR DESCRIPTION
When sharing nodes, the name of the sharee node is not exposed (instead it is hardcoded to "device-of-shared-to-user"), which means that we can't determine the tailnet of that node.  Don't immediately fail when that happens, since it only matters if "Expected-Tailnet" is used.