### PR TITLE
clientupdate: return ErrUnsupported for macSys clients

### DIFF
--- a/clientupdate/clientupdate.go
+++ b/clientupdate/clientupdate.go
@@ -185,7 +185,9 @@ func (up *Updater) getUpdateFunction() updateFunction {
 		case !up.Arguments.AppStore && !version.IsSandboxedMacOS():
 			return nil
 		case !up.Arguments.AppStore && strings.HasSuffix(os.Getenv("HOME"), "/io.tailscale.ipn.macsys/Data"):
-			return up.updateMacSys
+			// TODO(noncombatant): return up.updateMacSys when we figure out why
+			// Sparkle update doesn't work when running "tailscale update".
+			return nil
 		default:
 			return up.updateMacAppStore
 		}

--- a/ipn/ipnlocal/c2n.go
+++ b/ipn/ipnlocal/c2n.go
@@ -258,8 +258,6 @@ func (b *LocalBackend) handleC2NPostureIdentityGet(w http.ResponseWriter, r *htt
 
 func (b *LocalBackend) newC2NUpdateResponse() tailcfg.C2NUpdateResponse {
 	// If NewUpdater does not return an error, we can update the installation.
-	// Exception: When version.IsMacSysExt returns true, we don't support that
-	// yet. TODO(cpalmer, #6995): Implement it.
 	//
 	// Note that we create the Updater solely to check for errors; we do not
 	// invoke it here. For this purpose, it is ok to pass it a zero Arguments.
@@ -267,7 +265,7 @@ func (b *LocalBackend) newC2NUpdateResponse() tailcfg.C2NUpdateResponse {
 	_, err := clientupdate.NewUpdater(clientupdate.Arguments{})
 	return tailcfg.C2NUpdateResponse{
 		Enabled:   envknob.AllowsRemoteUpdate() || prefs.Apply,
-		Supported: err == nil && !version.IsMacSysExt(),
+		Supported: err == nil,
 	}
 }
 


### PR DESCRIPTION
The Sparkle-based update is not quite working yet. Make `NewUpdater` return `ErrUnsupported` for it to avoid the proliferation of exceptions up the stack.

Updates #755