### PR TITLE
fix: to get the dirty field of version from vcs.modified value

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -131,7 +131,7 @@ var getEmbeddedInfo = lazy.SyncFunc(func() embeddedInfo {
 				ret.commitDate = strings.ReplaceAll(ret.commitDate, "-", "")
 			}
 		case "vcs.modified":
-			ret.dirty = true
+			ret.dirty = s.Value == "true"
 		}
 	}
 	if ret.commit == "" || ret.commitDate == "" {


### PR DESCRIPTION
Signed-off-by: Chenyang Gao <gps949@outlook.com>

Current code will set the "dirty" field of VersionInfo always "true" if vcs.modified flag is there. No matter whether the flag is "true" or "false".     
It will make sense to set this field due to vcs.modified value, not only the existence of the key.