### PR TITLE
tailcfg,ipn,appc: add c2n endpoint for appc domain routes

### DIFF
--- a/appc/appconnector.go
+++ b/appc/appconnector.go
@@ -81,6 +81,20 @@ func (e *AppConnector) Domains() views.Slice[string] {
 	return views.SliceOf(xmaps.Keys(e.domains))
 }
 
+// DomainRoutes returns a map of domains to resolved IP
+// addresses.
+func (e *AppConnector) DomainRoutes() map[string][]netip.Addr {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	drCopy := make(map[string][]netip.Addr)
+	for k, v := range e.domains {
+		copy(drCopy[k], v)
+	}
+
+	return drCopy
+}
+
 // ObserveDNSResponse is a callback invoked by the DNS resolver when a DNS
 // response is being returned over the PeerAPI. The response is parsed and
 // matched against the configured domains, if matched the routeAdvertiser is

--- a/tailcfg/c2ntypes.go
+++ b/tailcfg/c2ntypes.go
@@ -5,6 +5,8 @@
 
 package tailcfg
 
+import "net/netip"
+
 // C2NSSHUsernamesRequest is the request for the /ssh/usernames.
 // A GET request without a request body is equivalent to the zero value of this type.
 // Otherwise, a POST request with a JSON-encoded request body is expected.
@@ -63,4 +65,13 @@ type C2NPostureIdentityResponse struct {
 	// PostureDisabled indicates if the machine has opted out of
 	// device posture collection.
 	PostureDisabled bool `json:",omitempty"`
+}
+
+// C2NAppConnectorDomainRoutesResponse contains a map of domains to
+// slice of addresses, indicating what IP addresses have been resolved
+// for each domain.
+type C2NAppConnectorDomainRoutesResponse struct {
+	// Domains is a map of lower case domain names with no trailing dot,
+	// to a list of resolved IP addresses.
+	Domains map[string][]netip.Addr
 }


### PR DESCRIPTION
This change introduces a c2n endpoint that returns a map of domains to a slice of resolved IP addresses for the domain.

Fixes tailscale/corp#15657