### PR TITLE
cmd/serve: don't convert localhost to 127.0.0.1

### DIFF
--- a/cmd/tailscale/cli/serve_v2_test.go
+++ b/cmd/tailscale/cli/serve_v2_test.go
@@ -74,7 +74,7 @@ func TestServeDevConfigMutations(t *testing.T) {
 					TCP: map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}},
 					Web: map[ipn.HostPort]*ipn.WebServerConfig{
 						"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
-							"/": {Proxy: "http://127.0.0.1:3000"},
+							"/": {Proxy: "http://localhost:3000"},
 						}},
 					},
 					AllowFunnel: map[ipn.HostPort]bool{"foo.test.ts.net:443": true},
@@ -89,7 +89,7 @@ func TestServeDevConfigMutations(t *testing.T) {
 					TCP: map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}},
 					Web: map[ipn.HostPort]*ipn.WebServerConfig{
 						"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
-							"/": {Proxy: "http://127.0.0.1:3000"},
+							"/": {Proxy: "http://localhost:3000"},
 						}},
 					},
 				},
@@ -103,7 +103,7 @@ func TestServeDevConfigMutations(t *testing.T) {
 					TCP: map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}},
 					Web: map[ipn.HostPort]*ipn.WebServerConfig{
 						"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
-							"/": {Proxy: "http://127.0.0.1:3000"},
+							"/": {Proxy: "http://localhost:3000"},
 						}},
 					},
 				},
@@ -117,7 +117,7 @@ func TestServeDevConfigMutations(t *testing.T) {
 					TCP: map[uint16]*ipn.TCPPortHandler{80: {HTTP: true}},
 					Web: map[ipn.HostPort]*ipn.WebServerConfig{
 						"foo.test.ts.net:80": {Handlers: map[string]*ipn.HTTPHandler{
-							"/": {Proxy: "http://127.0.0.1:3000"},
+							"/": {Proxy: "http://localhost:3000"},
 						}},
 					},
 				},
@@ -131,7 +131,7 @@ func TestServeDevConfigMutations(t *testing.T) {
 					TCP: map[uint16]*ipn.TCPPortHandler{8443: {HTTPS: true}},
 					Web: map[ipn.HostPort]*ipn.WebServerConfig{
 						"foo.test.ts.net:8443": {Handlers: map[string]*ipn.HTTPHandler{
-							"/": {Proxy: "http://127.0.0.1:3000"},
+							"/": {Proxy: "http://localhost:3000"},
 						}},
 					},
 				},
@@ -146,7 +146,7 @@ func TestServeDevConfigMutations(t *testing.T) {
 						TCP: map[uint16]*ipn.TCPPortHandler{80: {HTTP: true}},
 						Web: map[ipn.HostPort]*ipn.WebServerConfig{
 							"foo.test.ts.net:80": {Handlers: map[string]*ipn.HTTPHandler{
-								"/": {Proxy: "http://127.0.0.1:3000"},
+								"/": {Proxy: "http://localhost:3000"},
 							}},
 						},
 					},
@@ -157,10 +157,10 @@ func TestServeDevConfigMutations(t *testing.T) {
 						TCP: map[uint16]*ipn.TCPPortHandler{80: {HTTP: true}, 9999: {HTTP: true}},
 						Web: map[ipn.HostPort]*ipn.WebServerConfig{
 							"foo.test.ts.net:80": {Handlers: map[string]*ipn.HTTPHandler{
-								"/": {Proxy: "http://127.0.0.1:3000"},
+								"/": {Proxy: "http://localhost:3000"},
 							}},
 							"foo.test.ts.net:9999": {Handlers: map[string]*ipn.HTTPHandler{
-								"/abc": {Proxy: "http://127.0.0.1:3001"},
+								"/abc": {Proxy: "http://localhost:3001"},
 							}},
 						},
 					},
@@ -171,7 +171,7 @@ func TestServeDevConfigMutations(t *testing.T) {
 						TCP: map[uint16]*ipn.TCPPortHandler{80: {HTTP: true}},
 						Web: map[ipn.HostPort]*ipn.WebServerConfig{
 							"foo.test.ts.net:80": {Handlers: map[string]*ipn.HTTPHandler{
-								"/": {Proxy: "http://127.0.0.1:3000"},
+								"/": {Proxy: "http://localhost:3000"},
 							}},
 						},
 					},
@@ -182,7 +182,7 @@ func TestServeDevConfigMutations(t *testing.T) {
 						TCP: map[uint16]*ipn.TCPPortHandler{80: {HTTP: true}, 8080: {HTTP: true}},
 						Web: map[ipn.HostPort]*ipn.WebServerConfig{
 							"foo.test.ts.net:80": {Handlers: map[string]*ipn.HTTPHandler{
-								"/": {Proxy: "http://127.0.0.1:3000"},
+								"/": {Proxy: "http://localhost:3000"},
 							}},
 							"foo.test.ts.net:8080": {Handlers: map[string]*ipn.HTTPHandler{
 								"/abc": {Proxy: "http://127.0.0.1:3001"},
@@ -236,7 +236,7 @@ func TestServeDevConfigMutations(t *testing.T) {
 						TCP: map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}},
 						Web: map[ipn.HostPort]*ipn.WebServerConfig{
 							"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
-								"/": {Proxy: "http://127.0.0.1:3000"},
+								"/": {Proxy: "http://localhost:3000"},
 							}},
 						},
 					},
@@ -247,10 +247,10 @@ func TestServeDevConfigMutations(t *testing.T) {
 						TCP: map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}, 9999: {HTTPS: true}},
 						Web: map[ipn.HostPort]*ipn.WebServerConfig{
 							"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
-								"/": {Proxy: "http://127.0.0.1:3000"},
+								"/": {Proxy: "http://localhost:3000"},
 							}},
 							"foo.test.ts.net:9999": {Handlers: map[string]*ipn.HTTPHandler{
-								"/abc": {Proxy: "http://127.0.0.1:3001"},
+								"/abc": {Proxy: "http://localhost:3001"},
 							}},
 						},
 					},
@@ -261,7 +261,7 @@ func TestServeDevConfigMutations(t *testing.T) {
 						TCP: map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}},
 						Web: map[ipn.HostPort]*ipn.WebServerConfig{
 							"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
-								"/": {Proxy: "http://127.0.0.1:3000"},
+								"/": {Proxy: "http://localhost:3000"},
 							}},
 						},
 					},
@@ -272,7 +272,7 @@ func TestServeDevConfigMutations(t *testing.T) {
 						TCP: map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}, 8443: {HTTPS: true}},
 						Web: map[ipn.HostPort]*ipn.WebServerConfig{
 							"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
-								"/": {Proxy: "http://127.0.0.1:3000"},
+								"/": {Proxy: "http://localhost:3000"},
 							}},
 							"foo.test.ts.net:8443": {Handlers: map[string]*ipn.HTTPHandler{
 								"/abc": {Proxy: "http://127.0.0.1:3001"},
@@ -361,7 +361,7 @@ func TestServeDevConfigMutations(t *testing.T) {
 						TCP: map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}},
 						Web: map[ipn.HostPort]*ipn.WebServerConfig{
 							"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
-								"/foo": {Proxy: "http://127.0.0.1:3000"},
+								"/foo": {Proxy: "http://localhost:3000"},
 							}},
 						},
 					},
@@ -372,10 +372,10 @@ func TestServeDevConfigMutations(t *testing.T) {
 						TCP: map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}, 8443: {HTTPS: true}},
 						Web: map[ipn.HostPort]*ipn.WebServerConfig{
 							"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
-								"/foo": {Proxy: "http://127.0.0.1:3000"},
+								"/foo": {Proxy: "http://localhost:3000"},
 							}},
 							"foo.test.ts.net:8443": {Handlers: map[string]*ipn.HTTPHandler{
-								"/foo": {Proxy: "http://127.0.0.1:3000"},
+								"/foo": {Proxy: "http://localhost:3000"},
 							}},
 						},
 					},
@@ -439,7 +439,7 @@ func TestServeDevConfigMutations(t *testing.T) {
 					want: &ipn.ServeConfig{
 						TCP: map[uint16]*ipn.TCPPortHandler{
 							443: {
-								TCPForward:   "127.0.0.1:5432",
+								TCPForward:   "localhost:5432",
 								TerminateTLS: "foo.test.ts.net",
 							},
 						},
@@ -466,7 +466,7 @@ func TestServeDevConfigMutations(t *testing.T) {
 					want: &ipn.ServeConfig{
 						TCP: map[uint16]*ipn.TCPPortHandler{
 							443: {
-								TCPForward:   "127.0.0.1:123",
+								TCPForward:   "localhost:123",
 								TerminateTLS: "foo.test.ts.net",
 							},
 						},
@@ -560,7 +560,7 @@ func TestServeDevConfigMutations(t *testing.T) {
 						TCP: map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}},
 						Web: map[ipn.HostPort]*ipn.WebServerConfig{
 							"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
-								"/": {Proxy: "http://127.0.0.1:3000"},
+								"/": {Proxy: "http://localhost:3000"},
 							}},
 						},
 					},
@@ -572,7 +572,7 @@ func TestServeDevConfigMutations(t *testing.T) {
 						TCP:         map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}},
 						Web: map[ipn.HostPort]*ipn.WebServerConfig{
 							"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
-								"/": {Proxy: "http://127.0.0.1:3000"},
+								"/": {Proxy: "http://localhost:3000"},
 							}},
 						},
 					},
@@ -584,10 +584,10 @@ func TestServeDevConfigMutations(t *testing.T) {
 						TCP:         map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}, 8443: {HTTPS: true}},
 						Web: map[ipn.HostPort]*ipn.WebServerConfig{
 							"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
-								"/": {Proxy: "http://127.0.0.1:3000"},
+								"/": {Proxy: "http://localhost:3000"},
 							}},
 							"foo.test.ts.net:8443": {Handlers: map[string]*ipn.HTTPHandler{
-								"/bar": {Proxy: "http://127.0.0.1:3001"},
+								"/bar": {Proxy: "http://localhost:3001"},
 							}},
 						},
 					},
@@ -599,10 +599,10 @@ func TestServeDevConfigMutations(t *testing.T) {
 						TCP:         map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}, 8443: {HTTPS: true}},
 						Web: map[ipn.HostPort]*ipn.WebServerConfig{
 							"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
-								"/": {Proxy: "http://127.0.0.1:3000"},
+								"/": {Proxy: "http://localhost:3000"},
 							}},
 							"foo.test.ts.net:8443": {Handlers: map[string]*ipn.HTTPHandler{
-								"/bar": {Proxy: "http://127.0.0.1:3001"},
+								"/bar": {Proxy: "http://localhost:3001"},
 							}},
 						},
 					},
@@ -614,10 +614,10 @@ func TestServeDevConfigMutations(t *testing.T) {
 						TCP:         map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}, 8443: {HTTPS: true}},
 						Web: map[ipn.HostPort]*ipn.WebServerConfig{
 							"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
-								"/": {Proxy: "http://127.0.0.1:3000"},
+								"/": {Proxy: "http://localhost:3000"},
 							}},
 							"foo.test.ts.net:8443": {Handlers: map[string]*ipn.HTTPHandler{
-								"/bar": {Proxy: "http://127.0.0.1:3001"},
+								"/bar": {Proxy: "http://localhost:3001"},
 							}},
 						},
 					},
@@ -628,7 +628,7 @@ func TestServeDevConfigMutations(t *testing.T) {
 						TCP: map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}},
 						Web: map[ipn.HostPort]*ipn.WebServerConfig{
 							"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
-								"/": {Proxy: "http://127.0.0.1:3000"},
+								"/": {Proxy: "http://localhost:3000"},
 							}},
 						},
 					},
@@ -636,10 +636,10 @@ func TestServeDevConfigMutations(t *testing.T) {
 				{ // start a tcp forwarder on 8443
 					command: cmd("serve --bg --tcp=8443 tcp://localhost:5432"),
 					want: &ipn.ServeConfig{
-						TCP: map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}, 8443: {TCPForward: "127.0.0.1:5432"}},
+						TCP: map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}, 8443: {TCPForward: "localhost:5432"}},
 						Web: map[ipn.HostPort]*ipn.WebServerConfig{
 							"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
-								"/": {Proxy: "http://127.0.0.1:3000"},
+								"/": {Proxy: "http://localhost:3000"},
 							}},
 						},
 					},
@@ -647,7 +647,7 @@ func TestServeDevConfigMutations(t *testing.T) {
 				{ // remove primary port http handler
 					command: cmd("serve off"),
 					want: &ipn.ServeConfig{
-						TCP: map[uint16]*ipn.TCPPortHandler{8443: {TCPForward: "127.0.0.1:5432"}},
+						TCP: map[uint16]*ipn.TCPPortHandler{8443: {TCPForward: "localhost:5432"}},
 					},
 				},
 				{ // remove tcp forwarder
@@ -717,7 +717,7 @@ func TestServeDevConfigMutations(t *testing.T) {
 					want: &ipn.ServeConfig{
 						TCP: map[uint16]*ipn.TCPPortHandler{
 							443: {
-								TCPForward:   "127.0.0.1:5432",
+								TCPForward:   "localhost:5432",
 								TerminateTLS: "foo.test.ts.net",
 							},
 						},
@@ -738,7 +738,7 @@ func TestServeDevConfigMutations(t *testing.T) {
 						TCP: map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}},
 						Web: map[ipn.HostPort]*ipn.WebServerConfig{
 							"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
-								"/": {Proxy: "http://127.0.0.1:3000"},
+								"/": {Proxy: "http://localhost:3000"},
 							}},
 						},
 					},
@@ -758,7 +758,7 @@ func TestServeDevConfigMutations(t *testing.T) {
 						TCP: map[uint16]*ipn.TCPPortHandler{4545: {HTTPS: true}},
 						Web: map[ipn.HostPort]*ipn.WebServerConfig{
 							"foo.test.ts.net:4545": {Handlers: map[string]*ipn.HTTPHandler{
-								"/foo": {Proxy: "http://127.0.0.1:3000"},
+								"/foo": {Proxy: "http://localhost:3000"},
 							}},
 						},
 					},
@@ -769,8 +769,8 @@ func TestServeDevConfigMutations(t *testing.T) {
 						TCP: map[uint16]*ipn.TCPPortHandler{4545: {HTTPS: true}},
 						Web: map[ipn.HostPort]*ipn.WebServerConfig{
 							"foo.test.ts.net:4545": {Handlers: map[string]*ipn.HTTPHandler{
-								"/foo": {Proxy: "http://127.0.0.1:3000"},
-								"/bar": {Proxy: "http://127.0.0.1:3000"},
+								"/foo": {Proxy: "http://localhost:3000"},
+								"/bar": {Proxy: "http://localhost:3000"},
 							}},
 						},
 					},
@@ -800,7 +800,7 @@ func TestServeDevConfigMutations(t *testing.T) {
 						TCP: map[uint16]*ipn.TCPPortHandler{3000: {HTTP: true}},
 						Web: map[ipn.HostPort]*ipn.WebServerConfig{
 							"foo.test.ts.net:3000": {Handlers: map[string]*ipn.HTTPHandler{
-								"/": {Proxy: "http://127.0.0.1:3000"},
+								"/": {Proxy: "http://localhost:3000"},
 							}},
 						},
 					},

--- a/ipn/serve.go
+++ b/ipn/serve.go
@@ -538,7 +538,7 @@ func ExpandProxyTargetValue(target string, supportedSchemes []string, defaultSch
 		return "", fmt.Errorf("invalid port %q", u.Port())
 	}
 
-	u.Host = fmt.Sprintf("%s:%d", host, port)
+	u.Host = fmt.Sprintf("%s:%d", u.Hostname(), port)
 
 	return u.String(), nil
 }

--- a/ipn/serve_test.go
+++ b/ipn/serve_test.go
@@ -137,14 +137,13 @@ func TestExpandProxyTargetDev(t *testing.T) {
 		wantErr          bool
 	}{
 		{name: "port-only", input: "8080", expected: "http://127.0.0.1:8080"},
-		{name: "hostname+port", input: "localhost:8080", expected: "http://127.0.0.1:8080"},
-		{name: "convert-localhost", input: "http://localhost:8080", expected: "http://127.0.0.1:8080"},
+		{name: "hostname+port", input: "localhost:8080", expected: "http://localhost:8080"},
 		{name: "no-change", input: "http://127.0.0.1:8080", expected: "http://127.0.0.1:8080"},
 		{name: "include-path", input: "http://127.0.0.1:8080/foo", expected: "http://127.0.0.1:8080/foo"},
-		{name: "https-scheme", input: "https://localhost:8080", expected: "https://127.0.0.1:8080"},
-		{name: "https+insecure-scheme", input: "https+insecure://localhost:8080", expected: "https+insecure://127.0.0.1:8080"},
-		{name: "change-default-scheme", input: "localhost:8080", defaultScheme: "https", expected: "https://127.0.0.1:8080"},
-		{name: "change-supported-schemes", input: "localhost:8080", defaultScheme: "tcp", supportedSchemes: []string{"tcp"}, expected: "tcp://127.0.0.1:8080"},
+		{name: "https-scheme", input: "https://localhost:8080", expected: "https://localhost:8080"},
+		{name: "https+insecure-scheme", input: "https+insecure://localhost:8080", expected: "https+insecure://localhost:8080"},
+		{name: "change-default-scheme", input: "localhost:8080", defaultScheme: "https", expected: "https://localhost:8080"},
+		{name: "change-supported-schemes", input: "localhost:8080", defaultScheme: "tcp", supportedSchemes: []string{"tcp"}, expected: "tcp://localhost:8080"},
 
 		// errors
 		{name: "invalid-port", input: "localhost:9999999", wantErr: true},


### PR DESCRIPTION
This is not valid in many situations, specifically when running a local astro site that listens on localhost, but ignores 127.0.0.1

Fixes: https://github.com/tailscale/tailscale/issues/12201