### PR TITLE
ipn: sort VIP services before hashing

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -8058,7 +8058,14 @@ func (b *LocalBackend) vipServicesFromPrefsLocked(prefs ipn.PrefsView) []*tailcf
 		services[sn].Active = true
 	}
 
-	return slicesx.MapValues(services)
+	servicesList := slicesx.MapValues(services)
+	// [slicesx.MapValues] provides the values in an indeterminate order, but since we'll
+	// be hashing a representation of this list later we want it to be in a consistent
+	// order.
+	slices.SortFunc(servicesList, func(a, b *tailcfg.VIPService) int {
+		return strings.Compare(a.Name.String(), b.Name.String())
+	})
+	return servicesList
 }
 
 var (


### PR DESCRIPTION
We're computing the list of services to hash by iterating over the values of a map, the ordering of which is not guaranteed. This can cause the hash to fluctuate depending on the ordering if there's more than one service hosted by the same host.

Updates tailscale/corp#25733.