### PR TITLE
tsidp: update README to refer to community projects

### DIFF
--- a/cmd/tsidp/README.md
+++ b/cmd/tsidp/README.md
@@ -1,6 +1,6 @@
 # `tsidp` - Tailscale OpenID Connect (OIDC) Identity Provider
 
-[![status: experimental](https://img.shields.io/badge/status-experimental-blue)](https://tailscale.com/kb/1167/release-stages/#experimental)
+[![status: community project](https://img.shields.io/badge/status-community_project-blue)](https://tailscale.com/kb/1531/community-projects)
 
 `tsidp` is an OIDC Identity Provider (IdP) server that integrates with your Tailscale network. It allows you to use Tailscale identities for authentication in applications that support OpenID Connect, enabling single sign-on (SSO) capabilities within your tailnet.
 
@@ -89,7 +89,7 @@ The `tsidp` server supports several command-line flags:
 
 ## Support
 
-This is an [experimental](https://tailscale.com/kb/1167/release-stages#experimental), work in progress feature. For issues or questions, file issues on the [GitHub repository](https://github.com/tailscale/tailscale)
+This is an experimental, work in progress, [community project](https://tailscale.com/kb/1531/community-projects). For issues or questions, file issues on the [GitHub repository](https://github.com/tailscale/tailscale).
 
 ## License
 


### PR DESCRIPTION
We dropped the idea of the Experimental release stage in tailscale/tailscale-www#7697, in favour of [Community Projects](https://tailscale.com/community/community-projects).

Updates #cleanup