### PR TITLE
wgengine/magicsock: simplify tryEnableUDPOffload()

### DIFF
--- a/wgengine/magicsock/magicsock_linux.go
+++ b/wgengine/magicsock/magicsock_linux.go
@@ -328,11 +328,7 @@ func tryEnableUDPOffload(pconn nettype.PacketConn) (hasTX bool, hasRX bool) {
 		}
 		err = rc.Control(func(fd uintptr) {
 			_, errSyscall := syscall.GetsockoptInt(int(fd), unix.IPPROTO_UDP, unix.UDP_SEGMENT)
-			if errSyscall != nil {
-				// no point in checking RX, TX support was added first.
-				return
-			}
-			hasTX = true
+			hasTX = errSyscall == nil
 			errSyscall = syscall.SetsockoptInt(int(fd), unix.IPPROTO_UDP, unix.UDP_GRO, 1)
 			hasRX = errSyscall == nil
 		})


### PR DESCRIPTION
Don't assume Linux lacks UDP_GRO support if it lacks UDP_SEGMENT support. This mirrors a similar change in wireguard/wireguard-go@177caa7 for consistency sake. We haven't found any issues here, just being overly paranoid.

Updates #cleanup