### PR TITLE
health,ipn/ipnlocal: hide update warning when auto-updates are enabled

### DIFF
--- a/ipn/ipnlocal/profiles.go
+++ b/ipn/ipnlocal/profiles.go
@@ -448,7 +448,7 @@ func (pm *profileManager) updateHealth() {
 	if !pm.prefs.Valid() {
 		return
 	}
-	pm.health.SetCheckForUpdates(pm.prefs.AutoUpdate().Check)
+	pm.health.SetAutoUpdatePrefs(pm.prefs.AutoUpdate().Check, pm.prefs.AutoUpdate().Apply)
 }
 
 // NewProfile creates and switches to a new unnamed profile. The new profile is


### PR DESCRIPTION
When auto-udpates are enabled, we don't need to nag users to update after a new release, before we release auto-updates.

Updates https://github.com/tailscale/corp/issues/20081