### PR TITLE
wgengine/netstack: re-enable gVisor GSO on Linux

### DIFF
--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -329,8 +329,8 @@ func Create(logf logger.Logf, tundev *tstun.Wrapper, e wgengine.Engine, mc *magi
 	supportedGROKind := groNotSupported
 	if runtime.GOOS == "linux" {
 		// TODO(jwhited): add Windows support https://github.com/tailscale/corp/issues/21874
-		// TODO(jwhited): re-enable GSO https://github.com/tailscale/corp/issues/22511
 		supportedGROKind = tcpGROSupported
+		supportedGSOKind = stack.HostGSOSupported
 	}
 	linkEP := newLinkEndpoint(512, uint32(tstun.DefaultTUNMTU()), "", supportedGROKind)
 	linkEP.SupportedGSOKind = supportedGSOKind


### PR DESCRIPTION
This was previously disabled in 8e42510 due to missing GSO-awareness in tstun, which was resolved in d097096.

Updates tailscale/corp#22511