### PR TITLE
prober: fix data race when altering derpmap

### DIFF
--- a/prober/derp.go
+++ b/prober/derp.go
@@ -188,6 +188,9 @@ func (d *derpProber) updateMap(ctx context.Context) error {
 			if existing, ok := d.nodes[n.HostName]; ok {
 				return fmt.Errorf("derpmap has duplicate nodes: %+v and %+v", existing, n)
 			}
+			// Allow the prober to monitor nodes marked as
+			// STUN only in the default map
+			n.STUNOnly = false
 			d.nodes[n.HostName] = n
 		}
 	}
@@ -348,8 +351,6 @@ func newConn(ctx context.Context, dm *tailcfg.DERPMap, n *tailcfg.DERPNode) (*de
 	priv := key.NewNode()
 	dc := derphttp.NewRegionClient(priv, l, nil /* no netMon */, func() *tailcfg.DERPRegion {
 		rid := n.RegionID
-		// Allow the prober to monitor nodes marked as STUN only in the default map
-		n.STUNOnly = false
 		return &tailcfg.DERPRegion{
 			RegionID:   rid,
 			RegionCode: fmt.Sprintf("%s-%s", dm.Regions[rid].RegionCode, n.Name),


### PR DESCRIPTION
Move the clearing of STUNOnly flag to the updateMap() function.

Fixes #8395