### PR TITLE
wgengine/magicsock: remove superfluous "discokey" from log

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -4224,7 +4224,7 @@ func (de *endpoint) updateFromNode(n *tailcfg.Node, heartbeatDisabled bool) {
 	de.expired = n.Expired
 
 	if de.discoKey != n.DiscoKey {
-		de.c.logf("[v1] magicsock: disco: node %s changed from discokey %s to %s", de.publicKey.ShortString(), de.discoKey, n.DiscoKey)
+		de.c.logf("[v1] magicsock: disco: node %s changed from %s to %s", de.publicKey.ShortString(), de.discoKey, n.DiscoKey)
 		de.discoKey = n.DiscoKey
 		de.discoShort = de.discoKey.ShortString()
 		de.resetLocked()


### PR DESCRIPTION
The stringification of the discokey type now prepends "discokey:"
Fixes https://github.com/tailscale/tailscale/issues/3074

Signed-off-by: Denton Gentry <dgentry@tailscale.com>