### PR TITLE
cmd/tailscale: add licenses link to web UI

### DIFF
--- a/cmd/tailscale/cli/licenses.go
+++ b/cmd/tailscale/cli/licenses.go
@@ -19,24 +19,27 @@ var licensesCmd = &ffcli.Command{
 	Exec:       runLicenses,
 }
 
-func runLicenses(ctx context.Context, args []string) error {
-	var licenseURL string
+// licensesURL returns the absolute URL containing open source license information for the current platform.
+func licensesURL() string {
 	switch runtime.GOOS {
 	case "android":
-		licenseURL = "https://tailscale.com/licenses/android"
+		return "https://tailscale.com/licenses/android"
 	case "darwin", "ios":
-		licenseURL = "https://tailscale.com/licenses/apple"
+		return "https://tailscale.com/licenses/apple"
 	case "windows":
-		licenseURL = "https://tailscale.com/licenses/windows"
+		return "https://tailscale.com/licenses/windows"
 	default:
-		licenseURL = "https://tailscale.com/licenses/tailscale"
+		return "https://tailscale.com/licenses/tailscale"
 	}
+}
 
+func runLicenses(ctx context.Context, args []string) error {
+	licenses := licensesURL()
 	outln(`
 Tailscale wouldn't be possible without the contributions of thousands of open
 source developers. To see the open source packages included in Tailscale and
 their respective license information, visit:
 
-    ` + licenseURL)
+    ` + licenses)
 	return nil
 }

--- a/cmd/tailscale/cli/web.go
+++ b/cmd/tailscale/cli/web.go
@@ -59,6 +59,7 @@ type tmplData struct {
 	IP                string
 	AdvertiseExitNode bool
 	AdvertiseRoutes   string
+	LicensesURL       string
 }
 
 var webCmd = &ffcli.Command{
@@ -392,6 +393,7 @@ func webHandler(w http.ResponseWriter, r *http.Request) {
 		Profile:      profile,
 		Status:       st.BackendState,
 		DeviceName:   deviceName,
+		LicensesURL:  licensesURL(),
 	}
 	exitNodeRouteV4 := netip.MustParsePrefix("0.0.0.0/0")
 	exitNodeRouteV6 := netip.MustParsePrefix("::/0")

--- a/cmd/tailscale/cli/web.html
+++ b/cmd/tailscale/cli/web.html
@@ -11,7 +11,7 @@
 </head>
 
 <body class="py-14">
-<main class="container max-w-lg mx-auto py-6 px-8 bg-white rounded-md shadow-2xl" style="width: 95%">
+<main class="container max-w-lg mx-auto mb-8 py-6 px-8 bg-white rounded-md shadow-2xl" style="width: 95%">
 	<header class="flex justify-between items-center min-width-0 py-2 mb-8">
 		<svg width="26" height="26" viewBox="0 0 23 23" title="Tailscale" fill="none" xmlns="http://www.w3.org/2000/svg"
 			class="flex-shrink-0 mr-4">
@@ -100,6 +100,9 @@
 	</div>
 	{{ end }}
 </main>
+<footer class="container max-w-lg mx-auto text-center">
+	<a class="text-xs text-gray-500 hover:text-gray-600" href="{{ .LicensesURL }}">Open Source Licenses</a>
+</footer>
 <script>(function () {
 const advertiseExitNode = {{.AdvertiseExitNode}};
 let fetchingUrl = false;


### PR DESCRIPTION
The `tailscale web` UI is the primary interface for Synology and Home Assistant users (and perhaps others), so is the logical place to put our open source license notices.  I don't love adding things to what is currently a very minimal UI, but I'm not sure of a better option.

Updates tailscale/corp#5780

<img width="581" alt="Screen Shot 2022-09-09 at 12 19 55 PM" src="https://user-images.githubusercontent.com/1112/189427755-486abb27-53e5-44c1-bf8c-f4164348bbee.png">
