### PR TITLE
portlist: refactor, introduce OS-specific types

### DIFF
--- a/portlist/netstat_test.go
+++ b/portlist/netstat_test.go
@@ -71,19 +71,19 @@ udp4       0      0  *.5553                 *.*
 
 func TestParsePortsNetstat(t *testing.T) {
 	want := List{
-		Port{"tcp", 22, "", ""},
-		Port{"tcp", 23, "", ""},
-		Port{"tcp", 24, "", ""},
-		Port{"tcp", 32, "sshd", ""},
-		Port{"udp", 53, "chrome", ""},
-		Port{"udp", 53, "funball", ""},
-		Port{"udp", 5050, "CDPSvc", ""},
-		Port{"udp", 5353, "", ""},
-		Port{"udp", 5354, "", ""},
-		Port{"udp", 5453, "", ""},
-		Port{"udp", 5553, "", ""},
-		Port{"tcp", 8185, "", ""}, // but not 8186, 8187, 8188 on localhost
-		Port{"udp", 9353, "iTunes", ""},
+		Port{"tcp", 22, ""},
+		Port{"tcp", 23, ""},
+		Port{"tcp", 24, ""},
+		Port{"tcp", 32, "sshd"},
+		Port{"udp", 53, "chrome"},
+		Port{"udp", 53, "funball"},
+		Port{"udp", 5050, "CDPSvc"},
+		Port{"udp", 5353, ""},
+		Port{"udp", 5354, ""},
+		Port{"udp", 5453, ""},
+		Port{"udp", 5553, ""},
+		Port{"tcp", 8185, ""}, // but not 8186, 8187, 8188 on localhost
+		Port{"udp", 9353, "iTunes"},
 	}
 
 	pl := appendParsePortsNetstat(nil, netstatOutput)

--- a/portlist/poller.go
+++ b/portlist/poller.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"tailscale.com/envknob"
@@ -24,6 +25,18 @@ var debugDisablePortlist = envknob.RegisterBool("TS_DEBUG_DISABLE_PORTLIST")
 type Poller struct {
 	c chan List // unbuffered
 
+	// os, if non-nil, is an OS-specific implementation of the portlist getting
+	// code. When non-nil, it's responsible for getting the complete list of
+	// cached ports complete with the process name. That is, when set,
+	// addProcesses is not used.
+	//
+	// This is part of a multi-step migration (starting 2022-10-22) to move to
+	// using osImpl for all of Linux, macOS (unsandboxed), and Windows. But
+	// during the transition period, we support this being nil.
+	// TODO(bradfitz): finish that migration.
+	os     osImpl
+	osOnce sync.Once // guards init of os
+
 	// closeCtx is the context that's canceled on Close.
 	closeCtx       context.Context
 	closeCtxCancel context.CancelFunc
@@ -33,8 +46,25 @@ type Poller struct {
 	// scatch is memory for Poller.getList to reuse between calls.
 	scratch []Port
 
-	prev List // most recent data
+	prev List // most recent data, not aliasing scratch
 }
+
+// osImpl is the OS-specific implementation of getting the open listening ports.
+type osImpl interface {
+	Close() error
+
+	// AppendListeningPorts appends to base (which must have length 0 but
+	// optional capacity) the list of listening ports. The Port struct should be
+	// populated as completely as possible. Another pass will not add anything
+	// to it.
+	//
+	// The appended ports should be in a sorted (or at least stable) order so
+	// the caller can cheaply detect when there are no changes.
+	AppendListeningPorts(base []Port) ([]Port, error)
+}
+
+// newOSImpl, if non-nil, constructs a new osImpl.
+var newOSImpl func() osImpl
 
 // NewPoller returns a new portlist Poller. It returns an error
 // if the portlist couldn't be obtained.
@@ -50,6 +80,7 @@ func NewPoller() (*Poller, error) {
 		runDone: make(chan struct{}),
 	}
 	p.closeCtx, p.closeCtxCancel = context.WithCancel(context.Background())
+	p.osOnce.Do(p.initOSField)
 
 	// Do one initial poll synchronously so we can return an error
 	// early.
@@ -59,6 +90,12 @@ func NewPoller() (*Poller, error) {
 		return nil, err
 	}
 	return p, nil
+}
+
+func (p *Poller) initOSField() {
+	if newOSImpl != nil {
+		p.os = newOSImpl()
+	}
 }
 
 // Updates return the channel that receives port list updates.
@@ -71,6 +108,9 @@ func (p *Poller) Updates() <-chan List { return p.c }
 func (p *Poller) Close() error {
 	p.closeCtxCancel()
 	<-p.runDone
+	if p.os != nil {
+		p.os.Close()
+	}
 	return nil
 }
 
@@ -109,10 +149,12 @@ func (p *Poller) Run(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
-			if pl.sameInodes(p.prev) {
+			if pl.equal(p.prev) {
 				continue
 			}
-			p.prev = pl
+			// New value. Make a copy, as pl might alias pl.scratch
+			// and prev must not.
+			p.prev = append([]Port(nil), pl...)
 			if sent, err := p.send(ctx, p.prev); !sent {
 				return err
 			}
@@ -128,13 +170,21 @@ func (p *Poller) getList() (List, error) {
 	if debugDisablePortlist() {
 		return nil, nil
 	}
+	p.osOnce.Do(p.initOSField)
 	var err error
+	if p.os != nil {
+		p.scratch, err = p.os.AppendListeningPorts(p.scratch[:0])
+		return p.scratch, err
+	}
+
+	// Old path for OSes that don't have osImpl yet.
+	// TODO(bradfitz): delete these when macOS and Windows are converted.
 	p.scratch, err = appendListeningPorts(p.scratch[:0])
 	if err != nil {
 		return nil, fmt.Errorf("listPorts: %s", err)
 	}
 	pl := sortAndDedup(p.scratch)
-	if pl.sameInodes(p.prev) {
+	if pl.equal(p.prev) {
 		// Nothing changed, skip inode lookup
 		return p.prev, nil
 	}

--- a/portlist/portlist.go
+++ b/portlist/portlist.go
@@ -19,48 +19,33 @@ type Port struct {
 	Proto   string // "tcp" or "udp"
 	Port    uint16 // port number
 	Process string // optional process name, if found
-
-	inode string // OS-specific; "socket:[165614651]" on Linux
 }
 
 // List is a list of Ports.
 type List []Port
 
 func (a *Port) lessThan(b *Port) bool {
-	if a.Port < b.Port {
-		return true
-	} else if a.Port > b.Port {
-		return false
+	if a.Port != b.Port {
+		return a.Port < b.Port
 	}
-
-	if a.Proto < b.Proto {
-		return true
-	} else if a.Proto > b.Proto {
-		return false
+	if a.Proto != b.Proto {
+		return a.Proto < b.Proto
 	}
-
-	if a.inode < b.inode {
-		return true
-	} else if a.inode > b.inode {
-		return false
-	}
-
-	if a.Process < b.Process {
-		return true
-	} else if a.Process > b.Process {
-		return false
-	}
-	return false
+	return a.Process < b.Process
 }
 
-func (a List) sameInodes(b List) bool {
+func (a *Port) equal(b *Port) bool {
+	return a.Port == b.Port &&
+		a.Proto == b.Proto &&
+		a.Process == b.Process
+}
+
+func (a List) equal(b List) bool {
 	if len(a) != len(b) {
 		return false
 	}
 	for i := range a {
-		if a[i].Proto != b[i].Proto ||
-			a[i].Port != b[i].Port ||
-			a[i].inode != b[i].inode {
+		if !a[i].equal(&b[i]) {
 			return false
 		}
 	}
@@ -70,8 +55,8 @@ func (a List) sameInodes(b List) bool {
 func (pl List) String() string {
 	var sb strings.Builder
 	for _, v := range pl {
-		fmt.Fprintf(&sb, "%-3s %5d %-17s %#v\n",
-			v.Proto, v.Port, v.inode, v.Process)
+		fmt.Fprintf(&sb, "%-3s %5d %#v\n",
+			v.Proto, v.Port, v.Process)
 	}
 	return strings.TrimRight(sb.String(), "\n")
 }

--- a/portlist/portlist_linux_test.go
+++ b/portlist/portlist_linux_test.go
@@ -41,12 +41,12 @@ func TestParsePorts(t *testing.T) {
 		name string
 		in   string
 		file string
-		want []Port
+		want map[string]*portMeta
 	}{
 		{
 			name: "empty",
 			in:   "header line (ignored)\n",
-			want: nil,
+			want: map[string]*portMeta{},
 		},
 		{
 			name: "ipv4",
@@ -56,8 +56,10 @@ func TestParsePorts(t *testing.T) {
   1: 00000000:0016 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 34062 1 0000000000000000 100 0 0 10 0
   2: 5501A8C0:ADD4 B25E9536:01BB 01 00000000:00000000 02:00000B2B 00000000  1000        0 155276677 2 0000000000000000 22 4 30 10 -1
 `,
-			want: []Port{
-				{Proto: "tcp", Port: 22, inode: "socket:[34062]"},
+			want: map[string]*portMeta{
+				"socket:[34062]": &portMeta{
+					port: Port{Proto: "tcp", Port: 22},
+				},
 			},
 		},
 		{
@@ -69,14 +71,17 @@ func TestParsePorts(t *testing.T) {
    2: 00000000000000000000000000000000:0016 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 34064 1 0000000000000000 100 0 0 10 0
    3: 69050120005716BC64906EBE009ECD4D:D506 0047062600000000000000006E171268:01BB 01 00000000:00000000 02:0000009E 00000000  1000        0 151042856 2 0000000000000000 21 4 28 10 -1
 `,
-			want: []Port{
-				{Proto: "tcp", Port: 8081, inode: "socket:[142240557]"},
-				{Proto: "tcp", Port: 22, inode: "socket:[34064]"},
+			want: map[string]*portMeta{
+				"socket:[142240557]": &portMeta{
+					port: Port{Proto: "tcp", Port: 8081},
+				},
+				"socket:[34064]": &portMeta{
+					port: Port{Proto: "tcp", Port: 22},
+				},
 			},
 		},
 	}
 
-	stringCache := new(internedStrings)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := bytes.NewBufferString(tt.in)
@@ -85,12 +90,16 @@ func TestParsePorts(t *testing.T) {
 			if tt.file != "" {
 				file = tt.file
 			}
-			got, err := appendParsePorts(nil, stringCache, r, file)
+			li := newLinuxImplBase()
+			err := li.parseProcNetFile(r, file)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			if diff := cmp.Diff(got, tt.want, cmp.AllowUnexported(Port{})); diff != "" {
+			for _, pm := range tt.want {
+				pm.keep = true
+				pm.needsProcName = true
+			}
+			if diff := cmp.Diff(li.known, tt.want, cmp.AllowUnexported(Port{}), cmp.AllowUnexported(portMeta{})); diff != "" {
 				t.Errorf("unexpected parsed ports (-got+want):\n%s", diff)
 			}
 		})
@@ -110,36 +119,20 @@ func BenchmarkParsePorts(b *testing.B) {
 		contents.WriteString("   3: 69050120005716BC64906EBE009ECD4D:D506 0047062600000000000000006E171268:01BB 01 00000000:00000000 02:0000009E 00000000  1000        0 151042856 2 0000000000000000 21 4 28 10 -1\n")
 	}
 
-	want := []Port{
-		{Proto: "tcp", Port: 8081, inode: "socket:[142240557]"},
-		{Proto: "tcp", Port: 22, inode: "socket:[34064]"},
-	}
+	li := newLinuxImplBase()
 
 	r := bytes.NewReader(contents.Bytes())
 	br := bufio.NewReader(&contents)
-	stringCache := new(internedStrings)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		r.Seek(0, io.SeekStart)
 		br.Reset(r)
-		got, err := appendParsePorts(nil, stringCache, br, "tcp6")
+		err := li.parseProcNetFile(br, "tcp6")
 		if err != nil {
 			b.Fatal(err)
 		}
-		if len(got) != 2 || got[0].Port != 8081 || got[1].Port != 22 {
-			b.Fatalf("wrong result:\n got %+v\nwant %+v", got, want)
-		}
-	}
-}
-
-func BenchmarkListPorts(b *testing.B) {
-	b.ReportAllocs()
-	var base []Port
-	for i := 0; i < b.N; i++ {
-		var err error
-		base, err = appendListeningPorts(base[:0])
-		if err != nil {
-			b.Fatal(err)
+		if len(li.known) != 2 {
+			b.Fatalf("wrong results; want 2 parsed got %d", len(li.known))
 		}
 	}
 }

--- a/portlist/portlist_test.go
+++ b/portlist/portlist_test.go
@@ -47,7 +47,7 @@ func TestIgnoreLocallyBoundPorts(t *testing.T) {
 	}
 }
 
-func TestLessThan(t *testing.T) {
+func TestEqualLessThan(t *testing.T) {
 	tests := []struct {
 		name string
 		a, b Port
@@ -55,80 +55,62 @@ func TestLessThan(t *testing.T) {
 	}{
 		{
 			"Port a < b",
-			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
-			Port{Proto: "tcp", Port: 101, Process: "proc1", inode: "inode1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc1"},
+			Port{Proto: "tcp", Port: 101, Process: "proc1"},
 			true,
 		},
 		{
 			"Port a > b",
-			Port{Proto: "tcp", Port: 101, Process: "proc1", inode: "inode1"},
-			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			Port{Proto: "tcp", Port: 101, Process: "proc1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc1"},
 			false,
 		},
 		{
 			"Proto a < b",
-			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
-			Port{Proto: "udp", Port: 100, Process: "proc1", inode: "inode1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc1"},
+			Port{Proto: "udp", Port: 100, Process: "proc1"},
 			true,
 		},
 		{
 			"Proto a < b",
-			Port{Proto: "udp", Port: 100, Process: "proc1", inode: "inode1"},
-			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
-			false,
-		},
-		{
-			"inode a < b",
-			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
-			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode2"},
-			true,
-		},
-		{
-			"inode a > b",
-			Port{Proto: "tcp", Port: 100, Process: "proc2", inode: "inode2"},
-			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			Port{Proto: "udp", Port: 100, Process: "proc1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc1"},
 			false,
 		},
 		{
 			"Process a < b",
-			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
-			Port{Proto: "tcp", Port: 100, Process: "proc2", inode: "inode1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc2"},
 			true,
 		},
 		{
 			"Process a > b",
-			Port{Proto: "tcp", Port: 100, Process: "proc2", inode: "inode1"},
-			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc2"},
+			Port{Proto: "tcp", Port: 100, Process: "proc1"},
 			false,
 		},
 		{
 			"Port evaluated first",
-			Port{Proto: "udp", Port: 100, Process: "proc2", inode: "inode2"},
-			Port{Proto: "tcp", Port: 101, Process: "proc1", inode: "inode1"},
+			Port{Proto: "udp", Port: 100, Process: "proc2"},
+			Port{Proto: "tcp", Port: 101, Process: "proc1"},
 			true,
 		},
 		{
 			"Proto evaluated second",
-			Port{Proto: "tcp", Port: 100, Process: "proc2", inode: "inode2"},
-			Port{Proto: "udp", Port: 100, Process: "proc1", inode: "inode1"},
-			true,
-		},
-		{
-			"inode evaluated third",
-			Port{Proto: "tcp", Port: 100, Process: "proc2", inode: "inode1"},
-			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode2"},
+			Port{Proto: "tcp", Port: 100, Process: "proc2"},
+			Port{Proto: "udp", Port: 100, Process: "proc1"},
 			true,
 		},
 		{
 			"Process evaluated fourth",
-			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
-			Port{Proto: "tcp", Port: 100, Process: "proc2", inode: "inode1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc2"},
 			true,
 		},
 		{
 			"equal",
-			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
-			Port{Proto: "tcp", Port: 100, Process: "proc1", inode: "inode1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc1"},
+			Port{Proto: "tcp", Port: 100, Process: "proc1"},
 			false,
 		},
 	}
@@ -138,58 +120,14 @@ func TestLessThan(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("%s: Equal = %v; want %v", tt.name, got, tt.want)
 		}
-	}
-}
-
-func TestSameInodes(t *testing.T) {
-	port1 := Port{Proto: "tcp", Port: 100, Process: "proc", inode: "inode1"}
-	port2 := Port{Proto: "tcp", Port: 100, Process: "proc", inode: "inode1"}
-	portProto := Port{Proto: "udp", Port: 100, Process: "proc", inode: "inode1"}
-	portPort := Port{Proto: "tcp", Port: 101, Process: "proc", inode: "inode1"}
-	portInode := Port{Proto: "tcp", Port: 100, Process: "proc", inode: "inode2"}
-	portProcess := Port{Proto: "tcp", Port: 100, Process: "other", inode: "inode1"}
-
-	tests := []struct {
-		name string
-		a, b List
-		want bool
-	}{
-		{
-			"identical",
-			List{port1, port1},
-			List{port2, port2},
-			true,
-		},
-		{
-			"proto differs",
-			List{port1, port1},
-			List{port2, portProto},
-			false,
-		},
-		{
-			"port differs",
-			List{port1, port1},
-			List{port2, portPort},
-			false,
-		},
-		{
-			"inode differs",
-			List{port1, port1},
-			List{port2, portInode},
-			false,
-		},
-		{
-			// SameInodes does not check the Process field
-			"Process differs",
-			List{port1, port1},
-			List{port2, portProcess},
-			true,
-		},
-	}
-	for _, tt := range tests {
-		got := tt.a.sameInodes(tt.b)
-		if got != tt.want {
-			t.Errorf("%s: Equal = %v; want %v", tt.name, got, tt.want)
+		lessBack := tt.b.lessThan(&tt.a)
+		if got && lessBack {
+			t.Errorf("%s: both a and b report being less than each other", tt.name)
+		}
+		wantEqual := !got && !lessBack
+		gotEqual := tt.a.equal(&tt.b)
+		if gotEqual != wantEqual {
+			t.Errorf("%s: equal = %v; want %v", tt.name, gotEqual, wantEqual)
 		}
 	}
 }


### PR DESCRIPTION
Add an osImpl interface that can be stateful and thus more efficient between calls. It will later be implemented by all OSes but for now this change only adds a Linux implementation.

Remove Port.inode. It was only used by Linux and moves into its osImpl.

Don't reopen /proc/net/* files on each run. Turns out you can just keep then open and seek to the beginning and reread and the contents are fresh.

    name                    old time/op    new time/op    delta
    GetListIncremental-8    7.29ms ± 2%    6.53ms ± 1%  -10.50%  (p=0.000 n=9+9)

    name                   old alloc/op   new alloc/op   delta
    GetListIncremental-8    1.30kB ±13%    0.70kB ± 5%  -46.38%  (p=0.000 n=9+10)

    name                  old allocs/op  new allocs/op  delta
    GetListIncremental-8      33.2 ±11%      18.0 ± 0%  -45.82%  (p=0.000 n=9+10)

Updates #5958
