### PR TITLE
net/tlsdial,tstest,version: use go command from $PATH

### DIFF
--- a/net/tlsdial/tlsdial_test.go
+++ b/net/tlsdial/tlsdial_test.go
@@ -43,7 +43,7 @@ func TestFallbackRootWorks(t *testing.T) {
 	crtFile := filepath.Join(d, "tlsdial.test.crt")
 	keyFile := filepath.Join(d, "tlsdial.test.key")
 	caFile := filepath.Join(d, "rootCA.pem")
-	cmd := exec.Command(filepath.Join(runtime.GOROOT(), "bin", "go"),
+	cmd := exec.Command("go",
 		"run", "filippo.io/mkcert",
 		"--cert-file="+crtFile,
 		"--key-file="+keyFile,

--- a/tstest/archtest/qemu_test.go
+++ b/tstest/archtest/qemu_test.go
@@ -11,8 +11,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -53,7 +51,7 @@ func TestInQemu(t *testing.T) {
 				}
 				t.Logf("using %v", look)
 			}
-			cmd := exec.Command(filepath.Join(runtime.GOROOT(), "bin", "go"),
+			cmd := exec.Command("go",
 				"test",
 				"--exec="+execVia,
 				"-v",

--- a/tstest/iosdeps/iosdeps_test.go
+++ b/tstest/iosdeps/iosdeps_test.go
@@ -13,13 +13,11 @@ import (
 	"encoding/json"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"runtime"
 	"testing"
 )
 
 func TestDeps(t *testing.T) {
-	cmd := exec.Command(filepath.Join(runtime.GOROOT(), "bin", "go"), "list", "-json", ".")
+	cmd := exec.Command("go", "list", "-json", ".")
 	cmd.Env = append(os.Environ(), "GOOS=ios", "GOARCH=arm64")
 	out, err := cmd.Output()
 	if err != nil {

--- a/tstest/jsdeps/jsdeps_test.go
+++ b/tstest/jsdeps/jsdeps_test.go
@@ -13,13 +13,11 @@ import (
 	"encoding/json"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"runtime"
 	"testing"
 )
 
 func TestDeps(t *testing.T) {
-	cmd := exec.Command(filepath.Join(runtime.GOROOT(), "bin", "go"), "list", "-json", ".")
+	cmd := exec.Command("go", "list", "-json", ".")
 	cmd.Env = append(os.Environ(), "GOOS=js", "GOARCH=wasm")
 	out, err := cmd.Output()
 	if err != nil {

--- a/version/modinfo_test.go
+++ b/version/modinfo_test.go
@@ -23,8 +23,7 @@ var (
 func TestFindModuleInfo(t *testing.T) {
 	dir := t.TempDir()
 	name := filepath.Join(dir, "tailscaled-version-test")
-	goTool := filepath.Join(runtime.GOROOT(), "bin", "go"+exe())
-	out, err := exec.Command(goTool, "build", "-o", name, "tailscale.com/cmd/tailscaled").CombinedOutput()
+	out, err := exec.Command("go", "build", "-o", name, "tailscale.com/cmd/tailscaled").CombinedOutput()
 	if err != nil {
 		t.Fatalf("failed to build tailscaled: %v\n%s", err, out)
 	}


### PR DESCRIPTION
Go now includes the GOROOT bin directory in $PATH while running tests and generate, so it is no longer necessary to construct a path using runtime.GOROOT().

Fixes #6689

Signed-off-by: James Tucker <james@tailscale.com>