### PR TITLE
cmd/k8s-operator,k8s-operator: allow setting a `priorityClassName`

### DIFF
--- a/cmd/k8s-operator/deploy/crds/tailscale.com_proxyclasses.yaml
+++ b/cmd/k8s-operator/deploy/crds/tailscale.com_proxyclasses.yaml
@@ -1093,6 +1093,13 @@ spec:
                           type: object
                           additionalProperties:
                             type: string
+                        priorityClassName:
+                          description: |-
+                            PriorityClassName for the proxy Pod.
+                            By default Tailscale Kubernetes operator does not apply any priority class.
+                            https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v
+                            1/#scheduling
+                          type: string
                         securityContext:
                           description: |-
                             Proxy Pod's security context.

--- a/cmd/k8s-operator/deploy/manifests/operator.yaml
+++ b/cmd/k8s-operator/deploy/manifests/operator.yaml
@@ -1567,6 +1567,13 @@ spec:
                                                     selector.
                                                     https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling
                                                 type: object
+                                            priorityClassName:
+                                                description: |-
+                                                    PriorityClassName for the proxy Pod.
+                                                    By default Tailscale Kubernetes operator does not apply any priority class.
+                                                    https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v
+                                                    1/#scheduling
+                                                type: string
                                             securityContext:
                                                 description: |-
                                                     Proxy Pod's security context.

--- a/cmd/k8s-operator/sts.go
+++ b/cmd/k8s-operator/sts.go
@@ -800,6 +800,7 @@ func applyProxyClassToStatefulSet(pc *tsapi.ProxyClass, ss *appsv1.StatefulSet, 
 	ss.Spec.Template.Spec.NodeSelector = wantsPod.NodeSelector
 	ss.Spec.Template.Spec.Affinity = wantsPod.Affinity
 	ss.Spec.Template.Spec.Tolerations = wantsPod.Tolerations
+	ss.Spec.Template.Spec.PriorityClassName = wantsPod.PriorityClassName
 	ss.Spec.Template.Spec.TopologySpreadConstraints = wantsPod.TopologySpreadConstraints
 
 	// Update containers.

--- a/cmd/k8s-operator/sts_test.go
+++ b/cmd/k8s-operator/sts_test.go
@@ -75,6 +75,7 @@ func Test_applyProxyClassToStatefulSet(t *testing.T) {
 					NodeSelector:     map[string]string{"beta.kubernetes.io/os": "linux"},
 					Affinity:         &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{}}},
 					Tolerations:      []corev1.Toleration{{Key: "", Operator: "Exists"}},
+					PriorityClassName: "high-priority",
 					TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
 						{
 							WhenUnsatisfiable: "DoNotSchedule",
@@ -197,6 +198,7 @@ func Test_applyProxyClassToStatefulSet(t *testing.T) {
 	wantSS.Spec.Template.Spec.Containers[0].ImagePullPolicy = "IfNotPresent"
 	wantSS.Spec.Template.Spec.InitContainers[0].Image = "ghcr.io/my-repo/tailscale:v0.01testsomething"
 	wantSS.Spec.Template.Spec.InitContainers[0].ImagePullPolicy = "IfNotPresent"
+	wantSS.Spec.Template.Spec.PriorityClassName = proxyClassAllOpts.Spec.StatefulSet.Pod.PriorityClassName
 
 	gotSS := applyProxyClassToStatefulSet(proxyClassAllOpts, nonUserspaceProxySS.DeepCopy(), new(tailscaleSTSConfig), zl.Sugar())
 	if diff := cmp.Diff(gotSS, wantSS); diff != "" {

--- a/k8s-operator/api.md
+++ b/k8s-operator/api.md
@@ -466,6 +466,7 @@ _Appears in:_
 | `nodeSelector` _object (keys:string, values:string)_ | Proxy Pod's node selector.<br />By default Tailscale Kubernetes operator does not apply any node<br />selector.<br />https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling |  |  |
 | `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.3/#toleration-v1-core) array_ | Proxy Pod's tolerations.<br />By default Tailscale Kubernetes operator does not apply any<br />tolerations.<br />https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling |  |  |
 | `topologySpreadConstraints` _[TopologySpreadConstraint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.3/#topologyspreadconstraint-v1-core) array_ | Proxy Pod's topology spread constraints.<br />By default Tailscale Kubernetes operator does not apply any topology spread constraints.<br />https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ |  |  |
+| `priorityClassName` _string_ | PriorityClassName for the proxy Pod.<br />By default Tailscale Kubernetes operator does not apply any priority class.<br />https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v<br />1/#scheduling |  |  |
 
 
 #### PortRange

--- a/k8s-operator/apis/v1alpha1/types_proxyclass.go
+++ b/k8s-operator/apis/v1alpha1/types_proxyclass.go
@@ -297,6 +297,12 @@ type Pod struct {
 	// https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
 	// +optional
 	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
+	// PriorityClassName for the proxy Pod.
+	// By default Tailscale Kubernetes operator does not apply any priority class.
+	// https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v
+	// 1/#scheduling
+	// +optional
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 }
 
 // +kubebuilder:validation:XValidation:rule="!(has(self.serviceMonitor) && self.serviceMonitor.enable  && !self.enable)",message="ServiceMonitor can only be enabled if metrics are enabled"


### PR DESCRIPTION
Fixes #16682

Signed-off-by: Lee Briggs <lee@leebriggs.co.uk>
