### PR TITLE
tailcfg: fix broken test from comment change

### DIFF
--- a/tailcfg/tailcfg_test.go
+++ b/tailcfg/tailcfg_test.go
@@ -661,7 +661,7 @@ func TestRegisterRequestNilClone(t *testing.T) {
 // We've screwed this up several times.
 func TestCurrentCapabilityVersion(t *testing.T) {
 	f := must.Get(os.ReadFile("tailcfg.go"))
-	matches := regexp.MustCompile(`(?m)^//\s+(\d+): \d\d\d\d-\d\d-\d\d: `).FindAllStringSubmatch(string(f), -1)
+	matches := regexp.MustCompile(`(?m)^//[\s-]+(\d+): \d\d\d\d-\d\d-\d\d: `).FindAllStringSubmatch(string(f), -1)
 	max := 0
 	for _, m := range matches {
 		n := must.Get(strconv.Atoi(m[1]))


### PR DESCRIPTION
Fix broken build from 255c0472fb0f5c13c40b90eb9da87337da312e63

"Oh, that's safe to commit because most tests are passing and it's just a comment change!", I thought, forgetting I'd added a test that parses its comments.
