### PR TITLE
cmd/tailscale: allow Tailscale to work with Unraid web interface

### DIFF
--- a/cmd/tailscale/cli/web.go
+++ b/cmd/tailscale/cli/web.go
@@ -61,6 +61,8 @@ type tmplData struct {
 	TUNMode           bool
 	IsSynology        bool
 	DSMVersion        int // 6 or 7, if IsSynology=true
+	IsUnraid          bool
+	UnraidToken       string
 	IPNVersion        string
 }
 
@@ -441,6 +443,8 @@ func webHandler(w http.ResponseWriter, r *http.Request) {
 		TUNMode:      st.TUN,
 		IsSynology:   distro.Get() == distro.Synology || envknob.Bool("TS_FAKE_SYNOLOGY"),
 		DSMVersion:   distro.DSMVersion(),
+		IsUnraid:     distro.Get() == distro.Unraid,
+		UnraidToken:  os.Getenv("UNRAID_CSRF_TOKEN"),
 		IPNVersion:   versionShort,
 	}
 	exitNodeRouteV4 := netip.MustParsePrefix("0.0.0.0/0")

--- a/cmd/tailscale/cli/web.html
+++ b/cmd/tailscale/cli/web.html
@@ -116,10 +116,12 @@
 	<a class="text-xs text-gray-500 hover:text-gray-600" href="{{ .LicensesURL }}">Open Source Licenses</a>
 </footer>
 <script>(function () {
-const advertiseExitNode = {{.AdvertiseExitNode}};
+const advertiseExitNode = {{ .AdvertiseExitNode }};
+const isUnraid = {{ .IsUnraid }};
+const unraidCsrfToken = "{{ .UnraidToken }}";
 let fetchingUrl = false;
 var data = {
-	AdvertiseRoutes: "{{.AdvertiseRoutes}}",
+	AdvertiseRoutes: "{{ .AdvertiseRoutes }}",
 	AdvertiseExitNode: advertiseExitNode,
 	Reauthenticate: false,
 	ForceLogout: false
@@ -141,15 +143,27 @@ function postData(e) {
 	}
 	const nextUrl = new URL(window.location);
 	nextUrl.search = nextParams.toString()
-	const url = nextUrl.toString();
 
+	let body = JSON.stringify(data);
+	let contentType = "application/json";
+
+	if (isUnraid) {
+		const params = new URLSearchParams();
+		params.append("csrf_token", unraidCsrfToken);
+		params.append("ts_data", JSON.stringify(data));
+
+		body = params.toString();
+		contentType = "application/x-www-form-urlencoded;charset=UTF-8";
+	}
+
+	const url = nextUrl.toString();
 	fetch(url, {
 		method: "POST",
 		headers: {
 			"Accept": "application/json",
-			"Content-Type": "application/json",
+			"Content-Type": contentType,
 		},
-		body: JSON.stringify(data)
+		body: body
 	}).then(res => res.json()).then(res => {
 		fetchingUrl = false;
 		const err = res["error"];
@@ -158,7 +172,11 @@ function postData(e) {
 		}
 		const url = res["url"];
 		if (url) {
-			document.location.href = url;
+			if(isUnraid) {
+				window.open(url, "_blank");
+			} else {
+				document.location.href = url;
+			}
 		} else {
 			location.reload();
 		}


### PR DESCRIPTION
This change allows the Tailscale web interface to be embedded within the Unraid web UI.

Specifically:
- Adds the CSRF token that Unraid requires for all incoming POSTs to the web UI
- Opens authentication pages in a new window (otherwise, security errors occur in the browser)

Closes #8026