### PR TITLE
tool/gocross: force use of our custom toolchain

### DIFF
--- a/tool/gocross/autoflags.go
+++ b/tool/gocross/autoflags.go
@@ -191,6 +191,7 @@ func autoflagsForTest(argv []string, env *Environment, goroot, nativeGOOS, nativ
 	env.Set("CC", cc)
 	env.Set("TS_LINK_FAIL_REFLECT", boolStr(failReflect))
 	env.Set("GOROOT", goroot)
+	env.Set("GOTOOLCHAIN", "local")
 
 	if subcommand == "env" {
 		return argv, env, nil

--- a/tool/gocross/autoflags_test.go
+++ b/tool/gocross/autoflags_test.go
@@ -49,6 +49,7 @@ GOARM=5 (was <nil>)
 GOMIPS=softfloat (was <nil>)
 GOOS=linux (was <nil>)
 GOROOT=/goroot (was <nil>)
+GOTOOLCHAIN=local (was <nil>)
 TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			wantArgv: []string{
 				"gocross", "build",
@@ -74,6 +75,7 @@ GOARM=5 (was <nil>)
 GOMIPS=softfloat (was <nil>)
 GOOS=linux (was <nil>)
 GOROOT=/goroot (was <nil>)
+GOTOOLCHAIN=local (was <nil>)
 TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			wantArgv: []string{
 				"gocross", "install",
@@ -102,6 +104,7 @@ GOARM=5 (was <nil>)
 GOMIPS=softfloat (was <nil>)
 GOOS=linux (was <nil>)
 GOROOT=/goroot (was <nil>)
+GOTOOLCHAIN=local (was <nil>)
 TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			wantArgv: []string{
 				"gocross", "build",
@@ -130,6 +133,7 @@ GOARM=5 (was <nil>)
 GOMIPS=softfloat (was <nil>)
 GOOS=freebsd (was freebsd)
 GOROOT=/goroot (was <nil>)
+GOTOOLCHAIN=local (was <nil>)
 TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			wantArgv: []string{
 				"gocross", "build",
@@ -155,6 +159,7 @@ GOARM=5 (was <nil>)
 GOMIPS=softfloat (was <nil>)
 GOOS=linux (was <nil>)
 GOROOT=/goroot (was <nil>)
+GOTOOLCHAIN=local (was <nil>)
 TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			wantArgv: []string{
 				"gocross", "test",
@@ -184,6 +189,7 @@ GOARM=5 (was <nil>)
 GOMIPS=softfloat (was <nil>)
 GOOS=windows (was windows)
 GOROOT=/goroot (was <nil>)
+GOTOOLCHAIN=local (was <nil>)
 TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			wantArgv: []string{
 				"gocross", "build",
@@ -209,6 +215,7 @@ GOARM=5 (was <nil>)
 GOMIPS=softfloat (was <nil>)
 GOOS=darwin (was <nil>)
 GOROOT=/goroot (was <nil>)
+GOTOOLCHAIN=local (was <nil>)
 TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			wantArgv: []string{
 				"gocross", "build",
@@ -237,6 +244,7 @@ GOARM=5 (was <nil>)
 GOMIPS=softfloat (was <nil>)
 GOOS=darwin (was <nil>)
 GOROOT=/goroot (was <nil>)
+GOTOOLCHAIN=local (was <nil>)
 TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			wantArgv: []string{
 				"gocross", "build",
@@ -265,6 +273,7 @@ GOARM=5 (was <nil>)
 GOMIPS=softfloat (was <nil>)
 GOOS=ios (was ios)
 GOROOT=/goroot (was <nil>)
+GOTOOLCHAIN=local (was <nil>)
 TS_LINK_FAIL_REFLECT=1 (was <nil>)`,
 			wantArgv: []string{
 				"gocross", "build",
@@ -297,6 +306,7 @@ GOARM=5 (was <nil>)
 GOMIPS=softfloat (was <nil>)
 GOOS=darwin (was darwin)
 GOROOT=/goroot (was <nil>)
+GOTOOLCHAIN=local (was <nil>)
 TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			wantArgv: []string{
 				"gocross", "build",
@@ -329,6 +339,7 @@ GOARM=5 (was <nil>)
 GOMIPS=softfloat (was <nil>)
 GOOS=ios (was ios)
 GOROOT=/goroot (was <nil>)
+GOTOOLCHAIN=local (was <nil>)
 TS_LINK_FAIL_REFLECT=1 (was <nil>)`,
 			wantArgv: []string{
 				"gocross", "build",
@@ -354,6 +365,7 @@ GOARM=5 (was <nil>)
 GOMIPS=softfloat (was <nil>)
 GOOS=linux (was <nil>)
 GOROOT=/special/toolchain/path (was <nil>)
+GOTOOLCHAIN=local (was <nil>)
 TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			wantArgv: []string{
 				"go", "build",
@@ -379,6 +391,7 @@ GOARM=5 (was <nil>)
 GOMIPS=softfloat (was <nil>)
 GOOS=linux (was <nil>)
 GOROOT=/goroot (was <nil>)
+GOTOOLCHAIN=local (was <nil>)
 TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			wantArgv: []string{
 				"gocross", "list",
@@ -407,6 +420,7 @@ GOARM=5 (was <nil>)
 GOMIPS=softfloat (was <nil>)
 GOOS=linux (was <nil>)
 GOROOT=/goroot (was <nil>)
+GOTOOLCHAIN=local (was <nil>)
 TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			wantArgv: []string{
 				"gocross", "build",
@@ -433,6 +447,7 @@ GOARM=5 (was <nil>)
 GOMIPS=softfloat (was <nil>)
 GOOS=linux (was <nil>)
 GOROOT=/goroot (was <nil>)
+GOTOOLCHAIN=local (was <nil>)
 TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			wantArgv: []string{
 				"go", "run",
@@ -441,6 +456,35 @@ TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 				"-ldflags", "-X tailscale.com/version.longStamp=1.2.3-long -X tailscale.com/version.shortStamp=1.2.3 -X tailscale.com/version.gitCommitStamp=abcd -X tailscale.com/version.extraGitCommitStamp=defg '-extldflags=-static'",
 				"./cmd/mkctr",
 				"--tags=foo",
+			},
+		},
+		{
+			name: "linux_amd64_to_linux_amd64_custom_toolchain",
+			env: map[string]string{
+				"GOTOOLCHAIN": "go1.30rc5",
+			},
+			argv:         []string{"gocross", "build", "./cmd/tailcontrol"},
+			goroot:       "/goroot",
+			nativeGOOS:   "linux",
+			nativeGOARCH: "amd64",
+
+			envDiff: `CC=cc (was <nil>)
+CGO_CFLAGS=-O3 -std=gnu11 (was <nil>)
+CGO_ENABLED=1 (was <nil>)
+CGO_LDFLAGS= (was <nil>)
+GOARCH=amd64 (was <nil>)
+GOARM=5 (was <nil>)
+GOMIPS=softfloat (was <nil>)
+GOOS=linux (was <nil>)
+GOROOT=/goroot (was <nil>)
+GOTOOLCHAIN=local (was go1.30rc5)
+TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
+			wantArgv: []string{
+				"gocross", "build",
+				"-trimpath",
+				"-tags=tailscale_go,osusergo,netgo",
+				"-ldflags", "-X tailscale.com/version.longStamp=1.2.3-long -X tailscale.com/version.shortStamp=1.2.3 -X tailscale.com/version.gitCommitStamp=abcd -X tailscale.com/version.extraGitCommitStamp=defg '-extldflags=-static'",
+				"./cmd/tailcontrol",
 			},
 		},
 	}


### PR DESCRIPTION
The new 'toolchain' directive in go.mod can sometimes force the use of an upstream toolchain against our wishes. Concurrently, some of our dependencies have added the 'toolchain' directive, which transitively adds it to our own go.mod. Force all uses of gocross to ignore that directive and stick to our customized toolchain.

Updates #cleanup