### PR TITLE
cmd/derper: support no mesh key

### DIFF
--- a/cmd/derper/derper.go
+++ b/cmd/derper/derper.go
@@ -235,6 +235,8 @@ func main() {
 
 	if meshKey == "" && *dev {
 		log.Printf("No mesh key configured for --dev mode")
+	} else if meshKey == "" {
+		log.Printf("No mesh key configured")
 	} else if key, err := checkMeshKey(meshKey); err != nil {
 		log.Fatalf("invalid mesh key: %v", err)
 	} else {


### PR DESCRIPTION
Incorrect disabled support for not having a mesh key in d5316a4fbb4a1105ce2ba6f92d9688452b7747cd

Allow for no mesh key to be set.

Fixes #14928