### PR TITLE
net/netmon: remove extra panic guard around ParseRIB

### DIFF
--- a/net/netmon/netmon_darwin.go
+++ b/net/netmon/netmon_darwin.go
@@ -56,18 +56,7 @@ func (m *darwinRouteMon) Receive() (message, error) {
 		if err != nil {
 			return nil, err
 		}
-		msgs, err := func() (msgs []route.Message, err error) {
-			defer func() {
-				// TODO(raggi,#14201): remove once we've got a fix from
-				// golang/go#70528.
-				msg := recover()
-				if msg != nil {
-					msgs = nil
-					err = fmt.Errorf("panic in route.ParseRIB: %s", msg)
-				}
-			}()
-			return route.ParseRIB(route.RIBTypeRoute, m.buf[:n])
-		}()
+		msgs, err := route.ParseRIB(route.RIBTypeRoute, m.buf[:n])
 		if err != nil {
 			if debugRouteMessages {
 				m.logf("read %d bytes (% 02x), failed to parse RIB: %v", n, m.buf[:n], err)


### PR DESCRIPTION
This was an extra defense added for #14201 that is no longer required.

Fixes #14201