### PR TITLE
client/web: ensure path prefix has a leading slash

### DIFF
--- a/client/web/web.go
+++ b/client/web/web.go
@@ -176,11 +176,12 @@ func NewServer(opts ServerOpts) (s *Server, err error) {
 		waitAuthURL: opts.WaitAuthURL,
 	}
 	if opts.PathPrefix != "" {
-		// In enforcePrefix, we add the necessary leading '/'. If we did not
-		// strip 1 or more leading '/'s here, we would end up redirecting
-		// clients to e.g. //example.com (a schema-less URL that points to
-		// another site). See https://github.com/tailscale/corp/issues/16268.
-		s.pathPrefix = strings.TrimLeft(path.Clean(opts.PathPrefix), "/\\")
+		// Enforce that path prefix always has a single leading '/'
+		// so that it is treated as a relative URL path.
+		// We strip multiple leading '/' to prevent schema-less offsite URLs like "//example.com".
+		//
+		// See https://github.com/tailscale/corp/issues/16268.
+		s.pathPrefix = "/" + strings.TrimLeft(path.Clean(opts.PathPrefix), "/\\")
 	}
 	if s.mode == ManageServerMode {
 		if opts.NewAuthURL == nil {


### PR DESCRIPTION
This is simply an extra check to prevent hypothetical issues if a prefix such as `--prefix="javascript:alert(1)"` was provided.  This isn't really necessary since the prefix is a configuration flag provided by the device owner, not user input.  But it does enforce that we are always interpreting the provided value as a path relative to the root.

Fixes: tailscale/corp#16268