### PR TITLE
wgengine/magicsock: gather physical-layer statistics

### DIFF
--- a/wgengine/netlog/logger.go
+++ b/wgengine/netlog/logger.go
@@ -31,8 +31,7 @@ const pollPeriod = 5 * time.Second
 
 // Device is an abstraction over a tunnel device or a magic socket.
 // *tstun.Wrapper implements this interface.
-//
-// TODO(joetsai): Make *magicsock.Conn implement this interface.
+// *magicsock.Conn implements this interface.
 type Device interface {
 	SetStatisticsEnabled(bool)
 	ExtractStatistics() map[netlogtype.Connection]netlogtype.Counts

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -953,7 +953,7 @@ func (e *userspaceEngine) Reconfig(cfg *wgcfg.Config, routerCfg *router.Config, 
 		nid := cfg.NetworkLogging.NodeID
 		tid := cfg.NetworkLogging.DomainID
 		e.logf("wgengine: Reconfig: starting up network logger (node:%s tailnet:%s)", nid.Public(), tid.Public())
-		if err := e.networkLogger.Startup(nid, tid, e.tundev, nil); err != nil {
+		if err := e.networkLogger.Startup(nid, tid, e.tundev, e.magicConn); err != nil {
 			e.logf("wgengine: Reconfig: error starting up network logger: %v", err)
 		}
 	}


### PR DESCRIPTION
There is utility in logging traffic statistics that occurs at the physical layer. That is, in order to send packets virtually to a particular tailscale IP address, what physical endpoints did we need to communicate with?

This functionality logs IP addresses identical to what had always been logged in magicsock prior to #5823, so there is no increase in PII being logged.

ExtractStatistics returns a mapping of connections to counts. The source is always a tailscale IP address (without port), while the destination is some endpoint reachable on WAN or LAN. As a special case, traffic routed through DERP will use 127.3.3.40 as the destination address with the port being the DERP region.

This entire feature is only enabled if data-plane audit logging is enabled on the tailnet (by default it is disabled).

Example of type of information logged:

	------------------------------------  Tx[P/s]    Tx[B/s]  Rx[P/s]   Rx[B/s]
	PhysicalTraffic:                       25.80      3.39Ki   38.80     5.57Ki
	    100.1.2.3 -> 143.11.22.33:41641    15.40      2.00Ki   23.20     3.37Ki
	    100.4.5.6 -> 192.168.0.100:41641   10.20      1.38Ki   15.60     2.20Ki
	    100.7.8.9 -> 127.3.3.40:2           0.20      6.40      0.00     0.00

Signed-off-by: Joe Tsai <joetsai@digital-static.net>