### PR TITLE
cmd/tailscale/cli: [serve/funnel] provide correct command for disabling

### DIFF
--- a/cmd/tailscale/cli/serve_v2_test.go
+++ b/cmd/tailscale/cli/serve_v2_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"tailscale.com/ipn"
+	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/types/logger"
 )
 
@@ -1027,6 +1028,105 @@ func TestCleanURLPath(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMessageForPort(t *testing.T) {
+	tests := []struct {
+		name        string
+		subcmd      serveMode
+		serveConfig *ipn.ServeConfig
+		status      *ipnstate.Status
+		dnsName     string
+		srvType     serveType
+		srvPort     uint16
+		expected    string
+	}{
+		{
+			name:   "funnel-https",
+			subcmd: funnel,
+			serveConfig: &ipn.ServeConfig{
+				TCP: map[uint16]*ipn.TCPPortHandler{
+					443: {HTTPS: true},
+				},
+				Web: map[ipn.HostPort]*ipn.WebServerConfig{
+					"foo.test.ts.net:443": {
+						Handlers: map[string]*ipn.HTTPHandler{
+							"/": {Proxy: "http://127.0.0.1:3000"},
+						},
+					},
+				},
+				AllowFunnel: map[ipn.HostPort]bool{
+					"foo.test.ts.net:443": true,
+				},
+			},
+			status:  &ipnstate.Status{},
+			dnsName: "foo.test.ts.net",
+			srvType: serveTypeHTTPS,
+			srvPort: 443,
+			expected: strings.Join([]string{
+				msgFunnelAvailable,
+				"https://foo.test.ts.net",
+				"",
+				"|-- / proxy http://127.0.0.1:3000",
+				"",
+				fmt.Sprintf(msgRunningInBackground, "Funnel"),
+				fmt.Sprintf(msgDisableProxy, "funnel", "https", 443),
+			}, "\n"),
+		},
+		{
+			name:   "serve-http",
+			subcmd: serve,
+			serveConfig: &ipn.ServeConfig{
+				TCP: map[uint16]*ipn.TCPPortHandler{
+					443: {HTTP: true},
+				},
+				Web: map[ipn.HostPort]*ipn.WebServerConfig{
+					"foo.test.ts.net:80": {
+						Handlers: map[string]*ipn.HTTPHandler{
+							"/": {Proxy: "http://127.0.0.1:3000"},
+						},
+					},
+				},
+			},
+			status:  &ipnstate.Status{},
+			dnsName: "foo.test.ts.net",
+			srvType: serveTypeHTTP,
+			srvPort: 80,
+			expected: strings.Join([]string{
+				msgServeAvailable,
+				"https://foo.test.ts.net:80",
+				"",
+				"|-- / proxy http://127.0.0.1:3000",
+				"",
+				fmt.Sprintf(msgRunningInBackground, "Serve"),
+				fmt.Sprintf(msgDisableProxy, "serve", "http", 80),
+			}, "\n"),
+		},
+	}
+
+	for _, tt := range tests {
+		e := &serveEnv{bg: true, subcmd: tt.subcmd}
+
+		t.Run(tt.name, func(t *testing.T) {
+			actual := e.messageForPort(tt.serveConfig, tt.status, tt.dnsName, tt.srvType, tt.srvPort)
+
+			if actual == "" {
+				t.Errorf("Got empty message")
+			}
+
+			if actual != tt.expected {
+				t.Errorf("Got: %q; expected: %q", actual, tt.expected)
+			}
+		})
+	}
+}
+
+func unindent(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimSpace(line)
+	}
+	return strings.Join(lines, "\n")
 }
 
 func TestIsLegacyInvocation(t *testing.T) {


### PR DESCRIPTION
The `off` subcommand removes a serve/funnel for the corresponding type and port. Previously, we were not providing this which would result in an error if someone was using something than the default https=443.

closes #9858