### PR TITLE
ipn/localapi: require only read permission for WatchIPNBus

### DIFF
--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -930,8 +930,8 @@ func InUseOtherUserIPNStream(w http.ResponseWriter, r *http.Request, err error) 
 }
 
 func (h *Handler) serveWatchIPNBus(w http.ResponseWriter, r *http.Request) {
-	if !h.PermitWrite {
-		http.Error(w, "denied", http.StatusForbidden)
+	if !h.PermitRead {
+		http.Error(w, "watch ipn bus access denied", http.StatusForbidden)
 		return
 	}
 	f, ok := w.(http.Flusher)


### PR DESCRIPTION
Allow calls to `WatchIPNBus` to be permformed by clients with Readonly permissions. This brings it in line with the permissions required for `Status`, which also exposes the similar information.

This allows clients to get realtime updates about the tailnet in their own applications, without needing to actively poll the `Status` endpoint.

Fixes https://github.com/tailscale/tailscale/issues/7797