### PR TITLE
cmd/tsconnect: close the SSH session an unload event instead of beforeunload

### DIFF
--- a/cmd/tsconnect/src/lib/ssh.ts
+++ b/cmd/tsconnect/src/lib/ssh.ts
@@ -42,7 +42,7 @@ export function runSSHSession(
   term.focus()
 
   let resizeObserver: ResizeObserver | undefined
-  let handleBeforeUnload: ((e: BeforeUnloadEvent) => void) | undefined
+  let handleUnload: ((e: Event) => void) | undefined
 
   const sshSession = ipn.ssh(def.hostname, def.username, {
     writeFn(input) {
@@ -60,8 +60,8 @@ export function runSSHSession(
     onDone() {
       resizeObserver?.disconnect()
       term.dispose()
-      if (handleBeforeUnload) {
-        parentWindow.removeEventListener("beforeunload", handleBeforeUnload)
+      if (handleUnload) {
+        parentWindow.removeEventListener("unload", handleUnload)
       }
       onDone()
     },
@@ -75,6 +75,6 @@ export function runSSHSession(
 
   // Close the session if the user closes the window without an explicit
   // exit.
-  handleBeforeUnload = () => sshSession.close()
-  parentWindow.addEventListener("beforeunload", handleBeforeUnload)
+  handleUnload = () => sshSession.close()
+  parentWindow.addEventListener("unload", handleUnload)
 }


### PR DESCRIPTION
The window may not end up getting unloaded (if other `beforeunload` handlers prevent the event), thus we should only close the SSH session if it's truly getting unloaded.

Updates tailscale/corp#7304