### PR TITLE
net/interfaces: fix test hang on Darwin

### DIFF
--- a/net/interfaces/interfaces_darwin_test.go
+++ b/net/interfaces/interfaces_darwin_test.go
@@ -5,6 +5,7 @@ package interfaces
 
 import (
 	"errors"
+	"io"
 	"net/netip"
 	"os/exec"
 	"testing"
@@ -69,6 +70,7 @@ func likelyHomeRouterIPDarwinExec() (ret netip.Addr, netif string, ok bool) {
 		return
 	}
 	defer cmd.Wait()
+	defer io.Copy(io.Discard, stdout) // clear the pipe to prevent hangs
 
 	var f []mem.RO
 	lineread.Reader(stdout, func(lineb []byte) error {


### PR DESCRIPTION
This test could hang because the subprocess was blocked on writing to the stdout pipe if we find the address we're looking for early in the output.

Updates #cleanup


Change-Id: I68d82c22a5d782098187ae6d8577e43063b72573