### PR TITLE
ipn/ipnlocal: use double dash flag style

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -909,7 +909,7 @@ func (b *LocalBackend) setClientStatus(st controlclient.Status) {
 
 	if st.NetMap != nil {
 		if envknob.NoLogsNoSupport() && hasCapability(st.NetMap, tailcfg.CapabilityDataPlaneAuditLogs) {
-			msg := "tailnet requires logging to be enabled. Remove -no-logs-no-support from tailscaled command line."
+			msg := "tailnet requires logging to be enabled. Remove --no-logs-no-support from tailscaled command line."
 			health.SetLocalLogConfigHealth(errors.New(msg))
 			// Connecting to this tailnet without logging is forbidden; boot us outta here.
 			b.mu.Lock()


### PR DESCRIPTION
The Go style weirds people out so we try to stick to the more well-known double hyphen style in docs.
