### PR TITLE
all: cleanup unused code, part 1

### DIFF
--- a/net/packet/packet_test.go
+++ b/net/packet/packet_test.go
@@ -74,18 +74,6 @@ var icmp4ReplyBuffer = []byte{
 	0x72, 0x65, 0x70, 0x6c, 0x79, 0x5f, 0x70, 0x61, 0x79, 0x6c, 0x6f, 0x61, 0x64,
 }
 
-var icmp4ReplyDecode = Parsed{
-	b:       icmp4ReplyBuffer,
-	subofs:  20,
-	dataofs: 24,
-	length:  len(icmp4ReplyBuffer),
-
-	IPVersion: 4,
-	IPProto:   ICMPv4,
-	Src:       mustIPPort("1.2.3.4:0"),
-	Dst:       mustIPPort("5.6.7.8:0"),
-}
-
 // ICMPv6 Router Solicitation
 var icmp6PacketBuffer = []byte{
 	0x60, 0x00, 0x00, 0x00, 0x00, 0x08, 0x3a, 0xff,
@@ -255,17 +243,6 @@ var udp4ReplyBuffer = []byte{
 	0x02, 0x37, 0x00, 0x7b, 0x00, 0x15, 0xd3, 0x9d,
 	// "reply_payload"
 	0x72, 0x65, 0x70, 0x6c, 0x79, 0x5f, 0x70, 0x61, 0x79, 0x6c, 0x6f, 0x61, 0x64,
-}
-
-var udp4ReplyDecode = Parsed{
-	b:       udp4ReplyBuffer,
-	subofs:  20,
-	dataofs: 28,
-	length:  len(udp4ReplyBuffer),
-
-	IPProto: UDP,
-	Src:     mustIPPort("1.2.3.4:567"),
-	Dst:     mustIPPort("5.6.7.8:123"),
 }
 
 // First TCP fragment of a packet with leading 24 bytes of 'a's

--- a/net/portmapper/igd_test.go
+++ b/net/portmapper/igd_test.go
@@ -50,9 +50,7 @@ type TestIGDOptions struct {
 type igdCounters struct {
 	numUPnPDiscoRecv     int32
 	numUPnPOtherUDPRecv  int32
-	numUPnPHTTPRecv      int32
 	numPMPRecv           int32
-	numPMPDiscoRecv      int32
 	numPCPRecv           int32
 	numPCPDiscoRecv      int32
 	numPCPMapRecv        int32

--- a/net/proxymux/mux_test.go
+++ b/net/proxymux/mux_test.go
@@ -138,8 +138,8 @@ func mkWorld(t *testing.T) (ret *world) {
 	}
 	go httpProxy.Serve(ret.httpListener)
 
-	socksProxy := socks5.Server{}
-	go socksProxy.Serve(ret.socksListener)
+	ret.socksProxy = &socks5.Server{}
+	go ret.socksProxy.Serve(ret.socksListener)
 
 	ret.httpClient = &http.Client{
 		Transport: &http.Transport{

--- a/net/routetable/routetable.go
+++ b/net/routetable/routetable.go
@@ -16,6 +16,7 @@ import (
 
 var (
 	defaultRouteIPv4 = RouteDestination{Prefix: netip.PrefixFrom(netip.IPv4Unspecified(), 0)}
+	//lint:ignore U1000 used in routetable_bsd_test.go
 	defaultRouteIPv6 = RouteDestination{Prefix: netip.PrefixFrom(netip.IPv6Unspecified(), 0)}
 )
 

--- a/net/tsaddr/tsaddr.go
+++ b/net/tsaddr/tsaddr.go
@@ -37,7 +37,6 @@ func CGNATRange() netip.Prefix {
 
 var (
 	cgnatRange   oncePrefix
-	ulaRange     oncePrefix
 	tsUlaRange   oncePrefix
 	tsViaRange   oncePrefix
 	ula4To6Range oncePrefix

--- a/net/tsdial/peerapi_macios_ext.go
+++ b/net/tsdial/peerapi_macios_ext.go
@@ -26,7 +26,7 @@ func peerDialControlFuncNetworkExtension(d *Dialer) func(network, address string
 	defer d.mu.Unlock()
 
 	index := -1
-	if x, ok := d.interfaceIndexLocked(d.tunName); ok {
+	if x, ok := interfaceIndexLocked(d); ok {
 		index = x
 	}
 	var lc net.ListenConfig
@@ -37,4 +37,16 @@ func peerDialControlFuncNetworkExtension(d *Dialer) func(network, address string
 		}
 		return lc.Control(network, address, c)
 	}
+}
+
+func interfaceIndexLocked(d *Dialer) (index int, ok bool) {
+	if d.netMon == nil {
+		return 0, false
+	}
+	st := d.netMon.InterfaceState()
+	iface, ok := st.Interface[d.tunName]
+	if !ok {
+		return 0, false
+	}
+	return iface.Index, true
 }

--- a/net/tsdial/tsdial.go
+++ b/net/tsdial/tsdial.go
@@ -196,18 +196,6 @@ func (d *Dialer) closeSysConn(id int) {
 	go c.Close() // ignore the error
 }
 
-func (d *Dialer) interfaceIndexLocked(ifName string) (index int, ok bool) {
-	if d.netMon == nil {
-		return 0, false
-	}
-	st := d.netMon.InterfaceState()
-	iface, ok := st.Interface[ifName]
-	if !ok {
-		return 0, false
-	}
-	return iface.Index, true
-}
-
 // peerDialControlFunc is non-nil on platforms that require a way to
 // bind to dial out to other peers.
 var peerDialControlFunc func(*Dialer) func(network, address string, c syscall.RawConn) error

--- a/net/tstun/wrap_test.go
+++ b/net/tstun/wrap_test.go
@@ -258,7 +258,6 @@ func TestWriteAndInject(t *testing.T) {
 	chtun, tun := newChannelTUN(t.Logf, false)
 	defer tun.Close()
 
-	const size = 2 // all payloads have this size
 	written := []string{"w0", "w1"}
 	injected := []string{"i0", "i1"}
 

--- a/release/dist/cli/cli.go
+++ b/release/dist/cli/cli.go
@@ -6,10 +6,7 @@ package cli
 
 import (
 	"context"
-	"crypto"
-	"crypto/x509"
 	"encoding/binary"
-	"encoding/pem"
 	"errors"
 	"flag"
 	"fmt"
@@ -211,24 +208,6 @@ func runBuild(ctx context.Context, filters []string, targets []dist.Target) erro
 
 	fmt.Println("Done! Took", time.Since(st))
 	return nil
-}
-
-func parseSigningKey(path string) (crypto.Signer, error) {
-	if path == "" {
-		return nil, nil
-	}
-	raw, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	b, rest := pem.Decode(raw)
-	if b == nil {
-		return nil, fmt.Errorf("failed to decode PEM data in %q", path)
-	}
-	if len(rest) > 0 {
-		return nil, fmt.Errorf("trailing data in %q, please check that the key file was not corrupted", path)
-	}
-	return x509.ParseECPrivateKey(b.Bytes)
 }
 
 var genKeyArgs struct {

--- a/ssh/tailssh/tailssh.go
+++ b/ssh/tailssh/tailssh.go
@@ -1905,20 +1905,18 @@ func envEq(a, b string) bool {
 }
 
 var (
-	metricActiveSessions       = clientmetric.NewGauge("ssh_active_sessions")
-	metricIncomingConnections  = clientmetric.NewCounter("ssh_incoming_connections")
-	metricPublicKeyConnections = clientmetric.NewCounter("ssh_publickey_connections") // total
-	metricPublicKeyAccepts     = clientmetric.NewCounter("ssh_publickey_accepts")     // accepted subset of ssh_publickey_connections
-	metricTerminalAccept       = clientmetric.NewCounter("ssh_terminalaction_accept")
-	metricTerminalReject       = clientmetric.NewCounter("ssh_terminalaction_reject")
-	metricTerminalInterrupt    = clientmetric.NewCounter("ssh_terminalaction_interrupt")
-	metricTerminalMalformed    = clientmetric.NewCounter("ssh_terminalaction_malformed")
-	metricTerminalFetchError   = clientmetric.NewCounter("ssh_terminalaction_fetch_error")
-	metricHolds                = clientmetric.NewCounter("ssh_holds")
-	metricPolicyChangeKick     = clientmetric.NewCounter("ssh_policy_change_kick")
-	metricSFTP                 = clientmetric.NewCounter("ssh_sftp_sessions")
-	metricLocalPortForward     = clientmetric.NewCounter("ssh_local_port_forward_requests")
-	metricRemotePortForward    = clientmetric.NewCounter("ssh_remote_port_forward_requests")
+	metricActiveSessions      = clientmetric.NewGauge("ssh_active_sessions")
+	metricIncomingConnections = clientmetric.NewCounter("ssh_incoming_connections")
+	metricPublicKeyAccepts    = clientmetric.NewCounter("ssh_publickey_accepts") // accepted subset of ssh_publickey_connections
+	metricTerminalAccept      = clientmetric.NewCounter("ssh_terminalaction_accept")
+	metricTerminalReject      = clientmetric.NewCounter("ssh_terminalaction_reject")
+	metricTerminalMalformed   = clientmetric.NewCounter("ssh_terminalaction_malformed")
+	metricTerminalFetchError  = clientmetric.NewCounter("ssh_terminalaction_fetch_error")
+	metricHolds               = clientmetric.NewCounter("ssh_holds")
+	metricPolicyChangeKick    = clientmetric.NewCounter("ssh_policy_change_kick")
+	metricSFTP                = clientmetric.NewCounter("ssh_sftp_sessions")
+	metricLocalPortForward    = clientmetric.NewCounter("ssh_local_port_forward_requests")
+	metricRemotePortForward   = clientmetric.NewCounter("ssh_remote_port_forward_requests")
 )
 
 // userVisibleError is a wrapper around an error that implements

--- a/tailcfg/tailcfg_test.go
+++ b/tailcfg/tailcfg_test.go
@@ -4,7 +4,6 @@
 package tailcfg_test
 
 import (
-	"encoding"
 	"encoding/json"
 	"net/netip"
 	"os"
@@ -636,30 +635,6 @@ func TestNetInfoFields(t *testing.T) {
 	if have := fieldsOf(reflect.TypeOf(NetInfo{})); !reflect.DeepEqual(have, handled) {
 		t.Errorf("NetInfo.Clone/BasicallyEqually check might be out of sync\nfields: %q\nhandled: %q\n",
 			have, handled)
-	}
-}
-
-type keyIn interface {
-	String() string
-	MarshalText() ([]byte, error)
-}
-
-func testKey(t *testing.T, prefix string, in keyIn, out encoding.TextUnmarshaler) {
-	got, err := in.MarshalText()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := out.UnmarshalText(got); err != nil {
-		t.Fatal(err)
-	}
-	if s := in.String(); string(got) != s {
-		t.Errorf("MarshalText = %q != String %q", got, s)
-	}
-	if !strings.HasPrefix(string(got), prefix) {
-		t.Errorf("%q didn't start with prefix %q", got, prefix)
-	}
-	if reflect.ValueOf(out).Elem().Interface() != in {
-		t.Errorf("mismatch after unmarshal")
 	}
 }
 

--- a/tka/scenario_test.go
+++ b/tka/scenario_test.go
@@ -5,9 +5,7 @@ package tka
 
 import (
 	"crypto/ed25519"
-	"fmt"
 	"sort"
-	"strings"
 	"testing"
 )
 
@@ -98,22 +96,6 @@ func (s *scenarioTest) mkNodeWithForks(name string, signWithDefault bool, chains
 	}
 
 	return n
-}
-
-func aumsToNames(n *scenarioNode, aums []AUM) string {
-	out := make([]string, 0, len(aums))
-outer:
-	for _, a := range aums {
-		for name, candidate := range n.AUMs {
-			if candidate.Hash() == a.Hash() {
-				out = append(out, name)
-				continue outer
-			}
-		}
-		out = append(out, fmt.Sprintf("%x", a.Hash()))
-	}
-
-	return strings.Join(out, ",")
 }
 
 func (s *scenarioTest) syncBetween(n1, n2 *scenarioNode) error {

--- a/tool/gocross/goroot.go
+++ b/tool/gocross/goroot.go
@@ -6,7 +6,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -37,30 +36,6 @@ func makeGoroot(toolchainRoot, outPath string) error {
 	}
 	if err := linkFarm(filepath.Join(toolchainRoot, "bin"), filepath.Join(outPath, "bin")); err != nil {
 		return fmt.Errorf("creating GOROOT/bin link farm: %v", err)
-	}
-
-	return nil
-}
-
-func copyFile(src, dst string) error {
-	s, err := os.Open(src)
-	if err != nil {
-		return fmt.Errorf("opening %q: %v", src, err)
-	}
-	defer s.Close()
-
-	d, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE, 0755)
-	if err != nil {
-		return fmt.Errorf("opening %q: %v", dst, err)
-	}
-
-	if _, err := io.Copy(d, s); err != nil {
-		d.Close()
-		return fmt.Errorf("copying %q to %q: %v", src, dst, err)
-	}
-
-	if err := d.Close(); err != nil {
-		return fmt.Errorf("closing %q: %v", dst, err)
 	}
 
 	return nil

--- a/tstest/archtest/archtest_test.go
+++ b/tstest/archtest/archtest_test.go
@@ -14,7 +14,7 @@ import (
 func TestAlignedAtomicInt64(t *testing.T) {
 	type T struct {
 		A atomicbitops.Int64
-		x int32
+		_ int32
 		B atomicbitops.Int64
 	}
 

--- a/tstest/integration/vms/derive_bindhost_test.go
+++ b/tstest/integration/vms/derive_bindhost_test.go
@@ -4,7 +4,6 @@
 package vms
 
 import (
-	"io"
 	"net/netip"
 	"runtime"
 	"testing"
@@ -43,9 +42,3 @@ func TestDeriveBindhost(t *testing.T) {
 	}
 	t.Log(deriveBindhost(t))
 }
-
-type nopWriteCloser struct {
-	io.Writer
-}
-
-func (nwc nopWriteCloser) Close() error { return nil }

--- a/tstest/integration/vms/vms_steps_test.go
+++ b/tstest/integration/vms/vms_steps_test.go
@@ -19,8 +19,6 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-const timeout = 15 * time.Second
-
 func retry(t *testing.T, fn func() error) {
 	t.Helper()
 	const tries = 3

--- a/tstest/natlab/natlab.go
+++ b/tstest/natlab/natlab.go
@@ -442,16 +442,6 @@ func (m *Machine) forwardPacket(p *Packet, iif *Interface) {
 	oif.net.write(p)
 }
 
-func unspecOf(ip netip.Addr) netip.Addr {
-	if ip.Is4() {
-		return v4unspec
-	}
-	if ip.Is6() {
-		return v6unspec
-	}
-	panic(fmt.Sprintf("bogus IP %#v", ip))
-}
-
 // Attach adds an interface to a machine.
 //
 // The first interface added to a Machine becomes that machine's
@@ -570,19 +560,6 @@ func (m *Machine) interfaceForIP(ip netip.Addr) (*Interface, error) {
 		}
 	}
 	return nil, fmt.Errorf("no route found to %v", ip)
-}
-
-func (m *Machine) hasv6() bool {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	for _, f := range m.interfaces {
-		for _, ip := range f.ips {
-			if ip.Is6() {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func (m *Machine) pickEphemPort() (port uint16, err error) {

--- a/tstime/rate/rate_test.go
+++ b/tstime/rate/rate_test.go
@@ -12,7 +12,6 @@
 package rate
 
 import (
-	"context"
 	"math"
 	"sync"
 	"sync/atomic"
@@ -59,10 +58,6 @@ var (
 	t0 = mono.Now()
 	t1 = t0.Add(time.Duration(1) * d)
 	t2 = t0.Add(time.Duration(2) * d)
-	t3 = t0.Add(time.Duration(3) * d)
-	t4 = t0.Add(time.Duration(4) * d)
-	t5 = t0.Add(time.Duration(5) * d)
-	t9 = t0.Add(time.Duration(9) * d)
 )
 
 type allow struct {
@@ -150,33 +145,6 @@ func TestSimultaneousRequests(t *testing.T) {
 	if numOK != burst {
 		t.Errorf("numOK = %d, want %d", numOK, burst)
 	}
-}
-
-type request struct {
-	t   time.Time
-	n   int
-	act time.Time
-	ok  bool
-}
-
-// dFromDuration converts a duration to a multiple of the global constant d
-func dFromDuration(dur time.Duration) int {
-	// Adding a millisecond to be swallowed by the integer division
-	// because we don't care about small inaccuracies
-	return int((dur + time.Millisecond) / d)
-}
-
-// dSince returns multiples of d since t0
-func dSince(t mono.Time) int {
-	return dFromDuration(t.Sub(t0))
-}
-
-type wait struct {
-	name   string
-	ctx    context.Context
-	n      int
-	delay  int // in multiples of d
-	nilErr bool
 }
 
 func BenchmarkAllowN(b *testing.B) {

--- a/util/deephash/deephash_test.go
+++ b/util/deephash/deephash_test.go
@@ -342,11 +342,11 @@ func getVal() *tailscaleTypes {
 }
 
 type IntThenByte struct {
-	i int
-	b byte
+	_ int
+	_ byte
 }
 
-type TwoInts struct{ a, b int }
+type TwoInts struct{ _, _ int }
 
 type IntIntByteInt struct {
 	i1, i2 int32
@@ -355,7 +355,6 @@ type IntIntByteInt struct {
 }
 
 func u8(n uint8) string   { return string([]byte{n}) }
-func u16(n uint16) string { return string(binary.LittleEndian.AppendUint16(nil, n)) }
 func u32(n uint32) string { return string(binary.LittleEndian.AppendUint32(nil, n)) }
 func u64(n uint64) string { return string(binary.LittleEndian.AppendUint64(nil, n)) }
 func ux(n uint) string {

--- a/util/deephash/types_test.go
+++ b/util/deephash/types_test.go
@@ -78,7 +78,7 @@ func TestTypeIsMemHashable(t *testing.T) {
 
 func TestTypeIsRecursive(t *testing.T) {
 	type RecursiveStruct struct {
-		v *RecursiveStruct
+		_ *RecursiveStruct
 	}
 	type RecursiveChan chan *RecursiveChan
 

--- a/util/syspolicy/policy_keys.go
+++ b/util/syspolicy/policy_keys.go
@@ -73,33 +73,3 @@ const (
 	// The default is "user-decides" unless otherwise stated.
 	PostureChecking Key = "PostureChecking"
 )
-
-var stringKeys = []Key{
-	ControlURL,
-	LogTarget,
-	Tailnet,
-	ExitNodeID,
-	ExitNodeIP,
-	EnableIncomingConnections,
-	EnableServerMode,
-	ExitNodeAllowLANAccess,
-	EnableTailscaleDNS,
-	EnableTailscaleSubnets,
-	AdminConsoleVisibility,
-	NetworkDevicesVisibility,
-	TestMenuVisibility,
-	UpdateMenuVisibility,
-	RunExitNodeVisibility,
-	PreferencesMenuVisibility,
-	ExitNodeMenuVisibility,
-	AutoUpdateVisibility,
-	KeyExpirationNoticeTime,
-	PostureChecking,
-}
-
-var boolKeys = []Key{
-	LogSCMInteractions,
-	FlushDNSOnSessionUnlock,
-}
-
-var uint64Keys = []Key{}

--- a/util/syspolicy/policy_keys_windows.go
+++ b/util/syspolicy/policy_keys_windows.go
@@ -1,0 +1,34 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package syspolicy
+
+var stringKeys = []Key{
+	ControlURL,
+	LogTarget,
+	Tailnet,
+	ExitNodeID,
+	ExitNodeIP,
+	EnableIncomingConnections,
+	EnableServerMode,
+	ExitNodeAllowLANAccess,
+	EnableTailscaleDNS,
+	EnableTailscaleSubnets,
+	AdminConsoleVisibility,
+	NetworkDevicesVisibility,
+	TestMenuVisibility,
+	UpdateMenuVisibility,
+	RunExitNodeVisibility,
+	PreferencesMenuVisibility,
+	ExitNodeMenuVisibility,
+	AutoUpdateVisibility,
+	KeyExpirationNoticeTime,
+	PostureChecking,
+}
+
+var boolKeys = []Key{
+	LogSCMInteractions,
+	FlushDNSOnSessionUnlock,
+}
+
+var uint64Keys = []Key{}

--- a/version/modinfo_test.go
+++ b/version/modinfo_test.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -34,13 +33,6 @@ func TestFindModuleInfo(t *testing.T) {
 	if !strings.HasPrefix(modinfo, prefix) {
 		t.Errorf("unexpected modinfo contents %q", modinfo)
 	}
-}
-
-func exe() string {
-	if runtime.GOOS == "windows" {
-		return ".exe"
-	}
-	return ""
 }
 
 var findModuleInfoName = flag.String("module-info-file", "", "if non-empty, test findModuleInfo against this filename")

--- a/version/prop.go
+++ b/version/prop.go
@@ -40,8 +40,6 @@ func OS() string {
 	return runtime.GOOS
 }
 
-var isSandboxedMacOS lazy.SyncValue[bool]
-
 // IsSandboxedMacOS reports whether this process is a sandboxed macOS
 // process (either the app or the extension). It is true for the Mac App Store
 // and macsys (System Extension) version on macOS, and false for
@@ -210,15 +208,17 @@ var getMeta lazy.SyncValue[Meta]
 
 // GetMeta returns version metadata about the current build.
 func GetMeta() Meta {
-	return Meta{
-		MajorMinorPatch: majorMinorPatch(),
-		Short:           Short(),
-		Long:            Long(),
-		GitCommit:       gitCommit(),
-		GitDirty:        gitDirty(),
-		ExtraGitCommit:  extraGitCommitStamp,
-		IsDev:           isDev(),
-		UnstableBranch:  IsUnstableBuild(),
-		Cap:             int(tailcfg.CurrentCapabilityVersion),
-	}
+	return getMeta.Get(func() Meta {
+		return Meta{
+			MajorMinorPatch: majorMinorPatch(),
+			Short:           Short(),
+			Long:            Long(),
+			GitCommit:       gitCommit(),
+			GitDirty:        gitDirty(),
+			ExtraGitCommit:  extraGitCommitStamp,
+			IsDev:           isDev(),
+			UnstableBranch:  IsUnstableBuild(),
+			Cap:             int(tailcfg.CurrentCapabilityVersion),
+		}
+	})
 }

--- a/wgengine/router/router_linux.go
+++ b/wgengine/router/router_linux.go
@@ -605,10 +605,6 @@ func (r *linuxRouter) getV6Available() bool {
 	return r.nfr.HasIPV6()
 }
 
-func (r *linuxRouter) getV6NATAvailable() bool {
-	return r.nfr.HasIPV6NAT()
-}
-
 // addAddress adds an IP/mask to the tunnel interface. Fails if the
 // address is already assigned to the interface, or if the addition
 // fails.

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -985,8 +985,6 @@ func (e *userspaceEngine) getStatusCallback() StatusCallback {
 	return e.statusCallback
 }
 
-var singleNewline = []byte{'\n'}
-
 var ErrEngineClosing = errors.New("engine closing; no status")
 
 func (e *userspaceEngine) getPeerStatusLite(pk key.NodePublic) (status ipnstate.PeerStatusLite, ok bool) {
@@ -1487,8 +1485,7 @@ func (ls fwdDNSLinkSelector) PickLink(ip netip.Addr) (linkName string) {
 }
 
 var (
-	metricMagicDNSPacketIn = clientmetric.NewCounter("magicdns_packet_in") // for 100.100.100.100
-	metricReflectToOS      = clientmetric.NewCounter("packet_reflect_to_os")
+	metricReflectToOS = clientmetric.NewCounter("packet_reflect_to_os")
 
 	metricNumMajorChanges = clientmetric.NewCounter("wgengine_major_changes")
 	metricNumMinorChanges = clientmetric.NewCounter("wgengine_minor_changes")


### PR DESCRIPTION
Run `staticcheck` with `U1000` to find unused code. This cleans up about a half of it. I'll do the other half separately to keep PRs manageable.

Updates #cleanup