### PR TITLE
cmd/tsidp: use advertised env vars for config

### DIFF
--- a/cmd/tsidp/Dockerfile
+++ b/cmd/tsidp/Dockerfile
@@ -38,4 +38,4 @@ ENV TAILSCALE_USE_WIP_CODE=1 \
 EXPOSE 443
 
 # Run the application
-ENTRYPOINT ["/app/tsidp"]
+ENTRYPOINT ["/bin/sh", "-c", "/app/tsidp --hostname=${TS_HOSTNAME} --dir=${TS_STATE_DIR}"]

--- a/cmd/tsidp/Dockerfile
+++ b/cmd/tsidp/Dockerfile
@@ -31,7 +31,7 @@ WORKDIR /app
 
 # Environment variables
 ENV TAILSCALE_USE_WIP_CODE=1 \
-    TS_HOSTNAME=tsidp \
+    TS_HOSTNAME=idp \
     TS_STATE_DIR=/var/lib/tsidp
 
 # Expose the default port

--- a/cmd/tsidp/README.md
+++ b/cmd/tsidp/README.md
@@ -38,7 +38,7 @@
      --name `tsidp` \
      -p 443:443 \
      -e TS_AUTHKEY=YOUR_TAILSCALE_AUTHKEY \
-     -e TS_HOSTNAME=tsidp \
+     -e TS_HOSTNAME=idp \
      -v tsidp-data:/var/lib/tsidp \
      tsidp:latest
    ```
@@ -88,7 +88,7 @@ The `tsidp` server supports several command-line flags:
 
 - `TS_AUTHKEY`: Your Tailscale authentication key (required)
 - `TS_HOSTNAME`: Hostname for the `tsidp` server (default: "idp")
-- `TS_STATE_DIR`: State directory (default: "/var/lib/tsidp")
+- `TS_STATE_DIR`: State directory (default: "/var/lib/tsidp" in Docker, otherwise tsnet default)
 - `TAILSCALE_USE_WIP_CODE`: Enable work-in-progress code (default: "1")
 
 ## Support

--- a/cmd/tsidp/README.md
+++ b/cmd/tsidp/README.md
@@ -82,13 +82,14 @@ The `tsidp` server supports several command-line flags:
 - `--port`: Port to listen on (default: 443)
 - `--local-port`: Allow requests from localhost
 - `--use-local-tailscaled`: Use local tailscaled instead of tsnet
+- `--hostname`: tsnet hostname
 - `--dir`: tsnet state directory
 
 ## Environment Variables
 
 - `TS_AUTHKEY`: Your Tailscale authentication key (required)
 - `TS_HOSTNAME`: Hostname for the `tsidp` server (default: "idp")
-- `TS_STATE_DIR`: State directory (default: "/var/lib/tsidp" in Docker, otherwise tsnet default)
+- `TS_STATE_DIR`: State directory (default: "/var/lib/tsidp")
 - `TAILSCALE_USE_WIP_CODE`: Enable work-in-progress code (default: "1")
 
 ## Support

--- a/cmd/tsidp/README.md
+++ b/cmd/tsidp/README.md
@@ -48,7 +48,7 @@
    docker logs tsidp
    ```
 
-   Visit `https://tsidp.tailnet.ts.net` to confirm the service is running.
+   Visit `https://idp.tailnet.ts.net` to confirm the service is running.
 
 ## Usage Example: Proxmox Integration
 
@@ -88,8 +88,8 @@ The `tsidp` server supports several command-line flags:
 ## Environment Variables
 
 - `TS_AUTHKEY`: Your Tailscale authentication key (required)
-- `TS_HOSTNAME`: Hostname for the `tsidp` server (default: "idp")
-- `TS_STATE_DIR`: State directory (default: "/var/lib/tsidp")
+- `TS_HOSTNAME`: Hostname for the `tsidp` server (default: "idp", Docker only)
+- `TS_STATE_DIR`: State directory (default: "/var/lib/tsidp", Docker only)
 - `TAILSCALE_USE_WIP_CODE`: Enable work-in-progress code (default: "1")
 
 ## Support

--- a/cmd/tsidp/tsidp.go
+++ b/cmd/tsidp/tsidp.go
@@ -65,16 +65,9 @@ var (
 	flagLocalPort          = flag.Int("local-port", -1, "allow requests from localhost")
 	flagUseLocalTailscaled = flag.Bool("use-local-tailscaled", false, "use local tailscaled instead of tsnet")
 	flagFunnel             = flag.Bool("funnel", false, "use Tailscale Funnel to make tsidp available on the public internet")
-	flagHostname           = flag.String("hostname", envOr("TS_HOSTNAME", "idp"), "tsnet hostname to use instead of idp")
-	flagDir                = flag.String("dir", envOr("TS_STATE_DIR", ""), "tsnet state directory; a default one will be created if not provided")
+	flagHostname           = flag.String("hostname", "idp", "tsnet hostname to use instead of idp")
+	flagDir                = flag.String("dir", "", "tsnet state directory; a default one will be created if not provided")
 )
-
-func envOr(key, defaultVal string) string {
-	if result, ok := os.LookupEnv(key); ok {
-		return result
-	}
-	return defaultVal
-}
 
 func main() {
 	flag.Parse()

--- a/cmd/tsidp/tsidp.go
+++ b/cmd/tsidp/tsidp.go
@@ -65,8 +65,16 @@ var (
 	flagLocalPort          = flag.Int("local-port", -1, "allow requests from localhost")
 	flagUseLocalTailscaled = flag.Bool("use-local-tailscaled", false, "use local tailscaled instead of tsnet")
 	flagFunnel             = flag.Bool("funnel", false, "use Tailscale Funnel to make tsidp available on the public internet")
-	flagDir                = flag.String("dir", "", "tsnet state directory; a default one will be created if not provided")
+	flagHostname           = flag.String("hostname", envOr("TS_HOSTNAME", "idp"), "tsnet hostname to use instead of idp")
+	flagDir                = flag.String("dir", envOr("TS_STATE_DIR", ""), "tsnet state directory; a default one will be created if not provided")
 )
+
+func envOr(key, defaultVal string) string {
+	if result, ok := os.LookupEnv(key); ok {
+		return result
+	}
+	return defaultVal
+}
 
 func main() {
 	flag.Parse()
@@ -121,7 +129,7 @@ func main() {
 		defer cleanup()
 	} else {
 		ts := &tsnet.Server{
-			Hostname: "idp",
+			Hostname: *flagHostname,
 			Dir:      *flagDir,
 		}
 		if *flagVerbose {


### PR DESCRIPTION
Fixes #14491

TS_HOSTNAME and TS_STATE_DIR are now actually used as advertised in the README.
(Since tsnet doesn't parse TS_HOSTNAME or TS_STATE_DIR by itself tmk).

Also changed Dockerfile to use `idp` to preserve the existing behavior.