### PR TITLE
ipn/ipnlocal: add docs header to serve HTTP proxy

### DIFF
--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -482,6 +482,7 @@ func (b *LocalBackend) addTailscaleIdentityHeaders(r *httputil.ProxyRequest) {
 	// Clear any incoming values squatting in the headers.
 	r.Out.Header.Del("Tailscale-User-Login")
 	r.Out.Header.Del("Tailscale-User-Name")
+	r.Out.Header.Del("Tailscale-Headers-Info")
 
 	c, ok := getServeHTTPContext(r.Out)
 	if !ok {
@@ -498,6 +499,7 @@ func (b *LocalBackend) addTailscaleIdentityHeaders(r *httputil.ProxyRequest) {
 	}
 	r.Out.Header.Set("Tailscale-User-Login", user.LoginName)
 	r.Out.Header.Set("Tailscale-User-Name", user.DisplayName)
+	r.Out.Header.Set("Tailscale-Headers-Info", "https://tailscale.com/s/serve-headers")
 }
 
 func (b *LocalBackend) serveWebHandler(w http.ResponseWriter, r *http.Request) {

--- a/ipn/ipnlocal/serve_test.go
+++ b/ipn/ipnlocal/serve_test.go
@@ -253,6 +253,7 @@ func TestServeHTTPProxy(t *testing.T) {
 				{"X-Forwarded-For", "100.150.151.152"},
 				{"Tailscale-User-Login", "someone@example.com"},
 				{"Tailscale-User-Name", "Some One"},
+				{"Tailscale-Headers-Info", "https://tailscale.com/s/serve-headers"},
 			},
 		},
 		{
@@ -263,6 +264,7 @@ func TestServeHTTPProxy(t *testing.T) {
 				{"X-Forwarded-For", "100.150.151.153"},
 				{"Tailscale-User-Login", ""},
 				{"Tailscale-User-Name", ""},
+				{"Tailscale-Headers-Info", ""},
 			},
 		},
 		{
@@ -273,6 +275,7 @@ func TestServeHTTPProxy(t *testing.T) {
 				{"X-Forwarded-For", "100.160.161.162"},
 				{"Tailscale-User-Login", ""},
 				{"Tailscale-User-Name", ""},
+				{"Tailscale-Headers-Info", ""},
 			},
 		},
 	}


### PR DESCRIPTION
Adds a `Tailscale-Headers-Info` header whenever the `Tailscale-User-` headers are filled from the HTTP proxy handler.

Planning on hooking this shorturl up to KB docs about the header values (i.e. what's a login name vs. display name) and security considerations to keep in mind while using these headers - notibly that they can also be filled from external requests that do not hit tailscaled.

Updates https://github.com/tailscale/tailscale/issues/6954