### PR TITLE
cmd/k8s-operator: update proxy config opts in Helm chart values with a note pointing to ProxyClass CRD

### DIFF
--- a/cmd/k8s-operator/deploy/chart/values.yaml
+++ b/cmd/k8s-operator/deploy/chart/values.yaml
@@ -51,6 +51,10 @@ operatorConfig:
 # proxies created by the operator.
 # https://tailscale.com/kb/1236/kubernetes-operator/#cluster-ingress
 # https://tailscale.com/kb/1236/kubernetes-operator/#cluster-egress
+# Note that this section contains only a few global configuration options and
+# will not be updated with more configuration options in the future.
+# If you need more configuration options, take a look at ProxyClass:
+# https://tailscale.com/kb/1236/kubernetes-operator#cluster-resource-customization-using-proxyclass-custom-resource
 proxyConfig:
   image:
     repo: tailscale/tailscale


### PR DESCRIPTION
Add a note to the proxy config opts in helm chart values file pointing at ProxyClass CRD docs, which has more config opts and is where new configuration knobs will be added in the future.

Updates tailscale/tailscale#12242