### PR TITLE
hostinfo, ipnlocal: add optional os-specific callback for querying the system hostname

### DIFF
--- a/hostinfo/hostinfo.go
+++ b/hostinfo/hostinfo.go
@@ -43,7 +43,7 @@ func RegisterHostinfoNewHook(f func(*tailcfg.Hostinfo)) {
 
 // New returns a partially populated Hostinfo for the current host.
 func New() *tailcfg.Hostinfo {
-	hostname, _ := os.Hostname()
+	hostname, _ := Hostname()
 	hostname = dnsname.FirstLabel(hostname)
 	hi := &tailcfg.Hostinfo{
 		IPNVersion:      version.Long(),
@@ -508,4 +508,20 @@ func IsInVM86() bool {
 	return isV86Cache.Get(func() bool {
 		return New().DeviceModel == copyV86DeviceModel
 	})
+}
+
+var hostNameFn atomic.Value // of func() (string, error)
+
+// SetHostNameFn sets a custom function for querying the system hostname.
+func SetHostNameFn(fn func() (string, error)) {
+	hostNameFn.Store(fn)
+}
+
+// Hostname returns the system hostname using the function
+// set by SetHostNameFn or os.Hostname by default.
+func Hostname() (string, error) {
+	if fn, ok := hostNameFn.Load().(func() (string, error)); ok && fn != nil {
+		return fn()
+	}
+	return os.Hostname()
 }

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1329,7 +1329,7 @@ func (b *LocalBackend) UpdateStatus(sb *ipnstate.StatusBuilder) {
 			}
 
 		} else {
-			ss.HostName, _ = os.Hostname()
+			ss.HostName, _ = hostinfo.Hostname()
 		}
 		for _, pln := range b.peerAPIListeners {
 			ss.PeerAPIURL = append(ss.PeerAPIURL, pln.urlStr)


### PR DESCRIPTION
updates tailscale/tailscale#13476

On darwin, os.Hostname can be unreliable when called from a sandboxed process.  To fix this, we will allow clients to set an optional callback to query the hostname via an alternative native API like SystemConfiguration (on mac).

We will leave the default implementation as os.Hostname since this works perfectly well for everything besides sandboxed darwin clients.