### PR TITLE
[WIP] utils/expvarx: reduce flakiness in TestSafeFuncHappyPath

### DIFF
--- a/util/expvarx/expvarx_test.go
+++ b/util/expvarx/expvarx_test.go
@@ -56,7 +56,7 @@ func TestSafeFuncHappyPath(t *testing.T) {
 	f := NewSafeFunc(expvar.Func(func() any {
 		count++
 		return count
-	}), time.Millisecond, nil)
+	}), time.Second, nil)
 
 	if got, want := f.Value(), 1; got != want {
 		t.Errorf("got %v, want %v", got, want)


### PR DESCRIPTION
This test has been flaky for over a year.  There are two documented failure modes:

a) L62: `f.Value()` returns `nil` instead of 1
b) L65: `f.Value()` returns 1 instead of 2

The `nil` is a clue -- `NewSafeFunc` wraps a function `f`, and if `f` takes longer than the timeout to execute, then `Value()` returns nil.

My theory: under heavy CPU load, the wrapper function takes longer than the 1ms limit to acquire the lock and increment `count`, causing timeouts and flaky test results.  This is difficult to reproduce locally unless your machine is CPU-bound.

This patch increases the timeout by 1000× to reduce flakiness.  The choice of a 1ms seems arbitrary, and the test doesn't depend on millisecond-level precision, so this changes should have no harmful side effects.

This theory only explains (a), not (b).  It's unclear how a timeout would cause an incorrect non-`nil` value (1 instead of 2) rather than just `nil`.

Updates https://github.com/tailscale/tailscale/issues/12247
Updates https://github.com/tailscale/tailscale/issues/15348