### PR TITLE
net/captivedetection: call SetHealthy once connectivity restored

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -780,6 +780,9 @@ func (b *LocalBackend) onHealthChange(w *health.Warnable, us *health.UnhealthySt
 		case <-ctx.Done():
 		}
 	} else {
+		// If connectivity is not impacted, we know for sure we're not behind a captive portal,
+		// so drop any warning, and signal that we don't need captive portal detection.
+		b.health.SetHealthy(captivePortalWarnable)
 		select {
 		case b.needsCaptiveDetection <- false:
 		case <-ctx.Done():

--- a/net/captivedetection/captivedetection.go
+++ b/net/captivedetection/captivedetection.go
@@ -97,7 +97,7 @@ func (d *Detector) detectCaptivePortalWithGOOS(ctx context.Context, netMon *netm
 		d.logf("[v2] attempting to do captive portal detection on interface %s", ifName)
 		res := d.detectOnInterface(ctx, i.Index, endpoints)
 		if res {
-			d.logf("DetectCaptivePortal(found=true,ifName=%s)", found, ifName)
+			d.logf("DetectCaptivePortal(found=true,ifName=%s)", ifName)
 			return true
 		}
 	}


### PR DESCRIPTION
Fixes tailscale/tailscale#12973
Updates tailscale/tailscale#1634

There was a logic issue in the captive detection code we shipped in https://github.com/tailscale/tailscale/pull/12707.

Assume a captive portal has been detected, and the user notified. Upon switching to another Wi-Fi that does *not* have a captive portal, we were issuing a signal to interrupt any pending captive detection attempt. However, we were not also setting the `captive-portal-detected` warnable to healthy. The result was that any "captive portal detected" alert would not be cleared from the UI.

Also fixes a broken log statement value.