### PR TITLE
ipn/ipnlocal: fix data race from missed locking in NetworkLockStatus

### DIFF
--- a/ipn/ipnlocal/network-lock.go
+++ b/ipn/ipnlocal/network-lock.go
@@ -294,6 +294,9 @@ func (b *LocalBackend) CanSupportNetworkLock() error {
 // NetworkLockStatus returns a structure describing the state of the
 // tailnet key authority, if any.
 func (b *LocalBackend) NetworkLockStatus() *ipnstate.NetworkLockStatus {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
 	if b.tka == nil {
 		return &ipnstate.NetworkLockStatus{
 			Enabled:   false,


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Write at 0x00c000abf358 by goroutine 742:
  tailscale.com/ipn/ipnlocal.(*LocalBackend).tkaBootstrapFromGenesisLocked()
      /home/ubuntu/go/pkg/mod/tailscale.com@v1.1.1-0.20221005181234-8602061f32de/ipn/ipnlocal/network-lock.go:265 +0x480
  tailscale.com/ipn/ipnlocal.(*LocalBackend).tkaSyncIfNeededLocked()
      /home/ubuntu/go/pkg/mod/tailscale.com@v1.1.1-0.20221005181234-8602061f32de/ipn/ipnlocal/network-lock.go:115 +0x358
  tailscale.com/ipn/ipnlocal.(*LocalBackend).setClientStatus()
      /home/ubuntu/go/pkg/mod/tailscale.com@v1.1.1-0.20221005181234-8602061f32de/ipn/ipnlocal/local.go:778 +0x864
  tailscale.com/ipn/ipnlocal.(*LocalBackend).setClientStatus-fm()
      <autogenerated>:1 +0xa4
  tailscale.com/control/controlclient.(*Auto).sendStatus()
      /home/ubuntu/go/pkg/mod/tailscale.com@v1.1.1-0.20221005181234-8602061f32de/control/controlclient/auto.go:597 +0x380
  tailscale.com/control/controlclient.(*Auto).mapRoutine.func2()
      /home/ubuntu/go/pkg/mod/tailscale.com@v1.1.1-0.20221005181234-8602061f32de/control/controlclient/auto.go:494 +0x288
  tailscale.com/control/controlclient.(*Direct).sendMapRequest()
      /home/ubuntu/go/pkg/mod/tailscale.com@v1.1.1-0.20221005181234-8602061f32de/control/controlclient/direct.go:1034 +0x3254
  tailscale.com/control/controlclient.(*Direct).PollNetMap()
      /home/ubuntu/go/pkg/mod/tailscale.com@v1.1.1-0.20221005181234-8602061f32de/control/controlclient/direct.go:682 +0x490
  tailscale.com/control/controlclient.(*Auto).mapRoutine()
      /home/ubuntu/go/pkg/mod/tailscale.com@v1.1.1-0.20221005181234-8602061f32de/control/controlclient/auto.go:464 +0x458
  tailscale.com/control/controlclient.(*Auto).Start.func2()
      /home/ubuntu/go/pkg/mod/tailscale.com@v1.1.1-0.20221005181234-8602061f32de/control/controlclient/auto.go:150 +0x34

Previous read at 0x00c000abf[358](https://github.com/tailscale/corp/actions/runs/3191780433/jobs/5208499526#step:4:359) by goroutine 568:
  tailscale.com/ipn/ipnlocal.(*LocalBackend).NetworkLockStatus()
      /home/ubuntu/go/pkg/mod/tailscale.com@v1.1.1-0.20221005181234-8602061f32de/ipn/ipnlocal/network-lock.go:297 +0x3c
  tailscale.io/ipn.TestNetworkLockE2E()
      /home/ubuntu/actions-runner/_work/corp/corp/ipn/network-lock_test.go:205 +0x1a2c
  testing.tRunner()
      /home/ubuntu/.cache/tailscale-go/src/testing/testing.go:1446 +0x188
  testing.(*T).Run.func1()
      /home/ubuntu/.cache/tailscale-go/src/testing/testing.go:1493 +0x40
```

Verified with `go test --count=100 --race ./ipn/ -v` on the corp repo.