### PR TITLE
taildrop: document and cleanup the package

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3545,11 +3545,11 @@ func (b *LocalBackend) initPeerAPIListener() {
 	ps := &peerAPIServer{
 		b: b,
 		taildrop: &taildrop.Handler{
-			Logf:                    b.logf,
-			Clock:                   b.clock,
-			RootDir:                 fileRoot,
-			DirectFileMode:          b.directFileRoot != "",
-			DirectFileDoFinalRename: b.directFileDoFinalRename,
+			Logf:             b.logf,
+			Clock:            b.clock,
+			Dir:              fileRoot,
+			DirectFileMode:   b.directFileRoot != "",
+			AvoidFinalRename: !b.directFileDoFinalRename,
 		},
 	}
 	if dm, ok := b.sys.DNSManager.GetOK(); ok {


### PR DESCRIPTION
Changes made:
* Unexport declarations specific to internal taildrop functionality.
* Document all exported functionality.
* Move TestRedactErr to the taildrop package.
* Rename and invert Handler.DirectFileDoFinalRename as AvoidFinalRename.

Updates tailscale/corp#14772