### PR TITLE
net/flowtrack: add json tags to Tuple

### DIFF
--- a/net/flowtrack/flowtrack.go
+++ b/net/flowtrack/flowtrack.go
@@ -20,9 +20,9 @@ import (
 
 // Tuple is a 5-tuple of proto, source and destination IP and port.
 type Tuple struct {
-	Proto ipproto.Proto
-	Src   netip.AddrPort
-	Dst   netip.AddrPort
+	Proto ipproto.Proto  `json:"proto"`
+	Src   netip.AddrPort `json:"src"`
+	Dst   netip.AddrPort `json:"dst"`
 }
 
 func (t Tuple) String() string {


### PR DESCRIPTION
By convention, JSON serialization uses camelCase.
Specify such names on the Tuple type.

Signed-off-by: Joe Tsai <joetsai@digital-static.net>