### PR TITLE
wgengine/netstack: fix data race in tests

### DIFF
--- a/wgengine/netstack/netstack_test.go
+++ b/wgengine/netstack/netstack_test.go
@@ -17,6 +17,7 @@ import (
 	"tailscale.com/net/tsaddr"
 	"tailscale.com/net/tsdial"
 	"tailscale.com/net/tstun"
+	"tailscale.com/tstest"
 	"tailscale.com/types/ipproto"
 	"tailscale.com/wgengine"
 	"tailscale.com/wgengine/filter"
@@ -89,12 +90,7 @@ func getMemStats() (ms runtime.MemStats) {
 func makeNetstack(t *testing.T, config func(*Impl)) *Impl {
 	tunDev := tstun.NewFake()
 	dialer := new(tsdial.Dialer)
-	logf := func(format string, args ...any) {
-		if !t.Failed() {
-			t.Helper()
-			t.Logf(format, args...)
-		}
-	}
+	logf := tstest.WhileTestRunningLogger(t)
 	eng, err := wgengine.NewUserspaceEngine(logf, wgengine.Config{
 		Tun:    tunDev,
 		Dialer: dialer,


### PR DESCRIPTION
This uses the helper function added in #6173 to avoid flakes like:
    https://github.com/tailscale/tailscale/actions/runs/3826912237/jobs/6511078024

Signed-off-by: Andrew Dunham <andrew@du.nham.ca>
Change-Id: If3f1d3b9c0f64ffcb4ba9a30d3522ec49484f993