### PR TITLE
ssh/tailssh: add support for remote/reverse port forwarding

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -99,7 +99,8 @@ type CapabilityVersion int
 //   - 60: 2023-04-06: Client understands IsWireGuardOnly
 //   - 61: 2023-04-18: Client understand SSHAction.SSHRecorderFailureAction
 //   - 62: 2023-05-05: Client can notify control over noise for SSHEventNotificationRequest recording failure events
-const CurrentCapabilityVersion CapabilityVersion = 62
+//   - 63: 2023-06-08: Client understands SSHAction.AllowRemotePortForwarding.
+const CurrentCapabilityVersion CapabilityVersion = 63
 
 type StableID string
 
@@ -2047,6 +2048,10 @@ type SSHAction struct {
 	// AllowLocalPortForwarding, if true, allows accepted connections
 	// to use local port forwarding if requested.
 	AllowLocalPortForwarding bool `json:"allowLocalPortForwarding,omitempty"`
+
+	// AllowRemotePortForwarding, if true, allows accepted connections
+	// to use remote port forwarding if requested.
+	AllowRemotePortForwarding bool `json:"allowRemotePortForwarding,omitempty"`
 
 	// Recorders defines the destinations of the SSH session recorders.
 	// The recording will be uploaded to http://addr:port/record.

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -408,15 +408,16 @@ func (src *SSHAction) Clone() *SSHAction {
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _SSHActionCloneNeedsRegeneration = SSHAction(struct {
-	Message                  string
-	Reject                   bool
-	Accept                   bool
-	SessionDuration          time.Duration
-	AllowAgentForwarding     bool
-	HoldAndDelegate          string
-	AllowLocalPortForwarding bool
-	Recorders                []netip.AddrPort
-	OnRecordingFailure       *SSHRecorderFailureAction
+	Message                   string
+	Reject                    bool
+	Accept                    bool
+	SessionDuration           time.Duration
+	AllowAgentForwarding      bool
+	HoldAndDelegate           string
+	AllowLocalPortForwarding  bool
+	AllowRemotePortForwarding bool
+	Recorders                 []netip.AddrPort
+	OnRecordingFailure        *SSHRecorderFailureAction
 }{})
 
 // Clone makes a deep copy of SSHPrincipal.

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -940,6 +940,7 @@ func (v SSHActionView) SessionDuration() time.Duration         { return v.ж.Ses
 func (v SSHActionView) AllowAgentForwarding() bool             { return v.ж.AllowAgentForwarding }
 func (v SSHActionView) HoldAndDelegate() string                { return v.ж.HoldAndDelegate }
 func (v SSHActionView) AllowLocalPortForwarding() bool         { return v.ж.AllowLocalPortForwarding }
+func (v SSHActionView) AllowRemotePortForwarding() bool        { return v.ж.AllowRemotePortForwarding }
 func (v SSHActionView) Recorders() views.Slice[netip.AddrPort] { return views.SliceOf(v.ж.Recorders) }
 func (v SSHActionView) OnRecordingFailure() *SSHRecorderFailureAction {
 	if v.ж.OnRecordingFailure == nil {
@@ -951,15 +952,16 @@ func (v SSHActionView) OnRecordingFailure() *SSHRecorderFailureAction {
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _SSHActionViewNeedsRegeneration = SSHAction(struct {
-	Message                  string
-	Reject                   bool
-	Accept                   bool
-	SessionDuration          time.Duration
-	AllowAgentForwarding     bool
-	HoldAndDelegate          string
-	AllowLocalPortForwarding bool
-	Recorders                []netip.AddrPort
-	OnRecordingFailure       *SSHRecorderFailureAction
+	Message                   string
+	Reject                    bool
+	Accept                    bool
+	SessionDuration           time.Duration
+	AllowAgentForwarding      bool
+	HoldAndDelegate           string
+	AllowLocalPortForwarding  bool
+	AllowRemotePortForwarding bool
+	Recorders                 []netip.AddrPort
+	OnRecordingFailure        *SSHRecorderFailureAction
 }{})
 
 // View returns a readonly view of SSHPrincipal.


### PR DESCRIPTION
This basically allows running services on the SSH client and reaching them from the SSH server during the session.

Updates #6575