### PR TITLE
ssh/tailssh: use control server time instead of local time

### DIFF
--- a/ipn/ipnlocal/expiry.go
+++ b/ipn/ipnlocal/expiry.go
@@ -217,3 +217,10 @@ func (em *expiryManager) nextPeerExpiry(nm *netmap.NetworkMap, localNow time.Tim
 
 	return nextExpiry
 }
+
+// ControlNow estimates the current time on the control server, calculated as
+// localNow + the delta between local and control server clocks as recorded
+// when the LocalBackend last received a time message from the control server.
+func (b *LocalBackend) ControlNow(localNow time.Time) time.Time {
+	return localNow.Add(b.em.clockDelta.Load())
+}

--- a/ssh/tailssh/tailssh.go
+++ b/ssh/tailssh/tailssh.go
@@ -109,6 +109,9 @@ func init() {
 			lb:             lb,
 			logf:           logf,
 			tailscaledPath: tsd,
+			timeNow: func() time.Time {
+				return lb.ControlNow(time.Now())
+			},
 		}
 
 		return srv, nil


### PR DESCRIPTION
    This takes advantage of existing functionality in ipn/ipnlocal to adjust
    the local clock based on periodic time signals from the control server.
    This way, when checking things like SSHRule expirations, calculations are
    protected from incorrectly set local clocks.

Fixes tailscale/corp#15796