### PR TITLE
Revert "licenses: add gliderlabs/ssh license"

### DIFF
--- a/.github/licenses.tmpl
+++ b/.github/licenses.tmpl
@@ -15,4 +15,3 @@ Some packages may only be included on certain architectures or operating systems
 {{ range . }}
  - [{{.Name}}](https://pkg.go.dev/{{.Name}}) ([{{.LicenseName}}]({{.LicenseURL}}))
 {{- end }}
- - [gliderlabs/ssh](https://github.com/tailscale/tailscale/tree/main/tempfork/gliderlabs/ssh) ([BSD-3-Clause](https://github.com/tailscale/tailscale/blob/main/tempfork/gliderlabs/ssh/LICENSE))


### PR DESCRIPTION
The gliderlabs/ssh license is actually already included in the standard package listing.  I'm not sure why I thought it wasn't.

Updates tailscale/corp#5780

This reverts commit 11dca08e93b001b93bce6dc4435e7ad2f44d326a.