### PR TITLE
controlclient,tailcfg,types: expose MaxKeyDuration via localapi

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -1044,7 +1044,7 @@ func (c *Direct) sendMapRequest(ctx context.Context, isStreaming bool, nu Netmap
 
 		var resp tailcfg.MapResponse
 		if err := c.decodeMsg(msg, &resp, machinePrivKey); err != nil {
-			vlogf("netmap: decode error: %v")
+			vlogf("netmap: decode error: %v", err)
 			return err
 		}
 		watchdogTimer.Stop()

--- a/control/controlclient/map.go
+++ b/control/controlclient/map.go
@@ -87,6 +87,7 @@ type mapSession struct {
 	lastPopBrowserURL      string
 	lastTKAInfo            *tailcfg.TKAInfo
 	lastNetmapSummary      string // from NetworkMap.VeryConcise
+	lastMaxExpiry          time.Duration
 }
 
 // newMapSession returns a mostly unconfigured new mapSession.
@@ -318,6 +319,9 @@ func (ms *mapSession) updateStateFromResponse(resp *tailcfg.MapResponse) {
 	}
 	if resp.TKAInfo != nil {
 		ms.lastTKAInfo = resp.TKAInfo
+	}
+	if resp.MaxKeyDuration > 0 {
+		ms.lastMaxExpiry = resp.MaxKeyDuration
 	}
 }
 
@@ -763,6 +767,7 @@ func (ms *mapSession) netmap() *netmap.NetworkMap {
 		DERPMap:           ms.lastDERPMap,
 		ControlHealth:     ms.lastHealth,
 		TKAEnabled:        ms.lastTKAInfo != nil && !ms.lastTKAInfo.Disabled,
+		MaxKeyDuration:    ms.lastMaxExpiry,
 	}
 
 	if ms.lastTKAInfo != nil && ms.lastTKAInfo.Head != "" {

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -125,7 +125,8 @@ type CapabilityVersion int
 //   - 82: 2023-12-01: Client understands NodeAttrLinuxMustUseIPTables, NodeAttrLinuxMustUseNfTables, c2n /netfilter-kind
 //   - 83: 2023-12-18: Client understands DefaultAutoUpdate
 //   - 84: 2024-01-04: Client understands SeamlessKeyRenewal
-const CurrentCapabilityVersion CapabilityVersion = 84
+//   - 85: 2024-01-05: Client understands MaxKeyDuration
+const CurrentCapabilityVersion CapabilityVersion = 85
 
 type StableID string
 
@@ -1886,6 +1887,10 @@ type MapResponse struct {
 	// auto-update setting doesn't change if the tailnet admin flips the
 	// default after the node registered.
 	DefaultAutoUpdate opt.Bool `json:",omitempty"`
+
+	// MaxKeyDuration describes the MaxKeyDuration setting for the tailnet.
+	// If zero, the value is unchanged.
+	MaxKeyDuration time.Duration `json:",omitempty"`
 }
 
 // ClientVersion is information about the latest client version that's available

--- a/types/netmap/netmap.go
+++ b/types/netmap/netmap.go
@@ -75,6 +75,9 @@ type NetworkMap struct {
 	DomainAuditLogID string
 
 	UserProfiles map[tailcfg.UserID]tailcfg.UserProfile
+
+	// MaxKeyDuration describes the MaxKeyDuration setting for the tailnet.
+	MaxKeyDuration time.Duration
 }
 
 // User returns nm.SelfNode.User if nm.SelfNode is non-nil, otherwise it returns

--- a/types/netmap/nodemut.go
+++ b/types/netmap/nodemut.go
@@ -177,5 +177,6 @@ func mapResponseContainsNonPatchFields(res *tailcfg.MapResponse) bool {
 		// function is called, so it should never be set anyway. But for
 		// completedness, and for tests, check it too:
 		res.PeersChanged != nil ||
-		res.DefaultAutoUpdate != ""
+		res.DefaultAutoUpdate != "" ||
+		res.MaxKeyDuration > 0
 }

--- a/types/netmap/nodemut_test.go
+++ b/types/netmap/nodemut_test.go
@@ -32,7 +32,7 @@ func TestMapResponseContainsNonPatchFields(t *testing.T) {
 			}
 			return reflect.ValueOf("foo").Convert(t)
 		case reflect.Int64:
-			return reflect.ValueOf(int64(1))
+			return reflect.ValueOf(int64(1)).Convert(t)
 		case reflect.Slice:
 			return reflect.MakeSlice(t, 1, 1)
 		case reflect.Ptr:


### PR DESCRIPTION
Updates tailscale/corp#16016

Design doc for more context: https://docs.google.com/document/d/1zaoCId-biwgMNThDLzK0R8_PGB11dddTSoOMnGlkTFU/

Probably makes sense to review this in tandem with tailscale/corp#16049 , which is the server-side change.