### PR TITLE
ipn/ipnlocal: make GetExt work earlier, before extension init

### DIFF
--- a/ipn/ipnext/ipnext.go
+++ b/ipn/ipnext/ipnext.go
@@ -114,7 +114,7 @@ func RegisterExtension(name string, newExt NewExtensionFn) {
 		panic(fmt.Sprintf("ipnext: newExt is nil: %q", name))
 	}
 	if extensions.Contains(name) {
-		panic(fmt.Sprintf("ipnext: duplicate extensions: %q", name))
+		panic(fmt.Sprintf("ipnext: duplicate extension name %q", name))
 	}
 	extensions.Set(name, &Definition{name, newExt})
 }


### PR DESCRIPTION
Taildrop wasn't working on iOS since #15971 because GetExt didn't work
until after init, but that PR moved Init until after Start.

This makes GetExt work before LocalBackend.Start (ExtensionHost.Init).

Updates #15812
