### PR TITLE
ipn: remove the preview-webclient node capability

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -4249,7 +4249,7 @@ func (b *LocalBackend) ShouldRunSSH() bool { return b.sshAtomicBool.Load() && en
 func (b *LocalBackend) ShouldRunWebClient() bool { return b.webClientAtomicBool.Load() }
 
 func (b *LocalBackend) setWebClientAtomicBoolLocked(nm *netmap.NetworkMap, prefs ipn.PrefsView) {
-	shouldRun := prefs.Valid() && prefs.RunWebClient() && hasCapability(nm, tailcfg.CapabilityPreviewWebClient)
+	shouldRun := prefs.Valid() && prefs.RunWebClient()
 	wasRunning := b.webClientAtomicBool.Swap(shouldRun)
 	if wasRunning && !shouldRun {
 		go b.WebClientShutdown() // stop web client

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -2041,7 +2041,6 @@ const (
 	CapabilityDataPlaneAuditLogs NodeCapability = "https://tailscale.com/cap/data-plane-audit-logs" // feature enabled
 	CapabilityDebug              NodeCapability = "https://tailscale.com/cap/debug"                 // exposes debug endpoints over the PeerAPI
 	CapabilityHTTPS              NodeCapability = "https"                                           // https cert provisioning enabled on tailnet
-	CapabilityPreviewWebClient   NodeCapability = "preview-webclient"                               // allows starting web client in tailscaled
 
 	// CapabilityBindToInterfaceByRoute changes how Darwin nodes create
 	// sockets (in the net/netns package). See that package for more


### PR DESCRIPTION
Now that 1.54 has released, and the new web client will be included in 1.56, we can remove the need for the node capability. This means that all 1.55 unstable builds, and then eventually the 1.56 build, will work without setting the node capability.

The web client still requires the "webclient" user pref, so this does NOT mean that the web client will be on by default for all devices.

Updates tailscale/corp#14335