### PR TITLE
client/tailscale/apitype: document never-nil property of WhoIsResponse

### DIFF
--- a/client/tailscale/apitype/apitype.go
+++ b/client/tailscale/apitype/apitype.go
@@ -10,6 +10,7 @@ import "tailscale.com/tailcfg"
 const LocalAPIHost = "local-tailscaled.sock"
 
 // WhoIsResponse is the JSON type returned by tailscaled debug server's /whois?ip=$IP handler.
+// In successful whois responses, Node and UserProfile are never nil.
 type WhoIsResponse struct {
 	Node        *tailcfg.Node
 	UserProfile *tailcfg.UserProfile

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -427,8 +427,8 @@ func (h *Handler) serveWhoIs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	res := &apitype.WhoIsResponse{
-		Node:        n,
-		UserProfile: &u,
+		Node:        n,  // always non-nil per WhoIsResponse contract
+		UserProfile: &u, // always non-nil per WhoIsResponse contract
 		CapMap:      b.PeerCaps(ipp.Addr()),
 	}
 	j, err := json.MarshalIndent(res, "", "\t")


### PR DESCRIPTION
Every time I use WhoIsResponse I end up writing mildly irritating nil-checking for both Node and UserProfile, but it turns out our code guarantees that both are non-nil in successful whois responses.

Updates #cleanup