### PR TITLE
client/tailscale: Fix NPE caused by erroneous close in error case

### DIFF
--- a/client/tailscale/localclient.go
+++ b/client/tailscale/localclient.go
@@ -1101,7 +1101,6 @@ func (lc *LocalClient) StreamDebugCapture(ctx context.Context) (io.ReadCloser, e
 	}
 	res, err := lc.doLocalRequestNiceError(req)
 	if err != nil {
-		res.Body.Close()
 		return nil, err
 	}
 	if res.StatusCode != 200 {


### PR DESCRIPTION
Fixes https://github.com/tailscale/tailscale/issues/7572

When handling an error during `StreamDebugCapture`, the response body is closed, even though the response struct is always nil. Thanks to https://github.com/darkrain42 for debugging this!!