### PR TITLE
logtail: always record timestamps in UTC

### DIFF
--- a/logtail/logtail.go
+++ b/logtail/logtail.go
@@ -519,7 +519,7 @@ func (l *Logger) encodeText(buf []byte, skipClientTime bool, procID uint32, proc
 		b = append(b, `"logtail": {`...)
 		if !skipClientTime {
 			b = append(b, `"client_time": "`...)
-			b = now.AppendFormat(b, time.RFC3339Nano)
+			b = now.UTC().AppendFormat(b, time.RFC3339Nano)
 			b = append(b, `",`...)
 		}
 		if procID != 0 {
@@ -612,7 +612,7 @@ func (l *Logger) encodeLocked(buf []byte, level int) []byte {
 	if !l.skipClientTime || l.procID != 0 || l.procSequence != 0 {
 		logtail := map[string]any{}
 		if !l.skipClientTime {
-			logtail["client_time"] = now.Format(time.RFC3339Nano)
+			logtail["client_time"] = now.UTC().Format(time.RFC3339Nano)
 		}
 		if l.procID != 0 {
 			logtail["proc_id"] = l.procID


### PR DESCRIPTION
Upstream optimizations to the Go time package will make unmarshaling of time.Time 3-6x faster. See:
* https://go.dev/cl/425116
* https://go.dev/cl/425197
* https://go.dev/cl/429862

The last optimization avoids a []byte -> string allocation if the timestamp string less than than 32B.
Unfortunately, the presence of a timezone breaks that optimization. Drop recording of timezone as this is non-essential information.

Most of the performance gains is upon unmarshal,
but there is also a slight performance benefit to
not marshaling the timezone as well.

Signed-off-by: Joe Tsai <joetsai@digital-static.net>