### PR TITLE
Revert "types/netmap,wgengine/magicsock: propagate CapVer to magicsoc…

### DIFF
--- a/types/netmap/nodemut.go
+++ b/types/netmap/nodemut.go
@@ -69,17 +69,6 @@ func (m NodeMutationLastSeen) Apply(n *tailcfg.Node) {
 	n.LastSeen = ptr.To(m.LastSeen)
 }
 
-// NodeMutationCap is a NodeMutation that says a node's
-// [tailcfg.CapabilityVersion] value has changed.
-type NodeMutationCap struct {
-	mutatingNodeID
-	Cap tailcfg.CapabilityVersion
-}
-
-func (m NodeMutationCap) Apply(n *tailcfg.Node) {
-	n.Cap = m.Cap
-}
-
 var peerChangeFields = sync.OnceValue(func() []reflect.StructField {
 	var fields []reflect.StructField
 	rt := reflect.TypeFor[tailcfg.PeerChange]()
@@ -116,8 +105,6 @@ func NodeMutationsFromPatch(p *tailcfg.PeerChange) (_ []NodeMutation, ok bool) {
 			ret = append(ret, NodeMutationOnline{mutatingNodeID(p.NodeID), *p.Online})
 		case "LastSeen":
 			ret = append(ret, NodeMutationLastSeen{mutatingNodeID(p.NodeID), *p.LastSeen})
-		case "Cap":
-			ret = append(ret, NodeMutationCap{mutatingNodeID(p.NodeID), p.Cap})
 		}
 	}
 	return ret, true

--- a/types/netmap/nodemut_test.go
+++ b/types/netmap/nodemut_test.go
@@ -177,14 +177,6 @@ func TestMutationsFromMapResponse(t *testing.T) {
 			},
 			want: nil,
 		},
-		{
-			name: "patch-cap",
-			mr: fromChanges(&tailcfg.PeerChange{
-				NodeID: 1,
-				Cap:    2,
-			}),
-			want: muts(NodeMutationCap{1, 2}),
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -203,7 +195,6 @@ func TestMutationsFromMapResponse(t *testing.T) {
 					NodeMutationDERPHome{},
 					NodeMutationOnline{},
 					NodeMutationLastSeen{},
-					NodeMutationCap{},
 				)); diff != "" {
 				t.Errorf("wrong result (-want +got):\n%s", diff)
 			}

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -3263,10 +3263,6 @@ func (c *Conn) onNodeMutationsUpdate(update NodeMutationsUpdate) {
 			ep.mu.Lock()
 			ep.setEndpointsLocked(views.SliceOf(m.Endpoints))
 			ep.mu.Unlock()
-		case netmap.NodeMutationCap:
-			ep.mu.Lock()
-			ep.relayCapable = capVerIsRelayCapable(m.Cap)
-			ep.mu.Unlock()
 		}
 	}
 }


### PR DESCRIPTION
…k.endpoint (#16244)"

This reverts commit 6a93b17c8cafc1d8e1c52e133511e52ed9086355.

The reverted commit added more complexity than it was worth at the current stage. Handling delta CapVer changes requires extensive changes to relayManager datastructures in order to also support delta updates of relay servers.

Updates tailscale/corp#27502