### PR TITLE
tailcfg: bump capver for using NodeAttrUserDialUseRoutes for DNS

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -135,7 +135,8 @@ type CapabilityVersion int
 //   - 92: 2024-05-06: Client understands NodeAttrUserDialUseRoutes.
 //   - 93: 2024-05-06: added support for stateful firewalling.
 //   - 94: 2024-05-06: Client understands Node.IsJailed.
-const CurrentCapabilityVersion CapabilityVersion = 94
+//   - 95: 2024-05-06: Client uses NodeAttrUserDialUseRoutes to change DNS dialing behavior.
+const CurrentCapabilityVersion CapabilityVersion = 95
 
 type StableID string
 


### PR DESCRIPTION
Missed in f62e678df8e1d4a3fd3a41f8c847c6b0a3605ac8.

Updates tailscale/corp#18725
Updates #4529