### PR TITLE
utils/expvarx, tstest/integration: mark two tests as known flaky

### DIFF
--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -170,6 +170,7 @@ func TestControlKnobs(t *testing.T) {
 }
 
 func TestCollectPanic(t *testing.T) {
+	flakytest.Mark(t, "https://github.com/tailscale/tailscale/issues/15865")
 	tstest.Shard(t)
 	tstest.Parallel(t)
 	env := NewTestEnv(t)

--- a/util/expvarx/expvarx_test.go
+++ b/util/expvarx/expvarx_test.go
@@ -10,6 +10,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"tailscale.com/cmd/testwrapper/flakytest"
 )
 
 func ExampleNewSafeFunc() {
@@ -52,6 +54,7 @@ func ExampleNewSafeFunc() {
 }
 
 func TestSafeFuncHappyPath(t *testing.T) {
+	flakytest.Mark(t, "https://github.com/tailscale/tailscale/issues/15348")
 	var count int
 	f := NewSafeFunc(expvar.Func(func() any {
 		count++


### PR DESCRIPTION
Updates #15348