### PR TITLE
net/dns: properly detect newer debian resolvconf

### DIFF
--- a/net/dns/resolvconf.go
+++ b/net/dns/resolvconf.go
@@ -6,6 +6,7 @@
 package dns
 
 import (
+	"bytes"
 	"os/exec"
 )
 
@@ -13,12 +14,16 @@ func resolvconfStyle() string {
 	if _, err := exec.LookPath("resolvconf"); err != nil {
 		return ""
 	}
-	if _, err := exec.Command("resolvconf", "--version").CombinedOutput(); err != nil {
+	output, err := exec.Command("resolvconf", "--version").CombinedOutput()
+	if err != nil {
 		// Debian resolvconf doesn't understand --version, and
 		// exits with a specific error code.
 		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 99 {
 			return "debian"
 		}
+	}
+	if bytes.HasPrefix(output, []byte("Debian resolvconf")) {
+		return "debian"
 	}
 	// Treat everything else as openresolv, by far the more popular implementation.
 	return "openresolv"


### PR DESCRIPTION
Tailscale attempts to determine if resolvconf or openresolv is in use by running `resolvconf --version`, under the assumption this command will error when run with Debian's resolvconf. This assumption is no longer true and leads to the wrong commands being run on newer versions of Debian with resolvconf >= 1.90. We can now check if the returned version string starts with "Debian resolvconf" if the command is successful.

Fixes #9218