### PR TITLE
Bump capver for clients to talk Noise over any HTTPS port

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -73,7 +73,8 @@ type CapabilityVersion int
 //	36: 2022-08-02: added PeersChangedPatch.{Key,DiscoKey,Online,LastSeen,KeyExpiry,Capabilities}
 //	37: 2022-08-09: added Debug.{SetForceBackgroundSTUN,SetRandomizeClientPort}; Debug are sticky
 //	38: 2022-08-11: added PingRequest.URLIsNoise
-const CurrentCapabilityVersion CapabilityVersion = 38
+//  39: 2022-08-15: clients can talk Noise over arbitrary HTTPS port
+const CurrentCapabilityVersion CapabilityVersion = 39
 
 type StableID string
 

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -73,7 +73,7 @@ type CapabilityVersion int
 //	36: 2022-08-02: added PeersChangedPatch.{Key,DiscoKey,Online,LastSeen,KeyExpiry,Capabilities}
 //	37: 2022-08-09: added Debug.{SetForceBackgroundSTUN,SetRandomizeClientPort}; Debug are sticky
 //	38: 2022-08-11: added PingRequest.URLIsNoise
-//  39: 2022-08-15: clients can talk Noise over arbitrary HTTPS port
+//	39: 2022-08-15: clients can talk Noise over arbitrary HTTPS port
 const CurrentCapabilityVersion CapabilityVersion = 39
 
 type StableID string


### PR DESCRIPTION
As result of https://github.com/tailscale/tailscale/pull/4323, clients can now connect to Noise over any HTTPS port. Although this is double encryption, it is common for Headscale users (as they tend to use random ports).

Given that Tailscale clients prior to merge that PR expect to have Noise-over-HTTPS in tcp/443, bumping CapabilityVersion helps us to identify which Noise-capable clients (capver<39) we should serve with the legacy protocol.

Signed-off-by: Juan Font Alonso <juanfontalonso@gmail.com>