### PR TITLE
cmd/derper: disable http2

### DIFF
--- a/cmd/derper/cert.go
+++ b/cmd/derper/cert.go
@@ -81,7 +81,7 @@ func (m *manualCertManager) TLSConfig() *tls.Config {
 	return &tls.Config{
 		Certificates: nil,
 		NextProtos: []string{
-			"h2", "http/1.1", // enable HTTP/2
+			"http/1.1",
 		},
 		GetCertificate: m.getCertificate,
 	}


### PR DESCRIPTION
The Go DERP client doesn't support HTTP/2. If an HTTP/2 proxy was placed in front of a DERP server requests will fail.

It wasn't clear to me why this was enabled, and it felt inappropriate to add HTTP/2 support to all of DERP.