### PR TITLE
net/tsdial: partially fix "tailscale nc" (UserDial) on macOS

### DIFF
--- a/cmd/tailscale/cli/ssh.go
+++ b/cmd/tailscale/cli/ssh.go
@@ -106,10 +106,8 @@ func runSSH(ctx context.Context, args []string) error {
 		"-o", "CanonicalizeHostname no", // https://github.com/tailscale/tailscale/issues/10348
 	)
 
-	// TODO(bradfitz): nc is currently broken on macOS:
-	// https://github.com/tailscale/tailscale/issues/4529
-	// So don't use it for now. MagicDNS is usually working on macOS anyway
-	// and they're not in userspace mode, so 'nc' isn't very useful.
+	// MagicDNS is usually working on macOS anyway and they're not in userspace
+	// mode, so 'nc' isn't very useful.
 	if runtime.GOOS != "darwin" {
 		socketArg := ""
 		if rootArgs.socket != "" && rootArgs.socket != paths.DefaultTailscaledSocket() {

--- a/version/prop.go
+++ b/version/prop.go
@@ -40,6 +40,15 @@ func OS() string {
 	return runtime.GOOS
 }
 
+// IsMacGUIVariant reports whether runtime.GOOS=="darwin" and this one of the
+// two GUI variants (that is, not tailscaled-on-macOS).
+// This predicate should not be used to determine sandboxing properties. It's
+// meant for callers to determine whether the NetworkExtension-like auto-netns
+// is in effect.
+func IsMacGUIVariant() bool {
+	return IsMacAppStore() || IsMacSysExt()
+}
+
 // IsSandboxedMacOS reports whether this process is a sandboxed macOS
 // process (either the app or the extension). It is true for the Mac App Store
 // and macsys (System Extension) version on macOS, and false for


### PR DESCRIPTION
net/tsdial: partially fix "tailscale nc" (UserDial) on macOS

At least in the case of dialing a Tailscale IP.

Updates #4529