### PR TITLE
Makefile: make it possibe to pass a custom tag when building dev images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 IMAGE_REPO ?= tailscale/tailscale
 SYNO_ARCH ?= "amd64"
 SYNO_DSM ?= "7"
+TAGS ?= "latest"
 
 vet: ## Run go vet
 	./tool/go vet ./...
@@ -67,7 +68,7 @@ publishdevimage: ## Build and publish tailscale image to location specified by $
 	@test "${REPO}" != "ghcr.io/tailscale/tailscale" || (echo "REPO=... must not be ghcr.io/tailscale/tailscale" && exit 1)
 	@test "${REPO}" != "tailscale/k8s-operator" || (echo "REPO=... must not be tailscale/k8s-operator" && exit 1)
 	@test "${REPO}" != "ghcr.io/tailscale/k8s-operator" || (echo "REPO=... must not be ghcr.io/tailscale/k8s-operator" && exit 1)
-	TAGS=latest REPOS=${REPO} PUSH=true TARGET=client ./build_docker.sh
+	TAGS="${TAGS}" REPOS=${REPO} PUSH=true TARGET=client ./build_docker.sh
 
 publishdevoperator: ## Build and publish k8s-operator image to location specified by ${REPO}
 	@test -n "${REPO}" || (echo "REPO=... required; e.g. REPO=ghcr.io/${USER}/tailscale" && exit 1)
@@ -75,7 +76,7 @@ publishdevoperator: ## Build and publish k8s-operator image to location specifie
 	@test "${REPO}" != "ghcr.io/tailscale/tailscale" || (echo "REPO=... must not be ghcr.io/tailscale/tailscale" && exit 1)
 	@test "${REPO}" != "tailscale/k8s-operator" || (echo "REPO=... must not be tailscale/k8s-operator" && exit 1)
 	@test "${REPO}" != "ghcr.io/tailscale/k8s-operator" || (echo "REPO=... must not be ghcr.io/tailscale/k8s-operator" && exit 1)
-	TAGS=latest REPOS=${REPO} PUSH=true TARGET=operator ./build_docker.sh
+	TAGS="${TAGS}" REPOS=${REPO} PUSH=true TARGET=operator ./build_docker.sh
 
 help: ## Show this help
 	@echo "\nSpecify a command. The choices are:\n"


### PR DESCRIPTION
At the moment the dev images for k8s-operator and proxy are always tagged only with `latest` tag which makes it slightly inconvenient to use them when redeploying with additional changes during development.

This makes it possibe to pass a custom tag:

`TAGS=v0.0.3 REPO=<some-repo> make publishdevoperator`


Updates #cleanup