### PR TITLE
posture: add network hardware addresses to posture identity

### DIFF
--- a/posture/hwaddr.go
+++ b/posture/hwaddr.go
@@ -1,0 +1,26 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package posture
+
+import (
+	"net/netip"
+	"slices"
+
+	"tailscale.com/net/netmon"
+)
+
+// GetHardwareAddrs returns the hardware addresses of all non-loopback
+// network interfaces.
+func GetHardwareAddrs() (hwaddrs []string, err error) {
+	err = netmon.ForeachInterface(func(i netmon.Interface, _ []netip.Prefix) {
+		if i.IsLoopback() {
+			return
+		}
+		if a := i.HardwareAddr.String(); a != "" {
+			hwaddrs = append(hwaddrs, a)
+		}
+	})
+	slices.Sort(hwaddrs)
+	return
+}

--- a/tailcfg/c2ntypes.go
+++ b/tailcfg/c2ntypes.go
@@ -55,12 +55,16 @@ type C2NUpdateResponse struct {
 	Started bool
 }
 
-// C2NPostureIdentityResponse contains either a set of identifying serial number
-// from the client or a boolean indicating that the machine has opted out of
-// posture collection.
+// C2NPostureIdentityResponse contains either a set of identifying serial
+// numbers and hardware addresses from the client, or a boolean flag
+// indicating that the machine has opted out of posture collection.
 type C2NPostureIdentityResponse struct {
 	// SerialNumbers is a list of serial numbers of the client machine.
 	SerialNumbers []string `json:",omitempty"`
+
+	// IfaceHardwareAddrs is a list of hardware addresses (MAC addresses)
+	// of the client machine's network interfaces.
+	IfaceHardwareAddrs []string `json:",omitempty"`
 
 	// PostureDisabled indicates if the machine has opted out of
 	// device posture collection.


### PR DESCRIPTION
If an optional `hwaddrs` URL parameter is present, add network interface hardware addresses to the posture identity response.

Just like with serial numbers, this requires client opt-in via MDM or `tailscale set --posture-checking=true`
(https://tailscale.com/kb/1326/device-identity)

Updates tailscale/corp#21371