### PR TITLE
tsnet: disable TestLoopbackSOCKS5 on Windows

### DIFF
--- a/tsnet/tsnet_test.go
+++ b/tsnet/tsnet_test.go
@@ -24,6 +24,7 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -356,6 +357,10 @@ func TestLoopbackLocalAPI(t *testing.T) {
 }
 
 func TestLoopbackSOCKS5(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TODO(#7876): test regressed on windows while CI was broken")
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 


### PR DESCRIPTION
This test is not regularly passing on CI, but seems to pass reliably locally. Needs deeper debugging.

Updates #7876