### PR TITLE
cmd/tailscale: Track serve/funnel usage

### DIFF
--- a/cmd/tailscale/cli/serve_dev_test.go
+++ b/cmd/tailscale/cli/serve_dev_test.go
@@ -1044,7 +1044,7 @@ func TestIsLegacyInvocation(t *testing.T) {
 
 	for _, tt := range tests {
 		args := strings.Join(tt.args, " ")
-		t.Run(fmt.Sprintf("%v %s", infoMap[tt.subcmd].Name, args), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%v %s", tt.subcmd, args), func(t *testing.T) {
 			actual := isLegacyInvocation(tt.subcmd, tt.args)
 
 			if actual != tt.expected {


### PR DESCRIPTION
Adds tracking to the WIP serve and funnel CLI changes that are currently behind the environment flag `TAILSCALE_USE_WIP_CODE`.

Updates https://github.com/tailscale/tailscale/issues/8489