### PR TITLE
control/controlclient: avert a data race when logging

### DIFF
--- a/control/controlclient/auto.go
+++ b/control/controlclient/auto.go
@@ -313,9 +313,12 @@ func (c *Auto) cancelMap() {
 // restartMap cancels the existing mapPoll and liteUpdates, and then starts a
 // new one.
 func (c *Auto) restartMap() {
-	c.cancelMap()
+	c.mu.Lock()
+	c.cancelMapLocked()
+	synced := c.synced
+	c.mu.Unlock()
 
-	c.logf("[v1] restartMap: synced=%v", c.synced)
+	c.logf("[v1] restartMap: synced=%v", synced)
 
 	select {
 	case c.newMapCh <- struct{}{}:


### PR DESCRIPTION
The read of the synced field for logging takes place outside the lock, and
races with other (locked) writes of this field, including for example the one
at current line 556 in mapRoutine.

Change-Id: I056b36d7a93025aafdf73528dd7645f10b791af6
Signed-off-by: M. J. Fromberger <fromberger@tailscale.com>
