### PR TITLE
get-authkey: require tags to be specified

### DIFF
--- a/cmd/get-authkey/main.go
+++ b/cmd/get-authkey/main.go
@@ -35,6 +35,10 @@ func main() {
 		log.Fatal("TS_API_CLIENT_ID and TS_API_CLIENT_SECRET must be set")
 	}
 
+	if *tags == "" {
+		log.Fatal("at least one tag must be specified")
+	}
+
 	baseUrl := os.Getenv("TS_BASE_URL")
 	if baseUrl == "" {
 		baseUrl = "https://api.tailscale.com"


### PR DESCRIPTION
Tailnet-owned auth keys (which all OAuth-created keys are) must include tags, since there is no user to own the registered devices.

Signed-off-by: Will Norris <will@tailscale.com>