### PR TITLE
cmd/tsconnect: switch back to public version of xterm npm package

### DIFF
--- a/cmd/tsconnect/package.json
+++ b/cmd/tsconnect/package.json
@@ -10,7 +10,7 @@
     "qrcode": "^1.5.0",
     "tailwindcss": "^3.1.6",
     "typescript": "^4.7.4",
-    "xterm": "mihaip/xterm.js#95100e3c870b59348bb4fa5504bab9f9317bac67",
+    "xterm": "5.0.0-beta.58",
     "xterm-addon-fit": "^0.5.0"
   },
   "scripts": {

--- a/cmd/tsconnect/yarn.lock
+++ b/cmd/tsconnect/yarn.lock
@@ -644,9 +644,10 @@ xterm-addon-fit@^0.5.0:
   resolved "https://registry.yarnpkg.com/xterm-addon-fit/-/xterm-addon-fit-0.5.0.tgz#2d51b983b786a97dcd6cde805e700c7f913bc596"
   integrity sha512-DsS9fqhXHacEmsPxBJZvfj2la30Iz9xk+UKjhQgnYNkrUIN5CYLbw7WEfz117c7+S86S/tpHPfvNxJsF5/G8wQ==
 
-xterm@mihaip/xterm.js#95100e3c870b59348bb4fa5504bab9f9317bac67:
-  version "4.19.0"
-  resolved "https://codeload.github.com/mihaip/xterm.js/tar.gz/95100e3c870b59348bb4fa5504bab9f9317bac67"
+xterm@5.0.0-beta.58:
+  version "5.0.0-beta.58"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-5.0.0-beta.58.tgz#e3e96ab9fd24d006ec16cc9351a060cc79e67e80"
+  integrity sha512-gjg39oKdgUKful27+7I1hvSK51lu/LRhdimFhfZyMvdk0iATH0FAfzv1eAvBKWY2UBgYUfxhicTkanYioANdMw==
 
 y18n@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
xtermjs/xterm.js#4069 was merged and published (in 5.0.0-beta.58), no need for the fork added by 01e6565e8a0193ec940a8eca9129dadb2c05e29d.