### PR TITLE
ipn/ipnlocal: add timeout to Acme get registration

### DIFF
--- a/ipn/ipnlocal/cert.go
+++ b/ipn/ipnlocal/cert.go
@@ -507,7 +507,10 @@ var getCertPEM = func(ctx context.Context, b *LocalBackend, cs certStore, logf l
 		logf("acme: using Directory URL %q", ac.DirectoryURL)
 	}
 
-	a, err := ac.GetReg(ctx, "" /* pre-RFC param */)
+	reg_ctx, reg_cancel := context.WithTimeout(ctx, 5*time.Second)
+	a, err := ac.GetReg(reg_ctx, "" /* pre-RFC param */)
+	reg_cancel()
+
 	switch {
 	case err == nil:
 		// Great, already registered.
@@ -525,8 +528,8 @@ var getCertPEM = func(ctx context.Context, b *LocalBackend, cs certStore, logf l
 		traceACME(a)
 	default:
 		return nil, fmt.Errorf("acme.GetReg: %w", err)
-
 	}
+
 	if a.Status != acme.StatusValid {
 		return nil, fmt.Errorf("unexpected ACME account status %q", a.Status)
 	}


### PR DESCRIPTION
Adds a timout to the first call to acme.Client in getCertPEM, which should prevent an unreachable Acme server (default LetsEncrypt) from tying up the cert handler, and in turn prevent `localapi/v0/cert/` from timing out client side (client\local\local.go:CertPairWithValidity).

This does not provide a custom error message, so the expected result from the server will be `500, acme.GetReg: <timeout>` Which is more or less what was already happening, but faster.

Updates #14677