### PR TITLE
ipn/ipnserver: remove protoSwitchConn shenanigans; just use http.Server early

### DIFF
--- a/ipn/ipnauth/ipnauth.go
+++ b/ipn/ipnauth/ipnauth.go
@@ -57,7 +57,6 @@ func (ci *ConnIdentity) UserID() string { return ci.userID }
 func (ci *ConnIdentity) User() *user.User       { return ci.user }
 func (ci *ConnIdentity) Pid() int               { return ci.pid }
 func (ci *ConnIdentity) IsUnixSock() bool       { return ci.isUnixSock }
-func (ci *ConnIdentity) NotWindows() bool       { return ci.notWindows }
 func (ci *ConnIdentity) Creds() *peercred.Creds { return ci.creds }
 
 // GetConnIdentity returns the localhost TCP connection's identity information

--- a/ipn/ipnserver/proxyconnect_js.go
+++ b/ipn/ipnserver/proxyconnect_js.go
@@ -4,14 +4,8 @@
 
 package ipnserver
 
-import (
-	"bufio"
-	"context"
-	"net"
+import "net/http"
 
-	"tailscale.com/types/logger"
-)
-
-func (s *Server) handleProxyConnectConn(ctx context.Context, br *bufio.Reader, c net.Conn, logf logger.Logf) {
+func (s *Server) handleProxyConnectConn(w http.ResponseWriter, r *http.Request) {
 	panic("unreachable")
 }


### PR DESCRIPTION
Now that everything's just HTTP, there's no longer a need to have a header-sniffing net.Conn wraper that dispatches which route to take. Refactor to just use an http.Server earlier instead.

Updates #6417
