### PR TITLE
clientupdate: cleanup tailscale binary copies on Windows

### DIFF
--- a/clientupdate/clientupdate.go
+++ b/clientupdate/clientupdate.go
@@ -765,6 +765,7 @@ you can run the command prompt as Administrator one of these ways:
 	up.Logf("authenticode verification succeeded")
 
 	up.Logf("making tailscale.exe copy to switch to...")
+	up.cleanupOldDownloads(filepath.Join(os.TempDir(), "tailscale-updater-*.exe"))
 	selfOrig, selfCopy, err := makeSelfCopy()
 	if err != nil {
 		return err


### PR DESCRIPTION
When updating on Windows, we make a copy of the tailscale.exe file in a temp directory to perform the update, because the original tailscale.exe gets deleted during the update.

This can eat up disk space if a machine is stuck doing repeated failed update attempts. Clean up old copies explicitly before making a new one, same as we do with MSIs.

Updates #10082