### PR TITLE
util/linuxfw,wgengine/router: enable IPv6 configuration when netfilter is disabled

### DIFF
--- a/util/linuxfw/iptables_runner.go
+++ b/util/linuxfw/iptables_runner.go
@@ -59,7 +59,7 @@ func newIPTablesRunner(logf logger.Logf) (*iptablesRunner, error) {
 	}
 
 	supportsV6, supportsV6NAT := false, false
-	v6err := checkIPv6(logf)
+	v6err := CheckIPv6(logf)
 	ip6terr := checkIP6TablesExists()
 	var ipt6 *iptables.IPTables
 	switch {

--- a/util/linuxfw/linuxfw.go
+++ b/util/linuxfw/linuxfw.go
@@ -130,7 +130,7 @@ func errCode(err error) int {
 // missing.  It does not check that IPv6 is currently functional or
 // that there's a global address, just that the system would support
 // IPv6 if it were on an IPv6 network.
-func checkIPv6(logf logger.Logf) error {
+func CheckIPv6(logf logger.Logf) error {
 	_, err := os.Stat("/proc/sys/net/ipv6")
 	if os.IsNotExist(err) {
 		return err

--- a/util/linuxfw/nftables_runner.go
+++ b/util/linuxfw/nftables_runner.go
@@ -546,7 +546,7 @@ func newNfTablesRunner(logf logger.Logf) (*nftablesRunner, error) {
 	}
 	nft4 := &nftable{Proto: nftables.TableFamilyIPv4}
 
-	v6err := checkIPv6(logf)
+	v6err := CheckIPv6(logf)
 	if v6err != nil {
 		logf("disabling tunneled IPv6 due to system IPv6 config: %v", v6err)
 	}


### PR DESCRIPTION

Updates #11434