### PR TITLE
ipn, ipn/ipnlocal: use Foreground field in ServeConfig

### DIFF
--- a/client/tailscale/localclient.go
+++ b/client/tailscale/localclient.go
@@ -1094,29 +1094,6 @@ func (lc *LocalClient) NetworkLockDisable(ctx context.Context, secret []byte) er
 	return nil
 }
 
-// StreamServe returns an io.ReadCloser that streams serve/Funnel
-// connections made to the provided HostPort.
-//
-// If Serve and Funnel were not already enabled for the HostPort in the ServeConfig,
-// the backend enables it for the duration of the context's lifespan and
-// then turns it back off once the context is closed. If either are already enabled,
-// then they remain that way but logs are still streamed
-func (lc *LocalClient) StreamServe(ctx context.Context, hp ipn.ServeStreamRequest) (io.ReadCloser, error) {
-	req, err := http.NewRequestWithContext(ctx, "POST", "http://"+apitype.LocalAPIHost+"/localapi/v0/stream-serve", jsonBody(hp))
-	if err != nil {
-		return nil, err
-	}
-	res, err := lc.doLocalRequestNiceError(req)
-	if err != nil {
-		return nil, err
-	}
-	if res.StatusCode != 200 {
-		res.Body.Close()
-		return nil, errors.New(res.Status)
-	}
-	return res.Body, nil
-}
-
 // GetServeConfig return the current serve config.
 //
 // If the serve config is empty, it returns (nil, nil).

--- a/cmd/tailscale/cli/serve.go
+++ b/cmd/tailscale/cli/serve.go
@@ -149,7 +149,6 @@ type localServeClient interface {
 	QueryFeature(ctx context.Context, feature string) (*tailcfg.QueryFeatureResponse, error)
 	WatchIPNBus(ctx context.Context, mask ipn.NotifyWatchOpt) (*tailscale.IPNBusWatcher, error)
 	IncrementCounter(ctx context.Context, name string, delta int) error
-	StreamServe(ctx context.Context, req ipn.ServeStreamRequest) (io.ReadCloser, error) // TODO: testing :)
 }
 
 // serveEnv is the environment the serve command runs within. All I/O should be

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -26,6 +26,7 @@ import (
 	"tailscale.com/types/logger"
 	"tailscale.com/types/logid"
 	"tailscale.com/types/netmap"
+	"tailscale.com/util/set"
 	"tailscale.com/wgengine"
 	"tailscale.com/wgengine/filter"
 	"tailscale.com/wgengine/wgcfg"
@@ -843,6 +844,9 @@ var _ legacyBackend = (*LocalBackend)(nil)
 
 func TestWatchNotificationsCallbacks(t *testing.T) {
 	b := new(LocalBackend)
+	// activeWatchSessions is typically set in NewLocalBackend
+	// so WatchNotifications expects it to be non-empty.
+	b.activeWatchSessions = make(set.Set[string])
 	n := new(ipn.Notify)
 	b.WatchNotifications(context.Background(), 0, func() {
 		b.mu.Lock()

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -97,7 +97,6 @@ var handler = map[string]localAPIHandler{
 	"set-expiry-sooner":           (*Handler).serveSetExpirySooner,
 	"start":                       (*Handler).serveStart,
 	"status":                      (*Handler).serveStatus,
-	"stream-serve":                (*Handler).serveStreamServe,
 	"tka/init":                    (*Handler).serveTKAInit,
 	"tka/log":                     (*Handler).serveTKALog,
 	"tka/modify":                  (*Handler).serveTKAModify,
@@ -852,35 +851,6 @@ func (h *Handler) serveServeConfig(w http.ResponseWriter, r *http.Request) {
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
-}
-
-// serveStreamServe handles foreground serve and funnel streams. This is
-// currently in development per https://github.com/tailscale/tailscale/issues/8489
-func (h *Handler) serveStreamServe(w http.ResponseWriter, r *http.Request) {
-	if !envknob.UseWIPCode() {
-		http.Error(w, "stream serve not yet available", http.StatusNotImplemented)
-		return
-	}
-	if !h.PermitWrite {
-		// Write permission required because we modify the ServeConfig.
-		http.Error(w, "serve stream denied", http.StatusForbidden)
-		return
-	}
-	if r.Method != "POST" {
-		http.Error(w, "POST required", http.StatusMethodNotAllowed)
-		return
-	}
-	var req ipn.ServeStreamRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeErrorJSON(w, fmt.Errorf("decoding HostPort: %w", err))
-		return
-	}
-	w.Header().Set("Content-Type", "application/json")
-	if err := h.b.StreamServe(r.Context(), w, req); err != nil {
-		writeErrorJSON(w, fmt.Errorf("streaming serve: %w", err))
-		return
-	}
-	w.WriteHeader(http.StatusOK)
 }
 
 func (h *Handler) serveCheckIPForwarding(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
ipn, ipn/ipnlocal: add Foreground field for ServeConfig
    
This PR adds a new field to the serve config that can be used to identify which serves are in "foreground mode" and then can also be used to ensure they do not get persisted to disk so that if Tailscaled gets ungracefully shutdown, the reloaded ServeConfig will not have those ports opened.
    
Updates #8489