### PR TITLE
ssh: ignore io.EOF from sftp.Server.Serve

### DIFF
--- a/ssh/tailssh/incubator.go
+++ b/ssh/tailssh/incubator.go
@@ -270,7 +270,12 @@ func beIncubator(args []string) error {
 		if err != nil {
 			return err
 		}
-		return server.Serve()
+		// TODO(https://github.com/pkg/sftp/pull/554): Revert the check for io.EOF,
+		// when sftp is patched to report clean termination.
+		if err := server.Serve(); err != nil && err != io.EOF {
+			return err
+		}
+		return nil
 	}
 
 	cmd := exec.Command(ia.cmdName, ia.cmdArgs...)


### PR DESCRIPTION
If the connection provided to sftp.NewServer is closed, Serve returns the io.EOF error verbatim from io.Reader.Read. This is an odd error since this is an expected situation, so we manually ignore io.EOF.
This is somewhat buggy since the sftp package itself incorrectly reports io.EOF in cases where it should actually be reporting io.ErrUnexpectedEOF.
See https://github.com/pkg/sftp/pull/554 which patches Serve to return nil on clean closes and fixes buggy uses of io.ReadFull.

Fixes #8592