### PR TITLE
ipn/ipnlocal: add /reset-auth LocalAPI endpoint

### DIFF
--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -83,6 +83,7 @@ var handler = map[string]localAPIHandler{
 	"ping":                        (*Handler).servePing,
 	"prefs":                       (*Handler).servePrefs,
 	"pprof":                       (*Handler).servePprof,
+	"reset-auth":                  (*Handler).serveResetAuth,
 	"serve-config":                (*Handler).serveServeConfig,
 	"set-dns":                     (*Handler).serveSetDNS,
 	"set-expiry-sooner":           (*Handler).serveSetExpirySooner,
@@ -619,6 +620,23 @@ func (h *Handler) servePprof(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	servePprofFunc(w, r)
+}
+
+func (h *Handler) serveResetAuth(w http.ResponseWriter, r *http.Request) {
+	if !h.PermitWrite {
+		http.Error(w, "reset-auth modify access denied", http.StatusForbidden)
+		return
+	}
+	if r.Method != httpm.POST {
+		http.Error(w, "use POST", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if err := h.b.ResetAuth(); err != nil {
+		http.Error(w, "reset-auth failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *Handler) serveServeConfig(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
The iOS has a command to reset the persisted state of the app, but it was doing its own direct keychain manipulation. This proved to be brittle (since we changed how preferences are stored with #6022), so we instead add a LocalAPI endpoint to do do this, which can be updated in tandem.

This clears the same state as the iOS implementation (tailscale/corp#3186), that is the machine key and preferences (which includes the node key). Notably this does not clear the logtail ID, so that logs from the device still end up in the same place.

Updates tailscale/corp#8923