### PR TITLE
control/controlclient, ipn: remove auditLog dependency from tsd

### DIFF
--- a/ipn/backend.go
+++ b/ipn/backend.go
@@ -257,4 +257,8 @@ type Options struct {
 	// AuthKey is an optional node auth key used to authorize a
 	// new node key without user interaction.
 	AuthKey string
+	// LogStore provides optional persistent storage for audit logs.  If nil, or not an
+	// [auditlog.LogStore], in memory storage will be used if the backend
+	// supports audit logging.
+	LogStore interface{}
 }

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -2404,11 +2404,9 @@ func (b *LocalBackend) Start(opts ipn.Options) error {
 	}
 
 	var auditLogShutdown func()
-	// Audit logging is only available if the client has set up a proper persistent
-	// store for the logs in sys.
-	store, ok := b.sys.AuditLogStore.GetOK()
+	store, ok := opts.LogStore.(auditlog.LogStore)
 	if !ok {
-		b.logf("auditlog: [unexpected] no persistent audit log storage configured.  using memory store.")
+		b.logf("auditlog: no persistent audit log storage configured.  using memory store.")
 		store = auditlog.NewLogStore(&memstore.Store{})
 	}
 

--- a/tsd/tsd.go
+++ b/tsd/tsd.go
@@ -25,7 +25,6 @@ import (
 	"tailscale.com/drive"
 	"tailscale.com/health"
 	"tailscale.com/ipn"
-	"tailscale.com/ipn/auditlog"
 	"tailscale.com/ipn/conffile"
 	"tailscale.com/ipn/desktop"
 	"tailscale.com/net/dns"
@@ -51,7 +50,6 @@ type System struct {
 	Router         SubSystem[router.Router]
 	Tun            SubSystem[*tstun.Wrapper]
 	StateStore     SubSystem[ipn.StateStore]
-	AuditLogStore  SubSystem[auditlog.LogStore]
 	Netstack       SubSystem[NetstackImpl] // actually a *netstack.Impl
 	DriveForLocal  SubSystem[drive.FileSystemForLocal]
 	DriveForRemote SubSystem[drive.FileSystemForRemote]
@@ -108,8 +106,6 @@ func (s *System) Set(v any) {
 		s.MagicSock.Set(v)
 	case ipn.StateStore:
 		s.StateStore.Set(v)
-	case auditlog.LogStore:
-		s.AuditLogStore.Set(v)
 	case NetstackImpl:
 		s.Netstack.Set(v)
 	case drive.FileSystemForLocal:


### PR DESCRIPTION
updates tailscale/corp#26435

Removes the auditLog depndency from tsd, and moves it to localBackend where it can simply be injected via the opts during localBackend.Start()