### PR TITLE
cmd/tailscale: make ssh command work when tailscaled is built with the ts_include_cli tag

### DIFF
--- a/cmd/tailscale/cli/ssh.go
+++ b/cmd/tailscale/cli/ssh.go
@@ -84,10 +84,6 @@ func runSSH(ctx context.Context, args []string) error {
 		// of failing. But for now:
 		return fmt.Errorf("no system 'ssh' command found: %w", err)
 	}
-	tailscaleBin, err := os.Executable()
-	if err != nil {
-		return err
-	}
 	knownHostsFile, err := writeKnownHosts(st)
 	if err != nil {
 		return err
@@ -116,7 +112,9 @@ func runSSH(ctx context.Context, args []string) error {
 
 		argv = append(argv,
 			"-o", fmt.Sprintf("ProxyCommand %q %s nc %%h %%p",
-				tailscaleBin,
+				// os.Executable() would return the real running binary but in case tailscale is built with the ts_include_cli tag,
+				// we need to return the started symlink instead
+				os.Args[0],
 				socketArg,
 			))
 	}


### PR DESCRIPTION
When tailscale is built with the ``ts_include_cli`` tag and the tailscaled binary is symlinked to tailscale (https://tailscale.com/kb/1207/small-tailscale), tailscale ssh fails like:

```console
$ tailscale ssh host -v
...
debug1: Local version string SSH-2.0-OpenSSH_9.7
2024/05/12 22:57:44 tailscaled does not take non-flag arguments: ["nc" "host" "22"]
kex_exchange_identification: Connection closed by remote host
Connection closed by UNKNOWN port 65535
```

Closes #12125