### PR TITLE
ipn/ipn{local,server}: extract logic that determines the "best" Tailscale profile to use

### DIFF
--- a/ipn/ipnserver/actor.go
+++ b/ipn/ipnserver/actor.go
@@ -32,6 +32,7 @@ type actor struct {
 	ci   *ipnauth.ConnIdentity
 
 	clientID ipnauth.ClientID
+	userID   ipn.WindowsUserID // cached Windows user ID of the connected client process.
 	// accessOverrideReason specifies the reason for overriding certain access restrictions,
 	// such as permitting a user to disconnect when the always-on mode is enabled,
 	// provided that such justification is allowed by the policy.
@@ -59,7 +60,14 @@ func newActor(logf logger.Logf, c net.Conn) (*actor, error) {
 		// connectivity on domain-joined devices and/or be slow.
 		clientID = ipnauth.ClientIDFrom(pid)
 	}
-	return &actor{logf: logf, ci: ci, clientID: clientID, isLocalSystem: connIsLocalSystem(ci)}, nil
+	return &actor{
+			logf:          logf,
+			ci:            ci,
+			clientID:      clientID,
+			userID:        ci.WindowsUserID(),
+			isLocalSystem: connIsLocalSystem(ci),
+		},
+		nil
 }
 
 // actorWithAccessOverride returns a new actor that carries the specified
@@ -106,7 +114,7 @@ func (a *actor) IsLocalAdmin(operatorUID string) bool {
 
 // UserID implements [ipnauth.Actor].
 func (a *actor) UserID() ipn.WindowsUserID {
-	return a.ci.WindowsUserID()
+	return a.userID
 }
 
 func (a *actor) pid() int {


### PR DESCRIPTION
In this PR, we further refactor `LocalBackend` and Unattended Mode to extract the logic that determines which profile should be used at the time of the check, such as when a LocalAPI client connects or disconnects. We then update `(*LocalBackend).switchProfileLockedOnEntry()` to to switch to the profile returned by `(*LocalBackend).resolveBestProfileLocked()` rather than to the caller-specified profile, and rename it to `switchToBestProfileLockedOnEntry()`.

This is done in preparation for updating `(*LocalBackend).getBackgroundProfileLocked()` to support Always-On mode by determining which profile to use based on which users, if any, are currently logged in and have an active foreground desktop session.

Updates #14823
Updates tailscale/corp#26247