### PR TITLE
control/controlclient: add a noiseClient.post helper method

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -1434,15 +1434,11 @@ func (c *Direct) getNoiseClient() (*noiseClient, error) {
 func (c *Direct) setDNSNoise(ctx context.Context, req *tailcfg.SetDNSRequest) error {
 	newReq := *req
 	newReq.Version = tailcfg.CurrentCapabilityVersion
-	np, err := c.getNoiseClient()
+	nc, err := c.getNoiseClient()
 	if err != nil {
 		return err
 	}
-	bodyData, err := json.Marshal(newReq)
-	if err != nil {
-		return err
-	}
-	res, err := np.Post(fmt.Sprintf("https://%v/%v", np.host, "machine/set-dns"), "application/json", bytes.NewReader(bodyData))
+	res, err := nc.post(ctx, "/machine/set-dns", req)
 	if err != nil {
 		return err
 	}

--- a/control/controlclient/noise.go
+++ b/control/controlclient/noise.go
@@ -5,8 +5,10 @@
 package controlclient
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"math"
 	"net"
 	"net/http"
@@ -227,4 +229,17 @@ func (nc *noiseClient) dial(_, _ string, _ *tls.Config) (net.Conn, error) {
 	ncc := &noiseConn{Conn: conn, id: connID, pool: nc}
 	mak.Set(&nc.connPool, ncc.id, ncc)
 	return ncc, nil
+}
+
+func (nc *noiseClient) post(ctx context.Context, path string, body any) (*http.Response, error) {
+	jbody, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://"+nc.host+path, bytes.NewReader(jbody))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return nc.Do(req)
 }


### PR DESCRIPTION
In prep for a future change that would've been very copy/paste-y.

And because the set-dns call doesn't currently use a context, so timeouts/cancelations are plumbed.
