### PR TITLE
.github/workflows: run one set of tests with the tailscale_go build tag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -235,6 +235,15 @@ jobs:
         ./tool/go run ./cmd/tsconnect --fast-compression build
         ./tool/go run ./cmd/tsconnect --fast-compression build-pkg
 
+  tailscale_go: # Subset of tests that depend on our custom Go toolchain.
+    runs-on: ubuntu-22.04
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3
+    - name: test tailscale_go
+      run: ./tool/go test -tags=tailscale_go,ts_enable_sockstats ./net/sockstats/...
+
+
   fuzz:
     # This target periodically breaks (see TS_FUZZ_CURRENTLY_BROKEN at the top
     # of the file), so it's more complex than usual: the 'build fuzzers' step
@@ -372,6 +381,7 @@ jobs:
       - cross
       - ios
       - wasm
+      - tailscale_go
       - fuzz
       - depaware
       - go_generate
@@ -416,6 +426,7 @@ jobs:
       - cross
       - ios
       - wasm
+      - tailscale_go
       - fuzz
       - depaware
       - go_generate

--- a/net/sockstats/sockstats_noop.go
+++ b/net/sockstats/sockstats_noop.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build !tailscale_go || !(darwin || ios || android)
+//go:build !tailscale_go || !(darwin || ios || android || ts_enable_sockstats)
 
 package sockstats
 

--- a/net/sockstats/sockstats_tsgo.go
+++ b/net/sockstats/sockstats_tsgo.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build tailscale_go && (darwin || ios || android)
+//go:build tailscale_go && (darwin || ios || android || ts_enable_sockstats)
 
 package sockstats
 

--- a/net/sockstats/sockstats_tsgo_test.go
+++ b/net/sockstats/sockstats_tsgo_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build tailscale_go && (darwin || ios || android)
+//go:build tailscale_go && (darwin || ios || android || ts_enable_sockstats)
 
 package sockstats
 
@@ -24,9 +24,9 @@ func (t *testTime) Add(d time.Duration) {
 
 func TestRadioMonitor(t *testing.T) {
 	tests := []struct {
-		name string
+		name     string
 		activity func(*testTime, *radioMonitor)
-		want int64
+		want     int64
 	}{
 		{
 			"no activity",


### PR DESCRIPTION
We use it to gate code that depends on custom Go toolchain, but it's currently only passed in the corp runners. Add a set on OSS so that we can catch regressions earlier.
    
To specifically test `sockstats` this required adding a build tag to explicitly enable them -- they're normally on for iOS, macOS and Android only, and we don't run tests on those platforms normally.