### PR TITLE
cmd/tailscale,ipn: minor fixes to tailscale lock commands

### DIFF
--- a/ipn/ipnstate/ipnstate.go
+++ b/ipn/ipnstate/ipnstate.go
@@ -67,6 +67,13 @@ type Status struct {
 	User map[tailcfg.UserID]tailcfg.UserProfile
 }
 
+// TKAKey describes a key trusted by network lock.
+type TKAKey struct {
+	Key      key.NLPublic
+	Metadata map[string]string
+	Votes    uint
+}
+
 // NetworkLockStatus represents whether network-lock is enabled,
 // along with details about the locally-known state of the tailnet
 // key authority.
@@ -78,8 +85,19 @@ type NetworkLockStatus struct {
 	// if network lock is not enabled.
 	Head *[32]byte
 
-	// PublicKey describes the nodes' network-lock public key.
+	// PublicKey describes the node's network-lock public key.
 	PublicKey key.NLPublic
+
+	// NodeKey describes the node's current node-key. This field is not
+	// populated if the node is not operating (i.e. waiting for a login).
+	NodeKey *key.NodePublic
+
+	// NodeKeySigned is true if our node is authorized by network-lock.
+	NodeKeySigned bool
+
+	// TrustedKeys describes the keys currently trusted to make changes
+	// to network-lock.
+	TrustedKeys []TKAKey
 }
 
 // TailnetStatus is information about a Tailscale network ("tailnet").

--- a/tka/key.go
+++ b/tka/key.go
@@ -85,6 +85,17 @@ func (k Key) ID() tkatype.KeyID {
 	}
 }
 
+// Ed25519 returns the ed25519 public key encoded by Key. An error is
+// returned for keys which do not represent ed25519 public keys.
+func (k Key) Ed25519() (ed25519.PublicKey, error) {
+	switch k.Kind {
+	case Key25519:
+		return ed25519.PublicKey(k.Public), nil
+	default:
+		return nil, fmt.Errorf("key is of type %v, not ed25519", k.Kind)
+	}
+}
+
 const maxMetaBytes = 512
 
 func (k Key) StaticValidate() error {

--- a/tka/tka.go
+++ b/tka/tka.go
@@ -705,3 +705,12 @@ func (a *Authority) KeyTrusted(keyID tkatype.KeyID) bool {
 	_, err := a.state.GetKey(keyID)
 	return err == nil
 }
+
+// Keys returns the set of keys trusted by the tailnet key authority.
+func (a *Authority) Keys() []Key {
+	out := make([]Key, len(a.state.Keys))
+	for i := range a.state.Keys {
+		out[i] = a.state.Keys[i].Clone()
+	}
+	return out
+}

--- a/types/key/nl.go
+++ b/types/key/nl.go
@@ -100,6 +100,17 @@ type NLPublic struct {
 	k [ed25519.PublicKeySize]byte
 }
 
+// NLPublicFromEd25519Unsafe converts an ed25519 public key into
+// a type of NLPublic.
+//
+// New uses of this function should be avoided, as its possible to
+// accidentally construct an NLPublic from a non network-lock key.
+func NLPublicFromEd25519Unsafe(public ed25519.PublicKey) NLPublic {
+	var out NLPublic
+	copy(out.k[:], public)
+	return out
+}
+
 // MarshalText implements encoding.TextUnmarshaler.
 func (k *NLPublic) UnmarshalText(b []byte) error {
 	return parseHex(k.k[:], mem.B(b), mem.S(nlPublicHexPrefix))


### PR DESCRIPTION
 * Fix broken add/remove key commands
 * Make lock status display whether the node is signed