### PR TITLE
scripts/installer.sh: auto-start tailscale on Alpine

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -528,6 +528,7 @@ main() {
 			set -x
 			$SUDO apk add tailscale
 			$SUDO rc-update add tailscale
+			$SUDO rc-update start tailscale
 			set +x
 			;;
 		xbps)


### PR DESCRIPTION
On Alpine, we add the tailscale service but fail to call start. This means that tailscale does not start up until the user reboots the machine.

Fixes #11161