### PR TITLE
ipn/ipnlocal,clientupdate: allow auto-updates in contaienrs

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -2575,6 +2575,12 @@ func (b *LocalBackend) onTailnetDefaultAutoUpdate(au bool) {
 		// user. Tailnet default should not affect us, even if it changes.
 		return
 	}
+	if au && b.hostinfo != nil && b.hostinfo.Container.EqualBool(true) {
+		// This is a containerized node, which is usually meant to be
+		// immutable. Do not enable auto-updates if the tailnet does. But users
+		// can still manually enable auto-updates on this node.
+		return
+	}
 	b.logf("using tailnet default auto-update setting: %v", au)
 	prefsClone := prefs.AsStruct()
 	prefsClone.AutoUpdate.Apply = opt.NewBool(au)


### PR DESCRIPTION
We assume most containers are immutable and don't expect tailscale running in them to auto-update. But there's no reason to prohibit it outright.

Ignore the tailnet-wide default auto-update setting in containers, but allow local users to turn on auto-updates via the CLI.

RELNOTE=Auto-updates are allowed in containers, but ignore the tailnet-wide default.

Fixes #12292