### PR TITLE
control/controlhttp: replace default go user-agent

### DIFF
--- a/control/controlhttp/client.go
+++ b/control/controlhttp/client.go
@@ -595,6 +595,7 @@ func (a *Dialer) tryURLUpgrade(ctx context.Context, u *url.URL, optAddr netip.Ad
 			"Upgrade":                             []string{controlhttpcommon.UpgradeHeaderValue},
 			"Connection":                          []string{"upgrade"},
 			controlhttpcommon.HandshakeHeaderName: []string{base64.StdEncoding.EncodeToString(init)},
+			"User-Agent":                          []string{getUserAgent()},
 		},
 	}
 	req = req.WithContext(ctx)

--- a/control/controlhttp/constants.go
+++ b/control/controlhttp/constants.go
@@ -17,6 +17,7 @@ import (
 	"tailscale.com/tstime"
 	"tailscale.com/types/key"
 	"tailscale.com/types/logger"
+	"tailscale.com/version"
 )
 
 const (
@@ -113,4 +114,8 @@ func strDef(v1, v2 string) string {
 		return v1
 	}
 	return v2
+}
+
+func getUserAgent() string {
+	return "Tailscale/" + version.Short()
 }


### PR DESCRIPTION
Most WAF rules disable default Go user agent as it's too generic. This commit replacing the default Go user agent (Go-http-client) with "Tailscale/<version>".