### PR TITLE
net/netns: implement UseSocketMark for Android.

### DIFF
--- a/net/netns/netns_android.go
+++ b/net/netns/netns_android.go
@@ -20,6 +20,11 @@ var (
 	androidProtectFunc   func(fd int) error
 )
 
+// UseSocketMark reports whether SO_MARK is in use. Android does not use SO_MARK.
+func UseSocketMark() bool {
+	return false
+}
+
 // SetAndroidProtectFunc register a func that Android provides that JNI calls into
 // https://developer.android.com/reference/android/net/VpnService#protect(int)
 // which is documented as:


### PR DESCRIPTION
Build fails on Android:
`../../../../go/pkg/mod/tailscale.com@v1.1.1-0.20220916223019-65c24b6334e9/wgengine/magicsock/magicsock_linux.go:133:12: undefined: netns.UseSocketMark`

Signed-off-by: Denton Gentry <dgentry@tailscale.com>