### PR TITLE
docs/windows/policy: remove an extra closing >

### DIFF
--- a/docs/windows/policy/tailscale.admx
+++ b/docs/windows/policy/tailscale.admx
@@ -98,7 +98,7 @@
       <parentCategory ref="Settings_Category" />
       <supportedOn ref="SINCE_V1_56" />
       <elements>
-        <text id="ExitNodeIDPrompt" valueName="ExitNodeID" required="true" />>
+        <text id="ExitNodeIDPrompt" valueName="ExitNodeID" required="true" />
       </elements>
     </policy>
     <policy name="AllowedSuggestedExitNodes" class="Machine" displayName="$(string.AllowedSuggestedExitNodes)" explainText="$(string.AllowedSuggestedExitNodes_Help)" presentation="$(presentation.AllowedSuggestedExitNodes)" key="Software\Policies\Tailscale\AllowedSuggestedExitNodes">


### PR DESCRIPTION
Something I accidentally added in #14217.
It doesn't seem to impact Intune or the Administrative Templates MMC extension, but it should still be fixed.

Updates #cleanup