### PR TITLE
cmd/containerboot: load auth key from file if TS_AUTHKEY_FILE is set

### DIFF
--- a/cmd/containerboot/main.go
+++ b/cmd/containerboot/main.go
@@ -13,6 +13,7 @@
 //
 //   - TS_AUTHKEY: the authkey to use for login. Also accepts TS_AUTH_KEY.
 //     If the value begins with "file:", it is treated as a path to a file containing the key.
+//   - TS_AUTHKEY_FILE: the path to a file containing the authkey to use for login.
 //   - TS_CLIENT_ID: the OAuth client ID. Can be used alone (ID token auto-generated
 //     in well-known environments), with TS_CLIENT_SECRET, or with TS_ID_TOKEN.
 //   - TS_CLIENT_SECRET: the OAuth client secret for generating authkeys.

--- a/cmd/containerboot/main_test.go
+++ b/cmd/containerboot/main_test.go
@@ -180,6 +180,29 @@ func TestContainerBoot(t *testing.T) {
 				},
 			}
 		},
+		"authkey_file": func(env *testEnv) testCase {
+			authFile := filepath.Join(env.d, "authkey.txt")
+			if err := os.WriteFile(authFile, []byte("tskey-key"), 0600); err != nil {
+				t.Fatalf("Failed to write authkey file: %v", err)
+			}
+			return testCase{
+				// Userspace mode, ephemeral storage, authkey provided via file.
+				Env: map[string]string{
+					"TS_AUTHKEY_FILE": authFile,
+				},
+				Phases: []phase{
+					{
+						WantCmds: []string{
+							"/usr/bin/tailscaled --socket=/tmp/tailscaled.sock --state=mem: --statedir=/tmp --tun=userspace-networking",
+							"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --authkey=tskey-key",
+						},
+					},
+					{
+						Notify: runningNotify,
+					},
+				},
+			}
+		},
 		"authkey_disk_state": func(env *testEnv) testCase {
 			return testCase{
 				Env: map[string]string{

--- a/cmd/containerboot/settings.go
+++ b/cmd/containerboot/settings.go
@@ -89,24 +89,24 @@ type settings struct {
 
 func configFromEnv() (*settings, error) {
 	cfg := &settings{
-		AuthKey:            defaultEnvs([]string{"TS_AUTHKEY", "TS_AUTH_KEY"}, ""),
-		ClientID:           defaultEnv("TS_CLIENT_ID", ""),
-		ClientSecret:       defaultEnv("TS_CLIENT_SECRET", ""),
-		IDToken:            defaultEnv("TS_ID_TOKEN", ""),
-		Audience:           defaultEnv("TS_AUDIENCE", ""),
-		Hostname:           defaultEnv("TS_HOSTNAME", ""),
-		Routes:             defaultEnvStringPointer("TS_ROUTES"),
-		ServeConfigPath:    defaultEnv("TS_SERVE_CONFIG", ""),
-		ProxyTargetIP:      defaultEnv("TS_DEST_IP", ""),
-		ProxyTargetDNSName: defaultEnv("TS_EXPERIMENTAL_DEST_DNS_NAME", ""),
-		TailnetTargetIP:    defaultEnv("TS_TAILNET_TARGET_IP", ""),
-		TailnetTargetFQDN:  defaultEnv("TS_TAILNET_TARGET_FQDN", ""),
-		DaemonExtraArgs:    defaultEnv("TS_TAILSCALED_EXTRA_ARGS", ""),
-		ExtraArgs:          defaultEnv("TS_EXTRA_ARGS", ""),
-		InKubernetes:       os.Getenv("KUBERNETES_SERVICE_HOST") != "",
-		UserspaceMode:      defaultBool("TS_USERSPACE", true),
-		StateDir:           defaultEnv("TS_STATE_DIR", ""),
-		AcceptDNS:          defaultEnvBoolPointer("TS_ACCEPT_DNS"),
+		AuthKey:                               defaultEnvs([]string{"TS_AUTHKEY", "TS_AUTH_KEY", "TS_AUTHKEY_FILE", "TS_AUTH_KEY_FILE"}, ""),
+		ClientID:                              defaultEnv("TS_CLIENT_ID", ""),
+		ClientSecret:                          defaultEnv("TS_CLIENT_SECRET", ""),
+		IDToken:                               defaultEnv("TS_ID_TOKEN", ""),
+		Audience:                              defaultEnv("TS_AUDIENCE", ""),
+		Hostname:                              defaultEnv("TS_HOSTNAME", ""),
+		Routes:                                defaultEnvStringPointer("TS_ROUTES"),
+		ServeConfigPath:                       defaultEnv("TS_SERVE_CONFIG", ""),
+		ProxyTargetIP:                         defaultEnv("TS_DEST_IP", ""),
+		ProxyTargetDNSName:                    defaultEnv("TS_EXPERIMENTAL_DEST_DNS_NAME", ""),
+		TailnetTargetIP:                       defaultEnv("TS_TAILNET_TARGET_IP", ""),
+		TailnetTargetFQDN:                     defaultEnv("TS_TAILNET_TARGET_FQDN", ""),
+		DaemonExtraArgs:                       defaultEnv("TS_TAILSCALED_EXTRA_ARGS", ""),
+		ExtraArgs:                             defaultEnv("TS_EXTRA_ARGS", ""),
+		InKubernetes:                          os.Getenv("KUBERNETES_SERVICE_HOST") != "",
+		UserspaceMode:                         defaultBool("TS_USERSPACE", true),
+		StateDir:                              defaultEnv("TS_STATE_DIR", ""),
+		AcceptDNS:                             defaultEnvBoolPointer("TS_ACCEPT_DNS"),
 		KubeSecret: func() string {
 			if os.Getenv("KUBERNETES_SERVICE_HOST") != "" {
 				return defaultEnv("TS_KUBE_SECRET", "tailscale")
@@ -485,9 +485,21 @@ func defaultEnvBoolPointer(name string) *bool {
 	return &ret
 }
 
+// defaultEnvs returns the value of the first envvar in names that is set,
+// or defVal if none are set. If the envvar ends with "_FILE", it reads the
+// value from the file specified by the envvar.
 func defaultEnvs(names []string, defVal string) string {
 	for _, name := range names {
-		if v, ok := os.LookupEnv(name); ok {
+		if strings.HasSuffix(name, "_FILE") {
+			if filepath, ok := os.LookupEnv(name); ok {
+				data, err := os.ReadFile(filepath)
+				if err != nil {
+					log.Printf("error reading env var %s from file %s: %v", name, filepath, err)
+					continue
+				}
+				return strings.TrimSpace(string(data))
+			}
+		} else if v, ok := os.LookupEnv(name); ok {
 			return v
 		}
 	}


### PR DESCRIPTION
This change adds a new environment variable `TS_AUTHKEY_FILE` that can be used instead of `TS_AUTHKEY` to specify the auth key to use for login. `TS_AUTHKEY` takes precedence over `TS_AUTHKEY_FILE` if both are set.

`containerboot` already supports file-backed secrets via `TS_AUTHKEY=file:/path`, so this PR is not introducing that capability for the first time. The case for `TS_AUTHKEY_FILE` is that `_FILE` is a more standard and operationally clearer interface for mounted secrets in container deployments: it matches common container-secret conventions, keeps the credential separate from the indirection mechanism, and is easier to wire through Compose/Kubernetes tooling.

More justification in the issue discussion: https://github.com/tailscale/tailscale/issues/14210#issuecomment-4185439890

Fixes <https://github.com/tailscale/tailscale/issues/14210>
