### PR TITLE
kube: allow overriding client api server URL via ENV

### DIFF
--- a/cmd/containerboot/kube.go
+++ b/cmd/containerboot/kube.go
@@ -138,9 +138,9 @@ func initKubeClient(root string) {
 	if err != nil {
 		log.Fatalf("Error creating kube client: %v", err)
 	}
-	if root != "/" {
-		// If we are running in a test, we need to set the URL to the
-		// httptest server.
+	if (root != "/") || os.Getenv("TS_KUBERNETES_READ_API_SERVER_ADDRESS_FROM_ENV") == "true" {
+		// Derive the API server address from the environment variables
+		// Used to set http server in tests, or optionally enabled by flag
 		kc.SetURL(fmt.Sprintf("https://%s:%s", os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT_HTTPS")))
 	}
 }

--- a/ipn/store/kubestore/store_kube.go
+++ b/ipn/store/kubestore/store_kube.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"time"
 
@@ -29,6 +30,10 @@ func New(_ logger.Logf, secretName string) (*Store, error) {
 	c, err := kube.New()
 	if err != nil {
 		return nil, err
+	}
+	if os.Getenv("TS_KUBERNETES_READ_API_SERVER_ADDRESS_FROM_ENV") == "true" {
+		// Derive the API server address from the environment variables
+		c.SetURL(fmt.Sprintf("https://%s:%s", os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT_HTTPS")))
 	}
 	canPatch, _, err := c.CheckSecretPermissions(context.Background(), secretName)
 	if err != nil {


### PR DESCRIPTION
In our environment, the endpoint for `kubernetes.default.svc` is in the RFC6598 address range. This conflicts with the range Tailscale uses for node address assignment; additionally, the proxy pod drops traffic to addresses in this range that are not from the `tailscale` interface:

`iifname != "tailscale0*" ip saddr 100.64.0.0/10 counter packets 0 bytes 0 drop`

Previously we worked around this by setting `--netfilter-mode=off` but as of #11238 this has become more challenging. 

I would like to instead override the address `containerboot` uses to talk to the kubernetes api server and point it to something not in the RFC6598 range. Having tested this locally it does appear to resolve my issue (where `containerboot` cannot `POST` to `kubernetes.default.svc`) 

Closes #11397