### PR TITLE
ipn,tsnet: update AdvertiseTags documentation

### DIFF
--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -158,11 +158,10 @@ type Prefs struct {
 	// connections. This overrides tailcfg.Hostinfo's ShieldsUp.
 	ShieldsUp bool
 
-	// AdvertiseTags specifies groups that this node wants to join, for
-	// purposes of ACL enforcement. These can be referenced from the ACL
-	// security policy. Note that advertising a tag doesn't guarantee that
-	// the control server will allow you to take on the rights for that
-	// tag.
+	// AdvertiseTags specifies tags that should be applied to this node, for
+	// purposes of ACL enforcement. These can be referenced from the ACL policy
+	// document. Note that advertising a tag on the client doesn't guarantee
+	// that the control server will allow the node to adopt that tag.
 	AdvertiseTags []string
 
 	// Hostname is the hostname to use for identifying the node. If

--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -124,11 +124,10 @@ type Server struct {
 	// field at zero unless you know what you are doing.
 	Port uint16
 
-	// AdvertiseTags specifies groups that this embedded server wants to join, for
-	// purposes of ACL enforcement. These can be referenced from the ACL
-	// security policy. Note that advertising a tag doesn't guarantee that
-	// the control server will allow you to take on the rights for that
-	// tag.
+	// AdvertiseTags specifies tags that should be applied to this node, for
+	// purposes of ACL enforcement. These can be referenced from the ACL policy
+	// document. Note that advertising a tag on the client doesn't guarantee
+	// that the control server will allow the node to adopt that tag.
 	AdvertiseTags []string
 
 	getCertForTesting func(*tls.ClientHelloInfo) (*tls.Certificate, error)


### PR DESCRIPTION
This is a follow-up to #15840, which had replicated the language from ipn/prefs
into tsnet. Here we keep the duplication (since the fields mean the same thing)
but update the wording to distinguish "tags" from "groups" which was misleading.

Instead of referring to groups, which is a term of art for a different entity,
update the doc comments to more accurately describe what tags are in reference
to the policy document.

Updates #cleanup

Change-Id: Iefff6f84981985f834bae7c6a6c34044f53f2ea2
Signed-off-by: M. J. Fromberger <fromberger@tailscale.com>
