### PR TITLE
types/persist: remove unused field Persist.Provider

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -671,9 +671,6 @@ func (c *Direct) doLogin(ctx context.Context, opt loginOpt) (mustRegen bool, new
 			request.NodeKey.ShortString())
 		return true, "", nil, nil
 	}
-	if resp.Login.Provider != "" {
-		persist.Provider = resp.Login.Provider
-	}
 	persist.UserProfile = tailcfg.UserProfile{
 		ID:            resp.User.ID,
 		DisplayName:   resp.Login.DisplayName,

--- a/types/persist/persist.go
+++ b/types/persist/persist.go
@@ -34,7 +34,6 @@ type Persist struct {
 
 	PrivateNodeKey    key.NodePrivate
 	OldPrivateNodeKey key.NodePrivate // needed to request key rotation
-	Provider          string
 	UserProfile       tailcfg.UserProfile
 	NetworkLockKey    key.NLPrivate
 	NodeID            tailcfg.StableNodeID
@@ -99,7 +98,6 @@ func (p *Persist) Equals(p2 *Persist) bool {
 	return p.LegacyFrontendPrivateMachineKey.Equal(p2.LegacyFrontendPrivateMachineKey) &&
 		p.PrivateNodeKey.Equal(p2.PrivateNodeKey) &&
 		p.OldPrivateNodeKey.Equal(p2.OldPrivateNodeKey) &&
-		p.Provider == p2.Provider &&
 		p.UserProfile.Equal(&p2.UserProfile) &&
 		p.NetworkLockKey.Equal(p2.NetworkLockKey) &&
 		p.NodeID == p2.NodeID &&

--- a/types/persist/persist_clone.go
+++ b/types/persist/persist_clone.go
@@ -29,7 +29,6 @@ var _PersistCloneNeedsRegeneration = Persist(struct {
 	LegacyFrontendPrivateMachineKey key.MachinePrivate
 	PrivateNodeKey                  key.NodePrivate
 	OldPrivateNodeKey               key.NodePrivate
-	Provider                        string
 	UserProfile                     tailcfg.UserProfile
 	NetworkLockKey                  key.NLPrivate
 	NodeID                          tailcfg.StableNodeID

--- a/types/persist/persist_test.go
+++ b/types/persist/persist_test.go
@@ -21,7 +21,7 @@ func fieldsOf(t reflect.Type) (fields []string) {
 }
 
 func TestPersistEqual(t *testing.T) {
-	persistHandles := []string{"LegacyFrontendPrivateMachineKey", "PrivateNodeKey", "OldPrivateNodeKey", "Provider", "UserProfile", "NetworkLockKey", "NodeID", "DisallowedTKAStateIDs"}
+	persistHandles := []string{"LegacyFrontendPrivateMachineKey", "PrivateNodeKey", "OldPrivateNodeKey", "UserProfile", "NetworkLockKey", "NodeID", "DisallowedTKAStateIDs"}
 	if have := fieldsOf(reflect.TypeFor[Persist]()); !reflect.DeepEqual(have, persistHandles) {
 		t.Errorf("Persist.Equal check might be out of sync\nfields: %q\nhandled: %q\n",
 			have, persistHandles)
@@ -72,16 +72,6 @@ func TestPersistEqual(t *testing.T) {
 			true,
 		},
 
-		{
-			&Persist{Provider: "google"},
-			&Persist{Provider: "o365"},
-			false,
-		},
-		{
-			&Persist{Provider: "google"},
-			&Persist{Provider: "google"},
-			true,
-		},
 		{
 			&Persist{UserProfile: tailcfg.UserProfile{
 				ID: tailcfg.UserID(3),

--- a/types/persist/persist_view.go
+++ b/types/persist/persist_view.go
@@ -67,7 +67,6 @@ func (v PersistView) LegacyFrontendPrivateMachineKey() key.MachinePrivate {
 }
 func (v PersistView) PrivateNodeKey() key.NodePrivate    { return v.ж.PrivateNodeKey }
 func (v PersistView) OldPrivateNodeKey() key.NodePrivate { return v.ж.OldPrivateNodeKey }
-func (v PersistView) Provider() string                   { return v.ж.Provider }
 func (v PersistView) UserProfile() tailcfg.UserProfile   { return v.ж.UserProfile }
 func (v PersistView) NetworkLockKey() key.NLPrivate      { return v.ж.NetworkLockKey }
 func (v PersistView) NodeID() tailcfg.StableNodeID       { return v.ж.NodeID }
@@ -81,7 +80,6 @@ var _PersistViewNeedsRegeneration = Persist(struct {
 	LegacyFrontendPrivateMachineKey key.MachinePrivate
 	PrivateNodeKey                  key.NodePrivate
 	OldPrivateNodeKey               key.NodePrivate
-	Provider                        string
 	UserProfile                     tailcfg.UserProfile
 	NetworkLockKey                  key.NLPrivate
 	NodeID                          tailcfg.StableNodeID


### PR DESCRIPTION
It was only obviously unused after the previous change, c39cde79d.

Updates #19334
