### PR TITLE
net/portmapper: fix nil pointer dereference in Client.createMapping

### DIFF
--- a/net/portmapper/portmapper.go
+++ b/net/portmapper/portmapper.go
@@ -508,11 +508,13 @@ func (c *Client) createMapping() {
 		}
 		return
 	}
-	c.updates.Publish(Mapping{
-		External:  mapping.External(),
-		Type:      mapping.MappingType(),
-		GoodUntil: mapping.GoodUntil(),
-	})
+	if c.updates != nil {
+		c.updates.Publish(Mapping{
+			External:  mapping.External(),
+			Type:      mapping.MappingType(),
+			GoodUntil: mapping.GoodUntil(),
+		})
+	}
 	if c.onChange != nil {
 		go c.onChange()
 	}


### PR DESCRIPTION
The `EventBus` in `net/portmapper.Config` is still optional and `Client.updates` can be `nil`.

Updates #15772