### PR TITLE
derp: Track flows internally

### DIFF
--- a/cmd/derper/derper.go
+++ b/cmd/derper/derper.go
@@ -217,6 +217,7 @@ func main() {
 		}
 	}))
 	debug.Handle("traffic", "Traffic check", http.HandlerFunc(s.ServeDebugTraffic))
+	debug.Handle("flows", "Flows", http.HandlerFunc(s.ServeDebugFlows))
 
 	if *runSTUN {
 		go serveSTUN(listenHost, *stunPort)

--- a/cmd/derper/derper.go
+++ b/cmd/derper/derper.go
@@ -219,6 +219,8 @@ func main() {
 	debug.Handle("traffic", "Traffic check", http.HandlerFunc(s.ServeDebugTraffic))
 	debug.Handle("flows", "Flows", http.HandlerFunc(s.ServeDebugFlows))
 
+	go s.CleanFlows()
+
 	if *runSTUN {
 		go serveSTUN(listenHost, *stunPort)
 	}


### PR DESCRIPTION
The derp server should track stats on flows between src/dst public keys and make them available in some way. This is a bare bones initial pass that does the absolute minimum and only for locally connected destinations, intended for discussion only.

Updates #3560