### PR TITLE
clientupdate: refuse to update in tsnet binaries

### DIFF
--- a/clientupdate/clientupdate.go
+++ b/clientupdate/clientupdate.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"tailscale.com/hostinfo"
 	"tailscale.com/types/logger"
 	"tailscale.com/util/cmpver"
 	"tailscale.com/version"
@@ -169,6 +170,12 @@ func NewUpdater(args Arguments) (*Updater, error) {
 type updateFunction func() error
 
 func (up *Updater) getUpdateFunction() (fn updateFunction, canAutoUpdate bool) {
+	hi := hostinfo.New()
+	// We don't know how to update custom tsnet binaries, it's up to the user.
+	if hi.Package == "tsnet" {
+		return nil, false
+	}
+
 	switch runtime.GOOS {
 	case "windows":
 		return up.updateWindows, true


### PR DESCRIPTION
When running via tsnet, c2n will be hooked up so requests to update can reach the node. But it will then apply whatever OS-specific update function, upgrading the local tailscaled instead.

We can't update tsnet automatically, so refuse it.

Fixes #14892