### PR TITLE
wgengine/magicsock: make debug-level stuff not logged by default

### DIFF
--- a/client/tailscale/localclient.go
+++ b/client/tailscale/localclient.go
@@ -318,6 +318,28 @@ func (lc *LocalClient) DebugAction(ctx context.Context, action string) error {
 	return nil
 }
 
+// SetComponentDebugLogging sets component's debug logging enabled for
+// the provided duration. If the duration is in the past, the debug logging
+// is disabled.
+func (lc *LocalClient) SetComponentDebugLogging(ctx context.Context, component string, d time.Duration) error {
+	body, err := lc.send(ctx, "POST",
+		fmt.Sprintf("/localapi/v0/component-debug-logging?component=%s&secs=%d",
+			url.QueryEscape(component), int64(d.Seconds())), 200, nil)
+	if err != nil {
+		return fmt.Errorf("error %w: %s", err, body)
+	}
+	var res struct {
+		Error string
+	}
+	if err := json.Unmarshal(body, &res); err != nil {
+		return err
+	}
+	if res.Error != "" {
+		return errors.New(res.Error)
+	}
+	return nil
+}
+
 // Status returns the Tailscale daemon's status.
 func Status(ctx context.Context) (*ipnstate.Status, error) {
 	return defaultLocalClient.Status(ctx)

--- a/ipn/backend.go
+++ b/ipn/backend.go
@@ -168,6 +168,11 @@ type PartialFile struct {
 //     LocalBackend.userID, a string like "user-$USER_ID" (used in
 //     server mode).
 //   - on Linux/etc, it's always "_daemon" (ipn.GlobalDaemonStateKey)
+//
+// Additionally, the StateKey can be debug setting name:
+//
+//   - "_debug_magicsock_until" with value being a unix timestamp stringified
+//   - "_debug_<component>_until" with value being a unix timestamp stringified
 type StateKey string
 
 type Options struct {

--- a/ipn/store.go
+++ b/ipn/store.go
@@ -6,6 +6,8 @@ package ipn
 
 import (
 	"errors"
+	"fmt"
+	"strconv"
 )
 
 // ErrStateNotExist is returned by StateStore.ReadState when the
@@ -35,7 +37,7 @@ const (
 	// StateKey "user-1234".
 	ServerModeStartKey = StateKey("server-mode-start-key")
 
-	// NLKeyStateKey is the key under which we store the nodes'
+	// NLKeyStateKey is the key under which we store the node's
 	// network-lock node key, in its key.NLPrivate.MarshalText representation.
 	NLKeyStateKey = StateKey("_nl-node-key")
 )
@@ -47,4 +49,18 @@ type StateStore interface {
 	ReadState(id StateKey) ([]byte, error)
 	// WriteState saves bs as the state associated with ID.
 	WriteState(id StateKey, bs []byte) error
+}
+
+// ReadStoreInt reads an integer from a StateStore.
+func ReadStoreInt(store StateStore, id StateKey) (int64, error) {
+	v, err := store.ReadState(id)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(string(v), 10, 64)
+}
+
+// PutStoreInt puts an integer into a StateStore.
+func PutStoreInt(store StateStore, id StateKey, val int64) error {
+	return store.WriteState(id, fmt.Appendf(nil, "%d", val))
 }

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -82,7 +82,8 @@ type CapabilityVersion int
 //   - 43: 2022-09-21: clients can return usernames for SSH
 //   - 44: 2022-09-22: MapResponse.ControlDialPlan
 //   - 45: 2022-09-26: c2n /debug/{goroutines,prefs,metrics}
-const CurrentCapabilityVersion CapabilityVersion = 45
+//   - 46: 2022-10-04: c2n /debug/component-logging
+const CurrentCapabilityVersion CapabilityVersion = 46
 
 type StableID string
 

--- a/wgengine/magicsock/magicsock_linux.go
+++ b/wgengine/magicsock/magicsock_linux.go
@@ -234,12 +234,12 @@ func (c *Conn) receiveDisco(pc net.PacketConn, isIPV6 bool) {
 		if acceptPort == 0 {
 			// This should only typically happen if the receiving address family
 			// was recently disabled.
-			c.logf("[v1] disco raw: dropping packet for port %d as acceptPort=0", dstPort)
+			c.dlogf("[v1] disco raw: dropping packet for port %d as acceptPort=0", dstPort)
 			continue
 		}
 
 		if dstPort != acceptPort {
-			c.logf("[v1] disco raw: dropping packet for port %d", dstPort)
+			c.dlogf("[v1] disco raw: dropping packet for port %d", dstPort)
 			continue
 		}
 


### PR DESCRIPTION
And start of mechanism for CLI or support to enable debug logging of a component for a fixed amount of time.

Updates #1548

