### PR TITLE
cmd/testwrapper/flakytest: don't spam stderr in Mark when not under wrapper

### DIFF
--- a/cmd/testwrapper/flakytest/flakytest.go
+++ b/cmd/testwrapper/flakytest/flakytest.go
@@ -19,7 +19,8 @@ import (
 const FlakyTestLogMessage = "flakytest: this is a known flaky test"
 
 // FlakeAttemptEnv is an environment variable that is set by cmd/testwrapper
-// when a flaky test is retried. It contains the attempt number, starting at 1.
+// when a flaky test is being (re)tried. It contains the attempt number,
+// starting at 1.
 const FlakeAttemptEnv = "TS_TESTWRAPPER_ATTEMPT"
 
 var issueRegexp = regexp.MustCompile(`\Ahttps://github\.com/tailscale/[a-zA-Z0-9_.-]+/issues/\d+\z`)
@@ -33,7 +34,11 @@ func Mark(t testing.TB, issue string) {
 	if !issueRegexp.MatchString(issue) {
 		t.Fatalf("bad issue format: %q", issue)
 	}
-
-	fmt.Fprintln(os.Stderr, FlakyTestLogMessage) // sentinel value for testwrapper
+	if _, ok := os.LookupEnv(FlakeAttemptEnv); ok {
+		// We're being run under cmd/testwrapper so send our sentinel message
+		// to stderr. (We avoid doing this when the env is absent to avoid
+		// spamming people running tests without the wrapper)
+		fmt.Fprintln(os.Stderr, FlakyTestLogMessage)
+	}
 	t.Logf("flakytest: issue tracking this flaky test: %s", issue)
 }


### PR DESCRIPTION
If the user's running "go test" by hand, no need to spam stderr with the sentinel marker. It already calls t.Logf (which only gets output on actual failure, or verbose mode) which is enough to tell users it's known flaky. Stderr OTOH always prints out and is distracting to manual "go test" users.

Updates #cleanup
