### PR TITLE
ipn/store: remove a layer of indirection for registering stores

### DIFF
--- a/ipn/store/store_aws.go
+++ b/ipn/store/store_aws.go
@@ -12,10 +12,6 @@ import (
 )
 
 func init() {
-	registerAvailableExternalStores = append(registerAvailableExternalStores, registerAWSStore)
-}
-
-func registerAWSStore() {
 	Register("arn:", func(logf logger.Logf, arg string) (ipn.StateStore, error) {
 		ssmARN, opts, err := awsstore.ParseARNAndOpts(arg)
 		if err != nil {

--- a/ipn/store/store_kube.go
+++ b/ipn/store/store_kube.go
@@ -14,10 +14,6 @@ import (
 )
 
 func init() {
-	registerAvailableExternalStores = append(registerAvailableExternalStores, registerKubeStore)
-}
-
-func registerKubeStore() {
 	Register("kube:", func(logf logger.Logf, path string) (ipn.StateStore, error) {
 		secretName := strings.TrimPrefix(path, "kube:")
 		return kubestore.New(logf, secretName)

--- a/ipn/store/stores.go
+++ b/ipn/store/stores.go
@@ -26,16 +26,8 @@ import (
 // The arg is of the form "prefix:rest", where prefix was previously registered with Register.
 type Provider func(logf logger.Logf, arg string) (ipn.StateStore, error)
 
-var regOnce sync.Once
-
-var registerAvailableExternalStores []func()
-
-func registerDefaultStores() {
+func init() {
 	Register("mem:", mem.New)
-
-	for _, f := range registerAvailableExternalStores {
-		f()
-	}
 }
 
 var knownStores map[string]Provider
@@ -55,7 +47,6 @@ var knownStores map[string]Provider
 //     the suffix is a Kubernetes secret name
 //   - In all other cases, the path is treated as a filepath.
 func New(logf logger.Logf, path string) (ipn.StateStore, error) {
-	regOnce.Do(registerDefaultStores)
 	for prefix, sf := range knownStores {
 		if strings.HasPrefix(path, prefix) {
 			// We can't strip the prefix here as some NewStoreFunc (like arn:)

--- a/ipn/store/stores_test.go
+++ b/ipn/store/stores_test.go
@@ -4,6 +4,7 @@
 package store
 
 import (
+	"maps"
 	"path/filepath"
 	"testing"
 
@@ -14,10 +15,9 @@ import (
 )
 
 func TestNewStore(t *testing.T) {
-	regOnce.Do(registerDefaultStores)
+	oldKnownStores := maps.Clone(knownStores)
 	t.Cleanup(func() {
-		knownStores = map[string]Provider{}
-		registerDefaultStores()
+		knownStores = oldKnownStores
 	})
 	knownStores = map[string]Provider{}
 


### PR DESCRIPTION
Registering a new store is cheap, it just adds a map entry. No need to lazy-init it with sync.Once and an intermediate slice holding init functions.

Updates #cleanup