### PR TITLE
tsnet: Default executable name on iOS

### DIFF
--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -505,6 +505,11 @@ func (s *Server) start() (reterr error) {
 			// directory and hostname when they're not supplied. But we can fall
 			// back to "tsnet" as well.
 			exe = "tsnet"
+		case "ios":
+			// When compiled as a framework (via TailscaleKit in libtailscale),
+			// os.Executable() returns an error, so fall back to "tsnet" there
+			// too.
+			exe = "tsnet"
 		default:
 			return err
 		}


### PR DESCRIPTION
When compiled into TailscaleKit.framework (via the libtailscale repository), os.Executable() returns an error instead of the name of the executable.  which manifests in the following error from Swift when starting a `TailscaleNode`:

```
TailscaleNode Error: internalError(Optional("tenet: cannot find executable path"))
```

This commit adds another branch to the switch statement that enumerates platforms which behave in this manner, and defaults to "tsnet" in the same manner as those other platforms.