### PR TITLE
Revert "tool/gocross: disable Linux static linking if GOCROSS_STATIC=0"

### DIFF
--- a/tool/gocross/autoflags.go
+++ b/tool/gocross/autoflags.go
@@ -6,7 +6,6 @@ package main
 import (
 	"fmt"
 	"runtime"
-	"strconv"
 	"strings"
 
 	"tailscale.com/version/mkversion"
@@ -63,9 +62,6 @@ func autoflagsForTest(argv []string, env *Environment, goroot, nativeGOOS, nativ
 
 	switch targetOS {
 	case "linux":
-		if v, _ := strconv.ParseBool(env.Get("GOCROSS_STATIC", "1")); !v {
-			break
-		}
 		// Getting Go to build a static binary with cgo enabled is a
 		// minor ordeal. The incantations you apparently need are
 		// documented at: https://github.com/golang/go/issues/26492


### PR DESCRIPTION
This reverts commit 2c0f0ee759cc571db06b4615c900fc2e905498b1.

Fixed by efac2cb8d672670b7

Updates tailscale/corp#15058
Updates tailscale/corp#13113
