### PR TITLE
go.mod: add test that replace directives aren't added in oss

### DIFF
--- a/gomod_test.go
+++ b/gomod_test.go
@@ -1,0 +1,25 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package tailscaleroot
+
+import (
+	"os"
+	"testing"
+
+	"golang.org/x/mod/modfile"
+)
+
+func TestGoMod(t *testing.T) {
+	goMod, err := os.ReadFile("go.mod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := modfile.Parse("go.mod", goMod, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Replace) > 0 {
+		t.Errorf("go.mod has %d replace directives; expect zero in this repo", len(f.Replace))
+	}
+}


### PR DESCRIPTION
Prevent future problems like we earlier with go.mod replace directives (e.g. removing our certstore replace in 6d6cf88d826c or wireguard-go in ea5ee6f87c15fa, both of which were reactions to problems caused by go.mod replace in non-root modules, often because people are using tsnet as a library from another module)

Updates #cleanup
