### PR TITLE
client/tailscale: add Device.PostureIdentity field

### DIFF
--- a/api.md
+++ b/api.md
@@ -277,6 +277,15 @@ You can also [list all devices in the tailnet](#list-tailnet-devices) to get the
   // tailnet lock is not enabled.
   // Learn more about tailnet lock at https://tailscale.com/kb/1226/.
   "tailnetLockKey": "",
+
+  // postureIdentity contains extra identifiers from the device when the tailnet
+  // it is connected to has device posture identification collection enabled.
+  // If the device has not opted-in to posture identification collection, this
+  // will contain {"disabled": true}.
+  // Learn more about posture identity at https://tailscale.com/kb/1326/device-identity
+  "postureIdentity": {
+    "serialNumbers": ["CP74LFQJXM"]
+  }
 }
 ```
 
@@ -328,6 +337,7 @@ Currently, there are two supported options:
   - `enabledRoutes`
   - `advertisedRoutes`
   - `clientConnectivity` (which contains the following fields: `mappingVariesByDestIP`, `derp`, `endpoints`, `latency`, and `clientSupports`)
+  - `postureIdentity`
 
 ### Request example
 

--- a/client/tailscale/devices.go
+++ b/client/tailscale/devices.go
@@ -71,6 +71,17 @@ type Device struct {
 	AdvertisedRoutes []string `json:"advertisedRoutes"` // Empty for external devices.
 
 	ClientConnectivity *ClientConnectivity `json:"clientConnectivity"`
+
+	// PostureIdentity contains extra identifiers collected from the device when
+	// the tailnet has the device posture identification features enabled. If
+	// Tailscale have attempted to collect this from the device but it has not
+	// opted in, PostureIdentity will have Disabled=true.
+	PostureIdentity *DevicePostureIdentity `json:"postureIdentity"`
+}
+
+type DevicePostureIdentity struct {
+	Disabled      bool     `json:"disabled,omitempty"`
+	SerialNumbers []string `json:"serialNumbers,omitempty"`
 }
 
 // DeviceFieldsOpts determines which fields should be returned in the response.


### PR DESCRIPTION
These new API fields come from tailscale/corp#15445.

Closes tailscale/corp#15617

Edit: We'll look at shipping this once the feature hits beta. Work-in-progress tests for these clients changes are in https://github.com/tailscale/corp/commit/92e5311c4c58f878d2f412cd765aac4a16ca11d1