### PR TITLE
cmd/tailscale/cli,ipn: mention available update in "tailscale status"

### DIFF
--- a/cmd/tailscale/cli/status.go
+++ b/cmd/tailscale/cli/status.go
@@ -236,6 +236,9 @@ func runStatus(ctx context.Context, args []string) error {
 		printHealth()
 	}
 	printFunnelStatus(ctx)
+	if cv := st.ClientVersion; cv != nil && !cv.RunningLatest && cv.LatestVersion != "" {
+		printf("# New Tailscale version is available: %q, run `tailscale update` to update.\n", cv.LatestVersion)
+	}
 	return nil
 }
 

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -266,6 +266,9 @@ type LocalBackend struct {
 	// at the moment that tkaSyncLock is taken).
 	tkaSyncLock sync.Mutex
 	clock       tstime.Clock
+
+	// Last ClientVersion received in MapResponse, guarded by mu.
+	lastClientVersion *tailcfg.ClientVersion
 }
 
 // clientGen is a func that creates a control plane client.
@@ -664,6 +667,9 @@ func (b *LocalBackend) updateStatus(sb *ipnstate.StatusBuilder, extraLocked func
 		s.TUN = !b.sys.IsNetstack()
 		s.BackendState = b.state.String()
 		s.AuthURL = b.authURLSticky
+		if prefs := b.pm.CurrentPrefs(); prefs.Valid() && prefs.AutoUpdate().Check {
+			s.ClientVersion = b.lastClientVersion
+		}
 		if err := health.OverallError(); err != nil {
 			switch e := err.(type) {
 			case multierr.Error:
@@ -2150,6 +2156,9 @@ func (b *LocalBackend) tellClientToBrowseToURL(url string) {
 // onClientVersion is called on MapResponse updates when a MapResponse contains
 // a non-nil ClientVersion message.
 func (b *LocalBackend) onClientVersion(v *tailcfg.ClientVersion) {
+	b.mu.Lock()
+	b.lastClientVersion = v
+	b.mu.Unlock()
 	switch runtime.GOOS {
 	case "darwin", "ios":
 		// These auto-update well enough, and we haven't converted the

--- a/ipn/ipnstate/ipnstate.go
+++ b/ipn/ipnstate/ipnstate.go
@@ -71,6 +71,8 @@ type Status struct {
 
 	Peer map[key.NodePublic]*PeerStatus
 	User map[tailcfg.UserID]tailcfg.UserProfile
+
+	ClientVersion *tailcfg.ClientVersion
 }
 
 // TKAKey describes a key trusted by network lock.

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -111,7 +111,8 @@ type CapabilityVersion int
 //   - 70: 2023-08-16: removed most Debug fields; added NodeAttrDisable*, NodeAttrDebug* instead
 //   - 71: 2023-08-17: added NodeAttrOneCGNATEnable, NodeAttrOneCGNATDisable
 //   - 72: 2023-08-23: TS-2023-006 UPnP issue fixed; UPnP can now be used again
-const CurrentCapabilityVersion CapabilityVersion = 72
+//   - 73: 2023-09-01: Non-Windows clients expect to receive ClientVersion
+const CurrentCapabilityVersion CapabilityVersion = 73
 
 type StableID string
 


### PR DESCRIPTION
Cache the last `ClientVersion` value that was received from coordination server and pass it in the localapi `/status` response. When running `tailscale status`, print a message if `RunningAsLatest` is `false`.

Updates #6907