### PR TITLE
wgengine: perform router reconfig for netlog-only changes

### DIFF
--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -956,6 +956,7 @@ func (e *userspaceEngine) Reconfig(cfg *wgcfg.Config, routerCfg *router.Config, 
 		if err := e.networkLogger.Startup(cfg.NodeID, nid, tid, e.tundev, e.magicConn); err != nil {
 			e.logf("wgengine: Reconfig: error starting up network logger: %v", err)
 		}
+		e.networkLogger.ReconfigRoutes(routerCfg)
 	}
 
 	if routerChanged {


### PR DESCRIPTION
If the network logging configruation changes (and nothing else) we will tear down the network logger and start it back up. However, doing so will lose the router configuration state. Manually reconfigure it with the routing state.

Signed-off-by: Joe Tsai <joetsai@digital-static.net>