### PR TITLE
ssh/tailssh: fix integration test

### DIFF
--- a/ssh/tailssh/tailssh_integration_test.go
+++ b/ssh/tailssh/tailssh_integration_test.go
@@ -611,7 +611,7 @@ func (tb *testBackend) NetMap() *netmap.NetworkMap {
 	}
 }
 
-func (tb *testBackend) WhoIs(ipp netip.AddrPort) (n tailcfg.NodeView, u tailcfg.UserProfile, ok bool) {
+func (tb *testBackend) WhoIs(_ string, ipp netip.AddrPort) (n tailcfg.NodeView, u tailcfg.UserProfile, ok bool) {
 	return (&tailcfg.Node{}).View(), tailcfg.UserProfile{
 		LoginName: tb.localUser + "@example.com",
 	}, true


### PR DESCRIPTION
The new ssh integration test target is failing on main
```
$ make sshintegrationtest
# tailscale.com/ssh/tailssh [tailscale.com/ssh/tailssh.test]
ssh/tailssh/tailssh_integration_test.go:488:19: cannot use &testBackend{…} (value of type *testBackend) as ipnLocalBackend value in struct literal: *testBackend does not implement ipnLocalBackend (wrong type for method WhoIs)
                have WhoIs(netip.AddrPort) (tailcfg.NodeView, tailcfg.UserProfile, bool)
                want WhoIs(string, netip.AddrPort) (tailcfg.NodeView, tailcfg.UserProfile, bool)
make: *** [Makefile:113: sshintegrationtest] Error 1
```
presumably because of the order in which the PR with it and https://github.com/tailscale/tailscale/pull/12385 got merged.
Updates#cleanup