### PR TITLE
docs/k8s: add TS prefix

### DIFF
--- a/docs/k8s/proxy.yaml
+++ b/docs/k8s/proxy.yaml
@@ -37,7 +37,7 @@ spec:
       valueFrom:
         secretKeyRef:
           name: tailscale-auth
-          key: AUTH_KEY
+          key: TS_AUTH_KEY
           optional: true
     - name: TS_DEST_IP
       value: "{{TS_DEST_IP}}"

--- a/docs/k8s/subnet.yaml
+++ b/docs/k8s/subnet.yaml
@@ -23,7 +23,7 @@ spec:
       valueFrom:
         secretKeyRef:
           name: tailscale-auth
-          key: AUTH_KEY
+          key: TS_AUTH_KEY
           optional: true
     - name: TS_ROUTES
       value: "{{TS_ROUTES}}"

--- a/docs/k8s/userspace-sidecar.yaml
+++ b/docs/k8s/userspace-sidecar.yaml
@@ -26,5 +26,5 @@ spec:
       valueFrom:
         secretKeyRef:
           name: tailscale-auth
-          key: AUTH_KEY
+          key: TS_AUTH_KEY
           optional: true


### PR DESCRIPTION
# WHAT

I added `TS` prefix to auth key based on [READ.md](https://github.com/tailscale/tailscale/blob/main/docs/k8s/README.md)

# WHY

The documentation describes the auth key as `TS_AUTH_KEY`, but the manifest uses `AUTH_KEY`, which did not work properly.


