### PR TITLE
net/dns/resolver: remove unused responseTimeout constant

### DIFF
--- a/net/dns/resolver/forwarder.go
+++ b/net/dns/resolver/forwarder.go
@@ -58,9 +58,6 @@ func truncatedFlagSet(pkt []byte) bool {
 }
 
 const (
-	// responseTimeout is the maximal amount of time to wait for a DNS response.
-	responseTimeout = 5 * time.Second
-
 	// dohTransportTimeout is how long to keep idle HTTP
 	// connections open to DNS-over-HTTPs servers. This is pretty
 	// arbitrary.


### PR DESCRIPTION
Timeout is now enforced elsewhere, see discussion in https://github.com/tailscale/tailscale/pull/4408#discussion_r970092333.