### PR TITLE
ipn/ipnlocal: proxy gRPC requests over h2c if needed

### DIFF
--- a/ipn/ipnlocal/serve_test.go
+++ b/ipn/ipnlocal/serve_test.go
@@ -587,3 +587,39 @@ func TestServeFileOrDirectory(t *testing.T) {
 		}
 	}
 }
+
+func Test_isGRPCContentType(t *testing.T) {
+	tests := map[string]struct {
+		contentType string
+		want        bool
+	}{
+		"application/grpc": {
+			contentType: "application/grpc",
+			want:        true,
+		},
+		"application/grpc;": {
+			contentType: "application/grpc;",
+			want:        true,
+		},
+		"application/grpc+": {
+			contentType: "application/grpc+",
+			want:        true,
+		},
+		"application/grpcfoobar": {
+			contentType: "application/grpcfoobar",
+		},
+		"application/text": {
+			contentType: "application/text",
+		},
+		"foobar": {
+			contentType: "foobar",
+		},
+	}
+	for name, scenario := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := isGRPCContentType(scenario.contentType); got != scenario.want {
+				t.Errorf("test case %s failed, isGRPCContentType() = %v, want %v", name, got, scenario.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Makes it possible for the proxy to work with a gRPC over h2c backend by detecting tha the request is for a grpc service + using prior knowledge of the proxy configuration to determine that it's not HTTPS.

This seems to be the best that we can do- @maisem and I were originally discussing detecting that it is an h2c backend, however it seems that the only way to reliably do this is with prior knowledge see https://datatracker.ietf.org/doc/html/rfc9113#name-http-2-version-identificati:~:text=The%20means%20by,%C2%B6
It seems like using the proxy host protocol prefix + request's proto + request's content type header should be sufficient for plaintext gRPC backends because:
- if the backend has an 'http' prefix, we at that point know that it's http (it would anyway likely not work if there was some redirection to https)
- we know that it's http/2 because it's grpc


Alternative that we considered was making it possible for users (or whoever defines serve config) to specify that the backend is h2c- but it seems like autodetection might be nicer for the gRPC cases and those might be the majority h2c users?



/cc @maisem @bradfitz 

Updates tailscale/tailscale#9725