### PR TITLE
cmd/tsconnect: fix xterm.js link opening not working when rendered into another window

### DIFF
--- a/cmd/tsconnect/src/lib/ssh.ts
+++ b/cmd/tsconnect/src/lib/ssh.ts
@@ -23,7 +23,9 @@ export function runSSHSession(
   term.open(termContainerNode)
   fitAddon.fit()
 
-  const webLinksAddon = new WebLinksAddon()
+  const webLinksAddon = new WebLinksAddon((event, uri) =>
+    event.view?.open(uri, "_blank", "noopener")
+  )
   term.loadAddon(webLinksAddon)
 
   let onDataHook: ((data: string) => void) | undefined


### PR DESCRIPTION
The default WebLinksAddon handler uses `window.open()`, but that gets blocked by the popup blocker when the event being handled is another window. We instead need to invoke `open()` on the window that the event was triggered in.