### PR TITLE
prober: add address family label for udp metrics

### DIFF
--- a/prober/derp.go
+++ b/prober/derp.go
@@ -596,11 +596,23 @@ func (d *derpProber) updateMap(ctx context.Context) error {
 }
 
 func (d *derpProber) ProbeUDP(ipaddr string, port int) ProbeClass {
+	initLabels := make(Labels)
+	ip := net.ParseIP(ipaddr)
+
+	if ip.To4() != nil {
+		initLabels["address_family"] = "ipv4"
+	} else if ip.To16() != nil { // Will return an IPv4 as 16 byte, so ensure the check for IPv4 precedes this
+		initLabels["address_family"] = "ipv6"
+	} else {
+		initLabels["address_family"] = "unknown"
+	}
+
 	return ProbeClass{
 		Probe: func(ctx context.Context) error {
 			return derpProbeUDP(ctx, ipaddr, port)
 		},
-		Class: "derp_udp",
+		Class:  "derp_udp",
+		Labels: initLabels,
 	}
 }
 

--- a/prober/prober.go
+++ b/prober/prober.go
@@ -404,10 +404,14 @@ func (p *Probe) recordEndLocked(err error) {
 		p.mSeconds.WithLabelValues("ok").Add(latency.Seconds())
 		p.latencyHist.Value = latency
 		p.latencyHist = p.latencyHist.Next()
+		p.mAttempts.WithLabelValues("fail").Add(0)
+		p.mSeconds.WithLabelValues("fail").Add(0)
 	} else {
 		p.latency = 0
 		p.mAttempts.WithLabelValues("fail").Inc()
 		p.mSeconds.WithLabelValues("fail").Add(latency.Seconds())
+		p.mAttempts.WithLabelValues("ok").Add(0)
+		p.mSeconds.WithLabelValues("ok").Add(0)
 	}
 	p.successHist.Value = p.succeeded
 	p.successHist = p.successHist.Next()


### PR DESCRIPTION
Add a label which differentiates the address family for STUN checks.

Also initialize the derpprobe_attempts_total and
derpprobe_seconds_total metrics by adding 0 for
the alternate fail/ok case.

Updates tailscale/corp#27249