### PR TITLE
tka: add function for generating signing deeplinks

### DIFF
--- a/tka/deeplink_test.go
+++ b/tka/deeplink_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package tka
+
+import (
+	"testing"
+)
+
+func TestGenerateDeeplink(t *testing.T) {
+	pub, _ := testingKey25519(t, 1)
+	key := Key{Kind: Key25519, Public: pub, Votes: 2}
+	c := newTestchain(t, `
+        G1 -> L1
+
+        G1.template = genesis
+    `,
+		optTemplate("genesis", AUM{MessageKind: AUMCheckpoint, State: &State{
+			Keys:               []Key{key},
+			DisablementSecrets: [][]byte{DisablementKDF([]byte{1, 2, 3})},
+		}}),
+	)
+	a, _ := Open(c.Chonk())
+
+	nodeKey := "nodekey:1234567890"
+	tlPub := "tlpub:1234567890"
+	deviceName := "Example Device"
+	osName := "iOS"
+	loginName := "insecure@example.com"
+
+	deeplink, err := a.NewDeeplink(NewDeeplinkParams{
+		NodeKey:    nodeKey,
+		TLPub:      tlPub,
+		DeviceName: deviceName,
+		OSName:     osName,
+		LoginName:  loginName,
+	})
+	if err != nil {
+		t.Errorf("deeplink generation failed: %v", err)
+	}
+
+	res := a.ValidateDeeplink(deeplink)
+	if !res.IsValid {
+		t.Errorf("deeplink validation failed: %s", res.Error)
+	}
+	if res.NodeKey != nodeKey {
+		t.Errorf("node key mismatch: %s != %s", res.NodeKey, nodeKey)
+	}
+	if res.TLPub != tlPub {
+		t.Errorf("tlpub mismatch: %s != %s", res.TLPub, tlPub)
+	}
+}


### PR DESCRIPTION
This commit continues the work from #8303, providing a method for a tka.Authority to generate valid deeplinks for signing devices. We'll use this to provide the necessary deeplinks for users to sign from their mobile devices.

Updates #8302

/cc @agottardo 