### PR TITLE
derp/derphttp: pass *tls.Config to WebSocket connections

### DIFF
--- a/derp/derphttp/websocket_js.go
+++ b/derp/derphttp/websocket_js.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build linux || windows || (darwin && !ios) || !js
+//go:build js
 
 package derphttp
 
@@ -10,7 +10,6 @@ import (
 	"crypto/tls"
 	"log"
 	"net"
-	"net/http"
 
 	"nhooyr.io/websocket"
 	"tailscale.com/net/wsconn"
@@ -23,11 +22,6 @@ func init() {
 func dialWebsocket(ctx context.Context, urlStr string, tlsConfig *tls.Config) (net.Conn, error) {
 	c, res, err := websocket.Dial(ctx, urlStr, &websocket.DialOptions{
 		Subprotocols: []string{"derp"},
-		HTTPClient: &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: tlsConfig,
-			},
-		},
 	})
 	if err != nil {
 		log.Printf("websocket Dial: %v, %+v", err, res)


### PR DESCRIPTION
This PR includes changes requested in the #7401 PR.
Updates #10147

> WebSocket connections were not getting a *tls.Config if set. This made it more difficult to test WebSocket connections with DERP.
> 
> This also allows forcing WebSockets on Windows and macOS, which seems fine.
- #7401