### PR TITLE
appc: fix removal of domain advertised routes matching control routes

### DIFF
--- a/appc/appconnector.go
+++ b/appc/appconnector.go
@@ -155,7 +155,7 @@ nextRoute:
 	for _, r := range routes {
 		for _, addr := range e.domains {
 			for _, a := range addr {
-				if r.Contains(a) {
+				if r.Contains(a) && netip.PrefixFrom(a, a.BitLen()) != r {
 					pfx := netip.PrefixFrom(a, a.BitLen())
 					toRemove = append(toRemove, pfx)
 					continue nextRoute

--- a/appc/appctest/appctest.go
+++ b/appc/appctest/appctest.go
@@ -10,7 +10,8 @@ import (
 
 // RouteCollector is a test helper that collects the list of routes advertised
 type RouteCollector struct {
-	routes []netip.Prefix
+	routes        []netip.Prefix
+	removedRoutes []netip.Prefix
 }
 
 func (rc *RouteCollector) AdvertiseRoute(pfx ...netip.Prefix) error {
@@ -24,9 +25,16 @@ func (rc *RouteCollector) UnadvertiseRoute(toRemove ...netip.Prefix) error {
 	for _, r := range routes {
 		if !slices.Contains(toRemove, r) {
 			rc.routes = append(rc.routes, r)
+		} else {
+			rc.removedRoutes = append(rc.removedRoutes, r)
 		}
 	}
 	return nil
+}
+
+// RemovedRoutes returns the list of routes that were removed.
+func (rc *RouteCollector) RemovedRoutes() []netip.Prefix {
+	return rc.removedRoutes
 }
 
 // Routes returns the ordered list of routes that were added, including


### PR DESCRIPTION
If control advised the connector to advertise a route that had already been discovered by DNS it would be incorrectly removed. Now those routes are preserved.

Updates tailscale/corp#16833