### PR TITLE
ipn/ipnlocal: fix passthrough of formatting arguments in PeerAPI doctor output

### DIFF
--- a/ipn/ipnlocal/peerapi.go
+++ b/ipn/ipnlocal/peerapi.go
@@ -832,7 +832,7 @@ func (h *peerAPIHandler) handleServeDoctor(w http.ResponseWriter, r *http.Reques
 	fmt.Fprintln(w, "<pre>")
 
 	h.ps.b.Doctor(r.Context(), func(format string, args ...any) {
-		line := fmt.Sprintf(format, args)
+		line := fmt.Sprintf(format, args...)
 		fmt.Fprintln(w, html.EscapeString(line))
 	})
 


### PR DESCRIPTION
Followup to #7235, we were not treating the formatting arguments as variadic. This worked OK for single values, but stopped working when we started passing multiple values (noticed while trying out #7244).