### PR TITLE
cmd/k8s-operator: Add NOTES.txt to Helm chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ client/web/build/assets
 *.xcworkspacedata
 /tstest/tailmac/bin
 /tstest/tailmac/build
+
+# Ignore personal IntelliJ settings
+.idea/

--- a/cmd/k8s-operator/deploy/chart/templates/NOTES.txt
+++ b/cmd/k8s-operator/deploy/chart/templates/NOTES.txt
@@ -1,0 +1,25 @@
+You have successfully installed the Tailscale Kubernetes Operator!
+
+Once connected, the operator should appear as a device within the Tailscale admin console:
+https://login.tailscale.com/admin/machines
+
+If you have not used the Tailscale operator before, here are some examples to try out:
+
+* Private Kubernetes API access and authorization using the API server proxy
+  https://tailscale.com/kb/1437/kubernetes-operator-api-server-proxy
+
+* Private access to cluster Services using an ingress proxy
+  https://tailscale.com/kb/1439/kubernetes-operator-cluster-ingress
+
+* Private access to the cluster's available subnets using a subnet router
+  https://tailscale.com/kb/1441/kubernetes-operator-connector
+
+You can also explore the CRDs, operator, and associated resources within the {{ .Release.Namespace }} namespace:
+
+$ kubectl explain connector
+$ kubectl explain proxygroup
+$ kubectl explain proxyclass
+$ kubectl explain recorder
+$ kubectl explain dnsconfig
+
+$ kubectl --namespace={{ .Release.Namespace }} get pods


### PR DESCRIPTION
This commit adds a NOTES.txt to the operator helm chart that will be written to the terminal upon successful installation of the operator.

It includes a small list of knowledgebase articles with possible next steps for the actor that installed the operator to the cluster. It also provides possible commands to use for explaining the custom resources.

Fixes #13427