### PR TITLE
control/control{client,http}: don't noise dial localhost:443 in http-only tests

### DIFF
--- a/control/controlhttp/constants.go
+++ b/control/controlhttp/constants.go
@@ -32,6 +32,11 @@ const (
 	serverUpgradePath = "/ts2021"
 )
 
+// NoPort is a sentinel value for Dialer.HTTPSPort to indicate that HTTPS
+// should not be tried on any port. It exists primarily for some localhost
+// tests where the control plane only runs on HTTP.
+const NoPort = "none"
+
 // Dialer contains configuration on how to dial the Tailscale control server.
 type Dialer struct {
 	// Hostname is the hostname to connect to, with no port number.
@@ -62,6 +67,8 @@ type Dialer struct {
 	// HTTPSPort is the port number to use when making a HTTPS connection.
 	//
 	// If not specified, this defaults to port 443.
+	//
+	// If "none" (NoPort), HTTPS is disabled.
 	HTTPSPort string
 
 	// Dialer is the dialer used to make outbound connections.

--- a/net/dnscache/dnscache.go
+++ b/net/dnscache/dnscache.go
@@ -416,10 +416,10 @@ func (d *dialer) DialContext(ctx context.Context, network, address string) (retC
 	if len(i4s) < 2 {
 		d.dnsCache.dlogf("dialing %s, %s for %s", network, ip, address)
 		c, err := dc.dialOne(ctx, ip.Unmap())
-		if err == nil || ctx.Err() != nil {
+		if err == nil || ctx.Err() != nil || !ip6.IsValid() {
 			return c, err
 		}
-		// Fall back to trying IPv6, if any.
+		// Fall back to trying IPv6.
 		return dc.dialOne(ctx, ip6)
 	}
 

--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -1791,6 +1791,7 @@ func (n *testNode) StartDaemonAsIPNGOOS(ipnGOOS string) *Daemon {
 		cmd.Args = append(cmd.Args, "--config="+n.configFile)
 	}
 	cmd.Env = append(os.Environ(),
+		"TS_CONTROL_IS_PLAINTEXT_HTTP=1",
 		"TS_DEBUG_PERMIT_HTTP_C2N=1",
 		"TS_LOG_TARGET="+n.env.LogCatcherServer.URL,
 		"HTTP_PROXY="+n.env.TrafficTrapServer.URL,


### PR DESCRIPTION
**[3 commits]**

1eaad7d3deb regressed some tests in another repo that were starting up
a control server on `http://127.0.0.1:nnn`. Because there was no https
running, and because of a bug in 1eaad7d3deb (which ended up checking
the recently-dialed-control check twice in a single dial call), we
ended up forcing only the use of TLS dials in a test that only had
plaintext HTTP running.

Instead, plumb down support for explicitly disabling TLS fallbacks and
use it only when running in a test and using `http` scheme control
plane URLs to 127.0.0.1 or localhost.

This fixes the tests elsewhere.

Updates #13597
