### PR TITLE
scripts/installer.sh: add SparkyLinux as a Debian derivative

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -186,6 +186,12 @@ main() {
 					VERSION="$DEBIAN_CODENAME"
 				fi
 				;;
+			sparky)
+				OS="debian"
+				PACKAGETYPE="apt"
+				VERSION="$DEBIAN_CODENAME"
+				APT_KEY_TYPE="keyring"
+				;;
 			centos)
 				OS="$ID"
 				VERSION="$VERSION_ID"


### PR DESCRIPTION
Fixes #15075 (TSS-53630)
Tested in VM