### PR TITLE
ipn/ipnlocal, util/syspolicy: make run exit node a preference option

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1274,6 +1274,11 @@ var preferencePolicies = []preferencePolicyInfo{
 		get: func(p ipn.PrefsView) bool { return p.AutoUpdate().Apply },
 		set: func(p *ipn.Prefs, v bool) { p.AutoUpdate.Apply = v },
 	},
+	{
+		key: syspolicy.EnableRunExitNode,
+		get: func(p ipn.PrefsView) bool { return p.AdvertisesExitNode() },
+		set: func(p *ipn.Prefs, v bool) { p.SetAdvertiseExitNode(v) },
+	},
 }
 
 // applySysPolicy overwrites configured preferences with policies that may be

--- a/util/syspolicy/policy_keys.go
+++ b/util/syspolicy/policy_keys.go
@@ -18,7 +18,8 @@ const (
 
 	// Keys with a string value that specifies an option: "always", "never", "user-decides".
 	// The default is "user-decides" unless otherwise stated. Enforcement of
-	// these policies is typically performed in ipnlocal.applySysPolicy().
+	// these policies is typically performed in ipnlocal.applySysPolicy(). GUIs
+	// typically hide menu items related to policies that are enforced.
 	EnableIncomingConnections Key = "AllowIncomingConnections"
 	EnableServerMode          Key = "UnattendedMode"
 	ExitNodeAllowLANAccess    Key = "ExitNodeAllowLANAccess"
@@ -31,15 +32,23 @@ const (
 	// installed. Its value is "InstallUpdates" because of an awkwardly-named
 	// visibility option "ApplyUpdates" on MacOS.
 	ApplyUpdates Key = "InstallUpdates"
+	// EnableRunExitNode controls if the device acts as an exit node. Even when
+	// running as an exit node, the device must be approved by a tailnet
+	// administrator. Its name is slightly awkward because RunExitNodeVisibility
+	// predates this option but is preserved for backwards compatibility.
+	EnableRunExitNode Key = "AdvertiseExitNode"
 
 	// Keys with a string value that controls visibility: "show", "hide".
 	// The default is "show" unless otherwise stated. Enforcement of these
 	// policies is typically performed by the UI code for the relevant operating
 	// system.
-	AdminConsoleVisibility    Key = "AdminConsole"
-	NetworkDevicesVisibility  Key = "NetworkDevices"
-	TestMenuVisibility        Key = "TestMenu"
-	UpdateMenuVisibility      Key = "UpdateMenu"
+	AdminConsoleVisibility   Key = "AdminConsole"
+	NetworkDevicesVisibility Key = "NetworkDevices"
+	TestMenuVisibility       Key = "TestMenu"
+	UpdateMenuVisibility     Key = "UpdateMenu"
+	// RunExitNodeVisibility controls if the "run as exit node" menu item is
+	// visible, without controlling the setting itself. This is preserved for
+	// backwards compatibility but prefer EnableRunExitNode in new deployments.
 	RunExitNodeVisibility     Key = "RunExitNode"
 	PreferencesMenuVisibility Key = "PreferencesMenu"
 	ExitNodeMenuVisibility    Key = "ExitNodesPicker"


### PR DESCRIPTION
Previously, the "RunExitNode" policy merely controlled the visibility of the "run as exit node" menu item, not the setting itself. This migrates that setting to a preference option named "AdvertiseExitNode".

Updates ENG-2138

Change-Id: Ia6a125beb6b4563d380c6162637ce4088f1117a0