### PR TITLE
ipn,tailconfig: clean up unreleased and removed app connector service

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3192,12 +3192,6 @@ func (b *LocalBackend) peerAPIServicesLocked() (ret []tailcfg.Service) {
 			Port:  1, // version
 		})
 	}
-	if b.appConnector != nil {
-		ret = append(ret, tailcfg.Service{
-			Proto: tailcfg.AppConnector,
-			Port:  1, // version
-		})
-	}
 	return ret
 }
 
@@ -3278,13 +3272,7 @@ func (b *LocalBackend) reconfigAppConnectorLocked(nm *netmap.NetworkMap, prefs i
 	}()
 
 	if !prefs.AppConnector().Advertise {
-		var old *appc.AppConnector
-		old, b.appConnector = b.appConnector, nil
-		if old != nil {
-			// Ensure that the app connector service will not be advertised now
-			// that b.appConnector is no longer set.
-			go b.doSetHostinfoFilterServices()
-		}
+		b.appConnector = nil
 		return
 	}
 
@@ -3318,10 +3306,6 @@ func (b *LocalBackend) reconfigAppConnectorLocked(nm *netmap.NetworkMap, prefs i
 	slices.Sort(domains)
 	slices.Compact(domains)
 	b.appConnector.UpdateDomains(domains)
-
-	// Ensure that the app connector service will be advertised now that
-	// b.appConnector is set.
-	go b.doSetHostinfoFilterServices()
 }
 
 // authReconfig pushes a new configuration into wgengine, if engine

--- a/ipn/policy/policy.go
+++ b/ipn/policy/policy.go
@@ -14,7 +14,7 @@ import (
 // to our peer nodes for discovery purposes.
 func IsInterestingService(s tailcfg.Service, os string) bool {
 	switch s.Proto {
-	case tailcfg.PeerAPI4, tailcfg.PeerAPI6, tailcfg.PeerAPIDNS, tailcfg.AppConnector:
+	case tailcfg.PeerAPI4, tailcfg.PeerAPI6, tailcfg.PeerAPIDNS:
 		return true
 	}
 	if s.Proto != tailcfg.TCP {

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -629,8 +629,6 @@ const (
 	PeerAPI4   = ServiceProto("peerapi4")
 	PeerAPI6   = ServiceProto("peerapi6")
 	PeerAPIDNS = ServiceProto("peerapi-dns-proxy")
-	// Deprecated: use the field on HostInfo instead.
-	AppConnector = ServiceProto("app-connector")
 )
 
 // Service represents a service running on a node.
@@ -651,9 +649,6 @@ type Service struct {
 	//        being a DNS proxy (when the node is an exit
 	//        node). For this service, the Port number is really
 	//        the version number of the service.
-	//     * "app-connector": (deprecated) the local app-connector
-	//        service is available. For this service, the Port number
-	//        is really the version number of the service.
 	Proto ServiceProto
 
 	// Port is the port number.


### PR DESCRIPTION
This was never released, and is replaced by HostInfo.AppConnector.

Updates tailscale/corp#15437
Signed-off-by: James Tucker <james@tailscale.com>