### PR TITLE
cmd/tsconnect: add error callback for SSH sessions

### DIFF
--- a/cmd/tsconnect/src/app/ssh.tsx
+++ b/cmd/tsconnect/src/app/ssh.tsx
@@ -46,7 +46,7 @@ function SSHSession({
   const ref = useRef<HTMLDivElement>(null)
   useEffect(() => {
     if (ref.current) {
-      runSSHSession(ref.current, def, ipn, onDone)
+      runSSHSession(ref.current, def, ipn, onDone, (err) => console.error(err))
     }
   }, [ref])
 

--- a/cmd/tsconnect/src/lib/ssh.ts
+++ b/cmd/tsconnect/src/lib/ssh.ts
@@ -12,6 +12,7 @@ export function runSSHSession(
   def: SSHSessionDef,
   ipn: IPN,
   onDone: () => void,
+  onError?: (err: string) => void,
   terminalOptions?: ITerminalOptions
 ) {
   const parentWindow = termContainerNode.ownerDocument.defaultView ?? window
@@ -46,7 +47,7 @@ export function runSSHSession(
       term.write(input)
     },
     writeErrorFn(err) {
-      console.error(err)
+      onError?.(err)
       term.write(err)
     },
     setReadFn(hook) {


### PR DESCRIPTION
We were just logging them to the console, which is useful for debugging, but we may want to show them in the UI too.

Updates tailscale/corp#6939
