### PR TITLE
Dockerfile,build_docker.sh: add a note on how to build local images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,15 @@
 # Tailscale images are currently built using https://github.com/tailscale/mkctr,
 # and the build script can be found in ./build_docker.sh.
 #
+# If you want to build local images for testing, you can use make.
+#
+# To build a Tailscale image and push to the local docker registry:
+#
+#   $ REPO=local/tailscale TAGS=v0.0.1 PLATFORM=local  make publishdevimage
+#
+# To build a Tailscale image and push to a remote docker registry:
+#
+#   $ REPO=<your-registry>/<your-repo>/tailscale TAGS=v0.0.1  make publishdevimage
 #
 # This Dockerfile includes all the tailscale binaries.
 #

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -6,6 +6,16 @@
 # hash of this repository as produced by ./cmd/mkversion.
 # This is the image build mechanim used to build the official Tailscale
 # container images.
+#
+# If you want to build local images for testing, you can use make, which provides few convenience wrappers around this script.
+#
+# To build a Tailscale image and push to the local docker registry:
+
+#   $ REPO=local/tailscale TAGS=v0.0.1 PLATFORM=local  make publishdevimage
+#
+# To build a Tailscale image and push to a remote docker registry:
+#
+#   $ REPO=<your-registry>/<your-repo>/tailscale TAGS=v0.0.1  make publishdevimage
 
 set -eu
 


### PR DESCRIPTION
This PR ads a note for how to build local images using make.

This is following an internal discussion- given that this repo contains a Dockerfile, a Makefile and a containers build script, it is not obvious what's the most straightforward way to build a local image.

Updates#cleanup