### PR TITLE
wgengine/netstack: correctly proxy half-closed TCP connections

### DIFF
--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -1435,6 +1435,13 @@ func (ns *Impl) acceptTCP(r *tcp.ForwarderRequest) {
 	}
 }
 
+// tcpCloser is an interface to abstract around various TCPConn types that
+// allow closing of the read and write streams independently of each other.
+type tcpCloser interface {
+	CloseRead() error
+	CloseWrite() error
+}
+
 func (ns *Impl) forwardTCP(getClient func(...tcpip.SettableSocketOption) *gonet.TCPConn, clientRemoteIP netip.Addr, wq *waiter.Queue, dialAddr netip.AddrPort) (handled bool) {
 	dialAddrStr := dialAddr.String()
 	if debugNetstack() {
@@ -1478,12 +1485,12 @@ func (ns *Impl) forwardTCP(getClient func(...tcpip.SettableSocketOption) *gonet.
 		ns.logf("netstack: could not connect to local backend server at %s: %v", dialAddr.String(), err)
 		return
 	}
+	defer backend.Close()
 
 	backendLocalAddr := backend.LocalAddr().(*net.TCPAddr)
 	backendLocalIPPort := netaddr.Unmap(backendLocalAddr.AddrPort())
 	if err := ns.pm.RegisterIPPortIdentity("tcp", backendLocalIPPort, clientRemoteIP); err != nil {
 		ns.logf("netstack: could not register TCP mapping %s: %v", backendLocalIPPort, err)
-		backend.Close()
 		return
 	}
 	defer ns.pm.UnregisterIPPortIdentity("tcp", backendLocalIPPort)
@@ -1499,12 +1506,13 @@ func (ns *Impl) forwardTCP(getClient func(...tcpip.SettableSocketOption) *gonet.
 	if client == nil {
 		return
 	}
+	defer client.Close()
 
 	// As of 2025-07-03, backend is always either a net.TCPConn
-	// from stdDialer.DialContext, or nil from hangDialer in
-	// tests (in which case we would have errored out by now),
-	// so this conversion should always succeed.
-	backendTCPConn, backendIsNetTCPConn := backend.(*net.TCPConn)
+	// from stdDialer.DialContext (which has the requisite functions),
+	// or nil from hangDialer in tests (in which case we would have
+	// errored out by now), so this conversion should always succeed.
+	backendTCPCloser, backendIsTCPCloser := backend.(tcpCloser)
 	connClosed := make(chan error, 2)
 	go func() {
 		_, err := io.Copy(backend, client)
@@ -1512,8 +1520,8 @@ func (ns *Impl) forwardTCP(getClient func(...tcpip.SettableSocketOption) *gonet.
 			err = fmt.Errorf("client -> backend: %w", err)
 		}
 		connClosed <- err
-		if backendIsNetTCPConn {
-			backendTCPConn.CloseWrite()
+		if backendIsTCPCloser {
+			backendTCPCloser.CloseWrite()
 		}
 		client.CloseRead()
 	}()
@@ -1522,8 +1530,8 @@ func (ns *Impl) forwardTCP(getClient func(...tcpip.SettableSocketOption) *gonet.
 		if err != nil {
 			err = fmt.Errorf("backend -> client: %w", err)
 		}
-		if backendIsNetTCPConn {
-			backendTCPConn.CloseRead()
+		if backendIsTCPCloser {
+			backendTCPCloser.CloseRead()
 		}
 		client.CloseWrite()
 		connClosed <- err


### PR DESCRIPTION
TCP connections are two unidirectional data streams, and if one of these streams closes, we should not assume the other half is closed as well. For example, if an HTTP client closes its write half of the connection early, it may still be expecting to receive data on its read half, so we should keep the server -> client half of the connection open, while terminating the client -> server half.

Fixes tailscale/corp#29837.