### PR TITLE
cmd/tailscale/cli: add --posture-checking to tailscale up

### DIFF
--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -601,6 +601,19 @@ func TestCheckForAccidentalSettingReverts(t *testing.T) {
 			goos: "linux",
 			want: "",
 		},
+		{
+			name:  "losing_posture_checking",
+			flags: []string{"--accept-dns"},
+			curPrefs: &ipn.Prefs{
+				ControlURL:          ipn.DefaultControlURL,
+				WantRunning:         false,
+				CorpDNS:             true,
+				PostureChecking:     true,
+				NetfilterMode:       preftype.NetfilterOn,
+				NoStatefulFiltering: opt.NewBool(true),
+			},
+			want: accidentalUpPrefix + " --accept-dns --posture-checking",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1045,6 +1058,7 @@ func TestUpdatePrefs(t *testing.T) {
 				NoSNATSet:                 true,
 				NoStatefulFilteringSet:    true,
 				OperatorUserSet:           true,
+				PostureCheckingSet:        true,
 				RouteAllSet:               true,
 				RunSSHSet:                 true,
 				ShieldsUpSet:              true,

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -116,6 +116,7 @@ func newUpFlagSet(goos string, upArgs *upArgsT, cmd string) *flag.FlagSet {
 	upf.StringVar(&upArgs.advertiseRoutes, "advertise-routes", "", "routes to advertise to other nodes (comma-separated, e.g. \"10.0.0.0/8,192.168.0.0/24\") or empty string to not advertise routes")
 	upf.BoolVar(&upArgs.advertiseConnector, "advertise-connector", false, "advertise this node as an app connector")
 	upf.BoolVar(&upArgs.advertiseDefaultRoute, "advertise-exit-node", false, "offer to be an exit node for internet traffic for the tailnet")
+	upf.BoolVar(&upArgs.postureChecking, "posture-checking", false, hidden+"allow management plane to gather device posture information")
 
 	if safesocket.GOOSUsesPeerCreds(goos) {
 		upf.StringVar(&upArgs.opUser, "operator", "", "Unix username to allow to operate on tailscaled without sudo")
@@ -194,6 +195,7 @@ type upArgsT struct {
 	timeout                time.Duration
 	acceptedRisks          string
 	profileName            string
+	postureChecking        bool
 }
 
 func (a upArgsT) getAuthKey() (string, error) {
@@ -304,6 +306,7 @@ func prefsFromUpArgs(upArgs upArgsT, warnf logger.Logf, st *ipnstate.Status, goo
 	prefs.OperatorUser = upArgs.opUser
 	prefs.ProfileName = upArgs.profileName
 	prefs.AppConnector.Advertise = upArgs.advertiseConnector
+	prefs.PostureChecking = upArgs.postureChecking
 
 	if goos == "linux" {
 		prefs.NoSNAT = !upArgs.snat
@@ -1053,6 +1056,8 @@ func prefsToFlags(env upCheckEnv, prefs *ipn.Prefs) (flagVal map[string]any) {
 			set(prefs.NetfilterMode.String())
 		case "unattended":
 			set(prefs.ForceDaemon)
+		case "posture-checking":
+			set(prefs.PostureChecking)
 		}
 	})
 	return ret


### PR DESCRIPTION
This will prevent `tailscale up` from resetting the posture checking client pref.

Fixes #12154