### PR TITLE
scripts/installer.sh: explicitly chmod 0644 installed files

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -7,14 +7,6 @@
 
 set -eu
 
-# Ensure that this script runs with the default umask for Linux. In practice,
-# this means that files created by this script (such as keyring files) will be
-# created with 644 permissions. This ensures that keyrings and other files
-# created by this script are readable by installers on systems where the
-# umask is set to a more restrictive value.
-# See https://github.com/tailscale/tailscale/issues/15133
-umask 022
-
 # All the code is wrapped in a main function that gets called at the
 # bottom of the file, so that a truncated partial download doesn't end
 # up executing half a script.
@@ -501,10 +493,13 @@ main() {
 				legacy)
 					$CURL "https://pkgs.tailscale.com/$TRACK/$OS/$VERSION.asc" | $SUDO apt-key add -
 					$CURL "https://pkgs.tailscale.com/$TRACK/$OS/$VERSION.list" | $SUDO tee /etc/apt/sources.list.d/tailscale.list
+					$SUDO chmod 0644 /etc/apt/sources.list.d/tailscale.list
 				;;
 				keyring)
 					$CURL "https://pkgs.tailscale.com/$TRACK/$OS/$VERSION.noarmor.gpg" | $SUDO tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
+					$SUDO chmod 0644 /usr/share/keyrings/tailscale-archive-keyring.gpg
 					$CURL "https://pkgs.tailscale.com/$TRACK/$OS/$VERSION.tailscale-keyring.list" | $SUDO tee /etc/apt/sources.list.d/tailscale.list
+					$SUDO chmod 0644 /etc/apt/sources.list.d/tailscale.list
 				;;
 			esac
 			$SUDO apt-get update


### PR DESCRIPTION
The fix in https://github.com/tailscale/tailscale/pull/15139 for ensuring that downloaded files are readable by apt-get on systems with restricted umask was not really working - when we `curl <file> | sudo tee <path>` the umask set at the top of the install script is not inherited by `sudo`, so this was only working if the whole script was run with `sudo`, see https://github.com/tailscale/tailscale/issues/15133#issuecomment-2686551161

This instead chmods the files that I observed are otherwise created with `0640` permission when umask is `027`.

I think this time I've tested it properly:
```

$ umask
0027
$ sudo less /etc/sudoers | grep umask
Defaults umask=027
$ ./installer.sh  # installer script from this PR
Installing Tailscale for debian bookworm, using method apt
+ sudo mkdir -p --mode=0755 /usr/share/keyrings
+ curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.noarmor.gpg
+ sudo tee /usr/share/keyrings/tailscale-archive-keyring.gpg
+ sudo chmod 0644 /usr/share/keyrings/tailscale-archive-keyring.gpg
+ + sudo tee /etc/apt/sources.list.d/tailscale.list
curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.tailscale-keyring.list
# Tailscale packages for debian bookworm
deb [signed-by=/usr/share/keyrings/tailscale-archive-keyring.gpg] https://pkgs.tailscale.com/stable/debian bookworm main
+ sudo chmod 0644 /etc/apt/sources.list.d/tailscale.list
+ sudo apt-get update
...
Installation complete! Log in to start using Tailscale by running:

sudo tailscale up
```

Updates tailscale/tailscale#15133