### PR TITLE
Revert "cmd/tailscale/cli: don't run CLI as a service on gokrazy"

### DIFF
--- a/cmd/tailscale/cli/cli.go
+++ b/cmd/tailscale/cli/cli.go
@@ -84,9 +84,9 @@ var localClient = tailscale.LocalClient{
 
 // Run runs the CLI. The args do not include the binary name.
 func Run(args []string) (err error) {
-	if runtime.GOOS == "linux" && os.Getenv("GOKRAZY_FIRST_START") == "1" && distro.Get() == distro.Gokrazy && os.Getppid() == 1 {
-		// We're running on gokrazy and it's the first start.
-		// Don't run the tailscale CLI as a service; just exit.
+	if runtime.GOOS == "linux" && os.Getenv("GOKRAZY_FIRST_START") == "1" && distro.Get() == distro.Gokrazy && os.Getppid() == 1 && len(args) == 0 {
+		// We're running on gokrazy and the user did not specify 'up'.
+		// Don't run the tailscale CLI and spam logs with usage; just exit.
 		// See https://gokrazy.org/development/process-interface/
 		os.Exit(0)
 	}


### PR DESCRIPTION
This reverts commit b7e48058c8d243adf1ff687e3e92d3fb02b035ea (cc @bradfitz )

That commit broke all documented ways of starting Tailscale on gokrazy: https://gokrazy.org/packages/tailscale/ — both Option A (tailscale up) and Option B (tailscale up --auth-key) rely on the tailscale CLI working.

fixes https://github.com/gokrazy/gokrazy/issues/286

I verified that the tailscale CLI just prints it help when started without arguments, i.e. it does not stay running and is not restarted:

![2025-01-12-tailscale-up-3](https://github.com/user-attachments/assets/a63cd11d-23c5-4481-ba97-989c75bfd3e6)


I verified that the tailscale CLI successfully exits when started with tailscale up --auth-key, regardless of whether the node has joined the tailnet yet or not.

![2025-01-12-tailscale-up-2](https://github.com/user-attachments/assets/bdd4dc64-c271-4a11-8c10-2f773d5dfb37)


I verified that the tailscale CLI successfully waits and exits when started with tailscale up, as expected.

![2025-01-12-tailscale-up](https://github.com/user-attachments/assets/662476f9-2359-41ed-a762-1752438a83ec)
