### PR TITLE
Revert "cmd/tailscale: access QNAP via localhost"

### DIFF
--- a/cmd/tailscale/cli/web.go
+++ b/cmd/tailscale/cli/web.go
@@ -224,8 +224,8 @@ func qnapAuthnQtoken(r *http.Request, user, token string) (string, *qnapAuthResp
 		"user":   []string{user},
 	}
 	u := url.URL{
-		Scheme:   "http",
-		Host:     "127.0.0.1:8080",
+		Scheme:   r.URL.Scheme,
+		Host:     r.URL.Host,
 		Path:     "/cgi-bin/authLogin.cgi",
 		RawQuery: query.Encode(),
 	}
@@ -238,8 +238,8 @@ func qnapAuthnSid(r *http.Request, user, sid string) (string, *qnapAuthResponse,
 		"sid": []string{sid},
 	}
 	u := url.URL{
-		Scheme:   "http",
-		Host:     "127.0.0.1:8080",
+		Scheme:   r.URL.Scheme,
+		Host:     r.URL.Host,
 		Path:     "/cgi-bin/authLogin.cgi",
 		RawQuery: query.Encode(),
 	}


### PR DESCRIPTION
When running `tailscale web` as a standalone process, it was necessary to send auth requests to QTS using localhost to avoid hitting the proxy recursively.

However running `tailscale web` as a process means it is consuming RAM all the time even when it isn't actively doing anything.

After switching back to the `tailscale web` CGI mode, we don't need to specifically use localhost for QNAP auth.

This reverts commit e0cadc54968519eae7e37e0e65ab9a7052bd54e8.

Signed-off-by: Denton Gentry <dgentry@tailscale.com>