### PR TITLE
net/packet/checksum: fix v6 NAT

### DIFF
--- a/net/packet/checksum/checksum.go
+++ b/net/packet/checksum/checksum.go
@@ -61,7 +61,7 @@ func UpdateDstAddr(q *packet.Parsed, dst netip.Addr) {
 	b := q.Buffer()
 	if dst.Is6() {
 		v6 := dst.As16()
-		copy(b[24:36], v6[:])
+		copy(b[24:40], v6[:])
 		updateV6PacketChecksums(q, old, dst)
 	} else {
 		v4 := dst.As4()

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -146,7 +146,8 @@ type CapabilityVersion int
 //   - 101: 2024-07-01: Client supports SSH agent forwarding when handling connections with /bin/su
 //   - 102: 2024-07-12: NodeAttrDisableMagicSockCryptoRouting support
 //   - 103: 2024-07-24: Client supports NodeAttrDisableCaptivePortalDetection
-const CurrentCapabilityVersion CapabilityVersion = 103
+//   - 104: 2024-08-03: SelfNodeV6MasqAddrForThisPeer now works
+const CurrentCapabilityVersion CapabilityVersion = 104
 
 type StableID string
 


### PR DESCRIPTION
We were copying 12 out of the 16 bytes which meant that the 1:1 NAT required would only work if the last 4 bytes happened to match between the new and old address, something that our tests accidentally had. Fix it by copying the full 16 bytes and make the tests also verify the addr and use rand addresses.

Updates #9511