### PR TITLE
ipn: ensure that conffile is source of truth for advertised services.

### DIFF
--- a/ipn/conf.go
+++ b/ipn/conf.go
@@ -145,9 +145,15 @@ func (c *ConfigVAlpha) ToPrefs() (MaskedPrefs, error) {
 		mp.AppConnector = *c.AppConnector
 		mp.AppConnectorSet = true
 	}
+	// Configfile should be the source of truth for whether this node
+	// advertises any services.  We need to ensure that each reload updates
+	// currently advertised services as else the transition from 'some
+	// services are advertised' to 'advertised services are empty/unset in
+	// conffile' would have no effect (especially given that an empty
+	// service slice would be omitted from the JSON config).
+	mp.AdvertiseServicesSet = true
 	if c.AdvertiseServices != nil {
 		mp.AdvertiseServices = c.AdvertiseServices
-		mp.AdvertiseServicesSet = true
 	}
 	return mp, nil
 }


### PR DESCRIPTION
If conffile is used to configure tailscaled, always update currently advertised services from conffile, even if they are empty in the conffile, to ensure that it is possible to transition to a state where no services are advertised.

Updates tailscale/corp#24795