### PR TITLE
tailconfig: add tailnet field to node

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -226,7 +226,7 @@ type Node struct {
 	//    "https://tailscale.com/cap/file-sharing"
 	Capabilities []string `json:",omitempty"`
 
-	// The following three computed fields hold the various names that can
+	// The following computed fields hold the various names that can
 	// be used for this node in UIs. They are populated from controlclient
 	// (not from control) by calling node.InitDisplayNames. These can be
 	// used directly or accessed via node.DisplayName or node.DisplayNames.
@@ -234,6 +234,7 @@ type Node struct {
 	ComputedName            string `json:",omitempty"` // MagicDNS base name (for normal non-shared-in nodes), FQDN (without trailing dot, for shared-in nodes), or Hostname (if no MagicDNS)
 	computedHostIfDifferent string // hostname, if different than ComputedName, otherwise empty
 	ComputedNameWithHost    string `json:",omitempty"` // either "ComputedName" or "ComputedName (computedHostIfDifferent)", if computedHostIfDifferent is set
+	TailnetName             string `json:",omitempty"` // SSO Tailnet name
 }
 
 // DisplayName returns the user-facing name for a node which should

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -95,6 +95,7 @@ var _NodeCloneNeedsRegeneration = Node(struct {
 	ComputedName            string
 	computedHostIfDifferent string
 	ComputedNameWithHost    string
+	TailnetName             string
 }{})
 
 // Clone makes a deep copy of Hostinfo.

--- a/tailcfg/tailcfg_test.go
+++ b/tailcfg/tailcfg_test.go
@@ -331,7 +331,7 @@ func TestNodeEqual(t *testing.T) {
 		"Created", "Tags", "PrimaryRoutes",
 		"LastSeen", "Online", "KeepAlive", "MachineAuthorized",
 		"Capabilities",
-		"ComputedName", "computedHostIfDifferent", "ComputedNameWithHost",
+		"ComputedName", "computedHostIfDifferent", "ComputedNameWithHost", "TailnetName",
 	}
 	if have := fieldsOf(reflect.TypeOf(Node{})); !reflect.DeepEqual(have, nodeHandles) {
 		t.Errorf("Node.Equal check might be out of sync\nfields: %q\nhandled: %q\n",

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -173,6 +173,7 @@ func (v NodeView) MachineAuthorized() bool           { return v.ж.MachineAuthor
 func (v NodeView) Capabilities() views.Slice[string] { return views.SliceOf(v.ж.Capabilities) }
 func (v NodeView) ComputedName() string              { return v.ж.ComputedName }
 func (v NodeView) ComputedNameWithHost() string      { return v.ж.ComputedNameWithHost }
+func (v NodeView) TailnetName() string               { return v.ж.TailnetName }
 func (v NodeView) Equal(v2 NodeView) bool            { return v.ж.Equal(v2.ж) }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
@@ -203,6 +204,7 @@ var _NodeViewNeedsRegeneration = Node(struct {
 	ComputedName            string
 	computedHostIfDifferent string
 	ComputedNameWithHost    string
+	TailnetName             string
 }{})
 
 // View returns a readonly view of Hostinfo.


### PR DESCRIPTION
Enable access to tailnet name from Node to track and avoid computing in unrelated functions like ngnix-auth

Signed-off-by: nyghtowl <warrick@tailscale.com>