### PR TITLE
Update type of installCRDs in kuberenetes-operator helm chart values

### DIFF
--- a/cmd/k8s-operator/deploy/chart/values.yaml
+++ b/cmd/k8s-operator/deploy/chart/values.yaml
@@ -12,7 +12,7 @@ oauth: {}
 # of chart installation. We do not use Helm's CRD installation mechanism as that
 # does not allow for upgrading CRDs.
 # https://helm.sh/docs/chart_best_practices/custom_resource_definitions/
-installCRDs: "true"
+installCRDs: true
 
 operatorConfig:
   # ACL tag that operator will be tagged with. Operator must be made owner of


### PR DESCRIPTION
Having double quotes (`"`) around the value made it appear like the helm chart should expect a string value for `installCRDs`. When updating the value to `false`, to keep the type the same I initially set it to the string `"false"`, but the chart still tried to create the CRDs. Removing the quotes fixed the issue, but I might have avoided a small inconvenience if the type was more obvious on the default.