### PR TITLE
cmd/k8s-operator: fix ProxyGroup hostname

### DIFF
--- a/cmd/k8s-operator/proxygroup.go
+++ b/cmd/k8s-operator/proxygroup.go
@@ -479,7 +479,7 @@ func pgTailscaledConfig(pg *tsapi.ProxyGroup, class *tsapi.ProxyClass, idx int32
 	}
 
 	if pg.Spec.HostnamePrefix != "" {
-		conf.Hostname = ptr.To(fmt.Sprintf("%s%d", pg.Spec.HostnamePrefix, idx))
+		conf.Hostname = ptr.To(fmt.Sprintf("%s-%d", pg.Spec.HostnamePrefix, idx))
 	}
 
 	if shouldAcceptRoutes(class) {


### PR DESCRIPTION
Fix the ProxyGroup hostname if derived from `.spec.hostnamePrefix` so that the ordinal is separated by dash.
This will change hostnames of existing replicas on upgrade, but that should be fine (not ingress, nothing should connect via MagicDNS name)

Updates tailscale/tailscale#14325