### PR TITLE
wgengine/router: drop non-Tailscale IPv6 traffic from ULA range

### DIFF
--- a/wgengine/router/router_linux_test.go
+++ b/wgengine/router/router_linux_test.go
@@ -117,6 +117,7 @@ v6/filter/FORWARD -j ts-forward
 v6/filter/INPUT -j ts-input
 v6/filter/ts-forward -i tailscale0 -j MARK --set-mark 0x40000/0xff0000
 v6/filter/ts-forward -m mark --mark 0x40000/0xff0000 -j ACCEPT
+v6/filter/ts-forward -o tailscale0 -s fd7a:115c:a1e0::/48 -j DROP
 v6/filter/ts-forward -o tailscale0 -j ACCEPT
 v6/nat/POSTROUTING -j ts-postrouting
 v6/nat/ts-postrouting -m mark --mark 0x40000/0xff0000 -j MASQUERADE
@@ -148,6 +149,7 @@ v6/filter/FORWARD -j ts-forward
 v6/filter/INPUT -j ts-input
 v6/filter/ts-forward -i tailscale0 -j MARK --set-mark 0x40000/0xff0000
 v6/filter/ts-forward -m mark --mark 0x40000/0xff0000 -j ACCEPT
+v6/filter/ts-forward -o tailscale0 -s fd7a:115c:a1e0::/48 -j DROP
 v6/filter/ts-forward -o tailscale0 -j ACCEPT
 v6/nat/POSTROUTING -j ts-postrouting
 `,
@@ -181,6 +183,7 @@ v6/filter/FORWARD -j ts-forward
 v6/filter/INPUT -j ts-input
 v6/filter/ts-forward -i tailscale0 -j MARK --set-mark 0x40000/0xff0000
 v6/filter/ts-forward -m mark --mark 0x40000/0xff0000 -j ACCEPT
+v6/filter/ts-forward -o tailscale0 -s fd7a:115c:a1e0::/48 -j DROP
 v6/filter/ts-forward -o tailscale0 -j ACCEPT
 v6/nat/POSTROUTING -j ts-postrouting
 `,
@@ -211,6 +214,7 @@ v6/filter/FORWARD -j ts-forward
 v6/filter/INPUT -j ts-input
 v6/filter/ts-forward -i tailscale0 -j MARK --set-mark 0x40000/0xff0000
 v6/filter/ts-forward -m mark --mark 0x40000/0xff0000 -j ACCEPT
+v6/filter/ts-forward -o tailscale0 -s fd7a:115c:a1e0::/48 -j DROP
 v6/filter/ts-forward -o tailscale0 -j ACCEPT
 v6/nat/POSTROUTING -j ts-postrouting
 `,
@@ -237,6 +241,7 @@ v4/filter/ts-input ! -i tailscale0 -s 100.115.92.0/23 -j RETURN
 v4/filter/ts-input ! -i tailscale0 -s 100.64.0.0/10 -j DROP
 v6/filter/ts-forward -i tailscale0 -j MARK --set-mark 0x40000/0xff0000
 v6/filter/ts-forward -m mark --mark 0x40000/0xff0000 -j ACCEPT
+v6/filter/ts-forward -o tailscale0 -s fd7a:115c:a1e0::/48 -j DROP
 v6/filter/ts-forward -o tailscale0 -j ACCEPT
 `,
 		},
@@ -266,6 +271,7 @@ v6/filter/FORWARD -j ts-forward
 v6/filter/INPUT -j ts-input
 v6/filter/ts-forward -i tailscale0 -j MARK --set-mark 0x40000/0xff0000
 v6/filter/ts-forward -m mark --mark 0x40000/0xff0000 -j ACCEPT
+v6/filter/ts-forward -o tailscale0 -s fd7a:115c:a1e0::/48 -j DROP
 v6/filter/ts-forward -o tailscale0 -j ACCEPT
 v6/nat/POSTROUTING -j ts-postrouting
 `,
@@ -298,6 +304,7 @@ v6/filter/FORWARD -j ts-forward
 v6/filter/INPUT -j ts-input
 v6/filter/ts-forward -i tailscale0 -j MARK --set-mark 0x40000/0xff0000
 v6/filter/ts-forward -m mark --mark 0x40000/0xff0000 -j ACCEPT
+v6/filter/ts-forward -o tailscale0 -s fd7a:115c:a1e0::/48 -j DROP
 v6/filter/ts-forward -o tailscale0 -j ACCEPT
 v6/nat/POSTROUTING -j ts-postrouting
 `,


### PR DESCRIPTION
This replicates the same behaviour in our IPv4 rules by dropping traffic from the IPv6 ULA range that Tailscale uses that does not come from Tailscale itself (i.e. does not have the fwmark).

Change-Id: I75bc09fab73b5171de09a6828549644637c8a495