### PR TITLE
cmd/natc: cleanup unused state

### DIFF
--- a/cmd/natc/ippool/ippool.go
+++ b/cmd/natc/ippool/ippool.go
@@ -24,7 +24,6 @@ var ErrNoIPsAvailable = errors.New("no IPs available")
 type IPPool struct {
 	perPeerMap syncs.Map[tailcfg.NodeID, *perPeerState]
 	IPSet      *netipx.IPSet
-	V6ULA      netip.Prefix
 }
 
 func (ipp *IPPool) DomainForIP(from tailcfg.NodeID, addr netip.Addr) (string, bool) {
@@ -44,7 +43,6 @@ func (ipp *IPPool) DomainForIP(from tailcfg.NodeID, addr netip.Addr) (string, bo
 func (ipp *IPPool) IPForDomain(from tailcfg.NodeID, domain string) (netip.Addr, error) {
 	npps := &perPeerState{
 		ipset: ipp.IPSet,
-		v6ULA: ipp.V6ULA,
 	}
 	ps, _ := ipp.perPeerMap.LoadOrStore(from, npps)
 	return ps.ipForDomain(domain)
@@ -52,7 +50,6 @@ func (ipp *IPPool) IPForDomain(from tailcfg.NodeID, domain string) (netip.Addr, 
 
 // perPeerState holds the state for a single peer.
 type perPeerState struct {
-	v6ULA netip.Prefix
 	ipset *netipx.IPSet
 
 	mu           sync.Mutex

--- a/cmd/natc/ippool/ippool_test.go
+++ b/cmd/natc/ippool/ippool_test.go
@@ -19,8 +19,7 @@ func TestIPPoolExhaustion(t *testing.T) {
 	var ipsb netipx.IPSetBuilder
 	ipsb.AddPrefix(smallPrefix)
 	addrPool := must.Get(ipsb.IPSet())
-	v6ULA := netip.MustParsePrefix("fd7a:115c:a1e0:a99c:0001::/80")
-	pool := IPPool{V6ULA: v6ULA, IPSet: addrPool}
+	pool := IPPool{IPSet: addrPool}
 
 	assignedIPs := make(map[netip.Addr]string)
 
@@ -52,9 +51,6 @@ func TestIPPoolExhaustion(t *testing.T) {
 		if addr.Is4() && !smallPrefix.Contains(addr) {
 			t.Errorf("IP %s for domain %q not in expected range %s", addr, domain, smallPrefix)
 		}
-		if addr.Is6() && !v6ULA.Contains(addr) {
-			t.Errorf("IP %s for domain %q not in expected range %s", addr, domain, v6ULA)
-		}
 	}
 
 	// expect one error for each iteration with the 5th domain
@@ -73,7 +69,6 @@ func TestIPPool(t *testing.T) {
 	ipsb.AddPrefix(netip.MustParsePrefix("100.64.1.0/24"))
 	addrPool := must.Get(ipsb.IPSet())
 	pool := IPPool{
-		V6ULA: netip.MustParsePrefix("fd7a:115c:a1e0:a99c:0001::/80"),
 		IPSet: addrPool,
 	}
 	from := tailcfg.NodeID(12345)

--- a/cmd/natc/natc.go
+++ b/cmd/natc/natc.go
@@ -153,7 +153,7 @@ func main() {
 		whois:      lc,
 		v6ULA:      v6ULA,
 		ignoreDsts: ignoreDstTable,
-		ipPool:     &ippool.IPPool{V6ULA: v6ULA, IPSet: addrPool},
+		ipPool:     &ippool.IPPool{IPSet: addrPool},
 		routes:     routes,
 		dnsAddr:    dnsAddr,
 		resolver:   net.DefaultResolver,

--- a/cmd/natc/natc_test.go
+++ b/cmd/natc/natc_test.go
@@ -270,7 +270,7 @@ func TestDNSResponse(t *testing.T) {
 		ignoreDsts: &bart.Table[bool]{},
 		routes:     routes,
 		v6ULA:      v6ULA,
-		ipPool:     &ippool.IPPool{V6ULA: v6ULA, IPSet: addrPool},
+		ipPool:     &ippool.IPPool{IPSet: addrPool},
 		dnsAddr:    dnsAddr,
 	}
 	c.ignoreDsts.Insert(netip.MustParsePrefix("8.8.4.4/32"), true)


### PR DESCRIPTION
perPeerState no longer needs to know the v6ULA.

Updates #14667