### PR TITLE
Add an option for tailscaled to disable the peerapi-dns service.

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -129,6 +129,7 @@ var args struct {
 	socksAddr      string // listen address for SOCKS5 server
 	httpProxyAddr  string // listen address for HTTP proxy server
 	disableLogs    bool
+	disablePeerAPIDNS    bool
 }
 
 var (
@@ -164,6 +165,7 @@ func main() {
 	flag.StringVar(&args.birdSocketPath, "bird-socket", "", "path of the bird unix socket")
 	flag.BoolVar(&printVersion, "version", false, "print version information and exit")
 	flag.BoolVar(&args.disableLogs, "no-logs-no-support", false, "disable log uploads; this also disables any technical support")
+	flag.BoolVar(&args.disablePeerAPIDNS, "no-peerapi-dns", false, "disable peer API DNS");
 
 	if len(os.Args) > 0 && filepath.Base(os.Args[0]) == "tailscale" && beCLI != nil {
 		beCLI()
@@ -458,7 +460,9 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("ipnserver.New: %w", err)
 	}
-	ns.SetLocalBackend(srv.LocalBackend())
+	backend := srv.LocalBackend()
+	backend.SetPeerAPIEnableDNS(!args.disablePeerAPIDNS)
+	ns.SetLocalBackend(backend)
 	if err := ns.Start(); err != nil {
 		log.Fatalf("failed to start netstack: %v", err)
 	}

--- a/ipn/ipnlocal/peerapi.go
+++ b/ipn/ipnlocal/peerapi.go
@@ -996,6 +996,10 @@ func (h *peerAPIHandler) replyToDNSQueries() bool {
 // handleDNSQuery implements a DoH server (RFC 8484) over the peerapi.
 // It's not over HTTPS as the spec dictates, but rather HTTP-over-WireGuard.
 func (h *peerAPIHandler) handleDNSQuery(w http.ResponseWriter, r *http.Request) {
+	if !h.ps.b.peerAPIEnableDNS {
+		http.Error(w, "denied, DNS service disabled", http.StatusForbidden)
+		return
+	}
 	if h.ps.resolver == nil {
 		http.Error(w, "DNS not wired up", http.StatusNotImplemented)
 		return


### PR DESCRIPTION
See also https://github.com/tailscale/tailscale/issues/4335

This is useful for exit node scenarios where we prefer DNS queries to go through the regular exit node routing rather than handled by the DoH service.

Why would we ever prefer that? One reason is if we are already hosting our own DNS infrastructure, and don't want to lose the association between clients and the DNS queries they are performing for security/firewall/logging reasons.