### PR TITLE
util/linuxfw: Fix comment which lists supported linux arches

### DIFF
--- a/util/linuxfw/linuxfw_unsupported.go
+++ b/util/linuxfw/linuxfw_unsupported.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-// NOTE: linux_{arm64, x86} are the only two currently supported archs due to missing
+// NOTE: linux_{arm64, amd64} are the only two currently supported archs due to missing
 // support in upstream dependencies.
 
 // TODO(#8502): add support for more architectures


### PR DESCRIPTION
Only arm64 and amd64 are supported

Signed-off-by: Craig Rodrigues <rodrigc@crodrigues.org>


For example, if you build with:

```
GOOS=linux GOARCH=386 ./tool/go install tailscale.com/cmd/tailscale tailscale.com/cmd/tailscaled
```

That is not supported, even though it is an x86 arch.

The lsupported arches are listed
in  the Build Constraints here: https://github.com/tailscale/tailscale/pull/9279/files#diff-87f1974e43e52bc996fdeb5ddd5246c8e267c0de9e1114446e55922b116360b6R8