### PR TITLE
cmd/derpprobe,prober: add ability to restrict specific kind of derp p…

### DIFF
--- a/cmd/derpprobe/config.go
+++ b/cmd/derpprobe/config.go
@@ -1,0 +1,58 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package main
+
+import "time"
+
+type config struct {
+	// DerpMap is a URL to a DERP map file.
+	DerpMap string
+
+	// ListenAddr is the address at which derpprobe should listen for HTTP requests.
+	ListenAddr string
+
+	// ProbeOnce, if true, causes dermap to run only one round of probes and then terminate.
+	ProbeOnce bool
+
+	// Spread introduces a random delay before the first run of any probe.
+	Spread bool
+
+	// MapInterval specifies how frequently to fetch an updated DERP map.
+	MapInterval time.Duration
+
+	// Mesh configures mesh probing.
+	Mesh ProbeConfig
+
+	// STUN configures STUN probing.
+	STUN ProbeConfig
+
+	// TLS configures TLS probing.
+	TLS ProbeConfig
+
+	// Banwdith configures bandwidth probing.
+	Bandwidth BandwidthConfig
+}
+
+// ProbeConfig configures a specific type of probe. It is only exported
+// because the cmp.Diff requires it to be.
+type ProbeConfig struct {
+	// Interval specifies how frequently to run the probe.
+	Interval time.Duration
+
+	// Regions, if non-empty, restricts this probe to the specified region codes.
+	Regions []string
+}
+
+// BandwidthConfig is a specialized form of [ProbeConfig] for bandwidth probes.
+// It is only exported because cmp.Diff requires it to be.
+type BandwidthConfig struct {
+	// Interval specifies how frequently to run the probe.
+	Interval time.Duration
+
+	// Regions, if non-empty, restricts this probe to the specified region codes.
+	Regions []string
+
+	// Size specifies how many bytes of data to send with each bandwidth probe.
+	Size int64
+}

--- a/cmd/derpprobe/config_test.go
+++ b/cmd/derpprobe/config_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v3"
+)
+
+func TestConfig(t *testing.T) {
+	var got config
+	if err := yaml.Unmarshal([]byte(configYAML), &got); err != nil {
+		t.Fatal(err)
+	}
+	want := config{
+		DerpMap:     "https://derpmap.example.com/path",
+		ListenAddr:  "*:8090",
+		ProbeOnce:   true,
+		Spread:      true,
+		MapInterval: 1 * time.Second,
+		Mesh: ProbeConfig{
+			Interval: 2 * time.Second,
+			Regions:  []string{"two"},
+		},
+		STUN: ProbeConfig{
+			Interval: 3 * time.Second,
+			Regions:  []string{"three"},
+		},
+		TLS: ProbeConfig{
+			Interval: 4 * time.Second,
+			Regions:  []string{"four"},
+		},
+		Bandwidth: BandwidthConfig{
+			Interval: 5 * time.Second,
+			Regions:  []string{"five"},
+			Size:     12345,
+		},
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Fatalf("Wrong config (-got +want):\n%s", diff)
+	}
+}
+
+const configYAML = `
+  derpmap: https://derpmap.example.com/path
+  listenaddr: "*:8090"
+  probeonce: true
+  spread: true
+  mapinterval: 1s
+  mesh:
+    interval: 2s
+    regions: ["two"]
+  stun:
+    interval: 3s
+    regions: ["three"]
+  tls:
+    interval: 4s
+    regions: ["four"]
+  bandwidth:
+    interval: 5s
+    size: 12345
+    regions: ["five"]
+`


### PR DESCRIPTION
…robes to specific regions

This introduces the ability to configure the derprobe command using a yaml config file. See config_test.go for a complete example of such a file.

Updates tailscale/corp#24522

This is a more flexible alternative to #14104 that allows restricting specific probes to specific regions.