### PR TITLE
ssh/tailssh: do not send EOT on session disconnection

### DIFF
--- a/ssh/tailssh/tailssh.go
+++ b/ssh/tailssh/tailssh.go
@@ -1037,9 +1037,6 @@ func (ss *sshSession) run() {
 		if _, err := io.Copy(rec.writer("i", ss.stdin), ss); err != nil {
 			logf("stdin copy: %v", err)
 			ss.ctx.CloseWithError(err)
-		} else if ss.ptyReq != nil {
-			const EOT = 4 // https://en.wikipedia.org/wiki/End-of-Transmission_character
-			ss.stdin.Write([]byte{EOT})
 		}
 	}()
 	go func() {


### PR DESCRIPTION
This was assumed to be the fix for mosh not working, however turns out all we really needed was the duplicate fd also introduced in the same commit (af412e8874e94dc3ac57c37c3ec5e0606aa08fbb).

Fixes #5103

Signed-off-by: Maisem Ali <maisem@tailscale.com>