### PR TITLE
net/dnsfallback: more explicitly pass through logf function

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -534,7 +534,7 @@ func getLocalBackend(ctx context.Context, logf logger.Logf, logID logid.PublicID
 		lb.SetLogFlusher(logPol.Logtail.StartFlush)
 	}
 	if root := lb.TailscaleVarRoot(); root != "" {
-		dnsfallback.SetCachePath(filepath.Join(root, "derpmap.cached.json"))
+		dnsfallback.SetCachePath(filepath.Join(root, "derpmap.cached.json"), logf)
 	}
 	lb.SetDecompressor(func() (controlclient.Decompressor, error) {
 		return smallzstd.NewDecoder(nil)

--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -211,7 +211,7 @@ func NewDirect(opts Options) (*Direct, error) {
 		dnsCache := &dnscache.Resolver{
 			Forward:          dnscache.Get().Forward, // use default cache's forwarder
 			UseLastGood:      true,
-			LookupIPFallback: dnsfallback.Lookup,
+			LookupIPFallback: dnsfallback.Lookup(opts.Logf),
 			Logf:             opts.Logf,
 		}
 		tr := http.DefaultTransport.(*http.Transport).Clone()

--- a/control/controlhttp/client.go
+++ b/control/controlhttp/client.go
@@ -393,7 +393,7 @@ func (a *Dialer) tryURLUpgrade(ctx context.Context, u *url.URL, addr netip.Addr,
 	} else {
 		dns = &dnscache.Resolver{
 			Forward:          dnscache.Get().Forward,
-			LookupIPFallback: dnsfallback.Lookup,
+			LookupIPFallback: dnsfallback.Lookup(a.logf),
 			UseLastGood:      true,
 			Logf:             a.Logf, // not a.logf method; we want to propagate nil-ness
 		}

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1077,7 +1077,7 @@ func (b *LocalBackend) setClientStatus(st controlclient.Status) {
 		b.e.SetDERPMap(st.NetMap.DERPMap)
 
 		// Update our cached DERP map
-		dnsfallback.UpdateCache(st.NetMap.DERPMap)
+		dnsfallback.UpdateCache(st.NetMap.DERPMap, b.logf)
 
 		b.send(ipn.Notify{NetMap: st.NetMap})
 	}

--- a/logpolicy/logpolicy.go
+++ b/logpolicy/logpolicy.go
@@ -711,7 +711,7 @@ func DialContext(ctx context.Context, netw, addr string) (net.Conn, error) {
 	dnsCache := &dnscache.Resolver{
 		Forward:          dnscache.Get().Forward, // use default cache's forwarder
 		UseLastGood:      true,
-		LookupIPFallback: dnsfallback.Lookup,
+		LookupIPFallback: dnsfallback.Lookup(log.Printf),
 	}
 	dialer := dnscache.Dialer(nd.DialContext, dnsCache)
 	c, err = dialer(ctx, netw, addr)

--- a/net/dnsfallback/dnsfallback_test.go
+++ b/net/dnsfallback/dnsfallback_test.go
@@ -24,11 +24,6 @@ func TestGetDERPMap(t *testing.T) {
 }
 
 func TestCache(t *testing.T) {
-	oldlog := logfunc.Load()
-	SetLogger(t.Logf)
-	t.Cleanup(func() {
-		SetLogger(oldlog)
-	})
 	cacheFile := filepath.Join(t.TempDir(), "cache.json")
 
 	// Write initial cache value
@@ -73,7 +68,7 @@ func TestCache(t *testing.T) {
 	cachedDERPMap.Store(nil)
 
 	// Load the cache
-	SetCachePath(cacheFile)
+	SetCachePath(cacheFile, t.Logf)
 	if cm := cachedDERPMap.Load(); !reflect.DeepEqual(initialCache, cm) {
 		t.Fatalf("cached map was %+v; want %+v", cm, initialCache)
 	}
@@ -105,11 +100,6 @@ func TestCache(t *testing.T) {
 }
 
 func TestCacheUnchanged(t *testing.T) {
-	oldlog := logfunc.Load()
-	SetLogger(t.Logf)
-	t.Cleanup(func() {
-		SetLogger(oldlog)
-	})
 	cacheFile := filepath.Join(t.TempDir(), "cache.json")
 
 	// Write initial cache value
@@ -140,7 +130,7 @@ func TestCacheUnchanged(t *testing.T) {
 	cachedDERPMap.Store(nil)
 
 	// Load the cache
-	SetCachePath(cacheFile)
+	SetCachePath(cacheFile, t.Logf)
 	if cm := cachedDERPMap.Load(); !reflect.DeepEqual(initialCache, cm) {
 		t.Fatalf("cached map was %+v; want %+v", cm, initialCache)
 	}
@@ -152,7 +142,7 @@ func TestCacheUnchanged(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	UpdateCache(initialCache)
+	UpdateCache(initialCache, t.Logf)
 	if _, err := os.Stat(cacheFile); !os.IsNotExist(err) {
 		t.Fatalf("got err=%v; expected to not find cache file", err)
 	}
@@ -173,7 +163,7 @@ func TestCacheUnchanged(t *testing.T) {
 	clonedNode.IPv4 = "1.2.3.5"
 	updatedCache.Regions[99].Nodes = append(updatedCache.Regions[99].Nodes, &clonedNode)
 
-	UpdateCache(updatedCache)
+	UpdateCache(updatedCache, t.Logf)
 	if st, err := os.Stat(cacheFile); err != nil {
 		t.Fatalf("could not stat cache file; err=%v", err)
 	} else if !st.Mode().IsRegular() || st.Size() == 0 {

--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -41,7 +41,6 @@ import (
 	"tailscale.com/logpolicy"
 	"tailscale.com/logtail"
 	"tailscale.com/logtail/filch"
-	"tailscale.com/net/dnsfallback"
 	"tailscale.com/net/memnet"
 	"tailscale.com/net/proxymux"
 	"tailscale.com/net/socks5"
@@ -649,25 +648,6 @@ func (s *Server) logf(format string, a ...interface{}) {
 		return
 	}
 	log.Printf(format, a...)
-}
-
-// ReplaceGlobalLoggers will replace any Tailscale-specific package-global
-// loggers with this Server's logger. It returns a function that, when called,
-// will undo any changes made.
-//
-// Note that calling this function from multiple Servers will result in the
-// last call taking all logs; logs are not duplicated.
-func (s *Server) ReplaceGlobalLoggers() (undo func()) {
-	var undos []func()
-
-	oldDnsFallback := dnsfallback.SetLogger(s.logf)
-	undos = append(undos, func() { dnsfallback.SetLogger(oldDnsFallback) })
-
-	return func() {
-		for _, fn := range undos {
-			fn()
-		}
-	}
 }
 
 // printAuthURLLoop loops once every few seconds while the server is still running and


### PR DESCRIPTION
Redoes the approach from #5550 and #7539 to explicitly pass in the `logf` function, instead of having global state that can be overridden.