### PR TITLE
feature/tpm: try opening /dev/tpmrm0 before /tmp/tpm0 on Linux

### DIFF
--- a/feature/tpm/tpm_linux.go
+++ b/feature/tpm/tpm_linux.go
@@ -9,5 +9,9 @@ import (
 )
 
 func open() (transport.TPMCloser, error) {
+	tpm, err := linuxtpm.Open("/dev/tpmrm0")
+	if err == nil {
+		return tpm, nil
+	}
 	return linuxtpm.Open("/dev/tpm0")
 }


### PR DESCRIPTION
The tpmrm0 is a kernel-managed version of tpm0 that multiplexes multiple concurrent connections. The basic tpm0 can only be accessed by one application at a time, which can be pretty unreliable.

Updates #15830