### PR TITLE
client/web: pipe unraid csrf token through apiFetch

### DIFF
--- a/client/web/src/components/legacy.tsx
+++ b/client/web/src/components/legacy.tsx
@@ -93,7 +93,7 @@ export function Header({
                   |{" "}
                   <button
                     onClick={() =>
-                      apiFetch("/local/v0/logout", { method: "POST" })
+                      apiFetch("/local/v0/logout", "POST")
                         .then(refreshData)
                         .catch((err) => alert("Logout failed: " + err.message))
                     }


### PR DESCRIPTION
Ensures that we're sending back the csrf token for all requests made back to unraid clients.

Updates tailscale/corp#13775