### PR TITLE
ipn/ipnlocal: strip origin and referer headers from Taildrive requests

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -4817,15 +4817,16 @@ func (rbw *responseBodyWrapper) Close() error {
 }
 
 func (dt *driveTransport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+	// Some WebDAV clients include origin and refer headers, which peerapi does
+	// not like. Remove them.
+	req.Header.Del("origin")
+	req.Header.Del("referer")
+
 	bw := &requestBodyWrapper{}
 	if req.Body != nil {
 		bw.ReadCloser = req.Body
 		req.Body = bw
 	}
-
-	// Strip origin and referer headers
-	req.Header.Del("origin")
-	req.Header.Del("referer")
 
 	defer func() {
 		contentType := "unknown"

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -4823,6 +4823,10 @@ func (dt *driveTransport) RoundTrip(req *http.Request) (resp *http.Response, err
 		req.Body = bw
 	}
 
+	// Strip origin and referer headers
+	req.Header.Del("origin")
+	req.Header.Del("referer")
+
 	defer func() {
 		contentType := "unknown"
 		switch req.Method {


### PR DESCRIPTION
peerapi does not want these, but rclone includes them. Stripping them out allows rclone to work with Taildrive configured as a WebDAV remote.

Updates #cleanup