### PR TITLE
portlist: remove NewPoller constructor

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -292,9 +292,11 @@ func NewLocalBackend(logf logger.Logf, logID logid.PublicID, sys *tsd.System, lo
 	osshare.SetFileSharingEnabled(false, logf)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	portpoll, err := portlist.NewPoller()
+	portpoll := new(portlist.Poller)
+	err = portpoll.Check()
 	if err != nil {
 		logf("skipping portlist: %s", err)
+		portpoll = nil
 	}
 
 	b := &LocalBackend{

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -296,6 +296,7 @@ func NewLocalBackend(logf logger.Logf, logID logid.PublicID, sys *tsd.System, lo
 	err = portpoll.Check()
 	if err != nil {
 		logf("skipping portlist: %s", err)
+		portpoll.Close()
 		portpoll = nil
 	}
 

--- a/portlist/poller.go
+++ b/portlist/poller.go
@@ -29,9 +29,8 @@ type Poller struct {
 	// This field should only be changed before calling Run.
 	IncludeLocalhost bool
 
-	c chan List // unbuffered
-
 	initOnce sync.Once // guards init of private fields
+	c        chan List // unbuffered
 
 	// os, if non-nil, is an OS-specific implementation of the portlist getting
 	// code. When non-nil, it's responsible for getting the complete list of

--- a/portlist/portlist_test.go
+++ b/portlist/portlist_test.go
@@ -176,7 +176,8 @@ func TestEqualLessThan(t *testing.T) {
 }
 
 func TestPoller(t *testing.T) {
-	p, err := NewPoller()
+	var p Poller
+	err := p.Check()
 	if err != nil {
 		t.Skipf("not running test: %v", err)
 	}


### PR DESCRIPTION
This is a follow up on PR #8172 and a breaking change that removes NewPoller. The issue with the previous PR was that NewPoller immediately initializes the underlying os implementation and therefore setting IncludeLocalhost as an exported field happened too late and cannot happen early enough. Using the zero value of Poller was also not an option from outside of the package because we need to set initial private fields

Fixes #8171