### PR TITLE
ipn/ipnlocal: better enforce system policies

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1116,6 +1116,9 @@ func (b *LocalBackend) SetControlClientStatus(c controlclient.Client, st control
 	if setExitNodeID(prefs, st.NetMap) {
 		prefsChanged = true
 	}
+	if applySysPolicy(prefs) {
+		prefsChanged = true
+	}
 
 	// Until recently, we did not store the account's tailnet name. So check if this is the case,
 	// and backfill it on incoming status update.
@@ -1222,6 +1225,35 @@ func (b *LocalBackend) SetControlClientStatus(c controlclient.Client, st control
 	// This is currently (2020-07-28) necessary; conditionally disabling it is fragile!
 	// This is where netmap information gets propagated to router and magicsock.
 	b.authReconfig()
+}
+
+// applySysPolicy overwrites configured preferences with policies that may be
+// configured by the system administrator in an OS-specific way.
+func applySysPolicy(prefs *ipn.Prefs) (anyChange bool) {
+	if controlURL, err := syspolicy.GetString(syspolicy.ControlURL, prefs.ControlURL); err == nil && prefs.ControlURL != controlURL {
+		prefs.ControlURL = controlURL
+		anyChange = true
+	}
+
+	// Allow Incoming (used by the UI) is the negation of ShieldsUp (used by the
+	// backend), so this has to convert between the two conventions.
+	if shieldsUp, err := syspolicy.GetPreferenceOption(syspolicy.EnableIncomingConnections); err == nil {
+		newVal := !shieldsUp.ShouldEnable(!prefs.ShieldsUp)
+		if prefs.ShieldsUp != newVal {
+			prefs.ShieldsUp = newVal
+			anyChange = true
+		}
+	}
+
+	if forceDaemon, err := syspolicy.GetPreferenceOption(syspolicy.EnableServerMode); err == nil {
+		newVal := forceDaemon.ShouldEnable(prefs.ForceDaemon)
+		if prefs.ForceDaemon != newVal {
+			prefs.ForceDaemon = newVal
+			anyChange = true
+		}
+	}
+
+	return anyChange
 }
 
 var _ controlclient.NetmapDeltaUpdater = (*LocalBackend)(nil)
@@ -3048,10 +3080,12 @@ func (b *LocalBackend) setPrefsLockedOnEntry(caller string, newp *ipn.Prefs) ipn
 	if oldp.Valid() {
 		newp.Persist = oldp.Persist().AsStruct() // caller isn't allowed to override this
 	}
-	// findExitNodeIDLocked returns whether it updated b.prefs, but
+	// setExitNodeID returns whether it updated b.prefs, but
 	// everything in this function treats b.prefs as completely new
 	// anyway. No-op if no exit node resolution is needed.
 	setExitNodeID(newp, netMap)
+	// applySysPolicy does likewise so we can also ignore its return value.
+	applySysPolicy(newp)
 	// We do this to avoid holding the lock while doing everything else.
 
 	oldHi := b.hostinfo

--- a/ipn/ipnlocal/profiles.go
+++ b/ipn/ipnlocal/profiles.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"net/netip"
 	"runtime"
 	"slices"
 	"strings"
@@ -19,7 +18,6 @@ import (
 	"tailscale.com/types/logger"
 	"tailscale.com/util/clientmetric"
 	"tailscale.com/util/cmpx"
-	"tailscale.com/util/winutil"
 )
 
 var errAlreadyMigrated = errors.New("profile migration already completed")
@@ -443,36 +441,17 @@ func (pm *profileManager) NewProfile() {
 	pm.currentProfile = &ipn.LoginProfile{}
 }
 
-// defaultPrefs is the default prefs for a new profile.
+// defaultPrefs is the default prefs for a new profile. This initializes before
+// even this package's init() so do not rely on other parts of the system being
+// fully initialized here (for example, syspolicy will not be available on
+// Apple platforms).
 var defaultPrefs = func() ipn.PrefsView {
 	prefs := ipn.NewPrefs()
 	prefs.LoggedOut = true
 	prefs.WantRunning = false
 
-	controlURL, _ := winutil.GetPolicyString("LoginURL")
-	prefs.ControlURL = controlURL
-
-	prefs.ExitNodeIP = resolveExitNodeIP(netip.Addr{})
-
-	// Allow Incoming (used by the UI) is the negation of ShieldsUp (used by the
-	// backend), so this has to convert between the two conventions.
-	shieldsUp, _ := winutil.GetPolicyString("AllowIncomingConnections")
-	prefs.ShieldsUp = shieldsUp == "never"
-	forceDaemon, _ := winutil.GetPolicyString("UnattendedMode")
-	prefs.ForceDaemon = forceDaemon == "always"
-
 	return prefs.View()
 }()
-
-func resolveExitNodeIP(defIP netip.Addr) (ret netip.Addr) {
-	ret = defIP
-	if exitNode, _ := winutil.GetPolicyString("ExitNodeIP"); exitNode != "" {
-		if ip, err := netip.ParseAddr(exitNode); err == nil {
-			ret = ip
-		}
-	}
-	return ret
-}
 
 // Store returns the StateStore used by the ProfileManager.
 func (pm *profileManager) Store() ipn.StateStore {

--- a/ipn/ipnlocal/profiles_windows.go
+++ b/ipn/ipnlocal/profiles_windows.go
@@ -67,9 +67,6 @@ func (pm *profileManager) loadLegacyPrefs() (string, ipn.PrefsView, error) {
 	}
 
 	prefs.ControlURL = policy.SelectControlURL(defaultPrefs.ControlURL(), prefs.ControlURL)
-	prefs.ExitNodeIP = resolveExitNodeIP(prefs.ExitNodeIP)
-	prefs.ShieldsUp = resolveShieldsUp(prefs.ShieldsUp)
-	prefs.ForceDaemon = resolveForceDaemon(prefs.ForceDaemon)
 
 	pm.logf("migrating Windows profile to new format")
 	return migrationSentinel, prefs.View(), nil
@@ -77,14 +74,4 @@ func (pm *profileManager) loadLegacyPrefs() (string, ipn.PrefsView, error) {
 
 func (pm *profileManager) completeMigration(migrationSentinel string) {
 	atomicfile.WriteFile(migrationSentinel, []byte{}, 0600)
-}
-
-func resolveShieldsUp(defval bool) bool {
-	pol := policy.GetPreferenceOptionPolicy("AllowIncomingConnections")
-	return !pol.ShouldEnable(!defval)
-}
-
-func resolveForceDaemon(defval bool) bool {
-	pol := policy.GetPreferenceOptionPolicy("UnattendedMode")
-	return pol.ShouldEnable(defval)
 }

--- a/util/syspolicy/policy_keys.go
+++ b/util/syspolicy/policy_keys.go
@@ -17,7 +17,8 @@ const (
 	ExitNodeIP Key = "ExitNodeIP" // default ""; if blank, no exit node is forced. Value is exit node IP.
 
 	// Keys with a string value that specifies an option: "always", "never", "user-decides".
-	// The default is "user-decides" unless otherwise stated.
+	// The default is "user-decides" unless otherwise stated. Enforcement of
+	// these policies is typically performed in ipnlocal.applySysPolicy().
 	EnableIncomingConnections Key = "AllowIncomingConnections"
 	EnableServerMode          Key = "UnattendedMode"
 	ExitNodeAllowLANAccess    Key = "ExitNodeAllowLANAccess"
@@ -25,7 +26,9 @@ const (
 	EnableTailscaleSubnets    Key = "EnableTailscaleSubnets"
 
 	// Keys with a string value that controls visibility: "show", "hide".
-	// The default is "show" unless otherwise stated.
+	// The default is "show" unless otherwise stated. Enforcement of these
+	// policies is typically performed by the UI code for the relevant operating
+	// system.
 	AdminConsoleVisibility    Key = "AdminConsole"
 	NetworkDevicesVisibility  Key = "NetworkDevices"
 	TestMenuVisibility        Key = "TestMenu"

--- a/util/syspolicy/syspolicy.go
+++ b/util/syspolicy/syspolicy.go
@@ -68,6 +68,12 @@ func (p PreferenceOption) ShouldEnable(userChoice bool) bool {
 	}
 }
 
+// WillOverride checks if the choice administered by the policy is different
+// from the user's choice.
+func (p PreferenceOption) WillOverride(userChoice bool) bool {
+	return p.ShouldEnable(userChoice) != userChoice
+}
+
 // GetPreferenceOption loads a policy from the registry that can be
 // managed by an enterprise policy management system and allows administrative
 // overrides of users' choices in a way that we do not want tailcontrol to have


### PR DESCRIPTION
Previously, policies affected the default prefs for a new profile, but
that does not affect existing profiles. This change ensures that
policies are applied whenever preferences are loaded or changed, so a
CLI or GUI client that does not respect the policies will still be
overridden.
    
Exit node IP is dropped from this PR as it was implemented elsewhere
in #10172.
    
Fixes tailscale/corp#15585
    
Change-Id: Ide4c3a4b00a64e43f506fa1fab70ef591407663f