### PR TITLE
types/persist: remove Persist.LegacyFrontendPrivateMachineKey

### DIFF
--- a/ipn/ipnlocal/state_test.go
+++ b/ipn/ipnlocal/state_test.go
@@ -949,8 +949,6 @@ func TestEditPrefsHasNoKeys(t *testing.T) {
 		Persist: &persist.Persist{
 			PrivateNodeKey:    key.NewNode(),
 			OldPrivateNodeKey: key.NewNode(),
-
-			LegacyFrontendPrivateMachineKey: key.NewMachine(),
 		},
 	}).View(), ipn.NetworkProfile{})
 	if p := b.pm.CurrentPrefs().Persist(); !p.Valid() || p.PrivateNodeKey().IsZero() {
@@ -975,10 +973,6 @@ func TestEditPrefsHasNoKeys(t *testing.T) {
 
 	if !p.Persist().OldPrivateNodeKey().IsZero() {
 		t.Errorf("OldPrivateNodeKey = %v; want zero", p.Persist().OldPrivateNodeKey())
-	}
-
-	if !p.Persist().LegacyFrontendPrivateMachineKey().IsZero() {
-		t.Errorf("LegacyFrontendPrivateMachineKey = %v; want zero", p.Persist().LegacyFrontendPrivateMachineKey())
 	}
 
 	if !p.Persist().NetworkLockKey().IsZero() {

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -469,19 +469,12 @@ func TestPrefsPretty(t *testing.T) {
 		},
 		{
 			Prefs{
-				Persist: &persist.Persist{},
-			},
-			"linux",
-			`Prefs{ra=false dns=false want=false routes=[] nf=off update=off Persist{lm=, o=, n= u=""}}`,
-		},
-		{
-			Prefs{
 				Persist: &persist.Persist{
 					PrivateNodeKey: key.NodePrivateFromRaw32(mem.B([]byte{1: 1, 31: 0})),
 				},
 			},
 			"linux",
-			`Prefs{ra=false dns=false want=false routes=[] nf=off update=off Persist{lm=, o=, n=[B1VKl] u=""}}`,
+			`Prefs{ra=false dns=false want=false routes=[] nf=off update=off Persist{o=, n=[B1VKl] u=""}}`,
 		},
 		{
 			Prefs{

--- a/types/persist/persist.go
+++ b/types/persist/persist.go
@@ -21,17 +21,6 @@ import (
 type Persist struct {
 	_ structs.Incomparable
 
-	// LegacyFrontendPrivateMachineKey is here temporarily
-	// (starting 2020-09-28) during migration of Windows users'
-	// machine keys from frontend storage to the backend. On the
-	// first LocalBackend.Start call, the backend will initialize
-	// the real (backend-owned) machine key from the frontend's
-	// provided value (if non-zero), picking a new random one if
-	// needed. This field should be considered read-only from GUI
-	// frontends. The real value should not be written back in
-	// this field, lest the frontend persist it to disk.
-	LegacyFrontendPrivateMachineKey key.MachinePrivate `json:"PrivateMachineKey"`
-
 	PrivateNodeKey    key.NodePrivate
 	OldPrivateNodeKey key.NodePrivate // needed to request key rotation
 	UserProfile       tailcfg.UserProfile
@@ -95,8 +84,7 @@ func (p *Persist) Equals(p2 *Persist) bool {
 		return false
 	}
 
-	return p.LegacyFrontendPrivateMachineKey.Equal(p2.LegacyFrontendPrivateMachineKey) &&
-		p.PrivateNodeKey.Equal(p2.PrivateNodeKey) &&
+	return p.PrivateNodeKey.Equal(p2.PrivateNodeKey) &&
 		p.OldPrivateNodeKey.Equal(p2.OldPrivateNodeKey) &&
 		p.UserProfile.Equal(&p2.UserProfile) &&
 		p.NetworkLockKey.Equal(p2.NetworkLockKey) &&
@@ -106,18 +94,14 @@ func (p *Persist) Equals(p2 *Persist) bool {
 
 func (p *Persist) Pretty() string {
 	var (
-		mk     key.MachinePublic
 		ok, nk key.NodePublic
 	)
-	if !p.LegacyFrontendPrivateMachineKey.IsZero() {
-		mk = p.LegacyFrontendPrivateMachineKey.Public()
-	}
 	if !p.OldPrivateNodeKey.IsZero() {
 		ok = p.OldPrivateNodeKey.Public()
 	}
 	if !p.PrivateNodeKey.IsZero() {
 		nk = p.PublicNodeKey()
 	}
-	return fmt.Sprintf("Persist{lm=%v, o=%v, n=%v u=%#v}",
-		mk.ShortString(), ok.ShortString(), nk.ShortString(), p.UserProfile.LoginName)
+	return fmt.Sprintf("Persist{o=%v, n=%v u=%#v}",
+		ok.ShortString(), nk.ShortString(), p.UserProfile.LoginName)
 }

--- a/types/persist/persist_clone.go
+++ b/types/persist/persist_clone.go
@@ -25,12 +25,11 @@ func (src *Persist) Clone() *Persist {
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _PersistCloneNeedsRegeneration = Persist(struct {
-	_                               structs.Incomparable
-	LegacyFrontendPrivateMachineKey key.MachinePrivate
-	PrivateNodeKey                  key.NodePrivate
-	OldPrivateNodeKey               key.NodePrivate
-	UserProfile                     tailcfg.UserProfile
-	NetworkLockKey                  key.NLPrivate
-	NodeID                          tailcfg.StableNodeID
-	DisallowedTKAStateIDs           []string
+	_                     structs.Incomparable
+	PrivateNodeKey        key.NodePrivate
+	OldPrivateNodeKey     key.NodePrivate
+	UserProfile           tailcfg.UserProfile
+	NetworkLockKey        key.NLPrivate
+	NodeID                tailcfg.StableNodeID
+	DisallowedTKAStateIDs []string
 }{})

--- a/types/persist/persist_test.go
+++ b/types/persist/persist_test.go
@@ -21,13 +21,12 @@ func fieldsOf(t reflect.Type) (fields []string) {
 }
 
 func TestPersistEqual(t *testing.T) {
-	persistHandles := []string{"LegacyFrontendPrivateMachineKey", "PrivateNodeKey", "OldPrivateNodeKey", "UserProfile", "NetworkLockKey", "NodeID", "DisallowedTKAStateIDs"}
+	persistHandles := []string{"PrivateNodeKey", "OldPrivateNodeKey", "UserProfile", "NetworkLockKey", "NodeID", "DisallowedTKAStateIDs"}
 	if have := fieldsOf(reflect.TypeFor[Persist]()); !reflect.DeepEqual(have, persistHandles) {
 		t.Errorf("Persist.Equal check might be out of sync\nfields: %q\nhandled: %q\n",
 			have, persistHandles)
 	}
 
-	m1 := key.NewMachine()
 	k1 := key.NewNode()
 	nl1 := key.NewNLPrivate()
 	tests := []struct {
@@ -38,17 +37,6 @@ func TestPersistEqual(t *testing.T) {
 		{nil, &Persist{}, false},
 		{&Persist{}, nil, false},
 		{&Persist{}, &Persist{}, true},
-
-		{
-			&Persist{LegacyFrontendPrivateMachineKey: m1},
-			&Persist{LegacyFrontendPrivateMachineKey: key.NewMachine()},
-			false,
-		},
-		{
-			&Persist{LegacyFrontendPrivateMachineKey: m1},
-			&Persist{LegacyFrontendPrivateMachineKey: m1},
-			true,
-		},
 
 		{
 			&Persist{PrivateNodeKey: k1},

--- a/types/persist/persist_view.go
+++ b/types/persist/persist_view.go
@@ -62,9 +62,6 @@ func (v *PersistView) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (v PersistView) LegacyFrontendPrivateMachineKey() key.MachinePrivate {
-	return v.ж.LegacyFrontendPrivateMachineKey
-}
 func (v PersistView) PrivateNodeKey() key.NodePrivate    { return v.ж.PrivateNodeKey }
 func (v PersistView) OldPrivateNodeKey() key.NodePrivate { return v.ж.OldPrivateNodeKey }
 func (v PersistView) UserProfile() tailcfg.UserProfile   { return v.ж.UserProfile }
@@ -76,12 +73,11 @@ func (v PersistView) DisallowedTKAStateIDs() views.Slice[string] {
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _PersistViewNeedsRegeneration = Persist(struct {
-	_                               structs.Incomparable
-	LegacyFrontendPrivateMachineKey key.MachinePrivate
-	PrivateNodeKey                  key.NodePrivate
-	OldPrivateNodeKey               key.NodePrivate
-	UserProfile                     tailcfg.UserProfile
-	NetworkLockKey                  key.NLPrivate
-	NodeID                          tailcfg.StableNodeID
-	DisallowedTKAStateIDs           []string
+	_                     structs.Incomparable
+	PrivateNodeKey        key.NodePrivate
+	OldPrivateNodeKey     key.NodePrivate
+	UserProfile           tailcfg.UserProfile
+	NetworkLockKey        key.NLPrivate
+	NodeID                tailcfg.StableNodeID
+	DisallowedTKAStateIDs []string
 }{})


### PR DESCRIPTION
It was a temporary migration over four years ago. It's no longer
relevant.

Updates #610
