### PR TITLE
api.md: update documentation for the "set ACL" endpoint

### DIFF
--- a/api.md
+++ b/api.md
@@ -485,6 +485,8 @@ Returns the updated ACL in JSON or HuJSON according to the `Accept` header on su
 ###### Headers
 `If-Match` - A request header. Set this value to the ETag header provided in an `ACL GET` request to avoid missed updates.
 
+A special value `ts-default` will ensure that ACL will be set only if current ACL is the default one (created automatically for each tailnet).
+
 `Accept` - Sets the return type of the updated ACL. Response is parsed `JSON` if `application/json` is explicitly named, otherwise HuJSON will be returned.
 
 ###### POST Body
@@ -497,6 +499,9 @@ An ACL policy may contain the following top-level properties:
 * `ACLs` - Access control lists.
 * `TagOwners` - Defines who is allowed to use which tags.
 * `Tests` - Run on ACL updates to check correct functionality of defined ACLs.
+* `AutoApprovers` - Defines which users can advertise routes or exit nodes without further approval.
+* `SSH` - Configures access policy for Tailscale SSH.
+* `NodeAttrs` - Defines which devices can use certain features.
 
 See https://tailscale.com/kb/1018/acls for more information on those properties.
 

--- a/api.md
+++ b/api.md
@@ -402,20 +402,20 @@ Etag: "e0b2816b418b3f266309d94426ac7668ab3c1fa87798785bf82f1085cc2f6d9c"
 
 // Example/default ACLs for unrestricted connections.
 {
-    "Tests": [],
+    "tests": [],
     // Declare static groups of users beyond those in the identity service.
-    "Groups": {
+    "groups": {
         "group:example": [
             "user1@example.com",
             "user2@example.com"
         ],
     },
     // Declare convenient hostname aliases to use in place of IP addresses.
-    "Hosts": {
+    "hosts": {
         "example-host-1": "100.100.100.100",
     },
     // Access control lists.
-    "ACLs": [
+    "acls": [
         // Match absolutely everything. Comment out this section if you want
         // to define specific ACL restrictions.
         {
@@ -494,14 +494,14 @@ A special value `ts-default` will ensure that ACL will be set only if current AC
 The POST body should be a JSON or [HuJSON](https://github.com/tailscale/hujson#hujson---human-json) formatted JSON object.
 An ACL policy may contain the following top-level properties:
 
-* `Groups` - Static groups of users which can be used for ACL rules.
-* `Hosts` - Hostname aliases to use in place of IP addresses or subnets.
-* `ACLs` - Access control lists.
-* `TagOwners` - Defines who is allowed to use which tags.
-* `Tests` - Run on ACL updates to check correct functionality of defined ACLs.
-* `AutoApprovers` - Defines which users can advertise routes or exit nodes without further approval.
-* `SSH` - Configures access policy for Tailscale SSH.
-* `NodeAttrs` - Defines which devices can use certain features.
+* `groups` - Static groups of users which can be used for ACL rules.
+* `hosts` - Hostname aliases to use in place of IP addresses or subnets.
+* `acls` - Access control lists.
+* `tagOwners` - Defines who is allowed to use which tags.
+* `tests` - Run on ACL updates to check correct functionality of defined ACLs.
+* `autoApprovers` - Defines which users can advertise routes or exit nodes without further approval.
+* `ssh` - Configures access policy for Tailscale SSH.
+* `nodeAttrs` - Defines which devices can use certain features.
 
 See https://tailscale.com/kb/1018/acls for more information on those properties.
 
@@ -514,22 +514,22 @@ curl 'https://api.tailscale.com/api/v2/tailnet/example.com/acl' \
   --data-binary '// Example/default ACLs for unrestricted connections.
 {
   // Declare tests to check functionality of ACL rules. User must be a valid user with registered machines.
-  "Tests": [
-    // {"User": "user1@example.com", "Allow": ["example-host-1:22"], "Deny": ["example-host-2:100"]},
+  "tests": [
+    // {"src": "user1@example.com", "accept": ["example-host-1:22"], "deny": ["example-host-2:100"]},
   ],
   // Declare static groups of users beyond those in the identity service.
-  "Groups": {
+  "groups": {
     "group:example": [ "user1@example.com", "user2@example.com" ],
   },
   // Declare convenient hostname aliases to use in place of IP addresses.
-  "Hosts": {
+  "hosts": {
     "example-host-1": "100.100.100.100",
   },
   // Access control lists.
-  "ACLs": [
+  "acls": [
     // Match absolutely everything. Comment out this section if you want
     // to define specific ACL restrictions.
-    { "Action": "accept", "Users": ["*"], "Ports": ["*:*"] },
+    { "action": "accept", "users": ["*"], "ports": ["*:*"] },
   ]
 }'
 ```
@@ -539,22 +539,22 @@ Response:
 // Example/default ACLs for unrestricted connections.
 {
   // Declare tests to check functionality of ACL rules. User must be a valid user with registered machines.
-  "Tests": [
-    // {"User": "user1@example.com", "Allow": ["example-host-1:22"], "Deny": ["example-host-2:100"]},
+  "tests": [
+    // {"src": "user1@example.com", "accept": ["example-host-1:22"], "deny": ["example-host-2:100"]},
   ],
   // Declare static groups of users beyond those in the identity service.
-  "Groups": {
+  "groups": {
     "group:example": [ "user1@example.com", "user2@example.com" ],
   },
   // Declare convenient hostname aliases to use in place of IP addresses.
-  "Hosts": {
+  "hosts": {
     "example-host-1": "100.100.100.100",
   },
   // Access control lists.
-  "ACLs": [
+  "acls": [
     // Match absolutely everything. Comment out this section if you want
     // to define specific ACL restrictions.
-    { "Action": "accept", "Users": ["*"], "Ports": ["*:*"] },
+    { "action": "accept", "users": ["*"], "ports": ["*:*"] },
   ]
 }
 ```
@@ -597,22 +597,22 @@ curl 'https://api.tailscale.com/api/v2/tailnet/example.com/acl/preview?previewFo
   --data-binary '// Example/default ACLs for unrestricted connections.
 {
   // Declare tests to check functionality of ACL rules. User must be a valid user with registered machines.
-  "Tests": [
-    // {"User": "user1@example.com", "Allow": ["example-host-1:22"], "Deny": ["example-host-2:100"]},
+  "tests": [
+    // {"src": "user1@example.com", "accept": ["example-host-1:22"], "deny": ["example-host-2:100"]},
   ],
   // Declare static groups of users beyond those in the identity service.
-  "Groups": {
+  "groups": {
     "group:example": [ "user1@example.com", "user2@example.com" ],
   },
   // Declare convenient hostname aliases to use in place of IP addresses.
-  "Hosts": {
+  "hosts": {
     "example-host-1": "100.100.100.100",
   },
   // Access control lists.
-  "ACLs": [
+  "acls": [
     // Match absolutely everything. Comment out this section if you want
     // to define specific ACL restrictions.
-    { "Action": "accept", "Users": ["*"], "Ports": ["*:*"] },
+    { "action": "accept", "users": ["*"], "ports": ["*:*"] },
   ]
 }'
 ```
@@ -648,7 +648,7 @@ curl 'https://api.tailscale.com/api/v2/tailnet/example.com/acl/validate' \
   -u "tskey-yourapikey123:" \
   --data-binary '
   [
-    {"User": "user1@example.com", "Allow": ["example-host-1:22"], "Deny": ["example-host-2:100"]}
+    {"src": "user1@example.com", "accept": ["example-host-1:22"], "deny": ["example-host-2:100"]}
   ]'
 ```
 
@@ -659,10 +659,10 @@ curl 'https://api.tailscale.com/api/v2/tailnet/example.com/acl/validate' \
   -u "tskey-yourapikey123:" \
   --data-binary '
   {
-    "ACLs": [
-     { "Action": "accept", "src": ["100.105.106.107"], "dst": ["1.2.3.4:*"] },
+    "acls": [
+     { "action": "accept", "src": ["100.105.106.107"], "dst": ["1.2.3.4:*"] },
     ],
-    "Tests", [
+    "tests", [
       {"src": "100.105.106.107", "allow": ["1.2.3.4:80"]}
     ],
   }'


### PR DESCRIPTION
This documents the `If-Match: "ts-default"` header that can be set to only overwrite the default ACL contents, and also briefly mentions a few of the new top-level ACL fields.

Updates tailscale/terraform-provider-tailscale#182

Signed-off-by: Anton Tolchanov <anton@tailscale.com>