### PR TITLE
ipn/ipnlocal: fix (*profileManager).DefaultUserProfileID for users other than current

### DIFF
--- a/ipn/ipnlocal/profiles_test.go
+++ b/ipn/ipnlocal/profiles_test.go
@@ -129,10 +129,10 @@ func TestProfileList(t *testing.T) {
 
 	pm.SetCurrentUserID("user1")
 	checkProfiles(t, "alice", "bob")
-	if lp := pm.findProfileByKey(carol.Key()); lp.Valid() {
+	if lp := pm.findProfileByKey("user1", carol.Key()); lp.Valid() {
 		t.Fatalf("found profile for user2 in user1's profile list")
 	}
-	if lp := pm.findProfileByName(carol.Name()); lp.Valid() {
+	if lp := pm.findProfileByName("user1", carol.Name()); lp.Valid() {
 		t.Fatalf("found profile for user2 in user1's profile list")
 	}
 


### PR DESCRIPTION
Currently, `profileManager` filters profiles based on their creator/owner and the "current user"'s UID. This causes `DefaultUserProfileID(uid ipn.WindowsUserID)` to work incorrectly when the `uid` doesn't match the current user.

While we plan to remove the concept of the "current user" completely, we're not there yet.

In this PR, we fix `DefaultUserProfileID` by updating `profileManager` to allow checking profile access for a given UID and modifying helper methods to accept UID as a parameter when returning matching profiles.

Updates #14823