### PR TITLE
net/ping: fix ICMP echo code field to 0

### DIFF
--- a/net/ping/ping.go
+++ b/net/ping/ping.go
@@ -303,7 +303,7 @@ func (p *Pinger) Send(ctx context.Context, dest net.Addr, data []byte) (time.Dur
 
 	m := icmp.Message{
 		Type: icmpType,
-		Code: icmpType.Protocol(),
+		Code: 0,
 		Body: &icmp.Echo{
 			ID:   int(p.id),
 			Seq:  int(seq),


### PR DESCRIPTION
The code was trying to pass the ICMP protocol number here (1), which is not a valid code. Many servers will not respond to echo messages with codes other than 0.