### PR TITLE
cmd/tailscale: use request Schema+Host for QNAP authLogin.cgi

### DIFF
--- a/cmd/tailscale/cli/web_test.go
+++ b/cmd/tailscale/cli/web_test.go
@@ -3,7 +3,10 @@
 
 package cli
 
-import "testing"
+import (
+	"net/url"
+	"testing"
+)
 
 func TestUrlOfListenAddr(t *testing.T) {
 	tests := []struct {
@@ -34,9 +37,65 @@ func TestUrlOfListenAddr(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			url := urlOfListenAddr(tt.in)
-			if url != tt.want {
-				t.Errorf("expected url: %q, got: %q", tt.want, url)
+			u := urlOfListenAddr(tt.in)
+			if u != tt.want {
+				t.Errorf("expected url: %q, got: %q", tt.want, u)
+			}
+		})
+	}
+}
+
+func TestQnapAuthnURL(t *testing.T) {
+	query := url.Values{
+		"qtoken": []string{"token"},
+	}
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "localhost http",
+			in:   "http://localhost:8088/",
+			want: "http://localhost:8088/cgi-bin/authLogin.cgi?qtoken=token",
+		},
+		{
+			name: "localhost https",
+			in:   "https://localhost:5000/",
+			want: "https://localhost:5000/cgi-bin/authLogin.cgi?qtoken=token",
+		},
+		{
+			name: "IP http",
+			in:   "http://10.1.20.4:80/",
+			want: "http://10.1.20.4:80/cgi-bin/authLogin.cgi?qtoken=token",
+		},
+		{
+			name: "IP6 https",
+			in:   "https://[ff7d:0:1:2::1]/",
+			want: "https://[ff7d:0:1:2::1]/cgi-bin/authLogin.cgi?qtoken=token",
+		},
+		{
+			name: "hostname https",
+			in:   "https://qnap.example.com/",
+			want: "https://qnap.example.com/cgi-bin/authLogin.cgi?qtoken=token",
+		},
+		{
+			name: "invalid URL",
+			in:   "This is not a URL, it is a really really really really really really really really really really really really long string to exercise the URL truncation code in the error path.",
+			want: "http://localhost/cgi-bin/authLogin.cgi?qtoken=token",
+		},
+		{
+			name: "err != nil",
+                        in:   "http://192.168.0.%31/",
+			want: "http://localhost/cgi-bin/authLogin.cgi?qtoken=token",
+		},
+
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := qnapAuthnURL(tt.in, query)
+			if u != tt.want {
+				t.Errorf("expected url: %q, got: %q", tt.want, u)
 			}
 		})
 	}


### PR DESCRIPTION
QNAP allows users to set the port number for the management WebUI, which includes authLogin.cgi. If they do, then connecting to localhost:8080 fails.

https://github.com/tailscale/tailscale-qpkg/issues/74#issuecomment-1407486911

We have to use the Scheme+Path from the request but disable any TLS verification for https:
- The UI can force https, but presents a completely invalid certificate
- The UI can change the port number, and though https://download.qnap.com/dev/API_QNAP_QTS_Authentication.pdf documents the use of localhost:8080 for authentication this fails if the user changed the port number.

This reverts commit 467ace7d0c0655e69cc219ec380c0119d909f36b.

Fixes https://github.com/tailscale/tailscale/issues/7108

Signed-off-by: Denton Gentry <dgentry@tailscale.com>