### PR TITLE
cmd/k8s-operator: drop trailing dot in tagged node name

### DIFF
--- a/cmd/k8s-operator/proxy.go
+++ b/cmd/k8s-operator/proxy.go
@@ -88,7 +88,7 @@ func runAuthProxy(s *tsnet.Server, rt http.RoundTripper, logf logger.Logf) {
 				if who.Node.IsTagged() {
 					// Use the nodes FQDN as the username, and the nodes tags as the groups.
 					// "Impersonate-Group" requires "Impersonate-User" to be set.
-					r.Header.Set("Impersonate-User", who.Node.Name)
+					r.Header.Set("Impersonate-User", strings.TrimSuffix(who.Node.Name, "."))
 					for _, tag := range who.Node.Tags {
 						r.Header.Add("Impersonate-Group", tag)
 					}

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -183,7 +183,12 @@ func (emptyStructJSONSlice) UnmarshalJSON([]byte) error { return nil }
 type Node struct {
 	ID       NodeID
 	StableID StableNodeID
-	Name     string // DNS
+
+	// Name is the FQDN of the node.
+	// It is also the MagicDNS name for the node.
+	// It has a trailing dot.
+	// e.g. "host.tail-scale.ts.net."
+	Name string
 
 	// User is the user who created the node. If ACL tags are in
 	// use for the node then it doesn't reflect the ACL identity


### PR DESCRIPTION
Also update tailcfg docs.

Updates #5055