### PR TITLE
cmd/tailscale/cli: omit "file" subcommand if taildrop is omitted from build

### DIFF
--- a/cmd/tailscale/cli/cli.go
+++ b/cmd/tailscale/cli/cli.go
@@ -207,6 +207,8 @@ func noDupFlagify(c *ffcli.Command) {
 	}
 }
 
+var fileCmd func() *ffcli.Command
+
 func newRootCmd() *ffcli.Command {
 	rootfs := newFlagSet("tailscale")
 	rootfs.Func("socket", "path to tailscaled socket", func(s string) error {
@@ -247,7 +249,7 @@ change in the future.
 			serveCmd(),
 			versionCmd,
 			webCmd,
-			fileCmd,
+			nilOrCall(fileCmd),
 			bugReportCmd,
 			certCmd,
 			netlockCmd,
@@ -284,6 +286,13 @@ change in the future.
 
 func nonNilCmds(cmds ...*ffcli.Command) []*ffcli.Command {
 	return slicesx.AppendNonzero(cmds[:0], cmds)
+}
+
+func nilOrCall(f func() *ffcli.Command) *ffcli.Command {
+	if f == nil {
+		return nil
+	}
+	return f()
 }
 
 func fatalf(format string, a ...any) {

--- a/cmd/tailscale/cli/file.go
+++ b/cmd/tailscale/cli/file.go
@@ -1,6 +1,8 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
+//go:build !ts_omit_taildrop
+
 package cli
 
 import (
@@ -38,14 +40,20 @@ import (
 	"tailscale.com/version"
 )
 
-var fileCmd = &ffcli.Command{
-	Name:       "file",
-	ShortUsage: "tailscale file <cp|get> ...",
-	ShortHelp:  "Send or receive files",
-	Subcommands: []*ffcli.Command{
-		fileCpCmd,
-		fileGetCmd,
-	},
+func init() {
+	fileCmd = getFileCmd
+}
+
+func getFileCmd() *ffcli.Command {
+	return &ffcli.Command{
+		Name:       "file",
+		ShortUsage: "tailscale file <cp|get> ...",
+		ShortHelp:  "Send or receive files",
+		Subcommands: []*ffcli.Command{
+			fileCpCmd,
+			fileGetCmd,
+		},
+	}
 }
 
 type countingReader struct {


### PR DESCRIPTION
Updates #15812
Updates #12614
