### PR TITLE
clientupdate: return NOTREACHED for macsys

### DIFF
--- a/clientupdate/clientupdate.go
+++ b/clientupdate/clientupdate.go
@@ -588,10 +588,7 @@ func parseAlpinePackageVersion(out []byte) (string, error) {
 }
 
 func (up *updater) updateMacSys() error {
-	// This is actually NOTREACHED, because code in Swift intercepted the
-	// `update` command before ever calling into this point. It invokes the
-	// Sparkle update GUI.
-	return nil
+	return errors.New("NOTREACHED: On MacSys builds, `tailscale update` is handled in Swift to launch the GUI updater")
 }
 
 func (up *updater) updateMacAppStore() error {

--- a/clientupdate/clientupdate.go
+++ b/clientupdate/clientupdate.go
@@ -588,12 +588,10 @@ func parseAlpinePackageVersion(out []byte) (string, error) {
 }
 
 func (up *updater) updateMacSys() error {
-	// use sparkle? do we have permissions from this context? does sudo help?
-	// We can at least fail with a command they can run to update from the shell.
-	// Like "tailscale update --macsys | sudo sh" or something.
-	//
-	// TODO(bradfitz,mihai): implement. But for now:
-	return errors.ErrUnsupported
+	// This is actually NOTREACHED, because code in Swift intercepted the
+	// `update` command before ever calling into this point. It invokes the
+	// Sparkle update GUI.
+	return nil
 }
 
 func (up *updater) updateMacAppStore() error {


### PR DESCRIPTION
The work is done in Swift; this is now a documentation placeholder.

Updates #6995