### PR TITLE
util/syspolicy: add ReadStringArray interface

### DIFF
--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -1568,6 +1568,11 @@ func (h *errorSyspolicyHandler) ReadBoolean(key string) (bool, error) {
 	return false, syspolicy.ErrNoSuchKey
 }
 
+func (h *errorSyspolicyHandler) ReadStringArray(key string) ([]string, error) {
+	h.t.Errorf("ReadStringArray(%q) unexpectedly called", key)
+	return nil, syspolicy.ErrNoSuchKey
+}
+
 type mockSyspolicyHandler struct {
 	t *testing.T
 	// stringPolicies is the collection of policies that we expect to see
@@ -1605,6 +1610,13 @@ func (h *mockSyspolicyHandler) ReadBoolean(key string) (bool, error) {
 		h.t.Errorf("ReadBoolean(%q) unexpectedly called", key)
 	}
 	return false, syspolicy.ErrNoSuchKey
+}
+
+func (h *mockSyspolicyHandler) ReadStringArray(key string) ([]string, error) {
+	if h.failUnknownPolicies {
+		h.t.Errorf("ReadStringArray(%q) unexpectedly called", key)
+	}
+	return nil, syspolicy.ErrNoSuchKey
 }
 
 func TestSetExitNodeIDPolicy(t *testing.T) {

--- a/util/syspolicy/handler.go
+++ b/util/syspolicy/handler.go
@@ -25,6 +25,9 @@ type Handler interface {
 	// ReadBool reads the policy setting's boolean value for the given key.
 	// It should return ErrNoSuchKey if the key does not have a value set.
 	ReadBoolean(key string) (bool, error)
+	// ReadStringArray reads the policy setting's string array value for the given key.
+	// It should return ErrNoSuchKey if the key does not have a value set.
+	ReadStringArray(key string) ([]string, error)
 }
 
 // ErrNoSuchKey is returned by a Handler when the specified key does not have a
@@ -44,6 +47,10 @@ func (defaultHandler) ReadUInt64(_ string) (uint64, error) {
 
 func (defaultHandler) ReadBoolean(_ string) (bool, error) {
 	return false, ErrNoSuchKey
+}
+
+func (defaultHandler) ReadStringArray(_ string) ([]string, error) {
+	return nil, ErrNoSuchKey
 }
 
 // markHandlerInUse is called before handler methods are called.

--- a/util/syspolicy/handler_windows.go
+++ b/util/syspolicy/handler_windows.go
@@ -93,3 +93,13 @@ func (windowsHandler) ReadBoolean(key string) (bool, error) {
 	}
 	return value != 0, err
 }
+
+func (windowsHandler) ReadStringArray(key string) ([]string, error) {
+	value, err := winutil.GetPolicyStringArray(key)
+	if errors.Is(err, winutil.ErrNoValue) {
+		err = ErrNoSuchKey
+	} else if err != nil {
+		windowsErrors.Add(1)
+	}
+	return value, err
+}

--- a/util/syspolicy/syspolicy.go
+++ b/util/syspolicy/syspolicy.go
@@ -36,6 +36,15 @@ func GetBoolean(key Key, defaultValue bool) (bool, error) {
 	return v, err
 }
 
+func GetStringArray(key Key, defaultValue []string) ([]string, error) {
+	markHandlerInUse()
+	v, err := handler.ReadStringArray(string(key))
+	if errors.Is(err, ErrNoSuchKey) {
+		return defaultValue, nil
+	}
+	return v, err
+}
+
 // PreferenceOption is a policy that governs whether a boolean variable
 // is forcibly assigned an administrator-defined value, or allowed to receive
 // a user-defined value.

--- a/util/syspolicy/syspolicy_test.go
+++ b/util/syspolicy/syspolicy_test.go
@@ -18,6 +18,7 @@ type testHandler struct {
 	s     string
 	u64   uint64
 	b     bool
+	sArr  []string
 	err   error
 	calls int // used for testing reads from cache vs. handler
 }
@@ -46,6 +47,14 @@ func (th *testHandler) ReadBoolean(key string) (bool, error) {
 	}
 	th.calls++
 	return th.b, th.err
+}
+
+func (th *testHandler) ReadStringArray(key string) ([]string, error) {
+	if key != string(th.key) {
+		th.t.Errorf("ReadStringArray(%q) want %q", key, th.key)
+	}
+	th.calls++
+	return th.sArr, th.err
 }
 
 func TestGetString(t *testing.T) {

--- a/util/winutil/winutil.go
+++ b/util/winutil/winutil.go
@@ -45,6 +45,10 @@ func GetPolicyInteger(name string) (uint64, error) {
 	return getPolicyInteger(name)
 }
 
+func GetPolicyStringArray(name string) ([]string, error) {
+	return getPolicyStringArray(name)
+}
+
 // GetRegString looks up a registry path in the local machine path, or returns
 // an empty string and error.
 //

--- a/util/winutil/winutil_notwindows.go
+++ b/util/winutil/winutil_notwindows.go
@@ -21,6 +21,8 @@ func getPolicyString(name string) (string, error) { return "", ErrNoValue }
 
 func getPolicyInteger(name string) (uint64, error) { return 0, ErrNoValue }
 
+func getPolicyStringArray(name string) ([]string, error) { return nil, ErrNoValue }
+
 func getRegString(name string) (string, error) { return "", ErrNoValue }
 
 func getRegInteger(name string) (uint64, error) { return 0, ErrNoValue }

--- a/util/winutil/winutil_windows.go
+++ b/util/winutil/winutil_windows.go
@@ -57,6 +57,10 @@ func getPolicyString(name string) (string, error) {
 	return s, err
 }
 
+func getPolicyStringArray(name string) ([]string, error) {
+	return getRegStringsInternal(regPolicyBase, name)
+}
+
 func getRegString(name string) (string, error) {
 	s, err := getRegStringInternal(regBase, name)
 	if err != nil {


### PR DESCRIPTION
Fixes tailscale/corp#19459

This PR adds the ability for users of the syspolicy handler to read string arrays from the MDM solution configured on the system.