### PR TITLE
cmd/derper, types/logger: move log filter to shared package

### DIFF
--- a/types/logger/logger_test.go
+++ b/types/logger/logger_test.go
@@ -258,3 +258,23 @@ func TestAsJSON(t *testing.T) {
 		t.Errorf("allocs = %v; want max 2", n)
 	}
 }
+
+func TestHTTPServerLogFilter(t *testing.T) {
+	var buf bytes.Buffer
+	logf := func(format string, args ...any) {
+		t.Logf("[logf] "+format, args...)
+		fmt.Fprintf(&buf, format, args...)
+	}
+
+	lf := HTTPServerLogFilter{logf}
+	quietLogger := log.New(lf, "", 0)
+
+	quietLogger.Printf("foo bar")
+	quietLogger.Printf("http: TLS handshake error from %s:%d: EOF", "1.2.3.4", 9999)
+	quietLogger.Printf("baz")
+
+	const want = "foo bar\nbaz\n"
+	if s := buf.String(); s != want {
+		t.Errorf("got buf=%q, want %q", s, want)
+	}
+}


### PR DESCRIPTION
So we can use it in trunkd to quiet down the logs there.

Updates #5563


Change-Id: Ie3177dc33f5ad103db832aab5a3e0e4f128f973f