### PR TITLE
tsweb: update ServeMux matching to 1.22.0 syntax

### DIFF
--- a/tsweb/debug.go
+++ b/tsweb/debug.go
@@ -46,13 +46,13 @@ func Debugger(mux *http.ServeMux) *DebugHandler {
 	ret := &DebugHandler{
 		mux: mux,
 	}
-	mux.Handle("/debug/", ret)
+	mux.Handle("GET /debug/", ret)
 
 	ret.KVFunc("Uptime", func() any { return varz.Uptime() })
 	ret.KV("Version", version.Long())
-	ret.Handle("vars", "Metrics (Go)", expvar.Handler())
-	ret.Handle("varz", "Metrics (Prometheus)", http.HandlerFunc(promvarz.Handler))
-	ret.Handle("pprof/", "pprof (index)", http.HandlerFunc(pprof.Index))
+	ret.Handle("GET vars", "Metrics (Go)", expvar.Handler())
+	ret.Handle("GET varz", "Metrics (Prometheus)", http.HandlerFunc(promvarz.Handler))
+	ret.Handle("GET pprof/", "pprof (index)", http.HandlerFunc(pprof.Index))
 	// the CPU profile handler is special because it responds
 	// streamily, unlike every other pprof handler. This means it's
 	// not made available through pprof.Index the way all the other
@@ -63,7 +63,7 @@ func Debugger(mux *http.ServeMux) *DebugHandler {
 	ret.HandleSilent("pprof/profile", http.HandlerFunc(pprof.Profile))
 	ret.URL("/debug/pprof/goroutine?debug=1", "Goroutines (collapsed)")
 	ret.URL("/debug/pprof/goroutine?debug=2", "Goroutines (full)")
-	ret.Handle("gc", "force GC", http.HandlerFunc(gcHandler))
+	ret.Handle("GET gc", "force GC", http.HandlerFunc(gcHandler))
 	hostname, err := os.Hostname()
 	if err == nil {
 		ret.KV("Machine", hostname)
@@ -98,7 +98,7 @@ func (d *DebugHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (d *DebugHandler) handle(slug string, handler http.Handler) string {
-	href := "/debug/" + slug
+	href := "GET /debug/" + slug
 	d.mux.Handle(href, Protected(debugBrowserHeaderHandler(handler)))
 	return href
 }


### PR DESCRIPTION
Updates #cleanup

Go 1.22.0 introduced the ability to use more expressive routing patterns that include HTTP method when constructing ServeMux entries. Applications that attempted to use these patterns in combination with the old `tsweb.Debugger` would experience a panic as Go would not permit the use of matching rules with mixed level of specificity. We now specify the method for each `/debug` handler to prevent incompatibilities.