### PR TITLE
client/tailscale, tsnet, ipn/ipnlocal: prove nodekey ownership over noise

### DIFF
--- a/client/tailscale/tailscale.go
+++ b/client/tailscale/tailscale.go
@@ -18,9 +18,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
-
-	"tailscale.com/types/key"
 )
 
 // I_Acknowledge_This_API_Is_Unstable must be set true to use this package
@@ -90,29 +87,6 @@ func (ak APIKey) modifyRequest(req *http.Request) {
 func (c *Client) setAuth(r *http.Request) {
 	if c.auth != nil {
 		c.auth.modifyRequest(r)
-	}
-}
-
-// nodeKeyAuth is an AuthMethod for NewClient that authenticates requests
-// using a node key over the Noise protocol.
-type nodeKeyAuth key.NodePublic
-
-func (k nodeKeyAuth) modifyRequest(req *http.Request) {
-	// QueryEscape the node key since it has a colon in it.
-	nk := url.QueryEscape(key.NodePublic(k).String())
-	req.SetBasicAuth(nk, "")
-}
-
-// NewNoiseClient is a convenience method for instantiating a new Client
-// that uses the Noise protocol for authentication.
-//
-// tailnet is the globally unique identifier for a Tailscale network, such
-// as "example.com" or "user@gmail.com".
-func NewNoiseClient(tailnet string, noiseRoundTripper http.RoundTripper, nk key.NodePublic) *Client {
-	return &Client{
-		tailnet:    tailnet,
-		auth:       nodeKeyAuth(nk),
-		HTTPClient: &http.Client{Transport: noiseRoundTripper},
 	}
 }
 

--- a/control/controlclient/auto.go
+++ b/control/controlclient/auto.go
@@ -730,3 +730,13 @@ func (c *Auto) SetDNS(ctx context.Context, req *tailcfg.SetDNSRequest) error {
 func (c *Auto) DoNoiseRequest(req *http.Request) (*http.Response, error) {
 	return c.direct.DoNoiseRequest(req)
 }
+
+// GetSingleUseNoiseRoundTripper returns a RoundTripper that can be only be used
+// once (and must be used once) to make a single HTTP request over the noise
+// channel to the coordination server.
+//
+// In addition to the RoundTripper, it returns the HTTP/2 channel's early noise
+// payload, if any.
+func (c *Auto) GetSingleUseNoiseRoundTripper(ctx context.Context) (http.RoundTripper, *tailcfg.EarlyNoise, error) {
+	return c.direct.GetSingleUseNoiseRoundTripper(ctx)
+}

--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -1607,6 +1607,33 @@ func (c *Direct) DoNoiseRequest(req *http.Request) (*http.Response, error) {
 	return nc.Do(req)
 }
 
+// GetSingleUseNoiseRoundTripper returns a RoundTripper that can be only be used
+// once (and must be used once) to make a single HTTP request over the noise
+// channel to the coordination server.
+//
+// In addition to the RoundTripper, it returns the HTTP/2 channel's early noise
+// payload, if any.
+func (c *Direct) GetSingleUseNoiseRoundTripper(ctx context.Context) (http.RoundTripper, *tailcfg.EarlyNoise, error) {
+	nc, err := c.getNoiseClient()
+	if err != nil {
+		return nil, nil, err
+	}
+	for tries := 0; tries < 3; tries++ {
+		conn, err := nc.getConn(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+		earlyPayloadMaybeNil, err := conn.getEarlyPayload(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+		if conn.h2cc.ReserveNewRequest() {
+			return conn, earlyPayloadMaybeNil, nil
+		}
+	}
+	return nil, nil, errors.New("[unexpected] failed to reserve a request on a connection")
+}
+
 // doPingerPing sends a Ping to pr.IP using pinger, and sends an http request back to
 // pr.URL with ping response data.
 func doPingerPing(logf logger.Logf, c *http.Client, pr *tailcfg.PingRequest, pinger Pinger, pingType tailcfg.PingType) {

--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -493,11 +493,8 @@ func (s *Server) APIClient() (*tailscale.Client, error) {
 		return nil, err
 	}
 
-	nm := s.lb.NetMap()
-	if nm == nil {
-		return nil, errors.New("no netmap, not logged in?")
-	}
-	c := tailscale.NewNoiseClient(nm.Domain, s.lb.NoiseRoundTripper(), nm.NodeKey)
+	c := tailscale.NewClient("-", nil)
+	c.HTTPClient = &http.Client{Transport: s.lb.KeyProvingNoiseRoundTripper()}
 	return c, nil
 }
 

--- a/types/key/chal.go
+++ b/types/key/chal.go
@@ -82,3 +82,6 @@ func (k ChallengePublic) MarshalText() ([]byte, error) {
 func (k *ChallengePublic) UnmarshalText(b []byte) error {
 	return parseHex(k.k[:], mem.B(b), mem.S(chalPublicHexPrefix))
 }
+
+// IsZero reports whether k is the zero value.
+func (k ChallengePublic) IsZero() bool { return k == ChallengePublic{} }


### PR DESCRIPTION
Updates #5972
