### PR TITLE
clientupdate,cmd/tailscale/cli: use cli.Stdout/Stderr

### DIFF
--- a/cmd/tailscale/cli/update.go
+++ b/cmd/tailscale/cli/update.go
@@ -63,7 +63,9 @@ func runUpdate(ctx context.Context, args []string) error {
 	err := clientupdate.Update(clientupdate.Arguments{
 		Version:  ver,
 		AppStore: updateArgs.appStore,
-		Logf:     func(format string, args ...any) { fmt.Printf(format+"\n", args...) },
+		Logf:     printf,
+		Stdout:   Stdout,
+		Stderr:   Stderr,
 		Confirm:  confirmUpdate,
 	})
 	if errors.Is(err, errors.ErrUnsupported) {


### PR DESCRIPTION
In case cli.Stdout/Stderr get overriden, all CLI output should use them instead of os.Stdout/Stderr. Update the `update` command to follow this pattern.

Updates #cleanup