### PR TITLE
ipn/ipnlocal: handle untagging nodes better

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -874,6 +874,9 @@ func (b *LocalBackend) setClientStatus(st controlclient.Status) {
 		if !envknob.TKASkipSignatureCheck() {
 			b.tkaFilterNetmapLocked(st.NetMap)
 		}
+		if b.updatePersistFromNetMapLocked(st.NetMap, prefs) {
+			prefsChanged = true
+		}
 		b.setNetMapLocked(st.NetMap)
 		b.updateFilterLocked(st.NetMap, prefs.View())
 	}
@@ -3339,22 +3342,35 @@ func hasCapability(nm *netmap.NetworkMap, cap string) bool {
 	return false
 }
 
+func (b *LocalBackend) updatePersistFromNetMapLocked(nm *netmap.NetworkMap, prefs *ipn.Prefs) (changed bool) {
+	if nm == nil || nm.SelfNode == nil {
+		return
+	}
+	up := nm.UserProfiles[nm.User]
+	if prefs.Persist.UserProfile.ID != up.ID {
+		// If the current profile doesn't match the
+		// network map's user profile, then we need to
+		// update the persisted UserProfile to match.
+		prefs.Persist.UserProfile = up
+		changed = true
+	}
+	if prefs.Persist.NodeID == "" {
+		// If the current profile doesn't have a NodeID,
+		// then we need to update the persisted NodeID to
+		// match.
+		prefs.Persist.NodeID = nm.SelfNode.StableID
+		changed = true
+	}
+	return changed
+}
+
 func (b *LocalBackend) setNetMapLocked(nm *netmap.NetworkMap) {
 	b.dialer.SetNetMap(nm)
 	var login string
 	if nm != nil {
-		up := nm.UserProfiles[nm.User]
-		login = up.LoginName
+		login = nm.UserProfiles[nm.User].LoginName
 		if login == "" {
 			login = "<missing-profile>"
-		}
-		if cp := b.pm.CurrentProfile(); cp.ID != "" && cp.UserProfile.ID != up.ID {
-			// If the current profile doesn't match the
-			// network map's user profile, then we need to
-			// update the persisted UserProfile to match.
-			prefs := b.pm.CurrentPrefs().AsStruct()
-			prefs.Persist.UserProfile = up
-			b.pm.SetPrefs(prefs.View())
 		}
 	}
 	b.netMap = nm

--- a/ipn/ipnlocal/state_test.go
+++ b/ipn/ipnlocal/state_test.go
@@ -473,6 +473,7 @@ func TestStateMachine(t *testing.T) {
 	t.Logf("\n\nLoginFinished")
 	notifies.expect(3)
 	cc.persist.LoginName = "user1"
+	cc.persist.UserProfile.LoginName = "user1"
 	cc.send(nil, "", true, &netmap.NetworkMap{})
 	{
 		nn := notifies.drain(3)
@@ -698,6 +699,7 @@ func TestStateMachine(t *testing.T) {
 	t.Logf("\n\nLoginFinished3")
 	notifies.expect(3)
 	cc.persist.LoginName = "user2"
+	cc.persist.UserProfile.LoginName = "user2"
 	cc.send(nil, "", true, &netmap.NetworkMap{
 		MachineStatus: tailcfg.MachineAuthorized,
 	})
@@ -833,6 +835,7 @@ func TestStateMachine(t *testing.T) {
 	t.Logf("\n\nLoginDifferent URL visited")
 	notifies.expect(3)
 	cc.persist.LoginName = "user3"
+	cc.persist.UserProfile.LoginName = "user3"
 	cc.send(nil, "", true, &netmap.NetworkMap{
 		MachineStatus: tailcfg.MachineAuthorized,
 	})

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -715,6 +715,13 @@ type LoginProfile struct {
 	// This is updated whenever the server provides a new UserProfile.
 	UserProfile tailcfg.UserProfile
 
+	// NodeID is the NodeID of the node that this profile is logged into.
+	// This should be stable across tagging and untagging nodes.
+	// It may seem redundant to check against both the UserProfile.UserID
+	// and the NodeID. However the NodeID can change if the node is deleted
+	// from the admin panel.
+	NodeID tailcfg.StableNodeID
+
 	// LocalUserID is the user ID of the user who created this profile.
 	// It is only relevant on Windows where we have a multi-user system.
 	// It is assigned once at profile creation time and never changes.

--- a/types/persist/persist.go
+++ b/types/persist/persist.go
@@ -38,6 +38,7 @@ type Persist struct {
 	LoginName         string
 	UserProfile       tailcfg.UserProfile
 	NetworkLockKey    key.NLPrivate
+	NodeID            tailcfg.StableNodeID
 }
 
 // PublicNodeKey returns the public key for the node key.
@@ -68,7 +69,8 @@ func (p *Persist) Equals(p2 *Persist) bool {
 		p.Provider == p2.Provider &&
 		p.LoginName == p2.LoginName &&
 		p.UserProfile == p2.UserProfile &&
-		p.NetworkLockKey.Equal(p2.NetworkLockKey)
+		p.NetworkLockKey.Equal(p2.NetworkLockKey) &&
+		p.NodeID == p2.NodeID
 }
 
 func (p *Persist) Pretty() string {

--- a/types/persist/persist_clone.go
+++ b/types/persist/persist_clone.go
@@ -33,4 +33,5 @@ var _PersistCloneNeedsRegeneration = Persist(struct {
 	LoginName                       string
 	UserProfile                     tailcfg.UserProfile
 	NetworkLockKey                  key.NLPrivate
+	NodeID                          tailcfg.StableNodeID
 }{})

--- a/types/persist/persist_test.go
+++ b/types/persist/persist_test.go
@@ -22,7 +22,7 @@ func fieldsOf(t reflect.Type) (fields []string) {
 }
 
 func TestPersistEqual(t *testing.T) {
-	persistHandles := []string{"LegacyFrontendPrivateMachineKey", "PrivateNodeKey", "OldPrivateNodeKey", "Provider", "LoginName", "UserProfile", "NetworkLockKey"}
+	persistHandles := []string{"LegacyFrontendPrivateMachineKey", "PrivateNodeKey", "OldPrivateNodeKey", "Provider", "LoginName", "UserProfile", "NetworkLockKey", "NodeID"}
 	if have := fieldsOf(reflect.TypeOf(Persist{})); !reflect.DeepEqual(have, persistHandles) {
 		t.Errorf("Persist.Equal check might be out of sync\nfields: %q\nhandled: %q\n",
 			have, persistHandles)
@@ -121,6 +121,16 @@ func TestPersistEqual(t *testing.T) {
 		{
 			&Persist{NetworkLockKey: nl1},
 			&Persist{NetworkLockKey: key.NewNLPrivate()},
+			false,
+		},
+		{
+			&Persist{NodeID: "abc"},
+			&Persist{NodeID: "abc"},
+			true,
+		},
+		{
+			&Persist{NodeID: ""},
+			&Persist{NodeID: "abc"},
 			false,
 		},
 	}

--- a/types/persist/persist_view.go
+++ b/types/persist/persist_view.go
@@ -71,6 +71,7 @@ func (v PersistView) Provider() string                   { return v.ж.Provider 
 func (v PersistView) LoginName() string                  { return v.ж.LoginName }
 func (v PersistView) UserProfile() tailcfg.UserProfile   { return v.ж.UserProfile }
 func (v PersistView) NetworkLockKey() key.NLPrivate      { return v.ж.NetworkLockKey }
+func (v PersistView) NodeID() tailcfg.StableNodeID       { return v.ж.NodeID }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _PersistViewNeedsRegeneration = Persist(struct {
@@ -82,4 +83,5 @@ var _PersistViewNeedsRegeneration = Persist(struct {
 	LoginName                       string
 	UserProfile                     tailcfg.UserProfile
 	NetworkLockKey                  key.NLPrivate
+	NodeID                          tailcfg.StableNodeID
 }{})


### PR DESCRIPTION
We would end up with duplicate profiles for the node as the UserID would have chnaged. In order to correctly deduplicate profiles, we need to look at both the UserID and the NodeID. A single machine can only ever have 1 profile per NodeID and 1 profile per UserID.

Note: UserID of a Node can change when the node is tagged/untagged, and the NodeID of a device can change when the node is deleted so we need to check for both.

Updates #713

Signed-off-by: Maisem Ali <maisem@tailscale.com>