### PR TITLE
cmd/{k8s-operator,k8s-proxy}: apply accept-routes configuration to k8s-proxy

### DIFF
--- a/cmd/k8s-operator/proxygroup.go
+++ b/cmd/k8s-operator/proxygroup.go
@@ -820,6 +820,10 @@ func (r *ProxyGroupReconciler) ensureConfigSecretsCreated(ctx context.Context, p
 				cfg.ServerURL = &r.loginServer
 			}
 
+			if proxyClass != nil && proxyClass.Spec.TailscaleConfig != nil {
+				cfg.AcceptRoutes = &proxyClass.Spec.TailscaleConfig.AcceptRoutes
+			}
+
 			cfgB, err := json.Marshal(cfg)
 			if err != nil {
 				return nil, fmt.Errorf("error marshalling k8s-proxy config: %w", err)

--- a/kube/k8s-proxy/conf/conf.go
+++ b/kube/k8s-proxy/conf/conf.go
@@ -54,6 +54,7 @@ type ConfigV1Alpha1 struct {
 	App           *string        `json:",omitempty"` // e.g. kubetypes.AppProxyGroupKubeAPIServer
 	KubeAPIServer *KubeAPIServer `json:",omitempty"` // Config specific to the API Server proxy.
 	ServerURL     *string        `json:",omitempty"` // URL of the Tailscale coordination server.
+	AcceptRoutes  *bool          `json:",omitempty"` // Accepts routes advertised by other Tailscale nodes.
 }
 
 type KubeAPIServer struct {


### PR DESCRIPTION
This commit modifies the k8s-operator and k8s-proxy to support passing down the accept-routes configuration from the proxy class as a configuration value read and used by the k8s-proxy when ran as a distinct container managed by the operator.

Updates https://github.com/tailscale/tailscale/issues/13358