### PR TITLE
safeweb: allow object-src: self in CSP

### DIFF
--- a/safeweb/http.go
+++ b/safeweb/http.go
@@ -89,7 +89,7 @@ var defaultCSP = strings.Join([]string{
 	`form-action 'self'`,      // disallow form submissions to other origins
 	`base-uri 'self'`,         // disallow base URIs from other origins
 	`block-all-mixed-content`, // disallow mixed content when serving over HTTPS
-	`object-src 'none'`,       // disallow embedding of resources from other origins
+	`object-src 'self'`,       // disallow embedding of resources from other origins
 }, "; ")
 
 // Config contains the configuration for a safeweb server.


### PR DESCRIPTION
This change is safe (self is still safe, by
definition), and makes the code match the comment.

Updates #cleanup