### PR TITLE
net/dns/resolver: return an empty successful response instead of NXDo…

### DIFF
--- a/net/dns/resolver/tsdns_test.go
+++ b/net/dns/resolver/tsdns_test.go
@@ -401,6 +401,12 @@ func TestResolveLocal(t *testing.T) {
 		// suffixes are currently hard-coded and not plumbed via the netmap)
 		{"via_form3_dec_example.com", dnsname.FQDN("1-2-3-4-via-1.example.com."), dns.TypeAAAA, netip.Addr{}, dns.RCodeRefused},
 		{"via_form3_dec_examplets.net", dnsname.FQDN("1-2-3-4-via-1.examplets.net."), dns.TypeAAAA, netip.Addr{}, dns.RCodeRefused},
+
+		// Resolve A and ALL types of resource records.
+		{"via_type_a", dnsname.FQDN("1-2-3-4-via-1."), dns.TypeA, netip.Addr{}, dns.RCodeSuccess},
+		{"via_invalid_type_a", dnsname.FQDN("1-2-3-4-via-."), dns.TypeA, netip.Addr{}, dns.RCodeRefused},
+		{"via_type_all", dnsname.FQDN("1-2-3-4-via-1."), dns.TypeALL, netip.MustParseAddr("fd7a:115c:a1e0:b1a:0:1:1.2.3.4"), dns.RCodeSuccess},
+		{"via_invalid_type_all", dnsname.FQDN("1-2-3-4-via-."), dns.TypeALL, netip.Addr{}, dns.RCodeRefused},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
…main when resolving A records for 4via6 domains

As quad-100 is an authoritative server for 4via6 domains, it should always return responses with a response code of 0 (indicating no error) when resolving records for these domains. If there's no resource record of the specified type (e.g. A), it should return a response with an empty answer section rather than NXDomain. Such a response indicates that there is at least one RR of a different type (e.g., AAAA), suggesting the Windows stub resolver to look for it.

Fixes tailscale/corp#20767