### PR TITLE
ipn/ipnlocal: don't append slash to proxy backend path that matches mount path exactly

### DIFF
--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -610,7 +610,20 @@ func (rp *reverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	p := &httputil.ReverseProxy{Rewrite: func(r *httputil.ProxyRequest) {
+		oldOutPath := r.Out.URL.Path
 		r.SetURL(rp.url)
+
+		// If mount point matches the request path exactly, the outbound
+		// request URL was set to empty string in serveWebHandler which
+		// would have resulted in the outbound path set to <proxy path>
+		// + '/' in SetURL. In that case, if the proxy path was set, we
+		// want to send the request to the <proxy path> (without the
+		// '/') .
+		if oldOutPath == "" && rp.url.Path != "" {
+			r.Out.URL.Path = rp.url.Path
+			r.Out.URL.RawPath = rp.url.RawPath
+		}
+
 		r.Out.Host = r.In.Host
 		addProxyForwardedHeaders(r)
 		rp.lb.addTailscaleIdentityHeaders(r)

--- a/ipn/ipnlocal/serve_test.go
+++ b/ipn/ipnlocal/serve_test.go
@@ -348,7 +348,108 @@ func TestServeConfigETag(t *testing.T) {
 	}
 }
 
-func TestServeHTTPProxy(t *testing.T) {
+func TestServeHTTPProxyPath(t *testing.T) {
+	b := newTestBackend(t)
+	// Start test serve endpoint.
+	testServ := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			// Set the request URL path to a response header, so the
+			// requested URL path can be checked in tests.
+			t.Logf("adding path %s", r.URL.Path)
+			w.Header().Add("Path", r.URL.Path)
+		},
+	))
+	defer testServ.Close()
+	tests := []struct {
+		name            string
+		mountPoint      string
+		proxyPath       string
+		requestPath     string
+		wantRequestPath string
+	}{
+		{
+			name:            "/foo -> /foo, with mount point and path /foo",
+			mountPoint:      "/foo",
+			proxyPath:       "/foo",
+			requestPath:     "/foo",
+			wantRequestPath: "/foo",
+		},
+		{
+			name:            "/foo/ -> /foo/, with mount point and path /foo",
+			mountPoint:      "/foo",
+			proxyPath:       "/foo",
+			requestPath:     "/foo/",
+			wantRequestPath: "/foo/",
+		},
+		{
+			name:            "/foo -> /foo/, with mount point and path /foo/",
+			mountPoint:      "/foo/",
+			proxyPath:       "/foo/",
+			requestPath:     "/foo",
+			wantRequestPath: "/foo/",
+		},
+		{
+			name:            "/-> /, with mount point and path /",
+			mountPoint:      "/",
+			proxyPath:       "/",
+			requestPath:     "/",
+			wantRequestPath: "/",
+		},
+		{
+			name:            "/foo -> /foo, with mount point and path /",
+			mountPoint:      "/",
+			proxyPath:       "/",
+			requestPath:     "/foo",
+			wantRequestPath: "/foo",
+		},
+		{
+			name:            "/foo/bar -> /foo/bar, with mount point and path /foo",
+			mountPoint:      "/foo",
+			proxyPath:       "/foo",
+			requestPath:     "/foo/bar",
+			wantRequestPath: "/foo/bar",
+		},
+		{
+			name:            "/foo/bar/baz -> /foo/bar/baz, with mount point and path /foo",
+			mountPoint:      "/foo",
+			proxyPath:       "/foo",
+			requestPath:     "/foo/bar/baz",
+			wantRequestPath: "/foo/bar/baz",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := &ipn.ServeConfig{
+				Web: map[ipn.HostPort]*ipn.WebServerConfig{
+					"example.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
+						tt.mountPoint: {Proxy: testServ.URL + tt.proxyPath},
+					}},
+				},
+			}
+			if err := b.SetServeConfig(conf, ""); err != nil {
+				t.Fatal(err)
+			}
+			req := &http.Request{
+				URL: &url.URL{Path: tt.requestPath},
+				TLS: &tls.ConnectionState{ServerName: "example.ts.net"},
+			}
+			req = req.WithContext(context.WithValue(req.Context(), serveHTTPContextKey{}, &serveHTTPContext{
+				DestPort: 443,
+				SrcAddr:  netip.MustParseAddrPort("1.2.3.4:1234"), // random src
+			}))
+
+			w := httptest.NewRecorder()
+			b.serveWebHandler(w, req)
+
+			// Verify what path was requested
+			p := w.Result().Header.Get("Path")
+			if p != tt.wantRequestPath {
+				t.Errorf("wanted request path %s got %s", tt.wantRequestPath, p)
+			}
+		})
+	}
+}
+func TestServeHTTPProxyHeaders(t *testing.T) {
 	b := newTestBackend(t)
 
 	// Start test serve endpoint.


### PR DESCRIPTION
When the serve reverse proxy receives a request that matches one of the web handlers, we [strip the handler's mount point section from the request URL](https://github.com/tailscale/tailscale/blob/v1.56.1/ipn/ipnlocal/serve.go#L742-L745) and later [call `httputil.ProxyRequest.SetURL`](https://github.com/tailscale/tailscale/blob/v1.56.1/ipn/ipnlocal/serve.go#L613) with the proxy path on the outgoing request URL.

In an edge case where the request path matches mount path exactly, we end up requesting path with an appended slash from the backend, i.e `/foo` -> `/foo/`. This is because the request path that matched the mount path was set to an empty string in `serveWebHandler`, then `httputil.ProxyRequest.SetURL` [calls `httputil.joinURLPath(<proxyPath>, '')`](https://cs.opensource.google/go/go/+/refs/tags/go1.21.6:src/net/http/httputil/reverseproxy.go;l=273),  which returns `<proxyPath>/`.

This PR fixes it by setting the path of the request to backend to the exact proxy path if the received request path is empty and the proxy path is not.

Updates tailscale/tailscale#10730

#10730 talks about Ingress' `Exact` path - we do not implement that as per [Kubernetes spec](https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types)- I will add a warning about that in a separate PR.