### PR TITLE
types/netmap: remove redundant Netmap.Hostinfo

### DIFF
--- a/control/controlclient/map.go
+++ b/control/controlclient/map.go
@@ -467,9 +467,6 @@ func (ms *mapSession) netmap() *netmap.NetworkMap {
 		nm.Expiry = node.KeyExpiry()
 		nm.Name = node.Name()
 		nm.Addresses = filterSelfAddresses(node.Addresses().AsSlice())
-		if node.Hostinfo().Valid() {
-			nm.Hostinfo = *node.Hostinfo().AsStruct()
-		}
 		if node.MachineAuthorized() {
 			nm.MachineStatus = tailcfg.MachineAuthorized
 		} else {

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -704,7 +704,9 @@ func (b *LocalBackend) updateStatus(sb *ipnstate.StatusBuilder, extraLocked func
 		ss.Online = health.GetInPollNetMap()
 		if b.netMap != nil {
 			ss.InNetworkMap = true
-			ss.HostName = b.netMap.Hostinfo.Hostname
+			if hi := b.netMap.SelfNode.Hostinfo(); hi.Valid() {
+				ss.HostName = hi.Hostname()
+			}
 			ss.DNSName = b.netMap.Name
 			ss.UserID = b.netMap.User()
 			if sn := b.netMap.SelfNode; sn.Valid() {

--- a/types/netmap/netmap.go
+++ b/types/netmap/netmap.go
@@ -23,8 +23,6 @@ import (
 // The fields should all be considered read-only. They might
 // alias parts of previous NetworkMap values.
 type NetworkMap struct {
-	// Core networking
-
 	SelfNode   tailcfg.NodeView
 	NodeKey    key.NodePublic
 	PrivateKey key.NodePrivate
@@ -44,10 +42,10 @@ type NetworkMap struct {
 	MachineStatus tailcfg.MachineStatus
 
 	MachineKey key.MachinePublic
-	Peers      []tailcfg.NodeView // sorted by Node.ID
-	DNS        tailcfg.DNSConfig
-	// TODO(maisem) : replace with View.
-	Hostinfo          tailcfg.Hostinfo
+
+	Peers []tailcfg.NodeView // sorted by Node.ID
+	DNS   tailcfg.DNSConfig
+
 	PacketFilter      []filter.Match
 	PacketFilterRules views.Slice[tailcfg.FilterRule]
 	SSHPolicy         *tailcfg.SSHPolicy // or nil, if not enabled/allowed


### PR DESCRIPTION
It was in SelfNode.Hostinfo anyway. The redundant copy was just
costing us an allocation per netmap (a Hostinfo.Clone).

Updates #1909
