### PR TITLE
wgengine/magicsock: don't acquire Conn.mu in udpRelayEndpointReady

### DIFF
--- a/wgengine/magicsock/endpoint.go
+++ b/wgengine/magicsock/endpoint.go
@@ -104,8 +104,6 @@ type endpoint struct {
 // be installed as de.bestAddr. It is only called by [relayManager] once it has
 // determined maybeBest is functional via [disco.Pong] reception.
 func (de *endpoint) udpRelayEndpointReady(maybeBest addrQuality) {
-	de.c.mu.Lock()
-	defer de.c.mu.Unlock()
 	de.mu.Lock()
 	defer de.mu.Unlock()
 


### PR DESCRIPTION
udpRelayEndpointReady used to write into the peerMap, which required holding Conn.mu, but this changed in f9e7131.

Updates #cleanup