### PR TITLE
cmd/tailscale: add licenses subcommand

### DIFF
--- a/cmd/tailscale/cli/cli.go
+++ b/cmd/tailscale/cli/cli.go
@@ -170,6 +170,7 @@ change in the future.
 			bugReportCmd,
 			certCmd,
 			netlockCmd,
+			licensesCmd,
 		},
 		FlagSet:   rootfs,
 		Exec:      func(context.Context, []string) error { return flag.ErrHelp },

--- a/cmd/tailscale/cli/licenses.go
+++ b/cmd/tailscale/cli/licenses.go
@@ -6,6 +6,7 @@ package cli
 
 import (
 	"context"
+	"runtime"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 )
@@ -19,11 +20,23 @@ var licensesCmd = &ffcli.Command{
 }
 
 func runLicenses(ctx context.Context, args []string) error {
+	var licenseURL string
+	switch runtime.GOOS {
+	case "android":
+		licenseURL = "https://tailscale.com/licenses/android"
+	case "darwin", "ios":
+		licenseURL = "https://tailscale.com/licenses/apple"
+	case "windows":
+		licenseURL = "https://tailscale.com/licenses/windows"
+	default:
+		licenseURL = "https://tailscale.com/licenses/tailscale"
+	}
+
 	outln(`
 Tailscale wouldn't be possible without the contributions of thousands of open
 source developers. To see the open source packages included in Tailscale and
 their respective license information, visit:
 
-    https://tailscale.com/licenses/tailscale`)
+    ` + licenseURL)
 	return nil
 }

--- a/cmd/tailscale/cli/licenses.go
+++ b/cmd/tailscale/cli/licenses.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cli
+
+import (
+	"context"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+)
+
+var licensesCmd = &ffcli.Command{
+	Name:       "licenses",
+	ShortUsage: "licenses",
+	ShortHelp:  "Get open source license information",
+	LongHelp:   "Get open source license information",
+	Exec:       runLicenses,
+}
+
+func runLicenses(ctx context.Context, args []string) error {
+	outln(`
+Tailscale wouldn't be possible without the contributions of thousands of open
+source developers. To see the open source packages included in Tailscale and
+their respective license information, visit:
+
+    https://tailscale.com/licenses/tailscale`)
+	return nil
+}


### PR DESCRIPTION
`tailscale licenses` will direct users to https://tailscale.com/licenses/tailscale for dependencies and licenses.

I'm not currently adding license information to tailscaled, since I believe we pretty much always distribute them together, and the link above covers the dependencies for both binaries.

Updates tailscale/corp#5780