### PR TITLE
tool/gocross: break circular dependency on tailcfg

### DIFF
--- a/tool/gocross/gocross_test.go
+++ b/tool/gocross/gocross_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package main
+
+import (
+	"testing"
+
+	"tailscale.com/tstest/deptest"
+)
+
+func TestDeps(t *testing.T) {
+	deptest.DepChecker{
+		BadDeps: map[string]string{
+			"tailscale.com/tailcfg": "circular dependency via go generate",
+			"tailscale.com/version": "circular dependency via go generate",
+		},
+	}.Check(t)
+}


### PR DESCRIPTION
Instead of using the version package (which depends on tailcfg.CurrentCapabilityVersion) to get the git commit hash, do it directly using debug.BuildInfo. This way, when changing struct fields in tailcfg, we can successfully `go generate` it without compiler errors.

Updates #9634
Updates https://github.com/tailscale/corp/issues/26717