### PR TITLE
ipn/ipnlocal: maintain a proxy handler per backend

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -206,7 +206,8 @@ type LocalBackend struct {
 	lastServeConfJSON mem.RO              // last JSON that was parsed into serveConfig
 	serveConfig       ipn.ServeConfigView // or !Valid if none
 
-	serveListeners map[netip.AddrPort]*serveListener // addrPort => serveListener
+	serveListeners       map[netip.AddrPort]*serveListener // addrPort => serveListener
+	serveProxyTransports map[string]*http.Transport        // proxy backend (HTTPHandler.Proxy) => http.Transport
 
 	// statusLock must be held before calling statusChanged.Wait() or
 	// statusChanged.Broadcast().

--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -402,6 +402,12 @@ func (b *LocalBackend) proxyHandlerForBackend(backend string) (*httputil.Reverse
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: insecure,
 		},
+		// Values for the following parameters have been copied from http.DefaultTransport.
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
 	}
 	return rp, nil
 }


### PR DESCRIPTION
By default, `http.Transport` keeps idle connections open hoping to re-use them in the future. Combined with a separate transport per request in HTTP proxy this results in idle connection leak.

I initially added simple transport caching per backend (see first commit) but then decided to keep proxy handlers per backend, which is a bit more complex given its interactions with prefs.