### PR TITLE
tailcfg: add Hostinfo.GoVersion

### DIFF
--- a/hostinfo/hostinfo.go
+++ b/hostinfo/hostinfo.go
@@ -38,6 +38,7 @@ func New() *tailcfg.Hostinfo {
 		Desktop:     desktop(),
 		Package:     packageTypeCached(),
 		GoArch:      runtime.GOARCH,
+		GoVersion:   runtime.Version(),
 		DeviceModel: deviceModel(),
 		Cloud:       string(cloudenv.Get()),
 	}

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -476,6 +476,7 @@ type Hostinfo struct {
 	ShieldsUp     bool           `json:",omitempty"` // indicates whether the host is blocking incoming connections
 	ShareeNode    bool           `json:",omitempty"` // indicates this node exists in netmap because it's owned by a shared-to user
 	GoArch        string         `json:",omitempty"` // the host's GOARCH value (of the running binary)
+	GoVersion     string         `json:",omitempty"` // Go version binary was built with
 	RoutableIPs   []netip.Prefix `json:",omitempty"` // set of IP ranges this client can route
 	RequestTags   []string       `json:",omitempty"` // set of ACL tags this node wants to claim
 	Services      []Service      `json:",omitempty"` // services advertised by this machine

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -127,6 +127,7 @@ var _HostinfoCloneNeedsRegeneration = Hostinfo(struct {
 	ShieldsUp     bool
 	ShareeNode    bool
 	GoArch        string
+	GoVersion     string
 	RoutableIPs   []netip.Prefix
 	RequestTags   []string
 	Services      []Service

--- a/tailcfg/tailcfg_test.go
+++ b/tailcfg/tailcfg_test.go
@@ -34,7 +34,7 @@ func TestHostinfoEqual(t *testing.T) {
 		"IPNVersion", "FrontendLogID", "BackendLogID",
 		"OS", "OSVersion", "Desktop", "Package", "DeviceModel", "Hostname",
 		"ShieldsUp", "ShareeNode",
-		"GoArch",
+		"GoArch", "GoVersion",
 		"RoutableIPs", "RequestTags",
 		"Services", "NetInfo", "SSH_HostKeys", "Cloud",
 	}

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -262,6 +262,7 @@ func (v HostinfoView) Hostname() string      { return v.ж.Hostname }
 func (v HostinfoView) ShieldsUp() bool       { return v.ж.ShieldsUp }
 func (v HostinfoView) ShareeNode() bool      { return v.ж.ShareeNode }
 func (v HostinfoView) GoArch() string        { return v.ж.GoArch }
+func (v HostinfoView) GoVersion() string     { return v.ж.GoVersion }
 func (v HostinfoView) RoutableIPs() views.IPPrefixSlice {
 	return views.IPPrefixSliceOf(v.ж.RoutableIPs)
 }
@@ -286,6 +287,7 @@ var _HostinfoViewNeedsRegeneration = Hostinfo(struct {
 	ShieldsUp     bool
 	ShareeNode    bool
 	GoArch        string
+	GoVersion     string
 	RoutableIPs   []netip.Prefix
 	RequestTags   []string
 	Services      []Service


### PR DESCRIPTION
So next time something like #5340 happens we can identify all affected
nodes and have the control plane send them health warnings.