### PR TITLE
client/web: add ServerMode to web.Server

### DIFF
--- a/client/web/web_test.go
+++ b/client/web/web_test.go
@@ -337,9 +337,9 @@ func TestAuthorizeRequest(t *testing.T) {
 	go localapi.Serve(lal)
 
 	s := &Server{
-		lc:          &tailscale.LocalClient{Dial: lal.Dial},
-		tsDebugMode: "full",
-		timeNow:     time.Now,
+		mode:    ManageServerMode,
+		lc:      &tailscale.LocalClient{Dial: lal.Dial},
+		timeNow: time.Now,
 	}
 	validCookie := "ts-cookie"
 	s.browserSessions.Store(validCookie, &browserSession{
@@ -428,9 +428,9 @@ func TestServeTailscaleAuth(t *testing.T) {
 	sixtyDaysAgo := timeNow.Add(-sessionCookieExpiry * 2)
 
 	s := &Server{
-		lc:          &tailscale.LocalClient{Dial: lal.Dial},
-		tsDebugMode: "full",
-		timeNow:     func() time.Time { return timeNow },
+		mode:    ManageServerMode,
+		lc:      &tailscale.LocalClient{Dial: lal.Dial},
+		timeNow: func() time.Time { return timeNow },
 	}
 
 	successCookie := "ts-cookie-success"

--- a/ipn/ipnlocal/web_client.go
+++ b/ipn/ipnlocal/web_client.go
@@ -52,6 +52,7 @@ func (b *LocalBackend) WebClientInit() (err error) {
 
 	b.logf("WebClientInit: initializing web ui")
 	if b.webClient.server, err = web.NewServer(web.ServerOpts{
+		Mode: web.ManageServerMode,
 		// TODO(sonia): allow passing back dev mode flag
 		LocalClient: b.webClient.lc,
 		Logf:        b.logf,

--- a/tsnet/example/web-client/web-client.go
+++ b/tsnet/example/web-client/web-client.go
@@ -31,6 +31,7 @@ func main() {
 
 	// Serve the Tailscale web client.
 	ws, err := web.NewServer(web.ServerOpts{
+		Mode:        web.LegacyServerMode,
 		DevMode:     *devMode,
 		LocalClient: lc,
 	})


### PR DESCRIPTION
Adds a new Mode to the web server, indicating the specific scenario the constructed server is intended to be run in. Also
starts filling this from the cli/web and ipn/ipnlocal callers.

From cli/web this gets filled conditionally based on whether the preview web client node cap is set. If not set, the existing
"legacy" client is served. If set, both a login/lobby and full management client are started (in "login" and "manage" modes respectively).

Updates tailscale/corp#14335