### PR TITLE
all: add userspace support for Solaris / illumos 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -313,6 +313,12 @@ jobs:
           # AIX
           - goos: aix
             goarch: ppc64
+          # Solaris
+          - goos: solaris
+            goarch: amd64
+          # illumos
+          - goos: illumos
+            goarch: amd64
 
     runs-on: ubuntu-22.04
     steps:

--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -81,7 +81,7 @@ func defaultTunName() string {
 		// "utun" is recognized by wireguard-go/tun/tun_darwin.go
 		// as a magic value that uses/creates any free number.
 		return "utun"
-	case "plan9", "aix":
+	case "plan9", "aix", "solaris", "illumos":
 		return "userspace-networking"
 	case "linux":
 		switch distro.Get() {
@@ -665,7 +665,7 @@ func handleSubnetsInNetstack() bool {
 		return true
 	}
 	switch runtime.GOOS {
-	case "windows", "darwin", "freebsd", "openbsd":
+	case "windows", "darwin", "freebsd", "openbsd", "solaris", "illumos":
 		// Enable on Windows and tailscaled-on-macOS (this doesn't
 		// affect the GUI clients), and on FreeBSD.
 		return true

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -4172,7 +4172,7 @@ func (b *LocalBackend) peerAPIServicesLocked() (ret []tailcfg.Service) {
 		})
 	}
 	switch runtime.GOOS {
-	case "linux", "freebsd", "openbsd", "illumos", "darwin", "windows", "android", "ios":
+	case "linux", "freebsd", "openbsd", "illumos", "solaris", "darwin", "windows", "android", "ios":
 		// These are the platforms currently supported by
 		// net/dns/resolver/tsdns.go:Resolver.HandleExitNodeDNSQuery.
 		ret = append(ret, tailcfg.Service{

--- a/ipn/ipnserver/actor.go
+++ b/ipn/ipnserver/actor.go
@@ -96,7 +96,7 @@ func (a *actor) Username() (string, error) {
 		}
 		defer tok.Close()
 		return tok.Username()
-	case "darwin", "linux":
+	case "darwin", "linux", "illumos", "solaris":
 		uid, ok := a.ci.Creds().UserID()
 		if !ok {
 			return "", errors.New("missing user ID")

--- a/ipn/ipnstate/ipnstate.go
+++ b/ipn/ipnstate/ipnstate.go
@@ -650,6 +650,8 @@ func osEmoji(os string) string {
 		return "🐡"
 	case "illumos":
 		return "☀️"
+	case "solaris":
+		return "🌤️"
 	}
 	return "👽"
 }

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -1097,7 +1097,7 @@ func (h *Handler) serveServeConfig(w http.ResponseWriter, r *http.Request) {
 
 func authorizeServeConfigForGOOSAndUserContext(goos string, configIn *ipn.ServeConfig, h *Handler) error {
 	switch goos {
-	case "windows", "linux", "darwin":
+	case "windows", "linux", "darwin", "illumos", "solaris":
 	default:
 		return nil
 	}
@@ -1117,7 +1117,7 @@ func authorizeServeConfigForGOOSAndUserContext(goos string, configIn *ipn.ServeC
 	switch goos {
 	case "windows":
 		return errors.New("must be a Windows local admin to serve a path")
-	case "linux", "darwin":
+	case "linux", "darwin", "illumos", "solaris":
 		return errors.New("must be root, or be an operator and able to run 'sudo tailscale' to serve a path")
 	default:
 		// We filter goos at the start of the func, this default case

--- a/ipn/localapi/localapi_test.go
+++ b/ipn/localapi/localapi_test.go
@@ -237,7 +237,7 @@ func TestShouldDenyServeConfigForGOOSAndUserContext(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		for _, goos := range []string{"linux", "windows", "darwin"} {
+		for _, goos := range []string{"linux", "windows", "darwin", "illumos", "solaris"} {
 			t.Run(goos+"-"+tt.name, func(t *testing.T) {
 				err := authorizeServeConfigForGOOSAndUserContext(goos, tt.configIn, tt.h)
 				gotErr := err != nil

--- a/net/dns/manager_default.go
+++ b/net/dns/manager_default.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build !linux && !freebsd && !openbsd && !windows && !darwin
+//go:build !linux && !freebsd && !openbsd && !windows && !darwin && !illumos && !solaris
 
 package dns
 

--- a/net/dns/manager_solaris.go
+++ b/net/dns/manager_solaris.go
@@ -1,0 +1,14 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package dns
+
+import (
+	"tailscale.com/control/controlknobs"
+	"tailscale.com/health"
+	"tailscale.com/types/logger"
+)
+
+func NewOSConfigurator(logf logger.Logf, health *health.Tracker, _ *controlknobs.Knobs, iface string) (OSConfigurator, error) {
+	return newDirectManager(logf, health), nil
+}

--- a/net/dns/resolver/tsdns.go
+++ b/net/dns/resolver/tsdns.go
@@ -384,7 +384,7 @@ func (r *Resolver) HandlePeerDNSQuery(ctx context.Context, q []byte, from netip.
 		// but for now that's probably good enough. Later we'll
 		// want to blend in everything from scutil --dns.
 		fallthrough
-	case "linux", "freebsd", "openbsd", "illumos", "ios":
+	case "linux", "freebsd", "openbsd", "illumos", "solaris", "ios":
 		nameserver, err := stubResolverForOS()
 		if err != nil {
 			r.logf("stubResolverForOS: %v", err)

--- a/net/tstun/tstun_stub.go
+++ b/net/tstun/tstun_stub.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build plan9 || aix
+//go:build plan9 || aix || solaris || illumos
 
 package tstun
 

--- a/net/tstun/tun.go
+++ b/net/tstun/tun.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build !wasm && !plan9 && !tamago && !aix
+//go:build !wasm && !plan9 && !tamago && !aix && !solaris && !illumos
 
 // Package tun creates a tuntap device, working around OS-specific
 // quirks if necessary.

--- a/paths/paths_unix.go
+++ b/paths/paths_unix.go
@@ -22,7 +22,7 @@ func init() {
 
 func statePath() string {
 	switch runtime.GOOS {
-	case "linux":
+	case "linux", "illumos", "solaris":
 		return "/var/lib/tailscale/tailscaled.state"
 	case "freebsd", "openbsd":
 		return "/var/db/tailscale/tailscaled.state"


### PR DESCRIPTION
Based on some quick testing on my machine, this correctly causes binaries built for illumos to default to userspace only and things appear to work. This includes doing a taildrive share from the userspace only illumos node and mounting it from  a Linux client.

This is part of #14565