### PR TITLE
cmd/dist,release/dist: add distsign signing hooks

### DIFF
--- a/cmd/dist/dist.go
+++ b/cmd/dist/dist.go
@@ -19,10 +19,10 @@ import (
 
 var synologyPackageCenter bool
 
-func getTargets(signers unixpkgs.Signers) ([]dist.Target, error) {
+func getTargets() ([]dist.Target, error) {
 	var ret []dist.Target
 
-	ret = append(ret, unixpkgs.Targets(signers)...)
+	ret = append(ret, unixpkgs.Targets(unixpkgs.Signers{})...)
 	// Synology packages can be built either for sideloading, or for
 	// distribution by Synology in their package center. When
 	// distributed through the package center, apps can request
@@ -33,7 +33,7 @@ func getTargets(signers unixpkgs.Signers) ([]dist.Target, error) {
 	// Since only we can provide packages to Synology for
 	// distribution, we default to building the "sideload" variant of
 	// packages that we distribute on pkgs.tailscale.com.
-	ret = append(ret, synology.Targets(synologyPackageCenter)...)
+	ret = append(ret, synology.Targets(synologyPackageCenter, nil)...)
 	return ret, nil
 }
 

--- a/release/dist/cli/cli.go
+++ b/release/dist/cli/cli.go
@@ -20,7 +20,6 @@ import (
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"tailscale.com/clientupdate/distsign"
 	"tailscale.com/release/dist"
-	"tailscale.com/release/dist/unixpkgs"
 )
 
 // CLI returns a CLI root command to build release packages.
@@ -28,7 +27,7 @@ import (
 // getTargets is a function that gets run in the Exec function of commands that
 // need to know the target list. Its execution is deferred in this way to allow
 // customization of command FlagSets with flags that influence the target list.
-func CLI(getTargets func(unixpkgs.Signers) ([]dist.Target, error)) *ffcli.Command {
+func CLI(getTargets func() ([]dist.Target, error)) *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "dist",
 		ShortUsage: "dist [flags] <command> [command flags]",
@@ -38,7 +37,7 @@ func CLI(getTargets func(unixpkgs.Signers) ([]dist.Target, error)) *ffcli.Comman
 			{
 				Name: "list",
 				Exec: func(ctx context.Context, args []string) error {
-					targets, err := getTargets(unixpkgs.Signers{})
+					targets, err := getTargets()
 					if err != nil {
 						return err
 					}
@@ -54,11 +53,7 @@ func CLI(getTargets func(unixpkgs.Signers) ([]dist.Target, error)) *ffcli.Comman
 			{
 				Name: "build",
 				Exec: func(ctx context.Context, args []string) error {
-					tgzSigner, err := parseSigningKey(buildArgs.tgzSigningKey)
-					if err != nil {
-						return err
-					}
-					targets, err := getTargets(unixpkgs.Signers{Tarball: tgzSigner})
+					targets, err := getTargets()
 					if err != nil {
 						return err
 					}
@@ -70,7 +65,6 @@ func CLI(getTargets func(unixpkgs.Signers) ([]dist.Target, error)) *ffcli.Comman
 					fs := flag.NewFlagSet("build", flag.ExitOnError)
 					fs.StringVar(&buildArgs.manifest, "manifest", "", "manifest file to write")
 					fs.BoolVar(&buildArgs.verbose, "verbose", false, "verbose logging")
-					fs.StringVar(&buildArgs.tgzSigningKey, "tgz-signing-key", "", "path to private signing key for release tarballs")
 					fs.StringVar(&buildArgs.webClientRoot, "web-client-root", "", "path to root of web client source to build")
 					return fs
 				})(),
@@ -117,7 +111,6 @@ func runList(ctx context.Context, filters []string, targets []dist.Target) error
 var buildArgs struct {
 	manifest      string
 	verbose       bool
-	tgzSigningKey string
 	webClientRoot string
 }
 

--- a/release/dist/synology/targets.go
+++ b/release/dist/synology/targets.go
@@ -26,7 +26,7 @@ var v7Models = []string{
 	"monaco",
 }
 
-func Targets(forPackageCenter bool) []dist.Target {
+func Targets(forPackageCenter bool, signer dist.Signer) []dist.Target {
 	var ret []dist.Target
 	for _, dsmVersion := range []int{6, 7} {
 		ret = append(ret,
@@ -38,6 +38,7 @@ func Targets(forPackageCenter bool) []dist.Target {
 					"GOARCH": "amd64",
 				},
 				packageCenter: forPackageCenter,
+				signer:        signer,
 			},
 			&target{
 				filenameArch:    "i686",
@@ -47,6 +48,7 @@ func Targets(forPackageCenter bool) []dist.Target {
 					"GOARCH": "386",
 				},
 				packageCenter: forPackageCenter,
+				signer:        signer,
 			},
 			&target{
 				filenameArch:    "armv8",
@@ -56,6 +58,7 @@ func Targets(forPackageCenter bool) []dist.Target {
 					"GOARCH": "arm64",
 				},
 				packageCenter: forPackageCenter,
+				signer:        signer,
 			})
 
 		// On older ARMv5 and ARMv7 platforms, synology used a whole
@@ -71,6 +74,7 @@ func Targets(forPackageCenter bool) []dist.Target {
 					"GOARM":  "5",
 				},
 				packageCenter: forPackageCenter,
+				signer:        signer,
 			})
 		}
 		for _, v7Arch := range v7Models {
@@ -83,6 +87,7 @@ func Targets(forPackageCenter bool) []dist.Target {
 					"GOARM":  "7",
 				},
 				packageCenter: forPackageCenter,
+				signer:        signer,
 			})
 		}
 	}

--- a/release/dist/unixpkgs/targets.go
+++ b/release/dist/unixpkgs/targets.go
@@ -4,9 +4,7 @@
 package unixpkgs
 
 import (
-	"crypto"
 	"fmt"
-	"io"
 	"sort"
 	"strings"
 
@@ -17,8 +15,8 @@ import (
 )
 
 type Signers struct {
-	Tarball crypto.Signer
-	RPM     func(io.Reader) ([]byte, error)
+	Tarball dist.Signer
+	RPM     dist.Signer
 }
 
 func Targets(signers Signers) []dist.Target {
@@ -49,7 +47,7 @@ func Targets(signers Signers) []dist.Target {
 				"GOOS":   goos,
 				"GOARCH": goarch,
 			},
-			signFn: signers.RPM,
+			signer: signers.RPM,
 		})
 	}
 


### PR DESCRIPTION
Add `dist.Signer` hook which can arbitrarily sign linux/synology artifacts. Plumb it through in `cmd/dist` and remove existing tarball signing key. Distsign signing will happen on a remote machine, not using a local key.

Updates #755
Updates #8760