### PR TITLE
client/web: indicate if ACLs prevent access

### DIFF
--- a/client/tailscale/localclient.go
+++ b/client/tailscale/localclient.go
@@ -1332,6 +1332,15 @@ func (lc *LocalClient) DebugDERPRegion(ctx context.Context, regionIDOrCode strin
 	return decodeJSON[*ipnstate.DebugDERPRegionReport](body)
 }
 
+// DebugPacketFilterRules returns the packet filter rules for the current device.
+func (lc *LocalClient) DebugPacketFilterRules(ctx context.Context) ([]tailcfg.FilterRule, error) {
+	body, err := lc.send(ctx, "POST", "/localapi/v0/debug-packet-filter-rules", 200, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error %w: %s", err, body)
+	}
+	return decodeJSON[[]tailcfg.FilterRule](body)
+}
+
 // DebugSetExpireIn marks the current node key to expire in d.
 //
 // This is meant primarily for debug and testing.

--- a/client/web/src/hooks/node-data.ts
+++ b/client/web/src/hooks/node-data.ts
@@ -36,6 +36,7 @@ export type NodeData = {
   ControlAdminURL: string
   LicensesURL: string
   Features: { [key in Feature]: boolean } // value is true if given feature is available on this client
+  ACLAllowsAnyIncomingTraffic: boolean
 }
 
 type NodeState =


### PR DESCRIPTION
Use the packet filter rules to determine if any device is allowed to connect on port 5252.  This does not check whether a specific device can connect (since we typically don't know the source device when this is used).  Nor does it specifically check for wide-open ACLs, which is something we may provide a warning about in the future.

Update the login popover content to display information when the src device is unable to connect to the dst device over its Tailscale IP. If we know it's an ACL issue, mention that, otherwise list a couple of things to check. In both cases, link to a placeholder URL to get more information about web client connection issues.

Updates #10261

This doesn't have any tests yet, but I wanted to go ahead and get it out for review.  I can easily test the packet filter check by mocking that localapi endpoint.  For the frontend changes, I tested them pretty extensively locally.