### PR TITLE
all: add client side jailing of peers

### DIFF
--- a/control/controlclient/map.go
+++ b/control/controlclient/map.go
@@ -736,6 +736,10 @@ func peerChangeDiff(was tailcfg.NodeView, n *tailcfg.Node) (_ *tailcfg.PeerChang
 			if was.IsWireGuardOnly() != n.IsWireGuardOnly {
 				return nil, false
 			}
+		case "IsJailed":
+			if was.IsJailed() != n.IsJailed {
+				return nil, false
+			}
 		case "Expired":
 			if was.Expired() != n.Expired {
 				return nil, false

--- a/net/tstun/wrap.go
+++ b/net/tstun/wrap.go
@@ -739,18 +739,16 @@ func peerConfigTableFromWGConfig(wcfg *wgcfg.Config) *peerConfigTable {
 			}
 		}
 
-		if !addrToUse4.IsValid() && !addrToUse6.IsValid() {
+		if !addrToUse4.IsValid() && !addrToUse6.IsValid() && !p.IsJailed {
 			// NAT not required for this peer.
 			continue
 		}
-
-		const peerIsJailed = false // TODO: implement jailed peers
 
 		// Use the same peer configuration for each address of the peer.
 		pc := &peerConfig{
 			dstMasqAddr4: addrToUse4,
 			dstMasqAddr6: addrToUse6,
-			jailed:       peerIsJailed,
+			jailed:       p.IsJailed,
 		}
 
 		// Insert an entry into our routing table for each allowed IP.

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -134,7 +134,8 @@ type CapabilityVersion int
 //   - 91: 2024-04-24: Client understands PeerCapabilityTaildriveSharer.
 //   - 92: 2024-05-06: Client understands NodeAttrUserDialUseRoutes.
 //   - 93: 2024-05-06: added support for stateful firewalling.
-const CurrentCapabilityVersion CapabilityVersion = 93
+//   - 94: 2024-05-06: Client understands Node.IsJailed.
+const CurrentCapabilityVersion CapabilityVersion = 94
 
 type StableID string
 
@@ -415,6 +416,11 @@ type Node struct {
 	// is not expected to speak Disco or DERP, and it must have Endpoints in
 	// order to be reachable.
 	IsWireGuardOnly bool `json:",omitempty"`
+
+	// IsJailed indicates that this node is jailed and should not be allowed
+	// initiate connections, however outbound connections to it should still be
+	// allowed.
+	IsJailed bool `json:",omitempty"`
 
 	// ExitNodeDNSResolvers is the list of DNS servers that should be used when this
 	// node is marked IsWireGuardOnly and being used as an exit node.
@@ -2046,7 +2052,8 @@ func (n *Node) Equal(n2 *Node) bool {
 		n.Expired == n2.Expired &&
 		eqPtr(n.SelfNodeV4MasqAddrForThisPeer, n2.SelfNodeV4MasqAddrForThisPeer) &&
 		eqPtr(n.SelfNodeV6MasqAddrForThisPeer, n2.SelfNodeV6MasqAddrForThisPeer) &&
-		n.IsWireGuardOnly == n2.IsWireGuardOnly
+		n.IsWireGuardOnly == n2.IsWireGuardOnly &&
+		n.IsJailed == n2.IsJailed
 }
 
 func eqPtr[T comparable](a, b *T) bool {

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -118,6 +118,7 @@ var _NodeCloneNeedsRegeneration = Node(struct {
 	SelfNodeV4MasqAddrForThisPeer *netip.Addr
 	SelfNodeV6MasqAddrForThisPeer *netip.Addr
 	IsWireGuardOnly               bool
+	IsJailed                      bool
 	ExitNodeDNSResolvers          []*dnstype.Resolver
 }{})
 

--- a/tailcfg/tailcfg_test.go
+++ b/tailcfg/tailcfg_test.go
@@ -363,7 +363,7 @@ func TestNodeEqual(t *testing.T) {
 		"UnsignedPeerAPIOnly",
 		"ComputedName", "computedHostIfDifferent", "ComputedNameWithHost",
 		"DataPlaneAuditLogID", "Expired", "SelfNodeV4MasqAddrForThisPeer",
-		"SelfNodeV6MasqAddrForThisPeer", "IsWireGuardOnly", "ExitNodeDNSResolvers",
+		"SelfNodeV6MasqAddrForThisPeer", "IsWireGuardOnly", "IsJailed", "ExitNodeDNSResolvers",
 	}
 	if have := fieldsOf(reflect.TypeFor[Node]()); !reflect.DeepEqual(have, nodeHandles) {
 		t.Errorf("Node.Equal check might be out of sync\nfields: %q\nhandled: %q\n",
@@ -605,6 +605,16 @@ func TestNodeEqual(t *testing.T) {
 					"foo": []RawMessage{`"bar"`},
 				},
 			},
+			false,
+		},
+		{
+			&Node{IsJailed: true},
+			&Node{IsJailed: true},
+			true,
+		},
+		{
+			&Node{IsJailed: false},
+			&Node{IsJailed: true},
 			false,
 		},
 	}

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -195,6 +195,7 @@ func (v NodeView) SelfNodeV6MasqAddrForThisPeer() *netip.Addr {
 }
 
 func (v NodeView) IsWireGuardOnly() bool { return v.ж.IsWireGuardOnly }
+func (v NodeView) IsJailed() bool        { return v.ж.IsJailed }
 func (v NodeView) ExitNodeDNSResolvers() views.SliceView[*dnstype.Resolver, dnstype.ResolverView] {
 	return views.SliceOfViews[*dnstype.Resolver, dnstype.ResolverView](v.ж.ExitNodeDNSResolvers)
 }
@@ -235,6 +236,7 @@ var _NodeViewNeedsRegeneration = Node(struct {
 	SelfNodeV4MasqAddrForThisPeer *netip.Addr
 	SelfNodeV6MasqAddrForThisPeer *netip.Addr
 	IsWireGuardOnly               bool
+	IsJailed                      bool
 	ExitNodeDNSResolvers          []*dnstype.Resolver
 }{})
 

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -1037,6 +1037,14 @@ func (e *userspaceEngine) SetFilter(filt *filter.Filter) {
 	e.tundev.SetFilter(filt)
 }
 
+func (e *userspaceEngine) GetJailedFilter() *filter.Filter {
+	return e.tundev.GetJailedFilter()
+}
+
+func (e *userspaceEngine) SetJailedFilter(filt *filter.Filter) {
+	e.tundev.SetJailedFilter(filt)
+}
+
 func (e *userspaceEngine) SetStatusCallback(cb StatusCallback) {
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/wgengine/watchdog.go
+++ b/wgengine/watchdog.go
@@ -129,6 +129,12 @@ func (e *watchdogEngine) GetFilter() *filter.Filter {
 func (e *watchdogEngine) SetFilter(filt *filter.Filter) {
 	e.watchdog("SetFilter", func() { e.wrap.SetFilter(filt) })
 }
+func (e *watchdogEngine) GetJailedFilter() *filter.Filter {
+	return e.wrap.GetJailedFilter()
+}
+func (e *watchdogEngine) SetJailedFilter(filt *filter.Filter) {
+	e.watchdog("SetJailedFilter", func() { e.wrap.SetJailedFilter(filt) })
+}
 func (e *watchdogEngine) SetStatusCallback(cb StatusCallback) {
 	e.watchdog("SetStatusCallback", func() { e.wrap.SetStatusCallback(cb) })
 }

--- a/wgengine/wgcfg/config.go
+++ b/wgengine/wgcfg/config.go
@@ -41,6 +41,7 @@ type Peer struct {
 	AllowedIPs          []netip.Prefix
 	V4MasqAddr          *netip.Addr // if non-nil, masquerade IPv4 traffic to this peer using this address
 	V6MasqAddr          *netip.Addr // if non-nil, masquerade IPv6 traffic to this peer using this address
+	IsJailed            bool        // if true, this peer is jailed and cannot initiate connections
 	PersistentKeepalive uint16      // in seconds between keep-alives; 0 to disable
 	// wireguard-go's endpoint for this peer. It should always equal Peer.PublicKey.
 	// We represent it explicitly so that we can detect if they diverge and recover.

--- a/wgengine/wgcfg/nmcfg/nmcfg.go
+++ b/wgengine/wgcfg/nmcfg/nmcfg.go
@@ -110,6 +110,7 @@ func WGCfg(nm *netmap.NetworkMap, logf logger.Logf, flags netmap.WGConfigFlags, 
 		didExitNodeWarn := false
 		cpeer.V4MasqAddr = peer.SelfNodeV4MasqAddrForThisPeer()
 		cpeer.V6MasqAddr = peer.SelfNodeV6MasqAddrForThisPeer()
+		cpeer.IsJailed = peer.IsJailed()
 		for i := range peer.AllowedIPs().Len() {
 			allowedIP := peer.AllowedIPs().At(i)
 			if allowedIP.Bits() == 0 && peer.StableID() != exitNode {

--- a/wgengine/wgcfg/wgcfg_clone.go
+++ b/wgengine/wgcfg/wgcfg_clone.go
@@ -74,6 +74,7 @@ var _PeerCloneNeedsRegeneration = Peer(struct {
 	AllowedIPs          []netip.Prefix
 	V4MasqAddr          *netip.Addr
 	V6MasqAddr          *netip.Addr
+	IsJailed            bool
 	PersistentKeepalive uint16
 	WGEndpoint          key.NodePublic
 }{})

--- a/wgengine/wgengine.go
+++ b/wgengine/wgengine.go
@@ -78,6 +78,13 @@ type Engine interface {
 	// SetFilter updates the packet filter.
 	SetFilter(*filter.Filter)
 
+	// GetJailedFilter returns the current packet filter for jailed nodes,
+	// if any.
+	GetJailedFilter() *filter.Filter
+
+	// SetJailedFilter updates the packet filter for jailed nodes.
+	SetJailedFilter(*filter.Filter)
+
 	// SetStatusCallback sets the function to call when the
 	// WireGuard status changes.
 	SetStatusCallback(StatusCallback)


### PR DESCRIPTION
Broken up into two commits.

The first commit is a no-op and does the refactor necessary to use two different packet filters,
the second commit does the plumbing and hooks up the new jailed packet filter for peers and
adds a test to ensure that jailing works as expected.

```
    ipn/ipnlocal,net/tstun,wgengine: create and plumb jailed packet filter
    
    This plumbs a packet filter for jailed nodes through to the
    tstun.Wrapper; the filter for a jailed node is equivalent to a "shields
    up" filter. Currently a no-op as there is no way for control to
    tell the client whether a peer is jailed.
```

```
    tailcfg,all: add/plumb Node.IsJailed
    
    This adds a new bool that can be sent down from control
    to do jailing on the client side. Previously this would
    only be done from control by modifying the packet filter
    we sent down to clients. This would result in a lot of
    additional work/CPU on control, we could instead just
    do this on the client. This has always been a TODO which
    we keep putting off, might as well do it now.
```
