### PR TITLE
prober: add HTTP endpoints for running probes and getting status

### DIFF
--- a/prober/prober.go
+++ b/prober/prober.go
@@ -7,18 +7,24 @@
 package prober
 
 import (
+	"container/ring"
 	"context"
-	"errors"
 	"fmt"
 	"hash/fnv"
 	"log"
 	"maps"
 	"math/rand"
+	"net/http"
 	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"tailscale.com/tsweb"
 )
+
+// recentHistSize is the number of recent probe results and latencies to keep
+// in memory.
+const recentHistSize = 10
 
 // ProbeClass defines a probe of a specific type: a probing function that will
 // be regularly ran, and metric labels that will be added automatically to all
@@ -106,6 +112,14 @@ func (p *Prober) Run(name string, interval time.Duration, labels Labels, pc Prob
 		l[k] = v
 	}
 
+	probe := newProbe(p, name, interval, l, pc)
+	p.probes[name] = probe
+	go probe.loop()
+	return probe
+}
+
+// newProbe creates a new Probe with the given parameters, but does not start it.
+func newProbe(p *Prober, name string, interval time.Duration, l prometheus.Labels, pc ProbeClass) *Probe {
 	ctx, cancel := context.WithCancel(context.Background())
 	probe := &Probe{
 		prober:  p,
@@ -117,6 +131,9 @@ func (p *Prober) Run(name string, interval time.Duration, labels Labels, pc Prob
 		probeClass:   pc,
 		interval:     interval,
 		initialDelay: initialDelay(name, interval),
+		successHist:  ring.New(recentHistSize),
+		latencyHist:  ring.New(recentHistSize),
+
 		metrics:      prometheus.NewRegistry(),
 		metricLabels: l,
 		mInterval:    prometheus.NewDesc("interval_secs", "Probe interval in seconds", nil, l),
@@ -131,15 +148,14 @@ func (p *Prober) Run(name string, interval time.Duration, labels Labels, pc Prob
 			Name: "seconds_total", Help: "Total amount of time spent executing the probe", ConstLabels: l,
 		}, []string{"status"}),
 	}
-
-	prometheus.WrapRegistererWithPrefix(p.namespace+"_", p.metrics).MustRegister(probe.metrics)
+	if p.metrics != nil {
+		prometheus.WrapRegistererWithPrefix(p.namespace+"_", p.metrics).MustRegister(probe.metrics)
+	}
 	probe.metrics.MustRegister(probe)
-
-	p.probes[name] = probe
-	go probe.loop()
 	return probe
 }
 
+// unregister removes a probe from the prober's internal state.
 func (p *Prober) unregister(probe *Probe) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -206,6 +222,7 @@ type Probe struct {
 	ctx     context.Context
 	cancel  context.CancelFunc // run to initiate shutdown
 	stopped chan struct{}      // closed when shutdown is complete
+	runMu   sync.Mutex         // ensures only one probe runs at a time
 
 	name         string
 	probeClass   ProbeClass
@@ -232,6 +249,10 @@ type Probe struct {
 	latency   time.Duration // last successful probe latency
 	succeeded bool          // whether the last doProbe call succeeded
 	lastErr   error
+
+	// History of recent probe results and latencies.
+	successHist *ring.Ring
+	latencyHist *ring.Ring
 }
 
 // Close shuts down the Probe and unregisters it from its Prober.
@@ -278,13 +299,17 @@ func (p *Probe) loop() {
 	}
 }
 
-// run invokes fun and records the results.
+// run invokes the probe function and records the result. It returns the probe
+// result and an error if the probe failed.
 //
-// fun is invoked with a timeout slightly less than interval, so that
-// the probe either succeeds or fails before the next cycle is
-// scheduled to start.
-func (p *Probe) run() {
-	start := p.recordStart()
+// The probe function is invoked with a timeout slightly less than interval, so
+// that the probe either succeeds or fails before the next cycle is scheduled to
+// start.
+func (p *Probe) run() (pi ProbeInfo, err error) {
+	p.runMu.Lock()
+	defer p.runMu.Unlock()
+
+	p.recordStart()
 	defer func() {
 		// Prevent a panic within one probe function from killing the
 		// entire prober, so that a single buggy probe doesn't destroy
@@ -293,29 +318,30 @@ func (p *Probe) run() {
 		// alert for debugging.
 		if r := recover(); r != nil {
 			log.Printf("probe %s panicked: %v", p.name, r)
-			p.recordEnd(start, errors.New("panic"))
+			err = fmt.Errorf("panic: %v", r)
+			p.recordEnd(err)
 		}
 	}()
 	timeout := time.Duration(float64(p.interval) * 0.8)
 	ctx, cancel := context.WithTimeout(p.ctx, timeout)
 	defer cancel()
 
-	err := p.probeClass.Probe(ctx)
-	p.recordEnd(start, err)
+	err = p.probeClass.Probe(ctx)
+	p.recordEnd(err)
 	if err != nil {
 		log.Printf("probe %s: %v", p.name, err)
 	}
+	pi = p.probeInfoLocked()
+	return
 }
 
-func (p *Probe) recordStart() time.Time {
-	st := p.prober.now()
+func (p *Probe) recordStart() {
 	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.start = st
-	return st
+	p.start = p.prober.now()
+	p.mu.Unlock()
 }
 
-func (p *Probe) recordEnd(start time.Time, err error) {
+func (p *Probe) recordEnd(err error) {
 	end := p.prober.now()
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -327,22 +353,55 @@ func (p *Probe) recordEnd(start time.Time, err error) {
 		p.latency = latency
 		p.mAttempts.WithLabelValues("ok").Inc()
 		p.mSeconds.WithLabelValues("ok").Add(latency.Seconds())
+		p.latencyHist.Value = latency
+		p.latencyHist = p.latencyHist.Next()
 	} else {
 		p.latency = 0
 		p.mAttempts.WithLabelValues("fail").Inc()
 		p.mSeconds.WithLabelValues("fail").Add(latency.Seconds())
 	}
+	p.successHist.Value = p.succeeded
+	p.successHist = p.successHist.Next()
 }
 
-// ProbeInfo is the state of a Probe.
+// ProbeInfo is a snapshot of the configuration and state of a Probe.
 type ProbeInfo struct {
-	Start   time.Time
-	End     time.Time
-	Latency string
-	Result  bool
-	Error   string
+	Name            string
+	Class           string
+	Interval        time.Duration
+	Labels          map[string]string
+	Start           time.Time
+	End             time.Time
+	Latency         time.Duration
+	Result          bool
+	Error           string
+	RecentResults   []bool
+	RecentLatencies []time.Duration
 }
 
+// RecentSuccessRatio returns the success ratio of the probe in the recent history.
+func (pb ProbeInfo) RecentSuccessRatio() float64 {
+	if len(pb.RecentResults) == 0 {
+		return 0
+	}
+	var sum int
+	for _, r := range pb.RecentResults {
+		if r {
+			sum++
+		}
+	}
+	return float64(sum) / float64(len(pb.RecentResults))
+}
+
+// RecentMedianLatency returns the median latency of the probe in the recent history.
+func (pb ProbeInfo) RecentMedianLatency() time.Duration {
+	if len(pb.RecentLatencies) == 0 {
+		return 0
+	}
+	return pb.RecentLatencies[len(pb.RecentLatencies)/2]
+}
+
+// ProbeInfo returns the state of all probes.
 func (p *Prober) ProbeInfo() map[string]ProbeInfo {
 	out := map[string]ProbeInfo{}
 
@@ -352,24 +411,67 @@ func (p *Prober) ProbeInfo() map[string]ProbeInfo {
 		probes = append(probes, probe)
 	}
 	p.mu.Unlock()
-
 	for _, probe := range probes {
 		probe.mu.Lock()
-		inf := ProbeInfo{
-			Start:  probe.start,
-			End:    probe.end,
-			Result: probe.succeeded,
-		}
-		if probe.lastErr != nil {
-			inf.Error = probe.lastErr.Error()
-		}
-		if probe.latency > 0 {
-			inf.Latency = probe.latency.String()
-		}
-		out[probe.name] = inf
+		out[probe.name] = probe.probeInfoLocked()
 		probe.mu.Unlock()
 	}
 	return out
+}
+
+// probeInfoLocked returns the state of the probe.
+func (probe *Probe) probeInfoLocked() ProbeInfo {
+	inf := ProbeInfo{
+		Name:     probe.name,
+		Class:    probe.probeClass.Class,
+		Interval: probe.interval,
+		Labels:   probe.metricLabels,
+		Start:    probe.start,
+		End:      probe.end,
+		Result:   probe.succeeded,
+	}
+	if probe.lastErr != nil {
+		inf.Error = probe.lastErr.Error()
+	}
+	if probe.latency > 0 {
+		inf.Latency = probe.latency
+	}
+	probe.latencyHist.Do(func(v any) {
+		if l, ok := v.(time.Duration); ok {
+			inf.RecentLatencies = append(inf.RecentLatencies, l)
+		}
+	})
+	probe.successHist.Do(func(v any) {
+		if r, ok := v.(bool); ok {
+			inf.RecentResults = append(inf.RecentResults, r)
+		}
+	})
+	return inf
+}
+
+// RunHandler runs a probe by name and returns the result as an HTTP response.
+func (p *Prober) RunHandler(w http.ResponseWriter, r *http.Request) error {
+	// Look up prober by name.
+	name := r.FormValue("name")
+	if name == "" {
+		return tsweb.Error(http.StatusBadRequest, "missing name parameter", nil)
+	}
+	p.mu.Lock()
+	probe, ok := p.probes[name]
+	prevInfo := probe.probeInfoLocked()
+	p.mu.Unlock()
+	if !ok {
+		return tsweb.Error(http.StatusNotFound, fmt.Sprintf("unknown probe %q", name), nil)
+	}
+	info, err := probe.run()
+	stats := fmt.Sprintf("Previous runs: success rate %d%%, median latency %v",
+		int(prevInfo.RecentSuccessRatio()*100), prevInfo.RecentMedianLatency())
+	if err != nil {
+		return tsweb.Error(http.StatusFailedDependency, fmt.Sprintf("Probe failed: %s\n%s", err.Error(), stats), err)
+	}
+	w.WriteHeader(respStatus)
+	w.Write([]byte(fmt.Sprintf("Probe succeeded in %v\n%s", info.Latency, stats)))
+	return nil
 }
 
 // Describe implements prometheus.Collector.

--- a/prober/prober_test.go
+++ b/prober/prober_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"tailscale.com/tstest"
 )
@@ -289,6 +291,173 @@ func TestOnceMode(t *testing.T) {
 		if c, err := testutil.GatherAndCount(p.metrics, metric); c != wantCount || err != nil {
 			t.Fatalf("expected %d %s metrics; got %d (error %s)", wantCount, metric, c, err)
 		}
+	}
+}
+
+func TestProberProbeInfo(t *testing.T) {
+	clk := newFakeTime()
+	p := newForTest(clk.Now, clk.NewTicker).WithOnce(true)
+
+	p.Run("probe1", probeInterval, nil, FuncProbe(func(context.Context) error {
+		clk.Advance(500 * time.Millisecond)
+		return nil
+	}))
+	p.Run("probe2", probeInterval, nil, FuncProbe(func(context.Context) error { return fmt.Errorf("error2") }))
+	p.Wait()
+
+	info := p.ProbeInfo()
+	wantInfo := map[string]ProbeInfo{
+		"probe1": {
+			Name:            "probe1",
+			Interval:        probeInterval,
+			Labels:          map[string]string{"class": "", "name": "probe1"},
+			Latency:         500 * time.Millisecond,
+			Result:          true,
+			RecentResults:   []bool{true},
+			RecentLatencies: []time.Duration{500 * time.Millisecond},
+		},
+		"probe2": {
+			Name:            "probe2",
+			Interval:        probeInterval,
+			Labels:          map[string]string{"class": "", "name": "probe2"},
+			Error:           "error2",
+			RecentResults:   []bool{false},
+			RecentLatencies: nil, // no latency for failed probes
+		},
+	}
+
+	if diff := cmp.Diff(wantInfo, info, cmpopts.IgnoreFields(ProbeInfo{}, "Start", "End")); diff != "" {
+		t.Fatalf("unexpected ProbeInfo (-want +got):\n%s", diff)
+	}
+}
+
+func TestProbeInfoRecent(t *testing.T) {
+	type probeResult struct {
+		latency time.Duration
+		err     error
+	}
+	tests := []struct {
+		name                    string
+		results                 []probeResult
+		wantProbeInfo           ProbeInfo
+		wantRecentSuccessRatio  float64
+		wantRecentMedianLatency time.Duration
+	}{
+		{
+			name:                    "no_runs",
+			wantProbeInfo:           ProbeInfo{},
+			wantRecentSuccessRatio:  0,
+			wantRecentMedianLatency: 0,
+		},
+		{
+			name:    "single_success",
+			results: []probeResult{{latency: 100 * time.Millisecond, err: nil}},
+			wantProbeInfo: ProbeInfo{
+				Latency:         100 * time.Millisecond,
+				Result:          true,
+				RecentResults:   []bool{true},
+				RecentLatencies: []time.Duration{100 * time.Millisecond},
+			},
+			wantRecentSuccessRatio:  1,
+			wantRecentMedianLatency: 100 * time.Millisecond,
+		},
+		{
+			name:    "single_failure",
+			results: []probeResult{{latency: 100 * time.Millisecond, err: errors.New("error123")}},
+			wantProbeInfo: ProbeInfo{
+				Result:          false,
+				RecentResults:   []bool{false},
+				RecentLatencies: nil,
+				Error:           "error123",
+			},
+			wantRecentSuccessRatio:  0,
+			wantRecentMedianLatency: 0,
+		},
+		{
+			name: "recent_mix",
+			results: []probeResult{
+				{latency: 10 * time.Millisecond, err: errors.New("error1")},
+				{latency: 20 * time.Millisecond, err: nil},
+				{latency: 30 * time.Millisecond, err: nil},
+				{latency: 40 * time.Millisecond, err: errors.New("error4")},
+				{latency: 50 * time.Millisecond, err: nil},
+				{latency: 60 * time.Millisecond, err: nil},
+				{latency: 70 * time.Millisecond, err: errors.New("error7")},
+				{latency: 80 * time.Millisecond, err: nil},
+			},
+			wantProbeInfo: ProbeInfo{
+				Result:        true,
+				Latency:       80 * time.Millisecond,
+				RecentResults: []bool{false, true, true, false, true, true, false, true},
+				RecentLatencies: []time.Duration{
+					20 * time.Millisecond,
+					30 * time.Millisecond,
+					50 * time.Millisecond,
+					60 * time.Millisecond,
+					80 * time.Millisecond,
+				},
+			},
+			wantRecentSuccessRatio:  0.625,
+			wantRecentMedianLatency: 50 * time.Millisecond,
+		},
+		{
+			name: "only_last_10",
+			results: []probeResult{
+				{latency: 10 * time.Millisecond, err: errors.New("old_error")},
+				{latency: 20 * time.Millisecond, err: nil},
+				{latency: 30 * time.Millisecond, err: nil},
+				{latency: 40 * time.Millisecond, err: nil},
+				{latency: 50 * time.Millisecond, err: nil},
+				{latency: 60 * time.Millisecond, err: nil},
+				{latency: 70 * time.Millisecond, err: nil},
+				{latency: 80 * time.Millisecond, err: nil},
+				{latency: 90 * time.Millisecond, err: nil},
+				{latency: 100 * time.Millisecond, err: nil},
+				{latency: 110 * time.Millisecond, err: nil},
+			},
+			wantProbeInfo: ProbeInfo{
+				Result:        true,
+				Latency:       110 * time.Millisecond,
+				RecentResults: []bool{true, true, true, true, true, true, true, true, true, true},
+				RecentLatencies: []time.Duration{
+					20 * time.Millisecond,
+					30 * time.Millisecond,
+					40 * time.Millisecond,
+					50 * time.Millisecond,
+					60 * time.Millisecond,
+					70 * time.Millisecond,
+					80 * time.Millisecond,
+					90 * time.Millisecond,
+					100 * time.Millisecond,
+					110 * time.Millisecond,
+				},
+			},
+			wantRecentSuccessRatio:  1,
+			wantRecentMedianLatency: 70 * time.Millisecond,
+		},
+	}
+
+	clk := newFakeTime()
+	p := newForTest(clk.Now, clk.NewTicker).WithOnce(true)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			probe := newProbe(p, "", probeInterval, nil, FuncProbe(func(context.Context) error { return nil }))
+			for _, r := range tt.results {
+				probe.recordStart()
+				clk.Advance(r.latency)
+				probe.recordEnd(r.err)
+			}
+			info := probe.probeInfoLocked()
+			if diff := cmp.Diff(tt.wantProbeInfo, info, cmpopts.IgnoreFields(ProbeInfo{}, "Start", "End", "Interval")); diff != "" {
+				t.Fatalf("unexpected ProbeInfo (-want +got):\n%s", diff)
+			}
+			if got := info.RecentSuccessRatio(); got != tt.wantRecentSuccessRatio {
+				t.Errorf("recentSuccessRatio() = %v, want %v", got, tt.wantRecentSuccessRatio)
+			}
+			if got := info.RecentMedianLatency(); got != tt.wantRecentMedianLatency {
+				t.Errorf("recentMedianLatency() = %v, want %v", got, tt.wantRecentMedianLatency)
+			}
+		})
 	}
 }
 

--- a/prober/status.go
+++ b/prober/status.go
@@ -1,0 +1,124 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package prober
+
+import (
+	"embed"
+	"fmt"
+	"html/template"
+	"net/http"
+	"strings"
+	"time"
+
+	"tailscale.com/tsweb"
+	"tailscale.com/util/mak"
+)
+
+//go:embed status.html
+var statusFiles embed.FS
+var statusTpl = template.Must(template.ParseFS(statusFiles, "status.html"))
+
+type statusHandlerOpt func(*statusHandlerParams)
+type statusHandlerParams struct {
+	title string
+
+	pageLinks  map[string]string
+	probeLinks map[string]string
+}
+
+// WithTitle sets the title of the status page.
+func WithTitle(title string) statusHandlerOpt {
+	return func(opts *statusHandlerParams) {
+		opts.title = title
+	}
+}
+
+// WithPageLink adds a top-level link to the status page.
+func WithPageLink(text, url string) statusHandlerOpt {
+	return func(opts *statusHandlerParams) {
+		mak.Set(&opts.pageLinks, text, url)
+	}
+}
+
+// WithProbeLink adds a link to each probe on the status page.
+// The textTpl and urlTpl are Go templates that will be rendered
+// with the respective ProbeInfo struct as the data.
+func WithProbeLink(textTpl, urlTpl string) statusHandlerOpt {
+	return func(opts *statusHandlerParams) {
+		mak.Set(&opts.probeLinks, textTpl, urlTpl)
+	}
+}
+
+// StatusHandler is a handler for the probe overview HTTP endpoint.
+// It shows a list of probes and their current status.
+func (p *Prober) StatusHandler(opts ...statusHandlerOpt) tsweb.ReturnHandlerFunc {
+	params := &statusHandlerParams{
+		title: "Prober Status",
+	}
+	for _, opt := range opts {
+		opt(params)
+	}
+	return func(w http.ResponseWriter, r *http.Request) error {
+		type probeStatus struct {
+			ProbeInfo
+			TimeSinceLast time.Duration
+			Links         map[string]template.URL
+		}
+		vars := struct {
+			Title           string
+			Links           map[string]template.URL
+			TotalProbes     int64
+			UnhealthyProbes int64
+			Probes          map[string]probeStatus
+		}{
+			Title: params.title,
+		}
+
+		for text, url := range params.pageLinks {
+			mak.Set(&vars.Links, text, template.URL(url))
+		}
+
+		for name, info := range p.ProbeInfo() {
+			vars.TotalProbes++
+			if !info.Result {
+				vars.UnhealthyProbes++
+			}
+			s := probeStatus{ProbeInfo: info}
+			if !info.End.IsZero() {
+				s.TimeSinceLast = time.Since(info.End)
+			}
+			for textTpl, urlTpl := range params.probeLinks {
+				text, err := renderTemplate(textTpl, info)
+				if err != nil {
+					return tsweb.Error(500, err.Error(), err)
+				}
+				url, err := renderTemplate(urlTpl, info)
+				if err != nil {
+					return tsweb.Error(500, err.Error(), err)
+				}
+				mak.Set(&s.Links, text, template.URL(url))
+			}
+			mak.Set(&vars.Probes, name, s)
+		}
+
+		if err := statusTpl.ExecuteTemplate(w, "status", vars); err != nil {
+			return tsweb.HTTPError{Code: 500, Err: err, Msg: "error rendering status page"}
+		}
+		return nil
+	}
+}
+
+// renderTemplate renders the given Go template with the provided data
+// and returns the result as a string.
+func renderTemplate(tpl string, data any) (string, error) {
+	t, err := template.New("").Parse(tpl)
+	if err != nil {
+		return "", fmt.Errorf("error parsing template %q: %w", tpl, err)
+	}
+	var buf strings.Builder
+	if err := t.ExecuteTemplate(&buf, "", data); err != nil {
+		return "", fmt.Errorf("error rendering template %q with data %v: %w", tpl, data, err)
+	}
+	return buf.String(), nil
+}

--- a/prober/status.html
+++ b/prober/status.html
@@ -1,0 +1,132 @@
+{{define "status"}}
+<html>
+    <head><title>{{.Title}}</title></head>
+    <style>
+        body {
+            /* max-width: 60rem; */
+            margin-left: auto;
+            margin-right: auto;
+            padding: 3rem 1rem 8rem;
+            line-height: 1.4;
+            font-size: 1rem;
+            font-weight: 400;
+            font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, Noto Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji;
+            text-rendering: optimizeLegibility;
+        }
+        .small {
+            font-size: 0.7rem;
+        }
+        h1 {
+            font-weight: 500;
+            letter-spacing: -.025em;
+        }
+        a { color: rgb(74 125 221); }
+        a:hover { color: rgb(73 100 149); }
+        ul {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+        }
+        ul>li::before {
+            position: absolute;
+            top: .625rem;
+            left: .125rem;
+            height: .375rem;
+            width: .375rem;
+            border-radius: 9999px;
+            background-color: currentColor;
+            opacity: .4;
+            content: "";
+        }
+        ul>li {
+            position: relative;
+            padding-left: 1.25rem;
+        }
+        th, td {
+            padding: 5px;
+            text-align: left;
+            background: #eeeeee;
+        }
+        .error {
+            color: red;
+        }
+    </style>
+<body>
+    <h1>{{.Title}}</h1>
+    <ul>
+        <li>Prober Status:
+        {{if .UnhealthyProbes }}
+            <span class="error">{{.UnhealthyProbes}}</span>
+            out of {{.TotalProbes}} probes failed or never ran.
+        {{else}}
+            All {{.TotalProbes}} probes are healthy
+        {{end}}
+        </li>
+        {{ range $text, $url := .Links }}
+        <li><a href="{{$url}}">{{$text}}</a></li>
+        {{end}}
+    </ul>
+
+    <h1>Probes:</h1>
+    <table class="sortable">
+        <thead><tr>
+            <th>Name</th>
+            <th>Class & Labels</th>
+            <th>Interval</th>
+            <th>Result</th>
+            <th>Success</th>
+            <th>Latency</th>
+            <th>Error</th>
+        </tr></thead>
+        <tbody>
+        {{range $name, $probeInfo := .Probes}}
+        <tr>
+            <td>
+                {{$name}}
+                {{range $text, $url := $probeInfo.Links}}
+                <br/>
+                <button onclick="location.href='{{$url}}';" type="button">
+                    {{$text}}
+                </button>
+                {{end}}
+            </td>
+            <td>{{$probeInfo.Class}}<br/>
+                <div class="small">
+                {{range $label, $value := $probeInfo.Labels}}
+                    {{$label}}={{$value}}<br/>
+                {{end}}
+                </div>
+            </td>
+            <td>{{$probeInfo.Interval}}</td>
+            <td data-sort="{{$probeInfo.TimeSinceLast.Milliseconds}}">
+                {{if $probeInfo.TimeSinceLast}}
+                    {{$probeInfo.TimeSinceLast.String}}<br/>
+                    <span class="small">{{$probeInfo.End}}</span>
+                {{else}}
+                    Never
+                {{end}}
+            </td>
+            <td>
+                {{if $probeInfo.Result}}
+                    {{$probeInfo.Result}}
+                {{else}}
+                    <span class="error">{{$probeInfo.Result}}</span>
+                {{end}}<br/>
+                <div class="small">Recent: {{$probeInfo.RecentResults}}</div>
+                <div class="small">Mean: {{$probeInfo.RecentSuccessRatio}}</div>
+            </td>
+            <td data-sort="{{$probeInfo.Latency.Milliseconds}}">
+                {{$probeInfo.Latency.String}}
+                <div class="small">Recent: {{$probeInfo.RecentLatencies}}</div>
+                <div class="small">Median: {{$probeInfo.RecentMedianLatency}}</div>
+            </td>
+            <td class="small">{{$probeInfo.Error}}</td>
+        </tr>
+        {{end}}
+        </tbody>
+    </table>
+    <link href="https://cdn.jsdelivr.net/gh/tofsjonas/sortable@latest/sortable-base.min.css" rel="stylesheet" />
+    <script src="https://cdn.jsdelivr.net/gh/tofsjonas/sortable@latest/sortable.min.js"></script>
+</body>
+</html>
+{{end}}


### PR DESCRIPTION
- Keep track of the last 10 probe results and successful probe latencies;
- Add an HTTP handler that triggers a given probe by name and returns it result as a plaintext HTML page or JSON, including recent probe results as a baseline
- Add a status page showing a list of all probes, their status, and a button that allows triggering a specific probe.
- Move `cmd/derpprobe` to the new status page.

Example:
<img width="1386" alt="Screenshot 2024-07-31 at 09 07 08" src="https://github.com/user-attachments/assets/12c4cad0-84b5-44c2-9668-1408768c480b">

Updates tailscale/corp#20583