### PR TITLE
cmd/tailscale: use localhost for QNAP authLogin.cgi

### DIFF
--- a/cmd/tailscale/cli/web.go
+++ b/cmd/tailscale/cli/web.go
@@ -223,8 +223,8 @@ func qnapAuthnQtoken(r *http.Request, user, token string) (string, *qnapAuthResp
 		"user":   []string{user},
 	}
 	u := url.URL{
-		Scheme:   r.URL.Scheme,
-		Host:     r.URL.Host,
+		Scheme:   "http",
+		Host:     "127.0.0.1:8080",
 		Path:     "/cgi-bin/authLogin.cgi",
 		RawQuery: query.Encode(),
 	}
@@ -237,8 +237,8 @@ func qnapAuthnSid(r *http.Request, user, sid string) (string, *qnapAuthResponse,
 		"sid": []string{sid},
 	}
 	u := url.URL{
-		Scheme:   r.URL.Scheme,
-		Host:     r.URL.Host,
+		Scheme:   "http",
+		Host:     "127.0.0.1:8080",
 		Path:     "/cgi-bin/authLogin.cgi",
 		RawQuery: query.Encode(),
 	}


### PR DESCRIPTION
When the user clicks on the Tailscale app in the QNAP App Center, we do a GET from /cgi-bin/authLogin.cgi to look up their SID.

If the user clicked "secure login" on the QNAP login page to use HTTPS, then our access to authLogin.cgi will also use HTTPS but the certiciate is self-signed. Our GET fails with:
`Get "https://10.1.10.41/cgi-bin/authLogin.cgi?sid=abcd0123": x509: cannot validate certificate for 10.1.10.41 because it doesn't contain any IP SANs`
or similar errors.

Instead, access QNAP authentication via http://localhost:8080/ as documented in
https://download.qnap.com/dev/API_QNAP_QTS_Authentication.pdf

Fixes https://github.com/tailscale/tailscale-qpkg/issues/62

Signed-off-by: Denton Gentry <dgentry@tailscale.com>