### PR TITLE
wgengine/router,ipn/ipnlocal: add MTU field to router config

### DIFF
--- a/wgengine/router/router.go
+++ b/wgengine/router/router.go
@@ -67,6 +67,11 @@ type Config struct {
 	// routing rules apply.
 	LocalRoutes []netip.Prefix
 
+	// NewMTU is currently only used by the MacOS network extension
+	// app to set the MTU of the tun in the router configuration
+	// callback. If zero, the MTU is unchanged.
+	NewMTU int
+
 	// Linux-only things below, ignored on other platforms.
 	SubnetRoutes     []netip.Prefix         // subnets being advertised to other Tailscale nodes
 	SNATSubnetRoutes bool                   // SNAT traffic to local subnets

--- a/wgengine/router/router_test.go
+++ b/wgengine/router/router_test.go
@@ -21,8 +21,8 @@ func mustCIDRs(ss ...string) []netip.Prefix {
 
 func TestConfigEqual(t *testing.T) {
 	testedFields := []string{
-		"LocalAddrs", "Routes", "LocalRoutes", "SubnetRoutes",
-		"SNATSubnetRoutes", "NetfilterMode",
+		"LocalAddrs", "Routes", "LocalRoutes", "NewMTU",
+		"SubnetRoutes", "SNATSubnetRoutes", "NetfilterMode",
 	}
 	configType := reflect.TypeOf(Config{})
 	configFields := []string{}
@@ -133,6 +133,16 @@ func TestConfigEqual(t *testing.T) {
 			&Config{NetfilterMode: preftype.NetfilterNoDivert},
 			&Config{NetfilterMode: preftype.NetfilterNoDivert},
 			true,
+		},
+		{
+			&Config{NewMTU: 0},
+			&Config{NewMTU: 0},
+			true,
+		},
+		{
+			&Config{NewMTU: 1280},
+			&Config{NewMTU: 0},
+			false,
 		},
 	}
 	for i, tt := range tests {


### PR DESCRIPTION
The MacOS client can't set the MTU when creating the tun due to lack of permissions, so add it to the router config and have MacOS set it in the callback using a method that it does have permissions for.

Updates #8219