### PR TITLE
ci: clear tailscale-go build cache before running self-hosted vm tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -204,7 +204,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4
     - name: Run VM tests
-      run: ./tool/go test ./tstest/integration/vms -v -no-s3 -run-vm-tests -run=TestRunUbuntu2004
+      run: rm -rf /tmp/.cache/tailscale-go && ./tool/go test ./tstest/integration/vms -v -no-s3 -run-vm-tests -run=TestRunUbuntu2004
       env:
         HOME: "/tmp"
         TMPDIR: "/tmp"


### PR DESCRIPTION
Prevents tests from failing due to partially initialized toolchain.

Updates #cleanup