### PR TITLE
cmd/tsconnect/wasm: register netstack.Impl with tsd.System

### DIFF
--- a/cmd/tsconnect/wasm/wasm_js.go
+++ b/cmd/tsconnect/wasm/wasm_js.go
@@ -113,6 +113,7 @@ func newIPN(jsConfig js.Value) map[string]any {
 	if err != nil {
 		log.Fatalf("netstack.Create: %v", err)
 	}
+	sys.Set(ns)
 	ns.ProcessLocalIPs = true
 	ns.ProcessSubnets = true
 


### PR DESCRIPTION
I missed this in 343c0f1031a and I guess we don't have integration
tests for wasm. But it compiled! :)

Updates #fixup to a #cleanup
