### PR TITLE
ssh/tailssh: monitor IPNBus for recorder host updates

### DIFF
--- a/sessionrecording/connect.go
+++ b/sessionrecording/connect.go
@@ -130,8 +130,10 @@ func SessionRecordingClientForDialer(dialCtx context.Context, dial func(context.
 				cancel()
 			}
 		}()
+
 		return dial(perAttemptCtx, network, addr)
 	}
+
 	return &http.Client{
 		Transport: tr,
 	}, nil

--- a/ssh/tailssh/tailssh_integration_test.go
+++ b/ssh/tailssh/tailssh_integration_test.go
@@ -35,6 +35,9 @@ import (
 	gossh "github.com/tailscale/golang-x-crypto/ssh"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
+	"tailscale.com/ipn"
+	"tailscale.com/ipn/ipnauth"
+	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/net/tsdial"
 	"tailscale.com/tailcfg"
 	glider "tailscale.com/tempfork/gliderlabs/ssh"
@@ -659,6 +662,14 @@ func (tb *testBackend) TailscaleVarRoot() string {
 
 func (tb *testBackend) NodeKey() key.NodePublic {
 	return key.NodePublic{}
+}
+
+func (tb *testBackend) Status() *ipnstate.Status {
+	return &ipnstate.Status{}
+}
+
+func (tb *testBackend) WatchNotificationsAs(ctx context.Context, actor ipnauth.Actor, mask ipn.NotifyWatchOpt, onWatchAdded func(), fn func(roNotify *ipn.Notify) (keepGoing bool)) {
+	return
 }
 
 type addressFakingConn struct {

--- a/ssh/tailssh/tailssh_test.go
+++ b/ssh/tailssh/tailssh_test.go
@@ -33,7 +33,10 @@ import (
 	"time"
 
 	gossh "github.com/tailscale/golang-x-crypto/ssh"
+	"tailscale.com/ipn"
+	"tailscale.com/ipn/ipnauth"
 	"tailscale.com/ipn/ipnlocal"
+	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/ipn/store/mem"
 	"tailscale.com/net/memnet"
 	"tailscale.com/net/tsdial"
@@ -459,6 +462,14 @@ func (ts *localState) TailscaleVarRoot() string {
 
 func (ts *localState) NodeKey() key.NodePublic {
 	return key.NewNode().Public()
+}
+
+func (ts *localState) Status() *ipnstate.Status {
+	return &ipnstate.Status{}
+}
+
+func (ts *localState) WatchNotificationsAs(ctx context.Context, actor ipnauth.Actor, mask ipn.NotifyWatchOpt, _ func(), _ func(_ *ipn.Notify) bool) {
+	return
 }
 
 func newSSHRule(action *tailcfg.SSHAction) *tailcfg.SSHRule {


### PR DESCRIPTION
Monitor the IPNBus for netmap updates that indicate that the previously selected SSH recorder node has become inaccessible and proactively terminate the SSH session if this happens.

Where possible set tighter KeepAlive parameters for the underlying connection to the recorder host.

Updates tailscale/corp#24023