### PR TITLE
README: update docs for building web client

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ We always require the latest Go release, currently Go 1.21. (While we build
 releases with our [Go fork](https://github.com/tailscale/go/), its use is not
 required.)
 
+To include the embedded web client (accessed via the `tailscale web` command),
+first build the client assets using:
+
+```
+./tool/yarn --cwd client/web install
+./tool/yarn --cwd client/web build
+```
+
+Build the `tailscale` and `tailscaled` binaries:
+
 ```
 go install tailscale.com/cmd/tailscale{,d}
 ```
@@ -56,17 +66,6 @@ instead, to burn commit IDs and version info into the binaries:
 If your distro has conventions that preclude the use of
 `build_dist.sh`, please do the equivalent of what it does in your
 distro's way, so that bug reports contain useful version information.
-
-## Building the web client
-
-To include the embedded web client (accessed via the `tailscale web` command),
-you'll need to build the client assets using:
-
-```
-./tool/yarn --cwd client/web build
-```
-
-Do this before building the `tailscale.com/cmd/tailscale` binary.
 
 ## Bugs
 


### PR DESCRIPTION
Move into the main "building" section and add the missing `yarn install` step.

Updates #9312