### PR TITLE
prober: add TLS probe constructor to split dial addr from cert name

### DIFF
--- a/prober/tls_test.go
+++ b/prober/tls_test.go
@@ -85,7 +85,7 @@ func TestTLSConnection(t *testing.T) {
 	srv.StartTLS()
 	defer srv.Close()
 
-	err = probeTLS(context.Background(), srv.Listener.Addr().String())
+	err = probeTLS(context.Background(), "fail.example.com", srv.Listener.Addr().String())
 	// The specific error message here is platform-specific ("certificate is not trusted"
 	// on macOS and "certificate signed by unknown authority" on Linux), so only check
 	// that it contains the word 'certificate'.


### PR DESCRIPTION
So we can probe load balancers by their unique DNS name but without asking for that cert name.

Updates tailscale/corp#13050
