### PR TITLE
cmd/tsconnect: pre-compress main.wasm when building the NPM package

### DIFF
--- a/cmd/tsconnect/build-pkg.go
+++ b/cmd/tsconnect/build-pkg.go
@@ -12,6 +12,7 @@ import (
 	"path"
 
 	"github.com/tailscale/hujson"
+	"tailscale.com/util/precompress"
 	"tailscale.com/version"
 )
 
@@ -37,6 +38,10 @@ func runBuildPkg() {
 
 	runEsbuild(*buildOptions)
 
+	if err := precompressWasm(); err != nil {
+		log.Fatalf("Could not pre-recompress wasm: %v", err)
+	}
+
 	log.Printf("Generating types...\n")
 	if err := runYarn("pkg-types"); err != nil {
 		log.Fatalf("Type generation failed: %v", err)
@@ -47,6 +52,13 @@ func runBuildPkg() {
 	}
 
 	log.Printf("Built package version %s", version.Long)
+}
+
+func precompressWasm() error {
+	log.Printf("Pre-compressing main.wasm...\n")
+	return precompress.Precompress(path.Join(*pkgDir, "main.wasm"), precompress.Options{
+		FastCompression: *fastCompression,
+	})
 }
 
 func updateVersion() error {

--- a/util/precompress/precompress.go
+++ b/util/precompress/precompress.go
@@ -42,7 +42,7 @@ func PrecompressDir(dirPath string, options Options) error {
 		}
 
 		eg.Go(func() error {
-			return precompress(p, options)
+			return Precompress(p, options)
 		})
 		return nil
 	})
@@ -81,12 +81,11 @@ func OpenPrecompressedFile(w http.ResponseWriter, r *http.Request, path string, 
 }
 
 var compressibleExtensions = map[string]bool{
-	".js":   true,
-	".css":  true,
-	".wasm": true,
+	".js":  true,
+	".css": true,
 }
 
-func precompress(path string, options Options) error {
+func Precompress(path string, options Options) error {
 	contents, err := os.ReadFile(path)
 	if err != nil {
 		return err


### PR DESCRIPTION
This way we can do that once (out of band, in the GitHub action), instead of increasing the time of each deploy that uses the package.

.wasm is removed from the list of automatically pre-compressed extensions, an OSS bump and small change on the corp side is needed to make use of this change.