### PR TITLE
util/codegen: add -copyright to control presence of copyright headers

### DIFF
--- a/util/codegen/codegen.go
+++ b/util/codegen/codegen.go
@@ -6,6 +6,7 @@ package codegen
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
 	"go/ast"
 	"go/token"
@@ -19,6 +20,8 @@ import (
 	"golang.org/x/tools/imports"
 	"tailscale.com/util/mak"
 )
+
+var flagCopyright = flag.Bool("copyright", true, "add Tailscale copyright to generated file headers")
 
 // LoadTypes returns all named types in pkgName, keyed by their type name.
 func LoadTypes(buildTags string, pkgName string) (*packages.Package, map[string]*types.Named, error) {
@@ -104,7 +107,9 @@ func (it *ImportTracker) Write(w io.Writer) {
 }
 
 func writeHeader(w io.Writer, tool, pkg string) {
-	fmt.Fprint(w, copyrightHeader)
+	if *flagCopyright {
+		fmt.Fprint(w, copyrightHeader)
+	}
 	fmt.Fprintf(w, genAndPackageHeader, tool, pkg)
 }
 


### PR DESCRIPTION
I took the simple approach of declaring a flag directly in the codegen package, rather than threading it through (as a bool param, yuck) in two places.

I also opted for a bool rather than anything more complicated: The header contains a copyright holder and a license indicator, and trying to model all of that in flags was going to get ugly. (Multiple flags? Read from a file?)

I'm happy to alter either of those choices if you prefer, though.

Fixes #7702

Oh and btw, looks like the fallback dns server file could use regeneration.
