### PR TITLE
ipn/ipnlocal: fire expiry timer when the current node expires

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -852,6 +852,13 @@ func (b *LocalBackend) setClientStatus(st controlclient.Status) {
 			}
 		}
 
+		// Ensure that we also fire this timer if our own node key expires.
+		if st.NetMap.SelfNode != nil {
+			if selfExpiry := st.NetMap.SelfNode.KeyExpiry; !selfExpiry.IsZero() && selfExpiry.Before(nextExpiry) {
+				nextExpiry = selfExpiry
+			}
+		}
+
 		if !nextExpiry.IsZero() {
 			tmrDuration := nextExpiry.Sub(now) + 10*time.Second
 			b.nmExpiryTimer = time.AfterFunc(tmrDuration, func() {


### PR DESCRIPTION
The current node isn't in NetMap.Peers, so without this we would not have fired this timer on self expiry.

Updates #6932

Signed-off-by: Andrew Dunham <andrew@du.nham.ca>
Change-Id: Id57f96985397e372f9226802d63b42ff92c95093