### PR TITLE
cmd/k8s-operator: move the operator into its own namespace.

### DIFF
--- a/cmd/k8s-operator/manifests/operator.yaml
+++ b/cmd/k8s-operator/manifests/operator.yaml
@@ -3,16 +3,23 @@
 # license that can be found in the LICENSE file.
 
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: tailscale
+---
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: proxies
+  namespace: tailscale
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: proxies
+  namespace: tailscale
 rules:
-- apiGroups: [""] # "" indicates the core API group
+- apiGroups: [""]
   resources: ["secrets"]
   verbs: ["*"]
 ---
@@ -20,9 +27,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: proxies
+  namespace: tailscale
 subjects:
 - kind: ServiceAccount
   name: proxies
+  namespace: tailscale
 roleRef:
   kind: Role
   name: proxies
@@ -32,6 +41,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: operator
+  namespace: tailscale
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -49,7 +59,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: operator
-  namespace: default
+  namespace: tailscale
 roleRef:
   kind: ClusterRole
   name: tailscale-operator
@@ -59,8 +69,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: operator
+  namespace: tailscale
 rules:
-- apiGroups: [""] # "" indicates the core API group
+- apiGroups: [""]
   resources: ["secrets"]
   verbs: ["*"]
 - apiGroups: ["apps"]
@@ -71,9 +82,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: operator
+  namespace: tailscale
 subjects:
 - kind: ServiceAccount
   name: operator
+  namespace: tailscale
 roleRef:
   kind: Role
   name: operator
@@ -82,7 +95,8 @@ roleRef:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: tailscale-operator-oauth
+  name: operator-oauth
+  namespace: tailscale
 stringData:
   client_id: # SET CLIENT ID HERE
   client_secret: # SET CLIENT SECRET HERE
@@ -90,26 +104,27 @@ stringData:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: tailscale-operator
+  name: operator
+  namespace: tailscale
 spec:
   replicas: 1
   strategy:
     type: Recreate
   selector:
     matchLabels:
-      app: tailscale-operator
+      app: operator
   template:
     metadata:
       labels:
-        app: tailscale-operator
+        app: operator
     spec:
       serviceAccountName: operator
       volumes:
       - name: oauth
         secret:
-          secretName: tailscale-operator-oauth
+          secretName: operator-oauth
       containers:
-        - name: tailscale-operator
+        - name: operator
           image: tailscale/k8s-operator:latest
           resources:
             requests:
@@ -119,7 +134,13 @@ spec:
             - name: OPERATOR_HOSTNAME
               value: tailscale-operator
             - name: OPERATOR_SECRET
-              value: tailscale-operator
+              value: operator
+            - name: OPERATOR_LOGGING
+              value: info
+            - name: OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: CLIENT_ID_FILE
               value: /oauth/client_id
             - name: CLIENT_SECRET_FILE

--- a/cmd/k8s-operator/operator.go
+++ b/cmd/k8s-operator/operator.go
@@ -54,7 +54,7 @@ func main() {
 		hostname         = defaultEnv("OPERATOR_HOSTNAME", "tailscale-operator")
 		kubeSecret       = defaultEnv("OPERATOR_SECRET", "")
 		operatorTags     = defaultEnv("OPERATOR_INITIAL_TAGS", "tag:k8s-operator")
-		tsNamespace      = defaultEnv("OPERATOR_NAMESPACE", "default")
+		tsNamespace      = defaultEnv("OPERATOR_NAMESPACE", "")
 		tslogging        = defaultEnv("OPERATOR_LOGGING", "info")
 		clientIDPath     = defaultEnv("CLIENT_ID_FILE", "")
 		clientSecretPath = defaultEnv("CLIENT_SECRET_FILE", "")


### PR DESCRIPTION
The operator creates a fair bit of internal cluster state to manage proxying, dumping it all in the default namespace is handy for development but rude for production.

Updates #502

Signed-off-by: David Anderson <danderson@tailscale.com>