### PR TITLE
flake: fixup version embedding

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
     # tailscaleRev is the git commit at which this flake was imported,
     # or the empty string when building from a local checkout of the
     # tailscale repo.
-    tailscaleRev = if builtins.hasAttr "rev" self then self.rev else "";
+    tailscaleRev = self.rev or "";
     # tailscale takes a nixpkgs package set, and builds Tailscale from
     # the same commit as this flake. IOW, it provides "tailscale built
     # from HEAD", where HEAD is "whatever commit you imported the
@@ -68,7 +68,7 @@
       src = ./.;
       vendorSha256 = pkgs.lib.fileContents ./go.mod.sri;
       nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.makeWrapper ];
-      ldflags = ["-X tailscale.com/version.GitCommit=${tailscaleRev}"];
+      ldflags = ["-X tailscale.com/version.gitCommitStamp=${tailscaleRev}"];
       CGO_ENABLED = 0;
       subPackages = [ "cmd/tailscale" "cmd/tailscaled" ];
       doCheck = false;


### PR DESCRIPTION
It looks like `gitCommitStamp` is the new "entrypoint" for setting this information.

Fixes #9996.

---

In https://github.com/tailscale/tailscale/pull/9991#discussion_r1374895191, it was suggested to also set the `gitDirtyStamp`, but unfortunately, Go doesn't seem to like converting the stringly command line flags to the boolean that the code expects:

```
tailscale.com/version.gitDirtyStamp: cannot set with -X: not a var of type string (type:bool)
```