### PR TITLE
version/mkversion: support collecting version info from tailscale/tailscale only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,7 @@ jobs:
         GOARCH: ${{ matrix.goarch }}
     - name: build variant CLIs
       run: |
+        export TS_USE_TOOLCHAIN=1
         ./build_dist.sh --extra-small ./cmd/tailscaled
         ./build_dist.sh --box ./cmd/tailscaled
         ./build_dist.sh --extra-small --box ./cmd/tailscaled

--- a/.github/workflows/tsconnect-pkg-publish.yml
+++ b/.github/workflows/tsconnect-pkg-publish.yml
@@ -21,6 +21,7 @@ jobs:
         # GOROOT is specified so that the Go/Wasm that is trigged by build-pk
         # also picks up our custom Go toolchain.
         run: |
+          export TS_USE_TOOLCHAIN=1
           ./build_dist.sh tailscale.com/cmd/tsconnect
           GOROOT="${HOME}/.cache/tailscale-go" ./tsconnect build-pkg
 

--- a/build_dist.sh
+++ b/build_dist.sh
@@ -11,42 +11,25 @@
 
 set -eu
 
-IFS=".$IFS" read -r major minor patch <VERSION.txt
-git_hash=$(git rev-parse HEAD)
-if ! git diff-index --quiet HEAD; then
-	git_hash="${git_hash}-dirty"
-fi
-base_hash=$(git rev-list --max-count=1 HEAD -- VERSION.txt)
-change_count=$(git rev-list --count HEAD "^$base_hash")
-short_hash=$(echo "$git_hash" | cut -c1-9)
-
-if expr "$minor" : "[0-9]*[13579]$" >/dev/null; then
-	patch="$change_count"
-	change_suffix=""
-elif [ "$change_count" != "0" ]; then
-	change_suffix="-$change_count"
-else
-	change_suffix=""
+go="go"
+if [ -n "${TS_USE_TOOLCHAIN:-}" ]; then
+	go="./tool/go"
 fi
 
-long_suffix="$change_suffix-t$short_hash"
-MINOR="$major.$minor"
-SHORT="$MINOR.$patch"
-LONG="${SHORT}$long_suffix"
-GIT_HASH="$git_hash"
+eval `$go run ./cmd/mkversion`
 
 if [ "$1" = "shellvars" ]; then
 	cat <<EOF
-VERSION_MINOR="$MINOR"
-VERSION_SHORT="$SHORT"
-VERSION_LONG="$LONG"
-VERSION_GIT_HASH="$GIT_HASH"
+VERSION_MINOR="$VERSION_MINOR"
+VERSION_SHORT="$VERSION_SHORT"
+VERSION_LONG="$VERSION_LONG"
+VERSION_GIT_HASH="$VERSION_GIT_HASH"
 EOF
 	exit 0
 fi
 
 tags=""
-ldflags="-X tailscale.com/version.longStamp=${LONG} -X tailscale.com/version.shortStamp=${SHORT}"
+ldflags="-X tailscale.com/version.longStamp=${VERSION_LONG} -X tailscale.com/version.shortStamp=${VERSION_SHORT}"
 
 # build_dist.sh arguments must precede go build arguments.
 while [ "$#" -gt 1 ]; do

--- a/go.mod
+++ b/go.mod
@@ -72,6 +72,7 @@ require (
 	go4.org/netipx v0.0.0-20220725152314-7e7bdc8411bf
 	golang.org/x/crypto v0.3.0
 	golang.org/x/exp v0.0.0-20221205204356-47842c84f3db
+	golang.org/x/mod v0.7.0
 	golang.org/x/net v0.7.0
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
 	golang.org/x/sync v0.1.0
@@ -304,7 +305,6 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20221208152030-732eee02a75a // indirect
 	golang.org/x/image v0.0.0-20201208152932-35266b937fa6 // indirect
-	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/version/mkversion/mkversion_test.go
+++ b/version/mkversion/mkversion_test.go
@@ -38,14 +38,7 @@ func TestMkversion(t *testing.T) {
            VERSION_SHORT="0.98.0"
            VERSION_LONG="0.98.0-tabcdef"
            VERSION_GIT_HASH="abcdef"
-           VERSION_EXTRA_HASH=""
-           VERSION_XCODE="100.98.0"
-           VERSION_XCODE_MACOS="273.27.3723"
-           VERSION_WINRES="0,98,0,0"
-           VERSION_TRACK="stable"
-           VERSION_MSIPRODUCT_AMD64="C653B075-AD91-5265-9DF8-0087D35D148D"
-           VERSION_MSIPRODUCT_ARM64="1C41380B-A742-5A3C-AF5D-DF7894DD0FB8"
-           VERSION_MSIPRODUCT_X86="4ABDDA14-7499-5C2E-A62A-DD435C50C4CB"`},
+           VERSION_TRACK="stable"`},
 		{mkInfo("abcdef", "", otherDate, 0, 98, 1, 0), `
            VERSION_MAJOR=0
            VERSION_MINOR=98
@@ -53,14 +46,7 @@ func TestMkversion(t *testing.T) {
            VERSION_SHORT="0.98.1"
            VERSION_LONG="0.98.1-tabcdef"
            VERSION_GIT_HASH="abcdef"
-           VERSION_EXTRA_HASH=""
-           VERSION_XCODE="100.98.1"
-           VERSION_XCODE_MACOS="273.27.3723"
-           VERSION_WINRES="0,98,1,0"
-           VERSION_TRACK="stable"
-           VERSION_MSIPRODUCT_AMD64="DFD6DCF2-06D8-5D19-BDA0-FAF31E44EC23"
-           VERSION_MSIPRODUCT_ARM64="A4CCF19C-372B-5007-AFD8-1AF661DFF670"
-           VERSION_MSIPRODUCT_X86="FF12E937-DDC4-5868-9B63-D35B2050D4EA"`},
+           VERSION_TRACK="stable"`},
 		{mkInfo("abcdef", "", otherDate, 1, 2, 9, 0), `
            VERSION_MAJOR=1
            VERSION_MINOR=2
@@ -68,14 +54,7 @@ func TestMkversion(t *testing.T) {
            VERSION_SHORT="1.2.9"
            VERSION_LONG="1.2.9-tabcdef"
            VERSION_GIT_HASH="abcdef"
-           VERSION_EXTRA_HASH=""
-           VERSION_XCODE="101.2.9"
-           VERSION_XCODE_MACOS="273.27.3723"
-           VERSION_WINRES="1,2,9,0"
-           VERSION_TRACK="stable"
-           VERSION_MSIPRODUCT_AMD64="D47B5157-FF26-5A10-A94E-50E4529303A9"
-           VERSION_MSIPRODUCT_ARM64="91D16F75-2A12-5E12-820A-67B89BF858E7"
-           VERSION_MSIPRODUCT_X86="8F1AC1C6-B93B-5C70-802E-6AE9591FA0D6"`},
+           VERSION_TRACK="stable"`},
 		{mkInfo("abcdef", "", otherDate, 1, 15, 0, 129), `
            VERSION_MAJOR=1
            VERSION_MINOR=15
@@ -83,11 +62,27 @@ func TestMkversion(t *testing.T) {
            VERSION_SHORT="1.15.129"
            VERSION_LONG="1.15.129-tabcdef"
            VERSION_GIT_HASH="abcdef"
-           VERSION_EXTRA_HASH=""
+           VERSION_TRACK="unstable"`},
+		{mkInfo("abcdef", "", otherDate, 1, 2, 0, 17), `
+           VERSION_MAJOR=1
+           VERSION_MINOR=2
+           VERSION_PATCH=0
+           VERSION_SHORT="1.2.0"
+           VERSION_LONG="1.2.0-17-tabcdef"
+           VERSION_GIT_HASH="abcdef"
+           VERSION_TRACK="stable"`},
+		{mkInfo("abcdef", "defghi", otherDate, 1, 15, 0, 129), `
+           VERSION_MAJOR=1
+           VERSION_MINOR=15
+           VERSION_PATCH=129
+           VERSION_SHORT="1.15.129"
+           VERSION_LONG="1.15.129-tabcdef-gdefghi"
+           VERSION_GIT_HASH="abcdef"
+           VERSION_TRACK="unstable"
+           VERSION_EXTRA_HASH="defghi"
            VERSION_XCODE="101.15.129"
            VERSION_XCODE_MACOS="273.27.3723"
            VERSION_WINRES="1,15,129,0"
-           VERSION_TRACK="unstable"
            VERSION_MSIPRODUCT_AMD64="89C96952-1FB8-5A4D-B02E-16A8060C56AA"
            VERSION_MSIPRODUCT_ARM64="DB1A2E86-66C4-5CEC-8F4C-7DB805370F3A"
            VERSION_MSIPRODUCT_X86="DC57C0C3-5164-5C92-86B3-2800CEFF0540"`},
@@ -98,14 +93,7 @@ func TestMkversion(t *testing.T) {
            VERSION_SHORT="1.2.0"
            VERSION_LONG="1.2.0-17-tabcdef"
            VERSION_GIT_HASH="abcdef"
-           VERSION_EXTRA_HASH=""
-           VERSION_XCODE="101.2.0"
-           VERSION_XCODE_MACOS="273.27.3723"
-           VERSION_WINRES="1,2,0,0"
-           VERSION_TRACK="stable"
-           VERSION_MSIPRODUCT_AMD64="0F9709AE-0E5E-51AF-BCCD-A25314B4CE8B"
-           VERSION_MSIPRODUCT_ARM64="39D5D46E-E644-5C80-9EF8-224AC1AD5969"
-           VERSION_MSIPRODUCT_X86="4487136B-2D11-5E42-BD80-B8529F3326F4"`},
+           VERSION_TRACK="stable"`},
 		{mkInfo("abcdef", "defghi", otherDate, 1, 15, 0, 129), `
            VERSION_MAJOR=1
            VERSION_MINOR=15
@@ -113,41 +101,11 @@ func TestMkversion(t *testing.T) {
            VERSION_SHORT="1.15.129"
            VERSION_LONG="1.15.129-tabcdef-gdefghi"
            VERSION_GIT_HASH="abcdef"
+           VERSION_TRACK="unstable"
            VERSION_EXTRA_HASH="defghi"
            VERSION_XCODE="101.15.129"
            VERSION_XCODE_MACOS="273.27.3723"
            VERSION_WINRES="1,15,129,0"
-           VERSION_TRACK="unstable"
-           VERSION_MSIPRODUCT_AMD64="89C96952-1FB8-5A4D-B02E-16A8060C56AA"
-           VERSION_MSIPRODUCT_ARM64="DB1A2E86-66C4-5CEC-8F4C-7DB805370F3A"
-           VERSION_MSIPRODUCT_X86="DC57C0C3-5164-5C92-86B3-2800CEFF0540"`},
-		{mkInfo("abcdef", "", otherDate, 1, 2, 0, 17), `
-           VERSION_MAJOR=1
-           VERSION_MINOR=2
-           VERSION_PATCH=0
-           VERSION_SHORT="1.2.0"
-           VERSION_LONG="1.2.0-17-tabcdef"
-           VERSION_GIT_HASH="abcdef"
-           VERSION_EXTRA_HASH=""
-           VERSION_XCODE="101.2.0"
-           VERSION_XCODE_MACOS="273.27.3723"
-           VERSION_WINRES="1,2,0,0"
-           VERSION_TRACK="stable"
-           VERSION_MSIPRODUCT_AMD64="0F9709AE-0E5E-51AF-BCCD-A25314B4CE8B"
-           VERSION_MSIPRODUCT_ARM64="39D5D46E-E644-5C80-9EF8-224AC1AD5969"
-           VERSION_MSIPRODUCT_X86="4487136B-2D11-5E42-BD80-B8529F3326F4"`},
-		{mkInfo("abcdef", "defghi", otherDate, 1, 15, 0, 129), `
-           VERSION_MAJOR=1
-           VERSION_MINOR=15
-           VERSION_PATCH=129
-           VERSION_SHORT="1.15.129"
-           VERSION_LONG="1.15.129-tabcdef-gdefghi"
-           VERSION_GIT_HASH="abcdef"
-           VERSION_EXTRA_HASH="defghi"
-           VERSION_XCODE="101.15.129"
-           VERSION_XCODE_MACOS="273.27.3723"
-           VERSION_WINRES="1,15,129,0"
-           VERSION_TRACK="unstable"
            VERSION_MSIPRODUCT_AMD64="89C96952-1FB8-5A4D-B02E-16A8060C56AA"
            VERSION_MSIPRODUCT_ARM64="DB1A2E86-66C4-5CEC-8F4C-7DB805370F3A"
            VERSION_MSIPRODUCT_X86="DC57C0C3-5164-5C92-86B3-2800CEFF0540"`},


### PR DESCRIPTION
And update build_dist.sh to use that code.