### PR TITLE
client/local: fix path with delete profile request

### DIFF
--- a/client/local/local.go
+++ b/client/local/local.go
@@ -1504,7 +1504,7 @@ func (lc *Client) SwitchProfile(ctx context.Context, profile ipn.ProfileID) erro
 // If the profile is the current profile, an empty profile
 // will be selected as if SwitchToEmptyProfile was called.
 func (lc *Client) DeleteProfile(ctx context.Context, profile ipn.ProfileID) error {
-	_, err := lc.send(ctx, "DELETE", "/localapi/v0/profiles"+url.PathEscape(string(profile)), http.StatusNoContent, nil)
+	_, err := lc.send(ctx, "DELETE", "/localapi/v0/profiles/"+url.PathEscape(string(profile)), http.StatusNoContent, nil)
 	return err
 }
 


### PR DESCRIPTION
Helps to fix: https://github.com/tailscale/tailscale/issues/12255 and needed for https://github.com/tailscale/tailscale/pull/15150

This fixes a bug in the local client where the DELETE request was not being sent correctly. The route was missing a slash before the url and this now matches the switch profile function.

This was included in https://github.com/tailscale/tailscale/pull/15150 but moved to its own PR by request of @bradfitz.