### PR TITLE
control/controlhttp: factor out some code in prep for future change

### DIFF
--- a/control/controlhttp/constants.go
+++ b/control/controlhttp/constants.go
@@ -95,8 +95,9 @@ type Dialer struct {
 	omitCertErrorLogging bool
 	testFallbackDelay    time.Duration
 
-	// tstime.Clock is used instead of time package for methods such as time.Now.
-	// If not specified, will default to tstime.StdClock{}.
+	// Clock, if non-nil, overrides the clock to use.
+	// If nil, tstime.StdClock is used.
+	// This exists primarily for tests.
 	Clock tstime.Clock
 }
 


### PR DESCRIPTION
This pulls out the clock and forceNoise443 code into methods on the
Dialer as cleanup in its own commit to make a future change less
distracting.

Updates #13597
