### PR TITLE
wgengine/router: add ip rules for unifi udm-pro

### DIFF
--- a/version/distro/distro.go
+++ b/version/distro/distro.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 
 	"tailscale.com/types/lazy"
 	"tailscale.com/util/lineiter"
@@ -30,6 +31,7 @@ const (
 	WDMyCloud = Distro("wdmycloud")
 	Unraid    = Distro("unraid")
 	Alpine    = Distro("alpine")
+	UDMPro    = Distro("udmpro")
 )
 
 var distro lazy.SyncValue[Distro]
@@ -75,6 +77,9 @@ func linuxDistro() Distro {
 	case have("/usr/local/bin/freenas-debug"):
 		// TrueNAS Scale runs on debian
 		return TrueNAS
+	case isUDMPro():
+		// UDM-Pro runs on debian
+		return UDMPro
 	case have("/etc/debian_version"):
 		return Debian
 	case have("/etc/arch-release"):
@@ -146,4 +151,45 @@ func DSMVersion() int {
 		}
 		return 0
 	})
+}
+
+// isUDMPro checks a couple of files known to exist on a UDM-Pro and returns
+// true if the expected content exists in the files.
+func isUDMPro() bool {
+	// This is a performance guardrail against trying to load both
+	// /etc/board.info and /sys/firmware/devicetree/base/soc/board-cfg/id when
+	// not running on Debian so we don't make unnecessary calls in situations
+	// where we definitely are NOT on a UDM Pro. In other words, the have() call
+	// is much cheaper than the two os.ReadFile() in fileContainsAnyString().
+	// That said, on Debian systems we will still be making the two
+	// os.ReadFile() in fileContainsAnyString().
+	if !have("/etc/debian_version") {
+		return false
+	}
+	if exists, err := fileContainsAnyString("/etc/board.info", "UDMPRO", "Dream Machine PRO"); err == nil && exists {
+		return true
+	}
+	if exists, err := fileContainsAnyString("/sys/firmware/devicetree/base/soc/board-cfg/id", "udm pro"); err == nil && exists {
+		return true
+	}
+	return false
+}
+
+// fileContainsAnyString is used to determine if one or more of the provided
+// strings exists in a file. This is not efficient for larger files. If you want
+// to use this function to parse large files, please refactor to use
+// `io.LimitedReader`.
+func fileContainsAnyString(filePath string, searchStrings ...string) (bool, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return false, err
+	}
+
+	content := string(data)
+	for _, searchString := range searchStrings {
+		if strings.Contains(content, searchString) {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/wgengine/router/router_linux_test.go
+++ b/wgengine/router/router_linux_test.go
@@ -28,6 +28,7 @@ import (
 	"tailscale.com/tstest"
 	"tailscale.com/types/logger"
 	"tailscale.com/util/linuxfw"
+	"tailscale.com/version/distro"
 )
 
 func TestRouterStates(t *testing.T) {
@@ -1230,4 +1231,25 @@ func adjustFwmask(t *testing.T, s string) string {
 	}
 
 	return fwmaskAdjustRe.ReplaceAllString(s, "$1")
+}
+
+func TestIPRulesForUDMPro(t *testing.T) {
+	// Override the global getDistroFunc
+	getDistroFunc = func() distro.Distro {
+		return distro.UDMPro
+	}
+	defer func() { getDistroFunc = distro.Get }() // Restore original after the test
+
+	expected := udmProIPRules
+	actual := ipRules()
+
+	if len(expected) != len(actual) {
+		t.Fatalf("Expected %d rules, got %d", len(expected), len(actual))
+	}
+
+	for i, rule := range expected {
+		if rule != actual[i] {
+			t.Errorf("Rule mismatch at index %d: expected %+v, got %+v", i, rule, actual[i])
+		}
+	}
 }


### PR DESCRIPTION
Hello Tailscale Team,

I'm contributing my first PR, focusing on UDM-Pro support. I realize the current form may not be ready for merge, and I'm seeking guidance for integration without negatively affecting other clients. Though it should be mentioned that this PR does function correctly on the UDM-Pro and eliminates the need for any additional scripts.

One idea was a CLI flag (`--ip-rule-mark ${priority}:${table}`), but its niche use might not be ideal. Detecting UDM-Pro programmatically could be a solution, though I'm unsure how to implement it effectively.

```sh
tailscale up --ip-rule-mark 21:201 --ip-rule-mark 22:202
```

Any advice or direction to better align this with Tailscale's architecture would be valuable.

This aims to address issue #4038 and is linked to the discussion in SierraSoftworks/tailscale-udm#51.

Thanks for any input!