### PR TITLE
cmd/tailscale/cli: make serve and funnel visible in list

### DIFF
--- a/cmd/tailscale/cli/cli.go
+++ b/cmd/tailscale/cli/cli.go
@@ -120,6 +120,8 @@ change in the future.
 			pingCmd,
 			ncCmd,
 			sshCmd,
+			funnelCmd,
+			serveCmd,
 			versionCmd,
 			webCmd,
 			fileCmd,
@@ -147,10 +149,6 @@ change in the future.
 	switch {
 	case slices.Contains(args, "debug"):
 		rootCmd.Subcommands = append(rootCmd.Subcommands, debugCmd)
-	case slices.Contains(args, "funnel"):
-		rootCmd.Subcommands = append(rootCmd.Subcommands, funnelCmd)
-	case slices.Contains(args, "serve"):
-		rootCmd.Subcommands = append(rootCmd.Subcommands, serveCmd)
 	case slices.Contains(args, "update"):
 		rootCmd.Subcommands = append(rootCmd.Subcommands, updateCmd)
 	}

--- a/cmd/tailscale/cli/funnel.go
+++ b/cmd/tailscale/cli/funnel.go
@@ -29,7 +29,7 @@ var funnelCmd = newFunnelCommand(&serveEnv{lc: &localClient})
 func newFunnelCommand(e *serveEnv) *ffcli.Command {
 	return &ffcli.Command{
 		Name:      "funnel",
-		ShortHelp: "[BETA] turn Tailscale Funnel on or off",
+		ShortHelp: "Turn on/off Funnel service",
 		ShortUsage: strings.TrimSpace(`
 funnel <serve-port> {on|off}
   funnel status [--json]

--- a/cmd/tailscale/cli/serve.go
+++ b/cmd/tailscale/cli/serve.go
@@ -33,7 +33,7 @@ var serveCmd = newServeCommand(&serveEnv{lc: &localClient})
 func newServeCommand(e *serveEnv) *ffcli.Command {
 	return &ffcli.Command{
 		Name:      "serve",
-		ShortHelp: "[BETA] Serve from your Tailscale node",
+		ShortHelp: "Serve content and local servers",
 		ShortUsage: strings.TrimSpace(`
 serve https:<port> <mount-point> <source> [off]
   serve tcp:<port> tcp://localhost:<local-port> [off]


### PR DESCRIPTION
Make serve and visible in the command list. Should've been done when they moved to
beta in v1.38.3.

Updates: #7613
