### PR TITLE
ipn/ipnlocal: add mutex to webClient struct

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -656,7 +656,7 @@ func (b *LocalBackend) Shutdown() {
 		b.debugSink = nil
 	}
 	b.mu.Unlock()
-	b.WebClientShutdown()
+	b.webClientShutdown()
 
 	if b.sockstatLogger != nil {
 		b.sockstatLogger.Shutdown()
@@ -4252,7 +4252,7 @@ func (b *LocalBackend) setWebClientAtomicBoolLocked(nm *netmap.NetworkMap, prefs
 	shouldRun := prefs.Valid() && prefs.RunWebClient()
 	wasRunning := b.webClientAtomicBool.Swap(shouldRun)
 	if wasRunning && !shouldRun {
-		go b.WebClientShutdown() // stop web client
+		go b.webClientShutdown() // stop web client
 	}
 }
 

--- a/ipn/ipnlocal/web_client_stub.go
+++ b/ipn/ipnlocal/web_client_stub.go
@@ -18,11 +18,11 @@ type webClient struct{}
 
 func (b *LocalBackend) ConfigureWebClient(lc *tailscale.LocalClient) {}
 
-func (b *LocalBackend) WebClientInit() error {
+func (b *LocalBackend) webClientGetOrInit() error {
 	return errors.New("not implemented")
 }
 
-func (b *LocalBackend) WebClientShutdown() {}
+func (b *LocalBackend) webClientShutdown() {}
 
 func (b *LocalBackend) handleWebClientConn(c net.Conn) error {
 	return errors.New("not implemented")


### PR DESCRIPTION
Adds a new sync.Mutex field to the webClient struct, rather than using the general LocalBackend mutex. Since webClientGetOrInit (previously WebClientInit) gets called on every connection, we want to avoid holding the lock on LocalBackend just to check if the server is initialized.

Moves all web_client.go funcs over to using the webClient.mu field.

Updates tailscale/corp#14335