### PR TITLE
control/controlclient: move lastPrintMap field from Direct to mapSession

### DIFF
--- a/control/controlclient/auto.go
+++ b/control/controlclient/auto.go
@@ -481,7 +481,7 @@ func (mrs mapRoutineState) UpdateNetmapDelta(muts []netmap.NodeMutation) bool {
 // control server, and keeping the netmap up to date.
 func (c *Auto) mapRoutine() {
 	defer close(c.mapDone)
-	mrs := &mapRoutineState{
+	mrs := mapRoutineState{
 		c:  c,
 		bo: backoff.NewBackoff("mapRoutine", c.logf, 30*time.Second),
 	}


### PR DESCRIPTION
It was a really a mutable field owned by mapSession that we didn't move
in earlier commits.

Once moved, it's then possible to de-func-ify the code and turn it into
a regular method rather than an installed optional hook.

Noticed while working to move map session lifetimes out of
Direct.sendMapRequest's single-HTTP-connection scope.

Updates #7175
Updates #cleanup
