### PR TITLE
go.mod: upgrade go-json-experiment for new Marshaler names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/frankban/quicktest v1.14.6
 	github.com/fxamacker/cbor/v2 v2.7.0
 	github.com/gaissmai/bart v0.11.1
-	github.com/go-json-experiment/json v0.0.0-20250103232110-6a9a0fde9288
+	github.com/go-json-experiment/json v0.0.0-20250108090738-82e3cf3dca05
 	github.com/go-logr/zapr v1.3.0
 	github.com/go-ole/go-ole v1.3.0
 	github.com/godbus/dbus/v5 v5.1.1-0.20230522191255-76236955d466

--- a/go.sum
+++ b/go.sum
@@ -339,6 +339,8 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-json-experiment/json v0.0.0-20250103232110-6a9a0fde9288 h1:KbX3Z3CgiYlbaavUq3Cj9/MjpO+88S7/AGXzynVDv84=
 github.com/go-json-experiment/json v0.0.0-20250103232110-6a9a0fde9288/go.mod h1:BWmvoE1Xia34f3l/ibJweyhrT+aROb/FQ6d+37F0e2s=
+github.com/go-json-experiment/json v0.0.0-20250108090738-82e3cf3dca05 h1:quTyRdkK9IzEjIlY2lH8Kf9C6NEsiWA03Q3JfjLW51Q=
+github.com/go-json-experiment/json v0.0.0-20250108090738-82e3cf3dca05/go.mod h1:BWmvoE1Xia34f3l/ibJweyhrT+aROb/FQ6d+37F0e2s=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=


### PR DESCRIPTION
https://github.com/go-json-experiment/json/commit/82e3cf3dca05 renames a few things, while maintaining support for the old names:

	* MarshalerV1 -> Marshaler
	* MarshalerV2 -> MarshalerTo
	* MarshalJSONV2 -> MarshalJSONTo
	* MarshalFuncV1 -> MarshalFunc
	* MarshalFuncV2 -> MarshalToFunc
	* UnmarshalerV1 -> Unmarshaler
	* UnmarshalerV2 -> UnmarshalerFrom
	* UnmarshalJSONV2 -> UnmarshalJSONFrom
	* UnmarshalFuncV1 -> UnmarshalFunc
	* UnmarshalFuncV2 -> UnmarshalFromFunc

If we upgrade past this commit we'll need to clean up any existing MarshalerV2 methods, which I suggest we do separately. We want to start implementing some of these efficient marshaller methods on our types in views, so let's do it using the newer names.

Commit range of upgrade: https://github.com/go-json-experiment/json/compare/6a9a0fde9288...82e3cf3dca05fcc096299c68cb00b27960cdc51f

Updates tailscale/corp#791
Updates tailscale/corp#26353