### PR TITLE
ipn/ipnlocal: refresh node key without blocking if cap enabled

### DIFF
--- a/control/controlknobs/controlknobs.go
+++ b/control/controlknobs/controlknobs.go
@@ -64,6 +64,11 @@ type Knobs struct {
 	// LinuxForceNfTables is whether the node should use nftables for Linux
 	// netfiltering, unless overridden by the user.
 	LinuxForceNfTables atomic.Bool
+
+	// SeamlessKeyRenewal is whether to enable the alpha functionality of
+	// renewing node keys without breaking connections.
+	// http://go/seamless-key-renewal
+	SeamlessKeyRenewal atomic.Bool
 }
 
 // UpdateFromNodeAttributes updates k (if non-nil) based on the provided self
@@ -89,6 +94,7 @@ func (k *Knobs) UpdateFromNodeAttributes(selfNodeAttrs []tailcfg.NodeCapability,
 		silentDisco                   = has(tailcfg.NodeAttrSilentDisco)
 		forceIPTables                 = has(tailcfg.NodeAttrLinuxMustUseIPTables)
 		forceNfTables                 = has(tailcfg.NodeAttrLinuxMustUseNfTables)
+		seamlessKeyRenewal            = has(tailcfg.NodeAttrSeamlessKeyRenewal)
 	)
 
 	if has(tailcfg.NodeAttrOneCGNATEnable) {
@@ -109,6 +115,7 @@ func (k *Knobs) UpdateFromNodeAttributes(selfNodeAttrs []tailcfg.NodeCapability,
 	k.SilentDisco.Store(silentDisco)
 	k.LinuxForceIPTables.Store(forceIPTables)
 	k.LinuxForceNfTables.Store(forceNfTables)
+	k.SeamlessKeyRenewal.Store(seamlessKeyRenewal)
 }
 
 // AsDebugJSON returns k as something that can be marshalled with json.Marshal
@@ -130,5 +137,6 @@ func (k *Knobs) AsDebugJSON() map[string]any {
 		"SilentDisco":                   k.SilentDisco.Load(),
 		"LinuxForceIPTables":            k.LinuxForceIPTables.Load(),
 		"LinuxForceNfTables":            k.LinuxForceNfTables.Load(),
+		"SeamlessKeyRenewal":            k.SeamlessKeyRenewal.Load(),
 	}
 }

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -124,7 +124,8 @@ type CapabilityVersion int
 //   - 81: 2023-11-17: MapResponse.PacketFilters (incremental packet filter updates)
 //   - 82: 2023-12-01: Client understands NodeAttrLinuxMustUseIPTables, NodeAttrLinuxMustUseNfTables, c2n /netfilter-kind
 //   - 83: 2023-12-18: Client understands DefaultAutoUpdate
-const CurrentCapabilityVersion CapabilityVersion = 83
+//   - 84: 2024-01-04: Client understands SeamlessKeyRenewal
+const CurrentCapabilityVersion CapabilityVersion = 84
 
 type StableID string
 
@@ -2190,6 +2191,10 @@ const (
 	// netfilter management.
 	// This cannot be set simultaneously with NodeAttrLinuxMustUseIPTables.
 	NodeAttrLinuxMustUseNfTables NodeCapability = "linux-netfilter?v=nftables"
+
+	// NodeAttrSeamlessKeyRenewal makes clients enable beta functionality
+	// of renewing node keys without breaking connections.
+	NodeAttrSeamlessKeyRenewal NodeCapability = "seamless-key-renewal"
 )
 
 // SetDNSRequest is a request to add a DNS record.


### PR DESCRIPTION
This is based off [earlier work pairing with Maisem](https://github.com/tailscale/tailscale/compare/maisem/login-renew?expand=1), but modifies it to be feature flagged rather than changing this for everyone.

The logic to the feature flagging is to ensure we can always _exit_ a blocked state, but never enter it if the feature flag is enabled. This is to ensure that if the flag changes, we don't end up stuck in a blocked state.

The motivation for the feature flagging is already covered in tailscale/corp#16302

Updates tailscale/corp#16016