### PR TITLE
control/controlknobs: make Knobs.AsDebugJSON automatic, not require maintenance

### DIFF
--- a/control/controlknobs/controlknobs_test.go
+++ b/control/controlknobs/controlknobs_test.go
@@ -6,6 +6,8 @@ package controlknobs
 import (
 	"reflect"
 	"testing"
+
+	"tailscale.com/types/logger"
 )
 
 func TestAsDebugJSON(t *testing.T) {
@@ -18,4 +20,5 @@ func TestAsDebugJSON(t *testing.T) {
 	if want := reflect.TypeFor[Knobs]().NumField(); len(got) != want {
 		t.Errorf("AsDebugJSON map has %d fields; want %v", len(got), want)
 	}
+	t.Logf("Got: %v", logger.AsJSON(got))
 }


### PR DESCRIPTION
The AsDebugJSON method (used only for a LocalAPI debug call) always
needed to be updated whenever a new controlknob was added. We had a
test for it, which was nice, but it was a tedious step we don't need
to do. Use reflect instead.

Updates #14788
