### PR TITLE
safeweb: Set Cross-Origin-Opener-Policy for browser requests

### DIFF
--- a/safeweb/http.go
+++ b/safeweb/http.go
@@ -376,6 +376,7 @@ func (s *Server) serveBrowser(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Security-Policy", s.csp)
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("Referer-Policy", "same-origin")
+	w.Header().Set("Cross-Origin-Opener-Policy", "same-origin")
 	if s.SecureContext {
 		w.Header().Set("Strict-Transport-Security", cmp.Or(s.StrictTransportSecurityOptions, DefaultStrictTransportSecurityOptions))
 	}


### PR DESCRIPTION
Set Cross-Origin-Opener-Policy: same-origin for all browser requests to
prevent window.location manipulation by malicious origins.

Updates tailscale/corp#28480

Thank you to Triet H.M. Pham for the report.

Signed-off-by: Patrick O'Doherty <patrick@tailscale.com>