### PR TITLE
wgengine/netlog: fix nil pointer dereference in logtail

### DIFF
--- a/wgengine/netlog/logger.go
+++ b/wgengine/netlog/logger.go
@@ -101,7 +101,7 @@ func (nl *Logger) Startup(nodeID tailcfg.StableNodeID, nodeLogID, domainLogID lo
 	}
 
 	// Startup a log stream to Tailscale's logging service.
-	httpc := &http.Client{Transport: logpolicy.NewLogtailTransport(logtail.DefaultHost, netMon, nl.logger.Logf)}
+	httpc := &http.Client{Transport: logpolicy.NewLogtailTransport(logtail.DefaultHost, netMon, nil)}
 	if testClient != nil {
 		httpc = testClient
 	}


### PR DESCRIPTION
When `Logger.Startup` is called and a new `http.Client` is initialized for logtail, `nl.logger` is nil. It's initialized right after creating the `http.Client`. But because we're passing a method value, it actually works and passes the value with a `nil` receiver.
Later, when `logtail.Logger.Logf` is called from the `http.Client`, `tailscaled` panics when trying to access the fields of that nil logger.