### PR TITLE
ipn/ipnlocal,tailcfg: introduce capability to gate TKA init paths

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -162,6 +162,7 @@ type LocalBackend struct {
 	tka            *tkaState
 	state          ipn.State
 	capFileSharing bool // whether netMap contains the file sharing capability
+	capTailnetLock bool // whether netMap contains the tailnet lock capability
 	// hostinfo is mutated in-place while mu is held.
 	hostinfo *tailcfg.Hostinfo
 	// netMap is not mutated in-place once set.
@@ -869,6 +870,8 @@ func (b *LocalBackend) setClientStatus(st controlclient.Status) {
 	}
 	// Prefs will be written out; this is not safe unless locked or cloned.
 	if st.NetMap != nil {
+		b.capTailnetLock = hasCapability(st.NetMap, tailcfg.CapabilityTailnetLockAlpha)
+
 		b.mu.Unlock() // respect locking rules for tkaSyncIfNeeded
 		if err := b.tkaSyncIfNeeded(st.NetMap, prefs.View()); err != nil {
 			b.logf("[v1] TKA sync error: %v", err)

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -87,7 +87,8 @@ type CapabilityVersion int
 //   - 48: 2022-11-02: Node.UnsignedPeerAPIOnly
 //   - 49: 2022-11-03: Client understands EarlyNoise
 //   - 50: 2022-11-14: Client understands CapabilityIngress
-const CurrentCapabilityVersion CapabilityVersion = 50
+//   - 51: 2022-11-30: Client understands CapabilityTailnetLockAlpha
+const CurrentCapabilityVersion CapabilityVersion = 51
 
 type StableID string
 
@@ -1706,6 +1707,12 @@ const (
 	CapabilitySSHRuleIn          = "https://tailscale.com/cap/ssh-rule-in"           // some SSH rule reach this node
 	CapabilityDataPlaneAuditLogs = "https://tailscale.com/cap/data-plane-audit-logs" // feature enabled
 	CapabilityDebug              = "https://tailscale.com/cap/debug"                 // exposes debug endpoints over the PeerAPI
+
+	// CapabilityTailnetLockAlpha indicates the node is in the tailnet lock alpha,
+	// and initialization of tailnet lock may proceed.
+	//
+	// TODO(tom): Remove this for 1.35 and later.
+	CapabilityTailnetLockAlpha = "https://tailscale.com/cap/tailnet-lock-alpha"
 
 	// Inter-node capabilities as specified in the MapResponse.PacketFilter[].CapGrants.
 


### PR DESCRIPTION
**CAPVER 51**

Previously, `TAILSCALE_USE_WIP_CODE` was needed to hit a bunch of the TKA paths. With this change:

 - Enablement codepaths (`NetworkLockInit`) and initialization codepaths (`tkaBootstrapFromGenesisLocked` via `tkaSyncIfNeeded`) require either the WIP envknob or `CapabilityTailnetLockAlpha`.
 - Normal operation codepaths (`tkaSyncIfNeeded`, `tkaFilterNetmapLocked`) require TKA to be initialized, or either-or the envknob / capability.
 - Auxillary commands (ie: changing tka keys) require TKA to be initialized.

The end result is that it shouldn't be possible to initialize TKA (or subsequently use any of its features) without being sent the capability or setting the envknob on tailscaled yourself.

I've also pulled out a bunch of unnecessary checks for `CanSupportNetworkLock()`.