### PR TITLE
cmd/tsidp: Add Docker image to README

### DIFF
--- a/cmd/tsidp/README.md
+++ b/cmd/tsidp/README.md
@@ -12,6 +12,10 @@
 
 ## Installation using Docker
 
+### Pre-built image
+
+A pre-built tsidp image exists at `tailscale/tsidp:unstable`.
+
 ### Building from Source
 
 ```bash


### PR DESCRIPTION
Noticed this image was available at https://hub.docker.com/r/tailscale/tsidp, might be useful to document this!