### PR TITLE
cmd,{get-authkey,tailscale}: remove unnecessary scope qualifier from …

### DIFF
--- a/cmd/get-authkey/main.go
+++ b/cmd/get-authkey/main.go
@@ -46,7 +46,6 @@ func main() {
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		TokenURL:     baseURL + "/api/v2/oauth/token",
-		Scopes:       []string{"device"},
 	}
 
 	ctx := context.Background()

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -1157,7 +1157,6 @@ func resolveAuthKey(ctx context.Context, v, tags string) (string, error) {
 		ClientID:     "some-client-id", // ignored
 		ClientSecret: clientSecret,
 		TokenURL:     baseURL + "/api/v2/oauth/token",
-		Scopes:       []string{"device"},
 	}
 
 	tsClient := tailscale.NewClient("-", nil)


### PR DESCRIPTION
…OAuth clients

OAuth clients that were used to generate an auth_key previously specified the scope 'device'. 'device' is not an actual scope, the real scope is 'devices'. The resulting OAuth token ended up including all scopes from the specified OAuth client, so the code was able to successfully create auth_keys.

It's better not to hardcode a scope here anyway, so that we have the flexibility of changing which scope(s) are used in the future without having to update old clients.

Since the qualifier never actually did anything, this commit simply removes it.

Updates tailscale/corp#24934

I tested this manually using an OAuth client that had only the `auth_keys` scope. I ran the `get-authkey` command and verified that it successfully created an auth_key for the tag `tag:example`. I also ran `tailscale up -authkey` using the OAuth client secret and verified that the machine successfully appeared on the tailnet.