### PR TITLE
cmd/k8s-operator/deploy,k8s-operator: document that metrics are unstable

### DIFF
--- a/cmd/k8s-operator/deploy/crds/tailscale.com_proxyclasses.yaml
+++ b/cmd/k8s-operator/deploy/crds/tailscale.com_proxyclasses.yaml
@@ -39,7 +39,7 @@ spec:
               type: object
               properties:
                 metrics:
-                  description: Configuration for proxy metrics. Metrics are currently not supported for egress proxies and for Ingress proxies that have been configured with tailscale.com/experimental-forward-cluster-traffic-via-ingress annotation.
+                  description: Configuration for proxy metrics. Metrics are currently not supported for egress proxies and for Ingress proxies that have been configured with tailscale.com/experimental-forward-cluster-traffic-via-ingress annotation. Note that the metrics are currently considered unstable and will likely change in breaking ways in the future - we only recommend that you use those for debugging purposes.
                   type: object
                   required:
                     - enable

--- a/cmd/k8s-operator/deploy/manifests/operator.yaml
+++ b/cmd/k8s-operator/deploy/manifests/operator.yaml
@@ -291,7 +291,7 @@ spec:
                         description: Specification of the desired state of the ProxyClass resource. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                         properties:
                             metrics:
-                                description: Configuration for proxy metrics. Metrics are currently not supported for egress proxies and for Ingress proxies that have been configured with tailscale.com/experimental-forward-cluster-traffic-via-ingress annotation.
+                                description: Configuration for proxy metrics. Metrics are currently not supported for egress proxies and for Ingress proxies that have been configured with tailscale.com/experimental-forward-cluster-traffic-via-ingress annotation. Note that the metrics are currently considered unstable and will likely change in breaking ways in the future - we only recommend that you use those for debugging purposes.
                                 properties:
                                     enable:
                                         description: Setting enable to true will make the proxy serve Tailscale metrics at <pod-ip>:9001/debug/metrics. Defaults to false.

--- a/k8s-operator/api.md
+++ b/k8s-operator/api.md
@@ -603,7 +603,7 @@ Specification of the desired state of the ProxyClass resource. https://git.k8s.i
         <td><b><a href="#proxyclassspecmetrics">metrics</a></b></td>
         <td>object</td>
         <td>
-          Configuration for proxy metrics. Metrics are currently not supported for egress proxies and for Ingress proxies that have been configured with tailscale.com/experimental-forward-cluster-traffic-via-ingress annotation.<br/>
+          Configuration for proxy metrics. Metrics are currently not supported for egress proxies and for Ingress proxies that have been configured with tailscale.com/experimental-forward-cluster-traffic-via-ingress annotation. Note that the metrics are currently considered unstable and will likely change in breaking ways in the future - we only recommend that you use those for debugging purposes.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -622,7 +622,7 @@ Specification of the desired state of the ProxyClass resource. https://git.k8s.i
 
 
 
-Configuration for proxy metrics. Metrics are currently not supported for egress proxies and for Ingress proxies that have been configured with tailscale.com/experimental-forward-cluster-traffic-via-ingress annotation.
+Configuration for proxy metrics. Metrics are currently not supported for egress proxies and for Ingress proxies that have been configured with tailscale.com/experimental-forward-cluster-traffic-via-ingress annotation. Note that the metrics are currently considered unstable and will likely change in breaking ways in the future - we only recommend that you use those for debugging purposes.
 
 <table>
     <thead>

--- a/k8s-operator/apis/v1alpha1/types_proxyclass.go
+++ b/k8s-operator/apis/v1alpha1/types_proxyclass.go
@@ -57,7 +57,9 @@ type ProxyClassSpec struct {
 	// Configuration for proxy metrics. Metrics are currently not supported
 	// for egress proxies and for Ingress proxies that have been configured
 	// with tailscale.com/experimental-forward-cluster-traffic-via-ingress
-	// annotation.
+	// annotation. Note that the metrics are currently considered unstable
+	// and will likely change in breaking ways in the future - we only
+	// recommend that you use those for debugging purposes.
 	// +optional
 	Metrics *Metrics `json:"metrics,omitempty"`
 }


### PR DESCRIPTION
In https://github.com/tailscale/tailscale/pull/11699 we added a new `proxyClass.spec.metrics` field to allow users to expose tailscled metrics on proxy Pod IP. However the tailscaled metrics are currently considered unstable, so we should warn users that breaking changes will be made in the future.