### PR TITLE
cmd/tailscaled: add disabled debug file to force reflect for binary size experiments

### DIFF
--- a/cmd/tailscaled/debug_forcereflect.go
+++ b/cmd/tailscaled/debug_forcereflect.go
@@ -1,0 +1,26 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build ts_debug_forcereflect
+
+// This file exists for benchmarking binary sizes. When the build tag is
+// enabled, it forces use of part of the reflect package that makes the Go
+// linker go into conservative retention mode where its deadcode pass can't
+// eliminate exported method.
+
+package main
+
+import (
+	"reflect"
+	"time"
+)
+
+func init() {
+	// See Go's src/cmd/compile/internal/walk/expr.go:usemethod for
+	// why this is isn't a const.
+	name := []byte("Bar")
+	if time.Now().Unix()&1 == 0 {
+		name[0] = 'X'
+	}
+	_, _ = reflect.TypeOf(12).MethodByName(string(name))
+}


### PR DESCRIPTION
This adds a file that's not compiled by default that exists just to
make it easier to do binary size checks, probing what a binary would
be like if it included reflect methods (as used by html/template, etc).

As an example, once tailscaled uses reflect.Type.MethodByName(non-const-string) anywhere,
the build jumps up by 14.5 MB:

    $ GOOS=linux GOARCH=amd64 ./tool/go build -tags=ts_include_cli,ts_omit_webclient,ts_omit_systray,ts_omit_debugeventbus -o before ./cmd/tailscaled

    $ GOOS=linux GOARCH=amd64 ./tool/go build -tags=ts_include_cli,ts_omit_webclient,ts_omit_systray,ts_omit_debugeventbus,ts_debug_forcereflect -o after ./cmd/tailscaled

    $ ls -l before after
    -rwxr-xr-x@ 1 bradfitz  staff  41011861 Sep  9 07:28 before
    -rwxr-xr-x@ 1 bradfitz  staff  55610948 Sep  9 07:29 after

This is particularly pronounced with large deps like the AWS SDK. If you compare using ts_omit_aws:

    -rwxr-xr-x@ 1 bradfitz  staff  38284771 Sep  9 07:40 no-aws-no-reflect
    -rwxr-xr-x@ 1 bradfitz  staff  45546491 Sep  9 07:41 no-aws-with-reflect

That means adding AWS to a non-reflect binary adds 2.7 MB but adding
AWS to a reflect binary adds 10 MB.

Updates #17063
Updates #12614
