### PR TITLE
util/linuxfw: add new netfilter rules for HA ingresses

### DIFF
--- a/util/linuxfw/fake_netfilter.go
+++ b/util/linuxfw/fake_netfilter.go
@@ -1,0 +1,95 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build linux
+
+package linuxfw
+
+import (
+	"net/netip"
+
+	"tailscale.com/types/logger"
+)
+
+// FakeNetfilterRunner is a fake netfilter runner for tests.
+type FakeNetfilterRunner struct {
+	// services is a map that tracks the firewall rules added/deleted via
+	// EnsureDNATRuleForSvc/DeleteDNATRuleForSvc.
+	services map[string]struct {
+		VIPServiceIP netip.Addr
+		ClusterIP    netip.Addr
+	}
+}
+
+// NewFakeNetfilterRunner creates a new FakeNetfilterRunner.
+func NewFakeNetfilterRunner() *FakeNetfilterRunner {
+	return &FakeNetfilterRunner{
+		services: make(map[string]struct {
+			VIPServiceIP netip.Addr
+			ClusterIP    netip.Addr
+		}),
+	}
+}
+
+func (f *FakeNetfilterRunner) EnsureDNATRuleForSvc(svcName string, origDst, dst netip.Addr) error {
+	f.services[svcName] = struct {
+		VIPServiceIP netip.Addr
+		ClusterIP    netip.Addr
+	}{origDst, dst}
+	return nil
+}
+
+func (f *FakeNetfilterRunner) DeleteDNATRuleForSvc(svcName string, origDst, dst netip.Addr) error {
+	delete(f.services, svcName)
+	return nil
+}
+
+func (f *FakeNetfilterRunner) GetServiceState() map[string]struct {
+	VIPServiceIP netip.Addr
+	ClusterIP    netip.Addr
+} {
+	return f.services
+}
+
+func (f *FakeNetfilterRunner) HasIPV6() bool {
+	return true
+}
+
+func (f *FakeNetfilterRunner) HasIPV6Filter() bool {
+	return true
+}
+
+func (f *FakeNetfilterRunner) HasIPV6NAT() bool {
+	return true
+}
+
+func (f *FakeNetfilterRunner) AddBase(tunname string) error              { return nil }
+func (f *FakeNetfilterRunner) DelBase() error                            { return nil }
+func (f *FakeNetfilterRunner) AddChains() error                          { return nil }
+func (f *FakeNetfilterRunner) DelChains() error                          { return nil }
+func (f *FakeNetfilterRunner) AddHooks() error                           { return nil }
+func (f *FakeNetfilterRunner) DelHooks(logf logger.Logf) error           { return nil }
+func (f *FakeNetfilterRunner) AddSNATRule() error                        { return nil }
+func (f *FakeNetfilterRunner) DelSNATRule() error                        { return nil }
+func (f *FakeNetfilterRunner) AddStatefulRule(tunname string) error      { return nil }
+func (f *FakeNetfilterRunner) DelStatefulRule(tunname string) error      { return nil }
+func (f *FakeNetfilterRunner) AddLoopbackRule(addr netip.Addr) error     { return nil }
+func (f *FakeNetfilterRunner) DelLoopbackRule(addr netip.Addr) error     { return nil }
+func (f *FakeNetfilterRunner) AddDNATRule(origDst, dst netip.Addr) error { return nil }
+func (f *FakeNetfilterRunner) DNATWithLoadBalancer(origDst netip.Addr, dsts []netip.Addr) error {
+	return nil
+}
+func (f *FakeNetfilterRunner) EnsureSNATForDst(src, dst netip.Addr) error               { return nil }
+func (f *FakeNetfilterRunner) DNATNonTailscaleTraffic(tun string, dst netip.Addr) error { return nil }
+func (f *FakeNetfilterRunner) ClampMSSToPMTU(tun string, addr netip.Addr) error         { return nil }
+func (f *FakeNetfilterRunner) AddMagicsockPortRule(port uint16, network string) error   { return nil }
+func (f *FakeNetfilterRunner) DelMagicsockPortRule(port uint16, network string) error   { return nil }
+func (f *FakeNetfilterRunner) DeletePortMapRuleForSvc(svc, tun string, targetIP netip.Addr, pm PortMap) error {
+	return nil
+}
+func (f *FakeNetfilterRunner) DeleteSvc(svc, tun string, targetIPs []netip.Addr, pms []PortMap) error {
+	return nil
+}
+func (f *FakeNetfilterRunner) EnsurePortMapRuleForSvc(svc, tun string, targetIP netip.Addr, pm PortMap) error {
+	return nil
+}

--- a/util/linuxfw/iptables_for_svcs_test.go
+++ b/util/linuxfw/iptables_for_svcs_test.go
@@ -153,6 +153,135 @@ func Test_iptablesRunner_DeleteSvc(t *testing.T) {
 	svcMustExist(t, "svc2", map[string][]string{v4Addr.String(): s2R1, v6Addr.String(): s2R2}, iptr)
 }
 
+func Test_iptablesRunner_EnsureDNATRuleForSvc(t *testing.T) {
+	v4OrigDst := netip.MustParseAddr("10.0.0.1")
+	v4Target := netip.MustParseAddr("10.0.0.2")
+	v6OrigDst := netip.MustParseAddr("fd7a:115c:a1e0::1")
+	v6Target := netip.MustParseAddr("fd7a:115c:a1e0::2")
+	v4Rule := argsForIngressRule("svc:test", v4OrigDst, v4Target)
+
+	tests := []struct {
+		name              string
+		svcName           string
+		origDst           netip.Addr
+		targetIP          netip.Addr
+		precreateSvcRules [][]string
+	}{
+		{
+			name:     "dnat_for_ipv4",
+			svcName:  "svc:test",
+			origDst:  v4OrigDst,
+			targetIP: v4Target,
+		},
+		{
+			name:     "dnat_for_ipv6",
+			svcName:  "svc:test-2",
+			origDst:  v6OrigDst,
+			targetIP: v6Target,
+		},
+		{
+			name:              "add_existing_rule",
+			svcName:           "svc:test",
+			origDst:           v4OrigDst,
+			targetIP:          v4Target,
+			precreateSvcRules: [][]string{v4Rule},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iptr := NewFakeIPTablesRunner()
+			table := iptr.getIPTByAddr(tt.targetIP)
+			for _, ruleset := range tt.precreateSvcRules {
+				mustPrecreateDNATRule(t, ruleset, table)
+			}
+			if err := iptr.EnsureDNATRuleForSvc(tt.svcName, tt.origDst, tt.targetIP); err != nil {
+				t.Errorf("[unexpected error] iptablesRunner.EnsureDNATRuleForSvc() = %v", err)
+			}
+			args := argsForIngressRule(tt.svcName, tt.origDst, tt.targetIP)
+			exists, err := table.Exists("nat", "PREROUTING", args...)
+			if err != nil {
+				t.Fatalf("error checking if rule exists: %v", err)
+			}
+			if !exists {
+				t.Errorf("expected rule was not created")
+			}
+		})
+	}
+}
+
+func Test_iptablesRunner_DeleteDNATRuleForSvc(t *testing.T) {
+	v4OrigDst := netip.MustParseAddr("10.0.0.1")
+	v4Target := netip.MustParseAddr("10.0.0.2")
+	v6OrigDst := netip.MustParseAddr("fd7a:115c:a1e0::1")
+	v6Target := netip.MustParseAddr("fd7a:115c:a1e0::2")
+	v4Rule := argsForIngressRule("svc:test", v4OrigDst, v4Target)
+	v6Rule := argsForIngressRule("svc:test", v6OrigDst, v6Target)
+
+	tests := []struct {
+		name              string
+		svcName           string
+		origDst           netip.Addr
+		targetIP          netip.Addr
+		precreateSvcRules [][]string
+	}{
+		{
+			name:              "multiple_rules_ipv4_deleted",
+			svcName:           "svc:test",
+			origDst:           v4OrigDst,
+			targetIP:          v4Target,
+			precreateSvcRules: [][]string{v4Rule, v6Rule},
+		},
+		{
+			name:              "multiple_rules_ipv6_deleted",
+			svcName:           "svc:test",
+			origDst:           v6OrigDst,
+			targetIP:          v6Target,
+			precreateSvcRules: [][]string{v4Rule, v6Rule},
+		},
+		{
+			name:              "non-existent_rule_deleted",
+			svcName:           "svc:test",
+			origDst:           v4OrigDst,
+			targetIP:          v4Target,
+			precreateSvcRules: [][]string{v6Rule},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iptr := NewFakeIPTablesRunner()
+			table := iptr.getIPTByAddr(tt.targetIP)
+			for _, ruleset := range tt.precreateSvcRules {
+				mustPrecreateDNATRule(t, ruleset, table)
+			}
+			if err := iptr.DeleteDNATRuleForSvc(tt.svcName, tt.origDst, tt.targetIP); err != nil {
+				t.Errorf("iptablesRunner.DeleteDNATRuleForSvc() errored: %v ", err)
+			}
+			deletedRule := argsForIngressRule(tt.svcName, tt.origDst, tt.targetIP)
+			exists, err := table.Exists("nat", "PREROUTING", deletedRule...)
+			if err != nil {
+				t.Fatalf("error verifying that rule does not exist after deletion: %v", err)
+			}
+			if exists {
+				t.Errorf("DNAT rule exists after deletion")
+			}
+		})
+	}
+}
+
+func mustPrecreateDNATRule(t *testing.T, rules []string, table iptablesInterface) {
+	t.Helper()
+	exists, err := table.Exists("nat", "PREROUTING", rules...)
+	if err != nil {
+		t.Fatalf("error ensuring that nat PREROUTING table exists: %v", err)
+	}
+	if exists {
+		return
+	}
+	if err := table.Append("nat", "PREROUTING", rules...); err != nil {
+		t.Fatalf("error precreating DNAT rule: %v", err)
+	}
+}
+
 func svcMustExist(t *testing.T, svcName string, rules map[string][]string, iptr *iptablesRunner) {
 	t.Helper()
 	for dst, ruleset := range rules {

--- a/wgengine/router/router_linux_test.go
+++ b/wgengine/router/router_linux_test.go
@@ -557,6 +557,14 @@ func (n *fakeIPTablesRunner) ClampMSSToPMTU(tun string, addr netip.Addr) error {
 	return errors.New("not implemented")
 }
 
+func (n *fakeIPTablesRunner) EnsureDNATRuleForSvc(svcName string, origDst, dst netip.Addr) error {
+	return errors.New("not implemented")
+}
+
+func (n *fakeIPTablesRunner) DeleteDNATRuleForSvc(svcName string, origDst, dst netip.Addr) error {
+	return errors.New("not implemented")
+}
+
 func (n *fakeIPTablesRunner) addBase4(tunname string) error {
 	curIPT := n.ipt4
 	newRules := []struct{ chain, rule string }{


### PR DESCRIPTION
Add new rules to update DNAT rules for Kubernetes operator's HA ingress where it's expected that rules will be added/removed frequently (so we don't want to keep old rules around or rewrite existing rules unnecessarily):
- allow deleting DNAT rules using metadata lookup
- allow inserting DNAT rules if they don't already exist (using metadata lookup)


The full working L3 HA ingress is at https://github.com/tailscale/tailscale/tree/irbekrm/ingress_services

Updates tailscale/tailscale#15895