### PR TITLE
ipn/ipnlocal: allow connecting to local web client in kernel networking mode

### DIFF
--- a/ipn/ipnlocal/web_client_stub.go
+++ b/ipn/ipnlocal/web_client_stub.go
@@ -27,3 +27,4 @@ func (b *LocalBackend) WebClientShutdown() {}
 func (b *LocalBackend) handleWebClientConn(c net.Conn) error {
 	return errors.New("not implemented")
 }
+func (b *LocalBackend) updateWebClientListenersLocked() {}


### PR DESCRIPTION
The local web client has the same characteristic as tailscale serve, in that it needs a local listener to allow for connections from the local machine itself when running in kernel networking mode.

This change renames and adapts the existing `serveListener` to allow it to be used by the web client as well.

Updates tailscale/corp#14335

cc @bradfitz who originally reviewed #6282 where this was added for tailscale serve.