### PR TITLE
client/web: add self node cache

### DIFF
--- a/cmd/tailscale/cli/web.go
+++ b/cmd/tailscale/cli/web.go
@@ -78,7 +78,7 @@ func runWeb(ctx context.Context, args []string) error {
 		return fmt.Errorf("too many non-flag arguments: %q", args)
 	}
 
-	webServer, cleanup := web.NewServer(web.ServerOpts{
+	webServer, cleanup := web.NewServer(ctx, web.ServerOpts{
 		DevMode:     webArgs.dev,
 		CGIMode:     webArgs.cgi,
 		LocalClient: &localClient,

--- a/tsnet/example/web-client/web-client.go
+++ b/tsnet/example/web-client/web-client.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"log"
 	"net/http"
@@ -20,6 +21,7 @@ var (
 
 func main() {
 	flag.Parse()
+	ctx := context.Background()
 
 	s := new(tsnet.Server)
 	defer s.Close()
@@ -30,7 +32,7 @@ func main() {
 	}
 
 	// Serve the Tailscale web client.
-	ws, cleanup := web.NewServer(web.ServerOpts{
+	ws, cleanup := web.NewServer(ctx, web.ServerOpts{
 		DevMode:     *devMode,
 		LocalClient: lc,
 	})


### PR DESCRIPTION
Adds a cached self node to the web client Server struct, which will be used from the web client api to verify that request came from the node's own machine (i.e. came from the web client frontend). We'll be using when we switch the web client api over to acting as a proxy to the localapi, to protect against DNS rebinding attacks.

Updates tailscale/corp#13775