### PR TITLE
ipn/ipnlocal: install IPv6 service addr route

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -4604,6 +4604,9 @@ func (b *LocalBackend) routerConfig(cfg *wgcfg.Config, prefs ipn.PrefsView, oneC
 	if slices.ContainsFunc(rs.LocalAddrs, tsaddr.PrefixIs4) {
 		rs.Routes = append(rs.Routes, netip.PrefixFrom(tsaddr.TailscaleServiceIP(), 32))
 	}
+	if slices.ContainsFunc(rs.LocalAddrs, tsaddr.PrefixIs6) {
+		rs.Routes = append(rs.Routes, netip.PrefixFrom(tsaddr.TailscaleServiceIPv6(), 128))
+	}
 
 	return rs
 }


### PR DESCRIPTION
This is the equivalent of quad-100, but for IPv6. This is technically already contained in the Tailscale IPv6 ULA prefix, but that is only installed when remote peers are visible via control with contained addrs. The service addr should always be reachable.

Updates #1152