### PR TITLE
wgengine/magicsock: don't reuse TCP conns across peer relay alloc reqs

### DIFF
--- a/wgengine/magicsock/relaymanager.go
+++ b/wgengine/magicsock/relaymanager.go
@@ -870,7 +870,11 @@ func doAllocate(ctx context.Context, server netip.AddrPort, discoKeys [2]key.Dis
 	if err != nil {
 		return udprelay.ServerEndpoint{}, err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	transport := &http.Transport{
+		DisableKeepAlives: true, // this transport is meant to be used once
+	}
+	client := &http.Client{Transport: transport}
+	resp, err := client.Do(req)
 	if err != nil {
 		return udprelay.ServerEndpoint{}, err
 	}


### PR DESCRIPTION
They must be closed when the request completes.

Updates tailscale/corp#30534