### PR TITLE
net/netmon: improve panic reporting from #14202

### DIFF
--- a/net/netmon/netmon_darwin.go
+++ b/net/netmon/netmon_darwin.go
@@ -58,9 +58,12 @@ func (m *darwinRouteMon) Receive() (message, error) {
 		}
 		msgs, err := func() (msgs []route.Message, err error) {
 			defer func() {
-				if recover() != nil {
+				// TODO(raggi,#14201): remove once we've got a fix from
+				// golang/go#70528.
+				msg := recover()
+				if msg != nil {
 					msgs = nil
-					err = fmt.Errorf("panic parsing route message")
+					err = fmt.Errorf("panic in route.ParseRIB: %s", msg)
 				}
 			}()
 			return route.ParseRIB(route.RIBTypeRoute, m.buf[:n])


### PR DESCRIPTION
I was hoping we'd catch an example input quickly, but the reporter had rebooted their machine and it is no longer exhibiting the behavior. As such this code may be sticking around quite a bit longer and we might encounter other errors, so include the panic in the log entry.

Updates #14201
Updates #14202
Updates golang/go#70528