### PR TITLE
util/vizerror: add As function to get wrapped Error

### DIFF
--- a/tsweb/tsweb.go
+++ b/tsweb/tsweb.go
@@ -266,11 +266,10 @@ func (h retHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err := h.rh.ServeHTTPReturn(lw, r)
 
 	var hErr HTTPError
-	var vizErr vizerror.Error
 	var hErrOK bool
 	if errors.As(err, &hErr) {
 		hErrOK = true
-	} else if errors.As(err, &vizErr) {
+	} else if vizErr, ok := vizerror.As(err); ok {
 		hErrOK = true
 		hErr = HTTPError{Msg: vizErr.Error()}
 	}

--- a/util/vizerror/vizerror.go
+++ b/util/vizerror/vizerror.go
@@ -42,3 +42,9 @@ func Wrap(err error) error {
 	}
 	return Error{err}
 }
+
+// As returns the first vizerror.Error in err's chain.
+func As(err error) (e Error, ok bool) {
+	ok = errors.As(err, &e)
+	return
+}

--- a/util/vizerror/vizerror_test.go
+++ b/util/vizerror/vizerror_test.go
@@ -5,6 +5,7 @@ package vizerror
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"testing"
 )
@@ -26,5 +27,18 @@ func TestErrorf(t *testing.T) {
 	// ensure error wrapping still works
 	if !errors.Is(err, fs.ErrNotExist) {
 		t.Errorf("error chain does not contain fs.ErrNotExist")
+	}
+}
+
+func TestAs(t *testing.T) {
+	verr := New("visible error")
+	err := fmt.Errorf("wrap: %w", verr)
+
+	got, ok := As(err)
+	if !ok {
+		t.Errorf("As() return false, want true")
+	}
+	if got != verr {
+		t.Errorf("As() returned error %v, want %v", got, verr)
 	}
 }


### PR DESCRIPTION
okay, NOW I get what you were suggesting [in this comment](https://github.com/tailscale/tailscale/pull/7120#discussion_r1091180336).