### PR TITLE
ipn: remove unused NLKeyStateKey constant

### DIFF
--- a/ipn/store.go
+++ b/ipn/store.go
@@ -43,10 +43,6 @@ const (
 	// StateKey "user-1234".
 	ServerModeStartKey = StateKey("server-mode-start-key")
 
-	// NLKeyStateKey is the key under which we store the node's
-	// network-lock node key, in its key.NLPrivate.MarshalText representation.
-	NLKeyStateKey = StateKey("_nl-node-key")
-
 	// KnownProfilesStateKey is the key under which we store the list of
 	// known profiles. The value is a JSON-encoded []LoginProfile.
 	KnownProfilesStateKey = StateKey("_profiles")


### PR DESCRIPTION
We stopped writing network lock keys as separate items with #6315, the constant is no longer used.