### PR TITLE
tsweb: set charset when exporting vars to prometheus

### DIFF
--- a/tsweb/varz/varz.go
+++ b/tsweb/varz/varz.go
@@ -240,7 +240,7 @@ type sortedKVs struct {
 //
 // This will evolve over time, or perhaps be replaced.
 func Handler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
 
 	s := sortedKVsPool.Get().(*sortedKVs)
 	defer sortedKVsPool.Put(s)


### PR DESCRIPTION
Appears to be safe & the actual correct value based on: https://github.com/prometheus/common/pull/119

Updates: corp#17075