### PR TITLE
wgengine/netstack: require local backend for netstack start

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -533,8 +533,7 @@ func getLocalBackend(ctx context.Context, logf logger.Logf, logid string) (_ *ip
 		return smallzstd.NewDecoder(nil)
 	})
 	configureTaildrop(logf, lb)
-	ns.SetLocalBackend(lb)
-	if err := ns.Start(); err != nil {
+	if err := ns.Start(lb); err != nil {
 		log.Fatalf("failed to start netstack: %v", err)
 	}
 	return lb, nil

--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -317,9 +317,6 @@ func (s *Server) start() (reterr error) {
 	}
 	ns.ProcessLocalIPs = true
 	ns.ForwardTCPIn = s.forwardTCP
-	if err := ns.Start(); err != nil {
-		return fmt.Errorf("failed to start netstack: %w", err)
-	}
 	s.netstack = ns
 	s.dialer.UseNetstackForIP = func(ip netip.Addr) bool {
 		_, ok := eng.PeerForIP(ip)
@@ -349,6 +346,9 @@ func (s *Server) start() (reterr error) {
 	lb.SetVarRoot(s.rootPath)
 	logf("tsnet starting with hostname %q, varRoot %q", s.hostname, s.rootPath)
 	s.lb = lb
+	if err := ns.Start(lb); err != nil {
+		return fmt.Errorf("failed to start netstack: %w", err)
+	}
 	closePool.addFunc(func() { s.lb.Shutdown() })
 	lb.SetDecompressor(func() (controlclient.Decompressor, error) {
 		return smallzstd.NewDecoder(nil)

--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -204,12 +204,6 @@ func (ns *Impl) Close() error {
 	return nil
 }
 
-// SetLocalBackend sets the LocalBackend; it should only be run before
-// the Start method is called.
-func (ns *Impl) SetLocalBackend(lb *ipnlocal.LocalBackend) {
-	ns.lb = lb
-}
-
 // wrapProtoHandler returns protocol handler h wrapped in a version
 // that dynamically reconfigures ns's subnet addresses as needed for
 // outbound traffic.
@@ -231,7 +225,11 @@ func (ns *Impl) wrapProtoHandler(h func(stack.TransportEndpointID, stack.PacketB
 
 // Start sets up all the handlers so netstack can start working. Implements
 // wgengine.FakeImpl.
-func (ns *Impl) Start() error {
+func (ns *Impl) Start(lb *ipnlocal.LocalBackend) error {
+	if lb == nil {
+		panic("nil LocalBackend")
+	}
+	ns.lb = lb
 	ns.e.AddNetworkMapCallback(ns.updateIPs)
 	// size = 0 means use default buffer size
 	const tcpReceiveBufferSize = 0


### PR DESCRIPTION
Local backend is used in determining if tailscale 4via6 forwarding needs to be used - enforcing local backend to be passed into the netstack start method will ensure that all tailscale clients will have a local backend. The mac client didn't initialize netstack w/ a local backend, and thus 4via6 routing didn't work for macos clients. 

Updates tailscale/tailscale#6764 (then needs macOS client changes too)