### PR TITLE
hello: display native ipv4

### DIFF
--- a/cmd/hello/hello.go
+++ b/cmd/hello/hello.go
@@ -20,6 +20,7 @@ import (
 
 	"tailscale.com/client/local"
 	"tailscale.com/client/tailscale/apitype"
+	"tailscale.com/tailcfg"
 )
 
 var (
@@ -133,6 +134,10 @@ type tmplData struct {
 func tailscaleIP(who *apitype.WhoIsResponse) string {
 	if who == nil {
 		return ""
+	}
+	vals, err := tailcfg.UnmarshalNodeCapJSON[string](who.Node.CapMap, tailcfg.NodeAttrNativeIPV4)
+	if err == nil && len(vals) > 0 {
+		return vals[0]
 	}
 	for _, nodeIP := range who.Node.Addresses {
 		if nodeIP.Addr().Is4() && nodeIP.IsSingleIP() {

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -2440,6 +2440,11 @@ const (
 	// type float64 representing the duration in seconds. This cap will be
 	// omitted if the tailnet's MaxKeyDuration is the default.
 	NodeAttrMaxKeyDuration NodeCapability = "tailnet.maxKeyDuration"
+
+	// NodeAttrNativeIPV4 contains the IPV4 address of the node in its
+	// native tailnet. This is currently only sent to Hello, in its
+	// peer node list.
+	NodeAttrNativeIPV4 NodeCapability = "native-ipv4"
 )
 
 // SetDNSRequest is a request to add a DNS record.


### PR DESCRIPTION
We are soon going to start assinging shared-in nodes a CGNAT IPv4 in the Hello tailnet when necessary, the same way that normal node shares assign a new IPv4 on conflict.

But Hello wants to display the node's native IPv4, the one it uses in its own tailnet. That IPv4 isn't available anywhere in the netmap today, because it's not normally needed for anything.

We are going to start sending that native IPv4 in the peer node CapMap, only for Hello's netmap responses. This change enables Hello to display that native IPv4 instead, when available.

Updates https://github.com/tailscale/corp/issues/25393

Change-Id: I87480b6d318ab028b41ef149eb3ba618bd7f1e08
Signed-off-by: Brian Palmer <brianp@tailscale.com>