### PR TITLE
control/controlclient: clean up various things in prep for state overhaul

### DIFF
--- a/control/controlclient/controlclient_test.go
+++ b/control/controlclient/controlclient_test.go
@@ -50,12 +50,7 @@ func TestStatusEqual(t *testing.T) {
 			true,
 		},
 		{
-			&Status{state: StateNew},
-			&Status{state: StateNew},
-			true,
-		},
-		{
-			&Status{state: StateNew},
+			&Status{},
 			&Status{state: StateAuthenticated},
 			false,
 		},


### PR DESCRIPTION
We want the overall state (used only for tests) to be computed from
the individual states of each component, rather than moving the state
around by hand in dozens of places.

In working towards that, we found a lot of things to clean up.

Updates #cleanup

Co-authored-by: Maisem Ali <maisem@tailscale.com>
