### PR TITLE
cmd/tailscale/cli: correct command emitted by exit node suggestion

### DIFF
--- a/cmd/tailscale/cli/exitnode.go
+++ b/cmd/tailscale/cli/exitnode.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/kballard/go-shellquote"
 	"github.com/peterbourgon/ff/v3/ffcli"
 	xmaps "golang.org/x/exp/maps"
 	"tailscale.com/envknob"
@@ -154,7 +155,8 @@ func runExitNodeSuggest(ctx context.Context, args []string) error {
 		fmt.Println("No exit node suggestion is available.")
 		return nil
 	}
-	fmt.Printf("Suggested exit node: %v\nTo accept this suggestion, use `tailscale set --exit-node=%v`.\n", res.Name, res.ID)
+	hostname := strings.TrimSuffix(res.Name, ".")
+	fmt.Printf("Suggested exit node: %v\nTo accept this suggestion, use `tailscale set --exit-node=%v`.\n", hostname, shellquote.Join(hostname))
 	return nil
 }
 


### PR DESCRIPTION
The exit node suggestion CLI command was written with the assumption that it's possible to provide a stableid on the command line, but this is incorrect. Instead, it will now emit the name of the exit node.

Fixes #12618

Change-Id: Id7277f395b5fca090a99b0d13bfee7b215bc9802