### PR TITLE
ipn/ipn{auth,server,local}: initial support for the always-on mode

### DIFF
--- a/ipn/ipnauth/access.go
+++ b/ipn/ipnauth/access.go
@@ -6,3 +6,9 @@ package ipnauth
 // ProfileAccess is a bitmask representing the requested, required, or granted
 // access rights to an [ipn.LoginProfile].
 type ProfileAccess uint32
+
+// Define access rights that might be granted or denied on a per-profile basis.
+const (
+	// Disconnect is required to disconnect (or switch from) a Tailscale profile.
+	Disconnect = ProfileAccess(1 << iota)
+)

--- a/ipn/ipnauth/access.go
+++ b/ipn/ipnauth/access.go
@@ -1,0 +1,8 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package ipnauth
+
+// ProfileAccess is a bitmask representing the requested, required, or granted
+// access rights to an [ipn.LoginProfile].
+type ProfileAccess uint32

--- a/ipn/ipnauth/actor.go
+++ b/ipn/ipnauth/actor.go
@@ -27,6 +27,10 @@ type Actor interface {
 	// a connected LocalAPI client. Otherwise, it returns a zero value and false.
 	ClientID() (_ ClientID, ok bool)
 
+	// CheckProfileAccess checks whether the actor has the requested access rights
+	// to the specified Tailscale profile. It returns an error if the access is denied.
+	CheckProfileAccess(profile ipn.LoginProfileView, requestedAccess ProfileAccess) error
+
 	// IsLocalSystem reports whether the actor is the Windows' Local System account.
 	//
 	// Deprecated: this method exists for compatibility with the current (as of 2024-08-27)

--- a/ipn/ipnauth/self.go
+++ b/ipn/ipnauth/self.go
@@ -1,0 +1,46 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package ipnauth
+
+import (
+	"tailscale.com/ipn"
+)
+
+// Self is a caller identity that represents the tailscaled itself and therefore
+// has unlimited access.
+var Self Actor = unrestricted{}
+
+// unrestricted is an [Actor] that has unlimited access to the currently running
+// tailscaled instance. It's typically used for operations performed by tailscaled
+// on its own, or upon a request from the control plane, rather on behalf of a user.
+type unrestricted struct{}
+
+// UserID implements [Actor].
+func (u unrestricted) UserID() ipn.WindowsUserID { return "" }
+
+// Username implements [Actor].
+func (u unrestricted) Username() (string, error) { return "", nil }
+
+// ClientID implements [Actor].
+// It always returns (NoClientID, false) because the tailscaled itself
+// is not a connected LocalAPI client.
+func (u unrestricted) ClientID() (_ ClientID, ok bool) { return NoClientID, false }
+
+// CheckProfileAccess implements [Actor].
+func (u unrestricted) CheckProfileAccess(_ ipn.LoginProfileView, _ ProfileAccess) error {
+	// Unrestricted access to all profiles.
+	return nil
+}
+
+// IsLocalSystem implements [Actor].
+//
+// Deprecated: this method exists for compatibility with the current (as of 2025-01-28)
+// permission model and will be removed as we progress on tailscale/corp#18342.
+func (u unrestricted) IsLocalSystem() bool { return false }
+
+// IsLocalAdmin implements [Actor].
+//
+// Deprecated: this method exists for compatibility with the current (as of 2025-01-28)
+// permission model and will be removed as we progress on tailscale/corp#18342.
+func (u unrestricted) IsLocalAdmin(operatorUID string) bool { return false }

--- a/ipn/ipnauth/test_actor.go
+++ b/ipn/ipnauth/test_actor.go
@@ -4,6 +4,8 @@
 package ipnauth
 
 import (
+	"errors"
+
 	"tailscale.com/ipn"
 )
 
@@ -17,7 +19,6 @@ type TestActor struct {
 	CID         ClientID          // non-zero if the actor represents a connected LocalAPI client
 	LocalSystem bool              // whether the actor represents the special Local System account on Windows
 	LocalAdmin  bool              // whether the actor has local admin access
-
 }
 
 // UserID implements [Actor].
@@ -28,6 +29,11 @@ func (a *TestActor) Username() (string, error) { return a.Name, a.NameErr }
 
 // ClientID implements [Actor].
 func (a *TestActor) ClientID() (_ ClientID, ok bool) { return a.CID, a.CID != NoClientID }
+
+// CheckProfileAccess implements [Actor].
+func (a *TestActor) CheckProfileAccess(profile ipn.LoginProfileView, _ ProfileAccess) error {
+	return errors.New("profile access denied")
+}
 
 // IsLocalSystem implements [Actor].
 func (a *TestActor) IsLocalSystem() bool { return a.LocalSystem }

--- a/ipn/ipnserver/actor.go
+++ b/ipn/ipnserver/actor.go
@@ -58,6 +58,14 @@ func newActor(logf logger.Logf, c net.Conn) (*actor, error) {
 	return &actor{logf: logf, ci: ci, clientID: clientID, isLocalSystem: connIsLocalSystem(ci)}, nil
 }
 
+// CheckProfileAccess implements [ipnauth.Actor].
+func (a *actor) CheckProfileAccess(profile ipn.LoginProfileView, requestedAccess ipnauth.ProfileAccess) error {
+	if profile.LocalUserID() != a.UserID() {
+		return errors.New("the target profile does not belong to the user")
+	}
+	return errors.New("the requested operation is not allowed")
+}
+
 // IsLocalSystem implements [ipnauth.Actor].
 func (a *actor) IsLocalSystem() bool {
 	return a.isLocalSystem

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -1381,7 +1381,7 @@ func (h *Handler) servePrefs(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		var err error
-		prefs, err = h.b.EditPrefs(mp)
+		prefs, err = h.b.EditPrefsAs(mp, h.Actor)
 		if err != nil {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)

--- a/util/syspolicy/policy_keys.go
+++ b/util/syspolicy/policy_keys.go
@@ -26,6 +26,15 @@ const (
 	ControlURL Key = "LoginURL"  // default ""; if blank, ipn uses ipn.DefaultControlURL.
 	LogTarget  Key = "LogTarget" // default ""; if blank logging uses logtail.DefaultHost.
 	Tailnet    Key = "Tailnet"   // default ""; if blank, no tailnet name is sent to the server.
+
+	// AlwaysOn is a boolean key that controls whether Tailscale
+	// should always remain in a connected state, and the user should
+	// not be able to disconnect at their discretion.
+	//
+	// Warning: This policy setting is experimental and may change or be removed in the future.
+	// It may also not be fully supported by all Tailscale clients until it is out of experimental status.
+	AlwaysOn Key = "AlwaysOn"
+
 	// ExitNodeID is the exit node's node id. default ""; if blank, no exit node is forced.
 	// Exit node ID takes precedence over exit node IP.
 	// To find the node ID, go to /api.md#device.
@@ -139,6 +148,7 @@ const (
 var implicitDefinitions = []*setting.Definition{
 	// Device policy settings (can only be configured on a per-device basis):
 	setting.NewDefinition(AllowedSuggestedExitNodes, setting.DeviceSetting, setting.StringListValue),
+	setting.NewDefinition(AlwaysOn, setting.DeviceSetting, setting.BooleanValue),
 	setting.NewDefinition(ApplyUpdates, setting.DeviceSetting, setting.PreferenceOptionValue),
 	setting.NewDefinition(AuthKey, setting.DeviceSetting, setting.StringValue),
 	setting.NewDefinition(CheckUpdates, setting.DeviceSetting, setting.PreferenceOptionValue),


### PR DESCRIPTION
[3 commits; can be reviewed either by commit or all at once]

In this PR, we update `LocalBackend` to set `WantRunning=true` when applying policy settings to the current profile's prefs, if the "always-on" mode is enabled.

We also implement a new `(*LocalBackend).EditPrefsAs()` method, which is like `EditPrefs` but accepts an `ipnauth.Actor` (e.g., a LocalAPI client's identity) that initiated the change. If `WantRunning` is being set to false, the new `EditPrefsAs` method checks whether the actor has `ipnauth.Disconnect` access to the profile and propagates an error if they do not.

To facilitate this check, we extend the `ipnauth.Actor` interface with a `CheckProfileAccess` method, and implement it for the legacy `ipnserver.actor` to allow a disconnect only if the "always-on" mode is not enabled by the `AlwaysOn` policy setting. We also implement an `ipnauth.unrestricted` actor, which represents `tailscaled` itself and therefore has unrestricted access to all profiles.

This is not a comprehensive solution to the "always-on" mode across platforms, as instead of disconnecting a user could achieve the same effect by creating a new empty profile, initiating a reauth, or by deleting the profile.
These are the things we should address in future PRs.

Updates #14823

Signed-off-by: Nick Khyl <nickk@tailscale.com>