### PR TITLE
client/tailscale: remove redundant error check

### DIFF
--- a/client/tailscale/localclient.go
+++ b/client/tailscale/localclient.go
@@ -1254,9 +1254,6 @@ func (lc *LocalClient) ReloadConfig(ctx context.Context) (ok bool, err error) {
 	if err != nil {
 		return
 	}
-	if err != nil {
-		return false, err
-	}
 	if res.Err != "" {
 		return false, errors.New(res.Err)
 	}


### PR DESCRIPTION
The error check on line 1254 means that this one is entirely redundant.