### PR TITLE
cmd/stunstamp: refactor connection construction

### DIFF
--- a/cmd/stunstamp/stunstamp_default.go
+++ b/cmd/stunstamp/stunstamp_default.go
@@ -20,8 +20,28 @@ func measureSTUNRTTKernel(conn io.ReadWriteCloser, hostname string, dst netip.Ad
 	return 0, errors.New("unimplemented")
 }
 
-func protocolSupportsKernelTS(_ protocol) bool {
-	return false
+func getProtocolSupportInfo(p protocol) protocolSupportInfo {
+	switch p {
+	case protocolSTUN:
+		return protocolSupportInfo{
+			kernelTS:    false,
+			userspaceTS: true,
+			stableConn:  true,
+		}
+	case protocolHTTPS:
+		return protocolSupportInfo{
+			kernelTS:    false,
+			userspaceTS: true,
+			stableConn:  true,
+		}
+	case protocolTCP:
+		return protocolSupportInfo{
+			kernelTS:    true,
+			userspaceTS: false,
+			stableConn:  true,
+		}
+	}
+	return protocolSupportInfo{}
 }
 
 func setSOReuseAddr(fd uintptr) error {

--- a/cmd/stunstamp/stunstamp_linux.go
+++ b/cmd/stunstamp/stunstamp_linux.go
@@ -138,12 +138,29 @@ func measureSTUNRTTKernel(conn io.ReadWriteCloser, hostname string, dst netip.Ad
 
 }
 
-func protocolSupportsKernelTS(p protocol) bool {
-	if p == protocolSTUN {
-		return true
+func getProtocolSupportInfo(p protocol) protocolSupportInfo {
+	switch p {
+	case protocolSTUN:
+		return protocolSupportInfo{
+			kernelTS:    true,
+			userspaceTS: true,
+			stableConn:  true,
+		}
+	case protocolHTTPS:
+		return protocolSupportInfo{
+			kernelTS:    false,
+			userspaceTS: true,
+			stableConn:  true,
+		}
+	case protocolTCP:
+		return protocolSupportInfo{
+			kernelTS:    true,
+			userspaceTS: false,
+			stableConn:  true,
+		}
+		// TODO(jwhited): add ICMP
 	}
-	// TODO: jwhited support ICMP
-	return false
+	return protocolSupportInfo{}
 }
 
 func setSOReuseAddr(fd uintptr) error {


### PR DESCRIPTION
getConns() is now responsible for returning both stable and unstable conns. conn and measureFn are now passed together via connAndMeasureFn. newConnAndMeasureFn() is responsible for constructing them.

TCP measurement timeouts are adjusted to more closely match netcheck.