### PR TITLE
cmd/k8s-operator: update env var in manifest to APISERVER_PROXY

### DIFF
--- a/cmd/k8s-operator/manifests/operator.yaml
+++ b/cmd/k8s-operator/manifests/operator.yaml
@@ -151,7 +151,7 @@ spec:
               value: tailscale/tailscale:unstable
             - name: PROXY_TAGS
               value: tag:k8s
-            - name: AUTH_PROXY
+            - name: APISERVER_PROXY
               value: "false"
           volumeMounts:
           - name: oauth


### PR DESCRIPTION
Replace the deprecated var with the one in docs to avoid confusion. Introduced in 335a5aaf9a25cb6969f7c043567425e7070ab21e.

Updates #8317
Fixes #9764