### PR TITLE
cmd/k8s-operator: auto sign node keys in locked tailnet

### DIFF
--- a/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
+++ b/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
@@ -89,6 +89,8 @@ spec:
               value: {{ .Values.loginServer }}
             - name: OPERATOR_INGRESS_CLASS_NAME
               value: {{ .Values.ingressClass.name }}
+            - name: OPERATOR_AUTO_SIGN_NODE_KEYS
+              value: {{ .Values.operatorConfig.autoSignNodeKeys | quote }}
             {{- if .Values.oauthSecretVolume }}
             - name: CLIENT_ID_FILE
               value: /oauth/client_id

--- a/cmd/k8s-operator/deploy/chart/values.yaml
+++ b/cmd/k8s-operator/deploy/chart/values.yaml
@@ -47,6 +47,12 @@ operatorConfig:
   defaultTags:
     - "tag:k8s-operator"
 
+  # Automatically sign node keys. If set to true, the operator will automatically
+  # sign node keys for devices it manages when running in a locked tailnet.
+  # In order for devices to be trusted, the operator's public lock key must be a
+  # trusted signer in the tailnet.
+  autoSignNodeKeys: true
+
   image:
     # Repository defaults to DockerHub, but images are also synced to ghcr.io/tailscale/k8s-operator.
     repository: tailscale/k8s-operator

--- a/cmd/k8s-operator/deploy/manifests/operator.yaml
+++ b/cmd/k8s-operator/deploy/manifests/operator.yaml
@@ -6579,6 +6579,8 @@ spec:
                       value: null
                     - name: OPERATOR_INGRESS_CLASS_NAME
                       value: tailscale
+                    - name: OPERATOR_AUTO_SIGN_NODE_KEYS
+                      value: "true"
                     - name: CLIENT_ID_FILE
                       value: /oauth/client_id
                     - name: CLIENT_SECRET_FILE

--- a/cmd/k8s-operator/node-key-signer.go
+++ b/cmd/k8s-operator/node-key-signer.go
@@ -1,0 +1,144 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !plan9
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/kube/kubetypes"
+	"tailscale.com/tailcfg"
+	"tailscale.com/types/key"
+)
+
+const (
+	longReque = 60 * time.Second
+)
+
+var (
+	errOperatorUntrusted = errors.New("operator key is not trusted by the network")
+)
+
+type tsLocalClient interface {
+	NetworkLockStatus(ctx context.Context) (*ipnstate.NetworkLockStatus, error)
+	NetworkLockSign(ctx context.Context, nodeKey key.NodePublic, verifier []byte) error
+}
+
+// NodeKeySignerReconciler is responsible for signing node keys for devices
+// managed by the tailscale operator. It does this by watching for changes to
+// secrets managed by the operator and signing the device node key with the
+// operator's lock key. If the network is not locked, it does nothing.
+type NodeKeySignerReconciler struct {
+	client.Client
+	logger        *zap.SugaredLogger
+	tsLocalClient tsLocalClient
+}
+
+func (a *NodeKeySignerReconciler) Reconcile(ctx context.Context, req reconcile.Request) (_ reconcile.Result, err error) {
+	logger := a.logger.With("secret-namespace", req.Namespace, "secret-name", req.Name)
+	logger.Debugf("starting reconcile")
+	defer logger.Debugf("reconcile finished")
+
+	secret := new(corev1.Secret)
+	err = a.Get(ctx, req.NamespacedName, secret)
+	if apierrors.IsNotFound(err) {
+		// Secret not found, could have been deleted after reconcile request.
+		logger.Debugf("secret not found, assuming it was deleted")
+		return reconcile.Result{}, nil
+	} else if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to get secret: %w", err)
+	}
+
+	if !secret.DeletionTimestamp.IsZero() {
+		// StatefulSet is being deleted, nothing to do.
+		logger.Debugf("secret is being deleted, skipping")
+		return reconcile.Result{}, nil
+	}
+
+	if !isManagedResource(secret) {
+		logger.Debugf("secret is not managed by the tailscale operator, skipping")
+		return reconcile.Result{}, nil
+	}
+
+	if done, err := a.signNodeKey(ctx, logger, secret); errors.Is(err, errOperatorUntrusted) {
+		return reconcile.Result{RequeueAfter: longReque}, nil
+	} else if !done {
+		return reconcile.Result{RequeueAfter: shortRequeue}, nil
+	} else if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to sign node key: %w", err)
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// signNodeKey signs the device node key with the operator's lock key if the
+// network is locked. It does nothing if the network is not locked or if the
+// device node key is already signed.
+// If the device is not ready to be signed yet and should be retried, it returns
+// false. If the device is signed or an error occurs, it returns true.
+func (a *NodeKeySignerReconciler) signNodeKey(ctx context.Context, logger *zap.SugaredLogger, secret *corev1.Secret) (bool, error) {
+	deviceId := tailcfg.StableNodeID(secret.Data[kubetypes.KeyDeviceID])
+	if deviceId.IsZero() {
+		logger.Debug("NodeID is empty. It may not be populated yet")
+		return false, nil
+	}
+
+	lockStatus, err := a.tsLocalClient.NetworkLockStatus(ctx)
+	if err != nil {
+		return true, fmt.Errorf("failed to get network lock status: %w", err)
+	}
+
+	if !lockStatus.Enabled {
+		logger.Debugf("Tailnet is not locked, skipping node key signing")
+		return true, nil
+	}
+
+	if findTKAPeerByStableID(lockStatus.VisiblePeers, deviceId) != nil {
+		// Device is a visible peer, no need to sign its node key.
+		return true, nil
+	}
+
+	// Check if the operator's lock key is trusted.
+	if !slices.ContainsFunc(lockStatus.TrustedKeys, func(k ipnstate.TKAKey) bool {
+		return lockStatus.PublicKey.Equal(k.Key)
+	}) {
+		logger.Warnf("Operator key is not trusted by the network. Add %q to the trusted signer keys", lockStatus.PublicKey.CLIString())
+		return true, errOperatorUntrusted
+	}
+
+	devicePeer := findTKAPeerByStableID(lockStatus.FilteredPeers, deviceId)
+	if devicePeer == nil {
+		logger.Debugf("Device %q is not found in filtered peers list, deferring signing", deviceId)
+		return false, nil
+	}
+
+	// Lock is enabled, but the device node key is not signed yet.
+	logger.Infof("Network is locked. Attempting to sign device node key with operator key %q", lockStatus.PublicKey.CLIString())
+
+	if err := a.tsLocalClient.NetworkLockSign(ctx, devicePeer.NodeKey, []byte(lockStatus.PublicKey.Verifier())); err != nil {
+		return true, fmt.Errorf("failed to sign node key: %w", err)
+	}
+
+	return true, nil
+}
+
+func findTKAPeerByStableID(peers []*ipnstate.TKAPeer, deviceId tailcfg.StableNodeID) *ipnstate.TKAPeer {
+	for _, p := range peers {
+		if p.StableID == deviceId {
+			return p
+		}
+	}
+	return nil
+}

--- a/cmd/k8s-operator/node-key-signer_test.go
+++ b/cmd/k8s-operator/node-key-signer_test.go
@@ -1,0 +1,284 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !plan9
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"tailscale.com/ipn/ipnstate"
+	tsapi "tailscale.com/k8s-operator/apis/v1alpha1"
+	"tailscale.com/kube/kubetypes"
+	"tailscale.com/tailcfg"
+	"tailscale.com/types/key"
+)
+
+var (
+	fakeOperatorPublic = key.NewNLPrivate().Public()
+)
+
+type fakeTSLocalClient struct {
+	networkLockStatus *ipnstate.NetworkLockStatus
+	signResult        error
+}
+
+var _ tsLocalClient = &fakeTSLocalClient{}
+
+func newFakeTSLocalClient() *fakeTSLocalClient {
+	return &fakeTSLocalClient{
+		networkLockStatus: &ipnstate.NetworkLockStatus{
+			Enabled:   true,
+			PublicKey: fakeOperatorPublic,
+			TrustedKeys: []ipnstate.TKAKey{
+				{Key: fakeOperatorPublic},
+			},
+			VisiblePeers:  make([]*ipnstate.TKAPeer, 0),
+			FilteredPeers: make([]*ipnstate.TKAPeer, 0),
+		},
+	}
+}
+
+// NetworkLockSign implements tsLocalClient.
+func (f *fakeTSLocalClient) NetworkLockSign(ctx context.Context, nodeKey key.NodePublic, verifier []byte) error {
+	return f.signResult
+}
+
+// NetworkLockStatus implements tsLocalClient.
+func (f *fakeTSLocalClient) NetworkLockStatus(ctx context.Context) (*ipnstate.NetworkLockStatus, error) {
+	return f.networkLockStatus, nil
+}
+
+func TestNodeKeySignerReconciler_signNodeKey(t *testing.T) {
+	var (
+		ctx         = context.TODO()
+		nodeId      = "fake-node-id"
+		nodeTkaPeer = &ipnstate.TKAPeer{
+			StableID: tailcfg.StableNodeID(nodeId),
+			NodeKey:  key.NewNode().Public(),
+		}
+		signingError = fmt.Errorf("signing error")
+	)
+	tests := []struct {
+		name          string
+		mutationFn    func(*fakeTSLocalClient, *corev1.Secret)
+		expectedDone  bool
+		expectedError error
+		expectedLogs  []string
+	}{
+		{
+			name: "network unlocked",
+			mutationFn: func(lc *fakeTSLocalClient, _ *corev1.Secret) {
+				lc.networkLockStatus.Enabled = false
+			},
+			expectedDone:  true,
+			expectedError: nil,
+			expectedLogs:  []string{"Tailnet is not locked, skipping node key signing"},
+		},
+		{
+			name: "device is visible peer",
+			mutationFn: func(lc *fakeTSLocalClient, _ *corev1.Secret) {
+				lc.networkLockStatus.VisiblePeers = []*ipnstate.TKAPeer{nodeTkaPeer}
+			},
+			expectedDone:  true,
+			expectedError: nil,
+			expectedLogs:  []string{},
+		},
+		{
+			name: "operator key not trusted",
+			mutationFn: func(lc *fakeTSLocalClient, _ *corev1.Secret) {
+				lc.networkLockStatus.TrustedKeys = nil
+			},
+			expectedDone:  true,
+			expectedError: errOperatorUntrusted,
+			expectedLogs: []string{
+				fmt.Sprintf("Operator key is not trusted by the network. Add %q to the trusted signer keys", fakeOperatorPublic.CLIString()),
+			},
+		},
+		{
+			name: "device not ready",
+			mutationFn: func(_ *fakeTSLocalClient, sec *corev1.Secret) {
+				delete(sec.Data, kubetypes.KeyDeviceID)
+			},
+			expectedDone:  false,
+			expectedError: nil,
+			expectedLogs:  []string{"NodeID is empty. It may not be populated yet"},
+		},
+		{
+			name:          "device not filtered peer",
+			mutationFn:    func(_ *fakeTSLocalClient, _ *corev1.Secret) {},
+			expectedDone:  false,
+			expectedError: nil,
+			expectedLogs: []string{
+				fmt.Sprintf("Device %q is not found in filtered peers list, deferring signing", nodeId),
+			},
+		},
+		{
+			name: "successful signing",
+			mutationFn: func(lc *fakeTSLocalClient, _ *corev1.Secret) {
+				lc.networkLockStatus.FilteredPeers = []*ipnstate.TKAPeer{nodeTkaPeer}
+			},
+			expectedDone:  true,
+			expectedError: nil,
+			expectedLogs: []string{
+				fmt.Sprintf("Network is locked. Attempting to sign device node key with operator key %q", fakeOperatorPublic.CLIString()),
+			},
+		},
+		{
+			name: "signing error",
+			mutationFn: func(lc *fakeTSLocalClient, _ *corev1.Secret) {
+				lc.networkLockStatus.FilteredPeers = []*ipnstate.TKAPeer{nodeTkaPeer}
+				lc.signResult = signingError
+			},
+			expectedDone:  true,
+			expectedError: signingError,
+			expectedLogs: []string{
+				fmt.Sprintf("Network is locked. Attempting to sign device node key with operator key %q", fakeOperatorPublic.CLIString()),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observerCore, observedLogs := observer.New(zapcore.DebugLevel)
+			logger := zap.New(observerCore).Sugar()
+
+			secret := &corev1.Secret{
+				Data: map[string][]byte{
+					kubetypes.KeyDeviceID: []byte(nodeId),
+				},
+			}
+
+			lc := newFakeTSLocalClient()
+			tt.mutationFn(lc, secret)
+			r := &NodeKeySignerReconciler{
+				tsLocalClient: lc,
+			}
+
+			done, err := r.signNodeKey(ctx, logger, secret)
+			if !errors.Is(err, tt.expectedError) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if done != tt.expectedDone {
+				t.Errorf("unexpected retry")
+			}
+			if len(observedLogs.All()) != len(tt.expectedLogs) {
+				t.Errorf("unexpected number of logs: %v", observedLogs.All())
+			}
+			for i, log := range observedLogs.All() {
+				if log.Message != tt.expectedLogs[i] {
+					t.Errorf("unexpected log: %v", log.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestNodeKeySignerReconciler_Reconcile(t *testing.T) {
+	zl, err := zap.NewDevelopment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lc := newFakeTSLocalClient()
+	// Since we're just testing the reconciliation logic, we don't need to
+	// enable the network lock.
+	lc.networkLockStatus.Enabled = false
+
+	tests := []struct {
+		name           string
+		mutateFn       func(*corev1.Secret)
+		expectedResult reconcile.Result
+	}{
+		{
+			name:           "no error",
+			mutateFn:       func(sec *corev1.Secret) {},
+			expectedResult: reconcile.Result{},
+		},
+		{
+			name: "missing device id",
+			mutateFn: func(sec *corev1.Secret) {
+				delete(sec.Data, kubetypes.KeyDeviceID)
+			},
+			expectedResult: reconcile.Result{RequeueAfter: 5 * time.Second},
+		},
+		{
+			name: "missing secret",
+			mutateFn: func(sec *corev1.Secret) {
+				// change the name to not match the request
+				sec.ObjectMeta.Name = "different-name"
+			},
+			expectedResult: reconcile.Result{},
+		},
+		{
+			name: "deleting secret",
+			mutateFn: func(sec *corev1.Secret) {
+				sec.ObjectMeta.DeletionTimestamp = &metav1.Time{
+					Time: time.Now(),
+				}
+				sec.ObjectMeta.Finalizers = []string{"finalizer"}
+			},
+			expectedResult: reconcile.Result{},
+		},
+		{
+			name: "unmanaged secret",
+			mutateFn: func(sec *corev1.Secret) {
+				delete(sec.Labels, kubetypes.LabelManaged)
+			},
+			expectedResult: reconcile.Result{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						kubetypes.LabelManaged: "true",
+					},
+				},
+				Data: map[string][]byte{
+					kubetypes.KeyDeviceID: []byte("fake-node-id"),
+				},
+			}
+
+			request := reconcile.Request{
+				NamespacedName: client.ObjectKeyFromObject(secret),
+			}
+
+			tt.mutateFn(secret)
+			fc := fake.NewClientBuilder().
+				WithScheme(tsapi.GlobalScheme).
+				WithObjects(secret).
+				Build()
+
+			r := &NodeKeySignerReconciler{
+				Client:        fc,
+				logger:        zl.Sugar(),
+				tsLocalClient: lc,
+			}
+
+			result, err := r.Reconcile(context.TODO(), request)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(result, tt.expectedResult) {
+				t.Errorf("unexpected result: %v", result)
+			}
+
+		})
+	}
+}

--- a/cmd/k8s-operator/operator.go
+++ b/cmd/k8s-operator/operator.go
@@ -98,6 +98,7 @@ func main() {
 		loginServer           = strings.TrimSuffix(defaultEnv("OPERATOR_LOGIN_SERVER", ""), "/")
 		ingressClassName      = defaultEnv("OPERATOR_INGRESS_CLASS_NAME", "tailscale")
 		operatorSAName        = defaultEnv("OPERATOR_SERVICE_ACCOUNT_NAME", "operator")
+		autoSignNodeKeys      = defaultBool("OPERATOR_AUTO_SIGN_NODE_KEYS", true)
 	)
 
 	var opts []kzap.Opts
@@ -169,6 +170,7 @@ func main() {
 		defaultProxyClass:             defaultProxyClass,
 		loginServer:                   loginServer,
 		ingressClassName:              ingressClassName,
+		autoSignNodeKeys:              autoSignNodeKeys,
 	})
 }
 
@@ -771,6 +773,28 @@ func runReconcilers(opts reconcilerOpts) {
 		startlog.Fatalf("could not create ProxyGroup reconciler: %v", err)
 	}
 
+	// NodeKeySigner reconciler.
+	// Only start the NodeKeySigner reconciler if autoSignNodeKeys is set to true.
+	if opts.autoSignNodeKeys {
+		secFilter := handler.EnqueueRequestsFromMapFunc(managedSecretHandler(opts.tailscaleNamespace))
+		tsLocalClient, err := opts.tsServer.LocalClient()
+		if err != nil {
+			startlog.Fatalf("getting local tailscale client: %v", err)
+		}
+		err = builder.
+			ControllerManagedBy(mgr).
+			Named("node-key-signer-reconciler").
+			Watches(&corev1.Secret{}, secFilter).
+			Complete(&NodeKeySignerReconciler{
+				Client:        mgr.GetClient(),
+				logger:        opts.log.Named("node-key-signer-reconciler"),
+				tsLocalClient: tsLocalClient,
+			})
+		if err != nil {
+			startlog.Fatalf("could not create node key signer reconciler: %v", err)
+		}
+	}
+
 	startlog.Infof("Startup complete, operator running, version: %s", version.Long())
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
 		startlog.Fatalf("could not start manager: %v", err)
@@ -825,6 +849,9 @@ type reconcilerOpts struct {
 	// ServiceAccount when minting tokens via the Kubernetes TokenRequest API for Tailnets that authenticate using
 	// workload identity federation.
 	operatorSAName string
+	// autoSignNodeKeys determines whether the operator should sign node keys
+	// for the Tailscale nodes when the tailnet is locked.
+	autoSignNodeKeys bool
 }
 
 // enqueueAllIngressEgressProxySvcsinNS returns a reconcile request for each
@@ -1039,6 +1066,22 @@ func proxyClassHandlerForSvc(cl client.Client, logger *zap.SugaredLogger, defaul
 		}
 
 		return reqs
+	}
+}
+
+// managedSecretHandler filters Secret events to only those which
+// are managed by the operator.
+func managedSecretHandler(ns string) handler.MapFunc {
+	return func(_ context.Context, o client.Object) []reconcile.Request {
+		if o.GetNamespace() != ns {
+			return nil
+		}
+		if !isManagedResource(o) {
+			return nil
+		}
+		return []reconcile.Request{
+			{NamespacedName: client.ObjectKeyFromObject(o)},
+		}
 	}
 }
 


### PR DESCRIPTION
This adds support for running the k8s operator in a locked tailnet. When the operator is running in a locked tailnet, it will sign node keys for devices which it manages. This is done by adding a new reconciler to the operator, `node-key-signer`, which will sign node keys for managed devices using the operator's own key.

The `node-key-signer` reconciler is enabled by setting the `OPERATOR_AUTO_SIGN_NODE_KEYS` environment variable to `true` (which is the default).

In order for the operator to sign node keys, the operator's public lock key must be trusted by the tailnet. If it's not, a warning will be logged and the operator will not sign node keys.

If the tailnet is not locked, no operation will be performed.

Fixes #13273 