### PR TITLE
net/netcheck: don't use a space in the captive portal challenge

### DIFF
--- a/cmd/derper/derper_test.go
+++ b/cmd/derper/derper_test.go
@@ -86,6 +86,11 @@ func TestNoContent(t *testing.T) {
 			want:  "response input",
 		},
 		{
+			name:  "valid challenge hostname",
+			input: "ts_derp99b.tailscale.com",
+			want:  "response ts_derp99b.tailscale.com",
+		},
+		{
 			name:  "invalid challenge",
 			input: "foo\x00bar",
 			want:  "",

--- a/net/netcheck/netcheck.go
+++ b/net/netcheck/netcheck.go
@@ -1126,7 +1126,10 @@ func (c *Client) checkCaptivePortal(ctx context.Context, dm *tailcfg.DERPMap, pr
 		return false, err
 	}
 
-	chal := "tailscale " + node.HostName
+	// Note: the set of valid characters in a challenge and the total
+	// length is limited; see isChallengeChar in cmd/derper for more
+	// details.
+	chal := "ts_" + node.HostName
 	req.Header.Set("X-Tailscale-Challenge", chal)
 	r, err := noRedirectClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
The derpers don't allow whitespace in the challenge.

Change-Id: I93a8b073b846b87854fba127b5c1d80db205f658
Signed-off-by: Andrew Dunham <andrew@tailscale.com>