### PR TITLE
net/interfaces: delete unused unexported function

### DIFF
--- a/net/interfaces/interfaces.go
+++ b/net/interfaces/interfaces.go
@@ -662,16 +662,6 @@ func (s *State) keepInterfaceInStringSummary(ifName string) bool {
 	return false
 }
 
-// isInterestingIP reports whether ip is an interesting IP that we
-// should log in interfaces.State logging. We don't need to show
-// loopback, link-local addresses, or non-Tailscale ULA addresses.
-func isInterestingIP(ip netip.Addr) bool {
-	if ip.IsLoopback() || ip.IsLinkLocalUnicast() {
-		return false
-	}
-	return true
-}
-
 var altNetInterfaces func() ([]Interface, error)
 
 // RegisterInterfaceGetter sets the function that's used to query

--- a/net/interfaces/interfaces_test.go
+++ b/net/interfaces/interfaces_test.go
@@ -284,27 +284,6 @@ func TestStateString(t *testing.T) {
 	}
 }
 
-func TestIsInterestingIP(t *testing.T) {
-	tests := []struct {
-		ip   string
-		want bool
-	}{
-		{"fd7a:115c:a1e0:ab12:4843:cd96:624a:4603", true}, // Tailscale private ULA
-		{"fd15:bbfa:c583:4fce:f4fb:4ff:fe1a:4148", true},  // Other private ULA
-		{"10.2.3.4", true},
-		{"127.0.0.1", false},
-		{"::1", false},
-		{"2001::2", true},
-		{"169.254.1.2", false},
-		{"fe80::1", false},
-	}
-	for _, tt := range tests {
-		if got := isInterestingIP(netip.MustParseAddr(tt.ip)); got != tt.want {
-			t.Errorf("isInterestingIP(%q) = %v, want %v", tt.ip, got, tt.want)
-		}
-	}
-}
-
 // tests (*State).Equal
 func TestEqual(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
It should've been deleted in 11ece02f5246dee.

Updates #9040
