### PR TITLE
control/controlhttp: use custom port for non-localhost JS noise client connections

### DIFF
--- a/control/controlhttp/client_js.go
+++ b/control/controlhttp/client_js.go
@@ -29,9 +29,11 @@ func (d *Dialer) Dial(ctx context.Context) (*controlbase.Conn, error) {
 
 	wsScheme := "wss"
 	host := d.Hostname
-	if host == "localhost" {
+	// If using a custom control server (on a non-standard port), prefer that.
+	// This mirrors the port selection in newNoiseClient from noise.go.
+	if d.HTTPPort != "" && d.HTTPPort != "80" && d.HTTPSPort == "443" {
 		wsScheme = "ws"
-		host = net.JoinHostPort(host, strDef(d.HTTPPort, "80"))
+		host = net.JoinHostPort(host, d.HTTPPort)
 	}
 	wsURL := &url.URL{
 		Scheme: wsScheme,


### PR DESCRIPTION
Control may not be bound to (just) localhost when sharing dev servers, allow the Wasm client to connect to it in that case too.