### PR TITLE
Restore SSH and exit-node capability in case of Home Assistant

### DIFF
--- a/envknob/featureknob/featureknob.go
+++ b/envknob/featureknob/featureknob.go
@@ -10,7 +10,6 @@ import (
 	"runtime"
 
 	"tailscale.com/envknob"
-	"tailscale.com/hostinfo"
 	"tailscale.com/version"
 	"tailscale.com/version/distro"
 )
@@ -25,14 +24,6 @@ func CanRunTailscaleSSH() error {
 		}
 		if distro.Get() == distro.QNAP && !envknob.UseWIPCode() {
 			return errors.New("The Tailscale SSH server does not run on QNAP.")
-		}
-
-		// Setting SSH on Home Assistant causes trouble on startup
-		// (since the flag is not being passed to `tailscale up`).
-		// Although Tailscale SSH does work here,
-		// it's not terribly useful since it's running in a separate container.
-		if hostinfo.GetEnvType() == hostinfo.HomeAssistantAddOn {
-			return errors.New("The Tailscale SSH server does not run on HomeAssistant.")
 		}
 		// otherwise okay
 	case "darwin":
@@ -58,10 +49,5 @@ func CanUseExitNode() error {
 		distro.QNAP:
 		return errors.New("Tailscale exit nodes cannot be used on " + string(dist))
 	}
-
-	if hostinfo.GetEnvType() == hostinfo.HomeAssistantAddOn {
-		return errors.New("Tailscale exit nodes cannot be used on HomeAssistant.")
-	}
-
 	return nil
 }


### PR DESCRIPTION
Fixes: #15552

SSH was disabled in #10538
Exit node was disabled in #13726
This PR enables ssh and exit-node options in case of Home Assistant.

Both are unnecessary bans without any basis:
- The "official" TS add-on (https://github.com/hassio-addons/addon-tailscale) doesn't use these functionality
- Other add-ons (eg. https://github.com/tsujamin/hass-addons) are using, and these got broken

Additionally I made some quick tests with the official TS add-on, and if I enable these functions, they work fine without any issue. You can say, that users using `/opt/tailscale set` will run into issues, but users should never use the cli to manipulate a Home Assistant add-on's functionality, or bear the consequencies.

And eg. there is this feature request (https://github.com/hassio-addons/addon-tailscale/discussions/409) in the official add-on to implement exit node capability, and when I've tried to implement it, I run into this unjustified general ban from TS.