### PR TITLE
net/sockstats: prevent crash in setNetMon

### DIFF
--- a/net/sockstats/sockstats_tsgo.go
+++ b/net/sockstats/sockstats_tsgo.go
@@ -279,7 +279,13 @@ func setNetMon(netMon *netmon.Monitor) {
 		if ifName == "" {
 			return
 		}
-		ifIndex := state.Interface[ifName].Index
+		// DefaultRouteInterface and Interface are gathered at different points in time.
+		// Check for existence first, to avoid a nil pointer dereference.
+		iface, ok := state.Interface[ifName]
+		if !ok {
+			return
+		}
+		ifIndex := iface.Index
 		sockStats.mu.Lock()
 		defer sockStats.mu.Unlock()
 		// Ignore changes to unknown interfaces -- it would require


### PR DESCRIPTION
Fixes tailscale/tailscale#13983

As @raggi pointed out, DefaultRouteInterface and Interface are set at different points in time. The map lookup in `setNetMon` should check whether the map contains a value for the interface name before getting the interface index. If it doesn't, it returns a zero value containing a pointer which will be nil in the zero value case, causing the panic.