### PR TITLE
Dockerfile: Adaptive iptables mode using kubernetes-sigs/iptables-wrappers

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -2,4 +2,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 FROM alpine:3.18
-RUN apk add --no-cache ca-certificates iptables iproute2 ip6tables iputils
+# https://github.com/kubernetes-sigs/iptables-wrappers
+ADD https://raw.githubusercontent.com/kubernetes-sigs/iptables-wrappers/v2/iptables-wrapper-installer.sh /iptables-wrapper-installer.sh
+RUN set -eux; \
+    apk add --no-cache ca-certificates iptables iproute2 ip6tables; \
+    sh /iptables-wrapper-installer.sh --no-sanity-check


### PR DESCRIPTION
Fixes: https://github.com/tailscale/tailscale/issues/12950
host is` legacy` mode:
```
$ iptables -V
iptables v1.8.4 (legacy)
$ docker run -ti --rm --net host   -v /run/xtables.lock:/run/xtables.lock \
  --cap-add=NET_ADMIN  --cap-add=NET_RAW  zhangguanzhang/tailscale:v1.70.0 iptables -V
iptables v1.8.9 (legacy)
```

host is` nf_tables` mode:

```
$ iptables -V
iptables v1.8.7 (nf_tables)
$ docker run -ti --rm --net host   -v /run/xtables.lock:/run/xtables.lock \
  --cap-add=NET_ADMIN  --cap-add=NET_RAW  zhangguanzhang/tailscale:v1.70.0 iptables -V
iptables v1.8.9 (nf_tables)
```