### PR TITLE
tstest/integration: remove vestigial env var set in tests

### DIFF
--- a/tstest/integration/integration.go
+++ b/tstest/integration/integration.go
@@ -684,7 +684,6 @@ func (n *TestNode) StartDaemonAsIPNGOOS(ipnGOOS string) *Daemon {
 		cmd.Args = append(cmd.Args, "--config="+n.configFile)
 	}
 	cmd.Env = append(os.Environ(),
-		"TS_CONTROL_IS_PLAINTEXT_HTTP=1",
 		"TS_DEBUG_PERMIT_HTTP_C2N=1",
 		"TS_LOG_TARGET="+n.env.LogCatcherServer.URL,
 		"HTTP_PROXY="+n.env.TrafficTrapServer.URL,


### PR DESCRIPTION
TS_CONTROL_IS_PLAINTEXT_HTTP no longer does anything as of
8fd471ce5748d2129dba584b4fa14b0d29229299

Updates #13597
