### PR TITLE
cmd/{k8s-operator,k8s-nameserver},k8s-operator: update nameserver config with records for ingress/egress proxies

### DIFF
--- a/cmd/k8s-nameserver/main.go
+++ b/cmd/k8s-nameserver/main.go
@@ -36,7 +36,6 @@ const (
 	// provided by a mounted Kubernetes Configmap. The Configmap mounted at
 	// /config is the only supported way for configuring this nameserver.
 	defaultDNSConfigDir    = "/config"
-	defaultDNSFile         = "dns.json"
 	kubeletMountedConfigLn = "..data"
 )
 
@@ -331,9 +330,9 @@ func ensureWatcherForKubeConfigMap(ctx context.Context) chan string {
 type configReaderFunc func() ([]byte, error)
 
 // configMapConfigReader reads the desired nameserver configuration from a
-// dns.json file in a ConfigMap mounted at /config.
+// records.json file in a ConfigMap mounted at /config.
 var configMapConfigReader configReaderFunc = func() ([]byte, error) {
-	if contents, err := os.ReadFile(filepath.Join(defaultDNSConfigDir, defaultDNSFile)); err == nil {
+	if contents, err := os.ReadFile(filepath.Join(defaultDNSConfigDir, operatorutils.DNSRecordsCMKey)); err == nil {
 		return contents, nil
 	} else if os.IsNotExist(err) {
 		return nil, nil

--- a/cmd/k8s-operator/deploy/chart/templates/operator-rbac.yaml
+++ b/cmd/k8s-operator/deploy/chart/templates/operator-rbac.yaml
@@ -53,6 +53,9 @@ rules:
 - apiGroups: ["apps"]
   resources: ["statefulsets", "deployments"]
   verbs: ["*"]
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/cmd/k8s-operator/deploy/crds/tailscale.com_dnsconfigs.yaml
+++ b/cmd/k8s-operator/deploy/crds/tailscale.com_dnsconfigs.yaml
@@ -17,7 +17,7 @@ spec:
   versions:
     - additionalPrinterColumns:
         - description: Service IP address of the nameserver
-          jsonPath: .status.nameserverStatus.ip
+          jsonPath: .status.nameserver.ip
           name: NameserverIP
           type: string
       name: v1alpha1
@@ -85,7 +85,7 @@ spec:
                   x-kubernetes-list-map-keys:
                     - type
                   x-kubernetes-list-type: map
-                nameserverStatus:
+                nameserver:
                   type: object
                   properties:
                     ip:

--- a/cmd/k8s-operator/deploy/examples/dnsconfig.yaml
+++ b/cmd/k8s-operator/deploy/examples/dnsconfig.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   nameserver:
     image:
-      repo: gcr.io/csi-test-290908/nameserver
-      tag: v0.0.1ns
+      repo: tailscale/k8s-nameserver
+      tag: unstable-v1.65

--- a/cmd/k8s-operator/deploy/examples/dnsconfig.yaml
+++ b/cmd/k8s-operator/deploy/examples/dnsconfig.yaml
@@ -1,0 +1,9 @@
+apiVersion: tailscale.com/v1alpha1
+kind: DNSConfig 
+metadata:
+  name: ts-dns
+spec:
+  nameserver:
+    image:
+      repo: gcr.io/csi-test-290908/nameserver
+      tag: v0.0.1ns

--- a/cmd/k8s-operator/deploy/manifests/nameserver/cm.yaml
+++ b/cmd/k8s-operator/deploy/manifests/nameserver/cm.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: dnsconfig
+  name: dnsrecords

--- a/cmd/k8s-operator/deploy/manifests/nameserver/deploy.yaml
+++ b/cmd/k8s-operator/deploy/manifests/nameserver/deploy.yaml
@@ -26,12 +26,12 @@ spec:
           protocol: UDP
           containerPort: 1053
         volumeMounts:
-        - name: dnsconfig
+        - name: dnsrecords
           mountPath: /config
       restartPolicy: Always
       serviceAccount: nameserver
       serviceAccountName: nameserver
       volumes:
-      - name: dnsconfig
+      - name: dnsrecords
         configMap:
-          name: dnsconfig
+          name: dnsrecords

--- a/cmd/k8s-operator/deploy/manifests/nameserver/sa.yaml
+++ b/cmd/k8s-operator/deploy/manifests/nameserver/sa.yaml
@@ -2,5 +2,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: nameserver
-imagePullSecrets:
-- name: foo

--- a/cmd/k8s-operator/deploy/manifests/operator.yaml
+++ b/cmd/k8s-operator/deploy/manifests/operator.yaml
@@ -1394,6 +1394,14 @@ rules:
         - deployments
       verbs:
         - '*'
+    - apiGroups:
+        - discovery.k8s.io
+      resources:
+        - endpointslices
+      verbs:
+        - get
+        - list
+        - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/cmd/k8s-operator/deploy/manifests/operator.yaml
+++ b/cmd/k8s-operator/deploy/manifests/operator.yaml
@@ -176,7 +176,7 @@ spec:
     versions:
         - additionalPrinterColumns:
             - description: Service IP address of the nameserver
-              jsonPath: .status.nameserverStatus.ip
+              jsonPath: .status.nameserver.ip
               name: NameserverIP
               type: string
           name: v1alpha1
@@ -240,7 +240,7 @@ spec:
                                 x-kubernetes-list-map-keys:
                                     - type
                                 x-kubernetes-list-type: map
-                            nameserverStatus:
+                            nameserver:
                                 properties:
                                     ip:
                                         type: string

--- a/cmd/k8s-operator/dnsrecords.go
+++ b/cmd/k8s-operator/dnsrecords.go
@@ -1,0 +1,335 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !plan9
+
+// tailscale-operator provides a way to expose services running in a Kubernetes
+// cluster to your Tailnet and to make Tailscale nodes available to cluster
+// workloads
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/net"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	operatorutils "tailscale.com/k8s-operator"
+	tsapi "tailscale.com/k8s-operator/apis/v1alpha1"
+	"tailscale.com/util/mak"
+)
+
+const (
+	dnsRecordsRecocilerFinalizer = "tailscale.com/dns-records-reconciler"
+	annotationTSMagicDNSName     = "tailscale.com/magic-dnsname"
+)
+
+// dnsRecordsReconciler knows how to update dnsrecords ConfigMap with DNS
+// records.
+// The records that it creates are:
+//   - For tailscale Ingress, a mapping of the Ingress's MagicDNSName to the IP address of
+//     the ingress proxy Pod.
+//   - For egress proxies configured via tailscale.com/tailnet-fqdn annotation, a
+//     mapping of the the tailnet FQDN to the IP address of the egress proxy Pod.
+//
+// Records will only created if there is exactly one ready
+// tailscale.com/v1alpha1.DNSConfig instance in the cluster (so that we know
+// that there is a ts.net nameserver deployed in the cluster).
+type dnsRecordsReconciler struct {
+	client.Client
+	tsNamespace           string // namespace in which we provision tailscale resources
+	logger                *zap.SugaredLogger
+	isDefaultLoadBalancer bool // true if operator is the default ingress controller in this cluster
+}
+
+// Reconcile takes a reconcile.Request for a headless Service fronting a
+// tailscale proxy and updates DNS Records in dnsrecords ConfigMap for the
+// in-cluster ts.net nameserver if required.
+func (dnsRR *dnsRecordsReconciler) Reconcile(ctx context.Context, req reconcile.Request) (res reconcile.Result, err error) {
+	logger := dnsRR.logger.With("Service", req.NamespacedName)
+	logger.Debugf("starting reconcile")
+	defer logger.Debugf("reconcile finished")
+
+	headlessSvc := new(corev1.Service)
+	err = dnsRR.Client.Get(ctx, req.NamespacedName, headlessSvc)
+	if apierrors.IsNotFound(err) {
+		logger.Debugf("Service not found")
+		return reconcile.Result{}, nil
+	}
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to get Service: %w", err)
+	}
+	if !(isManagedByType(headlessSvc, "svc") || isManagedByType(headlessSvc, "ingress")) {
+		logger.Debugf("Service is not a headless Service for a tailscale ingress or egress proxy; do nothing")
+		return reconcile.Result{}, nil
+	}
+
+	if !headlessSvc.DeletionTimestamp.IsZero() {
+		logger.Debug("Service is being deleted, clean up resources")
+		return reconcile.Result{}, dnsRR.maybeCleanup(ctx, headlessSvc, logger)
+	}
+
+	// Check that there is a ts.net nameserver deployed to the cluster by
+	// checking that there is a ready tailscale.com/v1alpha1.DNSConfig
+	// resource.
+	dnsCfgLst := new(tsapi.DNSConfigList)
+	if err = dnsRR.List(ctx, dnsCfgLst); err != nil {
+		return reconcile.Result{}, fmt.Errorf("error listing DNSConfigs: %w", err)
+	}
+	if len(dnsCfgLst.Items) == 0 {
+		logger.Debugf("DNSConfig does not exist, not creating DNS records")
+		return reconcile.Result{}, nil
+	}
+	if len(dnsCfgLst.Items) > 1 {
+		logger.Errorf("Invalid cluster state - more than one DNSConfig found in cluster. Please ensure no more than one exists")
+		return reconcile.Result{}, nil
+	}
+	dnsCfg := dnsCfgLst.Items[0]
+	if !operatorutils.DNSCfgIsReady(&dnsCfg) {
+		logger.Info("DNSConfig is not ready yet, waiting...")
+		return reconcile.Result{}, nil
+	}
+
+	return reconcile.Result{}, dnsRR.maybeProvision(ctx, headlessSvc, logger)
+}
+
+// maybeProvision ensures that dnsrecords ConfigMap contains a record for the
+// proxy associated with the headless Service.
+// The record is only provisioned if the proxy is for a tailscale Ingress or
+// egress configured via tailscale.com/tailnet-fqdn annotation.
+//
+// For Ingress, the record is a mapping between the MagicDNSName of the Ingress, retrieved from
+// ingress.status.loadBalancer.ingress.hostname field and the proxy Pod IP addresses
+// retrieved from the EndpoinSlice associated with this headless Service, i.e
+// Records{IP4: <MagicDNS name of the Ingress>: <[IPs of the ingress proxy Pods]>}
+//
+// For egress, the record is a mapping between tailscale.com/tailnet-fqdn
+// annotation and the proxy Pod IP addresses, retrieved from the EndpointSlice
+// associated with this headless Service, i.e
+// Records{IP4: {<tailscale.com/tailnet-fqdn>: <[IPs of the egress proxy Pods]>}
+//
+// If records need to be created for this proxy, maybeProvision will also:
+// - update the headless Service with a tailscale.com/magic-dnsname annotation
+// - update the headless Service with a finalizer
+func (dnsRR *dnsRecordsReconciler) maybeProvision(ctx context.Context, headlessSvc *corev1.Service, logger *zap.SugaredLogger) error {
+	if headlessSvc == nil {
+		logger.Info("[unexpected] maybeProvision called with a nil Service")
+		return nil
+	}
+	isEgressFQDNSvc, err := dnsRR.isSvcForFQDNEgressProxy(ctx, headlessSvc)
+	if err != nil {
+		return fmt.Errorf("error checking whether Service is for an egress proxy: %w", err)
+	}
+	if !(isEgressFQDNSvc || isManagedByType(headlessSvc, "ingress")) {
+		logger.Debug("Service is not fronting a proxy that we create DNS records for; do nothing")
+		return nil
+	}
+	fqdn, err := dnsRR.fqdnForDNSRecord(ctx, headlessSvc, logger)
+	if err != nil {
+		return fmt.Errorf("error determining DNS name for record: %w", err)
+	}
+	if fqdn == "" {
+		logger.Debugf("MagicDNS name does not (yet) exist, not provisioning DNS record")
+		return nil // a new reconcile will be triggered once it's added
+	}
+
+	oldHeadlessSvc := headlessSvc.DeepCopy()
+	// Ensure that headless Service is annotated with a finalizer to help
+	// with records cleanup when proxy resources are deleted.
+	if !slices.Contains(headlessSvc.Finalizers, dnsRecordsRecocilerFinalizer) {
+		headlessSvc.Finalizers = append(headlessSvc.Finalizers, dnsRecordsRecocilerFinalizer)
+	}
+	// Ensure that headless Service is annotated with the current MagicDNS
+	// name to help with records cleanup when proxy resources are deleted or
+	// MagicDNS name changes.
+	oldFqdn := headlessSvc.Annotations[annotationTSMagicDNSName]
+	if oldFqdn != "" && oldFqdn != fqdn { // i.e user has changed the value of tailscale.com/tailnet-fqdn annotation
+		logger.Debugf("MagicDNS name has changed, remvoving record for %s", oldFqdn)
+		updateFunc := func(rec *operatorutils.Records) {
+			delete(rec.IP4, oldFqdn)
+		}
+		if err = dnsRR.updateDNSConfig(ctx, updateFunc); err != nil {
+			return fmt.Errorf("error removing record for %s: %w", oldFqdn, err)
+		}
+	}
+	mak.Set(&headlessSvc.Annotations, annotationTSMagicDNSName, fqdn)
+	if !apiequality.Semantic.DeepEqual(oldHeadlessSvc, headlessSvc) {
+		logger.Infof("provisioning DNS record for MagicDNS name: %s", fqdn) // this will be printed exactly once
+		if err := dnsRR.Update(ctx, headlessSvc); err != nil {
+			return fmt.Errorf("error updating proxy headless Service metadata: %w", err)
+		}
+	}
+
+	// Get the Pod IP addresses for the proxy from the EndpointSlice for the
+	// headless Service.
+	labels := map[string]string{discoveryv1.LabelServiceName: headlessSvc.Name} // https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/#ownership
+	eps, err := getSingleObject[discoveryv1.EndpointSlice](ctx, dnsRR.Client, dnsRR.tsNamespace, labels)
+	if err != nil {
+		return fmt.Errorf("error getting proxy EndpointSlice: %w", err)
+	}
+	if eps == nil {
+		logger.Debugf("proxy EndpointSlice does not yet exist. We will reconcile again once it's created")
+		return nil
+	}
+	ips := make([]string, 0)
+	for _, ep := range eps.Endpoints {
+		for _, ip := range ips {
+			if !net.IsIPv4String(ip) {
+				logger.Infof("EndpointSlice contains IP address %q that is not IPv4, ignoring. Currently only IPv4 is supported", ip)
+			} else {
+				ips = append(ips, ip)
+			}
+		}
+		ips = append(ips, ep.Addresses...)
+	}
+	if len(ips) == 0 {
+		logger.Debugf("No endpoint addresses found. We will reconcile again once they are created.")
+		return nil
+	}
+	updateFunc := func(rec *operatorutils.Records) {
+		mak.Set(&rec.IP4, fqdn, ips)
+	}
+	if err = dnsRR.updateDNSConfig(ctx, updateFunc); err != nil {
+		return fmt.Errorf("error updating DNS records: %w", err)
+	}
+	return nil
+}
+
+// maybeCleanup ensures that the DNS record for the proxy has been removed from
+// dnsrecords ConfigMap and the tailscale.com/dns-records-reconciler finalizer
+// has been removed from the Service. If the record is not found in the
+// ConfigMap, the ConfigMap does not exist or the Service does not have
+// tailscale.com/magic-dnsname annotation, just remove the finalizer.
+func (h *dnsRecordsReconciler) maybeCleanup(ctx context.Context, headlessSvc *corev1.Service, logger *zap.SugaredLogger) error {
+	ix := slices.Index(headlessSvc.Finalizers, dnsRecordsRecocilerFinalizer)
+	if ix == -1 {
+		logger.Debugf("no finalizer, nothing to do")
+		return nil
+	}
+	cm := &corev1.ConfigMap{}
+	err := h.Client.Get(ctx, types.NamespacedName{Name: operatorutils.DNSRecordsCMName, Namespace: h.tsNamespace}, cm)
+	if apierrors.IsNotFound(err) {
+		logger.Debug("dsnrecords ConfigMap not found")
+		return h.removeHeadlessSvcFinalizer(ctx, headlessSvc)
+	}
+	if err != nil {
+		return fmt.Errorf("error retrieving dnsrecords ConfigMap: %w", err)
+	}
+	if cm.Data == nil {
+		logger.Debug("dnsrecords ConfigMap contains no records")
+		return h.removeHeadlessSvcFinalizer(ctx, headlessSvc)
+	}
+	_, ok := cm.Data[operatorutils.DNSRecordsCMKey]
+	if !ok {
+		logger.Debug("dnsrecords ConfigMap contains no records")
+		return h.removeHeadlessSvcFinalizer(ctx, headlessSvc)
+	}
+	fqdn, ok := headlessSvc.GetAnnotations()[annotationTSMagicDNSName]
+	if !ok || fqdn == "" {
+		return h.removeHeadlessSvcFinalizer(ctx, headlessSvc)
+	}
+	logger.Infof("removing DNS record for MagicDNS name %s", fqdn)
+	updateFunc := func(rec *operatorutils.Records) {
+		delete(rec.IP4, fqdn)
+	}
+	if err = h.updateDNSConfig(ctx, updateFunc); err != nil {
+		return fmt.Errorf("error updating DNS config: %w", err)
+	}
+	return h.removeHeadlessSvcFinalizer(ctx, headlessSvc)
+}
+
+func (dnsRR *dnsRecordsReconciler) removeHeadlessSvcFinalizer(ctx context.Context, headlessSvc *corev1.Service) error {
+	idx := slices.Index(headlessSvc.Finalizers, dnsRecordsRecocilerFinalizer)
+	if idx == -1 {
+		return nil
+	}
+	headlessSvc.Finalizers = append(headlessSvc.Finalizers[:idx], headlessSvc.Finalizers[idx+1:]...)
+	return dnsRR.Update(ctx, headlessSvc)
+}
+
+// fqdnForDNSRecord returns MagicDNS name associated with a given headless Service.
+// If the headless Service is for a tailscale Ingress proxy, returns ingress.status.loadBalancer.ingress.hostname.
+// If the headless Service is for an tailscale egress proxy configured via tailscale.com/tailnet-fqdn annotation, returns the annotation value.
+// This function is not expected to be called with headless Services for other
+// proxy types, or any other Services, but it just returns an empty string if
+// that happens.
+func (dnsRR *dnsRecordsReconciler) fqdnForDNSRecord(ctx context.Context, headlessSvc *corev1.Service, logger *zap.SugaredLogger) (string, error) {
+	parentName := parentFromObjectLabels(headlessSvc)
+	if isManagedByType(headlessSvc, "ingress") {
+		ing := new(networkingv1.Ingress)
+		if err := dnsRR.Get(ctx, parentName, ing); err != nil {
+			return "", err
+		}
+		if len(ing.Status.LoadBalancer.Ingress) == 0 {
+			return "", nil
+		}
+		return ing.Status.LoadBalancer.Ingress[0].Hostname, nil
+	}
+	if isManagedByType(headlessSvc, "svc") {
+		svc := new(corev1.Service)
+		if err := dnsRR.Get(ctx, parentName, svc); apierrors.IsNotFound(err) {
+			logger.Info("[unexpected] parent Service for egress proxy %s not found", headlessSvc.Name)
+			return "", nil
+		} else if err != nil {
+			return "", err
+		}
+		return svc.Annotations[AnnotationTailnetTargetFQDN], nil
+	}
+	return "", nil
+}
+
+// updateDNSConfig runs the provided update function against dnsrecords
+// ConfigMap. At this point the in-cluster ts.net nameserver is expected to be
+// successfully created together with the ConfigMap.
+func (dnsRR *dnsRecordsReconciler) updateDNSConfig(ctx context.Context, update func(*operatorutils.Records)) error {
+	cm := &corev1.ConfigMap{}
+	err := dnsRR.Get(ctx, types.NamespacedName{Name: operatorutils.DNSRecordsCMName, Namespace: dnsRR.tsNamespace}, cm)
+	if apierrors.IsNotFound(err) {
+		dnsRR.logger.Info("[unexpected] dnsrecords ConfigMap not found in cluster. Not updating DNS records. Please open an isue and attach operator logs.")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error retrieving dnsrecords ConfigMap: %w", err)
+	}
+	dnsRecords := operatorutils.Records{Version: operatorutils.Alpha1Version, IP4: map[string][]string{}}
+	if cm.Data != nil && cm.Data[operatorutils.DNSRecordsCMKey] != "" {
+		if err := json.Unmarshal([]byte(cm.Data[operatorutils.DNSRecordsCMKey]), &dnsRecords); err != nil {
+			return err
+		}
+	}
+	update(&dnsRecords)
+	dnsRecordsBs, err := json.Marshal(dnsRecords)
+	if err != nil {
+		return fmt.Errorf("error marshalling DNS records: %w", err)
+	}
+	mak.Set(&cm.Data, operatorutils.DNSRecordsCMKey, string(dnsRecordsBs))
+	return dnsRR.Update(ctx, cm)
+}
+
+// isSvcForFQDNEgressProxy returns true if the Service is a headless Service
+// created for a proxy for a tailscale egress Service configured via
+// tailscale.com/tailnet-fqdn annotation.
+func (dnsRR *dnsRecordsReconciler) isSvcForFQDNEgressProxy(ctx context.Context, svc *corev1.Service) (bool, error) {
+	if !isManagedByType(svc, "svc") {
+		return false, nil
+	}
+	parentName := parentFromObjectLabels(svc)
+	parentSvc := new(corev1.Service)
+	if err := dnsRR.Get(ctx, parentName, parentSvc); apierrors.IsNotFound(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+	annots := parentSvc.Annotations
+	return annots != nil && annots[AnnotationTailnetTargetFQDN] != "", nil
+}

--- a/cmd/k8s-operator/dnsrecords_test.go
+++ b/cmd/k8s-operator/dnsrecords_test.go
@@ -1,0 +1,198 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !plan9
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	operatorutils "tailscale.com/k8s-operator"
+	tsapi "tailscale.com/k8s-operator/apis/v1alpha1"
+	"tailscale.com/tstest"
+	"tailscale.com/types/ptr"
+)
+
+func TestDNSRecordsReconciler(t *testing.T) {
+	// Preconfigure a cluster with a DNSConfig
+	dnsConfig := &tsapi.DNSConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		TypeMeta: metav1.TypeMeta{Kind: "DNSConfig"},
+		Spec: tsapi.DNSConfigSpec{
+			Nameserver: &tsapi.Nameserver{},
+		}}
+	ing := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ts-ingress",
+			Namespace: "test",
+		},
+		Spec: networkingv1.IngressSpec{
+			IngressClassName: ptr.To("tailscale"),
+		},
+		Status: networkingv1.IngressStatus{
+			LoadBalancer: networkingv1.IngressLoadBalancerStatus{
+				Ingress: []networkingv1.IngressLoadBalancerIngress{{
+					Hostname: "cluster.ingress.ts.net"}},
+			},
+		},
+	}
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "dnsrecords", Namespace: "tailscale"}}
+	fc := fake.NewClientBuilder().
+		WithScheme(tsapi.GlobalScheme).
+		WithObjects(cm).
+		WithObjects(dnsConfig).
+		WithObjects(ing).
+		WithStatusSubresource(dnsConfig, ing).
+		Build()
+	zl, err := zap.NewDevelopment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cl := tstest.NewClock(tstest.ClockOpts{})
+	// Set the ready condition of the DNSConfig
+	mustUpdateStatus[tsapi.DNSConfig](t, fc, "", "test", func(c *tsapi.DNSConfig) {
+		operatorutils.SetDNSConfigCondition(c, tsapi.NameserverReady, metav1.ConditionTrue, reasonNameserverCreated, reasonNameserverCreated, 0, cl, zl.Sugar())
+	})
+	dnsRR := &dnsRecordsReconciler{
+		Client:      fc,
+		logger:      zl.Sugar(),
+		tsNamespace: "tailscale",
+	}
+
+	// 1. DNS record is created for an egress proxy configured via
+	// tailscale.com/tailnet-fqdn annotation
+	egressSvcFQDN := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "egress-fqdn",
+			Namespace:   "test",
+			Annotations: map[string]string{"tailscale.com/tailnet-fqdn": "foo.bar.ts.net"},
+		},
+		Spec: corev1.ServiceSpec{
+			ExternalName: "unused",
+			Type:         corev1.ServiceTypeExternalName,
+		},
+	}
+	headlessForEgressSvcFQDN := headlessSvcForParent(egressSvcFQDN, "svc") // create the proxy headless Service
+	ep := endpointSliceForService(headlessForEgressSvcFQDN, "10.9.8.7")
+	mustCreate(t, fc, egressSvcFQDN)
+	mustCreate(t, fc, headlessForEgressSvcFQDN)
+	mustCreate(t, fc, ep)
+	expectReconciled(t, dnsRR, "tailscale", "egress-fqdn") // dns-records-reconciler reconcile the headless Service
+	// ConfigMap should now have a record for foo.bar.ts.net -> 10.8.8.7
+	wantHosts := map[string][]string{"foo.bar.ts.net": {"10.9.8.7"}}
+	expectHostsRecords(t, fc, wantHosts)
+
+	// 2. DNS record is updated if tailscale.com/tailnet-fqdn annotation's
+	// value changes
+	mustUpdate(t, fc, "test", "egress-fqdn", func(svc *corev1.Service) {
+		svc.Annotations["tailscale.com/tailnet-fqdn"] = "baz.bar.ts.net"
+	})
+	expectReconciled(t, dnsRR, "tailscale", "egress-fqdn") // dns-records-reconciler reconcile the headless Service
+	wantHosts = map[string][]string{"baz.bar.ts.net": {"10.9.8.7"}}
+	expectHostsRecords(t, fc, wantHosts)
+
+	// 3. DNS record is updated if the IP address of the proxy Pod changes.
+	ep = endpointSliceForService(headlessForEgressSvcFQDN, "10.6.5.4")
+	mustUpdate(t, fc, ep.Namespace, ep.Name, func(ep *discoveryv1.EndpointSlice) {
+		ep.Endpoints[0].Addresses = []string{"10.6.5.4"}
+	})
+	expectReconciled(t, dnsRR, "tailscale", "egress-fqdn") // dns-records-reconciler reconcile the headless Service
+	wantHosts = map[string][]string{"baz.bar.ts.net": {"10.6.5.4"}}
+	expectHostsRecords(t, fc, wantHosts)
+
+	// 4. DNS record is created for an ingress proxy configured via Ingress
+	headlessForIngress := headlessSvcForParent(ing, "ingress")
+	ep = endpointSliceForService(headlessForIngress, "10.9.8.7")
+	mustCreate(t, fc, headlessForIngress)
+	mustCreate(t, fc, ep)
+	expectReconciled(t, dnsRR, "tailscale", "ts-ingress") // dns-records-reconciler should reconcile the headless Service
+	wantHosts["cluster.ingress.ts.net"] = []string{"10.9.8.7"}
+	expectHostsRecords(t, fc, wantHosts)
+
+	// 5. DNS records are updated if Ingress's MagicDNS name changes (i.e users changed spec.tls.hosts[0])
+	t.Log("test case 5")
+	mustUpdateStatus(t, fc, "test", "ts-ingress", func(ing *networkingv1.Ingress) {
+		ing.Status.LoadBalancer.Ingress[0].Hostname = "another.ingress.ts.net"
+	})
+	expectReconciled(t, dnsRR, "tailscale", "ts-ingress") // dns-records-reconciler should reconcile the headless Service
+	delete(wantHosts, "cluster.ingress.ts.net")
+	wantHosts["another.ingress.ts.net"] = []string{"10.9.8.7"}
+	expectHostsRecords(t, fc, wantHosts)
+
+	// 6. DNS records are updated if Ingress proxy's Pod IP changes
+	mustUpdate(t, fc, ep.Namespace, ep.Name, func(ep *discoveryv1.EndpointSlice) {
+		ep.Endpoints[0].Addresses = []string{"7.8.9.10"}
+	})
+	expectReconciled(t, dnsRR, "tailscale", "ts-ingress")
+	wantHosts["another.ingress.ts.net"] = []string{"7.8.9.10"}
+	expectHostsRecords(t, fc, wantHosts)
+}
+
+func headlessSvcForParent(o client.Object, typ string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      o.GetName(),
+			Namespace: "tailscale",
+			Labels: map[string]string{
+				LabelManaged:         "true",
+				LabelParentName:      o.GetName(),
+				LabelParentNamespace: o.GetNamespace(),
+				LabelParentType:      typ,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "None",
+			Type:      corev1.ServiceTypeClusterIP,
+			Selector:  map[string]string{"foo": "bar"},
+		},
+	}
+}
+
+func endpointSliceForService(svc *corev1.Service, ip string) *discoveryv1.EndpointSlice {
+	return &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svc.Name,
+			Namespace: svc.Namespace,
+			Labels:    map[string]string{discoveryv1.LabelServiceName: svc.Name},
+		},
+		Endpoints: []discoveryv1.Endpoint{{
+			Addresses: []string{ip},
+		}},
+	}
+}
+
+func expectHostsRecords(t *testing.T, cl client.Client, wantsHosts map[string][]string) {
+	t.Helper()
+	cm := new(corev1.ConfigMap)
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: "dnsrecords", Namespace: "tailscale"}, cm); err != nil {
+		t.Fatalf("getting dnsconfig ConfigMap: %v", err)
+	}
+	if cm.Data == nil {
+		t.Fatal("dnsconfig ConfigMap has no data")
+	}
+	dnsConfigString, ok := cm.Data[operatorutils.DNSRecordsCMKey]
+	if !ok {
+		t.Fatal("dnsconfig ConfigMap does not contain dnsconfig")
+	}
+	dnsConfig := &operatorutils.Records{}
+	if err := json.Unmarshal([]byte(dnsConfigString), dnsConfig); err != nil {
+		t.Fatalf("unmarshaling dnsconfig: %v", err)
+	}
+	if diff := cmp.Diff(dnsConfig.IP4, wantsHosts); diff != "" {
+		t.Fatalf("unexpected dns config (-got +want):\n%s", diff)
+	}
+}

--- a/cmd/k8s-operator/nameserver.go
+++ b/cmd/k8s-operator/nameserver.go
@@ -141,7 +141,7 @@ func (a *NameserverReconciler) Reconcile(ctx context.Context, req reconcile.Requ
 		return res, fmt.Errorf("error getting Service: %w", err)
 	}
 	if ip := svc.Spec.ClusterIP; ip != "" && ip != "None" {
-		dnsCfg.Status.NameserverStatus = &tsapi.NameserverStatus{
+		dnsCfg.Status.Nameserver = &tsapi.NameserverStatus{
 			IP: ip,
 		}
 		return setStatus(&dnsCfg, tsapi.NameserverReady, metav1.ConditionTrue, reasonNameserverCreated, reasonNameserverCreated)

--- a/cmd/k8s-operator/nameserver_test.go
+++ b/cmd/k8s-operator/nameserver_test.go
@@ -77,7 +77,7 @@ func TestNameserverReconciler(t *testing.T) {
 		svc.Spec.ClusterIP = "1.2.3.4"
 	})
 	expectReconciled(t, nr, "", "test")
-	dnsCfg.Status.NameserverStatus = &tsapi.NameserverStatus{
+	dnsCfg.Status.Nameserver = &tsapi.NameserverStatus{
 		IP: "1.2.3.4",
 	}
 	dnsCfg.Finalizers = []string{FinalizerName}

--- a/cmd/k8s-operator/nameserver_test.go
+++ b/cmd/k8s-operator/nameserver_test.go
@@ -105,14 +105,14 @@ func TestNameserverReconciler(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error marshalling ConfigMap contents: %v", err)
 	}
-	mustUpdate(t, fc, "tailscale", "dnsconfig", func(cm *corev1.ConfigMap) {
-		mak.Set(&cm.Data, "dns.json", string(bs))
+	mustUpdate(t, fc, "tailscale", "dnsrecords", func(cm *corev1.ConfigMap) {
+		mak.Set(&cm.Data, "records.json", string(bs))
 	})
 	expectReconciled(t, nr, "", "test")
-	wantCm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "dnsconfig",
+	wantCm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "dnsrecords",
 		Namespace: "tailscale", Labels: labels, OwnerReferences: []metav1.OwnerReference{*dnsCfgOwnerRef}},
 		TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
-		Data:     map[string]string{"dns.json": string(bs)},
+		Data:     map[string]string{"records.json": string(bs)},
 	}
 	expectEqual(t, fc, wantCm, nil)
 }

--- a/go.mod
+++ b/go.mod
@@ -371,7 +371,7 @@ require (
 	k8s.io/component-base v0.29.1 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240117194847-208609032b15 // indirect
-	k8s.io/utils v0.0.0-20240102154912-e7106e64919e // indirect
+	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
 	mvdan.cc/gofumpt v0.5.0 // indirect
 	mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed // indirect
 	mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b // indirect

--- a/k8s-operator/api.md
+++ b/k8s-operator/api.md
@@ -427,7 +427,7 @@ ConnectorCondition contains condition information for a Connector.
         </td>
         <td>false</td>
       </tr><tr>
-        <td><b><a href="#dnsconfigstatusnameserverstatus">nameserverStatus</a></b></td>
+        <td><b><a href="#dnsconfigstatusnameserver">nameserver</a></b></td>
         <td>object</td>
         <td>
           <br/>
@@ -503,7 +503,7 @@ ConnectorCondition contains condition information for a Connector.
 </table>
 
 
-### DNSConfig.status.nameserverStatus
+### DNSConfig.status.nameserver
 <sup><sup>[↩ Parent](#dnsconfigstatus)</sup></sup>
 
 

--- a/k8s-operator/apis/v1alpha1/types_tsdnsconfig.go
+++ b/k8s-operator/apis/v1alpha1/types_tsdnsconfig.go
@@ -17,7 +17,7 @@ var DNSConfigKind = "DNSConfig"
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,shortName=dc
-// +kubebuilder:printcolumn:name="NameserverIP",type="string",JSONPath=`.status.nameserverStatus.ip`,description="Service IP address of the nameserver"
+// +kubebuilder:printcolumn:name="NameserverIP",type="string",JSONPath=`.status.nameserver.ip`,description="Service IP address of the nameserver"
 
 type DNSConfig struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -60,7 +60,7 @@ type DNSConfigStatus struct {
 	// +optional
 	Conditions []ConnectorCondition `json:"conditions"`
 	// +optional
-	NameserverStatus *NameserverStatus `json:"nameserverStatus"`
+	Nameserver *NameserverStatus `json:"nameserver"`
 }
 
 type NameserverStatus struct {

--- a/k8s-operator/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/k8s-operator/apis/v1alpha1/zz_generated.deepcopy.go
@@ -252,8 +252,8 @@ func (in *DNSConfigStatus) DeepCopyInto(out *DNSConfigStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.NameserverStatus != nil {
-		in, out := &in.NameserverStatus, &out.NameserverStatus
+	if in.Nameserver != nil {
+		in, out := &in.Nameserver, &out.Nameserver
 		*out = new(NameserverStatus)
 		**out = **in
 	}

--- a/k8s-operator/tsdns.go
+++ b/k8s-operator/tsdns.go
@@ -5,12 +5,18 @@
 
 package kube
 
-const Alpha1Version = "v1alpha1"
+const (
+	Alpha1Version = "v1alpha1"
+
+	DNSRecordsCMName = "dnsrecords"
+	DNSRecordsCMKey  = "records.json"
+)
 
 type Records struct {
 	// Version is the version of this Records configuration. Version is
-	// intended to be used by ./cmd/k8s-nameserver to determine whether it
-	// can read this records configuration.
+	// written by the operator, i.e when it first populates the Records.
+	// k8s-nameserver must verify that it knows how to parse a given
+	// version.
 	Version string `json:"version"`
 	// IP4 contains a mapping of DNS names to IPv4 address(es).
 	IP4 map[string][]string `json:"ip4"`


### PR DESCRIPTION
This PR adds functionality to the operator to optionally populate DNS records config for the in-cluster ts.net nameserver (added in #11017) with records for cluster proxies' MagicDNS names:

- For [Tailscale Ingress](https://tailscale.com/kb/1236/kubernetes-operator#exposing-a-service-using-ingress) the record is a mapping between `Ingress`s MagicDNS name and the proxy's Pod IP 

- For cluster egress proxies configured via `tailscale.com/tailnet-fqdn` annotation the record is a mapping between the annotation's value and the proxy's Pod IP

No records are currently created for any other proxy types.

The records are created only if there is a ready `tailscale.com/v1alpha1.DNSConfig` instance in the cluster (see #11017 ) i.e if users have explicitly configured the operator to deploy the in-cluster ts.net nameserver.

Below see the user flow for a setup where:
- cluster A runs a service exposed over Tailscale Ingress that should be accesible by callers on tailnet as well as cluster workloads via the same DNS name (the MagicDNS of the Ingress) (see [use case description](https://github.com/tailscale/tailscale/issues/10027#issuecomment-1827763853)).
cluster A uses kube-dns.
- cluster B's workloads also need to access the service in cluster A and would like to do that using the same `Ingress`. They can do it by exposing the `Ingress` to their cluster (see [cross-cluster connectivity](https://tailscale.com/kb/1236/kubernetes-operator#exposing-a-service-in-one-cluster-to-another-cluster-cross-cluster-connectivity)). Because A's Service is exposed over HTTPS, they need to use the MagicDNS name of the `Ingress` (so it needs to resolve within the cluster). See [a use case](https://github.com/tailscale/tailscale/issues/11500#issuecomment-2027483538).
cluster B uses CoreDNS.

<details>
In cluster A:

1. Deploy the operator
2. Create a `DNSConfig` to tell the operator to deploy an in-cluster ts.net nameserver, i.e

<code>
$ kubectl apply -f ./cmd/k8s-operator/examples/dnsconfig.yaml
</code>

4. Update `kube-dns` ConfigMap to tell kube-dns to use the ts.net nameserver to resolve `ts.net` DNS names

<code>
$ k get dnsconfig
NAME     NAMESERVERIP
ts-dns   10.27.1.90
$ kubectl get cm kube-dns -n kube-system -oyaml
apiVersion: v1
data:
  stubDomains: |
    {
      "ts.net": ["10.27.1.90"]
    }
kind: ConfigMap
metadata:
  name: kube-dns
  namespace: kube-system
...
</code>

6. Create a workload exposed via tailscale `Ingress`.
Note the use of `tailscale.com/experimental-forward-cluster-traffic-via-ingress` annotation- this makes the ingress proxy to listen on the Pod's IP address which it does not do by default.

<code>
apiVersion: apps/v1
kind: Deployment
metadata:
  name: kuardfoobar
spec:
  selector:
    matchLabels:
      app: kuardfoobar
  template:
    metadata:
      labels:
        app: kuardfoobar
    spec:
      containers:
      - image: gcr.io/kuar-demo/kuard-amd64:1
        name: kuardfoobar
        ports:
        - containerPort: 8080
---
apiVersion: v1
kind: Service
metadata:
  name: kuardfoobar
spec:
  ports:
  - port: 80
    targetPort: 8080
  type: ClusterIP
  selector:
    app: kuardfoobar
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: kuardfoobar 
  annotations:
    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
spec:
  tls:
  - hosts:
    - "dnstest"
  rules:
  - http:
      paths:
      - backend:
          service:
            name: kuardfoobar
            port:
              number: 80
        pathType: Prefix 
        path: /
  ingressClassName: tailscale
</code>

7. Observe the MagicDNS name of the `Ingress` and that the workload can be accessed over that from a non-tailscale `Pod` in cluster:

<code>
$ kubectl get ingress
NAME          CLASS       HOSTS   ADDRESS                      PORTS     AGE
kuardfoobar   tailscale   *       dnstest-3.tailbd97a.ts.net   80, 443   64m
$ kubectl exec -it somepod -- sh
/ # curl -vvv https://dnstest-3.tailbd97a.ts.net
* Host dnstest-3.tailbd97a.ts.net:443 was resolved.
* IPv6: (none)
* IPv4: 10.0.0.6
*   Trying 10.0.0.6:443...
* Connected to dnstest-3.tailbd97a.ts.net (10.0.0.6) port 443
....
</code>


In cluster B:

1. Deploy the operator
2. Create a `DNSConfig` to tell the operator to deploy an in-cluster ts.net nameserver, i.e

<code>
$ kubectl apply -f ./cmd/k8s-operator/examples/dnsconfig.yaml
</code>

4. Update CoreDNS config to tell it to use the ts.net nameserver to resolve ts.net DNS names:

<code>
$ kubectl get dnsconfig
NAME     NAMESERVERIP
ts-dns   10.100.198.212
$ kubectl get cm coredns -n kube-system -oyaml
apiVersion: v1
data:
  Corefile: |
    ts.net {
      cache 5
      errors
      forward . 10.100.198.212
    }
    .:53 {
       <default contents>
    }
kind: ConfigMap
metadata:
  name: coredns
  namespace: kube-system
</code>

6. Create a tailscale egress proxy with a `tailscale.com/tailnet-fqdn` annotation pointing at the `Ingress` in cluster A:

<code>
kind: Service
metadata:
  annotations:
    tailscale.com/tailnet-fqdn: dnstest-3.tailbd97a.ts.net
  name: kuard-egress
spec:
  type: ExternalName
</code>

8. Verify that you can access the workload in cluster A over the MagicDNS name of `Ingress` in cluster A from a non-tailscale `Pod` in cluster B:

<code>
$ kubectl exec -it sompod -- sh
 # curl -vvv https://dnstest-3.tailbd97a.ts.net
* Host dnstest-3.tailbd97a.ts.net:443 was resolved.
* IPv6: (none)
* IPv4: 172.31.24.228
*   Trying 172.31.24.228:443...
* Connected to dnstest-3.tailbd97a.ts.net (172.31.24.228) port 443
...
</code>
</details>

Notes:
- users have to manually update kube-dns/CoreDNS config to add the stub nameserver's Service IP
- IPv6 Pod addresses currently not supported
- To access Tailscale Ingress from within a cluster via its MagicDNS name, users also have to annotate the `Ingress` resource with `tailscale.com/experimental-forward-cluster-traffic-via-ingress` annotation, see 
#11036 
- I have also tested that non-operator managed tailscale instances that accept Tailscale DNS, running in a `Pod` in a cluster configured with our nameserver, still use 100.100.100.100 to resolve tailnet DNS names. Operator configured proxies do not accept Tailscale DNS, so they _would_ use the ts.net nameserver. I cannot think of cases where this would be an issue (because they don't need to talk to anything on tailnet via MagicDNS)


cc @jaxxstorm 

Next steps:
- update build infra to publish nameserver images