### PR TITLE
cmd/tailscaled, util/winutil: changes to process and token APIs in wi…

### DIFF
--- a/cmd/tailscaled/tailscaled_windows.go
+++ b/cmd/tailscaled/tailscaled_windows.go
@@ -529,12 +529,11 @@ func uninstallWinTun(logf logger.Logf) {
 
 func fullyQualifiedWintunPath(logf logger.Logf) string {
 	var dir string
-	var buf [windows.MAX_PATH]uint16
-	length := uint32(len(buf))
-	if err := windows.QueryFullProcessImageName(windows.CurrentProcess(), 0, &buf[0], &length); err != nil {
-		logf("QueryFullProcessImageName failed: %v", err)
+	imgName, err := winutil.ProcessImageName(windows.CurrentProcess())
+	if err != nil {
+		logf("ProcessImageName failed: %v", err)
 	} else {
-		dir = filepath.Dir(windows.UTF16ToString(buf[:length]))
+		dir = filepath.Dir(imgName)
 	}
 
 	return filepath.Join(dir, "wintun.dll")


### PR DESCRIPTION
…nutil

This PR changes the internal getTokenInfo function to use generics. I also removed our own implementations for obtaining a token's user and primary group in favour of calling the ones now available in x/sys/windows.

Furthermore, I added two new functions for working with tokens, logon session IDs, and Terminal Services / RDP session IDs.

I modified our privilege enabling code to allow enabling of multiple privileges via one single function call.

Finally, I added the ProcessImageName function and updated the code in tailscaled_windows.go to use that instead of directly calling the underlying API.

All of these changes will be utilized by subsequent PRs pertaining to this issue.

Updates https://github.com/tailscale/corp/issues/13998