### PR TITLE
wgengine/magicsock: introduce virtualNetworkID type

### DIFF
--- a/wgengine/magicsock/endpoint.go
+++ b/wgengine/magicsock/endpoint.go
@@ -1112,7 +1112,7 @@ func (de *endpoint) sendDiscoPing(ep netip.AddrPort, discoKey key.DiscoPublic, t
 	size = min(size, MaxDiscoPingSize)
 	padding := max(size-discoPingSize, 0)
 
-	sent, _ := de.c.sendDiscoMessage(ep, nil, de.publicKey, discoKey, &disco.Ping{
+	sent, _ := de.c.sendDiscoMessage(ep, virtualNetworkID{}, de.publicKey, discoKey, &disco.Ping{
 		TxID:    [12]byte(txid),
 		NodeKey: de.c.publicKeyAtomic.Load(),
 		Padding: padding,

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"math/rand"
 	"net"
 	"net/http"
@@ -3313,6 +3314,55 @@ func Test_isDiscoMaybeGeneve(t *testing.T) {
 			}
 			if gotIsGeneveEncap != tt.wantIsGeneveEncap {
 				t.Errorf("isDiscoMaybeGeneve() gotIsGeneveEncap = %v, want %v", gotIsGeneveEncap, tt.wantIsGeneveEncap)
+			}
+		})
+	}
+}
+
+func Test_virtualNetworkID(t *testing.T) {
+	tests := []struct {
+		name string
+		set  *uint32
+		want uint32
+	}{
+		{
+			"don't set",
+			nil,
+			0,
+		},
+		{
+			"set 0",
+			ptr.To(uint32(0)),
+			0,
+		},
+		{
+			"set 1",
+			ptr.To(uint32(1)),
+			1,
+		},
+		{
+			"set math.MaxUint32",
+			ptr.To(uint32(math.MaxUint32)),
+			1<<24 - 1,
+		},
+		{
+			"set max 3-byte value",
+			ptr.To(uint32(1<<24 - 1)),
+			1<<24 - 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := virtualNetworkID{}
+			if tt.set != nil {
+				v.set(*tt.set)
+			}
+			if v.isSet() != (tt.set != nil) {
+				t.Fatalf("isSet: %v != wantIsSet: %v", v.isSet(), tt.set != nil)
+			}
+			if v.get() != tt.want {
+				t.Fatalf("get(): %v != want: %v", v.get(), tt.want)
 			}
 		})
 	}

--- a/wgengine/magicsock/relaymanager.go
+++ b/wgengine/magicsock/relaymanager.go
@@ -16,7 +16,6 @@ import (
 	"tailscale.com/disco"
 	udprelay "tailscale.com/net/udprelay/endpoint"
 	"tailscale.com/types/key"
-	"tailscale.com/types/ptr"
 	"tailscale.com/util/httpm"
 	"tailscale.com/util/set"
 )
@@ -500,10 +499,12 @@ func (r *relayManager) handshakeServerEndpoint(work *relayHandshakeWork) {
 
 	sentBindAny := false
 	bind := &disco.BindUDPRelayEndpoint{}
+	vni := virtualNetworkID{}
+	vni.set(work.se.VNI)
 	for _, addrPort := range work.se.AddrPorts {
 		if addrPort.IsValid() {
 			sentBindAny = true
-			go work.ep.c.sendDiscoMessage(addrPort, ptr.To(work.se.VNI), key.NodePublic{}, work.se.ServerDisco, bind, discoLog)
+			go work.ep.c.sendDiscoMessage(addrPort, vni, key.NodePublic{}, work.se.ServerDisco, bind, discoLog)
 		}
 	}
 	if !sentBindAny {
@@ -552,7 +553,7 @@ func (r *relayManager) handshakeServerEndpoint(work *relayHandshakeWork) {
 		//     [udprelay.ServerEndpoint] from becoming fully operational.
 		//  4. This is a singular tx with no roundtrip latency measurements
 		//     involved.
-		work.ep.c.sendDiscoMessage(challenge.from, ptr.To(work.se.VNI), key.NodePublic{}, work.se.ServerDisco, answer, discoLog)
+		work.ep.c.sendDiscoMessage(challenge.from, vni, key.NodePublic{}, work.se.ServerDisco, answer, discoLog)
 		return
 	case <-timer.C:
 		// The handshake timed out.


### PR DESCRIPTION
This type improves code clarity and reduces the chance of heap alloc as we pass it as a non-pointer. VNI being a 3-byte value enables us to track set vs unset via the reserved/unused byte.

Updates tailscale/corp#27502