### PR TITLE
client/systray: replace counter metric with gauge

### DIFF
--- a/client/local/local.go
+++ b/client/local/local.go
@@ -398,6 +398,23 @@ func (lc *Client) IncrementCounter(ctx context.Context, name string, delta int) 
 	return err
 }
 
+// IncrementGauge increments the value of a Tailscale daemon's gauge
+// metric by the given delta. If the metric has yet to exist, a new gauge
+// metric is created and initialized to delta. The delta value can be negative.
+func (lc *Client) IncrementGauge(ctx context.Context, name string, delta int) error {
+	type metricUpdate struct {
+		Name  string `json:"name"`
+		Type  string `json:"type"`
+		Value int    `json:"value"` // amount to increment by
+	}
+	_, err := lc.send(ctx, "POST", "/localapi/v0/upload-client-metrics", 200, jsonBody([]metricUpdate{{
+		Name:  name,
+		Type:  "gauge",
+		Value: delta,
+	}}))
+	return err
+}
+
 // TailDaemonLogs returns a stream the Tailscale daemon's logs as they arrive.
 // Close the context to stop the stream.
 func (lc *Client) TailDaemonLogs(ctx context.Context) (io.Reader, error) {

--- a/client/systray/systray.go
+++ b/client/systray/systray.go
@@ -61,7 +61,8 @@ func (menu *Menu) Run() {
 		case <-menu.bgCtx.Done():
 		}
 	}()
-	go menu.lc.IncrementCounter(menu.bgCtx, "systray_start", 1)
+	go menu.lc.IncrementGauge(menu.bgCtx, "systray_running", 1)
+	defer menu.lc.IncrementGauge(menu.bgCtx, "systray_running", -1)
 
 	systray.Run(menu.onReady, menu.onExit)
 }


### PR DESCRIPTION
Replace the existing systray_start counter metrics with a systray_running gauge metrics.

This also adds an IncrementGauge method to local client to parallel IncrementCounter. The LocalAPI handler supports both, we've just never added a client method for gauges.

Updates #1708

Change-Id: Ia101a4a3005adb9118051b3416f5a64a4a45987d