### PR TITLE
prober: include current probe results in run-probe text response

### DIFF
--- a/prober/prober.go
+++ b/prober/prober.go
@@ -570,9 +570,9 @@ func (p *Prober) RunHandler(w http.ResponseWriter, r *http.Request) error {
 		return nil
 	}
 
-	stats := fmt.Sprintf("Last %d probes: success rate %d%%, median latency %v\n",
-		len(prevInfo.RecentResults),
-		int(prevInfo.RecentSuccessRatio()*100), prevInfo.RecentMedianLatency())
+	stats := fmt.Sprintf("Last %d probes (including this one): success rate %d%%, median latency %v\n",
+		len(info.RecentResults),
+		int(info.RecentSuccessRatio()*100), info.RecentMedianLatency())
 	if err != nil {
 		return tsweb.Error(respStatus, fmt.Sprintf("Probe failed: %s\n%s", err.Error(), stats), err)
 	}


### PR DESCRIPTION
It was a bit confusing that provided history did not include the current probe results.

Updates tailscale/corp#20583