### PR TITLE
net/tstun: remove tailscaled_outbound_dropped_packets_total reason=acl metric for now

### DIFF
--- a/net/tstun/wrap.go
+++ b/net/tstun/wrap.go
@@ -876,9 +876,10 @@ func (t *Wrapper) filterPacketOutboundToWireGuard(p *packet.Parsed, pc *peerConf
 
 	if filt.RunOut(p, t.filterFlags) != filter.Accept {
 		metricPacketOutDropFilter.Add(1)
-		t.metrics.outboundDroppedPacketsTotal.Add(usermetric.DropLabels{
-			Reason: usermetric.ReasonACL,
-		}, 1)
+		// TODO(#14280): increment a t.metrics.outboundDroppedPacketsTotal here
+		// once we figure out & document what labels to use for multicast,
+		// link-local-unicast, IP fragments, etc. But they're not
+		// usermetric.ReasonACL.
 		return filter.Drop, gro
 	}
 

--- a/net/tstun/wrap_test.go
+++ b/net/tstun/wrap_test.go
@@ -453,7 +453,7 @@ func TestFilter(t *testing.T) {
 
 	assertMetricPackets(t, "inACL", 3, metricInboundDroppedPacketsACL)
 	assertMetricPackets(t, "inError", 0, metricInboundDroppedPacketsErr)
-	assertMetricPackets(t, "outACL", 1, metricOutboundDroppedPacketsACL)
+	assertMetricPackets(t, "outACL", 0, metricOutboundDroppedPacketsACL)
 }
 
 func assertMetricPackets(t *testing.T, metricName string, want, got int64) {


### PR DESCRIPTION
Updates #14280
