### PR TITLE
ipn/ipnlocal: log errors while fetching serial numbers

### DIFF
--- a/ipn/ipnlocal/c2n.go
+++ b/ipn/ipnlocal/c2n.go
@@ -332,12 +332,10 @@ func handleC2NPostureIdentityGet(b *LocalBackend, w http.ResponseWriter, r *http
 	}
 
 	if choice.ShouldEnable(b.Prefs().PostureChecking()) {
-		sns, err := posture.GetSerialNumbers(b.logf)
+		res.SerialNumbers, err = posture.GetSerialNumbers(b.logf)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
+			b.logf("c2n: GetSerialNumbers returned error: %v", err)
 		}
-		res.SerialNumbers = sns
 
 		// TODO(tailscale/corp#21371, 2024-07-10): once this has landed in a stable release
 		// and looks good in client metrics, remove this parameter and always report MAC


### PR DESCRIPTION
If the client cannot fetch a serial number, write a log message helping the user understand what happened. Also, don't just return the error immediately, since we still have a chance to collect network interface addresses.

Updates #5902