### PR TITLE
ssh/tailssh: handle session recording when running in userspace mode

### DIFF
--- a/ssh/tailssh/tailssh_test.go
+++ b/ssh/tailssh/tailssh_test.go
@@ -237,6 +237,10 @@ var (
 	testSignerOnce sync.Once
 )
 
+func (ts *localState) Dialer() *tsdial.Dialer {
+	return nil
+}
+
 func (ts *localState) GetSSH_HostKeys() ([]gossh.Signer, error) {
 	testSignerOnce.Do(func() {
 		_, priv, err := ed25519.GenerateKey(rand.Reader)


### PR DESCRIPTION
Previously it would dial out using the http.DefaultClient, however that doesn't work when tailscaled is running in userspace mode (e.g. when testing).

Updates tailscale/corp#9967