### PR TITLE
net/portmapper: don't pick external ports below 1024

### DIFF
--- a/net/portmapper/upnp.go
+++ b/net/portmapper/upnp.go
@@ -124,8 +124,15 @@ func addAnyPortMapping(
 			uint32(leaseDuration.Seconds()),
 		)
 	}
-	for externalPort == 0 {
-		externalPort = uint16(rand.Intn(65535))
+
+	// Some devices don't let clients add a port mapping for privileged
+	// ports (ports below 1024).
+	//
+	// Pick an external port that's greater than 1024 by getting a random
+	// number in [0, 65535 - 1024] and then adding 1024 to it, shifting the
+	// range to [1024, 65535].
+	if externalPort < 1024 {
+		externalPort = uint16(rand.Intn(65535-1024) + 1024)
 	}
 	err = upnp.AddPortMapping(
 		ctx,


### PR DESCRIPTION
Some devices don't let you UPnP portmap a port below 1024, so let's just avoid that range of ports entirely.

Updates #7377

Change-Id: Ib7603b1c9a019162cdc4fa21744a2cae48bb1d86