### PR TITLE
wgengine/magicsock: handle wireguard only clean up and log messages

### DIFF
--- a/wgengine/magicsock/endpoint.go
+++ b/wgengine/magicsock/endpoint.go
@@ -1123,7 +1123,11 @@ func (de *endpoint) stopAndReset() {
 	defer de.mu.Unlock()
 
 	if closing := de.c.closing.Load(); !closing {
-		de.c.logf("[v1] magicsock: doing cleanup for discovery key %s", de.discoShort())
+		if de.isWireguardOnly {
+			de.c.logf("[v1] magicsock: doing cleanup for wireguard key %s", de.publicKey.ShortString())
+		} else {
+			de.c.logf("[v1] magicsock: doing cleanup for discovery key %s", de.discoShort())
+		}
 	}
 
 	de.debugUpdates.Add(EndpointChange{
@@ -1149,8 +1153,10 @@ func (de *endpoint) resetLocked() {
 	for _, es := range de.endpointState {
 		es.lastPing = 0
 	}
-	for txid, sp := range de.sentPing {
-		de.removeSentDiscoPingLocked(txid, sp)
+	if !de.isWireguardOnly {
+		for txid, sp := range de.sentPing {
+			de.removeSentDiscoPingLocked(txid, sp)
+		}
 	}
 }
 


### PR DESCRIPTION
This change updates log messaging when cleaning up wireguard only peers. This change also stops us unnecessarily attempting to clean up disco pings for wireguard only endpoints.

Updates #7826