### PR TITLE
logtail: remove MustParsePublicID

### DIFF
--- a/logtail/id.go
+++ b/logtail/id.go
@@ -109,16 +109,6 @@ func ParsePublicID(s string) (PublicID, error) {
 	return p, nil
 }
 
-// MustParsePublicID calls ParsePublicID and panics in case of an error.
-// It is intended for use with constant strings, typically in tests.
-func MustParsePublicID(s string) PublicID {
-	id, err := ParsePublicID(s)
-	if err != nil {
-		panic(err)
-	}
-	return id
-}
-
 func (id PublicID) MarshalText() ([]byte, error) {
 	b := make([]byte, hex.EncodedLen(len(id)))
 	if i := hex.Encode(b, id[:]); i != len(b) {


### PR DESCRIPTION
This function is no longer necessary as you can trivially rewrite:

	logtail.MustParsePublicID(...)

with:

	must.Get(logtail.ParsePublicID(...))

Signed-off-by: Joe Tsai <joetsai@digital-static.net>