### PR TITLE
ipn/{ipnlocal,localapi}: use strs.CutPrefix, add more domain validation

### DIFF
--- a/ipn/ipnlocal/peerapi.go
+++ b/ipn/ipnlocal/peerapi.go
@@ -44,6 +44,7 @@ import (
 	"tailscale.com/net/netutil"
 	"tailscale.com/tailcfg"
 	"tailscale.com/util/clientmetric"
+	"tailscale.com/util/strs"
 	"tailscale.com/wgengine"
 	"tailscale.com/wgengine/filter"
 )
@@ -720,8 +721,8 @@ func (h *peerAPIHandler) handlePeerPut(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	rawPath := r.URL.EscapedPath()
-	suffix := strings.TrimPrefix(rawPath, "/v0/put/")
-	if suffix == rawPath {
+	suffix, ok := strs.CutPrefix(rawPath, "/v0/put/")
+	if !ok {
 		http.Error(w, "misconfigured internals", 500)
 		return
 	}

--- a/ipn/localapi/cert_test.go
+++ b/ipn/localapi/cert_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !ios && !android && !js
+// +build !ios,!android,!js
+
+package localapi
+
+import "testing"
+
+func TestValidLookingCertDomain(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"foo.com", true},
+		{"foo..com", false},
+		{"foo/com.com", false},
+		{"NUL", false},
+		{"", false},
+		{"foo\\bar.com", false},
+		{"foo\x00bar.com", false},
+	}
+	for _, tt := range tests {
+		if got := validLookingCertDomain(tt.in); got != tt.want {
+			t.Errorf("validLookingCertDomain(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
The GitHub CodeQL scanner flagged the localapi's cert domain usage as a problem because user input in the URL made it to disk stat checks.

The domain is validated against the ipnstate.Status later, and only authenticated root/configured users can hit this, but add some paranoia anyway.

