### PR TITLE
control/controlclient: stop restarting map polls on health change

### DIFF
--- a/control/controlclient/auto.go
+++ b/control/controlclient/auto.go
@@ -114,17 +114,9 @@ func NewNoStart(opts Options) (*Auto, error) {
 	}
 	c.authCtx, c.authCancel = context.WithCancel(context.Background())
 	c.mapCtx, c.mapCancel = context.WithCancel(context.Background())
-	c.unregisterHealthWatch = health.RegisterWatcher(c.onHealthChange)
+	c.unregisterHealthWatch = health.RegisterWatcher(direct.ReportHealthChange)
 	return c, nil
 
-}
-
-func (c *Auto) onHealthChange(sys health.Subsystem, err error) {
-	if sys == health.SysOverall {
-		return
-	}
-	c.logf("controlclient: restarting map request for %q health change to new state: %v", sys, err)
-	c.cancelMapSafely()
 }
 
 // SetPaused controls whether HTTP activity should be paused.

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -1684,6 +1684,13 @@ type SetDNSRequest struct {
 // SetDNSResponse is the response to a SetDNSRequest.
 type SetDNSResponse struct{}
 
+// HealthChangeRequest is the JSON request body type used to report
+// node health changes to https://<control>/machine/<mkey hex>/update-health.
+type HealthChangeRequest struct {
+	Subsys string // a health.Subsystem value in string form
+	Error  string // or empty if cleared
+}
+
 // SSHPolicy is the policy for how to handle incoming SSH connections
 // over Tailscale.
 type SSHPolicy struct {


### PR DESCRIPTION
At some point we started restarting map polls on health change, but we don't remember why. Maybe it was a desperate workaround for something. I'm not sure it ever worked.

Rather than have a haunted graveyard, remove it.

In its place, though, and somewhat as a safety backup, send those updates over the HTTP/2 noise channel if we have one open. Then if there was a reason that a map poll restart would help we could do it server-side. But mostly we can gather error stats and show machine-level health info for debugging.
