### PR TITLE
cmd/tailscale,ipn: add relay-server-port "tailscale set" flag and Pre…

### DIFF
--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -773,6 +773,7 @@ func init() {
 	addPrefFlagMapping("auto-update", "AutoUpdate.Apply")
 	addPrefFlagMapping("advertise-connector", "AppConnector")
 	addPrefFlagMapping("posture-checking", "PostureChecking")
+	addPrefFlagMapping("relay-server-port", "RelayServerPort")
 }
 
 func addPrefFlagMapping(flagName string, prefNames ...string) {

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -61,6 +61,9 @@ func (src *Prefs) Clone() *Prefs {
 			}
 		}
 	}
+	if dst.RelayServerPort != nil {
+		dst.RelayServerPort = ptr.To(*src.RelayServerPort)
+	}
 	dst.Persist = src.Persist.Clone()
 	return dst
 }
@@ -96,6 +99,7 @@ var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	PostureChecking        bool
 	NetfilterKind          string
 	DriveShares            []*drive.Share
+	RelayServerPort        *int
 	AllowSingleHosts       marshalAsTrueInJSON
 	Persist                *persist.Persist
 }{})

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -166,6 +166,10 @@ func (v PrefsView) NetfilterKind() string                 { return v.ж.Netfilte
 func (v PrefsView) DriveShares() views.SliceView[*drive.Share, drive.ShareView] {
 	return views.SliceOfViews[*drive.Share, drive.ShareView](v.ж.DriveShares)
 }
+func (v PrefsView) RelayServerPort() views.ValuePointer[int] {
+	return views.ValuePointerOf(v.ж.RelayServerPort)
+}
+
 func (v PrefsView) AllowSingleHosts() marshalAsTrueInJSON { return v.ж.AllowSingleHosts }
 func (v PrefsView) Persist() persist.PersistView          { return v.ж.Persist.View() }
 
@@ -200,6 +204,7 @@ var _PrefsViewNeedsRegeneration = Prefs(struct {
 	PostureChecking        bool
 	NetfilterKind          string
 	DriveShares            []*drive.Share
+	RelayServerPort        *int
 	AllowSingleHosts       marshalAsTrueInJSON
 	Persist                *persist.Persist
 }{})

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -65,6 +65,7 @@ func TestPrefsEqual(t *testing.T) {
 		"PostureChecking",
 		"NetfilterKind",
 		"DriveShares",
+		"RelayServerPort",
 		"AllowSingleHosts",
 		"Persist",
 	}
@@ -73,6 +74,9 @@ func TestPrefsEqual(t *testing.T) {
 			have, prefsHandles)
 	}
 
+	relayServerPort := func(port int) *int {
+		return &port
+	}
 	nets := func(strs ...string) (ns []netip.Prefix) {
 		for _, s := range strs {
 			n, err := netip.ParsePrefix(s)
@@ -339,6 +343,16 @@ func TestPrefsEqual(t *testing.T) {
 		{
 			&Prefs{AdvertiseServices: []string{"svc:tux", "svc:xenia"}},
 			&Prefs{AdvertiseServices: []string{"svc:tux", "svc:amelie"}},
+			false,
+		},
+		{
+			&Prefs{RelayServerPort: relayServerPort(0)},
+			&Prefs{RelayServerPort: nil},
+			false,
+		},
+		{
+			&Prefs{RelayServerPort: relayServerPort(0)},
+			&Prefs{RelayServerPort: relayServerPort(1)},
 			false,
 		},
 	}


### PR DESCRIPTION
…fs field

This flag is currently no-op and hidden. The flag does round trip through the related pref. Subsequent commits will tie them to net/udprelay.Server. There is no corresponding "tailscale up" flag, enabling/disabling of the relay server will only be supported via "tailscale set".

This is a string flag in order to support disablement via empty string as a port value of 0 means "enable the server and listen on a random unused port". Disablement via empty string also follows existing flag convention, e.g. advertise-routes.

Early internal discussions settled on "tailscale set --relay="<port>", but the author felt this was too ambiguous around client vs server, and may cause confusion in the future if we add related flags.

Updates tailscale/corp#27502