### PR TITLE
client/web: open auth URLs in new browser tab

### DIFF
--- a/client/web/src/hooks/node-data.ts
+++ b/client/web/src/hooks/node-data.ts
@@ -104,11 +104,7 @@ export default function useNodeData() {
           }
           const url = r["url"]
           if (url) {
-            if (data.IsUnraid) {
-              window.open(url, "_blank")
-            } else {
-              document.location.href = url
-            }
+            window.open(url, "_blank")
           }
           fetchNodeData()
         })


### PR DESCRIPTION
Open control server auth URLs in new browser tabs on web clients so users don't loose original client URL when redirected for login.

Updates tailscale/corp#13775