### PR TITLE
ipn/ipnlocal: update profile on server sent profile changes

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3300,10 +3300,10 @@ func (b *LocalBackend) setNetMapLocked(nm *netmap.NetworkMap) {
 		if login == "" {
 			login = "<missing-profile>"
 		}
-		if cp := b.pm.CurrentProfile(); cp.ID != "" && cp.UserProfile.ID == 0 {
-			// Migration to profiles: we didn't use to persist
-			// the UserProfile, so if we don't have one, fill it
-			// in from the NetworkMap.
+		if cp := b.pm.CurrentProfile(); cp.ID != "" && cp.UserProfile.ID != up.ID {
+			// If the current profile doesn't match the
+			// network map's user profile, then we need to
+			// update the persisted UserProfile to match.
 			prefs := b.pm.CurrentPrefs().AsStruct()
 			prefs.Persist.UserProfile = up
 			b.pm.SetPrefs(prefs.View())

--- a/ipn/ipnlocal/profiles.go
+++ b/ipn/ipnlocal/profiles.go
@@ -126,6 +126,7 @@ func (pm *profileManager) SetPrefs(prefsIn ipn.PrefsView) error {
 		up.DisplayName = up.LoginName
 	}
 	cp := pm.currentProfile
+	wasNamedWithLoginName := cp.Name == cp.UserProfile.LoginName
 	if pm.isNewProfile {
 		pm.isNewProfile = false
 		cp.ID, cp.Key = newUnusedID(pm.knownProfiles)
@@ -134,6 +135,9 @@ func (pm *profileManager) SetPrefs(prefsIn ipn.PrefsView) error {
 		cp.LocalUserID = pm.currentUserID
 	} else {
 		cp.UserProfile = ps.UserProfile
+	}
+	if wasNamedWithLoginName {
+		cp.Name = ps.LoginName
 	}
 	pm.knownProfiles[cp.ID] = cp
 	if err := pm.writeKnownProfiles(); err != nil {


### PR DESCRIPTION
We were not updating the LoginProfile.UserProfile when a netmap updated the UserProfile (e.g. when a node was tagged via the admin panel).

Updates #713

Signed-off-by: Maisem Ali <maisem@tailscale.com>