### PR TITLE
ipn: introduce app connector advertisement preference and flags

### DIFF
--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -893,6 +893,7 @@ func TestUpdatePrefs(t *testing.T) {
 				AdvertiseRoutesSet:        true,
 				AdvertiseTagsSet:          true,
 				AllowSingleHostsSet:       true,
+				AppConnectorSet:           true,
 				ControlURLSet:             true,
 				CorpDNSSet:                true,
 				ExitNodeAllowLANAccessSet: true,
@@ -1130,6 +1131,49 @@ func TestUpdatePrefs(t *testing.T) {
 			},
 			wantJustEditMP: nil,
 			env:            upCheckEnv{backendState: "Running"},
+		},
+		{
+			name:  "advertise_connector",
+			flags: []string{"--advertise-connector"},
+			curPrefs: &ipn.Prefs{
+				ControlURL:       ipn.DefaultControlURL,
+				AllowSingleHosts: true,
+				CorpDNS:          true,
+				NetfilterMode:    preftype.NetfilterOn,
+			},
+			wantJustEditMP: &ipn.MaskedPrefs{
+				AppConnectorSet: true,
+				WantRunningSet:  true,
+			},
+			env: upCheckEnv{backendState: "Running"},
+			checkUpdatePrefsMutations: func(t *testing.T, newPrefs *ipn.Prefs) {
+				if !newPrefs.AppConnector.Advertise {
+					t.Errorf("prefs.AppConnector.Advertise not set")
+				}
+			},
+		},
+		{
+			name:  "no_advertise_connector",
+			flags: []string{"--advertise-connector=false"},
+			curPrefs: &ipn.Prefs{
+				ControlURL:       ipn.DefaultControlURL,
+				AllowSingleHosts: true,
+				CorpDNS:          true,
+				NetfilterMode:    preftype.NetfilterOn,
+				AppConnector: ipn.AppConnectorPrefs{
+					Advertise: true,
+				},
+			},
+			wantJustEditMP: &ipn.MaskedPrefs{
+				AppConnectorSet: true,
+				WantRunningSet:  true,
+			},
+			env: upCheckEnv{backendState: "Running"},
+			checkUpdatePrefsMutations: func(t *testing.T, newPrefs *ipn.Prefs) {
+				if newPrefs.AppConnector.Advertise {
+					t.Errorf("prefs.AppConnector.Advertise not unset")
+				}
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/tailscale/cli/set.go
+++ b/cmd/tailscale/cli/set.go
@@ -45,6 +45,7 @@ type setArgsT struct {
 	hostname               string
 	advertiseRoutes        string
 	advertiseDefaultRoute  bool
+	advertiseConnector     bool
 	opUser                 string
 	acceptedRisks          string
 	profileName            string
@@ -67,6 +68,7 @@ func newSetFlagSet(goos string, setArgs *setArgsT) *flag.FlagSet {
 	setf.StringVar(&setArgs.hostname, "hostname", "", "hostname to use instead of the one provided by the OS")
 	setf.StringVar(&setArgs.advertiseRoutes, "advertise-routes", "", "routes to advertise to other nodes (comma-separated, e.g. \"10.0.0.0/8,192.168.0.0/24\") or empty string to not advertise routes")
 	setf.BoolVar(&setArgs.advertiseDefaultRoute, "advertise-exit-node", false, "offer to be an exit node for internet traffic for the tailnet")
+	setf.BoolVar(&setArgs.advertiseConnector, "advertise-connector", false, "offer to be an exit node for internet traffic for the tailnet")
 	setf.BoolVar(&setArgs.updateCheck, "update-check", true, "notify about available Tailscale updates")
 	setf.BoolVar(&setArgs.updateApply, "auto-update", false, "automatically update to the latest available version")
 	setf.BoolVar(&setArgs.postureChecking, "posture-checking", false, "HIDDEN: allow management plane to gather device posture information")
@@ -112,6 +114,9 @@ func runSet(ctx context.Context, args []string) (retErr error) {
 			AutoUpdate: ipn.AutoUpdatePrefs{
 				Check: setArgs.updateCheck,
 				Apply: setArgs.updateApply,
+			},
+			AppConnector: ipn.AppConnectorPrefs{
+				Advertise: setArgs.advertiseConnector,
 			},
 			PostureChecking: setArgs.postureChecking,
 		},

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -53,6 +53,7 @@ var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	OperatorUser           string
 	ProfileName            string
 	AutoUpdate             AutoUpdatePrefs
+	AppConnector           AppConnectorPrefs
 	PostureChecking        bool
 	Persist                *persist.Persist
 }{})

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -88,6 +88,7 @@ func (v PrefsView) NetfilterMode() preftype.NetfilterMode { return v.ж.Netfilte
 func (v PrefsView) OperatorUser() string                  { return v.ж.OperatorUser }
 func (v PrefsView) ProfileName() string                   { return v.ж.ProfileName }
 func (v PrefsView) AutoUpdate() AutoUpdatePrefs           { return v.ж.AutoUpdate }
+func (v PrefsView) AppConnector() AppConnectorPrefs       { return v.ж.AppConnector }
 func (v PrefsView) PostureChecking() bool                 { return v.ж.PostureChecking }
 func (v PrefsView) Persist() persist.PersistView          { return v.ж.Persist.View() }
 
@@ -116,6 +117,7 @@ var _PrefsViewNeedsRegeneration = Prefs(struct {
 	OperatorUser           string
 	ProfileName            string
 	AutoUpdate             AutoUpdatePrefs
+	AppConnector           AppConnectorPrefs
 	PostureChecking        bool
 	Persist                *persist.Persist
 }{})

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -205,6 +205,10 @@ type Prefs struct {
 	// AutoUpdatePrefs docs for more details.
 	AutoUpdate AutoUpdatePrefs
 
+	// AppConnector sets the app connector preferences for the node agent. See
+	// AppConnectorPrefs docs for more details.
+	AppConnector AppConnectorPrefs
+
 	// PostureChecking enables the collection of information used for device
 	// posture checks.
 	PostureChecking bool
@@ -227,6 +231,13 @@ type AutoUpdatePrefs struct {
 	// enabled, tailscaled will apply available updates in the background.
 	// Check must also be set when Apply is set.
 	Apply bool
+}
+
+// AppConnectorPrefs are the app connector settings for the node agent.
+type AppConnectorPrefs struct {
+	// Advertise specifies whether the app connector subsystem is advertising
+	// this node as a connector.
+	Advertise bool
 }
 
 // MaskedPrefs is a Prefs with an associated bitmask of which fields are set.
@@ -256,6 +267,7 @@ type MaskedPrefs struct {
 	OperatorUserSet           bool `json:",omitempty"`
 	ProfileNameSet            bool `json:",omitempty"`
 	AutoUpdateSet             bool `json:",omitempty"`
+	AppConnectorSet           bool `json:",omitempty"`
 	PostureCheckingSet        bool `json:",omitempty"`
 }
 
@@ -398,6 +410,7 @@ func (p *Prefs) pretty(goos string) string {
 		fmt.Fprintf(&sb, "op=%q ", p.OperatorUser)
 	}
 	sb.WriteString(p.AutoUpdate.Pretty())
+	sb.WriteString(p.AppConnector.Pretty())
 	if p.Persist != nil {
 		sb.WriteString(p.Persist.Pretty())
 	} else {
@@ -455,6 +468,7 @@ func (p *Prefs) Equals(p2 *Prefs) bool {
 		p.Persist.Equals(p2.Persist) &&
 		p.ProfileName == p2.ProfileName &&
 		p.AutoUpdate == p2.AutoUpdate &&
+		p.AppConnector == p2.AppConnector &&
 		p.PostureChecking == p2.PostureChecking
 }
 
@@ -466,6 +480,13 @@ func (au AutoUpdatePrefs) Pretty() string {
 		return "update=check "
 	}
 	return "update=off "
+}
+
+func (ap AppConnectorPrefs) Pretty() string {
+	if ap.Advertise {
+		return "appconnector=advertise "
+	}
+	return ""
 }
 
 func compareIPNets(a, b []netip.Prefix) bool {

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -58,6 +58,7 @@ func TestPrefsEqual(t *testing.T) {
 		"OperatorUser",
 		"ProfileName",
 		"AutoUpdate",
+		"AppConnector",
 		"PostureChecking",
 		"Persist",
 	}
@@ -307,6 +308,16 @@ func TestPrefsEqual(t *testing.T) {
 			true,
 		},
 		{
+			&Prefs{AppConnector: AppConnectorPrefs{Advertise: true}},
+			&Prefs{AppConnector: AppConnectorPrefs{Advertise: true}},
+			true,
+		},
+		{
+			&Prefs{AppConnector: AppConnectorPrefs{Advertise: true}},
+			&Prefs{AppConnector: AppConnectorPrefs{Advertise: false}},
+			false,
+		},
+		{
 			&Prefs{PostureChecking: true},
 			&Prefs{PostureChecking: true},
 			true,
@@ -515,6 +526,24 @@ func TestPrefsPretty(t *testing.T) {
 			},
 			"linux",
 			`Prefs{ra=false mesh=false dns=false want=false routes=[] nf=off update=on Persist=nil}`,
+		},
+		{
+			Prefs{
+				AppConnector: AppConnectorPrefs{
+					Advertise: true,
+				},
+			},
+			"linux",
+			`Prefs{ra=false mesh=false dns=false want=false routes=[] nf=off update=off appconnector=advertise Persist=nil}`,
+		},
+		{
+			Prefs{
+				AppConnector: AppConnectorPrefs{
+					Advertise: false,
+				},
+			},
+			"linux",
+			`Prefs{ra=false mesh=false dns=false want=false routes=[] nf=off update=off Persist=nil}`,
 		},
 	}
 	for i, tt := range tests {


### PR DESCRIPTION
Introduce a preference structure to store the setting for app connector
advertisement.

Introduce the associated flags:

  tailscale up --advertise-connector{=true,=false}
  tailscale set --advertise-connector{=true,=false}

```
% tailscale set --advertise-connector=false
% tailscale debug prefs | jq .AppConnector.Advertise
false
% tailscale set --advertise-connector=true
% tailscale debug prefs | jq .AppConnector.Advertise
true
% tailscale up --advertise-connector=false
% tailscale debug prefs | jq .AppConnector.Advertise
false
% tailscale up --advertise-connector=true
% tailscale debug prefs | jq .AppConnector.Advertise
true
```

Updates https://github.com/tailscale/corp/issues/15437
