### PR TITLE
Lazily initialize device model to speed up `init()`

### DIFF
--- a/hostinfo/hostinfo_linux.go
+++ b/hostinfo/hostinfo_linux.go
@@ -22,9 +22,7 @@ func init() {
 	distroName = distroNameLinux
 	distroVersion = distroVersionLinux
 	distroCodeName = distroCodeNameLinux
-	if v := linuxDeviceModel(); v != "" {
-		SetDeviceModel(v)
-	}
+	deviceModel = deviceModelLinux
 }
 
 var (
@@ -50,7 +48,7 @@ func distroCodeNameLinux() string {
 	return lazyVersionMeta.Get().DistroCodeName
 }
 
-func linuxDeviceModel() string {
+func deviceModelLinux() string {
 	for _, path := range []string{
 		// First try the Synology-specific location.
 		// Example: "DS916+-j"


### PR DESCRIPTION
This was causing a relatively constant ~10ms of delay on Linux.