### PR TITLE
various: allow configuring stateful firewalling on Linux

### DIFF
--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -655,12 +655,13 @@ func TestPrefsFromUpArgs(t *testing.T) {
 			goos: "linux",
 			args: upArgsFromOSArgs("linux"),
 			want: &ipn.Prefs{
-				ControlURL:       ipn.DefaultControlURL,
-				WantRunning:      true,
-				NoSNAT:           false,
-				NetfilterMode:    preftype.NetfilterOn,
-				CorpDNS:          true,
-				AllowSingleHosts: true,
+				ControlURL:          ipn.DefaultControlURL,
+				WantRunning:         true,
+				NoSNAT:              false,
+				NoStatefulFiltering: "false",
+				NetfilterMode:       preftype.NetfilterOn,
+				CorpDNS:             true,
+				AllowSingleHosts:    true,
 				AutoUpdate: ipn.AutoUpdatePrefs{
 					Check: true,
 				},
@@ -694,7 +695,8 @@ func TestPrefsFromUpArgs(t *testing.T) {
 					netip.MustParsePrefix("0.0.0.0/0"),
 					netip.MustParsePrefix("::/0"),
 				},
-				NetfilterMode: preftype.NetfilterOn,
+				NoStatefulFiltering: "false",
+				NetfilterMode:       preftype.NetfilterOn,
 				AutoUpdate: ipn.AutoUpdatePrefs{
 					Check: true,
 				},
@@ -781,9 +783,10 @@ func TestPrefsFromUpArgs(t *testing.T) {
 			},
 			wantWarn: "netfilter=nodivert; add iptables calls to ts-* chains manually.",
 			want: &ipn.Prefs{
-				WantRunning:   true,
-				NetfilterMode: preftype.NetfilterNoDivert,
-				NoSNAT:        true,
+				WantRunning:         true,
+				NetfilterMode:       preftype.NetfilterNoDivert,
+				NoSNAT:              true,
+				NoStatefulFiltering: "true",
 				AutoUpdate: ipn.AutoUpdatePrefs{
 					Check: true,
 				},
@@ -797,9 +800,10 @@ func TestPrefsFromUpArgs(t *testing.T) {
 			},
 			wantWarn: "netfilter=off; configure iptables yourself.",
 			want: &ipn.Prefs{
-				WantRunning:   true,
-				NetfilterMode: preftype.NetfilterOff,
-				NoSNAT:        true,
+				WantRunning:         true,
+				NetfilterMode:       preftype.NetfilterOff,
+				NoSNAT:              true,
+				NoStatefulFiltering: "true",
 				AutoUpdate: ipn.AutoUpdatePrefs{
 					Check: true,
 				},
@@ -813,8 +817,9 @@ func TestPrefsFromUpArgs(t *testing.T) {
 				netfilterMode:   "off",
 			},
 			want: &ipn.Prefs{
-				WantRunning: true,
-				NoSNAT:      true,
+				WantRunning:         true,
+				NoSNAT:              true,
+				NoStatefulFiltering: "true",
 				AdvertiseRoutes: []netip.Prefix{
 					netip.MustParsePrefix("fd7a:115c:a1e0:b1a::bb:10.0.0.0/112"),
 				},
@@ -831,8 +836,9 @@ func TestPrefsFromUpArgs(t *testing.T) {
 				netfilterMode:   "off",
 			},
 			want: &ipn.Prefs{
-				WantRunning: true,
-				NoSNAT:      true,
+				WantRunning:         true,
+				NoSNAT:              true,
+				NoStatefulFiltering: "true",
 				AdvertiseRoutes: []netip.Prefix{
 					netip.MustParsePrefix("fd7a:115c:a1e0:b1a::aabb:10.0.0.0/112"),
 				},
@@ -1031,6 +1037,7 @@ func TestUpdatePrefs(t *testing.T) {
 				HostnameSet:               true,
 				NetfilterModeSet:          true,
 				NoSNATSet:                 true,
+				NoStatefulFilteringSet:    true,
 				OperatorUserSet:           true,
 				RouteAllSet:               true,
 				RunSSHSet:                 true,

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -122,6 +122,7 @@ func newUpFlagSet(goos string, upArgs *upArgsT, cmd string) *flag.FlagSet {
 	switch goos {
 	case "linux":
 		upf.BoolVar(&upArgs.snat, "snat-subnet-routes", true, "source NAT traffic to local routes advertised with --advertise-routes")
+		upf.BoolVar(&upArgs.statefulFiltering, "stateful-filtering", true, "apply stateful filtering to forwarded packets (subnet routers, exit nodes, etc.)")
 		upf.StringVar(&upArgs.netfilterMode, "netfilter-mode", defaultNetfilterMode(), "netfilter mode (one of on, nodivert, off)")
 	case "windows":
 		upf.BoolVar(&upArgs.forceDaemon, "unattended", false, "run in \"Unattended Mode\" where Tailscale keeps running even after the current GUI user logs out (Windows-only)")
@@ -169,6 +170,7 @@ type upArgsT struct {
 	advertiseTags          string
 	advertiseConnector     bool
 	snat                   bool
+	statefulFiltering      bool
 	netfilterMode          string
 	authKeyOrFile          string // "secret" or "file:/path/to/secret"
 	hostname               string
@@ -291,6 +293,9 @@ func prefsFromUpArgs(upArgs upArgsT, warnf logger.Logf, st *ipnstate.Status, goo
 
 	if goos == "linux" {
 		prefs.NoSNAT = !upArgs.snat
+
+		// Backfills for NoStatefulFiltering occur when loading a profile; just set it explicitly here.
+		prefs.NoStatefulFiltering.Set(!upArgs.statefulFiltering)
 
 		switch upArgs.netfilterMode {
 		case "on":
@@ -730,6 +735,7 @@ func init() {
 	addPrefFlagMapping("netfilter-mode", "NetfilterMode")
 	addPrefFlagMapping("shields-up", "ShieldsUp")
 	addPrefFlagMapping("snat-subnet-routes", "NoSNAT")
+	addPrefFlagMapping("stateful-filtering", "NoStatefulFiltering")
 	addPrefFlagMapping("exit-node-allow-lan-access", "ExitNodeAllowLANAccess")
 	addPrefFlagMapping("unattended", "ForceDaemon")
 	addPrefFlagMapping("operator", "OperatorUser")
@@ -914,7 +920,7 @@ func applyImplicitPrefs(prefs, oldPrefs *ipn.Prefs, env upCheckEnv) {
 
 func flagAppliesToOS(flag, goos string) bool {
 	switch flag {
-	case "netfilter-mode", "snat-subnet-routes":
+	case "netfilter-mode", "snat-subnet-routes", "stateful-filtering":
 		return goos == "linux"
 	case "unattended":
 		return goos == "windows"
@@ -989,6 +995,16 @@ func prefsToFlags(env upCheckEnv, prefs *ipn.Prefs) (flagVal map[string]any) {
 			set(prefs.AppConnector.Advertise)
 		case "snat-subnet-routes":
 			set(!prefs.NoSNAT)
+		case "stateful-filtering":
+			// We only set the stateful-filtering flag to false if
+			// the pref (negated!) is explicitly set to true; unset
+			// or false is treated as enabled.
+			val, ok := prefs.NoStatefulFiltering.Get()
+			if ok && val {
+				set(false)
+			} else {
+				set(true)
+			}
 		case "netfilter-mode":
 			set(prefs.NetfilterMode.String())
 		case "unattended":

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -11,6 +11,7 @@ import (
 
 	"tailscale.com/drive"
 	"tailscale.com/tailcfg"
+	"tailscale.com/types/opt"
 	"tailscale.com/types/persist"
 	"tailscale.com/types/preftype"
 )
@@ -57,6 +58,7 @@ var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	Egg                    bool
 	AdvertiseRoutes        []netip.Prefix
 	NoSNAT                 bool
+	NoStatefulFiltering    opt.Bool
 	NetfilterMode          preftype.NetfilterMode
 	OperatorUser           string
 	ProfileName            string

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -12,6 +12,7 @@ import (
 
 	"tailscale.com/drive"
 	"tailscale.com/tailcfg"
+	"tailscale.com/types/opt"
 	"tailscale.com/types/persist"
 	"tailscale.com/types/preftype"
 	"tailscale.com/types/views"
@@ -86,6 +87,7 @@ func (v PrefsView) AdvertiseRoutes() views.Slice[netip.Prefix] {
 	return views.SliceOf(v.ж.AdvertiseRoutes)
 }
 func (v PrefsView) NoSNAT() bool                          { return v.ж.NoSNAT }
+func (v PrefsView) NoStatefulFiltering() opt.Bool         { return v.ж.NoStatefulFiltering }
 func (v PrefsView) NetfilterMode() preftype.NetfilterMode { return v.ж.NetfilterMode }
 func (v PrefsView) OperatorUser() string                  { return v.ж.OperatorUser }
 func (v PrefsView) ProfileName() string                   { return v.ж.ProfileName }
@@ -120,6 +122,7 @@ var _PrefsViewNeedsRegeneration = Prefs(struct {
 	Egg                    bool
 	AdvertiseRoutes        []netip.Prefix
 	NoSNAT                 bool
+	NoStatefulFiltering    opt.Bool
 	NetfilterMode          preftype.NetfilterMode
 	OperatorUser           string
 	ProfileName            string

--- a/ipn/ipnlocal/profiles.go
+++ b/ipn/ipnlocal/profiles.go
@@ -371,12 +371,39 @@ func (pm *profileManager) loadSavedPrefs(key ipn.StateKey) (ipn.PrefsView, error
 	// https://github.com/tailscale/tailscale/pull/11814/commits/1613b18f8280c2bce786980532d012c9f0454fa2#diff-314ba0d799f70c8998940903efb541e511f352b39a9eeeae8d475c921d66c2ac
 	// prefs could set AutoUpdate.Apply=true via EditPrefs or tailnet
 	// auto-update defaults. After that change, such value is "invalid" and
-	// cause any EditPrefs calls to fail (other than disabling autp-updates).
+	// cause any EditPrefs calls to fail (other than disabling auto-updates).
 	//
 	// Reset AutoUpdate.Apply if we detect such invalid prefs.
 	if savedPrefs.AutoUpdate.Apply.EqualBool(true) && !clientupdate.CanAutoUpdate() {
 		savedPrefs.AutoUpdate.Apply.Clear()
 	}
+
+	// Backfill a missing NoStatefulFiltering field based on the value of
+	// the NoSNAT field; we want to apply stateful filtering in all cases
+	// *except* where the user has disabled SNAT.
+	//
+	// Only backfill if the user hasn't set a value for
+	// NoStatefulFiltering, however.
+	_, haveNoStateful := savedPrefs.NoStatefulFiltering.Get()
+	if !haveNoStateful {
+		if savedPrefs.NoSNAT {
+			pm.logf("backfilling NoStatefulFiltering field to true because NoSNAT is set")
+
+			// No SNAT: no stateful filtering
+			savedPrefs.NoStatefulFiltering.Set(true)
+		} else {
+			pm.logf("backfilling NoStatefulFiltering field to false because NoSNAT is not set")
+
+			// SNAT (default): apply stateful filtering
+			savedPrefs.NoStatefulFiltering.Set(false)
+		}
+
+		// Write back to the preferences store now that we've updated it.
+		if err := pm.writePrefsToStore(key, savedPrefs.View()); err != nil {
+			return ipn.PrefsView{}, err
+		}
+	}
+
 	return savedPrefs.View(), nil
 }
 
@@ -468,6 +495,7 @@ var defaultPrefs = func() ipn.PrefsView {
 	prefs := ipn.NewPrefs()
 	prefs.LoggedOut = true
 	prefs.WantRunning = false
+	prefs.NoStatefulFiltering = "false"
 
 	return prefs.View()
 }()

--- a/ipn/ipnlocal/profiles_test.go
+++ b/ipn/ipnlocal/profiles_test.go
@@ -4,6 +4,7 @@
 package ipnlocal
 
 import (
+	"encoding/json"
 	"fmt"
 	"os/user"
 	"strconv"
@@ -12,12 +13,14 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"tailscale.com/clientupdate"
+	"tailscale.com/envknob"
 	"tailscale.com/health"
 	"tailscale.com/ipn"
 	"tailscale.com/ipn/store/mem"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/key"
 	"tailscale.com/types/logger"
+	"tailscale.com/types/opt"
 	"tailscale.com/types/persist"
 	"tailscale.com/util/must"
 )
@@ -598,5 +601,88 @@ func TestProfileManagementWindows(t *testing.T) {
 	checkProfiles(t)
 	if pm.CurrentUserID() != uid {
 		t.Fatalf("CurrentUserID = %q; want %q", pm.CurrentUserID(), uid)
+	}
+}
+
+func TestProfileBackfillStatefulFiltering(t *testing.T) {
+	envknob.Setenv("TS_DEBUG_PROFILES", "true")
+
+	tests := []struct {
+		noSNAT     bool
+		noStateful opt.Bool
+		want       bool
+	}{
+		// Default: NoSNAT is false, NoStatefulFiltering is false, so
+		// we want it to stay false.
+		{false, "false", false},
+
+		// NoSNAT being set to true and NoStatefulFiltering being false
+		// should result in NoStatefulFiltering still being false,
+		// since it was explicitly set.
+		{true, "false", false},
+
+		// If NoSNAT is false, and NoStatefulFiltering is unset, we
+		// backfill it to 'false'.
+		{false, "", false},
+
+		// If NoSNAT is true, and NoStatefulFiltering is unset, we
+		// backfill to 'true' to not break users of NoSNAT.
+		//
+		// In other words: if the user is not using SNAT, they almost
+		// certainly also don't want to use stateful filtering.
+		{true, "", true},
+
+		// However, if the user specifies both NoSNAT and stateful
+		// filtering, don't change that.
+		{true, "true", true},
+		{false, "true", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("noSNAT=%v,noStateful=%q", tt.noSNAT, tt.noStateful), func(t *testing.T) {
+			prefs := ipn.NewPrefs()
+			prefs.Persist = &persist.Persist{
+				NodeID: tailcfg.StableNodeID("node1"),
+				UserProfile: tailcfg.UserProfile{
+					ID:        tailcfg.UserID(1),
+					LoginName: "user1@example.com",
+				},
+			}
+
+			prefs.NoSNAT = tt.noSNAT
+			prefs.NoStatefulFiltering = tt.noStateful
+
+			// Make enough of a state store to load the prefs.
+			const profileName = "profile1"
+			bn := must.Get(json.Marshal(map[string]any{
+				string(ipn.CurrentProfileStateKey): []byte(profileName),
+				string(ipn.KnownProfilesStateKey): must.Get(json.Marshal(map[ipn.ProfileID]*ipn.LoginProfile{
+					profileName: {
+						ID:  "profile1-id",
+						Key: profileName,
+					},
+				})),
+				profileName: prefs.ToBytes(),
+			}))
+
+			store := new(mem.Store)
+			err := store.LoadFromJSON([]byte(bn))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ht := new(health.Tracker)
+			pm, err := newProfileManagerWithGOOS(store, t.Logf, ht, "linux")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Get the current profile and verify that we backfilled our
+			// StatefulFiltering boolean.
+			pf := pm.CurrentPrefs()
+			if !pf.NoStatefulFiltering().EqualBool(tt.want) {
+				t.Fatalf("got NoStatefulFiltering=%v, want %v", pf.NoStatefulFiltering(), tt.want)
+			}
+		})
 	}
 }

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -56,6 +56,7 @@ func TestPrefsEqual(t *testing.T) {
 		"Egg",
 		"AdvertiseRoutes",
 		"NoSNAT",
+		"NoStatefulFiltering",
 		"NetfilterMode",
 		"OperatorUser",
 		"ProfileName",

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -133,7 +133,8 @@ type CapabilityVersion int
 //   - 90: 2024-04-03: Client understands PeerCapabilityTaildrive.
 //   - 91: 2024-04-24: Client understands PeerCapabilityTaildriveSharer.
 //   - 92: 2024-05-06: Client understands NodeAttrUserDialUseRoutes.
-const CurrentCapabilityVersion CapabilityVersion = 92
+//   - 93: 2024-05-06: added support for stateful firewalling.
+const CurrentCapabilityVersion CapabilityVersion = 93
 
 type StableID string
 

--- a/util/linuxfw/fake.go
+++ b/util/linuxfw/fake.go
@@ -85,6 +85,15 @@ func (n *fakeIPTables) Delete(table, chain string, args ...string) error {
 	}
 }
 
+func (n *fakeIPTables) List(table, chain string) ([]string, error) {
+	k := table + "/" + chain
+	if rules, ok := n.n[k]; ok {
+		return rules, nil
+	} else {
+		return nil, fmt.Errorf("unknown table/chain %s", k)
+	}
+}
+
 func (n *fakeIPTables) ClearChain(table, chain string) error {
 	k := table + "/" + chain
 	if _, ok := n.n[k]; ok {

--- a/wgengine/router/router.go
+++ b/wgengine/router/router.go
@@ -88,9 +88,10 @@ type Config struct {
 	SubnetRoutes []netip.Prefix
 
 	// Linux-only things below, ignored on other platforms.
-	SNATSubnetRoutes bool                   // SNAT traffic to local subnets
-	NetfilterMode    preftype.NetfilterMode // how much to manage netfilter rules
-	NetfilterKind    string                 // what kind of netfilter to use (nftables, iptables)
+	SNATSubnetRoutes  bool                   // SNAT traffic to local subnets
+	StatefulFiltering bool                   // Apply stateful filtering to inbound connections
+	NetfilterMode     preftype.NetfilterMode // how much to manage netfilter rules
+	NetfilterKind     string                 // what kind of netfilter to use (nftables, iptables)
 }
 
 func (a *Config) Equal(b *Config) bool {

--- a/wgengine/router/router_test.go
+++ b/wgengine/router/router_test.go
@@ -23,8 +23,8 @@ func mustCIDRs(ss ...string) []netip.Prefix {
 func TestConfigEqual(t *testing.T) {
 	testedFields := []string{
 		"LocalAddrs", "Routes", "LocalRoutes", "NewMTU",
-		"SubnetRoutes", "SNATSubnetRoutes", "NetfilterMode",
-		"NetfilterKind",
+		"SubnetRoutes", "SNATSubnetRoutes", "StatefulFiltering",
+		"NetfilterMode", "NetfilterKind",
 	}
 	configType := reflect.TypeFor[Config]()
 	configFields := []string{}
@@ -123,6 +123,16 @@ func TestConfigEqual(t *testing.T) {
 		{
 			&Config{SNATSubnetRoutes: false},
 			&Config{SNATSubnetRoutes: false},
+			true,
+		},
+		{
+			&Config{StatefulFiltering: false},
+			&Config{StatefulFiltering: true},
+			false,
+		},
+		{
+			&Config{StatefulFiltering: false},
+			&Config{StatefulFiltering: false},
 			true,
 		},
 


### PR DESCRIPTION
Adds new `--stateful-filtering` flag to `tailscale up/set` which enables a stateful firewall using iptables/nftables on Linux subnet routers. Backfill the flag to match `--snat-subnet-routes`, as it could break some connections when mismatched.

Updates https://github.com/tailscale/corp/issues/19623

Change-Id: I7980e1fb736e234e66fa000d488066466c96ec85