### PR TITLE
Revert "tsweb: update Debugger ServeMux routes to 1.22.0 syntax"

### DIFF
--- a/tsweb/debug.go
+++ b/tsweb/debug.go
@@ -46,7 +46,7 @@ func Debugger(mux *http.ServeMux) *DebugHandler {
 	ret := &DebugHandler{
 		mux: mux,
 	}
-	mux.Handle("GET /debug/", ret)
+	mux.Handle("/debug/", ret)
 
 	ret.KVFunc("Uptime", func() any { return varz.Uptime() })
 	ret.KV("Version", version.Long())


### PR DESCRIPTION
Reverts tailscale/tailscale#11087

Updates #cleanup 

This PR needs additional changes to the registration of child handlers under `/debug`