### PR TITLE
all: add Node.HomeDERP int, phase out "127.3.3.40:$region" hack [capver 111]

### DIFF
--- a/control/controlbase/conn_test.go
+++ b/control/controlbase/conn_test.go
@@ -280,7 +280,7 @@ func TestConnMemoryOverhead(t *testing.T) {
 	growthTotal := int64(ms.HeapAlloc) - int64(ms0.HeapAlloc)
 	growthEach := float64(growthTotal) / float64(num)
 	t.Logf("Alloced %v bytes, %.2f B/each", growthTotal, growthEach)
-	const max = 2000
+	const max = 2048
 	if growthEach > max {
 		t.Errorf("allocated more than expected; want max %v bytes/each", max)
 	}

--- a/ipn/ipnlocal/expiry.go
+++ b/ipn/ipnlocal/expiry.go
@@ -116,7 +116,7 @@ func (em *expiryManager) flagExpiredPeers(netmap *netmap.NetworkMap, localNow ti
 		// since we discover endpoints via DERP, and due to DERP return
 		// path optimization.
 		mut.Endpoints = nil
-		mut.DERP = ""
+		mut.HomeDERP = 0
 
 		// Defense-in-depth: break the node's public key as well, in
 		// case something tries to communicate.

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -7381,15 +7381,7 @@ func suggestExitNode(report *netcheck.Report, netMap *netmap.NetworkMap, prevSug
 	}
 	distances := make([]nodeDistance, 0, len(candidates))
 	for _, c := range candidates {
-		if c.DERP() != "" {
-			ipp, err := netip.ParseAddrPort(c.DERP())
-			if err != nil {
-				continue
-			}
-			if ipp.Addr() != tailcfg.DerpMagicIPAddr {
-				continue
-			}
-			regionID := int(ipp.Port())
+		if regionID := c.HomeDERP(); regionID != 0 {
 			candidatesByRegion[regionID] = append(candidatesByRegion[regionID], c)
 			continue
 		}

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -1007,8 +1007,8 @@ func TestUpdateNetmapDelta(t *testing.T) {
 
 	wants := []*tailcfg.Node{
 		{
-			ID:   1,
-			DERP: "127.3.3.40:1",
+			ID:       1,
+			HomeDERP: 1,
 		},
 		{
 			ID:     2,
@@ -2021,7 +2021,7 @@ func TestAutoExitNodeSetNetInfoCallback(t *testing.T) {
 			netip.MustParsePrefix("100.64.1.1/32"),
 			netip.MustParsePrefix("fe70::1/128"),
 		},
-		DERP: "127.3.3.40:2",
+		HomeDERP: 2,
 	}
 	defaultDERPMap := &tailcfg.DERPMap{
 		Regions: map[int]*tailcfg.DERPRegion{
@@ -2985,7 +2985,7 @@ func makePeer(id tailcfg.NodeID, opts ...peerOptFunc) tailcfg.NodeView {
 		ID:       id,
 		StableID: tailcfg.StableNodeID(fmt.Sprintf("stable%d", id)),
 		Name:     fmt.Sprintf("peer%d", id),
-		DERP:     fmt.Sprintf("127.3.3.40:%d", id),
+		HomeDERP: int(id),
 	}
 	for _, opt := range opts {
 		opt(node)
@@ -3001,13 +3001,13 @@ func withName(name string) peerOptFunc {
 
 func withDERP(region int) peerOptFunc {
 	return func(n *tailcfg.Node) {
-		n.DERP = fmt.Sprintf("127.3.3.40:%d", region)
+		n.HomeDERP = region
 	}
 }
 
 func withoutDERP() peerOptFunc {
 	return func(n *tailcfg.Node) {
-		n.DERP = ""
+		n.HomeDERP = 0
 	}
 }
 

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -153,7 +153,8 @@ type CapabilityVersion int
 //   - 108: 2024-11-08: Client sends ServicesHash in Hostinfo, understands c2n GET /vip-services.
 //   - 109: 2024-11-18: Client supports filtertype.Match.SrcCaps (issue #12542)
 //   - 110: 2024-12-12: removed never-before-used Tailscale SSH public key support (#14373)
-const CurrentCapabilityVersion CapabilityVersion = 110
+//   - 111: 2025-01-14: Client supports a peer having Node.HomeDERP (issue #14636)
+const CurrentCapabilityVersion CapabilityVersion = 111
 
 // ID is an integer ID for a user, node, or login allocated by the
 // control plane.
@@ -346,15 +347,24 @@ type Node struct {
 	AllowedIPs   []netip.Prefix   // range of IP addresses to route to this node
 	Endpoints    []netip.AddrPort `json:",omitempty"` // IP+port (public via STUN, and local LANs)
 
-	// DERP is this node's home DERP region ID integer, but shoved into an
+	// LegacyDERPString is this node's home LegacyDERPString region ID integer, but shoved into an
 	// IP:port string for legacy reasons. The IP address is always "127.3.3.40"
 	// (a loopback address (127) followed by the digits over the letters DERP on
-	// a QWERTY keyboard (3.3.40)). The "port number" is the home DERP region ID
+	// a QWERTY keyboard (3.3.40)). The "port number" is the home LegacyDERPString region ID
 	// integer.
 	//
-	// TODO(bradfitz): simplify this legacy mess; add a new HomeDERPRegionID int
-	// field behind a new capver bump.
-	DERP string `json:",omitempty"` // DERP-in-IP:port ("127.3.3.40:N") endpoint
+	// Deprecated: HomeDERP has replaced this, but old servers might still send
+	// this field. See tailscale/tailscale#14636. Do not use this field in code
+	// other than in the upgradeNode func, which canonicalizes it to HomeDERP
+	// if it arrives as a LegacyDERPString string on the wire.
+	LegacyDERPString string `json:"DERP,omitempty"` // DERP-in-IP:port ("127.3.3.40:N") endpoint
+
+	// HomeDERP is the modern version of the DERP string field, with just an
+	// integer. The client advertises support for this as of capver 111.
+	//
+	// HomeDERP may be zero if not (yet) known, but ideally always be non-zero
+	// for magicsock connectivity to function normally.
+	HomeDERP int `json:",omitempty"` // DERP region ID of the node's home DERP
 
 	Hostinfo HostinfoView
 	Created  time.Time
@@ -2162,7 +2172,8 @@ func (n *Node) Equal(n2 *Node) bool {
 		slicesx.EqualSameNil(n.AllowedIPs, n2.AllowedIPs) &&
 		slicesx.EqualSameNil(n.PrimaryRoutes, n2.PrimaryRoutes) &&
 		slicesx.EqualSameNil(n.Endpoints, n2.Endpoints) &&
-		n.DERP == n2.DERP &&
+		n.LegacyDERPString == n2.LegacyDERPString &&
+		n.HomeDERP == n2.HomeDERP &&
 		n.Cap == n2.Cap &&
 		n.Hostinfo.Equal(n2.Hostinfo) &&
 		n.Created.Equal(n2.Created) &&

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -99,7 +99,8 @@ var _NodeCloneNeedsRegeneration = Node(struct {
 	Addresses                     []netip.Prefix
 	AllowedIPs                    []netip.Prefix
 	Endpoints                     []netip.AddrPort
-	DERP                          string
+	LegacyDERPString              string
+	HomeDERP                      int
 	Hostinfo                      HostinfoView
 	Created                       time.Time
 	Cap                           CapabilityVersion

--- a/tailcfg/tailcfg_test.go
+++ b/tailcfg/tailcfg_test.go
@@ -367,7 +367,7 @@ func TestNodeEqual(t *testing.T) {
 	nodeHandles := []string{
 		"ID", "StableID", "Name", "User", "Sharer",
 		"Key", "KeyExpiry", "KeySignature", "Machine", "DiscoKey",
-		"Addresses", "AllowedIPs", "Endpoints", "DERP", "Hostinfo",
+		"Addresses", "AllowedIPs", "Endpoints", "LegacyDERPString", "HomeDERP", "Hostinfo",
 		"Created", "Cap", "Tags", "PrimaryRoutes",
 		"LastSeen", "Online", "MachineAuthorized",
 		"Capabilities", "CapMap",
@@ -530,8 +530,13 @@ func TestNodeEqual(t *testing.T) {
 			true,
 		},
 		{
-			&Node{DERP: "foo"},
-			&Node{DERP: "bar"},
+			&Node{LegacyDERPString: "foo"},
+			&Node{LegacyDERPString: "bar"},
+			false,
+		},
+		{
+			&Node{HomeDERP: 1},
+			&Node{HomeDERP: 2},
 			false,
 		},
 		{

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -139,7 +139,8 @@ func (v NodeView) DiscoKey() key.DiscoPublic                { return v.ж.DiscoK
 func (v NodeView) Addresses() views.Slice[netip.Prefix]     { return views.SliceOf(v.ж.Addresses) }
 func (v NodeView) AllowedIPs() views.Slice[netip.Prefix]    { return views.SliceOf(v.ж.AllowedIPs) }
 func (v NodeView) Endpoints() views.Slice[netip.AddrPort]   { return views.SliceOf(v.ж.Endpoints) }
-func (v NodeView) DERP() string                             { return v.ж.DERP }
+func (v NodeView) LegacyDERPString() string                 { return v.ж.LegacyDERPString }
+func (v NodeView) HomeDERP() int                            { return v.ж.HomeDERP }
 func (v NodeView) Hostinfo() HostinfoView                   { return v.ж.Hostinfo }
 func (v NodeView) Created() time.Time                       { return v.ж.Created }
 func (v NodeView) Cap() CapabilityVersion                   { return v.ж.Cap }
@@ -192,7 +193,8 @@ var _NodeViewNeedsRegeneration = Node(struct {
 	Addresses                     []netip.Prefix
 	AllowedIPs                    []netip.Prefix
 	Endpoints                     []netip.AddrPort
-	DERP                          string
+	LegacyDERPString              string
+	HomeDERP                      int
 	Hostinfo                      HostinfoView
 	Created                       time.Time
 	Cap                           CapabilityVersion

--- a/tstest/integration/testcontrol/testcontrol.go
+++ b/tstest/integration/testcontrol/testcontrol.go
@@ -805,7 +805,7 @@ func (s *Server) serveMap(w http.ResponseWriter, r *http.Request, mkey key.Machi
 			node.Hostinfo = req.Hostinfo.View()
 			if ni := node.Hostinfo.NetInfo(); ni.Valid() {
 				if ni.PreferredDERP() != 0 {
-					node.DERP = fmt.Sprintf("127.3.3.40:%d", ni.PreferredDERP())
+					node.HomeDERP = ni.PreferredDERP()
 				}
 			}
 		}

--- a/types/netmap/netmap.go
+++ b/types/netmap/netmap.go
@@ -287,11 +287,8 @@ func printPeerConcise(buf *strings.Builder, p tailcfg.NodeView) {
 		epStrs[i] = fmt.Sprintf("%21v", e+strings.Repeat(" ", spaces))
 	}
 
-	derp := p.DERP()
-	const derpPrefix = "127.3.3.40:"
-	if strings.HasPrefix(derp, derpPrefix) {
-		derp = "D" + derp[len(derpPrefix):]
-	}
+	derp := fmt.Sprintf("D%d", p.HomeDERP())
+
 	var discoShort string
 	if !p.DiscoKey().IsZero() {
 		discoShort = p.DiscoKey().ShortString() + " "
@@ -311,7 +308,7 @@ func printPeerConcise(buf *strings.Builder, p tailcfg.NodeView) {
 // nodeConciseEqual reports whether a and b are equal for the fields accessed by printPeerConcise.
 func nodeConciseEqual(a, b tailcfg.NodeView) bool {
 	return a.Key() == b.Key() &&
-		a.DERP() == b.DERP() &&
+		a.HomeDERP() == b.HomeDERP() &&
 		a.DiscoKey() == b.DiscoKey() &&
 		views.SliceEqual(a.AllowedIPs(), b.AllowedIPs()) &&
 		views.SliceEqual(a.Endpoints(), b.Endpoints())

--- a/types/netmap/netmap_test.go
+++ b/types/netmap/netmap_test.go
@@ -63,12 +63,12 @@ func TestNetworkMapConcise(t *testing.T) {
 				Peers: nodeViews([]*tailcfg.Node{
 					{
 						Key:       testNodeKey(2),
-						DERP:      "127.3.3.40:2",
+						HomeDERP:  2,
 						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 					{
 						Key:       testNodeKey(3),
-						DERP:      "127.3.3.40:4",
+						HomeDERP:  4,
 						Endpoints: eps("10.2.0.100:12", "10.1.0.100:12345"),
 					},
 				}),
@@ -102,7 +102,7 @@ func TestConciseDiffFrom(t *testing.T) {
 				Peers: nodeViews([]*tailcfg.Node{
 					{
 						Key:       testNodeKey(2),
-						DERP:      "127.3.3.40:2",
+						HomeDERP:  2,
 						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 				}),
@@ -112,7 +112,7 @@ func TestConciseDiffFrom(t *testing.T) {
 				Peers: nodeViews([]*tailcfg.Node{
 					{
 						Key:       testNodeKey(2),
-						DERP:      "127.3.3.40:2",
+						HomeDERP:  2,
 						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 				}),
@@ -126,7 +126,7 @@ func TestConciseDiffFrom(t *testing.T) {
 				Peers: nodeViews([]*tailcfg.Node{
 					{
 						Key:       testNodeKey(2),
-						DERP:      "127.3.3.40:2",
+						HomeDERP:  2,
 						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 				}),
@@ -136,7 +136,7 @@ func TestConciseDiffFrom(t *testing.T) {
 				Peers: nodeViews([]*tailcfg.Node{
 					{
 						Key:       testNodeKey(2),
-						DERP:      "127.3.3.40:2",
+						HomeDERP:  2,
 						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 				}),
@@ -151,7 +151,7 @@ func TestConciseDiffFrom(t *testing.T) {
 					{
 						ID:        2,
 						Key:       testNodeKey(2),
-						DERP:      "127.3.3.40:2",
+						HomeDERP:  2,
 						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 				}),
@@ -162,19 +162,19 @@ func TestConciseDiffFrom(t *testing.T) {
 					{
 						ID:        1,
 						Key:       testNodeKey(1),
-						DERP:      "127.3.3.40:1",
+						HomeDERP:  1,
 						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 					{
 						ID:        2,
 						Key:       testNodeKey(2),
-						DERP:      "127.3.3.40:2",
+						HomeDERP:  2,
 						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 					{
 						ID:        3,
 						Key:       testNodeKey(3),
-						DERP:      "127.3.3.40:3",
+						HomeDERP:  3,
 						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 				}),
@@ -189,19 +189,19 @@ func TestConciseDiffFrom(t *testing.T) {
 					{
 						ID:        1,
 						Key:       testNodeKey(1),
-						DERP:      "127.3.3.40:1",
+						HomeDERP:  1,
 						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 					{
 						ID:        2,
 						Key:       testNodeKey(2),
-						DERP:      "127.3.3.40:2",
+						HomeDERP:  2,
 						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 					{
 						ID:        3,
 						Key:       testNodeKey(3),
-						DERP:      "127.3.3.40:3",
+						HomeDERP:  3,
 						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 				}),
@@ -212,7 +212,7 @@ func TestConciseDiffFrom(t *testing.T) {
 					{
 						ID:        2,
 						Key:       testNodeKey(2),
-						DERP:      "127.3.3.40:2",
+						HomeDERP:  2,
 						Endpoints: eps("192.168.0.100:12", "192.168.0.100:12354"),
 					},
 				}),
@@ -227,7 +227,7 @@ func TestConciseDiffFrom(t *testing.T) {
 					{
 						ID:        2,
 						Key:       testNodeKey(2),
-						DERP:      "127.3.3.40:2",
+						HomeDERP:  2,
 						Endpoints: eps("192.168.0.100:12", "1.1.1.1:1"),
 					},
 				}),
@@ -238,7 +238,7 @@ func TestConciseDiffFrom(t *testing.T) {
 					{
 						ID:        2,
 						Key:       testNodeKey(2),
-						DERP:      "127.3.3.40:2",
+						HomeDERP:  2,
 						Endpoints: eps("192.168.0.100:12", "1.1.1.1:2"),
 					},
 				}),
@@ -253,7 +253,7 @@ func TestConciseDiffFrom(t *testing.T) {
 					{
 						ID:         2,
 						Key:        testNodeKey(2),
-						DERP:       "127.3.3.40:2",
+						HomeDERP:   2,
 						Endpoints:  eps("192.168.0.100:41641", "1.1.1.1:41641"),
 						DiscoKey:   testDiscoKey("f00f00f00f"),
 						AllowedIPs: []netip.Prefix{netip.PrefixFrom(netaddr.IPv4(100, 102, 103, 104), 32)},
@@ -266,7 +266,7 @@ func TestConciseDiffFrom(t *testing.T) {
 					{
 						ID:         2,
 						Key:        testNodeKey(2),
-						DERP:       "127.3.3.40:2",
+						HomeDERP:   2,
 						Endpoints:  eps("192.168.0.100:41641", "1.1.1.1:41641"),
 						DiscoKey:   testDiscoKey("ba4ba4ba4b"),
 						AllowedIPs: []netip.Prefix{netip.PrefixFrom(netaddr.IPv4(100, 102, 103, 104), 32)},

--- a/types/netmap/nodemut.go
+++ b/types/netmap/nodemut.go
@@ -5,7 +5,6 @@ package netmap
 
 import (
 	"cmp"
-	"fmt"
 	"net/netip"
 	"reflect"
 	"slices"
@@ -35,7 +34,7 @@ type NodeMutationDERPHome struct {
 }
 
 func (m NodeMutationDERPHome) Apply(n *tailcfg.Node) {
-	n.DERP = fmt.Sprintf("127.3.3.40:%v", m.DERPRegion)
+	n.HomeDERP = m.DERPRegion
 }
 
 // NodeMutation is a NodeMutation that says a node's endpoints have changed.

--- a/wgengine/magicsock/endpoint.go
+++ b/wgengine/magicsock/endpoint.go
@@ -1359,7 +1359,7 @@ func (de *endpoint) updateFromNode(n tailcfg.NodeView, heartbeatDisabled bool, p
 		})
 		de.resetLocked()
 	}
-	if n.DERP() == "" {
+	if n.HomeDERP() == 0 {
 		if de.derpAddr.IsValid() {
 			de.debugUpdates.Add(EndpointChange{
 				When: time.Now(),
@@ -1369,7 +1369,7 @@ func (de *endpoint) updateFromNode(n tailcfg.NodeView, heartbeatDisabled bool, p
 		}
 		de.derpAddr = netip.AddrPort{}
 	} else {
-		newDerp, _ := netip.ParseAddrPort(n.DERP())
+		newDerp := netip.AddrPortFrom(tailcfg.DerpMagicIPAddr, uint16(n.HomeDERP()))
 		if de.derpAddr != newDerp {
 			de.debugUpdates.Add(EndpointChange{
 				When: time.Now(),

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -2337,10 +2337,7 @@ func devPanicf(format string, a ...any) {
 
 func (c *Conn) logEndpointCreated(n tailcfg.NodeView) {
 	c.logf("magicsock: created endpoint key=%s: disco=%s; %v", n.Key().ShortString(), n.DiscoKey().ShortString(), logger.ArgWriter(func(w *bufio.Writer) {
-		const derpPrefix = "127.3.3.40:"
-		if strings.HasPrefix(n.DERP(), derpPrefix) {
-			ipp, _ := netip.ParseAddrPort(n.DERP())
-			regionID := int(ipp.Port())
+		if regionID := n.HomeDERP(); regionID != 0 {
 			code := c.derpRegionCodeLocked(regionID)
 			if code != "" {
 				code = "(" + code + ")"

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -314,7 +314,7 @@ func meshStacks(logf logger.Logf, mutateNetmap func(idx int, nm *netmap.NetworkM
 				Addresses:  addrs,
 				AllowedIPs: addrs,
 				Endpoints:  epFromTyped(eps[i]),
-				DERP:       "127.3.3.40:1",
+				HomeDERP:   1,
 			}
 			nm.Peers = append(nm.Peers, peer.View())
 		}

--- a/wgengine/pendopen.go
+++ b/wgengine/pendopen.go
@@ -198,7 +198,7 @@ func (e *userspaceEngine) onOpenTimeout(flow flowtrack.Tuple) {
 			e.logf("open-conn-track: timeout opening %v; peer node %v running pre-0.100", flow, n.Key().ShortString())
 			return
 		}
-		if n.DERP() == "" {
+		if n.HomeDERP() == 0 {
 			e.logf("open-conn-track: timeout opening %v; peer node %v not connected to any DERP relay", flow, n.Key().ShortString())
 			return
 		}

--- a/wgengine/wgcfg/nmcfg/nmcfg.go
+++ b/wgengine/wgcfg/nmcfg/nmcfg.go
@@ -85,7 +85,7 @@ func WGCfg(nm *netmap.NetworkMap, logf logger.Logf, flags netmap.WGConfigFlags, 
 	skippedSubnets := new(bytes.Buffer)
 
 	for _, peer := range nm.Peers {
-		if peer.DiscoKey().IsZero() && peer.DERP() == "" && !peer.IsWireGuardOnly() {
+		if peer.DiscoKey().IsZero() && peer.HomeDERP() == 0 && !peer.IsWireGuardOnly() {
 			// Peer predates both DERP and active discovery, we cannot
 			// communicate with it.
 			logf("[v1] wgcfg: skipped peer %s, doesn't offer DERP or disco", peer.Key().ShortString())


### PR DESCRIPTION
This deprecates the old "DERP string" packing a DERP region ID into an
IP:port of 127.3.3.40:$REGION_ID and just uses an integer, like
PeerChange.DERPRegion does.

We still support servers sending the old form; they're converted to
the new form internally right when they're read off the network.

Updates #14636
