### PR TITLE
clientupdate: cleanup SPK and MSI downloads

### DIFF
--- a/clientupdate/clientupdate.go
+++ b/clientupdate/clientupdate.go
@@ -284,6 +284,7 @@ func (up *Updater) updateSynology() error {
 		return nil
 	}
 
+	up.cleanupOldDownloads(filepath.Join(os.TempDir(), "tailscale-update*"))
 	// Download the SPK into a temporary directory.
 	spkDir, err := os.MkdirTemp("", "tailscale-update")
 	if err != nil {
@@ -743,6 +744,7 @@ you can run the command prompt as Administrator one of these ways:
 	if err := os.MkdirAll(msiDir, 0700); err != nil {
 		return err
 	}
+	up.cleanupOldDownloads(filepath.Join(msiDir, "*.msi"))
 	pkgsPath := fmt.Sprintf("%s/tailscale-setup-%s-%s.msi", up.track, ver, arch)
 	msiTarget := filepath.Join(msiDir, path.Base(pkgsPath))
 	if err := up.downloadURLToFile(pkgsPath, msiTarget); err != nil {
@@ -829,6 +831,19 @@ func (up *Updater) installMSI(msi string) error {
 		up.Logf("msiexec uninstall: %v", err)
 	}
 	return err
+}
+
+func (up *Updater) cleanupOldDownloads(glob string) {
+	matches, err := filepath.Glob(glob)
+	if err != nil {
+		up.Logf("cleaning up old downloads: %v", err)
+		return
+	}
+	for _, m := range matches {
+		if err := os.RemoveAll(m); err != nil {
+			up.Logf("cleaning up old downloads: %v", err)
+		}
+	}
 }
 
 func msiUUIDForVersion(ver string) string {


### PR DESCRIPTION
After we're done installing, clean up the temp files. This prevents temp volumes from filling up on hosts that don't reboot often.

Fixes https://github.com/tailscale/tailscale/issues/10082