### PR TITLE
util/winutil: ensure domain controller address is used when retrievin…

### DIFF
--- a/util/winutil/mksyscall.go
+++ b/util/winutil/mksyscall.go
@@ -6,9 +6,11 @@ package winutil
 //go:generate go run golang.org/x/sys/windows/mkwinsyscall -output zsyscall_windows.go mksyscall.go
 //go:generate go run golang.org/x/tools/cmd/goimports -w zsyscall_windows.go
 
+//sys dsGetDcName(computerName *uint16, domainName *uint16, domainGuid *windows.GUID, siteName *uint16, flags dsGetDcNameFlag, dcInfo **_DOMAIN_CONTROLLER_INFO) (ret error) = netapi32.DsGetDcNameW
 //sys expandEnvironmentStringsForUser(token windows.Token, src *uint16, dst *uint16, dstLen uint32) (err error) [int32(failretval)==0] = userenv.ExpandEnvironmentStringsForUserW
 //sys getApplicationRestartSettings(process windows.Handle, commandLine *uint16, commandLineLen *uint32, flags *uint32) (ret wingoes.HRESULT) = kernel32.GetApplicationRestartSettings
 //sys loadUserProfile(token windows.Token, profileInfo *_PROFILEINFO) (err error) [int32(failretval)==0] = userenv.LoadUserProfileW
+//sys netValidateName(server *uint16, name *uint16, account *uint16, password *uint16, nameType _NETSETUP_NAME_TYPE) (ret error) = netapi32.NetValidateName
 //sys queryServiceConfig2(hService windows.Handle, infoLevel uint32, buf *byte, bufLen uint32, bytesNeeded *uint32) (err error) [failretval==0] = advapi32.QueryServiceConfig2W
 //sys registerApplicationRestart(cmdLineExclExeName *uint16, flags uint32) (ret wingoes.HRESULT) = kernel32.RegisterApplicationRestart
 //sys rmEndSession(session _RMHANDLE) (ret error) = rstrtmgr.RmEndSession

--- a/util/winutil/userprofile_windows_test.go
+++ b/util/winutil/userprofile_windows_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package winutil
+
+import (
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestGetRoamingProfilePath(t *testing.T) {
+	token := windows.GetCurrentProcessToken()
+	computerName, userName, err := getComputerAndUserName(token, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := getRoamingProfilePath(t.Logf, token, computerName, userName); err != nil {
+		t.Error(err)
+	}
+
+	// TODO(aaron): Flesh out better once can run tests under domain accounts.
+}


### PR DESCRIPTION
…g remote profile information

We cannot directly pass a flat domain name into NetUserGetInfo; we must resolve the address of a domain controller first.

This PR implements the appropriate resolution mechanisms to do that, and also exposes a couple of new utility APIs for future needs.

Fixes #12627