### PR TITLE
.github/workflows: use fast compression for NPM package CI check

### DIFF
--- a/.github/workflows/cross-wasm.yml
+++ b/.github/workflows/cross-wasm.yml
@@ -39,7 +39,7 @@ jobs:
       # that depend on it.
       run: |
         ./tool/go run ./cmd/tsconnect --fast-compression build
-        ./tool/go run ./cmd/tsconnect build-pkg
+        ./tool/go run ./cmd/tsconnect --fast-compression build-pkg
 
     - uses: k0kubun/action-slack@v2.0.0
       with:


### PR DESCRIPTION
Starting with #5946 we're compressing main.wasm when building the package, but that should not show down the CI check.