### PR TITLE
wgengine: remove SetDERPMap method from Engine interface

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1098,7 +1098,7 @@ func (b *LocalBackend) SetControlClientStatus(c controlclient.Client, st control
 		}
 
 		b.e.SetNetworkMap(st.NetMap)
-		b.e.SetDERPMap(st.NetMap.DERPMap)
+		b.magicConn().SetDERPMap(st.NetMap.DERPMap)
 
 		// Update our cached DERP map
 		dnsfallback.UpdateCache(st.NetMap.DERPMap, b.logf)
@@ -2896,7 +2896,7 @@ func (b *LocalBackend) setPrefsLockedOnEntry(caller string, newp *ipn.Prefs) ipn
 	}
 
 	if netMap != nil {
-		b.e.SetDERPMap(netMap.DERPMap)
+		b.magicConn().SetDERPMap(netMap.DERPMap)
 	}
 
 	if !oldp.WantRunning() && newp.WantRunning {

--- a/ipn/ipnlocal/peerapi.go
+++ b/ipn/ipnlocal/peerapi.go
@@ -1234,11 +1234,7 @@ func (h *peerAPIHandler) handleServeMagicsock(w http.ResponseWriter, r *http.Req
 		http.Error(w, "denied; no debug access", http.StatusForbidden)
 		return
 	}
-	if mc, ok := h.ps.b.sys.MagicSock.GetOK(); ok {
-		mc.ServeHTTPDebug(w, r)
-		return
-	}
-	http.Error(w, "miswired", 500)
+	h.ps.b.magicConn().ServeHTTPDebug(w, r)
 }
 
 func (h *peerAPIHandler) handleServeMetrics(w http.ResponseWriter, r *http.Request) {

--- a/wgengine/bench/wg.go
+++ b/wgengine/bench/wg.go
@@ -16,6 +16,7 @@ import (
 
 	"tailscale.com/net/dns"
 	"tailscale.com/tailcfg"
+	"tailscale.com/tsd"
 	"tailscale.com/types/key"
 	"tailscale.com/types/logger"
 	"tailscale.com/types/netmap"
@@ -38,11 +39,13 @@ func setupWGTest(b *testing.B, logf logger.Logf, traf *TrafficGen, a1, a2 netip.
 		logf: logger.WithPrefix(logf, "tun1: "),
 		traf: traf,
 	}
+	s1 := new(tsd.System)
 	e1, err := wgengine.NewUserspaceEngine(l1, wgengine.Config{
-		Router:     router.NewFake(l1),
-		NetMon:     nil,
-		ListenPort: 0,
-		Tun:        t1,
+		Router:       router.NewFake(l1),
+		NetMon:       nil,
+		ListenPort:   0,
+		Tun:          t1,
+		SetSubsystem: s1.Set,
 	})
 	if err != nil {
 		log.Fatalf("e1 init: %v", err)
@@ -62,11 +65,13 @@ func setupWGTest(b *testing.B, logf logger.Logf, traf *TrafficGen, a1, a2 netip.
 		logf: logger.WithPrefix(logf, "tun2: "),
 		traf: traf,
 	}
+	s2 := new(tsd.System)
 	e2, err := wgengine.NewUserspaceEngine(l2, wgengine.Config{
-		Router:     router.NewFake(l2),
-		NetMon:     nil,
-		ListenPort: 0,
-		Tun:        t2,
+		Router:       router.NewFake(l2),
+		NetMon:       nil,
+		ListenPort:   0,
+		Tun:          t2,
+		SetSubsystem: s2.Set,
 	})
 	if err != nil {
 		log.Fatalf("e2 init: %v", err)
@@ -156,8 +161,8 @@ func setupWGTest(b *testing.B, logf logger.Logf, traf *TrafficGen, a1, a2 netip.
 	})
 
 	// Not using DERP in this test (for now?).
-	e1.SetDERPMap(&tailcfg.DERPMap{})
-	e2.SetDERPMap(&tailcfg.DERPMap{})
+	s1.MagicSock.Get().SetDERPMap(&tailcfg.DERPMap{})
+	s2.MagicSock.Get().SetDERPMap(&tailcfg.DERPMap{})
 
 	wait.Wait()
 }

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -1150,10 +1150,6 @@ func (e *userspaceEngine) linkChange(delta *netmon.ChangeDelta) {
 	e.magicConn.ReSTUN(why)
 }
 
-func (e *userspaceEngine) SetDERPMap(dm *tailcfg.DERPMap) {
-	e.magicConn.SetDERPMap(dm)
-}
-
 func (e *userspaceEngine) SetNetworkMap(nm *netmap.NetworkMap) {
 	e.magicConn.SetNetworkMap(nm)
 	e.mu.Lock()

--- a/wgengine/watchdog.go
+++ b/wgengine/watchdog.go
@@ -137,9 +137,6 @@ func (e *watchdogEngine) UpdateStatus(sb *ipnstate.StatusBuilder) {
 func (e *watchdogEngine) RequestStatus() {
 	e.watchdog("RequestStatus", func() { e.wrap.RequestStatus() })
 }
-func (e *watchdogEngine) SetDERPMap(m *tailcfg.DERPMap) {
-	e.watchdog("SetDERPMap", func() { e.wrap.SetDERPMap(m) })
-}
 func (e *watchdogEngine) SetNetworkMap(nm *netmap.NetworkMap) {
 	e.watchdog("SetNetworkMap", func() { e.wrap.SetNetworkMap(nm) })
 }

--- a/wgengine/wgengine.go
+++ b/wgengine/wgengine.go
@@ -95,11 +95,6 @@ type Engine interface {
 	// TODO: return an error?
 	Wait()
 
-	// SetDERPMap controls which (if any) DERP servers are used.
-	// If nil, DERP is disabled. It starts disabled until a DERP map
-	// is configured.
-	SetDERPMap(*tailcfg.DERPMap)
-
 	// SetNetworkMap informs the engine of the latest network map
 	// from the server. The network map's DERPMap field should be
 	// ignored as as it might be disabled; get it from SetDERPMap


### PR DESCRIPTION
(continuing the mission of removing rando methods from the Engine
 interface that we don't need anymore)

Updates #cleanup
