### PR TITLE
cmd/tailscale/cli: use DNS name instead of Location to hide Mullvad exit nodes from status output

### DIFF
--- a/cmd/tailscale/cli/status.go
+++ b/cmd/tailscale/cli/status.go
@@ -70,6 +70,8 @@ var statusArgs struct {
 	peers   bool   // in CLI mode, show status of peer machines
 }
 
+const mullvadTCD = "mullvad.ts.net."
+
 func runStatus(ctx context.Context, args []string) error {
 	if len(args) > 0 {
 		return errors.New("unexpected non-flag arguments to 'tailscale status'")
@@ -212,9 +214,8 @@ func runStatus(ctx context.Context, args []string) error {
 			if ps.ShareeNode {
 				continue
 			}
-			if ps.Location != nil && ps.ExitNodeOption && !ps.ExitNode {
-				// Location based exit nodes are only shown with the
-				// `exit-node list` command.
+			if ps.ExitNodeOption && !ps.ExitNode && strings.HasSuffix(ps.DNSName, mullvadTCD) {
+				// Mullvad exit nodes are only shown with the `exit-node list` command.
 				locBasedExitNode = true
 				continue
 			}


### PR DESCRIPTION
Previously, we used a non-nil `Location` as an indicator that a peer is a Mullvad exit node. However, this is not, or no longer, reliable, since regular exit nodes may also have a non-nil `Location`, such as when `traffic-steering` is enabled for a tailnet.

In this PR, we update the plaintext `tailscale status` output to omit only Mullvad exit nodes, rather than all exit nodes with a non-nil `Location`. The JSON output remains unchanged and continues to include all peers.

Updates tailscale/corp#30614