### PR TITLE
client/web: fill devMode from an env var

### DIFF
--- a/client/web/web.go
+++ b/client/web/web.go
@@ -43,6 +43,9 @@ type Server struct {
 	lc      *tailscale.LocalClient
 	timeNow func() time.Time
 
+	// devMode indicates that the server run with frontend assets
+	// served by a Vite dev server, allowing for local development
+	// on the web client frontend.
 	devMode    bool
 	cgiMode    bool
 	pathPrefix string
@@ -100,11 +103,6 @@ type ServerOpts struct {
 	// Mode specifies the mode of web client being constructed.
 	Mode ServerMode
 
-	// DevMode indicates that the server should be started with frontend
-	// assets served by a Vite dev server, allowing for local development
-	// on the web client frontend.
-	DevMode bool
-
 	// CGIMode indicates if the server is running as a CGI script.
 	CGIMode bool
 
@@ -143,7 +141,7 @@ func NewServer(opts ServerOpts) (s *Server, err error) {
 	s = &Server{
 		mode:       opts.Mode,
 		logf:       opts.Logf,
-		devMode:    opts.DevMode,
+		devMode:    envknob.Bool("TS_DEBUG_WEB_CLIENT_DEV"),
 		lc:         opts.LocalClient,
 		cgiMode:    opts.CGIMode,
 		pathPrefix: opts.PathPrefix,
@@ -155,7 +153,7 @@ func NewServer(opts ServerOpts) (s *Server, err error) {
 	if s.logf == nil {
 		s.logf = log.Printf
 	}
-	s.assetsHandler, s.assetsCleanup = assetsHandler(opts.DevMode)
+	s.assetsHandler, s.assetsCleanup = assetsHandler(s.devMode)
 
 	var metric string // clientmetric to report on startup
 

--- a/cmd/tailscale/cli/web.go
+++ b/cmd/tailscale/cli/web.go
@@ -41,7 +41,6 @@ Tailscale, as opposed to a CLI or a native app.
 		webf := newFlagSet("web")
 		webf.StringVar(&webArgs.listen, "listen", "localhost:8088", "listen address; use port 0 for automatic")
 		webf.BoolVar(&webArgs.cgi, "cgi", false, "run as CGI script")
-		webf.BoolVar(&webArgs.dev, "dev", false, "run web client in developer mode [this flag is in development, use is unsupported]")
 		webf.StringVar(&webArgs.prefix, "prefix", "", "URL prefix added to requests (for cgi or reverse proxies)")
 		return webf
 	})(),
@@ -51,7 +50,6 @@ Tailscale, as opposed to a CLI or a native app.
 var webArgs struct {
 	listen string
 	cgi    bool
-	dev    bool
 	prefix string
 }
 
@@ -104,7 +102,6 @@ func runWeb(ctx context.Context, args []string) error {
 
 	webServer, err := web.NewServer(web.ServerOpts{
 		Mode:        cliServerMode,
-		DevMode:     webArgs.dev,
 		CGIMode:     webArgs.cgi,
 		PathPrefix:  webArgs.prefix,
 		LocalClient: &localClient,

--- a/ipn/ipnlocal/web_client.go
+++ b/ipn/ipnlocal/web_client.go
@@ -52,8 +52,7 @@ func (b *LocalBackend) WebClientInit() (err error) {
 
 	b.logf("WebClientInit: initializing web ui")
 	if b.webClient.server, err = web.NewServer(web.ServerOpts{
-		Mode: web.ManageServerMode,
-		// TODO(sonia): allow passing back dev mode flag
+		Mode:        web.ManageServerMode,
 		LocalClient: b.webClient.lc,
 		Logf:        b.logf,
 	}); err != nil {
@@ -75,8 +74,8 @@ func (b *LocalBackend) WebClientShutdown() {
 	b.mu.Unlock() // release lock before shutdown
 	if server != nil {
 		server.Shutdown()
+		b.logf("WebClientShutdown: shut down web ui")
 	}
-	b.logf("WebClientShutdown: shut down web ui")
 }
 
 // handleWebClientConn serves web client requests.

--- a/tsnet/example/web-client/web-client.go
+++ b/tsnet/example/web-client/web-client.go
@@ -14,8 +14,7 @@ import (
 )
 
 var (
-	addr    = flag.String("addr", "localhost:8060", "address of Tailscale web client")
-	devMode = flag.Bool("dev", false, "run web client in dev mode")
+	addr = flag.String("addr", "localhost:8060", "address of Tailscale web client")
 )
 
 func main() {
@@ -32,7 +31,6 @@ func main() {
 	// Serve the Tailscale web client.
 	ws, err := web.NewServer(web.ServerOpts{
 		Mode:        web.LegacyServerMode,
-		DevMode:     *devMode,
 		LocalClient: lc,
 	})
 	if err != nil {


### PR DESCRIPTION
Avoids the need to pipe a web client dev flag through the tailscaled command.

Updates tailscale/corp#14335