### PR TITLE
client/web,cmd/tailscale: add prefix flag for web command

### DIFF
--- a/client/web/qnap.go
+++ b/client/web/qnap.go
@@ -16,8 +16,6 @@ import (
 	"net/url"
 )
 
-const qnapPrefix = "/cgi-bin/qpkg/Tailscale/index.cgi/"
-
 // authorizeQNAP authenticates the logged-in QNAP user and verifies
 // that they are authorized to use the web client.  It returns true if the
 // request was handled and no further processing is required.

--- a/client/web/src/api.ts
+++ b/client/web/src/api.ts
@@ -23,7 +23,7 @@ export function apiFetch(
   const url = `api${endpoint}${search ? `?${search}` : ""}`
 
   var contentType: string
-  if (unraidCsrfToken) {
+  if (unraidCsrfToken && method === "POST") {
     const params = new URLSearchParams()
     params.append("csrf_token", unraidCsrfToken)
     if (body) {

--- a/client/web/synology.go
+++ b/client/web/synology.go
@@ -15,8 +15,6 @@ import (
 	"tailscale.com/util/groupmember"
 )
 
-const synologyPrefix = "/webman/3rdparty/Tailscale/index.cgi/"
-
 // authorizeSynology authenticates the logged-in Synology user and verifies
 // that they are authorized to use the web client.  It returns true if the
 // request was handled and no further processing is required.

--- a/cmd/tailscale/cli/web.go
+++ b/cmd/tailscale/cli/web.go
@@ -39,6 +39,7 @@ Tailscale, as opposed to a CLI or a native app.
 		webf.StringVar(&webArgs.listen, "listen", "localhost:8088", "listen address; use port 0 for automatic")
 		webf.BoolVar(&webArgs.cgi, "cgi", false, "run as CGI script")
 		webf.BoolVar(&webArgs.dev, "dev", false, "run web client in developer mode [this flag is in development, use is unsupported]")
+		webf.StringVar(&webArgs.prefix, "prefix", "", "URL prefix added to requests (for cgi or reverse proxies)")
 		return webf
 	})(),
 	Exec: runWeb,
@@ -48,6 +49,7 @@ var webArgs struct {
 	listen string
 	cgi    bool
 	dev    bool
+	prefix string
 }
 
 func tlsConfigFromEnvironment() *tls.Config {
@@ -81,6 +83,7 @@ func runWeb(ctx context.Context, args []string) error {
 	webServer, cleanup := web.NewServer(ctx, web.ServerOpts{
 		DevMode:     webArgs.dev,
 		CGIMode:     webArgs.cgi,
+		PathPrefix:  webArgs.prefix,
 		LocalClient: &localClient,
 	})
 	defer cleanup()

--- a/release/dist/synology/files/index.cgi
+++ b/release/dist/synology/files/index.cgi
@@ -1,2 +1,2 @@
 #! /bin/sh
-exec /var/packages/Tailscale/target/bin/tailscale web -cgi
+exec /var/packages/Tailscale/target/bin/tailscale web -cgi -prefix="/webman/3rdparty/Tailscale/index.cgi/"


### PR DESCRIPTION
We already had a path on the web client server struct, but hadn't plumbed it through to the CLI. Add that now and use it for Synology and QNAP instead of hard-coding the path. (Adding flag for QNAP is https://github.com/tailscale/tailscale-qpkg/pull/112) This will allow supporting other environments (like unraid) without additional changes to the client/web package.

Also fix a small bug in unraid handling to only include the csrf token on POST requests.

Updates tailscale/corp#13775