### PR TITLE
net/sockstats: fix calculation of radio power usage

### DIFF
--- a/net/sockstats/sockstats_tsgo_test.go
+++ b/net/sockstats/sockstats_tsgo_test.go
@@ -39,7 +39,7 @@ func TestRadioMonitor(t *testing.T) {
 				rm.active()
 				tt.Add(10 * time.Second)
 			},
-			50, // radio on 5 seconds of every 10 seconds
+			50, // radio on 5 seconds of 10 seconds
 		},
 		{
 			"400 iterations: 2 sec active, 1 min idle",
@@ -49,10 +49,18 @@ func TestRadioMonitor(t *testing.T) {
 					rm.active()
 					tt.Add(1 * time.Second)
 					rm.active()
-					tt.Add(1 * time.Minute)
+					tt.Add(59 * time.Second)
 				}
 			},
 			10, // radio on 6 seconds of every minute
+		},
+		{
+			"activity at end of time window",
+			func(tt *testTime, rm *radioMonitor) {
+				tt.Add(2 * time.Second)
+				rm.active()
+			},
+			50,
 		},
 	}
 


### PR DESCRIPTION
When splitting the radio monitor usage array, we were splitting at `now % 3600` to get values into chronological order.  This caused the value for the final second to be included at the beginning of the ordered slice rather than the end.  If there was activity during that final second, an extra five seconds of high power usage would get recorded in some cases. This could result in a final calculation of greater than 100% usage.

This corrects that by splitting values at `(now+1) % 3600`.

This also simplifies the percentage calculation by always rounding values down, which is sufficient for our usage.