### PR TITLE
tstest/integration/nat: remove -audio none flag from qemu

### DIFF
--- a/tstest/integration/nat/nat_test.go
+++ b/tstest/integration/nat/nat_test.go
@@ -271,7 +271,6 @@ func (nt *natTest) runTest(node1, node2 addNodeFunc) pingRoute {
 			"-chardev", "stdio,id=virtiocon0,mux=on",
 			"-device", "virtconsole,chardev=virtiocon0",
 			"-mon", "chardev=virtiocon0,mode=readline",
-			"-audio", "none",
 		)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr


### PR DESCRIPTION
It's too new to be supported in Debian bookworm so just remove it.
It doesn't seem to matter or help speed anything up.

Updates #13038
