### PR TITLE
net/dns: fix crash in tests

### DIFF
--- a/net/dns/manager.go
+++ b/net/dns/manager.go
@@ -52,11 +52,13 @@ type Manager struct {
 
 	resolver *resolver.Resolver
 	os       OSConfigurator
-	knobs    *controlknobs.Knobs
-	goos     string // if empty, gets set to runtime.GOOS
+	knobs    *controlknobs.Knobs // or nil
+	goos     string              // if empty, gets set to runtime.GOOS
 }
 
 // NewManagers created a new manager from the given config.
+//
+// knobs may be nil.
 func NewManager(logf logger.Logf, oscfg OSConfigurator, health *health.Tracker, dialer *tsdial.Dialer, linkSel resolver.ForwardLinkSelector, knobs *controlknobs.Knobs, goos string) *Manager {
 	if dialer == nil {
 		panic("nil Dialer")
@@ -296,7 +298,7 @@ func (m *Manager) compileConfig(cfg Config) (rcfg resolver.Config, ocfg OSConfig
 }
 
 func (m *Manager) disableSplitDNSOptimization() bool {
-	return m.knobs.DisableSplitDNSWhenNoCustomResolvers.Load()
+	return m.knobs != nil && m.knobs.DisableSplitDNSWhenNoCustomResolvers.Load()
 }
 
 // toIPsOnly returns only the IP portion of dnstype.Resolver.

--- a/net/dns/manager_test.go
+++ b/net/dns/manager_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"tailscale.com/control/controlknobs"
+	"tailscale.com/health"
 	"tailscale.com/net/dns/resolver"
 	"tailscale.com/net/netmon"
 	"tailscale.com/net/tsdial"
@@ -858,7 +860,8 @@ func TestManager(t *testing.T) {
 			if goos == "" {
 				goos = "linux"
 			}
-			m := NewManager(t.Logf, &f, nil, tsdial.NewDialer(netmon.NewStatic()), nil, nil, goos)
+			knobs := &controlknobs.Knobs{}
+			m := NewManager(t.Logf, &f, new(health.Tracker), tsdial.NewDialer(netmon.NewStatic()), nil, knobs, goos)
 			m.resolver.TestOnlySetHook(f.SetResolver)
 
 			if err := m.Set(test.in); err != nil {


### PR DESCRIPTION
Looks like #12346 as submitted with failing tests.

Updates #12346
