### PR TITLE
cmd/derper: close setec after use

### DIFF
--- a/cmd/derper/derper.go
+++ b/cmd/derper/derper.go
@@ -224,6 +224,7 @@ func main() {
 		}
 		meshKey = st.Secret(meshKeySecret).GetString()
 		log.Println("Got mesh key from setec store")
+		st.Close()
 	} else if *meshPSKFile != "" {
 		b, err := setec.StaticFile(*meshPSKFile)
 		if err != nil {


### PR DESCRIPTION
Since dynamic reload of setec is not supported in derper at this time, close the server after the secret is loaded.

Updates tailscale/corp#25756