### PR TITLE
ipn/ipn{ext,local}: allow extension lookup by name or type

### DIFF
--- a/ipn/ipnext/ipnext.go
+++ b/ipn/ipnext/ipnext.go
@@ -174,6 +174,9 @@ func DefinitionWithErrForTest(name string, err error) *Definition {
 //
 // A host must be safe for concurrent use.
 type Host interface {
+	// Extensions returns the host's [ExtensionServices].
+	Extensions() ExtensionServices
+
 	// Profiles returns the host's [ProfileServices].
 	Profiles() ProfileServices
 
@@ -195,6 +198,22 @@ type Host interface {
 	// control client is created. The returned function unregisters the callback.
 	// It is a runtime error to register a nil callback.
 	RegisterControlClientCallback(NewControlClientCallback) (unregister func())
+}
+
+// ExtensionServices provides access to the [Host]'s extension management services,
+// such as fetching active extensions.
+type ExtensionServices interface {
+	// FindExtensionByName returns an active extension with the given name,
+	// or nil if no such extension exists.
+	FindExtensionByName(name string) any
+
+	// FindMatchingExtension finds the first active extension that matches target,
+	// and if one is found, sets target to that extension and returns true.
+	// Otherwise, it returns false.
+	//
+	// It panics if target is not a non-nil pointer to either a type
+	// that implements [ipnext.Extension], or to any interface type.
+	FindMatchingExtension(target any) bool
 }
 
 // ProfileServices provides access to the [Host]'s profile management services,

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -589,6 +589,22 @@ func NewLocalBackend(logf logger.Logf, logID logid.PublicID, sys *tsd.System, lo
 	return b, nil
 }
 
+// FindExtensionByName returns an active extension with the given name,
+// or nil if no such extension exists.
+func (b *LocalBackend) FindExtensionByName(name string) any {
+	return b.extHost.Extensions().FindExtensionByName(name)
+}
+
+// FindMatchingExtension finds the first active extension that matches target,
+// and if one is found, sets target to that extension and returns true.
+// Otherwise, it returns false.
+//
+// It panics if target is not a non-nil pointer to either a type
+// that implements [ipnext.Extension], or to any interface type.
+func (b *LocalBackend) FindMatchingExtension(target any) bool {
+	return b.extHost.Extensions().FindMatchingExtension(target)
+}
+
 type componentLogState struct {
 	until time.Time
 	timer tstime.TimerController // if non-nil, the AfterFunc to disable it


### PR DESCRIPTION
In this PR, we add two methods to facilitate extension lookup by both extensions, and non-extensions (e.g., PeerAPI or LocalAPI handlers):
 - `FindExtensionByName` returns an extension with the specified name. It can then be type asserted to a given type.
 - `FindMatchingExtension` is like `errors.As`, but for extensions. It returns the first extension that matches the target type (either a specific extension or an interface).

Updates tailscale/corp#27645
Updates tailscale/corp#27502