### PR TITLE
flake.nix: use Go 1.21 to build tailscale, for real this time

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -70,7 +70,7 @@
     # So really, this flake is for tailscale devs to dogfood with, if
     # you're an end user you should be prepared for this flake to not
     # build periodically.
-    tailscale = pkgs: pkgs.buildGo120Module rec {
+    tailscale = pkgs: pkgs.buildGo121Module rec {
       name = "tailscale";
 
       src = ./.;


### PR DESCRIPTION
The previous change just switched the Go version used in the dev environment (for use with e.g. direnv), not the version used for the distribution build. Oops.

Updates #cleanup