### PR TITLE
.github/workflows: add artifact caching and remove double build on race

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,14 +46,30 @@ jobs:
         include:
           - goarch: amd64
           - goarch: amd64
-            variant: race
+            buildflags: "-race"
           - goarch: "386" # thanks yaml
     runs-on: ubuntu-22.04
     steps:
     - name: checkout
       uses: actions/checkout@v3
+    - name: Restore Cache
+      uses: actions/cache@v3
+      with:
+        # Note: unlike the other setups, this is only grabbing the mod download
+        # cache, rather than the whole mod directory, as the download cache
+        # contains zips that can be unpacked in parallel faster than they can be
+        # fetched and extracted by tar
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod/cache
+          ~\AppData\Local\go-build
+        # The -2- here should be incremented when the scheme of data to be
+        # cached changes (e.g. path above changes).
+        key: ${{ github.job }}-${{ runner.os }}-${{ matrix.goarch }}-${{ matrix.buildflags }}-go-2-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ github.job }}-${{ runner.os }}-${{ matrix.goarch }}-${{ matrix.buildflags }}-go-2-
     - name: build all
-      run: ./tool/go build ./...
+      run: ./tool/go build ${{matrix.buildflags}} ./...
       env:
         GOARCH: ${{ matrix.goarch }}
     - name: build variant CLIs
@@ -73,13 +89,7 @@ jobs:
     - name: build test wrapper
       run: ./tool/go build -o /tmp/testwrapper ./cmd/testwrapper
     - name: test all
-      if: matrix.variant != 'race'
-      run: ./tool/go test -exec=/tmp/testwrapper -bench=. -benchtime=1x ./...
-      env:
-        GOARCH: ${{ matrix.goarch }}
-    - name: test all (race)
-      if: matrix.variant == 'race'
-      run: ./tool/go test -race -exec=/tmp/testwrapper -bench=. -benchtime=1x ./...
+      run: ./tool/go test ${{matrix.buildflags}} -exec=/tmp/testwrapper -bench=. -benchtime=1x ./...
       env:
         GOARCH: ${{ matrix.goarch }}
     - name: check that no tracked files changed
@@ -116,12 +126,14 @@ jobs:
         # contains zips that can be unpacked in parallel faster than they can be
         # fetched and extracted by tar
         path: |
+          ~/.cache/go-build
           ~/go/pkg/mod/cache
           ~\AppData\Local\go-build
         # The -2- here should be incremented when the scheme of data to be
         # cached changes (e.g. path above changes).
-        # TODO(raggi): add a go version here.
-        key: ${{ runner.os }}-go-2-${{ hashFiles('**/go.sum') }}
+        key: ${{ github.job }}-${{ runner.os }}-go-2-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ github.job }}-${{ runner.os }}-go-2-
     - name: test
       # Don't use -bench=. -benchtime=1x.
       # Somewhere in the layers (powershell?)
@@ -181,6 +193,22 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v3
+    - name: Restore Cache
+      uses: actions/cache@v3
+      with:
+        # Note: unlike the other setups, this is only grabbing the mod download
+        # cache, rather than the whole mod directory, as the download cache
+        # contains zips that can be unpacked in parallel faster than they can be
+        # fetched and extracted by tar
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod/cache
+          ~\AppData\Local\go-build
+        # The -2- here should be incremented when the scheme of data to be
+        # cached changes (e.g. path above changes).
+        key: ${{ github.job }}-${{ runner.os }}-${{ matrix.goos }}-${{ matrix.goarch }}-go-2-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ github.job }}-${{ runner.os }}-${{ matrix.goos }}-${{ matrix.goarch }}-go-2-
     - name: build all
       run: ./tool/go build ./cmd/...
       env:
@@ -230,6 +258,22 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v3
+    - name: Restore Cache
+      uses: actions/cache@v3
+      with:
+        # Note: unlike the other setups, this is only grabbing the mod download
+        # cache, rather than the whole mod directory, as the download cache
+        # contains zips that can be unpacked in parallel faster than they can be
+        # fetched and extracted by tar
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod/cache
+          ~\AppData\Local\go-build
+        # The -2- here should be incremented when the scheme of data to be
+        # cached changes (e.g. path above changes).
+        key: ${{ github.job }}-${{ runner.os }}-go-2-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ github.job }}-${{ runner.os }}-go-2-
     - name: build tsconnect client
       run: ./tool/go build ./cmd/tsconnect/wasm ./cmd/tailscale/cli
       env:


### PR DESCRIPTION
Go artifact caching will help provided that the cache remains small enough - we can reuse the strategy from the Windows build where we only cache and pull the zips, but let go(1) do the many-file unpacking as it does so faster.

The race matrix was building once without race, then running all the tests with race, so change the matrix to incldue a `buildflags` parameter and use that both in the build and test steps.

Updates #cleanup