### PR TITLE
client/tailscale: add LocalClient.IncrementMetric func

### DIFF
--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -1458,10 +1458,9 @@ func (h *Handler) serveUploadClientMetrics(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	type clientMetricJSON struct {
-		Name string `json:"name"`
-		// One of "counter" or "gauge"
-		Type  string `json:"type"`
-		Value int    `json:"value"`
+		Name  string `json:"name"`
+		Type  string `json:"type"`  // one of "counter" or "gauge"
+		Value int    `json:"value"` // amount to increment metric by
 	}
 
 	var clientMetrics []clientMetricJSON


### PR DESCRIPTION
A #cleanup to add a func to utilize the already-present "/localapi/v0/upload-client-metrics" localapi endpoint.