### PR TITLE
control/controlclient: export NoiseClient

### DIFF
--- a/control/controlclient/noise_test.go
+++ b/control/controlclient/noise_test.go
@@ -75,7 +75,7 @@ func (tt noiseClientTest) run(t *testing.T) {
 	defer hs.Close()
 
 	dialer := new(tsdial.Dialer)
-	nc, err := newNoiseClient(clientPrivate, serverPrivate.Public(), hs.URL, dialer, nil)
+	nc, err := NewNoiseClient(clientPrivate, serverPrivate.Public(), hs.URL, dialer, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This allows reusing the NoiseClient in other repos without having to reimplement the earlyPayload logic.

Signed-off-by: Maisem Ali <maisem@tailscale.com>