### PR TITLE
scripts/check_license_headers: enforce license on ts/tsx files

### DIFF
--- a/client/web/src/api.ts
+++ b/client/web/src/api.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 let csrfToken: string
 let synoToken: string | undefined // required for synology API requests
 let unraidCsrfToken: string | undefined // required for unraid POST requests (#8062)

--- a/client/web/src/components/acl-tag.tsx
+++ b/client/web/src/components/acl-tag.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 import cx from "classnames"
 import React from "react"
 import Badge from "src/ui/badge"

--- a/client/web/src/components/app.tsx
+++ b/client/web/src/components/app.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 import cx from "classnames"
 import React, { useEffect } from "react"
 import { ReactComponent as TailscaleIcon } from "src/assets/icons/tailscale-icon.svg"

--- a/client/web/src/components/exit-node-selector.tsx
+++ b/client/web/src/components/exit-node-selector.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 import cx from "classnames"
 import React, { useCallback, useMemo, useRef, useState } from "react"
 import { ReactComponent as Check } from "src/assets/icons/check.svg"

--- a/client/web/src/components/login-toggle.tsx
+++ b/client/web/src/components/login-toggle.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 import cx from "classnames"
 import React, { useCallback, useEffect, useState } from "react"
 import { ReactComponent as ChevronDown } from "src/assets/icons/chevron-down.svg"

--- a/client/web/src/components/update-available.tsx
+++ b/client/web/src/components/update-available.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 import React from "react"
 import { VersionInfo } from "src/hooks/self-update"
 import { Link } from "wouter"

--- a/client/web/src/components/views/device-details-view.tsx
+++ b/client/web/src/components/views/device-details-view.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 import cx from "classnames"
 import React from "react"
 import { apiFetch } from "src/api"

--- a/client/web/src/components/views/home-view.tsx
+++ b/client/web/src/components/views/home-view.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 import cx from "classnames"
 import React from "react"
 import { ReactComponent as ArrowRight } from "src/assets/icons/arrow-right.svg"

--- a/client/web/src/components/views/login-view.tsx
+++ b/client/web/src/components/views/login-view.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 import React, { useCallback, useState } from "react"
 import { apiFetch } from "src/api"
 import { ReactComponent as TailscaleIcon } from "src/assets/icons/tailscale-icon.svg"

--- a/client/web/src/components/views/ssh-view.tsx
+++ b/client/web/src/components/views/ssh-view.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 import React from "react"
 import { PrefsUpdate } from "src/hooks/node-data"
 import Toggle from "src/ui/toggle"

--- a/client/web/src/components/views/updating-view.tsx
+++ b/client/web/src/components/views/updating-view.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 import React from "react"
 import { ReactComponent as CheckCircleIcon } from "src/assets/icons/check-circle.svg"
 import { ReactComponent as XCircleIcon } from "src/assets/icons/x-circle.svg"

--- a/client/web/src/hooks/auth.ts
+++ b/client/web/src/hooks/auth.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 import { useCallback, useEffect, useState } from "react"
 import { apiFetch, setSynoToken } from "src/api"
 

--- a/client/web/src/hooks/exit-nodes.ts
+++ b/client/web/src/hooks/exit-nodes.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 import { useEffect, useMemo, useState } from "react"
 import { apiFetch } from "src/api"
 

--- a/client/web/src/hooks/node-data.ts
+++ b/client/web/src/hooks/node-data.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 import { useCallback, useEffect, useState } from "react"
 import { apiFetch, setUnraidCsrfToken } from "src/api"
 import { ExitNode } from "src/hooks/exit-nodes"

--- a/client/web/src/hooks/self-update.ts
+++ b/client/web/src/hooks/self-update.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 import { useCallback, useEffect, useState } from "react"
 import { apiFetch } from "src/api"
 

--- a/client/web/src/index.tsx
+++ b/client/web/src/index.tsx
@@ -1,3 +1,13 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Preserved js license comment for web client app.
+/**
+ * @license
+ * Copyright (c) Tailscale Inc & AUTHORS
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 import React from "react"
 import { createRoot } from "react-dom/client"
 import App from "src/components/app"

--- a/client/web/src/ui/badge.tsx
+++ b/client/web/src/ui/badge.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 import cx from "classnames"
 import React, { HTMLAttributes } from "react"
 

--- a/client/web/src/ui/collapsible.tsx
+++ b/client/web/src/ui/collapsible.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 import * as Primitive from "@radix-ui/react-collapsible"
 import React, { useState } from "react"
 import { ReactComponent as ChevronDown } from "src/assets/icons/chevron-down.svg"

--- a/client/web/src/ui/input.tsx
+++ b/client/web/src/ui/input.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 import cx from "classnames"
 import React, { InputHTMLAttributes } from "react"
 

--- a/client/web/src/ui/popover.tsx
+++ b/client/web/src/ui/popover.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 import * as PopoverPrimitive from "@radix-ui/react-popover"
 import cx from "classnames"
 import React, { ReactNode } from "react"

--- a/client/web/src/ui/profile-pic.tsx
+++ b/client/web/src/ui/profile-pic.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 import cx from "classnames"
 import React from "react"
 

--- a/client/web/src/ui/search-input.tsx
+++ b/client/web/src/ui/search-input.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 import cx from "classnames"
 import React, { forwardRef, InputHTMLAttributes } from "react"
 import { ReactComponent as Search } from "src/assets/icons/search.svg"

--- a/client/web/src/ui/spinner.tsx
+++ b/client/web/src/ui/spinner.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 import cx from "classnames"
 import React, { HTMLAttributes } from "react"
 

--- a/client/web/src/ui/toggle.tsx
+++ b/client/web/src/ui/toggle.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 import cx from "classnames"
 import React, { ChangeEvent } from "react"
 

--- a/cmd/tsconnect/src/lib/ssh.ts
+++ b/cmd/tsconnect/src/lib/ssh.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 import { Terminal, ITerminalOptions } from "xterm"
 import { FitAddon } from "xterm-addon-fit"
 import { WebLinksAddon } from "xterm-addon-web-links"

--- a/scripts/check_license_headers.sh
+++ b/scripts/check_license_headers.sh
@@ -26,7 +26,7 @@ if [ $# != 1 ]; then
 fi
 
 fail=0
-for file in $(find $1 -name '*.go' -not -path '*/.git/*'); do
+for file in $(find $1 \( -name '*.go' -or -name '*.tsx' -or -name '*.ts' -not -name '*.config.ts' \) -not -path '*/.git/*' -not -path '*/node_modules/*'); do
     case $file in
         $1/tempfork/*)
             # Skip, tempfork of third-party code


### PR DESCRIPTION
Enforcing inclusion of our OSS license at the top of .ts and .tsx files. Also updates any relevant files in the repo that were previously missing the license comment. An additional `@license` comment is added to client/web/src/index.tsx to preserve the license in generated Javascript.

Updates #10261