### PR TITLE
control/controlclient,posture,util/syspolicy: use predefined syspolicy keys instead of string literals

### DIFF
--- a/control/controlclient/sign_supported.go
+++ b/control/controlclient/sign_supported.go
@@ -38,7 +38,7 @@ var getMachineCertificateSubjectOnce struct {
 // Example: "CN=Tailscale Inc Test Root CA,OU=Tailscale Inc Test Certificate Authority,O=Tailscale Inc,ST=ON,C=CA"
 func getMachineCertificateSubject() string {
 	getMachineCertificateSubjectOnce.Do(func() {
-		getMachineCertificateSubjectOnce.v, _ = syspolicy.GetString("MachineCertificateSubject", "")
+		getMachineCertificateSubjectOnce.v, _ = syspolicy.GetString(syspolicy.MachineCertificateSubject, "")
 	})
 
 	return getMachineCertificateSubjectOnce.v

--- a/posture/serialnumber_ios.go
+++ b/posture/serialnumber_ios.go
@@ -14,7 +14,7 @@ import (
 // MDM solution. It requires configuration via the DeviceSerialNumber system policy.
 // This is the only way to gather serial numbers on iOS and tvOS.
 func GetSerialNumbers(_ logger.Logf) ([]string, error) {
-	s, err := syspolicy.GetString("DeviceSerialNumber", "")
+	s, err := syspolicy.GetString(syspolicy.DeviceSerialNumber, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get serial number from MDM: %v", err)
 	}

--- a/util/syspolicy/policy_keys.go
+++ b/util/syspolicy/policy_keys.go
@@ -98,6 +98,14 @@ const (
 	// automatically authenticate managed devices, without requiring user interaction.
 	AuthKey Key = "AuthKey"
 
+	// MachineCertificateSubject is the exact name of a Subject that needs
+	// to be present in an identity's certificate chain to sign a RegisterRequest,
+	// formatted as per pkix.Name.String(). The Subject may be that of the identity
+	// itself, an intermediate CA or the root CA.
+	//
+	// Example: "CN=Tailscale Inc Test Root CA,OU=Tailscale Inc Test Certificate Authority,O=Tailscale Inc,ST=ON,C=CA"
+	MachineCertificateSubject Key = "MachineCertificateSubject"
+
 	// Keys with a string array value.
 	// AllowedSuggestedExitNodes's string array value is a list of exit node IDs that restricts which exit nodes are considered when generating suggestions for exit nodes.
 	AllowedSuggestedExitNodes Key = "AllowedSuggestedExitNodes"


### PR DESCRIPTION
With the upcoming `syspolicy` changes, it's imperative that all policy setting keys are defined in the `syspolicy` package for proper registration. Otherwise, the corresponding policy settings will not be read.

This updates a couple of places where we still use string literals rather than `syspolicy` consts.

Updates #12687