### PR TITLE
net/interfaces: always return an IPv4 LikelyHomeRouterIP

### DIFF
--- a/net/interfaces/interfaces.go
+++ b/net/interfaces/interfaces.go
@@ -613,8 +613,18 @@ func LikelyHomeRouterIP() (gateway, myIP netip.Addr, ok bool) {
 		return
 	}
 	ForeachInterfaceAddress(func(i Interface, pfx netip.Prefix) {
+		if !i.IsUp() {
+			// Skip interfaces that aren't up.
+			return
+		} else if myIP.IsValid() {
+			// We already have a valid self IP; skip this one.
+			return
+		}
+
 		ip := pfx.Addr()
-		if !i.IsUp() || !ip.IsValid() || myIP.IsValid() {
+		if !ip.IsValid() || !ip.Is4() {
+			// Skip IPs that aren't valid or aren't IPv4, since we
+			// always return an IPv4 address.
 			return
 		}
 		if gateway.IsPrivate() && ip.IsPrivate() {


### PR DESCRIPTION
We weren't filtering out IPv6 addresses from this function, so we could be returning an IPv4 gateway IP and an IPv6 self IP. Per the function comments, only return IPv4 addresses for the self IP.

Change-Id: If19a4aadc343fbd4383fc5290befa0eff006799e