### PR TITLE
ipn/ipnlocal: remove windows exception from profile migration

### DIFF
--- a/ipn/ipnlocal/profiles.go
+++ b/ipn/ipnlocal/profiles.go
@@ -534,7 +534,7 @@ func newProfileManagerWithGOOS(store ipn.StateStore, logf logger.Logf, goos stri
 		if err := pm.setPrefsLocked(prefs); err != nil {
 			return nil, err
 		}
-	} else if len(knownProfiles) == 0 && goos != "windows" {
+	} else if len(knownProfiles) == 0 {
 		// No known profiles, try a migration.
 		if err := pm.migrateFromLegacyPrefs(); err != nil {
 			return nil, err


### PR DESCRIPTION
The check in question results in profiles never being migrated to backend prefs on Windows clients. We should be doing that on Windows too.

This should be save vis-a-vis unattended mode since we won't see the unmigrated prefs until the GUI signs in.

Fixes #7398