### PR TITLE
cmd/k8s-operator: strip credentials from client config in noauth mode

### DIFF
--- a/cmd/k8s-operator/proxy.go
+++ b/cmd/k8s-operator/proxy.go
@@ -91,6 +91,9 @@ func maybeLaunchAPIServerProxy(zlog *zap.SugaredLogger, restConfig *rest.Config,
 	}
 	hostinfo.SetApp("k8s-operator-proxy")
 	startlog := zlog.Named("launchAPIProxy")
+	if mode == apiserverProxyModeNoAuth {
+		restConfig = rest.AnonymousClientConfig(restConfig)
+	}
 	cfg, err := restConfig.TransportConfig()
 	if err != nil {
 		startlog.Fatalf("could not get rest.TransportConfig(): %v", err)


### PR DESCRIPTION
Updates tailscale/corp#15526