### PR TITLE
ssh/tailssh: Max Username Length 256 for linux

### DIFF
--- a/ssh/tailssh/user.go
+++ b/ssh/tailssh/user.go
@@ -81,7 +81,11 @@ func userLookup(username string) (*userMeta, error) {
 }
 
 func validUsername(uid string) bool {
-	if len(uid) > 32 || len(uid) == 0 {
+	maxUid := 32
+	if runtime.GOOS == "linux" {
+		maxUid = 256
+	}
+	if len(uid) > maxUid || len(uid) == 0 {
 		return false
 	}
 	for _, r := range uid {


### PR DESCRIPTION
Max username length is increased to 256 on linux to match /usr/include/bits/local_lim.h

Fixes #8277

Signed-off-by: Derek Burdick <derek-burdick@users.noreply.github.com>