### PR TITLE
net/dns: [win] respond with SERVFAIL queries when no resolvers

### DIFF
--- a/net/dns/manager.go
+++ b/net/dns/manager.go
@@ -214,12 +214,11 @@ func (m *Manager) compileConfig(cfg Config) (rcfg resolver.Config, ocfg OSConfig
 	rcfg.Routes = routes
 	ocfg.Nameservers = []netip.Addr{cfg.serviceIP()}
 
-	// If the OS can't do native split-dns, read out the underlying
-	// resolver config and blend it into our config.
 	if m.os.SupportsSplitDNS() {
 		ocfg.MatchDomains = cfg.matchDomains()
-	}
-	if !m.os.SupportsSplitDNS() || isWindows {
+	} else {
+		// If the OS can't do native split-dns, read out the underlying
+		// resolver config and blend it into our config.
 		bcfg, err := m.os.GetBaseConfig()
 		if err != nil {
 			health.SetDNSOSHealth(err)


### PR DESCRIPTION
Currently we forward unmatched queries to the default resolver on
Windows. This results in duplicate queries being issued to the same
resolver which is just wasted.

Updates #1659

Signed-off-by: Maisem Ali <maisem@tailscale.com>