### PR TITLE
net/interfaces: handle iOS network transitions

### DIFF
--- a/net/interfaces/defaultroute_bsd.go
+++ b/net/interfaces/defaultroute_bsd.go
@@ -1,0 +1,26 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Common code for FreeBSD and Darwin. This might also work on other
+// BSD systems (e.g. OpenBSD) but has not been tested.
+// Not used on iOS. See defaultroute_ios.go.
+
+//go:build !ios && (darwin || freebsd)
+
+package interfaces
+
+import "net"
+
+func defaultRoute() (d DefaultRouteDetails, err error) {
+	idx, err := DefaultRouteInterfaceIndex()
+	if err != nil {
+		return d, err
+	}
+	iface, err := net.InterfaceByIndex(idx)
+	if err != nil {
+		return d, err
+	}
+	d.InterfaceName = iface.Name
+	d.InterfaceIndex = idx
+	return d, nil
+}

--- a/net/interfaces/defaultroute_ios.go
+++ b/net/interfaces/defaultroute_ios.go
@@ -1,0 +1,77 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build ios
+
+package interfaces
+
+import (
+	"log"
+)
+
+func defaultRoute() (d DefaultRouteDetails, err error) {
+	// We cannot rely on the delegated interface data on iOS. The NetworkExtension framework
+	// seems to set the delegate interface only once, upon the *creation* of the VPN tunnel.
+	// If a network transition (e.g. from Wi-Fi to Cellular) happens while the tunnel is
+	// connected, it will be ignored and we will still try to set Wi-Fi as the default route
+	// because the delegated interface is not updated by the NetworkExtension framework.
+	//
+	// Here we special-case iPhones and iPads with a simpler logic that doesn't look at
+	// the routing table: we try finding a hardcoded Wi-Fi interface, if it doesn't have
+	// an address, we fall back to cellular.
+
+	// Start by getting all available interfaces.
+	interfaces, err := netInterfaces()
+	if err != nil {
+		log.Printf("defaultroute_ios: could not get interfaces: %v", err)
+		return d, ErrNoGatewayIndexFound
+	}
+
+	// We start by looking at the Wi-Fi interface, which on iPhone is always called en0.
+	for _, ifc := range interfaces {
+		if ifc.Name != "en0" {
+			continue
+		}
+
+		if !ifc.IsUp() {
+			log.Println("defaultroute_ios: Wi-Fi interface en0 isn't up, will try cellular")
+			break
+		}
+
+		addrs, _ := ifc.Addrs()
+		if len(addrs) == 0 {
+			log.Println("defaultroute_ios: Wi-Fi interface en0 has no addresses")
+			break
+		}
+
+		log.Println("defaultroute_ios: returning Wi-Fi interface en0")
+		d.InterfaceName = ifc.Name
+		d.InterfaceIndex = ifc.Index
+		return d, nil
+	}
+
+	// Did it not work? Let's try with Cellular (pdp_ip0).
+	for _, ifc := range interfaces {
+		if ifc.Name != "pdp_ip0" {
+			continue
+		}
+
+		if !ifc.IsUp() {
+			log.Println("defaultroute_ios: cellular interface pdp_ip0 isn't up")
+			break
+		}
+
+		addrs, _ := ifc.Addrs()
+		if len(addrs) == 0 {
+			log.Println("defaultroute_ios: cellular interface pdp_ip0 has no addresses")
+			break
+		}
+
+		log.Println("defaultroute_ios: returning cellular interface pdp_ip0")
+		d.InterfaceName = ifc.Name
+		d.InterfaceIndex = ifc.Index
+		return d, nil
+	}
+
+	return d, ErrNoGatewayIndexFound
+}

--- a/net/interfaces/interfaces_bsd.go
+++ b/net/interfaces/interfaces_bsd.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"net"
 	"net/netip"
 	"syscall"
 
@@ -20,20 +19,6 @@ import (
 	"golang.org/x/sys/unix"
 	"tailscale.com/net/netaddr"
 )
-
-func defaultRoute() (d DefaultRouteDetails, err error) {
-	idx, err := DefaultRouteInterfaceIndex()
-	if err != nil {
-		return d, err
-	}
-	iface, err := net.InterfaceByIndex(idx)
-	if err != nil {
-		return d, err
-	}
-	d.InterfaceName = iface.Name
-	d.InterfaceIndex = idx
-	return d, nil
-}
 
 // ErrNoGatewayIndexFound is returned by DefaultRouteInterfaceIndex when no
 // default route is found.


### PR DESCRIPTION
Updates #8022
Updates #6075

On iOS, we currently rely on delegated interface information to figure out the default route interface.  The NetworkExtension framework in iOS seems to set the delegate interface only once, upon the *creation* of the VPN tunnel. If a network transition (e.g. from Wi-Fi to Cellular) happens while the tunnel is connected, it will be ignored and we will still try to set Wi-Fi as the default route because the delegated interface is not getting updated as connectivity transitions.

Here, we special-case iPhones and iPads with a simpler logic that doesn't look at the routing table: we try finding a hardcoded Wi-Fi interface called `en0`, if it doesn't have an address, we fall back to cellular, which is `pdp_ip0`.

I tested this on iPhones and iPads running iOS 17.1 and it appears to work. Switching between different cellular plans on a dual SIM configuration also works (the interface name remains `pdp_ip0`).

## To-Dos

- [ ] verify behaviour on other Apple platforms
- [ ] verify `en0` to `en0` transition on Mac
- [ ] verify behaviour on devices with no cellular interface
- [ ] verify behaviour on device with cellular data available, but disabled