### PR TITLE
cmd/tailscale,ipn: add auto-update flags and prefs

### DIFF
--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -556,6 +556,10 @@ func TestPrefsFromUpArgs(t *testing.T) {
 				NetfilterMode:    preftype.NetfilterOn,
 				CorpDNS:          true,
 				AllowSingleHosts: true,
+				AutoUpdate: ipn.AutoUpdatePrefs{
+					Check: true,
+					Apply: false,
+				},
 			},
 		},
 		{
@@ -569,6 +573,10 @@ func TestPrefsFromUpArgs(t *testing.T) {
 				AllowSingleHosts: true,
 				RouteAll:         true,
 				NetfilterMode:    preftype.NetfilterOn,
+				AutoUpdate: ipn.AutoUpdatePrefs{
+					Check: true,
+					Apply: false,
+				},
 			},
 		},
 		{
@@ -584,6 +592,10 @@ func TestPrefsFromUpArgs(t *testing.T) {
 					netip.MustParsePrefix("::/0"),
 				},
 				NetfilterMode: preftype.NetfilterOn,
+				AutoUpdate: ipn.AutoUpdatePrefs{
+					Check: true,
+					Apply: false,
+				},
 			},
 		},
 		{
@@ -670,6 +682,10 @@ func TestPrefsFromUpArgs(t *testing.T) {
 				WantRunning:   true,
 				NetfilterMode: preftype.NetfilterNoDivert,
 				NoSNAT:        true,
+				AutoUpdate: ipn.AutoUpdatePrefs{
+					Check: true,
+					Apply: false,
+				},
 			},
 		},
 		{
@@ -683,6 +699,10 @@ func TestPrefsFromUpArgs(t *testing.T) {
 				WantRunning:   true,
 				NetfilterMode: preftype.NetfilterOff,
 				NoSNAT:        true,
+				AutoUpdate: ipn.AutoUpdatePrefs{
+					Check: true,
+					Apply: false,
+				},
 			},
 		},
 		{
@@ -697,6 +717,10 @@ func TestPrefsFromUpArgs(t *testing.T) {
 				NoSNAT:      true,
 				AdvertiseRoutes: []netip.Prefix{
 					netip.MustParsePrefix("fd7a:115c:a1e0:b1a::bb:10.0.0.0/112"),
+				},
+				AutoUpdate: ipn.AutoUpdatePrefs{
+					Check: true,
+					Apply: false,
 				},
 			},
 		},

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -97,6 +97,8 @@ func newUpFlagSet(goos string, upArgs *upArgsT, cmd string) *flag.FlagSet {
 	}
 	upf := newFlagSet(cmd)
 
+	// When adding new flags, prefer to put them under "tailscale set" instead
+	// of here. Setting preferences via "tailscale up" is deprecated.
 	upf.BoolVar(&upArgs.qr, "qr", false, "show QR code for login URLs")
 	upf.StringVar(&upArgs.authKeyOrFile, "auth-key", "", `node authorization key; if it begins with "file:", then it's a path to a file containing the authkey`)
 
@@ -712,6 +714,8 @@ func init() {
 	addPrefFlagMapping("operator", "OperatorUser")
 	addPrefFlagMapping("ssh", "RunSSH")
 	addPrefFlagMapping("nickname", "ProfileName")
+	addPrefFlagMapping("update-check", "AutoUpdate")
+	addPrefFlagMapping("auto-update", "AutoUpdate")
 }
 
 func addPrefFlagMapping(flagName string, prefNames ...string) {

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -51,6 +51,7 @@ var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	NetfilterMode          preftype.NetfilterMode
 	OperatorUser           string
 	ProfileName            string
+	AutoUpdate             AutoUpdatePrefs
 	Persist                *persist.Persist
 }{})
 

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -86,6 +86,7 @@ func (v PrefsView) NoSNAT() bool                          { return v.ж.NoSNAT }
 func (v PrefsView) NetfilterMode() preftype.NetfilterMode { return v.ж.NetfilterMode }
 func (v PrefsView) OperatorUser() string                  { return v.ж.OperatorUser }
 func (v PrefsView) ProfileName() string                   { return v.ж.ProfileName }
+func (v PrefsView) AutoUpdate() AutoUpdatePrefs           { return v.ж.AutoUpdate }
 func (v PrefsView) Persist() persist.PersistView          { return v.ж.Persist.View() }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
@@ -111,6 +112,7 @@ var _PrefsViewNeedsRegeneration = Prefs(struct {
 	NetfilterMode          preftype.NetfilterMode
 	OperatorUser           string
 	ProfileName            string
+	AutoUpdate             AutoUpdatePrefs
 	Persist                *persist.Persist
 }{})
 

--- a/ipn/ipnlocal/c2n.go
+++ b/ipn/ipnlocal/c2n.go
@@ -127,9 +127,10 @@ func (b *LocalBackend) handleC2NUpdate(w http.ResponseWriter, r *http.Request) {
 	//
 	// Note that we create the Updater solely to check for errors; we do not
 	// invoke it here. For this purpose, it is ok to pass it a zero Arguments.
+	prefs := b.Prefs().AutoUpdate()
 	_, err := clientupdate.NewUpdater(clientupdate.Arguments{})
 	res := tailcfg.C2NUpdateResponse{
-		Enabled:   envknob.AllowsRemoteUpdate(),
+		Enabled:   envknob.AllowsRemoteUpdate() || prefs.Apply,
 		Supported: err == nil && !version.IsMacSysExt(),
 	}
 


### PR DESCRIPTION
The flags are hidden for now. Adding propagation to tailscaled and persistence only.

Updates #6907