### PR TITLE
cmd/derper: support explicit configuration of mesh dial hosts

### DIFF
--- a/cmd/derper/derper.go
+++ b/cmd/derper/derper.go
@@ -63,7 +63,7 @@ var (
 	runDERP     = flag.Bool("derp", true, "whether to run a DERP server. The only reason to set this false is if you're decommissioning a server but want to keep its bootstrap DNS functionality still running.")
 
 	meshPSKFile     = flag.String("mesh-psk-file", defaultMeshPSKFile(), "if non-empty, path to file containing the mesh pre-shared key file. It should contain some hex string; whitespace is trimmed.")
-	meshWith        = flag.String("mesh-with", "", "optional comma-separated list of hostnames to mesh with; the server's own hostname can be in the list")
+	meshWith        = flag.String("mesh-with", "", "optional comma-separated list of hostnames to mesh with; the server's own hostname can be in the list. If an entry contains a slash, the second part names a hostname to be used when dialing the target.")
 	bootstrapDNS    = flag.String("bootstrap-dns-names", "", "optional comma-separated list of hostnames to make available at /bootstrap-dns")
 	unpublishedDNS  = flag.String("unpublished-bootstrap-dns-names", "", "optional comma-separated list of hostnames to make available at /bootstrap-dns and not publish in the list. If an entry contains a slash, the second part names a DNS record to poll for its TXT record with a `0` to `100` value for rollout percentage.")
 	verifyClients   = flag.Bool("verify-clients", false, "verify clients to this DERP server through a local tailscaled instance.")

--- a/cmd/derper/mesh.go
+++ b/cmd/derper/mesh.go
@@ -10,7 +10,6 @@ import (
 	"log"
 	"net"
 	"strings"
-	"time"
 
 	"tailscale.com/derp"
 	"tailscale.com/derp/derphttp"
@@ -25,15 +24,28 @@ func startMesh(s *derp.Server) error {
 	if !s.HasMeshKey() {
 		return errors.New("--mesh-with requires --mesh-psk-file")
 	}
-	for _, host := range strings.Split(*meshWith, ",") {
-		if err := startMeshWithHost(s, host); err != nil {
+	for _, hostTuple := range strings.Split(*meshWith, ",") {
+		if err := startMeshWithHost(s, hostTuple); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func startMeshWithHost(s *derp.Server, host string) error {
+func startMeshWithHost(s *derp.Server, hostTuple string) error {
+	var host string
+	var dialHost string
+	hostParts := strings.Split(hostTuple, "/")
+	if len(hostParts) > 2 {
+		return fmt.Errorf("too many components in host tuple %q", hostTuple)
+	}
+	host = hostParts[0]
+	if len(hostParts) == 2 {
+		dialHost = hostParts[1]
+	} else {
+		dialHost = hostParts[0]
+	}
+
 	logf := logger.WithPrefix(log.Printf, fmt.Sprintf("mesh(%q): ", host))
 	netMon := netmon.NewStatic() // good enough for cmd/derper; no need for netns fanciness
 	c, err := derphttp.NewClient(s.PrivateKey(), "https://"+host+"/derp", logf, netMon)
@@ -43,35 +55,20 @@ func startMeshWithHost(s *derp.Server, host string) error {
 	c.MeshKey = s.MeshKey()
 	c.WatchConnectionChanges = true
 
-	// For meshed peers within a region, connect via VPC addresses.
-	c.SetURLDialer(func(ctx context.Context, network, addr string) (net.Conn, error) {
-		host, port, err := net.SplitHostPort(addr)
-		if err != nil {
-			logf("failed to split %q: %v", addr, err)
-			return nil, err
-		}
+	logf("will dial %q for %q", dialHost, host)
+	if dialHost != host {
 		var d net.Dialer
-		var r net.Resolver
-		if base, ok := strings.CutSuffix(host, ".tailscale.com"); ok && port == "443" {
-			subCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
-			defer cancel()
-			vpcHost := base + "-vpc.tailscale.com"
-			ips, err := r.LookupIP(subCtx, "ip", vpcHost)
+		c.SetURLDialer(func(ctx context.Context, network, addr string) (net.Conn, error) {
+			_, port, err := net.SplitHostPort(addr)
 			if err != nil {
-				logf("failed to resolve %v: %v", vpcHost, err)
+				logf("failed to split %q: %v", addr, err)
+				return nil, err
 			}
-			if len(ips) > 0 {
-				vpcAddr := net.JoinHostPort(ips[0].String(), port)
-				c, err := d.DialContext(subCtx, network, vpcAddr)
-				if err == nil {
-					logf("connected to %v (%v) instead of %v", vpcHost, ips[0], base)
-					return c, nil
-				}
-				logf("failed to connect to %v (%v): %v; trying non-VPC route", vpcHost, ips[0], err)
-			}
-		}
-		return d.DialContext(ctx, network, addr)
-	})
+			dialAddr := net.JoinHostPort(dialHost, port)
+			logf("dialing %q instead of %q", dialAddr, addr)
+			return d.DialContext(ctx, network, dialAddr)
+		})
+	}
 
 	add := func(m derp.PeerPresentMessage) { s.AddPacketForwarder(m.Key, c) }
 	remove := func(m derp.PeerGoneMessage) { s.RemovePacketForwarder(m.Peer, c) }


### PR DESCRIPTION
The --mesh-with flag now supports the specification of hostname tuples like derp1a.tailscale.com/derp1a-vpc.tailscale.com, which instructs derp to mesh with host 'derp1a.tailscale.com' but dial TCP connections to 'derp1a-vpc.tailscale.com'.

For backwards compatibility, --mesh-with still supports individual hostnames.

The logic which attempts to auto-discover '[host]-vpc.tailscale.com' dial hosts has been removed.

Updates tailscale/corp#25653