### PR TITLE
ipn/ipnauth: make new WindowsUserID type to consolidate docs

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -2076,12 +2076,12 @@ func (b *LocalBackend) CheckIPNConnectionAllowed(ci *ipnauth.ConnIdentity) error
 	if !b.pm.CurrentPrefs().ForceDaemon() {
 		return nil
 	}
-	uid := ci.UserID()
+	uid := ci.WindowsUserID()
 	if uid == "" {
 		return errors.New("empty user uid in connection identity")
 	}
 	if uid != serverModeUid {
-		return fmt.Errorf("Tailscale running in server mode (%q); connection from %q not allowed", b.tryLookupUserName(serverModeUid), b.tryLookupUserName(uid))
+		return fmt.Errorf("Tailscale running in server mode (%q); connection from %q not allowed", b.tryLookupUserName(string(serverModeUid)), b.tryLookupUserName(string(uid)))
 	}
 	return nil
 }
@@ -2257,7 +2257,7 @@ func (b *LocalBackend) shouldUploadServices() bool {
 // changed.
 //
 // On non-multi-user systems, the uid should be set to empty string.
-func (b *LocalBackend) SetCurrentUserID(uid string) {
+func (b *LocalBackend) SetCurrentUserID(uid ipn.WindowsUserID) {
 	b.mu.Lock()
 	if b.pm.CurrentUserID() == uid {
 		b.mu.Unlock()

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -702,6 +702,12 @@ func SavePrefs(filename string, p *Prefs) {
 // profile. It is a 4 character hex string like "1ab3".
 type ProfileID string
 
+// WindowsUserID is a userid (suitable for passing to ipnauth.LookupUserFromID
+// or os/user.LookupId) but only set on Windows. It's empty on all other
+// platforms, unless envknob.GOOS is in used, making Linux act like Windows for
+// tests.
+type WindowsUserID string
+
 // LoginProfile represents a single login profile as managed
 // by the ProfileManager.
 type LoginProfile struct {
@@ -734,5 +740,5 @@ type LoginProfile struct {
 	// LocalUserID is the user ID of the user who created this profile.
 	// It is only relevant on Windows where we have a multi-user system.
 	// It is assigned once at profile creation time and never changes.
-	LocalUserID string
+	LocalUserID WindowsUserID
 }


### PR DESCRIPTION
The "userID is empty everywhere but Windows" docs on lots of places but not everywhere while using just a string type was getting confusing. This makes a new type to wrap up those rules, however weird/historical they might be.
