### PR TITLE
client/web: restrict using an exit node on a couple more platforms

### DIFF
--- a/client/web/web.go
+++ b/client/web/web.go
@@ -729,14 +729,15 @@ func (s *Server) serveGetNodeData(w http.ResponseWriter, r *http.Request) {
 }
 
 func availableFeatures() map[string]bool {
+	env := hostinfo.GetEnvType()
 	features := map[string]bool{
-		"advertise-exit-node": true,                            // available on all platforms
-		"advertise-routes":    true,                            // available on all platforms
-		"use-exit-node":       distro.Get() != distro.Synology, // see https://github.com/tailscale/tailscale/issues/1995
+		"advertise-exit-node": true, // available on all platforms
+		"advertise-routes":    true, // available on all platforms
+		"use-exit-node":       canUseExitNode(env) == nil,
 		"ssh":                 envknob.CanRunTailscaleSSH() == nil,
 		"auto-update":         version.IsUnstableBuild() && clientupdate.CanAutoUpdate(),
 	}
-	if hostinfo.GetEnvType() == hostinfo.HomeAssistantAddOn {
+	if env == hostinfo.HomeAssistantAddOn {
 		// Setting SSH on Home Assistant causes trouble on startup
 		// (since the flag is not being passed to `tailscale up`).
 		// Although Tailscale SSH does work here,
@@ -744,6 +745,19 @@ func availableFeatures() map[string]bool {
 		features["ssh"] = false
 	}
 	return features
+}
+
+func canUseExitNode(env hostinfo.EnvType) error {
+	switch dist := distro.Get(); dist {
+	case distro.Synology, // see https://github.com/tailscale/tailscale/issues/1995
+		distro.QNAP,
+		distro.Unraid:
+		return fmt.Errorf("Tailscale exit nodes cannot be used on %s.", dist)
+	}
+	if env == hostinfo.HomeAssistantAddOn {
+		return errors.New("Tailscale exit nodes cannot be used on Home Assistant.")
+	}
+	return nil
 }
 
 // aclsAllowAccess returns whether tailnet ACLs (as expressed in the provided filter rules)


### PR DESCRIPTION
Completed testing of the new UI on the existing platforms that use it. From testing, QNAP, Unraid, and Home Assistant (in addition to Synology) all do not play well with using an exit node. For now, we're disabling this setting from the UI. CLI should be updated to also disallow selection of an exit node from these platforms. All platforms still allow for advertising as an exit node.



Updates #10261