### PR TITLE
ipn/ipnlocal: only call serve handler if non-nil

### DIFF
--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -93,9 +93,9 @@ func (b *LocalBackend) newServeListener(ctx context.Context, ap netip.AddrPort, 
 			if handler == nil {
 				b.logf("[unexpected] local-serve: no handler for %v to port %v", srcAddr, ap.Port())
 				conn.Close()
+				return nil
 			}
-			handler(conn)
-			return nil
+			return handler(conn)
 		},
 		bo: backoff.NewBackoff("serve-listener", logf, 30*time.Second),
 	}


### PR DESCRIPTION
return early if handler is nil. Go ahead and return the error from handler, though in this case the caller isn't doing anything with it (which has always been the case).

Updates #10177
Updates #10251