### PR TITLE
tsnet: expose logtail's Logf method

### DIFF
--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -493,6 +493,16 @@ func (s *Server) TailscaleIPs() (ip4, ip6 netip.Addr) {
 	return ip4, ip6
 }
 
+// Logtailf returns a [logger.Logf] that outputs to Tailscale's logging service and will be only visible to Tailscale's
+// support team. Logs written there cannot be retrieved by the user. This method always returns a non-nil value.
+func (s *Server) Logtailf() logger.Logf {
+	if s.logtail == nil {
+		return logger.Discard
+	}
+
+	return s.logtail.Logf
+}
+
 func (s *Server) getAuthKey() string {
 	if v := s.AuthKey; v != "" {
 		return v


### PR DESCRIPTION
This commit adds a new method to the tsnet.Server type named `Logtailf` that returns the underlying logtail instance's Logf method.

This is intended to be used within the Kubernetes operator to wrap its existing logger in a way such that operator specific logs can also be sent to control for support & debugging purposes.

Updates https://github.com/tailscale/corp/issues/32037