### PR TITLE
util/mak: deprecate NonNil, add type-safe NonNilSliceForJSON, NonNilMapForJSON

### DIFF
--- a/util/mak/mak.go
+++ b/util/mak/mak.go
@@ -25,10 +25,8 @@ func Set[K comparable, V any, T ~map[K]V](m *T, k K, v V) {
 // (currently only a slice or a map) and makes sure it's non-nil for
 // JSON serialization. (In particular, JavaScript clients usually want
 // the field to be defined after they decode the JSON.)
-// MakeNonNil takes a pointer to a Go data structure
-// (currently only a slice or a map) and makes sure it's non-nil for
-// JSON serialization. (In particular, JavaScript clients usually want
-// the field to be defined after they decode the JSON.)
+//
+// Deprecated: use NonNilSliceForJSON or NonNilMapForJSON instead.
 func NonNil(ptr interface{}) {
 	if ptr == nil {
 		panic("nil interface")
@@ -50,4 +48,24 @@ func NonNil(ptr interface{}) {
 	case reflect.Map:
 		rv.Set(reflect.MakeMap(rv.Type()))
 	}
+}
+
+// NonNilSliceForJSON makes sure that *slicePtr is non-nil so it will
+// won't be omitted from JSON serialization and possibly confuse JavaScript
+// clients expecting it to be preesnt.
+func NonNilSliceForJSON[T any, S ~[]T](slicePtr *S) {
+	if *slicePtr != nil {
+		return
+	}
+	*slicePtr = make([]T, 0)
+}
+
+// NonNilMapForJSON makes sure that *slicePtr is non-nil so it will
+// won't be omitted from JSON serialization and possibly confuse JavaScript
+// clients expecting it to be preesnt.
+func NonNilMapForJSON[K comparable, V any, M ~map[K]V](mapPtr *M) {
+	if *mapPtr != nil {
+		return
+	}
+	*mapPtr = make(M)
 }

--- a/util/mak/mak_test.go
+++ b/util/mak/mak_test.go
@@ -69,3 +69,21 @@ func TestNonNil(t *testing.T) {
 		t.Error("map still nil")
 	}
 }
+
+func TestNonNilMapForJSON(t *testing.T) {
+	type M map[string]int
+	var m M
+	NonNilMapForJSON(&m)
+	if m == nil {
+		t.Fatal("still nil")
+	}
+}
+
+func TestNonNilSliceForJSON(t *testing.T) {
+	type S []int
+	var s S
+	NonNilSliceForJSON(&s)
+	if s == nil {
+		t.Fatal("still nil")
+	}
+}


### PR DESCRIPTION
And put the rationale in the name too to save the callers the need for a comment.
