### PR TITLE
tsnet: remove old package doc experimental warning

### DIFF
--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 // Package tsnet provides Tailscale as a library.
-//
-// It is an experimental work in progress.
 package tsnet
 
 import (


### PR DESCRIPTION
It was scaring people. It's been pretty stable for quite some time now
and we're unlikely to change the API and break people at this point.
We might, but have been trying not to.

Fixes tailscale/corp#22933
