### PR TITLE
Address comments in PR-13982

### DIFF
--- a/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
+++ b/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       {{- if .Values.operatorConfig.hostNetwork.enabled }}
       hostNetwork: true
-      dnsPolicy: {{ .Values.operatorConfig.hostNetwork.dnsPolicy }}
+      dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -50,7 +50,7 @@ spec:
           {{- if .Values.operatorConfig.port.enabled }}
           ports:
             - containerPort: {{ .Values.operatorConfig.port.containerPort }}
-              protocol: TCP
+              protocol: UDP
           {{- end }}
           {{- with .Values.operatorConfig.resources }}
           resources:
@@ -77,7 +77,7 @@ spec:
             - name: CLIENT_SECRET_FILE
               value: /oauth/client_secret
             {{- if .Values.operatorConfig.port.enabled }}
-            - name: PORT
+            - name: TS_PORT
               value: {{ .Values.operatorConfig.port.containerPort | quote }}
             {{- end }}
             {{- $proxyTag := printf ":%s" ( .Values.proxyConfig.image.tag | default .Chart.AppVersion )}}

--- a/cmd/k8s-operator/deploy/chart/values.yaml
+++ b/cmd/k8s-operator/deploy/chart/values.yaml
@@ -30,7 +30,6 @@ operatorConfig:
   # Optional host network configuration. Likely only needed for public Kubernetes nodes
   hostNetwork:
     enabled: false
-    dnsPolicy: ClusterFirstWithHostNet  # Common options: ClusterFirst, ClusterFirstWithHostNet, Default
 
   image:
     # Repository defaults to DockerHub, but images are also synced to ghcr.io/tailscale/k8s-operator.


### PR DESCRIPTION
Hello! I currently administer an application that lives in a high-stakes environment - the applications are ran as various K8s workloads, and we divy up access to applications via Tailscale. As it stands with the vanilla/official charts, direct connections are not feasible without some small tweaks. I'd rather keep using the official charts instead of forking and maintaining a fork. 

Thus, this PR addresses concerns/comments left on this PR: https://github.com/tailscale/tailscale/pull/13982, which AFAICT will allow for direct connections within our cluster (we'd be able to pin a well-known port on the host machine, which can then be exposed publicly).

Happy to address any further issues to get this PR into a releasable state.