### PR TITLE
cmd/tailscale/cli: add latest version output to "tailscale version"

### DIFF
--- a/cmd/tailscale/cli/update.go
+++ b/cmd/tailscale/cli/update.go
@@ -874,6 +874,10 @@ func requestedTailscaleVersion(ver, track string) (string, error) {
 	if ver != "" {
 		return ver, nil
 	}
+	return latestTailscaleVersion(track)
+}
+
+func latestTailscaleVersion(track string) (string, error) {
 	url := fmt.Sprintf("https://pkgs.tailscale.com/%s/?mode=json&os=%s", track, runtime.GOOS)
 	res, err := http.Get(url)
 	if err != nil {


### PR DESCRIPTION
Add optional `--with-latest` flag to `tailscale version` to fetch the latest release version from `pkgs.tailscale.com`. This is useful to diagnose `tailscale update` behavior or write other tooling.

Example output:
```sh
$ tailscale version --with-latest --json
{
	"majorMinorPatch": "1.47.35",
	"short": "1.47.35",
	"long": "1.47.35-t6afffece8",
	"unstableBranch": true,
	"gitCommit": "6afffece8a32509aa7a4dc2972415ec58d8316de",
	"cap": 66,
	"latest": "1.45.61"
}
```

Fixes #8669