### PR TITLE
cmd/gitops-pusher: ignore previous etag if local acls match control

### DIFF
--- a/cmd/gitops-pusher/gitops-pusher.go
+++ b/cmd/gitops-pusher/gitops-pusher.go
@@ -66,6 +66,12 @@ func apply(cache *Cache, client *http.Client, tailnet, apiKey string) func(conte
 		log.Printf("local:   %s", localEtag)
 		log.Printf("cache:   %s", cache.PrevETag)
 
+		if controlEtag == localEtag {
+			cache.PrevETag = localEtag
+			log.Println("no update needed, doing nothing")
+			return nil
+		}
+
 		if cache.PrevETag != controlEtag {
 			if err := modifiedExternallyError(); err != nil {
 				if *failOnManualEdits {
@@ -74,12 +80,6 @@ func apply(cache *Cache, client *http.Client, tailnet, apiKey string) func(conte
 					fmt.Println(err)
 				}
 			}
-		}
-
-		if controlEtag == localEtag {
-			cache.PrevETag = localEtag
-			log.Println("no update needed, doing nothing")
-			return nil
 		}
 
 		if err := applyNewACL(ctx, client, tailnet, apiKey, *policyFname, controlEtag); err != nil {
@@ -113,6 +113,11 @@ func test(cache *Cache, client *http.Client, tailnet, apiKey string) func(contex
 		log.Printf("local:   %s", localEtag)
 		log.Printf("cache:   %s", cache.PrevETag)
 
+		if controlEtag == localEtag {
+			log.Println("no updates found, doing nothing")
+			return nil
+		}
+
 		if cache.PrevETag != controlEtag {
 			if err := modifiedExternallyError(); err != nil {
 				if *failOnManualEdits {
@@ -121,11 +126,6 @@ func test(cache *Cache, client *http.Client, tailnet, apiKey string) func(contex
 					fmt.Println(err)
 				}
 			}
-		}
-
-		if controlEtag == localEtag {
-			log.Println("no updates found, doing nothing")
-			return nil
 		}
 
 		if err := testNewACLs(ctx, client, tailnet, apiKey, *policyFname); err != nil {


### PR DESCRIPTION
In a situation when manual edits are made on the admin panel, around the GitOps process, the pusher will be stuck if `--fail-on-manual-edits` is set, as expected.

To recover from this, there are 2 options:
1. revert the admin panel changes to get back in sync with the code
2. check in the manual edits to code

The former will work well, since previous and local ETags will match control ETag again. The latter will still fail, since local and control ETags match, but previous does not.

For this situation, check the local ETag against control first and ignore previous when things are already in sync.

Updates https://github.com/tailscale/corp/issues/22177