### PR TITLE
wgengine: fix logger data race in tests

### DIFF
--- a/wgengine/userspace_ext_test.go
+++ b/wgengine/userspace_ext_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tailscale/wireguard-go/tun"
 	"tailscale.com/net/tstun"
 	"tailscale.com/tsd"
+	"tailscale.com/tstest"
 	"tailscale.com/types/logger"
 	"tailscale.com/wgengine"
 	"tailscale.com/wgengine/netstack"
@@ -17,7 +18,10 @@ import (
 
 func TestIsNetstack(t *testing.T) {
 	sys := new(tsd.System)
-	e, err := wgengine.NewUserspaceEngine(t.Logf, wgengine.Config{SetSubsystem: sys.Set})
+	e, err := wgengine.NewUserspaceEngine(
+		tstest.WhileTestRunningLogger(t),
+		wgengine.Config{SetSubsystem: sys.Set},
+	)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Observed in:
    https://github.com/tailscale/tailscale/actions/runs/8350904950/job/22858266932?pr=11463

Updates #11226

Change-Id: I9b57db4b34b6ad91d240cd9fa7e344fc0376d52d