### PR TITLE
wgengine/magicsock: set Geneve header protocol for WireGuard

### DIFF
--- a/wgengine/magicsock/batching_conn_linux.go
+++ b/wgengine/magicsock/batching_conn_linux.go
@@ -114,6 +114,7 @@ func (c *linuxBatchingConn) coalesceMessages(addr *net.UDPAddr, vni virtualNetwo
 	vniIsSet := vni.isSet()
 	var gh packet.GeneveHeader
 	if vniIsSet {
+		gh.Protocol = packet.GeneveProtocolWireGuard
 		gh.VNI = vni.get()
 	}
 	for i, buff := range buffs {
@@ -202,6 +203,7 @@ retry:
 		vniIsSet := addr.vni.isSet()
 		var gh packet.GeneveHeader
 		if vniIsSet {
+			gh.Protocol = packet.GeneveProtocolWireGuard
 			gh.VNI = addr.vni.get()
 			offset -= packet.GeneveFixedHeaderLength
 		}

--- a/wgengine/magicsock/rebinding_conn.go
+++ b/wgengine/magicsock/rebinding_conn.go
@@ -85,7 +85,8 @@ func (c *RebindingUDPConn) WriteBatchTo(buffs [][]byte, addr epAddr, offset int)
 			var gh packet.GeneveHeader
 			if vniIsSet {
 				gh = packet.GeneveHeader{
-					VNI: addr.vni.get(),
+					Protocol: packet.GeneveProtocolWireGuard,
+					VNI:      addr.vni.get(),
 				}
 			}
 			for _, buf := range buffs {


### PR DESCRIPTION
Otherwise receives interpret as naked WireGuard.

Updates tailscale/corp#27502