### PR TITLE
cmd/k8s-operator: handle NotFound secrets

### DIFF
--- a/cmd/k8s-operator/operator.go
+++ b/cmd/k8s-operator/operator.go
@@ -567,6 +567,9 @@ func (a *ServiceReconciler) getDeviceInfo(ctx context.Context, svc *corev1.Servi
 	if err != nil {
 		return "", "", err
 	}
+	if sec == nil {
+		return "", "", nil
+	}
 	id = string(sec.Data["device_id"])
 	if id == "" {
 		return "", "", nil


### PR DESCRIPTION
getSingleObject can return `nil, nil`, getDeviceInfo was not handling that case which resulted in panics.

Fixes #7303