### PR TITLE
hostinfo: improve accuracy of Linux desktop detection heuristic

### DIFF
--- a/hostinfo/hostinfo.go
+++ b/hostinfo/hostinfo.go
@@ -233,7 +233,6 @@ func desktop() (ret opt.Bool) {
 	seenDesktop := false
 	for lr := range lineiter.File("/proc/net/unix") {
 		line, _ := lr.Value()
-		seenDesktop = seenDesktop || mem.Contains(mem.B(line), mem.S(" @/tmp/dbus-"))
 		seenDesktop = seenDesktop || mem.Contains(mem.B(line), mem.S(".X11-unix"))
 		seenDesktop = seenDesktop || mem.Contains(mem.B(line), mem.S("/wayland-1"))
 	}


### PR DESCRIPTION
DBus doesn't imply desktop.

Updates #1708
