### PR TITLE
control/controlclient: fix recent set-dns regression

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -1438,7 +1438,7 @@ func (c *Direct) setDNSNoise(ctx context.Context, req *tailcfg.SetDNSRequest) er
 	if err != nil {
 		return err
 	}
-	res, err := nc.post(ctx, "/machine/set-dns", req)
+	res, err := nc.post(ctx, "/machine/set-dns", &newReq)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
SetDNS calls were broken by 6d04184325 the other day. Unreleased.

Caught by tests in another repo.
