### PR TITLE
cmd/tailscale: add emoji for illumos in status subcommand

### DIFF
--- a/ipn/ipnstate/ipnstate.go
+++ b/ipn/ipnstate/ipnstate.go
@@ -505,6 +505,8 @@ func osEmoji(os string) string {
 		return "👿"
 	case "openbsd":
 		return "🐡"
+	case "illumos":
+		return "☀️"
 	}
 	return "👽"
 }


### PR DESCRIPTION
As I close in on opening the PR for #697 it would be nice for non-illumos machines to give their illumos peers a nicer emoji instead of the default alien.
I think the Sun is fitting for SunOS operating systems.

It looks prettier in my browser when running the status web view than it does in the PR.