### PR TITLE
wgengine/netstack: add support for custom UDP flow handlers

### DIFF
--- a/types/nettype/nettype.go
+++ b/types/nettype/nettype.go
@@ -48,3 +48,9 @@ func (a packetListenerAdapter) ListenPacket(ctx context.Context, network, addres
 	}
 	return pc.(PacketConn), nil
 }
+
+// ConnPacketConn is the interface that's a superset of net.Conn and net.PacketConn.
+type ConnPacketConn interface {
+	net.Conn
+	net.PacketConn
+}


### PR DESCRIPTION
To be used by tsnet and sniproxy later.

Updates #5871
Updates #1748