### PR TITLE
cmd/containerboot: avoid leaking bash scripts after test runs

### DIFF
--- a/cmd/containerboot/main_test.go
+++ b/cmd/containerboot/main_test.go
@@ -689,7 +689,7 @@ func TestContainerBoot(t *testing.T) {
 				t.Fatalf("starting containerboot: %v", err)
 			}
 			defer func() {
-				cmd.Process.Signal(unix.SIGKILL)
+				cmd.Process.Signal(unix.SIGTERM)
 				cmd.Process.Wait()
 			}()
 

--- a/cmd/containerboot/test_tailscaled.sh
+++ b/cmd/containerboot/test_tailscaled.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# This is a fake tailscale CLI that records its arguments, symlinks a
+# This is a fake tailscale daemon that records its arguments, symlinks a
 # fake LocalAPI socket into place, and does nothing until terminated.
 #
 # It is used by main_test.go to test the behavior of containerboot.
@@ -33,5 +33,6 @@ if [[ -z "$socket" ]]; then
 fi
 
 ln -s "$TS_TEST_SOCKET" "$socket"
+trap 'rm -f "$socket"' EXIT
 
-while true; do sleep 1; done
+while sleep 10; do :; done


### PR DESCRIPTION
The test was sending SIGKILL to containerboot, which results in no signal propagation down to the bash script that is running as a child process, thus it leaks.

Minor changes to the test daemon script, so that it cleans up the socket that it creates on exit, and spawns fewer processes.

Fixes tailscale/corp#14833
Signed-off-by: James Tucker <james@tailscale.com>