### PR TITLE
types/logger, cmd/tailscale/cli: flesh out, simplify some non-unix build tags

### DIFF
--- a/cmd/tailscale/cli/ssh_unix.go
+++ b/cmd/tailscale/cli/ssh_unix.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build !js && !windows
+//go:build !wasm && !windows && !plan9
 
 package cli
 

--- a/types/logger/rusage_stub.go
+++ b/types/logger/rusage_stub.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build windows || js || wasip1
+//go:build windows || wasm || plan9
 
 package logger
 

--- a/types/logger/rusage_syscall.go
+++ b/types/logger/rusage_syscall.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build !windows && !js && !wasip1
+//go:build !windows && !wasm && !plan9
 
 package logger
 


### PR DESCRIPTION
Can write "wasm" instead of js || wasi1p, since there's only two:

    $ go tool dist list | grep wasm
    js/wasm
    wasip1/wasm

Plus, if GOOS=wasip2 is added later, we're already set.

Updates #5794