### PR TITLE
ipn/store: add support for stores to hook into a custom dialer

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -276,6 +276,9 @@ func NewLocalBackend(logf logger.Logf, logID logid.PublicID, store ipn.StateStor
 	if err != nil {
 		return nil, err
 	}
+	if sds, ok := store.(ipn.StateStoreDialerSetter); ok {
+		sds.SetDialer(dialer.SystemDial)
+	}
 
 	hi := hostinfo.New()
 	logf.JSON(1, "Hostinfo", hi)

--- a/ipn/store.go
+++ b/ipn/store.go
@@ -4,8 +4,10 @@
 package ipn
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"net"
 	"strconv"
 )
 
@@ -70,6 +72,12 @@ type StateStore interface {
 	ReadState(id StateKey) ([]byte, error)
 	// WriteState saves bs as the state associated with ID.
 	WriteState(id StateKey, bs []byte) error
+}
+
+// StateStoreDialerSetter is an optional interface that StateStores
+// can implement to allow the caller to set a custom dialer.
+type StateStoreDialerSetter interface {
+	SetDialer(d func(ctx context.Context, network, address string) (net.Conn, error))
 }
 
 // ReadStoreInt reads an integer from a StateStore.

--- a/ipn/store/kubestore/store_kube.go
+++ b/ipn/store/kubestore/store_kube.go
@@ -7,6 +7,7 @@ package kubestore
 
 import (
 	"context"
+	"net"
 	"strings"
 	"time"
 
@@ -31,6 +32,10 @@ func New(_ logger.Logf, secretName string) (*Store, error) {
 		client:     c,
 		secretName: secretName,
 	}, nil
+}
+
+func (s *Store) SetDialer(d func(ctx context.Context, network, address string) (net.Conn, error)) {
+	s.client.SetDialer(d)
 }
 
 func (s *Store) String() string { return "kube.Store" }

--- a/kube/client.go
+++ b/kube/client.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -88,6 +89,12 @@ func New() (*Client, error) {
 // This is used only for testing.
 func (c *Client) SetURL(url string) {
 	c.url = url
+}
+
+// SetDialer sets the dialer to use when establishing a connection
+// to the Kubernetes API server.
+func (c *Client) SetDialer(dialer func(ctx context.Context, network, addr string) (net.Conn, error)) {
+	c.client.Transport.(*http.Transport).DialContext = dialer
 }
 
 func (c *Client) expireToken() {


### PR DESCRIPTION
For stores like k8s secrets we need to dial out to the k8s API as though Tailscale wasn't running. The issue currently only manifests when you try to use an exit node while running inside a k8s cluster and are trying to use Kubernetes secrets as the backing store.

This doesn't address cmd/containerboot, which I'll do in a follow up.

Updates #7695

cc @uhthomas