### PR TITLE
ipn/ipnlocal: fix Taildrop regression from refactoring

### DIFF
--- a/ipn/ipnlocal/taildrop.go
+++ b/ipn/ipnlocal/taildrop.go
@@ -194,8 +194,8 @@ func (b *LocalBackend) FileTargets() ([]*apitype.FileTarget, error) {
 		if !p.Valid() || p.Hostinfo().OS() == "tvOS" {
 			return false
 		}
-		if self != p.User() {
-			return false
+		if self == p.User() {
+			return true
 		}
 		if p.Addresses().Len() != 0 && cn.PeerHasCap(p.Addresses().At(0).Addr(), tailcfg.PeerCapabilityFileSharingTarget) {
 			// Explicitly noted in the netmap ACL caps as a target.


### PR DESCRIPTION
This fixes a refactoring bug introduced in 8b72dd7873201

Tests (that failed on this) are coming in a separate change.

Updates #15812
