### PR TITLE
tool/gocross: treat empty GOOS/GOARCH as native GOOS/GOARCH

### DIFF
--- a/tool/gocross/autoflags.go
+++ b/tool/gocross/autoflags.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"cmp"
 	"fmt"
 	"runtime"
 	"strings"
@@ -32,8 +33,8 @@ func autoflagsForTest(argv []string, env *Environment, goroot, nativeGOOS, nativ
 		subcommand = ""
 
 		cc          = "cc"
-		targetOS    = env.Get("GOOS", nativeGOOS)
-		targetArch  = env.Get("GOARCH", nativeGOARCH)
+		targetOS    = cmp.Or(env.Get("GOOS", ""), nativeGOOS)
+		targetArch  = cmp.Or(env.Get("GOARCH", ""), nativeGOARCH)
 		buildFlags  = []string{"-trimpath"}
 		cgoCflags   = []string{"-O3", "-std=gnu11"}
 		cgoLdflags  []string

--- a/tool/gocross/autoflags_test.go
+++ b/tool/gocross/autoflags_test.go
@@ -285,6 +285,64 @@ TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			},
 		},
 		{
+			name: "darwin_arm64_to_darwin_arm64_empty_goos",
+			argv: []string{"gocross", "build", "./cmd/tailcontrol"},
+			env: map[string]string{
+				"GOOS": "",
+			},
+			goroot:       "/goroot",
+			nativeGOOS:   "darwin",
+			nativeGOARCH: "arm64",
+
+			envDiff: `CC=cc (was <nil>)
+CGO_CFLAGS=-O3 -std=gnu11 (was <nil>)
+CGO_ENABLED=1 (was <nil>)
+CGO_LDFLAGS= (was <nil>)
+GOARCH=arm64 (was <nil>)
+GOARM=5 (was <nil>)
+GOMIPS=softfloat (was <nil>)
+GOOS=darwin (was )
+GOROOT=/goroot (was <nil>)
+GOTOOLCHAIN=local (was <nil>)
+TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
+			wantArgv: []string{
+				"gocross", "build",
+				"-trimpath",
+				"-tags=tailscale_go,omitidna,omitpemdecrypt",
+				"-ldflags", "-X tailscale.com/version.longStamp=1.2.3-long -X tailscale.com/version.shortStamp=1.2.3 -X tailscale.com/version.gitCommitStamp=abcd -X tailscale.com/version.extraGitCommitStamp=defg",
+				"./cmd/tailcontrol",
+			},
+		},
+		{
+			name: "darwin_arm64_to_darwin_arm64_empty_goarch",
+			argv: []string{"gocross", "build", "./cmd/tailcontrol"},
+			env: map[string]string{
+				"GOARCH": "",
+			},
+			goroot:       "/goroot",
+			nativeGOOS:   "darwin",
+			nativeGOARCH: "arm64",
+
+			envDiff: `CC=cc (was <nil>)
+CGO_CFLAGS=-O3 -std=gnu11 (was <nil>)
+CGO_ENABLED=1 (was <nil>)
+CGO_LDFLAGS= (was <nil>)
+GOARCH=arm64 (was )
+GOARM=5 (was <nil>)
+GOMIPS=softfloat (was <nil>)
+GOOS=darwin (was <nil>)
+GOROOT=/goroot (was <nil>)
+GOTOOLCHAIN=local (was <nil>)
+TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
+			wantArgv: []string{
+				"gocross", "build",
+				"-trimpath",
+				"-tags=tailscale_go,omitidna,omitpemdecrypt",
+				"-ldflags", "-X tailscale.com/version.longStamp=1.2.3-long -X tailscale.com/version.shortStamp=1.2.3 -X tailscale.com/version.gitCommitStamp=abcd -X tailscale.com/version.extraGitCommitStamp=defg",
+				"./cmd/tailcontrol",
+			},
+		},
+		{
 			name: "darwin_arm64_to_darwin_amd64",
 			env: map[string]string{
 				"GOARCH": "amd64",


### PR DESCRIPTION
Tracking down the side effect can otherwise be a pain, for example on Darwin an empty GOOS resulted in CGO being implicitly disabled. The user intended for `export GOOS=` to act like unset, and while this is a misunderstanding, the main toolchain would treat it this way.

Fixes tailscale/corp#20059