### PR TITLE
health: add warming-up warnable

### DIFF
--- a/health/health_test.go
+++ b/health/health_test.go
@@ -6,6 +6,7 @@ package health
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"testing"
 	"time"
 )
@@ -199,15 +200,17 @@ func TestCheckDependsOnAppearsInUnhealthyState(t *testing.T) {
 	if !ok {
 		t.Fatalf("Expected an UnhealthyState for w1, got nothing")
 	}
-	if len(us1.DependsOn) != 0 {
-		t.Fatalf("Expected no DependsOn in the unhealthy state, got: %v", us1.DependsOn)
+	wantDependsOn := []WarnableCode{warmingUpWarnable.Code}
+	if !reflect.DeepEqual(us1.DependsOn, wantDependsOn) {
+		t.Fatalf("Expected DependsOn = %v in the unhealthy state, got: %v", wantDependsOn, us1.DependsOn)
 	}
 	ht.SetUnhealthy(w2, Args{ArgError: "w2 is also unhealthy now"})
 	us2, ok := ht.CurrentState().Warnings[w2.Code]
 	if !ok {
 		t.Fatalf("Expected an UnhealthyState for w2, got nothing")
 	}
-	if !reflect.DeepEqual(us2.DependsOn, []WarnableCode{w1.Code}) {
-		t.Fatalf("Expected DependsOn = [w1.Code] in the unhealthy state, got: %v", us2.DependsOn)
+	wantDependsOn = slices.Concat([]WarnableCode{w1.Code}, wantDependsOn)
+	if !reflect.DeepEqual(us2.DependsOn, wantDependsOn) {
+		t.Fatalf("Expected DependsOn = %v in the unhealthy state, got: %v", wantDependsOn, us2.DependsOn)
 	}
 }

--- a/health/state.go
+++ b/health/state.go
@@ -41,9 +41,16 @@ func (w *Warnable) unhealthyState(ws *warningState) *UnhealthyState {
 		text = w.Text(Args{})
 	}
 
-	dependsOnWarnableCodes := make([]WarnableCode, len(w.DependsOn))
+	dependsOnWarnableCodes := make([]WarnableCode, len(w.DependsOn), len(w.DependsOn)+1)
 	for i, d := range w.DependsOn {
 		dependsOnWarnableCodes[i] = d.Code
+	}
+
+	if w != warmingUpWarnable {
+		// Here we tell the frontend that all Warnables depend on warmingUpWarnable. GUIs will silence all warnings until all
+		// their dependencies are healthy. This is a special case to prevent the GUI from showing a bunch of warnings when
+		// the backend is still warming up.
+		dependsOnWarnableCodes = append(dependsOnWarnableCodes, warmingUpWarnable.Code)
 	}
 
 	return &UnhealthyState{

--- a/health/warnings.go
+++ b/health/warnings.go
@@ -5,6 +5,7 @@ package health
 
 import (
 	"fmt"
+	"time"
 )
 
 /**
@@ -211,4 +212,18 @@ var controlHealthWarnable = Register(&Warnable{
 	Text: func(args Args) string {
 		return fmt.Sprintf("The coordination server is reporting an health issue: %v", args[ArgError])
 	},
+})
+
+// warmingUpWarnableDuration is the duration for which the warmingUpWarnable is reported by the backend after the user
+// has changed ipnWantRunning to true from false.
+const warmingUpWarnableDuration = 5 * time.Second
+
+// warmingUpWarnable is a Warnable that is reported by the backend when it is starting up, for a maximum time of
+// warmingUpWarnableDuration. The GUIs use the presence of this Warnable to prevent showing any other warnings until
+// the backend is fully started.
+var warmingUpWarnable = Register(&Warnable{
+	Code:     "warming-up",
+	Title:    "Tailscale is starting",
+	Severity: SeverityLow,
+	Text:     StaticMessage("Tailscale is starting. Please wait."),
 })


### PR DESCRIPTION
Updates tailscale/tailscale#4136

Creates and exposes a 'fake' warnable that persists for the first 5 seconds of lifetime of the backend. This is used to silence spurious warnings while the backend is starting up.