### PR TITLE
cmd/k8s-operator: annotate proxy StatefulSets with the version of the operator that last synced the StatefulSet

### DIFF
--- a/cmd/k8s-operator/operator.go
+++ b/cmd/k8s-operator/operator.go
@@ -247,6 +247,7 @@ func runReconcilers(zlog *zap.SugaredLogger, s *tsnet.Server, tsNamespace string
 		proxyImage:             image,
 		proxyPriorityClassName: priorityClassName,
 		tsFirewallMode:         tsFirewallMode,
+		operatorVersion:        version.Short(),
 	}
 	err = builder.
 		ControllerManagedBy(mgr).

--- a/cmd/k8s-operator/sts.go
+++ b/cmd/k8s-operator/sts.go
@@ -55,7 +55,7 @@ const (
 
 	FinalizerName = "tailscale.com/finalizer"
 
-	// Annotations settable by users on services.
+	// Annotations settable by users on Services.
 	AnnotationExpose             = "tailscale.com/expose"
 	AnnotationTags               = "tailscale.com/tags"
 	AnnotationHostname           = "tailscale.com/hostname"
@@ -92,6 +92,8 @@ const (
 	// podAnnotationLastSetConfigFileHash is sha256 hash of the current tailscaled configuration contents.
 	podAnnotationLastSetConfigFileHash = "tailscale.com/operator-last-set-config-file-hash"
 
+	annotationOperatorVersion = "tailscale.com/operator-last-version" // version of tailscale operator that last updated this component
+
 	// tailscaledConfigKey is the name of the key in proxy Secret Data that
 	// holds the tailscaled config contents.
 	tailscaledConfigKey = "tailscaled"
@@ -101,7 +103,7 @@ var (
 	// tailscaleManagedLabels are label keys that tailscale operator sets on StatefulSets and Pods.
 	tailscaleManagedLabels = []string{LabelManaged, LabelParentType, LabelParentName, LabelParentNamespace, "app"}
 	// tailscaleManagedAnnotations are annotation keys that tailscale operator sets on StatefulSets and Pods.
-	tailscaleManagedAnnotations = []string{podAnnotationLastSetClusterIP, podAnnotationLastSetHostname, podAnnotationLastSetTailnetTargetIP, podAnnotationLastSetTailnetTargetFQDN, podAnnotationLastSetConfigFileHash}
+	tailscaleManagedAnnotations = []string{podAnnotationLastSetClusterIP, podAnnotationLastSetHostname, podAnnotationLastSetTailnetTargetIP, podAnnotationLastSetTailnetTargetFQDN, podAnnotationLastSetConfigFileHash, annotationOperatorVersion}
 )
 
 type tailscaleSTSConfig struct {
@@ -148,6 +150,7 @@ type tailscaleSTSReconciler struct {
 	proxyImage             string
 	proxyPriorityClassName string
 	tsFirewallMode         string
+	operatorVersion        string // current version of the operator as returned by tailscale.com/version
 }
 
 func (sts tailscaleSTSReconciler) validate() error {
@@ -571,6 +574,7 @@ func (a *tailscaleSTSReconciler) reconcileSTS(ctx context.Context, logger *zap.S
 			},
 		})
 	}
+	mak.Set(&ss.ObjectMeta.Annotations, annotationOperatorVersion, a.operatorVersion)
 	logger.Debugf("reconciling statefulset %s/%s", ss.GetNamespace(), ss.GetName())
 	if sts.ProxyClass != "" {
 		logger.Debugf("configuring proxy resources with ProxyClass %s", sts.ProxyClass)

--- a/cmd/k8s-operator/testutils_test.go
+++ b/cmd/k8s-operator/testutils_test.go
@@ -49,6 +49,7 @@ type configOpts struct {
 	serveConfig                                    *ipn.ServeConfig
 	shouldEnableForwardingClusterTrafficViaIngress bool
 	proxyClass                                     string // configuration from the named ProxyClass should be applied to proxy resources
+	operatorVersion                                string
 }
 
 func expectedSTS(t *testing.T, cl client.Client, opts configOpts) *appsv1.StatefulSet {
@@ -197,6 +198,7 @@ func expectedSTS(t *testing.T, cl client.Client, opts configOpts) *appsv1.Statef
 			},
 		},
 	}
+	mak.Set(&ss.ObjectMeta.Annotations, annotationOperatorVersion, opts.operatorVersion)
 	// If opts.proxyClass is set, retrieve the ProxyClass and apply
 	// configuration from that to the StatefulSet.
 	if opts.proxyClass != "" {
@@ -269,6 +271,7 @@ func expectedSTSUserspace(t *testing.T, cl client.Client, opts configOpts) *apps
 			},
 		},
 	}
+	mak.Set(&ss.ObjectMeta.Annotations, annotationOperatorVersion, opts.operatorVersion)
 	// If opts.proxyClass is set, retrieve the ProxyClass and apply
 	// configuration from that to the StatefulSet.
 	if opts.proxyClass != "" {


### PR DESCRIPTION
Add a `tailscale.com/operator-last-version` annotation to StatefulSets for ingress/egress proxies and Connectors.
Set it to the operator version of the current operator version each time the StatefulSet is reconciled by a new operator version.
This will help us to determine the proxy state when making changes in proxy configuration in the future.

One piece of work for which this is useful would be the change in auth key minting when we implement multiple replicas for operator components. We might _also_ want to track the version of the operator that _created_ the component. I haven't done that in this PR as 1) it is a bit more complicated (what to do with already existing proxies?) and 2) I would like to get this annotation in as soon as possible and 3) I think that even if we add an annotation for operator version that created the proxy, we will still need _this_ annotation (least to determine the possible state of a proxy for which we don't track what version of the operator created it)

Updates tailscale/tailscale#10407