### PR TITLE
github/workflows: move race tests to their own job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  race-root-integration:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+    - name: build test wrapper
+      run: ./tool/go build -o /tmp/testwrapper ./cmd/testwrapper
+    - name: integration tests as root
+      run: PATH=$PWD/tool:$PATH /tmp/testwrapper --sudo ./tstest/integration/ -race
+
   test:
     strategy:
       fail-fast: false # don't abort the entire matrix if one element fails
@@ -90,8 +100,6 @@ jobs:
         sudo apt-get -y install qemu-user
     - name: build test wrapper
       run: ./tool/go build -o /tmp/testwrapper ./cmd/testwrapper
-    - name: integration tests as root
-      run: PATH=$PWD/tool:$PATH /tmp/testwrapper --sudo ./tstest/integration/ ${{matrix.buildflags}}
     - name: test all
       run: PATH=$PWD/tool:$PATH /tmp/testwrapper ./... ${{matrix.buildflags}}
       env:


### PR DESCRIPTION
They're slow. Make them their own job that can run in parallel.

Also, only run them in race mode. No need to run them on 386 or non-race amd64.

Updates #7894