### PR TITLE
ipn/ipnlocal: add debug envknob for ACME directory URL

### DIFF
--- a/ipn/ipnlocal/cert.go
+++ b/ipn/ipnlocal/cert.go
@@ -659,8 +659,9 @@ func acmeClient(cs certStore) (*acme.Client, error) {
 	// LetsEncrypt), we should make sure that they support ARI extension (see
 	// shouldStartDomainRenewalARI).
 	return &acme.Client{
-		Key:       key,
-		UserAgent: "tailscaled/" + version.Long(),
+		Key:          key,
+		UserAgent:    "tailscaled/" + version.Long(),
+		DirectoryURL: envknob.String("TS_DEBUG_ACME_DIRECTORY_URL"),
 	}, nil
 }
 

--- a/ipn/ipnlocal/cert_test.go
+++ b/ipn/ipnlocal/cert_test.go
@@ -199,3 +199,19 @@ func TestShouldStartDomainRenewal(t *testing.T) {
 		})
 	}
 }
+
+func TestDebugACMEDirectoryURL(t *testing.T) {
+	for _, tc := range []string{"", "https://acme-staging-v02.api.letsencrypt.org/directory"} {
+		const setting = "TS_DEBUG_ACME_DIRECTORY_URL"
+		t.Run(tc, func(t *testing.T) {
+			t.Setenv(setting, tc)
+			ac, err := acmeClient(certStateStore{StateStore: new(mem.Store)})
+			if err != nil {
+				t.Fatalf("acmeClient creation err: %v", err)
+			}
+			if ac.DirectoryURL != tc {
+				t.Fatalf("acmeClient.DirectoryURL = %q, want %q", ac.DirectoryURL, tc)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds an envknob setting for changing the client's ACME directory URL. This allows testing cert issuing against LE's staging environment, as well as enabling local-only test environments, which is useful for avoiding the production rate limits in test and development scenarios.

If this turns out to be more generally useful than just for pre-prod and integration testing, we might want to think about graduating it to a non-debug option in the future, but starting small for now.

Fixes #14761

Change-Id: I191c840c0ca143a20e4fa54ea3b2f9b7cbfc889f