### PR TITLE
wgengine/magicsock: don't upgrade to linuxBatchingConn on Android

### DIFF
--- a/wgengine/magicsock/batching_conn_linux.go
+++ b/wgengine/magicsock/batching_conn_linux.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -366,6 +367,10 @@ func setGSOSizeInControl(control *[]byte, gsoSize uint16) {
 // tryUpgradeToBatchingConn probes the capabilities of the OS and pconn, and
 // upgrades pconn to a *linuxBatchingConn if appropriate.
 func tryUpgradeToBatchingConn(pconn nettype.PacketConn, network string, batchSize int) nettype.PacketConn {
+	if runtime.GOOS != "linux" {
+		// Exclude Android.
+		return pconn
+	}
 	if network != "udp4" && network != "udp6" {
 		return pconn
 	}


### PR DESCRIPTION
In a93dc6cdb10bcc87742011d3746660f06cf8cd1e tryUpgradeToBatchingConn() moved to build tag gated files, but the runtime.GOOS condition excluding Android was removed unintentionally from batching_conn_linux.go. Add it back.

Updates tailscale/corp#22348