### PR TITLE
cmd/k8s-operator: send container name to session recorder

### DIFF
--- a/cmd/k8s-operator/spdy-hijacker.go
+++ b/cmd/k8s-operator/spdy-hijacker.go
@@ -117,6 +117,7 @@ func (h *spdyHijacker) setUpRecording(ctx context.Context, conn net.Conn) (net.C
 		Kubernetes: &Kubernetes{
 			PodName:   h.pod,
 			Namespace: h.ns,
+			Container: strings.Join(qp["container"], " "),
 		},
 	}
 	if !h.who.Node.IsTagged() {
@@ -198,6 +199,7 @@ type CastHeader struct {
 type Kubernetes struct {
 	PodName   string
 	Namespace string
+	Container string
 }
 
 func closeConnWithWarning(conn net.Conn, msg string) error {


### PR DESCRIPTION
Adds the name of the container that is being exec-d to CastHeader, so that it gets sent to the session recorder.

Updates tailscale/corp#19821