### PR TITLE
cmd/k8s-operator/deploy: clarify helm install notes

### DIFF
--- a/cmd/k8s-operator/deploy/chart/templates/NOTES.txt
+++ b/cmd/k8s-operator/deploy/chart/templates/NOTES.txt
@@ -22,4 +22,6 @@ $ kubectl explain proxyclass
 $ kubectl explain recorder
 $ kubectl explain dnsconfig
 
-$ kubectl --namespace={{ .Release.Namespace }} get pods
+If you're interested to explore what resources were created:
+
+$ kubectl --namespace={{ .Release.Namespace }} get all -l app.kubernetes.io/managed-by=Helm


### PR DESCRIPTION
Based on feedback that it wasn't clear what the user is meant to do with the output of the last command, clarify that it's an optional command to explore what got created.

Updates #13427

Change-Id: Iff64ec6d02dc04bf4bbebf415d7ed1a44e7dd658