### PR TITLE
wgengine/router: implement UpdateMagicsockPort for CallbackRouter

### DIFF
--- a/wgengine/router/callback.go
+++ b/wgengine/router/callback.go
@@ -56,6 +56,13 @@ func (r *CallbackRouter) Set(rcfg *Config) error {
 	return r.SetBoth(r.rcfg, r.dcfg)
 }
 
+// UpdateMagicsockPort implements the Router interface. This implementation
+// does nothing and returns nil because this router does not currently need
+// to know what the magicsock UDP port is.
+func (r *CallbackRouter) UpdateMagicsockPort(_ uint16, _ string) error {
+	return nil
+}
+
 // SetDNS implements dns.OSConfigurator.
 func (r *CallbackRouter) SetDNS(dcfg dns.OSConfig) error {
 	r.mu.Lock()


### PR DESCRIPTION
Updates #9084.

This addition to the router interface was only needed for the Linux router, so an implementation that does nothing on other platforms is okay.