### PR TITLE
wgengine/magicsock: clear out endpoint statistics when it becomes bad

### DIFF
--- a/wgengine/magicsock/endpoint_default.go
+++ b/wgengine/magicsock/endpoint_default.go
@@ -1,0 +1,23 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !js && !wasm
+// +build !js,!wasm
+
+package magicsock
+
+import (
+	"errors"
+	"syscall"
+)
+
+// errHOSTUNREACH wraps unix.EHOSTUNREACH in an interface type to pass to
+// errors.Is while avoiding an allocation per call.
+var errHOSTUNREACH error = syscall.EHOSTUNREACH
+
+// isBadEndpointErr checks if err is one which is known to report that an
+// endpoint can no longer be sent to. It is not exhaustive, and for unknown
+// errors always reports false.
+func isBadEndpointErr(err error) bool {
+	return errors.Is(err, errHOSTUNREACH)
+}

--- a/wgengine/magicsock/endpoint_js.go
+++ b/wgengine/magicsock/endpoint_js.go
@@ -1,0 +1,14 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build js || wasm
+// +build js wasm
+
+package magicsock
+
+// isBadEndpointErr checks if err is one which is known to report that an
+// endpoint can no longer be sent to. It is not exhaustive, but covers known
+// cases.
+func isBadEndpointErr(err error) bool {
+	return false
+}


### PR DESCRIPTION
There are cases where we do not detect the non-viability of a route, but we will instead observe a failure to send. In a Disco path this would normally be handled as a side effect of Disco, which is not available to non-Disco WireGuard nodes. In both cases, recognizing the failure as such will result in faster convergence.

Updates #8999
Signed-off-by: James Tucker <james@tailscale.com>