### PR TITLE
tsweb: consider 304s as successful for quiet logging

### DIFF
--- a/tsweb/tsweb.go
+++ b/tsweb/tsweb.go
@@ -184,9 +184,9 @@ type ReturnHandler interface {
 }
 
 type HandlerOptions struct {
-	Quiet200s bool // if set, do not log successfully handled HTTP requests
-	Logf      logger.Logf
-	Now       func() time.Time // if nil, defaults to time.Now
+	QuietLoggingIfSuccessful bool // if set, do not log successfully handled HTTP requests (200 and 304 status codes)
+	Logf                     logger.Logf
+	Now                      func() time.Time // if nil, defaults to time.Now
 
 	// If non-nil, StatusCodeCounters maintains counters
 	// of status codes for handled responses.
@@ -316,7 +316,7 @@ func (h retHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if msg.Code != 200 || !h.opts.Quiet200s {
+	if !h.opts.QuietLoggingIfSuccessful || (msg.Code != http.StatusOK && msg.Code != http.StatusNotModified) {
 		h.opts.Logf("%s", msg)
 	}
 

--- a/tsweb/tsweb_test.go
+++ b/tsweb/tsweb_test.go
@@ -303,7 +303,7 @@ func BenchmarkLogNot200(b *testing.B) {
 		// Implicit 200 OK.
 		return nil
 	})
-	h := StdHandler(rh, HandlerOptions{Quiet200s: true})
+	h := StdHandler(rh, HandlerOptions{QuietLoggingIfSuccessful: true})
 	req := httptest.NewRequest("GET", "/", nil)
 	rw := new(httptest.ResponseRecorder)
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
Static resource handlers will generate lots of 304s, which are effectively successful responses.