### PR TITLE
cmd/derper, derp/derphttp: support, generate self-signed IP address certs

### DIFF
--- a/cmd/derper/cert.go
+++ b/cmd/derper/cert.go
@@ -4,16 +4,28 @@
 package main
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
+	"log"
+	"math/big"
 	"net"
 	"net/http"
+	"os"
 	"path/filepath"
 	"regexp"
+	"time"
 
 	"golang.org/x/crypto/acme/autocert"
+	"tailscale.com/tailcfg"
 )
 
 var unsafeHostnameCharacters = regexp.MustCompile(`[^a-zA-Z0-9-\.]`)
@@ -65,8 +77,18 @@ func NewManualCertManager(certdir, hostname string) (certProvider, error) {
 	crtPath := filepath.Join(certdir, keyname+".crt")
 	keyPath := filepath.Join(certdir, keyname+".key")
 	cert, err := tls.LoadX509KeyPair(crtPath, keyPath)
+	hostnameIP := net.ParseIP(hostname) // or nil if hostname isn't an IP address
 	if err != nil {
-		return nil, fmt.Errorf("can not load x509 key pair for hostname %q: %w", keyname, err)
+		// If the hostname is an IP address, automatically create a
+		// self-signed certificate for it.
+		var certp *tls.Certificate
+		if os.IsNotExist(err) && hostnameIP != nil {
+			certp, err = createSelfSignedIPCert(crtPath, keyPath, hostname)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("can not load x509 key pair for hostname %q: %w", keyname, err)
+		}
+		cert = *certp
 	}
 	// ensure hostname matches with the certificate
 	x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
@@ -75,6 +97,18 @@ func NewManualCertManager(certdir, hostname string) (certProvider, error) {
 	}
 	if err := x509Cert.VerifyHostname(hostname); err != nil {
 		return nil, fmt.Errorf("cert invalid for hostname %q: %w", hostname, err)
+	}
+	if hostnameIP != nil {
+		// If the hostname is an IP address, print out information on how to
+		// confgure this in the derpmap.
+		dn := &tailcfg.DERPNode{
+			Name:     "custom",
+			RegionID: 900,
+			HostName: hostname,
+			CertName: fmt.Sprintf("sha256-raw:%-02x", sha256.Sum256(x509Cert.Raw)),
+		}
+		dnJSON, _ := json.Marshal(dn)
+		log.Printf("Using self-signed certificate for IP address %q. Configure it in DERPMap using: (https://tailscale.com/s/custom-derp)\n  %s", hostname, dnJSON)
 	}
 	return &manualCertManager{
 		cert:       &cert,
@@ -108,4 +142,70 @@ func (m *manualCertManager) getCertificate(hi *tls.ClientHelloInfo) (*tls.Certif
 
 func (m *manualCertManager) HTTPHandler(fallback http.Handler) http.Handler {
 	return fallback
+}
+
+func createSelfSignedIPCert(crtPath, keyPath, ipStr string) (*tls.Certificate, error) {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return nil, fmt.Errorf("invalid IP address: %s", ipStr)
+	}
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate EC private key: %v", err)
+	}
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate serial number: %v", err)
+	}
+
+	now := time.Now()
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName: ipStr,
+		},
+		NotBefore: now,
+		NotAfter:  now.AddDate(1, 0, 0), // expires in 1 year; a bit over that is rejected by macOS etc
+
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	// Set the IP as a SAN.
+	template.IPAddresses = []net.IP{ip}
+
+	// Create the self-signed certificate.
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create certificate: %v", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+
+	keyBytes, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal EC private key: %v", err)
+	}
+
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes})
+
+	if err := os.MkdirAll(filepath.Dir(crtPath), 0700); err != nil {
+		return nil, fmt.Errorf("failed to create directory for certificate: %v", err)
+	}
+	if err := os.WriteFile(crtPath, certPEM, 0644); err != nil {
+		return nil, fmt.Errorf("failed to write certificate to %s: %v", crtPath, err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0600); err != nil {
+		return nil, fmt.Errorf("failed to write key to %s: %v", keyPath, err)
+	}
+
+	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tls.Certificate: %v", err)
+	}
+	return &tlsCert, nil
 }

--- a/derp/derphttp/derphttp_client.go
+++ b/derp/derphttp/derphttp_client.go
@@ -652,7 +652,11 @@ func (c *Client) tlsClient(nc net.Conn, node *tailcfg.DERPNode) *tls.Conn {
 			tlsConf.VerifyConnection = nil
 		}
 		if node.CertName != "" {
-			tlsdial.SetConfigExpectedCert(tlsConf, node.CertName)
+			if suf, ok := strings.CutPrefix(node.CertName, "sha256-raw:"); ok {
+				tlsdial.SetConfigExpectedCertHash(tlsConf, suf)
+			} else {
+				tlsdial.SetConfigExpectedCert(tlsConf, node.CertName)
+			}
 		}
 	}
 	return tls.Client(nc, tlsConf)
@@ -666,7 +670,7 @@ func (c *Client) tlsClient(nc net.Conn, node *tailcfg.DERPNode) *tls.Conn {
 func (c *Client) DialRegionTLS(ctx context.Context, reg *tailcfg.DERPRegion) (tlsConn *tls.Conn, connClose io.Closer, node *tailcfg.DERPNode, err error) {
 	tcpConn, node, err := c.dialRegion(ctx, reg)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, fmt.Errorf("dialRegion(%d): %w", reg.RegionID, err)
 	}
 	done := make(chan bool) // unbuffered
 	defer close(done)
@@ -741,6 +745,17 @@ func (c *Client) dialNode(ctx context.Context, n *tailcfg.DERPNode) (net.Conn, e
 
 	nwait := 0
 	startDial := func(dstPrimary, proto string) {
+		dst := cmp.Or(dstPrimary, n.HostName)
+
+		// If dialing an IP address directly, check its address family
+		// and bail out before incrementing nwait.
+		if ip, err := netip.ParseAddr(dst); err == nil {
+			if proto == "tcp4" && ip.Is6() ||
+				proto == "tcp6" && ip.Is4() {
+				return
+			}
+		}
+
 		nwait++
 		go func() {
 			if proto == "tcp4" && c.preferIPv6() {
@@ -755,7 +770,6 @@ func (c *Client) dialNode(ctx context.Context, n *tailcfg.DERPNode) (net.Conn, e
 					// Start v4 dial
 				}
 			}
-			dst := cmp.Or(dstPrimary, n.HostName)
 			port := "443"
 			if !c.useHTTPS() {
 				port = "3340"

--- a/tailcfg/derpmap.go
+++ b/tailcfg/derpmap.go
@@ -139,6 +139,12 @@ type DERPNode struct {
 	// name. If empty, HostName is used. If CertName is non-empty,
 	// HostName is only used for the TCP dial (if IPv4/IPv6 are
 	// not present) + TLS ClientHello.
+	//
+	// As a special case, if CertName starts with "sha256-raw:",
+	// then the rest of the string is a hex-encoded SHA256 of the
+	// cert to expect. This is used for self-signed certs.
+	// In this case, the HostName field will typically be an IP
+	// address literal.
 	CertName string `json:",omitempty"`
 
 	// IPv4 optionally forces an IPv4 address to use, instead of using DNS.


### PR DESCRIPTION
For people who can't use LetsEncrypt because it's banned.

Per https://github.com/tailscale/tailscale/issues/11776#issuecomment-2520955317

This does two things:

1) if you run derper with --certmode=manual and --hostname=$IP_ADDRESS
   we previously permitted, but now we also:
   * auto-generate the self-signed cert for you if it doesn't yet exist on disk
   * print out the derpmap configuration you need to use that
     self-signed cert

2) teaches derp/derphttp's derp dialer to verify the signature of
   self-signed TLS certs, if so declared in the existing
   DERPNode.CertName field, which previously existed for domain fronting,
   separating out the dial hostname from how certs are validates,
   so it's not overloaded much; that's what it was meant for.

Fixes #11776
