### PR TITLE
cmd/tailscaled: move cleanup to an implicit action during startup

### DIFF
--- a/cmd/tailscaled/tailscaled.service
+++ b/cmd/tailscaled/tailscaled.service
@@ -6,7 +6,6 @@ After=network-pre.target NetworkManager.service systemd-resolved.service
 
 [Service]
 EnvironmentFile=/etc/default/tailscaled
-ExecStartPre=/usr/sbin/tailscaled --cleanup
 ExecStart=/usr/sbin/tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/run/tailscale/tailscaled.sock --port=${PORT} $FLAGS
 ExecStopPost=/usr/sbin/tailscaled --cleanup
 

--- a/net/dns/manager.go
+++ b/net/dns/manager.go
@@ -449,10 +449,10 @@ func (m *Manager) FlushCaches() error {
 	return flushCaches()
 }
 
-// Cleanup restores the system DNS configuration to its original state
+// CleanUp restores the system DNS configuration to its original state
 // in case the Tailscale daemon terminated without closing the router.
 // No other state needs to be instantiated before this runs.
-func Cleanup(logf logger.Logf, interfaceName string) {
+func CleanUp(logf logger.Logf, interfaceName string) {
 	oscfg, err := NewOSConfigurator(logf, interfaceName)
 	if err != nil {
 		logf("creating dns cleanup: %v", err)

--- a/util/linuxfw/iptables_runner.go
+++ b/util/linuxfw/iptables_runner.go
@@ -561,9 +561,9 @@ func (i *iptablesRunner) DelMagicsockPortRule(port uint16, network string) error
 	return nil
 }
 
-// IPTablesCleanup removes all Tailscale added iptables rules.
+// IPTablesCleanUp removes all Tailscale added iptables rules.
 // Any errors that occur are logged to the provided logf.
-func IPTablesCleanup(logf logger.Logf) {
+func IPTablesCleanUp(logf logger.Logf) {
 	err := clearRules(iptables.ProtocolIPv4, logf)
 	if err != nil {
 		logf("linuxfw: clear iptables: %v", err)

--- a/wgengine/router/router.go
+++ b/wgengine/router/router.go
@@ -49,11 +49,11 @@ func New(logf logger.Logf, tundev tun.Device, netMon *netmon.Monitor) (Router, e
 	return newUserspaceRouter(logf, tundev, netMon)
 }
 
-// Cleanup restores the system network configuration to its original state
+// CleanUp restores the system network configuration to its original state
 // in case the Tailscale daemon terminated without closing the router.
 // No other state needs to be instantiated before this runs.
-func Cleanup(logf logger.Logf, interfaceName string) {
-	cleanup(logf, interfaceName)
+func CleanUp(logf logger.Logf, interfaceName string) {
+	cleanUp(logf, interfaceName)
 }
 
 // Config is the subset of Tailscale configuration that is relevant to

--- a/wgengine/router/router_darwin.go
+++ b/wgengine/router/router_darwin.go
@@ -13,6 +13,6 @@ func newUserspaceRouter(logf logger.Logf, tundev tun.Device, netMon *netmon.Moni
 	return newUserspaceBSDRouter(logf, tundev, netMon)
 }
 
-func cleanup(logger.Logf, string) {
+func cleanUp(logger.Logf, string) {
 	// Nothing to do.
 }

--- a/wgengine/router/router_default.go
+++ b/wgengine/router/router_default.go
@@ -18,6 +18,6 @@ func newUserspaceRouter(logf logger.Logf, tunDev tun.Device, netMon *netmon.Moni
 	return nil, fmt.Errorf("unsupported OS %q", runtime.GOOS)
 }
 
-func cleanup(logf logger.Logf, interfaceName string) {
+func cleanUp(logf logger.Logf, interfaceName string) {
 	// Nothing to do here.
 }

--- a/wgengine/router/router_freebsd.go
+++ b/wgengine/router/router_freebsd.go
@@ -18,7 +18,7 @@ func newUserspaceRouter(logf logger.Logf, tundev tun.Device, netMon *netmon.Moni
 	return newUserspaceBSDRouter(logf, tundev, netMon)
 }
 
-func cleanup(logf logger.Logf, interfaceName string) {
+func cleanUp(logf logger.Logf, interfaceName string) {
 	// If the interface was left behind, ifconfig down will not remove it.
 	// In fact, this will leave a system in a tainted state where starting tailscaled
 	// will result in "interface tailscale0 already exists"

--- a/wgengine/router/router_linux.go
+++ b/wgengine/router/router_linux.go
@@ -1396,12 +1396,12 @@ func normalizeCIDR(cidr netip.Prefix) string {
 	return cidr.Masked().String()
 }
 
-// cleanup removes all the rules and routes that were added by the linux router.
-// The function calls cleanup for both iptables and nftables since which ever
-// netfilter runner is used, the cleanup function for the other one doesn't do anything.
-func cleanup(logf logger.Logf, interfaceName string) {
+// cleanUp removes all the rules and routes that were added by the linux router.
+// The function calls cleanUp for both iptables and nftables since which ever
+// netfilter runner is used, the cleanUp function for the other one doesn't do anything.
+func cleanUp(logf logger.Logf, interfaceName string) {
 	if interfaceName != "userspace-networking" {
-		linuxfw.IPTablesCleanup(logf)
+		linuxfw.IPTablesCleanUp(logf)
 		linuxfw.NfTablesCleanUp(logf)
 	}
 }

--- a/wgengine/router/router_openbsd.go
+++ b/wgengine/router/router_openbsd.go
@@ -236,11 +236,11 @@ func (r *openbsdRouter) UpdateMagicsockPort(_ uint16, _ string) error {
 }
 
 func (r *openbsdRouter) Close() error {
-	cleanup(r.logf, r.tunname)
+	cleanUp(r.logf, r.tunname)
 	return nil
 }
 
-func cleanup(logf logger.Logf, interfaceName string) {
+func cleanUp(logf logger.Logf, interfaceName string) {
 	out, err := cmd("ifconfig", interfaceName, "down").CombinedOutput()
 	if err != nil {
 		logf("ifconfig down: %v\n%s", err, out)

--- a/wgengine/router/router_windows.go
+++ b/wgengine/router/router_windows.go
@@ -120,7 +120,7 @@ func (r *winRouter) Close() error {
 	return nil
 }
 
-func cleanup(logf logger.Logf, interfaceName string) {
+func cleanUp(logf logger.Logf, interfaceName string) {
 	// Nothing to do here.
 }
 


### PR DESCRIPTION
This removes a potentially increased boot delay for certain boot topologies where they block on ExecStartPre that may have socket activation dependencies on other system services (such as systemd-resolved and NetworkManager).

Fixes #11599