### PR TITLE
{release,version}: add DSM7.2 specific synology builds

### DIFF
--- a/release/dist/synology/targets.go
+++ b/release/dist/synology/targets.go
@@ -28,11 +28,22 @@ var v7Models = []string{
 
 func Targets(forPackageCenter bool, signer dist.Signer) []dist.Target {
 	var ret []dist.Target
-	for _, dsmVersion := range []int{6, 7} {
+	for _, dsmVersion := range []struct {
+		major int
+		minor int
+	}{
+		// DSM6
+		{major: 6},
+		// DSM7
+		{major: 7},
+		// DSM7.2
+		{major: 7, minor: 2},
+	} {
 		ret = append(ret,
 			&target{
 				filenameArch:    "x86_64",
-				dsmMajorVersion: dsmVersion,
+				dsmMajorVersion: dsmVersion.major,
+				dsmMinorVersion: dsmVersion.minor,
 				goenv: map[string]string{
 					"GOOS":   "linux",
 					"GOARCH": "amd64",
@@ -42,7 +53,8 @@ func Targets(forPackageCenter bool, signer dist.Signer) []dist.Target {
 			},
 			&target{
 				filenameArch:    "i686",
-				dsmMajorVersion: dsmVersion,
+				dsmMajorVersion: dsmVersion.major,
+				dsmMinorVersion: dsmVersion.minor,
 				goenv: map[string]string{
 					"GOOS":   "linux",
 					"GOARCH": "386",
@@ -52,7 +64,8 @@ func Targets(forPackageCenter bool, signer dist.Signer) []dist.Target {
 			},
 			&target{
 				filenameArch:    "armv8",
-				dsmMajorVersion: dsmVersion,
+				dsmMajorVersion: dsmVersion.major,
+				dsmMinorVersion: dsmVersion.minor,
 				goenv: map[string]string{
 					"GOOS":   "linux",
 					"GOARCH": "arm64",
@@ -67,7 +80,8 @@ func Targets(forPackageCenter bool, signer dist.Signer) []dist.Target {
 		for _, v5Arch := range v5Models {
 			ret = append(ret, &target{
 				filenameArch:    v5Arch,
-				dsmMajorVersion: dsmVersion,
+				dsmMajorVersion: dsmVersion.major,
+				dsmMinorVersion: dsmVersion.minor,
 				goenv: map[string]string{
 					"GOOS":   "linux",
 					"GOARCH": "arm",
@@ -80,7 +94,8 @@ func Targets(forPackageCenter bool, signer dist.Signer) []dist.Target {
 		for _, v7Arch := range v7Models {
 			ret = append(ret, &target{
 				filenameArch:    v7Arch,
-				dsmMajorVersion: dsmVersion,
+				dsmMajorVersion: dsmVersion.major,
+				dsmMinorVersion: dsmVersion.minor,
 				goenv: map[string]string{
 					"GOOS":   "linux",
 					"GOARCH": "arm",

--- a/version/mkversion/mkversion.go
+++ b/version/mkversion/mkversion.go
@@ -61,7 +61,7 @@ type VersionInfo struct {
 	// Winres is the version string that gets embedded into Windows exe
 	// metadata. It is of the form "x,y,z,0".
 	Winres string
-	// Synology is a map of Synology DSM major version to the
+	// Synology is a map of Synology DSM version to the
 	// Tailscale numeric version that gets embedded in Synology spk
 	// files.
 	Synology map[int]int64
@@ -252,12 +252,13 @@ func mkOutput(v verInfo) (VersionInfo, error) {
 		Track:   track,
 		Synology: map[int]int64{
 			// Synology requires that version numbers be in a specific format.
-			// Builds with version numbers that don't start with "60" or "70" will fail,
+			// Builds with version numbers that don't start with "60", "70", or "72" will fail,
 			// and the full version number must be within int32 range.
 			// So, we do the following mapping from our Tailscale version to Synology version,
 			// giving major version three decimal places, minor version three, and patch two.
-			6: 6*100_000_000 + int64(v.major-1)*1_000_000 + int64(v.minor)*1_000 + int64(v.patch),
-			7: 7*100_000_000 + int64(v.major-1)*1_000_000 + int64(v.minor)*1_000 + int64(v.patch),
+			60: 60*10_000_000 + int64(v.major-1)*1_000_000 + int64(v.minor)*1_000 + int64(v.patch),
+			70: 70*10_000_000 + int64(v.major-1)*1_000_000 + int64(v.minor)*1_000 + int64(v.patch),
+			72: 72*10_000_000 + int64(v.major-1)*1_000_000 + int64(v.minor)*1_000 + int64(v.patch),
 		},
 	}
 


### PR DESCRIPTION
Add separate builds for DSM7.2 for synology so that we can encode separate versioning information in the INFO file to distinguish between the two.

Fixes https://github.com/tailscale/corp/issues/22908