### PR TITLE
net/dns: deal with Windows wsl.exe hangs

### DIFF
--- a/net/dns/manager_windows.go
+++ b/net/dns/manager_windows.go
@@ -51,12 +51,14 @@ func NewOSConfigurator(logf logger.Logf, interfaceName string) (OSConfigurator, 
 		ret.nrptDB = newNRPTRuleDatabase(logf)
 	}
 
-	// Log WSL status once at startup.
-	if distros, err := wslDistros(); err != nil {
-		logf("WSL: could not list distributions: %v", err)
-	} else {
-		logf("WSL: found %d distributions", len(distros))
-	}
+	go func() {
+		// Log WSL status once at startup.
+		if distros, err := wslDistros(); err != nil {
+			logf("WSL: could not list distributions: %v", err)
+		} else {
+			logf("WSL: found %d distributions", len(distros))
+		}
+	}()
 
 	return ret, nil
 }


### PR DESCRIPTION
Despite the fact that WSL configuration is still disabled by default, we continue to log the machine's list of WSL distros as a diagnostic measure.

Unfortunately I have seen the "wsl.exe -l" command hang indefinitely. This patch adds a (more than reasonable) 10s timeout to ensure that tailscaled does not get stuck while executing this operation.

I also modified the Windows implementation of NewOSConfigurator to do the logging asynchronously, since that information is not required in order to continue starting up.

Fixes #7476