### PR TITLE
cmd/tailscale/cli: add set serve validations

### DIFF
--- a/cmd/tailscale/cli/serve_dev.go
+++ b/cmd/tailscale/cli/serve_dev.go
@@ -266,7 +266,7 @@ func (e *serveEnv) runServeCombined(subcmd serveMode) execFunc {
 		if turnOff {
 			err = e.unsetServe(sc, dnsName, srvType, srvPort, mount)
 		} else {
-			if err := validateConfig(sc, srvPort, srvType); err != nil {
+			if err := validateConfig(parentSC, srvPort, srvType); err != nil {
 				return err
 			}
 			err = e.setServe(sc, st, dnsName, srvType, srvPort, mount, args[0], funnel)


### PR DESCRIPTION
This PR adds validations for the new new funnel/serve commands under the following rules:
1. There is always a single config for one port (bg or fg).
2. Foreground configs under the same port cannot co-exists (for now).
3. Background configs can change as long as the serve type is the same.

Updates #8489