### PR TITLE
feature/taildrop,ipn/ipn{ext,local}: initialize taildrop for initial profile

### DIFF
--- a/feature/taildrop/ext.go
+++ b/feature/taildrop/ext.go
@@ -100,6 +100,10 @@ func (e *Extension) Init(h ipnext.Host) error {
 	h.Hooks().SetPeerStatus.Add(e.setPeerStatus)
 	h.Hooks().BackendStateChange.Add(e.onBackendStateChange)
 
+	// TODO(nickkhyl): remove this after the profileManager refactoring.
+	// See tailscale/tailscale#15974.
+	profile, prefs := h.Profiles().CurrentProfileState()
+	e.onChangeProfile(profile, prefs, false)
 	return nil
 }
 

--- a/feature/taildrop/integration_test.go
+++ b/feature/taildrop/integration_test.go
@@ -26,7 +26,6 @@ import (
 // TODO(bradfitz): add test between different users with the peercap to permit that?
 
 func TestTaildropIntegration(t *testing.T) {
-	t.Skip("known failing test; see https://github.com/tailscale/tailscale/issues/15970")
 	testTaildropIntegration(t, false)
 }
 

--- a/ipn/ipnext/ipnext.go
+++ b/ipn/ipnext/ipnext.go
@@ -37,7 +37,10 @@ type Extension interface {
 	// It must be the same as the name used to register the extension.
 	Name() string
 
-	// Init is called to initialize the extension when LocalBackend is initialized.
+	// Init is called to initialize the extension when LocalBackend's
+	// Start method is called. Extensions are created but not initialized
+	// unless LocalBackend is started.
+	//
 	// If the extension cannot be initialized, it must return an error,
 	// and its Shutdown method will not be called on the host's shutdown.
 	// Returned errors are not fatal; they are used for logging.
@@ -333,6 +336,7 @@ type Hooks struct {
 	// BackendStateChange is called when the backend state changes.
 	BackendStateChange feature.Hooks[func(ipn.State)]
 
+	// ProfileStateChange contains callbacks that are invoked when the current login profile
 	// or its [ipn.Prefs] change, after those changes have been made. The current login profile
 	// may be changed either because of a profile switch, or because the profile information
 	// was updated by [LocalBackend.SetControlClientStatus], including when the profile


### PR DESCRIPTION
Currently, `LocalBackend`/`ExtensionHost` doesn't invoke the profile change callback for the initial profile. Since the initial profile may vary depending on loaded extensions and applied policy settings, it can't be reliably determined until all extensions are initialized. Additionally, some extensions may asynchronously trigger a switch to the "best" profile (based on system state and policy settings) during initialization.

We intended to address these issues as part of the ongoing `profileManager`/`LocalBackend` refactoring, but the changes didn't land in time for the v1.84 release and the Taildrop refactoring.

In this PR, we update the Taildrop extension to retrieve the current profile at initialization time and handle it as a profile change.

We also defer extension initialization until `LocalBackend` has started, since the Taildrop extension already relies on this behavior (e.g., it requires clients to call `SetDirectFileRoot` before `Init`).

Updates #12614
Fixes #15970