### PR TITLE
cmd/k8s-operator: use the unstable operator image

### DIFF
--- a/cmd/k8s-operator/manifests/operator.yaml
+++ b/cmd/k8s-operator/manifests/operator.yaml
@@ -124,7 +124,7 @@ spec:
           secretName: operator-oauth
       containers:
         - name: operator
-          image: tailscale/k8s-operator:latest
+          image: tailscale/k8s-operator:unstable
           resources:
             requests:
               cpu: 500m


### PR DESCRIPTION
There is no stable release yet, and for alpha we want people on the unstable build while we iterate.

Updates #502

Signed-off-by: David Anderson <danderson@tailscale.com>