### PR TITLE
cmd/k8s-operator: warn if unsupported Ingress Exact path type is used.

### DIFF
--- a/cmd/k8s-operator/ingress.go
+++ b/cmd/k8s-operator/ingress.go
@@ -205,6 +205,15 @@ func (a *IngressReconciler) maybeProvision(ctx context.Context, logger *zap.Suga
 			continue
 		}
 		for _, p := range rule.HTTP.Paths {
+			// Send a warning if folks use Exact path type - to make
+			// it easier for us to support Exact path type matching
+			// in the future if needed.
+			// https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
+			if *p.PathType == networkingv1.PathTypeExact {
+				msg := "Exact path type strict matching is currently not supported and requests will be routed as for Prefix path type. This behaviour might change in the future."
+				logger.Warnf(fmt.Sprintf("Unsupported Path type exact for path %s. %s", p.Path, msg))
+				a.recorder.Eventf(ing, corev1.EventTypeWarning, "UnsupportedPathTypeExact", msg)
+			}
 			addIngressBackend(&p.Backend, p.Path)
 		}
 	}


### PR DESCRIPTION
[Kubernetes Ingress spec defines three path types](https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types), where path type `Exact` is meant to have strict request path matching where, for example, if the defined path is `/foo` a request for `/foo/bar` would be rejected (in the ingress controller as I understand).

We do not currently check path types and route as per the definition of `Prefix` path type. I am not sure if we need to implement `Exact`, but if a use case arises in the future, it would be good if users didn't depend on the current behaviour for `Exact`- ideally they should use `Prefix` now and let us know if they have a use case for the strict matching of `Exact`.

This PR adds a warning if a path with `Exact` path type is found.

Updates tailscale/tailscale#10730