### PR TITLE
net/dns/resolver: log forwarded query details when TS_DEBUG_DNS_FORWARD_SEND is enabled

### DIFF
--- a/net/dns/resolver/forwarder_test.go
+++ b/net/dns/resolver/forwarder_test.go
@@ -201,7 +201,7 @@ func BenchmarkNameFromQuery(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for range b.N {
-		_, err := nameFromQuery(msg)
+		_, _, err := nameFromQuery(msg)
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
Troubleshooting DNS resolution issues often requires additional information. This PR expands the effect of the `TS_DEBUG_DNS_FORWARD_SEND` envknob to `forwarder.forwardWithDestChan`, and includes the request type, domain name length, and the first 3 bytes of the domain's SHA-256 hash in the output.

Fixes #13070