### PR TITLE
ssh/tailssh: fix regression after LDAP support

### DIFF
--- a/ssh/tailssh/tailssh_test.go
+++ b/ssh/tailssh/tailssh_test.go
@@ -851,7 +851,7 @@ func TestSSH(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	um, err := userLookup(u.Uid)
+	um, err := userLookup(u.Username)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
58ab66ec51f1963fbee302c75ad0017d81d37884 added LDAP support for #4945 by shelling out to getdent.

It was supposed to fall back to the old method when getdent wasn't found, but some variable name confusion (uid vs username) meant the old path wasn't calling the right lookup function (user.LookupId instead of user.Lookup).

Which meant that changed probably also broke FreeBSD and macOS SSH support in addition to the reported OpenWRT regression.

The gokrazy support didn't look right either.

Fixes #8180
