### PR TITLE
util/linuxfw,go.{mod,sum}: don't log errors when cleaning up non-existant rules/chains

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.64
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.44.7
-	github.com/coreos/go-iptables v0.7.0
+	github.com/coreos/go-iptables v0.7.1-0.20240112124308-65c67c9f46e6
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/creack/pty v1.1.21

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/containerd/stargz-snapshotter/estargz v0.15.1 h1:eXJjw9RbkLFgioVaTG+G/ZW/0kEe2oEKCdS/ZxIyoCU=
 github.com/containerd/stargz-snapshotter/estargz v0.15.1/go.mod h1:gr2RNwukQ/S9Nv33Lt6UC7xEx58C+LHRdoqbEKjz1Kk=
-github.com/coreos/go-iptables v0.7.0 h1:XWM3V+MPRr5/q51NuWSgU0fqMad64Zyxs8ZUoMsamr8=
-github.com/coreos/go-iptables v0.7.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
+github.com/coreos/go-iptables v0.7.1-0.20240112124308-65c67c9f46e6 h1:8h5+bWd7R6AYUslN6c6iuZWTKsKxUFDlpnmilO6R2n0=
+github.com/coreos/go-iptables v0.7.1-0.20240112124308-65c67c9f46e6/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=
 github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=

--- a/util/linuxfw/iptables_runner_test.go
+++ b/util/linuxfw/iptables_runner_test.go
@@ -13,6 +13,12 @@ import (
 	"tailscale.com/net/tsaddr"
 )
 
+var testIsNotExistErr = "exitcode:1"
+
+func init() {
+	isNotExistError = func(e error) bool { return e.Error() == testIsNotExistErr }
+}
+
 func TestAddAndDeleteChains(t *testing.T) {
 	iptr := NewFakeIPTablesRunner()
 	err := iptr.AddChains()

--- a/util/linuxfw/linuxfw.go
+++ b/util/linuxfw/linuxfw.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -103,26 +102,6 @@ func getTailscaleFwmarkMask() []byte {
 // getTailscaleSubnetRouteMark returns the TailscaleSubnetRouteMark in bytes.
 func getTailscaleSubnetRouteMark() []byte {
 	return []byte{0x00, 0x04, 0x00, 0x00}
-}
-
-// errCode extracts and returns the process exit code from err, or
-// zero if err is nil.
-func errCode(err error) int {
-	if err == nil {
-		return 0
-	}
-	var e *exec.ExitError
-	if ok := errors.As(err, &e); ok {
-		return e.ExitCode()
-	}
-	s := err.Error()
-	if strings.HasPrefix(s, "exitcode:") {
-		code, err := strconv.Atoi(s[9:])
-		if err == nil {
-			return code
-		}
-	}
-	return -42
 }
 
 // checkIPv6 checks whether the system appears to have a working IPv6


### PR DESCRIPTION
See https://github.com/tailscale/corp/issues/19336#issuecomment-2072516735 for context - since 1.64 we attempt to clean up firewall rules on every tailscaled start, but our current cleanup was logging error messages if the rules/chains to be cleaned up were not found, which was every time after a 'normal' shutdown that would delete those rules and chains.

This resulted in a lot of confusing logs on start, see below for a container start:
<details>
<code>
...
2024/04/23 17:10:33 dns: using "direct" mode
2024/04/23 17:10:33 dns: using *dns.directManager
2024/04/23 17:10:33 deleting [-j ts-input] in filter/INPUT: running [/sbin/iptables -t filter -D INPUT -j ts-input --wait]: exit status 2: iptables v1.8.9 (legacy): Couldn't load target `ts-input':No such file or directory

Try `iptables -h' or 'iptables --help' for more information.
2024/04/23 17:10:33 deleting [-j ts-forward] in filter/FORWARD: running [/sbin/iptables -t filter -D FORWARD -j ts-forward --wait]: exit status 2: iptables v1.8.9 (legacy): Couldn't load target `ts-forward':No such file or directory

Try `iptables -h' or 'iptables --help' for more information.
2024/04/23 17:10:33 deleting [-j ts-postrouting] in nat/POSTROUTING: running [/sbin/iptables -t nat -D POSTROUTING -j ts-postrouting --wait]: exit status 2: iptables v1.8.9 (legacy): Couldn't load target `ts-postrouting':No such file or directory

Try `iptables -h' or 'iptables --help' for more information.
2024/04/23 17:10:33 deleting [-j ts-input] in filter/INPUT: running [/sbin/ip6tables -t filter -D INPUT -j ts-input --wait]: exit status 3: modprobe: can't change directory to '/lib/modules': No such file or directory
ip6tables v1.8.9 (legacy): can't initialize ip6tables table `filter': Table does not exist (do you need to insmod?)
Perhaps ip6tables or your kernel needs to be upgraded.
2024/04/23 17:10:33 deleting [-j ts-forward] in filter/FORWARD: running [/sbin/ip6tables -t filter -D FORWARD -j ts-forward --wait]: exit status 3: modprobe: can't change directory to '/lib/modules': No such file or directory
ip6tables v1.8.9 (legacy): can't initialize ip6tables table `filter': Table does not exist (do you need to insmod?)
Perhaps ip6tables or your kernel needs to be upgraded.
2024/04/23 17:10:33 [RATELIMIT] format("deleting %v in %s/%s: %v")
2024/04/23 17:10:33 linuxfw: clear ip6tables: multiple errors:
        flushing filter/ts-input: running [/sbin/ip6tables -t filter -N ts-input --wait]: exit status 3: modprobe: can't change directory to '/lib/modules': No such file or directory
ip6tables v1.8.9 (legacy): can't initialize ip6tables table `filter': Table does not exist (do you need to insmod?)
Perhaps ip6tables or your kernel needs to be upgraded.

        flushing filter/ts-forward: running [/sbin/ip6tables -t filter -N ts-forward --wait]: exit status 3: modprobe: can't change directory to '/lib/modules': No such file or directory
ip6tables v1.8.9 (legacy): can't initialize ip6tables table `filter': Table does not exist (do you need to insmod?)
Perhaps ip6tables or your kernel needs to be upgraded.

        flushing nat/ts-postrouting: running [/sbin/ip6tables -t nat -N ts-postrouting --wait]: exit status 3: modprobe: can't change directory to '/lib/modules': No such file or directory
ip6tables v1.8.9 (legacy): can't initialize ip6tables table `nat': Table does not exist (do you need to insmod?)
Perhaps ip6tables or your kernel needs to be upgraded.
...
</code>
</details>


This PR bumps go-iptables to a newer version that has a fix for the `go-iptables/Error.IsNotExists` function ([go-iptables#108](https://github.com/coreos/go-iptables/pull/108)) and uses that function to determine whether errors received on iptables rule and chain clean up are because the rule/chain does not exist- if so don't log the error.
I've tested that a container start with this PR does not result in cleanup logs because of non-existant rules/chains.

Updates corp#19336