### PR TITLE
wgengine/magicsock: make peerMap also keyed by NodeID

### DIFF
--- a/envknob/envknob.go
+++ b/envknob/envknob.go
@@ -389,11 +389,23 @@ func CanTaildrop() bool { return !Bool("TS_DISABLE_TAILDROP") }
 // SSHPolicyFile returns the path, if any, to the SSHPolicy JSON file for development.
 func SSHPolicyFile() string { return String("TS_DEBUG_SSH_POLICY_FILE") }
 
-// SSHIgnoreTailnetPolicy is whether to ignore the Tailnet SSH policy for development.
+// SSHIgnoreTailnetPolicy reports whether to ignore the Tailnet SSH policy for development.
 func SSHIgnoreTailnetPolicy() bool { return Bool("TS_DEBUG_SSH_IGNORE_TAILNET_POLICY") }
 
-// TKASkipSignatureCheck is whether to skip node-key signature checking for development.
+// TKASkipSignatureCheck reports whether to skip node-key signature checking for development.
 func TKASkipSignatureCheck() bool { return Bool("TS_UNSAFE_SKIP_NKS_VERIFICATION") }
+
+// CrashOnUnexpected reports whether the Tailscale client should panic
+// on unexpected conditions. If TS_DEBUG_CRASH_ON_UNEXPECTED is set, that's
+// used. Otherwise the default value is true for unstable builds.
+func CrashOnUnexpected() bool {
+	if v, ok := crashOnUnexpected().Get(); ok {
+		return v
+	}
+	return version.IsUnstableBuild()
+}
+
+var crashOnUnexpected = RegisterOptBool("TS_DEBUG_CRASH_ON_UNEXPECTED")
 
 // NoLogsNoSupport reports whether the client's opted out of log uploads and
 // technical support.

--- a/wgengine/magicsock/debugknobs.go
+++ b/wgengine/magicsock/debugknobs.go
@@ -15,6 +15,8 @@ var (
 	// debugDisco prints verbose logs of active discovery events as
 	// they happen.
 	debugDisco = envknob.RegisterBool("TS_DEBUG_DISCO")
+	// debugPeerMap prints verbose logs of changes to the peermap.
+	debugPeerMap = envknob.RegisterBool("TS_DEBUG_MAGICSOCK_PEERMAP")
 	// debugOmitLocalAddresses removes all local interface addresses
 	// from magicsock's discovered local endpoints. Used in some tests.
 	debugOmitLocalAddresses = envknob.RegisterBool("TS_DEBUG_OMIT_LOCAL_ADDRS")

--- a/wgengine/magicsock/debugknobs_stubs.go
+++ b/wgengine/magicsock/debugknobs_stubs.go
@@ -26,3 +26,4 @@ func debugUseDerpRouteEnv() string     { return "" }
 func debugUseDerpRoute() opt.Bool      { return "" }
 func debugRingBufferMaxSizeBytes() int { return 0 }
 func inTest() bool                     { return false }
+func debugPeerMap() bool               { return false }

--- a/wgengine/magicsock/endpoint.go
+++ b/wgengine/magicsock/endpoint.go
@@ -49,6 +49,7 @@ type endpoint struct {
 
 	// These fields are initialized once and never modified.
 	c            *Conn
+	nodeID       tailcfg.NodeID
 	publicKey    key.NodePublic // peer public key (for WireGuard + DERP)
 	publicKeyHex string         // cached output of publicKey.UntypedHexString
 	fakeWGAddr   netip.AddrPort // the UDP address we tell wireguard-go we're using

--- a/wgengine/userspace_test.go
+++ b/wgengine/userspace_test.go
@@ -109,6 +109,7 @@ func TestUserspaceEngineReconfig(t *testing.T) {
 		nm := &netmap.NetworkMap{
 			Peers: nodeViews([]*tailcfg.Node{
 				{
+					ID:  1,
 					Key: nkFromHex(nodeHex),
 				},
 			}),


### PR DESCRIPTION
In prep for incremental netmap update plumbing (#1909), make peerMap
also keyed by NodeID, as all the netmap node mutations passed around
later will be keyed by NodeID.

In the process, also:

* add envknob.InDevMode, as a signal that we can panic more aggressively
  in unexpected cases.
* pull two moderately large blocks of code in Conn.SetNetworkMap out
  into their own methods
* convert a few more sets from maps to set.Set

Updates #1909
