### PR TITLE
ipn/local: log OS-specific diagnostic information as JSON

### DIFF
--- a/cmd/tailscaled/tailscaled_windows.go
+++ b/cmd/tailscaled/tailscaled_windows.go
@@ -131,7 +131,7 @@ var syslogf logger.Logf = logger.Discard
 // Windows started.
 func runWindowsService(pol *logpolicy.Policy) error {
 	go func() {
-		osdiag.LogSupportInfo(logger.WithPrefix(log.Printf, "Support Info: "), osdiag.LogSupportInfoReasonStartup)
+		logger.Logf(log.Printf).JSON(1, "SupportInfo", osdiag.SupportInfo(osdiag.LogSupportInfoReasonStartup))
 	}()
 
 	if logSCMInteractions, _ := syspolicy.GetBoolean(syspolicy.LogSCMInteractions, false); logSCMInteractions {

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -379,7 +379,7 @@ func (h *Handler) serveBugReport(w http.ResponseWriter, r *http.Request) {
 	envknob.LogCurrent(logger.WithPrefix(h.logf, "user bugreport: "))
 
 	// OS-specific details
-	osdiag.LogSupportInfo(logger.WithPrefix(h.logf, "user bugreport OS: "), osdiag.LogSupportInfoReasonBugReport)
+	h.logf.JSON(1, "UserBugReportOS", osdiag.SupportInfo(osdiag.LogSupportInfoReasonBugReport))
 
 	if defBool(r.URL.Query().Get("diagnose"), false) {
 		h.b.Doctor(r.Context(), logger.WithPrefix(h.logf, "diag: "))

--- a/util/osdiag/osdiag.go
+++ b/util/osdiag/osdiag.go
@@ -4,8 +4,6 @@
 // Package osdiag provides loggers for OS-specific diagnostic information.
 package osdiag
 
-import "tailscale.com/types/logger"
-
 // LogSupportInfoReason is an enumeration indicating the reason for logging
 // support info.
 type LogSupportInfoReason int
@@ -15,9 +13,8 @@ const (
 	LogSupportInfoReasonBugReport                                 // a bugreport is in the process of being gathered.
 )
 
-// LogSupportInfo obtains OS-specific diagnostic information useful for
-// troubleshooting and support, and writes it to logf. The reason argument is
-// useful for governing the verbosity of this function's output.
-func LogSupportInfo(logf logger.Logf, reason LogSupportInfoReason) {
-	logSupportInfo(logf, reason)
+// SupportInfo obtains OS-specific diagnostic information for troubleshooting
+// and support. The reason governs the verbosity of the output.
+func SupportInfo(reason LogSupportInfoReason) map[string]any {
+	return supportInfo(reason)
 }

--- a/util/osdiag/osdiag_notwindows.go
+++ b/util/osdiag/osdiag_notwindows.go
@@ -5,7 +5,6 @@
 
 package osdiag
 
-import "tailscale.com/types/logger"
-
-func logSupportInfo(logger.Logf, LogSupportInfoReason) {
+func supportInfo(LogSupportInfoReason) map[string]any {
+	return nil
 }


### PR DESCRIPTION
There is an undocumented 16KiB limit for text log messages. However, the limit for JSON messages is 256KiB.
Even worse, logging JSON as text results in significant overhead since each double quote needs to be escaped.

Instead, use logger.Logf.JSON to explicitly log the info as JSON.

We also modify osdiag to return the information as structured data rather than implicitly have the package log on our behalf. This gives more control to the caller on how to log.

Updates #7802