### PR TITLE
tstime: fix ParseDuration for '6' digit

### DIFF
--- a/tstime/tstime.go
+++ b/tstime/tstime.go
@@ -144,15 +144,15 @@ func Parse3339B(b []byte) (time.Time, error) {
 	return parse3339m(mem.B(b))
 }
 
-// ParseDuration is more expressive than time.ParseDuration, also accepting d
-// (days) and w (weeks) literals.
+// ParseDuration is more expressive than time.ParseDuration,
+// also accepting 'd' (days) and 'w' (weeks) literals.
 func ParseDuration(s string) (time.Duration, error) {
 	for {
 		end := strings.IndexAny(s, "dw")
 		if end < 0 {
 			break
 		}
-		start := end - (len(s[:end]) - len(strings.TrimRight(s[:end], "012345789")))
+		start := end - (len(s[:end]) - len(strings.TrimRight(s[:end], "0123456789")))
 		n, err := strconv.Atoi(s[start:end])
 		if err != nil {
 			return 0, err

--- a/tstime/tstime_test.go
+++ b/tstime/tstime_test.go
@@ -109,6 +109,10 @@ func TestParseDuration(t *testing.T) {
 	}{
 		{"1h", time.Hour},
 		{"1d", 24 * time.Hour},
+		{"365d", 365 * 24 * time.Hour},
+		{"12345d", 12345 * 24 * time.Hour},
+		{"67890d", 67890 * 24 * time.Hour},
+		{"100d", 100 * 24 * time.Hour},
 		{"1d1d", 48 * time.Hour},
 		{"1h1d", 25 * time.Hour},
 		{"1d1h", 25 * time.Hour},


### PR DESCRIPTION
The cutset provided to strings.TrimRight was missing the digit '6', making it such that we couldn't parse something like "365d".

Signed-off-by: Joe Tsai <joetsai@digital-static.net>