### PR TITLE
wgengine/router: look up absolute path to netsh.exe on Windows

### DIFF
--- a/wgengine/router/router_windows_test.go
+++ b/wgengine/router/router_windows_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package router
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestGetNetshPath(t *testing.T) {
+	ft := &firewallTweaker{
+		logf: t.Logf,
+	}
+	path := ft.getNetshPath()
+	if !filepath.IsAbs(path) {
+		t.Errorf("expected absolute path for netsh.exe: %q", path)
+	}
+}


### PR DESCRIPTION
This is in response to logs from a customer that show that we're unable to run netsh due to the following error:

    router: firewall: adding Tailscale-Process rule to allow UDP for "C:\\Program Files\\Tailscale\\tailscaled.exe" ...
    router: firewall: error adding Tailscale-Process rule: exec: "netsh": cannot run executable found relative to current directory:

There's approximately no reason to ever dynamically look up the path of a system utility like netsh.exe, so instead let's first look for it in the System32 directory and only if that fails fall back to the previous behaviour.

Updates #10804

Change-Id: I68cfeb4cab091c79ccff3187d35f50359a690573