### PR TITLE
tka: make storage a parameter rather than an Authority struct member

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -148,7 +148,7 @@ type LocalBackend struct {
 	inServerMode   bool
 	machinePrivKey key.MachinePrivate
 	nlPrivKey      key.NLPrivate
-	tka            *tka.Authority
+	tka            *tkaState
 	state          ipn.State
 	capFileSharing bool // whether netMap contains the file sharing capability
 	// hostinfo is mutated in-place while mu is held.
@@ -2507,8 +2507,11 @@ func dnsConfigForNetmap(nm *netmap.NetworkMap, prefs *ipn.Prefs, logf logger.Log
 // used for locked tailnets.
 //
 // It should only be called before the LocalBackend is used.
-func (b *LocalBackend) SetTailnetKeyAuthority(a *tka.Authority) {
-	b.tka = a
+func (b *LocalBackend) SetTailnetKeyAuthority(a *tka.Authority, storage *tka.FS) {
+	b.tka = &tkaState{
+		authority: a,
+		storage:   storage,
+	}
 }
 
 // SetVarRoot sets the root directory of Tailscale's writable

--- a/ipn/ipnlocal/network-lock.go
+++ b/ipn/ipnlocal/network-lock.go
@@ -26,6 +26,11 @@ import (
 
 var networkLockAvailable = envknob.Bool("TS_EXPERIMENTAL_NETWORK_LOCK")
 
+type tkaState struct {
+	authority *tka.Authority
+	storage   *tka.FS
+}
+
 // CanSupportNetworkLock returns true if tailscaled is able to operate
 // a local tailnet key authority (and hence enforce network lock).
 func (b *LocalBackend) CanSupportNetworkLock() bool {
@@ -54,7 +59,7 @@ func (b *LocalBackend) NetworkLockStatus() *ipnstate.NetworkLockStatus {
 	}
 
 	var head [32]byte
-	h := b.tka.Head()
+	h := b.tka.authority.Head()
 	copy(head[:], h[:])
 
 	return &ipnstate.NetworkLockStatus{

--- a/ipn/ipnserver/server.go
+++ b/ipn/ipnserver/server.go
@@ -775,15 +775,15 @@ func New(logf logger.Logf, logid string, store ipn.StateStore, eng wgengine.Engi
 		chonkDir := filepath.Join(root, "chonk")
 		if _, err := os.Stat(chonkDir); err == nil {
 			// The directory exists, which means network-lock has been initialized.
-			chonk, err := tka.ChonkDir(chonkDir)
+			storage, err := tka.ChonkDir(chonkDir)
 			if err != nil {
 				return nil, fmt.Errorf("opening tailchonk: %v", err)
 			}
-			authority, err := tka.Open(chonk)
+			authority, err := tka.Open(storage)
 			if err != nil {
 				return nil, fmt.Errorf("initializing tka: %v", err)
 			}
-			b.SetTailnetKeyAuthority(authority)
+			b.SetTailnetKeyAuthority(authority, storage)
 			logf("tka initialized at head %x", authority.Head())
 		}
 	} else {

--- a/tka/builder_test.go
+++ b/tka/builder_test.go
@@ -28,7 +28,8 @@ func TestAuthorityBuilderAddKey(t *testing.T) {
 	pub, priv := testingKey25519(t, 1)
 	key := Key{Kind: Key25519, Public: pub, Votes: 2}
 
-	a, _, err := Create(&Mem{}, State{
+	storage := &Mem{}
+	a, _, err := Create(storage, State{
 		Keys:               []Key{key},
 		DisablementSecrets: [][]byte{disablementKDF([]byte{1, 2, 3})},
 	}, signer25519(priv))
@@ -50,7 +51,7 @@ func TestAuthorityBuilderAddKey(t *testing.T) {
 
 	// See if the update is valid by applying it to the authority
 	// + checking if the new key is there.
-	if err := a.Inform(updates); err != nil {
+	if err := a.Inform(storage, updates); err != nil {
 		t.Fatalf("could not apply generated updates: %v", err)
 	}
 	if _, err := a.state.GetKey(key2.ID()); err != nil {
@@ -64,7 +65,8 @@ func TestAuthorityBuilderRemoveKey(t *testing.T) {
 	pub2, _ := testingKey25519(t, 2)
 	key2 := Key{Kind: Key25519, Public: pub2, Votes: 1}
 
-	a, _, err := Create(&Mem{}, State{
+	storage := &Mem{}
+	a, _, err := Create(storage, State{
 		Keys:               []Key{key, key2},
 		DisablementSecrets: [][]byte{disablementKDF([]byte{1, 2, 3})},
 	}, signer25519(priv))
@@ -83,7 +85,7 @@ func TestAuthorityBuilderRemoveKey(t *testing.T) {
 
 	// See if the update is valid by applying it to the authority
 	// + checking if the key has been removed.
-	if err := a.Inform(updates); err != nil {
+	if err := a.Inform(storage, updates); err != nil {
 		t.Fatalf("could not apply generated updates: %v", err)
 	}
 	if _, err := a.state.GetKey(key2.ID()); err != ErrNoSuchKey {
@@ -95,7 +97,8 @@ func TestAuthorityBuilderSetKeyVote(t *testing.T) {
 	pub, priv := testingKey25519(t, 1)
 	key := Key{Kind: Key25519, Public: pub, Votes: 2}
 
-	a, _, err := Create(&Mem{}, State{
+	storage := &Mem{}
+	a, _, err := Create(storage, State{
 		Keys:               []Key{key},
 		DisablementSecrets: [][]byte{disablementKDF([]byte{1, 2, 3})},
 	}, signer25519(priv))
@@ -114,7 +117,7 @@ func TestAuthorityBuilderSetKeyVote(t *testing.T) {
 
 	// See if the update is valid by applying it to the authority
 	// + checking if the update is there.
-	if err := a.Inform(updates); err != nil {
+	if err := a.Inform(storage, updates); err != nil {
 		t.Fatalf("could not apply generated updates: %v", err)
 	}
 	k, err := a.state.GetKey(key.ID())
@@ -130,7 +133,8 @@ func TestAuthorityBuilderSetKeyMeta(t *testing.T) {
 	pub, priv := testingKey25519(t, 1)
 	key := Key{Kind: Key25519, Public: pub, Votes: 2, Meta: map[string]string{"a": "b"}}
 
-	a, _, err := Create(&Mem{}, State{
+	storage := &Mem{}
+	a, _, err := Create(storage, State{
 		Keys:               []Key{key},
 		DisablementSecrets: [][]byte{disablementKDF([]byte{1, 2, 3})},
 	}, signer25519(priv))
@@ -149,7 +153,7 @@ func TestAuthorityBuilderSetKeyMeta(t *testing.T) {
 
 	// See if the update is valid by applying it to the authority
 	// + checking if the update is there.
-	if err := a.Inform(updates); err != nil {
+	if err := a.Inform(storage, updates); err != nil {
 		t.Fatalf("could not apply generated updates: %v", err)
 	}
 	k, err := a.state.GetKey(key.ID())
@@ -165,7 +169,8 @@ func TestAuthorityBuilderMultiple(t *testing.T) {
 	pub, priv := testingKey25519(t, 1)
 	key := Key{Kind: Key25519, Public: pub, Votes: 2}
 
-	a, _, err := Create(&Mem{}, State{
+	storage := &Mem{}
+	a, _, err := Create(storage, State{
 		Keys:               []Key{key},
 		DisablementSecrets: [][]byte{disablementKDF([]byte{1, 2, 3})},
 	}, signer25519(priv))
@@ -193,7 +198,7 @@ func TestAuthorityBuilderMultiple(t *testing.T) {
 
 	// See if the update is valid by applying it to the authority
 	// + checking if the update is there.
-	if err := a.Inform(updates); err != nil {
+	if err := a.Inform(storage, updates); err != nil {
 		t.Fatalf("could not apply generated updates: %v", err)
 	}
 	k, err := a.state.GetKey(key2.ID())

--- a/tka/tka_test.go
+++ b/tka/tka_test.go
@@ -376,7 +376,7 @@ func TestAuthorityInformNonLinear(t *testing.T) {
 	// and forcing Inform() to take the slow path.
 	informAUMs := []AUM{c.AUMs["L1"], c.AUMs["L2"], c.AUMs["L3"], c.AUMs["L4"], c.AUMs["L5"]}
 
-	if err := a.Inform(informAUMs); err != nil {
+	if err := a.Inform(storage, informAUMs); err != nil {
 		t.Fatalf("Inform() failed: %v", err)
 	}
 	for i, update := range informAUMs {
@@ -419,7 +419,7 @@ func TestAuthorityInformLinear(t *testing.T) {
 
 	informAUMs := []AUM{c.AUMs["L1"], c.AUMs["L2"], c.AUMs["L3"]}
 
-	if err := a.Inform(informAUMs); err != nil {
+	if err := a.Inform(storage, informAUMs); err != nil {
 		t.Fatalf("Inform() failed: %v", err)
 	}
 	for i, update := range informAUMs {


### PR DESCRIPTION
Updates #5435

Based on the discussion in #5435, we can better support transactional data models
by making the underlying storage layer a parameter (which can be specialized for
the request) rather than a long-lived member of Authority.

Now that Authority is just an instantaneous snapshot of state, we can do things
like provide idempotent methods and make it cloneable, too.

/cc @crawshaw 