### PR TITLE
cmd/k8s-operator: add a metric to track the amount of ProxyClass resources

### DIFF
--- a/cmd/k8s-operator/proxyclass_test.go
+++ b/cmd/k8s-operator/proxyclass_test.go
@@ -29,7 +29,8 @@ func TestProxyClass(t *testing.T) {
 			// The apiserver is supposed to set the UID, but the fake client
 			// doesn't. So, set it explicitly because other code later depends
 			// on it being set.
-			UID: types.UID("1234-UID"),
+			UID:        types.UID("1234-UID"),
+			Finalizers: []string{"tailscale.com/finalizer"},
 		},
 		Spec: tsapi.ProxyClassSpec{
 			StatefulSet: &tsapi.StatefulSet{


### PR DESCRIPTION
Adds a new `k8s_proxyclass_resources` gauge to track currently managed `ProxyClass` resources.

Also starts adding finalizers to `ProxyClass`es to ensure that the reconciler can correctly update the gauge when `ProxyClass` is being deleted.

A side effect of this is that if users downgrade the operator version to one that does not clean up finalizers from `ProxyClass`, they will need to manually remove finalizers to be able to delete any `ProxyClass`es created from this or newer version. That should be acceptable.

Updates tailscale/tailscale#10709