### PR TITLE
tool/gocross: put the synthetic GOROOTs outside of the tsgo directory

### DIFF
--- a/tool/gocross/gocross-wrapper.sh
+++ b/tool/gocross/gocross-wrapper.sh
@@ -74,6 +74,7 @@ case "$REV" in
             echo "# Cleaning up old Go toolchain $hash" >&2
             rm -rf "$HOME/.cache/tsgo/$hash"
             rm -rf "$HOME/.cache/tsgo/$hash.extracted"
+            rm -rf "$HOME/.cache/tsgoroot/$hash"
         done
     fi
     ;;

--- a/tool/gocross/toolchain.go
+++ b/tool/gocross/toolchain.go
@@ -62,7 +62,7 @@ func getToolchain() (toolchainDir, gorootDir string, err error) {
 
 	cache := filepath.Join(os.Getenv("HOME"), ".cache")
 	toolchainDir = filepath.Join(cache, "tsgo", rev)
-	gorootDir = filepath.Join(toolchainDir, "gocross-goroot")
+	gorootDir = filepath.Join(cache, "tsgoroot", rev)
 
 	// You might wonder why getting the toolchain also provisions and returns a
 	// path suitable for use as GOROOT. Wonder no longer!


### PR DESCRIPTION
We aim to make the tsgo directories be read-only mounts on builders.

But gocross was previously writing within the ~/.cache/tsgo/$HASH/
directories to make the synthetic GOROOT directories.

This moves them to ~/.cache/tsgoroot/$HASH/ instead.

Updates tailscale/corp#28679
Updates tailscale/corp#26717
