### PR TITLE
cmd/tailscale/cli: pass "-o 'CanonicalizeHostname no'" to ssh

### DIFF
--- a/cmd/tailscale/cli/ssh.go
+++ b/cmd/tailscale/cli/ssh.go
@@ -103,6 +103,7 @@ func runSSH(ctx context.Context, args []string) error {
 		"-o", fmt.Sprintf("UserKnownHostsFile %q", knownHostsFile),
 		"-o", "UpdateHostKeys no",
 		"-o", "StrictHostKeyChecking yes",
+		"-o", "CanonicalizeHostname no", // https://github.com/tailscale/tailscale/issues/10348
 	)
 
 	// TODO(bradfitz): nc is currently broken on macOS:


### PR DESCRIPTION
Given that we're already passing the fully-qualified domain to ssh and have written the ssh_known_hosts ourselves, I think we can disable this option which breaks `tailscale ssh`.

Fixes #10348

---

I originally started with attempting to canonicalise the hostname ourselves but I'm not certain I know all transformations involved beyond trimming the final "." from the DNS name (played with in #10342).