### PR TITLE
.github: add flakehub-publish-tagged.yml

### DIFF
--- a/.github/workflows/flakehub-publish-tagged.yml
+++ b/.github/workflows/flakehub-publish-tagged.yml
@@ -1,0 +1,17 @@
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - '^v[0-9]+\.[0-9]*[02468]+\.[0-9]+$'
+jobs:
+  publish:
+    runs-on: "ubuntu-latest"
+    permissions:
+      id-token: "write"
+      contents: "read"
+    steps:
+      - uses: "actions/checkout@v3"
+      - uses: "DeterminateSystems/nix-installer-action@main"
+      - uses: "DeterminateSystems/flakehub-push@main"
+        with:
+          visibility: "public"


### PR DESCRIPTION
This workflow will publish a flake to flakehub when a tag is pushed to the repository. It will only publish tags that match the pattern `v*.*.*`.

Fixes #9008