### PR TITLE
cmd/testwrapper: exit code 1 when go build fails

### DIFF
--- a/cmd/testwrapper/testwrapper.go
+++ b/cmd/testwrapper/testwrapper.go
@@ -260,8 +260,11 @@ func main() {
 
 			var failed bool
 			for tr := range ch {
+				// Go assigns the package name "command-line-arguments" when you
+				// `go test FILE` rather than `go test PKG`. It's more
+				// convenient for us to to specify files in tests, so fix tr.pkg
+				// so that subsequent testwrapper attempts run correctly.
 				if tr.pkg == "command-line-arguments" {
-					// For passing filenames instead of packages in tests.
 					tr.pkg = pattern
 				}
 				if tr.pkgFinished {

--- a/cmd/testwrapper/testwrapper_test.go
+++ b/cmd/testwrapper/testwrapper_test.go
@@ -12,6 +12,98 @@ import (
 	"testing"
 )
 
+func TestRetry(t *testing.T) {
+	dir := t.TempDir()
+
+	testfile := filepath.Join(dir, "retry_test.go")
+	code := []byte(`package retry_test
+
+import (
+	"os"
+	"testing"
+	"tailscale.com/cmd/testwrapper/flakytest"
+)
+
+func TestOK(t *testing.T) {}
+
+func TestFlakeRun(t *testing.T) {
+	flakytest.Mark(t, "https://github.com/tailscale/tailscale/issues/0") // random issue
+	e := os.Getenv(flakytest.FlakeAttemptEnv)
+	if e == "" {
+		t.Skip("not running in testwrapper")
+	}
+	if e == "1" {
+		t.Fatal("First run in testwrapper, failing so that test is retried. This is expected.")
+	}
+}
+`)
+	if err := os.WriteFile(testfile, code, 0o644); err != nil {
+		t.Fatalf("writing package: %s", err)
+	}
+
+	out, err := exec.Command("go", "run", ".", "-v", testfile).CombinedOutput()
+	if err != nil {
+		t.Fatalf("go run . %s: %s with output:\n%s", testfile, err, out)
+	}
+
+	want := []byte("ok\t" + testfile + " [attempt=2]")
+	if !bytes.Contains(out, want) {
+		t.Fatalf("wanted output containing %q but got:\n%s", want, out)
+	}
+
+	if okRuns := bytes.Count(out, []byte("=== RUN   TestOK")); okRuns != 1 {
+		t.Fatalf("expected TestOK to be run once but was run %d times in output:\n%s", okRuns, out)
+	}
+	if flakeRuns := bytes.Count(out, []byte("=== RUN   TestFlakeRun")); flakeRuns != 2 {
+		t.Fatalf("expected TestFlakeRun to be run twice but was run %d times in output:\n%s", flakeRuns, out)
+	}
+
+	if testing.Verbose() {
+		t.Logf("success - output:\n%s", out)
+	}
+}
+
+func TestNoRetry(t *testing.T) {
+	dir := t.TempDir()
+
+	testfile := filepath.Join(dir, "noretry_test.go")
+	code := []byte(`package noretry_test
+
+import (
+	"testing"
+	"tailscale.com/cmd/testwrapper/flakytest"
+)
+
+func TestFlakeRun(t *testing.T) {
+	flakytest.Mark(t, "https://github.com/tailscale/tailscale/issues/0") // random issue
+	t.Error("shouldn't be retried")
+}
+
+func TestAlwaysError(t *testing.T) {
+	t.Error("error")
+}
+`)
+	if err := os.WriteFile(testfile, code, 0o644); err != nil {
+		t.Fatalf("writing package: %s", err)
+	}
+
+	out, err := exec.Command("go", "run", ".", testfile).Output()
+	if err == nil {
+		t.Fatalf("go run . %s: expected error but it succeeded with output:\n%s", testfile, out)
+	}
+	if code, _, ok := errExitCode(err); ok && code != 1 {
+		t.Fatalf("expected exit code 1 but got %d", code)
+	}
+
+	want := []byte("Not retrying flaky tests because non-flaky tests failed.")
+	if !bytes.Contains(out, want) {
+		t.Fatalf("wanted output containing %q but got:\n%s", want, out)
+	}
+	if testing.Verbose() {
+		t.Logf("success - output:\n%s", out)
+	}
+}
+
 func TestBuildError(t *testing.T) {
 	dir := t.TempDir()
 

--- a/cmd/testwrapper/testwrapper_test.go
+++ b/cmd/testwrapper/testwrapper_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package main_test
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestBuildError(t *testing.T) {
+	dir := t.TempDir()
+
+	// Construct our broken package.
+	testfile := filepath.Join(dir, "builderror_test.go")
+	code := []byte("package builderror_test\n\nderp")
+	err := os.WriteFile(testfile, code, 0o644)
+	if err != nil {
+		t.Fatalf("writing package: %s", err)
+	}
+
+	buildErr := []byte(`builderror_test.go:3:1: expected declaration, found derp`)
+
+	// Confirm `go test` exits with code 1.
+	_, err = exec.Command("go", "test", testfile).Output()
+	if code, stderr, ok := errExitCode(err); !ok || code != 1 {
+		t.Fatalf("go test %s: expected error with exit code 0 but got: %v", testfile, err)
+	} else if !bytes.Contains(stderr, buildErr) {
+		t.Fatalf("go test %s: expected build error containing %q but got:\n%s", testfile, buildErr, stderr)
+	}
+
+	// Confirm `testwrapper` exits with code 1.
+	_, err = exec.Command("go", "run", ".", testfile).Output()
+	if code, stderr, ok := errExitCode(err); !ok || code != 1 {
+		t.Fatalf("testwrapper %s: expected error with exit code 0 but got: %v", testfile, err)
+	} else if !bytes.Contains(stderr, buildErr) {
+		t.Fatalf("testwrapper %s: expected build error containing %q but got:\n%s", testfile, buildErr, stderr)
+	}
+}
+
+func errExitCode(err error) (int, []byte, bool) {
+	var exit *exec.ExitError
+	if errors.As(err, &exit) {
+		return exit.ExitCode(), exit.Stderr, true
+	}
+	return 0, nil, false
+}


### PR DESCRIPTION
Note that merging this PR will then block upgrading tailscale.com in corp until a darwin build error from the PR below is fixed.

Fixes #9275
Fixes #8586
Fixes tailscale/corp#13115