### PR TITLE
cmd/tailscale: add `chown` flag to `file get` (#15291)

### DIFF
--- a/cmd/tailscale/cli/file_stub.go
+++ b/cmd/tailscale/cli/file_stub.go
@@ -1,0 +1,16 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build windows || wasm || plan9 || tamago
+
+package cli
+
+import (
+	"errors"
+	"os"
+)
+
+// Stats a path and returns the owning uid and gid. Errors on non-unix platforms.
+func fileStat(_f *os.File) (int, int, error) {
+	return -1, -1, errors.New("Not implemented")
+}

--- a/cmd/tailscale/cli/file_unix.go
+++ b/cmd/tailscale/cli/file_unix.go
@@ -1,0 +1,26 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !windows && !wasm && !plan9 && !tamago
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// Stats a path and returns the owning uid and gid. Errors on non-unix platforms.
+func fileStat(f *os.File) (int, int, error) {
+	if f == nil {
+		return -1, -1, errors.New("file cannot be nil")
+	}
+
+	var stat syscall.Stat_t
+	if err := syscall.Stat(f.Name(), &stat); err != nil {
+		return -1, -1, err
+	}
+
+	return int(stat.Uid), int(stat.Gid), nil
+}


### PR DESCRIPTION
Fixes #15291

Not supported on non-unix platforms since they don't support `syscall.Stat` (used to preserve existing ids when calling os.Chown)