### PR TITLE
wgengine/magicsock: remove endpoint.wgEndpoint

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -2403,7 +2403,6 @@ func (c *Conn) SetNetworkMap(nm *netmap.NetworkMap) {
 			ep.discoKey = n.DiscoKey
 			ep.discoShort = n.DiscoKey.ShortString()
 		}
-		ep.wgEndpoint = n.Key.UntypedHexString()
 		ep.initFakeUDPAddr()
 		if debugDisco() { // rather than making a new knob
 			c.logf("magicsock: created endpoint key=%s: disco=%s; %v", n.Key.ShortString(), n.DiscoKey.ShortString(), logger.ArgWriter(func(w *bufio.Writer) {
@@ -3310,7 +3309,6 @@ type endpoint struct {
 	c          *Conn
 	publicKey  key.NodePublic // peer public key (for WireGuard + DERP)
 	fakeWGAddr netip.AddrPort // the UDP address we tell wireguard-go we're using
-	wgEndpoint string         // string from ParseEndpoint, holds a JSON-serialized wgcfg.Endpoints
 
 	// mu protects all following fields.
 	mu sync.Mutex // Lock ordering: Conn.mu, then endpoint.mu
@@ -3492,7 +3490,7 @@ func (de *endpoint) String() string {
 func (de *endpoint) ClearSrc()           {}
 func (de *endpoint) SrcToString() string { panic("unused") } // unused by wireguard-go
 func (de *endpoint) SrcIP() netip.Addr   { panic("unused") } // unused by wireguard-go
-func (de *endpoint) DstToString() string { return de.wgEndpoint }
+func (de *endpoint) DstToString() string { return de.publicKey.UntypedHexString() }
 func (de *endpoint) DstIP() netip.Addr   { panic("unused") }
 func (de *endpoint) DstToBytes() []byte  { return packIPPort(de.fakeWGAddr) }
 

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -1731,9 +1731,6 @@ func (m *peerMap) validate() error {
 		if got := pi.ep.publicKey; got != pub {
 			return fmt.Errorf("byNodeKey[%v].publicKey = %v", pub, got)
 		}
-		if got, want := pi.ep.wgEndpoint, pub.UntypedHexString(); got != want {
-			return fmt.Errorf("byNodeKey[%v].wgEndpoint = %q, want %q", pub, got, want)
-		}
 		if _, ok := seenEps[pi.ep]; ok {
 			return fmt.Errorf("duplicate endpoint present: %v", pi.ep.publicKey)
 		}


### PR DESCRIPTION
This field seems seldom used and the documentation is wrong. It is simpler to just derive its original value dynamically when endpoint.DstToString is called.

This method is potentially used by wireguard-go,
but not in any code path is performance sensitive. All calls to it use it in conjunction with fmt.Printf, which is going to be slow anyways since it uses Go reflection.

Signed-off-by: Joe Tsai <joetsai@digital-static.net>