### PR TITLE
cmd/natc: separate perPeerState from connector

### DIFF
--- a/cmd/natc/natc_test.go
+++ b/cmd/natc/natc_test.go
@@ -220,7 +220,7 @@ func TestPerPeerState(t *testing.T) {
 	}
 	c.setPrefixes([]netip.Prefix{netip.MustParsePrefix("100.64.1.0/24")})
 
-	ps := &perPeerState{c: c}
+	ps := newPerPeerState(c)
 
 	addrs, err := ps.ipForDomain("example.com")
 	if err != nil {
@@ -360,7 +360,7 @@ func TestIPPoolExhaustion(t *testing.T) {
 	}
 	c.setPrefixes([]netip.Prefix{smallPrefix})
 
-	ps := &perPeerState{c: c}
+	ps := newPerPeerState(c)
 
 	assignedIPs := make(map[netip.Addr]string)
 


### PR DESCRIPTION
Make the perPeerState objects able to function independently without a shared reference to the connector.

We don't currently change the values from connector that perPeerState uses at runtime. Explicitly copying them at perPeerState creation allows us to, for example, put the perPeerState into a consensus algorithm in the future.

Updates #14667