### PR TITLE
cmd/tsconnect: expose runSSHSession in npm package

### DIFF
--- a/cmd/tsconnect/src/app/ssh.tsx
+++ b/cmd/tsconnect/src/app/ssh.tsx
@@ -3,13 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import { useState, useCallback } from "preact/hooks"
-import { Terminal } from "xterm"
-import { FitAddon } from "xterm-addon-fit"
-
-type SSHSessionDef = {
-  username: string
-  hostname: string
-}
+import { runSSHSession, SSHSessionDef } from "../lib/ssh"
 
 export function SSH({ netMap, ipn }: { netMap: IPNNetMap; ipn: IPN }) {
   const [sshSessionDef, setSSHSessionDef] = useState<SSHSessionDef | null>(null)
@@ -53,51 +47,6 @@ function SSHSession({
       }}
     />
   )
-}
-
-function runSSHSession(
-  termContainerNode: HTMLDivElement,
-  def: SSHSessionDef,
-  ipn: IPN,
-  onDone: () => void
-) {
-  const term = new Terminal({
-    cursorBlink: true,
-  })
-  const fitAddon = new FitAddon()
-  term.loadAddon(fitAddon)
-  term.open(termContainerNode)
-  fitAddon.fit()
-
-  let onDataHook: ((data: string) => void) | undefined
-  term.onData((e) => {
-    onDataHook?.(e)
-  })
-
-  term.focus()
-
-  const sshSession = ipn.ssh(def.hostname, def.username, {
-    writeFn: (input) => term.write(input),
-    setReadFn: (hook) => (onDataHook = hook),
-    rows: term.rows,
-    cols: term.cols,
-    onDone: () => {
-      resizeObserver.disconnect()
-      term.dispose()
-      window.removeEventListener("beforeunload", handleBeforeUnload)
-      onDone()
-    },
-  })
-
-  // Make terminal and SSH session track the size of the containing DOM node.
-  const resizeObserver = new ResizeObserver(() => fitAddon.fit())
-  resizeObserver.observe(termContainerNode)
-  term.onResize(({ rows, cols }) => sshSession.resize(rows, cols))
-
-  // Close the session if the user closes the window without an explicit
-  // exit.
-  const handleBeforeUnload = () => sshSession.close()
-  window.addEventListener("beforeunload", handleBeforeUnload)
 }
 
 function NoSSHPeers() {

--- a/cmd/tsconnect/src/lib/ssh.ts
+++ b/cmd/tsconnect/src/lib/ssh.ts
@@ -1,0 +1,52 @@
+import { Terminal } from "xterm"
+import { FitAddon } from "xterm-addon-fit"
+
+export type SSHSessionDef = {
+  username: string
+  hostname: string
+}
+
+export function runSSHSession(
+  termContainerNode: HTMLDivElement,
+  def: SSHSessionDef,
+  ipn: IPN,
+  onDone: () => void
+) {
+  const term = new Terminal({
+    cursorBlink: true,
+  })
+  const fitAddon = new FitAddon()
+  term.loadAddon(fitAddon)
+  term.open(termContainerNode)
+  fitAddon.fit()
+
+  let onDataHook: ((data: string) => void) | undefined
+  term.onData((e) => {
+    onDataHook?.(e)
+  })
+
+  term.focus()
+
+  const sshSession = ipn.ssh(def.hostname, def.username, {
+    writeFn: (input) => term.write(input),
+    setReadFn: (hook) => (onDataHook = hook),
+    rows: term.rows,
+    cols: term.cols,
+    onDone: () => {
+      resizeObserver.disconnect()
+      term.dispose()
+      window.removeEventListener("beforeunload", handleBeforeUnload)
+      onDone()
+    },
+  })
+
+  // Make terminal and SSH session track the size of the containing DOM node.
+  const resizeObserver = new ResizeObserver(() => fitAddon.fit())
+  resizeObserver.observe(termContainerNode)
+  term.onResize(({ rows, cols }) => sshSession.resize(rows, cols))
+
+  // Close the session if the user closes the window without an explicit
+  // exit.
+  const handleBeforeUnload = () => sshSession.close()
+  window.addEventListener("beforeunload", handleBeforeUnload)
+}

--- a/cmd/tsconnect/src/pkg/pkg.ts
+++ b/cmd/tsconnect/src/pkg/pkg.ts
@@ -37,3 +37,5 @@ export async function createIPN(config: IPNPackageConfig): Promise<IPN> {
 
   return newIPN(config)
 }
+
+export { runSSHSession } from "../lib/ssh"


### PR DESCRIPTION
Move it to lib/ so that it can be used in both the app and the package.

Updates #5415

Signed-off-by: Mihai Parparita <mihai@tailscale.com>