### PR TITLE
cmd/tailscale: add set-raw to the new serve funnel commands

### DIFF
--- a/cmd/tailscale/cli/serve_v2.go
+++ b/cmd/tailscale/cli/serve_v2.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -174,6 +175,20 @@ func (e *serveEnv) runServeCombined(subcmd serveMode) execFunc {
 	e.subcmd = subcmd
 
 	return func(ctx context.Context, args []string) error {
+		// Undocumented debug command (not using ffcli subcommands) to set raw
+		// configs from stdin for now (2022-11-13).
+		if len(args) == 1 && args[0] == "set-raw" {
+			valb, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return err
+			}
+			sc := new(ipn.ServeConfig)
+			if err := json.Unmarshal(valb, sc); err != nil {
+				return fmt.Errorf("invalid JSON: %w", err)
+			}
+			return e.lc.SetServeConfig(ctx, sc)
+		}
+
 		if err := validateArgs(subcmd, args); err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR adds the same set-raw from the old flow into the new one so that users can continue to use it when transitioning into the new flow.

Updates #8489