### PR TITLE
net/dns: make directManager use /tmp/resolv.conf on gokrazy

### DIFF
--- a/net/dns/direct_linux.go
+++ b/net/dns/direct_linux.go
@@ -43,7 +43,7 @@ func (m *directManager) runFileWatcher() {
 		}
 		var match bool
 		for _, ev := range events {
-			if ev.Name == resolvConf {
+			if ev.Name == m.resolvConf {
 				match = true
 				break
 			}

--- a/net/dns/manager_linux.go
+++ b/net/dns/manager_linux.go
@@ -121,7 +121,7 @@ func dnsMode(logf logger.Logf, env newOSConfigEnv) (ret string, err error) {
 		dbg("resolved-ping", "yes")
 	}
 
-	bs, err := env.fs.ReadFile(resolvConf)
+	bs, err := env.fs.ReadFile(defaultResolvConf)
 	if os.IsNotExist(err) {
 		dbg("rc", "missing")
 		return "direct", nil


### PR DESCRIPTION
Appliances built using https://gokrazy.org/ have a read-only root file system, including /etc/resolv.conf, which is a symlink to /tmp/resolv.conf.

The system’s dhcp client overwrites /tmp/resolv.conf instead, so we need to use this path in Tailscale, too.

Fixes #8689
Updates gokrazy/gokrazy#209