### PR TITLE
cmd/containerboot: fix nil pointer exception (cherry-pick of #14357, #14358)

### DIFF
--- a/cmd/containerboot/kube.go
+++ b/cmd/containerboot/kube.go
@@ -24,6 +24,7 @@ import (
 type kubeClient struct {
 	kubeclient.Client
 	stateSecret string
+	canPatch    bool // whether the client has permissions to patch Kubernetes Secrets
 }
 
 func newKubeClient(root string, stateSecret string) (*kubeClient, error) {

--- a/cmd/containerboot/main.go
+++ b/cmd/containerboot/main.go
@@ -331,8 +331,10 @@ authLoop:
 		if err := client.SetServeConfig(ctx, new(ipn.ServeConfig)); err != nil {
 			log.Fatalf("failed to unset serve config: %v", err)
 		}
-		if err := kc.storeHTTPSEndpoint(ctx, ""); err != nil {
-			log.Fatalf("failed to update HTTPS endpoint in tailscale state: %v", err)
+		if hasKubeStateStore(cfg) {
+			if err := kc.storeHTTPSEndpoint(ctx, ""); err != nil {
+				log.Fatalf("failed to update HTTPS endpoint in tailscale state: %v", err)
+			}
 		}
 	}
 

--- a/cmd/containerboot/serve.go
+++ b/cmd/containerboot/serve.go
@@ -72,8 +72,10 @@ func watchServeConfigChanges(ctx context.Context, path string, cdChanged <-chan 
 		if err := updateServeConfig(ctx, sc, certDomain, lc); err != nil {
 			log.Fatalf("serve proxy: error updating serve config: %v", err)
 		}
-		if err := kc.storeHTTPSEndpoint(ctx, certDomain); err != nil {
-			log.Fatalf("serve proxy: error storing HTTPS endpoint: %v", err)
+		if kc != nil {
+			if err := kc.storeHTTPSEndpoint(ctx, certDomain); err != nil {
+				log.Fatalf("serve proxy: error storing HTTPS endpoint: %v", err)
+			}
 		}
 		prevServeConfig = sc
 	}

--- a/cmd/containerboot/serve.go
+++ b/cmd/containerboot/serve.go
@@ -72,7 +72,7 @@ func watchServeConfigChanges(ctx context.Context, path string, cdChanged <-chan 
 		if err := updateServeConfig(ctx, sc, certDomain, lc); err != nil {
 			log.Fatalf("serve proxy: error updating serve config: %v", err)
 		}
-		if kc != nil {
+		if kc != nil && kc.canPatch {
 			if err := kc.storeHTTPSEndpoint(ctx, certDomain); err != nil {
 				log.Fatalf("serve proxy: error storing HTTPS endpoint: %v", err)
 			}

--- a/cmd/containerboot/settings.go
+++ b/cmd/containerboot/settings.go
@@ -214,6 +214,7 @@ func (cfg *settings) setupKube(ctx context.Context, kc *kubeClient) error {
 		return fmt.Errorf("some Kubernetes permissions are missing, please check your RBAC configuration: %v", err)
 	}
 	cfg.KubernetesCanPatch = canPatch
+	kc.canPatch = canPatch
 
 	s, err := kc.GetSecret(ctx, cfg.KubeSecret)
 	if err != nil {


### PR DESCRIPTION
This is a cherry-pick that contains the three PRs that fixed the nil pointer exception for 1.78.1 Tailscale containers with `TS_SERVE_CONFIG` set (https://github.com/tailscale/tailscale/issues/14354):
- https://github.com/tailscale/tailscale/pull/14357
- https://github.com/tailscale/tailscale/pull/14358
- https://github.com/tailscale/tailscale/pull/14365

