### PR TITLE
Update Dockerfile to use golang:1.19-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@
 #     $ docker exec tailscaled tailscale status
 
 
-FROM golang:1.18-alpine AS build-env
+FROM golang:1.19-alpine AS build-env
 
 WORKDIR /go/src/tailscale
 


### PR DESCRIPTION
Tailscale @4a82b31 does not build in the container image due to using golang:1.18 image