### PR TITLE
control/controlhttp: Change method of WebSocket Upgrade request to GET

### DIFF
--- a/control/controlhttp/client.go
+++ b/control/controlhttp/client.go
@@ -569,7 +569,7 @@ func (a *Dialer) tryURLUpgrade(ctx context.Context, u *url.URL, optAddr netip.Ad
 	}
 	ctx = httptrace.WithClientTrace(ctx, &trace)
 	req := &http.Request{
-		Method: "POST",
+		Method: "GET",
 		URL:    u,
 		Header: http.Header{
 			"Upgrade":                             []string{controlhttpcommon.UpgradeHeaderValue},


### PR DESCRIPTION
Change method of WebSocket HTTP Upgrade request to GET so that it become compliant with RFC6455.

https://www.rfc-editor.org/rfc/rfc6455#section-4.1

> 
> Once a connection to the server has been established (including a
>    connection via a proxy or over a TLS-encrypted tunnel), the client
>    MUST send an opening handshake to the server.  The handshake consists
>    of an HTTP Upgrade request, along with a list of required and
>    optional header fields.  The requirements for this handshake are as
>    follows.
> 
>    2.   **The method of the request MUST be GET**, and the HTTP version MUST
>         be at least 1.1.