### PR TITLE
cmd/viewer,all: consistently use "read-only" instead of "readonly"

### DIFF
--- a/client/web/web.go
+++ b/client/web/web.go
@@ -89,8 +89,8 @@ type Server struct {
 type ServerMode string
 
 const (
-	// LoginServerMode serves a readonly login client for logging a
-	// node into a tailnet, and viewing a readonly interface of the
+	// LoginServerMode serves a read-only login client for logging a
+	// node into a tailnet, and viewing a read-only interface of the
 	// node's current Tailscale settings.
 	//
 	// In this mode, API calls are authenticated via platform auth.
@@ -110,7 +110,7 @@ const (
 	// This mode restricts the app to only being assessible over Tailscale,
 	// and API calls are authenticated via browser sessions associated with
 	// the source's Tailscale identity. If the source browser does not have
-	// a valid session, a readonly version of the app is displayed.
+	// a valid session, a read-only version of the app is displayed.
 	ManageServerMode ServerMode = "manage"
 )
 
@@ -695,16 +695,16 @@ func (s *Server) serveAPIAuth(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case sErr != nil && errors.Is(sErr, errNotUsingTailscale):
 		s.lc.IncrementCounter(r.Context(), "web_client_viewing_local", 1)
-		resp.Authorized = false // restricted to the readonly view
+		resp.Authorized = false // restricted to the read-only view
 	case sErr != nil && errors.Is(sErr, errNotOwner):
 		s.lc.IncrementCounter(r.Context(), "web_client_viewing_not_owner", 1)
-		resp.Authorized = false // restricted to the readonly view
+		resp.Authorized = false // restricted to the read-only view
 	case sErr != nil && errors.Is(sErr, errTaggedLocalSource):
 		s.lc.IncrementCounter(r.Context(), "web_client_viewing_local_tag", 1)
-		resp.Authorized = false // restricted to the readonly view
+		resp.Authorized = false // restricted to the read-only view
 	case sErr != nil && errors.Is(sErr, errTaggedRemoteSource):
 		s.lc.IncrementCounter(r.Context(), "web_client_viewing_remote_tag", 1)
-		resp.Authorized = false // restricted to the readonly view
+		resp.Authorized = false // restricted to the read-only view
 	case sErr != nil && !errors.Is(sErr, errNoSession):
 		// Any other error.
 		http.Error(w, sErr.Error(), http.StatusInternalServerError)

--- a/cmd/viewer/tests/tests.go
+++ b/cmd/viewer/tests/tests.go
@@ -140,7 +140,7 @@ func (c *Container[T]) Clone() *Container[T] {
 	panic(fmt.Errorf("%T contains pointers, but is not cloneable", c.Item))
 }
 
-// ContainerView is a pre-defined readonly view of a Container[T].
+// ContainerView is a pre-defined read-only view of a Container[T].
 type ContainerView[T views.ViewCloner[T, V], V views.StructView[T]] struct {
 	// ж is the underlying mutable value, named with a hard-to-type
 	// character that looks pointy like a pointer.
@@ -178,7 +178,7 @@ func (c *MapContainer[K, V]) Clone() *MapContainer[K, V] {
 	return &MapContainer[K, V]{m}
 }
 
-// MapContainerView is a pre-defined readonly view of a [MapContainer][K, T].
+// MapContainerView is a pre-defined read-only view of a [MapContainer][K, T].
 type MapContainerView[K comparable, T views.ViewCloner[T, V], V views.StructView[T]] struct {
 	// ж is the underlying mutable value, named with a hard-to-type
 	// character that looks pointy like a pointer.

--- a/cmd/viewer/tests/tests_view.go
+++ b/cmd/viewer/tests/tests_view.go
@@ -16,7 +16,7 @@ import (
 
 //go:generate go run tailscale.com/cmd/cloner  -clonefunc=false -type=StructWithPtrs,StructWithoutPtrs,Map,StructWithSlices,OnlyGetClone,StructWithEmbedded,GenericIntStruct,GenericNoPtrsStruct,GenericCloneableStruct,StructWithContainers,StructWithTypeAliasFields,GenericTypeAliasStruct
 
-// View returns a readonly view of StructWithPtrs.
+// View returns a read-only view of StructWithPtrs.
 func (p *StructWithPtrs) View() StructWithPtrsView {
 	return StructWithPtrsView{ж: p}
 }
@@ -32,7 +32,7 @@ type StructWithPtrsView struct {
 	ж *StructWithPtrs
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v StructWithPtrsView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -80,7 +80,7 @@ var _StructWithPtrsViewNeedsRegeneration = StructWithPtrs(struct {
 	NoCloneValue *StructWithoutPtrs
 }{})
 
-// View returns a readonly view of StructWithoutPtrs.
+// View returns a read-only view of StructWithoutPtrs.
 func (p *StructWithoutPtrs) View() StructWithoutPtrsView {
 	return StructWithoutPtrsView{ж: p}
 }
@@ -96,7 +96,7 @@ type StructWithoutPtrsView struct {
 	ж *StructWithoutPtrs
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v StructWithoutPtrsView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -134,7 +134,7 @@ var _StructWithoutPtrsViewNeedsRegeneration = StructWithoutPtrs(struct {
 	Pfx netip.Prefix
 }{})
 
-// View returns a readonly view of Map.
+// View returns a read-only view of Map.
 func (p *Map) View() MapView {
 	return MapView{ж: p}
 }
@@ -150,7 +150,7 @@ type MapView struct {
 	ж *Map
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v MapView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -240,7 +240,7 @@ var _MapViewNeedsRegeneration = Map(struct {
 	StructWithPtrKey    map[StructWithPtrs]int
 }{})
 
-// View returns a readonly view of StructWithSlices.
+// View returns a read-only view of StructWithSlices.
 func (p *StructWithSlices) View() StructWithSlicesView {
 	return StructWithSlicesView{ж: p}
 }
@@ -256,7 +256,7 @@ type StructWithSlicesView struct {
 	ж *StructWithSlices
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v StructWithSlicesView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -314,7 +314,7 @@ var _StructWithSlicesViewNeedsRegeneration = StructWithSlices(struct {
 	Ints           []*int
 }{})
 
-// View returns a readonly view of StructWithEmbedded.
+// View returns a read-only view of StructWithEmbedded.
 func (p *StructWithEmbedded) View() StructWithEmbeddedView {
 	return StructWithEmbeddedView{ж: p}
 }
@@ -330,7 +330,7 @@ type StructWithEmbeddedView struct {
 	ж *StructWithEmbedded
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v StructWithEmbeddedView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -370,7 +370,7 @@ var _StructWithEmbeddedViewNeedsRegeneration = StructWithEmbedded(struct {
 	StructWithSlices
 }{})
 
-// View returns a readonly view of GenericIntStruct.
+// View returns a read-only view of GenericIntStruct.
 func (p *GenericIntStruct[T]) View() GenericIntStructView[T] {
 	return GenericIntStructView[T]{ж: p}
 }
@@ -386,7 +386,7 @@ type GenericIntStructView[T constraints.Integer] struct {
 	ж *GenericIntStruct[T]
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v GenericIntStructView[T]) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -442,7 +442,7 @@ func _GenericIntStructViewNeedsRegeneration[T constraints.Integer](GenericIntStr
 	}{})
 }
 
-// View returns a readonly view of GenericNoPtrsStruct.
+// View returns a read-only view of GenericNoPtrsStruct.
 func (p *GenericNoPtrsStruct[T]) View() GenericNoPtrsStructView[T] {
 	return GenericNoPtrsStructView[T]{ж: p}
 }
@@ -458,7 +458,7 @@ type GenericNoPtrsStructView[T StructWithoutPtrs | netip.Prefix | BasicType] str
 	ж *GenericNoPtrsStruct[T]
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v GenericNoPtrsStructView[T]) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -514,7 +514,7 @@ func _GenericNoPtrsStructViewNeedsRegeneration[T StructWithoutPtrs | netip.Prefi
 	}{})
 }
 
-// View returns a readonly view of GenericCloneableStruct.
+// View returns a read-only view of GenericCloneableStruct.
 func (p *GenericCloneableStruct[T, V]) View() GenericCloneableStructView[T, V] {
 	return GenericCloneableStructView[T, V]{ж: p}
 }
@@ -530,7 +530,7 @@ type GenericCloneableStructView[T views.ViewCloner[T, V], V views.StructView[T]]
 	ж *GenericCloneableStruct[T, V]
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v GenericCloneableStructView[T, V]) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -589,7 +589,7 @@ func _GenericCloneableStructViewNeedsRegeneration[T views.ViewCloner[T, V], V vi
 	}{})
 }
 
-// View returns a readonly view of StructWithContainers.
+// View returns a read-only view of StructWithContainers.
 func (p *StructWithContainers) View() StructWithContainersView {
 	return StructWithContainersView{ж: p}
 }
@@ -605,7 +605,7 @@ type StructWithContainersView struct {
 	ж *StructWithContainers
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v StructWithContainersView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -661,7 +661,7 @@ var _StructWithContainersViewNeedsRegeneration = StructWithContainers(struct {
 	CloneableGenericMap       MapContainer[int, *GenericNoPtrsStruct[int]]
 }{})
 
-// View returns a readonly view of StructWithTypeAliasFields.
+// View returns a read-only view of StructWithTypeAliasFields.
 func (p *StructWithTypeAliasFields) View() StructWithTypeAliasFieldsView {
 	return StructWithTypeAliasFieldsView{ж: p}
 }
@@ -677,7 +677,7 @@ type StructWithTypeAliasFieldsView struct {
 	ж *StructWithTypeAliasFields
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v StructWithTypeAliasFieldsView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -759,7 +759,7 @@ var _StructWithTypeAliasFieldsViewNeedsRegeneration = StructWithTypeAliasFields(
 	MapOfSlicesWithoutPtrs map[string][]*StructWithoutPtrsAlias
 }{})
 
-// View returns a readonly view of GenericTypeAliasStruct.
+// View returns a read-only view of GenericTypeAliasStruct.
 func (p *GenericTypeAliasStruct[T, T2, V2]) View() GenericTypeAliasStructView[T, T2, V2] {
 	return GenericTypeAliasStructView[T, T2, V2]{ж: p}
 }
@@ -775,7 +775,7 @@ type GenericTypeAliasStructView[T integer, T2 views.ViewCloner[T2, V2], V2 views
 	ж *GenericTypeAliasStruct[T, T2, V2]
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v GenericTypeAliasStructView[T, T2, V2]) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with

--- a/cmd/viewer/viewer.go
+++ b/cmd/viewer/viewer.go
@@ -21,7 +21,7 @@ import (
 )
 
 const viewTemplateStr = `{{define "common"}}
-// View returns a readonly view of {{.StructName}}.
+// View returns a read-only view of {{.StructName}}.
 func (p *{{.StructName}}{{.TypeParamNames}}) View() {{.ViewName}}{{.TypeParamNames}} {
 	return {{.ViewName}}{{.TypeParamNames}}{ж: p}
 }
@@ -37,7 +37,7 @@ type {{.ViewName}}{{.TypeParams}} struct {
 	ж *{{.StructName}}{{.TypeParamNames}}
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v {{.ViewName}}{{.TypeParamNames}}) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -143,7 +143,7 @@ func genView(buf *bytes.Buffer, it *codegen.ImportTracker, typ *types.Named, _ *
 		MapValueView string
 		MapFn        string
 
-		// MakeViewFnName is the name of the function that accepts a value and returns a readonly view of it.
+		// MakeViewFnName is the name of the function that accepts a value and returns a read-only view of it.
 		MakeViewFnName string
 	}{
 		StructName: typ.Obj().Name(),

--- a/drive/drive_view.go
+++ b/drive/drive_view.go
@@ -14,7 +14,7 @@ import (
 
 //go:generate go run tailscale.com/cmd/cloner  -clonefunc=true -type=Share
 
-// View returns a readonly view of Share.
+// View returns a read-only view of Share.
 func (p *Share) View() ShareView {
 	return ShareView{ж: p}
 }
@@ -30,7 +30,7 @@ type ShareView struct {
 	ж *Share
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v ShareView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -20,7 +20,7 @@ import (
 
 //go:generate go run tailscale.com/cmd/cloner  -clonefunc=false -type=Prefs,ServeConfig,ServiceConfig,TCPPortHandler,HTTPHandler,WebServerConfig
 
-// View returns a readonly view of Prefs.
+// View returns a read-only view of Prefs.
 func (p *Prefs) View() PrefsView {
 	return PrefsView{ж: p}
 }
@@ -36,7 +36,7 @@ type PrefsView struct {
 	ж *Prefs
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v PrefsView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -138,7 +138,7 @@ var _PrefsViewNeedsRegeneration = Prefs(struct {
 	Persist                *persist.Persist
 }{})
 
-// View returns a readonly view of ServeConfig.
+// View returns a read-only view of ServeConfig.
 func (p *ServeConfig) View() ServeConfigView {
 	return ServeConfigView{ж: p}
 }
@@ -154,7 +154,7 @@ type ServeConfigView struct {
 	ж *ServeConfig
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v ServeConfigView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -222,7 +222,7 @@ var _ServeConfigViewNeedsRegeneration = ServeConfig(struct {
 	ETag        string
 }{})
 
-// View returns a readonly view of ServiceConfig.
+// View returns a read-only view of ServiceConfig.
 func (p *ServiceConfig) View() ServiceConfigView {
 	return ServiceConfigView{ж: p}
 }
@@ -238,7 +238,7 @@ type ServiceConfigView struct {
 	ж *ServiceConfig
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v ServiceConfigView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -287,7 +287,7 @@ var _ServiceConfigViewNeedsRegeneration = ServiceConfig(struct {
 	Tun bool
 }{})
 
-// View returns a readonly view of TCPPortHandler.
+// View returns a read-only view of TCPPortHandler.
 func (p *TCPPortHandler) View() TCPPortHandlerView {
 	return TCPPortHandlerView{ж: p}
 }
@@ -303,7 +303,7 @@ type TCPPortHandlerView struct {
 	ж *TCPPortHandler
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v TCPPortHandlerView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -345,7 +345,7 @@ var _TCPPortHandlerViewNeedsRegeneration = TCPPortHandler(struct {
 	TerminateTLS string
 }{})
 
-// View returns a readonly view of HTTPHandler.
+// View returns a read-only view of HTTPHandler.
 func (p *HTTPHandler) View() HTTPHandlerView {
 	return HTTPHandlerView{ж: p}
 }
@@ -361,7 +361,7 @@ type HTTPHandlerView struct {
 	ж *HTTPHandler
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v HTTPHandlerView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -401,7 +401,7 @@ var _HTTPHandlerViewNeedsRegeneration = HTTPHandler(struct {
 	Text  string
 }{})
 
-// View returns a readonly view of WebServerConfig.
+// View returns a read-only view of WebServerConfig.
 func (p *WebServerConfig) View() WebServerConfigView {
 	return WebServerConfigView{ж: p}
 }
@@ -417,7 +417,7 @@ type WebServerConfigView struct {
 	ж *WebServerConfig
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v WebServerConfigView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3952,7 +3952,7 @@ func (b *LocalBackend) wantIngressLocked() bool {
 
 // setPrefsLockedOnEntry requires b.mu be held to call it, but it
 // unlocks b.mu when done. newp ownership passes to this function.
-// It returns a readonly copy of the new prefs.
+// It returns a read-only copy of the new prefs.
 func (b *LocalBackend) setPrefsLockedOnEntry(newp *ipn.Prefs, unlock unlockOnce) ipn.PrefsView {
 	defer unlock()
 

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -21,7 +21,7 @@ import (
 
 //go:generate go run tailscale.com/cmd/cloner  -clonefunc=true -type=User,Node,Hostinfo,NetInfo,Login,DNSConfig,RegisterResponse,RegisterResponseAuth,RegisterRequest,DERPHomeParams,DERPRegion,DERPMap,DERPNode,SSHRule,SSHAction,SSHPrincipal,ControlDialPlan,Location,UserProfile
 
-// View returns a readonly view of User.
+// View returns a read-only view of User.
 func (p *User) View() UserView {
 	return UserView{ж: p}
 }
@@ -37,7 +37,7 @@ type UserView struct {
 	ж *User
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v UserView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -79,7 +79,7 @@ var _UserViewNeedsRegeneration = User(struct {
 	Created       time.Time
 }{})
 
-// View returns a readonly view of Node.
+// View returns a read-only view of Node.
 func (p *Node) View() NodeView {
 	return NodeView{ж: p}
 }
@@ -95,7 +95,7 @@ type NodeView struct {
 	ж *Node
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v NodeView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -216,7 +216,7 @@ var _NodeViewNeedsRegeneration = Node(struct {
 	ExitNodeDNSResolvers          []*dnstype.Resolver
 }{})
 
-// View returns a readonly view of Hostinfo.
+// View returns a read-only view of Hostinfo.
 func (p *Hostinfo) View() HostinfoView {
 	return HostinfoView{ж: p}
 }
@@ -232,7 +232,7 @@ type HostinfoView struct {
 	ж *Hostinfo
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v HostinfoView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -341,7 +341,7 @@ var _HostinfoViewNeedsRegeneration = Hostinfo(struct {
 	Location        *Location
 }{})
 
-// View returns a readonly view of NetInfo.
+// View returns a read-only view of NetInfo.
 func (p *NetInfo) View() NetInfoView {
 	return NetInfoView{ж: p}
 }
@@ -357,7 +357,7 @@ type NetInfoView struct {
 	ж *NetInfo
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v NetInfoView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -421,7 +421,7 @@ var _NetInfoViewNeedsRegeneration = NetInfo(struct {
 	FirewallMode          string
 }{})
 
-// View returns a readonly view of Login.
+// View returns a read-only view of Login.
 func (p *Login) View() LoginView {
 	return LoginView{ж: p}
 }
@@ -437,7 +437,7 @@ type LoginView struct {
 	ж *Login
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v LoginView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -482,7 +482,7 @@ var _LoginViewNeedsRegeneration = Login(struct {
 	ProfilePicURL string
 }{})
 
-// View returns a readonly view of DNSConfig.
+// View returns a read-only view of DNSConfig.
 func (p *DNSConfig) View() DNSConfigView {
 	return DNSConfigView{ж: p}
 }
@@ -498,7 +498,7 @@ type DNSConfigView struct {
 	ж *DNSConfig
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v DNSConfigView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -563,7 +563,7 @@ var _DNSConfigViewNeedsRegeneration = DNSConfig(struct {
 	TempCorpIssue13969  string
 }{})
 
-// View returns a readonly view of RegisterResponse.
+// View returns a read-only view of RegisterResponse.
 func (p *RegisterResponse) View() RegisterResponseView {
 	return RegisterResponseView{ж: p}
 }
@@ -579,7 +579,7 @@ type RegisterResponseView struct {
 	ж *RegisterResponse
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v RegisterResponseView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -629,7 +629,7 @@ var _RegisterResponseViewNeedsRegeneration = RegisterResponse(struct {
 	Error             string
 }{})
 
-// View returns a readonly view of RegisterResponseAuth.
+// View returns a read-only view of RegisterResponseAuth.
 func (p *RegisterResponseAuth) View() RegisterResponseAuthView {
 	return RegisterResponseAuthView{ж: p}
 }
@@ -645,7 +645,7 @@ type RegisterResponseAuthView struct {
 	ж *RegisterResponseAuth
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v RegisterResponseAuthView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -687,7 +687,7 @@ var _RegisterResponseAuthViewNeedsRegeneration = RegisterResponseAuth(struct {
 	AuthKey     string
 }{})
 
-// View returns a readonly view of RegisterRequest.
+// View returns a read-only view of RegisterRequest.
 func (p *RegisterRequest) View() RegisterRequestView {
 	return RegisterRequestView{ж: p}
 }
@@ -703,7 +703,7 @@ type RegisterRequestView struct {
 	ж *RegisterRequest
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v RegisterRequestView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -777,7 +777,7 @@ var _RegisterRequestViewNeedsRegeneration = RegisterRequest(struct {
 	Tailnet          string
 }{})
 
-// View returns a readonly view of DERPHomeParams.
+// View returns a read-only view of DERPHomeParams.
 func (p *DERPHomeParams) View() DERPHomeParamsView {
 	return DERPHomeParamsView{ж: p}
 }
@@ -793,7 +793,7 @@ type DERPHomeParamsView struct {
 	ж *DERPHomeParams
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v DERPHomeParamsView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -831,7 +831,7 @@ var _DERPHomeParamsViewNeedsRegeneration = DERPHomeParams(struct {
 	RegionScore map[int]float64
 }{})
 
-// View returns a readonly view of DERPRegion.
+// View returns a read-only view of DERPRegion.
 func (p *DERPRegion) View() DERPRegionView {
 	return DERPRegionView{ж: p}
 }
@@ -847,7 +847,7 @@ type DERPRegionView struct {
 	ж *DERPRegion
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v DERPRegionView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -897,7 +897,7 @@ var _DERPRegionViewNeedsRegeneration = DERPRegion(struct {
 	Nodes      []*DERPNode
 }{})
 
-// View returns a readonly view of DERPMap.
+// View returns a read-only view of DERPMap.
 func (p *DERPMap) View() DERPMapView {
 	return DERPMapView{ж: p}
 }
@@ -913,7 +913,7 @@ type DERPMapView struct {
 	ж *DERPMap
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v DERPMapView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -958,7 +958,7 @@ var _DERPMapViewNeedsRegeneration = DERPMap(struct {
 	OmitDefaultRegions bool
 }{})
 
-// View returns a readonly view of DERPNode.
+// View returns a read-only view of DERPNode.
 func (p *DERPNode) View() DERPNodeView {
 	return DERPNodeView{ж: p}
 }
@@ -974,7 +974,7 @@ type DERPNodeView struct {
 	ж *DERPNode
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v DERPNodeView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -1032,7 +1032,7 @@ var _DERPNodeViewNeedsRegeneration = DERPNode(struct {
 	CanPort80        bool
 }{})
 
-// View returns a readonly view of SSHRule.
+// View returns a read-only view of SSHRule.
 func (p *SSHRule) View() SSHRuleView {
 	return SSHRuleView{ж: p}
 }
@@ -1048,7 +1048,7 @@ type SSHRuleView struct {
 	ж *SSHRule
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v SSHRuleView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -1098,7 +1098,7 @@ var _SSHRuleViewNeedsRegeneration = SSHRule(struct {
 	AcceptEnv   []string
 }{})
 
-// View returns a readonly view of SSHAction.
+// View returns a read-only view of SSHAction.
 func (p *SSHAction) View() SSHActionView {
 	return SSHActionView{ж: p}
 }
@@ -1114,7 +1114,7 @@ type SSHActionView struct {
 	ж *SSHAction
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v SSHActionView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -1170,7 +1170,7 @@ var _SSHActionViewNeedsRegeneration = SSHAction(struct {
 	OnRecordingFailure        *SSHRecorderFailureAction
 }{})
 
-// View returns a readonly view of SSHPrincipal.
+// View returns a read-only view of SSHPrincipal.
 func (p *SSHPrincipal) View() SSHPrincipalView {
 	return SSHPrincipalView{ж: p}
 }
@@ -1186,7 +1186,7 @@ type SSHPrincipalView struct {
 	ж *SSHPrincipal
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v SSHPrincipalView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -1232,7 +1232,7 @@ var _SSHPrincipalViewNeedsRegeneration = SSHPrincipal(struct {
 	UnusedPubKeys []string
 }{})
 
-// View returns a readonly view of ControlDialPlan.
+// View returns a read-only view of ControlDialPlan.
 func (p *ControlDialPlan) View() ControlDialPlanView {
 	return ControlDialPlanView{ж: p}
 }
@@ -1248,7 +1248,7 @@ type ControlDialPlanView struct {
 	ж *ControlDialPlan
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v ControlDialPlanView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -1286,7 +1286,7 @@ var _ControlDialPlanViewNeedsRegeneration = ControlDialPlan(struct {
 	Candidates []ControlIPCandidate
 }{})
 
-// View returns a readonly view of Location.
+// View returns a read-only view of Location.
 func (p *Location) View() LocationView {
 	return LocationView{ж: p}
 }
@@ -1302,7 +1302,7 @@ type LocationView struct {
 	ж *Location
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v LocationView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -1350,7 +1350,7 @@ var _LocationViewNeedsRegeneration = Location(struct {
 	Priority    int
 }{})
 
-// View returns a readonly view of UserProfile.
+// View returns a read-only view of UserProfile.
 func (p *UserProfile) View() UserProfileView {
 	return UserProfileView{ж: p}
 }
@@ -1366,7 +1366,7 @@ type UserProfileView struct {
 	ж *UserProfile
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v UserProfileView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with

--- a/types/dnstype/dnstype_view.go
+++ b/types/dnstype/dnstype_view.go
@@ -15,7 +15,7 @@ import (
 
 //go:generate go run tailscale.com/cmd/cloner  -clonefunc=true -type=Resolver
 
-// View returns a readonly view of Resolver.
+// View returns a read-only view of Resolver.
 func (p *Resolver) View() ResolverView {
 	return ResolverView{ж: p}
 }
@@ -31,7 +31,7 @@ type ResolverView struct {
 	ж *Resolver
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v ResolverView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with

--- a/types/persist/persist_view.go
+++ b/types/persist/persist_view.go
@@ -17,7 +17,7 @@ import (
 
 //go:generate go run tailscale.com/cmd/cloner  -clonefunc=false -type=Persist
 
-// View returns a readonly view of Persist.
+// View returns a read-only view of Persist.
 func (p *Persist) View() PersistView {
 	return PersistView{ж: p}
 }
@@ -33,7 +33,7 @@ type PersistView struct {
 	ж *Persist
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v PersistView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with

--- a/types/prefs/prefs.go
+++ b/types/prefs/prefs.go
@@ -29,8 +29,8 @@ import (
 var (
 	// ErrManaged is the error returned when attempting to modify a managed preference.
 	ErrManaged = errors.New("cannot modify a managed preference")
-	// ErrReadOnly is the error returned when attempting to modify a readonly preference.
-	ErrReadOnly = errors.New("cannot modify a readonly preference")
+	// ErrReadOnly is the error returned when attempting to modify a read-only preference.
+	ErrReadOnly = errors.New("cannot modify a read-only preference")
 )
 
 // metadata holds type-agnostic preference metadata.

--- a/types/prefs/prefs_example/prefs_example_view.go
+++ b/types/prefs/prefs_example/prefs_example_view.go
@@ -20,7 +20,7 @@ import (
 
 //go:generate go run tailscale.com/cmd/cloner  -clonefunc=false -type=Prefs,AutoUpdatePrefs,AppConnectorPrefs
 
-// View returns a readonly view of Prefs.
+// View returns a read-only view of Prefs.
 func (p *Prefs) View() PrefsView {
 	return PrefsView{ж: p}
 }
@@ -36,7 +36,7 @@ type PrefsView struct {
 	ж *Prefs
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v PrefsView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -132,7 +132,7 @@ var _PrefsViewNeedsRegeneration = Prefs(struct {
 	Persist                *persist.Persist
 }{})
 
-// View returns a readonly view of AutoUpdatePrefs.
+// View returns a read-only view of AutoUpdatePrefs.
 func (p *AutoUpdatePrefs) View() AutoUpdatePrefsView {
 	return AutoUpdatePrefsView{ж: p}
 }
@@ -148,7 +148,7 @@ type AutoUpdatePrefsView struct {
 	ж *AutoUpdatePrefs
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v AutoUpdatePrefsView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -186,7 +186,7 @@ var _AutoUpdatePrefsViewNeedsRegeneration = AutoUpdatePrefs(struct {
 	Apply prefs.Item[opt.Bool]
 }{})
 
-// View returns a readonly view of AppConnectorPrefs.
+// View returns a read-only view of AppConnectorPrefs.
 func (p *AppConnectorPrefs) View() AppConnectorPrefsView {
 	return AppConnectorPrefsView{ж: p}
 }
@@ -202,7 +202,7 @@ type AppConnectorPrefsView struct {
 	ж *AppConnectorPrefs
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v AppConnectorPrefsView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with

--- a/types/prefs/prefs_view_test.go
+++ b/types/prefs/prefs_view_test.go
@@ -13,7 +13,7 @@ import (
 
 //go:generate go run tailscale.com/cmd/cloner  -clonefunc=false -type=TestPrefs,TestBundle,TestValueStruct,TestGenericStruct,TestPrefsGroup -tags=test
 
-// View returns a readonly view of TestPrefs.
+// View returns a read-only view of TestPrefs.
 func (p *TestPrefs) View() TestPrefsView {
 	return TestPrefsView{ж: p}
 }
@@ -29,7 +29,7 @@ type TestPrefsView struct {
 	ж *TestPrefs
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v TestPrefsView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -117,7 +117,7 @@ var _TestPrefsViewNeedsRegeneration = TestPrefs(struct {
 	Group           TestPrefsGroup
 }{})
 
-// View returns a readonly view of TestBundle.
+// View returns a read-only view of TestBundle.
 func (p *TestBundle) View() TestBundleView {
 	return TestBundleView{ж: p}
 }
@@ -133,7 +133,7 @@ type TestBundleView struct {
 	ж *TestBundle
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v TestBundleView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -172,7 +172,7 @@ var _TestBundleViewNeedsRegeneration = TestBundle(struct {
 	Nested *TestValueStruct
 }{})
 
-// View returns a readonly view of TestValueStruct.
+// View returns a read-only view of TestValueStruct.
 func (p *TestValueStruct) View() TestValueStructView {
 	return TestValueStructView{ж: p}
 }
@@ -188,7 +188,7 @@ type TestValueStructView struct {
 	ж *TestValueStruct
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v TestValueStructView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -225,7 +225,7 @@ var _TestValueStructViewNeedsRegeneration = TestValueStruct(struct {
 	Value int
 }{})
 
-// View returns a readonly view of TestGenericStruct.
+// View returns a read-only view of TestGenericStruct.
 func (p *TestGenericStruct[T]) View() TestGenericStructView[T] {
 	return TestGenericStructView[T]{ж: p}
 }
@@ -241,7 +241,7 @@ type TestGenericStructView[T ImmutableType] struct {
 	ж *TestGenericStruct[T]
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v TestGenericStructView[T]) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with
@@ -280,7 +280,7 @@ func _TestGenericStructViewNeedsRegeneration[T ImmutableType](TestGenericStruct[
 	}{})
 }
 
-// View returns a readonly view of TestPrefsGroup.
+// View returns a read-only view of TestPrefsGroup.
 func (p *TestPrefsGroup) View() TestPrefsGroupView {
 	return TestPrefsGroupView{ж: p}
 }
@@ -296,7 +296,7 @@ type TestPrefsGroupView struct {
 	ж *TestPrefsGroup
 }
 
-// Valid reports whether underlying value is non-nil.
+// Valid reports whether v's underlying value is non-nil.
 func (v TestPrefsGroupView) Valid() bool { return v.ж != nil }
 
 // AsStruct returns a clone of the underlying value which aliases no memory with

--- a/types/prefs/struct_map.go
+++ b/types/prefs/struct_map.go
@@ -83,7 +83,7 @@ type StructMapView[K MapKeyType, T views.ViewCloner[T, V], V views.StructView[T]
 	ж *StructMap[K, T]
 }
 
-// StructMapViewOf returns a readonly view of m.
+// StructMapViewOf returns a read-only view of m.
 // It is used by [tailscale.com/cmd/viewer].
 func StructMapViewOf[K MapKeyType, T views.ViewCloner[T, V], V views.StructView[T]](m *StructMap[K, T]) StructMapView[K, T, V] {
 	return StructMapView[K, T, V]{m}


### PR DESCRIPTION
Updates #cleanup
