### PR TITLE
util/syspolicy: add ManagedBy keys for Windows

### DIFF
--- a/util/syspolicy/policy_keys.go
+++ b/util/syspolicy/policy_keys.go
@@ -72,4 +72,15 @@ const (
 	// Key is a string value that specifies an option: "always", "never", "user-decides".
 	// The default is "user-decides" unless otherwise stated.
 	PostureChecking Key = "PostureChecking"
+
+	// ManagedByOrganizationName indicates the name of the organization managing the Tailscale
+	// install. It is displayed inside the client UI in a prominent location.
+	ManagedByOrganizationName Key = "ManagedByOrganizationName"
+	// ManagedByCaption is an info message displayed inside the client UI as a caption when
+	// ManagedByOrganizationName is set. It can be used to provide a pointer to support resources
+	// for Tailscale within the organization.
+	ManagedByCaption Key = "ManagedByCaption"
+	// ManagedByCaption is a valid URL pointing to a support help desk for Tailscale within the
+	// organization. A button in the client UI provides easy access to this URL.
+	ManagedByURL Key = "ManagedByURL"
 )

--- a/util/syspolicy/policy_keys_windows.go
+++ b/util/syspolicy/policy_keys_windows.go
@@ -24,6 +24,9 @@ var stringKeys = []Key{
 	AutoUpdateVisibility,
 	KeyExpirationNoticeTime,
 	PostureChecking,
+	ManagedByOrganizationName,
+	ManagedByCaption,
+	ManagedByURL,
 }
 
 var boolKeys = []Key{


### PR DESCRIPTION
Updates tailscale/corp#17652. Adds the ManagedBy* keys presently only used on Darwin platforms to OSS, for the Windows client.