### PR TITLE
cmd/tailscale/cli: support human-readable traffic bytes in status

### DIFF
--- a/cmd/tailscale/cli/status.go
+++ b/cmd/tailscale/cli/status.go
@@ -55,19 +55,23 @@ https://github.com/tailscale/tailscale/blob/main/ipn/ipnstate/ipnstate.go
 		fs.BoolVar(&statusArgs.self, "self", true, "show status of local machine")
 		fs.BoolVar(&statusArgs.peers, "peers", true, "show status of peers")
 		fs.StringVar(&statusArgs.listen, "listen", "127.0.0.1:8384", "listen address for web mode; use port 0 for automatic")
-		fs.BoolVar(&statusArgs.browser, "browser", true, "Open a browser in web mode")
+		fs.BoolVar(&statusArgs.browser, "browser", true, "open a browser in web mode")
+		fs.BoolVar(&statusArgs.humanReadableIEC, "human", false, "print human-readable bytes in IEC format (in powers of 1024)")
+		fs.BoolVar(&statusArgs.humanReadableSI, "human-si", false, "print human-readable bytes in SI format (in powers of 1000)")
 		return fs
 	})(),
 }
 
 var statusArgs struct {
-	json    bool   // JSON output mode
-	web     bool   // run webserver
-	listen  string // in web mode, webserver address to listen on, empty means auto
-	browser bool   // in web mode, whether to open browser
-	active  bool   // in CLI mode, filter output to only peers with active sessions
-	self    bool   // in CLI mode, show status of local machine
-	peers   bool   // in CLI mode, show status of peer machines
+	json             bool   // JSON output mode
+	web              bool   // run webserver
+	listen           string // in web mode, webserver address to listen on, empty means auto
+	browser          bool   // in web mode, whether to open browser
+	active           bool   // in CLI mode, filter output to only peers with active sessions
+	self             bool   // in CLI mode, show status of local machine
+	peers            bool   // in CLI mode, show status of peer machines
+	humanReadableIEC bool   // in CLI mode, print human-readable peer traffic bytes in IEC format
+	humanReadableSI  bool   // in CLI mode, print human-readable peer traffic bytes in SI format
 }
 
 func runStatus(ctx context.Context, args []string) error {
@@ -193,7 +197,13 @@ func runStatus(ctx context.Context, args []string) error {
 			}
 		}
 		if anyTraffic {
-			f(", tx %d rx %d", ps.TxBytes, ps.RxBytes)
+			if statusArgs.humanReadableIEC {
+				f("; tx %s rx %s", humanReadableBytes(ps.TxBytes, false), humanReadableBytes(ps.RxBytes, false))
+			} else if statusArgs.humanReadableSI {
+				f("; tx %s rx %s", humanReadableBytes(ps.TxBytes, true), humanReadableBytes(ps.RxBytes, true))
+			} else {
+				f("; tx %d rx %d", ps.TxBytes, ps.RxBytes)
+			}
 		}
 		f("\n")
 	}
@@ -335,4 +345,31 @@ func firstIPString(v []netip.Addr) string {
 		return ""
 	}
 	return v[0].String()
+}
+
+// humanReadableBytes returns a human-readable string for the given number of bytes.
+func humanReadableBytes(b int64, useSI bool) string {
+	var base float64
+	var units []string
+	if useSI {
+		base = 1000
+		units = []string{"B", "kB", "MB", "GB", "TB", "PB", "EB"}
+	} else {
+		base = 1024
+		units = []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"}
+	}
+	if b < int64(base) {
+		return fmt.Sprintf("%d B", b)
+	}
+
+	var exp int
+	div := float64(b)
+	for div >= base {
+		div /= base
+		exp++
+	}
+	if exp >= len(units) {
+		exp = len(units) - 1
+	}
+	return fmt.Sprintf("%.1f %s", div, units[exp])
 }

--- a/cmd/tailscale/cli/status_test.go
+++ b/cmd/tailscale/cli/status_test.go
@@ -1,0 +1,33 @@
+package cli
+
+import "testing"
+
+func TestHumanReadableBytes(t *testing.T) {
+	type args struct {
+		b     int64
+		useSI bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"IEC_0", args{0, false}, "0 B"},
+		{"IEC_42", args{42, false}, "42 B"},
+		{"IEC_1K", args{1024, false}, "1.0 KiB"},
+		{"IEC_1G", args{1073741824, false}, "1.0 GiB"},
+		{"IEC_1E", args{1152921504606846976, false}, "1.0 EiB"},
+		{"SI_0", args{0, true}, "0 B"},
+		{"SI_42", args{42, true}, "42 B"},
+		{"SI_1K", args{1000, true}, "1.0 kB"},
+		{"SI_1G", args{1000000000, true}, "1.0 GB"},
+		{"SI_1E", args{1000000000000000000, true}, "1.0 EB"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := humanReadableBytes(tt.args.b, tt.args.useSI); got != tt.want {
+				t.Errorf("humanReadableBytes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Current `tailscale status` can only display the peer traffic bytes counters (tx & rx) in pure integer numbers, it's hard to read when they are large.

The changes in this commit add two cli flags: `--human` and `--human-si`, to enable displaying human-readable bytes counters in IEC and SI format, respectively.

Fixes #8590