### PR TITLE
Fix tlsServerName not stripping port numbers if present

### DIFF
--- a/derp/derphttp/derphttp_client.go
+++ b/derp/derphttp/derphttp_client.go
@@ -226,7 +226,7 @@ func (c *Client) useHTTPS() bool {
 // tlsServerName returns the tls.Config.ServerName value (for the TLS ClientHello).
 func (c *Client) tlsServerName(node *tailcfg.DERPNode) string {
 	if c.url != nil {
-		return c.url.Host
+		return c.url.Hostname()
 	}
 	return node.HostName
 }


### PR DESCRIPTION
When trying to set up multiple derper instances meshing with each other, it turned out that while one can specify an alternative listening port using the `-a` flag, the TLS hostname gets incorrectly determined and includes the set alternative listening port as part of the hostname. Thus, the TLS hostname validation always fails when the `-mesh-with` values have ports.

This PR addresses this by using the [`Hostname`](https://pkg.go.dev/net/url#URL.Hostname) function instead of the [`Host`](https://pkg.go.dev/net/url#URL.Host) field.