### PR TITLE
Fix MagicDNS on OpenBSD

### DIFF
--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -1236,7 +1236,7 @@ func (e *userspaceEngine) linkChange(delta *netmon.ChangeDelta) {
 	// and Apple platforms.
 	if changed {
 		switch runtime.GOOS {
-		case "linux", "android", "ios", "darwin":
+		case "linux", "android", "ios", "darwin", "openbsd":
 			e.wgLock.Lock()
 			dnsCfg := e.lastDNSConfig
 			e.wgLock.Unlock()


### PR DESCRIPTION
Add OpenBSD to the list of platforms that need DNS reconfigured on link changes.

This fixes a problem with Magic DNS that often stops working on OpenBSD with following error message in `tailscale status`: "Tailscale can't reach the configured DNS servers. Internet connectivity may be affected.".

Without this change, I have to force reload tailscale (`tailscale down && tailscale up`) whenever DNS stops working.
