### PR TITLE
correct behaviour of tsconnect in 'dev' mode to not terminate the app…

### DIFF
--- a/cmd/tsconnect/common.go
+++ b/cmd/tsconnect/common.go
@@ -149,7 +149,11 @@ func runEsbuildServe(buildOptions esbuild.BuildOptions) {
 	if err != nil {
 		log.Fatalf("Cannot start esbuild server: %v", err)
 	}
-	log.Printf("Listening on http://%s:%d\n", result.Host, result.Port)
+	log.Printf("Listening on http://%s:%d\n  - type ctrl-c to stop the dev server.", result.Host, result.Port)
+	for true {
+		time.Sleep(time.Second) // Keep the app running or the server will stop
+	}
+
 }
 
 func runEsbuild(buildOptions esbuild.BuildOptions) esbuild.BuildResult {


### PR DESCRIPTION
… immediately-  it cant keep the dev web server running without this

To start the development server:
./tool/go run ./cmd/tsconnect dev
doc:
https://github.com/tailscale/tailscale/tree/main/cmd/tsconnect#tsconnect

this fixes a bug I reported at the end of this issue, which I think was closed without proper testing of 'dev' mode..
https://github.com/tailscale/tailscale/issues/8272