### PR TITLE
ipn/ipnlocal: fix `PeerByID` can not find `SelfNode`

### DIFF
--- a/ipn/ipnlocal/node_backend.go
+++ b/ipn/ipnlocal/node_backend.go
@@ -177,6 +177,11 @@ func (nb *nodeBackend) NodeByKey(k key.NodePublic) (_ tailcfg.NodeID, ok bool) {
 func (nb *nodeBackend) PeerByID(id tailcfg.NodeID) (_ tailcfg.NodeView, ok bool) {
 	nb.mu.Lock()
 	defer nb.mu.Unlock()
+	if nb.netMap != nil {
+		if self := nb.netMap.SelfNode; self.Valid() && self.ID() == id {
+			return self, true
+		}
+	}
 	n, ok := nb.peers[id]
 	return n, ok
 }


### PR DESCRIPTION
What Changed
Like NodeByKey, add an if stmt for checking the NodeId is SelfNode.

Why
Before [this commit](https://github.com/tailscale/tailscale/commit/8b72dd7873201b0944c48449b1facd08f4135dea), WhoIsNodeKey can query SelfNode by self node's nodekey, after that commit, only cn.NodeByKey(k) can check that but cn.PeerByID(nid) can't.
This breaks derper check node when self node try to connect derper in same host and derper with verify-clients enabled.

This commit Fixes #16052