### PR TITLE
client/web: use prefs.ControlURLOrDefault from controlSupportsCheckMode

### DIFF
--- a/client/web/auth.go
+++ b/client/web/auth.go
@@ -190,7 +190,7 @@ func (s *Server) controlSupportsCheckMode(ctx context.Context) bool {
 	if err != nil {
 		return true
 	}
-	controlURL, err := url.Parse(prefs.ControlURL)
+	controlURL, err := url.Parse(prefs.ControlURLOrDefault())
 	if err != nil {
 		return true
 	}


### PR DESCRIPTION
To be safe, use `prefs.ControlURLOrDefault()` rather than the current `prefs.ControlURL` directly.

Updates #10261