### PR TITLE
Add Open Container Image annotations as labels to the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,17 @@ ARG VERSION_GIT_HASH=""
 ENV VERSION_GIT_HASH=$VERSION_GIT_HASH
 ARG TARGETARCH
 
+# Basic build-time metadata as defined at https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
+LABEL org.opencontainers.image.title="Tailscale" \
+    org.opencontainers.image.description="The easiest, most secure way to use WireGuard and 2FA." \
+    org.opencontainers.image.version="$VERSION_SHORT" \
+    org.opencontainers.image.revision="$VERSION_GIT_HASH" \
+    org.opencontainers.image.url="https://tailscale.com" \
+    org.opencontainers.image.documentation="https://tailscale.com/kb" \
+    org.opencontainers.image.source="https://github.com/tailscale/tailscale" \
+    org.opencontainers.image.licenses="BSD-3-Clause" \
+    org.opencontainers.image.vendor="Tailscale Inc"
+
 RUN GOARCH=$TARGETARCH go install -ldflags="\
       -X tailscale.com/version.longStamp=$VERSION_LONG \
       -X tailscale.com/version.shortStamp=$VERSION_SHORT \


### PR DESCRIPTION
This PR introduces [Open Container Image (OCI)](https://opencontainers.org/) format [annotations](https://specs.opencontainers.org/image-spec/annotations/) as labels to the built Docker image.

By adding OCI-compliant annotations, we can embed information such as the source of the image, description, authorship, and versioning details directly within the image. This makes it easier to track the origin and intent of the image during distribution and use.

### Key Benefits

- **Enhanced Metadata**: The added labels include essential details like the image’s source repository, description, and version. This allows anyone inspecting the image to easily understand its purpose and origins.
- **Integration with Dependency Management Tools**: Tools like [Dependabot](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide) and [Renovate](https://docs.renovatebot.com/) will be able to recognise these labels and use them when opening PRs for dependency updates. This allows these tools to display detailed information about changes, making it easier for developers to assess the impact of updates.
- **Standardization**: Following OCI standards ensures compatibility with a wide range of container registries and tools that expect this metadata, improving interoperability across different platforms.

By including this metadata directly within the Docker image, we are ensuring better visibility into its lifecycle, contributing to improved automation and monitoring in CI/CD pipelines and simplifying compliance with image management standards.
