### PR TITLE
client/web: allow login client to still run tailscale up

### DIFF
--- a/client/web/web.go
+++ b/client/web/web.go
@@ -349,6 +349,10 @@ func (s *Server) serveLoginAPI(w http.ResponseWriter, r *http.Request) {
 		// TODO(soniaappasamy): we may want a minimal node data response here
 		s.serveGetNodeData(w, r)
 		return
+	case httpm.POST:
+		// TODO(will): refactor to expose only a dedicated login method
+		s.servePostNodeUpdate(w, r)
+		return
 	}
 	http.Error(w, "invalid endpoint", http.StatusNotFound)
 	return


### PR DESCRIPTION
I don't believe this has ever worked, since we didn't allow POST requests in the login client. But previously, we were primarily using the legacy client to login, so it didn't really matter. Now that we've removed the legacy client, we have no way to login.

This fixes the login client, allowing it to login, but it still needs to be refactored to expose a dedicated login method, without exposing all the node update functionality.

Updates tailscale/corp#14335