### PR TITLE
safeweb: add a ListenAndServe method to the Server type

### DIFF
--- a/safeweb/http.go
+++ b/safeweb/http.go
@@ -301,6 +301,19 @@ func (s *Server) Serve(ln net.Listener) error {
 	return s.h.Serve(ln)
 }
 
+// ListenAndServe listens on the TCP network address addr and then calls Serve
+// to handle requests on incoming connections. If addr == "", ":http" is used.
+func (s *Server) ListenAndServe(addr string) error {
+	if addr == "" {
+		addr = ":http"
+	}
+	lst, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	return s.Serve(lst)
+}
+
 // Close closes all client connections and stops accepting new ones.
 func (s *Server) Close() error {
 	return s.h.Close()


### PR DESCRIPTION
This is mainly intended to make it a little easier to drop in safeweb as a
replacement for existing http.Server use. What do you think?

Updates #13497

Change-Id: I398e9fa58ad0b9dc799ea280c9c7a32150150ee4
