### PR TITLE
ipn/ipnlocal: call restart backend on user changes

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -2097,8 +2097,15 @@ func (b *LocalBackend) shouldUploadServices() bool {
 
 func (b *LocalBackend) SetCurrentUserID(uid string) {
 	b.mu.Lock()
-	b.pm.SetCurrentUser(uid)
-	b.mu.Unlock()
+	if b.pm.CurrentUser() == uid {
+		b.mu.Unlock()
+		return
+	}
+	if err := b.pm.SetCurrentUser(uid); err != nil {
+		b.mu.Unlock()
+		return
+	}
+	b.resetForProfileChangeLockedOnEntry()
 }
 
 func (b *LocalBackend) CheckPrefs(p *ipn.Prefs) error {


### PR DESCRIPTION
This makes it so that the backend also restarts when users change, otherwise an extra call to Start was required.

Updates #713

Signed-off-by: Maisem Ali <maisem@tailscale.com>