### PR TITLE
cmd/tsidp: show oidc endpoints in web ui

### DIFF
--- a/cmd/tsidp/tsidp.go
+++ b/cmd/tsidp/tsidp.go
@@ -184,6 +184,13 @@ func main() {
 		srv.serverURL = fmt.Sprintf("https://%s", strings.TrimSuffix(st.Self.DNSName, "."))
 	}
 
+	// Since we now have the serverURL, we can populate the endpoints
+	srv.endpoints = endpoints{
+		authorizeEndpoint: srv.serverURL + "/authorize",
+		tokenEndpoint:     srv.serverURL + "/token",
+		userinfoEndpoint:  srv.serverURL + "/userinfo",
+	}
+
 	// Load funnel clients from disk if they exist, regardless of whether funnel is enabled
 	// This ensures OIDC clients persist across restarts
 	funnelClientsFilePath, err := getConfigFilePath(rootPath, funnelClientsFile)
@@ -319,6 +326,7 @@ type idpServer struct {
 	code          map[string]*authRequest  // keyed by random hex
 	accessToken   map[string]*authRequest  // keyed by random hex
 	funnelClients map[string]*funnelClient // keyed by client ID
+	endpoints     endpoints
 }
 
 type authRequest struct {
@@ -353,6 +361,12 @@ type authRequest struct {
 	// As of 2023-11-14, it is 5 minutes.
 	// TODO: add routine to delete expired tokens.
 	validTill time.Time
+}
+
+type endpoints struct {
+	authorizeEndpoint string
+	tokenEndpoint     string
+	userinfoEndpoint  string
 }
 
 // allowRelyingParty validates that a relying party identified either by a

--- a/cmd/tsidp/ui-list.html
+++ b/cmd/tsidp/ui-list.html
@@ -13,54 +13,60 @@
       <div class="header-actions">
         <div>
           <h2>OIDC Clients</h2>
-          {{if .}}
-            <p class="client-count">{{len .}} client{{if ne (len .) 1}}s{{end}} configured</p>
+          {{if .Clients}}
+          <p class="client-count">
+            {{len .Clients}} client{{if ne (len .Clients) 1}}s{{end}} configured
+          </p>
           {{end}}
         </div>
         <a href="/new" class="btn btn-primary">Add New Client</a>
       </div>
 
-      {{if .}}
-      <table>
-        <thead>
-          <tr>
-            <td>Name</td>
-            <td>Client ID</td>
-            <td>Redirect URI</td>
-            <td>Status</td>
-            <td>Actions</td>
-          </tr>
-        </thead>
-        <tbody>
-          {{range .}}
-          <tr>
-            <td>
-              {{if .Name}}
+      {{if .Clients}}
+      <div class="table-container">
+        <table>
+          <thead>
+            <tr>
+              <td>Name</td>
+              <td>Client ID</td>
+              <td>Redirect URI</td>
+              <td>Status</td>
+              <td>Actions</td>
+            </tr>
+          </thead>
+          <tbody>
+            {{range .Clients}}
+            <tr>
+              <td>
+                {{if .Name}}
                 <strong>{{.Name}}</strong>
-              {{else}}
+                {{else}}
                 <span class="text-muted">Unnamed Client</span>
-              {{end}}
-            </td>
-            <td>
-              <code class="client-id">{{.ID}}</code>
-            </td>
-            <td>
-              <span class="redirect-uri">{{.RedirectURI}}</span>
-            </td>
-            <td>
-              {{if .HasSecret}}
+                {{end}}
+              </td>
+              <td>
+                <code class="client-id">{{.ID}}</code>
+              </td>
+              <td>
+                <span class="redirect-uri">{{.RedirectURI}}</span>
+              </td>
+              <td>
+                {{if .HasSecret}}
                 <span class="status-active">Active</span>
-              {{else}}
+                {{else}}
                 <span class="status-inactive">No Secret</span>
-              {{end}}
-            </td>
-            <td>
-              <a href="/edit/{{.ID}}" class="btn btn-secondary btn-small">Edit</a>
-            </td>
-          </tr>
-          {{end}}
-        </tbody>
-      </table>
+                {{end}}
+              </td>
+              <td>
+                <a href="/edit/{{.ID}}" class="btn btn-secondary btn-small"
+                  >Edit</a
+                >
+              </td>
+            </tr>
+            {{end}}
+          </tbody>
+        </table>
+      </div>
       {{else}}
       <div class="empty-state">
         <h3>No OIDC clients configured</h3>
@@ -68,6 +74,36 @@
         <a href="/new" class="btn btn-primary">Add New Client</a>
       </div>
       {{end}}
+
+      <div class="oidc-endpoints-header">
+        <h2>OIDC Endpoints</h2>
+      </div>
+
+      <div class="oidc-endpoints">
+        <div class="oidc-endpoint">
+          <h3>Authorize</h3>
+          <code>{{.Endpoints.AuthorizeEndpoint}}/:nodeID</code>
+          <p class="text-muted">Endpoint used to get initial authorization.</p>
+          <div class="alert alert-info">
+            To get the node ID use
+            <code>tailscale whois --json some-node-ip | jq .Node.ID</code>
+          </div>
+        </div>
+        <div class="oidc-endpoint">
+          <h3>Token</h3>
+          <code>{{.Endpoints.TokenEndpoint}}</code>
+          <p class="text-muted">
+            Endpoint used to obtain the token after the initial authorization.
+          </p>
+        </div>
+        <div class="oidc-endpoint">
+          <h3>Userinfo</h3>
+          <code>{{.Endpoints.UserinfoEndpoint}}</code>
+          <p class="text-muted">
+            Endpoint used to obtain user information using the access token.
+          </p>
+        </div>
+      </div>
     </main>
   </body>
-</html> 
+</html>

--- a/cmd/tsidp/ui-style.css
+++ b/cmd/tsidp/ui-style.css
@@ -143,6 +143,10 @@ main {
 }
 
 /* Tables */
+.table-container {
+  overflow-x: auto;
+}
+
 table {
   width: 100%;
   border-spacing: 0;
@@ -318,6 +322,12 @@ tbody tr:hover {
   color: rgb(var(--color-success));
 }
 
+.alert-info {
+  background-color: rgb(var(--color-primary) / 0.1);
+  border: 1px solid rgb(var(--color-primary) / 0.3);
+  color: rgb(var(--color-primary) / 0.8);
+}
+
 .alert-error {
   background-color: rgb(var(--color-danger) / 0.1);
   border: 1px solid rgb(var(--color-danger) / 0.3);
@@ -410,6 +420,47 @@ tbody tr:hover {
   color: rgb(var(--color-gray-200));
 }
 
+/* OIDC Endpoints */
+.oidc-endpoints-header {
+  margin: 2rem 0 2rem 0;
+}
+
+.oidc-endpoints-header h2 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0 0 0.25rem 0;
+}
+
+.oidc-endpoints {
+  padding: 12px 16px;
+  border: 1px solid rgb(var(--color-gray-700));
+  border-radius: 8px;
+  background-color: rgb(var(--color-gray-800) / 0.5);
+}
+
+.oidc-endpoint h3 {
+  margin: 12px 0 0 6px;
+}
+
+.oidc-endpoint p {
+  margin: 6px 0 0 6px;
+  font-size: 14px;
+}
+
+.oidc-endpoint .alert {
+  margin: 12px 0 0 0;
+}
+
+.oidc-endpoint code {
+  font-family: "SF Mono", SFMono-Regular, ui-monospace, "DejaVu Sans Mono",
+    Menlo, Consolas, monospace;
+  font-size: 12px;
+  background-color: rgb(var(--color-gray-800));
+  padding: 2px 6px;
+  border-radius: 4px;
+  color: rgb(var(--color-gray-200));
+}
+
 /* Responsive design */
 @media (max-width: 768px) {
   .header-actions {
@@ -435,7 +486,7 @@ tbody tr:hover {
   table {
     font-size: 14px;
   }
-  
+
   td {
     padding: 8px 12px;
   }
@@ -443,4 +494,4 @@ tbody tr:hover {
   .client-id {
     font-size: 10px;
   }
-} 
+}

--- a/cmd/tsidp/ui.go
+++ b/cmd/tsidp/ui.go
@@ -81,8 +81,19 @@ func (s *idpServer) handleClientsList(w http.ResponseWriter, r *http.Request) {
 		return clients[i].ID < clients[j].ID
 	})
 
+	endpointDisplayData := endpointDisplayData{
+		AuthorizeEndpoint: s.endpoints.authorizeEndpoint,
+		TokenEndpoint:     s.endpoints.tokenEndpoint,
+		UserinfoEndpoint:  s.endpoints.userinfoEndpoint,
+	}
+
+	displayData := displayData{
+		Clients:   clients,
+		Endpoints: endpointDisplayData,
+	}
+
 	var buf bytes.Buffer
-	if err := listTmpl.Execute(&buf, clients); err != nil {
+	if err := listTmpl.Execute(&buf, displayData); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -266,6 +277,17 @@ type clientDisplayData struct {
 	IsEdit      bool
 	Success     string
 	Error       string
+}
+
+type endpointDisplayData struct {
+	AuthorizeEndpoint string
+	TokenEndpoint     string
+	UserinfoEndpoint  string
+}
+
+type displayData struct {
+	Clients   []clientDisplayData
+	Endpoints endpointDisplayData
 }
 
 func (s *idpServer) renderClientForm(w http.ResponseWriter, data clientDisplayData) error {


### PR DESCRIPTION
This commit creates a struct holding the oidc endpoints (authorize, token, userinfo) that ui.go uses to render a small informational box below the client list making the use of tsidp ednpoints easier. Additionally it fixes some small responsivness issues by allowing the client list table to scroll on overflow.

Fixes #16965

*P.S.* Prettier apparently did some formatting on the html file, hope you don't mind.