### PR TITLE
control/controlclient: add Auto.informRoutine

### DIFF
--- a/control/controlclient/direct_test.go
+++ b/control/controlclient/direct_test.go
@@ -42,7 +42,10 @@ func TestNewDirect(t *testing.T) {
 		t.Errorf("c.serverURL got %v want %v", c.serverURL, opts.ServerURL)
 	}
 
-	if !hi.Equal(c.hostinfo) {
+	// hi is stored without its NetInfo field.
+	hiWithoutNi := *hi
+	hiWithoutNi.NetInfo = nil
+	if !hiWithoutNi.Equal(c.hostinfo) {
 		t.Errorf("c.hostinfo got %v want %v", c.hostinfo, hi)
 	}
 


### PR DESCRIPTION
Instead of having updates replace the map polls, create a third goroutine which is solely responsible for making sure that control is aware of the latest client state.

This also makes it so that the streaming map polls are only broken when there are auth changes, or the client is paused.

Updates https://github.com/tailscale/corp/issues/5761