### PR TITLE
tailcfg: report StateEncrypted in Hostinfo

### DIFF
--- a/feature/tpm/tpm.go
+++ b/feature/tpm/tpm.go
@@ -159,6 +159,8 @@ func newStore(logf logger.Logf, path string) (ipn.StateStore, error) {
 // tpmStore is an ipn.StateStore that stores the state in a secretbox-encrypted
 // file using a TPM-sealed symmetric key.
 type tpmStore struct {
+	ipn.EncryptedStateStore
+
 	logf logger.Logf
 	path string
 	key  [32]byte

--- a/ipn/store.go
+++ b/ipn/store.go
@@ -113,3 +113,9 @@ func ReadStoreInt(store StateStore, id StateKey) (int64, error) {
 func PutStoreInt(store StateStore, id StateKey, val int64) error {
 	return WriteState(store, id, fmt.Appendf(nil, "%d", val))
 }
+
+// EncryptedStateStore is a marker interface implemented by StateStores that
+// encrypt data at rest.
+type EncryptedStateStore interface {
+	stateStoreIsEncrypted()
+}

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -162,7 +162,8 @@ type CapabilityVersion int
 //   - 115: 2025-03-07: Client understands DERPRegion.NoMeasureNoHome.
 //   - 116: 2025-05-05: Client serves MagicDNS "AAAA" if NodeAttrMagicDNSPeerAAAA set on self node
 //   - 117: 2025-05-28: Client understands DisplayMessages (structured health messages), but not necessarily PrimaryAction.
-const CurrentCapabilityVersion CapabilityVersion = 117
+//   - 118: 2025-07-01: Client sends Hostinfo.StateEncrypted to report whether the state file is encrypted at rest (#15830)
+const CurrentCapabilityVersion CapabilityVersion = 118
 
 // ID is an integer ID for a user, node, or login allocated by the
 // control plane.
@@ -878,6 +879,12 @@ type Hostinfo struct {
 	Location *Location `json:",omitempty"`
 
 	TPM *TPMInfo `json:",omitempty"` // TPM device metadata, if available
+	// StateEncrypted reports whether the node state is stored encrypted on
+	// disk. The actual mechanism is platform-specific:
+	//   * Apple nodes use the Keychain
+	//   * Linux and Windows nodes use the TPM
+	//   * Android apps use EncryptedSharedPreferences
+	StateEncrypted opt.Bool `json:",omitempty"`
 
 	// NOTE: any new fields containing pointers in this type
 	//       require changes to Hostinfo.Equal.

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -188,6 +188,7 @@ var _HostinfoCloneNeedsRegeneration = Hostinfo(struct {
 	ServicesHash    string
 	Location        *Location
 	TPM             *TPMInfo
+	StateEncrypted  opt.Bool
 }{})
 
 // Clone makes a deep copy of NetInfo.

--- a/tailcfg/tailcfg_test.go
+++ b/tailcfg/tailcfg_test.go
@@ -69,6 +69,7 @@ func TestHostinfoEqual(t *testing.T) {
 		"ServicesHash",
 		"Location",
 		"TPM",
+		"StateEncrypted",
 	}
 	if have := fieldsOf(reflect.TypeFor[Hostinfo]()); !reflect.DeepEqual(have, hiHandles) {
 		t.Errorf("Hostinfo.Equal check might be out of sync\nfields: %q\nhandled: %q\n",

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -303,6 +303,7 @@ func (v HostinfoView) ServicesHash() string                   { return v.ж.Serv
 func (v HostinfoView) Location() LocationView                 { return v.ж.Location.View() }
 func (v HostinfoView) TPM() views.ValuePointer[TPMInfo]       { return views.ValuePointerOf(v.ж.TPM) }
 
+func (v HostinfoView) StateEncrypted() opt.Bool   { return v.ж.StateEncrypted }
 func (v HostinfoView) Equal(v2 HostinfoView) bool { return v.ж.Equal(v2.ж) }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
@@ -346,6 +347,7 @@ var _HostinfoViewNeedsRegeneration = Hostinfo(struct {
 	ServicesHash    string
 	Location        *Location
 	TPM             *TPMInfo
+	StateEncrypted  opt.Bool
 }{})
 
 // View returns a read-only view of NetInfo.


### PR DESCRIPTION
Report whether the client is configured with state encryption (which varies by platform and can be optional on some). Wire it up to `--encrypt-state` in tailscaled, which is set for Linux/Windows, and set defaults for other platforms. Macsys will also report this if full Keychain migration is done.

Updates #15830