### PR TITLE
ssh/tailssh: fall back to /usr/bin/su if /usr/bin/login is not an option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -575,6 +575,16 @@ jobs:
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
+  ssh:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+    - name: run ssh tests
+      run: |
+        export PATH=$(./tool/go env GOROOT)/bin:$PATH
+        make sshintegrationtest
+
   check_mergeability:
     if: always()
     runs-on: ubuntu-22.04

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,17 @@ publishdevoperator: ## Build and publish k8s-operator image to location specifie
 	@test "${REPO}" != "ghcr.io/tailscale/k8s-operator" || (echo "REPO=... must not be ghcr.io/tailscale/k8s-operator" && exit 1)
 	TAGS="${TAGS}" REPOS=${REPO} PLATFORM=${PLATFORM} PUSH=true TARGET=operator ./build_docker.sh
 
+.PHONY: sshintegrationtest
+sshintegrationtest:
+	GOOS=linux GOARCH=amd64 go test -tags integrationtest -c ./ssh/tailssh -o ssh/tailssh/testcontainers/tailssh.test && \
+	echo "Testing on ubuntu:focal" && docker build --build-arg="BASE=ubuntu:focal" -t ssh-ubuntu-focal ssh/tailssh/testcontainers && \
+	echo "Testing on ubuntu:jammy" && docker build --build-arg="BASE=ubuntu:jammy" -t ssh-ubuntu-jammy ssh/tailssh/testcontainers && \
+	echo "Testing on ubuntu:mantic" && docker build --build-arg="BASE=ubuntu:mantic" -t ssh-ubuntu-mantic ssh/tailssh/testcontainers && \
+	echo "Testing on ubuntu:noble" && docker build --build-arg="BASE=ubuntu:noble" -t ssh-ubuntu-noble ssh/tailssh/testcontainers && \
+	echo "Testing on fedora:38" && docker build --build-arg="BASE=dokken/fedora-38" -t ssh-fedora-38 ssh/tailssh/testcontainers && \
+	echo "Testing on fedora:39" && docker build --build-arg="BASE=dokken/fedora-39" -t ssh-fedora-39 ssh/tailssh/testcontainers && \
+	echo "Testing on fedora:40" && docker build --build-arg="BASE=dokken/fedora-40" -t ssh-fedora-40 ssh/tailssh/testcontainers
+	
 help: ## Show this help
 	@echo "\nSpecify a command. The choices are:\n"
 	@grep -hE '^[0-9a-zA-Z_-]+:.*?## .*$$' ${MAKEFILE_LIST} | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[0;36m%-20s\033[m %s\n", $$1, $$2}'

--- a/ssh/tailssh/incubator_test.go
+++ b/ssh/tailssh/incubator_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build integrationtest
+// +build integrationtest
+
+package tailssh
+
+import (
+	"bufio"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"os/user"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// TestBeIncubator runs an integration test of the beIncubator function. It
+// expects an execution environment that meets the following requirements:
+//
+// - OS is one of MacOS, Linux, FreeBSD or OpenBSD
+// - User "testuser" exists
+// - "theuser" is in groups "groupone" and "grouptwo"
+func TestIntegrationBeIncubator(t *testing.T) {
+	runningInTest = true
+	t.Cleanup(func() {
+		runningInTest = false
+	})
+
+	testuser, err := user.Lookup("testuser")
+	if err != nil {
+		t.Fatal(err)
+	}
+	groupone, err := user.LookupGroup("groupone")
+	if err != nil {
+		t.Fatal(err)
+	}
+	grouptwo, err := user.LookupGroup("grouptwo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runCmd := func(cmd string) string {
+		errCh := make(chan error, 1)
+		defer func() {
+			select {
+			case err := <-errCh:
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+		}()
+
+		args := []string{
+			"--uid", testuser.Uid,
+			"--gid", testuser.Gid,
+			"--groups", groupone.Gid + "," + grouptwo.Gid,
+			"--local-user", "testuser",
+			"--remote-user", "remoteuser",
+			"--remote-ip", "192.168.1.180",
+			"--cmd", cmd,
+		}
+
+		log.Printf("Testing with args %+v", args)
+
+		stdinReader, stdin := io.Pipe()
+		stdoutReader, stdoutWriter := io.Pipe()
+		stderrReader, stderrWriter := io.Pipe()
+		defer stdin.Close()
+		defer stdoutReader.Close()
+		defer stderrReader.Close()
+
+		go func() {
+			errCh <- doBeIncubator(args, os.Environ(), stdinReader, stdoutWriter, stderrWriter)
+		}()
+
+		stdout := bufio.NewReader(stdoutReader)
+		go io.Copy(os.Stderr, stderrReader)
+		result, err := stdout.ReadString('\n')
+		if err != nil {
+			t.Fatal(err)
+		}
+		return strings.TrimSpace(result)
+	}
+
+	gotId := runCmd("id")
+	if !strings.Contains(gotId, "testuserd") {
+		t.Logf("id output %q missing testuser", gotId)
+	}
+	if !strings.Contains(gotId, "groupone") {
+		t.Logf("id output %q missing groupone", gotId)
+	}
+	if !strings.Contains(gotId, "grouptwo") {
+		t.Logf("id output %q missing grouptwo", gotId)
+	}
+
+	_, err = exec.LookPath("su")
+	if err == nil {
+		// If su command is present, make sure that pwd without TTY shows the
+		// correct directory.
+		gotPwd := runCmd("pwd")
+		wantPwd := "/home/testuserd"
+		if runtime.GOOS == "darwin" {
+			wantPwd = "/Users/testuser"
+		}
+		if diff := cmp.Diff(gotPwd, wantPwd); diff != "" {
+			t.Fatalf("unexpected pwd output (-got +want):\n%s", diff)
+		}
+	}
+}

--- a/ssh/tailssh/testcontainers/Dockerfile
+++ b/ssh/tailssh/testcontainers/Dockerfile
@@ -1,0 +1,11 @@
+ARG BASE
+FROM ${BASE}
+
+RUN groupadd -g 10000 groupone
+RUN groupadd -g 10001 grouptwo
+RUN useradd -g 10000 -G 10001 -u 10002 -m testuser
+COPY . .
+RUN ./tailssh.test -test.run TestIntegration
+# Remove the su command and run the test again to make sure it works without su
+RUN rm `which su`
+RUN ./tailssh.test -test.run TestIntegration


### PR DESCRIPTION
This works on more recent versions of Linux and has the benefit of allowing PAM login actions to run.

Updates #11854

This works on Ubuntu 22.04, Fedora 38 and ArchLinux.

Here's how this works:

`/usr/bin/login` requires a TTY. For ssh connections without a tty such as those made from VSCode, we skip `/usr/bin/login` and instead drop privileges and then directly execute the user's preferred shell (e.g. `bin/bash`). Because we skip the login step, PAM doesn't run.

Unlike `/usr/bin/login`, `/usr/bin/su` does not require a TTY, but still allows the creation of a login shell, triggering PAM to run. The downside to using `su` is that unlike `login`, it doesn't allow us to record the remote IP for logging purposes, but  otherwise it appears to work fairly equivalently.

So, if the ssh session wants a login shell but doesn't have a TTY, we attempt to use `/usr/bin/su`, if and only if the command is present and supports the necessary flags. This may also work on non-linux platforms, but to minimize testing burden this PR is restricted to just using this mechanism on Linux.