### PR TITLE
all: consistently initialize Logf when creating tsdial.Dialers

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -375,8 +375,7 @@ func run() error {
 
 	socksListener, httpProxyListener := mustStartProxyListeners(args.socksAddr, args.httpProxyAddr)
 
-	dialer := new(tsdial.Dialer) // mutated below (before used)
-	dialer.Logf = logf
+	dialer := &tsdial.Dialer{Logf: logf} // mutated below (before used)
 	e, useNetstack, err := createEngine(logf, linkMon, dialer)
 	if err != nil {
 		return fmt.Errorf("createEngine: %w", err)

--- a/cmd/tailscaled/tailscaled_windows.go
+++ b/cmd/tailscaled/tailscaled_windows.go
@@ -266,7 +266,7 @@ func startIPNServer(ctx context.Context, logid string) error {
 	if err != nil {
 		return fmt.Errorf("monitor: %w", err)
 	}
-	dialer := new(tsdial.Dialer)
+	dialer := &tsdial.Dialer{Logf: logf}
 
 	getEngineRaw := func() (wgengine.Engine, *netstack.Impl, error) {
 		dev, devName, err := tstun.New(logf, "Tailscale")

--- a/cmd/tsconnect/wasm/wasm_js.go
+++ b/cmd/tsconnect/wasm/wasm_js.go
@@ -96,7 +96,7 @@ func newIPN(jsConfig js.Value) map[string]any {
 	logtail := logtail.NewLogger(c, log.Printf)
 	logf := logtail.Logf
 
-	dialer := new(tsdial.Dialer)
+	dialer := &tsdial.Dialer{Logf: logf}
 	eng, err := wgengine.NewUserspaceEngine(logf, wgengine.Config{
 		Dialer: dialer,
 	})

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -214,7 +214,7 @@ func NewLocalBackend(logf logger.Logf, logid string, store ipn.StateStore, diale
 	logf.JSON(1, "Hostinfo", hi)
 	envknob.LogCurrent(logf)
 	if dialer == nil {
-		dialer = new(tsdial.Dialer)
+		dialer = &tsdial.Dialer{Logf: logf}
 	}
 
 	osshare.SetFileSharingEnabled(false, logf)

--- a/net/dns/manager.go
+++ b/net/dns/manager.go
@@ -540,7 +540,7 @@ func Cleanup(logf logger.Logf, interfaceName string) {
 		logf("creating dns cleanup: %v", err)
 		return
 	}
-	dns := NewManager(logf, oscfg, nil, new(tsdial.Dialer), nil)
+	dns := NewManager(logf, oscfg, nil, &tsdial.Dialer{Logf: logf}, nil)
 	if err := dns.Down(); err != nil {
 		logf("dns down: %v", err)
 	}

--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -271,7 +271,7 @@ func (s *Server) start() (reterr error) {
 	}
 	closePool.add(s.linkMon)
 
-	s.dialer = new(tsdial.Dialer) // mutated below (before used)
+	s.dialer = &tsdial.Dialer{Logf: logf} // mutated below (before used)
 	eng, err := wgengine.NewUserspaceEngine(logf, wgengine.Config{
 		ListenPort:  0,
 		LinkMonitor: s.linkMon,

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -282,7 +282,7 @@ func NewUserspaceEngine(logf logger.Logf, conf Config) (_ Engine, reterr error) 
 		conf.DNS = d
 	}
 	if conf.Dialer == nil {
-		conf.Dialer = new(tsdial.Dialer)
+		conf.Dialer = &tsdial.Dialer{Logf: logf}
 	}
 
 	var tsTUNDev *tstun.Wrapper


### PR DESCRIPTION
Most visible when using tsnet.Server, but could have resulted in dropped messages in a few other places too.

Fixes #5743