### PR TITLE
tsweb: avoid http-to-https redirect for localhost

### DIFF
--- a/tsweb/tsweb.go
+++ b/tsweb/tsweb.go
@@ -146,8 +146,10 @@ type Port80Handler struct {
 }
 
 func (h Port80Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ipStr, _, _ := net.SplitHostPort(r.RemoteAddr)
+	ip, _ := netip.ParseAddr(ipStr)
 	path := r.RequestURI
-	if path == "/debug" || strings.HasPrefix(path, "/debug") {
+	if ip.IsLoopback() || path == "/debug" || strings.HasPrefix(path, "/debug") {
 		h.Main.ServeHTTP(w, r)
 		return
 	}


### PR DESCRIPTION
If the client is connecting over loopback, then avoid the http-to-https redirect since this is connection within the kernel,
rather than over untrusted network, and also because https://localhost is unlikely to work as there isn't a CA that issues certs for localhost.

Updates tailscale/corp#11038