### PR TITLE
.github/workflows: delete CIFuzz job

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,5 +1,5 @@
 name: CIFuzz
-on: [pull_request]
+on: [] # was: [pull_request], but disabled in https://github.com/tailscale/tailscale/pull/7156
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
It doesn't yet support Go 1.20. We can bring it back later.

Updates #7123
