### PR TITLE
cmd/k8s-operator: allow letsencrypt staging on k8s proxies

### DIFF
--- a/cmd/k8s-operator/sts.go
+++ b/cmd/k8s-operator/sts.go
@@ -761,14 +761,21 @@ func applyProxyClassToStatefulSet(pc *tsapi.ProxyClass, ss *appsv1.StatefulSet, 
 			enableEndpoints(ss, metricsEnabled, debugEnabled)
 		}
 	}
-	if pc.Spec.UseLetsEncryptStagingEnvironment && (stsCfg.proxyType == proxyTypeIngressResource || stsCfg.proxyType == string(tsapi.ProxyGroupTypeIngress)) {
-		for i, c := range ss.Spec.Template.Spec.Containers {
-			if isMainContainer(&c) {
-				ss.Spec.Template.Spec.Containers[i].Env = append(ss.Spec.Template.Spec.Containers[i].Env, corev1.EnvVar{
-					Name:  "TS_DEBUG_ACME_DIRECTORY_URL",
-					Value: letsEncryptStagingEndpoint,
-				})
-				break
+
+	if stsCfg != nil {
+		usesLetsEncrypt := stsCfg.proxyType == proxyTypeIngressResource ||
+			stsCfg.proxyType == string(tsapi.ProxyGroupTypeIngress) ||
+			stsCfg.proxyType == string(tsapi.ProxyGroupTypeKubernetesAPIServer)
+
+		if pc.Spec.UseLetsEncryptStagingEnvironment && usesLetsEncrypt {
+			for i, c := range ss.Spec.Template.Spec.Containers {
+				if isMainContainer(&c) {
+					ss.Spec.Template.Spec.Containers[i].Env = append(ss.Spec.Template.Spec.Containers[i].Env, corev1.EnvVar{
+						Name:  "TS_DEBUG_ACME_DIRECTORY_URL",
+						Value: letsEncryptStagingEndpoint,
+					})
+					break
+				}
 			}
 		}
 	}

--- a/cmd/k8s-operator/sts_test.go
+++ b/cmd/k8s-operator/sts_test.go
@@ -61,6 +61,7 @@ func Test_applyProxyClassToStatefulSet(t *testing.T) {
 	// Setup
 	proxyClassAllOpts := &tsapi.ProxyClass{
 		Spec: tsapi.ProxyClassSpec{
+			UseLetsEncryptStagingEnvironment: true,
 			StatefulSet: &tsapi.StatefulSet{
 				Labels:      tsapi.Labels{"foo": "bar"},
 				Annotations: map[string]string{"foo.io/bar": "foo"},
@@ -292,6 +293,10 @@ func Test_applyProxyClassToStatefulSet(t *testing.T) {
 	if diff := cmp.Diff(gotSS, wantSS); diff != "" {
 		t.Errorf("Unexpected result applying ProxyClass with metrics enabled to a StatefulSet (-got +want):\n%s", diff)
 	}
+
+	// 8. A Kubernetes API proxy with letsencrypt staging enabled
+	gotSS = applyProxyClassToStatefulSet(proxyClassAllOpts, nonUserspaceProxySS.DeepCopy(), &tailscaleSTSConfig{proxyType: string(tsapi.ProxyGroupTypeKubernetesAPIServer)}, zl.Sugar())
+	verifyEnvVar(t, gotSS, "TS_DEBUG_ACME_DIRECTORY_URL", letsEncryptStagingEndpoint)
 }
 
 func Test_mergeStatefulSetLabelsOrAnnots(t *testing.T) {


### PR DESCRIPTION
This commit modifies the operator to detect the usage of k8s-apiserver type proxy groups that wish to use the letsencrypt staging directory and apply the appropriate environment variable to the statefulset it produces.

Updates #13358