### PR TITLE
safesocket: enable test to run on Windows unpriviliged

### DIFF
--- a/safesocket/basic_test.go
+++ b/safesocket/basic_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 )
 
+// downgradeSDDL is a no-op test helper on non-Windows systems.
+var downgradeSDDL = func() func() { return func() {} }
+
 func TestBasics(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("TODO(#7876): test regressed on windows while CI was broken")
-	}
 	// Make the socket in a temp dir rather than the cwd
 	// so that the test can be run from a mounted filesystem (#2367).
 	dir := t.TempDir()
@@ -22,6 +22,7 @@ func TestBasics(t *testing.T) {
 		sock = filepath.Join(dir, "test")
 	} else {
 		sock = fmt.Sprintf(`\\.\pipe\tailscale-test`)
+		t.Cleanup(downgradeSDDL())
 	}
 
 	l, err := Listen(sock)

--- a/safesocket/pipe_windows.go
+++ b/safesocket/pipe_windows.go
@@ -24,7 +24,8 @@ func setFlags(network, address string, c syscall.RawConn) error {
 
 // windowsSDDL is the Security Descriptor set on the namedpipe.
 // It provides read/write access to all users and the local system.
-const windowsSDDL = "O:BAG:BAD:PAI(A;OICI;GWGR;;;BU)(A;OICI;GWGR;;;SY)"
+// It is a var for testing, do not change this value.
+var windowsSDDL = "O:BAG:BAD:PAI(A;OICI;GWGR;;;BU)(A;OICI;GWGR;;;SY)"
 
 func listen(path string) (net.Listener, error) {
 	lc, err := winio.ListenPipe(

--- a/safesocket/pipe_windows_test.go
+++ b/safesocket/pipe_windows_test.go
@@ -1,0 +1,22 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package safesocket
+
+import "tailscale.com/util/winutil"
+
+func init() {
+	// downgradeSDDL is a test helper that downgrades the windowsSDDL variable if
+	// the currently running user does not have sufficient priviliges to set the
+	// SDDL.
+	downgradeSDDL = func() (cleanup func()) {
+		// The current default descriptor can not be set by mere mortal users,
+		// so we need to undo that for executing tests as a regular user.
+		if !winutil.IsCurrentProcessElevated() {
+			var orig string
+			orig, windowsSDDL = windowsSDDL, ""
+			return func() { windowsSDDL = orig }
+		}
+		return func() {}
+	}
+}


### PR DESCRIPTION
I manually tested that the code path that relaxes pipe permissions is not executed when run with elevated priviliges, and the test also passes in that case.

Updates #7876