### PR TITLE
ipn/ipnlocal: set the push device token correctly 

### DIFF
--- a/hostinfo/hostinfo.go
+++ b/hostinfo/hostinfo.go
@@ -53,7 +53,6 @@ func New() *tailcfg.Hostinfo {
 		GoVersion:       runtime.Version(),
 		Machine:         condCall(unameMachine),
 		DeviceModel:     deviceModel(),
-		PushDeviceToken: pushDeviceToken(),
 		Cloud:           string(cloudenv.Get()),
 		NoLogsNoSupport: envknob.NoLogsNoSupport(),
 		AllowsUpdate:    envknob.AllowsRemoteUpdate(),
@@ -166,17 +165,13 @@ func GetEnvType() EnvType {
 }
 
 var (
-	pushDeviceTokenAtomic atomic.Value // of string
-	deviceModelAtomic     atomic.Value // of string
-	osVersionAtomic       atomic.Value // of string
-	desktopAtomic         atomic.Value // of opt.Bool
-	packagingType         atomic.Value // of string
-	appType               atomic.Value // of string
-	firewallMode          atomic.Value // of string
+	deviceModelAtomic atomic.Value // of string
+	osVersionAtomic   atomic.Value // of string
+	desktopAtomic     atomic.Value // of opt.Bool
+	packagingType     atomic.Value // of string
+	appType           atomic.Value // of string
+	firewallMode      atomic.Value // of string
 )
-
-// SetPushDeviceToken sets the device token for use in Hostinfo updates.
-func SetPushDeviceToken(token string) { pushDeviceTokenAtomic.Store(token) }
 
 // SetDeviceModel sets the device model for use in Hostinfo updates.
 func SetDeviceModel(model string) { deviceModelAtomic.Store(model) }
@@ -200,11 +195,6 @@ func SetApp(v string) { appType.Store(v) }
 
 func deviceModel() string {
 	s, _ := deviceModelAtomic.Load().(string)
-	return s
-}
-
-func pushDeviceToken() string {
-	s, _ := pushDeviceTokenAtomic.Load().(string)
 	return s
 }
 

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -1553,8 +1553,7 @@ func (h *Handler) serveSetPushDeviceToken(w http.ResponseWriter, r *http.Request
 		http.Error(w, "invalid JSON body", http.StatusBadRequest)
 		return
 	}
-	hostinfo.SetPushDeviceToken(params.PushDeviceToken)
-	h.b.ResendHostinfoIfNeeded()
+	h.b.SetPushDeviceToken(params.PushDeviceToken)
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/ipn/localapi/localapi_test.go
+++ b/ipn/localapi/localapi_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 
 	"tailscale.com/client/tailscale/apitype"
-	"tailscale.com/hostinfo"
 	"tailscale.com/ipn/ipnlocal"
 	"tailscale.com/tailcfg"
 	"tailscale.com/tstest"
@@ -77,7 +76,7 @@ func TestSetPushDeviceToken(t *testing.T) {
 	if res.StatusCode != 200 {
 		t.Errorf("res.StatusCode=%d, want 200. body: %s", res.StatusCode, body)
 	}
-	if got := hostinfo.New().PushDeviceToken; got != want {
+	if got := h.b.GetPushDeviceToken(); got != want {
 		t.Errorf("hostinfo.PushDeviceToken=%q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
It would end up resetting whatever hostinfo we had constructed
and leave the backend statemachine in a broken state.
This fixes that by storing the PushDeviceToken on the LocalBackend
and populating it on Hostinfo before passing it to controlclient.
    
Updates #tailscale/corp#8940