### PR TITLE
cmd/tailscale/cli: suggest using "tailscale set", not "up", to set operator

### DIFF
--- a/cmd/tailscale/cli/cli.go
+++ b/cmd/tailscale/cli/cli.go
@@ -164,7 +164,7 @@ func Run(args []string) (err error) {
 
 	err = rootCmd.Run(context.Background())
 	if tailscale.IsAccessDeniedError(err) && os.Getuid() != 0 && runtime.GOOS != "windows" {
-		return fmt.Errorf("%v\n\nUse 'sudo tailscale %s' or 'tailscale up --operator=$USER' to not require root.", err, strings.Join(args, " "))
+		return fmt.Errorf("%v\n\nUse 'sudo tailscale %s'.\nTo not require root, use 'sudo tailscale set --operator=$USER' once.", err, strings.Join(args, " "))
 	}
 	if errors.Is(err, flag.ErrHelp) {
 		return nil


### PR DESCRIPTION
The same message was used for "up" and "down" permission failures, but
"set" works better for both. Suggesting "up --operator" for a "down"
permission failure was confusing.

It's not like the latter command works in one shot anyway.

Fixes #16008
