### PR TITLE
cmd/sync-containers: add github.Keychain

### DIFF
--- a/cmd/sync-containers/main.go
+++ b/cmd/sync-containers/main.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/authn/github"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -47,8 +48,9 @@ func main() {
 		log.Fatalf("--dst is required")
 	}
 
+	keychain := authn.NewMultiKeychain(authn.DefaultKeychain, github.Keychain)
 	opts := []remote.Option{
-		remote.WithAuthFromKeychain(authn.DefaultKeychain),
+		remote.WithAuthFromKeychain(keychain),
 		remote.WithContext(context.Background()),
 	}
 


### PR DESCRIPTION
Running sync-containers in a GitHub workflow will be simpler if we check github.Keychain, which uses the GITHUB_TOKEN if present.

Updates https://github.com/tailscale/corp/issues/8461

Signed-off-by: Denton Gentry <dgentry@tailscale.com>