### PR TITLE
release/dist: remove extra Close on a signed file

### DIFF
--- a/release/dist/dist.go
+++ b/release/dist/dist.go
@@ -45,9 +45,6 @@ func (s Signer) SignFile(filePath, sigPath string) error {
 	if err != nil {
 		return err
 	}
-	if err := f.Close(); err != nil {
-		return err
-	}
 	return os.WriteFile(sigPath, sig, 0644)
 }
 


### PR DESCRIPTION
We pass the file as an io.Reader to http.Post under the hood as request body. Post, helpfully, detects that the body is an io.Closer and closes it. So when we try to explicitly close it again, we get "file already closed" error.

The Close there is not load-bearing, we have a defer for it anyway. Remove the explicit close and error check.

Updates #cleanup