### PR TITLE
wgengine/filter: mark "Accept" TCP log lines as verbose

### DIFF
--- a/wgengine/filter/filter.go
+++ b/wgengine/filter/filter.go
@@ -312,7 +312,7 @@ func (f *Filter) logRateLimit(runflags RunFlags, q *packet.Parsed, dir direction
 		verdict = "Drop"
 		runflags &= HexdumpDrops
 	} else if r == Accept && (runflags&LogAccepts) != 0 && acceptBucket.Allow() {
-		verdict = "Accept"
+		verdict = "[v1] Accept"
 		runflags &= HexdumpAccepts
 	}
 


### PR DESCRIPTION
Changes "Accept" TCP logs to display in verbose logs only, and removes lines from default logging behavior.

Updates #12158