### PR TITLE
.github/workflows: add armv5 and armv7 cross tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,6 +146,12 @@ jobs:
             goarch: "386" # thanks yaml
           - goos: linux
             goarch: loong64
+          - goos: linux
+            goarch: arm
+            goarm: "5"
+          - goos: linux
+            goarch: arm
+            goarm: "7"
           # macOS
           - goos: darwin
             goarch: amd64
@@ -171,6 +177,7 @@ jobs:
       env:
         GOOS: ${{ matrix.goos }}
         GOARCH: ${{ matrix.goarch }}
+        GOARM: ${{ matrix.goarm }}
         CGO_ENABLED: "0"
     - name: build tests
       run: ./tool/go test -exec=true ./...


### PR DESCRIPTION
armv5 because that's what we ship to most downstreams right now, armv7 becuase that's what we want to ship more of.

Fixes https://github.com/tailscale/tailscale/issues/7269