### PR TITLE
nix: update nixpkgs flake, override go_1_20 for tailscale_go

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,11 +33,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671848398,
-        "narHash": "sha256-cJIIPd1kvCI6ne/S0facbiBNH7sZUzk405GfdSJPwZE=",
+        "lastModified": 1675153841,
+        "narHash": "sha256-EWvU3DLq+4dbJiukfhS7r6sWZyJikgXn6kNl7eHljW8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bb0359be0a1a08c8d74412fe8c69aa2ffb3f477e",
+        "rev": "ea692c2ad1afd6384e171eabef4f0887d2b882d3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,7 @@
     # nixpkgs style imports and flake semantics, unless upstream
     # nixpkgs exposes the buildGoModule constructor func explicitly.
     pkgsWithTailscaleGo = pkgs: pkgs.extend (final: prev: rec {
-      tailscale_go = prev.lib.overrideDerivation prev.go_1_19 (attrs: rec {
+      tailscale_go = prev.lib.overrideDerivation prev.go_1_20 (attrs: rec {
         name = "tailscale-go-${version}";
         version = tailscale-go-rev;
         src = pkgs.fetchFromGitHub {
@@ -82,9 +82,9 @@
         checkPhase = "";
         TAILSCALE_TOOLCHAIN_REV = tailscale-go-rev;
       });
-      # Override go_1_19 so that buildGo119Module below uses
+      # Override go_1_20 so that buildGo120Module below uses
       # tailscale's toolchain as well.
-      go_1_19 = tailscale_go;
+      go_1_20 = tailscale_go;
     });
 
     # tailscaleRev is the git commit at which this flake was imported,
@@ -108,7 +108,7 @@
     # So really, this flake is for tailscale devs to dogfood with, if
     # you're an end user you should be prepared for this flake to not
     # build periodically.
-    tailscale = pkgs: pkgs.buildGo119Module rec {
+    tailscale = pkgs: pkgs.buildGo120Module rec {
       name = "tailscale";
 
       src = ./.;


### PR DESCRIPTION
Bleeding edge Tailscale Nix flake broke after updating to go1.20rc3.

Go 1.20 moved to Go 1.17 as a bootstarp toolchain. Fortunately nixpkgs nixos-unstable already had a 1.20.nix with bootstrap117.nix.

```
❯ ./result/bin/tailscale version
1.37.0-dev
  track: unstable (dev); frequent updates and bugs are likely
  go version: go1.20rc3-ts6a17f14c05
```