### PR TITLE
tailcfg: add AcceptEnv field to SSHRule

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -2451,6 +2451,13 @@ type SSHRule struct {
 	// Action is the outcome to task.
 	// A nil or invalid action means to deny.
 	Action *SSHAction `json:"action"`
+
+	// AcceptEnv is a slice of environment variable names that are allowlisted
+	// for the SSH rule in the policy file.
+	//
+	// AcceptEnv values may contain * and ? wildcard characters which match against
+	// an arbitrary number of characters or a single character respectively.
+	AcceptEnv []string `json:"acceptEnv,omitempty"`
 }
 
 // SSHPrincipal is either a particular node or a user on any node.

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -505,6 +505,7 @@ func (src *SSHRule) Clone() *SSHRule {
 	}
 	dst.SSHUsers = maps.Clone(src.SSHUsers)
 	dst.Action = src.Action.Clone()
+	dst.AcceptEnv = append(src.AcceptEnv[:0:0], src.AcceptEnv...)
 	return dst
 }
 
@@ -514,6 +515,7 @@ var _SSHRuleCloneNeedsRegeneration = SSHRule(struct {
 	Principals  []*SSHPrincipal
 	SSHUsers    map[string]string
 	Action      *SSHAction
+	AcceptEnv   []string
 }{})
 
 // Clone makes a deep copy of SSHAction.

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -1126,6 +1126,7 @@ func (v SSHRuleView) Principals() views.SliceView[*SSHPrincipal, SSHPrincipalVie
 
 func (v SSHRuleView) SSHUsers() views.Map[string, string] { return views.MapOf(v.ж.SSHUsers) }
 func (v SSHRuleView) Action() SSHActionView               { return v.ж.Action.View() }
+func (v SSHRuleView) AcceptEnv() views.Slice[string]      { return views.SliceOf(v.ж.AcceptEnv) }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _SSHRuleViewNeedsRegeneration = SSHRule(struct {
@@ -1133,6 +1134,7 @@ var _SSHRuleViewNeedsRegeneration = SSHRule(struct {
 	Principals  []*SSHPrincipal
 	SSHUsers    map[string]string
 	Action      *SSHAction
+	AcceptEnv   []string
 }{})
 
 // View returns a readonly view of SSHAction.


### PR DESCRIPTION
Add an `AcceptEnv` field to `SSHRule`. This will contain the collection of environment variable names / patterns that are specified in the `acceptEnv` block for the SSH rule within the policy file. This will be used in the tailscale client to filter out unacceptable environment variables.

Updates: https://github.com/tailscale/corp/issues/22775