### PR TITLE
client/web: add new readonly mode

### DIFF
--- a/client/web/src/components/login-toggle.tsx
+++ b/client/web/src/components/login-toggle.tsx
@@ -162,7 +162,19 @@ function LoginPopoverContent({
       </div>
       {!auth.canManageNode && (
         <>
-          {!auth.viewerIdentity ? (
+          {auth.serverMode === "readonly" ? (
+            <p className="text-gray-500 text-xs">
+              This web interface is running in read-only mode.{" "}
+              <a
+                href="https://tailscale.com/s/web-client-read-only"
+                className="text-blue-700"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Learn more &rarr;
+              </a>
+            </p>
+          ) : !auth.viewerIdentity ? (
             // User is not connected over Tailscale.
             // These states are only possible on the login client.
             <>

--- a/client/web/src/hooks/auth.ts
+++ b/client/web/src/hooks/auth.ts
@@ -12,7 +12,7 @@ export enum AuthType {
 export type AuthResponse = {
   authNeeded?: AuthType
   canManageNode: boolean
-  serverMode: "login" | "manage"
+  serverMode: "login" | "readonly" | "manage"
   viewerIdentity?: {
     loginName: string
     nodeName: string

--- a/cmd/tailscale/cli/web.go
+++ b/cmd/tailscale/cli/web.go
@@ -42,15 +42,17 @@ Tailscale, as opposed to a CLI or a native app.
 		webf.StringVar(&webArgs.listen, "listen", "localhost:8088", "listen address; use port 0 for automatic")
 		webf.BoolVar(&webArgs.cgi, "cgi", false, "run as CGI script")
 		webf.StringVar(&webArgs.prefix, "prefix", "", "URL prefix added to requests (for cgi or reverse proxies)")
+		webf.BoolVar(&webArgs.readonly, "readonly", false, "run web UI in read-only mode")
 		return webf
 	})(),
 	Exec: runWeb,
 }
 
 var webArgs struct {
-	listen string
-	cgi    bool
-	prefix string
+	listen   string
+	cgi      bool
+	prefix   string
+	readonly bool
 }
 
 func tlsConfigFromEnvironment() *tls.Config {
@@ -94,20 +96,26 @@ func runWeb(ctx context.Context, args []string) error {
 	if prefs, err := localClient.GetPrefs(ctx); err == nil {
 		existingWebClient = prefs.RunWebClient
 	}
-	if !existingWebClient {
+	var startedManagementClient bool // we started the management client
+	if !existingWebClient && !webArgs.readonly {
 		// Also start full client in tailscaled.
 		log.Printf("starting tailscaled web client at %s:%d\n", selfIP.String(), web.ListenPort)
 		if err := setRunWebClient(ctx, true); err != nil {
 			return fmt.Errorf("starting web client in tailscaled: %w", err)
 		}
+		startedManagementClient = true
 	}
 
-	webServer, err := web.NewServer(web.ServerOpts{
+	opts := web.ServerOpts{
 		Mode:        web.LoginServerMode,
 		CGIMode:     webArgs.cgi,
 		PathPrefix:  webArgs.prefix,
 		LocalClient: &localClient,
-	})
+	}
+	if webArgs.readonly {
+		opts.Mode = web.ReadOnlyServerMode
+	}
+	webServer, err := web.NewServer(opts)
 	if err != nil {
 		log.Printf("tailscale.web: %v", err)
 		return err
@@ -117,10 +125,10 @@ func runWeb(ctx context.Context, args []string) error {
 		case <-ctx.Done():
 			// Shutdown the server.
 			webServer.Shutdown()
-			if !webArgs.cgi && !existingWebClient {
+			if !webArgs.cgi && startedManagementClient {
 				log.Println("stopping tailscaled web client")
 				// When not in cgi mode, shut down the tailscaled
-				// web client on cli termination.
+				// web client on cli termination if we started it.
 				if err := setRunWebClient(context.Background(), false); err != nil {
 					log.Printf("stopping tailscaled web client: %v", err)
 				}


### PR DESCRIPTION
The new read-only mode is only accessible when running `tailscale web` by passing a new `-readonly` flag. This new mode is identical to the existing login mode with two exceptions:

 - the management client in tailscaled is not started (though if it is already running, it is left alone)

 - the client does not prompt the user to login or switch to the management client. Instead, a message is shown instructing the user to use other means to manage the device.

I implemented this as a new mode rather than a separate boolean flag on the server, since otherwise it was not obvious to me what it would mean to have a client in manage mode with a read-only flag.  Those things are mutually exclusive, so adding a new mode seemed appropriate.

Updates #10979