### PR TITLE
cmd/gitops-pusher: be less paranoid about external modifications

### DIFF
--- a/cmd/gitops-pusher/gitops-pusher.go
+++ b/cmd/gitops-pusher/gitops-pusher.go
@@ -30,17 +30,14 @@ var (
 	cacheFname   = rootFlagSet.String("cache-file", "./version-cache.json", "filename for the previous known version hash")
 	timeout      = rootFlagSet.Duration("timeout", 5*time.Minute, "timeout for the entire CI run")
 	githubSyntax = rootFlagSet.Bool("github-syntax", true, "use GitHub Action error syntax (https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message)")
-
-	modifiedExternallyFailure = make(chan struct{}, 1)
 )
 
 func modifiedExternallyError() {
 	if *githubSyntax {
-		fmt.Printf("::error file=%s,line=1,col=1,title=Policy File Modified Externally::The policy file was modified externally in the admin console.\n", *policyFname)
+		fmt.Printf("::warning file=%s,line=1,col=1,title=Policy File Modified Externally::The policy file was modified externally in the admin console.\n", *policyFname)
 	} else {
 		fmt.Printf("The policy file was modified externally in the admin console.\n")
 	}
-	modifiedExternallyFailure <- struct{}{}
 }
 
 func apply(cache *Cache, tailnet, apiKey string) func(context.Context, []string) error {
@@ -205,10 +202,6 @@ func main() {
 
 	if err := root.Run(ctx); err != nil {
 		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	if len(modifiedExternallyFailure) != 0 {
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This makes a "modified externally" error turn into a "modified externally" warning. It means CI won't fail if someone does something manually in the admin console.

Signed-off-by: Xe <xe@tailscale.com>