### PR TITLE
build_docker.sh: use docker hub for base image hosting.

### DIFF
--- a/build_docker.sh
+++ b/build_docker.sh
@@ -26,7 +26,7 @@ eval $(./build_dist.sh shellvars)
 
 DEFAULT_TARGET="client"
 DEFAULT_TAGS="v${VERSION_SHORT},v${VERSION_MINOR}"
-DEFAULT_BASE="ghcr.io/tailscale/alpine-base:3.16"
+DEFAULT_BASE="tailscale/alpine-base:3.16"
 
 PUSH="${PUSH:-false}"
 TARGET="${TARGET:-${DEFAULT_TARGET}}"


### PR DESCRIPTION
Signed-off-by: David Anderson <danderson@tailscale.com>