### PR TITLE
cmd/tailscale: extend hostname length checks

### DIFF
--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -621,9 +621,16 @@ func TestPrefsFromUpArgs(t *testing.T) {
 		{
 			name: "error_long_hostname",
 			args: upArgsT{
-				hostname: strings.Repeat("a", 300),
+				hostname: strings.Repeat(strings.Repeat("a", 63)+".", 5),
 			},
-			wantErr: `hostname too long: 300 bytes (max 256)`,
+			wantErr: `hostname too long: 320 bytes (max 255)`,
+		},
+		{
+			name: "error_long_label",
+			args: upArgsT{
+				hostname: strings.Repeat("a", 64) + ".example.com",
+			},
+			wantErr: `first label of the hostname (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) is too long: 64 bytes (max 63)`,
 		},
 		{
 			name: "error_linux_netfilter_empty",

--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -621,16 +621,16 @@ func TestPrefsFromUpArgs(t *testing.T) {
 		{
 			name: "error_long_hostname",
 			args: upArgsT{
-				hostname: strings.Repeat(strings.Repeat("a", 63)+".", 5),
+				hostname: strings.Repeat(strings.Repeat("a", 63)+".", 4),
 			},
-			wantErr: `hostname too long: 320 bytes (max 255)`,
+			wantErr: `"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" is too long to be a DNS name`,
 		},
 		{
 			name: "error_long_label",
 			args: upArgsT{
 				hostname: strings.Repeat("a", 64) + ".example.com",
 			},
-			wantErr: `first label of the hostname (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) is too long: 64 bytes (max 63)`,
+			wantErr: `"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" is not a valid DNS label`,
 		},
 		{
 			name: "error_linux_netfilter_empty",

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -321,13 +321,8 @@ func prefsFromUpArgs(upArgs upArgsT, warnf logger.Logf, st *ipnstate.Status, goo
 		}
 	}
 
-	// RFC 1035 says the length of a DNS name is restricted to 255 octets or less.
-	if len(upArgs.hostname) > 255 {
-		return nil, fmt.Errorf("hostname too long: %d bytes (max 255)", len(upArgs.hostname))
-	}
-	// RFC 1035 says the length of a DNS label is restricted to 63 octets or less.
-	if shortname := dnsname.FirstLabel(upArgs.hostname); len(shortname) > 63 {
-		return nil, fmt.Errorf("first label of the hostname (%s) is too long: %d bytes (max 63)", shortname, len(shortname))
+	if err := dnsname.ValidHostname(upArgs.hostname); upArgs.hostname != "" && err != nil {
+		return nil, err
 	}
 
 	prefs := ipn.NewPrefs()

--- a/util/dnsname/dnsname.go
+++ b/util/dnsname/dnsname.go
@@ -214,6 +214,21 @@ func FirstLabel(hostname string) string {
 	return first
 }
 
+// ValidHostname checks if a string is a valid hostname.
+func ValidHostname(hostname string) error {
+	fqdn, err := ToFQDN(hostname)
+	if err != nil {
+		return err
+	}
+
+	for _, label := range strings.Split(fqdn.WithoutTrailingDot(), ".") {
+		if err := ValidLabel(label); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 var separators = map[byte]bool{
 	' ': true,
 	'.': true,

--- a/util/dnsname/dnsname_test.go
+++ b/util/dnsname/dnsname_test.go
@@ -185,6 +185,31 @@ func TestTrimSuffix(t *testing.T) {
 	}
 }
 
+func TestValidHostname(t *testing.T) {
+	tests := []struct {
+		hostname string
+		wantErr  string
+	}{
+		{"example", ""},
+		{"example.com", ""},
+		{" example", `must start with a letter or number`},
+		{"example-.com", `must end with a letter or number`},
+		{strings.Repeat("a", 63), ""},
+		{strings.Repeat("a", 64), `is too long, max length is 63 bytes`},
+		{strings.Repeat(strings.Repeat("a", 63)+".", 4), "is too long to be a DNS name"},
+		{"www.what🤦lol.example.com", "contains invalid character"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.hostname, func(t *testing.T) {
+			err := ValidHostname(test.hostname)
+			if (err == nil) != (test.wantErr == "") || (err != nil && !strings.Contains(err.Error(), test.wantErr)) {
+				t.Fatalf("ValidHostname(%s)=%v; expected %v", test.hostname, err, test.wantErr)
+			}
+		})
+	}
+}
+
 var sinkFQDN FQDN
 
 func BenchmarkToFQDN(b *testing.B) {


### PR DESCRIPTION
In addition to checking the total length, enforce the 63-char limit on the first label. Use limits documented in RFC 1035.

Updates https://github.com/tailscale/corp/issues/10012