### PR TITLE
cmd/tailscaled: default to userspace-networking on plan9

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -76,6 +76,8 @@ func defaultTunName() string {
 		// "utun" is recognized by wireguard-go/tun/tun_darwin.go
 		// as a magic value that uses/creates any free number.
 		return "utun"
+	case "plan9":
+		return "userspace-networking"
 	case "linux":
 		switch distro.Get() {
 		case distro.Synology:


### PR DESCRIPTION
No tun support yet.

Updates #5794
