### PR TITLE
cmd/stunstamp: refactor to support multiple protocols

### DIFF
--- a/cmd/stunstamp/stunstamp_default.go
+++ b/cmd/stunstamp/stunstamp_default.go
@@ -8,18 +8,18 @@ package main
 import (
 	"errors"
 	"io"
-	"net"
+	"net/netip"
 	"time"
 )
 
-func getConnKernelTimestamp() (io.ReadWriteCloser, error) {
+func getUDPConnKernelTimestamp() (io.ReadWriteCloser, error) {
 	return nil, errors.New("unimplemented")
 }
 
-func measureRTTKernel(conn io.ReadWriteCloser, dst *net.UDPAddr) (rtt time.Duration, err error) {
+func measureSTUNRTTKernel(conn io.ReadWriteCloser, dst netip.AddrPort) (rtt time.Duration, err error) {
 	return 0, errors.New("unimplemented")
 }
 
-func supportsKernelTS() bool {
+func protocolSupportsKernelTS(_ protocol) bool {
 	return false
 }


### PR DESCRIPTION
'stun' has been removed from metric names and replaced with a protocol label. This refactor is preparation work for HTTPS & ICMP support.

Updates tailscale/corp#22114