### PR TITLE
ipn/ipnlocal: make pricing restriction message for Tailnet Lock clearer

### DIFF
--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -1970,6 +1970,11 @@ func (h *Handler) serveTKAInit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !h.b.NetworkLockAllowed() {
+		http.Error(w, "Tailnet Lock is not supported on your pricing plan", http.StatusForbidden)
+		return
+	}
+
 	if err := h.b.NetworkLockInit(req.Keys, req.DisablementValues, req.SupportDisablement); err != nil {
 		http.Error(w, "initialization failed: "+err.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
Example:

```bash
$ tailscale lock init --gen-disablement-for-support --gen-disablements 10 --confirm tlpub:4266e5269c50683e2a61ad9c4d4f7fdee0a1cec0e370c1e308c656198dac1360
You are initializing tailnet lock with the following trusted signing keys:
 - tlpub:4266e5269c50683e2a61ad9c4d4f7fdee0a1cec0e370c1e308c656198dac1360 (25519 key)

error: Access denied: Tailnet Lock is not supported on your pricing plan
...
```

Fixes tailscale/corp#24417