### PR TITLE
wgengine/magicsock: annotate, skip flaky TestIsWireGuardOnlyPickEndpointByPing

### DIFF
--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -2422,6 +2422,8 @@ func applyNetworkMap(t *testing.T, m *magicStack, nm *netmap.NetworkMap) {
 }
 
 func TestIsWireGuardOnlyPickEndpointByPing(t *testing.T) {
+	t.Skip("This test is flaky; see https://github.com/tailscale/tailscale/issues/8037")
+
 	clock := &tstest.Clock{}
 	derpMap, cleanup := runDERPAndStun(t, t.Logf, localhostListener{}, netaddr.IPv4(127, 0, 0, 1))
 	defer cleanup()


### PR DESCRIPTION
Updates #8037
Updates #7826