### PR TITLE
cmd/k8s-operator: default nameserver image to tailscale/k8s-nameserver:unstable

### DIFF
--- a/cmd/k8s-operator/nameserver.go
+++ b/cmd/k8s-operator/nameserver.go
@@ -41,6 +41,12 @@ const (
 
 	messageNameserverCreationFailed  = "Failed creating nameserver resources: %v"
 	messageMultipleDNSConfigsPresent = "Multiple DNSConfig resources found in cluster. Please ensure no more than one is present."
+
+	defaultNameserverImageRepo = "tailscale/k8s-nameserver"
+	// TODO (irbekrm): once we start publishing nameserver images for stable
+	// track, replace 'unstable' here with the version of this operator
+	// instance.
+	defaultNameserverImageTag = "unstable"
 )
 
 // NameserverReconciler knows how to create nameserver resources in cluster in
@@ -163,11 +169,13 @@ func (a *NameserverReconciler) maybeProvision(ctx context.Context, tsDNSCfg *tsa
 		ownerRefs: []metav1.OwnerReference{*metav1.NewControllerRef(tsDNSCfg, tsapi.SchemeGroupVersion.WithKind("DNSConfig"))},
 		namespace: a.tsNamespace,
 		labels:    labels,
+		imageRepo: defaultNameserverImageRepo,
+		imageTag:  defaultNameserverImageTag,
 	}
-	if tsDNSCfg.Spec.Nameserver.Image.Repo != "" {
+	if tsDNSCfg.Spec.Nameserver.Image != nil && tsDNSCfg.Spec.Nameserver.Image.Repo != "" {
 		dCfg.imageRepo = tsDNSCfg.Spec.Nameserver.Image.Repo
 	}
-	if tsDNSCfg.Spec.Nameserver.Image.Tag != "" {
+	if tsDNSCfg.Spec.Nameserver.Image != nil && tsDNSCfg.Spec.Nameserver.Image.Tag != "" {
 		dCfg.imageTag = tsDNSCfg.Spec.Nameserver.Image.Tag
 	}
 	for _, deployable := range []deployable{saDeployable, deployDeployable, svcDeployable, cmDeployable} {

--- a/cmd/k8s-operator/nameserver_test.go
+++ b/cmd/k8s-operator/nameserver_test.go
@@ -115,4 +115,13 @@ func TestNameserverReconciler(t *testing.T) {
 		Data:     map[string]string{"records.json": string(bs)},
 	}
 	expectEqual(t, fc, wantCm, nil)
+
+	// Verify that if dnsconfig.spec.nameserver.image.{repo,tag} are unset,
+	// the nameserver image defaults to tailscale/k8s-nameserver:unstable.
+	mustUpdate(t, fc, "", "test", func(dnsCfg *tsapi.DNSConfig) {
+		dnsCfg.Spec.Nameserver.Image = nil
+	})
+	expectReconciled(t, nr, "", "test")
+	wantsDeploy.Spec.Template.Spec.Containers[0].Image = "tailscale/k8s-nameserver:unstable"
+	expectEqual(t, fc, wantsDeploy, nil)
 }


### PR DESCRIPTION
This PR starts defaulting the image for the nameserver, that the Kubernetes operator can optionally deploy, to `tailscale/k8s-nameserver:unstable`.

We are now publishing nameserver images to `tailscale/k8s-nameserver`, so we can start defaulting the images if users haven't set them explicitly, same as we already do with proxy images.

The nameserver images are currently only published for unstable track, so we have to use the static 'unstable' tag. Once we start publishing to stable, we can make the operator default to its own tag (because then we'll know that for each operator tag X there is also a nameserver tag X as we always cut all images for a given tag.

Updates tailscale/tailscale#10499