### PR TITLE
tsweb: export version metrics to Prometheus

### DIFF
--- a/tsweb/tsweb.go
+++ b/tsweb/tsweb.go
@@ -540,6 +540,10 @@ func writePromExpVar(w io.Writer, prefix string, kv expvar.KeyValue) {
 				writeMemstats(w, &ms)
 				return
 			}
+			if vs, ok := v.(string); ok && strings.HasSuffix(name, "version") {
+				fmt.Fprintf(w, "%s{version=%q} 1\n", name, vs)
+				return
+			}
 			switch v := v.(type) {
 			case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, uintptr, float32, float64:
 				fmt.Fprintf(w, "%s %v\n", name, v)

--- a/tsweb/tsweb_test.go
+++ b/tsweb/tsweb_test.go
@@ -537,6 +537,12 @@ foo_totalY 4
 			"custom_var_value 42\n",
 		},
 		{
+			"string_version_var",
+			"foo_version",
+			expvar.Func(func() any { return "1.2.3-foo15" }),
+			"foo_version{version=\"1.2.3-foo15\"} 1\n",
+		},
+		{
 			"field_ordering",
 			"foo",
 			someExpVarWithFieldNamesSorting(),


### PR DESCRIPTION
This will allow tracking build versions and runtime versions in Prometheus.

Signed-off-by: Anton Tolchanov <anton@tailscale.com>