### PR TITLE
cmd/tailscale,ipn/ipnlocal: print debug component names

### DIFF
--- a/cmd/tailscale/cli/debug.go
+++ b/cmd/tailscale/cli/debug.go
@@ -63,9 +63,10 @@ var debugCmd = &ffcli.Command{
 			ShortHelp: "print DERP map",
 		},
 		{
-			Name:      "component-logs",
-			Exec:      runDebugComponentLogs,
-			ShortHelp: "enable/disable debug logs for a component",
+			Name:       "component-logs",
+			Exec:       runDebugComponentLogs,
+			ShortHelp:  "enable/disable debug logs for a component",
+			ShortUsage: "tailscale debug component-logs [" + strings.Join(ipn.DebuggableComponents, "|") + "]",
 			FlagSet: (func() *flag.FlagSet {
 				fs := newFlagSet("component-logs")
 				fs.DurationVar(&debugComponentLogsArgs.forDur, "for", time.Hour, "how long to enable debug logs for; zero or negative means to disable")
@@ -724,7 +725,7 @@ var debugComponentLogsArgs struct {
 
 func runDebugComponentLogs(ctx context.Context, args []string) error {
 	if len(args) != 1 {
-		return errors.New("usage: debug component-logs <component>")
+		return errors.New("usage: debug component-logs [" + strings.Join(ipn.DebuggableComponents, "|") + "]")
 	}
 	component := args[0]
 	dur := debugComponentLogsArgs.forDur

--- a/ipn/backend.go
+++ b/ipn/backend.go
@@ -192,6 +192,13 @@ type PartialFile struct {
 //   - "_debug_<component>_until" with value being a unix timestamp stringified
 type StateKey string
 
+// DebuggableComponents is a list of components whose debugging can be turned on
+// and off individually using the tailscale debug command.
+var DebuggableComponents = []string{
+	"magicsock",
+	"sockstats",
+}
+
 type Options struct {
 	// FrontendLogID is the public logtail id used by the frontend.
 	FrontendLogID string

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -386,7 +386,7 @@ func NewLocalBackend(logf logger.Logf, logID logid.PublicID, sys *tsd.System, lo
 		b.logf("[unexpected] failed to wire up PeerAPI port for engine %T", e)
 	}
 
-	for _, component := range debuggableComponents {
+	for _, component := range ipn.DebuggableComponents {
 		key := componentStateKey(component)
 		if ut, err := ipn.ReadStoreInt(pm.Store(), key); err == nil {
 			if until := time.Unix(ut, 0); until.After(b.clock.Now()) {
@@ -402,11 +402,6 @@ func NewLocalBackend(logf logger.Logf, logID logid.PublicID, sys *tsd.System, lo
 type componentLogState struct {
 	until time.Time
 	timer tstime.TimerController // if non-nil, the AfterFunc to disable it
-}
-
-var debuggableComponents = []string{
-	"magicsock",
-	"sockstats",
 }
 
 func componentStateKey(component string) ipn.StateKey {
@@ -440,7 +435,7 @@ func (b *LocalBackend) SetComponentDebugLogging(component string, until time.Tim
 			}
 		}
 	}
-	if setEnabled == nil || !slices.Contains(debuggableComponents, component) {
+	if setEnabled == nil || !slices.Contains(ipn.DebuggableComponents, component) {
 		return fmt.Errorf("unknown component %q", component)
 	}
 	timeUnixOrZero := func(t time.Time) int64 {


### PR DESCRIPTION
Make the 'tailscale debug component-logs' command print the component names for which extra logging can be turned on, for easier discoverability of debug functions.

Updates #cleanup