### PR TITLE
tsweb: add QuietLogging option to allow use of only OnCompletion for instrumentation

### DIFF
--- a/tsweb/tsweb.go
+++ b/tsweb/tsweb.go
@@ -276,6 +276,10 @@ type LogOptions struct {
 	// Now is a function giving the current time. Defaults to [time.Now].
 	Now func() time.Time
 
+	// QuietLogging suppresses all logging of handled HTTP requests, even if
+	// there are errors or status codes considered unsuccessful. Use this option
+	// to add your own logging in OnCompletion.
+	QuietLogging bool
 	// QuietLoggingIfSuccessful suppresses logging of handled HTTP requests
 	// where the request's response status code is 200 or 304.
 	QuietLoggingIfSuccessful bool
@@ -569,7 +573,7 @@ func (h logHandler) logRequest(r *http.Request, lw *loggingResponseWriter, msg A
 		}
 	}
 
-	if !h.opts.QuietLoggingIfSuccessful || (msg.Code != http.StatusOK && msg.Code != http.StatusNotModified) {
+	if !h.opts.QuietLogging && !(h.opts.QuietLoggingIfSuccessful && (msg.Code == http.StatusOK || msg.Code == http.StatusNotModified)) {
 		h.opts.Logf("%s", msg)
 	}
 


### PR DESCRIPTION
This PR adds a QuietLogging option to tsweb.LogOptions so that we can use its OnCompletion callbacks without decorating all handlers for each of logging, tracing and metrics. We have some services we'd like to add these to without also adding logging of every request.

Opened for discussion.

Fixes https://github.com/tailscale/tailscale/issues/12837