### PR TITLE
ipn/ipnlocal: revert some locking changes ahead of release branch cut

### DIFF
--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -4299,7 +4299,7 @@ func (b *LocalBackend) SetPrefsForTest(newp *ipn.Prefs) {
 	}
 	unlock := b.lockAndGetUnlock()
 	defer unlock()
-	b.setPrefsLocked(newp)
+	b.setPrefsLockedOnEntry(newp, unlock)
 }
 
 type peerOptFunc func(*tailcfg.Node)

--- a/ipn/ipnlocal/profiles.go
+++ b/ipn/ipnlocal/profiles.go
@@ -180,7 +180,7 @@ func (pm *profileManager) SwitchToProfile(profile ipn.LoginProfileView) (cp ipn.
 		f(pm.currentProfile, pm.prefs, false)
 	}
 	// Do not call pm.extHost.NotifyProfileChange here; it is invoked in
-	// [LocalBackend.resetForProfileChangeLocked] after the netmap reset.
+	// [LocalBackend.resetForProfileChangeLockedOnEntry] after the netmap reset.
 	// TODO(nickkhyl): Consider moving it here (or into the stateChangeCb handler
 	// in [LocalBackend]) once the profile/node state, including the netmap,
 	// is actually tied to the current profile.
@@ -359,9 +359,9 @@ func (pm *profileManager) SetPrefs(prefsIn ipn.PrefsView, np ipn.NetworkProfile)
 	// where prefsIn is the previous profile's prefs with an updated Persist, LoggedOut,
 	// WantRunning and possibly other fields. This may not be the desired behavior.
 	//
-	// Additionally, LocalBackend doesn't treat it as a proper profile switch,
-	// meaning that [LocalBackend.resetForProfileChangeLocked] is not called and
-	// certain node/profile-specific state may not be reset as expected.
+	// Additionally, LocalBackend doesn't treat it as a proper profile switch, meaning that
+	// [LocalBackend.resetForProfileChangeLockedOnEntry] is not called and certain
+	// node/profile-specific state may not be reset as expected.
 	//
 	// However, [profileManager] notifies [ipnext.Extension]s about the profile change,
 	// so features migrated from LocalBackend to external packages should not be affected.
@@ -494,9 +494,10 @@ func (pm *profileManager) setProfilePrefsNoPermCheck(profile ipn.LoginProfileVie
 		oldPrefs := pm.prefs
 		pm.prefs = clonedPrefs
 
-		// Sadly, profile prefs can be changed in multiple ways.  It's pretty
-		// chaotic, and in many cases callers use unexported methods of the
-		// profile manager instead of going through [LocalBackend.setPrefsLocked]
+		// Sadly, profile prefs can be changed in multiple ways.
+		// It's pretty chaotic, and in many cases callers use
+		// unexported methods of the profile manager instead of
+		// going through [LocalBackend.setPrefsLockedOnEntry]
 		// or at least using [profileManager.SetPrefs].
 		//
 		// While we should definitely clean this up to improve


### PR DESCRIPTION
To reduce risk to the shortly-upcoming release, revert some of the incremental
changes to locking behaviour in the LocalBackend. We can reapply these after
the release to get exercise in unstable builds, but for now the schedule is
close.

This reverts the following commits:

b411ffb52f13 "ipn/ipnlocal: remove UnlockEarly from doSetHostinfoFilterServices"
9002e5fd6b8e "ipn/ipnlocal: remove an unnecessary unlock shortcut"
2fb9472990ea "ipn/ipnlocal: remove unnecessary usees of lockAndGetUnlock"
6c8fef961eab "ipn/ipnlocal: replace the LockedOnEntry pattern with conventional lock/unlock discipline (#16925)"

Updates #11649
Updates #15160

Change-Id: I6b1006c18fd1c2f1abfb847761e480a60957b883
Signed-off-by: M. J. Fromberger <fromberger@tailscale.com>
