### PR TITLE
util/syspolicy: add some additional policy keys

### DIFF
--- a/util/syspolicy/policy_keys.go
+++ b/util/syspolicy/policy_keys.go
@@ -16,6 +16,8 @@ const (
 	EnableIncomingConnections Key = "AllowIncomingConnections"
 	EnableServerMode          Key = "UnattendedMode"
 	ExitNodeAllowLANAccess    Key = "ExitNodeAllowLANAccess"
+	EnableTailscaleDNS        Key = "EnableTailscaleDNSSettings"
+	EnableTailscaleSubnets    Key = "EnableTailscaleSubnets"
 
 	// Keys with a string value that controls visibility: "show", "hide".
 	// The default is "show" unless otherwise stated.
@@ -25,6 +27,8 @@ const (
 	UpdateMenuVisibility      Key = "UpdateMenu"
 	RunExitNodeVisibility     Key = "RunExitNode"
 	PreferencesMenuVisibility Key = "PreferencesMenu"
+	ExitNodeMenuVisibility    Key = "ExitNodesPicker"
+	AutoUpdateVisibility      Key = "ApplyUpdates"
 
 	// Keys with a string value formatted for use with time.ParseDuration().
 	KeyExpirationNoticeTime Key = "KeyExpirationNotice" // default 24 hours


### PR DESCRIPTION
These policy keys are supported on Apple platforms in Swift code; in order to support them on platforms using Go (e.g. Windows), they also need to be recorded here.

This does not affect any code, it simply adds the constants for now.

Updates ENG-2240
Updates ENG-2127
Updates ENG-2133

Change-Id: I0aa9863a3641e5844479da3b162761452db1ef42