### PR TITLE
wgengine: remove LinkChange method from Engine interface

### DIFF
--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -1099,13 +1099,6 @@ func (e *userspaceEngine) Wait() {
 	<-e.waitCh
 }
 
-// LinkChange signals a network change event. It's currently
-// (2021-03-03) only called on Android. On other platforms, netMon
-// generates link change events for us.
-func (e *userspaceEngine) LinkChange(_ bool) {
-	e.netMon.InjectEvent()
-}
-
 func (e *userspaceEngine) linkChange(delta *netmon.ChangeDelta) {
 	changed := delta.Major // TODO(bradfitz): ask more specific questions?
 	cur := delta.New

--- a/wgengine/watchdog.go
+++ b/wgengine/watchdog.go
@@ -137,9 +137,6 @@ func (e *watchdogEngine) UpdateStatus(sb *ipnstate.StatusBuilder) {
 func (e *watchdogEngine) RequestStatus() {
 	e.watchdog("RequestStatus", func() { e.wrap.RequestStatus() })
 }
-func (e *watchdogEngine) LinkChange(isExpensive bool) {
-	e.watchdog("LinkChange", func() { e.wrap.LinkChange(isExpensive) })
-}
 func (e *watchdogEngine) SetDERPMap(m *tailcfg.DERPMap) {
 	e.watchdog("SetDERPMap", func() { e.wrap.SetDERPMap(m) })
 }

--- a/wgengine/wgengine.go
+++ b/wgengine/wgengine.go
@@ -95,21 +95,6 @@ type Engine interface {
 	// TODO: return an error?
 	Wait()
 
-	// LinkChange informs the engine that the system network
-	// link has changed.
-	//
-	// The isExpensive parameter is not used.
-	//
-	// LinkChange should be called whenever something changed with
-	// the network, no matter how minor.
-	//
-	// Deprecated: don't use this method. It was removed shortly
-	// before the Tailscale 1.6 release when we remembered that
-	// Android doesn't use the Linux-based network monitor and has
-	// its own mechanism that uses LinkChange. Android is the only
-	// caller of this method now. Don't add more.
-	LinkChange(isExpensive bool)
-
 	// SetDERPMap controls which (if any) DERP servers are used.
 	// If nil, DERP is disabled. It starts disabled until a DERP map
 	// is configured.


### PR DESCRIPTION
It was only used by Android, until
https://github.com/tailscale/tailscale-android/pull/131 which does the call to the netMon directly instead.

Updates #cleanup