### PR TITLE
derp/derphttp: fix DERP TLS client server name inclusion in URL form

### DIFF
--- a/derp/derphttp/derphttp_client.go
+++ b/derp/derphttp/derphttp_client.go
@@ -648,12 +648,14 @@ func (c *Client) dialRegion(ctx context.Context, reg *tailcfg.DERPRegion) (net.C
 
 func (c *Client) tlsClient(nc net.Conn, node *tailcfg.DERPNode) *tls.Conn {
 	tlsConf := tlsdial.Config(c.HealthTracker, c.TLSConfig)
+	// node is allowed to be nil here, tlsServerName falls back to using the URL
+	// if node is nil.
+	tlsConf.ServerName = c.tlsServerName(node)
 	if node != nil {
 		if node.InsecureForTests {
 			tlsConf.InsecureSkipVerify = true
 			tlsConf.VerifyConnection = nil
 		}
-		tlsConf.ServerName = c.tlsServerName(node)
 		if node.CertName != "" {
 			if suf, ok := strings.CutPrefix(node.CertName, "sha256-raw:"); ok {
 				tlsdial.SetConfigExpectedCertHash(tlsConf, suf)


### PR DESCRIPTION
When dialed with just an URL and no node, the recent proxy fixes caused a regression where there was no TLS server name being included.

Updates #16222
Updates #16223