### PR TITLE
util/linuxfw: move detection logic

### DIFF
--- a/util/linuxfw/detector.go
+++ b/util/linuxfw/detector.go
@@ -1,0 +1,110 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build linux
+
+package linuxfw
+
+import (
+	"tailscale.com/envknob"
+	"tailscale.com/hostinfo"
+	"tailscale.com/types/logger"
+	"tailscale.com/version/distro"
+)
+
+func detectFirewallMode(logf logger.Logf) FirewallMode {
+	if distro.Get() == distro.Gokrazy {
+		// Reduce startup logging on gokrazy. There's no way to do iptables on
+		// gokrazy anyway.
+		logf("GoKrazy should use nftables.")
+		hostinfo.SetFirewallMode("nft-gokrazy")
+		return FirewallModeNfTables
+	}
+
+	envMode := envknob.String("TS_DEBUG_FIREWALL_MODE")
+	// We now use iptables as default and have "auto" and "nftables" as
+	// options for people to test further.
+	switch envMode {
+	case "auto":
+		return pickFirewallModeFromInstalledRules(logf, linuxFWDetector{})
+	case "nftables":
+		logf("envknob TS_DEBUG_FIREWALL_MODE=nftables set")
+		hostinfo.SetFirewallMode("nft-forced")
+		return FirewallModeNfTables
+	case "iptables":
+		logf("envknob TS_DEBUG_FIREWALL_MODE=iptables set")
+		hostinfo.SetFirewallMode("ipt-forced")
+	default:
+		logf("default choosing iptables")
+		hostinfo.SetFirewallMode("ipt-default")
+	}
+	return FirewallModeIPTables
+}
+
+// tableDetector abstracts helpers to detect the firewall mode.
+// It is implemented for testing purposes.
+type tableDetector interface {
+	iptDetect() (int, error)
+	nftDetect() (int, error)
+}
+
+type linuxFWDetector struct{}
+
+// iptDetect returns the number of iptables rules in the current namespace.
+func (l linuxFWDetector) iptDetect() (int, error) {
+	return detectIptables()
+}
+
+// nftDetect returns the number of nftables rules in the current namespace.
+func (l linuxFWDetector) nftDetect() (int, error) {
+	return detectNetfilter()
+}
+
+// pickFirewallModeFromInstalledRules returns the firewall mode to use based on
+// the environment and the system's capabilities.
+func pickFirewallModeFromInstalledRules(logf logger.Logf, det tableDetector) FirewallMode {
+	if distro.Get() == distro.Gokrazy {
+		// Reduce startup logging on gokrazy. There's no way to do iptables on
+		// gokrazy anyway.
+		return FirewallModeNfTables
+	}
+	iptAva, nftAva := true, true
+	iptRuleCount, err := det.iptDetect()
+	if err != nil {
+		logf("detect iptables rule: %v", err)
+		iptAva = false
+	}
+	nftRuleCount, err := det.nftDetect()
+	if err != nil {
+		logf("detect nftables rule: %v", err)
+		nftAva = false
+	}
+	logf("nftables rule count: %d, iptables rule count: %d", nftRuleCount, iptRuleCount)
+	switch {
+	case nftRuleCount > 0 && iptRuleCount == 0:
+		logf("nftables is currently in use")
+		hostinfo.SetFirewallMode("nft-inuse")
+		return FirewallModeNfTables
+	case iptRuleCount > 0 && nftRuleCount == 0:
+		logf("iptables is currently in use")
+		hostinfo.SetFirewallMode("ipt-inuse")
+		return FirewallModeIPTables
+	case nftAva:
+		// if both iptables and nftables are available but
+		// neither/both are currently used, use nftables.
+		logf("nftables is available")
+		hostinfo.SetFirewallMode("nft")
+		return FirewallModeNfTables
+	case iptAva:
+		logf("iptables is available")
+		hostinfo.SetFirewallMode("ipt")
+		return FirewallModeIPTables
+	default:
+		// if neither iptables nor nftables are available, use iptablesRunner as a dummy
+		// runner which exists but won't do anything. Creating iptablesRunner errors only
+		// if the iptables command is missing or doesn’t support "--version", as long as it
+		// can determine a version then it’ll carry on.
+		hostinfo.SetFirewallMode("ipt-fb")
+		return FirewallModeIPTables
+	}
+}

--- a/util/linuxfw/iptables.go
+++ b/util/linuxfw/iptables.go
@@ -23,13 +23,13 @@ func DebugIptables(logf logger.Logf) error {
 	return nil
 }
 
-// DetectIptables returns the number of iptables rules that are present in the
+// detectIptables returns the number of iptables rules that are present in the
 // system, ignoring the default "ACCEPT" rule present in the standard iptables
 // chains.
 //
 // It only returns an error when there is no iptables binary, or when iptables -S
 // fails. In all other cases, it returns the number of non-default rules.
-func DetectIptables() (int, error) {
+func detectIptables() (int, error) {
 	// run "iptables -S" to get the list of rules using iptables
 	// exec.Command returns an error if the binary is not found
 	cmd := exec.Command("iptables", "-S")

--- a/util/linuxfw/iptables_runner.go
+++ b/util/linuxfw/iptables_runner.go
@@ -45,11 +45,11 @@ func checkIP6TablesExists() error {
 	return nil
 }
 
-// NewIPTablesRunner constructs a NetfilterRunner that programs iptables rules.
+// newIPTablesRunner constructs a NetfilterRunner that programs iptables rules.
 // If the underlying iptables library fails to initialize, that error is
 // returned. The runner probes for IPv6 support once at initialization time and
 // if not found, no IPv6 rules will be modified for the lifetime of the runner.
-func NewIPTablesRunner(logf logger.Logf) (*iptablesRunner, error) {
+func newIPTablesRunner(logf logger.Logf) (*iptablesRunner, error) {
 	ipt4, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
 	if err != nil {
 		return nil, err
@@ -79,12 +79,12 @@ func NewIPTablesRunner(logf logger.Logf) (*iptablesRunner, error) {
 	return &iptablesRunner{ipt4, ipt6, supportsV6, supportsV6NAT}, nil
 }
 
-// HasIPV6 returns true if the system supports IPv6.
+// HasIPV6 reports true if the system supports IPv6.
 func (i *iptablesRunner) HasIPV6() bool {
 	return i.v6Available
 }
 
-// HasIPV6NAT returns true if the system supports IPv6 NAT.
+// HasIPV6NAT reports true if the system supports IPv6 NAT.
 func (i *iptablesRunner) HasIPV6NAT() bool {
 	return i.v6NATAvailable
 }

--- a/util/linuxfw/linuxfw_unsupported.go
+++ b/util/linuxfw/linuxfw_unsupported.go
@@ -25,16 +25,16 @@ func DebugNetfilter(logf logger.Logf) error {
 }
 
 // DetectNetfilter is not supported on non-Linux platforms.
-func DetectNetfilter() (int, error) {
+func detectNetfilter() (int, error) {
 	return 0, ErrUnsupported
 }
 
 // DebugIptables is not supported on non-Linux platforms.
-func DebugIptables(logf logger.Logf) error {
+func debugIptables(logf logger.Logf) error {
 	return ErrUnsupported
 }
 
 // DetectIptables is not supported on non-Linux platforms.
-func DetectIptables() (int, error) {
+func detectIptables() (int, error) {
 	return 0, ErrUnsupported
 }

--- a/util/linuxfw/nftables.go
+++ b/util/linuxfw/nftables.go
@@ -103,8 +103,8 @@ func DebugNetfilter(logf logger.Logf) error {
 	return nil
 }
 
-// DetectNetfilter returns the number of nftables rules present in the system.
-func DetectNetfilter() (int, error) {
+// detectNetfilter returns the number of nftables rules present in the system.
+func detectNetfilter() (int, error) {
 	conn, err := nftables.New()
 	if err != nil {
 		return 0, FWModeNotSupportedError{


### PR DESCRIPTION
Just a refactor to consolidate the firewall detection logic in a single package so that it can be reused in a later commit by containerboot.

Updates #9310