### PR TITLE
net/dnscache: remove completed TODO

### DIFF
--- a/net/dnscache/dnscache.go
+++ b/net/dnscache/dnscache.go
@@ -1,8 +1,6 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-// TODO(bradfitz): update this code to use netaddr more
-
 // Package dnscache contains a minimal DNS cache that makes a bunch of
 // assumptions that are only valid for us. Not recommended for general use.
 package dnscache


### PR DESCRIPTION
The other IP types don't appear to be imported anymore, and after a scan through I couldn't see any substantial usage of other representations, so I think this TODO is complete.

Updates #cleanup
Signed-off-by: James Tucker <james@tailscale.com>