### PR TITLE
cmd/containerboot: add more tests, check that egress service config  is only set when running on kube

### DIFF
--- a/cmd/containerboot/settings.go
+++ b/cmd/containerboot/settings.go
@@ -199,6 +199,9 @@ func (s *settings) validate() error {
 	if s.HealthCheckEnabled && s.HealthCheckAddrPort != "" {
 		return errors.New("TS_HEALTHCHECK_ADDR_PORT is deprecated and will be removed in 1.82.0, use TS_ENABLE_HEALTH_CHECK and optionally TS_LOCAL_ADDR_PORT")
 	}
+	if s.EgressSvcsCfgPath != "" && !(s.InKubernetes && s.KubeSecret != "") {
+		return errors.New("TS_EGRESS_SERVICES_CONFIG_PATH is only supported for Tailscale running on Kubernetes")
+	}
 	return nil
 }
 


### PR DESCRIPTION
Add more tests for containerboot startup (including that would have caught https://github.com/tailscale/tailscale/pull/14357), add a validation that egress services config is only set for instances running on Kubernetes.

Updates tailscale/tailscale#14357