### PR TITLE
tailcfg: Add FirewallMode to NetInfo to provide metrics.

### DIFF
--- a/hostinfo/hostinfo.go
+++ b/hostinfo/hostinfo.go
@@ -171,6 +171,7 @@ var (
 	desktopAtomic         atomic.Value // of opt.Bool
 	packagingType         atomic.Value // of string
 	appType               atomic.Value // of string
+	firewallMode          atomic.Value // of string
 )
 
 // SetPushDeviceToken sets the device token for use in Hostinfo updates.
@@ -181,6 +182,9 @@ func SetDeviceModel(model string) { deviceModelAtomic.Store(model) }
 
 // SetOSVersion sets the OS version.
 func SetOSVersion(v string) { osVersionAtomic.Store(v) }
+
+// SetFirewallMode sets the firewall mode for the app.
+func SetFirewallMode(v string) { firewallMode.Store(v) }
 
 // SetPackage sets the packaging type for the app.
 //
@@ -200,6 +204,13 @@ func deviceModel() string {
 
 func pushDeviceToken() string {
 	s, _ := pushDeviceTokenAtomic.Load().(string)
+	return s
+}
+
+// FirewallMode returns the firewall mode for the app.
+// It is empty if unset.
+func FirewallMode() string {
+	s, _ := firewallMode.Load().(string)
 	return s
 }
 

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -734,6 +734,11 @@ type NetInfo struct {
 	// the control plane.
 	DERPLatency map[string]float64 `json:",omitempty"`
 
+	// FirewallMode is the current firewall utility in use by router (iptables, nftables).
+	// FirewallMode ipt means iptables, nft means nftables. When it's empty user is not using
+	// our netfilter runners to manage firewall rules.
+	FirewallMode string `json:",omitempty"`
+
 	// Update BasicallyEqual when adding fields.
 }
 
@@ -741,10 +746,10 @@ func (ni *NetInfo) String() string {
 	if ni == nil {
 		return "NetInfo(nil)"
 	}
-	return fmt.Sprintf("NetInfo{varies=%v hairpin=%v ipv6=%v ipv6os=%v udp=%v icmpv4=%v derp=#%v portmap=%v link=%q}",
+	return fmt.Sprintf("NetInfo{varies=%v hairpin=%v ipv6=%v ipv6os=%v udp=%v icmpv4=%v derp=#%v portmap=%v link=%q firewallmode=%q}",
 		ni.MappingVariesByDestIP, ni.HairPinning, ni.WorkingIPv6,
 		ni.OSHasIPv6, ni.WorkingUDP, ni.WorkingICMPv4,
-		ni.PreferredDERP, ni.portMapSummary(), ni.LinkType)
+		ni.PreferredDERP, ni.portMapSummary(), ni.LinkType, ni.FirewallMode)
 }
 
 func (ni *NetInfo) portMapSummary() string {
@@ -792,7 +797,8 @@ func (ni *NetInfo) BasicallyEqual(ni2 *NetInfo) bool {
 		ni.PMP == ni2.PMP &&
 		ni.PCP == ni2.PCP &&
 		ni.PreferredDERP == ni2.PreferredDERP &&
-		ni.LinkType == ni2.LinkType
+		ni.LinkType == ni2.LinkType &&
+		ni.FirewallMode == ni2.FirewallMode
 }
 
 // Equal reports whether h and h2 are equal.

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -195,6 +195,7 @@ var _NetInfoCloneNeedsRegeneration = NetInfo(struct {
 	PreferredDERP         int
 	LinkType              string
 	DERPLatency           map[string]float64
+	FirewallMode          string
 }{})
 
 // Clone makes a deep copy of Login.

--- a/tailcfg/tailcfg_test.go
+++ b/tailcfg/tailcfg_test.go
@@ -571,6 +571,7 @@ func TestNetInfoFields(t *testing.T) {
 		"PreferredDERP",
 		"LinkType",
 		"DERPLatency",
+		"FirewallMode",
 	}
 	if have := fieldsOf(reflect.TypeOf(NetInfo{})); !reflect.DeepEqual(have, handled) {
 		t.Errorf("NetInfo.Clone/BasicallyEqually check might be out of sync\nfields: %q\nhandled: %q\n",

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -408,6 +408,7 @@ func (v NetInfoView) PreferredDERP() int              { return v.ж.PreferredDER
 func (v NetInfoView) LinkType() string                { return v.ж.LinkType }
 
 func (v NetInfoView) DERPLatency() views.Map[string, float64] { return views.MapOf(v.ж.DERPLatency) }
+func (v NetInfoView) FirewallMode() string                    { return v.ж.FirewallMode }
 func (v NetInfoView) String() string                          { return v.ж.String() }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
@@ -425,6 +426,7 @@ var _NetInfoViewNeedsRegeneration = NetInfo(struct {
 	PreferredDERP         int
 	LinkType              string
 	DERPLatency           map[string]float64
+	FirewallMode          string
 }{})
 
 // View returns a readonly view of Login.

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -641,6 +641,7 @@ func (c *Conn) updateNetInfo(ctx context.Context) (*netcheck.Report, error) {
 	if !c.setNearestDERP(ni.PreferredDERP) {
 		ni.PreferredDERP = 0
 	}
+	ni.FirewallMode = hostinfo.FirewallMode()
 
 	c.callNetInfoCallback(ni)
 	return report, nil


### PR DESCRIPTION
To record wether user is using iptables or nftables after we add support to nftables on linux, we are adding a field FirewallMode to NetInfo in HostInfo to reflect what firewall mode the host is running, and form metrics. The information is gained from a global constant in hostinfo.go. We set it when selection heuristic made the decision, and magicsock reports this to control.

Updates: tailscale/corp#13943