### PR TITLE
cmd/containerboot: add support for setting ServeConfig

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -171,7 +171,7 @@ require (
 	github.com/fatih/color v1.15.0 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/firefart/nonamedreturns v1.0.4 // indirect
-	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	github.com/fsnotify/fsnotify v1.6.0
 	github.com/fzipp/gocyclo v0.6.0 // indirect
 	github.com/go-critic/go-critic v0.8.0 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect


### PR DESCRIPTION
This watches the provided path for a JSON encoded ipn.ServeConfig. Everytime the file changes, or the nodes FQDN changes it reapplies the ServeConfig.

At boot time, it nils out any previous ServeConfig just like tsnet does.

As the ServeConfig requires pre-existing knowledge of the nodes FQDN to do SNI matching, it introduces a special `${TS_CERT_DOMAIN}` value in the JSON file which is replaced with the known CertDomain before it is applied.

Updates #502
Updates #7895