### PR TITLE
cmd/k8s-operator: update device authorization copy

### DIFF
--- a/cmd/k8s-operator/operator.go
+++ b/cmd/k8s-operator/operator.go
@@ -166,7 +166,7 @@ waitOnline:
 			loginDone = true
 		case "NeedsMachineAuth":
 			if !machineAuthShown {
-				startlog.Infof("Machine authorization required, please visit the admin panel to authorize")
+				startlog.Infof("Machine approval required, please visit the admin panel to approve")
 				machineAuthShown = true
 			}
 		default:


### PR DESCRIPTION
"Device Authorization" was recently renamed to "Device Approval" on the control side. This change updates the k8s operator to match.