### PR TITLE
wgengine/magicsock: implement probing of UDP path lifetime

### DIFF
--- a/control/controlknobs/controlknobs.go
+++ b/control/controlknobs/controlknobs.go
@@ -69,6 +69,10 @@ type Knobs struct {
 	// renewing node keys without breaking connections.
 	// http://go/seamless-key-renewal
 	SeamlessKeyRenewal atomic.Bool
+
+	// ProbeUDPLifetime is whether the node should probe UDP path lifetime on
+	// the tail end of an active direct connection in magicsock.
+	ProbeUDPLifetime atomic.Bool
 }
 
 // UpdateFromNodeAttributes updates k (if non-nil) based on the provided self
@@ -95,6 +99,7 @@ func (k *Knobs) UpdateFromNodeAttributes(selfNodeAttrs []tailcfg.NodeCapability,
 		forceIPTables                 = has(tailcfg.NodeAttrLinuxMustUseIPTables)
 		forceNfTables                 = has(tailcfg.NodeAttrLinuxMustUseNfTables)
 		seamlessKeyRenewal            = has(tailcfg.NodeAttrSeamlessKeyRenewal)
+		probeUDPLifetime              = has(tailcfg.NodeAttrProbeUDPLifetime)
 	)
 
 	if has(tailcfg.NodeAttrOneCGNATEnable) {
@@ -116,6 +121,7 @@ func (k *Knobs) UpdateFromNodeAttributes(selfNodeAttrs []tailcfg.NodeCapability,
 	k.LinuxForceIPTables.Store(forceIPTables)
 	k.LinuxForceNfTables.Store(forceNfTables)
 	k.SeamlessKeyRenewal.Store(seamlessKeyRenewal)
+	k.ProbeUDPLifetime.Store(probeUDPLifetime)
 }
 
 // AsDebugJSON returns k as something that can be marshalled with json.Marshal
@@ -138,5 +144,6 @@ func (k *Knobs) AsDebugJSON() map[string]any {
 		"LinuxForceIPTables":            k.LinuxForceIPTables.Load(),
 		"LinuxForceNfTables":            k.LinuxForceNfTables.Load(),
 		"SeamlessKeyRenewal":            k.SeamlessKeyRenewal.Load(),
+		"ProbeUDPLifetime":              k.ProbeUDPLifetime.Load(),
 	}
 }

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -4556,6 +4556,7 @@ func (b *LocalBackend) setNetMapLocked(nm *netmap.NetworkMap) {
 	}
 
 	b.MagicConn().SetSilentDisco(b.ControlKnobs().SilentDisco.Load())
+	b.MagicConn().SetProbeUDPLifetime(b.ControlKnobs().ProbeUDPLifetime.Load())
 
 	b.setDebugLogsByCapabilityLocked(nm)
 

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -126,7 +126,8 @@ type CapabilityVersion int
 //   - 83: 2023-12-18: Client understands DefaultAutoUpdate
 //   - 84: 2024-01-04: Client understands SeamlessKeyRenewal
 //   - 85: 2024-01-05: Client understands MaxKeyDuration
-const CurrentCapabilityVersion CapabilityVersion = 85
+//   - 86: 2024-01-23: Client understands NodeAttrProbeUDPLifetime
+const CurrentCapabilityVersion CapabilityVersion = 86
 
 type StableID string
 
@@ -2203,6 +2204,10 @@ const (
 	// NodeAttrSeamlessKeyRenewal makes clients enable beta functionality
 	// of renewing node keys without breaking connections.
 	NodeAttrSeamlessKeyRenewal NodeCapability = "seamless-key-renewal"
+
+	// NodeAttrProbeUDPLifetime makes the client probe UDP path lifetime at the
+	// tail end of an active direct connection in magicsock.
+	NodeAttrProbeUDPLifetime NodeCapability = "probe-udp-lifetime"
 )
 
 // SetDNSRequest is a request to add a DNS record.

--- a/types/key/disco.go
+++ b/types/key/disco.go
@@ -4,6 +4,7 @@
 package key
 
 import (
+	"bytes"
 	"crypto/subtle"
 	"fmt"
 
@@ -125,6 +126,14 @@ func (k DiscoPublic) String() string {
 		panic(err)
 	}
 	return string(bs)
+}
+
+// Compare returns an integer comparing DiscoPublic k and l lexicographically.
+// The result will be 0 if k == l, -1 if k < l, and +1 if k > l. This is useful
+// for situations requiring only one node in a pair to perform some operation,
+// e.g. probing UDP path lifetime.
+func (k DiscoPublic) Compare(l DiscoPublic) int {
+	return bytes.Compare(k.k[:], l.k[:])
 }
 
 // AppendText implements encoding.TextAppender.

--- a/wgengine/magicsock/debughttp.go
+++ b/wgengine/magicsock/debughttp.go
@@ -123,11 +123,11 @@ func (c *Conn) ServeHTTPDebug(w http.ResponseWriter, r *http.Request) {
 }
 
 func printEndpointHTML(w io.Writer, ep *endpoint) {
-	lastRecv := ep.lastRecv.LoadAtomic()
+	lastRecv := ep.lastRecvWG.LoadAtomic()
 
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
-	if ep.lastSend == 0 && lastRecv == 0 {
+	if ep.lastSendExt == 0 && lastRecv == 0 {
 		return // no activity ever
 	}
 
@@ -142,7 +142,7 @@ func printEndpointHTML(w io.Writer, ep *endpoint) {
 
 	fmt.Fprintf(w, "<p>Best: <b>%+v</b>, %v ago (for %v)</p>\n", ep.bestAddr, fmtMono(ep.bestAddrAt), ep.trustBestAddrUntil.Sub(mnow).Round(time.Millisecond))
 	fmt.Fprintf(w, "<p>heartbeating: %v</p>\n", ep.heartBeatTimer != nil)
-	fmt.Fprintf(w, "<p>lastSend: %v ago</p>\n", fmtMono(ep.lastSend))
+	fmt.Fprintf(w, "<p>lastSend: %v ago</p>\n", fmtMono(ep.lastSendExt))
 	fmt.Fprintf(w, "<p>lastFullPing: %v ago</p>\n", fmtMono(ep.lastFullPing))
 
 	eps := make([]netip.AddrPort, 0, len(ep.endpointState))

--- a/wgengine/magicsock/derp.go
+++ b/wgengine/magicsock/derp.go
@@ -26,6 +26,7 @@ import (
 	"tailscale.com/net/tsaddr"
 	"tailscale.com/syncs"
 	"tailscale.com/tailcfg"
+	"tailscale.com/tstime/mono"
 	"tailscale.com/types/key"
 	"tailscale.com/types/logger"
 	"tailscale.com/util/mak"
@@ -668,7 +669,7 @@ func (c *Conn) processDERPReadResult(dm derpReadResult, b []byte) (n int, ep *en
 		return 0, nil
 	}
 
-	ep.noteRecvActivity(ipp)
+	ep.noteRecvActivity(ipp, mono.Now())
 	if stats := c.stats.Load(); stats != nil {
 		stats.UpdateRxPhysical(ep.nodeAddr, ipp, dm.n)
 	}

--- a/wgengine/magicsock/discopingpurpose_string.go
+++ b/wgengine/magicsock/discopingpurpose_string.go
@@ -14,11 +14,12 @@ func _() {
 	_ = x[pingDiscovery-0]
 	_ = x[pingHeartbeat-1]
 	_ = x[pingCLI-2]
+	_ = x[pingHeartbeatForUDPLifetime-3]
 }
 
-const _discoPingPurpose_name = "DiscoveryHeartbeatCLI"
+const _discoPingPurpose_name = "DiscoveryHeartbeatCLIHeartbeatForUDPLifetime"
 
-var _discoPingPurpose_index = [...]uint8{0, 9, 18, 21}
+var _discoPingPurpose_index = [...]uint8{0, 9, 18, 21, 44}
 
 func (i discoPingPurpose) String() string {
 	if i < 0 || i >= discoPingPurpose(len(_discoPingPurpose_index)-1) {

--- a/wgengine/magicsock/endpoint_test.go
+++ b/wgengine/magicsock/endpoint_test.go
@@ -1,0 +1,326 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package magicsock
+
+import (
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/dsnet/try"
+	"tailscale.com/types/key"
+)
+
+func TestProbeUDPLifetimeConfig_Equals(t *testing.T) {
+	tests := []struct {
+		name string
+		a    *ProbeUDPLifetimeConfig
+		b    *ProbeUDPLifetimeConfig
+		want bool
+	}{
+		{
+			"both sides nil",
+			nil,
+			nil,
+			true,
+		},
+		{
+			"equal pointers",
+			defaultProbeUDPLifetimeConfig,
+			defaultProbeUDPLifetimeConfig,
+			true,
+		},
+		{
+			"a nil",
+			nil,
+			&ProbeUDPLifetimeConfig{
+				Cliffs:             []time.Duration{time.Second},
+				CycleCanStartEvery: time.Hour,
+			},
+			false,
+		},
+		{
+			"b nil",
+			&ProbeUDPLifetimeConfig{
+				Cliffs:             []time.Duration{time.Second},
+				CycleCanStartEvery: time.Hour,
+			},
+			nil,
+			false,
+		},
+		{
+			"Cliffs unequal",
+			&ProbeUDPLifetimeConfig{
+				Cliffs:             []time.Duration{time.Second},
+				CycleCanStartEvery: time.Hour,
+			},
+			&ProbeUDPLifetimeConfig{
+				Cliffs:             []time.Duration{time.Second * 2},
+				CycleCanStartEvery: time.Hour,
+			},
+			false,
+		},
+		{
+			"CycleCanStartEvery unequal",
+			&ProbeUDPLifetimeConfig{
+				Cliffs:             []time.Duration{time.Second},
+				CycleCanStartEvery: time.Hour,
+			},
+			&ProbeUDPLifetimeConfig{
+				Cliffs:             []time.Duration{time.Second},
+				CycleCanStartEvery: time.Hour * 2,
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.a.Equals(tt.b); got != tt.want {
+				t.Errorf("Equals() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProbeUDPLifetimeConfig_Valid(t *testing.T) {
+	tests := []struct {
+		name string
+		p    *ProbeUDPLifetimeConfig
+		want bool
+	}{
+		{
+			"default config valid",
+			defaultProbeUDPLifetimeConfig,
+			true,
+		},
+		{
+			"no cliffs",
+			&ProbeUDPLifetimeConfig{
+				CycleCanStartEvery: time.Hour,
+			},
+			false,
+		},
+		{
+			"zero CycleCanStartEvery",
+			&ProbeUDPLifetimeConfig{
+				Cliffs:             []time.Duration{time.Second * 10},
+				CycleCanStartEvery: 0,
+			},
+			false,
+		},
+		{
+			"cliff too small",
+			&ProbeUDPLifetimeConfig{
+				Cliffs:             []time.Duration{min(udpLifetimeProbeCliffSlack*2, heartbeatInterval)},
+				CycleCanStartEvery: time.Hour,
+			},
+			false,
+		},
+		{
+			"duplicate Cliffs values",
+			&ProbeUDPLifetimeConfig{
+				Cliffs:             []time.Duration{time.Second * 2, time.Second * 2},
+				CycleCanStartEvery: time.Hour,
+			},
+			false,
+		},
+		{
+			"Cliffs not ascending",
+			&ProbeUDPLifetimeConfig{
+				Cliffs:             []time.Duration{time.Second * 2, time.Second * 1},
+				CycleCanStartEvery: time.Hour,
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.p.Valid(); got != tt.want {
+				t.Errorf("Valid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_endpoint_maybeProbeUDPLifetimeLocked(t *testing.T) {
+	var lower, higher key.DiscoPublic
+	a := key.NewDisco().Public()
+	b := key.NewDisco().Public()
+	if a.String() < b.String() {
+		lower = a
+		higher = b
+	} else {
+		lower = b
+		higher = a
+	}
+	addr := addrQuality{AddrPort: try.E1[netip.AddrPort](netip.ParseAddrPort("1.1.1.1:1"))}
+	newProbeUDPLifetime := func() *probeUDPLifetime {
+		return &probeUDPLifetime{
+			config: *defaultProbeUDPLifetimeConfig,
+		}
+	}
+
+	tests := []struct {
+		name                     string
+		localDisco               key.DiscoPublic
+		remoteDisco              *key.DiscoPublic
+		probeUDPLifetimeFn       func() *probeUDPLifetime
+		bestAddr                 addrQuality
+		wantAfterInactivityForFn func(*probeUDPLifetime) time.Duration
+		wantMaybe                bool
+	}{
+		{
+			"nil probeUDPLifetime",
+			higher,
+			&lower,
+			func() *probeUDPLifetime {
+				return nil
+			},
+			addr,
+			func(lifetime *probeUDPLifetime) time.Duration {
+				return 0
+			},
+			false,
+		},
+		{
+			"local higher disco key",
+			higher,
+			&lower,
+			newProbeUDPLifetime,
+			addr,
+			func(lifetime *probeUDPLifetime) time.Duration {
+				return 0
+			},
+			false,
+		},
+		{
+			"remote no disco key",
+			higher,
+			nil,
+			newProbeUDPLifetime,
+			addr,
+			func(lifetime *probeUDPLifetime) time.Duration {
+				return 0
+			},
+			false,
+		},
+		{
+			"invalid bestAddr",
+			lower,
+			&higher,
+			newProbeUDPLifetime,
+			addrQuality{},
+			func(lifetime *probeUDPLifetime) time.Duration {
+				return 0
+			},
+			false,
+		},
+		{
+			"cycle started too recently",
+			lower,
+			&higher,
+			func() *probeUDPLifetime {
+				l := newProbeUDPLifetime()
+				l.cycleActive = false
+				l.cycleStartedAt = time.Now()
+				return l
+			},
+			addr,
+			func(lifetime *probeUDPLifetime) time.Duration {
+				return 0
+			},
+			false,
+		},
+		{
+			"maybe cliff 0 cycle not active",
+			lower,
+			&higher,
+			func() *probeUDPLifetime {
+				l := newProbeUDPLifetime()
+				l.cycleActive = false
+				l.cycleStartedAt = time.Now().Add(-l.config.CycleCanStartEvery).Add(-time.Second)
+				return l
+			},
+			addr,
+			func(lifetime *probeUDPLifetime) time.Duration {
+				return lifetime.config.Cliffs[0] - udpLifetimeProbeCliffSlack
+			},
+			true,
+		},
+		{
+			"maybe cliff 0",
+			lower,
+			&higher,
+			func() *probeUDPLifetime {
+				l := newProbeUDPLifetime()
+				l.cycleActive = true
+				l.currentCliff = 0
+				return l
+			},
+			addr,
+			func(lifetime *probeUDPLifetime) time.Duration {
+				return lifetime.config.Cliffs[0] - udpLifetimeProbeCliffSlack
+			},
+			true,
+		},
+		{
+			"maybe cliff 1",
+			lower,
+			&higher,
+			func() *probeUDPLifetime {
+				l := newProbeUDPLifetime()
+				l.cycleActive = true
+				l.currentCliff = 1
+				return l
+			},
+			addr,
+			func(lifetime *probeUDPLifetime) time.Duration {
+				return lifetime.config.Cliffs[1] - udpLifetimeProbeCliffSlack
+			},
+			true,
+		},
+		{
+			"maybe cliff 2",
+			lower,
+			&higher,
+			func() *probeUDPLifetime {
+				l := newProbeUDPLifetime()
+				l.cycleActive = true
+				l.currentCliff = 2
+				return l
+			},
+			addr,
+			func(lifetime *probeUDPLifetime) time.Duration {
+				return lifetime.config.Cliffs[2] - udpLifetimeProbeCliffSlack
+			},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			de := &endpoint{
+				c: &Conn{
+					discoPublic: tt.localDisco,
+				},
+				bestAddr: tt.bestAddr,
+			}
+			if tt.remoteDisco != nil {
+				remote := &endpointDisco{
+					key: *tt.remoteDisco,
+				}
+				de.disco.Store(remote)
+			}
+			p := tt.probeUDPLifetimeFn()
+			de.probeUDPLifetime = p
+			gotAfterInactivityFor, gotMaybe := de.maybeProbeUDPLifetimeLocked()
+			wantAfterInactivityFor := tt.wantAfterInactivityForFn(p)
+			if gotAfterInactivityFor != wantAfterInactivityFor {
+				t.Errorf("maybeProbeUDPLifetimeLocked() gotAfterInactivityFor = %v, want %v", gotAfterInactivityFor, wantAfterInactivityFor)
+			}
+			if gotMaybe != tt.wantMaybe {
+				t.Errorf("maybeProbeUDPLifetimeLocked() gotMaybe = %v, want %v", gotMaybe, tt.wantMaybe)
+			}
+		})
+	}
+}

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -141,6 +141,8 @@ type Conn struct {
 
 	silentDiscoOn atomic.Bool // whether silent disco is enabled
 
+	probeUDPLifetimeOn atomic.Bool // whether probing of UDP lifetime is enabled
+
 	// noV4Send is whether IPv4 UDP is known to be unable to transmit
 	// at all. This could happen if the socket is in an invalid state
 	// (as can happen on darwin after a network link status change).
@@ -749,7 +751,7 @@ func (c *Conn) LastRecvActivityOfNodeKey(nk key.NodePublic) string {
 	if !ok {
 		return "never"
 	}
-	saw := de.lastRecv.LoadAtomic()
+	saw := de.lastRecvWG.LoadAtomic()
 	if saw == 0 {
 		return "never"
 	}
@@ -1236,7 +1238,9 @@ func (c *Conn) receiveIP(b []byte, ipp netip.AddrPort, cache *ippEndpointCache) 
 		cache.gen = de.numStopAndReset()
 		ep = de
 	}
-	ep.noteRecvActivity(ipp)
+	now := mono.Now()
+	ep.lastRecvUDPAny.StoreAtomic(now)
+	ep.noteRecvActivity(ipp, now)
 	if stats := c.stats.Load(); stats != nil {
 		stats.UpdateRxPhysical(ep.nodeAddr, ipp, len(b))
 	}
@@ -1383,6 +1387,15 @@ func (c *Conn) handleDiscoMessage(msg []byte, src netip.AddrPort, derpNodeSrc ke
 		return
 	}
 
+	isDERP := src.Addr() == tailcfg.DerpMagicIPAddr
+	if !isDERP {
+		// Record receive time for UDP transport packets.
+		pi, ok := c.peerMap.byIPPort[src]
+		if ok {
+			pi.ep.lastRecvUDPAny.StoreAtomic(mono.Now())
+		}
+	}
+
 	// We're now reasonably sure we're expecting communication from
 	// this peer, do the heavy crypto lifting to see what they want.
 	//
@@ -1430,7 +1443,6 @@ func (c *Conn) handleDiscoMessage(msg []byte, src netip.AddrPort, derpNodeSrc ke
 		return
 	}
 
-	isDERP := src.Addr() == tailcfg.DerpMagicIPAddr
 	if isDERP {
 		metricRecvDiscoDERP.Add(1)
 	} else {
@@ -1817,11 +1829,13 @@ func debugRingBufferSize(numPeers int) int {
 // They might be set by envknob and/or controlknob.
 // The value is comparable.
 type debugFlags struct {
-	heartbeatDisabled bool
+	heartbeatDisabled  bool
+	probeUDPLifetimeOn bool
 }
 
 func (c *Conn) debugFlagsLocked() (f debugFlags) {
 	f.heartbeatDisabled = debugEnableSilentDisco() || c.silentDiscoOn.Load()
+	f.probeUDPLifetimeOn = c.probeUDPLifetimeOn.Load()
 	return
 }
 
@@ -1844,6 +1858,19 @@ func (c *Conn) SilentDisco() bool {
 	defer c.mu.Unlock()
 	flags := c.debugFlagsLocked()
 	return flags.heartbeatDisabled
+}
+
+// SetProbeUDPLifetime toggles probing of UDP lifetime based on v.
+func (c *Conn) SetProbeUDPLifetime(v bool) {
+	old := c.probeUDPLifetimeOn.Swap(v)
+	if old == v {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.peerMap.forEachEndpoint(func(ep *endpoint) {
+		ep.setProbeUDPLifetimeOn(v)
+	})
 }
 
 // SetNetworkMap is called when the control client gets a new network
@@ -1876,7 +1903,8 @@ func (c *Conn) SetNetworkMap(nm *netmap.NetworkMap) {
 	if nodesEqual(priorPeers, curPeers) && c.lastFlags == flags {
 		// The rest of this function is all adjusting state for peers that have
 		// changed. But if the set of peers is equal and the debug flags (for
-		// silent disco) haven't changed, no need to do anything else.
+		// silent disco and probe UDP lifetime) haven't changed, there is no
+		// need to do anything else.
 		return
 	}
 
@@ -1927,7 +1955,7 @@ func (c *Conn) SetNetworkMap(nm *netmap.NetworkMap) {
 			if epDisco := ep.disco.Load(); epDisco != nil {
 				oldDiscoKey = epDisco.key
 			}
-			ep.updateFromNode(n, flags.heartbeatDisabled)
+			ep.updateFromNode(n, flags.heartbeatDisabled, flags.probeUDPLifetimeOn)
 			c.peerMap.upsertEndpoint(ep, oldDiscoKey) // maybe update discokey mappings in peerMap
 			continue
 		}
@@ -1980,7 +2008,7 @@ func (c *Conn) SetNetworkMap(nm *netmap.NetworkMap) {
 			c.logEndpointCreated(n)
 		}
 
-		ep.updateFromNode(n, flags.heartbeatDisabled)
+		ep.updateFromNode(n, flags.heartbeatDisabled, flags.probeUDPLifetimeOn)
 		c.peerMap.upsertEndpoint(ep, key.DiscoPublic{})
 	}
 
@@ -2947,7 +2975,33 @@ var (
 	// received an peer MTU probe response for a given MTU size.
 	// TODO: add proper support for label maps in clientmetrics
 	metricRecvDiscoPeerMTUProbesByMTU syncs.Map[string, *clientmetric.Metric]
+
+	// metricUDPLifetime* metrics pertain to UDP lifetime probing, see type
+	// probeUDPLifetime. These metrics assume a static/default configuration for
+	// probing (defaultProbeUDPLifetimeConfig) until we disseminate
+	// ProbeUDPLifetimeConfig from control, and have lifetime management (GC old
+	// metrics) of clientmetrics or similar.
+	metricUDPLifetimeCliffsScheduled             = newUDPLifetimeCounter("magicsock_udp_lifetime_cliffs_scheduled")
+	metricUDPLifetimeCliffsCompleted             = newUDPLifetimeCounter("magicsock_udp_lifetime_cliffs_completed")
+	metricUDPLifetimeCliffsMissed                = newUDPLifetimeCounter("magicsock_udp_lifetime_cliffs_missed")
+	metricUDPLifetimeCliffsRescheduled           = newUDPLifetimeCounter("magicsock_udp_lifetime_cliffs_rescheduled")
+	metricUDPLifetimeCyclesCompleted             = newUDPLifetimeCounter("magicsock_udp_lifetime_cycles_completed")
+	metricUDPLifetimeCycleCompleteNoCliffReached = newUDPLifetimeCounter("magicsock_udp_lifetime_cycle_complete_no_cliff_reached")
+	metricUDPLifetimeCycleCompleteAt10sCliff     = newUDPLifetimeCounter("magicsock_udp_lifetime_cycle_complete_at_10s_cliff")
+	metricUDPLifetimeCycleCompleteAt30sCliff     = newUDPLifetimeCounter("magicsock_udp_lifetime_cycle_complete_at_30s_cliff")
+	metricUDPLifetimeCycleCompleteAt60sCliff     = newUDPLifetimeCounter("magicsock_udp_lifetime_cycle_complete_at_60s_cliff")
 )
+
+// newUDPLifetimeCounter returns a new *clientmetric.Metric with the provided
+// name combined with a suffix representing defaultProbeUDPLifetimeConfig.
+func newUDPLifetimeCounter(name string) *clientmetric.Metric {
+	var sb strings.Builder
+	for _, cliff := range defaultProbeUDPLifetimeConfig.Cliffs {
+		sb.WriteString(fmt.Sprintf("%ds", cliff/time.Second))
+	}
+	sb.WriteString(fmt.Sprintf("_%ds", defaultProbeUDPLifetimeConfig.CycleCanStartEvery/time.Second))
+	return clientmetric.NewCounter(fmt.Sprintf("%s_%s", name, sb.String()))
+}
 
 func getPeerMTUsProbedMetric(mtu tstun.WireMTU) *clientmetric.Metric {
 	key := fmt.Sprintf("magicsock_recv_disco_peer_mtu_probes_by_mtu_%d", mtu)

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -1220,15 +1220,15 @@ func Test32bitAlignment(t *testing.T) {
 		},
 	}
 
-	if off := unsafe.Offsetof(de.lastRecv); off%8 != 0 {
-		t.Fatalf("endpoint.lastRecv is not 8-byte aligned")
+	if off := unsafe.Offsetof(de.lastRecvWG); off%8 != 0 {
+		t.Fatalf("endpoint.lastRecvWG is not 8-byte aligned")
 	}
 
-	de.noteRecvActivity(netip.AddrPort{}) // verify this doesn't panic on 32-bit
+	de.noteRecvActivity(netip.AddrPort{}, mono.Now()) // verify this doesn't panic on 32-bit
 	if called != 1 {
 		t.Fatal("expected call to noteRecvActivity")
 	}
-	de.noteRecvActivity(netip.AddrPort{})
+	de.noteRecvActivity(netip.AddrPort{}, mono.Now())
 	if called != 1 {
 		t.Error("expected no second call to noteRecvActivity")
 	}


### PR DESCRIPTION
This commit implements probing of UDP path lifetime on the tail end of an active direct connection. Probing configuration has two parts - Cliffs, which are various timeout cliffs of interest, and CycleCanStartEvery, which limits how often a probing cycle can start, per-endpoint. Initially a statically defined default configuration will be used. The default configuration has cliffs of 10s, 30s, and 60s, with a CycleCanStartEvery of 24h. Probing results are communicated via clientmetric counters. Probing is off by default, and can be enabled via control knob. Probing is purely informational and does not yet drive any magicsock behaviors.

Updates #540