### PR TITLE
client/tailscale: add deprecation notice to the internal ts API client

### DIFF
--- a/client/tailscale/tailscale.go
+++ b/client/tailscale/tailscale.go
@@ -36,6 +36,7 @@ const maxReadSize = 10 << 20
 //
 // Use NewClient to instantiate one. Exported fields should be set before
 // the client is used and not changed thereafter.
+// Deprecated: use https://github.com/tailscale/tailscale-client-go instead.
 type Client struct {
 	// tailnet is the globally unique identifier for a Tailscale network, such
 	// as "example.com" or "user@gmail.com".
@@ -98,6 +99,7 @@ func (c *Client) setAuth(r *http.Request) {
 // If httpClient is nil, then http.DefaultClient is used.
 // "api.tailscale.com" is set as the BaseURL for the returned client
 // and can be changed manually by the user.
+// Deprecated: use https://github.com/tailscale/tailscale-client-go instead.
 func NewClient(tailnet string, auth AuthMethod) *Client {
 	return &Client{
 		tailnet:   tailnet,


### PR DESCRIPTION
Add a deprecation notice to the internal Tailscale API client, so it's less easy for someone like me to forget that new methods shouldn't be added here.

I am not sure if we also want to entirely freeze it with a goal of removing it soon. For example, there is a PR that adds tests to this client's methods https://github.com/tailscale/tailscale/pull/14572

Updates tailscale/corp#25752