### PR TITLE
net/ipset: skip the loop over Prefixes when there's only one

### DIFF
--- a/net/ipset/ipset_test.go
+++ b/net/ipset/ipset_test.go
@@ -41,7 +41,7 @@ var newContainsIPFuncTests = []struct {
 	{
 		name:    "cidr-list-1",
 		pfx:     pp("10.0.0.0/8"),
-		want:    "linear-contains",
+		want:    "one-prefix",
 		wantIn:  aa("10.0.0.1", "10.2.3.4"),
 		wantOut: aa("8.8.8.8"),
 	},


### PR DESCRIPTION
For pprof cosmetic/confusion reasons more than performance, but it
might have tiny speed benefit.

Updates #12486
