### PR TITLE
util/expvar: fix flaky TestSafeFuncHappyPath test

### DIFF
--- a/util/expvarx/expvarx_test.go
+++ b/util/expvarx/expvarx_test.go
@@ -56,11 +56,20 @@ func TestSafeFuncHappyPath(t *testing.T) {
 	f := NewSafeFunc(expvar.Func(func() any {
 		count++
 		return count
-	}), time.Millisecond, nil)
+	}), 10*time.Millisecond, nil)
 
 	if got, want := f.Value(), 1; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
+
+	// If you call `f.Value()` in quick succession, it's possible for it
+	// to return a cached value rather than call the wrapped function again.
+	// This caused this test to be flaky.
+	//
+	// Introducing a small sleep ensures that the wrapped function will
+	// always be called twice.
+	time.Sleep(1 * time.Millisecond)
+
 	if got, want := f.Value(), 2; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}


### PR DESCRIPTION
This test had two common flaky failure modes:

a) L62: got `nil`, expected 1
b) L65: got 1, expected 2

Case (a) is a simple timeout issue, easy to fix.

Case (b) has a deeper cause: `SafeFunc.Value()` only allows one call to the wrapped function at a time.  However, there's a short window after a call finishes where the internal `inflight` lock hasn't been released yet. During this time, subsequent `Value()` calls return the previous result rather than triggering a new call to the wrapped function.

(Logging the wrapped function confirms this behaviour, and explains why we never see "got 0, expected 1" -- only later calls are affected.)

Fixes:

a) Increase the timeout for individual function calls.  Most already complete well within the timeout, so this should not affect test runtime.
b) Introduce a small sleep to avoid racing with the lock release.  This adds 1ms per run, a small price for eliminating test flakiness.

Stress testing before/after:
* Before: 11 failures in 205,763 runs
* After: 0 failures in 1,231,939 runs

Updates #12247
Updates #15348