### PR TITLE
cmd/containerboot: Add support for SSM parameters in docker

### DIFF
--- a/cmd/containerboot/main.go
+++ b/cmd/containerboot/main.go
@@ -142,6 +142,7 @@ func main() {
 		InKubernetes:                          os.Getenv("KUBERNETES_SERVICE_HOST") != "",
 		UserspaceMode:                         defaultBool("TS_USERSPACE", true),
 		StateDir:                              defaultEnv("TS_STATE_DIR", ""),
+		SsmArn:                                defaultEnv("TS_SSM_ARN", ""),
 		AcceptDNS:                             defaultEnvBoolPointer("TS_ACCEPT_DNS"),
 		KubeSecret:                            defaultEnv("TS_KUBE_SECRET", "tailscale"),
 		SOCKSProxyAddr:                        defaultEnv("TS_SOCKS5_SERVER", ""),
@@ -707,6 +708,12 @@ func tailscaledArgs(cfg *settings) []string {
 			cfg.StateDir = "/tmp"
 		}
 		fallthrough
+	case cfg.SsmArn != "":
+		args = append(args, "--state="+cfg.SsmArn)
+		if cfg.StateDir == "" {
+			cfg.StateDir = "/tmp"
+		}
+		fallthrough
 	case cfg.StateDir != "":
 		args = append(args, "--statedir="+cfg.StateDir)
 	default:
@@ -1089,6 +1096,7 @@ type settings struct {
 	StateDir                 string
 	AcceptDNS                *bool
 	KubeSecret               string
+	SsmArn                   string
 	SOCKSProxyAddr           string
 	HTTPProxyAddr            string
 	Socket                   string

--- a/cmd/containerboot/main_test.go
+++ b/cmd/containerboot/main_test.go
@@ -652,6 +652,21 @@ func TestContainerBoot(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "aws ssm parameter",
+			Env: map[string]string{
+				"TS_SSM_ARN": "arn:aws:ssm:us-west-2:123456789012:parameter/my-param",
+			},
+			Phases: []phase{
+				{
+					WantCmds: []string{
+						"/usr/bin/tailscaled --socket=/tmp/tailscaled.sock --state=arn:aws:ssm:us-west-2:123456789012:parameter/my-param --statedir=/tmp --tun=userspace-networking",
+					},
+				}, {
+					Notify: runningNotify,
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Updates#12180

This allows setting an SSM parameter for containerboot. Fixed #12180 