### PR TITLE
tstest/integration: set race flag when cross compiling, fail on race

### DIFF
--- a/tstest/integration/integration.go
+++ b/tstest/integration/integration.go
@@ -117,7 +117,11 @@ func build(outDir string, targets ...string) error {
 		// Fallback slow path for cross-compiled binaries.
 		for _, target := range targets {
 			outFile := filepath.Join(outDir, path.Base(target)+exe())
-			cmd := exec.Command(goBin, "build", "-o", outFile, target)
+			cmd := exec.Command(goBin, "build", "-o", outFile)
+			if version.IsRace() {
+				cmd.Args = append(cmd.Args, "-race")
+			}
+			cmd.Args = append(cmd.Args, target)
 			cmd.Env = append(os.Environ(), "GOARCH="+runtime.GOARCH)
 			if errOut, err := cmd.CombinedOutput(); err != nil {
 				return fmt.Errorf("failed to build %v with %v: %v, %s", target, goBin, err, errOut)

--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -42,6 +42,7 @@ import (
 	"tailscale.com/types/key"
 	"tailscale.com/types/logger"
 	"tailscale.com/util/rands"
+	"tailscale.com/version"
 )
 
 var (
@@ -1065,6 +1066,12 @@ func (n *testNode) StartDaemonAsIPNGOOS(ipnGOOS string) *Daemon {
 		"TS_LOGS_DIR="+t.TempDir(),
 		"TS_NETCHECK_GENERATE_204_URL="+n.env.ControlServer.URL+"/generate_204",
 	)
+	if version.IsRace() {
+		const knownBroken = true // TODO(bradfitz,maisem): enable this once we fix all the races :(
+		if !knownBroken {
+			cmd.Env = append(cmd.Env, "GORACE=halt_on_error=1")
+		}
+	}
 	cmd.Stderr = &nodeOutputParser{n: n}
 	if *verboseTailscaled {
 		cmd.Stdout = os.Stdout


### PR DESCRIPTION
Misc cleanups and things noticed while working on #7894 and pulled out
of a separate change. Submitting them on their own to not distract
from later changes.

Updates #7894

Co-authored-by: Maisem Ali <maisem@tailscale.com>
