### PR TITLE
cmd/tsconnect: output errors to the JS console too

### DIFF
--- a/cmd/tsconnect/src/types/wasm_js.d.ts
+++ b/cmd/tsconnect/src/types/wasm_js.d.ts
@@ -19,6 +19,7 @@ declare global {
       username: string,
       termConfig: {
         writeFn: (data: string) => void
+        writeErrorFn: (err: string) => void
         setReadFn: (readFn: (data: string) => void) => void
         rows: number
         cols: number

--- a/cmd/tsconnect/wasm/wasm_js.go
+++ b/cmd/tsconnect/wasm/wasm_js.go
@@ -347,6 +347,7 @@ type jsSSHSession struct {
 
 func (s *jsSSHSession) Run() {
 	writeFn := s.termConfig.Get("writeFn")
+	writeErrorFn := s.termConfig.Get("writeErrorFn")
 	setReadFn := s.termConfig.Get("setReadFn")
 	rows := s.termConfig.Get("rows").Int()
 	cols := s.termConfig.Get("cols").Int()
@@ -357,7 +358,7 @@ func (s *jsSSHSession) Run() {
 		writeFn.Invoke(s)
 	}
 	writeError := func(label string, err error) {
-		write(fmt.Sprintf("%s Error: %v\r\n", label, err))
+		writeErrorFn.Invoke(fmt.Sprintf("%s Error: %v\r\n", label, err))
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
We were just outputting them to the terminal, but that's hard to debug
because we immediately tear down the terminal when getting an error.

Signed-off-by: Mihai Parparita <mihai@tailscale.com>