### PR TITLE
cmd/k8s-operator: log user/group impersonated by apiserver proxy at debug level

### DIFF
--- a/cmd/k8s-operator/proxy_test.go
+++ b/cmd/k8s-operator/proxy_test.go
@@ -10,12 +10,17 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"go.uber.org/zap"
 	"tailscale.com/client/tailscale/apitype"
 	"tailscale.com/tailcfg"
 	"tailscale.com/util/must"
 )
 
 func TestImpersonationHeaders(t *testing.T) {
+	zl, err := zap.NewDevelopment()
+	if err != nil {
+		t.Fatal(err)
+	}
 	tests := []struct {
 		name     string
 		emailish string
@@ -100,7 +105,7 @@ func TestImpersonationHeaders(t *testing.T) {
 			},
 			CapMap: tc.capMap,
 		})
-		addImpersonationHeaders(r)
+		addImpersonationHeaders(r, zl.Sugar())
 
 		if d := cmp.Diff(tc.wantHeaders, r.Header); d != "" {
 			t.Errorf("unexpected header (-want +got):\n%s", d)


### PR DESCRIPTION
Configuring [api-server proxy](https://tailscale.com/kb/1236/kubernetes-operator/#configuring-the-api-server-proxy) involves a number of steps and there have been a few cases where it is not clear why it's not working as the user expected, see i.e #10127 .

This PR logs what user/group is being impersonated and why- that should help with debugging proxy issues.

(Alternative would be by looking at [kube apiserver logs or audit logs](https://github.com/kubernetes/apiserver/blob/v0.28.4/pkg/endpoints/filters/impersonation.go#L166-L170), however those will not be accessible to everyone).

Logging the headers will be quite verbose, but it should be okay to do it at debug level which is not the default and not what folks should use in production etc.

Updates tailscale/tailscale#10127