### PR TITLE
types/views: add test that LenIter doesn't allocate

### DIFF
--- a/types/views/views_test.go
+++ b/types/views/views_test.go
@@ -151,6 +151,15 @@ func TestLenIter(t *testing.T) {
 	if !reflect.DeepEqual(orig, got) {
 		t.Errorf("got %q; want %q", got, orig)
 	}
+	x := 0
+	n := testing.AllocsPerRun(10000, func() {
+		for range v.LenIter() {
+			x++
+		}
+	})
+	if n > 0 {
+		t.Errorf("allocs = %v; want 0", n)
+	}
 }
 
 func TestSliceEqual(t *testing.T) {


### PR DESCRIPTION
For a second we thought this was allocating but we were looking at a CPU profile (which showed calls to mallocgc view makeslice) instead of the alloc profile.

Updates golang/go#65685 (which if fixed wouldn't have confused us)
