### PR TITLE
.gitattributes: Force line endings to LF throughout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,9 @@
+# If using windows and WSL git will get line endings wrong
+# force to use lf line endings throughout
+* text  eol=lf
+*.PNG   -text
+*.gif   -text
+*.gz    -text
+
 go.mod filter=go-mod
 *.go  diff=golang


### PR DESCRIPTION
Resolves https://github.com/tailscale/tailscale/issues/16175

Steps involved:
- set all text files to use LF line endings
- remove the text attribute from PNG/gif/gz files to avoid unnecessarily making changes

