### PR TITLE
Revert "ipn/ipnstate: add home DERP to tailscale status JSON"

### DIFF
--- a/ipn/ipnstate/ipnstate.go
+++ b/ipn/ipnstate/ipnstate.go
@@ -53,9 +53,6 @@ type Status struct {
 	// If nil, an exit node is not in use.
 	ExitNodeStatus *ExitNodeStatus `json:"ExitNodeStatus,omitempty"`
 
-	// DERPHomeRegionID is the current home DERP region ID.
-	DERPHomeRegionID int
-
 	// Health contains health check problems.
 	// Empty means everything is good. (or at least that no known
 	// problems are detected)

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -2892,15 +2892,11 @@ func (c *Conn) UpdateStatus(sb *ipnstate.StatusBuilder) {
 		})
 	}
 
-	sb.MutateStatus(func(s *ipnstate.Status) {
-		s.DERPHomeRegionID = c.myDerp
-		c.foreachActiveDerpSortedLocked(func(node int, ad activeDerp) {
-			// TODO(bradfitz): add a method to ipnstate.StatusBuilder
-			// to include all the DERP connections we have open
-			// and add it here. See the other caller of foreachActiveDerpSortedLocked.
-		})
+	c.foreachActiveDerpSortedLocked(func(node int, ad activeDerp) {
+		// TODO(bradfitz): add a method to ipnstate.StatusBuilder
+		// to include all the DERP connections we have open
+		// and add it here. See the other caller of foreachActiveDerpSortedLocked.
 	})
-
 }
 
 // SetStatistics specifies a per-connection statistics aggregator.


### PR DESCRIPTION
This reverts commit 476a4c6ff174d46ce3b125c018c07c43713e1c10.

Reason: redundant with `tailscale status --json | jq '.Self.Relay'`
which we all forgot about. Whoops.

Updates #15625
