### PR TITLE
cmd/tsconnect: fix invalid memory address or nil pointer dereference

### DIFF
--- a/cmd/tsconnect/wasm/wasm_js.go
+++ b/cmd/tsconnect/wasm/wasm_js.go
@@ -110,6 +110,7 @@ func newIPN(jsConfig js.Value) map[string]any {
 		ControlKnobs:  sys.ControlKnobs(),
 		HealthTracker: sys.HealthTracker(),
 		Metrics:       sys.UserMetricsRegistry(),
+		EventBus:      sys.Bus.Get(),
 	})
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
the new method `sys := tsd.NewSystem()` will create new system with event bus, but `wgengine.NewUserspaceEngine` didn't receive the eventbus
then the netmonitor throw this nil pointer error
```
logtail started
wasm_exec.js:22 panic: runtime error: invalid memory address or nil pointer dereference
wasm_exec.js:22 [signal 0xb code=0x0 addr=0x0 pc=0x0]
wasm_exec.js:22 
wasm_exec.js:22 goroutine 7 [running]:
wasm_exec.js:22 tailscale.com/util/eventbus.(*Bus).Client(0x0, {0x279ddd, 0x6})
wasm_exec.js:22 	C:/Users/17904/go/pkg/mod/tailscale.com@v1.86.4/util/eventbus/bus.go:69 +0x8
wasm_exec.js:22 tailscale.com/net/netmon.New(0x0, 0x102ec80)
wasm_exec.js:22 	C:/Users/17904/go/pkg/mod/tailscale.com@v1.86.4/net/netmon/netmon.go:125 +0x8
wasm_exec.js:22 tailscale.com/wgengine.NewUserspaceEngine(0x102ec80, {{0x40dfa0, 0x102eca0}, 0x0, {0x409db0, 0x102ec80}, {0x409d78, 0xf69240}, 0x0, 0x0, ...})
wasm_exec.js:22 	C:/Users/17904/go/pkg/mod/tailscale.com@v1.86.4/wgengine/userspace.go:369 +0x5d
wasm_exec.js:22 main.newIPN({{}, 0x7ff8000100000011, 0x100c8c8})
wasm_exec.js:22 	C:/Users/17904/Desktop/wasm-test/wasm-rtc/main.go:132 +0x43
wasm_exec.js:22 main.main.func1({{}, 0x7ff8000100000005, 0x100c8b8}, {0x102ebe0, 0x1, 0x1})
wasm_exec.js:22 	C:/Users/17904/Desktop/wasm-test/wasm-rtc/main.go:52 +0x5
wasm_exec.js:22 syscall/js.handleEvent()
wasm_exec.js:22 	C:/Users/17904/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.6.windows-amd64/src/syscall/js/func.go:117 +0x28
```
pass the event bus to `wgengine.NewUserspaceEngine` can solve this problem