### PR TITLE
cli/serve: funnel interactive enablement flow tweaks

### DIFF
--- a/client/tailscale/localclient.go
+++ b/client/tailscale/localclient.go
@@ -259,13 +259,12 @@ func (lc *LocalClient) DaemonMetrics(ctx context.Context) ([]byte, error) {
 	return lc.get200(ctx, "/localapi/v0/metrics")
 }
 
-// IncrementMetric increments the value of a Tailscale daemon's metric by
-// the given delta. If the metric has yet to exist, a new counter metric is
-// created and initialized to delta.
+// IncrementCounter increments the value of a Tailscale daemon's counter
+// metric by the given delta. If the metric has yet to exist, a new counter
+// metric is created and initialized to delta.
 //
-// IncrementMetric only supports counter metrics and non-negative delta values.
-// Gauge metrics are unsupported.
-func (lc *LocalClient) IncrementMetric(ctx context.Context, name string, delta int) error {
+// IncrementCounter does not support gauge metrics or negative delta values.
+func (lc *LocalClient) IncrementCounter(ctx context.Context, name string, delta int) error {
 	type metricUpdate struct {
 		Name  string `json:"name"`
 		Type  string `json:"type"`

--- a/cmd/tailscale/cli/funnel.go
+++ b/cmd/tailscale/cli/funnel.go
@@ -94,8 +94,13 @@ func (e *serveEnv) runFunnel(ctx context.Context, args []string) error {
 	}
 	port := uint16(port64)
 
-	if err := e.verifyFunnelEnabled(ctx, st, port); err != nil {
-		return err
+	if on {
+		// Don't block from turning off existing Funnel if
+		// network configuration/capabilities have changed.
+		// Only block from starting new Funnels.
+		if err := e.verifyFunnelEnabled(ctx, st, port); err != nil {
+			return err
+		}
 	}
 
 	dnsName := strings.TrimSuffix(st.Self.DNSName, ".")
@@ -176,7 +181,7 @@ func printFunnelWarning(sc *ipn.ServeConfig) {
 		p, _ := strconv.ParseUint(portStr, 10, 16)
 		if _, ok := sc.TCP[uint16(p)]; !ok {
 			warn = true
-			fmt.Fprintf(os.Stderr, "Warning: funnel=on for %s, but no serve config\n", hp)
+			fmt.Fprintf(os.Stderr, "\nWarning: funnel=on for %s, but no serve config\n", hp)
 		}
 	}
 	if warn {

--- a/cmd/tailscale/cli/serve_test.go
+++ b/cmd/tailscale/cli/serve_test.go
@@ -893,7 +893,11 @@ func (lc *fakeLocalServeClient) QueryFeature(ctx context.Context, feature string
 }
 
 func (lc *fakeLocalServeClient) WatchIPNBus(ctx context.Context, mask ipn.NotifyWatchOpt) (*tailscale.IPNBusWatcher, error) {
-	return nil, nil
+	return nil, nil // unused in tests
+}
+
+func (lc *fakeLocalServeClient) IncrementCounter(ctx context.Context, name string, delta int) error {
+	return nil // unused in tests
 }
 
 // exactError returns an error checker that wants exactly the provided want error.


### PR DESCRIPTION
1. Add metrics to funnel flow.
2. Stop blocking users from turning off funnels when no longer in their node capabilities.
3. Rename LocalClient.IncrementMetric to IncrementCounter to better callout its usage is only for counter clientmetrics.

Updates tailscale/corp#10577