### PR TITLE
net/tstun: rename statististics method

### DIFF
--- a/net/tstun/wrap.go
+++ b/net/tstun/wrap.go
@@ -843,15 +843,15 @@ func (t *Wrapper) Unwrap() tun.Device {
 	return t.tdev
 }
 
-// StatisticsEnable enables per-connections packet counters.
-// StatisticsExtract must be called periodically to avoid unbounded memory use.
-func (t *Wrapper) StatisticsEnable(enable bool) {
+// SetStatisticsEnabled enables per-connections packet counters.
+// ExtractStatistics must be called periodically to avoid unbounded memory use.
+func (t *Wrapper) SetStatisticsEnabled(enable bool) {
 	t.stats.enabled.Store(enable)
 }
 
-// StatisticsExtract extracts and resets the counters for all active connections.
+// ExtractStatistics extracts and resets the counters for all active connections.
 // It must be called periodically otherwise the memory used is unbounded.
-func (t *Wrapper) StatisticsExtract() map[flowtrack.Tuple]tunstats.Counts {
+func (t *Wrapper) ExtractStatistics() map[flowtrack.Tuple]tunstats.Counts {
 	return t.stats.Extract()
 }
 

--- a/net/tstun/wrap_test.go
+++ b/net/tstun/wrap_test.go
@@ -286,8 +286,8 @@ func TestWriteAndInject(t *testing.T) {
 	}
 
 	// Statistics gathering is disabled by default.
-	if stats := tun.StatisticsExtract(); len(stats) > 0 {
-		t.Errorf("tun.StatisticsExtract = %v, want {}", stats)
+	if stats := tun.ExtractStatistics(); len(stats) > 0 {
+		t.Errorf("tun.ExtractStatistics = %v, want {}", stats)
 	}
 }
 
@@ -337,15 +337,15 @@ func TestFilter(t *testing.T) {
 	}()
 
 	var buf [MaxPacketSize]byte
-	tun.StatisticsEnable(true)
+	tun.SetStatisticsEnabled(true)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var n int
 			var err error
 			var filtered bool
 
-			if stats := tun.StatisticsExtract(); len(stats) > 0 {
-				t.Errorf("tun.StatisticsExtract = %v, want {}", stats)
+			if stats := tun.ExtractStatistics(); len(stats) > 0 {
+				t.Errorf("tun.ExtractStatistics = %v, want {}", stats)
 			}
 
 			if tt.dir == in {
@@ -378,7 +378,7 @@ func TestFilter(t *testing.T) {
 				}
 			}
 
-			got := tun.StatisticsExtract()
+			got := tun.ExtractStatistics()
 			want := map[flowtrack.Tuple]tunstats.Counts{}
 			if !tt.drop {
 				var p packet.Parsed
@@ -393,7 +393,7 @@ func TestFilter(t *testing.T) {
 				}
 			}
 			if !reflect.DeepEqual(got, want) {
-				t.Errorf("tun.StatisticsExtract = %v, want %v", got, want)
+				t.Errorf("tun.ExtractStatistics = %v, want %v", got, want)
 			}
 		})
 	}


### PR DESCRIPTION
Rename StatisticsEnable as SetStatisticsEnabled to be consistent with other similarly named methods.

Rename StatisticsExtract as ExtractStatistics to follow the convention where methods start with a verb.
It was originally named with Statistics as a prefix so that statistics related methods would sort well in godoc, but that property no longer holds.

Signed-off-by: Joe Tsai <joetsai@digital-static.net>