### PR TITLE
types/views: move AsMap to Map from *Map

### DIFF
--- a/types/views/views.go
+++ b/types/views/views.go
@@ -387,8 +387,8 @@ func (m *Map[K, V]) UnmarshalJSON(b []byte) error {
 // AsMap returns a shallow-clone of the underlying map.
 // If V is a pointer type, it is the caller's responsibility to make sure
 // the values are immutable.
-func (m *Map[K, V]) AsMap() map[K]V {
-	if m == nil {
+func (m Map[K, V]) AsMap() map[K]V {
+	if m.ж == nil {
 		return nil
 	}
 	return maps.Clone(m.ж)


### PR DESCRIPTION
This was a typo in 2e19790f611cd15d603eac35bae46cb3c707ef85. It should have been on `Map` and not on `*Map` as otherwise it doesn't allow for chaining like `someView.SomeMap().AsMap()` and requires first assigning it to a variable.

Updates #typo