### PR TITLE
Update ipn/store/awsstore/store_aws.go to wrap boolean values in aws.Bool

### DIFF
--- a/ipn/store/awsstore/store_aws.go
+++ b/ipn/store/awsstore/store_aws.go
@@ -105,7 +105,7 @@ func (s *awsStore) LoadState() error {
 		context.TODO(),
 		&ssm.GetParameterInput{
 			Name:           aws.String(s.ParameterName()),
-			WithDecryption: true,
+			WithDecryption: aws.Bool(true),
 		},
 	)
 
@@ -167,7 +167,7 @@ func (s *awsStore) persistState() error {
 		&ssm.PutParameterInput{
 			Name:      aws.String(s.ParameterName()),
 			Value:     aws.String(string(bs)),
-			Overwrite: true,
+			Overwrite: aws.Bool(true),
 			Tier:      ssmTypes.ParameterTierStandard,
 			Type:      ssmTypes.ParameterTypeSecureString,
 		},


### PR DESCRIPTION
`ssm.GetParameterInput` now requires that `WithDecryption` be passed by reference:

https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ssm#GetParameterInput