### PR TITLE
Kevin/add drain sub command for serve services

### DIFF
--- a/cmd/tailscale/cli/serve_legacy.go
+++ b/cmd/tailscale/cli/serve_legacy.go
@@ -745,21 +745,6 @@ func (e *serveEnv) runServeReset(ctx context.Context, args []string) error {
 	sc := new(ipn.ServeConfig)
 	return e.lc.SetServeConfig(ctx, sc)
 }
-func (e *serveEnv) runServeDrain(ctx context.Context, args []string) error {
-	if len(args) == 0 {
-		return errHelp
-	}
-	if len(args) != 1 {
-		fmt.Fprintf(Stderr, "error: invalid number of arguments\n\n")
-		return errHelp
-	}
-	svc := args[0]
-	err := tailcfg.ServiceName(svc).Validate()
-	if err != nil {
-		return fmt.Errorf("failed to parse service name: %w", err)
-	}
-	return e.removeServiceFromPrefs(ctx, svc)
-}
 
 // parseServePort parses a port number from a string and returns it as a
 // uint16. It returns an error if the port number is invalid or zero.

--- a/cmd/tailscale/cli/serve_legacy.go
+++ b/cmd/tailscale/cli/serve_legacy.go
@@ -745,6 +745,21 @@ func (e *serveEnv) runServeReset(ctx context.Context, args []string) error {
 	sc := new(ipn.ServeConfig)
 	return e.lc.SetServeConfig(ctx, sc)
 }
+func (e *serveEnv) runServeDrain(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		return errHelp
+	}
+	if len(args) != 1 {
+		fmt.Fprintf(Stderr, "error: invalid number of arguments\n\n")
+		return errHelp
+	}
+	svc := args[0]
+	err := tailcfg.ServiceName(svc).Validate()
+	if err != nil {
+		return fmt.Errorf("failed to parse service name: %w", err)
+	}
+	return e.removeServiceFromPrefs(ctx, svc)
+}
 
 // parseServePort parses a port number from a string and returns it as a
 // uint16. It returns an error if the port number is invalid or zero.

--- a/cmd/tailscale/cli/serve_v2.go
+++ b/cmd/tailscale/cli/serve_v2.go
@@ -203,6 +203,16 @@ func newServeV2Command(e *serveEnv, subcmd serveMode) *ffcli.Command {
 				Exec:       e.runServeReset,
 				FlagSet:    e.newFlags("serve-reset", nil),
 			},
+			{
+				Name:       "drain",
+				ShortUsage: fmt.Sprintf("tailscale %s drain <service>", info.Name),
+				ShortHelp:  "Drain a service from the current node",
+				LongHelp: "Make the current node no longer accept new connections for the specified service.\n" +
+					"Existing connections will continue to work until they are closed, but no new connections will be accepted.\n" +
+					"Use this command to gracefully remove a service from the current node without disrupting existing connections.\n" +
+					"<service> should be a service name (e.g., svc:my-service).",
+				Exec: e.runServeDrain,
+			},
 		},
 	}
 }
@@ -434,6 +444,32 @@ func (e *serveEnv) addServiceToPrefs(ctx context.Context, serviceName string) er
 		return nil // already advertised
 	}
 	advertisedServices = append(advertisedServices, serviceName)
+	_, err = e.lc.EditPrefs(ctx, &ipn.MaskedPrefs{
+		AdvertiseServicesSet: true,
+		Prefs: ipn.Prefs{
+			AdvertiseServices: advertisedServices,
+		},
+	})
+	return err
+}
+
+func (e *serveEnv) removeServiceFromPrefs(ctx context.Context, serviceName string) error {
+	prefs, err := e.lc.GetPrefs(ctx)
+	if err != nil {
+		return fmt.Errorf("error getting prefs: %w", err)
+	}
+	if len(prefs.AdvertiseServices) == 0 {
+		return nil // nothing to remove
+	}
+	var advertisedServices []string
+	for _, svc := range prefs.AdvertiseServices {
+		if svc != serviceName {
+			advertisedServices = append(advertisedServices, svc)
+		}
+	}
+	if len(advertisedServices) == len(prefs.AdvertiseServices) {
+		return nil // serviceName not found in prefs
+	}
 	_, err = e.lc.EditPrefs(ctx, &ipn.MaskedPrefs{
 		AdvertiseServicesSet: true,
 		Prefs: ipn.Prefs{

--- a/cmd/tailscale/cli/serve_v2.go
+++ b/cmd/tailscale/cli/serve_v2.go
@@ -468,7 +468,9 @@ func (e *serveEnv) removeServiceFromPrefs(ctx context.Context, serviceName tailc
 	}
 	_, err = e.lc.EditPrefs(ctx, &ipn.MaskedPrefs{
 		AdvertiseServicesSet: true,
-		Prefs:                *prefs,
+		Prefs: ipn.Prefs{
+			AdvertiseServices: prefs.AdvertiseServices,
+		},
 	})
 	return err
 }
@@ -482,9 +484,9 @@ func (e *serveEnv) runServeDrain(ctx context.Context, args []string) error {
 		return errHelp
 	}
 	svc := args[0]
-	svcName := tailcfg.AsServiceName(svc)
-	if svcName == noService {
-		return fmt.Errorf("failed to parse service name: %s", svc)
+	svcName := tailcfg.ServiceName(svc)
+	if err := svcName.Validate(); err != nil {
+		return fmt.Errorf("invalid service name: %s", err)
 	}
 	return e.removeServiceFromPrefs(ctx, svcName)
 }

--- a/cmd/tailscale/cli/serve_v2_test.go
+++ b/cmd/tailscale/cli/serve_v2_test.go
@@ -1212,6 +1212,54 @@ func TestAddServiceToPrefs(t *testing.T) {
 
 }
 
+func TestRemoveServiceFromPrefs(t *testing.T) {
+	tests := []struct {
+		name          string
+		dnsName       string
+		startServices []string
+		expected      []string
+	}{
+		{
+			name:     "remove service from empty prefs",
+			dnsName:  "svc:foo",
+			expected: []string{},
+		},
+		{
+			name:          "remove existing service from prefs",
+			dnsName:       "svc:foo",
+			startServices: []string{"svc:foo"},
+			expected:      []string{},
+		},
+		{
+			name:          "remove service not in prefs",
+			dnsName:       "svc:bar",
+			startServices: []string{"svc:foo"},
+			expected:      []string{"svc:foo"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lc := &fakeLocalServeClient{}
+			ctx := t.Context()
+			lc.EditPrefs(ctx, &ipn.MaskedPrefs{
+				AdvertiseServicesSet: true,
+				Prefs: ipn.Prefs{
+					AdvertiseServices: tt.startServices,
+				},
+			})
+			e := &serveEnv{lc: lc, bg: bgBoolFlag{true, false}}
+			err := e.removeServiceFromPrefs(ctx, tt.dnsName)
+			if err != nil {
+				t.Fatalf("removeServiceFromPrefs(%q) returned unexpected error: %v", tt.dnsName, err)
+			}
+			if !slices.Equal(lc.prefs.AdvertiseServices, tt.expected) {
+				t.Errorf("removeServiceFromPrefs(%q) = %v, want %v", tt.dnsName, lc.prefs.AdvertiseServices, tt.expected)
+			}
+		})
+	}
+}
+
 func TestMessageForPort(t *testing.T) {
 	svcIPMap := tailcfg.ServiceIPMappings{
 		"svc:foo": []netip.Addr{

--- a/cmd/tailscale/cli/serve_v2_test.go
+++ b/cmd/tailscale/cli/serve_v2_test.go
@@ -1215,24 +1215,24 @@ func TestAddServiceToPrefs(t *testing.T) {
 func TestRemoveServiceFromPrefs(t *testing.T) {
 	tests := []struct {
 		name          string
-		dnsName       string
+		svcName       tailcfg.ServiceName
 		startServices []string
 		expected      []string
 	}{
 		{
 			name:     "remove service from empty prefs",
-			dnsName:  "svc:foo",
+			svcName:  "svc:foo",
 			expected: []string{},
 		},
 		{
 			name:          "remove existing service from prefs",
-			dnsName:       "svc:foo",
+			svcName:       "svc:foo",
 			startServices: []string{"svc:foo"},
 			expected:      []string{},
 		},
 		{
 			name:          "remove service not in prefs",
-			dnsName:       "svc:bar",
+			svcName:       "svc:bar",
 			startServices: []string{"svc:foo"},
 			expected:      []string{"svc:foo"},
 		},
@@ -1249,12 +1249,12 @@ func TestRemoveServiceFromPrefs(t *testing.T) {
 				},
 			})
 			e := &serveEnv{lc: lc, bg: bgBoolFlag{true, false}}
-			err := e.removeServiceFromPrefs(ctx, tt.dnsName)
+			err := e.removeServiceFromPrefs(ctx, tt.svcName)
 			if err != nil {
-				t.Fatalf("removeServiceFromPrefs(%q) returned unexpected error: %v", tt.dnsName, err)
+				t.Fatalf("removeServiceFromPrefs(%q) returned unexpected error: %v", tt.svcName, err)
 			}
 			if !slices.Equal(lc.prefs.AdvertiseServices, tt.expected) {
-				t.Errorf("removeServiceFromPrefs(%q) = %v, want %v", tt.dnsName, lc.prefs.AdvertiseServices, tt.expected)
+				t.Errorf("removeServiceFromPrefs(%q) = %v, want %v", tt.svcName, lc.prefs.AdvertiseServices, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
This PR adds the drain subcommand for serving services. After we merge advertise and serve service as one step, we now need a way to "unadvertise" service and this is it.

Updates tailscale/corp#22954