### PR TITLE
cmd/dist: fix --synology-package-center flag

### DIFF
--- a/cmd/dist/dist.go
+++ b/cmd/dist/dist.go
@@ -33,6 +33,9 @@ func getTargets() ([]dist.Target, error) {
 	// Since only we can provide packages to Synology for
 	// distribution, we default to building the "sideload" variant of
 	// packages that we distribute on pkgs.tailscale.com.
+	//
+	// To build for package center, run
+	// ./tool/go run ./cmd/dist build --synology-package-center synology
 	ret = append(ret, synology.Targets(synologyPackageCenter, nil)...)
 	return ret, nil
 }

--- a/release/dist/synology/pkgs.go
+++ b/release/dist/synology/pkgs.go
@@ -44,7 +44,11 @@ func (t *target) Build(b *dist.Build) ([]string, error) {
 func (t *target) buildSPK(b *dist.Build, inner *innerPkg) ([]string, error) {
 	filename := fmt.Sprintf("tailscale-%s-%s-%d-dsm%d.spk", t.filenameArch, b.Version.Short, b.Version.Synology[t.dsmMajorVersion], t.dsmMajorVersion)
 	out := filepath.Join(b.Out, filename)
-	log.Printf("Building %s", filename)
+	if t.packageCenter {
+		log.Printf("Building %s (for package center)", filename)
+	} else {
+		log.Printf("Building %s (for sideloading)", filename)
+	}
 
 	privFile := fmt.Sprintf("privilege-dsm%d", t.dsmMajorVersion)
 	if t.packageCenter && t.dsmMajorVersion == 7 {


### PR DESCRIPTION
Running the following to build new Synology package center releases previously ignored the `--synology-package-center` flag, which is vital for making app store releases.

```
./tool/go run ./cmd/dist build synology --synology-package-center
```

This change updates `getTargets` to accept the args passed into the build command. And then checks for existance of the synology flag directly. This also allows us to move the synology flag out of the dist main func and into the CLI func where all other build flags are defined.

Can skip-issubot