### PR TITLE
cmd/containerboot,util/linuxfw: ensure that only one SNAT rule exists for a given match destination

### DIFF
--- a/cmd/containerboot/forwarding.go
+++ b/cmd/containerboot/forwarding.go
@@ -117,7 +117,7 @@ func installEgressForwardingRule(_ context.Context, dstStr string, tsIPs []netip
 	if err := nfr.DNATNonTailscaleTraffic("tailscale0", dst); err != nil {
 		return fmt.Errorf("installing egress proxy rules: %w", err)
 	}
-	if err := nfr.AddSNATRuleForDst(local, dst); err != nil {
+	if err := nfr.EnsureSNATForDst(local, dst); err != nil {
 		return fmt.Errorf("installing egress proxy rules: %w", err)
 	}
 	if err := nfr.ClampMSSToPMTU("tailscale0", dst); err != nil {

--- a/cmd/containerboot/main.go
+++ b/cmd/containerboot/main.go
@@ -481,7 +481,11 @@ runLoop:
 					egressAddrs = node.Addresses().AsSlice()
 					newCurentEgressIPs = deephash.Hash(&egressAddrs)
 					egressIPsHaveChanged = newCurentEgressIPs != currentEgressIPs
-					if egressIPsHaveChanged && len(egressAddrs) != 0 {
+					// The firewall rules get (re-)installed:
+					// - on startup
+					// - when the tailnet IPs of the tailnet target have changed
+					// - when the tailnet IPs of this node have changed
+					if (egressIPsHaveChanged || ipsHaveChanged) && len(egressAddrs) != 0 {
 						var rulesInstalled bool
 						for _, egressAddr := range egressAddrs {
 							ea := egressAddr.Addr()

--- a/cmd/containerboot/services.go
+++ b/cmd/containerboot/services.go
@@ -196,8 +196,7 @@ func (ep *egressProxy) syncEgressConfigs(cfgs *egressservices.Configs, status *e
 				if !local.IsValid() {
 					return nil, fmt.Errorf("no valid local IP: %v", local)
 				}
-				// TODO(irbekrm): only create the SNAT rule if it does not already exist.
-				if err := ep.nfr.AddSNATRuleForDst(local, t); err != nil {
+				if err := ep.nfr.EnsureSNATForDst(local, t); err != nil {
 					return nil, fmt.Errorf("error setting up SNAT rule: %w", err)
 				}
 			}

--- a/wgengine/router/router_linux_test.go
+++ b/wgengine/router/router_linux_test.go
@@ -530,7 +530,7 @@ func (n *fakeIPTablesRunner) DNATWithLoadBalancer(netip.Addr, []netip.Addr) erro
 	return errors.New("not implemented")
 }
 
-func (n *fakeIPTablesRunner) AddSNATRuleForDst(src, dst netip.Addr) error {
+func (n *fakeIPTablesRunner) EnsureSNATForDst(src, dst netip.Addr) error {
 	return errors.New("not implemented")
 }
 


### PR DESCRIPTION
This PR ensures that when the kube egress proxies firewall rules are refreshed, we don't end up with more than one SNAT rule for a match destination.

### Context

The [NetfilterRunner#AddSNATRuleForDst](https://github.com/tailscale/tailscale/blob/6de6ab015f3edc18565aecb9609467bab88a8ed7/util/linuxfw/nftables_runner.go#L564)  (currently only used from containerboot, mostly in kube proxy setups) method was adding a new rule each time it was called including:
- if a rule already existed
- if a rule matching the destination, but with different desired source IP already existed

This was causing issues especially for the in-progress egress HA proxies work, where the rules are now refreshed more frequently, so more redundant rules were being created.

### This change:

- only creates the rule if it doesn't already exist
- if a rule for the same dst, but different source is found, delete it
- also ensures that egress proxies refresh firewall rules if the node's tailnet IP changes
- Renames `AddSNATRuleForDst` -> `EnsureSNATForDst` to match the new behaviour

I've added unit tests, but also have tested by hand with both iptables and nftables, including testing the behaviour for when the node's tailnet IP changes and when the target tailnet IP changes.

Updates tailscale/tailscale#13406