### PR TITLE
cmd/cli: remove --webclient flag from up

### DIFF
--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -905,7 +905,6 @@ func TestUpdatePrefs(t *testing.T) {
 				OperatorUserSet:           true,
 				RouteAllSet:               true,
 				RunSSHSet:                 true,
-				RunWebClientSet:           true,
 				ShieldsUpSet:              true,
 				WantRunningSet:            true,
 			},

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -116,11 +116,6 @@ func newUpFlagSet(goos string, upArgs *upArgsT, cmd string) *flag.FlagSet {
 	upf.BoolVar(&upArgs.advertiseConnector, "advertise-connector", false, "advertise this node as an app connector")
 	upf.BoolVar(&upArgs.advertiseDefaultRoute, "advertise-exit-node", false, "offer to be an exit node for internet traffic for the tailnet")
 
-	// TODO(tailscale/corp#14335): during development only expose -webclient on dev and unstable builds
-	if version.GetMeta().IsDev || version.IsUnstableBuild() {
-		upf.BoolVar(&upArgs.runWebClient, "webclient", false, "run a web client, permitting access per tailnet admin's declared policy")
-	}
-
 	if safesocket.GOOSUsesPeerCreds(goos) {
 		upf.StringVar(&upArgs.opUser, "operator", "", "Unix username to allow to operate on tailscaled without sudo")
 	}


### PR DESCRIPTION
Causing issues building a stable release. Getting rid of the flag for now because it was only available in unstable, can still be turned on through localapi.

A #cleanup