### PR TITLE
various: add Unraid detection and direct Taildrop support

### DIFF
--- a/cmd/tailscale/cli/diag.go
+++ b/cmd/tailscale/cli/diag.go
@@ -66,7 +66,7 @@ func isSystemdSystem() bool {
 		return false
 	}
 	switch distro.Get() {
-	case distro.QNAP, distro.Gokrazy, distro.Synology:
+	case distro.QNAP, distro.Gokrazy, distro.Synology, distro.Unraid:
 		return false
 	}
 	_, err := exec.LookPath("systemctl")

--- a/hostinfo/hostinfo_linux.go
+++ b/hostinfo/hostinfo_linux.go
@@ -95,6 +95,8 @@ func linuxVersionMeta() (meta versionMeta) {
 		propFile = "/etc.defaults/VERSION"
 	case distro.OpenWrt:
 		propFile = "/etc/openwrt_release"
+	case distro.Unraid:
+		propFile = "/etc/unraid-version"
 	case distro.WDMyCloud:
 		slurp, _ := os.ReadFile("/etc/version")
 		meta.DistroVersion = string(bytes.TrimSpace(slurp))
@@ -153,6 +155,8 @@ func linuxVersionMeta() (meta versionMeta) {
 		meta.DistroVersion = m["productversion"]
 	case distro.OpenWrt:
 		meta.DistroVersion = m["DISTRIB_RELEASE"]
+	case distro.Unraid:
+		meta.DistroVersion = m["version"]
 	}
 	return
 }

--- a/ipn/ipnlocal/peerapi.go
+++ b/ipn/ipnlocal/peerapi.go
@@ -49,6 +49,7 @@ import (
 	"tailscale.com/tailcfg"
 	"tailscale.com/util/clientmetric"
 	"tailscale.com/util/multierr"
+	"tailscale.com/version/distro"
 	"tailscale.com/wgengine"
 	"tailscale.com/wgengine/filter"
 )
@@ -1088,6 +1089,10 @@ func (h *peerAPIHandler) handlePeerPut(w http.ResponseWriter, r *http.Request) {
 	}
 	if h.ps.rootDir == "" {
 		http.Error(w, errNoTaildrop.Error(), http.StatusInternalServerError)
+		return
+	}
+	if distro.Get() == distro.Unraid && !h.ps.directFileMode {
+		http.Error(w, "Taildrop folder not configured or accessible", http.StatusInternalServerError)
 		return
 	}
 	rawPath := r.URL.EscapedPath()

--- a/version/distro/distro.go
+++ b/version/distro/distro.go
@@ -29,6 +29,7 @@ const (
 	TrueNAS   = Distro("truenas")
 	Gokrazy   = Distro("gokrazy")
 	WDMyCloud = Distro("wdmycloud")
+	Unraid    = Distro("unraid")
 )
 
 var distro lazy.SyncValue[Distro]
@@ -90,6 +91,8 @@ func linuxDistro() Distro {
 		return WDMyCloud
 	case have("/usr/sbin/wd_crontab.sh"): // Western Digital MyCloud OS5
 		return WDMyCloud
+	case have("/etc/unraid-version"):
+		return Unraid
 	}
 	return ""
 }


### PR DESCRIPTION
The community Unraid plugin currently has to "simulate" being a QNAP NAS in order for Taildrop to use the NAS-style functionality (i.e., placing taildropped files directly into a folder on the device). This change adds Unraid as a detected distro and enables direct file mode.

Closes #8025 