### PR TITLE
tsnet: fix panic caused by logging after test finishes

### DIFF
--- a/tsnet/tsnet_test.go
+++ b/tsnet/tsnet_test.go
@@ -510,7 +510,7 @@ func TestStartStopStartGetsSameIP(t *testing.T) {
 			Dir:        tmps1,
 			ControlURL: controlURL,
 			Hostname:   "s1",
-			Logf:       logger.TestLogger(t),
+			Logf:       tstest.WhileTestRunningLogger(t),
 		}
 	}
 	s1 := newServer()


### PR DESCRIPTION
Updates #13773

Change-Id: I95e03eb6aef1639bd4a2efd3a415e2c10cdebc5a