### PR TITLE
cmd/tailscale/cli: Add a custom command for debugging node key expiry

### DIFF
--- a/cmd/tailscale/cli/cli.go
+++ b/cmd/tailscale/cli/cli.go
@@ -233,6 +233,7 @@ This CLI is still under active development. Commands and flags will
 change in the future.
 `),
 		Subcommands: nonNilCmds(
+			nodeKeyExpiryCmd,
 			upCmd,
 			downCmd,
 			setCmd,

--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -149,7 +149,7 @@ var geese = []string{"linux", "darwin", "windows", "freebsd"}
 // Also, issue 1880: advertise-exit-node was being ignored. Verify that all flags cause an edit.
 func TestUpdateMaskedPrefsFromUpFlag(t *testing.T) {
 	for _, goos := range geese {
-		var upArgs upArgsT
+		var upArgs nkeArgsT
 		fs := newUpFlagSet(goos, &upArgs, "up")
 		fs.VisitAll(func(f *flag.Flag) {
 			mp := new(ipn.MaskedPrefs)
@@ -624,7 +624,7 @@ func TestCheckForAccidentalSettingReverts(t *testing.T) {
 			if tt.goos != "" {
 				goos = tt.goos
 			}
-			var upArgs upArgsT
+			var upArgs nkeArgsT
 			flagSet := newUpFlagSet(goos, &upArgs, "up")
 			flags := CleanUpArgs(tt.flags)
 			flagSet.Parse(flags)
@@ -651,7 +651,7 @@ func TestCheckForAccidentalSettingReverts(t *testing.T) {
 	}
 }
 
-func upArgsFromOSArgs(goos string, flagArgs ...string) (args upArgsT) {
+func upArgsFromOSArgs(goos string, flagArgs ...string) (args nkeArgsT) {
 	fs := newUpFlagSet(goos, &args, "up")
 	fs.Parse(flagArgs) // populates args
 	return
@@ -660,7 +660,7 @@ func upArgsFromOSArgs(goos string, flagArgs ...string) (args upArgsT) {
 func TestPrefsFromUpArgs(t *testing.T) {
 	tests := []struct {
 		name     string
-		args     upArgsT
+		args     nkeArgsT
 		goos     string           // runtime.GOOS; empty means linux
 		st       *ipnstate.Status // or nil
 		want     *ipn.Prefs
@@ -720,70 +720,70 @@ func TestPrefsFromUpArgs(t *testing.T) {
 		},
 		{
 			name: "error_advertise_route_invalid_ip",
-			args: upArgsT{
+			args: nkeArgsT{
 				advertiseRoutes: "foo",
 			},
 			wantErr: `"foo" is not a valid IP address or CIDR prefix`,
 		},
 		{
 			name: "error_advertise_route_unmasked_bits",
-			args: upArgsT{
+			args: nkeArgsT{
 				advertiseRoutes: "1.2.3.4/16",
 			},
 			wantErr: `1.2.3.4/16 has non-address bits set; expected 1.2.0.0/16`,
 		},
 		{
 			name: "error_exit_node_bad_ip",
-			args: upArgsT{
+			args: nkeArgsT{
 				exitNodeIP: "foo",
 			},
 			wantErr: `invalid value "foo" for --exit-node; must be IP or unique node name`,
 		},
 		{
 			name: "error_exit_node_allow_lan_without_exit_node",
-			args: upArgsT{
+			args: nkeArgsT{
 				exitNodeAllowLANAccess: true,
 			},
 			wantErr: `--exit-node-allow-lan-access can only be used with --exit-node`,
 		},
 		{
 			name: "error_tag_prefix",
-			args: upArgsT{
+			args: nkeArgsT{
 				advertiseTags: "foo",
 			},
 			wantErr: `tag: "foo": tags must start with 'tag:'`,
 		},
 		{
 			name: "error_long_hostname",
-			args: upArgsT{
+			args: nkeArgsT{
 				hostname: strings.Repeat(strings.Repeat("a", 63)+".", 4),
 			},
 			wantErr: `"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" is too long to be a DNS name`,
 		},
 		{
 			name: "error_long_label",
-			args: upArgsT{
+			args: nkeArgsT{
 				hostname: strings.Repeat("a", 64) + ".example.com",
 			},
 			wantErr: `"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" is not a valid DNS label`,
 		},
 		{
 			name: "error_linux_netfilter_empty",
-			args: upArgsT{
+			args: nkeArgsT{
 				netfilterMode: "",
 			},
 			wantErr: `invalid value --netfilter-mode=""`,
 		},
 		{
 			name: "error_linux_netfilter_bogus",
-			args: upArgsT{
+			args: nkeArgsT{
 				netfilterMode: "bogus",
 			},
 			wantErr: `invalid value --netfilter-mode="bogus"`,
 		},
 		{
 			name: "error_exit_node_ip_is_self_ip",
-			args: upArgsT{
+			args: nkeArgsT{
 				exitNodeIP: "100.105.106.107",
 			},
 			st: &ipnstate.Status{
@@ -794,7 +794,7 @@ func TestPrefsFromUpArgs(t *testing.T) {
 		{
 			name: "warn_linux_netfilter_nodivert",
 			goos: "linux",
-			args: upArgsT{
+			args: nkeArgsT{
 				netfilterMode: "nodivert",
 			},
 			wantWarn: "netfilter=nodivert; add iptables calls to ts-* chains manually.",
@@ -811,7 +811,7 @@ func TestPrefsFromUpArgs(t *testing.T) {
 		{
 			name: "warn_linux_netfilter_off",
 			goos: "linux",
-			args: upArgsT{
+			args: nkeArgsT{
 				netfilterMode: "off",
 			},
 			wantWarn: "netfilter=off; configure iptables yourself.",
@@ -828,7 +828,7 @@ func TestPrefsFromUpArgs(t *testing.T) {
 		{
 			name: "via_route_good",
 			goos: "linux",
-			args: upArgsT{
+			args: nkeArgsT{
 				advertiseRoutes: "fd7a:115c:a1e0:b1a::bb:10.0.0.0/112",
 				netfilterMode:   "off",
 			},
@@ -847,7 +847,7 @@ func TestPrefsFromUpArgs(t *testing.T) {
 		{
 			name: "via_route_good_16_bit",
 			goos: "linux",
-			args: upArgsT{
+			args: nkeArgsT{
 				advertiseRoutes: "fd7a:115c:a1e0:b1a::aabb:10.0.0.0/112",
 				netfilterMode:   "off",
 			},
@@ -866,7 +866,7 @@ func TestPrefsFromUpArgs(t *testing.T) {
 		{
 			name: "via_route_short_prefix",
 			goos: "linux",
-			args: upArgsT{
+			args: nkeArgsT{
 				advertiseRoutes: "fd7a:115c:a1e0:b1a::/64",
 				netfilterMode:   "off",
 			},
@@ -875,7 +875,7 @@ func TestPrefsFromUpArgs(t *testing.T) {
 		{
 			name: "via_route_short_reserved_siteid",
 			goos: "linux",
-			args: upArgsT{
+			args: nkeArgsT{
 				advertiseRoutes: "fd7a:115c:a1e0:b1a:1234:5678::/112",
 				netfilterMode:   "off",
 			},
@@ -981,7 +981,7 @@ func TestPrefFlagMapping(t *testing.T) {
 
 func TestFlagAppliesToOS(t *testing.T) {
 	for _, goos := range geese {
-		var upArgs upArgsT
+		var upArgs nkeArgsT
 		fs := newUpFlagSet(goos, &upArgs, "up")
 		fs.VisitAll(func(f *flag.Flag) {
 			if !flagAppliesToOS(f.Name, goos) {
@@ -1172,7 +1172,7 @@ func TestUpdatePrefs(t *testing.T) {
 					t.Errorf("RunSSH not set to false")
 				}
 			},
-			env: upCheckEnv{backendState: "Running", upArgs: upArgsT{
+			env: upCheckEnv{backendState: "Running", upArgs: nkeArgsT{
 				runSSH: true,
 			}},
 		},

--- a/cmd/tailscale/cli/node_key_expiry.go
+++ b/cmd/tailscale/cli/node_key_expiry.go
@@ -1,0 +1,248 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"net/netip"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+	qrcode "github.com/skip2/go-qrcode"
+	"tailscale.com/ipn"
+	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/types/logger"
+	"tailscale.com/util/syspolicy/policyclient"
+	"tailscale.com/version/distro"
+)
+
+var nodeKeyExpiryCmd = &ffcli.Command{
+	Name:       "node-key-expiry",
+	ShortUsage: "tailscale node-key-expiry [flags]",
+	ShortHelp:  "Experimental command for testing seamless key expiry",
+
+	LongHelp: strings.TrimSpace("Experimental command for testing seamless key expiry"),
+	FlagSet:  upFlagSet,
+	Exec: func(ctx context.Context, args []string) error {
+		return runNke(ctx, "node-key-expiry", args, nkeArgsGlobal)
+	},
+}
+
+var nkeArgsGlobal nkeArgsT
+
+var nodeKeyExpiryFlagSet = newNkeFlagSet(effectiveGOOS(), &nkeArgsGlobal, "node-key-expiry")
+
+// newNodeKeyExpiryFlagSet returns a new flag set for the "node-key-expiry" command.
+func newNodeKeyExpiryFlagSet(nkeArgs *upArgsT, cmd string) *flag.FlagSet {
+	nkef := newFlagSet(cmd)
+
+	nkef.StringVar(&nkeArgs.authKeyOrFile, "auth-key", "", `node authorization key; if it begins with "file:", then it's a path to a file containing the authkey`)
+	nkef.StringVar(&nkeArgs.server, "login-server", ipn.DefaultControlURL, "base URL of control server")
+	nkef.DurationVar(&nkeArgs.timeout, "timeout", 0, "maximum amount of time to wait for tailscaled to enter a Running state; default (0s) blocks forever")
+	nkef.BoolVar(&nkeArgs.forceReauth, "force-reauth", false, "force reauthentication (WARNING: this will bring down the Tailscale connection and thus should not be done remotely over SSH or RDP)")
+	registerAcceptRiskFlag(nkef, &nkeArgs.acceptedRisks)
+
+	return nkef
+}
+
+func newNkeFlagSet(goos string, upArgs *nkeArgsT, cmd string) *flag.FlagSet {
+	upf := newFlagSet(cmd)
+
+	// When adding new flags, prefer to put them under "tailscale set" instead
+	// of here. Setting preferences via "tailscale up" is deprecated.
+	upf.BoolVar(&upArgs.qr, "qr", false, "show QR code for login URLs")
+	upf.StringVar(&upArgs.authKeyOrFile, "auth-key", "", `node authorization key; if it begins with "file:", then it's a path to a file containing the authkey`)
+
+	upf.StringVar(&upArgs.server, "login-server", ipn.DefaultControlURL, "base URL of control server")
+
+	upf.BoolVar(&upArgs.forceReauth, "force-reauth", false, "force reauthentication (WARNING: this will bring down the Tailscale connection and thus should not be done remotely over SSH or RDP)")
+	registerAcceptRiskFlag(upf, &upArgs.acceptedRisks)
+
+	return upf
+}
+
+// upArgsT is the type of upArgs, the argument struct for `tailscale up`.
+// As of 2024-10-08, upArgsT is frozen and no new arguments should be
+// added to it. Add new arguments to setArgsT instead.
+type nkeArgsT struct {
+	qr            bool
+	server        string
+	forceReauth   bool
+	authKeyOrFile string // "secret" or "file:/path/to/secret"
+	acceptedRisks string
+}
+
+func runNke(ctx context.Context, cmd string, args []string, upArgs nkeArgsT) (retErr error) {
+	st, err := localClient.Status(ctx)
+	if err != nil {
+		return fixTailscaledConnectError(err)
+	}
+	origAuthURL := st.AuthURL
+
+	// printAuthURL reports whether we should print out the
+	// provided auth URL from an IPN notify.
+	printAuthURL := func(url string) bool {
+		if url == "" {
+			// Probably unnecessary but we used to have a bug where tailscaled
+			// could send an empty URL over the IPN bus. ~Harmless to keep.
+			return false
+		}
+		if upArgs.authKeyOrFile != "" {
+			// Issue 1755: when using an authkey, don't
+			// show an authURL that might still be pending
+			// from a previous non-completed interactive
+			// login.
+			return false
+		}
+		if upArgs.forceReauth && url == origAuthURL {
+			return false
+		}
+		return true
+	}
+	prefs, err := prefsFromNkeArgs(upArgs, warnf, st, effectiveGOOS())
+	if err != nil {
+		fatalf("%s", err)
+	}
+
+	defer func() {
+		if retErr == nil {
+			checkUpWarnings(ctx)
+		}
+	}()
+
+	watchCtx, cancelWatch := context.WithCancel(ctx)
+	defer cancelWatch()
+
+	go func() {
+		interrupt := make(chan os.Signal, 1)
+		signal.Notify(interrupt, syscall.SIGINT, syscall.SIGTERM)
+		select {
+		case <-interrupt:
+			cancelWatch()
+		case <-watchCtx.Done():
+		}
+	}()
+
+	running := make(chan bool, 1) // gets value once in state ipn.Running
+	watchErr := make(chan error, 1)
+
+	if err := localClient.CheckPrefs(ctx, prefs); err != nil {
+		return err
+	}
+
+	authKey, err := upArgs.getAuthKey()
+	if err != nil {
+		return err
+	}
+	err = localClient.Start(ctx, ipn.Options{
+		AuthKey:     authKey,
+		UpdatePrefs: prefs,
+	})
+	if err != nil {
+		return err
+	}
+	if upArgs.forceReauth || !st.HaveNodeKey {
+		err := localClient.StartLoginInteractive(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	watcher, err := localClient.WatchIPNBus(watchCtx, ipn.NotifyInitialState)
+	if err != nil {
+		return err
+	}
+	defer watcher.Close()
+
+	go func() {
+		var lastURLPrinted string
+
+		for {
+			n, err := watcher.Next()
+			if err != nil {
+				watchErr <- err
+				return
+			}
+			if n.ErrMessage != nil {
+				msg := *n.ErrMessage
+				fatalf("backend error: %v\n", msg)
+			}
+			if s := n.State; s != nil {
+				switch *s {
+				case ipn.NeedsMachineAuth:
+					fmt.Fprintf(Stderr, "\nTo approve your machine, visit (as admin):\n\n\t%s\n\n", prefs.AdminPageURL(policyclient.Get()))
+				case ipn.Running:
+					// Done full authentication process
+					// Only need to print an update if we printed the "please click" message earlier.
+					fmt.Fprintf(Stderr, "Success.\n")
+					select {
+					case running <- true:
+					default:
+					}
+					cancelWatch()
+				}
+			}
+			if url := n.BrowseToURL; url != nil {
+				authURL := *url
+				if !printAuthURL(authURL) || authURL == lastURLPrinted {
+					continue
+				}
+				lastURLPrinted = authURL
+
+				fmt.Fprintf(Stderr, "\nTo authenticate, visit:\n\n\t%s\n\n", authURL)
+				if upArgs.qr {
+					q, err := qrcode.New(authURL, qrcode.Medium)
+					if err != nil {
+						log.Printf("QR code error: %v", err)
+					} else {
+						fmt.Fprintf(Stderr, "%s\n", q.ToString(false))
+					}
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (a nkeArgsT) getAuthKey() (string, error) {
+	v := a.authKeyOrFile
+	if file, ok := strings.CutPrefix(v, "file:"); ok {
+		b, err := os.ReadFile(file)
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(string(b)), nil
+	}
+	return v, nil
+}
+
+type nkeCheckEnv struct {
+	goos          string
+	user          string
+	flagSet       *flag.FlagSet
+	upArgs        nkeArgsT
+	backendState  string
+	curExitNodeIP netip.Addr
+	distro        distro.Distro
+}
+
+// prefsFromUpArgs returns the ipn.Prefs for the provided args.
+//
+// Note that the parameters upArgs and warnf are named intentionally
+// to shadow the globals to prevent accidental misuse of them. This
+// function exists for testing and should have no side effects or
+// outside interactions (e.g. no making Tailscale LocalAPI calls).
+func prefsFromNkeArgs(upArgs nkeArgsT, warnf logger.Logf, st *ipnstate.Status, goos string) (*ipn.Prefs, error) {
+	prefs := ipn.NewPrefs()
+	prefs.ControlURL = upArgs.server
+	prefs.WantRunning = true
+	return prefs, nil
+}

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -87,9 +87,9 @@ var upFlagSet = newUpFlagSet(effectiveGOOS(), &upArgsGlobal, "up")
 
 // newUpFlagSet returns a new flag set for the "up" and "login" commands.
 func newUpFlagSet(goos string, upArgs *upArgsT, cmd string) *flag.FlagSet {
-	if cmd != "up" && cmd != "login" {
-		panic("cmd must be up or login")
-	}
+	// if cmd != "up" && cmd != "login" {
+	// 	panic("cmd must be up or login")
+	// }
 	upf := newFlagSet(cmd)
 
 	// When adding new flags, prefer to put them under "tailscale set" instead
@@ -129,7 +129,7 @@ func newUpFlagSet(goos string, upArgs *upArgsT, cmd string) *flag.FlagSet {
 		upf.StringVar(&upArgs.profileName, "nickname", "", "short name for the account")
 	}
 
-	if cmd == "up" {
+	if cmd == "up" || cmd == "node-key-expiry" {
 		// Some flags are only for "up", not "login".
 		upf.BoolVar(&upArgs.json, "json", false, "output in JSON format (WARNING: format subject to change)")
 		upf.BoolVar(&upArgs.reset, "reset", false, "reset unspecified settings to their default values")


### PR DESCRIPTION
**Do not merge.** This adds a custom CLI command `tailscale node-key-expiry` which is a cut-down version of `tailscale up` to help us test and debug seamless key renewal in the CLI. It isn't intended for merging, just as a place for us to experiment.

Updates https://github.com/tailscale/corp/issues/31476