### PR TITLE
util/clientmetric: allow client metric values to be provided by a function

### DIFF
--- a/util/clientmetric/clientmetric_test.go
+++ b/util/clientmetric/clientmetric_test.go
@@ -72,3 +72,38 @@ func TestEncodeLogTailMetricsDelta(t *testing.T) {
 		t.Errorf("with increments = %q; want %q", got, want)
 	}
 }
+
+func TestDisableDeltas(t *testing.T) {
+	clearMetrics()
+
+	c := NewCounter("foo")
+	c.DisableDeltas()
+	c.Set(123)
+
+	if got, want := EncodeLogTailMetricsDelta(), "N06fooS02f601"; got != want {
+		t.Errorf("first = %q; want %q", got, want)
+	}
+
+	c.Set(456)
+	advanceTime()
+	if got, want := EncodeLogTailMetricsDelta(), "S029007"; got != want {
+		t.Errorf("second = %q; want %q", got, want)
+	}
+}
+
+func TestWithFunc(t *testing.T) {
+	clearMetrics()
+
+	v := int64(123)
+	NewCounterFunc("foo", func() int64 { return v })
+
+	if got, want := EncodeLogTailMetricsDelta(), "N06fooS02f601"; got != want {
+		t.Errorf("first = %q; want %q", got, want)
+	}
+
+	v = 456
+	advanceTime()
+	if got, want := EncodeLogTailMetricsDelta(), "I029a05"; got != want {
+		t.Errorf("second = %q; want %q", got, want)
+	}
+}


### PR DESCRIPTION
Adds `NewGaugeFunc` and `NewCounterFunc` (inspired by `expvar.Func`), which allow the current value to be reported by a function. This allows some client metric values to be computed on-demand during uploading (at most every 15 seconds), instead of being continuously updated.

clientmetric uploading had a bunch of micro-optimizations for memory access (#3331) which are not possible with this approach. However, any performance hit from function-based metrics is contained to those metrics only, and we expect to have very few.

Also adds a `DisableDeltas()` option for client metrics, so that absolute values are always reported. This makes server-side processing of some metrics easier to reason about.

Updates tailscale/corp#9230