### PR TITLE
derp: add optional debug logging for prober clients

### DIFF
--- a/cmd/derpprobe/derpprobe.go
+++ b/cmd/derpprobe/derpprobe.go
@@ -23,13 +23,14 @@ var (
 	derpMapURL = flag.String("derp-map", "https://login.tailscale.com/derpmap/default", "URL to DERP map (https:// or file://)")
 	listen     = flag.String("listen", ":8030", "HTTP listen address")
 	probeOnce  = flag.Bool("once", false, "probe once and print results, then exit; ignores the listen flag")
+	spread     = flag.Bool("spread", true, "whether to spread probing over time")
 	interval   = flag.Duration("interval", 15*time.Second, "probe interval")
 )
 
 func main() {
 	flag.Parse()
 
-	p := prober.New().WithSpread(true).WithOnce(*probeOnce)
+	p := prober.New().WithSpread(*spread).WithOnce(*probeOnce)
 	dp, err := prober.DERP(p, *derpMapURL, *interval, *interval, *interval)
 	if err != nil {
 		log.Fatal(err)

--- a/derp/derp_test.go
+++ b/derp/derp_test.go
@@ -660,6 +660,9 @@ type testFwd int
 func (testFwd) ForwardPacket(key.NodePublic, key.NodePublic, []byte) error {
 	panic("not called in tests")
 }
+func (testFwd) String() string {
+	panic("not called in tests")
+}
 
 func pubAll(b byte) (ret key.NodePublic) {
 	var bs [32]byte
@@ -787,6 +790,7 @@ type channelFwd struct {
 	c  chan []byte
 }
 
+func (f channelFwd) String() string { return "" }
 func (f channelFwd) ForwardPacket(_ key.NodePublic, _ key.NodePublic, packet []byte) error {
 	f.c <- packet
 	return nil

--- a/derp/derphttp/derphttp_client.go
+++ b/derp/derphttp/derphttp_client.go
@@ -82,6 +82,10 @@ type Client struct {
 	pingOut      map[derp.PingMessage]chan<- bool // chan to send to on pong
 }
 
+func (c *Client) String() string {
+	return fmt.Sprintf("<derphttp_client.Client %s url=%s>", c.serverPubKey.ShortString(), c.url)
+}
+
 // NewRegionClient returns a new DERP-over-HTTP client. It connects lazily.
 // To trigger a connection, use Connect.
 func NewRegionClient(privateKey key.NodePrivate, logf logger.Logf, getRegion func() *tailcfg.DERPRegion) *Client {

--- a/prober/derp.go
+++ b/prober/derp.go
@@ -273,6 +273,17 @@ func derpProbeNodePair(ctx context.Context, dm *tailcfg.DERPMap, from, to *tailc
 		time.Sleep(100 * time.Millisecond) // pretty arbitrary
 	}
 
+	latency, err = runDerpProbeNodePair(ctx, from, to, fromc, toc)
+	if err != nil {
+		// Record pubkeys on failed probes to aid investigation.
+		err = fmt.Errorf("%s -> %s: %w",
+			fromc.SelfPublicKey().ShortString(),
+			toc.SelfPublicKey().ShortString(), err)
+	}
+	return latency, err
+}
+
+func runDerpProbeNodePair(ctx context.Context, from, to *tailcfg.DERPNode, fromc, toc *derphttp.Client) (latency time.Duration, err error) {
 	// Make a random packet
 	pkt := make([]byte, 8)
 	crand.Read(pkt)


### PR DESCRIPTION
This allows tracking packet flow via logs for prober clients. Note that the new `sclient.debug()` function is called on every received packet, but will do nothing for most clients.

I have adjusted sclient logging to print public keys in short format rather than full. This takes effect even for existing non-debug logging (mostly client disconnect messages).

Example logs for a packet being sent from client [SbsJn] (connected to derper [dM2E3]) to client [10WOo] (connected to derper [AVxvv]):

```
derper [dM2E3]:
derp client 10.0.0.1:35470[SbsJn]: register single client mesh("10.0.1.1"): 4 peers
derp client 10.0.0.1:35470[SbsJn]: read frame type 4 len 40 err <nil>
derp client 10.0.0.1:35470[SbsJn]: SendPacket for [10WOo], forwarding via <derphttp_client.Client [AVxvv] url=https://10.0.1.1/derp>: <nil>
derp client 10.0.0.1:35470[SbsJn]: read frame type 0 len 0 err EOF
derp client 10.0.0.1:35470[SbsJn]: read EOF
derp client 10.0.0.1:35470[SbsJn]: sender failed: context canceled
derp client 10.0.0.1:35470[SbsJn]: removing connection

derper [AVxvv]:
derp client 10.0.1.1:50650[10WOo]: register single client
derp client 10.0.1.1:50650[10WOo]: received forwarded packet from [SbsJn] via [dM2E3]
derp client 10.0.1.1:50650[10WOo]: sendPkt attempt 0 enqueued
derp client 10.0.1.1:50650[10WOo]: sendPacket from [SbsJn]: <nil>
derp client 10.0.1.1:50650[10WOo]: read frame type 0 len 0 err EOF
derp client 10.0.1.1:50650[10WOo]: read EOF
derp client 10.0.1.1:50650[10WOo]: sender failed: context canceled
derp client 10.0.1.1:50650[10WOo]: removing connection
```

Also adjusted the derp prober library to log client pubkeys.