### PR TITLE
docker: add ability to invoke web option via env var #5799

### DIFF
--- a/docs/k8s/run.sh
+++ b/docs/k8s/run.sh
@@ -18,6 +18,7 @@ TS_SOCKS5_SERVER="${TS_SOCKS5_SERVER:-}"
 TS_OUTBOUND_HTTP_PROXY_LISTEN="${TS_OUTBOUND_HTTP_PROXY_LISTEN:-}"
 TS_TAILSCALED_EXTRA_ARGS="${TS_TAILSCALED_EXTRA_ARGS:-}"
 TS_SOCKET="${TS_SOCKET:-/tmp/tailscaled.sock}"
+TS_WEBUI="${TS_WEBUI:-}"
 
 set -e
 
@@ -81,8 +82,13 @@ if [[ ! -z "${TS_EXTRA_ARGS}" ]]; then
   UP_ARGS="${UP_ARGS} ${TS_EXTRA_ARGS:-}"
 fi
 
-echo "Running tailscale up"
-tailscale --socket="${TS_SOCKET}" up ${UP_ARGS}
+if [[ ! -z "${TS_WEBUI}" ]]; then
+  echo "Running tailscale web"
+  tailscale --socket="${TS_SOCKET}" web --listen ${HOSTNAME}:8088
+else
+  echo "Running tailscale up"
+  tailscale --socket="${TS_SOCKET}" up ${UP_ARGS}
+fi
 
 if [[ ! -z "${TS_DEST_IP}" ]]; then
   echo "Adding iptables rule for DNAT"


### PR DESCRIPTION
Adds a docker environmental variable flag to invoke 'tailscale web' instead of 'tailscale up'
to ease docker based app initialisation/integration.

Fixes #5799

Signed-off-by: Philip Guyton <philip@yewtreeapps.com>