### PR TITLE
Add automation to maintain flake.nix hashes.

### DIFF
--- a/cmd/nardump/README.md
+++ b/cmd/nardump/README.md
@@ -1,0 +1,7 @@
+# nardump
+
+nardump is like nix-store --dump, but in Go, writing a NAR file (tar-like,
+but focused on being reproducible) to stdout or to a hash with the --sri flag.
+
+It lets us calculate the Nix sha256 in shell.nix without the person running
+git-pull-oss.sh having Nix available.

--- a/cmd/nardump/nardump.go
+++ b/cmd/nardump/nardump.go
@@ -1,0 +1,185 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// nardump is like nix-store --dump, but in Go, writing a NAR
+// file (tar-like, but focused on being reproducible) to stdout
+// or to a hash with the --sri flag.
+//
+// It lets us calculate a Nix sha256 without the person running
+// git-pull-oss.sh having Nix available.
+package main
+
+// For the format, see:
+// See https://gist.github.com/jbeda/5c79d2b1434f0018d693
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"log"
+	"os"
+	"path"
+	"sort"
+)
+
+var sri = flag.Bool("sri", false, "print SRI")
+
+func main() {
+	flag.Parse()
+	if flag.NArg() != 1 {
+		log.Fatal("usage: nardump <dir>")
+	}
+	arg := flag.Arg(0)
+	if err := os.Chdir(arg); err != nil {
+		log.Fatal(err)
+	}
+	if *sri {
+		hash := sha256.New()
+		if err := writeNAR(hash, os.DirFS(".")); err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("sha256-%s\n", base64.StdEncoding.EncodeToString(hash.Sum(nil)))
+		return
+	}
+	bw := bufio.NewWriter(os.Stdout)
+	if err := writeNAR(bw, os.DirFS(".")); err != nil {
+		log.Fatal(err)
+	}
+	bw.Flush()
+}
+
+// writeNARError is a sentinel panic type that's recovered by writeNAR
+// and converted into the wrapped error.
+type writeNARError struct{ err error }
+
+// narWriter writes NAR files.
+type narWriter struct {
+	w  io.Writer
+	fs fs.FS
+}
+
+// writeNAR writes a NAR file to w from the root of fs.
+func writeNAR(w io.Writer, fs fs.FS) (err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			if we, ok := e.(writeNARError); ok {
+				err = we.err
+				return
+			}
+			panic(e)
+		}
+	}()
+	nw := &narWriter{w: w, fs: fs}
+	nw.str("nix-archive-1")
+	return nw.writeDir(".")
+}
+
+func (nw *narWriter) writeDir(dirPath string) error {
+	ents, err := fs.ReadDir(nw.fs, dirPath)
+	if err != nil {
+		return err
+	}
+	sort.Slice(ents, func(i, j int) bool {
+		return ents[i].Name() < ents[j].Name()
+	})
+	nw.str("(")
+	nw.str("type")
+	nw.str("directory")
+	for _, ent := range ents {
+		nw.str("entry")
+		nw.str("(")
+		nw.str("name")
+		nw.str(ent.Name())
+		nw.str("node")
+		mode := ent.Type()
+		sub := path.Join(dirPath, ent.Name())
+		var err error
+		switch {
+		case mode.IsRegular():
+			err = nw.writeRegular(sub)
+		case mode.IsDir():
+			err = nw.writeDir(sub)
+		default:
+			// TODO(bradfitz): symlink, but requires fighting io/fs a bit
+			// to get at Readlink or the osFS via fs. But for now
+			// we don't need symlinks because they're not in Go's archive.
+			return fmt.Errorf("unsupported file type %v at %q", sub, mode)
+		}
+		if err != nil {
+			return err
+		}
+		nw.str(")")
+	}
+	nw.str(")")
+	return nil
+}
+
+func (nw *narWriter) writeRegular(path string) error {
+	nw.str("(")
+	nw.str("type")
+	nw.str("regular")
+	fi, err := fs.Stat(nw.fs, path)
+	if err != nil {
+		return err
+	}
+	if fi.Mode()&0111 != 0 {
+		nw.str("executable")
+		nw.str("")
+	}
+	contents, err := fs.ReadFile(nw.fs, path)
+	if err != nil {
+		return err
+	}
+	nw.str("contents")
+	if err := writeBytes(nw.w, contents); err != nil {
+		return err
+	}
+	nw.str(")")
+	return nil
+}
+
+func (nw *narWriter) str(s string) {
+	if err := writeString(nw.w, s); err != nil {
+		panic(writeNARError{err})
+	}
+}
+
+func writeString(w io.Writer, s string) error {
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(len(s)))
+	if _, err := w.Write(buf[:]); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, s); err != nil {
+		return err
+	}
+	return writePad(w, len(s))
+}
+
+func writeBytes(w io.Writer, b []byte) error {
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(len(b)))
+	if _, err := w.Write(buf[:]); err != nil {
+		return err
+	}
+	if _, err := w.Write(b); err != nil {
+		return err
+	}
+	return writePad(w, len(b))
+}
+
+func writePad(w io.Writer, n int) error {
+	pad := n % 8
+	if pad == 0 {
+		return nil
+	}
+	var zeroes [8]byte
+	_, err := w.Write(zeroes[:8-pad])
+	return err
+}

--- a/flake.nix
+++ b/flake.nix
@@ -141,14 +141,17 @@
       };
       devShell = pkgs.mkShell {
         packages = with upstreamPkgs; [
-          pkgs.tailscale_go
+          curl
           git
-          gotools
           gopls
+          gotools
           graphviz
+          perl
+          pkgs.tailscale_go
         ];
       };
     };
   in
     flake-utils.lib.eachDefaultSystem (system: flakeForSystem nixpkgs system);
 }
+# nix-direnv cache busting line: sha256-imidcDJGVor43PqdTX7Js4/tjQ0JA2E1GdjuyLiPDHI= sha256-+5icFKDHXt3JMbUjLQGes4R+GeUi48xRgGd0yPKVrw0=

--- a/go.toolchain.sri
+++ b/go.toolchain.sri
@@ -1,1 +1,1 @@
-sha256-BvwZ/90izw0Ip3lh8eNkJvU46LKnOOhEXF0axkBi/Es=
+sha256-imidcDJGVor43PqdTX7Js4/tjQ0JA2E1GdjuyLiPDHI=

--- a/pull-toolchain.sh
+++ b/pull-toolchain.sh
@@ -9,8 +9,9 @@ upstream=$(git ls-remote https://github.com/tailscale/go "$go_branch" | awk '{pr
 current=$(cat go.toolchain.rev)
 if [ "$upstream" != "$current" ]; then
 	echo "$upstream" >go.toolchain.rev
+	./update-flake.sh
 fi
 
-if [ -n "$(git diff-index --name-only HEAD -- go.toolchain.rev)" ]; then
+if [ -n "$(git diff-index --name-only HEAD -- go.toolchain.rev go.toolchain.sri go.mod.sri)" ]; then
     echo "pull-toolchain.sh: changes imported. Use git commit to make them permanent." >&2
 fi

--- a/shell.nix
+++ b/shell.nix
@@ -7,7 +7,6 @@
 # Also look into direnv: https://direnv.net/, this can make it so that you can
 # automatically get your environment set up when you change folders into the
 # project.
-
 (import (
   let
     lock = builtins.fromJSON (builtins.readFile ./flake.lock);
@@ -17,3 +16,4 @@
 ) {
   src =  ./.;
 }).shellNix
+# nix-direnv cache busting line: sha256-imidcDJGVor43PqdTX7Js4/tjQ0JA2E1GdjuyLiPDHI= sha256-+5icFKDHXt3JMbUjLQGes4R+GeUi48xRgGd0yPKVrw0=

--- a/update-flake.sh
+++ b/update-flake.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Updates SRI hashes for flake.nix.
+
+set -eu
+
+REV=$(cat go.toolchain.rev)
+
+OUT=$(mktemp -d -t nar-hash-XXXXXX)
+rm -rf $OUT
+
+mkdir $OUT
+curl --silent -L https://github.com/tailscale/go/archive/refs/tags/build-$REV.tar.gz | tar -zx -C $OUT --strip-components 1
+go run tailscale.com/cmd/nardump --sri $OUT >go.toolchain.sri
+rm -rf $OUT
+
+go mod vendor -o $OUT
+go run tailscale.com/cmd/nardump --sri $OUT >go.mod.sri
+rm -rf $OUT
+
+# nix-direnv only watches the top-level nix file for changes. As a
+# result, when we change a referenced SRI file, we have to cause some
+# change to shell.nix and flake.nix as well, so that nix-direnv
+# notices and reevaluates everything. Sigh.
+perl -pi -e "s,# nix-direnv cache busting line:.*,# nix-direnv cache busting line: $(cat go.toolchain.sri) $(cat go.mod.sri)," shell.nix
+perl -pi -e "s,# nix-direnv cache busting line:.*,# nix-direnv cache busting line: $(cat go.toolchain.sri) $(cat go.mod.sri)," flake.nix


### PR DESCRIPTION
Keeps both the Go toolchain and go.mod SRI files up to date with `./update-flake.sh`. Incidentally, this also let me know I'd set the wrong toolchain SRI in the first place, and because of nix's cache-hit behavior it didn't tell me about it. Sigh.

This moves misc/nardump from our corp repo into oss, so that the tooling can invoke it here. Using git trickery, I made the nardump commit be authored by @bradfitz, to preserve authorship for posterity. I signed-off the commit though, since I'm the one pinky-swearing this code is okay per our DCO.