### PR TITLE
cmd/k8s-operator: Finalizer should requeue immediately

### DIFF
--- a/cmd/k8s-operator/operator_test.go
+++ b/cmd/k8s-operator/operator_test.go
@@ -60,6 +60,7 @@ func TestLoadBalancerClass(t *testing.T) {
 		},
 	})
 
+	expectRequeue(t, sr, "default", "test")
 	expectReconciled(t, sr, "default", "test")
 
 	fullName, shortName := findGenName(t, fc, "default", "test")
@@ -181,6 +182,7 @@ func TestAnnotations(t *testing.T) {
 		},
 	})
 
+	expectRequeue(t, sr, "default", "test")
 	expectReconciled(t, sr, "default", "test")
 
 	fullName, shortName := findGenName(t, fc, "default", "test")
@@ -278,6 +280,7 @@ func TestAnnotationIntoLB(t *testing.T) {
 		},
 	})
 
+	expectRequeue(t, sr, "default", "test")
 	expectReconciled(t, sr, "default", "test")
 
 	fullName, shortName := findGenName(t, fc, "default", "test")
@@ -394,6 +397,7 @@ func TestLBIntoAnnotation(t *testing.T) {
 		},
 	})
 
+	expectRequeue(t, sr, "default", "test")
 	expectReconciled(t, sr, "default", "test")
 
 	fullName, shortName := findGenName(t, fc, "default", "test")
@@ -692,11 +696,8 @@ func expectRequeue(t *testing.T, sr *ServiceReconciler, ns, name string) {
 	if err != nil {
 		t.Fatalf("Reconcile: unexpected error: %v", err)
 	}
-	if res.Requeue {
-		t.Fatalf("unexpected immediate requeue")
-	}
-	if res.RequeueAfter == 0 {
-		t.Fatalf("expected timed requeue, got success")
+	if !res.Requeue && res.RequeueAfter == 0 {
+		t.Fatalf("expected timed or immediate requeue, got success")
 	}
 }
 


### PR DESCRIPTION
Added details in the comment, long story short is that by not reconciling immediately there could be a race condition between the update, deletion, and next reconciliation; especially if there are long(ish) running operations.

Signed-off-by: Vince Prignano <vince@prigna.com>