### PR TITLE
release/dist: add deb/rpm arch mappings for mipses

### DIFF
--- a/release/dist/unixpkgs/pkgs.go
+++ b/release/dist/unixpkgs/pkgs.go
@@ -354,6 +354,10 @@ func debArch(arch string) string {
 		// can ship more than 1 ARM deb, so for now match redo's behavior of
 		// shipping armv5 binaries in an armv7 trenchcoat.
 		return "armhf"
+	case "mipsle":
+		return "mipsel"
+	case "mips64le":
+		return "mips64el"
 	default:
 		return arch
 	}
@@ -372,6 +376,10 @@ func rpmArch(arch string) string {
 		return "armv7hl"
 	case "arm64":
 		return "aarch64"
+	case "mipsle":
+		return "mipsel"
+	case "mips64le":
+		return "mips64el"
 	default:
 		return arch
 	}

--- a/release/dist/unixpkgs/targets.go
+++ b/release/dist/unixpkgs/targets.go
@@ -82,31 +82,31 @@ var (
 	}
 
 	debs = map[string]bool{
-		"linux/386":     true,
-		"linux/amd64":   true,
-		"linux/arm":     true,
-		"linux/arm64":   true,
-		"linux/riscv64": true,
-		// TODO: maybe mipses, we accidentally started building them at some
-		// point even though they probably don't work right.
-		// "linux/mips":     true,
-		// "linux/mipsle":   true,
+		"linux/386":      true,
+		"linux/amd64":    true,
+		"linux/arm":      true,
+		"linux/arm64":    true,
+		"linux/riscv64":  true,
+		"linux/mipsle":   true,
+		"linux/mips64le": true,
+		"linux/mips":     true,
+		// Debian does not support big endian mips64. Leave that out until we know
+		// we need it.
 		// "linux/mips64":   true,
-		// "linux/mips64le": true,
 	}
 
 	rpms = map[string]bool{
-		"linux/386":     true,
-		"linux/amd64":   true,
-		"linux/arm":     true,
-		"linux/arm64":   true,
-		"linux/riscv64": true,
-		// TODO: maybe mipses, we accidentally started building them at some
-		// point even though they probably don't work right.
+		"linux/386":      true,
+		"linux/amd64":    true,
+		"linux/arm":      true,
+		"linux/arm64":    true,
+		"linux/riscv64":  true,
+		"linux/mipsle":   true,
+		"linux/mips64le": true,
+		// Fedora only supports little endian mipses. Maybe some other distribution
+		// supports big-endian? Leave them out for now.
 		// "linux/mips":     true,
-		// "linux/mipsle":   true,
 		// "linux/mips64":   true,
-		// "linux/mips64le": true,
 	}
 )
 


### PR DESCRIPTION
According to https://wiki.debian.org/SupportedArchitectures Debian does not support big-endian mips64, so that one remains disabled.

According to https://fedoraproject.org/wiki/Architectures Fedora only supports little-endian mips, so leaving both big-endian ones out too.

Updates #8005.