### PR TITLE
ipn/ipnlocal: Update hostinfo to control on service config change (#16146)

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -6137,17 +6137,17 @@ func (b *LocalBackend) setTCPPortsInterceptedFromNetmapAndPrefsLocked(prefs ipn.
 		}
 	}
 
-	// Update funnel info in hostinfo and kick off control update if needed.
-	b.updateIngressLocked()
+	// Update funnel and service hash info in hostinfo and kick off control update if needed.
+	b.updateIngressAndServiceHashLocked(prefs)
 	b.setTCPPortsIntercepted(handlePorts)
 	b.setVIPServicesTCPPortsInterceptedLocked(vipServicesPorts)
 }
 
-// updateIngressLocked updates the hostinfo.WireIngress and hostinfo.IngressEnabled fields and kicks off a Hostinfo
-// update if the values have changed.
+// updateIngressAndServiceHashLocked updates the hostinfo.ServicesHash, hostinfo.WireIngress and
+// hostinfo.IngressEnabled fields and kicks off a Hostinfo update if the values have changed.
 //
 // b.mu must be held.
-func (b *LocalBackend) updateIngressLocked() {
+func (b *LocalBackend) updateIngressAndServiceHashLocked(prefs ipn.PrefsView) {
 	if b.hostinfo == nil {
 		return
 	}
@@ -6160,6 +6160,11 @@ func (b *LocalBackend) updateIngressLocked() {
 	if wire := b.shouldWireInactiveIngressLocked(); b.hostinfo.WireIngress != wire {
 		b.logf("Hostinfo.WireIngress changed to %v", wire)
 		b.hostinfo.WireIngress = wire
+		hostInfoChanged = true
+	}
+	latestHash := b.vipServiceHash(b.vipServicesFromPrefsLocked(prefs))
+	if b.hostinfo.ServicesHash != latestHash {
+		b.hostinfo.ServicesHash = latestHash
 		hostInfoChanged = true
 	}
 	// Kick off a Hostinfo update to control if ingress status has changed.


### PR DESCRIPTION
This PR cherry-picks https://github.com/tailscale/tailscale/pull/16146 into 1.84 release branch, so that we can cut a patch release for Kubernetes Operator with this change.

Without this fix the Kubernetes Operator's HA Ingress fails during initial setup (fails to provision TLS certs for the proxies).

Fixes tailscale/corp#29219

cc @tomhjp @ChaosInTheCRD 


(cherry picked from commit 7b06532ea108bd7d12785125c2423a1a4e9987b3)