### PR TITLE
net/netcheck: respect DERPRegion.Avoid on initial probe plan too

### DIFF
--- a/net/netcheck/netcheck.go
+++ b/net/netcheck/netcheck.go
@@ -541,7 +541,7 @@ func makeProbePlanInitial(dm *tailcfg.DERPMap, ifState *netmon.State) (plan prob
 	plan = make(probePlan)
 
 	for _, reg := range dm.Regions {
-		if len(reg.Nodes) == 0 {
+		if reg.Avoid || len(reg.Nodes) == 0 {
 			continue
 		}
 

--- a/net/netcheck/netcheck_test.go
+++ b/net/netcheck/netcheck_test.go
@@ -401,7 +401,7 @@ func TestMakeProbePlan(t *testing.T) {
 	basicMap := &tailcfg.DERPMap{
 		Regions: map[int]*tailcfg.DERPRegion{},
 	}
-	for rid := 1; rid <= 5; rid++ {
+	for rid := 1; rid <= 6; rid++ {
 		var nodes []*tailcfg.DERPNode
 		for nid := 0; nid < rid; nid++ {
 			nodes = append(nodes, &tailcfg.DERPNode{
@@ -415,6 +415,7 @@ func TestMakeProbePlan(t *testing.T) {
 		basicMap.Regions[rid] = &tailcfg.DERPRegion{
 			RegionID: rid,
 			Nodes:    nodes,
+			Avoid:    rid == 6,
 		}
 	}
 


### PR DESCRIPTION
As found by @jwhited / @raggi.

Updates #8603
Updates #13969
Updates tailscale/corp#24697