### PR TITLE
pull-toolchain.sh: don't run update-flake.sh

### DIFF
--- a/pull-toolchain.sh
+++ b/pull-toolchain.sh
@@ -9,9 +9,8 @@ upstream=$(git ls-remote https://github.com/tailscale/go "$go_branch" | awk '{pr
 current=$(cat go.toolchain.rev)
 if [ "$upstream" != "$current" ]; then
 	echo "$upstream" >go.toolchain.rev
-	./update-flake.sh
 fi
 
-if [ -n "$(git diff-index --name-only HEAD -- go.toolchain.rev go.mod.sri)" ]; then
+if [ -n "$(git diff-index --name-only HEAD -- go.toolchain.rev)" ]; then
     echo "pull-toolchain.sh: changes imported. Use git commit to make them permanent." >&2
 fi


### PR DESCRIPTION
We no longer carry an SRI hash for the toolchain, so flake updating is no longer needed for toolchain changes.

Signed-off-by: David Anderson <danderson@tailscale.com>