### PR TITLE
ipn/ipnlocal: serve web client on quad100 if enabled

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3113,6 +3113,9 @@ var (
 // apply to the socket before calling the handler.
 func (b *LocalBackend) TCPHandlerForDst(src, dst netip.AddrPort) (handler func(c net.Conn) error, opts []tcpip.SettableSocketOption) {
 	if dst.Port() == 80 && (dst.Addr() == magicDNSIP || dst.Addr() == magicDNSIPv6) {
+		if b.ShouldRunWebClient() {
+			return b.handleWebClientConn, opts
+		}
 		return b.HandleQuad100Port80Conn, opts
 	}
 	if !b.isLocalIP(dst.Addr()) {


### PR DESCRIPTION
if the user pref and nodecap for the new web client are enabled, serve the client over requests to 100.100.100.100.  Today, that is just a static page that lists the local Tailcale IP addresses.

For now, this will render the readonly full management client, with an "access" button that sends the user through check mode.  After completing check mode, they will still be in the read-only view, since they are not accessing the client over Tailscale.

Instead, quad100 should serve the lobby client that has a "manage" button that will open the management client on the Tailscale IP (and trigger check mode). That is something we'll fix in a subsequent PR in the web client code itself.

Updates tailscale/corp#14335