### PR TITLE
cmd/k8s-operator: validate Service tags, catch duplicate Tailscale Services in one cluster

### DIFF
--- a/cmd/k8s-operator/ingress-for-pg_test.go
+++ b/cmd/k8s-operator/ingress-for-pg_test.go
@@ -272,6 +272,7 @@ func TestValidateIngress(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-ingress",
 			Namespace: "default",
+			UID:       types.UID("1234-UID"),
 			Annotations: map[string]string{
 				AnnotationProxyGroup: "test-pg",
 			},
@@ -339,7 +340,7 @@ func TestValidateIngress(t *testing.T) {
 				},
 			},
 			pg:      readyProxyGroup,
-			wantErr: "tailscale.com/tags annotation contains invalid tag \"tag:invalid!\": tag names can only contain numbers, letters, or dashes",
+			wantErr: "Ingress contains invalid tags: invalid tag \"tag:invalid!\": tag names can only contain numbers, letters, or dashes",
 		},
 		{
 			name: "multiple_TLS_entries",
@@ -417,7 +418,7 @@ func TestValidateIngress(t *testing.T) {
 					},
 				},
 			}},
-			wantErr: `found duplicate Ingress "existing-ingress" for hostname "test" - multiple Ingresses for the same hostname in the same cluster are not allowed`,
+			wantErr: `found duplicate Ingress "default/existing-ingress" for hostname "test" - multiple Ingresses for the same hostname in the same cluster are not allowed`,
 		},
 	}
 

--- a/cmd/k8s-operator/operator_test.go
+++ b/cmd/k8s-operator/operator_test.go
@@ -1804,7 +1804,7 @@ func Test_metricsResourceCreation(t *testing.T) {
 
 func TestIgnorePGService(t *testing.T) {
 	// NOTE: creating proxygroup stuff just to be sure that it's all ignored
-	_, _, fc, _ := setupServiceTest(t)
+	_, _, fc, _, _ := setupServiceTest(t)
 
 	ft := &fakeTSClient{}
 	zl, err := zap.NewDevelopment()

--- a/cmd/k8s-operator/svc.go
+++ b/cmd/k8s-operator/svc.go
@@ -392,6 +392,7 @@ func validateService(svc *corev1.Service) []string {
 			violations = append(violations, fmt.Sprintf("invalid Tailscale hostname %q, use %q annotation to override: %s", svcName, AnnotationHostname, err))
 		}
 	}
+	violations = append(violations, tagViolations(svc)...)
 	return violations
 }
 


### PR DESCRIPTION
This PR adds two new validations:

- Validates that any tags set on Tailscale Kubernetes Services via `tailscale.com/tags` annotation are valid ACL tags (for both HA and non-HA Services)
If invalid tags are found, sets `Service` to invalid and logs an error:

```
status:
  conditions:
  - lastTransitionTime: "2025-05-22T14:27:31Z"
    message: 'invalid Service: invalid tag "k8s": tags must start with ''tag:'''
    reason: IngressSvcInvalid
    status: "False"
    type: TailscaleIngressSvcValid
  loadBalancer: {}
```


- Validates that no more than one Tailscale Kubernetes Service in HA mode refers to the same Tailscale Services
If more than one found, sets `Service` to invalid and logs an error:

```
  conditions:
  - lastTransitionTime: "2025-05-22T15:13:48Z"
    message: found duplicate Service "multi2" for hostname "multi" - multiple HA Services
      for the same hostname in the same cluster are not allowed
    reason: IngressSvcInvalid
    status: "False"
    type: TailscaleIngressSvcValid
```
```
{"level":"debug","ts":"2025-05-22T15:17:38Z","logger":"events","msg":"found duplicate Service \"multi2\" for hostname \"multi\" - multiple HA Services for the same hostname in the same cluster are not allowed","type":"Warning","object":{"kind":"Service","namespace":"default","name":"multi1","uid":"966df263-e008-4297-aa28-43b4aeefe45c","apiVersion":"v1","resourceVersion":"21047451"},"reason":"InvalidService"}
{"level":"debug","ts":"2025-05-22T15:17:38Z","logger":"events","msg":"found duplicate Service \"multi1\" for hostname \"multi\" - multiple HA Services for the same hostname in the same cluster are not allowed","type":"Warning","object":{"kind":"Service","namespace":"default","name":"multi2","uid":"cba61089-7298-431e-bfa8-5397c1054c07","apiVersion":"v1","resourceVersion":"21047454"},"reason":"InvalidService"}
```

Note that we don't attempt to validate if there isn't another resource of the same type using the same Tailscale Service. That's a problem we should solve in a way that works across multiple clusters, probably by updating the owner reference annotation to contain resource type.


Updates tailscale/tailscale#16054
Updates tailscale/tailscale#16035