### PR TITLE
client: update Whois docs to reflect implementation

### DIFF
--- a/client/tailscale/localclient.go
+++ b/client/tailscale/localclient.go
@@ -262,7 +262,7 @@ func (lc *LocalClient) get200(ctx context.Context, path string) ([]byte, error) 
 	return lc.send(ctx, "GET", path, 200, nil)
 }
 
-// WhoIs returns the owner of the remoteAddr, which must be an IP or IP:port.
+// WhoIs returns the owner of the remoteAddr, which must be an IP:port.
 //
 // Deprecated: use LocalClient.WhoIs.
 func WhoIs(ctx context.Context, remoteAddr string) (*apitype.WhoIsResponse, error) {
@@ -277,7 +277,7 @@ func decodeJSON[T any](b []byte) (ret T, err error) {
 	return ret, nil
 }
 
-// WhoIs returns the owner of the remoteAddr, which must be an IP or IP:port.
+// WhoIs returns the owner of the remoteAddr, which must be an IP:port.
 func (lc *LocalClient) WhoIs(ctx context.Context, remoteAddr string) (*apitype.WhoIsResponse, error) {
 	body, err := lc.get200(ctx, "/localapi/v0/whois?addr="+url.QueryEscape(remoteAddr))
 	if err != nil {


### PR DESCRIPTION
passing an IP only causes an error here:

https://github.com/tailscale/tailscale/blob/6f36f8842c3ee0908e1d4e50f9d0d9a387c9d980/ipn/localapi/localapi.go#L418-L421