### PR TITLE
cmd/containerboot: skip error log when authkey is found in secret

### DIFF
--- a/cmd/containerboot/settings.go
+++ b/cmd/containerboot/settings.go
@@ -248,6 +248,7 @@ func (cfg *settings) setupKube(ctx context.Context) error {
 			return errors.New("authkey found in TS_KUBE_SECRET, but the pod doesn't have patch permissions on the Secret to manage the authkey.")
 		}
 		cfg.AuthKey = key
+		return nil
 	}
 
 	log.Print("No authkey found in state Secret and TS_AUTHKEY not provided, login will be interactive if needed.")


### PR DESCRIPTION
When setting up the Kubernetes configuration, containerboot was unconditionnaly logging this message whether an `authkey` was found in the secret or not:
```
No authkey found in state Secret and TS_AUTHKEY not provided, login will be interactive if needed.
```