### PR TITLE
wgengine/magicsock: fix relayManager alloc work cleanup

### DIFF
--- a/wgengine/magicsock/relaymanager.go
+++ b/wgengine/magicsock/relaymanager.go
@@ -743,8 +743,11 @@ func (r *relayManager) allocateAllServersRunLoop(ep *endpoint) {
 	r.allocWorkByEndpoint[ep] = started
 	go func() {
 		started.wg.Wait()
-		started.cancel()
 		relayManagerInputEvent(r, ctx, &r.allocateWorkDoneCh, relayEndpointAllocWorkDoneEvent{work: started})
+		// cleanup context cancellation must come after the
+		// relayManagerInputEvent call, otherwise it returns early without
+		// writing the event to runLoop().
+		started.cancel()
 	}()
 }
 


### PR DESCRIPTION
Premature cancellation was preventing the work from ever being cleaned up in runLoop().

Updates tailscale/corp#27502