### PR TITLE
wgengine/wglog: add a prefix for all wireguard logs

### DIFF
--- a/wgengine/wglog/wglog.go
+++ b/wgengine/wglog/wglog.go
@@ -36,6 +36,7 @@ type strCache struct {
 // This logger silences repetitive/unhelpful noisy log lines
 // and rewrites peer keys from wireguard-go into Tailscale format.
 func NewLogger(logf logger.Logf) *Logger {
+	const prefix = "wg: "
 	ret := new(Logger)
 	wrapper := func(format string, args ...any) {
 		if strings.Contains(format, "Routine:") && !strings.Contains(format, "receive incoming") {
@@ -81,8 +82,8 @@ func NewLogger(logf logger.Logf) *Logger {
 		logf(format, newargs...)
 	}
 	ret.DeviceLogger = &device.Logger{
-		Verbosef: logger.WithPrefix(wrapper, "[v2] "),
-		Errorf:   wrapper,
+		Verbosef: logger.WithPrefix(wrapper, prefix+"[v2] "),
+		Errorf:   logger.WithPrefix(wrapper, prefix),
 	}
 	ret.strs = make(map[key.NodePublic]*strCache)
 	return ret

--- a/wgengine/wglog/wglog_test.go
+++ b/wgengine/wglog/wglog_test.go
@@ -22,9 +22,9 @@ func TestLogger(t *testing.T) {
 		want   string
 		omit   bool
 	}{
-		{"hi", nil, "hi", false},
+		{"hi", nil, "wg: hi", false},
 		{"Routine: starting", nil, "", true},
-		{"%v says it misses you", []any{stringer("peer(IMTB…r7lM)")}, "[IMTBr] says it misses you", false},
+		{"%v says it misses you", []any{stringer("peer(IMTB…r7lM)")}, "wg: [IMTBr] says it misses you", false},
 	}
 
 	type log struct {


### PR DESCRIPTION
Fixes #7041

Signed-off-by: James Tucker <james@tailscale.com>