### PR TITLE
net/netutil: remove a use of deprecated interfaces.GetState

### DIFF
--- a/net/netutil/ip_forward.go
+++ b/net/netutil/ip_forward.go
@@ -6,6 +6,7 @@ package netutil
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/netip"
 	"os"
@@ -145,8 +146,6 @@ func CheckIPForwarding(routes []netip.Prefix, state *interfaces.State) (warn, er
 // disabled or set to 'loose' mode for exit node functionality on any
 // interface.
 //
-// The state param can be nil, in which case interfaces.GetState is used.
-//
 // The routes should only be advertised routes, and should not contain the
 // node's Tailscale IPs.
 //
@@ -159,11 +158,7 @@ func CheckReversePathFiltering(state *interfaces.State) (warn []string, err erro
 	}
 
 	if state == nil {
-		var err error
-		state, err = interfaces.GetState()
-		if err != nil {
-			return nil, err
-		}
+		return nil, errors.New("no link state")
 	}
 
 	// The kernel uses the maximum value for rp_filter between the 'all'

--- a/net/netutil/netutil_test.go
+++ b/net/netutil/netutil_test.go
@@ -8,6 +8,8 @@ import (
 	"net"
 	"runtime"
 	"testing"
+
+	"tailscale.com/net/netmon"
 )
 
 type conn struct {
@@ -70,7 +72,13 @@ func TestCheckReversePathFiltering(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skipf("skipping on %s", runtime.GOOS)
 	}
-	warn, err := CheckReversePathFiltering(nil)
+	netMon, err := netmon.New(t.Logf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer netMon.Close()
+
+	warn, err := CheckReversePathFiltering(netMon.InterfaceState())
 	t.Logf("err: %v", err)
 	t.Logf("warnings: %v", warn)
 }


### PR DESCRIPTION
I'm working on moving all network state queries to be on
netmon.Monitor, removing old APIs.

Updates tailscale/corp#10910
Updates tailscale/corp#18960
Updates #7967
Updates #3299
