### PR TITLE
all: implement preauth-key support with tailnet lock

### DIFF
--- a/cmd/tailscale/cli/network-lock.go
+++ b/cmd/tailscale/cli/network-lock.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/mattn/go-colorable"
 	"github.com/mattn/go-isatty"
@@ -39,6 +40,7 @@ var netlockCmd = &ffcli.Command{
 		nlDisablementKDFCmd,
 		nlLogCmd,
 		nlLocalDisableCmd,
+		nlTskeyWrapCmd,
 	},
 	Exec: runNetworkLockStatus,
 }
@@ -620,5 +622,62 @@ func runNetworkLockLog(ctx context.Context, args []string) error {
 		}
 		fmt.Fprintln(stdOut, stanza)
 	}
+	return nil
+}
+
+var nlTskeyWrapCmd = &ffcli.Command{
+	Name:       "tskey-wrap",
+	ShortUsage: "tskey-wrap <tailscale pre-auth key>",
+	ShortHelp:  "Modifies a pre-auth key from the admin panel to work with tailnet lock",
+	LongHelp:   "Modifies a pre-auth key from the admin panel to work with tailnet lock",
+	Exec:       runTskeyWrapCmd,
+}
+
+func runTskeyWrapCmd(ctx context.Context, args []string) error {
+	if len(args) != 1 {
+		return errors.New("usage: lock tskey-wrap <tailscale pre-auth key>")
+	}
+	if strings.Contains(args[0], "--TL") {
+		return errors.New("Error: provided key was already wrapped")
+	}
+
+	st, err := localClient.StatusWithoutPeers(ctx)
+	if err != nil {
+		return fixTailscaledConnectError(err)
+	}
+
+	// Generate a separate tailnet-lock key just for the credential signature.
+	// We use the free-form meta strings to mark a little bit of metadata about this
+	// key.
+	priv := key.NewNLPrivate()
+	m := map[string]string{
+		"purpose":            "pre-auth key",
+		"wrapper_stableid":   string(st.Self.ID),
+		"wrapper_createtime": fmt.Sprint(time.Now().Unix()),
+	}
+	if strings.HasPrefix(args[0], "tskey-auth-") && strings.Index(args[0][len("tskey-auth-"):], "-") > 0 {
+		// We don't want to accidentally embed the nonce part of the authkey in
+		// the event the format changes. As such, we make sure its in the format we
+		// expect (tskey-auth-<stableID, inc CNTRL suffix>-nonce) before we parse
+		// out and embed the stableID.
+		s := strings.TrimPrefix(args[0], "tskey-auth-")
+		m["authkey_stableid"] = s[:strings.Index(s, "-")]
+	}
+	k := tka.Key{
+		Kind:   tka.Key25519,
+		Public: priv.Public().Verifier(),
+		Votes:  1,
+		Meta:   m,
+	}
+
+	wrapped, err := localClient.NetworkLockWrapPreauthKey(ctx, args[0], priv)
+	if err != nil {
+		return fmt.Errorf("wrapping failed: %w", err)
+	}
+	if err := localClient.NetworkLockModify(ctx, []tka.Key{k}, nil); err != nil {
+		return fmt.Errorf("add key failed: %w", err)
+	}
+
+	fmt.Println(wrapped)
 	return nil
 }

--- a/cmd/tailscale/cli/web_test.go
+++ b/cmd/tailscale/cli/web_test.go
@@ -86,10 +86,9 @@ func TestQnapAuthnURL(t *testing.T) {
 		},
 		{
 			name: "err != nil",
-                        in:   "http://192.168.0.%31/",
+			in:   "http://192.168.0.%31/",
 			want: "http://localhost/cgi-bin/authLogin.cgi?qtoken=token",
 		},
-
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/control/controlclient/direct_test.go
+++ b/control/controlclient/direct_test.go
@@ -4,6 +4,7 @@
 package controlclient
 
 import (
+	"crypto/ed25519"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -141,4 +142,43 @@ func TestTsmpPing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestDecodeWrappedAuthkey(t *testing.T) {
+	k, isWrapped, sig, priv := decodeWrappedAuthkey("tskey-32mjsdkdsffds9o87dsfkjlh", nil)
+	if want := "tskey-32mjsdkdsffds9o87dsfkjlh"; k != want {
+		t.Errorf("decodeWrappedAuthkey(<unwrapped-key>).key = %q, want %q", k, want)
+	}
+	if isWrapped {
+		t.Error("decodeWrappedAuthkey(<unwrapped-key>).isWrapped = true, want false")
+	}
+	if sig != nil {
+		t.Errorf("decodeWrappedAuthkey(<unwrapped-key>).sig = %v, want nil", sig)
+	}
+	if priv != nil {
+		t.Errorf("decodeWrappedAuthkey(<unwrapped-key>).priv = %v, want nil", priv)
+	}
+
+	k, isWrapped, sig, priv = decodeWrappedAuthkey("tskey-auth-k7UagY1CNTRL-ZZZZZ--TLpAEDA1ggnXuw4/fWnNWUwcoOjLemhOvml1juMl5lhLmY5sBUsj8EWEAfL2gdeD9g8VDw5tgcxCiHGlEb67BgU2DlFzZApi4LheLJraA+pYjTGChVhpZz1iyiBPD+U2qxDQAbM3+WFY0EBlggxmVqG53Hu0Rg+KmHJFMlUhfgzo+AQP6+Kk9GzvJJOs4-k36RdoSFqaoARfQo0UncHAV0t3YTqrkD5r/z2jTrE43GZWobnce7RGD4qYckUyVSF+DOj4BA/r4qT0bO8kk6zg", nil)
+	if want := "tskey-auth-k7UagY1CNTRL-ZZZZZ"; k != want {
+		t.Errorf("decodeWrappedAuthkey(<wrapped-key>).key = %q, want %q", k, want)
+	}
+	if !isWrapped {
+		t.Error("decodeWrappedAuthkey(<wrapped-key>).isWrapped = false, want true")
+	}
+
+	if sig == nil {
+		t.Fatal("decodeWrappedAuthkey(<wrapped-key>).sig = nil, want non-nil signature")
+	}
+	sigHash := sig.SigHash()
+	if !ed25519.Verify(sig.KeyID, sigHash[:], sig.Signature) {
+		t.Error("signature failed to verify")
+	}
+
+	// Make sure the private is correct by using it.
+	someSig := ed25519.Sign(priv, []byte{1, 2, 3, 4})
+	if !ed25519.Verify(sig.WrappingPubkey, []byte{1, 2, 3, 4}, someSig) {
+		t.Error("failed to use priv")
+	}
+
 }


### PR DESCRIPTION
Design (internal doc): http://go/tailnet-lock-preauth-keys

The basic idea:
1. Admin goes to admin panel to generate a preauth key
2. Admin runs `tailscale lock tskey-wrap tskey-auth-XXXXXXX` to get a longer form of the same thing
3. Admin can now `tailscale up --authkey tskey-auth-XXXXXXX--NNNNNNNNNNNNN` to bring up nodes in a locked tailnet unattended.

Implementation details:
1. A new tailnet-lock key is generated for every wrapped key, to permit revocation on a per-authkey basis
2. The new tailnet-lock key has a smol amount of metadata that gets stamped into it: (that it backed a preauth key, when it was created, and the stable ID of the node that created it). EG: `map[purpose:pre-auth key wrapper_createtime:1677789199 wrapper_stableid:nwkXEu1CNTRL]`
3. There are two pieces to the wrapping information: the SigCredential signature (a `NodeKeySignature` that endorses a single-use public key for signing a node key), and the single-use private key (ed25519 private).
4. When the `controlclient.Direct` starts and sees the authkey, it uses the embedded SigCredential + private key to generate a SigRotation signature and sign itself.

Thoughts?