### PR TITLE
prober: update runall handler to be generic

### DIFF
--- a/prober/prober.go
+++ b/prober/prober.go
@@ -18,6 +18,7 @@ import (
 	"maps"
 	"math/rand"
 	"net/http"
+	"slices"
 	"sync"
 	"time"
 
@@ -585,10 +586,12 @@ type RunHandlerAllResponse struct {
 }
 
 func (p *Prober) RunAllHandler(w http.ResponseWriter, r *http.Request) error {
+	excluded := r.URL.Query()["exclude"]
+
 	probes := make(map[string]*Probe)
 	p.mu.Lock()
 	for _, probe := range p.probes {
-		if !probe.IsContinuous() && probe.name != "derpmap-probe" {
+		if !probe.IsContinuous() && !slices.Contains(excluded, probe.name) {
 			probes[probe.name] = probe
 		}
 	}


### PR DESCRIPTION
Update the runall handler to be more generic with an exclude param to exclude multiple probes as the requesters definition.

Updates tailscale/corp#27370