### PR TITLE
.github/workflows: remove 'ci skip' boilerplate

### DIFF
--- a/.github/workflows/cross-android.yml
+++ b/.github/workflows/cross-android.yml
@@ -17,8 +17,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
-
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/.github/workflows/cross-darwin.yml
+++ b/.github/workflows/cross-darwin.yml
@@ -17,8 +17,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
-
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/.github/workflows/cross-freebsd.yml
+++ b/.github/workflows/cross-freebsd.yml
@@ -17,8 +17,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
-
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/.github/workflows/cross-loong64.yml
+++ b/.github/workflows/cross-loong64.yml
@@ -17,8 +17,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
-
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/.github/workflows/cross-openbsd.yml
+++ b/.github/workflows/cross-openbsd.yml
@@ -17,8 +17,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
-
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/.github/workflows/cross-wasm.yml
+++ b/.github/workflows/cross-wasm.yml
@@ -17,8 +17,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
-
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/.github/workflows/cross-windows.yml
+++ b/.github/workflows/cross-windows.yml
@@ -17,8 +17,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
-
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/.github/workflows/linux-race.yml
+++ b/.github/workflows/linux-race.yml
@@ -17,8 +17,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
-
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,8 +17,6 @@ jobs:
   build:
     runs-on: ubuntu-22.04
 
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
-
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/.github/workflows/linux32.yml
+++ b/.github/workflows/linux32.yml
@@ -17,8 +17,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
-
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -14,7 +14,8 @@ jobs:
   ubuntu2004-LTS-cloud-base:
     runs-on: [ self-hosted, linux, vm ]
 
-    if: "(github.repository == 'tailscale/tailscale') && !contains(github.event.head_commit.message, '[ci skip]')"
+    # VM tests run with some privileges, don't let them run on 3p PRs.
+    if: "github.repository == 'tailscale/tailscale'"
 
     steps:
       - name: Set GOPATH

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,8 +17,6 @@ jobs:
   test:
     runs-on: windows-latest
 
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
-
     steps:
     - name: Checkout code
       uses: actions/checkout@v3


### PR DESCRIPTION
We've never used the "[ci skip]" magic commit header in our history, across all our repos. This seems to be boilerplate we imported years ago and have since been copying around our CI configs.

Signed-off-by: David Anderson <danderson@tailscale.com>