### PR TITLE
safesocket: add isMacSysExt Check

### DIFF
--- a/safesocket/safesocket_darwin.go
+++ b/safesocket/safesocket_darwin.go
@@ -44,7 +44,7 @@ type safesocketDarwin struct {
 
 var ssd = safesocketDarwin{
 	isMacSysExt: version.IsMacSysExt,
-	isMacGUIApp: func() bool { return version.IsMacAppStore() || version.IsMacSysApp() },
+	isMacGUIApp: func() bool { return version.IsMacAppStore() || version.IsMacSysApp() || version.IsMacSysExt() },
 	checkConn:   true,
 	sharedDir:   "/Library/Tailscale",
 }


### PR DESCRIPTION
fixes tailscale/corp#26806

IsMacSysApp is not returning the correct answer... It looks like the rest of the code base uses
isMacSysExt (when what they really want to know is isMacSysApp).   To fix the immediate issue (localAPI and 
the CLA are broken entirely in corp), we'll add this check to safesocket which matches other usages, despite
the confusing naming.