### PR TITLE
cmd/stunstamp: implement ICMP{v6} probing

### DIFF
--- a/cmd/stunstamp/stunstamp_default.go
+++ b/cmd/stunstamp/stunstamp_default.go
@@ -40,8 +40,24 @@ func getProtocolSupportInfo(p protocol) protocolSupportInfo {
 			userspaceTS: false,
 			stableConn:  true,
 		}
+	case protocolICMP:
+		return protocolSupportInfo{
+			kernelTS:    false,
+			userspaceTS: false,
+			stableConn:  false,
+		}
 	}
 	return protocolSupportInfo{}
+}
+
+func getICMPConn(forDst netip.Addr, source timestampSource) (io.ReadWriteCloser, error) {
+	return nil, errors.New("platform unsupported")
+}
+
+func mkICMPRTTFn(source timestampSource) func(conn io.ReadWriteCloser, hostname string, dst netip.AddrPort) (rtt time.Duration, err error) {
+	return func(conn io.ReadWriteCloser, hostname string, dst netip.AddrPort) (rtt time.Duration, err error) {
+		return 0, errors.New("platform unsupported")
+	}
 }
 
 func setSOReuseAddr(fd uintptr) error {


### PR DESCRIPTION
This adds both userspace and kernel timestamping.

Updates tailscale/corp#22114