### PR TITLE
net/interfaces: ensure we return valid 'self' IP in LikelyHomeRouterIP

### DIFF
--- a/net/interfaces/interfaces.go
+++ b/net/interfaces/interfaces.go
@@ -557,6 +557,15 @@ func LikelyHomeRouterIP() (gateway, myIP netip.Addr, ok bool) {
 			// always return an IPv4 address.
 			return
 		}
+
+		// If this prefix ("interface") doesn't contain the gateway,
+		// then we skip it; this can happen if we have multiple valid
+		// interfaces and the interface with the route to the internet
+		// is ordered after another valid+running interface.
+		if !pfx.Contains(gateway) {
+			return
+		}
+
 		if gateway.IsPrivate() && ip.IsPrivate() {
 			myIP = ip
 			ok = true


### PR DESCRIPTION
Before this fix, LikelyHomeRouterIP could return a 'self' IP that doesn't correspond to the gateway address, since it picks the first private address when iterating over the set interfaces as the 'self' IP, without checking that the address corresponds with the previously-detected gateway.

This behaviour was introduced by accident in aaf2df7, where we deleted the following code:

    for _, prefix := range privatev4s {
        if prefix.Contains(gateway) && prefix.Contains(ip) {
            myIP = ip
            ok = true
            return
        }
    }

Other than checking that 'gateway' and 'ip' were private IP addresses (which were correctly replaced with a call to the netip.Addr.IsPrivate method), it also implicitly checked that both 'gateway' and 'ip' were a part of the *same* prefix, and thus likely to be the same interface.

Restore that behaviour by explicitly checking pfx.Contains(gateway), which, given that the 'ip' variable is derived from our prefix 'pfx', ensures that the 'self' IP will correspond to the returned 'gateway'.

Fixes #10466


Change-Id: Iddd2ee70cefb9fb40071986fefeace9ca2441ee6