### PR TITLE
tsweb/varz: add charset=utf-8 to varz handler

### DIFF
--- a/tsweb/varz/varz.go
+++ b/tsweb/varz/varz.go
@@ -274,7 +274,7 @@ type sortedKVs struct {
 //
 // This will evolve over time, or perhaps be replaced.
 func Handler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+	w.Header().Set("Content-Type", "text/plain;version=0.0.4;charset=utf-8")
 
 	s := sortedKVsPool.Get().(*sortedKVs)
 	defer sortedKVsPool.Put(s)


### PR DESCRIPTION
Some of our labels contain UTF-8 and get mojibaked in the browser
right now.

Updates tailscale/corp#18687
