### PR TITLE
taildrop: Allow category Z unicode characters

### DIFF
--- a/taildrop/taildrop.go
+++ b/taildrop/taildrop.go
@@ -169,7 +169,7 @@ func validFilenameRune(r rune) bool {
 		// sent.
 		return false
 	}
-	return unicode.IsPrint(r)
+	return unicode.IsGraphic(r)
 }
 
 func isPartialOrDeleted(s string) bool {

--- a/taildrop/taildrop_test.go
+++ b/taildrop/taildrop_test.go
@@ -55,6 +55,7 @@ func TestNextFilename(t *testing.T) {
 		{"my song.mp3", "my song (1).mp3", "my song (2).mp3"},
 		{"archive.7z", "archive (1).7z", "archive (2).7z"},
 		{"foo/bar/fizz", "foo/bar/fizz (1)", "foo/bar/fizz (2)"},
+		{"新完全マスター　N2　文法.pdf", "新完全マスター　N2　文法 (1).pdf", "新完全マスター　N2　文法 (2).pdf"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This will expand the unicode character categories that we allow for valid filenames to go from "L, M, N, P, S, and the ASCII space character" to "L, M, N, P, S, Zs"

Fixes #10105