### PR TITLE
go.mod.sri: update SRI hash for go.mod changes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -130,4 +130,4 @@
   in
     flake-utils.lib.eachDefaultSystem (system: flakeForSystem nixpkgs system);
 }
-# nix-direnv cache busting line: sha256-av4kr09rjNRmag94ziNjJuI/cg8b8lAD3Tk24t/ezH4=
+# nix-direnv cache busting line: sha256-cQRbR7e1BYgd49AfuuPHuKhjCG2tn9DenRlTqQyrHv8=

--- a/go.mod.sri
+++ b/go.mod.sri
@@ -1,1 +1,1 @@
-sha256-av4kr09rjNRmag94ziNjJuI/cg8b8lAD3Tk24t/ezH4=
+sha256-cQRbR7e1BYgd49AfuuPHuKhjCG2tn9DenRlTqQyrHv8=

--- a/shell.nix
+++ b/shell.nix
@@ -16,4 +16,4 @@
 ) {
   src =  ./.;
 }).shellNix
-# nix-direnv cache busting line: sha256-av4kr09rjNRmag94ziNjJuI/cg8b8lAD3Tk24t/ezH4=
+# nix-direnv cache busting line: sha256-cQRbR7e1BYgd49AfuuPHuKhjCG2tn9DenRlTqQyrHv8=


### PR DESCRIPTION
Triggered by tailscale/tailscale@097c2bcf6700e5dc074187bbe0c05ae4cd8b3c26