### PR TITLE
cmd/cloner: fix typo in test type's name

### DIFF
--- a/cmd/cloner/cloner_test.go
+++ b/cmd/cloner/cloner_test.go
@@ -13,7 +13,7 @@ func TestSliceContainer(t *testing.T) {
 	num := 5
 	examples := []struct {
 		name string
-		in   *clonerex.SliceContianer
+		in   *clonerex.SliceContainer
 	}{
 		{
 			name: "nil",
@@ -21,29 +21,29 @@ func TestSliceContainer(t *testing.T) {
 		},
 		{
 			name: "zero",
-			in:   &clonerex.SliceContianer{},
+			in:   &clonerex.SliceContainer{},
 		},
 		{
 			name: "empty",
-			in: &clonerex.SliceContianer{
+			in: &clonerex.SliceContainer{
 				Slice: []*int{},
 			},
 		},
 		{
 			name: "nils",
-			in: &clonerex.SliceContianer{
+			in: &clonerex.SliceContainer{
 				Slice: []*int{nil, nil, nil, nil, nil},
 			},
 		},
 		{
 			name: "one",
-			in: &clonerex.SliceContianer{
+			in: &clonerex.SliceContainer{
 				Slice: []*int{&num},
 			},
 		},
 		{
 			name: "several",
-			in: &clonerex.SliceContianer{
+			in: &clonerex.SliceContainer{
 				Slice: []*int{&num, &num, &num, &num, &num},
 			},
 		},

--- a/cmd/cloner/clonerex/clonerex.go
+++ b/cmd/cloner/clonerex/clonerex.go
@@ -1,10 +1,10 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:generate go run tailscale.com/cmd/cloner  -clonefunc=true -type SliceContianer
+//go:generate go run tailscale.com/cmd/cloner  -clonefunc=true -type SliceContainer
 
 package clonerex
 
-type SliceContianer struct {
+type SliceContainer struct {
 	Slice []*int
 }

--- a/cmd/cloner/clonerex/clonerex_clone.go
+++ b/cmd/cloner/clonerex/clonerex_clone.go
@@ -9,13 +9,13 @@ import (
 	"tailscale.com/types/ptr"
 )
 
-// Clone makes a deep copy of SliceContianer.
+// Clone makes a deep copy of SliceContainer.
 // The result aliases no memory with the original.
-func (src *SliceContianer) Clone() *SliceContianer {
+func (src *SliceContainer) Clone() *SliceContainer {
 	if src == nil {
 		return nil
 	}
-	dst := new(SliceContianer)
+	dst := new(SliceContainer)
 	*dst = *src
 	if src.Slice != nil {
 		dst.Slice = make([]*int, len(src.Slice))
@@ -31,21 +31,21 @@ func (src *SliceContianer) Clone() *SliceContianer {
 }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
-var _SliceContianerCloneNeedsRegeneration = SliceContianer(struct {
+var _SliceContainerCloneNeedsRegeneration = SliceContainer(struct {
 	Slice []*int
 }{})
 
 // Clone duplicates src into dst and reports whether it succeeded.
 // To succeed, <src, dst> must be of types <*T, *T> or <*T, **T>,
-// where T is one of SliceContianer.
+// where T is one of SliceContainer.
 func Clone(dst, src any) bool {
 	switch src := src.(type) {
-	case *SliceContianer:
+	case *SliceContainer:
 		switch dst := dst.(type) {
-		case *SliceContianer:
+		case *SliceContainer:
 			*dst = *src.Clone()
 			return true
-		case **SliceContianer:
+		case **SliceContainer:
 			*dst = src.Clone()
 			return true
 		}


### PR DESCRIPTION
s/SliceContianer/SliceContainer/g

Updates #9604