### PR TITLE
util/linuxfw: fix crash in DelSNATRule when no rules are found

### DIFF
--- a/util/linuxfw/nftables_runner.go
+++ b/util/linuxfw/nftables_runner.go
@@ -1109,7 +1109,9 @@ func (n *nftablesRunner) DelSNATRule() error {
 			return fmt.Errorf("find SNAT rule v4: %w", err)
 		}
 
-		_ = conn.DelRule(SNATRule)
+		if SNATRule != nil {
+			_ = conn.DelRule(SNATRule)
+		}
 	}
 
 	if err := conn.Flush(); err != nil {


### PR DESCRIPTION
Appears to be a missing nil handling case. I looked back over other usage of findRule and the others all have nil guards. findRule returns nil when no rules are found matching the arguments.

Fixes #9553
Signed-off-by: James Tucker <james@tailscale.com>