### PR TITLE
util/clientmetric: use counter in aggcounter

### DIFF
--- a/util/clientmetric/clientmetric.go
+++ b/util/clientmetric/clientmetric.go
@@ -270,7 +270,7 @@ func (c *AggregateCounter) UnregisterAll() {
 // a sum of expvar variables registered with it.
 func NewAggregateCounter(name string) *AggregateCounter {
 	c := &AggregateCounter{counters: set.Set[*expvar.Int]{}}
-	NewGaugeFunc(name, c.Value)
+	NewCounterFunc(name, c.Value)
 	return c
 }
 


### PR DESCRIPTION
Fixes an oversight where underlying aggregated metrics was published as gauge and not counter.

Fixes #14743