### PR TITLE
ipn/ipnlocal, util/syspolicy: add auto update policy

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1264,6 +1264,16 @@ var preferencePolicies = []preferencePolicyInfo{
 		get: func(p ipn.PrefsView) bool { return p.RouteAll() },
 		set: func(p *ipn.Prefs, v bool) { p.RouteAll = v },
 	},
+	{
+		key: syspolicy.CheckUpdates,
+		get: func(p ipn.PrefsView) bool { return p.AutoUpdate().Check },
+		set: func(p *ipn.Prefs, v bool) { p.AutoUpdate.Check = v },
+	},
+	{
+		key: syspolicy.ApplyUpdates,
+		get: func(p ipn.PrefsView) bool { return p.AutoUpdate().Apply },
+		set: func(p *ipn.Prefs, v bool) { p.AutoUpdate.Apply = v },
+	},
 }
 
 // applySysPolicy overwrites configured preferences with policies that may be

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -1775,6 +1775,82 @@ func TestApplySysPolicy(t *testing.T) {
 				syspolicy.ControlURL: "set",
 			},
 		},
+		{
+			name: "enable AutoUpdate apply does not unset check",
+			prefs: ipn.Prefs{
+				AutoUpdate: ipn.AutoUpdatePrefs{
+					Check: true,
+					Apply: false,
+				},
+			},
+			wantPrefs: ipn.Prefs{
+				AutoUpdate: ipn.AutoUpdatePrefs{
+					Check: true,
+					Apply: true,
+				},
+			},
+			wantAnyChange: true,
+			stringPolicies: map[syspolicy.Key]string{
+				syspolicy.ApplyUpdates: "always",
+			},
+		},
+		{
+			name: "disable AutoUpdate apply does not unset check",
+			prefs: ipn.Prefs{
+				AutoUpdate: ipn.AutoUpdatePrefs{
+					Check: true,
+					Apply: true,
+				},
+			},
+			wantPrefs: ipn.Prefs{
+				AutoUpdate: ipn.AutoUpdatePrefs{
+					Check: true,
+					Apply: false,
+				},
+			},
+			wantAnyChange: true,
+			stringPolicies: map[syspolicy.Key]string{
+				syspolicy.ApplyUpdates: "never",
+			},
+		},
+		{
+			name: "enable AutoUpdate check does not unset apply",
+			prefs: ipn.Prefs{
+				AutoUpdate: ipn.AutoUpdatePrefs{
+					Check: false,
+					Apply: true,
+				},
+			},
+			wantPrefs: ipn.Prefs{
+				AutoUpdate: ipn.AutoUpdatePrefs{
+					Check: true,
+					Apply: true,
+				},
+			},
+			wantAnyChange: true,
+			stringPolicies: map[syspolicy.Key]string{
+				syspolicy.CheckUpdates: "always",
+			},
+		},
+		{
+			name: "disable AutoUpdate check does not unset apply",
+			prefs: ipn.Prefs{
+				AutoUpdate: ipn.AutoUpdatePrefs{
+					Check: true,
+					Apply: true,
+				},
+			},
+			wantPrefs: ipn.Prefs{
+				AutoUpdate: ipn.AutoUpdatePrefs{
+					Check: false,
+					Apply: true,
+				},
+			},
+			wantAnyChange: true,
+			stringPolicies: map[syspolicy.Key]string{
+				syspolicy.CheckUpdates: "never",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/util/syspolicy/policy_keys.go
+++ b/util/syspolicy/policy_keys.go
@@ -24,6 +24,13 @@ const (
 	ExitNodeAllowLANAccess    Key = "ExitNodeAllowLANAccess"
 	EnableTailscaleDNS        Key = "UseTailscaleDNSSettings"
 	EnableTailscaleSubnets    Key = "UseTailscaleSubnets"
+	// CheckUpdates is the key to signal if the updater should periodically
+	// check for updates.
+	CheckUpdates Key = "CheckUpdates"
+	// ApplyUpdates is the key to signal if updates should be automatically
+	// installed. Its value is "InstallUpdates" because of an awkwardly-named
+	// visibility option "ApplyUpdates" on MacOS.
+	ApplyUpdates Key = "InstallUpdates"
 
 	// Keys with a string value that controls visibility: "show", "hide".
 	// The default is "show" unless otherwise stated. Enforcement of these
@@ -36,7 +43,11 @@ const (
 	RunExitNodeVisibility     Key = "RunExitNode"
 	PreferencesMenuVisibility Key = "PreferencesMenu"
 	ExitNodeMenuVisibility    Key = "ExitNodesPicker"
-	AutoUpdateVisibility      Key = "ApplyUpdates"
+	// AutoUpdateVisibility is the key to signal if the menu item for automatic
+	// installation of updates should be visible. It is only used by macsys
+	// installations and uses the Sparkle naming convention, even though it does
+	// not actually control updates, merely the UI for that setting.
+	AutoUpdateVisibility Key = "ApplyUpdates"
 
 	// Keys with a string value formatted for use with time.ParseDuration().
 	KeyExpirationNoticeTime Key = "KeyExpirationNotice" // default 24 hours


### PR DESCRIPTION
Due to the Sparkle preference naming convention, macsys already has a policy key named "ApplyUpdates" that merely shows or hides the menu item that controls if auto updates are installed, rather than directly controlling the setting.

For other platforms, we are going to use "InstallUpdates" instead because it seemed better than the other options that were considered.

Change-Id: Ia6a125beb6b4563d380c6162637ce4088f1117a0