### PR TITLE
control/controlclient: cancel map poll when logging out

### DIFF
--- a/control/controlclient/auto.go
+++ b/control/controlclient/auto.go
@@ -702,6 +702,7 @@ func (c *Auto) Logout(ctx context.Context) error {
 	}
 	c.mu.Unlock()
 	c.cancelAuth()
+	c.cancelMap()
 
 	timer, timerChannel := c.clock.NewTimer(10 * time.Second)
 	defer timer.Stop()


### PR DESCRIPTION
Don't depend on the server to do it.

Updates #cleanup
