### PR TITLE
ipn: add a WatchIPNBus option bit to subscribe to EngineStatus changes

### DIFF
--- a/client/tailscale/localclient.go
+++ b/client/tailscale/localclient.go
@@ -990,13 +990,6 @@ func (lc *LocalClient) DebugDERPRegion(ctx context.Context, regionIDOrCode strin
 	return decodeJSON[*ipnstate.DebugDERPRegionReport](body)
 }
 
-// WatchIPNMask are filtering options for LocalClient.WatchIPNBus.
-//
-// The zero value is a valid WatchOpt that means to watch everything.
-//
-// TODO(bradfitz): flesh out.
-type WatchIPNMask uint64
-
 // WatchIPNBus subscribes to the IPN notification bus. It returns a watcher
 // once the bus is connected successfully.
 //
@@ -1005,7 +998,9 @@ type WatchIPNMask uint64
 //
 // The returned IPNBusWatcher's Close method must be called when done to release
 // resources.
-func (lc *LocalClient) WatchIPNBus(ctx context.Context, mask WatchIPNMask) (*IPNBusWatcher, error) {
+//
+// A default set of ipn.Notify messages are returned but the set can be modified by mask.
+func (lc *LocalClient) WatchIPNBus(ctx context.Context, mask ipn.NotifyWatchOpt) (*IPNBusWatcher, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET",
 		"http://"+apitype.LocalAPIHost+"/localapi/v0/watch-ipn-bus?mask="+fmt.Sprint(mask),
 		nil)

--- a/ipn/backend.go
+++ b/ipn/backend.go
@@ -52,6 +52,17 @@ type EngineStatus struct {
 	LivePeers      map[key.NodePublic]ipnstate.PeerStatusLite
 }
 
+// NotifyWatchOpt is a bitmask of options about what type of Notify messages
+// to subscribe to.
+type NotifyWatchOpt uint64
+
+const (
+	// NotifyWatchEngineUpdates, if set, causes Engine updates to be sent to the
+	// client either regularly or when they change, without having to ask for
+	// each one via RequestEngineStatus.
+	NotifyWatchEngineUpdates NotifyWatchOpt = 1 << iota
+)
+
 // Notify is a communication from a backend (e.g. tailscaled) to a frontend
 // (cmd/tailscale, iOS, macOS, Win Tasktray).
 // In any given notification, any or all of these may be nil, meaning

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -602,8 +602,17 @@ func (h *Handler) serveWatchIPNBus(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	f.Flush()
 
+	var mask ipn.NotifyWatchOpt
+	if s := r.FormValue("mask"); s != "" {
+		v, err := strconv.ParseUint(s, 10, 64)
+		if err != nil {
+			http.Error(w, "bad mask", http.StatusBadRequest)
+			return
+		}
+		mask = ipn.NotifyWatchOpt(v)
+	}
 	ctx := r.Context()
-	h.b.WatchNotifications(ctx, func(roNotify *ipn.Notify) (keepGoing bool) {
+	h.b.WatchNotifications(ctx, mask, func(roNotify *ipn.Notify) (keepGoing bool) {
 		js, err := json.Marshal(roNotify)
 		if err != nil {
 			h.logf("json.Marshal: %v", err)


### PR DESCRIPTION
So GUI clients don't need to poll for it.

We still poll internally (for now!) but that's still cheaper. And will get much cheaper later, without having to modify clients once they start sending this bit.
