### PR TITLE
taildrop: remove breaking abstraction layers for apple

### DIFF
--- a/cmd/tailscaled/taildrop.go
+++ b/cmd/tailscaled/taildrop.go
@@ -27,7 +27,6 @@ func configureTaildrop(logf logger.Logf, lb *ipnlocal.LocalBackend) {
 		} else {
 			logf("%s Taildrop: using %v", dg, path)
 			lb.SetDirectFileRoot(path)
-			lb.SetDirectFileDoFinalRename(true)
 		}
 	}
 

--- a/ipn/backend.go
+++ b/ipn/backend.go
@@ -175,6 +175,7 @@ type PartialFile struct {
 	// in-progress '*.partial' file's path when the peerapi isn't
 	// being used; see LocalBackend.SetDirectFileRoot.
 	PartialPath string `json:",omitempty"`
+	FinalPath   string `json:",omitempty"`
 
 	// Done is set in "direct" mode when the partial file has been
 	// closed and is ready for the caller to rename away the

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -265,9 +265,8 @@ type LocalBackend struct {
 	// It's also used on several NAS platforms (Synology, TrueNAS, etc)
 	// but in that case DoFinalRename is also set true, which moves the
 	// *.partial file to its final name on completion.
-	directFileRoot          string
-	directFileDoFinalRename bool // false on macOS, true on several NAS platforms
-	componentLogUntil       map[string]componentLogState
+	directFileRoot    string
+	componentLogUntil map[string]componentLogState
 	// c2nUpdateStatus is the status of c2n-triggered client update.
 	c2nUpdateStatus     updateStatus
 	currentUser         ipnauth.WindowsToken
@@ -538,17 +537,6 @@ func (b *LocalBackend) SetDirectFileRoot(dir string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.directFileRoot = dir
-}
-
-// SetDirectFileDoFinalRename sets whether the peerapi file server should rename
-// a received "name.partial" file to "name" when the download is complete.
-//
-// This only applies when SetDirectFileRoot is non-empty.
-// The default is false.
-func (b *LocalBackend) SetDirectFileDoFinalRename(v bool) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	b.directFileDoFinalRename = v
 }
 
 // ReloadConfig reloads the backend's config from disk.
@@ -3877,13 +3865,12 @@ func (b *LocalBackend) initPeerAPIListener() {
 	ps := &peerAPIServer{
 		b: b,
 		taildrop: taildrop.ManagerOptions{
-			Logf:             b.logf,
-			Clock:            tstime.DefaultClock{Clock: b.clock},
-			State:            b.store,
-			Dir:              fileRoot,
-			DirectFileMode:   b.directFileRoot != "",
-			AvoidFinalRename: !b.directFileDoFinalRename,
-			SendFileNotify:   b.sendFileNotify,
+			Logf:           b.logf,
+			Clock:          tstime.DefaultClock{Clock: b.clock},
+			State:          b.store,
+			Dir:            fileRoot,
+			DirectFileMode: b.directFileRoot != "",
+			SendFileNotify: b.sendFileNotify,
 		}.New(),
 	}
 	if dm, ok := b.sys.DNSManager.GetOK(); ok {

--- a/taildrop/resume.go
+++ b/taildrop/resume.go
@@ -64,9 +64,6 @@ func (m *Manager) PartialFiles(id ClientID) (ret []string, err error) {
 	if m == nil || m.opts.Dir == "" {
 		return nil, ErrNoTaildrop
 	}
-	if m.opts.DirectFileMode && m.opts.AvoidFinalRename {
-		return nil, nil // resuming is not supported for users that peek at our file structure
-	}
 
 	suffix := id.partialSuffix()
 	if err := rangeDir(m.opts.Dir, func(de fs.DirEntry) bool {
@@ -90,9 +87,6 @@ func (m *Manager) HashPartialFile(id ClientID, baseName string) (next func() (Bl
 	}
 	noopNext := func() (BlockChecksum, error) { return BlockChecksum{}, io.EOF }
 	noopClose := func() error { return nil }
-	if m.opts.DirectFileMode && m.opts.AvoidFinalRename {
-		return noopNext, noopClose, nil // resuming is not supported for users that peek at our file structure
-	}
 
 	dstFile, err := joinDir(m.opts.Dir, baseName)
 	if err != nil {

--- a/taildrop/taildrop.go
+++ b/taildrop/taildrop.go
@@ -90,15 +90,6 @@ type ManagerOptions struct {
 	// copy them out, and then delete them.
 	DirectFileMode bool
 
-	// AvoidFinalRename specifies whether in DirectFileMode
-	// we should avoid renaming "foo.jpg.partial" to "foo.jpg" after reception.
-	//
-	// TODO(joetsai,rhea): Delete this. This is currently depended upon
-	// in the Apple platforms since it violates the abstraction layer
-	// and directly assumes how taildrop represents partial files.
-	// Right now, file resumption does not work on Apple.
-	AvoidFinalRename bool
-
 	// SendFileNotify is called periodically while a file is actively
 	// receiving the contents for the file. There is a final call
 	// to the function when reception completes.
@@ -244,6 +235,7 @@ func (m *Manager) IncomingFiles() []ipn.PartialFile {
 			DeclaredSize: f.size,
 			Received:     f.copied,
 			PartialPath:  f.partialPath,
+			FinalPath:    f.finalPath,
 			Done:         f.done,
 		})
 		return true


### PR DESCRIPTION
Removes the avoidFinalRename logic and all associated code as it is no longer required by the Apple clients. Enables resume logic to be usable for Apple clients.

Fixes tailscale/corp#14772

This and tailscale/corp#16589 need to be merged at the same time because there are dependencies for the apple client behavior in these two PRs