### PR TITLE
cmd/derpprobe: add /healthz endpoint

### DIFF
--- a/cmd/derpprobe/derpprobe.go
+++ b/cmd/derpprobe/derpprobe.go
@@ -75,6 +75,11 @@ func main() {
 		prober.WithPageLink("Prober metrics", "/debug/varz"),
 		prober.WithProbeLink("Run Probe", "/debug/probe-run?name={{.Name}}"),
 	), tsweb.HandlerOptions{Logf: log.Printf}))
+	mux.Handle("/healthz", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok\n"))
+	}))
 	log.Printf("Listening on %s", *listen)
 	log.Fatal(http.ListenAndServe(*listen, mux))
 }


### PR DESCRIPTION
For a customer that wants to run their own DERP prober, let's add a /healthz endpoint that can be used to monitor derpprobe itself.

Updates #6526


Change-Id: Iba315c999fc0b1a93d8c503c07cc733b4c8d5b6b