### PR TITLE
util/deephash: remove unused stack slice in typeIsRecursive

### DIFF
--- a/util/deephash/deephash.go
+++ b/util/deephash/deephash.go
@@ -647,8 +647,6 @@ func getTypeInfoLocked(t reflect.Type, incomplete map[reflect.Type]*typeInfo) *t
 func typeIsRecursive(t reflect.Type) bool {
 	inStack := map[reflect.Type]bool{}
 
-	var stack []reflect.Type
-
 	var visitType func(t reflect.Type) (isRecursiveSoFar bool)
 	visitType = func(t reflect.Type) (isRecursiveSoFar bool) {
 		switch t.Kind() {
@@ -679,11 +677,9 @@ func typeIsRecursive(t reflect.Type) bool {
 		if inStack[t] {
 			return true
 		}
-		stack = append(stack, t)
 		inStack[t] = true
 		defer func() {
 			delete(inStack, t)
-			stack = stack[:len(stack)-1]
 		}()
 
 		switch t.Kind() {


### PR DESCRIPTION
No operation ever reads from this variable.

Signed-off-by: Joe Tsai <joetsai@digital-static.net>