### PR TITLE
wgengine/netstack: only add addresses to correct protocols

### DIFF
--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -393,10 +393,14 @@ func (ns *Impl) UpdateNetstackIPs(nm *netmap.NetworkMap) {
 		pa := tcpip.ProtocolAddress{
 			AddressWithPrefix: ipp,
 		}
-		if ipp.Address.Unspecified() || ipp.Address.Len() == 16 {
+		switch ipp.Address.Len() {
+		case 16:
 			pa.Protocol = ipv6.ProtocolNumber
-		} else {
+		case 4:
 			pa.Protocol = ipv4.ProtocolNumber
+		default:
+			ns.logf("[unexpected] netstack: could not register IP %s without protocol: unknown IP length (%v)", ipp, ipp.Address.Len())
+			continue
 		}
 		var err tcpip.Error
 		err = ns.ipstack.AddProtocolAddress(nicID, pa, stack.AddressProperties{


### PR DESCRIPTION
Prior to an earlier netstack bump this code used a string conversion path to cover multiple cases of behavior seemingly checking for unspecified addresses, adding unspecified addresses to v6. The behavior is now crashy in netstack, as it is enforcing address length in various areas of the API, one in particular being address removal.

As netstack is now protocol specific, we must not create invalid protocol addresses - an address is v4 or v6, and the address value contained inside must match. If a control path attempts to do something otherwise it is now logged and skipped rather than incorrect addressing being added.

Fixes tailscale/corp#15377