### PR TITLE
scripts/installer.sh: add rpm GPG key import

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -504,6 +504,7 @@ main() {
 		;;
 		zypper)
 			set -x
+			$SUDO rpm --import "https://pkgs.tailscale.com/$TRACK/$OS/$VERSION/repo.gpg"
 			$SUDO zypper --non-interactive ar -g -r "https://pkgs.tailscale.com/$TRACK/$OS/$VERSION/tailscale.repo"
 			$SUDO zypper --non-interactive --gpg-auto-import-keys refresh
 			$SUDO zypper --non-interactive install tailscale


### PR DESCRIPTION
Extend the `zypper` install to import importing the GPG key used to sign the repository packages.

Fixes #11635