### PR TITLE
net/routetable: include unknown flags in the routetable doctor output

### DIFF
--- a/net/routetable/routetable_bsd.go
+++ b/net/routetable/routetable_bsd.go
@@ -64,6 +64,16 @@ func (r RouteEntryBSD) Format(f fmt.State, verb rune) {
 		}
 		pr("Flags: %v", r.Flags)
 
+		unknownFlags := r.RawFlags
+		for fv := range flags {
+			if r.RawFlags&fv == fv {
+				unknownFlags &= ^fv
+			}
+		}
+		if unknownFlags != 0 {
+			pr("UnknownFlags: %x ", unknownFlags)
+		}
+
 		w.WriteString("}")
 	}).Format(f, verb)
 }

--- a/net/routetable/routetable_darwin.go
+++ b/net/routetable/routetable_darwin.go
@@ -23,9 +23,14 @@ var flags = map[int]string{
 	unix.RTF_GLOBAL:    "global",
 	unix.RTF_HOST:      "host",
 	unix.RTF_IFSCOPE:   "ifscope",
+	unix.RTF_LOCAL:     "local",
 	unix.RTF_MULTICAST: "multicast",
 	unix.RTF_REJECT:    "reject",
 	unix.RTF_ROUTER:    "router",
 	unix.RTF_STATIC:    "static",
 	unix.RTF_UP:        "up",
+	// More obscure flags, just to have full coverage.
+	unix.RTF_LLINFO:    "{RTF_LLINFO}",
+	unix.RTF_PRCLONING: "{RTF_PRCLONING}",
+	unix.RTF_CLONING:   "{RTF_CLONING}",
 }


### PR DESCRIPTION
As part of the work on #7248 I wanted to know all of the flags on the `RouteMessage` struct that we get back from macOS. Though it doesn't turn out to be useful (when using an exit node/Tailscale is the default route, the flags for the physical interface routes are the same), it still seems useful from a debugging/comprehensiveness perspective.

Adds additional Darwin flags that were output once I enabled this mode.