### PR TITLE
ipn/store/kubestore: cache state in memory

### DIFF
--- a/ipn/store/mem/store_mem.go
+++ b/ipn/store/mem/store_mem.go
@@ -9,8 +9,10 @@ import (
 	"encoding/json"
 	"sync"
 
+	xmaps "golang.org/x/exp/maps"
 	"tailscale.com/ipn"
 	"tailscale.com/types/logger"
+	"tailscale.com/util/mak"
 )
 
 // New returns a new Store.
@@ -28,6 +30,7 @@ type Store struct {
 func (s *Store) String() string { return "mem.Store" }
 
 // ReadState implements the StateStore interface.
+// It returns ipn.ErrStateNotExist if the state does not exist.
 func (s *Store) ReadState(id ipn.StateKey) ([]byte, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -39,6 +42,7 @@ func (s *Store) ReadState(id ipn.StateKey) ([]byte, error) {
 }
 
 // WriteState implements the StateStore interface.
+// It never returns an error.
 func (s *Store) WriteState(id ipn.StateKey, bs []byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -47,6 +51,19 @@ func (s *Store) WriteState(id ipn.StateKey, bs []byte) error {
 	}
 	s.cache[id] = bytes.Clone(bs)
 	return nil
+}
+
+// LoadFromMap loads the in-memory cache from the provided map.
+// Any existing content is cleared, and the provided map is
+// copied into the cache.
+func (s *Store) LoadFromMap(m map[string][]byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	xmaps.Clear(s.cache)
+	for k, v := range m {
+		mak.Set(&s.cache, ipn.StateKey(k), v)
+	}
+	return
 }
 
 // LoadFromJSON attempts to unmarshal json content into the


### PR DESCRIPTION
This PR changes kubestore to write tailscale state to memory (as well as a Secret) on writes and read from memory only. On startup state is loaded from Secret if any exists.

This should:
- fix bugs caused by temporary errors connecting to kube API server (see https://github.com/tailscale/tailscale/issues/13900#issuecomment-2439483086)
- improve performance

I've tested this extensively with various setups (upgrade, a precreated Secret, etc)


This PR just picks up https://github.com/tailscale/tailscale/pull/7673 with a few small fixes

Fixes #7671
Updates https://github.com/tailscale/tailscale/issues/12079
Updates https://github.com/tailscale/tailscale/issues/13900