### PR TITLE
wgengine/monitor: don't log unhandled RTM_{NEW,DEL}LINK messages

### DIFF
--- a/wgengine/monitor/monitor_linux.go
+++ b/wgengine/monitor/monitor_linux.go
@@ -228,6 +228,10 @@ func (c *nlConn) Receive() (message, error) {
 			c.logf("%+v", rdm)
 		}
 		return rdm, nil
+	case unix.RTM_NEWLINK, unix.RTM_DELLINK:
+		// This is an unhandled message, but don't print an error.
+		// See https://github.com/tailscale/tailscale/issues/6806
+		return unspecifiedMessage{}, nil
 	default:
 		c.logf("unhandled netlink msg type %+v, %q", msg.Header, msg.Data)
 		return unspecifiedMessage{}, nil


### PR DESCRIPTION
These aren't handled, but it's not an error to get one.

Fixes #6806

Signed-off-by: Andrew Dunham <andrew@tailscale.com>
Change-Id: I1fcb9032ac36420aa72a048bf26f58360b9461f9