### PR TITLE
client/web: don't show login button if /ok errors

### DIFF
--- a/client/web/src/components/login-toggle.tsx
+++ b/client/web/src/components/login-toggle.tsx
@@ -106,9 +106,11 @@ function LoginPopoverContent({
     }
     setIsRunningCheck(true)
     fetch(`http://${node.IPv4}:5252/ok`, { mode: "no-cors" })
-      .then(() => {
+      .then((r) => {
+        if (r.ok) {
+          setCanConnectOverTS(true)
+        }
         setIsRunningCheck(false)
-        setCanConnectOverTS(true)
       })
       .catch(() => setIsRunningCheck(false))
   }, [auth.viewerIdentity, isRunningCheck, node.IPv4])


### PR DESCRIPTION
When displaying the login client, we check for connectivity to the management client by calling it's /ok handler. If that response is non-200, then there is something wrong with the management client, so don't render the login button.

Updates #10261