### PR TITLE
ipn/ipnlocal: disallow unsigned peers from WoL

### DIFF
--- a/ipn/ipnlocal/peerapi.go
+++ b/ipn/ipnlocal/peerapi.go
@@ -903,6 +903,9 @@ func (h *peerAPIHandler) canDebug() bool {
 
 // canWakeOnLAN reports whether h can send a Wake-on-LAN packet from this node.
 func (h *peerAPIHandler) canWakeOnLAN() bool {
+	if h.peerNode.UnsignedPeerAPIOnly {
+		return false
+	}
 	return h.isSelf || h.peerHasCap(tailcfg.CapabilityWakeOnLAN)
 }
 


### PR DESCRIPTION
Unsigned peers should not be allowed to generate Wake-on-Lan packets,
only access Funnel.

Updates #6934
Updates #7515
Updates #6475

Signed-off-by: James Tucker <james@tailscale.com>