### PR TITLE
ipn/ipnlocal: use rendezvous hashing to traffic-steer exit nodes

### DIFF
--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -5012,7 +5012,7 @@ func TestSuggestExitNodeTrafficSteering(t *testing.T) {
 			wantName: "peer1",
 		},
 		{
-			name: "many-suggested-exit-nodes",
+			name: "suggest-exit-node-stable-pick",
 			netMap: &netmap.NetworkMap{
 				SelfNode: selfNode.View(),
 				Peers: []tailcfg.NodeView{
@@ -5030,53 +5030,8 @@ func TestSuggestExitNodeTrafficSteering(t *testing.T) {
 						withSuggest()),
 				},
 			},
+			// Change this, if the hashing function changes.
 			wantID:   "stable3",
-			wantName: "peer3",
-		},
-		{
-			name: "suggested-exit-node-was-last-suggested",
-			netMap: &netmap.NetworkMap{
-				SelfNode: selfNode.View(),
-				Peers: []tailcfg.NodeView{
-					makePeer(1,
-						withExitRoutes(),
-						withSuggest()),
-					makePeer(2,
-						withExitRoutes(),
-						withSuggest()),
-					makePeer(3,
-						withExitRoutes(),
-						withSuggest()),
-					makePeer(4,
-						withExitRoutes(),
-						withSuggest()),
-				},
-			},
-			lastExit: "stable2", // overrides many-suggested-exit-nodes
-			wantID:   "stable2",
-			wantName: "peer2",
-		},
-		{
-			name: "suggested-exit-node-was-never-suggested",
-			netMap: &netmap.NetworkMap{
-				SelfNode: selfNode.View(),
-				Peers: []tailcfg.NodeView{
-					makePeer(1,
-						withExitRoutes(),
-						withSuggest()),
-					makePeer(2,
-						withExitRoutes(),
-						withSuggest()),
-					makePeer(3,
-						withExitRoutes(),
-						withSuggest()),
-					makePeer(4,
-						withExitRoutes(),
-						withSuggest()),
-				},
-			},
-			lastExit: "stable10",
-			wantID:   "stable3", // matches many-suggested-exit-nodes
 			wantName: "peer3",
 		},
 		{
@@ -5282,7 +5237,7 @@ func TestSuggestExitNodeTrafficSteering(t *testing.T) {
 			defer nb.shutdown(errShutdown)
 			nb.SetNetMap(tt.netMap)
 
-			got, err := suggestExitNodeUsingTrafficSteering(nb, tt.lastExit, allowList)
+			got, err := suggestExitNodeUsingTrafficSteering(nb, allowList)
 			if tt.wantErr == nil && err != nil {
 				t.Fatalf("err=%v, want nil", err)
 			}


### PR DESCRIPTION
With [auto exit nodes](https://tailscale.com/blog/auto-exit-nodes) enabled, the client picks exit nodes from the ones advertised in the network map. Usually, it picks the one with the highest priority score, but when the top spot is tied, it used to pick randomly. Then, once it made a selection, it would strongly prefer to stick with that exit node. It wouldn’t even consider another exit node unless the client was shutdown or the exit node went offline. This is to prevent flapping, where a client constantly chooses a different random exit node.

The major problem with this algorithm is that new exit nodes don’t get selected as often as they should. In fact, they wouldn’t even move over if a higher scoring exit node appeared.

Let’s say that you have an exit node and it’s overloaded. So you spin up a new exit node, right beside your existing one, in the hopes that the traffic will be split across them. But since the client had this strong affinity, they stick with the exit node they know and love.

Using rendezvous hashing, we can have different clients spread their selections equally across their top scoring exit nodes. When an exit node shuts down, its clients will spread themselves evenly to their other equal options. When an exit node starts, a proportional number of clients will migrate to their new best option.

Read more: https://en.wikipedia.org/wiki/Rendezvous_hashing

The trade-off is that starting up a new exit node may cause some clients to move over, interrupting their existing network connections. So this change is only enabled for tailnets with `traffic-steering` enabled.

Updates tailscale/corp#29966
Fixes #16551