### PR TITLE
k8s-operator: add Age column to all custom resources

### DIFF
--- a/cmd/k8s-operator/deploy/crds/tailscale.com_connectors.yaml
+++ b/cmd/k8s-operator/deploy/crds/tailscale.com_connectors.yaml
@@ -32,6 +32,9 @@ spec:
           jsonPath: .status.conditions[?(@.type == "ConnectorReady")].reason
           name: Status
           type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
       name: v1alpha1
       schema:
         openAPIV3Schema:

--- a/cmd/k8s-operator/deploy/crds/tailscale.com_dnsconfigs.yaml
+++ b/cmd/k8s-operator/deploy/crds/tailscale.com_dnsconfigs.yaml
@@ -20,6 +20,9 @@ spec:
           jsonPath: .status.nameserver.ip
           name: NameserverIP
           type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
       name: v1alpha1
       schema:
         openAPIV3Schema:

--- a/cmd/k8s-operator/deploy/crds/tailscale.com_proxyclasses.yaml
+++ b/cmd/k8s-operator/deploy/crds/tailscale.com_proxyclasses.yaml
@@ -18,6 +18,9 @@ spec:
           jsonPath: .status.conditions[?(@.type == "ProxyClassReady")].reason
           name: Status
           type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
       name: v1alpha1
       schema:
         openAPIV3Schema:

--- a/cmd/k8s-operator/deploy/crds/tailscale.com_proxygroups.yaml
+++ b/cmd/k8s-operator/deploy/crds/tailscale.com_proxygroups.yaml
@@ -24,6 +24,9 @@ spec:
           jsonPath: .spec.type
           name: Type
           type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
       name: v1alpha1
       schema:
         openAPIV3Schema:

--- a/cmd/k8s-operator/deploy/crds/tailscale.com_recorders.yaml
+++ b/cmd/k8s-operator/deploy/crds/tailscale.com_recorders.yaml
@@ -24,6 +24,9 @@ spec:
           jsonPath: .status.devices[?(@.url != "")].url
           name: URL
           type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
       name: v1alpha1
       schema:
         openAPIV3Schema:

--- a/cmd/k8s-operator/deploy/manifests/operator.yaml
+++ b/cmd/k8s-operator/deploy/manifests/operator.yaml
@@ -61,6 +61,9 @@ spec:
               jsonPath: .status.conditions[?(@.type == "ConnectorReady")].reason
               name: Status
               type: string
+            - jsonPath: .metadata.creationTimestamp
+              name: Age
+              type: date
           name: v1alpha1
           schema:
             openAPIV3Schema:
@@ -312,6 +315,9 @@ spec:
               jsonPath: .status.nameserver.ip
               name: NameserverIP
               type: string
+            - jsonPath: .metadata.creationTimestamp
+              name: Age
+              type: date
           name: v1alpha1
           schema:
             openAPIV3Schema:
@@ -492,6 +498,9 @@ spec:
               jsonPath: .status.conditions[?(@.type == "ProxyClassReady")].reason
               name: Status
               type: string
+            - jsonPath: .metadata.creationTimestamp
+              name: Age
+              type: date
           name: v1alpha1
           schema:
             openAPIV3Schema:
@@ -2803,6 +2812,9 @@ spec:
               jsonPath: .spec.type
               name: Type
               type: string
+            - jsonPath: .metadata.creationTimestamp
+              name: Age
+              type: date
           name: v1alpha1
           schema:
             openAPIV3Schema:
@@ -3013,6 +3025,9 @@ spec:
               jsonPath: .status.devices[?(@.url != "")].url
               name: URL
               type: string
+            - jsonPath: .metadata.creationTimestamp
+              name: Age
+              type: date
           name: v1alpha1
           schema:
             openAPIV3Schema:

--- a/k8s-operator/apis/v1alpha1/types_connector.go
+++ b/k8s-operator/apis/v1alpha1/types_connector.go
@@ -24,6 +24,7 @@ var ConnectorKind = "Connector"
 // +kubebuilder:printcolumn:name="IsExitNode",type="string",JSONPath=`.status.isExitNode`,description="Whether this Connector instance defines an exit node."
 // +kubebuilder:printcolumn:name="IsAppConnector",type="string",JSONPath=`.status.isAppConnector`,description="Whether this Connector instance is an app connector."
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=`.status.conditions[?(@.type == "ConnectorReady")].reason`,description="Status of the deployed Connector resources."
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Connector defines a Tailscale node that will be deployed in the cluster. The
 // node can be configured to act as a Tailscale subnet router and/or a Tailscale

--- a/k8s-operator/apis/v1alpha1/types_proxyclass.go
+++ b/k8s-operator/apis/v1alpha1/types_proxyclass.go
@@ -16,6 +16,7 @@ var ProxyClassKind = "ProxyClass"
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=`.status.conditions[?(@.type == "ProxyClassReady")].reason`,description="Status of the ProxyClass."
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // ProxyClass describes a set of configuration parameters that can be applied to
 // proxy resources created by the Tailscale Kubernetes operator.

--- a/k8s-operator/apis/v1alpha1/types_proxygroup.go
+++ b/k8s-operator/apis/v1alpha1/types_proxygroup.go
@@ -14,6 +14,7 @@ import (
 // +kubebuilder:resource:scope=Cluster,shortName=pg
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=`.status.conditions[?(@.type == "ProxyGroupReady")].reason`,description="Status of the deployed ProxyGroup resources."
 // +kubebuilder:printcolumn:name="Type",type="string",JSONPath=`.spec.type`,description="ProxyGroup type."
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // ProxyGroup defines a set of Tailscale devices that will act as proxies.
 // Currently only egress ProxyGroups are supported.

--- a/k8s-operator/apis/v1alpha1/types_recorder.go
+++ b/k8s-operator/apis/v1alpha1/types_recorder.go
@@ -15,6 +15,7 @@ import (
 // +kubebuilder:resource:scope=Cluster,shortName=rec
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=`.status.conditions[?(@.type == "RecorderReady")].reason`,description="Status of the deployed Recorder resources."
 // +kubebuilder:printcolumn:name="URL",type="string",JSONPath=`.status.devices[?(@.url != "")].url`,description="URL on which the UI is exposed if enabled."
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Recorder defines a tsrecorder device for recording SSH sessions. By default,
 // it will store recordings in a local ephemeral volume. If you want to persist

--- a/k8s-operator/apis/v1alpha1/types_tsdnsconfig.go
+++ b/k8s-operator/apis/v1alpha1/types_tsdnsconfig.go
@@ -18,6 +18,7 @@ var DNSConfigKind = "DNSConfig"
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,shortName=dc
 // +kubebuilder:printcolumn:name="NameserverIP",type="string",JSONPath=`.status.nameserver.ip`,description="Service IP address of the nameserver"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // DNSConfig can be deployed to cluster to make a subset of Tailscale MagicDNS
 // names resolvable by cluster workloads. Use this if: A) you need to refer to


### PR DESCRIPTION
This PR adds an 'Age' column to the ProxyGroup resource display in kubectl output.
The age is calculated from the resource's creation timestamp and will be displayed
in a human-readable format (e.g. "3h", "2d", etc.).

Changes:
- Added kubebuilder marker for the Age column in types_proxygroup.go
- The Age column uses the metadata.creationTimestamp field to calculate the resource's age

Fixes: #15499