### PR TITLE
net/art: allow non-pointers as values

### DIFF
--- a/net/art/stride_table.go
+++ b/net/art/stride_table.go
@@ -18,19 +18,6 @@ const (
 	debugStrideDelete = false
 )
 
-// strideEntry is a strideTable entry.
-type strideEntry[T any] struct {
-	// prefixIndex is the prefixIndex(...) value that caused this stride entry's
-	// value to be populated, or 0 if value is nil.
-	//
-	// We need to keep track of this because allot() uses it to determine
-	// whether an entry was propagated from a parent entry, or if it's a
-	// different independent route.
-	prefixIndex int
-	// value is the value associated with the strideEntry, if any.
-	value *T
-}
-
 // strideTable is a binary tree that implements an 8-bit routing table.
 //
 // The leaves of the binary tree are host routes (/8s). Each parent is a
@@ -54,7 +41,9 @@ type strideTable[T any] struct {
 	// paper, it's hijacked through sneaky C memory trickery to store
 	// the refcount, but this is Go, where we don't store random bits
 	// in pointers lest we confuse the GC)
-	entries [lastHostIndex + 1]strideEntry[T]
+	//
+	// A nil value means no route matches the queried route.
+	entries [lastHostIndex + 1]*T
 	// children are the child tables of this table. Each child
 	// represents the address space within one of this table's host
 	// routes (/8).
@@ -112,13 +101,6 @@ func (t *strideTable[T]) getOrCreateChild(addr uint8) (child *strideTable[T], cr
 	return ret, false
 }
 
-// getValAndChild returns both the prefix and child strideTable for
-// addr. Both returned values can be nil if no entry of that type
-// exists for addr.
-func (t *strideTable[T]) getValAndChild(addr uint8) (*T, *strideTable[T]) {
-	return t.entries[hostIndex(addr)].value, t.children[addr]
-}
-
 // findFirstChild returns the first child strideTable in t, or nil if
 // t has no children.
 func (t *strideTable[T]) findFirstChild() *strideTable[T] {
@@ -130,21 +112,41 @@ func (t *strideTable[T]) findFirstChild() *strideTable[T] {
 	return nil
 }
 
+// hasPrefixRootedAt reports whether t.entries[idx] is the root node of
+// a prefix.
+func (t *strideTable[T]) hasPrefixRootedAt(idx int) bool {
+	val := t.entries[idx]
+	if val == nil {
+		return false
+	}
+
+	parentIdx := parentIndex(idx)
+	if parentIdx == 0 {
+		// idx is non-nil, and is at the 0/0 route position.
+		return true
+	}
+	if parent := t.entries[parentIdx]; val != parent {
+		// parent node in the tree isn't the same prefix, so idx must
+		// be a root.
+		return true
+	}
+	return false
+}
+
 // allot updates entries whose stored prefixIndex matches oldPrefixIndex, in the
 // subtree rooted at idx. Matching entries have their stored prefixIndex set to
 // newPrefixIndex, and their value set to val.
 //
 // allot is the core of the ART algorithm, enabling efficient insertion/deletion
 // while preserving very fast lookups.
-func (t *strideTable[T]) allot(idx int, oldPrefixIndex, newPrefixIndex int, val *T) {
-	if t.entries[idx].prefixIndex != oldPrefixIndex {
-		// current prefixIndex isn't what we expect. This is a recursive call
-		// that found a child subtree that already has a more specific route
-		// installed. Don't touch it.
+func (t *strideTable[T]) allot(idx int, old, new *T) {
+	if t.entries[idx] != old {
+		// current idx isn't what we expect. This is a recursive call
+		// that found a child subtree that already has a more specific
+		// route installed. Don't touch it.
 		return
 	}
-	t.entries[idx].value = val
-	t.entries[idx].prefixIndex = newPrefixIndex
+	t.entries[idx] = new
 	if idx >= firstHostIndex {
 		// The entry we just updated was a host route, we're at the bottom of
 		// the binary tree.
@@ -152,51 +154,73 @@ func (t *strideTable[T]) allot(idx int, oldPrefixIndex, newPrefixIndex int, val 
 	}
 	// Propagate the allotment to this node's children.
 	left := idx << 1
-	t.allot(left, oldPrefixIndex, newPrefixIndex, val)
+	t.allot(left, old, new)
 	right := left + 1
-	t.allot(right, oldPrefixIndex, newPrefixIndex, val)
+	t.allot(right, old, new)
 }
 
 // insert adds the route addr/prefixLen to t, with value val.
-func (t *strideTable[T]) insert(addr uint8, prefixLen int, val *T) {
+func (t *strideTable[T]) insert(addr uint8, prefixLen int, val T) {
 	idx := prefixIndex(addr, prefixLen)
-	old := t.entries[idx].value
-	oldIdx := t.entries[idx].prefixIndex
-	if oldIdx == idx && old == val {
-		// This exact prefix+value is already in the table.
-		return
-	}
-	t.allot(idx, oldIdx, idx, val)
-	if oldIdx != idx {
-		// This route entry was freshly created (not just updated), that's a new
-		// reference.
+	if !t.hasPrefixRootedAt(idx) {
+		// This route entry is being freshly created (not just
+		// updated), that's a new reference.
 		t.routeRefs++
 	}
+
+	old := t.entries[idx]
+
+	// For allot to work correctly, each distinct prefix in the
+	// strideTable must have a different value pointer, even if val is
+	// identical. This new()+assignment guarantees that each inserted
+	// prefix gets a unique address.
+	p := new(T)
+	*p = val
+
+	t.allot(idx, old, p)
 	return
 }
 
-// delete removes the route addr/prefixLen from t. Returns the value
-// that was associated with the deleted prefix, or nil if the prefix
-// wasn't in the strideTable.
-func (t *strideTable[T]) delete(addr uint8, prefixLen int) *T {
+// delete removes the route addr/prefixLen from t. Reports whether the
+// prefix existed in the table prior to deletion.
+func (t *strideTable[T]) delete(addr uint8, prefixLen int) (wasPresent bool) {
 	idx := prefixIndex(addr, prefixLen)
-	recordedIdx := t.entries[idx].prefixIndex
-	if recordedIdx != idx {
+	if !t.hasPrefixRootedAt(idx) {
 		// Route entry doesn't exist
-		return nil
+		return false
 	}
-	val := t.entries[idx].value
 
-	parentIdx := idx >> 1
-	t.allot(idx, idx, t.entries[parentIdx].prefixIndex, t.entries[parentIdx].value)
+	val := t.entries[idx]
+	var parentVal *T
+	if parentIdx := parentIndex(idx); parentIdx != 0 {
+		parentVal = t.entries[parentIdx]
+	}
+
+	t.allot(idx, val, parentVal)
 	t.routeRefs--
-	return val
+	return true
 }
 
-// get does a route lookup for addr and returns the associated value, or nil if
-// no route matched.
-func (t *strideTable[T]) get(addr uint8) *T {
-	return t.entries[hostIndex(addr)].value
+// get does a route lookup for addr and (value, true) if a matching
+// route exists, or (zero, false) otherwise.
+func (t *strideTable[T]) get(addr uint8) (ret T, ok bool) {
+	if val := t.entries[hostIndex(addr)]; val != nil {
+		return *val, true
+	}
+	return ret, false
+}
+
+// getValAndChild returns both the prefix value and child strideTable
+// for addr. valOK reports whether a prefix value exists for addr, and
+// child is non-nil if a child exists for addr.
+func (t *strideTable[T]) getValAndChild(addr uint8) (val T, valOK bool, child *strideTable[T]) {
+	vp := t.entries[hostIndex(addr)]
+	if vp != nil {
+		val = *vp
+		valOK = true
+	}
+	child = t.children[addr]
+	return
 }
 
 // TableDebugString returns the contents of t, formatted as a table with one
@@ -208,10 +232,10 @@ func (t *strideTable[T]) tableDebugString() string {
 			continue
 		}
 		v := "(nil)"
-		if ent.value != nil {
-			v = fmt.Sprint(*ent.value)
+		if ent != nil {
+			v = fmt.Sprint(*ent)
 		}
-		fmt.Fprintf(&ret, "idx=%3d (%s), parent=%3d (%s), val=%v\n", i, formatPrefixTable(inversePrefixIndex(i)), ent.prefixIndex, formatPrefixTable(inversePrefixIndex((ent.prefixIndex))), v)
+		fmt.Fprintf(&ret, "idx=%3d (%s), val=%v\n", i, formatPrefixTable(inversePrefixIndex(i)), v)
 	}
 	return ret.String()
 }
@@ -227,8 +251,8 @@ func (t *strideTable[T]) treeDebugString() string {
 
 func (t *strideTable[T]) treeDebugStringRec(w io.Writer, idx, indent int) {
 	addr, len := inversePrefixIndex(idx)
-	if t.entries[idx].prefixIndex != 0 && t.entries[idx].prefixIndex == idx {
-		fmt.Fprintf(w, "%s%d/%d (%02x/%d) = %v\n", strings.Repeat(" ", indent), addr, len, addr, len, *t.entries[idx].value)
+	if t.hasPrefixRootedAt(idx) {
+		fmt.Fprintf(w, "%s%d/%d (%02x/%d) = %v\n", strings.Repeat(" ", indent), addr, len, addr, len, *t.entries[idx])
 		indent += 2
 	}
 	if idx >= firstHostIndex {
@@ -249,6 +273,12 @@ func prefixIndex(addr uint8, prefixLen int) int {
 	//   - 42/8 is 1_00101010 (298): all bits of 42, with a 1 tacked on
 	//   - 48/4 is 1_0011 (19): 4 most-significant bits of 48, with a 1 tacked on
 	return (int(addr) >> (8 - prefixLen)) + (1 << prefixLen)
+}
+
+// parentIndex returns the index of idx's parent prefix, or 0 if idx
+// is the index of 0/0.
+func parentIndex(idx int) int {
+	return idx >> 1
 }
 
 // hostIndex returns the array index of the host route for addr.


### PR DESCRIPTION
Values are still turned into pointers internally to maintain the invariants of strideTable, but from the user's perspective it's now possible to tbl.Insert(pfx, true) rather than
tbl.Insert(pfx, ptr.To(true)).

Updates #7781

---

The benchmarks are a little noisy, but generally positive: insertion and deletion got 10-50% faster, and the route tables are half the size they were before. We do pay 1 extra alloc per insertion now (~3 allocs/insert instead of ~2), but given the prior API that's just an alloc from outside the table that's now moved inside, for most uses. Full Table benchmarks below.

```
goos: linux
goarch: amd64
pkg: tailscale.com/net/art
cpu: AMD Ryzen 9 5950X 16-Core Processor
                          │ before-tbl.txt │            after-tbl.txt             │
                          │     sec/op     │    sec/op     vs base                │
TableInsertion/ipv4/10         809.1n ± 1%   516.1n ±  0%  -36.21% (p=0.000 n=10)
TableInsertion/ipv4/100        906.9n ± 1%   617.4n ±  0%  -31.92% (p=0.000 n=10)
TableInsertion/ipv4/1000      1601.0n ± 3%   996.8n ±  2%  -37.74% (p=0.000 n=10)
TableInsertion/ipv4/10000      2.068µ ± 4%   1.378µ ±  5%  -33.39% (p=0.000 n=10)
TableInsertion/ipv6/10        1169.5n ± 1%   641.2n ±  0%  -45.17% (p=0.000 n=10)
TableInsertion/ipv6/100       1453.0n ± 7%   747.2n ±  0%  -48.58% (p=0.000 n=10)
TableInsertion/ipv6/1000       2.307µ ± 3%   1.401µ ±  2%  -39.26% (p=0.000 n=10)
TableInsertion/ipv6/10000      2.945µ ± 4%   1.930µ ±  3%  -34.47% (p=0.000 n=10)
TableDelete/ipv4/10            358.7n ± 2%   285.8n ±  1%  -20.34% (p=0.000 n=10)
TableDelete/ipv4/100           284.4n ± 1%   265.8n ±  3%   -6.54% (p=0.000 n=10)
TableDelete/ipv4/1000          406.2n ± 2%   363.9n ±  1%  -10.44% (p=0.000 n=10)
TableDelete/ipv4/10000         625.2n ± 7%   460.3n ±  6%  -26.38% (p=0.000 n=10)
TableDelete/ipv6/10            347.5n ± 1%   352.6n ±  1%   +1.50% (p=0.004 n=10)
TableDelete/ipv6/100           502.1n ± 0%   250.3n ±  0%  -50.15% (p=0.000 n=10)
TableDelete/ipv6/1000          516.4n ± 3%   425.3n ±  1%  -17.65% (p=0.000 n=10)
TableDelete/ipv6/10000         702.4n ± 4%   612.4n ± 10%  -12.82% (p=0.000 n=10)
TableGet/ipv4/10               48.19n ± 0%   47.40n ±  0%   -1.63% (p=0.000 n=10)
TableGet/ipv4/100              52.07n ± 0%   51.46n ±  0%   -1.18% (p=0.000 n=10)
TableGet/ipv4/1000             56.82n ± 1%   56.93n ±  1%        ~ (p=0.425 n=10)
TableGet/ipv4/10000            75.08n ± 1%   79.38n ±  1%   +5.73% (p=0.001 n=10)
TableGet/ipv6/10               47.08n ± 1%   38.83n ±  0%  -17.51% (p=0.000 n=10)
TableGet/ipv6/100              55.43n ± 0%   43.31n ±  2%  -21.87% (p=0.000 n=10)
TableGet/ipv6/1000             58.41n ± 2%   57.67n ±  1%   -1.28% (p=0.029 n=10)
TableGet/ipv6/10000            76.19n ± 4%   78.80n ±  4%        ~ (p=0.063 n=10)
geomean                        340.1n        264.7n        -22.17%

                          │ before-tbl.txt │             after-tbl.txt              │
                          │    avg-B/op    │   avg-B/op    vs base                  │
TableInsertion/ipv4/10       11.941Ki ± 0%   4.528Ki ± 0%  -62.08% (p=0.000 n=10)
TableInsertion/ipv4/100      10.870Ki ± 0%   5.758Ki ± 0%  -47.03% (p=0.000 n=10)
TableInsertion/ipv4/1000     10.405Ki ± 0%   5.109Ki ± 0%  -50.90% (p=0.000 n=10)
TableInsertion/ipv4/10000     9.099Ki ± 0%   4.356Ki ± 0%  -52.12% (p=0.000 n=10)
TableInsertion/ipv6/10       15.928Ki ± 0%   7.086Ki ± 0%  -55.51% (p=0.000 n=10)
TableInsertion/ipv6/100      13.664Ki ± 0%   7.168Ki ± 0%  -47.54% (p=0.000 n=10)
TableInsertion/ipv6/1000     14.829Ki ± 0%   7.151Ki ± 0%  -51.77% (p=0.000 n=10)
TableInsertion/ipv6/10000    13.220Ki ± 0%   6.333Ki ± 0%  -52.09% (p=0.000 n=10)
TableDelete/ipv4/10             3.220 ± 0%     2.400 ± 0%  -25.47% (p=0.000 n=10)
TableDelete/ipv4/100            3.940 ± 0%     3.840 ± 0%   -2.54% (p=0.000 n=10)
TableDelete/ipv4/1000           3.980 ± 0%     3.980 ± 0%        ~ (p=0.211 n=10)
TableDelete/ipv4/10000          4.000 ± 0%     4.000 ± 0%        ~ (p=1.000 n=10) ¹
TableDelete/ipv6/10             16.00 ± 0%     16.00 ± 0%        ~ (p=1.000 n=10) ¹
TableDelete/ipv6/100            15.84 ± 0%     16.00 ± 0%   +1.01% (p=0.000 n=10)
TableDelete/ipv6/1000           15.98 ± 0%     15.99 ± 0%   +0.06% (p=0.000 n=10)
TableDelete/ipv6/10000          16.00 ± 0%     16.00 ± 0%        ~ (p=1.000 n=10) ¹
geomean                         312.6          211.1       -32.47%
¹ all samples are equal

                          │ before-tbl.txt │              after-tbl.txt              │
                          │ avg-allocs/op  │ avg-allocs/op  vs base                  │
TableInsertion/ipv4/10          1.800 ± 0%      2.600 ± 0%  +44.44% (p=0.000 n=10)
TableInsertion/ipv4/100         1.800 ± 0%      2.880 ± 0%  +60.00% (p=0.000 n=10)
TableInsertion/ipv4/1000        1.780 ± 0%      2.800 ± 0%  +57.30% (p=0.000 n=10)
TableInsertion/ipv4/10000       1.690 ± 0%      2.680 ± 0%  +58.58% (p=0.000 n=10)
TableInsertion/ipv6/10          2.100 ± 0%      3.000 ± 0%  +42.86% (p=0.000 n=10)
TableInsertion/ipv6/100         2.010 ± 0%      3.110 ± 0%  +54.73% (p=0.000 n=10)
TableInsertion/ipv6/1000        2.120 ± 0%      3.120 ± 0%  +47.17% (p=0.000 n=10)
TableInsertion/ipv6/10000       2.000 ± 0%      2.990 ± 0%  +49.50% (p=0.000 n=10)
TableDelete/ipv4/10           1000.0m ± 0%     900.0m ± 0%  -10.00% (p=0.000 n=10)
TableDelete/ipv4/100           990.0m ± 0%     990.0m ± 0%        ~ (p=1.000 n=10) ¹
TableDelete/ipv4/1000           1.000 ± 0%      1.000 ± 0%        ~ (p=1.000 n=10) ¹
TableDelete/ipv4/10000          1.000 ± 0%      1.000 ± 0%        ~ (p=1.000 n=10) ¹
TableDelete/ipv6/10             1.000 ± 0%      1.000 ± 0%        ~ (p=1.000 n=10) ¹
TableDelete/ipv6/100           990.0m ± 0%    1000.0m ± 0%   +1.01% (p=0.000 n=10)
TableDelete/ipv6/1000           1.000 ± 0%      1.000 ± 0%        ~ (p=1.000 n=10) ¹
TableDelete/ipv6/10000          1.000 ± 0%      1.000 ± 0%        ~ (p=1.000 n=10) ¹
geomean                         1.379           1.688       +22.43%
¹ all samples are equal

                          │ before-tbl.txt │             after-tbl.txt             │
                          │    routes/s    │   routes/s    vs base                 │
TableInsertion/ipv4/10         1.236M ± 1%    1.937M ± 0%   +56.74% (p=0.000 n=10)
TableInsertion/ipv4/100        1.103M ± 1%    1.620M ± 0%   +46.90% (p=0.000 n=10)
TableInsertion/ipv4/1000       624.7k ± 3%   1003.3k ± 2%   +60.60% (p=0.000 n=10)
TableInsertion/ipv4/10000      483.5k ± 4%    726.0k ± 5%   +50.16% (p=0.000 n=10)
TableInsertion/ipv6/10         855.0k ± 1%   1559.4k ± 0%   +82.39% (p=0.000 n=10)
TableInsertion/ipv6/100        690.7k ± 7%   1338.4k ± 0%   +93.76% (p=0.000 n=10)
TableInsertion/ipv6/1000       433.5k ± 3%    713.7k ± 2%   +64.63% (p=0.000 n=10)
TableInsertion/ipv6/10000      339.5k ± 4%    518.2k ± 3%   +52.62% (p=0.000 n=10)
TableDelete/ipv4/10            2.788M ± 2%    3.499M ± 1%   +25.53% (p=0.000 n=10)
TableDelete/ipv4/100           3.516M ± 1%    3.762M ± 3%    +7.01% (p=0.000 n=10)
TableDelete/ipv4/1000          2.461M ± 2%    2.748M ± 1%   +11.66% (p=0.000 n=10)
TableDelete/ipv4/10000         1.599M ± 8%    2.172M ± 6%   +35.82% (p=0.000 n=10)
TableDelete/ipv6/10            2.878M ± 1%    2.836M ± 1%    -1.48% (p=0.004 n=10)
TableDelete/ipv6/100           1.992M ± 0%    3.996M ± 0%  +100.63% (p=0.000 n=10)
TableDelete/ipv6/1000          1.936M ± 3%    2.351M ± 1%   +21.44% (p=0.000 n=10)
TableDelete/ipv6/10000         1.424M ± 4%    1.633M ± 9%   +14.71% (p=0.000 n=10)
geomean                        1.212M         1.723M        +42.11%

                    │ before-tbl.txt │            after-tbl.txt            │
                    │    addrs/s     │   addrs/s    vs base                │
TableGet/ipv4/10         20.75M ± 0%   21.10M ± 0%   +1.66% (p=0.000 n=10)
TableGet/ipv4/100        19.20M ± 0%   19.43M ± 0%   +1.20% (p=0.000 n=10)
TableGet/ipv4/1000       17.60M ± 1%   17.56M ± 1%        ~ (p=0.436 n=10)
TableGet/ipv4/10000      13.32M ± 1%   12.60M ± 1%   -5.42% (p=0.002 n=10)
TableGet/ipv6/10         21.24M ± 1%   25.75M ± 0%  +21.23% (p=0.000 n=10)
TableGet/ipv6/100        18.04M ± 0%   23.09M ± 2%  +28.00% (p=0.000 n=10)
TableGet/ipv6/1000       17.12M ± 1%   17.34M ± 1%   +1.29% (p=0.029 n=10)
TableGet/ipv6/10000      13.13M ± 4%   12.69M ± 4%        ~ (p=0.063 n=10)
geomean                  17.31M        18.17M        +4.99%

                    │ before-tbl.txt │            after-tbl.txt            │
                    │      B/op      │    B/op     vs base                 │
TableGet/ipv4/10        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TableGet/ipv4/100       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TableGet/ipv4/1000      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TableGet/ipv4/10000     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TableGet/ipv6/10        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TableGet/ipv6/100       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TableGet/ipv6/1000      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TableGet/ipv6/10000     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                            ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                    │ before-tbl.txt │            after-tbl.txt            │
                    │   allocs/op    │ allocs/op   vs base                 │
TableGet/ipv4/10        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TableGet/ipv4/100       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TableGet/ipv4/1000      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TableGet/ipv4/10000     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TableGet/ipv6/10        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TableGet/ipv6/100       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TableGet/ipv6/1000      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TableGet/ipv6/10000     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                            ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```