### PR TITLE
types/views: optimize slices contains under some conditions

### DIFF
--- a/types/views/views.go
+++ b/types/views/views.go
@@ -274,8 +274,8 @@ func (v Slice[T]) IndexFunc(f func(T) bool) int {
 //
 // As it runs in O(n) time, use with care.
 func (v Slice[T]) ContainsFunc(f func(T) bool) bool {
-	for i := 0; i < v.Len(); i++ {
-		if f(v.At(i)) {
+	for _, x := range v.ж {
+		if f(x) {
 			return true
 		}
 	}
@@ -286,8 +286,8 @@ func (v Slice[T]) ContainsFunc(f func(T) bool) bool {
 //
 // As it runs in O(n) time, use with care.
 func SliceContains[T comparable](v Slice[T], e T) bool {
-	for i := 0; i < v.Len(); i++ {
-		if v.At(i) == e {
+	for _, x := range v.ж {
+		if x == e {
 			return true
 		}
 	}
@@ -296,8 +296,8 @@ func SliceContains[T comparable](v Slice[T], e T) bool {
 
 // SliceContainsFunc reports whether f reports true for any element in v.
 func SliceContainsFunc[T any](v Slice[T], f func(T) bool) bool {
-	for i := 0; i < v.Len(); i++ {
-		if f(v.At(i)) {
+	for _, x := range v.ж {
+		if f(x) {
 			return true
 		}
 	}


### PR DESCRIPTION
In control there are conditions where the leaf functions are not being optimized away (i.e. At is not inlined), resulting in undesirable time spent copying during SliceContains. This optimization is likely irrelevant to simpler code or smaller structures.

Updates #optimization