### PR TITLE
ipn/ipnlocal: perform additional sanity check in diskPath

### DIFF
--- a/ipn/ipnlocal/peerapi.go
+++ b/ipn/ipnlocal/peerapi.go
@@ -136,6 +136,9 @@ func (s *peerAPIServer) diskPath(baseName string) (fullPath string, ok bool) {
 			return "", false
 		}
 	}
+	if !filepath.IsLocal(baseName) {
+		return "", false
+	}
 	return filepath.Join(s.rootDir, baseName), true
 }
 


### PR DESCRIPTION
Use filepath.IsLocal to further validate the baseName.

Updates tailscale/corp#14772