### PR TITLE
ipn/localapi,client/web: clean up auth error handling

### DIFF
--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -2172,12 +2172,13 @@ func (h *Handler) serveDebugWebClient(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	defer resp.Body.Close()
-
-	if _, err := io.Copy(w, resp.Body); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		http.Error(w, string(body), resp.StatusCode)
 		return
 	}
+	w.Write(body)
 	w.Header().Set("Content-Type", "application/json")
 }
 


### PR DESCRIPTION
This commit makes two changes to the web client auth flow error handling:

1. Properly passes back the error code from the noise request from the localapi. Previously we were using io.Copy, which was always setting a 200 response status code.
2. Clean up web client browser sessions on any /wait endpoint error. This avoids the user getting in a stuck state if something goes wrong with their auth path.

Updates tailscale/corp#14335