### PR TITLE
cmd/containerboot,cmd/k8s-operator: reload tailscaled config

### DIFF
--- a/cmd/k8s-operator/operator_test.go
+++ b/cmd/k8s-operator/operator_test.go
@@ -1380,6 +1380,7 @@ func TestTailscaledConfigfileHash(t *testing.T) {
 	})
 
 	expectReconciled(t, sr, "default", "test")
+	expectReconciled(t, sr, "default", "test")
 
 	fullName, shortName := findGenName(t, fc, "default", "test", "svc")
 	o := configOpts{
@@ -1389,7 +1390,7 @@ func TestTailscaledConfigfileHash(t *testing.T) {
 		parentType:      "svc",
 		hostname:        "default-test",
 		clusterTargetIP: "10.20.30.40",
-		confFileHash:    "acf3467364b0a3ba9b8ee0dd772cb7c2f0bf585e288fa99b7fe4566009ed6041",
+		confFileHash:    "848bff4b5ba83ac999e6984c8464e597156daba961ae045e7dbaef606d54ab5e",
 		app:             kubetypes.AppIngressProxy,
 	}
 	expectEqual(t, fc, expectedSTS(t, fc, o), nil)

--- a/cmd/k8s-operator/proxygroup.go
+++ b/cmd/k8s-operator/proxygroup.go
@@ -261,17 +261,44 @@ func (r *ProxyGroupReconciler) maybeProvision(ctx context.Context, pg *tsapi.Pro
 			return fmt.Errorf("error provisioning ConfigMap: %w", err)
 		}
 	}
-	ss, err := pgStatefulSet(pg, r.tsNamespace, r.proxyImage, r.tsFirewallMode, cfgHash)
+	ss, err := pgStatefulSet(pg, r.tsNamespace, r.proxyImage, r.tsFirewallMode)
 	if err != nil {
 		return fmt.Errorf("error generating StatefulSet spec: %w", err)
 	}
 	ss = applyProxyClassToStatefulSet(proxyClass, ss, nil, logger)
-	if _, err := createOrUpdate(ctx, r.Client, r.tsNamespace, ss, func(s *appsv1.StatefulSet) {
+	capver, err := r.capVerForPG(ctx, pg, logger)
+	if err != nil {
+		return fmt.Errorf("error getting device info: %w", err)
+	}
+
+	updateSS := func(s *appsv1.StatefulSet) {
+
+		// This is a temporary workaround to ensure that egress ProxyGroup proxies with capver older than 110
+		// are restarted when tailscaled configfile contents have changed.
+		// This workaround ensures that:
+		// 1. The hash mechanism is used to trigger pod restarts for proxies below capver 110.
+		// 2. Proxies above capver are not unnecessarily restarted when the configfile contents change.
+		// 3. If the hash has alreay been set, but the capver is above 110, the old hash is preserved to avoid
+		// unnecessary pod restarts that could result in an update loop where capver cannot be determined for a
+		// restarting Pod and the hash is re-added again.
+		// Note that this workaround is only applied to egress ProxyGroups, because ingress ProxyGroup was added after capver 110.
+		// Note also that the hash annotation is only set on updates, not creation because if the StatefulSet is
+		// being created, there is no need for a restart.
+		// TODO(irbekrm): remove this in 1.84.
+		hash := cfgHash
+		if capver >= 110 {
+			hash = s.Spec.Template.GetAnnotations()[podAnnotationLastSetConfigFileHash]
+		}
+		s.Spec = ss.Spec
+		if hash != "" && pg.Spec.Type == tsapi.ProxyGroupTypeEgress {
+			mak.Set(&s.Spec.Template.Annotations, podAnnotationLastSetConfigFileHash, hash)
+		}
+
 		s.ObjectMeta.Labels = ss.ObjectMeta.Labels
 		s.ObjectMeta.Annotations = ss.ObjectMeta.Annotations
 		s.ObjectMeta.OwnerReferences = ss.ObjectMeta.OwnerReferences
-		s.Spec = ss.Spec
-	}); err != nil {
+	}
+	if _, err := createOrUpdate(ctx, r.Client, r.tsNamespace, ss, updateSS); err != nil {
 		return fmt.Errorf("error provisioning StatefulSet: %w", err)
 	}
 	mo := &metricsOpts{
@@ -564,12 +591,18 @@ func (r *ProxyGroupReconciler) getNodeMetadata(ctx context.Context, pg *tsapi.Pr
 			continue
 		}
 
-		metadata = append(metadata, nodeMetadata{
+		nm := nodeMetadata{
 			ordinal:     ordinal,
 			stateSecret: &secret,
 			tsID:        id,
 			dnsName:     dnsName,
-		})
+		}
+		pod := &corev1.Pod{}
+		if err := r.Get(ctx, client.ObjectKey{Namespace: r.tsNamespace, Name: secret.Name}, pod); err != nil && !apierrors.IsNotFound(err) {
+			return nil, err
+		}
+		nm.pod = pod
+		metadata = append(metadata, nm)
 	}
 
 	return metadata, nil
@@ -601,6 +634,27 @@ func (r *ProxyGroupReconciler) getDeviceInfo(ctx context.Context, pg *tsapi.Prox
 type nodeMetadata struct {
 	ordinal     int
 	stateSecret *corev1.Secret
+	pod         *corev1.Pod // nil if there is no Pod (yet)
 	tsID        tailcfg.StableNodeID
 	dnsName     string
+}
+
+// capVerForPG returns best effort capability version for the given ProxyGroup. It attempts to find it by looking at the
+// Secret + Pod for the replica with ordinal 0. Returns -1 if it is not possible to determine the capability version
+// (i.e there is no Pod yet).
+func (r *ProxyGroupReconciler) capVerForPG(ctx context.Context, pg *tsapi.ProxyGroup, logger *zap.SugaredLogger) (tailcfg.CapabilityVersion, error) {
+	metas, err := r.getNodeMetadata(ctx, pg)
+	if err != nil {
+		return -1, fmt.Errorf("error getting node metadata: %w", err)
+	}
+	if len(metas) != 0 {
+		dev, err := deviceInfo(metas[0].stateSecret, metas[0].pod, logger)
+		if err != nil {
+			return -1, fmt.Errorf("error getting device info: %w", err)
+		}
+		if dev != nil {
+			return dev.capver, nil
+		}
+	}
+	return -1, nil
 }

--- a/cmd/k8s-operator/proxygroup_specs.go
+++ b/cmd/k8s-operator/proxygroup_specs.go
@@ -21,7 +21,7 @@ import (
 
 // Returns the base StatefulSet definition for a ProxyGroup. A ProxyClass may be
 // applied over the top after.
-func pgStatefulSet(pg *tsapi.ProxyGroup, namespace, image, tsFirewallMode, cfgHash string) (*appsv1.StatefulSet, error) {
+func pgStatefulSet(pg *tsapi.ProxyGroup, namespace, image, tsFirewallMode string) (*appsv1.StatefulSet, error) {
 	ss := new(appsv1.StatefulSet)
 	if err := yaml.Unmarshal(proxyYaml, &ss); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal proxy spec: %w", err)
@@ -53,9 +53,6 @@ func pgStatefulSet(pg *tsapi.ProxyGroup, namespace, image, tsFirewallMode, cfgHa
 		Namespace:                  namespace,
 		Labels:                     pgLabels(pg.Name, nil),
 		DeletionGracePeriodSeconds: ptr.To[int64](10),
-		Annotations: map[string]string{
-			podAnnotationLastSetConfigFileHash: cfgHash,
-		},
 	}
 	tmpl.Spec.ServiceAccountName = pg.Name
 	tmpl.Spec.InitContainers[0].Image = image


### PR DESCRIPTION
Reload tailscaled mounted tailscaled config when file contents have changed instead of restarting the proxies.

I have tested that the reloading with a hostname change for ProxyGroup and advertised routes change for a Connector.

Updates tailscale/tailscale#13032
Updates tailscale/corp#24795