### PR TITLE
net/dns/resolver: add subdomain resolver support in MagicDNS

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3383,11 +3383,22 @@ func dnsConfigForNetmap(nm *netmap.NetworkMap, peers map[tailcfg.NodeID]tailcfg.
 			// Ignore.
 			continue
 		}
-		fqdn, err := dnsname.ToFQDN(rec.Name)
+		// If the name has a leading dot, but is not exactly '.'.
+		var isSuffix bool
+		// Assume upstream provides either a suffix or an FQDN that are
+		// respectively well formed.
+		if len(rec.Name) > 1 && rec.Name[0] == '.' {
+			isSuffix = true
+		}
+		fqdn, err := dnsname.NewFQDN(rec.Name)
 		if err != nil {
 			continue
 		}
-		dcfg.Hosts[fqdn] = append(dcfg.Hosts[fqdn], ip)
+		if isSuffix {
+			mak.Set(&dcfg.Suffixes, fqdn, append(dcfg.Suffixes[fqdn], ip))
+		} else {
+			dcfg.Hosts[fqdn] = append(dcfg.Hosts[fqdn], ip)
+		}
 	}
 
 	if !prefs.CorpDNS() {

--- a/net/dns/config.go
+++ b/net/dns/config.go
@@ -41,6 +41,14 @@ type Config struct {
 	// it to resolve, you also need to add appropriate routes to
 	// Routes.
 	Hosts map[dnsname.FQDN][]netip.Addr
+	// Suffixes maps DNS FQDNs and all subdomains to their IPs, which can be a
+	// mix of IPv4 and IPv6.
+	// Queries matching entries in Suffixes are resolved locally by
+	// 100.100.100.100 without leaving the machine.
+	// Adding an entry to Suffixes merely creates the record. If you want
+	// it to resolve, you also need to add appropriate routes to
+	// Routes.
+	Suffixes map[dnsname.FQDN][]netip.Addr
 	// OnlyIPv6, if true, uses the IPv6 service IP (for MagicDNS)
 	// instead of the IPv4 version (100.100.100.100).
 	OnlyIPv6 bool

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -120,7 +120,9 @@ type CapabilityVersion int
 //   - 77: 2023-10-03: Client understands Peers[].SelfNodeV6MasqAddrForThisPeer
 //   - 78: 2023-10-05: can handle c2n Wake-on-LAN sending
 //   - 79: 2023-10-05: Client understands UrgentSecurityUpdate in ClientVersion
-const CurrentCapabilityVersion CapabilityVersion = 79
+//   - 80: 2023-10-16: wildcards are supported as entries in Config.Hosts
+
+const CurrentCapabilityVersion CapabilityVersion = 80
 
 type StableID string
 
@@ -1553,7 +1555,10 @@ type DNSConfig struct {
 // DNSRecord is an extra DNS record to add to MagicDNS.
 type DNSRecord struct {
 	// Name is the fully qualified domain name of
-	// the record to add. The trailing dot is optional.
+	// the record to add. If a leading dot is
+	// present, the record will serve all
+	// subomdains as well as the fully qualified
+	// domain name. The trailing dot is optional.
 	Name string
 
 	// Type is the DNS record type.

--- a/util/dnsname/dnsname.go
+++ b/util/dnsname/dnsname.go
@@ -20,14 +20,12 @@ const (
 // A FQDN is a fully-qualified DNS name or name suffix.
 type FQDN string
 
-func ToFQDN(s string) (FQDN, error) {
+// NewFQDN converts a string to a FQDN that retains any leading '.' in the case of wildcards.
+func NewFQDN(s string) (FQDN, error) {
 	if len(s) == 0 || s == "." {
 		return FQDN("."), nil
 	}
 
-	if s[0] == '.' {
-		s = s[1:]
-	}
 	raw := s
 	totalLen := len(s)
 	if s[len(s)-1] == '.' {
@@ -41,6 +39,11 @@ func ToFQDN(s string) (FQDN, error) {
 
 	st := 0
 	for i := 0; i < len(s); i++ {
+		// Ignore leading '.' from wildcards for label processing
+		if i == 0 && s[i] == '.' {
+			st = i + 1
+			continue
+		}
 		if s[i] != '.' {
 			continue
 		}
@@ -63,6 +66,30 @@ func ToFQDN(s string) (FQDN, error) {
 		raw = raw + "."
 	}
 	return FQDN(raw), nil
+}
+
+// ToFQDN strips a leading '.' on a string before converting to a FQDN.
+func ToFQDN(s string) (FQDN, error) {
+	if len(s) == 0 || s == "." {
+		return FQDN("."), nil
+	}
+
+	if s[0] == '.' {
+		s = s[1:]
+	}
+	return NewFQDN(s)
+}
+
+// ToFQDNSuffix returns an FQDN with a leading '.'.
+func ToFQDNSuffix(s string) (FQDN, error) {
+	if len(s) == 0 || s == "." {
+		return FQDN("."), nil
+	}
+
+	if s[0] != '.' {
+		s = "." + s
+	}
+	return NewFQDN(s)
 }
 
 // WithTrailingDot returns f as a string, with a trailing dot.

--- a/util/dnsname/dnsname_test.go
+++ b/util/dnsname/dnsname_test.go
@@ -210,6 +210,92 @@ func TestValidHostname(t *testing.T) {
 	}
 }
 
+func TestNewFQDN(t *testing.T) {
+	tests := []struct {
+		in         string
+		want       FQDN
+		wantErr    bool
+		wantLabels int
+	}{
+		{"", ".", false, 0},
+		{".", ".", false, 0},
+		{".foo.com", ".foo.com.", false, 3},
+		{"foo.com.", "foo.com.", false, 2},
+	}
+
+	for _, test := range tests {
+		t.Run(test.in, func(t *testing.T) {
+			got, err := NewFQDN(test.in)
+			if got != test.want {
+				t.Errorf("NewFQDN(%q) got %q, want %q", test.in, got, test.want)
+			}
+			if (err != nil) != test.wantErr {
+				t.Errorf("NewFQDN(%q) err %v, wantErr=%v", test.in, err, test.wantErr)
+			}
+			if err != nil {
+				return
+			}
+
+			gotDot := got.WithTrailingDot()
+			if gotDot != string(test.want) {
+				t.Errorf("NewFQDN(%q).WithTrailingDot() got %q, want %q", test.in, gotDot, test.want)
+			}
+			gotNoDot := got.WithoutTrailingDot()
+			wantNoDot := string(test.want)[:len(test.want)-1]
+			if gotNoDot != wantNoDot {
+				t.Errorf("NewFQDN(%q).WithoutTrailingDot() got %q, want %q", test.in, gotNoDot, wantNoDot)
+			}
+
+			if gotLabels := got.NumLabels(); gotLabels != test.wantLabels {
+				t.Errorf("NewFQDN(%q).NumLabels() got %v, want %v", test.in, gotLabels, test.wantLabels)
+			}
+		})
+	}
+}
+
+func TestToFQDNSuffix(t *testing.T) {
+	tests := []struct {
+		in         string
+		want       FQDN
+		wantErr    bool
+		wantLabels int
+	}{
+		{"", ".", false, 0},
+		{".", ".", false, 0},
+		{".foo.com", ".foo.com.", false, 3},
+		{"foo.com.", ".foo.com.", false, 3},
+	}
+
+	for _, test := range tests {
+		t.Run(test.in, func(t *testing.T) {
+			got, err := ToFQDNSuffix(test.in)
+			if got != test.want {
+				t.Errorf("ToFQDNSuffix(%q) got %q, want %q", test.in, got, test.want)
+			}
+			if (err != nil) != test.wantErr {
+				t.Errorf("ToFQDNSuffix(%q) err %v, wantErr=%v", test.in, err, test.wantErr)
+			}
+			if err != nil {
+				return
+			}
+
+			gotDot := got.WithTrailingDot()
+			if gotDot != string(test.want) {
+				t.Errorf("ToFQDNSuffix(%q).WithTrailingDot() got %q, want %q", test.in, gotDot, test.want)
+			}
+			gotNoDot := got.WithoutTrailingDot()
+			wantNoDot := string(test.want)[:len(test.want)-1]
+			if gotNoDot != wantNoDot {
+				t.Errorf("ToFQDNSuffix(%q).WithoutTrailingDot() got %q, want %q", test.in, gotNoDot, wantNoDot)
+			}
+
+			if gotLabels := got.NumLabels(); gotLabels != test.wantLabels {
+				t.Errorf("ToFQDNSuffix(%q).NumLabels() got %v, want %v", test.in, gotLabels, test.wantLabels)
+			}
+		})
+	}
+}
+
 var sinkFQDN FQDN
 
 func BenchmarkToFQDN(b *testing.B) {


### PR DESCRIPTION
This PR adds processing of subdomains that if there is an entry for a wildcard entry in hosts for a domain, MagicDNS will resolve with the host IP.

Fixes #15037