### PR TITLE
cmd/tailscale/cli: add "configure jetkvm" subcommand

### DIFF
--- a/cmd/tailscale/cli/configure-jetkvm.go
+++ b/cmd/tailscale/cli/configure-jetkvm.go
@@ -1,0 +1,81 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build linux && !android && arm
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"flag"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+	"tailscale.com/version/distro"
+)
+
+func init() {
+	maybeJetKVMConfigureCmd = jetKVMConfigureCmd
+}
+
+func jetKVMConfigureCmd() *ffcli.Command {
+	if runtime.GOOS != "linux" || distro.Get() != distro.JetKVM {
+		return nil
+	}
+	return &ffcli.Command{
+		Name:       "jetkvm",
+		Exec:       runConfigureJetKVM,
+		ShortUsage: "tailscale configure jetkvm",
+		ShortHelp:  "Configure JetKVM to run tailscaled at boot",
+		LongHelp: strings.TrimSpace(`
+This command configures the JetKVM host to run tailscaled at boot.
+`),
+		FlagSet: (func() *flag.FlagSet {
+			fs := newFlagSet("jetkvm")
+			return fs
+		})(),
+	}
+}
+
+func runConfigureJetKVM(ctx context.Context, args []string) error {
+	if len(args) > 0 {
+		return errors.New("unknown arguments")
+	}
+	if runtime.GOOS != "linux" || distro.Get() != distro.JetKVM {
+		return errors.New("only implemented on JetKVM")
+	}
+	err := os.WriteFile("/etc/init.d/S22tailscale", bytes.TrimLeft([]byte(`
+#!/bin/sh
+# /etc/init.d/S22tailscale
+# Start/stop tailscaled
+
+case "$1" in
+  start)
+    /userdata/tailscale/tailscaled > /dev/null 2>&1 &
+    ;;
+  stop)
+    killall tailscaled
+    ;;
+  *)
+    echo "Usage: $0 {start|stop}"
+    exit 1
+    ;;
+esac
+`), "\n"), 0755)
+	if err != nil {
+		return err
+	}
+
+	if err := os.Symlink("/userdata/tailscale/tailscale", "/bin/tailscale"); err != nil {
+		if !os.IsExist(err) {
+			return err
+		}
+	}
+
+	printf("Done. Now restart your JetKVM.\n")
+	return nil
+}

--- a/cmd/tailscale/cli/configure.go
+++ b/cmd/tailscale/cli/configure.go
@@ -10,6 +10,8 @@ import (
 	"github.com/peterbourgon/ff/v3/ffcli"
 )
 
+var maybeJetKVMConfigureCmd func() *ffcli.Command // non-nil only on Linux/arm for JetKVM
+
 func configureCmd() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "configure",
@@ -29,6 +31,7 @@ services on the host to use Tailscale in more ways.
 			synologyConfigureCertCmd(),
 			ccall(maybeSysExtCmd),
 			ccall(maybeVPNConfigCmd),
+			ccall(maybeJetKVMConfigureCmd),
 		),
 	}
 }

--- a/version/distro/distro.go
+++ b/version/distro/distro.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 
 	"tailscale.com/types/lazy"
 	"tailscale.com/util/lineiter"
@@ -103,10 +104,18 @@ func linuxDistro() Distro {
 		return Unraid
 	case have("/etc/alpine-release"):
 		return Alpine
-	case haveDir("/userdata/jetkvm") && haveDir("/sys/kernel/config/usb_gadget/jetkvm"):
+	case runtime.GOARCH == "arm" && isDeviceModel("JetKVM"):
 		return JetKVM
 	}
 	return ""
+}
+
+func isDeviceModel(want string) bool {
+	if runtime.GOOS != "linux" {
+		return false
+	}
+	v, _ := os.ReadFile("/sys/firmware/devicetree/base/model")
+	return want == strings.Trim(string(v), "\x00\r\n\t ")
 }
 
 func freebsdDistro() Distro {


### PR DESCRIPTION
To write the init script.

And fix the JetKVM detection to work during early boot while the filesystem
and modules are still being loaded; it wasn't being detected on early boot
and then tailscaled was failing to start because it didn't know it was on JetKVM
and didn't modprobe tun.

Updates #16524
