### PR TITLE
cmd/tailscale/cli: fix configuring partially empty kubeconfig (cherry-pick for 1.62)

### DIFF
--- a/cmd/tailscale/cli/configure-kube.go
+++ b/cmd/tailscale/cli/configure-kube.go
@@ -119,7 +119,7 @@ func updateKubeconfig(cfgYaml []byte, fqdn string) ([]byte, error) {
 
 	var clusters []any
 	if cm, ok := cfg["clusters"]; ok {
-		clusters = cm.([]any)
+		clusters, _ = cm.([]any)
 	}
 	cfg["clusters"] = appendOrSetNamed(clusters, fqdn, map[string]any{
 		"name": fqdn,
@@ -130,7 +130,7 @@ func updateKubeconfig(cfgYaml []byte, fqdn string) ([]byte, error) {
 
 	var users []any
 	if um, ok := cfg["users"]; ok {
-		users = um.([]any)
+		users, _ = um.([]any)
 	}
 	cfg["users"] = appendOrSetNamed(users, "tailscale-auth", map[string]any{
 		// We just need one of these, and can reuse it for all clusters.
@@ -144,7 +144,7 @@ func updateKubeconfig(cfgYaml []byte, fqdn string) ([]byte, error) {
 
 	var contexts []any
 	if cm, ok := cfg["contexts"]; ok {
-		contexts = cm.([]any)
+		contexts, _ = cm.([]any)
 	}
 	cfg["contexts"] = appendOrSetNamed(contexts, fqdn, map[string]any{
 		"name": fqdn,

--- a/cmd/tailscale/cli/configure-kube_test.go
+++ b/cmd/tailscale/cli/configure-kube_test.go
@@ -53,6 +53,31 @@ users:
     token: unused`,
 		},
 		{
+			name: "all configs, clusters, users have been deleted",
+			in: `apiVersion: v1
+clusters: null
+contexts: null
+kind: Config
+current-context: some-non-existent-cluster
+users: null`,
+			want: `apiVersion: v1
+clusters:
+- cluster:
+    server: https://foo.tail-scale.ts.net
+  name: foo.tail-scale.ts.net
+contexts:
+- context:
+    cluster: foo.tail-scale.ts.net
+    user: tailscale-auth
+  name: foo.tail-scale.ts.net
+current-context: foo.tail-scale.ts.net
+kind: Config
+users:
+- name: tailscale-auth
+  user:
+    token: unused`,
+		},
+		{
 			name: "already-configured",
 			in: `apiVersion: v1
 clusters:


### PR DESCRIPTION
This PR cherry-picks https://github.com/tailscale/tailscale/pull/11417 to release-1.62 branch to be released as part of a 1.62 patch.

Updates tailscale/corp#18320