### PR TITLE
tool/gocross: add support for tvOS Simulator

### DIFF
--- a/tool/gocross/autoflags.go
+++ b/tool/gocross/autoflags.go
@@ -146,7 +146,11 @@ func autoflagsForTest(argv []string, env *Environment, goroot, nativeGOOS, nativ
 			case env.IsSet("MACOSX_DEPLOYMENT_TARGET"):
 				xcodeFlags = append(xcodeFlags, "-mmacosx-version-min="+env.Get("MACOSX_DEPLOYMENT_TARGET", ""))
 			case env.IsSet("TVOS_DEPLOYMENT_TARGET"):
-				xcodeFlags = append(xcodeFlags, "-mtvos-version-min="+env.Get("TVOS_DEPLOYMENT_TARGET", ""))
+				if env.Get("TARGET_DEVICE_PLATFORM_NAME", "") == "appletvsimulator" {
+					xcodeFlags = append(xcodeFlags, "-mtvos-simulator-version-min="+env.Get("TVOS_DEPLOYMENT_TARGET", ""))
+				} else {
+					xcodeFlags = append(xcodeFlags, "-mtvos-version-min="+env.Get("TVOS_DEPLOYMENT_TARGET", ""))
+				}
 			default:
 				return nil, nil, fmt.Errorf("invoked by Xcode but couldn't figure out deployment target. Did Xcode change its envvars again?")
 			}


### PR DESCRIPTION
Updates ENG-5321

Allow gocross to build a static library for the Apple TV Simulator.