### PR TITLE
client/web: refresh auth after syno login

### DIFF
--- a/client/web/src/hooks/auth.ts
+++ b/client/web/src/hooks/auth.ts
@@ -25,6 +25,7 @@ export type AuthResponse = {
 export default function useAuth() {
   const [data, setData] = useState<AuthResponse>()
   const [loading, setLoading] = useState<boolean>(true)
+  const [ranSynoAuth, setRanSynoAuth] = useState<boolean>(false)
 
   const loadAuth = useCallback(() => {
     setLoading(true)
@@ -37,6 +38,7 @@ export default function useAuth() {
               .then((r) => r.json())
               .then((a) => {
                 setSynoToken(a.SynoToken)
+                setRanSynoAuth(true)
                 setLoading(false)
               })
             break
@@ -78,6 +80,10 @@ export default function useAuth() {
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  useEffect(() => {
+    loadAuth() // Refresh auth state after syno auth runs
+  }, [loadAuth, ranSynoAuth])
 
   return {
     data,


### PR DESCRIPTION
Makes sure we refresh auth state after synology auth has run.

Updates #10261