### PR TITLE
k8s-operator: adding session type to cast header

### DIFF
--- a/k8s-operator/sessionrecording/hijacker.go
+++ b/k8s-operator/sessionrecording/hijacker.go
@@ -184,9 +184,10 @@ func (h *Hijacker) setUpRecording(ctx context.Context, conn net.Conn) (net.Conn,
 		SrcNode:   strings.TrimSuffix(h.who.Node.Name, "."),
 		SrcNodeID: h.who.Node.StableID,
 		Kubernetes: &sessionrecording.Kubernetes{
-			PodName:   h.pod,
-			Namespace: h.ns,
-			Container: container,
+			PodName:     h.pod,
+			Namespace:   h.ns,
+			Container:   container,
+			SessionType: string(h.sessionType),
 		},
 	}
 	if !h.who.Node.IsTagged() {


### PR DESCRIPTION
This PR adds the session type to the cast header that is sent to tsrecorder.

Updates #16490