### PR TITLE
client/web: fix 500 error after logout

### DIFF
--- a/client/web/web.go
+++ b/client/web/web.go
@@ -601,11 +601,7 @@ func (s *Server) serveGetNodeData(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	filterRules, err := s.lc.DebugPacketFilterRules(r.Context())
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	filterRules, _ := s.lc.DebugPacketFilterRules(r.Context())
 	data := &nodeData{
 		ID:               st.Self.ID,
 		Status:           st.BackendState,


### PR DESCRIPTION
Calling DebugPacketFilterRules fails when the node is not logged in, which was causing 500 errors on the node data endpoint after logging the node out. This change updates to only check the filter rules when the backend state is "Running".

Updates #10261