### PR TITLE
ssh/tailssh: handle dialing multiple recorders and failing open 

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -97,7 +97,8 @@ type CapabilityVersion int
 //   - 58: 2023-03-10: Client retries lite map updates before restarting map poll.
 //   - 59: 2023-03-16: Client understands Peers[].SelfNodeV4MasqAddrForThisPeer
 //   - 60: 2023-04-06: Client understands IsWireGuardOnly
-const CurrentCapabilityVersion CapabilityVersion = 60
+//   - 61: 2023-04-18: Client understand SSHAction.SSHRecorderFailureAction
+const CurrentCapabilityVersion CapabilityVersion = 61
 
 type StableID string
 

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -398,6 +398,10 @@ func (src *SSHAction) Clone() *SSHAction {
 	dst := new(SSHAction)
 	*dst = *src
 	dst.Recorders = append(src.Recorders[:0:0], src.Recorders...)
+	if dst.OnRecordingFailure != nil {
+		dst.OnRecordingFailure = new(SSHRecorderFailureAction)
+		*dst.OnRecordingFailure = *src.OnRecordingFailure
+	}
 	return dst
 }
 
@@ -411,6 +415,7 @@ var _SSHActionCloneNeedsRegeneration = SSHAction(struct {
 	HoldAndDelegate          string
 	AllowLocalPortForwarding bool
 	Recorders                []netip.AddrPort
+	OnRecordingFailure       *SSHRecorderFailureAction
 }{})
 
 // Clone makes a deep copy of SSHPrincipal.

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -939,6 +939,13 @@ func (v SSHActionView) AllowAgentForwarding() bool             { return v.ж.All
 func (v SSHActionView) HoldAndDelegate() string                { return v.ж.HoldAndDelegate }
 func (v SSHActionView) AllowLocalPortForwarding() bool         { return v.ж.AllowLocalPortForwarding }
 func (v SSHActionView) Recorders() views.Slice[netip.AddrPort] { return views.SliceOf(v.ж.Recorders) }
+func (v SSHActionView) OnRecordingFailure() *SSHRecorderFailureAction {
+	if v.ж.OnRecordingFailure == nil {
+		return nil
+	}
+	x := *v.ж.OnRecordingFailure
+	return &x
+}
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _SSHActionViewNeedsRegeneration = SSHAction(struct {
@@ -950,6 +957,7 @@ var _SSHActionViewNeedsRegeneration = SSHAction(struct {
 	HoldAndDelegate          string
 	AllowLocalPortForwarding bool
 	Recorders                []netip.AddrPort
+	OnRecordingFailure       *SSHRecorderFailureAction
 }{})
 
 // View returns a readonly view of SSHPrincipal.


### PR DESCRIPTION
This adds support to try dialing out to multiple recorders each
with a 5s timeout and an overall 30s timeout. It also starts respecting
the actions `OnRecordingFailure` field if set, if it is not set
it fails open.

Updates https://github.com/tailscale/corp/issues/9967

Signed-off-by: Maisem Ali <maisem@tailscale.com>