### PR TITLE
feature/capture: Fix dissector zero-division bug

### DIFF
--- a/feature/capture/dissector/ts-dissector.lua
+++ b/feature/capture/dissector/ts-dissector.lua
@@ -1,5 +1,5 @@
-function hasbit(x, p)
-  return x % (p + p) >= p       
+local function is_from_derp(x)
+  return x % 2 == 1
 end
 
 tsdebug_ll = Proto("tsdebug", "Tailscale debug")
@@ -75,7 +75,7 @@ function tsdisco_meta.dissector(buffer, pinfo, tree)
     local subtree = tree:add(tsdisco_meta, buffer(), "DISCO metadata")
 
     -- Parse flags
-    local from_derp = hasbit(buffer(offset, 1):le_uint(), 0)
+    local from_derp = is_from_derp(buffer(offset, 1):le_uint())
     subtree:add(DISCO_IS_DERP, from_derp) -- Flag bit 0
     offset = offset + 1
     -- Parse DERP public key


### PR DESCRIPTION
The first byte in DISCO metadata is used for flags. It has only one flag
and is set to `0x01` if the source address is the DERP magic adress. See
[`disco/pcap.go`](https://github.com/tailscale/tailscale/blob/986daca5eeeffa04bdb184d1ee13f70d04d33ff1/disco/pcap.go#L25-L28).

The dissector would fail to dissect DISCO frames with the error message
`Lua Error: [path/to]/.local/lib/wireshark/plugins/ts-dissector.lua:2: attempt to perform 'n%0'`.

Replaced the buggy `hasbit` function with a new `is_from_derp` function
to keep the implementation simple and readable.

Tested on macOS with Wireshark 4.4.0.

Fixes #15182
