### PR TITLE
cmd/k8s-operator: fix port name change bug for egress ProxyGroup proxies

### DIFF
--- a/cmd/k8s-operator/testutils_test.go
+++ b/cmd/k8s-operator/testutils_test.go
@@ -650,7 +650,7 @@ func removeHashAnnotation(sts *appsv1.StatefulSet) {
 func removeTargetPortsFromSvc(svc *corev1.Service) {
 	newPorts := make([]corev1.ServicePort, 0)
 	for _, p := range svc.Spec.Ports {
-		newPorts = append(newPorts, corev1.ServicePort{Protocol: p.Protocol, Port: p.Port})
+		newPorts = append(newPorts, corev1.ServicePort{Protocol: p.Protocol, Port: p.Port, Name: p.Name})
 	}
 	svc.Spec.Ports = newPorts
 }


### PR DESCRIPTION
See https://github.com/tailscale/tailscale/issues/13406#issuecomment-2507230388

This PR ensures that the ExternalName Service port names are always synced to the ClusterIP Service, to fix a bug where if users created a Service with a single unnamed port and later changed to 1+ named ports, the operator attempted to apply an invalid multi-port Service with an unnamed port. Also, fixes a small internal issue where not-yet Service status conditons were lost on a spec update.

I have updated the tests to so they would now catch this bug and also verified e2e that the scenario as described in https://github.com/tailscale/tailscale/issues/13406#issuecomment-2507230388 now works

Updates tailscale/tailscale#10102