### PR TITLE
cmd/k8s-operator: use unstable tailscale image as well

### DIFF
--- a/cmd/k8s-operator/manifests/operator.yaml
+++ b/cmd/k8s-operator/manifests/operator.yaml
@@ -145,7 +145,7 @@ spec:
             - name: CLIENT_SECRET_FILE
               value: /oauth/client_secret
             - name: PROXY_IMAGE
-              value: tailscale/tailscale:latest
+              value: tailscale/tailscale:unstable
             - name: PROXY_TAGS
               value: tag:k8s
           volumeMounts:


### PR DESCRIPTION
We need a post-1.36 tailscale image to handle custom hostnames correctly.

Updates #502

Signed-off-by: David Anderson <danderson@tailscale.com>