### PR TITLE
cmd/tailscale/cli: use "account" instead of "profile" in user-visible text

### DIFF
--- a/cmd/tailscale/cli/set.go
+++ b/cmd/tailscale/cli/set.go
@@ -50,7 +50,7 @@ type setArgsT struct {
 func newSetFlagSet(goos string, setArgs *setArgsT) *flag.FlagSet {
 	setf := newFlagSet("set")
 
-	setf.StringVar(&setArgs.profileName, "nickname", "", "nickname for the login profile")
+	setf.StringVar(&setArgs.profileName, "nickname", "", "nickname for the current account")
 	setf.BoolVar(&setArgs.acceptRoutes, "accept-routes", false, "accept routes advertised by other Tailscale nodes")
 	setf.BoolVar(&setArgs.acceptDNS, "accept-dns", false, "accept DNS configuration from the admin panel")
 	setf.StringVar(&setArgs.exitNodeIP, "exit-node", "", "Tailscale exit node (IP or base name) for internet traffic, or empty string to not use an exit node")

--- a/cmd/tailscale/cli/switch.go
+++ b/cmd/tailscale/cli/switch.go
@@ -17,10 +17,10 @@ import (
 
 var switchCmd = &ffcli.Command{
 	Name:      "switch",
-	ShortHelp: "Switches to a different Tailscale profile",
+	ShortHelp: "Switches to a different Tailscale account",
 	FlagSet: func() *flag.FlagSet {
 		fs := flag.NewFlagSet("switch", flag.ExitOnError)
-		fs.BoolVar(&switchArgs.list, "list", false, "list available profiles")
+		fs.BoolVar(&switchArgs.list, "list", false, "list available accounts")
 		return fs
 	}(),
 	Exec: switchProfile,
@@ -29,7 +29,7 @@ var switchCmd = &ffcli.Command{
   [ALPHA] switch <name>
   [ALPHA] switch --list
 
-"tailscale switch" switches between logged in profiles.
+"tailscale switch" switches between logged in accounts.
 This command is currently in alpha and may change in the future.`
 	},
 }
@@ -63,7 +63,7 @@ func switchProfile(ctx context.Context, args []string) error {
 	}
 	cp, all, err := localClient.ProfileStatus(ctx)
 	if err != nil {
-		errf("Failed to switch to profile: %v\n", err)
+		errf("Failed to switch to account: %v\n", err)
 		os.Exit(1)
 	}
 	var profID ipn.ProfileID
@@ -78,14 +78,14 @@ func switchProfile(ctx context.Context, args []string) error {
 		os.Exit(1)
 	}
 	if profID == cp.ID {
-		printf("Already on profile %q\n", args[0])
+		printf("Already on account %q\n", args[0])
 		os.Exit(0)
 	}
 	if err := localClient.SwitchProfile(ctx, profID); err != nil {
-		errf("Failed to switch to profile: %v\n", err)
+		errf("Failed to switch to account: %v\n", err)
 		os.Exit(1)
 	}
-	printf("Switching to profile %q\n", args[0])
+	printf("Switching to account %q\n", args[0])
 	for {
 		select {
 		case <-ctx.Done():

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -125,7 +125,7 @@ func newUpFlagSet(goos string, upArgs *upArgsT, cmd string) *flag.FlagSet {
 	upf.DurationVar(&upArgs.timeout, "timeout", 0, "maximum amount of time to wait for tailscaled to enter a Running state; default (0s) blocks forever")
 
 	if cmd == "login" {
-		upf.StringVar(&upArgs.profileName, "nickname", "", "short name for the login profile")
+		upf.StringVar(&upArgs.profileName, "nickname", "", "short name for the account")
 	}
 
 	if cmd == "up" {


### PR DESCRIPTION
Matches the UI clients

Updates #713