### PR TITLE
cmd/tailscale: access QNAP via localhost

### DIFF
--- a/cmd/tailscale/cli/web.go
+++ b/cmd/tailscale/cli/web.go
@@ -224,8 +224,8 @@ func qnapAuthnQtoken(r *http.Request, user, token string) (string, *qnapAuthResp
 		"user":   []string{user},
 	}
 	u := url.URL{
-		Scheme:   r.URL.Scheme,
-		Host:     r.URL.Host,
+		Scheme:   "http",
+		Host:     "127.0.0.1:8080",
 		Path:     "/cgi-bin/authLogin.cgi",
 		RawQuery: query.Encode(),
 	}
@@ -238,8 +238,8 @@ func qnapAuthnSid(r *http.Request, user, sid string) (string, *qnapAuthResponse,
 		"sid": []string{sid},
 	}
 	u := url.URL{
-		Scheme:   r.URL.Scheme,
-		Host:     r.URL.Host,
+		Scheme:   "http",
+		Host:     "127.0.0.1:8080",
 		Path:     "/cgi-bin/authLogin.cgi",
 		RawQuery: query.Encode(),
 	}


### PR DESCRIPTION
QNAP 5.x works much better if we let Apache proxy
tailscale web, which means the URLs can no longer
be relative since apache sends us an internal
URL. Access QNAP authentication via
http://localhost:8080/ as documented in
https://download.qnap.com/dev/API_QNAP_QTS_Authentication.pdf

Signed-off-by: Denton Gentry <dgentry@tailscale.com>