### PR TITLE
cmd/k8s-operator: grant secret permissions to auth proxy

### DIFF
--- a/cmd/k8s-operator/deploy/chart/templates/apiserverproxy-rbac.yaml
+++ b/cmd/k8s-operator/deploy/chart/templates/apiserverproxy-rbac.yaml
@@ -19,6 +19,9 @@ rules:
 - apiGroups: [""]
   resources: ["users", "groups"]
   verbs: ["impersonate"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["list", "get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
This commit modifies the role provided to the `kube-apiserver-auth-proxy` service account used by the operator when running the kube proxy to include the ability to get & list secrets.

The proxy attempts to check for the presence of a TLS certificate stored in a secret but fails due to lacking this permission. This causes a kubernetes API error to be surfaced in the machines UI in the admin panel. While the certificate is not required, it may confuse customers to see "Invalid Certificate" with a heavy kubernetes error.