### PR TITLE
net/netcheck: change DERP HTTPS latency measurement to TCP connect time

### DIFF
--- a/net/netcheck/netcheck.go
+++ b/net/netcheck/netcheck.go
@@ -1108,9 +1108,9 @@ func (c *Client) measureHTTPSLatency(ctx context.Context, reg *tailcfg.DERPRegio
 	}
 	result.End(c.timeNow())
 
-	// TODO: decide best timing heuristic here.
-	// Maybe the server should return the tcpinfo_rtt?
-	return result.ServerProcessing, ip, nil
+	// TODO(jwhited): consider simplified TCP RTT. We don't need HTTPS or TLS
+	//  involvement above.
+	return result.TCPConnection, ip, nil
 }
 
 func (c *Client) measureAllICMPLatency(ctx context.Context, rs *reportState, need []*tailcfg.DERPRegion) error {


### PR DESCRIPTION
HTTPS and ICMP latency are fallbacks when STUN doesn't work. The lowest value wins. When ICMP doesn't work you just get HTTPS. HTTPS latency was way more variable than it needed to be as we were measuring "server processing time" (inclusive of TLS, HTTPS) instead of just TCP connect time.

We don't need to perform an HTTPS request, we really just need a TCP ping, but aiming for a simpler change to start.

Updates tailscale/corp#22114