### PR TITLE
ipn/ipnlocal: modernize nm.Peers with AppendMatchingPeers

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -7907,6 +7907,9 @@ func suggestExitNodeUsingTrafficSteering(nb *nodeBackend, prev tailcfg.StableNod
 		if !p.Valid() {
 			return false
 		}
+		if !p.Online().Get() {
+			return false
+		}
 		if allowed != nil && !allowed.Contains(p.StableID()) {
 			return false
 		}


### PR DESCRIPTION
#### Two commits:
1. Thanks to @nickkhyl for pointing out that NetMap.Peers doesn’t get incremental updates since the last full NetMap update. Instead, he recommends using ipn/ipnlocal.nodeBackend.AppendMatchingPeers.

2. @nickkyl added an peer.Online check to suggestExitNodeUsingDERP, so it should also check when running suggestExitNodeUsingTrafficSteering.

Updates #cleanup