### PR TITLE
cmd/tsidp: allow CORS requests to openid-configuration

### DIFF
--- a/cmd/tsidp/tsidp.go
+++ b/cmd/tsidp/tsidp.go
@@ -765,6 +765,18 @@ var (
 )
 
 func (s *idpServer) serveOpenIDConfig(w http.ResponseWriter, r *http.Request) {
+	h := w.Header()
+	h.Set("Access-Control-Allow-Origin", "*")
+	h.Set("Access-Control-Allow-Method", "GET, OPTIONS")
+	// allow all to prevent errors from client sending their own bespoke headers
+	// and having the server reject the request.
+	h.Set("Access-Control-Allow-Headers", "*")
+
+	// early return for pre-flight OPTIONS requests.
+	if r.Method == "OPTIONS" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
 	if r.URL.Path != oidcConfigPath {
 		http.Error(w, "tsidp: not found", http.StatusNotFound)
 		return


### PR DESCRIPTION
Add support for Cross-Origin XHR requests to the openid-configuration
endpoint to enable integrations like Grafana whose web UI auto-populates 
the OIDC setup data from its contents.

Updates https://github.com/tailscale/tailscale/issues/10263

Signed-off-by: Patrick O'Doherty <patrick@tailscale.com>