### PR TITLE
net/dns: overwrite /tmp/resolv.conf on gokrazy

### DIFF
--- a/net/dns/direct.go
+++ b/net/dns/direct.go
@@ -27,11 +27,6 @@ import (
 	"tailscale.com/version/distro"
 )
 
-const (
-	backupConf = "/etc/resolv.pre-tailscale-backup.conf"
-	resolvConf = "/etc/resolv.conf"
-)
-
 // writeResolvConf writes DNS configuration in resolv.conf format to the given writer.
 func writeResolvConf(w io.Writer, servers []netip.Addr, domains []dnsname.FQDN) error {
 	c := &resolvconffile.Config{

--- a/net/dns/resolvconfpath_default.go
+++ b/net/dns/resolvconfpath_default.go
@@ -1,0 +1,11 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !gokrazy
+
+package dns
+
+const (
+	resolvConf = "/etc/resolv.conf"
+	backupConf = "/etc/resolv.pre-tailscale-backup.conf"
+)

--- a/net/dns/resolvconfpath_gokrazy.go
+++ b/net/dns/resolvconfpath_gokrazy.go
@@ -1,0 +1,11 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build gokrazy
+
+package dns
+
+const (
+	resolvConf = "/tmp/resolv.conf"
+	backupConf = "/tmp/resolv.pre-tailscale-backup.conf"
+)


### PR DESCRIPTION
Appliances built using https://gokrazy.org/ have a read-only root file system, including /etc/resolv.conf, which is a symlink to /tmp/resolv.conf.

The system’s dhcp client overwrites /tmp/resolv.conf instead, so we need to use this path in Tailscale, too.

An alternative would have been to make the code follow symlinks when handling /etc/resolv.conf, but this fix feels a little simpler — less potential to break something and less code complexity.

related to https://github.com/gokrazy/gokrazy/issues/209