### PR TITLE
cmd/k8s-operator/deploy/chart: allow reading OAuth creds from a CSI driver's volume and annotating operator's Service account

### DIFF
--- a/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
+++ b/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
@@ -36,12 +36,12 @@ spec:
       {{- end }}
       volumes:
         - name: oauth
-        {{- with .Values.oauthSecretVolume }}
-        {{- toYaml . | nindent 8 }}
-        {{- else }}
+          {{- with .Values.oauthSecretVolume }}
+          {{- toYaml . | nindent 10 }}
+          {{- else }}
           secret:
             secretName: operator-oauth
-        {{- end }}
+          {{- end }}
       containers:
         - name: operator
           {{- with .Values.operatorConfig.securityContext }}

--- a/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
+++ b/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
@@ -35,9 +35,13 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-      - name: oauth
-        secret:
-          secretName: operator-oauth
+        - name: oauth
+        {{- with .Values.oauthSecretVolume }}
+        {{- toYaml . | nindent 8 }}
+        {{- else }}
+          secret:
+            secretName: operator-oauth
+        {{- end }}
       containers:
         - name: operator
           {{- with .Values.operatorConfig.securityContext }}

--- a/cmd/k8s-operator/deploy/chart/templates/operator-rbac.yaml
+++ b/cmd/k8s-operator/deploy/chart/templates/operator-rbac.yaml
@@ -6,6 +6,10 @@ kind: ServiceAccount
 metadata:
   name: operator
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.operatorConfig.serviceAccountAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/cmd/k8s-operator/deploy/chart/values.yaml
+++ b/cmd/k8s-operator/deploy/chart/values.yaml
@@ -3,13 +3,17 @@
 
 # Operator oauth credentials. If set a Kubernetes Secret with the provided
 # values will be created in the operator namespace. If unset a Secret named
-# operator-oauth must be precreated.
+# operator-oauth must be precreated or oauthSecretVolume needs to be adjusted.
+# This block will be overridden by oauthSecretVolume, if set.
 oauth: {}
   # clientId: ""
   # clientSecret: ""
 
-# Secret volume. If set it defines the volume the oauth secrets will be mounted
-# from. If unset the volume will reference the Secret named operator-oauth.
+# Secret volume.
+# If set it defines the volume the oauth secrets will be mounted from.
+# The volume needs to contain two files named `client_id` and `client_secret`.
+# If unset the volume will reference the Secret named operator-oauth.
+# This block will override the oauth block.
 oauthSecretVolume: {}
   # csi:
   #   driver: secrets-store.csi.k8s.io

--- a/cmd/k8s-operator/deploy/chart/values.yaml
+++ b/cmd/k8s-operator/deploy/chart/values.yaml
@@ -8,6 +8,17 @@ oauth: {}
   # clientId: ""
   # clientSecret: ""
 
+# Secret volume. If set it defines the volume the oauth secrets will be mounted
+# from. If unset the volume will reference the Secret named operator-oauth.
+oauthSecretVolume: {}
+  # csi:
+  #   driver: secrets-store.csi.k8s.io
+  #   readOnly: true
+  #   volumeAttributes:
+  #     secretProviderClass: tailscale-oauth
+  #
+  ## NAME is pre-defined!
+
 # installCRDs determines whether tailscale.com CRDs should be installed as part
 # of chart installation. We do not use Helm's CRD installation mechanism as that
 # does not allow for upgrading CRDs.

--- a/cmd/k8s-operator/deploy/chart/values.yaml
+++ b/cmd/k8s-operator/deploy/chart/values.yaml
@@ -51,6 +51,9 @@ operatorConfig:
   podAnnotations: {}
   podLabels: {}
 
+  serviceAccountAnnotations: {}
+  # eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/tailscale-operator-role
+
   tolerations: []
 
   affinity: {}


### PR DESCRIPTION
This is an alternative approach to #11270 / #12213

It does intentionally _not_ follow the `extraVolumes`/`extraMounts` pattern to increase ease-of-use, but solves the very specific problem of using [secrets-store-csi-driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver).

Not setting the new object results in falling back to the previous default behavior.