### PR TITLE
various: disable MPTCP when setting TCP_USER_TIMEOUT sockopt

### DIFF
--- a/cmd/derper/derper.go
+++ b/cmd/derper/derper.go
@@ -324,6 +324,9 @@ func main() {
 		Control:   ktimeout.UserTimeout(*tcpUserTimeout),
 		KeepAlive: *tcpKeepAlive,
 	}
+	// As of 2025-02-19, MPTCP does not support TCP_USER_TIMEOUT socket option
+	// set in ktimeout.UserTimeout above.
+	lc.SetMultipathTCP(false)
 
 	quietLogger := log.New(logger.HTTPServerLogFilter{Inner: log.Printf}, "", 0)
 	httpsrv := &http.Server{

--- a/net/ktimeout/ktimeout_linux_test.go
+++ b/net/ktimeout/ktimeout_linux_test.go
@@ -4,17 +4,22 @@
 package ktimeout
 
 import (
+	"context"
 	"net"
 	"testing"
 	"time"
 
-	"golang.org/x/net/nettest"
 	"golang.org/x/sys/unix"
 	"tailscale.com/util/must"
 )
 
 func TestSetUserTimeout(t *testing.T) {
-	l := must.Get(nettest.NewLocalListener("tcp"))
+	lc := net.ListenConfig{}
+	// As of 2025-02-19, MPTCP does not support TCP_USER_TIMEOUT socket option
+	// set in ktimeout.UserTimeout above.
+	lc.SetMultipathTCP(false)
+
+	l := must.Get(lc.Listen(context.Background(), "tcp", "localhost:0"))
 	defer l.Close()
 
 	var err error


### PR DESCRIPTION
There's nothing about it on
https://github.com/multipath-tcp/mptcp_net-next/issues/ but empirically MPTCP doesn't support this option on awly's kernel 6.13.2 and in GitHub actions.

Updates #15015