### PR TITLE
cmd/k8s-operator: fix Tailscale Service API errors check

### DIFF
--- a/cmd/k8s-operator/ingress-for-pg.go
+++ b/cmd/k8s-operator/ingress-for-pg.go
@@ -1105,13 +1105,11 @@ func isErrorFeatureFlagNotEnabled(err error) bool {
 	// Tailscale control plane when a Tailscale Service API call is made for a
 	// tailnet that does not have the Tailscale Services feature flag enabled.
 	const messageFFNotEnabled = "feature unavailable for tailnet"
-	var errResp *tailscale.ErrResponse
-	ok := errors.As(err, &errResp)
-	return ok && strings.Contains(errResp.Message, messageFFNotEnabled)
+	return err != nil && strings.Contains(err.Error(), messageFFNotEnabled)
 }
 
 func isErrorTailscaleServiceNotFound(err error) bool {
-	var errResp *tailscale.ErrResponse
+	var errResp tailscale.ErrResponse
 	ok := errors.As(err, &errResp)
 	return ok && errResp.Status == http.StatusNotFound
 }

--- a/cmd/k8s-operator/svc-for-pg_test.go
+++ b/cmd/k8s-operator/svc-for-pg_test.go
@@ -8,10 +8,8 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math/rand/v2"
-	"net/http"
 	"net/netip"
 	"testing"
 
@@ -23,7 +21,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"tailscale.com/internal/client/tailscale"
 	"tailscale.com/ipn/ipnstate"
 	tsoperator "tailscale.com/k8s-operator"
 	tsapi "tailscale.com/k8s-operator/apis/v1alpha1"
@@ -108,8 +105,7 @@ func TestServicePGReconciler_UpdateHostname(t *testing.T) {
 	if err == nil {
 		t.Fatalf("svc:default-%s not cleaned up", svc.Name)
 	}
-	var errResp *tailscale.ErrResponse
-	if !errors.As(err, &errResp) || errResp.Status != http.StatusNotFound {
+	if !isErrorTailscaleServiceNotFound(err) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/cmd/k8s-operator/testutils_test.go
+++ b/cmd/k8s-operator/testutils_test.go
@@ -901,11 +901,11 @@ func (c *fakeTSClient) GetVIPService(ctx context.Context, name tailcfg.ServiceNa
 	c.Lock()
 	defer c.Unlock()
 	if c.vipServices == nil {
-		return nil, &tailscale.ErrResponse{Status: http.StatusNotFound}
+		return nil, tailscale.ErrResponse{Status: http.StatusNotFound}
 	}
 	svc, ok := c.vipServices[name]
 	if !ok {
-		return nil, &tailscale.ErrResponse{Status: http.StatusNotFound}
+		return nil, tailscale.ErrResponse{Status: http.StatusNotFound}
 	}
 	return svc, nil
 }


### PR DESCRIPTION
It seems like there is some sort of general issue with either the internal client in this repo that attempts to parse the error returned from the API or with the logic API side- the error that we get in kube client is a pointer to our type if it's a 'feature flag not enabled' error, but a concrete type if it's a 404. Right now, I can't debug this and we need to fix the code, so this does that.

Updates tailscale/tailscale#15895