### PR TITLE
wgengine/magicsock: set up pathfinder

### DIFF
--- a/wgengine/magicsock/pathfinder.go
+++ b/wgengine/magicsock/pathfinder.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package magicsock
+
+// startPathFinder initializes the atomicSendFunc, and
+// will eventually kick off a goroutine that monitors whether
+// that sendFunc is still the best option for the endpoint
+// to use and adjusts accordingly.
+func (de *endpoint) startPathFinder() {
+	de.pathFinderRunning = true
+}


### PR DESCRIPTION
Sets up new file for separate silent disco goroutine, tentatively named pathfinder for now.

Updates #540

Co-authored-by: Brad Fitzpatrick <bradfitz@tailscale.com>
Signed-off-by: Jenny Zhang <jz@tailscale.com>