### PR TITLE
util/eventbus: remove debug UI from iOS build

### DIFF
--- a/util/eventbus/debughttp.go
+++ b/util/eventbus/debughttp.go
@@ -1,6 +1,8 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
+//go:build !ios
+
 package eventbus
 
 import (

--- a/util/eventbus/debughttp_ios.go
+++ b/util/eventbus/debughttp_ios.go
@@ -1,0 +1,18 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build ios
+
+package eventbus
+
+import "tailscale.com/tsweb"
+
+func registerHTTPDebugger(d *Debugger, td *tsweb.DebugHandler) {
+	// The event bus debugging UI uses html/template, which uses
+	// reflection for method lookups. This forces the compiler to
+	// retain a lot more code and information to make dynamic method
+	// dispatch work, which is unacceptable bloat for the iOS build.
+	//
+	// TODO: https://github.com/tailscale/tailscale/issues/15297 to
+	// bring the debug UI back to iOS somehow.
+}


### PR DESCRIPTION
The use of html/template causes reflect-based linker bloat. Longer term we have options to bring the UI back to iOS, but for now, cut it out.

Updates #15297 

---

First step of getting eventbus wired into tailscaled without the dependency sadness happening.