### PR TITLE
posture: deduplicate MAC addresses before returning them

### DIFF
--- a/posture/hwaddr.go
+++ b/posture/hwaddr.go
@@ -22,5 +22,5 @@ func GetHardwareAddrs() (hwaddrs []string, err error) {
 		}
 	})
 	slices.Sort(hwaddrs)
-	return
+	return slices.Compact(hwaddrs), err
 }


### PR DESCRIPTION
Some machines have multiple network interfaces with the same MAC address.

Updates tailscale/corp#21371