### PR TITLE
client/web: remove DebugMode from GET /api/data

### DIFF
--- a/client/web/src/hooks/node-data.ts
+++ b/client/web/src/hooks/node-data.ts
@@ -28,8 +28,6 @@ export type NodeData = {
   IsTagged: boolean
   Tags: string[]
   RunningSSHServer: boolean
-
-  DebugMode: "" | "login" | "full" // empty when not running in any debug mode
 }
 
 type NodeState =

--- a/cmd/tailscale/cli/web.go
+++ b/cmd/tailscale/cli/web.go
@@ -90,12 +90,10 @@ func runWeb(ctx context.Context, args []string) error {
 		selfIP = st.Self.TailscaleIPs[0]
 	}
 
-	cliServerMode := web.LegacyServerMode
 	var existingWebClient bool
 	if prefs, err := localClient.GetPrefs(ctx); err == nil {
 		existingWebClient = prefs.RunWebClient
 	}
-	cliServerMode = web.LoginServerMode
 	if !existingWebClient {
 		// Also start full client in tailscaled.
 		log.Printf("starting tailscaled web client at %s:%d\n", selfIP.String(), web.ListenPort)
@@ -105,7 +103,7 @@ func runWeb(ctx context.Context, args []string) error {
 	}
 
 	webServer, err := web.NewServer(web.ServerOpts{
-		Mode:        cliServerMode,
+		Mode:        web.LoginServerMode,
 		CGIMode:     webArgs.cgi,
 		PathPrefix:  webArgs.prefix,
 		LocalClient: &localClient,

--- a/tsnet/example/web-client/web-client.go
+++ b/tsnet/example/web-client/web-client.go
@@ -30,7 +30,7 @@ func main() {
 
 	// Serve the Tailscale web client.
 	ws, err := web.NewServer(web.ServerOpts{
-		Mode:        web.LegacyServerMode,
+		Mode:        web.LoginServerMode,
 		LocalClient: lc,
 	})
 	if err != nil {


### PR DESCRIPTION
No longer using this! Readonly state fully managed via auth endpoint.

A #cleanup