### PR TITLE
util/linuxfw: fix chain comparison

### DIFF
--- a/util/linuxfw/nftables_runner.go
+++ b/util/linuxfw/nftables_runner.go
@@ -447,7 +447,7 @@ func getOrCreateChain(c *nftables.Conn, cinfo chainInfo) (*nftables.Chain, error
 		// type/hook/priority, but for "conventional chains" assume they're what
 		// we expect (in case iptables-nft/ufw make minor behavior changes in
 		// the future).
-		if isTSChain(chain.Name) && (chain.Type != cinfo.chainType || chain.Hooknum != cinfo.chainHook || chain.Priority != cinfo.chainPriority) {
+		if isTSChain(chain.Name) && (chain.Type != cinfo.chainType || *chain.Hooknum != *cinfo.chainHook || *chain.Priority != *cinfo.chainPriority) {
 			return nil, fmt.Errorf("chain %s already exists with different type/hook/priority", cinfo.name)
 		}
 		return chain, nil


### PR DESCRIPTION
Don't compare pointer fields by pointer value, but by the actual value.

`getOrCreateChain` creates a nftables chain template and, for chains prefixed with `ts-`, if a chain already exists checks if the hook and priority are the same.
The check was comparing pointer fields by pointer value. Looks like it was never run a second time with a pre-existing `ts-` chain (?), but started failing in containers after I added #11588 which adds a new `ts-` chain that we attempt to 'get or create' potentially mutliple times during container run if some underlying values (proxy's backend IP) changes.

Updates#cleanup