### PR TITLE
appc,ipn/ipnlocal: optimize preference adjustments when routes update

### DIFF
--- a/appc/appctest/appctest.go
+++ b/appc/appctest/appctest.go
@@ -1,0 +1,41 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package appctest
+
+import (
+	"net/netip"
+	"slices"
+)
+
+// RouteCollector is a test helper that collects the list of routes advertised
+type RouteCollector struct {
+	routes []netip.Prefix
+}
+
+func (rc *RouteCollector) AdvertiseRoute(pfx ...netip.Prefix) error {
+	rc.routes = append(rc.routes, pfx...)
+	return nil
+}
+
+func (rc *RouteCollector) UnadvertiseRoute(toRemove ...netip.Prefix) error {
+	routes := rc.routes
+	rc.routes = rc.routes[:0]
+	for _, r := range routes {
+		if !slices.Contains(toRemove, r) {
+			rc.routes = append(rc.routes, r)
+		}
+	}
+	return nil
+}
+
+// Routes returns the ordered list of routes that were added, including
+// possible duplicates.
+func (rc *RouteCollector) Routes() []netip.Prefix {
+	return rc.routes
+}
+
+func (rc *RouteCollector) SetRoutes(routes []netip.Prefix) error {
+	rc.routes = routes
+	return nil
+}

--- a/ipn/ipnlocal/peerapi_test.go
+++ b/ipn/ipnlocal/peerapi_test.go
@@ -23,6 +23,7 @@ import (
 	"go4.org/netipx"
 	"golang.org/x/net/dns/dnsmessage"
 	"tailscale.com/appc"
+	"tailscale.com/appc/appctest"
 	"tailscale.com/client/tailscale/apitype"
 	"tailscale.com/ipn"
 	"tailscale.com/ipn/store/mem"
@@ -689,7 +690,7 @@ func TestPeerAPIReplyToDNSQueriesAreObserved(t *testing.T) {
 	var h peerAPIHandler
 	h.remoteAddr = netip.MustParseAddrPort("100.150.151.152:12345")
 
-	rc := &routeCollector{}
+	rc := &appctest.RouteCollector{}
 	eng, _ := wgengine.NewFakeUserspaceEngine(logger.Discard, 0)
 	pm := must.Get(newProfileManager(new(mem.Store), t.Logf))
 	h.ps = &peerAPIServer{
@@ -722,8 +723,8 @@ func TestPeerAPIReplyToDNSQueriesAreObserved(t *testing.T) {
 	h.ps.b.appConnector.Wait(ctx)
 
 	wantRoutes := []netip.Prefix{netip.MustParsePrefix("192.0.0.8/32")}
-	if !slices.Equal(rc.routes, wantRoutes) {
-		t.Errorf("got %v; want %v", rc.routes, wantRoutes)
+	if !slices.Equal(rc.Routes(), wantRoutes) {
+		t.Errorf("got %v; want %v", rc.Routes(), wantRoutes)
 	}
 }
 


### PR DESCRIPTION
This change allows us to perform batch modification for new route advertisements and route removals. Additionally, we now handle the case where newly added routes are covered by existing ranges.

This change also introduces a new appctest package that contains some shared functions used for testing.

Updates tailscale/corp#16833