### PR TITLE
tstest/deptest: add DepChecker.ExtraEnv option for callers to set

### DIFF
--- a/tstest/deptest/deptest.go
+++ b/tstest/deptest/deptest.go
@@ -27,6 +27,7 @@ type DepChecker struct {
 	BadDeps  map[string]string // package => why
 	WantDeps set.Set[string]   // packages expected
 	Tags     string            // comma-separated
+	ExtraEnv []string          // extra environment for "go list" (e.g. CGO_ENABLED=1)
 }
 
 func (c DepChecker) Check(t *testing.T) {
@@ -43,6 +44,7 @@ func (c DepChecker) Check(t *testing.T) {
 	if c.GOARCH != "" {
 		extraEnv = append(extraEnv, "GOARCH="+c.GOARCH)
 	}
+	extraEnv = append(extraEnv, c.ExtraEnv...)
 	cmd.Env = append(os.Environ(), extraEnv...)
 	out, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
For tests (in another repo) that use cgo, we'd like to set CGO_ENABLED=1
explicitly when evaluating cross-compiled deps with "go list".

Updates tailscale/corp#26717
Updates tailscale/corp#26737
