### PR TITLE
Update outdated hash

### DIFF
--- a/go.mod.sri
+++ b/go.mod.sri
@@ -1,1 +1,1 @@
-sha256-av4kr09rjNRmag94ziNjJuI/cg8b8lAD3Tk24t/ezH4=
+sha256-m/b7wAp0Dr+uLyCwezvbrVAeGGGAouV6AQ79x7ZFuRQ=


### PR DESCRIPTION
The rebuild from the flake fails if this hash isn't updated accordingly.