### PR TITLE
ssh/tailssh: fall back to using su when no TTY available on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,10 +115,7 @@ sshintegrationtest: ## Run the SSH integration tests in various Docker container
 	echo "Testing on ubuntu:focal" && docker build --build-arg="BASE=ubuntu:focal" -t ssh-ubuntu-focal ssh/tailssh/testcontainers && \
 	echo "Testing on ubuntu:jammy" && docker build --build-arg="BASE=ubuntu:jammy" -t ssh-ubuntu-jammy ssh/tailssh/testcontainers && \
 	echo "Testing on ubuntu:mantic" && docker build --build-arg="BASE=ubuntu:mantic" -t ssh-ubuntu-mantic ssh/tailssh/testcontainers && \
-	echo "Testing on ubuntu:noble" && docker build --build-arg="BASE=ubuntu:noble" -t ssh-ubuntu-noble ssh/tailssh/testcontainers && \
-	echo "Testing on fedora:38" && docker build --build-arg="BASE=dokken/fedora-38" -t ssh-fedora-38 ssh/tailssh/testcontainers && \
-	echo "Testing on fedora:39" && docker build --build-arg="BASE=dokken/fedora-39" -t ssh-fedora-39 ssh/tailssh/testcontainers && \
-	echo "Testing on fedora:40" && docker build --build-arg="BASE=dokken/fedora-40" -t ssh-fedora-40 ssh/tailssh/testcontainers
+	echo "Testing on ubuntu:noble" && docker build --build-arg="BASE=ubuntu:noble" -t ssh-ubuntu-noble ssh/tailssh/testcontainers
 
 help: ## Show this help
 	@echo "\nSpecify a command. The choices are:\n"

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.64
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.44.7
+	github.com/bramvdbogaerde/go-scp v1.4.0
 	github.com/coreos/go-iptables v0.7.1-0.20240112124308-65c67c9f46e6
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
 	github.com/creack/pty v1.1.21

--- a/go.sum
+++ b/go.sum
@@ -177,6 +177,8 @@ github.com/blizzy78/varnamelen v0.8.0 h1:oqSblyuQvFsW1hbBHh1zfwrKe3kcSj0rnXkKzsQ
 github.com/blizzy78/varnamelen v0.8.0/go.mod h1:V9TzQZ4fLJ1DSrjVDfl89H7aMnTvKkApdHeyESmyR7k=
 github.com/bombsimon/wsl/v3 v3.4.0 h1:RkSxjT3tmlptwfgEgTgU+KYKLI35p/tviNXNXiL2aNU=
 github.com/bombsimon/wsl/v3 v3.4.0/go.mod h1:KkIB+TXkqy6MvK9BDZVbZxKNYsE1/oLRJbIFtf14qqo=
+github.com/bramvdbogaerde/go-scp v1.4.0 h1:jKMwpwCbcX1KyvDbm/PDJuXcMuNVlLGi0Q0reuzjyKY=
+github.com/bramvdbogaerde/go-scp v1.4.0/go.mod h1:on2aH5AxaFb2G0N5Vsdy6B0Ml7k9HuHSwfo1y0QzAbQ=
 github.com/breml/bidichk v0.2.4 h1:i3yedFWWQ7YzjdZJHnPo9d/xURinSq3OM+gyM43K4/8=
 github.com/breml/bidichk v0.2.4/go.mod h1:7Zk0kRFt1LIZxtQdl9W9JwGAcLTTkOs+tN7wuEYGJ3s=
 github.com/breml/errchkjson v0.3.1 h1:hlIeXuspTyt8Y/UmP5qy1JocGNR00KQHgfaNtRAjoxQ=

--- a/ssh/tailssh/incubator_linux.go
+++ b/ssh/tailssh/incubator_linux.go
@@ -146,11 +146,11 @@ func releaseSession(sessionID string) error {
 }
 
 // maybeStartLoginSessionLinux is the linux implementation of maybeStartLoginSession.
-func maybeStartLoginSessionLinux(logf logger.Logf, ia incubatorArgs) (func() error, error) {
+func maybeStartLoginSessionLinux(dlogf logger.Logf, ia incubatorArgs) func() error {
 	if os.Geteuid() != 0 {
-		return nil, nil
+		return nil
 	}
-	logf("starting session for user %d", ia.uid)
+	dlogf("starting session for user %d", ia.uid)
 	// The only way we can actually start a new session is if we are
 	// running outside one and are root, which is typically the case
 	// for systemd managed tailscaled.
@@ -160,14 +160,14 @@ func maybeStartLoginSessionLinux(logf logger.Logf, ia incubatorArgs) (func() err
 		// We can look at the DBus GetSessionByPID API.
 		// https://www.freedesktop.org/software/systemd/man/org.freedesktop.login1.html
 		// For now best effort is fine.
-		logf("ssh: failed to CreateSession for user %q (%d) %v", ia.localUser, ia.uid, err)
-		return nil, nil
+		dlogf("ssh: failed to CreateSession for user %q (%d) %v", ia.localUser, ia.uid, err)
+		return nil
 	}
 	os.Setenv("DBUS_SESSION_BUS_ADDRESS", fmt.Sprintf("unix:path=%v/bus", resp.runtimePath))
 	if !resp.existing {
 		return func() error {
 			return releaseSession(resp.sessionID)
-		}, nil
+		}
 	}
-	return nil, nil
+	return nil
 }

--- a/ssh/tailssh/privs_test.go
+++ b/ssh/tailssh/privs_test.go
@@ -23,7 +23,7 @@ import (
 	"tailscale.com/types/logger"
 )
 
-func TestDropPrivileges(t *testing.T) {
+func TestDoDropPrivileges(t *testing.T) {
 	type SubprocInput struct {
 		UID              int
 		GID              int
@@ -49,7 +49,7 @@ func TestDropPrivileges(t *testing.T) {
 		f := os.NewFile(3, "out.json")
 
 		// We're in our subprocess; actually drop privileges now.
-		dropPrivileges(t.Logf, input.UID, input.GID, input.AdditionalGroups)
+		doDropPrivileges(t.Logf, input.UID, input.GID, input.AdditionalGroups)
 
 		additional, _ := syscall.Getgroups()
 

--- a/ssh/tailssh/testcontainers/Dockerfile
+++ b/ssh/tailssh/testcontainers/Dockerfile
@@ -1,18 +1,51 @@
 ARG BASE
 FROM ${BASE}
 
+RUN echo "Install openssh, needed for scp."
+RUN apt-get update -y && apt-get install -y openssh-client
+
 RUN groupadd -g 10000 groupone
 RUN groupadd -g 10001 grouptwo
-RUN useradd -g 10000 -G 10001 -u 10002 -m testuser
-COPY . .
+# Note - we do not create the user's home directory, pam_mkhomedir will do that
+# for us, and we want to test that PAM gets triggered by Tailscale SSH.
+RUN useradd -g 10000 -G 10001 -u 10002 testuser
 
-# First run tests normally.
-RUN TAILSCALED_PATH=`pwd`tailscaled ./tailssh.test -test.run TestIntegration
+RUN echo "Set up pam_mkhomedir."
+RUN sed -i -e 's/Default: no/Default: yes/g' /usr/share/pam-configs/mkhomedir || echo "might not be ubuntu"
+RUN cat /usr/share/pam-configs/mkhomedir
+RUN pam-auth-update --enable mkhomedir
 
-# Then remove the login command and make sure tests still pass.
-RUN rm `which login`
-RUN TAILSCALED_PATH=`pwd`tailscaled ./tailssh.test -test.run TestIntegration
+COPY tailscaled .
+COPY tailssh.test .
 
-# Then run tests as non-root user testuser.
+RUN chmod 755 tailscaled
+
+RUN echo "First run tests normally."
+RUN rm -Rf /home/testuser
+RUN TAILSCALED_PATH=`pwd`tailscaled ./tailssh.test -test.v -test.run TestIntegrationSFTP
+RUN rm -Rf /home/testuser
+RUN TAILSCALED_PATH=`pwd`tailscaled ./tailssh.test -test.v -test.run TestIntegrationSCP
+RUN rm -Rf /home/testuser
+RUN TAILSCALED_PATH=`pwd`tailscaled ./tailssh.test -test.v -test.run TestIntegrationSSH
+
+RUN echo "Then run tests as non-root user testuser and make sure tests still pass."
 RUN chown testuser:groupone /tmp/tailscalessh.log
-RUN TAILSCALED_PATH=`pwd`tailscaled su -m testuser -c "./tailssh.test -test.run TestIntegration"
+RUN TAILSCALED_PATH=`pwd`tailscaled su -m testuser -c "./tailssh.test -test.v -test.run TestIntegration TestDoDropPrivileges"
+
+RUN echo "Then remove the login command and make sure tests still pass."
+RUN chown root:root /tmp/tailscalessh.log
+RUN rm `which login`
+RUN rm -Rf /home/testuser
+RUN TAILSCALED_PATH=`pwd`tailscaled ./tailssh.test -test.v -test.run TestIntegrationSFTP
+RUN rm -Rf /home/testuser
+RUN TAILSCALED_PATH=`pwd`tailscaled ./tailssh.test -test.v -test.run TestIntegrationSCP
+RUN rm -Rf /home/testuser
+RUN TAILSCALED_PATH=`pwd`tailscaled ./tailssh.test -test.v -test.run TestIntegrationSSH
+
+RUN echo "Then remove the su command and make sure tests still pass."
+RUN chown root:root /tmp/tailscalessh.log
+RUN rm `which su`
+RUN TAILSCALED_PATH=`pwd`tailscaled ./tailssh.test -test.v -test.run TestIntegration
+
+RUN echo "Test doDropPrivileges"
+RUN TAILSCALED_PATH=`pwd`tailscaled ./tailssh.test -test.v -test.run TestDoDropPrivileges

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -136,7 +136,8 @@ type CapabilityVersion int
 //   - 93: 2024-05-06: added support for stateful firewalling.
 //   - 94: 2024-05-06: Client understands Node.IsJailed.
 //   - 95: 2024-05-06: Client uses NodeAttrUserDialUseRoutes to change DNS dialing behavior.
-const CurrentCapabilityVersion CapabilityVersion = 95
+//   - 96: 2024-05-29: Client understands NodeAttrSSHBehaviorV1
+const CurrentCapabilityVersion CapabilityVersion = 96
 
 type StableID string
 
@@ -2274,6 +2275,10 @@ const (
 	// depending on the destination address and the configured routes. When present, it also makes
 	// the DNS forwarder use UserDial instead of SystemDial when dialing resolvers.
 	NodeAttrUserDialUseRoutes NodeCapability = "user-dial-routes"
+
+	// NodeAttrSSHBehaviorV1 forces SSH to use the V1 behavior (no su, run SFTP in-process)
+	// Added 2024-05-29 in Tailscale version 1.68.
+	NodeAttrSSHBehaviorV1 NodeCapability = "ssh-behavior-v1"
 )
 
 // SetDNSRequest is a request to add a DNS record.


### PR DESCRIPTION
This allows pam authentication to run, triggering automation
like pam_mkhomedir.

Updates #11854