### PR TITLE
ipn/ipnlocal: remove the primary routes gauge for now

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -399,11 +399,6 @@ type metrics struct {
 	// approvedRoutes is a metric that reports the number of network routes served by the local node and approved
 	// by the control server.
 	approvedRoutes *usermetric.Gauge
-
-	// primaryRoutes is a metric that reports the number of primary network routes served by the local node.
-	// A route being a primary route implies that the route is currently served by this node, and not by another
-	// subnet router in a high availability configuration.
-	primaryRoutes *usermetric.Gauge
 }
 
 // clientGen is a func that creates a control plane client.
@@ -454,8 +449,6 @@ func NewLocalBackend(logf logger.Logf, logID logid.PublicID, sys *tsd.System, lo
 			"tailscaled_advertised_routes", "Number of advertised network routes (e.g. by a subnet router)"),
 		approvedRoutes: sys.UserMetricsRegistry().NewGauge(
 			"tailscaled_approved_routes", "Number of approved network routes (e.g. by a subnet router)"),
-		primaryRoutes: sys.UserMetricsRegistry().NewGauge(
-			"tailscaled_primary_routes", "Number of network routes for which this node is a primary router (in high availability configuration)"),
 	}
 
 	b := &LocalBackend{
@@ -5477,7 +5470,6 @@ func (b *LocalBackend) setNetMapLocked(nm *netmap.NetworkMap) {
 		// If there is no netmap, the client is going into a "turned off"
 		// state so reset the metrics.
 		b.metrics.approvedRoutes.Set(0)
-		b.metrics.primaryRoutes.Set(0)
 		return
 	}
 
@@ -5506,7 +5498,6 @@ func (b *LocalBackend) setNetMapLocked(nm *netmap.NetworkMap) {
 			}
 		}
 		b.metrics.approvedRoutes.Set(approved)
-		b.metrics.primaryRoutes.Set(float64(tsaddr.WithoutExitRoute(nm.SelfNode.PrimaryRoutes()).Len()))
 	}
 	for _, p := range nm.Peers {
 		addNode(p)

--- a/tsnet/tsnet_test.go
+++ b/tsnet/tsnet_test.go
@@ -1080,13 +1080,6 @@ func TestUserMetrics(t *testing.T) {
 		t.Errorf("metrics1, tailscaled_health_messages: got %v, want %v", got, want)
 	}
 
-	// The node is the primary subnet router for 2 routes:
-	// - 192.0.2.0/24
-	// - 192.0.5.1/32
-	if got, want := parsedMetrics1["tailscaled_primary_routes"], wantRoutes; got != want {
-		t.Errorf("metrics1, tailscaled_primary_routes: got %v, want %v", got, want)
-	}
-
 	// Verify that the amount of data recorded in bytes is higher or equal to the
 	// 10 megabytes sent.
 	inboundBytes1 := parsedMetrics1[`tailscaled_inbound_bytes_total{path="direct_ipv4"}`]
@@ -1129,11 +1122,6 @@ func TestUserMetrics(t *testing.T) {
 	// Validate the health counter metric against the status of the node
 	if got, want := parsedMetrics2[`tailscaled_health_messages{type="warning"}`], float64(len(status2.Health)); got != want {
 		t.Errorf("metrics2, tailscaled_health_messages: got %v, want %v", got, want)
-	}
-
-	// The node is the primary subnet router for 0 routes
-	if got, want := parsedMetrics2["tailscaled_primary_routes"], 0.0; got != want {
-		t.Errorf("metrics2, tailscaled_primary_routes: got %v, want %v", got, want)
 	}
 
 	// Verify that the amount of data recorded in bytes is higher or equal than the


### PR DESCRIPTION
Not confident this is the right way to expose this, so let's remote it for now.

Updates tailscale/corp#22075