### PR TITLE
wgengine/magicsock: only accept pong sent by CLI ping

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -1270,7 +1270,7 @@ func (c *Conn) sendDiscoMessage(dst netip.AddrPort, dstKey key.NodePublic, dstDi
 		// Can't send. (e.g. no IPv6 locally)
 	} else {
 		if !c.networkDown() {
-			c.logf("magicsock: disco: failed to send %T to %v: %v", m, dst, err)
+			c.logf("magicsock: disco: failed to send %v to %v: %v", disco.MessageSummary(m), dst, err)
 		}
 	}
 	return sent, err


### PR DESCRIPTION
Looking for suggestions on how to best restructure the code to deal with this. Currently the ping code has a number of special cases to handle discovery ping, CLI ping, size ping, and heartbeat ping that end up having the wrong behavior. It looks like we may need to do a little code reorganization to make this work

What this code does is fix a bug where CLI ping would accept any pong - including heartbeat pongs - as a reply to its ping. This is a problem because CLI ping cannot be used to probe MTU, since it will accept any heartbeat pong as a reply. It does it by pushing the code that fills out the pending CLI ping list to the point that we specify the tx id for the ping so that we can record it in the pending CLI ping entry.

The problem is: The code currently switches from DERP over to UDP-only once it gets any direct UDP connection, even if the connection can't handle the size of ping. This is due to a special case in the code to prevent flip-flopping between endpoints on CLI ping. This results in three successful pings from DERP, followed by timeouts for subsequent pings in the case that the path can't handle this size of packet. Ideally it would instead continue to ping all paths until it got a direct connection that can handle this size of ping, just like CLI pings with no size attached.