### PR TITLE
scripts/installer.sh: accept different capitalisation of deepin

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -154,7 +154,7 @@ main() {
 					APT_KEY_TYPE="keyring"
 				fi
 				;;
-			Deepin)  # https://github.com/tailscale/tailscale/issues/7862
+			Deepin|deepin)  # https://github.com/tailscale/tailscale/issues/7862
 				OS="debian"
 				PACKAGETYPE="apt"
 				if [ "$VERSION_ID" -lt 20 ]; then


### PR DESCRIPTION
Newer Deepin Linux versions use `deepin` as their ID, older ones used `Deepin`. 
Change makes the script not break on Deepin 23. Tested in VM.

Fixes #13570