### PR TITLE
ipn/store: omit AWS & Kubernetes support on 'small' Linux GOARCHes

### DIFF
--- a/build_docker.sh
+++ b/build_docker.sh
@@ -49,6 +49,7 @@ case "$TARGET" in
         -X tailscale.com/version.gitCommitStamp=${VERSION_GIT_HASH}" \
       --base="${BASE}" \
       --tags="${TAGS}" \
+      --gotags="ts_kube" \
       --repos="${REPOS}" \
       --push="${PUSH}" \
       --target="${PLATFORM}" \

--- a/ipn/store/store_aws.go
+++ b/ipn/store/store_aws.go
@@ -1,0 +1,18 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build (ts_aws || (linux && (arm64 || amd64))) && !ts_omit_aws
+
+package store
+
+import (
+	"tailscale.com/ipn/store/awsstore"
+)
+
+func init() {
+	registerAvailableExternalStores = append(registerAvailableExternalStores, registerAWSStore)
+}
+
+func registerAWSStore() {
+	Register("arn:", awsstore.New)
+}

--- a/ipn/store/store_kube.go
+++ b/ipn/store/store_kube.go
@@ -1,25 +1,25 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
+//go:build (ts_kube || (linux && (arm64 || amd64))) && !ts_omit_kube
+
 package store
 
 import (
 	"strings"
 
 	"tailscale.com/ipn"
-	"tailscale.com/ipn/store/awsstore"
 	"tailscale.com/ipn/store/kubestore"
 	"tailscale.com/types/logger"
 )
 
 func init() {
-	registerAvailableExternalStores = registerExternalStores
+	registerAvailableExternalStores = append(registerAvailableExternalStores, registerKubeStore)
 }
 
-func registerExternalStores() {
+func registerKubeStore() {
 	Register("kube:", func(logf logger.Logf, path string) (ipn.StateStore, error) {
 		secretName := strings.TrimPrefix(path, "kube:")
 		return kubestore.New(logf, secretName)
 	})
-	Register("arn:", awsstore.New)
 }

--- a/ipn/store/stores.go
+++ b/ipn/store/stores.go
@@ -28,13 +28,13 @@ type Provider func(logf logger.Logf, arg string) (ipn.StateStore, error)
 
 var regOnce sync.Once
 
-var registerAvailableExternalStores func()
+var registerAvailableExternalStores []func()
 
 func registerDefaultStores() {
 	Register("mem:", mem.New)
 
-	if registerAvailableExternalStores != nil {
-		registerAvailableExternalStores()
+	for _, f := range registerAvailableExternalStores {
+		f()
 	}
 }
 


### PR DESCRIPTION
This removes AWS and Kubernetes support from Linux binaries by default
on GOARCH values where people don't typically run on AWS or use
Kubernetes, such as 32-bit mips CPUs.

It primarily focuses on optimizing for the static binaries we
distribute. But for people building it themselves, they can set
ts_kube or ts_aws (the opposite of ts_omit_kube or ts_omit_aws) to
force it back on.

Makes tailscaled binary ~2.3MB (~7%) smaller.

Updates #7272, #10627 etc
