### PR TITLE
tailscale: update tailfs functions and vars to use drive naming

### DIFF
--- a/client/tailscale/localclient.go
+++ b/client/tailscale/localclient.go
@@ -1418,25 +1418,25 @@ func (lc *LocalClient) CheckUpdate(ctx context.Context) (*tailcfg.ClientVersion,
 	return &cv, nil
 }
 
-// TailFSSetFileServerAddr instructs TailFS to use the server at addr to access
+// DriveSetServerAddr instructs Taildrive to use the server at addr to access
 // the filesystem. This is used on platforms like Windows and MacOS to let
-// TailFS know to use the file server running in the GUI app.
-func (lc *LocalClient) TailFSSetFileServerAddr(ctx context.Context, addr string) error {
+// Taildrive know to use the file server running in the GUI app.
+func (lc *LocalClient) DriveSetServerAddr(ctx context.Context, addr string) error {
 	_, err := lc.send(ctx, "PUT", "/localapi/v0/tailfs/fileserver-address", http.StatusCreated, strings.NewReader(addr))
 	return err
 }
 
-// TailFSShareSet adds or updates the given share in the list of shares that
-// TailFS will serve to remote nodes. If a share with the same name already
+// DriveShareSet adds or updates the given share in the list of shares that
+// Taildrive will serve to remote nodes. If a share with the same name already
 // exists, the existing share is replaced/updated.
-func (lc *LocalClient) TailFSShareSet(ctx context.Context, share *drive.Share) error {
+func (lc *LocalClient) DriveShareSet(ctx context.Context, share *drive.Share) error {
 	_, err := lc.send(ctx, "PUT", "/localapi/v0/tailfs/shares", http.StatusCreated, jsonBody(share))
 	return err
 }
 
-// TailFSShareRemove removes the share with the given name from the list of
-// shares that TailFS will serve to remote nodes.
-func (lc *LocalClient) TailFSShareRemove(ctx context.Context, name string) error {
+// DriveShareRemove removes the share with the given name from the list of
+// shares that Taildrive will serve to remote nodes.
+func (lc *LocalClient) DriveShareRemove(ctx context.Context, name string) error {
 	_, err := lc.send(
 		ctx,
 		"DELETE",
@@ -1446,8 +1446,8 @@ func (lc *LocalClient) TailFSShareRemove(ctx context.Context, name string) error
 	return err
 }
 
-// TailFSShareRename renames the share from old to new name.
-func (lc *LocalClient) TailFSShareRename(ctx context.Context, oldName, newName string) error {
+// DriveShareRename renames the share from old to new name.
+func (lc *LocalClient) DriveShareRename(ctx context.Context, oldName, newName string) error {
 	_, err := lc.send(
 		ctx,
 		"POST",
@@ -1457,9 +1457,9 @@ func (lc *LocalClient) TailFSShareRename(ctx context.Context, oldName, newName s
 	return err
 }
 
-// TailFSShareList returns the list of shares that TailFS is currently serving
+// DriveShareList returns the list of shares that drive is currently serving
 // to remote nodes.
-func (lc *LocalClient) TailFSShareList(ctx context.Context) ([]*drive.Share, error) {
+func (lc *LocalClient) DriveShareList(ctx context.Context) ([]*drive.Share, error) {
 	result, err := lc.get200(ctx, "/localapi/v0/tailfs/shares")
 	if err != nil {
 		return nil, err

--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -829,7 +829,7 @@ func TestPrefFlagMapping(t *testing.T) {
 			// Handled by TS_DEBUG_FIREWALL_MODE env var, we don't want to have
 			// a CLI flag for this. The Pref is used by c2n.
 			continue
-		case "TailFSShares":
+		case "DriveShares":
 			// Handled by the tailscale share subcommand, we don't want a CLI
 			// flag for this.
 			continue

--- a/cmd/tailscale/cli/share.go
+++ b/cmd/tailscale/cli/share.go
@@ -69,7 +69,7 @@ func runShareSet(ctx context.Context, args []string) error {
 
 	name, path := args[0], args[1]
 
-	err := localClient.TailFSShareSet(ctx, &drive.Share{
+	err := localClient.DriveShareSet(ctx, &drive.Share{
 		Name: name,
 		Path: path,
 	})
@@ -86,7 +86,7 @@ func runShareRemove(ctx context.Context, args []string) error {
 	}
 	name := args[0]
 
-	err := localClient.TailFSShareRemove(ctx, name)
+	err := localClient.DriveShareRemove(ctx, name)
 	if err == nil {
 		fmt.Printf("Removed share %q\n", name)
 	}
@@ -101,7 +101,7 @@ func runShareRename(ctx context.Context, args []string) error {
 	oldName := args[0]
 	newName := args[1]
 
-	err := localClient.TailFSShareRename(ctx, oldName, newName)
+	err := localClient.DriveShareRename(ctx, oldName, newName)
 	if err == nil {
 		fmt.Printf("Renamed share %q to %q\n", oldName, newName)
 	}
@@ -114,7 +114,7 @@ func runShareList(ctx context.Context, args []string) error {
 		return fmt.Errorf("usage: tailscale %v", shareListUsage)
 	}
 
-	shares, err := localClient.TailFSShareList(ctx)
+	shares, err := localClient.DriveShareList(ctx)
 	if err != nil {
 		return err
 	}

--- a/drive/driveimpl/drive_test.go
+++ b/drive/driveimpl/drive_test.go
@@ -41,7 +41,7 @@ func init() {
 	drive.DisallowShareAs = true
 }
 
-// The tests in this file simulate real-life TailFS scenarios, but without
+// The tests in this file simulate real-life Taildrive scenarios, but without
 // going over the Tailscale network stack.
 func TestDirectoryListing(t *testing.T) {
 	s := newSystem(t)

--- a/drive/driveimpl/fileserver.go
+++ b/drive/driveimpl/fileserver.go
@@ -13,7 +13,7 @@ import (
 )
 
 // FileServer is a standalone WebDAV server that dynamically serves up shares.
-// It's typically used in a separate process from the actual TailFS server to
+// It's typically used in a separate process from the actual Taildrive server to
 // serve up files as an unprivileged user.
 type FileServer struct {
 	l             net.Listener

--- a/drive/driveimpl/local_impl.go
+++ b/drive/driveimpl/local_impl.go
@@ -42,8 +42,8 @@ func NewFileSystemForLocal(logf logger.Logf) *FileSystemForLocal {
 	return fs
 }
 
-// FileSystemForLocal is the TailFS filesystem exposed to local clients. It
-// provides a unified WebDAV interface to remote TailFS shares on other nodes.
+// FileSystemForLocal is the Taildrive filesystem exposed to local clients. It
+// provides a unified WebDAV interface to remote Taildrive shares on other nodes.
 type FileSystemForLocal struct {
 	logf     logger.Logf
 	h        *compositedav.Handler

--- a/drive/driveimpl/remote_impl.go
+++ b/drive/driveimpl/remote_impl.go
@@ -44,7 +44,7 @@ func NewFileSystemForRemote(logf logger.Logf) *FileSystemForRemote {
 	return fs
 }
 
-// FileSystemForRemote implements tailfs.FileSystemForRemote.
+// FileSystemForRemote implements drive.FileSystemForRemote.
 type FileSystemForRemote struct {
 	logf       logger.Logf
 	lockSystem webdav.LockSystem
@@ -58,15 +58,15 @@ type FileSystemForRemote struct {
 	userServers    map[string]*userServer
 }
 
-// SetFileServerAddr implements tailfs.FileSystemForRemote.
+// SetFileServerAddr implements drive.FileSystemForRemote.
 func (s *FileSystemForRemote) SetFileServerAddr(addr string) {
 	s.mu.Lock()
 	s.fileServerAddr = addr
 	s.mu.Unlock()
 }
 
-// SetShares implements tailfs.FileSystemForRemote. Shares must be sorted
-// according to tailfs.CompareShares.
+// SetShares implements drive.FileSystemForRemote. Shares must be sorted
+// according to drive.CompareShares.
 func (s *FileSystemForRemote) SetShares(shares []*drive.Share) {
 	userServers := make(map[string]*userServer)
 	if drive.AllowShareAs() {
@@ -176,7 +176,7 @@ func (s *FileSystemForRemote) buildChild(share *drive.Share) *compositedav.Child
 	}
 }
 
-// ServeHTTPWithPerms implements tailfs.FileSystemForRemote.
+// ServeHTTPWithPerms implements drive.FileSystemForRemote.
 func (s *FileSystemForRemote) ServeHTTPWithPerms(permissions drive.Permissions, w http.ResponseWriter, r *http.Request) {
 	isWrite := writeMethods[r.Method]
 	if isWrite {
@@ -228,7 +228,7 @@ func (s *FileSystemForRemote) closeChildren(children map[string]*compositedav.Ch
 	}
 }
 
-// Close() implements tailfs.FileSystemForRemote.
+// Close() implements drive.FileSystemForRemote.
 func (s *FileSystemForRemote) Close() error {
 	s.mu.Lock()
 	userServers := s.userServers

--- a/drive/driveimpl/shared/readonlydir.go
+++ b/drive/driveimpl/shared/readonlydir.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-// Package shared contains types and functions shared by different tailfs
+// Package shared contains types and functions shared by different drive
 // packages.
 package shared
 

--- a/drive/local.go
+++ b/drive/local.go
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 // Package drive provides a filesystem that allows sharing folders between
-// Tailscale nodes using WebDAV. The actual implementation of the core drive
+// Tailscale nodes using WebDAV. The actual implementation of the core Taildrive
 // functionality lives in package driveimpl. These packages are separated to
-// allow users of drive to refer to the interfaces without having a hard
-// dependency on drive, so that programs which don't actually use drive can
+// allow users of Taildrive to refer to the interfaces without having a hard
+// dependency on Taildrive, so that programs which don't actually use Taildrive can
 // avoid its transitive dependencies.
 package drive
 
@@ -14,15 +14,15 @@ import (
 	"net/http"
 )
 
-// Remote represents a remote TailFS node.
+// Remote represents a remote Taildrive node.
 type Remote struct {
 	Name      string
 	URL       string
 	Available func() bool
 }
 
-// FileSystemForLocal is the TailFS filesystem exposed to local clients. It
-// provides a unified WebDAV interface to remote TailFS shares on other nodes.
+// FileSystemForLocal is the Taildrive filesystem exposed to local clients. It
+// provides a unified WebDAV interface to remote Taildrive shares on other nodes.
 type FileSystemForLocal interface {
 	// HandleConn handles connections from local WebDAV clients
 	HandleConn(conn net.Conn, remoteAddr net.Addr) error

--- a/drive/remote.go
+++ b/drive/remote.go
@@ -22,7 +22,7 @@ func AllowShareAs() bool {
 	return !DisallowShareAs && doAllowShareAs()
 }
 
-// Share configures a folder to be shared through TailFS.
+// Share configures a folder to be shared through drive.
 type Share struct {
 	// Name is how this share appears on remote nodes.
 	Name string `json:"name,omitempty"`
@@ -78,7 +78,7 @@ func CompareShares(a, b *Share) int {
 	return strings.Compare(a.Name, b.Name)
 }
 
-// FileSystemForRemote is the TailFS filesystem exposed to remote nodes. It
+// FileSystemForRemote is the drive filesystem exposed to remote nodes. It
 // provides a unified WebDAV interface to local directories that have been
 // shared.
 type FileSystemForRemote interface {

--- a/ipn/backend.go
+++ b/ipn/backend.go
@@ -68,7 +68,7 @@ const (
 	NotifyInitialNetMap // if set, the first Notify message (sent immediately) will contain the current NetMap
 
 	NotifyNoPrivateKeys        // if set, private keys that would normally be sent in updates are zeroed out
-	NotifyInitialTailFSShares  // if set, the first Notify message (sent immediately) will contain the current TailFS Shares
+	NotifyInitialDriveShares   // if set, the first Notify message (sent immediately) will contain the current Taildrive Shares
 	NotifyInitialOutgoingFiles // if set, the first Notify message (sent immediately) will contain the current Taildrop OutgoingFiles
 )
 
@@ -130,13 +130,13 @@ type Notify struct {
 	// is available.
 	ClientVersion *tailcfg.ClientVersion `json:",omitempty"`
 
-	// TailFSShares tracks the full set of current TailFSShares that we're
+	// DriveShares tracks the full set of current DriveShares that we're
 	// publishing. Some client applications, like the MacOS and Windows clients,
 	// will listen for updates to this and handle serving these shares under
 	// the identity of the unprivileged user that is running the application. A
 	// nil value here means that we're not broadcasting shares information, an
 	// empty value means that there are no shares.
-	TailFSShares views.SliceView[*drive.Share, drive.ShareView]
+	DriveShares views.SliceView[*drive.Share, drive.ShareView]
 
 	// type is mirrored in xcode/Shared/IPN.swift
 }

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -25,10 +25,10 @@ func (src *Prefs) Clone() *Prefs {
 	*dst = *src
 	dst.AdvertiseTags = append(src.AdvertiseTags[:0:0], src.AdvertiseTags...)
 	dst.AdvertiseRoutes = append(src.AdvertiseRoutes[:0:0], src.AdvertiseRoutes...)
-	if src.TailFSShares != nil {
-		dst.TailFSShares = make([]*drive.Share, len(src.TailFSShares))
-		for i := range dst.TailFSShares {
-			dst.TailFSShares[i] = src.TailFSShares[i].Clone()
+	if src.DriveShares != nil {
+		dst.DriveShares = make([]*drive.Share, len(src.DriveShares))
+		for i := range dst.DriveShares {
+			dst.DriveShares[i] = src.DriveShares[i].Clone()
 		}
 	}
 	dst.Persist = src.Persist.Clone()
@@ -63,7 +63,7 @@ var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	AppConnector           AppConnectorPrefs
 	PostureChecking        bool
 	NetfilterKind          string
-	TailFSShares           []*drive.Share
+	DriveShares            []*drive.Share
 	Persist                *persist.Persist
 }{})
 

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -92,8 +92,8 @@ func (v PrefsView) AutoUpdate() AutoUpdatePrefs           { return v.ж.AutoUpda
 func (v PrefsView) AppConnector() AppConnectorPrefs       { return v.ж.AppConnector }
 func (v PrefsView) PostureChecking() bool                 { return v.ж.PostureChecking }
 func (v PrefsView) NetfilterKind() string                 { return v.ж.NetfilterKind }
-func (v PrefsView) TailFSShares() views.SliceView[*drive.Share, drive.ShareView] {
-	return views.SliceOfViews[*drive.Share, drive.ShareView](v.ж.TailFSShares)
+func (v PrefsView) DriveShares() views.SliceView[*drive.Share, drive.ShareView] {
+	return views.SliceOfViews[*drive.Share, drive.ShareView](v.ж.DriveShares)
 }
 func (v PrefsView) Persist() persist.PersistView { return v.ж.Persist.View() }
 
@@ -125,7 +125,7 @@ var _PrefsViewNeedsRegeneration = Prefs(struct {
 	AppConnector           AppConnectorPrefs
 	PostureChecking        bool
 	NetfilterKind          string
-	TailFSShares           []*drive.Share
+	DriveShares            []*drive.Share
 	Persist                *persist.Persist
 }{})
 

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -316,9 +316,9 @@ type LocalBackend struct {
 	// Last ClientVersion received in MapResponse, guarded by mu.
 	lastClientVersion *tailcfg.ClientVersion
 
-	// lastNotifiedTailFSShares keeps track of the last set of shares that we
+	// lastNotifiedDriveShares keeps track of the last set of shares that we
 	// notified about.
-	lastNotifiedTailFSShares atomic.Pointer[views.SliceView[*drive.Share, drive.ShareView]]
+	lastNotifiedDriveShares atomic.Pointer[views.SliceView[*drive.Share, drive.ShareView]]
 
 	// outgoingFiles keeps track of Taildrop outgoing files keyed to their OutgoingFile.ID
 	outgoingFiles map[string]*ipn.OutgoingFile
@@ -442,10 +442,10 @@ func NewLocalBackend(logf logger.Logf, logID logid.PublicID, sys *tsd.System, lo
 		}
 	}
 
-	// initialize TailFS shares from saved state
-	fs, ok := b.sys.TailFSForRemote.GetOK()
+	// initialize Taildrive shares from saved state
+	fs, ok := b.sys.DriveForRemote.GetOK()
 	if ok {
-		currentShares := b.pm.prefs.TailFSShares()
+		currentShares := b.pm.prefs.DriveShares()
 		if currentShares.Len() > 0 {
 			var shares []*drive.Share
 			for i := 0; i < currentShares.Len(); i++ {
@@ -2284,7 +2284,7 @@ func (b *LocalBackend) WatchNotifications(ctx context.Context, mask ipn.NotifyWa
 
 	b.mu.Lock()
 
-	const initialBits = ipn.NotifyInitialState | ipn.NotifyInitialPrefs | ipn.NotifyInitialNetMap | ipn.NotifyInitialTailFSShares
+	const initialBits = ipn.NotifyInitialState | ipn.NotifyInitialPrefs | ipn.NotifyInitialNetMap | ipn.NotifyInitialDriveShares
 	if mask&initialBits != 0 {
 		ini = &ipn.Notify{Version: version.Long()}
 		if mask&ipn.NotifyInitialState != 0 {
@@ -2300,8 +2300,8 @@ func (b *LocalBackend) WatchNotifications(ctx context.Context, mask ipn.NotifyWa
 		if mask&ipn.NotifyInitialNetMap != 0 {
 			ini.NetMap = b.netMap
 		}
-		if mask&ipn.NotifyInitialTailFSShares != 0 && b.tailFSSharingEnabledLocked() {
-			ini.TailFSShares = b.pm.prefs.TailFSShares()
+		if mask&ipn.NotifyInitialDriveShares != 0 && b.driveSharingEnabledLocked() {
+			ini.DriveShares = b.pm.prefs.DriveShares()
 		}
 	}
 
@@ -3374,8 +3374,8 @@ func (b *LocalBackend) TCPHandlerForDst(src, dst netip.AddrPort) (handler func(c
 				return b.handleWebClientConn, opts
 			}
 			return b.HandleQuad100Port80Conn, opts
-		case TailFSLocalPort:
-			return b.handleTailFSConn, opts
+		case DriveLocalPort:
+			return b.handleDriveConn, opts
 		}
 	}
 
@@ -3409,9 +3409,9 @@ func (b *LocalBackend) TCPHandlerForDst(src, dst netip.AddrPort) (handler func(c
 	return nil, nil
 }
 
-func (b *LocalBackend) handleTailFSConn(conn net.Conn) error {
-	fs, ok := b.sys.TailFSForLocal.GetOK()
-	if !ok || !b.TailFSAccessEnabled() {
+func (b *LocalBackend) handleDriveConn(conn net.Conn) error {
+	fs, ok := b.sys.DriveForLocal.GetOK()
+	if !ok || !b.DriveAccessEnabled() {
 		conn.Close()
 		return nil
 	}
@@ -4721,8 +4721,8 @@ func (b *LocalBackend) setNetMapLocked(nm *netmap.NetworkMap) {
 		}
 	}
 
-	b.updateTailFSPeersLocked(nm)
-	b.tailFSNotifyCurrentSharesLocked()
+	b.updateDrivePeersLocked(nm)
+	b.driveNotifyCurrentSharesLocked()
 }
 
 func (b *LocalBackend) updatePeersFromNetmapLocked(nm *netmap.NetworkMap) {
@@ -4749,10 +4749,10 @@ func (b *LocalBackend) updatePeersFromNetmapLocked(nm *netmap.NetworkMap) {
 	}
 }
 
-// tailFSTransport is an http.RoundTripper that uses the latest value of
+// driveTransport is an http.RoundTripper that uses the latest value of
 // b.Dialer().PeerAPITransport() for each round trip and imposes a short
 // dial timeout to avoid hanging on connecting to offline/unreachable hosts.
-type tailFSTransport struct {
+type driveTransport struct {
 	b *LocalBackend
 }
 
@@ -4809,7 +4809,7 @@ func (rbw *responseBodyWrapper) Close() error {
 	return err
 }
 
-func (t *tailFSTransport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+func (dt *driveTransport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
 	bw := &requestBodyWrapper{}
 	if req.Body != nil {
 		bw.ReadCloser = req.Body
@@ -4831,24 +4831,24 @@ func (t *tailFSTransport) RoundTrip(req *http.Request) (resp *http.Response, err
 			return
 		}
 
-		t.b.mu.Lock()
-		selfNodeKey := t.b.netMap.SelfNode.Key().ShortString()
-		t.b.mu.Unlock()
-		n, _, ok := t.b.WhoIs(netip.MustParseAddrPort(req.URL.Host))
+		dt.b.mu.Lock()
+		selfNodeKey := dt.b.netMap.SelfNode.Key().ShortString()
+		dt.b.mu.Unlock()
+		n, _, ok := dt.b.WhoIs(netip.MustParseAddrPort(req.URL.Host))
 		shareNodeKey := "unknown"
 		if ok {
 			shareNodeKey = string(n.Key().ShortString())
 		}
 
 		rbw := responseBodyWrapper{
-			log:           t.b.logf,
+			log:           dt.b.logf,
 			method:        req.Method,
 			bytesTx:       int64(bw.bytesRead),
 			selfNodeKey:   selfNodeKey,
 			shareNodeKey:  shareNodeKey,
 			contentType:   contentType,
 			contentLength: resp.ContentLength,
-			fileExtension: parseTailFSFileExtensionForLog(req.URL.Path),
+			fileExtension: parseDriveFileExtensionForLog(req.URL.Path),
 			statusCode:    resp.StatusCode,
 			ReadCloser:    resp.Body,
 		}
@@ -4865,7 +4865,7 @@ func (t *tailFSTransport) RoundTrip(req *http.Request) (resp *http.Response, err
 	// unreachable hosts.
 	dialTimeout := 1 * time.Second // TODO(oxtoacart): tune this
 
-	tr := t.b.Dialer().PeerAPITransport().Clone()
+	tr := dt.b.Dialer().PeerAPITransport().Clone()
 	dialContext := tr.DialContext
 	tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		ctxWithTimeout, cancel := context.WithTimeout(ctx, dialTimeout)

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -2201,12 +2201,12 @@ func TestTCPHandlerForDst(t *testing.T) {
 			intercept: false,
 		},
 		{
-			desc:      "intercept port 8080 (TailFS) on quad100 IPv4",
+			desc:      "intercept port 8080 (Taildrive) on quad100 IPv4",
 			dst:       "100.100.100.100:8080",
 			intercept: true,
 		},
 		{
-			desc:      "intercept port 8080 (TailFS) on quad100 IPv6",
+			desc:      "intercept port 8080 (Taildrive) on quad100 IPv6",
 			dst:       "[fd7a:115c:a1e0::53]:8080",
 			intercept: true,
 		},
@@ -2246,7 +2246,7 @@ func TestTCPHandlerForDst(t *testing.T) {
 	}
 }
 
-func TestTailFSManageShares(t *testing.T) {
+func TestDriveManageShares(t *testing.T) {
 	tests := []struct {
 		name     string
 		disabled bool
@@ -2316,7 +2316,7 @@ func TestTailFSManageShares(t *testing.T) {
 			name:     "add_disabled",
 			disabled: true,
 			add:      &drive.Share{Name: "a"},
-			expect:   ErrTailFSNotEnabled,
+			expect:   ErrDriveNotEnabled,
 		},
 		{
 			name: "remove",
@@ -2345,7 +2345,7 @@ func TestTailFSManageShares(t *testing.T) {
 			name:     "remove_disabled",
 			disabled: true,
 			remove:   "b",
-			expect:   ErrTailFSNotEnabled,
+			expect:   ErrDriveNotEnabled,
 		},
 		{
 			name: "rename",
@@ -2386,7 +2386,7 @@ func TestTailFSManageShares(t *testing.T) {
 			name:     "rename_disabled",
 			disabled: true,
 			rename:   [2]string{"a", "c"},
-			expect:   ErrTailFSNotEnabled,
+			expect:   ErrDriveNotEnabled,
 		},
 	}
 
@@ -2400,7 +2400,7 @@ func TestTailFSManageShares(t *testing.T) {
 			b := newTestBackend(t)
 			b.mu.Lock()
 			if tt.existing != nil {
-				b.tailFSSetSharesLocked(tt.existing)
+				b.driveSetSharesLocked(tt.existing)
 			}
 			if !tt.disabled {
 				self := b.netMap.SelfNode.AsStruct()
@@ -2423,7 +2423,7 @@ func TestTailFSManageShares(t *testing.T) {
 				func() { wg.Done() },
 				func(n *ipn.Notify) bool {
 					select {
-					case result <- n.TailFSShares:
+					case result <- n.DriveShares:
 					default:
 						//
 					}
@@ -2435,11 +2435,11 @@ func TestTailFSManageShares(t *testing.T) {
 			var err error
 			switch {
 			case tt.add != nil:
-				err = b.TailFSSetShare(tt.add)
+				err = b.DriveSetShare(tt.add)
 			case tt.remove != "":
-				err = b.TailFSRemoveShare(tt.remove)
+				err = b.DriveRemoveShare(tt.remove)
 			default:
-				err = b.TailFSRenameShare(tt.rename[0], tt.rename[1])
+				err = b.DriveRenameShare(tt.rename[0], tt.rename[1])
 			}
 
 			switch e := tt.expect.(type) {

--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -62,7 +62,7 @@ type serveHTTPContext struct {
 //
 // This is not used in userspace-networking mode.
 //
-// localListener is used by tailscale serve (TCP only), the built-in web client and tailfs.
+// localListener is used by tailscale serve (TCP only), the built-in web client and Taildrive.
 // Most serve traffic and peer traffic for the web client are intercepted by netstack.
 // This listener exists purely for connections from the machine itself, as that goes via the kernel,
 // so we need to be in the kernel's listening/routing tables.

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -225,9 +225,9 @@ type Prefs struct {
 	// Linux-only.
 	NetfilterKind string
 
-	// TailFSShares are the configured TailFSShares, stored in increasing order
+	// DriveShares are the configured DriveShares, stored in increasing order
 	// by name.
-	TailFSShares []*drive.Share
+	DriveShares []*drive.Share
 
 	// The Persist field is named 'Config' in the file for backward
 	// compatibility with earlier versions.
@@ -300,7 +300,7 @@ type MaskedPrefs struct {
 	AppConnectorSet           bool                `json:",omitempty"`
 	PostureCheckingSet        bool                `json:",omitempty"`
 	NetfilterKindSet          bool                `json:",omitempty"`
-	TailFSSharesSet           bool                `json:",omitempty"`
+	DriveSharesSet            bool                `json:",omitempty"`
 }
 
 type AutoUpdatePrefsMask struct {
@@ -564,7 +564,7 @@ func (p *Prefs) Equals(p2 *Prefs) bool {
 		p.AutoUpdate.Equals(p2.AutoUpdate) &&
 		p.AppConnector == p2.AppConnector &&
 		p.PostureChecking == p2.PostureChecking &&
-		slices.EqualFunc(p.TailFSShares, p2.TailFSShares, drive.SharesEqual) &&
+		slices.EqualFunc(p.DriveShares, p2.DriveShares, drive.SharesEqual) &&
 		p.NetfilterKind == p2.NetfilterKind
 }
 

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -62,7 +62,7 @@ func TestPrefsEqual(t *testing.T) {
 		"AppConnector",
 		"PostureChecking",
 		"NetfilterKind",
-		"TailFSShares",
+		"DriveShares",
 		"Persist",
 	}
 	if have := fieldsOf(reflect.TypeFor[Prefs]()); !reflect.DeepEqual(have, prefsHandles) {

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -1345,7 +1345,7 @@ const (
 	// PeerCapabilityWebUI grants the ability for a peer to edit features from the
 	// device Web UI.
 	PeerCapabilityWebUI PeerCapability = "tailscale.com/cap/webui"
-	// PeerCapabilityTailFS grants the ability for a peer to access tailfs shares.
+	// PeerCapabilityTailFS grants the ability for a peer to access Taildrive shares.
 	PeerCapabilityTailFS PeerCapability = "tailscale.com/cap/tailfs"
 )
 

--- a/tsd/tsd.go
+++ b/tsd/tsd.go
@@ -38,18 +38,18 @@ import (
 
 // System contains all the subsystems of a Tailscale node (tailscaled, etc.)
 type System struct {
-	Dialer          SubSystem[*tsdial.Dialer]
-	DNSManager      SubSystem[*dns.Manager] // can get its *resolver.Resolver from DNSManager.Resolver
-	Engine          SubSystem[wgengine.Engine]
-	NetMon          SubSystem[*netmon.Monitor]
-	MagicSock       SubSystem[*magicsock.Conn]
-	NetstackRouter  SubSystem[bool] // using Netstack at all (either entirely or at least for subnets)
-	Router          SubSystem[router.Router]
-	Tun             SubSystem[*tstun.Wrapper]
-	StateStore      SubSystem[ipn.StateStore]
-	Netstack        SubSystem[NetstackImpl] // actually a *netstack.Impl
-	TailFSForLocal  SubSystem[drive.FileSystemForLocal]
-	TailFSForRemote SubSystem[drive.FileSystemForRemote]
+	Dialer         SubSystem[*tsdial.Dialer]
+	DNSManager     SubSystem[*dns.Manager] // can get its *resolver.Resolver from DNSManager.Resolver
+	Engine         SubSystem[wgengine.Engine]
+	NetMon         SubSystem[*netmon.Monitor]
+	MagicSock      SubSystem[*magicsock.Conn]
+	NetstackRouter SubSystem[bool] // using Netstack at all (either entirely or at least for subnets)
+	Router         SubSystem[router.Router]
+	Tun            SubSystem[*tstun.Wrapper]
+	StateStore     SubSystem[ipn.StateStore]
+	Netstack       SubSystem[NetstackImpl] // actually a *netstack.Impl
+	DriveForLocal  SubSystem[drive.FileSystemForLocal]
+	DriveForRemote SubSystem[drive.FileSystemForRemote]
 
 	// InitialConfig is initial server config, if any.
 	// It is nil if the node is not in declarative mode.
@@ -102,9 +102,9 @@ func (s *System) Set(v any) {
 	case NetstackImpl:
 		s.Netstack.Set(v)
 	case drive.FileSystemForLocal:
-		s.TailFSForLocal.Set(v)
+		s.DriveForLocal.Set(v)
 	case drive.FileSystemForRemote:
-		s.TailFSForRemote.Set(v)
+		s.DriveForRemote.Set(v)
 	default:
 		panic(fmt.Sprintf("unknown type %T", v))
 	}

--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -529,7 +529,7 @@ func (s *Server) start() (reterr error) {
 	closePool.add(s.dialer)
 	sys.Set(eng)
 
-	// TODO(oxtoacart): do we need to support TailFS on tsnet, and if so, how?
+	// TODO(oxtoacart): do we need to support Taildrive on tsnet, and if so, how?
 	ns, err := netstack.Create(logf, sys.Tun.Get(), eng, sys.MagicSock.Get(), s.dialer, sys.DNSManager.Get(), sys.ProxyMapper(), nil)
 	if err != nil {
 		return fmt.Errorf("netstack.Create: %w", err)

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -204,9 +204,9 @@ type Config struct {
 	// SetSubsystem, if non-nil, is called for each new subsystem created, just before a successful return.
 	SetSubsystem func(any)
 
-	// TailFSForLocal, if populated, will cause the engine to expose a TailFS
+	// DriveForLocal, if populated, will cause the engine to expose a Taildrive
 	// listener at 100.100.100.100:8080.
-	TailFSForLocal drive.FileSystemForLocal
+	DriveForLocal drive.FileSystemForLocal
 }
 
 // NewFakeUserspaceEngine returns a new userspace engine for testing.
@@ -468,8 +468,8 @@ func NewUserspaceEngine(logf logger.Logf, conf Config) (_ Engine, reterr error) 
 		conf.SetSubsystem(conf.Router)
 		conf.SetSubsystem(conf.Dialer)
 		conf.SetSubsystem(e.netMon)
-		if conf.TailFSForLocal != nil {
-			conf.SetSubsystem(conf.TailFSForLocal)
+		if conf.DriveForLocal != nil {
+			conf.SetSubsystem(conf.DriveForLocal)
 		}
 	}
 


### PR DESCRIPTION
This change updates all tailfs functions and the majority of the tailfs variables to use the new drive naming.

Update tailscale/corp#16827