### PR TITLE
ipn/ipnlocal: make tkaSyncIfNeededLocked an exclusive section

### DIFF
--- a/ipn/ipnlocal/network-lock_test.go
+++ b/ipn/ipnlocal/network-lock_test.go
@@ -127,12 +127,10 @@ func TestTKAEnablementFlow(t *testing.T) {
 		},
 	}
 
-	b.mu.Lock()
-	err = b.tkaSyncIfNeededLocked(&netmap.NetworkMap{
+	err = b.tkaSyncIfNeeded(&netmap.NetworkMap{
 		TKAEnabled: true,
 		TKAHead:    a1.Head(),
 	})
-	b.mu.Unlock()
 	if err != nil {
 		t.Errorf("tkaSyncIfNeededLocked() failed: %v", err)
 	}
@@ -228,12 +226,10 @@ func TestTKADisablementFlow(t *testing.T) {
 
 	// Test that the wrong disablement secret does not shut down the authority.
 	returnWrongSecret = true
-	b.mu.Lock()
-	err = b.tkaSyncIfNeededLocked(&netmap.NetworkMap{
+	err = b.tkaSyncIfNeeded(&netmap.NetworkMap{
 		TKAEnabled: false,
 		TKAHead:    authority.Head(),
 	})
-	b.mu.Unlock()
 	if err != nil {
 		t.Errorf("tkaSyncIfNeededLocked() failed: %v", err)
 	}
@@ -243,12 +239,10 @@ func TestTKADisablementFlow(t *testing.T) {
 
 	// Test the correct disablement secret shuts down the authority.
 	returnWrongSecret = false
-	b.mu.Lock()
-	err = b.tkaSyncIfNeededLocked(&netmap.NetworkMap{
+	err = b.tkaSyncIfNeeded(&netmap.NetworkMap{
 		TKAEnabled: false,
 		TKAHead:    authority.Head(),
 	})
-	b.mu.Unlock()
 	if err != nil {
 		t.Errorf("tkaSyncIfNeededLocked() failed: %v", err)
 	}
@@ -468,12 +462,10 @@ func TestTKASync(t *testing.T) {
 			}
 
 			// Finally, lets trigger a sync.
-			b.mu.Lock()
-			err = b.tkaSyncIfNeededLocked(&netmap.NetworkMap{
+			err = b.tkaSyncIfNeeded(&netmap.NetworkMap{
 				TKAEnabled: true,
 				TKAHead:    controlAuthority.Head(),
 			})
-			b.mu.Unlock()
 			if err != nil {
 				t.Errorf("tkaSyncIfNeededLocked() failed: %v", err)
 			}


### PR DESCRIPTION
Running corp/ipn#TestNetworkLockE2E has a 1/300 chance of failing, and deskchecking suggests thats whats happening are two netmaps are racing each other to be processed through tkaSyncIfNeededLocked. This happens in the first place because we release b.mu during network RPCs.

To fix this, we make the tka sync logic an exclusive section, so two netmaps will need to wait for tka sync to complete serially (which is what we would want anyway, as the second run through probably wont need to sync).