### PR TITLE
serve: fix hostname for custom http ports

### DIFF
--- a/cmd/tailscale/cli/serve.go
+++ b/cmd/tailscale/cli/serve.go
@@ -699,7 +699,7 @@ func (e *serveEnv) printWebStatusTree(sc *ipn.ServeConfig, hp ipn.HostPort) erro
 		portPart = ""
 	}
 	if scheme == "http" {
-		hostname, _, _ := strings.Cut("host", ".")
+		hostname, _, _ := strings.Cut(host, ".")
 		printf("%s://%s%s (%s)\n", scheme, hostname, portPart, fStatus)
 	}
 	printf("%s://%s%s (%s)\n", scheme, host, portPart, fStatus)

--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -415,6 +415,9 @@ func (b *LocalBackend) getServeHandler(r *http.Request) (_ ipn.HTTPHandlerView, 
 	hostname := r.Host
 	if r.TLS == nil {
 		tcd := "." + b.Status().CurrentTailnet.MagicDNSSuffix
+		if host, _, err := net.SplitHostPort(hostname); err == nil {
+			hostname = host
+		}
 		if !strings.HasSuffix(hostname, tcd) {
 			hostname += tcd
 		}


### PR DESCRIPTION
When using a custom http port like 8080, this was resulting in a constructed hostname of `host.tailnet.ts.net:8080.tailnet.ts.net` when looking up the serve handler. Instead, strip off the port before adding the MagicDNS suffix.

Also use the actual hostname in `serve status` rather than the literal string "host".

Fixes #8635