### PR TITLE
cmd/k8s-operator/deploy/chart,.github/workflows: use helm chart API v2

### DIFF
--- a/.github/workflows/kubemanifests.yaml
+++ b/.github/workflows/kubemanifests.yaml
@@ -1,0 +1,24 @@
+name: "Kubernetes manifests"
+on:
+  pull_request:
+   paths: 
+   - './cmd/k8s-operator/'
+   - '.github/workflows/kubemanifests.yaml'
+
+# Cancel workflow run if there is a newer push to the same PR for which it is
+# running
+concurrency:
+  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  testchart:
+    runs-on: [ ubuntu-latest ]
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+    - name: Build and lint Helm chart
+      run: |
+        eval `./tool/go run ./cmd/mkversion`
+        ./tool/helm package --app-version="${VERSION_SHORT}" --version=${VERSION_SHORT} './cmd/k8s-operator/deploy/chart'
+        ./tool/helm lint "tailscale-operator-${VERSION_SHORT}.tgz"

--- a/cmd/k8s-operator/deploy/chart/Chart.yaml
+++ b/cmd/k8s-operator/deploy/chart/Chart.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) Tailscale Inc & AUTHORS
 # SPDX-License-Identifier: BSD-3-Clause
 
-apiVersion: v1
+apiVersion: v2
 name: tailscale-operator
 description: A Helm chart for Tailscale Kubernetes operator
 home: https://github.com/tailscale/tailscale


### PR DESCRIPTION
Helm chart was failing helm linter because I had added `type` field which only appears in Helm API v2.

I have upgraded the chart to use API v2 - as I understand [the main difference is that v2 does not support helm v2 deployment mechanism](https://helm.sh/docs/topics/charts/#the-apiversion-field)- but this is [long deprecated](https://helm.sh/blog/helm-v2-deprecation-timeline/) and I have not heard that anyone would still use that.

both v1 and v2 API versions are use by other projects:
- https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/Chart.yaml#L5
- https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/Chart.template.yaml#L1

Also added a CI test that packages chart and runs helm linter.

Updates tailscale/tailscale#9222