### PR TITLE
util/linuxfw: fix table name in DelStatefulRule

### DIFF
--- a/util/linuxfw/nftables_runner.go
+++ b/util/linuxfw/nftables_runner.go
@@ -1926,7 +1926,7 @@ func (n *nftablesRunner) DelStatefulRule(tunname string) error {
 			return fmt.Errorf("get forward chain: %w", err)
 		}
 		rule, err := findRule(conn, &nftables.Rule{
-			Table: table.Nat,
+			Table: table.Filter,
 			Chain: chain,
 			Exprs: exprs,
 		})


### PR DESCRIPTION
Updates #12061
Follow-up to #12072


Change-Id: I2ba8c4bff14d93816760ff5eaa1a16f17bad13c1