### PR TITLE
client: update DNSConfig type

### DIFF
--- a/client/tailscale/apitype/controltype.go
+++ b/client/tailscale/apitype/controltype.go
@@ -10,6 +10,7 @@ type DNSConfig struct {
 	Domains           []string                 `json:"domains"`
 	Nameservers       []string                 `json:"nameservers"`
 	Proxied           bool                     `json:"proxied"`
+	DNSFilterURL      string                   `json:"DNSFilterURL"`
 }
 
 type DNSResolver struct {

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -1403,6 +1403,8 @@ type DNSConfig struct {
 	//
 	// Matches are case insensitive.
 	ExitNodeFilteredSet []string `json:",omitempty"`
+	// DNSFilterURL contains a user inputed URL that should have a list of domains to be blocked
+	DNSFilterURL string `json:",omitempty"`
 }
 
 // DNSRecord is an extra DNS record to add to MagicDNS.

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -261,6 +261,7 @@ var _DNSConfigCloneNeedsRegeneration = DNSConfig(struct {
 	CertDomains         []string
 	ExtraRecords        []DNSRecord
 	ExitNodeFilteredSet []string
+	DNSFilterURL        string
 }{})
 
 // Clone makes a deep copy of RegisterResponse.

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -557,6 +557,7 @@ func (v DNSConfigView) ExtraRecords() views.Slice[DNSRecord] { return views.Slic
 func (v DNSConfigView) ExitNodeFilteredSet() views.Slice[string] {
 	return views.SliceOf(v.ж.ExitNodeFilteredSet)
 }
+func (v DNSConfigView) DNSFilterURL() string { return v.ж.DNSFilterURL }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _DNSConfigViewNeedsRegeneration = DNSConfig(struct {
@@ -569,6 +570,7 @@ var _DNSConfigViewNeedsRegeneration = DNSConfig(struct {
 	CertDomains         []string
 	ExtraRecords        []DNSRecord
 	ExitNodeFilteredSet []string
+	DNSFilterURL        string
 }{})
 
 // View returns a readonly view of RegisterResponse.


### PR DESCRIPTION
This PR adds DNSFilterURL to the DNSConfig type to be used by control changes to add DNS filtering logic

Fixes #cleanup