### PR TITLE
scripts/installer.sh: fix DNF 5 detection on all locales

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -521,7 +521,7 @@ main() {
 		dnf)
 			# DNF 5 has a different argument format; determine which one we have.
 			DNF_VERSION="3"
-			if dnf --version | grep -q '^dnf5 version'; then
+			if LANG=C.UTF-8 dnf --version | grep -q '^dnf5 version'; then
 				DNF_VERSION="5"
 			fi
 


### PR DESCRIPTION
When the install script is run on a system with DNF as package manager, first it detects if is using version 3 or 5.
The form of detecting version 5 only works if command `dnf --version` returns exactly `dnf5  version`. This can change with locales that are not C or english based.

For example, on my Nobara install, I'm running with locale `LANG=es_ES.utf8`, and `dnf --version` returns this:
```bash
$ dnf --version
dnf5 versión 5.2.10.0
dnf5 versión de API de plugin 2.0
libdnf5 versión 5.2.10.0
versión de API de plugin de libdnf5 2.1
```

With that in mind, `$DNF_VERSION` is incorrectly set at 3:
```bash
$ DNF_VERSION="3"

$ if dnf --version | grep -q '^dnf5 version'; then
          DNF_VERSION="5"
  fi

$ echo $DNF_VERSION
3
```

In order to fix it, we can run `dnf --version` with `LANG=C-UTF.8` to ensure that the output is not changed by user's locale:
```bash
$ LANG=C.UTF-8 dnf --version
dnf5 version 5.2.10.0
dnf5 plugin API version 2.0
libdnf5 version 5.2.10.0
libdnf5 plugin API version 2.1
```

```bash
$ DNF_VERSION="3"

$ if LANG=C.UTF-8 dnf --version | grep -q '^dnf5 version'; then
          DNF_VERSION="5"
  fi

$ echo $DNF_VERSION
5
```