### PR TITLE
net/netcheck: fix crash in checkCaptivePortal

### DIFF
--- a/net/netcheck/netcheck.go
+++ b/net/netcheck/netcheck.go
@@ -1105,6 +1105,9 @@ func (c *Client) checkCaptivePortal(ctx context.Context, dm *tailcfg.DERPMap, pr
 			}
 			rids = append(rids, id)
 		}
+		if len(rids) == 0 {
+			return false, nil
+		}
 		preferredDERP = rids[rand.Intn(len(rids))]
 	}
 


### PR DESCRIPTION
If netcheck happens before there's a derpmap.

This seems to only affect Headscale because it doesn't send a derpmap as early?

