### PR TITLE
`tailscale`: Add a `route-table` subcommand

### DIFF
--- a/cmd/tailscale/cli/cli.go
+++ b/cmd/tailscale/cli/cli.go
@@ -311,6 +311,7 @@ change in the future.
 			systrayCmd,
 			appcRoutesCmd,
 			waitCmd,
+			routeTableCmd,
 		),
 		FlagSet: rootfs,
 		Exec: func(ctx context.Context, args []string) error {

--- a/cmd/tailscale/cli/route-table.go
+++ b/cmd/tailscale/cli/route-table.go
@@ -1,0 +1,86 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+	"tailscale.com/client/tailscale"
+	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/paths"
+)
+
+var routeTableCmd = &ffcli.Command{
+	Name:       "route-table",
+	ShortUsage: "tailscale route-table",
+	ShortHelp:  "Show the IP routing table",
+	LongHelp:   "Show the IP routing table",
+	Exec:       showRouteTable,
+}
+
+type routeEntry struct {
+	prefix  string
+	nextHop string
+}
+
+func showRouteTable(ctx context.Context, args []string) error {
+	var localClient = tailscale.LocalClient{
+		Socket: paths.DefaultTailscaledSocket(),
+	}
+	tailscaleStatus, err := localClient.Status(ctx)
+	if err != nil {
+		return fixTailscaledConnectError(err)
+	}
+
+	routes := collectRoutes(tailscaleStatus)
+	printRouteTable(routes)
+	return nil
+}
+
+func collectRoutes(status *ipnstate.Status) []routeEntry {
+	var routes []routeEntry
+
+	for _, peer := range status.Peer {
+		if peer.TailscaleIPs == nil || len(peer.TailscaleIPs) == 0 {
+			continue
+		}
+		nextHop := peer.TailscaleIPs[0].String()
+
+		if peer.AllowedIPs != nil {
+			for i := 0; i < peer.AllowedIPs.Len(); i++ {
+				prefix := peer.AllowedIPs.At(i).String()
+				routes = append(routes, routeEntry{
+					prefix:  prefix,
+					nextHop: nextHop,
+				})
+			}
+		}
+	}
+
+	// Sort routes for consistent output
+	sort.Slice(routes, func(i, j int) bool {
+		return routes[i].prefix < routes[j].prefix
+	})
+
+	return routes
+}
+
+func printRouteTable(routes []routeEntry) {
+	fmt.Println("Tailscale IP Routing Table")
+	fmt.Println("Codes: T - Tailscale")
+	fmt.Println()
+
+	for _, route := range routes {
+		prefix := strings.Split(route.prefix, "/")
+		network := prefix[0]
+		mask := prefix[1]
+
+		fmt.Printf("T    %s [1/0] via %s\n", network, route.nextHop)
+		fmt.Printf("         %s/%s\n", network, mask)
+	}
+}

--- a/cmd/tailscale/cli/route-table.go
+++ b/cmd/tailscale/cli/route-table.go
@@ -8,8 +8,11 @@ import (
 	"flag"
 	"fmt"
 	"net/netip"
+	"os"
 	"sort"
+	"text/tabwriter"
 
+	"github.com/mattn/go-isatty"
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"tailscale.com/client/tailscale"
 	"tailscale.com/ipn/ipnstate"
@@ -61,7 +64,7 @@ func collectRoutes(status *ipnstate.Status, includeTailnetIPs bool) []routeEntry
 			continue
 		}
 		nextHopIP := peer.TailscaleIPs[0]
-		nextHopName := peer.HostName
+		nextHopName := peer.DNSName
 
 		if peer.AllowedIPs != nil {
 			for i := 0; i < peer.AllowedIPs.Len(); i++ {
@@ -78,7 +81,6 @@ func collectRoutes(status *ipnstate.Status, includeTailnetIPs bool) []routeEntry
 		}
 	}
 
-	// Sort routes for consistent output
 	sort.Slice(routes, func(i, j int) bool {
 		if routes[i].prefix.Addr().Compare(routes[j].prefix.Addr()) == 0 {
 			return routes[i].prefix.Bits() > routes[j].prefix.Bits()
@@ -99,11 +101,28 @@ func isTailscaleNodeIP(prefix netip.Prefix, tailscaleIPs []netip.Addr) bool {
 }
 
 func printRouteTable(routes []routeEntry) {
-	fmt.Println("Tailscale IP Routing Table")
-	fmt.Println("Codes: T - Tailscale")
-	fmt.Println()
+	isTTY := isatty.IsTerminal(os.Stdout.Fd())
 
-	for _, route := range routes {
-		fmt.Printf("T    %s via %s (%s)\n", route.prefix, route.nextHopIP, route.nextHopName)
+	if isTTY {
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "Tailscale IP Routing Table")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Prefix\tNext Hop\tDNS Name")
+		fmt.Fprintln(w, "------\t--------\t--------")
+
+		for _, route := range routes {
+			fmt.Fprintf(w, "%s\t%s\t%s\n",
+				route.prefix,
+				route.nextHopIP,
+				route.nextHopName)
+		}
+		w.Flush()
+	} else {
+		fmt.Println("Tailscale IP Routing Table")
+		fmt.Println()
+
+		for _, route := range routes {
+			fmt.Printf("%s via %s (%s)\n", route.prefix, route.nextHopIP, route.nextHopName)
+		}
 	}
 }


### PR DESCRIPTION
Addresses #14781

## Context

As an admin of a large Tailnet with many subnet routers, managed by a diverse group of administrators, I would like to have a place to list all currently routed subnets on my Tailnet.

Currently, the only place that this is surfaced is in the admin dashboard, but which requires clicking through on each node to see what routes it is announcing and accepted.

## Change

This change introduces a `route-table` subcommand for the `tailscale` CLI.

It examines the current tailnet state from tailscaled, looks at the `AllowedIPs` property, and builds up a "routing table"-like object.

Finally, if the output is a TTY, this prints a formatted table, and if not prints a textual list.

## Example Outputs

```
~/src/tailscale $ go run ./cmd/tailscale route-table

Tailscale IP Routing Table

Prefix              Next Hop       Hostname
------              --------       --------
10.0.0.0/11         100.106.43.28  tailscale
10.255.0.0/16       100.106.43.28  tailscale
192.33.255.0/24     100.106.43.28  tailscale
2620:11a:b00f::/48  100.106.43.28  tailscale
```

```
~/src/tailscale $ go run ./cmd/tailscale route-table --tailnet-ips

Tailscale IP Routing Table

Prefix                         Next Hop        Hostname
------                         --------        --------
10.0.0.0/11                    100.106.43.28   tailscale
10.255.0.0/16                  100.106.43.28   tailscale
100.80.209.20/32               100.80.209.20   maelstrom
100.81.2.57/32                 100.81.2.57     Tims-MBP
100.87.124.37/32               100.87.124.37   oak
100.95.197.122/32              100.95.197.122  ash
100.106.43.28/32               100.106.43.28   tailscale
100.110.165.32/32              100.110.165.32  quercus
192.33.255.0/24                100.106.43.28   tailscale
2620:11a:b00f::/48             100.106.43.28   tailscale
fd7a:115c:a1e0::1a01:239/128   100.81.2.57     Tims-MBP
fd7a:115c:a1e0::a517:7c25/128  100.87.124.37   oak
fd7a:115c:a1e0::c301:c57a/128  100.95.197.122  ash
fd7a:115c:a1e0::ce01:d114/128  100.80.209.20   maelstrom
fd7a:115c:a1e0::d401:2b1c/128  100.106.43.28   tailscale
fd7a:115c:a1e0::df01:a522/128  100.110.165.32  quercus
```