### PR TITLE
cmd/stunstamp: increase probe jitter

### DIFF
--- a/cmd/stunstamp/stunstamp.go
+++ b/cmd/stunstamp/stunstamp.go
@@ -380,7 +380,7 @@ func probe(meta nodeMeta, cf *connAndMeasureFn, dstPort int) (*time.Duration, er
 		Port: dstPort,
 	}
 
-	time.Sleep(rand.N(200 * time.Millisecond)) // jitter across tx
+	time.Sleep(rand.N(400 * time.Millisecond)) // jitter across tx
 	rtt, err := cf.fn(cf.conn, meta.hostname, netip.AddrPortFrom(meta.addr, uint16(dstPort)))
 	if err != nil {
 		if isTemporaryOrTimeoutErr(err) {


### PR DESCRIPTION
We've added more probe targets recently which has resulted in more timeouts behind restrictive NATs in localized testing that don't like how many flows we are creating at once. Not so much an issue for datacenter or cloud-hosted deployments.

Updates tailscale/corp#22114