### PR TITLE
net/netutil: parse IP forwarding val as int, not bool

### DIFF
--- a/net/netutil/ip_forward.go
+++ b/net/netutil/ip_forward.go
@@ -212,9 +212,16 @@ func ipForwardingEnabledLinux(p protocol, iface string) (bool, error) {
 		}
 		return false, err
 	}
-	on, err := strconv.ParseBool(string(bytes.TrimSpace(bs)))
+
+	val, err := strconv.ParseInt(string(bytes.TrimSpace(bs)), 10, 32)
 	if err != nil {
 		return false, fmt.Errorf("couldn't parse %s: %w", k, err)
 	}
+	// 0 = disabled, 1 = enabled, 2 = enabled (but uncommon)
+	// https://github.com/tailscale/tailscale/issues/8375
+	if val < 0 || val > 2 {
+		return false, fmt.Errorf("unexpected value %d for %s", val, k)
+	}
+	on := val == 1 || val == 2
 	return on, nil
 }


### PR DESCRIPTION
This commit updates our IP forwarding parsing logic to allow the less common but still valid value of `2` to be parsed as `true`, which fixes an error some users encountered.

Fixes #8375