### PR TITLE
util/syspolicy/policyclient: always use no-op policyclient in tests by default

### DIFF
--- a/util/syspolicy/policyclient/policyclient.go
+++ b/util/syspolicy/policyclient/policyclient.go
@@ -11,6 +11,7 @@ import (
 
 	"tailscale.com/util/syspolicy/pkey"
 	"tailscale.com/util/syspolicy/ptype"
+	"tailscale.com/util/testenv"
 )
 
 // Client is the interface between code making questions about the system policy
@@ -68,8 +69,15 @@ type Client interface {
 
 // Get returns a non-nil [Client] implementation as a function of the
 // build tags. It returns a no-op implementation if the full syspolicy
-// package is omitted from the build.
+// package is omitted from the build, or in tests.
 func Get() Client {
+	if testenv.InTest() {
+		// This is a little redundant (the Windows implementation at least
+		// already does this) but it's here for redundancy and clarity, that we
+		// don't want to accidentally use the real system policy when running
+		// tests.
+		return NoPolicyClient{}
+	}
 	return client
 }
 


### PR DESCRIPTION
We should never use the real syspolicy implementation in tests by
default. (the machine's configuration shouldn't affect tests)

You either specify a test policy, or you get a no-op one.

Updates #16998
