### PR TITLE
docs/k8s: record the Tailscale device ID in a k8s annotation.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN GOARCH=$TARGETARCH go install -ldflags="\
       -v ./cmd/tailscale ./cmd/tailscaled
 
 FROM alpine:3.16
-RUN apk add --no-cache ca-certificates iptables iproute2 ip6tables
+RUN apk add --no-cache ca-certificates iptables iproute2 ip6tables jq curl
 
 COPY --from=build-env /go/bin/* /usr/local/bin/
 COPY --from=build-env /go/src/tailscale/docs/k8s/run.sh /usr/local/bin/

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -3,4 +3,4 @@
 # license that can be found in the LICENSE file.
 
 FROM alpine:3.16
-RUN apk add --no-cache ca-certificates iptables iproute2 ip6tables
+RUN apk add --no-cache ca-certificates iptables iproute2 ip6tables jq curl


### PR DESCRIPTION
When a Tailscale pod comes up with k8s state storage, if it successfully authenticates it records its device ID in the tailscale.com/device-id annotation on the state secret.

Signed-off-by: David Anderson <danderson@tailscale.com>