### PR TITLE
net/dns: disable DNS registration for Tailscale interface on Windows

### DIFF
--- a/net/dns/manager_windows.go
+++ b/net/dns/manager_windows.go
@@ -469,6 +469,9 @@ func (m *windowsManager) disableDynamicUpdates() error {
 		}
 		defer k.Close()
 
+		if err := k.SetDWordValue("RegistrationEnabled", 0); err != nil {
+			return err
+		}
 		if err := k.SetDWordValue("DisableDynamicUpdate", 1); err != nil {
 			return err
 		}


### PR DESCRIPTION
We already disable dynamic updates by setting `DisableDynamicUpdate` to `1` for the Tailscale interface. However, this does not prevent non-dynamic DNS registration from happening when `ipconfig /registerdns` runs and in similar scenarios. Notably, `dns/windowsManager.SetDNS` runs `ipconfig /registerdns`, triggering DNS registration for all interfaces that do not explicitly disable it.

In this PR, we update `dns/windowsManager.disableDynamicUpdates` to also set `RegistrationEnabled` to `0`.

Fixes #13411