### PR TITLE
CI: make all workflows get Go version from go.mod

### DIFF
--- a/.github/workflows/cross-darwin.yml
+++ b/.github/workflows/cross-darwin.yml
@@ -19,15 +19,14 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
 
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version-file: go.mod
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: macOS build cmd
       env:

--- a/.github/workflows/cross-freebsd.yml
+++ b/.github/workflows/cross-freebsd.yml
@@ -19,15 +19,14 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
 
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version-file: go.mod
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: FreeBSD build cmd
       env:

--- a/.github/workflows/cross-openbsd.yml
+++ b/.github/workflows/cross-openbsd.yml
@@ -19,15 +19,14 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
 
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version-file: go.mod
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: OpenBSD build cmd
       env:

--- a/.github/workflows/cross-wasm.yml
+++ b/.github/workflows/cross-wasm.yml
@@ -19,15 +19,14 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
 
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version-file: go.mod
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: Wasm client build
       env:

--- a/.github/workflows/cross-windows.yml
+++ b/.github/workflows/cross-windows.yml
@@ -19,15 +19,14 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
 
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version-file: go.mod
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: Windows build cmd
       env:

--- a/.github/workflows/depaware.yml
+++ b/.github/workflows/depaware.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
-
-    - name: Check out code
-      uses: actions/checkout@v3
+        go-version-file: go.mod
 
     - name: depaware
       run: go run github.com/tailscale/depaware --check

--- a/.github/workflows/go_generate.yml
+++ b/.github/workflows/go_generate.yml
@@ -18,15 +18,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.19
-
       - name: Check out code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
 
       - name: check 'go generate' is clean
         run: |

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
-
-    - name: Check out code
-      uses: actions/checkout@v3
+        go-version-file: go.mod
 
     - name: Run license checker
       run: ./scripts/check_license_headers.sh .

--- a/.github/workflows/linux-race.yml
+++ b/.github/workflows/linux-race.yml
@@ -19,15 +19,14 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
 
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version-file: go.mod
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: Basic build
       run: go build ./cmd/...

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,15 +19,14 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
 
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version-file: go.mod
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: Basic build
       run: go build ./cmd/...

--- a/.github/workflows/linux32.yml
+++ b/.github/workflows/linux32.yml
@@ -19,15 +19,14 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
 
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version-file: go.mod
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: Basic build
       run: GOARCH=386 go build ./cmd/...

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,12 +16,12 @@ jobs:
   gofmt:
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code
+      uses: actions/checkout@v3
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
-    - name: Check out code
-      uses: actions/checkout@v3
+        go-version-file: go.mod
     - name: Run gofmt (goimports)
       run: go run golang.org/x/tools/cmd/goimports -d --format-only .
     - uses: k0kubun/action-slack@v2.0.0

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -19,13 +19,13 @@ jobs:
       - name: Set GOPATH
         run: echo "GOPATH=$HOME/go" >> $GITHUB_ENV
 
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
-
-      - name: Checkout Code
-        uses: actions/checkout@v3
+          go-version-file: go.mod
 
       - name: Run VM tests
         run: go test ./tstest/integration/vms -v -no-s3 -run-vm-tests -run=TestRunUbuntu2004

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,14 +19,13 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
 
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19.x
-
-    - name: Checkout code
-      uses: actions/checkout@v3
+        go-version-file: go.mod
 
     - name: Restore Cache
       uses: actions/cache@v3


### PR DESCRIPTION
The next time we update the toolchain, all of the CI
Actions will automatically use it when go.mod is updated.

Signed-off-by: Denton Gentry <dgentry@tailscale.com>