### PR TITLE
tsnet: add ipn notification callback

### DIFF
--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -88,6 +88,11 @@ type Server struct {
 	// If empty, the Tailscale default is used.
 	ControlURL string
 
+	// NotifyFunc is an optional callback function for engine updates from
+	// the LocalBackend. This can be used as an alternative to polling the
+	// LocalAPI in client applications.
+	NotifyFunc func(*ipn.Notify) (keepGoing bool)
+
 	initOnce         sync.Once
 	initErr          error
 	lb               *ipnlocal.LocalBackend
@@ -342,6 +347,15 @@ func (s *Server) start() (reterr error) {
 	lb, err := ipnlocal.NewLocalBackend(logf, logid, s.Store, "", s.dialer, eng, loginFlags)
 	if err != nil {
 		return fmt.Errorf("NewLocalBackend: %v", err)
+	}
+	if s.NotifyFunc != nil {
+		notifCtx, cancel := context.WithCancel(context.Background())
+		closePool.addFunc(cancel)
+		go lb.WatchNotifications(
+			notifCtx,
+			ipn.NotifyWatchEngineUpdates,
+			s.NotifyFunc,
+		)
 	}
 	lb.SetVarRoot(s.rootPath)
 	logf("tsnet starting with hostname %q, varRoot %q", s.hostname, s.rootPath)


### PR DESCRIPTION
Hey y'all, using `tsnet` for service discovery (i.e. other nodes on the network), figured I'd PR a small change that really helped with this. Previously, if you wanted to keep up to date with peers on the network, you'd have to poll the LocalAPI every few seconds, not super fun. I think `WatchNotifications` itself polls every few seconds under the hood (saw a @bradfitz [TODO](https://github.com/tailscale/tailscale/blob/be67b8e75b9bedb28fc8502c9295fb5f4b3fbb5f/ipn/ipnlocal/local.go#L1809) related to this), though this is likely more efficient than the LocalAPI polling approach mentioned above.

As a (not so great) example, `tsnet` users can now do something like this (to keep track of any peers with matching tags):
```
&tsnet.Server{
	Hostname:  hostname,
	Dir:       dir,
	AuthKey:   authKey,
	Ephemeral: true,
	Logf:      func(format string, args ...any) {},
	NotifyFunc: func(n *ipn.Notify) (keepGoing bool) {
		if n.NetMap != nil {
			ic.mu.Lock()
			existing := make(map[string]struct{}, len(ic.peers))
			for id := range ic.peers {
				existing[id] = struct{}{}
			}
			ic.peers = make(map[string]*tailcfg.Node, len(n.NetMap.Peers))
			for _, p := range n.NetMap.Peers {
				if p.Online == nil || !*p.Online {
					continue
				}
				cloned := p.Clone()
				slices.Sort(cloned.Tags)
				if !slices.Equal(cloned.Tags, ic.selfTags) {
					continue
				}
				ic.peers[cloned.ID.String()] = cloned
				if _, ok := existing[cloned.ID.String()]; ok {
					delete(existing, cloned.ID.String())
				} else {
					log.Printf("found matching peer %q (%v)", cloned.ID, cloned.Addresses)
				}
			}
			for id := range existing {
				log.Printf("peer %q disconnected", id)
			}
			ic.mu.Unlock()
		}
		return true
	},
}
```

Obv. very niche use case, figured I'd open a PR and start a conversation about it. Definitely open to ideas here, and if there's a better approach to solving the same problem, would love to hear it. Thanks!