### PR TITLE
tsnet: always attempt to create storage directory

### DIFF
--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -415,9 +415,9 @@ func (s *Server) start() (reterr error) {
 		if err != nil {
 			return err
 		}
-		if err := os.MkdirAll(s.rootPath, 0700); err != nil {
-			return err
-		}
+	}
+	if err := os.MkdirAll(s.rootPath, 0700); err != nil {
+		return err
 	}
 	if fi, err := os.Stat(s.rootPath); err != nil {
 		return err


### PR DESCRIPTION
This lets users start a server with:

	Dir: "./my-demo"

easily.