### PR TITLE
tool/gocross: add debug data to CGO builds

### DIFF
--- a/tool/gocross/autoflags.go
+++ b/tool/gocross/autoflags.go
@@ -36,7 +36,7 @@ func autoflagsForTest(argv []string, env *Environment, goroot, nativeGOOS, nativ
 		targetOS    = cmp.Or(env.Get("GOOS", ""), nativeGOOS)
 		targetArch  = cmp.Or(env.Get("GOARCH", ""), nativeGOARCH)
 		buildFlags  = []string{"-trimpath"}
-		cgoCflags   = []string{"-O3", "-std=gnu11"}
+		cgoCflags   = []string{"-O3", "-std=gnu11", "-g"}
 		cgoLdflags  []string
 		ldflags     []string
 		tags        = []string{"tailscale_go"}

--- a/tool/gocross/autoflags_test.go
+++ b/tool/gocross/autoflags_test.go
@@ -41,7 +41,7 @@ func TestAutoflags(t *testing.T) {
 			nativeGOARCH: "amd64",
 
 			envDiff: `CC=cc (was <nil>)
-CGO_CFLAGS=-O3 -std=gnu11 (was <nil>)
+CGO_CFLAGS=-O3 -std=gnu11 -g (was <nil>)
 CGO_ENABLED=1 (was <nil>)
 CGO_LDFLAGS= (was <nil>)
 GOARCH=amd64 (was <nil>)
@@ -67,7 +67,7 @@ TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			nativeGOARCH: "amd64",
 
 			envDiff: `CC=cc (was <nil>)
-CGO_CFLAGS=-O3 -std=gnu11 (was <nil>)
+CGO_CFLAGS=-O3 -std=gnu11 -g (was <nil>)
 CGO_ENABLED=1 (was <nil>)
 CGO_LDFLAGS= (was <nil>)
 GOARCH=amd64 (was <nil>)
@@ -96,7 +96,7 @@ TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			nativeGOARCH: "amd64",
 
 			envDiff: `CC=cc (was <nil>)
-CGO_CFLAGS=-O3 -std=gnu11 (was <nil>)
+CGO_CFLAGS=-O3 -std=gnu11 -g (was <nil>)
 CGO_ENABLED=0 (was <nil>)
 CGO_LDFLAGS= (was <nil>)
 GOARCH=riscv64 (was riscv64)
@@ -125,7 +125,7 @@ TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			nativeGOARCH: "amd64",
 
 			envDiff: `CC=cc (was <nil>)
-CGO_CFLAGS=-O3 -std=gnu11 (was <nil>)
+CGO_CFLAGS=-O3 -std=gnu11 -g (was <nil>)
 CGO_ENABLED=0 (was <nil>)
 CGO_LDFLAGS= (was <nil>)
 GOARCH=amd64 (was <nil>)
@@ -151,7 +151,7 @@ TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			nativeGOARCH: "amd64",
 
 			envDiff: `CC=cc (was <nil>)
-CGO_CFLAGS=-O3 -std=gnu11 (was <nil>)
+CGO_CFLAGS=-O3 -std=gnu11 -g (was <nil>)
 CGO_ENABLED=1 (was <nil>)
 CGO_LDFLAGS= (was <nil>)
 GOARCH=amd64 (was <nil>)
@@ -181,7 +181,7 @@ TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			nativeGOARCH: "amd64",
 
 			envDiff: `CC=cc (was <nil>)
-CGO_CFLAGS=-O3 -std=gnu11 (was <nil>)
+CGO_CFLAGS=-O3 -std=gnu11 -g (was <nil>)
 CGO_ENABLED=0 (was <nil>)
 CGO_LDFLAGS= (was <nil>)
 GOARCH=amd64 (was <nil>)
@@ -210,7 +210,7 @@ TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			nativeGOARCH: "amd64",
 
 			envDiff: `CC=cc (was <nil>)
-CGO_CFLAGS=-O3 -std=gnu11 (was <nil>)
+CGO_CFLAGS=-O3 -std=gnu11 -g (was <nil>)
 CGO_ENABLED=0 (was <nil>)
 CGO_LDFLAGS= (was <nil>)
 GOARCH=amd64 (was <nil>)
@@ -240,7 +240,7 @@ TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			nativeGOARCH: "amd64",
 
 			envDiff: `CC=cc (was <nil>)
-CGO_CFLAGS=-O3 -std=gnu11 (was <nil>)
+CGO_CFLAGS=-O3 -std=gnu11 -g (was <nil>)
 CGO_ENABLED=1 (was 1)
 CGO_LDFLAGS= (was <nil>)
 GOARCH=amd64 (was <nil>)
@@ -266,7 +266,7 @@ TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			nativeGOARCH: "arm64",
 
 			envDiff: `CC=cc (was <nil>)
-CGO_CFLAGS=-O3 -std=gnu11 (was <nil>)
+CGO_CFLAGS=-O3 -std=gnu11 -g (was <nil>)
 CGO_ENABLED=1 (was <nil>)
 CGO_LDFLAGS= (was <nil>)
 GOARCH=arm64 (was <nil>)
@@ -295,7 +295,7 @@ TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			nativeGOARCH: "arm64",
 
 			envDiff: `CC=cc (was <nil>)
-CGO_CFLAGS=-O3 -std=gnu11 (was <nil>)
+CGO_CFLAGS=-O3 -std=gnu11 -g (was <nil>)
 CGO_ENABLED=1 (was <nil>)
 CGO_LDFLAGS= (was <nil>)
 GOARCH=arm64 (was <nil>)
@@ -324,7 +324,7 @@ TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			nativeGOARCH: "arm64",
 
 			envDiff: `CC=cc (was <nil>)
-CGO_CFLAGS=-O3 -std=gnu11 (was <nil>)
+CGO_CFLAGS=-O3 -std=gnu11 -g (was <nil>)
 CGO_ENABLED=1 (was <nil>)
 CGO_LDFLAGS= (was <nil>)
 GOARCH=arm64 (was )
@@ -353,7 +353,7 @@ TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			nativeGOARCH: "arm64",
 
 			envDiff: `CC=cc (was <nil>)
-CGO_CFLAGS=-O3 -std=gnu11 (was <nil>)
+CGO_CFLAGS=-O3 -std=gnu11 -g (was <nil>)
 CGO_ENABLED=1 (was <nil>)
 CGO_LDFLAGS= (was <nil>)
 GOARCH=amd64 (was amd64)
@@ -382,7 +382,7 @@ TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			nativeGOARCH: "arm64",
 
 			envDiff: `CC=cc (was <nil>)
-CGO_CFLAGS=-O3 -std=gnu11 (was <nil>)
+CGO_CFLAGS=-O3 -std=gnu11 -g (was <nil>)
 CGO_ENABLED=1 (was <nil>)
 CGO_LDFLAGS= (was <nil>)
 GOARCH=arm64 (was <nil>)
@@ -415,7 +415,7 @@ TS_LINK_FAIL_REFLECT=1 (was <nil>)`,
 			nativeGOARCH: "arm64",
 
 			envDiff: `CC=cc (was <nil>)
-CGO_CFLAGS=-O3 -std=gnu11 -mmacosx-version-min=11.3 -isysroot /my/sdk/root -arch x86_64 (was <nil>)
+CGO_CFLAGS=-O3 -std=gnu11 -g -mmacosx-version-min=11.3 -isysroot /my/sdk/root -arch x86_64 (was <nil>)
 CGO_ENABLED=1 (was <nil>)
 CGO_LDFLAGS=-mmacosx-version-min=11.3 -isysroot /my/sdk/root -arch x86_64 (was <nil>)
 GOARCH=amd64 (was amd64)
@@ -448,7 +448,7 @@ TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			nativeGOARCH: "amd64",
 
 			envDiff: `CC=cc (was <nil>)
-CGO_CFLAGS=-O3 -std=gnu11 -miphoneos-version-min=15.0 -isysroot /my/sdk/root -arch arm64 (was <nil>)
+CGO_CFLAGS=-O3 -std=gnu11 -g -miphoneos-version-min=15.0 -isysroot /my/sdk/root -arch arm64 (was <nil>)
 CGO_ENABLED=1 (was <nil>)
 CGO_LDFLAGS=-miphoneos-version-min=15.0 -isysroot /my/sdk/root -arch arm64 (was <nil>)
 GOARCH=arm64 (was arm64)
@@ -474,7 +474,7 @@ TS_LINK_FAIL_REFLECT=1 (was <nil>)`,
 			nativeGOARCH: "amd64",
 
 			envDiff: `CC=cc (was <nil>)
-CGO_CFLAGS=-O3 -std=gnu11 (was <nil>)
+CGO_CFLAGS=-O3 -std=gnu11 -g (was <nil>)
 CGO_ENABLED=1 (was <nil>)
 CGO_LDFLAGS= (was <nil>)
 GOARCH=amd64 (was <nil>)
@@ -500,7 +500,7 @@ TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			nativeGOARCH: "amd64",
 
 			envDiff: `CC=cc (was <nil>)
-CGO_CFLAGS=-O3 -std=gnu11 (was <nil>)
+CGO_CFLAGS=-O3 -std=gnu11 -g (was <nil>)
 CGO_ENABLED=1 (was <nil>)
 CGO_LDFLAGS= (was <nil>)
 GOARCH=amd64 (was <nil>)
@@ -529,7 +529,7 @@ TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			nativeGOARCH: "amd64",
 
 			envDiff: `CC=cc (was <nil>)
-CGO_CFLAGS=-O3 -std=gnu11 (was <nil>)
+CGO_CFLAGS=-O3 -std=gnu11 -g (was <nil>)
 CGO_ENABLED=1 (was <nil>)
 CGO_LDFLAGS= (was <nil>)
 GOARCH=amd64 (was <nil>)
@@ -556,7 +556,7 @@ TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			nativeGOARCH: "amd64",
 
 			envDiff: `CC=cc (was <nil>)
-CGO_CFLAGS=-O3 -std=gnu11 (was <nil>)
+CGO_CFLAGS=-O3 -std=gnu11 -g (was <nil>)
 CGO_ENABLED=1 (was <nil>)
 CGO_LDFLAGS= (was <nil>)
 GOARCH=amd64 (was <nil>)
@@ -586,7 +586,7 @@ TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			nativeGOARCH: "amd64",
 
 			envDiff: `CC=cc (was <nil>)
-CGO_CFLAGS=-O3 -std=gnu11 (was <nil>)
+CGO_CFLAGS=-O3 -std=gnu11 -g (was <nil>)
 CGO_ENABLED=1 (was <nil>)
 CGO_LDFLAGS= (was <nil>)
 GOARCH=amd64 (was <nil>)


### PR DESCRIPTION
We don't build a lot of tools with CGO, but we do build some, and it's extremely valuable for production services in particular to have symbols included - for perf and so on.

I tested various other builds that could be affected negatively, in particular macOS/iOS, but those use split-dwarf already as part of their build path, and Android which does not currently use gocross.

One binary which is normally 120mb only grew to 123mb, so the trade-off is definitely worthwhile in context.

Updates tailscale/corp#20296