### PR TITLE
net/tstun: finish wiring IPv6 NAT support

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -117,7 +117,8 @@ type CapabilityVersion int
 //   - 74: 2023-09-18: Client understands NodeCapMap
 //   - 75: 2023-09-12: Client understands NodeAttrDNSForwarderDisableTCPRetries
 //   - 76: 2023-09-20: Client understands ExitNodeDNSResolvers for IsWireGuardOnly nodes
-const CurrentCapabilityVersion CapabilityVersion = 76
+//   - 77: 2023-10-03: Client understands Peers[].SelfNodeV6MasqAddrForThisPeer
+const CurrentCapabilityVersion CapabilityVersion = 77
 
 type StableID string
 

--- a/tstest/integration/testcontrol/testcontrol.go
+++ b/tstest/integration/testcontrol/testcontrol.go
@@ -900,8 +900,13 @@ func (s *Server) MapResponse(req *tailcfg.MapRequest) (res *tailcfg.MapResponse,
 		peerAddress := s.masquerades[p.Key][node.Key]
 		s.mu.Unlock()
 		if peerAddress.IsValid() {
-			p.Addresses[0] = netip.PrefixFrom(peerAddress, peerAddress.BitLen())
-			p.AllowedIPs[0] = netip.PrefixFrom(peerAddress, peerAddress.BitLen())
+			if peerAddress.Is6() {
+				p.Addresses[1] = netip.PrefixFrom(peerAddress, peerAddress.BitLen())
+				p.AllowedIPs[1] = netip.PrefixFrom(peerAddress, peerAddress.BitLen())
+			} else {
+				p.Addresses[0] = netip.PrefixFrom(peerAddress, peerAddress.BitLen())
+				p.AllowedIPs[0] = netip.PrefixFrom(peerAddress, peerAddress.BitLen())
+			}
 		}
 		res.Peers = append(res.Peers, p)
 	}

--- a/types/ipproto/ipproto.go
+++ b/types/ipproto/ipproto.go
@@ -6,6 +6,26 @@ package ipproto
 
 import "fmt"
 
+// IPProtoVersion describes the IP address version.
+type IPProtoVersion uint8
+
+// Valid IPProtoVersion values.
+const (
+	IPProtoVersion4 = 4
+	IPProtoVersion6 = 6
+)
+
+func (p IPProtoVersion) String() string {
+	switch p {
+	case IPProtoVersion4:
+		return "IPv4"
+	case IPProtoVersion6:
+		return "IPv6"
+	default:
+		return fmt.Sprintf("IPProtoVersion-%d", int(p))
+	}
+}
+
 // Proto is an IP subprotocol as defined by the IANA protocol
 // numbers list
 // (https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml),


### PR DESCRIPTION
This change generalizes the natConfig type in the data plane to handle both ipv6 and ipv4 addresses. The existing implementation is unchanged, the main changes are just struct structuring and construction of the NAT tables for different address families.

The existing NAT test is updated to also run with v6 addresses and passes fine.

I will need someone with a v6 internet connection to test this manually. This probably looks like:
1. Pulling my changes
2. Enabling mullvad and configuring it for your local node
3. Yeeting some change to set `SelfNodeV6MasqAddrForThisPeer` appropriately for the mullvad peers (/cc @james what would this be?)
4. Building/running locally and see if you can send v6 traffic over Mullvad