### PR TITLE
cmd/tailscale: support write files to stdout for file get

### DIFF
--- a/cmd/tailscale/cli/file.go
+++ b/cmd/tailscale/cli/file.go
@@ -463,6 +463,14 @@ func receiveFile(ctx context.Context, wf apitype.WaitingFile, dir string) (targe
 		return "", 0, fmt.Errorf("opening inbox file %q: %w", wf.Name, err)
 	}
 	defer rc.Close()
+	if dir == "-" {
+		f := os.Stdout
+		_, err = io.Copy(f, rc)
+		if err != nil {
+			return "", 0, fmt.Errorf("failed to write %v: %v", f.Name(), err)
+		}
+		return f.Name(), size, nil
+	}
 	f, err := openFileOrSubstitute(dir, wf.Name, getArgs.conflict)
 	if err != nil {
 		return "", 0, err
@@ -542,8 +550,10 @@ func runFileGet(ctx context.Context, args []string) error {
 		return wipeInbox(ctx)
 	}
 
-	if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
-		return fmt.Errorf("%q is not a directory", dir)
+	if dir != "-" {
+		if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
+			return fmt.Errorf("%q is not a directory", dir)
+		}
 	}
 	if getArgs.loop {
 		for {


### PR DESCRIPTION
This resolves #8981.

Caveat: Tailscale might write log messages to stdout. Normally `file get` does not print any message.
