### PR TITLE
ssh: don't use -l option for shells on OpenBSD

### DIFF
--- a/ssh/tailssh/incubator.go
+++ b/ssh/tailssh/incubator.go
@@ -1096,8 +1096,8 @@ func (ia *incubatorArgs) loginArgs(loginCmdPath string) []string {
 
 func shellArgs(isShell bool, cmd string) []string {
 	if isShell {
-		if runtime.GOOS == freebsd {
-			// freebsd's shells don't support the "-l" option, so we can't run as a login shell
+		if runtime.GOOS == freebsd || runtime.GOOS == openbsd {
+			// bsd shells don't support the "-l" option, so we can't run as a login shell
 			return []string{}
 		}
 		return []string{"-l"}


### PR DESCRIPTION
Shells on OpenBSD don't support the -l option. This means that when handling SSH in-process, we can't give the user a login shell, but this change at least allows connecting at all.

Updates #13338