### PR TITLE
.github/workflows: add checklocks

### DIFF
--- a/.github/workflows/checklocks.yml
+++ b/.github/workflows/checklocks.yml
@@ -1,0 +1,28 @@
+name: checklocks
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - '**/*.go'
+      - '.github/workflows/checklocks.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  checklocks:
+    runs-on: [ ubuntu-latest ]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Build checklocks
+        run: ./tool/go build -o /tmp/checklocks gvisor.dev/gvisor/tools/checklocks/cmd/checklocks
+
+      - name: Run checklocks vet
+        # TODO: remove || true once we have applied checklocks annotations everywhere.
+        run: ./tool/go vet -vettool=/tmp/checklocks ./... || true


### PR DESCRIPTION
Currently the checklocks step is not configured to fail, as we do not yet have the appropriate annotations.

Updates tailscale/corp#14381