### PR TITLE
util/linuxfw: allow IPv6 routes when ip6tables are unavailable

### DIFF
--- a/util/linuxfw/fake.go
+++ b/util/linuxfw/fake.go
@@ -121,6 +121,6 @@ func NewFakeIPTablesRunner() *iptablesRunner {
 	ipt4 := newFakeIPTables()
 	ipt6 := newFakeIPTables()
 
-	iptr := &iptablesRunner{ipt4, ipt6, true, true}
+	iptr := &iptablesRunner{ipt4, ipt6, true, true, true}
 	return iptr
 }


### PR DESCRIPTION
This PR attempts to fix the issue introduced in 1.62 where tailscale subnet router installations on hosts that don't have kernel support for ip6tables filter table are no longer able to route to IPv6 endpoints, see https://github.com/tailscale/tailscale/issues/11434, https://github.com/tailscale/tailscale/issues/11430

It seems like in some cases (Synology) ip6tables are not usable, but the system should still be able to configure route table with IPv6 routes. This PR allows to disable ip6tables supports whilst still allowing for router setup in those cases.

This PR attempts to fix it by allowing wgengine routes for IPv6 to be configured even if _ip6tables_ don't seem to be available.

I don't have a Synology host or another host without ip6tables filter table readily available that I coudl actually reproduce the bug and verify the fix.

(cc @raggi @sailorfrag )

