### PR TITLE
health: add mutex to subsystemsWarnables

### DIFF
--- a/health/health.go
+++ b/health/health.go
@@ -123,6 +123,7 @@ const (
 )
 
 var subsystemsWarnables = map[Subsystem]*Warnable{}
+var subsystemsWarnablesLock sync.Mutex = sync.Mutex{}
 
 const legacyErrorArgKey = "LegacyError"
 
@@ -130,6 +131,9 @@ const legacyErrorArgKey = "LegacyError"
 // *temporarily* while we migrate the old health infrastructure based on
 // Subsystems to the new Warnables architecture.
 func (s Subsystem) Warnable() *Warnable {
+	subsystemsWarnablesLock.Lock()
+	defer subsystemsWarnablesLock.Unlock()
+
 	if w, ok := subsystemsWarnables[s]; ok {
 		return w
 	} else {


### PR DESCRIPTION
Updates tailscale/tailscale#12479

I believe subsystemsWarnables needs a mutex to solve the issue.