### PR TITLE
tka: implement credential signatures (key material delegation)

### DIFF
--- a/ipn/ipnlocal/network-lock.go
+++ b/ipn/ipnlocal/network-lock.go
@@ -147,7 +147,7 @@ func signNodeKey(nodeInfo tailcfg.TKASignInfo, signer key.NLPrivate) (*tka.NodeK
 		SigKind:        tka.SigDirect,
 		KeyID:          signer.KeyID(),
 		Pubkey:         p,
-		RotationPubkey: nodeInfo.RotationPubkey,
+		WrappingPubkey: nodeInfo.RotationPubkey,
 	}
 	sig.Signature, err = signer.SignNKS(sig.SigHash())
 	if err != nil {

--- a/tka/tka.go
+++ b/tka/tka.go
@@ -673,6 +673,10 @@ func (a *Authority) NodeKeyAuthorized(nodeKey key.NodePublic, nodeKeySignature t
 	if err := decoded.Unserialize(nodeKeySignature); err != nil {
 		return fmt.Errorf("unserialize: %v", err)
 	}
+	if decoded.SigKind == SigCredential {
+		return errors.New("credential signatures cannot authorize nodes on their own")
+	}
+
 	key, err := a.state.GetKey(decoded.KeyID)
 	if err != nil {
 		return fmt.Errorf("key: %v", err)


### PR DESCRIPTION
This will be needed to support preauth-keys with network lock in the future, so getting the core mechanics out of the way now.