### PR TITLE
ipn/ipnlocal: fix netstack peerapi crash over IPv6

### DIFF
--- a/ipn/ipnlocal/peerapi.go
+++ b/ipn/ipnlocal/peerapi.go
@@ -530,7 +530,7 @@ func (pln *peerAPIListener) ServeConn(src netip.AddrPort, c net.Conn) {
 	if addH2C != nil {
 		addH2C(httpServer)
 	}
-	go httpServer.Serve(netutil.NewOneConnListener(c, pln.ln.Addr()))
+	go httpServer.Serve(netutil.NewOneConnListener(c, nil))
 }
 
 // peerAPIHandler serves the PeerAPI for a source specific client.


### PR DESCRIPTION
The peerapi IPv6 listener has a nil listener.
But we didn't need the listener's address anyway, so don't try to use it.
