### PR TITLE
.github/workflows: reviewing depaware.txt is unnecessary

### DIFF
--- a/.github/workflows/request-dataplane-review.yml
+++ b/.github/workflows/request-dataplane-review.yml
@@ -8,6 +8,8 @@ on:
       - ".github/workflows/request-dataplane-review.yml"
       - "**/*derp*"
       - "**/derp*/**"
+    paths-ignore:
+      - "**/depaware.txt"
 
 jobs:
   request-dataplane-review:


### PR DESCRIPTION
@tailscale/dataplane almost never needs to review depaware.txt, when it is the only change to the DERP implementation.

Related #16372
Updates #cleanup