### PR TITLE
tsnet/examples/tshello: update example for LocalClient method

### DIFF
--- a/tsnet/example/tshello/tshello.go
+++ b/tsnet/example/tshello/tshello.go
@@ -32,13 +32,18 @@ func main() {
 	}
 	defer ln.Close()
 
+	lc, err := s.LocalClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	if *addr == ":443" {
 		ln = tls.NewListener(ln, &tls.Config{
 			GetCertificate: tailscale.GetCertificate,
 		})
 	}
 	log.Fatal(http.Serve(ln, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		who, err := tailscale.WhoIs(r.Context(), r.RemoteAddr)
+		who, err := lc.WhoIs(r.Context(), r.RemoteAddr)
 		if err != nil {
 			http.Error(w, err.Error(), 500)
 			return


### PR DESCRIPTION
Before this would silently fail if this program was running on a machine that was not already running Tailscale. This patch changes the WhoIs call to use the tsnet.Server LocalClient instead of the global tailscale LocalClient.

Signed-off-by: Xe <xe@tailscale.com>