### PR TITLE
cmd/tsconnect: remove debugging code

### DIFF
--- a/cmd/tsconnect/src/lib/ssh.ts
+++ b/cmd/tsconnect/src/lib/ssh.ts
@@ -30,7 +30,7 @@ export function runSSHSession(
   let resizeObserver: ResizeObserver | undefined
   let handleBeforeUnload: ((e: BeforeUnloadEvent) => void) | undefined
 
-  const sshSession = ipn.ssh(def.hostname + "2", def.username, {
+  const sshSession = ipn.ssh(def.hostname, def.username, {
     writeFn(input) {
       term.write(input)
     },


### PR DESCRIPTION
Remove test prefix added to validate the error code from 27f36f77c364562bc1ca660c241291e23606e54d.

Signed-off-by: Mihai Parparita <mihai@tailscale.com>