### PR TITLE
net/netns: don't log errors when we can't get the default route on Darwin

### DIFF
--- a/net/interfaces/interfaces_bsd.go
+++ b/net/interfaces/interfaces_bsd.go
@@ -35,6 +35,10 @@ func defaultRoute() (d DefaultRouteDetails, err error) {
 	return d, nil
 }
 
+// ErrNoGatewayIndexFound is returned by DefaultRouteInterfaceIndex when no
+// default route is found.
+var ErrNoGatewayIndexFound = errors.New("no gateway index found")
+
 // DefaultRouteInterfaceIndex returns the index of the network interface that
 // owns the default route. It returns the first IPv4 or IPv6 default route it
 // finds (it does not prefer one or the other).
@@ -75,7 +79,7 @@ func DefaultRouteInterfaceIndex() (int, error) {
 			return rm.Index, nil
 		}
 	}
-	return 0, errors.New("no gateway index found")
+	return 0, ErrNoGatewayIndexFound
 }
 
 func init() {

--- a/net/netns/netns_darwin.go
+++ b/net/netns/netns_darwin.go
@@ -61,7 +61,12 @@ func getInterfaceIndex(logf logger.Logf, address string) (int, error) {
 	defaultIdx := func() (int, error) {
 		idx, err := interfaces.DefaultRouteInterfaceIndex()
 		if err != nil {
-			logf("[unexpected] netns: DefaultRouteInterfaceIndex: %v", err)
+			// It's somewhat common for there to be no default gateway route
+			// (e.g. on a phone with no connectivity), don't log those errors
+			// since they are expected.
+			if !errors.Is(err, interfaces.ErrNoGatewayIndexFound) {
+				logf("[unexpected] netns: DefaultRouteInterfaceIndex: %v", err)
+			}
 			return -1, err
 		}
 		return idx, nil


### PR DESCRIPTION
It's somewhat common (e.g. when a phone has no reception), and leads to lots of logspam.

Updates #7850