### PR TITLE
cmd/k8s-operator,kube/kubeclient,docs/k8s: update manifest templates to ensure kube client can emit Events

### DIFF
--- a/cmd/k8s-operator/tsrecorder_specs.go
+++ b/cmd/k8s-operator/tsrecorder_specs.go
@@ -130,6 +130,15 @@ func tsrRole(tsr *tsapi.Recorder, namespace string) *rbacv1.Role {
 					fmt.Sprintf("%s-0", tsr.Name), // Contains the node state.
 				},
 			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"events"},
+				Verbs: []string{
+					"get",
+					"create",
+					"patch",
+				},
+			},
 		},
 	}
 }
@@ -200,6 +209,14 @@ func env(tsr *tsapi.Recorder) []corev1.EnvVar {
 				FieldRef: &corev1.ObjectFieldSelector{
 					// Secret is named after the pod.
 					FieldPath: "metadata.name",
+				},
+			},
+		},
+		{
+			Name: "POD_UID",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.uid",
 				},
 			},
 		},

--- a/docs/k8s/proxy.yaml
+++ b/docs/k8s/proxy.yaml
@@ -44,6 +44,14 @@ spec:
       value: "{{TS_DEST_IP}}"
     - name: TS_AUTH_ONCE
       value: "true"
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: POD_UID
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.uid
     securityContext:
       capabilities:
         add:

--- a/docs/k8s/role.yaml
+++ b/docs/k8s/role.yaml
@@ -13,3 +13,6 @@ rules:
   resourceNames: ["{{TS_KUBE_SECRET}}"]
   resources: ["secrets"]
   verbs: ["get", "update", "patch"]
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["events"]
+  verbs: ["get", "create", "patch"]

--- a/docs/k8s/sidecar.yaml
+++ b/docs/k8s/sidecar.yaml
@@ -26,6 +26,14 @@ spec:
           name: tailscale-auth
           key: TS_AUTHKEY
           optional: true
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: POD_UID
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.uid
     securityContext:
       capabilities:
         add:

--- a/docs/k8s/subnet.yaml
+++ b/docs/k8s/subnet.yaml
@@ -28,6 +28,14 @@ spec:
           optional: true
     - name: TS_ROUTES
       value: "{{TS_ROUTES}}"
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: POD_UID
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.uid
     securityContext:
       capabilities:
         add:

--- a/docs/k8s/userspace-sidecar.yaml
+++ b/docs/k8s/userspace-sidecar.yaml
@@ -27,3 +27,11 @@ spec:
           name: tailscale-auth
           key: TS_AUTHKEY
           optional: true
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: POD_UID
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.uid

--- a/kube/kubeclient/client_test.go
+++ b/kube/kubeclient/client_test.go
@@ -134,7 +134,7 @@ func fakeKubeAPIRequest(t *testing.T, argSets []args) kubeAPIRequestFunc {
 			t.Errorf("[%d] got method %q, wants method %q", count, gotMethod, a.wantsMethod)
 		}
 		if gotUrl != a.wantsURL {
-			t.Errorf("[%d] got URL %q, wants URL %q", count, gotMethod, a.wantsMethod)
+			t.Errorf("[%d] got URL %q, wants URL %q", count, gotUrl, a.wantsURL)
 		}
 		if d := cmp.Diff(gotIn, a.wantsIn); d != "" {
 			t.Errorf("[%d] unexpected payload (-want + got):\n%s", count, d)


### PR DESCRIPTION
This is a follow-up to #14112 where our internal kube client was updated to allow it to emit Events - this updates our sample kube manifests and tsrecorder manifest templates so they can benefit from this functionality.

Updates tailscale/tailscale#14080