### PR TITLE
safesocket: correct logic for determining if we're a macOS GUI client

### DIFF
--- a/safesocket/safesocket_darwin.go
+++ b/safesocket/safesocket_darwin.go
@@ -37,16 +37,16 @@ type safesocketDarwin struct {
 	sameuserproofFD *os.File // file descriptor for macos app store sameuserproof file
 	sharedDir       string   // shared directory for location of sameuserproof file
 
-	checkConn        bool        // Check macsys safesocket port before returning it
-	isMacSysExt      func() bool // For testing only to force macsys
-	isSandboxedMacos func() bool // For testing only to force macOS sandbox
+	checkConn   bool        // Check macsys safesocket port before returning it
+	isMacSysExt func() bool // For testing only to force macsys
+	isMacGUIApp func() bool // For testing only to force macOS sandbox
 }
 
 var ssd = safesocketDarwin{
-	isMacSysExt:      version.IsMacSysExt,
-	isSandboxedMacos: version.IsSandboxedMacOS,
-	checkConn:        true,
-	sharedDir:        "/Library/Tailscale",
+	isMacSysExt: version.IsMacSysExt,
+	isMacGUIApp: func() bool { return version.IsMacAppStore() || version.IsMacSysApp() },
+	checkConn:   true,
+	sharedDir:   "/Library/Tailscale",
 }
 
 // There are three ways a Darwin binary can be run: as the Mac App Store (macOS)
@@ -68,7 +68,7 @@ func localTCPPortAndTokenDarwin() (port int, token string, err error) {
 	ssd.mu.Lock()
 	defer ssd.mu.Unlock()
 
-	if !ssd.isSandboxedMacos() {
+	if !ssd.isMacGUIApp() {
 		return 0, "", ErrNoTokenOnOS
 	}
 

--- a/safesocket/safesocket_darwin_test.go
+++ b/safesocket/safesocket_darwin_test.go
@@ -17,7 +17,7 @@ import (
 func TestSetCredentials(t *testing.T) {
 	wantPort := 123
 	wantToken := "token"
-	tstest.Replace(t, &ssd.isSandboxedMacos, func() bool { return true })
+	tstest.Replace(t, &ssd.isMacGUIApp, func() bool { return true })
 	SetCredentials(wantToken, wantPort)
 
 	gotPort, gotToken, err := LocalTCPPortAndToken()
@@ -38,7 +38,7 @@ func TestSetCredentials(t *testing.T) {
 // returns a listener and a non-zero port and non-empty token.
 func TestInitListenerDarwin(t *testing.T) {
 	temp := t.TempDir()
-	tstest.Replace(t, &ssd.isSandboxedMacos, func() bool { return true })
+	tstest.Replace(t, &ssd.isMacGUIApp, func() bool { return true })
 
 	ln, err := InitListenerDarwin(temp)
 	if err != nil || ln == nil {


### PR DESCRIPTION
fixes tailscale/corp#26806

The fix for this was incorrect. We care only if the caller is the macSys or macOs app.  isSandBoxedMacOS doesn't give us the correct answer for macSys because technically, macsys isn't sandboxed anymore.

This is the correct logic:
version.IsMacAppStore() || version.IsMacSysApp()