### PR TITLE
ipn/localapi: only flush relevant data in multiFilePostResponseWriter…

### DIFF
--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -1752,10 +1752,17 @@ func (ww *multiFilePostResponseWriter) Write(p []byte) (int, error) {
 }
 
 func (ww *multiFilePostResponseWriter) Flush(w http.ResponseWriter) error {
-	maps.Copy(w.Header(), ww.Header())
-	w.WriteHeader(ww.statusCode)
-	_, err := io.Copy(w, ww.body)
-	return err
+	if ww.header != nil {
+		maps.Copy(w.Header(), ww.header)
+	}
+	if ww.statusCode > 0 {
+		w.WriteHeader(ww.statusCode)
+	}
+	if ww.body != nil {
+		_, err := io.Copy(w, ww.body)
+		return err
+	}
+	return nil
 }
 
 func (h *Handler) singleFilePut(


### PR DESCRIPTION
….Flush()

This prevents two things:

1. Crashing if there's no response body
2. Sending a nonsensical 0 response status code

Updates tailscale/corp#22357