### PR TITLE
cmd/tsconnect: add dev-pkg command for two-sided development

### DIFF
--- a/cmd/tsconnect/README.md
+++ b/cmd/tsconnect/README.md
@@ -38,3 +38,12 @@ The client is also available as an NPM package. To build it, run:
 ```
 
 That places the output in the `pkg/` directory, which may then be uploaded to a package registry (or installed from the file path directly).
+
+To do two-sided development (on both the NPM package and code that uses it), run:
+
+```
+./tool/go run ./cmd/tsconnect dev-pkg
+
+```
+
+This serves the module at http://localhost:9090/pkg/pkg.js and the generated wasm file at http://localhost:9090/pkg/main.wasm. The two files can be used as drop-in replacements for normal imports of the NPM module.

--- a/cmd/tsconnect/build-pkg.go
+++ b/cmd/tsconnect/build-pkg.go
@@ -11,13 +11,12 @@ import (
 	"os"
 	"path"
 
-	esbuild "github.com/evanw/esbuild/pkg/api"
 	"github.com/tailscale/hujson"
 	"tailscale.com/version"
 )
 
 func runBuildPkg() {
-	buildOptions, err := commonSetup(prodMode)
+	buildOptions, err := commonPkgSetup(prodMode)
 	if err != nil {
 		log.Fatalf("Cannot setup: %v", err)
 	}
@@ -31,10 +30,6 @@ func runBuildPkg() {
 		log.Fatalf("Cannot clean %s: %v", *pkgDir, err)
 	}
 
-	buildOptions.EntryPoints = []string{"src/pkg/pkg.ts", "src/pkg/pkg.css"}
-	buildOptions.Outdir = *pkgDir
-	buildOptions.Format = esbuild.FormatESModule
-	buildOptions.AssetNames = "[name]"
 	buildOptions.Write = true
 	buildOptions.MinifyWhitespace = true
 	buildOptions.MinifyIdentifiers = true

--- a/cmd/tsconnect/dev-pkg.go
+++ b/cmd/tsconnect/dev-pkg.go
@@ -8,8 +8,8 @@ import (
 	"log"
 )
 
-func runDev() {
-	buildOptions, err := commonSetup(devMode)
+func runDevPkg() {
+	buildOptions, err := commonPkgSetup(devMode)
 	if err != nil {
 		log.Fatalf("Cannot setup: %v", err)
 	}

--- a/cmd/tsconnect/tsconnect.go
+++ b/cmd/tsconnect/tsconnect.go
@@ -36,6 +36,8 @@ func main() {
 	switch flag.Arg(0) {
 	case "dev":
 		runDev()
+	case "dev-pkg":
+		runDevPkg()
 	case "build":
 		runBuild()
 	case "build-pkg":


### PR DESCRIPTION
Allows imports of the NPM package added by 1a093ef4822b973ec86d481924690349eddba5cb
to be replaced with import("http://localhost:9090/pkg/pkg.js"), so that
changes can be made in parallel to both the module and code that uses
it (without any need for NPM publishing or even building of the package).

Updates #5415

Signed-off-by: Mihai Parparita <mihai@tailscale.com>