### PR TITLE
cmd/gitops-pusher: only use OAuth creds if non-empty string

### DIFF
--- a/cmd/gitops-pusher/gitops-pusher.go
+++ b/cmd/gitops-pusher/gitops-pusher.go
@@ -162,7 +162,9 @@ func main() {
 		log.Fatal("set either the envvar TS_API_KEY or TS_OAUTH_ID and TS_OAUTH_SECRET")
 	}
 	var client *http.Client
-	if oiok {
+	if oiok && (oauthId != "" || oauthSecret != "") {
+		// Both should ideally be set, but if either are non-empty it means the user had an intent
+		// to set _something_, so they should receive the oauth error flow.
 		oauthConfig := &clientcredentials.Config{
 			ClientID:     oauthId,
 			ClientSecret: oauthSecret,


### PR DESCRIPTION
`os.LookupEnv` may return true if the variable is present in the environment but an empty string. We should only attempt to set OAuth Config if thsoe values are non-empty.

Updates gitops-acl-action#33