### PR TITLE
ipn/localapi: add endpoint to handle APNS payloads

### DIFF
--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -85,6 +85,7 @@ var handler = map[string]localAPIHandler{
 	"derpmap":                     (*Handler).serveDERPMap,
 	"dev-set-state-store":         (*Handler).serveDevSetStateStore,
 	"set-push-device-token":       (*Handler).serveSetPushDeviceToken,
+	"handle-push-message":         (*Handler).serveHandlePushMessage,
 	"dial":                        (*Handler).serveDial,
 	"file-targets":                (*Handler).serveFileTargets,
 	"goroutines":                  (*Handler).serveGoroutines,
@@ -1554,6 +1555,26 @@ func (h *Handler) serveSetPushDeviceToken(w http.ResponseWriter, r *http.Request
 		return
 	}
 	h.b.SetPushDeviceToken(params.PushDeviceToken)
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) serveHandlePushMessage(w http.ResponseWriter, r *http.Request) {
+	if !h.PermitWrite {
+		http.Error(w, "handle push message not allowed", http.StatusForbidden)
+		return
+	}
+	if r.Method != "POST" {
+		http.Error(w, "unsupported method", http.StatusMethodNotAllowed)
+		return
+	}
+	var pushMessageBody map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&pushMessageBody); err != nil {
+		http.Error(w, "failed to decode JSON body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// TODO(bradfitz): do something with pushMessageBody
+
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -1574,8 +1574,9 @@ func (h *Handler) serveHandlePushMessage(w http.ResponseWriter, r *http.Request)
 	}
 
 	// TODO(bradfitz): do something with pushMessageBody
+	h.logf("localapi: got push message: %v", logger.AsJSON(pushMessageBody))
 
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *Handler) serveUploadClientMetrics(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This PR adds a new `handle-push-message` local API endpoint. When an APNS payload is delivered to the main app, this endpoint can be used to forward the JSON body of the message to the backend, making a POST request.

Fixes #9971. 

Updates #9845.

cc @bradfitz