### PR TITLE
cmd/tailscale/cli: fix panic in netcheck print when no DERP home

### DIFF
--- a/cmd/tailscale/cli/netcheck.go
+++ b/cmd/tailscale/cli/netcheck.go
@@ -148,7 +148,11 @@ func printReport(dm *tailcfg.DERPMap, report *netcheck.Report) error {
 	if len(report.RegionLatency) == 0 {
 		printf("\t* Nearest DERP: unknown (no response to latency probes)\n")
 	} else {
-		printf("\t* Nearest DERP: %v\n", dm.Regions[report.PreferredDERP].RegionName)
+		if report.PreferredDERP != 0 {
+			printf("\t* Nearest DERP: %v\n", dm.Regions[report.PreferredDERP].RegionName)
+		} else {
+			printf("\t* Nearest DERP: [none]\n")
+		}
 		printf("\t* DERP latency:\n")
 		var rids []int
 		for rid := range dm.Regions {


### PR DESCRIPTION
Fixes #8016