### PR TITLE
net/dnscache: use net/netip

### DIFF
--- a/net/dnscache/dnscache_test.go
+++ b/net/dnscache/dnscache_test.go
@@ -131,7 +131,7 @@ func TestResolverAllHostStaticResult(t *testing.T) {
 	if got, want := ip6.String(), "2001:4860:4860::8888"; got != want {
 		t.Errorf("ip4 got %q; want %q", got, want)
 	}
-	if got, want := fmt.Sprintf("%q", allIPs), `[{"2001:4860:4860::8888" ""} {"2001:4860:4860::8844" ""} {"8.8.8.8" ""} {"8.8.4.4" ""}]`; got != want {
+	if got, want := fmt.Sprintf("%q", allIPs), `["2001:4860:4860::8888" "2001:4860:4860::8844" "8.8.8.8" "8.8.4.4"]`; got != want {
 		t.Errorf("allIPs got %q; want %q", got, want)
 	}
 


### PR DESCRIPTION
Removes usage of net.IP and net.IPAddr where possible from net/dnscache.

Fixes #5282

Signed-off-by: Kris Brandow <kris.brandow@gmail.com>