### PR TITLE
net/dns/resolver: remove maxDoHInFlight

### DIFF
--- a/net/dns/resolver/doh_test.go
+++ b/net/dns/resolver/doh_test.go
@@ -45,9 +45,7 @@ func TestDoH(t *testing.T) {
 		t.Fatal("no known DoH")
 	}
 
-	f := &forwarder{
-		dohSem: make(chan struct{}, 10),
-	}
+	f := &forwarder{}
 
 	for _, urlBase := range prefixes {
 		t.Run(urlBase, func(t *testing.T) {

--- a/net/dns/resolver/forwarder_test.go
+++ b/net/dns/resolver/forwarder_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	dns "golang.org/x/net/dns/dnsmessage"
-	"tailscale.com/hostinfo"
 	"tailscale.com/types/dnstype"
 )
 
@@ -138,33 +137,6 @@ func TestGetRCode(t *testing.T) {
 			got := getRCode(tt.packet)
 			if got != tt.want {
 				t.Errorf("got %d; want %d", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestMaxDoHInFlight(t *testing.T) {
-	tests := []struct {
-		goos string
-		ver  string
-		want int
-	}{
-		{"ios", "", 10},
-		{"ios", "1532", 10},
-		{"ios", "9.3.2", 10},
-		{"ios", "14.3.2", 10},
-		{"ios", "15.3.2", 1000},
-		{"ios", "20.3.2", 1000},
-		{"android", "", 1000},
-		{"darwin", "", 1000},
-		{"linux", "", 1000},
-	}
-	for _, tc := range tests {
-		t.Run(fmt.Sprintf("%s-%s", tc.goos, tc.ver), func(t *testing.T) {
-			hostinfo.SetOSVersion(tc.ver)
-			got := maxDoHInFlight(tc.goos)
-			if got != tc.want {
-				t.Errorf("got %d; want %d", got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
It was originally added to control memory use on iOS (#2490), but then was relaxed conditionally when running on iOS 15 (#3098). Now that we require iOS 15, there's no need for the limit at all, so simplify back to the original state.