### PR TITLE
tsnet: return an empty interface on error from Listen

### DIFF
--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -916,7 +916,11 @@ func (s *Server) APIClient() (*tailscale.Client, error) {
 // such as those routed inbound via subnet routes, explicitly specify
 // the listening address or use RegisterFallbackTCPHandler.
 func (s *Server) Listen(network, addr string) (net.Listener, error) {
-	return s.listen(network, addr, listenOnTailnet)
+	lst, err := s.listen(network, addr, listenOnTailnet)
+	if err != nil {
+		return nil, err
+	}
+	return lst, nil
 }
 
 // ListenPacket announces on the Tailscale network.


### PR DESCRIPTION
The internal helper returns a nil *listener, which is safe because we only do
so on error -- however it irks static analysis tools like staticcheck.

Updates #12182

Change-Id: If445e71a254263afbea60c7da26f906ffe73cd80
