### PR TITLE
derp: track histograms of packet drops by client

### DIFF
--- a/derp/prometheus_adapter.go
+++ b/derp/prometheus_adapter.go
@@ -1,0 +1,31 @@
+package derp
+
+import (
+	"io"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/expfmt"
+)
+
+var (
+	expFormat = expfmt.NewFormat(expfmt.TypeTextPlain)
+)
+
+// collectorVar implements expvar.Var and metrics.PrometheusWriter
+type collectorVar struct {
+	prometheus.Collector
+}
+
+func (cw collectorVar) String() string {
+	return `"CollectorVar"`
+}
+
+func (cw collectorVar) WritePrometheus(w io.Writer, name string) {
+	reg := prometheus.NewRegistry()
+	_ = reg.Register(cw)
+	mfs, _ := reg.Gather()
+	enc := expfmt.NewEncoder(w, expFormat)
+	for _, mf := range mfs {
+		_ = enc.Encode(mf)
+	}
+}


### PR DESCRIPTION
When packets are dropped, track this for both the client from which the packet was received and the client to which it was sent. Distinguish drops by kind (disco vs non-disco) and drop reason.

Every 10 seconds, calculate the rate of drops per second per client, and collect a histogram showing the distribution of clients by drops per second.