### PR TITLE
util/deephash: tighten up SelfHasher API

### DIFF
--- a/util/deephash/deephash_test.go
+++ b/util/deephash/deephash_test.go
@@ -42,11 +42,19 @@ func (p appendBytes) AppendTo(b []byte) []byte {
 	return append(b, p...)
 }
 
-type implsSelfHasherValueRecv struct {
+type selfHasherValueRecv struct {
 	emit uint64
 }
 
-func (s implsSelfHasherValueRecv) Hash(h *hashx.Block512) {
+func (s selfHasherValueRecv) Hash(h *hashx.Block512) {
+	h.HashUint64(s.emit)
+}
+
+type selfHasherPointerRecv struct {
+	emit uint64
+}
+
+func (s *selfHasherPointerRecv) Hash(h *hashx.Block512) {
 	h.HashUint64(s.emit)
 }
 
@@ -178,12 +186,12 @@ func TestHash(t *testing.T) {
 			b[0] = 1
 			return b
 		}()))}, wantEq: false},
-		{in: tuple{&implsSelfHasher{}, &implsSelfHasher{}}, wantEq: true},
-		{in: tuple{(*implsSelfHasher)(nil), (*implsSelfHasher)(nil)}, wantEq: true},
-		{in: tuple{(*implsSelfHasher)(nil), &implsSelfHasher{}}, wantEq: false},
-		{in: tuple{&implsSelfHasher{emit: 1}, &implsSelfHasher{emit: 2}}, wantEq: false},
-		{in: tuple{implsSelfHasherValueRecv{emit: 1}, implsSelfHasherValueRecv{emit: 2}}, wantEq: false},
-		{in: tuple{implsSelfHasherValueRecv{emit: 2}, implsSelfHasherValueRecv{emit: 2}}, wantEq: true},
+		{in: tuple{&selfHasherPointerRecv{}, &selfHasherPointerRecv{}}, wantEq: true},
+		{in: tuple{(*selfHasherPointerRecv)(nil), (*selfHasherPointerRecv)(nil)}, wantEq: true},
+		{in: tuple{(*selfHasherPointerRecv)(nil), &selfHasherPointerRecv{}}, wantEq: false},
+		{in: tuple{&selfHasherPointerRecv{emit: 1}, &selfHasherPointerRecv{emit: 2}}, wantEq: false},
+		{in: tuple{selfHasherValueRecv{emit: 1}, selfHasherValueRecv{emit: 2}}, wantEq: false},
+		{in: tuple{selfHasherValueRecv{emit: 2}, selfHasherValueRecv{emit: 2}}, wantEq: true},
 	}
 
 	for _, tt := range tests {

--- a/util/deephash/types.go
+++ b/util/deephash/types.go
@@ -7,20 +7,7 @@ import (
 	"net/netip"
 	"reflect"
 	"time"
-
-	"tailscale.com/util/hashx"
 )
-
-// SelfHasher is the interface implemented by types that can compute their own hash
-// by writing values through the given parameter.
-//
-// Implementations of Hash MUST NOT call `Reset` or `Sum` on the provided argument.
-//
-// This interface should not be considered stable and is likely to change in the
-// future.
-type SelfHasher interface {
-	Hash(*hashx.Block512)
-}
 
 var (
 	timeTimeType   = reflect.TypeOf((*time.Time)(nil)).Elem()

--- a/util/deephash/types_test.go
+++ b/util/deephash/types_test.go
@@ -12,16 +12,7 @@ import (
 
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/structs"
-	"tailscale.com/util/hashx"
 )
-
-type implsSelfHasher struct {
-	emit uint64
-}
-
-func (s *implsSelfHasher) Hash(h *hashx.Block512) {
-	h.HashUint64(s.emit)
-}
 
 func TestTypeIsMemHashable(t *testing.T) {
 	tests := []struct {
@@ -76,7 +67,7 @@ func TestTypeIsMemHashable(t *testing.T) {
 			false},
 		{[0]chan bool{}, true},
 		{struct{ f [0]func() }{}, true},
-		{&implsSelfHasher{}, false},
+		{&selfHasherPointerRecv{}, false},
 	}
 	for _, tt := range tests {
 		got := typeIsMemHashable(reflect.TypeOf(tt.val))
@@ -112,7 +103,7 @@ func TestTypeIsRecursive(t *testing.T) {
 		{val: unsafe.Pointer(nil), want: false},
 		{val: make(RecursiveChan), want: true},
 		{val: make(chan int), want: false},
-		{val: (*implsSelfHasher)(nil), want: false},
+		{val: (*selfHasherPointerRecv)(nil), want: false},
 	}
 	for _, tt := range tests {
 		got := typeIsRecursive(reflect.TypeOf(tt.val))


### PR DESCRIPTION
Providing a hashx.Block512 is an implementation detail of how deephash works today, but providing an opaque type with mostly equivalent API (i.e., HashUint8, HashBytes, etc. methods) is still sensible. Thus, define a public Hasher type that exposes exactly the API that an implementation of SelfHasher would want to call. This gives us freedom to change the hashing algorithm of deephash at some point in the future.

Also, this type is likely going to be called by types that are going to memoize their own hash results, we additionally add a HashSum method to simplify this use case.

Add documentation to SelfHasher on how a type might implement it.

Updates: corp#16409