### PR TITLE
ipn/ipnlocal: call initTKALocked on backend start

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1287,6 +1287,10 @@ func (b *LocalBackend) Start(opts ipn.Options) error {
 	b.cc = cc
 	b.ccAuto, _ = cc.(*controlclient.Auto)
 	endpoints := b.endpoints
+
+	if err := b.initTKALocked(); err != nil {
+		b.logf("initTKALocked: %v", err)
+	}
 	var tkaHead string
 	if b.tka != nil {
 		head, err := b.tka.authority.Head().MarshalText()


### PR DESCRIPTION
Somewhere in the last week's changes to ipnlocal we broke TKA initialization. This manifests later, which upon getting a netmap TKA tries to initialize from scratch but finds it already had stored state:

```
tkaSyncIfNeeded: enabled=true, head=Q5UJDFVMPCZFQH6TLRE7KZSSBXOZGMKFLBV2LCGE75A7SSXFVL6A
TKA sync error: bootstrap: tka bootstrap: tailchonk is not empty
```

Is this the right place to call `initTKALocked` in the new, profiley world?