### PR TITLE
tailfs: listen for local clients only on 100.100.100.100

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -287,8 +287,6 @@ type LocalBackend struct {
 	serveListeners     map[netip.AddrPort]*localListener // listeners for local serve traffic
 	serveProxyHandlers sync.Map                          // string (HTTPHandler.Proxy) => *reverseProxy
 
-	tailFSListeners map[netip.AddrPort]*localListener // listeners for local tailfs traffic
-
 	// statusLock must be held before calling statusChanged.Wait() or
 	// statusChanged.Broadcast().
 	statusLock    sync.Mutex
@@ -4768,10 +4766,6 @@ func (b *LocalBackend) setTCPPortsInterceptedFromNetmapAndPrefsLocked(prefs ipn.
 		if !b.sys.IsNetstack() {
 			b.updateWebClientListenersLocked()
 		}
-	}
-
-	if !b.sys.IsNetstack() {
-		b.updateTailFSListenersLocked()
 	}
 
 	b.reloadServeConfigLocked(prefs)

--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -919,10 +919,10 @@ func (ns *Impl) acceptTCP(r *tcp.ForwarderRequest) {
 		return gonet.NewTCPConn(&wq, ep)
 	}
 
-	// Local DNS Service (DNS and WebDAV)
+	// Local Services (DNS and WebDAV)
 	hittingServiceIP := dialIP == serviceIP || dialIP == serviceIPv6
 	hittingDNS := hittingServiceIP && reqDetails.LocalPort == 53
-	hittingTailFS := hittingServiceIP && ns.tailFSForLocal != nil && reqDetails.LocalPort == 8080
+	hittingTailFS := hittingServiceIP && ns.tailFSForLocal != nil && reqDetails.LocalPort == ipnlocal.TailFSLocalPort
 	if hittingDNS || hittingTailFS {
 		c := getConnOrReset()
 		if c == nil {


### PR DESCRIPTION
FileSystemForLocal was listening on the node's Tailscale address, which potentially exposes the user's view of TailFS shares to other Tailnet users. Remote nodes should connect to exported shares via the peerapi.

This removes that code so that FileSystemForLocal is only avaialable on 100.100.100.100:8080.

Updates tailscale/corp#16827