### PR TITLE
drive/driveimpl: do not serve WebDAV on tvOS

### DIFF
--- a/drive/driveimpl/local_impl.go
+++ b/drive/driveimpl/local_impl.go
@@ -14,6 +14,7 @@ import (
 	"tailscale.com/drive/driveimpl/compositedav"
 	"tailscale.com/drive/driveimpl/dirfs"
 	"tailscale.com/types/logger"
+	"tailscale.com/version"
 )
 
 const (
@@ -55,6 +56,11 @@ type FileSystemForLocal struct {
 }
 
 func (s *FileSystemForLocal) startServing() {
+	if version.IsAppleTV() {
+		s.logf("won't serve taildrive on Apple TV")
+		return
+	}
+
 	hs := &http.Server{Handler: s.h}
 	go func() {
 		err := hs.Serve(s.listener)


### PR DESCRIPTION
Fixes tailscale/tailscale#13765

There is no need to serve a local filesystem on tvOS, given that there is no filesystem there. Disable it with a platform check.

Noting there are likely more platforms that we can exclude.

cc @oxtoacart to be sure this is okay to do