### PR TITLE
health: send ImpactsConnectivity value over LocalAPI

### DIFF
--- a/health/state.go
+++ b/health/state.go
@@ -23,13 +23,14 @@ type State struct {
 // Representation contains information to be shown to the user to inform them
 // that a Warnable is currently unhealthy.
 type UnhealthyState struct {
-	WarnableCode WarnableCode
-	Severity     Severity
-	Title        string
-	Text         string
-	BrokenSince  *time.Time     `json:",omitempty"`
-	Args         Args           `json:",omitempty"`
-	DependsOn    []WarnableCode `json:",omitempty"`
+	WarnableCode        WarnableCode
+	Severity            Severity
+	Title               string
+	Text                string
+	BrokenSince         *time.Time     `json:",omitempty"`
+	Args                Args           `json:",omitempty"`
+	DependsOn           []WarnableCode `json:",omitempty"`
+	ImpactsConnectivity bool           `json:",omitempty"`
 }
 
 // unhealthyState returns a unhealthyState of the Warnable given its current warningState.
@@ -54,13 +55,14 @@ func (w *Warnable) unhealthyState(ws *warningState) *UnhealthyState {
 	}
 
 	return &UnhealthyState{
-		WarnableCode: w.Code,
-		Severity:     w.Severity,
-		Title:        w.Title,
-		Text:         text,
-		BrokenSince:  &ws.BrokenSince,
-		Args:         ws.Args,
-		DependsOn:    dependsOnWarnableCodes,
+		WarnableCode:        w.Code,
+		Severity:            w.Severity,
+		Title:               w.Title,
+		Text:                text,
+		BrokenSince:         &ws.BrokenSince,
+		Args:                ws.Args,
+		DependsOn:           dependsOnWarnableCodes,
+		ImpactsConnectivity: w.ImpactsConnectivity,
 	}
 }
 

--- a/health/warnings.go
+++ b/health/warnings.go
@@ -94,13 +94,13 @@ var LoginStateWarnable = Register(&Warnable{
 	},
 })
 
-// notInMapPollWarnable is a Warnable that warns the user that they cannot connect to the control server.
+// notInMapPollWarnable is a Warnable that warns the user that we are using a stale network map.
 var notInMapPollWarnable = Register(&Warnable{
 	Code:      "not-in-map-poll",
-	Title:     "Cannot connect to control server",
+	Title:     "Out of sync",
 	Severity:  SeverityMedium,
 	DependsOn: []*Warnable{NetworkStatusWarnable},
-	Text:      StaticMessage("Cannot connect to the control server (not in map poll). Check your Internet connection."),
+	Text:      StaticMessage("Unable to connect to the Tailscale coordination server to synchronize the state of your tailnet. Peer reachability might degrade over time."),
 })
 
 // noDERPHomeWarnable is a Warnable that warns the user that Tailscale doesn't have a home DERP.


### PR DESCRIPTION
Updates tailscale/tailscale#4136

We should make sure to send the value of ImpactsConnectivity over to the clients using LocalAPI as they need it to display alerts in the GUI properly.