### PR TITLE
Net/DNS/Publicdns: update the IPv6 range that we use to recreate route endpoint for control D

### DIFF
--- a/net/dns/publicdns/publicdns.go
+++ b/net/dns/publicdns/publicdns.go
@@ -125,8 +125,8 @@ func DoHIPsOfBase(dohBase string) []netip.Addr {
 		return []netip.Addr{
 			controlDv4One,
 			controlDv4Two,
-			controlDv6Gen(nextDNSv6RangeA.Addr(), pathStr),
-			controlDv6Gen(nextDNSv6RangeB.Addr(), pathStr),
+			controlDv6Gen(controlDv6RangeA.Addr(), pathStr),
+			controlDv6Gen(controlDv6RangeB.Addr(), pathStr),
 		}
 	}
 	return nil

--- a/net/dns/publicdns/publicdns_test.go
+++ b/net/dns/publicdns/publicdns_test.go
@@ -121,8 +121,8 @@ func TestDoHIPsOfBase(t *testing.T) {
 			want: ips(
 				"76.76.2.22",
 				"76.76.10.22",
-				"2a07:a8c0:0:6:7b5b:5949:35ad:0",
-				"2a07:a8c1:0:6:7b5b:5949:35ad:0",
+				"2606:1a40:0:6:7b5b:5949:35ad:0",
+				"2606:1a40:1:6:7b5b:5949:35ad:0",
 			),
 		},
 		{
@@ -130,8 +130,8 @@ func TestDoHIPsOfBase(t *testing.T) {
 			want: ips(
 				"76.76.2.22",
 				"76.76.10.22",
-				"2a07:a8c0:0:ffff:ffff:ffff:ffff:0",
-				"2a07:a8c1:0:ffff:ffff:ffff:ffff:0",
+				"2606:1a40:0:ffff:ffff:ffff:ffff:0",
+				"2606:1a40:1:ffff:ffff:ffff:ffff:0",
 			),
 		},
 	}


### PR DESCRIPTION
In this commit I updated the Ipv6 range we use to generate Control D DOH ip, we were using the NextDNSRanges to generate Control D DOH ip, updated to use the correct range.

Solves: #12144
Updates: #7946 