### PR TITLE
util/linuxfw: add new arch build constraints

### DIFF
--- a/tsnet/tsnet_test.go
+++ b/tsnet/tsnet_test.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"golang.org/x/net/proxy"
+	"tailscale.com/cmd/testwrapper/flakytest"
 	"tailscale.com/ipn"
 	"tailscale.com/ipn/store/mem"
 	"tailscale.com/net/netns"
@@ -356,6 +357,7 @@ func TestLoopbackLocalAPI(t *testing.T) {
 }
 
 func TestLoopbackSOCKS5(t *testing.T) {
+	flakytest.Mark(t, "https://github.com/tailscale/tailscale/issues/8198")
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 

--- a/util/linuxfw/iptables.go
+++ b/util/linuxfw/iptables.go
@@ -1,7 +1,8 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build linux && !(386 || loong64 || arm || armbe)
+// TODO(#8502): add support for more architectures
+//go:build linux && (arm64 || amd64)
 
 package linuxfw
 

--- a/util/linuxfw/linuxfw_struct_linux_test.go
+++ b/util/linuxfw/linuxfw_struct_linux_test.go
@@ -1,7 +1,8 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build linux && !(386 || loong64 || arm || armbe)
+// TODO(#8502): add support for more architectures
+//go:build linux && (arm64 || amd64)
 
 package linuxfw
 

--- a/util/linuxfw/linuxfw_unsupported.go
+++ b/util/linuxfw/linuxfw_unsupported.go
@@ -1,10 +1,11 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-// NOTE: linux_{386,loong64,arm,armbe} are currently unsupported due to missing
+// NOTE: linux_{arm64, x86} are the only two currently supported archs due to missing
 // support in upstream dependencies.
 
-//go:build !linux || (linux && (386 || loong64 || arm || armbe))
+// TODO(#8502): add support for more architectures
+//go:build !linux || (linux && !(arm64 || amd64))
 
 package linuxfw
 

--- a/util/linuxfw/nftables.go
+++ b/util/linuxfw/nftables.go
@@ -1,7 +1,8 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build linux && !(386 || loong64 || arm || armbe)
+// TODO(#8502): add support for more architectures
+//go:build linux && (arm64 || amd64)
 
 package linuxfw
 

--- a/util/linuxfw/nftables_types.go
+++ b/util/linuxfw/nftables_types.go
@@ -1,7 +1,8 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build linux && !(386 || loong64 || arm || armbe)
+// TODO(#8502): add support for more architectures
+//go:build linux && (arm64 || amd64)
 
 package linuxfw
 


### PR DESCRIPTION
Exclide GOARCHs including: mips, mips64, mips64le, mipsle, riscv64. These archs are not supported by gvisor.dev/gvisor/pkg/hostarch.

Updates: #391, #8502

The `gvisor` dependency only supports arm64 and x86 architectures. So we should not include relative files in build when we are on other archs, and include the linuxfw_unsupported file in the build. 

Notice that only `iptables.go` is referencing `gvisor` so technically we only need to exclude `iptables.go` from build. Tho all these files are not really used to we can exclude them just to be safe.