### PR TITLE
wgengine/magicsock: exclude disco from throughput metrics

### DIFF
--- a/wgengine/magicsock/derp.go
+++ b/wgengine/magicsock/derp.go
@@ -644,9 +644,10 @@ func (c *Conn) runDerpReader(ctx context.Context, regionID int, dc *derphttp.Cli
 }
 
 type derpWriteRequest struct {
-	addr   netip.AddrPort
-	pubKey key.NodePublic
-	b      []byte // copied; ownership passed to receiver
+	addr    netip.AddrPort
+	pubKey  key.NodePublic
+	b       []byte // copied; ownership passed to receiver
+	isDisco bool
 }
 
 // runDerpWriter runs in a goroutine for the life of a DERP
@@ -668,7 +669,7 @@ func (c *Conn) runDerpWriter(ctx context.Context, dc *derphttp.Client, ch <-chan
 			if err != nil {
 				c.logf("magicsock: derp.Send(%v): %v", wr.addr, err)
 				metricSendDERPError.Add(1)
-			} else {
+			} else if !wr.isDisco {
 				c.metrics.outboundPacketsDERPTotal.Add(1)
 				c.metrics.outboundBytesDERPTotal.Add(int64(len(wr.b)))
 			}
@@ -691,8 +692,6 @@ func (c *connBind) receiveDERP(buffs [][]byte, sizes []int, eps []conn.Endpoint)
 			// No data read occurred. Wait for another packet.
 			continue
 		}
-		c.metrics.inboundPacketsDERPTotal.Add(1)
-		c.metrics.inboundBytesDERPTotal.Add(int64(n))
 		sizes[0] = n
 		eps[0] = ep
 		return 1, nil
@@ -732,6 +731,9 @@ func (c *Conn) processDERPReadResult(dm derpReadResult, b []byte) (n int, ep *en
 	if stats := c.stats.Load(); stats != nil {
 		stats.UpdateRxPhysical(ep.nodeAddr, ipp, 1, dm.n)
 	}
+
+	c.metrics.inboundPacketsDERPTotal.Add(1)
+	c.metrics.inboundBytesDERPTotal.Add(int64(n))
 	return n, ep
 }
 

--- a/wgengine/magicsock/endpoint.go
+++ b/wgengine/magicsock/endpoint.go
@@ -983,7 +983,8 @@ func (de *endpoint) send(buffs [][]byte) error {
 		allOk := true
 		var txBytes int
 		for _, buff := range buffs {
-			ok, _ := de.c.sendAddr(derpAddr, de.publicKey, buff)
+			const isDisco = false
+			ok, _ := de.c.sendAddr(derpAddr, de.publicKey, buff, isDisco)
 			txBytes += len(buff)
 			if !ok {
 				allOk = false


### PR DESCRIPTION
The user-facing metrics are intended to track data transmitted at the overlay network level, so we should not increment them for outgoing disco packages that go over DERP.

Updates tailscale/corp#22075