### PR TITLE
 cmd/{k8s-operator,k8s-proxy},kube/k8s-proxy: add static endpoints for kube-apiserver type ProxyGroups

### DIFF
--- a/cmd/k8s-operator/proxygroup.go
+++ b/cmd/k8s-operator/proxygroup.go
@@ -824,6 +824,10 @@ func (r *ProxyGroupReconciler) ensureConfigSecretsCreated(ctx context.Context, p
 				cfg.AcceptRoutes = &proxyClass.Spec.TailscaleConfig.AcceptRoutes
 			}
 
+			if len(endpoints[nodePortSvcName]) > 0 {
+				cfg.StaticEndpoints = endpoints[nodePortSvcName]
+			}
+
 			cfgB, err := json.Marshal(cfg)
 			if err != nil {
 				return nil, fmt.Errorf("error marshalling k8s-proxy config: %w", err)

--- a/kube/k8s-proxy/conf/conf.go
+++ b/kube/k8s-proxy/conf/conf.go
@@ -10,6 +10,7 @@ package conf
 import (
 	"encoding/json"
 	"fmt"
+	"net/netip"
 	"os"
 
 	"github.com/tailscale/hujson"
@@ -55,6 +56,9 @@ type ConfigV1Alpha1 struct {
 	KubeAPIServer *KubeAPIServer `json:",omitempty"` // Config specific to the API Server proxy.
 	ServerURL     *string        `json:",omitempty"` // URL of the Tailscale coordination server.
 	AcceptRoutes  *bool          `json:",omitempty"` // Accepts routes advertised by other Tailscale nodes.
+	// StaticEndpoints are additional, user-defined endpoints that this node
+	// should advertise amongst its wireguard endpoints.
+	StaticEndpoints []netip.AddrPort `json:",omitempty"`
 }
 
 type KubeAPIServer struct {


### PR DESCRIPTION
Recently, [Static Endpoints were implemented](https://github.com/tailscale/tailscale/pull/16115) for ProxyGroups. This PR implements Static Endpoints for the new HA kube-apiserver ProxyGroup type.

Note that this implementation uses `os.Setenv` in process the `k8s-proxy` container to configure `StaticEndpoints`. This is due to the fact that we cannot currently configure it via the `ipn.ConfigVAlpha`or prefs via tsnet.

Updates https://github.com/tailscale/tailscale/issues/13358