### PR TITLE
types/lazy: re-init SyncValue during test cleanup if it wasn't set before SetForTest

### DIFF
--- a/types/lazy/lazy.go
+++ b/types/lazy/lazy.go
@@ -170,8 +170,8 @@ type TB interface {
 func (z *SyncValue[T]) SetForTest(tb TB, val T, err error) {
 	tb.Helper()
 
-	z.once.Do(func() {})
 	oldErr, oldVal := z.err.Load(), z.v
+	z.once.Do(func() {})
 
 	z.v = val
 	if err != nil {
@@ -181,7 +181,11 @@ func (z *SyncValue[T]) SetForTest(tb TB, val T, err error) {
 	}
 
 	tb.Cleanup(func() {
-		z.v = oldVal
-		z.err.Store(oldErr)
+		if oldErr == nil {
+			*z = SyncValue[T]{}
+		} else {
+			z.v = oldVal
+			z.err.Store(oldErr)
+		}
 	})
 }

--- a/types/lazy/sync_test.go
+++ b/types/lazy/sync_test.go
@@ -290,6 +290,22 @@ func TestSyncValueSetForTest(t *testing.T) {
 						t.Fatalf("CleanupValue: got %v; want %v", gotCleanupValue, wantCleanupValue)
 					}
 				})
+			} else {
+				// Verify that if v wasn't set prior to SetForTest, it's
+				// reverted to a valid unset state during the test cleanup.
+				t.Cleanup(func() {
+					if _, _, ok := v.PeekErr(); ok {
+						t.Fatal("SyncValue is set after cleanup")
+					}
+					wantCleanupValue, wantCleanupErr := 42, errors.New("ka-boom")
+					gotCleanupValue, gotCleanupErr := v.GetErr(func() (int, error) { return wantCleanupValue, wantCleanupErr })
+					if gotCleanupErr != wantCleanupErr {
+						t.Fatalf("CleanupErr: got %v; want %v", gotCleanupErr, wantCleanupErr)
+					}
+					if gotCleanupValue != wantCleanupValue {
+						t.Fatalf("CleanupValue: got %v; want %v", gotCleanupValue, wantCleanupValue)
+					}
+				})
 			}
 
 			// Set the test value and/or error.


### PR DESCRIPTION
Updates #12687