### PR TITLE
userspace-networking: support resolving SplitDNS via dns.Manager

### DIFF
--- a/net/dns/quad100conn.go
+++ b/net/dns/quad100conn.go
@@ -1,0 +1,58 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package dns
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"net/netip"
+	"time"
+)
+
+type Quad100conn struct {
+	Ctx        context.Context
+	DnsManager *Manager
+
+	rbuf bytes.Buffer
+}
+
+var (
+	_ net.Conn       = (*Quad100conn)(nil)
+	_ net.PacketConn = (*Quad100conn)(nil) // be a PacketConn to change net.Resolver semantics
+)
+
+func (*Quad100conn) Close() error                       { return nil }
+func (*Quad100conn) LocalAddr() net.Addr                { return todoAddr{} }
+func (*Quad100conn) RemoteAddr() net.Addr               { return todoAddr{} }
+func (*Quad100conn) SetDeadline(t time.Time) error      { return nil }
+func (*Quad100conn) SetReadDeadline(t time.Time) error  { return nil }
+func (*Quad100conn) SetWriteDeadline(t time.Time) error { return nil }
+
+func (c *Quad100conn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
+	return c.Write(p)
+}
+
+func (c *Quad100conn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
+	n, err = c.Read(p)
+	return n, todoAddr{}, err
+}
+
+func (c *Quad100conn) Read(p []byte) (n int, err error) {
+	return c.rbuf.Read(p)
+}
+
+func (c *Quad100conn) Write(packet []byte) (n int, err error) {
+	pkt, err := c.DnsManager.Query(c.Ctx, packet, "tcp", netip.AddrPort{})
+	if err != nil {
+		return 0, err
+	}
+	c.rbuf.Write(pkt)
+	return len(packet), nil
+}
+
+type todoAddr struct{}
+
+func (todoAddr) Network() string { return "unused" }
+func (todoAddr) String() string  { return "unused-todoAddr" }

--- a/net/dns/resolver/forwarder.go
+++ b/net/dns/resolver/forwarder.go
@@ -701,7 +701,7 @@ func (f *forwarder) sendTCP(ctx context.Context, fq *forwardQuery, rr resolverAn
 	ctx, cancel := context.WithTimeout(ctx, tcpQueryTimeout)
 	defer cancel()
 
-	conn, err := f.dialer.SystemDial(ctx, tcpFam, ipp.String())
+	conn, err := f.dialer.UserDial(ctx, tcpFam, ipp.String())
 	if err != nil {
 		return nil, err
 	}

--- a/net/tsdial/tsdial.go
+++ b/net/tsdial/tsdial.go
@@ -41,6 +41,8 @@ type Dialer struct {
 	// If nil, it's not used.
 	NetstackDialTCP func(context.Context, netip.AddrPort) (net.Conn, error)
 
+	UserDialCustomResolver func(string) (netip.Addr, error)
+
 	peerClientOnce sync.Once
 	peerClient     *http.Client
 
@@ -251,11 +253,20 @@ func (d *Dialer) userDialResolve(ctx context.Context, network, addr string) (net
 		return ipp, err
 	}
 
+	// Try tsdns resolver next to resolve SplitDNS
+	host, port, err := splitHostPort(addr)
+	if d.UserDialCustomResolver != nil {
+		ip, err := d.UserDialCustomResolver(host)
+		if err == nil {
+			ipp := netip.AddrPortFrom(ip, port)
+			return ipp, err
+		}
+	}
+
 	// Otherwise, hit the network.
 
 	// TODO(bradfitz): wire up net/dnscache too.
 
-	host, port, err := splitHostPort(addr)
 	if err != nil {
 		// addr is malformed.
 		return netip.AddrPort{}, err


### PR DESCRIPTION
# Context

I have a tailnet setup where I sent "*.svc.cluster.local" to my kubernetes DNS server to effectively make all kubernetes services easily accessible on other nodes. However, this does not work when I'm using userspace networking mode since they do not update OS DNS settings and has no quad100 resolver. A couple issues (#4677, #9619) seems to be describing the same issue.

# Patch

- Add a `Quad100conn` (similar to how `dohConn`) struct for the DNS resolver. This just use the `dns.Manager` to perform the resolution and fake a IO interface for it.
- Add a `UserDialCustomResolver` to `Dialer` so we can override the IP resolution in `UserDial` (which is used by proxy handlers) to use the forementioned `Quad100conn`
- Update the dns `Forwarder` to use `UserDial` instead so it can reach into tailnet on userspace networking mode (This might have a side-effect that it will use the `UserDialCustomResolver` earlier too, however, the DNS servers are specified as IP address, so this should be fine.)
- Change `Dialer.UserDial` to use the quad100 resolver after MagicDNS

--

🙇 This is my first time contributing to tailscale and I'm by no means a tailscale and barely writes golang in my day-to-day, so apologizes for smelly code or decisions. Let me know how if any changes are needed!