### PR TITLE
util/expvarx: deflake TestSafeFuncHappyPath with synctest

### DIFF
--- a/util/expvarx/expvarx_test.go
+++ b/util/expvarx/expvarx_test.go
@@ -9,9 +9,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
-
-	"tailscale.com/cmd/testwrapper/flakytest"
 )
 
 func ExampleNewSafeFunc() {
@@ -54,19 +53,21 @@ func ExampleNewSafeFunc() {
 }
 
 func TestSafeFuncHappyPath(t *testing.T) {
-	flakytest.Mark(t, "https://github.com/tailscale/tailscale/issues/15348")
-	var count int
-	f := NewSafeFunc(expvar.Func(func() any {
-		count++
-		return count
-	}), time.Millisecond, nil)
+	synctest.Test(t, func(t *testing.T) {
+		var count int
+		f := NewSafeFunc(expvar.Func(func() any {
+			count++
+			return count
+		}), time.Second, nil)
 
-	if got, want := f.Value(), 1; got != want {
-		t.Errorf("got %v, want %v", got, want)
-	}
-	if got, want := f.Value(), 2; got != want {
-		t.Errorf("got %v, want %v", got, want)
-	}
+		if got, want := f.Value(), 1; got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+		time.Sleep(5 * time.Second) // (fake time in synctest)
+		if got, want := f.Value(), 2; got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
 }
 
 func TestSafeFuncSlow(t *testing.T) {


### PR DESCRIPTION
I probably could've deflaked this without synctest, but might as well use
it now that Go 1.25 has it.

Fixes #15348
