### PR TITLE
util/linuxfw: rename ErrorFWModeNotSupported

### DIFF
--- a/util/linuxfw/iptables.go
+++ b/util/linuxfw/iptables.go
@@ -49,7 +49,7 @@ func DetectIptables() (int, error) {
 	case err != nil && ip6err == nil:
 		allLines = ip6lines
 	default:
-		return 0, ErrorFWModeNotSupported{
+		return 0, FWModeNotSupportedError{
 			Mode: FirewallModeIPTables,
 			Err:  fmt.Errorf("iptables command run fail: %w", multierr.New(err, ip6err)),
 		}

--- a/util/linuxfw/linuxfw.go
+++ b/util/linuxfw/linuxfw.go
@@ -29,21 +29,21 @@ const (
 	Masq
 )
 
-type ErrorFWModeNotSupported struct {
+type FWModeNotSupportedError struct {
 	Mode FirewallMode
 	Err  error
 }
 
-func (e ErrorFWModeNotSupported) Error() string {
+func (e FWModeNotSupportedError) Error() string {
 	return fmt.Sprintf("firewall mode %q not supported: %v", e.Mode, e.Err)
 }
 
-func (e ErrorFWModeNotSupported) Is(target error) bool {
-	_, ok := target.(ErrorFWModeNotSupported)
+func (e FWModeNotSupportedError) Is(target error) bool {
+	_, ok := target.(FWModeNotSupportedError)
 	return ok
 }
 
-func (e ErrorFWModeNotSupported) Unwrap() error {
+func (e FWModeNotSupportedError) Unwrap() error {
 	return e.Err
 }
 

--- a/util/linuxfw/nftables.go
+++ b/util/linuxfw/nftables.go
@@ -107,7 +107,7 @@ func DebugNetfilter(logf logger.Logf) error {
 func DetectNetfilter() (int, error) {
 	conn, err := nftables.New()
 	if err != nil {
-		return 0, ErrorFWModeNotSupported{
+		return 0, FWModeNotSupportedError{
 			Mode: FirewallModeNfTables,
 			Err:  err,
 		}
@@ -115,7 +115,7 @@ func DetectNetfilter() (int, error) {
 
 	chains, err := conn.ListChains()
 	if err != nil {
-		return 0, ErrorFWModeNotSupported{
+		return 0, FWModeNotSupportedError{
 			Mode: FirewallModeNfTables,
 			Err:  fmt.Errorf("cannot list chains: %w", err),
 		}


### PR DESCRIPTION
Go style is for error variables to start with "err" (or "Err") and for error types to end in "Error".

Updates #cleanup