### PR TITLE
wgengine{,/netstack}: remove AddNetworkMapCallback from Engine interface

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -496,6 +496,7 @@ func getLocalBackend(ctx context.Context, logf logger.Logf, logID logid.PublicID
 	if err != nil {
 		return nil, fmt.Errorf("newNetstack: %w", err)
 	}
+	sys.Set(ns)
 	ns.ProcessLocalIPs = onlyNetstack
 	ns.ProcessSubnets = onlyNetstack || handleSubnetsInNetstack()
 

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -4077,6 +4077,9 @@ func hasCapability(nm *netmap.NetworkMap, cap string) bool {
 // Tailscale is turned off.
 func (b *LocalBackend) setNetMapLocked(nm *netmap.NetworkMap) {
 	b.dialer.SetNetMap(nm)
+	if ns, ok := b.sys.Netstack.GetOK(); ok {
+		ns.UpdateNetstackIPs(nm)
+	}
 	var login string
 	if nm != nil {
 		login = cmpx.Or(nm.UserProfiles[nm.User()].LoginName, "<missing-profile>")

--- a/tsd/tsd.go
+++ b/tsd/tsd.go
@@ -27,6 +27,7 @@ import (
 	"tailscale.com/net/netmon"
 	"tailscale.com/net/tsdial"
 	"tailscale.com/net/tstun"
+	"tailscale.com/types/netmap"
 	"tailscale.com/wgengine"
 	"tailscale.com/wgengine/magicsock"
 	"tailscale.com/wgengine/router"
@@ -43,7 +44,15 @@ type System struct {
 	Router         SubSystem[router.Router]
 	Tun            SubSystem[*tstun.Wrapper]
 	StateStore     SubSystem[ipn.StateStore]
+	Netstack       SubSystem[NetstackImpl] // actually a *netstack.Impl
 	controlKnobs   controlknobs.Knobs
+}
+
+// NetstackImpl is the interface that *netstack.Impl implements.
+// It's an interface for circular dependency reasons: netstack.Impl
+// references LocalBackend, and LocalBackend has a tsd.System.
+type NetstackImpl interface {
+	UpdateNetstackIPs(*netmap.NetworkMap)
 }
 
 // Set is a convenience method to set a subsystem value.
@@ -67,6 +76,8 @@ func (s *System) Set(v any) {
 		s.MagicSock.Set(v)
 	case ipn.StateStore:
 		s.StateStore.Set(v)
+	case NetstackImpl:
+		s.Netstack.Set(v)
 	default:
 		panic(fmt.Sprintf("unknown type %T", v))
 	}

--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -513,6 +513,7 @@ func (s *Server) start() (reterr error) {
 	if err != nil {
 		return fmt.Errorf("netstack.Create: %w", err)
 	}
+	sys.Set(ns)
 	ns.ProcessLocalIPs = true
 	ns.GetTCPHandlerForFlow = s.getTCPHandlerForFlow
 	ns.GetUDPHandlerForFlow = s.getUDPHandlerForFlow

--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -41,6 +41,7 @@ import (
 	"tailscale.com/tstest/integration/testcontrol"
 	"tailscale.com/types/key"
 	"tailscale.com/types/logger"
+	"tailscale.com/util/rands"
 )
 
 var (
@@ -876,7 +877,9 @@ func newTestNode(t *testing.T, env *testEnv) *testNode {
 	dir := t.TempDir()
 	sockFile := filepath.Join(dir, "tailscale.sock")
 	if len(sockFile) >= 104 {
-		t.Fatalf("sockFile path %q (len %v) is too long, must be < 104", sockFile, len(sockFile))
+		// Maximum length for a unix socket on darwin. Try something else.
+		sockFile = filepath.Join(os.TempDir(), rands.HexString(8)+".sock")
+		t.Cleanup(func() { os.Remove(sockFile) })
 	}
 	return &testNode{
 		env:       env,

--- a/wgengine/watchdog.go
+++ b/wgengine/watchdog.go
@@ -149,11 +149,6 @@ func (e *watchdogEngine) SetDERPMap(m *tailcfg.DERPMap) {
 func (e *watchdogEngine) SetNetworkMap(nm *netmap.NetworkMap) {
 	e.watchdog("SetNetworkMap", func() { e.wrap.SetNetworkMap(nm) })
 }
-func (e *watchdogEngine) AddNetworkMapCallback(callback NetworkMapCallback) func() {
-	var fn func()
-	e.watchdog("AddNetworkMapCallback", func() { fn = e.wrap.AddNetworkMapCallback(callback) })
-	return func() { e.watchdog("RemoveNetworkMapCallback", fn) }
-}
 func (e *watchdogEngine) DiscoPublicKey() (k key.DiscoPublic) {
 	e.watchdog("DiscoPublicKey", func() { k = e.wrap.DiscoPublicKey() })
 	return k

--- a/wgengine/wgengine.go
+++ b/wgengine/wgengine.go
@@ -125,12 +125,6 @@ type Engine interface {
 	// The network map should only be read from.
 	SetNetworkMap(*netmap.NetworkMap)
 
-	// AddNetworkMapCallback adds a function to a list of callbacks
-	// that are called when the network map updates. It returns a
-	// function that when called would remove the function from the
-	// list of callbacks.
-	AddNetworkMapCallback(NetworkMapCallback) (removeCallback func())
-
 	// SetNetInfoCallback sets the function to call when a
 	// new NetInfo summary is available.
 	SetNetInfoCallback(NetInfoCallback)


### PR DESCRIPTION
It had exactly one user: netstack. Just have LocalBackend notify netstack when here's a new netmap instead, simplifying the bloated Engine interface that has grown a bunch of non-Engine-y things. (plenty of rando stuff remains after this, but it's a start)

Updates #cleanup
