### PR TITLE
Improve message on --accept-routes=False default

### DIFF
--- a/health/healthmsg/healthmsg.go
+++ b/health/healthmsg/healthmsg.go
@@ -8,7 +8,8 @@
 package healthmsg
 
 const (
-	WarnAcceptRoutesOff = "Some peers are advertising routes but --accept-routes is false"
+	// TODO change link to shortened one
+	WarnAcceptRoutesOff = "Some peers are advertising routes but --accept-routes is disabled (legacy default). To fix that, run tailscale set --accept-routes. For more info, see https://tailscale.com/kb/1019/subnets/#step-6-use-your-subnet-routes-from-other-machines"
 	TailscaleSSHOnBut   = "Tailscale SSH enabled, but " // + ... something from caller
 	LockedOut           = "this node is locked out; it will not have connectivity until it is signed. For more info, see https://tailscale.com/s/locked-out"
 )


### PR DESCRIPTION
Reflecting on comment https://github.com/tailscale/tailscale/issues/2053#issuecomment-1747211200

This change introduces following aspects to the message:
- declare the current default as legacy
- without further research, a helpful command can be copy&pasted to regain the modern default
- link to an article of Tailscale declairing the differing defaults on Windows / Mac OS and Linux

Todo:
- [ ] I assume the link should be changed to an explicit shortened variant (`https://tailscale.com/s/`), which I cannot create. I’m happy to replace the link if someone of you sets that one up for me.