### PR TITLE
wgengine/magicsock: avoid log spam from ReceiveFunc on shutdown

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -1299,7 +1299,7 @@ func (c *Conn) mkReceiveFunc(ruc *RebindingUDPConn, healthItem *health.ReceiveFu
 			healthItem.Enter()
 			defer healthItem.Exit()
 			defer func() {
-				if retErr != nil {
+				if retErr != nil && !c.closing.Load() {
 					c.logf("Receive func %s exiting with error: %T, %v", healthItem.Name(), retErr, retErr)
 				}
 			}()


### PR DESCRIPTION
The new logging in 2dd71e64ac11675e is spammy at shutdown:

    Receive func ReceiveIPv6 exiting with error: *net.OpError, read udp [::]:38869: raw-read udp6 [::]:38869: use of closed network connection
    Receive func ReceiveIPv4 exiting with error: *net.OpError, read udp 0.0.0.0:36123: raw-read udp4 0.0.0.0:36123: use of closed network connection

Skip it if we're in the process of shutting down.

Updates #10976
