### PR TITLE
cmd/tailscale/cli: run Watch with NotifyNoPrivateKeys

### DIFF
--- a/cmd/tailscale/cli/serve_v2.go
+++ b/cmd/tailscale/cli/serve_v2.go
@@ -272,7 +272,7 @@ func (e *serveEnv) runServeCombined(subcmd serveMode) execFunc {
 			// if foreground mode, create a WatchIPNBus session
 			// and use the nested config for all following operations
 			// TODO(marwan-at-work): nested-config validations should happen here or previous to this point.
-			watcher, err = e.lc.WatchIPNBus(ctx, ipn.NotifyInitialState)
+			watcher, err = e.lc.WatchIPNBus(ctx, ipn.NotifyInitialState|ipn.NotifyNoPrivateKeys)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
When running as non-root non-operator user, you get this error:
```
$ tailscale serve 8080
Access denied: watch IPN bus access denied, must set ipn.NotifyNoPrivateKeys when not running as admin/root or operator

Use 'sudo tailscale serve 8080' or 'tailscale up --operator=$USER' to not require root.
```

It should fail, but the error message is confusing.

With this fix:
```
$ tailscale serve 8080
sending serve config: Access denied: serve config denied

Use 'sudo tailscale serve 8080' or 'tailscale up --operator=$USER' to not require root.
```

Updates #cleanup