### PR TITLE
tstest/integration: mark all integration tests as flaky

### DIFF
--- a/cmd/testwrapper/flakytest/flakytest.go
+++ b/cmd/testwrapper/flakytest/flakytest.go
@@ -26,7 +26,7 @@ var issueRegexp = regexp.MustCompile(`\Ahttps://github\.com/tailscale/[a-zA-Z0-9
 // the status of the flaky test being marked, of the format:
 //
 //	https://github.com/tailscale/myRepo-H3re/issues/12345
-func Mark(t *testing.T, issue string) {
+func Mark(t testing.TB, issue string) {
 	if !issueRegexp.MatchString(issue) {
 		t.Fatalf("bad issue format: %q", issue)
 	}

--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -591,6 +591,7 @@ func newTestEnv(t testing.TB, opts ...testEnvOpt) *testEnv {
 	if runtime.GOOS == "windows" {
 		t.Skip("not tested/working on Windows yet")
 	}
+	flakytest.Mark(t, "https://github.com/tailscale/tailscale/issues/7036")
 	derpMap := RunDERPAndSTUN(t, logger.Discard, "127.0.0.1")
 	logc := new(LogCatcher)
 	control := &testcontrol.Server{


### PR DESCRIPTION
Updates #7036

Change-Id: I3aec5ad680078199ba984bf8afc20b2f2eb37257
Signed-off-by: Andrew Dunham <andrew@du.nham.ca>