### PR TITLE
client/web: only enforce path prefix in CGI mode

### DIFF
--- a/client/web/web.go
+++ b/client/web/web.go
@@ -227,7 +227,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	handler := s.serve
 
 	// if path prefix is defined, strip it from requests.
-	if s.pathPrefix != "" {
+	if s.cgiMode && s.pathPrefix != "" {
 		handler = enforcePrefix(s.pathPrefix, handler)
 	}
 


### PR DESCRIPTION
The client has changed a bit since we introduced the path prefix.  It is now used for two things:

- its original purpose, of ensuring that when the client is run in CGI mode at arbitrary paths, then relative paths for assets continue to work

- we also now pass the path to the frontend and use wouter to manage routes for the various subpages of the client.

When the client is run behind a reverse proxy (as it is in Home Assistant), it is common for the proxy to rewrite the request so that the backend application doesn't see the path it's being served at. In this case, we don't need to call enforcePrefix, since it's already stripped before it reaches us.  However, wouter (our react router library) still sees the original path in the browser, and needs to know what part of it is the prefix that needs to be stripped off.

We're handling this by now only calling enforcePrefix when run in CGI mode. For Home Assistant, or any other platform that runs the client behind a reverse proxy with a custom path, they will still need to pass the `-prefix` flag to `tailscale web`, but we will only use it for route handling in the frontend.

Updates #10261