### PR TITLE
fix: allow exit node on unraid

### DIFF
--- a/envknob/featureknob/featureknob.go
+++ b/envknob/featureknob/featureknob.go
@@ -55,8 +55,7 @@ func CanRunTailscaleSSH() error {
 func CanUseExitNode() error {
 	switch dist := distro.Get(); dist {
 	case distro.Synology, // see https://github.com/tailscale/tailscale/issues/1995
-		distro.QNAP,
-		distro.Unraid:
+		distro.QNAP:
 		return errors.New("Tailscale exit nodes cannot be used on " + string(dist))
 	}
 


### PR DESCRIPTION
Ref: #14372

This PR removes the restriction preventing Unraid installations from using exit nodes.

I have been unable to find a reason for this action. After the restriction was reported to me by Unraid users, I attempted to get information via #14372 and by reaching out to Tailscale directly, with no response via either method.

After removing the restriction, I ran this build on my Unraid test cluster and exit nodes worked properly.