### PR TITLE
types/tkatype: add test for MarshaledSignature's JSON format

### DIFF
--- a/types/tkatype/tkatype_test.go
+++ b/types/tkatype/tkatype_test.go
@@ -4,6 +4,7 @@
 package tkatype
 
 import (
+	"encoding/json"
 	"testing"
 
 	"golang.org/x/crypto/blake2s"
@@ -18,5 +19,25 @@ func TestSigHashSize(t *testing.T) {
 	var nksHash NKSSigHash
 	if len(nksHash) != blake2s.Size {
 		t.Errorf("NKSSigHash is wrong size: got %d, want %d", len(nksHash), blake2s.Size)
+	}
+}
+
+func TestMarshaledSignatureJSON(t *testing.T) {
+	sig := MarshaledSignature("abcdef")
+	j, err := json.Marshal(sig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const encoded = `"YWJjZGVm"`
+	if string(j) != encoded {
+		t.Errorf("got JSON %q; want %q", j, encoded)
+	}
+
+	var back MarshaledSignature
+	if err := json.Unmarshal([]byte(encoded), &back); err != nil {
+		t.Fatal(err)
+	}
+	if string(back) != string(sig) {
+		t.Errorf("decoded JSON back to %q; want %q", back, sig)
 	}
 }


### PR DESCRIPTION
Lock in its wire format before a potential change to its Go type.

Updates #1909
