### PR TITLE
ipn: fix localapi and peerapi protocol for taildrop resume

### DIFF
--- a/ipn/ipnlocal/peerapi.go
+++ b/ipn/ipnlocal/peerapi.go
@@ -655,7 +655,7 @@ func (h *peerAPIHandler) handlePeerPut(w http.ResponseWriter, r *http.Request) {
 		var err error
 		id := taildrop.ClientID(h.peerNode.StableID())
 
-		if r.URL.Path == "/v0/put/"+baseName {
+		if prefix == "" {
 			resp, err = h.ps.taildrop.PartialFiles(id)
 		} else {
 			ranges, ok := httphdr.ParseRange(r.Header.Get("Range"))


### PR DESCRIPTION
Minor fixes:
* The branch for listing or hashing partial files was inverted.
* The host for peerapi call needs to be real (rather than bogus).
* Handle remote peers that don't support resuming.
* Make resume failures non-fatal (since we can still continue).

This was tested locally, end-to-end system test is future work.