### PR TITLE
tsweb: remove allocs introduced by earlier change

### DIFF
--- a/tsweb/tsweb_test.go
+++ b/tsweb/tsweb_test.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -724,5 +725,21 @@ func TestPort80Handler(t *testing.T) {
 				t.Errorf("Location = %q; want %q", got, want)
 			}
 		})
+	}
+}
+
+func TestSortedStructAllocs(t *testing.T) {
+	f := reflect.ValueOf(struct {
+		Foo int
+		Bar int
+		Baz int
+	}{})
+	n := testing.AllocsPerRun(1000, func() {
+		foreachExportedStructField(f, func(fieldOrJSONName, metricType string, rv reflect.Value) {
+			// Nothing.
+		})
+	})
+	if n != 0 {
+		t.Errorf("allocs = %v; want 0", n)
 	}
 }


### PR DESCRIPTION
This removes the ~9 allocs added by #5869, while still keeping struct fields sorted (the previous commit's tests still pass). And add a test to lock it in that this shouldn't allocate.

Updates #5778
