### PR TITLE
fix todo: eval all 2xx status codes as success in client

### DIFF
--- a/client/tailscale/acl.go
+++ b/client/tailscale/acl.go
@@ -13,6 +13,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/netip"
+
+	"tailscale.com/util/httpclient"
 )
 
 // ACLRow defines a rule that grants access by a set of users or groups to a set
@@ -83,8 +85,7 @@ func (c *Client) ACL(ctx context.Context) (acl *ACL, err error) {
 	}
 
 	// If status code was not successful, return the error.
-	// TODO: Change the check for the StatusCode to include other 2XX success codes.
-	if resp.StatusCode != http.StatusOK {
+	if !httpclient.IsSuccess(resp.StatusCode) {
 		return nil, handleErrorResponse(b, resp)
 	}
 
@@ -183,8 +184,7 @@ func (c *Client) aclPOSTRequest(ctx context.Context, body []byte, avoidCollision
 	}
 
 	// If status code was not successful, return the error.
-	// TODO: Change the check for the StatusCode to include other 2XX success codes.
-	if resp.StatusCode != http.StatusOK {
+	if !httpclient.IsSuccess(resp.StatusCode) {
 		// check if test error
 		var ate ACLTestError
 		if err := json.Unmarshal(b, &ate); err != nil {
@@ -307,8 +307,7 @@ func (c *Client) previewACLPostRequest(ctx context.Context, body []byte, preview
 	}
 
 	// If status code was not successful, return the error.
-	// TODO: Change the check for the StatusCode to include other 2XX success codes.
-	if resp.StatusCode != http.StatusOK {
+	if !httpclient.IsSuccess(resp.StatusCode) {
 		return nil, handleErrorResponse(b, resp)
 	}
 	if err = json.Unmarshal(b, &res); err != nil {

--- a/client/tailscale/devices.go
+++ b/client/tailscale/devices.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"tailscale.com/types/opt"
+	"tailscale.com/util/httpclient"
 )
 
 type GetDevicesResponse struct {
@@ -135,8 +136,7 @@ func (c *Client) Devices(ctx context.Context, fields *DeviceFieldsOpts) (deviceL
 		return nil, err
 	}
 	// If status code was not successful, return the error.
-	// TODO: Change the check for the StatusCode to include other 2XX success codes.
-	if resp.StatusCode != http.StatusOK {
+	if !httpclient.IsSuccess(resp.StatusCode) {
 		return nil, handleErrorResponse(b, resp)
 	}
 
@@ -174,8 +174,7 @@ func (c *Client) Device(ctx context.Context, deviceID string, fields *DeviceFiel
 		return nil, err
 	}
 	// If status code was not successful, return the error.
-	// TODO: Change the check for the StatusCode to include other 2XX success codes.
-	if resp.StatusCode != http.StatusOK {
+	if !httpclient.IsSuccess(resp.StatusCode) {
 		return nil, handleErrorResponse(b, resp)
 	}
 
@@ -204,8 +203,7 @@ func (c *Client) DeleteDevice(ctx context.Context, deviceID string) (err error) 
 		return err
 	}
 	// If status code was not successful, return the error.
-	// TODO: Change the check for the StatusCode to include other 2XX success codes.
-	if resp.StatusCode != http.StatusOK {
+	if !httpclient.IsSuccess(resp.StatusCode) {
 		return handleErrorResponse(b, resp)
 	}
 	return nil
@@ -224,8 +222,7 @@ func (c *Client) AuthorizeDevice(ctx context.Context, deviceID string) error {
 		return err
 	}
 	// If status code was not successful, return the error.
-	// TODO: Change the check for the StatusCode to include other 2XX success codes.
-	if resp.StatusCode != http.StatusOK {
+	if !httpclient.IsSuccess(resp.StatusCode) {
 		return handleErrorResponse(b, resp)
 	}
 
@@ -252,8 +249,7 @@ func (c *Client) SetTags(ctx context.Context, deviceID string, tags []string) er
 		return err
 	}
 	// If status code was not successful, return the error.
-	// TODO: Change the check for the StatusCode to include other 2XX success codes.
-	if resp.StatusCode != http.StatusOK {
+	if !httpclient.IsSuccess(resp.StatusCode) {
 		return handleErrorResponse(b, resp)
 	}
 

--- a/client/tailscale/dns.go
+++ b/client/tailscale/dns.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 
 	"tailscale.com/client/tailscale/apitype"
+	"tailscale.com/util/httpclient"
 )
 
 // DNSNameServers is returned when retrieving the list of nameservers.
@@ -56,8 +57,7 @@ func (c *Client) dnsGETRequest(ctx context.Context, endpoint string) ([]byte, er
 	}
 
 	// If status code was not successful, return the error.
-	// TODO: Change the check for the StatusCode to include other 2XX success codes.
-	if resp.StatusCode != http.StatusOK {
+	if !httpclient.IsSuccess(resp.StatusCode) {
 		return nil, handleErrorResponse(b, resp)
 	}
 
@@ -83,8 +83,7 @@ func (c *Client) dnsPOSTRequest(ctx context.Context, endpoint string, postData i
 	}
 
 	// If status code was not successful, return the error.
-	// TODO: Change the check for the StatusCode to include other 2XX success codes.
-	if resp.StatusCode != http.StatusOK {
+	if !httpclient.IsSuccess(resp.StatusCode) {
 		return nil, handleErrorResponse(b, resp)
 	}
 

--- a/client/tailscale/routes.go
+++ b/client/tailscale/routes.go
@@ -13,6 +13,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/netip"
+
+	"tailscale.com/util/httpclient"
 )
 
 // Routes contains the lists of subnet routes that are currently advertised by a device,
@@ -43,8 +45,7 @@ func (c *Client) Routes(ctx context.Context, deviceID string) (routes *Routes, e
 		return nil, err
 	}
 	// If status code was not successful, return the error.
-	// TODO: Change the check for the StatusCode to include other 2XX success codes.
-	if resp.StatusCode != http.StatusOK {
+	if !httpclient.IsSuccess(resp.StatusCode) {
 		return nil, handleErrorResponse(b, resp)
 	}
 
@@ -83,8 +84,7 @@ func (c *Client) SetRoutes(ctx context.Context, deviceID string, subnets []netip
 		return nil, err
 	}
 	// If status code was not successful, return the error.
-	// TODO: Change the check for the StatusCode to include other 2XX success codes.
-	if resp.StatusCode != http.StatusOK {
+	if !httpclient.IsSuccess(resp.StatusCode) {
 		return nil, handleErrorResponse(b, resp)
 	}
 

--- a/util/httpclient/httpclient.go
+++ b/util/httpclient/httpclient.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package httpclient has helpers for http clients
+// Inspiration: https://github.com/bradfitz/exp-httpclient/blob/master/problems.md
+package httpclient
+
+import (
+	"net/http"
+)
+
+// IsSuccess returns true if the http response was successful based on the response's status code
+// Defined by RFC 7231 in section 6.3: https://www.rfc-editor.org/rfc/rfc7231#section-6.3
+// Cribbed from: https://github.com/bradfitz/exp-httpclient/blob/53da77bc832c4fe16ffd283306738ebe93ed083e/http/status.go#L61-L65
+func IsSuccess(statusCode int) bool {
+	return statusCode >= http.StatusOK && statusCode < http.StatusMultipleChoices // StatusMultipleChoices == 300
+}

--- a/util/httpclient/httpclient_test.go
+++ b/util/httpclient/httpclient_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package httpclient has helpers for http clients
+package httpclient
+
+import (
+	"testing"
+)
+
+func TestIsSuccess(t *testing.T) {
+	if IsSuccess(-1) {
+		t.Error("status code = -1  returns a successful http response")
+	}
+	if IsSuccess(0) {
+		t.Error("status code = 0   returns a successful http response")
+	}
+	if IsSuccess(199) {
+		t.Error("status code = 199 returns a successful http response")
+	}
+	if !IsSuccess(200) {
+		t.Error("status code = 200 returns a failed http response")
+	}
+	if !IsSuccess(299) {
+		t.Error("status code = 299 returns a failed http response")
+	}
+	if IsSuccess(300) {
+		t.Error("status code = 300 returns a successful http response")
+	}
+}


### PR DESCRIPTION
Signed-off-by: Ariel Marcus <ajmarcus@gmail.com>

Not sure if this was still something worth addressing but noticed the following `TODO` in the client code:

```
// TODO: Change the check for the StatusCode to include other 2XX success codes.
```

Did some research that led me to this golang [proposal](https://github.com/golang/go/issues/29652) and old-ish [repo](https://github.com/bradfitz/exp-httpclient/blob/master/problems.md#too-easy-to-not-check-return-status-codes) that explores some ergonomic fixes to golang's http client.

Totally fine taking a different approach if this isn't a good solution. :)