### PR TITLE
tool/gocross: handle additional Xcode build flags

### DIFF
--- a/tool/gocross/autoflags.go
+++ b/tool/gocross/autoflags.go
@@ -128,6 +128,12 @@ func autoflagsForTest(argv []string, env *Environment, goroot, nativeGOOS, nativ
 			// Minimum OS version being targeted, results in
 			// e.g. -mmacosx-version-min=11.3, -miphoneos-version-min=15.0
 			switch {
+			case env.IsSet("XROS_DEPLOYMENT_TARGET"):
+				if env.Get("TARGET_DEVICE_PLATFORM_NAME", "") == "xrsimulator" {
+					xcodeFlags = append(xcodeFlags, "-mtargetos=xros"+env.Get("XROS_DEPLOYMENT_TARGET", "")+"-simulator")
+				} else {
+					xcodeFlags = append(xcodeFlags, "-mtargetos=xros"+env.Get("XROS_DEPLOYMENT_TARGET", ""))
+				}
 			case env.IsSet("IPHONEOS_DEPLOYMENT_TARGET"):
 				if env.Get("TARGET_DEVICE_PLATFORM_NAME", "") == "iphonesimulator" {
 					xcodeFlags = append(xcodeFlags, "-miphonesimulator-version-min="+env.Get("IPHONEOS_DEPLOYMENT_TARGET", ""))


### PR DESCRIPTION
Adds logic in gocross to detect environment variables and pass the right flags so that the backend can be built with more platforms.