### PR TITLE
clientupdate: mention release track when running latest

### DIFF
--- a/clientupdate/clientupdate.go
+++ b/clientupdate/clientupdate.go
@@ -237,10 +237,10 @@ func Update(args Arguments) error {
 func (up *Updater) confirm(ver string) bool {
 	switch cmpver.Compare(version.Short(), ver) {
 	case 0:
-		up.Logf("already running %v; no update needed", ver)
+		up.Logf("already running %v version %v; no update needed", up.track, ver)
 		return false
 	case 1:
-		up.Logf("installed version %v is newer than the latest available version %v; no update needed", version.Short(), ver)
+		up.Logf("installed %v version %v is newer than the latest available version %v; no update needed", up.track, version.Short(), ver)
 		return false
 	}
 	if up.Confirm != nil {


### PR DESCRIPTION
Not all users know about our tracks and versioning scheme. They can be confused when e.g. 1.52.0 is out but 1.53.0 is available. Or when 1.52.0 is our but 1.53 has not been built yet and user is on 1.51.x.

Mentioning the track in output should hint at why update is not happening.

Updates #cleanup