### PR TITLE
wgengine: plumb the PeerByKey from wgengine to magicsock

### DIFF
--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -347,6 +347,7 @@ func NewUserspaceEngine(logf logger.Logf, conf Config) (_ Engine, reterr error) 
 		NetMon:           e.netMon,
 		ControlKnobs:     conf.ControlKnobs,
 		OnPortUpdate:     onPortUpdate,
+		PeerByKeyFunc:    e.PeerByKey,
 	}
 
 	var err error


### PR DESCRIPTION
This was just added in 69f4b459 which doesn't yet use it. This still
doesn't yet use it. It just pushes it down deeper into magicsock where
it'll used later.

Updates #7617
