### PR TITLE
util/linuxfw: return nil interface not concrete type

### DIFF
--- a/util/linuxfw/nftables_runner.go
+++ b/util/linuxfw/nftables_runner.go
@@ -592,9 +592,23 @@ func New(logf logger.Logf, prefHint string) (NetfilterRunner, error) {
 	mode := detectFirewallMode(logf, prefHint)
 	switch mode {
 	case FirewallModeIPTables:
-		return newIPTablesRunner(logf)
+		// Note that we don't simply return an newIPTablesRunner here because it
+		// would return a `nil` iptablesRunner which is different from returning
+		// a nil NetfilterRunner.
+		ipr, err := newIPTablesRunner(logf)
+		if err != nil {
+			return nil, err
+		}
+		return ipr, nil
 	case FirewallModeNfTables:
-		return newNfTablesRunner(logf)
+		// Note that we don't simply return an newNfTablesRunner here because it
+		// would return a `nil` nftablesRunner which is different from returning
+		// a nil NetfilterRunner.
+		nfr, err := newNfTablesRunner(logf)
+		if err != nil {
+			return nil, err
+		}
+		return nfr, nil
 	default:
 		return nil, fmt.Errorf("unknown firewall mode %v", mode)
 	}

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -374,7 +374,7 @@ func NewUserspaceEngine(logf logger.Logf, conf Config) (_ Engine, reterr error) 
 		e.logf("onPortUpdate(port=%v, network=%s)", port, network)
 
 		if err := e.router.UpdateMagicsockPort(port, network); err != nil {
-			e.logf("UpdateMagicsockPort(port=%v, network=%s) failed: %w", port, network, err)
+			e.logf("UpdateMagicsockPort(port=%v, network=%s) failed: %v", port, network, err)
 		}
 	}
 	magicsockOpts := magicsock.Options{


### PR DESCRIPTION
It was returning a nil `*iptablesRunner` instead of a nil `NetfilterRunner` interface which would then fail checks later.

Fixes #13012