### PR TITLE
cmd/tailscale/cli: add backwards compatibility 'up' processing for legacy client

### DIFF
--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -762,6 +762,9 @@ func TestPrefFlagMapping(t *testing.T) {
 		case "NotepadURLs":
 			// TODO(bradfitz): https://github.com/tailscale/tailscale/issues/1830
 			continue
+		case "Egg":
+			// Not applicable.
+			continue
 		}
 		t.Errorf("unexpected new ipn.Pref field %q is not handled by up.go (see addPrefFlagMapping and checkForAccidentalSettingReverts)", prefName)
 	}

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -406,8 +406,12 @@ func updatePrefs(prefs, curPrefs *ipn.Prefs, env upCheckEnv) (simpleUp bool, jus
 }
 
 func runUp(ctx context.Context, args []string) (retErr error) {
+	var egg bool
 	if len(args) > 0 {
-		fatalf("too many non-flag arguments: %q", args)
+		egg = fmt.Sprint(args) == "[up down down left right left right b a]"
+		if !egg {
+			fatalf("too many non-flag arguments: %q", args)
+		}
 	}
 
 	st, err := localClient.Status(ctx)
@@ -493,6 +497,7 @@ func runUp(ctx context.Context, args []string) (retErr error) {
 		fatalf("%s", err)
 	}
 	if justEditMP != nil {
+		justEditMP.EggSet = true
 		_, err := localClient.EditPrefs(ctx, justEditMP)
 		return err
 	}

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -48,6 +48,7 @@ var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	Hostname               string
 	NotepadURLs            bool
 	ForceDaemon            bool
+	Egg                    bool
 	AdvertiseRoutes        []netip.Prefix
 	NoSNAT                 bool
 	NetfilterMode          preftype.NetfilterMode

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -163,6 +163,9 @@ type Prefs struct {
 	// for Linux/etc, which always operate in daemon mode.
 	ForceDaemon bool `json:"ForceDaemon,omitempty"`
 
+	// Egg is a optional debug flag.
+	Egg bool
+
 	// The following block of options only have an effect on Linux.
 
 	// AdvertiseRoutes specifies CIDR prefixes to advertise into the
@@ -217,6 +220,7 @@ type MaskedPrefs struct {
 	HostnameSet               bool `json:",omitempty"`
 	NotepadURLsSet            bool `json:",omitempty"`
 	ForceDaemonSet            bool `json:",omitempty"`
+	EggSet                    bool `json:",omitempty"`
 	AdvertiseRoutesSet        bool `json:",omitempty"`
 	NoSNATSet                 bool `json:",omitempty"`
 	NetfilterModeSet          bool `json:",omitempty"`

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -52,6 +52,7 @@ func TestPrefsEqual(t *testing.T) {
 		"Hostname",
 		"NotepadURLs",
 		"ForceDaemon",
+		"Egg",
 		"AdvertiseRoutes",
 		"NoSNAT",
 		"NetfilterMode",


### PR DESCRIPTION
Updates tailscale/corp#6781
