### PR TITLE
client/systray: disable 'more settings' menu if backend not running

### DIFF
--- a/client/systray/systray.go
+++ b/client/systray/systray.go
@@ -306,11 +306,14 @@ func (menu *Menu) rebuild() {
 		menu.rebuildExitNodeMenu(ctx)
 	}
 
-	if menu.status != nil {
-		menu.more = systray.AddMenuItem("More settings", "")
+	menu.more = systray.AddMenuItem("More settings", "")
+	if menu.status != nil && menu.status.BackendState == "Running" {
+		// web client is only available if backend is running
 		onClick(ctx, menu.more, func(_ context.Context) {
 			webbrowser.Open("http://100.100.100.100/")
 		})
+	} else {
+		menu.more.Disable()
 	}
 
 	// TODO(#15528): this menu item shouldn't be necessary at all,


### PR DESCRIPTION
Thanks to /u/niftyrider for reporting the issue: https://www.reddit.com/r/Tailscale/comments/1mqe4ei/comment/n90grx0/

Updates #1708

Change-Id: Ia101a4a3005adb9118051b3416f5a64a4a45987d