### PR TITLE
cmd/containerboot: provide extra args to 'tailscale set'

### DIFF
--- a/cmd/containerboot/main.go
+++ b/cmd/containerboot/main.go
@@ -25,6 +25,10 @@
 //     destination defined by a MagicDNS name.
 //   - TS_TAILSCALED_EXTRA_ARGS: extra arguments to 'tailscaled'.
 //   - TS_EXTRA_ARGS: extra arguments to 'tailscale up'.
+//   - TS_SET_EXTRA_ARGS: extra arguments to 'tailscale set'.'tailscale set' is
+//     run on subsequent container restarts if TS_AUTH_ONCE is set to true. It
+//     gets passed values of TS_ACCEPT_DNS, TS_SOCKET, TS_ROUTES, TS_HOSTNAME
+//     and TS_SET_EXTRA_ARGS.
 //   - TS_USERSPACE: run with userspace networking (the default)
 //     instead of kernel networking.
 //   - TS_STATE_DIR: the directory in which to store tailscaled
@@ -111,6 +115,7 @@ func main() {
 		TailnetTargetFQDN: defaultEnv("TS_TAILNET_TARGET_FQDN", ""),
 		DaemonExtraArgs:   defaultEnv("TS_TAILSCALED_EXTRA_ARGS", ""),
 		ExtraArgs:         defaultEnv("TS_EXTRA_ARGS", ""),
+		SetExtraArgs:      defaultEnv("TS_SET_EXTRA_ARGS", ""),
 		InKubernetes:      os.Getenv("KUBERNETES_SERVICE_HOST") != "",
 		UserspaceMode:     defaultBool("TS_USERSPACE", true),
 		StateDir:          defaultEnv("TS_STATE_DIR", ""),
@@ -695,6 +700,9 @@ func tailscaleSet(ctx context.Context, cfg *settings) error {
 	if cfg.Hostname != "" {
 		args = append(args, "--hostname="+cfg.Hostname)
 	}
+	if cfg.SetExtraArgs != "" {
+		args = append(args, strings.Fields(cfg.SetExtraArgs)...)
+	}
 	log.Printf("Running 'tailscale set'")
 	cmd := exec.CommandContext(ctx, "tailscale", args...)
 	cmd.Stdout = os.Stdout
@@ -877,6 +885,7 @@ type settings struct {
 	ServeConfigPath    string
 	DaemonExtraArgs    string
 	ExtraArgs          string
+	SetExtraArgs       string
 	InKubernetes       bool
 	UserspaceMode      bool
 	StateDir           string

--- a/cmd/containerboot/main_test.go
+++ b/cmd/containerboot/main_test.go
@@ -350,8 +350,9 @@ func TestContainerBoot(t *testing.T) {
 		{
 			Name: "authkey_once",
 			Env: map[string]string{
-				"TS_AUTHKEY":   "tskey-key",
-				"TS_AUTH_ONCE": "true",
+				"TS_AUTHKEY":        "tskey-key",
+				"TS_AUTH_ONCE":      "true",
+				"TS_SET_EXTRA_ARGS": "--advertise-exit-node=true --advertise-app-connector=true",
 			},
 			Phases: []phase{
 				{
@@ -370,7 +371,7 @@ func TestContainerBoot(t *testing.T) {
 				{
 					Notify: runningNotify,
 					WantCmds: []string{
-						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock set --accept-dns=false",
+						"/usr/bin/tailscale --socket=/tmp/tailscaled.sock set --accept-dns=false --advertise-exit-node=true --advertise-app-connector=true",
 					},
 				},
 			},


### PR DESCRIPTION
#### Context

Introduces a new `TS_SET_EXTRA_ARGS` that can be used to provide additonal args to 'tailscale set'.

In #10724 we are adding functionality to the `Connector` custom resource to allow users to set the Tailscale node created for the `Connector` as an exit node. Tailscale Kubernetes operator should configure the node to advertise exit node/not advertise exit node in response to changes users make to `isExitNode` field on `Connector` spec.
However, currently it is not possible to _change_ the `--advertise-exit-node` flag value for operator proxies because the only way how to pass it is `TS_EXTRA_ARGS` env var that is [only read when the Tailnet node is created]() and not on subsequent updates/container restarts.

#### Long term

It is of course not optimal to add another env var there- long term we should either teach `tailscale login`/`tailscale set` to read config from a file or have some shim in containerboot that reads config from a file and configures `tailscale` accordingly.

#### Alternatives

- instead of `TS_EXTRA_ARGS` add `TS_IS_EXIT_NODE`. But we probably will also need to allow to pass `--advertise-app-connector` (maybe before we have time to build a better configuration mechanism?) so that'd be two env vars instead of one.

- don't do this, tell users that `connector.spec.isExitNode` cannot be changed post- `Connector` creation and some time in future fix it by implementing a better config mechanism (see above). Bad user experience for `Connector` in short term.

- don't `TS_AUTH_ONCE` for `Connector` or don't clean up the auth key so the operator can force the proxy to log in if it has detected that the exit node setting has changed (?). Probably hacky and error prone

Updates tailscale/tailscale#10708