### PR TITLE
wgengine/netstack: use build tags to exclude gVisor GRO importation o…

### DIFF
--- a/wgengine/netstack/gro_default.go
+++ b/wgengine/netstack/gro_default.go
@@ -1,0 +1,16 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !ios
+
+package netstack
+
+import (
+	nsgro "gvisor.dev/gvisor/pkg/tcpip/stack/gro"
+)
+
+// gro wraps a gVisor GRO implementation. It exists solely to prevent iOS from
+// importing said package (see _ios.go).
+type gro struct {
+	nsgro.GRO
+}

--- a/wgengine/netstack/gro_ios.go
+++ b/wgengine/netstack/gro_ios.go
@@ -1,0 +1,30 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build ios
+
+package netstack
+
+import (
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+)
+
+// gro on iOS delivers packets to its Dispatcher, immediately. This type exists
+// to prevent importation of the gVisor GRO implementation as said package
+// increases binary size. This is a penalty we do not wish to pay since we
+// currently do not leverage GRO on iOS.
+type gro struct {
+	Dispatcher stack.NetworkDispatcher
+}
+
+func (g *gro) Init(v bool) {
+	if v {
+		panic("GRO is not supported on this platform")
+	}
+}
+
+func (g *gro) Flush() {}
+
+func (g *gro) Enqueue(pkt *stack.PacketBuffer) {
+	g.Dispatcher.DeliverNetworkPacket(pkt.NetworkProtocolNumber, pkt)
+}

--- a/wgengine/netstack/link_endpoint.go
+++ b/wgengine/netstack/link_endpoint.go
@@ -14,7 +14,6 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip/header"
 	"gvisor.dev/gvisor/pkg/tcpip/header/parse"
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
-	"gvisor.dev/gvisor/pkg/tcpip/stack/gro"
 	"tailscale.com/net/packet"
 	"tailscale.com/types/ipproto"
 )
@@ -96,7 +95,7 @@ type linkEndpoint struct {
 	dispatcher stack.NetworkDispatcher
 	linkAddr   tcpip.LinkAddress
 	mtu        uint32
-	gro        gro.GRO // mu only guards access to gro.Dispatcher
+	gro        gro // mu only guards access to gro.Dispatcher
 
 	q *queue // outbound
 }


### PR DESCRIPTION
…n iOS

Updates tailscale/corp#22125