### PR TITLE
types/bools: fix doc typo

### DIFF
--- a/types/bools/bools.go
+++ b/types/bools/bools.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-// Package bools contains the [Int], [Compare], and [Select] functions.
+// Package bools contains the [Int], [Compare], and [IfElse] functions.
 package bools
 
 // Int returns 1 for true and 0 for false.


### PR DESCRIPTION
The Select function was renamed as IfElse.

Updates #cleanup