### PR TITLE
cmd/tailscale/cli: document usage more clearly

### DIFF
--- a/cmd/tailscale/cli/whois.go
+++ b/cmd/tailscale/cli/whois.go
@@ -18,7 +18,7 @@ import (
 
 var whoisCmd = &ffcli.Command{
 	Name:       "whois",
-	ShortUsage: "whois [--json] [ip|ip:port]",
+	ShortUsage: "whois [--json] ip[:port]",
 	ShortHelp:  "Show the machine and user associated with a Tailscale IP (v4 or v6)",
 	LongHelp: strings.TrimSpace(`
 	'tailscale whois' shows the machine and user associated with a Tailscale IP (v4 or v6).


### PR DESCRIPTION
The IP argument is required; only the port is optional.

Updates #10605