### PR TITLE
scripts/install.sh: add special case for Parrot Security

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -68,6 +68,14 @@ main() {
 				if [ -z "${VERSION_ID:-}" ]; then
 					# rolling release. If you haven't kept current, that's on you.
 					APT_KEY_TYPE="keyring"
+				# Parrot Security is a special case that uses ID=debian
+				elif [ "$NAME" = "Parrot Security" ]; then
+					# All versions new enough to have this behaviour prefer keyring
+					# and their VERSION_ID is not consistent with Debian.
+					APT_KEY_TYPE="keyring"
+					# They don't specify the Debian version they're based off in os-release
+					# but Parrot 6 is based on Debian 12 Bookworm.
+					VERSION=bookworm
 				elif [ "$VERSION_ID" -lt 11 ]; then
 					APT_KEY_TYPE="legacy"
 				else


### PR DESCRIPTION
Their `os-release` doesn't follow convention, so we do some special casing to get it work. 

Specifically note the lack of an `ID_LIKE` and the `ID` being Debian rather than the ID of their distro like other derivatives. 

The script interprets this as being Debian Lory which obviously isn't a thing so it fails to supported version check. We capture this based on `NAME` (the only consistent value, not ideal to match on but there aren't many other choices) and rewrite it to Debian Bookworm so that the script succeeds its checks.

Make sure the Actions tests pass before approving/merging, there are tests for Debian and for Parrot Security.

Fixes https://github.com/tailscale/tailscale/issues/10778

old:
```
$ docker run -it parrotsec/core:lts-amd64
┌─[root@718076d0be7e]─[/]
└──╼ #cat /etc/os-release
PRETTY_NAME="Parrot OS 5.1 (Electro Ara)"
NAME="Parrot OS"
VERSION_ID="5.1"
VERSION="5.1 (Electro Ara)"
VERSION_CODENAME=ara
ID=parrot
ID_LIKE=debian
HOME_URL="https://www.parrotsec.org/"
SUPPORT_URL="https://community.parrotsec.org/"
BUG_REPORT_URL="https://community.parrotsec.org/"
```

to new:
```
$ docker run -it parrotsec/core:latest
Unable to find image 'parrotsec/core:latest' locally
latest: Pulling from parrotsec/core
db573f9d7b0a: Pull complete
160642ab8191: Pull complete
Digest: sha256:3d0f045b4760984efba40728585fca47f3d4d9cf852a16d907a96365010072b1
Status: Downloaded newer image for parrotsec/core:latest
┌─[root@f39c822d9599]─[/]
└──╼ #cat /etc/os-release
PRETTY_NAME="Parrot Security 6.2 (lorikeet)"
NAME="Parrot Security"
VERSION_ID="6.2"
VERSION="6.2 (lorikeet)"
VERSION_CODENAME=lory
ID=debian
HOME_URL="https://www.parrotsec.org/"
SUPPORT_URL="https://www.parrotsec.org/community/"
BUG_REPORT_URL="https://gitlab.com/parrotsec/"
```