### PR TITLE
util/deephash: simplify canMemHash

### DIFF
--- a/util/deephash/deephash_test.go
+++ b/util/deephash/deephash_test.go
@@ -379,20 +379,18 @@ func TestCanMemHash(t *testing.T) {
 			_ uint8
 			_ int
 		}{}, false}, // gap
-		{
-			struct {
-				_ structs.Incomparable // if not last, zero-width
-				x int
-			}{},
-			true,
-		},
-		{
-			struct {
-				x int
-				_ structs.Incomparable // zero-width last: has space, can't memhash
-			}{},
-			false,
-		}}
+		{struct {
+			_ structs.Incomparable // if not last, zero-width
+			x int
+		}{}, true},
+		{struct {
+			x int
+			_ structs.Incomparable // zero-width last: has space, can't memhash
+		}{},
+			false},
+		{[0]chan bool{}, true},
+		{struct{ f [0]func() }{}, true},
+	}
 	for _, tt := range tests {
 		got := canMemHash(reflect.TypeOf(tt.val))
 		if got != tt.want {


### PR DESCRIPTION
Put the t.Size() == 0 check first since this is applicable in all cases.
Drop the last struct field conditional since this is covered by the
sumFieldSize check at the end.

Signed-off-by: Joe Tsai <joetsai@digital-static.net>