### PR TITLE
types/dnstype: update the usage documentation on dnstype.Resolver

### DIFF
--- a/types/dnstype/dnstype.go
+++ b/types/dnstype/dnstype.go
@@ -21,6 +21,8 @@ type Resolver struct {
 	//    as of 2022-09-08 only used for certain well-known resolvers
 	//    (see the publicdns package) for which the IP addresses to dial DoH are
 	//    known ahead of time, so bootstrap DNS resolution is not required.
+	//  - "http://node-address:port/path" for DNS over HTTP over WireGuard. This
+	//    is implemented in the PeerAPI for exit nodes and app connectors.
 	//  - [TODO] "tls://resolver.com" for DNS over TCP+TLS
 	Addr string `json:",omitempty"`
 


### PR DESCRIPTION
There was pre-existing additional usage for Exit Node DNS resolution via PeerAPI, as well as new usage just introduced for App Connectors.

Fixes ENG-2324
Updates #cleanup
Signed-off-by: James Tucker <james@tailscale.com>