### PR TITLE
net/routetable: increase route limit used by the test

### DIFF
--- a/net/routetable/routetable_linux_test.go
+++ b/net/routetable/routetable_linux_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestGetRouteTable(t *testing.T) {
-	routes, err := Get(1000)
+	routes, err := Get(512000) // arbitrarily large
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
I was running all tests while preparing a recent stable release, and this was failing because my computer is connected to a fairly large tailnet.

```
--- FAIL: TestGetRouteTable (0.01s)
    routetable_linux_test.go:32: expected at least one default route;
    ...
```

```
$ ip route show table 52  | wc -l
1051
```

Updates #cleanup