### PR TITLE
posture: stop logging serial numbers

### DIFF
--- a/posture/serialnumber_notmacos.go
+++ b/posture/serialnumber_notmacos.go
@@ -98,8 +98,5 @@ func GetSerialNumbers(logf logger.Logf) ([]string, error) {
 			}
 		}
 	}
-
-	logf("got serial numbers %v", serials)
-
 	return serials, nil
 }


### PR DESCRIPTION
Logging serial numbers every time they are read might have been useful early on, but seems unnecessary now.

Updates #5902