### PR TITLE
cmd/derpprobe: exit with non-zero status if --once fails

### DIFF
--- a/cmd/derpprobe/derpprobe.go
+++ b/cmd/derpprobe/derpprobe.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"sort"
 	"time"
 
@@ -74,6 +75,9 @@ func main() {
 		}
 		for _, s := range st.bad {
 			log.Printf("bad: %s", s)
+		}
+		if len(st.bad) > 0 {
+			os.Exit(1)
 		}
 		return
 	}


### PR DESCRIPTION
`cmd/derpprobe --once` didn’t respect the convention of non-zero exit status for a failed run. It would always exit zero (i.e. success), even. This patch fixes that, but only for `--once` mode.

Fixes: #15925