### PR TITLE
ipn/ipnlocal: account for ControlURL when merging profiles

### DIFF
--- a/ipn/ipnlocal/profiles_test.go
+++ b/ipn/ipnlocal/profiles_test.go
@@ -131,15 +131,22 @@ func TestProfileList(t *testing.T) {
 	if lp := pm.findProfileByName(carol.Name); lp != nil {
 		t.Fatalf("found profile for user2 in user1's profile list")
 	}
-	if lp := pm.findProfilesByNodeID(carol.NodeID); lp != nil {
+	if lp := pm.findProfilesByNodeID(carol.ControlURL, carol.NodeID); lp != nil {
 		t.Fatalf("found profile for user2 in user1's profile list")
 	}
-	if lp := pm.findProfilesByUserID(carol.UserProfile.ID); lp != nil {
+	if lp := pm.findProfilesByUserID(carol.ControlURL, carol.UserProfile.ID); lp != nil {
 		t.Fatalf("found profile for user2 in user1's profile list")
 	}
 
 	pm.SetCurrentUserID("user2")
 	checkProfiles(t, "carol")
+	if lp := pm.findProfilesByNodeID(carol.ControlURL, carol.NodeID); lp == nil {
+		t.Fatalf("did not find profile for user2 in user2's profile list")
+	}
+	if lp := pm.findProfilesByUserID(carol.ControlURL, carol.UserProfile.ID); lp == nil {
+		t.Fatalf("did not find profile for user2 in user2's profile list")
+	}
+
 }
 
 // TestProfileManagement tests creating, loading, and switching profiles.

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -741,4 +741,8 @@ type LoginProfile struct {
 	// It is only relevant on Windows where we have a multi-user system.
 	// It is assigned once at profile creation time and never changes.
 	LocalUserID WindowsUserID
+
+	// ControlURL is the URL of the control server that this profile is logged
+	// into.
+	ControlURL string
 }


### PR DESCRIPTION
We merge/dedupe profiles based on UserID and NodeID, however we were not accounting for ControlURLs.

Updates #713

Signed-off-by: Maisem Ali <maisem@tailscale.com>