### PR TITLE
Add flag --exit-node-use-dns

### DIFF
--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -39,6 +39,7 @@ var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	ExitNodeID             tailcfg.StableNodeID
 	ExitNodeIP             netip.Addr
 	ExitNodeAllowLANAccess bool
+	ExitNodeUseDNS         bool
 	CorpDNS                bool
 	RunSSH                 bool
 	WantRunning            bool

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -104,6 +104,10 @@ type Prefs struct {
 	// routed directly or via the exit node.
 	ExitNodeAllowLANAccess bool
 
+	// ExitNodeUseDNS indicates whether DNS requests should be made directly or
+	// routed via the exit node.
+	ExitNodeUseDNS bool
+
 	// CorpDNS specifies whether to install the Tailscale network's
 	// DNS configuration, if it exists.
 	CorpDNS bool
@@ -210,6 +214,7 @@ type MaskedPrefs struct {
 	ExitNodeIDSet             bool `json:",omitempty"`
 	ExitNodeIPSet             bool `json:",omitempty"`
 	ExitNodeAllowLANAccessSet bool `json:",omitempty"`
+	ExitNodeUseDNSSet         bool `json:",omitempty"`
 	CorpDNSSet                bool `json:",omitempty"`
 	RunSSHSet                 bool `json:",omitempty"`
 	WantRunningSet            bool `json:",omitempty"`
@@ -313,9 +318,9 @@ func (p *Prefs) pretty(goos string) string {
 		sb.WriteString("shields=true ")
 	}
 	if p.ExitNodeIP.IsValid() {
-		fmt.Fprintf(&sb, "exit=%v lan=%t ", p.ExitNodeIP, p.ExitNodeAllowLANAccess)
+		fmt.Fprintf(&sb, "exit=%v lan=%t useDNS=%t ", p.ExitNodeIP, p.ExitNodeAllowLANAccess, p.ExitNodeUseDNS)
 	} else if !p.ExitNodeID.IsZero() {
-		fmt.Fprintf(&sb, "exit=%v lan=%t ", p.ExitNodeID, p.ExitNodeAllowLANAccess)
+		fmt.Fprintf(&sb, "exit=%v lan=%t useDNS=%t ", p.ExitNodeID, p.ExitNodeAllowLANAccess, p.ExitNodeUseDNS)
 	}
 	if len(p.AdvertiseRoutes) > 0 || goos == "linux" {
 		fmt.Fprintf(&sb, "routes=%v ", p.AdvertiseRoutes)
@@ -370,6 +375,7 @@ func (p *Prefs) Equals(p2 *Prefs) bool {
 		p.ExitNodeID == p2.ExitNodeID &&
 		p.ExitNodeIP == p2.ExitNodeIP &&
 		p.ExitNodeAllowLANAccess == p2.ExitNodeAllowLANAccess &&
+		p.ExitNodeUseDNS == p2.ExitNodeUseDNS &&
 		p.CorpDNS == p2.CorpDNS &&
 		p.RunSSH == p2.RunSSH &&
 		p.WantRunning == p2.WantRunning &&


### PR DESCRIPTION
It lets the user configure if DNS requests should be handled by the given exit node or should be handled as without an exit node (still routing the traffic through it, but not leveraging the tailscale daemon of the exit node itself; at least thats the plan).

This fixes #5875.

Known bugs:
- [ ] when upgrading from a running tailscale instance, the default seems to be false, not true, which would keep the same behavior on upgrading.

What is still to do:
- [ ] test without exit node (PR should change nothing)
- [x] test with exit node & with "Override local DNS" & with global nameserver set
- [ ] test with exit node & without "Override local DNS" & with global nameserver set
- [ ] test with exit node & without "Override local DNS" & without any global nameserver set
- [ ] test proper on other platforms than Linux (same tests than showed above)
  - [ ] Windows (do not have myself)
  - [ ] Mac OS X (do not have myself)
  - [ ] Android (UI missing; have myself)
  - [ ] iOS (UI missing; do not have myself)
- [ ] add automated tests for the new flag

This change only affects one device by itself, so only one needs to be updated (not the exit node). You should be able to revert to your old version after testing.

I test it the changes by building them, running the new tailscaled instead of the old one. I flip the new flag multiple times, verify that the log uses if enabled the DoH resolver of the exit node, or if disabled the configured global nameserver / the locally announced dns resolver. I verify that still tailscale is the main name resolver by checking for MagicDNS still working & verify that the correct DNS resolver is choosen by the same way as explained in #5875.

Signed-off-by: Felix Stupp <felix.stupp@banananet.work>