### PR TITLE
cmd/k8s-operator: use our own container image instead of busybox

### DIFF
--- a/cmd/k8s-operator/manifests/proxy.yaml
+++ b/cmd/k8s-operator/manifests/proxy.yaml
@@ -12,7 +12,6 @@ spec:
       serviceAccountName: proxies
       initContainers:
         - name: sysctler
-          image: busybox
           securityContext:
             privileged: true
           command: ["/bin/sh"]

--- a/cmd/k8s-operator/operator_test.go
+++ b/cmd/k8s-operator/operator_test.go
@@ -899,7 +899,7 @@ func expectedSTS(stsName, secretName, hostname, priorityClassName string) *appsv
 					InitContainers: []corev1.Container{
 						{
 							Name:    "sysctler",
-							Image:   "busybox",
+							Image:   "tailscale/tailscale",
 							Command: []string{"/bin/sh"},
 							Args:    []string{"-c", "sysctl -w net.ipv4.ip_forward=1 net.ipv6.conf.all.forwarding=1"},
 							SecurityContext: &corev1.SecurityContext{
@@ -968,7 +968,7 @@ func expectedEgressSTS(stsName, secretName, tailnetTargetIP, hostname, priorityC
 					InitContainers: []corev1.Container{
 						{
 							Name:    "sysctler",
-							Image:   "busybox",
+							Image:   "tailscale/tailscale",
 							Command: []string{"/bin/sh"},
 							Args:    []string{"-c", "sysctl -w net.ipv4.ip_forward=1 net.ipv6.conf.all.forwarding=1"},
 							SecurityContext: &corev1.SecurityContext{

--- a/cmd/k8s-operator/sts.go
+++ b/cmd/k8s-operator/sts.go
@@ -307,6 +307,13 @@ func (a *tailscaleSTSReconciler) reconcileSTS(ctx context.Context, logger *zap.S
 		if err := yaml.Unmarshal(proxyYaml, &ss); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal proxy spec: %w", err)
 		}
+		for i := range ss.Spec.Template.Spec.InitContainers {
+			c := &ss.Spec.Template.Spec.InitContainers[i]
+			if c.Name == "sysctler" {
+				c.Image = a.proxyImage
+				break
+			}
+		}
 	}
 	container := &ss.Spec.Template.Spec.Containers[0]
 	container.Image = a.proxyImage

--- a/docs/k8s/proxy.yaml
+++ b/docs/k8s/proxy.yaml
@@ -11,7 +11,7 @@ spec:
     # the container. The `net.ipv4.ip_forward` sysctl is not allowlisted
     # in Kubelet by default.
   - name: sysctler
-    image: busybox
+    image: "ghcr.io/tailscale/tailscale:latest"
     securityContext:
       privileged: true
     command: ["/bin/sh"]


### PR DESCRIPTION
We already have sysctl in the `tailscale/tailscale` image, just use that.

Updates #cleanup