### PR TITLE
cmd/containerboot: don't attempt to patch a Secret field without permissions

### DIFF
--- a/cmd/containerboot/kube.go
+++ b/cmd/containerboot/kube.go
@@ -24,6 +24,7 @@ import (
 type kubeClient struct {
 	kubeclient.Client
 	stateSecret string
+	canPatch    bool // whether the client has permissions to patch Kubernetes Secrets
 }
 
 func newKubeClient(root string, stateSecret string) (*kubeClient, error) {

--- a/cmd/containerboot/serve.go
+++ b/cmd/containerboot/serve.go
@@ -72,7 +72,7 @@ func watchServeConfigChanges(ctx context.Context, path string, cdChanged <-chan 
 		if err := updateServeConfig(ctx, sc, certDomain, lc); err != nil {
 			log.Fatalf("serve proxy: error updating serve config: %v", err)
 		}
-		if kc != nil {
+		if kc != nil && kc.canPatch {
 			if err := kc.storeHTTPSEndpoint(ctx, certDomain); err != nil {
 				log.Fatalf("serve proxy: error storing HTTPS endpoint: %v", err)
 			}

--- a/cmd/containerboot/settings.go
+++ b/cmd/containerboot/settings.go
@@ -217,6 +217,7 @@ func (cfg *settings) setupKube(ctx context.Context, kc *kubeClient) error {
 		return fmt.Errorf("some Kubernetes permissions are missing, please check your RBAC configuration: %v", err)
 	}
 	cfg.KubernetesCanPatch = canPatch
+	kc.canPatch = canPatch
 
 	s, err := kc.GetSecret(ctx, cfg.KubeSecret)
 	if err != nil {


### PR DESCRIPTION
We can still have some Kubernetes clients running that don't have PATCH permissions against the state Secret (maybe?). Check for PATCH permissions before attempting to write Secret field.