### PR TITLE
cmd/tailscale/cli: add ability to set short names for profiles

### DIFF
--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -480,6 +480,19 @@ func TestCheckForAccidentalSettingReverts(t *testing.T) {
 			distro: "", // not Synology
 			want:   accidentalUpPrefix + " --hostname=foo --accept-routes",
 		},
+		{
+			name:  "profile_name_ignored_in_up",
+			flags: []string{"--hostname=foo"},
+			curPrefs: &ipn.Prefs{
+				ControlURL:       "https://login.tailscale.com",
+				CorpDNS:          true,
+				AllowSingleHosts: true,
+				NetfilterMode:    preftype.NetfilterOn,
+				ProfileName:      "foo",
+			},
+			goos: "linux",
+			want: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/tailscale/cli/login.go
+++ b/cmd/tailscale/cli/login.go
@@ -27,6 +27,6 @@ This command is currently in alpha and may change in the future.`,
 		if err := localClient.SwitchToEmptyProfile(ctx); err != nil {
 			return err
 		}
-		return runUp(ctx, args, loginArgs)
+		return runUp(ctx, "login", args, loginArgs)
 	},
 }

--- a/cmd/tailscale/cli/set.go
+++ b/cmd/tailscale/cli/set.go
@@ -43,11 +43,13 @@ type setArgsT struct {
 	advertiseDefaultRoute  bool
 	opUser                 string
 	acceptedRisks          string
+	profileName            string
 }
 
 func newSetFlagSet(goos string, setArgs *setArgsT) *flag.FlagSet {
 	setf := newFlagSet("set")
 
+	setf.StringVar(&setArgs.profileName, "nickname", "", "nickname for the login profile")
 	setf.BoolVar(&setArgs.acceptRoutes, "accept-routes", false, "accept routes advertised by other Tailscale nodes")
 	setf.BoolVar(&setArgs.acceptDNS, "accept-dns", false, "accept DNS configuration from the admin panel")
 	setf.StringVar(&setArgs.exitNodeIP, "exit-node", "", "Tailscale exit node (IP or base name) for internet traffic, or empty string to not use an exit node")
@@ -81,6 +83,7 @@ func runSet(ctx context.Context, args []string) (retErr error) {
 
 	maskedPrefs := &ipn.MaskedPrefs{
 		Prefs: ipn.Prefs{
+			ProfileName:            setArgs.profileName,
 			RouteAll:               setArgs.acceptRoutes,
 			CorpDNS:                setArgs.acceptDNS,
 			ExitNodeAllowLANAccess: setArgs.exitNodeAllowLANAccess,
@@ -131,6 +134,11 @@ func runSet(ctx context.Context, args []string) (retErr error) {
 		if err := presentSSHToggleRisk(wantSSH, haveSSH, setArgs.acceptedRisks); err != nil {
 			return err
 		}
+	}
+	checkPrefs := curPrefs.Clone()
+	checkPrefs.ApplyEdits(maskedPrefs)
+	if err := localClient.CheckPrefs(ctx, checkPrefs); err != nil {
+		return err
 	}
 
 	_, err = localClient.EditPrefs(ctx, maskedPrefs)

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -59,7 +59,7 @@ settings.)
 `),
 	FlagSet: upFlagSet,
 	Exec: func(ctx context.Context, args []string) error {
-		return runUp(ctx, args, upArgsGlobal)
+		return runUp(ctx, "up", args, upArgsGlobal)
 	},
 }
 
@@ -121,6 +121,10 @@ func newUpFlagSet(goos string, upArgs *upArgsT, cmd string) *flag.FlagSet {
 	}
 	upf.DurationVar(&upArgs.timeout, "timeout", 0, "maximum amount of time to wait for tailscaled to enter a Running state; default (0s) blocks forever")
 
+	if cmd == "login" {
+		upf.StringVar(&upArgs.profileName, "nickname", "", "short name for the login profile")
+	}
+
 	if cmd == "up" {
 		// Some flags are only for "up", not "login".
 		upf.BoolVar(&upArgs.json, "json", false, "output in JSON format (WARNING: format subject to change)")
@@ -128,6 +132,7 @@ func newUpFlagSet(goos string, upArgs *upArgsT, cmd string) *flag.FlagSet {
 		upf.BoolVar(&upArgs.forceReauth, "force-reauth", false, "force reauthentication")
 		registerAcceptRiskFlag(upf, &upArgs.acceptedRisks)
 	}
+
 	return upf
 }
 
@@ -162,6 +167,7 @@ type upArgsT struct {
 	json                   bool
 	timeout                time.Duration
 	acceptedRisks          string
+	profileName            string
 }
 
 func (a upArgsT) getAuthKey() (string, error) {
@@ -343,6 +349,7 @@ func prefsFromUpArgs(upArgs upArgsT, warnf logger.Logf, st *ipnstate.Status, goo
 	prefs.Hostname = upArgs.hostname
 	prefs.ForceDaemon = upArgs.forceDaemon
 	prefs.OperatorUser = upArgs.opUser
+	prefs.ProfileName = upArgs.profileName
 
 	if goos == "linux" {
 		prefs.NoSNAT = !upArgs.snat
@@ -437,7 +444,7 @@ func presentSSHToggleRisk(wantSSH, haveSSH bool, acceptedRisks string) error {
 	return presentRiskToUser(riskLoseSSH, `You are connected using Tailscale SSH; this action will result in your session disconnecting.`, acceptedRisks)
 }
 
-func runUp(ctx context.Context, args []string, upArgs upArgsT) (retErr error) {
+func runUp(ctx context.Context, cmd string, args []string, upArgs upArgsT) (retErr error) {
 	var egg bool
 	if len(args) > 0 {
 		egg = fmt.Sprint(args) == "[up down down left right left right b a]"
@@ -495,6 +502,11 @@ func runUp(ctx context.Context, args []string, upArgs upArgsT) (retErr error) {
 	curPrefs, err := localClient.GetPrefs(ctx)
 	if err != nil {
 		return err
+	}
+	if cmd == "up" {
+		// "tailscale up" should not be able to change the
+		// profile name.
+		prefs.ProfileName = curPrefs.ProfileName
 	}
 
 	env := upCheckEnv{
@@ -764,6 +776,7 @@ func init() {
 	addPrefFlagMapping("unattended", "ForceDaemon")
 	addPrefFlagMapping("operator", "OperatorUser")
 	addPrefFlagMapping("ssh", "RunSSH")
+	addPrefFlagMapping("nickname", "ProfileName")
 }
 
 func addPrefFlagMapping(flagName string, prefNames ...string) {

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -53,6 +53,7 @@ var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	NoSNAT                 bool
 	NetfilterMode          preftype.NetfilterMode
 	OperatorUser           string
+	ProfileName            string
 	Persist                *persist.Persist
 }{})
 

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -86,6 +86,7 @@ func (v PrefsView) AdvertiseRoutes() views.IPPrefixSlice {
 func (v PrefsView) NoSNAT() bool                          { return v.ж.NoSNAT }
 func (v PrefsView) NetfilterMode() preftype.NetfilterMode { return v.ж.NetfilterMode }
 func (v PrefsView) OperatorUser() string                  { return v.ж.OperatorUser }
+func (v PrefsView) ProfileName() string                   { return v.ж.ProfileName }
 func (v PrefsView) Persist() *persist.Persist {
 	if v.ж.Persist == nil {
 		return nil
@@ -116,6 +117,7 @@ var _PrefsViewNeedsRegeneration = Prefs(struct {
 	NoSNAT                 bool
 	NetfilterMode          preftype.NetfilterMode
 	OperatorUser           string
+	ProfileName            string
 	Persist                *persist.Persist
 }{})
 

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -2107,6 +2107,9 @@ func (b *LocalBackend) checkPrefsLocked(p *ipn.Prefs) error {
 		// Keep this one just for testing.
 		errs = append(errs, errors.New("bad hostname [test]"))
 	}
+	if err := b.checkProfileNameLocked(p); err != nil {
+		errs = append(errs, err)
+	}
 	if err := b.checkSSHPrefsLocked(p); err != nil {
 		errs = append(errs, err)
 	}
@@ -2222,6 +2225,23 @@ func (b *LocalBackend) EditPrefs(mp *ipn.MaskedPrefs) (ipn.PrefsView, error) {
 
 	// This should return the public prefs, not the private ones.
 	return stripKeysFromPrefs(newPrefs), nil
+}
+
+func (b *LocalBackend) checkProfileNameLocked(p *ipn.Prefs) error {
+	if p.ProfileName == "" {
+		// It is always okay to clear the profile name.
+		return nil
+	}
+	id := b.pm.ProfileIDForName(p.ProfileName)
+	if id == "" {
+		// No profile with that name exists. That's fine.
+		return nil
+	}
+	if id != b.pm.CurrentProfile().ID {
+		// Name is already in use by another profile.
+		return fmt.Errorf("profile name %q already in use", p.ProfileName)
+	}
+	return nil
 }
 
 // SetPrefs saves new user preferences and propagates them throughout

--- a/ipn/ipnlocal/profiles.go
+++ b/ipn/ipnlocal/profiles.go
@@ -96,6 +96,16 @@ func (pm *profileManager) findProfilesByUserID(userID tailcfg.UserID) []*ipn.Log
 	return out
 }
 
+// ProfileIDForName returns the profile ID for the profile with the
+// given name. It returns "" if no such profile exists.
+func (pm *profileManager) ProfileIDForName(name string) ipn.ProfileID {
+	p := pm.findProfileByName(name)
+	if p == nil {
+		return ""
+	}
+	return p.ID
+}
+
 func (pm *profileManager) findProfileByName(name string) *ipn.LoginProfile {
 	for _, p := range pm.knownProfiles {
 		if p.Name == name {

--- a/ipn/ipnlocal/profiles.go
+++ b/ipn/ipnlocal/profiles.go
@@ -174,9 +174,13 @@ func (pm *profileManager) SetPrefs(prefsIn ipn.PrefsView) error {
 		}
 		cp.LocalUserID = pm.currentUserID
 	}
+	if prefs.ProfileName() != "" {
+		cp.Name = prefs.ProfileName()
+	} else {
+		cp.Name = up.LoginName
+	}
 	cp.UserProfile = newPersist.UserProfile
 	cp.NodeID = newPersist.NodeID
-	cp.Name = up.LoginName
 	pm.knownProfiles[cp.ID] = cp
 	pm.currentProfile = cp
 	if err := pm.writeKnownProfiles(); err != nil {

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -190,7 +190,7 @@ type Prefs struct {
 	// operate tailscaled without being root or using sudo.
 	OperatorUser string `json:",omitempty"`
 
-	// ProfileName is the desired name of the profile. If empty, then the users
+	// ProfileName is the desired name of the profile. If empty, then the user's
 	// LoginName is used. It is only used for display purposes in the client UI
 	// and CLI.
 	ProfileName string `json:",omitempty"`

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -190,6 +190,11 @@ type Prefs struct {
 	// operate tailscaled without being root or using sudo.
 	OperatorUser string `json:",omitempty"`
 
+	// ProfileName is the desired name of the profile. If empty, then the users
+	// LoginName is used. It is only used for display purposes in the client UI
+	// and CLI.
+	ProfileName string `json:",omitempty"`
+
 	// The Persist field is named 'Config' in the file for backward
 	// compatibility with earlier versions.
 	// TODO(apenwarr): We should move this out of here, it's not a pref.
@@ -222,6 +227,7 @@ type MaskedPrefs struct {
 	NoSNATSet                 bool `json:",omitempty"`
 	NetfilterModeSet          bool `json:",omitempty"`
 	OperatorUserSet           bool `json:",omitempty"`
+	ProfileNameSet            bool `json:",omitempty"`
 }
 
 // ApplyEdits mutates p, assigning fields from m.Prefs for each MaskedPrefs
@@ -406,7 +412,8 @@ func (p *Prefs) Equals(p2 *Prefs) bool {
 		p.ForceDaemon == p2.ForceDaemon &&
 		compareIPNets(p.AdvertiseRoutes, p2.AdvertiseRoutes) &&
 		compareStrings(p.AdvertiseTags, p2.AdvertiseTags) &&
-		p.Persist.Equals(p2.Persist)
+		p.Persist.Equals(p2.Persist) &&
+		p.ProfileName == p2.ProfileName
 }
 
 func compareIPNets(a, b []netip.Prefix) bool {

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -56,6 +56,7 @@ func TestPrefsEqual(t *testing.T) {
 		"NoSNAT",
 		"NetfilterMode",
 		"OperatorUser",
+		"ProfileName",
 		"Persist",
 	}
 	if have := fieldsOf(reflect.TypeOf(Prefs{})); !reflect.DeepEqual(have, prefsHandles) {
@@ -271,6 +272,16 @@ func TestPrefsEqual(t *testing.T) {
 			&Prefs{Persist: &persist.Persist{LoginName: "dave"}},
 			&Prefs{Persist: &persist.Persist{LoginName: "dave"}},
 			true,
+		},
+		{
+			&Prefs{ProfileName: "work"},
+			&Prefs{ProfileName: "work"},
+			true,
+		},
+		{
+			&Prefs{ProfileName: "work"},
+			&Prefs{ProfileName: "home"},
+			false,
 		},
 	}
 	for i, tt := range tests {


### PR DESCRIPTION
This adds a `--nickname` flag to `tailscale login|set`.
    
Updates #713
    
Signed-off-by: Maisem Ali <maisem@tailscale.com>