### PR TITLE
release/dist/synology: remove 'version' field from ui/config

### DIFF
--- a/release/dist/synology/files/config
+++ b/release/dist/synology/files/config
@@ -2,7 +2,6 @@
 	".url": {
 		"SYNO.SDS.Tailscale": {
 			"type": "url",
-			"version": "1.8.3",
 			"title": "Tailscale",
 			"icon": "PACKAGE_ICON_256.PNG",
 			"url": "webman/3rdparty/Tailscale/",

--- a/release/dist/synology/pkgs.go
+++ b/release/dist/synology/pkgs.go
@@ -176,7 +176,7 @@ func (m *synologyBuilds) buildInnerPackage(b *dist.Build, dsmVersion int, goenv 
 			static(fmt.Sprintf("logrotate-dsm%d", dsmVersion), "conf/logrotate.conf", 0644),
 			dir("ui"),
 			static("PACKAGE_ICON_256.PNG", "ui/PACKAGE_ICON_256.PNG", 0644),
-			static("config", "ui/config", 0644), // TODO: this has "1.8.3" hard-coded in it; why? what is it? bug?
+			static("config", "ui/config", 0644),
 			static("index.cgi", "ui/index.cgi", 0755))
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
As far as I can tell from the DSM documentation and known undocumented fields, there is no 'version' field in this config file that DSM cares about.

Updates #8232