### PR TITLE
cmd/containerboot, cmd/k8s-operator: Add flag to k8s-operator and proxy to enable NFTABLES

### DIFF
--- a/cmd/k8s-operator/manifests/operator.yaml
+++ b/cmd/k8s-operator/manifests/operator.yaml
@@ -150,6 +150,8 @@ spec:
               value: tag:k8s
             - name: AUTH_PROXY
               value: "false"
+            - name: OPERATOR_USENFT
+              value: "false"
           volumeMounts:
           - name: oauth
             mountPath: /oauth

--- a/docs/k8s/proxy.yaml
+++ b/docs/k8s/proxy.yaml
@@ -42,6 +42,8 @@ spec:
       value: "{{TS_DEST_IP}}"
     - name: TS_AUTH_ONCE
       value: "true"
+    - name: TS_TEST_USENFT
+      value: "false"
     securityContext:
       capabilities:
         add:


### PR DESCRIPTION
Add flag to k8s-operator and proxy to enable experimental TS_DEBUG_USE_NETLINK_NFTABLES support in tailscaled that was introduced in https://github.com/tailscale/tailscale/pull/8555

Fixes #8111, #8733
Ref #391