### PR TITLE
net/packet: allow more ICMP errors

### DIFF
--- a/net/packet/icmp4.go
+++ b/net/packet/icmp4.go
@@ -23,6 +23,7 @@ const (
 	ICMP4EchoRequest  ICMP4Type = 0x08
 	ICMP4Unreachable  ICMP4Type = 0x03
 	ICMP4TimeExceeded ICMP4Type = 0x0b
+	ICMP4ParamProblem ICMP4Type = 0x12
 )
 
 func (t ICMP4Type) String() string {
@@ -35,6 +36,8 @@ func (t ICMP4Type) String() string {
 		return "Unreachable"
 	case ICMP4TimeExceeded:
 		return "TimeExceeded"
+	case ICMP4ParamProblem:
+		return "ParamProblem"
 	default:
 		return "Unknown"
 	}

--- a/net/packet/icmp6.go
+++ b/net/packet/icmp6.go
@@ -20,7 +20,9 @@ type ICMP6Type uint8
 
 const (
 	ICMP6Unreachable  ICMP6Type = 1
+	ICMP6PacketTooBig ICMP6Type = 2
 	ICMP6TimeExceeded ICMP6Type = 3
+	ICMP6ParamProblem ICMP6Type = 4
 	ICMP6EchoRequest  ICMP6Type = 128
 	ICMP6EchoReply    ICMP6Type = 129
 )
@@ -29,8 +31,12 @@ func (t ICMP6Type) String() string {
 	switch t {
 	case ICMP6Unreachable:
 		return "Unreachable"
+	case ICMP6PacketTooBig:
+		return "PacketTooBig"
 	case ICMP6TimeExceeded:
 		return "TimeExceeded"
+	case ICMP6ParamProblem:
+		return "ParamProblem"
 	case ICMP6EchoRequest:
 		return "EchoRequest"
 	case ICMP6EchoReply:

--- a/net/packet/packet.go
+++ b/net/packet/packet.go
@@ -416,13 +416,13 @@ func (q *Parsed) IsError() bool {
 			return false
 		}
 		t := ICMP4Type(q.b[q.subofs])
-		return t == ICMP4Unreachable || t == ICMP4TimeExceeded
+		return t == ICMP4Unreachable || t == ICMP4TimeExceeded || t == ICMP4ParamProblem
 	case ipproto.ICMPv6:
 		if len(q.b) < q.subofs+8 {
 			return false
 		}
 		t := ICMP6Type(q.b[q.subofs])
-		return t == ICMP6Unreachable || t == ICMP6TimeExceeded
+		return t == ICMP6Unreachable || t == ICMP6PacketTooBig || t == ICMP6TimeExceeded || t == ICMP6ParamProblem
 	default:
 		return false
 	}


### PR DESCRIPTION
We now allow some more ICMP errors to flow, specifically:

- ICMP parameter problem in both IPv4 and IPv6 (corrupt headers)
- ICMP Packet Too Big (for IPv6 PMTU)

Updates #311
Updates #8102
Updates #11002