### PR TITLE
.github: build gocross using regular GOPROXY settings

### DIFF
--- a/.github/workflows/update-webclient-prebuilt.yml
+++ b/.github/workflows/update-webclient-prebuilt.yml
@@ -18,6 +18,7 @@ jobs:
 
       - name: Run go get
         run: |
+          ./tool/go version # build gocross if needed using regular GOPROXY
           GOPROXY=direct ./tool/go get github.com/tailscale/web-client-prebuilt
           ./tool/go mod tidy
 


### PR DESCRIPTION
This `go get` action has been running very slowly, and I'm pretty sure it's because we're building gocross on the first `./tool/go` run, and because we've set `GOPROXY=direct`, it's going directly to GitHub to fetch all of the gocross dependencies.

Updates #cleanup