### PR TITLE
tsweb: use object-src instead of plugin-types

### DIFF
--- a/tsweb/debug.go
+++ b/tsweb/debug.go
@@ -167,7 +167,7 @@ func debugBrowserHeaderHandler(h http.Handler) http.Handler {
 		// The only difference from AddBrowserHeaders is that this policy
 		// allows inline CSS styles. They make debug pages much easier to
 		// prototype, while the risk of user-injected CSS is relatively low.
-		w.Header().Set("Content-Security-Policy", "default-src 'self'; frame-ancestors 'none'; form-action 'self'; base-uri 'self'; block-all-mixed-content; plugin-types 'none'; style-src 'self' 'unsafe-inline'")
+		w.Header().Set("Content-Security-Policy", "default-src 'self'; frame-ancestors 'none'; form-action 'self'; base-uri 'self'; block-all-mixed-content; object-src 'none'; style-src 'self' 'unsafe-inline'")
 		h.ServeHTTP(w, r)
 	})
 }

--- a/tsweb/tsweb.go
+++ b/tsweb/tsweb.go
@@ -458,7 +458,7 @@ func VarzHandler(w http.ResponseWriter, r *http.Request) {
 // https://infosec.mozilla.org/guidelines/web_security
 func AddBrowserHeaders(w http.ResponseWriter) {
 	w.Header().Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
-	w.Header().Set("Content-Security-Policy", "default-src 'self'; frame-ancestors 'none'; form-action 'self'; base-uri 'self'; block-all-mixed-content; plugin-types 'none'")
+	w.Header().Set("Content-Security-Policy", "default-src 'self'; frame-ancestors 'none'; form-action 'self'; base-uri 'self'; block-all-mixed-content; object-src 'none'")
 	w.Header().Set("X-Frame-Options", "DENY")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 }


### PR DESCRIPTION
plugin-types is deprecated, and setting object-src: 'none' is best practice. This should result in no functional change.

Fixes #10718