### PR TITLE
net/netcheck: preserve STUN port defaulting to 3478

### DIFF
--- a/net/netcheck/netcheck.go
+++ b/net/netcheck/netcheck.go
@@ -1542,6 +1542,9 @@ func (c *Client) nodeAddrPort(ctx context.Context, n *tailcfg.DERPNode, port int
 	if port < 0 || port > 1<<16-1 {
 		return zero, false
 	}
+	if port == 0 {
+		port = 3478
+	}
 	if n.STUNTestIP != "" {
 		ip, err := netip.ParseAddr(n.STUNTestIP)
 		if err != nil {


### PR DESCRIPTION
In https://github.com/tailscale/tailscale/pull/14261 we removed the defaulting of the STUN port to 3478 to not set it for cases where it's set to -1 (disable). However, with that we also lost the previous behaviour where STUN ports set to 0 are defaulted to 3478, which is intended (see [this comment](https://github.com/tailscale/tailscale/blob/7f9ebc0a83f82922787f4e8336b9f626d895a08c/tailcfg/derpmap.go#L159))

That caused some nodes to incorrectly report that they have no UDP connectivity, see https://github.com/tailscale/tailscale/issues/14287

@bradfitz - I don't know if this is the right fix or rather the derpmaps received on clients should already have ports defaulted to 3478?
When I curl derpmap on my client via localapi (which seems to be [how a client would get the derpmap for the STUN check](https://github.com/tailscale/tailscale/blob/df94a1487076f744742d5b5c3a234d628bfd2bb5/cmd/tailscale/cli/netcheck.go#L81)), I don't see the STUN ports set for any DERP nodes

I have tested that this change fixes https://github.com/tailscale/tailscale/issues/14287

Updates tailscale/tailscale#14287