### PR TITLE
net/netcheck: fix probeProto.String result for IPv6 probes

### DIFF
--- a/net/netcheck/netcheck.go
+++ b/net/netcheck/netcheck.go
@@ -345,7 +345,7 @@ func (p probeProto) String() string {
 	case probeIPv4:
 		return "v4"
 	case probeIPv6:
-		return "v4"
+		return "v6"
 	case probeHTTPS:
 		return "https"
 	}


### PR DESCRIPTION
This bug was introduced in e6b84f215 (May 2020) but was only used in
tests when stringifying probeProto values on failure so it wasn't
noticed for a long time.

But then it was moved into non-test code in 8450a18aa (Jun 2024) and I
didn't notice during the code movement that it was wrong. It's still
only used in failure paths in logs, but having wrong/ambiguous
debugging information isn't the best.

Whoops.

Updates tailscale/corp#20654
