### PR TITLE
nix: update nix and use go 1.24

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1724748588,
-        "narHash": "sha256-NlpGA4+AIf1dKNq76ps90rxowlFXUsV9x7vK/mN37JM=",
+        "lastModified": 1743938762,
+        "narHash": "sha256-UgFYn8sGv9B8PoFpUfCa43CjMZBl1x/ShQhRDHBFQdI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a6292e34000dc93d43bccf78338770c1c5ec8a99",
+        "rev": "74a40410369a1c35ee09b8a1abee6f4acbedc059",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -130,4 +130,4 @@
   in
     flake-utils.lib.eachDefaultSystem (system: flakeForSystem nixpkgs system);
 }
-# nix-direnv cache busting line: sha256-xO1DuLWi6/lpA9ubA2ZYVJM+CkVNA5IaVGZxX9my0j0=
+# nix-direnv cache busting line: sha256-av4kr09rjNRmag94ziNjJuI/cg8b8lAD3Tk24t/ezH4=

--- a/flake.nix
+++ b/flake.nix
@@ -68,7 +68,7 @@
     # you're an end user you should be prepared for this flake to not
     # build periodically.
     tailscale = pkgs:
-      pkgs.buildGo123Module rec {
+      pkgs.buildGo124Module rec {
         name = "tailscale";
 
         src = ./.;
@@ -118,7 +118,7 @@
           gotools
           graphviz
           perl
-          go_1_23
+          go_1_24
           yarn
 
           # qemu and e2fsprogs are needed for natlab

--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,7 @@
         vendorHash = pkgs.lib.fileContents ./go.mod.sri;
         nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [pkgs.makeWrapper];
         ldflags = ["-X tailscale.com/version.gitCommitStamp=${tailscaleRev}"];
-        CGO_ENABLED = 0;
+        env.CGO_ENABLED = 0;
         subPackages = ["cmd/tailscale" "cmd/tailscaled"];
         doCheck = false;
 

--- a/go.mod.sri
+++ b/go.mod.sri
@@ -1,1 +1,1 @@
-sha256-xO1DuLWi6/lpA9ubA2ZYVJM+CkVNA5IaVGZxX9my0j0=
+sha256-av4kr09rjNRmag94ziNjJuI/cg8b8lAD3Tk24t/ezH4=

--- a/shell.nix
+++ b/shell.nix
@@ -16,4 +16,4 @@
 ) {
   src =  ./.;
 }).shellNix
-# nix-direnv cache busting line: sha256-xO1DuLWi6/lpA9ubA2ZYVJM+CkVNA5IaVGZxX9my0j0=
+# nix-direnv cache busting line: sha256-av4kr09rjNRmag94ziNjJuI/cg8b8lAD3Tk24t/ezH4=


### PR DESCRIPTION
Updates #15015

This fixes building with `nix build` on latest code.