### PR TITLE
kube: use system dialer

### DIFF
--- a/kube/client.go
+++ b/kube/client.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"tailscale.com/net/tsdial"
 	"tailscale.com/util/multierr"
 )
 
@@ -76,6 +77,7 @@ func New() (*Client, error) {
 		ns:  string(ns),
 		client: &http.Client{
 			Transport: &http.Transport{
+				DialContext: (&tsdial.Dialer{}).SystemDial,
 				TLSClientConfig: &tls.Config{
 					RootCAs: cp,
 				},


### PR DESCRIPTION
Requests to the Kubernetes API are currently routed through the exit node and timeout. Tailscale instead needs to connect directly to the Kubernetes API using a system dialer.

Fixes #7695