### PR TITLE
cmd/k8s-operator: allow different proxy init image

### DIFF
--- a/cmd/k8s-operator/operator_test.go
+++ b/cmd/k8s-operator/operator_test.go
@@ -37,11 +37,12 @@ func TestLoadBalancerClass(t *testing.T) {
 	sr := &ServiceReconciler{
 		Client: fc,
 		ssr: &tailscaleSTSReconciler{
-			Client:            fc,
-			tsClient:          ft,
-			defaultTags:       []string{"tag:k8s"},
-			operatorNamespace: "operator-ns",
-			proxyImage:        "tailscale/tailscale",
+			Client:                fc,
+			tsClient:              ft,
+			defaultTags:           []string{"tag:k8s"},
+			operatorNamespace:     "operator-ns",
+			proxyImage:            "tailscale/tailscale",
+			proxyInitBusyboxImage: "busybox",
 		},
 		logger: zl.Sugar(),
 	}
@@ -165,11 +166,12 @@ func TestTailnetTargetIPAnnotation(t *testing.T) {
 	sr := &ServiceReconciler{
 		Client: fc,
 		ssr: &tailscaleSTSReconciler{
-			Client:            fc,
-			tsClient:          ft,
-			defaultTags:       []string{"tag:k8s"},
-			operatorNamespace: "operator-ns",
-			proxyImage:        "tailscale/tailscale",
+			Client:                fc,
+			tsClient:              ft,
+			defaultTags:           []string{"tag:k8s"},
+			operatorNamespace:     "operator-ns",
+			proxyImage:            "tailscale/tailscale",
+			proxyInitBusyboxImage: "busybox",
 		},
 		logger: zl.Sugar(),
 	}
@@ -270,11 +272,12 @@ func TestAnnotations(t *testing.T) {
 	sr := &ServiceReconciler{
 		Client: fc,
 		ssr: &tailscaleSTSReconciler{
-			Client:            fc,
-			tsClient:          ft,
-			defaultTags:       []string{"tag:k8s"},
-			operatorNamespace: "operator-ns",
-			proxyImage:        "tailscale/tailscale",
+			Client:                fc,
+			tsClient:              ft,
+			defaultTags:           []string{"tag:k8s"},
+			operatorNamespace:     "operator-ns",
+			proxyImage:            "tailscale/tailscale",
+			proxyInitBusyboxImage: "busybox",
 		},
 		logger: zl.Sugar(),
 	}
@@ -370,11 +373,12 @@ func TestAnnotationIntoLB(t *testing.T) {
 	sr := &ServiceReconciler{
 		Client: fc,
 		ssr: &tailscaleSTSReconciler{
-			Client:            fc,
-			tsClient:          ft,
-			defaultTags:       []string{"tag:k8s"},
-			operatorNamespace: "operator-ns",
-			proxyImage:        "tailscale/tailscale",
+			Client:                fc,
+			tsClient:              ft,
+			defaultTags:           []string{"tag:k8s"},
+			operatorNamespace:     "operator-ns",
+			proxyImage:            "tailscale/tailscale",
+			proxyInitBusyboxImage: "busybox",
 		},
 		logger: zl.Sugar(),
 	}
@@ -495,11 +499,12 @@ func TestLBIntoAnnotation(t *testing.T) {
 	sr := &ServiceReconciler{
 		Client: fc,
 		ssr: &tailscaleSTSReconciler{
-			Client:            fc,
-			tsClient:          ft,
-			defaultTags:       []string{"tag:k8s"},
-			operatorNamespace: "operator-ns",
-			proxyImage:        "tailscale/tailscale",
+			Client:                fc,
+			tsClient:              ft,
+			defaultTags:           []string{"tag:k8s"},
+			operatorNamespace:     "operator-ns",
+			proxyImage:            "tailscale/tailscale",
+			proxyInitBusyboxImage: "busybox",
 		},
 		logger: zl.Sugar(),
 	}
@@ -625,11 +630,12 @@ func TestCustomHostname(t *testing.T) {
 	sr := &ServiceReconciler{
 		Client: fc,
 		ssr: &tailscaleSTSReconciler{
-			Client:            fc,
-			tsClient:          ft,
-			defaultTags:       []string{"tag:k8s"},
-			operatorNamespace: "operator-ns",
-			proxyImage:        "tailscale/tailscale",
+			Client:                fc,
+			tsClient:              ft,
+			defaultTags:           []string{"tag:k8s"},
+			operatorNamespace:     "operator-ns",
+			proxyImage:            "tailscale/tailscale",
+			proxyInitBusyboxImage: "busybox",
 		},
 		logger: zl.Sugar(),
 	}
@@ -735,6 +741,7 @@ func TestCustomPriorityClassName(t *testing.T) {
 			defaultTags:            []string{"tag:k8s"},
 			operatorNamespace:      "operator-ns",
 			proxyImage:             "tailscale/tailscale",
+			proxyInitBusyboxImage:  "busybox",
 			proxyPriorityClassName: "tailscale-critical",
 		},
 		logger: zl.Sugar(),
@@ -778,11 +785,12 @@ func TestDefaultLoadBalancer(t *testing.T) {
 	sr := &ServiceReconciler{
 		Client: fc,
 		ssr: &tailscaleSTSReconciler{
-			Client:            fc,
-			tsClient:          ft,
-			defaultTags:       []string{"tag:k8s"},
-			operatorNamespace: "operator-ns",
-			proxyImage:        "tailscale/tailscale",
+			Client:                fc,
+			tsClient:              ft,
+			defaultTags:           []string{"tag:k8s"},
+			operatorNamespace:     "operator-ns",
+			proxyImage:            "tailscale/tailscale",
+			proxyInitBusyboxImage: "busybox",
 		},
 		logger:                zl.Sugar(),
 		isDefaultLoadBalancer: true,

--- a/cmd/k8s-operator/sts.go
+++ b/cmd/k8s-operator/sts.go
@@ -73,12 +73,13 @@ type tailscaleSTSConfig struct {
 
 type tailscaleSTSReconciler struct {
 	client.Client
-	tsnetServer            *tsnet.Server
-	tsClient               tsClient
-	defaultTags            []string
-	operatorNamespace      string
-	proxyImage             string
-	proxyPriorityClassName string
+	tsnetServer                    *tsnet.Server
+	tsClient                       tsClient
+	defaultTags                    []string
+	operatorNamespace              string
+	proxyImage                     string
+	proxyInitBusyboxContainerImage string
+	proxyPriorityClassName         string
 }
 
 // IsHTTPSEnabledOnTailnet reports whether HTTPS is enabled on the tailnet.
@@ -308,6 +309,10 @@ func (a *tailscaleSTSReconciler) reconcileSTS(ctx context.Context, logger *zap.S
 			return nil, fmt.Errorf("failed to unmarshal proxy spec: %w", err)
 		}
 	}
+
+	initContainer := &ss.Spec.Template.Spec.initContainers[0]
+	initContainer.Image = a.proxyInitBusyboxContainerImage 
+
 	container := &ss.Spec.Template.Spec.Containers[0]
 	container.Image = a.proxyImage
 	container.Env = append(container.Env,


### PR DESCRIPTION
Allows you to pass in an environment variable to the operator to change the proxy init container image, defaults to busybox from docker hub.

fixes #8919