### PR TITLE
ipn,client,cmd,net: expose DNS mode via local API

### DIFF
--- a/client/local/local.go
+++ b/client/local/local.go
@@ -1080,6 +1080,21 @@ func (lc *Client) CurrentDERPMap(ctx context.Context) (*tailcfg.DERPMap, error) 
 	return &derpMap, nil
 }
 
+// CurrentDNSMode returns the DNS manager mode that tailscaled is using.
+// If the daemon or platform doesn't support DNS mode detection, an empty
+// string is returned.
+func (lc *Client) CurrentDNSMode(ctx context.Context) (string, error) {
+	body, err := lc.get200(ctx, "/localapi/v0/dns-mode")
+	if err != nil {
+		return "", err
+	}
+	var res struct{ Mode string }
+	if err := json.Unmarshal(body, &res); err != nil {
+		return "", err
+	}
+	return res.Mode, nil
+}
+
 // CertPair returns a cert and private key for the provided DNS domain.
 //
 // It returns a cached certificate from disk if it's still valid.

--- a/cmd/tailscale/cli/netcheck.go
+++ b/cmd/tailscale/cli/netcheck.go
@@ -101,8 +101,14 @@ func runNetcheck(ctx context.Context, args []string) error {
 		}
 	}
 	for {
+		dnsMode, err := localClient.CurrentDNSMode(ctx)
+		if err != nil && netcheckArgs.verbose {
+			log.Printf("netcheck: DNS mode query failed: %v", err)
+		}
 		t0 := time.Now()
-		report, err := c.GetReport(ctx, dm, nil)
+		report, err := c.GetReport(ctx, dm, &netcheck.GetReportOpts{
+			DNSMode: dnsMode,
+		})
 		d := time.Since(t0)
 		if netcheckArgs.verbose {
 			c.Logf("GetReport took %v; err=%v", d.Round(time.Millisecond), err)
@@ -110,7 +116,7 @@ func runNetcheck(ctx context.Context, args []string) error {
 		if err != nil {
 			return fmt.Errorf("netcheck: %w", err)
 		}
-		if err := printReport(dm, report); err != nil {
+		if err := printReport(Stdout, dm, report); err != nil {
 			return err
 		}
 		if netcheckArgs.every == 0 {
@@ -120,7 +126,7 @@ func runNetcheck(ctx context.Context, args []string) error {
 	}
 }
 
-func printReport(dm *tailcfg.DERPMap, report *netcheck.Report) error {
+func printReport(w io.Writer, dm *tailcfg.DERPMap, report *netcheck.Report) error {
 	var j []byte
 	var err error
 	switch netcheckArgs.format {
@@ -137,45 +143,48 @@ func printReport(dm *tailcfg.DERPMap, report *netcheck.Report) error {
 	}
 	if j != nil {
 		j = append(j, '\n')
-		Stdout.Write(j)
+		w.Write(j)
 		return nil
 	}
 
-	printf("\nReport:\n")
-	printf("\t* Time: %v\n", report.Now.Format(time.RFC3339Nano))
-	printf("\t* UDP: %v\n", report.UDP)
+	fmt.Fprintf(w, "\nReport:\n")
+	fmt.Fprintf(w, "\t* Time: %v\n", report.Now.Format(time.RFC3339Nano))
+	fmt.Fprintf(w, "\t* UDP: %v\n", report.UDP)
 	if report.GlobalV4.IsValid() {
-		printf("\t* IPv4: yes, %s\n", report.GlobalV4)
+		fmt.Fprintf(w, "\t* IPv4: yes, %s\n", report.GlobalV4)
 	} else {
-		printf("\t* IPv4: (no addr found)\n")
+		fmt.Fprintf(w, "\t* IPv4: (no addr found)\n")
 	}
 	if report.GlobalV6.IsValid() {
-		printf("\t* IPv6: yes, %s\n", report.GlobalV6)
+		fmt.Fprintf(w, "\t* IPv6: yes, %s\n", report.GlobalV6)
 	} else if report.IPv6 {
-		printf("\t* IPv6: (no addr found)\n")
+		fmt.Fprintf(w, "\t* IPv6: (no addr found)\n")
 	} else if report.OSHasIPv6 {
-		printf("\t* IPv6: no, but OS has support\n")
+		fmt.Fprintf(w, "\t* IPv6: no, but OS has support\n")
 	} else {
-		printf("\t* IPv6: no, unavailable in OS\n")
+		fmt.Fprintf(w, "\t* IPv6: no, unavailable in OS\n")
 	}
-	printf("\t* MappingVariesByDestIP: %v\n", report.MappingVariesByDestIP)
-	printf("\t* PortMapping: %v\n", portMapping(report))
+	fmt.Fprintf(w, "\t* MappingVariesByDestIP: %v\n", report.MappingVariesByDestIP)
+	fmt.Fprintf(w, "\t* PortMapping: %v\n", portMapping(report))
+	if report.DNSMode != "" {
+		fmt.Fprintf(w, "\t* DNS Mode: %s\n", report.DNSMode)
+	}
 	if report.CaptivePortal != "" {
-		printf("\t* CaptivePortal: %v\n", report.CaptivePortal)
+		fmt.Fprintf(w, "\t* CaptivePortal: %v\n", report.CaptivePortal)
 	}
 
 	// When DERP latency checking failed,
 	// magicsock will try to pick the DERP server that
 	// most of your other nodes are also using
 	if len(report.RegionLatency) == 0 {
-		printf("\t* Nearest DERP: unknown (no response to latency probes)\n")
+		fmt.Fprintf(w, "\t* Nearest DERP: unknown (no response to latency probes)\n")
 	} else {
 		if report.PreferredDERP != 0 {
-			printf("\t* Nearest DERP: %v\n", dm.Regions[report.PreferredDERP].RegionName)
+			fmt.Fprintf(w, "\t* Nearest DERP: %v\n", dm.Regions[report.PreferredDERP].RegionName)
 		} else {
-			printf("\t* Nearest DERP: [none]\n")
+			fmt.Fprintf(w, "\t* Nearest DERP: [none]\n")
 		}
-		printf("\t* DERP latency:\n")
+		fmt.Fprintf(w, "\t* DERP latency:\n")
 		var rids []int
 		for rid := range dm.Regions {
 			rids = append(rids, rid)
@@ -202,7 +211,7 @@ func printReport(dm *tailcfg.DERPMap, report *netcheck.Report) error {
 			if netcheckArgs.verbose {
 				derpNum = fmt.Sprintf("derp%d, ", rid)
 			}
-			printf("\t\t- %3s: %-7s (%s%s)\n", r.RegionCode, latency, derpNum, r.RegionName)
+			fmt.Fprintf(w, "\t\t- %3s: %-7s (%s%s)\n", r.RegionCode, latency, derpNum, r.RegionName)
 		}
 	}
 	return nil

--- a/cmd/tailscale/cli/netcheck_test.go
+++ b/cmd/tailscale/cli/netcheck_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"tailscale.com/net/netcheck"
+	"tailscale.com/tailcfg"
+)
+
+func TestPrintReportShowsDNSMode(t *testing.T) {
+	testCases := []struct {
+		name           string
+		dnsMode        string
+		expectInOutput bool
+	}{
+		{"dns mode set", "direct", true},
+		{"dns mode empty", "", false},
+		{"dns mode other", "systemd-resolved", true},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // capture range variable for parallel tests
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Setup a minimal DERP map for the report.
+			mockDERPMap := &tailcfg.DERPMap{Regions: map[int]*tailcfg.DERPRegion{1: {RegionID: 1, RegionName: "d1"}}}
+			// Create a report with the test case's DNSMode.
+			report := &netcheck.Report{Now: time.Unix(0, 0), DNSMode: tc.dnsMode}
+
+			// Capture output by writing to a buffer.
+			var outputBuf bytes.Buffer
+
+			// Ensure human-readable output
+			netcheckArgs.format = ""
+			if err := printReport(&outputBuf, mockDERPMap, report); err != nil {
+				t.Fatalf("printReport failed: %v", err)
+			}
+
+			output := outputBuf.String()
+			if tc.expectInOutput {
+				if !strings.Contains(output, "DNS Mode: "+ tc.dnsMode) {
+					t.Errorf("expected DNS Mode %q in output, got: %q", tc.dnsMode, output)
+				}
+			} else {
+				if strings.Contains(output, "DNS Mode:") {
+					t.Errorf("did not expect DNS Mode line in output, got: %q", output)
+				}
+			}
+		})
+	}
+}

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -40,6 +40,7 @@ import (
 	"tailscale.com/ipn/ipnlocal"
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/logtail"
+	"tailscale.com/net/dns"
 	"tailscale.com/net/netmon"
 	"tailscale.com/net/netutil"
 	"tailscale.com/net/portmapper"
@@ -104,6 +105,7 @@ var handler = map[string]LocalAPIHandler{
 	"dev-set-state-store":          (*Handler).serveDevSetStateStore,
 	"dial":                         (*Handler).serveDial,
 	"disconnect-control":           (*Handler).disconnectControl,
+	"dns-mode":                     (*Handler).serveDNSMode,
 	"dns-osconfig":                 (*Handler).serveDNSOSConfig,
 	"dns-query":                    (*Handler).serveDNSQuery,
 	"drive/fileserver-address":     (*Handler).serveDriveServerAddr,
@@ -2612,6 +2614,35 @@ func (h *Handler) serveDNSQuery(w http.ResponseWriter, r *http.Request) {
 		Bytes:     res,
 		Resolvers: rrs,
 	})
+}
+
+// serveDNSMode reports the DNS manager mode tailscaled is using.
+// - Only GET is allowed.
+// - Requires PermitRead.
+// Responds with JSON: { "mode": "<current mode>" }.
+func (h *Handler) serveDNSMode(w http.ResponseWriter, r *http.Request) {
+	if r.Method != httpm.GET {
+		http.Error(w, "only GET allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !h.PermitRead {
+		http.Error(w, "dns-mode access denied", http.StatusForbidden)
+		return
+	}
+
+	payload := struct {
+		Mode string `json:"mode"`
+	}{
+		Mode: dns.CurrentDNSMode(),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	encoder := json.NewEncoder(w)
+	if err := encoder.Encode(payload); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 }
 
 // serveDriveServerAddr handles updates of the Taildrive file server address.

--- a/net/dns/manager_linux.go
+++ b/net/dns/manager_linux.go
@@ -50,6 +50,7 @@ func NewOSConfigurator(logf logger.Logf, health *health.Tracker, _ *controlknobs
 	if err != nil {
 		return nil, err
 	}
+	SetCurrentDNSMode(mode)
 	publishOnce.Do(func() {
 		sanitizedMode := strings.ReplaceAll(mode, "-", "_")
 		m := clientmetric.NewGauge(fmt.Sprintf("dns_manager_linux_mode_%s", sanitizedMode))

--- a/net/dns/mode_linux.go
+++ b/net/dns/mode_linux.go
@@ -1,0 +1,60 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build linux && !android
+
+package dns
+
+import (
+	"sync"
+
+	"tailscale.com/types/logger"
+)
+
+var (
+	currentModeMu  sync.Mutex
+	currentMode    string
+	currentModeSet bool
+)
+
+// currentMode is a cached value set the first time CurrentDNSMode is called or
+// when the DNS engine initializes via SetCurrentDNSMode. It reflects the mode
+// tailscaled is actively using and is safe for repeated reads without further
+// system probing.
+
+// CurrentDNSMode reports the DNS manager mode detected on this system.
+// The result is cached after the first call or after SetCurrentDNSMode
+// updates it when the engine starts.
+func CurrentDNSMode() string {
+	currentModeMu.Lock()
+	if !currentModeSet {
+		mode, err := dnsMode(logger.Discard, nil, newOSConfigEnv{
+			fs:                directFS{},
+			dbusPing:          dbusPing,
+			dbusReadString:    dbusReadString,
+			nmIsUsingResolved: nmIsUsingResolved,
+			nmVersionBetween:  nmVersionBetween,
+			resolvconfStyle:   resolvconfStyle,
+		})
+		if err == nil {
+			currentMode = mode
+			currentModeSet = true
+		}
+	}
+	m := currentMode
+	currentModeMu.Unlock()
+	return m
+}
+
+// SetCurrentDNSMode sets the cached DNS manager mode. 
+// It is intended for use by NewOSConfigurator to record the
+// mode that tailscaled actually uses.
+func SetCurrentDNSMode(mode string) {
+	if mode == "" {
+		return
+	}
+	currentModeMu.Lock()
+	currentMode = mode
+	currentModeSet = true
+	currentModeMu.Unlock()
+}

--- a/net/dns/mode_linux_test.go
+++ b/net/dns/mode_linux_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build linux && !android
+
+package dns
+
+import (
+	"sync"
+	"testing"
+)
+func TestCurrentDNSModeCache(t *testing.T) {
+	currentModeMu = sync.Mutex{}
+	currentMode = ""
+	currentModeSet = false
+	SetCurrentDNSMode("direct")
+	if got := CurrentDNSMode(); got != "direct" {
+		t.Fatalf("CurrentDNSMode=%q, want direct", got)
+	}
+	if got := CurrentDNSMode(); got != "direct" {
+		t.Fatalf("cached value changed: %q", got)
+	}
+}
+
+func TestSetCurrentDNSModeOnce(t *testing.T) {
+	currentModeMu = sync.Mutex{}
+	currentMode = ""
+	currentModeSet = false
+	SetCurrentDNSMode("direct")
+	SetCurrentDNSMode("systemd-resolved")
+	if got := CurrentDNSMode(); got != "systemd-resolved" {
+		t.Fatalf("CurrentDNSMode=%q, want systemd-resolved", got)
+	}
+}

--- a/net/dns/mode_notlinux.go
+++ b/net/dns/mode_notlinux.go
@@ -1,0 +1,13 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !linux || android
+
+package dns
+
+// CurrentDNSMode returns the DNS manager mode when available.
+// On unsupported platforms it returns an empty string.
+func CurrentDNSMode() string { return "" }
+
+// SetCurrentDNSMode is a no-op on platforms without DNS mode detection.
+func SetCurrentDNSMode(string) {}

--- a/net/dns/mode_notlinux_test.go
+++ b/net/dns/mode_notlinux_test.go
@@ -1,0 +1,18 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !linux || android
+
+package dns
+
+import "testing"
+
+func TestCurrentDNSModeStub(t *testing.T) {
+	if CurrentDNSMode() != "" {
+		t.Errorf("expected empty DNS mode")
+	}
+	SetCurrentDNSMode("direct")
+	if CurrentDNSMode() != "" {
+		t.Errorf("SetCurrentDNSMode should have no effect")
+	}
+}

--- a/net/netcheck/netcheck_test.go
+++ b/net/netcheck/netcheck_test.go
@@ -1049,3 +1049,33 @@ func TestNoUDPNilGetReportOpts(t *testing.T) {
 		t.Fatal("unexpected working UDP")
 	}
 }
+
+func TestGetReportOptDNSMode(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name    string
+		dnsMode string
+	}{
+		{"direct", "direct"},
+		{"system", "system"},
+		{"none", "none"},
+		{"empty", ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c := newTestClient(t)
+			ctx := t.Context()
+
+			dm := stuntest.DERPMapOf("1.2.3.4:1234")
+			r, err := c.GetReport(ctx, dm, &GetReportOpts{DNSMode: tc.dnsMode})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if r.DNSMode != tc.dnsMode {
+				t.Fatalf("DNSMode=%q, want %q", r.DNSMode, tc.dnsMode)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hi all—I'm new to the repo and this is my first contribution.  

This PR adds `/localapi/v0/dns-mode` to report the DNS manager mode in use. The client library gains `CurrentDNSMode` for querying this endpoint, and `tailscale netcheck` now displays the result. Tests cover the new handler and client method.

If Tailscaled isn’t available, the call fails cleanly and execution continues. In verbose mode, an error is printed to aid in debugging.

See previous discussion in PR #10542
Updates  #10474