### PR TITLE
ipn/ipnlocal: add logging and locking to c2n /update

### DIFF
--- a/clientupdate/clientupdate.go
+++ b/clientupdate/clientupdate.go
@@ -128,8 +128,8 @@ func NewUpdater(args Arguments) (*Updater, error) {
 			return nil, err
 		}
 	}
-	if args.PkgsAddr == "" {
-		args.PkgsAddr = "https://pkgs.tailscale.com"
+	if up.Arguments.PkgsAddr == "" {
+		up.Arguments.PkgsAddr = "https://pkgs.tailscale.com"
 	}
 	return &up, nil
 }

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -240,6 +240,8 @@ type LocalBackend struct {
 	directFileRoot          string
 	directFileDoFinalRename bool // false on macOS, true on several NAS platforms
 	componentLogUntil       map[string]componentLogState
+	// c2nUpdateStatus is the status of c2n-triggered client update.
+	c2nUpdateStatus updateStatus
 
 	// ServeConfig fields. (also guarded by mu)
 	lastServeConfJSON   mem.RO              // last JSON that was parsed into serveConfig
@@ -266,6 +268,10 @@ type LocalBackend struct {
 	// at the moment that tkaSyncLock is taken).
 	tkaSyncLock sync.Mutex
 	clock       tstime.Clock
+}
+
+type updateStatus struct {
+	started bool
 }
 
 // clientGen is a func that creates a control plane client.

--- a/tailcfg/c2ntypes.go
+++ b/tailcfg/c2ntypes.go
@@ -39,7 +39,7 @@ type C2NSSHUsernamesResponse struct {
 // its Tailscale installation.
 type C2NUpdateResponse struct {
 	// Err is the error message, if any.
-	Err string
+	Err string `json:",omitempty"`
 
 	// Enabled indicates whether the user has opted in to updates triggered from
 	// control.


### PR DESCRIPTION
Log some progress info to make updates more debuggable. Also, track whether an active update is already started and return an error if a concurrent update is attempted.

Some planned future PRs:
* add JSON output to `tailscale update`
* use JSON output from `tailscale update` to provide a more detailed status of in-progress update (stage, download progress, etc)

Updates #6907