### PR TITLE
client/web: fix key expiry text when expiry disabled

### DIFF
--- a/client/web/src/components/views/device-details-view.tsx
+++ b/client/web/src/components/views/device-details-view.tsx
@@ -94,7 +94,9 @@ export default function DeviceDetailsView({
                   {node.KeyExpired
                     ? "Expired"
                     : // TODO: present as relative expiry (e.g. "5 months from now")
-                      new Date(node.KeyExpiry).toLocaleString()}
+                    node.KeyExpiry
+                    ? new Date(node.KeyExpiry).toLocaleString()
+                    : "No expiry"}
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
Displays "No expiry" when disabled.

Updates #10261