### PR TITLE
ipn/ipnlocal: empty allowed exit nodes syspolicy should be treated as…

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -6456,7 +6456,7 @@ func suggestExitNode(report *netcheck.Report, netMap *netmap.NetworkMap, r *rand
 	var allowedCandidates set.Set[string]
 	if allowed, err := syspolicy.GetStringArray(syspolicy.AllowedSuggestedExitNodes, nil); err != nil {
 		return res, fmt.Errorf("unable to read %s policy: %w", syspolicy.AllowedSuggestedExitNodes, err)
-	} else if allowed != nil {
+	} else if allowed != nil && len(allowed) > 0 {
 		allowedCandidates = set.SetOf(allowed)
 	}
 	candidates := make([]tailcfg.NodeView, 0, len(netMap.Peers))


### PR DESCRIPTION
… allow all

Updates tailscale/corp#19681

If the syspolicy returns an empty list of allowed exit nodes, this should be treated as "allow all" rather than "allow none"