### PR TITLE
ipn/ipnlocal: fix build, remove another Notify.BackendLogID reference that crept in

### DIFF
--- a/ipn/ipnlocal/bus.go
+++ b/ipn/ipnlocal/bus.go
@@ -146,7 +146,6 @@ func isNotableNotify(n *ipn.Notify) bool {
 	}
 	return n.State != nil ||
 		n.SessionID != "" ||
-		n.BackendLogID != nil ||
 		n.BrowseToURL != nil ||
 		n.LocalTCPPort != nil ||
 		n.ClientVersion != nil ||


### PR DESCRIPTION
I merged 5cae7c51bfa (removing Notify.BackendLogID) and 93db50356536e
(adding another reference to Notify.BackendLogID) that didn't have merge
conflicts, but didn't compile together.

This removes the new reference, fixing the build.

Updates #14129
