### PR TITLE
tstest/integration: mark TestTwoNodes as flaky

### DIFF
--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -213,6 +213,7 @@ func TestCollectPanic(t *testing.T) {
 
 func TestControlTimeLogLine(t *testing.T) {
 	tstest.Shard(t)
+	flakytest.Mark(t, "https://github.com/tailscale/tailscale/issues/11962")
 	tstest.Parallel(t)
 	env := newTestEnv(t)
 	env.LogCatcher.StoreRawJSON()

--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -345,6 +345,7 @@ func TestConfigFileAuthKey(t *testing.T) {
 
 func TestTwoNodes(t *testing.T) {
 	tstest.Shard(t)
+	flakytest.Mark(t, "https://github.com/tailscale/tailscale/issues/11960")
 	tstest.Parallel(t)
 	env := newTestEnv(t)
 


### PR DESCRIPTION
I couldn't reproduce this locally, but it's failing pretty consistently for me in CI.

Updates #11960


Change-Id: Id78b063a3b8768e2dfe47b5ab1c0cab36dcb53eb