### PR TITLE
tailcfg: remove now-unused TailscaleFunnelEnabled method

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -927,14 +927,6 @@ func (hi *Hostinfo) TailscaleSSHEnabled() bool {
 
 func (v HostinfoView) TailscaleSSHEnabled() bool { return v.ж.TailscaleSSHEnabled() }
 
-// TailscaleFunnelEnabled reports whether or not this node has explicitly
-// enabled Funnel.
-func (hi *Hostinfo) TailscaleFunnelEnabled() bool {
-	return hi != nil && hi.WireIngress
-}
-
-func (v HostinfoView) TailscaleFunnelEnabled() bool { return v.ж.TailscaleFunnelEnabled() }
-
 // NetInfo contains information about the host's network state.
 type NetInfo struct {
 	// MappingVariesByDestIP says whether the host's NAT mappings


### PR DESCRIPTION
As of tailscale/corp#26003

Updates tailscale/tailscale#11572
