### PR TITLE
net/netmon: swap to swift-derived defaultRoute on macos

### DIFF
--- a/net/netmon/defaultroute_bsd.go
+++ b/net/netmon/defaultroute_bsd.go
@@ -1,11 +1,11 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-// Common code for FreeBSD and Darwin. This might also work on other
+// Common code for FreeBSD. This might also work on other
 // BSD systems (e.g. OpenBSD) but has not been tested.
-// Not used on iOS. See defaultroute_ios.go.
+// Not used on iOS or macOS. See defaultroute_darwin.go.
 
-//go:build !ios && (darwin || freebsd)
+//go:build freebsd
 
 package netmon
 


### PR DESCRIPTION
Updates tailscale/corp#18960

iOS uses Apple's NetworkMonitor to track the default interface and there's no reason we shouldn't also use this on macOS, for the same reasons noted in the comments for why this change was made on iOS.

This eliminates the need to load and parse the routing table when querying the defaultRouter() in almost all cases.

A slight modification here (on both platforms) to fallback to the default BSD logic in the unhappy-path rather than making assumptions that may not hold.  If netmon is eventually parsing AF_ROUTE and able to give a consistently correct answer for the  default interface index, we can fall back to that and eliminate the Swift dependency.