### PR TITLE
types/views: optimize SliceEqualAnyOrderFunc for small slices

### DIFF
--- a/types/views/views_test.go
+++ b/types/views/views_test.go
@@ -188,6 +188,15 @@ func TestSliceEqualAnyOrderFunc(t *testing.T) {
 
 	// Nothing shared
 	c.Check(SliceEqualAnyOrderFunc(v, ncFrom("baz", "qux"), cmp), qt.Equals, false)
+
+	// Long slice that matches
+	longSlice := ncFrom("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
+	longSame := ncFrom("b", "a", "c", "d", "e", "f", "g", "h", "i", "j") // first 2 elems swapped
+	c.Check(SliceEqualAnyOrderFunc(longSlice, longSame, cmp), qt.Equals, true)
+
+	// Long difference; past the quadratic limit
+	longDiff := ncFrom("b", "a", "c", "d", "e", "f", "g", "h", "i", "k") // differs at end
+	c.Check(SliceEqualAnyOrderFunc(longSlice, longDiff, cmp), qt.Equals, false)
 }
 
 func TestSliceEqual(t *testing.T) {


### PR DESCRIPTION
If the total number of differences is less than a small amount, just do the dumb quadratic thing and compare every single object instead of allocating a map.

Updates tailscale/corp#25479


Change-Id: I8931b4355a2da4ec0f19739927311cf88711a840