### PR TITLE
net/dnsfallback: shuffle returned IPs

### DIFF
--- a/net/dnsfallback/dnsfallback.go
+++ b/net/dnsfallback/dnsfallback.go
@@ -87,6 +87,7 @@ func Lookup(ctx context.Context, host string) ([]netip.Addr, error) {
 			continue
 		}
 		if ips := dm[host]; len(ips) > 0 {
+			rand.Shuffle(len(ips), func(i, j int) { ips[i], ips[j] = ips[j], ips[i] })
 			logf("bootstrapDNS(%q, %q) for %q = %v", cand.dnsName, cand.ip, host, ips)
 			return ips, nil
 		}


### PR DESCRIPTION
This ensures that we're trying multiple returned IPs, since the DERP servers return the same response to all queries. This should increase the chances that we eventually reach a working IP.


Change-Id: Ie8d4fb93df96da910fae49ae71bf3e402b9fdecc