### PR TITLE
cmd/tailscale/cli: make netcheck run even if machine lacks TLS certs

### DIFF
--- a/cmd/tailscale/cli/netcheck.go
+++ b/cmd/tailscale/cli/netcheck.go
@@ -21,6 +21,7 @@ import (
 	"tailscale.com/net/netcheck"
 	"tailscale.com/net/netmon"
 	"tailscale.com/net/portmapper"
+	"tailscale.com/net/tlsdial"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/logger"
 )
@@ -76,7 +77,8 @@ func runNetcheck(ctx context.Context, args []string) error {
 		log.Printf("No DERP map from tailscaled; using default.")
 	}
 	if err != nil || noRegions {
-		dm, err = prodDERPMap(ctx, http.DefaultClient)
+		hc := &http.Client{Transport: tlsdial.NewTransport()}
+		dm, err = prodDERPMap(ctx, hc)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
We have a fancy package for doing TLS cert validation even if the machine doesn't have TLS certs (for LetsEncrypt only) but the CLI's netcheck command wasn't using it.

Also, update the tlsdial's outdated package docs while here.

Updates #cleanup
