### PR TITLE
cmd/containerboot: add iptables based MSS clamping for ingress/egress proxies

### DIFF
--- a/cmd/containerboot/main_test.go
+++ b/cmd/containerboot/main_test.go
@@ -330,6 +330,7 @@ func TestContainerBoot(t *testing.T) {
 					WantCmds: []string{
 						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock set --accept-dns=false",
 						"/usr/bin/iptables -t nat -I PREROUTING 1 -d 100.64.0.1 -j DNAT --to-destination 1.2.3.4",
+						"/usr/bin/iptables -t mangle -A FORWARD -o tailscale0 -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu",
 					},
 				},
 			},
@@ -354,6 +355,7 @@ func TestContainerBoot(t *testing.T) {
 						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock set --accept-dns=false",
 						"/usr/bin/iptables -t nat -I PREROUTING 1 ! -i tailscale0 -j DNAT --to-destination 100.99.99.99",
 						"/usr/bin/iptables -t nat -I POSTROUTING 1 --destination 100.99.99.99 -j SNAT --to-source 100.64.0.1",
+						"/usr/bin/iptables -t mangle -A FORWARD -o tailscale0 -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu",
 					},
 				},
 			},


### PR DESCRIPTION
In typical k8s setups, the MTU configured on the eth0 interfaces is typically 1500 which results in packets being dropped when they make it to proxy pods as the tailscale0 interface has a 1280 MTU.

As the primary use of this functionality is TCP, add iptables based MSS clamping to allow connectivity.

Updates #502