### PR TITLE
util/usermetric: add more drop labels

### DIFF
--- a/net/tstun/wrap.go
+++ b/net/tstun/wrap.go
@@ -874,12 +874,13 @@ func (t *Wrapper) filterPacketOutboundToWireGuard(p *packet.Parsed, pc *peerConf
 		return filter.Drop, gro
 	}
 
-	if filt.RunOut(p, t.filterFlags) != filter.Accept {
+	if resp, reason := filt.RunOut(p, t.filterFlags); resp != filter.Accept {
 		metricPacketOutDropFilter.Add(1)
-		// TODO(#14280): increment a t.metrics.outboundDroppedPacketsTotal here
-		// once we figure out & document what labels to use for multicast,
-		// link-local-unicast, IP fragments, etc. But they're not
-		// usermetric.ReasonACL.
+		if reason != "" {
+			t.metrics.outboundDroppedPacketsTotal.Add(usermetric.DropLabels{
+				Reason: reason,
+			}, 1)
+		}
 		return filter.Drop, gro
 	}
 

--- a/util/usermetric/metrics.go
+++ b/util/usermetric/metrics.go
@@ -41,6 +41,9 @@ const (
 	// ReasonFragment means that the packet was dropped because it was an IP fragment.
 	ReasonFragment DropReason = "fragment"
 
+	// ReasonUnknownProtocol means that the packet was dropped because it was an unknown protocol.
+	ReasonUnknownProtocol DropReason = "unknown_protocol"
+
 	// ReasonError means that the packet was dropped because of an error.
 	ReasonError DropReason = "error"
 )

--- a/util/usermetric/metrics.go
+++ b/util/usermetric/metrics.go
@@ -28,6 +28,19 @@ const (
 	// ReasonACL means that the packet was not permitted by ACL.
 	ReasonACL DropReason = "acl"
 
+	// ReasonMulticast means that the packet was dropped because it was a multicast packet.
+	ReasonMulticast DropReason = "multicast"
+
+	// ReasonLinkLocalUnicast means that the packet was dropped because it was a link-local unicast packet.
+	ReasonLinkLocalUnicast DropReason = "link_local_unicast"
+
+	// ReasonTooShort means that the packet was dropped because it was a bad packet,
+	// this could be due to a short packet.
+	ReasonTooShort DropReason = "too_short"
+
+	// ReasonFragment means that the packet was dropped because it was an IP fragment.
+	ReasonFragment DropReason = "fragment"
+
 	// ReasonError means that the packet was dropped because of an error.
 	ReasonError DropReason = "error"
 )

--- a/wgengine/filter/filter.go
+++ b/wgengine/filter/filter.go
@@ -621,6 +621,11 @@ func (f *Filter) pre(q *packet.Parsed, rf RunFlags, dir direction) (Response, us
 		return Drop, usermetric.ReasonTooShort
 	}
 
+	if q.IPProto == ipproto.Unknown {
+		f.logRateLimit(rf, q, dir, Drop, "unknown proto")
+		return Drop, usermetric.ReasonUnknownProtocol
+	}
+
 	if q.Dst.Addr().IsMulticast() {
 		f.logRateLimit(rf, q, dir, Drop, "multicast")
 		return Drop, usermetric.ReasonMulticast

--- a/wgengine/filter/filter_test.go
+++ b/wgengine/filter/filter_test.go
@@ -390,7 +390,8 @@ func TestPreFilter(t *testing.T) {
 	}{
 		{"empty", Accept, "", []byte{}},
 		{"short", Drop, usermetric.ReasonTooShort, []byte("short")},
-		{"junk", Drop, "", raw4default(ipproto.Unknown, 10)},
+		{"short-junk", Drop, usermetric.ReasonTooShort, raw4default(ipproto.Unknown, 10)},
+		{"long-junk", Drop, usermetric.ReasonUnknownProtocol, raw4default(ipproto.Unknown, 21)},
 		{"fragment", Accept, "", raw4default(ipproto.Fragment, 40)},
 		{"tcp", noVerdict, "", raw4default(ipproto.TCP, 0)},
 		{"udp", noVerdict, "", raw4default(ipproto.UDP, 0)},


### PR DESCRIPTION
This PR  adds back the outgoing drop metric that was removed in https://github.com/tailscale/tailscale/pull/14281.

This returns the most common drop reasons when we evaluate the package. We could instead instrument the filter struct with a metrics pointer, but it is quite a lot more involved so I wanted to hear opinions on this first.

Updates #14280

Signed-off-by: Kristoffer Dalby <kristoffer@tailscale.com>