### PR TITLE
tsnet: add Server method to listener

### DIFF
--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -541,6 +541,9 @@ func (ln *listener) Close() error {
 	return nil
 }
 
+// Server returns the tsnet Server associated with the listener.
+func (ln *listener) Server() *Server { return ln.s }
+
 type addr struct{ ln *listener }
 
 func (a addr) Network() string { return a.ln.key.network }

--- a/tsnet/tsnet_test.go
+++ b/tsnet/tsnet_test.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tsnet
+
+import "testing"
+
+// TestListener_Server ensures that the listener type always keeps the Server
+// method, which is used by some external applications to identify a tsnet.Listener
+// from other net.Listeners, as well as access the underlying Server.
+func TestListener_Server(t *testing.T) {
+	s := &Server{}
+	ln := listener{s: s}
+	if ln.Server() != s {
+		t.Errorf("listener.Server() returned %v, want %v", ln.Server(), s)
+	}
+}


### PR DESCRIPTION
Allow callers to verify that a net.Listener is a tsnet.listener by type asserting against this Server method, as well as providing access to the underlying Server.

This is initially being added to support the caddy integration in caddyserver/caddy#5002.