### PR TITLE
scripts/installer.sh: fix --yes argument for freebsd

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -573,7 +573,7 @@ main() {
 			;;
 		pkg)
 			set -x
-			$SUDO pkg install tailscale --yes
+			$SUDO pkg install --yes tailscale
 			$SUDO service tailscaled enable
 			$SUDO service tailscaled start
 			set +x


### PR DESCRIPTION
This argument apparently has to be before the package name

Updates #14745