### PR TITLE
tka: Use strict decoding settings, implement Unserialize()

### DIFF
--- a/tka/aum.go
+++ b/tka/aum.go
@@ -212,6 +212,10 @@ func (a *AUM) StaticValidate() error {
 }
 
 // Serialize returns the given AUM in a serialized format.
+//
+// We would implement encoding.BinaryMarshaler, except that would
+// unfortunately get called by the cbor marshaller resulting in infinite
+// recursion.
 func (a *AUM) Serialize() []byte {
 	// Why CBOR and not something like JSON?
 	//
@@ -241,6 +245,16 @@ func (a *AUM) Serialize() []byte {
 		panic(err)
 	}
 	return out.Bytes()
+}
+
+// Unserialize decodes bytes representing a marshaled AUM.
+//
+// We would implement encoding.BinaryUnmarshaler, except that would
+// unfortunately get called by the cbor unmarshaller resulting in infinite
+// recursion.
+func (a *AUM) Unserialize(data []byte) error {
+	dec, _ := cborDecOpts.DecMode()
+	return dec.Unmarshal(data, a)
 }
 
 // Hash returns a cryptographic digest of all AUM contents.

--- a/tka/aum_test.go
+++ b/tka/aum_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fxamacker/cbor/v2"
 	"github.com/google/go-cmp/cmp"
 	"golang.org/x/crypto/blake2s"
 	"tailscale.com/types/tkatype"
@@ -165,7 +164,7 @@ func TestSerialization(t *testing.T) {
 			}
 
 			var decodedAUM AUM
-			if err := cbor.Unmarshal(data, &decodedAUM); err != nil {
+			if err := decodedAUM.Unserialize(data); err != nil {
 				t.Fatalf("Unmarshal failed: %v", err)
 			}
 			if diff := cmp.Diff(tc.AUM, decodedAUM); diff != "" {

--- a/tka/sig.go
+++ b/tka/sig.go
@@ -68,6 +68,10 @@ func (s NodeKeySignature) sigHash() [blake2s.Size]byte {
 }
 
 // Serialize returns the given NKS in a serialized format.
+//
+// We would implement encoding.BinaryMarshaler, except that would
+// unfortunately get called by the cbor marshaller resulting in infinite
+// recursion.
 func (s *NodeKeySignature) Serialize() tkatype.MarshaledSignature {
 	out := bytes.NewBuffer(make([]byte, 0, 128)) // 64byte sig + 32byte keyID + 32byte headroom
 	encoder, err := cbor.CTAP2EncOptions().EncMode()
@@ -81,6 +85,16 @@ func (s *NodeKeySignature) Serialize() tkatype.MarshaledSignature {
 		panic(err)
 	}
 	return out.Bytes()
+}
+
+// Unserialize decodes bytes representing a marshaled NKS.
+//
+// We would implement encoding.BinaryUnmarshaler, except that would
+// unfortunately get called by the cbor unmarshaller resulting in infinite
+// recursion.
+func (s *NodeKeySignature) Unserialize(data []byte) error {
+	dec, _ := cborDecOpts.DecMode()
+	return dec.Unmarshal(data, s)
 }
 
 // verifySignature checks that the NodeKeySignature is authentic and certified

--- a/tka/sig_test.go
+++ b/tka/sig_test.go
@@ -7,6 +7,8 @@ package tka
 import (
 	"crypto/ed25519"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestSigDirect(t *testing.T) {
@@ -30,5 +32,26 @@ func TestSigDirect(t *testing.T) {
 
 	if err := sig.verifySignature(key); err != nil {
 		t.Fatalf("verifySignature() failed: %v", err)
+	}
+}
+
+func TestSigSerializeUnserialize(t *testing.T) {
+	nodeKeyPub := []byte{1, 2, 3, 4}
+	pub, priv := testingKey25519(t, 1)
+	key := Key{Kind: Key25519, Public: pub, Votes: 2}
+	sig := NodeKeySignature{
+		SigKind: SigDirect,
+		KeyID:   key.ID(),
+		Pubkey:  nodeKeyPub,
+	}
+	sigHash := sig.sigHash()
+	sig.Signature = ed25519.Sign(priv, sigHash[:])
+
+	var decoded NodeKeySignature
+	if err := decoded.Unserialize(sig.Serialize()); err != nil {
+		t.Fatalf("Unserialize() failed: %v", err)
+	}
+	if diff := cmp.Diff(sig, decoded); diff != "" {
+		t.Errorf("unmarshalled version differs (-want, +got):\n%s", diff)
 	}
 }

--- a/tka/tailchonk.go
+++ b/tka/tailchonk.go
@@ -261,8 +261,13 @@ func (c *FS) get(h AUMHash) (*fsHashInfo, error) {
 	}
 	defer f.Close()
 
+	m, err := cborDecOpts.DecMode()
+	if err != nil {
+		return nil, err
+	}
+
 	var out fsHashInfo
-	if err := cbor.NewDecoder(f).Decode(&out); err != nil {
+	if err := m.NewDecoder(f).Decode(&out); err != nil {
 		return nil, err
 	}
 	if out.AUM != nil && out.AUM.Hash() != h {
@@ -420,8 +425,13 @@ func (c *FS) commit(h AUMHash, updater func(*fsHashInfo)) error {
 		return fmt.Errorf("creating directory: %v", err)
 	}
 
+	m, err := cbor.CTAP2EncOptions().EncMode()
+	if err != nil {
+		return fmt.Errorf("cbor EncMode: %v", err)
+	}
+
 	var buff bytes.Buffer
-	if err := cbor.NewEncoder(&buff).Encode(toCommit); err != nil {
+	if err := m.NewEncoder(&buff).Encode(toCommit); err != nil {
 		return fmt.Errorf("encoding: %v", err)
 	}
 	return atomicfile.WriteFile(filepath.Join(dir, base), buff.Bytes(), 0644)

--- a/tka/tka_test.go
+++ b/tka/tka_test.go
@@ -317,11 +317,11 @@ func TestCreateBootstrapAuthority(t *testing.T) {
 	}
 
 	// Both authorities should trust the key laid down in the genesis state.
-	if _, err := a1.state.GetKey(key.ID()); err != nil {
-		t.Errorf("reading genesis key from a1: %v", err)
+	if !a1.KeyTrusted(key.ID()) {
+		t.Error("a1 did not trust genesis key")
 	}
-	if _, err := a2.state.GetKey(key.ID()); err != nil {
-		t.Errorf("reading genesis key from a2: %v", err)
+	if !a2.KeyTrusted(key.ID()) {
+		t.Error("a2 did not trust genesis key")
 	}
 }
 


### PR DESCRIPTION
Unfortunately I can't use the regular names `MarshalBinary()` and `UnmarshalBinary()` due to cbor semantics :(