### PR TITLE
client/web: restrict serveAPI endpoints to peer capabilities

### DIFF
--- a/client/web/auth.go
+++ b/client/web/auth.go
@@ -234,7 +234,11 @@ func (s *Server) newSessionID() (string, error) {
 	return "", errors.New("too many collisions generating new session; please refresh page")
 }
 
-type peerCapabilities map[capFeature]bool // value is true if the peer can edit the given feature
+// peerCapabilities holds information about what a source
+// peer is allowed to edit via the web UI.
+//
+// map value is true if the peer can edit the given feature.
+type peerCapabilities map[capFeature]bool
 
 // canEdit is true if the peerCapabilities grant edit access
 // to the given feature.

--- a/client/web/web_test.go
+++ b/client/web/web_test.go
@@ -4,6 +4,7 @@
 package web
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -86,75 +87,172 @@ func TestQnapAuthnURL(t *testing.T) {
 
 // TestServeAPI tests the web client api's handling of
 //  1. invalid endpoint errors
-//  2. localapi proxy allowlist
+//  2. permissioning of api endpoints based on node capabilities
 func TestServeAPI(t *testing.T) {
+	selfTags := views.SliceOf([]string{"tag:server"})
+	self := &ipnstate.PeerStatus{ID: "self", Tags: &selfTags}
+	prefs := &ipn.Prefs{}
+
+	remoteUser := &tailcfg.UserProfile{ID: tailcfg.UserID(1)}
+	remoteIPWithAllCapabilities := "100.100.100.101"
+	remoteIPWithNoCapabilities := "100.100.100.102"
+
 	lal := memnet.Listen("local-tailscaled.sock:80")
 	defer lal.Close()
-	// Serve dummy localapi. Just returns "success".
-	localapi := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "success")
-	})}
+	localapi := mockLocalAPI(t,
+		map[string]*apitype.WhoIsResponse{
+			remoteIPWithAllCapabilities: {
+				Node:        &tailcfg.Node{StableID: "node1"},
+				UserProfile: remoteUser,
+				CapMap:      tailcfg.PeerCapMap{tailcfg.PeerCapabilityWebUI: []tailcfg.RawMessage{"{\"canEdit\":[\"*\"]}"}},
+			},
+			remoteIPWithNoCapabilities: {
+				Node:        &tailcfg.Node{StableID: "node2"},
+				UserProfile: remoteUser,
+			},
+		},
+		func() *ipnstate.PeerStatus { return self },
+		func() *ipn.Prefs { return prefs },
+		nil,
+	)
 	defer localapi.Close()
-
 	go localapi.Serve(lal)
-	s := &Server{lc: &tailscale.LocalClient{Dial: lal.Dial}}
+
+	s := &Server{
+		mode:    ManageServerMode,
+		lc:      &tailscale.LocalClient{Dial: lal.Dial},
+		timeNow: time.Now,
+	}
+
+	type requestTest struct {
+		remoteIP     string
+		wantResponse string
+		wantStatus   int
+	}
 
 	tests := []struct {
-		name           string
-		reqMethod      string
 		reqPath        string
+		reqMethod      string
 		reqContentType string
-		wantResp       string
-		wantStatus     int
+		reqBody        string
+		tests          []requestTest
 	}{{
-		name:       "invalid_endpoint",
-		reqMethod:  httpm.POST,
-		reqPath:    "/not-an-endpoint",
-		wantResp:   "invalid endpoint",
-		wantStatus: http.StatusNotFound,
+		reqPath:   "/not-an-endpoint",
+		reqMethod: httpm.POST,
+		tests: []requestTest{{
+			remoteIP:     remoteIPWithNoCapabilities,
+			wantResponse: "invalid endpoint",
+			wantStatus:   http.StatusNotFound,
+		}, {
+			remoteIP:     remoteIPWithAllCapabilities,
+			wantResponse: "invalid endpoint",
+			wantStatus:   http.StatusNotFound,
+		}},
 	}, {
-		name:       "not_in_localapi_allowlist",
-		reqMethod:  httpm.POST,
-		reqPath:    "/local/v0/not-allowlisted",
-		wantResp:   "/v0/not-allowlisted not allowed from localapi proxy",
-		wantStatus: http.StatusForbidden,
+		reqPath:   "/local/v0/not-an-endpoint",
+		reqMethod: httpm.POST,
+		tests: []requestTest{{
+			remoteIP:     remoteIPWithNoCapabilities,
+			wantResponse: "invalid endpoint",
+			wantStatus:   http.StatusNotFound,
+		}, {
+			remoteIP:     remoteIPWithAllCapabilities,
+			wantResponse: "invalid endpoint",
+			wantStatus:   http.StatusNotFound,
+		}},
 	}, {
-		name:       "in_localapi_allowlist",
-		reqMethod:  httpm.POST,
-		reqPath:    "/local/v0/logout",
-		wantResp:   "success", // Successfully allowed to hit localapi.
-		wantStatus: http.StatusOK,
+		reqPath:   "/local/v0/logout",
+		reqMethod: httpm.POST,
+		tests: []requestTest{{
+			remoteIP:     remoteIPWithNoCapabilities,
+			wantResponse: "not allowed", // requesting node has insufficient permissions
+			wantStatus:   http.StatusUnauthorized,
+		}, {
+			remoteIP:     remoteIPWithAllCapabilities,
+			wantResponse: "success", // requesting node has sufficient permissions
+			wantStatus:   http.StatusOK,
+		}},
 	}, {
-		name:           "patch_bad_contenttype",
-		reqMethod:      httpm.PATCH,
+		reqPath:   "/exit-nodes",
+		reqMethod: httpm.GET,
+		tests: []requestTest{{
+			remoteIP:     remoteIPWithNoCapabilities,
+			wantResponse: "null",
+			wantStatus:   http.StatusOK, // allowed, no additional capabilities required
+		}, {
+			remoteIP:     remoteIPWithAllCapabilities,
+			wantResponse: "null",
+			wantStatus:   http.StatusOK,
+		}},
+	}, {
+		reqPath:   "/routes",
+		reqMethod: httpm.POST,
+		reqBody:   "{\"setExitNode\":true}",
+		tests: []requestTest{{
+			remoteIP:     remoteIPWithNoCapabilities,
+			wantResponse: "not allowed",
+			wantStatus:   http.StatusUnauthorized,
+		}, {
+			remoteIP:   remoteIPWithAllCapabilities,
+			wantStatus: http.StatusOK,
+		}},
+	}, {
 		reqPath:        "/local/v0/prefs",
+		reqMethod:      httpm.PATCH,
+		reqBody:        "{\"runSSHSet\":true}",
+		reqContentType: "application/json",
+		tests: []requestTest{{
+			remoteIP:     remoteIPWithNoCapabilities,
+			wantResponse: "not allowed",
+			wantStatus:   http.StatusUnauthorized,
+		}, {
+			remoteIP:   remoteIPWithAllCapabilities,
+			wantStatus: http.StatusOK,
+		}},
+	}, {
+		reqPath:        "/local/v0/prefs",
+		reqMethod:      httpm.PATCH,
 		reqContentType: "multipart/form-data",
-		wantResp:       "invalid request",
-		wantStatus:     http.StatusBadRequest,
+		tests: []requestTest{{
+			remoteIP:     remoteIPWithNoCapabilities,
+			wantResponse: "invalid request",
+			wantStatus:   http.StatusBadRequest,
+		}, {
+			remoteIP:     remoteIPWithAllCapabilities,
+			wantResponse: "invalid request",
+			wantStatus:   http.StatusBadRequest,
+		}},
 	}}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			r := httptest.NewRequest(tt.reqMethod, "/api"+tt.reqPath, nil)
-			if tt.reqContentType != "" {
-				r.Header.Add("Content-Type", tt.reqContentType)
-			}
-			w := httptest.NewRecorder()
+		for _, req := range tt.tests {
+			t.Run(req.remoteIP+"_requesting_"+tt.reqPath, func(t *testing.T) {
+				var reqBody io.Reader
+				if tt.reqBody != "" {
+					reqBody = bytes.NewBuffer([]byte(tt.reqBody))
+				}
+				r := httptest.NewRequest(tt.reqMethod, "/api"+tt.reqPath, reqBody)
+				r.RemoteAddr = req.remoteIP
+				if tt.reqContentType != "" {
+					r.Header.Add("Content-Type", tt.reqContentType)
+				}
+				w := httptest.NewRecorder()
 
-			s.serveAPI(w, r)
-			res := w.Result()
-			defer res.Body.Close()
-			if gotStatus := res.StatusCode; tt.wantStatus != gotStatus {
-				t.Errorf("wrong status; want=%v, got=%v", tt.wantStatus, gotStatus)
-			}
-			body, err := io.ReadAll(res.Body)
-			if err != nil {
-				t.Fatal(err)
-			}
-			gotResp := strings.TrimSuffix(string(body), "\n") // trim trailing newline
-			if tt.wantResp != gotResp {
-				t.Errorf("wrong response; want=%q, got=%q", tt.wantResp, gotResp)
-			}
-		})
+				s.serveAPI(w, r)
+				res := w.Result()
+				defer res.Body.Close()
+				if gotStatus := res.StatusCode; req.wantStatus != gotStatus {
+					t.Errorf("wrong status; want=%v, got=%v", req.wantStatus, gotStatus)
+				}
+				body, err := io.ReadAll(res.Body)
+				if err != nil {
+					t.Fatal(err)
+				}
+				gotResp := strings.TrimSuffix(string(body), "\n") // trim trailing newline
+				if req.wantResponse != gotResp {
+					t.Errorf("wrong response; want=%q, got=%q", req.wantResponse, gotResp)
+				}
+			})
+		}
 	}
 }
 
@@ -1338,6 +1436,9 @@ func mockLocalAPI(t *testing.T, whoIs map[string]*apitype.WhoIsResponse, self fu
 			}
 			metricCapture(metricNames[0].Name)
 			writeJSON(w, struct{}{})
+			return
+		case "/localapi/v0/logout":
+			fmt.Fprintf(w, "success")
 			return
 		default:
 			t.Fatalf("unhandled localapi test endpoint %q, add to localapi handler func in test", r.URL.Path)


### PR DESCRIPTION
This change adds a new apiHandler struct for use from serveAPI to aid with restricting endpoints to specific peer capabilities.

Updates tailscale/corp#16695