### PR TITLE
util/eventbus: don't allow publishers to skip events while debugging

### DIFF
--- a/util/eventbus/bus.go
+++ b/util/eventbus/bus.go
@@ -173,6 +173,10 @@ func (b *Bus) dest(t reflect.Type) []*subscribeState {
 }
 
 func (b *Bus) shouldPublish(t reflect.Type) bool {
+	if b.routeDebug.active() {
+		return true
+	}
+
 	b.topicsMu.Lock()
 	defer b.topicsMu.Unlock()
 	return len(b.topics[t]) > 0

--- a/util/eventbus/client.go
+++ b/util/eventbus/client.go
@@ -93,7 +93,7 @@ func (c *Client) publish() chan<- PublishedEvent {
 }
 
 func (c *Client) shouldPublish(t reflect.Type) bool {
-	return c.bus.shouldPublish(t)
+	return c.publishDebug.active() || c.bus.shouldPublish(t)
 }
 
 // Subscribe requests delivery of events of type T through the given


### PR DESCRIPTION
If any debugging hook might see an event, Publisher.ShouldPublish should tell its caller to publish even if there are no ordinary subscribers.

Updates #15160