### PR TITLE
ipn/ipnlocal,control/controlclient: make Logout more sync

### DIFF
--- a/cmd/tsconnect/wasm/wasm_js.go
+++ b/cmd/tsconnect/wasm/wasm_js.go
@@ -329,7 +329,7 @@ func (i *jsIPN) logout() {
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		i.lb.LogoutSync(ctx)
+		i.lb.Logout(ctx)
 	}()
 }
 

--- a/control/controlclient/status.go
+++ b/control/controlclient/status.go
@@ -93,12 +93,6 @@ type Status struct {
 // TODO(bradfitz): delete this and everything around Status.state.
 func (s *Status) LoginFinished() bool { return s.state == StateAuthenticated }
 
-// LogoutFinished reports whether the controlclient is in its "StateNotAuthenticated"
-// state where we don't want to be logged in.
-//
-// TODO(bradfitz): delete this and everything around Status.state.
-func (s *Status) LogoutFinished() bool { return s.state == StateNotAuthenticated }
-
 // StateForTest returns the internal state of s for tests only.
 func (s *Status) StateForTest() State { return s.state }
 

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -566,7 +566,7 @@ func (b *LocalBackend) Shutdown() {
 		ctx, cancel := context.WithTimeout(b.ctx, 5*time.Second)
 		defer cancel()
 		t0 := time.Now()
-		err := b.LogoutSync(ctx) // best effort
+		err := b.Logout(ctx) // best effort
 		td := time.Since(t0).Round(time.Millisecond)
 		if err != nil {
 			b.logf("failed to log out ephemeral node on shutdown after %v: %v", td, err)
@@ -3907,7 +3907,9 @@ func (b *LocalBackend) ShouldHandleViaIP(ip netip.Addr) bool {
 	return false
 }
 
-func (b *LocalBackend) LogoutSync(ctx context.Context) error {
+// Logout logs out the current profile, if any, and waits for the logout to
+// complete.
+func (b *LocalBackend) Logout(ctx context.Context) error {
 	b.mu.Lock()
 	if !b.hasNodeKeyLocked() {
 		// Already logged out.

--- a/ipn/ipnlocal/profiles.go
+++ b/ipn/ipnlocal/profiles.go
@@ -439,6 +439,7 @@ func (pm *profileManager) NewProfile() {
 // defaultPrefs is the default prefs for a new profile.
 var defaultPrefs = func() ipn.PrefsView {
 	prefs := ipn.NewPrefs()
+	prefs.LoggedOut = true
 	prefs.WantRunning = false
 
 	prefs.ControlURL = winutil.GetPolicyString("LoginURL", "")

--- a/ipn/ipnlocal/profiles.go
+++ b/ipn/ipnlocal/profiles.go
@@ -28,6 +28,8 @@ var debug = envknob.RegisterBool("TS_DEBUG_PROFILES")
 
 // profileManager is a wrapper around a StateStore that manages
 // multiple profiles and the current profile.
+//
+// It is not safe for concurrent use.
 type profileManager struct {
 	store ipn.StateStore
 	logf  logger.Logf

--- a/ipn/ipnlocal/state_test.go
+++ b/ipn/ipnlocal/state_test.go
@@ -580,7 +580,7 @@ func TestStateMachine(t *testing.T) {
 	store.awaitWrite()
 	t.Logf("\n\nLogout")
 	notifies.expect(5)
-	b.LogoutSync(context.Background())
+	b.Logout(context.Background())
 	{
 		nn := notifies.drain(5)
 		previousCC.assertCalls("pause", "Logout", "unpause", "Shutdown")
@@ -610,7 +610,7 @@ func TestStateMachine(t *testing.T) {
 	// A second logout should be a no-op as we are in the NeedsLogin state.
 	t.Logf("\n\nLogout2")
 	notifies.expect(0)
-	b.LogoutSync(context.Background())
+	b.Logout(context.Background())
 	{
 		notifies.drain(0)
 		cc.assertCalls()
@@ -623,7 +623,7 @@ func TestStateMachine(t *testing.T) {
 	// AuthCantContinue state.
 	t.Logf("\n\nLogout3")
 	notifies.expect(3)
-	b.LogoutSync(context.Background())
+	b.Logout(context.Background())
 	{
 		notifies.drain(0)
 		cc.assertCalls()

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -1056,7 +1056,7 @@ func (h *Handler) serveLogout(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "want POST", 400)
 		return
 	}
-	err := h.b.LogoutSync(r.Context())
+	err := h.b.Logout(r.Context())
 	if err == nil {
 		w.WriteHeader(http.StatusNoContent)
 		return

--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -945,9 +945,11 @@ func (n *testNode) StartDaemonAsIPNGOOS(ipnGOOS string) *Daemon {
 
 func (n *testNode) MustUp(extraArgs ...string) {
 	t := n.env.t
+	t.Helper()
 	args := []string{
 		"up",
 		"--login-server=" + n.env.ControlServer.URL,
+		"--reset",
 	}
 	args = append(args, extraArgs...)
 	cmd := n.Tailscale(args...)


### PR DESCRIPTION
We already removed the async API, make it more sync and remove
the FinishLogout state too.
    
This also makes the callback be synchronous again as the previous
attempt was trying to work around the logout callback resulting
in a client shutdown getting blocked forever.
    
Updates #3833
    
Signed-off-by: Maisem Ali <maisem@tailscale.com>