### PR TITLE
.github: pin re-actors/alls-green to latest 1.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -601,6 +601,6 @@ jobs:
     steps:
     - name: Decide if change is okay to merge
       if: github.event_name != 'push'
-      uses: re-actors/alls-green@release/v1
+      uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
       with:
         jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Pin re-actors/alls-green usage to latest 1.x. This was previously pointing to `@release/v2` which pulls in the latest changes from this branch as they are released, with the potential to break our workflows if a breaking change or malicious version on this stream is ever pushed.

Changing this to a pinned version also means that dependabot will keep this in the pinned version format (e.g., referencing a SHA) when it opens a PR to bump the dependency.

Updates #cleanup