### PR TITLE
prober: make histogram buckets cumulative

### DIFF
--- a/prober/histogram.go
+++ b/prober/histogram.go
@@ -45,6 +45,5 @@ func (h *histogram) add(v float64) {
 			continue
 		}
 		h.bucketedCounts[b] += 1
-		break
 	}
 }

--- a/prober/histogram_test.go
+++ b/prober/histogram_test.go
@@ -23,7 +23,7 @@ func TestHistogram(t *testing.T) {
 	if diff := cmp.Diff(h.sum, 7.5); diff != "" {
 		t.Errorf("wrong sum; (-got+want):%v", diff)
 	}
-	if diff := cmp.Diff(h.bucketedCounts, map[float64]uint64{1: 2, 2: 2}); diff != "" {
+	if diff := cmp.Diff(h.bucketedCounts, map[float64]uint64{1: 2, 2: 4}); diff != "" {
 		t.Errorf("wrong bucketedCounts; (-got+want):%v", diff)
 	}
 }


### PR DESCRIPTION
Histogram buckets should include counts for all values under the bucket ceiling, not just those between the ceiling and the next lower ceiling.

See https://prometheus.io/docs/tutorials/understanding_metric_types/#histogram

Updates tailscale/corp#24522