### PR TITLE
net/dns/publicdns: update Mullvad DoH server list

### DIFF
--- a/net/dns/publicdns/publicdns.go
+++ b/net/dns/publicdns/publicdns.go
@@ -182,14 +182,22 @@ func populate() {
 	addDoH("2620:fe::fe:10", "https://dns10.quad9.net/dns-query")
 
 	// Mullvad
-	addDoH("194.242.2.2", "https://doh.mullvad.net/dns-query")
-	addDoH("193.19.108.2", "https://doh.mullvad.net/dns-query")
-	addDoH("2a07:e340::2", "https://doh.mullvad.net/dns-query")
-
-	// Mullvad -Ads
-	addDoH("194.242.2.3", "https://adblock.doh.mullvad.net/dns-query")
-	addDoH("193.19.108.3", "https://adblock.doh.mullvad.net/dns-query")
-	addDoH("2a07:e340::3", "https://adblock.doh.mullvad.net/dns-query")
+	// See https://mullvad.net/en/help/dns-over-https-and-dns-over-tls/
+	// Mullvad (default)
+	addDoH("194.242.2.2", "https://dns.mullvad.net/dns-query")
+	addDoH("2a07:e340::2", "https://dns.mullvad.net/dns-query")
+	// Mullvad (adblock)
+	addDoH("194.242.2.3", "https://adblock.dns.mullvad.net/dns-query")
+	addDoH("2a07:e340::3", "https://adblock.dns.mullvad.net/dns-query")
+	// Mullvad (base)
+	addDoH("194.242.2.4", "https://base.dns.mullvad.net/dns-query")
+	addDoH("2a07:e340::4", "https://base.dns.mullvad.net/dns-query")
+	// Mullvad (extended)
+	addDoH("194.242.2.5", "https://extended.dns.mullvad.net/dns-query")
+	addDoH("2a07:e340::5", "https://extended.dns.mullvad.net/dns-query")
+	// Mullvad (all)
+	addDoH("194.242.2.9", "https://all.dns.mullvad.net/dns-query")
+	addDoH("2a07:e340::9", "https://all.dns.mullvad.net/dns-query")
 
 	// Wikimedia
 	addDoH(wikimediaDNSv4, "https://wikimedia-dns.org/dns-query")


### PR DESCRIPTION
The following IPs are not used anymore: 193.19.108.2 and 193.19.108.3.
All of the servers are now named consistently under dns.mullvad.net.
Several new servers were added.

https://mullvad.net/en/help/dns-over-https-and-dns-over-tls/

Updates #5416
Updates #9345
