### PR TITLE
all: use set.Set consistently instead of map[T]struct{}

### DIFF
--- a/health/health.go
+++ b/health/health.go
@@ -27,7 +27,7 @@ var (
 
 	sysErr    = map[Subsystem]error{}                   // error key => err (or nil for no error)
 	watchers  = set.HandleSet[func(Subsystem, error)]{} // opt func to run if error state changes
-	warnables = map[*Warnable]struct{}{}                // set of warnables
+	warnables = set.Set[*Warnable]{}
 	timer     *time.Timer
 
 	debugHandler = map[string]http.Handler{}
@@ -84,7 +84,7 @@ func NewWarnable(opts ...WarnableOpt) *Warnable {
 	}
 	mu.Lock()
 	defer mu.Unlock()
-	warnables[w] = struct{}{}
+	warnables.Add(w)
 	return w
 }
 

--- a/health/health_test.go
+++ b/health/health_test.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	"tailscale.com/util/set"
 )
 
 func TestAppendWarnableDebugFlags(t *testing.T) {
@@ -35,5 +37,5 @@ func TestAppendWarnableDebugFlags(t *testing.T) {
 func resetWarnables() {
 	mu.Lock()
 	defer mu.Unlock()
-	warnables = make(map[*Warnable]struct{})
+	warnables = set.Set[*Warnable]{}
 }

--- a/net/dns/nrpt_windows.go
+++ b/net/dns/nrpt_windows.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/sys/windows/registry"
 	"tailscale.com/types/logger"
 	"tailscale.com/util/dnsname"
+	"tailscale.com/util/set"
 	"tailscale.com/util/winutil"
 )
 
@@ -158,14 +159,14 @@ func (db *nrptRuleDatabase) detectWriteAsGP() {
 	}
 
 	// Add *all* rules from the GP subkey into a set.
-	gpSubkeyMap := make(map[string]struct{}, len(gpSubkeyNames))
+	gpSubkeyMap := make(set.Set[string], len(gpSubkeyNames))
 	for _, gpSubkey := range gpSubkeyNames {
-		gpSubkeyMap[strings.ToUpper(gpSubkey)] = struct{}{}
+		gpSubkeyMap.Add(strings.ToUpper(gpSubkey))
 	}
 
 	// Remove *our* rules from the set.
 	for _, ourRuleID := range db.ruleIDs {
-		delete(gpSubkeyMap, strings.ToUpper(ourRuleID))
+		gpSubkeyMap.Delete(strings.ToUpper(ourRuleID))
 	}
 
 	// Any leftover rules do not belong to us. When group policy is being used

--- a/net/tstun/wrap.go
+++ b/net/tstun/wrap.go
@@ -35,6 +35,7 @@ import (
 	"tailscale.com/types/views"
 	"tailscale.com/util/clientmetric"
 	"tailscale.com/util/mak"
+	"tailscale.com/util/set"
 	"tailscale.com/wgengine/capture"
 	"tailscale.com/wgengine/filter"
 	"tailscale.com/wgengine/wgcfg"
@@ -589,7 +590,7 @@ func natConfigFromWGConfig(wcfg *wgcfg.Config) *natV4Config {
 	var (
 		rt           table.RoutingTableBuilder
 		dstMasqAddrs map[key.NodePublic]netip.Addr
-		listenAddrs  map[netip.Addr]struct{}
+		listenAddrs  set.Set[netip.Addr]
 	)
 
 	// When using an exit node that requires masquerading, we need to

--- a/util/set/set.go
+++ b/util/set/set.go
@@ -10,6 +10,9 @@ type Set[T comparable] map[T]struct{}
 // Add adds e to the set.
 func (s Set[T]) Add(e T) { s[e] = struct{}{} }
 
+// Delete removes e from the set.
+func (s Set[T]) Delete(e T) { delete(s, e) }
+
 // Contains reports whether s contains e.
 func (s Set[T]) Contains(e T) bool {
 	_, ok := s[e]

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -58,6 +58,7 @@ import (
 	"tailscale.com/types/ptr"
 	"tailscale.com/util/cibuild"
 	"tailscale.com/util/racebuild"
+	"tailscale.com/util/set"
 	"tailscale.com/wgengine/filter"
 	"tailscale.com/wgengine/wgcfg"
 	"tailscale.com/wgengine/wgcfg/nmcfg"
@@ -306,9 +307,9 @@ func meshStacks(logf logger.Logf, mutateNetmap func(idx int, nm *netmap.NetworkM
 		for i, m := range ms {
 			nm := buildNetmapLocked(i)
 			m.conn.SetNetworkMap(nm)
-			peerSet := make(map[key.NodePublic]struct{}, len(nm.Peers))
+			peerSet := make(set.Set[key.NodePublic], len(nm.Peers))
 			for _, peer := range nm.Peers {
-				peerSet[peer.Key()] = struct{}{}
+				peerSet.Add(peer.Key())
 			}
 			m.conn.UpdatePeers(peerSet)
 			wg, err := nmcfg.WGCfg(nm, logf, netmap.AllowSingleHosts, "")

--- a/wgengine/router/router_openbsd.go
+++ b/wgengine/router/router_openbsd.go
@@ -14,6 +14,7 @@ import (
 	"go4.org/netipx"
 	"tailscale.com/net/netmon"
 	"tailscale.com/types/logger"
+	"tailscale.com/util/set"
 )
 
 // For now this router only supports the WireGuard userspace implementation.
@@ -26,7 +27,7 @@ type openbsdRouter struct {
 	tunname string
 	local4  netip.Prefix
 	local6  netip.Prefix
-	routes  map[netip.Prefix]struct{}
+	routes  set.Set[netip.Prefix]
 }
 
 func newUserspaceRouter(logf logger.Logf, tundev tun.Device, netMon *netmon.Monitor) (Router, error) {
@@ -173,9 +174,9 @@ func (r *openbsdRouter) Set(cfg *Config) error {
 		}
 	}
 
-	newRoutes := make(map[netip.Prefix]struct{})
+	newRoutes := set.Set[netip.Prefix]{}
 	for _, route := range cfg.Routes {
-		newRoutes[route] = struct{}{}
+		newRoutes.Add(route)
 	}
 	for route := range r.routes {
 		if _, keep := newRoutes[route]; !keep {

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -44,6 +44,7 @@ import (
 	"tailscale.com/util/clientmetric"
 	"tailscale.com/util/deephash"
 	"tailscale.com/util/mak"
+	"tailscale.com/util/set"
 	"tailscale.com/wgengine/capture"
 	"tailscale.com/wgengine/filter"
 	"tailscale.com/wgengine/magicsock"
@@ -782,12 +783,12 @@ func (e *userspaceEngine) Reconfig(cfg *wgcfg.Config, routerCfg *router.Config, 
 	e.tundev.SetWGConfig(cfg)
 	e.lastDNSConfig = dnsCfg
 
-	peerSet := make(map[key.NodePublic]struct{}, len(cfg.Peers))
+	peerSet := make(set.Set[key.NodePublic], len(cfg.Peers))
 	e.mu.Lock()
 	e.peerSequence = e.peerSequence[:0]
 	for _, p := range cfg.Peers {
 		e.peerSequence = append(e.peerSequence, p.PublicKey)
-		peerSet[p.PublicKey] = struct{}{}
+		peerSet.Add(p.PublicKey)
 	}
 	nm := e.netMap
 	e.mu.Unlock()


### PR DESCRIPTION
I didn't clean up the more idiomatic map[T]bool with true values, at
least yet.  I just converted the relatively awkward struct{}-valued
maps.

Updates #cleanup
