### PR TITLE
ipn/ipnlocal: pull CapabilityPreviewWebClient into webClientAtomicBool

### DIFF
--- a/ipn/ipnlocal/web_client.go
+++ b/ipn/ipnlocal/web_client.go
@@ -14,7 +14,6 @@ import (
 	"tailscale.com/client/tailscale"
 	"tailscale.com/client/web"
 	"tailscale.com/net/netutil"
-	"tailscale.com/tailcfg"
 )
 
 // webClient holds state for the web interface for managing
@@ -41,7 +40,7 @@ func (b *LocalBackend) SetWebLocalClient(lc *tailscale.LocalClient) {
 // tailscaled instance.
 // If the web interface is already running, WebClientInit is a no-op.
 func (b *LocalBackend) WebClientInit() (err error) {
-	if !hasCapability(b.netMap, tailcfg.CapabilityPreviewWebClient) {
+	if !b.ShouldRunWebClient() {
 		return errors.New("web client not enabled for this device")
 	}
 


### PR DESCRIPTION
Now uses webClientAtomicBool as the source of truth for whether the web client should be running in tailscaled, with it updated when either the RunWebClient pref or CapabilityPreviewWebClient node capability changes.

This avoids requiring holding the LocalBackend lock on each call to ShouldRunWebClient to check for the CapabilityPreviewWebClient value.

Updates tailscale/corp#14335