### PR TITLE
health: support delayed Warnable visibility

### DIFF
--- a/health/health_test.go
+++ b/health/health_test.go
@@ -162,6 +162,53 @@ func TestWatcher(t *testing.T) {
 	}
 }
 
+// TestWatcherWithTimeToVisible tests that a registered watcher function gets called with the correct
+// Warnable and non-nil/nil UnhealthyState upon setting a Warnable to unhealthy/healthy, but the Warnable
+// has a TimeToVisible set, which means that a watcher should only be notified of an unhealthy state after
+// the TimeToVisible duration has passed.
+func TestSetUnhealthyWithTimeToVisible(t *testing.T) {
+	ht := Tracker{}
+	mw := Register(&Warnable{
+		Code:                "test-warnable-3-secs-to-visible",
+		Title:               "Test Warnable with 3 seconds to visible",
+		Text:                StaticMessage("Hello world"),
+		TimeToVisible:       2 * time.Second,
+		ImpactsConnectivity: true,
+	})
+	defer unregister(mw)
+
+	becameUnhealthy := make(chan struct{})
+	becameHealthy := make(chan struct{})
+
+	watchFunc := func(w *Warnable, us *UnhealthyState) {
+		if w != mw {
+			t.Fatalf("watcherFunc was called, but with an unexpected Warnable: %v, want: %v", w, w)
+		}
+
+		if us != nil {
+			t.Logf("watcherFunc was called with an UnhealthyState: %v", us)
+			becameUnhealthy <- struct{}{}
+		} else {
+			t.Logf("watcherFunc was called with an healthy state: %v", us)
+			becameHealthy <- struct{}{}
+		}
+	}
+
+	ht.RegisterWatcher(watchFunc)
+	ht.SetUnhealthy(mw, Args{ArgError: "Hello world"})
+
+	select {
+	case <-becameUnhealthy:
+		// Test failed because the watcher got notified of an unhealthy state
+		t.Fatalf("watcherFunc was called with an unhealthy state")
+	case <-becameHealthy:
+		// Test failed because the watcher got of a healthy state
+		t.Fatalf("watcherFunc was called with a healthy state")
+	case <-time.After(1 * time.Second):
+		// As expected, watcherFunc still had not been called after 1 second
+	}
+}
+
 func TestRegisterWarnablePanicsWithDuplicate(t *testing.T) {
 	w := &Warnable{
 		Code: "test-warnable-1",

--- a/health/state.go
+++ b/health/state.go
@@ -20,7 +20,7 @@ type State struct {
 	Warnings map[WarnableCode]UnhealthyState
 }
 
-// Representation contains information to be shown to the user to inform them
+// UnhealthyState contains information to be shown to the user to inform them
 // that a Warnable is currently unhealthy.
 type UnhealthyState struct {
 	WarnableCode        WarnableCode
@@ -86,6 +86,10 @@ func (t *Tracker) CurrentState() *State {
 	wm := map[WarnableCode]UnhealthyState{}
 
 	for w, ws := range t.warnableVal {
+		if !w.IsVisible(ws) {
+			// Skip invisible Warnables.
+			continue
+		}
 		wm[w.Code] = *w.unhealthyState(ws)
 	}
 

--- a/health/warnings.go
+++ b/health/warnings.go
@@ -59,6 +59,7 @@ var NetworkStatusWarnable = Register(&Warnable{
 	Severity:            SeverityMedium,
 	Text:                StaticMessage("Tailscale cannot connect because the network is down. Check your Internet connection."),
 	ImpactsConnectivity: true,
+	TimeToVisible:       5 * time.Second,
 })
 
 // IPNStateWarnable is a Warnable that warns the user that Tailscale is stopped.
@@ -101,6 +102,8 @@ var notInMapPollWarnable = Register(&Warnable{
 	Severity:  SeverityMedium,
 	DependsOn: []*Warnable{NetworkStatusWarnable},
 	Text:      StaticMessage("Unable to connect to the Tailscale coordination server to synchronize the state of your tailnet. Peer reachability might degrade over time."),
+	// 8 minutes reflects a maximum maintenance window for the coordination server.
+	TimeToVisible: 8 * time.Minute,
 })
 
 // noDERPHomeWarnable is a Warnable that warns the user that Tailscale doesn't have a home DERP.
@@ -111,6 +114,7 @@ var noDERPHomeWarnable = Register(&Warnable{
 	DependsOn:           []*Warnable{NetworkStatusWarnable},
 	Text:                StaticMessage("Tailscale could not connect to any relay server. Check your Internet connection."),
 	ImpactsConnectivity: true,
+	TimeToVisible:       10 * time.Second,
 })
 
 // noDERPConnectionWarnable is a Warnable that warns the user that Tailscale couldn't connect to a specific DERP server.
@@ -127,6 +131,7 @@ var noDERPConnectionWarnable = Register(&Warnable{
 		}
 	},
 	ImpactsConnectivity: true,
+	TimeToVisible:       10 * time.Second,
 })
 
 // derpTimeoutWarnable is a Warnable that warns the user that Tailscale hasn't heard from the home DERP region for a while.


### PR DESCRIPTION
Updates tailscale/tailscale#4136

To reduce the likelihood of presenting spurious warnings, add the ability to delay the visibility of certain Warnables, based on a TimeToVisible time.Duration field on each Warnable. The default is zero, meaning that a Warnable is immediately visible to the user when it enters an unhealthy state. Watchers of the Tracker are only notified via their callback once an unhealthy Warnable becomes visible.