### PR TITLE
net/dns/publicdns: update Quad9 addresses and references

### DIFF
--- a/net/dns/publicdns/publicdns.go
+++ b/net/dns/publicdns/publicdns.go
@@ -137,6 +137,7 @@ const (
 // populate is called once to initialize the knownDoH and dohIPsOfBase maps.
 func populate() {
 	// Cloudflare
+	// https://developers.cloudflare.com/1.1.1.1/ip-addresses/
 	addDoH("1.1.1.1", "https://cloudflare-dns.com/dns-query")
 	addDoH("1.0.0.1", "https://cloudflare-dns.com/dns-query")
 	addDoH("2606:4700:4700::1111", "https://cloudflare-dns.com/dns-query")
@@ -170,10 +171,17 @@ func populate() {
 	// addDoH("208.67.220.123", "https://doh.familyshield.opendns.com/dns-query")
 
 	// Quad9
+	// https://www.quad9.net/service/service-addresses-and-features
 	addDoH("9.9.9.9", "https://dns.quad9.net/dns-query")
 	addDoH("149.112.112.112", "https://dns.quad9.net/dns-query")
 	addDoH("2620:fe::fe", "https://dns.quad9.net/dns-query")
-	addDoH("2620:fe::fe:9", "https://dns.quad9.net/dns-query")
+	addDoH("2620:fe::9", "https://dns.quad9.net/dns-query")
+
+	// Quad9 +ECS +DNSSEC
+	addDoH("9.9.9.11", "https://dns11.quad9.net/dns-query")
+	addDoH("149.112.112.11", "https://dns11.quad9.net/dns-query")
+	addDoH("2620:fe::11", "https://dns11.quad9.net/dns-query")
+	addDoH("2620:fe::fe:11", "https://dns11.quad9.net/dns-query")
 
 	// Quad9 -DNSSEC
 	addDoH("9.9.9.10", "https://dns10.quad9.net/dns-query")


### PR DESCRIPTION
One Quad9 IPv6 address was incorrect, and an additional group needed adding. Additionally I checked Cloudflare and included source reference URLs for both.

Updates #cleanup
Signed-off-by: James Tucker <james@tailscale.com>