### PR TITLE
clientupdate: fix background install for linux tarballs

### DIFF
--- a/clientupdate/clientupdate.go
+++ b/clientupdate/clientupdate.go
@@ -911,7 +911,7 @@ func (up *Updater) updateLinuxBinary() error {
 func (up *Updater) downloadLinuxTarball(ver string) (string, error) {
 	dlDir, err := os.UserCacheDir()
 	if err != nil {
-		return "", err
+		dlDir = os.TempDir()
 	}
 	dlDir = filepath.Join(dlDir, "tailscale-update")
 	if err := os.MkdirAll(dlDir, 0700); err != nil {

--- a/ipn/ipnlocal/c2n.go
+++ b/ipn/ipnlocal/c2n.go
@@ -305,8 +305,11 @@ func findCmdTailscale() (string, error) {
 	}
 	switch runtime.GOOS {
 	case "linux":
-		if self == "/usr/sbin/tailscaled" {
+		if self == "/usr/sbin/tailscaled" || self == "/usr/bin/tailscaled" {
 			return "/usr/bin/tailscale", nil
+		}
+		if self == "/usr/local/sbin/tailscaled" || self == "/usr/local/bin/tailscaled" {
+			return "/usr/local/bin/tailscale", nil
 		}
 		return "", errors.New("tailscale not found in expected place")
 	case "windows":


### PR DESCRIPTION
Two bug fixes:
1. when tailscale update is executed as root, `os.UserCacheDir` may return an error because `$XDG_CACHE_HOME` and `$HOME` are not set; fallback to `os.TempDir` in those cases
2. on some weird distros (like my EndeavourOS), `/usr/sbin` is just a symlink to `/usr/bin`; when we resolve `tailscale` binary path from `tailscaled`, allow `tailscaled` to be in either directory

Updates #755