### PR TITLE
cmd/tailscale/cli: fix TestUpdatePrefs on macOS

### DIFF
--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -379,7 +379,7 @@ func updatePrefs(prefs, curPrefs *ipn.Prefs, env upCheckEnv) (simpleUp bool, jus
 		return false, nil, err
 	}
 
-	if runtime.GOOS == "darwin" && env.upArgs.advertiseConnector {
+	if env.goos == "darwin" && env.upArgs.advertiseConnector {
 		if err := presentRiskToUser(riskMacAppConnector, riskMacAppConnectorMessage, env.upArgs.acceptedRisks); err != nil {
 			return false, nil, err
 		}


### PR DESCRIPTION
It was failing about an unaccepted risk ("mac-app-connector") because
it was checking runtime.GOOS ("darwin") instead of the test's env.goos
string value ("linux", which doesn't have the warning).

Fixes #14544
