### PR TITLE
cmd/k8s-nameserver: fix AAAA record query response

### DIFF
--- a/cmd/k8s-nameserver/main_test.go
+++ b/cmd/k8s-nameserver/main_test.go
@@ -79,7 +79,7 @@ func TestNameserver(t *testing.T) {
 				}},
 		},
 		{
-			name: "AAAA record query",
+			name: "AAAA record query, A record exists",
 			ip4:  map[dnsname.FQDN][]net.IP{dnsname.FQDN("foo.bar.com."): {{1, 2, 3, 4}}},
 			query: &dns.Msg{
 				Question: []dns.Question{{Name: "foo.bar.com", Qtype: dns.TypeAAAA}},
@@ -88,26 +88,28 @@ func TestNameserver(t *testing.T) {
 			wantResp: &dns.Msg{
 				Question: []dns.Question{{Name: "foo.bar.com", Qtype: dns.TypeAAAA}},
 				MsgHdr: dns.MsgHdr{
-					Id:       1,
-					Rcode:    dns.RcodeNotImplemented,
-					Response: true,
-					Opcode:   dns.OpcodeQuery,
+					Id:            1,
+					Rcode:         dns.RcodeSuccess,
+					Response:      true,
+					Opcode:        dns.OpcodeQuery,
+					Authoritative: true,
 				}},
 		},
 		{
-			name: "AAAA record query",
+			name: "AAAA record query, A record does not exist",
 			ip4:  map[dnsname.FQDN][]net.IP{dnsname.FQDN("foo.bar.com."): {{1, 2, 3, 4}}},
 			query: &dns.Msg{
-				Question: []dns.Question{{Name: "foo.bar.com", Qtype: dns.TypeAAAA}},
+				Question: []dns.Question{{Name: "baz.bar.com", Qtype: dns.TypeAAAA}},
 				MsgHdr:   dns.MsgHdr{Id: 1},
 			},
 			wantResp: &dns.Msg{
-				Question: []dns.Question{{Name: "foo.bar.com", Qtype: dns.TypeAAAA}},
+				Question: []dns.Question{{Name: "baz.bar.com", Qtype: dns.TypeAAAA}},
 				MsgHdr: dns.MsgHdr{
-					Id:       1,
-					Rcode:    dns.RcodeNotImplemented,
-					Response: true,
-					Opcode:   dns.OpcodeQuery,
+					Id:            1,
+					Rcode:         dns.RcodeNameError,
+					Response:      true,
+					Opcode:        dns.OpcodeQuery,
+					Authoritative: true,
 				}},
 		},
 		{


### PR DESCRIPTION
### Background

See https://github.com/tailscale/tailscale/issues/12321 for context- although the nameserver for [cluster MagicDNS name resolution](https://tailscale.com/kb/1236/kubernetes-operator#expose-a-tailnet-https-service-to-your-cluster-workloads) does not currently support IPv6, we have to assume that AAAA records will be queries as part of normal DNS client query workflow

### The change

Return empty response and NOERROR for AAAA record queries for DNS names for which the nameserver has an A record.
This is to allow for callers that might be first sending an AAAA query and then, if that does not return a response, follow with an A record query. Previously we were returning NOTIMPL that caused some callers to potentially not follow with an A record query or misbehave in different ways.

Also return NXDOMAIN for AAAA record queries for names that we DO NOT have an A record for to ensure that the callers do not follow up with an A record query.

### Notes

Returning an empty response and NOERROR is the behaviour that RFC 4074 recommends:
https://datatracker.ietf.org/doc/html/rfc4074

I've tested that the nameserver from this PR returns the expected responses:
<details>
<code>
// nameserver with an IP 10.80.12.15

// 1. Query a DNS record for which there is an A record:
$ dig @10.80.12.15 -t AAAA  dnstest.tailbd97a.ts.net

; <<>> DiG 9.18.24 <<>> @10.80.12.15 -t AAAA dnstest.tailbd97a.ts.net
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 45364
;; flags: qr aa rd; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0
;; WARNING: recursion requested but not available

;; QUESTION SECTION:
;dnstest.tailbd97a.ts.net.      IN      AAAA

;; Query time: 0 msec
;; SERVER: 10.80.12.15#53(10.80.12.15) (UDP)
;; WHEN: Mon Jun 10 13:29:53 UTC 2024
;; MSG SIZE  rcvd: 42

// 2. Query a DNS record for which there is no A record

dig @10.80.12.15 -t AAAA  foo.tailbd97a.ts.net

; <<>> DiG 9.18.24 <<>> @10.80.12.15 -t AAAA foo.tailbd97a.ts.net
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 44381
;; flags: qr aa rd; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0
;; WARNING: recursion requested but not available

;; QUESTION SECTION:
;foo.tailbd97a.ts.net.          IN      AAAA

;; Query time: 0 msec
;; SERVER: 10.80.12.15#53(10.80.12.15) (UDP)
;; WHEN: Mon Jun 10 13:30:08 UTC 2024
;; MSG SIZE  rcvd: 38



</code>
</details>

Updates tailscale/tailscale#12321