### PR TITLE
ipn/store/awsstore: allow providing a KMS key

### DIFF
--- a/ipn/store/awsstore/store_aws_stub.go
+++ b/ipn/store/awsstore/store_aws_stub.go
@@ -13,6 +13,6 @@ import (
 	"tailscale.com/types/logger"
 )
 
-func New(logger.Logf, string) (ipn.StateStore, error) {
+func New(_ logger.Logf, _ string, _ string) (ipn.StateStore, error) {
 	return nil, fmt.Errorf("AWS store is not supported on %v", runtime.GOOS)
 }

--- a/ipn/store/awsstore/store_aws_test.go
+++ b/ipn/store/awsstore/store_aws_test.go
@@ -65,7 +65,7 @@ func TestNewAWSStore(t *testing.T) {
 		Resource:  "parameter/foo",
 	}
 
-	s, err := newStore(storeParameterARN.String(), mc)
+	s, err := newStore(storeParameterARN.String(), "arn:aws:kms:eu-west-1:123456789:key/MyCustomKey", mc)
 	if err != nil {
 		t.Fatalf("creating aws store failed: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestNewAWSStore(t *testing.T) {
 
 	// Build a brand new file store and check that both IDs written
 	// above are still there.
-	s2, err := newStore(storeParameterARN.String(), mc)
+	s2, err := newStore(storeParameterARN.String(), "arn:aws:kms:eu-west-1:123456789:key/MyCustomKey", mc)
 	if err != nil {
 		t.Fatalf("creating second aws store failed: %v", err)
 	}

--- a/ipn/store/store_aws.go
+++ b/ipn/store/store_aws.go
@@ -6,13 +6,34 @@
 package store
 
 import (
-	"tailscale.com/ipn/store/awsstore"
+    "strings"
+
+    "tailscale.com/ipn"
+    "tailscale.com/ipn/store/awsstore"
+    "tailscale.com/types/logger"
 )
 
 func init() {
-	registerAvailableExternalStores = append(registerAvailableExternalStores, registerAWSStore)
+    registerAvailableExternalStores = append(registerAvailableExternalStores, registerAWSStore)
 }
 
 func registerAWSStore() {
-	Register("arn:", awsstore.New)
+    Register("arn:", func(logf logger.Logf, arg string) (ipn.StateStore, error) {
+        // Extract the KMS key ID if present
+        kmsKeyID := ""
+        parts := strings.SplitN(arg, "?kmsKey=", 2)
+        ssmARN := parts[0]
+
+        if len(parts) == 2 {
+            kmsKeyID = parts[1]
+
+			// We allow an arn, a key ID, or an alias name.
+            if !strings.Contains(kmsKeyID, "/") &&
+               !strings.HasPrefix(kmsKeyID, "arn:aws:kms:") {
+                kmsKeyID = "alias/" + kmsKeyID
+            }
+        }
+
+        return awsstore.New(logf, ssmARN, kmsKeyID)
+    })
 }


### PR DESCRIPTION
Implements a KMS input for AWS parameter to support encrypting Tailscale
state

Fixes #14765

Signed-off-by: Lee Briggs <lee@leebriggs.co.uk>
