### PR TITLE
cmd/tsconnect: allow xterm.js terminal options to be passed in

### DIFF
--- a/cmd/tsconnect/src/lib/ssh.ts
+++ b/cmd/tsconnect/src/lib/ssh.ts
@@ -1,4 +1,4 @@
-import { Terminal } from "xterm"
+import { Terminal, ITerminalOptions } from "xterm"
 import { FitAddon } from "xterm-addon-fit"
 import { WebLinksAddon } from "xterm-addon-web-links"
 
@@ -11,11 +11,13 @@ export function runSSHSession(
   termContainerNode: HTMLDivElement,
   def: SSHSessionDef,
   ipn: IPN,
-  onDone: () => void
+  onDone: () => void,
+  terminalOptions?: ITerminalOptions
 ) {
   const term = new Terminal({
     cursorBlink: true,
     allowProposedApi: true,
+    ...terminalOptions,
   })
 
   const fitAddon = new FitAddon()


### PR DESCRIPTION
Allows clients to use a custom theme and other xterm.js customization options.

Fixes #5610