### PR TITLE
control/controlhttp: allow setting, getting Upgrade headers in Noise upgrade

### DIFF
--- a/control/controlclient/noise.go
+++ b/control/controlclient/noise.go
@@ -210,7 +210,7 @@ func (nc *noiseClient) dial(_, _ string, _ *tls.Config) (net.Conn, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	conn, err := (&controlhttp.Dialer{
+	clientConn, err := (&controlhttp.Dialer{
 		Hostname:        nc.host,
 		HTTPPort:        nc.httpPort,
 		HTTPSPort:       nc.httpsPort,
@@ -226,7 +226,7 @@ func (nc *noiseClient) dial(_, _ string, _ *tls.Config) (net.Conn, error) {
 
 	nc.mu.Lock()
 	defer nc.mu.Unlock()
-	ncc := &noiseConn{Conn: conn, id: connID, pool: nc}
+	ncc := &noiseConn{Conn: clientConn.Conn, id: connID, pool: nc}
 	mak.Set(&nc.connPool, ncc.id, ncc)
 	return ncc, nil
 }

--- a/control/controlhttp/client_common.go
+++ b/control/controlhttp/client_common.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package controlhttp
+
+import (
+	"net/http"
+
+	"tailscale.com/control/controlbase"
+)
+
+// ClientConn is a Tailscale control client as returned by the Dialer.
+//
+// It's effectively just a *controlbase.Conn (which it embeds) with
+// optional metadata.
+type ClientConn struct {
+	// Conn is the noise connection.
+	*controlbase.Conn
+
+	// UntrustedUpgradeHeaders are the HTTP headers seen in the
+	// 101 Switching Protocols upgrade response. They may be nil
+	// or even might've been tampered with by a middlebox.
+	// They should not be trusted.
+	UntrustedUpgradeHeaders http.Header
+}

--- a/control/controlhttp/http_test.go
+++ b/control/controlhttp/http_test.go
@@ -127,7 +127,7 @@ func testControlHTTP(t *testing.T, param httpTestParam) {
 	const testProtocolVersion = 1
 	sch := make(chan serverResult, 1)
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := AcceptHTTP(context.Background(), w, r, server)
+		conn, err := AcceptHTTP(context.Background(), w, r, server, nil)
 		if err != nil {
 			log.Print(err)
 		}
@@ -485,7 +485,7 @@ func TestDialPlan(t *testing.T) {
 			close(done)
 		})
 		var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			conn, err := AcceptHTTP(context.Background(), w, r, server)
+			conn, err := AcceptHTTP(context.Background(), w, r, server, nil)
 			if err != nil {
 				log.Print(err)
 			} else {


### PR DESCRIPTION
Not currently used, but will allow us to usually remove a round-trip for a future feature.

Updates #5972
