### PR TITLE
docs/k8s: don't call kubectl directly from Makefile

### DIFF
--- a/docs/k8s/Makefile
+++ b/docs/k8s/Makefile
@@ -6,22 +6,20 @@ SA_NAME ?= tailscale
 TS_KUBE_SECRET ?= tailscale
 
 rbac:
-	@sed -e "s;{{TS_KUBE_SECRET}};$(TS_KUBE_SECRET);g" role.yaml | kubectl apply -f -
-	@sed -e "s;{{SA_NAME}};$(SA_NAME);g" rolebinding.yaml | kubectl apply -f -
-	@sed -e "s;{{SA_NAME}};$(SA_NAME);g" sa.yaml | kubectl apply -f -
+	@sed -e "s;{{TS_KUBE_SECRET}};$(TS_KUBE_SECRET);g" role.yaml
+	@echo "---"
+	@sed -e "s;{{SA_NAME}};$(SA_NAME);g" rolebinding.yaml
+	@echo "---"
+	@sed -e "s;{{SA_NAME}};$(SA_NAME);g" sa.yaml
 
 sidecar:
-	@kubectl delete -f sidecar.yaml --ignore-not-found --grace-period=0
-	@sed -e "s;{{TS_KUBE_SECRET}};$(TS_KUBE_SECRET);g" sidecar.yaml | sed -e "s;{{SA_NAME}};$(SA_NAME);g" | kubectl create -f-
+	@sed -e "s;{{TS_KUBE_SECRET}};$(TS_KUBE_SECRET);g" sidecar.yaml | sed -e "s;{{SA_NAME}};$(SA_NAME);g"
 
 userspace-sidecar:
-	@kubectl delete -f userspace-sidecar.yaml --ignore-not-found --grace-period=0
-	@sed -e "s;{{TS_KUBE_SECRET}};$(TS_KUBE_SECRET);g" userspace-sidecar.yaml | sed -e "s;{{SA_NAME}};$(SA_NAME);g" | kubectl create -f-
+	@sed -e "s;{{TS_KUBE_SECRET}};$(TS_KUBE_SECRET);g" userspace-sidecar.yaml | sed -e "s;{{SA_NAME}};$(SA_NAME);g"
 
 proxy:
-	kubectl delete -f proxy.yaml --ignore-not-found --grace-period=0
-	sed -e "s;{{TS_KUBE_SECRET}};$(TS_KUBE_SECRET);g" proxy.yaml | sed -e "s;{{SA_NAME}};$(SA_NAME);g" | sed -e "s;{{TS_DEST_IP}};$(TS_DEST_IP);g" | kubectl create -f-
+	@sed -e "s;{{TS_KUBE_SECRET}};$(TS_KUBE_SECRET);g" proxy.yaml | sed -e "s;{{SA_NAME}};$(SA_NAME);g" | sed -e "s;{{TS_DEST_IP}};$(TS_DEST_IP);g"
 
 subnet-router:
-	@kubectl delete -f subnet.yaml --ignore-not-found --grace-period=0
-	@sed -e "s;{{TS_KUBE_SECRET}};$(TS_KUBE_SECRET);g" subnet.yaml | sed -e "s;{{SA_NAME}};$(SA_NAME);g" | sed -e "s;{{TS_ROUTES}};$(TS_ROUTES);g" | kubectl create -f-
+	@sed -e "s;{{TS_KUBE_SECRET}};$(TS_KUBE_SECRET);g" subnet.yaml | sed -e "s;{{SA_NAME}};$(SA_NAME);g" | sed -e "s;{{TS_ROUTES}};$(TS_ROUTES);g"

--- a/docs/k8s/README.md
+++ b/docs/k8s/README.md
@@ -26,7 +26,7 @@ There are quite a few ways of running Tailscale inside a Kubernetes Cluster, som
    ```bash
    export SA_NAME=tailscale
    export TS_KUBE_SECRET=tailscale-auth
-   make rbac
+   make rbac | kubectl apply -f-
    ```
 
 ### Sample Sidecar
@@ -36,7 +36,7 @@ Running as a sidecar allows you to directly expose a Kubernetes pod over Tailsca
 1. Create and login to the sample nginx pod with a Tailscale sidecar
 
    ```bash
-   make sidecar
+   make sidecar | kubectl apply -f-
    # If not using an auth key, authenticate by grabbing the Login URL here:
    kubectl logs nginx ts-sidecar
    ```
@@ -60,7 +60,7 @@ You can also run the sidecar in userspace mode. The obvious benefit is reducing 
 1. Create and login to the sample nginx pod with a Tailscale sidecar
 
    ```bash
-   make userspace-sidecar
+   make userspace-sidecar | kubectl apply -f-
    # If not using an auth key, authenticate by grabbing the Login URL here:
    kubectl logs nginx ts-sidecar
    ```
@@ -100,7 +100,7 @@ Running a Tailscale proxy allows you to provide inbound connectivity to a Kubern
 1. Deploy the proxy pod
 
    ```bash
-   make proxy
+   make proxy | kubectl apply -f-
    # If not using an auth key, authenticate by grabbing the Login URL here:
    kubectl logs proxy
    ```
@@ -133,7 +133,7 @@ the entire Kubernetes cluster network (assuming NetworkPolicies allow) over Tail
 1. Deploy the subnet-router pod.
 
    ```bash
-   make subnet-router
+   make subnet-router | kubectl apply -f-
    # If not using an auth key, authenticate by grabbing the Login URL here:
    kubectl logs subnet-router
    ```


### PR DESCRIPTION
Instead of calling kubectl directly in k8s Makefile, write the yaml to stdout so it can be reviewed/edited/etc before manually applying with kubectl.

Docs can be updated to, ex, `make subnet-router | kubectl apply -f -` so they can continue to work with "one click".

Fixes: https://github.com/tailscale/tailscale/issues/8511

Ping: @maisem 