### PR TITLE
wgengine/router: add auto selection heuristic for iptables/nftables

### DIFF
--- a/util/linuxfw/iptables.go
+++ b/util/linuxfw/iptables.go
@@ -7,7 +7,13 @@
 package linuxfw
 
 import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"unicode"
+
 	"tailscale.com/types/logger"
+	"tailscale.com/util/multierr"
 )
 
 // DebugNetfilter prints debug information about iptables rules to the
@@ -21,9 +27,44 @@ func DebugIptables(logf logger.Logf) error {
 // system, ignoring the default "ACCEPT" rule present in the standard iptables
 // chains.
 //
-// It only returns an error when the kernel returns an error (i.e. when a
-// syscall fails); when there are no iptables rules, it is valid for this
-// function to return 0, nil.
+// It only returns an error when there is no iptables binary, or when iptables -S
+// fails. In all other cases, it returns the number of non-default rules.
 func DetectIptables() (int, error) {
-	panic("unused")
+	// run "iptables -S" to get the list of rules using iptables
+	// exec.Command returns an error if the binary is not found
+	cmd := exec.Command("iptables", "-S")
+	output, err := cmd.Output()
+	ip6cmd := exec.Command("ip6tables", "-S")
+	ip6output, ip6err := ip6cmd.Output()
+	var allLines []string
+	outputStr := string(output)
+	lines := strings.Split(outputStr, "\n")
+	ip6outputStr := string(ip6output)
+	ip6lines := strings.Split(ip6outputStr, "\n")
+	switch {
+	case err == nil && ip6err == nil:
+		allLines = append(lines, ip6lines...)
+	case err == nil && ip6err != nil:
+		allLines = lines
+	case err != nil && ip6err == nil:
+		allLines = ip6lines
+	default:
+		return 0, ErrorFWModeNotSupported{
+			Mode: FirewallModeIPTables,
+			Err:  fmt.Errorf("iptables command run fail: %w", multierr.New(err, ip6err)),
+		}
+	}
+
+	// count the number of non-default rules
+	count := 0
+	for _, line := range allLines {
+		trimmedLine := strings.TrimLeftFunc(line, unicode.IsSpace)
+		if line != "" && strings.HasPrefix(trimmedLine, "-A") {
+			// if the line is not empty and starts with "-A", it is a rule appended not default
+			count++
+		}
+	}
+
+	// return the count of non-default rules
+	return count, nil
 }

--- a/util/linuxfw/linuxfw.go
+++ b/util/linuxfw/linuxfw.go
@@ -29,6 +29,31 @@ const (
 	Masq
 )
 
+type ErrorFWModeNotSupported struct {
+	Mode FirewallMode
+	Err  error
+}
+
+func (e ErrorFWModeNotSupported) Error() string {
+	return fmt.Sprintf("firewall mode %q not supported: %v", e.Mode, e.Err)
+}
+
+func (e ErrorFWModeNotSupported) Is(target error) bool {
+	_, ok := target.(ErrorFWModeNotSupported)
+	return ok
+}
+
+func (e ErrorFWModeNotSupported) Unwrap() error {
+	return e.Err
+}
+
+type FirewallMode string
+
+const (
+	FirewallModeIPTables FirewallMode = "iptables"
+	FirewallModeNfTables FirewallMode = "nftables"
+)
+
 // The following bits are added to packet marks for Tailscale use.
 //
 // We tried to pick bits sufficiently out of the way that it's

--- a/util/linuxfw/nftables.go
+++ b/util/linuxfw/nftables.go
@@ -107,12 +107,18 @@ func DebugNetfilter(logf logger.Logf) error {
 func DetectNetfilter() (int, error) {
 	conn, err := nftables.New()
 	if err != nil {
-		return 0, err
+		return 0, ErrorFWModeNotSupported{
+			Mode: FirewallModeNfTables,
+			Err:  err,
+		}
 	}
 
 	chains, err := conn.ListChains()
 	if err != nil {
-		return 0, fmt.Errorf("cannot list chains: %w", err)
+		return 0, ErrorFWModeNotSupported{
+			Mode: FirewallModeNfTables,
+			Err:  fmt.Errorf("cannot list chains: %w", err),
+		}
 	}
 
 	var validRules int

--- a/wgengine/router/router_linux_test.go
+++ b/wgengine/router/router_linux_test.go
@@ -1062,3 +1062,63 @@ func adjustFwmask(t *testing.T, s string) string {
 
 	return fwmaskAdjustRe.ReplaceAllString(s, "$1")
 }
+
+type testFWDetector struct {
+	iptRuleCount, nftRuleCount int
+	iptErr, nftErr             error
+}
+
+func (t *testFWDetector) iptDetect() (int, error) {
+	return t.iptRuleCount, t.iptErr
+}
+
+func (t *testFWDetector) nftDetect() (int, error) {
+	return t.nftRuleCount, t.nftErr
+}
+
+func TestChooseFireWallMode(t *testing.T) {
+	tests := []struct {
+		name string
+		det  *testFWDetector
+		want linuxfw.FirewallMode
+	}{
+		{
+			name: "using iptables legacy",
+			det:  &testFWDetector{iptRuleCount: 1},
+			want: linuxfw.FirewallModeIPTables,
+		},
+		{
+			name: "using nftables",
+			det:  &testFWDetector{nftRuleCount: 1},
+			want: linuxfw.FirewallModeNfTables,
+		},
+		{
+			name: "using both iptables and nftables",
+			det:  &testFWDetector{iptRuleCount: 2, nftRuleCount: 2},
+			want: linuxfw.FirewallModeNfTables,
+		},
+		{
+			name: "not using any firewall, both available",
+			det:  &testFWDetector{},
+			want: linuxfw.FirewallModeNfTables,
+		},
+		{
+			name: "not using any firewall, iptables available only",
+			det:  &testFWDetector{iptRuleCount: 1, nftErr: errors.New("nft error")},
+			want: linuxfw.FirewallModeIPTables,
+		},
+		{
+			name: "not using any firewall, nftables available only",
+			det:  &testFWDetector{iptErr: errors.New("iptables error"), nftRuleCount: 1},
+			want: linuxfw.FirewallModeNfTables,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := chooseFireWallMode(t.Logf, tt.det)
+			if got != tt.want {
+				t.Errorf("chooseFireWallMode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary:

This change implements `chooseFireWallMode` that decides which one of `iptables`/`nftables` will be used.

### Issue related

Updates: #391 
Fix: #8111 #8733

### Changes made

1. Added `chooseFireWallMode` that automatically decides which one of `iptables` or`nftables` should be used.
2. Replaced the `TS_DEBUG_USE_NETLINK_NFTABLES` envknob with `TS_DEBUG_FIREWALL_MODE` that should be set to either 'iptables' or 'nftables' to select firewall mode manually.
3. Reimplemented `DetectIptables` that detects `iptables` binary and returns number of rules in `iptables` in current network namespace.


### Thought Process
1. It is a very edge case when iptables binary is not available, nft is also not available and iptables is in use. So we are not supporting this case for now.
2. It is a very edge case when nftables is only available throught `nft` binary but not netlinkAPI, so we will skip this case for now also. This is usually due to system configuration.
3. We always prioritize nftables ahead of iptables due to it's excellence in performance, and less likely to fail in containerized environment.
4. When In a container, if there was other app in the same container using `iptables`, we use iptables since if iptables wouldn't work the container would fail anyways. Otherwise we tend to use `nftables` since netlinkAPI is less likely to run into incompatibility issues.

### Expected Result

1. If either `'iptables'` or `'nftables'` is set for `TS_DEBUG_FIREWALL_MODE` use the tool respectively.
5. If `nftables` is in use already use nftables.
6. if `iptables` is already in use user iptables, notice that since iptables-nft would write to nftables subsystem, iptables here refer to iptables-legacy.
7. Otherwise if `nftables` is available throught `netlink API`, use nftables. This case includes both ipt, nft are in use, neither is used or iptables-nft was used.
8. If only `iptables` binary is available, use iptables.
9. If neither iptables or nftables is available, return error.


### How to test

On linux environment do the following:

1. Bring up tailscaled by running `sudo TS_DEBUG_FIREWALL_MODE=iptables ./tool/go run ./cmd/tailscaled`
2. Start tailscale by running `sudo ./tool/go run ./cmd/tailscale up`.
3. Run `sudo iptables -L` to view the rules added. In log of tailscaled, there should be a line `router: router: envknob TS_DEBUG_NETFILTER_MODE=iptables set`.
4. Turn everything down.
5. Bring up tailscaled by running `sudo TS_DEBUG_FIREWALL_MODE=nftables ./tool/go run ./cmd/tailscaled`
6. Start tailscale by running `sudo ./tool/go run ./cmd/tailscale up`.
7. Run `sudo nft list ruleset` to view the rules added. In the output log of tailscaled, it should say `router: envknob TS_DEBUG_NETFILTER_MODE=nftables set`.
8. Turn everything down.
9.  Buring up tailscaled by running `sudo ./tool/go run ./cmd/tailscaled`
10. Start tailscale
11. You should see the count of iptables rules and nftables rule currently in system from the log in the form 
```
router: router: iptables rule count: {number}
router: router: nftables rule count: {number}
```
if iptables is associated with iptables-nft, or nftables is used, it's likely that bother number are non zero depending on system implementation.
12. Your tailscale should be working, with which ever mode is selected.
