### PR TITLE
tool/gocross: fix incorrect relpath usage in bootstrap script

### DIFF
--- a/tool/gocross/gocross-wrapper.sh
+++ b/tool/gocross/gocross-wrapper.sh
@@ -31,7 +31,7 @@ toolchain="$HOME/.cache/tailscale-go"
 if [ -d "$toolchain" ]; then
     # A toolchain exists, but is it recent enough to compile gocross? If not,
     # wipe it out so that the next if block fetches a usable one.
-    want_go_minor=$(grep -E '^go ' "$repo_root/go.mod" | cut -f2 -d'.')
+    want_go_minor=$(grep -E '^go ' "go.mod" | cut -f2 -d'.')
     have_go_minor=$(cut -f2 -d'.' <$toolchain/VERSION)
     if [ -z "$have_go_minor" -o "$have_go_minor" -lt "$want_go_minor" ]; then
         rm -rf "$toolchain" "$toolchain.extracted"
@@ -45,7 +45,7 @@ if [ ! -d "$toolchain" ]; then
     # build with Go N-1. So, if we have no cached tailscale toolchain at all,
     # fetch the initial one in shell. Once gocross is built, it'll manage
     # updates.
-    read -r REV <$repo_root/go.toolchain.rev
+    read -r REV <go.toolchain.rev
 
     case "$REV" in
     /*)
@@ -80,7 +80,7 @@ fi
 # case, cmd/cloner invokes go with GO111MODULE=off at some stage.
 #
 # Anyway, build gocross in a stripped down universe.
-gocross_path="$repo_root/gocross"
+gocross_path="gocross"
 gocross_ok=0
 wantver="$(git rev-parse HEAD)"
 if [ -x "$gocross_path" ]; then


### PR DESCRIPTION
The subshell in which gocross gets built cd's to the corp checkout dir near the top, so all future references to corp repository files should be simple relative paths, and not reference $repo_root. When $repo_root is an absolute path, it doesn't matter and everything works out, but on some OSes and shells and invocations, $repo_root is a completely relative path that is invalidated by the "cd".

Fixes tailscale/corp#11183

---

Woops, fixed this bug in the wrong repo, so our repo sync logic reverted it. Fixing in the right place this time.