### PR TITLE
ipn: generate LoginProfileView and use it instead of *LoginProfile where appropriate

### DIFF
--- a/ipn/doc.go
+++ b/ipn/doc.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:generate go run tailscale.com/cmd/viewer -type=Prefs,ServeConfig,ServiceConfig,TCPPortHandler,HTTPHandler,WebServerConfig
+//go:generate go run tailscale.com/cmd/viewer -type=LoginProfile,Prefs,ServeConfig,ServiceConfig,TCPPortHandler,HTTPHandler,WebServerConfig
 
 // Package ipn implements the interactions between the Tailscale cloud
 // control plane and the local network stack.

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -17,6 +17,29 @@ import (
 	"tailscale.com/types/ptr"
 )
 
+// Clone makes a deep copy of LoginProfile.
+// The result aliases no memory with the original.
+func (src *LoginProfile) Clone() *LoginProfile {
+	if src == nil {
+		return nil
+	}
+	dst := new(LoginProfile)
+	*dst = *src
+	return dst
+}
+
+// A compilation failure here means this code must be regenerated, with the command at the top of this file.
+var _LoginProfileCloneNeedsRegeneration = LoginProfile(struct {
+	ID             ProfileID
+	Name           string
+	NetworkProfile NetworkProfile
+	Key            StateKey
+	UserProfile    tailcfg.UserProfile
+	NodeID         tailcfg.StableNodeID
+	LocalUserID    WindowsUserID
+	ControlURL     string
+}{})
+
 // Clone makes a deep copy of Prefs.
 // The result aliases no memory with the original.
 func (src *Prefs) Clone() *Prefs {

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -4087,9 +4087,9 @@ func TestReadWriteRouteInfo(t *testing.T) {
 	b := newTestBackend(t)
 	prof1 := ipn.LoginProfile{ID: "id1", Key: "key1"}
 	prof2 := ipn.LoginProfile{ID: "id2", Key: "key2"}
-	b.pm.knownProfiles["id1"] = &prof1
-	b.pm.knownProfiles["id2"] = &prof2
-	b.pm.currentProfile = &prof1
+	b.pm.knownProfiles["id1"] = prof1.View()
+	b.pm.knownProfiles["id2"] = prof2.View()
+	b.pm.currentProfile = prof1.View()
 
 	// set up routeInfo
 	ri1 := &appc.RouteInfo{}

--- a/ipn/ipnlocal/network-lock.go
+++ b/ipn/ipnlocal/network-lock.go
@@ -407,7 +407,7 @@ func (b *LocalBackend) tkaApplyDisablementLocked(secret []byte) error {
 //
 // b.mu must be held.
 func (b *LocalBackend) chonkPathLocked() string {
-	return filepath.Join(b.TailscaleVarRoot(), "tka-profiles", string(b.pm.CurrentProfile().ID))
+	return filepath.Join(b.TailscaleVarRoot(), "tka-profiles", string(b.pm.CurrentProfile().ID()))
 }
 
 // tkaBootstrapFromGenesisLocked initializes the local (on-disk) state of the
@@ -455,7 +455,7 @@ func (b *LocalBackend) tkaBootstrapFromGenesisLocked(g tkatype.MarshaledAUM, per
 	}
 
 	b.tka = &tkaState{
-		profile:   b.pm.CurrentProfile().ID,
+		profile:   b.pm.CurrentProfile().ID(),
 		authority: authority,
 		storage:   chonk,
 	}

--- a/ipn/ipnlocal/network-lock_test.go
+++ b/ipn/ipnlocal/network-lock_test.go
@@ -202,7 +202,7 @@ func TestTKADisablementFlow(t *testing.T) {
 	}).View(), ipn.NetworkProfile{}))
 
 	temp := t.TempDir()
-	tkaPath := filepath.Join(temp, "tka-profile", string(pm.CurrentProfile().ID))
+	tkaPath := filepath.Join(temp, "tka-profile", string(pm.CurrentProfile().ID()))
 	os.Mkdir(tkaPath, 0755)
 	chonk, err := tka.ChonkDir(tkaPath)
 	if err != nil {
@@ -410,7 +410,7 @@ func TestTKASync(t *testing.T) {
 			}
 
 			temp := t.TempDir()
-			tkaPath := filepath.Join(temp, "tka-profile", string(pm.CurrentProfile().ID))
+			tkaPath := filepath.Join(temp, "tka-profile", string(pm.CurrentProfile().ID()))
 			os.Mkdir(tkaPath, 0755)
 			// Setup the TKA authority on the node.
 			nodeStorage, err := tka.ChonkDir(tkaPath)
@@ -710,7 +710,7 @@ func TestTKADisable(t *testing.T) {
 	}).View(), ipn.NetworkProfile{}))
 
 	temp := t.TempDir()
-	tkaPath := filepath.Join(temp, "tka-profile", string(pm.CurrentProfile().ID))
+	tkaPath := filepath.Join(temp, "tka-profile", string(pm.CurrentProfile().ID()))
 	os.Mkdir(tkaPath, 0755)
 	key := tka.Key{Kind: tka.Key25519, Public: nlPriv.Public().Verifier(), Votes: 2}
 	chonk, err := tka.ChonkDir(tkaPath)
@@ -770,7 +770,7 @@ func TestTKADisable(t *testing.T) {
 		ccAuto:  cc,
 		logf:    t.Logf,
 		tka: &tkaState{
-			profile:   pm.CurrentProfile().ID,
+			profile:   pm.CurrentProfile().ID(),
 			authority: authority,
 			storage:   chonk,
 		},
@@ -805,7 +805,7 @@ func TestTKASign(t *testing.T) {
 	key := tka.Key{Kind: tka.Key25519, Public: nlPriv.Public().Verifier(), Votes: 2}
 
 	temp := t.TempDir()
-	tkaPath := filepath.Join(temp, "tka-profile", string(pm.CurrentProfile().ID))
+	tkaPath := filepath.Join(temp, "tka-profile", string(pm.CurrentProfile().ID()))
 	os.Mkdir(tkaPath, 0755)
 	chonk, err := tka.ChonkDir(tkaPath)
 	if err != nil {
@@ -890,7 +890,7 @@ func TestTKAForceDisable(t *testing.T) {
 	}).View(), ipn.NetworkProfile{}))
 
 	temp := t.TempDir()
-	tkaPath := filepath.Join(temp, "tka-profile", string(pm.CurrentProfile().ID))
+	tkaPath := filepath.Join(temp, "tka-profile", string(pm.CurrentProfile().ID()))
 	os.Mkdir(tkaPath, 0755)
 	chonk, err := tka.ChonkDir(tkaPath)
 	if err != nil {
@@ -989,7 +989,7 @@ func TestTKAAffectedSigs(t *testing.T) {
 	tkaKey := tka.Key{Kind: tka.Key25519, Public: nlPriv.Public().Verifier(), Votes: 2}
 
 	temp := t.TempDir()
-	tkaPath := filepath.Join(temp, "tka-profile", string(pm.CurrentProfile().ID))
+	tkaPath := filepath.Join(temp, "tka-profile", string(pm.CurrentProfile().ID()))
 	os.Mkdir(tkaPath, 0755)
 	chonk, err := tka.ChonkDir(tkaPath)
 	if err != nil {
@@ -1124,7 +1124,7 @@ func TestTKARecoverCompromisedKeyFlow(t *testing.T) {
 	compromisedKey := tka.Key{Kind: tka.Key25519, Public: compromisedPriv.Public().Verifier(), Votes: 1}
 
 	temp := t.TempDir()
-	tkaPath := filepath.Join(temp, "tka-profile", string(pm.CurrentProfile().ID))
+	tkaPath := filepath.Join(temp, "tka-profile", string(pm.CurrentProfile().ID()))
 	os.Mkdir(tkaPath, 0755)
 	chonk, err := tka.ChonkDir(tkaPath)
 	if err != nil {

--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -318,7 +318,7 @@ func (b *LocalBackend) setServeConfigLocked(config *ipn.ServeConfig, etag string
 		bs = j
 	}
 
-	profileID := b.pm.CurrentProfile().ID
+	profileID := b.pm.CurrentProfile().ID()
 	confKey := ipn.ServeConfigKey(profileID)
 	if err := b.store.WriteState(confKey, bs); err != nil {
 		return fmt.Errorf("writing ServeConfig to StateStore: %w", err)

--- a/ipn/ipnlocal/serve_test.go
+++ b/ipn/ipnlocal/serve_test.go
@@ -898,7 +898,7 @@ func newTestBackend(t *testing.T) *LocalBackend {
 	b.SetVarRoot(dir)
 
 	pm := must.Get(newProfileManager(new(mem.Store), logf, new(health.Tracker)))
-	pm.currentProfile = &ipn.LoginProfile{ID: "id0"}
+	pm.currentProfile = (&ipn.LoginProfile{ID: "id0"}).View()
 	b.pm = pm
 
 	b.netMap = &netmap.NetworkMap{

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -2601,8 +2601,8 @@ func (h *Handler) serveProfiles(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case httpm.GET:
 		profiles := h.b.ListProfiles()
-		profileIndex := slices.IndexFunc(profiles, func(p ipn.LoginProfile) bool {
-			return p.ID == profileID
+		profileIndex := slices.IndexFunc(profiles, func(p ipn.LoginProfileView) bool {
+			return p.ID() == profileID
 		})
 		if profileIndex == -1 {
 			http.Error(w, "Profile not found", http.StatusNotFound)


### PR DESCRIPTION
Conventionally, we use views (e.g., `ipn.PrefsView`, `tailcfg.NodeView`, etc.) when dealing with structs that shouldn't be accidentally mutated. However, `ipn.LoginProfile` has been an exception so far, with a mix of passing and returning `LoginProfile` by reference (allowing accidental mutations) and by value (which is wasteful, given its current size of 192 bytes).

In this PR, we generate an `ipn.LoginProfileView` and use it instead of passing/returning `LoginProfiles` by mutable reference or copying them when passing/returning by value. Now, `LoginProfiles` can only be mutated by `(*profileManager).setProfilePrefs`.

Updates #14823