### PR TITLE
net/netcheck: remove arbitrary deadlines from GetReport() tests

### DIFF
--- a/net/netcheck/netcheck_test.go
+++ b/net/netcheck/netcheck_test.go
@@ -38,7 +38,7 @@ func TestBasic(t *testing.T) {
 
 	c := newTestClient(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	if err := c.Standalone(ctx, "127.0.0.1:0"); err != nil {
@@ -117,7 +117,7 @@ func TestWorksWhenUDPBlocked(t *testing.T) {
 
 	c := newTestClient(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	r, err := c.GetReport(ctx, dm, nil)
@@ -870,5 +870,32 @@ func TestReportTimeouts(t *testing.T) {
 	}
 	if ReportTimeout < httpsProbeTimeout {
 		t.Errorf("ReportTimeout (%v) cannot be less than httpsProbeTimeout (%v)", ReportTimeout, httpsProbeTimeout)
+	}
+}
+
+func TestNoUDPNilGetReportOpts(t *testing.T) {
+	blackhole, err := net.ListenPacket("udp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to open blackhole STUN listener: %v", err)
+	}
+	defer blackhole.Close()
+
+	dm := stuntest.DERPMapOf(blackhole.LocalAddr().String())
+	for _, region := range dm.Regions {
+		for _, n := range region.Nodes {
+			n.STUNOnly = false // exercise ICMP & HTTPS probing
+		}
+	}
+
+	c := newTestClient(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r, err := c.GetReport(ctx, dm, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.UDP {
+		t.Fatal("unexpected working UDP")
 	}
 }


### PR DESCRIPTION
Updates #13783
Updates #13394