### PR TITLE
wgengine/netlog: add support for magicsock statistics

### DIFF
--- a/wgengine/netlog/logger_test.go
+++ b/wgengine/netlog/logger_test.go
@@ -59,7 +59,7 @@ func TestResourceCheck(t *testing.T) {
 	var l Logger
 	var d fakeDevice
 	for i := 0; i < 10; i++ {
-		must.Do(l.Startup(logtail.PrivateID{}, logtail.PrivateID{}, &d))
+		must.Do(l.Startup(logtail.PrivateID{}, logtail.PrivateID{}, &d, nil))
 		l.ReconfigRoutes(&router.Config{})
 		must.Do(l.Shutdown(context.Background()))
 		c.Assert(d.toggled, qt.Equals, 2*(i+1))

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -953,7 +953,7 @@ func (e *userspaceEngine) Reconfig(cfg *wgcfg.Config, routerCfg *router.Config, 
 		nid := cfg.NetworkLogging.NodeID
 		tid := cfg.NetworkLogging.DomainID
 		e.logf("wgengine: Reconfig: starting up network logger (node:%s tailnet:%s)", nid.Public(), tid.Public())
-		if err := e.networkLogger.Startup(nid, tid, e.tundev); err != nil {
+		if err := e.networkLogger.Startup(nid, tid, e.tundev, nil); err != nil {
 			e.logf("wgengine: Reconfig: error starting up network logger: %v", err)
 		}
 	}


### PR DESCRIPTION
This sets up Logger to handle statistics at the magicsock layer, where we can correlate traffic between a particular tailscale IP address and any number of physical endpoints used to contact the node that hosts that tailscale address.

We also export Message and TupleCounts to better document the JSON format that is being sent to the logging infrastructure.

Signed-off-by: Joe Tsai <joetsai@digital-static.net>