### PR TITLE
wgengine/wgcfg: plumb down audit log IDs

### DIFF
--- a/control/controlclient/map.go
+++ b/control/controlclient/map.go
@@ -45,6 +45,7 @@ type mapSession struct {
 	collectServices        bool
 	previousPeers          []*tailcfg.Node // for delta-purposes
 	lastDomain             string
+	lastDomainAuditLogID   string
 	lastHealth             []string
 	lastPopBrowserURL      string
 	stickyDebug            tailcfg.Debug // accumulated opt.Bool values
@@ -113,6 +114,9 @@ func (ms *mapSession) netmapForResponse(resp *tailcfg.MapResponse) *netmap.Netwo
 	if resp.Domain != "" {
 		ms.lastDomain = resp.Domain
 	}
+	if resp.DomainDataPlaneAuditLogID != "" {
+		ms.lastDomainAuditLogID = resp.DomainDataPlaneAuditLogID
+	}
 	if resp.Health != nil {
 		ms.lastHealth = resp.Health
 	}
@@ -143,20 +147,21 @@ func (ms *mapSession) netmapForResponse(resp *tailcfg.MapResponse) *netmap.Netwo
 	}
 
 	nm := &netmap.NetworkMap{
-		NodeKey:         ms.privateNodeKey.Public(),
-		PrivateKey:      ms.privateNodeKey,
-		MachineKey:      ms.machinePubKey,
-		Peers:           resp.Peers,
-		UserProfiles:    make(map[tailcfg.UserID]tailcfg.UserProfile),
-		Domain:          ms.lastDomain,
-		DNS:             *ms.lastDNSConfig,
-		PacketFilter:    ms.lastParsedPacketFilter,
-		SSHPolicy:       ms.lastSSHPolicy,
-		CollectServices: ms.collectServices,
-		DERPMap:         ms.lastDERPMap,
-		Debug:           debug,
-		ControlHealth:   ms.lastHealth,
-		TKAEnabled:      ms.lastTKAInfo != nil && !ms.lastTKAInfo.Disabled,
+		NodeKey:          ms.privateNodeKey.Public(),
+		PrivateKey:       ms.privateNodeKey,
+		MachineKey:       ms.machinePubKey,
+		Peers:            resp.Peers,
+		UserProfiles:     make(map[tailcfg.UserID]tailcfg.UserProfile),
+		Domain:           ms.lastDomain,
+		DomainAuditLogID: ms.lastDomainAuditLogID,
+		DNS:              *ms.lastDNSConfig,
+		PacketFilter:     ms.lastParsedPacketFilter,
+		SSHPolicy:        ms.lastSSHPolicy,
+		CollectServices:  ms.collectServices,
+		DERPMap:          ms.lastDERPMap,
+		Debug:            debug,
+		ControlHealth:    ms.lastHealth,
+		TKAEnabled:       ms.lastTKAInfo != nil && !ms.lastTKAInfo.Disabled,
 	}
 	ms.netMapBuilding = nm
 

--- a/types/netmap/netmap.go
+++ b/types/netmap/netmap.go
@@ -76,6 +76,11 @@ type NetworkMap struct {
 	// Domain is the current Tailnet name.
 	Domain string
 
+	// DomainAuditLogID is an audit log ID provided by control and
+	// only populated if the domain opts into data-plane audit logging.
+	// If this is empty, then data-plane audit logging is disabled.
+	DomainAuditLogID string
+
 	UserProfiles map[tailcfg.UserID]tailcfg.UserProfile
 }
 

--- a/wgengine/wgcfg/config.go
+++ b/wgengine/wgcfg/config.go
@@ -8,6 +8,7 @@ package wgcfg
 import (
 	"net/netip"
 
+	"tailscale.com/logtail"
 	"tailscale.com/types/key"
 )
 
@@ -22,6 +23,13 @@ type Config struct {
 	MTU        uint16
 	DNS        []netip.Addr
 	Peers      []Peer
+
+	// NetworkLogging enables network logging.
+	// It is disabled if either ID is the zero value.
+	NetworkLogging struct {
+		NodeID   logtail.PrivateID
+		DomainID logtail.PrivateID
+	}
 }
 
 type Peer struct {

--- a/wgengine/wgcfg/wgcfg_clone.go
+++ b/wgengine/wgcfg/wgcfg_clone.go
@@ -9,6 +9,7 @@ package wgcfg
 import (
 	"net/netip"
 
+	"tailscale.com/logtail"
 	"tailscale.com/types/key"
 )
 
@@ -31,12 +32,16 @@ func (src *Config) Clone() *Config {
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _ConfigCloneNeedsRegeneration = Config(struct {
-	Name       string
-	PrivateKey key.NodePrivate
-	Addresses  []netip.Prefix
-	MTU        uint16
-	DNS        []netip.Addr
-	Peers      []Peer
+	Name           string
+	PrivateKey     key.NodePrivate
+	Addresses      []netip.Prefix
+	MTU            uint16
+	DNS            []netip.Addr
+	Peers          []Peer
+	NetworkLogging struct {
+		NodeID   logtail.PrivateID
+		DomainID logtail.PrivateID
+	}
 }{})
 
 // Clone makes a deep copy of Peer.


### PR DESCRIPTION
The node and domain audit log IDs are provided in the map response, but are ultimately going to be used in wgengine since that's the layer that manages the tstun.Wrapper.

Do the plumbing work to get this field passed down the stack.

Signed-off-by: Joe Tsai <joetsai@digital-static.net>