### PR TITLE
cmd/tsconnect: fix null pointer dereference when DNS lookups fail

### DIFF
--- a/cmd/tsconnect/wasm/wasm_js.go
+++ b/cmd/tsconnect/wasm/wasm_js.go
@@ -463,6 +463,10 @@ func (s *jsSSHSession) Run() {
 }
 
 func (s *jsSSHSession) Close() error {
+	if s.session == nil {
+		// We never had a chance to open the session, ignore the close request.
+		return nil
+	}
 	return s.session.Close()
 }
 


### PR DESCRIPTION
If we never had a chance to open the SSH session we should not try to close it.

Fixes #6089