### PR TITLE
cmd/tsidp: remove backticks in README in shell example

### DIFF
--- a/cmd/tsidp/README.md
+++ b/cmd/tsidp/README.md
@@ -35,7 +35,7 @@
 
    ```bash
    docker run -d \
-     --name `tsidp` \
+     --name tsidp \
      -p 443:443 \
      -e TS_AUTHKEY=YOUR_TAILSCALE_AUTHKEY \
      -e TS_HOSTNAME=idp \


### PR DESCRIPTION
Fixes #15818
