### PR TITLE
Dockerfile: add a warning that this is not used to build our published images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
 # Copyright (c) Tailscale Inc & AUTHORS
 # SPDX-License-Identifier: BSD-3-Clause
 
+# Note that this Dockerfile is currently NOT used to build any of the published
+# Tailscale container images and may have drifted from the image build mechanism
+# we use.
+# Tailscale images are currently built using https://github.com/tailscale/mkctr,
+# and the build script can be found in ./build_docker.sh.
+#
+#
 # This Dockerfile includes all the tailscale binaries.
 #
 # To build the Dockerfile:


### PR DESCRIPTION
Add a warning that the Dockerfile in the OSS repo is not the currently used mechanism to build the images we publish - for folks who want to contribute to image build scripts or otherwise need to understand the image build process that we use.

Updates#cleanup