### PR TITLE
tsweb: update doc on BucketedStatsOptions.Finish to match behavior

### DIFF
--- a/tsweb/tsweb.go
+++ b/tsweb/tsweb.go
@@ -189,7 +189,8 @@ type BucketedStatsOptions struct {
 	Started *metrics.LabelMap
 
 	// If non-nil, Finished maintains a counter of all requests which
-	// have finished processing (that is, the HTTP handler has returned).
+	// have finished processing with success (that is, the HTTP handler has
+	// returned).
 	Finished *metrics.LabelMap
 }
 


### PR DESCRIPTION
I originally came to update this to match the documented behavior, but the code is deliberately avoiding this behavior currently, making it hard to decide how to update this. For now just align the documentation to the behavior.

Updates #cleanup