### PR TITLE
cmd/tailscale: also warn about IP forwarding if using CLI set

### DIFF
--- a/cmd/tailscale/cli/set.go
+++ b/cmd/tailscale/cli/set.go
@@ -135,6 +135,7 @@ func runSet(ctx context.Context, args []string) (retErr error) {
 		}
 	}
 
+	warnOnAdvertiseRouts(ctx, &maskedPrefs.Prefs)
 	var advertiseExitNodeSet, advertiseRoutesSet bool
 	setFlagSet.Visit(func(f *flag.Flag) {
 		updateMaskedPrefsFromUpOrSetFlag(maskedPrefs, f.Name)

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -437,18 +437,7 @@ func runUp(ctx context.Context, cmd string, args []string, upArgs upArgsT) (retE
 		fatalf("%s", err)
 	}
 
-	if len(prefs.AdvertiseRoutes) > 0 || prefs.AppConnector.Advertise {
-		// TODO(jwhited): compress CheckIPForwarding and CheckUDPGROForwarding
-		//  into a single HTTP req.
-		if err := localClient.CheckIPForwarding(ctx); err != nil {
-			warnf("%v", err)
-		}
-		if runtime.GOOS == "linux" {
-			if err := localClient.CheckUDPGROForwarding(ctx); err != nil {
-				warnf("%v", err)
-			}
-		}
-	}
+	warnOnAdvertiseRouts(ctx, prefs)
 
 	curPrefs, err := localClient.GetPrefs(ctx)
 	if err != nil {
@@ -1158,4 +1147,19 @@ func resolveAuthKey(ctx context.Context, v, tags string) (string, error) {
 		return "", err
 	}
 	return authkey, nil
+}
+
+func warnOnAdvertiseRouts(ctx context.Context, prefs *ipn.Prefs) {
+	if len(prefs.AdvertiseRoutes) > 0 || prefs.AppConnector.Advertise {
+		// TODO(jwhited): compress CheckIPForwarding and CheckUDPGROForwarding
+		//  into a single HTTP req.
+		if err := localClient.CheckIPForwarding(ctx); err != nil {
+			warnf("%v", err)
+		}
+		if runtime.GOOS == "linux" {
+			if err := localClient.CheckUDPGROForwarding(ctx); err != nil {
+				warnf("%v", err)
+			}
+		}
+	}
 }


### PR DESCRIPTION
We warn users about IP forwarding being disabled when using `--avertise-routes` in `tailscale up`, this adds the same warnings to `tailscale set`.

Updates tailscale/corp#9968
Signed-off-by: Jenny Zhang <jz@tailscale.com>