### PR TITLE
wgengine: remove DiscoKey method from Engine interface

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1467,7 +1467,7 @@ func (b *LocalBackend) Start(opts ipn.Options) error {
 		})
 	}
 
-	discoPublic := b.e.DiscoPublicKey()
+	discoPublic := b.magicConn().DiscoPublicKey()
 
 	var err error
 

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -1157,10 +1157,6 @@ func (e *userspaceEngine) SetNetworkMap(nm *netmap.NetworkMap) {
 	e.mu.Unlock()
 }
 
-func (e *userspaceEngine) DiscoPublicKey() key.DiscoPublic {
-	return e.magicConn.DiscoPublicKey()
-}
-
 func (e *userspaceEngine) UpdateStatus(sb *ipnstate.StatusBuilder) {
 	st, err := e.getStatus()
 	if err != nil {

--- a/wgengine/watchdog.go
+++ b/wgengine/watchdog.go
@@ -18,7 +18,6 @@ import (
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/net/dns"
 	"tailscale.com/tailcfg"
-	"tailscale.com/types/key"
 	"tailscale.com/types/netmap"
 	"tailscale.com/wgengine/capture"
 	"tailscale.com/wgengine/filter"
@@ -139,10 +138,6 @@ func (e *watchdogEngine) RequestStatus() {
 }
 func (e *watchdogEngine) SetNetworkMap(nm *netmap.NetworkMap) {
 	e.watchdog("SetNetworkMap", func() { e.wrap.SetNetworkMap(nm) })
-}
-func (e *watchdogEngine) DiscoPublicKey() (k key.DiscoPublic) {
-	e.watchdog("DiscoPublicKey", func() { k = e.wrap.DiscoPublicKey() })
-	return k
 }
 func (e *watchdogEngine) Ping(ip netip.Addr, pingType tailcfg.PingType, size int, cb func(*ipnstate.PingResult)) {
 	e.watchdog("Ping", func() { e.wrap.Ping(ip, pingType, size, cb) })

--- a/wgengine/wgengine.go
+++ b/wgengine/wgengine.go
@@ -11,7 +11,6 @@ import (
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/net/dns"
 	"tailscale.com/tailcfg"
-	"tailscale.com/types/key"
 	"tailscale.com/types/netmap"
 	"tailscale.com/wgengine/capture"
 	"tailscale.com/wgengine/filter"
@@ -101,10 +100,6 @@ type Engine interface {
 	// instead.
 	// The network map should only be read from.
 	SetNetworkMap(*netmap.NetworkMap)
-
-	// DiscoPublicKey gets the public key used for path discovery
-	// messages.
-	DiscoPublicKey() key.DiscoPublic
 
 	// UpdateStatus populates the network state using the provided
 	// status builder.


### PR DESCRIPTION
It has one user (LocalBackend) which can ask magicsock itself.

Updates #cleanup
