### PR TITLE
control/controlclient: run SetControlClientStatus in goroutine

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1396,6 +1396,7 @@ func (b *LocalBackend) Start(opts ipn.Options) error {
 	wantRunning := prefs.WantRunning()
 	if wantRunning {
 		if err := b.initMachineKeyLocked(); err != nil {
+			b.mu.Unlock()
 			return fmt.Errorf("initMachineKeyLocked: %w", err)
 		}
 	}


### PR DESCRIPTION
We have cases where the SetControlClientStatus would result in a Shutdown call back into the auto client that would block forever. The right thing to do here is to fix the LocalBackend state machine but thats a different dumpster fire that we are slowly making progress towards.

This makes it so that the SetControlClientStatus happens in a different goroutine so that calls back into the auto client do not block.

Also add a few missing mu.Unlocks in LocalBackend.Start.

Updates #9181