### PR TITLE
version: add GitCommitTime to Meta

### DIFF
--- a/version/prop.go
+++ b/version/prop.go
@@ -230,6 +230,9 @@ type Meta struct {
 	// daemon, if requested.
 	DaemonLong string `json:"daemonLong,omitempty"`
 
+	// GitCommitTime is the commit time of the git commit in GitCommit.
+	GitCommitTime string `json:"gitCommitTime,omitempty"`
+
 	// Cap is the current Tailscale capability version. It's a monotonically
 	// incrementing integer that's incremented whenever a new capability is
 	// added.
@@ -245,6 +248,7 @@ func GetMeta() Meta {
 			MajorMinorPatch: majorMinorPatch(),
 			Short:           Short(),
 			Long:            Long(),
+			GitCommitTime:   getEmbeddedInfo().commitTime,
 			GitCommit:       gitCommit(),
 			GitDirty:        gitDirty(),
 			ExtraGitCommit:  extraGitCommitStamp,

--- a/version/version.go
+++ b/version/version.go
@@ -105,6 +105,7 @@ type embeddedInfo struct {
 	valid      bool
 	commit     string
 	commitDate string
+	commitTime string
 	dirty      bool
 }
 
@@ -126,6 +127,7 @@ var getEmbeddedInfo = lazy.SyncFunc(func() embeddedInfo {
 		case "vcs.revision":
 			ret.commit = s.Value
 		case "vcs.time":
+			ret.commitTime = s.Value
 			if len(s.Value) >= len("yyyy-mm-dd") {
 				ret.commitDate = s.Value[:len("yyyy-mm-dd")]
 				ret.commitDate = strings.ReplaceAll(ret.commitDate, "-", "")


### PR DESCRIPTION
Reverts the previous change that didn't add CommitTime and only added CommitDate in a new exported function. Instead of exporting that, add a new field to Meta instead.