### PR TITLE
ipn/ipnlocal: add delegated interface information to /interfaces PeerAPI handler

### DIFF
--- a/net/interfaces/interfaces.go
+++ b/net/interfaces/interfaces.go
@@ -756,3 +756,15 @@ func HasCGNATInterface() (bool, error) {
 	}
 	return hasCGNATInterface, nil
 }
+
+var interfaceDebugExtras func(ifIndex int) (string, error)
+
+// InterfaceDebugExtras returns extra debugging information about an interface
+// if any (an empty string will be returned if there are no additional details).
+// Formatting is platform-dependent and should not be parsed.
+func InterfaceDebugExtras(ifIndex int) (string, error) {
+	if interfaceDebugExtras != nil {
+		return interfaceDebugExtras(ifIndex)
+	}
+	return "", nil
+}

--- a/net/interfaces/interfaces_darwin.go
+++ b/net/interfaces/interfaces_darwin.go
@@ -4,6 +4,7 @@
 package interfaces
 
 import (
+	"fmt"
 	"net"
 	"strings"
 	"sync"
@@ -27,6 +28,10 @@ func parseRoutingTable(rib []byte) ([]route.Message, error) {
 var ifNames struct {
 	sync.Mutex
 	m map[int]string // ifindex => name
+}
+
+func init() {
+	interfaceDebugExtras = interfaceDebugExtrasDarwin
 }
 
 // getDelegatedInterface returns the interface index of the underlying interface
@@ -92,4 +97,15 @@ func getDelegatedInterface(ifIndex int) (int, error) {
 		return 0, errno
 	}
 	return int(ifr.ifr_delegated), nil
+}
+
+func interfaceDebugExtrasDarwin(ifIndex int) (string, error) {
+	delegated, err := getDelegatedInterface(ifIndex)
+	if err != nil {
+		return "", err
+	}
+	if delegated == 0 {
+		return "", nil
+	}
+	return fmt.Sprintf("delegated=%d", delegated), nil
 }


### PR DESCRIPTION
Exposes the delegated interface data added by #7248 in the debug endpoint. I would have found it useful when working on that PR, and it may be handy in the future as well.

Also makes the interfaces table slightly easier to parse by adding borders to it. To make then nicer-looking, the CSP was relaxed to allow inline styles.