### PR TITLE
control/controlhttp: don't require valid TLS cert for Noise connection

### DIFF
--- a/control/controlhttp/constants.go
+++ b/control/controlhttp/constants.go
@@ -78,9 +78,9 @@ type Dialer struct {
 	proxyFunc func(*http.Request) (*url.URL, error) // or nil
 
 	// For tests only
-	drainFinished     chan struct{}
-	insecureTLS       bool
-	testFallbackDelay time.Duration
+	drainFinished        chan struct{}
+	omitCertErrorLogging bool
+	testFallbackDelay    time.Duration
 }
 
 func strDef(v1, v2 string) string {

--- a/control/controlhttp/http_test.go
+++ b/control/controlhttp/http_test.go
@@ -194,16 +194,16 @@ func testControlHTTP(t *testing.T, param httpTestParam) {
 	}
 
 	a := &Dialer{
-		Hostname:          "localhost",
-		HTTPPort:          strconv.Itoa(httpLn.Addr().(*net.TCPAddr).Port),
-		HTTPSPort:         strconv.Itoa(httpsLn.Addr().(*net.TCPAddr).Port),
-		MachineKey:        client,
-		ControlKey:        server.Public(),
-		ProtocolVersion:   testProtocolVersion,
-		Dialer:            new(tsdial.Dialer).SystemDial,
-		Logf:              t.Logf,
-		insecureTLS:       true,
-		testFallbackDelay: 50 * time.Millisecond,
+		Hostname:             "localhost",
+		HTTPPort:             strconv.Itoa(httpLn.Addr().(*net.TCPAddr).Port),
+		HTTPSPort:            strconv.Itoa(httpsLn.Addr().(*net.TCPAddr).Port),
+		MachineKey:           client,
+		ControlKey:           server.Public(),
+		ProtocolVersion:      testProtocolVersion,
+		Dialer:               new(tsdial.Dialer).SystemDial,
+		Logf:                 t.Logf,
+		omitCertErrorLogging: true,
+		testFallbackDelay:    50 * time.Millisecond,
 	}
 
 	if proxy != nil {
@@ -646,19 +646,19 @@ func TestDialPlan(t *testing.T) {
 
 			drained := make(chan struct{})
 			a := &Dialer{
-				Hostname:          host,
-				HTTPPort:          httpPort,
-				HTTPSPort:         httpsPort,
-				MachineKey:        client,
-				ControlKey:        server.Public(),
-				ProtocolVersion:   testProtocolVersion,
-				Dialer:            dialer.Dial,
-				Logf:              t.Logf,
-				DialPlan:          tt.plan,
-				proxyFunc:         func(*http.Request) (*url.URL, error) { return nil, nil },
-				drainFinished:     drained,
-				insecureTLS:       true,
-				testFallbackDelay: 50 * time.Millisecond,
+				Hostname:             host,
+				HTTPPort:             httpPort,
+				HTTPSPort:            httpsPort,
+				MachineKey:           client,
+				ControlKey:           server.Public(),
+				ProtocolVersion:      testProtocolVersion,
+				Dialer:               dialer.Dial,
+				Logf:                 t.Logf,
+				DialPlan:             tt.plan,
+				proxyFunc:            func(*http.Request) (*url.URL, error) { return nil, nil },
+				drainFinished:        drained,
+				omitCertErrorLogging: true,
+				testFallbackDelay:    50 * time.Millisecond,
 			}
 
 			conn, err := a.dial(ctx)


### PR DESCRIPTION
We don't require any cert at all for Noise-over-plaintext-port-80-HTTP, so why require a valid cert chain for Noise-over-HTTPS? The reason we use HTTPS at all is to get through firewalls that allow tcp/443 but not tcp/80, not because we need the security properties of TLS.

Updates #3198
