### PR TITLE
cmd/tailscale: clean up dns --help messages

### DIFF
--- a/cmd/tailscale/cli/dns-query.go
+++ b/cmd/tailscale/cli/dns-query.go
@@ -9,11 +9,30 @@ import (
 	"fmt"
 	"net/netip"
 	"os"
+	"strings"
 	"text/tabwriter"
 
+	"github.com/peterbourgon/ff/v3/ffcli"
 	"golang.org/x/net/dns/dnsmessage"
 	"tailscale.com/types/dnstype"
 )
+
+var dnsQueryCmd = &ffcli.Command{
+	Name:       "query",
+	ShortUsage: "tailscale dns query <name> [a|aaaa|cname|mx|ns|opt|ptr|srv|txt]",
+	Exec:       runDNSQuery,
+	ShortHelp:  "Perform a DNS query",
+	LongHelp: strings.TrimSpace(`
+The 'tailscale dns query' subcommand performs a DNS query for the specified name
+using the internal DNS forwarder (100.100.100.100).
+
+By default, the DNS query will request an A record. Another DNS record type can
+be specified as the second parameter.
+
+The output also provides information about the resolver(s) used to resolve the
+query.
+`),
+}
 
 func runDNSQuery(ctx context.Context, args []string) error {
 	if len(args) < 1 {

--- a/cmd/tailscale/cli/dns.go
+++ b/cmd/tailscale/cli/dns.go
@@ -4,46 +4,32 @@
 package cli
 
 import (
-	"flag"
+	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 )
 
 var dnsCmd = &ffcli.Command{
-	Name:       "dns",
-	ShortHelp:  "Diagnose the internal DNS forwarder",
-	LongHelp:   dnsCmdLongHelp(),
-	ShortUsage: "tailscale dns <subcommand> [flags]",
-	UsageFunc:  usageFuncNoDefaultValues,
+	Name:      "dns",
+	ShortHelp: "Diagnose the internal DNS forwarder",
+	LongHelp: strings.TrimSpace(`
+The 'tailscale dns' subcommand provides tools for diagnosing the internal DNS
+forwarder (100.100.100.100).
+
+For more information about the DNS functionality built into Tailscale, refer to
+https://tailscale.com/kb/1054/dns.
+`),
+	ShortUsage: strings.Join([]string{
+		dnsStatusCmd.ShortUsage,
+		dnsQueryCmd.ShortUsage,
+	}, "\n"),
+	UsageFunc: usageFuncNoDefaultValues,
 	Subcommands: []*ffcli.Command{
-		{
-			Name:       "status",
-			ShortUsage: "tailscale dns status [--all]",
-			Exec:       runDNSStatus,
-			ShortHelp:  "Print the current DNS status and configuration",
-			LongHelp:   dnsStatusLongHelp(),
-			FlagSet: (func() *flag.FlagSet {
-				fs := newFlagSet("status")
-				fs.BoolVar(&dnsStatusArgs.all, "all", false, "outputs advanced debugging information (fallback resolvers, nameservers, cert domains, extra records, and exit node filtered set)")
-				return fs
-			})(),
-		},
-		{
-			Name:       "query",
-			ShortUsage: "tailscale dns query <name> [a|aaaa|cname|mx|ns|opt|ptr|srv|txt]",
-			Exec:       runDNSQuery,
-			ShortHelp:  "Perform a DNS query",
-			LongHelp:   "The 'tailscale dns query' subcommand performs a DNS query for the specified name using the internal DNS forwarder (100.100.100.100).\n\nIt also provides information about the resolver(s) used to resolve the query.",
-		},
+		dnsStatusCmd,
+		dnsQueryCmd,
 
 		// TODO: implement `tailscale log` here
 
 		// The above work is tracked in https://github.com/tailscale/tailscale/issues/13326
 	},
-}
-
-func dnsCmdLongHelp() string {
-	return `The 'tailscale dns' subcommand provides tools for diagnosing the internal DNS forwarder (100.100.100.100).
-	
-For more information about the DNS functionality built into Tailscale, refer to https://tailscale.com/kb/1054/dns.`
 }


### PR DESCRIPTION
This patch contains the following cleanups:

1. Simplify `ffcli.Command` definitions;
2. Word-wrap help text, consistent with other commands;
3. `tailscale dns --help` usage makes subcommand usage more obvious;
4. `tailscale dns query --help` describes DNS record types.

Updates #cleanup

# Examples

``` console
sfllaw@h2co3:~/src/tailscale$ go run ./cmd/tailscale dns --help
Diagnose the internal DNS forwarder

USAGE
  tailscale dns status [--all]
  tailscale dns query <name> [a|aaaa|cname|mx|ns|opt|ptr|srv|txt]

The 'tailscale dns' subcommand provides tools for diagnosing the internal DNS
forwarder (100.100.100.100).

For more information about the DNS functionality built into Tailscale, refer to
https://tailscale.com/kb/1054/dns.

SUBCOMMANDS
  status  Print the current DNS status and configuration
  query   Perform a DNS query
```

``` console
sfllaw@h2co3:~/src/tailscale$ go run ./cmd/tailscale dns status --help
Print the current DNS status and configuration

USAGE
  tailscale dns status [--all]

The 'tailscale dns status' subcommand prints the current DNS status and
configuration, including:

- Whether the built-in DNS forwarder is enabled.

- The MagicDNS configuration provided by the coordination server.

- Details on which resolver(s) Tailscale believes the system is using by
  default.

The --all flag can be used to output advanced debugging information, including
fallback resolvers, nameservers, certificate domains, extra records, and the
exit node filtered set.

=== Contents of the MagicDNS configuration ===

The MagicDNS configuration is provided by the coordination server to the client
and includes the following components:

- MagicDNS enablement status: Indicates whether MagicDNS is enabled across the
  entire tailnet.

- MagicDNS Suffix: The DNS suffix used for devices within your tailnet.

- DNS Name: The DNS name that other devices in the tailnet can use to reach this
  device.

- Resolvers: The preferred DNS resolver(s) to be used for resolving queries, in
  order of preference. If no resolvers are listed here, the system defaults are
  used.

- Split DNS Routes: Custom DNS resolvers may be used to resolve hostnames in
  specific domains, this is also known as a 'Split DNS' configuration. The
  mapping of domains to their respective resolvers is provided here.

- Certificate Domains: The DNS names for which the coordination server will
  assist in provisioning TLS certificates.

- Extra Records: Additional DNS records that the coordination server might
  provide to the internal DNS resolver.

- Exit Node Filtered Set: DNS suffixes that the node, when acting as an exit
  node DNS proxy, will not answer.

For more information about the DNS functionality built into Tailscale, refer to
https://tailscale.com/kb/1054/dns.

FLAGS
  --all, --all=false
        outputs advanced debugging information (default false)
```

``` console
sfllaw@h2co3:~/src/tailscale$ go run ./cmd/tailscale dns query --help
Perform a DNS query

USAGE
  tailscale dns query <name> [a|aaaa|cname|mx|ns|opt|ptr|srv|txt]

The 'tailscale dns query' subcommand performs a DNS query for the specified name
using the internal DNS forwarder (100.100.100.100).

By default, the DNS query will request an A record. Another DNS record type can
be specified as the second parameter.

The output also provides information about the resolver(s) used to resolve the
query.
```