### PR TITLE
net/sockstats: expose debug info

### DIFF
--- a/ipn/ipnlocal/c2n.go
+++ b/ipn/ipnlocal/c2n.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"tailscale.com/envknob"
+	"tailscale.com/net/sockstats"
 	"tailscale.com/tailcfg"
 	"tailscale.com/util/clientmetric"
 	"tailscale.com/util/goroutines"
@@ -94,7 +95,8 @@ func (b *LocalBackend) handleC2N(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		b.sockstatLogger.Flush()
-		fmt.Fprintln(w, b.sockstatLogger.LogID())
+		fmt.Fprintf(w, "logid: %s\n", b.sockstatLogger.LogID())
+		fmt.Fprintf(w, "debug info: %v\n", sockstats.DebugInfo())
 	default:
 		http.Error(w, "unknown c2n path", http.StatusBadRequest)
 	}

--- a/ipn/ipnlocal/peerapi.go
+++ b/ipn/ipnlocal/peerapi.go
@@ -947,6 +947,12 @@ func (h *peerAPIHandler) handleServeSockStats(w http.ResponseWriter, r *http.Req
 	fmt.Fprintln(w, "</tfoot>")
 
 	fmt.Fprintln(w, "</table>")
+
+	fmt.Fprintln(w, "<h2>Debug Info</h2>")
+
+	fmt.Fprintln(w, "<pre>")
+	fmt.Fprintln(w, html.EscapeString(sockstats.DebugInfo()))
+	fmt.Fprintln(w, "</pre>")
 }
 
 type incomingFile struct {

--- a/net/sockstats/sockstats.go
+++ b/net/sockstats/sockstats.go
@@ -119,3 +119,9 @@ type LinkMonitor interface {
 func SetLinkMonitor(lm LinkMonitor) {
 	setLinkMonitor(lm)
 }
+
+// DebugInfo returns a string containing debug information about the tracked
+// statistics.
+func DebugInfo() string {
+	return debugInfo()
+}

--- a/net/sockstats/sockstats_noop.go
+++ b/net/sockstats/sockstats_noop.go
@@ -31,3 +31,7 @@ func getValidation() *ValidationSockStats {
 
 func setLinkMonitor(lm LinkMonitor) {
 }
+
+func debugInfo() string {
+	return ""
+}

--- a/net/sockstats/sockstats_tsgo_test.go
+++ b/net/sockstats/sockstats_tsgo_test.go
@@ -37,9 +37,18 @@ func TestRadioMonitor(t *testing.T) {
 			"active, 10 sec idle",
 			func(tt *testTime, rm *radioMonitor) {
 				rm.active()
-				tt.Add(10 * time.Second)
+				tt.Add(9 * time.Second)
 			},
 			50, // radio on 5 seconds of 10 seconds
+		},
+		{
+			"active, spanning two seconds",
+			func(tt *testTime, rm *radioMonitor) {
+				rm.active()
+				tt.Add(1100 * time.Millisecond)
+				rm.active()
+			},
+			100, // radio on for 2 seconds
 		},
 		{
 			"400 iterations: 2 sec active, 1 min idle",
@@ -57,7 +66,7 @@ func TestRadioMonitor(t *testing.T) {
 		{
 			"activity at end of time window",
 			func(tt *testTime, rm *radioMonitor) {
-				tt.Add(2 * time.Second)
+				tt.Add(1 * time.Second)
 				rm.active()
 			},
 			50,


### PR DESCRIPTION
Exposes some internal state of the sockstats package via the C2N and PeerAPI endpoints, so that it can be used for debugging. For now this includes the estimated radio on percentage and a second-by-second view of the times the radio was active.

Also fixes another off-by-one error in the radio on percentage that was leading to >100% values (if n seconds have passed since we started to monitor, there may be n + 1 possible seconds where the radio could have been on).

Updates tailscale/corp#9230