### PR TITLE
Roll back atypical `*Locked` methods in `LocalBackend`

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -4946,34 +4946,36 @@ func (b *LocalBackend) peerAPIServicesLocked() (ret []tailcfg.Service) {
 // TODO(danderson): we shouldn't be mangling hostinfo here after
 // painstakingly constructing it in twelvety other places.
 func (b *LocalBackend) doSetHostinfoFilterServices() {
-	// Check the control client, hostinfo, and services under the mutex.
-	// On return, either both the client and hostinfo are nil, or both are non-nil.
-	// When non-nil, the Hostinfo is a clone of the value carried by b, safe to modify.
-	cc, hi, peerAPIServices := func() (controlclient.Client, *tailcfg.Hostinfo, []tailcfg.Service) {
-		b.mu.Lock()
-		defer b.mu.Unlock()
+	unlock := b.lockAndGetUnlock()
+	defer unlock()
 
-		if b.cc == nil {
-			return nil, nil, nil // control client isn't up yet
-		} else if b.hostinfo == nil {
-			b.logf("[unexpected] doSetHostinfoFilterServices with nil hostinfo")
-			return nil, nil, nil
-		}
-		svc := b.peerAPIServicesLocked()
-		if b.egg {
-			svc = append(svc, tailcfg.Service{Proto: "egg", Port: 1})
-		}
-		// Make a clone of hostinfo so we can mutate the service field, below.
-		return b.cc, b.hostinfo.Clone(), svc
-	}()
-	if cc == nil || hi == nil {
+	cc := b.cc
+	if cc == nil {
+		// Control client isn't up yet.
 		return
 	}
+	if b.hostinfo == nil {
+		b.logf("[unexpected] doSetHostinfoFilterServices with nil hostinfo")
+		return
+	}
+	peerAPIServices := b.peerAPIServicesLocked()
+	if b.egg {
+		peerAPIServices = append(peerAPIServices, tailcfg.Service{Proto: "egg", Port: 1})
+	}
 
+	// TODO(maisem,bradfitz): store hostinfo as a view, not as a mutable struct.
+	hi := *b.hostinfo // shallow copy
+	unlock.UnlockEarly()
+
+	// Make a shallow copy of hostinfo so we can mutate
+	// at the Service field.
 	if !b.shouldUploadServices() {
 		hi.Services = []tailcfg.Service{}
 	}
-	hi.Services = append(hi.Services, peerAPIServices...)
+	// Don't mutate hi.Service's underlying array. Append to
+	// the slice with no free capacity.
+	c := len(hi.Services)
+	hi.Services = append(hi.Services[:c:c], peerAPIServices...)
 	hi.PushDeviceToken = b.pushDeviceToken.Load()
 
 	// Compare the expected ports from peerAPIServices to the actual ports in hi.Services.
@@ -4983,7 +4985,7 @@ func (b *LocalBackend) doSetHostinfoFilterServices() {
 		b.logf("Hostinfo peerAPI ports changed: expected %v, got %v", expectedPorts, actualPorts)
 	}
 
-	cc.SetHostinfo(hi)
+	cc.SetHostinfo(&hi)
 }
 
 type portPair struct {

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -4300,7 +4300,7 @@ func (b *LocalBackend) SetPrefsForTest(newp *ipn.Prefs) {
 	}
 	unlock := b.lockAndGetUnlock()
 	defer unlock()
-	b.setPrefsLocked(newp)
+	b.setPrefsLockedOnEntry(newp, unlock)
 }
 
 type peerOptFunc func(*tailcfg.Node)

--- a/ipn/ipnlocal/profiles.go
+++ b/ipn/ipnlocal/profiles.go
@@ -180,7 +180,7 @@ func (pm *profileManager) SwitchToProfile(profile ipn.LoginProfileView) (cp ipn.
 		f(pm.currentProfile, pm.prefs, false)
 	}
 	// Do not call pm.extHost.NotifyProfileChange here; it is invoked in
-	// [LocalBackend.resetForProfileChangeLocked] after the netmap reset.
+	// [LocalBackend.resetForProfileChangeLockedOnEntry] after the netmap reset.
 	// TODO(nickkhyl): Consider moving it here (or into the stateChangeCb handler
 	// in [LocalBackend]) once the profile/node state, including the netmap,
 	// is actually tied to the current profile.
@@ -359,9 +359,9 @@ func (pm *profileManager) SetPrefs(prefsIn ipn.PrefsView, np ipn.NetworkProfile)
 	// where prefsIn is the previous profile's prefs with an updated Persist, LoggedOut,
 	// WantRunning and possibly other fields. This may not be the desired behavior.
 	//
-	// Additionally, LocalBackend doesn't treat it as a proper profile switch,
-	// meaning that [LocalBackend.resetForProfileChangeLocked] is not called and
-	// certain node/profile-specific state may not be reset as expected.
+	// Additionally, LocalBackend doesn't treat it as a proper profile switch, meaning that
+	// [LocalBackend.resetForProfileChangeLockedOnEntry] is not called and certain
+	// node/profile-specific state may not be reset as expected.
 	//
 	// However, [profileManager] notifies [ipnext.Extension]s about the profile change,
 	// so features migrated from LocalBackend to external packages should not be affected.
@@ -494,9 +494,10 @@ func (pm *profileManager) setProfilePrefsNoPermCheck(profile ipn.LoginProfileVie
 		oldPrefs := pm.prefs
 		pm.prefs = clonedPrefs
 
-		// Sadly, profile prefs can be changed in multiple ways.  It's pretty
-		// chaotic, and in many cases callers use unexported methods of the
-		// profile manager instead of going through [LocalBackend.setPrefsLocked]
+		// Sadly, profile prefs can be changed in multiple ways.
+		// It's pretty chaotic, and in many cases callers use
+		// unexported methods of the profile manager instead of
+		// going through [LocalBackend.setPrefsLockedOnEntry]
 		// or at least using [profileManager.SetPrefs].
 		//
 		// While we should definitely clean this up to improve


### PR DESCRIPTION
[3 commits]

This rolls back atypical `*Locked` methods which unlock on entry and re-lock on exit, introduced in #16925 and #16943.

Updates tailscale/corp#31713