### PR TITLE
client/web: fix redirect logic when accessing login client over TS IP

### DIFF
--- a/client/web/src/components/login-toggle.tsx
+++ b/client/web/src/components/login-toggle.tsx
@@ -125,7 +125,7 @@ function LoginPopoverContent({
   useEffect(() => checkTSConnection(), [])
 
   const handleSignInClick = useCallback(() => {
-    if (auth.viewerIdentity) {
+    if (auth.viewerIdentity && auth.serverMode === "manage") {
       if (window.self !== window.top) {
         // if we're inside an iframe, start session in new window
         let url = new URL(window.location.href)
@@ -145,7 +145,7 @@ function LoginPopoverContent({
         window.location.href = manageURL
       }
     }
-  }, [node.IPv4, auth.viewerIdentity, newSession])
+  }, [auth.viewerIdentity, auth.serverMode, newSession, node.IPv4])
 
   return (
     <div onMouseEnter={!canConnectOverTS ? checkTSConnection : undefined}>

--- a/client/web/src/hooks/auth.ts
+++ b/client/web/src/hooks/auth.ts
@@ -12,6 +12,7 @@ export enum AuthType {
 export type AuthResponse = {
   authNeeded?: AuthType
   canManageNode: boolean
+  serverMode: "login" | "manage"
   viewerIdentity?: {
     loginName: string
     nodeName: string

--- a/client/web/web.go
+++ b/client/web/web.go
@@ -396,6 +396,7 @@ type authResponse struct {
 	AuthNeeded     authType        `json:"authNeeded,omitempty"` // filled when user needs to complete a specific type of auth
 	CanManageNode  bool            `json:"canManageNode"`
 	ViewerIdentity *viewerIdentity `json:"viewerIdentity,omitempty"`
+	ServerMode     ServerMode      `json:"serverMode"`
 }
 
 // viewerIdentity is the Tailscale identity of the source node
@@ -411,6 +412,7 @@ type viewerIdentity struct {
 // and returns an authResponse indicating the current auth state and any steps the user needs to take.
 func (s *Server) serveAPIAuth(w http.ResponseWriter, r *http.Request) {
 	var resp authResponse
+	resp.ServerMode = s.mode
 	session, whois, status, sErr := s.getSession(r)
 
 	if whois != nil {

--- a/client/web/web_test.go
+++ b/client/web/web_test.go
@@ -523,7 +523,7 @@ func TestServeAuth(t *testing.T) {
 			name:          "no-session",
 			path:          "/api/auth",
 			wantStatus:    http.StatusOK,
-			wantResp:      &authResponse{AuthNeeded: tailscaleAuth, ViewerIdentity: vi},
+			wantResp:      &authResponse{AuthNeeded: tailscaleAuth, ViewerIdentity: vi, ServerMode: ManageServerMode},
 			wantNewCookie: false,
 			wantSession:   nil,
 		},
@@ -548,7 +548,7 @@ func TestServeAuth(t *testing.T) {
 			path:       "/api/auth",
 			cookie:     successCookie,
 			wantStatus: http.StatusOK,
-			wantResp:   &authResponse{AuthNeeded: tailscaleAuth, ViewerIdentity: vi},
+			wantResp:   &authResponse{AuthNeeded: tailscaleAuth, ViewerIdentity: vi, ServerMode: ManageServerMode},
 			wantSession: &browserSession{
 				ID:            successCookie,
 				SrcNode:       remoteNode.Node.ID,
@@ -596,7 +596,7 @@ func TestServeAuth(t *testing.T) {
 			path:       "/api/auth",
 			cookie:     successCookie,
 			wantStatus: http.StatusOK,
-			wantResp:   &authResponse{CanManageNode: true, ViewerIdentity: vi},
+			wantResp:   &authResponse{CanManageNode: true, ViewerIdentity: vi, ServerMode: ManageServerMode},
 			wantSession: &browserSession{
 				ID:            successCookie,
 				SrcNode:       remoteNode.Node.ID,


### PR DESCRIPTION
Was previously failing to redirect to the manage client when accessing the login client with the Tailscale IP.

Updates #10261
Fixes tailscale/corp#16348