### PR TITLE
docs/k8s: don't run subnet router in userspace mode

### DIFF
--- a/docs/k8s/subnet.yaml
+++ b/docs/k8s/subnet.yaml
@@ -17,7 +17,9 @@ spec:
     - name: TS_KUBE_SECRET
       value: "{{TS_KUBE_SECRET}}"
     - name: TS_USERSPACE
-      value: "true"
+      value: "false"
+    - name: TS_DEBUG_FIREWALL_MODE
+      value: auto
     - name: TS_AUTHKEY
       valueFrom:
         secretKeyRef:


### PR DESCRIPTION
This PR updates our example standalone subnet router deployment yaml to not run in userspace mode.

Folks shouldn't need to run in userspace unless they specifically need it (i.e need to run on host network) and running in userspace would mean a performance hit for the subnet router.