### PR TITLE
cmd/k8s-operator: set different app type for operator with proxy enabled/disabled

### DIFF
--- a/cmd/k8s-operator/proxy.go
+++ b/cmd/k8s-operator/proxy.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/client-go/transport"
 	"tailscale.com/client/tailscale"
 	"tailscale.com/client/tailscale/apitype"
-	"tailscale.com/hostinfo"
 	"tailscale.com/tailcfg"
 	"tailscale.com/tsnet"
 	"tailscale.com/types/logger"
@@ -84,12 +83,10 @@ func parseAPIProxyMode() apiServerProxyMode {
 // maybeLaunchAPIServerProxy launches the auth proxy, which is a small HTTP server
 // that authenticates requests using the Tailscale LocalAPI and then proxies
 // them to the kube-apiserver.
-func maybeLaunchAPIServerProxy(zlog *zap.SugaredLogger, restConfig *rest.Config, s *tsnet.Server) {
-	mode := parseAPIProxyMode()
+func maybeLaunchAPIServerProxy(zlog *zap.SugaredLogger, restConfig *rest.Config, s *tsnet.Server, mode apiServerProxyMode) {
 	if mode == apiserverProxyModeDisabled {
 		return
 	}
-	hostinfo.SetApp("k8s-operator-proxy")
 	startlog := zlog.Named("launchAPIProxy")
 	if mode == apiserverProxyModeNoAuth {
 		restConfig = rest.AnonymousClientConfig(restConfig)


### PR DESCRIPTION
This PR fixes a bug where, although we intend to set different app type for operator with proxy enabled vs disabled, it was in practice always set to 'k8s-operator' because that code path got hit first and early.

I have tested this fix by deploying operator from this PR with the proxy enabled and checked that 'App' gets set to 'k8s-operator-proxy'. This can be observed in the operator logs if the logging level is set to 'debug':
```
k logs deploy/operator -n tailscale
...
{"level":"debug","ts":"2023-11-02T13:13:44Z","logger":"tailscaled","msg":"control: [v1] HostInfo: {\"IPNVersion\":\"1.53.51-t50aeac003\",\"BackendLogID\":\"7aa1bca5af2cdc83c59b51a77c57f8b871dc188455862c4d36797a11a4d0edf3\",\"OS\":\"linux\",\"OSVersion\":\"5.15.120+\",\"Container\":false,\"Env\":\"k8s\",\"Distro\":\"alpine\",\"DistroVersion\":\"3.16.7\",\"App\":\"k8s-operator-proxy\",\"Desktop\":false,\"Package\":\"tsnet\",\"Hostname\":\"tailscale-operator\",\"Machine\":\"x86_64\",\"GoArch\":\"amd64\",\"GoArchVar\":\"v1\",\"GoVersion\":\"go1.21.3\",\"Services\":[{\"Proto\":\"peerapi4\",\"Port\":47531},{\"Proto\":\"peerapi6\",\"Port\":47531},{\"Proto\":\"peerapi-dns-proxy\",\"Port\":1}],\"Cloud\":\"gcp\",\"Userspace\":true,\"UserspaceRouter\":true}"}
...
```