### PR TITLE
wgengine/netstack: optimize shouldProcessInbound, avoiding 4via6 lookups

### DIFF
--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -559,8 +559,8 @@ func (ns *Impl) shouldProcessInbound(p *packet.Parsed, t *tstun.Wrapper) bool {
 			return true
 		}
 	}
-	if p.IPVersion == 6 && viaRange.Contains(p.Dst.Addr()) {
-		return ns.lb != nil && ns.lb.ShouldHandleViaIP(p.Dst.Addr())
+	if p.IPVersion == 6 && !isLocal && viaRange.Contains(dstIP) {
+		return ns.lb != nil && ns.lb.ShouldHandleViaIP(dstIP)
 	}
 	if !ns.ProcessLocalIPs && !ns.ProcessSubnets {
 		// Fast path for common case (e.g. Linux server in TUN mode) where


### PR DESCRIPTION
All IPv6 packets for the self address were doing netip.Prefix.Contains lookups.

If if we know they're for a self address (which we already previously computed and have sitting in a bool), then they can't be for a 4via6 range.
