### PR TITLE
net/tstun: fix spelling of "WireGuard"

### DIFF
--- a/net/tstun/wrap.go
+++ b/net/tstun/wrap.go
@@ -160,8 +160,8 @@ type Wrapper struct {
 	// PreFilterPacketInboundFromWireGuard is the inbound filter function that runs before the main filter
 	// and therefore sees the packets that may be later dropped by it.
 	PreFilterPacketInboundFromWireGuard FilterFunc
-	// PostFilterPacketInboundFromWireGaurd is the inbound filter function that runs after the main filter.
-	PostFilterPacketInboundFromWireGaurd FilterFunc
+	// PostFilterPacketInboundFromWireGuard is the inbound filter function that runs after the main filter.
+	PostFilterPacketInboundFromWireGuard FilterFunc
 	// PreFilterPacketOutboundToWireGuardNetstackIntercept is a filter function that runs before the main filter
 	// for packets from the local system. This filter is populated by netstack to hook
 	// packets that should be handled by netstack. If set, this filter runs before
@@ -1047,8 +1047,8 @@ func (t *Wrapper) filterPacketInboundFromWireGuard(p *packet.Parsed, captHook ca
 		return filter.Drop
 	}
 
-	if t.PostFilterPacketInboundFromWireGaurd != nil {
-		if res := t.PostFilterPacketInboundFromWireGaurd(p, t); res.IsDrop() {
+	if t.PostFilterPacketInboundFromWireGuard != nil {
+		if res := t.PostFilterPacketInboundFromWireGuard(p, t); res.IsDrop() {
 			return res
 		}
 	}

--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -320,7 +320,7 @@ func Create(logf logger.Logf, tundev *tstun.Wrapper, e wgengine.Engine, mc *magi
 	}
 	ns.ctx, ns.ctxCancel = context.WithCancel(context.Background())
 	ns.atomicIsLocalIPFunc.Store(tsaddr.FalseContainsIPFunc())
-	ns.tundev.PostFilterPacketInboundFromWireGaurd = ns.injectInbound
+	ns.tundev.PostFilterPacketInboundFromWireGuard = ns.injectInbound
 	ns.tundev.PreFilterPacketOutboundToWireGuardNetstackIntercept = ns.handleLocalPackets
 	stacksForMetrics.Store(ns, struct{}{})
 	return ns, nil

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -359,7 +359,7 @@ func NewUserspaceEngine(logf logger.Logf, conf Config) (_ Engine, reterr error) 
 	tsTUNDev.SetDiscoKey(e.magicConn.DiscoPublicKey())
 
 	if conf.RespondToPing {
-		e.tundev.PostFilterPacketInboundFromWireGaurd = echoRespondToAll
+		e.tundev.PostFilterPacketInboundFromWireGuard = echoRespondToAll
 	}
 	e.tundev.PreFilterPacketOutboundToWireGuardEngineIntercept = e.handleLocalPackets
 


### PR DESCRIPTION
Updates #cleanup


Change-Id: Ida7e30f4689bc18f5f7502f53a0adb5ac3c7981a