### PR TITLE
all: store NL keys per profile

### DIFF
--- a/cmd/tailscale/cli/network-lock.go
+++ b/cmd/tailscale/cli/network-lock.go
@@ -93,12 +93,14 @@ func runNetworkLockStatus(ctx context.Context, args []string) error {
 		fmt.Println()
 	}
 
-	p, err := st.PublicKey.MarshalText()
-	if err != nil {
-		return err
+	if !st.PublicKey.IsZero() {
+		p, err := st.PublicKey.MarshalText()
+		if err != nil {
+			return err
+		}
+		fmt.Printf("This node's public-key: %s\n", p)
+		fmt.Println()
 	}
-	fmt.Printf("This node's public-key: %s\n", p)
-	fmt.Println()
 
 	if st.Enabled && len(st.TrustedKeys) > 0 {
 		fmt.Println("Keys trusted to make changes to network-lock:")

--- a/ipn/ipnlocal/network-lock.go
+++ b/ipn/ipnlocal/network-lock.go
@@ -35,6 +35,7 @@ var (
 )
 
 type tkaState struct {
+	profile   ipn.ProfileID
 	authority *tka.Authority
 	storage   *tka.FS
 }
@@ -251,7 +252,7 @@ func (b *LocalBackend) tkaSyncLocked(ourNodeKey key.NodePublic) error {
 // b.mu must be held & TKA must be initialized.
 func (b *LocalBackend) tkaApplyDisablementLocked(secret []byte) error {
 	if b.tka.authority.ValidDisablement(secret) {
-		if err := os.RemoveAll(b.chonkPath()); err != nil {
+		if err := os.RemoveAll(b.chonkPathLocked()); err != nil {
 			return err
 		}
 		b.tka = nil
@@ -260,10 +261,10 @@ func (b *LocalBackend) tkaApplyDisablementLocked(secret []byte) error {
 	return errors.New("incorrect disablement secret")
 }
 
-// chonkPath returns the absolute path to the directory in which TKA
+// chonkPathLocked returns the absolute path to the directory in which TKA
 // state (the 'tailchonk') is stored.
-func (b *LocalBackend) chonkPath() string {
-	return filepath.Join(b.TailscaleVarRoot(), "tka")
+func (b *LocalBackend) chonkPathLocked() string {
+	return filepath.Join(b.TailscaleVarRoot(), "tka-profiles", string(b.pm.CurrentProfile().ID))
 }
 
 // tkaBootstrapFromGenesisLocked initializes the local (on-disk) state of the
@@ -280,7 +281,10 @@ func (b *LocalBackend) tkaBootstrapFromGenesisLocked(g tkatype.MarshaledAUM) err
 		return fmt.Errorf("reading genesis: %v", err)
 	}
 
-	chonkDir := b.chonkPath()
+	chonkDir := b.chonkPathLocked()
+	if err := os.Mkdir(filepath.Dir(chonkDir), 0755); err != nil && !os.IsExist(err) {
+		return fmt.Errorf("creating chonk root dir: %v", err)
+	}
 	if err := os.Mkdir(chonkDir, 0755); err != nil && !os.IsExist(err) {
 		return fmt.Errorf("mkdir: %v", err)
 	}
@@ -295,6 +299,7 @@ func (b *LocalBackend) tkaBootstrapFromGenesisLocked(g tkatype.MarshaledAUM) err
 	}
 
 	b.tka = &tkaState{
+		profile:   b.pm.CurrentProfile().ID,
 		authority: authority,
 		storage:   chonk,
 	}
@@ -329,17 +334,27 @@ func (b *LocalBackend) NetworkLockStatus() *ipnstate.NetworkLockStatus {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	var nodeKey *key.NodePublic
+	var (
+		nodeKey *key.NodePublic
+		nlPriv  key.NLPrivate
+	)
 	if p := b.pm.CurrentPrefs(); p.Valid() && p.Persist() != nil && !p.Persist().PrivateNodeKey.IsZero() {
 		nkp := p.Persist().PublicNodeKey()
 		nodeKey = &nkp
+		nlPriv = p.Persist().NetworkLockKey
 	}
 
+	if nlPriv.IsZero() {
+		return &ipnstate.NetworkLockStatus{
+			Enabled: false,
+			NodeKey: nodeKey,
+		}
+	}
 	if b.tka == nil {
 		return &ipnstate.NetworkLockStatus{
 			Enabled:   false,
-			PublicKey: b.nlPrivKey.Public(),
 			NodeKey:   nodeKey,
+			PublicKey: nlPriv.Public(),
 		}
 	}
 
@@ -365,7 +380,7 @@ func (b *LocalBackend) NetworkLockStatus() *ipnstate.NetworkLockStatus {
 	return &ipnstate.NetworkLockStatus{
 		Enabled:       true,
 		Head:          &head,
-		PublicKey:     b.nlPrivKey.Public(),
+		PublicKey:     nlPriv.Public(),
 		NodeKey:       nodeKey,
 		NodeKeySigned: selfAuthorized,
 		TrustedKeys:   outKeys,
@@ -387,12 +402,14 @@ func (b *LocalBackend) NetworkLockInit(keys []tka.Key, disablementValues [][]byt
 	}
 
 	var ourNodeKey key.NodePublic
+	var nlPriv key.NLPrivate
 	b.mu.Lock()
 	if p := b.pm.CurrentPrefs(); p.Valid() && p.Persist() != nil && !p.Persist().PrivateNodeKey.IsZero() {
 		ourNodeKey = p.Persist().PublicNodeKey()
+		nlPriv = p.Persist().NetworkLockKey
 	}
 	b.mu.Unlock()
-	if ourNodeKey.IsZero() {
+	if ourNodeKey.IsZero() || nlPriv.IsZero() {
 		return errors.New("no node-key: is tailscale logged in?")
 	}
 
@@ -407,7 +424,7 @@ func (b *LocalBackend) NetworkLockInit(keys []tka.Key, disablementValues [][]byt
 		//    - DisablementSecret: value needed to disable.
 		//    - DisablementValue: the KDF of the disablement secret, a public value.
 		DisablementSecrets: disablementValues,
-	}, b.nlPrivKey)
+	}, nlPriv)
 	if err != nil {
 		return fmt.Errorf("tka.Create: %v", err)
 	}
@@ -430,7 +447,7 @@ func (b *LocalBackend) NetworkLockInit(keys []tka.Key, disablementValues [][]byt
 	// satisfy network-lock checks.
 	sigs := make(map[tailcfg.NodeID]tkatype.MarshaledSignature, len(initResp.NeedSignatures))
 	for _, nodeInfo := range initResp.NeedSignatures {
-		nks, err := signNodeKey(nodeInfo, b.nlPrivKey)
+		nks, err := signNodeKey(nodeInfo, nlPriv)
 		if err != nil {
 			return fmt.Errorf("generating signature: %v", err)
 		}
@@ -470,10 +487,18 @@ func (b *LocalBackend) NetworkLockSign(nodeKey key.NodePublic, rotationPublic []
 		b.mu.Lock()
 		defer b.mu.Unlock()
 
+		var nlPriv key.NLPrivate
+		if p := b.pm.CurrentPrefs(); p.Valid() && p.Persist() != nil {
+			nlPriv = p.Persist().NetworkLockKey
+		}
+		if nlPriv.IsZero() {
+			return key.NodePublic{}, tka.NodeKeySignature{}, errMissingNetmap
+		}
+
 		if b.tka == nil {
 			return key.NodePublic{}, tka.NodeKeySignature{}, errNetworkLockNotActive
 		}
-		if !b.tka.authority.KeyTrusted(b.nlPrivKey.KeyID()) {
+		if !b.tka.authority.KeyTrusted(nlPriv.KeyID()) {
 			return key.NodePublic{}, tka.NodeKeySignature{}, errors.New("this node is not trusted by network lock")
 		}
 
@@ -483,11 +508,11 @@ func (b *LocalBackend) NetworkLockSign(nodeKey key.NodePublic, rotationPublic []
 		}
 		sig := tka.NodeKeySignature{
 			SigKind:        tka.SigDirect,
-			KeyID:          b.nlPrivKey.KeyID(),
+			KeyID:          nlPriv.KeyID(),
 			Pubkey:         p,
 			WrappingPubkey: rotationPublic,
 		}
-		sig.Signature, err = b.nlPrivKey.SignNKS(sig.SigHash())
+		sig.Signature, err = nlPriv.SignNKS(sig.SigHash())
 		if err != nil {
 			return key.NodePublic{}, tka.NodeKeySignature{}, fmt.Errorf("signature failed: %w", err)
 		}
@@ -527,11 +552,18 @@ func (b *LocalBackend) NetworkLockModify(addKeys, removeKeys []tka.Key) (err err
 	if err := b.CanSupportNetworkLock(); err != nil {
 		return err
 	}
+	var nlPriv key.NLPrivate
+	if p := b.pm.CurrentPrefs(); p.Valid() && p.Persist() != nil {
+		nlPriv = p.Persist().NetworkLockKey
+	}
+	if nlPriv.IsZero() {
+		return errMissingNetmap
+	}
 	if b.tka == nil {
 		return errNetworkLockNotActive
 	}
 
-	updater := b.tka.authority.NewUpdater(b.nlPrivKey)
+	updater := b.tka.authority.NewUpdater(nlPriv)
 
 	for _, addKey := range addKeys {
 		if err := updater.AddKey(addKey); err != nil {

--- a/ipn/ipnlocal/profiles.go
+++ b/ipn/ipnlocal/profiles.go
@@ -252,8 +252,8 @@ func (pm *profileManager) loadSavedPrefs(key ipn.StateKey) (ipn.PrefsView, error
 	return savedPrefs.View(), nil
 }
 
-// CurrentProfile returns the name and ID of the current profile, or "" if the profile
-// is not named.
+// CurrentProfile returns the current LoginProfile.
+// The value may be zero if the profile is not persisted.
 func (pm *profileManager) CurrentProfile() ipn.LoginProfile {
 	return *pm.currentProfile
 }

--- a/ipn/ipnserver/server.go
+++ b/ipn/ipnserver/server.go
@@ -42,7 +42,6 @@ import (
 	"tailscale.com/net/tsdial"
 	"tailscale.com/safesocket"
 	"tailscale.com/smallzstd"
-	"tailscale.com/tka"
 	"tailscale.com/types/logger"
 	"tailscale.com/util/groupmember"
 	"tailscale.com/util/pidowner"
@@ -751,24 +750,7 @@ func New(logf logger.Logf, logid string, store ipn.StateStore, eng wgengine.Engi
 	})
 
 	if root := b.TailscaleVarRoot(); root != "" {
-		chonkDir := filepath.Join(root, "tka")
-		if _, err := os.Stat(chonkDir); err == nil {
-			// The directory exists, which means network-lock has been initialized.
-			storage, err := tka.ChonkDir(chonkDir)
-			if err != nil {
-				return nil, fmt.Errorf("opening tailchonk: %v", err)
-			}
-			authority, err := tka.Open(storage)
-			if err != nil {
-				return nil, fmt.Errorf("initializing tka: %v", err)
-			}
-			b.SetTailnetKeyAuthority(authority, storage)
-			logf("tka initialized at head %x", authority.Head())
-		}
-
 		dnsfallback.SetCachePath(filepath.Join(root, "derpmap.cached.json"))
-	} else {
-		logf("network-lock unavailable; no state directory")
 	}
 
 	dg := distro.Get()

--- a/ipn/ipnstate/ipnstate.go
+++ b/ipn/ipnstate/ipnstate.go
@@ -86,6 +86,7 @@ type NetworkLockStatus struct {
 	Head *[32]byte
 
 	// PublicKey describes the node's network-lock public key.
+	// It may be zero if the node has not logged in.
 	PublicKey key.NLPublic
 
 	// NodeKey describes the node's current node-key. This field is not

--- a/types/key/nl.go
+++ b/types/key/nl.go
@@ -60,6 +60,11 @@ func (k NLPrivate) MarshalText() ([]byte, error) {
 	return toHex(k.k[:], nlPrivateHexPrefix), nil
 }
 
+// Equal reports whether k and other are the same key.
+func (k NLPrivate) Equal(other NLPrivate) bool {
+	return subtle.ConstantTimeCompare(k.k[:], other.k[:]) == 1
+}
+
 // Public returns the public component of this key.
 func (k NLPrivate) Public() NLPublic {
 	var out NLPublic

--- a/types/persist/persist.go
+++ b/types/persist/persist.go
@@ -16,7 +16,8 @@ import (
 //go:generate go run tailscale.com/cmd/viewer -type=Persist
 
 // Persist is the JSON type stored on disk on nodes to remember their
-// settings between runs.
+// settings between runs. This is stored as part of ipn.Prefs and is
+// persisted per ipn.LoginProfile.
 type Persist struct {
 	_ structs.Incomparable
 
@@ -36,6 +37,7 @@ type Persist struct {
 	Provider          string
 	LoginName         string
 	UserProfile       tailcfg.UserProfile
+	NetworkLockKey    key.NLPrivate
 }
 
 // PublicNodeKey returns the public key for the node key.
@@ -65,7 +67,8 @@ func (p *Persist) Equals(p2 *Persist) bool {
 		p.OldPrivateNodeKey.Equal(p2.OldPrivateNodeKey) &&
 		p.Provider == p2.Provider &&
 		p.LoginName == p2.LoginName &&
-		p.UserProfile == p2.UserProfile
+		p.UserProfile == p2.UserProfile &&
+		p.NetworkLockKey.Equal(p2.NetworkLockKey)
 }
 
 func (p *Persist) Pretty() string {

--- a/types/persist/persist_clone.go
+++ b/types/persist/persist_clone.go
@@ -32,4 +32,5 @@ var _PersistCloneNeedsRegeneration = Persist(struct {
 	Provider                        string
 	LoginName                       string
 	UserProfile                     tailcfg.UserProfile
+	NetworkLockKey                  key.NLPrivate
 }{})

--- a/types/persist/persist_test.go
+++ b/types/persist/persist_test.go
@@ -22,7 +22,7 @@ func fieldsOf(t reflect.Type) (fields []string) {
 }
 
 func TestPersistEqual(t *testing.T) {
-	persistHandles := []string{"LegacyFrontendPrivateMachineKey", "PrivateNodeKey", "OldPrivateNodeKey", "Provider", "LoginName", "UserProfile"}
+	persistHandles := []string{"LegacyFrontendPrivateMachineKey", "PrivateNodeKey", "OldPrivateNodeKey", "Provider", "LoginName", "UserProfile", "NetworkLockKey"}
 	if have := fieldsOf(reflect.TypeOf(Persist{})); !reflect.DeepEqual(have, persistHandles) {
 		t.Errorf("Persist.Equal check might be out of sync\nfields: %q\nhandled: %q\n",
 			have, persistHandles)
@@ -30,6 +30,7 @@ func TestPersistEqual(t *testing.T) {
 
 	m1 := key.NewMachine()
 	k1 := key.NewNode()
+	nl1 := key.NewNLPrivate()
 	tests := []struct {
 		a, b *Persist
 		want bool
@@ -110,6 +111,16 @@ func TestPersistEqual(t *testing.T) {
 				ID:          tailcfg.UserID(3),
 				DisplayName: "foo",
 			}},
+			false,
+		},
+		{
+			&Persist{NetworkLockKey: nl1},
+			&Persist{NetworkLockKey: nl1},
+			true,
+		},
+		{
+			&Persist{NetworkLockKey: nl1},
+			&Persist{NetworkLockKey: key.NewNLPrivate()},
 			false,
 		},
 	}

--- a/types/persist/persist_view.go
+++ b/types/persist/persist_view.go
@@ -70,6 +70,7 @@ func (v PersistView) OldPrivateNodeKey() key.NodePrivate { return v.ж.OldPrivat
 func (v PersistView) Provider() string                   { return v.ж.Provider }
 func (v PersistView) LoginName() string                  { return v.ж.LoginName }
 func (v PersistView) UserProfile() tailcfg.UserProfile   { return v.ж.UserProfile }
+func (v PersistView) NetworkLockKey() key.NLPrivate      { return v.ж.NetworkLockKey }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _PersistViewNeedsRegeneration = Persist(struct {
@@ -80,4 +81,5 @@ var _PersistViewNeedsRegeneration = Persist(struct {
 	Provider                        string
 	LoginName                       string
 	UserProfile                     tailcfg.UserProfile
+	NetworkLockKey                  key.NLPrivate
 }{})


### PR DESCRIPTION
This moves the NetworkLock key from a dedicated StateKey to be part of the persist.Persist struct.
This struct is stored as part for ipn.Prefs and is also the place where we store the NodeKey.

It also moves the ChonkDir from "/tka" to "/tka-profile/<profile-id>". The rename was intentional
to be able to delete the "/tka" dir if it exists.

This means that we will have a unique key per profile, and a unique directory per profile.

Note: `tailscale logout` will delete the entire profile, including any keys. It currently does not
delete the ChonkDir.

Signed-off-by: Maisem Ali <maisem@tailscale.com>