### PR TITLE
cmd/serve: update warning for sandboxed macOS builds

### DIFF
--- a/cmd/tailscale/cli/serve_v2.go
+++ b/cmd/tailscale/cli/serve_v2.go
@@ -497,9 +497,9 @@ func (e *serveEnv) applyWebServe(sc *ipn.ServeConfig, dnsName string, srvPort ui
 		}
 		h.Text = text
 	case filepath.IsAbs(target):
-		if version.IsSandboxedMacOS() {
-			// don't allow path serving for now on macOS (2022-11-15)
-			return errors.New("path serving is not supported if sandboxed on macOS")
+		if version.IsMacAppStore() || version.IsMacSys() {
+			// The Tailscale network extension cannot serve arbitrary paths on macOS due to sandbox restrictions (2024-03-26)
+			return errors.New("Path serving is not supported on macOS due to sandbox restrictions. To use Tailscale Serve on macOS, switch to the open-source tailscaled distribution. See https://tailscale.com/kb/1065/macos-variants for more information.")
 		}
 
 		target = filepath.Clean(target)


### PR DESCRIPTION
Updates tailscale/corp#18662

Updates the detection logic and shows a (better) error message if attempting to use `tailscale serve` on macsys, where the CLI isn't sandboxed, but the network extension is.