### PR TITLE
ipn/localapi: plumb an event bus through the localapi.Handler

### DIFF
--- a/ipn/ipnserver/server.go
+++ b/ipn/ipnserver/server.go
@@ -199,7 +199,13 @@ func (s *Server) serveHTTP(w http.ResponseWriter, r *http.Request) {
 			ci = actorWithAccessOverride(actor, string(reason))
 		}
 
-		lah := localapi.NewHandler(ci, lb, s.logf, s.backendLogID)
+		lah := localapi.NewHandler(localapi.HandlerConfig{
+			Actor:    ci,
+			Backend:  lb,
+			Logf:     s.logf,
+			LogID:    s.backendLogID,
+			EventBus: lb.Sys().Bus.Get(),
+		})
 		if actor, ok := ci.(*actor); ok {
 			lah.PermitRead, lah.PermitWrite = actor.Permissions(lb.OperatorUserID())
 			lah.PermitCert = actor.CanFetchCerts()

--- a/net/portmapper/portmapper.go
+++ b/net/portmapper/portmapper.go
@@ -209,11 +209,8 @@ func (m *pmpMapping) Release(ctx context.Context) {
 
 // Config carries the settings for a [Client].
 type Config struct {
-	// EventBus, if non-nil, is used for event publication and subscription by
-	// portmapper clients created from this config.
-	//
-	// TODO(creachadair): As of 2025-03-19 this is optional, but is intended to
-	// become required non-nil.
+	// EventBus, which must be non-nil, is used for event publication and
+	// subscription by portmapper clients created from this config.
 	EventBus *eventbus.Bus
 
 	// Logf is called to generate text logs for the client. If nil, logger.Discard is used.

--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -274,7 +274,13 @@ func (s *Server) Loopback() (addr string, proxyCred, localAPICred string, err er
 		// out the CONNECT code from tailscaled/proxy.go that uses
 		// httputil.ReverseProxy and adding auth support.
 		go func() {
-			lah := localapi.NewHandler(ipnauth.Self, s.lb, s.logf, s.logid)
+			lah := localapi.NewHandler(localapi.HandlerConfig{
+				Actor:    ipnauth.Self,
+				Backend:  s.lb,
+				Logf:     s.logf,
+				LogID:    s.logid,
+				EventBus: s.sys.Bus.Get(),
+			})
 			lah.PermitWrite = true
 			lah.PermitRead = true
 			lah.RequiredPassword = s.localAPICred
@@ -676,7 +682,13 @@ func (s *Server) start() (reterr error) {
 	go s.printAuthURLLoop()
 
 	// Run the localapi handler, to allow fetching LetsEncrypt certs.
-	lah := localapi.NewHandler(ipnauth.Self, lb, tsLogf, s.logid)
+	lah := localapi.NewHandler(localapi.HandlerConfig{
+		Actor:    ipnauth.Self,
+		Backend:  lb,
+		Logf:     tsLogf,
+		LogID:    s.logid,
+		EventBus: sys.Bus.Get(),
+	})
 	lah.PermitWrite = true
 	lah.PermitRead = true
 


### PR DESCRIPTION
Some of the operations of the local API need an event bus to correctly
instantiate other components (notably including the portmapper).

This commit adds that, and as the parameter list is starting to get a bit long
and hard to read, I took the opportunity to move the arguments to a config
type. Only a few call sites needed to be updated and this API is not intended
for general use, so I did not bother to stage the change.

Change-Id: I7b057d71161bd859f5acb96e2f878a34c85be0ef
