### PR TITLE
cmd/containerboot: guard kubeClient against nil dereference

### DIFF
--- a/cmd/containerboot/main.go
+++ b/cmd/containerboot/main.go
@@ -331,8 +331,10 @@ authLoop:
 		if err := client.SetServeConfig(ctx, new(ipn.ServeConfig)); err != nil {
 			log.Fatalf("failed to unset serve config: %v", err)
 		}
-		if err := kc.storeHTTPSEndpoint(ctx, ""); err != nil {
-			log.Fatalf("failed to update HTTPS endpoint in tailscale state: %v", err)
+		if hasKubeStateStore(cfg) {
+			if err := kc.storeHTTPSEndpoint(ctx, ""); err != nil {
+				log.Fatalf("failed to update HTTPS endpoint in tailscale state: %v", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
A method on kc was called unconditionally, even if was not initialized, leading to a nil pointer dereference when TS_SERVE_CONFIG was set outside Kubernetes.

Add a guard symmetric with other uses of the kubeClient.

Fixes #14354.