### PR TITLE
control/controlclient: use dnscache.Resolver for Noise client

### DIFF
--- a/control/controlclient/noise_test.go
+++ b/control/controlclient/noise_test.go
@@ -74,7 +74,12 @@ func (tt noiseClientTest) run(t *testing.T) {
 	defer hs.Close()
 
 	dialer := new(tsdial.Dialer)
-	nc, err := NewNoiseClient(clientPrivate, serverPrivate.Public(), hs.URL, dialer, nil, nil, nil)
+	nc, err := NewNoiseClient(NoiseOpts{
+		PrivKey:      clientPrivate,
+		ServerPubKey: serverPrivate.Public(),
+		ServerURL:    hs.URL,
+		Dialer:       dialer,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/control/controlhttp/client.go
+++ b/control/controlhttp/client.go
@@ -374,6 +374,22 @@ func (a *Dialer) dialURL(ctx context.Context, u *url.URL, addr netip.Addr) (*Cli
 	}, nil
 }
 
+// resolver returns a.DNSCache if non-nil or a new *dnscache.Resolver
+// otherwise.
+func (a *Dialer) resolver() *dnscache.Resolver {
+	if a.DNSCache != nil {
+		return a.DNSCache
+	}
+
+	return &dnscache.Resolver{
+		Forward:          dnscache.Get().Forward,
+		LookupIPFallback: dnsfallback.MakeLookupFunc(a.logf, a.NetMon),
+		UseLastGood:      true,
+		Logf:             a.Logf, // not a.logf method; we want to propagate nil-ness
+		NetMon:           a.NetMon,
+	}
+}
+
 // tryURLUpgrade connects to u, and tries to upgrade it to a net.Conn. If addr
 // is valid, then no DNS is used and the connection will be made to the
 // provided address.
@@ -392,13 +408,7 @@ func (a *Dialer) tryURLUpgrade(ctx context.Context, u *url.URL, addr netip.Addr,
 			NetMon:                 a.NetMon,
 		}
 	} else {
-		dns = &dnscache.Resolver{
-			Forward:          dnscache.Get().Forward,
-			LookupIPFallback: dnsfallback.MakeLookupFunc(a.logf, a.NetMon),
-			UseLastGood:      true,
-			Logf:             a.Logf, // not a.logf method; we want to propagate nil-ness
-			NetMon:           a.NetMon,
-		}
+		dns = a.resolver()
 	}
 
 	var dialer dnscache.DialContextFunc

--- a/control/controlhttp/constants.go
+++ b/control/controlhttp/constants.go
@@ -67,6 +67,11 @@ type Dialer struct {
 	// If not specified, this defaults to net.Dialer.DialContext.
 	Dialer dnscache.DialContextFunc
 
+	// DNSCache is the caching Resolver used by this Dialer.
+	//
+	// If not specified, a new Resolver is created per attempt.
+	DNSCache *dnscache.Resolver
+
 	// Logf, if set, is a logging function to use; if unset, logs are
 	// dropped.
 	Logf logger.Logf


### PR DESCRIPTION
This passes the *dnscache.Resolver down from the Direct client into the Noise client and from there into the controlhttp client. This retains the Resolver so that it can share state across calls instead of creating a new resolver.

Updates https://github.com/tailscale/tailscale/issues/4845
Updates https://github.com/tailscale/tailscale/issues/6110

Change-Id: Ia5d6af1870f3b5b5d7dd5685d775dcf300aec7af