### PR TITLE
tailcfg: add optional Location field to DERPRegion

### DIFF
--- a/tailcfg/derpmap.go
+++ b/tailcfg/derpmap.go
@@ -67,6 +67,17 @@ type DERPRegion struct {
 	// away to a new region without Avoid set.
 	Avoid bool `json:",omitempty"`
 
+	// Location is an (optional) geographic location for this region; it is
+	// used in conjunction with ambient location information like the
+	// current cloud provider's region to try optimal regions first and
+	// exclude DERP regions on the other side of the world from being
+	// checked.
+	//
+	// If this region has no location, it should always be considered a
+	// candidate as maybe being the closest. That is, it should not be
+	// ruled out as a candidate if the node knows its own actual location.
+	Location *DERPLocation `json:",omitempty"`
+
 	// Nodes are the DERP nodes running in this region, in
 	// priority order for the current client. Client TLS
 	// connections should ideally only go to the first entry
@@ -142,6 +153,15 @@ type DERPNode struct {
 	// STUNTestIP is used in tests to override the STUN server's IP.
 	// If empty, it's assumed to be the same as the DERP server.
 	STUNTestIP string `json:",omitempty"`
+}
+
+// DERPLocation contains information about a DERP region's physical location.
+type DERPLocation struct {
+	// Latitude contains the latitude component of this location.
+	Latitude float64
+
+	// Longitude contains the longitude component of this location.
+	Longitude float64
 }
 
 // DotInvalid is a fake DNS TLD used in tests for an invalid hostname.

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -3,7 +3,7 @@
 
 package tailcfg
 
-//go:generate go run tailscale.com/cmd/viewer --type=User,Node,Hostinfo,NetInfo,Login,DNSConfig,RegisterResponse,DERPRegion,DERPMap,DERPNode,SSHRule,SSHAction,SSHPrincipal,ControlDialPlan --clonefunc
+//go:generate go run tailscale.com/cmd/viewer --type=User,Node,Hostinfo,NetInfo,Login,DNSConfig,RegisterResponse,DERPRegion,DERPLocation,DERPMap,DERPNode,SSHRule,SSHAction,SSHPrincipal,ControlDialPlan --clonefunc
 
 import (
 	"bytes"

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -285,6 +285,10 @@ func (src *DERPRegion) Clone() *DERPRegion {
 	}
 	dst := new(DERPRegion)
 	*dst = *src
+	if dst.Location != nil {
+		dst.Location = new(DERPLocation)
+		*dst.Location = *src.Location
+	}
 	dst.Nodes = make([]*DERPNode, len(src.Nodes))
 	for i := range dst.Nodes {
 		dst.Nodes[i] = src.Nodes[i].Clone()
@@ -298,7 +302,25 @@ var _DERPRegionCloneNeedsRegeneration = DERPRegion(struct {
 	RegionCode string
 	RegionName string
 	Avoid      bool
+	Location   *DERPLocation
 	Nodes      []*DERPNode
+}{})
+
+// Clone makes a deep copy of DERPLocation.
+// The result aliases no memory with the original.
+func (src *DERPLocation) Clone() *DERPLocation {
+	if src == nil {
+		return nil
+	}
+	dst := new(DERPLocation)
+	*dst = *src
+	return dst
+}
+
+// A compilation failure here means this code must be regenerated, with the command at the top of this file.
+var _DERPLocationCloneNeedsRegeneration = DERPLocation(struct {
+	Latitude  float64
+	Longitude float64
 }{})
 
 // Clone makes a deep copy of DERPMap.
@@ -448,7 +470,7 @@ var _ControlDialPlanCloneNeedsRegeneration = ControlDialPlan(struct {
 
 // Clone duplicates src into dst and reports whether it succeeded.
 // To succeed, <src, dst> must be of types <*T, *T> or <*T, **T>,
-// where T is one of User,Node,Hostinfo,NetInfo,Login,DNSConfig,RegisterResponse,DERPRegion,DERPMap,DERPNode,SSHRule,SSHAction,SSHPrincipal,ControlDialPlan.
+// where T is one of User,Node,Hostinfo,NetInfo,Login,DNSConfig,RegisterResponse,DERPRegion,DERPLocation,DERPMap,DERPNode,SSHRule,SSHAction,SSHPrincipal,ControlDialPlan.
 func Clone(dst, src any) bool {
 	switch src := src.(type) {
 	case *User:
@@ -520,6 +542,15 @@ func Clone(dst, src any) bool {
 			*dst = *src.Clone()
 			return true
 		case **DERPRegion:
+			*dst = src.Clone()
+			return true
+		}
+	case *DERPLocation:
+		switch dst := dst.(type) {
+		case *DERPLocation:
+			*dst = *src.Clone()
+			return true
+		case **DERPLocation:
 			*dst = src.Clone()
 			return true
 		}

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -20,7 +20,7 @@ import (
 	"tailscale.com/types/views"
 )
 
-//go:generate go run tailscale.com/cmd/cloner  -clonefunc=true -type=User,Node,Hostinfo,NetInfo,Login,DNSConfig,RegisterResponse,DERPRegion,DERPMap,DERPNode,SSHRule,SSHAction,SSHPrincipal,ControlDialPlan
+//go:generate go run tailscale.com/cmd/cloner  -clonefunc=true -type=User,Node,Hostinfo,NetInfo,Login,DNSConfig,RegisterResponse,DERPRegion,DERPLocation,DERPMap,DERPNode,SSHRule,SSHAction,SSHPrincipal,ControlDialPlan
 
 // View returns a readonly view of User.
 func (p *User) View() UserView {
@@ -668,6 +668,14 @@ func (v DERPRegionView) RegionID() int      { return v.ж.RegionID }
 func (v DERPRegionView) RegionCode() string { return v.ж.RegionCode }
 func (v DERPRegionView) RegionName() string { return v.ж.RegionName }
 func (v DERPRegionView) Avoid() bool        { return v.ж.Avoid }
+func (v DERPRegionView) Location() *DERPLocation {
+	if v.ж.Location == nil {
+		return nil
+	}
+	x := *v.ж.Location
+	return &x
+}
+
 func (v DERPRegionView) Nodes() views.SliceView[*DERPNode, DERPNodeView] {
 	return views.SliceOfViews[*DERPNode, DERPNodeView](v.ж.Nodes)
 }
@@ -678,7 +686,62 @@ var _DERPRegionViewNeedsRegeneration = DERPRegion(struct {
 	RegionCode string
 	RegionName string
 	Avoid      bool
+	Location   *DERPLocation
 	Nodes      []*DERPNode
+}{})
+
+// View returns a readonly view of DERPLocation.
+func (p *DERPLocation) View() DERPLocationView {
+	return DERPLocationView{ж: p}
+}
+
+// DERPLocationView provides a read-only view over DERPLocation.
+//
+// Its methods should only be called if `Valid()` returns true.
+type DERPLocationView struct {
+	// ж is the underlying mutable value, named with a hard-to-type
+	// character that looks pointy like a pointer.
+	// It is named distinctively to make you think of how dangerous it is to escape
+	// to callers. You must not let callers be able to mutate it.
+	ж *DERPLocation
+}
+
+// Valid reports whether underlying value is non-nil.
+func (v DERPLocationView) Valid() bool { return v.ж != nil }
+
+// AsStruct returns a clone of the underlying value which aliases no memory with
+// the original.
+func (v DERPLocationView) AsStruct() *DERPLocation {
+	if v.ж == nil {
+		return nil
+	}
+	return v.ж.Clone()
+}
+
+func (v DERPLocationView) MarshalJSON() ([]byte, error) { return json.Marshal(v.ж) }
+
+func (v *DERPLocationView) UnmarshalJSON(b []byte) error {
+	if v.ж != nil {
+		return errors.New("already initialized")
+	}
+	if len(b) == 0 {
+		return nil
+	}
+	var x DERPLocation
+	if err := json.Unmarshal(b, &x); err != nil {
+		return err
+	}
+	v.ж = &x
+	return nil
+}
+
+func (v DERPLocationView) Latitude() float64  { return v.ж.Latitude }
+func (v DERPLocationView) Longitude() float64 { return v.ж.Longitude }
+
+// A compilation failure here means this code must be regenerated, with the command at the top of this file.
+var _DERPLocationViewNeedsRegeneration = DERPLocation(struct {
+	Latitude  float64
+	Longitude float64
 }{})
 
 // View returns a readonly view of DERPMap.


### PR DESCRIPTION
This allows future optimizations for finding the closest DERP region without needing to send a netcheck probe to everywhere in the world.

Updates #7365

Change-Id: I9c0a235283d6a46959c68f87d4aa2fc1cb86ba19