### PR TITLE
cmd/stunstamp: validate STUN tx ID in responses

### DIFF
--- a/cmd/stunstamp/stunstamp_default.go
+++ b/cmd/stunstamp/stunstamp_default.go
@@ -16,8 +16,8 @@ func getConnKernelTimestamp() (io.ReadWriteCloser, error) {
 	return nil, errors.New("unimplemented")
 }
 
-func measureRTTKernel(conn io.ReadWriteCloser, dst *net.UDPAddr, req []byte) (resp []byte, rtt time.Duration, err error) {
-	return nil, 0, errors.New("unimplemented")
+func measureRTTKernel(conn io.ReadWriteCloser, dst *net.UDPAddr) (rtt time.Duration, err error) {
+	return 0, errors.New("unimplemented")
 }
 
 func supportsKernelTS() bool {


### PR DESCRIPTION
Extremely late arriving responses may leak across probing intervals.

Updates tailscale/corp#20344