### PR TITLE
cmd/sniproxy: draw the rest of the DNS owl.

### DIFF
--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -351,6 +351,24 @@ func (s *Server) doInit() {
 	}
 }
 
+// TailscaleIPs returns IPv4 and IPv6 addresses for this node. If the node
+// has not yet joined a tailnet or is otherwise unaware of its own IP addresses,
+// the returned ip4, ip6 will be !netip.IsValid().
+func (s *Server) TailscaleIPs() (ip4, ip6 netip.Addr) {
+	nm := s.lb.NetMap()
+	for _, addr := range nm.Addresses {
+		ip := addr.Addr()
+		if ip.Is6() {
+			ip6 = ip
+		}
+		if ip.Is4() {
+			ip4 = ip
+		}
+	}
+
+	return ip4, ip6
+}
+
 func (s *Server) getAuthKey() string {
 	if v := s.AuthKey; v != "" {
 		return v


### PR DESCRIPTION
Add a DNS server which always responds as its own IP addresses.

Additionally add a tsnet TailscaleIPs() function to return the IP addresses, both IPv4 and IPv6.

Updates https://github.com/tailscale/tailscale/issues/1748