### PR TITLE
cmd/natc: remove speculative tuning from natc

### DIFF
--- a/cmd/natc/natc.go
+++ b/cmd/natc/natc.go
@@ -27,8 +27,6 @@ import (
 	"github.com/inetaf/tcpproxy"
 	"github.com/peterbourgon/ff/v3"
 	"golang.org/x/net/dns/dnsmessage"
-	"gvisor.dev/gvisor/pkg/tcpip"
-	"gvisor.dev/gvisor/pkg/tcpip/transport/tcp"
 	"tailscale.com/client/local"
 	"tailscale.com/envknob"
 	"tailscale.com/hostinfo"
@@ -140,26 +138,6 @@ func main() {
 	}
 	// TODO(raggi): this is not a public interface or guarantee.
 	ns := ts.Sys().Netstack.Get().(*netstack.Impl)
-	tcpRXBufOpt := tcpip.TCPReceiveBufferSizeRangeOption{
-		Min:     tcp.MinBufferSize,
-		Default: tcp.DefaultReceiveBufferSize,
-		Max:     tcp.MaxBufferSize,
-	}
-	if err := ns.SetTransportProtocolOption(tcp.ProtocolNumber, &tcpRXBufOpt); err != nil {
-		log.Fatalf("could not set TCP RX buf size: %v", err)
-	}
-	tcpTXBufOpt := tcpip.TCPSendBufferSizeRangeOption{
-		Min:     tcp.MinBufferSize,
-		Default: tcp.DefaultSendBufferSize,
-		Max:     tcp.MaxBufferSize,
-	}
-	if err := ns.SetTransportProtocolOption(tcp.ProtocolNumber, &tcpTXBufOpt); err != nil {
-		log.Fatalf("could not set TCP TX buf size: %v", err)
-	}
-	mslOpt := tcpip.TCPTimeWaitTimeoutOption(5 * time.Second)
-	if err := ns.SetTransportProtocolOption(tcp.ProtocolNumber, &mslOpt); err != nil {
-		log.Fatalf("could not set TCP MSL: %v", err)
-	}
 	if *debugPort != 0 {
 		expvar.Publish("netstack", ns.ExpVar())
 	}


### PR DESCRIPTION
These tunings reduced memory usage while the implementation was struggling with earlier bugs, but will no longer be necessary after those bugs are addressed.

Depends #14933
Depends #14934
Updates #9707
Updates #10408
Updates tailscale/corp#24483
Updates tailscale/corp#25169