### PR TITLE
ipn/ipnlocal, tka: Implement TKA synchronization with the control plane

### DIFF
--- a/ipn/ipnlocal/network-lock_test.go
+++ b/ipn/ipnlocal/network-lock_test.go
@@ -23,6 +23,7 @@ import (
 	"tailscale.com/types/key"
 	"tailscale.com/types/netmap"
 	"tailscale.com/types/persist"
+	"tailscale.com/types/tkatype"
 )
 
 func fakeControlClient(t *testing.T, c *http.Client) *controlclient.Auto {
@@ -49,8 +50,6 @@ func fakeControlClient(t *testing.T, c *http.Client) *controlclient.Auto {
 	return cc
 }
 
-// NOTE: URLs must have a https scheme and example.com domain to work with the underlying
-// httptest plumbing, despite the domain being unused in the actual noise request transport.
 func fakeNoiseServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *http.Client) {
 	ts := httptest.NewUnstartedServer(handler)
 	ts.StartTLS()
@@ -104,6 +103,9 @@ func TestTKAEnablementFlow(t *testing.T) {
 				t.Fatal(err)
 			}
 
+		case "/machine/tka/sync/offer", "/machine/tka/sync/send":
+			t.Error("node attempted to sync, but should have been up to date")
+
 		default:
 			t.Errorf("unhandled endpoint path: %v", r.URL.Path)
 			w.WriteHeader(404)
@@ -126,7 +128,7 @@ func TestTKAEnablementFlow(t *testing.T) {
 	b.mu.Lock()
 	err = b.tkaSyncIfNeededLocked(&netmap.NetworkMap{
 		TKAEnabled: true,
-		TKAHead:    tka.AUMHash{},
+		TKAHead:    a1.Head(),
 	})
 	b.mu.Unlock()
 	if err != nil {
@@ -254,5 +256,231 @@ func TestTKADisablementFlow(t *testing.T) {
 	}
 	if _, err := os.Stat(b.chonkPath()); err == nil || !os.IsNotExist(err) {
 		t.Errorf("os.Stat(chonkDir) = %v, want ErrNotExist", err)
+	}
+}
+
+func TestTKASync(t *testing.T) {
+	networkLockAvailable = func() bool { return true } // Enable the feature flag
+
+	someKeyPriv := key.NewNLPrivate()
+	someKey := tka.Key{Kind: tka.Key25519, Public: someKeyPriv.Public().Verifier(), Votes: 1}
+
+	type tkaSyncScenario struct {
+		name string
+		// controlAUMs is called (if non-nil) to get any AUMs which the tka state
+		// on control should be seeded with.
+		controlAUMs func(*testing.T, *tka.Authority, tka.Chonk, tka.Signer) []tka.AUM
+		// controlAUMs is called (if non-nil) to get any AUMs which the tka state
+		// on the node should be seeded with.
+		nodeAUMs func(*testing.T, *tka.Authority, tka.Chonk, tka.Signer) []tka.AUM
+	}
+
+	tcs := []tkaSyncScenario{
+		{name: "up to date"},
+		{
+			name: "control has an update",
+			controlAUMs: func(t *testing.T, a *tka.Authority, storage tka.Chonk, signer tka.Signer) []tka.AUM {
+				b := a.NewUpdater(signer)
+				if err := b.RemoveKey(someKey.ID()); err != nil {
+					t.Fatal(err)
+				}
+				aums, err := b.Finalize(storage)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return aums
+			},
+		},
+		{
+			// AKA 'control data loss' scenario
+			name: "node has an update",
+			nodeAUMs: func(t *testing.T, a *tka.Authority, storage tka.Chonk, signer tka.Signer) []tka.AUM {
+				b := a.NewUpdater(signer)
+				if err := b.RemoveKey(someKey.ID()); err != nil {
+					t.Fatal(err)
+				}
+				aums, err := b.Finalize(storage)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return aums
+			},
+		},
+		{
+			// AKA 'control data loss + update in the meantime' scenario
+			name: "node and control diverge",
+			controlAUMs: func(t *testing.T, a *tka.Authority, storage tka.Chonk, signer tka.Signer) []tka.AUM {
+				b := a.NewUpdater(signer)
+				if err := b.SetKeyMeta(someKey.ID(), map[string]string{"ye": "swiggity"}); err != nil {
+					t.Fatal(err)
+				}
+				aums, err := b.Finalize(storage)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return aums
+			},
+			nodeAUMs: func(t *testing.T, a *tka.Authority, storage tka.Chonk, signer tka.Signer) []tka.AUM {
+				b := a.NewUpdater(signer)
+				if err := b.SetKeyMeta(someKey.ID(), map[string]string{"ye": "swooty"}); err != nil {
+					t.Fatal(err)
+				}
+				aums, err := b.Finalize(storage)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return aums
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			temp := t.TempDir()
+			os.Mkdir(filepath.Join(temp, "tka"), 0755)
+			nodePriv := key.NewNode()
+			nlPriv := key.NewNLPrivate()
+
+			// Setup the tka authority on the control plane.
+			key := tka.Key{Kind: tka.Key25519, Public: nlPriv.Public().Verifier(), Votes: 2}
+			controlStorage := &tka.Mem{}
+			controlAuthority, bootstrap, err := tka.Create(controlStorage, tka.State{
+				Keys:               []tka.Key{key, someKey},
+				DisablementSecrets: [][]byte{bytes.Repeat([]byte{0xa5}, 32)},
+			}, nlPriv)
+			if err != nil {
+				t.Fatalf("tka.Create() failed: %v", err)
+			}
+			if tc.controlAUMs != nil {
+				if err := controlAuthority.Inform(controlStorage, tc.controlAUMs(t, controlAuthority, controlStorage, nlPriv)); err != nil {
+					t.Fatalf("controlAuthority.Inform() failed: %v", err)
+				}
+			}
+
+			// Setup the TKA authority on the node.
+			nodeStorage, err := tka.ChonkDir(filepath.Join(temp, "tka"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			nodeAuthority, err := tka.Bootstrap(nodeStorage, bootstrap)
+			if err != nil {
+				t.Fatalf("tka.Bootstrap() failed: %v", err)
+			}
+			if tc.nodeAUMs != nil {
+				if err := nodeAuthority.Inform(nodeStorage, tc.nodeAUMs(t, nodeAuthority, nodeStorage, nlPriv)); err != nil {
+					t.Fatalf("nodeAuthority.Inform() failed: %v", err)
+				}
+			}
+
+			// Make a mock control server.
+			ts, client := fakeNoiseServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer r.Body.Close()
+				switch r.URL.Path {
+				case "/machine/tka/sync/offer":
+					body := new(tailcfg.TKASyncOfferRequest)
+					if err := json.NewDecoder(r.Body).Decode(body); err != nil {
+						t.Fatal(err)
+					}
+					t.Logf("got sync offer:\n%+v", body)
+					nodeOffer, err := toSyncOffer(body.Head, body.Ancestors)
+					if err != nil {
+						t.Fatal(err)
+					}
+					controlOffer, err := controlAuthority.SyncOffer(controlStorage)
+					if err != nil {
+						t.Fatal(err)
+					}
+					sendAUMs, err := controlAuthority.MissingAUMs(controlStorage, nodeOffer)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					head, ancestors, err := fromSyncOffer(controlOffer)
+					if err != nil {
+						t.Fatal(err)
+					}
+					resp := tailcfg.TKASyncOfferResponse{
+						Head:        head,
+						Ancestors:   ancestors,
+						MissingAUMs: make([]tkatype.MarshaledAUM, len(sendAUMs)),
+					}
+					for i, a := range sendAUMs {
+						resp.MissingAUMs[i] = a.Serialize()
+					}
+
+					t.Logf("responding to sync offer with:\n%+v", resp)
+					w.WriteHeader(200)
+					if err := json.NewEncoder(w).Encode(resp); err != nil {
+						t.Fatal(err)
+					}
+
+				case "/machine/tka/sync/send":
+					body := new(tailcfg.TKASyncSendRequest)
+					if err := json.NewDecoder(r.Body).Decode(body); err != nil {
+						t.Fatal(err)
+					}
+					t.Logf("got sync send:\n%+v", body)
+					toApply := make([]tka.AUM, len(body.MissingAUMs))
+					for i, a := range body.MissingAUMs {
+						if err := toApply[i].Unserialize(a); err != nil {
+							t.Fatalf("decoding missingAUM[%d]: %v", i, err)
+						}
+					}
+
+					if len(toApply) > 0 {
+						if err := controlAuthority.Inform(controlStorage, toApply); err != nil {
+							t.Fatalf("control.Inform(%+v) failed: %v", toApply, err)
+						}
+					}
+					head, err := controlAuthority.Head().MarshalText()
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					w.WriteHeader(200)
+					if err := json.NewEncoder(w).Encode(tailcfg.TKASyncSendResponse{Head: string(head)}); err != nil {
+						t.Fatal(err)
+					}
+
+				default:
+					t.Errorf("unhandled endpoint path: %v", r.URL.Path)
+					w.WriteHeader(404)
+				}
+			}))
+			defer ts.Close()
+
+			// Setup the client.
+			cc := fakeControlClient(t, client)
+			b := LocalBackend{
+				varRoot: temp,
+				cc:      cc,
+				ccAuto:  cc,
+				logf:    t.Logf,
+				tka: &tkaState{
+					authority: nodeAuthority,
+					storage:   nodeStorage,
+				},
+				prefs: &ipn.Prefs{
+					Persist: &persist.Persist{PrivateNodeKey: nodePriv},
+				},
+			}
+
+			// Finally, lets trigger a sync.
+			b.mu.Lock()
+			err = b.tkaSyncIfNeededLocked(&netmap.NetworkMap{
+				TKAEnabled: true,
+				TKAHead:    controlAuthority.Head(),
+			})
+			b.mu.Unlock()
+			if err != nil {
+				t.Errorf("tkaSyncIfNeededLocked() failed: %v", err)
+			}
+
+			// Check that at the end of this ordeal, the node and the control
+			// plane are in sync.
+			if nodeHead, controlHead := b.tka.authority.Head(), controlAuthority.Head(); nodeHead != controlHead {
+				t.Errorf("node head = %v, want %v", nodeHead, controlHead)
+			}
+		})
 	}
 }

--- a/tka/tailchonk.go
+++ b/tka/tailchonk.go
@@ -214,6 +214,9 @@ func (c *FS) AUM(hash AUMHash) (AUM, error) {
 
 	info, err := c.get(hash)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return AUM{}, os.ErrNotExist
+		}
 		return AUM{}, err
 	}
 	if info.AUM == nil {

--- a/tka/tailchonk_test.go
+++ b/tka/tailchonk_test.go
@@ -58,6 +58,18 @@ func TestTailchonk_ChildAUMs(t *testing.T) {
 	}
 }
 
+func TestTailchonk_AUMMissing(t *testing.T) {
+	for _, chonk := range []Chonk{&Mem{}, &FS{base: t.TempDir()}} {
+		t.Run(fmt.Sprintf("%T", chonk), func(t *testing.T) {
+			var notExists AUMHash
+			notExists[:][0] = 42
+			if _, err := chonk.AUM(notExists); err != os.ErrNotExist {
+				t.Errorf("chonk.AUM(notExists).err = %v, want %v", err, os.ErrNotExist)
+			}
+		})
+	}
+}
+
 func TestTailchonkMem_Orphans(t *testing.T) {
 	chonk := Mem{}
 


### PR DESCRIPTION
This implement the client-side of TKA sync. I've opted to implement mocks for testing on this end, I'll do the usual controlclient tests on the PR for control.