### PR TITLE
cmd/systray: set ipn.NotifyNoPrivateKeys, permit non-operator use

### DIFF
--- a/cmd/systray/systray.go
+++ b/cmd/systray/systray.go
@@ -180,7 +180,7 @@ func (menu *Menu) eventLoop(ctx context.Context) {
 // watchIPNBus subscribes to the tailscale event bus and sends state updates to chState.
 // This method does not return.
 func watchIPNBus(ctx context.Context) {
-	watcher, err := localClient.WatchIPNBus(ctx, ipn.NotifyInitialState)
+	watcher, err := localClient.WatchIPNBus(ctx, ipn.NotifyInitialState|ipn.NotifyNoPrivateKeys)
 	if err != nil {
 		log.Printf("watching ipn bus: %v", err)
 	}


### PR DESCRIPTION
Otherwise you get "Access denied: watch IPN bus access denied, must
set ipn.NotifyNoPrivateKeys when not running as admin/root or
operator".

This lets a non-operator at least start the app and see the status, even
if they can't change everything. (the web UI is unaffected by operator)

A future change can add a LocalAPI call to check permissions and guide
people through adding a user as an operator (perhaps the web client
can do that?)

Updates #1708
