### PR TITLE
syncs: add Map.Len to get the length of the Map

### DIFF
--- a/syncs/syncs.go
+++ b/syncs/syncs.go
@@ -220,6 +220,13 @@ func (m *Map[K, V]) Range(f func(key K, value V) bool) {
 	}
 }
 
+// Len returns the length of the map.
+func (m *Map[K, V]) Len() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.m)
+}
+
 // WaitGroup is identical to [sync.WaitGroup],
 // but provides a Go method to start a goroutine.
 type WaitGroup struct{ sync.WaitGroup }


### PR DESCRIPTION
I need this for a corp change where I have a set as a queue, and make a different decisison if the set is empty.

Updates tailscale/corp#10344