### PR TITLE
util/syspolicy/internal/metrics: replace dots with underscores for metric names

### DIFF
--- a/util/syspolicy/internal/metrics/metrics.go
+++ b/util/syspolicy/internal/metrics/metrics.go
@@ -285,6 +285,7 @@ func SetHooksForTest(tb internal.TB, addMetric, setMetric metricFn) {
 
 func newSettingMetric(key setting.Key, scope setting.Scope, suffix string, typ clientmetric.Type) metric {
 	name := strings.ReplaceAll(string(key), string(setting.KeyPathSeparator), "_")
+	name = strings.ReplaceAll(name, ".", "_") // dots are not allowed in metric names
 	return newMetric([]string{name, metricScopeName(scope), suffix}, typ)
 }
 


### PR DESCRIPTION
Dots are not allowed in metric names and cause panics. Since we use dots in policy setting names like `AlwaysOn.OverrideWithReason`, let's replace them with underscores. We don’t want to use `setting.KeyPathSeparator` here just yet to make it fully hierarchical, but we will decide as we progress on the (experimental) `AlwaysOn.*` policy settings.

tailscale/corp#26146