### PR TITLE
cmd/tailscaled: use explicit equal sign in --port=$PORT in tailscaled.service

### DIFF
--- a/cmd/tailscaled/tailscaled.service
+++ b/cmd/tailscaled/tailscaled.service
@@ -7,7 +7,7 @@ After=network-pre.target NetworkManager.service systemd-resolved.service
 [Service]
 EnvironmentFile=/etc/default/tailscaled
 ExecStartPre=/usr/sbin/tailscaled --cleanup
-ExecStart=/usr/sbin/tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/run/tailscale/tailscaled.sock --port $PORT $FLAGS
+ExecStart=/usr/sbin/tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/run/tailscale/tailscaled.sock --port=${PORT} $FLAGS
 ExecStopPost=/usr/sbin/tailscaled --cleanup
 
 Restart=on-failure


### PR DESCRIPTION
Personal preference (so it's obvious it's not a bool flag), but it also matches the --state= before it.

Bonus: stop allowing PORT to sneak in extra flags to be passed as their own arguments, as $FOO and ${FOO} expand differently. (${FOO} is required to concat to strings)
