### PR TITLE
all: replace deprecated ioutil references

### DIFF
--- a/cmd/ssh-auth-none-demo/ssh-auth-none-demo.go
+++ b/cmd/ssh-auth-none-demo/ssh-auth-none-demo.go
@@ -19,7 +19,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -149,7 +148,7 @@ func getHostKeys(dir string) (ret []ssh.Signer, err error) {
 
 func hostKeyFileOrCreate(keyDir, typ string) ([]byte, error) {
 	path := filepath.Join(keyDir, "ssh_host_"+typ+"_key")
-	v, err := ioutil.ReadFile(path)
+	v, err := os.ReadFile(path)
 	if err == nil {
 		return v, nil
 	}

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -1708,7 +1707,7 @@ func (h *Handler) serveTKADisable(w http.ResponseWriter, r *http.Request) {
 	}
 
 	body := io.LimitReader(r.Body, 1024*1024)
-	secret, err := ioutil.ReadAll(body)
+	secret, err := io.ReadAll(body)
 	if err != nil {
 		http.Error(w, "reading secret", 400)
 		return
@@ -1781,7 +1780,7 @@ func (h *Handler) serveTKAAffectedSigs(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "use POST", http.StatusMethodNotAllowed)
 		return
 	}
-	keyID, err := ioutil.ReadAll(http.MaxBytesReader(w, r.Body, 2048))
+	keyID, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 2048))
 	if err != nil {
 		http.Error(w, "reading body", http.StatusBadRequest)
 		return
@@ -1850,7 +1849,7 @@ func (h *Handler) serveTKACosignRecoveryAUM(w http.ResponseWriter, r *http.Reque
 	}
 
 	body := io.LimitReader(r.Body, 1024*1024)
-	aumBytes, err := ioutil.ReadAll(body)
+	aumBytes, err := io.ReadAll(body)
 	if err != nil {
 		http.Error(w, "reading AUM", http.StatusBadRequest)
 		return
@@ -1881,7 +1880,7 @@ func (h *Handler) serveTKASubmitRecoveryAUM(w http.ResponseWriter, r *http.Reque
 	}
 
 	body := io.LimitReader(r.Body, 1024*1024)
-	aumBytes, err := ioutil.ReadAll(body)
+	aumBytes, err := io.ReadAll(body)
 	if err != nil {
 		http.Error(w, "reading AUM", http.StatusBadRequest)
 		return

--- a/ssh/tailssh/tailssh_test.go
+++ b/ssh/tailssh/tailssh_test.go
@@ -15,7 +15,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -562,7 +561,7 @@ func TestSSHRecordingNonInteractive(t *testing.T) {
 	recordingServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer cancel()
 		var err error
-		recording, err = ioutil.ReadAll(r.Body)
+		recording, err = io.ReadAll(r.Body)
 		if err != nil {
 			t.Error(err)
 			return

--- a/tsnet/tsnet_test.go
+++ b/tsnet/tsnet_test.go
@@ -16,7 +16,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"net/http"
@@ -523,7 +522,7 @@ func TestFunnel(t *testing.T) {
 		t.Errorf("unexpected status code: %v", resp.StatusCode)
 		return
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tstest/iosdeps/iosdeps.go
+++ b/tstest/iosdeps/iosdeps.go
@@ -17,7 +17,6 @@ import (
 	_ "fmt"
 	_ "io"
 	_ "io/fs"
-	_ "io/ioutil"
 	_ "log"
 	_ "math"
 	_ "net"


### PR DESCRIPTION
This PR removes calls to ioutil library and replaces them with their new locations in the io and os packages.

Fixes #9034