### PR TITLE
client/web: check r.Host rather than r.URL.Host

### DIFF
--- a/client/web/web.go
+++ b/client/web/web.go
@@ -261,7 +261,7 @@ func (s *Server) requireTailscaleIP(w http.ResponseWriter, r *http.Request) (han
 		ipv6ServiceHost = "[" + tsaddr.TailscaleServiceIPv6String + "]"
 	)
 	// allow requests on quad-100 (or ipv6 equivalent)
-	if r.URL.Host == ipv4ServiceHost || r.URL.Host == ipv6ServiceHost {
+	if r.Host == ipv4ServiceHost || r.Host == ipv6ServiceHost {
 		return false
 	}
 


### PR DESCRIPTION
r.URL.Host is not typically populated on server requests.

Updates tailscale/corp#14335