### PR TITLE
util/syspolicy/source: use errors instead of github.com/pkg/errors

### DIFF
--- a/util/syspolicy/source/env_policy_store.go
+++ b/util/syspolicy/source/env_policy_store.go
@@ -4,13 +4,13 @@
 package source
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
 	"strings"
 	"unicode/utf8"
 
-	"github.com/pkg/errors"
 	"tailscale.com/util/syspolicy/setting"
 )
 


### PR DESCRIPTION
Updates #12687