### PR TITLE
ipn/ipnlocal: [serve] Trim mountPoint prefix from proxy path

### DIFF
--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -476,7 +476,12 @@ func (b *LocalBackend) serveWebHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "unknown proxy destination", http.StatusInternalServerError)
 			return
 		}
-		p.(http.Handler).ServeHTTP(w, r)
+		h := p.(http.Handler)
+		// Trim the mount point from the URL path before proxying. (#6571)
+		if r.URL.Path != "/" {
+			h = http.StripPrefix(strings.TrimSuffix(mountPoint, "/"), h)
+		}
+		h.ServeHTTP(w, r)
 		return
 	}
 


### PR DESCRIPTION
This change trims the mountPoint from the request URL path before
sending the request to the reverse proxy.

Today if you mount a proxy at `/foo` and request to
`/foo/bar/baz`, we leak the `mountPoint` `/foo` as part of the request
URL's path.

This fix makes removed the `mountPoint` prefix from the path so
proxied services receive requests as if they were running at the root
(`/`) path.

This could be an issue if the app generates URLs (in HTML or otherwise)
and assumes `/path`. In this case, those URLs will 404.

With that, I still think we should trim by default and not leak the
`mountPoint` (specific to Tailscale) into whatever app is hosted.
If it causes an issue with URL generation, I'd suggest looking at configuring
an app-specific path prefix or running Caddy as a more advanced
solution.

Fixes: #6571

Signed-off-by: Shayne Sweeney <shayne@tailscale.com>