### PR TITLE
wgengine/magicsock: remove dead code (i think)

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -8,7 +8,6 @@ package magicsock
 import (
 	"bufio"
 	"context"
-	crand "crypto/rand"
 	"errors"
 	"fmt"
 	"io"
@@ -1241,10 +1240,6 @@ func (c *Conn) sendDiscoMessage(dst netip.AddrPort, dstKey key.NodePublic, dstDi
 	if c.closed {
 		c.mu.Unlock()
 		return false, errConnClosed
-	}
-	var nonce [disco.NonceLen]byte
-	if _, err := crand.Read(nonce[:]); err != nil {
-		panic(err) // worth dying for
 	}
 	pkt := make([]byte, 0, 512) // TODO: size it correctly? pool? if it matters.
 	pkt = append(pkt, disco.Magic...)


### PR DESCRIPTION
The nonce value is not read by anything, and `di.sharedKey.Seal()` a few lines below generates its own (and also panics on `crand.Read()` errors).

I really really hope this isn't somehow magically load-bearing. 😅