### PR TITLE
all: fix golangci-lint errors

### DIFF
--- a/cmd/addlicense/main.go
+++ b/cmd/addlicense/main.go
@@ -18,12 +18,12 @@ var (
 )
 
 func usage() {
-	fmt.Fprintf(os.Stderr, `
+	fmt.Fprint(os.Stderr, `
 usage: addlicense -file FILE <subcommand args...>
 `[1:])
 
 	flag.PrintDefaults()
-	fmt.Fprintf(os.Stderr, `
+	fmt.Fprint(os.Stderr, `
 addlicense adds a Tailscale license to the beginning of file.
 
 It is intended for use with 'go generate', so it also runs a subcommand,

--- a/cmd/k8s-operator/proxy.go
+++ b/cmd/k8s-operator/proxy.go
@@ -311,7 +311,7 @@ func (h *apiserverProxy) addImpersonationHeadersAsRequired(r *http.Request) {
 
 	// Now add the impersonation headers that we want.
 	if err := addImpersonationHeaders(r, h.log); err != nil {
-		log.Printf("failed to add impersonation headers: " + err.Error())
+		log.Print("failed to add impersonation headers: ", err.Error())
 	}
 }
 

--- a/cmd/tailscale/cli/risks.go
+++ b/cmd/tailscale/cli/risks.go
@@ -77,7 +77,7 @@ func presentRiskToUser(riskType, riskMessage, acceptedRisks string) error {
 	for left := riskAbortTimeSeconds; left > 0; left-- {
 		msg := fmt.Sprintf("\rContinuing in %d seconds...", left)
 		msgLen = len(msg)
-		printf(msg)
+		printf("%s", msg)
 		select {
 		case <-interrupt:
 			printf("\r%s\r", strings.Repeat("x", msgLen+1))

--- a/cmd/tsconnect/tsconnect.go
+++ b/cmd/tsconnect/tsconnect.go
@@ -53,12 +53,12 @@ func main() {
 }
 
 func usage() {
-	fmt.Fprintf(os.Stderr, `
+	fmt.Fprint(os.Stderr, `
 usage: tsconnect {dev|build|serve}
 `[1:])
 
 	flag.PrintDefaults()
-	fmt.Fprintf(os.Stderr, `
+	fmt.Fprint(os.Stderr, `
 
 tsconnect implements development/build/serving workflows for Tailscale Connect.
 It can be invoked with one of three subcommands:

--- a/net/tshttpproxy/tshttpproxy_synology.go
+++ b/net/tshttpproxy/tshttpproxy_synology.go
@@ -47,7 +47,7 @@ func synologyProxyFromConfigCached(req *http.Request) (*url.URL, error) {
 	var err error
 	modtime := mtime(synologyProxyConfigPath)
 
-	if modtime != cache.updated {
+	if !modtime.Equal(cache.updated) {
 		cache.httpProxy, cache.httpsProxy, err = synologyProxiesFromConfig()
 		cache.updated = modtime
 	}

--- a/net/tshttpproxy/tshttpproxy_synology_test.go
+++ b/net/tshttpproxy/tshttpproxy_synology_test.go
@@ -41,7 +41,7 @@ func TestSynologyProxyFromConfigCached(t *testing.T) {
 			t.Fatalf("got %s, %v; want nil, nil", val, err)
 		}
 
-		if got, want := cache.updated, time.Unix(0, 0); got != want {
+		if got, want := cache.updated.UTC(), time.Unix(0, 0).UTC(); !got.Equal(want) {
 			t.Fatalf("got %s, want %s", got, want)
 		}
 		if cache.httpProxy != nil {

--- a/ssh/tailssh/incubator.go
+++ b/ssh/tailssh/incubator.go
@@ -1014,10 +1014,10 @@ func (ss *sshSession) startWithStdPipes() (err error) {
 
 func envForUser(u *userMeta) []string {
 	return []string{
-		fmt.Sprintf("SHELL=" + u.LoginShell()),
-		fmt.Sprintf("USER=" + u.Username),
-		fmt.Sprintf("HOME=" + u.HomeDir),
-		fmt.Sprintf("PATH=" + defaultPathForUser(&u.User)),
+		fmt.Sprintf("SHELL=%s", u.LoginShell()),
+		fmt.Sprintf("USER=%s", u.Username),
+		fmt.Sprintf("HOME=%s", u.HomeDir),
+		fmt.Sprintf("PATH=%s", defaultPathForUser(&u.User)),
 	}
 }
 

--- a/tstest/integration/testcontrol/testcontrol.go
+++ b/tstest/integration/testcontrol/testcontrol.go
@@ -955,7 +955,7 @@ func (s *Server) MapResponse(req *tailcfg.MapRequest) (res *tailcfg.MapResponse,
 	if dns != nil && s.MagicDNSDomain != "" {
 		dns = dns.Clone()
 		dns.CertDomains = []string{
-			fmt.Sprintf(node.Hostinfo.Hostname() + "." + s.MagicDNSDomain),
+			node.Hostinfo.Hostname() + "." + s.MagicDNSDomain,
 		}
 	}
 


### PR DESCRIPTION
These erroneously blocked a recent PR, which I fixed by simply re-running CI. But we might as well fix them anyway. These are mostly `printf` to `print` and a couple of `!=` to `!Equal()`

Updates #cleanup