### PR TITLE
wgengine/wglog: quieten WireGuard logs for allowedips

### DIFF
--- a/wgengine/wglog/wglog.go
+++ b/wgengine/wglog/wglog.go
@@ -52,6 +52,13 @@ func NewLogger(logf logger.Logf) *Logger {
 			// See https://github.com/tailscale/tailscale/issues/1388.
 			return
 		}
+		if strings.Contains(format, "Adding allowedip") {
+			// Drop. See https://github.com/tailscale/corp/issues/17532.
+			// AppConnectors (as one example) may have many subnet routes, and
+			// the messaging related to these is not specific enough to be
+			// useful.
+			return
+		}
 		replace := ret.replace.Load()
 		if replace == nil {
 			// No replacements specified; log as originally planned.

--- a/wgengine/wglog/wglog_test.go
+++ b/wgengine/wglog/wglog_test.go
@@ -64,6 +64,23 @@ func TestLogger(t *testing.T) {
 	}
 }
 
+func TestSuppressLogs(t *testing.T) {
+	var logs []string
+	logf := func(format string, args ...any) {
+		logs = append(logs, fmt.Sprintf(format, args...))
+	}
+	x := wglog.NewLogger(logf)
+	x.DeviceLogger.Verbosef("pass")
+	x.DeviceLogger.Verbosef("UAPI: Adding allowedip")
+
+	if len(logs) != 1 {
+		t.Fatalf("got %d logs, want 1", len(logs))
+	}
+	if logs[0] != "wg: [v2] pass" {
+		t.Errorf("got %q, want \"wg: [v2] pass\"", logs[0])
+	}
+}
+
 func stringer(s string) stringerString {
 	return stringerString(s)
 }


### PR DESCRIPTION
An increasing number of users have very large subnet route configurations, which can produce very large amounts of log data when WireGuard is reconfigured. The logs don't contain the actual routes, so they're largely useless for diagnostics, so we'll just suppress them.

Fixes tailscale/corp#17532