### PR TITLE
util/eventbus: add debugger methods to list pub/sub types

### DIFF
--- a/util/eventbus/client.go
+++ b/util/eventbus/client.go
@@ -59,6 +59,20 @@ func (c *Client) peekSubscribeState() *subscribeState {
 	return c.sub
 }
 
+func (c *Client) publishTypes() []reflect.Type {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ret := make([]reflect.Type, 0, len(c.pub))
+	for pub := range c.pub {
+		ret = append(ret, pub.publishType())
+	}
+	return ret
+}
+
+func (c *Client) subscribeTypes() []reflect.Type {
+	return c.peekSubscribeState().subscribeTypes()
+}
+
 func (c *Client) subscribeState() *subscribeState {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/util/eventbus/debug.go
+++ b/util/eventbus/debug.go
@@ -5,6 +5,7 @@ package eventbus
 
 import (
 	"fmt"
+	"reflect"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -106,6 +107,27 @@ func (d *Debugger) WatchPublish(client *Client) *Subscriber[PublishedEvent] {
 func (d *Debugger) WatchSubscribe(client *Client) *Subscriber[DeliveredEvent] {
 	d.checkClient(client)
 	return newMonitor(client.subscribeState().debug.add)
+}
+
+// PublishTypes returns the list of types being published by client.
+//
+// The returned types are those for which the client has obtained a
+// [Publisher]. The client may not have ever sent the type in
+// question.
+func (d *Debugger) PublishTypes(client *Client) []reflect.Type {
+	d.checkClient(client)
+	return client.publishTypes()
+}
+
+// SubscribeTypes returns the list of types being subscribed to by
+// client.
+//
+// The returned types are those for which the client has obtained a
+// [Subscriber]. The client may not have ever received the type in
+// question, and here may not be any publishers of the type.
+func (d *Debugger) SubscribeTypes(client *Client) []reflect.Type {
+	d.checkClient(client)
+	return client.subscribeTypes()
 }
 
 // A hook collects hook functions that can be run as a group.

--- a/util/eventbus/subscribe.go
+++ b/util/eventbus/subscribe.go
@@ -120,6 +120,20 @@ func (s *subscribeState) snapshotQueue() []DeliveredEvent {
 	}
 }
 
+func (s *subscribeState) subscribeTypes() []reflect.Type {
+	if s == nil {
+		return nil
+	}
+
+	s.outputsMu.Lock()
+	defer s.outputsMu.Unlock()
+	ret := make([]reflect.Type, 0, len(s.outputs))
+	for t := range s.outputs {
+		ret = append(ret, t)
+	}
+	return ret
+}
+
 func (s *subscribeState) addSubscriber(t reflect.Type, sub subscriber) {
 	s.outputsMu.Lock()
 	defer s.outputsMu.Unlock()


### PR DESCRIPTION
This lets debug tools list the types that clients are wielding, so that they can build a dataflow graph and other debugging views.

Updates #15160