### PR TITLE
net/netcheck: add a Now field to the netcheck Report

### DIFF
--- a/cmd/tailscale/cli/netcheck.go
+++ b/cmd/tailscale/cli/netcheck.go
@@ -136,6 +136,7 @@ func printReport(dm *tailcfg.DERPMap, report *netcheck.Report) error {
 	}
 
 	printf("\nReport:\n")
+	printf("\t* Time: %v\n", report.Now.Format(time.RFC3339Nano))
 	printf("\t* UDP: %v\n", report.UDP)
 	if report.GlobalV4.IsValid() {
 		printf("\t* IPv4: yes, %s\n", report.GlobalV4)

--- a/net/netcheck/netcheck.go
+++ b/net/netcheck/netcheck.go
@@ -85,13 +85,14 @@ const (
 
 // Report contains the result of a single netcheck.
 type Report struct {
-	UDP         bool // a UDP STUN round trip completed
-	IPv6        bool // an IPv6 STUN round trip completed
-	IPv4        bool // an IPv4 STUN round trip completed
-	IPv6CanSend bool // an IPv6 packet was able to be sent
-	IPv4CanSend bool // an IPv4 packet was able to be sent
-	OSHasIPv6   bool // could bind a socket to ::1
-	ICMPv4      bool // an ICMPv4 round trip completed
+	Now         time.Time // the time the report was run
+	UDP         bool      // a UDP STUN round trip completed
+	IPv6        bool      // an IPv6 STUN round trip completed
+	IPv4        bool      // an IPv4 STUN round trip completed
+	IPv6CanSend bool      // an IPv6 packet was able to be sent
+	IPv4CanSend bool      // an IPv4 packet was able to be sent
+	OSHasIPv6   bool      // could bind a socket to ::1
+	ICMPv4      bool      // an ICMPv4 round trip completed
 
 	// MappingVariesByDestIP is whether STUN results depend which
 	// STUN server you're talking to (on IPv4).
@@ -1297,6 +1298,7 @@ func (c *Client) addReportHistoryAndSetPreferredDERP(rs *reportState, r *Report,
 		c.prev = map[time.Time]*Report{}
 	}
 	now := c.timeNow()
+	r.Now = now.UTC()
 	c.prev[now] = r
 	c.last = r
 


### PR DESCRIPTION
This allows us to print the time that a netcheck was run, which is useful in debugging.

Updates #10972


Change-Id: Id48d30d4eb6d5208efb2b1526a71d83fe7f9320b