### PR TITLE
Add a knob to pass TS_DEBUG_FIREWALL_MODE from operator to container

### DIFF
--- a/cmd/k8s-operator/ingress.go
+++ b/cmd/k8s-operator/ingress.go
@@ -219,6 +219,7 @@ func (a *IngressReconciler) maybeProvision(ctx context.Context, logger *zap.Suga
 		ServeConfig:         sc,
 		Tags:                tags,
 		ChildResourceLabels: crl,
+		TSDebugFirewallMode: defaultEnv("TS_DEBUG_FIREWALL_MODE", ""),
 	}
 
 	if _, err := a.ssr.Provision(ctx, logger, sts); err != nil {

--- a/cmd/k8s-operator/sts.go
+++ b/cmd/k8s-operator/sts.go
@@ -66,6 +66,9 @@ type tailscaleSTSConfig struct {
 	// Tailscale IP of a Tailscale service we are setting up egress for
 	TailnetTargetIP string
 
+	// Knob to force the type of firewall used (iptables / nftables)
+	TSDebugFirewallMode string
+
 	Hostname string
 	Tags     []string // if empty, use defaultTags
 }
@@ -352,6 +355,13 @@ func (a *tailscaleSTSReconciler) reconcileSTS(ctx context.Context, logger *zap.S
 			},
 		})
 	}
+	if sts.TSDebugFirewallMode != "" {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  "TS_DEBUG_FIREWALL_MODE",
+			Value: sts.TSDebugFirewallMode,
+		})
+	}
+
 	ss.ObjectMeta = metav1.ObjectMeta{
 		Name:      headlessSvc.Name,
 		Namespace: a.operatorNamespace,


### PR DESCRIPTION
This allows forcing of selection of iptables or nftables allows
as specified here: https://tailscale.com/kb/1294/firewall-mode/

Fixes #9310

Signed-off-by: Craig Rodrigues <rodrigc@crodrigues.org>
