### PR TITLE
ipn, ipn/ipnlocal: add Foreground field to ServeConfig

### DIFF
--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -76,6 +76,12 @@ func (src *ServeConfig) Clone() *ServeConfig {
 		}
 	}
 	dst.AllowFunnel = maps.Clone(src.AllowFunnel)
+	if dst.Foreground != nil {
+		dst.Foreground = map[string]*ServeConfig{}
+		for k, v := range src.Foreground {
+			dst.Foreground[k] = v.Clone()
+		}
+	}
 	return dst
 }
 
@@ -84,6 +90,7 @@ var _ServeConfigCloneNeedsRegeneration = ServeConfig(struct {
 	TCP         map[uint16]*TCPPortHandler
 	Web         map[HostPort]*WebServerConfig
 	AllowFunnel map[HostPort]bool
+	Foreground  map[string]*ServeConfig
 }{})
 
 // Clone makes a deep copy of TCPPortHandler.

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -177,11 +177,18 @@ func (v ServeConfigView) AllowFunnel() views.Map[HostPort, bool] {
 	return views.MapOf(v.ж.AllowFunnel)
 }
 
+func (v ServeConfigView) Foreground() views.MapFn[string, *ServeConfig, ServeConfigView] {
+	return views.MapFnOf(v.ж.Foreground, func(t *ServeConfig) ServeConfigView {
+		return t.View()
+	})
+}
+
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _ServeConfigViewNeedsRegeneration = ServeConfig(struct {
 	TCP         map[uint16]*TCPPortHandler
 	Web         map[HostPort]*WebServerConfig
 	AllowFunnel map[HostPort]bool
+	Foreground  map[string]*ServeConfig
 }{})
 
 // View returns a readonly view of TCPPortHandler.

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -2014,6 +2014,8 @@ func (b *LocalBackend) WatchNotifications(ctx context.Context, mask ipn.NotifyWa
 		go b.pollRequestEngineStatus(ctx)
 	}
 
+	defer b.DeleteForegroundSession(sessionID) // TODO(marwan-at-work): check err
+
 	for {
 		select {
 		case <-ctx.Done():

--- a/ipn/serve.go
+++ b/ipn/serve.go
@@ -37,6 +37,14 @@ type ServeConfig struct {
 	// AllowFunnel is the set of SNI:port values for which funnel
 	// traffic is allowed, from trusted ingress peers.
 	AllowFunnel map[HostPort]bool `json:",omitempty"`
+
+	// Foreground is a map of an IPN Bus session id to a
+	// foreground serve config. Note that only TCP and Web
+	// are used inside the Foreground map.
+	//
+	// TODO(marwan-at-work): this is not currently
+	// used. Remove the TODO in the follow up PR.
+	Foreground map[string]*ServeConfig `json:",omitempty"`
 }
 
 // HostPort is an SNI name and port number, joined by a colon.


### PR DESCRIPTION
This PR adds a new field to the ServeConfig which maps WatchIPNBus session ids to foreground serve configs.

The PR also adds a DeleteForegroundSession method to ensure the config gets cleaned up on sessions ending.

Note this field is not currently used but will be in follow up work.

Updates #8489