### PR TITLE
wgengine/filter: fix copy/pasteo in new benchmark's v6 CIDR

### DIFF
--- a/wgengine/filter/filter_test.go
+++ b/wgengine/filter/filter_test.go
@@ -1008,7 +1008,7 @@ func benchmarkFile(b *testing.B, file string, opt benchOpt) {
 	var localNets netipx.IPSetBuilder
 	pfx := []netip.Prefix{
 		netip.MustParsePrefix("100.96.14.120/32"),
-		netip.MustParsePrefix("fd7a:115c:a1e0:ab12:4843:cd96:6260:e78/32"),
+		netip.MustParsePrefix("fd7a:115c:a1e0:ab12:4843:cd96:6260:e78/128"),
 	}
 	for _, p := range pfx {
 		localNets.AddPrefix(p)


### PR DESCRIPTION
I noticed the not-local-v6 numbers were nowhere near the v4 numbers
(they should be identical) and then saw this. It meant the
Addr().Next() wasn't picking an IP that was no longer local, as
assumed.

Updates #12486
