### PR TITLE
cmd/k8s-operator: fix egress service name

### DIFF
--- a/cmd/k8s-operator/operator_test.go
+++ b/cmd/k8s-operator/operator_test.go
@@ -218,7 +218,7 @@ func TestTailnetTargetIPAnnotation(t *testing.T) {
 			},
 		},
 		Spec: corev1.ServiceSpec{
-			ExternalName: fmt.Sprintf("%s.operator-ns.svc", shortName),
+			ExternalName: fmt.Sprintf("%s.operator-ns.svc.cluster.local", shortName),
 			Type:         corev1.ServiceTypeExternalName,
 			Selector:     nil,
 		},

--- a/cmd/k8s-operator/svc.go
+++ b/cmd/k8s-operator/svc.go
@@ -184,7 +184,10 @@ func (a *ServiceReconciler) maybeProvision(ctx context.Context, logger *zap.Suga
 	}
 
 	if sts.TailnetTargetIP != "" {
-		headlessSvcName := hsvc.Name + "." + hsvc.Namespace + ".svc"
+		// TODO (irbekrm): cluster.local is the default DNS name, but
+		// can be changed by users. Make this configurable or figure out
+		// how to discover the DNS name from within operator
+		headlessSvcName := hsvc.Name + "." + hsvc.Namespace + ".svc.cluster.local"
 		if svc.Spec.ExternalName != headlessSvcName || svc.Spec.Type != corev1.ServiceTypeExternalName {
 			svc.Spec.ExternalName = headlessSvcName
 			svc.Spec.Selector = nil


### PR DESCRIPTION
Fix the external name for egress Service.

Updates https://github.com/tailscale/tailscale/issues/502