### PR TITLE
cmd/natc: send TCP keepalives to upstreams

### DIFF
--- a/cmd/natc/natc.go
+++ b/cmd/natc/natc.go
@@ -475,7 +475,8 @@ func proxyTCPConn(c net.Conn, dest string) {
 		},
 	}
 	p.AddRoute(addrPortStr, &tcpproxy.DialProxy{
-		Addr: fmt.Sprintf("%s:%s", dest, port),
+		Addr:            fmt.Sprintf("%s:%s", dest, port),
+		KeepAlivePeriod: time.Second,
 	})
 	p.Start()
 }


### PR DESCRIPTION
Idle connections may silently close, detect those closures with TCP keeliave.

Updates tailscale/corp#25169