### PR TITLE
adjust build tags for tamago

### DIFF
--- a/logtail/filch/filch_stub.go
+++ b/logtail/filch/filch_stub.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build wasm || plan9
+//go:build wasm || plan9 || tamago
 
 package filch
 


### PR DESCRIPTION
This PR adjust build tags to allow compilation under the [TamaGo framework](https://github.com/usbarmory/tamago).