### PR TITLE
cmd/tailscaled, tstest/integration: make tailscaled die when parent dies

### DIFF
--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -934,6 +934,15 @@ func (n *testNode) StartDaemonAsIPNGOOS(ipnGOOS string) *Daemon {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = io.MultiWriter(cmd.Stderr, os.Stderr)
 	}
+	if runtime.GOOS != "windows" {
+		pr, pw, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { pw.Close() })
+		cmd.ExtraFiles = append(cmd.ExtraFiles, pr)
+		cmd.Env = append(cmd.Env, "TS_PARENT_DEATH_FD=3")
+	}
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("starting tailscaled: %v", err)
 	}


### PR DESCRIPTION
I noticed that failed tests were leaving aroudn stray tailscaled processes
on macOS at least.

To repro, add this to tstest/integration:

    func TestFailInFewSeconds(t *testing.T) {
        t.Parallel()
        time.Sleep(3 * time.Second)
        os.Exit(1)
        t.Fatal("boom")
    }

Those three seconds let the other parallel tests (with all their
tailscaled child processes) start up and start running their tests,
but then we violently os.Exit(1) the test driver and all the children
were kept alive (and were spinning away, using all available CPU in
gvisor scheduler code, which is a separate scary issue)

Updates #cleanup

Co-authored-by: Maisem Ali <maisem@tailscale.com>
