### PR TITLE
 k8s-operator: adding session type to cast header (#16660)

### DIFF
--- a/k8s-operator/sessionrecording/hijacker.go
+++ b/k8s-operator/sessionrecording/hijacker.go
@@ -184,9 +184,10 @@ func (h *Hijacker) setUpRecording(ctx context.Context, conn net.Conn) (net.Conn,
 		SrcNode:   strings.TrimSuffix(h.who.Node.Name, "."),
 		SrcNodeID: h.who.Node.StableID,
 		Kubernetes: &sessionrecording.Kubernetes{
-			PodName:   h.pod,
-			Namespace: h.ns,
-			Container: container,
+			PodName:     h.pod,
+			Namespace:   h.ns,
+			Container:   container,
+			SessionType: string(h.sessionType),
 		},
 	}
 	if !h.who.Node.IsTagged() {


### PR DESCRIPTION
Cherry-picks https://github.com/tailscale/tailscale/pull/16660 into 1.86 branch to provide tsrecorder with the session type (`attach` or `exec`) for which is being recorded.

Updates https://github.com/tailscale/tailscale/issues/16490