### PR TITLE
ipn/ipnlocal: call serve handler for local traffic

### DIFF
--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -94,6 +94,7 @@ func (b *LocalBackend) newServeListener(ctx context.Context, ap netip.AddrPort, 
 				b.logf("[unexpected] local-serve: no handler for %v to port %v", srcAddr, ap.Port())
 				conn.Close()
 			}
+			handler(conn)
 			return nil
 		},
 		bo: backoff.NewBackoff("serve-listener", logf, 30*time.Second),


### PR DESCRIPTION
Tailscale serve maintains a set of listeners so that serve traffic from the local device can be properly served when running in kernel networking mode. #10177 refactored that logic so that it could be reused by the internal web client as well. However, in my refactoring I missed actually calling the serve handler to handle the traffic.

Updates #10177