### PR TITLE
release/dist/qnap: verify code signing

### DIFF
--- a/release/dist/qnap/files/scripts/Dockerfile.qpkg
+++ b/release/dist/qnap/files/scripts/Dockerfile.qpkg
@@ -9,13 +9,13 @@ RUN apt-get update -y && \
     curl \
     patch
 
-# Install QNAP QDK (force a specific version to pick up updates)
-RUN git clone https://github.com/tailscale/QDK.git && cd /QDK && git reset --hard 6aba74f6b4c8ea0c30b8aec9f3476f428f6a58a1
-RUN cd /QDK && ./InstallToUbuntu.sh install
-ENV PATH="/usr/share/QDK/bin:${PATH}"
-
 # Install Google Cloud PKCS11 module
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 RUN apt-get update -y && apt-get install -y --no-install-recommends google-cloud-cli libengine-pkcs11-openssl
-RUN curl -L https://github.com/GoogleCloudPlatform/kms-integrations/releases/download/pkcs11-v1.6/libkmsp11-1.6-linux-amd64.tar.gz | tar xz
+RUN curl -L https://github.com/GoogleCloudPlatform/kms-integrations/releases/download/pkcs11-v1.7/libkmsp11-1.7-linux-amd64.tar.gz | tar xz
+
+# Install QNAP QDK (force a specific version to pick up updates)
+RUN git clone https://github.com/tailscale/QDK.git && cd /QDK && git reset --hard 8478a990decf0b0bb259ae11c636e66bfeff2433
+RUN cd /QDK && ./InstallToUbuntu.sh install
+ENV PATH="/usr/share/QDK/bin:${PATH}"

--- a/release/dist/qnap/files/scripts/sign-qpkg.sh
+++ b/release/dist/qnap/files/scripts/sign-qpkg.sh
@@ -13,7 +13,7 @@ log_directory: "/tmp/kmsp11"
 chmod 0600 pkcs11-config.yaml
 
 export KMS_PKCS11_CONFIG=`readlink -f pkcs11-config.yaml`
-export PKCS11_MODULE_PATH=/libkmsp11-1.6-linux-amd64/libkmsp11.so
+export PKCS11_MODULE_PATH=/libkmsp11-1.7-linux-amd64/libkmsp11.so
 
 # Verify signature of pkcs11 module
 # See https://github.com/GoogleCloudPlatform/kms-integrations/blob/master/kmsp11/docs/user_guide.md#downloading-and-verifying-the-library


### PR DESCRIPTION
This pulls in a change from github.com/tailscale/QDK to verify code signing when using QNAP_SIGNING_SCRIPT.

It also upgrades to the latest Google Cloud PKCS#11 library, and reorders the Dockerfile to allow for more efficient future upgrades to the included QDK.

Updates tailscale/corp#23528

Depends on https://github.com/tailscale/QDK/pull/3