### PR TITLE
tailcfg: rename and retype ServiceHost capability

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -2398,8 +2398,11 @@ const (
 	NodeAttrSSHEnvironmentVariables NodeCapability = "ssh-env-vars"
 
 	// NodeAttrServiceHost grants a peer the ability to serve as a host for a
-	// set of given VIP services. The value of this key in [NodeCapMap] is
-	// of type [ServiceIPMappings].
+	// set of given VIP services. A service host is a Tailscale node that can
+	// act as a provider for a VIP service (ie. fulfills all the port mapping
+	// requirements set up in control), and opts into acting as a provider
+	// (by using `tailscale advertise`).
+	// The value of this key in [NodeCapMap] is of type [ServiceIPMappings].
 	NodeAttrServiceHost NodeCapability = "service-host"
 )
 
@@ -2896,6 +2899,8 @@ const LBHeader = "Ts-Lb"
 //	  "svc:web": ["100.102.42.3", "fd7a:115c:a1e0::abcd"],
 //	}
 //
-// where the IP addresses are the IPs of the VIP services that the service host
-// is expected to add to its AllowedIPs.
+// where the IP addresses are the IPs of the VIP services. These IPs are also
+// provided in AllowedIPs, but this lets the client know which services
+// correspond to those IPs. Any service IPs in AllowedIPs that don't correspond
+// to a service this client is hosting can be ignored by it.
 type ServiceIPMappings map[string][]netip.Addr

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -1453,11 +1453,6 @@ const (
 	// user groups as Kubernetes user groups. This capability is read by
 	// peers that are Tailscale Kubernetes operator instances.
 	PeerCapabilityKubernetes PeerCapability = "tailscale.com/cap/kubernetes"
-
-	// PeerCapabilityServicesDestination grants a peer the ability to serve as
-	// a destination for a set of given VIP services, which is provided as the
-	// value of this key in NodeCapMap.
-	PeerCapabilityServicesDestination PeerCapability = "tailscale.com/cap/services-destination"
 )
 
 // NodeCapMap is a map of capabilities to their optional values. It is valid for
@@ -2401,6 +2396,11 @@ const (
 	// NodeAttrSSHEnvironmentVariables enables logic for handling environment variables sent
 	// via SendEnv in the SSH server and applying them to the SSH session.
 	NodeAttrSSHEnvironmentVariables NodeCapability = "ssh-env-vars"
+
+	// NodeAttrServiceHost grants a peer the ability to serve as a host for a
+	// set of given VIP services. The value of this key in [NodeCapMap] is
+	// of type [ServiceIPMappings].
+	NodeAttrServiceHost NodeCapability = "service-host"
 )
 
 // SetDNSRequest is a request to add a DNS record.
@@ -2883,3 +2883,19 @@ type EarlyNoise struct {
 // For some request types, the header may have multiple values. (e.g. OldNodeKey
 // vs NodeKey)
 const LBHeader = "Ts-Lb"
+
+// ServiceIPMappings maps service names (strings that conform to
+// [CheckServiceName]) to lists of IP addresses. This is used as the value of
+// the [NodeAttrServiceHost] capability, to inform service hosts what IP
+// addresses they need to listen on for each service that they are advertising.
+//
+// This is of the form:
+//
+//	{
+//	  "svc:samba": ["100.65.32.1", "fd7a:115c:a1e0::1234"],
+//	  "svc:web": ["100.102.42.3", "fd7a:115c:a1e0::abcd"],
+//	}
+//
+// where the IP addresses are the IPs of the VIP services that the service host
+// is expected to add to its AllowedIPs.
+type ServiceIPMappings map[string][]netip.Addr

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -2397,12 +2397,13 @@ const (
 	// via SendEnv in the SSH server and applying them to the SSH session.
 	NodeAttrSSHEnvironmentVariables NodeCapability = "ssh-env-vars"
 
-	// NodeAttrServiceHost grants a peer the ability to serve as a host for a
-	// set of given VIP services. A service host is a Tailscale node that can
-	// act as a provider for a VIP service (ie. fulfills all the port mapping
-	// requirements set up in control), and opts into acting as a provider
-	// (by using `tailscale advertise`).
-	// The value of this key in [NodeCapMap] is of type [ServiceIPMappings].
+	// NodeAttrServiceHost indicates the VIP Services for which the client is
+	// approved to act as a service host, and which IP addresses are assigned
+	// to those VIP Services. Any VIP Services that the client is not
+	// advertising can be ignored.
+	// Each value of this key in [NodeCapMap] is of type [ServiceIPMappings].
+	// If multiple values of this key exist, they should be merged in sequence
+	// (replace conflicting keys)..
 	NodeAttrServiceHost NodeCapability = "service-host"
 )
 
@@ -2901,6 +2902,6 @@ const LBHeader = "Ts-Lb"
 //
 // where the IP addresses are the IPs of the VIP services. These IPs are also
 // provided in AllowedIPs, but this lets the client know which services
-// correspond to those IPs. Any service IPs in AllowedIPs that don't correspond
-// to a service this client is hosting can be ignored by it.
+// correspond to those IPs. Any services that don't correspond to a service
+// this client is hosting can be ignored.
 type ServiceIPMappings map[string][]netip.Addr

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -2403,7 +2403,7 @@ const (
 	// advertising can be ignored.
 	// Each value of this key in [NodeCapMap] is of type [ServiceIPMappings].
 	// If multiple values of this key exist, they should be merged in sequence
-	// (replace conflicting keys)..
+	// (replace conflicting keys).
 	NodeAttrServiceHost NodeCapability = "service-host"
 )
 


### PR DESCRIPTION
Updates tailscale/corp#22743.

In #14046, this was accidentally made a PeerCapability when it should have been NodeCapability. Also, renaming it to use the nomenclature that we decided on after #14046 went up (ServiceHost instead of ServiceDestination).

This shouldn't break anything, since no one was using this string or variable yet.