### PR TITLE
health: allow hiding arbitrary warnable codes

### DIFF
--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -777,6 +777,7 @@ func init() {
 	addPrefFlagMapping("auto-update", "AutoUpdate.Apply")
 	addPrefFlagMapping("advertise-connector", "AppConnector")
 	addPrefFlagMapping("posture-checking", "PostureChecking")
+	addPrefFlagMapping("hide-health-warnings", "HideHealthWarnings")
 }
 
 func addPrefFlagMapping(flagName string, prefNames ...string) {

--- a/health/state.go
+++ b/health/state.go
@@ -4,6 +4,7 @@
 package health
 
 import (
+	"slices"
 	"time"
 )
 
@@ -86,7 +87,7 @@ func (t *Tracker) CurrentState() *State {
 	wm := map[WarnableCode]UnhealthyState{}
 
 	for w, ws := range t.warnableVal {
-		if !w.IsVisible(ws) {
+		if !w.IsVisible(ws) || slices.Contains(t.hideWarnables, w.Code) {
 			// Skip invisible Warnables.
 			continue
 		}

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -10,6 +10,7 @@ import (
 	"net/netip"
 
 	"tailscale.com/drive"
+	"tailscale.com/health"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/opt"
 	"tailscale.com/types/persist"
@@ -38,6 +39,7 @@ func (src *Prefs) Clone() *Prefs {
 			}
 		}
 	}
+	dst.HideHealthWarnings = append(src.HideHealthWarnings[:0:0], src.HideHealthWarnings...)
 	dst.Persist = src.Persist.Clone()
 	return dst
 }
@@ -73,6 +75,7 @@ var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	PostureChecking        bool
 	NetfilterKind          string
 	DriveShares            []*drive.Share
+	HideHealthWarnings     []health.WarnableCode
 	AllowSingleHosts       marshalAsTrueInJSON
 	Persist                *persist.Persist
 }{})

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -11,6 +11,7 @@ import (
 	"net/netip"
 
 	"tailscale.com/drive"
+	"tailscale.com/health"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/opt"
 	"tailscale.com/types/persist"
@@ -100,6 +101,9 @@ func (v PrefsView) NetfilterKind() string                 { return v.ж.Netfilte
 func (v PrefsView) DriveShares() views.SliceView[*drive.Share, drive.ShareView] {
 	return views.SliceOfViews[*drive.Share, drive.ShareView](v.ж.DriveShares)
 }
+func (v PrefsView) HideHealthWarnings() views.Slice[health.WarnableCode] {
+	return views.SliceOf(v.ж.HideHealthWarnings)
+}
 func (v PrefsView) AllowSingleHosts() marshalAsTrueInJSON { return v.ж.AllowSingleHosts }
 func (v PrefsView) Persist() persist.PersistView          { return v.ж.Persist.View() }
 
@@ -134,6 +138,7 @@ var _PrefsViewNeedsRegeneration = Prefs(struct {
 	PostureChecking        bool
 	NetfilterKind          string
 	DriveShares            []*drive.Share
+	HideHealthWarnings     []health.WarnableCode
 	AllowSingleHosts       marshalAsTrueInJSON
 	Persist                *persist.Persist
 }{})

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -19,6 +19,7 @@ import (
 
 	"tailscale.com/atomicfile"
 	"tailscale.com/drive"
+	"tailscale.com/health"
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/net/netaddr"
 	"tailscale.com/net/tsaddr"
@@ -245,6 +246,9 @@ type Prefs struct {
 	// by name.
 	DriveShares []*drive.Share
 
+	// HideHealthWarnings is a list of warnable codes to hide from the user.
+	HideHealthWarnings []health.WarnableCode
+
 	// AllowSingleHosts was a legacy field that was always true
 	// for the past 4.5 years. It controlled whether Tailscale
 	// peers got /32 or /127 routes for each other.
@@ -336,6 +340,7 @@ type MaskedPrefs struct {
 	PostureCheckingSet        bool                `json:",omitempty"`
 	NetfilterKindSet          bool                `json:",omitempty"`
 	DriveSharesSet            bool                `json:",omitempty"`
+	HideHealthWarningsSet     bool                `json:",omitempty"`
 }
 
 // SetsInternal reports whether mp has any of the Internal*Set field bools set
@@ -615,7 +620,8 @@ func (p *Prefs) Equals(p2 *Prefs) bool {
 		p.AppConnector == p2.AppConnector &&
 		p.PostureChecking == p2.PostureChecking &&
 		slices.EqualFunc(p.DriveShares, p2.DriveShares, drive.SharesEqual) &&
-		p.NetfilterKind == p2.NetfilterKind
+		p.NetfilterKind == p2.NetfilterKind &&
+		slices.Equal(p.HideHealthWarnings, p2.HideHealthWarnings)
 }
 
 func (au AutoUpdatePrefs) Pretty() string {

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -65,6 +65,7 @@ func TestPrefsEqual(t *testing.T) {
 		"PostureChecking",
 		"NetfilterKind",
 		"DriveShares",
+		"HideHealthWarnings",
 		"AllowSingleHosts",
 		"Persist",
 	}

--- a/util/syspolicy/policy_keys.go
+++ b/util/syspolicy/policy_keys.go
@@ -126,6 +126,9 @@ const (
 	// Keys with a string array value.
 	// AllowedSuggestedExitNodes's string array value is a list of exit node IDs that restricts which exit nodes are considered when generating suggestions for exit nodes.
 	AllowedSuggestedExitNodes Key = "AllowedSuggestedExitNodes"
+	// HideHealthWarnings hides the specified health.WarnableCode types from
+	// the user when they become unhealthy.
+	HideHealthWarnings Key = "HideHealthWarnings"
 )
 
 // implicitDefinitions is a list of [setting.Definition] that will be registered
@@ -170,6 +173,7 @@ var implicitDefinitions = []*setting.Definition{
 	setting.NewDefinition(TestMenuVisibility, setting.UserSetting, setting.VisibilityValue),
 	setting.NewDefinition(UpdateMenuVisibility, setting.UserSetting, setting.VisibilityValue),
 	setting.NewDefinition(OnboardingFlowVisibility, setting.UserSetting, setting.VisibilityValue),
+	setting.NewDefinition(HideHealthWarnings, setting.UserSetting, setting.StringListValue),
 }
 
 func init() {


### PR DESCRIPTION
If we add a warning that has false positives, or is expected by the user, the user can now hide it. This can be done via "tailscale set" or MDM policies.

Updates #3198