### PR TITLE
cmd{containerboot,k8s-operator},util/linuxfw: support ExternalName Services

### DIFF
--- a/cmd/k8s-operator/sts.go
+++ b/cmd/k8s-operator/sts.go
@@ -87,6 +87,7 @@ const (
 	// ensure that it does not get removed when a ProxyClass configuration
 	// is applied.
 	podAnnotationLastSetClusterIP         = "tailscale.com/operator-last-set-cluster-ip"
+	podAnnotationLastSetClusterDNSName    = "tailscale.com/operator-last-set-cluster-dns-name"
 	podAnnotationLastSetTailnetTargetIP   = "tailscale.com/operator-last-set-ts-tailnet-target-ip"
 	podAnnotationLastSetTailnetTargetFQDN = "tailscale.com/operator-last-set-ts-tailnet-target-fqdn"
 	// podAnnotationLastSetConfigFileHash is sha256 hash of the current tailscaled configuration contents.
@@ -109,8 +110,9 @@ type tailscaleSTSConfig struct {
 	ParentResourceUID   string
 	ChildResourceLabels map[string]string
 
-	ServeConfig     *ipn.ServeConfig // if serve config is set, this is a proxy for Ingress
-	ClusterTargetIP string           // ingress target
+	ServeConfig          *ipn.ServeConfig // if serve config is set, this is a proxy for Ingress
+	ClusterTargetIP      string           // ingress target IP
+	ClusterTargetDNSName string           // ingress target DNS name
 	// If set to true, operator should configure containerboot to forward
 	// cluster traffic via the proxy set up for Kubernetes Ingress.
 	ForwardClusterTrafficViaL7IngressProxy bool
@@ -536,6 +538,12 @@ func (a *tailscaleSTSReconciler) reconcileSTS(ctx context.Context, logger *zap.S
 			Value: sts.ClusterTargetIP,
 		})
 		mak.Set(&ss.Spec.Template.Annotations, podAnnotationLastSetClusterIP, sts.ClusterTargetIP)
+	} else if sts.ClusterTargetDNSName != "" {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  "TS_DEST_DNS_NAME",
+			Value: sts.ClusterTargetDNSName,
+		})
+		mak.Set(&ss.Spec.Template.Annotations, podAnnotationLastSetClusterDNSName, sts.ClusterTargetDNSName)
 	} else if sts.TailnetTargetIP != "" {
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name:  "TS_TAILNET_TARGET_IP",

--- a/cmd/k8s-operator/sts.go
+++ b/cmd/k8s-operator/sts.go
@@ -540,7 +540,7 @@ func (a *tailscaleSTSReconciler) reconcileSTS(ctx context.Context, logger *zap.S
 		mak.Set(&ss.Spec.Template.Annotations, podAnnotationLastSetClusterIP, sts.ClusterTargetIP)
 	} else if sts.ClusterTargetDNSName != "" {
 		container.Env = append(container.Env, corev1.EnvVar{
-			Name:  "TS_DEST_DNS_NAME",
+			Name:  "TS_EXPERIMENTAL_DEST_DNS_NAME",
 			Value: sts.ClusterTargetDNSName,
 		})
 		mak.Set(&ss.Spec.Template.Annotations, podAnnotationLastSetClusterDNSName, sts.ClusterTargetDNSName)

--- a/cmd/k8s-operator/testutils_test.go
+++ b/cmd/k8s-operator/testutils_test.go
@@ -43,6 +43,7 @@ type configOpts struct {
 	tailnetTargetIP                                string
 	tailnetTargetFQDN                              string
 	clusterTargetIP                                string
+	clusterTargetDNS                               string
 	subnetRoutes                                   string
 	isExitNode                                     bool
 	confFileHash                                   string
@@ -126,6 +127,12 @@ func expectedSTS(t *testing.T, cl client.Client, opts configOpts) *appsv1.Statef
 			Value: opts.clusterTargetIP,
 		})
 		annots["tailscale.com/operator-last-set-cluster-ip"] = opts.clusterTargetIP
+	} else if opts.clusterTargetDNS != "" {
+		tsContainer.Env = append(tsContainer.Env, corev1.EnvVar{
+			Name:  "TS_DEST_DNS_NAME",
+			Value: opts.clusterTargetDNS,
+		})
+		annots["tailscale.com/operator-last-set-cluster-dns-name"] = opts.clusterTargetDNS
 	}
 	if opts.serveConfig != nil {
 		tsContainer.Env = append(tsContainer.Env, corev1.EnvVar{

--- a/cmd/k8s-operator/testutils_test.go
+++ b/cmd/k8s-operator/testutils_test.go
@@ -129,7 +129,7 @@ func expectedSTS(t *testing.T, cl client.Client, opts configOpts) *appsv1.Statef
 		annots["tailscale.com/operator-last-set-cluster-ip"] = opts.clusterTargetIP
 	} else if opts.clusterTargetDNS != "" {
 		tsContainer.Env = append(tsContainer.Env, corev1.EnvVar{
-			Name:  "TS_DEST_DNS_NAME",
+			Name:  "TS_EXPERIMENTAL_DEST_DNS_NAME",
 			Value: opts.clusterTargetDNS,
 		})
 		annots["tailscale.com/operator-last-set-cluster-dns-name"] = opts.clusterTargetDNS

--- a/wgengine/router/router_linux_test.go
+++ b/wgengine/router/router_linux_test.go
@@ -470,6 +470,10 @@ func (n *fakeIPTablesRunner) AddDNATRule(origDst, dst netip.Addr) error {
 	return errors.New("not implemented")
 }
 
+func (n *fakeIPTablesRunner) DNATWithLoadBalancer(netip.Addr, []netip.Addr) error {
+	return errors.New("not implemented")
+}
+
 func (n *fakeIPTablesRunner) AddSNATRuleForDst(src, dst netip.Addr) error {
 	return errors.New("not implemented")
 }


### PR DESCRIPTION
See https://github.com/tailscale/tailscale/issues/10606 for context, especially  https://github.com/tailscale/tailscale/issues/10606#issuecomment-1858858609

This PR adds initial support to exposing targets accessible from within the Kubernetes cluster to tailnet via DNS names using an [`ExternalName` `Service`](https://kubernetes.io/docs/concepts/services-networking/service/#externalname).

To expose a target accessible from within a cluster:

## Flow

1. A user would create an `ExternalName` `Service`:

```yaml
apiVersion: v1
kind: Service
metadata:
  name: foo 
  annotations:
    tailscale.com/expose: "true"
spec:
  type: ExternalName
  externalName: <dns-name>
```

2. The Kubernetes operator will reconcile the `Service` and create a proxy based on containerboot  deployment with [`TS_DEST_DNS_NAME` env var](https://github.com/tailscale/tailscale/pull/11802/commits/dff1eeb47257e1336bde1fd1898132190ac54668#diff-700830ac79a41da42cd3a82065f0fee3003a4390eead4db1de4bf30557a06bd6R22) set to the DNS name from the `ExternalName` `Service`

3. The proxy will resolve the DNS name once on start and then every 10 minutes. It will ensure that traffic received on the proxy's tailnet IP address is forwarded to the backends.

4. Users should then be able to reach the backends from the tailnet via the tailscale IP address or MagicDNS name of the proxy, i.e
```
$ kubectl get secret -n tailscale -l tailscale.com/managed="true",tailscale.com/parent-resource=foo,tailscale.com/parent-resource-ns=default -ojson | jq -r '.items[0].data.device_ips' | base64 -d
["100.44.55.66", "fd7a:115c:a1e0::8e01:2765"]
$ curl -L 100.44.55.66
...
```

## Notes

- for target DNS names that resolve to multiple IP addresses the traffic is only load balanced accross alll addresses when the firewall mode is iptables. When the firewall mode is nftables, the traffic is sent to the first IP address. This needs fixing, I've tried to set up load balancing with nftables, but currently am seeing weird issues for repeated connections see [here](https://github.com/tailscale/tailscale/commit/d37f2f508509c6c35ad724fd75a27685b90b575b#diff-a3bcbcd1ca198799f4f768dc56fea913e1945a6b3ec9dbec89325a84a19a85e7R148-R232).
