### PR TITLE
gokrazy, various: use point versions of Go and update Nix deps

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -120,6 +120,10 @@
           perl
           go_1_23
           yarn
+
+          # qemu and e2fsprogs are needed for natlab
+          qemu
+          e2fsprogs
         ];
       };
     };

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module tailscale.com
 
-go 1.23
+go 1.23.1
 
 require (
 	filippo.io/mkcert v1.4.4

--- a/gokrazy/go.mod
+++ b/gokrazy/go.mod
@@ -1,6 +1,6 @@
 module tailscale.com/gokrazy
 
-go 1.23.0
+go 1.23.1
 
 require github.com/gokrazy/tools v0.0.0-20240730192548-9f81add3a91e
 

--- a/gokrazy/natlabapp.arm64/builddir/github.com/gokrazy/kernel.arm64/go.mod
+++ b/gokrazy/natlabapp.arm64/builddir/github.com/gokrazy/kernel.arm64/go.mod
@@ -1,5 +1,5 @@
 module gokrazy/build/natlabapp.arm64
 
-go 1.23.0
+go 1.23.1
 
 require github.com/gokrazy/kernel.arm64 v0.0.0-20240830035047-cdba87a9eb0e // indirect

--- a/gokrazy/natlabapp.arm64/builddir/tailscale.com/go.mod
+++ b/gokrazy/natlabapp.arm64/builddir/tailscale.com/go.mod
@@ -1,6 +1,6 @@
 module gokrazy/build/tsapp
 
-go 1.23
+go 1.23.1
 
 replace tailscale.com => ../../../..
 

--- a/gokrazy/natlabapp/builddir/tailscale.com/go.mod
+++ b/gokrazy/natlabapp/builddir/tailscale.com/go.mod
@@ -1,6 +1,6 @@
 module gokrazy/build/tsapp
 
-go 1.23
+go 1.23.1
 
 replace tailscale.com => ../../../..
 

--- a/gokrazy/natlabapp/builddir/tailscale.com/go.sum
+++ b/gokrazy/natlabapp/builddir/tailscale.com/go.sum
@@ -70,6 +70,8 @@ github.com/illarion/gonotify v1.0.1 h1:F1d+0Fgbq/sDWjj/r66ekjDG+IDeecQKUFH4wNwso
 github.com/illarion/gonotify v1.0.1/go.mod h1:zt5pmDofZpU1f8aqlK0+95eQhoEAn/d4G4B/FjVW4jE=
 github.com/illarion/gonotify/v2 v2.0.2 h1:oDH5yvxq9oiQGWUeut42uShcWzOy/hsT9E7pvO95+kQ=
 github.com/illarion/gonotify/v2 v2.0.2/go.mod h1:38oIJTgFqupkEydkkClkbL6i5lXV/bxdH9do5TALPEE=
+github.com/illarion/gonotify/v2 v2.0.3 h1:B6+SKPo/0Sw8cRJh1aLzNEeNVFfzE3c6N+o+vyxM+9A=
+github.com/illarion/gonotify/v2 v2.0.3/go.mod h1:38oIJTgFqupkEydkkClkbL6i5lXV/bxdH9do5TALPEE=
 github.com/insomniacslk/dhcp v0.0.0-20231206064809-8c70d406f6d2 h1:9K06NfxkBh25x56yVhWWlKFE8YpicaSfHwoV8SFbueA=
 github.com/insomniacslk/dhcp v0.0.0-20231206064809-8c70d406f6d2/go.mod h1:3A9PQ1cunSDF/1rbTq99Ts4pVnycWg+vlPkfeD2NLFI=
 github.com/jellydator/ttlcache/v3 v3.1.0 h1:0gPFG0IHHP6xyUyXq+JaD8fwkDCqgqwohXNJBcYE71g=
@@ -132,6 +134,8 @@ github.com/tailscale/wireguard-go v0.0.0-20240705152531-2f5d148bcfe1 h1:ycpNCSYw
 github.com/tailscale/wireguard-go v0.0.0-20240705152531-2f5d148bcfe1/go.mod h1:BOm5fXUBFM+m9woLNBoxI9TaBXXhGNP50LX/TGIvGb4=
 github.com/tailscale/wireguard-go v0.0.0-20240731203015-71393c576b98 h1:RNpJrXfI5u6e+uzyIzvmnXbhmhdRkVf//90sMBH3lso=
 github.com/tailscale/wireguard-go v0.0.0-20240731203015-71393c576b98/go.mod h1:BOm5fXUBFM+m9woLNBoxI9TaBXXhGNP50LX/TGIvGb4=
+github.com/tailscale/wireguard-go v0.0.0-20240905161824-799c1978fafc h1:cezaQN9pvKVaw56Ma5qr/G646uKIYP0yQf+OyWN/okc=
+github.com/tailscale/wireguard-go v0.0.0-20240905161824-799c1978fafc/go.mod h1:BOm5fXUBFM+m9woLNBoxI9TaBXXhGNP50LX/TGIvGb4=
 github.com/tailscale/xnet v0.0.0-20240117122442-62b9a7c569f9 h1:81P7rjnikHKTJ75EkjppvbwUfKHDHYk6LJpO5PZy8pA=
 github.com/tailscale/xnet v0.0.0-20240117122442-62b9a7c569f9/go.mod h1:orPd6JZXXRyuDusYilywte7k094d7dycXXU5YnWsrwg=
 github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e h1:zOGKqN5D5hHhiYUp091JqK7DPCqSARyUfduhGUY8Bek=

--- a/gokrazy/tsapp/builddir/tailscale.com/go.mod
+++ b/gokrazy/tsapp/builddir/tailscale.com/go.mod
@@ -1,6 +1,6 @@
 module gokrazy/build/tsapp
 
-go 1.23
+go 1.23.1
 
 replace tailscale.com => ../../../..
 


### PR DESCRIPTION
This un-breaks vim-go (which doesn't understand "go 1.23") and allows the natlab tests to work in a Nix shell (by adding the "qemu-img" and "mkfs.ext4" binaries to the shell). These binaries are available even on macOS, as I'm testing on my M1 Max.

Updates #13038


Change-Id: I99f8521b5de93ea47dc33b099d5b243ffc1303da