### PR TITLE
cmd/tailscale, magicsock: add debug command to flip DERP homes

### DIFF
--- a/cmd/tailscale/cli/debug.go
+++ b/cmd/tailscale/cli/debug.go
@@ -140,6 +140,11 @@ var debugCmd = &ffcli.Command{
 			ShortHelp: "break any open DERP connections from the daemon",
 		},
 		{
+			Name:      "pick-new-derp",
+			Exec:      localAPIAction("pick-new-derp"),
+			ShortHelp: "switch to some other random DERP home region for a short time",
+		},
+		{
 			Name:      "force-netmap-update",
 			Exec:      localAPIAction("force-netmap-update"),
 			ShortHelp: "force a full no-op netmap update (for load testing)",

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -2156,6 +2156,12 @@ func (b *LocalBackend) DebugForceNetmapUpdate() {
 	b.setNetMapLocked(nm)
 }
 
+// DebugPickNewDERP forwards to magicsock.Conn.DebugPickNewDERP.
+// See its docs.
+func (b *LocalBackend) DebugPickNewDERP() error {
+	return b.sys.MagicSock.Get().DebugPickNewDERP()
+}
+
 // send delivers n to the connected frontend and any API watchers from
 // LocalBackend.WatchNotifications (via the LocalAPI).
 //

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -566,6 +566,8 @@ func (h *Handler) serveDebug(w http.ResponseWriter, r *http.Request) {
 		if err == nil {
 			return
 		}
+	case "pick-new-derp":
+		err = h.b.DebugPickNewDERP()
 	case "":
 		err = fmt.Errorf("missing parameter 'action'")
 	default:


### PR DESCRIPTION
For testing netmap patchification server-side.

Updates #1909
