### PR TITLE
cmd/k8s-operator: require namespace config

### DIFF
--- a/cmd/k8s-operator/operator.go
+++ b/cmd/k8s-operator/operator.go
@@ -88,6 +88,15 @@ func main() {
 	zlog := kzap.NewRaw(opts...).Sugar()
 	logf.SetLogger(zapr.NewLogger(zlog.Desugar()))
 
+	if tsNamespace == "" {
+		const namespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+		b, err := os.ReadFile(namespaceFile)
+		if err != nil {
+			zlog.Fatalf("Could not get operator namespace from OPERATOR_NAMESPACE environment variable or default projected volume: %v", err)
+		}
+		tsNamespace = strings.TrimSpace(string(b))
+	}
+
 	// The operator can run either as a plain operator or it can
 	// additionally act as api-server proxy
 	// https://tailscale.com/kb/1236/kubernetes-operator/?q=kubernetes#accessing-the-kubernetes-control-plane-using-an-api-server-proxy.


### PR DESCRIPTION
Most users should not run into this because it's set in the helm chart and the deploy manifest, but if namespace is not set we get confusing authz errors because the kube client tries to fetch some namespaced resources as though they're cluster-scoped and reports permission denied. Try to detect namespace from the default projected volume, and otherwise fatal.

To test in a real cluster, delete just the `OPERATOR_NAMESPACE` environment variable from the deployment's spec first, and observe it still runs smoothly. Then set `automountServiceAccountToken: false` in the pod spec and it should fatal with the new log line as the namespace file is no longer available.

Fixes #cleanup

Change-Id: I64b34191e440b61204b9ad30bbfa117abbbe09c3