### PR TITLE
clientupdate: disable on Unraid

### DIFF
--- a/clientupdate/clientupdate.go
+++ b/clientupdate/clientupdate.go
@@ -178,6 +178,7 @@ func (up *Updater) getUpdateFunction() (fn updateFunction, canAutoUpdate bool) {
 		case distro.Unraid:
 			// Unraid runs from memory, updates must be installed via the Unraid
 			// plugin manager to be persistent.
+			// TODO(awly): implement Unraid updates using the 'plugin' CLI.
 			return nil, false
 		}
 		switch {

--- a/clientupdate/clientupdate.go
+++ b/clientupdate/clientupdate.go
@@ -175,6 +175,10 @@ func (up *Updater) getUpdateFunction() (fn updateFunction, canAutoUpdate bool) {
 			return up.updateLinuxBinary, true
 		case distro.Alpine:
 			return up.updateAlpineLike, true
+		case distro.Unraid:
+			// Unraid runs from memory, updates must be installed via the Unraid
+			// plugin manager to be persistent.
+			return nil, false
 		}
 		switch {
 		case haveExecutable("pacman"):


### PR DESCRIPTION
The built-in update will not work properly on Unraid since the system runs from memory and "reinstalls" itself on every boot. Updates must be applied via the Unraid plugin system since this will allow the update to persist across reboots.

If users attempt to use the built-in updater, they could encounter unusual behavior (Tailscale rolling back on restart, Unraid errors, etc.).

Updates dkaser/unraid-tailscale#94