### PR TITLE
ipn/ipnlocal: move tailcfg.Netinfo ownership to LocalBackend

### DIFF
--- a/control/controlclient/auto.go
+++ b/control/controlclient/auto.go
@@ -564,18 +564,6 @@ func (c *Auto) SetHostinfo(hi *tailcfg.Hostinfo) {
 	c.updateControl()
 }
 
-func (c *Auto) SetNetInfo(ni *tailcfg.NetInfo) {
-	if ni == nil {
-		panic("nil NetInfo")
-	}
-	if !c.direct.SetNetInfo(ni) {
-		return
-	}
-
-	// Send new NetInfo to server
-	c.updateControl()
-}
-
 // SetTKAHead updates the TKA head hash that map-request infrastructure sends.
 func (c *Auto) SetTKAHead(headHash string) {
 	if !c.direct.SetTKAHead(headHash) {

--- a/control/controlclient/client.go
+++ b/control/controlclient/client.go
@@ -65,12 +65,6 @@ type Client interface {
 	// in a separate http request. It has nothing to do with the rest of
 	// the state machine.
 	SetHostinfo(*tailcfg.Hostinfo)
-	// SetNetinfo changes the NetIinfo structure that will be sent in
-	// subsequent node registration requests.
-	// TODO: a server-side change would let us simply upload this
-	// in a separate http request. It has nothing to do with the rest of
-	// the state machine.
-	SetNetInfo(*tailcfg.NetInfo)
 	// SetTKAHead changes the TKA head hash value that will be sent in
 	// subsequent netmap requests.
 	SetTKAHead(headHash string)


### PR DESCRIPTION
The only thing place which owned the copy of Netinfo was the controlclient, which meant that we had another place where we were modifying the hostinfo and blending fields in. This moves all of that logic to now occur solely in LocalBackend.

Updates #cleanup