### PR TITLE
util/linuxfw,wgengine/router: (cherry-pick) enable IPv6 configuration when netfilter is disabled

### DIFF
--- a/util/linuxfw/iptables_runner.go
+++ b/util/linuxfw/iptables_runner.go
@@ -59,7 +59,7 @@ func newIPTablesRunner(logf logger.Logf) (*iptablesRunner, error) {
 	}
 
 	supportsV6, supportsV6NAT := false, false
-	v6err := checkIPv6(logf)
+	v6err := CheckIPv6(logf)
 	ip6terr := checkIP6TablesExists()
 	var ipt6 *iptables.IPTables
 	switch {

--- a/util/linuxfw/linuxfw.go
+++ b/util/linuxfw/linuxfw.go
@@ -130,7 +130,7 @@ func errCode(err error) int {
 // missing.  It does not check that IPv6 is currently functional or
 // that there's a global address, just that the system would support
 // IPv6 if it were on an IPv6 network.
-func checkIPv6(logf logger.Logf) error {
+func CheckIPv6(logf logger.Logf) error {
 	_, err := os.Stat("/proc/sys/net/ipv6")
 	if os.IsNotExist(err) {
 		return err

--- a/util/linuxfw/nftables_runner.go
+++ b/util/linuxfw/nftables_runner.go
@@ -546,7 +546,7 @@ func newNfTablesRunner(logf logger.Logf) (*nftablesRunner, error) {
 	}
 	nft4 := &nftable{Proto: nftables.TableFamilyIPv4}
 
-	v6err := checkIPv6(logf)
+	v6err := CheckIPv6(logf)
 	if v6err != nil {
 		logf("disabling tunneled IPv6 due to system IPv6 config: %v", v6err)
 	}


### PR DESCRIPTION
This cherry-picks @raggi 's fix for Synology subnet router bug in 1.62 to release/1.62 branch.

A user has confirmed that the fix works https://github.com/tailscale/tailscale/issues/11434#issuecomment-2015952670 so we can cherry-pick and release the 1.62.1 patch

Updates #11434

Signed-off-by: James Tucker <james@tailscale.com>
(cherry picked from commit 3f7313dbdbb86b166b115c59bff444b1dc301e64)