### PR TITLE
cmd/tailscale/cli: add `remove` command for accounts

### DIFF
--- a/cmd/tailscale/cli/switch.go
+++ b/cmd/tailscale/cli/switch.go
@@ -122,40 +122,8 @@ func switchProfile(ctx context.Context, args []string) error {
 		errf("Failed to switch to account: %v\n", err)
 		os.Exit(1)
 	}
-	var profID ipn.ProfileID
-	// Allow matching by ID, Tailnet, Account, or Display Name
-	// in that order.
-	for _, p := range all {
-		if p.ID == ipn.ProfileID(args[0]) {
-			profID = p.ID
-			break
-		}
-	}
-	if profID == "" {
-		for _, p := range all {
-			if p.NetworkProfile.DomainName == args[0] {
-				profID = p.ID
-				break
-			}
-		}
-	}
-	if profID == "" {
-		for _, p := range all {
-			if p.Name == args[0] {
-				profID = p.ID
-				break
-			}
-		}
-	}
-	if profID == "" {
-		for _, p := range all {
-			if p.NetworkProfile.DisplayName == args[0] {
-				profID = p.ID
-				break
-			}
-		}
-	}
-	if profID == "" {
+	profID, ok := matchProfile(args[0], all)
+	if !ok {
 		errf("No profile named %q\n", args[0])
 		os.Exit(1)
 	}
@@ -229,7 +197,7 @@ func removeProfile(ctx context.Context, args []string) error {
 }
 
 func matchProfile(arg string, all []ipn.LoginProfile) (ipn.ProfileID, bool) {
-	// Allow matching by ID, Tailnet, or Account
+	// Allow matching by ID, Tailnet, Account, or Display Name
 	// in that order.
 	for _, p := range all {
 		if p.ID == ipn.ProfileID(arg) {
@@ -243,6 +211,11 @@ func matchProfile(arg string, all []ipn.LoginProfile) (ipn.ProfileID, bool) {
 	}
 	for _, p := range all {
 		if p.Name == arg {
+			return p.ID, true
+		}
+	}
+	for _, p := range all {
+		if p.NetworkProfile.DisplayName == arg {
 			return p.ID, true
 		}
 	}

--- a/cmd/tailscale/cli/switch.go
+++ b/cmd/tailscale/cli/switch.go
@@ -34,6 +34,22 @@ This command is currently in alpha and may change in the future.`,
 		return fs
 	}(),
 	Exec: switchProfile,
+
+	// Add remove subcommand
+	Subcommands: []*ffcli.Command{
+		{
+			Name:       "remove",
+			ShortUsage: "tailscale switch remove <id>",
+			ShortHelp:  "Remove a Tailscale account",
+			LongHelp: `"tailscale switch remove" removes a Tailscale account from the
+local machine. This does not delete the account itself, but
+it will no longer be available for switching to. You can
+add it back by logging in again.
+
+This command is currently in alpha and may change in the future.`,
+			Exec: removeProfile,
+		},
+	},
 }
 
 func init() {
@@ -185,4 +201,50 @@ func switchProfile(ctx context.Context, args []string) error {
 			os.Exit(1)
 		}
 	}
+}
+
+func removeProfile(ctx context.Context, args []string) error {
+	if len(args) != 1 {
+		outln("usage: tailscale switch remove NAME")
+		os.Exit(1)
+	}
+	cp, all, err := localClient.ProfileStatus(ctx)
+	if err != nil {
+		errf("Failed to remove account: %v\n", err)
+		os.Exit(1)
+	}
+
+	profID, ok := matchProfile(args[0], all)
+	if !ok {
+		errf("No profile named %q\n", args[0])
+		os.Exit(1)
+	}
+
+	if profID == cp.ID {
+		printf("Already on account %q\n", args[0])
+		os.Exit(0)
+	}
+
+	return localClient.DeleteProfile(ctx, profID)
+}
+
+func matchProfile(arg string, all []ipn.LoginProfile) (ipn.ProfileID, bool) {
+	// Allow matching by ID, Tailnet, or Account
+	// in that order.
+	for _, p := range all {
+		if p.ID == ipn.ProfileID(arg) {
+			return p.ID, true
+		}
+	}
+	for _, p := range all {
+		if p.NetworkProfile.DomainName == arg {
+			return p.ID, true
+		}
+	}
+	for _, p := range all {
+		if p.Name == arg {
+			return p.ID, true
+		}
+	}
+	return "", false
 }


### PR DESCRIPTION
Fixes #12255

Add a new command to the CLI to remove a profile from the local client. This also fixes a bug in the local client where the DELETE request was not being sent correctly.

I decided to go with this approach instead of what is mentioned as a request solution for the following reasons.

1. Since commands like `switch`, `login` and `logout` reference the user's account(s), I felt it made more sense to have it be a regular command instead of the functionality being contained under the `switch` command. 
2. This makes it more accessible for Linux users who do not have a GUI interface and would look towards `tailscale --help` for directions on how to remove an account
3. The command name `remove` seemed a bit clearer than using `delete` as `delete` could be interpreted as fully purging an account and its info. Additionally, `remove` is the word chosen for the GUI options