### PR TITLE
control/controlknobs,tailcfg,wgengine/magicsock: remove DRPO shutoff switch

### DIFF
--- a/control/controlknobs/controlknobs.go
+++ b/control/controlknobs/controlknobs.go
@@ -19,10 +19,6 @@ type Knobs struct {
 	// DisableUPnP indicates whether to attempt UPnP mapping.
 	DisableUPnP atomic.Bool
 
-	// DisableDRPO is whether control says to disable the
-	// DERP route optimization (Issue 150).
-	DisableDRPO atomic.Bool
-
 	// KeepFullWGConfig is whether we should disable the lazy wireguard
 	// programming and instead give WireGuard the full netmap always, even for
 	// idle peers.
@@ -110,7 +106,6 @@ func (k *Knobs) UpdateFromNodeAttributes(capMap tailcfg.NodeCapMap) {
 	has := capMap.Contains
 	var (
 		keepFullWG                           = has(tailcfg.NodeAttrDebugDisableWGTrim)
-		disableDRPO                          = has(tailcfg.NodeAttrDebugDisableDRPO)
 		disableUPnP                          = has(tailcfg.NodeAttrDisableUPnP)
 		randomizeClientPort                  = has(tailcfg.NodeAttrRandomizeClientPort)
 		disableDeltaUpdates                  = has(tailcfg.NodeAttrDisableDeltaUpdates)
@@ -136,7 +131,6 @@ func (k *Knobs) UpdateFromNodeAttributes(capMap tailcfg.NodeCapMap) {
 	}
 
 	k.KeepFullWGConfig.Store(keepFullWG)
-	k.DisableDRPO.Store(disableDRPO)
 	k.DisableUPnP.Store(disableUPnP)
 	k.RandomizeClientPort.Store(randomizeClientPort)
 	k.OneCGNAT.Store(oneCGNAT)
@@ -163,7 +157,6 @@ func (k *Knobs) AsDebugJSON() map[string]any {
 	}
 	return map[string]any{
 		"DisableUPnP":                          k.DisableUPnP.Load(),
-		"DisableDRPO":                          k.DisableDRPO.Load(),
 		"KeepFullWGConfig":                     k.KeepFullWGConfig.Load(),
 		"RandomizeClientPort":                  k.RandomizeClientPort.Load(),
 		"OneCGNAT":                             k.OneCGNAT.Load(),

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -2203,10 +2203,6 @@ const (
 	// always giving WireGuard the full netmap, even for idle peers.
 	NodeAttrDebugDisableWGTrim NodeCapability = "debug-no-wg-trim"
 
-	// NodeAttrDebugDisableDRPO disables the DERP Return Path Optimization.
-	// See Issue 150.
-	NodeAttrDebugDisableDRPO NodeCapability = "debug-disable-drpo"
-
 	// NodeAttrDisableSubnetsIfPAC controls whether subnet routers should be
 	// disabled if WPAD is present on the network.
 	NodeAttrDisableSubnetsIfPAC NodeCapability = "debug-disable-subnets-if-pac"

--- a/wgengine/magicsock/debugknobs.go
+++ b/wgengine/magicsock/debugknobs.go
@@ -20,9 +20,6 @@ var (
 	// debugOmitLocalAddresses removes all local interface addresses
 	// from magicsock's discovered local endpoints. Used in some tests.
 	debugOmitLocalAddresses = envknob.RegisterBool("TS_DEBUG_OMIT_LOCAL_ADDRS")
-	// debugUseDerpRoute temporarily (2020-03-22) controls whether DERP
-	// reverse routing is enabled (Issue 150).
-	debugUseDerpRoute = envknob.RegisterOptBool("TS_DEBUG_ENABLE_DERP_ROUTE")
 	// logDerpVerbose logs all received DERP packets, including their
 	// full payload.
 	logDerpVerbose = envknob.RegisterBool("TS_DEBUG_DERP")

--- a/wgengine/magicsock/debugknobs_stubs.go
+++ b/wgengine/magicsock/debugknobs_stubs.go
@@ -22,8 +22,6 @@ func debugEnableSilentDisco() bool     { return false }
 func debugSendCallMeUnknownPeer() bool { return false }
 func debugPMTUD() bool                 { return false }
 func debugUseDERPAddr() string         { return "" }
-func debugUseDerpRouteEnv() string     { return "" }
-func debugUseDerpRoute() opt.Bool      { return "" }
 func debugEnablePMTUD() opt.Bool       { return "" }
 func debugRingBufferMaxSizeBytes() int { return 0 }
 func inTest() bool                     { return false }


### PR DESCRIPTION
The DERP Return Path Optimization (DRPO) is over four years old (and
on by default for over two) and we haven't had problems, so time to
remove the emergency shutoff code (controlknob) which we've never
used. The controlknobs are only meant for new features, to mitigate
risk. But we don't want to keep them forever, as they kinda pollute
the code.

Updates #150
