### PR TITLE
cmd/k8s-operator: fix chart syntax error

### DIFF
--- a/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
+++ b/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: operator
       {{- with .Values.operatorConfig.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.operatorConfig.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
       - name: oauth


### PR DESCRIPTION
`with` block modifies scope https://helm.sh/docs/chart_template_guide/control_structures/#modifying-scope-using-with so things cannot be accessed by referring to top level values.

Updates #9222