### PR TITLE
ipn/ipnlocal: Update hostinfo to control on service config change

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -6146,17 +6146,17 @@ func (b *LocalBackend) setTCPPortsInterceptedFromNetmapAndPrefsLocked(prefs ipn.
 		}
 	}
 
-	// Update funnel info in hostinfo and kick off control update if needed.
-	b.updateIngressLocked()
+	// Update funnel and service hash info in hostinfo and kick off control update if needed.
+	b.updateIngressAndServiceHashLocked(prefs)
 	b.setTCPPortsIntercepted(handlePorts)
 	b.setVIPServicesTCPPortsInterceptedLocked(vipServicesPorts)
 }
 
-// updateIngressLocked updates the hostinfo.WireIngress and hostinfo.IngressEnabled fields and kicks off a Hostinfo
-// update if the values have changed.
+// updateIngressAndServiceHashLocked updates the hostinfo.ServicesHash, hostinfo.WireIngress and
+// hostinfo.IngressEnabled fields and kicks off a Hostinfo update if the values have changed.
 //
 // b.mu must be held.
-func (b *LocalBackend) updateIngressLocked() {
+func (b *LocalBackend) updateIngressAndServiceHashLocked(prefs ipn.PrefsView) {
 	if b.hostinfo == nil {
 		return
 	}
@@ -6169,6 +6169,11 @@ func (b *LocalBackend) updateIngressLocked() {
 	if wire := b.shouldWireInactiveIngressLocked(); b.hostinfo.WireIngress != wire {
 		b.logf("Hostinfo.WireIngress changed to %v", wire)
 		b.hostinfo.WireIngress = wire
+		hostInfoChanged = true
+	}
+	latestHash := b.vipServiceHash(b.vipServicesFromPrefsLocked(prefs))
+	if b.hostinfo.ServicesHash != latestHash {
+		b.hostinfo.ServicesHash = latestHash
 		hostInfoChanged = true
 	}
 	// Kick off a Hostinfo update to control if ingress status has changed.


### PR DESCRIPTION
This commit fixes the bug that c2n requests are skiped when updating vipServices in serveConfig. This then resulted netmap update being skipped which caused inaccuracy of Capmap info on client side. After this fix, client always inform control about it's vipServices config changes.

Fixes tailscale/corp#29219