### PR TITLE
ipn/localapi: do not permit use of UpdatePrefs parameter in /start API

### DIFF
--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -1323,6 +1323,10 @@ func (h *Handler) serveStart(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	if o.UpdatePrefs != nil {
+		http.Error(w, "The UpdatePrefs parameter is not supported via localapi, please use the /prefs endpoint to update preferences before logging in", http.StatusBadRequest)
+		return
+	}
 	err := h.b.Start(o)
 	if err != nil {
 		// TODO(bradfitz): map error to a good HTTP error


### PR DESCRIPTION
Clients almost always misuse this parameter, blowing away important default preferences. It is safer for clients to edit prefs via the /prefs endpoint.

Updates #11731