### PR TITLE
feature/relayserver: use PeerAPIHandler.Logf()

### DIFF
--- a/feature/relayserver/relayserver.go
+++ b/feature/relayserver/relayserver.go
@@ -142,7 +142,7 @@ func handlePeerAPIRelayAllocateEndpoint(h ipnlocal.PeerAPIHandler, w http.Respon
 
 	httpErrAndLog := func(message string, code int) {
 		http.Error(w, message, code)
-		e.logf("peerapi: request from %v returned code %d: %s", h.RemoteAddr(), code, message)
+		h.Logf("relayserver: request from %v returned code %d: %s", h.RemoteAddr(), code, message)
 	}
 
 	if !h.PeerCaps().HasCapability(tailcfg.PeerCapabilityRelay) {


### PR DESCRIPTION
This was recently added, use it to be consistent.

Updates tailscale/corp#27502