### PR TITLE
util/linuxfw: make nftable runner's `getOrCreateChain` return the newly created chain

### DIFF
--- a/util/linuxfw/nftables_runner.go
+++ b/util/linuxfw/nftables_runner.go
@@ -429,7 +429,7 @@ func getOrCreateChain(c *nftables.Conn, cinfo chainInfo) (*nftables.Chain, error
 		return chain, nil
 	}
 
-	_ = c.AddChain(&nftables.Chain{
+	chain = c.AddChain(&nftables.Chain{
 		Name:     cinfo.name,
 		Table:    cinfo.table,
 		Type:     cinfo.chainType,


### PR DESCRIPTION
Ensure that if `getOrCreateChain` creates a new chain, it actually returns the created chain

Updates tailscale/tailscale#10399