### PR TITLE
tailcfg,hostinfo: add App field to identify tsnet uses

### DIFF
--- a/cmd/k8s-operator/operator.go
+++ b/cmd/k8s-operator/operator.go
@@ -99,9 +99,9 @@ func main() {
 	tsClient.HTTPClient = credentials.Client(context.Background())
 
 	if shouldRunAuthProxy {
-		hostinfo.SetPackage("k8s-operator-proxy")
+		hostinfo.SetApp("k8s-operator-proxy")
 	} else {
-		hostinfo.SetPackage("k8s-operator")
+		hostinfo.SetApp("k8s-operator")
 	}
 
 	s := &tsnet.Server{

--- a/hostinfo/hostinfo.go
+++ b/hostinfo/hostinfo.go
@@ -36,6 +36,7 @@ func New() *tailcfg.Hostinfo {
 	return &tailcfg.Hostinfo{
 		IPNVersion:      version.Long(),
 		Hostname:        hostname,
+		App:             appTypeCached(),
 		OS:              version.OS(),
 		OSVersion:       GetOSVersion(),
 		Container:       lazyInContainer.Get(),
@@ -112,6 +113,13 @@ func GetOSVersion() string {
 	return ""
 }
 
+func appTypeCached() string {
+	if v, ok := appType.Load().(string); ok {
+		return v
+	}
+	return ""
+}
+
 func packageTypeCached() string {
 	if v, _ := packagingType.Load().(string); v != "" {
 		return v
@@ -159,6 +167,7 @@ var (
 	osVersionAtomic       atomic.Value // of string
 	desktopAtomic         atomic.Value // of opt.Bool
 	packagingType         atomic.Value // of string
+	appType               atomic.Value // of string
 )
 
 // SetPushDeviceToken sets the device token for use in Hostinfo updates.
@@ -175,6 +184,11 @@ func SetOSVersion(v string) { osVersionAtomic.Store(v) }
 // As of 2022-03-25, this is used by Android ("nogoogle" for the
 // F-Droid build) and tsnet (set to "tsnet").
 func SetPackage(v string) { packagingType.Store(v) }
+
+// SetApp sets the app type for the app.
+// It is used by tsnet to specify what app is using it such as "golinks"
+// and "k8s-operator".
+func SetApp(v string) { appType.Store(v) }
 
 func deviceModel() string {
 	s, _ := deviceModelAtomic.Load().(string)

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -522,6 +522,9 @@ type Hostinfo struct {
 	DistroVersion  string   `json:",omitempty"` // "20.04", ...
 	DistroCodeName string   `json:",omitempty"` // "jammy", "bullseye", ...
 
+	// App is used to disambiguate Tailscale clients that run using tsnet.
+	App string `json:",omitempty"` // "k8s-operator", "golinks", ...
+
 	Desktop         opt.Bool       `json:",omitempty"` // if a desktop was detected on Linux
 	Package         string         `json:",omitempty"` // Tailscale package to disambiguate ("choco", "appstore", etc; "" for unknown)
 	DeviceModel     string         `json:",omitempty"` // mobile phone model ("Pixel 3a", "iPhone12,3")

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -128,6 +128,7 @@ var _HostinfoCloneNeedsRegeneration = Hostinfo(struct {
 	Distro          string
 	DistroVersion   string
 	DistroCodeName  string
+	App             string
 	Desktop         opt.Bool
 	Package         string
 	DeviceModel     string

--- a/tailcfg/tailcfg_test.go
+++ b/tailcfg/tailcfg_test.go
@@ -41,6 +41,7 @@ func TestHostinfoEqual(t *testing.T) {
 		"Distro",
 		"DistroVersion",
 		"DistroCodeName",
+		"App",
 		"Desktop",
 		"Package",
 		"DeviceModel",
@@ -215,6 +216,16 @@ func TestHostinfoEqual(t *testing.T) {
 			&Hostinfo{SSH_HostKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO.... root@bar"}},
 			&Hostinfo{},
 			false,
+		},
+		{
+			&Hostinfo{App: "golink"},
+			&Hostinfo{App: "abc"},
+			false,
+		},
+		{
+			&Hostinfo{App: "golink"},
+			&Hostinfo{App: "golink"},
+			true,
 		},
 	}
 	for i, tt := range tests {

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -267,6 +267,7 @@ func (v HostinfoView) Env() string             { return v.ж.Env }
 func (v HostinfoView) Distro() string          { return v.ж.Distro }
 func (v HostinfoView) DistroVersion() string   { return v.ж.DistroVersion }
 func (v HostinfoView) DistroCodeName() string  { return v.ж.DistroCodeName }
+func (v HostinfoView) App() string             { return v.ж.App }
 func (v HostinfoView) Desktop() opt.Bool       { return v.ж.Desktop }
 func (v HostinfoView) Package() string         { return v.ж.Package }
 func (v HostinfoView) DeviceModel() string     { return v.ж.DeviceModel }
@@ -305,6 +306,7 @@ var _HostinfoViewNeedsRegeneration = Hostinfo(struct {
 	Distro          string
 	DistroVersion   string
 	DistroCodeName  string
+	App             string
 	Desktop         opt.Bool
 	Package         string
 	DeviceModel     string


### PR DESCRIPTION
This allows us to differentiate between the various tsnet apps that we have like `golinks` and `k8s-operator`.

Feedback from https://github.com/tailscale/golink/pull/64