### PR TITLE
ipnlocal: log failure to get ssh host keys

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -4125,7 +4125,11 @@ func (b *LocalBackend) applyPrefsToHostinfoLocked(hi *tailcfg.Hostinfo, prefs ip
 		// TODO(bradfitz): this is called with b.mu held. Not ideal.
 		// If the filesystem gets wedged or something we could block for
 		// a long time. But probably fine.
-		sshHostKeys = b.getSSHHostKeyPublicStrings()
+		var err error
+		sshHostKeys, err = b.getSSHHostKeyPublicStrings()
+		if err != nil {
+			b.logf("warning: unable to get SSH host keys, SSH will appear as disabled for this node: %v", err)
+		}
 	}
 	hi.SSH_HostKeys = sshHostKeys
 

--- a/ipn/ipnlocal/ssh.go
+++ b/ipn/ipnlocal/ssh.go
@@ -210,12 +210,16 @@ func (b *LocalBackend) getSystemSSH_HostKeys() (ret map[string]ssh.Signer) {
 	return ret
 }
 
-func (b *LocalBackend) getSSHHostKeyPublicStrings() (ret []string) {
-	signers, _ := b.GetSSH_HostKeys()
-	for _, signer := range signers {
-		ret = append(ret, strings.TrimSpace(string(ssh.MarshalAuthorizedKey(signer.PublicKey()))))
+func (b *LocalBackend) getSSHHostKeyPublicStrings() ([]string, error) {
+	signers, err := b.GetSSH_HostKeys()
+	if err != nil {
+		return nil, err
 	}
-	return ret
+	var keyStrings []string
+	for _, signer := range signers {
+		keyStrings = append(keyStrings, strings.TrimSpace(string(ssh.MarshalAuthorizedKey(signer.PublicKey()))))
+	}
+	return keyStrings, nil
 }
 
 // tailscaleSSHEnabled reports whether Tailscale SSH is currently enabled based

--- a/ipn/ipnlocal/ssh_stub.go
+++ b/ipn/ipnlocal/ssh_stub.go
@@ -11,8 +11,8 @@ import (
 	"tailscale.com/tailcfg"
 )
 
-func (b *LocalBackend) getSSHHostKeyPublicStrings() []string {
-	return nil
+func (b *LocalBackend) getSSHHostKeyPublicStrings() ([]string, error) {
+	return nil, nil
 }
 
 func (b *LocalBackend) getSSHUsernames(*tailcfg.C2NSSHUsernamesRequest) (*tailcfg.C2NSSHUsernamesResponse, error) {


### PR DESCRIPTION
When reporting ssh host keys to control, log a warning if we're unable to get the SSH host keys.

Updates #cleanup

Relates to tailscale/support-escalations#21.