### PR TITLE
wgengine/filter: split local+logs lookups by IPv4-vs-IPv6

### DIFF
--- a/wgengine/filter/filter_test.go
+++ b/wgengine/filter/filter_test.go
@@ -440,10 +440,11 @@ func TestLoggingPrivacy(t *testing.T) {
 	}
 
 	f := newFilter(logf)
-	f.logIPs = tsaddr.NewContainsIPFunc(views.SliceOf([]netip.Prefix{
+	f.logIPs4 = tsaddr.NewContainsIPFunc(views.SliceOf([]netip.Prefix{
 		tsaddr.CGNATRange(),
 		tsaddr.TailscaleULARange(),
 	}))
+	f.logIPs6 = f.logIPs4
 
 	var (
 		ts4       = netip.AddrPortFrom(tsaddr.CGNATRange().Addr().Next(), 1234)


### PR DESCRIPTION
If we already know it's an incoming IPv4 packet, no need to match
against the set of IPv6s and vice versa.

    goos: darwin
    goarch: arm64
    pkg: tailscale.com/wgengine/filter
                                         │   before    │                after                │
                                         │   sec/op    │   sec/op     vs base                │
    FilterMatch/not-local-v4-8             21.40n ± 3%   16.04n ± 1%  -25.09% (p=0.000 n=10)
    FilterMatch/not-local-v6-8             20.75n ± 9%   15.71n ± 0%  -24.31% (p=0.000 n=10)
    FilterMatch/no-match-v4-8              81.37n ± 1%   78.57n ± 3%   -3.43% (p=0.005 n=10)
    FilterMatch/no-match-v6-8              77.73n ± 2%   73.71n ± 3%   -5.18% (p=0.002 n=10)
    FilterMatch/tcp-not-syn-v4-8           21.41n ± 3%   16.86n ± 0%  -21.25% (p=0.000 n=10)
    FilterMatch/tcp-not-syn-v4-no-logs-8   10.04n ± 0%   10.05n ± 0%        ~ (p=0.446 n=10)
    geomean                                29.07n        25.05n       -13.84%

Updates #12486
