### PR TITLE
ipn/localapi: don't indent status response

### DIFF
--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -1202,9 +1202,7 @@ func (h *Handler) serveStatus(w http.ResponseWriter, r *http.Request) {
 	} else {
 		st = h.b.StatusWithoutPeers()
 	}
-	e := json.NewEncoder(w)
-	e.SetIndent("", "\t")
-	e.Encode(st)
+	json.NewEncoder(w).Encode(st)
 }
 
 func (h *Handler) serveDebugPeerEndpointChanges(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Doing indented JSON marshaling results in encoding/json allocating an internal buffer, so even when encoding directly to a writer, it still generates a lot of garbage.

Updates tailscale/corp#18514