### PR TITLE
cmd/tsidp: add README and Dockerfile

### DIFF
--- a/cmd/tsidp/Dockerfile
+++ b/cmd/tsidp/Dockerfile
@@ -1,0 +1,41 @@
+# Build stage
+FROM golang:alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache git
+
+# Set working directory
+WORKDIR /src
+
+# Copy only go.mod and go.sum first to leverage Docker caching
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the entire repository
+COPY . .
+
+# Build the tsidp binary
+RUN go build -o /bin/tsidp ./cmd/tsidp
+
+# Final stage
+FROM alpine:latest
+
+# Create necessary directories
+RUN mkdir -p /var/lib/tsidp
+
+# Copy binary from builder stage
+COPY --from=builder /bin/tsidp /app/tsidp
+
+# Set working directory
+WORKDIR /app
+
+# Environment variables
+ENV TAILSCALE_USE_WIP_CODE=1 \
+    TS_HOSTNAME=tsidp \
+    TS_STATE_DIR=/var/lib/tsidp
+
+# Expose the default port
+EXPOSE 443
+
+# Run the application
+ENTRYPOINT ["/app/tsidp"]

--- a/cmd/tsidp/README.md
+++ b/cmd/tsidp/README.md
@@ -1,0 +1,100 @@
+# `tsidp` - Tailscale OpenID Connect (OIDC) Identity Provider
+
+[![status: experimental](https://img.shields.io/badge/status-experimental-blue)](https://tailscale.com/kb/1167/release-stages/#experimental)
+
+`tsidp` is an OIDC Identity Provider (IdP) server that integrates with your Tailscale network. It allows you to use Tailscale identities for authentication in applications that support OpenID Connect, enabling single sign-on (SSO) capabilities within your tailnet.
+
+## Prerequisites
+
+- A Tailscale network (tailnet) with magicDNS and HTTPS enabled
+- A Tailscale authentication key from your tailnet
+- Docker installed on your system
+
+## Installation using Docker
+
+1. **Build the Docker Image**
+
+   The Dockerfile uses a multi-stage build process to:
+   - Build the `tsidp` binary from source
+   - Create a minimal Alpine-based image with just the necessary components
+
+   ```bash
+   # Clone the Tailscale repository
+   git clone https://github.com/tailscale/tailscale.git
+   cd tailscale
+   ```
+
+   ```bash
+   # Build the Docker image
+   docker build -t tsidp:latest -f cmd/tsidp/Dockerfile .
+   ```
+
+2. **Run the Container**
+
+   Replace `YOUR_TAILSCALE_AUTHKEY` with your Tailscale authentication key.
+
+   ```bash
+   docker run -d \
+     --name `tsidp` \
+     -p 443:443 \
+     -e TS_AUTHKEY=YOUR_TAILSCALE_AUTHKEY \
+     -e TS_HOSTNAME=tsidp \
+     -v tsidp-data:/var/lib/tsidp \
+     tsidp:latest
+   ```
+
+3. **Verify Installation**
+   ```bash
+   docker logs tsidp
+   ```
+
+   Visit `https://tsidp.tailnet.ts.net` to confirm the service is running.
+
+## Usage Example: Proxmox Integration
+
+Here's how to configure Proxmox to use `tsidp` for authentication:
+
+1. In Proxmox, navigate to Datacenter > Realms > Add OpenID Connect Server
+
+2. Configure the following settings:
+   - Issuer URL: `https://idp.velociraptor.ts.net`
+   - Realm: `tailscale` (or your preferred name)
+   - Client ID: `unused`
+   - Client Key: `unused`
+   - Default: `true`
+   - Autocreate users: `true`
+   - Username claim: `email`
+
+3. Set up user permissions:
+   - Go to Datacenter > Permissions > Groups
+   - Create a new group (e.g., "tsadmins")
+   - Click Permissions in the sidebar
+   - Add Group Permission
+   - Set Path to `/` for full admin access or scope as needed
+   - Set the group and role
+   - Add Tailscale-authenticated users to the group
+
+## Configuration Options
+
+The `tsidp` server supports several command-line flags:
+
+- `--verbose`: Enable verbose logging
+- `--port`: Port to listen on (default: 443)
+- `--local-port`: Allow requests from localhost
+- `--use-local-tailscaled`: Use local tailscaled instead of tsnet
+- `--dir`: tsnet state directory
+
+## Environment Variables
+
+- `TS_AUTHKEY`: Your Tailscale authentication key (required)
+- `TS_HOSTNAME`: Hostname for the `tsidp` server (default: "idp")
+- `TS_STATE_DIR`: State directory (default: "/var/lib/tsidp")
+- `TAILSCALE_USE_WIP_CODE`: Enable work-in-progress code (default: "1")
+
+## Support
+
+This is an [experimental](https://tailscale.com/kb/1167/release-stages#experimental), work in progress feature. For issues or questions, file issues on the [GitHub repository](https://github.com/tailscale/tailscale)
+
+## License
+
+BSD-3-Clause License. See [LICENSE](../../LICENSE) for details.


### PR DESCRIPTION
Adds documentation in a README for the tsidp tool. ~Adds the setup script written by @IronicBadger.~ Adds a Dockerfile for deployment.

Updates #15204