### PR TITLE
health/dns: reduce severity of DNS unavailable warning

### DIFF
--- a/net/dns/resolver/forwarder.go
+++ b/net/dns/resolver/forwarder.go
@@ -177,7 +177,7 @@ func clampEDNSSize(packet []byte, maxSize uint16) {
 var dnsForwarderFailing = health.Register(&health.Warnable{
 	Code:                "dns-forward-failing",
 	Title:               "DNS unavailable",
-	Severity:            health.SeverityHigh,
+	Severity:            health.SeverityMedium,
 	DependsOn:           []*health.Warnable{health.NetworkStatusWarnable},
 	Text:                health.StaticMessage("Tailscale can't reach the configured DNS servers. Internet connectivity may be affected."),
 	ImpactsConnectivity: true,


### PR DESCRIPTION
Fixes tailscale/tailscale#13151

`DNS unavailable` was marked as a high severity warning. If people enter an area with bad cellular reception, they're bound to receive so many of these notifications as soon as the DNS can't be reached anymore. On Android (and other platforms), high severity notifications trigger a system notification. To reduce notification fatigue, here we reduce the severity level to medium. A medium severity warning will still display the warning icon on platforms with a tray icon because of the `ImpactsConnectivity=true` flag being set here, but it won't show a notification anymore. 