### PR TITLE
cmd/nginx-auth/nginx-auth: update auth to allow for new domains

### DIFF
--- a/cmd/nginx-auth/nginx-auth.go
+++ b/cmd/nginx-auth/nginx-auth.go
@@ -75,12 +75,7 @@ func main() {
 				log.Printf("can't extract tailnet name from hostname %q", info.Node.Name)
 				return
 			}
-			tailnet, _, ok = strings.Cut(tailnet, ".beta.tailscale.net")
-			if !ok {
-				w.WriteHeader(http.StatusUnauthorized)
-				log.Printf("can't extract tailnet name from hostname %q", info.Node.Name)
-				return
-			}
+			tailnet = strings.TrimSuffix(tailnet, ".beta.tailscale.net")
 		}
 
 		if expectedTailnet := r.Header.Get("Expected-Tailnet"); expectedTailnet != "" && expectedTailnet != tailnet {


### PR DESCRIPTION
With MagicDNS GA, we are giving every tailnet a tailnet-<hex>.ts.net name.
We will only parse out if legacy domains include beta.tailscale.net; otherwise,
set tailnet to the full domain format going forward.
