### PR TITLE
cmd/tailscale: annotate tailnet-lock keys which wrap pre-auth keys

### DIFF
--- a/cmd/tailscale/cli/network-lock.go
+++ b/cmd/tailscale/cli/network-lock.go
@@ -232,6 +232,15 @@ func runNetworkLockStatus(ctx context.Context, args []string) error {
 			if k.Key == st.PublicKey {
 				line.WriteString("(self)")
 			}
+			if k.Metadata["purpose"] == "pre-auth key" {
+				if preauthKeyID := k.Metadata["authkey_stableid"]; preauthKeyID != "" {
+					line.WriteString("(pre-auth key ")
+					line.WriteString(preauthKeyID)
+					line.WriteString(")")
+				} else {
+					line.WriteString("(pre-auth key)")
+				}
+			}
 			fmt.Println(line.String())
 		}
 	}


### PR DESCRIPTION
Looks like this:

```
[xxx@tslptp:~/nl-test]$ sudo ./tailscale --socket n1/sock lock
Warning: client version "1.37.0-dev20230308-tce9947431-dirty" != tailscaled server version "1.37.0-dev20230308-tb95fa0a1f-dirty"
Tailnet lock is ENABLED.

This node is accessible under tailnet lock.

This node's tailnet-lock key: tlpub:c962606bf9cd8dd729c4e62e2321fe8db91af44252fafb3be30f48ce57624834

Trusted signing keys:
	tlpub:c962606bf9cd8dd729c4e62e2321fe8db91af44252fafb3be30f48ce57624834	42	(self)
	tlpub:4b43334e6de941f89d3a8bf384cf9a8e04f1b881a31caf473daf65c4176425a3	69	
	tlpub:58b2f24f333037b4d703f4dc1fe9f8d308fe4cd5bbe64154c9e1270eb6d00949	1	(backing pre-auth key k7UagY1CNTRL)

The following nodes are locked out by tailnet lock and cannot connect to other nodes:
	tslptp-9.tail1ef32.ts.net.	100.108.234.23, fd7a:115c:a1e0:ab12:4843:cd96:626c:ea17	nUaQLW6CNTRL
```