### PR TITLE
docs/k8s: fix subnet router manifest

### DIFF
--- a/docs/k8s/subnet.yaml
+++ b/docs/k8s/subnet.yaml
@@ -29,5 +29,6 @@ spec:
     - name: TS_ROUTES
       value: "{{TS_ROUTES}}"
     securityContext:
-      runAsUser: 1000
-      runAsGroup: 1000
+      capabilities:
+        add:
+        - NET_ADMIN


### PR DESCRIPTION
In https://github.com/tailscale/tailscale/pull/11363 I changed the subnet router manifest to run in tun mode (for performance reasons), but did not
change the security context to give it NET_ADMIN cap, which is required to for the tailscale socket.

I have tested that the updated manifests deploy a functioning subnet router.

Updates tailscale/tailscale#12083