### PR TITLE
cmd/tsconnect: enable web links addon in the terminal

### DIFF
--- a/cmd/tsconnect/package.json
+++ b/cmd/tsconnect/package.json
@@ -11,7 +11,8 @@
     "tailwindcss": "^3.1.6",
     "typescript": "^4.7.4",
     "xterm": "5.0.0-beta.58",
-    "xterm-addon-fit": "^0.5.0"
+    "xterm-addon-fit": "^0.5.0",
+    "xterm-addon-web-links": "0.7.0-beta.6"
   },
   "scripts": {
     "lint": "tsc --noEmit",

--- a/cmd/tsconnect/src/app/app.tsx
+++ b/cmd/tsconnect/src/app/app.tsx
@@ -92,6 +92,12 @@ class App extends Component<{}, AppState> {
   }
 
   handleBrowseToURL = (url: string) => {
+    if (this.state.ipnState === "Running") {
+      // Ignore URL requests if we're already running -- it's most likely an
+      // SSH check mode trigger and we already linkify the displayed URL
+      // in the terminal.
+      return
+    }
     this.setState({ browseToURL: url })
   }
 

--- a/cmd/tsconnect/src/lib/ssh.ts
+++ b/cmd/tsconnect/src/lib/ssh.ts
@@ -1,5 +1,6 @@
 import { Terminal } from "xterm"
 import { FitAddon } from "xterm-addon-fit"
+import { WebLinksAddon } from "xterm-addon-web-links"
 
 export type SSHSessionDef = {
   username: string
@@ -14,11 +15,16 @@ export function runSSHSession(
 ) {
   const term = new Terminal({
     cursorBlink: true,
+    allowProposedApi: true,
   })
+
   const fitAddon = new FitAddon()
   term.loadAddon(fitAddon)
   term.open(termContainerNode)
   fitAddon.fit()
+
+  const webLinksAddon = new WebLinksAddon()
+  term.loadAddon(webLinksAddon)
 
   let onDataHook: ((data: string) => void) | undefined
   term.onData((e) => {

--- a/cmd/tsconnect/yarn.lock
+++ b/cmd/tsconnect/yarn.lock
@@ -649,6 +649,11 @@ xterm@5.0.0-beta.58:
   resolved "https://registry.yarnpkg.com/xterm/-/xterm-5.0.0-beta.58.tgz#e3e96ab9fd24d006ec16cc9351a060cc79e67e80"
   integrity sha512-gjg39oKdgUKful27+7I1hvSK51lu/LRhdimFhfZyMvdk0iATH0FAfzv1eAvBKWY2UBgYUfxhicTkanYioANdMw==
 
+xterm-addon-web-links@0.7.0-beta.6:
+  version "0.7.0-beta.6"
+  resolved "https://registry.yarnpkg.com/xterm-addon-web-links/-/xterm-addon-web-links-0.7.0-beta.6.tgz#ec63b681b4f0f0135fa039f53664f65fe9d9f43a"
+  integrity sha512-nD/r/GchGTN4c9gAIVLWVoxExTzAUV7E9xZnwsvhuwI4CEE6yqO15ns8g2hdcUrsPyCbNEw05mIrkF6W5Yj8qA==
+
 y18n@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"


### PR DESCRIPTION
More user friendly, and as a side-effect we handle SSH check mode better, since the URL that's output is now clickable.

Fixes #5247