### PR TITLE
cmd/k8s-operator/deploy/chart: document some chart values

### DIFF
--- a/cmd/k8s-operator/deploy/chart/values.yaml
+++ b/cmd/k8s-operator/deploy/chart/values.yaml
@@ -22,7 +22,7 @@ operatorConfig:
     tag: ""
     digest: ""
     pullPolicy: Always
-  logging: "info"
+  logging: "info" # info, debug, dev
   hostname: "tailscale-operator"
   nodeSelector:
     kubernetes.io/os: linux
@@ -53,7 +53,9 @@ proxyConfig:
   # ACL tag that operator will tag proxies with. Operator must be made owner of
   # these tags
   # https://tailscale.com/kb/1236/kubernetes-operator/?q=operator#setting-up-the-kubernetes-operator
-  defaultTags: tag:k8s
+  # Multiple tags can be passed as a comma-separated string i.e 'tag:k8s-proxies,tag:prod'.
+  # Note that if you pass multiple tags to this field via `--set` flag to helm upgrade/install commands you must escape the comma (for example, "tag:k8s-proxies\,tag:prod"). See https://github.com/helm/helm/issues/1556
+  defaultTags: "tag:k8s"
   firewallMode: auto
 
 # apiServerProxyConfig allows to configure whether the operator should expose


### PR DESCRIPTION
Document how to pass multiple tag values for default proxy tags via Helm. Also document available log levels for the operator.

The comments in the Helm values file are user facing documentation- they are visible if a user runs views available values for the chart by running  `helm show values tailscale/tailscale-operator`


Updates #cleanup