### PR TITLE
ipn/ipnlocal: improve dohQuery error to suggest `?dns=` and `?q=`

### DIFF
--- a/ipn/ipnlocal/peerapi.go
+++ b/ipn/ipnlocal/peerapi.go
@@ -859,7 +859,7 @@ func dohQuery(r *http.Request) (dnsQuery []byte, publicErr string) {
 	case "GET":
 		q64 := r.FormValue("dns")
 		if q64 == "" {
-			return nil, "missing 'dns' parameter"
+			return nil, "missing ‘dns’ parameter; try '?dns=' (DoH standard) or use '?q=<name>' for JSON debug mode"
 		}
 		if base64.RawURLEncoding.DecodedLen(len(q64)) > maxQueryLen {
 			return nil, "query too large"


### PR DESCRIPTION
Previously, a missing or invalid `dns` parameter on GET `/dns-query` returned only “missing ‘dns’ parameter”. Now the error message guides users to `?dns=` or `?q=`.

Updates: #16055