### PR TITLE
derp/derphttp: set cache-control to disallow caching of captive portal checks

### DIFF
--- a/derp/derphttp/derphttp_server.go
+++ b/derp/derphttp/derphttp_server.go
@@ -98,6 +98,7 @@ func ServeNoContent(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set(NoContentResponseHeader, "response "+challenge)
 		}
 	}
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate, no-transform, max-age=0")
 	w.WriteHeader(http.StatusNoContent)
 }
 


### PR DESCRIPTION
Observed on some airlines, Squid is configured to cache and transform these results, which is disruptive. The server and client should both actively request that this is not done.

Updates #14856