### PR TITLE
cmd/tailscaled: support "ts_omit_ssh" build tag to remove SSH

### DIFF
--- a/cmd/tailscaled/deps_test.go
+++ b/cmd/tailscaled/deps_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package main
+
+import (
+	"testing"
+
+	"tailscale.com/tstest/deptest"
+)
+
+func TestOmitSSH(t *testing.T) {
+	const msg = "unexpected with ts_omit_ssh"
+	deptest.DepChecker{
+		GOOS:   "linux",
+		GOARCH: "amd64",
+		Tags:   "ts_omit_ssh",
+		BadDeps: map[string]string{
+			"tailscale.com/ssh/tailssh":            msg,
+			"golang.org/x/crypto/ssh":              msg,
+			"tailscale.com/sessionrecording":       msg,
+			"github.com/anmitsu/go-shlex":          msg,
+			"github.com/creack/pty":                msg,
+			"github.com/kr/fs":                     msg,
+			"github.com/pkg/sftp":                  msg,
+			"github.com/u-root/u-root/pkg/termios": msg,
+			"tempfork/gliderlabs/ssh":              msg,
+		},
+	}.Check(t)
+}

--- a/cmd/tailscaled/ssh.go
+++ b/cmd/tailscaled/ssh.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build linux || darwin || freebsd || openbsd
+//go:build (linux || darwin || freebsd || openbsd) && !ts_omit_ssh
 
 package main
 

--- a/tstest/deptest/deptest.go
+++ b/tstest/deptest/deptest.go
@@ -21,6 +21,7 @@ type DepChecker struct {
 	GOOS    string            // optional
 	GOARCH  string            // optional
 	BadDeps map[string]string // package => why
+	Tags    string            // comma-separated
 }
 
 func (c DepChecker) Check(t *testing.T) {
@@ -29,7 +30,7 @@ func (c DepChecker) Check(t *testing.T) {
 		t.Skip("skipping dep tests on windows hosts")
 	}
 	t.Helper()
-	cmd := exec.Command("go", "list", "-json", ".")
+	cmd := exec.Command("go", "list", "-json", "-tags="+c.Tags, ".")
 	var extraEnv []string
 	if c.GOOS != "" {
 		extraEnv = append(extraEnv, "GOOS="+c.GOOS)


### PR DESCRIPTION
Some environments would like to remove Tailscale SSH support for the
binary for various reasons when not needed (either for peace of mind,
or the ~1MB of binary space savings).

Updates tailscale/corp#24454
Updates #1278
Updates #12614
