### PR TITLE
cmd/k8s-operator: handle changes to services w/o teardown

### DIFF
--- a/cmd/k8s-operator/operator_test.go
+++ b/cmd/k8s-operator/operator_test.go
@@ -720,6 +720,10 @@ func expectedSTS(stsName, secretName, hostname, priorityClassName string) *appsv
 			ServiceName: stsName,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"tailscale.com/operator-last-set-hostname": hostname,
+						"tailscale.com/operator-last-set-ip":       "10.20.30.40",
+					},
 					DeletionGracePeriodSeconds: ptr.To[int64](10),
 					Labels:                     map[string]string{"app": "1234-UID"},
 				},

--- a/cmd/k8s-operator/sts.go
+++ b/cmd/k8s-operator/sts.go
@@ -32,9 +32,15 @@ const (
 
 	FinalizerName = "tailscale.com/finalizer"
 
+	// Annotations settable by users on services.
 	AnnotationExpose   = "tailscale.com/expose"
 	AnnotationTags     = "tailscale.com/tags"
 	AnnotationHostname = "tailscale.com/hostname"
+
+	// Annotations set by the operator on pods to trigger restarts when the
+	// hostname or IP changes.
+	podAnnotationLastSetIP       = "tailscale.com/operator-last-set-ip"
+	podAnnotationLastSetHostname = "tailscale.com/operator-last-set-hostname"
 )
 
 type tailscaleSTSConfig struct {
@@ -276,7 +282,18 @@ func (a *tailscaleSTSReconciler) reconcileSTS(ctx context.Context, logger *zap.S
 			"app": sts.ParentResourceUID,
 		},
 	}
-	ss.Spec.Template.ObjectMeta.Labels = map[string]string{
+
+	// containerboot currently doesn't have a way to re-read the hostname/ip as
+	// it is passed via an environment variable. So we need to restart the
+	// container when the value changes. We do this by adding an annotation to
+	// the pod template that contains the last value we set.
+	ss.Spec.Template.Annotations = map[string]string{
+		"tailscale.com/operator-last-set-hostname": sts.Hostname,
+	}
+	if sts.TargetIP != "" {
+		ss.Spec.Template.Annotations["tailscale.com/operator-last-set-ip"] = sts.TargetIP
+	}
+	ss.Spec.Template.Labels = map[string]string{
 		"app": sts.ParentResourceUID,
 	}
 	ss.Spec.Template.Spec.PriorityClassName = a.proxyPriorityClassName


### PR DESCRIPTION
Previously users would have to unexpose/expose the service in order to change Hostname/TargetIP. This now applies those changes by causing a StatefulSet rollout now that a61a9ab087e16270bc039252e7620aae4de3d56e is in.

Updates #502