### PR TITLE
Adding missing proto field in ACL parsing structures

### DIFF
--- a/client/tailscale/acl.go
+++ b/client/tailscale/acl.go
@@ -19,6 +19,7 @@ import (
 // Only one of Src/Dst or Users/Ports may be specified.
 type ACLRow struct {
 	Action string   `json:"action,omitempty"` // valid values: "accept"
+	Proto  string   `json:"proto,omitempty"`  // protocol
 	Users  []string `json:"users,omitempty"`  // old name for src
 	Ports  []string `json:"ports,omitempty"`  // old name for dst
 	Src    []string `json:"src,omitempty"`
@@ -31,6 +32,7 @@ type ACLRow struct {
 type ACLTest struct {
 	Src    string   `json:"src,omitempty"`    // source
 	User   string   `json:"user,omitempty"`   // old name for source
+	Proto  string   `json:"proto,omitempty"`  // protocol
 	Accept []string `json:"accept,omitempty"` // expected destination ip:port that user can access
 	Deny   []string `json:"deny,omitempty"`   // expected destination ip:port that user cannot access
 


### PR DESCRIPTION
I was working on a downstream library to parse ACL rules. I noticed the Protocol field was missing in ACL rules and tests when parsing from the API or a file. I'm assuming this was just not needed on the client side and it's done correctly on the server-side :). This PR simply adds the missing fields to the type on the client, although they are unused fields in the source code.