### PR TITLE
wgengine: respect --no-logs-no-support flag for network logging

### DIFF
--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -887,6 +887,9 @@ func (e *userspaceEngine) Reconfig(cfg *wgcfg.Config, routerCfg *router.Config, 
 	netLogIDsWasValid := !oldLogIDs.NodeID.IsZero() && !oldLogIDs.DomainID.IsZero()
 	netLogIDsChanged := netLogIDsNowValid && netLogIDsWasValid && newLogIDs != oldLogIDs
 	netLogRunning := netLogIDsNowValid && !routerCfg.Equal(&router.Config{})
+	if envknob.NoLogsNoSupport() {
+		netLogRunning = false
+	}
 
 	// TODO(bradfitz,danderson): maybe delete this isDNSIPOverTailscale
 	// field and delete the resolver.ForwardLinkSelector hook and


### PR DESCRIPTION
In the future this will cause a node to be unable to join the tailnet if network logging is enabled.

Signed-off-by: Joe Tsai <joetsai@digital-static.net>