### PR TITLE
.github/workflows: descope natlab CI for now until GitHub flakes are fixed

### DIFF
--- a/.github/workflows/natlab-integrationtest.yml
+++ b/.github/workflows/natlab-integrationtest.yml
@@ -9,10 +9,7 @@ concurrency:
 on:
   pull_request:
     paths:
-      - "tailcfg/**"
-      - "wgengine/**"
-      - "ipn/ipnlocal/**"
-      - ".github/workflows/natlab-integrationtest.yml"
+      - "tstest/integration/nat/nat_test.go"
 jobs:
   natlab-integrationtest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The natlab VM tests are flaking on GitHub Actions.

To not distract people, disable them for now (unless they're touched
directly) until they're made more reliable, which will be some painful
debugging probably.

Updates #13038
