### PR TITLE
derp: add a unique.Make-vs-local map benchmark

### DIFF
--- a/derp/derp_test.go
+++ b/derp/derp_test.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unique"
 
 	"go4.org/mem"
 	"golang.org/x/time/rate"
@@ -1597,4 +1598,41 @@ func TestServerRepliesToPing(t *testing.T) {
 			return
 		}
 	}
+}
+
+func BenchmarkUnique(b *testing.B) {
+	var key [32]byte
+	for i := range key {
+		key[i] = byte(i)
+	}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			h := unique.Make(key)
+			if h.Value() != key {
+				b.Fatal("unexpected")
+			}
+		}
+	})
+}
+
+func BenchmarkLocalMap(b *testing.B) {
+	var key [32]byte
+	for i := range key {
+		key[i] = byte(i)
+	}
+	m := map[[32]byte]bool{
+		key: true,
+	}
+	k2 := key
+	for i := range k2 {
+		k2[0] = byte(i + 1)
+		m[k2] = false
+	}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if !m[key] {
+				b.Fatal("unexpected")
+			}
+		}
+	})
 }


### PR DESCRIPTION
goos: darwin
    goarch: arm64
    pkg: tailscale.com/derp
    cpu: Apple M1
    BenchmarkUnique-8       139699720               10.59 ns/op
    BenchmarkUnique-8       138409840                8.619 ns/op
    BenchmarkUnique-8       134697708                8.521 ns/op
    BenchmarkUnique-8       136568799                8.653 ns/op
    BenchmarkUnique-8       134478981                8.647 ns/op
    BenchmarkLocalMap-8     675015452                1.643 ns/op
    BenchmarkLocalMap-8     717245598                1.648 ns/op
    BenchmarkLocalMap-8     697626253                1.657 ns/op
    BenchmarkLocalMap-8     729024962                1.670 ns/op
    BenchmarkLocalMap-8     712870580                1.668 ns/op
    PASS
    ok      tailscale.com/derp      19.038s

Updates tailscale/corp#24485
