### PR TITLE
fix sys.Set(router) issue will crash the daemon in some OSs

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -649,7 +649,6 @@ func tryEngine(logf logger.Logf, sys *tsd.System, name string) (onlyNetstack boo
 			dev.Close()
 			return false, fmt.Errorf("creating router: %w", err)
 		}
-		sys.Set(r)
 
 		d, err := dns.NewOSConfigurator(logf, devName)
 		if err != nil {
@@ -663,6 +662,8 @@ func tryEngine(logf logger.Logf, sys *tsd.System, name string) (onlyNetstack boo
 			conf.Router = netstack.NewSubnetRouterWrapper(conf.Router)
 			netstackSubnetRouter = true
 		}
+		
+		sys.Set(conf.Router)
 	}
 	e, err := wgengine.NewUserspaceEngine(logf, conf)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Chenyang Gao <gps949@outlook.com>

in commit 6e96744, the tsd system type has been added. Which will cause the daemon will crash on some  OSs (Windows, darwin and so on). The root cause is that on those OSs, handleSubnetsInNetstack() will return true and set the conf.Router with a wrapper.  Later in NewUserspaceEngine() it will do subsystem set and found that early set router mismatch to current value, then panic.