### PR TITLE
client/tailscale,ipn/ipn{local,server},util/syspolicy: implement the AlwaysOn.OverrideWithReason policy setting

### DIFF
--- a/client/tailscale/apitype/apitype.go
+++ b/client/tailscale/apitype/apitype.go
@@ -7,10 +7,28 @@ package apitype
 import (
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/dnstype"
+	"tailscale.com/util/ctxkey"
 )
 
 // LocalAPIHost is the Host header value used by the LocalAPI.
 const LocalAPIHost = "local-tailscaled.sock"
+
+// RequestReasonHeader is the header used to pass justification for a LocalAPI request,
+// such as when a user wants to perform an action they don't have permission for,
+// and a policy allows it with justification. As of 2025-01-29, it is only used to
+// allow a user to disconnect Tailscale when the "always-on" mode is enabled.
+//
+// The header value is base64-encoded using the standard encoding defined in RFC 4648.
+//
+// See tailscale/corp#26146.
+const RequestReasonHeader = "X-Tailscale-Reason"
+
+// RequestReasonKey is the context key used to pass the request reason
+// when making a LocalAPI request via [tailscale.LocalClient].
+// It's value is a raw string. An empty string means no reason was provided.
+//
+// See tailscale/corp#26146.
+var RequestReasonKey = ctxkey.New(RequestReasonHeader, "")
 
 // WhoIsResponse is the JSON type returned by tailscaled debug server's /whois?ip=$IP handler.
 // In successful whois responses, Node and UserProfile are never nil.

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -1861,7 +1861,7 @@ func TestSetExitNodeIDPolicy(t *testing.T) {
 			b.lastSuggestedExitNode = test.lastSuggestedExitNode
 
 			prefs := b.pm.prefs.AsStruct()
-			if changed := applySysPolicy(prefs, test.lastSuggestedExitNode) || setExitNodeID(prefs, test.nm); changed != test.prefsChanged {
+			if changed := applySysPolicy(prefs, test.lastSuggestedExitNode, false) || setExitNodeID(prefs, test.nm); changed != test.prefsChanged {
 				t.Errorf("wanted prefs changed %v, got prefs changed %v", test.prefsChanged, changed)
 			}
 
@@ -2421,7 +2421,7 @@ func TestApplySysPolicy(t *testing.T) {
 			t.Run("unit", func(t *testing.T) {
 				prefs := tt.prefs.Clone()
 
-				gotAnyChange := applySysPolicy(prefs, "")
+				gotAnyChange := applySysPolicy(prefs, "", false)
 
 				if gotAnyChange && prefs.Equals(&tt.prefs) {
 					t.Errorf("anyChange but prefs is unchanged: %v", prefs.Pretty())
@@ -2569,7 +2569,7 @@ func TestPreferencePolicyInfo(t *testing.T) {
 					prefs := defaultPrefs.AsStruct()
 					pp.set(prefs, tt.initialValue)
 
-					gotAnyChange := applySysPolicy(prefs, "")
+					gotAnyChange := applySysPolicy(prefs, "", false)
 
 					if gotAnyChange != tt.wantChange {
 						t.Errorf("anyChange=%v, want %v", gotAnyChange, tt.wantChange)

--- a/util/syspolicy/policy_keys.go
+++ b/util/syspolicy/policy_keys.go
@@ -34,7 +34,13 @@ const (
 	// Warning: This policy setting is experimental and may change or be removed in the future.
 	// It may also not be fully supported by all Tailscale clients until it is out of experimental status.
 	// See tailscale/corp#26247, tailscale/corp#26248 and tailscale/corp#26249 for more information.
-	AlwaysOn Key = "AlwaysOn"
+	AlwaysOn Key = "AlwaysOn.Enabled"
+
+	// AlwaysOnOverrideWithReason is a boolean key that alters the behavior
+	// of [AlwaysOn]. When true, the user is allowed to disconnect Tailscale
+	// by providing a reason. The reason is logged and sent to the control
+	// for auditing purposes. It has no effect when [AlwaysOn] is false.
+	AlwaysOnOverrideWithReason Key = "AlwaysOn.OverrideWithReason"
 
 	// ExitNodeID is the exit node's node id. default ""; if blank, no exit node is forced.
 	// Exit node ID takes precedence over exit node IP.
@@ -150,6 +156,7 @@ var implicitDefinitions = []*setting.Definition{
 	// Device policy settings (can only be configured on a per-device basis):
 	setting.NewDefinition(AllowedSuggestedExitNodes, setting.DeviceSetting, setting.StringListValue),
 	setting.NewDefinition(AlwaysOn, setting.DeviceSetting, setting.BooleanValue),
+	setting.NewDefinition(AlwaysOnOverrideWithReason, setting.DeviceSetting, setting.BooleanValue),
 	setting.NewDefinition(ApplyUpdates, setting.DeviceSetting, setting.PreferenceOptionValue),
 	setting.NewDefinition(AuthKey, setting.DeviceSetting, setting.StringValue),
 	setting.NewDefinition(CheckUpdates, setting.DeviceSetting, setting.PreferenceOptionValue),


### PR DESCRIPTION
In this PR, we update `client/tailscale.LocalClient` to allow sending requests with an optional `X-Tailscale-Reason` header. We then update `ipn/ipnserver.{actor,Server}` to retrieve this reason, if specified, and use it to determine whether `ipnauth.Disconnect` is allowed when the `AlwaysOn.OverrideWithReason` policy setting is enabled. For now, we log the reason, along with the profile and OS username, to the backend log.

Finally, we update `LocalBackend` to remember when a disconnect was permitted and do not reconnect automatically unless the policy changes.

Updates tailscale/corp#26146