### PR TITLE
derp: fix omitted word in comment

### DIFF
--- a/derp/derp_server.go
+++ b/derp/derp_server.go
@@ -1692,7 +1692,7 @@ func (c *sclient) sendLoop(ctx context.Context) error {
 			if werr = c.bw.Flush(); werr != nil {
 				return werr
 			}
-			if inBatch != 0 { // the first loop will almost hit default & be size zero
+			if inBatch != 0 { // the first loop will almost always hit default & be size zero
 				c.s.bufferedWriteFrames.Observe(float64(inBatch))
 				inBatch = 0
 			}


### PR DESCRIPTION
Fix comment just added in 38f236c7259.

Updates tailscale/corp#23668
Updates #cleanup
