### PR TITLE
net/*: remove Windows exceptions for when Resolver.PreferGo didn't work

### DIFF
--- a/net/dns/resolver/tsdns_test.go
+++ b/net/dns/resolver/tsdns_test.go
@@ -1106,10 +1106,6 @@ type linkSelFunc func(ip netip.Addr) string
 func (f linkSelFunc) PickLink(ip netip.Addr) string { return f(ip) }
 
 func TestHandleExitNodeDNSQueryWithNetPkg(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on Windows; waiting for golang.org/issue/33097")
-	}
-
 	records := []any{
 		"no-records.test.",
 		dnsHandler(),
@@ -1405,9 +1401,6 @@ func TestHandleExitNodeDNSQueryWithNetPkg(t *testing.T) {
 // newWrapResolver returns a resolver that uses r (via handleExitNodeDNSQueryWithNetPkg)
 // to make DNS requests.
 func newWrapResolver(r *net.Resolver) *net.Resolver {
-	if runtime.GOOS == "windows" {
-		panic("doesn't work on Windows") // golang.org/issue/33097
-	}
 	return &net.Resolver{
 		PreferGo: true,
 		Dial: func(ctx context.Context, network, addr string) (net.Conn, error) {

--- a/net/dnscache/messagecache_test.go
+++ b/net/dnscache/messagecache_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"runtime"
 	"testing"
 	"time"
 
@@ -249,14 +248,6 @@ func TestGetDNSQueryCacheKey(t *testing.T) {
 }
 
 func getGoNetPacketDNSQuery(name string) []byte {
-	if runtime.GOOS == "windows" {
-		// On Windows, Go's net.Resolver doesn't use the DNS client.
-		// See https://github.com/golang/go/issues/33097 which
-		// was approved but not yet implemented.
-		// For now just pretend it's implemented to make this test
-		// pass on Windows with complicated the caller.
-		return makeQ(123, name)
-	}
 	res := make(chan []byte, 1)
 	r := &net.Resolver{
 		PreferGo: true,

--- a/net/tsdial/tsdial.go
+++ b/net/tsdial/tsdial.go
@@ -322,7 +322,7 @@ func (d *Dialer) userDialResolve(ctx context.Context, network, addr string) (net
 	}
 
 	var r net.Resolver
-	if exitDNSDoH != "" && runtime.GOOS != "windows" { // Windows: https://github.com/golang/go/issues/33097
+	if exitDNSDoH != "" {
 		r.PreferGo = true
 		r.Dial = func(ctx context.Context, network, address string) (net.Conn, error) {
 			return &dohConn{


### PR DESCRIPTION
Resolver.PreferGo didn't used to work on Windows.

It was fixed in 2022, though. (https://github.com/golang/go/issues/33097)

Updates #5161
