### PR TITLE
paths, version/distro: detect Synology DSM version better, use for socket path

### DIFF
--- a/paths/paths.go
+++ b/paths/paths.go
@@ -30,15 +30,11 @@ func DefaultTailscaledSocket() string {
 	}
 	switch distro.Get() {
 	case distro.Synology:
-		// TODO(maisem): be smarter about this. We can parse /etc/VERSION.
-		const dsm6Sock = "/var/packages/Tailscale/etc/tailscaled.sock"
-		const dsm7Sock = "/var/packages/Tailscale/var/tailscaled.sock"
-		if fi, err := os.Stat(dsm6Sock); err == nil && !fi.IsDir() {
-			return dsm6Sock
+		if distro.DSMVersion() == 6 {
+			return "/var/packages/Tailscale/etc/tailscaled.sock"
 		}
-		if fi, err := os.Stat(dsm7Sock); err == nil && !fi.IsDir() {
-			return dsm7Sock
-		}
+		// DSM 7 (and higher? or failure to detect.)
+		return "/var/packages/Tailscale/var/tailscaled.sock"
 	case distro.Gokrazy:
 		return "/perm/tailscaled/tailscaled.sock"
 	}


### PR DESCRIPTION
Resolves a TODO in the code noted while discussing QNAP defaults.

Tested on DSM6 and DSM7.
