### PR TITLE
control/controlhttp: move Dial options into options struct

### DIFF
--- a/cmd/tailscale/cli/debug.go
+++ b/cmd/tailscale/cli/debug.go
@@ -489,7 +489,15 @@ func runTS2021(ctx context.Context, args []string) error {
 		return c, err
 	}
 
-	conn, err := controlhttp.Dial(ctx, ts2021Args.host, "80", "443", machinePrivate, keys.PublicKey, uint16(ts2021Args.version), dialFunc)
+	conn, err := (&controlhttp.Dialer{
+		Hostname:        ts2021Args.host,
+		HTTPPort:        "80",
+		HTTPSPort:       "443",
+		MachineKey:      machinePrivate,
+		ControlKey:      keys.PublicKey,
+		ProtocolVersion: uint16(ts2021Args.version),
+		Dialer:          dialFunc,
+	}).Dial(ctx)
 	log.Printf("controlhttp.Dial = %p, %v", conn, err)
 	if err != nil {
 		return err

--- a/control/controlclient/noise.go
+++ b/control/controlclient/noise.go
@@ -165,7 +165,15 @@ func (nc *noiseClient) dial(_, _ string, _ *tls.Config) (net.Conn, error) {
 		// thousand version numbers before getting to this point.
 		panic("capability version is too high to fit in the wire protocol")
 	}
-	conn, err := controlhttp.Dial(ctx, nc.host, nc.httpPort, nc.httpsPort, nc.privKey, nc.serverPubKey, uint16(tailcfg.CurrentCapabilityVersion), nc.dialer.SystemDial)
+	conn, err := (&controlhttp.Dialer{
+		Hostname:        nc.host,
+		HTTPPort:        nc.httpPort,
+		HTTPSPort:       nc.httpsPort,
+		MachineKey:      nc.privKey,
+		ControlKey:      nc.serverPubKey,
+		ProtocolVersion: uint16(tailcfg.CurrentCapabilityVersion),
+		Dialer:          nc.dialer.SystemDial,
+	}).Dial(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/control/controlhttp/constants.go
+++ b/control/controlhttp/constants.go
@@ -4,6 +4,16 @@
 
 package controlhttp
 
+import (
+	"net/http"
+	"net/url"
+	"time"
+
+	"tailscale.com/net/dnscache"
+	"tailscale.com/types/key"
+	"tailscale.com/types/logger"
+)
+
 const (
 	// upgradeHeader is the value of the Upgrade HTTP header used to
 	// indicate the Tailscale control protocol.
@@ -18,3 +28,58 @@ const (
 	// to do the protocol switch is located.
 	serverUpgradePath = "/ts2021"
 )
+
+// Dialer contains configuration on how to dial the Tailscale control server.
+type Dialer struct {
+	// Hostname is the hostname to connect to, with no port number.
+	//
+	// This field is required.
+	Hostname string
+
+	// MachineKey contains the current machine's private key.
+	//
+	// This field is required.
+	MachineKey key.MachinePrivate
+
+	// ControlKey contains the expected public key for the control server.
+	//
+	// This field is required.
+	ControlKey key.MachinePublic
+
+	// ProtocolVersion is the expected protocol version to negotiate.
+	//
+	// This field is required.
+	ProtocolVersion uint16
+
+	// HTTPPort is the port number to use when making a HTTP connection.
+	//
+	// If not specified, this defaults to port 80.
+	HTTPPort string
+
+	// HTTPSPort is the port number to use when making a HTTPS connection.
+	//
+	// If not specified, this defaults to port 443.
+	HTTPSPort string
+
+	// Dialer is the dialer used to make outbound connections.
+	//
+	// If not specified, this defaults to net.Dialer.DialContext.
+	Dialer dnscache.DialContextFunc
+
+	// Logf, if set, is a logging function to use; if unset, logs are
+	// dropped.
+	Logf logger.Logf
+
+	proxyFunc func(*http.Request) (*url.URL, error) // or nil
+
+	// For tests only
+	insecureTLS       bool
+	testFallbackDelay time.Duration
+}
+
+func strDef(v1, v2 string) string {
+	if v1 != "" {
+		return v1
+	}
+	return v2
+}

--- a/control/controlhttp/http_test.go
+++ b/control/controlhttp/http_test.go
@@ -170,15 +170,16 @@ func testControlHTTP(t *testing.T, param httpTestParam) {
 		defer cancel()
 	}
 
-	a := dialParams{
-		host:              "localhost",
-		httpPort:          strconv.Itoa(httpLn.Addr().(*net.TCPAddr).Port),
-		httpsPort:         strconv.Itoa(httpsLn.Addr().(*net.TCPAddr).Port),
-		machineKey:        client,
-		controlKey:        server.Public(),
-		version:           testProtocolVersion,
+	a := &Dialer{
+		Hostname:          "localhost",
+		HTTPPort:          strconv.Itoa(httpLn.Addr().(*net.TCPAddr).Port),
+		HTTPSPort:         strconv.Itoa(httpsLn.Addr().(*net.TCPAddr).Port),
+		MachineKey:        client,
+		ControlKey:        server.Public(),
+		ProtocolVersion:   testProtocolVersion,
+		Dialer:            new(tsdial.Dialer).SystemDial,
+		Logf:              t.Logf,
 		insecureTLS:       true,
-		dialer:            new(tsdial.Dialer).SystemDial,
 		testFallbackDelay: 50 * time.Millisecond,
 	}
 


### PR DESCRIPTION
This turns 'dialParams' into something more like net.Dialer, where configuration fields are public on the struct.

Split out of #5648

Change-Id: I0c56fd151dc5489c3c94fb40d18fd639e06473bc
Signed-off-by: Andrew Dunham <andrew@tailscale.com>