### PR TITLE
appc: fix a deadlock in route advertisements

### DIFF
--- a/appc/appctest/appctest.go
+++ b/appc/appctest/appctest.go
@@ -11,12 +11,22 @@ import (
 
 // RouteCollector is a test helper that collects the list of routes advertised
 type RouteCollector struct {
+	// AdvertiseCallback (optional) is called synchronously from
+	// AdvertiseRoute.
+	AdvertiseCallback func()
+	// UnadvertiseCallback (optional) is called synchronously from
+	// UnadvertiseRoute.
+	UnadvertiseCallback func()
+
 	routes        []netip.Prefix
 	removedRoutes []netip.Prefix
 }
 
 func (rc *RouteCollector) AdvertiseRoute(pfx ...netip.Prefix) error {
 	rc.routes = append(rc.routes, pfx...)
+	if rc.AdvertiseCallback != nil {
+		rc.AdvertiseCallback()
+	}
 	return nil
 }
 
@@ -29,6 +39,9 @@ func (rc *RouteCollector) UnadvertiseRoute(toRemove ...netip.Prefix) error {
 		} else {
 			rc.removedRoutes = append(rc.removedRoutes, r)
 		}
+	}
+	if rc.UnadvertiseCallback != nil {
+		rc.UnadvertiseCallback()
 	}
 	return nil
 }


### PR DESCRIPTION
Backport https://github.com/tailscale/tailscale/pull/15031 into 1.80.

`routeAdvertiser` is the `iplocal.LocalBackend`. Calls to `Advertise/UnadvertiseRoute` end up calling `EditPrefs` which in turn calls `authReconfig` which finally calls `readvertiseAppConnectorRoutes` which calls `AppConnector.DomainRoutes` and gets stuck on a mutex that was already held when `routeAdvertiser` was called.

Make all calls to `routeAdvertiser` in `app.AppConnector` go through the execqueue instead as a short-term fix.

Updates tailscale/corp#25965