### PR TITLE
net/netcheck: ignore PreferredDERP changes that are small

### DIFF
--- a/net/netcheck/netcheck_test.go
+++ b/net/netcheck/netcheck_test.go
@@ -328,6 +328,15 @@ func TestAddReportHistoryAndSetPreferredDERP(t *testing.T) {
 			wantDERP:    1, // 2 didn't get fast enough
 		},
 		{
+			name: "preferred_derp_hysteresis_no_switch_absolute",
+			steps: []step{
+				{0 * time.Second, report("d1", 4*time.Millisecond, "d2", 5*time.Millisecond)},
+				{1 * time.Second, report("d1", 4*time.Millisecond, "d2", 1*time.Millisecond)},
+			},
+			wantPrevLen: 2,
+			wantDERP:    1, // 2 is 50%+ faster, but the absolute diff is <10ms
+		},
+		{
 			name: "preferred_derp_hysteresis_do_switch",
 			steps: []step{
 				{0 * time.Second, report("d1", 4, "d2", 5)},


### PR DESCRIPTION
If the absolute value of the difference between the current PreferredDERP's latency and the best latency is <= 10ms, don't change it and instead prefer the previous value.

This is in addition to the existing hysteresis that tries to remain on the previous DERP region if the relative improvement is small, but handles nodes that have low latency to >1 DERP region better.

Updates #8603


Change-Id: I1e34c94178f8c9a68a69921c5bc0227337514c70