### PR TITLE
.github/workflows: fix path filter for 'Kubernetes manifests' test job

### DIFF
--- a/.github/workflows/kubemanifests.yaml
+++ b/.github/workflows/kubemanifests.yaml
@@ -2,8 +2,8 @@ name: "Kubernetes manifests"
 on:
   pull_request:
    paths: 
-   - './cmd/k8s-operator/**'
-   - './k8s-operator/**'
+   - 'cmd/k8s-operator/**'
+   - 'k8s-operator/**'
    - '.github/workflows/kubemanifests.yaml'
 
 # Cancel workflow run if there is a newer push to the same PR for which it is


### PR DESCRIPTION
CI job path filter does not expect relative paths https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-paths

Updates#cleanup