### PR TITLE
cmd/testwrapper: apply results of all unit tests to coverage for all …

### DIFF
--- a/cmd/testwrapper/testwrapper.go
+++ b/cmd/testwrapper/testwrapper.go
@@ -278,6 +278,7 @@ func main() {
 				goTestArgsWithCoverage,
 				fmt.Sprintf("-coverprofile=%v", coverageFile),
 				"-covermode=set",
+				"-coverpkg=./...",
 			)
 		}
 


### PR DESCRIPTION
…packages

This allows coverage from tests that hit multiple packages at once to be reflected in all those packages' coverage.

Updates #cleanup