### PR TITLE
net/tsaddr: extract IsTailscaleIPv4 from IsTailscaleIP

### DIFF
--- a/net/tsaddr/tsaddr.go
+++ b/net/tsaddr/tsaddr.go
@@ -66,13 +66,19 @@ const (
 	TailscaleServiceIPv6String = "fd7a:115c:a1e0::53"
 )
 
-// IsTailscaleIP reports whether ip is an IP address in a range that
+// IsTailscaleIP reports whether IP is an IP address in a range that
 // Tailscale assigns from.
 func IsTailscaleIP(ip netip.Addr) bool {
 	if ip.Is4() {
-		return CGNATRange().Contains(ip) && !ChromeOSVMRange().Contains(ip)
+		return IsTailscaleIPv4(ip)
 	}
 	return TailscaleULARange().Contains(ip)
+}
+
+// IsTailscaleIPv4 reports whether an IPv4 IP is an IP address that
+// Tailscale assigns from.
+func IsTailscaleIPv4(ip netip.Addr) bool {
+	return CGNATRange().Contains(ip) && !ChromeOSVMRange().Contains(ip)
 }
 
 // TailscaleULARange returns the IPv6 Unique Local Address range that

--- a/net/tsaddr/tsaddr_test.go
+++ b/net/tsaddr/tsaddr_test.go
@@ -222,3 +222,71 @@ func TestContainsExitRoute(t *testing.T) {
 		}
 	}
 }
+
+func TestIsTailscaleIPv4(t *testing.T) {
+	tests := []struct {
+		in   netip.Addr
+		want bool
+	}{
+		{
+			in:   netip.MustParseAddr("100.67.19.57"),
+			want: true,
+		},
+		{
+			in:   netip.MustParseAddr("10.10.10.10"),
+			want: false,
+		},
+		{
+
+			in:   netip.MustParseAddr("fd7a:115c:a1e0:3f2b:7a1d:4e88:9c2b:7f01"),
+			want: false,
+		},
+		{
+			in:   netip.MustParseAddr("bc9d:0aa0:1f0a:69ab:eb5c:28e0:5456:a518"),
+			want: false,
+		},
+		{
+			in:   netip.MustParseAddr("100.115.92.157"),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		if got := IsTailscaleIPv4(tt.in); got != tt.want {
+			t.Errorf("IsTailscaleIPv4() = %v, want %v", got, tt.want)
+		}
+	}
+}
+
+func TestIsTailscaleIP(t *testing.T) {
+	tests := []struct {
+		in   netip.Addr
+		want bool
+	}{
+		{
+			in:   netip.MustParseAddr("100.67.19.57"),
+			want: true,
+		},
+		{
+			in:   netip.MustParseAddr("10.10.10.10"),
+			want: false,
+		},
+		{
+
+			in:   netip.MustParseAddr("fd7a:115c:a1e0:3f2b:7a1d:4e88:9c2b:7f01"),
+			want: true,
+		},
+		{
+			in:   netip.MustParseAddr("bc9d:0aa0:1f0a:69ab:eb5c:28e0:5456:a518"),
+			want: false,
+		},
+		{
+			in:   netip.MustParseAddr("100.115.92.157"),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		if got := IsTailscaleIP(tt.in); got != tt.want {
+			t.Errorf("IsTailscaleIP() = %v, want %v", got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Extracts tsaddr.IsTailscaleIPv4 out of tsaddr.IsTailscaleIP.

This will allow for checking valid Tailscale assigned IPv4 addresses without checking IPv6 addresses.

Updates #14168
Updates tailscale/corp#24620