### PR TITLE
cmd/{k8s-operator,k8s-proxy},kube: use consistent type for auth mode config

### DIFF
--- a/cmd/k8s-operator/operator.go
+++ b/cmd/k8s-operator/operator.go
@@ -113,7 +113,7 @@ func main() {
 	// additionally act as api-server proxy
 	// https://tailscale.com/kb/1236/kubernetes-operator/?q=kubernetes#accessing-the-kubernetes-control-plane-using-an-api-server-proxy.
 	mode := parseAPIProxyMode()
-	if mode == apiServerProxyModeDisabled {
+	if mode == nil {
 		hostinfo.SetApp(kubetypes.AppOperator)
 	} else {
 		hostinfo.SetApp(kubetypes.AppInProcessAPIServerProxy)
@@ -122,8 +122,8 @@ func main() {
 	s, tsc := initTSNet(zlog, loginServer)
 	defer s.Close()
 	restConfig := config.GetConfigOrDie()
-	if mode != apiServerProxyModeDisabled {
-		ap, err := apiproxy.NewAPIServerProxy(zlog, restConfig, s, mode == apiServerProxyModeEnabled, true)
+	if mode != nil {
+		ap, err := apiproxy.NewAPIServerProxy(zlog, restConfig, s, *mode, true)
 		if err != nil {
 			zlog.Fatalf("error creating API server proxy: %v", err)
 		}

--- a/cmd/k8s-operator/proxygroup.go
+++ b/cmd/k8s-operator/proxygroup.go
@@ -805,6 +805,10 @@ func (r *ProxyGroupReconciler) ensureConfigSecretsCreated(ctx context.Context, p
 				}
 			}
 
+			mode := kubetypes.APIServerProxyModeAuth
+			if !isAuthAPIServerProxy(pg) {
+				mode = kubetypes.APIServerProxyModeNoAuth
+			}
 			cfg := conf.VersionedConfig{
 				Version: "v1alpha1",
 				ConfigV1Alpha1: &conf.ConfigV1Alpha1{
@@ -816,8 +820,8 @@ func (r *ProxyGroupReconciler) ensureConfigSecretsCreated(ctx context.Context, p
 					// Reloadable fields.
 					Hostname: &hostname,
 					APIServerProxy: &conf.APIServerProxyConfig{
-						Enabled:  opt.NewBool(true),
-						AuthMode: opt.NewBool(isAuthAPIServerProxy(pg)),
+						Enabled: opt.NewBool(true),
+						Mode:    &mode,
 						// The first replica is elected as the cert issuer, same
 						// as containerboot does for ingress-pg-reconciler.
 						IssueCerts: opt.NewBool(i == 0),

--- a/cmd/k8s-operator/proxygroup_test.go
+++ b/cmd/k8s-operator/proxygroup_test.go
@@ -1376,7 +1376,7 @@ func TestKubeAPIServerType_DoesNotOverwriteServicesConfig(t *testing.T) {
 			Hostname: ptr.To("test-k8s-apiserver-0"),
 			APIServerProxy: &conf.APIServerProxyConfig{
 				Enabled:    opt.NewBool(true),
-				AuthMode:   opt.NewBool(false),
+				Mode:       ptr.To(kubetypes.APIServerProxyModeNoAuth),
 				IssueCerts: opt.NewBool(true),
 			},
 		},

--- a/cmd/k8s-proxy/k8s-proxy.go
+++ b/cmd/k8s-proxy/k8s-proxy.go
@@ -34,6 +34,7 @@ import (
 	apiproxy "tailscale.com/k8s-operator/api-proxy"
 	"tailscale.com/kube/certs"
 	"tailscale.com/kube/k8s-proxy/conf"
+	"tailscale.com/kube/kubetypes"
 	klc "tailscale.com/kube/localclient"
 	"tailscale.com/kube/services"
 	"tailscale.com/kube/state"
@@ -238,11 +239,11 @@ func run(logger *zap.SugaredLogger) error {
 	}
 
 	// Setup for the API server proxy.
-	authMode := true
-	if cfg.Parsed.APIServerProxy != nil && cfg.Parsed.APIServerProxy.AuthMode.EqualBool(false) {
-		authMode = false
+	mode := kubetypes.APIServerProxyModeAuth
+	if cfg.Parsed.APIServerProxy != nil && cfg.Parsed.APIServerProxy.Mode != nil {
+		mode = *cfg.Parsed.APIServerProxy.Mode
 	}
-	ap, err := apiproxy.NewAPIServerProxy(logger.Named("apiserver-proxy"), restConfig, ts, authMode, false)
+	ap, err := apiproxy.NewAPIServerProxy(logger.Named("apiserver-proxy"), restConfig, ts, mode, false)
 	if err != nil {
 		return fmt.Errorf("error creating api server proxy: %w", err)
 	}

--- a/k8s-operator/sessionrecording/hijacker.go
+++ b/k8s-operator/sessionrecording/hijacker.go
@@ -57,7 +57,7 @@ var (
 	counterSessionRecordingsUploaded = clientmetric.NewCounter("k8s_auth_proxy_session_recordings_uploaded")
 )
 
-func New(opts HijackerOpts) *Hijacker {
+func NewHijacker(opts HijackerOpts) *Hijacker {
 	return &Hijacker{
 		ts:                opts.TS,
 		req:               opts.Req,

--- a/kube/k8s-proxy/conf/conf.go
+++ b/kube/k8s-proxy/conf/conf.go
@@ -14,6 +14,7 @@ import (
 	"net/netip"
 
 	"github.com/tailscale/hujson"
+	"tailscale.com/kube/kubetypes"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/opt"
 )
@@ -66,10 +67,10 @@ type ConfigV1Alpha1 struct {
 }
 
 type APIServerProxyConfig struct {
-	Enabled     opt.Bool             `json:",omitempty"` // Whether to enable the API Server proxy.
-	AuthMode    opt.Bool             `json:",omitempty"` // Run in auth or noauth mode.
-	ServiceName *tailcfg.ServiceName `json:",omitempty"` // Name of the Tailscale Service to advertise.
-	IssueCerts  opt.Bool             `json:",omitempty"` // Whether this replica should issue TLS certs for the Tailscale Service.
+	Enabled     opt.Bool                      `json:",omitempty"` // Whether to enable the API Server proxy.
+	Mode        *kubetypes.APIServerProxyMode `json:",omitempty"` // "auth" or "noauth" mode.
+	ServiceName *tailcfg.ServiceName          `json:",omitempty"` // Name of the Tailscale Service to advertise.
+	IssueCerts  opt.Bool                      `json:",omitempty"` // Whether this replica should issue TLS certs for the Tailscale Service.
 }
 
 // Load reads and parses the config file at the provided path on disk.

--- a/kube/kubetypes/types.go
+++ b/kube/kubetypes/types.go
@@ -3,6 +3,8 @@
 
 package kubetypes
 
+import "fmt"
+
 const (
 	// Hostinfo App values for the Tailscale Kubernetes Operator components.
 	AppOperator                = "k8s-operator"
@@ -59,5 +61,24 @@ const (
 	LabelSecretTypeState  = "state"
 	LabelSecretTypeCerts  = "certs"
 
-	KubeAPIServerConfigFile = "config.hujson"
+	KubeAPIServerConfigFile                     = "config.hujson"
+	APIServerProxyModeAuth   APIServerProxyMode = "auth"
+	APIServerProxyModeNoAuth APIServerProxyMode = "noauth"
 )
+
+// APIServerProxyMode specifies whether the API server proxy will add
+// impersonation headers to requests based on the caller's Tailscale identity.
+// May be "auth" or "noauth".
+type APIServerProxyMode string
+
+func (a *APIServerProxyMode) UnmarshalJSON(data []byte) error {
+	switch string(data) {
+	case `"auth"`:
+		*a = APIServerProxyModeAuth
+	case `"noauth"`:
+		*a = APIServerProxyModeNoAuth
+	default:
+		return fmt.Errorf("unknown APIServerProxyMode %q", data)
+	}
+	return nil
+}

--- a/kube/kubetypes/types_test.go
+++ b/kube/kubetypes/types_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package kubetypes
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestUnmarshalAPIServerProxyMode(t *testing.T) {
+	tests := []struct {
+		data     string
+		expected APIServerProxyMode
+	}{
+		{data: `{"mode":"auth"}`, expected: APIServerProxyModeAuth},
+		{data: `{"mode":"noauth"}`, expected: APIServerProxyModeNoAuth},
+		{data: `{"mode":""}`, expected: ""},
+		{data: `{"mode":"Auth"}`, expected: ""},
+		{data: `{"mode":"unknown"}`, expected: ""},
+	}
+
+	for _, tc := range tests {
+		var s struct {
+			Mode *APIServerProxyMode `json:",omitempty"`
+		}
+		err := json.Unmarshal([]byte(tc.data), &s)
+		if tc.expected == "" {
+			if err == nil {
+				t.Errorf("expected error for %q, got none", tc.data)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("unexpected error for %q: %v", tc.data, err)
+			continue
+		}
+		if *s.Mode != tc.expected {
+			t.Errorf("for %q expected %q, got %q", tc.data, tc.expected, *s.Mode)
+		}
+	}
+}


### PR DESCRIPTION
Updates k8s-proxy's config so its auth mode config matches what we set in kube-apiserver ProxyGroups for consistency.

Updates #13358

Change-Id: I95e29cec6ded2dc7c6d2d03f968a25c822bc0e01