### PR TITLE
ipn/ipnlocal: call checkPrefs in Start too

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1122,6 +1122,17 @@ func (b *LocalBackend) Start(opts ipn.Options) error {
 	}
 
 	b.mu.Lock()
+	if opts.UpdatePrefs != nil {
+		if err := b.checkPrefsLocked(opts.UpdatePrefs); err != nil {
+			b.mu.Unlock()
+			return err
+		}
+	} else if opts.LegacyMigrationPrefs != nil {
+		if err := b.checkPrefsLocked(opts.LegacyMigrationPrefs); err != nil {
+			b.mu.Unlock()
+			return err
+		}
+	}
 	profileID := b.pm.CurrentProfile().ID
 
 	// The iOS client sends a "Start" whenever its UI screen comes

--- a/wgengine/netstack/netstack_test.go
+++ b/wgengine/netstack/netstack_test.go
@@ -268,10 +268,11 @@ func looksLikeATailscaleSelfAddress(addr netip.Addr) bool {
 
 func TestShouldProcessInbound(t *testing.T) {
 	testCases := []struct {
-		name  string
-		pkt   *packet.Parsed
-		setup func(*Impl)
-		want  bool
+		name      string
+		pkt       *packet.Parsed
+		setup     func(*Impl)
+		want      bool
+		runOnGOOS string
 	}{
 		{
 			name: "ipv6-via",
@@ -349,7 +350,8 @@ func TestShouldProcessInbound(t *testing.T) {
 					return addr.String() == "100.101.102.104" // Dst, above
 				})
 			},
-			want: true,
+			want:      true,
+			runOnGOOS: "linux",
 		},
 		{
 			name: "tailscale-ssh-disabled",
@@ -443,6 +445,9 @@ func TestShouldProcessInbound(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.runOnGOOS != "" && runtime.GOOS != tc.runOnGOOS {
+				t.Skipf("skipping on GOOS=%v", runtime.GOOS)
+			}
 			impl := makeNetstack(t, func(i *Impl) {
 				defer t.Logf("netstack setup finished")
 


### PR DESCRIPTION
We were not calling checkPrefs on `opts.*Prefs` in (*LocalBackend).Start().

Updates #713

Signed-off-by: Maisem Ali <maisem@tailscale.com>