### PR TITLE
.github: update flakehub workflow to support existing tags

### DIFF
--- a/.github/workflows/flakehub-publish-tagged.yml
+++ b/.github/workflows/flakehub-publish-tagged.yml
@@ -4,16 +4,24 @@ on:
   push:
     tags:
       - "v[0-9]+.*[02468].[0-9]+"
-
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "The existing tag to publish to FlakeHub"
+        type: "string"
+        required: true
 jobs:
-  publish:
+  flakehub-publish:
     runs-on: "ubuntu-latest"
     permissions:
       id-token: "write"
       contents: "read"
     steps:
       - uses: "actions/checkout@v3"
+        with:
+          ref: "${{ (inputs.tag != null) && format('refs/tags/{0}', inputs.tag) || '' }}"
       - uses: "DeterminateSystems/nix-installer-action@main"
       - uses: "DeterminateSystems/flakehub-push@main"
         with:
           visibility: "public"
+          tag: "${{ inputs.tag }}"


### PR DESCRIPTION
This adds a workflow_dispatch input to the update-flakehub workflow that allows the user to specify an existing tag to publish to FlakeHub. This is useful for publishing a version of a package that has already been tagged in the repository.

Updates #9008