### PR TITLE
ipn/ipnlocal: rename SetWebLocalClient to ConfigureWebClient

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -570,7 +570,7 @@ func getLocalBackend(ctx context.Context, logf logger.Logf, logID logid.PublicID
 	if root := lb.TailscaleVarRoot(); root != "" {
 		dnsfallback.SetCachePath(filepath.Join(root, "derpmap.cached.json"), logf)
 	}
-	lb.SetWebLocalClient(&tailscale.LocalClient{Socket: args.socketpath, UseSocketOnly: args.socketpath != ""})
+	lb.ConfigureWebClient(&tailscale.LocalClient{Socket: args.socketpath, UseSocketOnly: args.socketpath != ""})
 	configureTaildrop(logf, lb)
 	if err := ns.Start(lb); err != nil {
 		log.Fatalf("failed to start netstack: %v", err)

--- a/ipn/ipnlocal/web_client.go
+++ b/ipn/ipnlocal/web_client.go
@@ -26,7 +26,7 @@ const webClientPort = web.ListenPort
 
 // webClient holds state for the web interface for managing
 // this tailscale instance. The web interface is not used by
-// default, but initialized by calling LocalBackend.WebOrInit.
+// default, but initialized by calling LocalBackend.WebClientInit.
 type webClient struct {
 	server *web.Server // or nil, initialized lazily
 
@@ -36,9 +36,10 @@ type webClient struct {
 	lc *tailscale.LocalClient
 }
 
-// SetWebLocalClient sets the b.web.lc function.
-// If lc is provided as nil, b.web.lc is cleared out.
-func (b *LocalBackend) SetWebLocalClient(lc *tailscale.LocalClient) {
+// ConfigureWebClient configures b.web prior to use.
+// Specifially, it sets b.web.lc to the provided LocalClient.
+// If provided as nil, b.web.lc is cleared out.
+func (b *LocalBackend) ConfigureWebClient(lc *tailscale.LocalClient) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.webClient.lc = lc

--- a/ipn/ipnlocal/web_client_stub.go
+++ b/ipn/ipnlocal/web_client_stub.go
@@ -16,7 +16,7 @@ const webClientPort = 5252
 
 type webClient struct{}
 
-func (b *LocalBackend) SetWebLocalClient(lc *tailscale.LocalClient) {}
+func (b *LocalBackend) ConfigureWebClient(lc *tailscale.LocalClient) {}
 
 func (b *LocalBackend) WebClientInit() error {
 	return errors.New("not implemented")


### PR DESCRIPTION
For consistency with the "WebClient" naming of the other functions here. Also fixed a doc typo.

A #cleanup