### PR TITLE
.github/workflows: fix regular breakage of go toolchains

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -206,7 +206,7 @@ jobs:
     - name: Run VM tests
       run: ./tool/go test ./tstest/integration/vms -v -no-s3 -run-vm-tests -run=TestRunUbuntu2004
       env:
-        HOME: "/tmp"
+        HOME: "/var/lib/ghrunner/home"
         TMPDIR: "/tmp"
         XDG_CACHE_HOME: "/var/lib/ghrunner/cache"
 


### PR DESCRIPTION
This server recently had a common ansible applied, which added a periodic /tmp cleaner, as is needed on other CI machines to deal with test tempfile leakage. The setting of $HOME to /tmp means that the go toolchain in there was regularly getting pruned by the tmp cleaner, but often incompletely, because it was also in use.

Move HOME to a runner owned directory.

Updates #11248