### PR TITLE
cm/k8s-operator,cmd/containerboot: fix STS config, adds another test case

### DIFF
--- a/cmd/k8s-operator/svc.go
+++ b/cmd/k8s-operator/svc.go
@@ -125,11 +125,15 @@ func (a *ServiceReconciler) maybeProvision(ctx context.Context, logger *zap.Suga
 	sts := &tailscaleSTSConfig{
 		ParentResourceName:  svc.Name,
 		ParentResourceUID:   string(svc.UID),
-		ClusterTargetIP:     svc.Spec.ClusterIP,
 		Hostname:            hostname,
 		Tags:                tags,
 		ChildResourceLabels: crl,
-		TailnetTargetIP:     svc.Annotations[AnnotationTailnetTargetIP],
+	}
+
+	if a.shouldExpose(svc) {
+		sts.ClusterTargetIP = svc.Spec.ClusterIP
+	} else if a.hasTailnetTargetAnnotation(svc) {
+		sts.TailnetTargetIP = svc.Annotations[AnnotationTailnetTargetIP]
 	}
 
 	var hsvc *corev1.Service


### PR DESCRIPTION
This small PR:
- ensures that Statefulset reconciler config has only one of Cluster target IP or tailnet target IP
- adds a test case for containerboot egress proxy mode.

Updates tailscale/tailscale#8184