### PR TITLE
net/portmapper: avert a panic when a mapping is not available (#16686)

### DIFF
--- a/net/portmapper/portmapper.go
+++ b/net/portmapper/portmapper.go
@@ -507,6 +507,13 @@ func (c *Client) createMapping() {
 			c.logf("createOrGetMapping: %v", err)
 		}
 		return
+	} else if mapping == nil {
+		return
+
+		// TODO(creachadair): This was already logged in createOrGetMapping.
+		// It really should not happen at all, but we will need to untangle
+		// the control flow to eliminate that possibility. Meanwhile, this
+		// mitigates a panic downstream, cf. #16662.
 	}
 	if c.updates != nil {
 		c.updates.Publish(Mapping{


### PR DESCRIPTION
Ideally when we attempt to create a new port mapping, we should not return without error when no mapping is available. We already log these cases as unexpected, so this change is just to avoiding panicking dispatch on the invalid result in those cases. We still separately need to fix the underlying control flow.

Updates #16662

Change-Id: I51e8a116b922b49eda45e31cd27f6b89dd51abc8


(cherry picked from commit 5ce3845a021b8384814f8279546af80e9fddbf39)