### PR TITLE
wgengine/magicsock: only used cached results for GetLastNetcheckReport

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -3027,18 +3027,9 @@ func getPeerMTUsProbedMetric(mtu tstun.WireMTU) *clientmetric.Metric {
 	return mm
 }
 
-// GetLastNetcheckReport returns the last netcheck report, running a new one if a recent one does not exist.
+// GetLastNetcheckReport returns the last netcheck report, returning nil if a recent one does not exist.
 func (c *Conn) GetLastNetcheckReport(ctx context.Context) *netcheck.Report {
-	lastReport := c.lastNetCheckReport.Load()
-	if lastReport == nil {
-		nr, err := c.updateNetInfo(ctx)
-		if err != nil {
-			c.logf("magicsock.Conn.GetLastNetcheckReport: updateNetInfo: %v", err)
-			return nil
-		}
-		return nr
-	}
-	return lastReport
+	return c.lastNetCheckReport.Load()
 }
 
 // SetLastNetcheckReportForTest sets the magicsock conn's last netcheck report.


### PR DESCRIPTION
When querying for an exit node suggestion, occasionally it triggers a new report concurrently with an existing report in progress. Generally, there should always be a recent report or one in progress, so it is redundant to start one there, and it causes concurrency issues.

Fixes #12643

Change-Id: I66ab9003972f673e5d4416f40eccd7c6676272a5