### PR TITLE
ipn/ipnlocal: plumb ExitNodeDNSResolvers for IsWireGuardOnly exit nodes

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -115,7 +115,8 @@ type CapabilityVersion int
 //   - 73: 2023-09-01: Non-Windows clients expect to receive ClientVersion
 //   - 74: 2023-09-18: Client understands NodeCapMap
 //   - 75: 2023-09-12: Client understands NodeAttrDNSForwarderDisableTCPRetries
-const CurrentCapabilityVersion CapabilityVersion = 75
+//   - 76: 2023-09-20: Client understands ExitNodeDNSResolvers for IsWireGuardOnly nodes
+const CurrentCapabilityVersion CapabilityVersion = 76
 
 type StableID string
 


### PR DESCRIPTION
Control sends ExitNodeDNSResolvers when configured for IsWireGuardOnly nodes that are to be used as the default resolver with a lower precedence than split DNS, and a lower precedence than "Override local DNS", but otherwise before local DNS is used when the exit node is in use.

Neither of the below changes were problematic, but appeared so alongside a number of other client and external changes. See tailscale/corp#14809.

Reland ea9dd8fabc64d7f4d054c2c45743728129f1430b.
Reland d52ab181c3c55354fb47a224a194d0d2c080301b.

Updates #9377
Updates tailscale/corp#14809