### PR TITLE
ssh/tailssh: fix double race condition with non-pty command

### DIFF
--- a/ssh/tailssh/tailssh_test.go
+++ b/ssh/tailssh/tailssh_test.go
@@ -25,6 +25,7 @@ import (
 	"os/user"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -945,6 +946,19 @@ func TestSSH(t *testing.T) {
 		t.Logf("Got: %q and %q", outBuf.Bytes(), errBuf.Bytes())
 		// TODO: figure out why these aren't right. should be
 		// "foo\n" and "bar\n", not "\n" and "bar\n".
+	})
+
+	t.Run("large_file", func(t *testing.T) {
+		const wantSize = 1e6
+		var outBuf bytes.Buffer
+		cmd := execSSH("head", "-c", strconv.Itoa(wantSize), "/dev/zero")
+		cmd.Stdout = &outBuf
+		if err := cmd.Run(); err != nil {
+			t.Fatal(err)
+		}
+		if gotSize := outBuf.Len(); gotSize != wantSize {
+			t.Fatalf("got %d, want %d", gotSize, int(wantSize))
+		}
 	})
 
 	t.Run("stdin", func(t *testing.T) {


### PR DESCRIPTION
There are two race conditions in output handling.

The first race condition is due to a misuse of exec.Cmd.StdoutPipe. The documentation explicitly forbids concurrent use of StdoutPipe with exec.Cmd.Wait (see golang/go#60908) because Wait will close both sides of the pipe once the process ends without any guarantees that all data has been read from the pipe. To fix this, we allocate the os.Pipes ourselves and manage cleanup ourselves when the process has ended.

The second race condition is because sshSession.run waits upon exec.Cmd to finish and then immediately proceeds to call ss.Exit, which will close all output streams going to the SSH client. This may interrupt any asynchronous io.Copy still copying data. To fix this, we close the write-side of the os.Pipes after the process has finished (and before calling ss.Exit) and synchronously wait for the io.Copy routines to finish.

Fixes #7601