### PR TITLE
net/netcheck, tailcfg: track whether OS supports IPv6

### DIFF
--- a/net/netcheck/netcheck.go
+++ b/net/netcheck/netcheck.go
@@ -1342,6 +1342,9 @@ func (c *Client) logConciseReport(r *Report, dm *tailcfg.DERPMap) {
 		}
 
 		fmt.Fprintf(w, " v6=%v", r.IPv6)
+		if !r.IPv6 {
+			fmt.Fprintf(w, " v6os=%v", r.OSHasIPv6)
+		}
 		fmt.Fprintf(w, " mapvarydest=%v", r.MappingVariesByDestIP)
 		fmt.Fprintf(w, " hair=%v", r.HairPinning)
 		if r.AnyPortMappingChecked() {

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -597,11 +597,10 @@ func (ni *NetInfo) String() string {
 	if ni == nil {
 		return "NetInfo(nil)"
 	}
-	return fmt.Sprintf("NetInfo{varies=%v hairpin=%v ipv6=%v udp=%v icmpv4=%v derp=#%v portmap=%v link=%q}",
+	return fmt.Sprintf("NetInfo{varies=%v hairpin=%v ipv6=%v ipv6os=%v udp=%v icmpv4=%v derp=#%v portmap=%v link=%q}",
 		ni.MappingVariesByDestIP, ni.HairPinning, ni.WorkingIPv6,
-		ni.WorkingUDP, ni.WorkingICMPv4, ni.PreferredDERP,
-		ni.portMapSummary(),
-		ni.LinkType)
+		ni.OSHasIPv6, ni.WorkingUDP, ni.WorkingICMPv4,
+		ni.PreferredDERP, ni.portMapSummary(), ni.LinkType)
 }
 
 func (ni *NetInfo) portMapSummary() string {

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -807,6 +807,7 @@ func (c *Conn) updateNetInfo(ctx context.Context) (*netcheck.Report, error) {
 		ni.DERPLatency[fmt.Sprintf("%d-v6", rid)] = d.Seconds()
 	}
 	ni.WorkingIPv6.Set(report.IPv6)
+	ni.OSHasIPv6.Set(report.OSHasIPv6)
 	ni.WorkingUDP.Set(report.UDP)
 	ni.WorkingICMPv4.Set(report.ICMPv4)
 	ni.PreferredDERP = report.PreferredDERP


### PR DESCRIPTION
We had previously added this to the netcheck report in #5087 but never copied it into the NetInfo struct. Additionally, add it to log lines so it's visible to support.

Change-Id: Ib6266f7c6aeb2eb2a28922aeafd950fe1bf5627e
Signed-off-by: Andrew Dunham <andrew@tailscale.com>