### PR TITLE
.github/workflows: disable generate check for util/winutil

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -384,8 +384,9 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4
     - name: check that 'go generate' is clean
+      # util/winutil is excluded because of #9579
       run: |
-        pkgs=$(./tool/go list ./... | grep -v dnsfallback)
+        pkgs=$(./tool/go list ./... | grep -v dnsfallback | grep -v util/winutil)
         ./tool/go generate $pkgs
         echo
         echo


### PR DESCRIPTION
util/winutil is performing a two-stage generate first generating syscall stubs, one with an external package reference, and then using goimports that appears to have previously imported that package. As of current main, this is not working, and so flows that trigger the go_generate check will fail on non-matching output.

Updates #9579
Signed-off-by: James Tucker <james@tailscale.com>