### PR TITLE
ipn/localapi: print node IDs, pubkeys, and expiry on bugreport

### DIFF
--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -314,6 +314,14 @@ func (h *Handler) serveBugReport(w http.ResponseWriter, r *http.Request) {
 	} else {
 		h.logf("user bugreport health: ok")
 	}
+	if nm := h.b.NetMap(); nm != nil {
+		if self := nm.SelfNode; self != nil {
+			h.logf("user bugreport node info: nodeid=%q stableid=%q expiry=%q", self.ID, self.StableID, self.KeyExpiry.Format(time.RFC3339))
+		}
+		h.logf("user bugreport public keys: machine=%q node=%q", nm.MachineKey, nm.NodeKey)
+	} else {
+		h.logf("user bugreport netmap: no active netmap")
+	}
 	if defBool(r.URL.Query().Get("diagnose"), false) {
 		h.b.Doctor(r.Context(), logger.WithPrefix(h.logf, "diag: "))
 	}


### PR DESCRIPTION
Having this information near the "user bugreport" line makes it easier to identify the node and expiry without spelunking through the rest of the logs.

Signed-off-by: Andrew Dunham <andrew@du.nham.ca>
Change-Id: I1597c783efc06574fa4c8f211e68d835f20b6ccb