### PR TITLE
Specify patch version in go.mod to fix toolchain not available error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module tailscale.com
 
-go 1.22
+go 1.22.0
 
 require (
 	filippo.io/mkcert v1.4.4


### PR DESCRIPTION
This PR should relate to https://github.com/tailscale/tailscale/issues/11058

I saw this issue.

```
$ go mod tidy
go: downloading go1.22 (linux/amd64)                   
go: download go1.22 for linux/amd64: toolchain not available
```

Then, followed https://github.com/golang/go/issues/62278#issuecomment-1933790368, then it's fixed.