### PR TITLE
cmd/tailscale/cli: add update notification to "up"

### DIFF
--- a/cmd/tailscale/cli/status.go
+++ b/cmd/tailscale/cli/status.go
@@ -25,6 +25,7 @@ import (
 	"tailscale.com/net/interfaces"
 	"tailscale.com/util/cmpx"
 	"tailscale.com/util/dnsname"
+	"tailscale.com/version"
 )
 
 var statusCmd = &ffcli.Command{
@@ -237,7 +238,7 @@ func runStatus(ctx context.Context, args []string) error {
 	}
 	printFunnelStatus(ctx)
 	if cv := st.ClientVersion; cv != nil && !cv.RunningLatest && cv.LatestVersion != "" {
-		printf("# New Tailscale version is available: %q, run `tailscale update` to update.\n", cv.LatestVersion)
+		printf("# Update available: %v -> %v, run `tailscale update` or `tailscale set --auto-update` to update.\n", version.Short(), cv.LatestVersion)
 	}
 	return nil
 }


### PR DESCRIPTION
Add available update message in "tailscale up" output. Also update the message in "tailscale status" to match and mention auto-update.

Note: we might need to remove the `tailscale set --auto-update` part if we don't finish everything before 1.52 release.

Updates https://github.com/tailscale/tailscale/issues/755