### PR TITLE
taildrop: fix TestResume

### DIFF
--- a/taildrop/resume_test.go
+++ b/taildrop/resume_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestResume(t *testing.T) {
-	t.Skip("currently failing on Windows")
 	oldBlockSize := blockSize
 	defer func() { blockSize = oldBlockSize }()
 	blockSize = 256
@@ -29,11 +28,14 @@ func TestResume(t *testing.T) {
 
 	t.Run("resume-noexist", func(t *testing.T) {
 		r := io.Reader(bytes.NewReader(want))
+
 		next, close, err := m.HashPartialFile("", "foo")
 		must.Do(err)
 		defer close()
 		offset, r, err := ResumeReader(r, next)
 		must.Do(err)
+		must.Do(close()) // Windows wants the file handle to be closed to rename it.
+
 		must.Get(m.PutFile("", "foo", r, offset, -1))
 		got := must.Get(os.ReadFile(must.Get(joinDir(m.opts.Dir, "foo"))))
 		if !bytes.Equal(got, want) {
@@ -43,25 +45,30 @@ func TestResume(t *testing.T) {
 
 	t.Run("resume-retry", func(t *testing.T) {
 		rn := rand.New(rand.NewSource(0))
-		for {
+		for i := 0; true; i++ {
 			r := io.Reader(bytes.NewReader(want))
-			next, close, err := m.HashPartialFile("", "foo")
+
+			next, close, err := m.HashPartialFile("", "bar")
 			must.Do(err)
 			defer close()
 			offset, r, err := ResumeReader(r, next)
 			must.Do(err)
+			must.Do(close()) // Windows wants the file handle to be closed to rename it.
+
 			numWant := rn.Int63n(min(int64(len(want))-offset, 1000) + 1)
 			if offset < int64(len(want)) {
 				r = io.MultiReader(io.LimitReader(r, numWant), iotest.ErrReader(io.ErrClosedPipe))
 			}
-			if _, err := m.PutFile("", "foo", r, offset, -1); err == nil {
+			if _, err := m.PutFile("", "bar", r, offset, -1); err == nil {
 				break
 			}
+			if i > 1000 {
+				t.Fatalf("too many iterations to complete the test")
+			}
 		}
-		got := must.Get(os.ReadFile(must.Get(joinDir(m.opts.Dir, "foo"))))
+		got := must.Get(os.ReadFile(must.Get(joinDir(m.opts.Dir, "bar"))))
 		if !bytes.Equal(got, want) {
 			t.Errorf("content mismatches")
 		}
 	})
-
 }


### PR DESCRIPTION
Previously, the test simply relied on:
	defer close()
to cleanup file handles.

This works fine on Unix-based systems,
but not on Windows, which dislikes deleting files
where an open file handle continues to exist.

Fix the test by explicitly closing the file handle after we are done with the resource.

Updates tailscale/corp#14772