### PR TITLE
cmd/tailscale/cli: prefix all --help usages with "tailscale ...", some tidying

### DIFF
--- a/cmd/tailscale/cli/bugreport.go
+++ b/cmd/tailscale/cli/bugreport.go
@@ -17,7 +17,7 @@ var bugReportCmd = &ffcli.Command{
 	Name:       "bugreport",
 	Exec:       runBugReport,
 	ShortHelp:  "Print a shareable identifier to help diagnose issues",
-	ShortUsage: "bugreport [note]",
+	ShortUsage: "tailscale bugreport [note]",
 	FlagSet: (func() *flag.FlagSet {
 		fs := newFlagSet("bugreport")
 		fs.BoolVar(&bugReportArgs.diagnose, "diagnose", false, "run additional in-depth checks")

--- a/cmd/tailscale/cli/cert.go
+++ b/cmd/tailscale/cli/cert.go
@@ -28,7 +28,7 @@ var certCmd = &ffcli.Command{
 	Name:       "cert",
 	Exec:       runCert,
 	ShortHelp:  "Get TLS certs",
-	ShortUsage: "cert [flags] <domain>",
+	ShortUsage: "tailscale cert [flags] <domain>",
 	FlagSet: (func() *flag.FlagSet {
 		fs := newFlagSet("cert")
 		fs.StringVar(&certArgs.certFile, "cert-file", "", "output cert file or \"-\" for stdout; defaults to DOMAIN.crt if --cert-file and --key-file are both unset")

--- a/cmd/tailscale/cli/configure-kube.go
+++ b/cmd/tailscale/cli/configure-kube.go
@@ -27,7 +27,7 @@ func init() {
 var configureKubeconfigCmd = &ffcli.Command{
 	Name:       "kubeconfig",
 	ShortHelp:  "[ALPHA] Connect to a Kubernetes cluster using a Tailscale Auth Proxy",
-	ShortUsage: "kubeconfig <hostname-or-fqdn>",
+	ShortUsage: "tailscale configure kubeconfig <hostname-or-fqdn>",
 	LongHelp: strings.TrimSpace(`
 Run this command to configure kubectl to connect to a Kubernetes cluster over Tailscale.
 

--- a/cmd/tailscale/cli/configure-synology.go
+++ b/cmd/tailscale/cli/configure-synology.go
@@ -22,10 +22,11 @@ import (
 // used to configure Synology devices, but is now a compatibility alias to
 // "tailscale configure synology".
 var configureHostCmd = &ffcli.Command{
-	Name:      "configure-host",
-	Exec:      runConfigureSynology,
-	ShortHelp: synologyConfigureCmd.ShortHelp,
-	LongHelp:  synologyConfigureCmd.LongHelp,
+	Name:       "configure-host",
+	Exec:       runConfigureSynology,
+	ShortUsage: "tailscale configure-host",
+	ShortHelp:  synologyConfigureCmd.ShortHelp,
+	LongHelp:   synologyConfigureCmd.LongHelp,
 	FlagSet: (func() *flag.FlagSet {
 		fs := newFlagSet("configure-host")
 		return fs
@@ -33,9 +34,10 @@ var configureHostCmd = &ffcli.Command{
 }
 
 var synologyConfigureCmd = &ffcli.Command{
-	Name:      "synology",
-	Exec:      runConfigureSynology,
-	ShortHelp: "Configure Synology to enable outbound connections",
+	Name:       "synology",
+	Exec:       runConfigureSynology,
+	ShortUsage: "tailscale configure synology",
+	ShortHelp:  "Configure Synology to enable outbound connections",
 	LongHelp: strings.TrimSpace(`
 This command is intended to run at boot as root on a Synology device to
 create the /dev/net/tun device and give the tailscaled binary permission

--- a/cmd/tailscale/cli/configure.go
+++ b/cmd/tailscale/cli/configure.go
@@ -14,8 +14,9 @@ import (
 )
 
 var configureCmd = &ffcli.Command{
-	Name:      "configure",
-	ShortHelp: "[ALPHA] Configure the host to enable more Tailscale features",
+	Name:       "configure",
+	ShortUsage: "tailscale configure <subcommand>",
+	ShortHelp:  "[ALPHA] Configure the host to enable more Tailscale features",
 	LongHelp: strings.TrimSpace(`
 The 'configure' set of commands are intended to provide a way to enable different
 services on the host to use Tailscale in more ways.

--- a/cmd/tailscale/cli/debug.go
+++ b/cmd/tailscale/cli/debug.go
@@ -45,9 +45,10 @@ import (
 )
 
 var debugCmd = &ffcli.Command{
-	Name:     "debug",
-	Exec:     runDebug,
-	LongHelp: `"tailscale debug" contains misc debug facilities; it is not a stable interface.`,
+	Name:       "debug",
+	Exec:       runDebug,
+	ShortUsage: "tailscale debug <debug-flags | subcommand>",
+	LongHelp:   `HIDDEN: "tailscale debug" contains misc debug facilities; it is not a stable interface.`,
 	FlagSet: (func() *flag.FlagSet {
 		fs := newFlagSet("debug")
 		fs.StringVar(&debugArgs.file, "file", "", "get, delete:NAME, or NAME")
@@ -58,15 +59,16 @@ var debugCmd = &ffcli.Command{
 	})(),
 	Subcommands: []*ffcli.Command{
 		{
-			Name:      "derp-map",
-			Exec:      runDERPMap,
-			ShortHelp: "print DERP map",
+			Name:       "derp-map",
+			ShortUsage: "tailscale debug derp-map",
+			Exec:       runDERPMap,
+			ShortHelp:  "Print DERP map",
 		},
 		{
 			Name:       "component-logs",
-			Exec:       runDebugComponentLogs,
-			ShortHelp:  "enable/disable debug logs for a component",
 			ShortUsage: "tailscale debug component-logs [" + strings.Join(ipn.DebuggableComponents, "|") + "]",
+			Exec:       runDebugComponentLogs,
+			ShortHelp:  "Enable/disable debug logs for a component",
 			FlagSet: (func() *flag.FlagSet {
 				fs := newFlagSet("component-logs")
 				fs.DurationVar(&debugComponentLogsArgs.forDur, "for", time.Hour, "how long to enable debug logs for; zero or negative means to disable")
@@ -74,14 +76,16 @@ var debugCmd = &ffcli.Command{
 			})(),
 		},
 		{
-			Name:      "daemon-goroutines",
-			Exec:      runDaemonGoroutines,
-			ShortHelp: "print tailscaled's goroutines",
+			Name:       "daemon-goroutines",
+			ShortUsage: "tailscale debug daemon-goroutines",
+			Exec:       runDaemonGoroutines,
+			ShortHelp:  "Print tailscaled's goroutines",
 		},
 		{
-			Name:      "daemon-logs",
-			Exec:      runDaemonLogs,
-			ShortHelp: "watch tailscaled's server logs",
+			Name:       "daemon-logs",
+			ShortUsage: "tailscale debug daemon-logs",
+			Exec:       runDaemonLogs,
+			ShortHelp:  "Watch tailscaled's server logs",
 			FlagSet: (func() *flag.FlagSet {
 				fs := newFlagSet("daemon-logs")
 				fs.IntVar(&daemonLogsArgs.verbose, "verbose", 0, "verbosity level")
@@ -90,9 +94,10 @@ var debugCmd = &ffcli.Command{
 			})(),
 		},
 		{
-			Name:      "metrics",
-			Exec:      runDaemonMetrics,
-			ShortHelp: "print tailscaled's metrics",
+			Name:       "metrics",
+			ShortUsage: "tailscale debug metrics",
+			Exec:       runDaemonMetrics,
+			ShortHelp:  "Print tailscaled's metrics",
 			FlagSet: (func() *flag.FlagSet {
 				fs := newFlagSet("metrics")
 				fs.BoolVar(&metricsArgs.watch, "watch", false, "print JSON dump of delta values")
@@ -100,80 +105,95 @@ var debugCmd = &ffcli.Command{
 			})(),
 		},
 		{
-			Name:      "env",
-			Exec:      runEnv,
-			ShortHelp: "print cmd/tailscale environment",
+			Name:       "env",
+			ShortUsage: "tailscale debug env",
+			Exec:       runEnv,
+			ShortHelp:  "Print cmd/tailscale environment",
 		},
 		{
-			Name:      "stat",
-			Exec:      runStat,
-			ShortHelp: "stat a file",
+			Name:       "stat",
+			ShortUsage: "tailscale debug stat <files...>",
+			Exec:       runStat,
+			ShortHelp:  "Stat a file",
 		},
 		{
-			Name:      "hostinfo",
-			Exec:      runHostinfo,
-			ShortHelp: "print hostinfo",
+			Name:       "hostinfo",
+			ShortUsage: "tailscale debug hostinfo",
+			Exec:       runHostinfo,
+			ShortHelp:  "Print hostinfo",
 		},
 		{
-			Name:      "local-creds",
-			Exec:      runLocalCreds,
-			ShortHelp: "print how to access Tailscale LocalAPI",
+			Name:       "local-creds",
+			ShortUsage: "tailscale debug local-creds",
+			Exec:       runLocalCreds,
+			ShortHelp:  "Print how to access Tailscale LocalAPI",
 		},
 		{
-			Name:      "restun",
-			Exec:      localAPIAction("restun"),
-			ShortHelp: "force a magicsock restun",
+			Name:       "restun",
+			ShortUsage: "tailscale debug restun",
+			Exec:       localAPIAction("restun"),
+			ShortHelp:  "Force a magicsock restun",
 		},
 		{
-			Name:      "rebind",
-			Exec:      localAPIAction("rebind"),
-			ShortHelp: "force a magicsock rebind",
+			Name:       "rebind",
+			ShortUsage: "tailscale debug rebind",
+			Exec:       localAPIAction("rebind"),
+			ShortHelp:  "Force a magicsock rebind",
 		},
 		{
-			Name:      "derp-set-on-demand",
-			Exec:      localAPIAction("derp-set-homeless"),
-			ShortHelp: "enable DERP on-demand mode (breaks reachability)",
+			Name:       "derp-set-on-demand",
+			ShortUsage: "tailscale debug derp-set-on-demand",
+			Exec:       localAPIAction("derp-set-homeless"),
+			ShortHelp:  "Enable DERP on-demand mode (breaks reachability)",
 		},
 		{
-			Name:      "derp-unset-on-demand",
-			Exec:      localAPIAction("derp-unset-homeless"),
-			ShortHelp: "disable DERP on-demand mode",
+			Name:       "derp-unset-on-demand",
+			ShortUsage: "tailscale debug derp-unset-on-demand",
+			Exec:       localAPIAction("derp-unset-homeless"),
+			ShortHelp:  "Disable DERP on-demand mode",
 		},
 		{
-			Name:      "break-tcp-conns",
-			Exec:      localAPIAction("break-tcp-conns"),
-			ShortHelp: "break any open TCP connections from the daemon",
+			Name:       "break-tcp-conns",
+			ShortUsage: "tailscale debug break-tcp-conns",
+			Exec:       localAPIAction("break-tcp-conns"),
+			ShortHelp:  "Break any open TCP connections from the daemon",
 		},
 		{
-			Name:      "break-derp-conns",
-			Exec:      localAPIAction("break-derp-conns"),
-			ShortHelp: "break any open DERP connections from the daemon",
+			Name:       "break-derp-conns",
+			ShortUsage: "tailscale debug break-derp-conns",
+			Exec:       localAPIAction("break-derp-conns"),
+			ShortHelp:  "Break any open DERP connections from the daemon",
 		},
 		{
-			Name:      "pick-new-derp",
-			Exec:      localAPIAction("pick-new-derp"),
-			ShortHelp: "switch to some other random DERP home region for a short time",
+			Name:       "pick-new-derp",
+			ShortUsage: "tailscale debug pick-new-derp",
+			Exec:       localAPIAction("pick-new-derp"),
+			ShortHelp:  "Switch to some other random DERP home region for a short time",
 		},
 		{
-			Name:      "force-netmap-update",
-			Exec:      localAPIAction("force-netmap-update"),
-			ShortHelp: "force a full no-op netmap update (for load testing)",
+			Name:       "force-netmap-update",
+			ShortUsage: "tailscale debug force-netmap-update",
+			Exec:       localAPIAction("force-netmap-update"),
+			ShortHelp:  "Force a full no-op netmap update (for load testing)",
 		},
 		{
 			// TODO(bradfitz,maisem): eventually promote this out of debug
-			Name:      "reload-config",
-			Exec:      reloadConfig,
-			ShortHelp: "reload config",
+			Name:       "reload-config",
+			ShortUsage: "tailscale debug reload-config",
+			Exec:       reloadConfig,
+			ShortHelp:  "Reload config",
 		},
 		{
-			Name:      "control-knobs",
-			Exec:      debugControlKnobs,
-			ShortHelp: "see current control knobs",
+			Name:       "control-knobs",
+			ShortUsage: "tailscale debug control-knobs",
+			Exec:       debugControlKnobs,
+			ShortHelp:  "See current control knobs",
 		},
 		{
-			Name:      "prefs",
-			Exec:      runPrefs,
-			ShortHelp: "print prefs",
+			Name:       "prefs",
+			ShortUsage: "tailscale debug prefs",
+			Exec:       runPrefs,
+			ShortHelp:  "Print prefs",
 			FlagSet: (func() *flag.FlagSet {
 				fs := newFlagSet("prefs")
 				fs.BoolVar(&prefsArgs.pretty, "pretty", false, "If true, pretty-print output")
@@ -181,9 +201,10 @@ var debugCmd = &ffcli.Command{
 			})(),
 		},
 		{
-			Name:      "watch-ipn",
-			Exec:      runWatchIPN,
-			ShortHelp: "subscribe to IPN message bus",
+			Name:       "watch-ipn",
+			ShortUsage: "tailscale debug watch-ipn",
+			Exec:       runWatchIPN,
+			ShortHelp:  "Subscribe to IPN message bus",
 			FlagSet: (func() *flag.FlagSet {
 				fs := newFlagSet("watch-ipn")
 				fs.BoolVar(&watchIPNArgs.netmap, "netmap", true, "include netmap in messages")
@@ -194,9 +215,10 @@ var debugCmd = &ffcli.Command{
 			})(),
 		},
 		{
-			Name:      "netmap",
-			Exec:      runNetmap,
-			ShortHelp: "print the current network map",
+			Name:       "netmap",
+			ShortUsage: "tailscale debug netmap",
+			Exec:       runNetmap,
+			ShortHelp:  "Print the current network map",
 			FlagSet: (func() *flag.FlagSet {
 				fs := newFlagSet("netmap")
 				fs.BoolVar(&netmapArgs.showPrivateKey, "show-private-key", false, "include node private key in printed netmap")
@@ -204,14 +226,17 @@ var debugCmd = &ffcli.Command{
 			})(),
 		},
 		{
-			Name:      "via",
+			Name: "via",
+			ShortUsage: "tailscale via <site-id> <v4-cidr>\n" +
+				"tailscale via <v6-route>",
 			Exec:      runVia,
-			ShortHelp: "convert between site-specific IPv4 CIDRs and IPv6 'via' routes",
+			ShortHelp: "Convert between site-specific IPv4 CIDRs and IPv6 'via' routes",
 		},
 		{
-			Name:      "ts2021",
-			Exec:      runTS2021,
-			ShortHelp: "debug ts2021 protocol connectivity",
+			Name:       "ts2021",
+			ShortUsage: "tailscale debug ts2021",
+			Exec:       runTS2021,
+			ShortHelp:  "Debug ts2021 protocol connectivity",
 			FlagSet: (func() *flag.FlagSet {
 				fs := newFlagSet("ts2021")
 				fs.StringVar(&ts2021Args.host, "host", "controlplane.tailscale.com", "hostname of control plane")
@@ -221,9 +246,10 @@ var debugCmd = &ffcli.Command{
 			})(),
 		},
 		{
-			Name:      "set-expire",
-			Exec:      runSetExpire,
-			ShortHelp: "manipulate node key expiry for testing",
+			Name:       "set-expire",
+			ShortUsage: "tailscale debug set-expire --in=1m",
+			Exec:       runSetExpire,
+			ShortHelp:  "Manipulate node key expiry for testing",
 			FlagSet: (func() *flag.FlagSet {
 				fs := newFlagSet("set-expire")
 				fs.DurationVar(&setExpireArgs.in, "in", 0, "if non-zero, set node key to expire this duration from now")
@@ -231,9 +257,10 @@ var debugCmd = &ffcli.Command{
 			})(),
 		},
 		{
-			Name:      "dev-store-set",
-			Exec:      runDevStoreSet,
-			ShortHelp: "set a key/value pair during development",
+			Name:       "dev-store-set",
+			ShortUsage: "tailscale debug dev-store-set",
+			Exec:       runDevStoreSet,
+			ShortHelp:  "Set a key/value pair during development",
 			FlagSet: (func() *flag.FlagSet {
 				fs := newFlagSet("store-set")
 				fs.BoolVar(&devStoreSetArgs.danger, "danger", false, "accept danger")
@@ -241,14 +268,16 @@ var debugCmd = &ffcli.Command{
 			})(),
 		},
 		{
-			Name:      "derp",
-			Exec:      runDebugDERP,
-			ShortHelp: "test a DERP configuration",
+			Name:       "derp",
+			ShortUsage: "tailscale debug derp",
+			Exec:       runDebugDERP,
+			ShortHelp:  "Test a DERP configuration",
 		},
 		{
-			Name:      "capture",
-			Exec:      runCapture,
-			ShortHelp: "streams pcaps for debugging",
+			Name:       "capture",
+			ShortUsage: "tailscale debug capture",
+			Exec:       runCapture,
+			ShortHelp:  "Streams pcaps for debugging",
 			FlagSet: (func() *flag.FlagSet {
 				fs := newFlagSet("capture")
 				fs.StringVar(&captureArgs.outFile, "o", "", "path to stream the pcap (or - for stdout), leave empty to start wireshark")
@@ -256,9 +285,10 @@ var debugCmd = &ffcli.Command{
 			})(),
 		},
 		{
-			Name:      "portmap",
-			Exec:      debugPortmap,
-			ShortHelp: "run portmap debugging",
+			Name:       "portmap",
+			ShortUsage: "tailscale debug portmap",
+			Exec:       debugPortmap,
+			ShortHelp:  "Run portmap debugging",
 			FlagSet: (func() *flag.FlagSet {
 				fs := newFlagSet("portmap")
 				fs.DurationVar(&debugPortmapArgs.duration, "duration", 5*time.Second, "timeout for port mapping")
@@ -270,14 +300,16 @@ var debugCmd = &ffcli.Command{
 			})(),
 		},
 		{
-			Name:      "peer-endpoint-changes",
-			Exec:      runPeerEndpointChanges,
-			ShortHelp: "prints debug information about a peer's endpoint changes",
+			Name:       "peer-endpoint-changes",
+			ShortUsage: "tailscale debug peer-endpoint-changes <hostname-or-IP>",
+			Exec:       runPeerEndpointChanges,
+			ShortHelp:  "Prints debug information about a peer's endpoint changes",
 		},
 		{
-			Name:      "dial-types",
-			Exec:      runDebugDialTypes,
-			ShortHelp: "prints debug information about connecting to a given host or IP",
+			Name:       "dial-types",
+			ShortUsage: "tailscale debug dial-types <hostname-or-IP> <port>",
+			Exec:       runDebugDialTypes,
+			ShortHelp:  "Prints debug information about connecting to a given host or IP",
 			FlagSet: (func() *flag.FlagSet {
 				fs := newFlagSet("dial-types")
 				fs.StringVar(&debugDialTypesArgs.network, "network", "tcp", `network type to dial ("tcp", "udp", etc.)`)
@@ -867,7 +899,7 @@ var setExpireArgs struct {
 
 func runSetExpire(ctx context.Context, args []string) error {
 	if len(args) != 0 || setExpireArgs.in == 0 {
-		return errors.New("usage --in=<duration>")
+		return errors.New("usage: tailscale debug set-expire --in=<duration>")
 	}
 	return localClient.DebugSetExpireIn(ctx, setExpireArgs.in)
 }
@@ -966,7 +998,7 @@ func runPeerEndpointChanges(ctx context.Context, args []string) error {
 	}
 
 	if len(args) != 1 || args[0] == "" {
-		return errors.New("usage: peer-status <hostname-or-IP>")
+		return errors.New("usage: tailscale debug peer-endpoint-changes <hostname-or-IP>")
 	}
 	var ip string
 
@@ -1042,7 +1074,7 @@ func runDebugDialTypes(ctx context.Context, args []string) error {
 	}
 
 	if len(args) != 2 || args[0] == "" || args[1] == "" {
-		return errors.New("usage: dial-types <hostname-or-IP> <port>")
+		return errors.New("usage: tailscale debug dial-types <hostname-or-IP> <port>")
 	}
 
 	port, err := strconv.ParseUint(args[1], 10, 16)

--- a/cmd/tailscale/cli/down.go
+++ b/cmd/tailscale/cli/down.go
@@ -14,7 +14,7 @@ import (
 
 var downCmd = &ffcli.Command{
 	Name:       "down",
-	ShortUsage: "down",
+	ShortUsage: "tailscale down",
 	ShortHelp:  "Disconnect from Tailscale",
 
 	Exec:    runDown,

--- a/cmd/tailscale/cli/drive.go
+++ b/cmd/tailscale/cli/drive.go
@@ -14,10 +14,10 @@ import (
 )
 
 const (
-	driveShareUsage   = "drive share <name> <path>"
-	driveRenameUsage  = "drive rename <oldname> <newname>"
-	driveUnshareUsage = "drive unshare <name>"
-	driveListUsage    = "drive list"
+	driveShareUsage   = "tailscale drive share <name> <path>"
+	driveRenameUsage  = "tailscale drive rename <oldname> <newname>"
+	driveUnshareUsage = "tailscale drive unshare <name>"
+	driveListUsage    = "tailscale drive list"
 )
 
 var driveCmd = &ffcli.Command{
@@ -33,28 +33,32 @@ var driveCmd = &ffcli.Command{
 	UsageFunc: usageFuncNoDefaultValues,
 	Subcommands: []*ffcli.Command{
 		{
-			Name:      "share",
-			Exec:      runDriveShare,
-			ShortHelp: "[ALPHA] create or modify a share",
-			UsageFunc: usageFunc,
+			Name:       "share",
+			ShortUsage: driveShareUsage,
+			Exec:       runDriveShare,
+			ShortHelp:  "[ALPHA] create or modify a share",
+			UsageFunc:  usageFunc,
 		},
 		{
-			Name:      "rename",
-			ShortHelp: "[ALPHA] rename a share",
-			Exec:      runDriveRename,
-			UsageFunc: usageFunc,
+			Name:       "rename",
+			ShortUsage: driveRenameUsage,
+			ShortHelp:  "[ALPHA] rename a share",
+			Exec:       runDriveRename,
+			UsageFunc:  usageFunc,
 		},
 		{
-			Name:      "unshare",
-			ShortHelp: "[ALPHA] remove a share",
-			Exec:      runDriveUnshare,
-			UsageFunc: usageFunc,
+			Name:       "unshare",
+			ShortUsage: driveUnshareUsage,
+			ShortHelp:  "[ALPHA] remove a share",
+			Exec:       runDriveUnshare,
+			UsageFunc:  usageFunc,
 		},
 		{
-			Name:      "list",
-			ShortHelp: "[ALPHA] list current shares",
-			Exec:      runDriveList,
-			UsageFunc: usageFunc,
+			Name:       "list",
+			ShortUsage: driveListUsage,
+			ShortHelp:  "[ALPHA] list current shares",
+			Exec:       runDriveList,
+			UsageFunc:  usageFunc,
 		},
 	},
 	Exec: func(context.Context, []string) error {
@@ -237,8 +241,8 @@ You can get a list of currently published shares by running:
 
   $ tailscale drive list`
 
-var shareLongHelpAs = `
+const shareLongHelpAs = `
 
 If you want a share to be accessed as a different user, you can use sudo to accomplish this. For example, to create the aforementioned share as "theuser", you could run:
 
-	$ sudo -u theuser tailscale drive share docs /Users/theuser/Documents`
+  $ sudo -u theuser tailscale drive share docs /Users/theuser/Documents`

--- a/cmd/tailscale/cli/exitnode.go
+++ b/cmd/tailscale/cli/exitnode.go
@@ -23,7 +23,7 @@ import (
 func exitNodeCmd() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "exit-node",
-		ShortUsage: "exit-node [flags]",
+		ShortUsage: "tailscale exit-node [flags]",
 		ShortHelp:  "Show machines on your tailnet configured as exit nodes",
 		LongHelp:   "Show machines on your tailnet configured as exit nodes",
 		Exec: func(context.Context, []string) error {
@@ -32,7 +32,7 @@ func exitNodeCmd() *ffcli.Command {
 		Subcommands: append([]*ffcli.Command{
 			{
 				Name:       "list",
-				ShortUsage: "exit-node list [flags]",
+				ShortUsage: "tailscale exit-node list [flags]",
 				ShortHelp:  "Show exit nodes",
 				Exec:       runExitNodeList,
 				FlagSet: (func() *flag.FlagSet {
@@ -48,13 +48,13 @@ func exitNodeCmd() *ffcli.Command {
 				return []*ffcli.Command{
 					{
 						Name:       "connect",
-						ShortUsage: "exit-node connect",
+						ShortUsage: "tailscale exit-node connect",
 						ShortHelp:  "connect to most recently used exit node",
 						Exec:       exitNodeSetUse(true),
 					},
 					{
 						Name:       "disconnect",
-						ShortUsage: "exit-node disconnect",
+						ShortUsage: "tailscale exit-node disconnect",
 						ShortHelp:  "disconnect from current exit node, if any",
 						Exec:       exitNodeSetUse(false),
 					},

--- a/cmd/tailscale/cli/file.go
+++ b/cmd/tailscale/cli/file.go
@@ -38,7 +38,7 @@ import (
 
 var fileCmd = &ffcli.Command{
 	Name:       "file",
-	ShortUsage: "file <cp|get> ...",
+	ShortUsage: "tailscale file <cp|get> ...",
 	ShortHelp:  "Send or receive files",
 	Subcommands: []*ffcli.Command{
 		fileCpCmd,
@@ -65,7 +65,7 @@ func (c *countingReader) Read(buf []byte) (int, error) {
 
 var fileCpCmd = &ffcli.Command{
 	Name:       "cp",
-	ShortUsage: "file cp <files...> <target>:",
+	ShortUsage: "tailscale file cp <files...> <target>:",
 	ShortHelp:  "Copy file(s) to a host",
 	Exec:       runCp,
 	FlagSet: (func() *flag.FlagSet {
@@ -412,7 +412,7 @@ func (v *onConflict) Set(s string) error {
 
 var fileGetCmd = &ffcli.Command{
 	Name:       "get",
-	ShortUsage: "file get [--wait] [--verbose] [--conflict=(skip|overwrite|rename)] <target-directory>",
+	ShortUsage: "tailscale file get [--wait] [--verbose] [--conflict=(skip|overwrite|rename)] <target-directory>",
 	ShortHelp:  "Move files out of the Tailscale file inbox",
 	Exec:       runFileGet,
 	FlagSet: (func() *flag.FlagSet {
@@ -420,7 +420,7 @@ var fileGetCmd = &ffcli.Command{
 		fs.BoolVar(&getArgs.wait, "wait", false, "wait for a file to arrive if inbox is empty")
 		fs.BoolVar(&getArgs.loop, "loop", false, "run get in a loop, receiving files as they come in")
 		fs.BoolVar(&getArgs.verbose, "verbose", false, "verbose output")
-		fs.Var(&getArgs.conflict, "conflict", `behavior when a conflicting (same-named) file already exists in the target directory.
+		fs.Var(&getArgs.conflict, "conflict", "`behavior`"+` when a conflicting (same-named) file already exists in the target directory.
 	skip:       skip conflicting files: leave them in the taildrop inbox and print an error. get any non-conflicting files
 	overwrite:  overwrite existing file
 	rename:     write to a new number-suffixed filename`)

--- a/cmd/tailscale/cli/funnel.go
+++ b/cmd/tailscale/cli/funnel.go
@@ -36,9 +36,9 @@ func newFunnelCommand(e *serveEnv) *ffcli.Command {
 		Name:      "funnel",
 		ShortHelp: "Turn on/off Funnel service",
 		ShortUsage: strings.Join([]string{
-			"funnel <serve-port> {on|off}",
-			"funnel status [--json]",
-		}, "\n  "),
+			"tailscale funnel <serve-port> {on|off}",
+			"tailscale funnel status [--json]",
+		}, "\n"),
 		LongHelp: strings.Join([]string{
 			"Funnel allows you to publish a 'tailscale serve'",
 			"server publicly, open to the entire internet.",
@@ -46,17 +46,16 @@ func newFunnelCommand(e *serveEnv) *ffcli.Command {
 			"Turning off Funnel only turns off serving to the internet.",
 			"It does not affect serving to your tailnet.",
 		}, "\n"),
-		Exec:      e.runFunnel,
-		UsageFunc: usageFunc,
+		Exec: e.runFunnel,
 		Subcommands: []*ffcli.Command{
 			{
-				Name:      "status",
-				Exec:      e.runServeStatus,
-				ShortHelp: "show current serve/funnel status",
+				Name:       "status",
+				Exec:       e.runServeStatus,
+				ShortUsage: "tailscale funnel status [--json]",
+				ShortHelp:  "Show current serve/funnel status",
 				FlagSet: e.newFlags("funnel-status", func(fs *flag.FlagSet) {
 					fs.BoolVar(&e.json, "json", false, "output JSON")
 				}),
-				UsageFunc: usageFunc,
 			},
 		},
 	}

--- a/cmd/tailscale/cli/id-token.go
+++ b/cmd/tailscale/cli/id-token.go
@@ -12,8 +12,8 @@ import (
 
 var idTokenCmd = &ffcli.Command{
 	Name:       "id-token",
-	ShortUsage: "id-token <aud>",
-	ShortHelp:  "fetch an OIDC id-token for the Tailscale machine",
+	ShortUsage: "tailscale id-token <aud>",
+	ShortHelp:  "Fetch an OIDC id-token for the Tailscale machine",
 	Exec:       runIDToken,
 }
 

--- a/cmd/tailscale/cli/ip.go
+++ b/cmd/tailscale/cli/ip.go
@@ -16,7 +16,7 @@ import (
 
 var ipCmd = &ffcli.Command{
 	Name:       "ip",
-	ShortUsage: "ip [-1] [-4] [-6] [peer hostname or ip address]",
+	ShortUsage: "tailscale ip [-1] [-4] [-6] [peer hostname or ip address]",
 	ShortHelp:  "Show Tailscale IP addresses",
 	LongHelp:   "Show Tailscale IP addresses for peer. Peer defaults to the current machine.",
 	Exec:       runIP,

--- a/cmd/tailscale/cli/licenses.go
+++ b/cmd/tailscale/cli/licenses.go
@@ -12,7 +12,7 @@ import (
 
 var licensesCmd = &ffcli.Command{
 	Name:       "licenses",
-	ShortUsage: "licenses",
+	ShortUsage: "tailscale licenses",
 	ShortHelp:  "Get open source license information",
 	LongHelp:   "Get open source license information",
 	Exec:       runLicenses,

--- a/cmd/tailscale/cli/login.go
+++ b/cmd/tailscale/cli/login.go
@@ -14,11 +14,10 @@ var loginArgs upArgsT
 
 var loginCmd = &ffcli.Command{
 	Name:       "login",
-	ShortUsage: "login [flags]",
+	ShortUsage: "tailscale login [flags]",
 	ShortHelp:  "Log in to a Tailscale account",
 	LongHelp: `"tailscale login" logs this machine in to your Tailscale network.
 This command is currently in alpha and may change in the future.`,
-	UsageFunc: usageFunc,
 	FlagSet: func() *flag.FlagSet {
 		return newUpFlagSet(effectiveGOOS(), &loginArgs, "login")
 	}(),

--- a/cmd/tailscale/cli/logout.go
+++ b/cmd/tailscale/cli/logout.go
@@ -13,7 +13,7 @@ import (
 
 var logoutCmd = &ffcli.Command{
 	Name:       "logout",
-	ShortUsage: "logout [flags]",
+	ShortUsage: "tailscale logout",
 	ShortHelp:  "Disconnect from Tailscale and expire current node key",
 
 	LongHelp: strings.TrimSpace(`

--- a/cmd/tailscale/cli/nc.go
+++ b/cmd/tailscale/cli/nc.go
@@ -16,7 +16,7 @@ import (
 
 var ncCmd = &ffcli.Command{
 	Name:       "nc",
-	ShortUsage: "nc <hostname-or-IP> <port>",
+	ShortUsage: "tailscale nc <hostname-or-IP> <port>",
 	ShortHelp:  "Connect to a port on a host, connected to stdin/stdout",
 	Exec:       runNC,
 }

--- a/cmd/tailscale/cli/netcheck.go
+++ b/cmd/tailscale/cli/netcheck.go
@@ -28,7 +28,7 @@ import (
 
 var netcheckCmd = &ffcli.Command{
 	Name:       "netcheck",
-	ShortUsage: "netcheck",
+	ShortUsage: "tailscale netcheck",
 	ShortHelp:  "Print an analysis of local network conditions",
 	Exec:       runNetcheck,
 	FlagSet: (func() *flag.FlagSet {

--- a/cmd/tailscale/cli/network-lock.go
+++ b/cmd/tailscale/cli/network-lock.go
@@ -26,7 +26,7 @@ import (
 
 var netlockCmd = &ffcli.Command{
 	Name:       "lock",
-	ShortUsage: "lock <sub-command> <arguments>",
+	ShortUsage: "tailscale lock <sub-command> <arguments>",
 	ShortHelp:  "Manage tailnet lock",
 	LongHelp:   "Manage tailnet lock",
 	Subcommands: []*ffcli.Command{
@@ -61,7 +61,7 @@ var nlInitArgs struct {
 
 var nlInitCmd = &ffcli.Command{
 	Name:       "init",
-	ShortUsage: "init [--gen-disablement-for-support] --gen-disablements N <trusted-key>...",
+	ShortUsage: "tailscale lock init [--gen-disablement-for-support] --gen-disablements N <trusted-key>...",
 	ShortHelp:  "Initialize tailnet lock",
 	LongHelp: strings.TrimSpace(`
 
@@ -183,7 +183,7 @@ var nlStatusArgs struct {
 
 var nlStatusCmd = &ffcli.Command{
 	Name:       "status",
-	ShortUsage: "status",
+	ShortUsage: "tailscale lock status",
 	ShortHelp:  "Outputs the state of tailnet lock",
 	LongHelp:   "Outputs the state of tailnet lock",
 	Exec:       runNetworkLockStatus,
@@ -280,7 +280,7 @@ func runNetworkLockStatus(ctx context.Context, args []string) error {
 
 var nlAddCmd = &ffcli.Command{
 	Name:       "add",
-	ShortUsage: "add <public-key>...",
+	ShortUsage: "tailscale lock add <public-key>...",
 	ShortHelp:  "Adds one or more trusted signing keys to tailnet lock",
 	LongHelp:   "Adds one or more trusted signing keys to tailnet lock",
 	Exec: func(ctx context.Context, args []string) error {
@@ -294,7 +294,7 @@ var nlRemoveArgs struct {
 
 var nlRemoveCmd = &ffcli.Command{
 	Name:       "remove",
-	ShortUsage: "remove [--re-sign=false] <public-key>...",
+	ShortUsage: "tailscale lock remove [--re-sign=false] <public-key>...",
 	ShortHelp:  "Removes one or more trusted signing keys from tailnet lock",
 	LongHelp:   "Removes one or more trusted signing keys from tailnet lock",
 	Exec:       runNetworkLockRemove,
@@ -435,7 +435,7 @@ func runNetworkLockModify(ctx context.Context, addArgs, removeArgs []string) err
 
 var nlSignCmd = &ffcli.Command{
 	Name:       "sign",
-	ShortUsage: "sign <node-key> [<rotation-key>] or sign <auth-key>",
+	ShortUsage: "tailscale lock sign <node-key> [<rotation-key>] or sign <auth-key>",
 	ShortHelp:  "Signs a node or pre-approved auth key",
 	LongHelp: `Either:
   - signs a node key and transmits the signature to the coordination server, or
@@ -479,7 +479,7 @@ func runNetworkLockSign(ctx context.Context, args []string) error {
 
 var nlDisableCmd = &ffcli.Command{
 	Name:       "disable",
-	ShortUsage: "disable <disablement-secret>",
+	ShortUsage: "tailscale lock disable <disablement-secret>",
 	ShortHelp:  "Consumes a disablement secret to shut down tailnet lock for the tailnet",
 	LongHelp: strings.TrimSpace(`
 
@@ -508,7 +508,7 @@ func runNetworkLockDisable(ctx context.Context, args []string) error {
 
 var nlLocalDisableCmd = &ffcli.Command{
 	Name:       "local-disable",
-	ShortUsage: "local-disable",
+	ShortUsage: "tailscale lock local-disable",
 	ShortHelp:  "Disables tailnet lock for this node only",
 	LongHelp: strings.TrimSpace(`
 
@@ -530,7 +530,7 @@ func runNetworkLockLocalDisable(ctx context.Context, args []string) error {
 
 var nlDisablementKDFCmd = &ffcli.Command{
 	Name:       "disablement-kdf",
-	ShortUsage: "disablement-kdf <hex-encoded-disablement-secret>",
+	ShortUsage: "tailscale lock disablement-kdf <hex-encoded-disablement-secret>",
 	ShortHelp:  "Computes a disablement value from a disablement secret (advanced users only)",
 	LongHelp:   "Computes a disablement value from a disablement secret (advanced users only)",
 	Exec:       runNetworkLockDisablementKDF,
@@ -555,7 +555,7 @@ var nlLogArgs struct {
 
 var nlLogCmd = &ffcli.Command{
 	Name:       "log",
-	ShortUsage: "log [--limit N]",
+	ShortUsage: "tailscale lock log [--limit N]",
 	ShortHelp:  "List changes applied to tailnet lock",
 	LongHelp:   "List changes applied to tailnet lock",
 	Exec:       runNetworkLockLog,
@@ -719,7 +719,7 @@ var nlRevokeKeysArgs struct {
 
 var nlRevokeKeysCmd = &ffcli.Command{
 	Name:       "revoke-keys",
-	ShortUsage: "revoke-keys <tailnet-lock-key>...\n  revoke-keys [--cosign] [--finish] <recovery-blob>",
+	ShortUsage: "tailscale lock revoke-keys <tailnet-lock-key>...\n  revoke-keys [--cosign] [--finish] <recovery-blob>",
 	ShortHelp:  "Revoke compromised tailnet-lock keys",
 	LongHelp: `Retroactively revoke the specified tailnet lock keys (tlpub:abc).
 

--- a/cmd/tailscale/cli/ping.go
+++ b/cmd/tailscale/cli/ping.go
@@ -23,7 +23,7 @@ import (
 
 var pingCmd = &ffcli.Command{
 	Name:       "ping",
-	ShortUsage: "ping <hostname-or-IP>",
+	ShortUsage: "tailscale ping <hostname-or-IP>",
 	ShortHelp:  "Ping a host at the Tailscale layer, see how it routed",
 	LongHelp: strings.TrimSpace(`
 

--- a/cmd/tailscale/cli/serve_legacy.go
+++ b/cmd/tailscale/cli/serve_legacy.go
@@ -44,13 +44,13 @@ func newServeLegacyCommand(e *serveEnv) *ffcli.Command {
 		Name:      "serve",
 		ShortHelp: "Serve content and local servers",
 		ShortUsage: strings.Join([]string{
-			"serve http:<port> <mount-point> <source> [off]",
-			"serve https:<port> <mount-point> <source> [off]",
-			"serve tcp:<port> tcp://localhost:<local-port> [off]",
-			"serve tls-terminated-tcp:<port> tcp://localhost:<local-port> [off]",
-			"serve status [--json]",
-			"serve reset",
-		}, "\n  "),
+			"tailscale serve http:<port> <mount-point> <source> [off]",
+			"tailscale serve https:<port> <mount-point> <source> [off]",
+			"tailscale serve tcp:<port> tcp://localhost:<local-port> [off]",
+			"tailscale serve tls-terminated-tcp:<port> tcp://localhost:<local-port> [off]",
+			"tailscale serve status [--json]",
+			"tailscale serve reset",
+		}, "\n"),
 		LongHelp: strings.TrimSpace(`
 *** BETA; all of this is subject to change ***
 
@@ -91,24 +91,21 @@ EXAMPLES
     local plaintext server on port 80:
     $ tailscale serve tls-terminated-tcp:443 tcp://localhost:80
 `),
-		Exec:      e.runServe,
-		UsageFunc: usageFunc,
+		Exec: e.runServe,
 		Subcommands: []*ffcli.Command{
 			{
 				Name:      "status",
 				Exec:      e.runServeStatus,
-				ShortHelp: "show current serve/funnel status",
+				ShortHelp: "Show current serve/funnel status",
 				FlagSet: e.newFlags("serve-status", func(fs *flag.FlagSet) {
 					fs.BoolVar(&e.json, "json", false, "output JSON")
 				}),
-				UsageFunc: usageFunc,
 			},
 			{
 				Name:      "reset",
 				Exec:      e.runServeReset,
-				ShortHelp: "reset current serve/funnel config",
+				ShortHelp: "Reset current serve/funnel config",
 				FlagSet:   e.newFlags("serve-reset", nil),
-				UsageFunc: usageFunc,
 			},
 		},
 	}

--- a/cmd/tailscale/cli/serve_v2.go
+++ b/cmd/tailscale/cli/serve_v2.go
@@ -110,10 +110,10 @@ func newServeV2Command(e *serveEnv, subcmd serveMode) *ffcli.Command {
 		Name:      info.Name,
 		ShortHelp: info.ShortHelp,
 		ShortUsage: strings.Join([]string{
-			fmt.Sprintf("%s <target>", info.Name),
-			fmt.Sprintf("%s status [--json]", info.Name),
-			fmt.Sprintf("%s reset", info.Name),
-		}, "\n  "),
+			fmt.Sprintf("tailscale %s <target>", info.Name),
+			fmt.Sprintf("tailscale %s status [--json]", info.Name),
+			fmt.Sprintf("tailscale %s reset", info.Name),
+		}, "\n"),
 		LongHelp: info.LongHelp + fmt.Sprintf(strings.TrimSpace(serveHelpCommon), info.Name),
 		Exec:     e.runServeCombined(subcmd),
 
@@ -131,20 +131,20 @@ func newServeV2Command(e *serveEnv, subcmd serveMode) *ffcli.Command {
 		UsageFunc: usageFuncNoDefaultValues,
 		Subcommands: []*ffcli.Command{
 			{
-				Name:      "status",
-				Exec:      e.runServeStatus,
-				ShortHelp: "view current proxy configuration",
+				Name:       "status",
+				ShortUsage: "tailscale " + info.Name + " status [--json]",
+				Exec:       e.runServeStatus,
+				ShortHelp:  "View current " + info.Name + " configuration",
 				FlagSet: e.newFlags("serve-status", func(fs *flag.FlagSet) {
 					fs.BoolVar(&e.json, "json", false, "output JSON")
 				}),
-				UsageFunc: usageFunc,
 			},
 			{
-				Name:      "reset",
-				ShortHelp: "reset current serve/funnel config",
-				Exec:      e.runServeReset,
-				FlagSet:   e.newFlags("serve-reset", nil),
-				UsageFunc: usageFunc,
+				Name:       "reset",
+				ShortUsage: "tailscale " + info.Name + " reset",
+				ShortHelp:  "Reset current " + info.Name + " config",
+				Exec:       e.runServeReset,
+				FlagSet:    e.newFlags("serve-reset", nil),
 			},
 		},
 	}

--- a/cmd/tailscale/cli/set.go
+++ b/cmd/tailscale/cli/set.go
@@ -25,7 +25,7 @@ import (
 
 var setCmd = &ffcli.Command{
 	Name:       "set",
-	ShortUsage: "set [flags]",
+	ShortUsage: "tailscale set [flags]",
 	ShortHelp:  "Change specified preferences",
 	LongHelp: `"tailscale set" allows changing specific preferences.
 

--- a/cmd/tailscale/cli/ssh.go
+++ b/cmd/tailscale/cli/ssh.go
@@ -26,7 +26,7 @@ import (
 
 var sshCmd = &ffcli.Command{
 	Name:       "ssh",
-	ShortUsage: "ssh [user@]<host> [args...]",
+	ShortUsage: "tailscale ssh [user@]<host> [args...]",
 	ShortHelp:  "SSH to a Tailscale machine",
 	LongHelp: strings.TrimSpace(`
 

--- a/cmd/tailscale/cli/status.go
+++ b/cmd/tailscale/cli/status.go
@@ -29,7 +29,7 @@ import (
 
 var statusCmd = &ffcli.Command{
 	Name:       "status",
-	ShortUsage: "status [--active] [--web] [--json]",
+	ShortUsage: "tailscale status [--active] [--web] [--json]",
 	ShortHelp:  "Show state of tailscaled and its connections",
 	LongHelp: strings.TrimSpace(`
 

--- a/cmd/tailscale/cli/switch.go
+++ b/cmd/tailscale/cli/switch.go
@@ -17,26 +17,22 @@ import (
 )
 
 var switchCmd = &ffcli.Command{
-	Name:      "switch",
-	ShortHelp: "Switches to a different Tailscale account",
+	Name:       "switch",
+	ShortUsage: "tailscale switch <id>",
+	ShortHelp:  "Switches to a different Tailscale account",
+	LongHelp: `"tailscale switch" switches between logged in accounts. You can
+use the ID that's returned from 'tailnet switch -list'
+to pick which profile you want to switch to. Alternatively, you
+can use the Tailnet or the account names to switch as well.
+
+This command is currently in alpha and may change in the future.`,
+
 	FlagSet: func() *flag.FlagSet {
 		fs := flag.NewFlagSet("switch", flag.ExitOnError)
 		fs.BoolVar(&switchArgs.list, "list", false, "list available accounts")
 		return fs
 	}(),
 	Exec: switchProfile,
-	UsageFunc: func(*ffcli.Command) string {
-		return `USAGE
-  switch <id>
-  switch --list
-
-"tailscale switch" switches between logged in accounts. You can
-use the ID that's returned from 'tailnet switch -list'
-to pick which profile you want to switch to. Alternatively, you
-can use the Tailnet or the account names to switch as well.
-
-This command is currently in alpha and may change in the future.`
-	},
 }
 
 var switchArgs struct {

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -44,7 +44,7 @@ import (
 
 var upCmd = &ffcli.Command{
 	Name:       "up",
-	ShortUsage: "up [flags]",
+	ShortUsage: "tailscale up [flags]",
 	ShortHelp:  "Connect to Tailscale, logging in if needed",
 
 	LongHelp: strings.TrimSpace(`

--- a/cmd/tailscale/cli/update.go
+++ b/cmd/tailscale/cli/update.go
@@ -19,7 +19,7 @@ import (
 
 var updateCmd = &ffcli.Command{
 	Name:       "update",
-	ShortUsage: "update",
+	ShortUsage: "tailscale update",
 	ShortHelp:  "Update Tailscale to the latest/different version",
 	Exec:       runUpdate,
 	FlagSet: (func() *flag.FlagSet {

--- a/cmd/tailscale/cli/version.go
+++ b/cmd/tailscale/cli/version.go
@@ -17,7 +17,7 @@ import (
 
 var versionCmd = &ffcli.Command{
 	Name:       "version",
-	ShortUsage: "version [flags]",
+	ShortUsage: "tailscale version [flags]",
 	ShortHelp:  "Print Tailscale version",
 	FlagSet: (func() *flag.FlagSet {
 		fs := newFlagSet("version")

--- a/cmd/tailscale/cli/web.go
+++ b/cmd/tailscale/cli/web.go
@@ -26,7 +26,7 @@ import (
 
 var webCmd = &ffcli.Command{
 	Name:       "web",
-	ShortUsage: "web [flags]",
+	ShortUsage: "tailscale web [flags]",
 	ShortHelp:  "Run a web server for controlling Tailscale",
 
 	LongHelp: strings.TrimSpace(`

--- a/cmd/tailscale/cli/whois.go
+++ b/cmd/tailscale/cli/whois.go
@@ -17,13 +17,12 @@ import (
 
 var whoisCmd = &ffcli.Command{
 	Name:       "whois",
-	ShortUsage: "whois [--json] ip[:port]",
+	ShortUsage: "tailscale whois [--json] ip[:port]",
 	ShortHelp:  "Show the machine and user associated with a Tailscale IP (v4 or v6)",
 	LongHelp: strings.TrimSpace(`
 	'tailscale whois' shows the machine and user associated with a Tailscale IP (v4 or v6).
 	`),
-	UsageFunc: usageFunc,
-	Exec:      runWhoIs,
+	Exec: runWhoIs,
 	FlagSet: func() *flag.FlagSet {
 		fs := newFlagSet("whois")
 		fs.BoolVar(&whoIsArgs.json, "json", false, "output in JSON format")


### PR DESCRIPTION
Fixes #11664 

The main changes to `--help` output are:

* I've added ShortHelp above the USAGE on --help output, and capitalize all of their first letters
* All USAGEs now show the full "tailscale ..." invocation, e.g. "USAGE: cp ..." is now "USAGE: tailscale file cp ...".
* All sub-subcommands now use our custom usage function too
* Hide subcommands with "HIDDEN: " prefixes (also done in #11336), but needed here for TS_DUMP_HELP to show everything


Here's a diff of all the `--help` output from main (-) to this PR (+):

</details>

```diff
--- help-main.txt	2024-04-05 10:25:53
+++ help-updated.txt	2024-04-05 10:25:52
@@ -1,1172 +1,1196 @@
 ===
+The easiest, most secure way to use WireGuard.
+
 USAGE
   tailscale [flags] <subcommand> [command flags]
 
 For help on subcommands, add --help after: "tailscale status --help".
 
 This CLI is still under active development. Commands and flags will
 change in the future.
 
 SUBCOMMANDS
   up         Connect to Tailscale, logging in if needed
   down       Disconnect from Tailscale
   set        Change specified preferences
   login      Log in to a Tailscale account
   logout     Disconnect from Tailscale and expire current node key
   switch     Switches to a different Tailscale account
   configure  [ALPHA] Configure the host to enable more Tailscale features
   netcheck   Print an analysis of local network conditions
   ip         Show Tailscale IP addresses
   status     Show state of tailscaled and its connections
   ping       Ping a host at the Tailscale layer, see how it routed
   nc         Connect to a port on a host, connected to stdin/stdout
   ssh        SSH to a Tailscale machine
   funnel     Serve content and local servers on the internet
   serve      Serve content and local servers on your tailnet
   version    Print Tailscale version
   web        Run a web server for controlling Tailscale
   file       Send or receive files
   bugreport  Print a shareable identifier to help diagnose issues
   cert       Get TLS certs
   lock       Manage tailnet lock
   licenses   Get open source license information
   exit-node  Show machines on your tailnet configured as exit nodes
   update     Update Tailscale to the latest/different version
   whois      Show the machine and user associated with a Tailscale IP (v4 or v6)
 
 FLAGS
   --socket string
     	path to tailscaled socket (default /var/run/tailscaled.socket)
 ===
+Connect to Tailscale, logging in if needed
+
 USAGE
-  up [flags]
+  tailscale up [flags]
 
 "tailscale up" connects this machine to your Tailscale network,
 triggering authentication if necessary.
 
 With no flags, "tailscale up" brings the network online without
 changing any settings. (That is, it's the opposite of "tailscale
 down").
 
 If flags are specified, the flags must be the complete set of desired
 settings. An error is returned if any setting would be changed as a
 result of an unspecified flag's default value, unless the --reset flag
 is also used. (The flags --auth-key, --force-reauth, and --qr are not
 considered settings that need to be re-specified when modifying
 settings.)
 
 FLAGS
   --accept-dns, --accept-dns=false
     	accept DNS configuration from the admin panel (default true)
   --accept-risk string
     	accept risk and skip confirmation for risk types: lose-ssh,all
   --accept-routes, --accept-routes=false
     	accept routes advertised by other Tailscale nodes (default false)
   --advertise-connector, --advertise-connector=false
     	advertise this node as an app connector (default false)
   --advertise-exit-node, --advertise-exit-node=false
     	offer to be an exit node for internet traffic for the tailnet (default false)
   --advertise-routes string
     	routes to advertise to other nodes (comma-separated, e.g. "10.0.0.0/8,192.168.0.0/24") or empty string to not advertise routes
   --advertise-tags string
     	comma-separated ACL tags to request; each must start with "tag:" (e.g. "tag:eng,tag:montreal,tag:ssh")
   --auth-key string
     	node authorization key; if it begins with "file:", then it's a path to a file containing the authkey
   --exit-node string
     	Tailscale exit node (IP or base name) for internet traffic, or empty string to not use an exit node
   --exit-node-allow-lan-access, --exit-node-allow-lan-access=false
     	Allow direct access to the local network when routing traffic via an exit node (default false)
   --force-reauth, --force-reauth=false
     	force reauthentication (default false)
   --hostname string
     	hostname to use instead of the one provided by the OS
   --json, --json=false
     	output in JSON format (WARNING: format subject to change) (default false)
   --login-server string
     	base URL of control server (default https://controlplane.tailscale.com)
   --operator string
     	Unix username to allow to operate on tailscaled without sudo
   --qr, --qr=false
     	show QR code for login URLs (default false)
   --reset, --reset=false
     	reset unspecified settings to their default values (default false)
   --shields-up, --shields-up=false
     	don't allow incoming connections (default false)
   --ssh, --ssh=false
     	run an SSH server, permitting access per tailnet admin's declared policy (default false)
   --timeout duration
     	maximum amount of time to wait for tailscaled to enter a Running state; default (0s) blocks forever (default 0s)
 ===
+Disconnect from Tailscale
+
 USAGE
-  down
+  tailscale down
 
 FLAGS
   --accept-risk string
     	accept risk and skip confirmation for risk types: lose-ssh,all
 ===
+Change specified preferences
+
 USAGE
-  set [flags]
+  tailscale set [flags]
 
 "tailscale set" allows changing specific preferences.
 
 Unlike "tailscale up", this command does not require the complete set of desired settings.
 
 Only settings explicitly mentioned will be set. There are no default values.
 
 FLAGS
   --accept-dns, --accept-dns=false
     	accept DNS configuration from the admin panel
   --accept-risk string
     	accept risk and skip confirmation for risk types: lose-ssh,all
   --accept-routes, --accept-routes=false
     	accept routes advertised by other Tailscale nodes
   --advertise-connector, --advertise-connector=false
     	offer to be an app connector for domain specific internet traffic for the tailnet
   --advertise-exit-node, --advertise-exit-node=false
     	offer to be an exit node for internet traffic for the tailnet
   --advertise-routes string
     	routes to advertise to other nodes (comma-separated, e.g. "10.0.0.0/8,192.168.0.0/24") or empty string to not advertise routes
   --auto-update, --auto-update=false
     	automatically update to the latest available version
   --exit-node string
     	Tailscale exit node (IP or base name) for internet traffic, or empty string to not use an exit node
   --exit-node-allow-lan-access, --exit-node-allow-lan-access=false
     	Allow direct access to the local network when routing traffic via an exit node
   --hostname string
     	hostname to use instead of the one provided by the OS
   --nickname string
     	nickname for the current account
   --operator string
     	Unix username to allow to operate on tailscaled without sudo
   --shields-up, --shields-up=false
     	don't allow incoming connections
   --ssh, --ssh=false
     	run an SSH server, permitting access per tailnet admin's declared policy
   --update-check, --update-check=false
     	notify about available Tailscale updates
   --webclient, --webclient=false
     	expose the web interface for managing this node over Tailscale at port 5252
 ===
+Log in to a Tailscale account
+
 USAGE
-  login [flags]
+  tailscale login [flags]
 
 "tailscale login" logs this machine in to your Tailscale network.
 This command is currently in alpha and may change in the future.
 
 FLAGS
   --accept-dns, --accept-dns=false
     	accept DNS configuration from the admin panel (default true)
   --accept-routes, --accept-routes=false
     	accept routes advertised by other Tailscale nodes (default false)
   --advertise-connector, --advertise-connector=false
     	advertise this node as an app connector (default false)
   --advertise-exit-node, --advertise-exit-node=false
     	offer to be an exit node for internet traffic for the tailnet (default false)
   --advertise-routes string
     	routes to advertise to other nodes (comma-separated, e.g. "10.0.0.0/8,192.168.0.0/24") or empty string to not advertise routes
   --advertise-tags string
     	comma-separated ACL tags to request; each must start with "tag:" (e.g. "tag:eng,tag:montreal,tag:ssh")
   --auth-key string
     	node authorization key; if it begins with "file:", then it's a path to a file containing the authkey
   --exit-node string
     	Tailscale exit node (IP or base name) for internet traffic, or empty string to not use an exit node
   --exit-node-allow-lan-access, --exit-node-allow-lan-access=false
     	Allow direct access to the local network when routing traffic via an exit node (default false)
   --hostname string
     	hostname to use instead of the one provided by the OS
   --login-server string
     	base URL of control server (default https://controlplane.tailscale.com)
   --nickname string
     	short name for the account
   --operator string
     	Unix username to allow to operate on tailscaled without sudo
   --qr, --qr=false
     	show QR code for login URLs (default false)
   --shields-up, --shields-up=false
     	don't allow incoming connections (default false)
   --ssh, --ssh=false
     	run an SSH server, permitting access per tailnet admin's declared policy (default false)
   --timeout duration
     	maximum amount of time to wait for tailscaled to enter a Running state; default (0s) blocks forever (default 0s)
 ===
+Disconnect from Tailscale and expire current node key
+
 USAGE
-  logout [flags]
+  tailscale logout
 
 "tailscale logout" brings the network down and invalidates
 the current node key, forcing a future use of it to cause
 a reauthentication.
 ===
+Switches to a different Tailscale account
+
 USAGE
-  switch <id>
-  switch --list
+  tailscale switch <id>
 
 "tailscale switch" switches between logged in accounts. You can
 use the ID that's returned from 'tailnet switch -list'
 to pick which profile you want to switch to. Alternatively, you
 can use the Tailnet or the account names to switch as well.
 
 This command is currently in alpha and may change in the future.
+
+FLAGS
+  --list, --list=false
+    	list available accounts (default false)
 ===
+[ALPHA] Configure the host to enable more Tailscale features
+
 USAGE
-  configure
+  tailscale configure <subcommand>
 
 The 'configure' set of commands are intended to provide a way to enable different
 services on the host to use Tailscale in more ways.
 
 SUBCOMMANDS
   kubeconfig  [ALPHA] Connect to a Kubernetes cluster using a Tailscale Auth Proxy
 ===
-DESCRIPTION
-  [ALPHA] Connect to a Kubernetes cluster using a Tailscale Auth Proxy
+[ALPHA] Connect to a Kubernetes cluster using a Tailscale Auth Proxy
 
 USAGE
-  kubeconfig <hostname-or-fqdn>
+  tailscale configure kubeconfig <hostname-or-fqdn>
 
 Run this command to configure kubectl to connect to a Kubernetes cluster over Tailscale.
 
 The hostname argument should be set to the Tailscale hostname of the peer running as an auth proxy in the cluster.
 
 See: https://tailscale.com/s/k8s-auth-proxy
-
 ===
+Print an analysis of local network conditions
+
 USAGE
-  netcheck
+  tailscale netcheck
 
 FLAGS
   --every duration
     	if non-zero, do an incremental report with the given frequency (default 0s)
   --format string
     	output format; empty (for human-readable), "json" or "json-line"
   --verbose, --verbose=false
     	verbose logs (default false)
 ===
+Show Tailscale IP addresses
+
 USAGE
-  ip [-1] [-4] [-6] [peer hostname or ip address]
+  tailscale ip [-1] [-4] [-6] [peer hostname or ip address]
 
 Show Tailscale IP addresses for peer. Peer defaults to the current machine.
 
 FLAGS
   --1, --1=false
     	only print one IP address (default false)
   --4, --4=false
     	only print IPv4 address (default false)
   --6, --6=false
     	only print IPv6 address (default false)
 ===
+Show state of tailscaled and its connections
+
 USAGE
-  status [--active] [--web] [--json]
+  tailscale status [--active] [--web] [--json]
 
 JSON FORMAT
 
 Warning: this format has changed between releases and might change more
 in the future.
 
 For a description of the fields, see the "type Status" declaration at:
 
 https://github.com/tailscale/tailscale/blob/main/ipn/ipnstate/ipnstate.go
 
 (and be sure to select branch/tag that corresponds to the version
  of Tailscale you're running)
 
 FLAGS
   --active, --active=false
     	filter output to only peers with active sessions (not applicable to web mode) (default false)
   --browser, --browser=false
     	Open a browser in web mode (default true)
   --json, --json=false
     	output in JSON format (WARNING: format subject to change) (default false)
   --listen string
     	listen address for web mode; use port 0 for automatic (default 127.0.0.1:8384)
   --peers, --peers=false
     	show status of peers (default true)
   --self, --self=false
     	show status of local machine (default true)
   --web, --web=false
     	run webserver with HTML showing status (default false)
 ===
+Ping a host at the Tailscale layer, see how it routed
+
 USAGE
-  ping <hostname-or-IP>
+  tailscale ping <hostname-or-IP>
 
 The 'tailscale ping' command pings a peer node from the Tailscale layer
 and reports which route it took for each response. The first ping or
 so will likely go over DERP (Tailscale's TCP relay protocol) while NAT
 traversal finds a direct path through.
 
 If 'tailscale ping' works but a normal ping does not, that means one
 side's operating system firewall is blocking packets; 'tailscale ping'
 does not inject packets into either side's TUN devices.
 
 By default, 'tailscale ping' stops after 10 pings or once a direct
 (non-DERP) path has been established, whichever comes first.
 
 The provided hostname must resolve to or be a Tailscale IP
 (e.g. 100.x.y.z) or a subnet IP advertised by a Tailscale
 relay node.
 
 FLAGS
   --c int
     	max number of pings to send. 0 for infinity. (default 10)
   --icmp, --icmp=false
     	do a ICMP-level ping (through WireGuard, but not the local host OS stack) (default false)
   --peerapi, --peerapi=false
     	try hitting the peer's peerapi HTTP server (default false)
   --size int
     	size of the ping message (disco pings only). 0 for minimum size. (default 0)
   --timeout duration
     	timeout before giving up on a ping (default 5s)
   --tsmp, --tsmp=false
     	do a TSMP-level ping (through WireGuard, but not either host OS stack) (default false)
   --until-direct, --until-direct=false
     	stop once a direct path is established (default true)
   --verbose, --verbose=false
     	verbose output (default false)
 ===
+Connect to a port on a host, connected to stdin/stdout
+
 USAGE
-  nc <hostname-or-IP> <port>
+  tailscale nc <hostname-or-IP> <port>
 ===
+SSH to a Tailscale machine
+
 USAGE
-  ssh [user@]<host> [args...]
+  tailscale ssh [user@]<host> [args...]
 
 The 'tailscale ssh' command is an optional wrapper around the system 'ssh'
 command that's useful in some cases. Tailscale SSH does not require its use;
 most users running the Tailscale SSH server will prefer to just use the normal
 'ssh' command or their normal SSH client.
 
 The 'tailscale ssh' wrapper adds a few things:
 
 * It resolves the destination server name in its arguments using MagicDNS,
   even if --accept-dns=false.
 * It works in userspace-networking mode, by supplying a ProxyCommand to the
   system 'ssh' command that connects via a pipe through tailscaled.
 * It automatically checks the destination server's SSH host key against the
   node's SSH host key as advertised via the Tailscale coordination server.
 ===
+Serve content and local servers on the internet
+
 USAGE
-  funnel <target>
-  funnel status [--json]
-  funnel reset
+  tailscale funnel <target>
+  tailscale funnel status [--json]
+  tailscale funnel reset
 
 Funnel enables you to share a local server on the internet using Tailscale.
 
 To share only within your tailnet, use `tailscale serve`
 
 <target> can be a file, directory, text, or most commonly the location to a service running on the
 local machine. The location to the location service can be expressed as a port number (e.g., 3000),
 a partial URL (e.g., localhost:3000), or a full URL including a path (e.g., http://localhost:3000/foo).
 
 EXAMPLES
   - Expose an HTTP server running at 127.0.0.1:3000 in the foreground:
     $ tailscale funnel 3000
 
   - Expose an HTTP server running at 127.0.0.1:3000 in the background:
     $ tailscale funnel --bg 3000
 
   - Expose an HTTPS server with invalid or self-signed certificates at https://localhost:8443
     $ tailscale funnel https+insecure://localhost:8443
 
 For more examples and use cases visit our docs site https://tailscale.com/kb/1247/funnel-serve-use-cases
 
 SUBCOMMANDS
-  status  view current proxy configuration
-  reset   reset current serve/funnel config
+  status  View current funnel configuration
+  reset   Reset current funnel config
 
 FLAGS
   --bg, --bg=false
     	Run the command as a background process (default false)
   --https uint
     	Expose an HTTPS server at the specified port (default mode)
   --set-path string
     	Appends the specified path to the base URL for accessing the underlying service
   --tcp uint
     	Expose a TCP forwarder to forward raw TCP packets at the specified port
   --tls-terminated-tcp uint
     	Expose a TCP forwarder to forward TLS-terminated TCP packets at the specified port
   --yes, --yes=false
     	Update without interactive prompts (default false)
 ===
+View current funnel configuration
+
 USAGE
-  status
+  tailscale funnel status [--json]
 
 FLAGS
   --json, --json=false
     	output JSON (default false)
 ===
+Reset current funnel config
+
 USAGE
-  reset
+  tailscale funnel reset
 ===
+Serve content and local servers on your tailnet
+
 USAGE
-  serve <target>
-  serve status [--json]
-  serve reset
+  tailscale serve <target>
+  tailscale serve status [--json]
+  tailscale serve reset
 
 Tailscale Serve enables you to share a local server securely within your tailnet.
 
 To share a local server on the internet, use `tailscale funnel`
 
 <target> can be a file, directory, text, or most commonly the location to a service running on the
 local machine. The location to the location service can be expressed as a port number (e.g., 3000),
 a partial URL (e.g., localhost:3000), or a full URL including a path (e.g., http://localhost:3000/foo).
 
 EXAMPLES
   - Expose an HTTP server running at 127.0.0.1:3000 in the foreground:
     $ tailscale serve 3000
 
   - Expose an HTTP server running at 127.0.0.1:3000 in the background:
     $ tailscale serve --bg 3000
 
   - Expose an HTTPS server with invalid or self-signed certificates at https://localhost:8443
     $ tailscale serve https+insecure://localhost:8443
 
 For more examples and use cases visit our docs site https://tailscale.com/kb/1247/funnel-serve-use-cases
 
 SUBCOMMANDS
-  status  view current proxy configuration
-  reset   reset current serve/funnel config
+  status  View current serve configuration
+  reset   Reset current serve config
 
 FLAGS
   --bg, --bg=false
     	Run the command as a background process (default false)
   --http uint
     	Expose an HTTP server at the specified port
   --https uint
     	Expose an HTTPS server at the specified port (default mode)
   --set-path string
     	Appends the specified path to the base URL for accessing the underlying service
   --tcp uint
     	Expose a TCP forwarder to forward raw TCP packets at the specified port
   --tls-terminated-tcp uint
     	Expose a TCP forwarder to forward TLS-terminated TCP packets at the specified port
   --yes, --yes=false
     	Update without interactive prompts (default false)
 ===
+View current serve configuration
+
 USAGE
-  status
+  tailscale serve status [--json]
 
 FLAGS
   --json, --json=false
     	output JSON (default false)
 ===
+Reset current serve config
+
 USAGE
-  reset
+  tailscale serve reset
 ===
+Print Tailscale version
+
 USAGE
-  version [flags]
+  tailscale version [flags]
 
 FLAGS
   --daemon, --daemon=false
     	also print local node's daemon version (default false)
   --json, --json=false
     	output in JSON format (default false)
   --upstream, --upstream=false
     	fetch and print the latest upstream release version from pkgs.tailscale.com (default false)
 ===
+Run a web server for controlling Tailscale
+
 USAGE
-  web [flags]
+  tailscale web [flags]
 
 "tailscale web" runs a webserver for controlling the Tailscale daemon.
 
 It's primarily intended for use on Synology, QNAP, and other
 NAS devices where a web interface is the natural place to control
 Tailscale, as opposed to a CLI or a native app.
 
 FLAGS
   --cgi, --cgi=false
     	run as CGI script (default false)
   --listen string
     	listen address; use port 0 for automatic (default localhost:8088)
   --prefix string
     	URL prefix added to requests (for cgi or reverse proxies)
   --readonly, --readonly=false
     	run web UI in read-only mode (default false)
 ===
+Send or receive files
+
 USAGE
-  file <cp|get> ...
+  tailscale file <cp|get> ...
 
 SUBCOMMANDS
   cp   Copy file(s) to a host
   get  Move files out of the Tailscale file inbox
 ===
-DESCRIPTION
-  Copy file(s) to a host
+Copy file(s) to a host
 
 USAGE
-  file cp <files...> <target>:
+  tailscale file cp <files...> <target>:
 
 FLAGS
-  -name string    alternate filename to use, especially useful when <file> is "-" (stdin)
-  -targets=false  list possible file cp targets
-  -verbose=false  verbose output
-
+  --name string
+    	alternate filename to use, especially useful when <file> is "-" (stdin)
+  --targets, --targets=false
+    	list possible file cp targets (default false)
+  --verbose, --verbose=false
+    	verbose output (default false)
 ===
-DESCRIPTION
-  Move files out of the Tailscale file inbox
+Move files out of the Tailscale file inbox
 
 USAGE
-  file get [--wait] [--verbose] [--conflict=(skip|overwrite|rename)] <target-directory>
+  tailscale file get [--wait] [--verbose] [--conflict=(skip|overwrite|rename)] <target-directory>
 
 FLAGS
-  -conflict skip  behavior when a conflicting (same-named) file already exists in the target directory.
-                  skip:       skip conflicting files: leave them in the taildrop inbox and print an error. get any non-conflicting files
-                  overwrite:  overwrite existing file
-                  rename:     write to a new number-suffixed filename
-  -loop=false     run get in a loop, receiving files as they come in
-  -verbose=false  verbose output
-  -wait=false     wait for a file to arrive if inbox is empty
-
+  --conflict behavior
+    	behavior when a conflicting (same-named) file already exists in the target directory.
+    		skip:       skip conflicting files: leave them in the taildrop inbox and print an error. get any non-conflicting files
+    		overwrite:  overwrite existing file
+    		rename:     write to a new number-suffixed filename (default skip)
+  --loop, --loop=false
+    	run get in a loop, receiving files as they come in (default false)
+  --verbose, --verbose=false
+    	verbose output (default false)
+  --wait, --wait=false
+    	wait for a file to arrive if inbox is empty (default false)
 ===
+Print a shareable identifier to help diagnose issues
+
 USAGE
-  bugreport [note]
+  tailscale bugreport [note]
 
 FLAGS
   --diagnose, --diagnose=false
     	run additional in-depth checks (default false)
   --record, --record=false
     	if true, pause and then write another bugreport (default false)
 ===
+Get TLS certs
+
 USAGE
-  cert [flags] <domain>
+  tailscale cert [flags] <domain>
 
 FLAGS
   --cert-file string
     	output cert file or "-" for stdout; defaults to DOMAIN.crt if --cert-file and --key-file are both unset
   --key-file string
     	output key file or "-" for stdout; defaults to DOMAIN.key if --cert-file and --key-file are both unset
   --serve-demo, --serve-demo=false
     	if true, serve on port :443 using the cert as a demo, instead of writing out the files to disk (default false)
 ===
+Manage tailnet lock
+
 USAGE
-  lock <sub-command> <arguments>
+  tailscale lock <sub-command> <arguments>
 
 Manage tailnet lock
 
 SUBCOMMANDS
   init             Initialize tailnet lock
   status           Outputs the state of tailnet lock
   add              Adds one or more trusted signing keys to tailnet lock
   remove           Removes one or more trusted signing keys from tailnet lock
   sign             Signs a node or pre-approved auth key
   disable          Consumes a disablement secret to shut down tailnet lock for the tailnet
   disablement-kdf  Computes a disablement value from a disablement secret (advanced users only)
   log              List changes applied to tailnet lock
   local-disable    Disables tailnet lock for this node only
   revoke-keys      Revoke compromised tailnet-lock keys
 ===
-DESCRIPTION
-  Initialize tailnet lock
+Initialize tailnet lock
 
 USAGE
-  init [--gen-disablement-for-support] --gen-disablements N <trusted-key>...
+  tailscale lock init [--gen-disablement-for-support] --gen-disablements N <trusted-key>...
 
 The 'tailscale lock init' command initializes tailnet lock for the
 entire tailnet. The tailnet lock keys specified are those initially
 trusted to sign nodes or to make further changes to tailnet lock.
 
 You can identify the tailnet lock key for a node you wish to trust by
 running 'tailscale lock' on that node, and copying the node's tailnet
 lock key.
 
 To disable tailnet lock, use the 'tailscale lock disable' command
 along with one of the disablement secrets.
 The number of disablement secrets to be generated is specified using the
 --gen-disablements flag. Initializing tailnet lock requires at least
 one disablement.
 
 If --gen-disablement-for-support is specified, an additional disablement secret
 will be generated and transmitted to Tailscale, which support can use to disable
 tailnet lock. We recommend setting this flag.
 
 FLAGS
-  -confirm=false                      do not prompt for confirmation
-  -gen-disablement-for-support=false  generates and transmits a disablement secret for Tailscale support
-  -gen-disablements 1                 number of disablement secrets to generate
-
+  --confirm, --confirm=false
+    	do not prompt for confirmation (default false)
+  --gen-disablement-for-support, --gen-disablement-for-support=false
+    	generates and transmits a disablement secret for Tailscale support (default false)
+  --gen-disablements int
+    	number of disablement secrets to generate (default 1)
 ===
-DESCRIPTION
-  Outputs the state of tailnet lock
+Outputs the state of tailnet lock
 
 USAGE
-  status
+  tailscale lock status
 
 Outputs the state of tailnet lock
 
 FLAGS
-  -json=false  output in JSON format (WARNING: format subject to change)
-
+  --json, --json=false
+    	output in JSON format (WARNING: format subject to change) (default false)
 ===
-DESCRIPTION
-  Adds one or more trusted signing keys to tailnet lock
+Adds one or more trusted signing keys to tailnet lock
 
 USAGE
-  add <public-key>...
+  tailscale lock add <public-key>...
 
 Adds one or more trusted signing keys to tailnet lock
-
 ===
-DESCRIPTION
-  Removes one or more trusted signing keys from tailnet lock
+Removes one or more trusted signing keys from tailnet lock
 
 USAGE
-  remove [--re-sign=false] <public-key>...
+  tailscale lock remove [--re-sign=false] <public-key>...
 
 Removes one or more trusted signing keys from tailnet lock
 
 FLAGS
-  -re-sign=true  resign signatures which would be invalidated by removal of trusted signing keys
-
+  --re-sign, --re-sign=false
+    	resign signatures which would be invalidated by removal of trusted signing keys (default true)
 ===
-DESCRIPTION
-  Signs a node or pre-approved auth key
+Signs a node or pre-approved auth key
 
 USAGE
-  sign <node-key> [<rotation-key>] or sign <auth-key>
+  tailscale lock sign <node-key> [<rotation-key>] or sign <auth-key>
 
 Either:
   - signs a node key and transmits the signature to the coordination server, or
   - signs a pre-approved auth key, printing it in a form that can be used to bring up nodes under tailnet lock
-
 ===
-DESCRIPTION
-  Consumes a disablement secret to shut down tailnet lock for the tailnet
+Consumes a disablement secret to shut down tailnet lock for the tailnet
 
 USAGE
-  disable <disablement-secret>
+  tailscale lock disable <disablement-secret>
 
 The 'tailscale lock disable' command uses the specified disablement
 secret to disable tailnet lock.
 
 If tailnet lock is re-enabled, new disablement secrets can be generated.
 
 Once this secret is used, it has been distributed
 to all nodes in the tailnet and should be considered public.
-
 ===
-DESCRIPTION
-  Computes a disablement value from a disablement secret (advanced users only)
+Computes a disablement value from a disablement secret (advanced users only)
 
 USAGE
-  disablement-kdf <hex-encoded-disablement-secret>
+  tailscale lock disablement-kdf <hex-encoded-disablement-secret>
 
 Computes a disablement value from a disablement secret (advanced users only)
-
 ===
-DESCRIPTION
-  List changes applied to tailnet lock
+List changes applied to tailnet lock
 
 USAGE
-  log [--limit N]
+  tailscale lock log [--limit N]
 
 List changes applied to tailnet lock
 
 FLAGS
-  -json=false  output in JSON format (WARNING: format subject to change)
-  -limit 50    max number of updates to list
-
+  --json, --json=false
+    	output in JSON format (WARNING: format subject to change) (default false)
+  --limit int
+    	max number of updates to list (default 50)
 ===
-DESCRIPTION
-  Disables tailnet lock for this node only
+Disables tailnet lock for this node only
 
 USAGE
-  local-disable
+  tailscale lock local-disable
 
 The 'tailscale lock local-disable' command disables tailnet lock for only
 the current node.
 
 If the current node is locked out, this does not mean that it can initiate
 connections in a tailnet with tailnet lock enabled. Rather, this means
 that the current node will accept traffic from other nodes in the tailnet
 that are locked out.
-
 ===
-DESCRIPTION
-  Revoke compromised tailnet-lock keys
+Revoke compromised tailnet-lock keys
 
 USAGE
-  revoke-keys <tailnet-lock-key>...
-  revoke-keys [--cosign] [--finish] <recovery-blob>
+  tailscale lock revoke-keys <tailnet-lock-key>...
+    revoke-keys [--cosign] [--finish] <recovery-blob>
 
 Retroactively revoke the specified tailnet lock keys (tlpub:abc).
 
 Revoked keys are prevented from being used in the future. Any nodes previously signed
 by revoked keys lose their authorization and must be signed again.
 
 Revocation is a multi-step process that requires several signing nodes to `--cosign` the revocation. Use `tailscale lock remove` instead if the key has not been compromised.
 
 1. To start, run `tailscale revoke-keys <tlpub-keys>` with the tailnet lock keys to revoke.
 2. Re-run the `--cosign` command output by `revoke-keys` on other signing nodes. Use the
    most recent command output on the next signing node in sequence.
 3. Once the number of `--cosign`s is greater than the number of keys being revoked,
    run the command one final time with `--finish` instead of `--cosign`.
 
 FLAGS
-  -cosign=false      continue generating the recovery using the tailnet lock key on this device and the provided recovery blob
-  -finish=false      finish the recovery process by transmitting the revocation
-  -fork-from string  parent AUM hash to rewrite from (advanced users only)
-
+  --cosign, --cosign=false
+    	continue generating the recovery using the tailnet lock key on this device and the provided recovery blob (default false)
+  --finish, --finish=false
+    	finish the recovery process by transmitting the revocation (default false)
+  --fork-from string
+    	parent AUM hash to rewrite from (advanced users only)
 ===
+Get open source license information
+
 USAGE
-  licenses
+  tailscale licenses
 
 Get open source license information
 ===
+Show machines on your tailnet configured as exit nodes
+
 USAGE
-  exit-node [flags]
+  tailscale exit-node <subcommand>
 
 Show machines on your tailnet configured as exit nodes
 
 SUBCOMMANDS
   list  Show exit nodes
 ===
-DESCRIPTION
-  Show exit nodes
+Show exit nodes
 
 USAGE
-  exit-node list [flags]
+  tailscale exit-node list [flags]
 
 FLAGS
-  -filter string  filter exit nodes by country
-
+  --filter string
+    	filter exit nodes by country
 ===
+Update Tailscale to the latest/different version
+
 USAGE
-  update
+  tailscale update
 
 FLAGS
   --dry-run, --dry-run=false
     	print what update would do without doing it, or prompts (default false)
   --track string
     	which track to check for updates: "stable" or "unstable" (dev); empty means same as current
   --version string
     	explicit version to update/downgrade to
   --yes, --yes=false
     	update without interactive prompts (default false)
 ===
+Show the machine and user associated with a Tailscale IP (v4 or v6)
+
 USAGE
-  whois [--json] ip[:port]
+  tailscale whois [--json] ip[:port]
 
 'tailscale whois' shows the machine and user associated with a Tailscale IP (v4 or v6).
 
 FLAGS
   --json, --json=false
     	output in JSON format (default false)
 ===
 USAGE
-  debug
+  tailscale debug [debug-flags] <subcommand>
 
 "tailscale debug" contains misc debug facilities; it is not a stable interface.
 
 SUBCOMMANDS
-  derp-map               print DERP map
-  component-logs         enable/disable debug logs for a component
-  daemon-goroutines      print tailscaled's goroutines
-  daemon-logs            watch tailscaled's server logs
-  metrics                print tailscaled's metrics
-  env                    print cmd/tailscale environment
-  stat                   stat a file
-  hostinfo               print hostinfo
-  local-creds            print how to access Tailscale LocalAPI
-  restun                 force a magicsock restun
-  rebind                 force a magicsock rebind
-  derp-set-on-demand     enable DERP on-demand mode (breaks reachability)
-  derp-unset-on-demand   disable DERP on-demand mode
-  break-tcp-conns        break any open TCP connections from the daemon
-  break-derp-conns       break any open DERP connections from the daemon
-  pick-new-derp          switch to some other random DERP home region for a short time
-  force-netmap-update    force a full no-op netmap update (for load testing)
-  reload-config          reload config
-  control-knobs          see current control knobs
-  prefs                  print prefs
-  watch-ipn              subscribe to IPN message bus
-  netmap                 print the current network map
-  via                    convert between site-specific IPv4 CIDRs and IPv6 'via' routes
-  ts2021                 debug ts2021 protocol connectivity
-  set-expire             manipulate node key expiry for testing
-  dev-store-set          set a key/value pair during development
-  derp                   test a DERP configuration
-  capture                streams pcaps for debugging
-  portmap                run portmap debugging
-  peer-endpoint-changes  prints debug information about a peer's endpoint changes
-  dial-types             prints debug information about connecting to a given host or IP
+  derp-map               Print DERP map
+  component-logs         Enable/disable debug logs for a component
+  daemon-goroutines      Print tailscaled's goroutines
+  daemon-logs            Watch tailscaled's server logs
+  metrics                Print tailscaled's metrics
+  env                    Print cmd/tailscale environment
+  stat                   Stat a file
+  hostinfo               Print hostinfo
+  local-creds            Print how to access Tailscale LocalAPI
+  restun                 Force a magicsock restun
+  rebind                 Force a magicsock rebind
+  derp-set-on-demand     Enable DERP on-demand mode (breaks reachability)
+  derp-unset-on-demand   Disable DERP on-demand mode
+  break-tcp-conns        Break any open TCP connections from the daemon
+  break-derp-conns       Break any open DERP connections from the daemon
+  pick-new-derp          Switch to some other random DERP home region for a short time
+  force-netmap-update    Force a full no-op netmap update (for load testing)
+  reload-config          Reload config
+  control-knobs          See current control knobs
+  prefs                  Print prefs
+  watch-ipn              Subscribe to IPN message bus
+  netmap                 Print the current network map
+  via                    Convert between site-specific IPv4 CIDRs and IPv6 'via' routes
+  ts2021                 Debug ts2021 protocol connectivity
+  set-expire             Manipulate node key expiry for testing
+  dev-store-set          Set a key/value pair during development
+  derp                   Test a DERP configuration
+  capture                Streams pcaps for debugging
+  portmap                Run portmap debugging
+  peer-endpoint-changes  Prints debug information about a peer's endpoint changes
+  dial-types             Prints debug information about connecting to a given host or IP
 
 FLAGS
   --cpu-profile string
     	if non-empty, grab a CPU profile for --profile-seconds seconds and write it to this file; - for stdout
   --file string
     	get, delete:NAME, or NAME
   --mem-profile string
     	if non-empty, grab a memory profile and write it to this file; - for stdout
   --profile-seconds int
     	number of seconds to run a CPU profile for, when --cpu-profile is non-empty (default 15)
 ===
-DESCRIPTION
-  print DERP map
+Print DERP map
 
 USAGE
-  derp-map
-
+  tailscale debug derp-map
 ===
-DESCRIPTION
-  enable/disable debug logs for a component
+Enable/disable debug logs for a component
 
 USAGE
   tailscale debug component-logs [magicsock|sockstats]
 
 FLAGS
-  -for 1h0m0s  how long to enable debug logs for; zero or negative means to disable
-
+  --for duration
+    	how long to enable debug logs for; zero or negative means to disable (default 1h0m0s)
 ===
-DESCRIPTION
-  print tailscaled's goroutines
+Print tailscaled's goroutines
 
 USAGE
-  daemon-goroutines
-
+  tailscale debug daemon-goroutines
 ===
-DESCRIPTION
-  watch tailscaled's server logs
+Watch tailscaled's server logs
 
 USAGE
-  daemon-logs
+  tailscale debug daemon-logs
 
 FLAGS
-  -time=false  include client time
-  -verbose 0   verbosity level
-
+  --time, --time=false
+    	include client time (default false)
+  --verbose int
+    	verbosity level (default 0)
 ===
-DESCRIPTION
-  print tailscaled's metrics
+Print tailscaled's metrics
 
 USAGE
-  metrics
+  tailscale debug metrics
 
 FLAGS
-  -watch=false  print JSON dump of delta values
-
+  --watch, --watch=false
+    	print JSON dump of delta values (default false)
 ===
-DESCRIPTION
-  print cmd/tailscale environment
+Print cmd/tailscale environment
 
 USAGE
-  env
-
+  tailscale debug env
 ===
-DESCRIPTION
-  stat a file
+Stat a file
 
 USAGE
-  stat
-
+  tailscale debug stat <files...>
 ===
-DESCRIPTION
-  print hostinfo
+Print hostinfo
 
 USAGE
-  hostinfo
-
+  tailscale debug hostinfo
 ===
-DESCRIPTION
-  print how to access Tailscale LocalAPI
+Print how to access Tailscale LocalAPI
 
 USAGE
-  local-creds
-
+  tailscale debug local-creds
 ===
-DESCRIPTION
-  force a magicsock restun
+Force a magicsock restun
 
 USAGE
-  restun
-
+  tailscale debug restun
 ===
-DESCRIPTION
-  force a magicsock rebind
+Force a magicsock rebind
 
 USAGE
-  rebind
-
+  tailscale debug rebind
 ===
-DESCRIPTION
-  enable DERP on-demand mode (breaks reachability)
+Enable DERP on-demand mode (breaks reachability)
 
 USAGE
-  derp-set-on-demand
-
+  tailscale debug derp-set-on-demand
 ===
-DESCRIPTION
-  disable DERP on-demand mode
+Disable DERP on-demand mode
 
 USAGE
-  derp-unset-on-demand
-
+  tailscale debug derp-unset-on-demand
 ===
-DESCRIPTION
-  break any open TCP connections from the daemon
+Break any open TCP connections from the daemon
 
 USAGE
-  break-tcp-conns
-
+  tailscale debug break-tcp-conns
 ===
-DESCRIPTION
-  break any open DERP connections from the daemon
+Break any open DERP connections from the daemon
 
 USAGE
-  break-derp-conns
-
+  tailscale debug break-derp-conns
 ===
-DESCRIPTION
-  switch to some other random DERP home region for a short time
+Switch to some other random DERP home region for a short time
 
 USAGE
-  pick-new-derp
-
+  tailscale debug pick-new-derp
 ===
-DESCRIPTION
-  force a full no-op netmap update (for load testing)
+Force a full no-op netmap update (for load testing)
 
 USAGE
-  force-netmap-update
-
+  tailscale debug force-netmap-update
 ===
-DESCRIPTION
-  reload config
+Reload config
 
 USAGE
-  reload-config
-
+  tailscale debug reload-config
 ===
-DESCRIPTION
-  see current control knobs
+See current control knobs
 
 USAGE
-  control-knobs
-
+  tailscale debug control-knobs
 ===
-DESCRIPTION
-  print prefs
+Print prefs
 
 USAGE
-  prefs
+  tailscale debug prefs
 
 FLAGS
-  -pretty=false  If true, pretty-print output
-
+  --pretty, --pretty=false
+    	If true, pretty-print output (default false)
 ===
-DESCRIPTION
-  subscribe to IPN message bus
+Subscribe to IPN message bus
 
 USAGE
-  watch-ipn
+  tailscale debug watch-ipn
 
 FLAGS
-  -count 0                 exit after printing this many statuses, or 0 to keep going forever
-  -initial=false           include initial status
-  -netmap=true             include netmap in messages
-  -show-private-key=false  include node private key in printed netmap
-
+  --count int
+    	exit after printing this many statuses, or 0 to keep going forever (default 0)
+  --initial, --initial=false
+    	include initial status (default false)
+  --netmap, --netmap=false
+    	include netmap in messages (default true)
+  --show-private-key, --show-private-key=false
+    	include node private key in printed netmap (default false)
 ===
-DESCRIPTION
-  print the current network map
+Print the current network map
 
 USAGE
-  netmap
+  tailscale debug netmap
 
 FLAGS
-  -show-private-key=false  include node private key in printed netmap
-
+  --show-private-key, --show-private-key=false
+    	include node private key in printed netmap (default false)
 ===
-DESCRIPTION
-  convert between site-specific IPv4 CIDRs and IPv6 'via' routes
+Convert between site-specific IPv4 CIDRs and IPv6 'via' routes
 
 USAGE
-  via
-
+  tailscale debug via <site-id> <v4-cidr>
+  tailscale debug via <v6-route>
 ===
-DESCRIPTION
-  debug ts2021 protocol connectivity
+Debug ts2021 protocol connectivity
 
 USAGE
-  ts2021
+  tailscale debug ts2021
 
 FLAGS
-  -host controlplane.tailscale.com  hostname of control plane
-  -verbose=false                    be extra verbose
-  -version 90                       protocol version
-
+  --host string
+    	hostname of control plane (default controlplane.tailscale.com)
+  --verbose, --verbose=false
+    	be extra verbose (default false)
+  --version int
+    	protocol version (default 90)
 ===
-DESCRIPTION
-  manipulate node key expiry for testing
+Manipulate node key expiry for testing
 
 USAGE
-  set-expire
+  tailscale debug set-expire --in=1m
 
 FLAGS
-  -in 0s  if non-zero, set node key to expire this duration from now
-
+  --in duration
+    	if non-zero, set node key to expire this duration from now (default 0s)
 ===
-DESCRIPTION
-  set a key/value pair during development
+Set a key/value pair during development
 
 USAGE
-  dev-store-set
+  tailscale debug dev-store-set
 
 FLAGS
-  -danger=false  accept danger
-
+  --danger, --danger=false
+    	accept danger (default false)
 ===
-DESCRIPTION
-  test a DERP configuration
+Test a DERP configuration
 
 USAGE
-  derp
-
+  tailscale debug derp
 ===
-DESCRIPTION
-  streams pcaps for debugging
+Streams pcaps for debugging
 
 USAGE
-  capture
+  tailscale debug capture
 
 FLAGS
-  -o string  path to stream the pcap (or - for stdout), leave empty to start wireshark
-
+  --o string
+    	path to stream the pcap (or - for stdout), leave empty to start wireshark
 ===
-DESCRIPTION
-  run portmap debugging
+Run portmap debugging
 
 USAGE
-  portmap
+  tailscale debug portmap
 
 FLAGS
-  -duration 5s          timeout for port mapping
-  -gateway-addr string  override gateway IP (must also pass --self-addr)
-  -log-http=false       print all HTTP requests and responses to the log
-  -self-addr string     override self IP (must also pass --gateway-addr)
-  -type string          portmap debug type (one of "", "pmp", "pcp", or "upnp")
-
+  --duration duration
+    	timeout for port mapping (default 5s)
+  --gateway-addr string
+    	override gateway IP (must also pass --self-addr)
+  --log-http, --log-http=false
+    	print all HTTP requests and responses to the log (default false)
+  --self-addr string
+    	override self IP (must also pass --gateway-addr)
+  --type string
+    	portmap debug type (one of "", "pmp", "pcp", or "upnp")
 ===
-DESCRIPTION
-  prints debug information about a peer's endpoint changes
+Prints debug information about a peer's endpoint changes
 
 USAGE
-  peer-endpoint-changes
-
+  tailscale debug peer-endpoint-changes <hostname-or-IP>
 ===
-DESCRIPTION
-  prints debug information about connecting to a given host or IP
+Prints debug information about connecting to a given host or IP
 
 USAGE
-  dial-types
+  tailscale debug dial-types <hostname-or-IP> <port>
 
 FLAGS
-  -network tcp  network type to dial ("tcp", "udp", etc.)
-
+  --network string
+    	network type to dial ("tcp", "udp", etc.) (default tcp)
 ===
+Share a directory with your tailnet
+
 USAGE
-  share set <name> <path>
-  share remove <name>
-  share list
+  tailscale share set <name> <path>
+  tailscale share remove <name>
+  tailscale share list
 
 Tailscale share allows you to share directories with other machines on your tailnet.
 
 In order to share folders, your node needs to have the node attribute "drive:share".
 
 In order to access shares, your node needs to have the node attribute "drive:access".
 
 For example, to enable sharing and accessing shares for all member nodes:
 
   "nodeAttrs": [
     {
       "target": ["autogroup:member"],
       "attr": [
         "drive:share",
         "drive:access",
       ],
     }]
 
 Each share is identified by a name and points to a directory at a specific path. For example, to share the path /Users/me/Documents under the name "docs", you would run:
 
   $ tailscale share set docs /Users/me/Documents
 
 Note that the system forces share names to lowercase to avoid problems with clients that don't support case-sensitive filenames.
 
 Share names may only contain the letters a-z, underscore _, parentheses (), or spaces. Leading and trailing spaces are omitted.
 
 All Tailscale shares have a globally unique path consisting of the tailnet, the machine name and the share name. For example, if the above share was created on the machine "mylaptop" on the tailnet "mydomain.com", the share's path would be:
 
   /mydomain.com/mylaptop/docs
 
 In order to access this share, other machines on the tailnet can connect to the above path on a WebDAV server running at 100.100.100.100:8080, for example:
 
   http://100.100.100.100:8080/mydomain.com/mylaptop/docs
 
 Permissions to access shares are controlled via ACLs. For example, to give yourself read/write access and give the group "home" read-only access to the above share, use the below ACL grants:
 
   "grants": [
     {
       "src": ["mylogin@domain.com"],
       "dst": ["mylaptop's ip address"],
       "app": {
         "tailscale.com/cap/drive": [{
           "shares": ["docs"],
           "access": "rw"
         }]
       }
     },
     {
       "src": ["group:home"],
       "dst": ["mylaptop"],
       "app": {
         "tailscale.com/cap/drive": [{
           "shares": ["docs"],
           "access": "ro"
         }]
       }
     }]
 
 To categorically give yourself access to all your shares, you can use the below ACL grant:
 
   "grants": [
     {
       "src": ["autogroup:member"],
       "dst": ["autogroup:self"],
       "app": {
         "tailscale.com/cap/drive": [{
           "shares": ["*"],
           "access": "rw"
         }]
       }
     }]
 
 Whenever either you or anyone in the group "home" connects to the share, they connect as if they are using your local machine user. They'll be able to read the same files as your user and if they create files, those files will be owned by your user.
 
 If you want a share to be accessed as a different user, you can use sudo to accomplish this. For example, to create the aforementioned share as "theuser", you could run:
 
-	$ sudo -u theuser tailscale share set docs /Users/theuser/Documents
+  $ sudo -u theuser tailscale share set docs /Users/theuser/Documents
 
 You can rename shares, for example you could rename the above share by running:
 
   $ tailscale share rename docs newdocs
 
 You can remove shares by name, for example you could remove the above share by running:
 
   $ tailscale share remove newdocs
 
 You can get a list of currently published shares by running:
 
   $ tailscale share list
 
 SUBCOMMANDS
-  set     [ALPHA] set a share
-  rename  [ALPHA] rename a share
-  remove  [ALPHA] remove a share
-  list    [ALPHA] list current shares
+  set     [ALPHA] Set a share
+  rename  [ALPHA] Rename a share
+  remove  [ALPHA] Remove a share
+  list    [ALPHA] List current shares
 ===
+[ALPHA] Set a share
+
 USAGE
-  set
+  tailscale share set <name> <path>
 ===
+[ALPHA] Rename a share
+
 USAGE
-  rename
+  tailscale share rename <oldname> <newname>
 ===
+[ALPHA] Remove a share
+
 USAGE
-  remove
+  tailscale share remove <name>
 ===
+[ALPHA] List current shares
+
 USAGE
-  list
+  tailscale share list
```