### PR TITLE
util/goroutines: let ScrubbedGoroutineDump get only current stack

### DIFF
--- a/control/controlclient/debug.go
+++ b/control/controlclient/debug.go
@@ -20,7 +20,7 @@ func dumpGoroutinesToURL(c *http.Client, targetURL string) {
 
 	zbuf := new(bytes.Buffer)
 	zw := gzip.NewWriter(zbuf)
-	zw.Write(goroutines.ScrubbedGoroutineDump())
+	zw.Write(goroutines.ScrubbedGoroutineDump(true))
 	zw.Close()
 
 	req, err := http.NewRequestWithContext(ctx, "PUT", targetURL, zbuf)

--- a/ipn/ipnlocal/c2n.go
+++ b/ipn/ipnlocal/c2n.go
@@ -49,7 +49,7 @@ func (b *LocalBackend) handleC2N(w http.ResponseWriter, r *http.Request) {
 		}
 	case "/debug/goroutines":
 		w.Header().Set("Content-Type", "text/plain")
-		w.Write(goroutines.ScrubbedGoroutineDump())
+		w.Write(goroutines.ScrubbedGoroutineDump(true))
 	case "/debug/prefs":
 		writeJSON(b.Prefs())
 	case "/debug/metrics":

--- a/util/goroutines/goroutines.go
+++ b/util/goroutines/goroutines.go
@@ -11,15 +11,16 @@ import (
 	"strconv"
 )
 
-// ScrubbedGoroutineDump returns the list of all current goroutines, but with the actual
-// values of arguments scrubbed out, lest it contain some private key material.
-func ScrubbedGoroutineDump() []byte {
+// ScrubbedGoroutineDump returns either the current goroutine's stack or all
+// goroutines' stacks, but with the actual values of arguments scrubbed out,
+// lest it contain some private key material.
+func ScrubbedGoroutineDump(all bool) []byte {
 	var buf []byte
 	// Grab stacks multiple times into increasingly larger buffer sizes
 	// to minimize the risk that we blow past our iOS memory limit.
 	for size := 1 << 10; size <= 1<<20; size += 1 << 10 {
 		buf = make([]byte, size)
-		buf = buf[:runtime.Stack(buf, true)]
+		buf = buf[:runtime.Stack(buf, all)]
 		if len(buf) < size {
 			// It fit.
 			break

--- a/util/goroutines/goroutines_test.go
+++ b/util/goroutines/goroutines_test.go
@@ -6,7 +6,7 @@ package goroutines
 import "testing"
 
 func TestScrubbedGoroutineDump(t *testing.T) {
-	t.Logf("Got:\n%s\n", ScrubbedGoroutineDump())
+	t.Logf("Got:\n%s\n", ScrubbedGoroutineDump(true))
 }
 
 func TestScrubHex(t *testing.T) {


### PR DESCRIPTION
ScrubbedGoroutineDump previously only returned the stacks of all goroutines. I also want to be able to use this for only the current goroutine's stack. Add a bool param to support both ways.

Updates tailscale/corp#5149