### PR TITLE
funnel: change references from alpha to beta

### DIFF
--- a/cmd/tailscale/cli/funnel.go
+++ b/cmd/tailscale/cli/funnel.go
@@ -29,7 +29,7 @@ var funnelCmd = newFunnelCommand(&serveEnv{lc: &localClient})
 func newFunnelCommand(e *serveEnv) *ffcli.Command {
 	return &ffcli.Command{
 		Name:      "funnel",
-		ShortHelp: "[ALPHA] turn Tailscale Funnel on or off",
+		ShortHelp: "[BETA] turn Tailscale Funnel on or off",
 		ShortUsage: strings.TrimSpace(`
 funnel <serve-port> {on|off}
   funnel status [--json]

--- a/cmd/tailscale/cli/serve.go
+++ b/cmd/tailscale/cli/serve.go
@@ -33,7 +33,7 @@ var serveCmd = newServeCommand(&serveEnv{lc: &localClient})
 func newServeCommand(e *serveEnv) *ffcli.Command {
 	return &ffcli.Command{
 		Name:      "serve",
-		ShortHelp: "[ALPHA] Serve from your Tailscale node",
+		ShortHelp: "[BETA] Serve from your Tailscale node",
 		ShortUsage: strings.TrimSpace(`
 serve https:<port> <mount-point> <source> [off]
   serve tcp:<port> tcp://localhost:<local-port> [off]
@@ -41,7 +41,7 @@ serve https:<port> <mount-point> <source> [off]
   serve status [--json]
 `),
 		LongHelp: strings.TrimSpace(`
-*** ALPHA; all of this is subject to change ***
+*** BETA; all of this is subject to change ***
 
 The 'tailscale serve' set of commands allows you to serve
 content and local servers from your Tailscale node to

--- a/ipn/serve.go
+++ b/ipn/serve.go
@@ -180,7 +180,7 @@ func (sc *ServeConfig) IsFunnelOn() bool {
 // CheckFunnelAccess checks whether Funnel access is allowed for the given node
 // and port.
 // It checks:
-//  1. an invite was used to join the Funnel alpha
+//  1. Funnel is enabled on the Tailnet
 //  2. HTTPS is enabled on the Tailnet
 //  3. the node has the "funnel" nodeAttr
 //  4. the port is allowed for Funnel
@@ -190,7 +190,7 @@ func (sc *ServeConfig) IsFunnelOn() bool {
 // Funnel.
 func CheckFunnelAccess(port uint16, nodeAttrs []string) error {
 	if slices.Contains(nodeAttrs, tailcfg.CapabilityWarnFunnelNoInvite) {
-		return errors.New("Funnel not available; an invite is required to join the alpha. See https://tailscale.com/s/no-funnel.")
+		return errors.New("Funnel not enabled; See https://tailscale.com/s/no-funnel.")
 	}
 	if slices.Contains(nodeAttrs, tailcfg.CapabilityWarnFunnelNoHTTPS) {
 		return errors.New("Funnel not available; HTTPS must be enabled. See https://tailscale.com/s/https.")

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -1822,7 +1822,8 @@ const (
 
 	// Funnel warning capabilities used for reporting errors to the user.
 
-	// CapabilityWarnFunnelNoInvite indicates an invite has not been accepted for the Funnel alpha.
+	// CapabilityWarnFunnelNoInvite indicates whether Funnel is enabled for the tailnet.
+	// NOTE: In transition from Alpha to Beta, this capability is being reused as the enablement.
 	CapabilityWarnFunnelNoInvite = "https://tailscale.com/cap/warn-funnel-no-invite"
 
 	// CapabilityWarnFunnelNoHTTPS indicates HTTPS has not been enabled for the tailnet.


### PR DESCRIPTION
Updates CLI and docs to reference Funnel as beta

Signed-off-by: Shayne Sweeney <shayne@tailscale.com>
