### PR TITLE
 drive: move normalizeShareName into pkg drive and make func public

### DIFF
--- a/drive/remote_test.go
+++ b/drive/remote_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-package ipnlocal
+package drive
 
 import (
 	"fmt"
@@ -29,7 +29,7 @@ func TestNormalizeShareName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("name %q", tt.name), func(t *testing.T) {
-			got, err := normalizeShareName(tt.name)
+			got, err := NormalizeShareName(tt.name)
 			if tt.err != nil && err != tt.err {
 				t.Errorf("wanted error %v, got %v", tt.err, err)
 			} else if got != tt.want {

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -2404,13 +2404,13 @@ func TestDriveManageShares(t *testing.T) {
 		{
 			name:   "add_bad_name",
 			add:    &drive.Share{Name: "$"},
-			expect: ErrInvalidShareName,
+			expect: drive.ErrInvalidShareName,
 		},
 		{
 			name:     "add_disabled",
 			disabled: true,
 			add:      &drive.Share{Name: "a"},
-			expect:   ErrDriveNotEnabled,
+			expect:   drive.ErrDriveNotEnabled,
 		},
 		{
 			name: "remove",
@@ -2439,7 +2439,7 @@ func TestDriveManageShares(t *testing.T) {
 			name:     "remove_disabled",
 			disabled: true,
 			remove:   "b",
-			expect:   ErrDriveNotEnabled,
+			expect:   drive.ErrDriveNotEnabled,
 		},
 		{
 			name: "rename",
@@ -2474,13 +2474,13 @@ func TestDriveManageShares(t *testing.T) {
 		{
 			name:   "rename_bad_name",
 			rename: [2]string{"a", "$"},
-			expect: ErrInvalidShareName,
+			expect: drive.ErrInvalidShareName,
 		},
 		{
 			name:     "rename_disabled",
 			disabled: true,
 			rename:   [2]string{"a", "c"},
-			expect:   ErrDriveNotEnabled,
+			expect:   drive.ErrDriveNotEnabled,
 		},
 	}
 

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -2792,7 +2792,7 @@ func (h *Handler) serveShares(w http.ResponseWriter, r *http.Request) {
 		}
 		err = h.b.DriveSetShare(&share)
 		if err != nil {
-			if errors.Is(err, ipnlocal.ErrInvalidShareName) {
+			if errors.Is(err, drive.ErrInvalidShareName) {
 				http.Error(w, "invalid share name", http.StatusBadRequest)
 				return
 			}
@@ -2833,7 +2833,7 @@ func (h *Handler) serveShares(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, "share name already used", http.StatusBadRequest)
 				return
 			}
-			if errors.Is(err, ipnlocal.ErrInvalidShareName) {
+			if errors.Is(err, drive.ErrInvalidShareName) {
 				http.Error(w, "invalid share name", http.StatusBadRequest)
 				return
 			}


### PR DESCRIPTION
This change makes the normalizeShareName function public, so it can be
used for validation in control.