### PR TITLE
cmd/k8s-operator,k8s-operator: host network and port

### DIFF
--- a/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
+++ b/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
@@ -1,6 +1,5 @@
 # Copyright (c) Tailscale Inc & AUTHORS
 # SPDX-License-Identifier: BSD-3-Clause
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -25,6 +24,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.operatorConfig.hostNetwork.enabled }}
+      hostNetwork: true
+      dnsPolicy: {{ .Values.operatorConfig.hostNetwork.dnsPolicy }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -43,6 +46,11 @@ spec:
           {{- with .Values.operatorConfig.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.operatorConfig.port.enabled }}
+          ports:
+            - containerPort: {{ .Values.operatorConfig.port.containerPort }}
+              protocol: TCP
           {{- end }}
           {{- with .Values.operatorConfig.resources }}
           resources:
@@ -68,6 +76,10 @@ spec:
               value: /oauth/client_id
             - name: CLIENT_SECRET_FILE
               value: /oauth/client_secret
+            {{- if .Values.operatorConfig.port.enabled }}
+            - name: PORT
+              value: {{ .Values.operatorConfig.port.containerPort | quote }}
+            {{- end }}
             {{- $proxyTag := printf ":%s" ( .Values.proxyConfig.image.tag | default .Chart.AppVersion )}}
             - name: PROXY_IMAGE
               value: {{ coalesce .Values.proxyConfig.image.repo .Values.proxyConfig.image.repository }}{{- if .Values.proxyConfig.image.digest -}}{{ printf "@%s" .Values.proxyConfig.image.digest}}{{- else -}}{{ printf "%s" $proxyTag }}{{- end }}

--- a/cmd/k8s-operator/deploy/chart/values.yaml
+++ b/cmd/k8s-operator/deploy/chart/values.yaml
@@ -22,6 +22,16 @@ operatorConfig:
   defaultTags:
     - "tag:k8s-operator"
 
+  # Manual configuration of Tailscaled port
+  port:
+    enabled: false
+    containerPort: 8080
+
+  # Optional host network configuration. Likely only needed for public Kubernetes nodes
+  hostNetwork:
+    enabled: false
+    dnsPolicy: ClusterFirstWithHostNet  # Common options: ClusterFirst, ClusterFirstWithHostNet, Default
+
   image:
     # Repository defaults to DockerHub, but images are also synced to ghcr.io/tailscale/k8s-operator.
     repository: tailscale/k8s-operator


### PR DESCRIPTION
Allow helm users to configure the host networking for the operator
deployment, and specify a port to open.

Fixes #13981

Signed-off-by: Lee Briggs <lee@leebriggs.co.uk>
