### PR TITLE
cmd/tailscale,ipn/ipnlocal: pass available update as health message

### DIFF
--- a/cmd/tailscale/cli/status.go
+++ b/cmd/tailscale/cli/status.go
@@ -25,7 +25,6 @@ import (
 	"tailscale.com/net/interfaces"
 	"tailscale.com/util/cmpx"
 	"tailscale.com/util/dnsname"
-	"tailscale.com/version"
 )
 
 var statusCmd = &ffcli.Command{
@@ -237,13 +236,6 @@ func runStatus(ctx context.Context, args []string) error {
 		printHealth()
 	}
 	printFunnelStatus(ctx)
-	if cv := st.ClientVersion; cv != nil && !cv.RunningLatest && cv.LatestVersion != "" {
-		if cv.UrgentSecurityUpdate {
-			printf("# Security update available: %v -> %v, run `tailscale update` or `tailscale set --auto-update` to update.\n", version.Short(), cv.LatestVersion)
-		} else {
-			printf("# Update available: %v -> %v, run `tailscale update` or `tailscale set --auto-update` to update.\n", version.Short(), cv.LatestVersion)
-		}
-	}
 	return nil
 }
 

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -501,7 +501,6 @@ func runUp(ctx context.Context, cmd string, args []string, upArgs upArgsT) (retE
 	startLoginInteractive := func() { loginOnce.Do(func() { localClient.StartLoginInteractive(ctx) }) }
 
 	go func() {
-		var cv *tailcfg.ClientVersion
 		for {
 			n, err := watcher.Next()
 			if err != nil {
@@ -511,9 +510,6 @@ func runUp(ctx context.Context, cmd string, args []string, upArgs upArgsT) (retE
 			if n.ErrMessage != nil {
 				msg := *n.ErrMessage
 				fatalf("backend error: %v\n", msg)
-			}
-			if n.ClientVersion != nil {
-				cv = n.ClientVersion
 			}
 			if s := n.State; s != nil {
 				switch *s {
@@ -533,15 +529,6 @@ func runUp(ctx context.Context, cmd string, args []string, upArgs upArgsT) (retE
 					} else if printed {
 						// Only need to print an update if we printed the "please click" message earlier.
 						fmt.Fprintf(Stderr, "Success.\n")
-						if cv != nil && !cv.RunningLatest && cv.LatestVersion != "" {
-							if cv.UrgentSecurityUpdate {
-								fmt.Fprintf(Stderr, "\nSecurity update available: %v -> %v\n", version.Short(), cv.LatestVersion)
-							} else {
-								fmt.Fprintf(Stderr, "\nUpdate available: %v -> %v\n", version.Short(), cv.LatestVersion)
-							}
-							fmt.Fprintln(Stderr, "Changelog: https://tailscale.com/changelog/#client")
-							fmt.Fprintln(Stderr, "Run `tailscale update` or `tailscale set --auto-update` to update")
-						}
 					}
 					select {
 					case running <- true:
@@ -664,7 +651,8 @@ func runUp(ctx context.Context, cmd string, args []string, upArgs upArgsT) (retE
 func upWorthyWarning(s string) bool {
 	return strings.Contains(s, healthmsg.TailscaleSSHOnBut) ||
 		strings.Contains(s, healthmsg.WarnAcceptRoutesOff) ||
-		strings.Contains(s, healthmsg.LockedOut)
+		strings.Contains(s, healthmsg.LockedOut) ||
+		strings.Contains(strings.ToLower(s), "update available: ")
 }
 
 func checkUpWarnings(ctx context.Context) {

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -729,6 +729,13 @@ func (b *LocalBackend) UpdateStatus(sb *ipnstate.StatusBuilder) {
 		s.AuthURL = b.authURLSticky
 		if prefs := b.pm.CurrentPrefs(); prefs.Valid() && prefs.AutoUpdate().Check {
 			s.ClientVersion = b.lastClientVersion
+			if cv := b.lastClientVersion; cv != nil && !cv.RunningLatest && cv.LatestVersion != "" {
+				if cv.UrgentSecurityUpdate {
+					s.Health = append(s.Health, fmt.Sprintf("Security update available: %v -> %v, run `tailscale update` or `tailscale set --auto-update` to update", version.Short(), cv.LatestVersion))
+				} else {
+					s.Health = append(s.Health, fmt.Sprintf("Update available: %v -> %v, run `tailscale update` or `tailscale set --auto-update` to update", version.Short(), cv.LatestVersion))
+				}
+			}
 		}
 		if err := health.OverallError(); err != nil {
 			switch e := err.(type) {


### PR DESCRIPTION
To be consistent with the formatting of other warnings, pass available update health message instead of handling ClientVersion in the CLI.

Fixes #10312