### PR TITLE
cmd/containerboot: revert to using tailscale up

### DIFF
--- a/cmd/containerboot/main_test.go
+++ b/cmd/containerboot/main_test.go
@@ -129,22 +129,16 @@ func TestContainerBoot(t *testing.T) {
 		{
 			// Out of the box default: runs in userspace mode, ephemeral storage, interactive login.
 			Name: "no_args",
-			Env: map[string]string{
-				"TS_AUTH_ONCE": "false",
-			},
-
+			Env:  nil,
 			Phases: []phase{
 				{
 					WantCmds: []string{
 						"/usr/bin/tailscaled --socket=/tmp/tailscaled.sock --state=mem: --statedir=/tmp --tun=userspace-networking",
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock login",
+						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false",
 					},
 				},
 				{
 					Notify: runningNotify,
-					WantCmds: []string{
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock set --accept-dns=false",
-					},
 				},
 			},
 		},
@@ -152,21 +146,17 @@ func TestContainerBoot(t *testing.T) {
 			// Userspace mode, ephemeral storage, authkey provided on every run.
 			Name: "authkey",
 			Env: map[string]string{
-				"TS_AUTHKEY":   "tskey-key",
-				"TS_AUTH_ONCE": "false",
+				"TS_AUTHKEY": "tskey-key",
 			},
 			Phases: []phase{
 				{
 					WantCmds: []string{
 						"/usr/bin/tailscaled --socket=/tmp/tailscaled.sock --state=mem: --statedir=/tmp --tun=userspace-networking",
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock login --authkey=tskey-key",
+						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --authkey=tskey-key",
 					},
 				},
 				{
 					Notify: runningNotify,
-					WantCmds: []string{
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock set --accept-dns=false",
-					},
 				},
 			},
 		},
@@ -174,21 +164,17 @@ func TestContainerBoot(t *testing.T) {
 			// Userspace mode, ephemeral storage, authkey provided on every run.
 			Name: "authkey-old-flag",
 			Env: map[string]string{
-				"TS_AUTH_KEY":  "tskey-key",
-				"TS_AUTH_ONCE": "false",
+				"TS_AUTH_KEY": "tskey-key",
 			},
 			Phases: []phase{
 				{
 					WantCmds: []string{
 						"/usr/bin/tailscaled --socket=/tmp/tailscaled.sock --state=mem: --statedir=/tmp --tun=userspace-networking",
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock login --authkey=tskey-key",
+						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --authkey=tskey-key",
 					},
 				},
 				{
 					Notify: runningNotify,
-					WantCmds: []string{
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock set --accept-dns=false",
-					},
 				},
 			},
 		},
@@ -197,35 +183,30 @@ func TestContainerBoot(t *testing.T) {
 			Env: map[string]string{
 				"TS_AUTHKEY":   "tskey-key",
 				"TS_STATE_DIR": filepath.Join(d, "tmp"),
-				"TS_AUTH_ONCE": "false",
 			},
 			Phases: []phase{
 				{
 					WantCmds: []string{
 						"/usr/bin/tailscaled --socket=/tmp/tailscaled.sock --statedir=/tmp --tun=userspace-networking",
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock login --authkey=tskey-key",
+						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --authkey=tskey-key",
 					},
 				},
 				{
 					Notify: runningNotify,
-					WantCmds: []string{
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock set --accept-dns=false",
-					},
 				},
 			},
 		},
 		{
 			Name: "routes",
 			Env: map[string]string{
-				"TS_AUTHKEY":   "tskey-key",
-				"TS_ROUTES":    "1.2.3.0/24,10.20.30.0/24",
-				"TS_AUTH_ONCE": "false",
+				"TS_AUTHKEY": "tskey-key",
+				"TS_ROUTES":  "1.2.3.0/24,10.20.30.0/24",
 			},
 			Phases: []phase{
 				{
 					WantCmds: []string{
 						"/usr/bin/tailscaled --socket=/tmp/tailscaled.sock --state=mem: --statedir=/tmp --tun=userspace-networking",
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock login --authkey=tskey-key",
+						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --authkey=tskey-key --advertise-routes=1.2.3.0/24,10.20.30.0/24",
 					},
 				},
 				{
@@ -233,9 +214,6 @@ func TestContainerBoot(t *testing.T) {
 					WantFiles: map[string]string{
 						"proc/sys/net/ipv4/ip_forward":          "0",
 						"proc/sys/net/ipv6/conf/all/forwarding": "0",
-					},
-					WantCmds: []string{
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock set --accept-dns=false --advertise-routes=1.2.3.0/24,10.20.30.0/24",
 					},
 				},
 			},
@@ -246,13 +224,12 @@ func TestContainerBoot(t *testing.T) {
 				"TS_AUTHKEY":   "tskey-key",
 				"TS_ROUTES":    "1.2.3.0/24,10.20.30.0/24",
 				"TS_USERSPACE": "false",
-				"TS_AUTH_ONCE": "false",
 			},
 			Phases: []phase{
 				{
 					WantCmds: []string{
 						"/usr/bin/tailscaled --socket=/tmp/tailscaled.sock --state=mem: --statedir=/tmp",
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock login --authkey=tskey-key",
+						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --authkey=tskey-key --advertise-routes=1.2.3.0/24,10.20.30.0/24",
 					},
 				},
 				{
@@ -260,9 +237,6 @@ func TestContainerBoot(t *testing.T) {
 					WantFiles: map[string]string{
 						"proc/sys/net/ipv4/ip_forward":          "1",
 						"proc/sys/net/ipv6/conf/all/forwarding": "0",
-					},
-					WantCmds: []string{
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock set --accept-dns=false --advertise-routes=1.2.3.0/24,10.20.30.0/24",
 					},
 				},
 			},
@@ -273,13 +247,12 @@ func TestContainerBoot(t *testing.T) {
 				"TS_AUTHKEY":   "tskey-key",
 				"TS_ROUTES":    "::/64,1::/64",
 				"TS_USERSPACE": "false",
-				"TS_AUTH_ONCE": "false",
 			},
 			Phases: []phase{
 				{
 					WantCmds: []string{
 						"/usr/bin/tailscaled --socket=/tmp/tailscaled.sock --state=mem: --statedir=/tmp",
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock login --authkey=tskey-key",
+						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --authkey=tskey-key --advertise-routes=::/64,1::/64",
 					},
 				},
 				{
@@ -287,9 +260,6 @@ func TestContainerBoot(t *testing.T) {
 					WantFiles: map[string]string{
 						"proc/sys/net/ipv4/ip_forward":          "0",
 						"proc/sys/net/ipv6/conf/all/forwarding": "1",
-					},
-					WantCmds: []string{
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock set --accept-dns=false --advertise-routes=::/64,1::/64",
 					},
 				},
 			},
@@ -300,13 +270,12 @@ func TestContainerBoot(t *testing.T) {
 				"TS_AUTHKEY":   "tskey-key",
 				"TS_ROUTES":    "::/64,1.2.3.0/24",
 				"TS_USERSPACE": "false",
-				"TS_AUTH_ONCE": "false",
 			},
 			Phases: []phase{
 				{
 					WantCmds: []string{
 						"/usr/bin/tailscaled --socket=/tmp/tailscaled.sock --state=mem: --statedir=/tmp",
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock login --authkey=tskey-key",
+						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --authkey=tskey-key --advertise-routes=::/64,1.2.3.0/24",
 					},
 				},
 				{
@@ -314,9 +283,6 @@ func TestContainerBoot(t *testing.T) {
 					WantFiles: map[string]string{
 						"proc/sys/net/ipv4/ip_forward":          "1",
 						"proc/sys/net/ipv6/conf/all/forwarding": "1",
-					},
-					WantCmds: []string{
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock set --accept-dns=false --advertise-routes=::/64,1.2.3.0/24",
 					},
 				},
 			},
@@ -327,20 +293,16 @@ func TestContainerBoot(t *testing.T) {
 				"TS_AUTHKEY":   "tskey-key",
 				"TS_DEST_IP":   "1.2.3.4",
 				"TS_USERSPACE": "false",
-				"TS_AUTH_ONCE": "false",
 			},
 			Phases: []phase{
 				{
 					WantCmds: []string{
 						"/usr/bin/tailscaled --socket=/tmp/tailscaled.sock --state=mem: --statedir=/tmp",
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock login --authkey=tskey-key",
+						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --authkey=tskey-key",
 					},
 				},
 				{
 					Notify: runningNotify,
-					WantCmds: []string{
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock set --accept-dns=false",
-					},
 				},
 			},
 		},
@@ -350,20 +312,16 @@ func TestContainerBoot(t *testing.T) {
 				"TS_AUTHKEY":           "tskey-key",
 				"TS_TAILNET_TARGET_IP": "100.99.99.99",
 				"TS_USERSPACE":         "false",
-				"TS_AUTH_ONCE":         "false",
 			},
 			Phases: []phase{
 				{
 					WantCmds: []string{
 						"/usr/bin/tailscaled --socket=/tmp/tailscaled.sock --state=mem: --statedir=/tmp",
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock login --authkey=tskey-key",
+						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --authkey=tskey-key",
 					},
 				},
 				{
 					Notify: runningNotify,
-					WantCmds: []string{
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock set --accept-dns=false",
-					},
 				},
 			},
 		},
@@ -384,7 +342,7 @@ func TestContainerBoot(t *testing.T) {
 						State: ptr.To(ipn.NeedsLogin),
 					},
 					WantCmds: []string{
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock login --authkey=tskey-key",
+						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --authkey=tskey-key",
 					},
 				},
 				{
@@ -400,7 +358,6 @@ func TestContainerBoot(t *testing.T) {
 			Env: map[string]string{
 				"KUBERNETES_SERVICE_HOST":       kube.Host,
 				"KUBERNETES_SERVICE_PORT_HTTPS": kube.Port,
-				"TS_AUTH_ONCE":                  "false",
 			},
 			KubeSecret: map[string]string{
 				"authkey": "tskey-key",
@@ -409,7 +366,7 @@ func TestContainerBoot(t *testing.T) {
 				{
 					WantCmds: []string{
 						"/usr/bin/tailscaled --socket=/tmp/tailscaled.sock --state=kube:tailscale --statedir=/tmp --tun=userspace-networking",
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock login --authkey=tskey-key",
+						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --authkey=tskey-key",
 					},
 					WantKubeSecret: map[string]string{
 						"authkey": "tskey-key",
@@ -417,9 +374,6 @@ func TestContainerBoot(t *testing.T) {
 				},
 				{
 					Notify: runningNotify,
-					WantCmds: []string{
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock set --accept-dns=false",
-					},
 					WantKubeSecret: map[string]string{
 						"authkey":     "tskey-key",
 						"device_fqdn": "test-node.test.ts.net",
@@ -438,22 +392,18 @@ func TestContainerBoot(t *testing.T) {
 				"TS_KUBE_SECRET": "",
 				"TS_STATE_DIR":   filepath.Join(d, "tmp"),
 				"TS_AUTHKEY":     "tskey-key",
-				"TS_AUTH_ONCE":   "false",
 			},
 			KubeSecret: map[string]string{},
 			Phases: []phase{
 				{
 					WantCmds: []string{
 						"/usr/bin/tailscaled --socket=/tmp/tailscaled.sock --statedir=/tmp --tun=userspace-networking",
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock login --authkey=tskey-key",
+						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --authkey=tskey-key",
 					},
 					WantKubeSecret: map[string]string{},
 				},
 				{
-					Notify: runningNotify,
-					WantCmds: []string{
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock set --accept-dns=false",
-					},
+					Notify:         runningNotify,
 					WantKubeSecret: map[string]string{},
 				},
 			},
@@ -464,7 +414,6 @@ func TestContainerBoot(t *testing.T) {
 				"KUBERNETES_SERVICE_HOST":       kube.Host,
 				"KUBERNETES_SERVICE_PORT_HTTPS": kube.Port,
 				"TS_AUTHKEY":                    "tskey-key",
-				"TS_AUTH_ONCE":                  "false",
 			},
 			KubeSecret:    map[string]string{},
 			KubeDenyPatch: true,
@@ -472,15 +421,12 @@ func TestContainerBoot(t *testing.T) {
 				{
 					WantCmds: []string{
 						"/usr/bin/tailscaled --socket=/tmp/tailscaled.sock --state=kube:tailscale --statedir=/tmp --tun=userspace-networking",
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock login --authkey=tskey-key",
+						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --authkey=tskey-key",
 					},
 					WantKubeSecret: map[string]string{},
 				},
 				{
-					Notify: runningNotify,
-					WantCmds: []string{
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock set --accept-dns=false",
-					},
+					Notify:         runningNotify,
 					WantKubeSecret: map[string]string{},
 				},
 			},
@@ -510,7 +456,7 @@ func TestContainerBoot(t *testing.T) {
 						State: ptr.To(ipn.NeedsLogin),
 					},
 					WantCmds: []string{
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock login --authkey=tskey-key",
+						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --authkey=tskey-key",
 					},
 					WantKubeSecret: map[string]string{
 						"authkey": "tskey-key",
@@ -534,7 +480,6 @@ func TestContainerBoot(t *testing.T) {
 			Env: map[string]string{
 				"KUBERNETES_SERVICE_HOST":       kube.Host,
 				"KUBERNETES_SERVICE_PORT_HTTPS": kube.Port,
-				"TS_AUTH_ONCE":                  "false",
 			},
 			KubeSecret: map[string]string{
 				"authkey": "tskey-key",
@@ -543,7 +488,7 @@ func TestContainerBoot(t *testing.T) {
 				{
 					WantCmds: []string{
 						"/usr/bin/tailscaled --socket=/tmp/tailscaled.sock --state=kube:tailscale --statedir=/tmp --tun=userspace-networking",
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock login --authkey=tskey-key",
+						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --authkey=tskey-key",
 					},
 					WantKubeSecret: map[string]string{
 						"authkey": "tskey-key",
@@ -551,9 +496,6 @@ func TestContainerBoot(t *testing.T) {
 				},
 				{
 					Notify: runningNotify,
-					WantCmds: []string{
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock set --accept-dns=false",
-					},
 					WantKubeSecret: map[string]string{
 						"authkey":     "tskey-key",
 						"device_fqdn": "test-node.test.ts.net",
@@ -586,20 +528,16 @@ func TestContainerBoot(t *testing.T) {
 			Env: map[string]string{
 				"TS_SOCKS5_SERVER":              "localhost:1080",
 				"TS_OUTBOUND_HTTP_PROXY_LISTEN": "localhost:8080",
-				"TS_AUTH_ONCE":                  "false",
 			},
 			Phases: []phase{
 				{
 					WantCmds: []string{
 						"/usr/bin/tailscaled --socket=/tmp/tailscaled.sock --state=mem: --statedir=/tmp --tun=userspace-networking --socks5-server=localhost:1080 --outbound-http-proxy-listen=localhost:8080",
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock login",
+						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false",
 					},
 				},
 				{
 					Notify: runningNotify,
-					WantCmds: []string{
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock set --accept-dns=false",
-					},
 				},
 			},
 		},
@@ -607,20 +545,16 @@ func TestContainerBoot(t *testing.T) {
 			Name: "dns",
 			Env: map[string]string{
 				"TS_ACCEPT_DNS": "true",
-				"TS_AUTH_ONCE":  "false",
 			},
 			Phases: []phase{
 				{
 					WantCmds: []string{
 						"/usr/bin/tailscaled --socket=/tmp/tailscaled.sock --state=mem: --statedir=/tmp --tun=userspace-networking",
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock login",
+						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=true",
 					},
 				},
 				{
 					Notify: runningNotify,
-					WantCmds: []string{
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock set --accept-dns=true",
-					},
 				},
 			},
 		},
@@ -629,41 +563,31 @@ func TestContainerBoot(t *testing.T) {
 			Env: map[string]string{
 				"TS_EXTRA_ARGS":            "--widget=rotated",
 				"TS_TAILSCALED_EXTRA_ARGS": "--experiments=widgets",
-				"TS_AUTH_ONCE":             "false",
 			},
 			Phases: []phase{
 				{
 					WantCmds: []string{
 						"/usr/bin/tailscaled --socket=/tmp/tailscaled.sock --state=mem: --statedir=/tmp --tun=userspace-networking --experiments=widgets",
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock login --widget=rotated",
+						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --widget=rotated",
 					},
-				},
-				{
+				}, {
 					Notify: runningNotify,
-					WantCmds: []string{
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock set --accept-dns=false",
-					},
 				},
 			},
 		},
 		{
 			Name: "hostname",
 			Env: map[string]string{
-				"TS_HOSTNAME":  "my-server",
-				"TS_AUTH_ONCE": "false",
+				"TS_HOSTNAME": "my-server",
 			},
 			Phases: []phase{
 				{
 					WantCmds: []string{
 						"/usr/bin/tailscaled --socket=/tmp/tailscaled.sock --state=mem: --statedir=/tmp --tun=userspace-networking",
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock login",
+						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --hostname=my-server",
 					},
-				},
-				{
+				}, {
 					Notify: runningNotify,
-					WantCmds: []string{
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock set --accept-dns=false --hostname=my-server",
-					},
 				},
 			},
 		},


### PR DESCRIPTION
This partially reverts commits a61a9ab087e16270bc039252e7620aae4de3d56e and 7538f386710b80c6b4c1997797be28a661210d4a and fully reverts 4823a7e591ef859250114ad20b337d4358af9ead.

The goal of that commit was to reapply known config whenever the container restarts. However, that already happens when TS_AUTH_ONCE was false (the default back then). So we only had to selectively reapply the config if TS_AUTH_ONCE is true, this does exactly that.

This is a little sad that we have to revert to `tailscale up`, but it fixes the backwards incompatibility problem.

Updates tailscale/tailscale#9539