### PR TITLE
ipn/{ipnserver,localapi},tsnet: use ipnauth.Self as the actor in tsnet localapi handlers

### DIFF
--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -169,10 +169,9 @@ var (
 	metrics   = map[string]*clientmetric.Metric{}
 )
 
-// NewHandler creates a new LocalAPI HTTP handler. All parameters except netMon
-// are required (if non-nil it's used to do faster interface lookups).
-func NewHandler(b *ipnlocal.LocalBackend, logf logger.Logf, logID logid.PublicID) *Handler {
-	return &Handler{b: b, logf: logf, backendLogID: logID, clock: tstime.StdClock{}}
+// NewHandler creates a new LocalAPI HTTP handler. All parameters are required.
+func NewHandler(actor ipnauth.Actor, b *ipnlocal.LocalBackend, logf logger.Logf, logID logid.PublicID) *Handler {
+	return &Handler{Actor: actor, b: b, logf: logf, backendLogID: logID, clock: tstime.StdClock{}}
 }
 
 type Handler struct {

--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -33,6 +33,7 @@ import (
 	"tailscale.com/health"
 	"tailscale.com/hostinfo"
 	"tailscale.com/ipn"
+	"tailscale.com/ipn/ipnauth"
 	"tailscale.com/ipn/ipnlocal"
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/ipn/localapi"
@@ -272,7 +273,7 @@ func (s *Server) Loopback() (addr string, proxyCred, localAPICred string, err er
 		// out the CONNECT code from tailscaled/proxy.go that uses
 		// httputil.ReverseProxy and adding auth support.
 		go func() {
-			lah := localapi.NewHandler(s.lb, s.logf, s.logid)
+			lah := localapi.NewHandler(ipnauth.Self, s.lb, s.logf, s.logid)
 			lah.PermitWrite = true
 			lah.PermitRead = true
 			lah.RequiredPassword = s.localAPICred
@@ -667,7 +668,7 @@ func (s *Server) start() (reterr error) {
 	go s.printAuthURLLoop()
 
 	// Run the localapi handler, to allow fetching LetsEncrypt certs.
-	lah := localapi.NewHandler(lb, tsLogf, s.logid)
+	lah := localapi.NewHandler(ipnauth.Self, lb, tsLogf, s.logid)
 	lah.PermitWrite = true
 	lah.PermitRead = true
 


### PR DESCRIPTION
With #14843 merged, `(*localapi.Handler).servePrefs()` now requires a non-nil `Handler.Actor`, and other places may soon require it as well.

In this PR, we update `localapi.NewHandler` with a new required parameter for the actor. We then update `tsnet` to use `ipnauth.Self`.

We also rearrange the code in `(*ipnserver.Server).serveHTTP()` to pass the actor via `Handler`'s constructor instead of the field.

Updates #14823