### PR TITLE
cmd/tailscale/cli: make set without args print usage

### DIFF
--- a/cmd/tailscale/cli/set.go
+++ b/cmd/tailscale/cli/set.go
@@ -110,8 +110,7 @@ func runSet(ctx context.Context, args []string) (retErr error) {
 	})
 
 	if maskedPrefs.IsEmpty() {
-		println("no flags specified")
-		return nil
+		return flag.ErrHelp
 	}
 
 	if maskedPrefs.RunSSHSet {


### PR DESCRIPTION
Make "tailscale set" by itself be equivalent to "tailscale set -h" rather than just say "you did it wrong" and make people do another -h step.
