### PR TITLE
net/dns: getting base DNS config is not supported on macOS

### DIFF
--- a/net/dns/manager_darwin.go
+++ b/net/dns/manager_darwin.go
@@ -6,7 +6,6 @@ package dns
 
 import (
 	"bytes"
-	"errors"
 	"os"
 
 	"go4.org/mem"
@@ -85,7 +84,7 @@ func (c *darwinConfigurator) SetDNS(cfg OSConfig) error {
 }
 
 func (c *darwinConfigurator) GetBaseConfig() (OSConfig, error) {
-	return OSConfig{}, errors.New("[unexpected] unreachable")
+	return OSConfig{}, ErrGetBaseConfigNotSupported
 }
 
 const macResolverFileHeader = "# Added by tailscaled\n"


### PR DESCRIPTION
Instead of returning a custom error, use ErrGetBaseConfigNotSupported that seems to be intended for this use case. This fixes DNS resolution on macOS clients compiled from source.

Signed-off-by: Anton Tolchanov <anton@tailscale.com>