### PR TITLE
Revert "ipn/ipnlocal: re-advertise appc routes on startup (#14609)"

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -4356,33 +4356,6 @@ func (b *LocalBackend) reconfigAppConnectorLocked(nm *netmap.NetworkMap, prefs i
 	b.appConnector.UpdateDomainsAndRoutes(domains, routes)
 }
 
-func (b *LocalBackend) readvertiseAppConnectorRoutes() {
-	var domainRoutes map[string][]netip.Addr
-	b.mu.Lock()
-	if b.appConnector != nil {
-		domainRoutes = b.appConnector.DomainRoutes()
-	}
-	b.mu.Unlock()
-	if domainRoutes == nil {
-		return
-	}
-
-	// Re-advertise the stored routes, in case stored state got out of
-	// sync with previously advertised routes in prefs.
-	var prefixes []netip.Prefix
-	for _, ips := range domainRoutes {
-		for _, ip := range ips {
-			prefixes = append(prefixes, netip.PrefixFrom(ip, ip.BitLen()))
-		}
-	}
-	// Note: AdvertiseRoute will trim routes that are already
-	// advertised, so if everything is already being advertised this is
-	// a noop.
-	if err := b.AdvertiseRoute(prefixes...); err != nil {
-		b.logf("error advertising stored app connector routes: %v", err)
-	}
-}
-
 // authReconfig pushes a new configuration into wgengine, if engine
 // updates are not currently blocked, based on the cached netmap and
 // user prefs.
@@ -4461,7 +4434,6 @@ func (b *LocalBackend) authReconfig() {
 	}
 
 	b.initPeerAPIListener()
-	b.readvertiseAppConnectorRoutes()
 }
 
 // shouldUseOneCGNATRoute reports whether we should prefer to make one big
@@ -7204,7 +7176,7 @@ var ErrDisallowedAutoRoute = errors.New("route is not allowed")
 // If the route is disallowed, ErrDisallowedAutoRoute is returned.
 func (b *LocalBackend) AdvertiseRoute(ipps ...netip.Prefix) error {
 	finalRoutes := b.Prefs().AdvertiseRoutes().AsSlice()
-	var newRoutes []netip.Prefix
+	newRoutes := false
 
 	for _, ipp := range ipps {
 		if !allowedAutoRoute(ipp) {
@@ -7220,14 +7192,13 @@ func (b *LocalBackend) AdvertiseRoute(ipps ...netip.Prefix) error {
 		}
 
 		finalRoutes = append(finalRoutes, ipp)
-		newRoutes = append(newRoutes, ipp)
+		newRoutes = true
 	}
 
-	if len(newRoutes) == 0 {
+	if !newRoutes {
 		return nil
 	}
 
-	b.logf("advertising new app connector routes: %v", newRoutes)
 	_, err := b.EditPrefs(&ipn.MaskedPrefs{
 		Prefs: ipn.Prefs{
 			AdvertiseRoutes: finalRoutes,


### PR DESCRIPTION
This reverts commit 1b303ee5baef3ddab40be4d1c2 (#14609).

It caused a deadlock; see tailscale/corp#25965

Updates tailscale/corp#25965
Updates #13680
Updates #14606
