### PR TITLE
ipn/ipnlocal: ensure Persist information is saved to server mode star…

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -861,6 +861,7 @@ func (b *LocalBackend) setClientStatus(st controlclient.Status) {
 		b.setNetMapLocked(st.NetMap)
 		b.updateFilterLocked(st.NetMap, b.prefs)
 	}
+	userID := b.userID
 	b.mu.Unlock()
 
 	// Now complete the lock-free parts of what we started while locked.
@@ -870,6 +871,8 @@ func (b *LocalBackend) setClientStatus(st controlclient.Status) {
 				b.logf("Failed to save new controlclient state: %v", err)
 			}
 		}
+		b.writeServerModeStartState(userID, prefs.View())
+
 		p := prefs.View()
 		b.send(ipn.Notify{Prefs: &p})
 	}


### PR DESCRIPTION
…t state

Numerous issues have been filed concerning an inability to install and run Tailscale headlessly in unattended mode, particularly after rebooting. The server mode `Prefs` stored in `server-state.conf` were not being updated with `Persist` state once the node had been succesfully logged in.

Users have been working around this by finagling with the GUI to make it force a state rewrite. This patch makes that unnecessary by ensuring the required server mode state is updated when prefs are updated by the control client.

Fixes https://github.com/tailscale/tailscale/issues/3186

Signed-off-by: Aaron Klotz <aaron@tailscale.com>