### PR TITLE
portlist: add BenchmarkGetListIncremental

### DIFF
--- a/portlist/portlist_test.go
+++ b/portlist/portlist_test.go
@@ -195,12 +195,23 @@ func TestSameInodes(t *testing.T) {
 }
 
 func BenchmarkGetList(b *testing.B) {
+	benchmarkGetList(b, false)
+}
+
+func BenchmarkGetListIncremental(b *testing.B) {
+	benchmarkGetList(b, true)
+}
+
+func benchmarkGetList(b *testing.B, incremental bool) {
 	b.ReportAllocs()
 	var p Poller
 	for i := 0; i < b.N; i++ {
-		_, err := p.getList()
+		pl, err := p.getList()
 		if err != nil {
 			b.Fatal(err)
+		}
+		if incremental {
+			p.prev = pl
 		}
 	}
 }


### PR DESCRIPTION
In contrast to BenchmarkGetList, this new BenchmarkGetListIncremental acts like what happens in practice, remembering the previous run and avoiding work that's already been done previously.

Currently:

    BenchmarkGetList
    BenchmarkGetList-8                           100          11011100 ns/op           68411 B/op       2211 allocs/op
    BenchmarkGetList-8                           100          11443410 ns/op           69073 B/op       2223 allocs/op
    BenchmarkGetList-8                           100          11217311 ns/op           68421 B/op       2197 allocs/op
    BenchmarkGetList-8                           100          11035559 ns/op           68801 B/op       2220 allocs/op
    BenchmarkGetList-8                           100          10921596 ns/op           69226 B/op       2225 allocs/op
    BenchmarkGetListIncremental
    BenchmarkGetListIncremental-8                168           7187217 ns/op            1192 B/op         28 allocs/op
    BenchmarkGetListIncremental-8                172           7004525 ns/op            1194 B/op         28 allocs/op
    BenchmarkGetListIncremental-8                162           7235889 ns/op            1221 B/op         29 allocs/op
    BenchmarkGetListIncremental-8                164           7035671 ns/op            1219 B/op         29 allocs/op
    BenchmarkGetListIncremental-8                174           7095448 ns/op            1114 B/op         27 allocs/op

Updates #5958