### PR TITLE
.github/workflows: re-enable CIFuzz job

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,5 +1,5 @@
 name: CIFuzz
-on: [] # was: [pull_request], but disabled in https://github.com/tailscale/tailscale/pull/7156
+on: [pull_request]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
Having an empty `on` spec results in the job still running, but it immediately fails with a "No jobs were run" message.

Go back to the original `on: [pull_request]` spec, and disable the workflow in the GitHub UI instead.

This reverts commit f7b3156f1635d539bc59e5015661b235f80f2b90.