### PR TITLE
HTTP headers are supposed to be handled case insensitively

### DIFF
--- a/control/controlhttp/server.go
+++ b/control/controlhttp/server.go
@@ -35,7 +35,7 @@ func AcceptHTTP(ctx context.Context, w http.ResponseWriter, r *http.Request, pri
 }
 
 func acceptHTTP(ctx context.Context, w http.ResponseWriter, r *http.Request, private key.MachinePrivate, earlyWrite func(protocolVersion int, w io.Writer) error) (_ *controlbase.Conn, retErr error) {
-	next := r.Header.Get("Upgrade")
+	next := strings.ToLower(r.Header.Get("Upgrade"))
 	if next == "" {
 		http.Error(w, "missing next protocol", http.StatusBadRequest)
 		return nil, errors.New("no next protocol in HTTP request")


### PR DESCRIPTION
Ran into a problem with apache that sends "WebSocket" to backend servers when reverse proxying a websocket. Tailscale does not accept that string.

According to [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-upgrade) names should be handled case-insensitively