### PR TITLE
go.toolchain.branch: update to Go 1.20

### DIFF
--- a/go.toolchain.branch
+++ b/go.toolchain.branch
@@ -1,1 +1,1 @@
-tailscale.go1.19
+tailscale.go1.20


### PR DESCRIPTION
Updates #7123
