### PR TITLE
client/web: relax CSP restrictions for manage client

### DIFF
--- a/client/web/web.go
+++ b/client/web/web.go
@@ -220,9 +220,12 @@ func (s *Server) serve(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		w.Header().Set("X-Frame-Options", "DENY")
-		w.Header().Set("Content-Security-Policy", "default-src 'self'")
-		w.Header().Set("Cross-Origin-Resource-Policy", "same-origin")
+		if !s.devMode {
+			w.Header().Set("X-Frame-Options", "DENY")
+			// TODO: use CSP nonce or hash to eliminate need for unsafe-inline
+			w.Header().Set("Content-Security-Policy", "default-src 'self' 'unsafe-inline'; img-src * data:")
+			w.Header().Set("Cross-Origin-Resource-Policy", "same-origin")
+		}
 	}
 
 	if strings.HasPrefix(r.URL.Path, "/api/") {


### PR DESCRIPTION
Don't return CSP headers in dev mode, since that includes a bunch of extra things like the vite server.

Allow images from any source, which is needed to load user profile images.

Allow 'unsafe-inline' for various inline scripts and style react uses. We can eliminate this by using CSP nonce or hash values, but we'll need to look into the best way to handle that. There appear to be several react plugins for this, but I haven't evaluated any of them.

Updates tailscale/corp#14335