### PR TITLE
disco,net/tstun,wgengine/magicsock: probe and record peer MTU

### DIFF
--- a/disco/disco.go
+++ b/disco/disco.go
@@ -261,7 +261,7 @@ func parsePong(ver uint8, p []byte) (m *Pong, err error) {
 func MessageSummary(m Message) string {
 	switch m := m.(type) {
 	case *Ping:
-		return fmt.Sprintf("ping tx=%x", m.TxID[:6])
+		return fmt.Sprintf("ping tx=%x padding=%v", m.TxID[:6], m.Padding)
 	case *Pong:
 		return fmt.Sprintf("pong tx=%x", m.TxID[:6])
 	case *CallMeMaybe:

--- a/net/tstun/mtu_test.go
+++ b/net/tstun/mtu_test.go
@@ -39,15 +39,18 @@ func TestDefaultTunMTU(t *testing.T) {
 		t.Errorf("default TUN MTU = %d, want %d, clamping failed", DefaultTUNMTU(), maxTUNMTU)
 	}
 
-	// If PMTUD is enabled, the MTU should default to the largest probed
-	// MTU, but only if the user hasn't requested a specific MTU.
+	// If PMTUD is enabled, the MTU should default to the safe MTU, but only
+	// if the user hasn't requested a specific MTU.
+	//
+	// TODO: When PMTUD is generating PTB responses, this will become the
+	// largest MTU we probe.
 	os.Setenv("TS_DEBUG_MTU", "")
 	os.Setenv("TS_DEBUG_ENABLE_PMTUD", "true")
-	if DefaultTUNMTU() != WireToTUNMTU(MaxProbedWireMTU) {
-		t.Errorf("default TUN MTU = %d, want %d", DefaultTUNMTU(), WireToTUNMTU(MaxProbedWireMTU))
+	if DefaultTUNMTU() != safeTUNMTU {
+		t.Errorf("default TUN MTU = %d, want %d", DefaultTUNMTU(), safeTUNMTU)
 	}
 	// TS_DEBUG_MTU should take precedence over TS_DEBUG_ENABLE_PMTUD.
-	mtu = WireToTUNMTU(MaxProbedWireMTU - 1)
+	mtu = WireToTUNMTU(MaxPacketSize - 1)
 	os.Setenv("TS_DEBUG_MTU", strconv.Itoa(int(mtu)))
 	if DefaultTUNMTU() != mtu {
 		t.Errorf("default TUN MTU = %d, want %d", DefaultTUNMTU(), mtu)

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -1567,7 +1567,7 @@ func (c *Conn) handlePingLocked(dm *disco.Ping, src netip.AddrPort, di *discoInf
 		if numNodes > 1 {
 			pingNodeSrcStr = "[one-of-multi]"
 		}
-		c.dlogf("[v1] magicsock: disco: %v<-%v (%v, %v)  got ping tx=%x", c.discoShort, di.discoShort, pingNodeSrcStr, src, dm.TxID[:6])
+		c.dlogf("[v1] magicsock: disco: %v<-%v (%v, %v)  got ping tx=%x padding=%v", c.discoShort, di.discoShort, pingNodeSrcStr, src, dm.TxID[:6], dm.Padding)
 	}
 
 	ipDst := src

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -2936,7 +2936,7 @@ func TestAddrForPingSizeLocked(t *testing.T) {
 		},
 		{
 			desc:            "ping_size_too_big_for_trusted_UDP_addr_should_start_discovery_and_send_to_DERP",
-			size:            pktLenToPingSize(1501, validUdpAddr.Addr()),
+			size:            pktLenToPingSize(1501, validUdpAddr.Addr().Is6()),
 			mtu:             1500,
 			bestAddr:        true,
 			bestAddrTrusted: true,
@@ -2945,7 +2945,7 @@ func TestAddrForPingSizeLocked(t *testing.T) {
 		},
 		{
 			desc:            "ping_size_too_big_for_untrusted_UDP_addr_should_start_discovery_and_send_to_DERP",
-			size:            pktLenToPingSize(1501, validUdpAddr.Addr()),
+			size:            pktLenToPingSize(1501, validUdpAddr.Addr().Is6()),
 			mtu:             1500,
 			bestAddr:        true,
 			bestAddrTrusted: false,
@@ -2954,7 +2954,7 @@ func TestAddrForPingSizeLocked(t *testing.T) {
 		},
 		{
 			desc:            "ping_size_small_enough_for_trusted_UDP_addr_should_send_to_UDP_and_not_DERP",
-			size:            pktLenToPingSize(1500, validUdpAddr.Addr()),
+			size:            pktLenToPingSize(1500, validUdpAddr.Addr().Is6()),
 			mtu:             1500,
 			bestAddr:        true,
 			bestAddrTrusted: true,
@@ -2963,7 +2963,7 @@ func TestAddrForPingSizeLocked(t *testing.T) {
 		},
 		{
 			desc:            "ping_size_small_enough_for_untrusted_UDP_addr_should_send_to_UDP_and_DERP",
-			size:            pktLenToPingSize(1500, validUdpAddr.Addr()),
+			size:            pktLenToPingSize(1500, validUdpAddr.Addr().Is6()),
 			mtu:             1500,
 			bestAddr:        true,
 			bestAddrTrusted: false,

--- a/wgengine/magicsock/peermtu.go
+++ b/wgengine/magicsock/peermtu.go
@@ -5,6 +5,8 @@
 
 package magicsock
 
+import "tailscale.com/net/tstun"
+
 // Peer path MTU routines shared by platforms that implement it.
 
 // DontFragSetting returns true if at least one of the underlying sockets of
@@ -101,6 +103,9 @@ func (c *Conn) UpdatePMTUD() {
 		_ = c.setDontFragment("udp4", false)
 		_ = c.setDontFragment("udp6", false)
 		newStatus = false
+	}
+	if debugPMTUD() {
+		c.logf("magicsock: peermtu: peer MTU probes are %v", tstun.WireMTUsToProbe)
 	}
 	c.peerMTUEnabled.Store(newStatus)
 	c.resetEndpointStates()


### PR DESCRIPTION
disco,net/tstun,wgengine/magicsock: probe and record peer MTU

Automatically probe and record the path MTU to a peer when peer MTU is enabled, 
but do not use the MTU information for anything other than metrics yet.

Updates #311
