### PR TITLE
envknob: ensure f is not nil before using it

### DIFF
--- a/envknob/envknob.go
+++ b/envknob/envknob.go
@@ -492,7 +492,11 @@ func ApplyDiskConfig() (err error) {
 	defer func() {
 		if err != nil {
 			// Stash away our return error for the healthcheck package to use.
-			applyDiskConfigErr = fmt.Errorf("error parsing %s: %w", f.Name(), err)
+			if f != nil {
+				applyDiskConfigErr = fmt.Errorf("error parsing %s: %w", f.Name(), err)
+			} else {
+				applyDiskConfigErr = fmt.Errorf("error applying disk config: %w", err)
+			}
 		}
 	}()
 


### PR DESCRIPTION
This PR fixes a panic that I saw in the mac app where parsing the env file fails but we don't get to see the error due to the panic of using f.Name()

Fixes #11425