### PR TITLE
appc: don't schedule advertisement of 0 routes

### DIFF
--- a/appc/appconnector.go
+++ b/appc/appconnector.go
@@ -442,8 +442,10 @@ func (e *AppConnector) ObserveDNSResponse(res []byte) {
 			}
 		}
 
-		e.logf("[v2] observed new routes for %s: %s", domain, toAdvertise)
-		e.scheduleAdvertisement(domain, toAdvertise...)
+		if len(toAdvertise) > 0 {
+			e.logf("[v2] observed new routes for %s: %s", domain, toAdvertise)
+			e.scheduleAdvertisement(domain, toAdvertise...)
+		}
 	}
 }
 


### PR DESCRIPTION
When the store-appc-routes flag is on for a tailnet we are writing the routes more often than seems necessary. Investigation reveals that we are doing so ~every time we observe a dns response, even if this causes us not to advertise any new routes. So when we have no new routes, instead do not advertise routes.

Fixes #12593