### PR TITLE
tsnet/tsnet: clear ipn.ServeConfig on Up for tsnet apps

### DIFF
--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -277,6 +277,14 @@ func (s *Server) Up(ctx context.Context) (*ipnstate.Status, error) {
 				if len(status.TailscaleIPs) == 0 {
 					return nil, errors.New("tsnet.Up: running, but no ip")
 				}
+
+				// Clear the persisted serve config state to prevent stale configuration
+				// from code changes. This is a temporary workaround until we have a better
+				// way to handle this. (2023-03-11)
+				if err := lc.SetServeConfig(ctx, new(ipn.ServeConfig)); err != nil {
+					return nil, fmt.Errorf("tsnet.Up: %w", err)
+				}
+
 				return status, nil
 			}
 			// TODO: in the future, return an error on ipn.NeedsLogin


### PR DESCRIPTION
We persist the ServeConfig, even for tsnet apps. It's quite possible for
the ServeConfig to be out of step with the code. Example: If you run
`ListenFunnel` then later turn it off, the ServeConfig will still show
it enabled, the admin console will show it enabled, but the packet
handler will reject the packets.

Workaround by clearing the ServeConfig in `tsnet.Up`
