### PR TITLE
ipn/ipnlocal: discard node keys that have been rotated out

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -558,7 +558,7 @@ func (c *Direct) doLogin(ctx context.Context, opt loginOpt) (mustRegen bool, new
 
 	var nodeKeySignature tkatype.MarshaledSignature
 	if !oldNodeKey.IsZero() && opt.OldNodeKeySignature != nil {
-		if nodeKeySignature, err = resignNKS(persist.NetworkLockKey, tryingNewKey.Public(), opt.OldNodeKeySignature); err != nil {
+		if nodeKeySignature, err = tka.ResignNKS(persist.NetworkLockKey, tryingNewKey.Public(), opt.OldNodeKeySignature); err != nil {
 			c.logf("Failed re-signing node-key signature: %v", err)
 		}
 	} else if isWrapped {
@@ -727,45 +727,6 @@ func (c *Direct) doLogin(ctx context.Context, opt loginOpt) (mustRegen bool, new
 		return regen, "", nil, ctx.Err()
 	}
 	return false, resp.AuthURL, nil, nil
-}
-
-// resignNKS re-signs a node-key signature for a new node-key.
-//
-// This only matters on network-locked tailnets, because node-key signatures are
-// how other nodes know that a node-key is authentic. When the node-key is
-// rotated then the existing signature becomes invalid, so this function is
-// responsible for generating a new wrapping signature to certify the new node-key.
-//
-// The signature itself is a SigRotation signature, which embeds the old signature
-// and certifies the new node-key as a replacement for the old by signing the new
-// signature with RotationPubkey (which is the node's own network-lock key).
-func resignNKS(priv key.NLPrivate, nodeKey key.NodePublic, oldNKS tkatype.MarshaledSignature) (tkatype.MarshaledSignature, error) {
-	var oldSig tka.NodeKeySignature
-	if err := oldSig.Unserialize(oldNKS); err != nil {
-		return nil, fmt.Errorf("decoding NKS: %w", err)
-	}
-
-	nk, err := nodeKey.MarshalBinary()
-	if err != nil {
-		return nil, fmt.Errorf("marshalling node-key: %w", err)
-	}
-
-	if bytes.Equal(nk, oldSig.Pubkey) {
-		// The old signature is valid for the node-key we are using, so just
-		// use it verbatim.
-		return oldNKS, nil
-	}
-
-	newSig := tka.NodeKeySignature{
-		SigKind: tka.SigRotation,
-		Pubkey:  nk,
-		Nested:  &oldSig,
-	}
-	if newSig.Signature, err = priv.SignNKS(newSig.SigHash()); err != nil {
-		return nil, fmt.Errorf("signing NKS: %w", err)
-	}
-
-	return newSig.Serialize(), nil
 }
 
 // newEndpoints acquires c.mu and sets the local port and endpoints and reports

--- a/tka/tka.go
+++ b/tka/tka.go
@@ -668,25 +668,36 @@ func (a *Authority) Inform(storage Chonk, updates []AUM) error {
 // NodeKeyAuthorized checks if the provided nodeKeySignature authorizes
 // the given node key.
 func (a *Authority) NodeKeyAuthorized(nodeKey key.NodePublic, nodeKeySignature tkatype.MarshaledSignature) error {
+	_, err := a.NodeKeyAuthorizedWithDetails(nodeKey, nodeKeySignature)
+	return err
+}
+
+// NodeKeyAuthorized checks if the provided nodeKeySignature authorizes
+// the given node key, and returns RotationDetails if the signature is
+// a valid rotation signature.
+func (a *Authority) NodeKeyAuthorizedWithDetails(nodeKey key.NodePublic, nodeKeySignature tkatype.MarshaledSignature) (*RotationDetails, error) {
 	var decoded NodeKeySignature
 	if err := decoded.Unserialize(nodeKeySignature); err != nil {
-		return fmt.Errorf("unserialize: %v", err)
+		return nil, fmt.Errorf("unserialize: %v", err)
 	}
 	if decoded.SigKind == SigCredential {
-		return errors.New("credential signatures cannot authorize nodes on their own")
+		return nil, errors.New("credential signatures cannot authorize nodes on their own")
 	}
 
 	kID, err := decoded.authorizingKeyID()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	key, err := a.state.GetKey(kID)
 	if err != nil {
-		return fmt.Errorf("key: %v", err)
+		return nil, fmt.Errorf("key: %v", err)
 	}
 
-	return decoded.verifySignature(nodeKey, key)
+	if err := decoded.verifySignature(nodeKey, key); err != nil {
+		return nil, err
+	}
+	return decoded.rotationDetails()
 }
 
 // KeyTrusted returns true if the given keyID is trusted by the tailnet


### PR DESCRIPTION
A non-signing node can be allowed to re-sign its new node keys following key renewal/rotation (e.g. via `tailscale up --force-reauth`). To be able to do this, node's TLK is written into WrappingPubkey field of the initial SigDirect signature, signed by a signing node.

The intended use of this field implies that, for each WrappingPubkey, we typically expect to have at most one active node with a signature tracing back to that key. Multiple valid signatures referring to the same WrappingPubkey can occur if a client's state has been cloned, but it's something we explicitly discourage and don't support: https://tailscale.com/s/clone

This change propagates rotation details (wrapping public key, a list of previous node keys that have been rotated out) to netmap processing, and adds tracking of obsolete node keys that, when found, will get filtered out.

Updates tailscale/corp#19764