### PR TITLE
cmd/testwrapper: handle timeouts as test failures

### DIFF
--- a/cmd/testwrapper/testwrapper.go
+++ b/cmd/testwrapper/testwrapper.go
@@ -247,6 +247,12 @@ func main() {
 			go runTests(ctx, thisRun.attempt, pt, otherArgs, ch)
 			for tr := range ch {
 				if tr.pkgFinished {
+					if tr.outcome == "fail" && len(toRetry[tr.name.pkg]) == 0 {
+						// If a package fails and we don't have any tests to
+						// retry, then we should fail. This typically happens
+						// when a package times out.
+						failed = true
+					}
 					printPkgOutcome(tr.name.pkg, tr.outcome, thisRun.attempt)
 					continue
 				}


### PR DESCRIPTION
While investigating the fix in 7538f386710b80c6b4c1997797be28a661210d4a, I was curious why the testwrapper didn't fail. Turns out if the test times out and there was no explicit failure, the only message we get is that the overall pkg failed and no failure information about the individual test. This resulted in a 0 exit code.

This fixes that by failing the explicit case of the pkg failing when there is nothing to retry for that pkg.

Updates #8493