### PR TITLE
client/web: always run platform auth for login mode

### DIFF
--- a/client/web/web.go
+++ b/client/web/web.go
@@ -406,7 +406,7 @@ func (s *Server) serveAPIAuth(w http.ResponseWriter, r *http.Request) {
 
 	session, whois, err := s.getSession(r)
 	switch {
-	case err != nil && errors.Is(err, errNotUsingTailscale):
+	case s.mode == LoginServerMode || errors.Is(err, errNotUsingTailscale):
 		// not using tailscale, so perform platform auth
 		switch distro.Get() {
 		case distro.Synology:


### PR DESCRIPTION
Even if connected to the login client over tailscale, still check platform auth so the browser can obtain the tokens it needs to make platform requests complete successfully.

Updates #10261