### PR TITLE
ipn/ipnlocal: handle masquerade addresses in PeerAPI

### DIFF
--- a/net/tsdial/tsdial.go
+++ b/net/tsdial/tsdial.go
@@ -367,6 +367,8 @@ func (d *Dialer) PeerAPIHTTPClient() *http.Client {
 		t := http.DefaultTransport.(*http.Transport).Clone()
 		t.Dial = nil
 		t.DialContext = d.dialPeerAPI
+		// Do not use the environment proxy for PeerAPI.
+		t.Proxy = nil
 		d.peerClient = &http.Client{Transport: t}
 	})
 	return d.peerClient

--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -601,7 +601,15 @@ func TestNATPing(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			if err := n1.Tailscale("ping", "-peerapi", tc.n1SeesN2IP.String()).Run(); err != nil {
+				t.Fatal(err)
+			}
+
 			if err := n2.Tailscale("ping", tc.n2SeesN1IP.String()).Run(); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := n2.Tailscale("ping", "-peerapi", tc.n2SeesN1IP.String()).Run(); err != nil {
 				t.Fatal(err)
 			}
 		})


### PR DESCRIPTION
Without this, the peer fails to do anything over the PeerAPI if it
has a masquerade address.

```
Apr 19 13:58:15 hydrogen tailscaled[6696]: peerapi: invalid request from <ip>:58334: 100.64.0.1/32 not found in self addresses
```

Updates #8020