### PR TITLE
ipn/localapi: rename /profile to /pprof

### DIFF
--- a/client/tailscale/localclient.go
+++ b/client/tailscale/localclient.go
@@ -255,8 +255,8 @@ func (lc *LocalClient) DaemonMetrics(ctx context.Context) ([]byte, error) {
 	return lc.get200(ctx, "/localapi/v0/metrics")
 }
 
-// Profile returns a pprof profile of the Tailscale daemon.
-func (lc *LocalClient) Profile(ctx context.Context, pprofType string, sec int) ([]byte, error) {
+// Pprof returns a pprof profile of the Tailscale daemon.
+func (lc *LocalClient) Pprof(ctx context.Context, pprofType string, sec int) ([]byte, error) {
 	var secArg string
 	if sec < 0 || sec > 300 {
 		return nil, errors.New("duration out of range")
@@ -264,7 +264,7 @@ func (lc *LocalClient) Profile(ctx context.Context, pprofType string, sec int) (
 	if sec != 0 || pprofType == "profile" {
 		secArg = fmt.Sprint(sec)
 	}
-	return lc.get200(ctx, fmt.Sprintf("/localapi/v0/profile?name=%s&seconds=%v", url.QueryEscape(pprofType), secArg))
+	return lc.get200(ctx, fmt.Sprintf("/localapi/v0/pprof?name=%s&seconds=%v", url.QueryEscape(pprofType), secArg))
 }
 
 // BugReportOpts contains options to pass to the Tailscale daemon when

--- a/cmd/tailscale/cli/debug.go
+++ b/cmd/tailscale/cli/debug.go
@@ -188,9 +188,9 @@ func runDebug(ctx context.Context, args []string) error {
 	}
 	var usedFlag bool
 	if out := debugArgs.cpuFile; out != "" {
-		usedFlag = true // TODO(bradfitz): add "profile" subcommand
+		usedFlag = true // TODO(bradfitz): add "pprof" subcommand
 		log.Printf("Capturing CPU profile for %v seconds ...", debugArgs.cpuSec)
-		if v, err := localClient.Profile(ctx, "profile", debugArgs.cpuSec); err != nil {
+		if v, err := localClient.Pprof(ctx, "profile", debugArgs.cpuSec); err != nil {
 			return err
 		} else {
 			if err := writeProfile(out, v); err != nil {
@@ -200,9 +200,9 @@ func runDebug(ctx context.Context, args []string) error {
 		}
 	}
 	if out := debugArgs.memFile; out != "" {
-		usedFlag = true // TODO(bradfitz): add "profile" subcommand
+		usedFlag = true // TODO(bradfitz): add "pprof" subcommand
 		log.Printf("Capturing memory profile ...")
-		if v, err := localClient.Profile(ctx, "heap", 0); err != nil {
+		if v, err := localClient.Pprof(ctx, "heap", 0); err != nil {
 			return err
 		} else {
 			if err := writeProfile(out, v); err != nil {

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -71,7 +71,7 @@ var handler = map[string]localAPIHandler{
 	"metrics":                 (*Handler).serveMetrics,
 	"ping":                    (*Handler).servePing,
 	"prefs":                   (*Handler).servePrefs,
-	"profile":                 (*Handler).serveProfile,
+	"pprof":                   (*Handler).servePprof,
 	"set-dns":                 (*Handler).serveSetDNS,
 	"set-expiry-sooner":       (*Handler).serveSetExpirySooner,
 	"status":                  (*Handler).serveStatus,
@@ -437,22 +437,22 @@ func (h *Handler) serveComponentDebugLogging(w http.ResponseWriter, r *http.Requ
 	json.NewEncoder(w).Encode(res)
 }
 
-// serveProfileFunc is the implementation of Handler.serveProfile, after auth,
+// servePprofFunc is the implementation of Handler.servePprof, after auth,
 // for platforms where we want to link it in.
-var serveProfileFunc func(http.ResponseWriter, *http.Request)
+var servePprofFunc func(http.ResponseWriter, *http.Request)
 
-func (h *Handler) serveProfile(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) servePprof(w http.ResponseWriter, r *http.Request) {
 	// Require write access out of paranoia that the profile dump
 	// might contain something sensitive.
 	if !h.PermitWrite {
 		http.Error(w, "profile access denied", http.StatusForbidden)
 		return
 	}
-	if serveProfileFunc == nil {
+	if servePprofFunc == nil {
 		http.Error(w, "not implemented on this platform", http.StatusServiceUnavailable)
 		return
 	}
-	serveProfileFunc(w, r)
+	servePprofFunc(w, r)
 }
 
 func (h *Handler) serveCheckIPForwarding(w http.ResponseWriter, r *http.Request) {

--- a/ipn/localapi/pprof.go
+++ b/ipn/localapi/pprof.go
@@ -15,10 +15,10 @@ import (
 )
 
 func init() {
-	serveProfileFunc = serveProfile
+	servePprofFunc = servePprof
 }
 
-func serveProfile(w http.ResponseWriter, r *http.Request) {
+func servePprof(w http.ResponseWriter, r *http.Request) {
 	name := r.FormValue("name")
 	switch name {
 	case "profile":


### PR DESCRIPTION
Avoids name collision with profiles for user switching.