### PR TITLE
ipn/ipnlocal: fix nil bus panic

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -515,7 +515,16 @@ func NewLocalBackend(logf logger.Logf, logID logid.PublicID, sys *tsd.System, lo
 		captiveCancel:         nil, // so that we start checkCaptivePortalLoop when Running
 		needsCaptiveDetection: make(chan bool),
 	}
-	nb := newNodeBackend(ctx, b.sys.Bus.Get())
+	var bus *eventbus.Bus
+	if b.sys != nil {
+		bus = b.sys.Bus.Get()
+	}
+	if bus == nil {
+		log.Printf("WARNING: sys.Bus is not set; using fallback bus.")
+		bus = eventbus.New()
+	}
+	nb := newNodeBackend(ctx, bus)
+
 	b.currentNodeAtomic.Store(nb)
 	nb.ready()
 


### PR DESCRIPTION
Android was hitting a panic due to the event bus not being set when creating a new local backend. This adds a nil check and fallback if the eventbus has not been initiated.

Updates #cleanup