### PR TITLE
client/web: fix rendering of node owner profile

### DIFF
--- a/client/web/web.go
+++ b/client/web/web.go
@@ -299,7 +299,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	st, err := s.lc.StatusWithoutPeers(ctx)
+	st, err := s.lc.Status(ctx)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
Before:
<img width="535" alt="Screenshot 2023-08-09 at 8 01 09 PM" src="https://github.com/tailscale/tailscale/assets/1112/ac556a43-1cfb-4eac-941e-39f801de7d9a">

After:
<img width="529" alt="Screenshot 2023-08-09 at 8 01 28 PM" src="https://github.com/tailscale/tailscale/assets/1112/ccdde365-5c0b-4040-8819-f754676ae936">

Fixes #8837