### PR TITLE
net/tstun,wgengine/netstack: implement TCP GRO for local services

### DIFF
--- a/net/tstun/wrap_test.go
+++ b/net/tstun/wrap_test.go
@@ -615,7 +615,7 @@ func TestFilterDiscoLoop(t *testing.T) {
 	memLog.Reset()
 	pp := new(packet.Parsed)
 	pp.Decode(pkt)
-	got = tw.filterPacketOutboundToWireGuard(pp, nil)
+	got, _ = tw.filterPacketOutboundToWireGuard(pp, nil, nil)
 	if got != filter.DropSilently {
 		t.Errorf("got %v; want DropSilently", got)
 	}

--- a/wgengine/netstack/netstack_test.go
+++ b/wgengine/netstack/netstack_test.go
@@ -750,7 +750,7 @@ func TestHandleLocalPackets(t *testing.T) {
 			Dst:       netip.MustParseAddrPort("100.100.100.100:53"),
 			TCPFlags:  packet.TCPSyn,
 		}
-		resp := impl.handleLocalPackets(pkt, impl.tundev)
+		resp, _ := impl.handleLocalPackets(pkt, impl.tundev, nil)
 		if resp != filter.DropSilently {
 			t.Errorf("got filter outcome %v, want filter.DropSilently", resp)
 		}
@@ -767,7 +767,7 @@ func TestHandleLocalPackets(t *testing.T) {
 			Dst:      netip.MustParseAddrPort("[fd7a:115c:a1e0:b1a:0:7:a01:109]:5678"),
 			TCPFlags: packet.TCPSyn,
 		}
-		resp := impl.handleLocalPackets(pkt, impl.tundev)
+		resp, _ := impl.handleLocalPackets(pkt, impl.tundev, nil)
 
 		// DropSilently is the outcome we expected, since we actually
 		// handled this packet by injecting it into netstack, which
@@ -789,7 +789,7 @@ func TestHandleLocalPackets(t *testing.T) {
 			Dst:      netip.MustParseAddrPort("[fd7a:115c:a1e0:b1a:0:63:a01:109]:5678"),
 			TCPFlags: packet.TCPSyn,
 		}
-		resp := impl.handleLocalPackets(pkt, impl.tundev)
+		resp, _ := impl.handleLocalPackets(pkt, impl.tundev, nil)
 
 		// Accept means that handleLocalPackets does not handle this
 		// packet, we "accept" it to continue further processing,


### PR DESCRIPTION
Throughput improves substantially when measured via netstack loopback
(TS_DEBUG_NETSTACK_LOOPBACK_PORT).

Before (d21ebc2):
jwhited@i5-12400-2:~$ iperf3 -V -c 100.100.100.100
Starting Test: protocol: TCP, 1 streams, 131072 byte blocks
Test Complete. Summary Results:
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec  5.77 GBytes  4.95 Gbits/sec    0 sender
[  5]   0.00-10.01  sec  5.77 GBytes  4.95 Gbits/sec      receiver

After:
jwhited@i5-12400-2:~$ iperf3 -V -c 100.100.100.100
Starting Test: protocol: TCP, 1 streams, 131072 byte blocks
Test Complete. Summary Results:
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec  12.7 GBytes  10.9 Gbits/sec    0 sender
[  5]   0.00-10.00  sec  12.7 GBytes  10.9 Gbits/sec      receiver

Updates tailscale/corp#22754