### PR TITLE
Hardening the systemd service

### DIFF
--- a/cmd/tailscaled/tailscaled.service
+++ b/cmd/tailscaled/tailscaled.service
@@ -20,5 +20,24 @@ CacheDirectory=tailscale
 CacheDirectoryMode=0750
 Type=notify
 
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectClock=true
+ProtectKernelLogs=true
+ProtectKernelTunables=true
+ProtectProc=ptraceable
+ProtectControlGroups=true
+ProtectHostname=true
+RestrictSUIDSGID=true
+RestrictRealtime=true
+PrivateTmp=true
+SystemCallArchitectures=native
+MemoryDenyWriteExecute=true
+LockPersonality=true
+CapabilityBoundingSet=CAP_NET_ADMIN
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+SystemCallFilter=~@clock @cpu-emulation @debug @module @mount @obsolete @privileged @raw-io @reboot @resources @swap
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
```
$ systemd-analyze security tailscaled.service
  NAME                                                        DESCRIPTION                                                                                                EXPOSURE
✗ SystemCallFilter=~@swap                                     System call deny list defined for service, and @swap is not included (e.g. swapoff is allowed)                  0.2
✗ SystemCallFilter=~@resources                                System call deny list defined for service, and @resources is not included (e.g. ioprio_set is allowed)          0.2
✗ SystemCallFilter=~@reboot                                   System call deny list defined for service, and @reboot is not included (e.g. kexec_file_load is allowed)        0.2
✗ SystemCallFilter=~@raw-io                                   System call deny list defined for service, and @raw-io is not included (e.g. ioperm is allowed)                 0.2
✗ SystemCallFilter=~@privileged                               System call deny list defined for service, and @privileged is not included (e.g. chown is allowed)              0.2
✗ SystemCallFilter=~@obsolete                                 System call deny list defined for service, and @obsolete is not included (e.g. _sysctl is allowed)              0.1
✗ SystemCallFilter=~@mount                                    System call deny list defined for service, and @mount is not included (e.g. chroot is allowed)                  0.2
✗ SystemCallFilter=~@module                                   System call deny list defined for service, and @module is not included (e.g. delete_module is allowed)          0.2
✗ SystemCallFilter=~@debug                                    System call deny list defined for service, and @debug is not included (e.g. lookup_dcookie is allowed)          0.2
✗ SystemCallFilter=~@cpu-emulation                            System call deny list defined for service, and @cpu-emulation is not included (e.g. modify_ldt is allowed)      0.1
✓ SystemCallFilter=~@clock                                    System call deny list defined for service, and @clock is included
✗ RootDirectory=/RootImage=                                   Service runs within the host's root directory                                                                   0.1
  SupplementaryGroups=                                        Service runs as root, option does not matter
  RemoveIPC=                                                  Service runs as root, option does not apply
✗ User=/DynamicUser=                                          Service runs as root user                                                                                       0.4
✓ RestrictRealtime=                                           Service realtime scheduling access is restricted
✓ CapabilityBoundingSet=~CAP_SYS_TIME                         Service processes cannot change the system clock
✓ NoNewPrivileges=                                            Service processes cannot acquire new privileges
✓ AmbientCapabilities=                                        Service process does not receive ambient capabilities
✗ PrivateDevices=                                             Service potentially has access to hardware devices                                                              0.2
✗ ProtectKernelModules=                                       Service may load or read kernel modules                                                                         0.2
✓ CapabilityBoundingSet=~CAP_BPF                              Service may load BPF programs
✓ SystemCallArchitectures=                                    Service may execute system calls only with native ABI
✗ RestrictNamespaces=~user                                    Service may create user namespaces                                                                              0.3
✗ RestrictNamespaces=~pid                                     Service may create process namespaces                                                                           0.1
✗ RestrictNamespaces=~net                                     Service may create network namespaces                                                                           0.1
✗ RestrictNamespaces=~uts                                     Service may create hostname namespaces                                                                          0.1
✗ RestrictNamespaces=~mnt                                     Service may create file system namespaces                                                                       0.1
✗ RestrictNamespaces=~cgroup                                  Service may create cgroup namespaces                                                                            0.1
✗ RestrictNamespaces=~ipc                                     Service may create IPC namespaces                                                                               0.1
✗ RestrictAddressFamilies=~AF_NETLINK                         Service may allocate netlink sockets                                                                            0.1
✗ RestrictAddressFamilies=~AF_UNIX                            Service may allocate local sockets                                                                              0.1
✗ RestrictAddressFamilies=~AF_(INET|INET6)                    Service may allocate Internet sockets                                                                           0.3
✓ ProtectSystem=                                              Service has strict read-only access to the OS file hierarchy
✓ ProtectProc=                                                Service has restricted access to process tree (/proc hidepid=)
✓ CapabilityBoundingSet=~CAP_SYS_RAWIO                        Service has no raw I/O access
✓ CapabilityBoundingSet=~CAP_SYS_PTRACE                       Service has no ptrace() debugging abilities
✓ CapabilityBoundingSet=~CAP_SYS_(NICE|RESOURCE)              Service has no privileges to change resource use parameters
✓ CapabilityBoundingSet=~CAP_NET_(BIND_SERVICE|BROADCAST|RAW) Service has no elevated networking privileges
✗ DeviceAllow=                                                Service has no device ACL                                                                                       0.2
✓ CapabilityBoundingSet=~CAP_AUDIT_*                          Service has no audit subsystem access
✓ CapabilityBoundingSet=~CAP_SYS_ADMIN                        Service has no administrator privileges
✓ PrivateTmp=                                                 Service has no access to other software's temporary files
✓ ProcSubset=                                                 Service has no access to non-process /proc files (/proc subset=)
✓ CapabilityBoundingSet=~CAP_SYSLOG                           Service has no access to kernel logging
✓ ProtectHome=                                                Service has no access to home directories
✗ CapabilityBoundingSet=~CAP_NET_ADMIN                        Service has network configuration privileges                                                                    0.2
✗ PrivateNetwork=                                             Service has access to the host's network                                                                        0.5
✗ PrivateUsers=                                               Service has access to other users                                                                               0.2
✓ KeyringMode=                                                Service doesn't share key material with other services
✓ Delegate=                                                   Service does not maintain its own delegated control group subtree
✗ IPAddressDeny=                                              Service does not define an IP address allow list                                                                0.2
✓ NotifyAccess=                                               Service child processes cannot alter service state
✓ ProtectClock=                                               Service cannot write to the hardware clock or system clock
✓ CapabilityBoundingSet=~CAP_SYS_PACCT                        Service cannot use acct()
✓ CapabilityBoundingSet=~CAP_KILL                             Service cannot send UNIX signals to arbitrary processes
✓ ProtectKernelLogs=                                          Service cannot read from or write to the kernel log ring buffer
✓ CapabilityBoundingSet=~CAP_WAKE_ALARM                       Service cannot program timers that wake up the system
✓ CapabilityBoundingSet=~CAP_(DAC_*|FOWNER|IPC_OWNER)         Service cannot override UNIX file/IPC permission checks
✓ ProtectControlGroups=                                       Service cannot modify the control group file system
✓ CapabilityBoundingSet=~CAP_LINUX_IMMUTABLE                  Service cannot mark files immutable
✓ CapabilityBoundingSet=~CAP_IPC_LOCK                         Service cannot lock memory into RAM
✓ CapabilityBoundingSet=~CAP_SYS_MODULE                       Service cannot load kernel modules
✓ CapabilityBoundingSet=~CAP_SYS_TTY_CONFIG                   Service cannot issue vhangup()
✓ CapabilityBoundingSet=~CAP_SYS_BOOT                         Service cannot issue reboot()
✓ CapabilityBoundingSet=~CAP_SYS_CHROOT                       Service cannot issue chroot()
✓ PrivateMounts=                                              Service cannot install system mounts
✓ CapabilityBoundingSet=~CAP_BLOCK_SUSPEND                    Service cannot establish wake locks
✓ MemoryDenyWriteExecute=                                     Service cannot create writable executable memory mappings
✓ CapabilityBoundingSet=~CAP_LEASE                            Service cannot create file leases
✓ CapabilityBoundingSet=~CAP_MKNOD                            Service cannot create device nodes
✓ ProtectHostname=                                            Service cannot change system host/domainname
✓ CapabilityBoundingSet=~CAP_(CHOWN|FSETID|SETFCAP)           Service cannot change file ownership/access mode/capabilities
✓ CapabilityBoundingSet=~CAP_SET(UID|GID|PCAP)                Service cannot change UID/GID identities/capabilities
✓ LockPersonality=                                            Service cannot change ABI personality
✓ ProtectKernelTunables=                                      Service cannot alter kernel tunables (/proc/sys, …)
✓ RestrictAddressFamilies=~AF_PACKET                          Service cannot allocate packet sockets
✓ RestrictAddressFamilies=~…                                  Service cannot allocate exotic sockets
✓ CapabilityBoundingSet=~CAP_MAC_*                            Service cannot adjust SMACK MAC
✓ RestrictSUIDSGID=                                           SUID/SGID file creation by service is restricted
✗ UMask=                                                      Files created by service are world-readable by default                                                          0.1

→ Overall exposure level for tailscaled.service: 4.4 OK 🙂
```