### PR TITLE
taildrop: fix defer in loop

### DIFF
--- a/taildrop/taildrop.go
+++ b/taildrop/taildrop.go
@@ -228,7 +228,6 @@ func (m *Manager) IncomingFiles() []ipn.PartialFile {
 	files := make([]ipn.PartialFile, 0)
 	for k, f := range m.incomingFiles.All() {
 		f.mu.Lock()
-		defer f.mu.Unlock()
 		files = append(files, ipn.PartialFile{
 			Name:         k.name,
 			Started:      f.started,
@@ -238,6 +237,7 @@ func (m *Manager) IncomingFiles() []ipn.PartialFile {
 			FinalPath:    f.finalPath,
 			Done:         f.done,
 		})
+		f.mu.Unlock()
 	}
 	return files
 }


### PR DESCRIPTION
PR #13756 switched from using syncs.Map.Range to the All iterator.
However, this affects the scope of a defer.

Updates #11038