### PR TITLE
net/netns: add functionality to bind outgoing sockets based on route table

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -48,6 +48,7 @@ import (
 	"tailscale.com/net/dnscache"
 	"tailscale.com/net/dnsfallback"
 	"tailscale.com/net/interfaces"
+	"tailscale.com/net/netns"
 	"tailscale.com/net/netutil"
 	"tailscale.com/net/tsaddr"
 	"tailscale.com/net/tsdial"
@@ -3822,6 +3823,9 @@ func (b *LocalBackend) setNetMapLocked(nm *netmap.NetworkMap) {
 	b.capFileSharing = fs
 
 	b.setDebugLogsByCapabilityLocked(nm)
+
+	// See the netns package for documentation on what this capability does.
+	netns.SetBindToInterfaceByRoute(hasCapability(nm, tailcfg.CapabilityBindToInterfaceByRoute))
 
 	b.setTCPPortsInterceptedFromNetmapAndPrefsLocked(b.pm.CurrentPrefs())
 	if nm == nil {

--- a/net/netns/netns.go
+++ b/net/netns/netns.go
@@ -32,6 +32,17 @@ func SetEnabled(on bool) {
 	disabled.Store(!on)
 }
 
+var bindToInterfaceByRoute atomic.Bool
+
+// SetBindToInterfaceByRoute enables or disables whether we use the system's
+// route information to bind to a particular interface. It is the same as
+// setting the TS_BIND_TO_INTERFACE_BY_ROUTE.
+//
+// Currently, this only changes the behaviour on macOS.
+func SetBindToInterfaceByRoute(v bool) {
+	bindToInterfaceByRoute.Store(v)
+}
+
 // Listener returns a new net.Listener with its Control hook func
 // initialized as necessary to run in logical network namespace that
 // doesn't route back into Tailscale.

--- a/net/netns/netns_darwin_test.go
+++ b/net/netns/netns_darwin_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2023 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package netns
+
+import (
+	"testing"
+
+	"tailscale.com/net/interfaces"
+)
+
+func TestGetInterfaceIndex(t *testing.T) {
+	oldVal := bindToInterfaceByRoute.Load()
+	t.Cleanup(func() { bindToInterfaceByRoute.Store(oldVal) })
+	bindToInterfaceByRoute.Store(true)
+
+	tests := []struct {
+		name string
+		addr string
+		err  string
+	}{
+		{
+			name: "IP_and_port",
+			addr: "8.8.8.8:53",
+		},
+		{
+			name: "bare_ip",
+			addr: "8.8.8.8",
+		},
+		{
+			name: "invalid",
+			addr: "!!!!!",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			idx, err := getInterfaceIndex(t.Logf, tc.addr)
+			if err != nil {
+				if tc.err == "" {
+					t.Fatalf("got unexpected error: %v", err)
+				}
+				if errstr := err.Error(); errstr != tc.err {
+					t.Errorf("expected error %q, got %q", errstr, tc.err)
+				}
+			} else {
+				t.Logf("getInterfaceIndex(%q) = %d", tc.addr, idx)
+				if tc.err != "" {
+					t.Fatalf("wanted error %q", tc.err)
+				}
+				if idx < 0 {
+					t.Fatalf("got invalid index %d", idx)
+				}
+			}
+		})
+	}
+
+	t.Run("NoTailscale", func(t *testing.T) {
+		_, tsif, err := interfaces.Tailscale()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if tsif == nil {
+			t.Skip("no tailscale interface on this machine")
+		}
+
+		defaultIdx, err := interfaces.DefaultRouteInterfaceIndex()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		idx, err := getInterfaceIndex(t.Logf, "100.100.100.100:53")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Logf("tailscaleIdx=%d defaultIdx=%d idx=%d", tsif.Index, defaultIdx, idx)
+
+		if idx == tsif.Index {
+			t.Fatalf("got idx=%d; wanted not Tailscale interface", idx)
+		} else if idx != defaultIdx {
+			t.Fatalf("got idx=%d, want %d", idx, defaultIdx)
+		}
+	})
+}

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -94,7 +94,8 @@ type CapabilityVersion int
 //   - 54: 2023-01-19: Node.Cap added, PeersChangedPatch.Cap, uses Node.Cap for ExitDNS before Hostinfo.Services fallback
 //   - 55: 2023-01-23: start of c2n GET+POST /update handler
 //   - 56: 2023-01-24: Client understands CapabilityDebugTSDNSResolution
-const CurrentCapabilityVersion CapabilityVersion = 56
+//   - 57: 2023-01-25: Client understands CapabilityBindToInterfaceByRoute
+const CurrentCapabilityVersion CapabilityVersion = 57
 
 type StableID string
 
@@ -1725,6 +1726,11 @@ const (
 	CapabilitySSHRuleIn          = "https://tailscale.com/cap/ssh-rule-in"           // some SSH rule reach this node
 	CapabilityDataPlaneAuditLogs = "https://tailscale.com/cap/data-plane-audit-logs" // feature enabled
 	CapabilityDebug              = "https://tailscale.com/cap/debug"                 // exposes debug endpoints over the PeerAPI
+
+	// CapabilityBindToInterfaceByRoute changes how Darwin nodes create
+	// sockets (in the net/netns package). See that package for more
+	// details on the behaviour of this capability.
+	CapabilityBindToInterfaceByRoute = "https://tailscale.com/cap/bind-to-interface-by-route"
 
 	// CapabilityTailnetLockAlpha indicates the node is in the tailnet lock alpha,
 	// and initialization of tailnet lock may proceed.


### PR DESCRIPTION
When turned on via environment variable (off by default), this will use the BSD routing APIs to query what interface index a socket should be bound to, rather than binding to the default interface in all cases.

Updates https://github.com/tailscale/tailscale/issues/5719
Updates https://github.com/tailscale/tailscale/pull/5940

Signed-off-by: Andrew Dunham <andrew@du.nham.ca>
Change-Id: Ib4c919471f377b7a08cd3413f8e8caacb29fee0b