### PR TITLE
net/dnscache: Handle 4-in-6 addresses in DNS responses

### DIFF
--- a/net/dnscache/dnscache.go
+++ b/net/dnscache/dnscache.go
@@ -276,6 +276,11 @@ func (r *Resolver) lookupIP(host string) (ip, ip6 netip.Addr, allIPs []netip.Add
 		return netip.Addr{}, netip.Addr{}, nil, fmt.Errorf("no IPs for %q found", host)
 	}
 
+        // Unmap everything; LookupNetIP can return mapped addresses (see #5698)
+	for i := range ips {
+		ips[i] = ips[i].Unmap()
+	}
+
 	have4 := false
 	for _, ipa := range ips {
 		if ipa.Is4() {


### PR DESCRIPTION
On Android, the system resolver can return IPv4 addresses as IPv6-mapped addresses (i.e. `::ffff:a.b.c.d`). After the switch to `net/netip` (19008a3), this case is no longer handled and a response like this will be seen as failure to resolve any IPv4 addresses.

Handle this case by simply calling `Unmap()` on the returned IP when it is a 4-in-6 address. Fixes #5698.