### PR TITLE
wgengine/netstack: increase maxInFlightConnectionAttempts

### DIFF
--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -256,7 +256,7 @@ func (ns *Impl) Start(lb *ipnlocal.LocalBackend) error {
 	ns.e.AddNetworkMapCallback(ns.updateIPs)
 	// size = 0 means use default buffer size
 	const tcpReceiveBufferSize = 0
-	const maxInFlightConnectionAttempts = 16
+	const maxInFlightConnectionAttempts = 1024
 	tcpFwd := tcp.NewForwarder(ns.ipstack, tcpReceiveBufferSize, maxInFlightConnectionAttempts, ns.acceptTCP)
 	udpFwd := udp.NewForwarder(ns.ipstack, ns.acceptUDP)
 	ns.ipstack.SetTransportProtocolHandler(tcp.ProtocolNumber, ns.wrapProtoHandler(tcpFwd.HandlePacket))


### PR DESCRIPTION
Address reports of subnet router instability when running in `--tun=userspace-networking` mode.

Fixes https://github.com/tailscale/corp/issues/12184