### PR TITLE
client/web: add security attributes on session cookie

### DIFF
--- a/client/web/web.go
+++ b/client/web/web.go
@@ -480,11 +480,19 @@ func (s *Server) serveAPIAuthSessionNew(w http.ResponseWriter, r *http.Request) 
 		}
 		// Set the cookie on browser.
 		http.SetCookie(w, &http.Cookie{
-			Name:    sessionCookieName,
-			Value:   session.ID,
-			Raw:     session.ID,
-			Path:    "/",
-			Expires: session.expires(),
+			Name:     sessionCookieName,
+			Value:    session.ID,
+			Raw:      session.ID,
+			Path:     "/",
+			HttpOnly: true,
+			SameSite: http.SameSiteStrictMode,
+			Expires:  session.expires(),
+			// We can't set Secure to true because we serve over HTTP
+			// (but only on Tailscale IPs, hence over encrypted
+			// connections that a LAN-local attacker cannot sniff).
+			// In the future, we could support HTTPS requests using
+			// the full MagicDNS hostname, and could set this.
+			// Secure:  true,
 		})
 	}
 


### PR DESCRIPTION
Limit cookies to HTTP requests (not accessible from javascript). Set SameSite to "Lax", which is similar to "Strict" but allows for cookies to be included in requests that come from offsite links.  This will be necessary when we link to the web client from the admin console.

Updates #10261
Fixes tailscale/corp#16265