### PR TITLE
wgengine/magicsock: move UDP relay path discovery to heartbeat()

### DIFF
--- a/wgengine/magicsock/endpoint_test.go
+++ b/wgengine/magicsock/endpoint_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"tailscale.com/tailcfg"
 	"tailscale.com/types/key"
 )
 
@@ -319,6 +320,47 @@ func Test_endpoint_maybeProbeUDPLifetimeLocked(t *testing.T) {
 			}
 			if gotMaybe != tt.wantMaybe {
 				t.Errorf("maybeProbeUDPLifetimeLocked() gotMaybe = %v, want %v", gotMaybe, tt.wantMaybe)
+			}
+		})
+	}
+}
+
+func Test_epAddr_isDirectUDP(t *testing.T) {
+	vni := virtualNetworkID{}
+	vni.set(7)
+	tests := []struct {
+		name string
+		ap   netip.AddrPort
+		vni  virtualNetworkID
+		want bool
+	}{
+		{
+			name: "true",
+			ap:   netip.MustParseAddrPort("192.0.2.1:7"),
+			vni:  virtualNetworkID{},
+			want: true,
+		},
+		{
+			name: "false derp magic addr",
+			ap:   netip.AddrPortFrom(tailcfg.DerpMagicIPAddr, 0),
+			vni:  virtualNetworkID{},
+			want: false,
+		},
+		{
+			name: "false vni set",
+			ap:   netip.MustParseAddrPort("192.0.2.1:7"),
+			vni:  vni,
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := epAddr{
+				ap:  tt.ap,
+				vni: tt.vni,
+			}
+			if got := e.isDirect(); got != tt.want {
+				t.Errorf("isDirect() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -3494,9 +3494,17 @@ const (
 	// keep NAT mappings alive.
 	sessionActiveTimeout = 45 * time.Second
 
-	// upgradeInterval is how often we try to upgrade to a better path
-	// even if we have some non-DERP route that works.
-	upgradeInterval = 1 * time.Minute
+	// upgradeUDPDirectInterval is how often we try to upgrade to a better,
+	// direct UDP path even if we have some direct UDP path that works.
+	upgradeUDPDirectInterval = 1 * time.Minute
+
+	// upgradeUDPRelayInterval is how often we try to discover UDP relay paths
+	// even if we have a UDP relay path that works.
+	upgradeUDPRelayInterval = 1 * time.Minute
+
+	// discoverUDPRelayPathsInterval is the minimum time between UDP relay path
+	// discovery.
+	discoverUDPRelayPathsInterval = 30 * time.Second
 
 	// heartbeatInterval is how often pings to the best UDP address
 	// are sent.


### PR DESCRIPTION
This was previously hooked around direct UDP path discovery / CallMeMaybe transmission, and related conditions. Now it is subject to relay-specific considerations.

Updates tailscale/corp#27502