### PR TITLE
cmd/k8s-operator: use oauth credentials for API access.

### DIFF
--- a/cmd/k8s-operator/manifests/operator.yaml
+++ b/cmd/k8s-operator/manifests/operator.yaml
@@ -79,6 +79,14 @@ roleRef:
   name: operator
   apiGroup: rbac.authorization.k8s.io
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tailscale-operator-oauth
+stringData:
+  client_id: # SET CLIENT ID HERE
+  client_secret: # SET CLIENT SECRET HERE
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -96,6 +104,10 @@ spec:
         app: tailscale-operator
     spec:
       serviceAccountName: operator
+      volumes:
+      - name: oauth
+        secret:
+          secretName: tailscale-operator-oauth
       containers:
         - name: tailscale-operator
           image: tailscale/k8s-operator:latest
@@ -108,7 +120,15 @@ spec:
               value: tailscale-operator
             - name: OPERATOR_SECRET
               value: tailscale-operator
+            - name: CLIENT_ID_FILE
+              value: /oauth/client_id
+            - name: CLIENT_SECRET_FILE
+              value: /oauth/client_secret
             - name: PROXY_IMAGE
               value: tailscale/tailscale:latest
             - name: PROXY_TAGS
               value: tag:k8s
+          volumeMounts:
+          - name: oauth
+            mountPath: /oauth
+            readOnly: true

--- a/go.mod
+++ b/go.mod
@@ -71,6 +71,7 @@ require (
 	golang.org/x/crypto v0.3.0
 	golang.org/x/exp v0.0.0-20221205204356-47842c84f3db
 	golang.org/x/net v0.2.0
+	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	golang.org/x/sys v0.2.0
 	golang.org/x/term v0.2.0
@@ -301,7 +302,6 @@ require (
 	golang.org/x/exp/typeparams v0.0.0-20220328175248-053ad81199eb // indirect
 	golang.org/x/image v0.0.0-20201208152932-35266b937fa6 // indirect
 	golang.org/x/mod v0.6.0 // indirect
-	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect
 	golang.org/x/text v0.4.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect


### PR DESCRIPTION
This automates both the operator's initial login, and provisioning/deprovisioning of proxies.

Signed-off-by: David Anderson <danderson@tailscale.com>