### PR TITLE
cmd,ipn/ipnlocal,tailcfg: implement TKA disablement

### DIFF
--- a/client/tailscale/localclient.go
+++ b/client/tailscale/localclient.go
@@ -778,13 +778,16 @@ func (lc *LocalClient) NetworkLockStatus(ctx context.Context) (*ipnstate.Network
 }
 
 // NetworkLockInit initializes the tailnet key authority.
-func (lc *LocalClient) NetworkLockInit(ctx context.Context, keys []tka.Key) (*ipnstate.NetworkLockStatus, error) {
+//
+// TODO(tom): Plumb through disablement secrets.
+func (lc *LocalClient) NetworkLockInit(ctx context.Context, keys []tka.Key, disablementValues [][]byte) (*ipnstate.NetworkLockStatus, error) {
 	var b bytes.Buffer
 	type initRequest struct {
-		Keys []tka.Key
+		Keys              []tka.Key
+		DisablementValues [][]byte
 	}
 
-	if err := json.NewEncoder(&b).Encode(initRequest{Keys: keys}); err != nil {
+	if err := json.NewEncoder(&b).Encode(initRequest{Keys: keys, DisablementValues: disablementValues}); err != nil {
 		return nil, err
 	}
 

--- a/cmd/tailscale/cli/network-lock.go
+++ b/cmd/tailscale/cli/network-lock.go
@@ -5,6 +5,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -51,7 +52,10 @@ func runNetworkLockInit(ctx context.Context, args []string) error {
 		return err
 	}
 
-	status, err := localClient.NetworkLockInit(ctx, keys)
+	// TODO(tom): Implement specification of disablement values from the command line.
+	disablementValues := [][]byte{bytes.Repeat([]byte{0xa5}, 32)}
+
+	status, err := localClient.NetworkLockInit(ctx, keys, disablementValues)
 	if err != nil {
 		return err
 	}

--- a/control/controlclient/auto.go
+++ b/control/controlclient/auto.go
@@ -561,6 +561,11 @@ func (c *Auto) SetNetInfo(ni *tailcfg.NetInfo) {
 	c.sendNewMapRequest()
 }
 
+// SetTKAHead updates the TKA head hash that map-request infrastructure sends.
+func (c *Auto) SetTKAHead(headHash string) {
+	c.direct.SetTKAHead(headHash)
+}
+
 func (c *Auto) sendStatus(who string, err error, url string, nm *netmap.NetworkMap) {
 	c.mu.Lock()
 	if c.closed {

--- a/control/controlclient/client.go
+++ b/control/controlclient/client.go
@@ -65,6 +65,9 @@ type Client interface {
 	// in a separate http request. It has nothing to do with the rest of
 	// the state machine.
 	SetNetInfo(*tailcfg.NetInfo)
+	// SetTKAHead changes the TKA head hash value that will be sent in
+	// subsequent netmap requests.
+	SetTKAHead(headHash string)
 	// UpdateEndpoints changes the Endpoint structure that will be sent
 	// in subsequent node registration requests.
 	// TODO: a server-side change would let us simply upload this

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -830,6 +830,16 @@ func (b *LocalBackend) setClientStatus(st controlclient.Status) {
 			b.logf("[v1] TKA sync error: %v", err)
 		}
 		b.mu.Lock()
+		if b.tka != nil {
+			head, err := b.tka.authority.Head().MarshalText()
+			if err != nil {
+				b.logf("[v1] error marshalling tka head: %v", err)
+			} else {
+				b.cc.SetTKAHead(string(head))
+			}
+		} else {
+			b.cc.SetTKAHead("")
+		}
 
 		if !envknob.TKASkipSignatureCheck() {
 			b.tkaFilterNetmapLocked(st.NetMap)
@@ -1225,11 +1235,21 @@ func (b *LocalBackend) Start(opts ipn.Options) error {
 	b.cc = cc
 	b.ccAuto, _ = cc.(*controlclient.Auto)
 	endpoints := b.endpoints
+	var tkaHead string
+	if b.tka != nil {
+		head, err := b.tka.authority.Head().MarshalText()
+		if err != nil {
+			b.mu.Unlock()
+			return fmt.Errorf("marshalling tka head: %w", err)
+		}
+		tkaHead = string(head)
+	}
 	b.mu.Unlock()
 
 	if endpoints != nil {
 		cc.UpdateEndpoints(endpoints)
 	}
+	cc.SetTKAHead(tkaHead)
 
 	b.e.SetNetInfoCallback(b.setNetInfo)
 

--- a/ipn/ipnlocal/state_test.go
+++ b/ipn/ipnlocal/state_test.go
@@ -248,6 +248,10 @@ func (cc *mockControl) SetNetInfo(ni *tailcfg.NetInfo) {
 	cc.called("SetNetInfo")
 }
 
+func (cc *mockControl) SetTKAHead(head string) {
+	cc.logf("SetTKAHead: %s", head)
+}
+
 func (cc *mockControl) UpdateEndpoints(endpoints []tailcfg.Endpoint) {
 	// validate endpoint information here?
 	cc.logf("UpdateEndpoints:  ep=%v", endpoints)

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -932,7 +932,8 @@ func (h *Handler) serveTKAInit(w http.ResponseWriter, r *http.Request) {
 	}
 
 	type initRequest struct {
-		Keys []tka.Key
+		Keys              []tka.Key
+		DisablementValues [][]byte
 	}
 	var req initRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -940,7 +941,7 @@ func (h *Handler) serveTKAInit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.b.NetworkLockInit(req.Keys); err != nil {
+	if err := h.b.NetworkLockInit(req.Keys, req.DisablementValues); err != nil {
 		http.Error(w, "initialization failed: "+err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -947,6 +947,11 @@ type MapRequest struct {
 	// EndpointTypes are the types of the corresponding endpoints in Endpoints.
 	EndpointTypes []EndpointType `json:",omitempty"`
 
+	// TKAHead describes the hash of the latest AUM applied to the local
+	// tailnet key authority, if one is operating.
+	// It is encoded as tka.AUMHash.MarshalText.
+	TKAHead string `json:",omitempty"`
+
 	// ReadOnly is whether the client just wants to fetch the
 	// MapResponse, without updating their Endpoints. The
 	// Endpoints field will be ignored and LastSeen will not be

--- a/tailcfg/tka.go
+++ b/tailcfg/tka.go
@@ -86,9 +86,6 @@ type TKAInfo struct {
 	//
 	// If the Head state differs to that known locally, the node should perform
 	// synchronization via a separate RPC.
-	//
-	// TODO(tom): Implement AUM synchronization as noise endpoints
-	// /machine/tka/sync/offer & /machine/tka/sync/send.
 	Head string `json:",omitempty"`
 
 	// Disabled indicates the control plane believes TKA should be disabled,
@@ -97,9 +94,6 @@ type TKAInfo struct {
 	// disable TKA locally.
 	// This field exists to disambiguate a nil TKAInfo in a delta mapresponse
 	// from a nil TKAInfo indicating TKA should be disabled.
-	//
-	// TODO(tom): Implement /machine/tka/bootstrap as a noise endpoint, to
-	// communicate the genesis AUM & any disablement secrets.
 	Disabled bool `json:",omitempty"`
 }
 
@@ -162,7 +156,8 @@ type TKASyncOfferResponse struct {
 }
 
 // TKASyncSendRequest encodes AUMs that a node believes the control plane
-// is missing.
+// is missing, and notifies control of its local TKA state (specifically
+// the head hash).
 type TKASyncSendRequest struct {
 	// Version is the client's capabilities.
 	Version CapabilityVersion
@@ -170,9 +165,15 @@ type TKASyncSendRequest struct {
 	// NodeKey is the client's current node key.
 	NodeKey key.NodePublic
 
+	// Head represents the node's head AUMHash (tka.Authority.Head) after
+	// applying any AUMs from the sync-offer response.
+	// It is encoded as tka.AUMHash.MarshalText.
+	Head string
+
 	// MissingAUMs encodes AUMs that the node believes the control plane
 	// is missing.
 	MissingAUMs []tkatype.MarshaledAUM
+
 	// Interactive is true if additional error checking should be performed as
 	// the request is on behalf of an interactive operation (e.g., an
 	// administrator publishing new changes) as opposed to an automatic
@@ -186,4 +187,30 @@ type TKASyncSendResponse struct {
 	// Head represents the control plane's head AUMHash (tka.Authority.Head),
 	// after applying the missing AUMs.
 	Head string
+}
+
+// TKADisableRequest disables network-lock across the tailnet using the
+// provided disablement secret.
+//
+// This is the request schema for a /tka/disable noise RPC.
+type TKADisableRequest struct {
+	// Version is the client's capabilities.
+	Version CapabilityVersion
+
+	// NodeKey is the client's current node key.
+	NodeKey key.NodePublic
+
+	// Head represents the node's head AUMHash (tka.Authority.Head).
+	// It is encoded as tka.AUMHash.MarshalText.
+	Head string
+
+	// DisablementSecret encodes the secret necessary to disable TKA.
+	DisablementSecret []byte
+}
+
+// TKADisableResponse is the JSON response from a /tka/disable RPC.
+// This schema describes the successful disablement of the tailnet's
+// key authority.
+type TKADisableResponse struct {
+	// Nothing. (yet?)
 }


### PR DESCRIPTION
 * Plumb disablement values through some of the internals of TKA enablement.
 * Transmit the node's TKA hash at the end of sync so the control plane understands each node's head.
 * Implement /machine/tka/disable RPC to actuate disablement on the control plane.
 * Send the TKA head hash in the map request. Changes to this value are communicated via sync-send; the map request is not restarted.

There is a partner PR for the control server I'll send shortly.