### PR TITLE
cmd/k8s-operator: sprinkle debug/info logging throughout.

### DIFF
--- a/cmd/k8s-operator/operator.go
+++ b/cmd/k8s-operator/operator.go
@@ -380,7 +380,7 @@ func (a *ServiceReconciler) Reconcile(ctx context.Context, req reconcile.Request
 		if err := a.Status().Update(ctx, svc); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to update service status: %w", err)
 		}
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+		return reconcile.Result{}, nil
 	}
 
 	logger.Debugf("setting ingress hostname to %q", tsHost)

--- a/cmd/k8s-operator/operator_test.go
+++ b/cmd/k8s-operator/operator_test.go
@@ -60,7 +60,7 @@ func TestLoadBalancerClass(t *testing.T) {
 		},
 	})
 
-	expectRequeue(t, sr, "default", "test")
+	expectReconciled(t, sr, "default", "test")
 
 	fullName, shortName := findGenName(t, fc, "default", "test")
 
@@ -394,7 +394,7 @@ func TestLBIntoAnnotation(t *testing.T) {
 		},
 	})
 
-	expectRequeue(t, sr, "default", "test")
+	expectReconciled(t, sr, "default", "test")
 
 	fullName, shortName := findGenName(t, fc, "default", "test")
 

--- a/cmd/k8s-operator/operator_test.go
+++ b/cmd/k8s-operator/operator_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -28,12 +29,17 @@ import (
 func TestLoadBalancerClass(t *testing.T) {
 	fc := fake.NewFakeClient()
 	ft := &fakeTSClient{}
+	zl, err := zap.NewDevelopment()
+	if err != nil {
+		t.Fatal(err)
+	}
 	sr := &ServiceReconciler{
 		Client:            fc,
 		tsClient:          ft,
 		defaultTags:       []string{"tag:k8s"},
 		operatorNamespace: "operator-ns",
 		proxyImage:        "tailscale/tailscale",
+		logger:            zl.Sugar(),
 	}
 
 	// Create a service that we should manage, and check that the initial round
@@ -142,12 +148,17 @@ func TestLoadBalancerClass(t *testing.T) {
 func TestAnnotations(t *testing.T) {
 	fc := fake.NewFakeClient()
 	ft := &fakeTSClient{}
+	zl, err := zap.NewDevelopment()
+	if err != nil {
+		t.Fatal(err)
+	}
 	sr := &ServiceReconciler{
 		Client:            fc,
 		tsClient:          ft,
 		defaultTags:       []string{"tag:k8s"},
 		operatorNamespace: "operator-ns",
 		proxyImage:        "tailscale/tailscale",
+		logger:            zl.Sugar(),
 	}
 
 	// Create a service that we should manage, and check that the initial round
@@ -234,12 +245,17 @@ func TestAnnotations(t *testing.T) {
 func TestAnnotationIntoLB(t *testing.T) {
 	fc := fake.NewFakeClient()
 	ft := &fakeTSClient{}
+	zl, err := zap.NewDevelopment()
+	if err != nil {
+		t.Fatal(err)
+	}
 	sr := &ServiceReconciler{
 		Client:            fc,
 		tsClient:          ft,
 		defaultTags:       []string{"tag:k8s"},
 		operatorNamespace: "operator-ns",
 		proxyImage:        "tailscale/tailscale",
+		logger:            zl.Sugar(),
 	}
 
 	// Create a service that we should manage, and check that the initial round
@@ -347,12 +363,17 @@ func TestAnnotationIntoLB(t *testing.T) {
 func TestLBIntoAnnotation(t *testing.T) {
 	fc := fake.NewFakeClient()
 	ft := &fakeTSClient{}
+	zl, err := zap.NewDevelopment()
+	if err != nil {
+		t.Fatal(err)
+	}
 	sr := &ServiceReconciler{
 		Client:            fc,
 		tsClient:          ft,
 		defaultTags:       []string{"tag:k8s"},
 		operatorNamespace: "operator-ns",
 		proxyImage:        "tailscale/tailscale",
+		logger:            zl.Sugar(),
 	}
 
 	// Create a service that we should manage, and check that the initial round

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/frankban/quicktest v1.14.0
 	github.com/fxamacker/cbor/v2 v2.4.0
 	github.com/go-json-experiment/json v0.0.0-20221017203807-c5ed296b8c92
+	github.com/go-logr/zapr v1.2.3
 	github.com/go-ole/go-ole v1.2.6
 	github.com/godbus/dbus/v5 v5.0.6
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
@@ -64,6 +65,7 @@ require (
 	github.com/toqueteos/webbrowser v1.2.0
 	github.com/u-root/u-root v0.9.1-0.20221111022710-6e9699743f5d
 	github.com/vishvananda/netlink v1.1.1-0.20211118161826-650dca95af54
+	go.uber.org/zap v1.21.0
 	go4.org/mem v0.0.0-20210711025021-927187094b94
 	go4.org/netipx v0.0.0-20220725152314-7e7bdc8411bf
 	golang.org/x/crypto v0.3.0
@@ -154,7 +156,6 @@ require (
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
 	github.com/go-git/go-git/v5 v5.4.2 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
-	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.14 // indirect
@@ -297,7 +298,6 @@ require (
 	github.com/yeya24/promlinter v0.1.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20220328175248-053ad81199eb // indirect
 	golang.org/x/image v0.0.0-20201208152932-35266b937fa6 // indirect
 	golang.org/x/mod v0.6.0 // indirect


### PR DESCRIPTION
As is convention in the k8s world, use zap for structured logging. For development, OPERATOR_LOGGING=dev switches to a more human-readable output than JSON.

Updates #502

Signed-off-by: David Anderson <danderson@tailscale.com>