### PR TITLE
wgengine/magicsock: fix the freshness of endpoints in callmemaybe

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -634,16 +634,17 @@ func (c *Conn) setEndpoints(endpoints []tailcfg.Endpoint) (changed bool) {
 	}
 
 	c.lastEndpointsTime = time.Now()
+	if !endpointSetsEqual(endpoints, c.lastEndpoints) {
+		changed = true
+	}
+	// lastEndpoints must be updated before onEndpointsRefreshed,
+	// as CallMyMaybe sent via this callback must observe the new endpoints.
+	c.lastEndpoints = endpoints
 	for de, fn := range c.onEndpointRefreshed {
 		go fn()
 		delete(c.onEndpointRefreshed, de)
 	}
-
-	if endpointSetsEqual(endpoints, c.lastEndpoints) {
-		return false
-	}
-	c.lastEndpoints = endpoints
-	return true
+	return changed
 }
 
 // SetStaticEndpoints sets static endpoints to the provided value and triggers


### PR DESCRIPTION
Endpoint storage and state updates are all over the place so the full story is hard to track, but explicitly callmemaybe is executed by a callback that is triggered before the write of new endpoints into the storage that CallMeMaybe sends read from. This is now reordered, so that CallMeMaybe should always observe the most recent endpoints.