### PR TITLE
ipn/store/kubestore: don't error if state cannot be preloaded because Secret does not exist

### DIFF
--- a/ipn/store/kubestore/store_kube.go
+++ b/ipn/store/kubestore/store_kube.go
@@ -53,7 +53,7 @@ func New(_ logger.Logf, secretName string) (*Store, error) {
 		secretName: secretName,
 	}
 	// Load latest state from kube Secret if it already exists.
-	if err := s.loadState(); err != nil {
+	if err := s.loadState(); err != nil && err != ipn.ErrStateNotExist {
 		return nil, fmt.Errorf("error loading state from kube Secret: %w", err)
 	}
 	return s, nil


### PR DESCRIPTION
Preloading of tailscale state from kube Secret should not error if the Secret does not exist.

Updates tailscale/tailscale#7671