### PR TITLE
types/netmap: start phasing out Addresses, add GetAddresses method

### DIFF
--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -205,7 +205,9 @@ func (b *LocalBackend) updateServeTCPPortNetMapAddrListenersLocked(ports []uint1
 		return
 	}
 
-	for _, a := range nm.Addresses {
+	addrs := nm.GetAddresses()
+	for i := range addrs.LenIter() {
+		a := addrs.At(i)
 		for _, p := range ports {
 			addrPort := netip.AddrPortFrom(a.Addr(), p)
 			if _, ok := b.serveListeners[addrPort]; ok {

--- a/net/tsdial/dnsmap.go
+++ b/net/tsdial/dnsmap.go
@@ -35,14 +35,15 @@ func dnsMapFromNetworkMap(nm *netmap.NetworkMap) dnsMap {
 	ret := make(dnsMap)
 	suffix := nm.MagicDNSSuffix()
 	have4 := false
-	if nm.Name != "" && len(nm.Addresses) > 0 {
-		ip := nm.Addresses[0].Addr()
+	addrs := nm.GetAddresses()
+	if nm.Name != "" && addrs.Len() > 0 {
+		ip := addrs.At(0).Addr()
 		ret[canonMapKey(nm.Name)] = ip
 		if dnsname.HasSuffix(nm.Name, suffix) {
 			ret[canonMapKey(dnsname.TrimSuffix(nm.Name, suffix))] = ip
 		}
-		for _, a := range nm.Addresses {
-			if a.Addr().Is4() {
+		for i := range addrs.LenIter() {
+			if addrs.At(i).Addr().Is4() {
 				have4 = true
 			}
 		}

--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -408,7 +408,9 @@ func (s *Server) TailscaleIPs() (ip4, ip6 netip.Addr) {
 	if nm == nil {
 		return
 	}
-	for _, addr := range nm.Addresses {
+	addrs := nm.GetAddresses()
+	for i := range addrs.LenIter() {
+		addr := addrs.At(i)
 		ip := addr.Addr()
 		if ip.Is6() {
 			ip6 = ip

--- a/types/netmap/netmap.go
+++ b/types/netmap/netmap.go
@@ -35,7 +35,8 @@ type NetworkMap struct {
 
 	// Addresses is SelfNode.Addresses. (IP addresses of this Node directly)
 	//
-	// TODO(bradfitz): remove this field and make this a method.
+	// Deprecated: use GetAddresses instead. As of 2023-09-17, this field
+	// is being phased out.
 	Addresses []netip.Prefix
 
 	// MachineStatus is either tailcfg.MachineAuthorized or tailcfg.MachineUnauthorized,
@@ -97,6 +98,22 @@ func (nm *NetworkMap) User() tailcfg.UserID {
 		return nm.SelfNode.User()
 	}
 	return 0
+}
+
+// GetAddresses returns the self node's addresses, or the zero value
+// if SelfNode is invalid.
+func (nm *NetworkMap) GetAddresses() views.Slice[netip.Prefix] {
+	var zero views.Slice[netip.Prefix]
+	if nm.Addresses != nil {
+		// For now (2023-09-17), let the deprecated Addressees field take
+		// precedence. This is a migration mechanism while we update tests &
+		// code cross-repo.
+		return views.SliceOf(nm.Addresses)
+	}
+	if !nm.SelfNode.Valid() {
+		return zero
+	}
+	return nm.SelfNode.Addresses()
 }
 
 // AnyPeersAdvertiseRoutes reports whether any peer is advertising non-exit node routes.

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -1816,8 +1816,8 @@ func (c *Conn) SetNetworkMap(nm *netmap.NetworkMap) {
 	c.peers = curPeers
 
 	flags := c.debugFlagsLocked()
-	if len(nm.Addresses) > 0 {
-		c.firstAddrForTest = nm.Addresses[0].Addr()
+	if addrs := nm.GetAddresses(); addrs.Len() > 0 {
+		c.firstAddrForTest = addrs.At(0).Addr()
 	} else {
 		c.firstAddrForTest = netip.Addr{}
 	}


### PR DESCRIPTION
NetworkMap.Addresses is redundant with the SelfNode.Addresses. This
works towards a TODO to delete NetworkMap.Addresses and replace it
with a method.

This is similar to #9389.

Updates #cleanup
