### PR TITLE
tsnet/example/web-client: listen on localhost

### DIFF
--- a/tsnet/example/web-client/web-client.go
+++ b/tsnet/example/web-client/web-client.go
@@ -14,6 +14,7 @@ import (
 )
 
 var (
+	addr    = flag.String("addr", "localhost:8060", "address of Tailscale web client")
 	devMode = flag.Bool("dev", false, "run web client in dev mode")
 )
 
@@ -23,12 +24,6 @@ func main() {
 	s := new(tsnet.Server)
 	defer s.Close()
 
-	ln, err := s.Listen("tcp", ":80")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer ln.Close()
-
 	lc, err := s.LocalClient()
 	if err != nil {
 		log.Fatal(err)
@@ -37,7 +32,8 @@ func main() {
 	// Serve the Tailscale web client.
 	ws, cleanup := web.NewServer(*devMode, lc)
 	defer cleanup()
-	if err := http.Serve(ln, ws); err != nil {
+	log.Printf("Serving Tailscale web client on http://%s", *addr)
+	if err := http.ListenAndServe(*addr, ws); err != nil {
 		if err != http.ErrServerClosed {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
Serving the web client on the tailscale interface, while useful for remote management, is also inherently risky if ACLs are not configured appropriately. Switch the example to listen only on localhost, which is a much safer default. This is still a valuable example, since it still demonstrates how to have a web client connected to a tsnet instance.

Updates #13775