### PR TITLE
ipn/ipn{local,server}: remove ResetForClientDisconnect in favor of SetCurrentUser(nil)

### DIFF
--- a/ipn/ipnserver/server.go
+++ b/ipn/ipnserver/server.go
@@ -434,7 +434,7 @@ func (s *Server) addActiveHTTPRequest(req *http.Request, actor ipnauth.Actor) (o
 				s.logf("client disconnected; staying alive in server mode")
 			} else {
 				s.logf("client disconnected; stopping server")
-				lb.ResetForClientDisconnect()
+				lb.SetCurrentUser(nil)
 			}
 		}
 


### PR DESCRIPTION
There’s `(*LocalBackend).ResetForClientDisconnect`, and there’s also `(*LocalBackend).resetForProfileChangeLockedOnEntry`. Both methods essentially did the same thing but in slightly different ways. For example, `resetForProfileChangeLockedOnEntry` didn’t reset the control client until `(*LocalBackend).Start()` was called at the very end and didn’t reset the `keyExpired` flag, while `ResetForClientDisconnect` didn’t reinitialize TKA.

Since `SetCurrentUser` can be called with a nil argument to reset the currently connected user and internally calls `resetForProfileChangeLockedOnEntry`, we can remove `ResetForClientDisconnect` and let `SetCurrentUser` and `resetForProfileChangeLockedOnEntry` handle it.

Updates #14823