### PR TITLE
net/netcheck: use dnscache.Resolver when resolving DERP IPs

### DIFF
--- a/cmd/tailscale/cli/netcheck.go
+++ b/cmd/tailscale/cli/netcheck.go
@@ -48,6 +48,7 @@ func runNetcheck(ctx context.Context, args []string) error {
 	c := &netcheck.Client{
 		UDPBindAddr: envknob.String("TS_DEBUG_NETCHECK_UDP_BIND"),
 		PortMapper:  portmapper.NewClient(logger.WithPrefix(log.Printf, "portmap: "), nil, nil),
+		UseDNSCache: false, // always resolve, don't cache
 	}
 	if netcheckArgs.verbose {
 		c.Logf = logger.WithPrefix(log.Printf, "netcheck: ")

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -660,6 +660,7 @@ func NewConn(opts Options) (*Conn, error) {
 		GetSTUNConn6:        func() netcheck.STUNConn { return &c.pconn6 },
 		SkipExternalNetwork: inTest(),
 		PortMapper:          c.portMapper,
+		UseDNSCache:         true,
 	}
 
 	c.ignoreSTUNPackets()


### PR DESCRIPTION
This also adds a bunch of tests for this function to ensure that we're returning the proper IP(s) in all cases.

Change-Id: I0d9d57170dbab5f2bf07abdf78ecd17e0e635399