### PR TITLE
cmd/k8s-operator: update connector example

### DIFF
--- a/cmd/k8s-operator/deploy/examples/connector.yaml
+++ b/cmd/k8s-operator/deploy/examples/connector.yaml
@@ -11,7 +11,8 @@ metadata:
 spec:
   tags:
   - "tag:prod"
-  hostname: ts-prod
+  hostnamePrefix: ts-prod
+  replicas: 2
   subnetRouter:
     advertiseRoutes:
     - "10.40.0.0/14"


### PR DESCRIPTION
This commit modifies the connector example to use the new hostname prefix and replicas fields