### PR TITLE
safesocket: respect context timeout when sleeping for 250ms in retry loop

### DIFF
--- a/safesocket/safesocket.go
+++ b/safesocket/safesocket.go
@@ -61,7 +61,11 @@ func ConnectContext(ctx context.Context, path string) (net.Conn, error) {
 			if ctx.Err() != nil {
 				return nil, ctx.Err()
 			}
-			time.Sleep(250 * time.Millisecond)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(250 * time.Millisecond):
+			}
 			continue
 		}
 		return c, err


### PR DESCRIPTION
Noticed while working on a dev tool that uses local.Client.

Updates #cleanup
