### PR TITLE
tstest: make ResourceCheck panic on parallel tests

### DIFF
--- a/tstest/resource.go
+++ b/tstest/resource.go
@@ -13,8 +13,19 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+// ResourceCheck takes a snapshot of the current goroutines and registers a
+// cleanup on tb to verify that after the rest, all goroutines created by the
+// test go away. (well, at least that the count matches. Maybe in the future it
+// can look at specific routines).
+//
+// It panics if called from a parallel test.
 func ResourceCheck(tb testing.TB) {
 	tb.Helper()
+
+	// Set an environment variable (anything at all) just for the
+	// side effect of tb.Setenv panicking if we're in a parallel test.
+	tb.Setenv("TS_CHECKING_RESOURCES", "1")
+
 	startN, startStacks := goroutines()
 	tb.Cleanup(func() {
 		if tb.Failed() {

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -705,6 +705,8 @@ func TestDiscokeyChange(t *testing.T) {
 }
 
 func TestActiveDiscovery(t *testing.T) {
+	tstest.ResourceCheck(t)
+
 	t.Run("simple_internet", func(t *testing.T) {
 		t.Parallel()
 		mstun := &natlab.Machine{Name: "stun"}
@@ -900,7 +902,6 @@ func newPinger(t *testing.T, logf logger.Logf, src, dst *magicStack) (cleanup fu
 // get exercised.
 func testActiveDiscovery(t *testing.T, d *devices) {
 	tstest.PanicOnLog()
-	tstest.ResourceCheck(t)
 
 	tlogf, setT := makeNestable(t)
 	setT(t)


### PR DESCRIPTION
To find potential flakes earlier.

Updates #deflake-effort
