### PR TITLE
cmd/k8s-operator: fix Pod IP selection

### DIFF
--- a/cmd/k8s-operator/egress-eps.go
+++ b/cmd/k8s-operator/egress-eps.go
@@ -111,9 +111,13 @@ func (er *egressEpsReconciler) Reconcile(ctx context.Context, req reconcile.Requ
 		if !ready {
 			continue // maybe next time
 		}
+		podIP, err := podIPv4(&pod) // we currently only support IPv4
+		if err != nil {
+			return res, fmt.Errorf("error determining IPv4 address for Pod: %w", err)
+		}
 		newEndpoints = append(newEndpoints, discoveryv1.Endpoint{
 			Hostname:  (*string)(&pod.UID),
-			Addresses: []string{pod.Status.PodIP},
+			Addresses: []string{podIP},
 			Conditions: discoveryv1.EndpointConditions{
 				Ready:       ptr.To(true),
 				Serving:     ptr.To(true),

--- a/cmd/k8s-operator/egress-eps_test.go
+++ b/cmd/k8s-operator/egress-eps_test.go
@@ -104,7 +104,7 @@ func TestTailscaleEgressEndpointSlices(t *testing.T) {
 		})
 		expectReconciled(t, er, "operator-ns", "foo")
 		eps.Endpoints = append(eps.Endpoints, discoveryv1.Endpoint{
-			Addresses: []string{pod.Status.PodIP},
+			Addresses: []string{"10.0.0.1"},
 			Hostname:  pointer.To("foo"),
 			Conditions: discoveryv1.EndpointConditions{
 				Serving:     pointer.ToBool(true),


### PR DESCRIPTION
Ensure that `.status.podIPs` field is used to select Pod's IP in all reconcilers.

Updates tailscale/tailscale#13406