### PR TITLE
client/web: show manage button in readonly view

### DIFF
--- a/client/web/src/components/views/readonly-client-view.tsx
+++ b/client/web/src/components/views/readonly-client-view.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { AuthResponse, AuthType, SessionsCallbacks } from "src/hooks/auth"
+import { AuthResponse, AuthType } from "src/hooks/auth"
 import { NodeData } from "src/hooks/node-data"
 import { ReactComponent as ConnectedDeviceIcon } from "src/icons/connected-device.svg"
 import { ReactComponent as TailscaleLogo } from "src/icons/tailscale-logo.svg"
@@ -17,11 +17,11 @@ import ProfilePic from "src/ui/profile-pic"
 export default function ReadonlyClientView({
   data,
   auth,
-  sessions,
+  newSession,
 }: {
   data: NodeData
   auth?: AuthResponse
-  sessions: SessionsCallbacks
+  newSession: () => Promise<void>
 }) {
   return (
     <>
@@ -51,18 +51,22 @@ export default function ReadonlyClientView({
               <div className="text-sm leading-tight">{data.IP}</div>
             </div>
           </div>
-          {auth?.authNeeded == AuthType.tailscale && (
-            <button
-              className="button button-blue ml-6"
-              onClick={() => {
-                sessions
-                  .new()
-                  .then((url) => window.open(url, "_blank"))
-                  .then(() => sessions.wait())
-              }}
-            >
+          {auth?.authNeeded == AuthType.tailscale ? (
+            <button className="button button-blue ml-6" onClick={newSession}>
               Access
             </button>
+          ) : (
+            window.location.hostname != data.IP && (
+              // TODO: check connectivity to tailscale IP
+              <button
+                className="button button-blue ml-6"
+                onClick={() => {
+                  window.location.href = `http://${data.IP}:5252/?check=now`
+                }}
+              >
+                Manage
+              </button>
+            )
           )}
         </div>
       </div>


### PR DESCRIPTION
We render the readonly view in two situations:
- the client is in login mode, and the device is connected
- the client is in manage mode, but the user does not yet have a session

If the user is not authenticated, and they are not currently on the Tailscale IP address, render a "Manage" button that will take them to the Tailcale IP of the device and immediately start check mode.  This ends up being used for login clients and accessing the full client over quad100.

Still to do is detecting if they have connectivity to the Tailscale IP, and disabling the button if not.

Updates tailscale/corp#14335