### PR TITLE
ipn/store: improve FileStore.WriteState atomicity

### DIFF
--- a/ipn/store.go
+++ b/ipn/store.go
@@ -68,8 +68,9 @@ func CurrentProfileKey(userID string) StateKey {
 
 // StateStore persists state, and produces it back on request.
 type StateStore interface {
-	// ReadState returns the bytes associated with ID. Returns (nil,
-	// ErrStateNotExist) if the ID doesn't have associated state.
+	// ReadState returns the bytes associated with ID.
+	// It returns (nil, ErrStateNotExist) if the ID doesn't have associated state.
+	// The returned value must not be mutated.
 	ReadState(id StateKey) ([]byte, error)
 	// WriteState saves bs as the state associated with ID.
 	//


### PR DESCRIPTION
If an error occurs with FileStore.WriteState, it should not record the provided value as this results in an inconsistency between what is cached in memory and what is stored on disk.

Also, update the documentation of StateStore.ReadState to indicate that the returned value should be treated as immutable. This property is assumed by the fact that FileStore.ReadState returns the same slice of bytes for repeated calls to the same key.

Updates #cleanup