### PR TITLE
util/codegen: support embedded fields

### DIFF
--- a/cmd/viewer/tests/tests.go
+++ b/cmd/viewer/tests/tests.go
@@ -9,7 +9,7 @@ import (
 	"net/netip"
 )
 
-//go:generate go run tailscale.com/cmd/viewer --type=StructWithPtrs,StructWithoutPtrs,Map,StructWithSlices,OnlyGetClone --clone-only-type=OnlyGetClone
+//go:generate go run tailscale.com/cmd/viewer --type=StructWithPtrs,StructWithoutPtrs,Map,StructWithSlices,OnlyGetClone,StructWithEmbedded --clone-only-type=OnlyGetClone
 
 type StructWithoutPtrs struct {
 	Int int
@@ -60,4 +60,9 @@ type StructWithSlices struct {
 
 type OnlyGetClone struct {
 	SinViewerPorFavor bool
+}
+
+type StructWithEmbedded struct {
+	A *StructWithPtrs
+	StructWithSlices
 }

--- a/cmd/viewer/tests/tests_clone.go
+++ b/cmd/viewer/tests/tests_clone.go
@@ -211,3 +211,22 @@ func (src *OnlyGetClone) Clone() *OnlyGetClone {
 var _OnlyGetCloneCloneNeedsRegeneration = OnlyGetClone(struct {
 	SinViewerPorFavor bool
 }{})
+
+// Clone makes a deep copy of StructWithEmbedded.
+// The result aliases no memory with the original.
+func (src *StructWithEmbedded) Clone() *StructWithEmbedded {
+	if src == nil {
+		return nil
+	}
+	dst := new(StructWithEmbedded)
+	*dst = *src
+	dst.A = src.A.Clone()
+	dst.StructWithSlices = *src.StructWithSlices.Clone()
+	return dst
+}
+
+// A compilation failure here means this code must be regenerated, with the command at the top of this file.
+var _StructWithEmbeddedCloneNeedsRegeneration = StructWithEmbedded(struct {
+	A *StructWithPtrs
+	StructWithSlices
+}{})

--- a/util/codegen/codegen.go
+++ b/util/codegen/codegen.go
@@ -202,13 +202,18 @@ func AssertStructUnchanged(t *types.Struct, tname, ctx string, it *ImportTracker
 	w("var _%s%sNeedsRegeneration = %s(struct {", tname, ctx, tname)
 
 	for i := 0; i < t.NumFields(); i++ {
-		fname := t.Field(i).Name()
+		st := t.Field(i)
+		fname := st.Name()
 		ft := t.Field(i).Type()
 		if IsInvalid(ft) {
 			continue
 		}
 		qname := it.QualifiedName(ft)
-		w("\t%s %s", fname, qname)
+		if st.Anonymous() {
+			w("\t%s ", fname)
+		} else {
+			w("\t%s %s", fname, qname)
+		}
 	}
 
 	w("}{})\n")


### PR DESCRIPTION
I noticed cmd/{cloner,viewer} didn't support structs with embedded fields while working on a change in another repo. This adds support.