### PR TITLE
portlist: unexport GetList

### DIFF
--- a/portlist/poller.go
+++ b/portlist/poller.go
@@ -45,7 +45,7 @@ func NewPoller() (*Poller, error) {
 	// Do one initial poll synchronously so we can return an error
 	// early.
 	var err error
-	p.prev, err = GetList(nil)
+	p.prev, err = getList(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func (p *Poller) Run(ctx context.Context) error {
 	for {
 		select {
 		case <-tick.C:
-			pl, err := GetList(p.prev)
+			pl, err := getList(p.prev)
 			if err != nil {
 				p.Err = err
 				return err

--- a/portlist/portlist.go
+++ b/portlist/portlist.go
@@ -76,7 +76,7 @@ func (pl List) String() string {
 
 var debugDisablePortlist = envknob.RegisterBool("TS_DEBUG_DISABLE_PORTLIST")
 
-func GetList(prev List) (List, error) {
+func getList(prev List) (List, error) {
 	if debugDisablePortlist() {
 		return nil, nil
 	}

--- a/portlist/portlist_test.go
+++ b/portlist/portlist_test.go
@@ -14,7 +14,7 @@ import (
 func TestGetList(t *testing.T) {
 	tstest.ResourceCheck(t)
 
-	pl, err := GetList(nil)
+	pl, err := getList(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,7 +34,7 @@ func TestIgnoreLocallyBoundPorts(t *testing.T) {
 	defer ln.Close()
 	ta := ln.Addr().(*net.TCPAddr)
 	port := ta.Port
-	pl, err := GetList(nil)
+	pl, err := getList(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -195,7 +195,7 @@ func TestSameInodes(t *testing.T) {
 func BenchmarkGetList(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_, err := GetList(nil)
+		_, err := getList(nil)
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
It's an internal implementation detail, and I plan to refactor it for performance (garbage) reasons anyway, so start by hiding it.

Updates #5958
