### PR TITLE
envknob: generalize Windows tailscaled-env.txt support

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -131,8 +131,12 @@ var subCommands = map[string]*func([]string) error{
 
 var beCLI func() // non-nil if CLI is linked in
 
+var diskConfigErr error
+
 func main() {
 	envknob.PanicIfAnyEnvCheckedInInit()
+	diskConfigErr = envknob.ApplyDiskConfig()
+
 	printVersion := false
 	flag.IntVar(&args.verbose, "verbose", 0, "log verbosity level; 0 is default, 1 or higher are increasingly verbose")
 	flag.BoolVar(&args.cleanup, "cleanup", false, "clean up system state and exit")
@@ -308,6 +312,10 @@ func run() error {
 		defer cancel()
 		pol.Shutdown(ctx)
 	}()
+
+	if diskConfigErr != nil {
+		log.Printf("Error reading environment config: %v", diskConfigErr)
+	}
 
 	if isWindowsService() {
 		// Run the IPN server from the Windows service manager.

--- a/cmd/tailscaled/tailscaled_windows.go
+++ b/cmd/tailscaled/tailscaled_windows.go
@@ -197,6 +197,9 @@ func beWindowsSubprocess() bool {
 
 	log.Printf("Program starting: v%v: %#v", version.Long, os.Args)
 	log.Printf("subproc mode: logid=%v", logid)
+	if diskConfigErr != nil {
+		log.Printf("Error reading environment config: %v", diskConfigErr)
+	}
 
 	go func() {
 		b := make([]byte, 16)

--- a/envknob/envknob_windows.go
+++ b/envknob/envknob_windows.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package envknob
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func init() {
+	platformApplyDiskConfig = platformApplyDiskConfigWindows
+}
+
+func platformApplyDiskConfigWindows() error {
+	name := filepath.Join(os.Getenv("ProgramData"), "Tailscale", "tailscaled-env.txt")
+	f, err := os.Open(name)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return applyKeyValueEnv(f)
+}


### PR DESCRIPTION
ipnserver previously had support for a Windows-only environment variable mechanism that further only worked when Windows was running as a service, not from a console.

But we want it to work from tailscaed too, and we want it to work on macOS and Synology. So move it to envknob, now that envknob can change values at runtime post-init.

A future change will wire this up for more platforms, and do something more for CLI flags like --port, which the bug was originally about.

Updates #5114