### PR TITLE
ipn/localapi: reuse buffer for encoding JSON in serveWatchIPNBus

### DIFF
--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -1291,14 +1291,16 @@ func (h *Handler) serveWatchIPNBus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	buf := bytes.NewBuffer(nil)
 	ctx := r.Context()
 	h.b.WatchNotifications(ctx, mask, f.Flush, func(roNotify *ipn.Notify) (keepGoing bool) {
-		js, err := json.Marshal(roNotify)
+		buf.Reset()
+		err := json.NewEncoder(buf).Encode(roNotify)
 		if err != nil {
 			h.logf("json.Marshal: %v", err)
 			return false
 		}
-		if _, err := fmt.Fprintf(w, "%s\n", js); err != nil {
+		if _, err := w.Write(buf.Bytes()); err != nil {
 			return false
 		}
 		f.Flush()


### PR DESCRIPTION
Reuse a single byte buffer for JSON encoding all notifications to the same subscriber. This retains more memory, but produces less garbage.

Updates tailscale/corp#18514