### PR TITLE
tailcfg: add json omitempty to DNSConfig.ExitNodeFilteredSet

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -1282,7 +1282,7 @@ type DNSConfig struct {
 	// match.
 	//
 	// Matches are case insensitive.
-	ExitNodeFilteredSet []string
+	ExitNodeFilteredSet []string `json:",omitempty"`
 }
 
 // DNSRecord is an extra DNS record to add to MagicDNS.


### PR DESCRIPTION
We were storing a lot of `"ExitNodeFilteredSet":null` in the database.

Updates tailscale/corp#1818 (found in the process)