### PR TITLE
clientupdate: return true for CanAutoUpdate for macsys

### DIFF
--- a/clientupdate/clientupdate.go
+++ b/clientupdate/clientupdate.go
@@ -248,6 +248,11 @@ func (up *Updater) getUpdateFunction() (fn updateFunction, canAutoUpdate bool) {
 // CanAutoUpdate reports whether auto-updating via the clientupdate package
 // is supported for the current os/distro.
 func CanAutoUpdate() bool {
+	if version.IsMacSysExt() {
+		// Macsys uses Sparkle for auto-updates, which doesn't have an update
+		// function in this package.
+		return true
+	}
 	_, canAutoUpdate := (&Updater{}).getUpdateFunction()
 	return canAutoUpdate
 }

--- a/cmd/tailscale/cli/set.go
+++ b/cmd/tailscale/cli/set.go
@@ -210,6 +210,9 @@ func runSet(ctx context.Context, args []string) (retErr error) {
 		}
 	}
 	if maskedPrefs.AutoUpdateSet.ApplySet {
+		if !clientupdate.CanAutoUpdate() {
+			return errors.New("automatic updates are not supported on this platform")
+		}
 		// On macsys, tailscaled will set the Sparkle auto-update setting. It
 		// does not use clientupdate.
 		if version.IsMacSysExt() {
@@ -220,10 +223,6 @@ func runSet(ctx context.Context, args []string) (retErr error) {
 			out, err := exec.Command("defaults", "write", "io.tailscale.ipn.macsys", "SUAutomaticallyUpdate", apply).CombinedOutput()
 			if err != nil {
 				return fmt.Errorf("failed to enable automatic updates: %v, %q", err, out)
-			}
-		} else {
-			if !clientupdate.CanAutoUpdate() {
-				return errors.New("automatic updates are not supported on this platform")
 			}
 		}
 	}

--- a/ipn/ipnlocal/autoupdate.go
+++ b/ipn/ipnlocal/autoupdate.go
@@ -11,6 +11,7 @@ import (
 
 	"tailscale.com/clientupdate"
 	"tailscale.com/ipn"
+	"tailscale.com/version"
 )
 
 func (b *LocalBackend) stopOfflineAutoUpdate() {
@@ -28,6 +29,10 @@ func (b *LocalBackend) maybeStartOfflineAutoUpdate(prefs ipn.PrefsView) {
 	// AutoUpdate.Apply field in prefs can only be true for platforms that
 	// support auto-updates. But check it here again, just in case.
 	if !clientupdate.CanAutoUpdate() {
+		return
+	}
+	// On macsys, auto-updates are managed by Sparkle.
+	if version.IsMacSysExt() {
 		return
 	}
 

--- a/ipn/ipnlocal/c2n.go
+++ b/ipn/ipnlocal/c2n.go
@@ -355,7 +355,7 @@ func (b *LocalBackend) newC2NUpdateResponse() tailcfg.C2NUpdateResponse {
 	prefs := b.Prefs().AutoUpdate()
 	return tailcfg.C2NUpdateResponse{
 		Enabled:   envknob.AllowsRemoteUpdate() || prefs.Apply.EqualBool(true),
-		Supported: clientupdate.CanAutoUpdate(),
+		Supported: clientupdate.CanAutoUpdate() && !version.IsMacSysExt(),
 	}
 }
 


### PR DESCRIPTION
While `clientupdate.Updater` won't be able to apply updates on macsys, we use `clientupdate.CanAutoUpdate` to gate the EditPrefs endpoint in localAPI. We should allow the GUI client to set AutoUpdate.Apply on macsys for it to properly get reported to the control plane. This also allows the tailnet-wide default for auto-updates to propagate to macsys clients.

Updates https://github.com/tailscale/corp/issues/21339