### PR TITLE
ipn/ipnlocal: reload some prefs changes when tailscaled configfile reload endpoint is called

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -626,7 +626,7 @@ func (b *LocalBackend) SetDirectFileRoot(dir string) {
 // success, or (false, error) on failure.
 //
 // If it is called whilst the LocalBackend is in 'Running' state, only a subset
-// of changes currently deemed safe to chnage for a running system are applied.
+// of changes currently deemed safe to change for a running system are applied.
 // The rest of the changes will get applied next time LocalBackend starts and
 // config is reloaded. Currently (08/2024) changes safe to apply while running
 // are changes to '.AcceptRoutes', '.AdvertiseRoutes' and '.StaticEndpoints'
@@ -705,8 +705,7 @@ func (b *LocalBackend) setConfigLocked(conf *conffile.Config, unlock unlockOnce)
 	return err
 }
 
-// needStaticEndpointUpdate accepts a configfile and returns true if the
-// configfile contains a change to the static wireguard endpoints.
+// needStaticEndpointUpdate reports whether newConf modifies the static wireguard endpoints.
 func (b *LocalBackend) needStaticEndpointsUpdate(newConf *conffile.Config) bool {
 	// If the new configfile does not have static endpoints set and existing
 	// config does not have any (to unset), no need to update.

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -659,6 +659,11 @@ func (c *Conn) SetStaticEndpoints(ep views.Slice[netip.AddrPort]) {
 	c.ReSTUN("static-endpoint-change")
 }
 
+// GetStaticEndpoints returns any wireguard endpoints explicitly configured by user.
+func (c *Conn) GetStaticEndpoints() views.Slice[netip.AddrPort] {
+	return c.staticEndpoints
+}
+
 // setNetInfoHavePortMap updates NetInfo.HavePortMap to true.
 func (c *Conn) setNetInfoHavePortMap() {
 	c.mu.Lock()

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -645,7 +645,7 @@ func (c *Conn) setEndpoints(endpoints []tailcfg.Endpoint) (changed bool) {
 
 // SetStaticEndpoints sets static endpoints to the provided value and triggers
 // an asynchronous update of the endpoints that this node advertises.
-// Static endpoints are endpoints explicitly configured by user.
+// Static endpoints are endpoints explicitly configured by the user.
 func (c *Conn) SetStaticEndpoints(ep views.Slice[netip.AddrPort]) {
 	c.mu.Lock()
 	if reflect.DeepEqual(c.staticEndpoints.AsSlice(), ep.AsSlice()) {
@@ -659,8 +659,10 @@ func (c *Conn) SetStaticEndpoints(ep views.Slice[netip.AddrPort]) {
 	c.ReSTUN("static-endpoint-change")
 }
 
-// GetStaticEndpoints returns any wireguard endpoints explicitly configured by user.
+// GetStaticEndpoints returns any wireguard endpoints explicitly configured by the user.
 func (c *Conn) GetStaticEndpoints() views.Slice[netip.AddrPort] {
+	c.mu.Lock()
+	c.mu.Unlock()
 	return c.staticEndpoints
 }
 


### PR DESCRIPTION
This is the first part of work towards making it possible to reload tailscaled config in containers, so that the runner does not need to restart the container on configfile changes, see #13032 

This change ensures that if values of '.AcceptRoutes' and '.AdvertizeRoutes' fields have changed when reload local API endpoint is called, the change will be applied for a LocalBackend in 'Running' state. These specific fields where chosen because those are the values that can change by user action in kube operator proxies. We can then gradually allow more values to be reloaded as we make the configfile easier to use in any containerized environment.

cc @tomhjp @maisem 

Updates tailscale/tailscale#13032