### PR TITLE
tsweb/varz: use default metrics.LabelMap.Label on serialization

### DIFF
--- a/tsweb/varz/varz.go
+++ b/tsweb/varz/varz.go
@@ -189,7 +189,7 @@ func writePromExpVar(w io.Writer, prefix string, kv expvar.KeyValue) {
 		// IntMap uses expvar.Map on the inside, which presorts
 		// keys. The output ordering is deterministic.
 		v.Do(func(kv expvar.KeyValue) {
-			fmt.Fprintf(w, "%s{%s=%q} %v\n", name, v.Label, kv.Key, kv.Value)
+			fmt.Fprintf(w, "%s{%s=%q} %v\n", name, cmpx.Or(v.Label, "label"), kv.Key, kv.Value)
 		})
 	case *expvar.Map:
 		if label != "" && typ != "" {

--- a/tsweb/varz/varz_test.go
+++ b/tsweb/varz/varz_test.go
@@ -166,6 +166,16 @@ func TestVarzHandler(t *testing.T) {
 			"control_save_config{reason=\"fun\"} 1\ncontrol_save_config{reason=\"new\"} 1\ncontrol_save_config{reason=\"updated\"} 1\n",
 		},
 		{
+			"metrics_label_map_unlabeled",
+			"foo",
+			(func() *metrics.LabelMap {
+				m := &metrics.LabelMap{Label: ""}
+				m.Add("a", 1)
+				return m
+			})(),
+			"foo{label=\"a\"} 1\n",
+		},
+		{
 			"expvar_label_map",
 			"counter_labelmap_keyname_m",
 			func() *expvar.Map {


### PR DESCRIPTION
To not break Prometheus if the label is unset.

Updates tailscale/corp#12830