### PR TITLE
feature/relayserver,net/{netcheck,udprelay}: implement addr discovery

### DIFF
--- a/feature/relayserver/relayserver.go
+++ b/feature/relayserver/relayserver.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"net/netip"
 	"sync"
 
 	"tailscale.com/envknob"
@@ -136,7 +135,7 @@ func (e *extension) relayServerOrInit() (relayServer, error) {
 		return nil, errors.New("TAILSCALE_USE_WIP_CODE envvar is not set")
 	}
 	var err error
-	e.server, _, err = udprelay.NewServer(*e.port, []netip.Addr{netip.MustParseAddr("127.0.0.1")})
+	e.server, _, err = udprelay.NewServer(e.logf, *e.port, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/net/udprelay/server_test.go
+++ b/net/udprelay/server_test.go
@@ -156,7 +156,7 @@ func TestServer(t *testing.T) {
 
 	ipv4LoopbackAddr := netip.MustParseAddr("127.0.0.1")
 
-	server, _, err := NewServer(0, []netip.Addr{ipv4LoopbackAddr})
+	server, _, err := NewServer(t.Logf, 0, []netip.Addr{ipv4LoopbackAddr})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The relay server now fetches IPs from local interfaces and external perspective IP:port's via netcheck (STUN).

Updates tailscale/corp#27502