### PR TITLE
cmd/systray: add extra padding around notification icon

### DIFF
--- a/cmd/systray/logo.go
+++ b/cmd/systray/logo.go
@@ -128,8 +128,14 @@ var (
 
 // render returns a PNG image of the logo.
 func (logo tsLogo) render() *bytes.Buffer {
-	const radius = 25
 	const borderUnits = 1
+	return logo.renderWithBorder(borderUnits)
+}
+
+// renderWithBorder returns a PNG image of the logo with the specified border width.
+// One border unit is equal to the radius of a tailscale logo dot.
+func (logo tsLogo) renderWithBorder(borderUnits int) *bytes.Buffer {
+	const radius = 25
 	dim := radius * (8 + borderUnits*2)
 
 	dc := gg.NewContext(dim, dim)

--- a/cmd/systray/systray.go
+++ b/cmd/systray/systray.go
@@ -62,7 +62,7 @@ func onReady() {
 
 	// dbus wants a file path for notification icons, so copy to a temp file.
 	appIcon, _ = os.CreateTemp("", "tailscale-systray.png")
-	io.Copy(appIcon, connected.render())
+	io.Copy(appIcon, connected.renderWithBorder(3))
 
 	chState = make(chan ipn.State, 1)
 


### PR DESCRIPTION
Some notification managers crop the application icon to a circle, so ensure we have enough padding to account for that.

Before and after with swaync configured to use circular application icons:

![icon-before](https://github.com/user-attachments/assets/604c7e98-724f-400a-b193-3e1a1c5572c6)
![icon-after](https://github.com/user-attachments/assets/232e55c3-bf9c-4f6b-976b-34d6de78bcd9)


Updates #1708

Change-Id: Ia101a4a3005adb9118051b3416f5a64a4a45987d