### PR TITLE
client/web: skip check mode for non-tailscale.com control servers

### DIFF
--- a/client/web/auth.go
+++ b/client/web/auth.go
@@ -9,6 +9,8 @@ import (
 	"encoding/base64"
 	"errors"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"tailscale.com/client/tailscale/apitype"
@@ -148,10 +150,6 @@ func (s *Server) getSession(r *http.Request) (*browserSession, *apitype.WhoIsRes
 // and stores it back to the session cache. Creating of a new session includes
 // generating a new auth URL from the control server.
 func (s *Server) newSession(ctx context.Context, src *apitype.WhoIsResponse) (*browserSession, error) {
-	a, err := s.newAuthURL(ctx, src.Node.ID)
-	if err != nil {
-		return nil, err
-	}
 	sid, err := s.newSessionID()
 	if err != nil {
 		return nil, err
@@ -160,12 +158,42 @@ func (s *Server) newSession(ctx context.Context, src *apitype.WhoIsResponse) (*b
 		ID:      sid,
 		SrcNode: src.Node.ID,
 		SrcUser: src.UserProfile.ID,
-		AuthID:  a.ID,
-		AuthURL: a.URL,
 		Created: s.timeNow(),
 	}
+
+	if s.controlSupportsCheckMode(ctx) {
+		// control supports check mode, so get a new auth URL and return.
+		a, err := s.newAuthURL(ctx, src.Node.ID)
+		if err != nil {
+			return nil, err
+		}
+		session.AuthID = a.ID
+		session.AuthURL = a.URL
+	} else {
+		// control does not support check mode, so there is no additional auth we can do.
+		session.Authenticated = true
+	}
+
 	s.browserSessions.Store(sid, session)
 	return session, nil
+}
+
+// controlSupportsCheckMode returns whether the current control server supports web client check mode.
+// We assume that only "tailscale.com" control servers support check mode.
+// This allows the web client to be used with non-standard control servers.
+// If an error occurs getting the control URL, this method returns true to fail closed.
+//
+// TODO(juanfont/headscale#1623): adjust or remove this when headscale supports check mode.
+func (s *Server) controlSupportsCheckMode(ctx context.Context) bool {
+	prefs, err := s.lc.GetPrefs(ctx)
+	if err != nil {
+		return true
+	}
+	controlURL, err := url.Parse(prefs.ControlURL)
+	if err != nil {
+		return true
+	}
+	return strings.HasSuffix(controlURL.Host, ".tailscale.com")
 }
 
 // awaitUserAuth blocks until the given session auth has been completed

--- a/client/web/auth.go
+++ b/client/web/auth.go
@@ -178,7 +178,7 @@ func (s *Server) newSession(ctx context.Context, src *apitype.WhoIsResponse) (*b
 	return session, nil
 }
 
-// controlSupportsCheckMode returns whether the current control server supports web client check mode.
+// controlSupportsCheckMode returns whether the current control server supports web client check mode, to verify a user's identity.
 // We assume that only "tailscale.com" control servers support check mode.
 // This allows the web client to be used with non-standard control servers.
 // If an error occurs getting the control URL, this method returns true to fail closed.

--- a/client/web/src/hooks/auth.ts
+++ b/client/web/src/hooks/auth.ts
@@ -55,10 +55,10 @@ export default function useAuth() {
       .then((d) => {
         if (d.authUrl) {
           window.open(d.authUrl, "_blank")
-          // refresh data when auth complete
-          apiFetch("/auth/session/wait", "GET").then(() => loadAuth())
+          return apiFetch("/auth/session/wait", "GET")
         }
       })
+      .then(() => loadAuth())
       .catch((error) => {
         console.error(error)
       })


### PR DESCRIPTION
Only enforce check mode if the control server URL ends in ".tailscale.com".  This allows the web client to be used with headscale (or other) control servers while we work with the project to add check mode support (tracked in juanfont/headscale#1623).

Updates #10261

I don't *love* all of the string pointers in the tests, but it does seem to work fine and is consistent with how we do this in some other tests.  It does mean that we have to be careful not to run these test cases in parallel, but that's probably fine.