### PR TITLE
tsnet/example/tshello: use strings.Cut

### DIFF
--- a/tsnet/example/tshello/tshello.go
+++ b/tsnet/example/tshello/tshello.go
@@ -57,8 +57,6 @@ func main() {
 }
 
 func firstLabel(s string) string {
-	if i := strings.Index(s, "."); i != -1 {
-		return s[:i]
-	}
+	s, _, _ = strings.Cut(s, ".")
 	return s
 }


### PR DESCRIPTION
strings.Cut allows us to be more precise here. This example was written before strings.Cut existed.

Signed-off-by: Xe <xe@tailscale.com>