### PR TITLE
net/dnsfallback: update `dns-fallback-servers.json`

### DIFF
--- a/net/dnsfallback/dns-fallback-servers.json
+++ b/net/dnsfallback/dns-fallback-servers.json
@@ -6,25 +6,25 @@
 			"RegionName": "r1",
 			"Nodes": [
 				{
-					"Name": "1c",
+					"Name": "1f",
 					"RegionID": 1,
-					"HostName": "derp1c.tailscale.com",
-					"IPv4": "104.248.8.210",
-					"IPv6": "2604:a880:800:10::7a0:e001"
+					"HostName": "derp1f.tailscale.com",
+					"IPv4": "199.38.181.104",
+					"IPv6": "2607:f740:f::bc"
 				},
 				{
-					"Name": "1d",
+					"Name": "1g",
 					"RegionID": 1,
-					"HostName": "derp1d.tailscale.com",
-					"IPv4": "165.22.33.71",
-					"IPv6": "2604:a880:800:10::7fe:f001"
+					"HostName": "derp1g.tailscale.com",
+					"IPv4": "209.177.145.120",
+					"IPv6": "2607:f740:f::3eb"
 				},
 				{
-					"Name": "1e",
+					"Name": "1h",
 					"RegionID": 1,
-					"HostName": "derp1e.tailscale.com",
-					"IPv4": "64.225.56.166",
-					"IPv6": "2604:a880:800:10::873:4001"
+					"HostName": "derp1h.tailscale.com",
+					"IPv4": "199.38.181.93",
+					"IPv6": "2607:f740:f::afd"
 				}
 			]
 		},
@@ -34,11 +34,25 @@
 			"RegionName": "r10",
 			"Nodes": [
 				{
-					"Name": "10a",
+					"Name": "10b",
 					"RegionID": 10,
-					"HostName": "derp10.tailscale.com",
-					"IPv4": "137.220.36.168",
-					"IPv6": "2001:19f0:8001:2d9:5400:2ff:feef:bbb1"
+					"HostName": "derp10b.tailscale.com",
+					"IPv4": "192.73.240.161",
+					"IPv6": "2607:f740:14::61c"
+				},
+				{
+					"Name": "10c",
+					"RegionID": 10,
+					"HostName": "derp10c.tailscale.com",
+					"IPv4": "192.73.240.121",
+					"IPv6": "2607:f740:14::40c"
+				},
+				{
+					"Name": "10d",
+					"RegionID": 10,
+					"HostName": "derp10d.tailscale.com",
+					"IPv4": "192.73.240.132",
+					"IPv6": "2607:f740:14::500"
 				}
 			]
 		},
@@ -48,11 +62,25 @@
 			"RegionName": "r11",
 			"Nodes": [
 				{
-					"Name": "11a",
+					"Name": "11b",
 					"RegionID": 11,
-					"HostName": "derp11.tailscale.com",
-					"IPv4": "18.230.97.74",
-					"IPv6": "2600:1f1e:ee4:5611:ec5c:1736:d43b:a454"
+					"HostName": "derp11b.tailscale.com",
+					"IPv4": "148.163.220.129",
+					"IPv6": "2607:f740:1::211"
+				},
+				{
+					"Name": "11c",
+					"RegionID": 11,
+					"HostName": "derp11c.tailscale.com",
+					"IPv4": "148.163.220.134",
+					"IPv6": "2607:f740:1::861"
+				},
+				{
+					"Name": "11d",
+					"RegionID": 11,
+					"HostName": "derp11d.tailscale.com",
+					"IPv4": "148.163.220.210",
+					"IPv6": "2607:f740:1::2e6"
 				}
 			]
 		},
@@ -62,25 +90,221 @@
 			"RegionName": "r12",
 			"Nodes": [
 				{
-					"Name": "12a",
+					"Name": "12d",
 					"RegionID": 12,
-					"HostName": "derp12.tailscale.com",
-					"IPv4": "216.128.144.130",
-					"IPv6": "2001:19f0:5c01:289:5400:3ff:fe8d:cb5e"
+					"HostName": "derp12d.tailscale.com",
+					"IPv4": "209.177.158.246",
+					"IPv6": "2607:f740:e::811"
 				},
 				{
-					"Name": "12b",
+					"Name": "12e",
 					"RegionID": 12,
-					"HostName": "derp12b.tailscale.com",
-					"IPv4": "45.63.71.144",
-					"IPv6": "2001:19f0:5c01:48a:5400:3ff:fe8d:cb5f"
+					"HostName": "derp12e.tailscale.com",
+					"IPv4": "209.177.158.15",
+					"IPv6": "2607:f740:e::b17"
 				},
 				{
-					"Name": "12c",
+					"Name": "12f",
 					"RegionID": 12,
-					"HostName": "derp12c.tailscale.com",
-					"IPv4": "149.28.119.105",
-					"IPv6": "2001:19f0:5c01:2cb:5400:3ff:fe8d:cb60"
+					"HostName": "derp12f.tailscale.com",
+					"IPv4": "199.38.182.118",
+					"IPv6": "2607:f740:e::4c8"
+				}
+			]
+		},
+		"13": {
+			"RegionID": 13,
+			"RegionCode": "r13",
+			"RegionName": "r13",
+			"Nodes": [
+				{
+					"Name": "13b",
+					"RegionID": 13,
+					"HostName": "derp13b.tailscale.com",
+					"IPv4": "192.73.242.187",
+					"IPv6": "2607:f740:16::640"
+				},
+				{
+					"Name": "13c",
+					"RegionID": 13,
+					"HostName": "derp13c.tailscale.com",
+					"IPv4": "192.73.242.28",
+					"IPv6": "2607:f740:16::5c"
+				},
+				{
+					"Name": "13d",
+					"RegionID": 13,
+					"HostName": "derp13d.tailscale.com",
+					"IPv4": "192.73.242.204",
+					"IPv6": "2607:f740:16::c23"
+				}
+			]
+		},
+		"14": {
+			"RegionID": 14,
+			"RegionCode": "r14",
+			"RegionName": "r14",
+			"Nodes": [
+				{
+					"Name": "14b",
+					"RegionID": 14,
+					"HostName": "derp14b.tailscale.com",
+					"IPv4": "176.58.93.248",
+					"IPv6": "2a00:dd80:3c::807"
+				},
+				{
+					"Name": "14c",
+					"RegionID": 14,
+					"HostName": "derp14c.tailscale.com",
+					"IPv4": "176.58.93.147",
+					"IPv6": "2a00:dd80:3c::b09"
+				},
+				{
+					"Name": "14d",
+					"RegionID": 14,
+					"HostName": "derp14d.tailscale.com",
+					"IPv4": "176.58.93.154",
+					"IPv6": "2a00:dd80:3c::3d5"
+				}
+			]
+		},
+		"15": {
+			"RegionID": 15,
+			"RegionCode": "r15",
+			"RegionName": "r15",
+			"Nodes": [
+				{
+					"Name": "15b",
+					"RegionID": 15,
+					"HostName": "derp15b.tailscale.com",
+					"IPv4": "102.67.165.90",
+					"IPv6": "2c0f:edb0:0:10::963"
+				},
+				{
+					"Name": "15c",
+					"RegionID": 15,
+					"HostName": "derp15c.tailscale.com",
+					"IPv4": "102.67.165.185",
+					"IPv6": "2c0f:edb0:0:10::b59"
+				},
+				{
+					"Name": "15d",
+					"RegionID": 15,
+					"HostName": "derp15d.tailscale.com",
+					"IPv4": "102.67.165.36",
+					"IPv6": "2c0f:edb0:0:10::599"
+				}
+			]
+		},
+		"16": {
+			"RegionID": 16,
+			"RegionCode": "r16",
+			"RegionName": "r16",
+			"Nodes": [
+				{
+					"Name": "16b",
+					"RegionID": 16,
+					"HostName": "derp16b.tailscale.com",
+					"IPv4": "192.73.243.135",
+					"IPv6": "2607:f740:17::476"
+				},
+				{
+					"Name": "16c",
+					"RegionID": 16,
+					"HostName": "derp16c.tailscale.com",
+					"IPv4": "192.73.243.229",
+					"IPv6": "2607:f740:17::4e4"
+				},
+				{
+					"Name": "16d",
+					"RegionID": 16,
+					"HostName": "derp16d.tailscale.com",
+					"IPv4": "192.73.243.141",
+					"IPv6": "2607:f740:17::475"
+				}
+			]
+		},
+		"17": {
+			"RegionID": 17,
+			"RegionCode": "r17",
+			"RegionName": "r17",
+			"Nodes": [
+				{
+					"Name": "17b",
+					"RegionID": 17,
+					"HostName": "derp17b.tailscale.com",
+					"IPv4": "192.73.244.245",
+					"IPv6": "2607:f740:c::646"
+				},
+				{
+					"Name": "17c",
+					"RegionID": 17,
+					"HostName": "derp17c.tailscale.com",
+					"IPv4": "208.111.40.12",
+					"IPv6": "2607:f740:c::10"
+				},
+				{
+					"Name": "17d",
+					"RegionID": 17,
+					"HostName": "derp17d.tailscale.com",
+					"IPv4": "208.111.40.216",
+					"IPv6": "2607:f740:c::e1b"
+				}
+			]
+		},
+		"18": {
+			"RegionID": 18,
+			"RegionCode": "r18",
+			"RegionName": "r18",
+			"Nodes": [
+				{
+					"Name": "18b",
+					"RegionID": 18,
+					"HostName": "derp18b.tailscale.com",
+					"IPv4": "176.58.90.147",
+					"IPv6": "2a00:dd80:3e::363"
+				},
+				{
+					"Name": "18c",
+					"RegionID": 18,
+					"HostName": "derp18c.tailscale.com",
+					"IPv4": "176.58.90.207",
+					"IPv6": "2a00:dd80:3e::c19"
+				},
+				{
+					"Name": "18d",
+					"RegionID": 18,
+					"HostName": "derp18d.tailscale.com",
+					"IPv4": "176.58.90.104",
+					"IPv6": "2a00:dd80:3e::f2e"
+				}
+			]
+		},
+		"19": {
+			"RegionID": 19,
+			"RegionCode": "r19",
+			"RegionName": "r19",
+			"Nodes": [
+				{
+					"Name": "19b",
+					"RegionID": 19,
+					"HostName": "derp19b.tailscale.com",
+					"IPv4": "45.159.97.144",
+					"IPv6": "2a00:dd80:14:10::335"
+				},
+				{
+					"Name": "19c",
+					"RegionID": 19,
+					"HostName": "derp19c.tailscale.com",
+					"IPv4": "45.159.97.61",
+					"IPv6": "2a00:dd80:14:10::20"
+				},
+				{
+					"Name": "19d",
+					"RegionID": 19,
+					"HostName": "derp19d.tailscale.com",
+					"IPv4": "45.159.97.233",
+					"IPv6": "2a00:dd80:14:10::34a"
 				}
 			]
 		},
@@ -112,17 +336,171 @@
 				}
 			]
 		},
+		"20": {
+			"RegionID": 20,
+			"RegionCode": "r20",
+			"RegionName": "r20",
+			"Nodes": [
+				{
+					"Name": "20b",
+					"RegionID": 20,
+					"HostName": "derp20b.tailscale.com",
+					"IPv4": "103.6.84.152",
+					"IPv6": "2403:2500:8000:1::ef6"
+				},
+				{
+					"Name": "20c",
+					"RegionID": 20,
+					"HostName": "derp20c.tailscale.com",
+					"IPv4": "205.147.105.30",
+					"IPv6": "2403:2500:8000:1::5fb"
+				},
+				{
+					"Name": "20d",
+					"RegionID": 20,
+					"HostName": "derp20d.tailscale.com",
+					"IPv4": "205.147.105.78",
+					"IPv6": "2403:2500:8000:1::e9a"
+				}
+			]
+		},
+		"21": {
+			"RegionID": 21,
+			"RegionCode": "r21",
+			"RegionName": "r21",
+			"Nodes": [
+				{
+					"Name": "21b",
+					"RegionID": 21,
+					"HostName": "derp21b.tailscale.com",
+					"IPv4": "162.248.221.199",
+					"IPv6": "2607:f740:50::1d1"
+				},
+				{
+					"Name": "21c",
+					"RegionID": 21,
+					"HostName": "derp21c.tailscale.com",
+					"IPv4": "162.248.221.215",
+					"IPv6": "2607:f740:50::f10"
+				},
+				{
+					"Name": "21d",
+					"RegionID": 21,
+					"HostName": "derp21d.tailscale.com",
+					"IPv4": "162.248.221.248",
+					"IPv6": "2607:f740:50::ca4"
+				}
+			]
+		},
+		"22": {
+			"RegionID": 22,
+			"RegionCode": "r22",
+			"RegionName": "r22",
+			"Nodes": [
+				{
+					"Name": "22b",
+					"RegionID": 22,
+					"HostName": "derp22b.tailscale.com",
+					"IPv4": "45.159.98.196",
+					"IPv6": "2a00:dd80:40:100::316"
+				},
+				{
+					"Name": "22c",
+					"RegionID": 22,
+					"HostName": "derp22c.tailscale.com",
+					"IPv4": "45.159.98.253",
+					"IPv6": "2a00:dd80:40:100::3f"
+				},
+				{
+					"Name": "22d",
+					"RegionID": 22,
+					"HostName": "derp22d.tailscale.com",
+					"IPv4": "45.159.98.145",
+					"IPv6": "2a00:dd80:40:100::211"
+				}
+			]
+		},
+		"23": {
+			"RegionID": 23,
+			"RegionCode": "r23",
+			"RegionName": "r23",
+			"Nodes": [
+				{
+					"Name": "23b",
+					"RegionID": 23,
+					"HostName": "derp23b.tailscale.com",
+					"IPv4": "185.34.3.232",
+					"IPv6": "2a00:dd80:3f:100::76f"
+				},
+				{
+					"Name": "23c",
+					"RegionID": 23,
+					"HostName": "derp23c.tailscale.com",
+					"IPv4": "185.34.3.207",
+					"IPv6": "2a00:dd80:3f:100::a50"
+				},
+				{
+					"Name": "23d",
+					"RegionID": 23,
+					"HostName": "derp23d.tailscale.com",
+					"IPv4": "185.34.3.75",
+					"IPv6": "2a00:dd80:3f:100::97e"
+				}
+			]
+		},
+		"24": {
+			"RegionID": 24,
+			"RegionCode": "r24",
+			"RegionName": "r24",
+			"Nodes": [
+				{
+					"Name": "24b",
+					"RegionID": 24,
+					"HostName": "derp24b.tailscale.com",
+					"IPv4": "208.83.234.151",
+					"IPv6": "2001:19f0:c000:c586:5400:04ff:fe26:2ba6"
+				},
+				{
+					"Name": "24c",
+					"RegionID": 24,
+					"HostName": "derp24c.tailscale.com",
+					"IPv4": "208.83.233.233",
+					"IPv6": "2001:19f0:c000:c591:5400:04ff:fe26:2c5f"
+				},
+				{
+					"Name": "24d",
+					"RegionID": 24,
+					"HostName": "derp24d.tailscale.com",
+					"IPv4": "208.72.155.133",
+					"IPv6": "2001:19f0:c000:c564:5400:04ff:fe26:2ba8"
+				}
+			]
+		},
 		"3": {
 			"RegionID": 3,
 			"RegionCode": "r3",
 			"RegionName": "r3",
 			"Nodes": [
 				{
-					"Name": "3a",
+					"Name": "3b",
 					"RegionID": 3,
-					"HostName": "derp3.tailscale.com",
-					"IPv4": "68.183.179.66",
-					"IPv6": "2400:6180:0:d1::67d:8001"
+					"HostName": "derp3b.tailscale.com",
+					"IPv4": "43.245.49.105",
+					"IPv6": "2403:2500:300::b0c"
+				},
+				{
+					"Name": "3c",
+					"RegionID": 3,
+					"HostName": "derp3c.tailscale.com",
+					"IPv4": "43.245.49.83",
+					"IPv6": "2403:2500:300::57a"
+				},
+				{
+					"Name": "3d",
+					"RegionID": 3,
+					"HostName": "derp3d.tailscale.com",
+					"IPv4": "43.245.49.144",
+					"IPv6": "2403:2500:300::df9"
 				}
 			]
 		},
@@ -132,25 +510,25 @@
 			"RegionName": "r4",
 			"Nodes": [
 				{
-					"Name": "4c",
+					"Name": "4f",
 					"RegionID": 4,
-					"HostName": "derp4c.tailscale.com",
-					"IPv4": "134.122.77.138",
-					"IPv6": "2a03:b0c0:3:d0::1501:6001"
+					"HostName": "derp4f.tailscale.com",
+					"IPv4": "185.40.234.219",
+					"IPv6": "2a00:dd80:20::a25"
 				},
 				{
-					"Name": "4d",
+					"Name": "4g",
 					"RegionID": 4,
-					"HostName": "derp4d.tailscale.com",
-					"IPv4": "134.122.94.167",
-					"IPv6": "2a03:b0c0:3:d0::1501:b001"
+					"HostName": "derp4g.tailscale.com",
+					"IPv4": "185.40.234.113",
+					"IPv6": "2a00:dd80:20::8f"
 				},
 				{
-					"Name": "4e",
+					"Name": "4h",
 					"RegionID": 4,
-					"HostName": "derp4e.tailscale.com",
-					"IPv4": "134.122.74.153",
-					"IPv6": "2a03:b0c0:3:d0::29:9001"
+					"HostName": "derp4h.tailscale.com",
+					"IPv4": "185.40.234.77",
+					"IPv6": "2a00:dd80:20::bcf"
 				}
 			]
 		},
@@ -160,11 +538,25 @@
 			"RegionName": "r5",
 			"Nodes": [
 				{
-					"Name": "5a",
+					"Name": "5b",
 					"RegionID": 5,
-					"HostName": "derp5.tailscale.com",
-					"IPv4": "103.43.75.49",
-					"IPv6": "2001:19f0:5801:10b7:5400:2ff:feaa:284c"
+					"HostName": "derp5b.tailscale.com",
+					"IPv4": "43.245.48.220",
+					"IPv6": "2403:2500:9000:1::ce7"
+				},
+				{
+					"Name": "5c",
+					"RegionID": 5,
+					"HostName": "derp5c.tailscale.com",
+					"IPv4": "43.245.48.50",
+					"IPv6": "2403:2500:9000:1::f57"
+				},
+				{
+					"Name": "5d",
+					"RegionID": 5,
+					"HostName": "derp5d.tailscale.com",
+					"IPv4": "43.245.48.250",
+					"IPv6": "2403:2500:9000:1::43"
 				}
 			]
 		},
@@ -188,11 +580,25 @@
 			"RegionName": "r7",
 			"Nodes": [
 				{
-					"Name": "7a",
+					"Name": "7b",
 					"RegionID": 7,
-					"HostName": "derp7.tailscale.com",
-					"IPv4": "167.179.89.145",
-					"IPv6": "2401:c080:1000:467f:5400:2ff:feee:22aa"
+					"HostName": "derp7b.tailscale.com",
+					"IPv4": "103.84.155.178",
+					"IPv6": "2403:2500:400:20::b79"
+				},
+				{
+					"Name": "7c",
+					"RegionID": 7,
+					"HostName": "derp7c.tailscale.com",
+					"IPv4": "103.84.155.188",
+					"IPv6": "2403:2500:400:20::835"
+				},
+				{
+					"Name": "7d",
+					"RegionID": 7,
+					"HostName": "derp7d.tailscale.com",
+					"IPv4": "103.84.155.46",
+					"IPv6": "2403:2500:400:20::cfe"
 				}
 			]
 		},
@@ -202,25 +608,25 @@
 			"RegionName": "r8",
 			"Nodes": [
 				{
-					"Name": "8b",
+					"Name": "8e",
 					"RegionID": 8,
-					"HostName": "derp8b.tailscale.com",
-					"IPv4": "46.101.74.201",
-					"IPv6": "2a03:b0c0:1:d0::ec1:e001"
+					"HostName": "derp8e.tailscale.com",
+					"IPv4": "176.58.92.144",
+					"IPv6": "2a00:dd80:3a::b33"
 				},
 				{
-					"Name": "8c",
+					"Name": "8f",
 					"RegionID": 8,
-					"HostName": "derp8c.tailscale.com",
-					"IPv4": "206.189.16.32",
-					"IPv6": "2a03:b0c0:1:d0::e1f:4001"
+					"HostName": "derp8f.tailscale.com",
+					"IPv4": "176.58.88.183",
+					"IPv6": "2a00:dd80:3a::dfa"
 				},
 				{
-					"Name": "8d",
+					"Name": "8g",
 					"RegionID": 8,
-					"HostName": "derp8d.tailscale.com",
-					"IPv4": "178.62.44.132",
-					"IPv6": "2a03:b0c0:1:d0::e08:e001"
+					"HostName": "derp8g.tailscale.com",
+					"IPv4": "176.58.92.254",
+					"IPv6": "2a00:dd80:3a::ed"
 				}
 			]
 		},
@@ -230,25 +636,25 @@
 			"RegionName": "r9",
 			"Nodes": [
 				{
-					"Name": "9a",
+					"Name": "9d",
 					"RegionID": 9,
-					"HostName": "derp9.tailscale.com",
-					"IPv4": "207.148.3.137",
-					"IPv6": "2001:19f0:6401:1d9c:5400:2ff:feef:bb82"
+					"HostName": "derp9d.tailscale.com",
+					"IPv4": "209.177.156.94",
+					"IPv6": "2607:f740:100::c05"
 				},
 				{
-					"Name": "9b",
+					"Name": "9e",
 					"RegionID": 9,
-					"HostName": "derp9b.tailscale.com",
-					"IPv4": "144.202.67.195",
-					"IPv6": "2001:19f0:6401:eb5:5400:3ff:fe8d:6d9b"
+					"HostName": "derp9e.tailscale.com",
+					"IPv4": "192.73.248.83",
+					"IPv6": "2607:f740:100::359"
 				},
 				{
-					"Name": "9c",
+					"Name": "9f",
 					"RegionID": 9,
-					"HostName": "derp9c.tailscale.com",
-					"IPv4": "155.138.243.219",
-					"IPv6": "2001:19f0:6401:fe7:5400:3ff:fe8d:6d9c"
+					"HostName": "derp9f.tailscale.com",
+					"IPv4": "209.177.156.197",
+					"IPv6": "2607:f740:100::cad"
 				}
 			]
 		}

--- a/net/dnsfallback/dnsfallback_test.go
+++ b/net/dnsfallback/dnsfallback_test.go
@@ -52,9 +52,9 @@ func TestCache(t *testing.T) {
 				RegionCode: "r1",
 				RegionName: "r1",
 				Nodes: []*tailcfg.DERPNode{{
-					Name:     "1c",
+					Name:     "1f",
 					RegionID: 1,
-					HostName: "derp1c.tailscale.com",
+					HostName: "derp1f.tailscale.com",
 					IPv4:     "127.0.0.1",
 					IPv6:     "::1",
 				}},
@@ -99,7 +99,7 @@ func TestCache(t *testing.T) {
 	// we don't accidentally start allowing overwrites due to some of the
 	// test's assumptions changing out from underneath us as we update the
 	// JSON file of fallback servers.
-	if getStaticDERPMap().Regions[1].Nodes[0].HostName != "derp1c.tailscale.com" {
+	if getStaticDERPMap().Regions[1].Nodes[0].HostName != "derp1f.tailscale.com" {
 		t.Errorf("DERP server has a different name; please update this test")
 	}
 }


### PR DESCRIPTION
I was getting some test errors and noticed the default derpmap changed. Not sure what's correct to do here, so feel free to close if this isn't intended to be updated.

Signed-Off-By: Colin Adler <colin1adler@gmail.com>