### PR TITLE
cmd/containerboot: don't parse empty subnet routes

### DIFF
--- a/cmd/containerboot/main.go
+++ b/cmd/containerboot/main.go
@@ -756,7 +756,7 @@ func ensureIPForwarding(root, clusterProxyTarget, tailnetTargetiP, tailnetTarget
 	if tailnetTargetFQDN != "" {
 		v4Forwarding = true
 	}
-	if routes != nil {
+	if routes != nil && *routes != "" {
 		for _, route := range strings.Split(*routes, ",") {
 			cidr, err := netip.ParsePrefix(route)
 			if err != nil {


### PR DESCRIPTION
Fixes a bug introduced [here](https://github.com/tailscale/tailscale/pull/10734/commits/fdbbf9ee95b717261e8d81077a73d5a9fbaacfb7#diff-700830ac79a41da42cd3a82065f0fee3003a4390eead4db1de4bf30557a06bd6L748-R759)  - I assumed that [`strings.Split`](https://github.com/tailscale/tailscale/blob/v1.56.1/cmd/containerboot/main.go#L749) returns an empty slice for an empty target, however it [returns a slice with one item](https://pkg.go.dev/strings#Split) - which causes us to loop over routes once and fail when parsing the empty string as an IP address:
```
$ k logs ts-prod-dg76j-0 -n tailscale
Defaulted container "tailscale" out of: tailscale, sysctler (init)
boot: 2024/01/04 11:46:39 Failed to enable IP forwarding: invalid subnet route: netip.ParsePrefix(""): no '/'
```