### PR TITLE
cmd/containerboot: preserve headers of metrics endpoints responses

### DIFF
--- a/cmd/containerboot/metrics.go
+++ b/cmd/containerboot/metrics.go
@@ -38,12 +38,12 @@ func proxy(w http.ResponseWriter, r *http.Request, url string, do func(*http.Req
 	}
 	defer resp.Body.Close()
 
-	w.WriteHeader(resp.StatusCode)
 	for key, val := range resp.Header {
 		for _, v := range val {
 			w.Header().Add(key, v)
 		}
 	}
+	w.WriteHeader(resp.StatusCode)
 	if _, err := io.Copy(w, resp.Body); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}


### PR DESCRIPTION
A small fix to only write status code header after adding the other headers copied from response as [header map cannot be modified after calling `WriteHeader`](https://cs.opensource.google/go/go/+/refs/tags/go1.23.3:src/net/http/server.go;l=101)

Updates tailscale/tailscale#11292