### PR TITLE
derp: reduce excess goroutines blocking on broadcasts

### DIFF
--- a/derp/derp_server.go
+++ b/derp/derp_server.go
@@ -1579,6 +1579,17 @@ func (c *sclient) sendMeshUpdates() error {
 	c.s.mu.Lock()
 	defer c.s.mu.Unlock()
 
+	// allow all happened-before mesh update request goroutines to complete, if
+	// we don't finish the task we'll queue another below.
+drainUpdates:
+	for {
+		select {
+		case <-c.meshUpdate:
+		default:
+			break drainUpdates
+		}
+	}
+
 	writes := 0
 	for _, pcs := range c.peerStateChange {
 		if c.bw.Available() <= frameHeaderLen+keyLen {


### PR DESCRIPTION
Observed on one busy derp node, there were 600 goroutines blocked writing to this channel, which represents not only more blocked routines than we need, but also excess wake-ups downstream as the latent goroutines writes represent no new work.

Updates #self