### PR TITLE
build_dist.sh: make cross-compilation friendly

### DIFF
--- a/build_dist.sh
+++ b/build_dist.sh
@@ -16,7 +16,7 @@ if [ -n "${TS_USE_TOOLCHAIN:-}" ]; then
 	go="./tool/go"
 fi
 
-eval `$go run ./cmd/mkversion`
+eval `GOOS=$($go env GOHOSTOS) GOARCH=$($go env GOHOSTARCH) $go run ./cmd/mkversion`
 
 if [ "$1" = "shellvars" ]; then
 	cat <<EOF


### PR DESCRIPTION
For the sunos port I do cross compilation on GitHub to publish release binaries for anyone not using distro packages.

This is how I fixed `build_dist.sh` to work for me, but ultimately I have no strong feelings on how this is accomplished.

I do think it's worth keeping that script cross-compilation friendly.