### PR TITLE
cli: implement `tailscale dns stream`

### DIFF
--- a/client/tailscale/localclient.go
+++ b/client/tailscale/localclient.go
@@ -1470,6 +1470,13 @@ func (lc *LocalClient) DebugDERPRegion(ctx context.Context, regionIDOrCode strin
 	return decodeJSON[*ipnstate.DebugDERPRegionReport](body)
 }
 
+// DebugEnvknob sets a envknob for debugging purposes.
+func (lc *LocalClient) DebugEnvknob(ctx context.Context, key, value string) error {
+	v := url.Values{"key": {key}, "value": {value}}
+	_, err := lc.send(ctx, "POST", "/localapi/v0/debug-envknob?"+v.Encode(), 200, nil)
+	return err
+}
+
 // DebugPacketFilterRules returns the packet filter rules for the current device.
 func (lc *LocalClient) DebugPacketFilterRules(ctx context.Context) ([]tailcfg.FilterRule, error) {
 	body, err := lc.send(ctx, "POST", "/localapi/v0/debug-packet-filter-rules", 200, nil)

--- a/cmd/tailscale/cli/dns-stream.go
+++ b/cmd/tailscale/cli/dns-stream.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func runDNSStream(ctx context.Context, args []string) error {
+	fmt.Printf(`Privacy warning! To stream DNS queries, this tool will set these Tailscale debug flags, which would normally be disabled by default:
+
+   - TS_DEBUG_DNS_FORWARD_SEND=true
+   - TS_DEBUG_DNS_INCLUDE_NAMES=true
+
+TS_DEBUG_DNS_FORWARD_SEND instructs Tailscale to log DNS queries and responses as they are handled by the internal DNS forwarder. 
+
+TS_DEBUG_DNS_INCLUDE_NAMES instructs Tailscale to include queried and resolved DNS hostnames in the logs.
+
+Unless the 'TS_NO_LOGS_NO_SUPPORT' flag was previously set, logs are uploaded to Tailscale for diagnostic and debugging purposes, which can be a concern in privacy-sensitive environments.
+
+If you are concerned about the privacy implications of this, run this tool with the '--no-names' flag, which will avoid logging hostnames.`)
+	fmt.Printf("\n\n")
+	fmt.Println("Press Enter to start streaming DNS logs, or Ctrl+C to quit this tool.")
+
+	buf := bufio.NewReader(os.Stdin)
+	_, err := buf.ReadBytes('\n')
+	if err != nil {
+		fmt.Println(err)
+		return nil
+	}
+
+	err = localClient.DebugEnvknob(ctx, "TS_DEBUG_DNS_FORWARD_SEND", "true")
+	if err != nil {
+		fmt.Printf("failed to set TS_DEBUG_DNS_FORWARD_SEND=true: %v\n", err)
+		return nil
+	}
+	err = localClient.DebugEnvknob(ctx, "TS_DEBUG_DNS_INCLUDE_NAMES", "true")
+	if err != nil {
+		fmt.Printf("failed to set TS_DEBUG_DNS_INCLUDE_NAMES=true: %v\n", err)
+		return nil
+	}
+
+	logs, err := localClient.TailDaemonLogs(ctx)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Streaming DNS logs. Press Ctrl+C to stop.")
+
+	d := json.NewDecoder(logs)
+	for {
+		var line struct {
+			Text    string `json:"text"`
+			Verbose int    `json:"v"`
+			Time    string `json:"client_time"`
+		}
+		err := d.Decode(&line)
+		if err != nil {
+			return err
+		}
+		text := strings.TrimSpace(line.Text)
+		dnsPrefix := "dns: resolver: forward: "
+		if !strings.HasPrefix(text, dnsPrefix) {
+			continue
+		}
+		text = strings.TrimPrefix(text, dnsPrefix)
+		fmt.Println(text)
+	}
+}

--- a/cmd/tailscale/cli/dns.go
+++ b/cmd/tailscale/cli/dns.go
@@ -35,8 +35,13 @@ var dnsCmd = &ffcli.Command{
 			ShortHelp:  "Perform a DNS query",
 			LongHelp:   "The 'tailscale dns query' subcommand performs a DNS query for the specified name using the internal DNS forwarder (100.100.100.100).\n\nIt also provides information about the resolver(s) used to resolve the query.",
 		},
-
-		// TODO: implement `tailscale log` here
+		{
+			Name:       "stream",
+			ShortUsage: "tailscale dns stream",
+			Exec:       runDNSStream,
+			ShortHelp:  "Stream DNS queries and responses",
+			LongHelp:   "The 'tailscale dns stream' subcommand streams DNS queries and responses to and from the internal DNS forwarder, which is useful for debugging DNS issues.",
+		},
 
 		// The above work is tracked in https://github.com/tailscale/tailscale/issues/13326
 	},


### PR DESCRIPTION
Updates tailscale/tailscale#13326

# WIP

This PR adds another subcommand to `tailscale dns`, to stream queries and answers returned by the DNS forwarder as they are handled.

Useful for debugging purposes, and is equivalent to setting the `TS_DEBUG_DNS_FORWARD_SEND` envknob and filtering the logs for relevant entries. This also adds a new envknob, `TS_DEBUG_DNS_INCLUDE_NAMES`, which includes the actual hostnames in the log lines (with a huge privacy warning!). This makes it easier to diagnose issues with DNS resolution.