### PR TITLE
cmd/tailscale/cli,ipn,ipn/ipnlocal: add AutoExitNode preference for automatic exit node selection

### DIFF
--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -971,6 +971,10 @@ func TestPrefFlagMapping(t *testing.T) {
 			// Used internally by LocalBackend as part of exit node usage toggling.
 			// No CLI flag for this.
 			continue
+		case "AutoExitNode":
+			// TODO(nickkhyl): should be handled by tailscale {set,up} --exit-node.
+			// See tailscale/tailscale#16459.
+			continue
 		}
 		t.Errorf("unexpected new ipn.Pref field %q is not handled by up.go (see addPrefFlagMapping and checkForAccidentalSettingReverts)", prefName)
 	}

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -74,6 +74,7 @@ var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	RouteAll               bool
 	ExitNodeID             tailcfg.StableNodeID
 	ExitNodeIP             netip.Addr
+	AutoExitNode           ExitNodeExpression
 	InternalExitNodePrior  tailcfg.StableNodeID
 	ExitNodeAllowLANAccess bool
 	CorpDNS                bool

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -135,6 +135,7 @@ func (v PrefsView) ControlURL() string                          { return v.ж.Co
 func (v PrefsView) RouteAll() bool                              { return v.ж.RouteAll }
 func (v PrefsView) ExitNodeID() tailcfg.StableNodeID            { return v.ж.ExitNodeID }
 func (v PrefsView) ExitNodeIP() netip.Addr                      { return v.ж.ExitNodeIP }
+func (v PrefsView) AutoExitNode() ExitNodeExpression            { return v.ж.AutoExitNode }
 func (v PrefsView) InternalExitNodePrior() tailcfg.StableNodeID { return v.ж.InternalExitNodePrior }
 func (v PrefsView) ExitNodeAllowLANAccess() bool                { return v.ж.ExitNodeAllowLANAccess }
 func (v PrefsView) CorpDNS() bool                               { return v.ж.CorpDNS }
@@ -179,6 +180,7 @@ var _PrefsViewNeedsRegeneration = Prefs(struct {
 	RouteAll               bool
 	ExitNodeID             tailcfg.StableNodeID
 	ExitNodeIP             netip.Addr
+	AutoExitNode           ExitNodeExpression
 	InternalExitNodePrior  tailcfg.StableNodeID
 	ExitNodeAllowLANAccess bool
 	CorpDNS                bool

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -40,6 +40,7 @@ func TestPrefsEqual(t *testing.T) {
 		"RouteAll",
 		"ExitNodeID",
 		"ExitNodeIP",
+		"AutoExitNode",
 		"InternalExitNodePrior",
 		"ExitNodeAllowLANAccess",
 		"CorpDNS",
@@ -147,6 +148,17 @@ func TestPrefsEqual(t *testing.T) {
 		{
 			&Prefs{ExitNodeIP: netip.MustParseAddr("1.2.3.4")},
 			&Prefs{ExitNodeIP: netip.MustParseAddr("1.2.3.4")},
+			true,
+		},
+
+		{
+			&Prefs{AutoExitNode: ""},
+			&Prefs{AutoExitNode: "auto:any"},
+			false,
+		},
+		{
+			&Prefs{AutoExitNode: "auto:any"},
+			&Prefs{AutoExitNode: "auto:any"},
 			true,
 		},
 


### PR DESCRIPTION
With this change, policy enforcement and exit node resolution can happen in separate steps, since enforcement no longer depends on resolving the suggested exit node. This keeps policy enforcement synchronous (e.g., when switching profiles), while allowing exit node resolution to be asynchronous on netmap updates, link changes, etc.

Additionally, the new preference will be used to let GUIs and CLIs switch back to "auto" mode after a manual exit node override, which is necessary for tailscale/corp#29969.

Updates tailscale/corp#29969
Updates #16459