### PR TITLE
cmd/tailscale: tailscale up is frozen

### DIFF
--- a/cmd/tailscale/cli/up_test.go
+++ b/cmd/tailscale/cli/up_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package cli
+
+import (
+	"flag"
+	"testing"
+
+	"tailscale.com/util/set"
+)
+
+// validUpFlags are the only flags that are valid for tailscale up. The up
+// command is frozen: no new preferences can be added. Instead, add them to
+// tailscale set.
+// See tailscale/tailscale#15460.
+var validUpFlags = set.Of(
+	"accept-dns",
+	"accept-risk",
+	"accept-routes",
+	"advertise-connector",
+	"advertise-exit-node",
+	"advertise-routes",
+	"advertise-tags",
+	"auth-key",
+	"exit-node",
+	"exit-node-allow-lan-access",
+	"force-reauth",
+	"host-routes",
+	"hostname",
+	"json",
+	"login-server",
+	"netfilter-mode",
+	"nickname",
+	"operator",
+	"posture-checking",
+	"qr",
+	"reset",
+	"shields-up",
+	"snat-subnet-routes",
+	"ssh",
+	"stateful-filtering",
+	"timeout",
+	"unattended",
+)
+
+// TestUpFlagSetIsFrozen complains when new flags are added to tailscale up.
+func TestUpFlagSetIsFrozen(t *testing.T) {
+	upFlagSet.VisitAll(func(f *flag.Flag) {
+		name := f.Name
+		if !validUpFlags.Contains(name) {
+			t.Errorf("--%s flag added to tailscale up, new prefs go in tailscale set: see tailscale/tailscale#15460", name)
+		}
+	})
+}


### PR DESCRIPTION
`tailscale set` was created to set preferences, which used to be overloaded into `tailscale up`. To move people over to the new command, `tailscale up` was supposed to be frozen, so no new preference flags would be added. But people forgot it was frozen, there was no test, and so new flags were added anyway.

TestUpFlagSetIsFrozen complains when new flags are added to `tailscale up`. This doesn’t try all combinations of GOOS, but the CI builds run in every OS, so this should be caught in the PR.

This problem is described, in detail, in #15460.