### PR TITLE
types/netmap,*: pass around UserProfiles as views (pointers) instead

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -1003,7 +1003,9 @@ func (c *Direct) sendMapRequest(ctx context.Context, isStreaming bool, nu Netmap
 		if persist == c.persist {
 			newPersist := persist.AsStruct()
 			newPersist.NodeID = nm.SelfNode.StableID()
-			newPersist.UserProfile = nm.UserProfiles[nm.User()]
+			if up, ok := nm.UserProfiles[nm.User()]; ok {
+				newPersist.UserProfile = *up.AsStruct()
+			}
 
 			c.persist = newPersist.View()
 			persist = c.persist

--- a/control/controlclient/map.go
+++ b/control/controlclient/map.go
@@ -77,7 +77,7 @@ type mapSession struct {
 	peers                  map[tailcfg.NodeID]tailcfg.NodeView
 	lastDNSConfig          *tailcfg.DNSConfig
 	lastDERPMap            *tailcfg.DERPMap
-	lastUserProfile        map[tailcfg.UserID]tailcfg.UserProfile
+	lastUserProfile        map[tailcfg.UserID]tailcfg.UserProfileView
 	lastPacketFilterRules  views.Slice[tailcfg.FilterRule] // concatenation of all namedPacketFilters
 	namedPacketFilters     map[string]views.Slice[tailcfg.FilterRule]
 	lastParsedPacketFilter []filter.Match
@@ -104,7 +104,7 @@ func newMapSession(privateNodeKey key.NodePrivate, nu NetmapUpdater, controlKnob
 		privateNodeKey:  privateNodeKey,
 		publicNodeKey:   privateNodeKey.Public(),
 		lastDNSConfig:   new(tailcfg.DNSConfig),
-		lastUserProfile: map[tailcfg.UserID]tailcfg.UserProfile{},
+		lastUserProfile: map[tailcfg.UserID]tailcfg.UserProfileView{},
 
 		// Non-nil no-op defaults, to be optionally overridden by the caller.
 		logf:              logger.Discard,
@@ -294,7 +294,7 @@ func (ms *mapSession) updateStateFromResponse(resp *tailcfg.MapResponse) {
 	}
 
 	for _, up := range resp.UserProfiles {
-		ms.lastUserProfile[up.ID] = up
+		ms.lastUserProfile[up.ID] = up.View()
 	}
 
 	if dm := resp.DERPMap; dm != nil {
@@ -837,7 +837,7 @@ func (ms *mapSession) netmap() *netmap.NetworkMap {
 		PrivateKey:        ms.privateNodeKey,
 		MachineKey:        ms.machinePubKey,
 		Peers:             peerViews,
-		UserProfiles:      make(map[tailcfg.UserID]tailcfg.UserProfile),
+		UserProfiles:      make(map[tailcfg.UserID]tailcfg.UserProfileView),
 		Domain:            ms.lastDomain,
 		DomainAuditLogID:  ms.lastDomainAuditLogID,
 		DNS:               *ms.lastDNSConfig,

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -1052,13 +1052,13 @@ func TestWhoIs(t *testing.T) {
 				Addresses: []netip.Prefix{netip.MustParsePrefix("100.200.200.200/32")},
 			}).View(),
 		},
-		UserProfiles: map[tailcfg.UserID]tailcfg.UserProfile{
-			10: {
+		UserProfiles: map[tailcfg.UserID]tailcfg.UserProfileView{
+			10: (&tailcfg.UserProfile{
 				DisplayName: "Myself",
-			},
-			20: {
+			}).View(),
+			20: (&tailcfg.UserProfile{
 				DisplayName: "Peer",
-			},
+			}).View(),
 		},
 	})
 	tests := []struct {
@@ -2754,12 +2754,12 @@ func TestTCPHandlerForDstWithVIPService(t *testing.T) {
 					tailcfg.NodeAttrServiceHost: []tailcfg.RawMessage{tailcfg.RawMessage(svcIPMapJSON)},
 				},
 			}).View(),
-			UserProfiles: map[tailcfg.UserID]tailcfg.UserProfile{
-				tailcfg.UserID(1): {
+			UserProfiles: map[tailcfg.UserID]tailcfg.UserProfileView{
+				tailcfg.UserID(1): (&tailcfg.UserProfile{
 					LoginName:     "someone@example.com",
 					DisplayName:   "Some One",
 					ProfilePicURL: "https://example.com/photo.jpg",
-				},
+				}).View(),
 			},
 		},
 	)

--- a/ipn/ipnlocal/serve_test.go
+++ b/ipn/ipnlocal/serve_test.go
@@ -327,12 +327,12 @@ func TestServeConfigServices(t *testing.T) {
 				tailcfg.NodeAttrServiceHost: []tailcfg.RawMessage{tailcfg.RawMessage(svcIPMapJSON)},
 			},
 		}).View(),
-		UserProfiles: map[tailcfg.UserID]tailcfg.UserProfile{
-			tailcfg.UserID(1): {
+		UserProfiles: map[tailcfg.UserID]tailcfg.UserProfileView{
+			tailcfg.UserID(1): (&tailcfg.UserProfile{
 				LoginName:     "someone@example.com",
 				DisplayName:   "Some One",
 				ProfilePicURL: "https://example.com/photo.jpg",
-			},
+			}).View(),
 		},
 	}
 
@@ -905,12 +905,12 @@ func newTestBackend(t *testing.T) *LocalBackend {
 		SelfNode: (&tailcfg.Node{
 			Name: "example.ts.net",
 		}).View(),
-		UserProfiles: map[tailcfg.UserID]tailcfg.UserProfile{
-			tailcfg.UserID(1): {
+		UserProfiles: map[tailcfg.UserID]tailcfg.UserProfileView{
+			tailcfg.UserID(1): (&tailcfg.UserProfile{
 				LoginName:     "someone@example.com",
 				DisplayName:   "Some One",
 				ProfilePicURL: "https://example.com/photo.jpg",
-			},
+			}).View(),
 		},
 	}
 	b.peers = map[tailcfg.NodeID]tailcfg.NodeView{

--- a/ipn/ipnstate/ipnstate.go
+++ b/ipn/ipnstate/ipnstate.go
@@ -367,7 +367,7 @@ func (sb *StatusBuilder) MutateSelfStatus(f func(*PeerStatus)) {
 }
 
 // AddUser adds a user profile to the status.
-func (sb *StatusBuilder) AddUser(id tailcfg.UserID, up tailcfg.UserProfile) {
+func (sb *StatusBuilder) AddUser(id tailcfg.UserID, up tailcfg.UserProfileView) {
 	if sb.locked {
 		log.Printf("[unexpected] ipnstate: AddUser after Locked")
 		return
@@ -377,7 +377,7 @@ func (sb *StatusBuilder) AddUser(id tailcfg.UserID, up tailcfg.UserProfile) {
 		sb.st.User = make(map[tailcfg.UserID]tailcfg.UserProfile)
 	}
 
-	sb.st.User[id] = up
+	sb.st.User[id] = *up.AsStruct()
 }
 
 // AddIP adds a Tailscale IP address to the status.

--- a/types/netmap/netmap.go
+++ b/types/netmap/netmap.go
@@ -76,7 +76,9 @@ type NetworkMap struct {
 	// If this is empty, then data-plane audit logging is disabled.
 	DomainAuditLogID string
 
-	UserProfiles map[tailcfg.UserID]tailcfg.UserProfile
+	// UserProfiles contains the profile information of UserIDs referenced
+	// in SelfNode and Peers.
+	UserProfiles map[tailcfg.UserID]tailcfg.UserProfileView
 
 	// MaxKeyDuration describes the MaxKeyDuration setting for the tailnet.
 	MaxKeyDuration time.Duration
@@ -289,7 +291,12 @@ func (nm *NetworkMap) PeerWithStableID(pid tailcfg.StableNodeID) (_ tailcfg.Node
 func (nm *NetworkMap) printConciseHeader(buf *strings.Builder) {
 	fmt.Fprintf(buf, "netmap: self: %v auth=%v",
 		nm.NodeKey.ShortString(), nm.GetMachineStatus())
-	login := nm.UserProfiles[nm.User()].LoginName
+
+	var login string
+	up, ok := nm.UserProfiles[nm.User()]
+	if ok {
+		login = up.LoginName()
+	}
 	if login == "" {
 		if nm.User().IsZero() {
 			login = "?"


### PR DESCRIPTION
Smaller.

Updates tailscale/corp#26058 (@andrew-d noticed during this)
