### PR TITLE
wgengine\router: fix the Tailscale-In firewall rule to work on domain networks

### DIFF
--- a/wgengine/router/ifconfig_windows.go
+++ b/wgengine/router/ifconfig_windows.go
@@ -210,7 +210,7 @@ func setPrivateNetwork(ifcLUID winipcfg.LUID) (bool, error) {
 			return false, fmt.Errorf("GetCategory: %v", err)
 		}
 
-		if cat != categoryPrivate {
+		if cat != categoryPrivate && cat != categoryDomain {
 			if err := n.SetCategory(categoryPrivate); err != nil {
 				return false, fmt.Errorf("SetCategory: %v", err)
 			}

--- a/wgengine/router/router_windows.go
+++ b/wgengine/router/router_windows.go
@@ -329,7 +329,7 @@ func (ft *firewallTweaker) doSet(local []string, killswitch bool, clear bool, pr
 	for _, cidr := range local {
 		ft.logf("adding Tailscale-In rule to allow %v ...", cidr)
 		var d time.Duration
-		d, err := ft.runFirewall("add", "rule", "name=Tailscale-In", "dir=in", "action=allow", "localip="+cidr, "profile=private", "enable=yes")
+		d, err := ft.runFirewall("add", "rule", "name=Tailscale-In", "dir=in", "action=allow", "localip="+cidr, "profile=private,domain", "enable=yes")
 		if err != nil {
 			ft.logf("error adding Tailscale-In rule to allow %v: %v", cidr, err)
 			return err


### PR DESCRIPTION
The Network Location Awareness service identifies networks authenticated against an Active Directory domain and categorizes them as "Domain Authenticated". This includes the Tailscale network if a Domain Controller is reachable through it.

If a network is categories as NLM_NETWORK_CATEGORY_DOMAIN_AUTHENTICATED, it is not possible to override its category, and we shouldn't attempt to do so. Additionally, our Windows Firewall rules should be compatible with both private and domain networks.

This fixes both issues.

Fixes #11813