### PR TITLE
ipn: add app connector config knob to conffile

### DIFF
--- a/ipn/conf.go
+++ b/ipn/conf.go
@@ -32,6 +32,8 @@ type ConfigVAlpha struct {
 	AdvertiseRoutes []netip.Prefix `json:",omitempty"`
 	DisableSNAT     opt.Bool       `json:",omitempty"`
 
+	AppConnector *AppConnectorPrefs `json:",omitempty"` // advertise app connector; defaults to false (if nil or explicitly set to false)
+
 	NetfilterMode       *string  `json:",omitempty"` // "on", "off", "nodivert"
 	NoStatefulFiltering opt.Bool `json:",omitempty"`
 
@@ -136,6 +138,10 @@ func (c *ConfigVAlpha) ToPrefs() (MaskedPrefs, error) {
 	if c.AutoUpdate != nil {
 		mp.AutoUpdate = *c.AutoUpdate
 		mp.AutoUpdateSet = AutoUpdatePrefsMask{ApplySet: true, CheckSet: true}
+	}
+	if c.AppConnector != nil {
+		mp.AppConnector = *c.AppConnector
+		mp.AppConnectorSet = true
 	}
 	return mp, nil
 }

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -149,7 +149,8 @@ type CapabilityVersion int
 //   - 104: 2024-08-03: SelfNodeV6MasqAddrForThisPeer now works
 //   - 105: 2024-08-05: Fixed SSH behavior on systems that use busybox (issue #12849)
 //   - 106: 2024-09-03: fix panic regression from cryptokey routing change (65fe0ba7b5)
-const CurrentCapabilityVersion CapabilityVersion = 106
+//   - 107: 2024-10-30: add App Connector to conffile (PR #13942)
+const CurrentCapabilityVersion CapabilityVersion = 107
 
 type StableID string
 


### PR DESCRIPTION
Make it possible to advertise app connector via a new conffile field.

This is the first step towards #11113 

Updates tailscale/tailscale#11113