### PR TITLE
ipn/ipnlocal: clean up suggested exit nodes and skip a failing (and incorrect) test

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -5835,23 +5835,16 @@ func (b *LocalBackend) pickNewAutoExitNode() {
 	unlock := b.lockAndGetUnlock()
 	defer unlock()
 
-	prefs := b.pm.CurrentPrefs()
-	if !prefs.Valid() {
-		b.logf("[unexpected]: received tailnet exit node ID pref change callback but current prefs are nil")
-		return
-	}
-	prefsClone := prefs.AsStruct()
 	newSuggestion, err := b.suggestExitNodeLocked(nil)
 	if err != nil {
 		b.logf("setAutoExitNodeID: %v", err)
 		return
 	}
-	if prefsClone.ExitNodeID == newSuggestion.ID {
+	if b.pm.CurrentPrefs().ExitNodeID() == newSuggestion.ID {
 		return
 	}
-	prefsClone.ExitNodeID = newSuggestion.ID
 	_, err = b.editPrefsLockedOnEntry(&ipn.MaskedPrefs{
-		Prefs:         *prefsClone,
+		Prefs:         ipn.Prefs{ExitNodeID: newSuggestion.ID},
 		ExitNodeIDSet: true,
 	}, unlock)
 	if err != nil {

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -7433,7 +7433,7 @@ func suggestExitNode(report *netcheck.Report, netMap *netmap.NetworkMap, prevSug
 	}
 	candidates := make([]tailcfg.NodeView, 0, len(netMap.Peers))
 	for _, peer := range netMap.Peers {
-		if !peer.Valid() {
+		if !peer.Valid() || !peer.Online().Get() {
 			continue
 		}
 		if allowList != nil && !allowList.Contains(peer.StableID()) {


### PR DESCRIPTION
[4 commits]

- fix checking whether an exit node candidate is online in the full netmap. This is mostly a no-op, since offline nodes don't have the `NodeAttrSuggestExitNode` `NodeCapability`, but it allows us to fix the incorrect `TestSetControlClientStatusAutoExitNode` without having to skip it.
- fix (and skip) `TestUpdateNetmapDeltaAutoExitNode`, as `suggestExitNode` doesn't currently handle delta updates. We'll fix that in a later commit after plumbing `nodeBackend` into it.
- remove the locked-on-entry pattern from `setAutoExitNodeIDLockedOnEntry`, rename it to `pickNewAutoExitNode` and use it instead of the original `pickNewAutoExitNode` that we added in #14517.
- simplify `pickNewAutoExitNode` a little bit.

Updates #16455
Updates tailscale/corp#29969