### PR TITLE
portlist: normalise space delimited process names

### DIFF
--- a/portlist/clean.go
+++ b/portlist/clean.go
@@ -26,6 +26,9 @@ func argvSubject(argv ...string) string {
 		ret = filepath.Base(argv[1])
 	}
 
+	// Handle space separated argv
+	ret, _, _ = strings.Cut(ret, " ")
+
 	// Remove common noise.
 	ret = strings.TrimSpace(ret)
 	ret = strings.TrimSuffix(ret, ".exe")

--- a/portlist/clean_test.go
+++ b/portlist/clean_test.go
@@ -31,6 +31,22 @@ func TestArgvSubject(t *testing.T) {
 			in:   []string{"/bin/mono", "/sbin/exampleProgram.bin"},
 			want: "exampleProgram.bin",
 		},
+		{
+			in:   []string{"/usr/bin/sshd_config [listener] 1 of 10-100 startups"},
+			want: "sshd_config",
+		},
+		{
+			in:   []string{"/usr/bin/sshd [listener] 0 of 10-100 startups"},
+			want: "sshd",
+		},
+		{
+			in:   []string{"/opt/aws/bin/eic_run_authorized_keys %u %f -o AuthorizedKeysCommandUser ec2-instance-connect [listener] 0 of 10-100 startups"},
+			want: "eic_run_authorized_keys",
+		},
+		{
+			in:   []string{"/usr/bin/nginx worker"},
+			want: "nginx",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Some process names are not only separated by NUL and contains spaces. This PR will check for these special cases and extract the base process name.

This fixes #3781 and other similar cases:

`sshd_config [listener] 1 of 10-100 startups` -> `sshd_config`

`nginx worker` -> `nginx`

Not sure if this approach might have bad performance impact, and that it might be better to tackle this in the Linux specific code where we split by `\x00`.