### PR TITLE
cmd/stunstamp: use measureFn more consistently in naming/signatures

### DIFF
--- a/cmd/stunstamp/stunstamp.go
+++ b/cmd/stunstamp/stunstamp.go
@@ -499,7 +499,7 @@ func newConnAndMeasureFn(forDst netip.Addr, source timestampSource, protocol pro
 		}
 		return &connAndMeasureFn{
 			conn: conn,
-			fn:   mkICMPRTTFn(source),
+			fn:   mkICMPMeasureFn(source),
 		}, nil
 	case protocolHTTPS:
 		localPort := 0

--- a/cmd/stunstamp/stunstamp_default.go
+++ b/cmd/stunstamp/stunstamp_default.go
@@ -54,7 +54,7 @@ func getICMPConn(forDst netip.Addr, source timestampSource) (io.ReadWriteCloser,
 	return nil, errors.New("platform unsupported")
 }
 
-func mkICMPRTTFn(source timestampSource) func(conn io.ReadWriteCloser, hostname string, dst netip.AddrPort) (rtt time.Duration, err error) {
+func mkICMPMeasureFn(source timestampSource) measureFn {
 	return func(conn io.ReadWriteCloser, hostname string, dst netip.AddrPort) (rtt time.Duration, err error) {
 		return 0, errors.New("platform unsupported")
 	}

--- a/cmd/stunstamp/stunstamp_linux.go
+++ b/cmd/stunstamp/stunstamp_linux.go
@@ -62,7 +62,7 @@ func parseTimestampFromCmsgs(oob []byte) (time.Time, error) {
 	return time.Time{}, errors.New("failed to parse timestamp from cmsgs")
 }
 
-func mkICMPRTTFn(source timestampSource) func(conn io.ReadWriteCloser, hostname string, dst netip.AddrPort) (rtt time.Duration, err error) {
+func mkICMPMeasureFn(source timestampSource) measureFn {
 	return func(conn io.ReadWriteCloser, hostname string, dst netip.AddrPort) (rtt time.Duration, err error) {
 		return measureICMPRTT(source, conn, hostname, dst)
 	}


### PR DESCRIPTION
Updates #cleanup