### PR TITLE
Allow the expiry time to be specified for new keys

### DIFF
--- a/client/tailscale/keys.go
+++ b/client/tailscale/keys.go
@@ -71,10 +71,18 @@ func (c *Client) Keys(ctx context.Context) ([]string, error) {
 // CreateKey creates a new key for the current user. Currently, only auth keys
 // can be created. Returns the key itself, which cannot be retrieved again
 // later, and the key metadata.
-func (c *Client) CreateKey(ctx context.Context, caps KeyCapabilities) (string, *Key, error) {
+func (c *Client) CreateKey(ctx context.Context, caps KeyCapabilities, expirySeconds int64) (string, *Key, error) {
+
+	ninetydays := int64(90 * 24 * 60 * 60)
+
+	if expirySeconds > ninetydays {
+		return "", nil, fmt.Errorf("expiry must be less than 90 days")
+	}
+
 	keyRequest := struct {
-		Capabilities KeyCapabilities `json:"capabilities"`
-	}{caps}
+		Capabilities  KeyCapabilities `json:"capabilities"`
+		ExpirySeconds int64           `json:"expirySeconds,omitempty"`
+	}{caps, int64(expirySeconds)}
 	bs, err := json.Marshal(keyRequest)
 	if err != nil {
 		return "", nil, err

--- a/cmd/k8s-operator/operator.go
+++ b/cmd/k8s-operator/operator.go
@@ -139,7 +139,9 @@ waitOnline:
 					},
 				},
 			}
-			authkey, _, err := tsClient.CreateKey(ctx, caps)
+			ninetyDays := 90 * 24 * time.Hour
+
+			authkey, _, err := tsClient.CreateKey(ctx, caps, int64(ninetyDays.Seconds()))
 			if err != nil {
 				startlog.Fatalf("creating operator authkey: %v", err)
 			}
@@ -249,7 +251,7 @@ type ServiceReconciler struct {
 }
 
 type tsClient interface {
-	CreateKey(ctx context.Context, caps tailscale.KeyCapabilities) (string, *tailscale.Key, error)
+	CreateKey(ctx context.Context, caps tailscale.KeyCapabilities, expirySeconds int64) (string, *tailscale.Key, error)
 	DeleteDevice(ctx context.Context, id string) error
 }
 
@@ -547,7 +549,8 @@ func (a *ServiceReconciler) newAuthKey(ctx context.Context, tags []string) (stri
 			},
 		},
 	}
-	key, _, err := a.tsClient.CreateKey(ctx, caps)
+	ninetyDays := 90 * 24 * time.Hour
+	key, _, err := a.tsClient.CreateKey(ctx, caps, int64(ninetyDays.Seconds()))
 	if err != nil {
 		return "", err
 	}

--- a/cmd/k8s-operator/operator_test.go
+++ b/cmd/k8s-operator/operator_test.go
@@ -706,14 +706,14 @@ type fakeTSClient struct {
 	deleted     []string
 }
 
-func (c *fakeTSClient) CreateKey(ctx context.Context, caps tailscale.KeyCapabilities) (string, *tailscale.Key, error) {
+func (c *fakeTSClient) CreateKey(ctx context.Context, caps tailscale.KeyCapabilities, expirySeconds int64) (string, *tailscale.Key, error) {
 	c.Lock()
 	defer c.Unlock()
 	c.keyRequests = append(c.keyRequests, caps)
 	k := &tailscale.Key{
 		ID:           "key",
 		Created:      time.Now(),
-		Expires:      time.Now().Add(24 * time.Hour),
+		Expires:      time.Now().Add(time.Second * time.Duration(expirySeconds)),
 		Capabilities: caps,
 	}
 	return "secret-authkey", k, nil


### PR DESCRIPTION
Adds a parameter for create key that allows a number of seconds (less than 90) to be specified for new keys.