### PR TITLE
syncs: re-enable TestWatchMultipleValues

### DIFF
--- a/syncs/watchdog_test.go
+++ b/syncs/watchdog_test.go
@@ -8,8 +8,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"tailscale.com/util/cibuild"
 )
 
 // Time-based tests are fundamentally flaky.
@@ -47,12 +45,6 @@ func TestWatchContended(t *testing.T) {
 }
 
 func TestWatchMultipleValues(t *testing.T) {
-	if cibuild.On() {
-		// On the CI machine, it sometimes takes 500ms to start a new goroutine.
-		// When this happens, we don't get enough events quickly enough.
-		// Nothing's wrong, and it's not worth working around. Just skip the test.
-		t.Skip("flaky on CI")
-	}
 	mu := new(sync.Mutex)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // not necessary, but keep vet happy


### PR DESCRIPTION
We've updated to a different set of CI machines since this test was disabled.

Fixes https://github.com/tailscale/tailscale/issues/1513

Signed-off-by: Denton Gentry <dgentry@tailscale.com>