### PR TITLE
client/tailscale: add godoc links in Deprecated comments

### DIFF
--- a/client/tailscale/localclient_aliases.go
+++ b/client/tailscale/localclient_aliases.go
@@ -12,95 +12,95 @@ import (
 	"tailscale.com/ipn/ipnstate"
 )
 
-// ErrPeerNotFound is an alias for tailscale.com/client/local.
+// ErrPeerNotFound is an alias for [tailscale.com/client/local.ErrPeerNotFound].
 //
-// Deprecated: import tailscale.com/client/local instead.
+// Deprecated: import [tailscale.com/client/local] instead.
 var ErrPeerNotFound = local.ErrPeerNotFound
 
-// LocalClient is an alias for tailscale.com/client/local.
+// LocalClient is an alias for [tailscale.com/client/local.Client].
 //
-// Deprecated: import tailscale.com/client/local instead.
+// Deprecated: import [tailscale.com/client/local] instead.
 type LocalClient = local.Client
 
-// IPNBusWatcher is an alias for tailscale.com/client/local.
+// IPNBusWatcher is an alias for [tailscale.com/client/local.IPNBusWatcher].
 //
-// Deprecated: import tailscale.com/client/local instead.
+// Deprecated: import [tailscale.com/client/local] instead.
 type IPNBusWatcher = local.IPNBusWatcher
 
-// BugReportOpts is an alias for tailscale.com/client/local.
+// BugReportOpts is an alias for [tailscale.com/client/local.BugReportOpts].
 //
-// Deprecated: import tailscale.com/client/local instead.
+// Deprecated: import [tailscale.com/client/local] instead.
 type BugReportOpts = local.BugReportOpts
 
-// DebugPortMapOpts is an alias for tailscale.com/client/local.
+// DebugPortmapOpts is an alias for [tailscale.com/client/local.DebugPortmapOpts].
 //
-// Deprecated: import tailscale.com/client/local instead.
+// Deprecated: import [tailscale.com/client/local] instead.
 type DebugPortmapOpts = local.DebugPortmapOpts
 
-// PingOpts is an alias for tailscale.com/client/local.
+// PingOpts is an alias for [tailscale.com/client/local.PingOpts].
 //
-// Deprecated: import tailscale.com/client/local instead.
+// Deprecated: import [tailscale.com/client/local] instead.
 type PingOpts = local.PingOpts
 
-// GetCertificate is an alias for tailscale.com/client/local.
+// GetCertificate is an alias for [tailscale.com/client/local.GetCertificate].
 //
-// Deprecated: import tailscale.com/client/local instead.
+// Deprecated: import [tailscale.com/client/local] instead and use [local.Client.GetCertificate].
 func GetCertificate(hi *tls.ClientHelloInfo) (*tls.Certificate, error) {
 	return local.GetCertificate(hi)
 }
 
-// SetVersionMismatchHandler is an alias for tailscale.com/client/local.
+// SetVersionMismatchHandler is an alias for [tailscale.com/client/local.SetVersionMismatchHandler].
 //
-// Deprecated: import tailscale.com/client/local instead.
+// Deprecated: import [tailscale.com/client/local] instead.
 func SetVersionMismatchHandler(f func(clientVer, serverVer string)) {
 	local.SetVersionMismatchHandler(f)
 }
 
-// IsAccessDeniedError is an alias for tailscale.com/client/local.
+// IsAccessDeniedError is an alias for [tailscale.com/client/local.IsAccessDeniedError].
 //
-// Deprecated: import tailscale.com/client/local instead.
+// Deprecated: import [tailscale.com/client/local] instead.
 func IsAccessDeniedError(err error) bool {
 	return local.IsAccessDeniedError(err)
 }
 
-// IsPreconditionsFailedError is an alias for tailscale.com/client/local.
+// IsPreconditionsFailedError is an alias for [tailscale.com/client/local.IsPreconditionsFailedError].
 //
-// Deprecated: import tailscale.com/client/local instead.
+// Deprecated: import [tailscale.com/client/local] instead.
 func IsPreconditionsFailedError(err error) bool {
 	return local.IsPreconditionsFailedError(err)
 }
 
-// WhoIs is an alias for tailscale.com/client/local.
+// WhoIs is an alias for [tailscale.com/client/local.WhoIs].
 //
-// Deprecated: import tailscale.com/client/local instead.
+// Deprecated: import [tailscale.com/client/local] instead and use [local.Client.WhoIs].
 func WhoIs(ctx context.Context, remoteAddr string) (*apitype.WhoIsResponse, error) {
 	return local.WhoIs(ctx, remoteAddr)
 }
 
-// Status is an alias for tailscale.com/client/local.
+// Status is an alias for [tailscale.com/client/local.Status].
 //
-// Deprecated: import tailscale.com/client/local instead.
+// Deprecated: import [tailscale.com/client/local] instead.
 func Status(ctx context.Context) (*ipnstate.Status, error) {
 	return local.Status(ctx)
 }
 
-// StatusWithoutPeers is an alias for tailscale.com/client/local.
+// StatusWithoutPeers is an alias for [tailscale.com/client/local.StatusWithoutPeers].
 //
-// Deprecated: import tailscale.com/client/local instead.
+// Deprecated: import [tailscale.com/client/local] instead.
 func StatusWithoutPeers(ctx context.Context) (*ipnstate.Status, error) {
 	return local.StatusWithoutPeers(ctx)
 }
 
-// CertPair is an alias for tailscale.com/client/local.
+// CertPair is an alias for [tailscale.com/client/local.CertPair].
 //
-// Deprecated: import tailscale.com/client/local instead.
+// Deprecated: import [tailscale.com/client/local] instead and use [local.Client.CertPair].
 func CertPair(ctx context.Context, domain string) (certPEM, keyPEM []byte, err error) {
 	return local.CertPair(ctx, domain)
 }
 
-// ExpandSNIName is an alias for tailscale.com/client/local.
+// ExpandSNIName is an alias for [tailscale.com/client/local.ExpandSNIName].
 //
-// Deprecated: import tailscale.com/client/local instead.
+// Deprecated: import [tailscale.com/client/local] instead and use [local.Client.ExpandSNIName].
 func ExpandSNIName(ctx context.Context, name string) (fqdn string, ok bool) {
 	return local.ExpandSNIName(ctx, name)
 }

--- a/client/tailscale/tailscale.go
+++ b/client/tailscale/tailscale.go
@@ -8,7 +8,7 @@
 // This package is only intended for internal and transitional use.
 //
 // Deprecated: the official control plane client is available at
-// tailscale.com/client/tailscale/v2.
+// [tailscale.com/client/tailscale/v2].
 package tailscale
 
 import (
@@ -22,7 +22,7 @@ import (
 )
 
 // I_Acknowledge_This_API_Is_Unstable must be set true to use this package
-// for now. This package is being replaced by tailscale.com/client/tailscale/v2.
+// for now. This package is being replaced by [tailscale.com/client/tailscale/v2].
 var I_Acknowledge_This_API_Is_Unstable = false
 
 // TODO: use url.PathEscape() for deviceID and tailnets when constructing requests.
@@ -34,10 +34,10 @@ const maxReadSize = 10 << 20
 
 // Client makes API calls to the Tailscale control plane API server.
 //
-// Use NewClient to instantiate one. Exported fields should be set before
+// Use [NewClient] to instantiate one. Exported fields should be set before
 // the client is used and not changed thereafter.
 //
-// Deprecated: use tailscale.com/client/tailscale/v2 instead.
+// Deprecated: use [tailscale.com/client/tailscale/v2] instead.
 type Client struct {
 	// tailnet is the globally unique identifier for a Tailscale network, such
 	// as "example.com" or "user@gmail.com".
@@ -51,7 +51,7 @@ type Client struct {
 	BaseURL string
 
 	// HTTPClient optionally specifies an alternate HTTP client to use.
-	// If nil, http.DefaultClient is used.
+	// If nil, [http.DefaultClient] is used.
 	HTTPClient *http.Client
 
 	// UserAgent optionally specifies an alternate User-Agent header
@@ -119,7 +119,7 @@ type AuthMethod interface {
 	modifyRequest(req *http.Request)
 }
 
-// APIKey is an AuthMethod for NewClient that authenticates requests
+// APIKey is an [AuthMethod] for [NewClient] that authenticates requests
 // using an authkey.
 type APIKey string
 
@@ -133,15 +133,15 @@ func (c *Client) setAuth(r *http.Request) {
 	}
 }
 
-// NewClient is a convenience method for instantiating a new Client.
+// NewClient is a convenience method for instantiating a new [Client].
 //
 // tailnet is the globally unique identifier for a Tailscale network, such
 // as "example.com" or "user@gmail.com".
-// If httpClient is nil, then http.DefaultClient is used.
+// If httpClient is nil, then [http.DefaultClient] is used.
 // "api.tailscale.com" is set as the BaseURL for the returned client
 // and can be changed manually by the user.
 //
-// Deprecated: use tailscale.com/client/tailscale/v2 instead.
+// Deprecated: use [tailscale.com/client/tailscale/v2] instead.
 func NewClient(tailnet string, auth AuthMethod) *Client {
 	return &Client{
 		tailnet:   tailnet,
@@ -193,9 +193,9 @@ func (e ErrResponse) Error() string {
 }
 
 // HandleErrorResponse decodes the error message from the server and returns
-// an ErrResponse from it.
+// an [ErrResponse] from it.
 //
-// Deprecated: use tailscale.com/client/tailscale/v2 instead.
+// Deprecated: use [tailscale.com/client/tailscale/v2] instead.
 func HandleErrorResponse(b []byte, resp *http.Response) error {
 	var errResp ErrResponse
 	if err := json.Unmarshal(b, &errResp); err != nil {


### PR DESCRIPTION
Add [godoc links](https://go.dev/doc/comment#doclinks) in `Deprecated` comments of package `tailscale.com/client/tailscale`.