### PR TITLE
ipn/ipnlocal: do not attempt to start the auditlogger with a nil transport

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -5918,6 +5918,9 @@ func (b *LocalBackend) requestEngineStatusAndWait() {
 	b.logf("requestEngineStatusAndWait: got status update.")
 }
 
+// [controlclient.Auto] implements [auditlog.Transport].
+var _ auditlog.Transport = (*controlclient.Auto)(nil)
+
 // setControlClientLocked sets the control client to cc,
 // which may be nil.
 //
@@ -5925,12 +5928,12 @@ func (b *LocalBackend) requestEngineStatusAndWait() {
 func (b *LocalBackend) setControlClientLocked(cc controlclient.Client) {
 	b.cc = cc
 	b.ccAuto, _ = cc.(*controlclient.Auto)
-	if b.auditLogger != nil {
+	if t, ok := b.cc.(auditlog.Transport); ok && b.auditLogger != nil {
 		if err := b.auditLogger.SetProfileID(b.pm.CurrentProfile().ID()); err != nil {
 			b.logf("audit logger set profile ID failure: %v", err)
 		}
 
-		if err := b.auditLogger.Start(b.ccAuto); err != nil {
+		if err := b.auditLogger.Start(t); err != nil {
 			b.logf("audit logger start failure: %v", err)
 		}
 	}


### PR DESCRIPTION
`(*LocalBackend).setControlClientLocked()` is called to both set and reset `b.cc`. We shouldn't attempt to start the audit logger when `b.cc` is being reset (i.e., `cc` is `nil`).

However, it's fine to start the audit logger if `b.cc` implements `auditlog.Transport`, even if it's not a `controlclient.Auto` but a mock control client.

In this PR, we fix both issues and add an assertion that `*controlclient.Auto` is an `auditlog.Transport`. This ensures a compile-time failure if `*controlclient.Auto` ever stops being a valid transport due to future interface or implementation changes.

Updates tailscale/corp#26435