### PR TITLE
cmd/tailscale,ipn: support disablement args in lock cli, implement disable

### DIFF
--- a/client/tailscale/localclient.go
+++ b/client/tailscale/localclient.go
@@ -827,6 +827,14 @@ func (lc *LocalClient) SetServeConfig(ctx context.Context, config *ipn.ServeConf
 	return nil
 }
 
+// NetworkLockDisable shuts down network-lock across the tailnet.
+func (lc *LocalClient) NetworkLockDisable(ctx context.Context, secret []byte) error {
+	if _, err := lc.send(ctx, "POST", "/localapi/v0/tka/disable", 200, bytes.NewReader(secret)); err != nil {
+		return fmt.Errorf("error: %w", err)
+	}
+	return nil
+}
+
 // GetServeConfig return the current serve config.
 //
 // If the serve config is empty, it returns (nil, nil).


### PR DESCRIPTION
 * Support specifiying disablement values in lock init command
 * Support specifying rotation key in lock sign command
 * Implement lock disable command
 * Implement lock disablement-kdf command

This PR represents another chunk of CLI improvements (along with https://github.com/tailscale/tailscale/pull/6182).