### PR TITLE
cmd/k8s-operator: update RBAC to allow creating events

### DIFF
--- a/cmd/k8s-operator/manifests/operator.yaml
+++ b/cmd/k8s-operator/manifests/operator.yaml
@@ -48,7 +48,7 @@ metadata:
   name: tailscale-operator
 rules:
 - apiGroups: [""]
-  resources: ["services", "services/status"]
+  resources: ["events", "services", "services/status"]
   verbs: ["*"]
 - apiGroups: ["networking.k8s.io"]
   resources: ["ingresses", "ingresses/status"]


### PR DESCRIPTION
The new ingress reconcile raises events on failure, but I forgot to add the updated permission.

Updates #502