### PR TITLE
Makefile,build_docker.sh: build dev images for linux/amd64 only, allow to configure target platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ SYNO_ARCH ?= "amd64"
 SYNO_DSM ?= "7"
 TAGS ?= "latest"
 
+PLATFORM ?= "flyio" ## flyio==linux/amd64. Set to "" to build all platforms.
+
 vet: ## Run go vet
 	./tool/go vet ./...
 
@@ -88,7 +90,7 @@ publishdevimage: ## Build and publish tailscale image to location specified by $
 	@test "${REPO}" != "ghcr.io/tailscale/tailscale" || (echo "REPO=... must not be ghcr.io/tailscale/tailscale" && exit 1)
 	@test "${REPO}" != "tailscale/k8s-operator" || (echo "REPO=... must not be tailscale/k8s-operator" && exit 1)
 	@test "${REPO}" != "ghcr.io/tailscale/k8s-operator" || (echo "REPO=... must not be ghcr.io/tailscale/k8s-operator" && exit 1)
-	TAGS="${TAGS}" REPOS=${REPO} PUSH=true TARGET=client ./build_docker.sh
+	TAGS="${TAGS}" REPOS=${REPO} PLATFORM=${PLATFORM} PUSH=true TARGET=client ./build_docker.sh
 
 publishdevoperator: ## Build and publish k8s-operator image to location specified by ${REPO}
 	@test -n "${REPO}" || (echo "REPO=... required; e.g. REPO=ghcr.io/${USER}/tailscale" && exit 1)
@@ -96,7 +98,7 @@ publishdevoperator: ## Build and publish k8s-operator image to location specifie
 	@test "${REPO}" != "ghcr.io/tailscale/tailscale" || (echo "REPO=... must not be ghcr.io/tailscale/tailscale" && exit 1)
 	@test "${REPO}" != "tailscale/k8s-operator" || (echo "REPO=... must not be tailscale/k8s-operator" && exit 1)
 	@test "${REPO}" != "ghcr.io/tailscale/k8s-operator" || (echo "REPO=... must not be ghcr.io/tailscale/k8s-operator" && exit 1)
-	TAGS="${TAGS}" REPOS=${REPO} PUSH=true TARGET=operator ./build_docker.sh
+	TAGS="${TAGS}" REPOS=${REPO} PLATFORM=${PLATFORM} PUSH=true TARGET=operator ./build_docker.sh
 
 help: ## Show this help
 	@echo "\nSpecify a command. The choices are:\n"

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -32,6 +32,7 @@ PUSH="${PUSH:-false}"
 TARGET="${TARGET:-${DEFAULT_TARGET}}"
 TAGS="${TAGS:-${DEFAULT_TAGS}}"
 BASE="${BASE:-${DEFAULT_BASE}}"
+PLATFORM="${PLATFORM:-}" # default to all platforms
 
 case "$TARGET" in
   client)
@@ -50,6 +51,7 @@ case "$TARGET" in
       --tags="${TAGS}" \
       --repos="${REPOS}" \
       --push="${PUSH}" \
+      --target="${PLATFORM}" \
       /usr/local/bin/containerboot
     ;;
   operator)
@@ -65,6 +67,7 @@ case "$TARGET" in
       --tags="${TAGS}" \
       --repos="${REPOS}" \
       --push="${PUSH}" \
+      --target="${PLATFORM}" \
       /usr/local/bin/operator
     ;;
   *)


### PR DESCRIPTION
Build dev tailscale and k8s-operator images for linux/amd64 only by default, make it possible to configure target build platform via PLATFORM var.

To make it easier for folks who are working on containerboot and operator and build the images frequently.

Updates#cleanup