### PR TITLE
cmd/tsconnect: allow SSH connection timeout to be overridden

### DIFF
--- a/cmd/tsconnect/src/lib/ssh.ts
+++ b/cmd/tsconnect/src/lib/ssh.ts
@@ -5,6 +5,8 @@ import { WebLinksAddon } from "xterm-addon-web-links"
 export type SSHSessionDef = {
   username: string
   hostname: string
+  /** Defaults to 5 seconds */
+  timeoutSeconds?: number
 }
 
 export function runSSHSession(
@@ -62,6 +64,7 @@ export function runSSHSession(
       }
       onDone()
     },
+    timeoutSeconds: def.timeoutSeconds,
   })
 
   // Make terminal and SSH session track the size of the containing DOM node.

--- a/cmd/tsconnect/src/types/wasm_js.d.ts
+++ b/cmd/tsconnect/src/types/wasm_js.d.ts
@@ -23,6 +23,8 @@ declare global {
         setReadFn: (readFn: (data: string) => void) => void
         rows: number
         cols: number
+        /** Defaults to 5 seconds */
+        timeoutSeconds?: number
         onDone: () => void
       }
     ): IPNSSHSession

--- a/cmd/tsconnect/wasm/wasm_js.go
+++ b/cmd/tsconnect/wasm/wasm_js.go
@@ -360,6 +360,10 @@ func (s *jsSSHSession) Run() {
 	setReadFn := s.termConfig.Get("setReadFn")
 	rows := s.termConfig.Get("rows").Int()
 	cols := s.termConfig.Get("cols").Int()
+	timeoutSeconds := 5.0
+	if jsTimeoutSeconds := s.termConfig.Get("timeoutSeconds"); jsTimeoutSeconds.Type() == js.TypeNumber {
+		timeoutSeconds = jsTimeoutSeconds.Float()
+	}
 	onDone := s.termConfig.Get("onDone")
 	defer onDone.Invoke()
 
@@ -367,7 +371,7 @@ func (s *jsSSHSession) Run() {
 		writeErrorFn.Invoke(fmt.Sprintf("%s Error: %v\r\n", label, err))
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSeconds*float64(time.Second)))
 	defer cancel()
 	c, err := s.jsIPN.dialer.UserDial(ctx, "tcp", net.JoinHostPort(s.host, "22"))
 	if err != nil {


### PR DESCRIPTION
5 seconds may not be enough if we're still loading the derp map and connecting to a slow machine.

Updates #5693