### PR TITLE
util/linuxfw: fix typo in unexported doc comment

### DIFF
--- a/util/linuxfw/nftables_runner.go
+++ b/util/linuxfw/nftables_runner.go
@@ -136,7 +136,8 @@ func getChainsFromTable(c *nftables.Conn, table *nftables.Table) ([]*nftables.Ch
 	return ret, nil
 }
 
-// isTSChain retruns true if the chain name starts with ts
+// isTSChain reports whether `name` begins with "ts-" (and is thus a
+// Tailscale-managed chain).
 func isTSChain(name string) bool {
 	return strings.HasPrefix(name, "ts-")
 }


### PR DESCRIPTION
And flesh it out and use idiomatic doc style ("whether" for bools) and end in a period while there anyway.

Updates #cleanup
