### PR TITLE
tool/gocross: ensure there is no mid-build toolchain change

### DIFF
--- a/tool/gocross/autoflags.go
+++ b/tool/gocross/autoflags.go
@@ -169,6 +169,9 @@ func autoflagsForTest(argv []string, env *Environment, goroot, nativeGOOS, nativ
 	env.Set("CC", "cc")
 	env.Set("TS_LINK_FAIL_REFLECT", boolStr(failReflect))
 	env.Set("GOROOT", goroot)
+	// Ensure that we use the gocross toolchain, rather than switching part way
+	// through a build. See https://go.dev/doc/toolchain.
+	env.Set("GOTOOLCHAIN", "local")
 
 	if subcommand == "env" {
 		return argv, env, nil


### PR DESCRIPTION
Set GOTOOLCHAIN=local as per https://go.dev/doc/toolchain to prevent dynamic switching of the toolchain during a build.

I haven't reproduced directly that this contributes to symptoms we are presently diagnosing, but I am confident this is the behavior that we want.

Updates #cleanup
Signed-off-by: James Tucker <james@tailscale.com>