### PR TITLE
wgengine/filter: use NewContainsIPFunc for Srcs matches

### DIFF
--- a/wgengine/filter/filter_clone.go
+++ b/wgengine/filter/filter_clone.go
@@ -34,10 +34,11 @@ func (src *Match) Clone() *Match {
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _MatchCloneNeedsRegeneration = Match(struct {
-	IPProto []ipproto.Proto
-	Srcs    []netip.Prefix
-	Dsts    []NetPortRange
-	Caps    []CapMatch
+	IPProto      []ipproto.Proto
+	Srcs         []netip.Prefix
+	SrcsContains func(netip.Addr) bool
+	Dsts         []NetPortRange
+	Caps         []CapMatch
 }{})
 
 // Clone makes a deep copy of CapMatch.

--- a/wgengine/filter/tailcfg.go
+++ b/wgengine/filter/tailcfg.go
@@ -10,8 +10,10 @@ import (
 
 	"go4.org/netipx"
 	"tailscale.com/net/netaddr"
+	"tailscale.com/net/tsaddr"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/ipproto"
+	"tailscale.com/types/views"
 )
 
 var defaultProtos = []ipproto.Proto{
@@ -61,6 +63,7 @@ func MatchesFromFilterRules(pf []tailcfg.FilterRule) ([]Match, error) {
 			}
 			m.Srcs = append(m.Srcs, nets...)
 		}
+		m.SrcsContains = tsaddr.NewContainsIPFunc(views.SliceOf(m.Srcs))
 
 		for _, d := range r.DstPorts {
 			nets, err := parseIPSet(d.IP, d.Bits)


### PR DESCRIPTION
NewContainsIPFunc returns a contains matcher optimized for its
input. Use that instead of what this did before, always doing a test
over each of a list of netip.Prefixes.

    goos: darwin
    goarch: arm64
    pkg: tailscale.com/wgengine/filter
                        │   before    │                after                │
                        │   sec/op    │   sec/op     vs base                │
    FilterMatch/file1-8   32.60n ± 1%   18.87n ± 1%  -42.12% (p=0.000 n=10)

Updates #12486
