### PR TITLE
cmd/tsconnect: use empty string as the default state store key

### DIFF
--- a/cmd/tsconnect/README.md
+++ b/cmd/tsconnect/README.md
@@ -11,7 +11,7 @@ To start the development server:
 ./tool/go run ./cmd/tsconnect dev
 ```
 
-The site is served at http://localhost:9090/. JavaScript and CSS changes can be picked up with a browser reload. Go changes (including to the `wasm` package) require the server to be stopped and restarted. In development mode the state the Tailscale client is stored in `sessionStorage` and will thus survive page reloads (but not the tab being closed).
+The site is served at http://localhost:9090/. JavaScript, CSS and Go `wasm` package changes can be picked up with a browser reload. Server-side Go changes require the server to be stopped and restarted. In development mode the state the Tailscale client state is stored in `sessionStorage` and will thus survive page reloads (but not the tab being closed).
 
 ## Deployment
 

--- a/cmd/tsconnect/wasm/wasm_js.go
+++ b/cmd/tsconnect/wasm/wasm_js.go
@@ -124,7 +124,7 @@ func newIPN(jsConfig js.Value) map[string]any {
 
 	logid := lpc.PublicID.String()
 	srv := ipnserver.New(logf, logid)
-	lb, err := ipnlocal.NewLocalBackend(logf, logid, store, "wasm", dialer, eng, controlclient.LoginEphemeral)
+	lb, err := ipnlocal.NewLocalBackend(logf, logid, store, "", dialer, eng, controlclient.LoginEphemeral)
 	if err != nil {
 		log.Fatalf("ipnlocal.NewLocalBackend: %v", err)
 	}


### PR DESCRIPTION
Makes the Wasm client more similar to the others, and allows the default profile to be correctly picked up when restarting the client in dev mode (where we persist the state in sessionStorage).

Also update README to reflect that Go Wasm changes can be picked up with just a reload (as of #5383).