### PR TITLE
Revert "control/controlclient: delete unreferenced mapSession UserProfiles"

### DIFF
--- a/control/controlclient/map.go
+++ b/control/controlclient/map.go
@@ -195,10 +195,6 @@ func (ms *mapSession) HandleNonKeepAliveMapResponse(ctx context.Context, resp *t
 
 	ms.updateStateFromResponse(resp)
 
-	// Occasionally clean up old userprofile if it grows too much
-	// from e.g. ephemeral tagged nodes.
-	ms.cleanLastUserProfile()
-
 	if ms.tryHandleIncrementally(resp) {
 		ms.occasionallyPrintSummary(ms.lastNetmapSummary)
 		return nil
@@ -296,6 +292,7 @@ func (ms *mapSession) updateStateFromResponse(resp *tailcfg.MapResponse) {
 	for _, up := range resp.UserProfiles {
 		ms.lastUserProfile[up.ID] = up.View()
 	}
+	// TODO(bradfitz): clean up old user profiles? maybe not worth it.
 
 	if dm := resp.DERPMap; dm != nil {
 		ms.vlogf("netmap: new map contains DERP map")
@@ -541,32 +538,6 @@ func (ms *mapSession) addUserProfile(nm *netmap.NetworkMap, userID tailcfg.UserI
 	}
 	if up, ok := ms.lastUserProfile[userID]; ok {
 		nm.UserProfiles[userID] = up
-	}
-}
-
-// cleanLastUserProfile deletes any entries from lastUserProfile
-// that are not referenced by any peer or the self node.
-//
-// This is expensive enough that we don't do this on every message
-// from the server, but only when it's grown enough to matter.
-func (ms *mapSession) cleanLastUserProfile() {
-	if len(ms.lastUserProfile) < len(ms.peers)*2 {
-		// Hasn't grown enough to be worth cleaning.
-		return
-	}
-
-	keep := set.Set[tailcfg.UserID]{}
-	if node := ms.lastNode; node.Valid() {
-		keep.Add(node.User())
-	}
-	for _, n := range ms.peers {
-		keep.Add(n.User())
-		keep.Add(n.Sharer())
-	}
-	for userID := range ms.lastUserProfile {
-		if !keep.Contains(userID) {
-			delete(ms.lastUserProfile, userID)
-		}
 	}
 }
 


### PR DESCRIPTION
This reverts commit 413fb5b93311972e3a8d724bb696607ef3afe6f2.

See long story in #14992

Updates #14992
Updates tailscale/corp#26058
