### PR TITLE
wgengine/netstack: switch to cubic congestion control

### DIFF
--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -178,6 +178,11 @@ func Create(logf logger.Logf, tundev *tstun.Wrapper, e wgengine.Engine, mc *magi
 	if tcpipErr != nil {
 		return nil, fmt.Errorf("could not enable TCP SACK: %v", tcpipErr)
 	}
+	congestionOpt := tcpip.CongestionControlOption("cubic") // Reno is used by default
+	tcpipErr = ipstack.SetTransportProtocolOption(tcp.ProtocolNumber, &congestionOpt)
+	if tcpipErr != nil {
+		return nil, fmt.Errorf("could not set TCP congestion control: %v", tcpipErr)
+	}
 	linkEP := channel.New(512, tstun.DefaultMTU(), "")
 	if tcpipProblem := ipstack.CreateNIC(nicID, linkEP); tcpipProblem != nil {
 		return nil, fmt.Errorf("could not create netstack NIC: %v", tcpipProblem)


### PR DESCRIPTION
A retransmission issue surfaces in gVisor under Reno congestion control when dispatching a rapid sequence of small packets. This bug can be reliably replicated using tsnet with the patch delineated below:

```diff
diff --git a/tsnet/tsnet_test.go b/tsnet/tsnet_test.go
index 5ab27099..d9c2f51b 100644
--- a/tsnet/tsnet_test.go
+++ b/tsnet/tsnet_test.go
@@ -261,24 +261,20 @@ func TestConn(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	want := "hello"
-	if _, err := io.WriteString(w, want); err != nil {
-		t.Fatal(err)
-	}
-
-	got := make([]byte, len(want))
-	if _, err := io.ReadAtLeast(r, got, len(got)); err != nil {
-		t.Fatal(err)
-	}
-	t.Logf("got: %q", got)
-	if string(got) != want {
-		t.Errorf("got %q, want %q", got, want)
-	}
-
-	_, err = s2.Dial(ctx, "tcp", fmt.Sprintf("%s:8082", s1ip)) // some random port
-	if err == nil {
-		t.Fatalf("unexpected success; should have seen a connection refused error")
+	defer r.Close()
+	go io.Copy(io.Discard, r)
+
+	t.Log("writing")
+
+	payload := []byte(strings.Repeat("hello world\n", 65536/12))
+	size := 0
+	for i := 0; i < 1024*2; i++ {
+		t.Logf("write payload %d: %d bytes", i, size/1024)
+		n, err := w.Write(payload)
+		if err != nil {
+			t.Fatal(err)
+		}
+		size += n
 	}
 }
```

Execute the given test multiple iterations, and you'll observe it becomes unresponsive during payload writing. Under the hood, gVisor is invoking the following function:

https://github.com/google/gvisor/blob/0b76fe6c0038e71a3f9dd458193e6bcf92430f13/pkg/tcpip/transport/tcp/snd.go#L425-L435

After changing the congestion control to cubic (as this PR does), the behavior cannot be replicated. I'm unfamiliar with the implications of adjusting the congestion control to cubic, so guidance would be helpful here.

Related: https://github.com/tailscale/tailscale/issues/7560