### PR TITLE
cmd/tailscale: QR codes are now quarter-sized

### DIFF
--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -658,7 +658,7 @@ func runUp(ctx context.Context, cmd string, args []string, upArgs upArgsT) (retE
 						if err != nil {
 							log.Printf("QR code error: %v", err)
 						} else {
-							fmt.Fprintf(Stderr, "%s\n", q.ToString(false))
+							fmt.Fprintf(Stderr, "%s\n", q.ToSmallString(false))
 						}
 					}
 				}


### PR DESCRIPTION
When running `tailscale up --qr`, the QR code is rendered using two full blocks ██ to form a square pixel. This is a problem for people with smaller terminals, because the output is 37 lines high. All modern terminals support half block characters, like ▀ and ▄, which only takes 19 lines and can easily fit in a regular terminal window.

For example, https://login.tailscale.com/a/0123456789 is now rendered:

```
█████████████████████████████████████
█████████████████████████████████████
████ ▄▄▄▄▄ █ ▀▀   █▄▀▀ ▄ █ ▄▄▄▄▄ ████
████ █   █ █▀ ▄▄▄█▀█▄▀  ▄█ █   █ ████
████ █▄▄▄█ ██▄ ▄▀▀▄▄ ▀▀ ▀█ █▄▄▄█ ████
████▄▄▄▄▄▄▄█ ▀▄▀ █▄▀▄▀▄█ █▄▄▄▄▄▄▄████
████▄█▄ ▀▄▄▄█▀▄█▀ ▀▄ ▄  ▀▀ ▀▀▄█▄ ████
████▄▀▄▀▄█▄ █ ▄▄▄▄█▀██▀██▄▄█▀█▄▄▀████
████▄█▀ ▀ ▄█▄▄▀▄▀█ ▄ ▄█▀█▄▀██▄ ▀▀████
█████▀ ▀  ▄▀▀▀▀▄▀▄▀▀ ▄▄ ▄ ▀  █▄ ▄████
██████ ▄▄█▄▄▄▄▄▀ █ ▄▀▀▄█▀ █ ▄ ▀ █████
████▄█▄▄  ▄▀ ▀██▀  ▄█▀▀████▄▀█ ██████
█████▄▄▄█▄▄▄▀▀ █▄▄▄▄▄ ▀█ ▄▄▄   ▀▀████
████ ▄▄▄▄▄ █ ██▄ ▀ █▀█ ▄ █▄█  █▄█████
████ █   █ █▀  █ ▀█▄▄ █▀  ▄  ▀▄▀▄████
████ █▄▄▄█ █▄█▀█▄▀██▀██▄ ▀█▄▀▀▄▀▄████
████▄▄▄▄▄▄▄█▄▄███▄▄▄███▄▄▄██▄██▄█████
█████████████████████████████████████
▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
```

Whereas it used to look like this:

```
██████████████████████████████████████████████████████████████████████████
██████████████████████████████████████████████████████████████████████████
██████████████████████████████████████████████████████████████████████████
██████████████████████████████████████████████████████████████████████████
████████              ██  ████      ██  ████      ██              ████████
████████  ██████████  ██            ████      ██  ██  ██████████  ████████
████████  ██      ██  ████        ██████  ██      ██  ██      ██  ████████
████████  ██      ██  ██    ████████  ████      ████  ██      ██  ████████
████████  ██      ██  ████      ████      ████  ████  ██      ██  ████████
████████  ██████████  ██████  ██    ████          ██  ██████████  ████████
████████              ██  ██  ██  ██  ██  ██  ██  ██              ████████
████████████████████████    ██    ████  ██  ████  ████████████████████████
████████  ██    ██      ████  ████  ██          ████  ████  ██    ████████
██████████████    ████████  ████      ██  ██              ██████  ████████
████████  ██  ██  ██    ██          ██████████████    ██████    ██████████
██████████  ██  ██████  ██  ██████████  ████  ██████████  ██████  ████████
████████  ████  ██    ██    ██  ████        ██████  ██████    ████████████
████████████        ████████  ██  ██  ██  ████  ████  ██████      ████████
████████████  ██      ████████  ██  ████            ██    ██      ████████
██████████          ██        ██  ██      ████  ██        ████  ██████████
████████████      ██          ██  ██    ████  ████  ██      ██  ██████████
████████████  ████████████████    ██  ██    ████    ██  ██      ██████████
████████  ██          ██  ████████      ██████████████  ████  ████████████
████████████████    ██      ████      ████    ██████████  ██  ████████████
██████████      ██      ████  ██            ████              ████████████
████████████████████████      ████████████    ██  ██████          ████████
████████              ██  ████    ██  ██████      ██  ██    ██  ██████████
████████  ██████████  ██  ██████      ██  ██  ██  ██████    ██████████████
████████  ██      ██  ████    ██  ████      ████          ██  ██  ████████
████████  ██      ██  ██      ██    ██████  ██      ██      ██  ██████████
████████  ██      ██  ██  ██████  ████████████    ████  ████  ██  ████████
████████  ██████████  ██████  ████  ████  ██████    ████    ██  ██████████
████████              ██    ██████      ██████      ████  ████  ██████████
██████████████████████████████████████████████████████████████████████████
██████████████████████████████████████████████████████████████████████████
██████████████████████████████████████████████████████████████████████████
██████████████████████████████████████████████████████████████████████████
```

Fixes #17083