### PR TITLE
wgengine/router: update comment with TS_DEBUG_FIREWALL_MODE=nftables

### DIFF
--- a/wgengine/router/router_linux.go
+++ b/wgengine/router/router_linux.go
@@ -124,7 +124,7 @@ func chooseFireWallMode(logf logger.Logf, det tableDetector) linuxfw.FirewallMod
 }
 
 // newNetfilterRunner creates a netfilterRunner using either nftables or iptables.
-// As nftables is still experimental, iptables will be used unless TS_DEBUG_USE_NETLINK_NFTABLES is set.
+// As nftables is still experimental, iptables will be used unless TS_DEBUG_FIREWALL_MODE=nftables is set.
 func newNetfilterRunner(logf logger.Logf) (netfilterRunner, error) {
 	tableDetector := &linuxFWDetector{}
 	var mode linuxfw.FirewallMode


### PR DESCRIPTION
TS_DEBUG_USE_NETLINK_NFTABLES is not used anywhere in the code

Updates #391