### PR TITLE
cmd/containerboot: don't write device ID when not in Kubernetes.

### DIFF
--- a/cmd/containerboot/main.go
+++ b/cmd/containerboot/main.go
@@ -133,7 +133,7 @@ func main() {
 			log.Fatalf("installing proxy rules: %v", err)
 		}
 	}
-	if cfg.KubeSecret != "" {
+	if cfg.InKubernetes && cfg.KubeSecret != "" {
 		if err := storeDeviceID(ctx, cfg.KubeSecret, string(st.Self.ID)); err != nil {
 			log.Fatalf("storing device ID in kube secret: %v", err)
 		}


### PR DESCRIPTION
Fixes #6218.

Signed-off-by: David Anderson <danderson@tailscale.com>