### PR TITLE
Allow the expiry time to be specified for new keys

### DIFF
--- a/client/tailscale/keys.go
+++ b/client/tailscale/keys.go
@@ -70,12 +70,12 @@ func (c *Client) Keys(ctx context.Context) ([]string, error) {
 // CreateKey creates a new key for the current user. Currently, only auth keys
 // can be created. Returns the key itself, which cannot be retrieved again
 // later, and the key metadata.
-func (c *Client) CreateKey(ctx context.Context, caps KeyCapabilities, expirySeconds int64) (string, *Key, error) {
+func (c *Client) CreateKey(ctx context.Context, caps KeyCapabilities, expiry time.Duration) (string, *Key, error) {
 
-	ninetydays := int64(90 * 24 * 60 * 60)
-
-	if expirySeconds > ninetydays {
-		return "", nil, fmt.Errorf("expiry must be less than 90 days")
+	// convert expirySeconds to an int64 (seconds)
+	expirySeconds := int64(expiry.Seconds())
+	if expirySeconds < 0 {
+		return "", nil, fmt.Errorf("expiry must be positive")
 	}
 
 	keyRequest := struct {

--- a/client/tailscale/keys.go
+++ b/client/tailscale/keys.go
@@ -70,10 +70,18 @@ func (c *Client) Keys(ctx context.Context) ([]string, error) {
 // CreateKey creates a new key for the current user. Currently, only auth keys
 // can be created. Returns the key itself, which cannot be retrieved again
 // later, and the key metadata.
-func (c *Client) CreateKey(ctx context.Context, caps KeyCapabilities) (string, *Key, error) {
+func (c *Client) CreateKey(ctx context.Context, caps KeyCapabilities, expirySeconds int64) (string, *Key, error) {
+
+	ninetydays := int64(90 * 24 * 60 * 60)
+
+	if expirySeconds > ninetydays {
+		return "", nil, fmt.Errorf("expiry must be less than 90 days")
+	}
+
 	keyRequest := struct {
-		Capabilities KeyCapabilities `json:"capabilities"`
-	}{caps}
+		Capabilities  KeyCapabilities `json:"capabilities"`
+		ExpirySeconds int64           `json:"expirySeconds,omitempty"`
+	}{caps, int64(expirySeconds)}
 	bs, err := json.Marshal(keyRequest)
 	if err != nil {
 		return "", nil, err

--- a/cmd/get-authkey/main.go
+++ b/cmd/get-authkey/main.go
@@ -67,7 +67,7 @@ func main() {
 		},
 	}
 
-	authkey, _, err := tsClient.CreateKey(ctx, caps)
+	authkey, _, err := tsClient.CreateKey(ctx, caps, 0)
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/cmd/k8s-operator/operator.go
+++ b/cmd/k8s-operator/operator.go
@@ -152,7 +152,9 @@ waitOnline:
 					},
 				},
 			}
-			authkey, _, err := tsClient.CreateKey(ctx, caps)
+			ninetyDays := 90 * 24 * time.Hour
+
+			authkey, _, err := tsClient.CreateKey(ctx, caps, int64(ninetyDays.Seconds()))
 			if err != nil {
 				startlog.Fatalf("creating operator authkey: %v", err)
 			}
@@ -286,7 +288,7 @@ type ServiceReconciler struct {
 }
 
 type tsClient interface {
-	CreateKey(ctx context.Context, caps tailscale.KeyCapabilities) (string, *tailscale.Key, error)
+	CreateKey(ctx context.Context, caps tailscale.KeyCapabilities, expirySeconds int64) (string, *tailscale.Key, error)
 	DeleteDevice(ctx context.Context, id string) error
 }
 
@@ -589,7 +591,8 @@ func (a *ServiceReconciler) newAuthKey(ctx context.Context, tags []string) (stri
 			},
 		},
 	}
-	key, _, err := a.tsClient.CreateKey(ctx, caps)
+	ninetyDays := 90 * 24 * time.Hour
+	key, _, err := a.tsClient.CreateKey(ctx, caps, int64(ninetyDays.Seconds()))
 	if err != nil {
 		return "", err
 	}

--- a/cmd/k8s-operator/operator.go
+++ b/cmd/k8s-operator/operator.go
@@ -152,9 +152,9 @@ waitOnline:
 					},
 				},
 			}
-			ninetyDays := 90 * 24 * time.Hour
-
-			authkey, _, err := tsClient.CreateKey(ctx, caps, int64(ninetyDays.Seconds()))
+			// zeroSeconds adopts the default expiration time.
+			zeroSeconds := time.Duration(0 * time.Second)
+			authkey, _, err := tsClient.CreateKey(ctx, caps, zeroSeconds)
 			if err != nil {
 				startlog.Fatalf("creating operator authkey: %v", err)
 			}
@@ -288,7 +288,7 @@ type ServiceReconciler struct {
 }
 
 type tsClient interface {
-	CreateKey(ctx context.Context, caps tailscale.KeyCapabilities, expirySeconds int64) (string, *tailscale.Key, error)
+	CreateKey(ctx context.Context, caps tailscale.KeyCapabilities, expiry time.Duration) (string, *tailscale.Key, error)
 	DeleteDevice(ctx context.Context, id string) error
 }
 
@@ -591,8 +591,9 @@ func (a *ServiceReconciler) newAuthKey(ctx context.Context, tags []string) (stri
 			},
 		},
 	}
-	ninetyDays := 90 * 24 * time.Hour
-	key, _, err := a.tsClient.CreateKey(ctx, caps, int64(ninetyDays.Seconds()))
+
+	zeroDuration := time.Duration(0)
+	key, _, err := a.tsClient.CreateKey(ctx, caps, zeroDuration)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/k8s-operator/operator_test.go
+++ b/cmd/k8s-operator/operator_test.go
@@ -807,14 +807,14 @@ type fakeTSClient struct {
 	deleted     []string
 }
 
-func (c *fakeTSClient) CreateKey(ctx context.Context, caps tailscale.KeyCapabilities) (string, *tailscale.Key, error) {
+func (c *fakeTSClient) CreateKey(ctx context.Context, caps tailscale.KeyCapabilities, expirySeconds int64) (string, *tailscale.Key, error) {
 	c.Lock()
 	defer c.Unlock()
 	c.keyRequests = append(c.keyRequests, caps)
 	k := &tailscale.Key{
 		ID:           "key",
 		Created:      time.Now(),
-		Expires:      time.Now().Add(24 * time.Hour),
+		Expires:      time.Now().Add(time.Second * time.Duration(expirySeconds)),
 		Capabilities: caps,
 	}
 	return "secret-authkey", k, nil

--- a/cmd/k8s-operator/operator_test.go
+++ b/cmd/k8s-operator/operator_test.go
@@ -807,14 +807,14 @@ type fakeTSClient struct {
 	deleted     []string
 }
 
-func (c *fakeTSClient) CreateKey(ctx context.Context, caps tailscale.KeyCapabilities, expirySeconds int64) (string, *tailscale.Key, error) {
+func (c *fakeTSClient) CreateKey(ctx context.Context, caps tailscale.KeyCapabilities, expiry time.Duration) (string, *tailscale.Key, error) {
 	c.Lock()
 	defer c.Unlock()
 	c.keyRequests = append(c.keyRequests, caps)
 	k := &tailscale.Key{
 		ID:           "key",
 		Created:      time.Now(),
-		Expires:      time.Now().Add(time.Second * time.Duration(expirySeconds)),
+		Expires:      time.Now().Add(expiry),
 		Capabilities: caps,
 	}
 	return "secret-authkey", k, nil


### PR DESCRIPTION
Adds a parameter for create key that allows a number of seconds (less than 90) to be specified for new keys. 

Closes #7965 

Signed-off-by: Matthew Brown <matthew@bargrove.com>