### PR TITLE
wgengine/netlog: embed the StableNodeID of the authoring node

### DIFF
--- a/types/netlogtype/netlogtype.go
+++ b/types/netlogtype/netlogtype.go
@@ -9,11 +9,17 @@ import (
 	"net/netip"
 	"time"
 
+	"tailscale.com/tailcfg"
 	"tailscale.com/types/ipproto"
 )
 
+// TODO(joetsai): Remove "omitempty" if "omitzero" is ever supported in both
+// the v1 and v2 "json" packages.
+
 // Message is the log message that captures network traffic.
 type Message struct {
+	NodeID tailcfg.StableNodeID `json:"nodeId"` // e.g., "n123456CNTRL"
+
 	Start time.Time `json:"start"` // inclusive
 	End   time.Time `json:"end"`   // inclusive
 

--- a/wgengine/netlog/logger_test.go
+++ b/wgengine/netlog/logger_test.go
@@ -58,7 +58,7 @@ func TestResourceCheck(t *testing.T) {
 	var l Logger
 	var d fakeDevice
 	for i := 0; i < 10; i++ {
-		must.Do(l.Startup(logtail.PrivateID{}, logtail.PrivateID{}, &d, nil))
+		must.Do(l.Startup("", logtail.PrivateID{}, logtail.PrivateID{}, &d, nil))
 		l.ReconfigRoutes(&router.Config{})
 		must.Do(l.Shutdown(context.Background()))
 		c.Assert(d.toggled, qt.Equals, 2*(i+1))

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -953,7 +953,7 @@ func (e *userspaceEngine) Reconfig(cfg *wgcfg.Config, routerCfg *router.Config, 
 		nid := cfg.NetworkLogging.NodeID
 		tid := cfg.NetworkLogging.DomainID
 		e.logf("wgengine: Reconfig: starting up network logger (node:%s tailnet:%s)", nid.Public(), tid.Public())
-		if err := e.networkLogger.Startup(nid, tid, e.tundev, e.magicConn); err != nil {
+		if err := e.networkLogger.Startup(cfg.NodeID, nid, tid, e.tundev, e.magicConn); err != nil {
 			e.logf("wgengine: Reconfig: error starting up network logger: %v", err)
 		}
 	}

--- a/wgengine/wgcfg/config.go
+++ b/wgengine/wgcfg/config.go
@@ -9,6 +9,7 @@ import (
 	"net/netip"
 
 	"tailscale.com/logtail"
+	"tailscale.com/tailcfg"
 	"tailscale.com/types/key"
 )
 
@@ -18,6 +19,7 @@ import (
 // It only supports the set of things Tailscale uses.
 type Config struct {
 	Name       string
+	NodeID     tailcfg.StableNodeID
 	PrivateKey key.NodePrivate
 	Addresses  []netip.Prefix
 	MTU        uint16

--- a/wgengine/wgcfg/nmcfg/nmcfg.go
+++ b/wgengine/wgcfg/nmcfg/nmcfg.go
@@ -62,6 +62,7 @@ func WGCfg(nm *netmap.NetworkMap, logf logger.Logf, flags netmap.WGConfigFlags, 
 
 	// Setup log IDs for data plane audit logging.
 	if nm.SelfNode != nil {
+		cfg.NodeID = nm.SelfNode.StableID
 		canNetworkLog := slices.Contains(nm.SelfNode.Capabilities, tailcfg.CapabilityDataPlaneAuditLogs)
 		if canNetworkLog && nm.SelfNode.DataPlaneAuditLogID != "" && nm.DomainAuditLogID != "" {
 			nodeID, errNode := logtail.ParsePrivateID(nm.SelfNode.DataPlaneAuditLogID)

--- a/wgengine/wgcfg/wgcfg_clone.go
+++ b/wgengine/wgcfg/wgcfg_clone.go
@@ -10,6 +10,7 @@ import (
 	"net/netip"
 
 	"tailscale.com/logtail"
+	"tailscale.com/tailcfg"
 	"tailscale.com/types/key"
 )
 
@@ -33,6 +34,7 @@ func (src *Config) Clone() *Config {
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _ConfigCloneNeedsRegeneration = Config(struct {
 	Name           string
+	NodeID         tailcfg.StableNodeID
 	PrivateKey     key.NodePrivate
 	Addresses      []netip.Prefix
 	MTU            uint16


### PR DESCRIPTION
This allows network messages to be annotated with which node it came from.

Signed-off-by: Joe Tsai <joetsai@digital-static.net>