### PR TITLE
client/tailscale/apitype, tailcfg: delete never used mysterious PerDomain field

### DIFF
--- a/client/tailscale/apitype/controltype.go
+++ b/client/tailscale/apitype/controltype.go
@@ -11,7 +11,6 @@ type DNSConfig struct {
 	Domains           []string                 `json:"domains"`
 	Nameservers       []string                 `json:"nameservers"`
 	Proxied           bool                     `json:"proxied"`
-	PerDomain         bool                     `json:",omitempty"`
 }
 
 type DNSResolver struct {

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -1122,9 +1122,6 @@ type DNSConfig struct {
 	// Nameservers are the IP addresses of the nameservers to use.
 	Nameservers []netip.Addr `json:",omitempty"`
 
-	// PerDomain is not set by the control server, and does nothing.
-	PerDomain bool `json:",omitempty"`
-
 	// CertDomains are the set of DNS names for which the control
 	// plane server will assist with provisioning TLS
 	// certificates. See SetDNSRequest, which can be used to

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -239,7 +239,6 @@ var _DNSConfigCloneNeedsRegeneration = DNSConfig(struct {
 	Domains             []string
 	Proxied             bool
 	Nameservers         []netip.Addr
-	PerDomain           bool
 	CertDomains         []string
 	ExtraRecords        []DNSRecord
 	ExitNodeFilteredSet []string

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -515,7 +515,6 @@ func (v DNSConfigView) FallbackResolvers() views.SliceView[*dnstype.Resolver, dn
 func (v DNSConfigView) Domains() views.Slice[string]         { return views.SliceOf(v.ж.Domains) }
 func (v DNSConfigView) Proxied() bool                        { return v.ж.Proxied }
 func (v DNSConfigView) Nameservers() views.Slice[netip.Addr] { return views.SliceOf(v.ж.Nameservers) }
-func (v DNSConfigView) PerDomain() bool                      { return v.ж.PerDomain }
 func (v DNSConfigView) CertDomains() views.Slice[string]     { return views.SliceOf(v.ж.CertDomains) }
 func (v DNSConfigView) ExtraRecords() views.Slice[DNSRecord] { return views.SliceOf(v.ж.ExtraRecords) }
 func (v DNSConfigView) ExitNodeFilteredSet() views.Slice[string] {
@@ -530,7 +529,6 @@ var _DNSConfigViewNeedsRegeneration = DNSConfig(struct {
 	Domains             []string
 	Proxied             bool
 	Nameservers         []netip.Addr
-	PerDomain           bool
 	CertDomains         []string
 	ExtraRecords        []DNSRecord
 	ExitNodeFilteredSet []string


### PR DESCRIPTION
It does nothing and never did and I don't think anybody remembers what the original goal for it was.

Updates #5229 (fixes, but need to clean it up in another repo too)
