### PR TITLE
util/codegen: treat unique.Handle as an opaque value type

### DIFF
--- a/util/codegen/codegen.go
+++ b/util/codegen/codegen.go
@@ -277,11 +277,16 @@ func IsInvalid(t types.Type) bool {
 // It has special handling for some types that contain pointers
 // that we know are free from memory aliasing/mutation concerns.
 func ContainsPointers(typ types.Type) bool {
-	switch typ.String() {
+	s := typ.String()
+	switch s {
 	case "time.Time":
-		// time.Time contains a pointer that does not need copying
+		// time.Time contains a pointer that does not need cloning.
 		return false
-	case "inet.af/netip.Addr", "net/netip.Addr", "net/netip.Prefix", "net/netip.AddrPort":
+	case "inet.af/netip.Addr":
+		return false
+	}
+	if strings.HasPrefix(s, "unique.Handle[") {
+		// unique.Handle contains a pointer that does not need cloning.
 		return false
 	}
 	switch ft := typ.Underlying().(type) {

--- a/util/codegen/codegen_test.go
+++ b/util/codegen/codegen_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
+	"unique"
 	"unsafe"
 
 	"golang.org/x/exp/constraints"
@@ -82,6 +84,16 @@ type ValueUnionParamPtr[T netip.Prefix | BasicType] struct {
 
 type PointerUnionParam[T netip.Prefix | BasicType | IntPtr] struct {
 	V T
+}
+
+type StructWithUniqueHandle struct{ _ unique.Handle[[32]byte] }
+
+type StructWithTime struct{ _ time.Time }
+
+type StructWithNetipTypes struct {
+	_ netip.Addr
+	_ netip.AddrPort
+	_ netip.Prefix
 }
 
 type Interface interface {
@@ -160,6 +172,18 @@ func TestGenericContainsPointers(t *testing.T) {
 		{
 			typ:         "PointerUnionParam",
 			wantPointer: true,
+		},
+		{
+			typ:         "StructWithUniqueHandle",
+			wantPointer: false,
+		},
+		{
+			typ:         "StructWithTime",
+			wantPointer: false,
+		},
+		{
+			typ:         "StructWithNetipTypes",
+			wantPointer: false,
 		},
 	}
 


### PR DESCRIPTION
It doesn't need a Clone method, like a time.Time, etc.

And then, because Go 1.23+ uses unique.Handle internally for
the netip package types, we can remove those special cases.

Updates #14058 (pulled out from that PR)
Updates tailscale/corp#24485
