### PR TITLE
ipn/ipnlocal: change serial number policy to be PreferenceOption

### DIFF
--- a/ipn/ipnlocal/c2n.go
+++ b/ipn/ipnlocal/c2n.go
@@ -234,13 +234,16 @@ func (b *LocalBackend) handleC2NPostureIdentityGet(w http.ResponseWriter, r *htt
 	// this will first check syspolicy, MDM settings like Registry
 	// on Windows or defaults on macOS. If they are not set, it falls
 	// back to the cli-flag, `--posture-checking`.
-	enabled, err := syspolicy.GetBoolean(syspolicy.PostureChecking, b.Prefs().PostureChecking())
+	choice, err := syspolicy.GetPreferenceOption(syspolicy.PostureChecking)
 	if err != nil {
-		enabled = b.Prefs().PostureChecking()
-		b.logf("c2n: failed to read PostureChecking from syspolicy, returning default from CLI: %s; got error: %s", enabled, err)
+		b.logf(
+			"c2n: failed to read PostureChecking from syspolicy, returning default from CLI: %s; got error: %s",
+			b.Prefs().PostureChecking(),
+			err,
+		)
 	}
 
-	if enabled {
+	if choice.ShouldEnable(b.Prefs().PostureChecking()) {
 		sns, err := posture.GetSerialNumbers(b.logf)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/util/syspolicy/policy_keys.go
+++ b/util/syspolicy/policy_keys.go
@@ -33,7 +33,10 @@ const (
 	// The default is 0 unless otherwise stated.
 	LogSCMInteractions      Key = "LogSCMInteractions"
 	FlushDNSOnSessionUnlock Key = "FlushDNSOnSessionUnlock"
-	// Boolean key that indicates if posture checking is enabled and the client shall gather
+
+	// PostureChecking indicates if posture checking is enabled and the client shall gather
 	// posture data.
+	// Key is a string value that specifies an option: "always", "never", "user-decides".
+	// The default is "user-decides" unless otherwise stated.
 	PostureChecking Key = "PostureChecking"
 )


### PR DESCRIPTION
This commit changes the PostureChecking syspolicy key to be a PreferenceOption(user-defined, always, never) instead of Bool.

This aligns better with the defaults implementation on macOS allowing CLI arguments to be read when user-defined or no defaults is set.