### PR TITLE
posture, util/syspolicy: append DeviceSerialNumber from syspolicy on Windows

### DIFF
--- a/util/syspolicy/policy_keys_windows.go
+++ b/util/syspolicy/policy_keys_windows.go
@@ -28,6 +28,7 @@ var stringKeys = []Key{
 	ManagedByOrganizationName,
 	ManagedByCaption,
 	ManagedByURL,
+	DeviceSerialNumber,
 }
 
 var boolKeys = []Key{


### PR DESCRIPTION
Some off-the-shelf motherboards come with bogus serial number values like "System Serial Number", "To Be Filled By O.E.M.", "Unknown", or similar.

This updates posture.GetSerialNumbers to use DeviceSerialNumber syspolicy on Windows. If configured, its value will be appended to the list of serial numbers read from SMBIOS.

Fixes #12566