### PR TITLE
wgengine/magicsock: allow a CSV list for pretendpoint

### DIFF
--- a/wgengine/magicsock/debugknobs_stubs.go
+++ b/wgengine/magicsock/debugknobs_stubs.go
@@ -30,4 +30,4 @@ func debugEnablePMTUD() opt.Bool       { return "" }
 func debugRingBufferMaxSizeBytes() int { return 0 }
 func inTest() bool                     { return false }
 func debugPeerMap() bool               { return false }
-func pretendpoint() netip.AddrPort     { return netip.AddrPort{} }
+func pretendpoints() []netip.AddrPort  { return []netip.AddrPort{} }

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -920,10 +920,12 @@ func (c *Conn) determineEndpoints(ctx context.Context) ([]tailcfg.Endpoint, erro
 	}
 
 	// Temporarily (2024-07-08) during investigations, allow setting
-	// a pretend endpoint for testing NAT traversal scenarios.
+	// pretend endpoint(s) for testing NAT traversal scenarios.
 	// TODO(bradfitz): probably promote this to the config file.
 	// https://github.com/tailscale/tailscale/issues/12578
-	addAddr(pretendpoint(), tailcfg.EndpointExplicitConf)
+	for _, ap := range pretendpoints() {
+		addAddr(ap, tailcfg.EndpointExplicitConf)
+	}
 
 	// Update our set of endpoints by adding any endpoints that we
 	// previously found but haven't expired yet. This also updates the


### PR DESCRIPTION
Load Balancers often have more than one ingress IP, so allowing us to
add multiple means we can offer multiple options.

Updates #12578
