### PR TITLE
control/controlclient: send optional ConnectionHandleForTest with map requests

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -1385,6 +1385,12 @@ type MapRequest struct {
 	//     * "warn-router-unhealthy": client's Router implementation is
 	//       having problems.
 	DebugFlags []string `json:",omitempty"`
+
+	// ConnectionHandleForTest, if non-empty, is an opaque string sent by the client that
+	// identifies this specific connection to the server. The server may choose to
+	// use this handle to identify the connection for debugging or testing
+	// purposes. It has no semantic meaning.
+	ConnectionHandleForTest string `json:",omitempty"`
 }
 
 // PortRange represents a range of UDP or TCP port numbers.


### PR DESCRIPTION
This handle can be used in tests and debugging to identify the specific
client connection.

Updates tailscale/corp#28368

Change-Id: I48cc573fc0bcf018c66a18e67ad6c4f248fb760c
Signed-off-by: Brian Palmer <brianp@tailscale.com>