### PR TITLE
tool/gocross: remove trimpath from test builds

### DIFF
--- a/tool/gocross/autoflags.go
+++ b/tool/gocross/autoflags.go
@@ -35,7 +35,7 @@ func autoflagsForTest(argv []string, env *Environment, goroot, nativeGOOS, nativ
 		cc          = "cc"
 		targetOS    = cmp.Or(env.Get("GOOS", ""), nativeGOOS)
 		targetArch  = cmp.Or(env.Get("GOARCH", ""), nativeGOARCH)
-		buildFlags  = []string{"-trimpath"}
+		buildFlags  = []string{}
 		cgoCflags   = []string{"-O3", "-std=gnu11", "-g"}
 		cgoLdflags  []string
 		ldflags     []string
@@ -45,6 +45,10 @@ func autoflagsForTest(argv []string, env *Environment, goroot, nativeGOOS, nativ
 	)
 	if len(argv) > 1 {
 		subcommand = argv[1]
+	}
+
+	if subcommand != "test" {
+		buildFlags = append(buildFlags, "-trimpath")
 	}
 
 	switch subcommand {

--- a/tool/gocross/autoflags_test.go
+++ b/tool/gocross/autoflags_test.go
@@ -163,7 +163,6 @@ GOTOOLCHAIN=local (was <nil>)
 TS_LINK_FAIL_REFLECT=0 (was <nil>)`,
 			wantArgv: []string{
 				"gocross", "test",
-				"-trimpath",
 				"-tags=tailscale_go,osusergo,netgo",
 				"-ldflags", "-X tailscale.com/version.longStamp=1.2.3-long -X tailscale.com/version.shortStamp=1.2.3 -X tailscale.com/version.gitCommitStamp=abcd -X tailscale.com/version.extraGitCommitStamp=defg '-extldflags=-static'",
 				"-race",


### PR DESCRIPTION
trimpath can be inconvenient for IDEs and LSPs that do not always correctly handle module relative paths, and can also contribute to caching bugs taking effect. We rarely have a real need for trimpath of test produced binaries, so avoiding it should be a net win.

Updates #2988
Signed-off-by: James Tucker <james@tailscale.com>