### PR TITLE
ipn/ipnlocal: add traffic-steering nodecap

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -2622,6 +2622,10 @@ const (
 	// NodeAttrMagicDNSPeerAAAA is a capability that tells the node's MagicDNS
 	// server to answer AAAA queries about its peers. See tailscale/tailscale#1152.
 	NodeAttrMagicDNSPeerAAAA NodeCapability = "magicdns-aaaa"
+
+	// NodeAttrTrafficSteering configures the node to use the traffic
+	// steering subsystem for via routes. See tailscale/corp#29966.
+	NodeAttrTrafficSteering NodeCapability = "traffic-steering"
 )
 
 // SetDNSRequest is a request to add a DNS record.


### PR DESCRIPTION
To signal when a tailnet has the `traffic-steering` feature flag, Control will send a `traffic-steering` NodeCapability in netmap’s AllCaps.

This patch adds `tailcfg.NodeAttrTrafficSteering` so that it can be used in the control plane. Future patches will implement the actual steering mechanisms.

Updates tailscale/corp#29966