### PR TITLE
logpolicy,ipn,cmd/tailscaled: make log files unique

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -45,7 +45,6 @@ import (
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/ipn/policy"
 	"tailscale.com/log/sockstatlog"
-	"tailscale.com/logpolicy"
 	"tailscale.com/net/dns"
 	"tailscale.com/net/dnscache"
 	"tailscale.com/net/dnsfallback"
@@ -314,7 +313,12 @@ func NewLocalBackend(logf logger.Logf, logID logid.PublicID, sys *tsd.System, lo
 	}
 
 	netMon := sys.NetMon.Get()
-	b.sockstatLogger, err = sockstatlog.NewLogger(logpolicy.LogsDir(logf), logf, logID, netMon)
+	// Get the stored logdir here if it exists
+	logDir := ""
+	if v, err := store.ReadState(ipn.LogDirStateKey); err == nil {
+		logDir = string(v)
+	}
+	b.sockstatLogger, err = sockstatlog.NewLogger(logDir, logf, logID, netMon)
 	if err != nil {
 		log.Printf("error setting up sockstat logger: %v", err)
 	}

--- a/ipn/store.go
+++ b/ipn/store.go
@@ -52,6 +52,9 @@ const (
 	// CurrentProfileStateKey is the key under which we store the current
 	// profile.
 	CurrentProfileStateKey = StateKey("_current-profile")
+
+	// Log directory is the path of the directory where we store logs.
+	LogDirStateKey = StateKey("logdir")
 )
 
 // CurrentProfileID returns the StateKey that stores the


### PR DESCRIPTION
Proof of concept to generate unique log files and store them in the client's persistent config so that multiple clients can be run on the same machine without stomping on each other's log files. This uses os.MkdirTemp() to generate uniquely named subdirectories within the existing suite of potential log directories.

Fixes #8476