### PR TITLE
wgengine: log subnet router decision at v1 if we have a BIRD client

### DIFF
--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -853,6 +853,9 @@ func (e *userspaceEngine) Reconfig(cfg *wgcfg.Config, routerCfg *router.Config, 
 	isSubnetRouter := false
 	if e.birdClient != nil && nm != nil && nm.SelfNode != nil {
 		isSubnetRouter = hasOverlap(nm.SelfNode.PrimaryRoutes, nm.Hostinfo.RoutableIPs)
+		e.logf("[v1] Reconfig: hasOverlap(%v, %v) = %v; isSubnetRouter=%v lastIsSubnetRouter=%v",
+			nm.SelfNode.PrimaryRoutes, nm.Hostinfo.RoutableIPs,
+			isSubnetRouter, isSubnetRouter, e.lastIsSubnetRouter)
 	}
 	isSubnetRouterChanged := isSubnetRouter != e.lastIsSubnetRouter
 


### PR DESCRIPTION
Updates tailscale/coral#82

Change-Id: I398d75f7e178ff7c531ca09899c82cf974fc30c9