### PR TITLE
sessionrecording,ssh/tailssh,k8s-operator: log connected recorder address

### DIFF
--- a/k8s-operator/sessionrecording/hijacker_test.go
+++ b/k8s-operator/sessionrecording/hijacker_test.go
@@ -78,7 +78,10 @@ func Test_Hijacker(t *testing.T) {
 			tc := &fakes.TestConn{}
 			ch := make(chan error)
 			h := &Hijacker{
-				connectToRecorder: func(context.Context, []netip.AddrPort, func(context.Context, string, string) (net.Conn, error)) (wc io.WriteCloser, rec []*tailcfg.SSHRecordingAttempt, _ <-chan error, err error) {
+				connectToRecorder: func(context.Context,
+					[]netip.AddrPort,
+					func(context.Context, string, string) (net.Conn, error),
+				) (wc io.WriteCloser, rec []*tailcfg.SSHRecordingAttempt, _ <-chan error, err error) {
 					if tt.failRecorderConnect {
 						err = errors.New("test")
 					}

--- a/sessionrecording/connect.go
+++ b/sessionrecording/connect.go
@@ -105,7 +105,7 @@ func ConnectToRecorder(ctx context.Context, recs []netip.AddrPort, dial func(con
 			}
 			attempt.FailureMessage = err.Error()
 			errs = append(errs, err)
-			continue
+			continue // try the next recorder
 		}
 		return pw, attempts, errChan, nil
 	}


### PR DESCRIPTION
When a kubectl exec/ Tailscale SSH session needs to be recorded, the node (kube operator or SSH server) attempts to connect to a list of matching tsrecorder instances till it succeeds connecting to one (if at all). Log the address of the successfully connected recorder, so that if multiple recorders match, users know where the recording was sent to.

I have tested that the expected log line appears for both Tailscale SSH and kubectl exec session recording.
How it looks in logs (kubectl exec session recording):
```
{"level":"info","ts":"2024-09-05T06:49:09Z","logger":"apiserver-proxy","msg":"Connected to recorder at [fd7a:115c:a1e0::4d01:537d]:80"}
```

Updates tailscale/corp#19821