### PR TITLE
syncs: allocate map with Map.WithLock

### DIFF
--- a/syncs/syncs.go
+++ b/syncs/syncs.go
@@ -320,6 +320,9 @@ func (m *Map[K, V]) All() iter.Seq2[K, V] {
 func (m *Map[K, V]) WithLock(f func(m2 map[K]V)) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.m == nil {
+		m.m = make(map[K]V)
+	}
 	f(m.m)
 }
 


### PR DESCRIPTION
One primary purpose of WithLock is to mutate the underlying map. However, this can lead to a panic if it happens to be nil. Thus, always allocate a map before passing it to f.

Updates tailscale/corp#11038