### PR TITLE
wgengine/relaymanager: don't start runLoop() on init()

### DIFF
--- a/wgengine/magicsock/relaymanager.go
+++ b/wgengine/magicsock/relaymanager.go
@@ -206,7 +206,7 @@ func (r *relayManager) init() {
 		r.newServerEndpointCh = make(chan newRelayServerEndpointEvent)
 		r.rxHandshakeDiscoMsgCh = make(chan relayHandshakeDiscoMsgEvent)
 		r.runLoopStoppedCh = make(chan struct{}, 1)
-		go r.runLoop()
+		r.runLoopStoppedCh <- struct{}{}
 	})
 }
 


### PR DESCRIPTION
This is simply for consistency with relayManagerInputEvent(), which should be the sole launcher of runLoop().

Updates tailscale/corp#27502