### PR TITLE
tailcfg: add ServiceName

### DIFF
--- a/cmd/k8s-operator/ingress-for-pg_test.go
+++ b/cmd/k8s-operator/ingress-for-pg_test.go
@@ -137,7 +137,7 @@ func TestIngressPGReconciler(t *testing.T) {
 		t.Fatalf("unmarshaling serve config: %v", err)
 	}
 
-	if cfg.Services["my-svc"] == nil {
+	if cfg.Services["svc:my-svc"] == nil {
 		t.Error("expected serve config to contain VIPService configuration")
 	}
 

--- a/cmd/tailscale/cli/advertise.go
+++ b/cmd/tailscale/cli/advertise.go
@@ -66,7 +66,7 @@ func parseServiceNames(servicesArg string) ([]string, error) {
 	if servicesArg != "" {
 		services = strings.Split(servicesArg, ",")
 		for _, svc := range services {
-			err := tailcfg.CheckServiceName(svc)
+			err := tailcfg.ServiceName(svc).Validate()
 			if err != nil {
 				return nil, fmt.Errorf("service %q: %s", svc, err)
 			}

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -106,7 +106,7 @@ func (src *ServeConfig) Clone() *ServeConfig {
 		}
 	}
 	if dst.Services != nil {
-		dst.Services = map[string]*ServiceConfig{}
+		dst.Services = map[tailcfg.ServiceName]*ServiceConfig{}
 		for k, v := range src.Services {
 			if v == nil {
 				dst.Services[k] = nil
@@ -133,7 +133,7 @@ func (src *ServeConfig) Clone() *ServeConfig {
 var _ServeConfigCloneNeedsRegeneration = ServeConfig(struct {
 	TCP         map[uint16]*TCPPortHandler
 	Web         map[HostPort]*WebServerConfig
-	Services    map[string]*ServiceConfig
+	Services    map[tailcfg.ServiceName]*ServiceConfig
 	AllowFunnel map[HostPort]bool
 	Foreground  map[string]*ServeConfig
 	ETag        string

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -195,7 +195,7 @@ func (v ServeConfigView) Web() views.MapFn[HostPort, *WebServerConfig, WebServer
 	})
 }
 
-func (v ServeConfigView) Services() views.MapFn[string, *ServiceConfig, ServiceConfigView] {
+func (v ServeConfigView) Services() views.MapFn[tailcfg.ServiceName, *ServiceConfig, ServiceConfigView] {
 	return views.MapFnOf(v.ж.Services, func(t *ServiceConfig) ServiceConfigView {
 		return t.View()
 	})
@@ -216,7 +216,7 @@ func (v ServeConfigView) ETag() string { return v.ж.ETag }
 var _ServeConfigViewNeedsRegeneration = ServeConfig(struct {
 	TCP         map[uint16]*TCPPortHandler
 	Web         map[HostPort]*WebServerConfig
-	Services    map[string]*ServiceConfig
+	Services    map[tailcfg.ServiceName]*ServiceConfig
 	AllowFunnel map[HostPort]bool
 	Foreground  map[string]*ServeConfig
 	ETag        string

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -2715,7 +2715,7 @@ func TestTCPHandlerForDstWithVIPService(t *testing.T) {
 
 	err = b.setServeConfigLocked(
 		&ipn.ServeConfig{
-			Services: map[string]*ipn.ServiceConfig{
+			Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
 				"svc:foo": {
 					TCP: map[uint16]*ipn.TCPPortHandler{
 						882: {HTTP: true},
@@ -4747,7 +4747,7 @@ func TestGetVIPServices(t *testing.T) {
 			"served-only",
 			[]string{},
 			&ipn.ServeConfig{
-				Services: map[string]*ipn.ServiceConfig{
+				Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
 					"svc:abc": {Tun: true},
 				},
 			},
@@ -4762,7 +4762,7 @@ func TestGetVIPServices(t *testing.T) {
 			"served-and-advertised",
 			[]string{"svc:abc"},
 			&ipn.ServeConfig{
-				Services: map[string]*ipn.ServiceConfig{
+				Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
 					"svc:abc": {Tun: true},
 				},
 			},
@@ -4778,7 +4778,7 @@ func TestGetVIPServices(t *testing.T) {
 			"served-and-advertised-different-service",
 			[]string{"svc:def"},
 			&ipn.ServeConfig{
-				Services: map[string]*ipn.ServiceConfig{
+				Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
 					"svc:abc": {Tun: true},
 				},
 			},
@@ -4797,7 +4797,7 @@ func TestGetVIPServices(t *testing.T) {
 			"served-with-port-ranges-one-range-single",
 			[]string{},
 			&ipn.ServeConfig{
-				Services: map[string]*ipn.ServiceConfig{
+				Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
 					"svc:abc": {TCP: map[uint16]*ipn.TCPPortHandler{
 						80: {HTTPS: true},
 					}},
@@ -4814,7 +4814,7 @@ func TestGetVIPServices(t *testing.T) {
 			"served-with-port-ranges-one-range-multiple",
 			[]string{},
 			&ipn.ServeConfig{
-				Services: map[string]*ipn.ServiceConfig{
+				Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
 					"svc:abc": {TCP: map[uint16]*ipn.TCPPortHandler{
 						80: {HTTPS: true},
 						81: {HTTPS: true},
@@ -4833,7 +4833,7 @@ func TestGetVIPServices(t *testing.T) {
 			"served-with-port-ranges-multiple-ranges",
 			[]string{},
 			&ipn.ServeConfig{
-				Services: map[string]*ipn.ServiceConfig{
+				Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
 					"svc:abc": {TCP: map[uint16]*ipn.TCPPortHandler{
 						80:   {HTTPS: true},
 						81:   {HTTPS: true},
@@ -4866,7 +4866,7 @@ func TestGetVIPServices(t *testing.T) {
 			}
 			got := lb.vipServicesFromPrefsLocked(prefs.View())
 			slices.SortFunc(got, func(a, b *tailcfg.VIPService) int {
-				return strings.Compare(a.Name, b.Name)
+				return strings.Compare(a.Name.String(), b.Name.String())
 			})
 			if !reflect.DeepEqual(tt.want, got) {
 				t.Logf("want:")

--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -55,7 +55,7 @@ var serveHTTPContextKey ctxkey.Key[*serveHTTPContext]
 
 type serveHTTPContext struct {
 	SrcAddr       netip.AddrPort
-	ForVIPService string // VIP service name, empty string means local
+	ForVIPService tailcfg.ServiceName // "" means local
 	DestPort      uint16
 
 	// provides funnel-specific context, nil if not funneled
@@ -1006,7 +1006,7 @@ func allNumeric(s string) bool {
 	return s != ""
 }
 
-func (b *LocalBackend) webServerConfig(hostname string, forVIPService string, port uint16) (c ipn.WebServerConfigView, ok bool) {
+func (b *LocalBackend) webServerConfig(hostname string, forVIPService tailcfg.ServiceName, port uint16) (c ipn.WebServerConfigView, ok bool) {
 	key := ipn.HostPort(fmt.Sprintf("%s:%v", hostname, port))
 
 	b.mu.Lock()
@@ -1021,7 +1021,7 @@ func (b *LocalBackend) webServerConfig(hostname string, forVIPService string, po
 	return b.serveConfig.FindWeb(key)
 }
 
-func (b *LocalBackend) getTLSServeCertForPort(port uint16, forVIPService string) func(hi *tls.ClientHelloInfo) (*tls.Certificate, error) {
+func (b *LocalBackend) getTLSServeCertForPort(port uint16, forVIPService tailcfg.ServiceName) func(hi *tls.ClientHelloInfo) (*tls.Certificate, error) {
 	return func(hi *tls.ClientHelloInfo) (*tls.Certificate, error) {
 		if hi == nil || hi.ServerName == "" {
 			return nil, errors.New("no SNI ServerName")

--- a/ipn/ipnlocal/serve_test.go
+++ b/ipn/ipnlocal/serve_test.go
@@ -354,7 +354,7 @@ func TestServeConfigServices(t *testing.T) {
 		{
 			name: "one-incorrectly-configured-service",
 			conf: &ipn.ServeConfig{
-				Services: map[string]*ipn.ServiceConfig{
+				Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
 					"svc:foo": {
 						TCP: map[uint16]*ipn.TCPPortHandler{
 							80: {HTTP: true},
@@ -369,7 +369,7 @@ func TestServeConfigServices(t *testing.T) {
 			// one correctly configured service with packet should be intercepted
 			name: "one-service-intercept-packet",
 			conf: &ipn.ServeConfig{
-				Services: map[string]*ipn.ServiceConfig{
+				Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
 					"svc:foo": {
 						TCP: map[uint16]*ipn.TCPPortHandler{
 							80: {HTTP: true},
@@ -388,7 +388,7 @@ func TestServeConfigServices(t *testing.T) {
 			// one correctly configured service with packet should not be intercepted
 			name: "one-service-not-intercept-packet",
 			conf: &ipn.ServeConfig{
-				Services: map[string]*ipn.ServiceConfig{
+				Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
 					"svc:foo": {
 						TCP: map[uint16]*ipn.TCPPortHandler{
 							80: {HTTP: true},
@@ -406,10 +406,10 @@ func TestServeConfigServices(t *testing.T) {
 			intercepted: false,
 		},
 		{
-			//multiple correctly configured service with packet should be intercepted
+			// multiple correctly configured service with packet should be intercepted
 			name: "multiple-service-intercept-packet",
 			conf: &ipn.ServeConfig{
-				Services: map[string]*ipn.ServiceConfig{
+				Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
 					"svc:foo": {
 						TCP: map[uint16]*ipn.TCPPortHandler{
 							80: {HTTP: true},
@@ -437,7 +437,7 @@ func TestServeConfigServices(t *testing.T) {
 			// multiple correctly configured service with packet should not be intercepted
 			name: "multiple-service-not-intercept-packet",
 			conf: &ipn.ServeConfig{
-				Services: map[string]*ipn.ServiceConfig{
+				Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
 					"svc:foo": {
 						TCP: map[uint16]*ipn.TCPPortHandler{
 							80: {HTTP: true},

--- a/ipn/serve.go
+++ b/ipn/serve.go
@@ -57,7 +57,7 @@ type ServeConfig struct {
 
 	// Services maps from service name (in the form "svc:dns-label") to a ServiceConfig.
 	// Which describes the L3, L4, and L7 forwarding information for the service.
-	Services map[string]*ServiceConfig `json:",omitempty"`
+	Services map[tailcfg.ServiceName]*ServiceConfig `json:",omitempty"`
 
 	// AllowFunnel is the set of SNI:port values for which funnel
 	// traffic is allowed, from trusted ingress peers.
@@ -618,7 +618,7 @@ func (v ServeConfigView) Webs() iter.Seq2[HostPort, WebServerConfigView] {
 }
 
 // FindServiceTCP return the TCPPortHandlerView for the given service name and port.
-func (v ServeConfigView) FindServiceTCP(svcName string, port uint16) (res TCPPortHandlerView, ok bool) {
+func (v ServeConfigView) FindServiceTCP(svcName tailcfg.ServiceName, port uint16) (res TCPPortHandlerView, ok bool) {
 	svcCfg, ok := v.Services().GetOk(svcName)
 	if !ok {
 		return res, ok
@@ -626,7 +626,7 @@ func (v ServeConfigView) FindServiceTCP(svcName string, port uint16) (res TCPPor
 	return svcCfg.TCP().GetOk(port)
 }
 
-func (v ServeConfigView) FindServiceWeb(svcName string, hp HostPort) (res WebServerConfigView, ok bool) {
+func (v ServeConfigView) FindServiceWeb(svcName tailcfg.ServiceName, hp HostPort) (res WebServerConfigView, ok bool) {
 	if svcCfg, ok := v.Services().GetOk(svcName); ok {
 		if res, ok := svcCfg.Web().GetOk(hp); ok {
 			return res, ok

--- a/types/netmap/netmap.go
+++ b/types/netmap/netmap.go
@@ -427,10 +427,10 @@ const (
 )
 
 // IPServiceMappings maps IP addresses to service names. This is the inverse of
-// [ServiceIPMappings], and is used to inform clients which services is an VIP
-// address associated with. This is set to b.ipVIPServiceMap every time the
-// netmap is updated. This is used to reduce the cost for looking up the service
-// name for the dst IP address in the netStack packet processing workflow.
+// [tailcfg.ServiceIPMappings], and is used to inform track which service a VIP
+// is associated with. This is set to b.ipVIPServiceMap every time the netmap is
+// updated. This is used to reduce the cost for looking up the service name for
+// the dst IP address in the netStack packet processing workflow.
 //
 // This is of the form:
 //
@@ -440,4 +440,4 @@ const (
 //	  "100.102.42.3": "svc:web",
 //	  "fd7a:115c:a1e0::abcd": "svc:web",
 //	}
-type IPServiceMappings map[netip.Addr]string
+type IPServiceMappings map[netip.Addr]tailcfg.ServiceName


### PR DESCRIPTION
Rather than using a string everywhere and needing to clarify that the string should have the svc: prefix, create a separate type for Service names.

Updates tailscale/corp#24607

Change-Id: I720e022f61a7221644bb60955b72cacf42f59960