### PR TITLE
scripts/installer.sh: add bazzite handling

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -280,6 +280,14 @@ main() {
 				echo "services.tailscale.enable = true;"
 				exit 1
 				;;
+			bazzite)
+				echo "Bazzite comes with Tailscale installed by default."
+				echo "Please enable Tailscale by running the following commands as root:"
+				echo
+				echo "ujust enable-tailscale"
+				echo "tailscale up"
+				exit 1
+				;;
 			void)
 				OS="$ID"
 				VERSION="" # rolling release


### PR DESCRIPTION
Tested in a VM. We don't have packages for Bazzite but Bazzite has Tailscale preinstalled and people keep trying to run it and getting confused, so update the script to explain it's already installed by default and how to enable it. This is similar to advice we give NixOS users.

Fixes #14540