### PR TITLE
client/web: only check policy caps for tagged nodes

### DIFF
--- a/client/web/web.go
+++ b/client/web/web.go
@@ -477,7 +477,7 @@ func (s *Server) serveAPIAuth(w http.ResponseWriter, r *http.Request) {
 	session, whois, status, sErr := s.getSession(r)
 
 	if whois != nil {
-		caps, err := toPeerCapabilities(whois)
+		caps, err := toPeerCapabilities(status, whois)
 		if err != nil {
 			http.Error(w, sErr.Error(), http.StatusInternalServerError)
 			return


### PR DESCRIPTION
For user-owned nodes, only the owner is ever allowed to manage the node.

Updates tailscale/corp#16695