### PR TITLE
ipn/{ipnauth,ipnlocal,ipnserver}: send the auth URL to the user who started interactive login

### DIFF
--- a/ipn/ipnauth/ipnauth_notwindows.go
+++ b/ipn/ipnauth/ipnauth_notwindows.go
@@ -18,7 +18,9 @@ import (
 func GetConnIdentity(_ logger.Logf, c net.Conn) (ci *ConnIdentity, err error) {
 	ci = &ConnIdentity{conn: c, notWindows: true}
 	_, ci.isUnixSock = c.(*net.UnixConn)
-	ci.creds, _ = peercred.Get(c)
+	if ci.creds, _ = peercred.Get(c); ci.creds != nil {
+		ci.pid, _ = ci.creds.PID()
+	}
 	return ci, nil
 }
 

--- a/ipn/ipnauth/test_actor.go
+++ b/ipn/ipnauth/test_actor.go
@@ -1,0 +1,36 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package ipnauth
+
+import (
+	"tailscale.com/ipn"
+)
+
+var _ Actor = (*TestActor)(nil)
+
+// TestActor is an [Actor] used exclusively for testing purposes.
+type TestActor struct {
+	UID         ipn.WindowsUserID // OS-specific UID of the user, if the actor represents a local Windows user
+	Name        string            // username associated with the actor, or ""
+	NameErr     error             // error to be returned by [TestActor.Username]
+	CID         ClientID          // non-zero if the actor represents a connected LocalAPI client
+	LocalSystem bool              // whether the actor represents the special Local System account on Windows
+	LocalAdmin  bool              // whether the actor has local admin access
+
+}
+
+// UserID implements [Actor].
+func (a *TestActor) UserID() ipn.WindowsUserID { return a.UID }
+
+// Username implements [Actor].
+func (a *TestActor) Username() (string, error) { return a.Name, a.NameErr }
+
+// ClientID implements [Actor].
+func (a *TestActor) ClientID() (_ ClientID, ok bool) { return a.CID, a.CID != NoClientID }
+
+// IsLocalSystem implements [Actor].
+func (a *TestActor) IsLocalSystem() bool { return a.LocalSystem }
+
+// IsLocalAdmin implements [Actor].
+func (a *TestActor) IsLocalAdmin(operatorUID string) bool { return a.LocalAdmin }

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -154,10 +154,12 @@ func RegisterNewSSHServer(fn newSSHServerFunc) {
 	newSSHServer = fn
 }
 
-// watchSession represents a WatchNotifications channel
+// watchSession represents a WatchNotifications channel,
+// an [ipnauth.Actor] that owns it (e.g., a connected GUI/CLI),
 // and sessionID as required to close targeted buses.
 type watchSession struct {
 	ch        chan *ipn.Notify
+	owner     ipnauth.Actor // or nil
 	sessionID string
 	cancel    func() // call to signal that the session must be terminated
 }
@@ -264,9 +266,9 @@ type LocalBackend struct {
 	endpoints        []tailcfg.Endpoint
 	blocked          bool
 	keyExpired       bool
-	authURL          string    // non-empty if not Running
-	authURLTime      time.Time // when the authURL was received from the control server
-	interact         bool      // indicates whether a user requested interactive login
+	authURL          string        // non-empty if not Running
+	authURLTime      time.Time     // when the authURL was received from the control server
+	authActor        ipnauth.Actor // an actor who called [LocalBackend.StartLoginInteractive] last, or nil
 	egg              bool
 	prevIfState      *netmon.State
 	peerAPIServer    *peerAPIServer // or nil
@@ -2128,10 +2130,10 @@ func (b *LocalBackend) Start(opts ipn.Options) error {
 
 	blid := b.backendLogID.String()
 	b.logf("Backend: logs: be:%v fe:%v", blid, opts.FrontendLogID)
-	b.sendLocked(ipn.Notify{
+	b.sendToLocked(ipn.Notify{
 		BackendLogID: &blid,
 		Prefs:        &prefs,
-	})
+	}, allClients)
 
 	if !loggedOut && (b.hasNodeKeyLocked() || confWantRunning) {
 		// If we know that we're either logged in or meant to be
@@ -2656,10 +2658,15 @@ func applyConfigToHostinfo(hi *tailcfg.Hostinfo, c *conffile.Config) {
 // notifications. There is currently (2022-11-22) no mechanism provided to
 // detect when a message has been dropped.
 func (b *LocalBackend) WatchNotifications(ctx context.Context, mask ipn.NotifyWatchOpt, onWatchAdded func(), fn func(roNotify *ipn.Notify) (keepGoing bool)) {
+	b.WatchNotificationsAs(ctx, nil, mask, onWatchAdded, fn)
+}
+
+// WatchNotificationsAs is like WatchNotifications but takes an [ipnauth.Actor]
+// as an additional parameter. If non-nil, the specified callback is invoked
+// only for notifications relevant to this actor.
+func (b *LocalBackend) WatchNotificationsAs(ctx context.Context, actor ipnauth.Actor, mask ipn.NotifyWatchOpt, onWatchAdded func(), fn func(roNotify *ipn.Notify) (keepGoing bool)) {
 	ch := make(chan *ipn.Notify, 128)
-
 	sessionID := rands.HexString(16)
-
 	origFn := fn
 	if mask&ipn.NotifyNoPrivateKeys != 0 {
 		fn = func(n *ipn.Notify) bool {
@@ -2711,6 +2718,7 @@ func (b *LocalBackend) WatchNotifications(ctx context.Context, mask ipn.NotifyWa
 
 	session := &watchSession{
 		ch:        ch,
+		owner:     actor,
 		sessionID: sessionID,
 		cancel:    cancel,
 	}
@@ -2833,13 +2841,71 @@ func (b *LocalBackend) DebugPickNewDERP() error {
 //
 // b.mu must not be held.
 func (b *LocalBackend) send(n ipn.Notify) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	b.sendLocked(n)
+	b.sendTo(n, allClients)
 }
 
-// sendLocked is like send, but assumes b.mu is already held.
-func (b *LocalBackend) sendLocked(n ipn.Notify) {
+// notificationTarget describes a notification recipient.
+// A zero value is valid and indicate that the notification
+// should be broadcast to all active [watchSession]s.
+type notificationTarget struct {
+	// userID is the OS-specific UID of the target user.
+	// If empty, the notification is not user-specific and
+	// will be broadcast to all connected users.
+	// TODO(nickkhyl): make this field cross-platform rather
+	// than Windows-specific.
+	userID ipn.WindowsUserID
+	// clientID identifies a client that should be the exclusive recipient
+	// of the notification. A zero value indicates that notification should
+	// be sent to all sessions of the specified user.
+	clientID ipnauth.ClientID
+}
+
+var allClients = notificationTarget{} // broadcast to all connected clients
+
+// toNotificationTarget returns a [notificationTarget] that matches only actors
+// representing the same user as the specified actor. If the actor represents
+// a specific connected client, the [ipnauth.ClientID] must also match.
+// If the actor is nil, the [notificationTarget] matches all actors.
+func toNotificationTarget(actor ipnauth.Actor) notificationTarget {
+	t := notificationTarget{}
+	if actor != nil {
+		t.userID = actor.UserID()
+		t.clientID, _ = actor.ClientID()
+	}
+	return t
+}
+
+// match reports whether the specified actor should receive notifications
+// targeting t. If the actor is nil, it should only receive notifications
+// intended for all users.
+func (t notificationTarget) match(actor ipnauth.Actor) bool {
+	if t == allClients {
+		return true
+	}
+	if actor == nil {
+		return false
+	}
+	if t.userID != "" && t.userID != actor.UserID() {
+		return false
+	}
+	if t.clientID != ipnauth.NoClientID {
+		clientID, ok := actor.ClientID()
+		if !ok || clientID != t.clientID {
+			return false
+		}
+	}
+	return true
+}
+
+// sendTo is like [LocalBackend.send] but allows specifying a recipient.
+func (b *LocalBackend) sendTo(n ipn.Notify, recipient notificationTarget) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.sendToLocked(n, recipient)
+}
+
+// sendToLocked is like [LocalBackend.sendTo], but assumes b.mu is already held.
+func (b *LocalBackend) sendToLocked(n ipn.Notify, recipient notificationTarget) {
 	if n.Prefs != nil {
 		n.Prefs = ptr.To(stripKeysFromPrefs(*n.Prefs))
 	}
@@ -2853,10 +2919,12 @@ func (b *LocalBackend) sendLocked(n ipn.Notify) {
 	}
 
 	for _, sess := range b.notifyWatchers {
-		select {
-		case sess.ch <- &n:
-		default:
-			// Drop the notification if the channel is full.
+		if recipient.match(sess.owner) {
+			select {
+			case sess.ch <- &n:
+			default:
+				// Drop the notification if the channel is full.
+			}
 		}
 	}
 }
@@ -2891,15 +2959,18 @@ func (b *LocalBackend) sendFileNotify() {
 // This method is called when a new authURL is received from the control plane, meaning that either a user
 // has started a new interactive login (e.g., by running `tailscale login` or clicking Login in the GUI),
 // or the control plane was unable to authenticate this node non-interactively (e.g., due to key expiration).
-// b.interact indicates whether an interactive login is in progress.
+// A non-nil b.authActor indicates that an interactive login is in progress and was initiated by the specified actor.
 // If url is "", it is equivalent to calling [LocalBackend.resetAuthURLLocked] with b.mu held.
 func (b *LocalBackend) setAuthURL(url string) {
 	var popBrowser, keyExpired bool
+	var recipient ipnauth.Actor
 
 	b.mu.Lock()
 	switch {
 	case url == "":
 		b.resetAuthURLLocked()
+		b.mu.Unlock()
+		return
 	case b.authURL != url:
 		b.authURL = url
 		b.authURLTime = b.clock.Now()
@@ -2908,26 +2979,27 @@ func (b *LocalBackend) setAuthURL(url string) {
 		popBrowser = true
 	default:
 		// Otherwise, only open it if the user explicitly requests interactive login.
-		popBrowser = b.interact
+		popBrowser = b.authActor != nil
 	}
 	keyExpired = b.keyExpired
+	recipient = b.authActor // or nil
 	// Consume the StartLoginInteractive call, if any, that caused the control
 	// plane to send us this URL.
-	b.interact = false
+	b.authActor = nil
 	b.mu.Unlock()
 
 	if popBrowser {
-		b.popBrowserAuthNow(url, keyExpired)
+		b.popBrowserAuthNow(url, keyExpired, recipient)
 	}
 }
 
-// popBrowserAuthNow shuts down the data plane and sends an auth URL
-// to the connected frontend, if any.
+// popBrowserAuthNow shuts down the data plane and sends the URL to the recipient's
+// [watchSession]s if the recipient is non-nil; otherwise, it sends the URL to all watchSessions.
 // keyExpired is the value of b.keyExpired upon entry and indicates
 // whether the node's key has expired.
 // It must not be called with b.mu held.
-func (b *LocalBackend) popBrowserAuthNow(url string, keyExpired bool) {
-	b.logf("popBrowserAuthNow: url=%v, key-expired=%v, seamless-key-renewal=%v", url != "", keyExpired, b.seamlessRenewalEnabled())
+func (b *LocalBackend) popBrowserAuthNow(url string, keyExpired bool, recipient ipnauth.Actor) {
+	b.logf("popBrowserAuthNow(%q): url=%v, key-expired=%v, seamless-key-renewal=%v", maybeUsernameOf(recipient), url != "", keyExpired, b.seamlessRenewalEnabled())
 
 	// Deconfigure the local network data plane if:
 	// - seamless key renewal is not enabled;
@@ -2936,7 +3008,7 @@ func (b *LocalBackend) popBrowserAuthNow(url string, keyExpired bool) {
 		b.blockEngineUpdates(true)
 		b.stopEngineAndWait()
 	}
-	b.tellClientToBrowseToURL(url)
+	b.tellRecipientToBrowseToURL(url, toNotificationTarget(recipient))
 	if b.State() == ipn.Running {
 		b.enterState(ipn.Starting)
 	}
@@ -2977,8 +3049,13 @@ func (b *LocalBackend) validPopBrowserURL(urlStr string) bool {
 }
 
 func (b *LocalBackend) tellClientToBrowseToURL(url string) {
+	b.tellRecipientToBrowseToURL(url, allClients)
+}
+
+// tellRecipientToBrowseToURL is like tellClientToBrowseToURL but allows specifying a recipient.
+func (b *LocalBackend) tellRecipientToBrowseToURL(url string, recipient notificationTarget) {
 	if b.validPopBrowserURL(url) {
-		b.send(ipn.Notify{BrowseToURL: &url})
+		b.sendTo(ipn.Notify{BrowseToURL: &url}, recipient)
 	}
 }
 
@@ -3250,6 +3327,15 @@ func (b *LocalBackend) tryLookupUserName(uid string) string {
 // StartLoginInteractive attempts to pick up the in-progress flow where it left
 // off.
 func (b *LocalBackend) StartLoginInteractive(ctx context.Context) error {
+	return b.StartLoginInteractiveAs(ctx, nil)
+}
+
+// StartLoginInteractiveAs is like StartLoginInteractive but takes an [ipnauth.Actor]
+// as an additional parameter. If non-nil, the specified user is expected to complete
+// the interactive login, and therefore will receive the BrowseToURL notification once
+// the control plane sends us one. Otherwise, the notification will be delivered to all
+// active [watchSession]s.
+func (b *LocalBackend) StartLoginInteractiveAs(ctx context.Context, user ipnauth.Actor) error {
 	b.mu.Lock()
 	if b.cc == nil {
 		panic("LocalBackend.assertClient: b.cc == nil")
@@ -3263,17 +3349,17 @@ func (b *LocalBackend) StartLoginInteractive(ctx context.Context) error {
 	hasValidURL := url != "" && timeSinceAuthURLCreated < ((7*24*time.Hour)-(1*time.Hour))
 	if !hasValidURL {
 		// A user wants to log in interactively, but we don't have a valid authURL.
-		// Set a flag to indicate that interactive login is in progress, forcing
-		// a BrowseToURL notification once the authURL becomes available.
-		b.interact = true
+		// Remember the user who initiated the login, so that we can notify them
+		// once the authURL is available.
+		b.authActor = user
 	}
 	cc := b.cc
 	b.mu.Unlock()
 
-	b.logf("StartLoginInteractive: url=%v", hasValidURL)
+	b.logf("StartLoginInteractiveAs(%q): url=%v", maybeUsernameOf(user), hasValidURL)
 
 	if hasValidURL {
-		b.popBrowserAuthNow(url, keyExpired)
+		b.popBrowserAuthNow(url, keyExpired, user)
 	} else {
 		cc.Login(b.loginFlags | controlclient.LoginInteractive)
 	}
@@ -5119,7 +5205,7 @@ func (b *LocalBackend) resetControlClientLocked() controlclient.Client {
 func (b *LocalBackend) resetAuthURLLocked() {
 	b.authURL = ""
 	b.authURLTime = time.Time{}
-	b.interact = false
+	b.authActor = nil
 }
 
 // ResetForClientDisconnect resets the backend for GUI clients running
@@ -7363,4 +7449,14 @@ func (b *LocalBackend) srcIPHasCapForFilter(srcIP netip.Addr, cap tailcfg.NodeCa
 		return false
 	}
 	return n.HasCap(cap)
+}
+
+// maybeUsernameOf returns the actor's username if the actor
+// is non-nil and its username can be resolved.
+func maybeUsernameOf(actor ipnauth.Actor) string {
+	var username string
+	if actor != nil {
+		username, _ = actor.Username()
+	}
+	return username
 }

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -1231,7 +1231,7 @@ func (h *Handler) serveWatchIPNBus(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	ctx := r.Context()
 	enc := json.NewEncoder(w)
-	h.b.WatchNotifications(ctx, mask, f.Flush, func(roNotify *ipn.Notify) (keepGoing bool) {
+	h.b.WatchNotificationsAs(ctx, h.Actor, mask, f.Flush, func(roNotify *ipn.Notify) (keepGoing bool) {
 		err := enc.Encode(roNotify)
 		if err != nil {
 			h.logf("json.Encode: %v", err)
@@ -1251,7 +1251,7 @@ func (h *Handler) serveLoginInteractive(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "want POST", http.StatusBadRequest)
 		return
 	}
-	h.b.StartLoginInteractive(r.Context())
+	h.b.StartLoginInteractiveAs(r.Context(), h.Actor)
 	w.WriteHeader(http.StatusNoContent)
 	return
 }

--- a/ipn/localapi/localapi_test.go
+++ b/ipn/localapi/localapi_test.go
@@ -39,23 +39,6 @@ import (
 	"tailscale.com/wgengine"
 )
 
-var _ ipnauth.Actor = (*testActor)(nil)
-
-type testActor struct {
-	uid           ipn.WindowsUserID
-	name          string
-	isLocalSystem bool
-	isLocalAdmin  bool
-}
-
-func (u *testActor) UserID() ipn.WindowsUserID { return u.uid }
-
-func (u *testActor) Username() (string, error) { return u.name, nil }
-
-func (u *testActor) IsLocalSystem() bool { return u.isLocalSystem }
-
-func (u *testActor) IsLocalAdmin(operatorUID string) bool { return u.isLocalAdmin }
-
 func TestValidHost(t *testing.T) {
 	tests := []struct {
 		host  string
@@ -207,7 +190,7 @@ func TestWhoIsArgTypes(t *testing.T) {
 
 func TestShouldDenyServeConfigForGOOSAndUserContext(t *testing.T) {
 	newHandler := func(connIsLocalAdmin bool) *Handler {
-		return &Handler{Actor: &testActor{isLocalAdmin: connIsLocalAdmin}, b: newTestLocalBackend(t)}
+		return &Handler{Actor: &ipnauth.TestActor{LocalAdmin: connIsLocalAdmin}, b: newTestLocalBackend(t)}
 	}
 	tests := []struct {
 		name     string


### PR DESCRIPTION
We add the `ClientID()` method to the `ipnauth.Actor` interface and updated `ipnserver.actor` to implement it. This method returns a unique ID of the connected client if the actor represents one. It helps link a series of interactions initiated by the client, such as when a notification needs to be sent back to a specific session, rather than all active sessions, in response to a certain request.

We also add `LocalBackend.WatchNotificationsAs` and `LocalBackend.StartLoginInteractiveAs` methods, which are like `WatchNotifications` and `StartLoginInteractive` but accept an additional parameter specifying an `ipnauth.Actor` who initiates the operation. We store these actor identities in `watchSession.owner` and `LocalBackend.authActor`, respectively, and implement `LocalBackend.sendTo` and related helper methods to enable sending notifications to `watchSessions` associated with actors (or, more broadly, identifiable recipients).

We then use the above to change who receives the `BrowseToURL` notifications:
 - For user-initiated, interactive logins, the notification is delivered only to the user who initiated the process. If the initiating actor represents a specific connected client, the URL notification is sent back to the same LocalAPI client that called `StartLoginInteractive`. Otherwise, the notification is sent to all clients connected as that user. Currently, we only differentiate between users on Windows, as it is inherently a multi-user OS.
 - In all other cases (e.g., node key expiration), we send the notification to all connected users.

Updates tailscale/corp#18342