### PR TITLE
wgengine: remove SetNetInfoCallback method from Engine

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1552,7 +1552,11 @@ func (b *LocalBackend) Start(opts ipn.Options) error {
 	}
 	cc.SetTKAHead(tkaHead)
 
-	b.e.SetNetInfoCallback(b.setNetInfo)
+	if mc, err := b.magicConn(); err != nil {
+		return fmt.Errorf("looking up magicsock: %w", err)
+	} else {
+		mc.SetNetInfoCallback(b.setNetInfo)
+	}
 
 	blid := b.backendLogID.String()
 	b.logf("Backend: logs: be:%v fe:%v", blid, opts.FrontendLogID)

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -657,7 +657,7 @@ func (c *Conn) updateNetInfo(ctx context.Context) (*netcheck.Report, error) {
 	return report, nil
 }
 
-// callNetInfoCallback calls the NetInfo callback (if previously
+// callNetInfoCallback calls the callback (if previously
 // registered with SetNetInfoCallback) if ni has substantially changed
 // since the last state.
 //
@@ -691,6 +691,13 @@ func (c *Conn) addValidDiscoPathForTest(nodeKey key.NodePublic, addr netip.AddrP
 	c.peerMap.setNodeKeyForIPPort(addr, nodeKey)
 }
 
+// SetNetInfoCallback sets the func to be called whenever the network conditions
+// change.
+//
+// At most one func can be registered; the most recent one replaces any previous
+// registration.
+//
+// This is called by LocalBackend.
 func (c *Conn) SetNetInfoCallback(fn func(*tailcfg.NetInfo)) {
 	if fn == nil {
 		panic("nil NetInfoCallback")

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -1157,10 +1157,6 @@ func (e *userspaceEngine) linkChange(delta *netmon.ChangeDelta) {
 	e.magicConn.ReSTUN(why)
 }
 
-func (e *userspaceEngine) SetNetInfoCallback(cb NetInfoCallback) {
-	e.magicConn.SetNetInfoCallback(cb)
-}
-
 func (e *userspaceEngine) SetDERPMap(dm *tailcfg.DERPMap) {
 	e.magicConn.SetDERPMap(dm)
 }

--- a/wgengine/watchdog.go
+++ b/wgengine/watchdog.go
@@ -134,9 +134,6 @@ func (e *watchdogEngine) SetStatusCallback(cb StatusCallback) {
 func (e *watchdogEngine) UpdateStatus(sb *ipnstate.StatusBuilder) {
 	e.watchdog("UpdateStatus", func() { e.wrap.UpdateStatus(sb) })
 }
-func (e *watchdogEngine) SetNetInfoCallback(cb NetInfoCallback) {
-	e.watchdog("SetNetInfoCallback", func() { e.wrap.SetNetInfoCallback(cb) })
-}
 func (e *watchdogEngine) RequestStatus() {
 	e.watchdog("RequestStatus", func() { e.wrap.RequestStatus() })
 }

--- a/wgengine/wgengine.go
+++ b/wgengine/wgengine.go
@@ -35,9 +35,6 @@ type Status struct {
 // Exactly one of Status or error is non-nil.
 type StatusCallback func(*Status, error)
 
-// NetInfoCallback is the type used by Engine.SetNetInfoCallback.
-type NetInfoCallback func(*tailcfg.NetInfo)
-
 // NetworkMapCallback is the type used by callbacks that hook
 // into network map updates.
 type NetworkMapCallback func(*netmap.NetworkMap)
@@ -124,10 +121,6 @@ type Engine interface {
 	// instead.
 	// The network map should only be read from.
 	SetNetworkMap(*netmap.NetworkMap)
-
-	// SetNetInfoCallback sets the function to call when a
-	// new NetInfo summary is available.
-	SetNetInfoCallback(NetInfoCallback)
 
 	// DiscoPublicKey gets the public key used for path discovery
 	// messages.


### PR DESCRIPTION
LocalBackend can talk to magicsock on its own to do this without the "Engine" being involved.

(Continuing a little side quest of cleaning up the Engine interface...)

Updates #cleanup
