### PR TITLE
publicapi: add note that API docs have moved to existing docs files

### DIFF
--- a/api.md
+++ b/api.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> The Tailscale API documentation has moved to https://tailscale.com/api
+
 # Tailscale API
 
 The Tailscale API documentation is located in **[tailscale/publicapi](./publicapi/readme.md#tailscale-api)**.

--- a/publicapi/device.md
+++ b/publicapi/device.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> The Tailscale API documentation has moved to https://tailscale.com/api
+
 # Device
 
 A Tailscale device (sometimes referred to as _node_ or _machine_), is any computer or mobile device that joins a tailnet.

--- a/publicapi/deviceinvites.md
+++ b/publicapi/deviceinvites.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> The Tailscale API documentation has moved to https://tailscale.com/api
+
 # Device invites
 
 A device invite is an invitation that shares a device with an external user (a user not in the device's tailnet).

--- a/publicapi/readme.md
+++ b/publicapi/readme.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> The Tailscale API documentation has moved to https://tailscale.com/api
+
 # Tailscale API
 
 The Tailscale API is a (mostly) RESTful API. Typically, both `POST` bodies and responses are JSON-encoded.

--- a/publicapi/tailnet.md
+++ b/publicapi/tailnet.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> The Tailscale API documentation has moved to https://tailscale.com/api
+
 # Tailnet
 
 A tailnet is your private network, composed of all the devices on it and their configuration.

--- a/publicapi/userinvites.md
+++ b/publicapi/userinvites.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> The Tailscale API documentation has moved to https://tailscale.com/api
+
 # User invites
 
 A user invite is an active invitation that lets a user join a tailnet with a pre-assigned [user role](https://tailscale.com/kb/1138/user-roles).


### PR DESCRIPTION
Add note that API docs have moved to `https://tailscale.com/api` to the top of existing API docs markdown files.

Updates https://github.com/tailscale/corp/issues/1301