### PR TITLE
tailcfg: Support JSON-unmarshalling UserID from string.

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -122,6 +122,27 @@ func (u UserID) IsZero() bool {
 	return u == 0
 }
 
+func (u *UserID) UnmarshalJSON(b []byte) error {
+	return json.Unmarshal(unquoteInt(b), (*int64)(u))
+}
+
+// unquoteInt returns b without quotes if it is on the form `"[0-9]+"` or else
+// returns b directly.
+func unquoteInt(b []byte) []byte {
+	if len(b) < 3 {
+		return b
+	}
+	if b[0] != '"' || b[len(b)-1] != '"' {
+		return b
+	}
+	for i := 1; i < len(b)-1; i++ {
+		if b[i] < '0' || b[i] > '9' {
+			return b
+		}
+	}
+	return b[1 : len(b)-1]
+}
+
 type LoginID ID
 
 func (u LoginID) IsZero() bool {

--- a/tailcfg/tailcfg_test.go
+++ b/tailcfg/tailcfg_test.go
@@ -705,3 +705,53 @@ func TestCurrentCapabilityVersion(t *testing.T) {
 		t.Errorf("CurrentCapabilityVersion = %d; want %d", CurrentCapabilityVersion, max)
 	}
 }
+
+func TestUserUnmarshal_FromString(t *testing.T) {
+	tests := []struct {
+		from    string
+		want    UserID
+		wantErr string
+	}{
+		{
+			// JSON.parse('65132411450146196') => 65132411450146190 :(
+			from: `65132411450146196`,
+			want: 65132411450146196,
+		},
+		{
+			// JSON.parse('"65132411450146196"') => '65132411450146196' :)
+			from: `"65132411450146196"`,
+			want: 65132411450146196,
+		},
+		{
+			// Don't correct invalid JSON.
+			from:    `""123""`,
+			wantErr: "invalid character '1' after top-level value",
+		},
+		{
+			// Empty strings aren't ints.
+			from:    `""`,
+			wantErr: "cannot unmarshal string into Go value of type int64",
+		},
+		{
+			from:    `{}`,
+			wantErr: "cannot unmarshal object into Go value of type int64",
+		},
+	}
+	for _, test := range tests {
+		var got UserID
+		err := json.Unmarshal([]byte(test.from), &got)
+		if test.wantErr != "" {
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Errorf("input %q: want error containing %q but got: %v", test.from, test.wantErr, err)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("input %q: unexpected error: %s", test.from, err)
+			continue
+		}
+		if got != test.want {
+			t.Errorf("input %q: expected %#v but got %#v", test.from, test.want, got)
+		}
+	}
+}


### PR DESCRIPTION
If we merge this, eventually our clients will support receiving UserID strings, and we can later have the server return them by adding a <code>\`json:",string"\`</code> field tag to ipnstate.PeerStatus.UserID as in #8743.

(An alternative approach might be https://github.com/tailscale/tailscale/issues/7576#issuecomment-1706498888.)

Updates #7576