### PR TITLE
Make it possible to define controlURL for tsnet server

### DIFF
--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -82,6 +82,13 @@ type Server struct {
 	// used.
 	AuthKey string
 
+	// ControlURL is explicitly not set to signal that
+	// it's not yet configured, which relaxes the CLI "up"
+	// safety net features. It will get set to DefaultControlURL
+	// on first up. Or, if not, DefaultControlURL will be used
+	// later anyway. Can be overridden with TS_CONTROL_URL environment variable.
+	ControlURL string
+
 	initOnce         sync.Once
 	initErr          error
 	lb               *ipnlocal.LocalBackend
@@ -338,6 +345,12 @@ func (s *Server) start() (reterr error) {
 	prefs := ipn.NewPrefs()
 	prefs.Hostname = s.hostname
 	prefs.WantRunning = true
+	if os.Getenv("TS_CONTROL_URL") != "" {
+		prefs.ControlURL = os.Getenv("TS_CONTROL_URL")
+	}
+	if s.ControlURL != "" {
+		prefs.ControlURL = s.ControlURL
+	}
 	authKey := s.getAuthKey()
 	err = lb.Start(ipn.Options{
 		StateKey:    ipn.GlobalDaemonStateKey,


### PR DESCRIPTION
If using tsnet for userspace networking based tailscale services, it is currently not possible (at least it is not obvious for me) to override the controlURL aka login-server.

With this PR i am able to do so. I dont know if this is the it is supposed to do, happy to either adapt this PR according your suggestions, or even better learn how to override controlURL in the right way.

All in all, using tsnet is pure magic, thanks for this, it opens so much new solutions no one could think of before.