### PR TITLE
ipn, ipn/ipnlocal: add session identifier for WatchIPNBus

### DIFF
--- a/ipn/backend.go
+++ b/ipn/backend.go
@@ -74,8 +74,9 @@ const (
 // that they have not changed.
 // They are JSON-encoded on the wire, despite the lack of struct tags.
 type Notify struct {
-	_       structs.Incomparable
-	Version string // version number of IPN backend
+	_         structs.Incomparable
+	Version   string // version number of IPN backend
+	SessionID string // identifies the unique WatchIPNBus session.
 
 	// ErrMessage, if non-nil, contains a critical error message.
 	// For State InUseOtherUser, ErrMessage is not critical and just contains the details.


### PR DESCRIPTION
This PR adds a SessionID field to the ipn.Notify struct so that ipn buses can identify a session and register deferred clean up code in the future. The first use case this is for is to be able to tie foreground serve configs to a specific watch session and ensure its clean up when a connection is closed.

Updates #8489