### PR TITLE
cmd/k8s-operator: handle nil pointer when getting service secret

### DIFF
--- a/cmd/k8s-operator/operator.go
+++ b/cmd/k8s-operator/operator.go
@@ -542,7 +542,7 @@ func (a *ServiceReconciler) createOrGetSecret(ctx context.Context, logger *zap.S
 
 func (a *ServiceReconciler) getDeviceInfo(ctx context.Context, svc *corev1.Service) (id, hostname string, err error) {
 	sec, err := getSingleObject[corev1.Secret](ctx, a.Client, a.operatorNamespace, childResourceLabels(svc))
-	if err != nil {
+	if err != nil || sec == nil {
 		return "", "", err
 	}
 	id = string(sec.Data["device_id"])


### PR DESCRIPTION
related to #7303