### PR TITLE
cmd/k8s-operator,k8s-operator: include top-level CRD descriptions

### DIFF
--- a/cmd/k8s-operator/deploy/crds/tailscale.com_proxygroups.yaml
+++ b/cmd/k8s-operator/deploy/crds/tailscale.com_proxygroups.yaml
@@ -23,6 +23,17 @@ spec:
       name: v1alpha1
       schema:
         openAPIV3Schema:
+          description: |-
+            ProxyGroup defines a set of Tailscale devices that will act as proxies.
+            Currently only egress ProxyGroups are supported.
+
+            Use the tailscale.com/proxy-group annotation on a Service to specify that
+            the egress proxy should be implemented by a ProxyGroup instead of a single
+            dedicated proxy. In addition to running a highly available set of proxies,
+            ProxyGroup also allows for serving many annotated Services from a single
+            set of proxies to minimise resource consumption.
+
+            More info: https://tailscale.com/kb/1438/kubernetes-operator-cluster-egress
           type: object
           required:
             - spec

--- a/cmd/k8s-operator/deploy/crds/tailscale.com_recorders.yaml
+++ b/cmd/k8s-operator/deploy/crds/tailscale.com_recorders.yaml
@@ -27,6 +27,12 @@ spec:
       name: v1alpha1
       schema:
         openAPIV3Schema:
+          description: |-
+            Recorder defines a tsrecorder device for recording SSH sessions. By default,
+            it will store recordings in a local ephemeral volume. If you want to persist
+            recordings, you can configure an S3-compatible API for storage.
+
+            More info: https://tailscale.com/kb/1484/kubernetes-operator-deploying-tsrecorder
           type: object
           required:
             - spec

--- a/cmd/k8s-operator/deploy/manifests/operator.yaml
+++ b/cmd/k8s-operator/deploy/manifests/operator.yaml
@@ -2724,6 +2724,17 @@ spec:
           name: v1alpha1
           schema:
             openAPIV3Schema:
+                description: |-
+                    ProxyGroup defines a set of Tailscale devices that will act as proxies.
+                    Currently only egress ProxyGroups are supported.
+
+                    Use the tailscale.com/proxy-group annotation on a Service to specify that
+                    the egress proxy should be implemented by a ProxyGroup instead of a single
+                    dedicated proxy. In addition to running a highly available set of proxies,
+                    ProxyGroup also allows for serving many annotated Services from a single
+                    set of proxies to minimise resource consumption.
+
+                    More info: https://tailscale.com/kb/1438/kubernetes-operator-cluster-egress
                 properties:
                     apiVersion:
                         description: |-
@@ -2916,6 +2927,12 @@ spec:
           name: v1alpha1
           schema:
             openAPIV3Schema:
+                description: |-
+                    Recorder defines a tsrecorder device for recording SSH sessions. By default,
+                    it will store recordings in a local ephemeral volume. If you want to persist
+                    recordings, you can configure an S3-compatible API for storage.
+
+                    More info: https://tailscale.com/kb/1484/kubernetes-operator-deploying-tsrecorder
                 properties:
                     apiVersion:
                         description: |-

--- a/k8s-operator/api.md
+++ b/k8s-operator/api.md
@@ -508,7 +508,16 @@ _Appears in:_
 
 
 
+ProxyGroup defines a set of Tailscale devices that will act as proxies.
+Currently only egress ProxyGroups are supported.
 
+Use the tailscale.com/proxy-group annotation on a Service to specify that
+the egress proxy should be implemented by a ProxyGroup instead of a single
+dedicated proxy. In addition to running a highly available set of proxies,
+ProxyGroup also allows for serving many annotated Services from a single
+set of proxies to minimise resource consumption.
+
+More info: https://tailscale.com/kb/1438/kubernetes-operator-cluster-egress
 
 
 
@@ -602,7 +611,11 @@ _Appears in:_
 
 
 
+Recorder defines a tsrecorder device for recording SSH sessions. By default,
+it will store recordings in a local ephemeral volume. If you want to persist
+recordings, you can configure an S3-compatible API for storage.
 
+More info: https://tailscale.com/kb/1484/kubernetes-operator-deploying-tsrecorder
 
 
 

--- a/k8s-operator/apis/v1alpha1/types_proxygroup.go
+++ b/k8s-operator/apis/v1alpha1/types_proxygroup.go
@@ -14,6 +14,16 @@ import (
 // +kubebuilder:resource:scope=Cluster,shortName=pg
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=`.status.conditions[?(@.type == "ProxyGroupReady")].reason`,description="Status of the deployed ProxyGroup resources."
 
+// ProxyGroup defines a set of Tailscale devices that will act as proxies.
+// Currently only egress ProxyGroups are supported.
+//
+// Use the tailscale.com/proxy-group annotation on a Service to specify that
+// the egress proxy should be implemented by a ProxyGroup instead of a single
+// dedicated proxy. In addition to running a highly available set of proxies,
+// ProxyGroup also allows for serving many annotated Services from a single
+// set of proxies to minimise resource consumption.
+//
+// More info: https://tailscale.com/kb/1438/kubernetes-operator-cluster-egress
 type ProxyGroup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/k8s-operator/apis/v1alpha1/types_recorder.go
+++ b/k8s-operator/apis/v1alpha1/types_recorder.go
@@ -16,6 +16,11 @@ import (
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=`.status.conditions[?(@.type == "RecorderReady")].reason`,description="Status of the deployed Recorder resources."
 // +kubebuilder:printcolumn:name="URL",type="string",JSONPath=`.status.devices[?(@.url != "")].url`,description="URL on which the UI is exposed if enabled."
 
+// Recorder defines a tsrecorder device for recording SSH sessions. By default,
+// it will store recordings in a local ephemeral volume. If you want to persist
+// recordings, you can configure an S3-compatible API for storage.
+//
+// More info: https://tailscale.com/kb/1484/kubernetes-operator-deploying-tsrecorder
 type Recorder struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
When reading https://doc.crds.dev/github.com/tailscale/tailscale/tailscale.com/ProxyGroup/v1alpha1@v1.78.3 I noticed there is no top-level description for ProxyGroup and Recorder. Add one to give some high-level direction.

Updates #cleanup

Change-Id: I3666c5445be272ea5a1d4d02b6d5ad4c23afb09f