### PR TITLE
tka, types/key: add NLPublic.KeyID

### DIFF
--- a/types/key/nl.go
+++ b/types/key/nl.go
@@ -125,3 +125,8 @@ func (k NLPublic) IsZero() bool {
 func (k NLPublic) Equal(other NLPublic) bool {
 	return subtle.ConstantTimeCompare(k.k[:], other.k[:]) == 1
 }
+
+// KeyID returns a tkatype.KeyID that can be used with a tka.Authority.
+func (k NLPublic) KeyID() tkatype.KeyID {
+	return k.k[:]
+}


### PR DESCRIPTION
This allows direct use of NLPublic with tka.Authority.KeyTrusted() and similar without using tricks like converting the return value of Verifier.