### PR TITLE
ipn,cmd/tailscale,client/tailscale: add support for renaming TailFS s…

### DIFF
--- a/client/tailscale/localclient.go
+++ b/client/tailscale/localclient.go
@@ -1426,10 +1426,10 @@ func (lc *LocalClient) TailFSSetFileServerAddr(ctx context.Context, addr string)
 	return err
 }
 
-// TailFSShareAdd adds the given share to the list of shares that TailFS will
-// serve to remote nodes. If a share with the same name already exists, the
-// existing share is replaced/updated.
-func (lc *LocalClient) TailFSShareAdd(ctx context.Context, share *tailfs.Share) error {
+// TailFSShareSet adds or updates the given share in the list of shares that
+// TailFS will serve to remote nodes. If a share with the same name already
+// exists, the existing share is replaced/updated.
+func (lc *LocalClient) TailFSShareSet(ctx context.Context, share *tailfs.Share) error {
 	_, err := lc.send(ctx, "PUT", "/localapi/v0/tailfs/shares", http.StatusCreated, jsonBody(share))
 	return err
 }
@@ -1442,9 +1442,18 @@ func (lc *LocalClient) TailFSShareRemove(ctx context.Context, name string) error
 		"DELETE",
 		"/localapi/v0/tailfs/shares",
 		http.StatusNoContent,
-		jsonBody(&tailfs.Share{
-			Name: name,
-		}))
+		strings.NewReader(name))
+	return err
+}
+
+// TailFSShareRename renames the share from old to new name.
+func (lc *LocalClient) TailFSShareRename(ctx context.Context, oldName, newName string) error {
+	_, err := lc.send(
+		ctx,
+		"POST",
+		"/localapi/v0/tailfs/shares",
+		http.StatusNoContent,
+		jsonBody([2]string{oldName, newName}))
 	return err
 }
 

--- a/cmd/tailscale/cli/share.go
+++ b/cmd/tailscale/cli/share.go
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	shareAddUsage    = "share add <name> <path>"
+	shareSetUsage    = "share set <name> <path>"
+	shareRenameUsage = "share rename <oldname> <newname>"
 	shareRemoveUsage = "share remove <name>"
 	shareListUsage   = "share list"
 )
@@ -23,7 +24,7 @@ var shareCmd = &ffcli.Command{
 	Name:      "share",
 	ShortHelp: "Share a directory with your tailnet",
 	ShortUsage: strings.Join([]string{
-		shareAddUsage,
+		shareSetUsage,
 		shareRemoveUsage,
 		shareListUsage,
 	}, "\n  "),
@@ -31,9 +32,15 @@ var shareCmd = &ffcli.Command{
 	UsageFunc: usageFuncNoDefaultValues,
 	Subcommands: []*ffcli.Command{
 		{
-			Name:      "add",
-			Exec:      runShareAdd,
-			ShortHelp: "[ALPHA] add a share",
+			Name:      "set",
+			Exec:      runShareSet,
+			ShortHelp: "[ALPHA] set a share",
+			UsageFunc: usageFunc,
+		},
+		{
+			Name:      "rename",
+			ShortHelp: "[ALPHA] rename a share",
+			Exec:      runShareRename,
 			UsageFunc: usageFunc,
 		},
 		{
@@ -54,20 +61,20 @@ var shareCmd = &ffcli.Command{
 	},
 }
 
-// runShareAdd is the entry point for the "tailscale share add" command.
-func runShareAdd(ctx context.Context, args []string) error {
+// runShareSet is the entry point for the "tailscale share set" command.
+func runShareSet(ctx context.Context, args []string) error {
 	if len(args) != 2 {
-		return fmt.Errorf("usage: tailscale %v", shareAddUsage)
+		return fmt.Errorf("usage: tailscale %v", shareSetUsage)
 	}
 
 	name, path := args[0], args[1]
 
-	err := localClient.TailFSShareAdd(ctx, &tailfs.Share{
+	err := localClient.TailFSShareSet(ctx, &tailfs.Share{
 		Name: name,
 		Path: path,
 	})
 	if err == nil {
-		fmt.Printf("Added share %q at %q\n", name, path)
+		fmt.Printf("Set share %q at %q\n", name, path)
 	}
 	return err
 }
@@ -82,6 +89,21 @@ func runShareRemove(ctx context.Context, args []string) error {
 	err := localClient.TailFSShareRemove(ctx, name)
 	if err == nil {
 		fmt.Printf("Removed share %q\n", name)
+	}
+	return err
+}
+
+// runShareRename is the entry point for the "tailscale share rename" command.
+func runShareRename(ctx context.Context, args []string) error {
+	if len(args) != 2 {
+		return fmt.Errorf("usage: tailscale %v", shareRenameUsage)
+	}
+	oldName := args[0]
+	newName := args[1]
+
+	err := localClient.TailFSShareRename(ctx, oldName, newName)
+	if err == nil {
+		fmt.Printf("Renamed share %q to %q\n", oldName, newName)
 	}
 	return err
 }
@@ -148,7 +170,7 @@ For example, to enable sharing and accessing shares for all member nodes:
 
 Each share is identified by a name and points to a directory at a specific path. For example, to share the path /Users/me/Documents under the name "docs", you would run:
 
-  $ tailscale share add docs /Users/me/Documents
+  $ tailscale share set docs /Users/me/Documents
 
 Note that the system forces share names to lowercase to avoid problems with clients that don't support case-sensitive filenames.
 
@@ -202,9 +224,13 @@ To categorically give yourself access to all your shares, you can use the below 
 
 Whenever either you or anyone in the group "home" connects to the share, they connect as if they are using your local machine user. They'll be able to read the same files as your user and if they create files, those files will be owned by your user.%s
 
+You can rename shares, for example you could rename the above share by running:
+
+  $ tailscale share rename docs newdocs
+
 You can remove shares by name, for example you could remove the above share by running:
 
-  $ tailscale share remove docs
+  $ tailscale share remove newdocs
 
 You can get a list of currently published shares by running:
 
@@ -214,4 +240,4 @@ var shareLongHelpAs = `
 
 If you want a share to be accessed as a different user, you can use sudo to accomplish this. For example, to create the aforementioned share as "theuser", you could run:
 
-	$ sudo -u theuser tailscale share add docs /Users/theuser/Documents`
+	$ sudo -u theuser tailscale share set docs /Users/theuser/Documents`

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -5,16 +5,20 @@ package ipnlocal
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"net/netip"
+	"os"
 	"reflect"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"go4.org/netipx"
 	"golang.org/x/net/dns/dnsmessage"
 	"tailscale.com/appc"
@@ -25,6 +29,8 @@ import (
 	"tailscale.com/net/interfaces"
 	"tailscale.com/net/tsaddr"
 	"tailscale.com/tailcfg"
+	"tailscale.com/tailfs"
+	"tailscale.com/tailfs/tailfsimpl"
 	"tailscale.com/tsd"
 	"tailscale.com/tstest"
 	"tailscale.com/types/dnstype"
@@ -34,6 +40,7 @@ import (
 	"tailscale.com/types/netmap"
 	"tailscale.com/types/opt"
 	"tailscale.com/types/ptr"
+	"tailscale.com/types/views"
 	"tailscale.com/util/dnsname"
 	"tailscale.com/util/mak"
 	"tailscale.com/util/must"
@@ -2234,6 +2241,230 @@ func TestTCPHandlerForDst(t *testing.T) {
 				t.Error("intercepted traffic we shouldn't have")
 			} else if tt.intercept && h == nil {
 				t.Error("failed to intercept traffic we should have")
+			}
+		})
+	}
+}
+
+func TestTailFSManageShares(t *testing.T) {
+	tests := []struct {
+		name     string
+		disabled bool
+		existing []*tailfs.Share
+		add      *tailfs.Share
+		remove   string
+		rename   [2]string
+		expect   any
+	}{
+		{
+			name: "append",
+			existing: []*tailfs.Share{
+				{Name: "b"},
+				{Name: "d"},
+			},
+			add: &tailfs.Share{Name: "  E  "},
+			expect: []*tailfs.Share{
+				{Name: "b"},
+				{Name: "d"},
+				{Name: "e"},
+			},
+		},
+		{
+			name: "prepend",
+			existing: []*tailfs.Share{
+				{Name: "b"},
+				{Name: "d"},
+			},
+			add: &tailfs.Share{Name: "  A  "},
+			expect: []*tailfs.Share{
+				{Name: "a"},
+				{Name: "b"},
+				{Name: "d"},
+			},
+		},
+		{
+			name: "insert",
+			existing: []*tailfs.Share{
+				{Name: "b"},
+				{Name: "d"},
+			},
+			add: &tailfs.Share{Name: "  C  "},
+			expect: []*tailfs.Share{
+				{Name: "b"},
+				{Name: "c"},
+				{Name: "d"},
+			},
+		},
+		{
+			name: "replace",
+			existing: []*tailfs.Share{
+				{Name: "b", Path: "i"},
+				{Name: "d"},
+			},
+			add: &tailfs.Share{Name: "  B  ", Path: "ii"},
+			expect: []*tailfs.Share{
+				{Name: "b", Path: "ii"},
+				{Name: "d"},
+			},
+		},
+		{
+			name:   "add_bad_name",
+			add:    &tailfs.Share{Name: "$"},
+			expect: ErrInvalidShareName,
+		},
+		{
+			name:     "add_disabled",
+			disabled: true,
+			add:      &tailfs.Share{Name: "a"},
+			expect:   ErrTailFSNotEnabled,
+		},
+		{
+			name: "remove",
+			existing: []*tailfs.Share{
+				{Name: "a"},
+				{Name: "b"},
+				{Name: "c"},
+			},
+			remove: "b",
+			expect: []*tailfs.Share{
+				{Name: "a"},
+				{Name: "c"},
+			},
+		},
+		{
+			name: "remove_non_existing",
+			existing: []*tailfs.Share{
+				{Name: "a"},
+				{Name: "b"},
+				{Name: "c"},
+			},
+			remove: "D",
+			expect: os.ErrNotExist,
+		},
+		{
+			name:     "remove_disabled",
+			disabled: true,
+			remove:   "b",
+			expect:   ErrTailFSNotEnabled,
+		},
+		{
+			name: "rename",
+			existing: []*tailfs.Share{
+				{Name: "a"},
+				{Name: "b"},
+			},
+			rename: [2]string{"a", "  C  "},
+			expect: []*tailfs.Share{
+				{Name: "b"},
+				{Name: "c"},
+			},
+		},
+		{
+			name: "rename_not_exist",
+			existing: []*tailfs.Share{
+				{Name: "a"},
+				{Name: "b"},
+			},
+			rename: [2]string{"d", "c"},
+			expect: os.ErrNotExist,
+		},
+		{
+			name: "rename_exists",
+			existing: []*tailfs.Share{
+				{Name: "a"},
+				{Name: "b"},
+			},
+			rename: [2]string{"a", "b"},
+			expect: os.ErrExist,
+		},
+		{
+			name:   "rename_bad_name",
+			rename: [2]string{"a", "$"},
+			expect: ErrInvalidShareName,
+		},
+		{
+			name:     "rename_disabled",
+			disabled: true,
+			rename:   [2]string{"a", "c"},
+			expect:   ErrTailFSNotEnabled,
+		},
+	}
+
+	tailfs.DisallowShareAs = true
+	t.Cleanup(func() {
+		tailfs.DisallowShareAs = false
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := newTestBackend(t)
+			b.mu.Lock()
+			if tt.existing != nil {
+				b.tailFSSetSharesLocked(tt.existing)
+			}
+			if !tt.disabled {
+				self := b.netMap.SelfNode.AsStruct()
+				self.CapMap = tailcfg.NodeCapMap{tailcfg.NodeAttrsTailFSShare: nil}
+				b.netMap.SelfNode = self.View()
+				b.sys.Set(tailfsimpl.NewFileSystemForRemote(b.logf))
+			}
+			b.mu.Unlock()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			t.Cleanup(cancel)
+
+			result := make(chan views.SliceView[*tailfs.Share, tailfs.ShareView], 1)
+
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go b.WatchNotifications(
+				ctx,
+				0,
+				func() { wg.Done() },
+				func(n *ipn.Notify) bool {
+					select {
+					case result <- n.TailFSShares:
+					default:
+						//
+					}
+					return false
+				},
+			)
+			wg.Wait()
+
+			var err error
+			switch {
+			case tt.add != nil:
+				err = b.TailFSSetShare(tt.add)
+			case tt.remove != "":
+				err = b.TailFSRemoveShare(tt.remove)
+			default:
+				err = b.TailFSRenameShare(tt.rename[0], tt.rename[1])
+			}
+
+			switch e := tt.expect.(type) {
+			case error:
+				if !errors.Is(err, e) {
+					t.Errorf("expected error, want: %v got: %v", e, err)
+				}
+			case []*tailfs.Share:
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				} else {
+					r := <-result
+
+					got, err := json.MarshalIndent(r, "", "  ")
+					if err != nil {
+						t.Fatalf("can't marshal got: %v", err)
+					}
+					want, err := json.MarshalIndent(e, "", "  ")
+					if err != nil {
+						t.Fatalf("can't marshal want: %v", err)
+					}
+					if diff := cmp.Diff(string(got), string(want)); diff != "" {
+						t.Errorf("wrong shares; (-got+want):%v", diff)
+					}
+				}
 			}
 		})
 	}

--- a/ipn/ipnlocal/tailfs_test.go
+++ b/ipn/ipnlocal/tailfs_test.go
@@ -20,11 +20,11 @@ func TestNormalizeShareName(t *testing.T) {
 		},
 		{
 			name: "",
-			err:  errInvalidShareName,
+			err:  ErrInvalidShareName,
 		},
 		{
 			name: "generally good except for .",
-			err:  errInvalidShareName,
+			err:  ErrInvalidShareName,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
…hares

- Updates API to support renaming TailFS shares.
- Adds a CLI rename subcommand for renaming a share.
- Renames the CLI subcommand 'add' to 'set' to make it clear that this is an add or update.
- Adds a unit test for TailFS in ipnlocal

Updates tailscale/corp#16827