### PR TITLE
build_docker.sh: bump default base image

### DIFF
--- a/build_docker.sh
+++ b/build_docker.sh
@@ -16,7 +16,7 @@ eval "$(./build_dist.sh shellvars)"
 
 DEFAULT_TARGET="client"
 DEFAULT_TAGS="v${VERSION_SHORT},v${VERSION_MINOR}"
-DEFAULT_BASE="tailscale/alpine-base:3.18"
+DEFAULT_BASE="tailscale/alpine-base:3.19"
 # Set a few pre-defined OCI annotations. The source annotation is used by tools such as Renovate that scan the linked
 # Github repo to find release notes for any new image tags. Note that for official Tailscale images the default
 # annotations defined here will be overriden by release scripts that call this script.


### PR DESCRIPTION
We now have a tailscale/alpine-base:3.19- use that as the default base image.

Note that this change only applies to local dev builds.
Our image build infra uses ALPINE.txt file and I already build images using the 3.19 base (`unstable-v1.81.209` tag)

Updates tailscale/tailscale#15328