### PR TITLE
health: drop unnecessary logging in TestSetUnhealthyWithTimeToVisible

### DIFF
--- a/health/health_test.go
+++ b/health/health_test.go
@@ -186,10 +186,8 @@ func TestSetUnhealthyWithTimeToVisible(t *testing.T) {
 		}
 
 		if us != nil {
-			t.Logf("watcherFunc was called with an UnhealthyState: %v", us)
 			becameUnhealthy <- struct{}{}
 		} else {
-			t.Logf("watcherFunc was called with an healthy state: %v", us)
 			becameHealthy <- struct{}{}
 		}
 	}


### PR DESCRIPTION
Fixes tailscale/tailscale#12794

We were printing some leftover debug logs within a callback function that would be executed after the test completion, causing the test to fail. This change drops the log calls to address the issue.