### PR TITLE
client/systray: look for ubuntu gnome

### DIFF
--- a/client/systray/systray.go
+++ b/client/systray/systray.go
@@ -128,7 +128,7 @@ func init() {
 
 	desktop := strings.ToLower(os.Getenv("XDG_CURRENT_DESKTOP"))
 	switch desktop {
-	case "gnome":
+	case "gnome", "ubuntu:gnome":
 		// GNOME expands submenus downward in the main menu, rather than flyouts to the side.
 		// Either as a result of that or another limitation, there seems to be a maximum depth of submenus.
 		// Mullvad countries that have a city submenu are not being rendered, and so can't be selected.


### PR DESCRIPTION
Ubuntu gnome has a different name on at least 25.04.

Updates #1708

Signed-off-by: Claus Lensbøl <claus@tailscale.com>
