### PR TITLE
net/dns: fix typo in OSConfig logging

### DIFF
--- a/net/dns/osconfig.go
+++ b/net/dns/osconfig.go
@@ -82,7 +82,7 @@ func (o *OSConfig) WriteToBufioWriter(w *bufio.Writer) {
 		fmt.Fprintf(w, "SearchDomains:%v ", o.SearchDomains)
 	}
 	if len(o.MatchDomains) > 0 {
-		w.WriteString("SearchDomains:[")
+		w.WriteString("MatchDomains:[")
 		sp := ""
 		var numARPA int
 		for _, s := range o.MatchDomains {


### PR DESCRIPTION
Updates #cleanup


Change-Id: I48834a0a5944ed35509c63bdd2830aa34e1bddeb