### PR TITLE
cmd/tailscale/cli: do not allow update --version on macOS

### DIFF
--- a/cmd/tailscale/cli/update.go
+++ b/cmd/tailscale/cli/update.go
@@ -33,11 +33,13 @@ var updateCmd = &ffcli.Command{
 		//  - Alpine (and other apk-based distros)
 		//  - FreeBSD (and other pkg-based distros)
 		//  - Unraid/QNAP/Synology
+		//  - macOS
 		if distro.Get() != distro.Arch &&
 			distro.Get() != distro.Alpine &&
 			distro.Get() != distro.QNAP &&
 			distro.Get() != distro.Synology &&
-			runtime.GOOS != "freebsd" {
+			runtime.GOOS != "freebsd" &&
+			runtime.GOOS != "darwin" {
 			fs.StringVar(&updateArgs.track, "track", "", `which track to check for updates: "stable" or "unstable" (dev); empty means same as current`)
 			fs.StringVar(&updateArgs.version, "version", "", `explicit version to update/downgrade to`)
 		}


### PR DESCRIPTION
We do not support specific version updates or track switching on macOS. Do not populate the flag to avoid confusion.

Fixes https://github.com/tailscale/corp/issues/20939