### PR TITLE
ipn/ipnlocal: run "tailscale update" via systemd-run on Linux

### DIFF
--- a/ipn/ipnlocal/c2n.go
+++ b/ipn/ipnlocal/c2n.go
@@ -233,7 +233,7 @@ func (b *LocalBackend) handleC2NUpdatePost(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	cmd := exec.Command(cmdTS, "update", "--yes")
+	cmd := tailscaleUpdateCmd(cmdTS)
 	buf := new(bytes.Buffer)
 	cmd.Stdout = buf
 	cmd.Stderr = buf
@@ -363,6 +363,20 @@ func findCmdTailscale() (string, error) {
 		return ts, nil
 	}
 	return "", errors.New("tailscale executable not found in expected place")
+}
+
+func tailscaleUpdateCmd(cmdTS string) *exec.Cmd {
+	if runtime.GOOS != "linux" {
+		return exec.Command(cmdTS, "update", "--yes")
+	}
+	if _, err := exec.LookPath("systemd-run"); err != nil {
+		return exec.Command(cmdTS, "update", "--yes")
+	}
+	// When systemd-run is available, use it to run the update command. This
+	// creates a new temporary unit separate from the tailscaled unit. When
+	// tailscaled is restarted during the update, systemd won't kill this
+	// temporary update unit, which could cause unexpected breakage.
+	return exec.Command("systemd-run", "--wait", "--pipe", "--collect", cmdTS, "update", "--yes")
 }
 
 func regularFileExists(path string) bool {


### PR DESCRIPTION
When we run tailscled under systemd, restarting the unit kills all child processes, including "tailscale update". And during update, the package manager will restart the tailscaled unit. Specifically on Debian-based distros, interrupting `apt-get install` can get the system into a wedged state which requires the user to manually run `dpkg --configure` to recover.

To avoid all this, use `systemd-run` where available to run the `tailscale update` process. This launches it in a separate temporary unit and doesn't kill it when parent unit is restarted.

Also, detect when `apt-get install` complains about aborted update and try to restore the system by running `dpkg --configure tailscale`. This could help if the system unexpectedly shuts down during our auto-update.

Fixes https://github.com/tailscale/corp/issues/15771