### PR TITLE
control/controlclient: do not alias peer CapMap

### DIFF
--- a/control/controlclient/map.go
+++ b/control/controlclient/map.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net"
 	"reflect"
 	"slices"
@@ -668,14 +669,14 @@ func peerChangeDiff(was tailcfg.NodeView, n *tailcfg.Node) (_ *tailcfg.PeerChang
 				if n.CapMap == nil {
 					pc().CapMap = make(tailcfg.NodeCapMap)
 				} else {
-					pc().CapMap = n.CapMap
+					pc().CapMap = maps.Clone(n.CapMap)
 				}
 				break
 			}
 			was.CapMap().Range(func(k tailcfg.NodeCapability, v views.Slice[tailcfg.RawMessage]) bool {
 				nv, ok := n.CapMap[k]
 				if !ok || !views.SliceEqual(v, views.SliceOf(nv)) {
-					pc().CapMap = n.CapMap
+					pc().CapMap = maps.Clone(n.CapMap)
 					return false
 				}
 				return true

--- a/control/controlclient/map_test.go
+++ b/control/controlclient/map_test.go
@@ -866,6 +866,11 @@ func TestPeerChangeDiff(t *testing.T) {
 			b:    &tailcfg.Node{ID: 1, CapMap: tailcfg.NodeCapMap{}},
 			want: &tailcfg.PeerChange{NodeID: 1, CapMap: tailcfg.NodeCapMap{}},
 		}, {
+			name: "patch-capmap-remove-as-nil",
+			a:    &tailcfg.Node{ID: 1, CapMap: tailcfg.NodeCapMap{tailcfg.CapabilityAdmin: nil}},
+			b:    &tailcfg.Node{ID: 1},
+			want: &tailcfg.PeerChange{NodeID: 1, CapMap: tailcfg.NodeCapMap{}},
+		}, {
 			name: "patch-capmap-add-key-to-empty-map",
 			a:    &tailcfg.Node{ID: 1},
 			b:    &tailcfg.Node{ID: 1, CapMap: tailcfg.NodeCapMap{tailcfg.CapabilityAdmin: nil}},


### PR DESCRIPTION
Updates #cleanup

Change-Id: I10fd5e04310cdd7894a3caa3045b86eb0a06b6a0

Okay, this was more trivial than I initially feared it might be
cc @clairew 