### PR TITLE
{ipn,cmd/tailscale/cli}: move ServeConfig mutation logic to ipn/serve

### DIFF
--- a/cmd/tailscale/cli/funnel.go
+++ b/cmd/tailscale/cli/funnel.go
@@ -15,7 +15,6 @@ import (
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"tailscale.com/ipn"
 	"tailscale.com/tailcfg"
-	"tailscale.com/util/mak"
 )
 
 var funnelCmd = func() *ffcli.Command {
@@ -114,15 +113,8 @@ func (e *serveEnv) runFunnel(ctx context.Context, args []string) error {
 		// Nothing to do.
 		return nil
 	}
-	if on {
-		mak.Set(&sc.AllowFunnel, hp, true)
-	} else {
-		delete(sc.AllowFunnel, hp)
-		// clear map mostly for testing
-		if len(sc.AllowFunnel) == 0 {
-			sc.AllowFunnel = nil
-		}
-	}
+	sc.SetFunnel(dnsName, port, on)
+
 	if err := e.lc.SetServeConfig(ctx, sc); err != nil {
 		return err
 	}


### PR DESCRIPTION
Moving logic that manipulates a ServeConfig into recievers on the ServeConfig in the ipn package. This is setup work to allow the web client and cli to both utilize these shared functions to edit the serve config.

Any logic specific to flag parsing or validation is left untouched in the cli command. The web client will similarly manage its validation of user's requested changes. If validation logic becomes similar-enough, we can make a serve util for shared functionality, which likely does not make sense in ipn.

Updates #10261