### PR TITLE
cmd/k8s-operator: ensures proxy can run on GKE Autopilot

### DIFF
--- a/cmd/k8s-operator/manifests/proxy.yaml
+++ b/cmd/k8s-operator/manifests/proxy.yaml
@@ -35,3 +35,4 @@ spec:
             capabilities:
               add:
                 - NET_ADMIN
+                - NET_RAW

--- a/cmd/k8s-operator/operator.go
+++ b/cmd/k8s-operator/operator.go
@@ -53,6 +53,7 @@ func main() {
 		priorityClassName  = defaultEnv("PROXY_PRIORITY_CLASS_NAME", "")
 		tags               = defaultEnv("PROXY_TAGS", "tag:k8s")
 		shouldRunAuthProxy = defaultBool("AUTH_PROXY", false)
+		runInRestrictedEnv = defaultBool("RUN_IN_RESTRICTED_ENV", false)
 	)
 
 	var opts []kzap.Opts
@@ -73,7 +74,7 @@ func main() {
 	if shouldRunAuthProxy {
 		launchAuthProxy(zlog, restConfig, s)
 	}
-	startReconcilers(zlog, s, tsNamespace, restConfig, tsClient, image, priorityClassName, tags)
+	startReconcilers(zlog, s, tsNamespace, restConfig, tsClient, image, priorityClassName, tags, runInRestrictedEnv)
 }
 
 // initTSNet initializes the tsnet.Server and logs in to Tailscale. It uses the
@@ -182,7 +183,7 @@ waitOnline:
 
 // startReconcilers starts the controller-runtime manager and registers the
 // ServiceReconciler.
-func startReconcilers(zlog *zap.SugaredLogger, s *tsnet.Server, tsNamespace string, restConfig *rest.Config, tsClient *tailscale.Client, image, priorityClassName, tags string) {
+func startReconcilers(zlog *zap.SugaredLogger, s *tsnet.Server, tsNamespace string, restConfig *rest.Config, tsClient *tailscale.Client, image, priorityClassName, tags string, runInRestrictedEnv bool) {
 	var (
 		isDefaultLoadBalancer = defaultBool("OPERATOR_DEFAULT_LOAD_BALANCER", false)
 	)
@@ -231,6 +232,7 @@ func startReconcilers(zlog *zap.SugaredLogger, s *tsnet.Server, tsNamespace stri
 		operatorNamespace:      tsNamespace,
 		proxyImage:             image,
 		proxyPriorityClassName: priorityClassName,
+		runInRestrictedEnv:     runInRestrictedEnv,
 	}
 	err = builder.
 		ControllerManagedBy(mgr).


### PR DESCRIPTION
At the moment the k8s ingress/egress proxy cannot be created on GKE Autopilot (and probably similar restricted environments because):
- the embedded proxy manifest contains an init container that runs in privileged mode that is [not allowed on Autopilot](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-security#:~:text=Autopilot%20blocks%20privileged%20containers%20by%20default.%20Autopilot%20allows%20privileged%20containers%20from%20verified%20partners%20for%20purposes%20such%20as%20running%20security%20and%20monitoring%20tooling)
- the legacy iptables version, that we use requires NET_RAW cap that is by default dropped for pods in Autopilot
I didn't find why it needs it in docs, but
```
docker run --cap-drop=all --cap-add=net_admin tailscale/alpine-base:3.16 iptables -t nat -L
iptables v1.8.8 (legacy): can't initialize iptables table `nat': Permission denied (you must be root)
Perhaps iptables or your kernel needs to be upgraded.
```
vs
```
docker run --cap-drop=all --cap-add=net_raw --cap-add=net_admin tailscale/alpine-base:3.16 iptables -t nat -L
Chain PREROUTING (policy ACCEPT)
target     prot opt source               destination         
...
```

This PR makes two small changes:
- adds NET_RAW cap to the proxy manifest

- adds a new env var `RUN_IN_RESTRICTED_ENV` to the operator- if that is set then the privileged init container is dropped from manifests. This should be ok as forwarding is normally enabled, but if it wasn't the proxy would error [here](https://github.com/tailscale/tailscale/blob/v1.48.1/cmd/containerboot/main.go#L488)


I've tested that with this change the current versions of ingress and egress proxy can be created on GKE Autopilot.
There's a couple things that we'd need to document, [users would have to ensure that NET_ADMIN cap can be enabled](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-security#:~:text=NET_ADMIN%20for%20service%20meshes%20such%20as%20Istio%3A%20Specify%20%2D%2Dworkload%2Dpolicies%3Dallow%2Dnet%2Dadmin%20in%20your%20cluster%20creation%20command.%20Available%20on%20new%20and%20upgraded%20existing%20clusters%20running%20GKE%20version%201.27%20and%20later.), if this PR merges, I will update docs.

I spent a bit of time looking into using nftables/iptables-nft in the proxy (see https://github.com/tailscale/tailscale/tree/irbekrm/k8s-nftables), but it seems like this works in some kube setups, but not others and would potentially also affect tailscaled config, there is already a bunch of related issues, see i.e https://github.com/tailscale/tailscale/issues/5621 and linked issues- I think that needs a bit more looking into so this PR contains just the minimum change to get it to work on Autopilot.