### PR TITLE
util/osuser: run getent on non-Linux Unixes

### DIFF
--- a/util/osuser/user.go
+++ b/util/osuser/user.go
@@ -51,8 +51,10 @@ func LookupByUsername(username string) (*user.User, error) {
 type lookupStd func(string) (*user.User, error)
 
 func lookup(usernameOrUID string, std lookupStd, wantShell bool) (*user.User, string, error) {
-	// TODO(awly): we should use genet on more platforms, like FreeBSD.
-	if runtime.GOOS != "linux" {
+	// Skip getent entirely on Non-Unix platforms that won't ever have it.
+	// (Using HasPrefix for "wasip1", anticipating that WASI support will
+	// move beyond "preview 1" some day.)
+	if runtime.GOOS == "windows" || runtime.GOOS == "js" || strings.HasPrefix(runtime.GOOS, "wasi") {
 		u, err := std(usernameOrUID)
 		return u, "", err
 	}
@@ -128,6 +130,14 @@ func userLookupGetent(usernameOrUID string, std lookupStd) (*user.User, string, 
 	f := strings.SplitN(strings.TrimSpace(string(out)), ":", 10)
 	for len(f) < 7 {
 		f = append(f, "")
+	}
+	var mandatoryFields = []int{0, 2, 3, 5}
+	for _, v := range mandatoryFields {
+		if f[v] == "" {
+			log.Printf("getent for user %q returned invalid output: %q", usernameOrUID, out)
+			u, err := std(usernameOrUID)
+			return u, "", err
+		}
 	}
 	return &user.User{
 		Username: f[0],


### PR DESCRIPTION
Remove the restriction that getent is skipped on non-Linux unixes. Improve validation of the parsed output from getent, in case unknown systems return unusable information.

This is a long-standing TODO; Tailscale only uses getent on Linux to get the correct login shell: https://github.com/tailscale/tailscale/blob/d2fef01206cd7a96d684f9c69ba9e767de824ab4/util/osuser/user.go#L54-L58

There is a special workaround for macOS/Darwin in `ssh/tailssh`: https://github.com/tailscale/tailscale/blob/d2fef01206cd7a96d684f9c69ba9e767de824ab4/ssh/tailssh/user.go#L59-L61
...but other Unixes end up falling back to `/bin/sh` because the Go standard library functions don't return shell information.

`getent` isn't POSIX but is available on many, many systems. It makes sense to try it and handle error cases and unusable output before falling back to the standard library functions.

Fixes #12730.