### PR TITLE
Do not set cmd.Dir when spawning tailscaled ssh command

### DIFF
--- a/ssh/tailssh/incubator.go
+++ b/ssh/tailssh/incubator.go
@@ -113,6 +113,7 @@ func (ss *sshSession) newIncubatorCommand() (cmd *exec.Cmd) {
 		"--remote-ip=" + ci.src.Addr().String(),
 		"--has-tty=false", // updated in-place by startWithPTY
 		"--tty-name=",     // updated in-place by startWithPTY
+		"--pwd=" + ss.conn.localUser.HomeDir,
 	}
 
 	if isSFTP {
@@ -177,6 +178,7 @@ type incubatorArgs struct {
 	isShell      bool
 	loginCmdPath string
 	cmdArgs      []string
+	pwd          string
 }
 
 func parseIncubatorArgs(args []string) (a incubatorArgs) {
@@ -193,6 +195,7 @@ func parseIncubatorArgs(args []string) (a incubatorArgs) {
 	flags.BoolVar(&a.isShell, "shell", false, "is launching a shell (with no cmds)")
 	flags.BoolVar(&a.isSFTP, "sftp", false, "run sftp server (cmd is ignored)")
 	flags.StringVar(&a.loginCmdPath, "login-cmd", "", "the path to `login` cmd")
+	flags.StringVar(&a.pwd, "pwd", "/", "process initial working directory, if possible. else / is used")
 	flags.Parse(args)
 	a.cmdArgs = flags.Args()
 	return a
@@ -278,6 +281,12 @@ func beIncubator(args []string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Env = os.Environ()
+
+	if _, err := os.Stat(ia.pwd); err != nil && os.IsNotExist(err) {
+		cmd.Dir = "/"
+	} else {
+		cmd.Dir = ia.pwd
+	}
 
 	if ia.hasTTY {
 		// If we were launched with a tty then we should
@@ -428,16 +437,7 @@ func (ss *sshSession) launchProcess() error {
 	ss.cmd = ss.newIncubatorCommand()
 
 	cmd := ss.cmd
-	homeDir := ss.conn.localUser.HomeDir
-	if _, err := os.Stat(homeDir); err == nil {
-		cmd.Dir = homeDir
-	} else if os.IsNotExist(err) {
-		// If the home directory doesn't exist, we can't chdir to it.
-		// Instead, we'll chdir to the root directory.
-		cmd.Dir = "/"
-	} else {
-		return err
-	}
+
 	cmd.Env = envForUser(ss.conn.localUser)
 	for _, kv := range ss.Environ() {
 		if acceptEnvPair(kv) {


### PR DESCRIPTION
Leave cmd.Dir empty, which should configure spawned process to use working directory of existing process.

When a user logs in, their directory is set based on shell semantics and is not related to the working directory of 'tailscaled ssh' command, based on my testing.

Fixes #8118
Related to pull #4945
