### PR TITLE
net/captivedetection: exclude ipsec interfaces from captive portal detection

### DIFF
--- a/net/captivedetection/captivedetection.go
+++ b/net/captivedetection/captivedetection.go
@@ -112,7 +112,7 @@ func (d *Detector) detectCaptivePortalWithGOOS(ctx context.Context, netMon *netm
 // interfaces on iOS and Android, respectively, and would be needlessly battery-draining.
 func interfaceNameDoesNotNeedCaptiveDetection(ifName string, goos string) bool {
 	ifName = strings.ToLower(ifName)
-	excludedPrefixes := []string{"tailscale", "tun", "tap", "docker", "kube", "wg"}
+	excludedPrefixes := []string{"tailscale", "tun", "tap", "docker", "kube", "wg", "ipsec"}
 	if goos == "windows" {
 		excludedPrefixes = append(excludedPrefixes, "loopback", "tunnel", "ppp", "isatap", "teredo", "6to4")
 	} else if goos == "darwin" || goos == "ios" {


### PR DESCRIPTION
Updates tailscale/tailscale#1634

Logs from some iOS users (see `BUG-09a33c527e6c3b613b7334b5c232bc65c8fd8975f6aac406e1af1f406b642e3f-20240926003847Z-714344129d81d7e3`) indicate that we're pointlessly performing captive portal detection on certain interfaces named `ipsec*`. These are tunnels with the cellular carrier that do not offer Internet access, and are only used to provide internet calling functionality (VoLTE / VoWiFi).

```
attempting to do captive portal detection on interface ipsec1
attempting to do captive portal detection on interface ipsec6
```

This PR excludes interfaces with the `ipsec` prefix from captive portal detection.