### PR TITLE
control/controlhttp: remove ClientConn.UntrustedUpgradeHeaders

### DIFF
--- a/control/controlhttp/client_common.go
+++ b/control/controlhttp/client_common.go
@@ -5,8 +5,6 @@
 package controlhttp
 
 import (
-	"net/http"
-
 	"tailscale.com/control/controlbase"
 )
 
@@ -17,10 +15,4 @@ import (
 type ClientConn struct {
 	// Conn is the noise connection.
 	*controlbase.Conn
-
-	// UntrustedUpgradeHeaders are the HTTP headers seen in the
-	// 101 Switching Protocols upgrade response. They may be nil
-	// or even might've been tampered with by a middlebox.
-	// They should not be trusted.
-	UntrustedUpgradeHeaders http.Header
 }

--- a/control/controlhttp/client_js.go
+++ b/control/controlhttp/client_js.go
@@ -46,7 +46,7 @@ func (d *Dialer) Dial(ctx context.Context) (*ClientConn, error) {
 			handshakeHeaderName: []string{base64.StdEncoding.EncodeToString(init)},
 		}.Encode(),
 	}
-	wsConn, httpRes, err := websocket.Dial(ctx, wsURL.String(), &websocket.DialOptions{
+	wsConn, _, err := websocket.Dial(ctx, wsURL.String(), &websocket.DialOptions{
 		Subprotocols: []string{upgradeHeaderValue},
 	})
 	if err != nil {
@@ -58,8 +58,5 @@ func (d *Dialer) Dial(ctx context.Context) (*ClientConn, error) {
 		netConn.Close()
 		return nil, err
 	}
-	return &ClientConn{
-		Conn:                    cbConn,
-		UntrustedUpgradeHeaders: httpRes.Header,
-	}, nil
+	return &ClientConn{Conn: cbConn}, nil
 }


### PR DESCRIPTION
It was just added and unreleased but we've decided to go a different route.

Details are in 5e9e57ecf531f.

Updates #5972