### PR TITLE
all: use Go 1.21's binary.NativeEndian

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,6 @@ require (
 	github.com/inetaf/tcpproxy v0.0.0-20240214030015-3ce58045626c
 	github.com/insomniacslk/dhcp v0.0.0-20231206064809-8c70d406f6d2
 	github.com/jellydator/ttlcache/v3 v3.1.0
-	github.com/josharian/native v1.1.1-0.20230202152459-5c7d0dd6ab86
 	github.com/jsimonetti/rtnetlink v1.4.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/klauspost/compress v1.17.11
@@ -152,6 +151,7 @@ require (
 	github.com/google/pprof v0.0.0-20240409012703-83162a5b38cd // indirect
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/jjti/go-spancheck v0.5.3 // indirect
+	github.com/josharian/native v1.1.1-0.20230202152459-5c7d0dd6ab86 // indirect
 	github.com/karamaru-alpha/copyloopvar v1.0.8 // indirect
 	github.com/macabu/inamedparam v0.1.3 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect

--- a/net/dns/nm.go
+++ b/net/dns/nm.go
@@ -7,6 +7,7 @@ package dns
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"net"
 	"net/netip"
@@ -14,7 +15,6 @@ import (
 	"time"
 
 	"github.com/godbus/dbus/v5"
-	"github.com/josharian/native"
 	"tailscale.com/net/tsaddr"
 	"tailscale.com/util/dnsname"
 )
@@ -137,7 +137,7 @@ func (m *nmManager) trySet(ctx context.Context, config OSConfig) error {
 	for _, ip := range config.Nameservers {
 		b := ip.As16()
 		if ip.Is4() {
-			dnsv4 = append(dnsv4, native.Endian.Uint32(b[12:]))
+			dnsv4 = append(dnsv4, binary.NativeEndian.Uint32(b[12:]))
 		} else {
 			dnsv6 = append(dnsv6, b[:])
 		}

--- a/util/cstruct/cstruct.go
+++ b/util/cstruct/cstruct.go
@@ -6,10 +6,9 @@
 package cstruct
 
 import (
+	"encoding/binary"
 	"errors"
 	"io"
-
-	"github.com/josharian/native"
 )
 
 // Size of a pointer-typed value, in bits
@@ -120,7 +119,7 @@ func (d *Decoder) Uint16() uint16 {
 		d.err = err
 		return 0
 	}
-	return native.Endian.Uint16(d.dbuf[0:2])
+	return binary.NativeEndian.Uint16(d.dbuf[0:2])
 }
 
 // Uint32 returns a uint32 decoded from the buffer.
@@ -133,7 +132,7 @@ func (d *Decoder) Uint32() uint32 {
 		d.err = err
 		return 0
 	}
-	return native.Endian.Uint32(d.dbuf[0:4])
+	return binary.NativeEndian.Uint32(d.dbuf[0:4])
 }
 
 // Uint64 returns a uint64 decoded from the buffer.
@@ -146,7 +145,7 @@ func (d *Decoder) Uint64() uint64 {
 		d.err = err
 		return 0
 	}
-	return native.Endian.Uint64(d.dbuf[0:8])
+	return binary.NativeEndian.Uint64(d.dbuf[0:8])
 }
 
 // Uintptr returns a uintptr decoded from the buffer.

--- a/util/linuxfw/nftables.go
+++ b/util/linuxfw/nftables.go
@@ -8,6 +8,7 @@ package linuxfw
 
 import (
 	"cmp"
+	"encoding/binary"
 	"fmt"
 	"sort"
 	"strings"
@@ -15,7 +16,6 @@ import (
 	"github.com/google/nftables"
 	"github.com/google/nftables/expr"
 	"github.com/google/nftables/xt"
-	"github.com/josharian/native"
 	"golang.org/x/sys/unix"
 	"tailscale.com/types/logger"
 )
@@ -235,8 +235,8 @@ func printMatchInfo(name string, info xt.InfoAny) string {
 			break
 		}
 
-		pkttype := int(native.Endian.Uint32(data[0:4]))
-		invert := int(native.Endian.Uint32(data[4:8]))
+		pkttype := int(binary.NativeEndian.Uint32(data[0:4]))
+		invert := int(binary.NativeEndian.Uint32(data[4:8]))
 		var invertPrefix string
 		if invert != 0 {
 			invertPrefix = "!"


### PR DESCRIPTION
We still use josharian/native (hi @josharian!) via
netlink, but I also sent https://github.com/mdlayher/netlink/pull/220

Updates #8632
