### PR TITLE
ssh/tailssh: close sshContext on context cancellation

### DIFF
--- a/ssh/tailssh/tailssh.go
+++ b/ssh/tailssh/tailssh.go
@@ -770,7 +770,7 @@ func (c *conn) newSSHSession(s ssh.Session) *sshSession {
 	return &sshSession{
 		Session:  s,
 		sharedID: sharedID,
-		ctx:      newSSHContext(),
+		ctx:      newSSHContext(s.Context()),
 		conn:     c,
 		logf:     logger.WithPrefix(c.srv.logf, "ssh-session("+sharedID+"): "),
 	}


### PR DESCRIPTION
This was preventing tailscaled from shutting down properly if there were active sessions in certain states (e.g. waiting in check mode).

Signed-off-by: Maisem Ali <maisem@tailscale.com>