### PR TITLE
net/udprelay: log socket read errors

### DIFF
--- a/net/udprelay/server.go
+++ b/net/udprelay/server.go
@@ -581,6 +581,7 @@ func (s *Server) packetReadLoop(readFromSocket, otherSocket *net.UDPConn) {
 		// TODO: extract laddr from IP_PKTINFO for use in reply
 		n, from, err := readFromSocket.ReadFromUDPAddrPort(b)
 		if err != nil {
+			s.logf("error reading from socket(%v): %v", readFromSocket.LocalAddr(), err)
 			return
 		}
 		s.handlePacket(from, b[:n], readFromSocket, otherSocket)


### PR DESCRIPTION
Socket read errors currently close the server, so we need to understand when and why they occur.

Updates tailscale/corp#27502
Updates tailscale/corp#30118