### PR TITLE
ipn/ipnlocal: close foreground sessions on SetServeConfig

### DIFF
--- a/cmd/tailscale/cli/serve_dev.go
+++ b/cmd/tailscale/cli/serve_dev.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/url"
@@ -292,7 +293,7 @@ func (e *serveEnv) runServeCombined(subcmd serveMode) execFunc {
 			for {
 				_, err = watcher.Next()
 				if err != nil {
-					if errors.Is(err, context.Canceled) {
+					if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
 						return nil
 					}
 					return err

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -128,6 +128,13 @@ func RegisterNewSSHServer(fn newSSHServerFunc) {
 	newSSHServer = fn
 }
 
+// watchSession represents a WatchNotifications channel
+// and sessionID as required to close targeted buses.
+type watchSession struct {
+	ch        chan *ipn.Notify
+	sessionID string
+}
+
 // LocalBackend is the glue between the major pieces of the Tailscale
 // network software: the cloud control plane (via controlclient), the
 // network data plane (via wgengine), and the user-facing UIs and CLIs
@@ -233,7 +240,7 @@ type LocalBackend struct {
 	loginFlags       controlclient.LoginFlags
 	incomingFiles    map[*incomingFile]bool
 	fileWaiters      set.HandleSet[context.CancelFunc] // of wake-up funcs
-	notifyWatchers   set.HandleSet[chan *ipn.Notify]
+	notifyWatchers   set.HandleSet[*watchSession]
 	lastStatusTime   time.Time // status.AsOf value of the last processed status update
 	// directFileRoot, if non-empty, means to write received files
 	// directly to this directory, without staging them in an
@@ -2044,7 +2051,7 @@ func (b *LocalBackend) WatchNotifications(ctx context.Context, mask ipn.NotifyWa
 		}
 	}
 
-	handle := b.notifyWatchers.Add(ch)
+	handle := b.notifyWatchers.Add(&watchSession{ch, sessionID})
 	b.mu.Unlock()
 
 	defer func() {
@@ -2089,8 +2096,8 @@ func (b *LocalBackend) WatchNotifications(ctx context.Context, mask ipn.NotifyWa
 		select {
 		case <-ctx.Done():
 			return
-		case n := <-ch:
-			if !fn(n) {
+		case n, ok := <-ch:
+			if !ok || !fn(n) {
 				return
 			}
 		}
@@ -2143,9 +2150,9 @@ func (b *LocalBackend) send(n ipn.Notify) {
 		n.FilesWaiting = &empty.Message{}
 	}
 
-	for _, ch := range b.notifyWatchers {
+	for _, sess := range b.notifyWatchers {
 		select {
-		case ch <- &n:
+		case sess.ch <- &n:
 		default:
 			// Drop the notification if the channel is full.
 		}

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -753,9 +753,9 @@ func TestWatchNotificationsCallbacks(t *testing.T) {
 		}
 		// Send a notification. Range over notifyWatchers to get the channel
 		// because WatchNotifications doesn't expose the handle for it.
-		for _, c := range b.notifyWatchers {
+		for _, sess := range b.notifyWatchers {
 			select {
-			case c <- n:
+			case sess.ch <- n:
 			default:
 				t.Fatalf("could not send notification")
 			}


### PR DESCRIPTION
This PR ensures zombie foregrounds are shutdown if a new ServeConfig is created that wipes the ongoing foreground ones. For example, "tailscale serve|funnel reset|off" should close all open sessions.

Updates #8489