### PR TITLE
wgengine/magicsock, types/nettype, etc: finish ReadFromUDPAddrPort netip migration

### DIFF
--- a/net/dns/resolver/forwarder.go
+++ b/net/dns/resolver/forwarder.go
@@ -521,7 +521,7 @@ func (f *forwarder) sendUDP(ctx context.Context, fq *forwardQuery, rr resolverAn
 
 	// The 1 extra byte is to detect packet truncation.
 	out := make([]byte, maxResponseBytes+1)
-	n, _, err := conn.ReadFrom(out)
+	n, _, err := conn.ReadFromUDPAddrPort(out)
 	if err != nil {
 		if err := ctx.Err(); err != nil {
 			return nil, err

--- a/types/nettype/nettype.go
+++ b/types/nettype/nettype.go
@@ -30,11 +30,11 @@ func (Std) ListenPacket(ctx context.Context, network, address string) (net.Packe
 	return conf.ListenPacket(ctx, network, address)
 }
 
-// PacketConn is a net.PacketConn that's about halfway (as of 2023-04-15)
-// converted to use netip.AddrPort.
+// PacketConn is like a net.PacketConn but uses the newer netip.AddrPort
+// write/read methods.
 type PacketConn interface {
 	WriteToUDPAddrPort([]byte, netip.AddrPort) (int, error)
-	ReadFrom(p []byte) (int, net.Addr, error)
+	ReadFromUDPAddrPort([]byte) (int, netip.AddrPort, error)
 	io.Closer
 	LocalAddr() net.Addr
 	SetDeadline(time.Time) error

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -1801,7 +1801,7 @@ func TestBlockForeverConnUnblocks(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		defer close(done)
-		_, _, err := c.ReadFrom(make([]byte, 1))
+		_, _, err := c.ReadFromUDPAddrPort(make([]byte, 1))
 		done <- err
 	}()
 	time.Sleep(50 * time.Millisecond) // give ReadFrom time to get blocked


### PR DESCRIPTION
So we're staying within the netip.Addr/AddrPort consistently and avoiding allocs/conversions to the legacy net addr types.

Updates #5162
