### PR TITLE
cmd/k8s-operator: Pass login server configuration to independent API proxy

### DIFF
--- a/cmd/k8s-operator/proxygroup.go
+++ b/cmd/k8s-operator/proxygroup.go
@@ -389,7 +389,7 @@ func (r *ProxyGroupReconciler) maybeProvision(ctx context.Context, pg *tsapi.Pro
 	if pg.Spec.Type == tsapi.ProxyGroupTypeKubernetesAPIServer {
 		defaultImage = r.k8sProxyImage
 	}
-	ss, err := pgStatefulSet(pg, r.tsNamespace, defaultImage, r.tsFirewallMode, tailscaledPort, proxyClass)
+	ss, err := pgStatefulSet(pg, r.tsNamespace, defaultImage, r.tsFirewallMode, tailscaledPort, proxyClass, r.loginServer)
 	if err != nil {
 		return r.notReadyErrf(pg, "error generating StatefulSet spec: %w", err)
 	}

--- a/cmd/k8s-operator/proxygroup_test.go
+++ b/cmd/k8s-operator/proxygroup_test.go
@@ -1049,6 +1049,7 @@ func TestProxyGroupTypes(t *testing.T) {
 		l:            zl.Sugar(),
 		tsClient:     &fakeTSClient{},
 		clock:        tstest.NewClock(tstest.ClockOpts{}),
+		loginServer:  "https://test.tailscale.com",
 	}
 
 	t.Run("egress_type", func(t *testing.T) {
@@ -1242,6 +1243,8 @@ func TestProxyGroupTypes(t *testing.T) {
 		if err := fc.Get(t.Context(), client.ObjectKey{Namespace: tsNamespace, Name: pg.Name}, sts); err != nil {
 			t.Fatalf("failed to get StatefulSet: %v", err)
 		}
+
+		verifyEnvVar(t, sts, "TS_K8S_PROXY_LOGIN_SERVER", reconciler.loginServer)
 
 		// Verify the StatefulSet configuration for KubernetesAPIServer type.
 		if sts.Spec.Template.Spec.Containers[0].Name != mainContainerName {
@@ -1588,7 +1591,7 @@ func expectProxyGroupResources(t *testing.T, fc client.WithWatch, pg *tsapi.Prox
 	role := pgRole(pg, tsNamespace)
 	roleBinding := pgRoleBinding(pg, tsNamespace)
 	serviceAccount := pgServiceAccount(pg, tsNamespace)
-	statefulSet, err := pgStatefulSet(pg, tsNamespace, testProxyImage, "auto", nil, proxyClass)
+	statefulSet, err := pgStatefulSet(pg, tsNamespace, testProxyImage, "auto", nil, proxyClass, "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This commit modifies the k8s-operator to apply the login server to any instances of the `ProxyGroup` resource that produces a k8s api proxy.

Updates https://github.com/tailscale/tailscale/issues/13358