### PR TITLE
hostinfo: [windows] check if running via Scoop

### DIFF
--- a/hostinfo/hostinfo_windows.go
+++ b/hostinfo/hostinfo_windows.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
@@ -68,6 +69,10 @@ func packageTypeWindows() string {
 	exe, err := os.Executable()
 	if err != nil {
 		return ""
+	}
+	home, _ := os.UserHomeDir()
+	if strings.HasPrefix(exe, filepath.Join(home, "scoop", "apps", "tailscale")) {
+		return "scoop"
 	}
 	dir := filepath.Dir(exe)
 	nsisUninstaller := filepath.Join(dir, "Uninstall-Tailscale.exe")


### PR DESCRIPTION
You can now install Tailscale on Windows via [Scoop](https://scoop.sh).

This change adds a check to `packageTypeWindows()`, looking at the exe's path, and checking if it starts with: `C:\User\<NAME>\scoop\apps\tailscale`. If so, it returns `"scoop"` as the package type.

Fixes: #6988

Signed-off-by: Shayne Sweeney <shayne@tailscale.com>