### PR TITLE
release: add shebang to the debian postinst script

### DIFF
--- a/release/deb/debian.postinst.sh
+++ b/release/deb/debian.postinst.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
 	deb-systemd-helper unmask 'tailscaled.service' >/dev/null || true
 	if deb-systemd-helper --quiet was-enabled 'tailscaled.service'; then


### PR DESCRIPTION
Seems like an omission, since we have it in postrm and prerm.

Fixes #10705