### PR TITLE
tsnet: do not error on NeedsMachineAuth for Up

### DIFF
--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -170,8 +170,7 @@ func (s *Server) Up(ctx context.Context) (*ipnstate.Status, error) {
 			return nil, fmt.Errorf("tsnet.Up: backend: %s", *n.ErrMessage)
 		}
 		if s := n.State; s != nil {
-			switch *s {
-			case ipn.Running:
+			if *s == ipn.Running {
 				status, err := lc.Status(ctx)
 				if err != nil {
 					return nil, fmt.Errorf("tsnet.Up: %w", err)
@@ -180,15 +179,13 @@ func (s *Server) Up(ctx context.Context) (*ipnstate.Status, error) {
 					return nil, errors.New("tsnet.Up: running, but no ip")
 				}
 				return status, nil
-			case ipn.NeedsMachineAuth:
-				return nil, errors.New("tsnet.Up: tailnet requested machine auth")
 			}
-			// TODO: in the future, return an error on NeedsLogin
-			// to improve the UX of trying out the tsnet package.
+			// TODO: in the future, return an error on ipn.NeedsLogin
+			// and ipn.NeedsMachineAuth to improve the UX of trying
+			// out the tsnet package.
 			//
 			// Unfortunately today, even when using an AuthKey we
-			// briefly see a NeedsLogin state. It would be nice
-			// to fix that.
+			// briefly see these states. It would be nice to fix.
 		}
 	}
 }


### PR DESCRIPTION
It turns out even with an AuthKey that pre-approves devices on a tailnet with machine auth turned on, we still temporarily see the NeedsMachineAuth state. So remove that error (for now).