### PR TITLE
client/web: remove 'unsafe-inline' from CSP

### DIFF
--- a/client/web/web.go
+++ b/client/web/web.go
@@ -253,7 +253,7 @@ func (s *Server) serve(w http.ResponseWriter, r *http.Request) {
 		if !s.devMode {
 			w.Header().Set("X-Frame-Options", "DENY")
 			// TODO: use CSP nonce or hash to eliminate need for unsafe-inline
-			w.Header().Set("Content-Security-Policy", "default-src 'self' 'unsafe-inline'; img-src * data:")
+			w.Header().Set("Content-Security-Policy", "default-src 'self'; img-src * data:")
 			w.Header().Set("Cross-Origin-Resource-Policy", "same-origin")
 		}
 	}


### PR DESCRIPTION
I seem to recall I needed this for things to work properly with the vite dev server, but that doesn't seem to be the case anymore?  Everything seems to work fine without it.  If we still have issues, we'll need to look into using a nonce or integrity attribute.

Updates #10261
Fixes tailscale/corp#16266