### PR TITLE
ipn/local: fix deadlock in initial suggested exit node query

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3141,7 +3141,7 @@ func (b *LocalBackend) WatchNotificationsAs(ctx context.Context, actor ipnauth.A
 			ini.Health = b.HealthTracker().CurrentState()
 		}
 		if mask&ipn.NotifyInitialSuggestedExitNode != 0 {
-			if en, err := b.SuggestExitNode(); err != nil {
+			if en, err := b.suggestExitNodeLocked(); err == nil {
 				ini.SuggestedExitNode = &en.ID
 			}
 		}


### PR DESCRIPTION
updates tailscale/corp#26369

b.mu is locked here.  We need to use suggestExitNodeLocked and err == nil, not err != nil