### PR TITLE
cli/set: add printout when web client started

### DIFF
--- a/cmd/tailscale/cli/set.go
+++ b/cmd/tailscale/cli/set.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
+	"tailscale.com/client/web"
 	"tailscale.com/clientupdate"
 	"tailscale.com/ipn"
 	"tailscale.com/net/netutil"
@@ -193,7 +194,15 @@ func runSet(ctx context.Context, args []string) (retErr error) {
 	}
 
 	_, err = localClient.EditPrefs(ctx, maskedPrefs)
-	return err
+	if err != nil {
+		return err
+	}
+
+	if setArgs.runWebClient && len(st.TailscaleIPs) > 0 {
+		printf("\nWeb interface now running at %s:%d", st.TailscaleIPs[0], web.ListenPort)
+	}
+
+	return nil
 }
 
 // calcAdvertiseRoutesForSet returns the new value for Prefs.AdvertiseRoutes based on the


### PR DESCRIPTION
Prints a helpful message with the web UI's address when running tailscale set --webclient.

Updates tailscale/corp#16345

```
$ tailscale set --webclient

Web interface now running at 100.101.101.101:5252
```