### PR TITLE
net/dns, types/dnstypes: update some comments, tests for DoH

### DIFF
--- a/net/dns/manager_test.go
+++ b/net/dns/manager_test.go
@@ -586,6 +586,18 @@ func TestManager(t *testing.T) {
 				Routes: upstreams(".", "2a07:a8c0::c3:a884"),
 			},
 		},
+		{
+			name: "nextdns-doh",
+			in: Config{
+				DefaultResolvers: mustRes("https://dns.nextdns.io/c3a884"),
+			},
+			os: OSConfig{
+				Nameservers: mustIPs("100.100.100.100"),
+			},
+			rs: resolver.Config{
+				Routes: upstreams(".", "https://dns.nextdns.io/c3a884"),
+			},
+		},
 	}
 
 	trIP := cmp.Transformer("ipStr", func(ip netip.Addr) string { return ip.String() })

--- a/net/dns/resolver/forwarder_test.go
+++ b/net/dns/resolver/forwarder_test.go
@@ -84,6 +84,11 @@ func TestResolversWithDelays(t *testing.T) {
 			in:   q("2a07:a8c0::c3:a884"),
 			want: o("https://dns.nextdns.io/c3a884"),
 		},
+		{
+			name: "nextdns-doh-input",
+			in:   q("https://dns.nextdns.io/c3a884"),
+			want: o("https://dns.nextdns.io/c3a884"),
+		},
 	}
 
 	for _, tt := range tests {

--- a/types/dnstype/dnstype.go
+++ b/types/dnstype/dnstype.go
@@ -17,8 +17,11 @@ type Resolver struct {
 	//  - A plain IP address for a "classic" UDP+TCP DNS resolver.
 	//    This is the common format as sent by the control plane.
 	//  - An IP:port, for tests.
+	//  - "https://resolver.com/path" for DNS over HTTPS; currently
+	//    as of 2022-09-08 only used for certain well-known resolvers
+	//    (see the publicdns package) for which the IP addresses to dial DoH are
+	//    known ahead of time, so bootstrap DNS resolution is not required.
 	//  - [TODO] "tls://resolver.com" for DNS over TCP+TLS
-	//  - [TODO] "https://resolver.com/query-tmpl" for DNS over HTTPS
 	Addr string `json:",omitempty"`
 
 	// BootstrapResolution is an optional suggested resolution for the
@@ -27,6 +30,8 @@ type Resolver struct {
 	// BootstrapResolution may be empty, in which case clients should
 	// look up the DoT/DoH server using their local "classic" DNS
 	// resolver.
+	//
+	// As of 2022-09-08, BootstrapResolution is not yet used.
 	BootstrapResolution []netip.Addr `json:",omitempty"`
 }
 


### PR DESCRIPTION
Clarify & verify that some DoH URLs can be sent over tailcfg in some limited cases.

Updates #2452
