### PR TITLE
k8s-operator/apis: revert ProxyGroup readiness cond name change

### DIFF
--- a/k8s-operator/apis/v1alpha1/types_connector.go
+++ b/k8s-operator/apis/v1alpha1/types_connector.go
@@ -172,7 +172,7 @@ type ConditionType string
 const (
 	ConnectorReady  ConditionType = `ConnectorReady`
 	ProxyClassReady ConditionType = `ProxyClassReady`
-	ProxyGroupReady ConditionType = `TailscaleProxyGroupReady`
+	ProxyGroupReady ConditionType = `ProxyGroupReady`
 	ProxyReady      ConditionType = `TailscaleProxyReady` // a Tailscale-specific condition type for corev1.Service
 	RecorderReady   ConditionType = `RecorderReady`
 	// EgressSvcValid gets set on a user configured ExternalName Service that defines a tailnet target to be exposed


### PR DESCRIPTION
No need to prefix this with 'Tailscale' for tailscale.com custom resource types.

Updates tailscale/tailscale#13406