### PR TITLE
cmd/viewer, types/views, util/codegen: add viewer support for custom container types

### DIFF
--- a/cmd/viewer/tests/tests.go
+++ b/cmd/viewer/tests/tests.go
@@ -9,10 +9,11 @@ import (
 	"net/netip"
 
 	"golang.org/x/exp/constraints"
+	"tailscale.com/types/ptr"
 	"tailscale.com/types/views"
 )
 
-//go:generate go run tailscale.com/cmd/viewer --type=StructWithPtrs,StructWithoutPtrs,Map,StructWithSlices,OnlyGetClone,StructWithEmbedded,GenericIntStruct,GenericNoPtrsStruct,GenericCloneableStruct --clone-only-type=OnlyGetClone
+//go:generate go run tailscale.com/cmd/viewer --type=StructWithPtrs,StructWithoutPtrs,Map,StructWithSlices,OnlyGetClone,StructWithEmbedded,GenericIntStruct,GenericNoPtrsStruct,GenericCloneableStruct,StructWithContainers --clone-only-type=OnlyGetClone
 
 type StructWithoutPtrs struct {
 	Int int
@@ -113,4 +114,51 @@ type GenericCloneableStruct[T views.ViewCloner[T, V], V views.StructView[T]] str
 	PtrKeyMap   map[*T]string `json:"-"`
 	PtrValueMap map[string]*T
 	SliceMap    map[string][]T
+}
+
+// Container is a pre-defined container type, such as a collection, an optional
+// value or a generic wrapper.
+type Container[T any] struct {
+	Item T
+}
+
+func (c *Container[T]) Clone() *Container[T] {
+	if c == nil {
+		return nil
+	}
+	if cloner, ok := any(c.Item).(views.Cloner[T]); ok {
+		return &Container[T]{cloner.Clone()}
+	}
+	if !views.ContainsPointers[T]() {
+		return ptr.To(*c)
+	}
+	panic(fmt.Errorf("%T contains pointers, but is not cloneable", c.Item))
+}
+
+// ContainerView is a pre-defined readonly view of a Container[T].
+type ContainerView[T views.ViewCloner[T, V], V views.StructView[T]] struct {
+	// ж is the underlying mutable value, named with a hard-to-type
+	// character that looks pointy like a pointer.
+	// It is named distinctively to make you think of how dangerous it is to escape
+	// to callers. You must not let callers be able to mutate it.
+	ж *Container[T]
+}
+
+func (cv ContainerView[T, V]) Item() V {
+	return cv.ж.Item.View()
+}
+
+func ContainerViewOf[T views.ViewCloner[T, V], V views.StructView[T]](c *Container[T]) ContainerView[T, V] {
+	return ContainerView[T, V]{c}
+}
+
+type GenericBasicStruct[T BasicType] struct {
+	Value T
+}
+
+type StructWithContainers struct {
+	IntContainer             Container[int]
+	CloneableContainer       Container[*StructWithPtrs]
+	BasicGenericContainer    Container[GenericBasicStruct[int]]
+	ClonableGenericContainer Container[*GenericNoPtrsStruct[int]]
 }

--- a/cmd/viewer/tests/tests_clone.go
+++ b/cmd/viewer/tests/tests_clone.go
@@ -416,3 +416,24 @@ func _GenericCloneableStructCloneNeedsRegeneration[T views.ViewCloner[T, V], V v
 		SliceMap    map[string][]T
 	}{})
 }
+
+// Clone makes a deep copy of StructWithContainers.
+// The result aliases no memory with the original.
+func (src *StructWithContainers) Clone() *StructWithContainers {
+	if src == nil {
+		return nil
+	}
+	dst := new(StructWithContainers)
+	*dst = *src
+	dst.CloneableContainer = *src.CloneableContainer.Clone()
+	dst.ClonableGenericContainer = *src.ClonableGenericContainer.Clone()
+	return dst
+}
+
+// A compilation failure here means this code must be regenerated, with the command at the top of this file.
+var _StructWithContainersCloneNeedsRegeneration = StructWithContainers(struct {
+	IntContainer             Container[int]
+	CloneableContainer       Container[*StructWithPtrs]
+	BasicGenericContainer    Container[GenericBasicStruct[int]]
+	ClonableGenericContainer Container[*GenericNoPtrsStruct[int]]
+}{})

--- a/types/views/views_test.go
+++ b/types/views/views_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"unsafe"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -20,6 +21,16 @@ type viewStruct struct {
 	Strings    Slice[string]
 	AddrsPtr   *Slice[netip.Prefix] `json:",omitempty"`
 	StringsPtr *Slice[string]       `json:",omitempty"`
+}
+
+type noPtrStruct struct {
+	Int int
+	Str string
+}
+
+type withPtrStruct struct {
+	Int    int
+	StrPtr *string
 }
 
 func BenchmarkSliceIteration(b *testing.B) {
@@ -187,5 +198,217 @@ func TestSliceMapKey(t *testing.T) {
 				t.Fatalf("wantDiff[%d, %+v, %q] == wantDiff[%d, %+v, %q] ", i, ki, si.AsSlice(), j, kj, sj.AsSlice())
 			}
 		}
+	}
+}
+
+func TestContainsPointers(t *testing.T) {
+	tests := []struct {
+		name     string
+		typ      reflect.Type
+		wantPtrs bool
+	}{
+		{
+			name:     "bool",
+			typ:      reflect.TypeFor[bool](),
+			wantPtrs: false,
+		},
+		{
+			name:     "int",
+			typ:      reflect.TypeFor[int](),
+			wantPtrs: false,
+		},
+		{
+			name:     "int8",
+			typ:      reflect.TypeFor[int8](),
+			wantPtrs: false,
+		},
+		{
+			name:     "int16",
+			typ:      reflect.TypeFor[int16](),
+			wantPtrs: false,
+		},
+		{
+			name:     "int32",
+			typ:      reflect.TypeFor[int32](),
+			wantPtrs: false,
+		},
+		{
+			name:     "int64",
+			typ:      reflect.TypeFor[int64](),
+			wantPtrs: false,
+		},
+		{
+			name:     "uint",
+			typ:      reflect.TypeFor[uint](),
+			wantPtrs: false,
+		},
+		{
+			name:     "uint8",
+			typ:      reflect.TypeFor[uint8](),
+			wantPtrs: false,
+		},
+		{
+			name:     "uint16",
+			typ:      reflect.TypeFor[uint16](),
+			wantPtrs: false,
+		},
+		{
+			name:     "uint32",
+			typ:      reflect.TypeFor[uint32](),
+			wantPtrs: false,
+		},
+		{
+			name:     "uint64",
+			typ:      reflect.TypeFor[uint64](),
+			wantPtrs: false,
+		},
+		{
+			name:     "uintptr",
+			typ:      reflect.TypeFor[uintptr](),
+			wantPtrs: false,
+		},
+		{
+			name:     "string",
+			typ:      reflect.TypeFor[string](),
+			wantPtrs: false,
+		},
+		{
+			name:     "float32",
+			typ:      reflect.TypeFor[float32](),
+			wantPtrs: false,
+		},
+		{
+			name:     "float64",
+			typ:      reflect.TypeFor[float64](),
+			wantPtrs: false,
+		},
+		{
+			name:     "complex64",
+			typ:      reflect.TypeFor[complex64](),
+			wantPtrs: false,
+		},
+		{
+			name:     "complex128",
+			typ:      reflect.TypeFor[complex128](),
+			wantPtrs: false,
+		},
+		{
+			name:     "netip-Addr",
+			typ:      reflect.TypeFor[netip.Addr](),
+			wantPtrs: false,
+		},
+		{
+			name:     "netip-Prefix",
+			typ:      reflect.TypeFor[netip.Prefix](),
+			wantPtrs: false,
+		},
+		{
+			name:     "netip-AddrPort",
+			typ:      reflect.TypeFor[netip.AddrPort](),
+			wantPtrs: false,
+		},
+		{
+			name:     "bool-ptr",
+			typ:      reflect.TypeFor[*bool](),
+			wantPtrs: true,
+		},
+		{
+			name:     "string-ptr",
+			typ:      reflect.TypeFor[*string](),
+			wantPtrs: true,
+		},
+		{
+			name:     "netip-Addr-ptr",
+			typ:      reflect.TypeFor[*netip.Addr](),
+			wantPtrs: true,
+		},
+		{
+			name:     "unsafe-ptr",
+			typ:      reflect.TypeFor[unsafe.Pointer](),
+			wantPtrs: true,
+		},
+		{
+			name:     "no-ptr-struct",
+			typ:      reflect.TypeFor[noPtrStruct](),
+			wantPtrs: false,
+		},
+		{
+			name:     "ptr-struct",
+			typ:      reflect.TypeFor[withPtrStruct](),
+			wantPtrs: true,
+		},
+		{
+			name:     "string-array",
+			typ:      reflect.TypeFor[[5]string](),
+			wantPtrs: false,
+		},
+		{
+			name:     "int-ptr-array",
+			typ:      reflect.TypeFor[[5]*int](),
+			wantPtrs: true,
+		},
+		{
+			name:     "no-ptr-struct-array",
+			typ:      reflect.TypeFor[[5]noPtrStruct](),
+			wantPtrs: false,
+		},
+		{
+			name:     "with-ptr-struct-array",
+			typ:      reflect.TypeFor[[5]withPtrStruct](),
+			wantPtrs: true,
+		},
+		{
+			name:     "string-slice",
+			typ:      reflect.TypeFor[[]string](),
+			wantPtrs: true,
+		},
+		{
+			name:     "int-ptr-slice",
+			typ:      reflect.TypeFor[[]int](),
+			wantPtrs: true,
+		},
+		{
+			name:     "no-ptr-struct-slice",
+			typ:      reflect.TypeFor[[]noPtrStruct](),
+			wantPtrs: true,
+		},
+		{
+			name:     "string-map",
+			typ:      reflect.TypeFor[map[string]string](),
+			wantPtrs: true,
+		},
+		{
+			name:     "int-map",
+			typ:      reflect.TypeFor[map[int]int](),
+			wantPtrs: true,
+		},
+		{
+			name:     "no-ptr-struct-map",
+			typ:      reflect.TypeFor[map[string]noPtrStruct](),
+			wantPtrs: true,
+		},
+		{
+			name:     "chan",
+			typ:      reflect.TypeFor[chan int](),
+			wantPtrs: true,
+		},
+		{
+			name:     "func",
+			typ:      reflect.TypeFor[func()](),
+			wantPtrs: true,
+		},
+		{
+			name:     "interface",
+			typ:      reflect.TypeFor[any](),
+			wantPtrs: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotPtrs := containsPointers(tt.typ); gotPtrs != tt.wantPtrs {
+				t.Errorf("got %v; want %v", gotPtrs, tt.wantPtrs)
+			}
+		})
 	}
 }

--- a/util/codegen/codegen.go
+++ b/util/codegen/codegen.go
@@ -111,6 +111,14 @@ func (it *ImportTracker) QualifiedName(t types.Type) string {
 	return types.TypeString(t, it.qualifier)
 }
 
+// PackagePrefix returns the prefix to be used when referencing named objects from pkg.
+func (it *ImportTracker) PackagePrefix(pkg *types.Package) string {
+	if s := it.qualifier(pkg); s != "" {
+		return s + "."
+	}
+	return ""
+}
+
 // Write prints all the tracked imports in a single import block to w.
 func (it *ImportTracker) Write(w io.Writer) {
 	fmt.Fprintf(w, "import (\n")


### PR DESCRIPTION
This adds support for container-like types such as Container[T] that don't explicitly specify a view type for T. Instead, a package implementing a container type should also implement and export a ContainerView[T, V] type and a ContainerViewOf(*Container[T]) ContainerView[T, V] function, which returns a view for the specified container, inferring the element view type V from the element type T.

Updates #12736