### PR TITLE
ipn,wgengine: only intercept TailFS traffic to quad 100

### DIFF
--- a/ipn/ipnlocal/serve_test.go
+++ b/ipn/ipnlocal/serve_test.go
@@ -684,7 +684,8 @@ func newTestBackend(t *testing.T) *LocalBackend {
 
 	b.netMap = &netmap.NetworkMap{
 		SelfNode: (&tailcfg.Node{
-			Name: "example.ts.net",
+			Name:         "example.ts.net",
+			Capabilities: []tailcfg.NodeCapability{tailcfg.NodeAttrsTailFSAccess},
 		}).View(),
 		UserProfiles: map[tailcfg.UserID]tailcfg.UserProfile{
 			tailcfg.UserID(1): {


### PR DESCRIPTION
Previously, we intercepted all userspace traffic to port 8080, which prevented users from exposing their own services to their tailnet at port 8080.

Now, we only intercept traffic to port 8080 if it's bound for 100.100.100.100 or fd7a:115c:a1e0::53.

Fixes #11283