### PR TITLE
tailcfg: make NetPortRange.Bits omitempty

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -1409,7 +1409,7 @@ var PortRangeAny = PortRange{0, 65535}
 type NetPortRange struct {
 	_     structs.Incomparable
 	IP    string // IP, CIDR, Range, or "*" (same formats as FilterRule.SrcIPs)
-	Bits  *int   // deprecated; the 2020 way to turn IP into a CIDR. See FilterRule.SrcBits.
+	Bits  *int   `json:",omitempty"` // deprecated; the 2020 way to turn IP into a CIDR. See FilterRule.SrcBits.
 	Ports PortRange
 }
 


### PR DESCRIPTION
This is deprecated anyway, and we don't need to be sending `"Bits":null` on the wire for the majority of clients.

Updates tailscale/corp#20965
Updates tailscale/corp#26353


Change-Id: I95a3e3d72619389ae34a6547ebf47043445374e1