### PR TITLE
net/dns: set OS DNS to 100.100.100.100 for route-less ExtraRecords [cap 41]

### DIFF
--- a/net/dns/config.go
+++ b/net/dns/config.go
@@ -91,6 +91,30 @@ func (c Config) hasDefaultIPResolversOnly() bool {
 	return true
 }
 
+// hasHostsWithoutSplitDNSRoutes reports whether c contains any Host entries
+// that aren't covered by a SplitDNS route suffix.
+func (c Config) hasHostsWithoutSplitDNSRoutes() bool {
+	// TODO(bradfitz): this could be more efficient, but we imagine
+	// the number of SplitDNS routes and/or hosts will be small.
+	for host := range c.Hosts {
+		if !c.hasSplitDNSRouteForHost(host) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasSplitDNSRouteForHost reports whether c contains a SplitDNS route
+// that contains hosts.
+func (c Config) hasSplitDNSRouteForHost(host dnsname.FQDN) bool {
+	for route := range c.Routes {
+		if route.Contains(host) {
+			return true
+		}
+	}
+	return false
+}
+
 func (c Config) hasDefaultResolvers() bool {
 	return len(c.DefaultResolvers) > 0
 }

--- a/net/dns/manager.go
+++ b/net/dns/manager.go
@@ -207,9 +207,14 @@ func (m *Manager) compileConfig(cfg Config) (rcfg resolver.Config, ocfg OSConfig
 		// case where cfg is entirely zero, in which case these
 		// configs clear all Tailscale DNS settings.
 		return rcfg, ocfg, nil
-	case cfg.hasDefaultIPResolversOnly():
-		// Trivial CorpDNS configuration, just override the OS
-		// resolver.
+	case cfg.hasDefaultIPResolversOnly() && !cfg.hasHostsWithoutSplitDNSRoutes():
+		// Trivial CorpDNS configuration, just override the OS resolver.
+		//
+		// If there are hosts (ExtraRecords) that are not covered by an existing
+		// SplitDNS route, then we don't go into this path so that we fall into
+		// the next case and send the extra record hosts queries through
+		// 100.100.100.100 instead where we can answer them.
+		//
 		// TODO: for OSes that support it, pass IP:port and DoH
 		// addresses directly to OS.
 		// https://github.com/tailscale/tailscale/issues/1666

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -77,7 +77,8 @@ type CapabilityVersion int
 //	38: 2022-08-11: added PingRequest.URLIsNoise
 //	39: 2022-08-15: clients can talk Noise over arbitrary HTTPS port
 //	40: 2022-08-22: added Node.KeySignature, PeersChangedPatch.KeySignature
-const CurrentCapabilityVersion CapabilityVersion = 40
+//	41: 2022-08-30: uses 100.100.100.100 for route-less ExtraRecords if global nameservers is set
+const CurrentCapabilityVersion CapabilityVersion = 41
 
 type StableID string
 


### PR DESCRIPTION
If ExtraRecords (Hosts) are specified without a corresponding split
DNS route and global DNS is specified, then program the host OS DNS to
use 100.100.100.100 so it can blend in those ExtraRecords.

Updates #1543