### PR TITLE
TKA tweaks, fixes, error handling

### DIFF
--- a/ipn/ipnlocal/network-lock.go
+++ b/ipn/ipnlocal/network-lock.go
@@ -666,7 +666,11 @@ func (b *LocalBackend) NetworkLockModify(addKeys, removeKeys []tka.Key) (err err
 		}
 	}
 	for _, removeKey := range removeKeys {
-		if err := updater.RemoveKey(removeKey.ID()); err != nil {
+		keyID, err := removeKey.ID()
+		if err != nil {
+			return err
+		}
+		if err := updater.RemoveKey(keyID); err != nil {
 			return err
 		}
 	}

--- a/ipn/ipnlocal/network-lock_test.go
+++ b/ipn/ipnlocal/network-lock_test.go
@@ -321,7 +321,7 @@ func TestTKASync(t *testing.T) {
 			name: "control has an update",
 			controlAUMs: func(t *testing.T, a *tka.Authority, storage tka.Chonk, signer tka.Signer) []tka.AUM {
 				b := a.NewUpdater(signer)
-				if err := b.RemoveKey(someKey.ID()); err != nil {
+				if err := b.RemoveKey(someKey.MustID()); err != nil {
 					t.Fatal(err)
 				}
 				aums, err := b.Finalize(storage)
@@ -336,7 +336,7 @@ func TestTKASync(t *testing.T) {
 			name: "node has an update",
 			nodeAUMs: func(t *testing.T, a *tka.Authority, storage tka.Chonk, signer tka.Signer) []tka.AUM {
 				b := a.NewUpdater(signer)
-				if err := b.RemoveKey(someKey.ID()); err != nil {
+				if err := b.RemoveKey(someKey.MustID()); err != nil {
 					t.Fatal(err)
 				}
 				aums, err := b.Finalize(storage)
@@ -351,7 +351,7 @@ func TestTKASync(t *testing.T) {
 			name: "node and control diverge",
 			controlAUMs: func(t *testing.T, a *tka.Authority, storage tka.Chonk, signer tka.Signer) []tka.AUM {
 				b := a.NewUpdater(signer)
-				if err := b.SetKeyMeta(someKey.ID(), map[string]string{"ye": "swiggity"}); err != nil {
+				if err := b.SetKeyMeta(someKey.MustID(), map[string]string{"ye": "swiggity"}); err != nil {
 					t.Fatal(err)
 				}
 				aums, err := b.Finalize(storage)
@@ -362,7 +362,7 @@ func TestTKASync(t *testing.T) {
 			},
 			nodeAUMs: func(t *testing.T, a *tka.Authority, storage tka.Chonk, signer tka.Signer) []tka.AUM {
 				b := a.NewUpdater(signer)
-				if err := b.SetKeyMeta(someKey.ID(), map[string]string{"ye": "swooty"}); err != nil {
+				if err := b.SetKeyMeta(someKey.MustID(), map[string]string{"ye": "swooty"}); err != nil {
 					t.Fatal(err)
 				}
 				aums, err := b.Finalize(storage)

--- a/tka/aum.go
+++ b/tka/aum.go
@@ -150,7 +150,7 @@ func (a *AUM) StaticValidate() error {
 		return errors.New("absent parent must be represented by a nil slice")
 	}
 	for i, sig := range a.Signatures {
-		if len(sig.KeyID) == 0 || len(sig.Signature) != ed25519.SignatureSize {
+		if len(sig.KeyID) != 32 || len(sig.Signature) != ed25519.SignatureSize {
 			return fmt.Errorf("signature %d has missing keyID or malformed signature", i)
 		}
 	}
@@ -196,8 +196,13 @@ func (a *AUM) StaticValidate() error {
 
 	case AUMNoOp:
 	default:
-		// TODO(tom): Ignore unknown AUMs for GA.
-		return fmt.Errorf("unknown AUM kind: %v", a.MessageKind)
+		// An AUM with an unknown message kind was received! That means
+		// that a future version of tailscaled added some feature we don't
+		// understand.
+		//
+		// The future-compatibility contract for AUM message types is that
+		// they must only add new features, not change the semantics of existing
+		// mechanisms or features. As such, old clients can safely ignore them.
 	}
 
 	return nil

--- a/tka/aum.go
+++ b/tka/aum.go
@@ -281,14 +281,20 @@ func (a *AUM) Parent() (h AUMHash, ok bool) {
 	return h, false
 }
 
-func (a *AUM) sign25519(priv ed25519.PrivateKey) {
+func (a *AUM) sign25519(priv ed25519.PrivateKey) error {
 	key := Key{Kind: Key25519, Public: priv.Public().(ed25519.PublicKey)}
 	sigHash := a.SigHash()
 
+	keyID, err := key.ID()
+	if err != nil {
+		return err
+	}
+
 	a.Signatures = append(a.Signatures, tkatype.Signature{
-		KeyID:     key.ID(),
+		KeyID:     keyID,
 		Signature: ed25519.Sign(priv, sigHash[:]),
 	})
+	return nil
 }
 
 // Weight computes the 'signature weight' of the AUM

--- a/tka/aum_test.go
+++ b/tka/aum_test.go
@@ -189,7 +189,7 @@ func TestAUMWeight(t *testing.T) {
 		{
 			"Unary key",
 			AUM{
-				Signatures: []tkatype.Signature{{KeyID: key.ID()}},
+				Signatures: []tkatype.Signature{{KeyID: key.MustID()}},
 			},
 			State{
 				Keys: []Key{key},
@@ -199,7 +199,7 @@ func TestAUMWeight(t *testing.T) {
 		{
 			"Multiple keys",
 			AUM{
-				Signatures: []tkatype.Signature{{KeyID: key.ID()}, {KeyID: key2.ID()}},
+				Signatures: []tkatype.Signature{{KeyID: key.MustID()}, {KeyID: key2.MustID()}},
 			},
 			State{
 				Keys: []Key{key, key2},
@@ -209,7 +209,7 @@ func TestAUMWeight(t *testing.T) {
 		{
 			"Double use",
 			AUM{
-				Signatures: []tkatype.Signature{{KeyID: key.ID()}, {KeyID: key.ID()}},
+				Signatures: []tkatype.Signature{{KeyID: key.MustID()}, {KeyID: key.MustID()}},
 			},
 			State{
 				Keys: []Key{key},

--- a/tka/builder.go
+++ b/tka/builder.go
@@ -60,7 +60,12 @@ func (b *UpdateBuilder) mkUpdate(update AUM) error {
 
 // AddKey adds a new key to the authority.
 func (b *UpdateBuilder) AddKey(key Key) error {
-	if _, err := b.state.GetKey(key.ID()); err == nil {
+	keyID, err := key.ID()
+	if err != nil {
+		return err
+	}
+
+	if _, err := b.state.GetKey(keyID); err == nil {
 		return fmt.Errorf("cannot add key %v: already exists", key)
 	}
 	return b.mkUpdate(AUM{MessageKind: AUMAddKey, Key: &key})

--- a/tka/builder_test.go
+++ b/tka/builder_test.go
@@ -19,7 +19,7 @@ func (s signer25519) SignAUM(sigHash tkatype.AUMSigHash) ([]tkatype.Signature, e
 	key := Key{Kind: Key25519, Public: priv.Public().(ed25519.PublicKey)}
 
 	return []tkatype.Signature{{
-		KeyID:     key.ID(),
+		KeyID:     key.MustID(),
 		Signature: ed25519.Sign(priv, sigHash[:]),
 	}}, nil
 }
@@ -54,7 +54,7 @@ func TestAuthorityBuilderAddKey(t *testing.T) {
 	if err := a.Inform(storage, updates); err != nil {
 		t.Fatalf("could not apply generated updates: %v", err)
 	}
-	if _, err := a.state.GetKey(key2.ID()); err != nil {
+	if _, err := a.state.GetKey(key2.MustID()); err != nil {
 		t.Errorf("could not read new key: %v", err)
 	}
 }
@@ -75,7 +75,7 @@ func TestAuthorityBuilderRemoveKey(t *testing.T) {
 	}
 
 	b := a.NewUpdater(signer25519(priv))
-	if err := b.RemoveKey(key2.ID()); err != nil {
+	if err := b.RemoveKey(key2.MustID()); err != nil {
 		t.Fatalf("RemoveKey(%v) failed: %v", key2, err)
 	}
 	updates, err := b.Finalize(storage)
@@ -88,7 +88,7 @@ func TestAuthorityBuilderRemoveKey(t *testing.T) {
 	if err := a.Inform(storage, updates); err != nil {
 		t.Fatalf("could not apply generated updates: %v", err)
 	}
-	if _, err := a.state.GetKey(key2.ID()); err != ErrNoSuchKey {
+	if _, err := a.state.GetKey(key2.MustID()); err != ErrNoSuchKey {
 		t.Errorf("GetKey(key2).err = %v, want %v", err, ErrNoSuchKey)
 	}
 }
@@ -107,8 +107,8 @@ func TestAuthorityBuilderSetKeyVote(t *testing.T) {
 	}
 
 	b := a.NewUpdater(signer25519(priv))
-	if err := b.SetKeyVote(key.ID(), 5); err != nil {
-		t.Fatalf("SetKeyVote(%v) failed: %v", key.ID(), err)
+	if err := b.SetKeyVote(key.MustID(), 5); err != nil {
+		t.Fatalf("SetKeyVote(%v) failed: %v", key.MustID(), err)
 	}
 	updates, err := b.Finalize(storage)
 	if err != nil {
@@ -120,7 +120,7 @@ func TestAuthorityBuilderSetKeyVote(t *testing.T) {
 	if err := a.Inform(storage, updates); err != nil {
 		t.Fatalf("could not apply generated updates: %v", err)
 	}
-	k, err := a.state.GetKey(key.ID())
+	k, err := a.state.GetKey(key.MustID())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,7 +143,7 @@ func TestAuthorityBuilderSetKeyMeta(t *testing.T) {
 	}
 
 	b := a.NewUpdater(signer25519(priv))
-	if err := b.SetKeyMeta(key.ID(), map[string]string{"b": "c"}); err != nil {
+	if err := b.SetKeyMeta(key.MustID(), map[string]string{"b": "c"}); err != nil {
 		t.Fatalf("SetKeyMeta(%v) failed: %v", key, err)
 	}
 	updates, err := b.Finalize(storage)
@@ -156,7 +156,7 @@ func TestAuthorityBuilderSetKeyMeta(t *testing.T) {
 	if err := a.Inform(storage, updates); err != nil {
 		t.Fatalf("could not apply generated updates: %v", err)
 	}
-	k, err := a.state.GetKey(key.ID())
+	k, err := a.state.GetKey(key.MustID())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -185,10 +185,10 @@ func TestAuthorityBuilderMultiple(t *testing.T) {
 	if err := b.AddKey(key2); err != nil {
 		t.Fatalf("AddKey(%v) failed: %v", key2, err)
 	}
-	if err := b.SetKeyVote(key2.ID(), 42); err != nil {
+	if err := b.SetKeyVote(key2.MustID(), 42); err != nil {
 		t.Fatalf("SetKeyVote(%v) failed: %v", key2, err)
 	}
-	if err := b.RemoveKey(key.ID()); err != nil {
+	if err := b.RemoveKey(key.MustID()); err != nil {
 		t.Fatalf("RemoveKey(%v) failed: %v", key, err)
 	}
 	updates, err := b.Finalize(storage)
@@ -201,14 +201,14 @@ func TestAuthorityBuilderMultiple(t *testing.T) {
 	if err := a.Inform(storage, updates); err != nil {
 		t.Fatalf("could not apply generated updates: %v", err)
 	}
-	k, err := a.state.GetKey(key2.ID())
+	k, err := a.state.GetKey(key2.MustID())
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got, want := k.Votes, uint(42); got != want {
 		t.Errorf("key.Votes = %d, want %d", got, want)
 	}
-	if _, err := a.state.GetKey(key.ID()); err != ErrNoSuchKey {
+	if _, err := a.state.GetKey(key.MustID()); err != ErrNoSuchKey {
 		t.Errorf("GetKey(key).err = %v, want %v", err, ErrNoSuchKey)
 	}
 }
@@ -243,7 +243,7 @@ func TestAuthorityBuilderCheckpointsAfterXUpdates(t *testing.T) {
 		if err := a.Inform(storage, updates); err != nil {
 			t.Fatalf("could not apply generated updates: %v", err)
 		}
-		if _, err := a.state.GetKey(key2.ID()); err != nil {
+		if _, err := a.state.GetKey(key2.MustID()); err != nil {
 			t.Fatal(err)
 		}
 

--- a/tka/chaintest_test.go
+++ b/tka/chaintest_test.go
@@ -267,7 +267,7 @@ func (c *testChain) makeAUM(v *testchainNode) AUM {
 	sigHash := aum.SigHash()
 	for _, key := range c.SignAllKeys {
 		aum.Signatures = append(aum.Signatures, tkatype.Signature{
-			KeyID:     c.Key[key].ID(),
+			KeyID:     c.Key[key].MustID(),
 			Signature: ed25519.Sign(c.KeyPrivs[key], sigHash[:]),
 		})
 	}
@@ -276,7 +276,7 @@ func (c *testChain) makeAUM(v *testchainNode) AUM {
 	// sign it using that key.
 	if key := v.SignedWith; key != "" {
 		aum.Signatures = append(aum.Signatures, tkatype.Signature{
-			KeyID:     c.Key[key].ID(),
+			KeyID:     c.Key[key].MustID(),
 			Signature: ed25519.Sign(c.KeyPrivs[key], sigHash[:]),
 		})
 	}

--- a/tka/key.go
+++ b/tka/key.go
@@ -74,14 +74,25 @@ func (k Key) Clone() Key {
 	return out
 }
 
-func (k Key) ID() tkatype.KeyID {
+// MustID returns the KeyID of the key, panicking if an error is
+// encountered. This must only be used for tests.
+func (k Key) MustID() tkatype.KeyID {
+	id, err := k.ID()
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
+// ID returns the KeyID of the key.
+func (k Key) ID() (tkatype.KeyID, error) {
 	switch k.Kind {
 	// Because 25519 public keys are so short, we just use the 32-byte
 	// public as their 'key ID'.
 	case Key25519:
-		return tkatype.KeyID(k.Public)
+		return tkatype.KeyID(k.Public), nil
 	default:
-		panic("unsupported key kind")
+		return nil, fmt.Errorf("unknown key kind: %v", k.Kind)
 	}
 }
 

--- a/tka/key_test.go
+++ b/tka/key_test.go
@@ -49,7 +49,7 @@ func TestVerify25519(t *testing.T) {
 	sigHash := aum.SigHash()
 	aum.Signatures = []tkatype.Signature{
 		{
-			KeyID:     key.ID(),
+			KeyID:     key.MustID(),
 			Signature: ed25519.Sign(priv, sigHash[:]),
 		},
 	}
@@ -92,7 +92,7 @@ func TestNLPrivate(t *testing.T) {
 
 	// We manually compute the keyID, so make sure its consistent with
 	// tka.Key.ID().
-	if !bytes.Equal(k.ID(), p.KeyID()) {
-		t.Errorf("private.KeyID() & tka KeyID differ: %x != %x", k.ID(), p.KeyID())
+	if !bytes.Equal(k.MustID(), p.KeyID()) {
+		t.Errorf("private.KeyID() & tka KeyID differ: %x != %x", k.MustID(), p.KeyID())
 	}
 }

--- a/tka/sig_test.go
+++ b/tka/sig_test.go
@@ -22,7 +22,7 @@ func TestSigDirect(t *testing.T) {
 
 	sig := NodeKeySignature{
 		SigKind: SigDirect,
-		KeyID:   k.ID(),
+		KeyID:   k.MustID(),
 		Pubkey:  nodeKeyPub,
 	}
 	sigHash := sig.SigHash()
@@ -65,7 +65,7 @@ func TestSigNested(t *testing.T) {
 	// the network-lock key.
 	nestedSig := NodeKeySignature{
 		SigKind:        SigDirect,
-		KeyID:          k.ID(),
+		KeyID:          k.MustID(),
 		Pubkey:         oldPub,
 		WrappingPubkey: rPub,
 	}
@@ -132,7 +132,7 @@ func TestSigNested_DeepNesting(t *testing.T) {
 	// the network-lock key.
 	nestedSig := NodeKeySignature{
 		SigKind:        SigDirect,
-		KeyID:          k.ID(),
+		KeyID:          k.MustID(),
 		Pubkey:         oldPub,
 		WrappingPubkey: rPub,
 	}
@@ -204,7 +204,7 @@ func TestSigCredential(t *testing.T) {
 	// public key.
 	nestedSig := NodeKeySignature{
 		SigKind:        SigCredential,
-		KeyID:          k.ID(),
+		KeyID:          k.MustID(),
 		WrappingPubkey: cPub,
 	}
 	sigHash := nestedSig.SigHash()
@@ -280,11 +280,11 @@ func TestSigSerializeUnserialize(t *testing.T) {
 	key := Key{Kind: Key25519, Public: pub, Votes: 2}
 	sig := NodeKeySignature{
 		SigKind: SigDirect,
-		KeyID:   key.ID(),
+		KeyID:   key.MustID(),
 		Pubkey:  nodeKeyPub,
 		Nested: &NodeKeySignature{
 			SigKind: SigDirect,
-			KeyID:   key.ID(),
+			KeyID:   key.MustID(),
 			Pubkey:  nodeKeyPub,
 		},
 	}

--- a/tka/tka_test.go
+++ b/tka/tka_test.go
@@ -124,7 +124,7 @@ func TestForkResolutionMessageType(t *testing.T) {
         L3.hashSeed = 18
     `,
 		optTemplate("addKey", AUM{MessageKind: AUMAddKey, Key: &key}),
-		optTemplate("removeKey", AUM{MessageKind: AUMRemoveKey, KeyID: key.ID()}))
+		optTemplate("removeKey", AUM{MessageKind: AUMRemoveKey, KeyID: key.MustID()}))
 
 	l1H := c.AUMHashes["L1"]
 	l2H := c.AUMHashes["L2"]
@@ -165,7 +165,7 @@ func TestComputeStateAt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("computeStateAt(G1) failed: %v", err)
 	}
-	if _, err := state.GetKey(key.ID()); err != ErrNoSuchKey {
+	if _, err := state.GetKey(key.MustID()); err != ErrNoSuchKey {
 		t.Errorf("expected key to be missing: err = %v", err)
 	}
 	if *state.LastAUMHash != c.AUMHashes["G1"] {
@@ -182,7 +182,7 @@ func TestComputeStateAt(t *testing.T) {
 		if *state.LastAUMHash != wantHash {
 			t.Errorf("LastAUMHash = %x, want %x", *state.LastAUMHash, wantHash)
 		}
-		if _, err := state.GetKey(key.ID()); err != nil {
+		if _, err := state.GetKey(key.MustID()); err != nil {
 			t.Errorf("expected key to be present at state: err = %v", err)
 		}
 	}
@@ -234,7 +234,7 @@ func TestOpenAuthority(t *testing.T) {
 
 	i2, i2H := fakeAUM(t, 2, &i1H)
 	i3, i3H := fakeAUM(t, 5, &i2H)
-	l2, l2H := fakeAUM(t, AUM{MessageKind: AUMNoOp, KeyID: []byte{7}, Signatures: []tkatype.Signature{{KeyID: key.ID()}}}, &i3H)
+	l2, l2H := fakeAUM(t, AUM{MessageKind: AUMNoOp, KeyID: []byte{7}, Signatures: []tkatype.Signature{{KeyID: key.MustID()}}}, &i3H)
 	l3, l3H := fakeAUM(t, 4, &i3H)
 
 	g2, g2H := fakeAUM(t, 8, nil)
@@ -266,7 +266,7 @@ func TestOpenAuthority(t *testing.T) {
 		t.Fatalf("New() failed: %v", err)
 	}
 	// Should include the key added in G1
-	if _, err := a.state.GetKey(key.ID()); err != nil {
+	if _, err := a.state.GetKey(key.MustID()); err != nil {
 		t.Errorf("missing G1 key: %v", err)
 	}
 	// The head of the chain should be L2.
@@ -338,10 +338,10 @@ func TestCreateBootstrapAuthority(t *testing.T) {
 	}
 
 	// Both authorities should trust the key laid down in the genesis state.
-	if !a1.KeyTrusted(key.ID()) {
+	if !a1.KeyTrusted(key.MustID()) {
 		t.Error("a1 did not trust genesis key")
 	}
-	if !a2.KeyTrusted(key.ID()) {
+	if !a2.KeyTrusted(key.MustID()) {
 		t.Error("a2 did not trust genesis key")
 	}
 }


### PR DESCRIPTION
 * `tka.Key.KeyID()` now returns an error instead of panicking.
 * Unknown AUM types are now correctly handled.
 * Minor UX tweaks and fixes falling out of the alpha.

The former two changes won't matter now (no new key types or AUM types) but we'll need to lockstep `1.34` in the future :grimacing: 