### PR TITLE
.github/workflows: add a pass/fail verdict job to the test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -404,3 +404,27 @@ jobs:
           }
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  check_mergeability:
+    if: always()
+    runs-on: ubuntu-22.04
+    needs:
+      - android
+      - test
+      - windows
+      - vm
+      - cross
+      - ios
+      - wasm
+      - fuzz
+      - depaware
+      - go_generate
+      - go_mod_tidy
+      - licenses
+      - staticcheck
+    steps:
+    - name: Decide if change is okay to merge
+      if: github.event_name != 'push'
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Github requires explicitly listing every single job within a workflow that is required for status checks, instead of letting you list entire workflows. This is ludicrous, and apparently this nonsense is the workaround.