### PR TITLE
tailcfg: pointerify RegisterRequest.Auth, omitemptify RegisterResponseAuth

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -1069,10 +1069,13 @@ func (st SignatureType) String() string {
 // in response to a RegisterRequest.
 type RegisterResponseAuth struct {
 	_ structs.Incomparable
+
 	// One of Provider/LoginName, Oauth2Token, or AuthKey is set.
-	Provider, LoginName string
-	Oauth2Token         *Oauth2Token
-	AuthKey             string
+
+	Provider    string       `json:",omitempty"`
+	LoginName   string       `json:",omitempty"`
+	Oauth2Token *Oauth2Token `json:",omitempty"`
+	AuthKey     string       `json:",omitempty"`
 }
 
 // RegisterRequest is sent by a client to register the key for a node.
@@ -1093,7 +1096,7 @@ type RegisterRequest struct {
 	NodeKey    key.NodePublic
 	OldNodeKey key.NodePublic
 	NLKey      key.NLPublic
-	Auth       RegisterResponseAuth
+	Auth       *RegisterResponseAuth `json:",omitempty"`
 	// Expiry optionally specifies the requested key expiry.
 	// The server policy may override.
 	// As a special case, if Expiry is in the past and NodeKey is

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -335,7 +335,7 @@ func (src *RegisterRequest) Clone() *RegisterRequest {
 	}
 	dst := new(RegisterRequest)
 	*dst = *src
-	dst.Auth = *src.Auth.Clone()
+	dst.Auth = src.Auth.Clone()
 	dst.Hostinfo = src.Hostinfo.Clone()
 	dst.NodeKeySignature = append(src.NodeKeySignature[:0:0], src.NodeKeySignature...)
 	if dst.Timestamp != nil {
@@ -353,7 +353,7 @@ var _RegisterRequestCloneNeedsRegeneration = RegisterRequest(struct {
 	NodeKey          key.NodePublic
 	OldNodeKey       key.NodePublic
 	NLKey            key.NLPublic
-	Auth             RegisterResponseAuth
+	Auth             *RegisterResponseAuth
 	Expiry           time.Time
 	Followup         string
 	Hostinfo         *Hostinfo

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -803,7 +803,7 @@ var _RegisterRequestViewNeedsRegeneration = RegisterRequest(struct {
 	NodeKey          key.NodePublic
 	OldNodeKey       key.NodePublic
 	NLKey            key.NLPublic
-	Auth             RegisterResponseAuth
+	Auth             *RegisterResponseAuth
 	Expiry           time.Time
 	Followup         string
 	Hostinfo         *Hostinfo

--- a/tstest/integration/testcontrol/testcontrol.go
+++ b/tstest/integration/testcontrol/testcontrol.go
@@ -585,7 +585,7 @@ func (s *Server) serveRegister(w http.ResponseWriter, r *http.Request, mkey key.
 		j, _ := json.MarshalIndent(req, "", "\t")
 		log.Printf("Got %T: %s", req, j)
 	}
-	if s.RequireAuthKey != "" && req.Auth.AuthKey != s.RequireAuthKey {
+	if s.RequireAuthKey != "" && (req.Auth == nil || req.Auth.AuthKey != s.RequireAuthKey) {
 		res := must.Get(s.encode(false, tailcfg.RegisterResponse{
 			Error: "invalid authkey",
 		}))


### PR DESCRIPTION
We were storing server-side lots of:

    "Auth":{"Provider":"","LoginName":"","Oauth2Token":null,"AuthKey":""},

That was about 7% of our total storage of pending RegisterRequest
bodies.

Updates tailscale/corp#19327
