### PR TITLE
ipn/ipnlocal: prevent deadlock on WebClientShutdown

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3013,7 +3013,7 @@ func (b *LocalBackend) setPrefsLockedOnEntry(caller string, newp *ipn.Prefs) ipn
 		}
 	}
 	if oldp.ShouldWebClientBeRunning() && !newp.ShouldWebClientBeRunning() {
-		b.WebClientShutdown()
+		go b.WebClientShutdown()
 	}
 	if netMap != nil {
 		newProfile := netMap.UserProfiles[netMap.User()]


### PR DESCRIPTION
WebClientShutdown tries to acquire the b.mu lock, so run it in a go routine so that it can finish shutdown after setPrefsLockedOnEntry is finished. This is the same reason b.sshServer.Shutdown is run in a go routine.

Updates tailscale/corp#14335