### PR TITLE
net/dns/resolver: use UserDial instead of SystemDial to dial DNS servers

### DIFF
--- a/control/controlknobs/controlknobs.go
+++ b/control/controlknobs/controlknobs.go
@@ -76,6 +76,11 @@ type Knobs struct {
 	// AppCStoreRoutes is whether the node should store RouteInfo to StateStore
 	// if it's an app connector.
 	AppCStoreRoutes atomic.Bool
+
+	// UserDialUseRoutes is whether tsdial.Dialer.UserDial should use routes to determine
+	// how to dial the destination address. When true, it also makes the DNS forwarder
+	// use UserDial instead of SystemDial when dialing resolvers.
+	UserDialUseRoutes atomic.Bool
 }
 
 // UpdateFromNodeAttributes updates k (if non-nil) based on the provided self
@@ -101,6 +106,7 @@ func (k *Knobs) UpdateFromNodeAttributes(capMap tailcfg.NodeCapMap) {
 		seamlessKeyRenewal            = has(tailcfg.NodeAttrSeamlessKeyRenewal)
 		probeUDPLifetime              = has(tailcfg.NodeAttrProbeUDPLifetime)
 		appCStoreRoutes               = has(tailcfg.NodeAttrStoreAppCRoutes)
+		userDialUseRoutes             = has(tailcfg.NodeAttrUserDialUseRoutes)
 	)
 
 	if has(tailcfg.NodeAttrOneCGNATEnable) {
@@ -124,6 +130,7 @@ func (k *Knobs) UpdateFromNodeAttributes(capMap tailcfg.NodeCapMap) {
 	k.SeamlessKeyRenewal.Store(seamlessKeyRenewal)
 	k.ProbeUDPLifetime.Store(probeUDPLifetime)
 	k.AppCStoreRoutes.Store(appCStoreRoutes)
+	k.UserDialUseRoutes.Store(userDialUseRoutes)
 }
 
 // AsDebugJSON returns k as something that can be marshalled with json.Marshal
@@ -148,5 +155,6 @@ func (k *Knobs) AsDebugJSON() map[string]any {
 		"SeamlessKeyRenewal":            k.SeamlessKeyRenewal.Load(),
 		"ProbeUDPLifetime":              k.ProbeUDPLifetime.Load(),
 		"AppCStoreRoutes":               k.AppCStoreRoutes.Load(),
+		"UserDialUseRoutes":             k.UserDialUseRoutes.Load(),
 	}
 }

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -2262,7 +2262,8 @@ const (
 	NodeAttrSuggestExitNodeUI NodeCapability = "suggest-exit-node-ui"
 
 	// NodeAttrUserDialUseRoutes makes UserDial use either the peer dialer or the system dialer,
-	// depending on the destination address and the configured routes.
+	// depending on the destination address and the configured routes. When present, it also makes
+	// the DNS forwarder use UserDial instead of SystemDial when dialing resolvers.
 	NodeAttrUserDialUseRoutes NodeCapability = "user-dial-routes"
 )
 


### PR DESCRIPTION
Now that tsdial.Dialer.UserDial has been updated to honor the configured routes and dial external network addresses without going through Tailscale, while also being able to dial a node/subnet router on the tailnet, we can start using UserDial to forward DNS requests. This is primarily needed for DNS over TCP when forwarding requests to internal DNS servers, but we also update getKnownDoHClientForProvider to use it.

Updates tailscale/corp#18725