### PR TITLE
control/controlclient: fix data race on tkaHead

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -856,6 +856,7 @@ func (c *Direct) sendMapRequest(ctx context.Context, isStreaming bool, nu Netmap
 	hi := c.hostInfoLocked()
 	backendLogID := hi.BackendLogID
 	connectionHandleForTest := c.connectionHandleForTest
+	tkaHead := c.tkaHead
 	var epStrs []string
 	var eps []netip.AddrPort
 	var epTypes []tailcfg.EndpointType
@@ -906,7 +907,7 @@ func (c *Direct) sendMapRequest(ctx context.Context, isStreaming bool, nu Netmap
 		Hostinfo:                hi,
 		DebugFlags:              c.debugFlags,
 		OmitPeers:               nu == nil,
-		TKAHead:                 c.tkaHead,
+		TKAHead:                 tkaHead,
 		ConnectionHandleForTest: connectionHandleForTest,
 	}
 	var extraDebugFlags []string


### PR DESCRIPTION
Grab a copy under mutex in sendMapRequest.

```
WARNING: DATA RACE
Read at 0x00c00cc833f8 by goroutine 83000:
  tailscale.com/control/controlclient.(*Direct).sendMapRequest()
      /home/awly/src/tailscale/control/controlclient/direct.go:909 +0x1404
  tailscale.com/control/controlclient.(*Direct).SendUpdate()
      /home/awly/src/tailscale/control/controlclient/direct.go:821 +0x35d
  tailscale.com/control/controlclient.(*Auto).updateRoutine()
      /home/awly/src/tailscale/control/controlclient/auto.go:85 +0x32d
  tailscale.com/control/controlclient.(*Auto).Start.gowrap3()
      /home/awly/src/tailscale/control/controlclient/auto.go:239 +0x33

Previous write at 0x00c00cc833f8 by goroutine 83294:
  tailscale.com/control/controlclient.(*Direct).SetTKAHead()
      /home/awly/src/tailscale/control/controlclient/direct.go:397 +0x114
  tailscale.com/control/controlclient.(*Auto).SetTKAHead()
      /home/awly/src/tailscale/control/controlclient/auto.go:579 +0x49
  tailscale.com/ipn/ipnlocal.(*LocalBackend).SetControlClientStatus()
      /home/awly/src/tailscale/ipn/ipnlocal/local.go:1687 +0x1e53
  tailscale.com/control/controlclient.(*Auto).sendStatus.func1()
      /home/awly/src/tailscale/control/controlclient/auto.go:629 +0x1a4
  tailscale.com/util/execqueue.(*ExecQueue).run()
      /home/awly/src/tailscale/util/execqueue/execqueue.go:57 +0x2f
  tailscale.com/util/execqueue.(*ExecQueue).Add.gowrap2()
      /home/awly/src/tailscale/util/execqueue/execqueue.go:31 +0x44
```

Updates #cleanup