### PR TITLE
appc: fix writing route info

### DIFF
--- a/appc/appconnector.go
+++ b/appc/appconnector.go
@@ -493,6 +493,7 @@ func (e *AppConnector) isAddrKnownLocked(domain string, addr netip.Addr) bool {
 			// record the new address associated with the domain for faster matching in subsequent
 			// requests and for diagnostic records.
 			e.addDomainAddrLocked(domain, addr)
+			e.storeRoutesLocked()
 			return true
 		}
 	}


### PR DESCRIPTION
Before the fix in 7eb8a77ac80b78a2917f0a78a6f4a9189d739797 we were writing route info on every DNS request. Since that fix we have only been writing when we advertise new routes. This means we haven't been writing domain->IP Address associations if the IP Address is covered by a control route. We do want to persist the info associating the domain and IP Address so make sure we also store routes in that case.

Fixes #12673