### PR TITLE
ipn/ipnlocal: add empty address to the app-connector localNets set

### DIFF
--- a/ipn/ipnlocal/peerapi.go
+++ b/ipn/ipnlocal/peerapi.go
@@ -881,6 +881,13 @@ func (h *peerAPIHandler) replyToDNSQueries() bool {
 	// ourselves. As a proxy for autogroup:internet access, we see
 	// if we would've accepted a packet to 0.0.0.0:53. We treat
 	// the IP 0.0.0.0 as being "the internet".
+	//
+	// Because of the way that filter checks work, rules are only
+	// checked after ensuring the destination IP is part of the
+	// local set of IPs. An exit node has 0.0.0.0/0 so its fine,
+	// but an app connector explicitly adds 0.0.0.0/32 (and the
+	// IPv6 equivalent) to make this work (see updateFilterLocked
+	// in LocalBackend).
 	f := b.filterAtomic.Load()
 	if f == nil {
 		return false


### PR DESCRIPTION
App connectors handle DNS requests for app domains over PeerAPI, but a safety check verifies the requesting peer has at least permission to send traffic to 0.0.0.0:53 (or 2000:: for IPv6) before handling the DNS request. The correct filter rules are synthesized by the coordination server and sent down, but the address needs to be part of the 'local net' for the filter package to even bother checking the filter rules, so we set them here.

Updates https://github.com/tailscale/corp/issues/1196
Updates: ENG-2405