### PR TITLE
release/dist: switch back to Ubuntu 20.04 for building QNAP packages

### DIFF
--- a/release/dist/qnap/files/scripts/Dockerfile.qpkg
+++ b/release/dist/qnap/files/scripts/Dockerfile.qpkg
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:20.04
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
After the switch to 24.04, unsigned packages did not build correctly (came out as only a few KBs).

Fixes tailscale/tailscale-qpkg#148

I tested this by installing an unsigned 64 bit Intel package built from this branch on a QNAP TS473.