### PR TITLE
control/controlclient: check c.closed in waitUnpause

### DIFF
--- a/control/controlclient/auto.go
+++ b/control/controlclient/auto.go
@@ -38,7 +38,7 @@ var _ Client = (*Auto)(nil)
 // closed).
 func (c *Auto) waitUnpause(routineLogName string) (keepRunning bool) {
 	c.mu.Lock()
-	if !c.paused {
+	if !c.paused || c.closed {
 		defer c.mu.Unlock()
 		return !c.closed
 	}


### PR DESCRIPTION
We would only check if the client was paused, but not if the client was closed. This meant that a call to Shutdown may block forever/leak goroutines

Updates #cleanup