### PR TITLE
cmd/tailscale/cli: add description to exit-node CLI command

### DIFF
--- a/cmd/tailscale/cli/exitnode.go
+++ b/cmd/tailscale/cli/exitnode.go
@@ -23,6 +23,8 @@ import (
 var exitNodeCmd = &ffcli.Command{
 	Name:       "exit-node",
 	ShortUsage: "exit-node [flags]",
+	ShortHelp:  "Show machines on your tailnet configured as exit nodes",
+	LongHelp:   "Show machines on your tailnet configured as exit nodes",
 	Subcommands: []*ffcli.Command{
 		{
 			Name:       "list",


### PR DESCRIPTION
This change adds a description to the exit-node CLI command. This description will be displayed when using `tailscale -h` and `tailscale exit-node -h`.

Fixes #10787