### PR TITLE
tstest/natlab: add latency & loss simulation

### DIFF
--- a/tstest/natlab/vnet/conf_test.go
+++ b/tstest/natlab/vnet/conf_test.go
@@ -3,7 +3,10 @@
 
 package vnet
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestConfig(t *testing.T) {
 	tests := []struct {
@@ -15,6 +18,16 @@ func TestConfig(t *testing.T) {
 			name: "simple",
 			setup: func(c *Config) {
 				c.AddNode(c.AddNetwork("2.1.1.1", "192.168.1.1/24", EasyNAT, NATPMP))
+				c.AddNode(c.AddNetwork("2.2.2.2", "10.2.0.1/16", HardNAT))
+			},
+		},
+		{
+			name: "latency-and-loss",
+			setup: func(c *Config) {
+				n1 := c.AddNetwork("2.1.1.1", "192.168.1.1/24", EasyNAT, NATPMP)
+				n1.SetLatency(time.Second)
+				n1.SetPacketLoss(0.1)
+				c.AddNode(n1)
 				c.AddNode(c.AddNetwork("2.2.2.2", "10.2.0.1/16", HardNAT))
 			},
 		},

--- a/tstest/natlab/vnet/vnet.go
+++ b/tstest/natlab/vnet/vnet.go
@@ -515,6 +515,8 @@ type network struct {
 	wanIP4         netip.Addr           // router's LAN IPv4, if any
 	lanIP4         netip.Prefix         // router's LAN IP + CIDR (e.g. 192.168.2.1/24)
 	breakWAN4      bool                 // break WAN IPv4 connectivity
+	latency        time.Duration        // latency applied to interface writes
+	lossRate       float64              // probability of dropping a packet (0.0 to 1.0)
 	nodesByIP4     map[netip.Addr]*node // by LAN IPv4
 	nodesByMAC     map[MAC]*node
 	logf           func(format string, args ...any)
@@ -977,7 +979,7 @@ func (n *network) writeEth(res []byte) bool {
 		n.writers.Range(func(mac MAC, nw networkWriter) bool {
 			if mac != srcMAC {
 				num++
-				nw.write(res)
+				n.conditionedWrite(nw, res)
 			}
 			return true
 		})
@@ -988,7 +990,7 @@ func (n *network) writeEth(res []byte) bool {
 		return false
 	}
 	if nw, ok := n.writers.Load(dstMAC); ok {
-		nw.write(res)
+		n.conditionedWrite(nw, res)
 		return true
 	}
 
@@ -999,6 +1001,23 @@ func (n *network) writeEth(res []byte) bool {
 	}
 
 	return false
+}
+
+func (n *network) conditionedWrite(nw networkWriter, packet []byte) {
+	if n.lossRate > 0 && rand.Float64() < n.lossRate {
+		// packet lost
+		return
+	}
+	if n.latency > 0 {
+		// copy the packet as there's no guarantee packet is owned long enough.
+		// TODO(raggi): this could be optimized substantially if necessary,
+		// a pool of buffers and a cheaper delay mechanism are both obvious improvements.
+		var pkt = make([]byte, len(packet))
+		copy(pkt, packet)
+		time.AfterFunc(n.latency, func() { nw.write(pkt) })
+	} else {
+		nw.write(packet)
+	}
 }
 
 var (


### PR DESCRIPTION
A simple implementation of latency and loss simulation, applied to writes to the ethernet interface of the NIC. The latency implementation could be optimized substantially later if necessary.

Updates #13355
Signed-off-by: James Tucker <james@tailscale.com>