### PR TITLE
net/dns: format OSConfig correctly with no pointers

### DIFF
--- a/net/dns/osconfig.go
+++ b/net/dns/osconfig.go
@@ -5,9 +5,12 @@
 package dns
 
 import (
+	"bufio"
 	"errors"
+	"fmt"
 	"net/netip"
 
+	"tailscale.com/types/logger"
 	"tailscale.com/util/dnsname"
 )
 
@@ -95,6 +98,44 @@ func (a OSConfig) Equal(b OSConfig) bool {
 	}
 
 	return true
+}
+
+// Format implements the fmt.Formatter interface to ensure that Hosts is
+// printed correctly (i.e. not as a bunch of pointers).
+//
+// Fixes https://github.com/tailscale/tailscale/issues/5669
+func (a OSConfig) Format(f fmt.State, verb rune) {
+	logger.ArgWriter(func(w *bufio.Writer) {
+		w.WriteString(`{Nameservers:[`)
+		for i, ns := range a.Nameservers {
+			if i != 0 {
+				w.WriteString(" ")
+			}
+			fmt.Fprintf(w, "%+v", ns)
+		}
+		w.WriteString(`] SearchDomains:[`)
+		for i, domain := range a.SearchDomains {
+			if i != 0 {
+				w.WriteString(" ")
+			}
+			fmt.Fprintf(w, "%+v", domain)
+		}
+		w.WriteString(`] MatchDomains:[`)
+		for i, domain := range a.MatchDomains {
+			if i != 0 {
+				w.WriteString(" ")
+			}
+			fmt.Fprintf(w, "%+v", domain)
+		}
+		w.WriteString(`] Hosts:[`)
+		for i, host := range a.Hosts {
+			if i != 0 {
+				w.WriteString(" ")
+			}
+			fmt.Fprintf(w, "%+v", host)
+		}
+		w.WriteString(`]}`)
+	}).Format(f, verb)
 }
 
 // ErrGetBaseConfigNotSupported is the error

--- a/net/dns/osconfig_test.go
+++ b/net/dns/osconfig_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package dns
+
+import (
+	"fmt"
+	"net/netip"
+	"testing"
+
+	"tailscale.com/util/dnsname"
+)
+
+func TestOSConfigPrintable(t *testing.T) {
+	ocfg := OSConfig{
+		Hosts: []*HostEntry{
+			{
+				Addr:  netip.AddrFrom4([4]byte{100, 1, 2, 3}),
+				Hosts: []string{"server", "client"},
+			},
+			{
+				Addr:  netip.AddrFrom4([4]byte{100, 1, 2, 4}),
+				Hosts: []string{"otherhost"},
+			},
+		},
+		Nameservers: []netip.Addr{
+			netip.AddrFrom4([4]byte{8, 8, 8, 8}),
+		},
+		SearchDomains: []dnsname.FQDN{
+			dnsname.FQDN("foo.beta.tailscale.net."),
+			dnsname.FQDN("bar.beta.tailscale.net."),
+		},
+		MatchDomains: []dnsname.FQDN{
+			dnsname.FQDN("ts.com."),
+		},
+	}
+	s := fmt.Sprintf("%+v", ocfg)
+
+	const expected = `{Nameservers:[8.8.8.8] SearchDomains:[foo.beta.tailscale.net. bar.beta.tailscale.net.] MatchDomains:[ts.com.] Hosts:[&{Addr:100.1.2.3 Hosts:[server client]} &{Addr:100.1.2.4 Hosts:[otherhost]}]}`
+	if s != expected {
+		t.Errorf("format mismatch:\n   got: %s\n  want: %s", s, expected)
+	}
+}


### PR DESCRIPTION
Fixes tailscale/tailscale#5669

Signed-off-by: Andrew Dunham <andrew@du.nham.ca>