### PR TITLE
types/logid: remove MustParsePublicID

### DIFF
--- a/types/logid/id.go
+++ b/types/logid/id.go
@@ -108,16 +108,6 @@ func ParsePublicID(s string) (PublicID, error) {
 	return p, nil
 }
 
-// MustParsePublicID calls ParsePublicID and panics in case of an error.
-// It is intended for use with constant strings, typically in tests.
-func MustParsePublicID(s string) PublicID {
-	id, err := ParsePublicID(s)
-	if err != nil {
-		panic(err)
-	}
-	return id
-}
-
 func (id PublicID) MarshalText() ([]byte, error) {
 	b := make([]byte, hex.EncodedLen(len(id)))
 	if i := hex.Encode(b, id[:]); i != len(b) {


### PR DESCRIPTION
Ever since the introduction of the "must" package, most MustXXX functions are no longer necessary.
Remove this as it is no longer depended upon
from within this repository and by the internal private repository.