### PR TITLE
client/systray: move cmd/systray to client/systray

### DIFF
--- a/client/systray/logo.go
+++ b/client/systray/logo.go
@@ -3,7 +3,7 @@
 
 //go:build cgo || !darwin
 
-package main
+package systray
 
 import (
 	"bytes"

--- a/client/systray/systray.go
+++ b/client/systray/systray.go
@@ -3,8 +3,8 @@
 
 //go:build cgo || !darwin
 
-// The systray command is a minimal Tailscale systray application for Linux.
-package main
+// Package systray provides a minimal Tailscale systray application.
+package systray
 
 import (
 	"context"
@@ -44,8 +44,8 @@ var (
 	hideMullvadCities bool
 )
 
-func main() {
-	menu := new(Menu)
+// Run starts the systray menu and blocks until the menu exits.
+func (menu *Menu) Run() {
 	menu.updateState()
 
 	// exit cleanly on SIGINT and SIGTERM

--- a/cmd/systray/systray.go
+++ b/cmd/systray/systray.go
@@ -1,0 +1,15 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build cgo || !darwin
+
+// systray is a minimal Tailscale systray application.
+package main
+
+import (
+	"tailscale.com/client/systray"
+)
+
+func main() {
+	new(systray.Menu).Run()
+}


### PR DESCRIPTION
Move `cmd/systray` to `client/systray`, and then make `cmd/systray` a tiny wrapper around the client package.  This prepares for calling the `client/systray` package from `cmd/tailscale`.

PR in two commits best reviewed individually, one that just renames the files, and then a second to add the wrapper.