### PR TITLE
wgengine/magicsock: allow a CSV list for pretendpoint

### DIFF
--- a/wgengine/magicsock/debugknobs_stubs.go
+++ b/wgengine/magicsock/debugknobs_stubs.go
@@ -30,4 +30,4 @@ func debugEnablePMTUD() opt.Bool       { return "" }
 func debugRingBufferMaxSizeBytes() int { return 0 }
 func inTest() bool                     { return false }
 func debugPeerMap() bool               { return false }
-func pretendpoint() netip.AddrPort     { return netip.AddrPort{} }
+func pretendpoints() []netip.AddrPort  { return []netip.AddrPort{} }


### PR DESCRIPTION
Load Balancers often have more than one ingress IP, so allowing us to add multiple means we can offer multiple options.

Updates #12578