### PR TITLE
drive: don't allow LOCK and UNLOCK methods

### DIFF
--- a/drive/driveimpl/compositedav/compositedav.go
+++ b/drive/driveimpl/compositedav/compositedav.go
@@ -93,7 +93,11 @@ var cacheInvalidatingMethods = map[string]bool{
 
 // ServeHTTP implements http.Handler.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if r.Method == "PROPFIND" {
+	switch r.Method {
+	case "LOCK", "UNLOCK":
+		http.Error(w, "locking is not currently supported", http.StatusMethodNotAllowed)
+		return
+	case "PROPFIND":
 		h.handlePROPFIND(w, r)
 		return
 	}


### PR DESCRIPTION
Temporarily disables support for locking until we reimplement it properly.

Updates #12097

Support for locking is optional per the WebDAV RFC, which suggests that clients should ["try for the best"](http://www.webdav.org/specs/rfc4918.html#rfc.section.6.7). The problem right now is that Taildrive responds with success to `LOCK` requests, leading clients to believe that locking is supported. Returning status 405 should tell them that locking isn't supported.

Longer term, of course it would be nice to support locking, but for now, at least we shouldn't mislead clients.