### PR TITLE
tailcfg: read max key duration from node cap map [capver 114]

### DIFF
--- a/control/controlclient/map.go
+++ b/control/controlclient/map.go
@@ -89,7 +89,6 @@ type mapSession struct {
 	lastPopBrowserURL      string
 	lastTKAInfo            *tailcfg.TKAInfo
 	lastNetmapSummary      string // from NetworkMap.VeryConcise
-	lastMaxExpiry          time.Duration
 }
 
 // newMapSession returns a mostly unconfigured new mapSession.
@@ -386,9 +385,6 @@ func (ms *mapSession) updateStateFromResponse(resp *tailcfg.MapResponse) {
 	}
 	if resp.TKAInfo != nil {
 		ms.lastTKAInfo = resp.TKAInfo
-	}
-	if resp.MaxKeyDuration > 0 {
-		ms.lastMaxExpiry = resp.MaxKeyDuration
 	}
 }
 
@@ -848,7 +844,6 @@ func (ms *mapSession) netmap() *netmap.NetworkMap {
 		DERPMap:           ms.lastDERPMap,
 		ControlHealth:     ms.lastHealth,
 		TKAEnabled:        ms.lastTKAInfo != nil && !ms.lastTKAInfo.Disabled,
-		MaxKeyDuration:    ms.lastMaxExpiry,
 	}
 
 	if ms.lastTKAInfo != nil && ms.lastTKAInfo.Head != "" {

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -2094,10 +2094,6 @@ type MapResponse struct {
 	// auto-update setting doesn't change if the tailnet admin flips the
 	// default after the node registered.
 	DefaultAutoUpdate opt.Bool `json:",omitempty"`
-
-	// MaxKeyDuration describes the MaxKeyDuration setting for the tailnet.
-	// If zero, the value is unchanged.
-	MaxKeyDuration time.Duration `json:",omitempty"`
 }
 
 // ClientVersion is information about the latest client version that's available

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -158,7 +158,8 @@ type CapabilityVersion int
 //   - 111: 2025-01-14: Client supports a peer having Node.HomeDERP (issue #14636)
 //   - 112: 2025-01-14: Client interprets AllowedIPs of nil as meaning same as Addresses
 //   - 113: 2025-01-20: Client communicates to control whether funnel is enabled by sending Hostinfo.IngressEnabled (#14688)
-const CurrentCapabilityVersion CapabilityVersion = 113
+//   - 114: 2025-01-30: NodeAttrMaxKeyDuration CapMap defined, clients might use it (no tailscaled code change) (#14829)
+const CurrentCapabilityVersion CapabilityVersion = 114
 
 // ID is an integer ID for a user, node, or login allocated by the
 // control plane.
@@ -2502,6 +2503,12 @@ const (
 	// If multiple values of this key exist, they should be merged in sequence
 	// (replace conflicting keys).
 	NodeAttrServiceHost NodeCapability = "service-host"
+
+	// NodeAttrMaxKeyDuration represents the MaxKeyDuration setting on the
+	// tailnet. The value of this key in [NodeCapMap] will be only one entry of
+	// type float64 representing the duration in seconds. This cap will be
+	// omitted if the tailnet's MaxKeyDuration is the default.
+	NodeAttrMaxKeyDuration NodeCapability = "tailnet.maxKeyDuration"
 )
 
 // SetDNSRequest is a request to add a DNS record.

--- a/types/netmap/netmap.go
+++ b/types/netmap/netmap.go
@@ -79,9 +79,6 @@ type NetworkMap struct {
 	// UserProfiles contains the profile information of UserIDs referenced
 	// in SelfNode and Peers.
 	UserProfiles map[tailcfg.UserID]tailcfg.UserProfileView
-
-	// MaxKeyDuration describes the MaxKeyDuration setting for the tailnet.
-	MaxKeyDuration time.Duration
 }
 
 // User returns nm.SelfNode.User if nm.SelfNode is non-nil, otherwise it returns

--- a/types/netmap/nodemut.go
+++ b/types/netmap/nodemut.go
@@ -176,6 +176,5 @@ func mapResponseContainsNonPatchFields(res *tailcfg.MapResponse) bool {
 		// function is called, so it should never be set anyway. But for
 		// completedness, and for tests, check it too:
 		res.PeersChanged != nil ||
-		res.DefaultAutoUpdate != "" ||
-		res.MaxKeyDuration > 0
+		res.DefaultAutoUpdate != ""
 }


### PR DESCRIPTION
This will be used by clients to make better decisions on when to warn users about impending key expiry.

Updates tailscale/corp#16016