### PR TITLE
tsweb: avoid dashes in Prometheus metric names

### DIFF
--- a/tsweb/tsweb.go
+++ b/tsweb/tsweb.go
@@ -474,7 +474,7 @@ func writePromExpVar(w io.Writer, prefix string, kv expvar.KeyValue) {
 			label, key = a, b
 		}
 	}
-	name := prefix + key
+	name := strings.ReplaceAll(prefix+key, "-", "_")
 
 	switch v := kv.Value.(type) {
 	case PrometheusVar:

--- a/tsweb/tsweb_test.go
+++ b/tsweb/tsweb_test.go
@@ -450,15 +450,15 @@ func TestVarzHandler(t *testing.T) {
 		},
 		{
 			"func_float64_gauge",
-			"gauge_x",
+			"gauge_y",
 			expvar.Func(func() any { return float64(1.2) }),
-			"# TYPE x gauge\nx 1.2\n",
+			"# TYPE y gauge\ny 1.2\n",
 		},
 		{
 			"func_float64_untyped",
-			"x",
+			"z",
 			expvar.Func(func() any { return float64(1.2) }),
-			"x 1.2\n",
+			"z 1.2\n",
 		},
 		{
 			"metrics_label_map",

--- a/tsweb/tsweb_test.go
+++ b/tsweb/tsweb_test.go
@@ -360,6 +360,12 @@ func TestVarzHandler(t *testing.T) {
 			"# TYPE foo counter\nfoo 0\n",
 		},
 		{
+			"dash_in_metric_name",
+			"counter_foo-bar",
+			new(expvar.Int),
+			"# TYPE foo_bar counter\nfoo_bar 0\n",
+		},
+		{
 			"int_with_type_counter",
 			"counter_foo",
 			new(expvar.Int),


### PR DESCRIPTION
Ideally we should strip other invalid characters too ([reference](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels)), but that would call for a regexp replacement which increases the number of allocations and makes `TestVarzHandlerSorting` fail.

Signed-off-by: Anton Tolchanov <anton@tailscale.com>