### PR TITLE
cmd/testwrapper: fix off-by-one error in maxAttempts check

### DIFF
--- a/cmd/testwrapper/testwrapper.go
+++ b/cmd/testwrapper/testwrapper.go
@@ -232,7 +232,7 @@ func main() {
 		var thisRun *nextRun
 		thisRun, toRun = toRun[0], toRun[1:]
 
-		if thisRun.attempt >= maxAttempts {
+		if thisRun.attempt > maxAttempts {
 			fmt.Println("max attempts reached")
 			os.Exit(1)
 		}


### PR DESCRIPTION
It was checking if `>= maxAttempts` which meant that the third attempt would never run.

Updates #8493