### PR TITLE
derp/derphttp,ipn/localapi,net/captivedetection: add cache resistance to captive portal detection

### DIFF
--- a/derp/derphttp/derphttp_server.go
+++ b/derp/derphttp/derphttp_server.go
@@ -98,6 +98,7 @@ func ServeNoContent(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set(NoContentResponseHeader, "response "+challenge)
 		}
 	}
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate, no-transform, max-age=0")
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -105,7 +106,7 @@ func isChallengeChar(c rune) bool {
 	// Semi-randomly chosen as a limited set of valid characters
 	return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') ||
 		('0' <= c && c <= '9') ||
-		c == '.' || c == '-' || c == '_'
+		c == '.' || c == '-' || c == '_' || c == ':'
 }
 
 const (

--- a/ipn/localapi/debugderp.go
+++ b/ipn/localapi/debugderp.go
@@ -231,8 +231,14 @@ func (h *Handler) serveDebugDERPRegion(w http.ResponseWriter, r *http.Request) {
 		connSuccess := checkConn(derpNode)
 
 		// Verify that the /generate_204 endpoint works
-		captivePortalURL := "http://" + derpNode.HostName + "/generate_204"
-		resp, err := client.Get(captivePortalURL)
+		captivePortalURL := fmt.Sprintf("http://%s/generate_204?t=%d", derpNode.HostName, time.Now().Unix())
+		req, err := http.NewRequest("GET", captivePortalURL, nil)
+		if err != nil {
+			st.Warnings = append(st.Warnings, fmt.Sprintf("Internal error creating request for captive portal check: %v", err))
+			continue
+		}
+		req.Header.Set("Cache-Control", "no-cache, no-store, must-revalidate, no-transform, max-age=0")
+		resp, err := client.Do(req)
 		if err != nil {
 			st.Warnings = append(st.Warnings, fmt.Sprintf("Error making request to the captive portal check %q; is port 80 blocked?", captivePortalURL))
 		} else {

--- a/net/captivedetection/captivedetection_test.go
+++ b/net/captivedetection/captivedetection_test.go
@@ -5,14 +5,21 @@ package captivedetection
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"runtime"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	"tailscale.com/derp/derphttp"
 	"tailscale.com/net/netmon"
 	"tailscale.com/syncs"
 	"tailscale.com/tstest/nettest"
+	"tailscale.com/util/must"
 )
 
 func TestAvailableEndpointsAlwaysAtLeastTwo(t *testing.T) {
@@ -79,5 +86,69 @@ func TestEndpointsAreUpAndReturnExpectedResponse(t *testing.T) {
 
 	if !good.Load() {
 		t.Errorf("no good endpoints found")
+	}
+}
+
+func TestCaptivePortalRequest(t *testing.T) {
+	d := NewDetector(t.Logf)
+	now := time.Now()
+	d.clock = func() time.Time { return now }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("expected GET, got %q", r.Method)
+		}
+		if r.URL.Path != "/generate_204" {
+			t.Errorf("expected /generate_204, got %q", r.URL.Path)
+		}
+		q := r.URL.Query()
+		if got, want := q.Get("t"), strconv.Itoa(int(now.Unix())); got != want {
+			t.Errorf("timestamp param; got %v, want %v", got, want)
+		}
+		w.Header().Set("X-Tailscale-Response", "response "+r.Header.Get("X-Tailscale-Challenge"))
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer s.Close()
+
+	e := Endpoint{
+		URL:                        must.Get(url.Parse(s.URL + "/generate_204")),
+		StatusCode:                 204,
+		ExpectedContent:            "",
+		SupportsTailscaleChallenge: true,
+	}
+
+	found, err := d.verifyCaptivePortalEndpoint(ctx, e, 0)
+	if err != nil {
+		t.Fatalf("verifyCaptivePortalEndpoint = %v, %v", found, err)
+	}
+	if found {
+		t.Errorf("verifyCaptivePortalEndpoint = %v, want false", found)
+	}
+}
+
+func TestAgainstDERPHandler(t *testing.T) {
+	d := NewDetector(t.Logf)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := httptest.NewServer(http.HandlerFunc(derphttp.ServeNoContent))
+	defer s.Close()
+	e := Endpoint{
+		URL:                        must.Get(url.Parse(s.URL + "/generate_204")),
+		StatusCode:                 204,
+		ExpectedContent:            "",
+		SupportsTailscaleChallenge: true,
+	}
+	found, err := d.verifyCaptivePortalEndpoint(ctx, e, 0)
+	if err != nil {
+		t.Fatalf("verifyCaptivePortalEndpoint = %v, %v", found, err)
+	}
+	if found {
+		t.Errorf("verifyCaptivePortalEndpoint = %v, want false", found)
 	}
 }


### PR DESCRIPTION
Observed on some airlines, Squid is configured to cache and transform
these results, which is disruptive. The server and client should both
actively request that this is not done by setting Cache-Control headers.

Send a timestamp parameter to further work against caches that do not
respect the cache-control headers.

Updates https://github.com/tailscale/tailscale/issues/14856
