### PR TITLE
control/controlknobs, all: add plumbed Knobs type, not global variables

### DIFF
--- a/cmd/tailscale/cli/netcheck.go
+++ b/cmd/tailscale/cli/netcheck.go
@@ -53,7 +53,7 @@ func runNetcheck(ctx context.Context, args []string) error {
 		return err
 	}
 	c := &netcheck.Client{
-		PortMapper:  portmapper.NewClient(logf, netMon, nil, nil),
+		PortMapper:  portmapper.NewClient(logf, netMon, nil, nil, nil),
 		UseDNSCache: false, // always resolve, don't cache
 	}
 	if netcheckArgs.verbose {

--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -607,6 +607,7 @@ func tryEngine(logf logger.Logf, sys *tsd.System, name string) (onlyNetstack boo
 		NetMon:       sys.NetMon.Get(),
 		Dialer:       sys.Dialer.Get(),
 		SetSubsystem: sys.Set,
+		ControlKnobs: sys.ControlKnobs(),
 	}
 
 	onlyNetstack = name == "userspace-networking"

--- a/cmd/tsconnect/wasm/wasm_js.go
+++ b/cmd/tsconnect/wasm/wasm_js.go
@@ -102,6 +102,7 @@ func newIPN(jsConfig js.Value) map[string]any {
 	eng, err := wgengine.NewUserspaceEngine(logf, wgengine.Config{
 		Dialer:       dialer,
 		SetSubsystem: sys.Set,
+		ControlKnobs: sys.ControlKnobs(),
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/control/controlclient/map_test.go
+++ b/control/controlclient/map_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"go4.org/mem"
+	"tailscale.com/control/controlknobs"
 	"tailscale.com/tailcfg"
 	"tailscale.com/tstest"
 	"tailscale.com/tstime"
@@ -392,7 +393,7 @@ func formatNodes(nodes []*tailcfg.Node) string {
 }
 
 func newTestMapSession(t testing.TB, nu NetmapUpdater) *mapSession {
-	ms := newMapSession(key.NewNode(), nu)
+	ms := newMapSession(key.NewNode(), nu, new(controlknobs.Knobs))
 	t.Cleanup(ms.Close)
 	ms.logf = t.Logf
 	return ms

--- a/control/controlknobs/controlknobs.go
+++ b/control/controlknobs/controlknobs.go
@@ -8,22 +8,30 @@ package controlknobs
 import (
 	"sync/atomic"
 
-	"tailscale.com/envknob"
+	"tailscale.com/syncs"
+	"tailscale.com/types/opt"
 )
 
-// disableUPnP indicates whether to attempt UPnP mapping.
-var disableUPnPControl atomic.Bool
+// Knobs is the set of knobs that the control plane's coordination server can
+// adjust at runtime.
+type Knobs struct {
+	// DisableUPnP indicates whether to attempt UPnP mapping.
+	DisableUPnP atomic.Bool
 
-var disableUPnpEnv = envknob.RegisterBool("TS_DISABLE_UPNP")
+	// DisableDRPO is whether control says to disable the
+	// DERP route optimization (Issue 150).
+	DisableDRPO atomic.Bool
 
-// DisableUPnP reports the last reported value from control
-// whether UPnP portmapping should be disabled.
-func DisableUPnP() bool {
-	return disableUPnPControl.Load() || disableUPnpEnv()
-}
+	// KeepFullWGConfig is whether we should disable the lazy wireguard
+	// programming and instead give WireGuard the full netmap always, even for
+	// idle peers.
+	KeepFullWGConfig atomic.Bool
 
-// SetDisableUPnP sets whether control says that UPnP should be
-// disabled.
-func SetDisableUPnP(v bool) {
-	disableUPnPControl.Store(v)
+	// RandomizeClientPort is whether control says we should randomize
+	// the client port.
+	RandomizeClientPort atomic.Bool
+
+	// OneCGNAT is whether the the node should make one big CGNAT route
+	// in the OS rather than one /32 per peer.
+	OneCGNAT syncs.AtomicValue[opt.Bool]
 }

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -694,7 +694,7 @@ func (h *Handler) serveDebugPortmap(w http.ResponseWriter, r *http.Request) {
 	done := make(chan bool, 1)
 
 	var c *portmapper.Client
-	c = portmapper.NewClient(logger.WithPrefix(logf, "portmapper: "), h.netMon, debugKnobs, func() {
+	c = portmapper.NewClient(logger.WithPrefix(logf, "portmapper: "), h.netMon, debugKnobs, h.b.ControlKnobs(), func() {
 		logf("portmapping changed.")
 		logf("have mapping: %v", c.HaveMapping())
 

--- a/net/portmapper/igd_test.go
+++ b/net/portmapper/igd_test.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"tailscale.com/control/controlknobs"
 	"tailscale.com/net/netaddr"
 	"tailscale.com/types/logger"
 )
@@ -249,7 +250,7 @@ func (d *TestIGD) handlePCPQuery(pkt []byte, src netip.AddrPort) {
 
 func newTestClient(t *testing.T, igd *TestIGD) *Client {
 	var c *Client
-	c = NewClient(t.Logf, nil, nil, func() {
+	c = NewClient(t.Logf, nil, nil, new(controlknobs.Knobs), func() {
 		t.Logf("port map changed")
 		t.Logf("have mapping: %v", c.HaveMapping())
 	})

--- a/net/portmapper/portmapper.go
+++ b/net/portmapper/portmapper.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"go4.org/mem"
+	"tailscale.com/control/controlknobs"
 	"tailscale.com/net/interfaces"
 	"tailscale.com/net/netaddr"
 	"tailscale.com/net/neterror"
@@ -66,6 +67,7 @@ const trustServiceStillAvailableDuration = 10 * time.Minute
 type Client struct {
 	logf         logger.Logf
 	netMon       *netmon.Monitor // optional; nil means interfaces will be looked up on-demand
+	controlKnobs *controlknobs.Knobs
 	ipAndGateway func() (gw, ip netip.Addr, ok bool)
 	onChange     func() // or nil
 	debug        DebugKnobs
@@ -166,15 +168,19 @@ func (m *pmpMapping) Release(ctx context.Context) {
 // The debug argument allows configuring the behaviour of the portmapper for
 // debugging; if nil, a sensible set of defaults will be used.
 //
-// The optional onChange argument specifies a func to run in a new
-// goroutine whenever the port mapping status has changed. If nil,
-// it doesn't make a callback.
-func NewClient(logf logger.Logf, netMon *netmon.Monitor, debug *DebugKnobs, onChange func()) *Client {
+// The controlKnobs, if non-nil, specifies the control knobs from the control
+// plane that might disable portmapping.
+//
+// The optional onChange argument specifies a func to run in a new goroutine
+// whenever the port mapping status has changed. If nil, it doesn't make a
+// callback.
+func NewClient(logf logger.Logf, netMon *netmon.Monitor, debug *DebugKnobs, controlKnobs *controlknobs.Knobs, onChange func()) *Client {
 	ret := &Client{
 		logf:         logf,
 		netMon:       netMon,
 		ipAndGateway: interfaces.LikelyHomeRouterIP,
 		onChange:     onChange,
+		controlKnobs: controlKnobs,
 	}
 	if debug != nil {
 		ret.debug = *debug

--- a/net/portmapper/portmapper_test.go
+++ b/net/portmapper/portmapper_test.go
@@ -10,13 +10,15 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	"tailscale.com/control/controlknobs"
 )
 
 func TestCreateOrGetMapping(t *testing.T) {
 	if v, _ := strconv.ParseBool(os.Getenv("HIT_NETWORK")); !v {
 		t.Skip("skipping test without HIT_NETWORK=1")
 	}
-	c := NewClient(t.Logf, nil, nil, nil)
+	c := NewClient(t.Logf, nil, nil, new(controlknobs.Knobs), nil)
 	defer c.Close()
 	c.SetLocalPort(1234)
 	for i := 0; i < 2; i++ {
@@ -32,7 +34,7 @@ func TestClientProbe(t *testing.T) {
 	if v, _ := strconv.ParseBool(os.Getenv("HIT_NETWORK")); !v {
 		t.Skip("skipping test without HIT_NETWORK=1")
 	}
-	c := NewClient(t.Logf, nil, nil, nil)
+	c := NewClient(t.Logf, nil, nil, new(controlknobs.Knobs), nil)
 	defer c.Close()
 	for i := 0; i < 3; i++ {
 		if i > 0 {
@@ -47,7 +49,7 @@ func TestClientProbeThenMap(t *testing.T) {
 	if v, _ := strconv.ParseBool(os.Getenv("HIT_NETWORK")); !v {
 		t.Skip("skipping test without HIT_NETWORK=1")
 	}
-	c := NewClient(t.Logf, nil, nil, nil)
+	c := NewClient(t.Logf, nil, nil, new(controlknobs.Knobs), nil)
 	defer c.Close()
 	c.SetLocalPort(1234)
 	res, err := c.Probe(context.Background())

--- a/tsd/tsd.go
+++ b/tsd/tsd.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"tailscale.com/control/controlknobs"
 	"tailscale.com/ipn"
 	"tailscale.com/net/dns"
 	"tailscale.com/net/netmon"
@@ -42,6 +43,7 @@ type System struct {
 	Router         SubSystem[router.Router]
 	Tun            SubSystem[*tstun.Wrapper]
 	StateStore     SubSystem[ipn.StateStore]
+	controlKnobs   controlknobs.Knobs
 }
 
 // Set is a convenience method to set a subsystem value.
@@ -83,6 +85,11 @@ func (s *System) IsNetstackRouter() bool {
 func (s *System) IsNetstack() bool {
 	name, _ := s.Tun.Get().Name()
 	return name == tstun.FakeTUNName
+}
+
+// ControlKnobs returns the control knobs for this node.
+func (s *System) ControlKnobs() *controlknobs.Knobs {
+	return &s.controlKnobs
 }
 
 // SubSystem represents some subsystem of the Tailscale node daemon.

--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -501,6 +501,7 @@ func (s *Server) start() (reterr error) {
 		NetMon:       s.netMon,
 		Dialer:       s.dialer,
 		SetSubsystem: sys.Set,
+		ControlKnobs: sys.ControlKnobs(),
 	})
 	if err != nil {
 		return err

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
 
+	"tailscale.com/control/controlknobs"
 	"tailscale.com/disco"
 	"tailscale.com/envknob"
 	"tailscale.com/health"
@@ -86,6 +87,7 @@ type Conn struct {
 	testOnlyPacketListener nettype.PacketListener
 	noteRecvActivity       func(key.NodePublic) // or nil, see Options.NoteRecvActivity
 	netMon                 *netmon.Monitor      // or nil
+	controlKnobs           *controlknobs.Knobs  // or nil
 
 	// ================================================================
 	// No locking required to access these fields, either because
@@ -339,6 +341,10 @@ type Options struct {
 	// NetMon is the network monitor to use.
 	// With one, the portmapper won't be used.
 	NetMon *netmon.Monitor
+
+	// ControlKnobs are the set of control knobs to use.
+	// If nil, they're ignored and not updated.
+	ControlKnobs *controlknobs.Knobs
 }
 
 func (o *Options) logf() logger.Logf {
@@ -399,13 +405,14 @@ func newConn() *Conn {
 func NewConn(opts Options) (*Conn, error) {
 	c := newConn()
 	c.port.Store(uint32(opts.Port))
+	c.controlKnobs = opts.ControlKnobs
 	c.logf = opts.logf()
 	c.epFunc = opts.endpointsFunc()
 	c.derpActiveFunc = opts.derpActiveFunc()
 	c.idleFunc = opts.IdleFunc
 	c.testOnlyPacketListener = opts.TestOnlyPacketListener
 	c.noteRecvActivity = opts.NoteRecvActivity
-	c.portMapper = portmapper.NewClient(logger.WithPrefix(c.logf, "portmapper: "), opts.NetMon, nil, c.onPortMapChanged)
+	c.portMapper = portmapper.NewClient(logger.WithPrefix(c.logf, "portmapper: "), opts.NetMon, nil, opts.ControlKnobs, c.onPortMapChanged)
 	if opts.NetMon != nil {
 		c.portMapper.SetGatewayLookupFunc(opts.NetMon.GatewayAndSelfIP)
 	}


### PR DESCRIPTION
Previously two tsnet nodes in the same process couldn't have disjoint
sets of controlknob settings from control as both would overwrite each
other's global variables.

This plumbs a new controlknobs.Knobs type around everywhere and hangs
the knobs sent by control on that instead.

Updates #9351
