### PR TITLE
refactor: use slices.Equal to simplify code

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -2175,7 +2175,7 @@ func (b *LocalBackend) setWgengineStatus(s *wgengine.Status, err error) {
 	es := b.parseWgStatusLocked(s)
 	cc := b.cc
 	b.engineStatus = es
-	needUpdateEndpoints := !endpointsEqual(s.LocalAddrs, b.endpoints)
+	needUpdateEndpoints := !slices.Equal(s.LocalAddrs, b.endpoints)
 	if needUpdateEndpoints {
 		b.endpoints = append([]tailcfg.Endpoint{}, s.LocalAddrs...)
 	}
@@ -2199,18 +2199,6 @@ func (b *LocalBackend) broadcastStatusChanged() {
 	b.statusLock.Lock()
 	b.statusChanged.Broadcast()
 	b.statusLock.Unlock()
-}
-
-func endpointsEqual(x, y []tailcfg.Endpoint) bool {
-	if len(x) != len(y) {
-		return false
-	}
-	for i := range x {
-		if x[i] != y[i] {
-			return false
-		}
-	}
-	return true
 }
 
 // SetNotifyCallback sets the function to call when the backend has something to

--- a/net/dns/config.go
+++ b/net/dns/config.go
@@ -8,6 +8,7 @@ import (
 	"bufio"
 	"fmt"
 	"net/netip"
+	"slices"
 	"sort"
 
 	"tailscale.com/control/controlknobs"
@@ -181,19 +182,7 @@ func sameResolverNames(a, b []*dnstype.Resolver) bool {
 		if a[i].Addr != b[i].Addr {
 			return false
 		}
-		if !sameIPs(a[i].BootstrapResolution, b[i].BootstrapResolution) {
-			return false
-		}
-	}
-	return true
-}
-
-func sameIPs(a, b []netip.Addr) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
+		if !slices.Equal(a[i].BootstrapResolution, b[i].BootstrapResolution) {
 			return false
 		}
 	}


### PR DESCRIPTION
In the Go 1.21 standard library, a new function has been introduced that enhances code conciseness and readability. It can be find  [here](https://pkg.go.dev/slices@go1.21.1#Equal).