### PR TITLE
wgengine/wglog: add TS_DEBUG_RAW_WGLOG envknob for raw wg logs

### DIFF
--- a/wgengine/wglog/wglog.go
+++ b/wgengine/wglog/wglog.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/tailscale/wireguard-go/device"
+	"tailscale.com/envknob"
 	"tailscale.com/syncs"
 	"tailscale.com/types/key"
 	"tailscale.com/types/logger"
@@ -86,6 +87,9 @@ func NewLogger(logf logger.Logf) *Logger {
 			newargs[i] = tsStr
 		}
 		logf(format, newargs...)
+	}
+	if envknob.Bool("TS_DEBUG_RAW_WGLOG") {
+		wrapper = logf
 	}
 	ret.DeviceLogger = &device.Logger{
 		Verbosef: logger.WithPrefix(wrapper, prefix+"[v2] "),


### PR DESCRIPTION
Updates #7617 (part of debugging it)
