### PR TITLE
cmd/tailscale: disable HTTPS verification for QNAP auth.

### DIFF
--- a/cmd/tailscale/cli/web.go
+++ b/cmd/tailscale/cli/web.go
@@ -247,7 +247,14 @@ func qnapAuthnSid(r *http.Request, user, sid string) (string, *qnapAuthResponse,
 }
 
 func qnapAuthnFinish(user, url string) (string, *qnapAuthResponse, error) {
-	resp, err := http.Get(url)
+	// QNAP Force HTTPS mode uses a self-signed certificate. Even importing
+	// the QNAP root CA isn't enough, the cert doesn't have a usable CN nor
+	// SAN. See https://github.com/tailscale/tailscale/issues/6903
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: tr}
+	resp, err := client.Get(url)
 	if err != nil {
 		return "", nil, err
 	}


### PR DESCRIPTION
QNAP's "Force HTTPS" mode redirects even localhost HTTP to HTTPS, but uses a self-signed certificate which fails verification. We accommodate this by disabling checking of the cert.

Fixes https://github.com/tailscale/tailscale/issues/6903

Signed-off-by: Denton Gentry <dgentry@tailscale.com>