### PR TITLE
net/dns: timeout DOH requests after 10s without response headers

### DIFF
--- a/net/dns/resolver/forwarder.go
+++ b/net/dns/resolver/forwarder.go
@@ -405,6 +405,9 @@ func (f *forwarder) getKnownDoHClientForProvider(urlBase string) (c *http.Client
 		Transport: &http.Transport{
 			ForceAttemptHTTP2: true,
 			IdleConnTimeout:   dohTransportTimeout,
+			// On mobile platforms TCP KeepAlive is disabled in the dialer,
+			// ensure that we timeout if the connection appears to be hung.
+			ResponseHeaderTimeout: 10 * time.Second,
 			DialContext: func(ctx context.Context, netw, addr string) (net.Conn, error) {
 				if !strings.HasPrefix(netw, "tcp") {
 					return nil, fmt.Errorf("unexpected network %q", netw)


### PR DESCRIPTION
If a client socket is remotely lost but the client is not sent an RST in response to the next request, the socket might sit in RTO for extended lengths of time, resulting in "no internet" for users. Instead, timeout after 10s, which will close the underlying socket, recovering from the situation more promptly.

Updates #10967