### PR TITLE
build_docker.sh: don't push to ghcr by default.

### DIFF
--- a/build_docker.sh
+++ b/build_docker.sh
@@ -24,7 +24,7 @@ export PATH=$PWD/tool:$PATH
 
 eval $(./build_dist.sh shellvars)
 DEFAULT_TAGS="v${VERSION_SHORT},v${VERSION_MINOR}"
-DEFAULT_REPOS="tailscale/tailscale,ghcr.io/tailscale/tailscale"
+DEFAULT_REPOS="tailscale/tailscale"
 DEFAULT_BASE="ghcr.io/tailscale/alpine-base:3.16"
 DEFAULT_TARGET="client"
 


### PR DESCRIPTION
Since we now sync ghcr indirectly due to credential headaches.

Signed-off-by: David Anderson <danderson@tailscale.com>