### PR TITLE
tsweb: allow HTTPError to unwrap errors

### DIFF
--- a/tsweb/tsweb.go
+++ b/tsweb/tsweb.go
@@ -421,6 +421,8 @@ type HTTPError struct {
 // Error implements the error interface.
 func (e HTTPError) Error() string { return fmt.Sprintf("httperror{%d, %q, %v}", e.Code, e.Msg, e.Err) }
 
+func (e HTTPError) Unwrap() error { return e.Err }
+
 // Error returns an HTTPError containing the given information.
 func Error(code int, msg string, err error) HTTPError {
 	return HTTPError{Code: code, Msg: msg, Err: err}

--- a/tsweb/tsweb_test.go
+++ b/tsweb/tsweb_test.go
@@ -327,6 +327,14 @@ func BenchmarkLog(b *testing.B) {
 	}
 }
 
+func TestHTTPError_Unwrap(t *testing.T) {
+	wrappedErr := fmt.Errorf("wrapped")
+	err := Error(404, "not found", wrappedErr)
+	if got := errors.Unwrap(err); got != wrappedErr {
+		t.Errorf("HTTPError.Unwrap() = %v, want %v", got, wrappedErr)
+	}
+}
+
 func TestVarzHandler(t *testing.T) {
 	t.Run("globals_log", func(t *testing.T) {
 		rec := httptest.NewRecorder()


### PR DESCRIPTION
This is needed for the changes in tailscale/corp#7296