### PR TITLE
net/interfaces: don't call GetList in List.ForeachInterface

### DIFF
--- a/net/interfaces/interfaces.go
+++ b/net/interfaces/interfaces.go
@@ -232,10 +232,6 @@ func ForeachInterface(fn func(Interface, []netip.Prefix)) error {
 // all its addresses. The IPPrefix's IP is the IP address assigned to
 // the interface, and Bits are the subnet mask.
 func (ifaces List) ForeachInterface(fn func(Interface, []netip.Prefix)) error {
-	ifaces, err := GetList()
-	if err != nil {
-		return err
-	}
 	for _, iface := range ifaces {
 		addrs, err := iface.Addrs()
 		if err != nil {


### PR DESCRIPTION
It looks like this was left by mistake in 4a3e2842.

Change-Id: Ie4e3d5842548cd2e8533b3552298fb1ce9ba761a
Signed-off-by: Andrew Dunham <andrew@tailscale.com>