### PR TITLE
prober: correct content-type response

### DIFF
--- a/prober/prober.go
+++ b/prober/prober.go
@@ -559,8 +559,8 @@ func (p *Prober) RunHandler(w http.ResponseWriter, r *http.Request) error {
 			PreviousSuccessRatio:  prevInfo.RecentSuccessRatio(),
 			PreviousMedianLatency: prevInfo.RecentMedianLatency(),
 		}
-		w.WriteHeader(respStatus)
 		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(respStatus)
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
 			return tsweb.Error(http.StatusInternalServerError, "error encoding JSON response", err)
 		}

--- a/prober/prober_test.go
+++ b/prober/prober_test.go
@@ -598,6 +598,9 @@ func TestProberRunHandler(t *testing.T) {
 				}
 
 				if reqJSON {
+					if w.Header().Get("Content-Type") != "application/json" {
+						t.Errorf("unexpected content type: got %q, want application/json", w.Header().Get("Content-Type"))
+					}
 					var gotJSON RunHandlerResponse
 					if err := json.Unmarshal(w.Body.Bytes(), &gotJSON); err != nil {
 						t.Fatalf("failed to unmarshal JSON response: %v; body: %s", err, w.Body.String())


### PR DESCRIPTION
Content-type was responding as test/plain for probes accepting application/json. Set content type header before setting the response code to correct this.

Updates tailscale/corp#27370