### PR TITLE
net/netns: indicate when android protect func is no longer nil

### DIFF
--- a/net/netns/netns_android_test.go
+++ b/net/netns/netns_android_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build android
+
+package netns
+
+import "testing"
+
+func TestSetAndroidProtectFunc(t *testing.T) {
+	// No function has previously been set.
+	hasPrevProtectFunc := SetAndroidProtectFunc(func(fd int) error { return nil })
+
+	if hasPrevProtectFunc {
+		t.Fatal("SetAndroidProtectFunc returned true, should be false")
+	}
+
+	hasPrevProtectFunc = SetAndroidProtectFunc(func(fd int) error { return nil })
+
+	if !hasPrevProtectFunc {
+		t.Fatal("SetAndroidProtectFunc returned false, should be true")
+	}
+}


### PR DESCRIPTION
We have been getting into routing loops due to the timing of when we bind sockets on starting the tailscale android app. At this point, we do not have access to `VpnService.protect()` and are unable to protect the magicsock sockets, which causes a routing loop issue until we forcibly rebind about 10 minutes into the service being started.

This change returns a bool from SetAndroidProtectFunc we get access to a func.

Updates tailscale/corp#13814