### PR TITLE
ipn/ipnlocal: use tsd.NewSystem instead of &tsd.System in a few more tests

### DIFF
--- a/ipn/ipnlocal/extension_host_test.go
+++ b/ipn/ipnlocal/extension_host_test.go
@@ -284,7 +284,7 @@ func TestNewExtensionHost(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			logf := tstest.WhileTestRunningLogger(t)
-			h, err := NewExtensionHost(logf, &tsd.System{}, &testBackend{}, tt.defs...)
+			h, err := NewExtensionHost(logf, tsd.NewSystem(), &testBackend{}, tt.defs...)
 			if gotErr := err != nil; gotErr != tt.wantErr {
 				t.Errorf("NewExtensionHost: gotErr %v(%v); wantErr %v", gotErr, err, tt.wantErr)
 			}
@@ -1118,7 +1118,7 @@ func newExtensionHostForTest[T ipnext.Extension](t *testing.T, b Backend, initia
 		}
 		defs[i] = ipnext.DefinitionForTest(ext)
 	}
-	h, err := NewExtensionHost(logf, &tsd.System{}, b, defs...)
+	h, err := NewExtensionHost(logf, tsd.NewSystem(), b, defs...)
 	if err != nil {
 		t.Fatalf("NewExtensionHost: %v", err)
 	}

--- a/ipn/ipnlocal/state_test.go
+++ b/ipn/ipnlocal/state_test.go
@@ -1397,7 +1397,7 @@ func newLocalBackendWithMockEngineAndControl(t *testing.T, enableLogging bool) (
 	dialer := &tsdial.Dialer{Logf: logf}
 	dialer.SetNetMon(netmon.NewStatic())
 
-	sys := &tsd.System{}
+	sys := tsd.NewSystem()
 	sys.Set(dialer)
 	sys.Set(dialer.NetMon())
 


### PR DESCRIPTION
These were likely added after everything else was updated to use `tsd.NewSystem`, in a feature branch, and before it was merged back into main.

Updates #15160