### PR TITLE
ipn/ipnserver: always allow Windows SYSTEM user to connect

### DIFF
--- a/ipn/ipnauth/ipnauth.go
+++ b/ipn/ipnauth/ipnauth.go
@@ -46,6 +46,8 @@ type WindowsToken interface {
 	// IsElevated reports whether the receiver is currently executing as an
 	// elevated administrative user.
 	IsElevated() bool
+	// IsLocalSystem reports whether the receiver is the built-in SYSTEM user.
+	IsLocalSystem() bool
 	// UserDir returns the special directory identified by folderID as associated
 	// with the receiver. folderID must be one of the KNOWNFOLDERID values from
 	// the x/sys/windows package, serialized as a stringified GUID.

--- a/ipn/ipnauth/ipnauth_windows.go
+++ b/ipn/ipnauth/ipnauth_windows.go
@@ -93,6 +93,12 @@ func (t *token) IsElevated() bool {
 	return t.t.IsElevated()
 }
 
+func (t *token) IsLocalSystem() bool {
+	// https://web.archive.org/web/2024/https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-security-identifiers
+	const systemUID = ipn.WindowsUserID("S-1-5-18")
+	return t.IsUID(systemUID)
+}
+
 func (t *token) UserDir(folderID string) (string, error) {
 	guid, err := windows.GUIDFromString(folderID)
 	if err != nil {

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -2735,6 +2735,16 @@ func (b *LocalBackend) CheckIPNConnectionAllowed(ci *ipnauth.ConnIdentity) error
 	if !b.pm.CurrentPrefs().ForceDaemon() {
 		return nil
 	}
+
+	// Always allow Windows SYSTEM user to connect,
+	// even if Tailscale is currently being used by another user.
+	if tok, err := ci.WindowsToken(); err == nil {
+		defer tok.Close()
+		if tok.IsLocalSystem() {
+			return nil
+		}
+	}
+
 	uid := ci.WindowsUserID()
 	if uid == "" {
 		return errors.New("empty user uid in connection identity")


### PR DESCRIPTION
When establishing connections to the ipnserver, we validate that the local user is allowed to connect.  If Tailscale is currently being managed by a different user (primarily for multi-user Windows installs), we don't allow the connection.

With the new device web UI, the inbound connection is coming from tailscaled itself, which is often running as "NT AUTHORITY\SYSTEM". In this case, we still want to allow the connection, even though it doesn't match the user running the Tailscale GUI. The SYSTEM user has full access to everything on the system anyway, so this doesn't escalate privileges.

Eventually, we want the device web UI to run outside of the tailscaled process, at which point this exception would probably not be needed.

Updates tailscale/corp#16393