### PR TITLE
cmd/k8s-operator: pass through tags as Impersonate-Group

### DIFF
--- a/cmd/k8s-operator/manifests/authproxy-rbac.yaml
+++ b/cmd/k8s-operator/manifests/authproxy-rbac.yaml
@@ -7,7 +7,7 @@ metadata:
   name: tailscale-auth-proxy
 rules:
 - apiGroups: [""]
-  resources: ["users"]
+  resources: ["users", "groups"]
   verbs: ["impersonate"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
We were not handling tags at all, pass them through as Impersonate-Group headers.
And use the FQDN for tagged nodes as Impersonate-User.

Updates #5055
