### PR TITLE
sockstats: refactor validation to be opt-in

### DIFF
--- a/ipn/ipnlocal/peerapi.go
+++ b/ipn/ipnlocal/peerapi.go
@@ -861,7 +861,7 @@ func (h *peerAPIHandler) handleServeSockStats(w http.ResponseWriter, r *http.Req
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	fmt.Fprintln(w, "<!DOCTYPE html><h1>Socket Stats</h1>")
 
-	stats := sockstats.Get()
+	stats, validation := sockstats.GetWithValidation()
 	if stats == nil {
 		fmt.Fprintln(w, "No socket stats available")
 		return
@@ -910,12 +910,12 @@ func (h *peerAPIHandler) handleServeSockStats(w http.ResponseWriter, r *http.Req
 			rxTotalByInterface[iface] += stat.RxBytesByInterface[iface]
 		}
 
-		if stat.ValidationRxBytes > 0 || stat.ValidationTxBytes > 0 {
+		if validationStat, ok := validation.Stats[label]; ok && (validationStat.RxBytes > 0 || validationStat.TxBytes > 0) {
 			fmt.Fprintf(w, "<td>Tx=%d (%+d) Rx=%d (%+d)</td>",
-				stat.ValidationTxBytes,
-				int64(stat.ValidationTxBytes)-int64(stat.TxBytes),
-				stat.ValidationRxBytes,
-				int64(stat.ValidationRxBytes)-int64(stat.RxBytes))
+				validationStat.TxBytes,
+				int64(validationStat.TxBytes)-int64(stat.TxBytes),
+				validationStat.RxBytes,
+				int64(validationStat.RxBytes)-int64(stat.RxBytes))
 		} else {
 			fmt.Fprintln(w, "<td></td>")
 		}

--- a/net/sockstats/sockstats_noop.go
+++ b/net/sockstats/sockstats_noop.go
@@ -17,5 +17,9 @@ func get() *SockStats {
 	return nil
 }
 
+func getValidation() *ValidationSockStats {
+	return nil
+}
+
 func setLinkMonitor(lm LinkMonitor) {
 }

--- a/net/sockstats/sockstats_tsgo.go
+++ b/net/sockstats/sockstats_tsgo.go
@@ -81,6 +81,7 @@ func withSockStats(ctx context.Context, label Label) context.Context {
 		tx, rx := tcpConnStats(c)
 		counters.validationTxBytes.Add(tx)
 		counters.validationRxBytes.Add(rx)
+		counters.validationConn.Store(nil)
 	}
 
 	// Don't bother adding these hooks if we can't get stats that they end up
@@ -142,14 +143,6 @@ func get() *SockStats {
 			RxBytes:            counters.rxBytes.Load(),
 			TxBytesByInterface: make(map[string]uint64),
 			RxBytesByInterface: make(map[string]uint64),
-
-			ValidationTxBytes: counters.validationTxBytes.Load(),
-			ValidationRxBytes: counters.validationRxBytes.Load(),
-		}
-		if c := counters.validationConn.Load(); c != nil && tcpConnStats != nil {
-			tx, rx := tcpConnStats(*c)
-			s.ValidationTxBytes += tx
-			s.ValidationRxBytes += rx
 		}
 		for iface, a := range counters.rxBytesByInterface {
 			ifName := sockStats.knownInterfaces[iface]
@@ -158,6 +151,30 @@ func get() *SockStats {
 		for iface, a := range counters.txBytesByInterface {
 			ifName := sockStats.knownInterfaces[iface]
 			s.TxBytesByInterface[ifName] = a.Load()
+		}
+		r.Stats[label] = s
+	}
+
+	return r
+}
+
+func getValidation() *ValidationSockStats {
+	sockStats.mu.Lock()
+	defer sockStats.mu.Unlock()
+
+	r := &ValidationSockStats{
+		Stats: make(map[Label]ValidationSockStat),
+	}
+
+	for label, counters := range sockStats.countersByLabel {
+		s := ValidationSockStat{
+			TxBytes: counters.validationTxBytes.Load(),
+			RxBytes: counters.validationRxBytes.Load(),
+		}
+		if c := counters.validationConn.Load(); c != nil && tcpConnStats != nil {
+			tx, rx := tcpConnStats(*c)
+			s.TxBytes += tx
+			s.RxBytes += rx
 		}
 		r.Stats[label] = s
 	}


### PR DESCRIPTION
Followup to #7499 to make validation a separate function (`GetWithValidation` vs. `Get`). This way callers that don't need it don't pay the cost of a syscall per active TCP socket.

Also clears the conn on close, so that we don't double-count the stats.

Also more consistently uses Go doc comments for the exported API of the sockstats package.

Updates tailscale/corp#9230
Updates #3363