### PR TITLE
cmd/tailscale/cli: wait for a force-reauth to complete with `tailscale up`

### DIFF
--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -337,14 +337,6 @@ func TestOneNodeUpAuth(t *testing.T) {
 			t.Run(fmt.Sprintf("%s-seamless-%t", tt.name, useSeamlessKeyRenewal), func(t *testing.T) {
 				tstest.Parallel(t)
 
-				// TODO(alexc): This test is failing because of a bug in `tailscale up` where
-				// it waits for ipn to enter the "Running" state.  If we're already logged in
-				// and running, this completes immediately, before we've had a chance to show
-				// the user the auth URL.
-				if tt.name == "up-with-force-reauth-after-login" {
-					t.Skip()
-				}
-
 				env := NewTestEnv(t, ConfigureControl(
 					func(control *testcontrol.Server) {
 						if tt.authKey != "" {


### PR DESCRIPTION
Previously the `up` command would only wait to receive a message from the IPN bus that the status is `Running`.  This breaks seamless key renewal, because IPN reports the running status and the CLI exits immediately, before it's had a chance to show you a new authentication URL.

Now we distinguish between two cases:

*   Without `--force-reauth` -- we behave as before, returning as soon as we get a `Running` status
*   With `--force-reauth` -- we wait to get a ~`LoginFinished`~ `NodeKeyChanged` notification from IPN, which confirms that the user completed the login flow

Updates tailscale/corp#31476

I tested this by running a local build against prod control and tested `tailscale up`, `tailscale up --force-reauth` and `tailscale down` with seamless both enabled and disabled.