### PR TITLE
safesocket: don't depend on go-ps on iOS

### DIFF
--- a/safesocket/safesocket_ps.go
+++ b/safesocket/safesocket_ps.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build linux || windows || darwin || freebsd
+//go:build linux || windows || (darwin && !ios) || freebsd
 
 package safesocket
 

--- a/tstest/iosdeps/iosdeps_test.go
+++ b/tstest/iosdeps/iosdeps_test.go
@@ -19,6 +19,7 @@ func TestDeps(t *testing.T) {
 			"html/template":              "linker bloat (MethodByName)",
 			"tailscale.com/net/wsconn":   "https://github.com/tailscale/tailscale/issues/13762",
 			"github.com/coder/websocket": "https://github.com/tailscale/tailscale/issues/13762",
+			"github.com/mitchellh/go-ps": "https://github.com/tailscale/tailscale/pull/13759",
 		},
 	}.Check(t)
 }


### PR DESCRIPTION
There's never a tailscaled on iOS. And we can't run child processes to
look for it anyway.

Updates tailscale/corp#20099
