### PR TITLE
Updated value for the kubernetes secret used by the sidecar container

### DIFF
--- a/docs/k8s/README.md
+++ b/docs/k8s/README.md
@@ -16,7 +16,7 @@ There are quite a few ways of running Tailscale inside a Kubernetes Cluster, som
    metadata:
      name: tailscale-auth
    stringData:
-     TS_AUTH_KEY: tskey-...
+     AUTH_KEY: tskey-...
    ```
 
 1. Tailscale (v1.16+) supports storing state inside a Kubernetes Secret.

--- a/docs/k8s/README.md
+++ b/docs/k8s/README.md
@@ -16,7 +16,7 @@ There are quite a few ways of running Tailscale inside a Kubernetes Cluster, som
    metadata:
      name: tailscale-auth
    stringData:
-     AUTH_KEY: tskey-...
+     TS_AUTH_KEY: tskey-...
    ```
 
 1. Tailscale (v1.16+) supports storing state inside a Kubernetes Secret.

--- a/docs/k8s/sidecar.yaml
+++ b/docs/k8s/sidecar.yaml
@@ -23,7 +23,7 @@ spec:
       valueFrom:
         secretKeyRef:
           name: tailscale-auth
-          key: AUTH_KEY
+          key: TS_AUTH_KEY
           optional: true
     securityContext:
       capabilities:


### PR DESCRIPTION
This changes sidecar.yaml so it uses the same value for the `key` stanza as the README.md and run.sh

Fixes: https://github.com/tailscale/tailscale/issues/5653

Signed-off-by: Tyler Lee <tyler.lee@radius.ai>