### PR TITLE
cmd/viewer: add support for map-like container types

### DIFF
--- a/cmd/viewer/tests/tests_clone.go
+++ b/cmd/viewer/tests/tests_clone.go
@@ -426,14 +426,18 @@ func (src *StructWithContainers) Clone() *StructWithContainers {
 	dst := new(StructWithContainers)
 	*dst = *src
 	dst.CloneableContainer = *src.CloneableContainer.Clone()
-	dst.ClonableGenericContainer = *src.ClonableGenericContainer.Clone()
+	dst.CloneableGenericContainer = *src.CloneableGenericContainer.Clone()
+	dst.CloneableMap = *src.CloneableMap.Clone()
+	dst.CloneableGenericMap = *src.CloneableGenericMap.Clone()
 	return dst
 }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _StructWithContainersCloneNeedsRegeneration = StructWithContainers(struct {
-	IntContainer             Container[int]
-	CloneableContainer       Container[*StructWithPtrs]
-	BasicGenericContainer    Container[GenericBasicStruct[int]]
-	ClonableGenericContainer Container[*GenericNoPtrsStruct[int]]
+	IntContainer              Container[int]
+	CloneableContainer        Container[*StructWithPtrs]
+	BasicGenericContainer     Container[GenericBasicStruct[int]]
+	CloneableGenericContainer Container[*GenericNoPtrsStruct[int]]
+	CloneableMap              MapContainer[int, *StructWithPtrs]
+	CloneableGenericMap       MapContainer[int, *GenericNoPtrsStruct[int]]
 }{})

--- a/cmd/viewer/tests/tests_view.go
+++ b/cmd/viewer/tests/tests_view.go
@@ -657,14 +657,22 @@ func (v StructWithContainersView) CloneableContainer() ContainerView[*StructWith
 func (v StructWithContainersView) BasicGenericContainer() Container[GenericBasicStruct[int]] {
 	return v.ж.BasicGenericContainer
 }
-func (v StructWithContainersView) ClonableGenericContainer() ContainerView[*GenericNoPtrsStruct[int], GenericNoPtrsStructView[int]] {
-	return ContainerViewOf(&v.ж.ClonableGenericContainer)
+func (v StructWithContainersView) CloneableGenericContainer() ContainerView[*GenericNoPtrsStruct[int], GenericNoPtrsStructView[int]] {
+	return ContainerViewOf(&v.ж.CloneableGenericContainer)
+}
+func (v StructWithContainersView) CloneableMap() MapContainerView[int, *StructWithPtrs, StructWithPtrsView] {
+	return MapContainerViewOf(&v.ж.CloneableMap)
+}
+func (v StructWithContainersView) CloneableGenericMap() MapContainerView[int, *GenericNoPtrsStruct[int], GenericNoPtrsStructView[int]] {
+	return MapContainerViewOf(&v.ж.CloneableGenericMap)
 }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _StructWithContainersViewNeedsRegeneration = StructWithContainers(struct {
-	IntContainer             Container[int]
-	CloneableContainer       Container[*StructWithPtrs]
-	BasicGenericContainer    Container[GenericBasicStruct[int]]
-	ClonableGenericContainer Container[*GenericNoPtrsStruct[int]]
+	IntContainer              Container[int]
+	CloneableContainer        Container[*StructWithPtrs]
+	BasicGenericContainer     Container[GenericBasicStruct[int]]
+	CloneableGenericContainer Container[*GenericNoPtrsStruct[int]]
+	CloneableMap              MapContainer[int, *StructWithPtrs]
+	CloneableGenericMap       MapContainer[int, *GenericNoPtrsStruct[int]]
 }{})

--- a/cmd/viewer/viewer.go
+++ b/cmd/viewer/viewer.go
@@ -448,7 +448,7 @@ func viewTypeForContainerType(typ types.Type) (*types.Named, *types.Func) {
 	}
 	// ...and add the element view type.
 	// For that, we need to first determine the named elem type...
-	elemType, ok := baseType(containerType.TypeArgs().At(0)).(*types.Named)
+	elemType, ok := baseType(containerType.TypeArgs().At(containerType.TypeArgs().Len() - 1)).(*types.Named)
 	if !ok {
 		return nil, nil
 	}


### PR DESCRIPTION
This PR modifies viewTypeForContainerType to use the last type parameter of a container type as the value type, enabling the implementation of map-like container types where the second-to-last (usually first) type parameter serves as the key type.

It also adds a MapContainer type to test the code generation.

Updates #12736