### PR TITLE
./github/workflows/kubemanifests.yaml: fix the included paths pattern

### DIFF
--- a/.github/workflows/kubemanifests.yaml
+++ b/.github/workflows/kubemanifests.yaml
@@ -2,8 +2,8 @@ name: "Kubernetes manifests"
 on:
   pull_request:
    paths: 
-   - './cmd/k8s-operator/'
-   - './k8s-operator/'
+   - './cmd/k8s-operator/**'
+   - './k8s-operator/**'
    - '.github/workflows/kubemanifests.yaml'
 
 # Cancel workflow run if there is a newer push to the same PR for which it is


### PR DESCRIPTION
Fix the pattern for paths whose changes should trigger the kube tests to run- they weren't actually running.

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore

Updates#cleanup