### PR TITLE
util/cmpver: faster Compare (-85% runtime)

### DIFF
--- a/util/cmpver/version.go
+++ b/util/cmpver/version.go
@@ -18,83 +18,144 @@
 // version numbers don't need it.
 package cmpver
 
-import (
-	"fmt"
-	"strconv"
-	"strings"
-)
-
-func isnum(r rune) bool {
-	return r >= '0' && r <= '9'
-}
-
-func notnum(r rune) bool {
-	return !isnum(r)
-}
-
 // Compare returns an integer comparing two strings as version
 // numbers. The result will be 0 if v1==v2, -1 if v1 < v2, and +1 if
 // v1 > v2.
 func Compare(v1, v2 string) int {
-	var (
-		f1, f2 string
-		n1, n2 uint64
-		err    error
-	)
-	for v1 != "" || v2 != "" {
-		// Compare the non-numeric character run lexicographically.
-		f1, v1 = splitPrefixFunc(v1, notnum)
-		f2, v2 = splitPrefixFunc(v2, notnum)
-
-		if res := strings.Compare(f1, f2); res != 0 {
-			return res
+	// Get empty strings out of the way.
+	if len(v1) == 0 {
+		if len(v2) == 0 {
+			return 0
 		}
-
-		// Compare the numeric character run numerically.
-		f1, v1 = splitPrefixFunc(v1, isnum)
-		f2, v2 = splitPrefixFunc(v2, isnum)
-
-		// ParseUint refuses to parse empty strings, which would only
-		// happen if we reached end-of-string. We follow the Debian
-		// convention that empty strings mean zero, because
-		// empirically that produces reasonable-feeling comparison
-		// behavior.
-		n1 = 0
-		if f1 != "" {
-			n1, err = strconv.ParseUint(f1, 10, 64)
-			if err != nil {
-				panic(fmt.Sprintf("all-number string %q didn't parse as string: %s", f1, err))
-			}
-		}
-
-		n2 = 0
-		if f2 != "" {
-			n2, err = strconv.ParseUint(f2, 10, 64)
-			if err != nil {
-				panic(fmt.Sprintf("all-number string %q didn't parse as string: %s", f2, err))
-			}
-		}
-
-		switch {
-		case n1 == n2:
-		case n1 < n2:
-			return -1
-		case n1 > n2:
-			return 1
-		}
+		return -1
+	}
+	if len(v2) == 0 {
+		return +1
 	}
 
-	// Only way to reach here is if v1 and v2 run out of fields
-	// simultaneously - i.e. exactly equal versions.
+	i, j := 0, 0
+	for {
+		// Consume runs of non-numeral alpha.
+		for {
+			a, b := v1[i], v2[j]
+			if isnum(a) {
+				if isnum(b) {
+					// We're switching to numbers.
+					break
+				}
+				// v1 has the shorter alpha string ending at i, so it's less.
+				return -1
+			}
+			if isnum(b) {
+				// v1 is the longer alpha string ending at i, so it's greater.
+				return +1
+			}
+
+			// Compare the next char in our text string.
+			if a < b {
+				return -1
+			}
+			if a > b {
+				return +1
+			}
+
+			// Check the next char.
+			i++
+			j++
+			if i == len(v1) || j == len(v2) {
+				goto exhausted
+			}
+		}
+
+		// Discard runs of zero. i and j can diverge here without meaning
+		// there's any difference between v1 and v2.
+		for i < len(v1) && v1[i] == '0' {
+			i++
+		}
+		for j < len(v2) && v2[j] == '0' {
+			j++
+		}
+		if i == len(v1) || j == len(v2) {
+			goto exhausted
+		}
+
+		// Compare runs of numerals.
+		for {
+			// Discard runs of common numerals.
+			a, b := v1[i], v2[j]
+			if !isnum(a) {
+				if !isnum(b) {
+					// The numbers were equal. We're switching to alpha.
+					break
+				}
+				// v2 has more digits, so v1 is less.
+				return -1
+			}
+			if !isnum(b) {
+				// v1 has more digits, so v1 is greater.
+				return +1
+			}
+			if a == b {
+				// Check the next numeral.
+				i++
+				j++
+				if i == len(v1) || j == len(v2) {
+					goto exhausted
+				}
+				continue
+			}
+
+			// Since we've found numeral a != numeral b, then the shortest
+			// remaining run of numerals points to the lower version. If they're
+			// equal length then smallest is determined directly from a and b.
+			for {
+				// Check if v1[i+1] continues to be a number.
+				var cm bool
+				if i+1 < len(v1) && isnum(v1[i+1]) {
+					cm = true
+					i++
+				}
+
+				// Check if v2[j+1] continues to be a number.
+				var cn bool
+				if j+1 < len(v2) && isnum(v2[j+1]) {
+					cn = true
+					j++
+				}
+
+				if !cm {
+					if !cn {
+						// Both numbers are the same length, compare a and b.
+						if a < b {
+							return -1
+						}
+						return +1
+					}
+					// v1 has the shorter run of numerals, so v1 is less.
+					return -1
+				}
+				if !cn {
+					// v2 has the shorter run of numerals, so v1 is greater.
+					return +1
+				}
+			}
+		}
+	}
+exhausted:
+	if i < len(v1) {
+		// We still had characters in v1, so v1 must have been longer/greater.
+		return +1
+	}
+	if j < len(v2) {
+		// We still had characters in v2, so v1 must have been shorter/less.
+		return -1
+	}
+	// We exhausted v1 and v2 at the same time. They're equal.
 	return 0
 }
 
-// splitPrefixFunc splits s at the first rune where f(rune) is false.
-func splitPrefixFunc(s string, f func(rune) bool) (string, string) {
-	for i, r := range s {
-		if !f(r) {
-			return s[:i], s[i:]
-		}
-	}
-	return s, s[:0]
+func isnum(c byte) bool {
+	// The previous version of this coded relied on strconv.ParseUint which only
+	// supports ASCII numerals, and so we shall too.
+	return c >= '0' && c <= '9'
 }

--- a/util/cmpver/version_test.go
+++ b/util/cmpver/version_test.go
@@ -9,156 +9,189 @@ import (
 	"tailscale.com/util/cmpver"
 )
 
+var tests = []struct {
+	name   string
+	v1, v2 string
+	want   int
+}{
+	{
+		name: "both empty",
+		want: 0,
+	},
+	{
+		name: "v1 empty",
+		v2:   "1.2.3",
+		want: -1,
+	},
+	{
+		name: "v2 empty",
+		v1:   "1.2.3",
+		want: 1,
+	},
+
+	{
+		name: "semver major",
+		v1:   "2.0.0",
+		v2:   "1.9.9",
+		want: 1,
+	},
+	{
+		name: "semver major",
+		v1:   "2.0.0",
+		v2:   "1.9.9",
+		want: 1,
+	},
+	{
+		name: "semver minor",
+		v1:   "1.9.0",
+		v2:   "1.8.9",
+		want: 1,
+	},
+	{
+		name: "semver minor missing",
+		v1:   "1.",
+		v2:   "1.8.9",
+		want: -1,
+	},
+	{
+		name: "semver patch",
+		v1:   "1.9.9",
+		v2:   "1.9.8",
+		want: 1,
+	},
+	{
+		name: "semver patch missing",
+		v1:   "1.8.",
+		v2:   "1.8.9",
+		want: -1,
+	},
+	{
+		name: "semver equal",
+		v1:   "1.9.8",
+		v2:   "1.9.8",
+		want: 0,
+	},
+
+	{
+		name: "tailscale major",
+		v1:   "1.0-0",
+		v2:   "0.97-105",
+		want: 1,
+	},
+	{
+		name: "tailscale minor",
+		v1:   "0.98-0",
+		v2:   "0.97-105",
+		want: 1,
+	},
+	{
+		name: "tailscale patch",
+		v1:   "0.97-120",
+		v2:   "0.97-105",
+		want: 1,
+	},
+	{
+		name: "tailscale equal",
+		v1:   "0.97-105",
+		v2:   "0.97-105",
+		want: 0,
+	},
+	{
+		// TODO: this test passes because '-' < '.', not because we have
+		// more '.'-separated fields before the '-'. Is that what we want?
+		name: "tailscale weird extra field",
+		v1:   "0.96.1-0", // more fields == larger
+		v2:   "0.96-105",
+		want: 1,
+	},
+	{
+		// Though ۱ and ۲ both satisfy unicode.IsNumber, our previous use
+		// of strconv.ParseUint with these characters would have lead us to
+		// panic. We're now only looking at ascii numbers, so test these are
+		// compared as text.
+		name: "only ascii numbers",
+		v1:   "۱۱", // 2x EXTENDED ARABIC-INDIC DIGIT ONE
+		v2:   "۲",  // 1x EXTENDED ARABIC-INDIC DIGIT TWO
+		want: -1,
+	},
+
+	{
+		name: "zeroes equal",
+		v1:   "0001",
+		v2:   "01",
+		want: 0,
+	},
+	{
+		name: "zeroes nested equal",
+		v1:   "9.0001",
+		v2:   "009.01",
+		want: 0,
+	},
+	{
+		name: "chars",
+		v1:   "aaaa0",
+		v2:   "aaa0",
+		want: 1,
+	},
+
+	// A few specific OS version tests below.
+	{
+		name: "windows version",
+		v1:   "10.0.19045.3324",
+		v2:   "10.0.18362",
+		want: 1,
+	},
+	{
+		name: "windows 11 is everything above 10.0.22000",
+		v1:   "10.0.22631.2262",
+		v2:   "10.0.22000",
+		want: 1,
+	},
+	{
+		name: "android short version",
+		v1:   "10",
+		v2:   "7",
+		want: 1,
+	},
+	{
+		name: "android longer version",
+		v1:   "7.1.2",
+		v2:   "7",
+		want: 1,
+	},
+	{
+		name: "iOS version",
+		v1:   "15.6.1",
+		v2:   "15.6",
+		want: 1,
+	},
+	{
+		name: "Linux short kernel version",
+		v1:   "4.4.302+",
+		v2:   "4.0",
+		want: 1,
+	},
+	{
+		name: "Linux long kernel version",
+		v1:   "4.14.255-311-248.529.amzn2.x86 64",
+		v2:   "4.0",
+		want: 1,
+	},
+	{
+		name: "FreeBSD version",
+		v1:   "14.0-CURRENT",
+		v2:   "14",
+		want: 1,
+	},
+	{
+		name: "Synology version",
+		v1:   "Synology 6.2.4; kernel=3.10.105",
+		v2:   "Synology 6",
+		want: 1,
+	},
+}
+
 func TestCompare(t *testing.T) {
-	tests := []struct {
-		name   string
-		v1, v2 string
-		want   int
-	}{
-		{
-			name: "both empty",
-			want: 0,
-		},
-		{
-			name: "v1 empty",
-			v2:   "1.2.3",
-			want: -1,
-		},
-		{
-			name: "v2 empty",
-			v1:   "1.2.3",
-			want: 1,
-		},
-
-		{
-			name: "semver major",
-			v1:   "2.0.0",
-			v2:   "1.9.9",
-			want: 1,
-		},
-		{
-			name: "semver major",
-			v1:   "2.0.0",
-			v2:   "1.9.9",
-			want: 1,
-		},
-		{
-			name: "semver minor",
-			v1:   "1.9.0",
-			v2:   "1.8.9",
-			want: 1,
-		},
-		{
-			name: "semver patch",
-			v1:   "1.9.9",
-			v2:   "1.9.8",
-			want: 1,
-		},
-		{
-			name: "semver equal",
-			v1:   "1.9.8",
-			v2:   "1.9.8",
-			want: 0,
-		},
-
-		{
-			name: "tailscale major",
-			v1:   "1.0-0",
-			v2:   "0.97-105",
-			want: 1,
-		},
-		{
-			name: "tailscale minor",
-			v1:   "0.98-0",
-			v2:   "0.97-105",
-			want: 1,
-		},
-		{
-			name: "tailscale patch",
-			v1:   "0.97-120",
-			v2:   "0.97-105",
-			want: 1,
-		},
-		{
-			name: "tailscale equal",
-			v1:   "0.97-105",
-			v2:   "0.97-105",
-			want: 0,
-		},
-		{
-			name: "tailscale weird extra field",
-			v1:   "0.96.1-0", // more fields == larger
-			v2:   "0.96-105",
-			want: 1,
-		},
-		{
-			// Though ۱ and ۲ both satisfy unicode.IsNumber, our previous use
-			// of strconv.ParseUint with these characters would have lead us to
-			// panic. We're now only looking at ascii numbers, so test these are
-			// compared as text.
-			name: "only ascii numbers",
-			v1:   "۱۱", // 2x EXTENDED ARABIC-INDIC DIGIT ONE
-			v2:   "۲",  // 1x EXTENDED ARABIC-INDIC DIGIT TWO
-			want: -1,
-		},
-
-		// A few specific OS version tests below.
-		{
-			name: "windows version",
-			v1:   "10.0.19045.3324",
-			v2:   "10.0.18362",
-			want: 1,
-		},
-		{
-			name: "windows 11 is everything above 10.0.22000",
-			v1:   "10.0.22631.2262",
-			v2:   "10.0.22000",
-			want: 1,
-		},
-		{
-			name: "android short version",
-			v1:   "10",
-			v2:   "7",
-			want: 1,
-		},
-		{
-			name: "android longer version",
-			v1:   "7.1.2",
-			v2:   "7",
-			want: 1,
-		},
-		{
-			name: "iOS version",
-			v1:   "15.6.1",
-			v2:   "15.6",
-			want: 1,
-		},
-		{
-			name: "Linux short kernel version",
-			v1:   "4.4.302+",
-			v2:   "4.0",
-			want: 1,
-		},
-		{
-			name: "Linux long kernel version",
-			v1:   "4.14.255-311-248.529.amzn2.x86_64",
-			v2:   "4.0",
-			want: 1,
-		},
-		{
-			name: "FreeBSD version",
-			v1:   "14.0-CURRENT",
-			v2:   "14",
-			want: 1,
-		},
-		{
-			name: "Synology version",
-			v1:   "Synology 6.2.4; kernel=3.10.105",
-			v2:   "Synology 6",
-			want: 1,
-		},
-	}
-
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got := cmpver.Compare(test.v1, test.v2)
@@ -171,8 +204,23 @@ func TestCompare(t *testing.T) {
 				t.Errorf("Compare(%v, %v) = %v, want %v", test.v2, test.v1, got2, -test.want)
 			}
 			// Check that version comparison does not allocate.
-			if n := testing.AllocsPerRun(100, func() { cmpver.Compare(test.v1, test.v2) }); n > 0 {
+			if n := testing.AllocsPerRun(100, func() { got = cmpver.Compare(test.v1, test.v2) }); n > 0 {
 				t.Errorf("Compare(%v, %v) got %v allocs per run", test.v1, test.v2, n)
+			}
+			_ = got
+		})
+	}
+}
+
+func BenchmarkCompare(b *testing.B) {
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			var got int
+			for i := 0; i < b.N; i++ {
+				got = cmpver.Compare(test.v1, test.v2)
+			}
+			if got != test.want {
+				b.Errorf("Compare(%v, %v) = %v, want %v", test.v1, test.v2, got, test.want)
 			}
 		})
 	}


### PR DESCRIPTION
This comes at the cost of being much harder to read and reason about. I'm open to opinions on whether this is a worthwhile trade-off.

Benchmark comparing before/after eb773f99:

```
goos: darwin
goarch: arm64
pkg: tailscale.com/util/cmpver
                                                    │ base@2e861c35.log │ build.icio_cmpver-faster@eb773f99.log │
                                                    │      sec/op       │     sec/op      vs base               │
Compare/both_empty-12                                       1.991n ± 2%      1.982n ± 3%        ~ (p=0.900 n=6)
Compare/v1_empty-12                                        18.385n ± 4%      1.947n ± 2%  -89.41% (p=0.002 n=6)
Compare/v2_empty-12                                        18.430n ± 7%      1.932n ± 3%  -89.51% (p=0.002 n=6)
Compare/semver_major-12                                    26.390n ± 4%      5.435n ± 3%  -79.41% (p=0.002 n=6)
Compare/semver_major#01-12                                 26.250n ± 3%      5.420n ± 3%  -79.35% (p=0.002 n=6)
Compare/semver_minor-12                                     61.44n ± 4%      10.29n ± 4%  -83.25% (p=0.002 n=6)
Compare/semver_minor_missing-12                            51.565n ± 4%      5.215n ± 3%  -89.89% (p=0.002 n=6)
Compare/semver_patch-12                                     93.48n ± 5%      13.25n ± 5%  -85.83% (p=0.002 n=6)
Compare/semver_patch_missing-12                            86.840n ± 5%      9.211n ± 3%  -89.39% (p=0.002 n=6)
Compare/semver_equal-12                                     94.07n ± 5%      12.47n ± 5%  -86.74% (p=0.002 n=6)
Compare/tailscale_major-12                                 26.230n ± 4%      4.066n ± 3%  -84.50% (p=0.002 n=6)
Compare/tailscale_minor-12                                  67.36n ± 4%      11.85n ± 4%  -82.41% (p=0.002 n=6)
Compare/tailscale_patch-12                                 111.95n ± 3%      17.18n ± 4%  -84.65% (p=0.002 n=6)
Compare/tailscale_equal-12                                 111.95n ± 4%      16.10n ± 6%  -85.62% (p=0.002 n=6)
Compare/tailscale_weird_extra_field-12                      88.45n ± 4%      10.68n ± 4%  -87.93% (p=0.002 n=6)
Compare/only_ascii_numbers-12                              15.455n ± 5%      2.942n ± 2%  -80.96% (p=0.002 n=6)
Compare/zeroes_equal-12                                    33.845n ± 4%      5.390n ± 4%  -84.07% (p=0.002 n=6)
Compare/zeroes_nested_equal-12                              74.69n ± 4%      12.05n ± 5%  -83.86% (p=0.002 n=6)
Compare/windows_version-12                                 120.60n ± 4%      19.33n ± 4%  -83.98% (p=0.002 n=6)
Compare/windows_11_is_everything_above_10.0.22000-12       120.40n ± 3%      19.06n ± 4%  -84.17% (p=0.002 n=6)
Compare/android_short_version-12                           25.745n ± 5%      4.617n ± 3%  -82.06% (p=0.002 n=6)
Compare/android_longer_version-12                          34.985n ± 4%      4.330n ± 3%  -87.62% (p=0.002 n=6)
Compare/iOS_version-12                                     77.420n ± 3%      9.532n ± 4%  -87.69% (p=0.002 n=6)
Compare/Linux_short_kernel_version-12                      60.645n ± 3%      7.319n ± 4%  -87.93% (p=0.002 n=6)
Compare/Linux_long_kernel_version-12                       64.495n ± 3%      7.311n ± 4%  -88.67% (p=0.002 n=6)
Compare/FreeBSD_version-12                                 44.035n ± 3%      5.114n ± 4%  -88.39% (p=0.002 n=6)
Compare/Synology_version-12                                 64.77n ± 3%      13.07n ± 5%  -79.83% (p=0.002 n=6)
Compare/chars-12                                                             4.865n ± 4%
geomean                                                     46.38n           7.065n       -84.55%
```