### PR TITLE
net/dns: fix broken dns benchmark tests

### DIFF
--- a/net/dns/resolver/forwarder.go
+++ b/net/dns/resolver/forwarder.go
@@ -224,11 +224,12 @@ func newForwarder(logf logger.Logf, netMon *netmon.Monitor, linkSel ForwardLinkS
 		panic("nil netMon")
 	}
 	f := &forwarder{
-		logf:         logger.WithPrefix(logf, "forward: "),
-		netMon:       netMon,
-		linkSel:      linkSel,
-		dialer:       dialer,
-		controlKnobs: knobs,
+		logf:                    logger.WithPrefix(logf, "forward: "),
+		netMon:                  netMon,
+		linkSel:                 linkSel,
+		dialer:                  dialer,
+		controlKnobs:            knobs,
+		missingUpstreamRecovery: func() {},
 	}
 	f.ctx, f.ctxCancel = context.WithCancel(context.Background())
 	return f


### PR DESCRIPTION
Updates tailscale/corp#20677

The recover function wasn't getting set in the benchmark tests.  Now defaults to an empty func to things don't blow up if it's not set.