### PR TITLE
Avoid subshell for variable outputs in docs/k8 Makefile

### DIFF
--- a/docs/k8s/Makefile
+++ b/docs/k8s/Makefile
@@ -7,22 +7,22 @@ SA_NAME ?= tailscale
 TS_KUBE_SECRET ?= tailscale
 
 rbac:
-	@sed -e "s;{{TS_KUBE_SECRET}};$(TS_KUBE_SECRET);g" role.yaml | kubectl apply -f -
-	@sed -e "s;{{SA_NAME}};$(SA_NAME);g" rolebinding.yaml | kubectl apply -f -
-	@sed -e "s;{{SA_NAME}};$(SA_NAME);g" sa.yaml | kubectl apply -f -
+	@sed -e "s;{{TS_KUBE_SECRET}};$TS_KUBE_SECRET;g" role.yaml | kubectl apply -f -
+	@sed -e "s;{{SA_NAME}};$SA_NAME;g" rolebinding.yaml | kubectl apply -f -
+	@sed -e "s;{{SA_NAME}};$SA_NAME;g" sa.yaml | kubectl apply -f -
 
 sidecar:
 	@kubectl delete -f sidecar.yaml --ignore-not-found --grace-period=0
-	@sed -e "s;{{TS_KUBE_SECRET}};$(TS_KUBE_SECRET);g" sidecar.yaml | sed -e "s;{{SA_NAME}};$(SA_NAME);g" | kubectl create -f-
+	@sed -e "s;{{TS_KUBE_SECRET}};$TS_KUBE_SECRET;g" sidecar.yaml | sed -e "s;{{SA_NAME}};$SA_NAME;g" | kubectl create -f-
 
 userspace-sidecar:
 	@kubectl delete -f userspace-sidecar.yaml --ignore-not-found --grace-period=0
-	@sed -e "s;{{TS_KUBE_SECRET}};$(TS_KUBE_SECRET);g" userspace-sidecar.yaml | sed -e "s;{{SA_NAME}};$(SA_NAME);g" | kubectl create -f-
+	@sed -e "s;{{TS_KUBE_SECRET}};$TS_KUBE_SECRET;g" userspace-sidecar.yaml | sed -e "s;{{SA_NAME}};$SA_NAME;g" | kubectl create -f-
 
 proxy:
 	kubectl delete -f proxy.yaml --ignore-not-found --grace-period=0
-	sed -e "s;{{TS_KUBE_SECRET}};$(TS_KUBE_SECRET);g" proxy.yaml | sed -e "s;{{SA_NAME}};$(SA_NAME);g" | sed -e "s;{{TS_DEST_IP}};$(TS_DEST_IP);g" | kubectl create -f-
+	sed -e "s;{{TS_KUBE_SECRET}};$TS_KUBE_SECRET;g" proxy.yaml | sed -e "s;{{SA_NAME}};$SA_NAME;g" | sed -e "s;{{TS_DEST_IP}};$TS_DEST_IP;g" | kubectl create -f-
 
 subnet-router:
 	@kubectl delete -f subnet.yaml --ignore-not-found --grace-period=0
-	@sed -e "s;{{TS_KUBE_SECRET}};$(TS_KUBE_SECRET);g" subnet.yaml | sed -e "s;{{SA_NAME}};$(SA_NAME);g" | sed -e "s;{{TS_ROUTES}};$(TS_ROUTES);g" | kubectl create -f-
+	@sed -e "s;{{TS_KUBE_SECRET}};$TS_KUBE_SECRET;g" subnet.yaml | sed -e "s;{{SA_NAME}};$SA_NAME;g" | sed -e "s;{{TS_ROUTES}};$TS_ROUTES;g" | kubectl create -f-

--- a/docs/k8s/Makefile
+++ b/docs/k8s/Makefile
@@ -7,22 +7,22 @@ SA_NAME ?= tailscale
 TS_KUBE_SECRET ?= tailscale
 
 rbac:
-	@sed -e "s;{{TS_KUBE_SECRET}};$TS_KUBE_SECRET;g" role.yaml | kubectl apply -f -
-	@sed -e "s;{{SA_NAME}};$SA_NAME;g" rolebinding.yaml | kubectl apply -f -
-	@sed -e "s;{{SA_NAME}};$SA_NAME;g" sa.yaml | kubectl apply -f -
+	@sed -e "s;{{TS_KUBE_SECRET}};${TS_KUBE_SECRET};g" role.yaml | kubectl apply -f -
+	@sed -e "s;{{SA_NAME}};${SA_NAME};g" rolebinding.yaml | kubectl apply -f -
+	@sed -e "s;{{SA_NAME}};${SA_NAME};g" sa.yaml | kubectl apply -f -
 
 sidecar:
 	@kubectl delete -f sidecar.yaml --ignore-not-found --grace-period=0
-	@sed -e "s;{{TS_KUBE_SECRET}};$TS_KUBE_SECRET;g" sidecar.yaml | sed -e "s;{{SA_NAME}};$SA_NAME;g" | kubectl create -f-
+	@sed -e "s;{{TS_KUBE_SECRET}};${TS_KUBE_SECRET};g" sidecar.yaml | sed -e "s;{{SA_NAME}};${SA_NAME};g" | kubectl create -f-
 
 userspace-sidecar:
 	@kubectl delete -f userspace-sidecar.yaml --ignore-not-found --grace-period=0
-	@sed -e "s;{{TS_KUBE_SECRET}};$TS_KUBE_SECRET;g" userspace-sidecar.yaml | sed -e "s;{{SA_NAME}};$SA_NAME;g" | kubectl create -f-
+	@sed -e "s;{{TS_KUBE_SECRET}};${TS_KUBE_SECRET};g" userspace-sidecar.yaml | sed -e "s;{{SA_NAME}};${SA_NAME};g" | kubectl create -f-
 
 proxy:
 	kubectl delete -f proxy.yaml --ignore-not-found --grace-period=0
-	sed -e "s;{{TS_KUBE_SECRET}};$TS_KUBE_SECRET;g" proxy.yaml | sed -e "s;{{SA_NAME}};$SA_NAME;g" | sed -e "s;{{TS_DEST_IP}};$TS_DEST_IP;g" | kubectl create -f-
+	sed -e "s;{{TS_KUBE_SECRET}};${TS_KUBE_SECRET};g" proxy.yaml | sed -e "s;{{SA_NAME}};${SA_NAME};g" | sed -e "s;{{TS_DEST_IP}};${TS_DEST_IP};g" | kubectl create -f-
 
 subnet-router:
 	@kubectl delete -f subnet.yaml --ignore-not-found --grace-period=0
-	@sed -e "s;{{TS_KUBE_SECRET}};$TS_KUBE_SECRET;g" subnet.yaml | sed -e "s;{{SA_NAME}};$SA_NAME;g" | sed -e "s;{{TS_ROUTES}};$TS_ROUTES;g" | kubectl create -f-
+	@sed -e "s;{{TS_KUBE_SECRET}};${TS_KUBE_SECRET};g" subnet.yaml | sed -e "s;{{SA_NAME}};${SA_NAME};g" | sed -e "s;{{TS_ROUTES}};${TS_ROUTES};g" | kubectl create -f-


### PR DESCRIPTION
docs/k8s Makefile has been updated to output variables.

Prior to this change bash-like shells would interpret `$(...)` as a subshell and essentially yield an empty string. I'm presuming this was originally intended to be curly braces?
```
zsh: command not found: TS_KUBE_SECRET
zsh: command not found: TS_DEST_IP
zsh: command not found: SA_NAME
```