### PR TITLE
cmd/tailscaled: make tun mode default on gokrazy

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -85,20 +85,6 @@ func defaultTunName() string {
 			// Try TUN, but fall back to userspace networking if needed.
 			// See https://github.com/tailscale/tailscale-synology/issues/35
 			return "tailscale0,userspace-networking"
-		case distro.Gokrazy:
-			// Gokrazy doesn't yet work in tun mode because the whole
-			// Gokrazy thing is no C code, and Tailscale currently
-			// depends on the iptables binary for Linux's
-			// wgengine/router.
-			// But on Gokrazy there's no legacy iptables, so we could use netlink
-			// to program nft-iptables directly. It just isn't done yet;
-			// see https://github.com/tailscale/tailscale/issues/391
-			//
-			// But Gokrazy does have the tun module built-in, so users
-			// can still run --tun=tailscale0 if they wish, if they
-			// arrange for iptables to be present or run in "tailscale
-			// up --netfilter-mode=off" mode, perhaps. Untested.
-			return "userspace-networking"
 		}
 
 	}


### PR DESCRIPTION
Now that we have nftable support this works fine and force it on gokrazy since 25a8daf405a9db68187989428548405fa0a94d65.

Updates gokrazy/gokrazy#209