### PR TITLE
wgengine/magicsock: don't use BPF receive when SO_MARK doesn't work.

### DIFF
--- a/net/netns/netns_linux.go
+++ b/net/netns/netns_linux.go
@@ -65,9 +65,9 @@ func socketMarkWorks() bool {
 
 var forceBindToDevice = envknob.Bool("TS_FORCE_LINUX_BIND_TO_DEVICE")
 
-// useSocketMark reports whether SO_MARK works.
+// UseSocketMark reports whether SO_MARK is in use.
 // If it doesn't, we have to use SO_BINDTODEVICE on our sockets instead.
-func useSocketMark() bool {
+func UseSocketMark() bool {
 	if forceBindToDevice {
 		return false
 	}
@@ -103,7 +103,7 @@ func controlC(network, address string, c syscall.RawConn) error {
 
 	var sockErr error
 	err := c.Control(func(fd uintptr) {
-		if useSocketMark() {
+		if UseSocketMark() {
 			sockErr = setBypassMark(fd)
 		} else {
 			sockErr = bindToDevice(fd)

--- a/wgengine/magicsock/magicsock_linux.go
+++ b/wgengine/magicsock/magicsock_linux.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/net/bpf"
 	"golang.org/x/sys/unix"
 	"tailscale.com/envknob"
+	"tailscale.com/net/netns"
 	"tailscale.com/types/key"
 )
 
@@ -126,6 +127,11 @@ var (
 func (c *Conn) listenRawDisco(family string) (io.Closer, error) {
 	if debugDisableRawDisco {
 		return nil, errors.New("raw disco listening disabled by debug flag")
+	}
+
+	// https://github.com/tailscale/tailscale/issues/5607
+	if !netns.UseSocketMark() {
+		return nil, errors.New("raw disco listening disabled, SO_MARK unavailable")
 	}
 
 	var (


### PR DESCRIPTION
Fixes #5607

Signed-off-by: David Anderson <danderson@tailscale.com>