### PR TITLE
util/linuxfw, wgengine/router: display iptables version

### DIFF
--- a/util/linuxfw/linuxfw_unsupported.go
+++ b/util/linuxfw/linuxfw_unsupported.go
@@ -34,6 +34,11 @@ func DebugIptables(logf logger.Logf) error {
 	return ErrUnsupported
 }
 
+// GetIptablesCliVersion is not supported on non-Linux platforms.
+func GetIptablesCliVersion() ([]string, error) {
+	return nil, ErrUnsupported
+}
+
 // DetectIptables is not supported on non-Linux platforms.
 func DetectIptables() (int, error) {
 	return 0, ErrUnsupported


### PR DESCRIPTION
Log the version of the iptables binary
to help better debug the logic in chooseFirewallMode() on different platforms.

Updates #391
Updates #9247