### PR TITLE
Remove /var/lib mount recommendation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@
 #
 # To run the tailscaled agent:
 #
-#     $ docker run -d --name=tailscaled -v /var/lib:/var/lib -v /dev/net/tun:/dev/net/tun --network=host --privileged tailscale/tailscale tailscaled
+#     $ docker run -d --name=tailscaled -v /dev/net/tun:/dev/net/tun --network=host --privileged tailscale/tailscale tailscaled
 #
 # To then log in:
 #


### PR DESCRIPTION
Can we remove `/var/lib` mount recommendation for starting `taislcaled` in container? It looks unnecessary and excessive security wise. Is there good reason for doing that when running a container? At least in all my scenarios i was able to run `tailscaled` without mounting it.