### PR TITLE
cmd/containerboot: don't attempt to write kube Secret in non-kube environments

### DIFF
--- a/cmd/containerboot/serve.go
+++ b/cmd/containerboot/serve.go
@@ -72,8 +72,10 @@ func watchServeConfigChanges(ctx context.Context, path string, cdChanged <-chan 
 		if err := updateServeConfig(ctx, sc, certDomain, lc); err != nil {
 			log.Fatalf("serve proxy: error updating serve config: %v", err)
 		}
-		if err := kc.storeHTTPSEndpoint(ctx, certDomain); err != nil {
-			log.Fatalf("serve proxy: error storing HTTPS endpoint: %v", err)
+		if kc != nil {
+			if err := kc.storeHTTPSEndpoint(ctx, certDomain); err != nil {
+				log.Fatalf("serve proxy: error storing HTTPS endpoint: %v", err)
+			}
 		}
 		prevServeConfig = sc
 	}


### PR DESCRIPTION
A follow-up to https://github.com/tailscale/tailscale/pull/14357, fixes a second place where the `https_endpoint` field was written to the kube Secret without a check + adds some tests that would have caught this.

I've tested that non-kube containers work with `TS_SERVE_CONFIG` with this change, i.e
```
docker run -it -e TS_AUTHKEY=<key> -v $(pwd)/serve-config.json:/serve-config.json -e TS_SERVE_CONFIG=/serve-config.json --privileged=true <image>
```

Updates tailscale/tailscale#14354