### PR TITLE
all: implement lock revoke-keys command

### DIFF
--- a/ipn/ipnlocal/network-lock_test.go
+++ b/ipn/ipnlocal/network-lock_test.go
@@ -994,3 +994,129 @@ func TestTKAAffectedSigs(t *testing.T) {
 		})
 	}
 }
+
+func TestTKARecoverCompromisedKeyFlow(t *testing.T) {
+	nodePriv := key.NewNode()
+	nlPriv := key.NewNLPrivate()
+	cosignPriv := key.NewNLPrivate()
+	compromisedPriv := key.NewNLPrivate()
+
+	pm := must.Get(newProfileManager(new(mem.Store), t.Logf))
+	must.Do(pm.SetPrefs((&ipn.Prefs{
+		Persist: &persist.Persist{
+			PrivateNodeKey: nodePriv,
+			NetworkLockKey: nlPriv,
+		},
+	}).View()))
+
+	// Make a fake TKA authority, to seed local state.
+	disablementSecret := bytes.Repeat([]byte{0xa5}, 32)
+	key := tka.Key{Kind: tka.Key25519, Public: nlPriv.Public().Verifier(), Votes: 2}
+	cosignKey := tka.Key{Kind: tka.Key25519, Public: cosignPriv.Public().Verifier(), Votes: 2}
+	compromisedKey := tka.Key{Kind: tka.Key25519, Public: compromisedPriv.Public().Verifier(), Votes: 1}
+
+	temp := t.TempDir()
+	tkaPath := filepath.Join(temp, "tka-profile", string(pm.CurrentProfile().ID))
+	os.Mkdir(tkaPath, 0755)
+	chonk, err := tka.ChonkDir(tkaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authority, _, err := tka.Create(chonk, tka.State{
+		Keys:               []tka.Key{key, compromisedKey, cosignKey},
+		DisablementSecrets: [][]byte{tka.DisablementKDF(disablementSecret)},
+	}, nlPriv)
+	if err != nil {
+		t.Fatalf("tka.Create() failed: %v", err)
+	}
+
+	ts, client := fakeNoiseServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		switch r.URL.Path {
+		case "/machine/tka/sync/send":
+			body := new(tailcfg.TKASyncSendRequest)
+			if err := json.NewDecoder(r.Body).Decode(body); err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("got sync send:\n%+v", body)
+
+			var remoteHead tka.AUMHash
+			if err := remoteHead.UnmarshalText([]byte(body.Head)); err != nil {
+				t.Fatalf("head unmarshal: %v", err)
+			}
+			toApply := make([]tka.AUM, len(body.MissingAUMs))
+			for i, a := range body.MissingAUMs {
+				if err := toApply[i].Unserialize(a); err != nil {
+					t.Fatalf("decoding missingAUM[%d]: %v", i, err)
+				}
+			}
+
+			// Apply the recovery AUM to an authority to make sure it works.
+			if err := authority.Inform(chonk, toApply); err != nil {
+				t.Errorf("recovery AUM could not be applied: %v", err)
+			}
+			// Make sure the key we removed isn't trusted.
+			if authority.KeyTrusted(compromisedPriv.KeyID()) {
+				t.Error("compromised key was not removed from tka")
+			}
+
+			w.WriteHeader(200)
+			if err := json.NewEncoder(w).Encode(tailcfg.TKASubmitSignatureResponse{}); err != nil {
+				t.Fatal(err)
+			}
+
+		default:
+			t.Errorf("unhandled endpoint path: %v", r.URL.Path)
+			w.WriteHeader(404)
+		}
+	}))
+	defer ts.Close()
+	cc := fakeControlClient(t, client)
+	b := LocalBackend{
+		varRoot: temp,
+		cc:      cc,
+		ccAuto:  cc,
+		logf:    t.Logf,
+		tka: &tkaState{
+			authority: authority,
+			storage:   chonk,
+		},
+		pm:    pm,
+		store: pm.Store(),
+	}
+
+	aum, err := b.NetworkLockGenerateRecoveryAUM([]tkatype.KeyID{compromisedPriv.KeyID()}, tka.AUMHash{})
+	if err != nil {
+		t.Fatalf("NetworkLockGenerateRecoveryAUM() failed: %v", err)
+	}
+
+	// Cosign using the cosigning key.
+	{
+		pm := must.Get(newProfileManager(new(mem.Store), t.Logf))
+		must.Do(pm.SetPrefs((&ipn.Prefs{
+			Persist: &persist.Persist{
+				PrivateNodeKey: nodePriv,
+				NetworkLockKey: cosignPriv,
+			},
+		}).View()))
+		b := LocalBackend{
+			varRoot: temp,
+			logf:    t.Logf,
+			tka: &tkaState{
+				authority: authority,
+				storage:   chonk,
+			},
+			pm:    pm,
+			store: pm.Store(),
+		}
+		if aum, err = b.NetworkLockCosignRecoveryAUM(aum); err != nil {
+			t.Fatalf("NetworkLockCosignRecoveryAUM() failed: %v", err)
+		}
+	}
+
+	// Finally, submit the recovery AUM. Validation is done
+	// in the fake control handler.
+	if err := b.NetworkLockSubmitRecoveryAUM(aum); err != nil {
+		t.Errorf("NetworkLockSubmitRecoveryAUM() failed: %v", err)
+	}
+}

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -44,6 +44,7 @@ import (
 	"tailscale.com/types/logger"
 	"tailscale.com/types/logid"
 	"tailscale.com/types/ptr"
+	"tailscale.com/types/tkatype"
 	"tailscale.com/util/clientmetric"
 	"tailscale.com/util/httpm"
 	"tailscale.com/util/mak"
@@ -106,6 +107,9 @@ var handler = map[string]localAPIHandler{
 	"tka/affected-sigs":           (*Handler).serveTKAAffectedSigs,
 	"tka/wrap-preauth-key":        (*Handler).serveTKAWrapPreauthKey,
 	"tka/verify-deeplink":         (*Handler).serveTKAVerifySigningDeeplink,
+	"tka/generate-recovery-aum":   (*Handler).serveTKAGenerateRecoveryAUM,
+	"tka/cosign-recovery-aum":     (*Handler).serveTKACosignRecoveryAUM,
+	"tka/submit-recovery-aum":     (*Handler).serveTKASubmitRecoveryAUM,
 	"upload-client-metrics":       (*Handler).serveUploadClientMetrics,
 	"watch-ipn-bus":               (*Handler).serveWatchIPNBus,
 	"whois":                       (*Handler).serveWhoIs,
@@ -1745,6 +1749,103 @@ func (h *Handler) serveTKAAffectedSigs(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(j)
+}
+
+func (h *Handler) serveTKAGenerateRecoveryAUM(w http.ResponseWriter, r *http.Request) {
+	if !h.PermitWrite {
+		http.Error(w, "access denied", http.StatusForbidden)
+		return
+	}
+	if r.Method != httpm.POST {
+		http.Error(w, "use POST", http.StatusMethodNotAllowed)
+		return
+	}
+
+	type verifyRequest struct {
+		Keys     []tkatype.KeyID
+		ForkFrom string
+	}
+	var req verifyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON for verifyRequest body", http.StatusBadRequest)
+		return
+	}
+
+	var forkFrom tka.AUMHash
+	if req.ForkFrom != "" {
+		if err := forkFrom.UnmarshalText([]byte(req.ForkFrom)); err != nil {
+			http.Error(w, "decoding fork-from: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+
+	res, err := h.b.NetworkLockGenerateRecoveryAUM(req.Keys, forkFrom)
+	if err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Write(res.Serialize())
+}
+
+func (h *Handler) serveTKACosignRecoveryAUM(w http.ResponseWriter, r *http.Request) {
+	if !h.PermitWrite {
+		http.Error(w, "access denied", http.StatusForbidden)
+		return
+	}
+	if r.Method != httpm.POST {
+		http.Error(w, "use POST", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body := io.LimitReader(r.Body, 1024*1024)
+	aumBytes, err := ioutil.ReadAll(body)
+	if err != nil {
+		http.Error(w, "reading AUM", http.StatusBadRequest)
+		return
+	}
+	var aum tka.AUM
+	if err := aum.Unserialize(aumBytes); err != nil {
+		http.Error(w, "decoding AUM", http.StatusBadRequest)
+		return
+	}
+
+	res, err := h.b.NetworkLockCosignRecoveryAUM(&aum)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Write(res.Serialize())
+}
+
+func (h *Handler) serveTKASubmitRecoveryAUM(w http.ResponseWriter, r *http.Request) {
+	if !h.PermitWrite {
+		http.Error(w, "access denied", http.StatusForbidden)
+		return
+	}
+	if r.Method != httpm.POST {
+		http.Error(w, "use POST", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body := io.LimitReader(r.Body, 1024*1024)
+	aumBytes, err := ioutil.ReadAll(body)
+	if err != nil {
+		http.Error(w, "reading AUM", http.StatusBadRequest)
+		return
+	}
+	var aum tka.AUM
+	if err := aum.Unserialize(aumBytes); err != nil {
+		http.Error(w, "decoding AUM", http.StatusBadRequest)
+		return
+	}
+
+	if err := h.b.NetworkLockSubmitRecoveryAUM(&aum); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
 }
 
 // serveProfiles serves profile switching-related endpoints. Supported methods

--- a/tka/tka.go
+++ b/tka/tka.go
@@ -28,6 +28,9 @@ var cborDecOpts = cbor.DecOptions{
 	MaxMapPairs:      1024,
 }
 
+// Arbitrarily chosen limit on scanning AUM trees.
+const maxScanIterations = 2000
+
 // Authority is a Tailnet Key Authority. This type is the main coupling
 // point to the rest of the tailscale client.
 //
@@ -471,7 +474,7 @@ func Open(storage Chonk) (*Authority, error) {
 		return nil, fmt.Errorf("reading last ancestor: %v", err)
 	}
 
-	c, err := computeActiveChain(storage, a, 2000)
+	c, err := computeActiveChain(storage, a, maxScanIterations)
 	if err != nil {
 		return nil, fmt.Errorf("active chain: %v", err)
 	}
@@ -604,7 +607,7 @@ func (a *Authority) InformIdempotent(storage Chonk, updates []AUM) (Authority, e
 		state, hasState := stateAt[parent]
 		var err error
 		if !hasState {
-			if state, err = computeStateAt(storage, 2000, parent); err != nil {
+			if state, err = computeStateAt(storage, maxScanIterations, parent); err != nil {
 				return Authority{}, fmt.Errorf("update %d computing state: %v", i, err)
 			}
 			stateAt[parent] = state
@@ -639,7 +642,7 @@ func (a *Authority) InformIdempotent(storage Chonk, updates []AUM) (Authority, e
 	}
 
 	oldestAncestor := a.oldestAncestor.Hash()
-	c, err := computeActiveChain(storage, &oldestAncestor, 2000)
+	c, err := computeActiveChain(storage, &oldestAncestor, maxScanIterations)
 	if err != nil {
 		return Authority{}, fmt.Errorf("recomputing active chain: %v", err)
 	}
@@ -720,4 +723,116 @@ func (a *Authority) Compact(storage CompactableChonk, o CompactionOptions) error
 	}
 	a.oldestAncestor = ancestor
 	return nil
+}
+
+// findParentForRewrite finds the parent AUM to use when rewriting state to
+// retroactively remove trust in the specified keys.
+func (a *Authority) findParentForRewrite(storage Chonk, removeKeys []tkatype.KeyID, ourKey tkatype.KeyID) (AUMHash, error) {
+	cursor := a.Head()
+
+	for {
+		if cursor == a.oldestAncestor.Hash() {
+			// We've reached as far back in our history as we can,
+			// so we have to rewrite from here.
+			break
+		}
+
+		aum, err := storage.AUM(cursor)
+		if err != nil {
+			return AUMHash{}, fmt.Errorf("reading AUM %v: %w", cursor, err)
+		}
+
+		// An ideal rewrite parent trusts none of the keys to be removed.
+		state, err := computeStateAt(storage, maxScanIterations, cursor)
+		if err != nil {
+			return AUMHash{}, fmt.Errorf("computing state for %v: %w", cursor, err)
+		}
+		keyTrusted := false
+		for _, key := range removeKeys {
+			if _, err := state.GetKey(key); err == nil {
+				keyTrusted = true
+			}
+		}
+		if !keyTrusted {
+			// Success: the revoked keys are not trusted!
+			// Lets check that our key was trusted to ensure
+			// we can sign a fork from here.
+			if _, err := state.GetKey(ourKey); err == nil {
+				break
+			}
+		}
+
+		parent, hasParent := aum.Parent()
+		if !hasParent {
+			// This is the genesis AUM, so we have to rewrite from here.
+			break
+		}
+		cursor = parent
+	}
+
+	return cursor, nil
+}
+
+// MakeRetroactiveRevocation generates a forking update which revokes the specified keys, in
+// such a manner that any malicious use of those keys is erased.
+//
+// If forkFrom is specified, it is used as the parent AUM to fork from. If the zero value,
+// the parent AUM is determined automatically.
+//
+// The generated AUM must be signed with more signatures than the sum of key votes that
+// were compromised, before being consumed by tka.Authority methods.
+func (a *Authority) MakeRetroactiveRevocation(storage Chonk, removeKeys []tkatype.KeyID, ourKey tkatype.KeyID, forkFrom AUMHash) (*AUM, error) {
+	var parent AUMHash
+	if forkFrom == (AUMHash{}) {
+		// Make sure at least one of the recovery keys is currently trusted.
+		foundKey := false
+		for _, k := range removeKeys {
+			if _, err := a.state.GetKey(k); err == nil {
+				foundKey = true
+				break
+			}
+		}
+		if !foundKey {
+			return nil, errors.New("no provided key is currently trusted")
+		}
+
+		p, err := a.findParentForRewrite(storage, removeKeys, ourKey)
+		if err != nil {
+			return nil, fmt.Errorf("finding parent: %v", err)
+		}
+		parent = p
+	} else {
+		parent = forkFrom
+	}
+
+	// Construct the new state where the revoked keys are no longer trusted.
+	state := a.state.Clone()
+	for _, keyToRevoke := range removeKeys {
+		idx := -1
+		for i := range state.Keys {
+			keyID, err := state.Keys[i].ID()
+			if err != nil {
+				return nil, fmt.Errorf("computing keyID: %v", err)
+			}
+			if bytes.Equal(keyToRevoke, keyID) {
+				idx = i
+				break
+			}
+		}
+		if idx >= 0 {
+			state.Keys = append(state.Keys[:idx], state.Keys[idx+1:]...)
+		}
+	}
+	if len(state.Keys) == 0 {
+		return nil, errors.New("cannot revoke all trusted keys")
+	}
+	state.LastAUMHash = nil // checkpoints can't specify a LastAUMHash
+
+	forkingAUM := &AUM{
+		MessageKind: AUMCheckpoint,
+		State:       &state,
+		PrevAUMHash: parent[:],
+	}
+
+	return forkingAUM, forkingAUM.StaticValidate()
 }


### PR DESCRIPTION
The recover-compromised-key command allows nodes with tailnet lock keys
to collaborate to erase the use of a compromised key, and remove trust
in it.

I could use some help with the help text for sure.

```
[nix-shell:~/tailscale]$ go build -o tailscale ./cmd/tailscale && sudo ./tailscale --socket=/tmp/ts/ts1.sock lock recover-compromised-key --help
USAGE
  recover-compromised-key <tailnet-lock-key>... or recover-compromised-key [--cosign] [--finish] <recovery-blob>

Retroactively revokes trust in the specified keys, erasing any trust in those keys and preventing them from being used in the future.

Start the process by running: tailscale recover-compromised-key <keys>, where keys is the list of compromised tailnet-lock keys.

The outputted command will then need to be run on other devices with trusted tailnet-lock keys to co-sign the recovery blob.
The latest-outputted from each cosign command should be used each time.

Once the command has been run on more devices than keys were compromised, the final outputted command can be run again with the --finish flag.

FLAGS
  -cosign=false  continue generating the recovery using the tailnet lock key on this device and the provided recovery blob
  -finish=false  finish the recovery process by transmitting the revocation
  ```

Signed-off-by: Tom DNetto <tom@tailscale.com>
Updates ENG-1848