### PR TITLE
net/netcheck: use DERP frames as a signal for home region liveness

### DIFF
--- a/cmd/tailscale/cli/netcheck.go
+++ b/cmd/tailscale/cli/netcheck.go
@@ -85,7 +85,7 @@ func runNetcheck(ctx context.Context, args []string) error {
 	}
 	for {
 		t0 := time.Now()
-		report, err := c.GetReport(ctx, dm)
+		report, err := c.GetReport(ctx, dm, nil)
 		d := time.Since(t0)
 		if netcheckArgs.verbose {
 			c.Logf("GetReport took %v; err=%v", d.Round(time.Millisecond), err)

--- a/health/health.go
+++ b/health/health.go
@@ -360,11 +360,22 @@ func SetDERPRegionHealth(region int, problem string) {
 	selfCheckLocked()
 }
 
+// NoteDERPRegionReceivedFrame is called to note that a frame was received from
+// the given DERP region at the current time.
 func NoteDERPRegionReceivedFrame(region int) {
 	mu.Lock()
 	defer mu.Unlock()
 	derpRegionLastFrame[region] = time.Now()
 	selfCheckLocked()
+}
+
+// GetDERPRegionReceivedTime returns the last time that a frame was received
+// from the given DERP region, or the zero time if no communication with that
+// region has occurred.
+func GetDERPRegionReceivedTime(region int) time.Time {
+	mu.Lock()
+	defer mu.Unlock()
+	return derpRegionLastFrame[region]
 }
 
 // state is an ipn.State.String() value: "Running", "Stopped", "NeedsLogin", etc.

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -628,7 +628,17 @@ func (c *Conn) updateNetInfo(ctx context.Context) (*netcheck.Report, error) {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
-	report, err := c.netChecker.GetReport(ctx, dm)
+	report, err := c.netChecker.GetReport(ctx, dm, &netcheck.GetReportOpts{
+		// Pass information about the last time that we received a
+		// frame from a DERP server to our netchecker to help avoid
+		// flapping the home region while there's still active
+		// communication.
+		//
+		// NOTE(andrew-d): I don't love that we're depending on the
+		// health package here, but I'd rather do that and not store
+		// the exact same state in two different places.
+		GetLastDERPActivity: health.GetDERPRegionReceivedTime,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This uses the fact that we've received a frame from a given DERP region within a certain time as a signal that the region is stil present (and thus can still be a node's PreferredDERP / home region) even if we don't get a STUN response from that region during a netcheck.

This should help avoid DERP flaps that occur due to losing STUN probes while still having a valid and active TCP connection to the DERP server.

Updates #8603


Change-Id: If7da6312581e1d434d5c0811697319c621e187a0