### PR TITLE
dnstype, ipnlocal: dnstype.Resolver.UseWithExitNode controls exit node DNS behavior

### DIFF
--- a/client/tailscale/apitype/controltype.go
+++ b/client/tailscale/apitype/controltype.go
@@ -3,17 +3,50 @@
 
 package apitype
 
+// DNSConfig is the DNS configuration for a tailnet
+// used in /tailnet/{tailnet}/dns/config.
 type DNSConfig struct {
-	Resolvers          []DNSResolver            `json:"resolvers"`
-	FallbackResolvers  []DNSResolver            `json:"fallbackResolvers"`
-	Routes             map[string][]DNSResolver `json:"routes"`
-	Domains            []string                 `json:"domains"`
-	Nameservers        []string                 `json:"nameservers"`
-	Proxied            bool                     `json:"proxied"`
-	TempCorpIssue13969 string                   `json:"TempCorpIssue13969,omitempty"`
+	// Resolvers are the global DNS resolvers to use
+	// overriding the local OS configuration.
+	Resolvers []DNSResolver `json:"resolvers"`
+
+	// FallbackResolvers are used as global resolvers when
+	// the client is unable to determine the OS's preferred DNS servers.
+	FallbackResolvers []DNSResolver `json:"fallbackResolvers"`
+
+	// Routes map DNS name suffixes to a set of DNS resolvers,
+	// used for Split DNS and other advanced routing overlays.
+	Routes map[string][]DNSResolver `json:"routes"`
+
+	// Domains are the search domains to use.
+	Domains []string `json:"domains"`
+
+	// Proxied means MagicDNS is enabled.
+	Proxied bool `json:"proxied"`
+
+	// TempCorpIssue13969 is from an internal hack day prototype,
+	// See tailscale/corp#13969.
+	TempCorpIssue13969 string `json:"TempCorpIssue13969,omitempty"`
+
+	// Nameservers are the IP addresses of global nameservers to use.
+	// This is a deprecated format but may still be found in tailnets
+	// that were configured a long time ago. When making updates,
+	// set Resolvers and leave Nameservers empty.
+	Nameservers []string `json:"nameservers"`
 }
 
+// DNSResolver is a DNS resolver in a DNS configuration.
 type DNSResolver struct {
-	Addr                string   `json:"addr"`
+	// Addr is the address of the DNS resolver.
+	// It is usually an IP address or a DoH URL.
+	// See dnstype.Resolver.Addr for full details.
+	Addr string `json:"addr"`
+
+	// BootstrapResolution is an optional suggested resolution for
+	// the DoT/DoH resolver.
 	BootstrapResolution []string `json:"bootstrapResolution,omitempty"`
+
+	// UseWithExitNode signals this resolver should be used
+	// even when a tailscale exit node is configured on a device.
+	UseWithExitNode bool `json:"useWithExitNode,omitempty"`
 }

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -169,7 +169,8 @@ type CapabilityVersion int
 //   - 122: 2025-07-21: Client sends Hostinfo.ExitNodeID to report which exit node it has selected, if any.
 //   - 123: 2025-07-28: fix deadlock regression from cryptokey routing change (issue #16651)
 //   - 124: 2025-08-08: removed NodeAttrDisableMagicSockCryptoRouting support, crypto routing is now mandatory
-const CurrentCapabilityVersion CapabilityVersion = 124
+//   - 125: 2025-08-11: dnstype.Resolver adds UseWithExitNode field.
+const CurrentCapabilityVersion CapabilityVersion = 125
 
 // ID is an integer ID for a user, node, or login allocated by the
 // control plane.
@@ -1730,10 +1731,9 @@ type DNSConfig struct {
 	// proxying to be enabled.
 	Proxied bool `json:",omitempty"`
 
-	// The following fields are only set and used by
-	// MapRequest.Version >=9 and <14.
-
-	// Nameservers are the IP addresses of the nameservers to use.
+	// Nameservers are the IP addresses of the global nameservers to use.
+	//
+	// Deprecated: this is only set and used by MapRequest.Version >=9 and <14. Use Resolvers instead.
 	Nameservers []netip.Addr `json:",omitempty"`
 
 	// CertDomains are the set of DNS names for which the control

--- a/types/dnstype/dnstype.go
+++ b/types/dnstype/dnstype.go
@@ -35,6 +35,12 @@ type Resolver struct {
 	//
 	// As of 2022-09-08, BootstrapResolution is not yet used.
 	BootstrapResolution []netip.Addr `json:",omitempty"`
+
+	// UseWithExitNode designates that this resolver should continue to be used when an
+	// exit node is in use. Normally, DNS resolution is delegated to the exit node but
+	// there are situations where it is preferable to still use a Split DNS server and/or
+	// global DNS server instead of the exit node.
+	UseWithExitNode bool `json:",omitempty"`
 }
 
 // IPPort returns r.Addr as an IP address and port if either
@@ -64,5 +70,7 @@ func (r *Resolver) Equal(other *Resolver) bool {
 		return true
 	}
 
-	return r.Addr == other.Addr && slices.Equal(r.BootstrapResolution, other.BootstrapResolution)
+	return r.Addr == other.Addr &&
+		slices.Equal(r.BootstrapResolution, other.BootstrapResolution) &&
+		r.UseWithExitNode == other.UseWithExitNode
 }

--- a/types/dnstype/dnstype_clone.go
+++ b/types/dnstype/dnstype_clone.go
@@ -25,6 +25,7 @@ func (src *Resolver) Clone() *Resolver {
 var _ResolverCloneNeedsRegeneration = Resolver(struct {
 	Addr                string
 	BootstrapResolution []netip.Addr
+	UseWithExitNode     bool
 }{})
 
 // Clone duplicates src into dst and reports whether it succeeded.

--- a/types/dnstype/dnstype_test.go
+++ b/types/dnstype/dnstype_test.go
@@ -17,7 +17,7 @@ func TestResolverEqual(t *testing.T) {
 		fieldNames = append(fieldNames, field.Name)
 	}
 	sort.Strings(fieldNames)
-	if !slices.Equal(fieldNames, []string{"Addr", "BootstrapResolution"}) {
+	if !slices.Equal(fieldNames, []string{"Addr", "BootstrapResolution", "UseWithExitNode"}) {
 		t.Errorf("Resolver fields changed; update test")
 	}
 
@@ -66,6 +66,18 @@ func TestResolverEqual(t *testing.T) {
 				Addr:                "dns.example.com",
 				BootstrapResolution: []netip.Addr{netip.MustParseAddr("8.8.4.4")},
 			},
+			want: false,
+		},
+		{
+			name: "equal UseWithExitNode",
+			a:    &Resolver{Addr: "dns.example.com", UseWithExitNode: true},
+			b:    &Resolver{Addr: "dns.example.com", UseWithExitNode: true},
+			want: true,
+		},
+		{
+			name: "not equal UseWithExitNode",
+			a:    &Resolver{Addr: "dns.example.com", UseWithExitNode: true},
+			b:    &Resolver{Addr: "dns.example.com", UseWithExitNode: false},
 			want: false,
 		},
 	}

--- a/types/dnstype/dnstype_view.go
+++ b/types/dnstype/dnstype_view.go
@@ -88,10 +88,12 @@ func (v ResolverView) Addr() string { return v.ж.Addr }
 func (v ResolverView) BootstrapResolution() views.Slice[netip.Addr] {
 	return views.SliceOf(v.ж.BootstrapResolution)
 }
+func (v ResolverView) UseWithExitNode() bool      { return v.ж.UseWithExitNode }
 func (v ResolverView) Equal(v2 ResolverView) bool { return v.ж.Equal(v2.ж) }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _ResolverViewNeedsRegeneration = Resolver(struct {
 	Addr                string
 	BootstrapResolution []netip.Addr
+	UseWithExitNode     bool
 }{})


### PR DESCRIPTION
Updates #8237 

Fixes tailscale/corp#30906
Fixes tailscale/corp#30907

- dnstype.Resolver  adds a boolean UseWithExitNode that controls whether the resolver should be used in tailscale exit node contexts (not wireguard exit nodes)
- If UseWithExitNode resolvers are found, they are installed as the global resolvers
- If no UseWithExitNode resolvers are found, the exit node resolver continues to be installed as the global resolver
- Split DNS Routes referencing UseWithExitNode resolvers are also installed.

I wanted to get this PR up, but I am in parallel bringing these changes into corp, making sure it compiles, and doing some light local controller testing.

This PR also adds some test coverage split DNS routes with zero-length resolver lists, independent of UseWithExitNode routes.

A former version of this PR as of d12c7a4 created a new dns type in tailcfg that embedded the dnstype.Resolver, but after some re-evaluation, we decided to back to the original plan. I'm happy to chat more about that decision out of band.