### PR TITLE
net/tsaddr: add WithoutExitRoutes and IsExitRoute

### DIFF
--- a/net/netutil/routes.go
+++ b/net/netutil/routes.go
@@ -13,11 +13,6 @@ import (
 	"tailscale.com/net/tsaddr"
 )
 
-var (
-	ipv4default = netip.MustParsePrefix("0.0.0.0/0")
-	ipv6default = netip.MustParsePrefix("::/0")
-)
-
 func validateViaPrefix(ipp netip.Prefix) error {
 	if !tsaddr.IsViaPrefix(ipp) {
 		return fmt.Errorf("%v is not a 4-in-6 prefix", ipp)
@@ -60,22 +55,22 @@ func CalcAdvertiseRoutes(advertiseRoutes string, advertiseDefaultRoute bool) ([]
 					return nil, err
 				}
 			}
-			if ipp == ipv4default {
+			if ipp == tsaddr.AllIPv4() {
 				default4 = true
-			} else if ipp == ipv6default {
+			} else if ipp == tsaddr.AllIPv6() {
 				default6 = true
 			}
 			routeMap[ipp] = true
 		}
 		if default4 && !default6 {
-			return nil, fmt.Errorf("%s advertised without its IPv6 counterpart, please also advertise %s", ipv4default, ipv6default)
+			return nil, fmt.Errorf("%s advertised without its IPv6 counterpart, please also advertise %s", tsaddr.AllIPv4(), tsaddr.AllIPv6())
 		} else if default6 && !default4 {
-			return nil, fmt.Errorf("%s advertised without its IPv4 counterpart, please also advertise %s", ipv6default, ipv4default)
+			return nil, fmt.Errorf("%s advertised without its IPv4 counterpart, please also advertise %s", tsaddr.AllIPv6(), tsaddr.AllIPv4())
 		}
 	}
 	if advertiseDefaultRoute {
-		routeMap[netip.MustParsePrefix("0.0.0.0/0")] = true
-		routeMap[netip.MustParsePrefix("::/0")] = true
+		routeMap[tsaddr.AllIPv4()] = true
+		routeMap[tsaddr.AllIPv6()] = true
 	}
 	if len(routeMap) == 0 {
 		return nil, nil


### PR DESCRIPTION
This PR moves and reuses some common exit route checks to `tsaddr` and hunts down uses and redefinitions of commonly used prefixes and checks related to exit nodes.

I did notice that in various parts of the codebase we do slightly inconsistent checks:

when checking if a route is an exit node, sometimes we do a full compare to `0.0.0.0/0` and sometimes we just check
if the bits is 0. I've added one testcase demonstrating the difference, see comment.

when checking if there are exit nodes, we are also sometimes checking if either (`0.0.0.0/0` _and_ `::/0`) or one of (`0.0.0.0/0` _or_ `::/0`) are present.

I dont address this in this PR, just an observation that might some times be relevant.

Updates #cleanup

Signed-off-by: Kristoffer Dalby <kristoffer@tailscale.com>