### PR TITLE
ipn/conf.go: add VIPServices to tailscaled configfile

### DIFF
--- a/ipn/conf.go
+++ b/ipn/conf.go
@@ -32,6 +32,8 @@ type ConfigVAlpha struct {
 	AdvertiseRoutes []netip.Prefix `json:",omitempty"`
 	DisableSNAT     opt.Bool       `json:",omitempty"`
 
+	AdvertiseServices []string `json:",omitempty"`
+
 	AppConnector *AppConnectorPrefs `json:",omitempty"` // advertise app connector; defaults to false (if nil or explicitly set to false)
 
 	NetfilterMode       *string  `json:",omitempty"` // "on", "off", "nodivert"
@@ -142,6 +144,10 @@ func (c *ConfigVAlpha) ToPrefs() (MaskedPrefs, error) {
 	if c.AppConnector != nil {
 		mp.AppConnector = *c.AppConnector
 		mp.AppConnectorSet = true
+	}
+	if c.AdvertiseServices != nil {
+		mp.AdvertiseServices = c.AdvertiseServices
+		mp.AdvertiseServicesSet = true
 	}
 	return mp, nil
 }


### PR DESCRIPTION
This is not used by anything just yet.

I am not bumping capver this time- although normally we would need to do it when adding a new field here that's meant to be used by kube operator/proxies (see https://github.com/tailscale/tailscale/pull/13942/commits/e045805c941069765fb9c77d8fa466562ce6dec4#r1822767271), this time it will not be used by any proxies created from a tailscale version older than this change.

I've verified that when the new field is set and config is reloaded, the advertised services appear in prefs.

Updates tailscale/corp#24795