### PR TITLE
ipn/ipnlocal: fix controlclient reentrancy when deleting profile during logout

### DIFF
--- a/client/tailscale/localclient.go
+++ b/client/tailscale/localclient.go
@@ -548,6 +548,11 @@ func (lc *LocalClient) Logout(ctx context.Context) error {
 	return err
 }
 
+func (lc *LocalClient) LogoutAsync(ctx context.Context) error {
+	_, err := lc.send(ctx, "POST", "/localapi/v0/logout?async=true", http.StatusNoContent, nil)
+	return err
+}
+
 // SetDNS adds a DNS TXT record for the given domain name, containing
 // the provided TXT value. The intended use case is answering
 // LetsEncrypt/ACME dns-01 challenges.

--- a/cmd/tailscale/cli/logout.go
+++ b/cmd/tailscale/cli/logout.go
@@ -6,6 +6,7 @@ package cli
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"strings"
 
@@ -23,11 +24,23 @@ the current node key, forcing a future use of it to cause
 a reauthentication.
 `),
 	Exec: runLogout,
+	FlagSet: (func() *flag.FlagSet {
+		fs := newFlagSet("logout")
+		fs.BoolVar(&logoutArgs.async, "async", false, "Does not wait for logout to be complete (status can be queried to determine success)")
+		return fs
+	})(),
+}
+
+var logoutArgs struct {
+	async bool
 }
 
 func runLogout(ctx context.Context, args []string) error {
 	if len(args) > 0 {
 		return fmt.Errorf("too many non-flag arguments: %q", args)
+	}
+	if logoutArgs.async {
+		return localClient.LogoutAsync(ctx)
 	}
 	return localClient.Logout(ctx)
 }

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -552,7 +552,12 @@ func (h *Handler) serveLogout(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "want POST", 400)
 		return
 	}
-	err := h.b.LogoutSync(r.Context())
+	var err error
+	if defBool(r.FormValue("async"), false) {
+		h.b.Logout()
+	} else {
+		err = h.b.LogoutSync(r.Context())
+	}
 	if err == nil {
 		w.WriteHeader(http.StatusNoContent)
 		return

--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -555,6 +555,23 @@ func TestLogoutRemovesAllPeers(t *testing.T) {
 	wantNode0PeerCount(expectedPeers) // all existing peers and the new node
 }
 
+func TestLogoutAsyncState(t *testing.T) {
+	t.Parallel()
+	env := newTestEnv(t)
+	node := newTestNode(t, env)
+	node.StartDaemon()
+	node.AwaitResponding()
+	node.MustUp()
+	node.AwaitIP()
+	node.AwaitRunning()
+
+	log.Printf("running logout CLI")
+	if err := node.Tailscale("logout", "--async").Run(); err != nil {
+		t.Fatalf("logout: %v", err)
+	}
+	node.AwaitNeedsLogin()
+}
+
 // testEnv contains the test environment (set of servers) used by one
 // or more nodes.
 type testEnv struct {


### PR DESCRIPTION
Deletion of profiles on logout (#6297) added a `LocalBackend.Start()` call within `setClientStatus()`, but that's a callback from the controlclient. `Start()` ends calling back into the controlclient (to shut it down), and we end up stuck in a deadlock waiting for the `authDone` channel to be closed.

Fixed by making the Start call asynchronous. To reproduce this in a test case, we need to do an asynchronous logout, so add a CLI option for that.