### PR TITLE
net/dns/resolver: fix dns-sd NXDOMAIN responses from quad-100

### DIFF
--- a/net/dns/resolver/forwarder.go
+++ b/net/dns/resolver/forwarder.go
@@ -1093,6 +1093,8 @@ func nxDomainResponse(req packet) (res packet, err error) {
 	// TODO(bradfitz): should we add an SOA record in the Authority
 	// section too? (for the nxdomain negative caching TTL)
 	// For which zone? Does iOS care?
+	b.StartQuestions()
+	b.Question(p.Question)
 	res.bs, err = b.Finish()
 	res.addr = req.addr
 	return res, err


### PR DESCRIPTION
mdnsResponder at least as of macOS Sequoia does not find NXDOMAIN responses to these dns-sd PTR queries acceptable unless they include the question section in the response. This was found debugging #13511, once we turned on additional diagnostic reporting from mdnsResponder we witnessed:

```
Received unacceptable 12-byte response from 100.100.100.100 over UDP via utun6/27 -- id: 0x7F41 (32577), flags: 0x8183 (R/Query, RD, RA, NXDomain), counts: 0/0/0/0,
```

If the response includes a question section, the resposnes are acceptable, e.g.:

```
Received acceptable 59-byte response from 8.8.8.8 over UDP via en0/17 -- id: 0x2E55 (11861), flags: 0x8183 (R/Query, RD, RA, NXDomain), counts: 1/0/0/0,
```

This may be contributing to an issue under diagnosis in #13511 wherein some combination of conditions results in mdnsResponder no longer answering DNS queries correctly to applications on the system for extended periods of time (multiple minutes), while dig against quad-100 provides correct responses for those same domains.  If additional debug logging is enabled in mdnsResponder we see it reporting:

```
Penalizing server 100.100.100.100 for 60 seconds
```


It is also possible that the reason that macOS & iOS never "stopped spamming" these queries is that they have never been replied to with acceptable responses. It is not clear if this special case handling of dns-sd PTR queries was ever beneficial, and given this evidence may have always been harmful. If we subsequently observe that the queries settle down now that they have acceptable responses, we should remove these special cases - making upstream queries very occasionally isn't a lot of battery, so we should be better off having to maintain less special cases and avoid bugs of this class.

Updates #2442
Updates #3025
Updates #3363
Updates #3594
Updates #13511