### PR TITLE
ipn/ipnlocal,tka: generate a nonce for each TKA state

### DIFF
--- a/ipn/ipnlocal/network-lock.go
+++ b/ipn/ipnlocal/network-lock.go
@@ -6,7 +6,9 @@ package ipnlocal
 
 import (
 	"bytes"
+	"crypto/rand"
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -413,6 +415,11 @@ func (b *LocalBackend) NetworkLockInit(keys []tka.Key, disablementValues [][]byt
 		return errors.New("no node-key: is tailscale logged in?")
 	}
 
+	var entropy [16]byte
+	if _, err := rand.Read(entropy[:]); err != nil {
+		return err
+	}
+
 	// Generates a genesis AUM representing trust in the provided keys.
 	// We use an in-memory tailchonk because we don't want to commit to
 	// the filesystem until we've finished the initialization sequence,
@@ -424,6 +431,9 @@ func (b *LocalBackend) NetworkLockInit(keys []tka.Key, disablementValues [][]byt
 		//    - DisablementSecret: value needed to disable.
 		//    - DisablementValue: the KDF of the disablement secret, a public value.
 		DisablementSecrets: disablementValues,
+
+		StateID1: binary.LittleEndian.Uint64(entropy[:8]),
+		StateID2: binary.LittleEndian.Uint64(entropy[8:]),
 	}, nlPriv)
 	if err != nil {
 		return fmt.Errorf("tka.Create: %v", err)

--- a/tka/state_test.go
+++ b/tka/state_test.go
@@ -45,6 +45,13 @@ func TestCloneState(t *testing.T) {
 			},
 		},
 		{
+			"StateID",
+			State{
+				StateID1: 42,
+				StateID2: 22,
+			},
+		},
+		{
 			"DisablementSecrets",
 			State{
 				DisablementSecrets: [][]byte{
@@ -222,6 +229,12 @@ func TestApplyUpdateErrors(t *testing.T) {
 				Keys: []Key{{Kind: Key25519, Public: []byte{1, 2, 3, 4}}},
 			},
 			errors.New("parent AUMHash mismatch"),
+		},
+		{
+			"Bad StateID",
+			[]AUM{{MessageKind: AUMCheckpoint, State: &State{StateID1: 1}}},
+			State{Keys: []Key{{Kind: Key25519, Public: []byte{1}}}, StateID1: 42},
+			errors.New("checkpointed state has an incorrect stateID"),
 		},
 	}
 


### PR DESCRIPTION
We generate a persistent 16-byte nonce thats fixed for the life of a tailnet key authority. The primary purpose of this is to randomize the genesis AUM hash, but such a value could be useful for future features.