### PR TITLE
logpolicy: use syspolicy to override LogTarget

### DIFF
--- a/logpolicy/logpolicy.go
+++ b/logpolicy/logpolicy.go
@@ -48,8 +48,8 @@ import (
 	"tailscale.com/util/clientmetric"
 	"tailscale.com/util/must"
 	"tailscale.com/util/racebuild"
+	"tailscale.com/util/syspolicy"
 	"tailscale.com/util/testenv"
-	"tailscale.com/util/winutil"
 	"tailscale.com/version"
 	"tailscale.com/version/distro"
 )
@@ -61,14 +61,8 @@ var getLogTargetOnce struct {
 
 func getLogTarget() string {
 	getLogTargetOnce.Do(func() {
-		if val, ok := os.LookupEnv("TS_LOG_TARGET"); ok {
-			getLogTargetOnce.v = val
-		} else {
-			if runtime.GOOS == "windows" {
-				logTarget, _ := winutil.GetRegString("LogTarget")
-				getLogTargetOnce.v = logTarget
-			}
-		}
+		envTarget, _ := os.LookupEnv("TS_LOG_TARGET")
+		getLogTargetOnce.v, _ = syspolicy.GetString(syspolicy.LogTarget, envTarget)
 	})
 
 	return getLogTargetOnce.v


### PR DESCRIPTION
Previously, for Windows clients only, a registry value named LogTarget could override the log server, but only if the environment variable was unset.

To allow administrators to enforce using a particular log server, switch this to make the registry value take precedence over the environment variable, and switch to the newer syspolicy.GetString so that the log target can be specified by a GPO more easily.

Updates ENG-2515

Change-Id: Ia618986b0e07715d7db4c6df170a24d511c904c9

Testing: manually tested
1. Old registry value on its own
2. New registry value on its own
3. Environment variable on its own
4. New registry value + environment variable, new registry value wins
5. Nothing set