### PR TITLE
cmd/tailscale/cli: show exit-node filter message only when filter not provided

### DIFF
--- a/cmd/tailscale/cli/exitnode.go
+++ b/cmd/tailscale/cli/exitnode.go
@@ -137,7 +137,9 @@ func runExitNodeList(ctx context.Context, args []string) error {
 	}
 	fmt.Fprintln(w)
 	fmt.Fprintln(w)
-	fmt.Fprintln(w, "# To view the complete list of exit nodes for a country, use `tailscale exit-node list --filter=` followed by the country name.")
+	if exitNodeArgs.filter == "" {
+		fmt.Fprintln(w, "# To view the complete list of exit nodes for a country, use `tailscale exit-node list --filter=` followed by the country name.")
+	}
 	fmt.Fprintln(w, "# To use an exit node, use `tailscale set --exit-node=` followed by the hostname or IP.")
 	if hasAnyExitNodeSuggestions(peers) {
 		fmt.Fprintln(w, "# To have Tailscale suggest an exit node, use `tailscale exit-node suggest`.")


### PR DESCRIPTION
Currently, the message
```
# To view the complete list of exit nodes for a country, use `tailscale exit-node list --filter=` followed by the country name.
```
is *always* printed when running the `tailscale exit-node list` command.

With this PR, the message is only printed if a filter is *not* provided.