### PR TITLE
cmd/derper,derp: make TCP write timeout configurable

### DIFF
--- a/cmd/derper/derper.go
+++ b/cmd/derper/derper.go
@@ -77,6 +77,8 @@ var (
 	tcpKeepAlive = flag.Duration("tcp-keepalive-time", 10*time.Minute, "TCP keepalive time")
 	// tcpUserTimeout is intentionally short, so that hung connections are cleaned up promptly. DERPs should be nearby users.
 	tcpUserTimeout = flag.Duration("tcp-user-timeout", 15*time.Second, "TCP user timeout")
+	// tcpWriteTimeout is the timeout for writing to client TCP connections. It does not apply to mesh connections.
+	tcpWriteTimeout = flag.Duration("tcp-write-timeout", derp.DefaultTCPWiteTimeout, "TCP write timeout; 0 results in no timeout being set on writes")
 )
 
 var (
@@ -173,6 +175,7 @@ func main() {
 	s.SetVerifyClient(*verifyClients)
 	s.SetVerifyClientURL(*verifyClientURL)
 	s.SetVerifyClientURLFailOpen(*verifyFailOpen)
+	s.SetTCPWriteTimeout(*tcpWriteTimeout)
 
 	if *meshPSKFile != "" {
 		b, err := os.ReadFile(*meshPSKFile)

--- a/derp/derp.go
+++ b/derp/derp.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"time"
 )
 
@@ -253,4 +254,15 @@ func writeFrame(bw *bufio.Writer, t frameType, b []byte) error {
 		return err
 	}
 	return bw.Flush()
+}
+
+// Conn is the subset of the underlying net.Conn the DERP Server needs.
+// It is a defined type so that non-net connections can be used.
+type Conn interface {
+	io.WriteCloser
+	LocalAddr() net.Addr
+	// The *Deadline methods follow the semantics of net.Conn.
+	SetDeadline(time.Time) error
+	SetReadDeadline(time.Time) error
+	SetWriteDeadline(time.Time) error
 }

--- a/derp/derp_server.go
+++ b/derp/derp_server.go
@@ -23,7 +23,6 @@ import (
 	"math"
 	"math/big"
 	"math/rand/v2"
-	"net"
 	"net/http"
 	"net/netip"
 	"os"
@@ -339,17 +338,6 @@ func (s *dupClientSet) removeClient(c *sclient) bool {
 type PacketForwarder interface {
 	ForwardPacket(src, dst key.NodePublic, payload []byte) error
 	String() string
-}
-
-// Conn is the subset of the underlying net.Conn the DERP Server needs.
-// It is a defined type so that non-net connections can be used.
-type Conn interface {
-	io.WriteCloser
-	LocalAddr() net.Addr
-	// The *Deadline methods follow the semantics of net.Conn.
-	SetDeadline(time.Time) error
-	SetReadDeadline(time.Time) error
-	SetWriteDeadline(time.Time) error
 }
 
 var packetsDropped = metrics.NewMultiLabelMap[dropReasonKindLabels](


### PR DESCRIPTION
This PR includes two commits.

1. Move the Conn interface to `derp.go` to clarify that it's used by both the server and client code.
2. Add a command-line flag for configuring the write timeout

Updates tailscale/corp#26045.