### PR TITLE
net/tshttpproxy: add macOS support for system proxy

### DIFF
--- a/net/tshttpproxy/tshttpproxy.go
+++ b/net/tshttpproxy/tshttpproxy.go
@@ -38,6 +38,23 @@ var (
 	proxyFunc    func(*url.URL) (*url.URL, error)
 )
 
+// SetProxyFunc can be used by clients to set a platform-specific function for proxy resolution.
+// If config is set when this function is called, an error will be returned.
+// The provided function should return a proxy URL for the given request URL,
+// nil if no proxy is enabled for the request URL, or an error if proxy settings cannot be resolved.
+func SetProxyFunc(fn func(*url.URL) (*url.URL, error)) error {
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Allow override only if config is not set
+	if config != nil {
+		return fmt.Errorf("tshttpproxy: SetProxyFunc can only be called when config is not set")
+	}
+
+	proxyFunc = fn
+	return nil
+}
+
 func getProxyFunc() func(*url.URL) (*url.URL, error) {
 	// Create config/proxyFunc if it's not created
 	mu.Lock()


### PR DESCRIPTION
Exposes a setter for proxyFunc to allow the macOS client to resolve proxy settings via SystemConfiguration. Setting is only permitted if config is nil.

Updates tailscale/corp#30668