### PR TITLE
util/sha256x: rename Hash as Block512

### DIFF
--- a/util/deephash/deephash.go
+++ b/util/deephash/deephash.go
@@ -34,7 +34,7 @@ import (
 	"time"
 	"unsafe"
 
-	"tailscale.com/util/sha256x"
+	hashx "tailscale.com/util/sha256x"
 )
 
 // There is much overlap between the theory of serialization and hashing.
@@ -82,7 +82,7 @@ const scratchSize = 128
 // hasher is reusable state for hashing a value.
 // Get one via hasherPool.
 type hasher struct {
-	sha256x.Hash
+	hashx.Block512
 	scratch    [scratchSize]byte
 	visitStack visitStack
 }
@@ -109,6 +109,13 @@ var (
 
 func initSeed() {
 	seed = uint64(time.Now().UnixNano())
+}
+
+func (h *hasher) Reset() {
+	if h.Block512.Hash == nil {
+		h.Block512.Hash = sha256.New()
+	}
+	h.Block512.Reset()
 }
 
 func (h *hasher) sum() (s Sum) {

--- a/util/deephash/deephash_test.go
+++ b/util/deephash/deephash_test.go
@@ -531,7 +531,7 @@ func TestGetTypeHasher(t *testing.T) {
 			fn := getTypeInfo(va.Type()).hasher()
 			hb := &hashBuffer{Hash: sha256.New()}
 			h := new(hasher)
-			h.Hash.H = hb
+			h.Block512.Hash = hb
 			got := fn(h, va)
 			const ptrSize = 32 << uintptr(^uintptr(0)>>63)
 			if tt.out32 != "" && ptrSize == 32 {
@@ -628,7 +628,7 @@ func TestHashMapAcyclic(t *testing.T) {
 		v := addressableValue{reflect.ValueOf(&m).Elem()}
 		hb.Reset()
 		h := new(hasher)
-		h.Hash.H = hb
+		h.Block512.Hash = hb
 		h.hashMap(v, ti, false)
 		h.sum()
 		if got[string(hb.B)] {
@@ -648,7 +648,7 @@ func TestPrintArray(t *testing.T) {
 	x := T{X: [32]byte{1: 1, 31: 31}}
 	hb := &hashBuffer{Hash: sha256.New()}
 	h := new(hasher)
-	h.Hash.H = hb
+	h.Block512.Hash = hb
 	h.hashValue(addressableValue{reflect.ValueOf(&x).Elem()}, false)
 	h.sum()
 	const want = "\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x1f"
@@ -669,7 +669,7 @@ func BenchmarkHashMapAcyclic(b *testing.B) {
 	ti := getTypeInfo(v.Type())
 
 	h := new(hasher)
-	h.Hash.H = hb
+	h.Block512.Hash = hb
 
 	for i := 0; i < b.N; i++ {
 		h.Reset()

--- a/util/sha256x/sha256_test.go
+++ b/util/sha256x/sha256_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package sha256x
+package hashx
 
 import (
 	"crypto/sha256"
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"tailscale.com/util/must"
 )
 
 // naiveHash is an obviously correct implementation of Hash.
@@ -74,7 +75,7 @@ func hashSuite(h hasher) {
 
 func Test(t *testing.T) {
 	c := qt.New(t)
-	h1 := New()
+	h1 := must.Get(New512(sha256.New()))
 	h2 := newNaive()
 	hashSuite(h1)
 	hashSuite(h2)
@@ -84,44 +85,44 @@ func Test(t *testing.T) {
 func TestAllocations(t *testing.T) {
 	c := qt.New(t)
 	c.Run("Sum", func(c *qt.C) {
-		h := New()
+		h := must.Get(New512(sha256.New()))
 		c.Assert(testing.AllocsPerRun(100, func() {
 			var a [sha256.Size]byte
 			h.Sum(a[:0])
 		}), qt.Equals, 0.0)
 	})
 	c.Run("HashUint8", func(c *qt.C) {
-		h := New()
+		h := must.Get(New512(sha256.New()))
 		c.Assert(testing.AllocsPerRun(100, func() {
 			h.HashUint8(0x01)
 		}), qt.Equals, 0.0)
 	})
 	c.Run("HashUint16", func(c *qt.C) {
-		h := New()
+		h := must.Get(New512(sha256.New()))
 		c.Assert(testing.AllocsPerRun(100, func() {
 			h.HashUint16(0x0123)
 		}), qt.Equals, 0.0)
 	})
 	c.Run("HashUint32", func(c *qt.C) {
-		h := New()
+		h := must.Get(New512(sha256.New()))
 		c.Assert(testing.AllocsPerRun(100, func() {
 			h.HashUint32(0x01234567)
 		}), qt.Equals, 0.0)
 	})
 	c.Run("HashUint64", func(c *qt.C) {
-		h := New()
+		h := must.Get(New512(sha256.New()))
 		c.Assert(testing.AllocsPerRun(100, func() {
 			h.HashUint64(0x0123456789abcdef)
 		}), qt.Equals, 0.0)
 	})
 	c.Run("HashBytes", func(c *qt.C) {
-		h := New()
+		h := must.Get(New512(sha256.New()))
 		c.Assert(testing.AllocsPerRun(100, func() {
 			h.HashBytes(bytes)
 		}), qt.Equals, 0.0)
 	})
 	c.Run("HashString", func(c *qt.C) {
-		h := New()
+		h := must.Get(New512(sha256.New()))
 		c.Assert(testing.AllocsPerRun(100, func() {
 			h.HashString("abcdefghijklmnopqrstuvwxyz")
 		}), qt.Equals, 0.0)
@@ -158,7 +159,7 @@ func Fuzz(f *testing.F) {
 		r1 := rand.New(rand.NewSource(seed))
 		r2 := rand.New(rand.NewSource(seed))
 
-		h1 := New()
+		h1 := must.Get(New512(sha256.New()))
 		h2 := newNaive()
 
 		execute(h1, r1)
@@ -185,7 +186,7 @@ func Benchmark(b *testing.B) {
 	var sum [sha256.Size]byte
 	b.Run("Hash", func(b *testing.B) {
 		b.ReportAllocs()
-		h := New()
+		h := must.Get(New512(sha256.New()))
 		for i := 0; i < b.N; i++ {
 			h.Reset()
 			hashSuite(h)


### PR DESCRIPTION
Rename Hash as Block512 to indicate that this is a general-purpose
hash.Hash for any algorithm that operates on 512-bit block sizes.

A subsequent commit will move the sha256x package to hashx.
This is done separately to avoid confusing git.

Signed-off-by: Joe Tsai <joetsai@digital-static.net>