### PR TITLE
cmd/tailscale: change serve and funnel calls to StatusWithoutPeers

### DIFF
--- a/cmd/tailscale/cli/funnel.go
+++ b/cmd/tailscale/cli/funnel.go
@@ -83,7 +83,7 @@ func (e *serveEnv) runFunnel(ctx context.Context, args []string) error {
 	if sc == nil {
 		sc = new(ipn.ServeConfig)
 	}
-	st, err := e.getLocalClientStatus(ctx)
+	st, err := e.getLocalClientStatusWithoutPeers(ctx)
 	if err != nil {
 		return fmt.Errorf("getting client status: %w", err)
 	}
@@ -146,7 +146,7 @@ func (e *serveEnv) verifyFunnelEnabled(ctx context.Context, st *ipnstate.Status,
 		return nil // already enabled
 	}
 	enableErr := e.enableFeatureInteractive(ctx, "funnel", hasFunnelAttrs)
-	st, statusErr := e.getLocalClientStatus(ctx) // get updated status; interactive flow may block
+	st, statusErr := e.getLocalClientStatusWithoutPeers(ctx) // get updated status; interactive flow may block
 	switch {
 	case statusErr != nil:
 		return fmt.Errorf("getting client status: %w", statusErr)

--- a/cmd/tailscale/cli/serve_test.go
+++ b/cmd/tailscale/cli/serve_test.go
@@ -810,7 +810,7 @@ func TestVerifyFunnelEnabled(t *testing.T) {
 				defer func() { fakeStatus.Self.Capabilities = oldCaps }() // reset after test
 				fakeStatus.Self.Capabilities = tt.caps
 			}
-			st, err := e.getLocalClientStatus(ctx)
+			st, err := e.getLocalClientStatusWithoutPeers(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -861,7 +861,7 @@ var fakeStatus = &ipnstate.Status{
 	},
 }
 
-func (lc *fakeLocalServeClient) Status(ctx context.Context) (*ipnstate.Status, error) {
+func (lc *fakeLocalServeClient) StatusWithoutPeers(ctx context.Context) (*ipnstate.Status, error) {
 	return fakeStatus, nil
 }
 


### PR DESCRIPTION
The tailscale serve|funnel commands frequently call the LocalBackend's Status but they never need the peers to be included. This PR changes the call to be StatusWithoutPeers which should gain a noticeable speed improvement

Updates #8489