### PR TITLE
cmd/derper,derp,derp/derphttp: fix race in mesh watcher

### DIFF
--- a/cmd/derper/mesh.go
+++ b/cmd/derper/mesh.go
@@ -41,6 +41,7 @@ func startMeshWithHost(s *derp.Server, host string) error {
 		return err
 	}
 	c.MeshKey = s.MeshKey()
+	c.IsWatcher = true
 
 	// For meshed peers within a region, connect via VPC addresses.
 	c.SetURLDialer(func(ctx context.Context, network, addr string) (net.Conn, error) {

--- a/derp/derp.go
+++ b/derp/derp.go
@@ -87,12 +87,7 @@ const (
 	// members of the DERP region when they're meshed up together.
 	framePeerPresent = frameType(0x09) // 32B pub key of peer that's connected + optional 18B ip:port (16 byte IP + 2 byte BE uint16 port)
 
-	// frameWatchConns is how one DERP node in a regional mesh
-	// subscribes to the others in the region.
-	// There's no payload. If the sender doesn't have permission, the connection
-	// is closed. Otherwise, the client is initially flooded with
-	// framePeerPresent for all connected nodes, and then a stream of
-	// framePeerPresent & framePeerGone has peers connect and disconnect.
+	// frameWatchConns is obsolete and has been replaced by the IsWatcher client opt.
 	frameWatchConns = frameType(0x10)
 
 	// frameClosePeer is a privileged frame type (requires the

--- a/derp/derp_client.go
+++ b/derp/derp_client.go
@@ -403,10 +403,6 @@ type ServerInfoMessage struct {
 	// Zero means unspecified. There might be a limit, but the
 	// client need not try to respect it.
 	TokenBucketBytesBurst int
-
-	// AtomicWatchConn is whether this server can do an atomic upgrade of a
-	// connection to become a mesh peer watcher.
-	AtomicWatchConn bool
 }
 
 func (ServerInfoMessage) msg() {}

--- a/derp/derp_test.go
+++ b/derp/derp_test.go
@@ -589,14 +589,11 @@ func newRegularClient(t *testing.T, ts *testServer, name string) *testClient {
 func newTestWatcher(t *testing.T, ts *testServer, name string) *testClient {
 	return newTestClient(t, ts, name, func(nc net.Conn, priv key.NodePrivate, logf logger.Logf) (*Client, error) {
 		brw := bufio.NewReadWriter(bufio.NewReader(nc), bufio.NewWriter(nc))
-		c, err := NewClient(priv, nc, brw, logf, MeshKey("mesh-key"))
+		c, err := NewClient(priv, nc, brw, logf, MeshKey("mesh-key"), IsWatcher(true))
 		if err != nil {
 			return nil, err
 		}
 		waitConnect(t, c)
-		if err := c.WatchConnectionChanges(); err != nil {
-			return nil, err
-		}
 		return c, nil
 	})
 }

--- a/derp/derphttp/derphttp_test.go
+++ b/derp/derphttp/derphttp_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"net"
 	"net/http"
+	"net/netip"
 	"sync"
 	"testing"
 	"time"
@@ -204,5 +205,184 @@ func TestPing(t *testing.T) {
 	err = c.Ping(context.Background())
 	if err != nil {
 		t.Fatalf("Ping: %v", err)
+	}
+}
+
+func newTestServer(t *testing.T, k key.NodePrivate) (serverURL string, s *derp.Server) {
+	s = derp.NewServer(k, t.Logf)
+	httpsrv := &http.Server{
+		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),
+		Handler:      Handler(s),
+	}
+
+	ln, err := net.Listen("tcp4", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverURL = "http://" + ln.Addr().String()
+	s.SetMeshKey("1234")
+
+	go func() {
+		if err := httpsrv.Serve(ln); err != nil {
+			if err == http.ErrServerClosed {
+				t.Logf("server closed")
+				return
+			}
+			panic(err)
+		}
+	}()
+	return
+}
+
+func newWatcherClient(t *testing.T, watcherPrivateKey key.NodePrivate, serverToWatchURL string) (c *Client) {
+	c, err := NewClient(watcherPrivateKey, serverToWatchURL, t.Logf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.MeshKey = "1234"
+	c.IsWatcher = true
+	return
+}
+
+// Simulate a broken connection
+func (c *Client) breakConnection(brokenClient *derp.Client) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.client != brokenClient {
+		return
+	}
+	if c.netConn != nil {
+		c.netConn.Close()
+		c.netConn = nil
+	}
+	c.client = nil
+}
+
+// Test that a watcher connection successfully reconnects and processes peer
+// updates after a different thread breaks and reconnects the connection, while
+// the watcher is waiting on recv().
+func TestBreakWatcherConnRecv(t *testing.T) {
+	// Make the watcher server
+	serverPrivateKey1 := key.NewNode()
+	_, s1 := newTestServer(t, serverPrivateKey1)
+	defer s1.Close()
+
+	// Make the watched server
+	serverPrivateKey2 := key.NewNode()
+	serverURL2, s2 := newTestServer(t, serverPrivateKey2)
+	defer s2.Close()
+
+	// Make the watcher (but it is not connected yet)
+	watcher1 := newWatcherClient(t, serverPrivateKey1, serverURL2)
+	defer watcher1.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	watcherChan := make(chan any, 1)
+
+	var peers int
+	add := func(k key.NodePublic, _ netip.AddrPort) {
+		t.Logf("add: %v", k.ShortString())
+		peers++
+		// Signal that the watcher has run
+		watcherChan <- 0
+	}
+	remove := func(k key.NodePublic) { t.Logf("remove: %v", k.ShortString()); peers-- }
+
+	// Set the wait time after a connection fails to much lower
+	retryInterval = 50 * time.Millisecond
+
+	// Start the watcher thread (which connects to the watched server)
+	go watcher1.RunWatchConnectionLoop(ctx, serverPrivateKey1.Public(), t.Logf, add, remove)
+
+	timer := time.NewTimer(5 * time.Second)
+
+	// Wait for the watcher to run, then break the connection and check if it
+	// reconnected and received peer updates.
+	for i := 0; i < 10; i++ {
+		select {
+		case <-watcherChan:
+			if peers != 1 {
+				t.Fatal("wrong number of peers added during watcher connection")
+			}
+		case <-timer.C:
+			t.Fatalf("watcher did not process the peer update")
+		}
+		watcher1.breakConnection(watcher1.client)
+		// re-establish connection by sending a packet
+		watcher1.ForwardPacket(key.NodePublic{}, key.NodePublic{}, []byte("bogus"))
+
+		if !timer.Stop() {
+			<-timer.C
+		}
+		timer.Reset(5 * time.Second)
+	}
+}
+
+// Test that a watcher connection successfully reconnects and processes peer
+// updates after a different thread breaks and reconnects the connection, while
+// the watcher is not waiting on recv().
+func TestBreakWatcherConn(t *testing.T) {
+	// Make the watcher server
+	serverPrivateKey1 := key.NewNode()
+	_, s1 := newTestServer(t, serverPrivateKey1)
+	defer s1.Close()
+
+	// Make the watched server
+	serverPrivateKey2 := key.NewNode()
+	serverURL2, s2 := newTestServer(t, serverPrivateKey2)
+	defer s2.Close()
+
+	// Make the watcher (but it is not connected yet)
+	watcher1 := newWatcherClient(t, serverPrivateKey1, serverURL2)
+	defer watcher1.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	watcherChan := make(chan any, 1)
+	breakerChan := make(chan any, 1)
+
+	var peers int
+	add := func(k key.NodePublic, _ netip.AddrPort) {
+		t.Logf("add: %v", k.ShortString())
+		peers++
+		// Signal that the watcher has run
+		watcherChan <- 0
+		// Wait for breaker to run
+		<-breakerChan
+	}
+	remove := func(k key.NodePublic) { t.Logf("remove: %v", k.ShortString()); peers-- }
+
+	// Set the wait time after a connection fails to much lower
+	retryInterval = 50 * time.Millisecond
+
+	// Start the watcher thread (which connects to the watched server)
+	go watcher1.RunWatchConnectionLoop(ctx, serverPrivateKey1.Public(), t.Logf, add, remove)
+
+	timer := time.NewTimer(5 * time.Second)
+
+	// Wait for the watcher to run, then break the connection and check if it
+	// reconnected and received peer updates.
+	for i := 0; i < 10; i++ {
+		select {
+		case <-watcherChan:
+			if peers != 1 {
+				t.Fatal("wrong number of peers added during watcher connection")
+			}
+		case <-timer.C:
+			t.Fatalf("watcher did not process the peer update")
+		}
+		watcher1.breakConnection(watcher1.client)
+		// re-establish connection by sending a packet
+		watcher1.ForwardPacket(key.NodePublic{}, key.NodePublic{}, []byte("bogus"))
+		// signal that the breaker is done
+		breakerChan <- 0
+
+		if !timer.Stop() {
+			<-timer.C
+		}
+		timer.Reset(5 * time.Second)
 	}
 }

--- a/derp/derphttp/mesh_client.go
+++ b/derp/derphttp/mesh_client.go
@@ -145,7 +145,6 @@ func (c *Client) RunWatchConnectionLoop(ctx context.Context, ignoreServerKey key
 						key.NodePublic(m.Peer).ShortString(), c.ServerPublicKey().ShortString(), m.Reason)
 				}
 				updatePeer(key.NodePublic(m.Peer), netip.AddrPort{}, false)
-			default:
 			}
 			if now := c.clock.Now(); now.Sub(lastStatus) > statusInterval {
 				lastStatus = now

--- a/derp/derphttp/mesh_client.go
+++ b/derp/derphttp/mesh_client.go
@@ -146,7 +146,6 @@ func (c *Client) RunWatchConnectionLoop(ctx context.Context, ignoreServerKey key
 				}
 				updatePeer(key.NodePublic(m.Peer), netip.AddrPort{}, false)
 			default:
-				// Do nothing
 			}
 			if now := c.clock.Now(); now.Sub(lastStatus) > statusInterval {
 				lastStatus = now


### PR DESCRIPTION
Fix a race condition in the mesh peer update watcher code by replacing the watch connections frame with a client option that atomically upgrade the connection to a watcher connection. Add tests for two different failure modes of the watcher loop.

Fixes tailscale/corp#9916