### PR TITLE
wgengine/magicsock: add nodeid to panic condition on public key reuse

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -1893,7 +1893,7 @@ func (c *Conn) SetNetworkMap(nm *netmap.NetworkMap) {
 			// that differs from the one the NodeID had. But double check.
 			if ep.nodeID != n.ID() {
 				// Server error.
-				devPanicf("public key moved between nodeIDs")
+				devPanicf("public key moved between nodeIDs (old=%v new=%v, key=%s)", ep.nodeID, n.ID(), n.Key().String())
 			} else {
 				// Internal data structures out of sync.
 				devPanicf("public key found in peerMap but not by nodeID")


### PR DESCRIPTION
If the condition arises, it should be easy to track down.

Updates #9547
Signed-off-by: James Tucker <james@tailscale.com>