### PR TITLE
ipn, ipn/ipnlocal: add an in memory serve config

### DIFF
--- a/client/tailscale/localclient.go
+++ b/client/tailscale/localclient.go
@@ -1091,6 +1091,17 @@ func (lc *LocalClient) GetServeConfig(ctx context.Context) (*ipn.ServeConfig, er
 	return getServeConfigFromJSON(body)
 }
 
+// GetMemoryServeConfig return the current serve config.
+//
+// If the serve config is empty, it returns (nil, nil).
+func (lc *LocalClient) GetMemoryServeConfig(ctx context.Context) (*ipn.ServeConfig, error) {
+	body, err := lc.send(ctx, "GET", "/localapi/v0/serve-config?memory=true", 200, nil)
+	if err != nil {
+		return nil, fmt.Errorf("getting serve config: %w", err)
+	}
+	return getServeConfigFromJSON(body)
+}
+
 func getServeConfigFromJSON(body []byte) (sc *ipn.ServeConfig, err error) {
 	if err := json.Unmarshal(body, &sc); err != nil {
 		return nil, err

--- a/cmd/tailscale/cli/funnel.go
+++ b/cmd/tailscale/cli/funnel.go
@@ -44,7 +44,7 @@ func newFunnelCommand(e *serveEnv) *ffcli.Command {
 		ShortHelp: "Turn on/off Funnel service",
 		ShortUsage: strings.Join([]string{
 			"funnel <serve-port> {on|off}",
-			"funnel status [--json]",
+			"funnel status [--json] [--memory]",
 		}, "\n  "),
 		LongHelp: strings.Join([]string{
 			"Funnel allows you to publish a 'tailscale serve'",
@@ -62,6 +62,7 @@ func newFunnelCommand(e *serveEnv) *ffcli.Command {
 				ShortHelp: "show current serve/funnel status",
 				FlagSet: e.newFlags("funnel-status", func(fs *flag.FlagSet) {
 					fs.BoolVar(&e.json, "json", false, "output JSON")
+					fs.BoolVar(&e.memory, "memory", false, "in memory config")
 				}),
 				UsageFunc: usageFunc,
 			},

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -80,6 +80,7 @@ func (src *ServeConfig) Clone() *ServeConfig {
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _ServeConfigCloneNeedsRegeneration = ServeConfig(struct {
+	InMemory    bool
 	TCP         map[uint16]*TCPPortHandler
 	Web         map[HostPort]*WebServerConfig
 	AllowFunnel map[HostPort]bool

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -159,6 +159,8 @@ func (v *ServeConfigView) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+func (v ServeConfigView) InMemory() bool { return v.ж.InMemory }
+
 func (v ServeConfigView) TCP() views.MapFn[uint16, *TCPPortHandler, TCPPortHandlerView] {
 	return views.MapFnOf(v.ж.TCP, func(t *TCPPortHandler) TCPPortHandlerView {
 		return t.View()
@@ -177,6 +179,7 @@ func (v ServeConfigView) AllowFunnel() views.Map[HostPort, bool] {
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _ServeConfigViewNeedsRegeneration = ServeConfig(struct {
+	InMemory    bool
 	TCP         map[uint16]*TCPPortHandler
 	Web         map[HostPort]*WebServerConfig
 	AllowFunnel map[HostPort]bool

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -835,7 +835,7 @@ func (h *Handler) serveServeConfig(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		config := h.b.ServeConfig()
+		config := h.b.ServeConfig(r.FormValue("memory") == "true")
 		json.NewEncoder(w).Encode(config)
 	case "POST":
 		if !h.PermitWrite {

--- a/ipn/serve.go
+++ b/ipn/serve.go
@@ -26,6 +26,11 @@ func ServeConfigKey(profileID ProfileID) StateKey {
 // ServeConfig is the JSON type stored in the StateStore for
 // StateKey "_serve/$PROFILE_ID" as returned by ServeConfigKey.
 type ServeConfig struct {
+	// InMemory indicates whether this config
+	// is persisted in the local store or is
+	// an in memory config
+	InMemory bool
+
 	// TCP are the list of TCP port numbers that tailscaled should handle for
 	// the Tailscale IP addresses. (not subnet routers, etc)
 	TCP map[uint16]*TCPPortHandler `json:",omitempty"`


### PR DESCRIPTION
Note: this PR probably breaks a lot of code paths, but it's a super early draft to see what it looks like to have an in memory serve config.

This PR adds a parallel in-memory ServeConfig so that foreground funnels are guaranteed to go away in case of unexpected shutdown

Updates #8489