### PR TITLE
all: skip looking for package comments in .git/ repository

### DIFF
--- a/pkgdoc_test.go
+++ b/pkgdoc_test.go
@@ -26,6 +26,9 @@ func TestPackageDocs(t *testing.T) {
 		if err != nil {
 			return err
 		}
+		if fi.Mode().IsDir() && path == ".git" {
+			return filepath.SkipDir // No documentation lives in .git
+		}
 		if fi.Mode().IsRegular() && strings.HasSuffix(path, ".go") {
 			if strings.HasSuffix(path, "_test.go") {
 				return nil


### PR DESCRIPTION
The `.git/` directory is the Git repository and not part of the working tree.

This patch fixes spurious failures because something inside `.git/` has a `.go` suffix. For example, there’s a branch named `c22wen/magicsock.go` which is definitely not a Go source file.

``` console
sfllaw@host:~/tailscale$ git fetch origin c22wen/magicsock.go
From https://github.com/tailscale/tailscale
 * branch                c22wen/magicsock.go -> FETCH_HEAD
sfllaw@host:~/tailscale$ go test . -run 'TestPackageDocs'
=== RUN   TestPackageDocs
    pkgdoc_test.go:46: failed to ParseFile ".git/logs/refs/remotes/origin/c22wen/magicsock.go": .git/logs/refs/remotes/upstream/c22wen/magicsock.go:1:1: expected 'package', found 0000000000000000000000000000000000000000 (and 1 more errors)
--- FAIL: TestPackageDocs (0.01s)
FAIL
FAIL	tailscale.com	0.015s
FAIL
```

Fixes: #15383