### PR TITLE
cmd/stunstamp: implement HTTPS & TCP latency measurements

### DIFF
--- a/cmd/stunstamp/stunstamp_default.go
+++ b/cmd/stunstamp/stunstamp_default.go
@@ -16,10 +16,14 @@ func getUDPConnKernelTimestamp() (io.ReadWriteCloser, error) {
 	return nil, errors.New("unimplemented")
 }
 
-func measureSTUNRTTKernel(conn io.ReadWriteCloser, dst netip.AddrPort) (rtt time.Duration, err error) {
+func measureSTUNRTTKernel(conn io.ReadWriteCloser, hostname string, dst netip.AddrPort) (rtt time.Duration, err error) {
 	return 0, errors.New("unimplemented")
 }
 
 func protocolSupportsKernelTS(_ protocol) bool {
 	return false
+}
+
+func setSOReuseAddr(fd uintptr) error {
+	return nil
 }


### PR DESCRIPTION
HTTPS mirrors current netcheck behavior and TCP uses tcp_info->rtt.

Updates tailscale/corp#22114