### PR TITLE
tool/gocross: handle TVOS_DEPLOYMENT_TARGET

### DIFF
--- a/tool/gocross/autoflags.go
+++ b/tool/gocross/autoflags.go
@@ -114,6 +114,8 @@ func autoflagsForTest(argv []string, env *Environment, goroot, nativeGOOS, nativ
 				xcodeFlags = append(xcodeFlags, "-miphoneos-version-min="+env.Get("IPHONEOS_DEPLOYMENT_TARGET", ""))
 			case env.IsSet("MACOSX_DEPLOYMENT_TARGET"):
 				xcodeFlags = append(xcodeFlags, "-mmacosx-version-min="+env.Get("MACOSX_DEPLOYMENT_TARGET", ""))
+			case env.IsSet("TVOS_DEPLOYMENT_TARGET"):
+				xcodeFlags = append(xcodeFlags, "-mtvos-version-min="+env.Get("TVOS_DEPLOYMENT_TARGET", ""))
 			default:
 				return nil, nil, fmt.Errorf("invoked by Xcode but couldn't figure out deployment target. Did Xcode change its envvars again?")
 			}


### PR DESCRIPTION
First step to start working on #8282. This is needed in order to build our network extension on tvOS.