### PR TITLE
control/controlclient: merge, simplify two health check calls

### DIFF
--- a/control/controlclient/auto.go
+++ b/control/controlclient/auto.go
@@ -489,7 +489,6 @@ type mapRoutineState struct {
 
 func (mrs mapRoutineState) UpdateFullNetmap(nm *netmap.NetworkMap) {
 	c := mrs.c
-	health.SetInPollNetMap(true)
 
 	c.mu.Lock()
 	ctx := c.mapCtx
@@ -561,11 +560,11 @@ func (c *Auto) mapRoutine() {
 				c.logf("[v1] mapRoutine: new map needed while idle.")
 			}
 		} else {
-			health.SetInPollNetMap(false)
+			health.SetOutOfPollNetMap()
 
 			err := c.direct.PollNetMap(ctx, mrs)
 
-			health.SetInPollNetMap(false)
+			health.SetOutOfPollNetMap()
 			c.mu.Lock()
 			c.synced = false
 			if c.state == StateSynchronized {

--- a/health/health.go
+++ b/health/health.go
@@ -279,27 +279,31 @@ func SetControlHealth(problems []string) {
 
 // GotStreamedMapResponse notes that we got a tailcfg.MapResponse
 // message in streaming mode, even if it's just a keep-alive message.
+//
+// This also notes that a map poll is in progress. To unset that, call
+// SetOutOfPollNetMap().
 func GotStreamedMapResponse() {
 	mu.Lock()
 	defer mu.Unlock()
 	lastStreamedMapResponse = time.Now()
+	if !inMapPoll {
+		inMapPoll = true
+		inMapPollSince = time.Now()
+	}
 	selfCheckLocked()
 }
 
-// SetInPollNetMap records whether the client has an open
-// HTTP long poll open to the control plane.
-func SetInPollNetMap(v bool) {
+// SetOutOfPollNetMap records that the client is no longer in
+// an HTTP map request long poll to the control plane.
+func SetOutOfPollNetMap() {
 	mu.Lock()
 	defer mu.Unlock()
-	if v == inMapPoll {
+	if !inMapPoll {
 		return
 	}
-	inMapPoll = v
-	if v {
-		inMapPollSince = time.Now()
-	} else {
-		lastMapPollEndedAt = time.Now()
-	}
+	inMapPoll = false
+	lastMapPollEndedAt = time.Now()
+	selfCheckLocked()
 }
 
 // GetInPollNetMap reports whether the client has an open


### PR DESCRIPTION
I'm trying to remove some stuff from the netmap update path.

Updates #1909
