### PR TITLE
net/netcheck: reenable TestBasic on Windows

### DIFF
--- a/net/netcheck/netcheck_test.go
+++ b/net/netcheck/netcheck_test.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/netip"
 	"reflect"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -156,9 +155,6 @@ func TestHairpinWait(t *testing.T) {
 }
 
 func TestBasic(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("TODO(#7876): test regressed on windows while CI was broken")
-	}
 	stunAddr, cleanup := stuntest.Serve(t)
 	defer cleanup()
 


### PR DESCRIPTION
This test was either fixed by intermediate changes or was mis-flagged as failing during #7876 triage.

Updates #7876