### PR TITLE
tsnet: return net.Listener from s.listen

### DIFF
--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -1146,7 +1146,7 @@ func resolveListenAddr(network, addr string) (netip.AddrPort, error) {
 	return netip.AddrPortFrom(bindHostOrZero, uint16(port)), nil
 }
 
-func (s *Server) listen(network, addr string, lnOn listenOn) (*listener, error) {
+func (s *Server) listen(network, addr string, lnOn listenOn) (net.Listener, error) {
 	switch network {
 	case "", "tcp", "tcp4", "tcp6", "udp", "udp4", "udp6":
 	default:


### PR DESCRIPTION
A `*listener` implements net.Listener which breaks a test in another repo.

Regressed in 42cfbf427c671265d3c1fc47408b7961aa7eaec4.

Updates #12182