### PR TITLE
.github: fix flakehub-publish-tagged.yml glob

### DIFF
--- a/.github/workflows/flakehub-publish-tagged.yml
+++ b/.github/workflows/flakehub-publish-tagged.yml
@@ -1,8 +1,10 @@
+name: update-flakehub
+
 on:
-  workflow_dispatch:
   push:
     tags:
-      - '^v[0-9]+\.[0-9]*[02468]+\.[0-9]+$'
+      - "v[0-9]+.*[02468].[0-9]+"
+
 jobs:
   publish:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
The previous regex was too advanced for GitHub Actions. They only support a simpler glob syntax.

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

Updates #9008