### PR TITLE
release/dist/unixpkgs: demote deb iptables+iproute2 packages to recommended

### DIFF
--- a/release/dist/unixpkgs/pkgs.go
+++ b/release/dist/unixpkgs/pkgs.go
@@ -250,10 +250,25 @@ func (t *debTarget) Build(b *dist.Build) ([]string, error) {
 				PreRemove:   filepath.Join(repoDir, "release/deb/debian.prerm.sh"),
 				PostRemove:  filepath.Join(repoDir, "release/deb/debian.postrm.sh"),
 			},
-			Depends:    []string{"iptables", "iproute2"},
-			Recommends: []string{"tailscale-archive-keyring (>= 1.35.181)"},
-			Replaces:   []string{"tailscale-relay"},
-			Conflicts:  []string{"tailscale-relay"},
+			Depends: []string{},
+			Recommends: []string{
+				"tailscale-archive-keyring (>= 1.35.181)",
+				// iptables is often required but not strictly needed; see
+				// https://github.com/tailscale/tailscale/issues/9236.
+				// We want to let people be able to install without it
+				// or remove it after the fact if they want.
+				"iptables",
+				// The "ip" command isn't needed since 2021-11-01 in
+				// 408b0923a61972ed but kept as an option as of
+				// 2021-11-18 in d24ed3f68e35e802d531371.  See
+				// https://github.com/tailscale/tailscale/issues/391.
+				// We keep it recommended because it's usually
+				// installed anyway and it's useful for debugging. But
+				// we can live without it, so it's not Depends.
+				"iproute2",
+			},
+			Replaces:  []string{"tailscale-relay"},
+			Conflicts: []string{"tailscale-relay"},
 		},
 	})
 	pkg, err := nfpm.Get("deb")


### PR DESCRIPTION
Fixes #9236
