### PR TITLE
ipn/ipnlocal: rename web fields/structs to webClient

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -206,7 +206,7 @@ type LocalBackend struct {
 	httpTestClient *http.Client // for controlclient. nil by default, used by tests.
 	ccGen          clientGen    // function for producing controlclient; lazily populated
 	sshServer      SSHServer    // or nil, initialized lazily.
-	web            webServer
+	webClient      webClient
 	notify         func(ipn.Notify)
 	cc             controlclient.Client
 	ccAuto         *controlclient.Auto // if cc is of type *controlclient.Auto
@@ -645,7 +645,7 @@ func (b *LocalBackend) Shutdown() {
 		b.debugSink = nil
 	}
 	b.mu.Unlock()
-	b.WebShutdown()
+	b.WebClientShutdown()
 
 	if b.sockstatLogger != nil {
 		b.sockstatLogger.Shutdown()
@@ -3018,7 +3018,7 @@ func (b *LocalBackend) setPrefsLockedOnEntry(caller string, newp *ipn.Prefs) ipn
 		}
 	}
 	if oldp.ShouldWebClientBeRunning() && !newp.ShouldWebClientBeRunning() {
-		b.WebShutdown()
+		b.WebClientShutdown()
 	}
 	if netMap != nil {
 		newProfile := netMap.UserProfiles[netMap.User()]

--- a/ipn/ipnlocal/web_client.go
+++ b/ipn/ipnlocal/web_client.go
@@ -17,11 +17,11 @@ import (
 	"tailscale.com/net/netutil"
 )
 
-// webServer holds state for the web interface for managing
+// webClient holds state for the web interface for managing
 // this tailscale instance. The web interface is not used by
 // default, but initialized by calling LocalBackend.WebOrInit.
-type webServer struct {
-	ws *web.Server // or nil, initialized lazily
+type webClient struct {
+	server *web.Server // or nil, initialized lazily
 
 	// lc optionally specifies a LocalClient to use to connect
 	// to the localapi for this tailscaled instance.
@@ -34,57 +34,56 @@ type webServer struct {
 func (b *LocalBackend) SetWebLocalClient(lc *tailscale.LocalClient) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	b.web.lc = lc
+	b.webClient.lc = lc
 }
 
-// WebInit initializes the web interface for managing
-// this tailscaled instance. If the web interface is
-// already running, WebInit is a no-op.
-func (b *LocalBackend) WebInit() (err error) {
+// WebClientInit initializes the web interface for managing this
+// tailscaled instance.
+// If the web interface is already running, WebClientInit is a no-op.
+func (b *LocalBackend) WebClientInit() (err error) {
 	if !envknob.Bool("TS_DEBUG_WEB_UI") {
 		return errors.New("web ui flag unset")
 	}
 
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if b.web.ws != nil {
+	if b.webClient.server != nil {
 		return nil
 	}
 
-	b.logf("WebInit: initializing web ui")
-	if b.web.ws, err = web.NewServer(web.ServerOpts{
+	b.logf("WebClientInit: initializing web ui")
+	if b.webClient.server, err = web.NewServer(web.ServerOpts{
 		// TODO(sonia): allow passing back dev mode flag
-		LocalClient: b.web.lc,
+		LocalClient: b.webClient.lc,
 		Logf:        b.logf,
 	}); err != nil {
 		return fmt.Errorf("web.NewServer: %w", err)
 	}
 
-	b.logf("WebInit: started web ui")
+	b.logf("WebClientInit: started web ui")
 	return nil
 }
 
-// WebShutdown shuts down any running b.web servers and
-// clears out b.web state (besides the b.web.lc field,
-// which is left untouched because required for future
-// web startups).
-// WebShutdown obtains the b.mu lock.
-func (b *LocalBackend) WebShutdown() {
+// WebClientShutdown shuts down any running b.webClient servers and
+// clears out b.webClient state (besides the b.webClient.lc field,
+// which is left untouched because required for future web startups).
+// WebClientShutdown obtains the b.mu lock.
+func (b *LocalBackend) WebClientShutdown() {
 	b.mu.Lock()
-	webS := b.web.ws
-	b.web.ws = nil
+	server := b.webClient.server
+	b.webClient.server = nil
 	b.mu.Unlock() // release lock before shutdown
-	if webS != nil {
-		b.web.ws.Shutdown()
+	if server != nil {
+		server.Shutdown()
 	}
-	b.logf("WebShutdown: shut down web ui")
+	b.logf("WebClientShutdown: shut down web ui")
 }
 
 // handleWebClientConn serves web client requests.
 func (b *LocalBackend) handleWebClientConn(c net.Conn) error {
-	if err := b.WebInit(); err != nil {
+	if err := b.WebClientInit(); err != nil {
 		return err
 	}
-	s := http.Server{Handler: b.web.ws}
+	s := http.Server{Handler: b.webClient.server}
 	return s.Serve(netutil.NewOneConnListener(c, nil))
 }

--- a/ipn/ipnlocal/web_client_stub.go
+++ b/ipn/ipnlocal/web_client_stub.go
@@ -12,15 +12,15 @@ import (
 	"tailscale.com/client/tailscale"
 )
 
-type webServer struct{}
+type webClient struct{}
 
 func (b *LocalBackend) SetWebLocalClient(lc *tailscale.LocalClient) {}
 
-func (b *LocalBackend) WebInit() error {
+func (b *LocalBackend) WebClientInit() error {
 	return errors.New("not implemented")
 }
 
-func (b *LocalBackend) WebShutdown() {}
+func (b *LocalBackend) WebClientShutdown() {}
 
 func (b *LocalBackend) handleWebClientConn(c net.Conn) error {
 	return errors.New("not implemented")

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -62,11 +62,11 @@ type localAPIHandler func(*Handler, http.ResponseWriter, *http.Request)
 // then it's a prefix match.
 var handler = map[string]localAPIHandler{
 	// The prefix match handlers end with a slash:
-	"cert/":     (*Handler).serveCert,
-	"file-put/": (*Handler).serveFilePut,
-	"files/":    (*Handler).serveFiles,
-	"profiles/": (*Handler).serveProfiles,
-	"web/":      (*Handler).serveWeb,
+	"cert/":      (*Handler).serveCert,
+	"file-put/":  (*Handler).serveFilePut,
+	"files/":     (*Handler).serveFiles,
+	"profiles/":  (*Handler).serveProfiles,
+	"webclient/": (*Handler).serveWebClient,
 
 	// The other /localapi/v0/NAME handlers are exact matches and contain only NAME
 	// without a trailing slash:
@@ -2234,7 +2234,7 @@ func (h *Handler) serveDebugWebClient(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 }
 
-func (h *Handler) serveWeb(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) serveWebClient(w http.ResponseWriter, r *http.Request) {
 	if !h.PermitWrite {
 		http.Error(w, "access denied", http.StatusForbidden)
 		return
@@ -2244,8 +2244,8 @@ func (h *Handler) serveWeb(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	switch r.URL.Path {
-	case "/localapi/v0/web/start":
-		if err := h.b.WebInit(); err != nil {
+	case "/localapi/v0/webclient/start":
+		if err := h.b.WebClientInit(); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -2256,8 +2256,8 @@ func (h *Handler) serveWeb(w http.ResponseWriter, r *http.Request) {
 		})
 		w.WriteHeader(http.StatusOK)
 		return
-	case "/localapi/v0/web/stop":
-		h.b.WebShutdown()
+	case "/localapi/v0/webclient/stop":
+		h.b.WebClientShutdown()
 		// try to set pref, but ignore errors
 		_, _ = h.b.EditPrefs(&ipn.MaskedPrefs{
 			Prefs:           ipn.Prefs{RunWebClient: false},


### PR DESCRIPTION
For consistency and clarity around what the LocalBackend.web field is used for.

Updates tailscale/corp#14335