### PR TITLE
tempfork/acme: fix TestSyncedToUpstream with Windows line endings

### DIFF
--- a/tempfork/acme/sync_to_upstream_test.go
+++ b/tempfork/acme/sync_to_upstream_test.go
@@ -55,7 +55,7 @@ func TestSyncedToUpstream(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			m[name] = string(b)
+			m[name] = strings.ReplaceAll(string(b), "\r", "")
 		}
 
 		return m


### PR DESCRIPTION
Updates #10238
