### PR TITLE
resolver: always use UserDial for DNS TCP fallback to fix routing for Tailscale IPs

### DIFF
--- a/net/dns/resolver/forwarder.go
+++ b/net/dns/resolver/forwarder.go
@@ -753,7 +753,7 @@ func (f *forwarder) getDialerType() dnscache.DialContextFunc {
 		// See https://github.com/tailscale/tailscale/issues/12027.
 		return f.dialer.UserDial
 	}
-	return f.dialer.SystemDial
+	return f.dialer.UserDial
 }
 
 func (f *forwarder) sendTCP(ctx context.Context, fq *forwardQuery, rr resolverAndDelay) (ret []byte, err error) {


### PR DESCRIPTION
This fixes a bug where TCP fallback for DNS queries fails when using Tailscale IP addresses (100.x.x.x) as DNS servers. The issue occurs because SystemDial is used for TCP connections, which routes traffic over the physical interface instead of the Tailscale interface.

By always using UserDial for DNS resolution, we ensure that connections to Tailscale IPs properly use Tailscale routes while still correctly handling external DNS servers.

Fixes issue #14854