### PR TITLE
net/netutil: allow 16-bit 4via6 site IDs

### DIFF
--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -719,6 +719,24 @@ func TestPrefsFromUpArgs(t *testing.T) {
 			},
 		},
 		{
+			name: "via_route_good_16_bit",
+			goos: "linux",
+			args: upArgsT{
+				advertiseRoutes: "fd7a:115c:a1e0:b1a::aabb:10.0.0.0/112",
+				netfilterMode:   "off",
+			},
+			want: &ipn.Prefs{
+				WantRunning: true,
+				NoSNAT:      true,
+				AdvertiseRoutes: []netip.Prefix{
+					netip.MustParsePrefix("fd7a:115c:a1e0:b1a::aabb:10.0.0.0/112"),
+				},
+				AutoUpdate: ipn.AutoUpdatePrefs{
+					Check: true,
+				},
+			},
+		},
+		{
 			name: "via_route_short_prefix",
 			goos: "linux",
 			args: upArgsT{
@@ -734,7 +752,7 @@ func TestPrefsFromUpArgs(t *testing.T) {
 				advertiseRoutes: "fd7a:115c:a1e0:b1a:1234:5678::/112",
 				netfilterMode:   "off",
 			},
-			wantErr: "route fd7a:115c:a1e0:b1a:1234:5678::/112 contains invalid site ID 12345678; must be 0xff or less",
+			wantErr: "route fd7a:115c:a1e0:b1a:1234:5678::/112 contains invalid site ID 12345678; must be 0xffff or less",
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/tailscale/cli/debug.go
+++ b/cmd/tailscale/cli/debug.go
@@ -693,8 +693,8 @@ func runVia(ctx context.Context, args []string) error {
 		if err != nil {
 			return fmt.Errorf("invalid site-id %q; must be decimal or hex with 0x prefix", args[0])
 		}
-		if siteID > 0xff {
-			return fmt.Errorf("site-id values over 255 are currently reserved")
+		if siteID > 0xffff {
+			return fmt.Errorf("site-id values over 65535 are currently reserved")
 		}
 		ipp, err := netip.ParsePrefix(args[1])
 		if err != nil {

--- a/net/netutil/routes.go
+++ b/net/netutil/routes.go
@@ -29,11 +29,12 @@ func validateViaPrefix(ipp netip.Prefix) error {
 	// The first 64 bits of a are the via prefix.
 	// The next 32 bits are the "site ID".
 	// The last 32 bits are the IPv4.
-	// For now, we reserve the top 3 bytes of the site ID,
-	// and only allow users to use site IDs 0-255.
+	//
+	// We used to only allow advertising site IDs from 0-255, but we have
+	// since relaxed this (as of 2024-01) to allow IDs from 0-65535.
 	siteID := binary.BigEndian.Uint32(a[8:12])
-	if siteID > 0xFF {
-		return fmt.Errorf("route %v contains invalid site ID %08x; must be 0xff or less", ipp, siteID)
+	if siteID > 0xFFFF {
+		return fmt.Errorf("route %v contains invalid site ID %08x; must be 0xffff or less", ipp, siteID)
 	}
 	return nil
 }


### PR DESCRIPTION
The prefix has space for 32-bit site IDs, but the validateViaPrefix function would previously have disallowed site IDs greater than 255.

Fixes tailscale/corp#16470


Change-Id: I4cdb0711dafb577fae72d86c4014cf623fa538ef