### PR TITLE
net/tstun: remove unused function DefaultMTU()

### DIFF
--- a/net/tstun/mtu.go
+++ b/net/tstun/mtu.go
@@ -141,12 +141,6 @@ func DefaultTUNMTU() TUNMTU {
 	return safeTUNMTU
 }
 
-// Temporary workaround for code on corp that uses this function name.
-// TODO(val): Remove as soon as corp OSS is updated.
-func DefaultMTU() uint32 {
-	return uint32(DefaultTUNMTU())
-}
-
 // DefaultWireMTU returns the default TUN MTU, adjusted for wireguard
 // overhead.
 func DefaultWireMTU() WireMTU {


### PR DESCRIPTION
Now that corp is updated, remove the shim code to bridge the rename from DefaultMTU() to DefaultTUNMTU.

Updates #311