### PR TITLE
ipnlocal: add GetSSH_HostKeys method to LocalBackend of ssh_stub

### DIFF
--- a/ipn/ipnlocal/ssh_stub.go
+++ b/ipn/ipnlocal/ssh_stub.go
@@ -8,6 +8,7 @@ package ipnlocal
 import (
 	"errors"
 
+	"golang.org/x/crypto/ssh"
 	"tailscale.com/tailcfg"
 )
 
@@ -16,5 +17,9 @@ func (b *LocalBackend) getSSHHostKeyPublicStrings() ([]string, error) {
 }
 
 func (b *LocalBackend) getSSHUsernames(*tailcfg.C2NSSHUsernamesRequest) (*tailcfg.C2NSSHUsernamesResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (b *LocalBackend) GetSSH_HostKeys() (keys []ssh.Signer, err error) {
 	return nil, errors.New("not implemented")
 }


### PR DESCRIPTION
When it is built for Android, it will fail with the following error:

```
Error: ssh/tailssh/tailssh.go:110:20: cannot use lb (variable of type *ipnlocal.LocalBackend) as ipnLocalBackend value in struct literal: *ipnlocal.LocalBackend does not implement ipnLocalBackend (missing method GetSSH_HostKeys)
```