### PR TITLE
tailcfg: bump capver for earlier cryptokey panic fix [capver 106]

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -148,7 +148,8 @@ type CapabilityVersion int
 //   - 103: 2024-07-24: Client supports NodeAttrDisableCaptivePortalDetection
 //   - 104: 2024-08-03: SelfNodeV6MasqAddrForThisPeer now works
 //   - 105: 2024-08-05: Fixed SSH behavior on systems that use busybox (issue #12849)
-const CurrentCapabilityVersion CapabilityVersion = 105
+//   - 106: 2024-09-03: fix panic regression from cryptokey routing change (65fe0ba7b5)
+const CurrentCapabilityVersion CapabilityVersion = 106
 
 type StableID string
 


### PR DESCRIPTION
I should've bumped capver in 65fe0ba7b5 but forgot.

This lets us turn off the cryptokey routing change from control for
the affected panicky range of commits, based on capver.

Updates #13332
Updates tailscale/corp#20732
