### PR TITLE
client/web: add visual indication for exit node pending approval

### DIFF
--- a/client/web/src/api.ts
+++ b/client/web/src/api.ts
@@ -92,7 +92,8 @@ export function useAPI() {
     <MutateDataType, FetchDataType = any>(
       key: string,
       fetch: Promise<FetchDataType>,
-      optimisticData: (current: MutateDataType) => MutateDataType
+      optimisticData: (current: MutateDataType) => MutateDataType,
+      revalidate?: boolean // optionally specify whether to run final revalidation (step 3)
     ): Promise<FetchDataType | undefined> => {
       const options: MutatorOptions = {
         /**
@@ -105,6 +106,7 @@ export function useAPI() {
          */
         populateCache: false,
         optimisticData,
+        revalidate: revalidate,
       }
       return mutate(key, fetch, options)
     },
@@ -226,8 +228,12 @@ export function useAPI() {
                 ...old,
                 UsingExitNode: Boolean(body.UseExitNode) ? t.data : undefined,
                 AdvertisingExitNode: Boolean(body.AdvertiseExitNode),
+                AdvertisingExitNodeApproved: Boolean(body.AdvertiseExitNode)
+                  ? true // gets updated in revalidation
+                  : old.AdvertisingExitNodeApproved,
               }
-            }
+            },
+            false // skip final revalidation
           )
             .then(() => metrics.forEach((m) => incrementMetric(m)))
             .catch(handlePostError("Failed to update exit node"))

--- a/client/web/src/types.ts
+++ b/client/web/src/types.ts
@@ -15,6 +15,7 @@ export type NodeData = {
   KeyExpired: boolean
   UsingExitNode?: ExitNode
   AdvertisingExitNode: boolean
+  AdvertisingExitNodeApproved: boolean
   AdvertisedRoutes?: SubnetRoute[]
   TUNMode: boolean
   IsSynology: boolean

--- a/client/web/web.go
+++ b/client/web/web.go
@@ -555,10 +555,11 @@ type nodeData struct {
 	UnraidToken string
 	URLPrefix   string // if set, the URL prefix the client is served behind
 
-	UsingExitNode       *exitNode
-	AdvertisingExitNode bool
-	AdvertisedRoutes    []subnetRoute // excludes exit node routes
-	RunningSSHServer    bool
+	UsingExitNode               *exitNode
+	AdvertisingExitNode         bool
+	AdvertisingExitNodeApproved bool          // whether running this node as an exit node has been approved by an admin
+	AdvertisedRoutes            []subnetRoute // excludes exit node routes
+	RunningSSHServer            bool
 
 	ClientVersion *tailcfg.ClientVersion
 
@@ -657,6 +658,8 @@ func (s *Server) serveGetNodeData(w http.ResponseWriter, r *http.Request) {
 			return p == route
 		})
 	}
+	data.AdvertisingExitNodeApproved = routeApproved(exitNodeRouteV4) || routeApproved(exitNodeRouteV6)
+
 	for _, r := range prefs.AdvertiseRoutes {
 		if r == exitNodeRouteV4 || r == exitNodeRouteV6 {
 			data.AdvertisingExitNode = true


### PR DESCRIPTION
Add visual indication when running as an exit node prior to receiving admin approval.

Updates https://github.com/tailscale/tailscale/issues/10261

https://github.com/tailscale/tailscale/assets/8587567/8b10e1d4-0b43-4aac-bec1-d32d6b392147


