### PR TITLE
tstest: relax ResourceCheck to 3s

### DIFF
--- a/tstest/resource.go
+++ b/tstest/resource.go
@@ -22,11 +22,11 @@ func ResourceCheck(tb testing.TB) {
 			return
 		}
 		// Goroutines might be still exiting.
-		for i := 0; i < 100; i++ {
+		for i := 0; i < 300; i++ {
 			if runtime.NumGoroutine() <= startN {
 				return
 			}
-			time.Sleep(5 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 		}
 		endN, endStacks := goroutines()
 		if endN <= startN {


### PR DESCRIPTION
It was only waiting for 0.5s (5ms * 100), but our CI is too slow so make it wait up to 3s (10ms * 300).

Updates tailscale/corp#14515