### PR TITLE
util/deephash: completely refactor

### DIFF
--- a/util/deephash/deephash_test.go
+++ b/util/deephash/deephash_test.go
@@ -7,8 +7,6 @@ package deephash
 import (
 	"archive/tar"
 	"crypto/sha256"
-	"encoding/binary"
-	"fmt"
 	"hash"
 	"io"
 	"math"
@@ -27,7 +25,6 @@ import (
 	"tailscale.com/types/ipproto"
 	"tailscale.com/types/key"
 	"tailscale.com/types/structs"
-	"tailscale.com/util/deephash/testtype"
 	"tailscale.com/util/dnsname"
 	"tailscale.com/version"
 	"tailscale.com/wgengine/filter"
@@ -401,6 +398,7 @@ func TestCanMemHash(t *testing.T) {
 	}
 }
 
+/*
 func u8(n uint8) string   { return string([]byte{n}) }
 func u16(n uint16) string { return string(binary.LittleEndian.AppendUint16(nil, n)) }
 func u32(n uint32) string { return string(binary.LittleEndian.AppendUint32(nil, n)) }
@@ -652,6 +650,7 @@ func TestGetTypeHasher(t *testing.T) {
 		})
 	}
 }
+*/
 
 var sink Sum
 
@@ -715,6 +714,7 @@ func BenchmarkHashPacketFilter(b *testing.B) {
 	}
 }
 
+/*
 func TestHashMapAcyclic(t *testing.T) {
 	m := map[int]string{}
 	for i := 0; i < 100; i++ {
@@ -778,6 +778,7 @@ func BenchmarkHashMapAcyclic(b *testing.B) {
 		h.hashMap(v, ti, false)
 	}
 }
+*/
 
 func BenchmarkTailcfgNode(b *testing.B) {
 	b.ReportAllocs()

--- a/util/deephash/pointer.go
+++ b/util/deephash/pointer.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package deephash
+
+import (
+	"net/netip"
+	"reflect"
+	"time"
+	"unsafe"
+)
+
+// unsafePointer is an untyped pointer.
+// It is the caller's responsibility to call operations on the correct type.
+type unsafePointer struct{ p unsafe.Pointer }
+
+func unsafePointerOf(v reflect.Value) unsafePointer {
+	return unsafePointer{v.UnsafePointer()}
+}
+func (p unsafePointer) isNil() bool {
+	return p.p == nil
+}
+func (p unsafePointer) pointerElem() unsafePointer {
+	return unsafePointer{*(*unsafe.Pointer)(p.p)}
+}
+func (p unsafePointer) sliceLen() int {
+	return (*reflect.SliceHeader)(p.p).Len
+}
+func (p unsafePointer) sliceArray() unsafePointer {
+	return unsafePointer{unsafe.Pointer((*reflect.SliceHeader)(p.p).Data)}
+}
+func (p unsafePointer) arrayIndex(index int, size uintptr) unsafePointer {
+	return unsafePointer{unsafe.Add(p.p, uintptr(index)*size)}
+}
+func (p unsafePointer) structField(index int, offset, size uintptr) unsafePointer {
+	return unsafePointer{unsafe.Add(p.p, offset)}
+}
+func (p unsafePointer) asString() *string {
+	return (*string)(p.p)
+}
+func (p unsafePointer) asTime() *time.Time {
+	return (*time.Time)(p.p)
+}
+func (p unsafePointer) asAddr() *netip.Addr {
+	return (*netip.Addr)(p.p)
+}
+func (p unsafePointer) asValue(typ reflect.Type) reflect.Value {
+	return reflect.NewAt(typ, p.p)
+}
+func (p unsafePointer) asMemory(size uintptr) []byte {
+	return unsafe.Slice((*byte)(p.p), size)
+}

--- a/util/deephash/pointer_norace.go
+++ b/util/deephash/pointer_norace.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !race
+
+package deephash
+
+import "reflect"
+
+type pointer = unsafePointer
+
+func pointerOf(v reflect.Value) pointer { return unsafePointerOf(v) }

--- a/util/deephash/pointer_race.go
+++ b/util/deephash/pointer_race.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build race
+
+package deephash
+
+import (
+	"fmt"
+	"net/netip"
+	"reflect"
+	"time"
+)
+
+// pointer is a typed pointer that performs safety checks for every operation.
+type pointer struct {
+	unsafePointer
+	t reflect.Type // type of pointed-at value; may be nil
+	n uintptr      // size of valid memory after p
+}
+
+func pointerOf(v reflect.Value) pointer {
+	assert(v.Kind() == reflect.Pointer, "got %v, want pointer", v.Kind())
+	te := v.Type().Elem()
+	return pointer{unsafePointerOf(v), te, te.Size()}
+}
+
+func (p pointer) pointerElem() pointer {
+	assert(p.t.Kind() == reflect.Pointer, "got %v, want pointer", p.t.Kind())
+	te := p.t.Elem()
+	return pointer{p.unsafePointer.pointerElem(), te, te.Size()}
+}
+
+func (p pointer) sliceLen() int {
+	assert(p.t.Kind() == reflect.Slice, "got %v, want slice", p.t.Kind())
+	return p.unsafePointer.sliceLen()
+}
+
+func (p pointer) sliceArray() pointer {
+	assert(p.t.Kind() == reflect.Slice, "got %v, want slice", p.t.Kind())
+	n := p.sliceLen()
+	assert(n >= 0, "got negative slice length %d", n)
+	ta := reflect.ArrayOf(n, p.t.Elem())
+	return pointer{p.unsafePointer.sliceArray(), ta, ta.Size()}
+}
+
+func (p pointer) arrayIndex(index int, size uintptr) pointer {
+	assert(p.t.Kind() == reflect.Array, "got %v, want array", p.t.Kind())
+	assert(0 <= index && index < p.t.Len(), "got array of size %d, want to access element %d", p.t.Len(), index)
+	assert(p.t.Elem().Size() == size, "got element size of %d, want %d", p.t.Elem().Size(), size)
+	te := p.t.Elem()
+	return pointer{p.unsafePointer.arrayIndex(index, size), te, te.Size()}
+}
+
+func (p pointer) structField(index int, offset, size uintptr) pointer {
+	assert(p.t.Kind() == reflect.Struct, "got %v, want struct", p.t.Kind())
+	assert(p.n >= offset, "got size of %d, want excessive start offset of %d", p.n, offset)
+	assert(p.n >= offset+size, "got size of %d, want excessive end offset of %d", p.n, offset+size)
+	if index < 0 {
+		return pointer{p.unsafePointer.structField(index, offset, size), nil, size}
+	}
+	sf := p.t.Field(index)
+	t := sf.Type
+	assert(sf.Offset == offset, "got offset of %d, want offset %d", sf.Offset, offset)
+	assert(t.Size() == size, "got size of %d, want size %d", t.Size(), size)
+	return pointer{p.unsafePointer.structField(index, offset, size), t, t.Size()}
+}
+
+func (p pointer) asString() *string {
+	assert(p.t.Kind() == reflect.String, "got %v, want string", p.t)
+	return p.unsafePointer.asString()
+}
+
+func (p pointer) asTime() *time.Time {
+	assert(p.t == timeTimeType, "got %v, want %v", p.t, timeTimeType)
+	return p.unsafePointer.asTime()
+}
+
+func (p pointer) asAddr() *netip.Addr {
+	assert(p.t == netipAddrType, "got %v, want %v", p.t, netipAddrType)
+	return p.unsafePointer.asAddr()
+}
+
+func (p pointer) asValue(typ reflect.Type) reflect.Value {
+	assert(p.t == typ, "got %v, want %v", p.t, typ)
+	return p.unsafePointer.asValue(typ)
+}
+
+func (p pointer) asMemory(size uintptr) []byte {
+	assert(p.n >= size, "got size of %d, want excessive size of %d", p.n, size)
+	return p.unsafePointer.asMemory(size)
+}
+
+func assert(b bool, f string, a ...any) {
+	if !b {
+		panic(fmt.Sprintf(f, a...))
+	}
+}


### PR DESCRIPTION
DO NOT SUBMIT

This is an experiment to see where we would want this to go.
If we're already using unsafe to hash memory,
then embrace the use of unsafe and stay out of reflect.

Rather than a typeHasherFunc that operates on

	func(*hasher, addressableValue)

we operate on

	func(*hasher, unsafe.Pointer)

where the unsafe.Pointer is identical to addressableValue.UnsafePointer.

We drop support for interface{ AppendTo([]byte) []byte }.
While that was more efficient in the prior pure-reflect implementation,
it is no longer true today. Instead, rely on direct memory hashing
of crypto-key types that have this method, and/or add direct
support for types that cannot be memory hashed
(for example time.Time and netip.Addr).

Performance:

	Hash-24                18.4µs ± 1%    13.5µs ± 1%  -26.82%  (p=0.000 n=9+9)
	HashPacketFilter-24    2.52µs ± 3%    2.24µs ± 1%  -11.14%  (p=0.000 n=10+10)
	TailcfgNode-24         1.42µs ± 1%    1.35µs ± 1%   -4.99%  (p=0.000 n=10+10)
	HashArray-24            324ns ± 1%     312ns ± 1%   -3.76%  (p=0.000 n=9+10)

SHA-256 hashing now takes up ~55% of the benchmark time.
We will get an additional boost in performance when Go's crypto/sha256
package uses native instructions. See https://go.dev/cl/408795.

Signed-off-by: Joe Tsai <joetsai@digital-static.net>