### PR TITLE
net/flowtrack,wgengine/filter: refactor Cache to use generics

### DIFF
--- a/net/flowtrack/flowtrack_test.go
+++ b/net/flowtrack/flowtrack_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestCache(t *testing.T) {
-	c := &Cache{MaxEntries: 2}
+	c := &Cache[int]{MaxEntries: 2}
 
 	k1 := Tuple{Src: netip.MustParseAddrPort("1.1.1.1:1"), Dst: netip.MustParseAddrPort("1.1.1.1:1")}
 	k2 := Tuple{Src: netip.MustParseAddrPort("1.1.1.1:1"), Dst: netip.MustParseAddrPort("2.2.2.2:2")}
@@ -25,13 +25,13 @@ func TestCache(t *testing.T) {
 			t.Fatalf("Len = %d; want %d", got, want)
 		}
 	}
-	wantVal := func(key Tuple, want any) {
+	wantVal := func(key Tuple, want int) {
 		t.Helper()
 		got, ok := c.Get(key)
 		if !ok {
 			t.Fatalf("Get(%q) failed; want value %v", key, want)
 		}
-		if got != want {
+		if *got != want {
 			t.Fatalf("Get(%q) = %v; want %v", key, got, want)
 		}
 	}
@@ -73,7 +73,7 @@ func TestCache(t *testing.T) {
 		if !ok {
 			t.Fatal("missing k3")
 		}
-		if got != 30 {
+		if *got != 30 {
 			t.Fatalf("got = %d; want 30", got)
 		}
 	})

--- a/wgengine/filter/filter.go
+++ b/wgengine/filter/filter.go
@@ -59,7 +59,7 @@ type Filter struct {
 // filterState is a state cache of past seen packets.
 type filterState struct {
 	mu  sync.Mutex
-	lru *flowtrack.Cache // from flowtrack.Tuple -> nil
+	lru *flowtrack.Cache[struct{}] // from flowtrack.Tuple -> struct{}
 }
 
 // lruMax is the size of the LRU cache in filterState.
@@ -176,7 +176,7 @@ func New(matches []Match, localNets *netipx.IPSet, logIPs *netipx.IPSet, shareSt
 		state = shareStateWith.state
 	} else {
 		state = &filterState{
-			lru: &flowtrack.Cache{MaxEntries: lruMax},
+			lru: &flowtrack.Cache[struct{}]{MaxEntries: lruMax},
 		}
 	}
 	f := &Filter{
@@ -517,7 +517,7 @@ func (f *Filter) runOut(q *packet.Parsed) (r Response, why string) {
 			Src:   q.Dst, Dst: q.Src, // src/dst reversed
 		}
 		f.state.mu.Lock()
-		f.state.lru.Add(tuple, nil)
+		f.state.lru.Add(tuple, struct{}{})
 		f.state.mu.Unlock()
 	}
 	return Accept, "ok out"


### PR DESCRIPTION
Now that we have generics.