### PR TITLE
drive: fix index out of bounds when parsing request local paths

### DIFF
--- a/drive/driveimpl/fileserver.go
+++ b/drive/driveimpl/fileserver.go
@@ -142,6 +142,10 @@ func (s *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if len(parts) < 2 {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
 	r.URL.Path = shared.Join(parts[2:]...)
 	share := parts[1]
 	s.sharesMu.RLock()

--- a/drive/driveimpl/shared/pathutil.go
+++ b/drive/driveimpl/shared/pathutil.go
@@ -22,6 +22,9 @@ const (
 // CleanAndSplit cleans the provided path p and splits it into its constituent
 // parts. This is different from path.Split which just splits a path into prefix
 // and suffix.
+//
+// If p is empty or contains only path separators, CleanAndSplit returns a slice
+// of length 1 whose only element is "".
 func CleanAndSplit(p string) []string {
 	return strings.Split(strings.Trim(path.Clean(p), sepStringAndDot), sepString)
 }
@@ -38,6 +41,8 @@ func Parent(p string) string {
 }
 
 // Join behaves like path.Join() but also includes a leading slash.
+//
+// When parts are missing, the result is "/".
 func Join(parts ...string) string {
 	fullParts := make([]string, 0, len(parts))
 	fullParts = append(fullParts, sepString)

--- a/drive/driveimpl/shared/pathutil_test.go
+++ b/drive/driveimpl/shared/pathutil_test.go
@@ -40,6 +40,7 @@ func TestJoin(t *testing.T) {
 		parts []string
 		want  string
 	}{
+		{[]string{}, "/"},
 		{[]string{""}, "/"},
 		{[]string{"a"}, "/a"},
 		{[]string{"/a"}, "/a"},


### PR DESCRIPTION
Fix the index out of bound panic when a request is made to the local fileserver mux with a valid secret-token, but missing share name.

Example error:
http: panic serving 127.0.0.1:40974: runtime error: slice bounds out of range [2:1]

Additionally, we documentation the edge case behavior of utilities that this fileserver mux depends on.