### PR TITLE
wgengine/magicsock: export packet drop metric for outbound errors

### DIFF
--- a/net/tstun/wrap_test.go
+++ b/net/tstun/wrap_test.go
@@ -441,13 +441,13 @@ func TestFilter(t *testing.T) {
 	}
 
 	var metricInboundDroppedPacketsACL, metricInboundDroppedPacketsErr, metricOutboundDroppedPacketsACL int64
-	if m, ok := tun.metrics.inboundDroppedPacketsTotal.Get(dropPacketLabel{Reason: DropReasonACL}).(*expvar.Int); ok {
+	if m, ok := tun.metrics.inboundDroppedPacketsTotal.Get(usermetric.DropLabels{Reason: usermetric.ReasonACL}).(*expvar.Int); ok {
 		metricInboundDroppedPacketsACL = m.Value()
 	}
-	if m, ok := tun.metrics.inboundDroppedPacketsTotal.Get(dropPacketLabel{Reason: DropReasonError}).(*expvar.Int); ok {
+	if m, ok := tun.metrics.inboundDroppedPacketsTotal.Get(usermetric.DropLabels{Reason: usermetric.ReasonError}).(*expvar.Int); ok {
 		metricInboundDroppedPacketsErr = m.Value()
 	}
-	if m, ok := tun.metrics.outboundDroppedPacketsTotal.Get(dropPacketLabel{Reason: DropReasonACL}).(*expvar.Int); ok {
+	if m, ok := tun.metrics.outboundDroppedPacketsTotal.Get(usermetric.DropLabels{Reason: usermetric.ReasonACL}).(*expvar.Int); ok {
 		metricOutboundDroppedPacketsACL = m.Value()
 	}
 

--- a/util/usermetric/metrics.go
+++ b/util/usermetric/metrics.go
@@ -1,0 +1,69 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+// This file contains user-facing metrics that are used by multiple packages.
+// Use it to define more common metrics. Any changes to the registry and
+// metric types should be in usermetric.go.
+
+package usermetric
+
+import (
+	"sync"
+
+	"tailscale.com/metrics"
+)
+
+// Metrics contains user-facing metrics that are used by multiple packages.
+type Metrics struct {
+	initOnce sync.Once
+
+	droppedPacketsInbound  *metrics.MultiLabelMap[DropLabels]
+	droppedPacketsOutbound *metrics.MultiLabelMap[DropLabels]
+}
+
+// DropReason is the reason why a packet was dropped.
+type DropReason string
+
+const (
+	// ReasonACL means that the packet was not permitted by ACL.
+	ReasonACL DropReason = "acl"
+
+	// ReasonError means that the packet was dropped because of an error.
+	ReasonError DropReason = "error"
+)
+
+// DropLabels contains common label(s) for dropped packet counters.
+type DropLabels struct {
+	Reason DropReason
+}
+
+// initOnce initializes the common metrics.
+func (r *Registry) initOnce() {
+	r.m.initOnce.Do(func() {
+		r.m.droppedPacketsInbound = NewMultiLabelMapWithRegistry[DropLabels](
+			r,
+			"tailscaled_inbound_dropped_packets_total",
+			"counter",
+			"Counts the number of dropped packets received by the node from other peers",
+		)
+		r.m.droppedPacketsOutbound = NewMultiLabelMapWithRegistry[DropLabels](
+			r,
+			"tailscaled_outbound_dropped_packets_total",
+			"counter",
+			"Counts the number of packets dropped while being sent to other peers",
+		)
+	})
+}
+
+// DroppedPacketsOutbound returns the outbound dropped packet metric, creating it
+// if necessary.
+func (r *Registry) DroppedPacketsOutbound() *metrics.MultiLabelMap[DropLabels] {
+	r.initOnce()
+	return r.m.droppedPacketsOutbound
+}
+
+// DroppedPacketsInbound returns the inbound dropped packet metric.
+func (r *Registry) DroppedPacketsInbound() *metrics.MultiLabelMap[DropLabels] {
+	r.initOnce()
+	return r.m.droppedPacketsInbound
+}

--- a/util/usermetric/usermetric.go
+++ b/util/usermetric/usermetric.go
@@ -19,6 +19,9 @@ import (
 // Registry tracks user-facing metrics of various Tailscale subsystems.
 type Registry struct {
 	vars expvar.Map
+
+	// m contains common metrics owned by the registry.
+	m Metrics
 }
 
 // NewMultiLabelMapWithRegistry creates and register a new

--- a/wgengine/magicsock/derp.go
+++ b/wgengine/magicsock/derp.go
@@ -674,6 +674,9 @@ func (c *Conn) runDerpWriter(ctx context.Context, dc *derphttp.Client, ch <-chan
 			if err != nil {
 				c.logf("magicsock: derp.Send(%v): %v", wr.addr, err)
 				metricSendDERPError.Add(1)
+				if !wr.isDisco {
+					c.metrics.outboundPacketsDroppedErrors.Add(1)
+				}
 			} else if !wr.isDisco {
 				c.metrics.outboundPacketsDERPTotal.Add(1)
 				c.metrics.outboundBytesDERPTotal.Add(int64(len(wr.b)))


### PR DESCRIPTION
Another take on #13637.

This required sharing the dropped packet metric between two packages (tstun and magicsock), so I've moved its definition to `util/usermetric`.

Updates tailscale/corp#22075