### PR TITLE
all: simplify slice to array conversions

### DIFF
--- a/feature/tpm/tpm.go
+++ b/feature/tpm/tpm.go
@@ -353,7 +353,7 @@ func unseal(logf logger.Logf, data encryptedData) (*decryptedData, error) {
 	}
 
 	return &decryptedData{
-		Key:  *(*[32]byte)(unsealedKey),
+		Key:  [32]byte(unsealedKey),
 		Data: unsealedData,
 	}, nil
 }

--- a/net/tsaddr/tsaddr.go
+++ b/net/tsaddr/tsaddr.go
@@ -299,7 +299,7 @@ func IsViaPrefix(p netip.Prefix) bool {
 func UnmapVia(ip netip.Addr) netip.Addr {
 	if TailscaleViaRange().Contains(ip) {
 		a := ip.As16()
-		return netip.AddrFrom4(*(*[4]byte)(a[12:16]))
+		return netip.AddrFrom4([4]byte(a[12:16]))
 	}
 	return ip
 }

--- a/util/deephash/deephash_test.go
+++ b/util/deephash/deephash_test.go
@@ -915,8 +915,8 @@ func FuzzAddr(f *testing.F) {
 		binary.LittleEndian.PutUint64(b2[8:], u2b)
 
 		var ips [4]netip.Addr
-		ips[0] = netip.AddrFrom4(*(*[4]byte)(b1[:]))
-		ips[1] = netip.AddrFrom4(*(*[4]byte)(b2[:]))
+		ips[0] = netip.AddrFrom4([4]byte(b1[:]))
+		ips[1] = netip.AddrFrom4([4]byte(b2[:]))
 		ips[2] = netip.AddrFrom16(b1)
 		if zone1 != "" {
 			ips[2] = ips[2].WithZone(zone1)


### PR DESCRIPTION
### Description

These changes improve the codebase by simplifying slice-to-array conversions.

Since Go 1.20, it's possible to convert from a slice to an array using simpler syntax. This PR updates existing conversions to use the new native syntax.

References:

- https://go.dev/ref/spec#Conversions_from_slice_to_array_or_array_pointer
- https://github.com/golang/go/issues/69820