### PR TITLE
cmd/printdep: support printing the toolchain SRI hash.

### DIFF
--- a/cmd/printdep/printdep.go
+++ b/cmd/printdep/printdep.go
@@ -19,6 +19,7 @@ import (
 var (
 	goToolchain    = flag.Bool("go", false, "print the supported Go toolchain git hash (a github.com/tailscale/go commit)")
 	goToolchainURL = flag.Bool("go-url", false, "print the URL to the tarball of the Tailscale Go toolchain")
+	goToolchainSRI = flag.Bool("go-sri", false, "print the SRI hash of the Tailscale Go toolchain")
 	alpine         = flag.Bool("alpine", false, "print the tag of alpine docker image")
 )
 
@@ -47,5 +48,8 @@ func main() {
 			log.Fatalf("unsupported GOOS %q", runtime.GOOS)
 		}
 		fmt.Printf("https://github.com/tailscale/go/releases/download/build-%s/%s%s.tar.gz\n", strings.TrimSpace(ts.GoToolchainRev), runtime.GOOS, suffix)
+	}
+	if *goToolchainSRI {
+		fmt.Println(strings.TrimSpace(ts.GoToolchainSRI))
 	}
 }

--- a/version-embed.go
+++ b/version-embed.go
@@ -18,3 +18,9 @@ var AlpineDockerTag string
 //
 //go:embed go.toolchain.rev
 var GoToolchainRev string
+
+// GoToolchainSRI is the Nix SRI hash of the Go toolchain identified
+// by GoToolchainRev. It may end in a newline.
+//
+//go:embed go.toolchain.sri
+var GoToolchainSRI string


### PR DESCRIPTION
Updates #6845.

Signed-off-by: David Anderson <danderson@tailscale.com>