### PR TITLE
util/winutil/s4u: fix incorrect token type specified in s4u Login

### DIFF
--- a/util/winutil/s4u/s4u_windows.go
+++ b/util/winutil/s4u/s4u_windows.go
@@ -124,7 +124,7 @@ const (
 //
 // The current OS thread's access token must have SeTcbPrivilege.
 func Login(logf logger.Logf, srcName string, u *user.User, capLevel CapabilityLevel) (sess *Session, err error) {
-	token, err := createToken(srcName, u, tokenTypeIdentification, capLevel)
+	token, err := createToken(srcName, u, tokenTypeImpersonation, capLevel)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This was correct before, I think I just made a copy/paste error when updating that PR.

Updates #12383