### PR TITLE
util/linuxfw: add build constraints excluding GOARCH=arm

### DIFF
--- a/util/linuxfw/iptables.go
+++ b/util/linuxfw/iptables.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build linux && !(386 || loong64)
+//go:build linux && !(386 || loong64 || arm || armbe)
 
 package linuxfw
 

--- a/util/linuxfw/linuxfw_struct_linux_test.go
+++ b/util/linuxfw/linuxfw_struct_linux_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build linux && !(386 || loong64)
+//go:build linux && !(386 || loong64 || arm || armbe)
 
 package linuxfw
 

--- a/util/linuxfw/linuxfw_unsupported.go
+++ b/util/linuxfw/linuxfw_unsupported.go
@@ -1,10 +1,10 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-// NOTE: linux_386 and linux_loong64 are currently unsupported due to missing
+// NOTE: linux_{386,loong64,arm,armbe} are currently unsupported due to missing
 // support in upstream dependencies.
 
-//go:build !linux || (linux && (386 || loong64))
+//go:build !linux || (linux && (386 || loong64 || arm || armbe))
 
 package linuxfw
 

--- a/util/linuxfw/nftables.go
+++ b/util/linuxfw/nftables.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build linux && !(386 || loong64)
+//go:build linux && !(386 || loong64 || arm || armbe)
 
 package linuxfw
 

--- a/util/linuxfw/nftables_types.go
+++ b/util/linuxfw/nftables_types.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build linux && !(386 || loong64)
+//go:build linux && !(386 || loong64 || arm || armbe)
 
 package linuxfw
 


### PR DESCRIPTION
This isn't currently supported due to missing support in upstream dependencies, and also we don't use this package anywhere right now. Just conditionally skip this for now.

Fixes #7268

Change-Id: Ie7389c2c0816b39b410c02a7276051a4c18b6450