### PR TITLE
version/mkversion: enforce synology versions within int32 range

### DIFF
--- a/version/mkversion/mkversion.go
+++ b/version/mkversion/mkversion.go
@@ -251,8 +251,13 @@ func mkOutput(v verInfo) (VersionInfo, error) {
 		GitDate: fmt.Sprintf("%s", v.date),
 		Track:   track,
 		Synology: map[int]int64{
-			6: 6*1_000_000_000 + int64(v.major-1)*1_000_000 + int64(v.minor)*1_000 + int64(v.patch),
-			7: 7*1_000_000_000 + int64(v.major-1)*1_000_000 + int64(v.minor)*1_000 + int64(v.patch),
+			// Synology requires that version numbers be in a specific format.
+			// Builds with version numbers that don't start with "60" or "70" will fail,
+			// and the full version number must be within int32 range.
+			// So, we do the following mapping from our Tailscale version to Synology version,
+			// giving major version three decimal places, minor version three, and patch two.
+			6: 6*100_000_000 + int64(v.major-1)*1_000_000 + int64(v.minor)*1_000 + int64(v.patch),
+			7: 7*100_000_000 + int64(v.major-1)*1_000_000 + int64(v.minor)*1_000 + int64(v.patch),
 		},
 	}
 


### PR DESCRIPTION
Synology requires version numbers are within int32 range. This change updates the version logic to keep things closer within the range, and errors on building when the range is exceeded.

Updates #cleanup