### PR TITLE
.github/workflows: fix typo in XDG_CACHE_HOME

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,7 +208,7 @@ jobs:
       env:
         HOME: "/tmp"
         TMPDIR: "/tmp"
-        XDB_CACHE_HOME: "/var/lib/ghrunner/cache"
+        XDG_CACHE_HOME: "/var/lib/ghrunner/cache"
 
   race-build:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This appears to be one of the contributors to this CI target regularly entering a bad state with a partially written toolchain.

Updates #self