### PR TITLE
adjust build tags for tamago

### DIFF
--- a/logtail/filch/filch_unix.go
+++ b/logtail/filch/filch_unix.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build !windows && !wasm && !plan9
+//go:build !windows && !wasm && !plan9 && !tamago
 
 package filch
 

--- a/net/interfaces/interfaces.go
+++ b/net/interfaces/interfaces.go
@@ -396,7 +396,7 @@ func (s *State) HasPAC() bool { return s != nil && s.PAC != "" }
 
 // AnyInterfaceUp reports whether any interface seems like it has Internet access.
 func (s *State) AnyInterfaceUp() bool {
-	if runtime.GOOS == "js" {
+	if runtime.GOOS == "js" || runtime.GOOS == "tamago" {
 		return true
 	}
 	return s != nil && (s.HaveV4 || s.HaveV6)

--- a/net/tstun/tun.go
+++ b/net/tstun/tun.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build !wasm && !plan9
+//go:build !wasm && !plan9 && !tamago
 
 // Package tun creates a tuntap device, working around OS-specific
 // quirks if necessary.

--- a/paths/paths_unix.go
+++ b/paths/paths_unix.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build !windows && !wasm && !plan9
+//go:build !windows && !wasm && !plan9 && !tamago
 
 package paths
 

--- a/types/logger/rusage_stub.go
+++ b/types/logger/rusage_stub.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build windows || wasm || plan9
+//go:build windows || wasm || plan9 || tamago
 
 package logger
 

--- a/types/logger/rusage_syscall.go
+++ b/types/logger/rusage_syscall.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build !windows && !wasm && !plan9
+//go:build !windows && !wasm && !plan9 && !tamago
 
 package logger
 


### PR DESCRIPTION
This PR adjust build tags to allow compilation under the [TamaGo framework](https://github.com/usbarmory/tamago).