### PR TITLE
ipn/localapi: remove webclient endpoint

### DIFF
--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -62,11 +62,10 @@ type localAPIHandler func(*Handler, http.ResponseWriter, *http.Request)
 // then it's a prefix match.
 var handler = map[string]localAPIHandler{
 	// The prefix match handlers end with a slash:
-	"cert/":      (*Handler).serveCert,
-	"file-put/":  (*Handler).serveFilePut,
-	"files/":     (*Handler).serveFiles,
-	"profiles/":  (*Handler).serveProfiles,
-	"webclient/": (*Handler).serveWebClient,
+	"cert/":     (*Handler).serveCert,
+	"file-put/": (*Handler).serveFilePut,
+	"files/":    (*Handler).serveFiles,
+	"profiles/": (*Handler).serveProfiles,
 
 	// The other /localapi/v0/NAME handlers are exact matches and contain only NAME
 	// without a trailing slash:
@@ -2241,43 +2240,6 @@ func (h *Handler) serveDebugWebClient(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Write(body)
 	w.Header().Set("Content-Type", "application/json")
-}
-
-func (h *Handler) serveWebClient(w http.ResponseWriter, r *http.Request) {
-	if !h.PermitWrite {
-		http.Error(w, "access denied", http.StatusForbidden)
-		return
-	}
-	if r.Method != httpm.POST {
-		http.Error(w, "use POST", http.StatusMethodNotAllowed)
-		return
-	}
-	switch r.URL.Path {
-	case "/localapi/v0/webclient/start":
-		if err := h.b.WebClientInit(); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		// try to set pref, but ignore errors
-		_, _ = h.b.EditPrefs(&ipn.MaskedPrefs{
-			Prefs:           ipn.Prefs{RunWebClient: true},
-			RunWebClientSet: true,
-		})
-		w.WriteHeader(http.StatusOK)
-		return
-	case "/localapi/v0/webclient/stop":
-		h.b.WebClientShutdown()
-		// try to set pref, but ignore errors
-		_, _ = h.b.EditPrefs(&ipn.MaskedPrefs{
-			Prefs:           ipn.Prefs{RunWebClient: false},
-			RunWebClientSet: true,
-		})
-		w.WriteHeader(http.StatusOK)
-		return
-	default:
-		http.Error(w, "invalid action", http.StatusBadRequest)
-		return
-	}
 }
 
 func defBool(a string, def bool) bool {


### PR DESCRIPTION
Managing starting/stopping tailscaled web client purely via setting the RunWebClient pref.

Updates tailscale/corp#14335