### PR TITLE
ipn/ipnlocal: return IPv6 addresses in MagicDNS [capver 84]

### DIFF
--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -1136,7 +1136,14 @@ func TestDNSConfigForNetmapForExitNodeConfigs(t *testing.T) {
 			}
 
 			prefs := &ipn.Prefs{ExitNodeID: tc.exitNode, CorpDNS: true}
-			got := dnsConfigForNetmap(nm, peersMap(tc.peers), prefs.View(), t.Logf, "")
+			b := &LocalBackend{
+				netMap: nm,
+				logf:   t.Logf,
+				peers:  peersMap(tc.peers),
+			}
+			b.mu.Lock()
+			got := b.dnsConfigForNetmapLocked(prefs.View(), "")
+			b.mu.Unlock()
 			if !resolversEqual(t, got.DefaultResolvers, tc.wantDefaultResolvers) {
 				t.Errorf("DefaultResolvers: got %#v, want %#v", got.DefaultResolvers, tc.wantDefaultResolvers)
 			}

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -124,7 +124,8 @@ type CapabilityVersion int
 //   - 81: 2023-11-17: MapResponse.PacketFilters (incremental packet filter updates)
 //   - 82: 2023-12-01: Client understands NodeAttrLinuxMustUseIPTables, NodeAttrLinuxMustUseNfTables, c2n /netfilter-kind
 //   - 83: 2023-12-18: Client understands DefaultAutoUpdate
-const CurrentCapabilityVersion CapabilityVersion = 83
+//   - 84: 2023-01-03: Client understands Node.NoIPv6
+const CurrentCapabilityVersion CapabilityVersion = 84
 
 type StableID string
 
@@ -407,6 +408,11 @@ type Node struct {
 	// ExitNodeDNSResolvers is the list of DNS servers that should be used when this
 	// node is marked IsWireGuardOnly and being used as an exit node.
 	ExitNodeDNSResolvers []*dnstype.Resolver `json:",omitempty"`
+
+	// NoIPv6 is set when this node has broken IPv6 support at the
+	// operating system level, and thus cannot receive IPv6 packets even
+	// inside a Wireguard tunnel.
+	NoIPv6 bool `json:",omitempty"`
 }
 
 // HasCap reports whether the node has the given capability.
@@ -2015,7 +2021,8 @@ func (n *Node) Equal(n2 *Node) bool {
 		n.Expired == n2.Expired &&
 		eqPtr(n.SelfNodeV4MasqAddrForThisPeer, n2.SelfNodeV4MasqAddrForThisPeer) &&
 		eqPtr(n.SelfNodeV6MasqAddrForThisPeer, n2.SelfNodeV6MasqAddrForThisPeer) &&
-		n.IsWireGuardOnly == n2.IsWireGuardOnly
+		n.IsWireGuardOnly == n2.IsWireGuardOnly &&
+		n.NoIPv6 == n2.NoIPv6
 }
 
 func eqPtr[T comparable](a, b *T) bool {

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -119,6 +119,7 @@ var _NodeCloneNeedsRegeneration = Node(struct {
 	SelfNodeV6MasqAddrForThisPeer *netip.Addr
 	IsWireGuardOnly               bool
 	ExitNodeDNSResolvers          []*dnstype.Resolver
+	NoIPv6                        bool
 }{})
 
 // Clone makes a deep copy of Hostinfo.

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -198,6 +198,7 @@ func (v NodeView) IsWireGuardOnly() bool { return v.ж.IsWireGuardOnly }
 func (v NodeView) ExitNodeDNSResolvers() views.SliceView[*dnstype.Resolver, dnstype.ResolverView] {
 	return views.SliceOfViews[*dnstype.Resolver, dnstype.ResolverView](v.ж.ExitNodeDNSResolvers)
 }
+func (v NodeView) NoIPv6() bool           { return v.ж.NoIPv6 }
 func (v NodeView) Equal(v2 NodeView) bool { return v.ж.Equal(v2.ж) }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
@@ -236,6 +237,7 @@ var _NodeViewNeedsRegeneration = Node(struct {
 	SelfNodeV6MasqAddrForThisPeer *netip.Addr
 	IsWireGuardOnly               bool
 	ExitNodeDNSResolvers          []*dnstype.Resolver
+	NoIPv6                        bool
 }{})
 
 // View returns a readonly view of Hostinfo.


### PR DESCRIPTION
Unless a node has the "NoIPv6" flag set, return IPv6 addresses for that node in MagicDNS. Also bump the capability version so control can determine whether to send this field to the client.


Change-Id: Ia36b9c787af32d5904320893be88be3d3873d72e