### PR TITLE
ipn/ipnlocal: fix peerapi ingress endpoint

### DIFF
--- a/ipn/ipnlocal/peerapi.go
+++ b/ipn/ipnlocal/peerapi.go
@@ -417,7 +417,7 @@ func (h *peerAPIHandler) handleServeIngress(w http.ResponseWriter, r *http.Reque
 	}
 	logAndError := func(code int, publicMsg string) {
 		h.logf("ingress: bad request from %v: %s", h.remoteAddr, publicMsg)
-		http.Error(w, publicMsg, http.StatusMethodNotAllowed)
+		http.Error(w, publicMsg, code)
 	}
 	bad := func(publicMsg string) {
 		logAndError(http.StatusBadRequest, publicMsg)


### PR DESCRIPTION
The http.StatusMethodNotAllowed status code was being erroneously set instead of http.StatusBadRequest in multiple places.

Updates #cleanup