### PR TITLE
cmd/natc,wgengine/netstack: tune buffer size and segment lifetime in …

### DIFF
--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -405,6 +405,14 @@ func (ns *Impl) Close() error {
 	return nil
 }
 
+// SetTransportProtocolOption forwards to the underlying
+// [stack.Stack.SetTransportProtocolOption]. Callers are responsible for
+// ensuring that the options are valid, compatible and appropriate for their use
+// case. Compatibility may change at any version.
+func (ns *Impl) SetTransportProtocolOption(transport tcpip.TransportProtocolNumber, option tcpip.SettableTransportProtocolOption) tcpip.Error {
+	return ns.ipstack.SetTransportProtocolOption(transport, option)
+}
+
 // A single process might have several netstacks running at the same time.
 // Exported clientmetric counters will have a sum of counters of all of them.
 var stacksForMetrics syncs.Map[*Impl, struct{}]


### PR DESCRIPTION
…natc

Some natc instances have been observed with excessive memory growth, dominant in gvisor buffers. It is likely that the connection buffers are sticking around for too long due to the default long segment time, and uptuned buffer size applied by default in wgengine/netstack. Apply configurations in natc specifically which are a better match for the natc use case, most notably a 5s maximum segment lifetime.

Updates tailscale/corp#25169