### PR TITLE
util/osdiag, util/winutil: expose Windows policy key

### DIFF
--- a/util/osdiag/osdiag_windows.go
+++ b/util/osdiag/osdiag_windows.go
@@ -54,7 +54,7 @@ const (
 func getSupportInfo(w io.Writer, reason LogSupportInfoReason) error {
 	output := make(map[string]any)
 
-	regInfo, err := getRegistrySupportInfo(registry.LOCAL_MACHINE, []string{`SOFTWARE\Policies\Tailscale`, winutil.RegBase})
+	regInfo, err := getRegistrySupportInfo(registry.LOCAL_MACHINE, []string{winutil.RegPolicyBase, winutil.RegBase})
 	if err == nil {
 		output[supportInfoKeyRegistry] = regInfo
 	} else {

--- a/util/winutil/winutil.go
+++ b/util/winutil/winutil.go
@@ -8,9 +8,16 @@ import (
 	"os/user"
 )
 
-// RegBase is the registry path inside HKEY_LOCAL_MACHINE where registry settings
-// are stored. This constant is a non-empty string only when GOOS=windows.
-const RegBase = regBase
+const (
+	// RegBase is the registry path inside HKEY_LOCAL_MACHINE where registry settings
+	// are stored. This constant is a non-empty string only when GOOS=windows.
+	RegBase = regBase
+
+	// RegPolicyBase is the registry path inside HKEY_LOCAL_MACHINE where registry
+	// policies are stored. This constant is a non-empty string only when
+	// GOOS=windows.
+	RegPolicyBase = regPolicyBase
+)
 
 // GetPolicyString looks up a registry value in the local machine's path for
 // system policies, or returns empty string and the error.

--- a/util/winutil/winutil_notwindows.go
+++ b/util/winutil/winutil_notwindows.go
@@ -13,6 +13,7 @@ import (
 )
 
 const regBase = ``
+const regPolicyBase = ``
 
 var ErrNoValue = errors.New("no value because registry is unavailable on this OS")
 


### PR DESCRIPTION
The Windows base registry key is already exported but the policy key was not. util/osdiag currently replicates the string rather than the preferred approach of reusing the constant.

Updates #cleanup

Change-Id: I6c1c45337896c744059b85643da2364fb3f232f2