### PR TITLE
cmd/tailscale, cmd/tailscaled: move portmapper debugging into tailscale CLI

### DIFF
--- a/cmd/tailscale/cli/netcheck.go
+++ b/cmd/tailscale/cli/netcheck.go
@@ -47,7 +47,7 @@ var netcheckArgs struct {
 func runNetcheck(ctx context.Context, args []string) error {
 	c := &netcheck.Client{
 		UDPBindAddr: envknob.String("TS_DEBUG_NETCHECK_UDP_BIND"),
-		PortMapper:  portmapper.NewClient(logger.WithPrefix(log.Printf, "portmap: "), nil),
+		PortMapper:  portmapper.NewClient(logger.WithPrefix(log.Printf, "portmap: "), nil, nil),
 	}
 	if netcheckArgs.verbose {
 		c.Logf = logger.WithPrefix(log.Printf, "netcheck: ")

--- a/net/portmapper/igd_test.go
+++ b/net/portmapper/igd_test.go
@@ -249,7 +249,7 @@ func (d *TestIGD) handlePCPQuery(pkt []byte, src netip.AddrPort) {
 
 func newTestClient(t *testing.T, igd *TestIGD) *Client {
 	var c *Client
-	c = NewClient(t.Logf, func() {
+	c = NewClient(t.Logf, nil, func() {
 		t.Logf("port map changed")
 		t.Logf("have mapping: %v", c.HaveMapping())
 	})

--- a/net/portmapper/portmapper_test.go
+++ b/net/portmapper/portmapper_test.go
@@ -16,7 +16,7 @@ func TestCreateOrGetMapping(t *testing.T) {
 	if v, _ := strconv.ParseBool(os.Getenv("HIT_NETWORK")); !v {
 		t.Skip("skipping test without HIT_NETWORK=1")
 	}
-	c := NewClient(t.Logf, nil)
+	c := NewClient(t.Logf, nil, nil)
 	defer c.Close()
 	c.SetLocalPort(1234)
 	for i := 0; i < 2; i++ {
@@ -32,7 +32,7 @@ func TestClientProbe(t *testing.T) {
 	if v, _ := strconv.ParseBool(os.Getenv("HIT_NETWORK")); !v {
 		t.Skip("skipping test without HIT_NETWORK=1")
 	}
-	c := NewClient(t.Logf, nil)
+	c := NewClient(t.Logf, nil, nil)
 	defer c.Close()
 	for i := 0; i < 3; i++ {
 		if i > 0 {
@@ -47,7 +47,7 @@ func TestClientProbeThenMap(t *testing.T) {
 	if v, _ := strconv.ParseBool(os.Getenv("HIT_NETWORK")); !v {
 		t.Skip("skipping test without HIT_NETWORK=1")
 	}
-	c := NewClient(t.Logf, nil)
+	c := NewClient(t.Logf, nil, nil)
 	defer c.Close()
 	c.SetLocalPort(1234)
 	res, err := c.Probe(context.Background())

--- a/net/portmapper/upnp_test.go
+++ b/net/portmapper/upnp_test.go
@@ -112,7 +112,7 @@ func TestGetUPnPClient(t *testing.T) {
 			gw, _ := netip.AddrFromSlice(ts.Listener.Addr().(*net.TCPAddr).IP)
 			gw = gw.Unmap()
 			var logBuf tstest.MemLogger
-			c, err := getUPnPClient(context.Background(), logBuf.Logf, gw, uPnPDiscoResponse{
+			c, err := getUPnPClient(context.Background(), logBuf.Logf, DebugKnobs{}, gw, uPnPDiscoResponse{
 				Location: ts.URL + "/rootDesc.xml",
 			})
 			if err != nil {

--- a/tstest/integration/tailscaled_deps_test_darwin.go
+++ b/tstest/integration/tailscaled_deps_test_darwin.go
@@ -25,7 +25,6 @@ import (
 	_ "tailscale.com/net/dnsfallback"
 	_ "tailscale.com/net/interfaces"
 	_ "tailscale.com/net/netns"
-	_ "tailscale.com/net/portmapper"
 	_ "tailscale.com/net/proxymux"
 	_ "tailscale.com/net/socks5"
 	_ "tailscale.com/net/tsdial"

--- a/tstest/integration/tailscaled_deps_test_freebsd.go
+++ b/tstest/integration/tailscaled_deps_test_freebsd.go
@@ -25,7 +25,6 @@ import (
 	_ "tailscale.com/net/dnsfallback"
 	_ "tailscale.com/net/interfaces"
 	_ "tailscale.com/net/netns"
-	_ "tailscale.com/net/portmapper"
 	_ "tailscale.com/net/proxymux"
 	_ "tailscale.com/net/socks5"
 	_ "tailscale.com/net/tsdial"

--- a/tstest/integration/tailscaled_deps_test_linux.go
+++ b/tstest/integration/tailscaled_deps_test_linux.go
@@ -25,7 +25,6 @@ import (
 	_ "tailscale.com/net/dnsfallback"
 	_ "tailscale.com/net/interfaces"
 	_ "tailscale.com/net/netns"
-	_ "tailscale.com/net/portmapper"
 	_ "tailscale.com/net/proxymux"
 	_ "tailscale.com/net/socks5"
 	_ "tailscale.com/net/tsdial"

--- a/tstest/integration/tailscaled_deps_test_openbsd.go
+++ b/tstest/integration/tailscaled_deps_test_openbsd.go
@@ -25,7 +25,6 @@ import (
 	_ "tailscale.com/net/dnsfallback"
 	_ "tailscale.com/net/interfaces"
 	_ "tailscale.com/net/netns"
-	_ "tailscale.com/net/portmapper"
 	_ "tailscale.com/net/proxymux"
 	_ "tailscale.com/net/socks5"
 	_ "tailscale.com/net/tsdial"

--- a/tstest/integration/tailscaled_deps_test_windows.go
+++ b/tstest/integration/tailscaled_deps_test_windows.go
@@ -33,7 +33,6 @@ import (
 	_ "tailscale.com/net/dnsfallback"
 	_ "tailscale.com/net/interfaces"
 	_ "tailscale.com/net/netns"
-	_ "tailscale.com/net/portmapper"
 	_ "tailscale.com/net/proxymux"
 	_ "tailscale.com/net/socks5"
 	_ "tailscale.com/net/tsdial"

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -632,7 +632,7 @@ func NewConn(opts Options) (*Conn, error) {
 	c.idleFunc = opts.IdleFunc
 	c.testOnlyPacketListener = opts.TestOnlyPacketListener
 	c.noteRecvActivity = opts.NoteRecvActivity
-	c.portMapper = portmapper.NewClient(logger.WithPrefix(c.logf, "portmapper: "), c.onPortMapChanged)
+	c.portMapper = portmapper.NewClient(logger.WithPrefix(c.logf, "portmapper: "), nil, c.onPortMapChanged)
 	if opts.LinkMonitor != nil {
 		c.portMapper.SetGatewayLookupFunc(opts.LinkMonitor.GatewayAndSelfIP)
 	}


### PR DESCRIPTION
The debug flag on tailscaled isn't available in the macOS App Store build, since we don't have a tailscaled binary; move it to the 'tailscale debug' CLI that is available on all platforms instead.

Updates #7377

Change-Id: I47bffe4461e036fab577c2e51e173f4003592ff7