### PR TITLE
atomicfile: only run test on Linux.

### DIFF
--- a/atomicfile/atomicfile_test.go
+++ b/atomicfile/atomicfile_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build !js && !windows
+//go:build linux
 
 package atomicfile
 


### PR DESCRIPTION
macOS doesn't like the test, in the setup where it creates a unix-domain socket:
```
atomicfile_test.go:27: listen unix
/var/folders/_2/42v283xx1xgbjdbyvhlm13hc0000gp/T/TestDoesNotOverwriteIrregularFiles1507752327/001/special:
bind: invalid argument
```

I think at this point we should assume the socket
as written in the test only works on Linux.

Updates #7658