### PR TITLE
cmd/tailscale,ipn: implement lock sign command

### DIFF
--- a/client/tailscale/localclient.go
+++ b/client/tailscale/localclient.go
@@ -36,6 +36,7 @@ import (
 	"tailscale.com/safesocket"
 	"tailscale.com/tailcfg"
 	"tailscale.com/tka"
+	"tailscale.com/types/key"
 )
 
 // defaultLocalClient is the default LocalClient when using the legacy
@@ -825,6 +826,25 @@ func (lc *LocalClient) NetworkLockModify(ctx context.Context, addKeys, removeKey
 		return nil, err
 	}
 	return pr, nil
+}
+
+// NetworkLockSign signs the specified node-key and transmits that signature to the control plane.
+// rotationPublic, if specified, must be an ed25519 public key.
+func (lc *LocalClient) NetworkLockSign(ctx context.Context, nodeKey key.NodePublic, rotationPublic []byte) error {
+	var b bytes.Buffer
+	type signRequest struct {
+		NodeKey        key.NodePublic
+		RotationPublic []byte
+	}
+
+	if err := json.NewEncoder(&b).Encode(signRequest{NodeKey: nodeKey, RotationPublic: rotationPublic}); err != nil {
+		return err
+	}
+
+	if _, err := lc.send(ctx, "POST", "/localapi/v0/tka/sign", 200, &b); err != nil {
+		return fmt.Errorf("error: %w", err)
+	}
+	return nil
 }
 
 // tailscaledConnectHint gives a little thing about why tailscaled (or

--- a/cmd/tailscale/cli/network-lock.go
+++ b/cmd/tailscale/cli/network-lock.go
@@ -26,6 +26,7 @@ var netlockCmd = &ffcli.Command{
 		nlStatusCmd,
 		nlAddCmd,
 		nlRemoveCmd,
+		nlSignCmd,
 	},
 	Exec: runNetworkLockStatus,
 }
@@ -162,4 +163,28 @@ func runNetworkLockModify(ctx context.Context, addArgs, removeArgs []string) err
 
 	fmt.Printf("Status: %+v\n\n", status)
 	return nil
+}
+
+var nlSignCmd = &ffcli.Command{
+	Name:       "sign",
+	ShortUsage: "sign <node-key>",
+	ShortHelp:  "Signs a node-key and transmits that signature to the control plane",
+	Exec:       runNetworkLockSign,
+}
+
+// TODO(tom): Implement specifying the rotation key for the signature.
+func runNetworkLockSign(ctx context.Context, args []string) error {
+	switch len(args) {
+	case 0:
+		return errors.New("expected node-key as second argument")
+	case 1:
+		var nodeKey key.NodePublic
+		if err := nodeKey.UnmarshalText([]byte(args[0])); err != nil {
+			return fmt.Errorf("decoding node-key: %w", err)
+		}
+
+		return localClient.NetworkLockSign(ctx, nodeKey, nil)
+	default:
+		return errors.New("expected a single node-key as only argument")
+	}
 }

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -34,6 +34,7 @@ import (
 	"tailscale.com/net/netutil"
 	"tailscale.com/tailcfg"
 	"tailscale.com/tka"
+	"tailscale.com/types/key"
 	"tailscale.com/types/logger"
 	"tailscale.com/util/clientmetric"
 	"tailscale.com/util/mak"
@@ -75,6 +76,7 @@ var handler = map[string]localAPIHandler{
 	"status":                  (*Handler).serveStatus,
 	"tka/init":                (*Handler).serveTKAInit,
 	"tka/modify":              (*Handler).serveTKAModify,
+	"tka/sign":                (*Handler).serveTKASign,
 	"tka/status":              (*Handler).serveTKAStatus,
 	"upload-client-metrics":   (*Handler).serveUploadClientMetrics,
 	"whois":                   (*Handler).serveWhoIs,
@@ -919,6 +921,34 @@ func (h *Handler) serveTKAStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(j)
+}
+
+func (h *Handler) serveTKASign(w http.ResponseWriter, r *http.Request) {
+	if !h.PermitRead {
+		http.Error(w, "lock status access denied", http.StatusForbidden)
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "use POST", http.StatusMethodNotAllowed)
+		return
+	}
+
+	type signRequest struct {
+		NodeKey        key.NodePublic
+		RotationPublic []byte
+	}
+	var req signRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+
+	if err := h.b.NetworkLockSign(req.NodeKey, req.RotationPublic); err != nil {
+		http.Error(w, "signing failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
 
 func (h *Handler) serveTKAInit(w http.ResponseWriter, r *http.Request) {

--- a/tailcfg/tka.go
+++ b/tailcfg/tka.go
@@ -214,3 +214,23 @@ type TKADisableRequest struct {
 type TKADisableResponse struct {
 	// Nothing. (yet?)
 }
+
+// TKASubmitSignatureRequest transmits a node-key signature to the control plane.
+//
+// This is the request schema for a /tka/sign noise RPC.
+type TKASubmitSignatureRequest struct {
+	// Version is the client's capabilities.
+	Version CapabilityVersion
+
+	// NodeKey is the client's current node key. The node-key which
+	// is being signed is embedded in Signature.
+	NodeKey key.NodePublic
+
+	// Signature encodes the node-key signature being submitted.
+	Signature tkatype.MarshaledSignature
+}
+
+// TKASubmitSignatureResponse is the JSON response from a /tka/sign RPC.
+type TKASubmitSignatureResponse struct {
+	// Nothing. (yet?)
+}


### PR DESCRIPTION
This implements `tailscale lock sign <node-key>`.