### PR TITLE
ssh/tailssh: fetch group IDs using the id command

### DIFF
--- a/ssh/tailssh/user.go
+++ b/ssh/tailssh/user.go
@@ -34,14 +34,7 @@ type userMeta struct {
 
 // GroupIds returns the list of group IDs that the user is a member of.
 func (u *userMeta) GroupIds() ([]string, error) {
-	if runtime.GOOS == "linux" && distro.Get() == distro.Gokrazy {
-		// Gokrazy is a single-user appliance with ~no userspace.
-		// There aren't users to look up (no /etc/passwd, etc)
-		// so rather than fail below, just hardcode root.
-		// TODO(bradfitz): fix os/user upstream instead?
-		return []string{"0"}, nil
-	}
-	return u.User.GroupIds()
+	return osuser.GetGroupIds(&u.User)
 }
 
 // userLookup is like os/user.Lookup but it returns a *userMeta wrapper
@@ -51,6 +44,7 @@ func userLookup(username string) (*userMeta, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return &userMeta{User: *u, loginShellCached: s}, nil
 }
 

--- a/util/osuser/group_ids.go
+++ b/util/osuser/group_ids.go
@@ -1,0 +1,50 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package osuser
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"os/user"
+	"runtime"
+	"strings"
+	"time"
+
+	"tailscale.com/version/distro"
+)
+
+// GetGroupIds returns the list of group IDs that the user is a member of, or
+// an error. It will first try to use the 'id' command to get the group IDs,
+// and if that fails, it will fall back to the user.GroupIds method.
+func GetGroupIds(user *user.User) ([]string, error) {
+	if runtime.GOOS != "linux" {
+		return user.GroupIds()
+	}
+
+	if distro.Get() == distro.Gokrazy {
+		// Gokrazy is a single-user appliance with ~no userspace.
+		// There aren't users to look up (no /etc/passwd, etc)
+		// so rather than fail below, just hardcode root.
+		// TODO(bradfitz): fix os/user upstream instead?
+		return []string{"0"}, nil
+	}
+
+	if ids, err := getGroupIdsWithId(user.Username); err == nil {
+		return ids, nil
+	}
+	return user.GroupIds()
+}
+
+func getGroupIdsWithId(usernameOrUID string) ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "id", "-Gz", usernameOrUID)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("running 'id' command: %w", err)
+	}
+	return strings.Split(string(out), "\x00"), nil
+}

--- a/util/osuser/group_ids.go
+++ b/util/osuser/group_ids.go
@@ -46,5 +46,9 @@ func getGroupIdsWithId(usernameOrUID string) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("running 'id' command: %w", err)
 	}
-	return strings.Split(string(out), "\x00"), nil
+	return parseGroupIds(out), nil
+}
+
+func parseGroupIds(cmdOutput []byte) []string {
+	return strings.Split(strings.Trim(string(cmdOutput), "\n\x00"), "\x00")
 }

--- a/util/osuser/group_ids_test.go
+++ b/util/osuser/group_ids_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package osuser
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestParseGroupIds(t *testing.T) {
+	tests := []struct {
+		in       string
+		expected []string
+	}{
+		{"5000\x005001\n", []string{"5000", "5001"}},
+		{"5000\n", []string{"5000"}},
+		{"\n", []string{""}},
+	}
+	for _, test := range tests {
+		actual := parseGroupIds([]byte(test.in))
+		if !slices.Equal(actual, test.expected) {
+			t.Errorf("parseGroupIds(%q) = %q, wanted %s", test.in, actual, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
I verified that this fixes #11682 by doing the following:

1. Install LDAP on my Ubuntu workstation following [these instructions](https://ubuntu.com/server/docs/install-and-configure-ldap)
2. Enabling ldaps using [these instructions](https://ubuntu.com/server/docs/ldap-and-transport-layer-security-tls)
3. Enabling sssd using [these instructions](https://ubuntu.com/server/docs/how-to-set-up-sssd-with-ldap)
4. Creating a user named `john` who is a member of two posix groups in ldap, `miners` (primary) and `friends` (supplementary)
5. Connecting to this workstation via Tailscale from [VSCode Remote SSH](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh) and seeing that the `id` command only returns the primary group `miners`
6. Deploying the fix
7. Killing any running VSCode processes on the Linux workstation
8. Connecting again and seeing that the `id` command now returns `miners` and `friends`

I also created a folder owned by `friends` that was owner and group writeable but not world writeable, then created a file in that folder from within VSCode. The file was successfully created, which verifies that VSCode has the necessary permissions. It should be noted that since `miners` is the user's primary group, the file's ownership was `miners`, not `friends`. This is expected.

I also SSH'd to the Linux workstation from Warp both before and after the fix and saw the same results as with VSCode.