### PR TITLE
appc,ipn/ipnlocal,types/appctype: implement control provided routes

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3436,14 +3436,21 @@ func (b *LocalBackend) reconfigAppConnectorLocked(nm *netmap.NetworkMap, prefs i
 		})
 	}
 
-	var domains []string
+	var (
+		domains []string
+		routes  []netip.Prefix
+	)
 	for _, attr := range attrs {
 		if slices.Contains(attr.Connectors, "*") || selfHasTag(attr.Connectors) {
 			domains = append(domains, attr.Domains...)
+			routes = append(routes, attr.Routes...)
 		}
 	}
 	slices.Sort(domains)
+	slices.SortFunc(routes, func(i, j netip.Prefix) int { return i.Addr().Compare(j.Addr()) })
 	domains = slices.Compact(domains)
+	routes = slices.Compact(routes)
+	b.appConnector.UpdateRoutes(routes)
 	b.appConnector.UpdateDomains(domains)
 }
 
@@ -5789,6 +5796,30 @@ func (b *LocalBackend) AdvertiseRoute(ipp netip.Prefix) error {
 	_, err := b.EditPrefs(&ipn.MaskedPrefs{
 		Prefs: ipn.Prefs{
 			AdvertiseRoutes: routes,
+		},
+		AdvertiseRoutesSet: true,
+	})
+	return err
+}
+
+// UnadvertiseRoute implements the appc.RouteAdvertiser interface. It removes
+// a route advertisement if one is present in the existing routes.
+func (b *LocalBackend) UnadvertiseRoute(ipp netip.Prefix) error {
+	currentRoutes := b.Prefs().AdvertiseRoutes().AsSlice()
+	if !slices.Contains(currentRoutes, ipp) {
+		return nil
+	}
+
+	newRoutes := currentRoutes[:0]
+	for _, r := range currentRoutes {
+		if r != ipp {
+			newRoutes = append(newRoutes, r)
+		}
+	}
+
+	_, err := b.EditPrefs(&ipn.MaskedPrefs{
+		Prefs: ipn.Prefs{
+			AdvertiseRoutes: newRoutes,
 		},
 		AdvertiseRoutesSet: true,
 	})

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -1169,6 +1169,13 @@ func TestRouteAdvertiser(t *testing.T) {
 	if routes.Len() != 1 || routes.At(0) != testPrefix {
 		t.Fatalf("got routes %v, want %v", routes, []netip.Prefix{testPrefix})
 	}
+
+	must.Do(ra.UnadvertiseRoute(testPrefix))
+
+	routes = b.Prefs().AdvertiseRoutes()
+	if routes.Len() != 0 {
+		t.Fatalf("got routes %v, want none", routes)
+	}
 }
 
 func TestRouterAdvertiserIgnoresContainedRoutes(t *testing.T) {
@@ -1349,6 +1356,17 @@ type routeCollector struct {
 
 func (rc *routeCollector) AdvertiseRoute(pfx netip.Prefix) error {
 	rc.routes = append(rc.routes, pfx)
+	return nil
+}
+
+func (rc *routeCollector) UnadvertiseRoute(pfx netip.Prefix) error {
+	routes := rc.routes
+	rc.routes = rc.routes[:0]
+	for _, r := range routes {
+		if r != pfx {
+			rc.routes = append(rc.routes, r)
+		}
+	}
 	return nil
 }
 

--- a/types/appctype/appconnector.go
+++ b/types/appctype/appconnector.go
@@ -66,6 +66,8 @@ type AppConnectorAttr struct {
 	// Domains enumerates the domains serviced by the specified app connectors.
 	// Domains can be of the form: example.com, or *.example.com.
 	Domains []string `json:"domains,omitempty"`
+	// Routes enumerates the predetermined routes to be advertised by the specified app connectors.
+	Routes []netip.Prefix `json:"routes,omitempty"`
 	// Connectors enumerates the app connectors which service these domains.
 	// These can either be "*" to match any advertising connector, or a
 	// tag of the form tag:<tag-name>.


### PR DESCRIPTION
Control can now send down a set of routes along with the domains, and the routes will be advertised, with any newly overlapped routes being removed to reduce the size of the routing table.

Fixes tailscale/corp#16833
Signed-off-by: James Tucker <james@tailscale.com>