### PR TITLE
client/web, clientupdate, util/linuxfw, wgengine/magicsock: Use %v verb for errors

### DIFF
--- a/client/web/web.go
+++ b/client/web/web.go
@@ -457,7 +457,7 @@ func (s *Server) csrfKey() []byte {
 	// create a new key
 	key := make([]byte, 32)
 	if _, err := rand.Read(key); err != nil {
-		log.Fatal("error generating CSRF key: %w", err)
+		log.Fatalf("error generating CSRF key: %v", err)
 	}
 
 	// if running in CGI mode, try to write the newly created key to disk, and exit if it fails.

--- a/clientupdate/clientupdate.go
+++ b/clientupdate/clientupdate.go
@@ -863,7 +863,7 @@ func (up *Updater) updateLinuxBinary() error {
 		return err
 	}
 	if err := os.Remove(dlPath); err != nil {
-		up.Logf("failed to clean up %q: %w", dlPath, err)
+		up.Logf("failed to clean up %q: %v", dlPath, err)
 	}
 	if err := restartSystemdUnit(context.Background()); err != nil {
 		if errors.Is(err, errors.ErrUnsupported) {

--- a/util/linuxfw/nftables_runner.go
+++ b/util/linuxfw/nftables_runner.go
@@ -186,7 +186,7 @@ func NewNfTablesRunner(logf logger.Logf) (*nftablesRunner, error) {
 
 	v6err := checkIPv6(logf)
 	if v6err != nil {
-		logf("disabling tunneled IPv6 due to system IPv6 config: %w", v6err)
+		logf("disabling tunneled IPv6 due to system IPv6 config: %v", v6err)
 	}
 	supportsV6 := v6err == nil
 	supportsV6NAT := supportsV6 && checkSupportsV6NAT()

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -24,6 +24,7 @@ import (
 	"go4.org/mem"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
+
 	"tailscale.com/disco"
 	"tailscale.com/envknob"
 	"tailscale.com/health"
@@ -1644,7 +1645,7 @@ func (c *Conn) SetPreferredPort(port uint16) {
 	c.port.Store(uint32(port))
 
 	if err := c.rebind(dropCurrentPort); err != nil {
-		c.logf("%w", err)
+		c.logf("%v", err)
 		return
 	}
 	c.resetEndpointStates()
@@ -2276,7 +2277,7 @@ func (c *Conn) rebind(curPortFate currentPortFate) error {
 func (c *Conn) Rebind() {
 	metricRebindCalls.Add(1)
 	if err := c.rebind(keepCurrentPort); err != nil {
-		c.logf("%w", err)
+		c.logf("%v", err)
 		return
 	}
 


### PR DESCRIPTION
Replace %w verb with %v verb when logging errors.
Use %w only for wrapping errors with fmt.Errorf()

Fixes: #9213

Signed-off-by: Craig Rodrigues <rodrigc@crodrigues.org>
