### PR TITLE
Stop trying to use netlink on android

### DIFF
--- a/net/routetable/routetable_linux.go
+++ b/net/routetable/routetable_linux.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build linux
+//go:build linux && !android
 
 package routetable
 

--- a/net/routetable/routetable_other.go
+++ b/net/routetable/routetable_other.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build !linux && !darwin && !freebsd
+//go:build android || (!linux && !darwin && !freebsd)
 
 package routetable
 

--- a/net/tstun/linkattrs_linux.go
+++ b/net/tstun/linkattrs_linux.go
@@ -1,6 +1,8 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
+//go:build !android
+
 package tstun
 
 import (

--- a/net/tstun/linkattrs_notlinux.go
+++ b/net/tstun/linkattrs_notlinux.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build !linux
+//go:build !linux || android
 
 package tstun
 

--- a/wgengine/router/router_android.go
+++ b/wgengine/router/router_android.go
@@ -1,0 +1,29 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build android
+
+package router
+
+import (
+	"github.com/tailscale/wireguard-go/tun"
+	"tailscale.com/health"
+	"tailscale.com/net/netmon"
+	"tailscale.com/types/logger"
+)
+
+func newUserspaceRouter(logf logger.Logf, tunDev tun.Device, netMon *netmon.Monitor, health *health.Tracker) (Router, error) {
+	// Note, this codepath is _not_ used when building the android app
+	// from github.com/tailscale/tailscale-android. The android app
+	// constructs its own wgengine with a custom router implementation
+	// that plugs into Android networking APIs.
+	//
+	// In practice, the only place this fake router gets used is when
+	// you build a tsnet app for android, in which case we don't want
+	// to touch the OS network stack and a no-op router is correct.
+	return NewFake(logf), nil
+}
+
+func cleanUp(logf logger.Logf, interfaceName string) {
+	// Nothing to do here.
+}

--- a/wgengine/router/router_linux.go
+++ b/wgengine/router/router_linux.go
@@ -1,6 +1,8 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
+//go:build !android
+
 package router
 
 import (


### PR DESCRIPTION
Android >=14 forbids the use of netlink sockets by apps, which results in either initialization failures or getting killed by the sandbox.

This should not affect the Tailscale android app in https://github.com/tailscale/tailscale-android, since it uses its own libtailscale shim to construct a data plane with a router that plugs into Android's native networking APIs. This only affects builds of tsnet programs targeting android, since without the additional logic from tailscale-android, Go considers `android` to be a subset of the `linux` GOOS, and thus selects implementations that try to use netlink.

Fixes #9836

---

I don't love sprinkling more build tags to deal with this, better HAL APIs would be preferable... But tactically, this unblocks other work until we get to refactors.