### PR TITLE
ipn/ipnlocal: check that sockstatLogger is available in c2n endpoint

### DIFF
--- a/ipn/ipnlocal/c2n.go
+++ b/ipn/ipnlocal/c2n.go
@@ -89,6 +89,10 @@ func (b *LocalBackend) handleC2N(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.Header().Set("Content-Type", "text/plain")
+		if b.sockstatLogger == nil {
+			http.Error(w, "no sockstatLogger", http.StatusInternalServerError)
+			return
+		}
 		b.sockstatLogger.Flush()
 		fmt.Fprintln(w, b.sockstatLogger.LogID())
 	default:


### PR DESCRIPTION
Otherwise there may be a panic if it's nil (and the control side of the c2n call will just time out).