### PR TITLE
control/controlhttp: don't link ts2021 server + websocket code on iOS

### DIFF
--- a/control/controlhttp/server.go
+++ b/control/controlhttp/server.go
@@ -1,6 +1,8 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
+//go:build !ios
+
 package controlhttp
 
 import (

--- a/tstest/iosdeps/iosdeps_test.go
+++ b/tstest/iosdeps/iosdeps_test.go
@@ -14,9 +14,11 @@ func TestDeps(t *testing.T) {
 		GOOS:   "ios",
 		GOARCH: "arm64",
 		BadDeps: map[string]string{
-			"testing":       "do not use testing package in production code",
-			"text/template": "linker bloat (MethodByName)",
-			"html/template": "linker bloat (MethodByName)",
+			"testing":                    "do not use testing package in production code",
+			"text/template":              "linker bloat (MethodByName)",
+			"html/template":              "linker bloat (MethodByName)",
+			"tailscale.com/net/wsconn":   "https://github.com/tailscale/tailscale/issues/13762",
+			"github.com/coder/websocket": "https://github.com/tailscale/tailscale/issues/13762",
 		},
 	}.Check(t)
 }


### PR DESCRIPTION
We probably shouldn't link it in anywhere, but let's fix iOS for now.

Updates #13762
Updates tailscale/corp#20099
