### PR TITLE
cmd/containerboot: allow setting --accept-dns via TS_EXTRA_ARGS again

### DIFF
--- a/cmd/containerboot/settings_test.go
+++ b/cmd/containerboot/settings_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build linux
+
+package main
+
+import "testing"
+
+func Test_parseAcceptDNS(t *testing.T) {
+	tests := []struct {
+		name          string
+		extraArgs     string
+		acceptDNS     bool
+		wantExtraArgs string
+		wantAcceptDNS bool
+	}{
+		{
+			name:          "false_extra_args_unset",
+			extraArgs:     "",
+			wantExtraArgs: "",
+			wantAcceptDNS: false,
+		},
+		{
+			name:          "false_unrelated_args_set",
+			extraArgs:     "--accept-routes=true --advertise-routes=10.0.0.1/32",
+			wantExtraArgs: "--accept-routes=true --advertise-routes=10.0.0.1/32",
+			wantAcceptDNS: false,
+		},
+		{
+			name:          "true_extra_args_unset",
+			extraArgs:     "",
+			acceptDNS:     true,
+			wantExtraArgs: "",
+			wantAcceptDNS: true,
+		},
+		{
+			name:          "true_unrelated_args_set",
+			acceptDNS:     true,
+			extraArgs:     "--accept-routes=true --advertise-routes=10.0.0.1/32",
+			wantExtraArgs: "--accept-routes=true --advertise-routes=10.0.0.1/32",
+			wantAcceptDNS: true,
+		},
+		{
+			name:          "false_extra_args_set_to_false",
+			extraArgs:     "--accept-dns=false",
+			wantExtraArgs: "",
+			wantAcceptDNS: false,
+		},
+		{
+			name:          "false_extra_args_set_to_true",
+			extraArgs:     "--accept-dns=true",
+			wantExtraArgs: "",
+			wantAcceptDNS: true,
+		},
+		{
+			name:          "true_extra_args_set_to_false",
+			extraArgs:     "--accept-dns=false",
+			acceptDNS:     true,
+			wantExtraArgs: "",
+			wantAcceptDNS: false,
+		},
+		{
+			name:          "true_extra_args_set_to_true",
+			extraArgs:     "--accept-dns=true",
+			acceptDNS:     true,
+			wantExtraArgs: "",
+			wantAcceptDNS: true,
+		},
+		{
+			name:          "false_extra_args_set_to_true_implicitly",
+			extraArgs:     "--accept-dns",
+			wantExtraArgs: "",
+			wantAcceptDNS: true,
+		},
+		{
+			name:          "false_extra_args_set_to_true_implicitly_with_unrelated_args",
+			extraArgs:     "--accept-dns --accept-routes --advertise-routes=10.0.0.1/32",
+			wantExtraArgs: "--accept-routes --advertise-routes=10.0.0.1/32",
+			wantAcceptDNS: true,
+		},
+		{
+			name:          "false_extra_args_set_to_true_implicitly_surrounded_with_unrelated_args",
+			extraArgs:     "--accept-routes --accept-dns --advertise-routes=10.0.0.1/32",
+			wantExtraArgs: "--accept-routes --advertise-routes=10.0.0.1/32",
+			wantAcceptDNS: true,
+		},
+		{
+			name:          "true_extra_args_set_to_false_with_unrelated_args",
+			extraArgs:     "--accept-routes --accept-dns=false",
+			acceptDNS:     true,
+			wantExtraArgs: "--accept-routes",
+			wantAcceptDNS: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotExtraArgs, gotAcceptDNS := parseAcceptDNS(tt.extraArgs, tt.acceptDNS)
+			if gotExtraArgs != tt.wantExtraArgs {
+				t.Errorf("parseAcceptDNS() gotExtraArgs = %v, want %v", gotExtraArgs, tt.wantExtraArgs)
+			}
+			if gotAcceptDNS != tt.wantAcceptDNS {
+				t.Errorf("parseAcceptDNS() gotAcceptDNS = %v, want %v", gotAcceptDNS, tt.wantAcceptDNS)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In 1.84 we made 'tailscale set'/'tailscale up' error out if duplicate command line flags are passed, see https://github.com/tailscale/tailscale/issues/16108

This broke some container configurations as we have two env vars that can be used to set --accept-dns flag:

- TS_ACCEPT_DNS- specifically for --accept-dns
- TS_EXTRA_ARGS- accepts any arbitrary 'tailscale up'/'tailscale set' flag.

We default TS_ACCEPT_DNS to false (to make the container behaviour more declarative- the CLI flags expect an explicit 'false' to change state true -> false, rather than just being unset), which with the new restrictive CLI behaviour resulted in failure for users who had set --accept-dns via TS_EXTRA_ARGS as the flag would be provided twice.
(See the defaulting [here](https://github.com/tailscale/tailscale/blob/b0d35975c0462a8499667ac7b52d685b5e90465a/cmd/containerboot/tailscaled.go#L118))

This PR re-instates the previous behaviour by checking if TS_EXTRA_ARGS contains --accept-dns flag and if so using its value to override TS_ACCEPT_DNS.

Really this illustrates that we should ideally move away from the env vars/flag parsing mechanism eventually.