### PR TITLE
wgengine/router,util/linuxfw: don't attempt to configure IPv6 firewall rules with ip6tables that don't support filter table

### DIFF
--- a/util/linuxfw/fake.go
+++ b/util/linuxfw/fake.go
@@ -121,6 +121,6 @@ func NewFakeIPTablesRunner() *iptablesRunner {
 	ipt4 := newFakeIPTables()
 	ipt6 := newFakeIPTables()
 
-	iptr := &iptablesRunner{ipt4, ipt6, true, true}
+	iptr := &iptablesRunner{ipt4, ipt6, true, true, true}
 	return iptr
 }

--- a/wgengine/router/router_linux_test.go
+++ b/wgengine/router/router_linux_test.go
@@ -659,8 +659,9 @@ func (n *fakeIPTablesRunner) DelMagicsockPortRule(port uint16, network string) e
 	return nil
 }
 
-func (n *fakeIPTablesRunner) HasIPV6() bool    { return true }
-func (n *fakeIPTablesRunner) HasIPV6NAT() bool { return true }
+func (n *fakeIPTablesRunner) HasIPV6() bool       { return true }
+func (n *fakeIPTablesRunner) HasIPV6NAT() bool    { return true }
+func (n *fakeIPTablesRunner) HasIPV6Filter() bool { return true }
 
 // fakeOS implements commandRunner and provides v4 and v6
 // netfilterRunners, but captures changes without touching the OS.


### PR DESCRIPTION
- In https://github.com/tailscale/tailscale/pull/11381 we added a stricter check for whether ip6tables filter table is supported to fix an issue where, in container environments that ran on hosts with partial support ip6tables (no filter table), we anyway attempted to configure IPv6 firewall, errored out and skipped the rest of the router configuration, resulting in hard-to-debug issues
- https://github.com/tailscale/tailscale/pull/11381 broke Synology IPv6 subnet routers where iptables are not supported, but IPv6 routes should still be set up, see https://github.com/tailscale/tailscale/issues/11430
- We fixed the broken Synology subnet routers in https://github.com/tailscale/tailscale/pull/11494 by changing the configuration logic slightly so that if iptables don't seem to support IPv6, but [netfilter is off]() IPv6 routes are still configured (this is because Synology [runs with netfilter off](https://github.com/tailscale/tailscale/blob/v1.62.1/wgengine/router/router_linux.go#L462))

However, netfilter can also be off during a regular Linux client router setup, so this resulted in a buggy sequence:
1. wgengine starts, netfilter is [set to off](https://github.com/tailscale/tailscale/blob/v1.62.1/wgengine/router/router_linux.go#L89)
2. `UpdateMagicSockPort` runs with port for IPv6 and because netfilter is off + our changed logic, it determines that `linuxRouter.magicsockPortv6` needs to be set ([here](https://github.com/tailscale/tailscale/blob/v1.63.0-pre/wgengine/router/router_linux.go#L419-L422))
3. router gets reconfigured for the linux client and the netfilter is turned on
4. `linuxRouter.setNetfilterMode` runs with a netfilter mode change false -> true, so we hit [this path](https://github.com/tailscale/tailscale/blob/v1.63.0-pre/wgengine/router/router_linux.go#L526) and because `linuxRouter.magicsockPortv6` is still set and we use the _current_ netfilter mode (off) in the IPv6 availability check, we end up attempting to set the IPv6 firewall rules, error out and the rest of the router config remains unset, resulting in a broken client


This PR attempts to ensure that:
- if the host supports IPv6 we always set routing policy rules (To preserve IPv6 routing support in Synology)
- if the firewall is in iptables mode, but ip6tables filter table was not found, we don't attempt to configure any IPv6 firewall rules

I have tested this with an IPv4 host (container) with no IPv6 filter table support:

- on host:
<details>
<code>
/ # env | grep TS_DEBUG_FIREWALL
TS_DEBUG_FIREWALL_MODE=iptables
/ # ip -6 rule list
0:      from all lookup local
5210:   from all fwmark 0x80000/0xff0000 lookup main
5230:   from all fwmark 0x80000/0xff0000 lookup default
5250:   from all fwmark 0x80000/0xff0000 unreachable
5270:   from all lookup 52
32766:  from all lookup main
/ # ip6tables -t filter -L
modprobe: can't change directory to '/lib/modules': No such file or directory
ip6tables v1.8.9 (legacy): can't initialize ip6tables table `filter': Table does not exist (do you need to insmod?)
Perhaps ip6tables or your kernel needs to be upgraded.
</code>
</details>

- logs:
<details>
<code>
...
boot: 2024/03/28 19:09:27 [v1] kernel supports IPv6 policy routing (found 6 rules)
boot: 2024/03/28 19:09:27 ip6tables filtering is not supported on this host: running [/sbin/ip6tables -t filter -S --wait]: exit status 3: modprobe: can't change directory to '/lib/modules': No such file or directory
ip6tables v1.8.9 (legacy): can't initialize ip6tables table `filter': Table does not exist (do you need to insmod?)
Perhaps ip6tables or your kernel needs to be upgraded.
boot: 2024/03/28 19:09:27 v6 = true, v6filter = false, v6nat = false
...
</code>
</details>

I have also tested it on an IPv6 host (container) with firewall in iptables mode:

- host

<details>
<code>
 # env | grep TS_DEBUG_FIRE
TS_DEBUG_FIREWALL_MODE=iptables
/ # ip -6 rule list
0:      from all lookup local
5210:   from all fwmark 0x80000/0xff0000 lookup main
5230:   from all fwmark 0x80000/0xff0000 lookup default
5250:   from all fwmark 0x80000/0xff0000 unreachable
5270:   from all lookup 52
32766:  from all lookup main
/ # ip6tables -t filter -L
Chain INPUT (policy ACCEPT)
target     prot opt source               destination         
ts-input   all  --  anywhere             anywhere            

Chain FORWARD (policy ACCEPT)
target     prot opt source               destination         
ts-forward  all  --  anywhere             anywhere            

Chain OUTPUT (policy ACCEPT)
target     prot opt source               destination         

Chain ts-forward (1 references)
target     prot opt source               destination         
MARK       all  --  anywhere             anywhere             MARK xset 0x40000/0xff0000
ACCEPT     all  --  anywhere             anywhere             mark match 0x40000/0xff0000
ACCEPT     all  --  anywhere             anywhere            

Chain ts-input (1 references)
target     prot opt source               destination         
ACCEPT     all  --  fd7a:115c:a1e0::8f01:5e37  anywhere            
ACCEPT     all  --  anywhere             anywhere            
ACCEPT     udp  --  anywhere             anywhere             udp dpt:53101
</code>
</details>


- logs

<details>
<code>
...
boot: 2024/03/28 19:51:09 [v1] kernel supports IPv6 policy routing (found 6 rules)
2024/03/28 19:51:09 magicsock: derp-8 connected; connGen=1
2024/03/28 19:51:09 health("overall"): ok
boot: 2024/03/28 19:51:09 v6 = true, v6filter = true, v6nat = true
...
</code>
</detaills>

When/if it merges, we'd still have to test with Synology.

Updates tailscale/tailscale#11540