### PR TITLE
tsweb: update Debugger ServeMux routes to 1.22.0 syntax

### DIFF
--- a/tsweb/debug.go
+++ b/tsweb/debug.go
@@ -46,7 +46,7 @@ func Debugger(mux *http.ServeMux) *DebugHandler {
 	ret := &DebugHandler{
 		mux: mux,
 	}
-	mux.Handle("/debug/", ret)
+	mux.Handle("GET /debug/", ret)
 
 	ret.KVFunc("Uptime", func() any { return varz.Uptime() })
 	ret.KV("Version", version.Long())


### PR DESCRIPTION
Updates #cleanup

Go 1.22.0 introduced the ability to use more expressive routing patterns that include HTTP method when constructing ServeMux entries. Applications that attempted to use these patterns in combination with the old `tsweb.Debugger` would experience a panic as Go would not permit the use of matching rules with mixed level of specificity.