### PR TITLE
ipn/ipnserver: remove IdleTimeout

### DIFF
--- a/ipn/ipnserver/server.go
+++ b/ipn/ipnserver/server.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"time"
 	"unicode"
 
 	"tailscale.com/envknob"
@@ -505,15 +504,7 @@ func (s *Server) Run(ctx context.Context, ln net.Listener) error {
 		ConnContext: func(ctx context.Context, c net.Conn) context.Context {
 			return contextWithActor(ctx, s.logf, c)
 		},
-		// Localhost connections are cheap; so only do
-		// keep-alives for a short period of time, as these
-		// active connections lock the server into only serving
-		// that user. If the user has this page open, we don't
-		// want another switching user to be locked out for
-		// minutes. 5 seconds is enough to let browser hit
-		// favicon.ico and such.
-		IdleTimeout: 5 * time.Second,
-		ErrorLog:    logger.StdLogger(logger.WithPrefix(s.logf, "ipnserver: ")),
+		ErrorLog: logger.StdLogger(logger.WithPrefix(s.logf, "ipnserver: ")),
 	}
 	if err := hs.Serve(ln); err != nil {
 		if err := ctx.Err(); err != nil {


### PR DESCRIPTION
We no longer need this on Windows, and it was never required on other platforms. It just results in more short-lived connections unless we use HTTP/2.

Updates tailscale/corp#18342