### PR TITLE
cmd/derper, derp, tailcfg: add admission controller URL option

### DIFF
--- a/cmd/derper/derper.go
+++ b/cmd/derper/derper.go
@@ -49,11 +49,13 @@ var (
 	runSTUN    = flag.Bool("stun", true, "whether to run a STUN server. It will bind to the same IP (if any) as the --addr flag value.")
 	runDERP    = flag.Bool("derp", true, "whether to run a DERP server. The only reason to set this false is if you're decommissioning a server but want to keep its bootstrap DNS functionality still running.")
 
-	meshPSKFile    = flag.String("mesh-psk-file", defaultMeshPSKFile(), "if non-empty, path to file containing the mesh pre-shared key file. It should contain some hex string; whitespace is trimmed.")
-	meshWith       = flag.String("mesh-with", "", "optional comma-separated list of hostnames to mesh with; the server's own hostname can be in the list")
-	bootstrapDNS   = flag.String("bootstrap-dns-names", "", "optional comma-separated list of hostnames to make available at /bootstrap-dns")
-	unpublishedDNS = flag.String("unpublished-bootstrap-dns-names", "", "optional comma-separated list of hostnames to make available at /bootstrap-dns and not publish in the list")
-	verifyClients  = flag.Bool("verify-clients", false, "verify clients to this DERP server through a local tailscaled instance.")
+	meshPSKFile     = flag.String("mesh-psk-file", defaultMeshPSKFile(), "if non-empty, path to file containing the mesh pre-shared key file. It should contain some hex string; whitespace is trimmed.")
+	meshWith        = flag.String("mesh-with", "", "optional comma-separated list of hostnames to mesh with; the server's own hostname can be in the list")
+	bootstrapDNS    = flag.String("bootstrap-dns-names", "", "optional comma-separated list of hostnames to make available at /bootstrap-dns")
+	unpublishedDNS  = flag.String("unpublished-bootstrap-dns-names", "", "optional comma-separated list of hostnames to make available at /bootstrap-dns and not publish in the list")
+	verifyClients   = flag.Bool("verify-clients", false, "verify clients to this DERP server through a local tailscaled instance.")
+	verifyClientURL = flag.String("verify-client-url", "", "if non-empty, an admission controller URL for permitting client connections; see tailcfg.DERPAdmitClientRequest")
+	verifyFailOpen  = flag.Bool("verify-client-url-fail-open", true, "whether we fail open if --verify-client-url is unreachable")
 
 	acceptConnLimit = flag.Float64("accept-connection-limit", math.Inf(+1), "rate limit for accepting new connection")
 	acceptConnBurst = flag.Int("accept-connection-burst", math.MaxInt, "burst limit for accepting new connection")
@@ -147,6 +149,8 @@ func main() {
 
 	s := derp.NewServer(cfg.PrivateKey, log.Printf)
 	s.SetVerifyClient(*verifyClients)
+	s.SetVerifyClientURL(*verifyClientURL)
+	s.SetVerifyClientURLFailOpen(*verifyFailOpen)
 
 	if *meshPSKFile != "" {
 		b, err := os.ReadFile(*meshPSKFile)

--- a/tailcfg/derpmap.go
+++ b/tailcfg/derpmap.go
@@ -3,7 +3,12 @@
 
 package tailcfg
 
-import "sort"
+import (
+	"net/netip"
+	"sort"
+
+	"tailscale.com/types/key"
+)
 
 // DERPMap describes the set of DERP packet relay servers that are available.
 type DERPMap struct {
@@ -176,3 +181,17 @@ type DERPNode struct {
 
 // DotInvalid is a fake DNS TLD used in tests for an invalid hostname.
 const DotInvalid = ".invalid"
+
+// DERPAdmitClientRequest is the JSON request body of a POST to derper's
+// --verify-client-url admission controller URL.
+type DERPAdmitClientRequest struct {
+	NodePublic key.NodePublic // key to query for admission
+	Source     netip.Addr     // derp client's IP address
+}
+
+// DERPAdmitClientResponse is the response to a DERPAdmitClientRequest.
+type DERPAdmitClientResponse struct {
+	Allow bool // whether to permit client
+
+	// TODO(bradfitz,maisem): bandwidth limits, etc?
+}


### PR DESCRIPTION
So derpers can check an external URL for whether to permit access
to a certain public key.

Updates tailscale/corp#17693

Co-authored-by: Maisem Ali <maisem@tailscale.com>
