### PR TITLE
wgengine: return explicit lo0 for loopback addrs on sandboxed macOS

### DIFF
--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -1580,6 +1580,12 @@ type fwdDNSLinkSelector struct {
 }
 
 func (ls fwdDNSLinkSelector) PickLink(ip netip.Addr) (linkName string) {
+	// sandboxed macOS does not automatically bind to the loopback interface so
+	// we must be explicit about it.
+	if runtime.GOOS == "darwin" && ip.IsLoopback() {
+		return "lo0"
+	}
+
 	if ls.ue.isDNSIPOverTailscale.Load()(ip) {
 		return ls.tunName
 	}


### PR DESCRIPTION
fixes tailscale/corp#27506

The source address link selection for forwarded DNS queries on sandboxed macOS doesn't deal with loopback addresses correctly resulting in "network unreachable" errors.   This adds an explicit check to ensure we return the loopback interface for loopback addresses instead of the default empty interface when the runtime.GOOS is darwin. 

Tested on both macos, macsys and tailscaled with a simple DNS proxy.  Forwarded requests to 127/8 are now all routed correctly.