### PR TITLE
tailcfg: add CanPort80 field to DERPNode

### DIFF
--- a/tailcfg/derpmap.go
+++ b/tailcfg/derpmap.go
@@ -142,6 +142,10 @@ type DERPNode struct {
 	// STUNTestIP is used in tests to override the STUN server's IP.
 	// If empty, it's assumed to be the same as the DERP server.
 	STUNTestIP string `json:",omitempty"`
+
+	// CanPort80 specifies whether this DERP node is accessible over HTTP
+	// on port 80 specifically. This is used for captive portal checks.
+	CanPort80 bool `json:",omitempty"`
 }
 
 // DotInvalid is a fake DNS TLD used in tests for an invalid hostname.

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -353,6 +353,7 @@ var _DERPNodeCloneNeedsRegeneration = DERPNode(struct {
 	DERPPort         int
 	InsecureForTests bool
 	STUNTestIP       string
+	CanPort80        bool
 }{})
 
 // Clone makes a deep copy of SSHRule.

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -802,6 +802,7 @@ func (v DERPNodeView) STUNOnly() bool         { return v.ж.STUNOnly }
 func (v DERPNodeView) DERPPort() int          { return v.ж.DERPPort }
 func (v DERPNodeView) InsecureForTests() bool { return v.ж.InsecureForTests }
 func (v DERPNodeView) STUNTestIP() string     { return v.ж.STUNTestIP }
+func (v DERPNodeView) CanPort80() bool        { return v.ж.CanPort80 }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _DERPNodeViewNeedsRegeneration = DERPNode(struct {
@@ -816,6 +817,7 @@ var _DERPNodeViewNeedsRegeneration = DERPNode(struct {
 	DERPPort         int
 	InsecureForTests bool
 	STUNTestIP       string
+	CanPort80        bool
 }{})
 
 // View returns a readonly view of SSHRule.


### PR DESCRIPTION
A follow-up PR will start using this field after we set it in our production DERPMap.

Updates #7925

Change-Id: Idb41b79e6055dddb8944f79d91ad4a186ace98c7