### PR TITLE
client/web: fix exit node selector styling

### DIFF
--- a/client/web/src/components/exit-node-selector.tsx
+++ b/client/web/src/components/exit-node-selector.tsx
@@ -205,10 +205,11 @@ function ExitNodeSelectorInner({
   )
 
   return (
-    <div className="w-[calc(var(--radix-popover-trigger-width)-16px)] py-1 rounded-lg shadow">
+    <div className="w-[calc(var(--radix-popover-trigger-width)-16px)] pb-1 rounded-lg shadow">
       <SearchInput
         name="exit-node-search"
-        inputClassName="w-full px-4 py-2"
+        inputClassName="w-full px-4 py-2 border-none rounded-b-none"
+        autoFocus
         autoCorrect="off"
         autoComplete="off"
         autoCapitalize="off"
@@ -231,7 +232,7 @@ function ExitNodeSelectorInner({
               group.nodes.length > 0 && (
                 <div
                   key={group.id}
-                  className="pb-1 mb-1 border-b last:border-b-0 last:mb-0"
+                  className="pb-1 mb-1 border-b last:border-b-0 border-gray-200 last:mb-0"
                 >
                   {group.name && (
                     <div className="px-4 py-2 text-gray-500 text-xs font-medium uppercase tracking-wide">


### PR DESCRIPTION
Remove padding on top of search bar, remove rounded corners of bottom border of earch bar, and add auto focus.

Updates #10261

Before
![Screenshot 2023-12-06 at 2 14 56 PM](https://github.com/tailscale/tailscale/assets/9019214/e37d2dd2-148a-479d-86a5-257a4cf6cc15)

After
![Screenshot 2023-12-06 at 2 14 29 PM](https://github.com/tailscale/tailscale/assets/9019214/c697085c-38f6-4092-8e4e-759880365b68)
