### PR TITLE
cmd/tsconnect: allow root directory to be passed in

### DIFF
--- a/cmd/tsconnect/common.go
+++ b/cmd/tsconnect/common.go
@@ -71,6 +71,9 @@ func commonSetup(dev bool) (*esbuild.BuildOptions, error) {
 }
 
 func findRepoRoot() (string, error) {
+	if *rootDir != "" {
+		return *rootDir, nil
+	}
 	cwd, err := os.Getwd()
 	if err != nil {
 		return "", err

--- a/cmd/tsconnect/tsconnect.go
+++ b/cmd/tsconnect/tsconnect.go
@@ -23,6 +23,7 @@ var (
 	yarnPath        = flag.String("yarnpath", "../../tool/yarn", "path yarn executable used to install JavaScript dependencies")
 	fastCompression = flag.Bool("fast-compression", false, "Use faster compression when building, to speed up build time. Meant to iterative/debugging use only.")
 	devControl      = flag.String("dev-control", "", "URL of a development control server to be used with dev. If provided without specifying dev, an error will be returned.")
+	rootDir         = flag.String("rootdir", "", "Root directory of repo. If not specified, will be inferred from the cwd.")
 )
 
 func main() {


### PR DESCRIPTION
#7339 changed the root directory logic to find the ancestor of the cwd with a go.mod file. This works when running the the binary from this repo directly, but breaks when we're a dependency in another repo.

Allow the directory to be passed in via a `-rootdir` flag (the repo that depends on it can then use `go list -m -f '{{.Dir}}' tailscale.com` or similar to pass in the value).

Updates tailscale/corp#10165