### PR TITLE
cmd/tailscale/cli: error when serving foreground if bg already exists

### DIFF
--- a/cmd/tailscale/cli/serve_dev.go
+++ b/cmd/tailscale/cli/serve_dev.go
@@ -266,7 +266,7 @@ func (e *serveEnv) runServeCombined(subcmd serveMode) execFunc {
 		if turnOff {
 			err = e.unsetServe(sc, dnsName, srvType, srvPort, mount)
 		} else {
-			if err := validateConfig(parentSC, srvPort, srvType); err != nil {
+			if err := e.validateConfig(parentSC, srvPort, srvType); err != nil {
 				return err
 			}
 			err = e.setServe(sc, st, dnsName, srvType, srvPort, mount, args[0], funnel)
@@ -304,13 +304,16 @@ func (e *serveEnv) runServeCombined(subcmd serveMode) execFunc {
 	}
 }
 
-func validateConfig(sc *ipn.ServeConfig, port uint16, wantServe serveType) error {
+func (e *serveEnv) validateConfig(sc *ipn.ServeConfig, port uint16, wantServe serveType) error {
 	sc, isFg := findConfig(sc, port)
 	if sc == nil {
 		return nil
 	}
 	if isFg {
 		return errors.New("foreground already exists under this port")
+	}
+	if !e.bg {
+		return errors.New("background serve already exists under this port")
 	}
 	existingServe := serveFromPortHandler(sc.TCP[port])
 	if wantServe != existingServe {

--- a/cmd/tailscale/cli/serve_dev_test.go
+++ b/cmd/tailscale/cli/serve_dev_test.go
@@ -788,6 +788,7 @@ func TestValidateConfig(t *testing.T) {
 		cfg       *ipn.ServeConfig
 		servePort uint16
 		serveType serveType
+		bg        bool
 		wantErr   bool
 	}{
 		{
@@ -805,6 +806,7 @@ func TestValidateConfig(t *testing.T) {
 					443: {HTTPS: true},
 				},
 			},
+			bg:        true,
 			servePort: 10000,
 			serveType: serveTypeHTTPS,
 		},
@@ -816,17 +818,19 @@ func TestValidateConfig(t *testing.T) {
 					443: {TCPForward: "http://localhost:4545"},
 				},
 			},
+			bg:        true,
 			servePort: 443,
 			serveType: serveTypeTCP,
 		},
 		{
 			name: "override_bg_tcp",
-			desc: "error when overwriting previous port under a different serve type ",
+			desc: "error when overwriting previous port under a different serve type",
 			cfg: &ipn.ServeConfig{
 				TCP: map[uint16]*ipn.TCPPortHandler{
 					443: {HTTPS: true},
 				},
 			},
+			bg:        true,
 			servePort: 443,
 			serveType: serveTypeHTTP,
 			wantErr:   true,
@@ -869,7 +873,8 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateConfig(tc.cfg, tc.servePort, tc.serveType)
+			se := serveEnv{bg: tc.bg}
+			err := se.validateConfig(tc.cfg, tc.servePort, tc.serveType)
 			if err == nil && tc.wantErr {
 				t.Fatal("expected an error but got nil")
 			}


### PR DESCRIPTION
This PR fixes a bug to make sure that we don't allow two configs exist with duplicate ports

Updates #8489