### PR TITLE
net/dns/publicdns: also support NextDNS DoH query parameters

### DIFF
--- a/net/dns/publicdns/publicdns.go
+++ b/net/dns/publicdns/publicdns.go
@@ -69,6 +69,10 @@ func KnownDoHPrefixes() []string {
 	return ret
 }
 
+func isSlashOrQuestionMark(r rune) bool {
+	return r == '/' || r == '?'
+}
+
 // DoHIPsOfBase returns the IP addresses to use to dial the provided DoH base
 // URL.
 //
@@ -81,8 +85,11 @@ func DoHIPsOfBase(dohBase string) []netip.Addr {
 	}
 	if hexStr, ok := strs.CutPrefix(dohBase, "https://dns.nextdns.io/"); ok {
 		// The path is of the form /<profile-hex>[/<hostname>/<model>/<device id>...]
+		// or /<profile-hex>?<query params>
 		// but only the <profile-hex> is required. Ignore the rest:
-		hexStr, _, _ = strings.Cut(hexStr, "/") // discard any optional
+		if i := strings.IndexFunc(hexStr, isSlashOrQuestionMark); i != -1 {
+			hexStr = hexStr[:i]
+		}
 
 		// TODO(bradfitz): using the NextDNS anycast addresses works but is not
 		// ideal. Some of their regions have better latency via a non-anycast IP

--- a/net/dns/publicdns/publicdns_test.go
+++ b/net/dns/publicdns/publicdns_test.go
@@ -95,6 +95,15 @@ func TestDoHIPsOfBase(t *testing.T) {
 				"2a07:a8c1::c3:a884",
 			),
 		},
+		{
+			base: "https://dns.nextdns.io/c3a884?with=query&params",
+			want: ips(
+				"45.90.28.0",
+				"45.90.30.0",
+				"2a07:a8c0::c3:a884",
+				"2a07:a8c1::c3:a884",
+			),
+		},
 	}
 	for _, tt := range tests {
 		got := DoHIPsOfBase(tt.base)


### PR DESCRIPTION
The plan has changed. Doing query parameters rather than path + heades. NextDNS added support for query parameters.

Updates #2452
