### PR TITLE
cmd/containerboot: ensure that --advertise-routes can be unset

### DIFF
--- a/cmd/containerboot/main_test.go
+++ b/cmd/containerboot/main_test.go
@@ -219,6 +219,28 @@ func TestContainerBoot(t *testing.T) {
 			},
 		},
 		{
+			Name: "empty routes",
+			Env: map[string]string{
+				"TS_AUTHKEY": "tskey-key",
+				"TS_ROUTES":  "",
+			},
+			Phases: []phase{
+				{
+					WantCmds: []string{
+						"/usr/bin/tailscaled --socket=/tmp/tailscaled.sock --state=mem: --statedir=/tmp --tun=userspace-networking",
+						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --authkey=tskey-key --advertise-routes=",
+					},
+				},
+				{
+					Notify: runningNotify,
+					WantFiles: map[string]string{
+						"proc/sys/net/ipv4/ip_forward":          "0",
+						"proc/sys/net/ipv6/conf/all/forwarding": "0",
+					},
+				},
+			},
+		},
+		{
 			Name: "routes_kernel_ipv4",
 			Env: map[string]string{
 				"TS_AUTHKEY":   "tskey-key",


### PR DESCRIPTION
A Tailnet node can be told to stop advertise subnets by passing an empty string to `--advertise-routes` flag to `tailscale up`/`tailscale set`.
containerboot currently ignores `TS_ROUTES` if it's set to empty string, which means that the only way to stop a containerised tailscale with `TS_AUTH_ONCE` set to true would be to recreate it (if it's not created with `TS_AUTH_ONCE` this can probably be achieved by passing `--advertise-routes` to `TS_EXTRA_ARGS` instead (?)).
This would cause issues for #10724 where we should allow subnet routes to be added as well as removed from an existing `Connector` custom resource.
This PR ensures that if `TS_ROUTES` is empty (either because it's unset or explicitly set to empty string) `--advertise-routes` too is set to empty string.

This means that we do not distinguish between `TS_ROUTES` env var being unset vs being set to an empty string explicitly, but I cannot think how that would cause issues, given that in containers presumably the desired config is always passed in full.

Updates tailscale/tailscale#10708