### PR TITLE
ipn/ipnlocal,tka: Fix bugs found by integration testing

### DIFF
--- a/ipn/ipnlocal/network-lock_test.go
+++ b/ipn/ipnlocal/network-lock_test.go
@@ -64,7 +64,7 @@ func fakeNoiseServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, 
 }
 
 func TestTKAEnablementFlow(t *testing.T) {
-	networkLockAvailable = func() bool { return true } // Enable the feature flag
+	envknob.Setenv("TAILSCALE_USE_WIP_CODE", "1")
 	nodePriv := key.NewNode()
 
 	// Make a fake TKA authority, getting a usable genesis AUM which
@@ -145,7 +145,7 @@ func TestTKAEnablementFlow(t *testing.T) {
 }
 
 func TestTKADisablementFlow(t *testing.T) {
-	networkLockAvailable = func() bool { return true } // Enable the feature flag
+	envknob.Setenv("TAILSCALE_USE_WIP_CODE", "1")
 	temp := t.TempDir()
 	os.Mkdir(filepath.Join(temp, "tka"), 0755)
 	nodePriv := key.NewNode()
@@ -262,7 +262,7 @@ func TestTKADisablementFlow(t *testing.T) {
 }
 
 func TestTKASync(t *testing.T) {
-	networkLockAvailable = func() bool { return true } // Enable the feature flag
+	envknob.Setenv("TAILSCALE_USE_WIP_CODE", "1")
 
 	someKeyPriv := key.NewNLPrivate()
 	someKey := tka.Key{Kind: tka.Key25519, Public: someKeyPriv.Public().Verifier(), Votes: 1}

--- a/tka/state.go
+++ b/tka/state.go
@@ -249,6 +249,10 @@ func (s *State) staticValidateCheckpoint() error {
 		if err := k.StaticValidate(); err != nil {
 			return fmt.Errorf("key[%d]: %v", i, err)
 		}
+	}
+	// NOTE: The max number of keys is constrained (512), so
+	// O(n^2) is fine.
+	for i, k := range s.Keys {
 		for j, k2 := range s.Keys {
 			if i == j {
 				continue


### PR DESCRIPTION
 * `tka.State.staticValidateCheckpoint` could call methods on a contained key prior to calling StaticValidate on that key
 * Remove broken backoff / RPC retry logic from tka methods in ipn/ipnlocal, to be fixed at a later time
 * Deduplicate `LocalBackend.sendAUMsLocked` as it does the same thing as `tkaDoSyncSend`
 * Fix `ipn.LocalBackend.NetworkLockModify()` which would attempt to take `b.mu` twice and deadlock
 * Add methods on ipnlocal.LocalBackend to be used in integration tests