### PR TITLE
wgengine/magicsock: reenable magicsock tests on Windows

### DIFF
--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -150,9 +150,6 @@ type magicStack struct {
 // friends. You need to call conn.SetNetworkMap and dev.Reconfig
 // before anything interesting happens.
 func newMagicStack(t testing.TB, logf logger.Logf, l nettype.PacketListener, derpMap *tailcfg.DERPMap) *magicStack {
-	if runtime.GOOS == "windows" {
-		t.Skip("TODO(#7876): test regressed on windows while CI was broken")
-	}
 	privateKey := key.NewNode()
 	return newMagicStackWithKey(t, logf, l, derpMap, privateKey)
 }
@@ -346,9 +343,6 @@ func meshStacks(logf logger.Logf, mutateNetmap func(idx int, nm *netmap.NetworkM
 }
 
 func TestNewConn(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("TODO(#7876): test regressed on windows while CI was broken")
-	}
 	tstest.PanicOnLog()
 	tstest.ResourceCheck(t)
 
@@ -627,9 +621,6 @@ func TestTwoDevicePing(t *testing.T) {
 }
 
 func TestDiscokeyChange(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("TODO(#7876): test regressed on windows while CI was broken")
-	}
 	tstest.PanicOnLog()
 	tstest.ResourceCheck(t)
 
@@ -697,9 +688,6 @@ func TestDiscokeyChange(t *testing.T) {
 }
 
 func TestActiveDiscovery(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("TODO(#7876): test regressed on windows while CI was broken")
-	}
 	t.Run("simple_internet", func(t *testing.T) {
 		t.Parallel()
 		mstun := &natlab.Machine{Name: "stun"}
@@ -2170,9 +2158,6 @@ func newWireguard(t *testing.T, uapi string, aips []netip.Prefix) (*device.Devic
 }
 
 func TestIsWireGuardOnlyPeer(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("TODO(#7876): test regressed on windows while CI was broken")
-	}
 	derpMap, cleanup := runDERPAndStun(t, t.Logf, localhostListener{}, netaddr.IPv4(127, 0, 0, 1))
 	defer cleanup()
 
@@ -2227,9 +2212,6 @@ func TestIsWireGuardOnlyPeer(t *testing.T) {
 }
 
 func TestIsWireGuardOnlyPeerWithMasquerade(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("TODO(#7876): test regressed on windows while CI was broken")
-	}
 	derpMap, cleanup := runDERPAndStun(t, t.Logf, localhostListener{}, netaddr.IPv4(127, 0, 0, 1))
 	defer cleanup()
 


### PR DESCRIPTION
These tests are passing locally and on CI. They had failed earlier in
the day when first fixing up CI, and it is not immediately clear why. I
have cycled IPv6 support locally, but this should not have a substantial
effect.


Updates #7876