### PR TITLE
tailcfg: reformat CurrentCapabilityVersion to be a bulleted list

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -40,44 +40,44 @@ type CapabilityVersion int
 //
 // History of versions:
 //
-//	 3: implicit compression, keep-alives
-//	 4: opt-in keep-alives via KeepAlive field, opt-in compression via Compress
-//	 5: 2020-10-19, implies IncludeIPv6, delta Peers/UserProfiles, supports MagicDNS
-//	 6: 2020-12-07: means MapResponse.PacketFilter nil means unchanged
-//	 7: 2020-12-15: FilterRule.SrcIPs accepts CIDRs+ranges, doesn't warn about 0.0.0.0/::
-//	 8: 2020-12-19: client can buggily receive IPv6 addresses and routes if beta enabled server-side
-//	 9: 2020-12-30: client doesn't auto-add implicit search domains from peers; only DNSConfig.Domains
-//	10: 2021-01-17: client understands MapResponse.PeerSeenChange
-//	11: 2021-03-03: client understands IPv6, multiple default routes, and goroutine dumping
-//	12: 2021-03-04: client understands PingRequest
-//	13: 2021-03-19: client understands FilterRule.IPProto
-//	14: 2021-04-07: client understands DNSConfig.Routes and DNSConfig.Resolvers
-//	15: 2021-04-12: client treats nil MapResponse.DNSConfig as meaning unchanged
-//	16: 2021-04-15: client understands Node.Online, MapResponse.OnlineChange
-//	17: 2021-04-18: MapResponse.Domain empty means unchanged
-//	18: 2021-04-19: MapResponse.Node nil means unchanged (all fields now omitempty)
-//	19: 2021-04-21: MapResponse.Debug.SleepSeconds
-//	20: 2021-06-11: MapResponse.LastSeen used even less (https://github.com/tailscale/tailscale/issues/2107)
-//	21: 2021-06-15: added MapResponse.DNSConfig.CertDomains
-//	22: 2021-06-16: added MapResponse.DNSConfig.ExtraRecords
-//	23: 2021-08-25: DNSConfig.Routes values may be empty (for ExtraRecords support in 1.14.1+)
-//	24: 2021-09-18: MapResponse.Health from control to node; node shows in "tailscale status"
-//	25: 2021-11-01: MapResponse.Debug.Exit
-//	26: 2022-01-12: (nothing, just bumping for 1.20.0)
-//	27: 2022-02-18: start of SSHPolicy being respected
-//	28: 2022-03-09: client can communicate over Noise.
-//	29: 2022-03-21: MapResponse.PopBrowserURL
-//	30: 2022-03-22: client can request id tokens.
-//	31: 2022-04-15: PingRequest & PingResponse TSMP & disco support
-//	32: 2022-04-17: client knows FilterRule.CapMatch
-//	33: 2022-07-20: added MapResponse.PeersChangedPatch (DERPRegion + Endpoints)
-//	34: 2022-08-02: client understands CapabilityFileSharingTarget
-//	36: 2022-08-02: added PeersChangedPatch.{Key,DiscoKey,Online,LastSeen,KeyExpiry,Capabilities}
-//	37: 2022-08-09: added Debug.{SetForceBackgroundSTUN,SetRandomizeClientPort}; Debug are sticky
-//	38: 2022-08-11: added PingRequest.URLIsNoise
-//	39: 2022-08-15: clients can talk Noise over arbitrary HTTPS port
-//	40: 2022-08-22: added Node.KeySignature, PeersChangedPatch.KeySignature
-//	41: 2022-08-30: uses 100.100.100.100 for route-less ExtraRecords if global nameservers is set
+//   - 3: implicit compression, keep-alives
+//   - 4: opt-in keep-alives via KeepAlive field, opt-in compression via Compress
+//   - 5: 2020-10-19, implies IncludeIPv6, delta Peers/UserProfiles, supports MagicDNS
+//   - 6: 2020-12-07: means MapResponse.PacketFilter nil means unchanged
+//   - 7: 2020-12-15: FilterRule.SrcIPs accepts CIDRs+ranges, doesn't warn about 0.0.0.0/::
+//   - 8: 2020-12-19: client can buggily receive IPv6 addresses and routes if beta enabled server-side
+//   - 9: 2020-12-30: client doesn't auto-add implicit search domains from peers; only DNSConfig.Domains
+//   - 10: 2021-01-17: client understands MapResponse.PeerSeenChange
+//   - 11: 2021-03-03: client understands IPv6, multiple default routes, and goroutine dumping
+//   - 12: 2021-03-04: client understands PingRequest
+//   - 13: 2021-03-19: client understands FilterRule.IPProto
+//   - 14: 2021-04-07: client understands DNSConfig.Routes and DNSConfig.Resolvers
+//   - 15: 2021-04-12: client treats nil MapResponse.DNSConfig as meaning unchanged
+//   - 16: 2021-04-15: client understands Node.Online, MapResponse.OnlineChange
+//   - 17: 2021-04-18: MapResponse.Domain empty means unchanged
+//   - 18: 2021-04-19: MapResponse.Node nil means unchanged (all fields now omitempty)
+//   - 19: 2021-04-21: MapResponse.Debug.SleepSeconds
+//   - 20: 2021-06-11: MapResponse.LastSeen used even less (https://github.com/tailscale/tailscale/issues/2107)
+//   - 21: 2021-06-15: added MapResponse.DNSConfig.CertDomains
+//   - 22: 2021-06-16: added MapResponse.DNSConfig.ExtraRecords
+//   - 23: 2021-08-25: DNSConfig.Routes values may be empty (for ExtraRecords support in 1.14.1+)
+//   - 24: 2021-09-18: MapResponse.Health from control to node; node shows in "tailscale status"
+//   - 25: 2021-11-01: MapResponse.Debug.Exit
+//   - 26: 2022-01-12: (nothing, just bumping for 1.20.0)
+//   - 27: 2022-02-18: start of SSHPolicy being respected
+//   - 28: 2022-03-09: client can communicate over Noise.
+//   - 29: 2022-03-21: MapResponse.PopBrowserURL
+//   - 30: 2022-03-22: client can request id tokens.
+//   - 31: 2022-04-15: PingRequest & PingResponse TSMP & disco support
+//   - 32: 2022-04-17: client knows FilterRule.CapMatch
+//   - 33: 2022-07-20: added MapResponse.PeersChangedPatch (DERPRegion + Endpoints)
+//   - 34: 2022-08-02: client understands CapabilityFileSharingTarget
+//   - 36: 2022-08-02: added PeersChangedPatch.{Key,DiscoKey,Online,LastSeen,KeyExpiry,Capabilities}
+//   - 37: 2022-08-09: added Debug.{SetForceBackgroundSTUN,SetRandomizeClientPort}; Debug are sticky
+//   - 38: 2022-08-11: added PingRequest.URLIsNoise
+//   - 39: 2022-08-15: clients can talk Noise over arbitrary HTTPS port
+//   - 40: 2022-08-22: added Node.KeySignature, PeersChangedPatch.KeySignature
+//   - 41: 2022-08-30: uses 100.100.100.100 for route-less ExtraRecords if global nameservers is set
 const CurrentCapabilityVersion CapabilityVersion = 41
 
 type StableID string


### PR DESCRIPTION
gofmt in 1.19 is now opinionated about structured text formatting in comments. It did not like our style and kept fighting us whenever we changed these lines. Give up the fight and be a bulleted list for it.

See:

* https://go.dev/doc/go1.19#go-doc and
* https://go.dev/doc/comment

Updates #4872
