### PR TITLE
fix: #13195 ipn/ipnlocal/drive.go  Redundant drive shares notify

### DIFF
--- a/ipn/ipnlocal/drive.go
+++ b/ipn/ipnlocal/drive.go
@@ -252,6 +252,7 @@ func (b *LocalBackend) driveNotifyShares(shares views.SliceView[*drive.Share, dr
 	// Ensures shares is not nil to distinguish "no shares" from "not notifying shares"
 	if shares.IsNil() {
 		shares = views.SliceOfViews(make([]*drive.Share, 0))
+		b.lastNotifiedDriveShares.Store(&shares)
 	}
 	b.send(ipn.Notify{DriveShares: shares})
 }


### PR DESCRIPTION
The comment "Ensures shares is not nil to distinguish 'no shares' from 'not notifying shares'" indicates that the variable `shares` might be changed from `nil` to `[]`. However, `lastNotifiedDriveShares` does not save this change, causing the drive shares to always notify changes.