### PR TITLE
.github/workflows: fix slack-action format in govulncheck.yml

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -27,8 +27,9 @@ jobs:
           payload: >
             {
               "attachments": [{
-                "text": "${{ job.status }}: ${{ github.workflow }} <https://github.com/${{ github.repository }}/commit/${{ github.sha }}/checks>
-                        (<https://github.com/${{ github.repository }}/commit/${{ github.sha }}|commit>) of ${{ github.repository }}@${{ github.ref_name }} by ${{ github.event.head_commit.committer.name }}",
+                "title": "${{ job.status }}: ${{ github.workflow }}",
+                "title_link": "https://github.com/${{ github.repository }}/commit/${{ github.sha }}/checks",
+                "text": "${{ github.repository }}@${{ github.sha }}",
                 "color": "danger"
               }]
             }


### PR DESCRIPTION
Currently slack messages for errors fail:
https://github.com/tailscale/tailscale/actions/runs/6159104272/job/16713248204

```
Error: Unexpected token
 in JSON at position 151
```

This is likely due to the line break in the text. Restructure the message to use separate title/text and fix the slack webhook body.