### PR TITLE
cmd/k8s-operator: Set login server on tsrecorder nodes

### DIFF
--- a/cmd/k8s-operator/tsrecorder.go
+++ b/cmd/k8s-operator/tsrecorder.go
@@ -59,6 +59,7 @@ type RecorderReconciler struct {
 	clock       tstime.Clock
 	tsNamespace string
 	tsClient    tsClient
+	loginServer string
 
 	mu        sync.Mutex           // protects following
 	recorders set.Slice[types.UID] // for recorders gauge
@@ -202,7 +203,7 @@ func (r *RecorderReconciler) maybeProvision(ctx context.Context, tsr *tsapi.Reco
 	}); err != nil {
 		return fmt.Errorf("error creating RoleBinding: %w", err)
 	}
-	ss := tsrStatefulSet(tsr, r.tsNamespace)
+	ss := tsrStatefulSet(tsr, r.tsNamespace, r.loginServer)
 	if _, err := createOrUpdate(ctx, r.Client, r.tsNamespace, ss, func(s *appsv1.StatefulSet) {
 		s.ObjectMeta.Labels = ss.ObjectMeta.Labels
 		s.ObjectMeta.Annotations = ss.ObjectMeta.Annotations

--- a/cmd/k8s-operator/tsrecorder_specs.go
+++ b/cmd/k8s-operator/tsrecorder_specs.go
@@ -17,7 +17,7 @@ import (
 	"tailscale.com/version"
 )
 
-func tsrStatefulSet(tsr *tsapi.Recorder, namespace string) *appsv1.StatefulSet {
+func tsrStatefulSet(tsr *tsapi.Recorder, namespace string, loginServer string) *appsv1.StatefulSet {
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            tsr.Name,
@@ -59,7 +59,7 @@ func tsrStatefulSet(tsr *tsapi.Recorder, namespace string) *appsv1.StatefulSet {
 							ImagePullPolicy: tsr.Spec.StatefulSet.Pod.Container.ImagePullPolicy,
 							Resources:       tsr.Spec.StatefulSet.Pod.Container.Resources,
 							SecurityContext: tsr.Spec.StatefulSet.Pod.Container.SecurityContext,
-							Env:             env(tsr),
+							Env:             env(tsr, loginServer),
 							EnvFrom: func() []corev1.EnvFromSource {
 								if tsr.Spec.Storage.S3 == nil || tsr.Spec.Storage.S3.Credentials.Secret.Name == "" {
 									return nil
@@ -201,7 +201,7 @@ func tsrStateSecret(tsr *tsapi.Recorder, namespace string) *corev1.Secret {
 	}
 }
 
-func env(tsr *tsapi.Recorder) []corev1.EnvVar {
+func env(tsr *tsapi.Recorder, loginServer string) []corev1.EnvVar {
 	envs := []corev1.EnvVar{
 		{
 			Name: "TS_AUTHKEY",
@@ -238,6 +238,10 @@ func env(tsr *tsapi.Recorder) []corev1.EnvVar {
 		{
 			Name:  "TSRECORDER_HOSTNAME",
 			Value: "$(POD_NAME)",
+		},
+		{
+			Name:  "TSRECORDER_LOGIN_SERVER",
+			Value: loginServer,
 		},
 	}
 

--- a/cmd/k8s-operator/tsrecorder_specs_test.go
+++ b/cmd/k8s-operator/tsrecorder_specs_test.go
@@ -90,7 +90,7 @@ func TestRecorderSpecs(t *testing.T) {
 			},
 		}
 
-		ss := tsrStatefulSet(tsr, tsNamespace)
+		ss := tsrStatefulSet(tsr, tsNamespace, tsLoginServer)
 
 		// StatefulSet-level.
 		if diff := cmp.Diff(ss.Annotations, tsr.Spec.StatefulSet.Annotations); diff != "" {
@@ -124,7 +124,7 @@ func TestRecorderSpecs(t *testing.T) {
 		}
 
 		// Container-level.
-		if diff := cmp.Diff(ss.Spec.Template.Spec.Containers[0].Env, env(tsr)); diff != "" {
+		if diff := cmp.Diff(ss.Spec.Template.Spec.Containers[0].Env, env(tsr, tsLoginServer)); diff != "" {
 			t.Errorf("(-got +want):\n%s", diff)
 		}
 		if diff := cmp.Diff(ss.Spec.Template.Spec.Containers[0].Image, tsr.Spec.StatefulSet.Pod.Container.Image); diff != "" {

--- a/cmd/k8s-operator/tsrecorder_test.go
+++ b/cmd/k8s-operator/tsrecorder_test.go
@@ -25,7 +25,10 @@ import (
 	"tailscale.com/tstest"
 )
 
-const tsNamespace = "tailscale"
+const (
+	tsNamespace   = "tailscale"
+	tsLoginServer = "example.tailscale.com"
+)
 
 func TestRecorder(t *testing.T) {
 	tsr := &tsapi.Recorder{
@@ -51,6 +54,7 @@ func TestRecorder(t *testing.T) {
 		recorder:    fr,
 		l:           zl.Sugar(),
 		clock:       cl,
+		loginServer: tsLoginServer,
 	}
 
 	t.Run("invalid_spec_gives_an_error_condition", func(t *testing.T) {
@@ -234,7 +238,7 @@ func expectRecorderResources(t *testing.T, fc client.WithWatch, tsr *tsapi.Recor
 	role := tsrRole(tsr, tsNamespace)
 	roleBinding := tsrRoleBinding(tsr, tsNamespace)
 	serviceAccount := tsrServiceAccount(tsr, tsNamespace)
-	statefulSet := tsrStatefulSet(tsr, tsNamespace)
+	statefulSet := tsrStatefulSet(tsr, tsNamespace, tsLoginServer)
 
 	if shouldExist {
 		expectEqual(t, fc, auth)


### PR DESCRIPTION
This commit modifies the recorder node reconciler to include the environment variable added in https://github.com/tailscale/corp/pull/30058 which allows for configuration of the coordination server.

Updates https://github.com/tailscale/corp/issues/29847