### PR TITLE
ipn/ipnlocal: return error on missing --unattended on CLI up on Windows

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -2498,6 +2498,9 @@ func (b *LocalBackend) checkPrefsLocked(p *ipn.Prefs) error {
 	if err := b.checkExitNodePrefsLocked(p); err != nil {
 		errs = append(errs, err)
 	}
+	if runtime.GOOS == "windows" && p.WantRunning && !p.ForceDaemon && len(b.notifyWatchers) == 0 {
+		errs = append(errs, errors.New("Use 'tailscale up --unattended' on Windows without GUI"))
+	}
 	return multierr.New(errs...)
 }
 


### PR DESCRIPTION
Maybe not the best long-term fix, but better than letting the user start the server for a millisecond just to have it all torn down as their CLI command finishes running.

Updates #7055
