### PR TITLE
net/portmapper: fire an event when a port mapping is updated

### DIFF
--- a/net/portmapper/portmapper.go
+++ b/net/portmapper/portmapper.go
@@ -518,7 +518,7 @@ func (c *Client) createMapping() {
 	}
 }
 
-// MappingEvent is an event recording the allocation of a port mapping.
+// Mapping is an event recording the allocation of a port mapping.
 type Mapping struct {
 	External  netip.AddrPort
 	Type      string

--- a/net/portmapper/portmapper.go
+++ b/net/portmapper/portmapper.go
@@ -85,7 +85,7 @@ const trustServiceStillAvailableDuration = 10 * time.Minute
 
 // Client is a port mapping client.
 type Client struct {
-	eventBus     *eventbus.Bus
+	updates      *eventbus.Publisher[Mapping]
 	logf         logger.Logf
 	netMon       *netmon.Monitor // optional; nil means interfaces will be looked up on-demand
 	controlKnobs *controlknobs.Knobs
@@ -238,12 +238,14 @@ func NewClient(c Config) *Client {
 		panic("nil netMon")
 	}
 	ret := &Client{
-		eventBus:     c.EventBus,
 		logf:         c.Logf,
 		netMon:       c.NetMon,
 		ipAndGateway: netmon.LikelyHomeRouterIP, // TODO(bradfitz): move this to method on netMon
 		onChange:     c.OnChange,
 		controlKnobs: c.ControlKnobs,
+	}
+	if c.EventBus != nil {
+		ret.updates = eventbus.Publish[Mapping](c.EventBus.Client("portmapper"))
 	}
 	if ret.logf == nil {
 		ret.logf = logger.Discard
@@ -279,6 +281,9 @@ func (c *Client) Close() error {
 	}
 	c.closed = true
 	c.invalidateMappingsLocked(true)
+	if c.updates != nil {
+		c.updates.Close()
+	}
 	// TODO: close some future ever-listening UDP socket(s),
 	// waiting for multicast announcements from router.
 	return nil
@@ -490,11 +495,30 @@ func (c *Client) createMapping() {
 		c.runningCreate = false
 	}()
 
-	if _, err := c.createOrGetMapping(ctx); err == nil && c.onChange != nil {
-		go c.onChange()
-	} else if err != nil && !IsNoMappingError(err) {
-		c.logf("createOrGetMapping: %v", err)
+	mapping, _, err := c.createOrGetMapping(ctx)
+	if err != nil {
+		if !IsNoMappingError(err) {
+			c.logf("createOrGetMapping: %v", err)
+		}
+		return
 	}
+	c.updates.Publish(Mapping{
+		External:  mapping.External(),
+		Type:      mapping.MappingType(),
+		GoodUntil: mapping.GoodUntil(),
+	})
+	if c.onChange != nil {
+		go c.onChange()
+	}
+}
+
+// MappingEvent is an event recording the allocation of a port mapping.
+type Mapping struct {
+	External  netip.AddrPort
+	Type      string
+	GoodUntil time.Time
+
+	// TODO(creachadair): Record whether we reused an existing mapping?
 }
 
 // wildcardIP is used when the previous external IP is not known for PCP port mapping.
@@ -505,19 +529,19 @@ var wildcardIP = netip.MustParseAddr("0.0.0.0")
 //
 // If no mapping is available, the error will be of type
 // NoMappingError; see IsNoMappingError.
-func (c *Client) createOrGetMapping(ctx context.Context) (external netip.AddrPort, err error) {
+func (c *Client) createOrGetMapping(ctx context.Context) (mapping mapping, external netip.AddrPort, err error) {
 	if c.debug.disableAll() {
-		return netip.AddrPort{}, NoMappingError{ErrPortMappingDisabled}
+		return nil, netip.AddrPort{}, NoMappingError{ErrPortMappingDisabled}
 	}
 	if c.debug.DisableUPnP && c.debug.DisablePCP && c.debug.DisablePMP {
-		return netip.AddrPort{}, NoMappingError{ErrNoPortMappingServices}
+		return nil, netip.AddrPort{}, NoMappingError{ErrNoPortMappingServices}
 	}
 	gw, myIP, ok := c.gatewayAndSelfIP()
 	if !ok {
-		return netip.AddrPort{}, NoMappingError{ErrGatewayRange}
+		return nil, netip.AddrPort{}, NoMappingError{ErrGatewayRange}
 	}
 	if gw.Is6() {
-		return netip.AddrPort{}, NoMappingError{ErrGatewayIPv6}
+		return nil, netip.AddrPort{}, NoMappingError{ErrGatewayIPv6}
 	}
 
 	now := time.Now()
@@ -546,6 +570,17 @@ func (c *Client) createOrGetMapping(ctx context.Context) (external netip.AddrPor
 			return
 		}
 
+		// TODO(creachadair): This is more subtle than it should be. Ideally we
+		// would just return the mapping directly, but there are many different
+		// paths through the function with carefully-balanced locks, and not all
+		// the paths have a mapping to return. As a workaround, while we're here
+		// doing cleanup under the lock, grab the final mapping value and return
+		// it, so the caller does not need to grab the lock again and potentially
+		// race with a later update. The mapping itself is concurrency-safe.
+		//
+		// We should restructure this code so the locks are properly scoped.
+		mapping = c.mapping
+
 		// Print the internal details of each mapping if we're being verbose.
 		if c.debug.VerboseLogs {
 			c.logf("successfully obtained mapping: now=%d external=%v type=%s mapping=%s",
@@ -571,7 +606,7 @@ func (c *Client) createOrGetMapping(ctx context.Context) (external netip.AddrPor
 		if now.Before(m.RenewAfter()) {
 			defer c.mu.Unlock()
 			reusedExisting = true
-			return m.External(), nil
+			return nil, m.External(), nil
 		}
 		// The mapping might still be valid, so just try to renew it.
 		prevPort = m.External().Port()
@@ -580,10 +615,10 @@ func (c *Client) createOrGetMapping(ctx context.Context) (external netip.AddrPor
 	if c.debug.DisablePCP && c.debug.DisablePMP {
 		c.mu.Unlock()
 		if external, ok := c.getUPnPPortMapping(ctx, gw, internalAddr, prevPort); ok {
-			return external, nil
+			return nil, external, nil
 		}
 		c.vlogf("fallback to UPnP due to PCP and PMP being disabled failed")
-		return netip.AddrPort{}, NoMappingError{ErrNoPortMappingServices}
+		return nil, netip.AddrPort{}, NoMappingError{ErrNoPortMappingServices}
 	}
 
 	// If we just did a Probe (e.g. via netchecker) but didn't
@@ -610,16 +645,16 @@ func (c *Client) createOrGetMapping(ctx context.Context) (external netip.AddrPor
 		c.mu.Unlock()
 		// fallback to UPnP portmapping
 		if external, ok := c.getUPnPPortMapping(ctx, gw, internalAddr, prevPort); ok {
-			return external, nil
+			return nil, external, nil
 		}
 		c.vlogf("fallback to UPnP due to no PCP and PMP failed")
-		return netip.AddrPort{}, NoMappingError{ErrNoPortMappingServices}
+		return nil, netip.AddrPort{}, NoMappingError{ErrNoPortMappingServices}
 	}
 	c.mu.Unlock()
 
 	uc, err := c.listenPacket(ctx, "udp4", ":0")
 	if err != nil {
-		return netip.AddrPort{}, err
+		return nil, netip.AddrPort{}, err
 	}
 	defer uc.Close()
 
@@ -639,7 +674,7 @@ func (c *Client) createOrGetMapping(ctx context.Context) (external netip.AddrPor
 			if neterror.TreatAsLostUDP(err) {
 				err = NoMappingError{ErrNoPortMappingServices}
 			}
-			return netip.AddrPort{}, err
+			return nil, netip.AddrPort{}, err
 		}
 	} else {
 		// Ask for our external address if needed.
@@ -648,7 +683,7 @@ func (c *Client) createOrGetMapping(ctx context.Context) (external netip.AddrPor
 				if neterror.TreatAsLostUDP(err) {
 					err = NoMappingError{ErrNoPortMappingServices}
 				}
-				return netip.AddrPort{}, err
+				return nil, netip.AddrPort{}, err
 			}
 		}
 
@@ -657,7 +692,7 @@ func (c *Client) createOrGetMapping(ctx context.Context) (external netip.AddrPor
 			if neterror.TreatAsLostUDP(err) {
 				err = NoMappingError{ErrNoPortMappingServices}
 			}
-			return netip.AddrPort{}, err
+			return nil, netip.AddrPort{}, err
 		}
 	}
 
@@ -666,13 +701,13 @@ func (c *Client) createOrGetMapping(ctx context.Context) (external netip.AddrPor
 		n, src, err := uc.ReadFromUDPAddrPort(res)
 		if err != nil {
 			if ctx.Err() == context.Canceled {
-				return netip.AddrPort{}, err
+				return nil, netip.AddrPort{}, err
 			}
 			// fallback to UPnP portmapping
 			if mapping, ok := c.getUPnPPortMapping(ctx, gw, internalAddr, prevPort); ok {
-				return mapping, nil
+				return nil, mapping, nil
 			}
-			return netip.AddrPort{}, NoMappingError{ErrNoPortMappingServices}
+			return nil, netip.AddrPort{}, NoMappingError{ErrNoPortMappingServices}
 		}
 		src = netaddr.Unmap(src)
 		if !src.IsValid() {
@@ -688,7 +723,7 @@ func (c *Client) createOrGetMapping(ctx context.Context) (external netip.AddrPor
 					continue
 				}
 				if pres.ResultCode != 0 {
-					return netip.AddrPort{}, NoMappingError{fmt.Errorf("PMP response Op=0x%x,Res=0x%x", pres.OpCode, pres.ResultCode)}
+					return nil, netip.AddrPort{}, NoMappingError{fmt.Errorf("PMP response Op=0x%x,Res=0x%x", pres.OpCode, pres.ResultCode)}
 				}
 				if pres.OpCode == pmpOpReply|pmpOpMapPublicAddr {
 					m.external = netip.AddrPortFrom(pres.PublicAddr, m.external.Port())
@@ -706,7 +741,7 @@ func (c *Client) createOrGetMapping(ctx context.Context) (external netip.AddrPor
 				if err != nil {
 					c.logf("failed to get PCP mapping: %v", err)
 					// PCP should only have a single packet response
-					return netip.AddrPort{}, NoMappingError{ErrNoPortMappingServices}
+					return nil, netip.AddrPort{}, NoMappingError{ErrNoPortMappingServices}
 				}
 				pcpMapping.c = c
 				pcpMapping.internal = m.internal
@@ -714,10 +749,10 @@ func (c *Client) createOrGetMapping(ctx context.Context) (external netip.AddrPor
 				c.mu.Lock()
 				defer c.mu.Unlock()
 				c.mapping = pcpMapping
-				return pcpMapping.external, nil
+				return pcpMapping, pcpMapping.external, nil
 			default:
 				c.logf("unknown PMP/PCP version number: %d %v", version, res[:n])
-				return netip.AddrPort{}, NoMappingError{ErrNoPortMappingServices}
+				return nil, netip.AddrPort{}, NoMappingError{ErrNoPortMappingServices}
 			}
 		}
 
@@ -725,7 +760,7 @@ func (c *Client) createOrGetMapping(ctx context.Context) (external netip.AddrPor
 			c.mu.Lock()
 			defer c.mu.Unlock()
 			c.mapping = m
-			return m.external, nil
+			return nil, m.external, nil
 		}
 	}
 }

--- a/net/portmapper/select_test.go
+++ b/net/portmapper/select_test.go
@@ -163,9 +163,8 @@ func TestSelectBestService(t *testing.T) {
 				Desc:    rootDesc,
 				Control: tt.control,
 			})
-			c := newTestClient(t, igd)
+			c := newTestClient(t, igd, nil)
 			t.Logf("Listening on upnp=%v", c.testUPnPPort)
-			defer c.Close()
 
 			// Ensure that we're using the HTTP client that talks to our test IGD server
 			ctx := context.Background()

--- a/net/portmapper/upnp_test.go
+++ b/net/portmapper/upnp_test.go
@@ -586,9 +586,8 @@ func TestGetUPnPPortMapping(t *testing.T) {
 			},
 		})
 
-		c := newTestClient(t, igd)
+		c := newTestClient(t, igd, nil)
 		t.Logf("Listening on upnp=%v", c.testUPnPPort)
-		defer c.Close()
 
 		c.debug.VerboseLogs = true
 
@@ -689,10 +688,9 @@ func TestGetUPnPPortMapping_LeaseDuration(t *testing.T) {
 			})
 
 			ctx := context.Background()
-			c := newTestClient(t, igd)
+			c := newTestClient(t, igd, nil)
 			c.debug.VerboseLogs = true
 			t.Logf("Listening on upnp=%v", c.testUPnPPort)
-			defer c.Close()
 
 			// Actually test the UPnP port mapping.
 			mustProbeUPnP(t, ctx, c)
@@ -735,8 +733,7 @@ func TestGetUPnPPortMapping_NoValidServices(t *testing.T) {
 		Desc: noSupportedServicesRootDesc,
 	})
 
-	c := newTestClient(t, igd)
-	defer c.Close()
+	c := newTestClient(t, igd, nil)
 	c.debug.VerboseLogs = true
 
 	ctx := context.Background()
@@ -778,8 +775,7 @@ func TestGetUPnPPortMapping_Legacy(t *testing.T) {
 		},
 	})
 
-	c := newTestClient(t, igd)
-	defer c.Close()
+	c := newTestClient(t, igd, nil)
 	c.debug.VerboseLogs = true
 
 	ctx := context.Background()
@@ -806,9 +802,8 @@ func TestGetUPnPPortMappingNoResponses(t *testing.T) {
 	}
 	defer igd.Close()
 
-	c := newTestClient(t, igd)
+	c := newTestClient(t, igd, nil)
 	t.Logf("Listening on upnp=%v", c.testUPnPPort)
-	defer c.Close()
 
 	c.debug.VerboseLogs = true
 
@@ -939,8 +934,7 @@ func TestGetUPnPPortMapping_Invalid(t *testing.T) {
 				},
 			})
 
-			c := newTestClient(t, igd)
-			defer c.Close()
+			c := newTestClient(t, igd, nil)
 			c.debug.VerboseLogs = true
 
 			ctx := context.Background()


### PR DESCRIPTION
When an event bus is configured, publish an event each time a new port mapping
is updated. Publication is unconditional and occurs prior to calling any
callback that is registered. For now, the callback is still fired in a separate
goroutine as before -- later, those callbacks should become subscriptions to
the published event.

For now, the event type is defined as a new type here in the package. We will
want to move it to a more central package when there are subscribers. The event
wrapper is effectively a subset of the data exported by the internal mapping
interface, but on a concrete struct so the bus plumbing can inspect it.

Add a basic functionality test just to verify that the publication occurs.

I changed a bit of the control flow to support publication, but there is a lot
more refactoring we can and should do in this package. I deferred that for now,
as the control flow is very subtle and involves a lot of carefully tuned lock
and unlock pairs across multiple methods.
