### PR TITLE
util/syspolicy/setting: use a custom marshaler for time.Duration

### DIFF
--- a/util/syspolicy/setting/snapshot_test.go
+++ b/util/syspolicy/setting/snapshot_test.go
@@ -492,6 +492,18 @@ func TestMarshalUnmarshalSnapshot(t *testing.T) {
 			wantJSON: `{"Settings": {"ListPolicy": {"Value": ["Value1", "Value2"]}}}`,
 		},
 		{
+			name:     "Duration/Zero",
+			snapshot: NewSnapshot(map[Key]RawItem{"DurationPolicy": RawItemOf(time.Duration(0))}),
+			wantJSON: `{"Settings": {"DurationPolicy": {"Value": "0s"}}}`,
+			wantBack: NewSnapshot(map[Key]RawItem{"DurationPolicy": RawItemOf("0s")}),
+		},
+		{
+			name:     "Duration/NonZero",
+			snapshot: NewSnapshot(map[Key]RawItem{"DurationPolicy": RawItemOf(2 * time.Hour)}),
+			wantJSON: `{"Settings": {"DurationPolicy": {"Value": "2h0m0s"}}}`,
+			wantBack: NewSnapshot(map[Key]RawItem{"DurationPolicy": RawItemOf("2h0m0s")}),
+		},
+		{
 			name: "Empty/With-Summary",
 			snapshot: NewSnapshot(
 				map[Key]RawItem{},


### PR DESCRIPTION
`jsonv2` now returns an error when you marshal or unmarshal a `time.Duration` without an explicit format flag. This is an intentional, temporary choice until the default `time.Duration` representation is decided (see golang/go#71631).

`setting.Snapshot` can hold `time.Duration` values inside a map[string]any, so the `jsonv2` update breaks marshaling. In this PR, we start using a custom marshaler until that decision is made or golang/go#71664 lets us specify the format explicitly.

This fixes `tailscale syspolicy list` failing when `KeyExpirationNotice` or any other `time.Duration` policy setting is configured.

Fixes #16683


(cherry picked from commit 4df02bbb486d07b0ad23f59c4cb3675ab691e79b)