### PR TITLE
tsnet: fix handling of non-empty hostnames in Server.Listen

### DIFF
--- a/tsnet/tsnet_test.go
+++ b/tsnet/tsnet_test.go
@@ -28,11 +28,15 @@ func TestListenerPort(t *testing.T) {
 		wantErr bool
 	}{
 		{"tcp", ":80", false},
+		{"tcp4", ":9001", false},
+		{"tcp6", ":10023", false},
+		{"tcp", ":80", false},
 		{"foo", ":80", true},
 		{"tcp", ":http", false},  // built-in name to Go; doesn't require cgo, /etc/services
 		{"tcp", ":https", false}, // built-in name to Go; doesn't require cgo, /etc/services
 		{"tcp", ":gibberishsdlkfj", true},
 		{"tcp", ":%!d(string=80)", true}, // issue 6201
+		{"tcp", "wharrgarbl:2023", true}, // issue 6815
 	}
 	for _, tt := range tests {
 		s := &Server{}


### PR DESCRIPTION
tsnet: fix handling of non-empty hostname in Server.Listen

If Listen is called with a non-empty hostname, packets will not correctly be
forwarded. Document that the hostname must be empty, and report an error if it
is not.

Since the hostname is now definitely empty, omit it from the listener's lookup
plumbing.

Moreover, since we only support TCP protocols, that does not need to be part of
the lookup key either.

Fixes #6815.
