### PR TITLE
net/netns: remove some logspam by avoiding logging parse errors due t…

### DIFF
--- a/net/netns/netns_darwin.go
+++ b/net/netns/netns_darwin.go
@@ -92,7 +92,9 @@ func getInterfaceIndex(logf logger.Logf, netMon *netmon.Monitor, address string)
 	// If the address doesn't parse, use the default index.
 	addr, err := parseAddress(address)
 	if err != nil {
-		logf("[unexpected] netns: error parsing address %q: %v", address, err)
+		if err != errUnspecifiedHost {
+			logf("[unexpected] netns: error parsing address %q: %v", address, err)
+		}
 		return defaultIdx()
 	}
 

--- a/net/netns/netns_dw.go
+++ b/net/netns/netns_dw.go
@@ -6,15 +6,21 @@
 package netns
 
 import (
+	"errors"
 	"net"
 	"net/netip"
 )
+
+var errUnspecifiedHost = errors.New("unspecified host")
 
 func parseAddress(address string) (addr netip.Addr, err error) {
 	host, _, err := net.SplitHostPort(address)
 	if err != nil {
 		// error means the string didn't contain a port number, so use the string directly
 		host = address
+	}
+	if host == "" {
+		return addr, errUnspecifiedHost
 	}
 
 	return netip.ParseAddr(host)

--- a/net/netns/netns_windows.go
+++ b/net/netns/netns_windows.go
@@ -102,7 +102,9 @@ func controlC(logf logger.Logf, network, address string, c syscall.RawConn) (err
 				}
 			}
 		} else {
-			logf("[unexpected] netns: error parsing address %q: %v", address, err)
+			if err != errUnspecifiedHost {
+				logf("[unexpected] netns: error parsing address %q: %v", address, err)
+			}
 			ifaceIdxV4, ifaceIdxV6 = defIfaceIdxV4, defIfaceIdxV6
 		}
 	} else {


### PR DESCRIPTION
…o unspecified addresses

I updated the address parsing stuff to return a specific error for unspecified addresses specified as empty strings, and look for that when logging errors. I explicitly did not make parseAddress return a netip.Addr containing an unspecified address because at this layer, in the absence of any address, we don't necessarily know the address family we're dealing with.

For the purposes of this code I think this is fine, at least until we implement #12588.

Fixes #12979