### PR TITLE
wgengine/router: add debug logging component logs

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -566,7 +566,9 @@ func componentStateKey(component string) ipn.StateKey {
 // The following components are recognized:
 //
 //   - magicsock
+//   - router
 //   - sockstats
+//   - syspolicy
 func (b *LocalBackend) SetComponentDebugLogging(component string, until time.Time) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -575,6 +577,12 @@ func (b *LocalBackend) SetComponentDebugLogging(component string, until time.Tim
 	switch component {
 	case "magicsock":
 		setEnabled = b.MagicConn().SetDebugLoggingEnabled
+	case "router":
+		if r, ok := b.sys.Router.GetOK(); ok {
+			setEnabled = r.SetDebugLoggingEnabled
+		} else {
+			return fmt.Errorf("no router available")
+		}
 	case "sockstats":
 		if b.sockstatLogger != nil {
 			setEnabled = func(v bool) {

--- a/wgengine/router/callback.go
+++ b/wgengine/router/callback.go
@@ -30,6 +30,10 @@ type CallbackRouter struct {
 	// ignored thereafter.
 	InitialMTU uint32
 
+	// SetDebugLoggingEnabledFunc optionally specifies a function to call
+	// when the SetDebugLoggingEnabled method is called.
+	SetDebugLoggingEnabledFunc func(enabled bool)
+
 	mu        sync.Mutex    // protects all the following
 	didSetMTU bool          // if we set the MTU already
 	rcfg      *Config       // last applied router config
@@ -61,6 +65,13 @@ func (r *CallbackRouter) Set(rcfg *Config) error {
 // to know what the magicsock UDP port is.
 func (r *CallbackRouter) UpdateMagicsockPort(_ uint16, _ string) error {
 	return nil
+}
+
+// SetDebugLoggingEnabled implements the Router interface.
+func (r *CallbackRouter) SetDebugLoggingEnabled(enabled bool) {
+	if r.SetDebugLoggingEnabledFunc != nil {
+		r.SetDebugLoggingEnabledFunc(enabled)
+	}
 }
 
 // SetDNS implements dns.OSConfigurator.

--- a/wgengine/router/router.go
+++ b/wgengine/router/router.go
@@ -36,6 +36,10 @@ type Router interface {
 	// network should be either "udp4" or "udp6".
 	UpdateMagicsockPort(port uint16, network string) error
 
+	// SetDebugLoggingEnabled enables or disables debug logging in the
+	// router implementation.
+	SetDebugLoggingEnabled(enabled bool)
+
 	// Close closes the router.
 	Close() error
 }

--- a/wgengine/router/router_fake.go
+++ b/wgengine/router/router_fake.go
@@ -32,6 +32,10 @@ func (r fakeRouter) UpdateMagicsockPort(_ uint16, _ string) error {
 	return nil
 }
 
+func (r fakeRouter) SetDebugLoggingEnabled(_ bool) {
+	r.logf("[v1] warning: fakeRouter.SetDebugLoggingEnabled: not implemented.")
+}
+
 func (r fakeRouter) Close() error {
 	r.logf("[v1] warning: fakeRouter.Close: not implemented.")
 	return nil

--- a/wgengine/router/router_openbsd.go
+++ b/wgengine/router/router_openbsd.go
@@ -236,6 +236,11 @@ func (r *openbsdRouter) UpdateMagicsockPort(_ uint16, _ string) error {
 	return nil
 }
 
+// SetDebugLoggingEnabled implements the Router interface.
+func (r *openbsdRouter) SetDebugLoggingEnabled(_ bool) {
+	// TODO(andrew-d): implement; see https://github.com/tailscale/tailscale/issues/13887
+}
+
 func (r *openbsdRouter) Close() error {
 	cleanUp(r.logf, r.tunname)
 	return nil

--- a/wgengine/router/router_userspace_bsd.go
+++ b/wgengine/router/router_userspace_bsd.go
@@ -206,6 +206,10 @@ func (r *userspaceBSDRouter) UpdateMagicsockPort(_ uint16, _ string) error {
 	return nil
 }
 
+func (r *userspaceBSDRouter) SetDebugLoggingEnabled(_ bool) {
+	// TODO(andrew-d): implement; see https://github.com/tailscale/tailscale/issues/13887
+}
+
 func (r *userspaceBSDRouter) Close() error {
 	return nil
 }


### PR DESCRIPTION
This uses the "component logging" feature to allow turning on additional debug logs for the Router at runtime. Currently, it's only implemented on Linux and with the CallbackRouter at this time.

Updates #13887


Change-Id: I251a7705765f950d118850f1e14f465729ba45c5