### PR TITLE
util/codegen: Remove year from copyright header.

### DIFF
--- a/cmd/viewer/tests/tests_clone.go
+++ b/cmd/viewer/tests/tests_clone.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Copyright (c) Tailscale Inc & AUTHORS All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmd/viewer/tests/tests_view.go
+++ b/cmd/viewer/tests/tests_view.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Copyright (c) Tailscale Inc & AUTHORS All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Copyright (c) Tailscale Inc & AUTHORS All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Copyright (c) Tailscale Inc & AUTHORS All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/ipn/ipnstate/ipnstate_clone.go
+++ b/ipn/ipnstate/ipnstate_clone.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Copyright (c) Tailscale Inc & AUTHORS All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/scripts/check_license_headers.sh
+++ b/scripts/check_license_headers.sh
@@ -10,7 +10,7 @@
 check_file() {
     got=$1
 
-    for year in `seq 2019 2022`; do
+    for year in `seq 2019 2023`; do
         want=$(cat <<EOF
 // Copyright (c) $year Tailscale Inc & AUTHORS All rights reserved.
 // Use of this source code is governed by a BSD-style
@@ -21,6 +21,19 @@ EOF
             return 0
         fi
     done
+
+    # For the benefit of generated files, we also allow no year in
+    # the header. https://github.com/tailscale/tailscale/issues/6865
+    want=$(cat <<EOF
+// Copyright (c) Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+EOF
+    )
+    if [ "$got" = "$want" ]; then
+        return 0
+    fi
+
     return 1
 }
 

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Copyright (c) Tailscale Inc & AUTHORS All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Copyright (c) Tailscale Inc & AUTHORS All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/types/dnstype/dnstype_clone.go
+++ b/types/dnstype/dnstype_clone.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Copyright (c) Tailscale Inc & AUTHORS All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/types/dnstype/dnstype_view.go
+++ b/types/dnstype/dnstype_view.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Copyright (c) Tailscale Inc & AUTHORS All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/types/persist/persist_clone.go
+++ b/types/persist/persist_clone.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Copyright (c) Tailscale Inc & AUTHORS All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/types/persist/persist_view.go
+++ b/types/persist/persist_view.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Copyright (c) Tailscale Inc & AUTHORS All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/util/codegen/codegen.go
+++ b/util/codegen/codegen.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"reflect"
 	"strings"
-	"time"
 
 	"golang.org/x/tools/go/packages"
 	"golang.org/x/tools/imports"
@@ -54,7 +53,7 @@ func HasNoClone(structTag string) bool {
 	return false
 }
 
-const header = `// Copyright (c) %d Tailscale Inc & AUTHORS All rights reserved.
+const header = `// Copyright (c) Tailscale Inc & AUTHORS All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -105,7 +104,7 @@ func (it *ImportTracker) Write(w io.Writer) {
 }
 
 func writeHeader(w io.Writer, tool, pkg string) {
-	fmt.Fprintf(w, header, time.Now().Year(), tool, pkg)
+	fmt.Fprintf(w, header, tool, pkg)
 }
 
 // WritePackageFile adds a file with the provided imports and contents to package.

--- a/wgengine/filter/filter_clone.go
+++ b/wgengine/filter/filter_clone.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Copyright (c) Tailscale Inc & AUTHORS All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/wgengine/wgcfg/wgcfg_clone.go
+++ b/wgengine/wgcfg/wgcfg_clone.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+// Copyright (c) Tailscale Inc & AUTHORS All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 


### PR DESCRIPTION
Copyright notices in software are not supposed to update the year in the header.

Because we have a CI check for `go generate`, we're failing CI until we go update all of the copyright headers in generated files to say 2023.

Fixes https://github.com/tailscale/tailscale/issues/6865

Signed-off-by: Denton Gentry <dgentry@tailscale.com>