### PR TITLE
testnet: added new error when uHTTPS enabled but MagicDNC Disabled

### DIFF
--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -959,6 +959,11 @@ func (s *Server) ListenTLS(network, addr string) (net.Listener, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(st.CertDomains) != 0 {
+		if st.CurrentTailnet.MagicDNSEnabled == false {
+			return nil, errors.New("tsnet: you must enable MagicDNS in the in the DNS page of the admin console. See https://login.tailscale.com/admin/dns")
+		}
+	}
 	if len(st.CertDomains) == 0 {
 		return nil, errors.New("tsnet: you must enable HTTPS in the admin panel to proceed. See https://tailscale.com/s/https")
 	}

--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -959,10 +959,8 @@ func (s *Server) ListenTLS(network, addr string) (net.Listener, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(st.CertDomains) != 0 {
-		if st.CurrentTailnet.MagicDNSEnabled == false {
-			return nil, errors.New("tsnet: you must enable MagicDNS in the in the DNS page of the admin console. See https://login.tailscale.com/admin/dns")
-		}
+	if !st.CurrentTailnet.MagicDNSEnabled {
+		return nil, errors.New("tsnet: you must enable MagicDNS in the in the DNS page of the admin panel to proceed. See https://tailscale.com/s/https")
 	}
 	if len(st.CertDomains) == 0 {
 		return nil, errors.New("tsnet: you must enable HTTPS in the admin panel to proceed. See https://tailscale.com/s/https")


### PR DESCRIPTION
Add a new error when users attempt to use tsnet https serving on a tailnet with HTTPS enabled but MagicDNS disabled

[Issue](https://github.com/tailscale/tailscale/issues/12303)