### PR TITLE
adjust build tags for tamago

### DIFF
--- a/posture/serialnumber_stub.go
+++ b/posture/serialnumber_stub.go
@@ -8,7 +8,7 @@
 // solaris: currently unsupported by go-smbios:
 // https://github.com/digitalocean/go-smbios/pull/21
 
-//go:build ios || android || solaris || plan9 || js || wasm || (darwin && !cgo)
+//go:build ios || android || solaris || plan9 || js || wasm || (darwin && !cgo) || tamago
 
 package posture
 


### PR DESCRIPTION
This PR adjust build tags to allow compilation under the [TamaGo framework](https://github.com/usbarmory/tamago).