### PR TITLE
ipn/ipnlocal: also accept service IP IPv6 literal in brackets for quad100

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3925,6 +3925,17 @@ func (b *LocalBackend) HandleQuad100Port80Conn(c net.Conn) {
 	s.Serve(netutil.NewOneConnListener(c, nil))
 }
 
+func validQuad100Host(h string) bool {
+	switch h {
+	case "",
+		tsaddr.TailscaleServiceIPString,
+		tsaddr.TailscaleServiceIPv6String,
+		"[" + tsaddr.TailscaleServiceIPv6String + "]":
+		return true
+	}
+	return false
+}
+
 func (b *LocalBackend) handleQuad100Port80Conn(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Frame-Options", "DENY")
 	w.Header().Set("Content-Security-Policy", "default-src 'self';")
@@ -3932,9 +3943,7 @@ func (b *LocalBackend) handleQuad100Port80Conn(w http.ResponseWriter, r *http.Re
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	switch r.Host {
-	case "", tsaddr.TailscaleServiceIP().String(), tsaddr.TailscaleServiceIPv6().String():
-	default:
+	if !validQuad100Host(r.Host) {
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}

--- a/net/tsaddr/tsaddr.go
+++ b/net/tsaddr/tsaddr.go
@@ -57,9 +57,14 @@ func TailscaleServiceIP() netip.Addr {
 //
 // For IPv4, use TailscaleServiceIP.
 func TailscaleServiceIPv6() netip.Addr {
-	serviceIPv6.Do(func() { mustPrefix(&serviceIPv6.v, "fd7a:115c:a1e0::53/128") })
+	serviceIPv6.Do(func() { mustPrefix(&serviceIPv6.v, TailscaleServiceIPv6String+"/128") })
 	return serviceIPv6.v.Addr()
 }
+
+const (
+	TailscaleServiceIPString   = "100.100.100.100"
+	TailscaleServiceIPv6String = "fd7a:115c:a1e0::53"
+)
 
 // IsTailscaleIP reports whether ip is an IP address in a range that
 // Tailscale assigns from.

--- a/net/tsaddr/tsaddr_test.go
+++ b/net/tsaddr/tsaddr_test.go
@@ -32,11 +32,25 @@ func TestInCrostiniRange(t *testing.T) {
 	}
 }
 
+func TestTailscaleServiceIP(t *testing.T) {
+	got := TailscaleServiceIP().String()
+	want := "100.100.100.100"
+	if got != want {
+		t.Errorf("got %q; want %q", got, want)
+	}
+	if TailscaleServiceIPString != want {
+		t.Error("TailscaleServiceIPString is not consistent")
+	}
+}
+
 func TestTailscaleServiceIPv6(t *testing.T) {
 	got := TailscaleServiceIPv6().String()
 	want := "fd7a:115c:a1e0::53"
 	if got != want {
 		t.Errorf("got %q; want %q", got, want)
+	}
+	if TailscaleServiceIPv6String != want {
+		t.Error("TailscaleServiceIPv6String is not consistent")
 	}
 }
 


### PR DESCRIPTION
The fix in 4fc8538e2 was sufficient for IPv6. Browsers (can?) send the IPv6 literal, even without a port number, in brackets.

Updates tailscale/corp#7948
