### PR TITLE
scripts/installer.sh: ensure default umask for the installer

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -7,6 +7,14 @@
 
 set -eu
 
+# Ensure that this script runs with the default umask for Linux. In practice,
+# this means that files created by this script (such as keyring files) will be
+# created with 644 permissions. This ensures that keyrings and other files
+# created by this script are readable by installers on systems where the
+# umask is set to a more restrictive value.
+# See https://github.com/tailscale/tailscale/issues/15133
+umask 022
+
 # All the code is wrapped in a main function that gets called at the
 # bottom of the file, so that a truncated partial download doesn't end
 # up executing half a script.


### PR DESCRIPTION
Ensures default Linux umask 022 for the installer script to make sure that files created by the installer can be accessed by other tools, such as apt-get

I have tested that with this setting the installer script succeeds on a system where umask is 027 (and tested that without this setting it fails).

Alternatively, I could have modified permissions on individual artifacts created by this script (i.e. chmod `/usr/share/keyrings/tailscale-archive-keyring.gpg` to make sure `apt-get` can read it- but that would have the downside that as we are adding more install methods to the script this could break again).

I have only tested this on Debian, but `umask` should work on all Linux flavours and MacOS.

Updates tailscale/tailscale#15133