### PR TITLE
prober: support creating multiple probes in ForEachAddr

### DIFF
--- a/prober/dns_example_test.go
+++ b/prober/dns_example_test.go
@@ -39,14 +39,15 @@ func ExampleForEachAddr() {
 	}
 
 	// This function is called every time we discover a new IP address to check.
-	makeTLSProbe := func(addr netip.Addr) *prober.Probe {
+	makeTLSProbe := func(addr netip.Addr) []*prober.Probe {
 		pf := prober.TLSWithIP(*hostname, netip.AddrPortFrom(addr, 443))
 		if *verbose {
 			logger := logger.WithPrefix(log.Printf, fmt.Sprintf("[tls %s]: ", addr))
 			pf = probeLogWrapper(logger, pf)
 		}
 
-		return p.Run(fmt.Sprintf("website/%s/tls", addr), every30s, nil, pf)
+		probe := p.Run(fmt.Sprintf("website/%s/tls", addr), every30s, nil, pf)
+		return []*prober.Probe{probe}
 	}
 
 	// Determine whether to use IPv4 or IPv6 based on whether we can create

--- a/prober/dns_test.go
+++ b/prober/dns_test.go
@@ -48,7 +48,7 @@ func TestForEachAddr(t *testing.T) {
 		mu         sync.Mutex // protects following
 		registered []netip.Addr
 	)
-	newProbe := func(addr netip.Addr) *Probe {
+	newProbe := func(addr netip.Addr) []*Probe {
 		// Called to register a new prober
 		t.Logf("called to register new probe for %v", addr)
 
@@ -57,9 +57,10 @@ func TestForEachAddr(t *testing.T) {
 		registered = append(registered, addr)
 
 		// Return a probe that does nothing; we don't care about what this does.
-		return p.Run(fmt.Sprintf("website/%s", addr), probeInterval, nil, func(_ context.Context) error {
+		probe := p.Run(fmt.Sprintf("website/%s", addr), probeInterval, nil, func(_ context.Context) error {
 			return nil
 		})
+		return []*Probe{probe}
 	}
 
 	fep := makeForEachAddr("tailscale.com", newProbe, opts)


### PR DESCRIPTION
So that we can e.g. check TLS on multiple ports for a given IP.

Updates tailscale/corp#16367

Change-Id: I81d840a4c88138de1cbb2032b917741c009470e6