### PR TITLE
cmd/derpprobe,prober: add ability to continuously probe bandwidth and…

### DIFF
--- a/cmd/derpprobe/derpprobe.go
+++ b/cmd/derpprobe/derpprobe.go
@@ -27,7 +27,7 @@ var (
 	meshInterval = flag.Duration("mesh-interval", 15*time.Second, "mesh probe interval")
 	stunInterval = flag.Duration("stun-interval", 15*time.Second, "STUN probe interval")
 	tlsInterval  = flag.Duration("tls-interval", 15*time.Second, "TLS probe interval")
-	bwInterval   = flag.Duration("bw-interval", 0, "bandwidth probe interval (0 = no bandwidth probing)")
+	bwInterval   = flag.Duration("bw-interval", 0, "bandwidth probe interval (0 = no bandwidth probing, > 0 = periodic bandwidth probing, < 0 = continuous bandwidth probing)")
 	bwSize       = flag.Int64("bw-probe-size-bytes", 1_000_000, "bandwidth probe size")
 	regionCode   = flag.String("region-code", "", "probe only this region (e.g. 'lax'); if left blank, all regions will be probed")
 )
@@ -45,7 +45,7 @@ func main() {
 		prober.WithSTUNProbing(*stunInterval),
 		prober.WithTLSProbing(*tlsInterval),
 	}
-	if *bwInterval > 0 {
+	if *bwInterval != 0 {
 		opts = append(opts, prober.WithBandwidthProbing(*bwInterval, *bwSize))
 	}
 	if *regionCode != "" {
@@ -106,7 +106,7 @@ func getOverallStatus(p *prober.Prober) (o overallStatus) {
 			// Do not show probes that have not finished yet.
 			continue
 		}
-		if i.Result {
+		if i.Status == prober.ProbeStatusSucceeded {
 			o.addGoodf("%s: %s", p, i.Latency)
 		} else {
 			o.addBadf("%s: %s", p, i.Error)

--- a/derp/derphttp/derphttp_client.go
+++ b/derp/derphttp/derphttp_client.go
@@ -748,7 +748,7 @@ func (c *Client) dialNode(ctx context.Context, n *tailcfg.DERPNode) (net.Conn, e
 				select {
 				case <-ctx.Done():
 					// Either user canceled original context,
-					// it timed out, or the v6 dial succeeded.
+					// if timed out, or the v6 dial succeeded.
 					t.Stop()
 					return
 				case <-tChannel:
@@ -757,6 +757,9 @@ func (c *Client) dialNode(ctx context.Context, n *tailcfg.DERPNode) (net.Conn, e
 			}
 			dst := cmp.Or(dstPrimary, n.HostName)
 			port := "443"
+			if !c.useHTTPS() {
+				port = "3340"
+			}
 			if n.DERPPort != 0 {
 				port = fmt.Sprint(n.DERPPort)
 			}

--- a/prober/derp_test.go
+++ b/prober/derp_test.go
@@ -192,7 +192,7 @@ func TestRunDerpProbeNodePair(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	err = runDerpProbeNodePair(ctx, &tailcfg.DERPNode{Name: "c1"}, &tailcfg.DERPNode{Name: "c2"}, c1, c2, 100_000_000)
+	err = runDerpProbeNodePairOnce(ctx, &tailcfg.DERPNode{Name: "c1"}, &tailcfg.DERPNode{Name: "c2"}, c1, c2, 100_000_000)
 	if err != nil {
 		t.Error(err)
 	}
@@ -235,5 +235,14 @@ func Test_packetsForSize(t *testing.T) {
 				t.Errorf("packetsForSize(%d) is unique=%v (returned %d different answers); want unique=%v", tt.size, unique, len(hashes), unique)
 			}
 		})
+	}
+}
+
+func TestWallAndExt(t *testing.T) {
+	now := time.Now()
+	now2 := fromWallAndExt(wallAndExt(now))
+	diff := now2.Sub(now)
+	if now2.Sub(now) != 0 {
+		t.Fatalf("fromWallAndExt(wallAndExt(now)) = %v; want 0", diff)
 	}
 }

--- a/prober/prober.go
+++ b/prober/prober.go
@@ -256,6 +256,11 @@ type Probe struct {
 	latencyHist *ring.Ring
 }
 
+// IsContinuous indicates that this is a continuous probe.
+func (p *Probe) IsContinuous() bool {
+	return p.interval < 0
+}
+
 // Close shuts down the Probe and unregisters it from its Prober.
 // It is safe to Run a new probe of the same name after Close returns.
 func (p *Probe) Close() error {
@@ -286,6 +291,22 @@ func (p *Probe) loop() {
 
 	if p.prober.once {
 		return
+	}
+
+	if p.IsContinuous() {
+		// Probe function is going to run continuously.
+		for {
+			p.run()
+			// Wait and then retry if probe fails. We use the inverse of the
+			// configured negative interval as our sleep period.
+			// TODO(percy):implement exponential backoff.
+			select {
+			case <-time.After(-1 * p.interval):
+				p.run()
+			case <-p.ctx.Done():
+				return
+			}
+		}
 	}
 
 	p.tick = p.prober.newTicker(p.interval)
@@ -323,9 +344,17 @@ func (p *Probe) run() (pi ProbeInfo, err error) {
 			p.recordEnd(err)
 		}
 	}()
-	timeout := time.Duration(float64(p.interval) * 0.8)
-	ctx, cancel := context.WithTimeout(p.ctx, timeout)
-	defer cancel()
+	ctx := p.ctx
+	if p.IsContinuous() {
+		p.mu.Lock()
+		p.lastErr = nil
+		p.mu.Unlock()
+	} else {
+		timeout := time.Duration(float64(p.interval) * 0.8)
+		var cancel func()
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
 
 	err = p.probeClass.Probe(ctx)
 	p.recordEnd(err)
@@ -365,6 +394,16 @@ func (p *Probe) recordEnd(err error) {
 	p.successHist = p.successHist.Next()
 }
 
+// ProbeStatus indicates the status of a probe.
+type ProbeStatus string
+
+const (
+	ProbeStatusUnknown   = "unknown"
+	ProbeStatusRunning   = "running"
+	ProbeStatusFailed    = "failed"
+	ProbeStatusSucceeded = "succeeded"
+)
+
 // ProbeInfo is a snapshot of the configuration and state of a Probe.
 type ProbeInfo struct {
 	Name            string
@@ -374,7 +413,7 @@ type ProbeInfo struct {
 	Start           time.Time
 	End             time.Time
 	Latency         time.Duration
-	Result          bool
+	Status          ProbeStatus
 	Error           string
 	RecentResults   []bool
 	RecentLatencies []time.Duration
@@ -400,6 +439,10 @@ func (pb ProbeInfo) RecentMedianLatency() time.Duration {
 		return 0
 	}
 	return pb.RecentLatencies[len(pb.RecentLatencies)/2]
+}
+
+func (pb ProbeInfo) Continuous() bool {
+	return pb.Interval < 0
 }
 
 // ProbeInfo returns the state of all probes.
@@ -429,9 +472,14 @@ func (probe *Probe) probeInfoLocked() ProbeInfo {
 		Labels:   probe.metricLabels,
 		Start:    probe.start,
 		End:      probe.end,
-		Result:   probe.succeeded,
 	}
-	if probe.lastErr != nil {
+	inf.Status = ProbeStatusUnknown
+	if probe.end.Before(probe.start) {
+		inf.Status = ProbeStatusRunning
+	} else if probe.succeeded {
+		inf.Status = ProbeStatusSucceeded
+	} else if probe.lastErr != nil {
+		inf.Status = ProbeStatusFailed
 		inf.Error = probe.lastErr.Error()
 	}
 	if probe.latency > 0 {
@@ -467,7 +515,7 @@ func (p *Prober) RunHandler(w http.ResponseWriter, r *http.Request) error {
 	p.mu.Lock()
 	probe, ok := p.probes[name]
 	p.mu.Unlock()
-	if !ok {
+	if !ok || probe.IsContinuous() {
 		return tsweb.Error(http.StatusNotFound, fmt.Sprintf("unknown probe %q", name), nil)
 	}
 
@@ -531,7 +579,8 @@ func (p *Probe) Collect(ch chan<- prometheus.Metric) {
 	if !p.start.IsZero() {
 		ch <- prometheus.MustNewConstMetric(p.mStartTime, prometheus.GaugeValue, float64(p.start.Unix()))
 	}
-	if p.end.IsZero() {
+	// For periodic probes that haven't ended, don't collect probe metrics yet.
+	if p.end.IsZero() && !p.IsContinuous() {
 		return
 	}
 	ch <- prometheus.MustNewConstMetric(p.mEndTime, prometheus.GaugeValue, float64(p.end.Unix()))

--- a/prober/prober_test.go
+++ b/prober/prober_test.go
@@ -316,7 +316,7 @@ func TestProberProbeInfo(t *testing.T) {
 			Interval:        probeInterval,
 			Labels:          map[string]string{"class": "", "name": "probe1"},
 			Latency:         500 * time.Millisecond,
-			Result:          true,
+			Status:          ProbeStatusSucceeded,
 			RecentResults:   []bool{true},
 			RecentLatencies: []time.Duration{500 * time.Millisecond},
 		},
@@ -324,6 +324,7 @@ func TestProberProbeInfo(t *testing.T) {
 			Name:            "probe2",
 			Interval:        probeInterval,
 			Labels:          map[string]string{"class": "", "name": "probe2"},
+			Status:          ProbeStatusFailed,
 			Error:           "error2",
 			RecentResults:   []bool{false},
 			RecentLatencies: nil, // no latency for failed probes
@@ -349,7 +350,7 @@ func TestProbeInfoRecent(t *testing.T) {
 	}{
 		{
 			name:                    "no_runs",
-			wantProbeInfo:           ProbeInfo{},
+			wantProbeInfo:           ProbeInfo{Status: ProbeStatusUnknown},
 			wantRecentSuccessRatio:  0,
 			wantRecentMedianLatency: 0,
 		},
@@ -358,7 +359,7 @@ func TestProbeInfoRecent(t *testing.T) {
 			results: []probeResult{{latency: 100 * time.Millisecond, err: nil}},
 			wantProbeInfo: ProbeInfo{
 				Latency:         100 * time.Millisecond,
-				Result:          true,
+				Status:          ProbeStatusSucceeded,
 				RecentResults:   []bool{true},
 				RecentLatencies: []time.Duration{100 * time.Millisecond},
 			},
@@ -369,7 +370,7 @@ func TestProbeInfoRecent(t *testing.T) {
 			name:    "single_failure",
 			results: []probeResult{{latency: 100 * time.Millisecond, err: errors.New("error123")}},
 			wantProbeInfo: ProbeInfo{
-				Result:          false,
+				Status:          ProbeStatusFailed,
 				RecentResults:   []bool{false},
 				RecentLatencies: nil,
 				Error:           "error123",
@@ -390,7 +391,7 @@ func TestProbeInfoRecent(t *testing.T) {
 				{latency: 80 * time.Millisecond, err: nil},
 			},
 			wantProbeInfo: ProbeInfo{
-				Result:        true,
+				Status:        ProbeStatusSucceeded,
 				Latency:       80 * time.Millisecond,
 				RecentResults: []bool{false, true, true, false, true, true, false, true},
 				RecentLatencies: []time.Duration{
@@ -420,7 +421,7 @@ func TestProbeInfoRecent(t *testing.T) {
 				{latency: 110 * time.Millisecond, err: nil},
 			},
 			wantProbeInfo: ProbeInfo{
-				Result:        true,
+				Status:        ProbeStatusSucceeded,
 				Latency:       110 * time.Millisecond,
 				RecentResults: []bool{true, true, true, true, true, true, true, true, true, true},
 				RecentLatencies: []time.Duration{
@@ -483,7 +484,7 @@ func TestProberRunHandler(t *testing.T) {
 				ProbeInfo: ProbeInfo{
 					Name:          "success",
 					Interval:      probeInterval,
-					Result:        true,
+					Status:        ProbeStatusSucceeded,
 					RecentResults: []bool{true, true},
 				},
 				PreviousSuccessRatio: 1,
@@ -498,7 +499,7 @@ func TestProberRunHandler(t *testing.T) {
 				ProbeInfo: ProbeInfo{
 					Name:          "failure",
 					Interval:      probeInterval,
-					Result:        false,
+					Status:        ProbeStatusFailed,
 					Error:         "error123",
 					RecentResults: []bool{false, false},
 				},

--- a/prober/status.html
+++ b/prober/status.html
@@ -73,8 +73,9 @@
             <th>Name</th>
             <th>Probe Class & Labels</th>
             <th>Interval</th>
-            <th>Last Attempt</th>
-            <th>Success</th>
+            <th>Last Finished</th>
+            <th>Last Started</th>
+            <th>Status</th>
             <th>Latency</th>
             <th>Last Error</th>
         </tr></thead>
@@ -85,9 +86,11 @@
                 {{$name}}
                 {{range $text, $url := $probeInfo.Links}}
                 <br/>
-                <button onclick="location.href='{{$url}}';" type="button">
-                    {{$text}}
-                </button>
+                {{if not $probeInfo.Continuous}}
+                    <button onclick="location.href='{{$url}}';" type="button">
+                        {{$text}}
+                    </button>
+                {{end}}
                 {{end}}
             </td>
             <td>{{$probeInfo.Class}}<br/>
@@ -97,28 +100,48 @@
                 {{end}}
                 </div>
             </td>
-            <td>{{$probeInfo.Interval}}</td>
-            <td data-sort="{{$probeInfo.TimeSinceLast.Milliseconds}}">
-                {{if $probeInfo.TimeSinceLast}}
-                    {{$probeInfo.TimeSinceLast.String}} ago<br/>
+            <td>
+                {{if $probeInfo.Continuous}}
+                    Continuous
+                {{else}}
+                    {{$probeInfo.Interval}}
+                {{end}}
+            </td>
+            <td data-sort="{{$probeInfo.TimeSinceLastEnd.Milliseconds}}">
+                {{if $probeInfo.TimeSinceLastEnd}}
+                    {{$probeInfo.TimeSinceLastEnd.String}} ago<br/>
                     <span class="small">{{$probeInfo.End.Format "2006-01-02T15:04:05Z07:00"}}</span>
                 {{else}}
                     Never
                 {{end}}
             </td>
-            <td>
-                {{if $probeInfo.Result}}
-                    {{$probeInfo.Result}}
+            <td data-sort="{{$probeInfo.TimeSinceLastStart.Milliseconds}}">
+                {{if $probeInfo.TimeSinceLastStart}}
+                    {{$probeInfo.TimeSinceLastStart.String}} ago<br/>
+                    <span class="small">{{$probeInfo.Start.Format "2006-01-02T15:04:05Z07:00"}}</span>
                 {{else}}
-                    <span class="error">{{$probeInfo.Result}}</span>
+                    Never
+                {{end}}
+            </td>
+            <td>
+                {{if $probeInfo.Error}}
+                    <span class="error">{{$probeInfo.Status}}</span>
+                {{else}}
+                    {{$probeInfo.Status}}
                 {{end}}<br/>
-                <div class="small">Recent: {{$probeInfo.RecentResults}}</div>
-                <div class="small">Mean: {{$probeInfo.RecentSuccessRatio}}</div>
+                {{if not $probeInfo.Continuous}}
+                    <div class="small">Recent: {{$probeInfo.RecentResults}}</div>
+                    <div class="small">Mean: {{$probeInfo.RecentSuccessRatio}}</div>
+                {{end}}
             </td>
             <td data-sort="{{$probeInfo.Latency.Milliseconds}}">
-                {{$probeInfo.Latency.String}}
-                <div class="small">Recent: {{$probeInfo.RecentLatencies}}</div>
-                <div class="small">Median: {{$probeInfo.RecentMedianLatency}}</div>
+                {{if $probeInfo.Continuous}}
+                    n/a
+                {{else}}
+                    {{$probeInfo.Latency.String}}
+                    <div class="small">Recent: {{$probeInfo.RecentLatencies}}</div>
+                    <div class="small">Median: {{$probeInfo.RecentMedianLatency}}</div>
+                {{end}}
             </td>
             <td class="small">{{$probeInfo.Error}}</td>
         </tr>


### PR DESCRIPTION
… track queuing delay

Setting the bw-interval to a negative value enables continuous bandwidth probing. When probing bandwidth continuously, the prober also tracks packet transit times, which can be used as a measure of queuing delay.

Updates tailscale/corp#24522

I tested this by running against a local derper and manually observing my `/metrics` endpoint. With a 64KB packet size, I was seeing 2 Gbps throughput and a queuing delay usually under 2ms.

Here is an example of the metrics as they would be exported to Prometheus.

```
# HELP derpprobe_derp_bw_probe_continuous_bytes_total Total data transferred
# TYPE derpprobe_derp_bw_probe_continuous_bytes_total counter
derpprobe_derp_bw_probe_continuous_bytes_total{class="derp_bw",derp_path="single",hostname="localhost",name="derp/dev/1f/1f/bw",region="dev",region_id="1"} 6.8105856e+10
# HELP derpprobe_derp_bw_probe_continuous_queuing_delays_seconds Distribution of queuing delays
# TYPE derpprobe_derp_bw_probe_continuous_queuing_delays_seconds histogram
derpprobe_derp_bw_probe_continuous_queuing_delays_seconds_bucket{class="derp_bw",derp_path="single",hostname="localhost",name="derp/dev/1f/1f/bw",region="dev",region_id="1",le="0.0001"} 42791
derpprobe_derp_bw_probe_continuous_queuing_delays_seconds_bucket{class="derp_bw",derp_path="single",hostname="localhost",name="derp/dev/1f/1f/bw",region="dev",region_id="1",le="0.0002"} 730496
derpprobe_derp_bw_probe_continuous_queuing_delays_seconds_bucket{class="derp_bw",derp_path="single",hostname="localhost",name="derp/dev/1f/1f/bw",region="dev",region_id="1",le="0.0005"} 287610
derpprobe_derp_bw_probe_continuous_queuing_delays_seconds_bucket{class="derp_bw",derp_path="single",hostname="localhost",name="derp/dev/1f/1f/bw",region="dev",region_id="1",le="+Inf"} 1.064154e+06
derpprobe_derp_bw_probe_continuous_queuing_delays_seconds_sum{class="derp_bw",derp_path="single",hostname="localhost",name="derp/dev/1f/1f/bw",region="dev",region_id="1"} 188.88120006199648
derpprobe_derp_bw_probe_continuous_queuing_delays_seconds_count{class="derp_bw",derp_path="single",hostname="localhost",name="derp/dev/1f/1f/bw",region="dev",region_id="1"} 1.064154e+06
# HELP derpprobe_derp_bw_probe_continuous_size_bytes Payload size of the bandwidth prober
# TYPE derpprobe_derp_bw_probe_continuous_size_bytes gauge
derpprobe_derp_bw_probe_continuous_size_bytes{class="derp_bw",derp_path="single",hostname="localhost",name="derp/dev/1f/1f/bw",region="dev",region_id="1"} 64000
```