### PR TITLE
cmd/tailscale/cli: update serve debug set command after FUS profile change

### DIFF
--- a/cmd/tailscale/cli/debug.go
+++ b/cmd/tailscale/cli/debug.go
@@ -562,17 +562,6 @@ var devStoreSetArgs struct {
 }
 
 func runDevStoreSet(ctx context.Context, args []string) error {
-	// TODO(bradfitz): remove this temporary (2022-11-09) hack once
-	// profile stuff and serving CLI commands are more fleshed out.
-	isServe := len(args) >= 1 && strings.HasPrefix(args[0], "_serve/")
-	if isServe {
-		st, err := localClient.StatusWithoutPeers(ctx)
-		if err != nil {
-			return err
-		}
-		args[0] = "_serve/node-" + string(st.Self.ID)
-		log.Printf("Using key %q instead.", args[0])
-	}
 	if len(args) != 2 {
 		return errors.New("usage: dev-store-set --danger <key> <value>")
 	}
@@ -584,11 +573,6 @@ func runDevStoreSet(ctx context.Context, args []string) error {
 		valb, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
-		}
-		if isServe {
-			if err := json.Unmarshal(valb, new(ipn.ServeConfig)); err != nil {
-				return fmt.Errorf("invalid JSON: %w", err)
-			}
 		}
 		val = string(valb)
 	}

--- a/cmd/tailscale/cli/serve.go
+++ b/cmd/tailscale/cli/serve.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"io"
 	"os"
 
@@ -101,6 +102,19 @@ func (e *serveEnv) stdout() io.Writer {
 }
 
 func (e *serveEnv) runServe(ctx context.Context, args []string) error {
+	// Undocumented debug command (not using ffcli subcommands) to set raw
+	// configs from stdin for now (2022-11-13).
+	if len(args) == 1 && args[0] == "set-raw" {
+		valb, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return err
+		}
+		sc := new(ipn.ServeConfig)
+		if err := json.Unmarshal(valb, sc); err != nil {
+			return fmt.Errorf("invalid JSON: %w", err)
+		}
+		return localClient.SetServeConfig(ctx, sc)
+	}
 	panic("TODO")
 }
 


### PR DESCRIPTION
The key changed, but also we have a localapi method to set it anyway, so use that.

Updates tailscale/corp#7515
