### PR TITLE
ipn: remove unused Options.LegacyMigrationPrefs

### DIFF
--- a/ipn/backend.go
+++ b/ipn/backend.go
@@ -232,18 +232,11 @@ var DebuggableComponents = []string{
 type Options struct {
 	// FrontendLogID is the public logtail id used by the frontend.
 	FrontendLogID string
-	// LegacyMigrationPrefs are used to migrate preferences from the
-	// frontend to the backend.
-	// If non-nil, they are imported as a new profile.
-	LegacyMigrationPrefs *Prefs `json:"Prefs"`
-	// UpdatePrefs, if provided, overrides Options.LegacyMigrationPrefs
-	// *and* the Prefs already stored in the backend state, *except* for
-	// the Persist member. If you just want to provide prefs, this is
-	// probably what you want.
+	// UpdatePrefs, if provided, overrides the Prefs already stored in the
+	// backend state, *except* for the Persist member.
 	//
 	// TODO(apenwarr): Rename this to Prefs, and possibly move Prefs.Persist
-	//   elsewhere entirely (as it always should have been). Or, move the
-	//   fancy state migration stuff out of Start().
+	// elsewhere entirely (as it always should have been).
 	UpdatePrefs *Prefs
 	// AuthKey is an optional node auth key used to authorize a
 	// new node key without user interaction.

--- a/wgengine/netstack/netstack_test.go
+++ b/wgengine/netstack/netstack_test.go
@@ -292,7 +292,7 @@ func TestShouldProcessInbound(t *testing.T) {
 					netip.MustParsePrefix("fd7a:115c:a1e0:b1a:0:7:a01:100/120"),
 				}
 				i.lb.Start(ipn.Options{
-					LegacyMigrationPrefs: prefs,
+					UpdatePrefs: prefs,
 				})
 				i.atomicIsLocalIPFunc.Store(looksLikeATailscaleSelfAddress)
 			},
@@ -325,7 +325,7 @@ func TestShouldProcessInbound(t *testing.T) {
 					netip.MustParsePrefix("fd7a:115c:a1e0:b1a:0:7:a01:200/120"),
 				}
 				i.lb.Start(ipn.Options{
-					LegacyMigrationPrefs: prefs,
+					UpdatePrefs: prefs,
 				})
 			},
 			want: false,
@@ -343,7 +343,7 @@ func TestShouldProcessInbound(t *testing.T) {
 				prefs := ipn.NewPrefs()
 				prefs.RunSSH = true
 				i.lb.Start(ipn.Options{
-					LegacyMigrationPrefs: prefs,
+					UpdatePrefs: prefs,
 				})
 				i.atomicIsLocalIPFunc.Store(func(addr netip.Addr) bool {
 					return addr.String() == "100.101.102.104" // Dst, above
@@ -365,7 +365,7 @@ func TestShouldProcessInbound(t *testing.T) {
 				prefs := ipn.NewPrefs()
 				prefs.RunSSH = false // default, but to be explicit
 				i.lb.Start(ipn.Options{
-					LegacyMigrationPrefs: prefs,
+					UpdatePrefs: prefs,
 				})
 				i.atomicIsLocalIPFunc.Store(func(addr netip.Addr) bool {
 					return addr.String() == "100.101.102.104" // Dst, above
@@ -430,7 +430,7 @@ func TestShouldProcessInbound(t *testing.T) {
 					netip.MustParsePrefix("10.0.0.1/24"),
 				}
 				i.lb.Start(ipn.Options{
-					LegacyMigrationPrefs: prefs,
+					UpdatePrefs: prefs,
 				})
 
 				// Set the PeerAPI port to the Dst port above.
@@ -549,7 +549,7 @@ func TestTCPForwardLimits(t *testing.T) {
 		netip.MustParsePrefix("192.0.2.0/24"),
 	}
 	impl.lb.Start(ipn.Options{
-		LegacyMigrationPrefs: prefs,
+		UpdatePrefs: prefs,
 	})
 	impl.atomicIsLocalIPFunc.Store(looksLikeATailscaleSelfAddress)
 
@@ -629,7 +629,7 @@ func TestTCPForwardLimits_PerClient(t *testing.T) {
 		netip.MustParsePrefix("192.0.2.0/24"),
 	}
 	impl.lb.Start(ipn.Options{
-		LegacyMigrationPrefs: prefs,
+		UpdatePrefs: prefs,
 	})
 	impl.atomicIsLocalIPFunc.Store(looksLikeATailscaleSelfAddress)
 


### PR DESCRIPTION
I'm on a mission to simplify LocalBackend.Start and its locking
and deflake some tests.

I noticed this hasn't been used since March 2023 when it was removed
from the Windows client in corp 66be796d33c.

So, delete.

Updates #11649
