### PR TITLE
cmd/tailscale: set /dev/net perms in configure-host

### DIFF
--- a/cmd/tailscale/cli/configure-host.go
+++ b/cmd/tailscale/cli/configure-host.go
@@ -62,6 +62,9 @@ func runConfigureHost(ctx context.Context, args []string) error {
 			return fmt.Errorf("creating /dev/net/tun: %v, %s", err, out)
 		}
 	}
+	if err := os.Chmod("/dev/net", 0755); err != nil {
+		return err
+	}
 	if err := os.Chmod("/dev/net/tun", 0666); err != nil {
 		return err
 	}


### PR DESCRIPTION
Several customers have had issues due to the permissions
on /dev/net. Set permissions to 0755.

Fixes https://github.com/tailscale/tailscale/issues/5048

Signed-off-by: Denton Gentry <dgentry@tailscale.com>