### PR TITLE
cmd/tailscale/cli: [up] fix CreateKey missing argument

### DIFF
--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -1198,7 +1198,8 @@ func resolveAuthKey(ctx context.Context, v, tags string) (string, error) {
 		},
 	}
 
-	authkey, _, err := tsClient.CreateKey(ctx, caps)
+	const defaultExpiry = 0
+	authkey, _, err := tsClient.CreateKey(ctx, caps, defaultExpiry)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Signed-off-by: Shayne Sweeney <shayne@tailscale.com>
