### PR TITLE
cmd/tailscaled: enable hybrid netstack mode on openbsd too

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -481,7 +481,7 @@ func shouldWrapNetstack() bool {
 		return true
 	}
 	switch runtime.GOOS {
-	case "windows", "darwin", "freebsd":
+	case "windows", "darwin", "freebsd", "openbsd":
 		// Enable on Windows and tailscaled-on-macOS (this doesn't
 		// affect the GUI clients), and on FreeBSD.
 		return true


### PR DESCRIPTION
Apparently OpenBSD can forward packets with manual configuration,

https://github.com/tailscale/tailscale/issues/2498#issuecomment-1114216999

But this makes it work by default. People doing things by hand can
set TS_DEBUG_WRAP_NETSTACK=0 in the environment.
