### PR TITLE
cmd/k8s-operator: helm chart add missing keys

### DIFF
--- a/cmd/k8s-operator/deploy/chart/values.yaml
+++ b/cmd/k8s-operator/deploy/chart/values.yaml
@@ -22,12 +22,6 @@ operatorConfig:
     kubernetes.io/os: linux
 
   resources: {}
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
 
   podAnnotations: {}
 

--- a/cmd/k8s-operator/deploy/chart/values.yaml
+++ b/cmd/k8s-operator/deploy/chart/values.yaml
@@ -15,11 +15,29 @@ operatorConfig:
     # used.
     tag: ""
     digest: ""
+    pullPolicy: Always
   logging: "info"
   hostname: "tailscale-operator"
   nodeSelector:
     kubernetes.io/os: linux
 
+  resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+  podAnnotations: {}
+
+  tolerations: []
+
+  affinity: {}
+
+  podSecurityContext: {}
+
+  securityContext: {}
 
 # proxyConfig contains configuraton that will be applied to any ingress/egress
 # proxies created by the operator.
@@ -43,3 +61,5 @@ proxyConfig:
 # https://tailscale.com/kb/1236/kubernetes-operator/#accessing-the-kubernetes-control-plane-using-an-api-server-proxy
 apiServerProxyConfig:
   mode: "false" # "true", "false", "noauth"
+
+imagePullSecrets: []

--- a/cmd/k8s-operator/deploy/chart/values.yaml
+++ b/cmd/k8s-operator/deploy/chart/values.yaml
@@ -4,9 +4,9 @@
 # Operator oauth credentials. If set a Kubernetes Secret with the provided
 # values will be created in the operator namespace. If unset a Secret named
 # operator-oauth must be precreated.
-# oauth:
-#   clientId: ""
-#   clientSecret: ""
+oauth: {}
+  # clientId: ""
+  # clientSecret: ""
 
 operatorConfig:
   image:


### PR DESCRIPTION
Closes https://github.com/tailscale/tailscale/issues/10182.

Add missing keys to helm chart default values.