### PR TITLE
.github: update and pin actions/upload-artifact to latest 4.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -456,12 +456,16 @@ jobs:
         fuzz-seconds: 300
         dry-run: false
         language: go
+    - name: Set artifacts_path in env (workaround for actions/upload-artifact#176)
+      if: steps.run.outcome != 'success' && steps.build.outcome == 'success'
+      run: |
+        echo "artifacts_path=$(realpath .)" >> $GITHUB_ENV
     - name: upload crash
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       if: steps.run.outcome != 'success' && steps.build.outcome == 'success'
       with:
         name: artifacts
-        path: ./out/artifacts
+        path: ${{ env.artifacts_path }}/out/artifacts
 
   depaware:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Update and pin actions/upload-artifact usage to latest 4.x. These were previously pointing to @3 which pulls in the latest v3 as they are released, with the potential to break our workflows if a breaking change or malicious version on the @3 stream is ever pushed.

Changing this to a pinned version also means that dependabot will keep this in the pinned version format (e.g., referencing a SHA) when it opens a PR to bump the dependency.

Updates #cleanup