### PR TITLE
cmd/tailscale/cli: disallow empty text "" from serve CLI

### DIFF
--- a/cmd/tailscale/cli/serve.go
+++ b/cmd/tailscale/cli/serve.go
@@ -285,6 +285,9 @@ func (e *serveEnv) runServe(ctx context.Context, args []string) error {
 		}
 		h.Proxy = t
 	case "text":
+		if args[2] == "" {
+			return errors.New("unable to serve; text cannot be an empty string")
+		}
 		h.Text = args[2]
 	default:
 		fmt.Fprintf(os.Stderr, "error: unknown serve type %q\n\n", args[1])


### PR DESCRIPTION
Current behavior is broken. tailscale serve text / "" returns no error and shows up in tailscale serve status but requests return a 500 "empty handler".

Adds an error if the user passes in an empty string for the text handler.

Closes https://github.com/tailscale/tailscale/issues/6405