### PR TITLE
drive: rewrite Location headers

### DIFF
--- a/drive/driveimpl/compositedav/propfind.go
+++ b/drive/driveimpl/compositedav/propfind.go
@@ -37,7 +37,7 @@ func (h *Handler) handlePROPFIND(w http.ResponseWriter, r *http.Request) {
 		bw := &bufferingResponseWriter{ResponseWriter: w}
 
 		mpl := h.maxPathLength(r)
-		h.delegate(pathComponents[mpl-1:], bw, r)
+		h.delegate(mpl, pathComponents[mpl-1:], bw, r)
 
 		// Fixup paths to add the requested path as a prefix.
 		pathPrefix := shared.Join(pathComponents[0:mpl]...)

--- a/drive/driveimpl/shared/pathutil.go
+++ b/drive/driveimpl/shared/pathutil.go
@@ -4,6 +4,7 @@
 package shared
 
 import (
+	"net/url"
 	"path"
 	"strings"
 )
@@ -31,6 +32,16 @@ func Join(parts ...string) string {
 	fullParts = append(fullParts, sepString)
 	for _, part := range parts {
 		fullParts = append(fullParts, part)
+	}
+	return path.Join(fullParts...)
+}
+
+// JoinEscaped is like Join but path escapes each part.
+func JoinEscaped(parts ...string) string {
+	fullParts := make([]string, 0, len(parts))
+	fullParts = append(fullParts, sepString)
+	for _, part := range parts {
+		fullParts = append(fullParts, url.PathEscape(part))
 	}
 	return path.Join(fullParts...)
 }


### PR DESCRIPTION
This ensures that MOVE, LOCK and any other verbs that use the Location header work correctly.

Fixes #11758