### PR TITLE
wgengine/magicsock: don't peer relay if NodeAttrOnlyTCP443 is set

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -2704,6 +2704,7 @@ func (c *Conn) onNodeViewsUpdate(update NodeViewsUpdate) {
 
 	relayClientEnabled := update.SelfNode.Valid() &&
 		!update.SelfNode.HasCap(tailcfg.NodeAttrDisableRelayClient) &&
+		!update.SelfNode.HasCap(tailcfg.NodeAttrOnlyTCP443) &&
 		envknob.UseWIPCode()
 
 	c.mu.Lock()


### PR DESCRIPTION
Updates tailscale/corp#30138