### PR TITLE
cmd/tailscale/cli: capitalize Get

### DIFF
--- a/cmd/tailscale/cli/cert.go
+++ b/cmd/tailscale/cli/cert.go
@@ -28,7 +28,7 @@ import (
 var certCmd = &ffcli.Command{
 	Name:       "cert",
 	Exec:       runCert,
-	ShortHelp:  "get TLS certs",
+	ShortHelp:  "Get TLS certs",
 	ShortUsage: "cert [flags] <domain>",
 	FlagSet: (func() *flag.FlagSet {
 		fs := newFlagSet("cert")


### PR DESCRIPTION
Signed-off-by: Maya Kaczorowski <15946341+mayakacz@users.noreply.github.com>

Fixes `tailscale cert` help text to be capitalized like all other short help