### PR TITLE
wf/firewall: allow link-local multicast for permitted local routes when the killswitch is on on Windows

### DIFF
--- a/tstest/test-wishlist.md
+++ b/tstest/test-wishlist.md
@@ -13,5 +13,8 @@ reference to an issue or PR about the feature.
 
 # The list
 
-- ...
+- Link-local multicast, and mDNS/LLMNR specifically, when an exit node is used,
+  both with and without the "Allow local network access" option enabled.
+  When the option is disabled, we should still permit it for internal interfaces,
+  such as Hyper-V/WSL2 on Windows.
 


### PR DESCRIPTION
When an Exit Node is used, we create a WFP rule to block all inbound and outbound traffic, along with several rules to permit specific types of traffic. Notably, we allow all inbound and outbound traffic to and from `LocalRoutes` specified in `wgengine/router.Config`. The list of allowed routes always includes routes for internal interfaces, such as loopback and virtual Hyper-V/WSL2 interfaces, and may also include LAN routes if the "Allow local network access" option is enabled. However, these permitting rules do not allow link-local multicast on the corresponding interfaces. This results in broken mDNS/LLMNR, and potentially other similar issues, whenever an exit node is used.

In this PR, we update `(*wf.Firewall).UpdatePermittedRoutes()` to create rules allowing outbound and inbound link-local multicast traffic to and from the permitted IP ranges, partially resolving the mDNS/LLMNR and `*.local` name resolution issue.

Since Windows does not attempt to send mDNS/LLMNR queries if a catch-all NRPT rule is present, it is still necessary to disable the creation of that rule using the `disable-local-dns-override-via-nrpt` nodeAttr.

Updates #13571