### PR TITLE
cmd/tailscale: remove TS_EXPERIMENT_OAUTH_AUTHKEY guardrail

### DIFF
--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -30,7 +30,6 @@ import (
 	qrcode "github.com/skip2/go-qrcode"
 	"golang.org/x/oauth2/clientcredentials"
 	"tailscale.com/client/tailscale"
-	"tailscale.com/envknob"
 	"tailscale.com/health/healthmsg"
 	"tailscale.com/ipn"
 	"tailscale.com/ipn/ipnstate"
@@ -1131,9 +1130,6 @@ func init() {
 func resolveAuthKey(ctx context.Context, v, tags string) (string, error) {
 	if !strings.HasPrefix(v, "tskey-client-") {
 		return v, nil
-	}
-	if !envknob.Bool("TS_EXPERIMENT_OAUTH_AUTHKEY") {
-		return "", errors.New("oauth authkeys are in experimental status")
 	}
 	if tags == "" {
 		return "", errors.New("oauth authkeys require --advertise-tags")


### PR DESCRIPTION
We've had support for OAuth client keys in `--authkey=...` for several releases, and we're using it in
https://github.com/tailscale/github-action

Remove the TS_EXPERIMENT_* guardrail, it is fully supported now.

Fixes https://github.com/tailscale/tailscale/issues/8403