### PR TITLE
scripts/installer.sh: check connectivity with pkgs.tailscale.com

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -321,6 +321,17 @@ main() {
 		exit 1
 	fi
 
+	TEST_URL="https://pkgs.tailscale.com/"
+	RC=0
+	TEST_OUT=$($CURL "$TEST_URL" 2>&1) || RC=$?
+	if [ $RC != 0 ]; then
+		echo "The installer cannot reach $TEST_URL"
+		echo "Please make sure that your machine has internet access."
+		echo "Test output:"
+		echo $TEST_OUT
+		exit 1
+	fi
+
 	# Step 2: having detected an OS we support, is it one of the
 	# versions we support?
 	OS_UNSUPPORTED=


### PR DESCRIPTION
Installer script relies on pkgs.tailscale.com being reachable, both for checking what Linux distros are supported, but also for actually downloading repo configuration files, gpg keys and packages themselves.

This change adds a simple reachability check which will print an error message when pkgs.tailscale.com is not reachable.

Fixes https://github.com/tailscale/corp/issues/8952