### PR TITLE
cmd/tailscaled: actually derive statedir from statepath

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -255,9 +255,9 @@ func main() {
 		log.Fatalf("--bird-socket is not supported on %s", runtime.GOOS)
 	}
 
-	// Only apply a default statepath when neither have been provided, so that a
-	// user may specify only --statedir if they wish.
 	if args.statepath == "" && args.statedir == "" {
+		// Only apply a default statepath when neither have been provided, so that a
+		// user may specify only --statedir if they wish.
 		if paths.MakeAutomaticStateDir() {
 			d := paths.DefaultTailscaledStateDir()
 			if d != "" {
@@ -269,6 +269,9 @@ func main() {
 		} else {
 			args.statepath = paths.DefaultTailscaledStateFile()
 		}
+	} else if args.statedir == "" && args.statepath != "" {
+		// When only a statepath is specified, derive statedir from statepath.
+		args.statedir = filepath.Dir(args.statepath)
 	}
 
 	if args.encryptState {


### PR DESCRIPTION
The documentation for `--statedir` says that if unspecified, it will be derived from `--state` if possible. It was not. In addition, if `--state` was specified, `--statedir` was not even defaulted to its usual default, so remained empty.

Now, if only `--state` is specified, `--statedir` is derived from it.

Updates #14025