### PR TITLE
cmd/k8s-operator: sync StatefulSet labels to their Pods

### DIFF
--- a/cmd/k8s-operator/sts.go
+++ b/cmd/k8s-operator/sts.go
@@ -411,6 +411,9 @@ func (a *tailscaleSTSReconciler) reconcileSTS(ctx context.Context, logger *zap.S
 		},
 	}
 	mak.Set(&ss.Spec.Template.Labels, "app", sts.ParentResourceUID)
+	for key, val := range sts.ChildResourceLabels {
+		ss.Spec.Template.Labels[key] = val // sync StatefulSet labels to Pod to make it easier for users to select the Pod
+	}
 
 	// Generic containerboot configuration options.
 	container.Env = append(container.Env,

--- a/cmd/k8s-operator/testutils_test.go
+++ b/cmd/k8s-operator/testutils_test.go
@@ -147,7 +147,13 @@ func expectedSTS(opts configOpts) *appsv1.StatefulSet {
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations:                annots,
 					DeletionGracePeriodSeconds: ptr.To[int64](10),
-					Labels:                     map[string]string{"app": "1234-UID"},
+					Labels: map[string]string{
+						"tailscale.com/managed":              "true",
+						"tailscale.com/parent-resource":      "test",
+						"tailscale.com/parent-resource-ns":   opts.namespace,
+						"tailscale.com/parent-resource-type": opts.parentType,
+						"app":                                "1234-UID",
+					},
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: "proxies",


### PR DESCRIPTION
Sync StatefulSet child labels to their Pods that users have predictable label values to use when configuring network policies (see #10854 )

Updates tailscale/tailscale#10854