### PR TITLE
cmd/tailscale: Check App Store tailscaled dialable before selecting.

### DIFF
--- a/safesocket/safesocket_darwin.go
+++ b/safesocket/safesocket_darwin.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 func init() {
@@ -48,9 +49,11 @@ func localTCPPortAndTokenMacsys() (port int, token string, err error) {
 		return 0, "", errors.New("empty auth token in sameuserproof file")
 	}
 
-	// The above files exist forever after the first run. Check that the server
-	// is actually running (though it may still be in a Stopped state).
-	conn, err := net.Dial("tcp", "127.0.0.1:"+portStr)
+	// The above files exist forever after the first run of
+	// /Applications/Tailscale.app, so check we can connect to avoid returning a
+	// port nothing is listening on. Connect to "127.0.0.1" rather than
+	// "localhost" due to #7851.
+	conn, err := net.DialTimeout("tcp", "127.0.0.1:"+portStr, time.Second)
 	if err != nil {
 		return 0, "", err
 	}

--- a/safesocket/safesocket_darwin.go
+++ b/safesocket/safesocket_darwin.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -46,6 +47,15 @@ func localTCPPortAndTokenMacsys() (port int, token string, err error) {
 	if auth == "" {
 		return 0, "", errors.New("empty auth token in sameuserproof file")
 	}
+
+	// The above files exist forever after the first run. Check that the server
+	// is actually running (though it may still be in a Stopped state).
+	conn, err := net.Dial("tcp", "127.0.0.1:"+portStr)
+	if err != nil {
+		return 0, "", err
+	}
+	conn.Close()
+
 	return port, auth, nil
 }
 


### PR DESCRIPTION
My earlier PR #9217 attempted to fix the same issue, but suffered from not letting the user connect to non-oss tailscaled if oss tailscaled was listening on the socket. The --socket flag doesn't let you select the mac apps.

Rather than leave the user unable to choose which tailscaled to connect to, this PR keeps the mac/socket preference order the same and checks a bit harder whether the macsys version really is running. Now, we still prefer the App Store Tailscale (even if it's listening with BackendState=Stopped) and you can use --socket to switch. But now if you quit the App Store Tailscale, we'll try the socket without needing the flag.

Fixes #5761