### PR TITLE
cmd/tsidp: Fix sending string for refresh_token

### DIFF
--- a/cmd/tsidp/tsidp.go
+++ b/cmd/tsidp/tsidp.go
@@ -795,7 +795,7 @@ type oidcTokenResponse struct {
 	IDToken      string `json:"id_token"`
 	TokenType    string `json:"token_type"`
 	AccessToken  string `json:"access_token"`
-	RefreshToken string `json:"refresh_token"`
+	RefreshToken string `json:"refresh_token,omitempty"`
 	ExpiresIn    int    `json:"expires_in"`
 }
 


### PR DESCRIPTION
In accordance with the OIDC/OAuth 2.0 protocol, do not send an empty refresh_token and instead omit the field when empty.

Fixes https://github.com/tailscale/tailscale/issues/16073