### PR TITLE
wgengine/wgcfg: don't send UAPI to disable keep-alives on new peers

### DIFF
--- a/wgengine/wgcfg/config.go
+++ b/wgengine/wgcfg/config.go
@@ -39,7 +39,7 @@ type Peer struct {
 	AllowedIPs          []netip.Prefix
 	V4MasqAddr          *netip.Addr // if non-nil, masquerade IPv4 traffic to this peer using this address
 	V6MasqAddr          *netip.Addr // if non-nil, masquerade IPv6 traffic to this peer using this address
-	PersistentKeepalive uint16
+	PersistentKeepalive uint16      // in seconds between keep-alives; 0 to disable
 	// wireguard-go's endpoint for this peer. It should always equal Peer.PublicKey.
 	// We represent it explicitly so that we can detect if they diverge and recover.
 	// There is no need to set WGEndpoint explicitly when constructing a Peer by hand.

--- a/wgengine/wgcfg/writer.go
+++ b/wgengine/wgcfg/writer.go
@@ -62,7 +62,7 @@ func (cfg *Config) ToUAPI(logf logger.Logf, w io.Writer, prev *Config) error {
 		// to ensure that we're writing the full peer configuration.
 		willSetEndpoint := oldPeer.WGEndpoint != p.PublicKey || !wasPresent
 		willChangeIPs := !cidrsEqual(oldPeer.AllowedIPs, p.AllowedIPs) || !wasPresent
-		willChangeKeepalive := oldPeer.PersistentKeepalive != p.PersistentKeepalive || !wasPresent
+		willChangeKeepalive := oldPeer.PersistentKeepalive != p.PersistentKeepalive // if not wasPresent, no need to redundantly set zero (default)
 
 		if !willSetEndpoint && !willChangeIPs && !willChangeKeepalive {
 			// It's safe to skip doing anything here; wireguard-go


### PR DESCRIPTION
That's already the default. Avoid the overhead of writing it on one side and reading it on the other to do nothing.

Updates #cleanup (noticed while researching something else)
