### PR TITLE
cmd/k8s-operator: fix base truncating for extra long Service names

### DIFF
--- a/cmd/k8s-operator/sts.go
+++ b/cmd/k8s-operator/sts.go
@@ -214,16 +214,21 @@ const maxStatefulSetNameLength = 63 - 10 - 1
 // generation will NOT result in a StatefulSet name longer than 52 chars.
 // This is done because of https://github.com/kubernetes/kubernetes/issues/64023.
 func statefulSetNameBase(parent string) string {
-
 	base := fmt.Sprintf("ts-%s-", parent)
-
-	// Calculate what length name GenerateName returns for this base.
 	generator := names.SimpleNameGenerator
-	generatedName := generator.GenerateName(base)
-
-	if excess := len(generatedName) - maxStatefulSetNameLength; excess > 0 {
-		base = base[:len(base)-excess-1] // take extra char off to make space for hyphen
-		base = base + "-"                // re-instate hyphen
+	tooLong := true
+	for tooLong {
+		generatedName := generator.GenerateName(base)
+		if excess := len(generatedName) - maxStatefulSetNameLength; excess > 0 {
+			base = base[:len(base)-1-excess] // cut off the excess chars
+		}
+		if !strings.HasSuffix(base, "-") { // dash may have been cut by the generator
+			base = base + "-"
+		}
+		generatedName = generator.GenerateName(base)
+		if excess := len(generatedName) - maxStatefulSetNameLength; excess <= 0 {
+			tooLong = false
+		}
 	}
 	return base
 }

--- a/cmd/k8s-operator/sts.go
+++ b/cmd/k8s-operator/sts.go
@@ -216,21 +216,17 @@ const maxStatefulSetNameLength = 63 - 10 - 1
 func statefulSetNameBase(parent string) string {
 	base := fmt.Sprintf("ts-%s-", parent)
 	generator := names.SimpleNameGenerator
-	tooLong := true
-	for tooLong {
+	for {
 		generatedName := generator.GenerateName(base)
-		if excess := len(generatedName) - maxStatefulSetNameLength; excess > 0 {
-			base = base[:len(base)-1-excess] // cut off the excess chars
+		excess := len(generatedName) - maxStatefulSetNameLength
+		if excess <= 0 {
+			return base
 		}
+		base = base[:len(base)-1-excess]   // cut off the excess chars
 		if !strings.HasSuffix(base, "-") { // dash may have been cut by the generator
 			base = base + "-"
 		}
-		generatedName = generator.GenerateName(base)
-		if excess := len(generatedName) - maxStatefulSetNameLength; excess <= 0 {
-			tooLong = false
-		}
 	}
-	return base
 }
 
 func (a *tailscaleSTSReconciler) reconcileHeadlessService(ctx context.Context, logger *zap.SugaredLogger, sts *tailscaleSTSConfig) (*corev1.Service, error) {

--- a/cmd/k8s-operator/sts_test.go
+++ b/cmd/k8s-operator/sts_test.go
@@ -6,6 +6,9 @@
 package main
 
 import (
+	"fmt"
+	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -19,32 +22,21 @@ import (
 // https://github.com/kubernetes/kubernetes/blob/v1.28.4/staging/src/k8s.io/apiserver/pkg/storage/names/generate.go#L45.
 // https://github.com/kubernetes/kubernetes/pull/116430
 func Test_statefulSetNameBase(t *testing.T) {
-	tests := []struct {
-		name string
-		in   string
-		out  string
-	}{
-		{
-			name: "43 chars",
-			in:   "oidhexl9o832hcbhyg4uz6o0s7u9uae54h5k8ofs9xb",
-			out:  "ts-oidhexl9o832hcbhyg4uz6o0s7u9uae54h5k8ofs9xb-",
-		},
-		{
-			name: "44 chars",
-			in:   "oidhexl9o832hcbhyg4uz6o0s7u9uae54h5k8ofs9xbo",
-			out:  "ts-oidhexl9o832hcbhyg4uz6o0s7u9uae54h5k8ofs9xb-",
-		},
-		{
-			name: "42 chars",
-			in:   "oidhexl9o832hcbhyg4uz6o0s7u9uae54h5k8ofs9x",
-			out:  "ts-oidhexl9o832hcbhyg4uz6o0s7u9uae54h5k8ofs9x-",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := statefulSetNameBase(tt.in); got != tt.out {
-				t.Errorf("stsNamePrefix(%s) = %q, want %s", tt.in, got, tt.out)
-			}
-		})
+	// Service name lengths can be 1 - 63 chars, be paranoid and test them all.
+	var b strings.Builder
+	b.WriteString("a")
+	for len(b.String()) < 63 {
+		baseLength := len(b.String())
+		if baseLength > 43 {
+			baseLength = 43 // currently 43 is the max base length
+		}
+		wantsNameR := regexp.MustCompile(`^ts-a{` + fmt.Sprint(baseLength) + `}-$`) // to match a string like ts-aaaa-
+		gotName := statefulSetNameBase(b.String())
+		if _, err := b.WriteString("a"); err != nil {
+			t.Fatalf("error writing to string builder: %v", err)
+		}
+		if !wantsNameR.MatchString(gotName) {
+			t.Fatalf("expected string %s to match regex %s ", gotName, wantsNameR.String()) // fatal rather than error as this test is called 63 times
+		}
 	}
 }

--- a/cmd/k8s-operator/sts_test.go
+++ b/cmd/k8s-operator/sts_test.go
@@ -24,17 +24,16 @@ import (
 func Test_statefulSetNameBase(t *testing.T) {
 	// Service name lengths can be 1 - 63 chars, be paranoid and test them all.
 	var b strings.Builder
-	b.WriteString("a")
-	for len(b.String()) < 63 {
+	for b.Len() < 63 {
+		if _, err := b.WriteString("a"); err != nil {
+			t.Fatalf("error writing to string builder: %v", err)
+		}
 		baseLength := len(b.String())
 		if baseLength > 43 {
 			baseLength = 43 // currently 43 is the max base length
 		}
 		wantsNameR := regexp.MustCompile(`^ts-a{` + fmt.Sprint(baseLength) + `}-$`) // to match a string like ts-aaaa-
 		gotName := statefulSetNameBase(b.String())
-		if _, err := b.WriteString("a"); err != nil {
-			t.Fatalf("error writing to string builder: %v", err)
-		}
 		if !wantsNameR.MatchString(gotName) {
 			t.Fatalf("expected string %s to match regex %s ", gotName, wantsNameR.String()) // fatal rather than error as this test is called 63 times
 		}


### PR DESCRIPTION
#### Context

StatefulSet names for ingress/egress proxies [are calculated using Kubernetes name generator and the parent resource name as a base](https://github.com/tailscale/tailscale/blob/v1.56.1/cmd/k8s-operator/sts.go#L215-L218).
We currently try pre-calculate how long the generated name will be and cut the base it is to be longer than 52 chars, see https://github.com/tailscale/tailscale/pull/10343.

#### Problem

The name generator also cuts the base, but has [a higher max cap](https://github.com/kubernetes/kubernetes/blob/v1.28.4/staging/src/k8s.io/apiserver/pkg/storage/names/generate.go#L46). This commit fixes a bug where, if we get a shortened base back from _the generator_, we cut off too little as the base that we have cut will be passed into the generator again, which will then itself cut less because the base is shorter- so we end up with a too long name again.

#### Fix

This PR fixes it by cutting recursively to ensure that, if the cut base produces a longer name again after being put through the name  generator, we cut again till we ensure that the generated name will definitely be no longer than 52 chars.

#### Notes

The longest `Service` name supported before this fix is 54 chars. I have tested that with the contents of this PR vs latest release and verified that both produced the same base (so that the change in this PR does not calculate different names for existing StatefulSets)



Updates tailscale/tailscale#10807