### PR TITLE
ipn: replace web client debug flag with node capability

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -570,9 +570,7 @@ func getLocalBackend(ctx context.Context, logf logger.Logf, logID logid.PublicID
 	if root := lb.TailscaleVarRoot(); root != "" {
 		dnsfallback.SetCachePath(filepath.Join(root, "derpmap.cached.json"), logf)
 	}
-	if envknob.Bool("TS_DEBUG_WEB_UI") {
-		lb.SetWebLocalClient(&tailscale.LocalClient{Socket: args.socketpath, UseSocketOnly: args.socketpath != ""})
-	}
+	lb.SetWebLocalClient(&tailscale.LocalClient{Socket: args.socketpath, UseSocketOnly: args.socketpath != ""})
 	configureTaildrop(logf, lb)
 	if err := ns.Start(lb); err != nil {
 		log.Fatalf("failed to start netstack: %v", err)

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -2920,11 +2920,6 @@ func (b *LocalBackend) EditPrefs(mp *ipn.MaskedPrefs) (ipn.PrefsView, error) {
 		b.logf("EditPrefs requests SSH, but disabled by envknob; returning error")
 		return ipn.PrefsView{}, errors.New("Tailscale SSH server administratively disabled.")
 	}
-	if p1.RunWebClient && !envknob.Bool("TS_DEBUG_WEB_UI") {
-		b.mu.Unlock()
-		b.logf("EditPrefs requests web client, but disabled by envknob; returning error")
-		return ipn.PrefsView{}, errors.New("web ui flag not set")
-	}
 	if p1.View().Equals(p0) {
 		b.mu.Unlock()
 		return stripKeysFromPrefs(p0), nil
@@ -4161,7 +4156,7 @@ func (b *LocalBackend) ResetForClientDisconnect() {
 func (b *LocalBackend) ShouldRunSSH() bool { return b.sshAtomicBool.Load() && envknob.CanSSHD() }
 
 func (b *LocalBackend) ShouldRunWebClient() bool {
-	return b.webclientAtomicBool.Load() && envknob.Bool("TS_DEBUG_WEB_UI")
+	return b.webclientAtomicBool.Load() && hasCapability(b.netMap, tailcfg.CapabilityPreviewWebClient)
 }
 
 // ShouldHandleViaIP reports whether ip is an IPv6 address in the

--- a/ipn/ipnlocal/web_client.go
+++ b/ipn/ipnlocal/web_client.go
@@ -13,8 +13,8 @@ import (
 
 	"tailscale.com/client/tailscale"
 	"tailscale.com/client/web"
-	"tailscale.com/envknob"
 	"tailscale.com/net/netutil"
+	"tailscale.com/tailcfg"
 )
 
 // webClient holds state for the web interface for managing
@@ -41,8 +41,8 @@ func (b *LocalBackend) SetWebLocalClient(lc *tailscale.LocalClient) {
 // tailscaled instance.
 // If the web interface is already running, WebClientInit is a no-op.
 func (b *LocalBackend) WebClientInit() (err error) {
-	if !envknob.Bool("TS_DEBUG_WEB_UI") {
-		return errors.New("web ui flag unset")
+	if !hasCapability(b.netMap, tailcfg.CapabilityPreviewWebClient) {
+		return errors.New("web client not enabled for this device")
 	}
 
 	b.mu.Lock()

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -2040,6 +2040,7 @@ const (
 	CapabilityDataPlaneAuditLogs NodeCapability = "https://tailscale.com/cap/data-plane-audit-logs" // feature enabled
 	CapabilityDebug              NodeCapability = "https://tailscale.com/cap/debug"                 // exposes debug endpoints over the PeerAPI
 	CapabilityHTTPS              NodeCapability = "https"                                           // https cert provisioning enabled on tailnet
+	CapabilityPreviewWebClient   NodeCapability = "preview-webclient"                               // allows starting web client in tailscaled
 
 	// CapabilityBindToInterfaceByRoute changes how Darwin nodes create
 	// sockets (in the net/netns package). See that package for more


### PR DESCRIPTION
The web client in tailscaled is now enabled by setting the "preview-webclient" node capability in the tailnet policy file:

```json
"nodeAttrs": [
  {"target": ["*"], "attr": ["preview-webclient"]},
],
```

This makes it much easier to test on real NAS devices where setting additional environment variables is kind of a pain.  We still need to update the client itself to no longer require the `--dev` flag or `TS_DEBUG_WEB_CLIENT_MODE` var.

Updates tailscale/corp#14335