### PR TITLE
cmd/tailscaled: update ConfigureWebClient's UseSocketOnly value

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -556,7 +556,10 @@ func getLocalBackend(ctx context.Context, logf logger.Logf, logID logid.PublicID
 	if root := lb.TailscaleVarRoot(); root != "" {
 		dnsfallback.SetCachePath(filepath.Join(root, "derpmap.cached.json"), logf)
 	}
-	lb.ConfigureWebClient(&tailscale.LocalClient{Socket: args.socketpath, UseSocketOnly: args.socketpath != ""})
+	lb.ConfigureWebClient(&tailscale.LocalClient{
+		Socket:        args.socketpath,
+		UseSocketOnly: args.socketpath != paths.DefaultTailscaledSocket(),
+	})
 	configureTaildrop(logf, lb)
 	if err := ns.Start(lb); err != nil {
 		log.Fatalf("failed to start netstack: %v", err)


### PR DESCRIPTION
Previously were always setting `UseSocketOnly` because we were comparing `args.socketpath != ""`, but `args.socketpath` flag always gets filled with `paths.DefaultTailscaledSocket()` when not provided. Rather than comparing to the empty string, compare to the default value to determine if `UseSocketOnly` should be set.

Should fix issue with web client being unreachable for Mac App Store variant of the mac build.
```
error getting status: Failed to connect to local Tailscale daemon for /localapi/v0/status; not running? Error: dial unix /var/run/tailscaled.socket: connect: no such file or directory
```

Updates #16054