### PR TITLE
ipn/ipnlocal: use presence of NodeID to identify logins

### DIFF
--- a/ipn/ipnlocal/profiles.go
+++ b/ipn/ipnlocal/profiles.go
@@ -185,7 +185,7 @@ func init() {
 func (pm *profileManager) SetPrefs(prefsIn ipn.PrefsView) error {
 	prefs := prefsIn.AsStruct().View()
 	newPersist := prefs.Persist().AsStruct()
-	if newPersist == nil || newPersist.LoginName == "" {
+	if newPersist == nil || newPersist.NodeID == "" {
 		return pm.setPrefsLocked(prefs)
 	}
 	up := newPersist.UserProfile

--- a/ipn/ipnlocal/profiles_test.go
+++ b/ipn/ipnlocal/profiles_test.go
@@ -5,6 +5,7 @@ package ipnlocal
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	"tailscale.com/ipn"
@@ -337,6 +338,7 @@ func TestProfileManagementWindows(t *testing.T) {
 				ID:        id,
 				LoginName: loginName,
 			},
+			NodeID: tailcfg.StableNodeID(strconv.Itoa(int(id))),
 		}
 		if err := pm.SetPrefs(p.View()); err != nil {
 			t.Fatal(err)

--- a/ipn/ipnlocal/state_test.go
+++ b/ipn/ipnlocal/state_test.go
@@ -473,6 +473,7 @@ func TestStateMachine(t *testing.T) {
 	notifies.expect(3)
 	cc.persist.LoginName = "user1"
 	cc.persist.UserProfile.LoginName = "user1"
+	cc.persist.NodeID = "node1"
 	cc.send(nil, "", true, &netmap.NetworkMap{})
 	{
 		nn := notifies.drain(3)
@@ -699,6 +700,7 @@ func TestStateMachine(t *testing.T) {
 	notifies.expect(3)
 	cc.persist.LoginName = "user2"
 	cc.persist.UserProfile.LoginName = "user2"
+	cc.persist.NodeID = "node2"
 	cc.send(nil, "", true, &netmap.NetworkMap{
 		MachineStatus: tailcfg.MachineAuthorized,
 	})
@@ -835,6 +837,7 @@ func TestStateMachine(t *testing.T) {
 	notifies.expect(3)
 	cc.persist.LoginName = "user3"
 	cc.persist.UserProfile.LoginName = "user3"
+	cc.persist.NodeID = "node3"
 	cc.send(nil, "", true, &netmap.NetworkMap{
 		MachineStatus: tailcfg.MachineAuthorized,
 	})


### PR DESCRIPTION
The profileManager was using the LoginName as a proxy to figure out if the profile had logged in, however the LoginName is not present if the node was created with an Auth Key that does not have an associated user.

Signed-off-by: Maisem Ali <maisem@tailscale.com>