### PR TITLE
ipn/ipnlocal: convert more tests to use policytest, de-global-ify

### DIFF
--- a/util/syspolicy/policytest/policytest.go
+++ b/util/syspolicy/policytest/policytest.go
@@ -19,7 +19,12 @@ import (
 // It is used for testing purposes to simulate policy client behavior.
 //
 // It panics if a value is Set with one type and then accessed with a different
-// expected type.
+// expected type and/or value. Some accessors such as GetPreferenceOption and
+// GetVisibility support either a ptype.PreferenceOption/ptype.Visibility in the
+// map, or the string representation as supported by their UnmarshalText
+// methods.
+//
+// The map value may be an error to return that error value from the accessor.
 type Config map[pkey.Key]any
 
 var _ policyclient.Client = Config{}
@@ -33,70 +38,108 @@ func (c *Config) Set(key pkey.Key, value any) {
 
 func (c Config) GetStringArray(key pkey.Key, defaultVal []string) ([]string, error) {
 	if val, ok := c[key]; ok {
-		if arr, ok := val.([]string); ok {
-			return arr, nil
+		switch val := val.(type) {
+		case []string:
+			return val, nil
+		case error:
+			return nil, val
+		default:
+			panic(fmt.Sprintf("key %s is not a []string; got %T", key, val))
 		}
-		panic(fmt.Sprintf("key %s is not a []string", key))
 	}
 	return defaultVal, nil
 }
 
 func (c Config) GetString(key pkey.Key, defaultVal string) (string, error) {
 	if val, ok := c[key]; ok {
-		if str, ok := val.(string); ok {
-			return str, nil
+		switch val := val.(type) {
+		case string:
+			return val, nil
+		case error:
+			return "", val
+		default:
+			panic(fmt.Sprintf("key %s is not a string; got %T", key, val))
 		}
-		panic(fmt.Sprintf("key %s is not a string", key))
 	}
 	return defaultVal, nil
 }
 
 func (c Config) GetBoolean(key pkey.Key, defaultVal bool) (bool, error) {
 	if val, ok := c[key]; ok {
-		if b, ok := val.(bool); ok {
-			return b, nil
+		switch val := val.(type) {
+		case bool:
+			return val, nil
+		case error:
+			return false, val
+		default:
+			panic(fmt.Sprintf("key %s is not a bool; got %T", key, val))
 		}
-		panic(fmt.Sprintf("key %s is not a bool", key))
 	}
 	return defaultVal, nil
 }
 
 func (c Config) GetUint64(key pkey.Key, defaultVal uint64) (uint64, error) {
 	if val, ok := c[key]; ok {
-		if u, ok := val.(uint64); ok {
-			return u, nil
+		switch val := val.(type) {
+		case uint64:
+			return val, nil
+		case error:
+			return 0, val
+		default:
+			panic(fmt.Sprintf("key %s is not a uint64; got %T", key, val))
 		}
-		panic(fmt.Sprintf("key %s is not a uint64", key))
 	}
 	return defaultVal, nil
 }
 
 func (c Config) GetDuration(key pkey.Key, defaultVal time.Duration) (time.Duration, error) {
 	if val, ok := c[key]; ok {
-		if d, ok := val.(time.Duration); ok {
-			return d, nil
+		switch val := val.(type) {
+		case time.Duration:
+			return val, nil
+		case error:
+			return 0, val
+		default:
+			panic(fmt.Sprintf("key %s is not a time.Duration; got %T", key, val))
 		}
-		panic(fmt.Sprintf("key %s is not a time.Duration", key))
 	}
 	return defaultVal, nil
 }
 
 func (c Config) GetPreferenceOption(key pkey.Key, defaultVal ptype.PreferenceOption) (ptype.PreferenceOption, error) {
 	if val, ok := c[key]; ok {
-		if p, ok := val.(ptype.PreferenceOption); ok {
-			return p, nil
+		switch val := val.(type) {
+		case ptype.PreferenceOption:
+			return val, nil
+		case error:
+			var zero ptype.PreferenceOption
+			return zero, val
+		case string:
+			var p ptype.PreferenceOption
+			err := p.UnmarshalText(([]byte)(val))
+			return p, err
+		default:
+			panic(fmt.Sprintf("key %s is not a ptype.PreferenceOption", key))
 		}
-		panic(fmt.Sprintf("key %s is not a ptype.PreferenceOption", key))
 	}
 	return defaultVal, nil
 }
 
 func (c Config) GetVisibility(key pkey.Key) (ptype.Visibility, error) {
 	if val, ok := c[key]; ok {
-		if p, ok := val.(ptype.Visibility); ok {
-			return p, nil
+		switch val := val.(type) {
+		case ptype.Visibility:
+			return val, nil
+		case error:
+			var zero ptype.Visibility
+			return zero, val
+		case string:
+			var p ptype.Visibility
+			err := p.UnmarshalText(([]byte)(val))
+			return p, err
+		default:
+			panic(fmt.Sprintf("key %s is not a ptype.Visibility", key))
 		}
-		panic(fmt.Sprintf("key %s is not a ptype.Visibility", key))
 	}
 	return ptype.Visibility(ptype.ShowChoiceByPolicy), nil
 }


### PR DESCRIPTION
Now that we have policytest and the policyclient.Client interface, we
can de-global-ify many of the tests, letting them run concurrently
with each other, and just removing global variable complexity.

This does ~half of the LocalBackend ones.

Updates #16998
