### PR TITLE
Reference tailscale in cli switch command description

### DIFF
--- a/cmd/tailscale/cli/switch.go
+++ b/cmd/tailscale/cli/switch.go
@@ -22,7 +22,7 @@ var switchCmd = &ffcli.Command{
 	ShortUsage: "tailscale switch <id>",
 	ShortHelp:  "Switches to a different Tailscale account",
 	LongHelp: `"tailscale switch" switches between logged in accounts. You can
-use the ID that's returned from 'tailnet switch -list'
+use the ID that's returned from 'tailscale switch -list'
 to pick which profile you want to switch to. Alternatively, you
 can use the Tailnet or the account names to switch as well.
 


### PR DESCRIPTION
The `switch` command's long description incorrectly references `tailnet switch -list`. Update this text so that it uses the correct form:  `tailscale switch -list`.

Updates: #14468