### PR TITLE
ipn/ipnlocal: network-lock, error if no pubkey instead of panic

### DIFF
--- a/ipn/ipnlocal/network-lock.go
+++ b/ipn/ipnlocal/network-lock.go
@@ -255,7 +255,10 @@ func (b *LocalBackend) tkaSyncIfNeeded(nm *netmap.NetworkMap, prefs ipn.PrefsVie
 		b.logf("tkaSyncIfNeeded: enabled=%v, head=%v", nm.TKAEnabled, nm.TKAHead)
 	}
 
-	ourNodeKey := prefs.Persist().PublicNodeKey()
+	ourNodeKey, ok := prefs.Persist().PublicNodeKeyOK()
+	if !ok {
+		return errors.New("tkaSyncIfNeeded: no node key in prefs")
+	}
 
 	isEnabled := b.tka != nil
 	wantEnabled := nm.TKAEnabled


### PR DESCRIPTION
While working on a load generator utility, spinning up and down a huge amount of clients, I encountered a panic when trying to _close_ a tsnet client when network lock attempts to get the public key of a node here.

It occurred quite rarely, and only when doing 100s of clients and I have been unable to figure where the key is unset before this line is called. 

Based on the function where this line exists, it seem reasonable to return an error instead of panicking. 