### PR TITLE
ipn/ipnlocal: do unexpired cert renewals in the background

### DIFF
--- a/ipn/ipnlocal/cert_js.go
+++ b/ipn/ipnlocal/cert_js.go
@@ -12,6 +12,6 @@ type TLSCertKeyPair struct {
 	CertPEM, KeyPEM []byte
 }
 
-func (b *LocalBackend) GetCertPEM(ctx context.Context, domain string, syncRenewal bool) (*TLSCertKeyPair, error) {
+func (b *LocalBackend) GetCertPEM(ctx context.Context, domain string) (*TLSCertKeyPair, error) {
 	return nil, errors.New("not implemented for js/wasm")
 }

--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -451,7 +451,7 @@ func (b *LocalBackend) tcpHandlerForServe(dport uint16, srcAddr netip.AddrPort) 
 					GetCertificate: func(hi *tls.ClientHelloInfo) (*tls.Certificate, error) {
 						ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 						defer cancel()
-						pair, err := b.GetCertPEM(ctx, sni, false)
+						pair, err := b.GetCertPEM(ctx, sni)
 						if err != nil {
 							return nil, err
 						}
@@ -757,7 +757,7 @@ func (b *LocalBackend) getTLSServeCertForPort(port uint16) func(hi *tls.ClientHe
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
-		pair, err := b.GetCertPEM(ctx, hi.ServerName, false)
+		pair, err := b.GetCertPEM(ctx, hi.ServerName)
 		if err != nil {
 			return nil, err
 		}

--- a/ipn/localapi/cert.go
+++ b/ipn/localapi/cert.go
@@ -23,7 +23,7 @@ func (h *Handler) serveCert(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "internal handler config wired wrong", 500)
 		return
 	}
-	pair, err := h.b.GetCertPEM(r.Context(), domain, true)
+	pair, err := h.b.GetCertPEM(r.Context(), domain)
 	if err != nil {
 		// TODO(bradfitz): 500 is a little lazy here. The errors returned from
 		// GetCertPEM (and everywhere) should carry info info to get whether


### PR DESCRIPTION
We were eagerly doing a synchronous renewal of the cert while trying to serve traffic. Instead of that, just do the cert renewal in the background and continue serving traffic as long as the cert is still valid.

Fixes #9783