### PR TITLE
cmd/tsconnect: add README to generated NPM package

### DIFF
--- a/cmd/tsconnect/README.md
+++ b/cmd/tsconnect/README.md
@@ -31,7 +31,7 @@ By default the build output is placed in the `dist/` directory and embedded in t
 
 # Library / NPM Package
 
-The client is also available as an NPM package. To build it, run:
+The client is also available as [an NPM package](https://www.npmjs.com/package/@tailscale/connect). To build it, run:
 
 ```
 ./tool/go run ./cmd/tsconnect build-pkg

--- a/cmd/tsconnect/README.pkg.md
+++ b/cmd/tsconnect/README.pkg.md
@@ -1,0 +1,3 @@
+# @tailscale/connect
+
+NPM package that contains a WebAssembly-based Tailscale client, see [the `cmd/tsconnect` directory in the tailscale repo](https://github.com/tailscale/tailscale/tree/main/cmd/tsconnect#library--npm-package) for more details.

--- a/cmd/tsconnect/build-pkg.go
+++ b/cmd/tsconnect/build-pkg.go
@@ -27,7 +27,7 @@ func runBuildPkg() {
 		log.Fatalf("Linting failed: %v", err)
 	}
 
-	if err := cleanDir(*pkgDir, "package.json"); err != nil {
+	if err := cleanDir(*pkgDir); err != nil {
 		log.Fatalf("Cannot clean %s: %v", *pkgDir, err)
 	}
 
@@ -49,6 +49,10 @@ func runBuildPkg() {
 
 	if err := updateVersion(); err != nil {
 		log.Fatalf("Cannot update version: %v", err)
+	}
+
+	if err := copyReadme(); err != nil {
+		log.Fatalf("Cannot copy readme: %v", err)
 	}
 
 	log.Printf("Built package version %s", version.Long)
@@ -83,4 +87,12 @@ func updateVersion() error {
 	}
 
 	return os.WriteFile(path.Join(*pkgDir, "package.json"), packageJSONBytes, 0644)
+}
+
+func copyReadme() error {
+	readmeBytes, err := os.ReadFile("README.pkg.md")
+	if err != nil {
+		return fmt.Errorf("Could not read README.pkg.md: %w", err)
+	}
+	return os.WriteFile(path.Join(*pkgDir, "README.md"), readmeBytes, 0644)
 }


### PR DESCRIPTION
Makes the landing page at https://www.npmjs.com/package/@tailscale/connect look slightly nicer.

Fixes #5976