### PR TITLE
util/deephash: avoid variadic argument for Update

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1180,7 +1180,15 @@ func (b *LocalBackend) updateFilterLocked(netMap *netmap.NetworkMap, prefs *ipn.
 		sshPol = *netMap.SSHPolicy
 	}
 
-	changed := deephash.Update(&b.filterHash, haveNetmap, addrs, packetFilter, localNets.Ranges(), logNets.Ranges(), shieldsUp, sshPol)
+	changed := deephash.Update(&b.filterHash, &struct {
+		HaveNetmap  bool
+		Addrs       []netip.Prefix
+		FilterMatch []filter.Match
+		LocalNets   []netipx.IPRange
+		LogNets     []netipx.IPRange
+		ShieldsUp   bool
+		SSHPolicy   tailcfg.SSHPolicy
+	}{haveNetmap, addrs, packetFilter, localNets.Ranges(), logNets.Ranges(), shieldsUp, sshPol})
 	if !changed {
 		return
 	}

--- a/util/deephash/deephash.go
+++ b/util/deephash/deephash.go
@@ -188,14 +188,13 @@ func HasherForType[T any]() func(T) Sum {
 }
 
 // Update sets last to the hash of v and reports whether its value changed.
-func Update(last *Sum, v ...any) (changed bool) {
+func Update(last *Sum, v any) (changed bool) {
 	sum := Hash(v)
-	if sum == *last {
-		// unchanged.
-		return false
+	changed = sum != *last
+	if changed {
+		*last = sum
 	}
-	*last = sum
-	return true
+	return changed
 }
 
 var appenderToType = reflect.TypeOf((*appenderTo)(nil)).Elem()


### PR DESCRIPTION
Hashing []any is slow since hashing of interfaces is slow.
Hashing of interfaces is slow since we pessimistically assume
that cycles can occur through them and start cycle tracking.

Drop the variadic signature of Update and fix callers to pass in
an anonymous struct so that we are hashing concrete types
near the root of the value tree.

Signed-off-by: Joe Tsai <joetsai@digital-static.net>