### PR TITLE
net/udprelay: change Server.AllocateEndpoint existing alloc strategy

### DIFF
--- a/net/udprelay/server_test.go
+++ b/net/udprelay/server_test.go
@@ -174,8 +174,7 @@ func TestServer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// We expect the same endpoint details as the 3-way bind handshake has not
-	// yet been completed for both relay client parties.
+	// We expect the same endpoint details pre-handshake.
 	if diff := cmp.Diff(dupEndpoint, endpoint, cmpopts.EquateComparable(netip.AddrPort{}, key.DiscoPublic{})); diff != "" {
 		t.Fatalf("wrong dupEndpoint (-got +want)\n%s", diff)
 	}
@@ -190,6 +189,15 @@ func TestServer(t *testing.T) {
 
 	tcA.handshake(t)
 	tcB.handshake(t)
+
+	dupEndpoint, err = server.AllocateEndpoint(discoA.Public(), discoB.Public())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// We expect the same endpoint details post-handshake.
+	if diff := cmp.Diff(dupEndpoint, endpoint, cmpopts.EquateComparable(netip.AddrPort{}, key.DiscoPublic{})); diff != "" {
+		t.Fatalf("wrong dupEndpoint (-got +want)\n%s", diff)
+	}
 
 	txToB := []byte{1, 2, 3}
 	tcA.writeDataPkt(t, txToB)


### PR DESCRIPTION
The previous strategy assumed clients maintained adequate state to understand the relationship between endpoint allocation and the server it was allocated on.

magicsock will not have awareness of the server's disco key pre-allocation, it only understands peerAPI address at this point. The second client to allocate on the same server could trigger re-allocation, breaking a functional relay server endpoint.

If magicsock needs to force reallocation we can add opt-in behaviors for this later.

Updates tailscale/corp#27502