### PR TITLE
ipn/ipnlocal: fix LocalBackend.WhoIs for self

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -868,9 +868,16 @@ func (b *LocalBackend) WhoIs(ipp netip.AddrPort) (n tailcfg.NodeView, u tailcfg.
 			return zero, u, false
 		}
 	}
+	if b.netMap == nil {
+		return zero, u, false
+	}
 	n, ok = b.peers[nid]
 	if !ok {
-		return zero, u, false
+		// Check if this the self-node, which would not appear in peers.
+		if !b.netMap.SelfNode.Valid() || nid != b.netMap.SelfNode.ID() {
+			return zero, u, false
+		}
+		n = b.netMap.SelfNode
 	}
 	u, ok = b.netMap.UserProfiles[n.User()]
 	if !ok {


### PR DESCRIPTION
9538e9f97035ce7a382d2b395db3368bd0326113 broke LocalBackend.WhoIs where you can no longer lookup yourself in WhoIs.
This occurs because the LocalBackend.peers map only contains peers. If we fail to lookup a peer, double-check whether it is ourself.

Fixes #9470