### PR TITLE
health: remove SysDNSOS, add two Warnables for read+set system DNS config

### DIFF
--- a/health/health.go
+++ b/health/health.go
@@ -128,9 +128,6 @@ const (
 	// SysDNS is the name of the net/dns subsystem.
 	SysDNS = Subsystem("dns")
 
-	// SysDNSOS is the name of the net/dns OSConfigurator subsystem.
-	SysDNSOS = Subsystem("dns-os")
-
 	// SysDNSManager is the name of the net/dns manager subsystem.
 	SysDNSManager = Subsystem("dns-manager")
 
@@ -141,7 +138,7 @@ const (
 var subsystemsWarnables = map[Subsystem]*Warnable{}
 
 func init() {
-	for _, s := range []Subsystem{SysRouter, SysDNS, SysDNSOS, SysDNSManager, SysTKA} {
+	for _, s := range []Subsystem{SysRouter, SysDNS, SysDNSManager, SysTKA} {
 		w := Register(&Warnable{
 			Code:     WarnableCode(s),
 			Severity: SeverityMedium,
@@ -510,21 +507,11 @@ func (t *Tracker) SetDNSHealth(err error) { t.setErr(SysDNS, err) }
 // Deprecated: Warnables should be preferred over Subsystem errors.
 func (t *Tracker) DNSHealth() error { return t.get(SysDNS) }
 
-// SetDNSOSHealth sets the state of the net/dns.OSConfigurator
-//
-// Deprecated: Warnables should be preferred over Subsystem errors.
-func (t *Tracker) SetDNSOSHealth(err error) { t.setErr(SysDNSOS, err) }
-
 // SetDNSManagerHealth sets the state of the Linux net/dns manager's
 // discovery of the /etc/resolv.conf situation.
 //
 // Deprecated: Warnables should be preferred over Subsystem errors.
 func (t *Tracker) SetDNSManagerHealth(err error) { t.setErr(SysDNSManager, err) }
-
-// DNSOSHealth returns the net/dns.OSConfigurator error state.
-//
-// Deprecated: Warnables should be preferred over Subsystem errors.
-func (t *Tracker) DNSOSHealth() error { return t.get(SysDNSOS) }
 
 // SetTKAHealth sets the health of the tailnet key authority.
 //

--- a/net/dns/resolved.go
+++ b/net/dns/resolved.go
@@ -163,9 +163,9 @@ func (m *resolvedManager) run(ctx context.Context) {
 		}
 		conn.Signal(signals)
 
-		// Reset backoff and SetNSOSHealth after successful on reconnect.
+		// Reset backoff and set osConfigurationSetWarnable to healthy after a successful reconnect.
 		bo.BackOff(ctx, nil)
-		m.health.SetDNSOSHealth(nil)
+		m.health.SetHealthy(osConfigurationSetWarnable)
 		return nil
 	}
 
@@ -243,9 +243,12 @@ func (m *resolvedManager) run(ctx context.Context) {
 			// Set health while holding the lock, because this will
 			// graciously serialize the resync's health outcome with a
 			// concurrent SetDNS call.
-			m.health.SetDNSOSHealth(err)
+
 			if err != nil {
 				m.logf("failed to configure systemd-resolved: %v", err)
+				m.health.SetUnhealthy(osConfigurationSetWarnable, health.Args{health.ArgError: err.Error()})
+			} else {
+				m.health.SetHealthy(osConfigurationSetWarnable)
 			}
 		}
 	}


### PR DESCRIPTION
Fixes tailscale/tailscale#13871

- Drops the legacy SysDNSOS subsystem in the health framework, as subsystems are deprecated.
- Adds two separate Warnables, with user-friendly errors for errors that might occur when either reading or setting the system DNS configuration. Unlike the previous subsystem errors, these two Warnables have their `DependsOn` set to `health.NetworkStatusWarnable`, meaning that if the network is down, the Warnables won't fire and no warning will be presented to the user if unhealthy.