### PR TITLE
ipn/ipnlocal: fix data race in tests

### DIFF
--- a/ipn/ipnlocal/serve_test.go
+++ b/ipn/ipnlocal/serve_test.go
@@ -29,6 +29,7 @@ import (
 	"tailscale.com/ipn/store/mem"
 	"tailscale.com/tailcfg"
 	"tailscale.com/tsd"
+	"tailscale.com/tstest"
 	"tailscale.com/types/logger"
 	"tailscale.com/types/logid"
 	"tailscale.com/types/netmap"
@@ -668,7 +669,7 @@ func newTestBackend(t *testing.T) *LocalBackend {
 	var logf logger.Logf = logger.Discard
 	const debug = true
 	if debug {
-		logf = logger.WithPrefix(t.Logf, "... ")
+		logf = logger.WithPrefix(tstest.WhileTestRunningLogger(t), "... ")
 	}
 
 	sys := &tsd.System{}


### PR DESCRIPTION
We can observe a data race in tests when logging after a test is finished. `b.onHealthChange` is called in a goroutine after being registered with `health.Tracker.RegisterWatcher`, which calls callbacks in `setUnhealthyLocked` in a new goroutine.

See: https://github.com/tailscale/tailscale/actions/runs/9672919302/job/26686038740

Updates #12054


Change-Id: Ibf22cc994965d88a9e7236544878d5373f91229e