### PR TITLE
cmd/k8s-operator: use state Secret for checking device auth

### DIFF
--- a/cmd/containerboot/kube_test.go
+++ b/cmd/containerboot/kube_test.go
@@ -8,13 +8,18 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"tailscale.com/ipn"
+	"tailscale.com/kube/egressservices"
+	"tailscale.com/kube/ingressservices"
 	"tailscale.com/kube/kubeapi"
 	"tailscale.com/kube/kubeclient"
+	"tailscale.com/kube/kubetypes"
+	"tailscale.com/tailcfg"
 )
 
 func TestSetupKube(t *testing.T) {
@@ -236,5 +241,80 @@ func TestWaitForConsistentState(t *testing.T) {
 	data[string(ipn.CurrentProfileStateKey)] = []byte("")
 	if err := kc.waitForConsistentState(ctx); err != nil {
 		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestResetContainerbootState(t *testing.T) {
+	capver := fmt.Appendf(nil, "%d", tailcfg.CurrentCapabilityVersion)
+	for name, tc := range map[string]struct {
+		podUID   string
+		initial  map[string][]byte
+		expected map[string][]byte
+	}{
+		"empty_initial": {
+			podUID:  "1234",
+			initial: map[string][]byte{},
+			expected: map[string][]byte{
+				kubetypes.KeyCapVer: capver,
+				kubetypes.KeyPodUID: []byte("1234"),
+			},
+		},
+		"empty_initial_no_pod_uid": {
+			initial: map[string][]byte{},
+			expected: map[string][]byte{
+				kubetypes.KeyCapVer: capver,
+			},
+		},
+		"only_relevant_keys_updated": {
+			podUID: "1234",
+			initial: map[string][]byte{
+				kubetypes.KeyCapVer:              []byte("1"),
+				kubetypes.KeyPodUID:              []byte("5678"),
+				kubetypes.KeyDeviceID:            []byte("device-id"),
+				kubetypes.KeyDeviceFQDN:          []byte("device-fqdn"),
+				kubetypes.KeyDeviceIPs:           []byte(`["192.0.2.1"]`),
+				kubetypes.KeyHTTPSEndpoint:       []byte("https://example.com"),
+				egressservices.KeyEgressServices: []byte("egress-services"),
+				ingressservices.IngressConfigKey: []byte("ingress-config"),
+				"_current-profile":               []byte("current-profile"),
+				"_machinekey":                    []byte("machine-key"),
+				"_profiles":                      []byte("profiles"),
+				"_serve_e0ce":                    []byte("serve-e0ce"),
+				"profile-e0ce":                   []byte("profile-e0ce"),
+			},
+			expected: map[string][]byte{
+				kubetypes.KeyCapVer: capver,
+				kubetypes.KeyPodUID: []byte("1234"),
+				// Cleared keys.
+				kubetypes.KeyDeviceID:            nil,
+				kubetypes.KeyDeviceFQDN:          nil,
+				kubetypes.KeyDeviceIPs:           nil,
+				kubetypes.KeyHTTPSEndpoint:       nil,
+				egressservices.KeyEgressServices: nil,
+				ingressservices.IngressConfigKey: nil,
+				// Tailscaled keys not included in patch.
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var actual map[string][]byte
+			kc := &kubeClient{stateSecret: "foo", Client: &kubeclient.FakeClient{
+				GetSecretImpl: func(context.Context, string) (*kubeapi.Secret, error) {
+					return &kubeapi.Secret{
+						Data: tc.initial,
+					}, nil
+				},
+				StrategicMergePatchSecretImpl: func(ctx context.Context, name string, secret *kubeapi.Secret, _ string) error {
+					actual = secret.Data
+					return nil
+				},
+			}}
+			if err := kc.resetContainerbootState(context.Background(), tc.podUID); err != nil {
+				t.Fatalf("resetContainerbootState() error = %v", err)
+			}
+			if diff := cmp.Diff(tc.expected, actual); diff != "" {
+				t.Errorf("resetContainerbootState() mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/cmd/containerboot/main_test.go
+++ b/cmd/containerboot/main_test.go
@@ -460,6 +460,7 @@ func TestContainerBoot(t *testing.T) {
 				Env: map[string]string{
 					"KUBERNETES_SERVICE_HOST":       env.kube.Host,
 					"KUBERNETES_SERVICE_PORT_HTTPS": env.kube.Port,
+					"POD_UID":                       "some-pod-uid",
 				},
 				KubeSecret: map[string]string{
 					"authkey": "tskey-key",
@@ -471,17 +472,20 @@ func TestContainerBoot(t *testing.T) {
 							"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --authkey=tskey-key",
 						},
 						WantKubeSecret: map[string]string{
-							"authkey": "tskey-key",
+							"authkey":           "tskey-key",
+							kubetypes.KeyCapVer: capver,
+							kubetypes.KeyPodUID: "some-pod-uid",
 						},
 					},
 					{
 						Notify: runningNotify,
 						WantKubeSecret: map[string]string{
-							"authkey":          "tskey-key",
-							"device_fqdn":      "test-node.test.ts.net",
-							"device_id":        "myID",
-							"device_ips":       `["100.64.0.1"]`,
-							"tailscale_capver": capver,
+							"authkey":           "tskey-key",
+							"device_fqdn":       "test-node.test.ts.net",
+							"device_id":         "myID",
+							"device_ips":        `["100.64.0.1"]`,
+							kubetypes.KeyCapVer: capver,
+							kubetypes.KeyPodUID: "some-pod-uid",
 						},
 					},
 				},
@@ -554,7 +558,8 @@ func TestContainerBoot(t *testing.T) {
 							"/usr/bin/tailscaled --socket=/tmp/tailscaled.sock --state=kube:tailscale --statedir=/tmp --tun=userspace-networking",
 						},
 						WantKubeSecret: map[string]string{
-							"authkey": "tskey-key",
+							"authkey":           "tskey-key",
+							kubetypes.KeyCapVer: capver,
 						},
 					},
 					{
@@ -565,7 +570,8 @@ func TestContainerBoot(t *testing.T) {
 							"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --authkey=tskey-key",
 						},
 						WantKubeSecret: map[string]string{
-							"authkey": "tskey-key",
+							"authkey":           "tskey-key",
+							kubetypes.KeyCapVer: capver,
 						},
 					},
 					{
@@ -574,10 +580,10 @@ func TestContainerBoot(t *testing.T) {
 							"/usr/bin/tailscale --socket=/tmp/tailscaled.sock set --accept-dns=false",
 						},
 						WantKubeSecret: map[string]string{
-							"device_fqdn":      "test-node.test.ts.net",
-							"device_id":        "myID",
-							"device_ips":       `["100.64.0.1"]`,
-							"tailscale_capver": capver,
+							"device_fqdn":       "test-node.test.ts.net",
+							"device_id":         "myID",
+							"device_ips":        `["100.64.0.1"]`,
+							kubetypes.KeyCapVer: capver,
 						},
 					},
 				},
@@ -599,17 +605,18 @@ func TestContainerBoot(t *testing.T) {
 							"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --authkey=tskey-key",
 						},
 						WantKubeSecret: map[string]string{
-							"authkey": "tskey-key",
+							"authkey":           "tskey-key",
+							kubetypes.KeyCapVer: capver,
 						},
 					},
 					{
 						Notify: runningNotify,
 						WantKubeSecret: map[string]string{
-							"authkey":          "tskey-key",
-							"device_fqdn":      "test-node.test.ts.net",
-							"device_id":        "myID",
-							"device_ips":       `["100.64.0.1"]`,
-							"tailscale_capver": capver,
+							"authkey":           "tskey-key",
+							"device_fqdn":       "test-node.test.ts.net",
+							"device_id":         "myID",
+							"device_ips":        `["100.64.0.1"]`,
+							kubetypes.KeyCapVer: capver,
 						},
 					},
 					{
@@ -624,11 +631,11 @@ func TestContainerBoot(t *testing.T) {
 							},
 						},
 						WantKubeSecret: map[string]string{
-							"authkey":          "tskey-key",
-							"device_fqdn":      "new-name.test.ts.net",
-							"device_id":        "newID",
-							"device_ips":       `["100.64.0.1"]`,
-							"tailscale_capver": capver,
+							"authkey":           "tskey-key",
+							"device_fqdn":       "new-name.test.ts.net",
+							"device_id":         "newID",
+							"device_ips":        `["100.64.0.1"]`,
+							kubetypes.KeyCapVer: capver,
 						},
 					},
 				},
@@ -912,18 +919,19 @@ func TestContainerBoot(t *testing.T) {
 							"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --authkey=tskey-key",
 						},
 						WantKubeSecret: map[string]string{
-							"authkey": "tskey-key",
+							"authkey":           "tskey-key",
+							kubetypes.KeyCapVer: capver,
 						},
 					},
 					{
 						Notify: runningNotify,
 						WantKubeSecret: map[string]string{
-							"authkey":          "tskey-key",
-							"device_fqdn":      "test-node.test.ts.net",
-							"device_id":        "myID",
-							"device_ips":       `["100.64.0.1"]`,
-							"https_endpoint":   "no-https",
-							"tailscale_capver": capver,
+							"authkey":           "tskey-key",
+							"device_fqdn":       "test-node.test.ts.net",
+							"device_id":         "myID",
+							"device_ips":        `["100.64.0.1"]`,
+							"https_endpoint":    "no-https",
+							kubetypes.KeyCapVer: capver,
 						},
 					},
 				},
@@ -947,7 +955,8 @@ func TestContainerBoot(t *testing.T) {
 							"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --authkey=tskey-key",
 						},
 						WantKubeSecret: map[string]string{
-							"authkey": "tskey-key",
+							"authkey":           "tskey-key",
+							kubetypes.KeyCapVer: capver,
 						},
 						EndpointStatuses: map[string]int{
 							egressSvcTerminateURL(env.localAddrPort): 200,
@@ -956,12 +965,12 @@ func TestContainerBoot(t *testing.T) {
 					{
 						Notify: runningNotify,
 						WantKubeSecret: map[string]string{
-							"egress-services":  mustBase64(t, egressStatus),
-							"authkey":          "tskey-key",
-							"device_fqdn":      "test-node.test.ts.net",
-							"device_id":        "myID",
-							"device_ips":       `["100.64.0.1"]`,
-							"tailscale_capver": capver,
+							"egress-services":   string(mustJSON(t, egressStatus)),
+							"authkey":           "tskey-key",
+							"device_fqdn":       "test-node.test.ts.net",
+							"device_id":         "myID",
+							"device_ips":        `["100.64.0.1"]`,
+							kubetypes.KeyCapVer: capver,
 						},
 						EndpointStatuses: map[string]int{
 							egressSvcTerminateURL(env.localAddrPort): 200,
@@ -1002,7 +1011,8 @@ func TestContainerBoot(t *testing.T) {
 							"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --authkey=tskey-key",
 						},
 						WantKubeSecret: map[string]string{
-							"authkey": "tskey-key",
+							"authkey":           "tskey-key",
+							kubetypes.KeyCapVer: capver,
 						},
 					},
 					{
@@ -1016,10 +1026,11 @@ func TestContainerBoot(t *testing.T) {
 							// Missing "_current-profile" key.
 						},
 						WantKubeSecret: map[string]string{
-							"authkey":      "tskey-key",
-							"_machinekey":  "foo",
-							"_profiles":    "foo",
-							"profile-baff": "foo",
+							"authkey":           "tskey-key",
+							"_machinekey":       "foo",
+							"_profiles":         "foo",
+							"profile-baff":      "foo",
+							kubetypes.KeyCapVer: capver,
 						},
 						WantLog: "Waiting for tailscaled to finish writing state to Secret \"tailscale\"",
 					},
@@ -1029,11 +1040,12 @@ func TestContainerBoot(t *testing.T) {
 							"_current-profile": "foo",
 						},
 						WantKubeSecret: map[string]string{
-							"authkey":          "tskey-key",
-							"_machinekey":      "foo",
-							"_profiles":        "foo",
-							"profile-baff":     "foo",
-							"_current-profile": "foo",
+							"authkey":           "tskey-key",
+							"_machinekey":       "foo",
+							"_profiles":         "foo",
+							"profile-baff":      "foo",
+							"_current-profile":  "foo",
+							kubetypes.KeyCapVer: capver,
 						},
 						WantLog:      "HTTP server at [::]:9002 closed",
 						WantExitCode: ptr.To(0),
@@ -1061,7 +1073,7 @@ func TestContainerBoot(t *testing.T) {
 				fmt.Sprintf("TS_TEST_SOCKET=%s", env.lapi.Path),
 				fmt.Sprintf("TS_SOCKET=%s", env.runningSockPath),
 				fmt.Sprintf("TS_TEST_ONLY_ROOT=%s", env.d),
-				fmt.Sprint("TS_TEST_FAKE_NETFILTER=true"),
+				"TS_TEST_FAKE_NETFILTER=true",
 			}
 			for k, v := range tc.Env {
 				cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
@@ -1489,10 +1501,7 @@ func (k *kubeServer) serveSecret(w http.ResponseWriter, r *http.Request) {
 		}
 		switch r.Header.Get("Content-Type") {
 		case "application/json-patch+json":
-			req := []struct {
-				Op   string `json:"op"`
-				Path string `json:"path"`
-			}{}
+			req := []kubeclient.JSONPatch{}
 			if err := json.Unmarshal(bs, &req); err != nil {
 				panic(fmt.Sprintf("json decode failed: %v. Body:\n\n%s", err, string(bs)))
 			}
@@ -1503,23 +1512,20 @@ func (k *kubeServer) serveSecret(w http.ResponseWriter, r *http.Request) {
 						panic(fmt.Sprintf("unsupported json-patch path %q", op.Path))
 					}
 					delete(k.secret, strings.TrimPrefix(op.Path, "/data/"))
-				case "replace":
+				case "add", "replace":
 					path, ok := strings.CutPrefix(op.Path, "/data/")
 					if !ok {
 						panic(fmt.Sprintf("unsupported json-patch path %q", op.Path))
 					}
-					req := make([]kubeclient.JSONPatch, 0)
-					if err := json.Unmarshal(bs, &req); err != nil {
-						panic(fmt.Sprintf("json decode failed: %v. Body:\n\n%s", err, string(bs)))
+					val, ok := op.Value.(string)
+					if !ok {
+						panic(fmt.Sprintf("unsupported json patch value %v: cannot be converted to string", op.Value))
 					}
-
-					for _, patch := range req {
-						val, ok := patch.Value.(string)
-						if !ok {
-							panic(fmt.Sprintf("unsupported json patch value %v: cannot be converted to string", patch.Value))
-						}
-						k.secret[path] = val
+					v, err := base64.StdEncoding.DecodeString(val)
+					if err != nil {
+						panic(fmt.Sprintf("json patch value %q is not base64 encoded: %v", val, err))
 					}
+					k.secret[path] = string(v)
 				default:
 					panic(fmt.Sprintf("unsupported json-patch op %q", op.Op))
 				}

--- a/cmd/k8s-operator/egress-services-readiness.go
+++ b/cmd/k8s-operator/egress-services-readiness.go
@@ -102,7 +102,7 @@ func (esrr *egressSvcsReadinessReconciler) Reconcile(ctx context.Context, req re
 		msg = err.Error()
 		return res, err
 	}
-	if !tsoperator.ProxyGroupIsReady(pg) {
+	if !tsoperator.ProxyGroupAvailable(pg) {
 		l.Infof("ProxyGroup for Service is not ready, waiting...")
 		reason, msg = reasonClusterResourcesNotReady, reasonClusterResourcesNotReady
 		st = metav1.ConditionFalse

--- a/cmd/k8s-operator/egress-services-readiness_test.go
+++ b/cmd/k8s-operator/egress-services-readiness_test.go
@@ -137,7 +137,7 @@ func setReady(svc *corev1.Service, cl tstime.Clock, l *zap.SugaredLogger, replic
 }
 
 func setPGReady(pg *tsapi.ProxyGroup, cl tstime.Clock, l *zap.SugaredLogger) {
-	tsoperator.SetProxyGroupCondition(pg, tsapi.ProxyGroupReady, metav1.ConditionTrue, "foo", "foo", pg.Generation, cl, l)
+	tsoperator.SetProxyGroupCondition(pg, tsapi.ProxyGroupAvailable, metav1.ConditionTrue, "foo", "foo", pg.Generation, cl, l)
 }
 
 func setEndpointForReplica(pg *tsapi.ProxyGroup, ordinal int32, eps *discoveryv1.EndpointSlice) {

--- a/cmd/k8s-operator/egress-services.go
+++ b/cmd/k8s-operator/egress-services.go
@@ -531,7 +531,7 @@ func (esr *egressSvcsReconciler) validateClusterResources(ctx context.Context, s
 		tsoperator.RemoveServiceCondition(svc, tsapi.EgressSvcConfigured)
 		return false, nil
 	}
-	if !tsoperator.ProxyGroupIsReady(pg) {
+	if !tsoperator.ProxyGroupAvailable(pg) {
 		tsoperator.SetServiceCondition(svc, tsapi.EgressSvcValid, metav1.ConditionUnknown, reasonProxyGroupNotReady, reasonProxyGroupNotReady, esr.clock, l)
 		tsoperator.RemoveServiceCondition(svc, tsapi.EgressSvcConfigured)
 	}

--- a/cmd/k8s-operator/ingress-for-pg.go
+++ b/cmd/k8s-operator/ingress-for-pg.go
@@ -182,7 +182,7 @@ func (r *HAIngressReconciler) maybeProvision(ctx context.Context, hostname strin
 		}
 		return false, fmt.Errorf("getting ProxyGroup %q: %w", pgName, err)
 	}
-	if !tsoperator.ProxyGroupIsReady(pg) {
+	if !tsoperator.ProxyGroupAvailable(pg) {
 		logger.Infof("ProxyGroup is not (yet) ready")
 		return false, nil
 	}
@@ -666,7 +666,7 @@ func (r *HAIngressReconciler) validateIngress(ctx context.Context, ing *networki
 	}
 
 	// Validate TLS configuration
-	if ing.Spec.TLS != nil && len(ing.Spec.TLS) > 0 && (len(ing.Spec.TLS) > 1 || len(ing.Spec.TLS[0].Hosts) > 1) {
+	if len(ing.Spec.TLS) > 0 && (len(ing.Spec.TLS) > 1 || len(ing.Spec.TLS[0].Hosts) > 1) {
 		errs = append(errs, fmt.Errorf("Ingress contains invalid TLS block %v: only a single TLS entry with a single host is allowed", ing.Spec.TLS))
 	}
 
@@ -683,7 +683,7 @@ func (r *HAIngressReconciler) validateIngress(ctx context.Context, ing *networki
 	}
 
 	// Validate ProxyGroup readiness
-	if !tsoperator.ProxyGroupIsReady(pg) {
+	if !tsoperator.ProxyGroupAvailable(pg) {
 		errs = append(errs, fmt.Errorf("ProxyGroup %q is not ready", pg.Name))
 	}
 

--- a/cmd/k8s-operator/ingress-for-pg_test.go
+++ b/cmd/k8s-operator/ingress-for-pg_test.go
@@ -305,7 +305,7 @@ func TestValidateIngress(t *testing.T) {
 		Status: tsapi.ProxyGroupStatus{
 			Conditions: []metav1.Condition{
 				{
-					Type:               string(tsapi.ProxyGroupReady),
+					Type:               string(tsapi.ProxyGroupAvailable),
 					Status:             metav1.ConditionTrue,
 					ObservedGeneration: 1,
 				},
@@ -399,7 +399,7 @@ func TestValidateIngress(t *testing.T) {
 				Status: tsapi.ProxyGroupStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:               string(tsapi.ProxyGroupReady),
+							Type:               string(tsapi.ProxyGroupAvailable),
 							Status:             metav1.ConditionFalse,
 							ObservedGeneration: 1,
 						},
@@ -755,7 +755,7 @@ func verifyTailscaledConfig(t *testing.T, fc client.Client, pgName string, expec
 			Labels:    pgSecretLabels(pgName, "config"),
 		},
 		Data: map[string][]byte{
-			tsoperator.TailscaledConfigFileName(106): []byte(fmt.Sprintf(`{"Version":""%s}`, expected)),
+			tsoperator.TailscaledConfigFileName(pgMinCapabilityVersion): []byte(fmt.Sprintf(`{"Version":""%s}`, expected)),
 		},
 	})
 }
@@ -794,13 +794,13 @@ func createPGResources(t *testing.T, fc client.Client, pgName string) {
 			Labels:    pgSecretLabels(pgName, "config"),
 		},
 		Data: map[string][]byte{
-			tsoperator.TailscaledConfigFileName(106): []byte("{}"),
+			tsoperator.TailscaledConfigFileName(pgMinCapabilityVersion): []byte("{}"),
 		},
 	}
 	mustCreate(t, fc, pgCfgSecret)
 	pg.Status.Conditions = []metav1.Condition{
 		{
-			Type:               string(tsapi.ProxyGroupReady),
+			Type:               string(tsapi.ProxyGroupAvailable),
 			Status:             metav1.ConditionTrue,
 			ObservedGeneration: 1,
 		},

--- a/cmd/k8s-operator/proxygroup_specs.go
+++ b/cmd/k8s-operator/proxygroup_specs.go
@@ -351,7 +351,7 @@ func pgStateSecrets(pg *tsapi.ProxyGroup, namespace string) (secrets []*corev1.S
 	for i := range pgReplicas(pg) {
 		secrets = append(secrets, &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            fmt.Sprintf("%s-%d", pg.Name, i),
+				Name:            pgStateSecretName(pg.Name, i),
 				Namespace:       namespace,
 				Labels:          pgSecretLabels(pg.Name, "state"),
 				OwnerReferences: pgOwnerReference(pg),
@@ -420,6 +420,10 @@ func pgReplicas(pg *tsapi.ProxyGroup) int32 {
 
 func pgConfigSecretName(pgName string, i int32) string {
 	return fmt.Sprintf("%s-%d-config", pgName, i)
+}
+
+func pgStateSecretName(pgName string, i int32) string {
+	return fmt.Sprintf("%s-%d", pgName, i)
 }
 
 func pgEgressCMName(pg string) string {

--- a/cmd/k8s-operator/svc-for-pg.go
+++ b/cmd/k8s-operator/svc-for-pg.go
@@ -164,7 +164,7 @@ func (r *HAServiceReconciler) maybeProvision(ctx context.Context, hostname strin
 		}
 		return false, fmt.Errorf("getting ProxyGroup %q: %w", pgName, err)
 	}
-	if !tsoperator.ProxyGroupIsReady(pg) {
+	if !tsoperator.ProxyGroupAvailable(pg) {
 		logger.Infof("ProxyGroup is not (yet) ready")
 		return false, nil
 	}

--- a/cmd/k8s-operator/svc-for-pg_test.go
+++ b/cmd/k8s-operator/svc-for-pg_test.go
@@ -142,7 +142,7 @@ func setupServiceTest(t *testing.T) (*HAServiceReconciler, *corev1.Secret, clien
 			Labels:    pgSecretLabels("test-pg", "config"),
 		},
 		Data: map[string][]byte{
-			tsoperator.TailscaledConfigFileName(106): []byte(`{"Version":""}`),
+			tsoperator.TailscaledConfigFileName(pgMinCapabilityVersion): []byte(`{"Version":""}`),
 		},
 	}
 
@@ -179,7 +179,7 @@ func setupServiceTest(t *testing.T) (*HAServiceReconciler, *corev1.Secret, clien
 	// Set ProxyGroup status to ready
 	pg.Status.Conditions = []metav1.Condition{
 		{
-			Type:               string(tsapi.ProxyGroupReady),
+			Type:               string(tsapi.ProxyGroupAvailable),
 			Status:             metav1.ConditionTrue,
 			ObservedGeneration: 1,
 		},

--- a/cmd/k8s-operator/tsrecorder.go
+++ b/cmd/k8s-operator/tsrecorder.go
@@ -446,18 +446,15 @@ func (r *RecorderReconciler) getDeviceInfo(ctx context.Context, tsrName string) 
 		return tsapi.RecorderTailnetDevice{}, false, err
 	}
 
-	return getDeviceInfo(ctx, r.tsClient, secret)
-}
-
-func getDeviceInfo(ctx context.Context, tsClient tsClient, secret *corev1.Secret) (d tsapi.RecorderTailnetDevice, ok bool, err error) {
 	prefs, ok, err := getDevicePrefs(secret)
 	if !ok || err != nil {
 		return tsapi.RecorderTailnetDevice{}, false, err
 	}
 
 	// TODO(tomhjp): The profile info doesn't include addresses, which is why we
-	// need the API. Should we instead update the profile to include addresses?
-	device, err := tsClient.Device(ctx, string(prefs.Config.NodeID), nil)
+	// need the API. Should maybe update tsrecorder to write IPs to the state
+	// Secret like containerboot does.
+	device, err := r.tsClient.Device(ctx, string(prefs.Config.NodeID), nil)
 	if err != nil {
 		return tsapi.RecorderTailnetDevice{}, false, fmt.Errorf("failed to get device info from API: %w", err)
 	}

--- a/k8s-operator/apis/v1alpha1/types_connector.go
+++ b/k8s-operator/apis/v1alpha1/types_connector.go
@@ -205,11 +205,12 @@ type ConnectorStatus struct {
 type ConditionType string
 
 const (
-	ConnectorReady  ConditionType = `ConnectorReady`
-	ProxyClassReady ConditionType = `ProxyClassReady`
-	ProxyGroupReady ConditionType = `ProxyGroupReady`
-	ProxyReady      ConditionType = `TailscaleProxyReady` // a Tailscale-specific condition type for corev1.Service
-	RecorderReady   ConditionType = `RecorderReady`
+	ConnectorReady      ConditionType = `ConnectorReady`
+	ProxyClassReady     ConditionType = `ProxyClassReady`
+	ProxyGroupReady     ConditionType = `ProxyGroupReady`     // All proxy Pods running.
+	ProxyGroupAvailable ConditionType = `ProxyGroupAvailable` // At least one proxy Pod running.
+	ProxyReady          ConditionType = `TailscaleProxyReady` // a Tailscale-specific condition type for corev1.Service
+	RecorderReady       ConditionType = `RecorderReady`
 	// EgressSvcValid gets set on a user configured ExternalName Service that defines a tailnet target to be exposed
 	// on a ProxyGroup.
 	// Set to true if the user provided configuration is valid.

--- a/k8s-operator/conditions.go
+++ b/k8s-operator/conditions.go
@@ -137,8 +137,16 @@ func ProxyClassIsReady(pc *tsapi.ProxyClass) bool {
 }
 
 func ProxyGroupIsReady(pg *tsapi.ProxyGroup) bool {
+	return proxyGroupCondition(pg, tsapi.ProxyGroupReady)
+}
+
+func ProxyGroupAvailable(pg *tsapi.ProxyGroup) bool {
+	return proxyGroupCondition(pg, tsapi.ProxyGroupAvailable)
+}
+
+func proxyGroupCondition(pg *tsapi.ProxyGroup, condType tsapi.ConditionType) bool {
 	idx := xslices.IndexFunc(pg.Status.Conditions, func(cond metav1.Condition) bool {
-		return cond.Type == string(tsapi.ProxyGroupReady)
+		return cond.Type == string(condType)
 	})
 	if idx == -1 {
 		return false

--- a/kube/kubeclient/fake_client.go
+++ b/kube/kubeclient/fake_client.go
@@ -13,12 +13,13 @@ import (
 var _ Client = &FakeClient{}
 
 type FakeClient struct {
-	GetSecretImpl              func(context.Context, string) (*kubeapi.Secret, error)
-	CheckSecretPermissionsImpl func(ctx context.Context, name string) (bool, bool, error)
-	CreateSecretImpl           func(context.Context, *kubeapi.Secret) error
-	UpdateSecretImpl           func(context.Context, *kubeapi.Secret) error
-	JSONPatchResourceImpl      func(context.Context, string, string, []JSONPatch) error
-	ListSecretsImpl            func(context.Context, map[string]string) (*kubeapi.SecretList, error)
+	GetSecretImpl                 func(context.Context, string) (*kubeapi.Secret, error)
+	CheckSecretPermissionsImpl    func(ctx context.Context, name string) (bool, bool, error)
+	CreateSecretImpl              func(context.Context, *kubeapi.Secret) error
+	UpdateSecretImpl              func(context.Context, *kubeapi.Secret) error
+	JSONPatchResourceImpl         func(context.Context, string, string, []JSONPatch) error
+	ListSecretsImpl               func(context.Context, map[string]string) (*kubeapi.SecretList, error)
+	StrategicMergePatchSecretImpl func(context.Context, string, *kubeapi.Secret, string) error
 }
 
 func (fc *FakeClient) CheckSecretPermissions(ctx context.Context, name string) (bool, bool, error) {
@@ -30,8 +31,8 @@ func (fc *FakeClient) GetSecret(ctx context.Context, name string) (*kubeapi.Secr
 func (fc *FakeClient) SetURL(_ string) {}
 func (fc *FakeClient) SetDialer(dialer func(ctx context.Context, network, addr string) (net.Conn, error)) {
 }
-func (fc *FakeClient) StrategicMergePatchSecret(context.Context, string, *kubeapi.Secret, string) error {
-	return nil
+func (fc *FakeClient) StrategicMergePatchSecret(ctx context.Context, name string, s *kubeapi.Secret, fieldManager string) error {
+	return fc.StrategicMergePatchSecretImpl(ctx, name, s, fieldManager)
 }
 func (fc *FakeClient) Event(context.Context, string, string, string) error {
 	return nil


### PR DESCRIPTION
Previously, the operator checked the `ProxyGroup` status fields for information on how many of the proxies had successfully authed. Use their state `Secrets` instead as a more reliable source of truth.

Containerboot has written `device_fqdn` and `device_ips` keys to the state `Secret` since inception, and `pod_uid` since 1.78.0, so there's no need to use the API for that data. Read it from the state `Secret` for consistency. However, to ensure we don't read data from a previous run of containerboot, make sure we reset containerboot's state keys on startup.

One other knock-on effect of that is `ProxyGroups` can briefly be marked not Ready while a `Pod` is restarting. Introduce a new `ProxyGroupAvailable` condition to more accurately reflect when downstream controllers can implement flows that rely on a `ProxyGroup` having at least 1 proxy Pod running.

Fixes #16327

Change-Id: I026c18e9d23e87109a471a87b8e4fb6271716a66