### PR TITLE
cmd/k8s-operator: remove configuration knob for Connector functionality

### DIFF
--- a/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
+++ b/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
@@ -59,8 +59,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: ENABLE_CONNECTOR
-              value: "{{ .Values.enableConnector }}"
             - name: CLIENT_ID_FILE
               value: /oauth/client_id
             - name: CLIENT_SECRET_FILE

--- a/cmd/k8s-operator/deploy/chart/values.yaml
+++ b/cmd/k8s-operator/deploy/chart/values.yaml
@@ -8,10 +8,6 @@ oauth: {}
   # clientId: ""
   # clientSecret: ""
 
-# enableConnector determines whether the operator should reconcile
-# connector.tailscale.com custom resources.
-enableConnector: "false"
-
 # installCRDs determines whether tailscale.com CRDs should be installed as part
 # of chart installation. We do not use Helm's CRD installation mechanism as that
 # does not allow for upgrading CRDs.

--- a/cmd/k8s-operator/deploy/manifests/operator.yaml
+++ b/cmd/k8s-operator/deploy/manifests/operator.yaml
@@ -286,8 +286,6 @@ spec:
                       valueFrom:
                         fieldRef:
                             fieldPath: metadata.namespace
-                    - name: ENABLE_CONNECTOR
-                      value: "false"
                     - name: CLIENT_ID_FILE
                       value: /oauth/client_id
                     - name: CLIENT_SECRET_FILE


### PR DESCRIPTION
The configuration knob (that defaulted to Connector being disabled) was added largely because the Connector CRD had to be installed in a separate step. Now when the CRD has been added to both chart and static manifest, we can have it on by default.

This PR removes the `ENABLE_CONNECTOR` configuration knob (this was never released) and make the connector reconciler always run. This means that the `connectors.tailscale.com` CRD has to be always installed (else the reconciler would error when trying to retrieve an object of schema that the api-server does not understand). This is fine as we now always install the CRD by default.

The latest published 'unstable' Helm chart `v1.57.70` and the static manifest at ./cmd/k8s-operator/deploy/manifests/operator.yaml` both install the CRD by default.
