### PR TITLE
drive: use secret token to authenticate access to file server on loca…

### DIFF
--- a/drive/driveimpl/compositedav/compositedav.go
+++ b/drive/driveimpl/compositedav/compositedav.go
@@ -162,7 +162,7 @@ func (h *Handler) delegate(mpl int, pathComponents []string, w http.ResponseWrit
 
 	u, err := url.Parse(baseURL)
 	if err != nil {
-		h.logf("warning: parse base URL %s failed: %s", child.BaseURL, err)
+		h.logf("warning: parse base URL %s failed: %s", baseURL, err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/drive/driveimpl/drive_test.go
+++ b/drive/driveimpl/drive_test.go
@@ -131,7 +131,11 @@ func TestSecretTokenAuth(t *testing.T) {
 		Transport: &http.Transport{DisableKeepAlives: true},
 	}
 	addr := strings.Split(fileserverAddr, "|")[1]
-	u := fmt.Sprintf("http://%s/%s/%s", addr, "fakesecret", url.PathEscape(file111))
+	wrongSecret, err := generateSecretToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	u := fmt.Sprintf("http://%s/%s/%s", addr, wrongSecret, url.PathEscape(file111))
 	resp, err := client.Get(u)
 	if err != nil {
 		t.Fatal(err)

--- a/drive/driveimpl/fileserver.go
+++ b/drive/driveimpl/fileserver.go
@@ -5,6 +5,7 @@ package driveimpl
 
 import (
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
 	"net"
@@ -117,7 +118,8 @@ func (s *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	parts := shared.CleanAndSplit(r.URL.Path)
 
 	token := parts[0]
-	if token != s.secretToken {
+	a, b := []byte(token), []byte(s.secretToken)
+	if len(a) != len(b) || subtle.ConstantTimeCompare(a, b) != 1 {
 		w.WriteHeader(http.StatusForbidden)
 		return
 	}

--- a/drive/driveimpl/fileserver.go
+++ b/drive/driveimpl/fileserver.go
@@ -138,7 +138,7 @@ func (s *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	token := parts[0]
 	a, b := []byte(token), []byte(s.secretToken)
-	if len(a) != len(b) || subtle.ConstantTimeCompare(a, b) != 1 {
+	if subtle.ConstantTimeCompare(a, b) != 1 {
 		w.WriteHeader(http.StatusForbidden)
 		return
 	}

--- a/drive/driveimpl/fileserver.go
+++ b/drive/driveimpl/fileserver.go
@@ -48,7 +48,6 @@ func NewFileServer() (*FileServer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("listen: %w", err)
 	}
-	// }
 
 	secretToken, err := generateSecretToken()
 	if err != nil {

--- a/drive/driveimpl/local_impl.go
+++ b/drive/driveimpl/local_impl.go
@@ -77,7 +77,7 @@ func (s *FileSystemForLocal) SetRemotes(domain string, remotes []*drive.Remote, 
 				Name:      remote.Name,
 				Available: remote.Available,
 			},
-			BaseURL:   remote.URL,
+			BaseURL:   func() (string, error) { return remote.URL, nil },
 			Transport: transport,
 		})
 	}

--- a/drive/remote.go
+++ b/drive/remote.go
@@ -95,6 +95,9 @@ type FileSystemForRemote interface {
 	// sandboxed where we can't spawn user-specific sub-processes and instead
 	// rely on the UI application that's already running as an unprivileged
 	// user to access the filesystem for us.
+	//
+	// Note that this includes both the file server's secret token and its
+	// address, delimited by a pipe |.
 	SetFileServerAddr(addr string)
 
 	// SetShares sets the complete set of shares exposed by this node. If


### PR DESCRIPTION
…lhost

This prevents Mark-of-the-Web bypass attacks in case someone visits the localhost WebDAV server directly.

Fixes tailscale/corp#19592