### PR TITLE
ipn/store: make StateStore.All optional

### DIFF
--- a/cmd/tsconnect/src/lib/js-state-store.ts
+++ b/cmd/tsconnect/src/lib/js-state-store.ts
@@ -10,7 +10,4 @@ export const sessionStateStorage: IPNStateStorage = {
   getState(id) {
     return window.sessionStorage[`ipn-state-${id}`] || ""
   },
-  all() {
-    return JSON.stringify(window.sessionStorage)
-  },
 }

--- a/cmd/tsconnect/src/types/wasm_js.d.ts
+++ b/cmd/tsconnect/src/types/wasm_js.d.ts
@@ -44,7 +44,6 @@ declare global {
   interface IPNStateStorage {
     setState(id: string, value: string): void
     getState(id: string): string
-    all(): string
   }
 
   type IPNConfig = {

--- a/cmd/tsconnect/wasm/wasm_js.go
+++ b/cmd/tsconnect/wasm/wasm_js.go
@@ -15,7 +15,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"iter"
 	"log"
 	"math/rand/v2"
 	"net"
@@ -578,29 +577,6 @@ func (s *jsStateStore) ReadState(id ipn.StateKey) ([]byte, error) {
 func (s *jsStateStore) WriteState(id ipn.StateKey, bs []byte) error {
 	s.jsStateStorage.Call("setState", string(id), hex.EncodeToString(bs))
 	return nil
-}
-
-func (s *jsStateStore) All() iter.Seq2[ipn.StateKey, []byte] {
-	return func(yield func(ipn.StateKey, []byte) bool) {
-		jsValue := s.jsStateStorage.Call("all")
-		if jsValue.String() == "" {
-			return
-		}
-		buf, err := hex.DecodeString(jsValue.String())
-		if err != nil {
-			return
-		}
-		var state map[string][]byte
-		if err := json.Unmarshal(buf, &state); err != nil {
-			return
-		}
-
-		for k, v := range state {
-			if !yield(ipn.StateKey(k), v) {
-				break
-			}
-		}
-	}
 }
 
 func mapSlice[T any, M any](a []T, f func(T) M) []M {

--- a/feature/tpm/tpm.go
+++ b/feature/tpm/tpm.go
@@ -217,6 +217,10 @@ func (s *tpmStore) All() iter.Seq2[ipn.StateKey, []byte] {
 	}
 }
 
+// Ensure tpmStore implements store.ExportableStore for migration to/from
+// store.FileStore.
+var _ store.ExportableStore = (*tpmStore)(nil)
+
 // The nested levels of encoding and encryption are confusing, so here's what's
 // going on in plain English.
 //

--- a/ipn/store.go
+++ b/ipn/store.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"iter"
 	"net"
 	"strconv"
 )
@@ -84,11 +83,6 @@ type StateStore interface {
 	// instead, which only writes if the value is different from what's
 	// already in the store.
 	WriteState(id StateKey, bs []byte) error
-	// All returns an iterator over all StateStore keys. Using ReadState or
-	// WriteState is not safe while iterating and can lead to a deadlock.
-	// The order of keys in the iterator is not specified and may change
-	// between runs.
-	All() iter.Seq2[StateKey, []byte]
 }
 
 // WriteState is a wrapper around store.WriteState that only writes if

--- a/ipn/store/awsstore/store_aws.go
+++ b/ipn/store/awsstore/store_aws.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"iter"
 	"net/url"
 	"regexp"
 	"strings"
@@ -253,8 +252,4 @@ func (s *awsStore) persistState() error {
 
 	_, err = s.ssmClient.PutParameter(context.TODO(), in)
 	return err
-}
-
-func (s *awsStore) All() iter.Seq2[ipn.StateKey, []byte] {
-	return s.memory.All()
 }

--- a/ipn/store/kubestore/store_kube.go
+++ b/ipn/store/kubestore/store_kube.go
@@ -7,7 +7,6 @@ package kubestore
 import (
 	"context"
 	"fmt"
-	"iter"
 	"log"
 	"net"
 	"os"
@@ -428,8 +427,4 @@ func sanitizeKey[T ~string](k T) string {
 		}
 		return '_'
 	}, string(k))
-}
-
-func (s *Store) All() iter.Seq2[ipn.StateKey, []byte] {
-	return s.memory.All()
 }

--- a/ipn/store/mem/store_mem.go
+++ b/ipn/store/mem/store_mem.go
@@ -7,7 +7,6 @@ package mem
 import (
 	"bytes"
 	"encoding/json"
-	"iter"
 	"sync"
 
 	xmaps "golang.org/x/exp/maps"
@@ -85,17 +84,4 @@ func (s *Store) ExportToJSON() ([]byte, error) {
 		return []byte("{}"), nil
 	}
 	return json.MarshalIndent(s.cache, "", "  ")
-}
-
-func (s *Store) All() iter.Seq2[ipn.StateKey, []byte] {
-	return func(yield func(ipn.StateKey, []byte) bool) {
-		s.mu.Lock()
-		defer s.mu.Unlock()
-
-		for k, v := range s.cache {
-			if !yield(k, v) {
-				break
-			}
-		}
-	}
 }


### PR DESCRIPTION
This method is only needed to migrate between store.FileStore and tpm.tpmStore. We can make a runtime type assertion instead of implementing an unused method for every platform.

FYI @willh-ts @kari-ts @nickoneill 

Updates #15830