### PR TITLE
cmd/tailscaled: add TS_DEBUG_BACKEND_DELAY_SEC for testing async startup

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -416,6 +416,16 @@ func startIPNServer(ctx context.Context, logf logger.Logf, logid string) error {
 
 	go func() {
 		t0 := time.Now()
+		if s, ok := envknob.LookupInt("TS_DEBUG_BACKEND_DELAY_SEC"); ok {
+			d := time.Duration(s) * time.Second
+			logf("sleeping %v before starting backend...", d)
+			select {
+			case <-time.After(d):
+				logf("slept %v; starting backend...", d)
+			case <-ctx.Done():
+				return
+			}
+		}
 		lb, err := getLocalBackend(ctx, logf, logid)
 		if err == nil {
 			logf("got LocalBackend in %v", time.Since(t0).Round(time.Millisecond))


### PR DESCRIPTION
This adds an envknob to make testing async startup more reproducible. We want the Windows GUI to behave well when wintun is not (or it's doing its initial slow driver installation), but during testing it's often too fast to see that it's working. This lets it be slowed down.

Updates #6522
