### PR TITLE
portlist: populate Pid field on Linux

### DIFF
--- a/portlist/portlist.go
+++ b/portlist/portlist.go
@@ -17,8 +17,8 @@ import (
 type Port struct {
 	Proto   string // "tcp" or "udp"
 	Port    uint16 // port number
-	Process string // optional process name, if found
-	Pid     int    // process id, if known
+	Process string // optional process name, if found (requires suitable permissions)
+	Pid     int    // process ID, if known (requires suitable permissions)
 }
 
 // List is a list of Ports.

--- a/portlist/portlist_linux.go
+++ b/portlist/portlist_linux.go
@@ -322,6 +322,8 @@ func (li *linuxImpl) findProcessNames(need map[string]*portMeta) error {
 				pe.pid = int(p)
 			}
 			pe.port.Process = argvSubject(argv...)
+			pid64, _ := mem.ParseInt(pid, 10, 0)
+			pe.port.Pid = int(pid64)
 			pe.needsProcName = false
 			delete(need, string(targetBuf[:n]))
 			if len(need) == 0 {


### PR DESCRIPTION
The Port.Pid was always more of an implementation detail on some platforms and isn't necessary on Linux so it was never populated. (Nothing outside the portlist package ever used it)

But might as well populate it for consistency since we have it in memory and its absence confused people.

Updates #cleanup
