### PR TITLE
util/winutil: avoid extra imports in mksyscall output

### DIFF
--- a/util/winutil/mksyscall.go
+++ b/util/winutil/mksyscall.go
@@ -4,7 +4,6 @@
 package winutil
 
 //go:generate go run golang.org/x/sys/windows/mkwinsyscall -output zsyscall_windows.go mksyscall.go
-//go:generate go run golang.org/x/tools/cmd/goimports -w zsyscall_windows.go
 
 //sys queryServiceConfig2(hService windows.Handle, infoLevel uint32, buf *byte, bufLen uint32, bytesNeeded *uint32) (err error) [failretval==0] = advapi32.QueryServiceConfig2W
-//sys registerApplicationRestart(cmdLineExclExeName *uint16, flags uint32) (ret wingoes.HRESULT) = kernel32.RegisterApplicationRestart
+//sys registerApplicationRestart(cmdLineExclExeName *uint16, flags uint32) (ret int32) = kernel32.RegisterApplicationRestart

--- a/util/winutil/winutil_windows.go
+++ b/util/winutil/winutil_windows.go
@@ -604,8 +604,8 @@ func registerForRestart(opts RegisterForRestartOpts) error {
 		}
 	}
 
-	hr := registerApplicationRestart(cmdLine, flags)
-	if e := wingoes.ErrorFromHRESULT(hr); e.Failed() {
+	r := registerApplicationRestart(cmdLine, flags)
+	if e := wingoes.ErrorFromHRESULT(wingoes.HRESULT(r)); e.Failed() {
 		return e
 	}
 

--- a/util/winutil/zsyscall_windows.go
+++ b/util/winutil/zsyscall_windows.go
@@ -6,7 +6,6 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/dblohm7/wingoes"
 	"golang.org/x/sys/windows"
 )
 
@@ -54,8 +53,8 @@ func queryServiceConfig2(hService windows.Handle, infoLevel uint32, buf *byte, b
 	return
 }
 
-func registerApplicationRestart(cmdLineExclExeName *uint16, flags uint32) (ret wingoes.HRESULT) {
+func registerApplicationRestart(cmdLineExclExeName *uint16, flags uint32) (ret int32) {
 	r0, _, _ := syscall.Syscall(procRegisterApplicationRestart.Addr(), 2, uintptr(unsafe.Pointer(cmdLineExclExeName)), uintptr(flags), 0)
-	ret = wingoes.HRESULT(r0)
+	ret = int32(r0)
 	return
 }


### PR DESCRIPTION
The goimports call does not appear to be working anymore. I attempted giving it explicit versions, or setting GOOS, none of which worked.

Avoiding the need for this seems to be the most robust solution I could find today.

Supersedes #9580
Fixes #9579
Signed-off-by: James Tucker <james@tailscale.com>