### PR TITLE
ipn/ipnlocal: validate ping type

### DIFF
--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -1331,7 +1331,7 @@ func (h *Handler) servePing(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	pingTypeStr := r.FormValue("type")
-	if ipStr == "" {
+	if pingTypeStr == "" {
 		http.Error(w, "missing 'type' parameter", 400)
 		return
 	}


### PR DESCRIPTION
Correct a minor cut-n-paste error that resulted in an invalid or missing ping type being accepted as a disco ping.

Fixes #8457