### PR TITLE
ipn/ipnstate: add AllowedIPs to PeerStatus

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -893,6 +893,10 @@ func peerStatusFromNode(ps *ipnstate.PeerStatus, n tailcfg.NodeView) {
 		v := n.PrimaryRoutes()
 		ps.PrimaryRoutes = &v
 	}
+	if n.AllowedIPs().Len() != 0 {
+		v := n.AllowedIPs()
+		ps.AllowedIPs = &v
+	}
 
 	if n.Expired() {
 		ps.Expired = true

--- a/ipn/ipnstate/ipnstate.go
+++ b/ipn/ipnstate/ipnstate.go
@@ -216,6 +216,8 @@ type PeerStatus struct {
 
 	// TailscaleIPs are the IP addresses assigned to the node.
 	TailscaleIPs []netip.Addr
+	// AllowedIPs are IP addresses allowed to route to this node.
+	AllowedIPs *views.Slice[netip.Prefix] `json:",omitempty"`
 
 	// Tags are the list of ACL tags applied to this node.
 	// See tailscale.com/tailcfg#Node.Tags for more information.
@@ -413,6 +415,9 @@ func (sb *StatusBuilder) AddPeer(peer key.NodePublic, st *PeerStatus) {
 	}
 	if v := st.PrimaryRoutes; v != nil && !v.IsNil() {
 		e.PrimaryRoutes = v
+	}
+	if v := st.AllowedIPs; v != nil && !v.IsNil() {
+		e.AllowedIPs = v
 	}
 	if v := st.Tags; v != nil && !v.IsNil() {
 		e.Tags = v


### PR DESCRIPTION
Adds AllowedIPs to PeerStatus, allowing for easier lookup of the routes allowed to be routed to a node. Will be using the AllowedIPs of the self node from the web client interface to display approval status of advertised routes.

Updates #10261