### PR TITLE
feature/taildrop: do not use m.opts.Dir for Android (#16316)

### DIFF
--- a/feature/taildrop/delete.go
+++ b/feature/taildrop/delete.go
@@ -6,9 +6,7 @@ package taildrop
 import (
 	"container/list"
 	"context"
-	"io/fs"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -28,7 +26,6 @@ const deleteDelay = time.Hour
 type fileDeleter struct {
 	logf  logger.Logf
 	clock tstime.DefaultClock
-	dir   string
 	event func(string) // called for certain events; for testing only
 
 	mu     sync.Mutex
@@ -39,6 +36,7 @@ type fileDeleter struct {
 	group       syncs.WaitGroup
 	shutdownCtx context.Context
 	shutdown    context.CancelFunc
+	fs          FileOps // must be used for all filesystem operations
 }
 
 // deleteFile is a specific file to delete after deleteDelay.
@@ -50,15 +48,14 @@ type deleteFile struct {
 func (d *fileDeleter) Init(m *manager, eventHook func(string)) {
 	d.logf = m.opts.Logf
 	d.clock = m.opts.Clock
-	d.dir = m.opts.Dir
 	d.event = eventHook
+	d.fs = m.opts.fileOps
 
 	d.byName = make(map[string]*list.Element)
 	d.emptySignal = make(chan struct{})
 	d.shutdownCtx, d.shutdown = context.WithCancel(context.Background())
 
 	// From a cold-start, load the list of partial and deleted files.
-	//
 	// Only run this if we have ever received at least one file
 	// to avoid ever touching the taildrop directory on systems (e.g., MacOS)
 	// that pop up a security dialog window upon first access.
@@ -71,38 +68,45 @@ func (d *fileDeleter) Init(m *manager, eventHook func(string)) {
 	d.group.Go(func() {
 		d.event("start full-scan")
 		defer d.event("end full-scan")
-		rangeDir(d.dir, func(de fs.DirEntry) bool {
+
+		if d.fs == nil {
+			d.logf("deleter: nil FileOps")
+		}
+
+		files, err := d.fs.ListFiles()
+		if err != nil {
+			d.logf("deleter: ListDir error: %v", err)
+			return
+		}
+		for _, filename := range files {
 			switch {
 			case d.shutdownCtx.Err() != nil:
-				return false // terminate early
-			case !de.Type().IsRegular():
-				return true
-			case strings.HasSuffix(de.Name(), partialSuffix):
+				return // terminate early
+			case strings.HasSuffix(filename, partialSuffix):
 				// Only enqueue the file for deletion if there is no active put.
-				nameID := strings.TrimSuffix(de.Name(), partialSuffix)
+				nameID := strings.TrimSuffix(filename, partialSuffix)
 				if i := strings.LastIndexByte(nameID, '.'); i > 0 {
 					key := incomingFileKey{clientID(nameID[i+len("."):]), nameID[:i]}
 					m.incomingFiles.LoadFunc(key, func(_ *incomingFile, loaded bool) {
 						if !loaded {
-							d.Insert(de.Name())
+							d.Insert(filename)
 						}
 					})
 				} else {
-					d.Insert(de.Name())
+					d.Insert(filename)
 				}
-			case strings.HasSuffix(de.Name(), deletedSuffix):
+			case strings.HasSuffix(filename, deletedSuffix):
 				// Best-effort immediate deletion of deleted files.
-				name := strings.TrimSuffix(de.Name(), deletedSuffix)
-				if os.Remove(filepath.Join(d.dir, name)) == nil {
-					if os.Remove(filepath.Join(d.dir, de.Name())) == nil {
-						break
+				name := strings.TrimSuffix(filename, deletedSuffix)
+				if d.fs.Remove(name) == nil {
+					if d.fs.Remove(filename) == nil {
+						continue
 					}
 				}
-				// Otherwise, enqueue the file for later deletion.
-				d.Insert(de.Name())
+				// Otherwise enqueue for later deletion.
+				d.Insert(filename)
 			}
-			return true
-		})
+		}
 	})
 }
 
@@ -149,13 +153,13 @@ func (d *fileDeleter) waitAndDelete(wait time.Duration) {
 
 			// Delete the expired file.
 			if name, ok := strings.CutSuffix(file.name, deletedSuffix); ok {
-				if err := os.Remove(filepath.Join(d.dir, name)); err != nil && !os.IsNotExist(err) {
+				if err := d.fs.Remove(name); err != nil && !os.IsNotExist(err) {
 					d.logf("could not delete: %v", redactError(err))
 					failed = append(failed, elem)
 					continue
 				}
 			}
-			if err := os.Remove(filepath.Join(d.dir, file.name)); err != nil && !os.IsNotExist(err) {
+			if err := d.fs.Remove(file.name); err != nil && !os.IsNotExist(err) {
 				d.logf("could not delete: %v", redactError(err))
 				failed = append(failed, elem)
 				continue

--- a/feature/taildrop/fileops.go
+++ b/feature/taildrop/fileops.go
@@ -1,0 +1,41 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package taildrop
+
+import (
+	"io"
+	"io/fs"
+	"os"
+)
+
+// FileOps abstracts over both local‐FS paths and Android SAF URIs.
+type FileOps interface {
+	// OpenWriter creates or truncates a file named relative to the receiver's root,
+	// seeking to the specified offset. If the file does not exist, it is created with mode perm
+	// on platforms that support it.
+	//
+	// It returns an [io.WriteCloser] and the file's absolute path, or an error.
+	// This call may block. Callers should avoid holding locks when calling OpenWriter.
+	OpenWriter(name string, offset int64, perm os.FileMode) (wc io.WriteCloser, path string, err error)
+
+	// Remove deletes a file or directory relative to the receiver's root.
+	// It returns [io.ErrNotExist] if the file or directory does not exist.
+	Remove(name string) error
+
+	// Rename atomically renames oldPath to a new file named newName,
+	// returning the full new path or an error.
+	Rename(oldPath, newName string) (newPath string, err error)
+
+	// ListFiles returns just the basenames of all regular files
+	// in the root directory.
+	ListFiles() ([]string, error)
+
+	// Stat returns the FileInfo for the given name or an error.
+	Stat(name string) (fs.FileInfo, error)
+
+	// OpenReader opens the given basename for the given name or an error.
+	OpenReader(name string) (io.ReadCloser, error)
+}
+
+var newFileOps func(dir string) (FileOps, error)

--- a/feature/taildrop/fileops_fs.go
+++ b/feature/taildrop/fileops_fs.go
@@ -1,0 +1,221 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+//go:build !android
+
+package taildrop
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+	"unicode/utf8"
+)
+
+var renameMu sync.Mutex
+
+// fsFileOps implements FileOps using the local filesystem rooted at a directory.
+// It is used on non-Android platforms.
+type fsFileOps struct{ rootDir string }
+
+func init() {
+	newFileOps = func(dir string) (FileOps, error) {
+		if dir == "" {
+			return nil, errors.New("rootDir cannot be empty")
+		}
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return nil, fmt.Errorf("mkdir %q: %w", dir, err)
+		}
+		return fsFileOps{rootDir: dir}, nil
+	}
+}
+
+func (f fsFileOps) OpenWriter(name string, offset int64, perm os.FileMode) (io.WriteCloser, string, error) {
+	path, err := joinDir(f.rootDir, name)
+	if err != nil {
+		return nil, "", err
+	}
+	if err = os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, "", err
+	}
+	fi, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, perm)
+	if err != nil {
+		return nil, "", err
+	}
+	if offset != 0 {
+		curr, err := fi.Seek(0, io.SeekEnd)
+		if err != nil {
+			fi.Close()
+			return nil, "", err
+		}
+		if offset < 0 || offset > curr {
+			fi.Close()
+			return nil, "", fmt.Errorf("offset %d out of range", offset)
+		}
+		if _, err := fi.Seek(offset, io.SeekStart); err != nil {
+			fi.Close()
+			return nil, "", err
+		}
+		if err := fi.Truncate(offset); err != nil {
+			fi.Close()
+			return nil, "", err
+		}
+	}
+	return fi, path, nil
+}
+
+func (f fsFileOps) Remove(name string) error {
+	path, err := joinDir(f.rootDir, name)
+	if err != nil {
+		return err
+	}
+	return os.Remove(path)
+}
+
+// Rename moves the partial file into its final name.
+// newName must be a base name (not absolute or containing path separators).
+// It will retry up to 10 times, de-dup same-checksum files, etc.
+func (f fsFileOps) Rename(oldPath, newName string) (newPath string, err error) {
+	var dst string
+	if filepath.IsAbs(newName) || strings.ContainsRune(newName, os.PathSeparator) {
+		return "", fmt.Errorf("invalid newName %q: must not be an absolute path or contain path separators", newName)
+	}
+
+	dst = filepath.Join(f.rootDir, newName)
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
+		return "", err
+	}
+
+	st, err := os.Stat(oldPath)
+	if err != nil {
+		return "", err
+	}
+	wantSize := st.Size()
+
+	const maxRetries = 10
+	for i := 0; i < maxRetries; i++ {
+		renameMu.Lock()
+		fi, statErr := os.Stat(dst)
+		// Atomically rename the partial file as the destination file if it doesn't exist.
+		// Otherwise, it returns the length of the current destination file.
+		// The operation is atomic.
+		if os.IsNotExist(statErr) {
+			err = os.Rename(oldPath, dst)
+			renameMu.Unlock()
+			if err != nil {
+				return "", err
+			}
+			return dst, nil
+		}
+		if statErr != nil {
+			renameMu.Unlock()
+			return "", statErr
+		}
+		gotSize := fi.Size()
+		renameMu.Unlock()
+
+		// Avoid the final rename if a destination file has the same contents.
+		//
+		// Note: this is best effort and copying files from iOS from the Media Library
+		// results in processing on the iOS side which means the size and shas of the
+		// same file can be different.
+		if gotSize == wantSize {
+			sumP, err := sha256File(oldPath)
+			if err != nil {
+				return "", err
+			}
+			sumD, err := sha256File(dst)
+			if err != nil {
+				return "", err
+			}
+			if bytes.Equal(sumP[:], sumD[:]) {
+				if err := os.Remove(oldPath); err != nil {
+					return "", err
+				}
+				return dst, nil
+			}
+		}
+
+		// Choose a new destination filename and try again.
+		dst = filepath.Join(filepath.Dir(dst), nextFilename(filepath.Base(dst)))
+	}
+
+	return "", fmt.Errorf("too many retries trying to rename %q to %q", oldPath, newName)
+}
+
+// sha256File computes the SHA‑256 of a file.
+func sha256File(path string) (sum [sha256.Size]byte, _ error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return sum, err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return sum, err
+	}
+	copy(sum[:], h.Sum(nil))
+	return sum, nil
+}
+
+func (f fsFileOps) ListFiles() ([]string, error) {
+	entries, err := os.ReadDir(f.rootDir)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, e := range entries {
+		if e.Type().IsRegular() {
+			names = append(names, e.Name())
+		}
+	}
+	return names, nil
+}
+
+func (f fsFileOps) Stat(name string) (fs.FileInfo, error) {
+	path, err := joinDir(f.rootDir, name)
+	if err != nil {
+		return nil, err
+	}
+	return os.Stat(path)
+}
+
+func (f fsFileOps) OpenReader(name string) (io.ReadCloser, error) {
+	path, err := joinDir(f.rootDir, name)
+	if err != nil {
+		return nil, err
+	}
+	return os.Open(path)
+}
+
+// joinDir is like [filepath.Join] but returns an error if baseName is too long,
+// is a relative path instead of a basename, or is otherwise invalid or unsafe for incoming files.
+func joinDir(dir, baseName string) (string, error) {
+	if !utf8.ValidString(baseName) ||
+		strings.TrimSpace(baseName) != baseName ||
+		len(baseName) > 255 {
+		return "", ErrInvalidFileName
+	}
+	// TODO: validate unicode normalization form too? Varies by platform.
+	clean := path.Clean(baseName)
+	if clean != baseName || clean == "." || clean == ".." {
+		return "", ErrInvalidFileName
+	}
+	for _, r := range baseName {
+		if !validFilenameRune(r) {
+			return "", ErrInvalidFileName
+		}
+	}
+	if !filepath.IsLocal(baseName) {
+		return "", ErrInvalidFileName
+	}
+	return filepath.Join(dir, baseName), nil
+}

--- a/feature/taildrop/paths.go
+++ b/feature/taildrop/paths.go
@@ -21,7 +21,7 @@ func (e *Extension) SetDirectFileRoot(root string) {
 // SetFileOps sets the platform specific file operations. This is used
 // to call Android's Storage Access Framework APIs.
 func (e *Extension) SetFileOps(fileOps FileOps) {
-	e.FileOps = fileOps
+	e.fileOps = fileOps
 }
 
 func (e *Extension) setPlatformDefaultDirectFileRoot() {

--- a/feature/taildrop/resume.go
+++ b/feature/taildrop/resume.go
@@ -9,7 +9,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"strings"
 )
@@ -51,19 +50,20 @@ func (cs *checksum) UnmarshalText(b []byte) error {
 
 // PartialFiles returns a list of partial files in [Handler.Dir]
 // that were sent (or is actively being sent) by the provided id.
-func (m *manager) PartialFiles(id clientID) (ret []string, err error) {
-	if m == nil || m.opts.Dir == "" {
+func (m *manager) PartialFiles(id clientID) ([]string, error) {
+	if m == nil || m.opts.fileOps == nil {
 		return nil, ErrNoTaildrop
 	}
-
 	suffix := id.partialSuffix()
-	if err := rangeDir(m.opts.Dir, func(de fs.DirEntry) bool {
-		if name := de.Name(); strings.HasSuffix(name, suffix) {
-			ret = append(ret, name)
+	files, err := m.opts.fileOps.ListFiles()
+	if err != nil {
+		return nil, redactError(err)
+	}
+	var ret []string
+	for _, filename := range files {
+		if strings.HasSuffix(filename, suffix) {
+			ret = append(ret, filename)
 		}
-		return true
-	}); err != nil {
-		return ret, redactError(err)
 	}
 	return ret, nil
 }
@@ -73,17 +73,13 @@ func (m *manager) PartialFiles(id clientID) (ret []string, err error) {
 // It returns (BlockChecksum{}, io.EOF) when the stream is complete.
 // It is the caller's responsibility to call close.
 func (m *manager) HashPartialFile(id clientID, baseName string) (next func() (blockChecksum, error), close func() error, err error) {
-	if m == nil || m.opts.Dir == "" {
+	if m == nil || m.opts.fileOps == nil {
 		return nil, nil, ErrNoTaildrop
 	}
 	noopNext := func() (blockChecksum, error) { return blockChecksum{}, io.EOF }
 	noopClose := func() error { return nil }
 
-	dstFile, err := joinDir(m.opts.Dir, baseName)
-	if err != nil {
-		return nil, nil, err
-	}
-	f, err := os.Open(dstFile + id.partialSuffix())
+	f, err := m.opts.fileOps.OpenReader(baseName + id.partialSuffix())
 	if err != nil {
 		if os.IsNotExist(err) {
 			return noopNext, noopClose, nil

--- a/feature/taildrop/resume_test.go
+++ b/feature/taildrop/resume_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"testing"
 	"testing/iotest"
 
@@ -19,7 +20,9 @@ func TestResume(t *testing.T) {
 	defer func() { blockSize = oldBlockSize }()
 	blockSize = 256
 
-	m := managerOptions{Logf: t.Logf, Dir: t.TempDir()}.New()
+	dir := t.TempDir()
+
+	m := managerOptions{Logf: t.Logf, fileOps: must.Get(newFileOps(dir))}.New()
 	defer m.Shutdown()
 
 	rn := rand.New(rand.NewSource(0))
@@ -37,7 +40,7 @@ func TestResume(t *testing.T) {
 		must.Do(close()) // Windows wants the file handle to be closed to rename it.
 
 		must.Get(m.PutFile("", "foo", r, offset, -1))
-		got := must.Get(os.ReadFile(must.Get(joinDir(m.opts.Dir, "foo"))))
+		got := must.Get(os.ReadFile(filepath.Join(dir, "foo")))
 		if !bytes.Equal(got, want) {
 			t.Errorf("content mismatches")
 		}
@@ -66,7 +69,7 @@ func TestResume(t *testing.T) {
 				t.Fatalf("too many iterations to complete the test")
 			}
 		}
-		got := must.Get(os.ReadFile(must.Get(joinDir(m.opts.Dir, "bar"))))
+		got := must.Get(os.ReadFile(filepath.Join(dir, "bar")))
 		if !bytes.Equal(got, want) {
 			t.Errorf("content mismatches")
 		}

--- a/feature/taildrop/send.go
+++ b/feature/taildrop/send.go
@@ -4,11 +4,8 @@
 package taildrop
 
 import (
-	"crypto/sha256"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -73,9 +70,10 @@ func (f *incomingFile) Write(p []byte) (n int, err error) {
 // specific partial file. This allows the client to determine whether to resume
 // a partial file. While resuming, PutFile may be called again with a non-zero
 // offset to specify where to resume receiving data at.
-func (m *manager) PutFile(id clientID, baseName string, r io.Reader, offset, length int64) (int64, error) {
+func (m *manager) PutFile(id clientID, baseName string, r io.Reader, offset, length int64) (fileLength int64, err error) {
+
 	switch {
-	case m == nil || m.opts.Dir == "":
+	case m == nil || m.opts.fileOps == nil:
 		return 0, ErrNoTaildrop
 	case !envknob.CanTaildrop():
 		return 0, ErrNoTaildrop
@@ -83,47 +81,47 @@ func (m *manager) PutFile(id clientID, baseName string, r io.Reader, offset, len
 		return 0, ErrNotAccessible
 	}
 
-	//Compute dstPath & avoid mid‑upload deletion
-	var dstPath string
-	if m.opts.Mode == PutModeDirect {
-		var err error
-		dstPath, err = joinDir(m.opts.Dir, baseName)
-		if err != nil {
-			return 0, err
-		}
-	} else {
-		// In SAF mode, we simply use the baseName as the destination "path"
-		// (the actual directory is managed by SAF).
-		dstPath = baseName
+	if err := validateBaseName(baseName); err != nil {
+		return 0, err
 	}
-	m.deleter.Remove(filepath.Base(dstPath)) // avoid deleting the partial file while receiving
 
-	// Check whether there is an in-progress transfer for the file.
-	partialFileKey := incomingFileKey{id, baseName}
-	inFile, loaded := m.incomingFiles.LoadOrInit(partialFileKey, func() *incomingFile {
-		return &incomingFile{
-			clock:          m.opts.Clock,
-			started:        m.opts.Clock.Now(),
-			size:           length,
-			sendFileNotify: m.opts.SendFileNotify,
-		}
-	})
-	if loaded {
-		return 0, ErrFileExists
-	}
-	defer m.incomingFiles.Delete(partialFileKey)
+	// and make sure we don't delete it while uploading:
+	m.deleter.Remove(baseName)
 
-	// Open writer & populate inFile paths
-	wc, partialPath, err := m.openWriterAndPaths(id, m.opts.Mode, inFile, baseName, dstPath, offset)
+	// Create (if not already) the partial file with read-write permissions.
+	partialName := baseName + id.partialSuffix()
+	wc, partialPath, err := m.opts.fileOps.OpenWriter(partialName, offset, 0o666)
 	if err != nil {
 		return 0, m.redactAndLogError("Create", err)
 	}
 	defer func() {
 		wc.Close()
 		if err != nil {
-			m.deleter.Insert(filepath.Base(partialPath)) // mark partial file for eventual deletion
+			m.deleter.Insert(partialName) // mark partial file for eventual deletion
 		}
 	}()
+
+	// Check whether there is an in-progress transfer for the file.
+	inFileKey := incomingFileKey{id, baseName}
+	inFile, loaded := m.incomingFiles.LoadOrInit(inFileKey, func() *incomingFile {
+		inFile := &incomingFile{
+			clock:          m.opts.Clock,
+			started:        m.opts.Clock.Now(),
+			size:           length,
+			sendFileNotify: m.opts.SendFileNotify,
+		}
+		if m.opts.DirectFileMode {
+			inFile.partialPath = partialPath
+		}
+		return inFile
+	})
+
+	inFile.w = wc
+
+	if loaded {
+		return 0, ErrFileExists
+	}
+	defer m.incomingFiles.Delete(inFileKey)
 
 	// Record that we have started to receive at least one file.
 	// This is used by the deleter upon a cold-start to scan the directory
@@ -148,220 +146,26 @@ func (m *manager) PutFile(id clientID, baseName string, r io.Reader, offset, len
 		return 0, m.redactAndLogError("Close", err)
 	}
 
-	fileLength := offset + copyLength
+	fileLength = offset + copyLength
 
 	inFile.mu.Lock()
 	inFile.done = true
 	inFile.mu.Unlock()
 
-	// Finalize rename
-	switch m.opts.Mode {
-	case PutModeDirect:
-		var finalDst string
-		finalDst, err = m.finalizeDirect(inFile, partialPath, dstPath, fileLength)
-		if err != nil {
-			return 0, m.redactAndLogError("Rename", err)
-		}
-		inFile.finalPath = finalDst
-
-	case PutModeAndroidSAF:
-		if err = m.finalizeSAF(partialPath, baseName); err != nil {
-			return 0, m.redactAndLogError("Rename", err)
-		}
+	// 6) Finalize (rename/move) the partial into place via FileOps.Rename
+	finalPath, err := m.opts.fileOps.Rename(partialPath, baseName)
+	if err != nil {
+		return 0, m.redactAndLogError("Rename", err)
 	}
+	inFile.finalPath = finalPath
 
 	m.totalReceived.Add(1)
 	m.opts.SendFileNotify()
 	return fileLength, nil
 }
 
-// openWriterAndPaths opens the correct writer, seeks/truncates if needed,
-// and sets inFile.partialPath & inFile.finalPath for later cleanup/rename.
-// The caller is responsible for closing the file on completion.
-func (m *manager) openWriterAndPaths(
-	id clientID,
-	mode PutMode,
-	inFile *incomingFile,
-	baseName string,
-	dstPath string,
-	offset int64,
-) (wc io.WriteCloser, partialPath string, err error) {
-	switch mode {
-
-	case PutModeDirect:
-		partialPath = dstPath + id.partialSuffix()
-		f, err := os.OpenFile(partialPath, os.O_CREATE|os.O_RDWR, 0o666)
-		if err != nil {
-			return nil, "", m.redactAndLogError("Create", err)
-		}
-		if offset != 0 {
-			curr, err := f.Seek(0, io.SeekEnd)
-			if err != nil {
-				f.Close()
-				return nil, "", m.redactAndLogError("Seek", err)
-			}
-			if offset < 0 || offset > curr {
-				f.Close()
-				return nil, "", m.redactAndLogError("Seek", fmt.Errorf("offset %d out of range", offset))
-			}
-			if _, err := f.Seek(offset, io.SeekStart); err != nil {
-				f.Close()
-				return nil, "", m.redactAndLogError("Seek", err)
-			}
-			if err := f.Truncate(offset); err != nil {
-				f.Close()
-				return nil, "", m.redactAndLogError("Truncate", err)
-			}
-		}
-		inFile.w = f
-		wc = f
-		inFile.partialPath = partialPath
-		inFile.finalPath = dstPath
-		return wc, partialPath, nil
-
-	case PutModeAndroidSAF:
-		if m.opts.FileOps == nil {
-			return nil, "", m.redactAndLogError("Create (SAF)", fmt.Errorf("missing FileOps"))
-		}
-		writer, uri, err := m.opts.FileOps.OpenFileWriter(baseName)
-		if err != nil {
-			return nil, "", m.redactAndLogError("Create (SAF)", fmt.Errorf("failed to open file for writing via SAF"))
-		}
-		if writer == nil || uri == "" {
-			return nil, "", fmt.Errorf("invalid SAF writer or URI")
-		}
-		// SAF mode does not support resuming, so enforce offset == 0.
-		if offset != 0 {
-			writer.Close()
-			return nil, "", m.redactAndLogError("Seek", fmt.Errorf("resuming is not supported in SAF mode"))
-		}
-		inFile.w = writer
-		wc = writer
-		partialPath = uri
-		inFile.partialPath = uri
-		inFile.finalPath = baseName
-		return wc, partialPath, nil
-
-	default:
-		return nil, "", fmt.Errorf("unsupported PutMode: %v", mode)
-	}
-}
-
-// finalizeDirect atomically renames or dedups the partial file, retrying
-// under new names up to 10 times. It returns the final path that succeeded.
-func (m *manager) finalizeDirect(
-	inFile *incomingFile,
-	partialPath string,
-	initialDst string,
-	fileLength int64,
-) (string, error) {
-	var (
-		once       sync.Once
-		cachedSum  [sha256.Size]byte
-		cacheErr   error
-		computeSum = func() ([sha256.Size]byte, error) {
-			once.Do(func() { cachedSum, cacheErr = sha256File(partialPath) })
-			return cachedSum, cacheErr
-		}
-	)
-
-	dstPath := initialDst
-	const maxRetries = 10
-	for i := 0; i < maxRetries; i++ {
-		// Atomically rename the partial file as the destination file if it doesn't exist.
-		// Otherwise, it returns the length of the current destination file.
-		// The operation is atomic.
-		lengthOnDisk, err := func() (int64, error) {
-			m.renameMu.Lock()
-			defer m.renameMu.Unlock()
-			fi, statErr := os.Stat(dstPath)
-			if os.IsNotExist(statErr) {
-				// dst missing → rename partial into place
-				return -1, os.Rename(partialPath, dstPath)
-			}
-			if statErr != nil {
-				return -1, statErr
-			}
-			return fi.Size(), nil
-		}()
-		if err != nil {
-			return "", err
-		}
-		if lengthOnDisk < 0 {
-			// successfully moved
-			inFile.finalPath = dstPath
-			return dstPath, nil
-		}
-
-		// Avoid the final rename if a destination file has the same contents.
-		//
-		// Note: this is best effort and copying files from iOS from the Media Library
-		// results in processing on the iOS side which means the size and shas of the
-		// same file can be different.
-		if lengthOnDisk == fileLength {
-			partSum, err := computeSum()
-			if err != nil {
-				return "", err
-			}
-			dstSum, err := sha256File(dstPath)
-			if err != nil {
-				return "", err
-			}
-			if partSum == dstSum {
-				// same content → drop the partial
-				if err := os.Remove(partialPath); err != nil {
-					return "", err
-				}
-				inFile.finalPath = dstPath
-				return dstPath, nil
-			}
-		}
-
-		// Choose a new destination filename and try again.
-		dstPath = nextFilename(dstPath)
-	}
-
-	return "", fmt.Errorf("too many retries trying to rename a partial file %q", initialDst)
-}
-
-// finalizeSAF retries RenamePartialFile up to 10 times, generating a new
-// name on each failure until the SAF URI changes.
-func (m *manager) finalizeSAF(
-	partialPath, finalName string,
-) error {
-	if m.opts.FileOps == nil {
-		return fmt.Errorf("missing FileOps for SAF finalize")
-	}
-	const maxTries = 10
-	name := finalName
-	for i := 0; i < maxTries; i++ {
-		newURI, err := m.opts.FileOps.RenamePartialFile(partialPath, m.opts.Dir, name)
-		if err != nil {
-			return err
-		}
-		if newURI != "" && newURI != name {
-			return nil
-		}
-		name = nextFilename(name)
-	}
-	return fmt.Errorf("failed to finalize SAF file after %d retries", maxTries)
-}
-
 func (m *manager) redactAndLogError(stage string, err error) error {
 	err = redactError(err)
 	m.opts.Logf("put %s error: %v", stage, err)
 	return err
-}
-
-func sha256File(file string) (out [sha256.Size]byte, err error) {
-	h := sha256.New()
-	f, err := os.Open(file)
-	if err != nil {
-		return out, err
-	}
-	defer f.Close()
-	if _, err := io.Copy(h, f); err != nil {
-		return out, err
-	}
-	return [sha256.Size]byte(h.Sum(nil)), nil
 }


### PR DESCRIPTION
In Android, we are prompting the user to select a Taildrop directory when they first receive a Taildrop: we block writes on Taildrop dir selection. This means that we cannot use Dir inside managerOptions, since the http request would not get the new Taildrop extension. This PR removes, in the Android case, the reliance on m.opts.Dir, and instead has FileOps hold the correct directory.

This expands FileOps to be the Taildrop interface for all file system operations.

Updates tailscale/corp#29211

Signed-off-by: kari-ts <kari@tailscale.com>

restore tstest

(cherry picked from commit d897d809d649b312a3f87d01d9f9426d518cdced)