### PR TITLE
types/netmap: deprecate NetworkMap.MachineStatus, add accessor method

### DIFF
--- a/cmd/tsconnect/wasm/wasm_js.go
+++ b/cmd/tsconnect/wasm/wasm_js.go
@@ -253,7 +253,7 @@ func (i *jsIPN) run(jsCallbacks js.Value) {
 						NodeKey:    nm.NodeKey.String(),
 						MachineKey: nm.MachineKey.String(),
 					},
-					MachineStatus: jsMachineStatus[nm.MachineStatus],
+					MachineStatus: jsMachineStatus[nm.GetMachineStatus()],
 				},
 				Peers: mapSlice(nm.Peers, func(p tailcfg.NodeView) jsNetMapPeerNode {
 					name := p.Name()

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3862,7 +3862,7 @@ func (b *LocalBackend) nextStateLocked() ipn.State {
 		// NetMap must be non-nil for us to get here.
 		// The node key expired, need to relogin.
 		return ipn.NeedsLogin
-	case netMap.MachineStatus != tailcfg.MachineAuthorized:
+	case netMap.GetMachineStatus() != tailcfg.MachineAuthorized:
 		// TODO(crawshaw): handle tailcfg.MachineInvalid
 		return ipn.NeedsMachineAuth
 	case state == ipn.NeedsMachineAuth:


### PR DESCRIPTION
Step 1 of deleting it, per TODO.

Updates #cleanup
