### PR TITLE
tsweb/promvarz: fix repeated expvar definition in test

### DIFF
--- a/tsweb/promvarz/promvarz_test.go
+++ b/tsweb/promvarz/promvarz_test.go
@@ -14,11 +14,14 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
+var (
+	testVar1 = expvar.NewInt("gauge_promvarz_test_expvar")
+	testVar2 = promauto.NewGauge(prometheus.GaugeOpts{Name: "promvarz_test_native"})
+)
+
 func TestHandler(t *testing.T) {
-	test1 := expvar.NewInt("gauge_promvarz_test_expvar")
-	test1.Set(42)
-	test2 := promauto.NewGauge(prometheus.GaugeOpts{Name: "promvarz_test_native"})
-	test2.Set(4242)
+	testVar1.Set(42)
+	testVar2.Set(4242)
 
 	svr := httptest.NewServer(http.HandlerFunc(Handler))
 	defer svr.Close()


### PR DESCRIPTION
expvar can only be defined once, so running tests with a repeat counter will fail if the variables are defined inside of the test function.

Observed failure:

```
--- FAIL: TestHandler (0.00s)
panic: Reuse of exported var name: gauge_promvarz_test_expvar
 [recovered]
        panic: Reuse of exported var name: gauge_promvarz_test_expvar

goroutine 9 [running]:
testing.tRunner.func1.2({0x100f267e0, 0x1400026e770})
        /usr/local/go/src/testing/testing.go:1526 +0x1c8
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1529 +0x364
panic({0x100f267e0, 0x1400026e770})
        /usr/local/go/src/runtime/panic.go:884 +0x1f4
log.Panicln({0x140000b8e20?, 0x1a?, 0x1400026e750?})
        /usr/local/go/src/log/log.go:398 +0x60
expvar.Publish({0x100e2b21d, 0x1a}, {0x100fd7a08?, 0x140000232c0})
        /usr/local/go/src/expvar/expvar.go:284 +0xc0
expvar.NewInt(...)
        /usr/local/go/src/expvar/expvar.go:304
tailscale.com/tsweb/promvarz.TestHandler(0x14000082b60)
        /Users/charlotte/ts-src/tailscale/tsweb/promvarz/promvarz_test.go:18 +0x5c
testing.tRunner(0x14000082b60, 0x100fd5858)
        /usr/local/go/src/testing/testing.go:1576 +0x104
created by testing.(*T).Run
        /usr/local/go/src/testing/testing.go:1629 +0x370
FAIL    tailscale.com/tsweb/promvarz    0.149s
```

Fixes https://github.com/tailscale/tailscale/pull/8065