### PR TITLE
logtail: always zstd compress with FastestCompression and LowMemory

### DIFF
--- a/logtail/logtail.go
+++ b/logtail/logtail.go
@@ -375,11 +375,9 @@ func (l *Logger) uploading(ctx context.Context) {
 			switch {
 			case l.zstdEncoder != nil:
 				zbody = l.zstdEncoder.EncodeAll(body, nil)
-			case l.lowMem:
+			default:
 				zbody = zstdframe.AppendEncode(nil, body,
 					zstdframe.FastestCompression, zstdframe.LowMemory(true))
-			default:
-				zbody = zstdframe.AppendEncode(nil, body)
 			}
 
 			// Only send it compressed if the bandwidth savings are sufficient.


### PR DESCRIPTION
This is based on empirical testing using actual logs data.

FastestCompression only incurs a marginal <1% compression ratio hit for a 2.25x reduction in memory use for small payloads (which are common if log uploads happen at a decently high frequency). The memory savings for large payloads is not as notable (1.1x reduction).

LowMemory only incurs a marginal <5% hit on performance for a 1.6-2.0x reduction in memory use for small or large payloads.

The memory gains for both settings justifies the loss of benefits, which are arguably minimal.

tailscale/corp#18514