### PR TITLE
util/syspolicy: rename incorrectly named policy keys

### DIFF
--- a/util/syspolicy/policy_keys.go
+++ b/util/syspolicy/policy_keys.go
@@ -21,8 +21,8 @@ const (
 	EnableIncomingConnections Key = "AllowIncomingConnections"
 	EnableServerMode          Key = "UnattendedMode"
 	ExitNodeAllowLANAccess    Key = "ExitNodeAllowLANAccess"
-	EnableTailscaleDNS        Key = "EnableTailscaleDNSSettings"
-	EnableTailscaleSubnets    Key = "EnableTailscaleSubnets"
+	EnableTailscaleDNS        Key = "UseTailscaleDNSSettings"
+	EnableTailscaleSubnets    Key = "UseTailscaleSubnets"
 
 	// Keys with a string value that controls visibility: "show", "hide".
 	// The default is "show" unless otherwise stated.


### PR DESCRIPTION
These keys were intended to match the Apple platforms, but accidentally used the wrong name.

Updates ENG-2133

Change-Id: I9ed7a17919e34e2d8896a5c64efc4d0c0003166e