### PR TITLE
.github/workflows: reviewing depaware.txt is unnecessary

### DIFF
--- a/.github/workflows/request-dataplane-review.yml
+++ b/.github/workflows/request-dataplane-review.yml
@@ -8,8 +8,7 @@ on:
       - ".github/workflows/request-dataplane-review.yml"
       - "**/*derp*"
       - "**/derp*/**"
-    paths-ignore:
-      - "**/depaware.txt"
+      - "!**/depaware.txt"
 
 jobs:
   request-dataplane-review:


### PR DESCRIPTION
Apparently, #16989 introduced a bug in request-dataplane-review.yml:

https://github.com/tailscale/tailscale/actions/runs/17359671087
> you may only define one of `paths` and `paths-ignore` for a single event

When the GitHub Action’s YAML fails to parse, it doesn’t show up as a check failure for that PR. (sigh)

Related #16372
Updates #cleanup