### PR TITLE
wgengine/netstack: revert cubic cc to reno cc (#15677)

### DIFF
--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -326,10 +326,15 @@ func Create(logf logger.Logf, tundev *tstun.Wrapper, e wgengine.Engine, mc *magi
 	if tcpipErr != nil {
 		return nil, fmt.Errorf("could not disable TCP RACK: %v", tcpipErr)
 	}
-	cubicOpt := tcpip.CongestionControlOption("cubic")
-	tcpipErr = ipstack.SetTransportProtocolOption(tcp.ProtocolNumber, &cubicOpt)
+	// gVisor defaults to reno at the time of writing. We explicitly set reno
+	// congestion control in order to prevent unexpected changes. Netstack
+	// has an int overflow in sender congestion window arithmetic that is more
+	// prone to trigger with cubic congestion control.
+	// See https://github.com/google/gvisor/issues/11632
+	renoOpt := tcpip.CongestionControlOption("reno")
+	tcpipErr = ipstack.SetTransportProtocolOption(tcp.ProtocolNumber, &renoOpt)
 	if tcpipErr != nil {
-		return nil, fmt.Errorf("could not set cubic congestion control: %v", tcpipErr)
+		return nil, fmt.Errorf("could not set reno congestion control: %v", tcpipErr)
 	}
 	err := setTCPBufSizes(ipstack)
 	if err != nil {


### PR DESCRIPTION
Cherry-picked from 62182fc37d44c0a8185b7d96f30465710dd68b66.

Updates google/gvisor#11632
Updates tailscale/corp#27717