### PR TITLE
cmd/tailscale/cli: use status before doing interactive feature query

### DIFF
--- a/cmd/tailscale/cli/serve_legacy_test.go
+++ b/cmd/tailscale/cli/serve_legacy_test.go
@@ -786,7 +786,7 @@ func TestVerifyFunnelEnabled(t *testing.T) {
 		{
 			name:                 "fallback-flow-enabled",
 			queryFeatureResponse: mockQueryFeatureResponse{resp: nil, err: errors.New("not-allowed")},
-			caps:                 []tailcfg.NodeCapability{tailcfg.CapabilityHTTPS, tailcfg.NodeAttrFunnel},
+			caps:                 []tailcfg.NodeCapability{tailcfg.CapabilityHTTPS, tailcfg.NodeAttrFunnel, "https://tailscale.com/cap/funnel-ports?ports=80,443,8080-8090"},
 			wantErr:              "", // no error, success
 		},
 		{
@@ -811,10 +811,6 @@ func TestVerifyFunnelEnabled(t *testing.T) {
 				defer func() { fakeStatus.Self.Capabilities = oldCaps }() // reset after test
 				fakeStatus.Self.Capabilities = tt.caps
 			}
-			st, err := e.getLocalClientStatusWithoutPeers(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
 
 			defer func() {
 				r := recover()
@@ -826,7 +822,7 @@ func TestVerifyFunnelEnabled(t *testing.T) {
 					t.Errorf("wrong panic; got=%s, want=%s", gotPanic, tt.wantPanic)
 				}
 			}()
-			gotErr := e.verifyFunnelEnabled(ctx, st, 443)
+			gotErr := e.verifyFunnelEnabled(ctx, 443)
 			var got string
 			if gotErr != nil {
 				got = gotErr.Error()

--- a/cmd/tailscale/cli/serve_v2.go
+++ b/cmd/tailscale/cli/serve_v2.go
@@ -213,15 +213,10 @@ func (e *serveEnv) runServeCombined(subcmd serveMode) execFunc {
 		ctx, cancel := signal.NotifyContext(ctx, os.Interrupt)
 		defer cancel()
 
-		st, err := e.getLocalClientStatusWithoutPeers(ctx)
-		if err != nil {
-			return fmt.Errorf("getting client status: %w", err)
-		}
-
 		funnel := subcmd == funnel
 		if funnel {
 			// verify node has funnel capabilities
-			if err := e.verifyFunnelEnabled(ctx, st, 443); err != nil {
+			if err := e.verifyFunnelEnabled(ctx, 443); err != nil {
 				return err
 			}
 		}
@@ -245,6 +240,10 @@ func (e *serveEnv) runServeCombined(subcmd serveMode) execFunc {
 		// nil if no config
 		if sc == nil {
 			sc = new(ipn.ServeConfig)
+		}
+		st, err := e.getLocalClientStatusWithoutPeers(ctx)
+		if err != nil {
+			return fmt.Errorf("getting client status: %w", err)
 		}
 		dnsName := strings.TrimSuffix(st.Self.DNSName, ".")
 


### PR DESCRIPTION
We were inconsistent whether we checked if the feature was already enabled which we could do cheaply using the locally available status. We would do the checks fine if we were turning on funnel, but not serve.

This moves the cap checks down into enableFeatureInteractive so that are always run.

Updates #9984