### PR TITLE
all: remove old +build tags

### DIFF
--- a/client/tailscale/acl.go
+++ b/client/tailscale/acl.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build go1.19
-// +build go1.19
 
 package tailscale
 

--- a/client/tailscale/devices.go
+++ b/client/tailscale/devices.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build go1.19
-// +build go1.19
 
 package tailscale
 

--- a/client/tailscale/dns.go
+++ b/client/tailscale/dns.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build go1.19
-// +build go1.19
 
 package tailscale
 

--- a/client/tailscale/localclient.go
+++ b/client/tailscale/localclient.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build go1.19
-// +build go1.19
 
 package tailscale
 

--- a/client/tailscale/required_version.go
+++ b/client/tailscale/required_version.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !go1.19
-// +build !go1.19
 
 package tailscale
 

--- a/client/tailscale/routes.go
+++ b/client/tailscale/routes.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build go1.19
-// +build go1.19
 
 package tailscale
 

--- a/client/tailscale/tailnet.go
+++ b/client/tailscale/tailnet.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build go1.19
-// +build go1.19
 
 package tailscale
 

--- a/client/tailscale/tailscale.go
+++ b/client/tailscale/tailscale.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build go1.19
-// +build go1.19
 
 // Package tailscale contains Go clients for the Tailscale Local API and
 // Tailscale control plane API.

--- a/cmd/containerboot/kube.go
+++ b/cmd/containerboot/kube.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package main
 

--- a/cmd/containerboot/main.go
+++ b/cmd/containerboot/main.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 // The containerboot binary is a wrapper for starting tailscaled in a
 // container. It handles reading the desired mode of operation out of

--- a/cmd/tailscale/cli/diag.go
+++ b/cmd/tailscale/cli/diag.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux || windows || darwin
-// +build linux windows darwin
 
 package cli
 

--- a/cmd/tailscale/cli/diag_other.go
+++ b/cmd/tailscale/cli/diag_other.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !linux && !windows && !darwin
-// +build !linux,!windows,!darwin
 
 package cli
 

--- a/cmd/tailscale/cli/ssh_exec.go
+++ b/cmd/tailscale/cli/ssh_exec.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !js && !windows
-// +build !js,!windows
 
 package cli
 

--- a/cmd/tailscale/cli/ssh_unix.go
+++ b/cmd/tailscale/cli/ssh_unix.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !js && !windows
-// +build !js,!windows
 
 package cli
 

--- a/cmd/tailscaled/debug.go
+++ b/cmd/tailscaled/debug.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build go1.19
-// +build go1.19
 
 package main
 

--- a/cmd/tailscaled/install_darwin.go
+++ b/cmd/tailscaled/install_darwin.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build go1.19
-// +build go1.19
 
 package main
 

--- a/cmd/tailscaled/install_windows.go
+++ b/cmd/tailscaled/install_windows.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build go1.19
-// +build go1.19
 
 package main
 

--- a/cmd/tailscaled/proxy.go
+++ b/cmd/tailscaled/proxy.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build go1.19
-// +build go1.19
 
 // HTTP proxy code
 

--- a/cmd/tailscaled/required_version.go
+++ b/cmd/tailscaled/required_version.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !go1.19
-// +build !go1.19
 
 package main
 

--- a/cmd/tailscaled/ssh.go
+++ b/cmd/tailscaled/ssh.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux || darwin
-// +build linux darwin
 
 package main
 

--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build go1.19
-// +build go1.19
 
 // The tailscaled program is the Tailscale client daemon. It's configured
 // and controlled via the tailscale CLI program.

--- a/cmd/tailscaled/tailscaled_bird.go
+++ b/cmd/tailscaled/tailscaled_bird.go
@@ -3,8 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build go1.19 && (linux || darwin || freebsd || openbsd)
-// +build go1.19
-// +build linux darwin freebsd openbsd
 
 package main
 

--- a/cmd/tailscaled/tailscaled_notwindows.go
+++ b/cmd/tailscaled/tailscaled_notwindows.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows && go1.19
-// +build !windows,go1.19
 
 package main // import "tailscale.com/cmd/tailscaled"
 

--- a/cmd/tailscaled/tailscaled_windows.go
+++ b/cmd/tailscaled/tailscaled_windows.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build go1.19
-// +build go1.19
 
 package main // import "tailscale.com/cmd/tailscaled"
 

--- a/cmd/tailscaled/with_cli.go
+++ b/cmd/tailscaled/with_cli.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ts_include_cli
-// +build ts_include_cli
 
 package main
 

--- a/cmd/tsshd/tsshd.go
+++ b/cmd/tsshd/tsshd.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 // The tsshd binary was an experimental SSH server that accepts connections
 // from anybody on the same Tailscale network.

--- a/control/controlclient/sign_supported.go
+++ b/control/controlclient/sign_supported.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build windows && cgo
-// +build windows,cgo
 
 // darwin,cgo is also supported by certstore but machineCertificateSubject will
 // need to be loaded by a different mechanism, so this is not currently enabled

--- a/control/controlclient/sign_supported_test.go
+++ b/control/controlclient/sign_supported_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build windows && cgo
-// +build windows,cgo
 
 package controlclient
 

--- a/control/controlclient/sign_unsupported.go
+++ b/control/controlclient/sign_unsupported.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows || !cgo
-// +build !windows !cgo
 
 package controlclient
 

--- a/control/controlhttp/client.go
+++ b/control/controlhttp/client.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !js
-// +build !js
 
 // Package controlhttp implements the Tailscale 2021 control protocol
 // base transport over HTTP.

--- a/derp/derp_server_default.go
+++ b/derp/derp_server_default.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !linux
-// +build !linux
 
 package derp
 

--- a/derp/derphttp/websocket.go
+++ b/derp/derphttp/websocket.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux || js
-// +build linux js
 
 package derphttp
 

--- a/disco/disco_fuzzer.go
+++ b/disco/disco_fuzzer.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 //go:build gofuzz
-// +build gofuzz
 
 package disco
 

--- a/hostinfo/hostinfo_darwin.go
+++ b/hostinfo/hostinfo_darwin.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build darwin
-// +build darwin
 
 package hostinfo
 

--- a/hostinfo/hostinfo_freebsd.go
+++ b/hostinfo/hostinfo_freebsd.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build freebsd
-// +build freebsd
 
 package hostinfo
 

--- a/hostinfo/hostinfo_linux.go
+++ b/hostinfo/hostinfo_linux.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux && !android
-// +build linux,!android
 
 package hostinfo
 

--- a/hostinfo/hostinfo_linux_test.go
+++ b/hostinfo/hostinfo_linux_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux && !android
-// +build linux,!android
 
 package hostinfo
 

--- a/internal/tooldeps/tooldeps.go
+++ b/internal/tooldeps/tooldeps.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build for_go_mod_tidy_only
-// +build for_go_mod_tidy_only
 
 package tooldeps
 

--- a/ipn/ipnlocal/peerapi_h2c.go
+++ b/ipn/ipnlocal/peerapi_h2c.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !ios && !android && !js
-// +build !ios,!android,!js
 
 package ipnlocal
 

--- a/ipn/ipnlocal/peerapi_macios_ext.go
+++ b/ipn/ipnlocal/peerapi_macios_ext.go
@@ -3,8 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ts_macext && (darwin || ios)
-// +build ts_macext
-// +build darwin ios
 
 package ipnlocal
 

--- a/ipn/ipnlocal/ssh.go
+++ b/ipn/ipnlocal/ssh.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux || (darwin && !ios)
-// +build linux darwin,!ios
 
 package ipnlocal
 

--- a/ipn/ipnlocal/ssh_test.go
+++ b/ipn/ipnlocal/ssh_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux || (darwin && !ios)
-// +build linux darwin,!ios
 
 package ipnlocal
 

--- a/ipn/ipnserver/proxyconnect.go
+++ b/ipn/ipnserver/proxyconnect.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !js
-// +build !js
 
 package ipnserver
 

--- a/ipn/localapi/cert.go
+++ b/ipn/localapi/cert.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !ios && !android && !js
-// +build !ios,!android,!js
 
 package localapi
 

--- a/ipn/localapi/cert_test.go
+++ b/ipn/localapi/cert_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !ios && !android && !js
-// +build !ios,!android,!js
 
 package localapi
 

--- a/ipn/localapi/disabled_stubs.go
+++ b/ipn/localapi/disabled_stubs.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ios || android || js
-// +build ios android js
 
 package localapi
 

--- a/ipn/localapi/profile.go
+++ b/ipn/localapi/profile.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !ios && !android && !js
-// +build !ios,!android,!js
 
 // We don't include it on mobile where we're more memory constrained and
 // there's no CLI to get at the results anyway.

--- a/ipn/store/awsstore/store_aws.go
+++ b/ipn/store/awsstore/store_aws.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux && !ts_omit_aws
-// +build linux,!ts_omit_aws
 
 // Package awsstore contains an ipn.StateStore implementation using AWS SSM.
 package awsstore

--- a/ipn/store/awsstore/store_aws_stub.go
+++ b/ipn/store/awsstore/store_aws_stub.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !linux || ts_omit_aws
-// +build !linux ts_omit_aws
 
 package awsstore
 

--- a/ipn/store/awsstore/store_aws_test.go
+++ b/ipn/store/awsstore/store_aws_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package awsstore
 

--- a/log/logheap/logheap.go
+++ b/log/logheap/logheap.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !js
-// +build !js
 
 // Package logheap logs a heap pprof profile.
 package logheap

--- a/logtail/filch/filch_unix.go
+++ b/logtail/filch/filch_unix.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows && !js
-// +build !windows,!js
 
 package filch
 

--- a/metrics/fds_notlinux.go
+++ b/metrics/fds_notlinux.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !linux
-// +build !linux
 
 package metrics
 

--- a/net/dns/debian_resolvconf.go
+++ b/net/dns/debian_resolvconf.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux || freebsd || openbsd
-// +build linux freebsd openbsd
 
 package dns
 

--- a/net/dns/flush_default.go
+++ b/net/dns/flush_default.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows
-// +build !windows
 
 package dns
 

--- a/net/dns/ini.go
+++ b/net/dns/ini.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build windows
-// +build windows
 
 package dns
 

--- a/net/dns/ini_test.go
+++ b/net/dns/ini_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build windows
-// +build windows
 
 package dns
 

--- a/net/dns/manager_default.go
+++ b/net/dns/manager_default.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !linux && !freebsd && !openbsd && !windows && !darwin
-// +build !linux,!freebsd,!openbsd,!windows,!darwin
 
 package dns
 

--- a/net/dns/nm.go
+++ b/net/dns/nm.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package dns
 

--- a/net/dns/openresolv.go
+++ b/net/dns/openresolv.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux || freebsd || openbsd
-// +build linux freebsd openbsd
 
 package dns
 

--- a/net/dns/resolvconf.go
+++ b/net/dns/resolvconf.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux || freebsd || openbsd
-// +build linux freebsd openbsd
 
 package dns
 

--- a/net/dns/resolvd.go
+++ b/net/dns/resolvd.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build openbsd
-// +build openbsd
 
 package dns
 

--- a/net/dns/resolved.go
+++ b/net/dns/resolved.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package dns
 

--- a/net/dns/resolver/macios_ext.go
+++ b/net/dns/resolver/macios_ext.go
@@ -3,8 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ts_macext && (darwin || ios)
-// +build ts_macext
-// +build darwin ios
 
 package resolver
 

--- a/net/dnsfallback/update-dns-fallbacks.go
+++ b/net/dnsfallback/update-dns-fallbacks.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/net/interfaces/interfaces_bsd.go
+++ b/net/interfaces/interfaces_bsd.go
@@ -6,7 +6,6 @@
 // BSD systems (e.g. OpenBSD) but has not been tested.
 
 //go:build darwin || freebsd
-// +build darwin freebsd
 
 package interfaces
 

--- a/net/interfaces/interfaces_default_route_test.go
+++ b/net/interfaces/interfaces_default_route_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux || (darwin && !ts_macext)
-// +build linux darwin,!ts_macext
 
 package interfaces
 

--- a/net/interfaces/interfaces_defaultrouteif_todo.go
+++ b/net/interfaces/interfaces_defaultrouteif_todo.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !linux && !windows && !darwin && !freebsd
-// +build !linux,!windows,!darwin,!freebsd
 
 package interfaces
 

--- a/net/interfaces/interfaces_freebsd.go
+++ b/net/interfaces/interfaces_freebsd.go
@@ -5,7 +5,6 @@
 // This might work on other BSDs, but only tested on FreeBSD.
 
 //go:build freebsd
-// +build freebsd
 
 package interfaces
 

--- a/net/netns/netns_android.go
+++ b/net/netns/netns_android.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build android
-// +build android
 
 package netns
 

--- a/net/netns/netns_darwin_tailscaled.go
+++ b/net/netns/netns_darwin_tailscaled.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build darwin && !ts_macext
-// +build darwin,!ts_macext
 
 package netns
 

--- a/net/netns/netns_default.go
+++ b/net/netns/netns_default.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build (!linux && !windows && !darwin) || (darwin && ts_macext)
-// +build !linux,!windows,!darwin darwin,ts_macext
 
 package netns
 

--- a/net/netns/netns_linux.go
+++ b/net/netns/netns_linux.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux && !android
-// +build linux,!android
 
 package netns
 

--- a/net/netns/netns_macios.go
+++ b/net/netns/netns_macios.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build darwin || ios
-// +build darwin ios
 
 package netns
 

--- a/net/netns/socks.go
+++ b/net/netns/socks.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !ios && !js
-// +build !ios,!js
 
 package netns
 

--- a/net/netstat/netstat_noimpl.go
+++ b/net/netstat/netstat_noimpl.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows
-// +build !windows
 
 package netstat
 

--- a/net/portmapper/disabled_stubs.go
+++ b/net/portmapper/disabled_stubs.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build js
-// +build js
 
 package portmapper
 

--- a/net/portmapper/upnp.go
+++ b/net/portmapper/upnp.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !js
-// +build !js
 
 // (no raw sockets in JS/WASM)
 

--- a/net/routetable/routetable_bsd.go
+++ b/net/routetable/routetable_bsd.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build darwin || freebsd
-// +build darwin freebsd
 
 package routetable
 

--- a/net/routetable/routetable_bsd_test.go
+++ b/net/routetable/routetable_bsd_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build darwin || freebsd
-// +build darwin freebsd
 
 package routetable
 

--- a/net/routetable/routetable_darwin.go
+++ b/net/routetable/routetable_darwin.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build darwin
-// +build darwin
 
 package routetable
 

--- a/net/routetable/routetable_freebsd.go
+++ b/net/routetable/routetable_freebsd.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build freebsd
-// +build freebsd
 
 package routetable
 

--- a/net/routetable/routetable_linux.go
+++ b/net/routetable/routetable_linux.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package routetable
 

--- a/net/routetable/routetable_linux_test.go
+++ b/net/routetable/routetable_linux_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package routetable
 

--- a/net/stun/stun_fuzzer.go
+++ b/net/stun/stun_fuzzer.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 //go:build gofuzz
-// +build gofuzz
 
 package stun
 

--- a/net/tlsdial/deps_test.go
+++ b/net/tlsdial/deps_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build for_go_mod_tidy_only
-// +build for_go_mod_tidy_only
 
 package tlsdial
 

--- a/net/tsdial/peerapi_macios_ext.go
+++ b/net/tsdial/peerapi_macios_ext.go
@@ -7,8 +7,6 @@
 // and System Extension). It's not used on tailscaled-on-macOS.
 
 //go:build ts_macext && (darwin || ios)
-// +build ts_macext
-// +build darwin ios
 
 package tsdial
 

--- a/net/tshttpproxy/tshttpproxy_future.go
+++ b/net/tshttpproxy/tshttpproxy_future.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build tailscale_go
-// +build tailscale_go
 
 // We want to use https://github.com/golang/go/issues/41048 but it's only in the
 // Tailscale Go tree for now. Hence the build tag above.

--- a/net/tshttpproxy/tshttpproxy_linux.go
+++ b/net/tshttpproxy/tshttpproxy_linux.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package tshttpproxy
 

--- a/net/tshttpproxy/tshttpproxy_synology.go
+++ b/net/tshttpproxy/tshttpproxy_synology.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package tshttpproxy
 

--- a/net/tshttpproxy/tshttpproxy_synology_test.go
+++ b/net/tshttpproxy/tshttpproxy_synology_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package tshttpproxy
 

--- a/net/tstun/ifstatus_noop.go
+++ b/net/tstun/ifstatus_noop.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows
-// +build !windows
 
 package tstun
 

--- a/net/tstun/linkattrs_notlinux.go
+++ b/net/tstun/linkattrs_notlinux.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !linux
-// +build !linux
 
 package tstun
 

--- a/net/tstun/tap_unsupported.go
+++ b/net/tstun/tap_unsupported.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !linux
-// +build !linux
 
 package tstun
 

--- a/net/tstun/tun.go
+++ b/net/tstun/tun.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !js
-// +build !js
 
 // Package tun creates a tuntap device, working around OS-specific
 // quirks if necessary.

--- a/net/tstun/tun_macos.go
+++ b/net/tstun/tun_macos.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build darwin && !ios
-// +build darwin,!ios
 
 package tstun
 

--- a/net/tstun/tun_notwindows.go
+++ b/net/tstun/tun_notwindows.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows
-// +build !windows
 
 package tstun
 

--- a/paths/paths_unix.go
+++ b/paths/paths_unix.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows && !js
-// +build !windows,!js
 
 package paths
 

--- a/portlist/netstat.go
+++ b/portlist/netstat.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !ios && !js
-// +build !ios,!js
 
 package portlist
 

--- a/portlist/netstat_exec.go
+++ b/portlist/netstat_exec.go
@@ -3,9 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build (windows || freebsd || openbsd || darwin) && !ios && !js
-// +build windows freebsd openbsd darwin
-// +build !ios
-// +build !js
 
 package portlist
 

--- a/portlist/netstat_test.go
+++ b/portlist/netstat_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !ios && !js
-// +build !ios,!js
 
 package portlist
 

--- a/portlist/portlist_ios.go
+++ b/portlist/portlist_ios.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ios
-// +build ios
 
 package portlist
 

--- a/portlist/portlist_macos.go
+++ b/portlist/portlist_macos.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build darwin && !ios
-// +build darwin,!ios
 
 package portlist
 

--- a/portlist/portlist_other.go
+++ b/portlist/portlist_other.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !linux && !windows && !darwin && !js
-// +build !linux,!windows,!darwin,!js
 
 package portlist
 

--- a/safesocket/safesocket_ps.go
+++ b/safesocket/safesocket_ps.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux || windows || darwin || freebsd
-// +build linux windows darwin freebsd
 
 package safesocket
 

--- a/safesocket/unixsocket.go
+++ b/safesocket/unixsocket.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows && !js
-// +build !windows,!js
 
 package safesocket
 

--- a/ssh/tailssh/incubator.go
+++ b/ssh/tailssh/incubator.go
@@ -9,7 +9,6 @@
 // then launches the requested `--cmd`.
 
 //go:build linux || (darwin && !ios)
-// +build linux darwin,!ios
 
 package tailssh
 

--- a/ssh/tailssh/incubator_linux.go
+++ b/ssh/tailssh/incubator_linux.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package tailssh
 

--- a/ssh/tailssh/tailssh.go
+++ b/ssh/tailssh/tailssh.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux || (darwin && !ios)
-// +build linux darwin,!ios
 
 // Package tailssh is an SSH server integrated into Tailscale.
 package tailssh

--- a/ssh/tailssh/tailssh_test.go
+++ b/ssh/tailssh/tailssh_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux || darwin
-// +build linux darwin
 
 package tailssh
 

--- a/syncs/locked_test.go
+++ b/syncs/locked_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build go1.13 && !go1.19
-// +build go1.13,!go1.19
 
 package syncs
 

--- a/tempfork/gliderlabs/ssh/context_test.go
+++ b/tempfork/gliderlabs/ssh/context_test.go
@@ -1,5 +1,4 @@
 //go:build glidertests
-// +build glidertests
 
 package ssh
 

--- a/tempfork/gliderlabs/ssh/options_test.go
+++ b/tempfork/gliderlabs/ssh/options_test.go
@@ -1,5 +1,4 @@
 //go:build glidertests
-// +build glidertests
 
 package ssh
 

--- a/tempfork/gliderlabs/ssh/server_test.go
+++ b/tempfork/gliderlabs/ssh/server_test.go
@@ -1,5 +1,4 @@
 //go:build glidertests
-// +build glidertests
 
 package ssh
 

--- a/tempfork/gliderlabs/ssh/session_test.go
+++ b/tempfork/gliderlabs/ssh/session_test.go
@@ -1,5 +1,4 @@
 //go:build glidertests
-// +build glidertests
 
 package ssh
 

--- a/tempfork/gliderlabs/ssh/tcpip_test.go
+++ b/tempfork/gliderlabs/ssh/tcpip_test.go
@@ -1,5 +1,4 @@
 //go:build glidertests
-// +build glidertests
 
 package ssh
 

--- a/tstest/archtest/qemu_test.go
+++ b/tstest/archtest/qemu_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux && amd64 && !race
-// +build linux,amd64,!race
 
 package archtest
 

--- a/tstest/integration/gen_deps.go
+++ b/tstest/integration/gen_deps.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/tstest/integration/vms/dns_tester.go
+++ b/tstest/integration/vms/dns_tester.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 // Command dns_tester exists in order to perform tests of our DNS
 // configuration stack. This was written because the state of DNS

--- a/tstest/integration/vms/harness_test.go
+++ b/tstest/integration/vms/harness_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows
-// +build !windows
 
 package vms
 

--- a/tstest/integration/vms/nixos_test.go
+++ b/tstest/integration/vms/nixos_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows
-// +build !windows
 
 package vms
 

--- a/tstest/integration/vms/top_level_test.go
+++ b/tstest/integration/vms/top_level_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows
-// +build !windows
 
 package vms
 

--- a/tstest/integration/vms/udp_tester.go
+++ b/tstest/integration/vms/udp_tester.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 // Command udp_tester exists because all of these distros being tested don't
 // have a consistent tool for doing UDP traffic. This is a very hacked up tool

--- a/tstest/integration/vms/vm_setup_test.go
+++ b/tstest/integration/vms/vm_setup_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows
-// +build !windows
 
 package vms
 

--- a/tstest/integration/vms/vms_steps_test.go
+++ b/tstest/integration/vms/vms_steps_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows
-// +build !windows
 
 package vms
 

--- a/tstest/integration/vms/vms_test.go
+++ b/tstest/integration/vms/vms_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows
-// +build !windows
 
 package vms
 

--- a/tstest/iosdeps/iosdeps_test.go
+++ b/tstest/iosdeps/iosdeps_test.go
@@ -6,7 +6,6 @@
 // worry about "go.exe" etc.
 
 //go:build !windows
-// +build !windows
 
 package iosdeps
 

--- a/tstest/jsdeps/jsdeps_test.go
+++ b/tstest/jsdeps/jsdeps_test.go
@@ -6,7 +6,6 @@
 // worry about "go.exe" etc.
 
 //go:build !windows
-// +build !windows
 
 package jsdeps
 

--- a/tstest/tools/tools.go
+++ b/tstest/tools/tools.go
@@ -6,7 +6,6 @@
 // tool modules from our go.mod.
 
 //go:build tools
-// +build tools
 
 package tools
 

--- a/tstime/rate/rate_test.go
+++ b/tstime/rate/rate_test.go
@@ -9,7 +9,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build go1.7
-// +build go1.7
 
 package rate
 

--- a/types/logger/rusage_stub.go
+++ b/types/logger/rusage_stub.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build windows || js
-// +build windows js
 
 package logger
 

--- a/types/logger/rusage_syscall.go
+++ b/types/logger/rusage_syscall.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows && !js
-// +build !windows,!js
 
 package logger
 

--- a/util/cstruct/cstruct_example_test.go
+++ b/util/cstruct/cstruct_example_test.go
@@ -5,7 +5,6 @@
 // Only built on 64-bit platforms to avoid complexity
 
 //go:build amd64 || arm64 || mips64le || ppc64le || riscv64
-// +build amd64 arm64 mips64le ppc64le riscv64
 
 package cstruct
 

--- a/util/endian/big.go
+++ b/util/endian/big.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build mips || mips64 || ppc64 || s390x
-// +build mips mips64 ppc64 s390x
 
 package endian
 

--- a/util/endian/little.go
+++ b/util/endian/little.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build 386 || amd64 || arm || arm64 || mips64le || mipsle || ppc64le || riscv64 || wasm
-// +build 386 amd64 arm arm64 mips64le mipsle ppc64le riscv64 wasm
 
 package endian
 

--- a/util/osshare/filesharingstatus_noop.go
+++ b/util/osshare/filesharingstatus_noop.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows
-// +build !windows
 
 package osshare
 

--- a/util/osshare/filesharingstatus_windows.go
+++ b/util/osshare/filesharingstatus_windows.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build windows
-// +build windows
 
 package osshare
 

--- a/util/pidowner/pidowner_noimpl.go
+++ b/util/pidowner/pidowner_noimpl.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows && !linux
-// +build !windows,!linux
 
 package pidowner
 

--- a/util/racebuild/off.go
+++ b/util/racebuild/off.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !race
-// +build !race
 
 package racebuild
 

--- a/util/racebuild/on.go
+++ b/util/racebuild/on.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build race
-// +build race
 
 package racebuild
 

--- a/util/systemd/systemd_linux.go
+++ b/util/systemd/systemd_linux.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package systemd
 

--- a/util/systemd/systemd_nonlinux.go
+++ b/util/systemd/systemd_nonlinux.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !linux
-// +build !linux
 
 package systemd
 

--- a/util/winutil/winutil_notwindows.go
+++ b/util/winutil/winutil_notwindows.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows
-// +build !windows
 
 package winutil
 

--- a/version/cmdname.go
+++ b/version/cmdname.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !ios
-// +build !ios
 
 package version
 

--- a/version/cmdname_ios.go
+++ b/version/cmdname_ios.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ios
-// +build ios
 
 package version
 

--- a/version/race.go
+++ b/version/race.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build race
-// +build race
 
 package version
 

--- a/version/race_off.go
+++ b/version/race_off.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !race
-// +build !race
 
 package version
 

--- a/wf/firewall.go
+++ b/wf/firewall.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build windows
-// +build windows
 
 package wf
 

--- a/wgengine/magicsock/debugknobs.go
+++ b/wgengine/magicsock/debugknobs.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !ios && !js
-// +build !ios,!js
 
 package magicsock
 

--- a/wgengine/magicsock/debugknobs_stubs.go
+++ b/wgengine/magicsock/debugknobs_stubs.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ios || js
-// +build ios js
 
 package magicsock
 

--- a/wgengine/magicsock/magicsock_default.go
+++ b/wgengine/magicsock/magicsock_default.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !linux
-// +build !linux
 
 package magicsock
 

--- a/wgengine/magicsock/magicsock_unix_test.go
+++ b/wgengine/magicsock/magicsock_unix_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build unix
-// +build unix
 
 package magicsock
 

--- a/wgengine/monitor/monitor_linux.go
+++ b/wgengine/monitor/monitor_linux.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !android
-// +build !android
 
 package monitor
 

--- a/wgengine/monitor/monitor_polling.go
+++ b/wgengine/monitor/monitor_polling.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build (!linux && !freebsd && !windows && !darwin) || android
-// +build !linux,!freebsd,!windows,!darwin android
 
 package monitor
 

--- a/wgengine/monitor/polling.go
+++ b/wgengine/monitor/polling.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows && !darwin
-// +build !windows,!darwin
 
 package monitor
 

--- a/wgengine/router/router_default.go
+++ b/wgengine/router/router_default.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows && !linux && !darwin && !openbsd && !freebsd
-// +build !windows,!linux,!darwin,!openbsd,!freebsd
 
 package router
 

--- a/wgengine/router/router_userspace_bsd.go
+++ b/wgengine/router/router_userspace_bsd.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build darwin || freebsd
-// +build darwin freebsd
 
 package router
 

--- a/wgengine/router/runner.go
+++ b/wgengine/router/runner.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package router
 

--- a/wgengine/watchdog.go
+++ b/wgengine/watchdog.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !js
-// +build !js
 
 package wgengine
 

--- a/wgengine/winnet/winnet.go
+++ b/wgengine/winnet/winnet.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build windows
-// +build windows
 
 package winnet
 


### PR DESCRIPTION
The //go:build syntax was introduced in Go 1.17:

https://go.dev/doc/go1.17#build-lines

gofmt has kept the +build and go:build lines in sync since then, but enough time has passed. Time to remove them.

Done with:

    perl -i -npe 's,^// \+build.*\n,,' $(git grep -l -F '+build')