### PR TITLE
charts/tailscale-operator: WIP add a helm chart for cmd/k8s-operator

### DIFF
--- a/charts/tailscale-operator/.helmignore
+++ b/charts/tailscale-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/tailscale-operator/Chart.yaml
+++ b/charts/tailscale-operator/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: tailscale-operator
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "unstable"

--- a/charts/tailscale-operator/templates/_helpers.tpl
+++ b/charts/tailscale-operator/templates/_helpers.tpl
@@ -1,0 +1,91 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tailscale-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tailscale-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tailscale-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "tailscale-operator.labels" -}}
+helm.sh/chart: {{ include "tailscale-operator.chart" . }}
+{{ include "tailscale-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tailscale-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tailscale-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use for the operator
+*/}}
+{{- define "tailscale-operator.operator.serviceAccountName" -}}
+{{- if .Values.operator.serviceAccount.create }}
+{{- default (include "tailscale-operator.fullname" .) .Values.operator.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.operator.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use for the proxy
+*/}}
+{{- define "tailscale-operator.proxy.serviceAccountName" -}}
+{{- if .Values.operator.serviceAccount.create }}
+{{- default (printf "%s-%s" (include "tailscale-operator.fullname" .) "proxy") .Values.proxy.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.operator.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the rbac resources to use for the proxy
+*/}}
+{{- define "tailscale-operator.proxy.rbacName" -}}
+{{- printf "%s-%s" (include "tailscale-operator.fullname" .) "proxy" }}
+{{- end }}
+
+{{/*
+Create the name of the oauth secret to use
+*/}}
+{{- define "tailscale-operator.secretName" -}}
+{{- if .Values.secret.create }}
+{{- default (include "tailscale-operator.fullname" .) .Values.secret.name }}
+{{- else }}
+{{- default "default" .Values.secret.name }}
+{{- end }}
+{{- end }}

--- a/charts/tailscale-operator/templates/operator-cluster-role-binding.yaml
+++ b/charts/tailscale-operator/templates/operator-cluster-role-binding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "tailscale-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+    {{- with .Values.operator.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "tailscale-operator.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "tailscale-operator.operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "tailscale-operator.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/tailscale-operator/templates/operator-cluster-role.yaml
+++ b/charts/tailscale-operator/templates/operator-cluster-role.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "tailscale-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+    {{- with .Values.operator.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "tailscale-operator.fullname" . }}
+rules:
+  - apiGroups: [""]
+    resources: ["events", "services", "services/status"]
+    verbs: ["*"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "ingresses/status"]
+    verbs: ["*"]
+{{- end }}

--- a/charts/tailscale-operator/templates/operator-deployment.yaml
+++ b/charts/tailscale-operator/templates/operator-deployment.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tailscale-operator.fullname" . }}
+  labels:
+    {{- include "tailscale-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+spec:
+  replicas: 1
+  revisionHistoryLimit: {{ .Values.operator.revisionHistoryLimit }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "tailscale-operator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.operator.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "tailscale-operator.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.operator.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "tailscale-operator.operator.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.operator.podSecurityContext | nindent 8 }}
+      volumes:
+      - name: oauth
+        secret:
+          secretName: {{ include "tailscale-operator.secretName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.operator.securityContext | nindent 12 }}
+          image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.operator.resources | nindent 12 }}
+          env:
+            - name: "OPERATOR_HOSTNAME"
+              value: "{{ .Values.operator.hostname | default ( include "tailscale-operator.fullname" . ) }}"
+            - name: "OPERATOR_SECRET"
+              value: "{{ include "tailscale-operator.secretName" . }}"
+            - name: "OPERATOR_LOGGING"
+              value: "{{ .Values.operator.logging }}"
+            - name: "OPERATOR_NAMESPACE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: "CLIENT_ID_FILE"
+              value: "/oauth/client_id"
+            - name: "CLIENT_SECRET_FILE"
+              value: "/oauth/client_secret"
+            - name: "PROXY_IMAGE"
+              value: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.tag }}"
+            - name: "PROXY_TAGS"
+              value: "{{ join "," .Values.proxy.tags }}"
+            - name: "AUTH_PROXY"
+              value: "{{ .Values.operator.authProxy }}"
+          {{- if .Values.operator.extraEnvs }}
+            {{- toYaml .Values.operator.extraEnvs | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: oauth
+              mountPath: /oauth
+              readOnly: true
+      {{- with .Values.operator.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/tailscale-operator/templates/operator-role-binding.yaml
+++ b/charts/tailscale-operator/templates/operator-role-binding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    {{- include "tailscale-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+    {{- with .Values.operator.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "tailscale-operator.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "tailscale-operator.operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "tailscale-operator.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/tailscale-operator/templates/operator-role.yaml
+++ b/charts/tailscale-operator/templates/operator-role.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    {{- include "tailscale-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+    {{- with .Values.operator.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "tailscale-operator.fullname" . }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["*"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["*"]
+{{- end }}

--- a/charts/tailscale-operator/templates/operator-secret.yaml
+++ b/charts/tailscale-operator/templates/operator-secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.secret.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "tailscale-operator.secretName" . }}
+  labels:
+    {{- include "tailscale-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+stringData:
+    client_id: "{{ .Values.secret.clientId }}"
+    client_secret: "{{ .Values.secret.clientSecret }}"
+{{- end }}

--- a/charts/tailscale-operator/templates/operator-serviceaccount.yaml
+++ b/charts/tailscale-operator/templates/operator-serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.operator.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tailscale-operator.operator.serviceAccountName" . }}
+  labels:
+    {{- include "tailscale-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+  {{- with .Values.operator.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/tailscale-operator/templates/proxy-role-binding.yaml
+++ b/charts/tailscale-operator/templates/proxy-role-binding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    {{- include "tailscale-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: proxy
+    {{- with .Values.operator.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "tailscale-operator.proxy.rbacName" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "tailscale-operator.proxy.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "tailscale-operator.proxy.rbacName" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/tailscale-operator/templates/proxy-role.yaml
+++ b/charts/tailscale-operator/templates/proxy-role.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    {{- include "tailscale-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: proxy
+    {{- with .Values.operator.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "tailscale-operator.proxy.rbacName" . }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["*"]
+{{- end }}

--- a/charts/tailscale-operator/templates/proxy-serviceaccount.yaml
+++ b/charts/tailscale-operator/templates/proxy-serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.proxy.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tailscale-operator.proxy.serviceAccountName" . }}
+  labels:
+    {{- include "tailscale-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: proxy
+  {{- with .Values.proxy.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/tailscale-operator/values.yaml
+++ b/charts/tailscale-operator/values.yaml
@@ -1,0 +1,95 @@
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+operator:
+
+  # Default values for tailscale-operator.
+  # This is a YAML-formatted file.
+  # Declare variables to be passed into your templates.
+
+  # hostname:
+  logging: info
+  authProxy: "false"
+
+  revisionHistoryLimit: 10
+
+  image:
+    repository: tailscale/k8s-operator
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  extraEnvs: []
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+
+secret:
+  # Specifies whether an oauth secret should be created
+  create: false
+  # The name of the oauth secret to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+  # clientId:
+  # clientSecret:
+
+proxy:
+
+  image:
+    repository: tailscale/tailscale
+    pullPolicy: IfNotPresent
+    tag: "unstable"
+
+  tags:
+    - tag:k8s
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    # TODO unpin `proxies` once customizable proxy templates are supported
+    name: "proxies"
+
+rbac:
+  create: true


### PR DESCRIPTION
> **Note**
> This is a Work In Progress!

Create a Helm chart to deploy the k8s-operator.

Install using:

```
export TAILSCALE_CLIENT_ID="<client-id>"
export TAILSCALE_CLIENT_SECRET="<client-secret>"
helm -n tailscale install --set "secret.create=true" --set "secret.clientId=$TAILSCALE_CLIENT_ID" --set "secret.clientSecret=$TAILSCALE_CLIENT_SECRET" tailscale-operator .
```

### Remaining Tasks

- [ ] [Load proxy StatefulSet template from ConfigMap](https://github.com/tailscale/tailscale/issues/9062#issuecomment-1703089626)
  - [ ] Make sure the proxy serviceAccountName is not static
- [ ] README generated using helm-docs
- [ ] [Chart tests](https://helm.sh/docs/topics/chart_tests/)
- [ ] CI (readme, linting, etc.)
- [ ] Release management (maybe [chart-releaser-action](https://github.com/helm/chart-releaser-action)?)
- [ ] Clean up `helm create` boilerplate comments