### PR TITLE
wgengine/netstack: respond to service IPs in Linux tun mode

### DIFF
--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -630,9 +630,10 @@ var v4broadcast = netaddr.IPv4(255, 255, 255, 255)
 // address slice views.
 func (ns *Impl) UpdateNetstackIPs(nm *netmap.NetworkMap) {
 	var selfNode tailcfg.NodeView
+	var serviceAddrSet set.Set[netip.Addr]
 	if nm != nil {
 		vipServiceIPMap := nm.GetVIPServiceIPMap()
-		serviceAddrSet := set.Set[netip.Addr]{}
+		serviceAddrSet = make(set.Set[netip.Addr], len(vipServiceIPMap)*2)
 		for _, addrs := range vipServiceIPMap {
 			serviceAddrSet.AddSlice(addrs)
 		}
@@ -668,6 +669,11 @@ func (ns *Impl) UpdateNetstackIPs(nm *netmap.NetworkMap) {
 				newPfx[p] = true
 			}
 		}
+	}
+
+	for addr := range serviceAddrSet {
+		p := netip.PrefixFrom(addr, addr.BitLen())
+		newPfx[p] = true
 	}
 
 	pfxToAdd := make(map[netip.Prefix]bool)
@@ -1014,12 +1020,18 @@ func (ns *Impl) shouldProcessInbound(p *packet.Parsed, t *tstun.Wrapper) bool {
 			return true
 		}
 	}
-	if ns.lb != nil && p.IPProto == ipproto.TCP && isService {
-		// An assumption holds for this to work: when tun mode is on for a service,
-		// its tcp and web are not set. This is enforced in b.setServeConfigLocked.
-		if ns.lb.ShouldInterceptVIPServiceTCPPort(p.Dst) {
+	if isService {
+		if p.IsEchoRequest() {
 			return true
 		}
+		if ns.lb != nil && p.IPProto == ipproto.TCP {
+			// An assumption holds for this to work: when tun mode is on for a service,
+			// its tcp and web are not set. This is enforced in b.setServeConfigLocked.
+			if ns.lb.ShouldInterceptVIPServiceTCPPort(p.Dst) {
+				return true
+			}
+		}
+		return false
 	}
 	if p.IPVersion == 6 && !isLocal && viaRange.Contains(dstIP) {
 		return ns.lb != nil && ns.lb.ShouldHandleViaIP(dstIP)


### PR DESCRIPTION
When in tun mode on Linux, AllowedIPs are not automatically added to netstack because the kernel is responsible for handling subnet routes. This ensures that virtual IPs are always added to netstack.

When in tun mode, pings were also not being handled, so this adds explicit support for ping as well.

Fixes tailscale/corp#26387

Change-Id: I6af02848bf2572701288125f247d1eaa6f661107