### PR TITLE
cmd/tailscaled, tsnet: don't return an interface containing a nil pointer

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -511,7 +511,13 @@ func getLocalBackend(ctx context.Context, logf logger.Logf, logID logid.PublicID
 			return ok
 		}
 		dialer.NetstackDialTCP = func(ctx context.Context, dst netip.AddrPort) (net.Conn, error) {
-			return ns.DialContextTCP(ctx, dst)
+			// Note: don't just return ns.DialContextTCP or we'll
+			// return an interface containing a nil pointer.
+			tcpConn, err := ns.DialContextTCP(ctx, dst)
+			if err != nil {
+				return nil, err
+			}
+			return tcpConn, nil
 		}
 	}
 	if socksListener != nil || httpProxyListener != nil {

--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -546,7 +546,13 @@ func (s *Server) start() (reterr error) {
 		return ok
 	}
 	s.dialer.NetstackDialTCP = func(ctx context.Context, dst netip.AddrPort) (net.Conn, error) {
-		return ns.DialContextTCP(ctx, dst)
+		// Note: don't just return ns.DialContextTCP or we'll
+		// return an interface containing a nil pointer.
+		tcpConn, err := ns.DialContextTCP(ctx, dst)
+		if err != nil {
+			return nil, err
+		}
+		return tcpConn, nil
 	}
 
 	if s.Store == nil {


### PR DESCRIPTION
This tripped me up when I was testing something and wrote:

    if conn != nil {
        conn.Close()
    }

In netstack mode, when an error occurred we were getting a non-nil error and a non-nil interface that contained a nil pointer. Instead, just return a nil interface value.

Updates #cleanup


Change-Id: Id9ef3dd24529e0e8c53adc60ed914c31fbb10cc4