### PR TITLE
types/key: use tlpub: in error message

### DIFF
--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -1448,7 +1448,7 @@ func TestParseNLArgs(t *testing.T) {
 			name:      "disablements not allowed",
 			input:     []string{"disablement:" + strings.Repeat("02", 32)},
 			parseKeys: true,
-			wantErr:   fmt.Errorf("parsing key 1: key hex string doesn't have expected type prefix nlpub:"),
+			wantErr:   fmt.Errorf("parsing key 1: key hex string doesn't have expected type prefix tlpub:"),
 		},
 		{
 			name:              "keys not allowed",

--- a/types/key/nl.go
+++ b/types/key/nl.go
@@ -131,10 +131,10 @@ func NLPublicFromEd25519Unsafe(public ed25519.PublicKey) NLPublic {
 // is able to decode both the CLI form (tlpub:<hex>) & the
 // regular form (nlpub:<hex>).
 func (k *NLPublic) UnmarshalText(b []byte) error {
-	if mem.HasPrefix(mem.B(b), mem.S(nlPublicHexPrefixCLI)) {
-		return parseHex(k.k[:], mem.B(b), mem.S(nlPublicHexPrefixCLI))
+	if mem.HasPrefix(mem.B(b), mem.S(nlPublicHexPrefix)) {
+		return parseHex(k.k[:], mem.B(b), mem.S(nlPublicHexPrefix))
 	}
-	return parseHex(k.k[:], mem.B(b), mem.S(nlPublicHexPrefix))
+	return parseHex(k.k[:], mem.B(b), mem.S(nlPublicHexPrefixCLI))
 }
 
 // AppendText implements encoding.TextAppender.


### PR DESCRIPTION
Fixes tailscale/corp#19442
The change is done by switching the logic flow such that checking `tlpub:` is the fallback and its error message is the one that falls through.

Test was updated and passes with the new code. Manual testing also seems good: if you provide `nlpub:` it still works but the error for `foo:bar` tells you to use `tlpub:`

```
➜  tailscale git:(erisa/tlpub-prefix-warning) ./tool/go run ./cmd/tailscale lock init foo:bar
Warning: client version "1.75.84-t6d8acc267" != tailscaled server version "1.75.72-t1f8eea53a-ge56e13a96"
parsing key 1: key hex string doesn't have expected type prefix tlpub:
exit status 1
➜  tailscale git:(erisa/tlpub-prefix-warning) ./tool/go run ./cmd/tailscale lock init nlpub:bar
Warning: client version "1.75.84-t6d8acc267" != tailscaled server version "1.75.72-t1f8eea53a-ge56e13a96"
parsing key 1: key hex has the wrong size, got 3 want 64
exit status 1
➜  tailscale git:(erisa/tlpub-prefix-warning) ./tool/go run ./cmd/tailscale lock init tlpub:bar
Warning: client version "1.75.84-t6d8acc267" != tailscaled server version "1.75.72-t1f8eea53a-ge56e13a96"
parsing key 1: key hex has the wrong size, got 3 want 64
exit status 1
```