### PR TITLE
build_dist.sh: use $go consistently.

### DIFF
--- a/build_dist.sh
+++ b/build_dist.sh
@@ -49,4 +49,4 @@ while [ "$#" -gt 1 ]; do
 	esac
 done
 
-exec ./tool/go build ${tags:+-tags=$tags} -ldflags "$ldflags" "$@"
+exec $go build ${tags:+-tags=$tags} -ldflags "$ldflags" "$@"


### PR DESCRIPTION
The invocation at the end unconditionally used
./tool/go, but the structuring on lines 14-17
sets up to use a different toolchain if the
platform requires it.

Fixes https://github.com/tailscale/tailscale/issues/8156