### PR TITLE
prober: allow monitoring of nodes marked as STUN only in default derpmap

### DIFF
--- a/prober/derp.go
+++ b/prober/derp.go
@@ -348,6 +348,8 @@ func newConn(ctx context.Context, dm *tailcfg.DERPMap, n *tailcfg.DERPNode) (*de
 	priv := key.NewNode()
 	dc := derphttp.NewRegionClient(priv, l, nil /* no netMon */, func() *tailcfg.DERPRegion {
 		rid := n.RegionID
+		// Allow the prober to monitor nodes marked as STUN only in the default map
+		n.STUNOnly = false
 		return &tailcfg.DERPRegion{
 			RegionID:   rid,
 			RegionCode: fmt.Sprintf("%s-%s", dm.Regions[rid].RegionCode, n.Name),


### PR DESCRIPTION
prober uses NewRegionClient() to connect to a derper using a faked up single-node region, but NewRegionClient() fails to connect if there is no non-STUN only client in the region. Set the STUN only flag to false before we call NewRegionClient() so we can monitor nodes marked as STUN only in the default derpmap.

Updates #11492