### PR TITLE
ipn/ipnlocal: only check CanUseExitNode if we are attempting to use one

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3740,11 +3740,16 @@ func updateExitNodeUsageWarning(p ipn.PrefsView, state *netmon.State, healthTrac
 }
 
 func (b *LocalBackend) checkExitNodePrefsLocked(p *ipn.Prefs) error {
+	tryingToUseExitNode := p.ExitNodeIP.IsValid() || p.ExitNodeID != ""
+	if !tryingToUseExitNode {
+		return nil
+	}
+
 	if err := featureknob.CanUseExitNode(); err != nil {
 		return err
 	}
 
-	if (p.ExitNodeIP.IsValid() || p.ExitNodeID != "") && p.AdvertisesExitNode() {
+	if p.AdvertisesExitNode() {
 		return errors.New("Cannot advertise an exit node and use an exit node at the same time.")
 	}
 	return nil


### PR DESCRIPTION
In https://github.com/tailscale/tailscale/pull/13726 we added logic to `checkExitNodePrefsLocked` to error out on platforms where using an exit node is unsupported in order to give users more obvious feedback than having this silently fail downstream.

The above change neglected to properly check whether the device in question was actually trying to use an exit node when doing the check and was incorrectly returning an error on any calls to `checkExitNodePrefsLocked` on platforms where using an exit node is not supported as a result.

This change remedies this by adding a check to see whether the device is attempting to use an exit node before doing the `CanUseExitNode` check.

Updates https://github.com/tailscale/corp/issues/24835