### PR TITLE
add fallback template in dev mode if parsing fails

### DIFF
--- a/cmd/hello/hello.go
+++ b/cmd/hello/hello.go
@@ -51,7 +51,9 @@ func main() {
 		var err error
 		tmpl, err = template.New("home").Parse(embeddedTemplate)
 		if err != nil {
-			log.Printf("ignoring template error in dev mode: %v", err)
+			log.Printf("template parse error in dev mode: %v; using fallback template", err)
+			// Fallback minimal template to avoid nil pointer dereference
+			tmpl = template.Must(template.New("fallback").Parse("<html><body><h1>Template Error</h1><p>{{.}}</p></body></html>"))
 		}
 	} else {
 		if embeddedTemplate == "" {


### PR DESCRIPTION
hello: add fallback template in dev mode if parsing fails

If parsing the embedded template fails in dev mode, log the error and use a minimal fallback template to avoid a nil pointer dereference. This ensures the server can still respond with an error page instead of