### PR TITLE
tsnet: add Server.AdvertisedTags option

### DIFF
--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -113,6 +113,13 @@ type Server struct {
 	// field at zero unless you know what you are doing.
 	Port uint16
 
+	// AdvertiseTags specifies groups that this embedded server wants to join, for
+	// purposes of ACL enforcement. These can be referenced from the ACL
+	// security policy. Note that advertising a tag doesn't guarantee that
+	// the control server will allow you to take on the rights for that
+	// tag.
+	AdvertiseTags []string
+
 	getCertForTesting func(*tls.ClientHelloInfo) (*tls.Certificate, error)
 
 	initOnce         sync.Once
@@ -567,6 +574,7 @@ func (s *Server) start() (reterr error) {
 	prefs.Hostname = s.hostname
 	prefs.WantRunning = true
 	prefs.ControlURL = s.ControlURL
+	prefs.AdvertiseTags = s.AdvertiseTags
 	authKey := s.getAuthKey()
 	err = lb.Start(ipn.Options{
 		UpdatePrefs: prefs,


### PR DESCRIPTION
expose ipn.Prefs AdvertiseTags to library consumers

As part of my work on the [Tailscale-based Ingress Controller](https://github.com/valentinalexeev/tailscale-ingress-controller), I would like to be able to advertise additional tags on the tailing for HTTP and TCP services.

To achieve this, I need the tsnet library to accept the AdvertiseTags as an option when Server starts.