### PR TITLE
control/controlclient: reset backoff in mapRoutine on netmap recv

### DIFF
--- a/control/controlclient/auto.go
+++ b/control/controlclient/auto.go
@@ -551,6 +551,8 @@ func (c *Auto) mapRoutine() {
 				if stillAuthed {
 					c.sendStatus("mapRoutine-got-netmap", nil, "", nm)
 				}
+				// Reset the backoff timer if we got a netmap.
+				bo.BackOff(ctx, nil)
 			})
 
 			health.SetInPollNetMap(false)


### PR DESCRIPTION
We were never resetting the backoff in streaming mapResponses. The call to `PollNetMap` always returns with an error. Changing that contract is harder, so manually reset backoff when a netmap is received.

Updates tailscale/corp#12894