### PR TITLE
net/portmapper: check returned epoch from PMP and PCP protocols

### DIFF
--- a/net/portmapper/pcp.go
+++ b/net/portmapper/pcp.go
@@ -54,8 +54,7 @@ type pcpMapping struct {
 	renewAfter time.Time
 	goodUntil  time.Time
 
-	// TODO should this also contain an epoch?
-	// Doesn't seem to be used elsewhere, but can use it for validation at some point.
+	epoch uint32
 }
 
 func (p *pcpMapping) MappingType() string      { return "pcp" }
@@ -140,6 +139,7 @@ func parsePCPMapResponse(resp []byte) (*pcpMapping, error) {
 		external:   external,
 		renewAfter: now.Add(lifetime / 2),
 		goodUntil:  now.Add(lifetime),
+		epoch:      res.Epoch,
 	}
 
 	return mapping, nil


### PR DESCRIPTION
If the epoch that we see during a Probe is less than the existing epoch, it means that the gateway has either restarted or reset its configuration, and an existing mapping is no longer valid. Reset any saved mapping(s) if we detect this case so that a future createOrGetMapping will not attempt to re-use it.

Updates #10597


Change-Id: Ie3cddaf625cb94a29885f7a1eeea25dbf6b97b47