### PR TITLE
tailscale: Fix configure-host command for Synology

### DIFF
--- a/cmd/tailscale/cli/configure-host.go
+++ b/cmd/tailscale/cli/configure-host.go
@@ -48,11 +48,11 @@ func runConfigureHost(ctx context.Context, args []string) error {
 	if uid := os.Getuid(); uid != 0 {
 		return fmt.Errorf("must be run as root, not %q (%v)", os.Getenv("USER"), uid)
 	}
-	osVer := hostinfo.GetOSVersion()
-	isDSM6 := strings.HasPrefix(osVer, "Synology 6")
-	isDSM7 := strings.HasPrefix(osVer, "Synology 7")
+	hi:= hostinfo.New()
+	isDSM6 := strings.HasPrefix(hi.DistroVersion, "6.")
+	isDSM7 := strings.HasPrefix(hi.DistroVersion, "7.")
 	if !isDSM6 && !isDSM7 {
-		return fmt.Errorf("unsupported DSM version %q", osVer)
+		return fmt.Errorf("unsupported DSM version %q", hi.DistroVersion)
 	}
 	if _, err := os.Stat("/dev/net/tun"); os.IsNotExist(err) {
 		if err := os.MkdirAll("/dev/net", 0755); err != nil {


### PR DESCRIPTION
d5e7e309 changed the `hostinfo.GetVersion` from distro and distro version
to UTS Name Release and moved distribution information under
`hostinfo.Distro*`.

`tailscale configure-host` command implementation for Synology DSM
environments relies on the old semantics of this string for matching DSM
Major version so it's been broken for a few days.

Pull in `hostinfo` and prefix match `hostinfo.DistroVersion` to match
DSM major version.
