### PR TITLE
control/controlknobs,tailcfg,wgengine/magicsock: deprecate NodeAttrDi…

### DIFF
--- a/control/controlknobs/controlknobs.go
+++ b/control/controlknobs/controlknobs.go
@@ -98,10 +98,6 @@ type Knobs struct {
 	// allows us to disable the new behavior remotely if needed.
 	DisableLocalDNSOverrideViaNRPT atomic.Bool
 
-	// DisableCryptorouting indicates that the node should not use the
-	// magicsock crypto routing feature.
-	DisableCryptorouting atomic.Bool
-
 	// DisableCaptivePortalDetection is whether the node should not perform captive portal detection
 	// automatically when the network state changes.
 	DisableCaptivePortalDetection atomic.Bool
@@ -137,7 +133,6 @@ func (k *Knobs) UpdateFromNodeAttributes(capMap tailcfg.NodeCapMap) {
 		userDialUseRoutes                    = has(tailcfg.NodeAttrUserDialUseRoutes)
 		disableSplitDNSWhenNoCustomResolvers = has(tailcfg.NodeAttrDisableSplitDNSWhenNoCustomResolvers)
 		disableLocalDNSOverrideViaNRPT       = has(tailcfg.NodeAttrDisableLocalDNSOverrideViaNRPT)
-		disableCryptorouting                 = has(tailcfg.NodeAttrDisableMagicSockCryptoRouting)
 		disableCaptivePortalDetection        = has(tailcfg.NodeAttrDisableCaptivePortalDetection)
 		disableSkipStatusQueue               = has(tailcfg.NodeAttrDisableSkipStatusQueue)
 	)
@@ -165,7 +160,6 @@ func (k *Knobs) UpdateFromNodeAttributes(capMap tailcfg.NodeCapMap) {
 	k.UserDialUseRoutes.Store(userDialUseRoutes)
 	k.DisableSplitDNSWhenNoCustomResolvers.Store(disableSplitDNSWhenNoCustomResolvers)
 	k.DisableLocalDNSOverrideViaNRPT.Store(disableLocalDNSOverrideViaNRPT)
-	k.DisableCryptorouting.Store(disableCryptorouting)
 	k.DisableCaptivePortalDetection.Store(disableCaptivePortalDetection)
 	k.DisableSkipStatusQueue.Store(disableSkipStatusQueue)
 }

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -168,7 +168,8 @@ type CapabilityVersion int
 //   - 121: 2025-07-19: Client understands peer relay endpoint alloc with [disco.AllocateUDPRelayEndpointRequest] & [disco.AllocateUDPRelayEndpointResponse]
 //   - 122: 2025-07-21: Client sends Hostinfo.ExitNodeID to report which exit node it has selected, if any.
 //   - 123: 2025-07-28: fix deadlock regression from cryptokey routing change (issue #16651)
-const CurrentCapabilityVersion CapabilityVersion = 123
+//   - 124: 2025-08-08: removed NodeAttrDisableMagicSockCryptoRouting support, crypto routing is now mandatory
+const CurrentCapabilityVersion CapabilityVersion = 124
 
 // ID is an integer ID for a user, node, or login allocated by the
 // control plane.
@@ -2590,6 +2591,9 @@ const (
 
 	// NodeAttrDisableMagicSockCryptoRouting disables the use of the
 	// magicsock cryptorouting hook. See tailscale/corp#20732.
+	//
+	// Deprecated: NodeAttrDisableMagicSockCryptoRouting is deprecated as of
+	// CapabilityVersion 124, CryptoRouting is now mandatory. See tailscale/corp#31083.
 	NodeAttrDisableMagicSockCryptoRouting NodeCapability = "disable-magicsock-crypto-routing"
 
 	// NodeAttrDisableCaptivePortalDetection instructs the client to not perform captive portal detection

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -1842,12 +1842,6 @@ func (c *Conn) receiveIP(b []byte, ipp netip.AddrPort, cache *epAddrEndpointCach
 		de, ok := c.peerMap.endpointForEpAddr(src)
 		c.mu.Unlock()
 		if !ok {
-			if c.controlKnobs != nil && c.controlKnobs.DisableCryptorouting.Load() {
-				// Note: UDP relay is dependent on cryptorouting enablement. We
-				// only update Geneve-encapsulated [epAddr]s in the [peerMap]
-				// via [lazyEndpoint].
-				return nil, 0, false, false
-			}
 			// TODO(jwhited): reuse [lazyEndpoint] across calls to receiveIP()
 			//  for the same batch & [epAddr] src.
 			return &lazyEndpoint{c: c, src: src}, size, isGeneveEncap, true


### PR DESCRIPTION
…sableMagicSockCryptoRouting

Peer Relay is dependent on crypto routing, therefore crypto routing is now mandatory.

Updates tailscale/corp#20732
Updates tailscale/corp#31083