### PR TITLE
cmd/tailscale/cli: exit node filter should display all exit node options

### DIFF
--- a/cmd/tailscale/cli/exitnode_test.go
+++ b/cmd/tailscale/cli/exitnode_test.go
@@ -219,7 +219,7 @@ func TestFilterFormatAndSortExitNodes(t *testing.T) {
 						{
 							Name: "Rainier",
 							Peers: []*ipnstate.PeerStatus{
-								ps[2],
+								ps[2], ps[3],
 							},
 						},
 					},


### PR DESCRIPTION
This change expands the `exit-node list -filter` command to display all location based exit nodes for the filtered country. This allows users to switch to alternative servers when our recommended exit node is not working as intended.

This change also makes the country filter matching case insensitive, e.g. both USA and usa will work.

Before:
![Screenshot from 2024-07-03 11-02-14](https://github.com/tailscale/tailscale/assets/46385858/624f1385-a269-4ce1-932f-24c6ad54e936)

After: 

![Screenshot from 2024-07-03 11-01-54](https://github.com/tailscale/tailscale/assets/46385858/247ebb1d-34c9-4255-8409-7342b365e94a)


Updates #12698