### PR TITLE
ipn/localapi: close portmapper after debug

### DIFF
--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -689,6 +689,8 @@ func (h *Handler) serveDebugPortmap(w http.ResponseWriter, r *http.Request) {
 		}
 		logf("cb: no mapping")
 	})
+	defer c.Close()
+
 	linkMon, err := monitor.New(logger.WithPrefix(logf, "monitor: "))
 	if err != nil {
 		logf("error creating monitor: %v", err)


### PR DESCRIPTION
This ensures that any mappings that are created are correctly cleaned up, instead of waiting for them to expire in the router.

Updates #7377

Change-Id: I436248ee7740eded6d8adae5df525e785a8f7ccb