### PR TITLE
cmd/derper: add X-Content-Type-Options: nosniff

### DIFF
--- a/cmd/derper/derper.go
+++ b/cmd/derper/derper.go
@@ -289,6 +289,7 @@ func main() {
 			// these browser-centric headers anyway.
 			w.Header().Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
 			w.Header().Set("Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'; form-action 'none'; base-uri 'self'; block-all-mixed-content; plugin-types 'none'")
+			w.Header().Set("X-Content-Type-Options", "nosniff")
 			mux.ServeHTTP(w, r)
 		})
 		if *httpPort > -1 {

--- a/cmd/derper/derper.go
+++ b/cmd/derper/derper.go
@@ -182,26 +182,10 @@ func main() {
 	}
 	mux.HandleFunc("/derp/probe", probeHandler)
 	go refreshBootstrapDNSLoop()
-	mux.HandleFunc("/bootstrap-dns", handleBootstrapDNS)
+	mux.HandleFunc("/bootstrap-dns", tsweb.BrowserHeaderHandlerFunc(handleBootstrapDNS))
 	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tsweb.AddBrowserHeaders(w)
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		// Set HTTP headers to appease automated security scanners.
-		//
-		// Security automation gets cranky when HTTPS sites don't
-		// set HSTS, and when they don't specify a content
-		// security policy for XSS mitigation.
-		//
-		// DERP's HTTP interface is only ever used for debug
-		// access (for which trivial safe policies work just
-		// fine), and by DERP clients which don't obey any of
-		// these browser-centric headers anyway.
-		//
-		// Note: if we ever add a real UI component to DERP, these headers
-		// should move to a middleware wrapper that applies to more request
-		// paths.
-		w.Header().Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
-		w.Header().Set("Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'; form-action 'none'; base-uri 'self'; block-all-mixed-content; plugin-types 'none'")
-		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.WriteHeader(200)
 		io.WriteString(w, `<html><body>
 <h1>DERP</h1>
@@ -220,6 +204,7 @@ func main() {
 		}
 	}))
 	mux.Handle("/robots.txt", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tsweb.AddBrowserHeaders(w)
 		io.WriteString(w, "User-agent: *\nDisallow: /\n")
 	}))
 	mux.Handle("/generate_204", http.HandlerFunc(serveNoContent))

--- a/tsweb/debug.go
+++ b/tsweb/debug.go
@@ -46,12 +46,12 @@ func Debugger(mux *http.ServeMux) *DebugHandler {
 	ret := &DebugHandler{
 		mux: mux,
 	}
-	mux.Handle("/debug/", ret)
+	mux.Handle("/debug/", BrowserHeaderHandler(ret))
 
 	// Register this one directly on mux, rather than using
 	// ret.URL/etc, as we don't need another line of output on the
 	// index page. The /pprof/ index already covers it.
-	mux.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
+	mux.Handle("/debug/pprof/profile", BrowserHeaderHandler(http.HandlerFunc(pprof.Profile)))
 
 	ret.KVFunc("Uptime", func() any { return varz.Uptime() })
 	ret.KV("Version", version.Long())
@@ -97,7 +97,7 @@ func (d *DebugHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // entry in /debug/ for it.
 func (d *DebugHandler) Handle(slug, desc string, handler http.Handler) {
 	href := "/debug/" + slug
-	d.mux.Handle(href, Protected(handler))
+	d.mux.Handle(href, Protected(BrowserHeaderHandler(handler)))
 	d.URL(href, desc)
 }
 

--- a/tsweb/debug.go
+++ b/tsweb/debug.go
@@ -46,7 +46,7 @@ func Debugger(mux *http.ServeMux) *DebugHandler {
 	ret := &DebugHandler{
 		mux: mux,
 	}
-	mux.Handle("/debug/", BrowserHeaderHandler(ret))
+	mux.Handle("/debug/", ret)
 
 	// Register this one directly on mux, rather than using
 	// ret.URL/etc, as we don't need another line of output on the
@@ -80,6 +80,7 @@ func (d *DebugHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	AddBrowserHeaders(w)
 	f := func(format string, args ...any) { fmt.Fprintf(w, format, args...) }
 	f("<html><body><h1>%s debug</h1><ul>", version.CmdName())
 	for _, kv := range d.kvs {

--- a/tsweb/tsweb.go
+++ b/tsweb/tsweb.go
@@ -427,9 +427,9 @@ func VarzHandler(w http.ResponseWriter, r *http.Request) {
 // AddBrowserHeaders sets various HTTP security headers for browser-facing endpoints.
 //
 // The specific headers:
-// - require HTTPS access (HSTS)
-// - disallow iframe embedding
-// - mitigate MIME confusion attacks
+//   - require HTTPS access (HSTS)
+//   - disallow iframe embedding
+//   - mitigate MIME confusion attacks
 //
 // These headers are based on
 // https://infosec.mozilla.org/guidelines/web_security

--- a/tsweb/tsweb.go
+++ b/tsweb/tsweb.go
@@ -423,3 +423,37 @@ func Error(code int, msg string, err error) HTTPError {
 func VarzHandler(w http.ResponseWriter, r *http.Request) {
 	varz.Handler(w, r)
 }
+
+// AddBrowserHeaders sets various HTTP security headers for browser-facing endpoints.
+//
+// The specific headers:
+// - require HTTPS access (HSTS)
+// - disallow iframe embedding
+// - mitigate MIME confusion attacks
+//
+// These headers are based on
+// https://infosec.mozilla.org/guidelines/web_security
+func AddBrowserHeaders(w http.ResponseWriter) {
+	w.Header().Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
+	w.Header().Set("Content-Security-Policy", "default-src 'self'; frame-ancestors 'none'; form-action 'none'; base-uri 'self'; block-all-mixed-content; plugin-types 'none'")
+	w.Header().Set("X-Frame-Options", "DENY")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+}
+
+// BrowserHeaderHandler wraps the provided http.Handler with a call to
+// AddBrowserHeaders.
+func BrowserHeaderHandler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		AddBrowserHeaders(w)
+		h.ServeHTTP(w, r)
+	})
+}
+
+// BrowserHeaderHandlerFunc wraps the provided http.HandlerFunc with a call to
+// AddBrowserHeaders.
+func BrowserHeaderHandlerFunc(h http.HandlerFunc) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		AddBrowserHeaders(w)
+		h.ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
This is one of generic HTTP hardening headers (for XSS) that has no impact on real usage. Doesn't do much for derper, but makes security scanners happy.