### PR TITLE
.github/workflows: separate pre- and post-merge CI

### DIFF
--- a/.github/workflows/test-submitted.yml
+++ b/.github/workflows/test-submitted.yml
@@ -1,0 +1,36 @@
+# This is the post-merge CI that runs on on code pushed to our main branches.
+# It's identical to the CI that runs in PR, with the addition that it notifies
+# us in Slack on failure.
+name: CI
+
+on:
+  push:
+    branches:
+      - "main"
+      - "release-branch/*"
+
+jobs:
+  test:
+    uses: tailscale/tailscale/.github/workflows/test.yml@${{ github.sha }}
+
+  notify_slack:
+    if: failure()
+    needs: ["test"]
+    runs-on: ubuntu-22.04
+    steps:
+    - name: notify  
+      uses: ruby/action-slack@v3.0.0
+      with:
+        payload: |
+          {
+            "attachments": [{
+              "title": "Failure: ${{ github.workflow }}",
+              "title_link": "https://github.com/${{ github.repository }}/commit/${{ github.sha }}/checks",         
+              "text": "${{ github.repository }}@${{ github.ref_name }}: <https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>",
+              "fields": [{ "value": ${{ toJson(github.event.head_commit.message) }}, "short": false }],
+              "footer": "${{ github.event.head_commit.committer.name }} at ${{ github.event.head_commit.timestamp }}",
+              "color": "danger"
+            }]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test-submitted.yml
+++ b/.github/workflows/test-submitted.yml
@@ -4,6 +4,9 @@
 name: CI
 
 on:
+  pull_request:
+    branches:
+      - "*"
   push:
     branches:
       - "main"
@@ -11,7 +14,7 @@ on:
 
 jobs:
   test:
-    uses: tailscale/tailscale/.github/workflows/test.yml@${{ github.sha }}
+    uses: ./.github/workflows/test.yml
 
   notify_slack:
     if: failure()
@@ -24,7 +27,7 @@ jobs:
         payload: |
           {
             "attachments": [{
-              "title": "Failure: ${{ github.workflow }}",
+              "title": "TEST TEST TEST I AM DOING A TEST: ${{ github.workflow }}",
               "title_link": "https://github.com/${{ github.repository }}/commit/${{ github.sha }}/checks",         
               "text": "${{ github.repository }}@${{ github.ref_name }}: <https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>",
               "fields": [{ "value": ${{ toJson(github.event.head_commit.message) }}, "short": false }],

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,11 @@ env:
   TS_FUZZ_CURRENTLY_BROKEN: false
 
 on:
-  pull_request:
-    branches:
-      - "*"
+  # pull_request:
+  #   branches:
+  #     - "*"
   merge_group:
+  workflow_call:
 
 concurrency:
   # For PRs, later CI runs preempt previous ones. e.g. a force push on a PR
@@ -52,7 +53,7 @@ jobs:
         GOARCH: ${{ matrix.goarch }}
     - name: build variant CLIs
       run: |
-        export TS_USE_TOOLCHAIN=1
+        #export TS_USE_TOOLCHAIN=1
         ./build_dist.sh --extra-small ./cmd/tailscaled
         ./build_dist.sh --box ./cmd/tailscaled
         ./build_dist.sh --extra-small --box ./cmd/tailscaled

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,6 @@ env:
   TS_FUZZ_CURRENTLY_BROKEN: false
 
 on:
-  push:
-    branches:
-      - "main"
-      - "release-branch/*"
   pull_request:
     branches:
       - "*"
@@ -351,40 +347,3 @@ jobs:
       env:
         GOOS: ${{ matrix.goos }}
         GOARCH: ${{ matrix.goarch }}
-
-  notify_slack:
-    # Only notify slack for merged commits, not PR failures.
-    if: failure() && github.event_name == 'push'
-    # Any of these jobs failing causes a slack notification.
-    needs: 
-      - android
-      - test
-      - windows
-      - vm
-      - cross
-      - ios
-      - wasm
-      - fuzz
-      - depaware
-      - go_generate
-      - go_mod_tidy
-      - licenses
-      - staticcheck
-    runs-on: ubuntu-22.04
-    steps:
-    - name: notify  
-      uses: ruby/action-slack@v3.0.0
-      with:
-        payload: |
-          {
-            "attachments": [{
-              "title": "Failure: ${{ github.workflow }}",
-              "title_link": "https://github.com/${{ github.repository }}/commit/${{ github.sha }}/checks",         
-              "text": "${{ github.repository }}@${{ github.ref_name }}: <https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>",
-              "fields": [{ "value": ${{ toJson(github.event.head_commit.message) }}, "short": false }],
-              "footer": "${{ github.event.head_commit.committer.name }} at ${{ github.event.head_commit.timestamp }}",
-              "color": "danger"
-            }]
-          }
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
So that CI on PRs collapses cleanly into "everything is fine" in the happy path, instead of staying expanded because of the skipped notify_slack job.

Draft while I test that this even works.