### PR TITLE
Fix potential goroutine leak in syncs/watchdog.go

### DIFF
--- a/syncs/watchdog.go
+++ b/syncs/watchdog.go
@@ -29,7 +29,10 @@ func Watch(ctx context.Context, mu sync.Locker, tick, max time.Duration) chan ti
 			// Drop values written after c is closed.
 			return
 		}
-		c <- d
+		select {
+		case c <- d:
+		case <-ctx.Done():
+		}
 	}
 	closec := func() {
 		closemu.Lock()


### PR DESCRIPTION
Depending on how the preemption will occur, in some scenarios sendc would have blocked indefinitely even after cancelling the context.
