### PR TITLE
cmd/tailscale/cli: fix build break

### DIFF
--- a/cmd/tailscale/cli/debug.go
+++ b/cmd/tailscale/cli/debug.go
@@ -489,7 +489,7 @@ func runTS2021(ctx context.Context, args []string) error {
 		return c, err
 	}
 
-	conn, err := controlhttp.Dial(ctx, net.JoinHostPort(ts2021Args.host, "80"), machinePrivate, keys.PublicKey, uint16(ts2021Args.version), dialFunc)
+	conn, err := controlhttp.Dial(ctx, ts2021Args.host, "80", "443", machinePrivate, keys.PublicKey, uint16(ts2021Args.version), dialFunc)
 	log.Printf("controlhttp.Dial = %p, %v", conn, err)
 	if err != nil {
 		return err

--- a/control/controlhttp/client_js.go
+++ b/control/controlhttp/client_js.go
@@ -18,25 +18,20 @@ import (
 
 // Variant of Dial that tunnels the request over WebSockets, since we cannot do
 // bi-directional communication over an HTTP connection when in JS.
-func Dial(ctx context.Context, addr string, machineKey key.MachinePrivate, controlKey key.MachinePublic, protocolVersion uint16, dialer dnscache.DialContextFunc) (*controlbase.Conn, error) {
+func Dial(ctx context.Context, host string, httpPort string, httpsPort string, machineKey key.MachinePrivate, controlKey key.MachinePublic, protocolVersion uint16, dialer dnscache.DialContextFunc) (*controlbase.Conn, error) {
 	init, cont, err := controlbase.ClientDeferred(machineKey, controlKey, protocolVersion)
 	if err != nil {
 		return nil, err
 	}
 
-	host, _, err := net.SplitHostPort(addr)
-	if err != nil {
-		return nil, err
-	}
 	wsScheme := "wss"
-	wsHost := host
 	if host == "localhost" {
 		wsScheme = "ws"
-		wsHost = addr
+		host = net.JoinHostPort(host, httpPort)
 	}
 	wsURL := &url.URL{
 		Scheme: wsScheme,
-		Host:   wsHost,
+		Host:   host,
 		Path:   serverUpgradePath,
 		// Can't set HTTP headers on the websocket request, so we have to to send
 		// the handshake via an HTTP header.


### PR DESCRIPTION
Accidental break from 64d482ff482b6a616d7f24f939dbc5093d93909b.

Signed-off-by: Maisem Ali <maisem@tailscale.com>