### PR TITLE
tstest: parse goroutines for diff in ResourceCheck

### DIFF
--- a/tstest/resource.go
+++ b/tstest/resource.go
@@ -7,10 +7,10 @@ import (
 	"bytes"
 	"runtime"
 	"runtime/pprof"
+	"slices"
+	"strings"
 	"testing"
 	"time"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 // ResourceCheck takes a snapshot of the current goroutines and registers a
@@ -44,7 +44,20 @@ func ResourceCheck(tb testing.TB) {
 		if endN <= startN {
 			return
 		}
-		tb.Logf("goroutine diff:\n%v\n", cmp.Diff(startStacks, endStacks))
+
+		// Parse and print goroutines.
+		start := parseGoroutines(startStacks)
+		end := parseGoroutines(endStacks)
+		if testing.Verbose() {
+			tb.Logf("goroutines start:\n%s", printGoroutines(start))
+			tb.Logf("goroutines end:\n%s", printGoroutines(end))
+		}
+
+		// Print goroutine diff, omitting tstest.ResourceCheck goroutines.
+		self := func(g goroutine) bool { return bytes.Contains(g.stack, []byte("\ttailscale.com/tstest.goroutines+")) }
+		start.goroutines = slices.DeleteFunc(start.goroutines, self)
+		end.goroutines = slices.DeleteFunc(end.goroutines, self)
+		tb.Logf("goroutine diff (-start +end):\n%s", diffGoroutines(start, end))
 
 		// tb.Failed() above won't report on panics, so we shouldn't call Fatal
 		// here or we risk suppressing reporting of the panic.
@@ -57,4 +70,209 @@ func goroutines() (int, []byte) {
 	b := new(bytes.Buffer)
 	p.WriteTo(b, 1)
 	return p.Count(), b.Bytes()
+}
+
+// parseGoroutines takes pprof/goroutines?debug=1 -formatted output sorted by
+// count, and splits it into a separate list of goroutines with count and stack
+// separated.
+//
+// Example input:
+//
+//	goroutine profile: total 408
+//	48 @ 0x47bc0e 0x136c6b9 0x136c69e 0x136c7ab 0x1379809 0x13797fa 0x483da1
+//	#   0x136c6b8   gvisor.dev/gvisor/pkg/sync.Gopark+0x78                  gvisor.dev/gvisor@v0.0.0-20250205023644-9414b50a5633/pkg/sync/runtime_unsafe.go:33
+//	#   0x136c69d   gvisor.dev/gvisor/pkg/sleep.(*Sleeper).nextWaker+0x5d           gvisor.dev/gvisor@v0.0.0-20250205023644-9414b50a5633/pkg/sleep/sleep_unsafe.go:210
+//	#   0x136c7aa   gvisor.dev/gvisor/pkg/sleep.(*Sleeper).fetch+0x2a           gvisor.dev/gvisor@v0.0.0-20250205023644-9414b50a5633/pkg/sleep/sleep_unsafe.go:257
+//	#   0x1379808   gvisor.dev/gvisor/pkg/sleep.(*Sleeper).Fetch+0xa8           gvisor.dev/gvisor@v0.0.0-20250205023644-9414b50a5633/pkg/sleep/sleep_unsafe.go:280
+//	#   0x13797f9   gvisor.dev/gvisor/pkg/tcpip/transport/tcp.(*processor).start+0x99   gvisor.dev/gvisor@v0.0.0-20250205023644-9414b50a5633/pkg/tcpip/transport/tcp/dispatcher.go:291
+//
+//	48 @ 0x47bc0e 0x413705 0x4132b2 0x10fc905 0x483da1
+//	#   0x10fc904   github.com/tailscale/wireguard-go/device.(*Device).RoutineDecryption+0x184  github.com/tailscale/wireguard-go@v0.0.0-20250107165329-0b8b35511f19/device/receive.go:245
+//
+//	48 @ 0x47bc0e 0x413705 0x4132b2 0x10fcd2a 0x483da1
+//	#   0x10fcd29   github.com/tailscale/wireguard-go/device.(*Device).RoutineHandshake+0x169   github.com/tailscale/wireguard-go@v0.0.0-20250107165329-0b8b35511f19/device/receive.go:279
+//
+//	48 @ 0x47bc0e 0x413705 0x4132b2 0x1100ba7 0x483da1
+//	#   0x1100ba6   github.com/tailscale/wireguard-go/device.(*Device).RoutineEncryption+0x186  github.com/tailscale/wireguard-go@v0.0.0-20250107165329-0b8b35511f19/device/send.go:451
+//
+//	26 @ 0x47bc0e 0x458e57 0x847587 0x483da1
+//	#   0x847586    database/sql.(*DB).connectionOpener+0x86    database/sql/sql.go:1261
+//
+//	13 @ 0x47bc0e 0x458e57 0x754927 0x483da1
+//	#   0x754926    net/http.(*persistConn).writeLoop+0xe6  net/http/transport.go:2596
+//
+//	7 @ 0x47bc0e 0x413705 0x4132b2 0x10fda4d 0x483da1
+//	#   0x10fda4c   github.com/tailscale/wireguard-go/device.(*Peer).RoutineSequentialReceiver+0x16c    github.com/tailscale/wireguard-go@v0.0.0-20250107165329-0b8b35511f19/device/receive.go:443
+func parseGoroutines(g []byte) goroutineDump {
+	head, tail, ok := bytes.Cut(g, []byte("\n"))
+	if !ok {
+		return goroutineDump{head: head}
+	}
+
+	raw := bytes.Split(tail, []byte("\n\n"))
+	parsed := make([]goroutine, 0, len(raw))
+	for _, s := range raw {
+		count, rem, ok := bytes.Cut(s, []byte(" @ "))
+		if !ok {
+			continue
+		}
+		header, stack, _ := bytes.Cut(rem, []byte("\n"))
+		sort := slices.Clone(header)
+		reverseWords(sort)
+		parsed = append(parsed, goroutine{count, header, stack, sort})
+	}
+
+	return goroutineDump{head, parsed}
+}
+
+type goroutineDump struct {
+	head       []byte
+	goroutines []goroutine
+}
+
+// goroutine is a parsed stack trace in pprof goroutine output, e.g.
+// "10 @ 0x100 0x001\n# 0x100 test() test.go\n# 0x001 main() test.go".
+type goroutine struct {
+	count  []byte // e.g. "10"
+	header []byte // e.g. "0x100 0x001"
+	stack  []byte // e.g. "# 0x100 test() test.go\n# 0x001 main() test.go"
+
+	// sort is the same pointers as in header, but in reverse order so that we
+	// can place related goroutines near each other by sorting on this field.
+	// E.g. "0x001 0x100".
+	sort []byte
+}
+
+func (g goroutine) Compare(h goroutine) int {
+	return bytes.Compare(g.sort, h.sort)
+}
+
+// reverseWords repositions the words in b such that they are reversed.
+// Words are separated by spaces. New lines are not considered.
+// https://sketch.dev/sk/a4ef
+func reverseWords(b []byte) {
+	if len(b) == 0 {
+		return
+	}
+
+	// First, reverse the entire slice.
+	reverse(b)
+
+	// Then reverse each word individually.
+	start := 0
+	for i := 0; i <= len(b); i++ {
+		if i == len(b) || b[i] == ' ' {
+			reverse(b[start:i])
+			start = i + 1
+		}
+	}
+}
+
+// reverse reverses bytes in place
+func reverse(b []byte) {
+	for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {
+		b[i], b[j] = b[j], b[i]
+	}
+}
+
+// printGoroutines returns a text representation of h, gs equivalent to the
+// pprof ?debug=1 input parsed by parseGoroutines, except the goroutines are
+// sorted in an order easier for diffing.
+func printGoroutines(g goroutineDump) []byte {
+	var b bytes.Buffer
+	b.Write(g.head)
+
+	slices.SortFunc(g.goroutines, goroutine.Compare)
+	for _, g := range g.goroutines {
+		b.WriteString("\n\n")
+		b.Write(g.count)
+		b.WriteString(" @ ")
+		b.Write(g.header)
+		b.WriteString("\n")
+		if len(g.stack) > 0 {
+			b.Write(g.stack)
+		}
+	}
+
+	return b.Bytes()
+}
+
+// diffGoroutines returns a diff between goroutines of gx and gy.
+// Goroutines present in gx and absent from gy are prefixed with "-".
+// Goroutines absent from gx and present in gy are prefixed with "+".
+// Goroutines present in both but with different counts only show a prefix on the count line.
+func diffGoroutines(x, y goroutineDump) string {
+	hx, hy := x.head, y.head
+	gx, gy := x.goroutines, y.goroutines
+	var b strings.Builder
+	if !bytes.Equal(hx, hy) {
+		b.WriteString("- ")
+		b.Write(hx)
+		b.WriteString("\n+ ")
+		b.Write(hy)
+		b.WriteString("\n")
+	}
+
+	slices.SortFunc(gx, goroutine.Compare)
+	slices.SortFunc(gy, goroutine.Compare)
+
+	writeHeader := func(prefix string, g goroutine) {
+		b.WriteString(prefix)
+		b.Write(g.count)
+		b.WriteString(" @ ")
+		b.Write(g.header)
+		b.WriteString("\n")
+	}
+	writeStack := func(prefix string, g goroutine) {
+		s := g.stack
+		for {
+			var h []byte
+			h, s, _ = bytes.Cut(s, []byte("\n"))
+			if len(h) == 0 && len(s) == 0 {
+				break
+			}
+			b.WriteString(prefix)
+			b.Write(h)
+			b.WriteString("\n")
+		}
+	}
+
+	i, j := 0, 0
+	for {
+		var d int
+		switch {
+		case i < len(gx) && j < len(gy):
+			d = gx[i].Compare(gy[j])
+		case i < len(gx):
+			d = -1
+		case j < len(gy):
+			d = 1
+		default:
+			return b.String()
+		}
+
+		switch d {
+		case -1:
+			b.WriteString("\n")
+			writeHeader("- ", gx[i])
+			writeStack("- ", gx[i])
+			i++
+
+		case +1:
+			b.WriteString("\n")
+			writeHeader("+ ", gy[j])
+			writeStack("+ ", gy[j])
+			j++
+
+		case 0:
+			if !bytes.Equal(gx[i].count, gy[j].count) {
+				b.WriteString("\n")
+				writeHeader("- ", gx[i])
+				writeHeader("+ ", gy[j])
+				writeStack("  ", gy[j])
+			}
+			i++
+			j++
+		}
+	}
 }

--- a/tstest/resource_test.go
+++ b/tstest/resource_test.go
@@ -1,0 +1,256 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package tstest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestPrintGoroutines(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "empty",
+			in:   "goroutine profile: total 0\n",
+			want: "goroutine profile: total 0",
+		},
+		{
+			name: "single goroutine",
+			in: `goroutine profile: total 1
+1 @ 0x47bc0e 0x458e57 0x847587 0x483da1
+#   0x847586    database/sql.(*DB).connectionOpener+0x86    database/sql/sql.go:1261
+`,
+			want: `goroutine profile: total 1
+
+1 @ 0x47bc0e 0x458e57 0x847587 0x483da1
+#   0x847586    database/sql.(*DB).connectionOpener+0x86    database/sql/sql.go:1261
+`,
+		},
+		{
+			name: "multiple goroutines sorted",
+			in: `goroutine profile: total 14
+7 @ 0x47bc0e 0x413705 0x4132b2 0x10fda4d 0x483da1
+#   0x10fda4c   github.com/user/pkg.RoutineA+0x16c    pkg/a.go:443
+
+7 @ 0x47bc0e 0x458e57 0x754927 0x483da1
+#   0x754926    net/http.(*persistConn).writeLoop+0xe6  net/http/transport.go:2596
+`,
+			want: `goroutine profile: total 14
+
+7 @ 0x47bc0e 0x413705 0x4132b2 0x10fda4d 0x483da1
+#   0x10fda4c   github.com/user/pkg.RoutineA+0x16c    pkg/a.go:443
+
+7 @ 0x47bc0e 0x458e57 0x754927 0x483da1
+#   0x754926    net/http.(*persistConn).writeLoop+0xe6  net/http/transport.go:2596
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := string(printGoroutines(parseGoroutines([]byte(tt.in))))
+			if got != tt.want {
+				t.Errorf("printGoroutines() = %q, want %q, diff:\n%s", got, tt.want, cmp.Diff(tt.want, got))
+			}
+		})
+	}
+}
+
+func TestDiffPprofGoroutines(t *testing.T) {
+	tests := []struct {
+		name string
+		x, y string
+		want string
+	}{
+		{
+			name: "no difference",
+			x: `goroutine profile: total 1
+1 @ 0x47bc0e 0x458e57 0x847587 0x483da1
+#   0x847586    database/sql.(*DB).connectionOpener+0x86    database/sql/sql.go:1261`,
+			y: `goroutine profile: total 1
+1 @ 0x47bc0e 0x458e57 0x847587 0x483da1
+#   0x847586    database/sql.(*DB).connectionOpener+0x86    database/sql/sql.go:1261
+`,
+			want: "",
+		},
+		{
+			name: "different counts",
+			x: `goroutine profile: total 1
+1 @ 0x47bc0e 0x458e57 0x847587 0x483da1
+#   0x847586    database/sql.(*DB).connectionOpener+0x86    database/sql/sql.go:1261
+`,
+			y: `goroutine profile: total 2
+2 @ 0x47bc0e 0x458e57 0x847587 0x483da1
+#   0x847586    database/sql.(*DB).connectionOpener+0x86    database/sql/sql.go:1261
+`,
+			want: `- goroutine profile: total 1
++ goroutine profile: total 2
+
+- 1 @ 0x47bc0e 0x458e57 0x847587 0x483da1
++ 2 @ 0x47bc0e 0x458e57 0x847587 0x483da1
+  #   0x847586    database/sql.(*DB).connectionOpener+0x86    database/sql/sql.go:1261
+`,
+		},
+		{
+			name: "new goroutine",
+			x: `goroutine profile: total 1
+1 @ 0x47bc0e 0x458e57 0x847587 0x483da1
+#   0x847586    database/sql.(*DB).connectionOpener+0x86    database/sql/sql.go:1261
+`,
+			y: `goroutine profile: total 2
+1 @ 0x47bc0e 0x458e57 0x847587 0x483da1
+#   0x847586    database/sql.(*DB).connectionOpener+0x86    database/sql/sql.go:1261
+
+1 @ 0x47bc0e 0x458e57 0x754927 0x483da1
+#   0x754926    net/http.(*persistConn).writeLoop+0xe6  net/http/transport.go:2596
+`,
+			want: `- goroutine profile: total 1
++ goroutine profile: total 2
+
++ 1 @ 0x47bc0e 0x458e57 0x754927 0x483da1
++ #   0x754926    net/http.(*persistConn).writeLoop+0xe6  net/http/transport.go:2596
+`,
+		},
+		{
+			name: "removed goroutine",
+			x: `goroutine profile: total 2
+1 @ 0x47bc0e 0x458e57 0x847587 0x483da1
+#   0x847586    database/sql.(*DB).connectionOpener+0x86    database/sql/sql.go:1261
+
+1 @ 0x47bc0e 0x458e57 0x754927 0x483da1
+#   0x754926    net/http.(*persistConn).writeLoop+0xe6  net/http/transport.go:2596
+`,
+			y: `goroutine profile: total 1
+1 @ 0x47bc0e 0x458e57 0x847587 0x483da1
+#   0x847586    database/sql.(*DB).connectionOpener+0x86    database/sql/sql.go:1261
+`,
+			want: `- goroutine profile: total 2
++ goroutine profile: total 1
+
+- 1 @ 0x47bc0e 0x458e57 0x754927 0x483da1
+- #   0x754926    net/http.(*persistConn).writeLoop+0xe6  net/http/transport.go:2596
+`,
+		},
+		{
+			name: "removed many goroutine",
+			x: `goroutine profile: total 2
+1 @ 0x47bc0e 0x458e57 0x847587 0x483da1
+#   0x847586    database/sql.(*DB).connectionOpener+0x86    database/sql/sql.go:1261
+
+1 @ 0x47bc0e 0x458e57 0x754927 0x483da1
+#   0x754926    net/http.(*persistConn).writeLoop+0xe6  net/http/transport.go:2596
+`,
+			y: `goroutine profile: total 0`,
+			want: `- goroutine profile: total 2
++ goroutine profile: total 0
+
+- 1 @ 0x47bc0e 0x458e57 0x754927 0x483da1
+- #   0x754926    net/http.(*persistConn).writeLoop+0xe6  net/http/transport.go:2596
+
+- 1 @ 0x47bc0e 0x458e57 0x847587 0x483da1
+- #   0x847586    database/sql.(*DB).connectionOpener+0x86    database/sql/sql.go:1261
+`,
+		},
+		{
+			name: "invalid input x",
+			x:    "invalid",
+			y:    "goroutine profile: total 0\n",
+			want: "- invalid\n+ goroutine profile: total 0\n",
+		},
+		{
+			name: "invalid input y",
+			x:    "goroutine profile: total 0\n",
+			y:    "invalid",
+			want: "- goroutine profile: total 0\n+ invalid\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := diffGoroutines(
+				parseGoroutines([]byte(tt.x)),
+				parseGoroutines([]byte(tt.y)),
+			)
+			if got != tt.want {
+				t.Errorf("diffPprofGoroutines() diff:\ngot:\n%s\nwant:\n%s\ndiff (-want +got):\n%s", got, tt.want, cmp.Diff(tt.want, got))
+			}
+		})
+	}
+}
+
+func TestParseGoroutines(t *testing.T) {
+	tests := []struct {
+		name       string
+		in         string
+		wantHeader string
+		wantCount  int
+	}{
+		{
+			name:       "empty profile",
+			in:         "goroutine profile: total 0\n",
+			wantHeader: "goroutine profile: total 0",
+			wantCount:  0,
+		},
+		{
+			name: "single goroutine",
+			in: `goroutine profile: total 1
+1 @ 0x47bc0e 0x458e57 0x847587 0x483da1
+#   0x847586    database/sql.(*DB).connectionOpener+0x86    database/sql/sql.go:1261
+`,
+			wantHeader: "goroutine profile: total 1",
+			wantCount:  1,
+		},
+		{
+			name: "multiple goroutines",
+			in: `goroutine profile: total 14
+7 @ 0x47bc0e 0x413705 0x4132b2 0x10fda4d 0x483da1
+#   0x10fda4c   github.com/user/pkg.RoutineA+0x16c    pkg/a.go:443
+
+7 @ 0x47bc0e 0x458e57 0x754927 0x483da1
+#   0x754926    net/http.(*persistConn).writeLoop+0xe6  net/http/transport.go:2596
+`,
+			wantHeader: "goroutine profile: total 14",
+			wantCount:  2,
+		},
+		{
+			name:       "invalid format",
+			in:         "invalid",
+			wantHeader: "invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := parseGoroutines([]byte(tt.in))
+
+			if got := string(g.head); got != tt.wantHeader {
+				t.Errorf("parseGoroutines() header = %q, want %q", got, tt.wantHeader)
+			}
+			if got := len(g.goroutines); got != tt.wantCount {
+				t.Errorf("parseGoroutines() goroutine count = %d, want %d", got, tt.wantCount)
+			}
+
+			// Verify that the sort field is correctly reversed
+			for _, g := range g.goroutines {
+				original := strings.Fields(string(g.header))
+				sorted := strings.Fields(string(g.sort))
+				if len(original) != len(sorted) {
+					t.Errorf("sort field has different number of words: got %d, want %d", len(sorted), len(original))
+					continue
+				}
+				for i := 0; i < len(original); i++ {
+					if original[i] != sorted[len(sorted)-1-i] {
+						t.Errorf("sort field word mismatch at position %d: got %q, want %q", i, sorted[len(sorted)-1-i], original[i])
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
ResourceCheck was previously using cmp.Diff on multiline goroutine stacks The produced output was difficult to read for a number of reasons:

- the goroutines were sorted by count, and a changing count caused them to jump around
- diff is performed per-line, rather than per-stack

Instead, we now parse the pprof/goroutines?debug=1 format goroutines and only diff whole stacks.

Here's an example of the old cmp.Diff output. Any relevant details about why ResourceCheck is erroring are hidden in the `... // 102 identical, 2 removed, and 2 inserted lines` at the bottom, despite the massive diff that it produces:

```
resource.go:58: goroutine diff:
          bytes.Join({
        - 	"goroutine profile: total 34",
        + 	"goroutine profile: total 36",
          	"2 @ 0x104d23558 0x104ce6e38 0x104d22710 0x104d6b708 0x104d6ffdc 0x104d6ffcd 0x104f173b8 0x104f2e084 0x104f2d36c 0x1050333f0 0x10505f95c 0x104d2c104",
          	`#	0x104d2270f	internal/poll.runtime_pollWait+0x9f		/goroot/src/runtime/netpoll.go:351`,
          	... // 14 identical lines
          	`#	0x105e7cebb	pkg.run+0x5b	/src/runner.go:59`,
          	"",
        - 	"1 @ 0x104ce327c 0x104d22284 0x104e87444 0x104e87270 0x104e8495c 0x10570b974 0x10570b39c 0x1065afcb8 0x1065bc7ec 0x104df0064 0x104d2c104",
        - 	`#	0x104e87443	runtime/pprof.writeRuntimeProfile+0xb3				/goroot/src/runtime/pprof/pprof.go:796`,
        - 	`#	0x104e8726f	runtime/pprof.writeGoroutine+0x4f				/goroot/src/runtime/pprof/pprof.go:755`,
        - 	`#	0x104e8495b	runtime/pprof.(*Profile).WriteTo+0x14b				/goroot/src/runtime/pprof/pprof.go:377`,
        - 	`#	0x10570b973	tailscale.com/tstest.goroutines+0x53				/go/mod/src/tailscale.com/tstest/resource.go:70`,
        - 	`#	0x10570b39b	tailscale.com/tstest.ResourceCheck+0x5b				/go/mod/src/tailscale.com/tstest/resource.go:32`,
        - 	`#	0x1065afcb7	pkg/tstester.NewTSTester+0x87				/src/tstester/tstester.go:429`,
        - 	`#	0x1065bc7eb	pkg.TestPostureIdentity.func6+0xeb	/src/svc_test.go`,
        - 	`#	0x104df0063	testing.tRunner+0xe3						/goroot/src/testing/testing.go:1792`,
        + 	"1 @ 0x104ce327c 0x104d22284 0x104e87444 0x104e87270 0x104e8495c 0x10570b974 0x10570b550 0x104dee814 0x104def5d4 0x104df00fc 0x104df0090 0x104d2c104",
        + 	`#	0x104e87443	runtime/pprof.writeRuntimeProfile+0xb3		/goroot/src/runtime/pprof/pprof.go:796`,
        + 	`#	0x104e8726f	runtime/pprof.writeGoroutine+0x4f		/goroot/src/runtime/pprof/pprof.go:755`,
        + 	`#	0x104e8495b	runtime/pprof.(*Profile).WriteTo+0x14b		/goroot/src/runtime/pprof/pprof.go:377`,
        + 	`#	0x10570b973	tailscale.com/tstest.goroutines+0x53		/go/mod/src/tailscale.com/tstest/resource.go:70`,
        + 	`#	0x10570b54f	tailscale.com/tstest.ResourceCheck.func1+0xef	/go/mod/src/tailscale.com/tstest/resource.go:46`,
        + 	`#	0x104dee813	testing.(*common).Cleanup.func1+0xf3		/goroot/src/testing/testing.go:1211`,
        + 	`#	0x104def5d3	testing.(*common).runCleanup+0xe3		/goroot/src/testing/testing.go:1445`,
        + 	`#	0x104df00fb	testing.tRunner.func2+0x2b			/goroot/src/testing/testing.go:1786`,
        + 	`#	0x104df008f	testing.tRunner+0x10f				/goroot/src/testing/testing.go:1798`,
          	"",
          	"1 @ 0x104d23558 0x104cbb6fc 0x104cbb294 0x104df0dc8 0x104df2d50 0x104df0064 0x104df2c6c 0x104df19c8 0x1065c7880 0x104ced9e4 0x104d2c104",
          	... // 10 identical lines
          	`#	0x1065bc6df	pkg.TestPostureIdentity+0x41f	/src/svc_test.go`,
          	`#	0x104df0063	testing.tRunner+0xe3					/goroot/src/testing/testing.go:1792`,
        + 	"",
        + 	"1 @ 0x104d23558 0x104cbb6fc 0x104cbb294 0x106310bb4 0x104d2c104",
        + 	`#	0x106310bb3	pkg.initTracing.func1+0x73	/src/tracing.go:1426`,
        + 	"",
        + 	"1 @ 0x104d23558 0x104ce6e38 0x104d22710 0x104d6b708 0x104d6c9bc 0x104d6c9ad 0x104f15888 0x104f25294 0x104f77850 0x104dd8ec0 0x104f77a1c 0x104f751cc 0x104f7b09c 0x104f7b09d 0x105046d7c 0x104df50b8 0x104df5220 0x105047a2c 0x104d2c104",
        + 	`#	0x104d2270f	internal/poll.runtime_pollWait+0x9f		/goroot/src/runtime/netpoll.go:351`,
        + 	`#	0x104d6b707	internal/poll.(*pollDesc).wait+0x27		/goroot/src/internal/poll/fd_poll_runtime.go:84`,
        + 	`#	0x104d6c9bb	internal/poll.(*pollDesc).waitRead+0x1fb	/goroot/src/internal/poll/fd_poll_runtime.go:89`,
        + 	`#	0x104d6c9ac	internal/poll.(*FD).Read+0x1ec			/goroot/src/internal/poll/fd_unix.go:165`,
        + 	`#	0x104f15887	net.(*netFD).Read+0x27				/goroot/src/net/fd_posix.go:70`,
        + 	`#	0x104f25293	net.(*conn).Read+0x33				/goroot/src/net/net.go:194`,
        + 	`#	0x104f7784f	crypto/tls.(*atLeastReader).Read+0x3f		/goroot/src/crypto/tls/conn.go:809`,
        + 	`#	0x104dd8ebf	bytes.(*Buffer).ReadFrom+0x8f			/goroot/src/bytes/buffer.go:211`,
        + 	`#	0x104f77a1b	crypto/tls.(*Conn).readFromUntil+0xcb		/goroot/src/crypto/tls/conn.go:831`,
        + 	`#	0x104f751cb	crypto/tls.(*Conn).readRecordOrCCS+0x35b	/goroot/src/crypto/tls/conn.go:629`,
        + 	`#	0x104f7b09b	crypto/tls.(*Conn).readRecord+0x15b		/goroot/src/crypto/tls/conn.go:591`,
        + 	`#	0x104f7b09c	crypto/tls.(*Conn).Read+0x15c			/goroot/src/crypto/tls/conn.go:1385`,
        + 	`#	0x105046d7b	net/http.(*persistConn).Read+0x4b		/goroot/src/net/http/transport.go:2128`,
        + 	`#	0x104df50b7	bufio.(*Reader).fill+0xf7			/goroot/src/bufio/bufio.go:113`,
        + 	`#	0x104df521f	bufio.(*Reader).Peek+0x5f			/goroot/src/bufio/bufio.go:152`,
        + 	`#	0x105047a2b	net/http.(*persistConn).readLoop+0x12b		/goroot/src/net/http/transport.go:2281`,
          	... // 102 identical, 2 removed, and 2 inserted lines
          }, "\n")
```

With this new code (which omits stacks calling `tailscale.com/tstest.goroutines`) we now see the diff is:

```
    resource.go:60: goroutine diff (-start +end):
        - goroutine profile: total 34
        + goroutine profile: total 36

        + 1 @ 0x100af7178 0x100abaa58 0x100af6330 0x100b3f328 0x100b405dc 0x100b405cd 0x100ce94a8 0x100cf8eb4 0x100d4b470 0x100bacae0 0x100d4b63c 0x100d48dec 0x100d4ecbc 0x100d4ecbd 0x100e1a99c 0x100bc8cd8 0x100bc8e40 0x100e1b64c 0x100affd24
        + #	0x100af632f	internal/poll.runtime_pollWait+0x9f		/goroot/src/runtime/netpoll.go:351
        + #	0x100b3f327	internal/poll.(*pollDesc).wait+0x27		/goroot/src/internal/poll/fd_poll_runtime.go:84
        + #	0x100b405db	internal/poll.(*pollDesc).waitRead+0x1fb	/goroot/src/internal/poll/fd_poll_runtime.go:89
        + #	0x100b405cc	internal/poll.(*FD).Read+0x1ec			/goroot/src/internal/poll/fd_unix.go:165
        + #	0x100ce94a7	net.(*netFD).Read+0x27				/goroot/src/net/fd_posix.go:70
        + #	0x100cf8eb3	net.(*conn).Read+0x33				/goroot/src/net/net.go:194
        + #	0x100d4b46f	crypto/tls.(*atLeastReader).Read+0x3f		/goroot/src/crypto/tls/conn.go:809
        + #	0x100bacadf	bytes.(*Buffer).ReadFrom+0x8f			/goroot/src/bytes/buffer.go:211
        + #	0x100d4b63b	crypto/tls.(*Conn).readFromUntil+0xcb		/goroot/src/crypto/tls/conn.go:831
        + #	0x100d48deb	crypto/tls.(*Conn).readRecordOrCCS+0x35b	/goroot/src/crypto/tls/conn.go:629
        + #	0x100d4ecbb	crypto/tls.(*Conn).readRecord+0x15b		/goroot/src/crypto/tls/conn.go:591
        + #	0x100d4ecbc	crypto/tls.(*Conn).Read+0x15c			/goroot/src/crypto/tls/conn.go:1385
        + #	0x100e1a99b	net/http.(*persistConn).Read+0x4b		/goroot/src/net/http/transport.go:2128
        + #	0x100bc8cd7	bufio.(*Reader).fill+0xf7			/goroot/src/bufio/bufio.go:113
        + #	0x100bc8e3f	bufio.(*Reader).Peek+0x5f			/goroot/src/bufio/bufio.go:152
        + #	0x100e1b64b	net/http.(*persistConn).readLoop+0x12b		/goroot/src/net/http/transport.go:2281

        + 1 @ 0x100af7178 0x100ad5154 0x100e1cd5c 0x100affd24
        + #	0x100e1cd5b	net/http.(*persistConn).writeLoop+0x9b	/goroot/src/net/http/transport.go:2596
```

Updates #1253