### PR TITLE
ipn,types/persist: store disallowed TKA's in prefs, lock local-disable

### DIFF
--- a/client/tailscale/localclient.go
+++ b/client/tailscale/localclient.go
@@ -855,6 +855,21 @@ func (lc *LocalClient) NetworkLockLog(ctx context.Context, maxEntries int) ([]ip
 	return decodeJSON[[]ipnstate.NetworkLockUpdate](body)
 }
 
+// NetworkLockForceLocalDisable forcibly shuts down network lock on this node.
+func (lc *LocalClient) NetworkLockForceLocalDisable(ctx context.Context) error {
+	// This endpoint expects an empty JSON stanza as the payload.
+	var b bytes.Buffer
+	if err := json.NewEncoder(&b).Encode(struct{}{}); err != nil {
+		return err
+	}
+
+	if _, err := lc.send(ctx, "POST", "/localapi/v0/tka/force-local-disable", 200, &b); err != nil {
+		return fmt.Errorf("error: %w", err)
+	}
+	return nil
+}
+
+
 // SetServeConfig sets or replaces the serving settings.
 // If config is nil, settings are cleared and serving is disabled.
 func (lc *LocalClient) SetServeConfig(ctx context.Context, config *ipn.ServeConfig) error {

--- a/cmd/tailscale/cli/network-lock.go
+++ b/cmd/tailscale/cli/network-lock.go
@@ -37,6 +37,7 @@ var netlockCmd = &ffcli.Command{
 		nlDisableCmd,
 		nlDisablementKDFCmd,
 		nlLogCmd,
+		nlLocalDisableCmd,
 	},
 	Exec: runNetworkLockStatus,
 }
@@ -346,6 +347,17 @@ func runNetworkLockDisable(ctx context.Context, args []string) error {
 		return errors.New("usage: lock disable <disablement-secret>")
 	}
 	return localClient.NetworkLockDisable(ctx, secrets[0])
+}
+
+var nlLocalDisableCmd = &ffcli.Command{
+	Name:       "local-disable",
+	ShortUsage: "local-disable",
+	ShortHelp:  "Disables the currently-active tailnet lock for this node",
+	Exec:       runNetworkLockLocalDisable,
+}
+
+func runNetworkLockLocalDisable(ctx context.Context, args []string) error {
+	return localClient.NetworkLockForceLocalDisable(ctx)
 }
 
 var nlDisablementKDFCmd = &ffcli.Command{

--- a/ipn/ipnlocal/network-lock.go
+++ b/ipn/ipnlocal/network-lock.go
@@ -25,6 +25,7 @@ import (
 	"tailscale.com/tka"
 	"tailscale.com/types/key"
 	"tailscale.com/types/netmap"
+	"tailscale.com/types/persist"
 	"tailscale.com/types/tkatype"
 	"tailscale.com/util/mak"
 )
@@ -134,7 +135,7 @@ func (b *LocalBackend) tkaSyncIfNeeded(nm *netmap.NetworkMap, prefs ipn.PrefsVie
 		}
 
 		if wantEnabled && !isEnabled {
-			if err := b.tkaBootstrapFromGenesisLocked(bs.GenesisAUM); err != nil {
+			if err := b.tkaBootstrapFromGenesisLocked(bs.GenesisAUM, prefs.Persist()); err != nil {
 				return fmt.Errorf("bootstrap: %w", err)
 			}
 			isEnabled = true
@@ -278,7 +279,7 @@ func (b *LocalBackend) chonkPathLocked() string {
 // tailnet key authority, based on the given genesis AUM.
 //
 // b.mu must be held.
-func (b *LocalBackend) tkaBootstrapFromGenesisLocked(g tkatype.MarshaledAUM) error {
+func (b *LocalBackend) tkaBootstrapFromGenesisLocked(g tkatype.MarshaledAUM, persist *persist.Persist) error {
 	if err := b.CanSupportNetworkLock(); err != nil {
 		return err
 	}
@@ -286,6 +287,19 @@ func (b *LocalBackend) tkaBootstrapFromGenesisLocked(g tkatype.MarshaledAUM) err
 	var genesis tka.AUM
 	if err := genesis.Unserialize(g); err != nil {
 		return fmt.Errorf("reading genesis: %v", err)
+	}
+
+	if persist != nil && len(persist.DisallowedTKAStateIDs) > 0 {
+		if genesis.State == nil {
+			return errors.New("invalid genesis: missing State")
+		}
+		bootstrapStateID := fmt.Sprintf("%d:%d", genesis.State.StateID1, genesis.State.StateID2)
+
+		for _, stateID := range persist.DisallowedTKAStateIDs {
+			if stateID == bootstrapStateID {
+				return fmt.Errorf("TKA with stateID of %q is disallowed on this node", stateID)
+			}
+		}
 	}
 
 	chonkDir := b.chonkPathLocked()
@@ -493,6 +507,31 @@ func (b *LocalBackend) NetworkLockKeyTrustedForTest(keyID tkatype.KeyID) bool {
 		panic("network lock not initialized")
 	}
 	return b.tka.authority.KeyTrusted(keyID)
+}
+
+// NetworkLockForceLocalDisable shuts down TKA locally, and denylists the current
+// TKA from being initialized locally in future.
+func (b *LocalBackend) NetworkLockForceLocalDisable() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.tka == nil {
+		return errNetworkLockNotActive
+	}
+
+	id1, id2 := b.tka.authority.StateIDs()
+	stateID := fmt.Sprintf("%d:%d", id1, id2)
+
+	newPrefs := b.pm.CurrentPrefs().AsStruct().Clone() // .Persist should always be initialized here.
+	newPrefs.Persist.DisallowedTKAStateIDs = append(newPrefs.Persist.DisallowedTKAStateIDs, stateID)
+	if err := b.pm.SetPrefs(newPrefs.View()); err != nil {
+		return fmt.Errorf("saving prefs: %w", err)
+	}
+
+	if err := os.RemoveAll(b.chonkPathLocked()); err != nil {
+		return fmt.Errorf("deleting TKA state: %w", err)
+	}
+	b.tka = nil
+	return nil
 }
 
 // NetworkLockSign signs the given node-key and submits it to the control plane.

--- a/tka/tka.go
+++ b/tka/tka.go
@@ -714,3 +714,8 @@ func (a *Authority) Keys() []Key {
 	}
 	return out
 }
+
+// StateIDs returns the stateIDs for this tailnet key authority.
+func (a *Authority) StateIDs() (uint64, uint64) {
+	return a.state.StateID1, a.state.StateID2
+}

--- a/types/persist/persist.go
+++ b/types/persist/persist.go
@@ -7,6 +7,7 @@ package persist
 
 import (
 	"fmt"
+	"reflect"
 
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/key"
@@ -39,6 +40,12 @@ type Persist struct {
 	UserProfile       tailcfg.UserProfile
 	NetworkLockKey    key.NLPrivate
 	NodeID            tailcfg.StableNodeID
+
+	// DisallowedTKAStateIDs stores the tka.State.StateID values which
+	// this node will not operate network lock on. This is used to
+	// prevent bootstrapping TKA onto a key authority which was forcibly
+	// disabled.
+	DisallowedTKAStateIDs []string
 }
 
 // PublicNodeKey returns the public key for the node key.
@@ -70,7 +77,8 @@ func (p *Persist) Equals(p2 *Persist) bool {
 		p.LoginName == p2.LoginName &&
 		p.UserProfile == p2.UserProfile &&
 		p.NetworkLockKey.Equal(p2.NetworkLockKey) &&
-		p.NodeID == p2.NodeID
+		p.NodeID == p2.NodeID &&
+		reflect.DeepEqual(p.DisallowedTKAStateIDs, p2.DisallowedTKAStateIDs)
 }
 
 func (p *Persist) Pretty() string {

--- a/types/persist/persist_clone.go
+++ b/types/persist/persist_clone.go
@@ -20,6 +20,7 @@ func (src *Persist) Clone() *Persist {
 	}
 	dst := new(Persist)
 	*dst = *src
+	dst.DisallowedTKAStateIDs = append(src.DisallowedTKAStateIDs[:0:0], src.DisallowedTKAStateIDs...)
 	return dst
 }
 
@@ -34,4 +35,5 @@ var _PersistCloneNeedsRegeneration = Persist(struct {
 	UserProfile                     tailcfg.UserProfile
 	NetworkLockKey                  key.NLPrivate
 	NodeID                          tailcfg.StableNodeID
+	DisallowedTKAStateIDs           []string
 }{})

--- a/types/persist/persist_test.go
+++ b/types/persist/persist_test.go
@@ -22,7 +22,7 @@ func fieldsOf(t reflect.Type) (fields []string) {
 }
 
 func TestPersistEqual(t *testing.T) {
-	persistHandles := []string{"LegacyFrontendPrivateMachineKey", "PrivateNodeKey", "OldPrivateNodeKey", "Provider", "LoginName", "UserProfile", "NetworkLockKey", "NodeID"}
+	persistHandles := []string{"LegacyFrontendPrivateMachineKey", "PrivateNodeKey", "OldPrivateNodeKey", "Provider", "LoginName", "UserProfile", "NetworkLockKey", "NodeID", "DisallowedTKAStateIDs"}
 	if have := fieldsOf(reflect.TypeOf(Persist{})); !reflect.DeepEqual(have, persistHandles) {
 		t.Errorf("Persist.Equal check might be out of sync\nfields: %q\nhandled: %q\n",
 			have, persistHandles)
@@ -131,6 +131,11 @@ func TestPersistEqual(t *testing.T) {
 		{
 			&Persist{NodeID: ""},
 			&Persist{NodeID: "abc"},
+			false,
+		},
+		{
+			&Persist{DisallowedTKAStateIDs: nil},
+			&Persist{DisallowedTKAStateIDs: []string{"0:0"}},
 			false,
 		},
 	}

--- a/types/persist/persist_view.go
+++ b/types/persist/persist_view.go
@@ -13,6 +13,7 @@ import (
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/key"
 	"tailscale.com/types/structs"
+	"tailscale.com/types/views"
 )
 
 //go:generate go run tailscale.com/cmd/cloner  -clonefunc=false -type=Persist
@@ -72,6 +73,9 @@ func (v PersistView) LoginName() string                  { return v.ж.LoginName
 func (v PersistView) UserProfile() tailcfg.UserProfile   { return v.ж.UserProfile }
 func (v PersistView) NetworkLockKey() key.NLPrivate      { return v.ж.NetworkLockKey }
 func (v PersistView) NodeID() tailcfg.StableNodeID       { return v.ж.NodeID }
+func (v PersistView) DisallowedTKAStateIDs() views.Slice[string] {
+	return views.SliceOf(v.ж.DisallowedTKAStateIDs)
+}
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _PersistViewNeedsRegeneration = Persist(struct {
@@ -84,4 +88,5 @@ var _PersistViewNeedsRegeneration = Persist(struct {
 	UserProfile                     tailcfg.UserProfile
 	NetworkLockKey                  key.NLPrivate
 	NodeID                          tailcfg.StableNodeID
+	DisallowedTKAStateIDs           []string
 }{})


### PR DESCRIPTION
Implements `tailscale lock local-disable`, which shuts down tailnet lock on the local node. This can be done on all nodes if the disablement secrets are lost by the admin but they want to disable network lock.

/cc @maisem for changes to `persist.Persist`, and that I'm doing the right sequence to update that struct in `(*LocalBackend).NetworkLockForceLocalDisable`.