### PR TITLE
ipn/ipnlocal: [serve/funnel] add forwarded host and proto header

### DIFF
--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -447,8 +447,14 @@ func (b *LocalBackend) proxyHandlerForBackend(backend string) (*httputil.Reverse
 		Rewrite: func(r *httputil.ProxyRequest) {
 			r.SetURL(u)
 			r.Out.Host = r.In.Host
+			r.Out.Header.Set("X-Forwarded-Host", r.In.Host)
 			if c, ok := r.Out.Context().Value(serveHTTPContextKey{}).(*serveHTTPContext); ok {
 				r.Out.Header.Set("X-Forwarded-For", c.SrcAddr.Addr().String())
+			}
+			if r.In.TLS == nil {
+				r.Out.Header.Set("X-Forwarded-Proto", "http")
+			} else {
+				r.Out.Header.Set("X-Forwarded-Proto", "https")
 			}
 		},
 		Transport: &http.Transport{

--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -448,13 +448,9 @@ func (b *LocalBackend) proxyHandlerForBackend(backend string) (*httputil.Reverse
 			r.SetURL(u)
 			r.Out.Host = r.In.Host
 			r.Out.Header.Set("X-Forwarded-Host", r.In.Host)
+			r.Out.Header.Set("X-Forwarded-Proto", "https")
 			if c, ok := r.Out.Context().Value(serveHTTPContextKey{}).(*serveHTTPContext); ok {
 				r.Out.Header.Set("X-Forwarded-For", c.SrcAddr.Addr().String())
-			}
-			if r.In.TLS == nil {
-				r.Out.Header.Set("X-Forwarded-Proto", "http")
-			} else {
-				r.Out.Header.Set("X-Forwarded-Proto", "https")
 			}
 		},
 		Transport: &http.Transport{


### PR DESCRIPTION
This replicates the headers also sent by the golang reverse proxy by default (see the [recent commit](https://github.com/golang/go/commit/1513e57b704056b794f0706362fa3c949f2972a4)). Some applications depend on these headers to generate redirects or links correctly.

I verified this change by building the tool locally on my Mac, running an echo server and serving that via the locally built tailscale CLI. I then used my phone in the same tailnet to access this, verifying that the returned headers included both X-Forwarded-Host and X-Forwarded-Proto.

I need this change to continue with my personal Tailscale use case, so I'd be happy to see this get merged. Happy to adjust as needed, just let me know.

Fixes #7061.