### PR TITLE
taildrop: lazily perform full deletion scan after first taildrop use

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3616,6 +3616,7 @@ func (b *LocalBackend) initPeerAPIListener() {
 		taildrop: taildrop.ManagerOptions{
 			Logf:             b.logf,
 			Clock:            tstime.DefaultClock{Clock: b.clock},
+			State:            b.store,
 			Dir:              fileRoot,
 			DirectFileMode:   b.directFileRoot != "",
 			AvoidFinalRename: !b.directFileDoFinalRename,

--- a/ipn/store.go
+++ b/ipn/store.go
@@ -53,6 +53,11 @@ const (
 	// CurrentProfileStateKey is the key under which we store the current
 	// profile.
 	CurrentProfileStateKey = StateKey("_current-profile")
+
+	// TaildropReceivedKey is the key to indicate whether any taildrop file
+	// has ever been received (even if partially).
+	// Any non-empty value indicates that at least one file has been received.
+	TaildropReceivedKey = StateKey("_taildrop-received")
 )
 
 // CurrentProfileID returns the StateKey that stores the

--- a/taildrop/taildrop.go
+++ b/taildrop/taildrop.go
@@ -67,8 +67,9 @@ func (id ClientID) partialSuffix() string {
 
 // ManagerOptions are options to configure the [Manager].
 type ManagerOptions struct {
-	Logf  logger.Logf
-	Clock tstime.DefaultClock
+	Logf  logger.Logf         // may be nil
+	Clock tstime.DefaultClock // may be nil
+	State ipn.StateStore      // may be nil
 
 	// Dir is the directory to store received files.
 	// This main either be the final location for the files


### PR DESCRIPTION
Simply reading the taildrop directory can pop up security dialogs on platforms like macOS. Avoid this by only performing garbage collection of partial and deleted files after the first received taildrop file, which would have prompted the security dialog window.

Updates tailscale/corp#14772