### PR TITLE
licenses: add gliderlabs/ssh license

### DIFF
--- a/.github/licenses.tmpl
+++ b/.github/licenses.tmpl
@@ -15,3 +15,4 @@ Some packages may only be included on certain architectures or operating systems
 {{ range . }}
  - [{{.Name}}](https://pkg.go.dev/{{.Name}}) ([{{.LicenseName}}]({{.LicenseURL}}))
 {{- end }}
+ - [gliderlabs/ssh](https://github.com/tailscale/tailscale/tree/main/tempfork/gliderlabs/ssh) ([BSD-3-Clause](https://github.com/tailscale/tailscale/blob/main/tempfork/gliderlabs/ssh/LICENSE))


### PR DESCRIPTION
This package is included in the tempfork directory, rather than as a go module dependency, so is not included in the normal package list.

Updates tailscale/corp#5780