### PR TITLE
ipn/ipnlocal: fix AllowsUpdate disable after enable

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3771,7 +3771,7 @@ func (b *LocalBackend) applyPrefsToHostinfoLocked(hi *tailcfg.Hostinfo, prefs ip
 	hi.RoutableIPs = prefs.AdvertiseRoutes().AsSlice()
 	hi.RequestTags = prefs.AdvertiseTags().AsSlice()
 	hi.ShieldsUp = prefs.ShieldsUp()
-	hi.AllowsUpdate = hi.AllowsUpdate || prefs.AutoUpdate().Apply
+	hi.AllowsUpdate = envknob.AllowsRemoteUpdate() || prefs.AutoUpdate().Apply
 
 	var sshHostKeys []string
 	if prefs.RunSSH() && envknob.CanSSHD() {


### PR DESCRIPTION
The old code would always retain value `true` if it was set once, even if you then change `prefs.AutoUpdate.Apply` to `false`. Instead of using the previous value, use the default (envknob) value to OR with.

Updates #755