### PR TITLE
metrics: improve flaky tests

### DIFF
--- a/health/health.go
+++ b/health/health.go
@@ -331,7 +331,7 @@ func (t *Tracker) SetMetricsRegistry(reg *usermetric.Registry) {
 	)
 
 	t.metricHealthMessage.Set(metricHealthMessageLabel{
-		Type: "warning",
+		Type: MetricLabelWarning,
 	}, expvar.Func(func() any {
 		if t.nil() {
 			return 0
@@ -1282,6 +1282,8 @@ func (t *Tracker) LastNoiseDialWasRecent() bool {
 	t.lastNoiseDial = now
 	return dur < 2*time.Minute
 }
+
+const MetricLabelWarning = "warning"
 
 type metricHealthMessageLabel struct {
 	// TODO: break down by warnable.severity as well?

--- a/tsnet/tsnet_test.go
+++ b/tsnet/tsnet_test.go
@@ -1015,8 +1015,8 @@ func TestUserMetrics(t *testing.T) {
 
 	mustDirect(t, t.Logf, lc1, lc2)
 
-	// 10 megabytes
-	bytesToSend := 10 * 1024 * 1024
+	// 1 megabytes
+	bytesToSend := 1 * 1024 * 1024
 
 	// This asserts generates some traffic, it is factored out
 	// of TestUDPConn.
@@ -1059,14 +1059,13 @@ func TestUserMetrics(t *testing.T) {
 		t.Errorf("metrics1, tailscaled_approved_routes: got %v, want %v", got, want)
 	}
 
-	// Verify that the amount of data recorded in bytes is higher or equal to the
-	// 10 megabytes sent.
+	// Verify that the amount of data recorded in bytes is higher or equal to the data sent
 	inboundBytes1 := parsedMetrics1[`tailscaled_inbound_bytes_total{path="direct_ipv4"}`]
 	if inboundBytes1 < float64(bytesToSend) {
 		t.Errorf(`metrics1, tailscaled_inbound_bytes_total{path="direct_ipv4"}: expected higher (or equal) than %d, got: %f`, bytesToSend, inboundBytes1)
 	}
 
-	// But ensure that it is not too much higher than the 10 megabytes sent.
+	// But ensure that it is not too much higher than the data sent.
 	if inboundBytes1 > float64(bytesToSend)*bytesSentTolerance {
 		t.Errorf(`metrics1, tailscaled_inbound_bytes_total{path="direct_ipv4"}: expected lower than %f, got: %f`, float64(bytesToSend)*bytesSentTolerance, inboundBytes1)
 	}
@@ -1093,14 +1092,13 @@ func TestUserMetrics(t *testing.T) {
 		t.Errorf("metrics2, tailscaled_approved_routes: got %v, want %v", got, want)
 	}
 
-	// Verify that the amount of data recorded in bytes is higher or equal than the
-	// 10 megabytes sent.
+	// Verify that the amount of data recorded in bytes is higher or equal than the data sent.
 	outboundBytes2 := parsedMetrics2[`tailscaled_outbound_bytes_total{path="direct_ipv4"}`]
 	if outboundBytes2 < float64(bytesToSend) {
 		t.Errorf(`metrics2, tailscaled_outbound_bytes_total{path="direct_ipv4"}: expected higher (or equal) than %d, got: %f`, bytesToSend, outboundBytes2)
 	}
 
-	// But ensure that it is not too much higher than the 10 megabytes sent.
+	// But ensure that it is not too much higher than the data sent.
 	if outboundBytes2 > float64(bytesToSend)*bytesSentTolerance {
 		t.Errorf(`metrics2, tailscaled_outbound_bytes_total{path="direct_ipv4"}: expected lower than %f, got: %f`, float64(bytesToSend)*bytesSentTolerance, outboundBytes2)
 	}

--- a/tsnet/tsnet_test.go
+++ b/tsnet/tsnet_test.go
@@ -943,14 +943,14 @@ func sendData(logf func(format string, args ...any), ctx context.Context, bytesC
 }
 
 func TestUserMetricsByteCounters(t *testing.T) {
-	flakytest.Mark(t, "https://github.com/tailscale/tailscale/issues/13420")
-	tstest.ResourceCheck(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
 	controlURL, _ := startControl(t)
 	s1, s1ip, _ := startServer(t, ctx, controlURL, "s1")
+	defer s1.Close()
 	s2, s2ip, _ := startServer(t, ctx, controlURL, "s2")
+	defer s2.Close()
 
 	lc1, err := s1.LocalClient()
 	if err != nil {
@@ -1063,14 +1063,14 @@ func TestUserMetricsRouteGauges(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skipf("skipping on windows")
 	}
-	flakytest.Mark(t, "https://github.com/tailscale/tailscale/issues/13420")
-	tstest.ResourceCheck(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
 	controlURL, c := startControl(t)
 	s1, _, s1PubKey := startServer(t, ctx, controlURL, "s1")
+	defer s1.Close()
 	s2, _, _ := startServer(t, ctx, controlURL, "s2")
+	defer s2.Close()
 
 	s1.lb.EditPrefs(&ipn.MaskedPrefs{
 		Prefs: ipn.Prefs{

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -1267,7 +1267,7 @@ func (c *Conn) sendUDPBatch(addr netip.AddrPort, buffs [][]byte) (sent bool, err
 
 // sendUDP sends UDP packet b to ipp.
 // See sendAddr's docs on the return value meanings.
-func (c *Conn) sendUDP(ipp netip.AddrPort, b []byte) (sent bool, err error) {
+func (c *Conn) sendUDP(ipp netip.AddrPort, b []byte, isDisco bool) (sent bool, err error) {
 	if runtime.GOOS == "js" {
 		return false, errNoUDP
 	}
@@ -1276,7 +1276,7 @@ func (c *Conn) sendUDP(ipp netip.AddrPort, b []byte) (sent bool, err error) {
 		metricSendUDPError.Add(1)
 		_ = c.maybeRebindOnError(runtime.GOOS, err)
 	} else {
-		if sent {
+		if sent && !isDisco {
 			switch {
 			case ipp.Addr().Is4():
 				c.metrics.outboundPacketsIPv4Total.Add(1)
@@ -1371,7 +1371,7 @@ func (c *Conn) sendUDPStd(addr netip.AddrPort, b []byte) (sent bool, err error) 
 // returns (false, nil); it's not an error, but nothing was sent.
 func (c *Conn) sendAddr(addr netip.AddrPort, pubKey key.NodePublic, b []byte, isDisco bool) (sent bool, err error) {
 	if addr.Addr() != tailcfg.DerpMagicIPAddr {
-		return c.sendUDP(addr, b)
+		return c.sendUDP(addr, b, isDisco)
 	}
 
 	regionID := int(addr.Port())


### PR DESCRIPTION
To unpack and improve reliability of metrics integration tests:
- Move health metrics tests into the health package
- Reduce the data sent between test nodes (10MB to 1MB) and add better waiter
- Split advertised routes and data sent integration tests 

Tests ran locally over 10 000 times without any flake.

In addition, [afa3299](https://github.com/tailscale/tailscale/pull/14211/commits/afa3299dc0e4fa10fcbf4ebad6a690411630a36f), fixes a path in magicsock where discopackages was counted as data.

Updates #13420

Signed-off-by: Kristoffer Dalby <kristoffer@tailscale.com>