### PR TITLE
cmd/tsconnect/wasm: add missing tstun.Wrapper.Start call

### DIFF
--- a/cmd/tsconnect/wasm/wasm_js.go
+++ b/cmd/tsconnect/wasm/wasm_js.go
@@ -125,6 +125,7 @@ func newIPN(jsConfig js.Value) map[string]any {
 		return ns.DialContextTCP(ctx, dst)
 	}
 	sys.NetstackRouter.Set(true)
+	sys.Tun.Get().Start()
 
 	logid := lpc.PublicID
 	srv := ipnserver.New(logf, logid, sys.NetMon.Get())


### PR DESCRIPTION
It's required as of the recent 5297bd2cff8e.

Updates #7894
Updates #9394 (sure would be nice)
