### PR TITLE
wgengine/magicsock: close disco listeners on Conn.Close, fix Linux root TestNewConn

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -2134,6 +2134,12 @@ func (c *Conn) Close() error {
 	// They will frequently have been closed already by a call to connBind.Close.
 	c.pconn6.Close()
 	c.pconn4.Close()
+	if c.closeDisco4 != nil {
+		c.closeDisco4.Close()
+	}
+	if c.closeDisco6 != nil {
+		c.closeDisco6.Close()
+	}
 
 	// Wait on goroutines updating right at the end, once everything is
 	// already closed. We want everything else in the Conn to be


### PR DESCRIPTION
TestNewConn now passes as root on Linux. It wasn't closing the BPF listeners and their goroutines.

The code is still a mess of two Close overlapping code paths, but that can be refactored later. For now, make the two close paths more similar.

Updates #9945
