### PR TITLE
client/web: open new window if iframed

### DIFF
--- a/client/web/src/components/login-toggle.tsx
+++ b/client/web/src/components/login-toggle.tsx
@@ -126,7 +126,14 @@ function LoginPopoverContent({
 
   const handleSignInClick = useCallback(() => {
     if (auth.viewerIdentity) {
-      newSession()
+      if (window.self !== window.top) {
+        // if we're inside an iframe, start session in new window
+        let url = new URL(window.location.href)
+        url.searchParams.set("check", "now")
+        window.open(url, "_blank")
+      } else {
+        newSession()
+      }
     } else {
       // Must be connected over Tailscale to log in.
       // Send user to Tailscale IP and start check mode


### PR DESCRIPTION
Previously, we were only breaking out of iframes when accessing the login client over a local IP address (where viewerIdentity is not set). We need to also handle the case where the user is accessing the login client over the Tailscale IP, and similarly break out of the iframe when logging into the management client.

Updates #10261