### PR TITLE
clientupdate: handle multiple versions in "apk info tailscale" output

### DIFF
--- a/clientupdate/clientupdate.go
+++ b/clientupdate/clientupdate.go
@@ -665,6 +665,7 @@ func (up *Updater) updateAlpineLike() (err error) {
 
 func parseAlpinePackageVersion(out []byte) (string, error) {
 	s := bufio.NewScanner(bytes.NewReader(out))
+	var maxVer string
 	for s.Scan() {
 		// The line should look like this:
 		// tailscale-1.44.2-r0 description:
@@ -676,7 +677,13 @@ func parseAlpinePackageVersion(out []byte) (string, error) {
 		if len(parts) < 3 {
 			return "", fmt.Errorf("malformed info line: %q", line)
 		}
-		return parts[1], nil
+		ver := parts[1]
+		if cmpver.Compare(ver, maxVer) == 1 {
+			maxVer = ver
+		}
+	}
+	if maxVer != "" {
+		return maxVer, nil
 	}
 	return "", errors.New("tailscale version not found in output")
 }

--- a/clientupdate/clientupdate_test.go
+++ b/clientupdate/clientupdate_test.go
@@ -251,6 +251,29 @@ tailscale installed size:
 			out:     "",
 			wantErr: true,
 		},
+		{
+			desc: "multiple versions",
+			out: `
+tailscale-1.54.1-r0 description:
+The easiest, most secure way to use WireGuard and 2FA
+
+tailscale-1.54.1-r0 webpage:
+https://tailscale.com/
+
+tailscale-1.54.1-r0 installed size:
+34 MiB
+
+tailscale-1.58.2-r0 description:
+The easiest, most secure way to use WireGuard and 2FA
+
+tailscale-1.58.2-r0 webpage:
+https://tailscale.com/
+
+tailscale-1.58.2-r0 installed size:
+35 MiB
+`,
+			want: "1.58.2",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The package info output can list multiple package versions, and not in descending order. Find the newest version in the output, instead of the first one.

Fixes #11309