### PR TITLE
docs: fix capitalisation of "GitHub" in commit-messages.md

### DIFF
--- a/docs/commit-messages.md
+++ b/docs/commit-messages.md
@@ -100,7 +100,7 @@ shorter and easier to test.
 Updates #nnnn
 ```
 
-Please say `Updates` and not other common Github-recognized conventions (that is, don't use `For #nnnn`)
+Please say `Updates` and not other common GitHub-recognized conventions (that is, don't use `For #nnnn`)
 
 ## Public release notes
 


### PR DESCRIPTION
Updates: #cleanup