### PR TITLE
types/tkatype: change MarshaledSignature from []byte to string

### DIFF
--- a/control/controlclient/map.go
+++ b/control/controlclient/map.go
@@ -330,7 +330,7 @@ func undeltaPeers(mapRes *tailcfg.MapResponse, prev []*tailcfg.Node) {
 				if v := ec.Capabilities; v != nil {
 					n.Capabilities = *v
 				}
-				if v := ec.KeySignature; v != nil {
+				if v := ec.KeySignature; v != "" {
 					n.KeySignature = v
 				}
 			}

--- a/control/controlclient/map_test.go
+++ b/control/controlclient/map_test.go
@@ -212,12 +212,12 @@ func TestUndeltaPeers(t *testing.T) {
 			mapRes: &tailcfg.MapResponse{
 				PeersChangedPatch: []*tailcfg.PeerChange{{
 					NodeID:       1,
-					KeySignature: []byte{3, 4},
+					KeySignature: "ab",
 				}},
 			}, want: peers(&tailcfg.Node{
 				ID:           1,
 				Name:         "foo",
-				KeySignature: []byte{3, 4},
+				KeySignature: "ab",
 			}),
 		},
 		{

--- a/ipn/ipnlocal/network-lock.go
+++ b/ipn/ipnlocal/network-lock.go
@@ -73,8 +73,8 @@ func (b *LocalBackend) tkaFilterNetmapLocked(nm *netmap.NetworkMap) {
 			// Not subject to tailnet lock.
 			continue
 		}
-		keySig := tkatype.MarshaledSignature(p.KeySignature().StringCopy()) // TODO(bradfitz,maisem): this is unfortunate. Change tkatype.MarshaledSignature to a string for viewer?
-		if len(keySig) == 0 {
+		keySig := p.KeySignature()
+		if keySig == "" {
 			b.logf("Network lock is dropping peer %v(%v) due to missing signature", p.ID(), p.StableID())
 			mak.Set(&toDelete, i, true)
 		} else {
@@ -965,7 +965,7 @@ func (b *LocalBackend) NetworkLockWrapPreauthKey(preauthKey string, tkaKey key.N
 	}
 
 	b.logf("Generated network-lock credential signature using %s", tkaKey.Public().CLIString())
-	return fmt.Sprintf("%s--TL%s-%s", preauthKey, tkaSuffixEncoder.EncodeToString(sig.Serialize()), tkaSuffixEncoder.EncodeToString(priv)), nil
+	return fmt.Sprintf("%s--TL%s-%s", preauthKey, tkaSuffixEncoder.EncodeToString([]byte(sig.Serialize())), tkaSuffixEncoder.EncodeToString(priv)), nil
 }
 
 // NetworkLockVerifySigningDeeplink asks the authority to verify the given deeplink

--- a/ipn/ipnlocal/network-lock_test.go
+++ b/ipn/ipnlocal/network-lock_test.go
@@ -561,7 +561,7 @@ func TestTKAFilterNetmap(t *testing.T) {
 	nm := &netmap.NetworkMap{
 		Peers: nodeViews([]*tailcfg.Node{
 			{ID: 1, Key: n1.Public(), KeySignature: n1GoodSig.Serialize()},
-			{ID: 2, Key: n2.Public(), KeySignature: nil},                   // missing sig
+			{ID: 2, Key: n2.Public(), KeySignature: ""},                    // missing sig
 			{ID: 3, Key: n3.Public(), KeySignature: n1GoodSig.Serialize()}, // someone elses sig
 			{ID: 4, Key: n4.Public(), KeySignature: n4Sig.Serialize()},     // messed-up signature
 			{ID: 5, Key: n5.Public(), KeySignature: n5GoodSig.Serialize()},
@@ -987,7 +987,7 @@ func TestTKAAffectedSigs(t *testing.T) {
 				if len(sigs) != 1 {
 					t.Fatalf("len(sigs) = %d, want 1", len(sigs))
 				}
-				if !bytes.Equal(s.Serialize(), sigs[0]) {
+				if s.Serialize() != sigs[0] {
 					t.Errorf("unexpected signature: got %v, want %v", sigs[0], s.Serialize())
 				}
 			}

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -6,7 +6,6 @@ package tailcfg
 //go:generate go run tailscale.com/cmd/viewer --type=User,Node,Hostinfo,NetInfo,Login,DNSConfig,RegisterResponse,RegisterResponseAuth,RegisterRequest,DERPHomeParams,DERPRegion,DERPMap,DERPNode,SSHRule,SSHAction,SSHPrincipal,ControlDialPlan,Location,UserProfile --clonefunc
 
 import (
-	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -1786,7 +1785,7 @@ func (n *Node) Equal(n2 *Node) bool {
 		n.UnsignedPeerAPIOnly == n2.UnsignedPeerAPIOnly &&
 		n.Key == n2.Key &&
 		n.KeyExpiry.Equal(n2.KeyExpiry) &&
-		bytes.Equal(n.KeySignature, n2.KeySignature) &&
+		n.KeySignature == n2.KeySignature &&
 		n.Machine == n2.Machine &&
 		n.DiscoKey == n2.DiscoKey &&
 		eqPtr(n.Online, n2.Online) &&

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -46,7 +46,6 @@ func (src *Node) Clone() *Node {
 	}
 	dst := new(Node)
 	*dst = *src
-	dst.KeySignature = append(src.KeySignature[:0:0], src.KeySignature...)
 	dst.Addresses = append(src.Addresses[:0:0], src.Addresses...)
 	dst.AllowedIPs = append(src.AllowedIPs[:0:0], src.AllowedIPs...)
 	dst.Endpoints = append(src.Endpoints[:0:0], src.Endpoints...)
@@ -271,7 +270,6 @@ func (src *RegisterResponse) Clone() *RegisterResponse {
 	dst := new(RegisterResponse)
 	*dst = *src
 	dst.User = *src.User.Clone()
-	dst.NodeKeySignature = append(src.NodeKeySignature[:0:0], src.NodeKeySignature...)
 	return dst
 }
 
@@ -320,7 +318,6 @@ func (src *RegisterRequest) Clone() *RegisterRequest {
 	*dst = *src
 	dst.Auth = *src.Auth.Clone()
 	dst.Hostinfo = src.Hostinfo.Clone()
-	dst.NodeKeySignature = append(src.NodeKeySignature[:0:0], src.NodeKeySignature...)
 	if dst.Timestamp != nil {
 		dst.Timestamp = new(time.Time)
 		*dst.Timestamp = *src.Timestamp

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -136,7 +136,7 @@ func (v NodeView) User() UserID                             { return v.ж.User }
 func (v NodeView) Sharer() UserID                           { return v.ж.Sharer }
 func (v NodeView) Key() key.NodePublic                      { return v.ж.Key }
 func (v NodeView) KeyExpiry() time.Time                     { return v.ж.KeyExpiry }
-func (v NodeView) KeySignature() mem.RO                     { return mem.B(v.ж.KeySignature) }
+func (v NodeView) KeySignature() tkatype.MarshaledSignature { return v.ж.KeySignature }
 func (v NodeView) Machine() key.MachinePublic               { return v.ж.Machine }
 func (v NodeView) DiscoKey() key.DiscoPublic                { return v.ж.DiscoKey }
 func (v NodeView) Addresses() views.Slice[netip.Prefix]     { return views.SliceOf(v.ж.Addresses) }
@@ -610,13 +610,15 @@ func (v *RegisterResponseView) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (v RegisterResponseView) User() UserView           { return v.ж.User.View() }
-func (v RegisterResponseView) Login() Login             { return v.ж.Login }
-func (v RegisterResponseView) NodeKeyExpired() bool     { return v.ж.NodeKeyExpired }
-func (v RegisterResponseView) MachineAuthorized() bool  { return v.ж.MachineAuthorized }
-func (v RegisterResponseView) AuthURL() string          { return v.ж.AuthURL }
-func (v RegisterResponseView) NodeKeySignature() mem.RO { return mem.B(v.ж.NodeKeySignature) }
-func (v RegisterResponseView) Error() string            { return v.ж.Error }
+func (v RegisterResponseView) User() UserView          { return v.ж.User.View() }
+func (v RegisterResponseView) Login() Login            { return v.ж.Login }
+func (v RegisterResponseView) NodeKeyExpired() bool    { return v.ж.NodeKeyExpired }
+func (v RegisterResponseView) MachineAuthorized() bool { return v.ж.MachineAuthorized }
+func (v RegisterResponseView) AuthURL() string         { return v.ж.AuthURL }
+func (v RegisterResponseView) NodeKeySignature() tkatype.MarshaledSignature {
+	return v.ж.NodeKeySignature
+}
+func (v RegisterResponseView) Error() string { return v.ж.Error }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _RegisterResponseViewNeedsRegeneration = RegisterResponse(struct {
@@ -749,8 +751,10 @@ func (v RegisterRequestView) Expiry() time.Time              { return v.ж.Expir
 func (v RegisterRequestView) Followup() string               { return v.ж.Followup }
 func (v RegisterRequestView) Hostinfo() HostinfoView         { return v.ж.Hostinfo.View() }
 func (v RegisterRequestView) Ephemeral() bool                { return v.ж.Ephemeral }
-func (v RegisterRequestView) NodeKeySignature() mem.RO       { return mem.B(v.ж.NodeKeySignature) }
-func (v RegisterRequestView) SignatureType() SignatureType   { return v.ж.SignatureType }
+func (v RegisterRequestView) NodeKeySignature() tkatype.MarshaledSignature {
+	return v.ж.NodeKeySignature
+}
+func (v RegisterRequestView) SignatureType() SignatureType { return v.ж.SignatureType }
 func (v RegisterRequestView) Timestamp() *time.Time {
 	if v.ж.Timestamp == nil {
 		return nil

--- a/tka/sig.go
+++ b/tka/sig.go
@@ -166,7 +166,7 @@ func (s NodeKeySignature) authorizingKeyID() (tkatype.KeyID, error) {
 func (s NodeKeySignature) SigHash() [blake2s.Size]byte {
 	dupe := s
 	dupe.Signature = nil
-	return blake2s.Sum256(dupe.Serialize())
+	return blake2s.Sum256([]byte(dupe.Serialize()))
 }
 
 // Serialize returns the given NKS in a serialized format.
@@ -186,7 +186,7 @@ func (s *NodeKeySignature) Serialize() tkatype.MarshaledSignature {
 		// Writing to a bytes.Buffer should never fail.
 		panic(err)
 	}
-	return out.Bytes()
+	return tkatype.MarshaledSignature(out.Bytes())
 }
 
 // Unserialize decodes bytes representing a marshaled NKS.
@@ -194,9 +194,9 @@ func (s *NodeKeySignature) Serialize() tkatype.MarshaledSignature {
 // We would implement encoding.BinaryUnmarshaler, except that would
 // unfortunately get called by the cbor unmarshaller resulting in infinite
 // recursion.
-func (s *NodeKeySignature) Unserialize(data []byte) error {
+func (s *NodeKeySignature) Unserialize(data tkatype.MarshaledSignature) error {
 	dec, _ := cborDecOpts.DecMode()
-	return dec.Unmarshal(data, s)
+	return dec.Unmarshal([]byte(data), s)
 }
 
 // verifySignature checks that the NodeKeySignature is authentic & certified

--- a/types/tkatype/tkatype.go
+++ b/types/tkatype/tkatype.go
@@ -7,6 +7,8 @@
 // because this package encodes wire types that should be lightweight to use.
 package tkatype
 
+import "encoding/json"
+
 // KeyID references a verification key stored in the key authority. A keyID
 // uniquely identifies a key. KeyIDs are all 32 bytes.
 //
@@ -19,7 +21,26 @@ package tkatype
 type KeyID []byte
 
 // MarshaledSignature represents a marshaled tka.NodeKeySignature.
-type MarshaledSignature []byte
+//
+// While its underlying type is a string, it's just the raw signature bytes, not
+// hex or base64, etc.
+//
+// Think of it as []byte, which it used to be. It's a string only to make it
+// easier to use with cmd/viewer.
+type MarshaledSignature string
+
+func (a MarshaledSignature) MarshalJSON() ([]byte, error) {
+	return json.Marshal([]byte(a))
+}
+
+func (a *MarshaledSignature) UnmarshalJSON(b []byte) error {
+	var bs []byte
+	if err := json.Unmarshal(b, &bs); err != nil {
+		return err
+	}
+	*a = MarshaledSignature(bs)
+	return nil
+}
 
 // MarshaledAUM represents a marshaled tka.AUM.
 type MarshaledAUM []byte


### PR DESCRIPTION
The MarshaledSignature's underlying type of []byte didn't play nicely with cmd/viewer, which mapped the []byte to a mem.RO handle which was then clumsy to work with.

Instead, change it to a string. (But keep its JSON encoding for compatibility)

Updates #1909
