### PR TITLE
client/web: fix Vite CJS deprecation warning

### DIFF
--- a/client/web/package.json
+++ b/client/web/package.json
@@ -6,6 +6,7 @@
     "node": "18.16.1",
     "yarn": "1.22.19"
   },
+  "type": "module",
   "private": true,
   "dependencies": {
     "@radix-ui/react-collapsible": "^1.0.3",

--- a/client/web/tailwind.config.js
+++ b/client/web/tailwind.config.js
@@ -1,7 +1,7 @@
-const plugin = require("tailwindcss/plugin")
-const styles = require("./styles.json")
+import plugin from "tailwindcss/plugin"
+import styles from "./styles.json"
 
-module.exports = {
+const config = {
   theme: {
     screens: {
       sm: "420px",
@@ -96,20 +96,22 @@ module.exports = {
   plugins: [
     plugin(function ({ addVariant }) {
       addVariant("state-open", [
-        '&[data-state="open"]',
-        '[data-state="open"] &',
+        "&[data-state=“open”]",
+        "[data-state=“open”] &",
       ])
       addVariant("state-closed", [
-        '&[data-state="closed"]',
-        '[data-state="closed"] &',
+        "&[data-state=“closed”]",
+        "[data-state=“closed”] &",
       ])
       addVariant("state-delayed-open", [
-        '&[data-state="delayed-open"]',
-        '[data-state="delayed-open"] &',
+        "&[data-state=“delayed-open”]",
+        "[data-state=“delayed-open”] &",
       ])
-      addVariant("state-active", ['&[data-state="active"]'])
-      addVariant("state-inactive", ['&[data-state="inactive"]'])
+      addVariant("state-active", ["&[data-state=“active”]"])
+      addVariant("state-inactive", ["&[data-state=“inactive”]"])
     }),
   ],
   content: ["./src/**/*.html", "./src/**/*.{ts,tsx}", "./index.html"],
 }
+
+export default config


### PR DESCRIPTION
Starting in Vite 5, Vite now issues a deprecation warning when using a CJS-based Vite config file. This commit fixes it by adding the `"type": "module"` to our package.json to opt our files into ESM module behaviours.

Unlike the corp PR, this one can use `"type": "module"` because we're using Tailwind v3.3+, which supports ESM.