### PR TITLE
client/web: disable the "disable" button when disabled

### DIFF
--- a/client/web/src/components/exit-node-selector.tsx
+++ b/client/web/src/components/exit-node-selector.tsx
@@ -115,15 +115,17 @@ export default function ExitNodeSelector({
         </button>
         {(advertising || using) && (
           <button
-            className={cx("px-3 py-2 rounded-sm text-white cursor-pointer", {
+            className={cx("px-3 py-2 rounded-sm text-white", {
               "bg-orange-400": advertising,
               "bg-indigo-400": using,
+              "cursor-not-allowed": disabled,
             })}
             onClick={(e) => {
               e.preventDefault()
               e.stopPropagation()
               handleSelect(noExitNode)
             }}
+            disabled={disabled}
           >
             Disable
           </button>


### PR DESCRIPTION
We currently disable the exit-node drop down selector when the user is in read-only mode, but we missed disabling the "Disable" button also. Previously, it would display an error when clicked.

Updates tailscale/corp#14335