### PR TITLE
cmd/tsconnect: temporarily switch to xterm.js fork that handles popup windows

### DIFF
--- a/cmd/tsconnect/package.json
+++ b/cmd/tsconnect/package.json
@@ -10,7 +10,7 @@
     "qrcode": "^1.5.0",
     "tailwindcss": "^3.1.6",
     "typescript": "^4.7.4",
-    "xterm": "^4.18.0",
+    "xterm": "mihaip/xterm.js#95100e3c870b59348bb4fa5504bab9f9317bac67",
     "xterm-addon-fit": "^0.5.0"
   },
   "scripts": {

--- a/cmd/tsconnect/src/lib/ssh.ts
+++ b/cmd/tsconnect/src/lib/ssh.ts
@@ -54,7 +54,10 @@ export function runSSHSession(
   })
 
   // Make terminal and SSH session track the size of the containing DOM node.
-  resizeObserver = new ResizeObserver(() => fitAddon.fit())
+  resizeObserver =
+    new termContainerNode.ownerDocument.defaultView!.ResizeObserver(() =>
+      fitAddon.fit()
+    )
   resizeObserver.observe(termContainerNode)
   term.onResize(({ rows, cols }) => sshSession.resize(rows, cols))
 

--- a/cmd/tsconnect/yarn.lock
+++ b/cmd/tsconnect/yarn.lock
@@ -644,10 +644,9 @@ xterm-addon-fit@^0.5.0:
   resolved "https://registry.yarnpkg.com/xterm-addon-fit/-/xterm-addon-fit-0.5.0.tgz#2d51b983b786a97dcd6cde805e700c7f913bc596"
   integrity sha512-DsS9fqhXHacEmsPxBJZvfj2la30Iz9xk+UKjhQgnYNkrUIN5CYLbw7WEfz117c7+S86S/tpHPfvNxJsF5/G8wQ==
 
-xterm@^4.18.0:
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.18.0.tgz#a1f6ab2c330c3918fb094ae5f4c2562987398ea1"
-  integrity sha512-JQoc1S0dti6SQfI0bK1AZvGnAxH4MVw45ZPFSO6FHTInAiau3Ix77fSxNx3mX4eh9OL4AYa8+4C8f5UvnSfppQ==
+xterm@mihaip/xterm.js#95100e3c870b59348bb4fa5504bab9f9317bac67:
+  version "4.19.0"
+  resolved "https://codeload.github.com/mihaip/xterm.js/tar.gz/95100e3c870b59348bb4fa5504bab9f9317bac67"
 
 y18n@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
Allows other work to be unblocked while xtermjs/xterm.js#4069 is worked
through.

To enable testing the popup window handling, the standalone app allows
opening of SSH sessions in new windows by holding down the alt key
while pressing the SSH button.

Also includes a fix for #5567 (handling of resizes before the SSH session
is opened).