### PR TITLE
cmd/tailscale/cli: Improve messaging when Funnel is unavailable.

### DIFF
--- a/cmd/tailscale/cli/serve_test.go
+++ b/cmd/tailscale/cli/serve_test.go
@@ -49,6 +49,30 @@ func TestCleanMountPoint(t *testing.T) {
 	}
 }
 
+func TestCheckHasAccess(t *testing.T) {
+	tests := []struct {
+		caps    []string
+		wantErr bool
+	}{
+		{[]string{}, true}, // No "funnel" attribute
+		{[]string{tailcfg.CapabilityWarnFunnelNoInvite}, true},
+		{[]string{tailcfg.CapabilityWarnFunnelNoHTTPS}, true},
+		{[]string{tailcfg.NodeAttrFunnel}, false},
+	}
+	for _, tt := range tests {
+		err := checkHasAccess(tt.caps)
+		switch {
+		case err != nil && tt.wantErr,
+			err == nil && !tt.wantErr:
+			continue
+		case tt.wantErr:
+			t.Fatalf("got no error, want error")
+		case !tt.wantErr:
+			t.Fatalf("got error %v, want no error", err)
+		}
+	}
+}
+
 func TestServeConfigMutations(t *testing.T) {
 	// Stateful mutations, starting from an empty config.
 	type step struct {

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -1722,6 +1722,14 @@ const (
 	CapabilityWakeOnLAN = "https://tailscale.com/cap/wake-on-lan"
 	// CapabilityIngress grants the ability for a peer to send ingress traffic.
 	CapabilityIngress = "https://tailscale.com/cap/ingress"
+
+	// Funnel warning capabilities used for reporting errors to the user.
+
+	// CapabilityWarnFunnelNoInvite indicates an invite has not been accepted for the Funnel alpha.
+	CapabilityWarnFunnelNoInvite = "https://tailscale.com/cap/warn-funnel-no-invite"
+
+	// CapabilityWarnFunnelNoHTTPS indicates HTTPS has not been enabled for the tailnet.
+	CapabilityWarnFunnelNoHTTPS = "https://tailscale.com/cap/warn-funnel-no-https"
 )
 
 const (


### PR DESCRIPTION
There are three specific requirements for Funnel to work:
1) They must accept an invite.
2) They must enable HTTPS.
3) The "funnel" node attribute must be appropriately set up in the ACLs.