### PR TITLE
 ssh/tailssh: send ssh event notifications on recording failures 

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3627,6 +3627,19 @@ func (b *LocalBackend) hasNodeKey() bool {
 	return p.Valid() && p.Persist().Valid() && !p.Persist().PrivateNodeKey().IsZero()
 }
 
+// NodeKey returns the public node key.
+func (b *LocalBackend) NodeKey() key.NodePublic {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	p := b.pm.CurrentPrefs()
+	if !p.Valid() || !p.Persist().Valid() || p.Persist().PrivateNodeKey().IsZero() {
+		return key.NodePublic{}
+	}
+
+	return p.Persist().PublicNodeKey()
+}
+
 // nextState returns the state the backend seems to be in, based on
 // its internal state.
 func (b *LocalBackend) nextState() ipn.State {

--- a/ssh/tailssh/tailssh_test.go
+++ b/ssh/tailssh/tailssh_test.go
@@ -40,6 +40,7 @@ import (
 	"tailscale.com/tempfork/gliderlabs/ssh"
 	"tailscale.com/tsd"
 	"tailscale.com/tstest"
+	"tailscale.com/types/key"
 	"tailscale.com/types/logger"
 	"tailscale.com/types/logid"
 	"tailscale.com/types/netmap"
@@ -311,6 +312,10 @@ func (ts *localState) DoNoiseRequest(req *http.Request) (*http.Response, error) 
 
 func (ts *localState) TailscaleVarRoot() string {
 	return ""
+}
+
+func (ts *localState) NodeKey() key.NodePublic {
+	return key.NewNode().Public()
 }
 
 func newSSHRule(action *tailcfg.SSHAction) *tailcfg.SSHRule {

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -2075,9 +2075,11 @@ type SSHRecorderFailureAction struct {
 	NotifyURL string `json:",omitempty"`
 }
 
-// SSHRecordingFailureNotifyRequest is the JSON payload sent to the NotifyURL
-// when a recording fails.
-type SSHRecordingFailureNotifyRequest struct {
+// SSHEventNotifyRequest is the JSON payload sent to the NotifyURL
+// for an SSH event.
+type SSHEventNotifyRequest struct {
+	// EventType is the type of notify request being sent.
+	EventType SSHEventType
 	// CapVersion is the client's current CapabilityVersion.
 	CapVersion CapabilityVersion
 
@@ -2093,9 +2095,18 @@ type SSHRecordingFailureNotifyRequest struct {
 	// LocalUser is the user that was resolved from the SSHUser for the local machine.
 	LocalUser string
 
-	// Attempts is the list of recorders that were attempted, in order.
-	Attempts []SSHRecordingAttempt
+	// RecordingAttempts is the list of recorders that were attempted, in order.
+	RecordingAttempts []*SSHRecordingAttempt
 }
+
+// SSHEventType defines the event type linked to a SSH action or state.
+type SSHEventType int
+
+const (
+	UnspecifiedSSHEventType       SSHEventType = 0
+	SSHSessionRecordingRejected   SSHEventType = 1
+	SSHSessionRecordingTerminated SSHEventType = 2
+)
 
 // SSHRecordingAttempt is a single attempt to start a recording.
 type SSHRecordingAttempt struct {

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -98,7 +98,8 @@ type CapabilityVersion int
 //   - 59: 2023-03-16: Client understands Peers[].SelfNodeV4MasqAddrForThisPeer
 //   - 60: 2023-04-06: Client understands IsWireGuardOnly
 //   - 61: 2023-04-18: Client understand SSHAction.SSHRecorderFailureAction
-const CurrentCapabilityVersion CapabilityVersion = 61
+//   - 62: 2023-05-05: Client can notify control over noise for SSHEventNotificationRequest recording failure events
+const CurrentCapabilityVersion CapabilityVersion = 62
 
 type StableID string
 

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -2080,6 +2080,12 @@ type SSHRecorderFailureAction struct {
 type SSHEventNotifyRequest struct {
 	// EventType is the type of notify request being sent.
 	EventType SSHEventType
+
+	// ConnectionID uniquely identifies a connection made to the SSH server.
+	// It may be shared across multiple sessions over the same connection in
+	// case a single connection creates multiple sessions.
+	ConnectionID string
+
 	// CapVersion is the client's current CapabilityVersion.
 	CapVersion CapabilityVersion
 


### PR DESCRIPTION
This change sends an SSHEventNotificationRequest over noise when a
SSH session is set to fail closed and the session is unable to start
because a recorder is not available or a session is terminated because
connection to the recorder is ended. Each of these scenarios have their
own event type.