### PR TITLE
Revert "ipn/ipnlocal: add new DNS and subnet router policies"

### DIFF
--- a/ipn/ipnlocal/profiles.go
+++ b/ipn/ipnlocal/profiles.go
@@ -19,7 +19,6 @@ import (
 	"tailscale.com/types/logger"
 	"tailscale.com/util/clientmetric"
 	"tailscale.com/util/cmpx"
-	"tailscale.com/util/syspolicy"
 	"tailscale.com/util/winutil"
 )
 
@@ -464,10 +463,6 @@ var defaultPrefs = func() ipn.PrefsView {
 	prefs.ShieldsUp = shieldsUp == "never"
 	forceDaemon, _ := winutil.GetPolicyString("UnattendedMode")
 	prefs.ForceDaemon = forceDaemon == "always"
-	corpDNS, _ := syspolicy.GetPreferenceOption(syspolicy.EnableTailscaleDNS)
-	prefs.CorpDNS = corpDNS.ShouldEnable(false)
-	routeAll, _ := syspolicy.GetPreferenceOption(syspolicy.EnableTailscaleSubnets)
-	prefs.RouteAll = routeAll.ShouldEnable(false)
 
 	return prefs.View()
 }()

--- a/ipn/ipnlocal/profiles_windows.go
+++ b/ipn/ipnlocal/profiles_windows.go
@@ -13,7 +13,6 @@ import (
 
 	"tailscale.com/atomicfile"
 	"tailscale.com/ipn"
-	"tailscale.com/util/syspolicy"
 	"tailscale.com/util/winutil/policy"
 )
 
@@ -71,8 +70,6 @@ func (pm *profileManager) loadLegacyPrefs() (string, ipn.PrefsView, error) {
 	prefs.ExitNodeIP = resolveExitNodeIP(prefs.ExitNodeIP)
 	prefs.ShieldsUp = resolveShieldsUp(prefs.ShieldsUp)
 	prefs.ForceDaemon = resolveForceDaemon(prefs.ForceDaemon)
-	prefs.CorpDNS, _ = resolveOptionPolicy(syspolicy.EnableTailscaleDNS, prefs.CorpDNS)
-	prefs.RouteAll, _ = resolveOptionPolicy(syspolicy.EnableTailscaleSubnets, prefs.RouteAll)
 
 	pm.logf("migrating Windows profile to new format")
 	return migrationSentinel, prefs.View(), nil
@@ -90,12 +87,4 @@ func resolveShieldsUp(defval bool) bool {
 func resolveForceDaemon(defval bool) bool {
 	pol := policy.GetPreferenceOptionPolicy("UnattendedMode")
 	return pol.ShouldEnable(defval)
-}
-
-func resolveOptionPolicy(key syspolicy.Key, defval bool) (bool, error) {
-	pol, err := syspolicy.GetPreferenceOption(key)
-	if err != nil {
-		return defval, err
-	}
-	return pol.ShouldEnable(defval), nil
 }

--- a/util/syspolicy/policy_keys.go
+++ b/util/syspolicy/policy_keys.go
@@ -7,17 +7,14 @@ type Key string
 
 const (
 	// Keys with a string value
-	ControlURL Key = "LoginURL"   // default ""; if blank, ipn uses ipn.DefaultControlURL.
-	LogTarget  Key = "LogTarget"  // default ""; if blank logging uses logtail.DefaultHost.
-	ExitNodeIP Key = "ExitNodeIP" // default ""; set to the IP address of the desired exit node; still under development
-	Tailnet    Key = "Tailnet"    // default ""; if blank, no tailnet name is sent to the server.
+	ControlURL Key = "LoginURL"  // default ""; if blank, ipn uses ipn.DefaultControlURL.
+	LogTarget  Key = "LogTarget" // default ""; if blank logging uses logtail.DefaultHost.
+	Tailnet    Key = "Tailnet"   // default ""; if blank, no tailnet name is sent to the server.
 
 	// Keys with a string value that specifies an option: "always", "never", "user-decides".
 	// The default is "user-decides" unless otherwise stated.
 	EnableIncomingConnections Key = "AllowIncomingConnections"
 	EnableServerMode          Key = "UnattendedMode"
-	EnableTailscaleDNS        Key = "UseTailscaleDNSSettings"
-	EnableTailscaleSubnets    Key = "UseTailscaleSubnets"
 
 	// Keys with a string value that controls visibility: "show", "hide".
 	// The default is "show" unless otherwise stated.
@@ -27,8 +24,6 @@ const (
 	UpdateMenuVisibility      Key = "UpdateMenu"
 	RunExitNodeVisibility     Key = "RunExitNode"
 	PreferencesMenuVisibility Key = "PreferencesMenu"
-	ExitNodeMenuVisibility    Key = "ExitNodesPicker"
-	AutoUpdateVisibility      Key = "AutoUpdate"
 
 	// Keys with a string value formatted for use with time.ParseDuration().
 	KeyExpirationNoticeTime Key = "KeyExpirationNotice" // default 24 hours


### PR DESCRIPTION
Reverts tailscale/tailscale#9936. 

The change was causing unstable builds of the the macOS and macsys clients to crash on launch of the IPNExtension.