### PR TITLE
client/web: split build into separate module

### DIFF
--- a/.github/workflows/web-client-assets.yml
+++ b/.github/workflows/web-client-assets.yml
@@ -1,0 +1,33 @@
+# When the web client is updated, make sure that we have checked in the build/index.html
+# that points to the correct asset files. Even though we don't check the asset files
+# into version control, the index.html file must be kept up-to-date to prevent "dirty"
+# client builds.
+name: Web Client Assets
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "client/web/**"
+  pull_request:
+    branches:
+      - "*"
+    paths:
+      - "client/web/**"
+
+concurrency:
+  group: ${{ github.workflow }}-$${{ github.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  yarn_build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: check that 'yarn --cwd client/web build' is clean
+        run: |
+          ./tool/yarn --cwd client/web install
+          ./tool/yarn --cwd client/web build
+          git diff --name-only --exit-code || (echo "client/web/build/index.html needs updating. Please run 'yarn --cwd client/web build'."; exit 1)

--- a/.gitignore
+++ b/.gitignore
@@ -35,10 +35,5 @@ cmd/tailscaled/tailscaled
 # Ignore direnv nix-shell environment cache
 .direnv/
 
-# Ignore web client node modules
-.vite/
-client/web/node_modules
-client/web/build/assets
-
 /gocross
 /dist

--- a/client/web/.gitignore
+++ b/client/web/.gitignore
@@ -1,0 +1,5 @@
+.vite/
+node_modules
+!build/assets
+build/assets/*
+!build/assets/.keep

--- a/client/web/build/embed.go
+++ b/client/web/build/embed.go
@@ -1,0 +1,9 @@
+// Package build provides the build artifacts for the web client.
+package build
+
+import (
+	"embed"
+)
+
+//go:embed index.html all:assets
+var FS embed.FS

--- a/client/web/build/go.mod
+++ b/client/web/build/go.mod
@@ -1,0 +1,14 @@
+// The client/web/build module provides the build artifacts (JS and CSS bundles) for the Tailscale web client.
+// These artifacts are not checked into version control, but must be built locally before building the tailscale client.
+//
+// When the tailcale.com module is imported as a Go module (as it is in the Tailscale corp repo),
+// the source is placed in the read-only Go module cache.
+// Exposing client/web/build as a standalone module allows us to build the web client artifacts in a writable directory
+// and then use go.mod to replace that module with the local copy.
+//
+// This could also be achieved by using `go mod vendor` to copy modules into a writable directory,
+// but that copies far more than is really necessary.
+
+module tailscale.com/client/web/build
+
+go 1.21

--- a/client/web/vite.config.ts
+++ b/client/web/vite.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
   ],
   build: {
     outDir: "build",
+    emptyOutDir: false,
     sourcemap: true,
   },
   esbuild: {

--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,13 @@ require (
 	software.sslmate.com/src/go-pkcs12 v0.2.0
 )
 
-require github.com/gorilla/securecookie v1.1.1 // indirect
+// client/web/build is defined as a separate module so that it can be
+// replaced when building clients from the Tailscale corp repo.
+// When building locally, replace the build module with the local directory
+// so that we always stay in sync with the main tailscale.com module.
+require tailscale.com/client/web/build v0.0.0
+
+replace tailscale.com/client/web/build => ./client/web/build
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.2.1 // indirect
@@ -212,6 +218,7 @@ require (
 	github.com/goreleaser/chglog v0.5.0 // indirect
 	github.com/goreleaser/fileglob v1.3.0 // indirect
 	github.com/gorilla/csrf v1.7.1
+	github.com/gorilla/securecookie v1.1.1 // indirect
 	github.com/gostaticanalysis/analysisutil v0.7.1 // indirect
 	github.com/gostaticanalysis/comment v1.4.2 // indirect
 	github.com/gostaticanalysis/forcetypeassert v0.1.0 // indirect


### PR DESCRIPTION
Define `tailscale.com/client/web/build` as a separate Go module and move vite output to an "out" subdirectory. This allows client builds in corp to first build the web client assets into a local writable directory, then go.mod replace the `client/web/build` module with that local directory.

Change how we serve the default index page when assets haven't been built. This prevents "dirty" builds in corp when assets ARE built.

Updates tailscale/corp#14733