### PR TITLE
tool/gocross: bootstrap correctly on an older toolchain

### DIFF
--- a/tool/gocross/gocross-wrapper.sh
+++ b/tool/gocross/gocross-wrapper.sh
@@ -21,6 +21,15 @@ repo_root="$(dirname $0)/../.."
 
 toolchain="$HOME/.cache/tailscale-go"
 
+if [ -d "$toolchain" ]; then
+    # A toolchain exists, but is it recent enough to compile gocross? If not,
+    # wipe it out so that the next if block fetches a usable one.
+    want_go_minor=$(egrep '^go ' "$repo_root/go.mod" | cut -f2 -d'.')
+    have_go_minor=$(cut -f2 -d'.' <$toolchain/VERSION)
+    if [ -z "$have_go_minor" -o "$have_go_minor" -lt "$want_go_minor" ]; then
+        rm -rf "$toolchain" "$toolchain.extracted"
+    fi
+fi
 if [ ! -d "$toolchain" ]; then
     mkdir -p "$HOME/.cache"
 


### PR DESCRIPTION
Sometimes, our cached toolchain ends up being an older version of Go, older than our go.mod allows. In that scenario, gocross-wrapper.sh would find a usable toolchain, but then fail to compile gocross.

This change makes the wrapper script check that the cached toolchain's minor version is good enough to build tailscale.com, and re-bootstraps in shell if not.