### PR TITLE
cmd/tailscale/cli: set Sparkle auto-update on macsys

### DIFF
--- a/clientupdate/clientupdate.go
+++ b/clientupdate/clientupdate.go
@@ -202,7 +202,9 @@ func (up *Updater) getUpdateFunction() (fn updateFunction, canAutoUpdate bool) {
 			// support auto-updates.
 			return up.updateMacAppStore, false
 		case version.IsMacSysExt():
-			return up.updateMacSys, true
+			// Macsys update func kicks off Sparkle. Auto-updates are done by
+			// Sparkle.
+			return up.updateMacSys, false
 		default:
 			return nil, false
 		}

--- a/version/prop.go
+++ b/version/prop.go
@@ -59,6 +59,9 @@ func IsMacSysExt() bool {
 		return false
 	}
 	return isMacSysExt.Get(func() bool {
+		if strings.Contains(os.Getenv("HOME"), "/Containers/io.tailscale.ipn.macsys/") {
+			return true
+		}
 		exe, err := os.Executable()
 		if err != nil {
 			return false
@@ -76,6 +79,12 @@ func IsMacAppStore() bool {
 		return false
 	}
 	return isMacAppStore.Get(func() bool {
+		// Both macsys and app store versions can run CLI executable with
+		// suffix /Contents/MacOS/Tailscale. Check $HOME to filter out running
+		// as macsys.
+		if strings.Contains(os.Getenv("HOME"), "/Containers/io.tailscale.ipn.macsys/") {
+			return false
+		}
 		exe, err := os.Executable()
 		if err != nil {
 			return false


### PR DESCRIPTION
On `tailscale set --auto-update`, set the Sparkle plist option for it. Also make macsys report not supporting auto-updates over c2n, since they will be triggered by Sparkle locally.

Updates #755