### PR TITLE
build_dist.sh: make cross-compilation friendly for env CC specified

### DIFF
--- a/build_dist.sh
+++ b/build_dist.sh
@@ -16,7 +16,7 @@ if [ -n "${TS_USE_TOOLCHAIN:-}" ]; then
 	go="./tool/go"
 fi
 
-eval `GOOS=$($go env GOHOSTOS) GOARCH=$($go env GOHOSTARCH) $go run ./cmd/mkversion`
+eval `CGO_ENABLED=0 GOOS=$($go env GOHOSTOS) GOARCH=$($go env GOHOSTARCH) $go run ./cmd/mkversion`
 
 if [ "$1" = "shellvars" ]; then
 	cat <<EOF


### PR DESCRIPTION
I'm using tailscale on an openwrt device. Openwrt has its own toolchains so i have to specify `CC` env to openwrt toolchains gcc instead of the one of my host os.
However, `build_dist.sh` runs a `$go run ./cmd/mkversion` and it will fail when `CC` is specified.
I review the logic of mkversion and found it can be run using `CGO_ENABLED=0` to avoid `CC` modification.
