### PR TITLE
cmd/tailscale/cli: make dev-store-set debug command a bit more magic

### DIFF
--- a/cmd/tailscale/cli/debug.go
+++ b/cmd/tailscale/cli/debug.go
@@ -562,6 +562,16 @@ var devStoreSetArgs struct {
 }
 
 func runDevStoreSet(ctx context.Context, args []string) error {
+	// TODO(bradfitz): remove this temporary (2022-11-09) hack once
+	// profile stuff and serving CLI commands are more fleshed out.
+	if len(args) >= 1 && strings.HasPrefix(args[0], "_serve/") {
+		st, err := localClient.StatusWithoutPeers(ctx)
+		if err != nil {
+			return err
+		}
+		args[0] = "_serve/node-" + string(st.Self.ID)
+		log.Printf("Using key %q instead.", args[0])
+	}
 	if len(args) != 2 {
 		return errors.New("usage: dev-store-set --danger <key> <value>")
 	}


### PR DESCRIPTION
Temporarily at least. Makes sharing scripts during development easier.

Updates tailscale/corp#7515
