### PR TITLE
ipn/ipnlocal: log a summary of posture identity response

### DIFF
--- a/ipn/ipnlocal/c2n.go
+++ b/ipn/ipnlocal/c2n.go
@@ -350,6 +350,8 @@ func handleC2NPostureIdentityGet(b *LocalBackend, w http.ResponseWriter, r *http
 		res.PostureDisabled = true
 	}
 
+	b.logf("c2n: posture identity disabled=%v reported %d serials %d hwaddrs", res.PostureDisabled, len(res.SerialNumbers), len(res.IfaceHardwareAddrs))
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(res)
 }


### PR DESCRIPTION
Perhaps I was too opimistic in #13323 thinking we won't need logs for this. Let's log a summary of the response without logging specific identifiers.

Updates tailscale/corp#24437