### PR TITLE
Fix blank lines being added to resolv.conf on OpenBSD

### DIFF
--- a/net/dns/resolvd.go
+++ b/net/dns/resolvd.go
@@ -57,6 +57,7 @@ func (m *resolvdManager) SetDNS(config OSConfig) error {
 
 	if len(newSearch) > 1 {
 		newResolvConf = append(newResolvConf, []byte(strings.Join(newSearch, " "))...)
+		newResolvConf = append(newResolvConf, '\n')
 	}
 
 	err = m.fs.WriteFile(resolvConf, newResolvConf, 0644)
@@ -123,6 +124,6 @@ func (m resolvdManager) readResolvConf() (config OSConfig, err error) {
 }
 
 func removeSearchLines(orig []byte) []byte {
-	re := regexp.MustCompile(`(?m)^search\s+.+$`)
+	re := regexp.MustCompile(`(?ms)^search\s+.+$`)
 	return re.ReplaceAll(orig, []byte(""))
 }


### PR DESCRIPTION
During resolv.conf update, old 'search' lines are cleared but '\n' is not deleted, leaving behind a new blank line on every update.

This adds 's' flag to regexp, so '\n' is included in the match and deleted when old lines are cleared.

Also, insert missing `\n` when updated 'search' line is appended to resolv.conf.