### PR TITLE
cmd/tailscale/cli: don't print disablement secrets if init fails

### DIFF
--- a/cmd/tailscale/cli/network-lock.go
+++ b/cmd/tailscale/cli/network-lock.go
@@ -151,15 +151,15 @@ func runNetworkLockInit(ctx context.Context, args []string) error {
 		return nil
 	}
 
-	var disablementSecretsResp strings.Builder
+	var successMsg strings.Builder
 
-	fmt.Fprintf(&disablementSecretsResp, "%d disablement secrets have been generated and are printed below. Take note of them now, they WILL NOT be shown again.\n", nlInitArgs.numDisablements)
+	fmt.Fprintf(&successMsg, "%d disablement secrets have been generated and are printed below. Take note of them now, they WILL NOT be shown again.\n", nlInitArgs.numDisablements)
 	for range nlInitArgs.numDisablements {
 		var secret [32]byte
 		if _, err := rand.Read(secret[:]); err != nil {
 			return err
 		}
-		fmt.Fprintf(&disablementSecretsResp, "\tdisablement-secret:%X\n", secret[:])
+		fmt.Fprintf(&successMsg, "\tdisablement-secret:%X\n", secret[:])
 		disablementValues = append(disablementValues, tka.DisablementKDF(secret[:]))
 	}
 
@@ -170,7 +170,7 @@ func runNetworkLockInit(ctx context.Context, args []string) error {
 			return err
 		}
 		disablementValues = append(disablementValues, tka.DisablementKDF(supportDisablement))
-		fmt.Fprintln(&disablementSecretsResp, "A disablement secret for Tailscale support has been generated and will be transmitted to Tailscale upon initialization.")
+		fmt.Fprintln(&successMsg, "A disablement secret for Tailscale support has been generated and has been transmitted to Tailscale.")
 	}
 
 	// The state returned by NetworkLockInit likely doesn't contain the initialized state,
@@ -179,7 +179,7 @@ func runNetworkLockInit(ctx context.Context, args []string) error {
 		return err
 	}
 
-	fmt.Print(disablementSecretsResp.String())
+	fmt.Print(successMsg.String())
 	fmt.Println("Initialization complete.")
 	return nil
 }

--- a/cmd/tailscale/cli/network-lock.go
+++ b/cmd/tailscale/cli/network-lock.go
@@ -151,13 +151,15 @@ func runNetworkLockInit(ctx context.Context, args []string) error {
 		return nil
 	}
 
-	fmt.Printf("%d disablement secrets have been generated and are printed below. Take note of them now, they WILL NOT be shown again.\n", nlInitArgs.numDisablements)
+	var disablementSecretsResp strings.Builder
+
+	fmt.Fprintf(&disablementSecretsResp, "%d disablement secrets have been generated and are printed below. Take note of them now, they WILL NOT be shown again.\n", nlInitArgs.numDisablements)
 	for range nlInitArgs.numDisablements {
 		var secret [32]byte
 		if _, err := rand.Read(secret[:]); err != nil {
 			return err
 		}
-		fmt.Printf("\tdisablement-secret:%X\n", secret[:])
+		fmt.Fprintf(&disablementSecretsResp, "\tdisablement-secret:%X\n", secret[:])
 		disablementValues = append(disablementValues, tka.DisablementKDF(secret[:]))
 	}
 
@@ -168,7 +170,7 @@ func runNetworkLockInit(ctx context.Context, args []string) error {
 			return err
 		}
 		disablementValues = append(disablementValues, tka.DisablementKDF(supportDisablement))
-		fmt.Println("A disablement secret for Tailscale support has been generated and will be transmitted to Tailscale upon initialization.")
+		fmt.Fprintln(&disablementSecretsResp, "A disablement secret for Tailscale support has been generated and will be transmitted to Tailscale upon initialization.")
 	}
 
 	// The state returned by NetworkLockInit likely doesn't contain the initialized state,
@@ -177,6 +179,7 @@ func runNetworkLockInit(ctx context.Context, args []string) error {
 		return err
 	}
 
+	fmt.Print(disablementSecretsResp.String())
 	fmt.Println("Initialization complete.")
 	return nil
 }

--- a/cmd/tailscale/cli/network-lock.go
+++ b/cmd/tailscale/cli/network-lock.go
@@ -170,7 +170,7 @@ func runNetworkLockInit(ctx context.Context, args []string) error {
 			return err
 		}
 		disablementValues = append(disablementValues, tka.DisablementKDF(supportDisablement))
-		fmt.Fprintln(&successMsg, "A disablement secret for Tailscale support has been generated and has been transmitted to Tailscale.")
+		fmt.Fprintln(&successMsg, "A disablement secret for Tailscale support has been generated and transmitted to Tailscale.")
 	}
 
 	// The state returned by NetworkLockInit likely doesn't contain the initialized state,


### PR DESCRIPTION
Fixes tailscale/corp#11355

Before, with unusable disablement secrets on init failure:

```
➜  ~ tailscale lock init --gen-disablement-for-support --gen-disablements 10 --confirm tlpub:c5ddcf8264c93419c995bd19a047cd8b6cb41af6d993e631958aabe2bafd4927 tlpub:f32054d78442a6a6cb51479093ddf657b5c3e90572f27ee228d62e9ed7b6be7d
Warning: client version "1.74.1-t0ca17be4a" != tailscaled server version "1.75.47-t77832553e-g425477bf6"
You are initializing tailnet lock with the following trusted signing keys:
 - tlpub:c5ddcf8264c93419c995bd19a047cd8b6cb41af6d993e631958aabe2bafd4927 (25519 key)
 - tlpub:f32054d78442a6a6cb51479093ddf657b5c3e90572f27ee228d62e9ed7b6be7d (25519 key)

10 disablement secrets have been generated and are printed below. Take note of them now, they WILL NOT be shown again.
	disablement-secret:9ADE7E6E61CADEEB7FC7D5921EDAEDB541EB829423EA57EACA33AC7248F4D453
	disablement-secret:C40EC34878F0EF1F0B7ACF2222FD7C62961FF7E9695FD2490516E09D4A1DD96F
	disablement-secret:12CD3A8BC12C7D6938A4D0C6881BB82415877AACD3965A9F1CCC07F72F14A529
	disablement-secret:2B3174E1F0B1BB4CFCFBBBCCDB00AE1A4D4D289F8D516253925A27965489E628
	disablement-secret:CCD7E4C77F760E82CFBC221770776634DA15B939AA0CDCC8A3B58B457816B6FD
	disablement-secret:02D308C6BF3F9B6FF85A71A58D3C9697CE640A6CBFC5F9B98F717F9B9CE62994
	disablement-secret:F078A11F3DB2E2FF950F32F71BED104AC67695D8E1A76E38072E58EC49493563
	disablement-secret:8056DDD6ACBF771EFDD501A10597D94C8D8D79FA3251E9563FB45A314B96505A
	disablement-secret:91ADA8360D9ED11ACA9E82C8DD76050F69D0AC299FBE1083283001BD7376E714
	disablement-secret:86D816EBEC16CD4F845D44991E92FD3DFC06A2313046B6834C12786C70309490
A disablement secret for Tailscale support has been generated and will be transmitted to Tailscale upon initialization.
error: 500 Internal Server Error: initialization failed: tka init-begin RPC: request returned (403): user is not an admin
REQ-1402640fe-4d4b-4fca-a226-ad485d45a189
```

After, without them:

```
➜  tailscale git:(main) ✗ ./tool/go run ./cmd/tailscale lock init --gen-disablement-for-support --gen-disablements 10 --confirm tlpub:caf95fd6d507da05382a3f56c57698e910c7160492983df08eb1e6470e86249d tlpub:f7fbde0d5578db080bea9900528a325ee742a60dc5d0ce7afed07201f5cb2c08
Warning: client version "1.75.71-t6f694da91" != tailscaled server version "1.75.47-t77832553e-g425477bf6"
You are initializing tailnet lock with the following trusted signing keys:
 - tlpub:caf95fd6d507da05382a3f56c57698e910c7160492983df08eb1e6470e86249d (25519 key)
 - tlpub:f7fbde0d5578db080bea9900528a325ee742a60dc5d0ce7afed07201f5cb2c08 (25519 key)

error: 500 Internal Server Error: initialization failed: tka init-begin RPC: request returned (403): user is not an admin
REQ-16da2cc53-cba5-4e26-bf8c-7043e5e6eec8
exit status 1
```

success still shows them:

```
➜  tailscale git:(main) ✗ ./tool/go run ./cmd/tailscale lock init --gen-disablement-for-support --gen-disablements 10 --confirm tlpub:caf95fd6d507da05382a3f56c57698e910c7160492983df08eb1e6470e86249d tlpub:f7fbde0d5578db080bea9900528a325ee742a60dc5d0ce7afed07201f5cb2c08
Warning: client version "1.75.71-t6f694da91" != tailscaled server version "1.75.47-t77832553e-g425477bf6"
You are initializing tailnet lock with the following trusted signing keys:
 - tlpub:caf95fd6d507da05382a3f56c57698e910c7160492983df08eb1e6470e86249d (25519 key)
 - tlpub:f7fbde0d5578db080bea9900528a325ee742a60dc5d0ce7afed07201f5cb2c08 (25519 key)

10 disablement secrets have been generated and are printed below. Take note of them now, they WILL NOT be shown again.
        disablement-secret:FC9D524D1C79BC616585FBE4457AD9A0D9804561D828BB6A3E1DE5A0EA88DBC5
        disablement-secret:F26F6D1773B5995B9C20BA559E666B9CA712E018B325430D5470A3B0B5E2AF81
        disablement-secret:45411E03221E6C01A5473CDB66B6B072B9E2EA4679770D0511C506EF92881623
        disablement-secret:B0710B937CF31FF5AB6CCC76160A62EA2668E3978F7382CBE79CCDFFE46816B1
        disablement-secret:61F377A65C07FF1E3840053AEC2241698FB4D1078F61B3146D905BB99E967823
        disablement-secret:BAE009F28EDAD6CF4ADCB0BB5FE4D14721A98534BF29DA005750B19D41266B42
        disablement-secret:B67F321B62B7E0F2900F8F576C2EB842652FE01EC5BE974EC78349DA09172AB7
        disablement-secret:EAF8624494C77EE92029402016B17CF14088B5122AE435C5E860FD8BB80B78F3
        disablement-secret:65C1FBE2C95385CEC361825634470136C63D784E6A556738A734C23C4538C330
        disablement-secret:88EE814FC8047B907BB4D97275C63441492E1AFD699F5D5AC48135F6DD5E1B74
A disablement secret for Tailscale support has been generated and will be transmitted to Tailscale upon initialization.
Initialization complete.
```