### PR TITLE
tstest/integration/testcontrol: remove a vestigial unused parameter

### DIFF
--- a/tstest/integration/testcontrol/testcontrol.go
+++ b/tstest/integration/testcontrol/testcontrol.go
@@ -832,7 +832,7 @@ func (s *Server) serveMap(w http.ResponseWriter, r *http.Request, mkey key.Machi
 	w.WriteHeader(200)
 	for {
 		if resBytes, ok := s.takeRawMapMessage(req.NodeKey); ok {
-			if err := s.sendMapMsg(w, mkey, compress, resBytes); err != nil {
+			if err := s.sendMapMsg(w, compress, resBytes); err != nil {
 				s.logf("sendMapMsg of raw message: %v", err)
 				return
 			}
@@ -864,7 +864,7 @@ func (s *Server) serveMap(w http.ResponseWriter, r *http.Request, mkey key.Machi
 				s.logf("json.Marshal: %v", err)
 				return
 			}
-			if err := s.sendMapMsg(w, mkey, compress, resBytes); err != nil {
+			if err := s.sendMapMsg(w, compress, resBytes); err != nil {
 				return
 			}
 		}
@@ -895,7 +895,7 @@ func (s *Server) serveMap(w http.ResponseWriter, r *http.Request, mkey key.Machi
 				}
 				break keepAliveLoop
 			case <-keepAliveTimerCh:
-				if err := s.sendMapMsg(w, mkey, compress, keepAliveMsg); err != nil {
+				if err := s.sendMapMsg(w, compress, keepAliveMsg); err != nil {
 					return
 				}
 			}
@@ -1060,7 +1060,7 @@ func (s *Server) takeRawMapMessage(nk key.NodePublic) (mapResJSON []byte, ok boo
 	return mapResJSON, true
 }
 
-func (s *Server) sendMapMsg(w http.ResponseWriter, mkey key.MachinePublic, compress bool, msg any) error {
+func (s *Server) sendMapMsg(w http.ResponseWriter, compress bool, msg any) error {
 	resBytes, err := s.encode(compress, msg)
 	if err != nil {
 		return err


### PR DESCRIPTION
Back in the day this testcontrol package only spoke the
nacl-boxed-based control protocol, which used this.

Then we added ts2021, which didn't, but still sometimes used it.

Then we removed the old mode and didn't remove this parameter
in 2409661a0da956.

Updates #11585
