### PR TITLE
Revert "release/dist: run yarn build before building CLI"

### DIFF
--- a/release/dist/synology/pkgs.go
+++ b/release/dist/synology/pkgs.go
@@ -144,9 +144,6 @@ func getSynologyBuilds(b *dist.Build) *synologyBuilds {
 func (m *synologyBuilds) buildInnerPackage(b *dist.Build, dsmVersion int, goenv map[string]string) (*innerPkg, error) {
 	key := []any{dsmVersion, goenv}
 	return m.innerPkgs.Do(key, func() (*innerPkg, error) {
-		if err := b.BuildWebClientAssets(); err != nil {
-			return nil, err
-		}
 		ts, err := b.BuildGoBinary("tailscale.com/cmd/tailscale", goenv)
 		if err != nil {
 			return nil, err

--- a/release/dist/unixpkgs/pkgs.go
+++ b/release/dist/unixpkgs/pkgs.go
@@ -53,9 +53,6 @@ func (t *tgzTarget) Build(b *dist.Build) ([]string, error) {
 	} else {
 		filename = fmt.Sprintf("tailscale_%s_%s_%s.tgz", b.Version.Short, t.os(), t.arch())
 	}
-	if err := b.BuildWebClientAssets(); err != nil {
-		return nil, err
-	}
 	ts, err := b.BuildGoBinary("tailscale.com/cmd/tailscale", t.goEnv)
 	if err != nil {
 		return nil, err
@@ -196,9 +193,6 @@ func (t *debTarget) Build(b *dist.Build) ([]string, error) {
 		return nil, errors.New("deb only supported on linux")
 	}
 
-	if err := b.BuildWebClientAssets(); err != nil {
-		return nil, err
-	}
 	ts, err := b.BuildGoBinary("tailscale.com/cmd/tailscale", t.goEnv)
 	if err != nil {
 		return nil, err
@@ -311,9 +305,6 @@ func (t *rpmTarget) Build(b *dist.Build) ([]string, error) {
 		return nil, errors.New("rpm only supported on linux")
 	}
 
-	if err := b.BuildWebClientAssets(); err != nil {
-		return nil, err
-	}
 	ts, err := b.BuildGoBinary("tailscale.com/cmd/tailscale", t.goEnv)
 	if err != nil {
 		return nil, err

--- a/tool/yarn
+++ b/tool/yarn
@@ -21,7 +21,7 @@ fi
     cachedir="$HOME/.cache/tailscale-yarn"
     tarball="${cachedir}.tar.gz"
 
-    read -r want_rev < "./tool/yarn.rev"
+    read -r want_rev < "$(dirname "$0")/yarn.rev"
 
     got_rev=""
     if [[ -x "${cachedir}/bin/yarn" ]]; then


### PR DESCRIPTION
This caused breakages on the build server:

```
synology/dsm7/x86_64: chdir /home/ubuntu/builds/2023-08-21T21-47-38Z-unstable-main-tagged-devices/0/client/web: no such file or directory 
synology/dsm7/i686: chdir /home/ubuntu/builds/2023-08-21T21-47-38Z-unstable-main-tagged-devices/0/client/web: no such file or directory 
synology/dsm7/armv8: chdir /home/ubuntu/builds/2023-08-21T21-47-38Z-unstable-main-tagged-devices/0/client/web: no such file or directory 
...
```

Reverting while I investigate.

This reverts commit 0fb95ec07daa81d2a30a44af7d969249cec5bdc8.