### PR TITLE
cmd/tailscale: expose --webclient for all builds

### DIFF
--- a/cmd/tailscale/cli/set.go
+++ b/cmd/tailscale/cli/set.go
@@ -73,11 +73,7 @@ func newSetFlagSet(goos string, setArgs *setArgsT) *flag.FlagSet {
 	setf.BoolVar(&setArgs.updateCheck, "update-check", true, "notify about available Tailscale updates")
 	setf.BoolVar(&setArgs.updateApply, "auto-update", false, "automatically update to the latest available version")
 	setf.BoolVar(&setArgs.postureChecking, "posture-checking", false, "HIDDEN: allow management plane to gather device posture information")
-
-	// TODO(tailscale/corp#14335): during development only expose -webclient on dev and unstable builds
-	if version.GetMeta().IsDev || version.IsUnstableBuild() {
-		setf.BoolVar(&setArgs.runWebClient, "webclient", false, "run a web client, permitting access per tailnet admin's declared policy")
-	}
+	setf.BoolVar(&setArgs.runWebClient, "webclient", false, "run a web interface for managing this node, served over Tailscale at port 5252")
 
 	if safesocket.GOOSUsesPeerCreds(goos) {
 		setf.StringVar(&setArgs.opUser, "operator", "", "Unix username to allow to operate on tailscaled without sudo")


### PR DESCRIPTION
This removes the dev/unstable build check for the --webclient flag on `tailscale set`, so that it will be included in the next major stable release (1.56)

Updates tailscale/corp#14335