### PR TITLE
clientupdate: add support for QNAP

### DIFF
--- a/ipn/ipnlocal/c2n.go
+++ b/ipn/ipnlocal/c2n.go
@@ -31,6 +31,7 @@ import (
 	"tailscale.com/util/httpm"
 	"tailscale.com/util/syspolicy"
 	"tailscale.com/version"
+	"tailscale.com/version/distro"
 )
 
 var c2nLogHeap func(http.ResponseWriter, *http.Request) // non-nil on most platforms (c2n_pprof.go)
@@ -340,6 +341,14 @@ func findCmdTailscale() (string, error) {
 		}
 		if self == "/usr/local/sbin/tailscaled" || self == "/usr/local/bin/tailscaled" {
 			ts = "/usr/local/bin/tailscale"
+		}
+		if distro.Get() == distro.QNAP {
+			// The volume under /share/ where qpkg are installed is not
+			// predictable. But the rest of the path is.
+			ok, err := filepath.Match("/share/*/.qpkg/Tailscale/tailscaled", self)
+			if err == nil && ok {
+				ts = filepath.Join(filepath.Dir(self), "tailscale")
+			}
 		}
 	case "windows":
 		ts = filepath.Join(filepath.Dir(self), "tailscale.exe")


### PR DESCRIPTION
Use the `qpkg_cli` to check for updates and install them. There are a couple special things about this compare to other updaters:
* qpkg_cli can tell you when upgrade is available, but not what the version is
* qpkg_cli --add Tailscale works for new installs, upgrades and reinstalling existing version; even reinstall of existing version takes a while

Updates #10178