### PR TITLE
release: add proper min and max versions for DSM 7.x builds

### DIFF
--- a/release/dist/synology/pkgs.go
+++ b/release/dist/synology/pkgs.go
@@ -155,8 +155,15 @@ func (t *target) mkInfo(b *dist.Build, uncompressedSz int64) []byte {
 		f("os_min_ver", "6.0.1-7445")
 		f("os_max_ver", "7.0-40000")
 	case 7:
-		f("os_min_ver", "7.0-40000")
-		f("os_max_ver", "")
+		switch t.dsmMinorVersion {
+		case 0:
+			f("os_min_ver", "7.0-40000")
+			f("os_max_ver", "7.2-60000")
+		case 2:
+			f("os_min_ver", "7.2-60000")
+		default:
+			panic(fmt.Sprintf("unsupported DSM major.minor version %s", t.dsmVersionString()))
+		}
 	default:
 		panic(fmt.Sprintf("unsupported DSM major version %d", t.dsmMajorVersion))
 	}


### PR DESCRIPTION
Add an `os_max_ver` entry to the INFO file for DSM 7.0 builds with a value of `7.2-60000`, and change the `os_min_ver` for DSM 7.2 to `7.2-60000` as per Synology guidance on minimum and maximum versions for the different minor version packages.

Updates https://github.com/tailscale/corp/issues/22908