### PR TITLE
ipn/ipnserver: propagate http.Serve error

### DIFF
--- a/ipn/ipnserver/server.go
+++ b/ipn/ipnserver/server.go
@@ -516,6 +516,7 @@ func (s *Server) Run(ctx context.Context, ln net.Listener) error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
This ensures that we capture error returned by `Serve` and exit with a non-zero exit code if it happens.

Signed-off-by: Anton Tolchanov <anton@tailscale.com>