### PR TITLE
tailcfg,ipn/ipnlocal: send control info whether funnel is actually enabled

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -155,7 +155,8 @@ type CapabilityVersion int
 //   - 110: 2024-12-12: removed never-before-used Tailscale SSH public key support (#14373)
 //   - 111: 2025-01-14: Client supports a peer having Node.HomeDERP (issue #14636)
 //   - 112: 2025-01-14: Client interprets AllowedIPs of nil as meaning same as Addresses
-const CurrentCapabilityVersion CapabilityVersion = 112
+//   - 113: 2025-01-20: Client communicates to control whether funnel is enabled by sending Hostinfo.IngressEnabled (#14688)
+const CurrentCapabilityVersion CapabilityVersion = 113
 
 // ID is an integer ID for a user, node, or login allocated by the
 // control plane.
@@ -869,6 +870,7 @@ type Hostinfo struct {
 	ShareeNode      bool           `json:",omitempty"` // indicates this node exists in netmap because it's owned by a shared-to user
 	NoLogsNoSupport bool           `json:",omitempty"` // indicates that the user has opted out of sending logs and support
 	WireIngress     bool           `json:",omitempty"` // indicates that the node wants the option to receive ingress connections
+	IngressEnabled  bool           `json:",omitempty"` // if the node has any funnel endpoint enabled
 	AllowsUpdate    bool           `json:",omitempty"` // indicates that the node has opted-in to admin-console-drive remote updates
 	Machine         string         `json:",omitempty"` // the current host's machine type (uname -m)
 	GoArch          string         `json:",omitempty"` // GOARCH value (of the built binary)

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -166,6 +166,7 @@ var _HostinfoCloneNeedsRegeneration = Hostinfo(struct {
 	ShareeNode      bool
 	NoLogsNoSupport bool
 	WireIngress     bool
+	IngressEnabled  bool
 	AllowsUpdate    bool
 	Machine         string
 	GoArch          string

--- a/tailcfg/tailcfg_test.go
+++ b/tailcfg/tailcfg_test.go
@@ -51,6 +51,7 @@ func TestHostinfoEqual(t *testing.T) {
 		"ShareeNode",
 		"NoLogsNoSupport",
 		"WireIngress",
+		"IngressEnabled",
 		"AllowsUpdate",
 		"Machine",
 		"GoArch",
@@ -249,6 +250,26 @@ func TestHostinfoEqual(t *testing.T) {
 		{
 			&Hostinfo{ServicesHash: "084c799cd551dd1d8d5c5f9a5d593b2e931f5e36122ee5c793c1d08a19839cc0"},
 			&Hostinfo{},
+			false,
+		},
+		{
+			&Hostinfo{IngressEnabled: true},
+			&Hostinfo{},
+			false,
+		},
+		{
+			&Hostinfo{IngressEnabled: true},
+			&Hostinfo{IngressEnabled: true},
+			true,
+		},
+		{
+			&Hostinfo{IngressEnabled: false},
+			&Hostinfo{},
+			true,
+		},
+		{
+			&Hostinfo{IngressEnabled: false},
+			&Hostinfo{IngressEnabled: true},
 			false,
 		},
 	}

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -283,6 +283,7 @@ func (v HostinfoView) ShieldsUp() bool                        { return v.ж.Shie
 func (v HostinfoView) ShareeNode() bool                       { return v.ж.ShareeNode }
 func (v HostinfoView) NoLogsNoSupport() bool                  { return v.ж.NoLogsNoSupport }
 func (v HostinfoView) WireIngress() bool                      { return v.ж.WireIngress }
+func (v HostinfoView) IngressEnabled() bool                   { return v.ж.IngressEnabled }
 func (v HostinfoView) AllowsUpdate() bool                     { return v.ж.AllowsUpdate }
 func (v HostinfoView) Machine() string                        { return v.ж.Machine }
 func (v HostinfoView) GoArch() string                         { return v.ж.GoArch }
@@ -324,6 +325,7 @@ var _HostinfoViewNeedsRegeneration = Hostinfo(struct {
 	ShareeNode      bool
 	NoLogsNoSupport bool
 	WireIngress     bool
+	IngressEnabled  bool
 	AllowsUpdate    bool
 	Machine         string
 	GoArch          string


### PR DESCRIPTION
This PR is part of a fix for a bug, where a node with any 'AllowFunnel' block set in tailscale serve was being displayed as if having funnel enabled in the admin panel. It adds a new Hostinfo.IngressEnabled field that is set to true if the node has funnel actually enabled.
This will be sent to control and used to determine whether the node should have the 'Funnel' badge.

Updates tailscale/tailscale#11572
Updates tailscale/corp#25931