### PR TITLE
log/sockstatlog: don't block for more than 5s on shutdown

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -730,7 +730,9 @@ func (b *LocalBackend) Shutdown() {
 	b.webClientShutdown()
 
 	if b.sockstatLogger != nil {
-		b.sockstatLogger.Shutdown()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		b.sockstatLogger.Shutdown(ctx)
 	}
 	if b.peerAPIServer != nil {
 		b.peerAPIServer.taildrop.Shutdown()

--- a/log/sockstatlog/logger.go
+++ b/log/sockstatlog/logger.go
@@ -242,12 +242,12 @@ func (l *Logger) Flush() {
 	l.logger.StartFlush()
 }
 
-func (l *Logger) Shutdown() {
+func (l *Logger) Shutdown(ctx context.Context) {
 	if l.cancelFn != nil {
 		l.cancelFn()
 	}
 	l.filch.Close()
-	l.logger.Shutdown(context.Background())
+	l.logger.Shutdown(ctx)
 
 	type closeIdler interface {
 		CloseIdleConnections()

--- a/log/sockstatlog/logger_test.go
+++ b/log/sockstatlog/logger_test.go
@@ -4,6 +4,7 @@
 package sockstatlog
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -28,7 +29,7 @@ func TestResourceCleanup(t *testing.T) {
 		t.Fatal(err)
 	}
 	lg.Write([]byte("hello"))
-	lg.Shutdown()
+	lg.Shutdown(context.Background())
 }
 
 func TestDelta(t *testing.T) {


### PR DESCRIPTION
Fixes tailscale/corp#21618