### PR TITLE
syncs: relax TestWatchMultipleValues timing on Windows

### DIFF
--- a/syncs/watchdog_test.go
+++ b/syncs/watchdog_test.go
@@ -46,9 +46,6 @@ func TestWatchContended(t *testing.T) {
 }
 
 func TestWatchMultipleValues(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("TODO(#7876): test regressed on windows while CI was broken")
-	}
 	mu := new(sync.Mutex)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // not necessary, but keep vet happy
@@ -68,7 +65,13 @@ func TestWatchMultipleValues(t *testing.T) {
 			cancel()
 		}
 	}
-	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+	// See https://github.com/golang/go/issues/44343 - on Windows the Go runtime timer resolution is currently too coarse. Allow longer in that case.
+	want := 100 * time.Millisecond
+	if runtime.GOOS == "windows" {
+		want = 500 * time.Millisecond
+	}
+
+	if elapsed := time.Since(start); elapsed > want {
 		t.Errorf("expected 1 event per millisecond, got only %v events in %v", n, elapsed)
 	}
 }


### PR DESCRIPTION
The test is re-enabled for Windows with a relaxed time assertion.

On Windows the runtime poller currently does not have sufficient
resolution to meet the normal requirements for this test.

See https://github.com/golang/go/issues/44343 for background.

Updates https://github.com/tailscale/tailscale/issues/7876