### PR TITLE
client/web: fix hotreload proxy

### DIFF
--- a/client/web/vite.config.ts
+++ b/client/web/vite.config.ts
@@ -47,14 +47,8 @@ export default defineConfig({
     // This needs to be 127.0.0.1 instead of localhost, because of how our
     // Go proxy connects to it.
     host: "127.0.0.1",
-    // If you change the port, be sure to update the proxy in adminhttp.go too.
+    // If you change the port, be sure to update the proxy in assets.go too.
     port: 4000,
-    // Don't proxy the WebSocket connection used for live reloading by running
-    // it on a separate port.
-    hmr: {
-      protocol: "ws",
-      port: 4001,
-    },
   },
   test: {
     exclude: ["**/node_modules/**", "**/dist/**"],


### PR DESCRIPTION
Previously had HMR websocket set to run from a different port than the http proxy server. This was an old setting carried over from the corp repo admin panel config. It's messing with hot reloads when run from the tailscaled web client, as it keeps causing the full page to refresh each time a connection is made. Switching back to the default config here fixes things.

Updates tailscale/corp#14335