### PR TITLE
kube/{kubeapi,kubeclient},ipn/store/kubestore,cmd/{containerboot,k8s-operator}: emit kube Events for kube store operations

### DIFF
--- a/cmd/containerboot/kube.go
+++ b/cmd/containerboot/kube.go
@@ -61,7 +61,7 @@ func deleteAuthKey(ctx context.Context, secretName string) error {
 			Path: "/data/authkey",
 		},
 	}
-	if err := kc.JSONPatchSecret(ctx, secretName, m); err != nil {
+	if err := kc.JSONPatchResource(ctx, secretName, kubeclient.TypeSecrets, m); err != nil {
 		if s, ok := err.(*kubeapi.Status); ok && s.Code == http.StatusUnprocessableEntity {
 			// This is kubernetes-ese for "the field you asked to
 			// delete already doesn't exist", aka no-op.
@@ -81,7 +81,7 @@ func initKubeClient(root string) {
 		kubeclient.SetRootPathForTesting(root)
 	}
 	var err error
-	kc, err = kubeclient.New()
+	kc, err = kubeclient.New("tailscale-container")
 	if err != nil {
 		log.Fatalf("Error creating kube client: %v", err)
 	}

--- a/cmd/containerboot/services.go
+++ b/cmd/containerboot/services.go
@@ -389,7 +389,7 @@ func (ep *egressProxy) setStatus(ctx context.Context, status *egressservices.Sta
 		Path:  fmt.Sprintf("/data/%s", egressservices.KeyEgressServices),
 		Value: bs,
 	}
-	if err := ep.kc.JSONPatchSecret(ctx, ep.stateSecret, []kubeclient.JSONPatch{patch}); err != nil {
+	if err := ep.kc.JSONPatchResource(ctx, ep.stateSecret, kubeclient.TypeSecrets, []kubeclient.JSONPatch{patch}); err != nil {
 		return fmt.Errorf("error patching state Secret: %w", err)
 	}
 	ep.tailnetAddrs = n.NetMap.SelfNode.Addresses().AsSlice()

--- a/cmd/k8s-operator/deploy/chart/templates/proxy-rbac.yaml
+++ b/cmd/k8s-operator/deploy/chart/templates/proxy-rbac.yaml
@@ -16,6 +16,9 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["create","delete","deletecollection","get","list","patch","update","watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch", "get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/cmd/k8s-operator/deploy/manifests/operator.yaml
+++ b/cmd/k8s-operator/deploy/manifests/operator.yaml
@@ -4703,6 +4703,14 @@ rules:
         - patch
         - update
         - watch
+    - apiGroups:
+        - ""
+      resources:
+        - events
+      verbs:
+        - create
+        - patch
+        - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/cmd/k8s-operator/deploy/manifests/proxy.yaml
+++ b/cmd/k8s-operator/deploy/manifests/proxy.yaml
@@ -30,6 +30,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
           securityContext:
             capabilities:
               add:

--- a/cmd/k8s-operator/deploy/manifests/userspace-proxy.yaml
+++ b/cmd/k8s-operator/deploy/manifests/userspace-proxy.yaml
@@ -24,3 +24,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid

--- a/cmd/k8s-operator/proxygroup_specs.go
+++ b/cmd/k8s-operator/proxygroup_specs.go
@@ -127,15 +127,6 @@ func pgStatefulSet(pg *tsapi.ProxyGroup, namespace, image, tsFirewallMode, cfgHa
 				},
 			},
 			{
-				Name: "POD_NAME",
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{
-						// Secret is named after the pod.
-						FieldPath: "metadata.name",
-					},
-				},
-			},
-			{
 				Name:  "TS_KUBE_SECRET",
 				Value: "$(POD_NAME)",
 			},
@@ -146,10 +137,6 @@ func pgStatefulSet(pg *tsapi.ProxyGroup, namespace, image, tsFirewallMode, cfgHa
 			{
 				Name:  "TS_EXPERIMENTAL_VERSIONED_CONFIG_DIR",
 				Value: "/etc/tsconfig/$(POD_NAME)",
-			},
-			{
-				Name:  "TS_USERSPACE",
-				Value: "false",
 			},
 			{
 				Name:  "TS_INTERNAL_APP",
@@ -171,7 +158,7 @@ func pgStatefulSet(pg *tsapi.ProxyGroup, namespace, image, tsFirewallMode, cfgHa
 			})
 		}
 
-		return envs
+		return append(c.Env, envs...)
 	}()
 
 	return ss, nil
@@ -214,6 +201,15 @@ func pgRole(pg *tsapi.ProxyGroup, namespace string) *rbacv1.Role {
 					}
 					return secrets
 				}(),
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"events"},
+				Verbs: []string{
+					"create",
+					"patch",
+					"get",
+				},
 			},
 		},
 	}

--- a/cmd/k8s-operator/testutils_test.go
+++ b/cmd/k8s-operator/testutils_test.go
@@ -70,6 +70,8 @@ func expectedSTS(t *testing.T, cl client.Client, opts configOpts) *appsv1.Statef
 		Env: []corev1.EnvVar{
 			{Name: "TS_USERSPACE", Value: "false"},
 			{Name: "POD_IP", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{APIVersion: "", FieldPath: "status.podIP"}, ResourceFieldRef: nil, ConfigMapKeyRef: nil, SecretKeyRef: nil}},
+			{Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{APIVersion: "", FieldPath: "metadata.name"}, ResourceFieldRef: nil, ConfigMapKeyRef: nil, SecretKeyRef: nil}},
+			{Name: "POD_UID", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{APIVersion: "", FieldPath: "metadata.uid"}, ResourceFieldRef: nil, ConfigMapKeyRef: nil, SecretKeyRef: nil}},
 			{Name: "TS_KUBE_SECRET", Value: opts.secretName},
 			{Name: "EXPERIMENTAL_TS_CONFIGFILE_PATH", Value: "/etc/tsconfig/tailscaled"},
 			{Name: "TS_EXPERIMENTAL_VERSIONED_CONFIG_DIR", Value: "/etc/tsconfig"},
@@ -229,6 +231,8 @@ func expectedSTSUserspace(t *testing.T, cl client.Client, opts configOpts) *apps
 		Env: []corev1.EnvVar{
 			{Name: "TS_USERSPACE", Value: "true"},
 			{Name: "POD_IP", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{APIVersion: "", FieldPath: "status.podIP"}, ResourceFieldRef: nil, ConfigMapKeyRef: nil, SecretKeyRef: nil}},
+			{Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{APIVersion: "", FieldPath: "metadata.name"}, ResourceFieldRef: nil, ConfigMapKeyRef: nil, SecretKeyRef: nil}},
+			{Name: "POD_UID", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{APIVersion: "", FieldPath: "metadata.uid"}, ResourceFieldRef: nil, ConfigMapKeyRef: nil, SecretKeyRef: nil}},
 			{Name: "TS_KUBE_SECRET", Value: opts.secretName},
 			{Name: "EXPERIMENTAL_TS_CONFIGFILE_PATH", Value: "/etc/tsconfig/tailscaled"},
 			{Name: "TS_EXPERIMENTAL_VERSIONED_CONFIG_DIR", Value: "/etc/tsconfig"},

--- a/kube/kubeapi/api.go
+++ b/kube/kubeapi/api.go
@@ -7,7 +7,9 @@
 // dependency size for those consumers when adding anything new here.
 package kubeapi
 
-import "time"
+import (
+	"time"
+)
 
 // Note: The API types are copied from k8s.io/api{,machinery} to not introduce a
 // module dependency on the Kubernetes API as it pulls in many more dependencies.
@@ -151,6 +153,57 @@ type Secret struct {
 	Data map[string][]byte `json:"data,omitempty"`
 }
 
+// Event contains a subset of fields from corev1.Event.
+// https://github.com/kubernetes/api/blob/6cc44b8953ae704d6d9ec2adf32e7ae19199ea9f/core/v1/types.go#L7034
+// It is copied here to avoid having to import kube libraries.
+type Event struct {
+	TypeMeta   `json:",inline"`
+	ObjectMeta `json:"metadata"`
+	Message    string      `json:"message,omitempty"`
+	Reason     string      `json:"reason,omitempty"`
+	Source     EventSource `json:"source,omitempty"` // who is emitting this Event
+	Type       string      `json:"type,omitempty"`   // Normal or Warning
+	// InvolvedObject is the subject of the Event. `kubectl describe` will, for most object types, display any
+	// currently present cluster Events matching the object (but you probably want to set UID for this to work).
+	InvolvedObject ObjectReference `json:"involvedObject"`
+	Count          int32           `json:"count,omitempty"` // how many times Event was observed
+	FirstTimestamp time.Time       `json:"firstTimestamp,omitempty"`
+	LastTimestamp  time.Time       `json:"lastTimestamp,omitempty"`
+}
+
+// EventSource includes a subset of fields from corev1.EventSource.
+// https://github.com/kubernetes/api/blob/6cc44b8953ae704d6d9ec2adf32e7ae19199ea9f/core/v1/types.go#L7007
+// It is copied here to avoid having to import kube libraries.
+type EventSource struct {
+	// Component is the name of the component that is emitting the Event.
+	Component string `json:"component,omitempty"`
+}
+
+// ObjectReference contains a subset of fields from corev1.ObjectReference.
+// https://github.com/kubernetes/api/blob/6cc44b8953ae704d6d9ec2adf32e7ae19199ea9f/core/v1/types.go#L6902
+// It is copied here to avoid having to import kube libraries.
+type ObjectReference struct {
+	// Kind of the referent.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+	// +optional
+	Kind string `json:"kind,omitempty"`
+	// Namespace of the referent.
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+	// +optional
+	Namespace string `json:"namespace,omitempty"`
+	// Name of the referent.
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+	// +optional
+	Name string `json:"name,omitempty"`
+	// UID of the referent.
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+	// +optional
+	UID string `json:"uid,omitempty"`
+	// API version of the referent.
+	// +optional
+	APIVersion string `json:"apiVersion,omitempty"`
+}
+
 // Status is a return value for calls that don't return other objects.
 type Status struct {
 	TypeMeta `json:",inline"`
@@ -186,6 +239,6 @@ type Status struct {
 	Code int `json:"code,omitempty"`
 }
 
-func (s *Status) Error() string {
+func (s Status) Error() string {
 	return s.Message
 }

--- a/kube/kubeclient/client_test.go
+++ b/kube/kubeclient/client_test.go
@@ -1,0 +1,151 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package kubeclient
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"tailscale.com/kube/kubeapi"
+	"tailscale.com/tstest"
+)
+
+func Test_client_Event(t *testing.T) {
+	cl := &tstest.Clock{}
+	tests := []struct {
+		name    string
+		typ     string
+		reason  string
+		msg     string
+		argSets []args
+		wantErr bool
+	}{
+		{
+			name:   "new_event_gets_created",
+			typ:    "Normal",
+			reason: "TestReason",
+			msg:    "TestMessage",
+			argSets: []args{
+				{ // request to GET event returns not found
+					wantsMethod: "GET",
+					wantsURL:    "test-apiserver/api/v1/namespaces/test-ns/events/test-pod.test-uid.testreason",
+					setErr:      &kubeapi.Status{Code: 404},
+				},
+				{ // sends POST request to create event
+					wantsMethod: "POST",
+					wantsURL:    "test-apiserver/api/v1/namespaces/test-ns/events",
+					wantsIn: &kubeapi.Event{
+						ObjectMeta: kubeapi.ObjectMeta{
+							Name:      "test-pod.test-uid.testreason",
+							Namespace: "test-ns",
+						},
+						Type:    "Normal",
+						Reason:  "TestReason",
+						Message: "TestMessage",
+						Source: kubeapi.EventSource{
+							Component: "test-client",
+						},
+						InvolvedObject: kubeapi.ObjectReference{
+							Name:       "test-pod",
+							UID:        "test-uid",
+							Namespace:  "test-ns",
+							APIVersion: "v1",
+							Kind:       "Pod",
+						},
+						FirstTimestamp: cl.Now(),
+						LastTimestamp:  cl.Now(),
+						Count:          1,
+					},
+				},
+			},
+		},
+		{
+			name:   "existing_event_gets_patched",
+			typ:    "Warning",
+			reason: "TestReason",
+			msg:    "TestMsg",
+			argSets: []args{
+				{ // request to GET event does not error - this is enough to assume that event exists
+					wantsMethod: "GET",
+					wantsURL:    "test-apiserver/api/v1/namespaces/test-ns/events/test-pod.test-uid.testreason",
+					setOut:      []byte(`{"count":2}`),
+				},
+				{ // sends PATCH request to update the event
+					wantsMethod: "PATCH",
+					wantsURL:    "test-apiserver/api/v1/namespaces/test-ns/events/test-pod.test-uid.testreason",
+					wantsIn: []JSONPatch{
+						{Op: "replace", Path: "/count", Value: int32(3)},
+						{Op: "replace", Path: "/lastTimestamp", Value: cl.Now()},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &client{
+				cl:             cl,
+				name:           "test-client",
+				podName:        "test-pod",
+				podUID:         "test-uid",
+				url:            "test-apiserver",
+				ns:             "test-ns",
+				kubeAPIRequest: fakeKubeAPIRequest(t, tt.argSets),
+				hasEventsPerms: true,
+			}
+			if err := c.Event(context.Background(), tt.typ, tt.reason, tt.msg); (err != nil) != tt.wantErr {
+				t.Errorf("client.Event() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// args is a set of values for testing a single call to client.kubeAPIRequest.
+type args struct {
+	// wantsMethod is the expected value of 'method' arg.
+	wantsMethod string
+	// wantsURL is the expected value of 'url' arg.
+	wantsURL string
+	// wantsIn is the expected value of 'in' arg.
+	wantsIn any
+	// setOut can be set to a byte slice representing valid JSON. If set 'out' arg will get set to the unmarshalled
+	// JSON object.
+	setOut []byte
+	// setErr is the error that kubeAPIRequest will return.
+	setErr error
+}
+
+// fakeKubeAPIRequest can be used to test that a series of calls to client.kubeAPIRequest gets called with expected
+// values and to set these calls to return preconfigured values. 'argSets' should be set to a slice of expected
+// arguments and should-be return values of a series of kubeAPIRequest calls.
+func fakeKubeAPIRequest(t *testing.T, argSets []args) kubeAPIRequestFunc {
+	count := 0
+	f := func(ctx context.Context, gotMethod, gotUrl string, gotIn, gotOut any, opts ...func(*http.Request)) error {
+		t.Helper()
+		if count >= len(argSets) {
+			t.Fatalf("unexpected call to client.kubeAPIRequest, expected %d calls, but got a %dth call", len(argSets), count+1)
+		}
+		a := argSets[count]
+		if gotMethod != a.wantsMethod {
+			t.Errorf("[%d] got method %q, wants method %q", count, gotMethod, a.wantsMethod)
+		}
+		if gotUrl != a.wantsURL {
+			t.Errorf("[%d] got URL %q, wants URL %q", count, gotMethod, a.wantsMethod)
+		}
+		if d := cmp.Diff(gotIn, a.wantsIn); d != "" {
+			t.Errorf("[%d] unexpected payload (-want + got):\n%s", count, d)
+		}
+		if len(a.setOut) != 0 {
+			if err := json.Unmarshal(a.setOut, gotOut); err != nil {
+				t.Fatalf("[%d] error unmarshalling output: %v", count, err)
+			}
+		}
+		count++
+		return a.setErr
+	}
+	return f
+}

--- a/kube/kubeclient/fake_client.go
+++ b/kube/kubeclient/fake_client.go
@@ -29,7 +29,11 @@ func (fc *FakeClient) SetDialer(dialer func(ctx context.Context, network, addr s
 func (fc *FakeClient) StrategicMergePatchSecret(context.Context, string, *kubeapi.Secret, string) error {
 	return nil
 }
-func (fc *FakeClient) JSONPatchSecret(context.Context, string, []JSONPatch) error {
+func (fc *FakeClient) Event(context.Context, string, string, string) error {
+	return nil
+}
+
+func (fc *FakeClient) JSONPatchResource(context.Context, string, string, []JSONPatch) error {
 	return nil
 }
 func (fc *FakeClient) UpdateSecret(context.Context, *kubeapi.Secret) error { return nil }


### PR DESCRIPTION
This PR adds logic to emit [kube Events](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/) on a `Pod` running tailscale in response to events related to loading state from a Kubernetes `Secret`.
This is to make debugging easier in case of transient errors related to retrieving/writing state to a `Secret` (i.e because the API server was unable to serve the request).
A subset of these errors would result in container restarts meaning that we cannot really debug the issue by logging more because the logs of the original issue would be lost post-restart. The `Event`s are for a tied to a `Pod` (by name/namespace/uid), so they can still be viewed (i.e by `kubectl describe <pod-name>`) even after N restarts of a `Pod` that's in crashloop-ing)

The event logic is best effort, if the client is not able to write an `Event`, we log the error and continue.

Example events for a `Pod` that initially successfully loaded and updated state, but then failed to write state once:
```
$ kubectl describe pod <pod-name> -n tailscale
...
  Normal   TailscaledStateUpdated      15m (x2 over 15m)  tailscale-kube-store-client  Successfully updated tailscaled state Secret
  Normal   TailscaleStateLoaded        15m                tailscale-kube-store-client  Succesfully loaded tailscaled state from Secret
  Warning  TailscaleStateUpdateFailed  8s                 tailscale-kube-store-client  error patching Secret ts-prod-825sv-0 with /data/profile-fcec field
```

Updates tailscale/tailscale#14080