### PR TITLE
ipn: include local addrs in Notify's Engine field

### DIFF
--- a/ipn/backend.go
+++ b/ipn/backend.go
@@ -46,12 +46,13 @@ func (s State) String() string {
 		"Running"}[s]
 }
 
-// EngineStatus contains WireGuard engine stats.
+// EngineStatus contains WireGuard engine metadata and stats.
 type EngineStatus struct {
 	RBytes, WBytes int64
 	NumLive        int
 	LiveDERPs      int // number of active DERP connections
 	LivePeers      map[key.NodePublic]ipnstate.PeerStatusLite
+	LocalAddrs     []tailcfg.Endpoint // the set of possible endpoints for the magic conn
 }
 
 // NotifyWatchOpt is a bitmask of options about what type of Notify messages

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3813,6 +3813,7 @@ func (b *LocalBackend) pingPeerAPI(ctx context.Context, ip netip.Addr) (peer tai
 func (b *LocalBackend) parseWgStatusLocked(s *wgengine.Status) (ret ipn.EngineStatus) {
 	var peerStats, peerKeys strings.Builder
 
+	ret.LocalAddrs = s.LocalAddrs
 	ret.LiveDERPs = s.DERPs
 	ret.LivePeers = map[key.NodePublic]ipnstate.PeerStatusLite{}
 	for _, p := range s.Peers {


### PR DESCRIPTION
Include wgengine's local addrs in ipn.Notify's Engine field to allow clients of the local API to react to changes in configured static endpoints. The operator and containerboot will use this to post updates about the client's state to a status field.

Updates #14674

Change-Id: I9717c8081edd9398fba467c122139f4c56c31b0a