### PR TITLE
client/web: add initial types for using peer capabilities

### DIFF
--- a/client/web/web.go
+++ b/client/web/web.go
@@ -450,10 +450,11 @@ type authResponse struct {
 // viewerIdentity is the Tailscale identity of the source node
 // connected to this web client.
 type viewerIdentity struct {
-	LoginName     string `json:"loginName"`
-	NodeName      string `json:"nodeName"`
-	NodeIP        string `json:"nodeIP"`
-	ProfilePicURL string `json:"profilePicUrl,omitempty"`
+	LoginName     string           `json:"loginName"`
+	NodeName      string           `json:"nodeName"`
+	NodeIP        string           `json:"nodeIP"`
+	ProfilePicURL string           `json:"profilePicUrl,omitempty"`
+	Capabilities  peerCapabilities `json:"capabilities"` // features peer is allowed to edit
 }
 
 // serverAPIAuth handles requests to the /api/auth endpoint
@@ -464,10 +465,16 @@ func (s *Server) serveAPIAuth(w http.ResponseWriter, r *http.Request) {
 	session, whois, status, sErr := s.getSession(r)
 
 	if whois != nil {
+		caps, err := toPeerCapabilities(whois)
+		if err != nil {
+			http.Error(w, sErr.Error(), http.StatusInternalServerError)
+			return
+		}
 		resp.ViewerIdentity = &viewerIdentity{
 			LoginName:     whois.UserProfile.LoginName,
 			NodeName:      whois.Node.Name,
 			ProfilePicURL: whois.UserProfile.ProfilePicURL,
+			Capabilities:  caps,
 		}
 		if addrs := whois.Node.Addresses; len(addrs) > 0 {
 			resp.ViewerIdentity.NodeIP = addrs[0].Addr().String()

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -1341,6 +1341,9 @@ const (
 	PeerCapabilityWakeOnLAN PeerCapability = "https://tailscale.com/cap/wake-on-lan"
 	// PeerCapabilityIngress grants the ability for a peer to send ingress traffic.
 	PeerCapabilityIngress PeerCapability = "https://tailscale.com/cap/ingress"
+	// PeerCapabilityWebUI grants the ability for a peer to edit features from the
+	// device Web UI.
+	PeerCapabilityWebUI PeerCapability = "tailscale.com/cap/webui"
 )
 
 // NodeCapMap is a map of capabilities to their optional values. It is valid for


### PR DESCRIPTION
Sets up peer capability types for future use within the web client views and APIs.

Updates tailscale/corp#16695