### PR TITLE
envknob: add CanTaildrop (TS_DISABLE_TAILDROP) to disable taildrop on device

### DIFF
--- a/envknob/envknob.go
+++ b/envknob/envknob.go
@@ -264,12 +264,17 @@ func LookupInt(envVar string) (v int, ok bool) {
 // of Work-In-Progress code.
 func UseWIPCode() bool { return Bool("TAILSCALE_USE_WIP_CODE") }
 
-// CanSSHD is whether the Tailscale SSH server is allowed to run.
+// CanSSHD reports whether the Tailscale SSH server is allowed to run.
 //
-// If disabled, the SSH server won't start (won't intercept port 22)
-// if already enabled and any attempt to re-enable it will result in
-// an error.
+// If disabled (when this reports false), the SSH server won't start (won't
+// intercept port 22) if previously configured to do so and any attempt to
+// re-enable it will result in an error.
 func CanSSHD() bool { return !Bool("TS_DISABLE_SSH_SERVER") }
+
+// CanTaildrop reports whether the Taildrop feature is allowed to function.
+//
+// If disabled, Taildrop won't receive files regardless of user & server config.
+func CanTaildrop() bool { return !Bool("TS_DISABLE_TAILDROP") }
 
 // SSHPolicyFile returns the path, if any, to the SSHPolicy JSON file for development.
 func SSHPolicyFile() string { return String("TS_DEBUG_SSH_POLICY_FILE") }

--- a/ipn/ipnlocal/peerapi.go
+++ b/ipn/ipnlocal/peerapi.go
@@ -94,10 +94,6 @@ const (
 	deletedSuffix = ".deleted"
 )
 
-func (s *peerAPIServer) canReceiveFiles() bool {
-	return s != nil && s.rootDir != ""
-}
-
 func validFilenameRune(r rune) bool {
 	switch r {
 	case '/':
@@ -861,6 +857,10 @@ func (h *peerAPIHandler) peerHasCap(wantCap string) bool {
 }
 
 func (h *peerAPIHandler) handlePeerPut(w http.ResponseWriter, r *http.Request) {
+	if !envknob.CanTaildrop() {
+		http.Error(w, "Taildrop disabled on device", http.StatusForbidden)
+		return
+	}
 	if !h.canPutFile() {
 		http.Error(w, "Taildrop access denied", http.StatusForbidden)
 		return


### PR DESCRIPTION
This matches CanSSHD (TS_DISABLE_SSH_SERVER) for administratively disabling the code on a node, regardless of local or server configs.

This can be configured in /etc/default/tailscaled on Linux, %ProgramData%\Tailscale\tailscaled-env.txt on Windows, or /etc/tailscale/tailscaled-env.txt on Synology. (see getPlatformEnvFile)

Also delete some dead code and tidy up some docs.
