### PR TITLE
ipn/{ipnauth,ipnlocal,localapi}: make EditPrefs return an error if changing exit node is restricted by policy

### DIFF
--- a/ipn/ipnauth/self.go
+++ b/ipn/ipnauth/self.go
@@ -13,6 +13,11 @@ import (
 // has unlimited access.
 var Self Actor = unrestricted{}
 
+// TODO is a caller identity used when the operation is performed on behalf of a user,
+// rather than by tailscaled itself, but the surrounding function is not yet extended
+// to accept an [Actor] parameter. It grants the same unrestricted access as [Self].
+var TODO Actor = unrestricted{}
+
 // unrestricted is an [Actor] that has unlimited access to the currently running
 // tailscaled instance. It's typically used for operations performed by tailscaled
 // on its own, or upon a request from the control plane, rather on behalf of a user.
@@ -49,3 +54,10 @@ func (unrestricted) IsLocalSystem() bool { return false }
 // Deprecated: this method exists for compatibility with the current (as of 2025-01-28)
 // permission model and will be removed as we progress on tailscale/corp#18342.
 func (unrestricted) IsLocalAdmin(operatorUID string) bool { return false }
+
+// IsTailscaled reports whether the given Actor represents Tailscaled itself,
+// such as [Self] or a [TODO] placeholder actor.
+func IsTailscaled(a Actor) bool {
+	_, ok := a.(unrestricted)
+	return ok
+}

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -1910,7 +1910,7 @@ func (h *Handler) serveSetUseExitNodeEnabled(w http.ResponseWriter, r *http.Requ
 		http.Error(w, "invalid 'enabled' parameter", http.StatusBadRequest)
 		return
 	}
-	prefs, err := h.b.SetUseExitNodeEnabled(v)
+	prefs, err := h.b.SetUseExitNodeEnabled(h.Actor, v)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/util/syspolicy/syspolicy.go
+++ b/util/syspolicy/syspolicy.go
@@ -72,7 +72,10 @@ func HasAnyOf(keys ...Key) (bool, error) {
 		if errors.Is(err, setting.ErrNotConfigured) || errors.Is(err, setting.ErrNoSuchKey) {
 			continue
 		}
-		return err == nil, err // err may be nil or non-nil
+		if err != nil {
+			return false, err
+		}
+		return true, nil
 	}
 	return false, nil
 }


### PR DESCRIPTION
[2 commits]: the first adds `syspolicy.HasAnyOf`, used by the main commit

We extract `checkEditPrefsAccessLocked`, `adjustEditPrefsLocked`, and `onEditPrefsLocked` from the `EditPrefs` execution path, defining when each step is performed and what behavior is allowed at each stage.

Currently, this is primarily used to support Always On mode, to handle the Exit Node enablement toggle, and to report prefs edit metrics.

We then use it to enforce Exit Node policy settings by preventing users from setting an exit node and making `EditPrefs` return an error when an exit node is enforced by policy. This enforcement is also extended to the Exit Node toggle.

These changes prepare for supporting Exit Node overrides when permitted by policy and preventing logout while Always On mode is enabled.

In the future, implementation of these methods can be delegated to `ipnext` extensions via the feature hooks.

Updates tailscale/corp#29969
Updates tailscale/corp#26249