### PR TITLE
ipn,wgengine/magicsock: include StaticEndpoints in prefs

### DIFF
--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -971,6 +971,9 @@ func TestPrefFlagMapping(t *testing.T) {
 			// Used internally by LocalBackend as part of exit node usage toggling.
 			// No CLI flag for this.
 			continue
+		case "StaticEndpoints":
+			// Currently limited to setting via config file.
+			continue
 		}
 		t.Errorf("unexpected new ipn.Pref field %q is not handled by up.go (see addPrefFlagMapping and checkForAccidentalSettingReverts)", prefName)
 	}

--- a/ipn/conf.go
+++ b/ipn/conf.go
@@ -155,5 +155,10 @@ func (c *ConfigVAlpha) ToPrefs() (MaskedPrefs, error) {
 	if c.AdvertiseServices != nil {
 		mp.AdvertiseServices = c.AdvertiseServices
 	}
+	// Always true because we can't distinguish in JSON between unset and empty.
+	mp.StaticEndpointsSet = true
+	if c.StaticEndpoints != nil {
+		mp.StaticEndpoints = c.StaticEndpoints
+	}
 	return mp, nil
 }

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -51,6 +51,7 @@ func (src *Prefs) Clone() *Prefs {
 	dst.AdvertiseTags = append(src.AdvertiseTags[:0:0], src.AdvertiseTags...)
 	dst.AdvertiseRoutes = append(src.AdvertiseRoutes[:0:0], src.AdvertiseRoutes...)
 	dst.AdvertiseServices = append(src.AdvertiseServices[:0:0], src.AdvertiseServices...)
+	dst.StaticEndpoints = append(src.StaticEndpoints[:0:0], src.StaticEndpoints...)
 	if src.DriveShares != nil {
 		dst.DriveShares = make([]*drive.Share, len(src.DriveShares))
 		for i := range dst.DriveShares {
@@ -89,6 +90,7 @@ var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	Egg                    bool
 	AdvertiseRoutes        []netip.Prefix
 	AdvertiseServices      []string
+	StaticEndpoints        []netip.AddrPort
 	NoSNAT                 bool
 	NoStatefulFiltering    opt.Bool
 	NetfilterMode          preftype.NetfilterMode

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -154,6 +154,9 @@ func (v PrefsView) AdvertiseRoutes() views.Slice[netip.Prefix] {
 func (v PrefsView) AdvertiseServices() views.Slice[string] {
 	return views.SliceOf(v.ж.AdvertiseServices)
 }
+func (v PrefsView) StaticEndpoints() views.Slice[netip.AddrPort] {
+	return views.SliceOf(v.ж.StaticEndpoints)
+}
 func (v PrefsView) NoSNAT() bool                          { return v.ж.NoSNAT }
 func (v PrefsView) NoStatefulFiltering() opt.Bool         { return v.ж.NoStatefulFiltering }
 func (v PrefsView) NetfilterMode() preftype.NetfilterMode { return v.ж.NetfilterMode }
@@ -194,6 +197,7 @@ var _PrefsViewNeedsRegeneration = Prefs(struct {
 	Egg                    bool
 	AdvertiseRoutes        []netip.Prefix
 	AdvertiseServices      []string
+	StaticEndpoints        []netip.AddrPort
 	NoSNAT                 bool
 	NoStatefulFiltering    opt.Bool
 	NetfilterMode          preftype.NetfilterMode

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -186,6 +186,10 @@ type Prefs struct {
 	// control server.
 	AdvertiseServices []string
 
+	// StaticEndpoints are additional, user-defined endpoints that this node
+	// should advertise amongst its wireguard endpoints.
+	StaticEndpoints []netip.AddrPort `json:",omitempty"`
+
 	// NoSNAT specifies whether to source NAT traffic going to
 	// destinations in AdvertiseRoutes. The default is to apply source
 	// NAT, which makes the traffic appear to come from the router
@@ -340,6 +344,7 @@ type MaskedPrefs struct {
 	EggSet                    bool                `json:",omitempty"`
 	AdvertiseRoutesSet        bool                `json:",omitempty"`
 	AdvertiseServicesSet      bool                `json:",omitempty"`
+	StaticEndpointsSet        bool                `json:",omitempty"`
 	NoSNATSet                 bool                `json:",omitempty"`
 	NoStatefulFilteringSet    bool                `json:",omitempty"`
 	NetfilterModeSet          bool                `json:",omitempty"`
@@ -552,6 +557,9 @@ func (p *Prefs) pretty(goos string) string {
 	if len(p.AdvertiseServices) > 0 {
 		fmt.Fprintf(&sb, "services=%s ", strings.Join(p.AdvertiseServices, ","))
 	}
+	if len(p.StaticEndpoints) > 0 {
+		fmt.Fprintf(&sb, "staticEndpoints=%v ", p.StaticEndpoints)
+	}
 	if goos == "linux" {
 		fmt.Fprintf(&sb, "nf=%v ", p.NetfilterMode)
 	}
@@ -627,6 +635,7 @@ func (p *Prefs) Equals(p2 *Prefs) bool {
 		slices.Equal(p.AdvertiseRoutes, p2.AdvertiseRoutes) &&
 		slices.Equal(p.AdvertiseTags, p2.AdvertiseTags) &&
 		slices.Equal(p.AdvertiseServices, p2.AdvertiseServices) &&
+		slices.Equal(p.StaticEndpoints, p2.StaticEndpoints) &&
 		p.Persist.Equals(p2.Persist) &&
 		p.ProfileName == p2.ProfileName &&
 		p.AutoUpdate.Equals(p2.AutoUpdate) &&

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -55,6 +55,7 @@ func TestPrefsEqual(t *testing.T) {
 		"Egg",
 		"AdvertiseRoutes",
 		"AdvertiseServices",
+		"StaticEndpoints",
 		"NoSNAT",
 		"NoStatefulFiltering",
 		"NetfilterMode",
@@ -343,6 +344,16 @@ func TestPrefsEqual(t *testing.T) {
 		{
 			&Prefs{AdvertiseServices: []string{"svc:tux", "svc:xenia"}},
 			&Prefs{AdvertiseServices: []string{"svc:tux", "svc:amelie"}},
+			false,
+		},
+		{
+			&Prefs{StaticEndpoints: []netip.AddrPort{netip.MustParseAddrPort("127.0.0.1:0"), netip.MustParseAddrPort("[::1]:80")}},
+			&Prefs{StaticEndpoints: []netip.AddrPort{netip.MustParseAddrPort("127.0.0.1:0"), netip.MustParseAddrPort("[::1]:80")}},
+			true,
+		},
+		{
+			&Prefs{StaticEndpoints: []netip.AddrPort{netip.MustParseAddrPort("127.0.0.1:0"), netip.MustParseAddrPort("[::1]:80")}},
+			&Prefs{StaticEndpoints: []netip.AddrPort{netip.MustParseAddrPort("127.0.0.1:99"), netip.MustParseAddrPort("[::1]:80")}},
 			false,
 		},
 		{

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -17,7 +17,6 @@ import (
 	"math"
 	"net"
 	"net/netip"
-	"reflect"
 	"runtime"
 	"slices"
 	"strconv"
@@ -919,7 +918,7 @@ func (c *Conn) setEndpoints(endpoints []tailcfg.Endpoint) (changed bool) {
 // Static endpoints are endpoints explicitly configured by user.
 func (c *Conn) SetStaticEndpoints(ep views.Slice[netip.AddrPort]) {
 	c.mu.Lock()
-	if reflect.DeepEqual(c.staticEndpoints.AsSlice(), ep.AsSlice()) {
+	if views.SliceEqual(c.staticEndpoints, ep) {
 		return
 	}
 	c.staticEndpoints = ep


### PR DESCRIPTION
Previously this wasn't threaded all the way through to prefs because reloading didn't work, but that's fixed now. Make it more consistent with all the other settings in the config file by storing its state in the prefs, and trigger updates on the pref changing.

Updates #14674

Note: I've manually tested that config file reloads still propagate static endpoint changes all the way through to the netmap, but I'd love to know if there's an existing test suite for that.

Change-Id: I60602e3b6b5e7307ba1a7c8df7eb6cf6aeffc3f5