### PR TITLE
health: permit Tracker method calls on nil receiver

### DIFF
--- a/health/health_test.go
+++ b/health/health_test.go
@@ -31,3 +31,21 @@ func TestAppendWarnableDebugFlags(t *testing.T) {
 		}
 	}
 }
+
+// Test that all exported methods on *Tracker don't panic with a nil receiver.
+func TestNilMethodsDontCrash(t *testing.T) {
+	var nilt *Tracker
+	rv := reflect.ValueOf(nilt)
+	for i := 0; i < rv.NumMethod(); i++ {
+		mt := rv.Type().Method(i)
+		t.Logf("calling Tracker.%s ...", mt.Name)
+		var args []reflect.Value
+		for j := 0; j < mt.Type.NumIn(); j++ {
+			if j == 0 && mt.Type.In(j) == reflect.TypeFor[*Tracker]() {
+				continue
+			}
+			args = append(args, reflect.Zero(mt.Type.In(j)))
+		}
+		rv.Method(i).Call(args)
+	}
+}


### PR DESCRIPTION
In prep for tsd.System Tracker plumbing throughout tailscaled,
defensively permit all methods on Tracker to accept a nil receiver
without crashing, lest I screw something up later. (A health tracking
system that itself causes crashes would be no good.) Methods on nil
receivers should not be called, so a future change will also collect
their stacks (and panic during dev/test), but we should at least not
crash in prod.

This also locks that in with a test using reflect to automatically
call all methods on a nil receiver and check they don't crash.

Updates #11874
Updates #4136
