### PR TITLE
types/appctype: correct app-connector cap name in documentation

### DIFF
--- a/types/appctype/appconnector.go
+++ b/types/appctype/appconnector.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 // Package appcfg contains an experimental configuration structure for
-// "tailscale.com/app-connector" capmap extensions.
+// "tailscale.com/app-connectors" capmap extensions.
 package appctype
 
 import (


### PR DESCRIPTION
Updates #cleanup