### PR TITLE
ipn/ipnlocal,wgengine: move (*tsdial.Dialer).SetRoutes() calls from LocalBackend to userspaceEngine

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -64,7 +64,6 @@ import (
 	"tailscale.com/logpolicy"
 	"tailscale.com/net/captivedetection"
 	"tailscale.com/net/dns"
-	"tailscale.com/net/dns/resolver"
 	"tailscale.com/net/dnscache"
 	"tailscale.com/net/dnsfallback"
 	"tailscale.com/net/ipset"
@@ -4843,12 +4842,6 @@ func (b *LocalBackend) authReconfig() {
 		return
 	}
 	b.logf("[v1] authReconfig: ra=%v dns=%v 0x%02x: %v", prefs.RouteAll(), prefs.CorpDNS(), flags, err)
-
-	if resolver.ShouldUseRoutes(b.ControlKnobs()) {
-		b.dialer.SetRoutes(rcfg.Routes, rcfg.LocalRoutes)
-	} else {
-		b.dialer.SetRoutes(nil, nil)
-	}
 
 	b.initPeerAPIListener()
 	b.readvertiseAppConnectorRoutes()


### PR DESCRIPTION
This avoids reconfiguring the dialer unless the router config has changed.

Updates #12027