### PR TITLE
version: fix tvOS network extension bundle identifier

### DIFF
--- a/version/prop.go
+++ b/version/prop.go
@@ -88,7 +88,7 @@ func IsAppleTV() bool {
 		return false
 	}
 	return isAppleTV.Get(func() bool {
-		return strings.EqualFold(os.Getenv("XPC_SERVICE_NAME"), "io.tailscale.ipn.tvos.network-extension")
+		return strings.EqualFold(os.Getenv("XPC_SERVICE_NAME"), "io.tailscale.ipn.ios.network-extension-tvos")
 	})
 }
 


### PR DESCRIPTION
Fixes #8544. Updates #8282.

We renamed the tvOS network extension bundle identifier to io.tailscale.ipn.ios.network-extension-tvos from io.tailscale.ipn.tvos.network-extension to allow for a shared App Store submission between iOS and tvOS.

Need to adjust this in [version/prop.go](https://github.com/tailscale/tailscale/blob/cd4c71c1225aa6703b0766d1cde6b34c67a87dd6/version/prop.go#L91).