### PR TITLE
tailcfg, etc: plumb OnDemandDomains from the server

### DIFF
--- a/ipn/ipnlocal/dnsconfig_test.go
+++ b/ipn/ipnlocal/dnsconfig_test.go
@@ -305,6 +305,22 @@ func TestDNSConfigForNetmap(t *testing.T) {
 				Routes: map[dnsname.FQDN][]*dnstype.Resolver{},
 			},
 		},
+		{
+			name: "on_demand_domains",
+			nm: &netmap.NetworkMap{
+				DNS: tailcfg.DNSConfig{
+					OnDemandDomains: []string{"ts.net"},
+				},
+			},
+			prefs: &ipn.Prefs{
+				CorpDNS: true,
+			},
+			want: &dns.Config{
+				Hosts:           map[dnsname.FQDN][]netip.Addr{},
+				Routes:          map[dnsname.FQDN][]*dnstype.Resolver{},
+				OnDemandDomains: []string{"ts.net"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -2965,8 +2965,9 @@ func shouldUseOneCGNATRoute(nm *netmap.NetworkMap, logf logger.Logf, versionOS s
 // a runtime.GOOS.
 func dnsConfigForNetmap(nm *netmap.NetworkMap, prefs ipn.PrefsView, logf logger.Logf, versionOS string) *dns.Config {
 	dcfg := &dns.Config{
-		Routes: map[dnsname.FQDN][]*dnstype.Resolver{},
-		Hosts:  map[dnsname.FQDN][]netip.Addr{},
+		Routes:          map[dnsname.FQDN][]*dnstype.Resolver{},
+		Hosts:           map[dnsname.FQDN][]netip.Addr{},
+		OnDemandDomains: append([]string(nil), nm.DNS.OnDemandDomains...),
 	}
 
 	// selfV6Only is whether we only have IPv6 addresses ourselves.

--- a/net/dns/config.go
+++ b/net/dns/config.go
@@ -44,6 +44,14 @@ type Config struct {
 	// OnlyIPv6, if true, uses the IPv6 service IP (for MagicDNS)
 	// instead of the IPv4 version (100.100.100.100).
 	OnlyIPv6 bool
+	// OnDemandDomains are the set of domain names for which the OS
+	// should enable the tailscale client, if it is not already running.
+	//
+	// This is plumbed through to the onDemand rules of
+	// NETunnelProviderManager on macOS/iOS.
+	//
+	// The typical OnDemandDomains is ["ts.net"].
+	OnDemandDomains []string `json:",omitempty"`
 }
 
 func (c *Config) serviceIP() netip.Addr {

--- a/net/dns/osconfig.go
+++ b/net/dns/osconfig.go
@@ -63,10 +63,18 @@ type OSConfig struct {
 	// from the OS, which will only work with OSConfigurators that
 	// report SupportsSplitDNS()=true.
 	MatchDomains []dnsname.FQDN
+	// OnDemandDomains are the set of domain names for which the OS
+	// should enable the tailscale client, if it is not already running.
+	//
+	// This is plumbed through to the onDemand rules of
+	// NETunnelProviderManager on macOS/iOS.
+	//
+	// The typical OnDemandDomains is ["ts.net"].
+	OnDemandDomains []string
 }
 
 func (o OSConfig) IsZero() bool {
-	return len(o.Nameservers) == 0 && len(o.SearchDomains) == 0 && len(o.MatchDomains) == 0
+	return len(o.Nameservers) == 0 && len(o.SearchDomains) == 0 && len(o.MatchDomains) == 0 && len(o.OnDemandDomains) == 0
 }
 
 func (a OSConfig) Equal(b OSConfig) bool {
@@ -92,6 +100,11 @@ func (a OSConfig) Equal(b OSConfig) bool {
 	}
 	for i := range a.MatchDomains {
 		if a.MatchDomains[i] != b.MatchDomains[i] {
+			return false
+		}
+	}
+	for i := range a.OnDemandDomains {
+		if a.OnDemandDomains[i] != b.OnDemandDomains[i] {
 			return false
 		}
 	}
@@ -121,6 +134,13 @@ func (a OSConfig) Format(f fmt.State, verb rune) {
 		}
 		w.WriteString(`] MatchDomains:[`)
 		for i, domain := range a.MatchDomains {
+			if i != 0 {
+				w.WriteString(" ")
+			}
+			fmt.Fprintf(w, "%+v", domain)
+		}
+		w.WriteString(`] OnDemandDomains:[`)
+		for i, domain := range a.OnDemandDomains {
 			if i != 0 {
 				w.WriteString(" ")
 			}

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -1190,6 +1190,15 @@ type DNSConfig struct {
 	//
 	// Matches are case insensitive.
 	ExitNodeFilteredSet []string
+
+	// OnDemandDomains are the set of domain names for which the OS
+	// should enable the tailscale client, if it is not already running.
+	//
+	// This is plumbed through to the onDemand rules of
+	// NETunnelProviderManager on macOS/iOS.
+	//
+	// The typical OnDemandDomains is ["ts.net"].
+	OnDemandDomains []string `json:",omitempty"`
 }
 
 // DNSRecord is an extra DNS record to add to MagicDNS.

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -234,6 +234,7 @@ func (src *DNSConfig) Clone() *DNSConfig {
 	dst.CertDomains = append(src.CertDomains[:0:0], src.CertDomains...)
 	dst.ExtraRecords = append(src.ExtraRecords[:0:0], src.ExtraRecords...)
 	dst.ExitNodeFilteredSet = append(src.ExitNodeFilteredSet[:0:0], src.ExitNodeFilteredSet...)
+	dst.OnDemandDomains = append(src.OnDemandDomains[:0:0], src.OnDemandDomains...)
 	return dst
 }
 
@@ -248,6 +249,7 @@ var _DNSConfigCloneNeedsRegeneration = DNSConfig(struct {
 	CertDomains         []string
 	ExtraRecords        []DNSRecord
 	ExitNodeFilteredSet []string
+	OnDemandDomains     []string
 }{})
 
 // Clone makes a deep copy of RegisterResponse.

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -533,6 +533,9 @@ func (v DNSConfigView) ExtraRecords() views.Slice[DNSRecord] { return views.Slic
 func (v DNSConfigView) ExitNodeFilteredSet() views.Slice[string] {
 	return views.SliceOf(v.ж.ExitNodeFilteredSet)
 }
+func (v DNSConfigView) OnDemandDomains() views.Slice[string] {
+	return views.SliceOf(v.ж.OnDemandDomains)
+}
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _DNSConfigViewNeedsRegeneration = DNSConfig(struct {
@@ -545,6 +548,7 @@ var _DNSConfigViewNeedsRegeneration = DNSConfig(struct {
 	CertDomains         []string
 	ExtraRecords        []DNSRecord
 	ExitNodeFilteredSet []string
+	OnDemandDomains     []string
 }{})
 
 // View returns a readonly view of RegisterResponse.


### PR DESCRIPTION
This lets the server tell macOS/iOS that tailscale should be started to handle any "ts.net" domains.

Updates #1534

Signed-off-by: David Crawshaw <crawshaw@tailscale.com>