### PR TITLE
cmd/dist,release/dist: sign release tarballs with an ECDSA key

### DIFF
--- a/cmd/dist/dist.go
+++ b/cmd/dist/dist.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"context"
+	"crypto"
 	"errors"
 	"flag"
 	"log"
@@ -19,10 +20,10 @@ import (
 
 var synologyPackageCenter bool
 
-func getTargets() ([]dist.Target, error) {
+func getTargets(tgzSigner crypto.Signer) ([]dist.Target, error) {
 	var ret []dist.Target
 
-	ret = append(ret, unixpkgs.Targets()...)
+	ret = append(ret, unixpkgs.Targets(tgzSigner)...)
 	// Synology packages can be built either for sideloading, or for
 	// distribution by Synology in their package center. When
 	// distributed through the package center, apps can request

--- a/release/dist/unixpkgs/targets.go
+++ b/release/dist/unixpkgs/targets.go
@@ -4,6 +4,7 @@
 package unixpkgs
 
 import (
+	"crypto"
 	"fmt"
 	"sort"
 	"strings"
@@ -14,7 +15,7 @@ import (
 	_ "github.com/goreleaser/nfpm/rpm"
 )
 
-func Targets() []dist.Target {
+func Targets(signer crypto.Signer) []dist.Target {
 	var ret []dist.Target
 	for goosgoarch := range tarballs {
 		goos, goarch := splitGoosGoarch(goosgoarch)
@@ -23,6 +24,7 @@ func Targets() []dist.Target {
 				"GOOS":   goos,
 				"GOARCH": goarch,
 			},
+			signer: signer,
 		})
 	}
 	for goosgoarch := range debs {
@@ -53,6 +55,7 @@ func Targets() []dist.Target {
 			"GOARCH": "386",
 			"GO386":  "softfloat",
 		},
+		signer: signer,
 	})
 
 	sort.Slice(ret, func(i, j int) bool {


### PR DESCRIPTION
Pass an optional PEM-encoded ECDSA key to `cmd/dist` to sign all built tarballs. The signature is stored next to the tarball with a `.sig` extension.

Tested this with an `openssl`-generated key pair and verified the resulting signature.