### PR TITLE
health: use Warnables for system DNS configuration errors

### DIFF
--- a/health/health.go
+++ b/health/health.go
@@ -110,15 +110,6 @@ const (
 	// SysRouter is the name of the wgengine/router subsystem.
 	SysRouter = Subsystem("router")
 
-	// SysDNS is the name of the net/dns subsystem.
-	SysDNS = Subsystem("dns")
-
-	// SysDNSOS is the name of the net/dns OSConfigurator subsystem.
-	SysDNSOS = Subsystem("dns-os")
-
-	// SysDNSManager is the name of the net/dns manager subsystem.
-	SysDNSManager = Subsystem("dns-manager")
-
 	// SysTKA is the name of the tailnet key authority subsystem.
 	SysTKA = Subsystem("tailnet-lock")
 )
@@ -126,7 +117,7 @@ const (
 var subsystemsWarnables = map[Subsystem]*Warnable{}
 
 func init() {
-	for _, s := range []Subsystem{SysRouter, SysDNS, SysDNSOS, SysDNSManager, SysTKA} {
+	for _, s := range []Subsystem{SysRouter, SysTKA} {
 		w := Register(&Warnable{
 			Code:     WarnableCode(s),
 			Severity: SeverityMedium,
@@ -405,32 +396,6 @@ func (t *Tracker) SetRouterHealth(err error) { t.setErr(SysRouter, err) }
 //
 // Deprecated: Warnables should be preferred over Subsystem errors.
 func (t *Tracker) RouterHealth() error { return t.get(SysRouter) }
-
-// SetDNSHealth sets the state of the net/dns.Manager
-//
-// Deprecated: Warnables should be preferred over Subsystem errors.
-func (t *Tracker) SetDNSHealth(err error) { t.setErr(SysDNS, err) }
-
-// DNSHealth returns the net/dns.Manager error state.
-//
-// Deprecated: Warnables should be preferred over Subsystem errors.
-func (t *Tracker) DNSHealth() error { return t.get(SysDNS) }
-
-// SetDNSOSHealth sets the state of the net/dns.OSConfigurator
-//
-// Deprecated: Warnables should be preferred over Subsystem errors.
-func (t *Tracker) SetDNSOSHealth(err error) { t.setErr(SysDNSOS, err) }
-
-// SetDNSManagerHealth sets the state of the Linux net/dns manager's
-// discovery of the /etc/resolv.conf situation.
-//
-// Deprecated: Warnables should be preferred over Subsystem errors.
-func (t *Tracker) SetDNSManagerHealth(err error) { t.setErr(SysDNSManager, err) }
-
-// DNSOSHealth returns the net/dns.OSConfigurator error state.
-//
-// Deprecated: Warnables should be preferred over Subsystem errors.
-func (t *Tracker) DNSOSHealth() error { return t.get(SysDNSOS) }
 
 // SetTKAHealth sets the health of the tailnet key authority.
 //

--- a/net/dns/resolved.go
+++ b/net/dns/resolved.go
@@ -165,7 +165,7 @@ func (m *resolvedManager) run(ctx context.Context) {
 
 		// Reset backoff and SetNSOSHealth after successful on reconnect.
 		bo.BackOff(ctx, nil)
-		m.health.SetDNSOSHealth(nil)
+		m.health.SetHealthy(OSConfigWarnable)
 		return nil
 	}
 
@@ -243,9 +243,11 @@ func (m *resolvedManager) run(ctx context.Context) {
 			// Set health while holding the lock, because this will
 			// graciously serialize the resync's health outcome with a
 			// concurrent SetDNS call.
-			m.health.SetDNSOSHealth(err)
 			if err != nil {
 				m.logf("failed to configure systemd-resolved: %v", err)
+				m.health.SetUnhealthy(OSConfigWarnable, health.Args{health.ArgError: err.Error()})
+			} else {
+				m.health.SetHealthy(OSConfigWarnable)
 			}
 		}
 	}

--- a/net/dns/resolver/tsdns.go
+++ b/net/dns/resolver/tsdns.go
@@ -253,7 +253,7 @@ func (r *Resolver) SetMissingUpstreamRecovery(f func()) {
 
 func (r *Resolver) TestOnlySetHook(hook func(Config)) { r.saveConfigForTests = hook }
 
-func (r *Resolver) SetConfig(cfg Config) error {
+func (r *Resolver) SetConfig(cfg Config) {
 	if r.saveConfigForTests != nil {
 		r.saveConfigForTests(cfg)
 	}
@@ -273,7 +273,6 @@ func (r *Resolver) SetConfig(cfg Config) error {
 	r.localDomains = cfg.LocalDomains
 	r.hostToIP = cfg.Hosts
 	r.ipToHost = reverse
-	return nil
 }
 
 // Close shuts down the resolver and ensures poll goroutines have exited.

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -994,13 +994,15 @@ func (e *userspaceEngine) Reconfig(cfg *wgcfg.Config, routerCfg *router.Config, 
 		// assigned address.
 		e.logf("wgengine: Reconfig: configuring DNS")
 		err = e.dns.Set(*dnsCfg)
-		e.health.SetDNSHealth(err)
 		if err != nil {
+			e.health.SetUnhealthy(dns.OSConfigWarnable, health.Args{health.ArgError: err.Error()})
 			return err
 		}
 		if err := e.reconfigureVPNIfNecessary(); err != nil {
+			e.health.SetUnhealthy(dns.OSConfigWarnable, health.Args{health.ArgError: err.Error()})
 			return err
 		}
+		e.health.SetHealthy(dns.OSConfigWarnable)
 	}
 
 	// Shutdown the network logger.


### PR DESCRIPTION
Updates tailscale/tailscale#4136

Begins to use Warnables to replace the deprecated DNS health subsystem.