### PR TITLE
wgengine/router: consolidate routes before reconfiguring router for mobile clients

### DIFF
--- a/wgengine/router/consolidating_router.go
+++ b/wgengine/router/consolidating_router.go
@@ -1,0 +1,59 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package router
+
+import (
+	"go4.org/netipx"
+	"tailscale.com/types/logger"
+)
+
+// ConsolidatingRoutes wraps a Router with logic that consolidates Routes
+// whenever Set is called. It attempts to consolidate cfg.Routes into the
+// smallest possible set.
+func ConsolidatingRoutes(logf logger.Logf, router Router) Router {
+	return &consolidatingRouter{Router: router, logf: logger.WithPrefix(logf, "router: ")}
+}
+
+type consolidatingRouter struct {
+	Router
+	logf logger.Logf
+}
+
+// Set implements Router and attempts to consolidate cfg.Routes into the
+// smallest possible set.
+func (cr *consolidatingRouter) Set(cfg *Config) error {
+	return cr.Router.Set(cr.consolidateRoutes(cfg))
+}
+
+func (cr *consolidatingRouter) consolidateRoutes(cfg *Config) *Config {
+	if cfg == nil {
+		return nil
+	}
+	if len(cfg.Routes) < 2 {
+		return cfg
+	}
+	if len(cfg.Routes) == 2 && cfg.Routes[0].Addr().Is4() != cfg.Routes[1].Addr().Is4() {
+		return cfg
+	}
+	var builder netipx.IPSetBuilder
+	for _, route := range cfg.Routes {
+		builder.AddPrefix(route)
+	}
+	set, err := builder.IPSet()
+	if err != nil {
+		cr.logf("consolidateRoutes failed, keeping existing routes: %s", err)
+		return cfg
+	}
+	newRoutes := set.Prefixes()
+	oldLength := len(cfg.Routes)
+	newLength := len(newRoutes)
+	if oldLength == newLength {
+		// Nothing consolidated, return as-is.
+		return cfg
+	}
+	cr.logf("consolidated %d routes down to %d", oldLength, newLength)
+	newCfg := *cfg
+	newCfg.Routes = newRoutes
+	return &newCfg
+}

--- a/wgengine/router/consolidating_router_test.go
+++ b/wgengine/router/consolidating_router_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package router
+
+import (
+	"log"
+	"net/netip"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestConsolidateRoutes(t *testing.T) {
+	parseRoutes := func(routes ...string) []netip.Prefix {
+		parsed := make([]netip.Prefix, 0, len(routes))
+		for _, routeString := range routes {
+			route, err := netip.ParsePrefix(routeString)
+			if err != nil {
+				t.Fatal(err)
+			}
+			parsed = append(parsed, route)
+		}
+		return parsed
+	}
+
+	tests := []struct {
+		name string
+		cfg  *Config
+		want *Config
+	}{
+		{
+			"nil cfg",
+			nil,
+			nil,
+		},
+		{
+			"single route",
+			&Config{Routes: parseRoutes("10.0.0.0/32")},
+			&Config{Routes: parseRoutes("10.0.0.0/32")},
+		},
+		{
+			"two routes from different families",
+			&Config{Routes: parseRoutes("10.0.0.0/32", "2603:1030:c02::/47")},
+			&Config{Routes: parseRoutes("10.0.0.0/32", "2603:1030:c02::/47")},
+		},
+		{
+			"two disjoint routes",
+			&Config{Routes: parseRoutes("10.0.0.0/32", "10.0.2.0/32")},
+			&Config{Routes: parseRoutes("10.0.0.0/32", "10.0.2.0/32")},
+		},
+		{
+			"two overlapping routes",
+			&Config{Routes: parseRoutes("10.0.0.0/32", "10.0.0.0/31")},
+			&Config{Routes: parseRoutes("10.0.0.0/31")},
+		},
+	}
+
+	cr := &consolidatingRouter{logf: log.Printf}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := cr.consolidateRoutes(test.cfg)
+			if diff := cmp.Diff(got, test.want); diff != "" {
+				t.Errorf("wrong result; (-got+want):%v", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This helps reduce memory pressure on tailnets with large numbers of routes.

Updates tailscale/corp#19332

On a large tailnet like my corp tailnet, this results in about a 23% reduction in the number of routes.

```
26.9M/216.7M router: consolidated 5311 routes down to 4075
```