### PR TITLE
tool/gocross: make all Windows DLLs build with static libgcc

### DIFF
--- a/tool/gocross/autoflags.go
+++ b/tool/gocross/autoflags.go
@@ -96,6 +96,7 @@ func autoflagsForTest(argv []string, env *Environment, goroot, nativeGOOS, nativ
 		cgo = true
 		buildFlags = append(buildFlags, "-buildmode=c-shared")
 		ldflags = append(ldflags, "-H", "windows", "-s")
+		cgoLdflags = append(cgoLdflags, "-static")
 		var mingwArch string
 		switch targetArch {
 		case "amd64":


### PR DESCRIPTION
In this commit, we have updated the build process for our Windows DLLs to link statically with libgcc, ensuring our Windows DLLs are self-contained.

Updates #10617