### PR TITLE
k8s-operator: add IPv6 support for DNS records

### DIFF
--- a/cmd/k8s-nameserver/main_test.go
+++ b/cmd/k8s-nameserver/main_test.go
@@ -19,6 +19,7 @@ func TestNameserver(t *testing.T) {
 	tests := []struct {
 		name     string
 		ip4      map[dnsname.FQDN][]net.IP
+		ip6      map[dnsname.FQDN][]net.IP
 		query    *dns.Msg
 		wantResp *dns.Msg
 	}{
@@ -113,6 +114,49 @@ func TestNameserver(t *testing.T) {
 				}},
 		},
 		{
+			name: "AAAA record query with IPv6 record",
+			ip6:  map[dnsname.FQDN][]net.IP{dnsname.FQDN("foo.bar.com."): {net.ParseIP("2001:db8::1")}},
+			query: &dns.Msg{
+				Question: []dns.Question{{Name: "foo.bar.com", Qtype: dns.TypeAAAA}},
+				MsgHdr:   dns.MsgHdr{Id: 1, RecursionDesired: true},
+			},
+			wantResp: &dns.Msg{
+				Answer: []dns.RR{&dns.AAAA{Hdr: dns.RR_Header{
+					Name: "foo.bar.com", Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 0},
+					AAAA: net.ParseIP("2001:db8::1")}},
+				Question: []dns.Question{{Name: "foo.bar.com", Qtype: dns.TypeAAAA}},
+				MsgHdr: dns.MsgHdr{
+					Id:                 1,
+					Rcode:              dns.RcodeSuccess,
+					RecursionAvailable: false,
+					RecursionDesired:   true,
+					Response:           true,
+					Opcode:             dns.OpcodeQuery,
+					Authoritative:      true,
+				}},
+		},
+		{
+			name: "Dual-stack: both A and AAAA records exist",
+			ip4:  map[dnsname.FQDN][]net.IP{dnsname.FQDN("dual.bar.com."): {{10, 0, 0, 1}}},
+			ip6:  map[dnsname.FQDN][]net.IP{dnsname.FQDN("dual.bar.com."): {net.ParseIP("2001:db8::1")}},
+			query: &dns.Msg{
+				Question: []dns.Question{{Name: "dual.bar.com", Qtype: dns.TypeAAAA}},
+				MsgHdr:   dns.MsgHdr{Id: 1},
+			},
+			wantResp: &dns.Msg{
+				Answer: []dns.RR{&dns.AAAA{Hdr: dns.RR_Header{
+					Name: "dual.bar.com", Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 0},
+					AAAA: net.ParseIP("2001:db8::1")}},
+				Question: []dns.Question{{Name: "dual.bar.com", Qtype: dns.TypeAAAA}},
+				MsgHdr: dns.MsgHdr{
+					Id:            1,
+					Rcode:         dns.RcodeSuccess,
+					Response:      true,
+					Opcode:        dns.OpcodeQuery,
+					Authoritative: true,
+				}},
+		},
+		{
 			name: "CNAME record query",
 			ip4:  map[dnsname.FQDN][]net.IP{dnsname.FQDN("foo.bar.com."): {{1, 2, 3, 4}}},
 			query: &dns.Msg{
@@ -133,6 +177,7 @@ func TestNameserver(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ns := &nameserver{
 				ip4: tt.ip4,
+				ip6: tt.ip6,
 			}
 			handler := ns.handleFunc()
 			fakeRespW := &fakeResponseWriter{}
@@ -149,43 +194,63 @@ func TestResetRecords(t *testing.T) {
 		name     string
 		config   []byte
 		hasIp4   map[dnsname.FQDN][]net.IP
+		hasIp6   map[dnsname.FQDN][]net.IP
 		wantsIp4 map[dnsname.FQDN][]net.IP
+		wantsIp6 map[dnsname.FQDN][]net.IP
 		wantsErr bool
 	}{
 		{
 			name:     "previously empty nameserver.ip4 gets set",
 			config:   []byte(`{"version": "v1alpha1", "ip4": {"foo.bar.com": ["1.2.3.4"]}}`),
 			wantsIp4: map[dnsname.FQDN][]net.IP{"foo.bar.com.": {{1, 2, 3, 4}}},
+			wantsIp6: make(map[dnsname.FQDN][]net.IP),
 		},
 		{
 			name:     "nameserver.ip4 gets reset",
 			hasIp4:   map[dnsname.FQDN][]net.IP{"baz.bar.com.": {{1, 1, 3, 3}}},
 			config:   []byte(`{"version": "v1alpha1", "ip4": {"foo.bar.com": ["1.2.3.4"]}}`),
 			wantsIp4: map[dnsname.FQDN][]net.IP{"foo.bar.com.": {{1, 2, 3, 4}}},
+			wantsIp6: make(map[dnsname.FQDN][]net.IP),
 		},
 		{
 			name:     "configuration with incompatible version",
 			hasIp4:   map[dnsname.FQDN][]net.IP{"baz.bar.com.": {{1, 1, 3, 3}}},
 			config:   []byte(`{"version": "v1beta1", "ip4": {"foo.bar.com": ["1.2.3.4"]}}`),
 			wantsIp4: map[dnsname.FQDN][]net.IP{"baz.bar.com.": {{1, 1, 3, 3}}},
+			wantsIp6: nil,
 			wantsErr: true,
 		},
 		{
 			name:     "nameserver.ip4 gets reset to empty config when no configuration is provided",
 			hasIp4:   map[dnsname.FQDN][]net.IP{"baz.bar.com.": {{1, 1, 3, 3}}},
 			wantsIp4: make(map[dnsname.FQDN][]net.IP),
+			wantsIp6: make(map[dnsname.FQDN][]net.IP),
 		},
 		{
 			name:     "nameserver.ip4 gets reset to empty config when the provided configuration is empty",
 			hasIp4:   map[dnsname.FQDN][]net.IP{"baz.bar.com.": {{1, 1, 3, 3}}},
 			config:   []byte(`{"version": "v1alpha1", "ip4": {}}`),
 			wantsIp4: make(map[dnsname.FQDN][]net.IP),
+			wantsIp6: make(map[dnsname.FQDN][]net.IP),
+		},
+		{
+			name:     "nameserver.ip6 gets set",
+			config:   []byte(`{"version": "v1alpha1", "ip6": {"foo.bar.com": ["2001:db8::1"]}}`),
+			wantsIp4: make(map[dnsname.FQDN][]net.IP),
+			wantsIp6: map[dnsname.FQDN][]net.IP{"foo.bar.com.": {net.ParseIP("2001:db8::1")}},
+		},
+		{
+			name:     "dual-stack configuration",
+			config:   []byte(`{"version": "v1alpha1", "ip4": {"dual.bar.com": ["10.0.0.1"]}, "ip6": {"dual.bar.com": ["2001:db8::1"]}}`),
+			wantsIp4: map[dnsname.FQDN][]net.IP{"dual.bar.com.": {{10, 0, 0, 1}}},
+			wantsIp6: map[dnsname.FQDN][]net.IP{"dual.bar.com.": {net.ParseIP("2001:db8::1")}},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ns := &nameserver{
 				ip4:          tt.hasIp4,
+				ip6:          tt.hasIp6,
 				configReader: func() ([]byte, error) { return tt.config, nil },
 			}
 			if err := ns.resetRecords(); err == nil == tt.wantsErr {
@@ -193,6 +258,9 @@ func TestResetRecords(t *testing.T) {
 			}
 			if diff := cmp.Diff(ns.ip4, tt.wantsIp4); diff != "" {
 				t.Fatalf("unexpected nameserver.ip4 contents (-got +want): \n%s", diff)
+			}
+			if diff := cmp.Diff(ns.ip6, tt.wantsIp6); diff != "" {
+				t.Fatalf("unexpected nameserver.ip6 contents (-got +want): \n%s", diff)
 			}
 		})
 	}

--- a/cmd/k8s-operator/deploy/crds/tailscale.com_dnsconfigs.yaml
+++ b/cmd/k8s-operator/deploy/crds/tailscale.com_dnsconfigs.yaml
@@ -52,7 +52,6 @@ spec:
             using its MagicDNS name, you must also annotate the Ingress resource with
             tailscale.com/experimental-forward-cluster-traffic-via-ingress annotation to
             ensure that the proxy created for the Ingress listens on its Pod IP address.
-            NB: Clusters where Pods get assigned IPv6 addresses only are currently not supported.
           type: object
           required:
             - spec

--- a/cmd/k8s-operator/deploy/manifests/operator.yaml
+++ b/cmd/k8s-operator/deploy/manifests/operator.yaml
@@ -347,7 +347,6 @@ spec:
                     using its MagicDNS name, you must also annotate the Ingress resource with
                     tailscale.com/experimental-forward-cluster-traffic-via-ingress annotation to
                     ensure that the proxy created for the Ingress listens on its Pod IP address.
-                    NB: Clusters where Pods get assigned IPv6 addresses only are currently not supported.
                 properties:
                     apiVersion:
                         description: |-

--- a/k8s-operator/api.md
+++ b/k8s-operator/api.md
@@ -193,7 +193,6 @@ NB: if you want cluster workloads to be able to refer to Tailscale Ingress
 using its MagicDNS name, you must also annotate the Ingress resource with
 tailscale.com/experimental-forward-cluster-traffic-via-ingress annotation to
 ensure that the proxy created for the Ingress listens on its Pod IP address.
-NB: Clusters where Pods get assigned IPv6 addresses only are currently not supported.
 
 
 

--- a/k8s-operator/apis/v1alpha1/types_tsdnsconfig.go
+++ b/k8s-operator/apis/v1alpha1/types_tsdnsconfig.go
@@ -45,7 +45,6 @@ var DNSConfigKind = "DNSConfig"
 // using its MagicDNS name, you must also annotate the Ingress resource with
 // tailscale.com/experimental-forward-cluster-traffic-via-ingress annotation to
 // ensure that the proxy created for the Ingress listens on its Pod IP address.
-// NB: Clusters where Pods get assigned IPv6 addresses only are currently not supported.
 type DNSConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/k8s-operator/utils.go
+++ b/k8s-operator/utils.go
@@ -27,6 +27,11 @@ type Records struct {
 	Version string `json:"version"`
 	// IP4 contains a mapping of DNS names to IPv4 address(es).
 	IP4 map[string][]string `json:"ip4"`
+	// IP6 contains a mapping of DNS names to IPv6 address(es).
+	// This field is optional and will be omitted from JSON if empty.
+	// It enables dual-stack DNS support in Kubernetes clusters.
+	// +optional
+	IP6 map[string][]string `json:"ip6,omitempty"`
 }
 
 // TailscaledConfigFileName returns a tailscaled config file name in


### PR DESCRIPTION
This change adds full IPv6 support to the Kubernetes operator's DNS functionality, enabling dual-stack and IPv6-only cluster support.

Changes:
- Add IP6 field to Records struct for storing IPv6 addresses
- Update DNS records reconciler to handle both IPv4 and IPv6 from EndpointSlices
- Support dual-stack services with multiple ClusterIPs
- Implement AAAA record responses in k8s-nameserver

Fixes #16633