### PR TITLE
tstest/tailmac: fix Host.app path generation

### DIFF
--- a/tstest/tailmac/Swift/TailMac/TailMac.swift
+++ b/tstest/tailmac/Swift/TailMac/TailMac.swift
@@ -100,7 +100,10 @@ extension Tailmac {
         mutating func run() {
             let process = Process()
             let stdOutPipe = Pipe()
-            let appPath = "./Host.app/Contents/MacOS/Host"
+
+            let executablePath = CommandLine.arguments[0]
+            let executableDirectory = (executablePath as NSString).deletingLastPathComponent
+            let appPath = executableDirectory + "/Host.app/Contents/MacOS/Host"
 
             process.executableURL = URL(
                 fileURLWithPath: appPath,
@@ -109,7 +112,7 @@ extension Tailmac {
             )
 
             if !FileManager.default.fileExists(atPath: appPath) {
-                fatalError("Could not find Host.app.  This must be co-located with the tailmac utility")
+                fatalError("Could not find Host.app at \(appPath).  This must be co-located with the tailmac utility")
             }
 
             process.arguments = ["run", "--id", id]


### PR DESCRIPTION
updates tailscale/corp#24197

Generation of the Host.app path was erroneous and tailmac run would not work unless the pwd was tailmac/bin.  Now you can be able to invoke tailmac from anywhere.

Signed-off-by: Jonathan Nobels <jonathan@tailscale.com>