### PR TITLE
control/controlknobs,wgengine/magicsock: implement SilentDisco toggle

### DIFF
--- a/control/controlknobs/controlknobs.go
+++ b/control/controlknobs/controlknobs.go
@@ -52,6 +52,10 @@ type Knobs struct {
 	// DisableDNSForwarderTCPRetries is whether the DNS forwarder should
 	// skip retrying truncated queries over TCP.
 	DisableDNSForwarderTCPRetries atomic.Bool
+
+	// SilentDisco is whether the node should suppress disco heartbeats to its
+	// peers.
+	SilentDisco atomic.Bool
 }
 
 // UpdateFromNodeAttributes updates k (if non-nil) based on the provided self
@@ -74,6 +78,7 @@ func (k *Knobs) UpdateFromNodeAttributes(selfNodeAttrs []tailcfg.NodeCapability,
 		forceBackgroundSTUN           = has(tailcfg.NodeAttrDebugForceBackgroundSTUN)
 		peerMTUEnable                 = has(tailcfg.NodeAttrPeerMTUEnable)
 		dnsForwarderDisableTCPRetries = has(tailcfg.NodeAttrDNSForwarderDisableTCPRetries)
+		silentDisco                   = has(tailcfg.NodeAttrSilentDisco)
 	)
 
 	if has(tailcfg.NodeAttrOneCGNATEnable) {
@@ -91,6 +96,7 @@ func (k *Knobs) UpdateFromNodeAttributes(selfNodeAttrs []tailcfg.NodeCapability,
 	k.DisableDeltaUpdates.Store(disableDeltaUpdates)
 	k.PeerMTUEnable.Store(peerMTUEnable)
 	k.DisableDNSForwarderTCPRetries.Store(dnsForwarderDisableTCPRetries)
+	k.SilentDisco.Store(silentDisco)
 }
 
 // AsDebugJSON returns k as something that can be marshalled with json.Marshal
@@ -109,5 +115,6 @@ func (k *Knobs) AsDebugJSON() map[string]any {
 		"DisableDeltaUpdates":           k.DisableDeltaUpdates.Load(),
 		"PeerMTUEnable":                 k.PeerMTUEnable.Load(),
 		"DisableDNSForwarderTCPRetries": k.DisableDNSForwarderTCPRetries.Load(),
+		"SilentDisco":                   k.SilentDisco.Load(),
 	}
 }

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -4348,6 +4348,8 @@ func (b *LocalBackend) setNetMapLocked(nm *netmap.NetworkMap) {
 	}
 	b.capFileSharing = fs
 
+	b.magicConn().SetSilentDisco(b.ControlKnobs().SilentDisco.Load())
+
 	b.setDebugLogsByCapabilityLocked(nm)
 
 	// See the netns package for documentation on what this capability does.

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -2126,6 +2126,10 @@ const (
 	// fixed port.
 	NodeAttrRandomizeClientPort NodeCapability = "randomize-client-port"
 
+	// NodeAttrSilentDisco makes the client suppress disco heartbeats to its
+	// peers.
+	NodeAttrSilentDisco NodeCapability = "silent-disco"
+
 	// NodeAttrOneCGNATEnable makes the client prefer one big CGNAT /10 route
 	// rather than a /32 per peer. At most one of this or
 	// NodeAttrOneCGNATDisable may be set; if neither are, it's automatic.

--- a/wgengine/magicsock/endpoint.go
+++ b/wgengine/magicsock/endpoint.go
@@ -440,6 +440,13 @@ func (de *endpoint) heartbeat() {
 	de.heartBeatTimer = time.AfterFunc(heartbeatInterval, de.heartbeat)
 }
 
+// setHeartbeatDisabled sets heartbeatDisabled to the provided value.
+func (de *endpoint) setHeartbeatDisabled(v bool) {
+	de.mu.Lock()
+	defer de.mu.Unlock()
+	de.heartbeatDisabled = v
+}
+
 // wantFullPingLocked reports whether we should ping to all our peers looking for
 // a better path.
 //


### PR DESCRIPTION
This change exposes SilentDisco as a control knob, and plumbs it down to magicsock.endpoint. No changes are being made to magicsock.endpoint disco behavior, yet.