### PR TITLE
ipn/ipnlocal: exclude tvOS devices from taildrop file targets

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -4605,6 +4605,9 @@ func (b *LocalBackend) FileTargets() ([]*apitype.FileTarget, error) {
 		if !b.peerIsTaildropTargetLocked(p) {
 			continue
 		}
+		if p.Hostinfo().OS() == "tvOS" {
+			continue
+		}
 		peerAPI := peerAPIBase(b.netMap, p)
 		if peerAPI == "" {
 			continue

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -29,6 +29,7 @@ import (
 	"tailscale.com/types/netmap"
 	"tailscale.com/types/ptr"
 	"tailscale.com/util/dnsname"
+	"tailscale.com/util/mak"
 	"tailscale.com/util/set"
 	"tailscale.com/wgengine"
 	"tailscale.com/wgengine/filter"
@@ -462,6 +463,24 @@ func TestFileTargets(t *testing.T) {
 
 	b.capFileSharing = true
 	got, err := b.FileTargets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("unexpected %d peers", len(got))
+	}
+
+	var peerMap map[tailcfg.NodeID]tailcfg.NodeView
+	mak.NonNil(&peerMap)
+	var nodeID tailcfg.NodeID
+	nodeID = 1234
+	peer := &tailcfg.Node{
+		ID:       1234,
+		Hostinfo: (&tailcfg.Hostinfo{OS: "tvOS"}).View(),
+	}
+	peerMap[nodeID] = peer.View()
+	b.peers = peerMap
+	got, err = b.FileTargets()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
tvOS cannot accept files so we do not want to show them in the target list for taildrop.

Fixes #9903