### PR TITLE
ipn/ipnlocal: more explicitly say if sockstats are not available

### DIFF
--- a/ipn/ipnlocal/peerapi.go
+++ b/ipn/ipnlocal/peerapi.go
@@ -865,6 +865,11 @@ func (h *peerAPIHandler) handleServeSockStats(w http.ResponseWriter, r *http.Req
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	fmt.Fprintln(w, "<!DOCTYPE html><h1>Socket Stats</h1>")
 
+	if !sockstats.IsAvailable {
+		fmt.Fprintln(w, "Socket stats are not available for this client")
+		return
+	}
+
 	stats, interfaceStats, validation := sockstats.Get(), sockstats.GetInterfaces(), sockstats.GetValidation()
 	if stats == nil {
 		fmt.Fprintln(w, "No socket stats available")


### PR DESCRIPTION
Makes it more apparent in the PeerAPI endpoint that the client was not built with the appropriate toolchain or build tags.

Updates tailscale/corp#9230