### PR TITLE
net/dns: bump DNS-over-TCP size limit to 4k

### DIFF
--- a/net/dns/manager.go
+++ b/net/dns/manager.go
@@ -427,8 +427,8 @@ const (
 	// The RFCs don't specify the max size of a TCP-based DNS query,
 	// but we want to keep this reasonable. Given payloads are typically
 	// much larger and all known client send a single query, I've arbitrarily
-	// chosen 2k.
-	maxReqSizeTCP = 2048
+	// chosen 4k.
+	maxReqSizeTCP = 4096
 )
 
 // dnsTCPSession services DNS requests sent over TCP.


### PR DESCRIPTION
We saw a few cases where we hit this limit; bumping to 4k seems relatively uncontroversial.

Change-Id: I218fee3bc0d2fa5fde16eddc36497a73ebd7cbda
Signed-off-by: Andrew Dunham <andrew@du.nham.ca>