### PR TITLE
.github: test installer script in CI in docker

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -1,0 +1,102 @@
+name: test installer.sh
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - scripts/installer.sh
+  pull_request:
+    branches:
+      - "*"
+    paths:
+      - scripts/installer.sh
+
+jobs:
+  test:
+    strategy:
+      # Don't abort the entire matrix if one element fails.
+      fail-fast: false
+      # Don't start all of these at once, which could saturate Github workers.
+      max-parallel: 4
+      matrix:
+        image:
+          # This is a list of Docker images against which we test our installer.
+          # If you find that some of these no longer exist, please feel free
+          # to remove them from the list.
+          # When adding new images, please only use official ones.
+          - "debian:oldstable-slim"
+          - "debian:stable-slim"
+          - "debian:testing-slim"
+          - "debian:sid-slim"
+          - "ubuntu:18.04"
+          - "ubuntu:20.04"
+          - "ubuntu:22.04"
+          - "ubuntu:22.10"
+          - "ubuntu:23.04"
+          - "elementary/docker:stable"
+          - "elementary/docker:unstable"
+          - "parrotsec/core:lts-amd64"
+          - "parrotsec/core:latest"
+          - "kalilinux/kali-rolling"
+          - "kalilinux/kali-dev"
+          - "oraclelinux:9"
+          - "oraclelinux:8"
+          - "fedora:latest"
+          - "rockylinux:8.7"
+          - "rockylinux:9"
+          - "amazonlinux:latest"
+          - "opensuse/leap:latest"
+          - "opensuse/tumbleweed:latest"
+          - "archlinux:latest"
+          - "alpine:3.14"
+          - "alpine:latest"
+          - "alpine:edge"
+        deps:
+          # Run all images installing curl as a dependency.
+          - curl
+        include:
+          # Check a few images with wget rather than curl.
+          - { image: "debian:oldstable-slim", deps: "wget" }
+          - { image: "debian:sid-slim", deps: "wget" }
+          - { image: "ubuntu:23.04", deps: "wget" }
+          # Ubuntu 16.04 also needs apt-transport-https installed.
+          - { image: "ubuntu:16.04", deps: "curl apt-transport-https" }
+          - { image: "ubuntu:16.04", deps: "wget apt-transport-https" }
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.image }}
+      options: --user root
+    steps:
+    - name: install dependencies (yum)
+      # tar and gzip are needed by the actions/checkout below.
+      run: yum install -y --allowerasing tar gzip ${{ matrix.deps }}
+      if: |
+        contains(matrix.image, 'centos')
+        || contains(matrix.image, 'oraclelinux')
+        || contains(matrix.image, 'fedora')
+        || contains(matrix.image, 'amazonlinux')
+    - name: install dependencies (zypper)
+      # tar and gzip are needed by the actions/checkout below.
+      run: zypper --non-interactive install tar gzip
+      if: contains(matrix.image, 'opensuse')
+    - name: install dependencies (apt-get)
+      run: |
+        apt-get update
+        apt-get install -y ${{ matrix.deps }}
+      if: |
+        contains(matrix.image, 'debian')
+        || contains(matrix.image, 'ubuntu')
+        || contains(matrix.image, 'elementary')
+        || contains(matrix.image, 'parrotsec')
+        || contains(matrix.image, 'kalilinux')
+    - name: checkout
+      uses: actions/checkout@v3
+    - name: run installer
+      run: scripts/installer.sh
+      # Package installation can fail in docker because systemd is not running
+      # as PID 1, so ignore errors at this step. The real check is the
+      # `tailscale --version` command below.
+      continue-on-error: true
+    - name: check tailscale version
+      run: tailscale --version

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -430,7 +430,9 @@ main() {
 
 
 	# Step 4: run the installation.
-	echo "Installing Tailscale for $OS $VERSION, using method $PACKAGETYPE"
+	OSVERSION="$OS"
+	[ "$VERSION" != "" ] && OSVERSION="$OSVERSION $VERSION"
+	echo "Installing Tailscale for $OSVERSION, using method $PACKAGETYPE"
 	case "$PACKAGETYPE" in
 		apt)
 			export DEBIAN_FRONTEND=noninteractive
@@ -469,6 +471,7 @@ main() {
 		;;
 		dnf)
 			set -x
+			$SUDO dnf install -y 'dnf-command(config-manager)'
 			$SUDO dnf config-manager --add-repo "https://pkgs.tailscale.com/$TRACK/$OS/$VERSION/tailscale.repo"
 			$SUDO dnf install -y tailscale
 			$SUDO systemctl enable --now tailscaled
@@ -483,14 +486,15 @@ main() {
 		;;
 		zypper)
 			set -x
-			$SUDO zypper ar -g -r "https://pkgs.tailscale.com/$TRACK/$OS/$VERSION/tailscale.repo"
-			$SUDO zypper ref
-			$SUDO zypper in tailscale
+			$SUDO zypper --non-interactive ar -g -r "https://pkgs.tailscale.com/$TRACK/$OS/$VERSION/tailscale.repo"
+			$SUDO zypper --non-interactive --gpg-auto-import-keys refresh
+			$SUDO zypper --non-interactive install tailscale
 			$SUDO systemctl enable --now tailscaled
 			set +x
 			;;
 		pacman)
 			set -x
+			$SUDO pacman -Sy
 			$SUDO pacman -S tailscale --noconfirm
 			$SUDO systemctl enable --now tailscaled
 			set +x
@@ -510,7 +514,7 @@ main() {
 			;;
 		xbps)
 			set -x
-			$SUDO xbps-install tailscale -y 
+			$SUDO xbps-install tailscale -y
 			set +x
 			;;
 		emerge)


### PR DESCRIPTION
Every time we change `installer.sh`, run it in a few docker containers based on different Linux distros, just as a simple test.

Also includes a few changes to the installer script itself to make installation work in Docker:
- install `dnf config-manager` command before running it
- run `zypper` in non-interactive mode
- update `pacman` indexes before installing packages

Updates https://github.com/tailscale/corp/issues/8952