### PR TITLE
ipn/ipnlocal: use MagicDNSName of the current profile instead of generating a full ipnstate.Status

### DIFF
--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -632,7 +632,7 @@ func (b *LocalBackend) getServeHandler(r *http.Request) (_ ipn.HTTPHandlerView, 
 
 	hostname := r.Host
 	if r.TLS == nil {
-		tcd := "." + b.Status().CurrentTailnet.MagicDNSSuffix
+		tcd := "." + b.CurrentProfile().NetworkProfile().MagicDNSName
 		if host, _, err := net.SplitHostPort(hostname); err == nil {
 			hostname = host
 		}


### PR DESCRIPTION
Both are populated from the current netmap's `MagicDNSSuffix`. But building a full `ipnstate.Status` (with peers!) is expensive and unnecessary.

Updates #cleanup