### PR TITLE
envknob,kube/kubetypes,cmd/k8s-operator: add app type for ProxyGroup

### DIFF
--- a/cmd/k8s-operator/proxygroup.go
+++ b/cmd/k8s-operator/proxygroup.go
@@ -47,7 +47,7 @@ const (
 	reasonProxyGroupInvalid        = "ProxyGroupInvalid"
 )
 
-var gaugeProxyGroupResources = clientmetric.NewGauge(kubetypes.MetricProxyGroupCount)
+var gaugeProxyGroupResources = clientmetric.NewGauge(kubetypes.MetricProxyGroupEgressCount)
 
 // ProxyGroupReconciler ensures cluster resources for a ProxyGroup definition.
 type ProxyGroupReconciler struct {

--- a/cmd/k8s-operator/proxygroup_specs.go
+++ b/cmd/k8s-operator/proxygroup_specs.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/yaml"
 	tsapi "tailscale.com/k8s-operator/apis/v1alpha1"
 	"tailscale.com/kube/egressservices"
+	"tailscale.com/kube/kubetypes"
 	"tailscale.com/types/ptr"
 )
 
@@ -145,6 +146,10 @@ func pgStatefulSet(pg *tsapi.ProxyGroup, namespace, image, tsFirewallMode, cfgHa
 			{
 				Name:  "TS_USERSPACE",
 				Value: "false",
+			},
+			{
+				Name:  "TS_INTERNAL_APP",
+				Value: kubetypes.AppProxyGroupEgress,
 			},
 		}
 

--- a/envknob/envknob.go
+++ b/envknob/envknob.go
@@ -411,7 +411,7 @@ func TKASkipSignatureCheck() bool { return Bool("TS_UNSAFE_SKIP_NKS_VERIFICATION
 // Kubernetes Operator components.
 func App() string {
 	a := os.Getenv("TS_INTERNAL_APP")
-	if a == kubetypes.AppConnector || a == kubetypes.AppEgressProxy || a == kubetypes.AppIngressProxy || a == kubetypes.AppIngressResource {
+	if a == kubetypes.AppConnector || a == kubetypes.AppEgressProxy || a == kubetypes.AppIngressProxy || a == kubetypes.AppIngressResource || a == kubetypes.AppProxyGroupEgress || a == kubetypes.AppProxyGroupIngress {
 		return a
 	}
 	return ""

--- a/kube/kubetypes/metrics.go
+++ b/kube/kubetypes/metrics.go
@@ -5,12 +5,14 @@ package kubetypes
 
 const (
 	// Hostinfo App values for the Tailscale Kubernetes Operator components.
-	AppOperator        = "k8s-operator"
-	AppAPIServerProxy  = "k8s-operator-proxy"
-	AppIngressProxy    = "k8s-operator-ingress-proxy"
-	AppIngressResource = "k8s-operator-ingress-resource"
-	AppEgressProxy     = "k8s-operator-egress-proxy"
-	AppConnector       = "k8s-operator-connector-resource"
+	AppOperator          = "k8s-operator"
+	AppAPIServerProxy    = "k8s-operator-proxy"
+	AppIngressProxy      = "k8s-operator-ingress-proxy"
+	AppIngressResource   = "k8s-operator-ingress-resource"
+	AppEgressProxy       = "k8s-operator-egress-proxy"
+	AppConnector         = "k8s-operator-connector-resource"
+	AppProxyGroupEgress  = "k8s-operator-proxygroup-egress"
+	AppProxyGroupIngress = "k8s-operator-proxygroup-ingress"
 
 	// Clientmetrics for Tailscale Kubernetes Operator components
 	MetricIngressProxyCount              = "k8s_ingress_proxies"   // L3
@@ -22,5 +24,6 @@ const (
 	MetricNameserverCount                = "k8s_nameserver_resources"
 	MetricRecorderCount                  = "k8s_recorder_resources"
 	MetricEgressServiceCount             = "k8s_egress_service_resources"
-	MetricProxyGroupCount                = "k8s_proxygroup_resources"
+	MetricProxyGroupEgressCount          = "k8s_proxygroup_egress_resources"
+	MetricProxyGroupIngressCount         = "k8s_proxygroup_ingress_resources"
 )


### PR DESCRIPTION
Sets a custom hostinfo app type for ProxyGroup replicas, similarly to how we do it for all other Kubernetes Operator managed components.

Updates tailscale/tailscale#13406,tailscale/corp#22920