### PR TITLE
Appconnector: route identification and management prototype

### DIFF
--- a/client/tailscale/localclient.go
+++ b/client/tailscale/localclient.go
@@ -727,7 +727,7 @@ func (lc *LocalClient) EditPrefs(ctx context.Context, mp *ipn.MaskedPrefs) (*ipn
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println(decodeJSON[*ipn.Prefs](body))
+	fmt.Println(decodeJSON[*ipn.Prefs](body)) // Kevin debug
 	return decodeJSON[*ipn.Prefs](body)
 }
 

--- a/client/tailscale/localclient.go
+++ b/client/tailscale/localclient.go
@@ -727,7 +727,7 @@ func (lc *LocalClient) EditPrefs(ctx context.Context, mp *ipn.MaskedPrefs) (*ipn
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println(decodeJSON[*ipn.Prefs](body)) // Kevin debug
+	// fmt.Println(decodeJSON[*ipn.Prefs](body)) // Kevin debug
 	return decodeJSON[*ipn.Prefs](body)
 }
 

--- a/client/tailscale/localclient.go
+++ b/client/tailscale/localclient.go
@@ -727,6 +727,7 @@ func (lc *LocalClient) EditPrefs(ctx context.Context, mp *ipn.MaskedPrefs) (*ipn
 	if err != nil {
 		return nil, err
 	}
+	fmt.Println(decodeJSON[*ipn.Prefs](body))
 	return decodeJSON[*ipn.Prefs](body)
 }
 

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3223,6 +3223,13 @@ func (b *LocalBackend) setPrefsLockedOnEntry(caller string, newp *ipn.Prefs) ipn
 	if oldp.Valid() {
 		newp.Persist = oldp.Persist().AsStruct() // caller isn't allowed to override this
 	}
+	// we believe that for the purpose of figuring out advertisedRoutes setPrefsLockedOnEntry is _only_ called when
+	// up or set is used on the tailscale cli _not_ when we calculate the new advertisedRoutes field.
+	routeInfo := b.pm.CurrentRoutes()
+	routeInfo.Local = newp.AdvertiseRoutes
+	b.pm.SetCurrentRoutes(routeInfo)
+	//newp.AdvertiseRoutes = b.pm.CurrentRoutes.AsArray() (sort of thing)
+
 	// setExitNodeID returns whether it updated b.prefs, but
 	// everything in this function treats b.prefs as completely new
 	// anyway. No-op if no exit node resolution is needed.

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -355,6 +355,7 @@ func NewLocalBackend(logf logger.Logf, logID logid.PublicID, sys *tsd.System, lo
 			return nil, err
 		}
 	}
+	// Kevin comment: no need to do this since tailscaled startup will not affect routes.
 
 	envknob.LogCurrent(logf)
 	if dialer == nil {

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3141,10 +3141,12 @@ func (b *LocalBackend) PatchPrefsHandler(mp *ipn.MaskedPrefs) (ipn.PrefsView, er
 	// we believe that for the purpose of figuring out advertisedRoutes setPrefsLockedOnEntry is _only_ called when
 	// up or set is used on the tailscale cli _not_ when we calculate the new advertisedRoutes field.
 	routeInfo := b.pm.CurrentRoutes()
+	curRoutes := routeInfo.CorpAndDiscoveredAsSlice()
 	if mp.AdvertiseRoutesSet {
 		routeInfo.Local = mp.AdvertiseRoutes
 		b.pm.SetCurrentRoutes(routeInfo)
-		//newp.AdvertiseRoutes = b.pm.CurrentRoutes.AsArray() (sort of thing)
+		curRoutes := append(curRoutes, mp.AdvertiseRoutes...)
+		mp.AdvertiseRoutes = curRoutes
 	}
 	return b.EditPrefs(mp)
 }

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -5988,6 +5988,7 @@ func coveredRouteRangeNoDefault(finalRoutes []netip.Prefix, ipp netip.Prefix) bo
 // UnadvertiseRoute implements the appc.RouteAdvertiser interface. It removes
 // a route advertisement if one is present in the existing routes.
 func (b *LocalBackend) UnadvertiseRoute(toRemove ...netip.Prefix) error {
+	fmt.Println("We are unadvertising routes: ", toRemove)
 	currentRoutes := b.Prefs().AdvertiseRoutes().AsSlice()
 	finalRoutes := currentRoutes[:0]
 
@@ -5997,7 +5998,7 @@ func (b *LocalBackend) UnadvertiseRoute(toRemove ...netip.Prefix) error {
 		}
 		finalRoutes = append(finalRoutes, ipp)
 	}
-
+	fmt.Println("We are advertising these routes in unadvertising routes: ", finalRoutes)
 	_, err := b.EditPrefs(&ipn.MaskedPrefs{
 		Prefs: ipn.Prefs{
 			AdvertiseRoutes: finalRoutes,

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3562,6 +3562,8 @@ func (b *LocalBackend) reconfigAppConnectorLocked(nm *netmap.NetworkMap, prefs i
 	slices.SortFunc(routes, func(i, j netip.Prefix) int { return i.Addr().Compare(j.Addr()) })
 	domains = slices.Compact(domains)
 	routes = slices.Compact(routes)
+	fmt.Println("Connector Kevin: ", domains)
+	fmt.Println("Connector Kevin: ", routes)
 	b.appConnector.UpdateDomainsAndRoutes(domains, routes)
 }
 

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3181,6 +3181,7 @@ func (b *LocalBackend) EditPrefs(mp *ipn.MaskedPrefs) (ipn.PrefsView, error) {
 	// in setPrefsLocksOnEntry instead.
 
 	// This should return the public prefs, not the private ones.
+	fmt.Println("Editpref in local", b.pm.CurrentRoutes())
 	return stripKeysFromPrefs(newPrefs), nil
 }
 
@@ -6000,6 +6001,16 @@ func (b *LocalBackend) UnadvertiseRoute(toRemove ...netip.Prefix) error {
 		AdvertiseRoutesSet: true,
 	})
 	return err
+}
+
+func (b *LocalBackend) ReadRouteInfoFromStore() *ipn.RouteInfo {
+	b.pm.ReadRoutesForCurrentProfile()
+	return b.pm.CurrentRoutes()
+}
+
+func (b *LocalBackend) UpdateRoutesInfoToStore(newRouteInfo *ipn.RouteInfo) error {
+	b.pm.SetCurrentRoutes(newRouteInfo)
+	return nil
 }
 
 // seamlessRenewalEnabled reports whether seamless key renewals are enabled

--- a/ipn/ipnlocal/profiles.go
+++ b/ipn/ipnlocal/profiles.go
@@ -53,7 +53,10 @@ func (pm *profileManager) CurrentRoutes() *ipn.RouteInfo {
 
 func (pm *profileManager) SetCurrentRoutes(in *ipn.RouteInfo) error {
 	pm.currentRoutes = in
-	return pm.WriteRoutesForCurrentProfile()
+	if err := pm.WriteRoutesForCurrentProfile(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (pm *profileManager) WriteState(id ipn.StateKey, val []byte) error {

--- a/ipn/ipnlocal/profiles.go
+++ b/ipn/ipnlocal/profiles.go
@@ -47,6 +47,15 @@ func (pm *profileManager) dlogf(format string, args ...any) {
 	pm.logf(format, args...)
 }
 
+func (pm *profileManager) CurrentRoutes() *ipn.RouteInfo {
+	return pm.currentRoutes
+}
+
+func (pm *profileManager) SetCurrentRoutes(in *ipn.RouteInfo) error {
+	pm.currentRoutes = in
+	return pm.WriteRoutesForCurrentProfile()
+}
+
 func (pm *profileManager) WriteState(id ipn.StateKey, val []byte) error {
 	return ipn.WriteState(pm.store, id, val)
 }

--- a/ipn/ipnlocal/profiles.go
+++ b/ipn/ipnlocal/profiles.go
@@ -49,6 +49,25 @@ func (pm *profileManager) WriteState(id ipn.StateKey, val []byte) error {
 	return ipn.WriteState(pm.store, id, val)
 }
 
+func (pm *profileManager) WriteStateForCurrentProfile(id ipn.StateKey, val []byte) error {
+	var currentProfileKey ipn.StateKey
+	// TODO(fran) maybe we should error if the current profile is nil?
+	if pm.currentProfile != nil {
+		currentProfileKey = pm.currentProfile.Key
+	}
+	return ipn.WriteState(pm.store, currentProfileKey+"||"+id, val)
+}
+
+func (pm *profileManager) ReadStateForCurrentProfile(id ipn.StateKey) ([]byte, error) {
+	var currentProfileKey ipn.StateKey
+	// TODO(fran) maybe we should error if the current profile is nil?
+	if pm.currentProfile != nil {
+		currentProfileKey = pm.currentProfile.Key
+	}
+	fmt.Println(currentProfileKey)
+	return pm.store.ReadState(currentProfileKey + "||" + id)
+}
+
 // CurrentUserID returns the current user ID. It is only non-empty on
 // Windows where we have a multi-user system.
 func (pm *profileManager) CurrentUserID() ipn.WindowsUserID {

--- a/ipn/ipnlocal/profiles.go
+++ b/ipn/ipnlocal/profiles.go
@@ -65,7 +65,6 @@ func (pm *profileManager) WriteRoutesForCurrentProfile() error {
 	if err != nil {
 		return err
 	}
-
 	return pm.writeStateForCurrentProfile("_routes", routeInfoInBytes)
 }
 

--- a/ipn/ipnlocal/profiles.go
+++ b/ipn/ipnlocal/profiles.go
@@ -601,6 +601,7 @@ func newProfileManagerWithGOOS(store ipn.StateStore, logf logger.Logf, goos stri
 		} else {
 			pm.currentUserID = pm.currentProfile.LocalUserID
 		}
+		//Kevin TODO: we need to also load routing settings here.
 		prefs, err := pm.loadSavedPrefs(stateKey)
 		if err != nil {
 			return nil, err

--- a/ipn/ipnlocal/profiles_test.go
+++ b/ipn/ipnlocal/profiles_test.go
@@ -5,9 +5,11 @@ package ipnlocal
 
 import (
 	"fmt"
+	"net/netip"
 	"os/user"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -585,11 +587,11 @@ func TestFran(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = pm.WriteStateForCurrentProfile("x", []byte("hello"))
+	err = pm.writeStateForCurrentProfile("x", []byte("hello"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	bs, err := pm.ReadStateForCurrentProfile("x")
+	bs, err := pm.readStateForCurrentProfile("x")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -623,11 +625,11 @@ func TestFran(t *testing.T) {
 	pm.SetCurrentUserID("user1")
 	newProfile(t, "user1")
 
-	err = pm.WriteStateForCurrentProfile("x", []byte("hello user1"))
+	err = pm.writeStateForCurrentProfile("x", []byte("hello user1"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	bs, err = pm.ReadStateForCurrentProfile("x")
+	bs, err = pm.readStateForCurrentProfile("x")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -638,7 +640,7 @@ func TestFran(t *testing.T) {
 	}
 
 	pm.SetCurrentUserID("")
-	bs, err = pm.ReadStateForCurrentProfile("x")
+	bs, err = pm.readStateForCurrentProfile("x")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -646,5 +648,71 @@ func TestFran(t *testing.T) {
 	fmt.Println(s)
 	if s != "hello" {
 		t.Fatal("oh")
+	}
+}
+
+func TestKevin(t *testing.T) {
+	store := new(mem.Store)
+
+	pm, err := newProfileManagerWithGOOS(store, logger.Discard, "linux")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var id int
+	newProfile := func(t *testing.T, loginName string) ipn.PrefsView {
+		id++
+		t.Helper()
+		pm.NewProfile()
+		p := pm.CurrentPrefs().AsStruct()
+		p.Persist = &persist.Persist{
+			NodeID:         tailcfg.StableNodeID(fmt.Sprint(id)),
+			PrivateNodeKey: key.NewNode(),
+			UserProfile: tailcfg.UserProfile{
+				ID:        tailcfg.UserID(id),
+				LoginName: loginName,
+			},
+		}
+		if err := pm.SetPrefs(p.View(), ipn.NetworkProfile{}); err != nil {
+			t.Fatal(err)
+		}
+		return p.View()
+	}
+
+	pm.SetCurrentUserID("user1")
+	newProfile(t, "user1")
+
+	Prefix_1 := netip.MustParsePrefix("1.2.3.0/24")
+	Prefix_2 := netip.MustParsePrefix("2.3.4.5/32")
+	Prefix_3 := netip.MustParsePrefix("192.16.0.0/16")
+
+	fakeRouteInfo1 := ipn.RouteInfo{
+		Local: []netip.Prefix{Prefix_2},
+		Corp:  []netip.Prefix{Prefix_1},
+		Discovered: map[string]ipn.DatedRoute{
+			"Home.dom": {Route: Prefix_3, LastSeen: time.Now()},
+		},
+	}
+
+	fakeRouteInfo2 := ipn.RouteInfo{
+		Local: []netip.Prefix{Prefix_1},
+		Corp:  []netip.Prefix{Prefix_3},
+		Discovered: map[string]ipn.DatedRoute{
+			"Home.dom": {Route: Prefix_2, LastSeen: time.Now()},
+		},
+	}
+
+	pm.currentRoutes = &fakeRouteInfo1
+	if err := pm.WriteRoutesForCurrentProfile(); err != nil {
+		t.Fatal(err)
+	}
+
+	pm.currentRoutes = &fakeRouteInfo2
+	if err := pm.ReadRoutesForCurrentProfile(); err != nil {
+		t.Fatal(err)
+	}
+
+	if pm.currentRoutes.Corp[0] != Prefix_1 {
+		t.Fatal("That's not right")
 	}
 }

--- a/ipn/ipnlocal/profiles_test.go
+++ b/ipn/ipnlocal/profiles_test.go
@@ -707,12 +707,36 @@ func TestKevin(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	assertIsUser1Routes := func() {
+		if pm.currentRoutes.Corp[0] != Prefix_1 {
+			t.Fatal("That's not right")
+		}
+		if pm.currentRoutes.Discovered["Home.dom"].Route != Prefix_3 {
+			t.Fatal("That's not right: discovered")
+		}
+	}
+	assertIsUser2Routes := func() {
+		if pm.currentRoutes.Corp[0] != Prefix_3 {
+			t.Fatal("That's not right")
+		}
+		if pm.currentRoutes.Discovered["Home.dom"].Route != Prefix_2 {
+			t.Fatal("That's not right: discovered")
+		}
+	}
+	assertIsUser1Routes()
+
+	pm.SetCurrentUserID("user2")
+	newProfile(t, "user2")
 	pm.currentRoutes = &fakeRouteInfo2
-	if err := pm.ReadRoutesForCurrentProfile(); err != nil {
+	if err := pm.WriteRoutesForCurrentProfile(); err != nil {
 		t.Fatal(err)
 	}
+	assertIsUser2Routes()
 
-	if pm.currentRoutes.Corp[0] != Prefix_1 {
-		t.Fatal("That's not right")
-	}
+	pm.SetCurrentUserID("user1")
+	// should have read out the other route info
+	assertIsUser1Routes()
+
+	pm.SetCurrentUserID("user2")
+	assertIsUser2Routes()
 }

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -1378,7 +1378,7 @@ func (h *Handler) servePrefs(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		var err error
-		prefs, err = h.b.EditPrefs(mp)
+		prefs, err = h.b.PatchPrefsHandler(mp)
 		if err != nil {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -960,7 +960,27 @@ type RouteInfo struct {
 	Discovered map[string]DatedRoute
 }
 
-type DatedRoute struct {
-	Route    netip.Prefix
-	LastSeen time.Time
+func (r RouteInfo) UpdateRoutesInDiscoveredForDomain(domain string, addrs []netip.Prefix) {
+	newDatedRoutes := make(DatedRoute)
+	_, hasKey := r.Discovered[domain]
+	if !hasKey {
+		r.Discovered[domain] = addAddrsToDatedRoute(newDatedRoutes, addrs)
+		return
+	}
+
+	// kevin comment: we won't see any existing routes here because know addrs are filtered.
+	currentRoutes := r.Discovered[domain]
+	r.Discovered[domain] = addAddrsToDatedRoute(currentRoutes, addrs)
+	return
+}
+
+type DatedRoute = map[netip.Prefix]time.Time
+
+func addAddrsToDatedRoute(curDatedRoutes DatedRoute, addrs []netip.Prefix) DatedRoute {
+	time := time.Now()
+	ret := curDatedRoutes
+	for _, addr := range addrs {
+		ret[addr] = time
+	}
+	return ret
 }

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -16,6 +16,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"time"
 
 	"tailscale.com/atomicfile"
 	"tailscale.com/ipn/ipnstate"
@@ -951,4 +952,15 @@ type LoginProfile struct {
 	// ControlURL is the URL of the control server that this profile is logged
 	// into.
 	ControlURL string
+}
+
+type RouteInfo struct {
+	Local      []netip.Prefix
+	Corp       []netip.Prefix
+	Discovered map[string]DatedRoute
+}
+
+type DatedRoute struct {
+	Route    netip.Prefix
+	LastSeen time.Time
 }

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -974,13 +974,31 @@ func (r RouteInfo) UpdateRoutesInDiscoveredForDomain(domain string, addrs []neti
 	return
 }
 
+func (r RouteInfo) CorpAndDiscoveredAsSlice() []netip.Prefix {
+	dr := r.Corp
+	for _, routes := range r.Discovered {
+		for k := range routes {
+			dr = append(dr, k)
+		}
+	}
+	return dr
+}
+
 type DatedRoute = map[netip.Prefix]time.Time
 
-func addAddrsToDatedRoute(curDatedRoutes DatedRoute, addrs []netip.Prefix) DatedRoute {
+func addAddrsToDatedRoute(curDatedRoute DatedRoute, addrs []netip.Prefix) DatedRoute {
 	time := time.Now()
-	ret := curDatedRoutes
+	ret := curDatedRoute
 	for _, addr := range addrs {
 		ret[addr] = time
 	}
 	return ret
 }
+
+// func datedRouteToSlice(curDatedRoute DatedRoute) []netip.Prefix {
+// 	r := make([]netip.Prefix, 0, len(curDatedRoute))
+// 	for k := range curDatedRoute {
+// 		r = append(r, k)
+// 	}
+// 	return r
+// }

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -962,8 +962,8 @@ type RouteInfo struct {
 
 func (r RouteInfo) UpdateRoutesInDiscoveredForDomain(domain string, addrs []netip.Prefix) {
 	newDatedRoutes := make(DatedRoute)
-	_, hasKey := r.Discovered[domain]
-	if !hasKey {
+	val, hasKey := r.Discovered[domain]
+	if !hasKey || val == nil {
 		r.Discovered[domain] = addAddrsToDatedRoute(newDatedRoutes, addrs)
 		return
 	}

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -962,8 +962,9 @@ type RouteInfo struct {
 
 func (r RouteInfo) UpdateRoutesInDiscoveredForDomain(domain string, addrs []netip.Prefix) {
 	dr, hasKey := r.Discovered[domain]
+	fmt.Println("FRAN URIDFD", hasKey, dr, dr.Routes)
 	if !hasKey || dr == nil || dr.Routes == nil {
-		newDatedRoutes := &DatedRoute{make(map[netip.Prefix]time.Time), time.Now()}
+		newDatedRoutes := &DatedRoute{make(map[netip.Prefix]time.Time), time.Now().Truncate(1 * time.Hour)}
 		newDatedRoutes.addAddrsToDatedRoute(addrs)
 		r.Discovered[domain] = newDatedRoutes
 		return
@@ -991,6 +992,7 @@ func (r RouteInfo) OutDatedRoutesInDiscoveredForDomain(domain string) []netip.Pr
 		}
 	}
 	r.Discovered[domain] = dr
+	dr.LastCleanUp = time.Now().Truncate(1 * time.Hour)
 	return outdate
 }
 
@@ -1016,7 +1018,7 @@ func (d *DatedRoute) String() string {
 }
 
 func (d *DatedRoute) addAddrsToDatedRoute(addrs []netip.Prefix) {
-	time := time.Now()
+	time := time.Now().Truncate(1 * time.Hour)
 	for _, addr := range addrs {
 		d.Routes[addr] = time
 	}


### PR DESCRIPTION
- **add write to state store**
- **a prototype for writing and reading the route info for current profile**
- **read routes when switching profiles**
- **update currentRoutes when set is used on tailscale cli**
- **promote local routes recording to be before editprefs to avoid calling it when we didn't want to.**
- **add route storing for domain dns lookups, no domain delete yet**
- **add the ability to keep dns routes and corp routes advertised when set advertise-routes locally**
- **add the ability to remove routes associated with domain**
- **make routes from corp presisting and update with the list of route change on corp**
- **periodically remove dns looked up routes up on new look up results**
