### PR TITLE
cmd/tsconnect: allow hostname to be specified

### DIFF
--- a/cmd/tsconnect/src/types/wasm_js.d.ts
+++ b/cmd/tsconnect/src/types/wasm_js.d.ts
@@ -47,6 +47,7 @@ declare global {
     stateStorage?: IPNStateStorage
     authKey?: string
     controlURL?: string
+    hostname?: string
   }
 
   type IPNCallbacks = {


### PR DESCRIPTION
The auto-generated hostname is nice as a default, but there are cases where the client has a more specific name that it can generate.