### PR TITLE
tka: guard against key-length panics when verifying signatures

### DIFF
--- a/tka/key.go
+++ b/tka/key.go
@@ -145,6 +145,9 @@ func signatureVerify(s *tkatype.Signature, aumDigest tkatype.AUMSigHash, key Key
 	//            so we should use the public contained in the state machine.
 	switch key.Kind {
 	case Key25519:
+		if len(key.Public) != ed25519.PublicKeySize {
+			return fmt.Errorf("ed25519 key has wrong length: %d", len(key.Public))
+		}
 		if ed25519consensus.Verify(ed25519.PublicKey(key.Public), aumDigest[:], s.Signature) {
 			return nil
 		}

--- a/tka/sig.go
+++ b/tka/sig.go
@@ -225,6 +225,9 @@ func (s *NodeKeySignature) verifySignature(nodeKey key.NodePublic, verificationK
 		if !ok {
 			return errors.New("missing rotation key")
 		}
+		if len(verifyPub) != ed25519.PublicKeySize {
+			return fmt.Errorf("bad rotation key length: %d", len(verifyPub))
+		}
 		if !ed25519.Verify(ed25519.PublicKey(verifyPub[:]), sigHash[:], s.Signature) {
 			return errors.New("invalid signature")
 		}
@@ -249,6 +252,9 @@ func (s *NodeKeySignature) verifySignature(nodeKey key.NodePublic, verificationK
 		}
 		switch verificationKey.Kind {
 		case Key25519:
+			if len(verificationKey.Public) != ed25519.PublicKeySize {
+				return fmt.Errorf("ed25519 key has wrong length: %d", len(verificationKey.Public))
+			}
 			if ed25519consensus.Verify(ed25519.PublicKey(verificationKey.Public), sigHash[:], s.Signature) {
 				return nil
 			}


### PR DESCRIPTION
In late 2022 a subtle but crucial part of documentation was added to ed25519.Verify: It will panic if len(publicKey) is not [PublicKeySize].

https://cs.opensource.google/go/go/+/02ed0e5e67530e6b041989d55048ce373dc60327

This change catches that error so it won't lead to a panic.

Updates https://github.com/tailscale/corp/issues/8568