### PR TITLE
ipn/ipnlocal, types/netmap: replace hasCapability with set lookup on NetworkMap

### DIFF
--- a/types/netmap/netmap.go
+++ b/types/netmap/netmap.go
@@ -17,6 +17,7 @@ import (
 	"tailscale.com/tka"
 	"tailscale.com/types/key"
 	"tailscale.com/types/views"
+	"tailscale.com/util/set"
 	"tailscale.com/wgengine/filter"
 )
 
@@ -26,6 +27,7 @@ import (
 // alias parts of previous NetworkMap values.
 type NetworkMap struct {
 	SelfNode   tailcfg.NodeView
+	AllCaps    set.Set[tailcfg.NodeCapability] // set version of SelfNode.Capabilities + SelfNode.CapMap
 	NodeKey    key.NodePublic
 	PrivateKey key.NodePrivate
 	Expiry     time.Time
@@ -118,6 +120,11 @@ func (nm *NetworkMap) GetMachineStatus() tailcfg.MachineStatus {
 		return tailcfg.MachineAuthorized
 	}
 	return tailcfg.MachineUnauthorized
+}
+
+// HasCap reports whether nm is non-nil and nm.AllCaps contains c.
+func (nm *NetworkMap) HasCap(c tailcfg.NodeCapability) bool {
+	return nm != nil && nm.AllCaps.Contains(c)
 }
 
 // PeerByTailscaleIP returns a peer's Node based on its Tailscale IP.


### PR DESCRIPTION
When node attributes were super rare, the O(n) slice scans looking for
node attributes was more acceptable. But now more code and more users
are using increasingly more node attributes. Time to make it a map.

Noticed while working on tailscale/corp#17879

Updates #cleanup
