### PR TITLE
ipn/store/kubestore: sanitize keys loaded to in-memory store

### DIFF
--- a/ipn/store/kubestore/store_kube_test.go
+++ b/ipn/store/kubestore/store_kube_test.go
@@ -169,7 +169,7 @@ func TestUpdateStateSecret(t *testing.T) {
 
 			// Verify memory store was updated
 			for k, v := range tt.updates {
-				got, err := s.memory.ReadState(ipn.StateKey(k))
+				got, err := s.memory.ReadState(ipn.StateKey(sanitizeKey(k)))
 				if err != nil {
 					t.Errorf("reading from memory store: %v", err)
 					continue


### PR DESCRIPTION
Reads use the sanitized form, so unsanitized keys being stored in memory resulted in lookup failures, for example for serve config, where the key in non-sanitized form is like `serve/xyz`, in sanitized form `serve_xyz`.

Updates tailscale/tailscale#15134