### PR TITLE
.github/workflows: test that ./go/tool version matches go mod version

### DIFF
--- a/.github/workflows/checklocks.yml
+++ b/.github/workflows/checklocks.yml
@@ -10,7 +10,7 @@ on:
       - '.github/workflows/checklocks.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ on:
     - cron: '31 14 * * 5'
 
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/kubemanifests.yaml
+++ b/.github/workflows/kubemanifests.yaml
@@ -9,7 +9,7 @@ on:
 # Cancel workflow run if there is a newer push to the same PR for which it is
 # running
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/natlab-integrationtest.yml
+++ b/.github/workflows/natlab-integrationtest.yml
@@ -3,7 +3,7 @@
 name: "natlab-integrationtest"
 
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/ssh-integrationtest.yml
+++ b/.github/workflows/ssh-integrationtest.yml
@@ -3,7 +3,7 @@
 name: "ssh-integrationtest"
 
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/update-webclient-prebuilt.yml
+++ b/.github/workflows/update-webclient-prebuilt.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/webclient.yml
+++ b/.github/workflows/webclient.yml
@@ -15,7 +15,7 @@ on:
   #    - main
 
 concurrency:
-  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/version_test.go
+++ b/version_test.go
@@ -6,21 +6,16 @@ package tailscaleroot
 import (
 	"fmt"
 	"os"
-	"regexp"
+	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
+
+	"golang.org/x/mod/modfile"
 )
 
 func TestDockerfileVersion(t *testing.T) {
-	goMod, err := os.ReadFile("go.mod")
-	if err != nil {
-		t.Fatal(err)
-	}
-	m := regexp.MustCompile(`(?m)^go (\d\.\d+)\r?($|\.)`).FindStringSubmatch(string(goMod))
-	if m == nil {
-		t.Fatalf("didn't find go version in go.mod")
-	}
-	goVersion := m[1]
+	goVersion := mustGetGoModVersion(t, false)
 
 	dockerFile, err := os.ReadFile("Dockerfile")
 	if err != nil {
@@ -30,4 +25,61 @@ func TestDockerfileVersion(t *testing.T) {
 	if !strings.Contains(string(dockerFile), wantSub) {
 		t.Errorf("didn't find %q in Dockerfile", wantSub)
 	}
+}
+
+// TestGoVersion tests that the Go version specified in go.mod matches ./tool/go version.
+func TestGoVersion(t *testing.T) {
+	// We could special-case ./tool/go path for Windows, but really there is no
+	// need to run it there.
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test on Windows")
+	}
+	goModVersion := mustGetGoModVersion(t, true)
+
+	goToolCmd := exec.Command("./tool/go", "version")
+	goToolOutput, err := goToolCmd.Output()
+	if err != nil {
+		t.Fatalf("Failed to get ./tool/go version: %v", err)
+	}
+
+	// Version info will approximately look like 'go version go1.24.4 linux/amd64'.
+	parts := strings.Fields(string(goToolOutput))
+	if len(parts) < 4 {
+		t.Fatalf("Unexpected ./tool/go version output format: %s", goToolOutput)
+	}
+
+	goToolVersion := strings.TrimPrefix(parts[2], "go")
+
+	if goModVersion != goToolVersion {
+		t.Errorf("Go version in go.mod (%q) does not match the version of ./tool/go (%q).\nEnsure that the go.mod refers to the same Go version as ./go.toolchain.rev.",
+			goModVersion, goToolVersion)
+	}
+}
+
+func mustGetGoModVersion(t *testing.T, includePatchVersion bool) string {
+	t.Helper()
+
+	goModBytes, err := os.ReadFile("go.mod")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	modFile, err := modfile.Parse("go.mod", goModBytes, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if modFile.Go == nil {
+		t.Fatal("no Go version found in go.mod")
+	}
+
+	version := modFile.Go.Version
+
+	parts := strings.Split(version, ".")
+	if !includePatchVersion {
+		if len(parts) >= 2 {
+			version = parts[0] + "." + parts[1]
+		}
+	}
+	return version
 }


### PR DESCRIPTION
Tests that go mod version matches ./tool/go version.
Mismatched versions result in incosistent Go versions being used i.e. in CI jobs as the version in go.mod is used to determine what Go version Github actions pull in.

Also fixes a typo that had been copy-pasted into all workflows

Currently failing as expected https://github.com/tailscale/tailscale/actions/runs/15684481497/job/44184059067?pr=16285#step:8:11


Updates tailscale/tailscale#16283