### PR TITLE
tstest: make it clearer where AwaitRunning failed and why

### DIFF
--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -1942,6 +1942,8 @@ func (n *testNode) AwaitIP6() netip.Addr {
 
 // AwaitRunning waits for n to reach the IPN state "Running".
 func (n *testNode) AwaitRunning() {
+	t := n.env.t
+	t.Helper()
 	n.AwaitBackendState("Running")
 }
 
@@ -2015,7 +2017,7 @@ func (n *testNode) Status() (*ipnstate.Status, error) {
 	}
 	st := new(ipnstate.Status)
 	if err := json.Unmarshal(out, st); err != nil {
-		return nil, fmt.Errorf("decoding tailscale status JSON: %w", err)
+		return nil, fmt.Errorf("decoding tailscale status JSON: %w\njson:\n%s", err, out)
 	}
 	return st, nil
 }


### PR DESCRIPTION
As an example, without this patch you might get:

```
    integration_test.go:1945: failure/timeout waiting for transition to Running status: decoding tailscale status JSON: invalid character 'a' in literal true (expecting 'r')
```

(and that line of code is the `AwaitRunning` function itself)

With the patch you'd get:

```
    integration_test.go:534: failure/timeout waiting for transition to Running status: decoding tailscale status JSON: invalid character 'a' in literal true (expecting 'r')
        json:
        tailscale.toolchain.rev = "4fdaeeb8fe43bcdb4e8cc736433b9cd9c0ddd221", want "2b494987ff3c1a6a26e10570c490394ff0a77aa4"; but ignoring due to TS_PERMIT_TOOLCHAIN_MISMATCH=1
        {
          "Version": "1.81.118-t504c0203b",
          "TUN": false,
          "BackendState": "Running",
          "HaveNodeKey": true,
...
```

Which makes it much clearer what went wrong, and also the line number points you at the test `TestNodeAddressIPFields` rather than the `AwaitRunning` helper.