### PR TITLE
portlist: add a synchronous Poll method

### DIFF
--- a/portlist/portlist_test.go
+++ b/portlist/portlist_test.go
@@ -175,12 +175,33 @@ func TestEqualLessThan(t *testing.T) {
 	}
 }
 
+func TestClose(t *testing.T) {
+	var p Poller
+	err := p.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	p = Poller{}
+	_, _, err = p.Poll()
+	if err != nil {
+		t.Skipf("skipping due to poll error: %v", err)
+	}
+	err = p.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestPoller(t *testing.T) {
 	p, err := NewPoller()
 	if err != nil {
 		t.Skipf("not running test: %v", err)
 	}
-	defer p.Close()
+	t.Cleanup(func() {
+		if err := p.Close(); err != nil {
+			t.Errorf("error closing poller in test: %v", err)
+		}
+	})
 
 	var wg sync.WaitGroup
 	wg.Add(2)


### PR DESCRIPTION
This is a follow up on PR #8172 that adds a synchronous Poll method which allows for the Poller to be used as a zero value without needing the constructor. The local backend is also changed to use the new API. A follow up PR will remove the async functionality from the portlist package.

Updates #8171