### PR TITLE
client/systray: allow specifying tailscaled socket

### DIFF
--- a/client/systray/systray.go
+++ b/client/systray/systray.go
@@ -48,7 +48,12 @@ var (
 )
 
 // Run starts the systray menu and blocks until the menu exits.
-func (menu *Menu) Run() {
+// If client is nil, a default local.Client is used.
+func (menu *Menu) Run(client *local.Client) {
+	if client == nil {
+		client = &local.Client{}
+	}
+	menu.lc = client
 	menu.updateState()
 
 	// exit cleanly on SIGINT and SIGTERM
@@ -71,7 +76,7 @@ func (menu *Menu) Run() {
 type Menu struct {
 	mu sync.Mutex // protects the entire Menu
 
-	lc          local.Client
+	lc          *local.Client
 	status      *ipnstate.Status
 	curProfile  ipn.LoginProfile
 	allProfiles []ipn.LoginProfile

--- a/cmd/systray/systray.go
+++ b/cmd/systray/systray.go
@@ -7,9 +7,17 @@
 package main
 
 import (
+	"flag"
+
+	"tailscale.com/client/local"
 	"tailscale.com/client/systray"
+	"tailscale.com/paths"
 )
 
+var socket = flag.String("socket", paths.DefaultTailscaledSocket(), "path to tailscaled socket")
+
 func main() {
-	new(systray.Menu).Run()
+	flag.Parse()
+	lc := &local.Client{Socket: *socket}
+	new(systray.Menu).Run(lc)
 }

--- a/cmd/tailscale/cli/systray.go
+++ b/cmd/tailscale/cli/systray.go
@@ -17,8 +17,7 @@ var systrayCmd = &ffcli.Command{
 	ShortUsage: "tailscale systray",
 	ShortHelp:  "Run a systray application to manage Tailscale",
 	Exec: func(_ context.Context, _ []string) error {
-		// TODO(will): pass localClient to menu to use the global --socket flag
-		new(systray.Menu).Run()
+		new(systray.Menu).Run(&localClient)
 		return nil
 	},
 }


### PR DESCRIPTION
Pass a local.Client to systray.Run, so we can use the existing global localClient in the cmd/tailscale CLI.  Add socket flag to cmd/systray.

Updates #1708

Change-Id: Ia101a4a3005adb9118051b3416f5a64a4a45987d