### PR TITLE
ipn/ipnlocal: fix Taildrop not returning any sharing targets

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3287,7 +3287,7 @@ func (b *LocalBackend) FileTargets() ([]*apitype.FileTarget, error) {
 		return nil, errors.New("file sharing not enabled by Tailscale admin")
 	}
 	for _, p := range nm.Peers {
-		if p.User != nm.User || !slices.Contains(p.Capabilities, tailcfg.CapabilityFileSharingTarget) {
+		if p.User != nm.User && !slices.Contains(p.Capabilities, tailcfg.CapabilityFileSharingTarget) {
 			continue
 		}
 		peerAPI := peerAPIBase(b.netMap, p)


### PR DESCRIPTION
The CapabilityFileSharingTarget capability added by eb32847d8525e61c7435
is meant to control the ability to share with nodes not owned by the
current user, not to restrict all sharing (the coordination server is
not currently populating the capability at all)

Fixes tailscale/corp#6669

Signed-off-by: Mihai Parparita <mihai@tailscale.com>