### PR TITLE
DRAFT: Override using Exit Node as default resolver sometimes

### DIFF
--- a/ipn/ipnlocal/dnsconfig_test.go
+++ b/ipn/ipnlocal/dnsconfig_test.go
@@ -266,14 +266,14 @@ func TestDNSConfigForNetmap(t *testing.T) {
 			os:   "android",
 			nm: &netmap.NetworkMap{
 				DNS: tailcfg.DNSConfig{
-					Resolvers: []*dnstype.Resolver{
-						{Addr: "8.8.8.8"},
+					Resolvers: []*tailcfg.DNSResolver{
+						{Resolver: dnstype.Resolver{Addr: "8.8.8.8"}},
 					},
 					FallbackResolvers: []*dnstype.Resolver{
 						{Addr: "8.8.4.4"},
 					},
-					Routes: map[string][]*dnstype.Resolver{
-						"foo.com.": {{Addr: "1.2.3.4"}},
+					Routes: map[string][]*tailcfg.DNSResolver{
+						"foo.com.": {{Resolver: dnstype.Resolver{Addr: "1.2.3.4"}}},
 					},
 				},
 			},

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -2081,6 +2081,13 @@ func TestDNSConfigForNetmapForExitNodeConfigs(t *testing.T) {
 	}
 
 	defaultResolvers := []*dnstype.Resolver{{Addr: "default.example.com"}}
+	wrapResolvers := func(resolvers []*dnstype.Resolver) []*tailcfg.DNSResolver {
+		rr := make([]*tailcfg.DNSResolver, 0, len(resolvers))
+		for _, r := range resolvers {
+			rr = append(rr, &tailcfg.DNSResolver{Resolver: *r})
+		}
+		return rr
+	}
 	wgResolvers := []*dnstype.Resolver{{Addr: "wg.example.com"}}
 	peers := []tailcfg.NodeView{
 		(&tailcfg.Node{
@@ -2102,13 +2109,17 @@ func TestDNSConfigForNetmapForExitNodeConfigs(t *testing.T) {
 	routes := map[dnsname.FQDN][]*dnstype.Resolver{
 		"route.example.com.": {{Addr: "route.example.com"}},
 	}
-	stringifyRoutes := func(routes map[dnsname.FQDN][]*dnstype.Resolver) map[string][]*dnstype.Resolver {
+	stringifyRoutes := func(routes map[dnsname.FQDN][]*dnstype.Resolver) map[string][]*tailcfg.DNSResolver {
 		if routes == nil {
 			return nil
 		}
-		m := make(map[string][]*dnstype.Resolver)
+		m := make(map[string][]*tailcfg.DNSResolver)
 		for k, v := range routes {
-			m[string(k)] = v
+			var rr []*tailcfg.DNSResolver
+			for _, res := range v {
+				rr = append(rr, &tailcfg.DNSResolver{Resolver: *res})
+			}
+			m[string(k)] = rr
 		}
 		return m
 	}
@@ -2134,7 +2145,7 @@ func TestDNSConfigForNetmapForExitNodeConfigs(t *testing.T) {
 			name:                 "tsExit/noRoutes/defaultResolver",
 			exitNode:             "ts",
 			peers:                peers,
-			dnsConfig:            &tailcfg.DNSConfig{Resolvers: defaultResolvers},
+			dnsConfig:            &tailcfg.DNSConfig{Resolvers: wrapResolvers(defaultResolvers)},
 			wantDefaultResolvers: []*dnstype.Resolver{{Addr: exitDOH}},
 			wantRoutes:           nil,
 		},
@@ -2158,7 +2169,7 @@ func TestDNSConfigForNetmapForExitNodeConfigs(t *testing.T) {
 			name:                 "tsExit/routes/defaultResolver",
 			exitNode:             "ts",
 			peers:                peers,
-			dnsConfig:            &tailcfg.DNSConfig{Routes: stringifyRoutes(routes), Resolvers: defaultResolvers},
+			dnsConfig:            &tailcfg.DNSConfig{Routes: stringifyRoutes(routes), Resolvers: wrapResolvers(defaultResolvers)},
 			wantDefaultResolvers: []*dnstype.Resolver{{Addr: exitDOH}},
 			wantRoutes:           nil,
 		},
@@ -2179,7 +2190,7 @@ func TestDNSConfigForNetmapForExitNodeConfigs(t *testing.T) {
 			name:                 "wgExit/noRoutes/defaultResolver",
 			exitNode:             "wg",
 			peers:                peers,
-			dnsConfig:            &tailcfg.DNSConfig{Resolvers: defaultResolvers},
+			dnsConfig:            &tailcfg.DNSConfig{Resolvers: wrapResolvers(defaultResolvers)},
 			wantDefaultResolvers: defaultResolvers,
 			wantRoutes:           nil,
 		},
@@ -2187,7 +2198,7 @@ func TestDNSConfigForNetmapForExitNodeConfigs(t *testing.T) {
 			name:                 "wgExit/routes/defaultResolver",
 			exitNode:             "wg",
 			peers:                peers,
-			dnsConfig:            &tailcfg.DNSConfig{Routes: stringifyRoutes(routes), Resolvers: defaultResolvers},
+			dnsConfig:            &tailcfg.DNSConfig{Routes: stringifyRoutes(routes), Resolvers: wrapResolvers(defaultResolvers)},
 			wantDefaultResolvers: defaultResolvers,
 			wantRoutes:           routes,
 		},

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -252,7 +252,7 @@ func (src *DNSConfig) Clone() *DNSConfig {
 	dst := new(DNSConfig)
 	*dst = *src
 	if src.Resolvers != nil {
-		dst.Resolvers = make([]*dnstype.Resolver, len(src.Resolvers))
+		dst.Resolvers = make([]*DNSResolver, len(src.Resolvers))
 		for i := range dst.Resolvers {
 			if src.Resolvers[i] == nil {
 				dst.Resolvers[i] = nil
@@ -262,9 +262,9 @@ func (src *DNSConfig) Clone() *DNSConfig {
 		}
 	}
 	if dst.Routes != nil {
-		dst.Routes = map[string][]*dnstype.Resolver{}
+		dst.Routes = map[string][]*DNSResolver{}
 		for k := range src.Routes {
-			dst.Routes[k] = append([]*dnstype.Resolver{}, src.Routes[k]...)
+			dst.Routes[k] = append([]*DNSResolver{}, src.Routes[k]...)
 		}
 	}
 	if src.FallbackResolvers != nil {
@@ -287,8 +287,8 @@ func (src *DNSConfig) Clone() *DNSConfig {
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _DNSConfigCloneNeedsRegeneration = DNSConfig(struct {
-	Resolvers           []*dnstype.Resolver
-	Routes              map[string][]*dnstype.Resolver
+	Resolvers           []*DNSResolver
+	Routes              map[string][]*DNSResolver
 	FallbackResolvers   []*dnstype.Resolver
 	Domains             []string
 	Proxied             bool
@@ -651,9 +651,27 @@ var _VIPServiceCloneNeedsRegeneration = VIPService(struct {
 	Active bool
 }{})
 
+// Clone makes a deep copy of DNSResolver.
+// The result aliases no memory with the original.
+func (src *DNSResolver) Clone() *DNSResolver {
+	if src == nil {
+		return nil
+	}
+	dst := new(DNSResolver)
+	*dst = *src
+	dst.Resolver = *src.Resolver.Clone()
+	return dst
+}
+
+// A compilation failure here means this code must be regenerated, with the command at the top of this file.
+var _DNSResolverCloneNeedsRegeneration = DNSResolver(struct {
+	dnstype.Resolver
+	UseWithExitNode bool
+}{})
+
 // Clone duplicates src into dst and reports whether it succeeded.
 // To succeed, <src, dst> must be of types <*T, *T> or <*T, **T>,
-// where T is one of User,Node,Hostinfo,NetInfo,Login,DNSConfig,RegisterResponse,RegisterResponseAuth,RegisterRequest,DERPHomeParams,DERPRegion,DERPMap,DERPNode,SSHRule,SSHAction,SSHPrincipal,ControlDialPlan,Location,UserProfile,VIPService.
+// where T is one of User,Node,Hostinfo,NetInfo,Login,DNSConfig,RegisterResponse,RegisterResponseAuth,RegisterRequest,DERPHomeParams,DERPRegion,DERPMap,DERPNode,SSHRule,SSHAction,SSHPrincipal,ControlDialPlan,Location,UserProfile,VIPService,DNSResolver.
 func Clone(dst, src any) bool {
 	switch src := src.(type) {
 	case *User:
@@ -833,6 +851,15 @@ func Clone(dst, src any) bool {
 			*dst = *src.Clone()
 			return true
 		case **VIPService:
+			*dst = src.Clone()
+			return true
+		}
+	case *DNSResolver:
+		switch dst := dst.(type) {
+		case *DNSResolver:
+			*dst = *src.Clone()
+			return true
+		case **DNSResolver:
 			*dst = src.Clone()
 			return true
 		}

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -19,7 +19,7 @@ import (
 	"tailscale.com/types/views"
 )
 
-//go:generate go run tailscale.com/cmd/cloner  -clonefunc=true -type=User,Node,Hostinfo,NetInfo,Login,DNSConfig,RegisterResponse,RegisterResponseAuth,RegisterRequest,DERPHomeParams,DERPRegion,DERPMap,DERPNode,SSHRule,SSHAction,SSHPrincipal,ControlDialPlan,Location,UserProfile,VIPService
+//go:generate go run tailscale.com/cmd/cloner  -clonefunc=true -type=User,Node,Hostinfo,NetInfo,Login,DNSConfig,RegisterResponse,RegisterResponseAuth,RegisterRequest,DERPHomeParams,DERPRegion,DERPMap,DERPNode,SSHRule,SSHAction,SSHPrincipal,ControlDialPlan,Location,UserProfile,VIPService,DNSResolver
 
 // View returns a read-only view of User.
 func (p *User) View() UserView {
@@ -538,13 +538,13 @@ func (v *DNSConfigView) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (v DNSConfigView) Resolvers() views.SliceView[*dnstype.Resolver, dnstype.ResolverView] {
-	return views.SliceOfViews[*dnstype.Resolver, dnstype.ResolverView](v.ж.Resolvers)
+func (v DNSConfigView) Resolvers() views.SliceView[*DNSResolver, DNSResolverView] {
+	return views.SliceOfViews[*DNSResolver, DNSResolverView](v.ж.Resolvers)
 }
 
-func (v DNSConfigView) Routes() views.MapFn[string, []*dnstype.Resolver, views.SliceView[*dnstype.Resolver, dnstype.ResolverView]] {
-	return views.MapFnOf(v.ж.Routes, func(t []*dnstype.Resolver) views.SliceView[*dnstype.Resolver, dnstype.ResolverView] {
-		return views.SliceOfViews[*dnstype.Resolver, dnstype.ResolverView](t)
+func (v DNSConfigView) Routes() views.MapFn[string, []*DNSResolver, views.SliceView[*DNSResolver, DNSResolverView]] {
+	return views.MapFnOf(v.ж.Routes, func(t []*DNSResolver) views.SliceView[*DNSResolver, DNSResolverView] {
+		return views.SliceOfViews[*DNSResolver, DNSResolverView](t)
 	})
 }
 func (v DNSConfigView) FallbackResolvers() views.SliceView[*dnstype.Resolver, dnstype.ResolverView] {
@@ -562,8 +562,8 @@ func (v DNSConfigView) TempCorpIssue13969() string { return v.ж.TempCorpIssue13
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _DNSConfigViewNeedsRegeneration = DNSConfig(struct {
-	Resolvers           []*dnstype.Resolver
-	Routes              map[string][]*dnstype.Resolver
+	Resolvers           []*DNSResolver
+	Routes              map[string][]*DNSResolver
 	FallbackResolvers   []*dnstype.Resolver
 	Domains             []string
 	Proxied             bool
@@ -1476,4 +1476,58 @@ var _VIPServiceViewNeedsRegeneration = VIPService(struct {
 	Name   ServiceName
 	Ports  []ProtoPortRange
 	Active bool
+}{})
+
+// View returns a read-only view of DNSResolver.
+func (p *DNSResolver) View() DNSResolverView {
+	return DNSResolverView{ж: p}
+}
+
+// DNSResolverView provides a read-only view over DNSResolver.
+//
+// Its methods should only be called if `Valid()` returns true.
+type DNSResolverView struct {
+	// ж is the underlying mutable value, named with a hard-to-type
+	// character that looks pointy like a pointer.
+	// It is named distinctively to make you think of how dangerous it is to escape
+	// to callers. You must not let callers be able to mutate it.
+	ж *DNSResolver
+}
+
+// Valid reports whether v's underlying value is non-nil.
+func (v DNSResolverView) Valid() bool { return v.ж != nil }
+
+// AsStruct returns a clone of the underlying value which aliases no memory with
+// the original.
+func (v DNSResolverView) AsStruct() *DNSResolver {
+	if v.ж == nil {
+		return nil
+	}
+	return v.ж.Clone()
+}
+
+func (v DNSResolverView) MarshalJSON() ([]byte, error) { return json.Marshal(v.ж) }
+
+func (v *DNSResolverView) UnmarshalJSON(b []byte) error {
+	if v.ж != nil {
+		return errors.New("already initialized")
+	}
+	if len(b) == 0 {
+		return nil
+	}
+	var x DNSResolver
+	if err := json.Unmarshal(b, &x); err != nil {
+		return err
+	}
+	v.ж = &x
+	return nil
+}
+
+func (v DNSResolverView) Resolver() dnstype.ResolverView { return v.ж.Resolver.View() }
+func (v DNSResolverView) UseWithExitNode() bool          { return v.ж.UseWithExitNode }
+
+// A compilation failure here means this code must be regenerated, with the command at the top of this file.
+var _DNSResolverViewNeedsRegeneration = DNSResolver(struct {
+	dnstype.Resolver
+	UseWithExitNode bool
 }{})


### PR DESCRIPTION
## Initial Description

_leaving this here for history, but latest is in `Revisions` section below. Fine to ignore this section._

The basic approach:

- `OverrideExitNodeDNS` in dnstype.Resolver, examined in the processing of the netmap
- When we're in an new exit node context, look for Resolvers and Routes (that reference resolvers) with the flag set, and if any are found, add those. If none are found, use the exit node resolver as before.
- In either case, we exit early.


Open Questions:

- Some interesting cases to confirm:
  - Split DNS Routes that have empty resolver lists => exit node resolver is not installed.
  - Split DNS Routes that had non-empty resolver lists, but none of the resolvers had the flag set, so now empty => exit node resolver is not installed.
  - Split DNS Routes exist, but no DNS.Resolvers exist => again, exit node resolver is not installed. (also, is this case even possible at the UI level?)

_(edit: after typing this out I can see that this probably not what we want, as it conflicts with the approach above. Perhaps  the new `addSplitDNSRoutes()` should return a boolean indicating whether at least one resolver with the flag was found.)_
 
- We still exit early no matter what when in an exit node context, not considering anything with wireguard exit nodes or fallback DNS. Is that right?

- The changes to dnstype.Resolver break generated code in dnstype_clone.go and dnstype_view.go. Any pointers to scripts or make targets that cleanly handle generating code. (I tried invoking the cloner tool manually, and it complained about some missing arguments).

- Architecturally, it did feel a little funny putting this boolean in such a low level primitive. Theoretically a "resolver" in itself has no knowledge of what an exit node is. A slight modification might be to wrap the Resolver in a new "configuration" type, and use that throughout the netmap. Might be a big blast radius and not worth it though?

## Revisions

[fa1f8cb](https://github.com/tailscale/tailscale/pull/16737/commits/fa1f8cbdc91470108f1ae185809c15e473574a6b)

Changes the rules for Split DNS in the open questions above. Now:
- All resolver lists for Split DNS are empty, DNS.Resolvers empty => Exit Node Resolver is installed
- All resolver lists for Split DNS are empty after filtering, DNS.Resolvers empty => Exit Node Resolver is installed
- Resolver list for Split DNS contains at least one entry after filtering, regardless of whether there's anything in DNS.Resolvers => Those Split DNS resolvers are installed, exit node resolver not installed.
- DNS.Resolvers contains at least one entry after filtering, regardless of what is in Split DNS Resolver => The resolvers from DNS.Resolvers are installed, exit node resolver is not installed.

Open Questions that still apply:

- We still exit early no matter what when in an exit node context, not considering anything with wireguard exit nodes or fallback DNS. Is that right?

- The changes to dnstype.Resolver break generated code in dnstype_clone.go and dnstype_view.go. Any pointers to scripts or make targets that cleanly handle generating code. (I tried invoking the cloner tool manually, and it complained about some missing arguments).

- Architecturally, it did feel a little funny putting this boolean in such a low level primitive. Theoretically a "resolver" in itself has no knowledge of what an exit node is. A slight modification might be to wrap the Resolver in a new "configuration" type, and use that throughout the netmap. Might be a big blast radius and not worth it though?

b1001975b

- Addressed review feedback, bumping tailcfg version, and correctly handling the case where no default global resolvers are configured in an exit node context (exit node resolver should be installed, regardless of split DNS config).