### PR TITLE
linuxfw,wgengine/route,ipn: add c2n and nodeattrs to control linux netfilter

### DIFF
--- a/cmd/containerboot/main.go
+++ b/cmd/containerboot/main.go
@@ -91,7 +91,7 @@ func newNetfilterRunner(logf logger.Logf) (linuxfw.NetfilterRunner, error) {
 	if defaultBool("TS_TEST_FAKE_NETFILTER", false) {
 		return linuxfw.NewFakeIPTablesRunner(), nil
 	}
-	return linuxfw.New(logf)
+	return linuxfw.New(logf, "")
 }
 
 func main() {

--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -813,6 +813,10 @@ func TestPrefFlagMapping(t *testing.T) {
 		case "RunWebClient":
 			// TODO(tailscale/corp#14335): Currently behind a feature flag.
 			continue
+		case "NetfilterKind":
+			// Handled by TS_DEBUG_FIREWALL_MODE env var, we don't want to have
+			// a CLI flag for this. The Pref is used by c2n.
+			continue
 		}
 		t.Errorf("unexpected new ipn.Pref field %q is not handled by up.go (see addPrefFlagMapping and checkForAccidentalSettingReverts)", prefName)
 	}

--- a/control/controlknobs/controlknobs.go
+++ b/control/controlknobs/controlknobs.go
@@ -56,6 +56,14 @@ type Knobs struct {
 	// SilentDisco is whether the node should suppress disco heartbeats to its
 	// peers.
 	SilentDisco atomic.Bool
+
+	// LinuxForceIPTables is whether the node should use iptables for Linux
+	// netfiltering, unless overridden by the user.
+	LinuxForceIPTables atomic.Bool
+
+	// LinuxForceNfTables is whether the node should use nftables for Linux
+	// netfiltering, unless overridden by the user.
+	LinuxForceNfTables atomic.Bool
 }
 
 // UpdateFromNodeAttributes updates k (if non-nil) based on the provided self
@@ -79,6 +87,8 @@ func (k *Knobs) UpdateFromNodeAttributes(selfNodeAttrs []tailcfg.NodeCapability,
 		peerMTUEnable                 = has(tailcfg.NodeAttrPeerMTUEnable)
 		dnsForwarderDisableTCPRetries = has(tailcfg.NodeAttrDNSForwarderDisableTCPRetries)
 		silentDisco                   = has(tailcfg.NodeAttrSilentDisco)
+		forceIPTables                 = has(tailcfg.NodeAttrLinuxMustUseIPTables)
+		forceNfTables                 = has(tailcfg.NodeAttrLinuxMustUseNfTables)
 	)
 
 	if has(tailcfg.NodeAttrOneCGNATEnable) {
@@ -97,6 +107,8 @@ func (k *Knobs) UpdateFromNodeAttributes(selfNodeAttrs []tailcfg.NodeCapability,
 	k.PeerMTUEnable.Store(peerMTUEnable)
 	k.DisableDNSForwarderTCPRetries.Store(dnsForwarderDisableTCPRetries)
 	k.SilentDisco.Store(silentDisco)
+	k.LinuxForceIPTables.Store(forceIPTables)
+	k.LinuxForceNfTables.Store(forceNfTables)
 }
 
 // AsDebugJSON returns k as something that can be marshalled with json.Marshal
@@ -116,5 +128,7 @@ func (k *Knobs) AsDebugJSON() map[string]any {
 		"PeerMTUEnable":                 k.PeerMTUEnable.Load(),
 		"DisableDNSForwarderTCPRetries": k.DisableDNSForwarderTCPRetries.Load(),
 		"SilentDisco":                   k.SilentDisco.Load(),
+		"LinuxForceIPTables":            k.LinuxForceIPTables.Load(),
+		"LinuxForceNfTables":            k.LinuxForceNfTables.Load(),
 	}
 }

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -55,6 +55,7 @@ var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	AutoUpdate             AutoUpdatePrefs
 	AppConnector           AppConnectorPrefs
 	PostureChecking        bool
+	NetfilterKind          string
 	Persist                *persist.Persist
 }{})
 

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -90,6 +90,7 @@ func (v PrefsView) ProfileName() string                   { return v.ж.ProfileN
 func (v PrefsView) AutoUpdate() AutoUpdatePrefs           { return v.ж.AutoUpdate }
 func (v PrefsView) AppConnector() AppConnectorPrefs       { return v.ж.AppConnector }
 func (v PrefsView) PostureChecking() bool                 { return v.ж.PostureChecking }
+func (v PrefsView) NetfilterKind() string                 { return v.ж.NetfilterKind }
 func (v PrefsView) Persist() persist.PersistView          { return v.ж.Persist.View() }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
@@ -119,6 +120,7 @@ var _PrefsViewNeedsRegeneration = Prefs(struct {
 	AutoUpdate             AutoUpdatePrefs
 	AppConnector           AppConnectorPrefs
 	PostureChecking        bool
+	NetfilterKind          string
 	Persist                *persist.Persist
 }{})
 

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -270,6 +270,9 @@ type LocalBackend struct {
 	currentUser         ipnauth.WindowsToken
 	selfUpdateProgress  []ipnstate.UpdateProgress
 	lastSelfUpdateState ipnstate.SelfUpdateStatus
+	// capForcedNetfilter is the netfilter that control instructs Linux clients
+	// to use, unless overridden locally.
+	capForcedNetfilter string
 
 	// ServeConfig fields. (also guarded by mu)
 	lastServeConfJSON   mem.RO              // last JSON that was parsed into serveConfig
@@ -3887,12 +3890,21 @@ func (b *LocalBackend) routerConfig(cfg *wgcfg.Config, prefs ipn.PrefsView, oneC
 		singleRouteThreshold = 1
 	}
 
+	netfilterKind := b.capForcedNetfilter
+	if prefs.NetfilterKind() != "" {
+		if b.capForcedNetfilter != "" {
+			b.logf("nodeattr netfilter preference %s overridden by c2n pref %s", b.capForcedNetfilter, prefs.NetfilterKind())
+		}
+		netfilterKind = prefs.NetfilterKind()
+	}
+
 	rs := &router.Config{
 		LocalAddrs:       unmapIPPrefixes(cfg.Addresses),
 		SubnetRoutes:     unmapIPPrefixes(prefs.AdvertiseRoutes().AsSlice()),
 		SNATSubnetRoutes: !prefs.NoSNAT(),
 		NetfilterMode:    prefs.NetfilterMode(),
 		Routes:           peerRoutes(b.logf, cfg.Peers, singleRouteThreshold),
+		NetfilterKind:    netfilterKind,
 	}
 
 	if distro.Get() == distro.Synology {
@@ -4400,6 +4412,14 @@ func (b *LocalBackend) setNetMapLocked(nm *netmap.NetworkMap) {
 		osshare.SetFileSharingEnabled(fs, b.logf)
 	}
 	b.capFileSharing = fs
+
+	if hasCapability(nm, tailcfg.NodeAttrLinuxMustUseIPTables) {
+		b.capForcedNetfilter = "iptables"
+	} else if hasCapability(nm, tailcfg.NodeAttrLinuxMustUseNfTables) {
+		b.capForcedNetfilter = "nftables"
+	} else {
+		b.capForcedNetfilter = "" // empty string means client can auto-detect
+	}
 
 	b.MagicConn().SetSilentDisco(b.ControlKnobs().SilentDisco.Load())
 

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -45,6 +45,8 @@ func IsLoginServerSynonym(val any) bool {
 }
 
 // Prefs are the user modifiable settings of the Tailscale node agent.
+// When you add a Pref to this struct, remember to add a corresponding
+// field in MaskedPrefs, and check your field for equality in Prefs.Equals().
 type Prefs struct {
 	// ControlURL is the URL of the control server to use.
 	//
@@ -213,6 +215,11 @@ type Prefs struct {
 	// posture checks.
 	PostureChecking bool
 
+	// NetfilterKind specifies what netfilter implementation to use.
+	//
+	// Linux-only.
+	NetfilterKind string
+
 	// The Persist field is named 'Config' in the file for backward
 	// compatibility with earlier versions.
 	// TODO(apenwarr): We should move this out of here, it's not a pref.
@@ -241,6 +248,9 @@ type AppConnectorPrefs struct {
 }
 
 // MaskedPrefs is a Prefs with an associated bitmask of which fields are set.
+// Make sure that the bool you add here maintains the same ordering of fields
+// as the Prefs struct, because the ApplyEdits() function below relies on this
+// ordering to be the same.
 type MaskedPrefs struct {
 	Prefs
 
@@ -269,6 +279,7 @@ type MaskedPrefs struct {
 	AutoUpdateSet             bool `json:",omitempty"`
 	AppConnectorSet           bool `json:",omitempty"`
 	PostureCheckingSet        bool `json:",omitempty"`
+	NetfilterKindSet          bool `json:",omitempty"`
 }
 
 // ApplyEdits mutates p, assigning fields from m.Prefs for each MaskedPrefs
@@ -409,6 +420,9 @@ func (p *Prefs) pretty(goos string) string {
 	if p.OperatorUser != "" {
 		fmt.Fprintf(&sb, "op=%q ", p.OperatorUser)
 	}
+	if p.NetfilterKind != "" {
+		fmt.Fprintf(&sb, "netfilterKind=%s ", p.NetfilterKind)
+	}
 	sb.WriteString(p.AutoUpdate.Pretty())
 	sb.WriteString(p.AppConnector.Pretty())
 	if p.Persist != nil {
@@ -469,7 +483,8 @@ func (p *Prefs) Equals(p2 *Prefs) bool {
 		p.ProfileName == p2.ProfileName &&
 		p.AutoUpdate == p2.AutoUpdate &&
 		p.AppConnector == p2.AppConnector &&
-		p.PostureChecking == p2.PostureChecking
+		p.PostureChecking == p2.PostureChecking &&
+		p.NetfilterKind == p2.NetfilterKind
 }
 
 func (au AutoUpdatePrefs) Pretty() string {

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -60,6 +60,7 @@ func TestPrefsEqual(t *testing.T) {
 		"AutoUpdate",
 		"AppConnector",
 		"PostureChecking",
+		"NetfilterKind",
 		"Persist",
 	}
 	if have := fieldsOf(reflect.TypeOf(Prefs{})); !reflect.DeepEqual(have, prefsHandles) {
@@ -327,6 +328,16 @@ func TestPrefsEqual(t *testing.T) {
 			&Prefs{PostureChecking: false},
 			false,
 		},
+		{
+			&Prefs{NetfilterKind: "iptables"},
+			&Prefs{NetfilterKind: "iptables"},
+			true,
+		},
+		{
+			&Prefs{NetfilterKind: "nftables"},
+			&Prefs{NetfilterKind: ""},
+			false,
+		},
 	}
 	for i, tt := range tests {
 		got := tt.a.Equals(tt.b)
@@ -541,6 +552,20 @@ func TestPrefsPretty(t *testing.T) {
 				AppConnector: AppConnectorPrefs{
 					Advertise: false,
 				},
+			},
+			"linux",
+			`Prefs{ra=false mesh=false dns=false want=false routes=[] nf=off update=off Persist=nil}`,
+		},
+		{
+			Prefs{
+				NetfilterKind: "iptables",
+			},
+			"linux",
+			`Prefs{ra=false mesh=false dns=false want=false routes=[] nf=off netfilterKind=iptables update=off Persist=nil}`,
+		},
+		{
+			Prefs{
+				NetfilterKind: "",
 			},
 			"linux",
 			`Prefs{ra=false mesh=false dns=false want=false routes=[] nf=off update=off Persist=nil}`,

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -122,7 +122,8 @@ type CapabilityVersion int
 //   - 79: 2023-10-05: Client understands UrgentSecurityUpdate in ClientVersion
 //   - 80: 2023-11-16: can handle c2n GET /tls-cert-status
 //   - 81: 2023-11-17: MapResponse.PacketFilters (incremental packet filter updates)
-const CurrentCapabilityVersion CapabilityVersion = 81
+//   - 82: 2023-12-01: Client understands NodeAttrLinuxMustUseIPTables, NodeAttrLinuxMustUseNfTables, c2n /netfilter-kind
+const CurrentCapabilityVersion CapabilityVersion = 82
 
 type StableID string
 

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -2171,6 +2171,16 @@ const (
 	// NodeAttrDNSForwarderDisableTCPRetries disables retrying truncated
 	// DNS queries over TCP if the response is truncated.
 	NodeAttrDNSForwarderDisableTCPRetries NodeCapability = "dns-forwarder-disable-tcp-retries"
+
+	// NodeAttrLinuxMustUseIPTables forces Linux clients to use iptables for
+	// netfilter management.
+	// This cannot be set simultaneously with NodeAttrLinuxMustUseNfTables.
+	NodeAttrLinuxMustUseIPTables NodeCapability = "linux-netfilter?v=iptables"
+
+	// NodeAttrLinuxMustUseNfTables forces Linux clients to use nftables for
+	// netfilter management.
+	// This cannot be set simultaneously with NodeAttrLinuxMustUseIPTables.
+	NodeAttrLinuxMustUseNfTables NodeCapability = "linux-netfilter?v=nftables"
 )
 
 // SetDNSRequest is a request to add a DNS record.

--- a/util/linuxfw/nftables_runner.go
+++ b/util/linuxfw/nftables_runner.go
@@ -511,10 +511,13 @@ type NetfilterRunner interface {
 	ClampMSSToPMTU(tun string, addr netip.Addr) error
 }
 
-// New creates a NetfilterRunner using either nftables or iptables.
-// As nftables is still experimental, iptables will be used unless TS_DEBUG_USE_NETLINK_NFTABLES is set.
-func New(logf logger.Logf) (NetfilterRunner, error) {
-	mode := detectFirewallMode(logf)
+// New creates a NetfilterRunner, auto-detecting whether to use
+// nftables or iptables.
+// As nftables is still experimental, iptables will be used unless
+// either the TS_DEBUG_FIREWALL_MODE environment variable, or the prefHint
+// parameter, is set to one of "nftables" or "auto".
+func New(logf logger.Logf, prefHint string) (NetfilterRunner, error) {
+	mode := detectFirewallMode(logf, prefHint)
 	switch mode {
 	case FirewallModeIPTables:
 		return newIPTablesRunner(logf)

--- a/wgengine/router/router.go
+++ b/wgengine/router/router.go
@@ -76,6 +76,7 @@ type Config struct {
 	SubnetRoutes     []netip.Prefix         // subnets being advertised to other Tailscale nodes
 	SNATSubnetRoutes bool                   // SNAT traffic to local subnets
 	NetfilterMode    preftype.NetfilterMode // how much to manage netfilter rules
+	NetfilterKind    string                 // what kind of netfilter to use (nftables, iptables)
 }
 
 func (a *Config) Equal(b *Config) bool {

--- a/wgengine/router/router_linux_test.go
+++ b/wgengine/router/router_linux_test.go
@@ -331,7 +331,8 @@ ip route add throw 192.168.0.0/24 table 52` + basic,
 	defer mon.Close()
 
 	fake := NewFakeOS(t)
-	router, err := newUserspaceRouterAdvanced(t.Logf, "tailscale0", mon, fake.nfr, fake)
+	router, err := newUserspaceRouterAdvanced(t.Logf, "tailscale0", mon, fake)
+	router.(*linuxRouter).nfr = fake.nfr
 	if err != nil {
 		t.Fatalf("failed to create router: %v", err)
 	}

--- a/wgengine/router/router_test.go
+++ b/wgengine/router/router_test.go
@@ -23,6 +23,7 @@ func TestConfigEqual(t *testing.T) {
 	testedFields := []string{
 		"LocalAddrs", "Routes", "LocalRoutes", "NewMTU",
 		"SubnetRoutes", "SNATSubnetRoutes", "NetfilterMode",
+		"NetfilterKind",
 	}
 	configType := reflect.TypeOf(Config{})
 	configFields := []string{}


### PR DESCRIPTION
This allows for a break-glass control to remotely revert to one netfilter in case the other starts causing issues, without issuing a patch update.

Updates corp#14029.