### PR TITLE
licenses: add GitHub Action to update license notices

### DIFF
--- a/.github/licenses.tmpl
+++ b/.github/licenses.tmpl
@@ -1,6 +1,6 @@
 # Tailscale CLI and daemon dependencies
 
-The follow open source dependencies are used to build the [tailscale][] and
+The following open source dependencies are used to build the [tailscale][] and
 [tailscaled][] commands. These are primarily used on Linux and BSD variants as
 well as an [option for macOS][].
 

--- a/.github/licenses.tmpl
+++ b/.github/licenses.tmpl
@@ -1,0 +1,17 @@
+# Tailscale CLI and daemon dependencies
+
+The follow open source dependencies are used to build the [tailscale][] and
+[tailscaled][] commands. These are primarily used on Linux and BSD variants as
+well as an [option for macOS][].
+
+[tailscale]: https://pkg.go.dev/tailscale.com/cmd/tailscale
+[tailscaled]: https://pkg.go.dev/tailscale.com/cmd/tailscaled
+[option for macOS]: https://tailscale.com/kb/1065/macos-variants/
+
+## Go Packages
+
+Some packages may only be included on certain architectures or operating systems.
+
+{{ range . }}
+ - [{{.Name}}](https://pkg.go.dev/{{.Name}}) ([{{.LicenseName}}]({{.LicenseURL}}))
+{{- end }}

--- a/.github/workflows/go-licenses.yml
+++ b/.github/workflows/go-licenses.yml
@@ -1,0 +1,62 @@
+name: go-licenses
+
+on:
+  # run action when a change lands in the main branch which updates go.mod or
+  # our license template file. Also allow manual triggering.
+  push:
+    branches:
+      - main
+    paths:
+      - go.mod
+      - .github/licenses.tmpl
+      - .github/workflows/go-licenses.yml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  tailscale:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+
+      - name: Install go-licenses
+        run: |
+          go install github.com/google/go-licenses@v1.2.2-0.20220825154955-5eedde1c6584
+
+      - name: Run go-licenses
+        env:
+          # include all build tags to include platform-specific dependencies
+          GOFLAGS: "-tags=cgo,darwin,freebsd,ios,js,linux,openbsd,wasm,windows"
+        run: |
+          mkdir -p licenses
+          go-licenses report tailscale.com/cmd/tailscale tailscale.com/cmd/tailscaled > licenses/tailscale.md --template .github/licenses.tmpl
+
+      - name: Get access token
+        uses: tibdex/github-app-token@f717b5ecd4534d3c4df4ce9b5c1c2214f0f7cd06 # v1.6.0
+        id: generate-token
+        with:
+          app_id: ${{ secrets.LICENSING_APP_ID }}
+          private_key: ${{ secrets.LICENSING_APP_PRIVATE_KEY }}
+
+      - name: Send pull request
+        uses: peter-evans/create-pull-request@18f90432bedd2afd6a825469ffd38aa24712a91d #v4.1.1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          author: License Updater <noreply@tailscale.com>
+          branch: licenses/cli
+          branch-suffix: short-commit-hash
+          commit-message: "licenses: update tailscale{,d} licenses"
+          title: "licenses: update tailscale{,d} licenses"
+          body: Triggered by ${{ github.repository }}@${{ github.sha }}
+          delete-branch: true
+          team-reviewers: opensource-license-reviewers

--- a/.github/workflows/go-licenses.yml
+++ b/.github/workflows/go-licenses.yml
@@ -38,7 +38,7 @@ jobs:
           # include all build tags to include platform-specific dependencies
           GOFLAGS: "-tags=cgo,darwin,freebsd,ios,js,linux,openbsd,wasm,windows"
         run: |
-          mkdir -p licenses
+          [ -d licenses ] || mkdir licenses
           go-licenses report tailscale.com/cmd/tailscale tailscale.com/cmd/tailscaled > licenses/tailscale.md --template .github/licenses.tmpl
 
       - name: Get access token

--- a/.github/workflows/go-licenses.yml
+++ b/.github/workflows/go-licenses.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run go-licenses
         env:
           # include all build tags to include platform-specific dependencies
-          GOFLAGS: "-tags=cgo,darwin,freebsd,ios,js,linux,openbsd,wasm,windows"
+          GOFLAGS: "-tags=android,cgo,darwin,freebsd,ios,js,linux,openbsd,wasm,windows"
         run: |
           [ -d licenses ] || mkdir licenses
           go-licenses report tailscale.com/cmd/tailscale tailscale.com/cmd/tailscaled > licenses/tailscale.md --template .github/licenses.tmpl


### PR DESCRIPTION
This will update a licenses/tailscale.md file with all of our go dependencies and their respective licenses. Notices for other clients will be triggered by similar actions in other repos.

Updates tailscale/corp#5780

Example output that this will result in: https://github.com/willnorris/tailscale/blob/main/licenses/tailscale.md