### PR TITLE
util/eventbus: initial plumbing for introspection hooks

### DIFF
--- a/util/eventbus/client.go
+++ b/util/eventbus/client.go
@@ -17,8 +17,9 @@ import (
 // Subscribers that share the same client receive events one at a
 // time, in the order they were published.
 type Client struct {
-	name string
-	bus  *Bus
+	name         string
+	bus          *Bus
+	publishDebug hook[publishedEvent]
 
 	mu  sync.Mutex
 	pub set.Set[publisher]

--- a/util/eventbus/debug.go
+++ b/util/eventbus/debug.go
@@ -1,0 +1,62 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package eventbus
+
+import (
+	"slices"
+	"sync"
+	"sync/atomic"
+)
+
+// A hook collects hook functions that can be run as a group.
+type hook[T any] struct {
+	sync.Mutex
+	fns []hookFn[T]
+}
+
+var hookID atomic.Uint64
+
+// add registers fn to be called when the hook is run. Returns an
+// unregistration function that removes fn from the hook when called.
+//
+//lint:ignore U1000 Not used yet, but will be in an upcoming change
+func (h *hook[T]) add(fn func(T)) (remove func()) {
+	id := hookID.Add(1)
+	h.Lock()
+	defer h.Unlock()
+	h.fns = append(h.fns, hookFn[T]{id, fn})
+	return func() { h.remove(id) }
+}
+
+// remove removes the function with the given ID from the hook.
+//
+//lint:ignore U1000 Not used yet, but will be in an upcoming change
+func (h *hook[T]) remove(id uint64) {
+	h.Lock()
+	defer h.Unlock()
+	h.fns = slices.DeleteFunc(h.fns, func(f hookFn[T]) bool { return f.ID == id })
+}
+
+// active reports whether any functions are registered with the
+// hook. This can be used to skip expensive work when the hook is
+// inactive.
+func (h *hook[T]) active() bool {
+	h.Lock()
+	defer h.Unlock()
+	return len(h.fns) > 0
+}
+
+// run calls all registered functions with the value v.
+func (h *hook[T]) run(v T) {
+	h.Lock()
+	defer h.Unlock()
+	for _, fn := range h.fns {
+		fn.Fn(v)
+	}
+}
+
+type hookFn[T any] struct {
+	ID uint64
+	Fn func(T)
+}

--- a/util/eventbus/publish.go
+++ b/util/eventbus/publish.go
@@ -5,14 +5,7 @@ package eventbus
 
 import (
 	"reflect"
-	"time"
 )
-
-type publishedEvent struct {
-	Event     any
-	From      *Client
-	Published time.Time
-}
 
 // publisher is a uniformly typed wrapper around Publisher[T], so that
 // debugging facilities can look at active publishers.
@@ -60,9 +53,8 @@ func (p *Publisher[T]) Publish(v T) {
 	}
 
 	evt := publishedEvent{
-		Event:     v,
-		From:      p.client,
-		Published: time.Now(),
+		Event: v,
+		From:  p.client,
 	}
 
 	select {


### PR DESCRIPTION
Updates #15160 

---

This is just the internal machinery, with no exported interfaces yet. I added hooks at 3 points: in each publisher right before it tries to enqueue (i.e. the earliest possible point to observe an event), in the router after it's looked up subscribers but before it distributes the event to them (where an observer sees things in the global linear order, and can see the 1:N fanout to subscribers), and in subscribers right after an event has been delivered (where you can see e2e delivery latency, and total order as perceived by that one subscriber).

I'm honestly unsure if all these hook points have value, or if we'll end up retooling towards something more like trace spans once we've build out the debug facilities. But, this is a simple and straightforward place to start.