### PR TITLE
flake.nix: use ./tool instead of nixpkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -111,6 +111,10 @@
         tailscale = ts;
       };
       devShell = pkgs.mkShell {
+        shellHook = ''
+          export PATH=$PWD/tool:$PATH
+        '';
+
         packages = with pkgs; [
           curl
           git
@@ -118,8 +122,6 @@
           gotools
           graphviz
           perl
-          go_1_23
-          yarn
 
           # qemu and e2fsprogs are needed for natlab
           qemu

--- a/tool/helm
+++ b/tool/helm
@@ -32,36 +32,25 @@ fi
 
     if [[ "$want_rev" != "$got_rev" ]]; then
         rm -rf "$cachedir" "$tarball"
-        if [[ -n "${IN_NIX_SHELL:-}" ]]; then
-            nix_helm="$(which -a helm | grep /nix/store | head -1)"
-            nix_helm="${nix_helm%/helm}"
-            nix_helm_rev="${nix_helm##*-}"
-            if [[ "$nix_helm_rev" != "$want_rev" ]]; then
-                echo "Wrong helm version in Nix, got $nix_helm_rev want $want_rev" >&2
-		        exit 1
-            fi
-            ln -sf "$nix_helm" "$cachedir"
-        else
-            # works for linux and darwin
-            # https://github.com/helm/helm/releases
-            OS=$(uname -s | tr A-Z a-z)
-            ARCH=$(uname -m)
-            if [ "$ARCH" = "x86_64" ]; then
-                ARCH="amd64"
-            fi
-            if [ "$ARCH" = "aarch64" ]; then
-                ARCH="arm64"
-            fi
-            mkdir -p "$cachedir"
-            # When running on GitHub in CI, the below curl sometimes fails with
-            # INTERNAL_ERROR after finishing the download. The most common cause
-            # of INTERNAL_ERROR is glitches in intermediate hosts handling of
-            # HTTP/2 forwarding, so forcing HTTP 1.1 often fixes the issue. See
-            # https://github.com/tailscale/tailscale/issues/8988
-	        curl -f -L --http1.1 -o "$tarball" -sSL "https://get.helm.sh/helm-v${want_rev}-${OS}-${ARCH}.tar.gz"
-            (cd "$cachedir" && tar --strip-components=1 -xf "$tarball")
-            rm -f "$tarball"
+        # works for linux and darwin
+        # https://github.com/helm/helm/releases
+        OS=$(uname -s | tr A-Z a-z)
+        ARCH=$(uname -m)
+        if [ "$ARCH" = "x86_64" ]; then
+            ARCH="amd64"
         fi
+        if [ "$ARCH" = "aarch64" ]; then
+            ARCH="arm64"
+        fi
+        mkdir -p "$cachedir"
+        # When running on GitHub in CI, the below curl sometimes fails with
+        # INTERNAL_ERROR after finishing the download. The most common cause
+        # of INTERNAL_ERROR is glitches in intermediate hosts handling of
+        # HTTP/2 forwarding, so forcing HTTP 1.1 often fixes the issue. See
+        # https://github.com/tailscale/tailscale/issues/8988
+	    curl -f -L --http1.1 -o "$tarball" -sSL "https://get.helm.sh/helm-v${want_rev}-${OS}-${ARCH}.tar.gz"
+        (cd "$cachedir" && tar --strip-components=1 -xf "$tarball")
+        rm -f "$tarball"
     fi
 )
 


### PR DESCRIPTION
This ensure consistency between tooling used by nix and non-nix users.

Updates tailscale/corp#25620

Signed-off-by: Kristoffer Dalby <kristoffer@tailscale.com>