### PR TITLE
ipn: add watch opt to include actions in health messages

### DIFF
--- a/ipn/backend.go
+++ b/ipn/backend.go
@@ -81,6 +81,8 @@ const (
 	NotifyInitialHealthState NotifyWatchOpt = 1 << 7 // if set, the first Notify message (sent immediately) will contain the current health.State of the client
 
 	NotifyRateLimit NotifyWatchOpt = 1 << 8 // if set, rate limit spammy netmap updates to every few seconds
+
+	NotifyHealthActions NotifyWatchOpt = 1 << 9 // if set, include PrimaryActions in health.State. Otherwise append the action URL to the text
 )
 
 // Notify is a communication from a backend (e.g. tailscaled) to a frontend


### PR DESCRIPTION
Currently, any client with the latest client library in it (capver >= 117) will be able to handle `DisplayMessages` without URLs as they are mapped to the pre-existing `UnhealthyState` type. However they may not necessarily read the `PrimaryAction` field, which is a new field we added. We can't tell based on capver whether a client supports `PrimaryAction` or not.

This PR adds a `NotifyHealthActions` watch option, so when an app subscribes to the IPN bus via localapi it can signal if it understands `PrimaryAction`. If it does, we send it, if not then we concatenate the URL details to the message for compatibility with clients that have not implemented reading `PrimaryAction` yet.

Updates tailscale/corp#27759