### PR TITLE
tailcfg, all: use []netip.AddrPort instead of []string for Endpoints

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -845,8 +845,10 @@ func (c *Direct) sendMapRequest(ctx context.Context, isStreaming bool, nu Netmap
 	hi := c.hostInfoLocked()
 	backendLogID := hi.BackendLogID
 	var epStrs []string
+	var eps []netip.AddrPort
 	var epTypes []tailcfg.EndpointType
 	for _, ep := range c.endpoints {
+		eps = append(eps, ep.Addr)
 		epStrs = append(epStrs, ep.Addr.String())
 		epTypes = append(epTypes, ep.Type)
 	}
@@ -881,7 +883,7 @@ func (c *Direct) sendMapRequest(ctx context.Context, isStreaming bool, nu Netmap
 		KeepAlive:     true,
 		NodeKey:       persist.PublicNodeKey(),
 		DiscoKey:      c.discoPubKey,
-		Endpoints:     epStrs,
+		Endpoints:     eps,
 		EndpointTypes: epTypes,
 		Stream:        isStreaming,
 		Hostinfo:      hi,

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -269,9 +269,9 @@ type Node struct {
 	KeySignature tkatype.MarshaledSignature `json:",omitempty"`
 	Machine      key.MachinePublic
 	DiscoKey     key.DiscoPublic
-	Addresses    []netip.Prefix // IP addresses of this Node directly
-	AllowedIPs   []netip.Prefix // range of IP addresses to route to this node
-	Endpoints    []string       `json:",omitempty"` // IP+port (public via STUN, and local LANs)
+	Addresses    []netip.Prefix   // IP addresses of this Node directly
+	AllowedIPs   []netip.Prefix   // range of IP addresses to route to this node
+	Endpoints    []netip.AddrPort `json:",omitempty"` // IP+port (public via STUN, and local LANs)
 
 	// DERP is this node's home DERP region ID integer, but shoved into an
 	// IP:port string for legacy reasons. The IP address is always "127.3.3.40"
@@ -1211,7 +1211,7 @@ type MapRequest struct {
 
 	// Endpoints are the client's magicsock UDP ip:port endpoints (IPv4 or IPv6).
 	// These can be ignored if Stream is true and Version >= 68.
-	Endpoints []string
+	Endpoints []netip.AddrPort `json:",omitempty"`
 	// EndpointTypes are the types of the corresponding endpoints in Endpoints.
 	EndpointTypes []EndpointType `json:",omitempty"`
 
@@ -2516,7 +2516,7 @@ type PeerChange struct {
 
 	// Endpoints, if non-empty, means that NodeID's UDP Endpoints
 	// have changed to these.
-	Endpoints []string `json:",omitempty"`
+	Endpoints []netip.AddrPort `json:",omitempty"`
 
 	// Key, if non-nil, means that the NodeID's wireguard public key changed.
 	Key *key.NodePublic `json:",omitempty"`

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -97,7 +97,7 @@ var _NodeCloneNeedsRegeneration = Node(struct {
 	DiscoKey                      key.DiscoPublic
 	Addresses                     []netip.Prefix
 	AllowedIPs                    []netip.Prefix
-	Endpoints                     []string
+	Endpoints                     []netip.AddrPort
 	DERP                          string
 	Hostinfo                      HostinfoView
 	Created                       time.Time

--- a/tailcfg/tailcfg_test.go
+++ b/tailcfg/tailcfg_test.go
@@ -466,13 +466,13 @@ func TestNodeEqual(t *testing.T) {
 			true,
 		},
 		{
-			&Node{Endpoints: []string{}},
+			&Node{Endpoints: []netip.AddrPort{}},
 			&Node{Endpoints: nil},
 			false,
 		},
 		{
-			&Node{Endpoints: []string{}},
-			&Node{Endpoints: []string{}},
+			&Node{Endpoints: []netip.AddrPort{}},
+			&Node{Endpoints: []netip.AddrPort{}},
 			true,
 		},
 		{
@@ -677,7 +677,7 @@ func TestCloneNode(t *testing.T) {
 		{"zero_fields", &Node{
 			Addresses:  make([]netip.Prefix, 0),
 			AllowedIPs: make([]netip.Prefix, 0),
-			Endpoints:  make([]string, 0),
+			Endpoints:  make([]netip.AddrPort, 0),
 		}},
 	}
 	for _, tt := range tests {

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -142,7 +142,7 @@ func (v NodeView) Machine() key.MachinePublic               { return v.ж.Machin
 func (v NodeView) DiscoKey() key.DiscoPublic                { return v.ж.DiscoKey }
 func (v NodeView) Addresses() views.Slice[netip.Prefix]     { return views.SliceOf(v.ж.Addresses) }
 func (v NodeView) AllowedIPs() views.Slice[netip.Prefix]    { return views.SliceOf(v.ж.AllowedIPs) }
-func (v NodeView) Endpoints() views.Slice[string]           { return views.SliceOf(v.ж.Endpoints) }
+func (v NodeView) Endpoints() views.Slice[netip.AddrPort]   { return views.SliceOf(v.ж.Endpoints) }
 func (v NodeView) DERP() string                             { return v.ж.DERP }
 func (v NodeView) Hostinfo() HostinfoView                   { return v.ж.Hostinfo }
 func (v NodeView) Created() time.Time                       { return v.ж.Created }
@@ -214,7 +214,7 @@ var _NodeViewNeedsRegeneration = Node(struct {
 	DiscoKey                      key.DiscoPublic
 	Addresses                     []netip.Prefix
 	AllowedIPs                    []netip.Prefix
-	Endpoints                     []string
+	Endpoints                     []netip.AddrPort
 	DERP                          string
 	Hostinfo                      HostinfoView
 	Created                       time.Time

--- a/tstest/integration/testcontrol/testcontrol.go
+++ b/tstest/integration/testcontrol/testcontrol.go
@@ -1035,7 +1035,7 @@ func (s *Server) encode(mkey key.MachinePublic, compress bool, v any) (b []byte,
 //
 // Two types of IPv6 endpoints are considered invalid: link-local
 // addresses, and anything with a zone.
-func filterInvalidIPv6Endpoints(eps []string) []string {
+func filterInvalidIPv6Endpoints(eps []netip.AddrPort) []netip.AddrPort {
 	clean := eps[:0]
 	for _, ep := range eps {
 		if keepClientEndpoint(ep) {
@@ -1045,13 +1045,7 @@ func filterInvalidIPv6Endpoints(eps []string) []string {
 	return clean
 }
 
-func keepClientEndpoint(ep string) bool {
-	ipp, err := netip.ParseAddrPort(ep)
-	if err != nil {
-		// Shouldn't have made it this far if we unmarshalled
-		// the incoming JSON response.
-		return false
-	}
+func keepClientEndpoint(ipp netip.AddrPort) bool {
 	ip := ipp.Addr()
 	if ip.Zone() != "" {
 		return false

--- a/types/netmap/netmap.go
+++ b/types/netmap/netmap.go
@@ -267,7 +267,7 @@ func printPeerConcise(buf *strings.Builder, p tailcfg.NodeView) {
 
 	ep := make([]string, p.Endpoints().Len())
 	for i := range ep {
-		e := p.Endpoints().At(i)
+		e := p.Endpoints().At(i).String()
 		// Align vertically on the ':' between IP and port
 		colon := strings.IndexByte(e, ':')
 		spaces := 0

--- a/types/netmap/netmap_test.go
+++ b/types/netmap/netmap_test.go
@@ -42,6 +42,14 @@ func nodeViews(v []*tailcfg.Node) []tailcfg.NodeView {
 	return nv
 }
 
+func eps(s ...string) []netip.AddrPort {
+	var eps []netip.AddrPort
+	for _, ep := range s {
+		eps = append(eps, netip.MustParseAddrPort(ep))
+	}
+	return eps
+}
+
 func TestNetworkMapConcise(t *testing.T) {
 	for _, tt := range []struct {
 		name string
@@ -56,12 +64,12 @@ func TestNetworkMapConcise(t *testing.T) {
 					{
 						Key:       testNodeKey(2),
 						DERP:      "127.3.3.40:2",
-						Endpoints: []string{"192.168.0.100:12", "192.168.0.100:12354"},
+						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 					{
 						Key:       testNodeKey(3),
 						DERP:      "127.3.3.40:4",
-						Endpoints: []string{"10.2.0.100:12", "10.1.0.100:12345"},
+						Endpoints: eps("10.2.0.100:12", "10.1.0.100:12345"),
 					},
 				}),
 			},
@@ -95,7 +103,7 @@ func TestConciseDiffFrom(t *testing.T) {
 					{
 						Key:       testNodeKey(2),
 						DERP:      "127.3.3.40:2",
-						Endpoints: []string{"192.168.0.100:12", "192.168.0.100:12354"},
+						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 				}),
 			},
@@ -105,7 +113,7 @@ func TestConciseDiffFrom(t *testing.T) {
 					{
 						Key:       testNodeKey(2),
 						DERP:      "127.3.3.40:2",
-						Endpoints: []string{"192.168.0.100:12", "192.168.0.100:12354"},
+						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 				}),
 			},
@@ -119,7 +127,7 @@ func TestConciseDiffFrom(t *testing.T) {
 					{
 						Key:       testNodeKey(2),
 						DERP:      "127.3.3.40:2",
-						Endpoints: []string{"192.168.0.100:12", "192.168.0.100:12354"},
+						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 				}),
 			},
@@ -129,7 +137,7 @@ func TestConciseDiffFrom(t *testing.T) {
 					{
 						Key:       testNodeKey(2),
 						DERP:      "127.3.3.40:2",
-						Endpoints: []string{"192.168.0.100:12", "192.168.0.100:12354"},
+						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 				}),
 			},
@@ -144,7 +152,7 @@ func TestConciseDiffFrom(t *testing.T) {
 						ID:        2,
 						Key:       testNodeKey(2),
 						DERP:      "127.3.3.40:2",
-						Endpoints: []string{"192.168.0.100:12", "192.168.0.100:12354"},
+						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 				}),
 			},
@@ -155,19 +163,19 @@ func TestConciseDiffFrom(t *testing.T) {
 						ID:        1,
 						Key:       testNodeKey(1),
 						DERP:      "127.3.3.40:1",
-						Endpoints: []string{"192.168.0.100:12", "192.168.0.100:12354"},
+						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 					{
 						ID:        2,
 						Key:       testNodeKey(2),
 						DERP:      "127.3.3.40:2",
-						Endpoints: []string{"192.168.0.100:12", "192.168.0.100:12354"},
+						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 					{
 						ID:        3,
 						Key:       testNodeKey(3),
 						DERP:      "127.3.3.40:3",
-						Endpoints: []string{"192.168.0.100:12", "192.168.0.100:12354"},
+						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 				}),
 			},
@@ -182,19 +190,19 @@ func TestConciseDiffFrom(t *testing.T) {
 						ID:        1,
 						Key:       testNodeKey(1),
 						DERP:      "127.3.3.40:1",
-						Endpoints: []string{"192.168.0.100:12", "192.168.0.100:12354"},
+						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 					{
 						ID:        2,
 						Key:       testNodeKey(2),
 						DERP:      "127.3.3.40:2",
-						Endpoints: []string{"192.168.0.100:12", "192.168.0.100:12354"},
+						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 					{
 						ID:        3,
 						Key:       testNodeKey(3),
 						DERP:      "127.3.3.40:3",
-						Endpoints: []string{"192.168.0.100:12", "192.168.0.100:12354"},
+						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 				}),
 			},
@@ -205,7 +213,7 @@ func TestConciseDiffFrom(t *testing.T) {
 						ID:        2,
 						Key:       testNodeKey(2),
 						DERP:      "127.3.3.40:2",
-						Endpoints: []string{"192.168.0.100:12", "192.168.0.100:12354"},
+						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 				}),
 			},
@@ -220,7 +228,7 @@ func TestConciseDiffFrom(t *testing.T) {
 						ID:        2,
 						Key:       testNodeKey(2),
 						DERP:      "127.3.3.40:2",
-						Endpoints: []string{"192.168.0.100:12", "1.1.1.1:1"},
+						Endpoints: eps("192.168.0.100:12", "1.1.1.1:1"),
 					},
 				}),
 			},
@@ -231,7 +239,7 @@ func TestConciseDiffFrom(t *testing.T) {
 						ID:        2,
 						Key:       testNodeKey(2),
 						DERP:      "127.3.3.40:2",
-						Endpoints: []string{"192.168.0.100:12", "1.1.1.1:2"},
+						Endpoints: eps("192.168.0.100:12", "1.1.1.1:2"),
 					},
 				}),
 			},
@@ -246,7 +254,7 @@ func TestConciseDiffFrom(t *testing.T) {
 						ID:         2,
 						Key:        testNodeKey(2),
 						DERP:       "127.3.3.40:2",
-						Endpoints:  []string{"192.168.0.100:41641", "1.1.1.1:41641"},
+						Endpoints:  eps("192.168.0.100:41641", "1.1.1.1:41641"),
 						DiscoKey:   testDiscoKey("f00f00f00f"),
 						AllowedIPs: []netip.Prefix{netip.PrefixFrom(netaddr.IPv4(100, 102, 103, 104), 32)},
 					},
@@ -259,7 +267,7 @@ func TestConciseDiffFrom(t *testing.T) {
 						ID:         2,
 						Key:        testNodeKey(2),
 						DERP:       "127.3.3.40:2",
-						Endpoints:  []string{"192.168.0.100:41641", "1.1.1.1:41641"},
+						Endpoints:  eps("192.168.0.100:41641", "1.1.1.1:41641"),
 						DiscoKey:   testDiscoKey("ba4ba4ba4b"),
 						AllowedIPs: []netip.Prefix{netip.PrefixFrom(netaddr.IPv4(100, 102, 103, 104), 32)},
 					},

--- a/types/netmap/nodemut.go
+++ b/types/netmap/nodemut.go
@@ -45,11 +45,7 @@ type NodeMutationEndpoints struct {
 }
 
 func (m NodeMutationEndpoints) Apply(n *tailcfg.Node) {
-	eps := make([]string, len(m.Endpoints))
-	for i, ep := range m.Endpoints {
-		eps[i] = ep.String()
-	}
-	n.Endpoints = eps
+	n.Endpoints = slices.Clone(m.Endpoints)
 }
 
 // NodeMutationOnline is a NodeMutation that says a node is now online or
@@ -105,15 +101,7 @@ func NodeMutationsFromPatch(p *tailcfg.PeerChange) (_ []NodeMutation, ok bool) {
 		case "DERPRegion":
 			ret = append(ret, NodeMutationDERPHome{mutatingNodeID(p.NodeID), p.DERPRegion})
 		case "Endpoints":
-			eps := make([]netip.AddrPort, len(p.Endpoints))
-			for i, epStr := range p.Endpoints {
-				var err error
-				eps[i], err = netip.ParseAddrPort(epStr)
-				if err != nil {
-					return nil, false
-				}
-			}
-			ret = append(ret, NodeMutationEndpoints{mutatingNodeID(p.NodeID), eps})
+			ret = append(ret, NodeMutationEndpoints{mutatingNodeID(p.NodeID), slices.Clone(p.Endpoints)})
 		case "Online":
 			ret = append(ret, NodeMutationOnline{mutatingNodeID(p.NodeID), *p.Online})
 		case "LastSeen":

--- a/types/netmap/nodemut_test.go
+++ b/types/netmap/nodemut_test.go
@@ -91,10 +91,10 @@ func TestMutationsFromMapResponse(t *testing.T) {
 			name: "patch-ep",
 			mr: fromChanges(&tailcfg.PeerChange{
 				NodeID:    1,
-				Endpoints: []string{"1.2.3.4:567"},
+				Endpoints: eps("1.2.3.4:567"),
 			}, &tailcfg.PeerChange{
 				NodeID:    2,
-				Endpoints: []string{"8.9.10.11:1234"},
+				Endpoints: eps("8.9.10.11:1234"),
 			}),
 			want: muts(
 				NodeMutationEndpoints{1, []netip.AddrPort{netip.MustParseAddrPort("1.2.3.4:567")}},

--- a/wgengine/bench/wg.go
+++ b/wgengine/bench/wg.go
@@ -26,6 +26,13 @@ import (
 	"tailscale.com/wgengine/wgcfg"
 )
 
+func epFromTyped(eps []tailcfg.Endpoint) (ret []netip.AddrPort) {
+	for _, ep := range eps {
+		ret = append(ret, ep.Addr)
+	}
+	return
+}
+
 func setupWGTest(b *testing.B, logf logger.Logf, traf *TrafficGen, a1, a2 netip.Prefix) {
 	l1 := logger.WithPrefix(logf, "e1: ")
 	k1 := key.NewNode()
@@ -96,17 +103,12 @@ func setupWGTest(b *testing.B, logf logger.Logf, traf *TrafficGen, a1, a2 netip.
 		}
 		logf("e1 status: %v", *st)
 
-		var eps []string
-		for _, ep := range st.LocalAddrs {
-			eps = append(eps, ep.Addr.String())
-		}
-
 		n := &tailcfg.Node{
 			ID:         tailcfg.NodeID(0),
 			Name:       "n1",
 			Addresses:  []netip.Prefix{a1},
 			AllowedIPs: []netip.Prefix{a1},
-			Endpoints:  eps,
+			Endpoints:  epFromTyped(st.LocalAddrs),
 		}
 		e2.SetNetworkMap(&netmap.NetworkMap{
 			NodeKey:    k2.Public(),
@@ -133,17 +135,12 @@ func setupWGTest(b *testing.B, logf logger.Logf, traf *TrafficGen, a1, a2 netip.
 		}
 		logf("e2 status: %v", *st)
 
-		var eps []string
-		for _, ep := range st.LocalAddrs {
-			eps = append(eps, ep.Addr.String())
-		}
-
 		n := &tailcfg.Node{
 			ID:         tailcfg.NodeID(0),
 			Name:       "n2",
 			Addresses:  []netip.Prefix{a2},
 			AllowedIPs: []netip.Prefix{a2},
-			Endpoints:  eps,
+			Endpoints:  epFromTyped(st.LocalAddrs),
 		}
 		e1.SetNetworkMap(&netmap.NetworkMap{
 			NodeKey:    k1.Public(),

--- a/wgengine/magicsock/endpoint.go
+++ b/wgengine/magicsock/endpoint.go
@@ -29,7 +29,6 @@ import (
 	"tailscale.com/tstime/mono"
 	"tailscale.com/types/key"
 	"tailscale.com/types/logger"
-	"tailscale.com/types/views"
 	"tailscale.com/util/mak"
 	"tailscale.com/util/ringbuffer"
 )
@@ -812,19 +811,7 @@ func (de *endpoint) updateFromNode(n tailcfg.NodeView, heartbeatDisabled bool) {
 		de.derpAddr = newDerp
 	}
 
-	de.setEndpointsLocked(addrPortsFromStringsView{n.Endpoints()})
-}
-
-// addrPortsFromStringsView converts a view of AddrPort strings
-// to a view-like thing of netip.AddrPort.
-// TODO(bradfitz): change the type of tailcfg.Node.Endpoint.
-type addrPortsFromStringsView struct {
-	views.Slice[string]
-}
-
-func (a addrPortsFromStringsView) At(i int) netip.AddrPort {
-	ap, _ := netip.ParseAddrPort(a.Slice.At(i))
-	return ap // or the zero value on error
+	de.setEndpointsLocked(n.Endpoints())
 }
 
 func (de *endpoint) setEndpointsLocked(eps interface {


### PR DESCRIPTION
It's JSON wire compatible.

Updates #cleanup
