### PR TITLE
wgengine/netstack: increase gVisor's TCP send and receive buffer sizes

### DIFF
--- a/wgengine/netstack/netstack_tcpbuf_default.go
+++ b/wgengine/netstack/netstack_tcpbuf_default.go
@@ -1,0 +1,20 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !ios
+
+package netstack
+
+import (
+	"gvisor.dev/gvisor/pkg/tcpip/transport/tcp"
+)
+
+const (
+	tcpRXBufMinSize = tcp.MinBufferSize
+	tcpRXBufDefSize = tcp.DefaultSendBufferSize
+	tcpRXBufMaxSize = 8 << 20 // 8MiB
+
+	tcpTXBufMinSize = tcp.MinBufferSize
+	tcpTXBufDefSize = tcp.DefaultReceiveBufferSize
+	tcpTXBufMaxSize = 6 << 20 // 6MiB
+)

--- a/wgengine/netstack/netstack_tcpbuf_ios.go
+++ b/wgengine/netstack/netstack_tcpbuf_ios.go
@@ -1,0 +1,24 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build ios
+
+package netstack
+
+import (
+	"gvisor.dev/gvisor/pkg/tcpip/transport/tcp"
+)
+
+const (
+	// tcp{RX,TX}Buf{Min,Def,Max}Size mirror gVisor defaults. We leave these
+	// unchanged on iOS for now as to not increase pressure towards the
+	// NetworkExtension memory limit.
+	// TODO(jwhited): test memory/throughput impact of collapsing to values in _default.go
+	tcpRXBufMinSize = tcp.MinBufferSize
+	tcpRXBufDefSize = tcp.DefaultSendBufferSize
+	tcpRXBufMaxSize = tcp.MaxBufferSize
+
+	tcpTXBufMinSize = tcp.MinBufferSize
+	tcpTXBufDefSize = tcp.DefaultReceiveBufferSize
+	tcpTXBufMaxSize = tcp.MaxBufferSize
+)


### PR DESCRIPTION
wgengine/netstack: increase gVisor's TCP send and receive buffer sizes

This commit increases gVisor's TCP max send (4->6MiB) and receive
(4->8MiB) buffer sizes on all platforms except iOS. These values are
biased towards higher throughput on high bandwidth-delay product paths.

The iperf3 results below demonstrate the effect of this commit between
two Linux computers with i5-12400 CPUs. 100ms of RTT latency is
introduced via Linux's traffic control network emulator queue
discipline.

The first set of results are from commit f0230ce prior to TCP buffer
resizing.

gVisor write direction:
Test Complete. Summary Results:
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   180 MBytes   151 Mbits/sec    0  sender
[  5]   0.00-10.10  sec   179 MBytes   149 Mbits/sec       receiver

gVisor read direction:
Test Complete. Summary Results:
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.10  sec   337 MBytes   280 Mbits/sec   20 sender
[  5]   0.00-10.00  sec   323 MBytes   271 Mbits/sec         receiver

The second set of results are from this commit with increased TCP
buffer sizes.

gVisor write direction:
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   297 MBytes   249 Mbits/sec    0 sender
[  5]   0.00-10.10  sec   297 MBytes   247 Mbits/sec        receiver

gVisor read direction:
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.10  sec   501 MBytes   416 Mbits/sec   17  sender
[  5]   0.00-10.00  sec   485 MBytes   407 Mbits/sec       receiver

Updates #9707
Updates tailscale/corp#22119