### PR TITLE
cmd/tailscale: funnel wip cleanup and additional test coverage

### DIFF
--- a/cmd/tailscale/cli/serve.go
+++ b/cmd/tailscale/cli/serve.go
@@ -167,7 +167,7 @@ type serveEnv struct {
 	https            string    // HTTP port
 	http             string    // HTTP port
 	tcp              string    // TCP port
-	tlsTerminatedTcp string    // a TLS terminated TCP port
+	tlsTerminatedTCP string    // a TLS terminated TCP port
 	subcmd           serveMode // subcommand
 
 	lc localServeClient // localClient interface, specific to serve

--- a/cmd/tailscale/cli/serve_test.go
+++ b/cmd/tailscale/cli/serve_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -900,11 +899,6 @@ func (lc *fakeLocalServeClient) WatchIPNBus(ctx context.Context, mask ipn.Notify
 
 func (lc *fakeLocalServeClient) IncrementCounter(ctx context.Context, name string, delta int) error {
 	return nil // unused in tests
-}
-
-func (lc *fakeLocalServeClient) StreamServe(ctx context.Context, req ipn.ServeStreamRequest) (io.ReadCloser, error) {
-	// TODO: testing :)
-	return nil, nil
 }
 
 // exactError returns an error checker that wants exactly the provided want error.

--- a/ipn/serve.go
+++ b/ipn/serve.go
@@ -85,27 +85,6 @@ type FunnelConn struct {
 	Src netip.AddrPort
 }
 
-// ServeStreamRequest defines the JSON request body
-// for the serve stream endpoint
-type ServeStreamRequest struct {
-	// HostPort is the DNS and port of the tailscale
-	// URL.
-	HostPort HostPort `json:",omitempty"`
-
-	// Source is the user's serve source
-	// as defined in the `tailscale serve`
-	// command such as http://127.0.0.1:3000
-	Source string `json:",omitempty"`
-
-	// MountPoint is the path prefix for
-	// the given HostPort.
-	MountPoint string `json:",omitempty"`
-
-	// Funnel indicates whether the request
-	// is a serve request or a funnel one.
-	Funnel bool `json:",omitempty"`
-}
-
 // WebServerConfig describes a web server's configuration.
 type WebServerConfig struct {
 	Handlers map[string]*HTTPHandler // mountPoint => handler


### PR DESCRIPTION
General cleanup and additional test coverage of WIP code.

* use enum for serveType
* cleanMountPoint rewritten into cleanURLPath as it only handles URL paths
* refactor and test expandProxyTargetDev

> **Note**
> Behind the `TAILSCALE_USE_WIP_CODE` flag

See the [parent issue](https://github.com/tailscale/tailscale/issues/8489) for more context.