### PR TITLE
util/linuxfw: fix stateful packet filtering in nftables mode

### DIFF
--- a/util/linuxfw/nftables_runner.go
+++ b/util/linuxfw/nftables_runner.go
@@ -1773,7 +1773,7 @@ func makeStatefulRuleExprs(tunname string) []expr.Any {
 		// going to our TUN.
 		&expr.Meta{Key: expr.MetaKeyOIFNAME, Register: 1},
 		&expr.Cmp{
-			Op:       expr.CmpOpNeq,
+			Op:       expr.CmpOpEq,
 			Register: 1,
 			Data:     []byte(tunname),
 		},


### PR DESCRIPTION
To match iptables:
https://github.com/tailscale/tailscale/blob/b5dbf155b1b0fbd5947160d8bca4085c6ff039a5/util/linuxfw/iptables_runner.go#L536

Updates #12066