### PR TITLE
scripts: explicitly install tailscale-archive-keyring

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -487,7 +487,7 @@ main() {
 				;;
 			esac
 			$SUDO apt-get update
-			$SUDO apt-get install -y tailscale
+			$SUDO apt-get install -y tailscale tailscale-archive-keyring
 			if [ "$APT_SYSTEMCTL_START" = "true" ]; then
 				$SUDO systemctl enable --now tailscaled
 				$SUDO systemctl start tailscaled


### PR DESCRIPTION
This will ensure that the `tailscale-archive-keyring` Debian package gets installed by the installer script.

Fixes #3151

Signed-off-by: Anton Tolchanov <anton@tailscale.com>