### PR TITLE
clientupdate: distinguish when auto-updates are possible

### DIFF
--- a/cmd/tailscale/cli/set.go
+++ b/cmd/tailscale/cli/set.go
@@ -157,7 +157,7 @@ func runSet(ctx context.Context, args []string) (retErr error) {
 		}
 	}
 	if maskedPrefs.AutoUpdateSet {
-		_, err := clientupdate.NewUpdater(clientupdate.Arguments{})
+		_, err := clientupdate.NewUpdater(clientupdate.Arguments{ForAutoUpdate: true})
 		if errors.Is(err, errors.ErrUnsupported) {
 			return errors.New("automatic updates are not supported on this platform")
 		}

--- a/ipn/ipnlocal/c2n.go
+++ b/ipn/ipnlocal/c2n.go
@@ -265,7 +265,7 @@ func (b *LocalBackend) newC2NUpdateResponse() tailcfg.C2NUpdateResponse {
 	// Note that we create the Updater solely to check for errors; we do not
 	// invoke it here. For this purpose, it is ok to pass it a zero Arguments.
 	prefs := b.Prefs().AutoUpdate()
-	_, err := clientupdate.NewUpdater(clientupdate.Arguments{})
+	_, err := clientupdate.NewUpdater(clientupdate.Arguments{ForAutoUpdate: true})
 	return tailcfg.C2NUpdateResponse{
 		Enabled:   envknob.AllowsRemoteUpdate() || prefs.Apply,
 		Supported: err == nil,


### PR DESCRIPTION
clientupdate.Updater will have a non-nil Update func in a few cases where it doesn't actually perform an update:
* on Arch-like distros, where it prints instructions on how to update
* on macOS app store version, where it opens the app store page

Add a new clientupdate.Arguments field to cause NewUpdater to fail when we hit one of these cases. This results in c2n updates being "not supported" and `tailscale set --auto-update` returning an error.

Updates #755