### PR TITLE
scripts/installer.sh: set Deepin to a debian version

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -78,7 +78,7 @@ jobs:
         || contains(matrix.image, 'amazonlinux')
     - name: install dependencies (zypper)
       # tar and gzip are needed by the actions/checkout below.
-      run: zypper --non-interactive install tar gzip
+      run: zypper --non-interactive install tar gzip ${{ matrix.deps }}
       if: contains(matrix.image, 'opensuse')
     - name: install dependencies (apt-get)
       run: |

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -159,8 +159,10 @@ main() {
 				PACKAGETYPE="apt"
 				if [ "$VERSION_ID" -lt 20 ]; then
 					APT_KEY_TYPE="legacy"
+					VERSION="buster"
 				else
 					APT_KEY_TYPE="keyring"
+					VERSION="bullseye"
 				fi
 				;;
 			centos)


### PR DESCRIPTION
Deepin Linux 20.x reports its version as "apricot"
Set it to bullseye, the Debian version it corresponds to.

Also fix the installer CI: OpenSUSE Leap appears to have removed curl from the base image recently, we have to install it now.

Fixes https://github.com/tailscale/tailscale/issues/8850
Updates https://github.com/tailscale/tailscale/issues/7862
Updates https://github.com/tailscale/corp/issues/8952