### PR TITLE
client/web: use IPv4 instead of IP in login view

### DIFF
--- a/client/web/src/components/views/login-view.tsx
+++ b/client/web/src/components/views/login-view.tsx
@@ -49,7 +49,7 @@ export default function LoginView({
             Connect to Tailscale
           </Button>
         </>
-      ) : data.IP ? (
+      ) : data.IPv4 ? (
         <>
           <div className="mb-6">
             <p className="text-gray-700">


### PR DESCRIPTION
The IP property in node data was renamed to IPv4 but refactoring the usage of the property was missed in this file.

Updates https://github.com/tailscale/tailscale/issues/10261