### PR TITLE
cmd/gitops-pusher: fix logic for checking credentials

### DIFF
--- a/cmd/gitops-pusher/gitops-pusher.go
+++ b/cmd/gitops-pusher/gitops-pusher.go
@@ -158,7 +158,7 @@ func main() {
 	if !ok && (!oiok || !osok) {
 		log.Fatal("set envvar TS_API_KEY to your Tailscale API key or TS_OAUTH_ID and TS_OAUTH_SECRET to your Tailscale OAuth ID and Secret")
 	}
-	if ok && (oiok || osok) {
+	if apiKey != "" && (oauthId != "" || oauthSecret != "") {
 		log.Fatal("set either the envvar TS_API_KEY or TS_OAUTH_ID and TS_OAUTH_SECRET")
 	}
 	var client *http.Client


### PR DESCRIPTION
gitops-pusher supports authenticating with an API key or OAuth credentials (added in #7393). You shouldn't ever use both of those together, so we error if both are set.

In tailscale/gitops-acl-action#24, OAuth support is being added to the GitHub action. In that environment, both the TS_API_KEY and OAuth variables will be set, even if they are empty values.  This causes an error in gitops-pusher which expects only one to be set.

Update gitops-pusher to check that only one set of environment variables are non-empty, rather than just checking if they are set.

Updates #7393