### PR TITLE
logtail: fix Logger.Write return result

### DIFF
--- a/logtail/logtail.go
+++ b/logtail/logtail.go
@@ -735,6 +735,8 @@ func (l *Logger) Write(buf []byte) (int, error) {
 	if len(buf) == 0 {
 		return 0, nil
 	}
+	inLen := len(buf) // length as provided to us, before modifications to downstream writers
+
 	level, buf := parseAndRemoveLogLevel(buf)
 	if l.stderr != nil && l.stderr != io.Discard && int64(level) <= atomic.LoadInt64(&l.stderrLevel) {
 		if buf[len(buf)-1] == '\n' {
@@ -752,7 +754,7 @@ func (l *Logger) Write(buf []byte) (int, error) {
 
 	b := l.encodeLocked(buf, level)
 	_, err := l.sendLocked(b)
-	return len(buf), err
+	return inLen, err
 }
 
 var (


### PR DESCRIPTION
io.Writer says you need to write completely on err=nil. (the result int should be the same as the input buffer length)

We weren't doing that. We used to, but at some point the verbose filtering was modifying buf before the final return of len(buf).

We've been getting lucky probably, that callers haven't looked at our results and turned us into a short write error.

Updates #cleanup
Updates tailscale/corp#15664
