### PR TITLE
safesocket: detect macsys from within tailscaled

### DIFF
--- a/safesocket/safesocket_darwin.go
+++ b/safesocket/safesocket_darwin.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"tailscale.com/version"
 )
 
 func init() {
@@ -72,7 +74,7 @@ func localTCPPortAndTokenDarwin() (port int, token string, err error) {
 
 	if dir := os.Getenv("TS_MACOS_CLI_SHARED_DIR"); dir != "" {
 		// First see if we're running as the non-AppStore "macsys" variant.
-		if strings.Contains(os.Getenv("HOME"), "/Containers/io.tailscale.ipn.macsys/") {
+		if version.IsMacSysExt() {
 			if port, token, err := localTCPPortAndTokenMacsys(); err == nil {
 				return port, token, nil
 			}


### PR DESCRIPTION
macOS environment variables needed by safesocket are currently only being properly populated when called from the CLI. When using safesocket from within tailscaled (not typical, but done for the device web UI), HOME is not set, for example.  Instead, use XPC_SERVICE_NAME to detect that we are running on macsys.

This fixes the device web UI on macsys.

Updates tailscale/corp#16393