### PR TITLE
ipn/ipnlocal: stop offline auto-updates on shutdown

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -730,6 +730,7 @@ func (b *LocalBackend) Shutdown() {
 	if b.peerAPIServer != nil {
 		b.peerAPIServer.taildrop.Shutdown()
 	}
+	b.stopOfflineAutoUpdate()
 
 	b.unregisterNetMon()
 	b.unregisterHealthWatch()


### PR DESCRIPTION
Clean up the updater goroutine on shutdown, in addition to doing that on backend state change. This fixes a goroutine leak on shutdown in tests.

Updates #cleanup