### PR TITLE
net/speedtest: retune to meet iperf on localhost in a VM

### DIFF
--- a/cmd/speedtest/speedtest.go
+++ b/cmd/speedtest/speedtest.go
@@ -110,11 +110,12 @@ func runSpeedtest(ctx context.Context, args []string) error {
 	w := tabwriter.NewWriter(os.Stdout, 12, 0, 0, ' ', tabwriter.TabIndent)
 	fmt.Println("Results:")
 	fmt.Fprintln(w, "Interval\t\tTransfer\t\tBandwidth\t\t")
+	startTime := results[0].IntervalStart
 	for _, r := range results {
 		if r.Total {
 			fmt.Fprintln(w, "-------------------------------------------------------------------------")
 		}
-		fmt.Fprintf(w, "%.2f-%.2f\tsec\t%.4f\tMBits\t%.4f\tMbits/sec\t\n", r.IntervalStart.Seconds(), r.IntervalEnd.Seconds(), r.MegaBits(), r.MBitsPerSecond())
+		fmt.Fprintf(w, "%.2f-%.2f\tsec\t%.4f\tMBits\t%.4f\tMbits/sec\t\n", r.IntervalStart.Sub(startTime).Seconds(), r.IntervalEnd.Sub(startTime).Seconds(), r.MegaBits(), r.MBitsPerSecond())
 	}
 	w.Flush()
 	return nil

--- a/net/speedtest/speedtest.go
+++ b/net/speedtest/speedtest.go
@@ -11,11 +11,11 @@ import (
 )
 
 const (
-	blockSize       = 32000                 // size of the block of data to send
+	blockSize       = 2 * 1024 * 1024       // size of the block of data to send
 	MinDuration     = 5 * time.Second       // minimum duration for a test
 	DefaultDuration = MinDuration           // default duration for a test
 	MaxDuration     = 30 * time.Second      // maximum duration for a test
-	version         = 1                     // value used when comparing client and server versions
+	version         = 2                     // value used when comparing client and server versions
 	increment       = time.Second           // increment to display results for, in seconds
 	minInterval     = 10 * time.Millisecond // minimum interval length for a result to be included
 	DefaultPort     = 20333
@@ -37,14 +37,14 @@ type configResponse struct {
 
 // This represents the Result of a speedtest within a specific interval
 type Result struct {
-	Bytes         int           // number of bytes sent/received during the interval
-	IntervalStart time.Duration // duration between the start of the interval and the start of the test
-	IntervalEnd   time.Duration // duration between the end of the interval and the start of the test
-	Total         bool          // if true, this result struct represents the entire test, rather than a segment of the test
+	Bytes         int       // number of bytes sent/received during the interval
+	IntervalStart time.Time // start of the interval
+	IntervalEnd   time.Time // end of the interval
+	Total         bool      // if true, this result struct represents the entire test, rather than a segment of the test
 }
 
 func (r Result) MBitsPerSecond() float64 {
-	return r.MegaBits() / (r.IntervalEnd - r.IntervalStart).Seconds()
+	return r.MegaBits() / r.IntervalEnd.Sub(r.IntervalStart).Seconds()
 }
 
 func (r Result) MegaBytes() float64 {
@@ -56,7 +56,7 @@ func (r Result) MegaBits() float64 {
 }
 
 func (r Result) Interval() time.Duration {
-	return r.IntervalEnd - r.IntervalStart
+	return r.IntervalEnd.Sub(r.IntervalStart)
 }
 
 type Direction int

--- a/net/speedtest/speedtest_test.go
+++ b/net/speedtest/speedtest_test.go
@@ -7,6 +7,7 @@ package speedtest
 import (
 	"net"
 	"testing"
+	"time"
 )
 
 func TestDownload(t *testing.T) {
@@ -23,9 +24,9 @@ func TestDownload(t *testing.T) {
 	type state struct {
 		err error
 	}
-	displayResult := func(t *testing.T, r Result) {
+	displayResult := func(t *testing.T, r Result, start time.Time) {
 		t.Helper()
-		t.Logf("{ Megabytes: %.2f, Start: %.1f, End: %.1f, Total: %t }", r.MegaBytes(), r.IntervalStart.Seconds(), r.IntervalEnd.Seconds(), r.Total)
+		t.Logf("{ Megabytes: %.2f, Start: %.1f, End: %.1f, Total: %t }", r.MegaBytes(), r.IntervalStart.Sub(start).Seconds(), r.IntervalEnd.Sub(start).Seconds(), r.Total)
 	}
 	stateChan := make(chan state, 1)
 
@@ -49,8 +50,9 @@ func TestDownload(t *testing.T) {
 			t.Fatalf("download results: expected length: %d, actual length: %d", expectedLen, len(results))
 		}
 
+		start := results[0].IntervalStart
 		for _, result := range results {
-			displayResult(t, result)
+			displayResult(t, result, start)
 		}
 	})
 
@@ -66,8 +68,9 @@ func TestDownload(t *testing.T) {
 			t.Fatalf("upload results: expected length: %d, actual length: %d", expectedLen, len(results))
 		}
 
+		start := results[0].IntervalStart
 		for _, result := range results {
-			displayResult(t, result)
+			displayResult(t, result, start)
 		}
 	})
 


### PR DESCRIPTION
- removed some in-flow time calls
- increase buffer size to 2MB to overcome syscall cost
- move relative time computation from record to report time
