### PR TITLE
ipn/ipnlocal: fix a panic in setPrefsLockedOnEntry when cc is nil

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -4181,7 +4181,7 @@ func (b *LocalBackend) setPrefsLockedOnEntry(newp *ipn.Prefs, unlock unlockOnce)
 		b.MagicConn().SetDERPMap(netMap.DERPMap)
 	}
 
-	if !oldp.WantRunning() && newp.WantRunning {
+	if !oldp.WantRunning() && newp.WantRunning && cc != nil {
 		b.logf("transitioning to running; doing Login...")
 		cc.Login(controlclient.LoginDefault)
 	}


### PR DESCRIPTION
The AlwaysOn policy can be applied by `(*LocalBackend).applySysPolicy`, flipping `WantRunning` from false to true before `(*LocalBackend).Start()` has been called for the first time and set a control client in `b.cc`. This results in a `nil` pointer dereference and a panic when `setPrefsLockedOnEntry` applies the change and calls `controlclient.Client.Login()`.

In this PR, we fix it by only doing a login if `b.cc` has been set.

Updates #14823