### PR TITLE
wgengine/magicsock: add client flag and envknob to disable heartbeat

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -1456,6 +1456,10 @@ type Debug struct {
 	// re-enabled for the lifetime of the process.
 	DisableLogTail bool `json:",omitempty"`
 
+	// EnableSilentDisco disables the use of heartBeatTimer in magicsock and attempts to
+	// handle disco silently. See issue #540 for details.
+	EnableSilentDisco bool `json:",omitempty"`
+
 	// Exit optionally specifies that the client should os.Exit
 	// with this code.
 	Exit *int `json:",omitempty"`

--- a/wgengine/magicsock/debugknobs.go
+++ b/wgengine/magicsock/debugknobs.go
@@ -35,6 +35,9 @@ var (
 	debugReSTUNStopOnIdle = envknob.RegisterBool("TS_DEBUG_RESTUN_STOP_ON_IDLE")
 	// debugAlwaysDERP disables the use of UDP, forcing all peer communication over DERP.
 	debugAlwaysDERP = envknob.RegisterBool("TS_DEBUG_ALWAYS_USE_DERP")
+	// debugEnableSilentDisco disables the use of heartbeatTimer on the endpoint struct
+	// and attempts to handle disco silently. See issue #540 for details.
+	debugEnableSilentDisco = envknob.RegisterBool("TS_DEBUG_ENABLE_SILENT_DISCO")
 )
 
 // inTest reports whether the running program is a test that set the

--- a/wgengine/magicsock/debugknobs_stubs.go
+++ b/wgengine/magicsock/debugknobs_stubs.go
@@ -18,6 +18,7 @@ func debugOmitLocalAddresses() bool { return false }
 func logDerpVerbose() bool          { return false }
 func debugReSTUNStopOnIdle() bool   { return false }
 func debugAlwaysDERP() bool         { return false }
+func debugEnableSilentDisco() bool  { return false }
 func debugUseDerpRouteEnv() string  { return "" }
 func debugUseDerpRoute() opt.Bool   { return "" }
 


### PR DESCRIPTION
My notes from uhhhh six weeks ago aren't as clear as I remembered them being so this could be totally off base.

Change-Id: Idc9a72748e74145b068d67e6dd4a4ffe3932efd0
Signed-off-by: Jenny Zhang <jz@tailscale.com>