### PR TITLE
logpolicy: force TLS 1.3 handshake

### DIFF
--- a/logpolicy/logpolicy.go
+++ b/logpolicy/logpolicy.go
@@ -813,6 +813,8 @@ func NewLogtailTransport(host string, netMon *netmon.Monitor, health *health.Tra
 	}
 
 	tr.TLSClientConfig = tlsdial.Config(host, health, tr.TLSClientConfig)
+	// Force TLS 1.3 since we know log.tailscale.io supports it.
+	tr.TLSClientConfig.MinVersion = tls.VersionTLS13
 
 	return tr
 }


### PR DESCRIPTION
Updates tailscale/tailscale#3363

We know `log.tailscale.io` supports TLS 1.3, so we can enforce its usage in the client to shake some bytes off the TLS handshake each time a connection is opened to upload logs.