### PR TITLE
web: Support Host 100.100.100.100:80 in tailscaled web server

### DIFF
--- a/client/web/web.go
+++ b/client/web/web.go
@@ -318,7 +318,9 @@ func (s *Server) requireTailscaleIP(w http.ResponseWriter, r *http.Request) (han
 		ipv6ServiceHost = "[" + tsaddr.TailscaleServiceIPv6String + "]"
 	)
 	// allow requests on quad-100 (or ipv6 equivalent)
-	if r.Host == ipv4ServiceHost || r.Host == ipv6ServiceHost {
+	if r.Host == ipv4ServiceHost || r.Host == ipv6ServiceHost ||
+		r.Host == fmt.Sprintf("%s:%d", ipv4ServiceHost, 80) ||
+		r.Host == fmt.Sprintf("%s:%d", ipv6ServiceHost, 80) {
 		return false
 	}
 

--- a/client/web/web.go
+++ b/client/web/web.go
@@ -318,9 +318,8 @@ func (s *Server) requireTailscaleIP(w http.ResponseWriter, r *http.Request) (han
 		ipv6ServiceHost = "[" + tsaddr.TailscaleServiceIPv6String + "]"
 	)
 	// allow requests on quad-100 (or ipv6 equivalent)
-	if r.Host == ipv4ServiceHost || r.Host == ipv6ServiceHost ||
-		r.Host == fmt.Sprintf("%s:%d", ipv4ServiceHost, 80) ||
-		r.Host == fmt.Sprintf("%s:%d", ipv6ServiceHost, 80) {
+	host := strings.TrimSuffix(r.Host, ":80")
+	if host == ipv4ServiceHost || host == ipv6ServiceHost {
 		return false
 	}
 

--- a/client/web/web_test.go
+++ b/client/web/web_test.go
@@ -1175,6 +1175,16 @@ func TestRequireTailscaleIP(t *testing.T) {
 			target:      "http://[fd7a:115c:a1e0::53]/",
 			wantHandled: false,
 		},
+		{
+			name:        "quad-100:80",
+			target:      "http://100.100.100.100:80/",
+			wantHandled: false,
+		},
+		{
+			name:        "ipv6-service-addr:80",
+			target:      "http://[fd7a:115c:a1e0::53]:80/",
+			wantHandled: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This makes the web server running inside tailscaled on 100.100.100.100:80 support requests with
`Host: 100.100.100.100:80` and its IPv6 equivalent.

Prior to this commit, the web server replied to
such requests with a redirect to the node's Tailscale IP:5252.

This fix should be fine because:
1. Specifying port 80 in the Host header for requests to port 80 is permitted.
2. Prometheus, when pointed to scrape 100.100.100.100/metrics sends "Host: 100.100.100.100:80" and there's no way to make it not specify the port in that header.

Fixes https://github.com/tailscale/tailscale/issues/14415