### PR TITLE
fix typo in incomplete default routes error message

### DIFF
--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -252,7 +252,7 @@ func calcAdvertiseRoutes(advertiseRoutes string, advertiseDefaultRoute bool) ([]
 		if default4 && !default6 {
 			return nil, fmt.Errorf("%s advertised without its IPv6 counterpart, please also advertise %s", ipv4default, ipv6default)
 		} else if default6 && !default4 {
-			return nil, fmt.Errorf("%s advertised without its IPv6 counterpart, please also advertise %s", ipv6default, ipv4default)
+			return nil, fmt.Errorf("%s advertised without its IPv4 counterpart, please also advertise %s", ipv6default, ipv4default)
 		}
 	}
 	if advertiseDefaultRoute {


### PR DESCRIPTION
this message shows up when running:

```sh
$ sudo tailscale up --advertise-routes=::/0 --advertise-exit-node
::/0 advertised without its IPv6 counterpart, please also advertise 0.0.0.0/0
```