### PR TITLE
ipn/ipnlocal: allow multiple signature chains from the same SigCredential (cherry-pick) 

### DIFF
--- a/control/controlclient/direct_test.go
+++ b/control/controlclient/direct_test.go
@@ -4,7 +4,6 @@
 package controlclient
 
 import (
-	"crypto/ed25519"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -146,43 +145,4 @@ func TestTsmpPing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-}
-
-func TestDecodeWrappedAuthkey(t *testing.T) {
-	k, isWrapped, sig, priv := decodeWrappedAuthkey("tskey-32mjsdkdsffds9o87dsfkjlh", nil)
-	if want := "tskey-32mjsdkdsffds9o87dsfkjlh"; k != want {
-		t.Errorf("decodeWrappedAuthkey(<unwrapped-key>).key = %q, want %q", k, want)
-	}
-	if isWrapped {
-		t.Error("decodeWrappedAuthkey(<unwrapped-key>).isWrapped = true, want false")
-	}
-	if sig != nil {
-		t.Errorf("decodeWrappedAuthkey(<unwrapped-key>).sig = %v, want nil", sig)
-	}
-	if priv != nil {
-		t.Errorf("decodeWrappedAuthkey(<unwrapped-key>).priv = %v, want nil", priv)
-	}
-
-	k, isWrapped, sig, priv = decodeWrappedAuthkey("tskey-auth-k7UagY1CNTRL-ZZZZZ--TLpAEDA1ggnXuw4/fWnNWUwcoOjLemhOvml1juMl5lhLmY5sBUsj8EWEAfL2gdeD9g8VDw5tgcxCiHGlEb67BgU2DlFzZApi4LheLJraA+pYjTGChVhpZz1iyiBPD+U2qxDQAbM3+WFY0EBlggxmVqG53Hu0Rg+KmHJFMlUhfgzo+AQP6+Kk9GzvJJOs4-k36RdoSFqaoARfQo0UncHAV0t3YTqrkD5r/z2jTrE43GZWobnce7RGD4qYckUyVSF+DOj4BA/r4qT0bO8kk6zg", nil)
-	if want := "tskey-auth-k7UagY1CNTRL-ZZZZZ"; k != want {
-		t.Errorf("decodeWrappedAuthkey(<wrapped-key>).key = %q, want %q", k, want)
-	}
-	if !isWrapped {
-		t.Error("decodeWrappedAuthkey(<wrapped-key>).isWrapped = false, want true")
-	}
-
-	if sig == nil {
-		t.Fatal("decodeWrappedAuthkey(<wrapped-key>).sig = nil, want non-nil signature")
-	}
-	sigHash := sig.SigHash()
-	if !ed25519.Verify(sig.KeyID, sigHash[:], sig.Signature) {
-		t.Error("signature failed to verify")
-	}
-
-	// Make sure the private is correct by using it.
-	someSig := ed25519.Sign(priv, []byte{1, 2, 3, 4})
-	if !ed25519.Verify(sig.WrappingPubkey, []byte{1, 2, 3, 4}, someSig) {
-		t.Error("failed to use priv")
-	}
-
 }

--- a/tka/sig.go
+++ b/tka/sig.go
@@ -313,9 +313,9 @@ type RotationDetails struct {
 	// PrevNodeKeys is a list of node keys which have been rotated out.
 	PrevNodeKeys []key.NodePublic
 
-	// WrappingPubkey is the public key which has been authorized to sign
+	// InitialSig is the first signature in the chain which led to
 	// this rotating signature.
-	WrappingPubkey []byte
+	InitialSig *NodeKeySignature
 }
 
 // rotationDetails returns the RotationDetails for a SigRotation signature.
@@ -339,7 +339,7 @@ func (s *NodeKeySignature) rotationDetails() (*RotationDetails, error) {
 		}
 		nested = nested.Nested
 	}
-	sri.WrappingPubkey = nested.WrappingPubkey
+	sri.InitialSig = nested
 	return sri, nil
 }
 

--- a/tka/sig.go
+++ b/tka/sig.go
@@ -6,6 +6,7 @@ package tka
 import (
 	"bytes"
 	"crypto/ed25519"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	"github.com/hdevalence/ed25519consensus"
 	"golang.org/x/crypto/blake2s"
 	"tailscale.com/types/key"
+	"tailscale.com/types/logger"
 	"tailscale.com/types/tkatype"
 )
 
@@ -378,4 +380,65 @@ func ResignNKS(priv key.NLPrivate, nodeKey key.NodePublic, oldNKS tkatype.Marsha
 	}
 
 	return newSig.Serialize(), nil
+}
+
+// SignByCredential signs a node public key by a private key which has its
+// signing authority delegated by a SigCredential signature. This is used by
+// wrapped auth keys.
+func SignByCredential(privKey []byte, wrapped *NodeKeySignature, nodeKey key.NodePublic) (tkatype.MarshaledSignature, error) {
+	if wrapped.SigKind != SigCredential {
+		return nil, fmt.Errorf("wrapped signature must be a credential, got %v", wrapped.SigKind)
+	}
+
+	nk, err := nodeKey.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("marshalling node-key: %w", err)
+	}
+
+	sig := &NodeKeySignature{
+		SigKind: SigRotation,
+		Pubkey:  nk,
+		Nested:  wrapped,
+	}
+	sigHash := sig.SigHash()
+	sig.Signature = ed25519.Sign(privKey, sigHash[:])
+	return sig.Serialize(), nil
+}
+
+// DecodeWrappedAuthkey separates wrapping information from an authkey, if any.
+// In all cases the authkey is returned, sans wrapping information if any.
+//
+// If the authkey is wrapped, isWrapped returns true, along with the wrapping signature
+// and private key.
+func DecodeWrappedAuthkey(wrappedAuthKey string, logf logger.Logf) (authKey string, isWrapped bool, sig *NodeKeySignature, priv ed25519.PrivateKey) {
+	authKey, suffix, found := strings.Cut(wrappedAuthKey, "--TL")
+	if !found {
+		return wrappedAuthKey, false, nil, nil
+	}
+	sigBytes, privBytes, found := strings.Cut(suffix, "-")
+	if !found {
+		// TODO: propagate these errors to `tailscale up` output?
+		logf("decoding wrapped auth-key: did not find delimiter")
+		return wrappedAuthKey, false, nil, nil
+	}
+
+	rawSig, err := base64.RawStdEncoding.DecodeString(sigBytes)
+	if err != nil {
+		logf("decoding wrapped auth-key: signature decode: %v", err)
+		return wrappedAuthKey, false, nil, nil
+	}
+	rawPriv, err := base64.RawStdEncoding.DecodeString(privBytes)
+	if err != nil {
+		logf("decoding wrapped auth-key: priv decode: %v", err)
+		return wrappedAuthKey, false, nil, nil
+	}
+
+	sig = new(NodeKeySignature)
+	if err := sig.Unserialize(rawSig); err != nil {
+		logf("decoding wrapped auth-key: signature: %v", err)
+		return wrappedAuthKey, false, nil, nil
+	}
+	priv = ed25519.PrivateKey(rawPriv)
+
+	return authKey, true, sig, priv
 }

--- a/tka/sig_test.go
+++ b/tka/sig_test.go
@@ -439,3 +439,42 @@ func TestNodeKeySignatureRotationDetails(t *testing.T) {
 		})
 	}
 }
+
+func TestDecodeWrappedAuthkey(t *testing.T) {
+	k, isWrapped, sig, priv := DecodeWrappedAuthkey("tskey-32mjsdkdsffds9o87dsfkjlh", nil)
+	if want := "tskey-32mjsdkdsffds9o87dsfkjlh"; k != want {
+		t.Errorf("decodeWrappedAuthkey(<unwrapped-key>).key = %q, want %q", k, want)
+	}
+	if isWrapped {
+		t.Error("decodeWrappedAuthkey(<unwrapped-key>).isWrapped = true, want false")
+	}
+	if sig != nil {
+		t.Errorf("decodeWrappedAuthkey(<unwrapped-key>).sig = %v, want nil", sig)
+	}
+	if priv != nil {
+		t.Errorf("decodeWrappedAuthkey(<unwrapped-key>).priv = %v, want nil", priv)
+	}
+
+	k, isWrapped, sig, priv = DecodeWrappedAuthkey("tskey-auth-k7UagY1CNTRL-ZZZZZ--TLpAEDA1ggnXuw4/fWnNWUwcoOjLemhOvml1juMl5lhLmY5sBUsj8EWEAfL2gdeD9g8VDw5tgcxCiHGlEb67BgU2DlFzZApi4LheLJraA+pYjTGChVhpZz1iyiBPD+U2qxDQAbM3+WFY0EBlggxmVqG53Hu0Rg+KmHJFMlUhfgzo+AQP6+Kk9GzvJJOs4-k36RdoSFqaoARfQo0UncHAV0t3YTqrkD5r/z2jTrE43GZWobnce7RGD4qYckUyVSF+DOj4BA/r4qT0bO8kk6zg", nil)
+	if want := "tskey-auth-k7UagY1CNTRL-ZZZZZ"; k != want {
+		t.Errorf("decodeWrappedAuthkey(<wrapped-key>).key = %q, want %q", k, want)
+	}
+	if !isWrapped {
+		t.Error("decodeWrappedAuthkey(<wrapped-key>).isWrapped = false, want true")
+	}
+
+	if sig == nil {
+		t.Fatal("decodeWrappedAuthkey(<wrapped-key>).sig = nil, want non-nil signature")
+	}
+	sigHash := sig.SigHash()
+	if !ed25519.Verify(sig.KeyID, sigHash[:], sig.Signature) {
+		t.Error("signature failed to verify")
+	}
+
+	// Make sure the private is correct by using it.
+	someSig := ed25519.Sign(priv, []byte{1, 2, 3, 4})
+	if !ed25519.Verify(sig.WrappingPubkey, []byte{1, 2, 3, 4}, someSig) {
+		t.Error("failed to use priv")
+	}
+
+}


### PR DESCRIPTION
Cherry-pick #12638 into the stable release branch.

Updates https://github.com/tailscale/corp/issues/19764