### PR TITLE
logtail: increase maximum log line size in low memory mode

### DIFF
--- a/logtail/logtail.go
+++ b/logtail/logtail.go
@@ -558,7 +558,7 @@ func (l *Logger) encodeText(buf []byte, skipClientTime bool, procID uint32, proc
 	// Put a sanity cap on buf's size.
 	max := 16 << 10
 	if l.lowMem {
-		max = 255
+		max = 4 << 10
 	}
 	var nTruncated int
 	if len(buf) > max {

--- a/logtail/logtail_test.go
+++ b/logtail/logtail_test.go
@@ -189,7 +189,7 @@ func TestEncodeSpecialCases(t *testing.T) {
 	// lowMem + long string
 	l.skipClientTime = false
 	l.lowMem = true
-	longStr := strings.Repeat("0", 512)
+	longStr := strings.Repeat("0", 5120)
 	io.WriteString(l, longStr)
 	body = <-ts.uploaded
 	data = unmarshalOne(t, body)
@@ -197,8 +197,8 @@ func TestEncodeSpecialCases(t *testing.T) {
 	if !ok {
 		t.Errorf("lowMem: no text %v", data)
 	}
-	if n := len(text.(string)); n > 300 {
-		t.Errorf("lowMem: got %d chars; want <300 chars", n)
+	if n := len(text.(string)); n > 4500 {
+		t.Errorf("lowMem: got %d chars; want <4500 chars", n)
 	}
 
 	// -------------------------------------------------------------------------
@@ -332,10 +332,10 @@ func unmarshalOne(t *testing.T, body []byte) map[string]any {
 
 func TestEncodeTextTruncation(t *testing.T) {
 	lg := &Logger{timeNow: time.Now, lowMem: true}
-	in := bytes.Repeat([]byte("a"), 300)
+	in := bytes.Repeat([]byte("a"), 5120)
 	b := lg.encodeText(in, true, 0, 0, 0)
 	got := string(b)
-	want := `{"text": "` + strings.Repeat("a", 255) + `…+45"}` + "\n"
+	want := `{"text": "` + strings.Repeat("a", 4096) + `…+1024"}` + "\n"
 	if got != want {
 		t.Errorf("got:\n%qwant:\n%q\n", got, want)
 	}


### PR DESCRIPTION
The 255 byte limit was chosen more than 3 years ago (tailscale/corp@929635c9d98642d34ac735e0c2004f6d3d53c706), when iOS was operating under much more significant memory constraints. With iOS 15 the network extension has an increased limit, so increasing it to 4K should be fine.

The motivating factor was that the network interfaces being logged by `linkChange` in wgengine/userspace.go were getting truncated, and it would be useful to know why in some cases we're choosing the `pdp_ip1` cell interface instead of the `pdp_ip0` one.

Updates #7184
Updates #7188