### PR TITLE
ipn: serve web client requests from LocalBackend.TCPHandlerForDst

### DIFF
--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -810,6 +810,9 @@ func TestPrefFlagMapping(t *testing.T) {
 		case "Egg":
 			// Not applicable.
 			continue
+		case "RunWebClient":
+			// TODO(tailscale/corp#14335): Currently behind a feature flag.
+			continue
 		}
 		t.Errorf("unexpected new ipn.Pref field %q is not handled by up.go (see addPrefFlagMapping and checkForAccidentalSettingReverts)", prefName)
 	}

--- a/ipn/conf.go
+++ b/ipn/conf.go
@@ -36,6 +36,7 @@ type ConfigVAlpha struct {
 
 	PostureChecking opt.Bool         `json:",omitempty"`
 	RunSSHServer    opt.Bool         `json:",omitempty"` // Tailscale SSH
+	RunWebClient    opt.Bool         `json:",omitempty"`
 	ShieldsUp       opt.Bool         `json:",omitempty"`
 	AutoUpdate      *AutoUpdatePrefs `json:",omitempty"`
 	ServeConfigTemp *ServeConfig     `json:",omitempty"` // TODO(bradfitz,maisem): make separate stable type for this
@@ -112,6 +113,10 @@ func (c *ConfigVAlpha) ToPrefs() (MaskedPrefs, error) {
 	if c.RunSSHServer != "" {
 		mp.RunSSH = c.RunSSHServer.EqualBool(true)
 		mp.RunSSHSet = true
+	}
+	if c.RunWebClient != "" {
+		mp.RunWebClient = c.RunWebClient.EqualBool(true)
+		mp.RunWebClientSet = true
 	}
 	if c.ShieldsUp != "" {
 		mp.ShieldsUp = c.ShieldsUp.EqualBool(true)

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -38,6 +38,7 @@ var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	ExitNodeAllowLANAccess bool
 	CorpDNS                bool
 	RunSSH                 bool
+	RunWebClient           bool
 	WantRunning            bool
 	LoggedOut              bool
 	ShieldsUp              bool

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -71,6 +71,7 @@ func (v PrefsView) ExitNodeIP() netip.Addr             { return v.ж.ExitNodeIP 
 func (v PrefsView) ExitNodeAllowLANAccess() bool       { return v.ж.ExitNodeAllowLANAccess }
 func (v PrefsView) CorpDNS() bool                      { return v.ж.CorpDNS }
 func (v PrefsView) RunSSH() bool                       { return v.ж.RunSSH }
+func (v PrefsView) RunWebClient() bool                 { return v.ж.RunWebClient }
 func (v PrefsView) WantRunning() bool                  { return v.ж.WantRunning }
 func (v PrefsView) LoggedOut() bool                    { return v.ж.LoggedOut }
 func (v PrefsView) ShieldsUp() bool                    { return v.ж.ShieldsUp }
@@ -100,6 +101,7 @@ var _PrefsViewNeedsRegeneration = Prefs(struct {
 	ExitNodeAllowLANAccess bool
 	CorpDNS                bool
 	RunSSH                 bool
+	RunWebClient           bool
 	WantRunning            bool
 	LoggedOut              bool
 	ShieldsUp              bool

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3129,6 +3129,10 @@ func (b *LocalBackend) TCPHandlerForDst(src, dst netip.AddrPort) (handler func(c
 		opts = append(opts, ptr.To(tcpip.KeepaliveIdleOption(72*time.Hour)))
 		return b.handleSSHConn, opts
 	}
+	// TODO(will,sonia): allow customizing web client port ?
+	if dst.Port() == 5252 && b.ShouldRunWebClient() {
+		return b.handleWebClientConn, opts
+	}
 	if port, ok := b.GetPeerAPIPort(dst.Addr()); ok && dst.Port() == port {
 		return func(c net.Conn) error {
 			b.handlePeerAPIConn(src, dst, c)

--- a/ipn/ipnlocal/web_stub.go
+++ b/ipn/ipnlocal/web_stub.go
@@ -7,6 +7,7 @@ package ipnlocal
 
 import (
 	"errors"
+	"net"
 
 	"tailscale.com/client/tailscale"
 )
@@ -20,3 +21,7 @@ func (b *LocalBackend) WebInit() error {
 }
 
 func (b *LocalBackend) WebShutdown() {}
+
+func (b *LocalBackend) handleWebClientConn(c net.Conn) error {
+	return errors.New("not implemented")
+}

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -2249,10 +2249,20 @@ func (h *Handler) serveWeb(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		// try to set pref, but ignore errors
+		_, _ = h.b.EditPrefs(&ipn.MaskedPrefs{
+			Prefs:           ipn.Prefs{RunWebClient: true},
+			RunWebClientSet: true,
+		})
 		w.WriteHeader(http.StatusOK)
 		return
 	case "/localapi/v0/web/stop":
 		h.b.WebShutdown()
+		// try to set pref, but ignore errors
+		_, _ = h.b.EditPrefs(&ipn.MaskedPrefs{
+			Prefs:           ipn.Prefs{RunWebClient: false},
+			RunWebClientSet: true,
+		})
 		w.WriteHeader(http.StatusOK)
 		return
 	default:

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -112,6 +112,11 @@ type Prefs struct {
 	// policies as configured by the Tailnet's admin(s).
 	RunSSH bool
 
+	// RunWebClient bool is whether this node should run a web client,
+	// permitting access to peers according to the
+	// policies as configured by the Tailnet's admin(s).
+	RunWebClient bool
+
 	// WantRunning indicates whether networking should be active on
 	// this node.
 	WantRunning bool
@@ -236,6 +241,7 @@ type MaskedPrefs struct {
 	ExitNodeAllowLANAccessSet bool `json:",omitempty"`
 	CorpDNSSet                bool `json:",omitempty"`
 	RunSSHSet                 bool `json:",omitempty"`
+	RunWebClientSet           bool `json:",omitempty"`
 	WantRunningSet            bool `json:",omitempty"`
 	LoggedOutSet              bool `json:",omitempty"`
 	ShieldsUpSet              bool `json:",omitempty"`
@@ -350,6 +356,9 @@ func (p *Prefs) pretty(goos string) string {
 	if p.RunSSH {
 		sb.WriteString("ssh=true ")
 	}
+	if p.RunWebClient {
+		sb.WriteString("webclient=true ")
+	}
 	if p.LoggedOut {
 		sb.WriteString("loggedout=true ")
 	}
@@ -431,6 +440,7 @@ func (p *Prefs) Equals(p2 *Prefs) bool {
 		p.ExitNodeAllowLANAccess == p2.ExitNodeAllowLANAccess &&
 		p.CorpDNS == p2.CorpDNS &&
 		p.RunSSH == p2.RunSSH &&
+		p.RunWebClient == p2.RunWebClient &&
 		p.WantRunning == p2.WantRunning &&
 		p.LoggedOut == p2.LoggedOut &&
 		p.NotepadURLs == p2.NotepadURLs &&
@@ -689,6 +699,18 @@ func (p PrefsView) ShouldSSHBeRunning() bool {
 // the prefs.
 func (p *Prefs) ShouldSSHBeRunning() bool {
 	return p.WantRunning && p.RunSSH
+}
+
+// ShouldWebClientBeRunning reports whether the web client server should be running based on
+// the prefs.
+func (p PrefsView) ShouldWebClientBeRunning() bool {
+	return p.Valid() && p.ж.ShouldWebClientBeRunning()
+}
+
+// ShouldWebClientBeRunning reports whether the web client server should be running based on
+// the prefs.
+func (p *Prefs) ShouldWebClientBeRunning() bool {
+	return p.WantRunning && p.RunWebClient
 }
 
 // PrefsFromBytes deserializes Prefs from a JSON blob.

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -43,6 +43,7 @@ func TestPrefsEqual(t *testing.T) {
 		"ExitNodeAllowLANAccess",
 		"CorpDNS",
 		"RunSSH",
+		"RunWebClient",
 		"WantRunning",
 		"LoggedOut",
 		"ShieldsUp",


### PR DESCRIPTION
instead of starting a separate server listening on a particular port to serve the web client, use the TCPHandlerForDst method to intercept requests for the special web client port (currently 5252, probably configurable later).  Add a new user pref that tracks whether the web client should be enabled or not.

Updates https://github.com/tailscale/corp/issues/14335