### PR TITLE
tool/gocross: fix argument order to find

### DIFF
--- a/tool/gocross/gocross-wrapper.sh
+++ b/tool/gocross/gocross-wrapper.sh
@@ -67,7 +67,7 @@ case "$REV" in
         rm -f "$toolchain.tar.gz"
 
         # Do some cleanup of old toolchains while we're here.
-        for hash in $(find "$HOME/.cache/tsgo" -type f -maxdepth 1 -name '*.extracted' -mtime 90 -exec basename {} \; | sed 's/.extracted$//'); do
+        for hash in $(find "$HOME/.cache/tsgo" -maxdepth 1 -type f -name '*.extracted' -mtime 90 -exec basename {} \; | sed 's/.extracted$//'); do
             echo "# Cleaning up old Go toolchain $hash" >&2
             rm -rf "$HOME/.cache/tsgo/$hash"
             rm -rf "$HOME/.cache/tsgo/$hash.extracted"


### PR DESCRIPTION
To avoid warning:

    find: warning: you have specified the global option -maxdepth after the argument -type, but global options are not positional, i.e., -maxdepth affects tests specified before it as well as those specified after it.  Please specify global options before other arguments.

Fixes tailscale/corp#23689
