### PR TITLE
tailcfg: add RPC structs for /tka/affected-sigs

### DIFF
--- a/tailcfg/tka.go
+++ b/tailcfg/tka.go
@@ -238,3 +238,27 @@ type TKASubmitSignatureRequest struct {
 type TKASubmitSignatureResponse struct {
 	// Nothing. (yet?)
 }
+
+// TKASignaturesUsingKeyRequest asks the control plane for
+// all signatures which are signed by the provided keyID.
+//
+// This is the request schema for a /tka/affected-sigs RPC.
+type TKASignaturesUsingKeyRequest struct {
+	// Version is the client's capabilities.
+	Version CapabilityVersion
+
+	// NodeKey is the client's current node key.
+	NodeKey key.NodePublic
+
+	// KeyID is the key we are querying using.
+	KeyID tkatype.KeyID
+}
+
+// TKASignaturesUsingKeyResponse is the JSON response to
+// a /tka/affected-sigs RPC.
+//
+// It enumerates all signatures which are signed by the
+// queried keyID.
+type TKASignaturesUsingKeyResponse struct {
+	Signatures []tkatype.MarshaledSignature
+}


### PR DESCRIPTION
These RPCs will be used to power the future 'tailscale lock remove' default behavior of resigning signatures for which trust is about to be removed.