### PR TITLE
tsweb: relax CSP for debug handlers

### DIFF
--- a/tsweb/tsweb.go
+++ b/tsweb/tsweb.go
@@ -435,7 +435,7 @@ func VarzHandler(w http.ResponseWriter, r *http.Request) {
 // https://infosec.mozilla.org/guidelines/web_security
 func AddBrowserHeaders(w http.ResponseWriter) {
 	w.Header().Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
-	w.Header().Set("Content-Security-Policy", "default-src 'self'; frame-ancestors 'none'; form-action 'none'; base-uri 'self'; block-all-mixed-content; plugin-types 'none'")
+	w.Header().Set("Content-Security-Policy", "default-src 'self'; frame-ancestors 'none'; form-action 'self'; base-uri 'self'; block-all-mixed-content; plugin-types 'none'")
 	w.Header().Set("X-Frame-Options", "DENY")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 }


### PR DESCRIPTION
Allow inline CSS for debug handlers to make prototyping easier. These are generally not accessible to the public and the small risk of CSS injection via user content seems acceptable.

Also allow form submissions on the same domain, instead of banning all forms. An example of such form is
http://webhooks.corp.ts.net:6359/debug/private-nodes/

Updates #3576