### PR TITLE
ipn,wgengine/magicsock: allow setting static node endpoints via tailscaled configfile

### DIFF
--- a/ipn/conf.go
+++ b/ipn/conf.go
@@ -43,7 +43,7 @@ type ConfigVAlpha struct {
 	ServeConfigTemp *ServeConfig     `json:",omitempty"` // TODO(bradfitz,maisem): make separate stable type for this
 
 	// StaticEndpoints are additional, user-defined endpoints that this node
-	// should advertize amongst its wireguard endpoints.
+	// should advertise amongst its wireguard endpoints.
 	StaticEndpoints []netip.AddrPort `json:",omitempty"`
 
 	// TODO(bradfitz,maisem): future something like:

--- a/ipn/conf.go
+++ b/ipn/conf.go
@@ -42,6 +42,10 @@ type ConfigVAlpha struct {
 	AutoUpdate      *AutoUpdatePrefs `json:",omitempty"`
 	ServeConfigTemp *ServeConfig     `json:",omitempty"` // TODO(bradfitz,maisem): make separate stable type for this
 
+	// StaticEndpoints are additional, user-defined endpoints that this node
+	// should advertize amongst its wireguard endpoints.
+	StaticEndpoints []netip.AddrPort `json:",omitempty"`
+
 	// TODO(bradfitz,maisem): future something like:
 	// Profile map[string]*Config // keyed by alice@gmail.com, corp.com (TailnetSID)
 }

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"slices"
 	"sort"
@@ -391,18 +392,6 @@ func NewLocalBackend(logf logger.Logf, logID logid.PublicID, sys *tsd.System, lo
 		sds.SetDialer(dialer.SystemDial)
 	}
 
-	if sys.InitialConfig != nil {
-		p := pm.CurrentPrefs().AsStruct()
-		mp, err := sys.InitialConfig.Parsed.ToPrefs()
-		if err != nil {
-			return nil, err
-		}
-		p.ApplyEdits(&mp)
-		if err := pm.SetPrefs(p.View(), ipn.NetworkProfile{}); err != nil {
-			return nil, err
-		}
-	}
-
 	envknob.LogCurrent(logf)
 	osshare.SetFileSharingEnabled(false, logf)
 
@@ -417,7 +406,6 @@ func NewLocalBackend(logf logger.Logf, logID logid.PublicID, sys *tsd.System, lo
 		statsLogf:           logger.LogOnChange(logf, 5*time.Minute, clock.Now),
 		sys:                 sys,
 		health:              sys.HealthTracker(),
-		conf:                sys.InitialConfig,
 		e:                   e,
 		dialer:              dialer,
 		store:               store,
@@ -433,6 +421,12 @@ func NewLocalBackend(logf logger.Logf, logID logid.PublicID, sys *tsd.System, lo
 		lastSelfUpdateState: ipnstate.UpdateFinished,
 	}
 	mConn.SetNetInfoCallback(b.setNetInfo)
+
+	if sys.InitialConfig != nil {
+		if err := b.setConfigLocked(sys.InitialConfig); err != nil {
+			return nil, err
+		}
+	}
 
 	netMon := sys.NetMon.Get()
 	b.sockstatLogger, err = sockstatlog.NewLogger(logpolicy.LogsDir(logf), logf, logID, netMon, sys.HealthTracker())
@@ -616,9 +610,48 @@ func (b *LocalBackend) ReloadConfig() (ok bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	b.conf = conf
-	// TODO(bradfitz): apply things
+	if err := b.setConfigLocked(conf); err != nil {
+		return false, fmt.Errorf("error setting config: %w", err)
+	}
+
 	return true, nil
+}
+
+func (b *LocalBackend) setConfigLocked(conf *conffile.Config) error {
+
+	// TODO (irbekrm): notify the relevant components to consume any prefs
+	// updates. Currently only initial configfile settings are applied
+	// immediately.
+	p := b.pm.CurrentPrefs().AsStruct()
+	mp, err := conf.Parsed.ToPrefs()
+	if err != nil {
+		return fmt.Errorf("error parsing config to prefs: %w", err)
+	}
+	p.ApplyEdits(&mp)
+	if err := b.pm.SetPrefs(p.View(), ipn.NetworkProfile{}); err != nil {
+		return err
+	}
+
+	defer func() {
+		b.conf = conf
+	}()
+
+	if conf.Parsed.StaticEndpoints == nil && (b.conf == nil || b.conf.Parsed.StaticEndpoints == nil) {
+		return nil
+	}
+
+	// Ensure that magicsock conn has the up to date static wireguard
+	// endpoints. Setting the endpoints here triggers an asynchronous update
+	// of the node's advertized endpoints.
+	if b.conf == nil && len(conf.Parsed.StaticEndpoints) != 0 || !reflect.DeepEqual(conf.Parsed.StaticEndpoints, b.conf.Parsed.StaticEndpoints) {
+		ms, ok := b.sys.MagicSock.GetOK()
+		if !ok {
+			b.logf("[unexpected] ReloadConfig: MagicSock not set")
+		} else {
+			ms.SetStaticEndpoints(views.SliceOf(conf.Parsed.StaticEndpoints))
+		}
+	}
+	return nil
 }
 
 var assumeNetworkUpdateForTest = envknob.RegisterBool("TS_ASSUME_NETWORK_UP_FOR_TEST")

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -619,7 +619,7 @@ func (b *LocalBackend) ReloadConfig() (ok bool, err error) {
 
 func (b *LocalBackend) setConfigLocked(conf *conffile.Config) error {
 
-	// TODO (irbekrm): notify the relevant components to consume any prefs
+	// TODO(irbekrm): notify the relevant components to consume any prefs
 	// updates. Currently only initial configfile settings are applied
 	// immediately.
 	p := b.pm.CurrentPrefs().AsStruct()
@@ -642,7 +642,7 @@ func (b *LocalBackend) setConfigLocked(conf *conffile.Config) error {
 
 	// Ensure that magicsock conn has the up to date static wireguard
 	// endpoints. Setting the endpoints here triggers an asynchronous update
-	// of the node's advertized endpoints.
+	// of the node's advertised endpoints.
 	if b.conf == nil && len(conf.Parsed.StaticEndpoints) != 0 || !reflect.DeepEqual(conf.Parsed.StaticEndpoints, b.conf.Parsed.StaticEndpoints) {
 		ms, ok := b.sys.MagicSock.GetOK()
 		if !ok {


### PR DESCRIPTION
See https://github.com/tailscale/tailscale/pull/12735 for context - the new `TS_DEBUG_PRETENDPOINTS` env var has been tested and seems like a good solution for getting direct connections if you are on EKS and willing to use an NLB.

This PR attempts to allow configuring the same via the tailscaled configfile:

- Adds a new `StaticEndpoints` field to tailscaled config that can be used to statically configure the endpoints that the node advertizes

- Adds a method to magicsock to reset the static endpoints and asynchronously call ReSTUN to propagate the update

- Updates the method that is called when the configfile is reloaded to call the new magicsock method if there is a change in static endpoints
(Currently nothing calls the reload endpoint though. I've tested this PR by calling `curl -X POST --unix-socket /var/run/tailscale/tailscaled.sock "http://local-tailscaled.sock/localapi/v0/reload-config"` and observed that endpoints update in configfile gets propagated as expected)

Next steps:
- make containerboot call the reload LocalAPI endpoint when it sees that the mounted file has been updated
- make the configfile a bit easier to use for non-automated deployments

Updates tailscale/tailscale#12578