### PR TITLE
tool/gocross: fix regression detecting when gocross needs rebuild

### DIFF
--- a/tool/gocross/gocross-wrapper.sh
+++ b/tool/gocross/gocross-wrapper.sh
@@ -88,7 +88,7 @@ fi
 # case, cmd/cloner invokes go with GO111MODULE=off at some stage.
 #
 # Anyway, build gocross in a stripped down universe.
-gocross_path="gocross"
+gocross_path="./gocross"
 gocross_ok=0
 wantver="$(git rev-parse HEAD)"
 if [[ -x "$gocross_path" ]]; then

--- a/tool/gocross/gocross_wrapper_test.go
+++ b/tool/gocross/gocross_wrapper_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build linux || darwin
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestGocrossWrapper(t *testing.T) {
+	for i := range 2 { // once to build gocross; second to test it's cached
+		cmd := exec.Command("./gocross-wrapper.sh", "version")
+		cmd.Env = append(os.Environ(), "CI=true", "NOBASHDEBUG=false") // for "set -x" verbosity
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("gocross-wrapper.sh failed: %v\n%s", err, out)
+		}
+		if i > 0 && !strings.Contains(string(out), "gocross_ok=1\n") {
+			t.Errorf("expected to find 'gocross-ok=1'; got output:\n%s", out)
+		}
+	}
+}


### PR DESCRIPTION
Fix regression from #8108 (Mar 2023). Since that change, gocross has always been rebuilt on each run of ./tool/go (gocross-wrapper.sh), adding ~100ms.  (Well, not totally rebuilt; cmd/go's caching still ends up working fine.)

The problem was $gocross_path was just "gocross", which isn't in my path (and "." isn't in my $PATH, as it shouldn't be), so this line was always evaluating to the empty string:

    gotver="$($gocross_path gocross-version 2>/dev/null || echo '')"

The ./gocross is fine because of the earlier `cd "$repo_root"`

Updates tailscale/corp#21262
Updates tailscale/corp#21263
