### PR TITLE
wgengine/magicsock: remove premature return in handshakeServerEndpoint

### DIFF
--- a/wgengine/magicsock/relaymanager.go
+++ b/wgengine/magicsock/relaymanager.go
@@ -691,7 +691,6 @@ func (r *relayManager) handshakeServerEndpoint(work *relayHandshakeWork) {
 				// unexpected message type, silently discard
 				continue
 			}
-			return
 		case <-timer.C:
 			// The handshake timed out.
 			return


### PR DESCRIPTION
Any return underneath this select case must belong to a type switch case.

Updates tailscale/corp#27502