### PR TITLE
version/distro,wgengine/router: raise WSL eth0 MTU when too low

### DIFF
--- a/version/distro/distro.go
+++ b/version/distro/distro.go
@@ -32,6 +32,7 @@ const (
 )
 
 var distro lazy.SyncValue[Distro]
+var isWSL lazy.SyncValue[bool]
 
 // Get returns the current distro, or the empty string if unknown.
 func Get() Distro {
@@ -44,6 +45,15 @@ func Get() Distro {
 		default:
 			return Distro("")
 		}
+	})
+}
+
+// IsWSL reports whether we're running in the Windows Subsystem for Linux.
+func IsWSL() bool {
+	return runtime.GOOS == "linux" && isWSL.Get(func() bool {
+		// We could look for $WSL_INTEROP instead, however that may be missing if
+		// the user has started to use systemd in WSL2.
+		return have("/proc/sys/fs/binfmt_misc/WSLInterop") || have("/mnt/wsl")
 	})
 }
 


### PR DESCRIPTION
WSL has started to set the eth0 default route interface default to 1280 MTU, which is too low to carry 1280 byte packets from tailscale0 once wrapped in WireGuard. The change down to 1280 is very likely smaller than necessary for almost all users. We can not easily determine the ideal MTU, but if all the preconditions match, we raise the MTU to 1360, which is just enough for Tailscale traffic to work.

Updates #4833
Updates #7346