### PR TITLE
ipn/ipnlocal, tailcfg: add MagicDNS opt-in attr for IPv6 AAAA records

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -5056,6 +5056,8 @@ func dnsConfigForNetmap(nm *netmap.NetworkMap, peers map[tailcfg.NodeID]tailcfg.
 		!nm.GetAddresses().ContainsFunc(tsaddr.PrefixIs4)
 	dcfg.OnlyIPv6 = selfV6Only
 
+	wantAAAA := nm.AllCaps.Contains(tailcfg.NodeAttrMagicDNSPeerAAAA)
+
 	// Populate MagicDNS records. We do this unconditionally so that
 	// quad-100 can always respond to MagicDNS queries, even if the OS
 	// isn't configured to make MagicDNS resolution truly
@@ -5092,7 +5094,7 @@ func dnsConfigForNetmap(nm *netmap.NetworkMap, peers map[tailcfg.NodeID]tailcfg.
 			// https://github.com/tailscale/tailscale/issues/1152
 			// tracks adding the right capability reporting to
 			// enable AAAA in MagicDNS.
-			if addr.Addr().Is6() && have4 {
+			if addr.Addr().Is6() && have4 && !wantAAAA {
 				continue
 			}
 			ips = append(ips, addr.Addr())

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -160,7 +160,8 @@ type CapabilityVersion int
 //   - 113: 2025-01-20: Client communicates to control whether funnel is enabled by sending Hostinfo.IngressEnabled (#14688)
 //   - 114: 2025-01-30: NodeAttrMaxKeyDuration CapMap defined, clients might use it (no tailscaled code change) (#14829)
 //   - 115: 2025-03-07: Client understands DERPRegion.NoMeasureNoHome.
-const CurrentCapabilityVersion CapabilityVersion = 115
+//   - 116: 2025-05-05: Client serves MagicDNS "AAAA" if NodeAttrMagicDNSPeerAAAA set on self node
+const CurrentCapabilityVersion CapabilityVersion = 116
 
 // ID is an integer ID for a user, node, or login allocated by the
 // control plane.
@@ -2493,6 +2494,10 @@ const (
 	// NodeAttrRelayClient permits the node to act as an underlay UDP relay
 	// client. There are no expected values for this key in NodeCapMap.
 	NodeAttrRelayClient NodeCapability = "relay:client"
+
+	// NodeAttrMagicDNSPeerAAAA is a capability that tells the node's MagicDNS
+	// server to answer AAAA queries about its peers. See tailscale/tailscale#1152.
+	NodeAttrMagicDNSPeerAAAA NodeCapability = "magicdns-aaaa"
 )
 
 // SetDNSRequest is a request to add a DNS record.


### PR DESCRIPTION
Until we turn on AAAA by default (which might make some people rely on
Happy Eyeballs for targets without IPv6), this lets people turn it on
explicitly if they want.

We still should add a peer cap as well in the future to let a peer
explicitly say that it's cool with IPv6.

Related: https://github.com/tailscale/tailscale/pull/9574

Updates #1813
Updaets #1152
