### PR TITLE
.github/workflows: use Ubuntu 24.04 images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ concurrency:
 
 jobs:
   race-root-integration:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false # don't abort the entire matrix if one element fails
       matrix:
@@ -74,7 +74,7 @@ jobs:
             buildflags: "-race"
             shard: '3/3'
           - goarch: "386" # thanks yaml
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -187,7 +187,7 @@ jobs:
         find $(go env GOMODCACHE)/cache -type f -mmin +90 -delete
 
   privileged:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
       image: golang:latest
       options: --privileged
@@ -214,7 +214,7 @@ jobs:
         XDG_CACHE_HOME: "/var/lib/ghrunner/cache"
 
   race-build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -258,7 +258,7 @@ jobs:
           - goos: openbsd
             goarch: amd64
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -300,7 +300,7 @@ jobs:
 
   ios: # similar to cross above, but iOS can't build most of the repo. So, just
        #make it build a few smoke packages.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -328,7 +328,7 @@ jobs:
           - goos: illumos
             goarch: amd64
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -366,7 +366,7 @@ jobs:
     # similar to cross above, but android fails to build a few pieces of the
     # repo. We should fix those pieces, they're small, but as a stepping stone,
     # only test the subset of android that our past smoke test checked.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -381,7 +381,7 @@ jobs:
         GOARCH: arm64
 
   wasm: # builds tsconnect, which is the only wasm build we support
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -420,7 +420,7 @@ jobs:
         find $(go env GOMODCACHE)/cache -type f -mmin +90 -delete
 
   tailscale_go: # Subset of tests that depend on our custom Go toolchain.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -440,7 +440,7 @@ jobs:
     # explicit 'if' condition, because the default condition for steps is
     # 'success()', meaning "only run this if no previous steps failed".
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: build fuzzers
       id: build
@@ -492,7 +492,7 @@ jobs:
         path: ${{ env.artifacts_path }}/out/artifacts
 
   depaware:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -501,7 +501,7 @@ jobs:
         make depaware
 
   go_generate:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -514,7 +514,7 @@ jobs:
         git diff --name-only --exit-code || (echo "The files above need updating. Please run 'go generate'."; exit 1)
 
   go_mod_tidy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -526,7 +526,7 @@ jobs:
         git diff --name-only --exit-code || (echo "Please run 'go mod tidy'."; exit 1)
 
   licenses:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -534,7 +534,7 @@ jobs:
       run: ./scripts/check_license_headers.sh .
 
   staticcheck:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false # don't abort the entire matrix if one element fails
       matrix:
@@ -575,7 +575,7 @@ jobs:
       - go_mod_tidy
       - licenses
       - staticcheck
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: notify  
       # Only notify slack for merged commits, not PR failures.
@@ -604,7 +604,7 @@ jobs:
 
   check_mergeability:
     if: always()
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - android
       - test


### PR DESCRIPTION
Bumps Ubuntu version for test container images 22.04 -> 24.04.

(Could also change to `ubuntu-latest`, but it seems not a bad thing to be aware when versions change)

Updates#cleanup