### PR TITLE
clientupdate: do not allow msiexec to reboot the OS

### DIFF
--- a/clientupdate/clientupdate.go
+++ b/clientupdate/clientupdate.go
@@ -836,7 +836,7 @@ func (up *Updater) switchOutputToFile() (io.Closer, error) {
 func (up *Updater) installMSI(msi string) error {
 	var err error
 	for tries := 0; tries < 2; tries++ {
-		cmd := exec.Command("msiexec.exe", "/i", filepath.Base(msi), "/quiet", "/promptrestart", "/qn")
+		cmd := exec.Command("msiexec.exe", "/i", filepath.Base(msi), "/quiet", "/norestart", "/qn")
 		cmd.Dir = filepath.Dir(msi)
 		cmd.Stdout = up.Stdout
 		cmd.Stderr = up.Stderr


### PR DESCRIPTION
According to
https://learn.microsoft.com/en-us/windows/win32/msi/standard-installer-command-line-options#promptrestart, `/promptrestart` is ignored with `/quiet` is set, so msiexec.exe can sometimes silently trigger a reboot. The best we can do to reduce unexpected disruption is to just prevent restarts, until the user chooses to do it. Restarts aren't normally needed for Tailscale updates, but there seem to be some situations where it's triggered.

Updates #18254