### PR TITLE
wgengine/router: Increase range of rule priorities when detecting mwan3

### DIFF
--- a/wgengine/router/router_linux.go
+++ b/wgengine/router/router_linux.go
@@ -1713,7 +1713,7 @@ func checkOpenWRTUsingMWAN3() (bool, error) {
 		//
 		// We dont match on the mask because it can vary, or the
 		// table because I'm not sure if it can vary.
-		if r.Priority == 2001 && r.Mark != 0 {
+		if r.Priority >= 2001 && r.Priority <= 2004 && r.Mark != 0 {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
Updates: #5588

Context: https://github.com/tailscale/tailscale/pull/5588#issuecomment-1260655929

It seems that if the interface at index 1 is down, the rule is not installed and hence the platform will not be detected as an mwan3 installation even though we need to.

The rule priorities correspond to interface index minus 2000, so we increase the range we detect up to 2004 in the hope that at least one of the interfaces 1-4 will be up.
