### PR TITLE
cmd/tailscale/cli: prevent all dup flags, not just strings

### DIFF
--- a/cmd/tailscale/cli/cli.go
+++ b/cmd/tailscale/cli/cli.go
@@ -165,6 +165,41 @@ func Run(args []string) (err error) {
 	return err
 }
 
+type onceFlagValue struct {
+	flag.Value
+	set bool
+}
+
+func (v *onceFlagValue) Set(s string) error {
+	if v.set {
+		return fmt.Errorf("flag provided multiple times")
+	}
+	v.set = true
+	return v.Value.Set(s)
+}
+
+func (v *onceFlagValue) IsBoolFlag() bool {
+	type boolFlag interface {
+		IsBoolFlag() bool
+	}
+	bf, ok := v.Value.(boolFlag)
+	return ok && bf.IsBoolFlag()
+}
+
+// noDupFlagify modifies c recursively to make all the
+// flag values be wrappers that permit setting the value
+// at most once.
+func noDupFlagify(c *ffcli.Command) {
+	if c.FlagSet != nil {
+		c.FlagSet.VisitAll(func(f *flag.Flag) {
+			f.Value = &onceFlagValue{Value: f.Value}
+		})
+	}
+	for _, sub := range c.Subcommands {
+		noDupFlagify(sub)
+	}
+}
+
 func newRootCmd() *ffcli.Command {
 	rootfs := newFlagSet("tailscale")
 	rootfs.Func("socket", "path to tailscaled socket", func(s string) error {
@@ -236,6 +271,7 @@ change in the future.
 	})
 
 	ffcomplete.Inject(rootCmd, func(c *ffcli.Command) { c.LongHelp = hidden + c.LongHelp }, usageFunc)
+	noDupFlagify(rootCmd)
 	return rootCmd
 }
 

--- a/cmd/tailscale/cli/set.go
+++ b/cmd/tailscale/cli/set.go
@@ -49,7 +49,7 @@ type setArgsT struct {
 	runSSH                 bool
 	runWebClient           bool
 	hostname               string
-	advertiseRoutes        singleUseStringFlag
+	advertiseRoutes        string
 	advertiseDefaultRoute  bool
 	advertiseConnector     bool
 	opUser                 string
@@ -75,7 +75,7 @@ func newSetFlagSet(goos string, setArgs *setArgsT) *flag.FlagSet {
 	setf.BoolVar(&setArgs.shieldsUp, "shields-up", false, "don't allow incoming connections")
 	setf.BoolVar(&setArgs.runSSH, "ssh", false, "run an SSH server, permitting access per tailnet admin's declared policy")
 	setf.StringVar(&setArgs.hostname, "hostname", "", "hostname to use instead of the one provided by the OS")
-	setf.Var(&setArgs.advertiseRoutes, "advertise-routes", "routes to advertise to other nodes (comma-separated, e.g. \"10.0.0.0/8,192.168.0.0/24\") or empty string to not advertise routes")
+	setf.StringVar(&setArgs.advertiseRoutes, "advertise-routes", "", "routes to advertise to other nodes (comma-separated, e.g. \"10.0.0.0/8,192.168.0.0/24\") or empty string to not advertise routes")
 	setf.BoolVar(&setArgs.advertiseDefaultRoute, "advertise-exit-node", false, "offer to be an exit node for internet traffic for the tailnet")
 	setf.BoolVar(&setArgs.advertiseConnector, "advertise-connector", false, "offer to be an app connector for domain specific internet traffic for the tailnet")
 	setf.BoolVar(&setArgs.updateCheck, "update-check", true, "notify about available Tailscale updates")
@@ -259,11 +259,11 @@ func runSet(ctx context.Context, args []string) (retErr error) {
 // setArgs is the parsed command-line arguments.
 func calcAdvertiseRoutesForSet(advertiseExitNodeSet, advertiseRoutesSet bool, curPrefs *ipn.Prefs, setArgs setArgsT) (routes []netip.Prefix, err error) {
 	if advertiseExitNodeSet && advertiseRoutesSet {
-		return netutil.CalcAdvertiseRoutes(setArgs.advertiseRoutes.String(), setArgs.advertiseDefaultRoute)
+		return netutil.CalcAdvertiseRoutes(setArgs.advertiseRoutes, setArgs.advertiseDefaultRoute)
 
 	}
 	if advertiseRoutesSet {
-		return netutil.CalcAdvertiseRoutes(setArgs.advertiseRoutes.String(), curPrefs.AdvertisesExitNode())
+		return netutil.CalcAdvertiseRoutes(setArgs.advertiseRoutes, curPrefs.AdvertisesExitNode())
 	}
 	if advertiseExitNodeSet {
 		alreadyAdvertisesExitNode := curPrefs.AdvertisesExitNode()

--- a/cmd/tailscale/cli/set_test.go
+++ b/cmd/tailscale/cli/set_test.go
@@ -116,7 +116,7 @@ func TestCalcAdvertiseRoutesForSet(t *testing.T) {
 				sa.advertiseDefaultRoute = *tc.setExit
 			}
 			if tc.setRoutes != nil {
-				sa.advertiseRoutes = newSingleUseStringForTest(*tc.setRoutes)
+				sa.advertiseRoutes = *tc.setRoutes
 			}
 			got, err := calcAdvertiseRoutesForSet(tc.setExit != nil, tc.setRoutes != nil, curPrefs, sa)
 			if err != nil {

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -82,25 +82,6 @@ func acceptRouteDefault(goos string) bool {
 	return p.DefaultRouteAll(goos)
 }
 
-// singleUseStringFlag will throw an error if the flag is specified more than once.
-type singleUseStringFlag struct {
-	set   bool
-	value string
-}
-
-func (s singleUseStringFlag) String() string {
-	return s.value
-}
-
-func (s *singleUseStringFlag) Set(v string) error {
-	if s.set {
-		return errors.New("flag can only be specified once")
-	}
-	s.set = true
-	s.value = v
-	return nil
-}
-
 var upFlagSet = newUpFlagSet(effectiveGOOS(), &upArgsGlobal, "up")
 
 // newUpFlagSet returns a new flag set for the "up" and "login" commands.
@@ -123,9 +104,9 @@ func newUpFlagSet(goos string, upArgs *upArgsT, cmd string) *flag.FlagSet {
 	upf.BoolVar(&upArgs.exitNodeAllowLANAccess, "exit-node-allow-lan-access", false, "Allow direct access to the local network when routing traffic via an exit node")
 	upf.BoolVar(&upArgs.shieldsUp, "shields-up", false, "don't allow incoming connections")
 	upf.BoolVar(&upArgs.runSSH, "ssh", false, "run an SSH server, permitting access per tailnet admin's declared policy")
-	upf.Var(&upArgs.advertiseTags, "advertise-tags", "comma-separated ACL tags to request; each must start with \"tag:\" (e.g. \"tag:eng,tag:montreal,tag:ssh\")")
+	upf.StringVar(&upArgs.advertiseTags, "advertise-tags", "", "comma-separated ACL tags to request; each must start with \"tag:\" (e.g. \"tag:eng,tag:montreal,tag:ssh\")")
 	upf.StringVar(&upArgs.hostname, "hostname", "", "hostname to use instead of the one provided by the OS")
-	upf.Var(&upArgs.advertiseRoutes, "advertise-routes", "routes to advertise to other nodes (comma-separated, e.g. \"10.0.0.0/8,192.168.0.0/24\") or empty string to not advertise routes")
+	upf.StringVar(&upArgs.advertiseRoutes, "advertise-routes", "", "routes to advertise to other nodes (comma-separated, e.g. \"10.0.0.0/8,192.168.0.0/24\") or empty string to not advertise routes")
 	upf.BoolVar(&upArgs.advertiseConnector, "advertise-connector", false, "advertise this node as an app connector")
 	upf.BoolVar(&upArgs.advertiseDefaultRoute, "advertise-exit-node", false, "offer to be an exit node for internet traffic for the tailnet")
 	upf.BoolVar(&upArgs.postureChecking, "posture-checking", false, hidden+"allow management plane to gather device posture information")
@@ -193,9 +174,9 @@ type upArgsT struct {
 	runWebClient           bool
 	forceReauth            bool
 	forceDaemon            bool
-	advertiseRoutes        singleUseStringFlag
+	advertiseRoutes        string
 	advertiseDefaultRoute  bool
-	advertiseTags          singleUseStringFlag
+	advertiseTags          string
 	advertiseConnector     bool
 	snat                   bool
 	statefulFiltering      bool
@@ -263,7 +244,7 @@ func warnf(format string, args ...any) {
 // function exists for testing and should have no side effects or
 // outside interactions (e.g. no making Tailscale LocalAPI calls).
 func prefsFromUpArgs(upArgs upArgsT, warnf logger.Logf, st *ipnstate.Status, goos string) (*ipn.Prefs, error) {
-	routes, err := netutil.CalcAdvertiseRoutes(upArgs.advertiseRoutes.String(), upArgs.advertiseDefaultRoute)
+	routes, err := netutil.CalcAdvertiseRoutes(upArgs.advertiseRoutes, upArgs.advertiseDefaultRoute)
 	if err != nil {
 		return nil, err
 	}
@@ -273,8 +254,8 @@ func prefsFromUpArgs(upArgs upArgsT, warnf logger.Logf, st *ipnstate.Status, goo
 	}
 
 	var tags []string
-	if upArgs.advertiseTags.String() != "" {
-		tags = strings.Split(upArgs.advertiseTags.String(), ",")
+	if upArgs.advertiseTags != "" {
+		tags = strings.Split(upArgs.advertiseTags, ",")
 		for _, tag := range tags {
 			err := tailcfg.CheckTag(tag)
 			if err != nil {
@@ -574,7 +555,7 @@ func runUp(ctx context.Context, cmd string, args []string, upArgs upArgsT) (retE
 		if err != nil {
 			return err
 		}
-		authKey, err = resolveAuthKey(ctx, authKey, upArgs.advertiseTags.String())
+		authKey, err = resolveAuthKey(ctx, authKey, upArgs.advertiseTags)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The earlier #15534 prevent some dup string flags. This does it for all flag types.

Updates #6813
