### PR TITLE
ipn: add c2n endpoint for sockstats logs

### DIFF
--- a/ipn/ipnlocal/c2n.go
+++ b/ipn/ipnlocal/c2n.go
@@ -83,6 +83,9 @@ func (b *LocalBackend) handleC2N(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		writeJSON(res)
+	case "/sockstats":
+		w.Header().Set("Content-Type", "text/plain")
+		b.sockstatLogger.WriteLogs(w)
 	default:
 		http.Error(w, "unknown c2n path", http.StatusBadRequest)
 	}

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -310,7 +310,7 @@ func NewLocalBackend(logf logger.Logf, logid string, store ipn.StateStore, diale
 
 	// for now, only log sockstats on unstable builds
 	if version.IsUnstableBuild() {
-		b.sockstatLogger, err = sockstatlog.NewLogger(logpolicy.LogsDir(logf))
+		b.sockstatLogger, err = sockstatlog.NewLogger(logpolicy.LogsDir(logf), logf)
 		if err != nil {
 			log.Printf("error setting up sockstat logger: %v", err)
 		}


### PR DESCRIPTION
Add c2n endpoint for collecting sockstats logs from a device.