### PR TITLE
cmd/derper, control/controlhttp: disable WebSocket compression

### DIFF
--- a/cmd/derper/websocket.go
+++ b/cmd/derper/websocket.go
@@ -33,6 +33,12 @@ func addWebSocketSupport(s *derp.Server, base http.Handler) http.Handler {
 		c, err := websocket.Accept(w, r, &websocket.AcceptOptions{
 			Subprotocols:   []string{"derp"},
 			OriginPatterns: []string{"*"},
+			// Disable compression because we transmit WireGuard messages that
+			// are not compressible.
+			// Additionally, Safari has a broken implementation of compression
+			// (see https://github.com/nhooyr/websocket/issues/218) that makes
+			// enabling it actively harmful.
+			CompressionMode: websocket.CompressionDisabled,
 		})
 		if err != nil {
 			log.Printf("websocket.Accept: %v", err)

--- a/control/controlhttp/server.go
+++ b/control/controlhttp/server.go
@@ -82,6 +82,12 @@ func acceptWebsocket(ctx context.Context, w http.ResponseWriter, r *http.Request
 	c, err := websocket.Accept(w, r, &websocket.AcceptOptions{
 		Subprotocols:   []string{upgradeHeaderValue},
 		OriginPatterns: []string{"*"},
+		// Disable compression because we transmit Noise messages that are not
+		// compressible.
+		// Additionally, Safari has a broken implementation of compression
+		// (see https://github.com/nhooyr/websocket/issues/218) that makes
+		// enabling it actively harmful.
+		CompressionMode: websocket.CompressionDisabled,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("Could not accept WebSocket connection %v", err)


### PR DESCRIPTION
The data that we send over WebSockets is encrypted and thus not compressible. Additionally, Safari has a broken implementation of compression (see nhooyr/websocket#218) that makes enabling it actively harmful.

Fixes tailscale/corp#6943