### PR TITLE
net/interfaces: better handle multiple interfaces in LikelyHomeRouterIP

### DIFF
--- a/net/interfaces/interfaces_bsd.go
+++ b/net/interfaces/interfaces_bsd.go
@@ -86,16 +86,16 @@ func init() {
 	likelyHomeRouterIP = likelyHomeRouterIPBSDFetchRIB
 }
 
-func likelyHomeRouterIPBSDFetchRIB() (ret netip.Addr, ok bool) {
+func likelyHomeRouterIPBSDFetchRIB() (ret, myIP netip.Addr, ok bool) {
 	rib, err := fetchRoutingTable()
 	if err != nil {
 		log.Printf("routerIP/FetchRIB: %v", err)
-		return ret, false
+		return ret, myIP, false
 	}
 	msgs, err := parseRoutingTable(rib)
 	if err != nil {
 		log.Printf("routerIP/ParseRIB: %v", err)
-		return ret, false
+		return ret, myIP, false
 	}
 	for _, m := range msgs {
 		rm, ok := m.(*route.RouteMessage)
@@ -110,10 +110,18 @@ func likelyHomeRouterIPBSDFetchRIB() (ret netip.Addr, ok bool) {
 		if !ok {
 			continue
 		}
-		return netaddr.IPv4(gw.IP[0], gw.IP[1], gw.IP[2], gw.IP[3]), true
+		// If the route entry has an interface address associated with
+		// it, then parse and return that. This is optional.
+		if len(rm.Addrs) >= unix.RTAX_IFA {
+			if addr, ok := rm.Addrs[unix.RTAX_IFA].(*route.Inet4Addr); ok {
+				myIP = netaddr.IPv4(addr.IP[0], addr.IP[1], addr.IP[2], addr.IP[3])
+			}
+		}
+
+		return netaddr.IPv4(gw.IP[0], gw.IP[1], gw.IP[2], gw.IP[3]), myIP, true
 	}
 
-	return ret, false
+	return ret, myIP, false
 }
 
 var v4default = [4]byte{0, 0, 0, 0}

--- a/net/interfaces/interfaces_darwin_test.go
+++ b/net/interfaces/interfaces_darwin_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestLikelyHomeRouterIPSyscallExec(t *testing.T) {
-	syscallIP, syscallOK := likelyHomeRouterIPBSDFetchRIB()
+	syscallIP, _, syscallOK := likelyHomeRouterIPBSDFetchRIB()
 	netstatIP, netstatIf, netstatOK := likelyHomeRouterIPDarwinExec()
 
 	if syscallOK != netstatOK || syscallIP != netstatIP {

--- a/net/interfaces/interfaces_test.go
+++ b/net/interfaces/interfaces_test.go
@@ -83,8 +83,8 @@ func TestLikelyHomeRouterIP(t *testing.T) {
 	})
 
 	// Mock out the likelyHomeRouterIP to return a known gateway.
-	tstest.Replace(t, &likelyHomeRouterIP, func() (netip.Addr, bool) {
-		return netip.MustParseAddr("192.168.7.1"), true
+	tstest.Replace(t, &likelyHomeRouterIP, func() (netip.Addr, netip.Addr, bool) {
+		return netip.MustParseAddr("192.168.7.1"), netip.Addr{}, true
 	})
 
 	gw, my, ok := LikelyHomeRouterIP()
@@ -177,8 +177,8 @@ func TestLikelyHomeRouterIP_Prefix(t *testing.T) {
 	})
 
 	// Mock out the likelyHomeRouterIP to return a known gateway.
-	tstest.Replace(t, &likelyHomeRouterIP, func() (netip.Addr, bool) {
-		return netip.MustParseAddr("192.168.7.1"), true
+	tstest.Replace(t, &likelyHomeRouterIP, func() (netip.Addr, netip.Addr, bool) {
+		return netip.MustParseAddr("192.168.7.1"), netip.Addr{}, true
 	})
 
 	gw, my, ok := LikelyHomeRouterIP()

--- a/net/interfaces/interfaces_windows.go
+++ b/net/interfaces/interfaces_windows.go
@@ -25,7 +25,7 @@ func init() {
 	getPAC = getPACWindows
 }
 
-func likelyHomeRouterIPWindows() (ret netip.Addr, ok bool) {
+func likelyHomeRouterIPWindows() (ret netip.Addr, _ netip.Addr, ok bool) {
 	rs, err := winipcfg.GetIPForwardTable2(windows.AF_INET)
 	if err != nil {
 		log.Printf("routerIP/GetIPForwardTable2 error: %v", err)
@@ -92,10 +92,10 @@ func likelyHomeRouterIPWindows() (ret netip.Addr, ok bool) {
 
 	if ret.IsValid() && !ret.IsPrivate() {
 		// Default route has a non-private gateway
-		return netip.Addr{}, false
+		return netip.Addr{}, netip.Addr{}, false
 	}
 
-	return ret, ret.IsValid()
+	return ret, netip.Addr{}, ret.IsValid()
 }
 
 // NonTailscaleMTUs returns a map of interface LUID to interface MTU,


### PR DESCRIPTION
Currently, we get the "likely home router" gateway IP and then iterate through all IPs for all interfaces trying to match IPs to determine the source IP. However, on many platforms we know what interface the gateway is through, and thus we don't need to iterate through all interfaces checking IPs. Instead, use the IP address of the associated interface.

This better handles the case where we have multiple interfaces on a system all connected to the same gateway, and where the first interface that we visit (as iterated by ForeachInterfaceAddress) isn't also the default internet route.

Updates #8992

Change-Id: I8632f577f1136930f4ec60c76376527a19a47d1f