### PR TITLE
ipn/{ipnlocal,ipnstate}: start simplifying UpdateStatus/StatusBuilder

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -650,18 +650,8 @@ func (b *LocalBackend) StatusWithoutPeers() *ipnstate.Status {
 
 // UpdateStatus implements ipnstate.StatusUpdater.
 func (b *LocalBackend) UpdateStatus(sb *ipnstate.StatusBuilder) {
-	b.e.UpdateStatus(sb)
-	var extraLocked func(*ipnstate.StatusBuilder)
-	if sb.WantPeers {
-		extraLocked = b.populatePeerStatusLocked
-	}
-	b.updateStatus(sb, extraLocked)
-}
+	b.e.UpdateStatus(sb) // does wireguard + magicsock status
 
-// updateStatus populates sb with status.
-//
-// extraLocked, if non-nil, is called while b.mu is still held.
-func (b *LocalBackend) updateStatus(sb *ipnstate.StatusBuilder, extraLocked func(*ipnstate.StatusBuilder)) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -759,8 +749,8 @@ func (b *LocalBackend) updateStatus(sb *ipnstate.StatusBuilder, extraLocked func
 	// TODO: hostinfo, and its networkinfo
 	// TODO: EngineStatus copy (and deprecate it?)
 
-	if extraLocked != nil {
-		extraLocked(sb)
+	if sb.WantPeers {
+		b.populatePeerStatusLocked(sb)
 	}
 }
 


### PR DESCRIPTION
* Remove unnecessary mutexes (there's no concurrency)
* Simplify LocalBackend.UpdateStatus using the StatusBuilder.WantPeers
  field that was added in 0f604923d345ff, removing passing around some
  method values into func args. And then merge two methods.

More remains, but this is a start.

Updates #9433
