### PR TITLE
ipn/ipnlocal: fix TestOnTailnetDefaultAutoUpdate on unsupported platforms

### DIFF
--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -15,7 +15,6 @@ import (
 	"net/netip"
 	"os"
 	"reflect"
-	"runtime"
 	"slices"
 	"sync"
 	"testing"
@@ -2269,9 +2268,6 @@ func TestPreferencePolicyInfo(t *testing.T) {
 }
 
 func TestOnTailnetDefaultAutoUpdate(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip("test broken on macOS; see https://github.com/tailscale/tailscale/issues/11894")
-	}
 	tests := []struct {
 		before, after  opt.Bool
 		tailnetDefault bool
@@ -2316,7 +2312,14 @@ func TestOnTailnetDefaultAutoUpdate(t *testing.T) {
 				t.Fatal(err)
 			}
 			b.onTailnetDefaultAutoUpdate(tt.tailnetDefault)
-			if want, got := tt.after, b.pm.CurrentPrefs().AutoUpdate().Apply; got != want {
+			want := tt.after
+			// On platforms that don't support auto-update we can never
+			// transition to auto-updates being enabled. The value should
+			// remain unchanged after onTailnetDefaultAutoUpdate.
+			if !clientupdate.CanAutoUpdate() && want.EqualBool(true) {
+				want = tt.before
+			}
+			if got := b.pm.CurrentPrefs().AutoUpdate().Apply; got != want {
 				t.Errorf("got: %q, want %q", got, want)
 			}
 		})


### PR DESCRIPTION
We don't run CI tests on darwin in this repo, so this failure wasn't caught.

Fixes #11894