### PR TITLE
tsnet,wgenegine/netstack: add test and fix resource leaks

### DIFF
--- a/tsnet/tsnet_test.go
+++ b/tsnet/tsnet_test.go
@@ -34,6 +34,7 @@ import (
 	"tailscale.com/ipn/store/mem"
 	"tailscale.com/net/netns"
 	"tailscale.com/tailcfg"
+	"tailscale.com/tstest"
 	"tailscale.com/tstest/integration"
 	"tailscale.com/tstest/integration/testcontrol"
 	"tailscale.com/types/logger"
@@ -223,6 +224,7 @@ func startServer(t *testing.T, ctx context.Context, controlURL, hostname string)
 }
 
 func TestConn(t *testing.T) {
+	tstest.ResourceCheck(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -280,6 +282,7 @@ func TestConn(t *testing.T) {
 }
 
 func TestLoopbackLocalAPI(t *testing.T) {
+	tstest.ResourceCheck(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 

--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -222,6 +222,7 @@ func Create(logf logger.Logf, tundev *tstun.Wrapper, e wgengine.Engine, mc *magi
 func (ns *Impl) Close() error {
 	ns.ctxCancel()
 	ns.ipstack.Close()
+	ns.ipstack.Wait()
 	return nil
 }
 


### PR DESCRIPTION
We were not closing the http.Server and were also not waiting for netstack to fully close.