### PR TITLE
ipn/ipnlocal: handle all peer mutations in LocalBackend

### DIFF
--- a/ipn/backend.go
+++ b/ipn/backend.go
@@ -87,13 +87,14 @@ type Notify struct {
 	// For State InUseOtherUser, ErrMessage is not critical and just contains the details.
 	ErrMessage *string
 
-	LoginFinished *empty.Message     // non-nil when/if the login process succeeded
-	State         *State             // if non-nil, the new or current IPN state
-	Prefs         *PrefsView         // if non-nil && Valid, the new or current preferences
-	NetMap        *netmap.NetworkMap // if non-nil, the new or current netmap
-	Engine        *EngineStatus      // if non-nil, the new or current wireguard stats
-	BrowseToURL   *string            // if non-nil, UI should open a browser right now
-	BackendLogID  *string            // if non-nil, the public logtail ID used by backend
+	LoginFinished *empty.Message        // non-nil when/if the login process succeeded
+	State         *State                // if non-nil, the new or current IPN state
+	Prefs         *PrefsView            // if non-nil && Valid, the new or current preferences
+	NetMap        *netmap.NetworkMap    // if non-nil, the new or current netmap
+	PeerMutations []netmap.NodeMutation // if non-nil, the mutations to apply to NetMap.Peers
+	Engine        *EngineStatus         // if non-nil, the new or current wireguard stats
+	BrowseToURL   *string               // if non-nil, UI should open a browser right now
+	BackendLogID  *string               // if non-nil, the public logtail ID used by backend
 
 	// FilesWaiting if non-nil means that files are buffered in
 	// the Tailscale daemon and ready for local transfer to the

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -926,7 +926,7 @@ func TestUpdateNetmapDelta(t *testing.T) {
 	wants := []*tailcfg.Node{
 		{
 			ID:   1,
-			DERP: "", // unmodified by the delta
+			DERP: "127.3.3.40:1",
 		},
 		{
 			ID:     2,


### PR DESCRIPTION
Consumers of ipn.Notify (WatchIPNBus) need to be able to reconstruct the state of the world by just subscribing to changes after they ask for the InitialNetmap. This behavior was regressed when we made LocalBackend only handle a few types of mutations and not all; as the InitialNetmap sent down the WatchIPNBus may no longer contain all the up to date information and there was no way to recover the previously unhandled information.

This makes it so that the LocalBackend handles all mutations and panics if it sees an unknown type of mutation, and it also sends the mutations over the ipn.Notify bus.

Updates tailscale/corp#12990