### PR TITLE
docs/k8s: Use TS_AUTHKEY instead of TS_AUTH_KEY

### DIFF
--- a/docs/k8s/README.md
+++ b/docs/k8s/README.md
@@ -16,7 +16,7 @@ There are quite a few ways of running Tailscale inside a Kubernetes Cluster, som
    metadata:
      name: tailscale-auth
    stringData:
-     TS_AUTH_KEY: tskey-...
+     TS_AUTHKEY: tskey-...
    ```
 
 1. Tailscale (v1.16+) supports storing state inside a Kubernetes Secret.

--- a/docs/k8s/proxy.yaml
+++ b/docs/k8s/proxy.yaml
@@ -33,11 +33,11 @@ spec:
       value: "{{TS_KUBE_SECRET}}"
     - name: TS_USERSPACE
       value: "false"
-    - name: TS_AUTH_KEY
+    - name: TS_AUTHKEY
       valueFrom:
         secretKeyRef:
           name: tailscale-auth
-          key: TS_AUTH_KEY
+          key: TS_AUTHKEY
           optional: true
     - name: TS_DEST_IP
       value: "{{TS_DEST_IP}}"

--- a/docs/k8s/sidecar.yaml
+++ b/docs/k8s/sidecar.yaml
@@ -19,11 +19,11 @@ spec:
       value: "{{TS_KUBE_SECRET}}"
     - name: TS_USERSPACE
       value: "false"
-    - name: TS_AUTH_KEY
+    - name: TS_AUTHKEY
       valueFrom:
         secretKeyRef:
           name: tailscale-auth
-          key: TS_AUTH_KEY
+          key: TS_AUTHKEY
           optional: true
     securityContext:
       capabilities:

--- a/docs/k8s/subnet.yaml
+++ b/docs/k8s/subnet.yaml
@@ -19,11 +19,11 @@ spec:
       value: "{{TS_KUBE_SECRET}}"
     - name: TS_USERSPACE
       value: "true"
-    - name: TS_AUTH_KEY
+    - name: TS_AUTHKEY
       valueFrom:
         secretKeyRef:
           name: tailscale-auth
-          key: TS_AUTH_KEY
+          key: TS_AUTHKEY
           optional: true
     - name: TS_ROUTES
       value: "{{TS_ROUTES}}"

--- a/docs/k8s/userspace-sidecar.yaml
+++ b/docs/k8s/userspace-sidecar.yaml
@@ -22,9 +22,9 @@ spec:
       value: "{{TS_KUBE_SECRET}}"
     - name: TS_USERSPACE
       value: "true"
-    - name: TS_AUTH_KEY
+    - name: TS_AUTHKEY
       valueFrom:
         secretKeyRef:
           name: tailscale-auth
-          key: TS_AUTH_KEY
+          key: TS_AUTHKEY
           optional: true


### PR DESCRIPTION
Updates https://github.com/tailscale/tailscale-www/issues/2199.

Signed-off-by: Walter Poupore <walterp@tailscale.com>