### PR TITLE
tailcfg: document use of CapMap for peers

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -340,6 +340,16 @@ type Node struct {
 	// CapMap with an empty value.
 	//
 	// See NodeCapability for more information on keys.
+	//
+	// Metadata about nodes can be transmitted in 3 ways:
+	// 1. MapResponse.Node.CapMap describes attributes that affect behavior for
+	//    this node, such as which features have been enabled through the admin
+	//    panel and any associated configuration details.
+	// 2. MapResponse.PacketFilter(s) describes access (both IP and application
+	//    based) that should be granted to peers.
+	// 3. MapResponse.Peers[].CapMap describes attributes regarding a peer node,
+	//    such as which features the peer supports or if that peer is preferred
+	//    for a particular task vs other peers that could also be chosen.
 	CapMap NodeCapMap `json:",omitempty"`
 
 	// UnsignedPeerAPIOnly means that this node is not signed nor subject to TKA


### PR DESCRIPTION
Updates tailscale/corp#17516
Updates #11508

Change-Id: Iad2dafb38ffb9948bc2f3dfaf9c268f7d772cf56

 This supercedes #11379 and resolves the [documentation request discussion](https://github.com/tailscale/corp/pull/18027#discussion_r1515168103) in tailscale/corp#11379