### PR TITLE
hostinfo,build_docker.sh,tailcfg: more reliably detect being in a container

### DIFF
--- a/build_docker.sh
+++ b/build_docker.sh
@@ -56,6 +56,7 @@ case "$TARGET" in
         -X tailscale.com/version.gitCommitStamp=${VERSION_GIT_HASH}" \
       --base="${BASE}" \
       --tags="${TAGS}" \
+      --gotags="ts_kube,ts_package_container" \
       --repos="${REPOS}" \
       --push="${PUSH}" \
       --target="${PLATFORM}" \
@@ -72,6 +73,7 @@ case "$TARGET" in
         -X tailscale.com/version.gitCommitStamp=${VERSION_GIT_HASH}" \
       --base="${BASE}" \
       --tags="${TAGS}" \
+      --gotags="ts_kube,ts_package_container" \
       --repos="${REPOS}" \
       --push="${PUSH}" \
       --target="${PLATFORM}" \

--- a/hostinfo/hostinfo.go
+++ b/hostinfo/hostinfo.go
@@ -287,6 +287,11 @@ func inContainer() opt.Bool {
 	}
 	var ret opt.Bool
 	ret.Set(false)
+	if packageType != nil && packageType() == "container" {
+		// Go build tag ts_package_container was set during build.
+		ret.Set(true)
+		return ret
+	}
 	if _, err := os.Stat("/.dockerenv"); err == nil {
 		ret.Set(true)
 		return ret
@@ -362,7 +367,7 @@ func inFlyDotIo() bool {
 }
 
 func inReplit() bool {
-	// https://docs.replit.com/programming-ide/getting-repl-metadata
+	// https://docs.replit.com/replit-workspace/configuring-repl#environment-variables
 	if os.Getenv("REPL_OWNER") != "" && os.Getenv("REPL_SLUG") != "" {
 		return true
 	}

--- a/hostinfo/hostinfo.go
+++ b/hostinfo/hostinfo.go
@@ -280,7 +280,9 @@ func getEnvType() EnvType {
 	return ""
 }
 
-// inContainer reports whether we're running in a container.
+// inContainer reports whether we're running in a container. Best-effort only,
+// there's no foolproof way to detect this, but the build tag should catch all
+// official builds from 1.78.0.
 func inContainer() opt.Bool {
 	if runtime.GOOS != "linux" {
 		return ""
@@ -292,6 +294,8 @@ func inContainer() opt.Bool {
 		ret.Set(true)
 		return ret
 	}
+	// Only set if using docker's container runtime. Not guaranteed by
+	// documentation, but it's been in place for a long time.
 	if _, err := os.Stat("/.dockerenv"); err == nil {
 		ret.Set(true)
 		return ret

--- a/hostinfo/hostinfo_container_linux_test.go
+++ b/hostinfo/hostinfo_container_linux_test.go
@@ -11,6 +11,6 @@ import (
 
 func TestInContainer(t *testing.T) {
 	if got := inContainer(); !got.EqualBool(true) {
-		t.Error(got)
+		t.Errorf("inContainer = %v; want true due to ts_package_container build tag", got)
 	}
 }

--- a/hostinfo/hostinfo_container_linux_test.go
+++ b/hostinfo/hostinfo_container_linux_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build linux && !android && ts_package_container
+
+package hostinfo
+
+import (
+	"testing"
+)
+
+func TestInContainer(t *testing.T) {
+	if got := inContainer(); !got.EqualBool(true) {
+		t.Error(got)
+	}
+}

--- a/hostinfo/hostinfo_linux_test.go
+++ b/hostinfo/hostinfo_linux_test.go
@@ -37,6 +37,6 @@ remotes/origin/QTSFW_5.0.0`
 
 func TestInContainer(t *testing.T) {
 	if got := inContainer(); !got.EqualBool(false) {
-		t.Error(got)
+		t.Errorf("inContainer = %v; want false due to absence of ts_package_container build tag", got)
 	}
 }

--- a/hostinfo/hostinfo_linux_test.go
+++ b/hostinfo/hostinfo_linux_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build linux && !android
+//go:build linux && !android && !ts_package_container
 
 package hostinfo
 
@@ -32,5 +32,11 @@ remotes/origin/QTSFW_5.0.0`
 	want = ""
 	if got != want {
 		t.Errorf("got %q; want %q", got, want)
+	}
+}
+
+func TestInContainer(t *testing.T) {
+	if got := inContainer(); !got.EqualBool(false) {
+		t.Error(got)
 	}
 }

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -771,7 +771,7 @@ type Hostinfo struct {
 	// "5.10.0-17-amd64".
 	OSVersion string `json:",omitempty"`
 
-	Container      opt.Bool `json:",omitempty"` // whether the client is running in a container
+	Container      opt.Bool `json:",omitempty"` // best-effort whether the client is running in a container
 	Env            string   `json:",omitempty"` // a hostinfo.EnvType in string form
 	Distro         string   `json:",omitempty"` // "debian", "ubuntu", "nixos", ...
 	DistroVersion  string   `json:",omitempty"` // "20.04", ...


### PR DESCRIPTION
Our existing container-detection tricks did not work on Kubernetes, where Docker is no longer used as a container runtime. Extends the existing go build tags for containers to the other container packages and uses that to reliably detect builds that were created by Tailscale for use in a container. Unfortunately this doesn't necessarily improve detection for users' custom builds, but that's a separate issue.

Updates #13825

Note: the `hostinfo` package value is [set to](https://github.com/tailscale/tailscale/blob/a8f9c0d6e40a99e091e06572cd5e9b20db7baa21/tsnet/tsnet.go#L288) "tsnet" for any `tsnet` applications, which is a little awkward because it's not mutually exclusive with being in a container. I think it would also be reasonable to try to untangle that, but this change seems like a more straightforward initial improvement.

I believe CI won't run the `ts_package_container` tag version of the test, but it still seems worth adding that test for better human understanding and testing of changes. To run it manually: `go test -tags ts_package_container -run TestInContainer ./hostinfo/`. I have also deployed this change to a Kubernetes cluster to manually confirm it does correctly pick up being in a container.