### PR TITLE
Revert "client: allow the expiry time to be specified for new keys"

### DIFF
--- a/client/tailscale/keys.go
+++ b/client/tailscale/keys.go
@@ -70,18 +70,10 @@ func (c *Client) Keys(ctx context.Context) ([]string, error) {
 // CreateKey creates a new key for the current user. Currently, only auth keys
 // can be created. Returns the key itself, which cannot be retrieved again
 // later, and the key metadata.
-func (c *Client) CreateKey(ctx context.Context, caps KeyCapabilities, expiry time.Duration) (string, *Key, error) {
-
-	// convert expirySeconds to an int64 (seconds)
-	expirySeconds := int64(expiry.Seconds())
-	if expirySeconds < 0 {
-		return "", nil, fmt.Errorf("expiry must be positive")
-	}
-
+func (c *Client) CreateKey(ctx context.Context, caps KeyCapabilities) (string, *Key, error) {
 	keyRequest := struct {
-		Capabilities  KeyCapabilities `json:"capabilities"`
-		ExpirySeconds int64           `json:"expirySeconds,omitempty"`
-	}{caps, int64(expirySeconds)}
+		Capabilities KeyCapabilities `json:"capabilities"`
+	}{caps}
 	bs, err := json.Marshal(keyRequest)
 	if err != nil {
 		return "", nil, err

--- a/cmd/get-authkey/main.go
+++ b/cmd/get-authkey/main.go
@@ -67,7 +67,7 @@ func main() {
 		},
 	}
 
-	authkey, _, err := tsClient.CreateKey(ctx, caps, 0)
+	authkey, _, err := tsClient.CreateKey(ctx, caps)
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/cmd/k8s-operator/operator.go
+++ b/cmd/k8s-operator/operator.go
@@ -153,9 +153,7 @@ waitOnline:
 					},
 				},
 			}
-			// zeroSeconds adopts the default expiration time.
-			zeroSeconds := time.Duration(0 * time.Second)
-			authkey, _, err := tsClient.CreateKey(ctx, caps, zeroSeconds)
+			authkey, _, err := tsClient.CreateKey(ctx, caps)
 			if err != nil {
 				startlog.Fatalf("creating operator authkey: %v", err)
 			}
@@ -289,7 +287,7 @@ type ServiceReconciler struct {
 }
 
 type tsClient interface {
-	CreateKey(ctx context.Context, caps tailscale.KeyCapabilities, expiry time.Duration) (string, *tailscale.Key, error)
+	CreateKey(ctx context.Context, caps tailscale.KeyCapabilities) (string, *tailscale.Key, error)
 	DeleteDevice(ctx context.Context, id string) error
 }
 
@@ -595,9 +593,7 @@ func (a *ServiceReconciler) newAuthKey(ctx context.Context, tags []string) (stri
 			},
 		},
 	}
-
-	zeroDuration := time.Duration(0)
-	key, _, err := a.tsClient.CreateKey(ctx, caps, zeroDuration)
+	key, _, err := a.tsClient.CreateKey(ctx, caps)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/k8s-operator/operator_test.go
+++ b/cmd/k8s-operator/operator_test.go
@@ -807,14 +807,14 @@ type fakeTSClient struct {
 	deleted     []string
 }
 
-func (c *fakeTSClient) CreateKey(ctx context.Context, caps tailscale.KeyCapabilities, expiry time.Duration) (string, *tailscale.Key, error) {
+func (c *fakeTSClient) CreateKey(ctx context.Context, caps tailscale.KeyCapabilities) (string, *tailscale.Key, error) {
 	c.Lock()
 	defer c.Unlock()
 	c.keyRequests = append(c.keyRequests, caps)
 	k := &tailscale.Key{
 		ID:           "key",
 		Created:      time.Now(),
-		Expires:      time.Now().Add(expiry),
+		Expires:      time.Now().Add(24 * time.Hour),
 		Capabilities: caps,
 	}
 	return "secret-authkey", k, nil


### PR DESCRIPTION
This reverts commit 9b6e48658f36e347f009d819bfa69c85c08aa3cf.

Rebased PR doesn't build.