### PR TITLE
syncs: add Map.LoadOrInit for lazily initialized values

### DIFF
--- a/syncs/syncs_test.go
+++ b/syncs/syncs_test.go
@@ -91,8 +91,11 @@ func TestMap(t *testing.T) {
 	if v, ok := m.LoadOrStore("two", 2); v != 2 || ok {
 		t.Errorf(`LoadOrStore("two", 2) = (%v, %v), want (2, false)`, v, ok)
 	}
+	if v, ok := m.LoadOrInit("three", func() int { return 3 }); v != 3 || ok {
+		t.Errorf(`LoadOrInit("three", 3) = (%v, %v), want (3, true)`, v, ok)
+	}
 	got := map[string]int{}
-	want := map[string]int{"one": 1, "two": 2}
+	want := map[string]int{"one": 1, "two": 2, "three": 3}
 	m.Range(func(k string, v int) bool {
 		got[k] = v
 		return true
@@ -106,6 +109,7 @@ func TestMap(t *testing.T) {
 	if v, ok := m.LoadAndDelete("two"); v != 0 || ok {
 		t.Errorf(`LoadAndDelete("two) = (%v, %v), want (0, false)`, v, ok)
 	}
+	m.Delete("three")
 	m.Delete("one")
 	m.Delete("noexist")
 	got = map[string]int{}


### PR DESCRIPTION
I was reviewing some code that was performing this by hand, and wanted to suggest using syncs.Map, however as the code in question was allocating a non-trivial structure this would be necessary to meet the target.

Updates #cleanup