### PR TITLE
net/portmapper: add logs about obtained mapping(s)

### DIFF
--- a/net/portmapper/pcp.go
+++ b/net/portmapper/pcp.go
@@ -58,9 +58,16 @@ type pcpMapping struct {
 	// Doesn't seem to be used elsewhere, but can use it for validation at some point.
 }
 
+func (p *pcpMapping) MappingType() string      { return "pcp" }
 func (p *pcpMapping) GoodUntil() time.Time     { return p.goodUntil }
 func (p *pcpMapping) RenewAfter() time.Time    { return p.renewAfter }
 func (p *pcpMapping) External() netip.AddrPort { return p.external }
+func (p *pcpMapping) MappingDebug() string {
+	return fmt.Sprintf("pcpMapping{gw:%v, external:%v, internal:%v, renewAfter:%d, goodUntil:%d}",
+		p.gw, p.external, p.internal,
+		p.renewAfter.Unix(), p.goodUntil.Unix())
+}
+
 func (p *pcpMapping) Release(ctx context.Context) {
 	uc, err := p.c.listenPacket(ctx, "udp4", ":0")
 	if err != nil {

--- a/net/portmapper/portmapper_test.go
+++ b/net/portmapper/portmapper_test.go
@@ -51,6 +51,7 @@ func TestClientProbeThenMap(t *testing.T) {
 	}
 	c := NewClient(t.Logf, nil, nil, new(controlknobs.Knobs), nil)
 	defer c.Close()
+	c.debug.VerboseLogs = true
 	c.SetLocalPort(1234)
 	res, err := c.Probe(context.Background())
 	t.Logf("Probe: %+v, %v", res, err)

--- a/net/portmapper/upnp.go
+++ b/net/portmapper/upnp.go
@@ -68,9 +68,16 @@ type upnpMapping struct {
 //	https://github.com/tailscale/tailscale/issues/7377
 const upnpProtocolUDP = "UDP"
 
+func (u *upnpMapping) MappingType() string      { return "upnp" }
 func (u *upnpMapping) GoodUntil() time.Time     { return u.goodUntil }
 func (u *upnpMapping) RenewAfter() time.Time    { return u.renewAfter }
 func (u *upnpMapping) External() netip.AddrPort { return u.external }
+func (u *upnpMapping) MappingDebug() string {
+	return fmt.Sprintf("upnpMapping{gw:%v, external:%v, internal:%v, renewAfter:%d, goodUntil:%d, loc:%q}",
+		u.gw, u.external, u.internal,
+		u.renewAfter.Unix(), u.goodUntil.Unix(),
+		u.loc)
+}
 func (u *upnpMapping) Release(ctx context.Context) {
 	u.client.DeletePortMapping(ctx, "", u.external.Port(), upnpProtocolUDP)
 }


### PR DESCRIPTION
This logs additional information about what mapping(s) are obtained during the creation process, including whether we return an existing cached mapping.

Updates #10597

Change-Id: I9ff25071f064c91691db9ab0b9365ccc5f948d6e