### PR TITLE
ipn, ipn/ipnlocal: clean up documentation and use clock instead of time

### DIFF
--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -320,7 +320,6 @@ func (b *LocalBackend) StreamServe(ctx context.Context, w io.Writer, req ipn.Ser
 	// Clean up streamer when done.
 	defer func() {
 		b.mu.Lock()
-		mak.NonNilMapForJSON(&b.serveStreamers)
 		delete(b.serveStreamers[port], id)
 		b.mu.Unlock()
 	}()
@@ -400,7 +399,7 @@ func (b *LocalBackend) maybeLogServeConnection(destPort uint16, srcAddr netip.Ad
 
 	var log ipn.FunnelRequestLog
 	log.SrcAddr = srcAddr
-	log.Time = time.Now() // TODO: use a different clock somewhere?
+	log.Time = b.clock.Now()
 
 	if node, user, ok := b.WhoIs(srcAddr); ok {
 		log.NodeName = node.ComputedName()

--- a/ipn/serve.go
+++ b/ipn/serve.go
@@ -78,15 +78,16 @@ type FunnelConn struct {
 	Src netip.AddrPort
 }
 
-// ServeStreamRequest defines the json request body
+// ServeStreamRequest defines the JSON request body
 // for the serve stream endpoint
 type ServeStreamRequest struct {
 	// HostPort is the DNS and port of the tailscale
 	// URL.
 	HostPort HostPort `json:",omitempty"`
 
-	// Source is the user's serve destination
-	// such as their localhost server.
+	// Source is the user's serve source
+	// as defined in the `tailscale serve`
+	// command such as http://127.0.0.1:3000
 	Source string `json:",omitempty"`
 
 	// MountPoint is the path prefix for


### PR DESCRIPTION
This PR addresses a number of the follow ups from PR #8491 that were written after getting merged.

Updates #8489