### PR TITLE
util/linuxfw: insert rather than append nftables DNAT rule

### DIFF
--- a/util/linuxfw/nftables_runner.go
+++ b/util/linuxfw/nftables_runner.go
@@ -173,7 +173,7 @@ func (n *nftablesRunner) DNATNonTailscaleTraffic(tunname string, dst netip.Addr)
 			},
 		},
 	}
-	n.conn.AddRule(dnatRule)
+	n.conn.InsertRule(dnatRule)
 	return n.conn.Flush()
 }
 


### PR DESCRIPTION
Ensure that the latest DNATNonTailscaleTraffic rule gets inserted on top of any pre-existing rules.

Updates tailscale/tailscale#11281