### PR TITLE
tsnet: add a new error when HTTPS enabled but MagicDNC Disabled

### DIFF
--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -959,6 +959,9 @@ func (s *Server) ListenTLS(network, addr string) (net.Listener, error) {
 	if err != nil {
 		return nil, err
 	}
+	if !st.CurrentTailnet.MagicDNSEnabled {
+		return nil, errors.New("tsnet: you must enable MagicDNS in the in the DNS page of the admin panel to proceed. See https://tailscale.com/s/https")
+	}
 	if len(st.CertDomains) == 0 {
 		return nil, errors.New("tsnet: you must enable HTTPS in the admin panel to proceed. See https://tailscale.com/s/https")
 	}

--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -960,7 +960,7 @@ func (s *Server) ListenTLS(network, addr string) (net.Listener, error) {
 		return nil, err
 	}
 	if !st.CurrentTailnet.MagicDNSEnabled {
-		return nil, errors.New("tsnet: you must enable MagicDNS in the in the DNS page of the admin panel to proceed. See https://tailscale.com/s/https")
+		return nil, errors.New("tsnet: you must enable MagicDNS in the DNS page of the admin panel to proceed. See https://tailscale.com/s/https")
 	}
 	if len(st.CertDomains) == 0 {
 		return nil, errors.New("tsnet: you must enable HTTPS in the admin panel to proceed. See https://tailscale.com/s/https")


### PR DESCRIPTION
Add a new error when users attempt to use tsnet https serving on a tailnet with HTTPS enabled but MagicDNS disabled

[Issue](https://github.com/tailscale/tailscale/issues/12303)
