### PR TITLE
clientupdate/distsign: add ability to validate a binary that is alrea…

### DIFF
--- a/clientupdate/distsign/distsign_test.go
+++ b/clientupdate/distsign/distsign_test.go
@@ -204,9 +204,6 @@ func TestValidateLocalBinary(t *testing.T) {
 			want := []byte("world")
 			srv.addSigned("hello", want)
 			dst := filepath.Join(t.TempDir(), tt.src)
-			t.Cleanup(func() {
-				os.Remove(dst)
-			})
 			err := c.Download(context.Background(), tt.src, dst)
 			if err != nil {
 				t.Fatalf("unexpected error from Download(%q): %v", tt.src, err)


### PR DESCRIPTION
…dy located on disk

Our build system caches files locally and only updates them when something changes. Since I need to integrate some distsign stuff into the build system to validate our Windows 7 MSIs, I want to be able to check the cached copy before downloading another copy from pkgs.

Updates https://github.com/tailscale/corp/issues/14334