### PR TITLE
util/osdiag: add query for Windows page file configuration and status

### DIFF
--- a/util/osdiag/mksyscall.go
+++ b/util/osdiag/mksyscall.go
@@ -6,6 +6,7 @@ package osdiag
 //go:generate go run golang.org/x/sys/windows/mkwinsyscall -output zsyscall_windows.go mksyscall.go
 //go:generate go run golang.org/x/tools/cmd/goimports -w zsyscall_windows.go
 
+//sys globalMemoryStatusEx(memStatus *_MEMORYSTATUSEX) (err error) [int32(failretval)==0] = kernel32.GlobalMemoryStatusEx
 //sys regEnumValue(key registry.Key, index uint32, valueName *uint16, valueNameLen *uint32, reserved *uint32, valueType *uint32, pData *byte, cbData *uint32) (ret error) [failretval!=0] = advapi32.RegEnumValueW
 //sys wscEnumProtocols(iProtocols *int32, protocolBuffer *wsaProtocolInfo, bufLen *uint32, errno *int32) (ret int32) = ws2_32.WSCEnumProtocols
 //sys wscGetProviderInfo(providerId *windows.GUID, infoType _WSC_PROVIDER_INFO_TYPE, info unsafe.Pointer, infoSize *uintptr, flags uint32, errno *int32) (ret int32) = ws2_32.WSCGetProviderInfo


### PR DESCRIPTION
It's very common for OOM crashes on Windows to be caused by lack of page file space (the NT kernel does not overcommit). Since Windows automatically manages page file space by default, unless the machine is out of disk space, this is typically caused by manual page file configurations that are too small.

This patch obtains the current page file size, the amount of free page file space, and also determines whether the page file is automatically or manually managed.

Fixes #9090