### PR TITLE
cmd/tsconnect: stop writing build artifacts into src/

### DIFF
--- a/cmd/tsconnect/.gitignore
+++ b/cmd/tsconnect/.gitignore
@@ -1,4 +1,2 @@
-src/wasm_exec.js
-src/main.wasm
 node_modules/
 dist/


### PR DESCRIPTION
We can't write to src/ when tsconnect is used a dependency in another
repo (see also b763a12331d318d2dba52fb5b8ed8a407ba28b00). We therefore
need to switch from writing to src/ to using esbuild plugins to handle
the requests for wasm_exec.js (the Go JS runtime for Wasm) and the
Wasm build of the Go module.

This has the benefit of allowing Go/Wasm changes to be picked up without
restarting the server when in dev mode (Go compilation is fast enough
that we can do this on every request, CSS compilation continues to be
the long pole).

Fixes #5382

Signed-off-by: Mihai Parparita <mihai@tailscale.com>