### PR TITLE
client/web: add some security checks for full client

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3132,7 +3132,7 @@ func (b *LocalBackend) TCPHandlerForDst(src, dst netip.AddrPort) (handler func(c
 		return b.handleSSHConn, opts
 	}
 	// TODO(will,sonia): allow customizing web client port ?
-	if dst.Port() == 5252 && b.ShouldRunWebClient() {
+	if dst.Port() == webClientPort && b.ShouldRunWebClient() {
 		return b.handleWebClientConn, opts
 	}
 	if port, ok := b.GetPeerAPIPort(dst.Addr()); ok && dst.Port() == port {
@@ -4474,7 +4474,7 @@ func (b *LocalBackend) setTCPPortsInterceptedFromNetmapAndPrefsLocked(prefs ipn.
 		handlePorts = append(handlePorts, 22)
 	}
 	if b.ShouldRunWebClient() {
-		handlePorts = append(handlePorts, 5252)
+		handlePorts = append(handlePorts, webClientPort)
 	}
 
 	b.reloadServeConfigLocked(prefs)

--- a/ipn/ipnlocal/web_client.go
+++ b/ipn/ipnlocal/web_client.go
@@ -16,6 +16,8 @@ import (
 	"tailscale.com/net/netutil"
 )
 
+const webClientPort = web.ListenPort
+
 // webClient holds state for the web interface for managing
 // this tailscale instance. The web interface is not used by
 // default, but initialized by calling LocalBackend.WebOrInit.

--- a/ipn/ipnlocal/web_client_stub.go
+++ b/ipn/ipnlocal/web_client_stub.go
@@ -12,6 +12,8 @@ import (
 	"tailscale.com/client/tailscale"
 )
 
+const webClientPort = 5252
+
 type webClient struct{}
 
 func (b *LocalBackend) SetWebLocalClient(lc *tailscale.LocalClient) {}


### PR DESCRIPTION
Require that requests to servers in manage mode are made to the Tailscale IP (either ipv4 or ipv6) or quad-100 in order to mitigate dns rebinding attacks. I don't love that this is fetching status from localapi on every single request to get local IPs, particularly since these values don't change often, so we'll probably want to cache these.

Also set various security headers on those responses.  These might be too restrictive, but we can relax them as needed.

Allow requests to /ok (even in manage mode) with no checks. This will be used for the connectivity check from a login client to see if the management client is reachable.

Updates tailscale/corp#14335