### PR TITLE
.github: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,12 +1,12 @@
 name: Bug report
-description: File a bug report
+description: File a bug report. If you need help, contact support instead
 labels: [needs-triage, bug]
 body:
   - type: markdown
     attributes:
       value: |
-        Please check if your bug is [already filed](https://github.com/tailscale/tailscale/issues).
-        Have an urgent issue? Let us know by emailing us at <support@tailscale.com>.
+        Need help with your tailnet? [Contact support](https://tailscale.com/contact/support) instead.
+        Otherwise, please check if your bug is [already filed](https://github.com/tailscale/tailscale/issues) before filing a new one.
   - type: textarea
     id: what-happened
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,4 +5,4 @@ contact_links:
     about: Contact us for support
   - name: Troubleshooting
     url: https://tailscale.com/kb/1023/troubleshooting
-    about: Troubleshoot common issues
+    about: See the troubleshooting guide for help addressing common issues


### PR DESCRIPTION
Signed-off-by: Maya Kaczorowski <15946341+mayakacz@users.noreply.github.com>

Remove support@ email from issue template. Would prefer to have users fill in https://tailscale.com/contact/support as that has logged in information.