### PR TITLE
go.mod: bump github.com/go-json-experiment/json

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/frankban/quicktest v1.14.6
 	github.com/fxamacker/cbor/v2 v2.7.0
 	github.com/gaissmai/bart v0.18.0
-	github.com/go-json-experiment/json v0.0.0-20250103232110-6a9a0fde9288
+	github.com/go-json-experiment/json v0.0.0-20250223041408-d3c622f1b874
 	github.com/go-logr/zapr v1.3.0
 	github.com/go-ole/go-ole v1.3.0
 	github.com/godbus/dbus/v5 v5.1.1-0.20230522191255-76236955d466

--- a/go.sum
+++ b/go.sum
@@ -327,8 +327,8 @@ github.com/go-git/go-git/v5 v5.13.1/go.mod h1:qryJB4cSBoq3FRoBRf5A77joojuBcmPJ0q
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-json-experiment/json v0.0.0-20250103232110-6a9a0fde9288 h1:KbX3Z3CgiYlbaavUq3Cj9/MjpO+88S7/AGXzynVDv84=
-github.com/go-json-experiment/json v0.0.0-20250103232110-6a9a0fde9288/go.mod h1:BWmvoE1Xia34f3l/ibJweyhrT+aROb/FQ6d+37F0e2s=
+github.com/go-json-experiment/json v0.0.0-20250223041408-d3c622f1b874 h1:F8d1AJ6M9UQCavhwmO6ZsrYLfG8zVFWfEfMS2MXPkSY=
+github.com/go-json-experiment/json v0.0.0-20250223041408-d3c622f1b874/go.mod h1:TiCD2a1pcmjd7YnhGH0f/zKNcCD06B029pHhzV23c2M=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=

--- a/types/opt/value.go
+++ b/types/opt/value.go
@@ -100,31 +100,31 @@ func (o Value[T]) Equal(v Value[T]) bool {
 	return false
 }
 
-// MarshalJSONV2 implements [jsonv2.MarshalerV2].
-func (o Value[T]) MarshalJSONV2(enc *jsontext.Encoder, opts jsonv2.Options) error {
+// MarshalJSONTo implements [jsonv2.MarshalerTo].
+func (o Value[T]) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if !o.set {
 		return enc.WriteToken(jsontext.Null)
 	}
-	return jsonv2.MarshalEncode(enc, &o.value, opts)
+	return jsonv2.MarshalEncode(enc, &o.value)
 }
 
-// UnmarshalJSONV2 implements [jsonv2.UnmarshalerV2].
-func (o *Value[T]) UnmarshalJSONV2(dec *jsontext.Decoder, opts jsonv2.Options) error {
+// UnmarshalJSONFrom implements [jsonv2.UnmarshalerFrom].
+func (o *Value[T]) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	if dec.PeekKind() == 'n' {
 		*o = Value[T]{}
 		_, err := dec.ReadToken() // read null
 		return err
 	}
 	o.set = true
-	return jsonv2.UnmarshalDecode(dec, &o.value, opts)
+	return jsonv2.UnmarshalDecode(dec, &o.value)
 }
 
 // MarshalJSON implements [json.Marshaler].
 func (o Value[T]) MarshalJSON() ([]byte, error) {
-	return jsonv2.Marshal(o) // uses MarshalJSONV2
+	return jsonv2.Marshal(o) // uses MarshalJSONTo
 }
 
 // UnmarshalJSON implements [json.Unmarshaler].
 func (o *Value[T]) UnmarshalJSON(b []byte) error {
-	return jsonv2.Unmarshal(b, o) // uses UnmarshalJSONV2
+	return jsonv2.Unmarshal(b, o) // uses UnmarshalJSONFrom
 }

--- a/types/prefs/item.go
+++ b/types/prefs/item.go
@@ -152,15 +152,15 @@ func (iv ItemView[T, V]) Equal(iv2 ItemView[T, V]) bool {
 	return iv.ж.Equal(*iv2.ж)
 }
 
-// MarshalJSONV2 implements [jsonv2.MarshalerV2].
-func (iv ItemView[T, V]) MarshalJSONV2(out *jsontext.Encoder, opts jsonv2.Options) error {
-	return iv.ж.MarshalJSONV2(out, opts)
+// MarshalJSONTo implements [jsonv2.MarshalerTo].
+func (iv ItemView[T, V]) MarshalJSONTo(out *jsontext.Encoder) error {
+	return iv.ж.MarshalJSONTo(out)
 }
 
-// UnmarshalJSONV2 implements [jsonv2.UnmarshalerV2].
-func (iv *ItemView[T, V]) UnmarshalJSONV2(in *jsontext.Decoder, opts jsonv2.Options) error {
+// UnmarshalJSONFrom implements [jsonv2.UnmarshalerFrom].
+func (iv *ItemView[T, V]) UnmarshalJSONFrom(in *jsontext.Decoder) error {
 	var x Item[T]
-	if err := x.UnmarshalJSONV2(in, opts); err != nil {
+	if err := x.UnmarshalJSONFrom(in); err != nil {
 		return err
 	}
 	iv.ж = &x
@@ -169,10 +169,10 @@ func (iv *ItemView[T, V]) UnmarshalJSONV2(in *jsontext.Decoder, opts jsonv2.Opti
 
 // MarshalJSON implements [json.Marshaler].
 func (iv ItemView[T, V]) MarshalJSON() ([]byte, error) {
-	return jsonv2.Marshal(iv) // uses MarshalJSONV2
+	return jsonv2.Marshal(iv) // uses MarshalJSONTo
 }
 
 // UnmarshalJSON implements [json.Unmarshaler].
 func (iv *ItemView[T, V]) UnmarshalJSON(b []byte) error {
-	return jsonv2.Unmarshal(b, iv) // uses UnmarshalJSONV2
+	return jsonv2.Unmarshal(b, iv) // uses UnmarshalJSONFrom
 }

--- a/types/prefs/list.go
+++ b/types/prefs/list.go
@@ -157,15 +157,15 @@ func (lv ListView[T]) Equal(lv2 ListView[T]) bool {
 	return lv.ж.Equal(*lv2.ж)
 }
 
-// MarshalJSONV2 implements [jsonv2.MarshalerV2].
-func (lv ListView[T]) MarshalJSONV2(out *jsontext.Encoder, opts jsonv2.Options) error {
-	return lv.ж.MarshalJSONV2(out, opts)
+// MarshalJSONTo implements [jsonv2.MarshalerTo].
+func (lv ListView[T]) MarshalJSONTo(out *jsontext.Encoder) error {
+	return lv.ж.MarshalJSONTo(out)
 }
 
-// UnmarshalJSONV2 implements [jsonv2.UnmarshalerV2].
-func (lv *ListView[T]) UnmarshalJSONV2(in *jsontext.Decoder, opts jsonv2.Options) error {
+// UnmarshalJSONFrom implements [jsonv2.UnmarshalerFrom].
+func (lv *ListView[T]) UnmarshalJSONFrom(in *jsontext.Decoder) error {
 	var x List[T]
-	if err := x.UnmarshalJSONV2(in, opts); err != nil {
+	if err := x.UnmarshalJSONFrom(in); err != nil {
 		return err
 	}
 	lv.ж = &x
@@ -174,10 +174,10 @@ func (lv *ListView[T]) UnmarshalJSONV2(in *jsontext.Decoder, opts jsonv2.Options
 
 // MarshalJSON implements [json.Marshaler].
 func (lv ListView[T]) MarshalJSON() ([]byte, error) {
-	return jsonv2.Marshal(lv) // uses MarshalJSONV2
+	return jsonv2.Marshal(lv) // uses MarshalJSONTo
 }
 
 // UnmarshalJSON implements [json.Unmarshaler].
 func (lv *ListView[T]) UnmarshalJSON(b []byte) error {
-	return jsonv2.Unmarshal(b, lv) // uses UnmarshalJSONV2
+	return jsonv2.Unmarshal(b, lv) // uses UnmarshalJSONFrom
 }

--- a/types/prefs/map.go
+++ b/types/prefs/map.go
@@ -133,15 +133,15 @@ func (mv MapView[K, V]) Equal(mv2 MapView[K, V]) bool {
 	return mv.ж.Equal(*mv2.ж)
 }
 
-// MarshalJSONV2 implements [jsonv2.MarshalerV2].
-func (mv MapView[K, V]) MarshalJSONV2(out *jsontext.Encoder, opts jsonv2.Options) error {
-	return mv.ж.MarshalJSONV2(out, opts)
+// MarshalJSONTo implements [jsonv2.MarshalerTo].
+func (mv MapView[K, V]) MarshalJSONTo(out *jsontext.Encoder) error {
+	return mv.ж.MarshalJSONTo(out)
 }
 
-// UnmarshalJSONV2 implements [jsonv2.UnmarshalerV2].
-func (mv *MapView[K, V]) UnmarshalJSONV2(in *jsontext.Decoder, opts jsonv2.Options) error {
+// UnmarshalJSONFrom implements [jsonv2.UnmarshalerFrom].
+func (mv *MapView[K, V]) UnmarshalJSONFrom(in *jsontext.Decoder) error {
 	var x Map[K, V]
-	if err := x.UnmarshalJSONV2(in, opts); err != nil {
+	if err := x.UnmarshalJSONFrom(in); err != nil {
 		return err
 	}
 	mv.ж = &x
@@ -150,10 +150,10 @@ func (mv *MapView[K, V]) UnmarshalJSONV2(in *jsontext.Decoder, opts jsonv2.Optio
 
 // MarshalJSON implements [json.Marshaler].
 func (mv MapView[K, V]) MarshalJSON() ([]byte, error) {
-	return jsonv2.Marshal(mv) // uses MarshalJSONV2
+	return jsonv2.Marshal(mv) // uses MarshalJSONTo
 }
 
 // UnmarshalJSON implements [json.Unmarshaler].
 func (mv *MapView[K, V]) UnmarshalJSON(b []byte) error {
-	return jsonv2.Unmarshal(b, mv) // uses UnmarshalJSONV2
+	return jsonv2.Unmarshal(b, mv) // uses UnmarshalJSONFrom
 }

--- a/types/prefs/prefs.go
+++ b/types/prefs/prefs.go
@@ -158,22 +158,22 @@ func (p *preference[T]) SetReadOnly(readonly bool) {
 	p.s.Metadata.ReadOnly = readonly
 }
 
-// MarshalJSONV2 implements [jsonv2.MarshalerV2].
-func (p preference[T]) MarshalJSONV2(out *jsontext.Encoder, opts jsonv2.Options) error {
-	return jsonv2.MarshalEncode(out, &p.s, opts)
+// MarshalJSONTo implements [jsonv2.MarshalerTo].
+func (p preference[T]) MarshalJSONTo(out *jsontext.Encoder) error {
+	return jsonv2.MarshalEncode(out, &p.s)
 }
 
-// UnmarshalJSONV2 implements [jsonv2.UnmarshalerV2].
-func (p *preference[T]) UnmarshalJSONV2(in *jsontext.Decoder, opts jsonv2.Options) error {
-	return jsonv2.UnmarshalDecode(in, &p.s, opts)
+// UnmarshalJSONFrom implements [jsonv2.UnmarshalerFrom].
+func (p *preference[T]) UnmarshalJSONFrom(in *jsontext.Decoder) error {
+	return jsonv2.UnmarshalDecode(in, &p.s)
 }
 
 // MarshalJSON implements [json.Marshaler].
 func (p preference[T]) MarshalJSON() ([]byte, error) {
-	return jsonv2.Marshal(p) // uses MarshalJSONV2
+	return jsonv2.Marshal(p) // uses MarshalJSONTo
 }
 
 // UnmarshalJSON implements [json.Unmarshaler].
 func (p *preference[T]) UnmarshalJSON(b []byte) error {
-	return jsonv2.Unmarshal(b, p) // uses UnmarshalJSONV2
+	return jsonv2.Unmarshal(b, p) // uses UnmarshalJSONFrom
 }

--- a/types/prefs/prefs_example/prefs_types.go
+++ b/types/prefs/prefs_example/prefs_types.go
@@ -48,10 +48,10 @@ import (
 // the `omitzero` JSON tag option. This option is not supported by the
 // [encoding/json] package as of 2024-08-21; see golang/go#45669.
 // It is recommended that a prefs type implements both
-// [jsonv2.MarshalerV2]/[jsonv2.UnmarshalerV2] and [json.Marshaler]/[json.Unmarshaler]
+// [jsonv2.MarshalerTo]/[jsonv2.UnmarshalerFrom] and [json.Marshaler]/[json.Unmarshaler]
 // to ensure consistent and more performant marshaling, regardless of the JSON package
 // used at the call sites; the standard marshalers can be implemented via [jsonv2].
-// See [Prefs.MarshalJSONV2], [Prefs.UnmarshalJSONV2], [Prefs.MarshalJSON],
+// See [Prefs.MarshalJSONTo], [Prefs.UnmarshalJSONFrom], [Prefs.MarshalJSON],
 // and [Prefs.UnmarshalJSON] for an example implementation.
 type Prefs struct {
 	ControlURL prefs.Item[string]               `json:",omitzero"`
@@ -128,34 +128,34 @@ type AppConnectorPrefs struct {
 	Advertise prefs.Item[bool] `json:",omitzero"`
 }
 
-// MarshalJSONV2 implements [jsonv2.MarshalerV2].
+// MarshalJSONTo implements [jsonv2.MarshalerTo].
 // It is implemented as a performance improvement and to enable omission of
 // unconfigured preferences from the JSON output. See the [Prefs] doc for details.
-func (p Prefs) MarshalJSONV2(out *jsontext.Encoder, opts jsonv2.Options) error {
+func (p Prefs) MarshalJSONTo(out *jsontext.Encoder) error {
 	// The prefs type shadows the Prefs's method set,
 	// causing [jsonv2] to use the default marshaler and avoiding
 	// infinite recursion.
 	type prefs Prefs
-	return jsonv2.MarshalEncode(out, (*prefs)(&p), opts)
+	return jsonv2.MarshalEncode(out, (*prefs)(&p))
 }
 
-// UnmarshalJSONV2 implements [jsonv2.UnmarshalerV2].
-func (p *Prefs) UnmarshalJSONV2(in *jsontext.Decoder, opts jsonv2.Options) error {
+// UnmarshalJSONFrom implements [jsonv2.UnmarshalerFrom].
+func (p *Prefs) UnmarshalJSONFrom(in *jsontext.Decoder) error {
 	// The prefs type shadows the Prefs's method set,
 	// causing [jsonv2] to use the default unmarshaler and avoiding
 	// infinite recursion.
 	type prefs Prefs
-	return jsonv2.UnmarshalDecode(in, (*prefs)(p), opts)
+	return jsonv2.UnmarshalDecode(in, (*prefs)(p))
 }
 
 // MarshalJSON implements [json.Marshaler].
 func (p Prefs) MarshalJSON() ([]byte, error) {
-	return jsonv2.Marshal(p) // uses MarshalJSONV2
+	return jsonv2.Marshal(p) // uses MarshalJSONTo
 }
 
 // UnmarshalJSON implements [json.Unmarshaler].
 func (p *Prefs) UnmarshalJSON(b []byte) error {
-	return jsonv2.Unmarshal(b, p) // uses UnmarshalJSONV2
+	return jsonv2.Unmarshal(b, p) // uses UnmarshalJSONFrom
 }
 
 type marshalAsTrueInJSON struct{}

--- a/types/prefs/prefs_test.go
+++ b/types/prefs/prefs_test.go
@@ -53,32 +53,32 @@ type TestPrefs struct {
 	Group TestPrefsGroup `json:",omitzero"`
 }
 
-// MarshalJSONV2 implements [jsonv2.MarshalerV2].
-func (p TestPrefs) MarshalJSONV2(out *jsontext.Encoder, opts jsonv2.Options) error {
+// MarshalJSONTo implements [jsonv2.MarshalerTo].
+func (p TestPrefs) MarshalJSONTo(out *jsontext.Encoder) error {
 	// The testPrefs type shadows the TestPrefs's method set,
 	// causing jsonv2 to use the default marshaler and avoiding
 	// infinite recursion.
 	type testPrefs TestPrefs
-	return jsonv2.MarshalEncode(out, (*testPrefs)(&p), opts)
+	return jsonv2.MarshalEncode(out, (*testPrefs)(&p))
 }
 
-// UnmarshalJSONV2 implements [jsonv2.UnmarshalerV2].
-func (p *TestPrefs) UnmarshalJSONV2(in *jsontext.Decoder, opts jsonv2.Options) error {
+// UnmarshalJSONFrom implements [jsonv2.UnmarshalerFrom].
+func (p *TestPrefs) UnmarshalJSONFrom(in *jsontext.Decoder) error {
 	// The testPrefs type shadows the TestPrefs's method set,
 	// causing jsonv2 to use the default unmarshaler and avoiding
 	// infinite recursion.
 	type testPrefs TestPrefs
-	return jsonv2.UnmarshalDecode(in, (*testPrefs)(p), opts)
+	return jsonv2.UnmarshalDecode(in, (*testPrefs)(p))
 }
 
 // MarshalJSON implements [json.Marshaler].
 func (p TestPrefs) MarshalJSON() ([]byte, error) {
-	return jsonv2.Marshal(p) // uses MarshalJSONV2
+	return jsonv2.Marshal(p) // uses MarshalJSONTo
 }
 
 // UnmarshalJSON implements [json.Unmarshaler].
 func (p *TestPrefs) UnmarshalJSON(b []byte) error {
-	return jsonv2.Unmarshal(b, p) // uses UnmarshalJSONV2
+	return jsonv2.Unmarshal(b, p) // uses UnmarshalJSONFrom
 }
 
 // TestBundle is an example structure type that,

--- a/types/prefs/struct_list.go
+++ b/types/prefs/struct_list.go
@@ -169,15 +169,15 @@ func (lv StructListView[T, V]) Equal(lv2 StructListView[T, V]) bool {
 	return lv.ж.Equal(*lv2.ж)
 }
 
-// MarshalJSONV2 implements [jsonv2.MarshalerV2].
-func (lv StructListView[T, V]) MarshalJSONV2(out *jsontext.Encoder, opts jsonv2.Options) error {
-	return lv.ж.MarshalJSONV2(out, opts)
+// MarshalJSONTo implements [jsonv2.MarshalerTo].
+func (lv StructListView[T, V]) MarshalJSONTo(out *jsontext.Encoder) error {
+	return lv.ж.MarshalJSONTo(out)
 }
 
-// UnmarshalJSONV2 implements [jsonv2.UnmarshalerV2].
-func (lv *StructListView[T, V]) UnmarshalJSONV2(in *jsontext.Decoder, opts jsonv2.Options) error {
+// UnmarshalJSONFrom implements [jsonv2.UnmarshalerFrom].
+func (lv *StructListView[T, V]) UnmarshalJSONFrom(in *jsontext.Decoder) error {
 	var x StructList[T]
-	if err := x.UnmarshalJSONV2(in, opts); err != nil {
+	if err := x.UnmarshalJSONFrom(in); err != nil {
 		return err
 	}
 	lv.ж = &x
@@ -186,10 +186,10 @@ func (lv *StructListView[T, V]) UnmarshalJSONV2(in *jsontext.Decoder, opts jsonv
 
 // MarshalJSON implements [json.Marshaler].
 func (lv StructListView[T, V]) MarshalJSON() ([]byte, error) {
-	return jsonv2.Marshal(lv) // uses MarshalJSONV2
+	return jsonv2.Marshal(lv) // uses MarshalJSONTo
 }
 
 // UnmarshalJSON implements [json.Unmarshaler].
 func (lv *StructListView[T, V]) UnmarshalJSON(b []byte) error {
-	return jsonv2.Unmarshal(b, lv) // uses UnmarshalJSONV2
+	return jsonv2.Unmarshal(b, lv) // uses UnmarshalJSONFrom
 }

--- a/types/prefs/struct_map.go
+++ b/types/prefs/struct_map.go
@@ -149,15 +149,15 @@ func (mv StructMapView[K, T, V]) Equal(mv2 StructMapView[K, T, V]) bool {
 	return mv.ж.Equal(*mv2.ж)
 }
 
-// MarshalJSONV2 implements [jsonv2.MarshalerV2].
-func (mv StructMapView[K, T, V]) MarshalJSONV2(out *jsontext.Encoder, opts jsonv2.Options) error {
-	return mv.ж.MarshalJSONV2(out, opts)
+// MarshalJSONTo implements [jsonv2.MarshalerTo].
+func (mv StructMapView[K, T, V]) MarshalJSONTo(out *jsontext.Encoder) error {
+	return mv.ж.MarshalJSONTo(out)
 }
 
-// UnmarshalJSONV2 implements [jsonv2.UnmarshalerV2].
-func (mv *StructMapView[K, T, V]) UnmarshalJSONV2(in *jsontext.Decoder, opts jsonv2.Options) error {
+// UnmarshalJSONFrom implements [jsonv2.UnmarshalerFrom].
+func (mv *StructMapView[K, T, V]) UnmarshalJSONFrom(in *jsontext.Decoder) error {
 	var x StructMap[K, T]
-	if err := x.UnmarshalJSONV2(in, opts); err != nil {
+	if err := x.UnmarshalJSONFrom(in); err != nil {
 		return err
 	}
 	mv.ж = &x
@@ -166,10 +166,10 @@ func (mv *StructMapView[K, T, V]) UnmarshalJSONV2(in *jsontext.Decoder, opts jso
 
 // MarshalJSON implements [json.Marshaler].
 func (mv StructMapView[K, T, V]) MarshalJSON() ([]byte, error) {
-	return jsonv2.Marshal(mv) // uses MarshalJSONV2
+	return jsonv2.Marshal(mv) // uses MarshalJSONTo
 }
 
 // UnmarshalJSON implements [json.Unmarshaler].
 func (mv *StructMapView[K, T, V]) UnmarshalJSON(b []byte) error {
-	return jsonv2.Unmarshal(b, mv) // uses UnmarshalJSONV2
+	return jsonv2.Unmarshal(b, mv) // uses UnmarshalJSONFrom
 }

--- a/util/syspolicy/internal/internal.go
+++ b/util/syspolicy/internal/internal.go
@@ -56,10 +56,10 @@ func EqualJSONForTest(tb TB, j1, j2 jsontext.Value) (s1, s2 string, equal bool) 
 		return "", "", true
 	}
 	// Otherwise, format the values for display and return false.
-	if err := j1.Indent("", "\t"); err != nil {
+	if err := j1.Indent(); err != nil {
 		tb.Fatal(err)
 	}
-	if err := j2.Indent("", "\t"); err != nil {
+	if err := j2.Indent(); err != nil {
 		tb.Fatal(err)
 	}
 	return j1.String(), j2.String(), false

--- a/util/syspolicy/setting/origin.go
+++ b/util/syspolicy/setting/origin.go
@@ -50,22 +50,22 @@ func (s Origin) String() string {
 	return s.Scope().String()
 }
 
-// MarshalJSONV2 implements [jsonv2.MarshalerV2].
-func (s Origin) MarshalJSONV2(out *jsontext.Encoder, opts jsonv2.Options) error {
-	return jsonv2.MarshalEncode(out, &s.data, opts)
+// MarshalJSONTo implements [jsonv2.MarshalerTo].
+func (s Origin) MarshalJSONTo(out *jsontext.Encoder) error {
+	return jsonv2.MarshalEncode(out, &s.data)
 }
 
-// UnmarshalJSONV2 implements [jsonv2.UnmarshalerV2].
-func (s *Origin) UnmarshalJSONV2(in *jsontext.Decoder, opts jsonv2.Options) error {
-	return jsonv2.UnmarshalDecode(in, &s.data, opts)
+// UnmarshalJSONFrom implements [jsonv2.UnmarshalerFrom].
+func (s *Origin) UnmarshalJSONFrom(in *jsontext.Decoder) error {
+	return jsonv2.UnmarshalDecode(in, &s.data)
 }
 
 // MarshalJSON implements [json.Marshaler].
 func (s Origin) MarshalJSON() ([]byte, error) {
-	return jsonv2.Marshal(s) // uses MarshalJSONV2
+	return jsonv2.Marshal(s) // uses MarshalJSONTo
 }
 
 // UnmarshalJSON implements [json.Unmarshaler].
 func (s *Origin) UnmarshalJSON(b []byte) error {
-	return jsonv2.Unmarshal(b, s) // uses UnmarshalJSONV2
+	return jsonv2.Unmarshal(b, s) // uses UnmarshalJSONFrom
 }

--- a/util/syspolicy/setting/raw_item.go
+++ b/util/syspolicy/setting/raw_item.go
@@ -75,31 +75,31 @@ func (i RawItem) String() string {
 	return fmt.Sprintf("%v%s", i.data.Value.Value, suffix)
 }
 
-// MarshalJSONV2 implements [jsonv2.MarshalerV2].
-func (i RawItem) MarshalJSONV2(out *jsontext.Encoder, opts jsonv2.Options) error {
-	return jsonv2.MarshalEncode(out, &i.data, opts)
+// MarshalJSONTo implements [jsonv2.MarshalerTo].
+func (i RawItem) MarshalJSONTo(out *jsontext.Encoder) error {
+	return jsonv2.MarshalEncode(out, &i.data)
 }
 
-// UnmarshalJSONV2 implements [jsonv2.UnmarshalerV2].
-func (i *RawItem) UnmarshalJSONV2(in *jsontext.Decoder, opts jsonv2.Options) error {
-	return jsonv2.UnmarshalDecode(in, &i.data, opts)
+// UnmarshalJSONFrom implements [jsonv2.UnmarshalerFrom].
+func (i *RawItem) UnmarshalJSONFrom(in *jsontext.Decoder) error {
+	return jsonv2.UnmarshalDecode(in, &i.data)
 }
 
 // MarshalJSON implements [json.Marshaler].
 func (i RawItem) MarshalJSON() ([]byte, error) {
-	return jsonv2.Marshal(i) // uses MarshalJSONV2
+	return jsonv2.Marshal(i) // uses MarshalJSONTo
 }
 
 // UnmarshalJSON implements [json.Unmarshaler].
 func (i *RawItem) UnmarshalJSON(b []byte) error {
-	return jsonv2.Unmarshal(b, i) // uses UnmarshalJSONV2
+	return jsonv2.Unmarshal(b, i) // uses UnmarshalJSONFrom
 }
 
 // RawValue represents a raw policy setting value read from a policy store.
 // It is JSON-marshallable and facilitates unmarshalling of JSON values
 // into corresponding policy setting types, with special handling for JSON numbers
 // (unmarshalled as float64) and JSON string arrays (unmarshalled as []string).
-// See also [RawValue.UnmarshalJSONV2].
+// See also [RawValue.UnmarshalJSONFrom].
 type RawValue struct {
 	opt.Value[any]
 }
@@ -114,16 +114,16 @@ func RawValueOf[T RawValueType](v T) RawValue {
 	return RawValue{opt.ValueOf[any](v)}
 }
 
-// MarshalJSONV2 implements [jsonv2.MarshalerV2].
-func (v RawValue) MarshalJSONV2(out *jsontext.Encoder, opts jsonv2.Options) error {
-	return jsonv2.MarshalEncode(out, v.Value, opts)
+// MarshalJSONTo implements [jsonv2.MarshalerTo].
+func (v RawValue) MarshalJSONTo(out *jsontext.Encoder) error {
+	return jsonv2.MarshalEncode(out, v.Value)
 }
 
-// UnmarshalJSONV2 implements [jsonv2.UnmarshalerV2] by attempting to unmarshal
+// UnmarshalJSONFrom implements [jsonv2.UnmarshalerFrom] by attempting to unmarshal
 // a JSON value as one of the supported policy setting value types (bool, string, uint64, or []string),
 // based on the JSON value type. It fails if the JSON value is an object, if it's a JSON number that
 // cannot be represented as a uint64, or if a JSON array contains anything other than strings.
-func (v *RawValue) UnmarshalJSONV2(in *jsontext.Decoder, opts jsonv2.Options) error {
+func (v *RawValue) UnmarshalJSONFrom(in *jsontext.Decoder) error {
 	var valPtr any
 	switch k := in.PeekKind(); k {
 	case 't', 'f':
@@ -139,7 +139,7 @@ func (v *RawValue) UnmarshalJSONV2(in *jsontext.Decoder, opts jsonv2.Options) er
 	default:
 		panic("unreachable")
 	}
-	if err := jsonv2.UnmarshalDecode(in, valPtr, opts); err != nil {
+	if err := jsonv2.UnmarshalDecode(in, valPtr); err != nil {
 		v.Value.Clear()
 		return err
 	}
@@ -150,12 +150,12 @@ func (v *RawValue) UnmarshalJSONV2(in *jsontext.Decoder, opts jsonv2.Options) er
 
 // MarshalJSON implements [json.Marshaler].
 func (v RawValue) MarshalJSON() ([]byte, error) {
-	return jsonv2.Marshal(v) // uses MarshalJSONV2
+	return jsonv2.Marshal(v) // uses MarshalJSONTo
 }
 
 // UnmarshalJSON implements [json.Unmarshaler].
 func (v *RawValue) UnmarshalJSON(b []byte) error {
-	return jsonv2.Unmarshal(b, v) // uses UnmarshalJSONV2
+	return jsonv2.Unmarshal(b, v) // uses UnmarshalJSONFrom
 }
 
 // RawValues is a map of keyed setting values that can be read from a JSON.

--- a/util/syspolicy/setting/snapshot.go
+++ b/util/syspolicy/setting/snapshot.go
@@ -147,23 +147,23 @@ type snapshotJSON struct {
 	Settings map[Key]RawItem `json:",omitempty"`
 }
 
-// MarshalJSONV2 implements [jsonv2.MarshalerV2].
-func (s *Snapshot) MarshalJSONV2(out *jsontext.Encoder, opts jsonv2.Options) error {
+// MarshalJSONTo implements [jsonv2.MarshalerTo].
+func (s *Snapshot) MarshalJSONTo(out *jsontext.Encoder) error {
 	data := &snapshotJSON{}
 	if s != nil {
 		data.Summary = s.summary
 		data.Settings = s.m
 	}
-	return jsonv2.MarshalEncode(out, data, opts)
+	return jsonv2.MarshalEncode(out, data)
 }
 
-// UnmarshalJSONV2 implements [jsonv2.UnmarshalerV2].
-func (s *Snapshot) UnmarshalJSONV2(in *jsontext.Decoder, opts jsonv2.Options) error {
+// UnmarshalJSONFrom implements [jsonv2.UnmarshalerFrom].
+func (s *Snapshot) UnmarshalJSONFrom(in *jsontext.Decoder) error {
 	if s == nil {
 		return errors.New("s must not be nil")
 	}
 	data := &snapshotJSON{}
-	if err := jsonv2.UnmarshalDecode(in, data, opts); err != nil {
+	if err := jsonv2.UnmarshalDecode(in, data); err != nil {
 		return err
 	}
 	*s = Snapshot{m: data.Settings, sig: deephash.Hash(&data.Settings), summary: data.Summary}
@@ -172,12 +172,12 @@ func (s *Snapshot) UnmarshalJSONV2(in *jsontext.Decoder, opts jsonv2.Options) er
 
 // MarshalJSON implements [json.Marshaler].
 func (s *Snapshot) MarshalJSON() ([]byte, error) {
-	return jsonv2.Marshal(s) // uses MarshalJSONV2
+	return jsonv2.Marshal(s) // uses MarshalJSONTo
 }
 
 // UnmarshalJSON implements [json.Unmarshaler].
 func (s *Snapshot) UnmarshalJSON(b []byte) error {
-	return jsonv2.Unmarshal(b, s) // uses UnmarshalJSONV2
+	return jsonv2.Unmarshal(b, s) // uses UnmarshalJSONFrom
 }
 
 // MergeSnapshots returns a [Snapshot] that contains all [RawItem]s

--- a/util/syspolicy/setting/summary.go
+++ b/util/syspolicy/setting/summary.go
@@ -54,24 +54,24 @@ func (s Summary) String() string {
 	return s.data.Scope.String()
 }
 
-// MarshalJSONV2 implements [jsonv2.MarshalerV2].
-func (s Summary) MarshalJSONV2(out *jsontext.Encoder, opts jsonv2.Options) error {
-	return jsonv2.MarshalEncode(out, &s.data, opts)
+// MarshalJSONTo implements [jsonv2.MarshalerTo].
+func (s Summary) MarshalJSONTo(out *jsontext.Encoder) error {
+	return jsonv2.MarshalEncode(out, &s.data)
 }
 
-// UnmarshalJSONV2 implements [jsonv2.UnmarshalerV2].
-func (s *Summary) UnmarshalJSONV2(in *jsontext.Decoder, opts jsonv2.Options) error {
-	return jsonv2.UnmarshalDecode(in, &s.data, opts)
+// UnmarshalJSONFrom implements [jsonv2.UnmarshalerFrom].
+func (s *Summary) UnmarshalJSONFrom(in *jsontext.Decoder) error {
+	return jsonv2.UnmarshalDecode(in, &s.data)
 }
 
 // MarshalJSON implements [json.Marshaler].
 func (s Summary) MarshalJSON() ([]byte, error) {
-	return jsonv2.Marshal(s) // uses MarshalJSONV2
+	return jsonv2.Marshal(s) // uses MarshalJSONTo
 }
 
 // UnmarshalJSON implements [json.Unmarshaler].
 func (s *Summary) UnmarshalJSON(b []byte) error {
-	return jsonv2.Unmarshal(b, s) // uses UnmarshalJSONV2
+	return jsonv2.Unmarshal(b, s) // uses UnmarshalJSONFrom
 }
 
 // SummaryOption is an option that configures [Summary]


### PR DESCRIPTION
The upstream module has seen significant work making the v1 emulation layer a high fidelity re-implementation of v1 "encoding/json".

This addresses several upstream breaking changes:
* MarshalJSONV2 renamed as MarshalJSONTo
* UnmarshalJSONV2 renamed as UnmarshalJSONFrom
* Options argument removed from MarshalJSONV2
* Options argument removed from UnmarshalJSONV2

Updates #791