### PR TITLE
ssh/tailssh: add ssh session recording failed event type

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -2110,9 +2110,23 @@ type SSHEventNotifyRequest struct {
 type SSHEventType int
 
 const (
-	UnspecifiedSSHEventType       SSHEventType = 0
-	SSHSessionRecordingRejected   SSHEventType = 1
+	UnspecifiedSSHEventType SSHEventType = 0
+	// SSHSessionRecordingRejected is the event that
+	// defines when a SSH session cannot be started
+	// because no recorder is available for session
+	// recording, and the SSHRecorderFailureAction
+	// RejectSessionWithMessage is not empty.
+	SSHSessionRecordingRejected SSHEventType = 1
+	// SSHSessionRecordingTerminated is the event that
+	// defines when session recording has failed
+	// during the session and the SSHRecorderFailureAction
+	// TerminateSessionWithMessage is not empty.
 	SSHSessionRecordingTerminated SSHEventType = 2
+	// SSHSessionRecordingFailed is the event that
+	// defines when session recording is unavailable and
+	// the SSHRecorderFailureAction RejectSessionWithMessage
+	// or TerminateSessionWithMessage is empty.
+	SSHSessionRecordingFailed SSHEventType = 3
 )
 
 // SSHRecordingAttempt is a single attempt to start a recording.


### PR DESCRIPTION
This change introduces a SSHSessionRecordingFailed event type that is used when a session recording fails to start or fails during a session, and the on failure indicates that it should fail open.

Updates tailscale/corp#9967