### PR TITLE
cmd/dist,release/dist: sign QNAP builds with a Google Cloud hosted key

### DIFF
--- a/release/dist/qnap/files/scripts/Dockerfile.qpkg
+++ b/release/dist/qnap/files/scripts/Dockerfile.qpkg
@@ -1,9 +1,21 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
     git-core \
-    ca-certificates
-RUN git clone https://github.com/qnap-dev/QDK.git
+    ca-certificates \
+    apt-transport-https \
+    gnupg \
+    curl \
+    patch
+
+# Install QNAP QDK (force a specific version to pick up updates)
+RUN git clone https://github.com/tailscale/QDK.git && cd /QDK && git reset --hard 9a31a67387c583d19a81a378dcf7c25e2abe231d
 RUN cd /QDK && ./InstallToUbuntu.sh install
 ENV PATH="/usr/share/QDK/bin:${PATH}"
+
+# Install Google Cloud PKCS11 module
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+RUN apt-get update -y && apt-get install -y --no-install-recommends google-cloud-cli libengine-pkcs11-openssl
+RUN curl -L https://github.com/GoogleCloudPlatform/kms-integrations/releases/download/pkcs11-v1.6/libkmsp11-1.6-linux-amd64.tar.gz | tar xz

--- a/release/dist/qnap/files/scripts/sign-qpkg.sh
+++ b/release/dist/qnap/files/scripts/sign-qpkg.sh
@@ -1,0 +1,40 @@
+#! /usr/bin/env bash
+set -xeu
+
+mkdir -p "$HOME/.config/gcloud"
+echo "$GCLOUD_CREDENTIALS_BASE64" | base64 --decode > /root/.config/gcloud/application_default_credentials.json
+gcloud config set project "$GCLOUD_PROJECT"
+
+echo "---
+tokens:
+  - key_ring: \"$GCLOUD_KEYRING\"
+log_directory: "/tmp/kmsp11"
+" > pkcs11-config.yaml
+chmod 0600 pkcs11-config.yaml
+
+export KMS_PKCS11_CONFIG=`readlink -f pkcs11-config.yaml`
+export PKCS11_MODULE_PATH=/libkmsp11-1.6-linux-amd64/libkmsp11.so
+
+# Verify signature of pkcs11 module
+# See https://github.com/GoogleCloudPlatform/kms-integrations/blob/master/kmsp11/docs/user_guide.md#downloading-and-verifying-the-library
+echo "-----BEGIN PUBLIC KEY-----
+MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEtfLbXkHUVc9oUPTNyaEK3hIwmuGRoTtd
+6zDhwqjJuYaMwNd1aaFQLMawTwZgR0Xn27ymVWtqJHBe0FU9BPIQ+SFmKw+9jSwu
+/FuqbJnLmTnWMJ1jRCtyHNZawvv2wbiB
+-----END PUBLIC KEY-----" > pkcs11-release-signing-key.pem
+openssl dgst -sha384 -verify pkcs11-release-signing-key.pem -signature "$PKCS11_MODULE_PATH.sig" "$PKCS11_MODULE_PATH"
+
+echo "$QNAP_SIGNING_CERT_BASE64" | base64 --decode > cert.crt
+
+openssl cms \
+	-sign \
+	-binary \
+	-nodetach \
+	-engine pkcs11 \
+	-keyform engine \
+	-inkey "pkcs11:object=$QNAP_SIGNING_KEY_NAME" \
+	-keyopt rsa_padding_mode:pss \
+	-keyopt rsa_pss_saltlen:digest \
+	-signer cert.crt \
+	-in "$1" \
+	-out -

--- a/release/dist/qnap/targets.go
+++ b/release/dist/qnap/targets.go
@@ -3,16 +3,31 @@
 
 package qnap
 
-import "tailscale.com/release/dist"
+import (
+	"slices"
+
+	"tailscale.com/release/dist"
+)
 
 // Targets defines the dist.Targets for QNAP devices.
 //
-// If privateKeyPath and certificatePath are both provided non-empty,
-// these targets will be signed for QNAP app store release with built.
-func Targets(privateKeyPath, certificatePath string) []dist.Target {
+// If all parameters are provided non-empty, then the build will be signed using
+// a Google Cloud hosted key.
+//
+// gcloudCredentialsBase64 is the JSON credential for connecting to Google Cloud, base64 encoded.
+// gcloudKeyring is the full path to the Google Cloud keyring containing the signing key.
+// keyName is the name of the key.
+// certificateBase64 is the PEM certificate to use in the signature, base64 encoded.
+func Targets(gcloudCredentialsBase64, gcloudProject, gcloudKeyring, keyName, certificateBase64 string) []dist.Target {
 	var signerInfo *signer
-	if privateKeyPath != "" && certificatePath != "" {
-		signerInfo = &signer{privateKeyPath, certificatePath}
+	if !slices.Contains([]string{gcloudCredentialsBase64, gcloudProject, gcloudKeyring, keyName, certificateBase64}, "") {
+		signerInfo = &signer{
+			gcloudCredentialsBase64: gcloudCredentialsBase64,
+			gcloudProject:           gcloudProject,
+			gcloudKeyring:           gcloudKeyring,
+			keyName:                 keyName,
+			certificateBase64:       certificateBase64,
+		}
 	}
 	return []dist.Target{
 		&target{


### PR DESCRIPTION
QNAP now requires builds to be signed with an HSM.

This removes support for signing with a local keypair.

This adds support for signing with a Google Cloud hosted key.

The key should be an RSA key with protection level `HSM` and that uses PSS padding and a SHA256 digest.

The GCloud project, keyring and key name are passed in as command-line arguments.

The GCloud credentials and the PEM signing certificate are passed in as Base64-encoded command-line arguments.

Updates tailscale/corp#23528