### PR TITLE
ipn/{ipnlocal,localapi}: add API to toggle use of exit node

### DIFF
--- a/client/tailscale/localclient.go
+++ b/client/tailscale/localclient.go
@@ -1418,6 +1418,15 @@ func (lc *LocalClient) CheckUpdate(ctx context.Context) (*tailcfg.ClientVersion,
 	return &cv, nil
 }
 
+// SetUseExitNode toggles the use of an exit node on or off.
+// To turn it on, there must have been a previously used exit node.
+// The most previously used one is reused.
+// This is a convenience method for GUIs. To select an actual one, update the prefs.
+func (lc *LocalClient) SetUseExitNode(ctx context.Context, on bool) error {
+	_, err := lc.send(ctx, "POST", "/localapi/v0/set-use-exit-node-enabled?enabled="+strconv.FormatBool(on), http.StatusOK, nil)
+	return err
+}
+
 // DriveSetServerAddr instructs Taildrive to use the server at addr to access
 // the filesystem. This is used on platforms like Windows and MacOS to let
 // Taildrive know to use the file server running in the GUI app.

--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -833,6 +833,10 @@ func TestPrefFlagMapping(t *testing.T) {
 			// Handled by the tailscale share subcommand, we don't want a CLI
 			// flag for this.
 			continue
+		case "InternalExitNodePrior":
+			// Used internally by LocalBackend as part of exit node usage toggling.
+			// No CLI flag for this.
+			continue
 		}
 		t.Errorf("unexpected new ipn.Pref field %q is not handled by up.go (see addPrefFlagMapping and checkForAccidentalSettingReverts)", prefName)
 	}

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -42,6 +42,7 @@ var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	AllowSingleHosts       bool
 	ExitNodeID             tailcfg.StableNodeID
 	ExitNodeIP             netip.Addr
+	InternalExitNodePrior  string
 	ExitNodeAllowLANAccess bool
 	CorpDNS                bool
 	RunSSH                 bool

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -69,6 +69,7 @@ func (v PrefsView) RouteAll() bool                     { return v.ж.RouteAll }
 func (v PrefsView) AllowSingleHosts() bool             { return v.ж.AllowSingleHosts }
 func (v PrefsView) ExitNodeID() tailcfg.StableNodeID   { return v.ж.ExitNodeID }
 func (v PrefsView) ExitNodeIP() netip.Addr             { return v.ж.ExitNodeIP }
+func (v PrefsView) InternalExitNodePrior() string      { return v.ж.InternalExitNodePrior }
 func (v PrefsView) ExitNodeAllowLANAccess() bool       { return v.ж.ExitNodeAllowLANAccess }
 func (v PrefsView) CorpDNS() bool                      { return v.ж.CorpDNS }
 func (v PrefsView) RunSSH() bool                       { return v.ж.RunSSH }
@@ -104,6 +105,7 @@ var _PrefsViewNeedsRegeneration = Prefs(struct {
 	AllowSingleHosts       bool
 	ExitNodeID             tailcfg.StableNodeID
 	ExitNodeIP             netip.Addr
+	InternalExitNodePrior  string
 	ExitNodeAllowLANAccess bool
 	CorpDNS                bool
 	RunSSH                 bool

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -105,6 +105,14 @@ type Prefs struct {
 	ExitNodeID tailcfg.StableNodeID
 	ExitNodeIP netip.Addr
 
+	// InternalExitNodePrior is the most recently used ExitNodeID in string form. It is set by
+	// the backend on transition from exit node on to off and used by the
+	// backend. It's not of type tailcfg.StableNodeID because in the future we plan
+	// to overload this field to mean things like "Anything in country $FOO" too.
+	//
+	// As an Internal field, it can't be set by LocalAPI clients.
+	InternalExitNodePrior string
+
 	// ExitNodeAllowLANAccess indicates whether locally accessible subnets should be
 	// routed directly or via the exit node.
 	ExitNodeAllowLANAccess bool
@@ -279,6 +287,7 @@ type MaskedPrefs struct {
 	AllowSingleHostsSet       bool                `json:",omitempty"`
 	ExitNodeIDSet             bool                `json:",omitempty"`
 	ExitNodeIPSet             bool                `json:",omitempty"`
+	InternalExitNodePriorSet  bool                `json:",omitempty"` // Internal; can't be set by LocalAPI clients
 	ExitNodeAllowLANAccessSet bool                `json:",omitempty"`
 	CorpDNSSet                bool                `json:",omitempty"`
 	RunSSHSet                 bool                `json:",omitempty"`
@@ -301,6 +310,12 @@ type MaskedPrefs struct {
 	PostureCheckingSet        bool                `json:",omitempty"`
 	NetfilterKindSet          bool                `json:",omitempty"`
 	DriveSharesSet            bool                `json:",omitempty"`
+}
+
+// SetsInternal reports whether mp has any of the Internal*Set field bools set
+// to true.
+func (mp *MaskedPrefs) SetsInternal() bool {
+	return mp.InternalExitNodePriorSet
 }
 
 type AutoUpdatePrefsMask struct {
@@ -544,6 +559,7 @@ func (p *Prefs) Equals(p2 *Prefs) bool {
 		p.AllowSingleHosts == p2.AllowSingleHosts &&
 		p.ExitNodeID == p2.ExitNodeID &&
 		p.ExitNodeIP == p2.ExitNodeIP &&
+		p.InternalExitNodePrior == p2.InternalExitNodePrior &&
 		p.ExitNodeAllowLANAccess == p2.ExitNodeAllowLANAccess &&
 		p.CorpDNS == p2.CorpDNS &&
 		p.RunSSH == p2.RunSSH &&

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -41,6 +41,7 @@ func TestPrefsEqual(t *testing.T) {
 		"AllowSingleHosts",
 		"ExitNodeID",
 		"ExitNodeIP",
+		"InternalExitNodePrior",
 		"ExitNodeAllowLANAccess",
 		"CorpDNS",
 		"RunSSH",
@@ -612,6 +613,19 @@ func TestLoadPrefsFileWithZeroInIt(t *testing.T) {
 		return
 	}
 	t.Fatalf("unexpected prefs=%#v, err=%v", p, err)
+}
+
+func TestMaskedPrefsSetsInternal(t *testing.T) {
+	for _, f := range fieldsOf(reflect.TypeFor[MaskedPrefs]()) {
+		if !strings.HasSuffix(f, "Set") || !strings.HasPrefix(f, "Internal") {
+			continue
+		}
+		mp := new(MaskedPrefs)
+		reflect.ValueOf(mp).Elem().FieldByName(f).SetBool(true)
+		if !mp.SetsInternal() {
+			t.Errorf("MaskedPrefs.%sSet=true but SetsInternal=false", f)
+		}
+	}
 }
 
 func TestMaskedPrefsFields(t *testing.T) {


### PR DESCRIPTION
This is primarily for GUIs, so they don't need to remember the most
recently used exit node themselves.

This adds some CLI commands, but they're disabled and behind the WIP
envknob, as we need to consider naming (on/off is ambiguous with
running an exit node, etc) as well as automatic exit node selection in
the future. For now the CLI commands are effectively developer debug
things to test the LocalAPI.

Updates tailscale/corp#18724

