### PR TITLE
cmd/viewer,type/views: add MapSlice for maps of slices

### DIFF
--- a/cmd/viewer/tests/tests_view.go
+++ b/cmd/viewer/tests/tests_view.go
@@ -188,11 +188,7 @@ func (v *MapView) UnmarshalJSON(b []byte) error {
 
 func (v MapView) Int() views.Map[string, int] { return views.MapOf(v.ж.Int) }
 
-func (v MapView) SliceInt() views.MapFn[string, []int, views.Slice[int]] {
-	return views.MapFnOf(v.ж.SliceInt, func(t []int) views.Slice[int] {
-		return views.SliceOf(t)
-	})
-}
+func (v MapView) SliceInt() views.MapSlice[string, int] { return views.MapSliceOf(v.ж.SliceInt) }
 
 func (v MapView) StructPtrWithPtr() views.MapFn[string, *StructWithPtrs, StructWithPtrsView] {
 	return views.MapFnOf(v.ж.StructPtrWithPtr, func(t *StructWithPtrs) StructWithPtrsView {

--- a/cmd/viewer/viewer.go
+++ b/cmd/viewer/viewer.go
@@ -92,6 +92,9 @@ func(v {{.ViewName}}) {{.FieldName}}() views.MapFn[{{.MapKeyType}},{{.MapValueTy
 	return {{.MapFn}}
 })}
 {{end}}
+{{define "mapSliceField"}}
+func(v {{.ViewName}}) {{.FieldName}}() views.MapSlice[{{.MapKeyType}},{{.MapValueType}}] { return views.MapSliceOf(v.ж.{{.FieldName}}) }
+{{end}}
 {{define "unsupportedField"}}func(v {{.ViewName}}) {{.FieldName}}() {{.FieldType}} {panic("unsupported")}
 {{end}}
 {{define "stringFunc"}}func(v {{.ViewName}}) String() string { return v.ж.String() }
@@ -241,9 +244,8 @@ func genView(buf *bytes.Buffer, it *codegen.ImportTracker, typ *types.Named, thi
 				case *types.Basic, *types.Named:
 					sElem := it.QualifiedName(sElem)
 					args.MapValueView = fmt.Sprintf("views.Slice[%v]", sElem)
-					args.MapValueType = "[]" + sElem
-					args.MapFn = "views.SliceOf(t)"
-					template = "mapFnField"
+					args.MapValueType = sElem
+					template = "mapSliceField"
 				case *types.Pointer:
 					ptr := x
 					pElem := ptr.Elem()

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -6565,7 +6565,7 @@ func suggestExitNode(report *netcheck.Report, netMap *netmap.NetworkMap, prevSug
 		if allowList != nil && !allowList.Contains(peer.StableID()) {
 			continue
 		}
-		if peer.CapMap().Has(tailcfg.NodeAttrSuggestExitNode) && tsaddr.ContainsExitRoutes(peer.AllowedIPs()) {
+		if peer.CapMap().Contains(tailcfg.NodeAttrSuggestExitNode) && tsaddr.ContainsExitRoutes(peer.AllowedIPs()) {
 			candidates = append(candidates, peer)
 		}
 	}

--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -307,7 +307,7 @@ func (b *LocalBackend) setServeConfigLocked(config *ipn.ServeConfig, etag string
 	if prevConfig.Valid() {
 		has := func(string) bool { return false }
 		if b.serveConfig.Valid() {
-			has = b.serveConfig.Foreground().Has
+			has = b.serveConfig.Foreground().Contains
 		}
 		prevConfig.Foreground().Range(func(k string, v ipn.ServeConfigView) (cont bool) {
 			if !has(k) {
@@ -338,7 +338,7 @@ func (b *LocalBackend) ServeConfig() ipn.ServeConfigView {
 func (b *LocalBackend) DeleteForegroundSession(sessionID string) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if !b.serveConfig.Valid() || !b.serveConfig.Foreground().Has(sessionID) {
+	if !b.serveConfig.Valid() || !b.serveConfig.Foreground().Contains(sessionID) {
 		return nil
 	}
 	sc := b.serveConfig.AsStruct()

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -168,10 +168,8 @@ func (v NodeView) Online() *bool {
 func (v NodeView) MachineAuthorized() bool                   { return v.ж.MachineAuthorized }
 func (v NodeView) Capabilities() views.Slice[NodeCapability] { return views.SliceOf(v.ж.Capabilities) }
 
-func (v NodeView) CapMap() views.MapFn[NodeCapability, []RawMessage, views.Slice[RawMessage]] {
-	return views.MapFnOf(v.ж.CapMap, func(t []RawMessage) views.Slice[RawMessage] {
-		return views.SliceOf(t)
-	})
+func (v NodeView) CapMap() views.MapSlice[NodeCapability, RawMessage] {
+	return views.MapSliceOf(v.ж.CapMap)
 }
 func (v NodeView) UnsignedPeerAPIOnly() bool    { return v.ж.UnsignedPeerAPIOnly }
 func (v NodeView) ComputedName() string         { return v.ж.ComputedName }


### PR DESCRIPTION
This abstraction provides a nicer way to work with
maps of slices without having to write out three long type
params.

Updates tailscale/corp#20910
