### PR TITLE
wgengine/magicsock: clear endpoint state in noteConnectivityChange

### DIFF
--- a/wgengine/magicsock/endpoint.go
+++ b/wgengine/magicsock/endpoint.go
@@ -132,6 +132,14 @@ type endpointState struct {
 	index int16 // index in nodecfg.Node.Endpoints; meaningless if lastGotPing non-zero
 }
 
+// clear removes all derived / probed state from an endpointState.
+func (s *endpointState) clear() {
+	*s = endpointState{
+		index:       s.index,
+		lastGotPing: s.lastGotPing,
+	}
+}
+
 // pongHistoryCount is how many pongReply values we keep per endpointState
 const pongHistoryCount = 64
 
@@ -865,7 +873,12 @@ func (de *endpoint) noteConnectivityChange() {
 	de.mu.Lock()
 	defer de.mu.Unlock()
 
+	de.bestAddr = addrLatency{}
 	de.trustBestAddrUntil = 0
+
+	for k := range de.endpointState {
+		de.endpointState[k].clear()
+	}
 }
 
 // handlePongConnLocked handles a Pong message (a reply to an earlier ping).


### PR DESCRIPTION
There are latency values stored in bestAddr and endpointState that are no longer applicable after a connectivity change and should be cleared out, following the documented behavior of the function.

Updates #8999