### PR TITLE
wgengine/magicsock: add debug envknob for injecting an endpoint

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -1184,6 +1184,7 @@ const (
 	EndpointSTUN           = EndpointType(2)
 	EndpointPortmapped     = EndpointType(3)
 	EndpointSTUN4LocalPort = EndpointType(4) // hard NAT: STUN'ed IPv4 address + local fixed port
+	EndpointExplicitConf   = EndpointType(5) // explicitly configured (routing to be done by client)
 )
 
 func (et EndpointType) String() string {
@@ -1198,6 +1199,8 @@ func (et EndpointType) String() string {
 		return "portmap"
 	case EndpointSTUN4LocalPort:
 		return "stun4localport"
+	case EndpointExplicitConf:
+		return "explicitconf"
 	}
 	return "other"
 }

--- a/wgengine/magicsock/debugknobs.go
+++ b/wgengine/magicsock/debugknobs.go
@@ -6,6 +6,10 @@
 package magicsock
 
 import (
+	"log"
+	"net/netip"
+	"sync"
+
 	"tailscale.com/envknob"
 )
 
@@ -68,3 +72,18 @@ var (
 // checked every time at runtime, because tests set this after program
 // startup.
 func inTest() bool { return envknob.Bool("IN_TS_TEST") }
+
+// pretendpoint returns TS_DEBUG_PRETENDPOINT as an AddrPort, if set.
+// See https://github.com/tailscale/tailscale/issues/12578 and
+// https://github.com/tailscale/tailscale/pull/12735.
+var pretendpoint = sync.OnceValue(func() (ap netip.AddrPort) {
+	s := envknob.String("TS_DEBUG_PRETENDPOINT")
+	if s == "" {
+		return
+	}
+	ap, err := netip.ParseAddrPort(s)
+	if err != nil {
+		log.Printf("ignoring invalid TS_DEBUG_PRETENDPOINT %q: %v", s, err)
+	}
+	return ap
+})

--- a/wgengine/magicsock/debugknobs_stubs.go
+++ b/wgengine/magicsock/debugknobs_stubs.go
@@ -5,7 +5,11 @@
 
 package magicsock
 
-import "tailscale.com/types/opt"
+import (
+	"net/netip"
+
+	"tailscale.com/types/opt"
+)
 
 // All knobs are disabled on iOS and Wasm.
 //
@@ -26,3 +30,4 @@ func debugEnablePMTUD() opt.Bool       { return "" }
 func debugRingBufferMaxSizeBytes() int { return 0 }
 func inTest() bool                     { return false }
 func debugPeerMap() bool               { return false }
+func pretendpoint() netip.AddrPort     { return netip.AddrPort{} }

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -919,6 +919,12 @@ func (c *Conn) determineEndpoints(ctx context.Context) ([]tailcfg.Endpoint, erro
 		}
 	}
 
+	// Temporarily (2024-07-08) during investigations, allow setting
+	// a pretend endpoint for testing NAT traversal scenarios.
+	// TODO(bradfitz): probably promote this to the config file.
+	// https://github.com/tailscale/tailscale/issues/12578
+	addAddr(pretendpoint(), tailcfg.EndpointExplicitConf)
+
 	// Update our set of endpoints by adding any endpoints that we
 	// previously found but haven't expired yet. This also updates the
 	// cache with the set of endpoints discovered in this function.


### PR DESCRIPTION
For testing. Lee wants to play with 'AWS Global Accelerator Custom
Routing with Amazon Elastic Kubernetes Service'. If this works well
enough, we can promote it.

Updates #12578
