### PR TITLE
net/dns/publicdns: remove additional information in DOH URL passed to IPv6 address generation for controlD.

### DIFF
--- a/net/dns/publicdns/publicdns.go
+++ b/net/dns/publicdns/publicdns.go
@@ -10,6 +10,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"log"
 	"math/big"
 	"net/netip"
 	"sort"
@@ -122,6 +123,9 @@ func DoHIPsOfBase(dohBase string) []netip.Addr {
 		}
 	}
 	if pathStr, ok := strings.CutPrefix(dohBase, controlDBase); ok {
+		if i := strings.IndexFunc(pathStr, isSlashOrQuestionMark); i != -1 {
+			pathStr = pathStr[:i]
+		}
 		return []netip.Addr{
 			controlDv4One,
 			controlDv4Two,
@@ -318,7 +322,10 @@ func nextDNSv6Gen(ip netip.Addr, id []byte) netip.Addr {
 // e.g. https://dns.controld.com/hyq3ipr2ct
 func controlDv6Gen(ip netip.Addr, id string) netip.Addr {
 	b := make([]byte, 8)
-	decoded, _ := strconv.ParseUint(id, 36, 64)
+	decoded, err := strconv.ParseUint(id, 36, 64)
+	if err != nil {
+		log.Printf("controlDv6Gen: failed to parse id %q: %v", id, err)
+	}
 	binary.BigEndian.PutUint64(b, decoded)
 	a := ip.AsSlice()
 	copy(a[6:14], b)

--- a/net/dns/publicdns/publicdns_test.go
+++ b/net/dns/publicdns/publicdns_test.go
@@ -134,6 +134,15 @@ func TestDoHIPsOfBase(t *testing.T) {
 				"2606:1a40:1:ffff:ffff:ffff:ffff:0",
 			),
 		},
+		{
+			base: "https://dns.controld.com/hyq3ipr2ct/test-host-name",
+			want: ips(
+				"76.76.2.22",
+				"76.76.10.22",
+				"2606:1a40:0:6:7b5b:5949:35ad:0",
+				"2606:1a40:1:6:7b5b:5949:35ad:0",
+			),
+		},
 	}
 	for _, tt := range tests {
 		got := DoHIPsOfBase(tt.base)


### PR DESCRIPTION
This commit truncates any additional information (mainly hostnames) that's passed to controlD via DOH URL in `DoHIPsOfBase`. This change is to make sure only resolverID is passed to `controlDv6Gen` but not the additional information.

Before the  change, `DoHIPsOfBase` woud try to pass something like `abc123def45/kevin-macbook` to `controlDv6Gen` and parse it as a base-36 int. `controlDv6Gen` then swallows error and pretends nothing happens while returning empty ipv6 address.

Updates: #7946