### PR TITLE
scripts/installer.sh: check Photon OS version with pkg server.

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -316,7 +316,7 @@ main() {
 	# versions we support?
 	OS_UNSUPPORTED=
 	case "$OS" in
-		ubuntu|debian|raspbian|centos|oracle|rhel|amazon-linux|opensuse)
+		ubuntu|debian|raspbian|centos|oracle|rhel|amazon-linux|opensuse|photon)
 			# Check with the package server whether a given version is supported.
 			URL="https://pkgs.tailscale.com/$TRACK/$OS/$VERSION/installer-supported"
 			$CURL "$URL" 2> /dev/null | grep -q OK || OS_UNSUPPORTED=1
@@ -349,13 +349,6 @@ main() {
 			;;
 		openbsd)
 			OS_UNSUPPORTED=1
-			;;
-		photon)
-			if [ "$VERSION" != "3" ] && \
-			   [ "$VERSION" != "4" ]
-			then
-				OS_UNSUPPORTED=1
-			fi
 			;;
 		macos)
 			# We delegate macOS installation to the app store, it will


### PR DESCRIPTION
Photon OS support crossed streams with using pkgserve to check for supported versions 6f9aed1656d0d9ff1a22ed6a022120c6a4f43688. Make Photon OS also rely on pkgserve.

Updates https://github.com/tailscale/tailscale/issues/7651 Updates https://github.com/tailscale/corp/issues/8952