### PR TITLE
.github/workflows: replace tibdex with official GitHub Action

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -27,13 +27,12 @@ jobs:
         run: ./update-flake.sh
 
       - name: Get access token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         id: generate-token
         with:
-          app_id: ${{ secrets.LICENSING_APP_ID }}
-          installation_retrieval_mode: "id"
-          installation_retrieval_payload: ${{ secrets.LICENSING_APP_INSTALLATION_ID }}
-          private_key: ${{ secrets.LICENSING_APP_PRIVATE_KEY }}
+          # Get token for app: https://github.com/apps/tailscale-code-updater
+          app-id: ${{ secrets.CODE_UPDATER_APP_ID }}
+          private-key: ${{ secrets.CODE_UPDATER_APP_PRIVATE_KEY }}
 
       - name: Send pull request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e #v7.0.8

--- a/.github/workflows/update-webclient-prebuilt.yml
+++ b/.github/workflows/update-webclient-prebuilt.yml
@@ -23,15 +23,12 @@ jobs:
           ./tool/go mod tidy
 
       - name: Get access token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         id: generate-token
         with:
-          # TODO(will): this should use the code updater app rather than licensing.
-          # It has the same permissions, so not a big deal, but still.
-          app_id: ${{ secrets.LICENSING_APP_ID }}
-          installation_retrieval_mode: "id"
-          installation_retrieval_payload: ${{ secrets.LICENSING_APP_INSTALLATION_ID }}
-          private_key: ${{ secrets.LICENSING_APP_PRIVATE_KEY }}
+          # Get token for app: https://github.com/apps/tailscale-code-updater
+          app-id: ${{ secrets.CODE_UPDATER_APP_ID }}
+          private-key: ${{ secrets.CODE_UPDATER_APP_PRIVATE_KEY }}
 
       - name: Send pull request
         id: pull-request


### PR DESCRIPTION
GitHub used to recommend the [tibdex/github-app-token](https://github.com/tibdex/github-app-token) GitHub Action until they wrote their own [actions/create-github-app-token](https://github.com/actions/create-github-app-token).

This patch replaces the use of the third-party action with the official one.

Updates #cleanup

See also: https://github.com/tibdex/github-app-token/issues/99