### PR TITLE
health,ipn/ipnlocal: introduce eventbus in heath.Tracker

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -406,6 +406,7 @@ func run() (err error) {
 	// Install an event bus as early as possible, so that it's
 	// available universally when setting up everything else.
 	sys := tsd.NewSystem()
+	defer sys.Bus.Get().Close()
 
 	// Parse config, if specified, to fail early if it's invalid.
 	var conf *conffile.Config

--- a/health/health.go
+++ b/health/health.go
@@ -25,6 +25,7 @@ import (
 	"tailscale.com/tstime"
 	"tailscale.com/types/opt"
 	"tailscale.com/util/cibuild"
+	"tailscale.com/util/eventbus"
 	"tailscale.com/util/mak"
 	"tailscale.com/util/multierr"
 	"tailscale.com/util/set"
@@ -117,6 +118,9 @@ type Tracker struct {
 	localLogConfigErr           error
 	tlsConnectionErrors         map[string]error // map[ServerName]error
 	metricHealthMessage         *metrics.MultiLabelMap[metricHealthMessageLabel]
+
+	eventClient *eventbus.Client
+	changePub   *eventbus.Publisher[Change]
 }
 
 func (t *Tracker) now() time.Time {
@@ -131,6 +135,23 @@ func (t *Tracker) clock() tstime.Clock {
 		return t.testClock
 	}
 	return tstime.StdClock{}
+}
+
+// InitOnce exists to set up the eventClient and the publisher.
+// The method can be called on nil.
+// The method should not be called multiple times, and will panic if that happens.
+func (t *Tracker) InitOnce(bus *eventbus.Bus) {
+	if bus == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.eventClient != nil {
+		panic("eventClient already set")
+	}
+
+	t.eventClient = bus.Client("health.Tracker")
+	t.changePub = eventbus.Publish[Change](t.eventClient)
 }
 
 // Subsystem is the name of a subsystem whose health can be monitored.
@@ -418,6 +439,28 @@ func (t *Tracker) setUnhealthyLocked(w *Warnable, args Args) {
 			Warnable:        w,
 			UnhealthyState:  w.unhealthyState(ws),
 		}
+		// Eventbus publisher
+		if t.changePub != nil {
+			if w.IsVisible(ws, t.now) {
+				t.changePub.Publish(change)
+			} else {
+				visibleIn := w.TimeToVisible - t.now().Sub(brokenSince)
+				tc := t.clock().AfterFunc(visibleIn, func() {
+					t.mu.Lock()
+					defer t.mu.Unlock()
+					// Check if the Warnable is still unhealthy, as it could have become healthy between the time
+					// the timer was set for and the time it was executed.
+					if t.warnableVal[w] != nil {
+						t.changePub.Publish(change)
+						delete(t.pendingVisibleTimers, w)
+					}
+				})
+				mak.Set(&t.pendingVisibleTimers, w, tc)
+			}
+		}
+
+		// Direct callbacks
+		// TODO(cmol): Remove once all watchers have been moved to events
 		for _, cb := range t.watchers {
 			// If the Warnable has been unhealthy for more than its TimeToVisible, the callback should be
 			// executed immediately. Otherwise, the callback should be enqueued to run once the Warnable
@@ -473,7 +516,11 @@ func (t *Tracker) setHealthyLocked(w *Warnable) {
 		WarnableChanged: true,
 		Warnable:        w,
 	}
+	if t.changePub != nil {
+		t.changePub.Publish(change)
+	}
 	for _, cb := range t.watchers {
+		// TODO(cmol): Remove once all watchers have been moved to events
 		cb(change)
 	}
 }
@@ -484,7 +531,11 @@ func (t *Tracker) notifyWatchersControlChangedLocked() {
 	change := Change{
 		ControlHealthChanged: true,
 	}
+	if t.changePub != nil {
+		t.changePub.Publish(change)
+	}
 	for _, cb := range t.watchers {
+		// TODO(cmol): Remove once all watchers have been moved to events
 		cb(change)
 	}
 }

--- a/health/health_test.go
+++ b/health/health_test.go
@@ -18,9 +18,30 @@ import (
 	"tailscale.com/tstest"
 	"tailscale.com/tstime"
 	"tailscale.com/types/opt"
+	"tailscale.com/util/eventbus"
+	"tailscale.com/util/eventbus/eventbustest"
 	"tailscale.com/util/usermetric"
 	"tailscale.com/version"
 )
+
+func compareChange(c Change) func(c Change) (bool, error) {
+	return func(cEv Change) (bool, error) {
+		if cEv.ControlHealthChanged != c.ControlHealthChanged {
+			return false, fmt.Errorf("expected ControlHealthChanged %t, got %t", c.ControlHealthChanged, cEv.ControlHealthChanged)
+		}
+		if cEv.WarnableChanged != c.WarnableChanged {
+			return false, fmt.Errorf("expected WarnableChanged %t, got %t", c.WarnableChanged, cEv.WarnableChanged)
+		}
+		if c.Warnable != nil && (cEv.Warnable == nil || cEv.Warnable != c.Warnable) {
+			return false, fmt.Errorf("expected Warnable %+v, got %+v", c.Warnable, cEv.Warnable)
+		}
+
+		if c.UnhealthyState != nil && (cEv.UnhealthyState == nil || !maps.Equal(c.UnhealthyState.Args, cEv.UnhealthyState.Args)) {
+			return false, fmt.Errorf("expected UnhealthyState %+v, got %+v", c.UnhealthyState, cEv.UnhealthyState)
+		}
+		return true, nil
+	}
+}
 
 func TestAppendWarnableDebugFlags(t *testing.T) {
 	var tr Tracker
@@ -69,6 +90,9 @@ func TestNilMethodsDontCrash(t *testing.T) {
 
 func TestSetUnhealthyWithDuplicateThenHealthyAgain(t *testing.T) {
 	ht := Tracker{}
+	bus := eventbustest.NewBus(t)
+	watcher := eventbustest.NewWatcher(t, bus)
+	ht.InitOnce(bus)
 	if len(ht.Strings()) != 0 {
 		t.Fatalf("before first insertion, len(newTracker.Strings) = %d; want = 0", len(ht.Strings()))
 	}
@@ -92,10 +116,21 @@ func TestSetUnhealthyWithDuplicateThenHealthyAgain(t *testing.T) {
 	if !reflect.DeepEqual(ht.Strings(), want) {
 		t.Fatalf("after setting the healthy, newTracker.Strings() = %v; want = %v", ht.Strings(), want)
 	}
+
+	if err := eventbustest.ExpectExactly(watcher,
+		compareChange(Change{WarnableChanged: true, Warnable: testWarnable}),
+		compareChange(Change{WarnableChanged: true, Warnable: testWarnable}),
+		compareChange(Change{WarnableChanged: true, Warnable: testWarnable}),
+	); err != nil {
+		t.Fatalf("expected events, got %q", err)
+	}
 }
 
 func TestRemoveAllWarnings(t *testing.T) {
 	ht := Tracker{}
+	bus := eventbustest.NewBus(t)
+	watcher := eventbustest.NewWatcher(t, bus)
+	ht.InitOnce(bus)
 	if len(ht.Strings()) != 0 {
 		t.Fatalf("before first insertion, len(newTracker.Strings) = %d; want = 0", len(ht.Strings()))
 	}
@@ -109,67 +144,115 @@ func TestRemoveAllWarnings(t *testing.T) {
 	if len(ht.Strings()) != 0 {
 		t.Fatalf("after RemoveAll, len(newTracker.Strings) = %d; want = 0", len(ht.Strings()))
 	}
+	if err := eventbustest.ExpectExactly(watcher,
+		compareChange(Change{WarnableChanged: true, Warnable: testWarnable}),
+		compareChange(Change{WarnableChanged: true, Warnable: testWarnable}),
+	); err != nil {
+		t.Fatalf("expected events, got %q", err)
+	}
 }
 
 // TestWatcher tests that a registered watcher function gets called with the correct
 // Warnable and non-nil/nil UnhealthyState upon setting a Warnable to unhealthy/healthy.
 func TestWatcher(t *testing.T) {
-	ht := Tracker{}
-	wantText := "Hello world"
-	becameUnhealthy := make(chan struct{})
-	becameHealthy := make(chan struct{})
+	var unregister func()
+	tests := []struct {
+		name    string
+		preFunc func(t *Tracker, fn func(Change))
+	}{
+		{
+			name: "with callbacks",
+			preFunc: func(tht *Tracker, fn func(c Change)) {
+				unregister = tht.RegisterWatcher(fn)
+				if len(tht.watchers) != 1 {
+					t.Fatalf("after RegisterWatcher, len(newTracker.watchers) = %d; want = 1", len(tht.watchers))
+				}
+			},
+		},
+		{
+			name: "with eventbus",
+			preFunc: func(tht *Tracker, fn func(c Change)) {
+				bus := eventbustest.NewBus(t)
+				tht.InitOnce(bus)
+				client := bus.Client("healthwatchertestclient")
+				sub := eventbus.Subscribe[Change](client)
+				go func() {
+					for {
+						select {
+						case <-sub.Done():
+							return
+						case change := <-sub.Events():
+							fn(change)
+						}
+					}
+				}()
+			},
+		},
+	}
 
-	watcherFunc := func(c Change) {
-		w := c.Warnable
-		us := c.UnhealthyState
-		if w != testWarnable {
-			t.Fatalf("watcherFunc was called, but with an unexpected Warnable: %v, want: %v", w, testWarnable)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(*testing.T) {
+			ht := Tracker{}
+			wantText := "Hello world"
+			becameUnhealthy := make(chan struct{})
+			becameHealthy := make(chan struct{})
 
-		if us != nil {
-			if us.Text != wantText {
-				t.Fatalf("unexpected us.Text: %s, want: %s", us.Text, wantText)
+			watcherFunc := func(c Change) {
+				w := c.Warnable
+				us := c.UnhealthyState
+				if w != testWarnable {
+					t.Fatalf("watcherFunc was called, but with an unexpected Warnable: %v, want: %v", w, testWarnable)
+				}
+
+				if us != nil {
+					if us.Text != wantText {
+						t.Fatalf("unexpected us.Text: %s, want: %s", us.Text, wantText)
+					}
+					if us.Args[ArgError] != wantText {
+						t.Fatalf("unexpected us.Args[ArgError]: %s, want: %s", us.Args[ArgError], wantText)
+					}
+					becameUnhealthy <- struct{}{}
+				} else {
+					becameHealthy <- struct{}{}
+				}
 			}
-			if us.Args[ArgError] != wantText {
-				t.Fatalf("unexpected us.Args[ArgError]: %s, want: %s", us.Args[ArgError], wantText)
+
+			// Set up test
+			tt.preFunc(&ht, watcherFunc)
+
+			// Start running actual test
+			ht.SetUnhealthy(testWarnable, Args{ArgError: wantText})
+
+			select {
+			case <-becameUnhealthy:
+				// Test passed because the watcher got notified of an unhealthy state
+			case <-becameHealthy:
+				// Test failed because the watcher got of a healthy state instead of an unhealthy one
+				t.Fatalf("watcherFunc was called with a healthy state")
+			case <-time.After(1 * time.Second):
+				t.Fatalf("watcherFunc didn't get called upon calling SetUnhealthy")
 			}
-			becameUnhealthy <- struct{}{}
-		} else {
-			becameHealthy <- struct{}{}
-		}
-	}
 
-	unregisterFunc := ht.RegisterWatcher(watcherFunc)
-	if len(ht.watchers) != 1 {
-		t.Fatalf("after RegisterWatcher, len(newTracker.watchers) = %d; want = 1", len(ht.watchers))
-	}
-	ht.SetUnhealthy(testWarnable, Args{ArgError: wantText})
+			ht.SetHealthy(testWarnable)
 
-	select {
-	case <-becameUnhealthy:
-		// Test passed because the watcher got notified of an unhealthy state
-	case <-becameHealthy:
-		// Test failed because the watcher got of a healthy state instead of an unhealthy one
-		t.Fatalf("watcherFunc was called with a healthy state")
-	case <-time.After(1 * time.Second):
-		t.Fatalf("watcherFunc didn't get called upon calling SetUnhealthy")
-	}
+			select {
+			case <-becameUnhealthy:
+				// Test failed because the watcher got of an unhealthy state instead of a healthy one
+				t.Fatalf("watcherFunc was called with an unhealthy state")
+			case <-becameHealthy:
+				// Test passed because the watcher got notified of a healthy state
+			case <-time.After(1 * time.Second):
+				t.Fatalf("watcherFunc didn't get called upon calling SetUnhealthy")
+			}
 
-	ht.SetHealthy(testWarnable)
-
-	select {
-	case <-becameUnhealthy:
-		// Test failed because the watcher got of an unhealthy state instead of a healthy one
-		t.Fatalf("watcherFunc was called with an unhealthy state")
-	case <-becameHealthy:
-		// Test passed because the watcher got notified of a healthy state
-	case <-time.After(1 * time.Second):
-		t.Fatalf("watcherFunc didn't get called upon calling SetUnhealthy")
-	}
-
-	unregisterFunc()
-	if len(ht.watchers) != 0 {
-		t.Fatalf("after unregisterFunc, len(newTracker.watchers) = %d; want = 0", len(ht.watchers))
+			if unregister != nil {
+				unregister()
+				if len(ht.watchers) != 0 {
+					t.Fatalf("after unregisterFunc, len(newTracker.watchers) = %d; want = 0", len(ht.watchers))
+				}
+				unregister = nil
+			}
+		})
 	}
 }
 
@@ -178,45 +261,88 @@ func TestWatcher(t *testing.T) {
 // has a TimeToVisible set, which means that a watcher should only be notified of an unhealthy state after
 // the TimeToVisible duration has passed.
 func TestSetUnhealthyWithTimeToVisible(t *testing.T) {
-	ht := Tracker{}
-	mw := Register(&Warnable{
-		Code:                "test-warnable-3-secs-to-visible",
-		Title:               "Test Warnable with 3 seconds to visible",
-		Text:                StaticMessage("Hello world"),
-		TimeToVisible:       2 * time.Second,
-		ImpactsConnectivity: true,
-	})
-	defer unregister(mw)
-
-	becameUnhealthy := make(chan struct{})
-	becameHealthy := make(chan struct{})
-
-	watchFunc := func(c Change) {
-		w := c.Warnable
-		us := c.UnhealthyState
-		if w != mw {
-			t.Fatalf("watcherFunc was called, but with an unexpected Warnable: %v, want: %v", w, w)
-		}
-
-		if us != nil {
-			becameUnhealthy <- struct{}{}
-		} else {
-			becameHealthy <- struct{}{}
-		}
+	var unregisterWatcher func()
+	tests := []struct {
+		name    string
+		preFunc func(t *Tracker, fn func(Change))
+	}{
+		{
+			name: "with callbacks",
+			preFunc: func(tht *Tracker, fn func(c Change)) {
+				unregisterWatcher = tht.RegisterWatcher(fn)
+				if len(tht.watchers) != 1 {
+					t.Fatalf("after RegisterWatcher, len(newTracker.watchers) = %d; want = 1", len(tht.watchers))
+				}
+			},
+		},
+		{
+			name: "with eventbus",
+			preFunc: func(tht *Tracker, fn func(c Change)) {
+				bus := eventbustest.NewBus(t)
+				tht.InitOnce(bus)
+				client := bus.Client("healthwatchertestclient")
+				sub := eventbus.Subscribe[Change](client)
+				go func() {
+					for {
+						select {
+						case <-sub.Done():
+							return
+						case change := <-sub.Events():
+							fn(change)
+						}
+					}
+				}()
+			},
+		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(*testing.T) {
+			ht := Tracker{}
+			mw := Register(&Warnable{
+				Code:                "test-warnable-3-secs-to-visible",
+				Title:               "Test Warnable with 3 seconds to visible",
+				Text:                StaticMessage("Hello world"),
+				TimeToVisible:       2 * time.Second,
+				ImpactsConnectivity: true,
+			})
 
-	ht.RegisterWatcher(watchFunc)
-	ht.SetUnhealthy(mw, Args{ArgError: "Hello world"})
+			becameUnhealthy := make(chan struct{})
+			becameHealthy := make(chan struct{})
 
-	select {
-	case <-becameUnhealthy:
-		// Test failed because the watcher got notified of an unhealthy state
-		t.Fatalf("watcherFunc was called with an unhealthy state")
-	case <-becameHealthy:
-		// Test failed because the watcher got of a healthy state
-		t.Fatalf("watcherFunc was called with a healthy state")
-	case <-time.After(1 * time.Second):
-		// As expected, watcherFunc still had not been called after 1 second
+			watchFunc := func(c Change) {
+				w := c.Warnable
+				us := c.UnhealthyState
+				if w != mw {
+					t.Fatalf("watcherFunc was called, but with an unexpected Warnable: %v, want: %v", w, w)
+				}
+
+				if us != nil {
+					becameUnhealthy <- struct{}{}
+				} else {
+					becameHealthy <- struct{}{}
+				}
+			}
+
+			tt.preFunc(&ht, watchFunc)
+			ht.SetUnhealthy(mw, Args{ArgError: "Hello world"})
+
+			select {
+			case <-becameUnhealthy:
+				// Test failed because the watcher got notified of an unhealthy state
+				t.Fatalf("watcherFunc was called with an unhealthy state")
+			case <-becameHealthy:
+				// Test failed because the watcher got of a healthy state
+				t.Fatalf("watcherFunc was called with a healthy state")
+			case <-time.After(1 * time.Second):
+				// As expected, watcherFunc still had not been called after 1 second
+			}
+
+			if unregisterWatcher != nil {
+				unregisterWatcher()
+				unregisterWatcher = nil
+			}
+			unregister(mw)
+		})
 	}
 }
 
@@ -357,6 +483,8 @@ func TestShowUpdateWarnable(t *testing.T) {
 				applyUpdates:    tt.apply,
 				latestVersion:   tt.cv,
 			}
+			bus := eventbustest.NewBus(t)
+			tr.InitOnce(bus)
 			gotWarnable, gotShow := tr.showUpdateWarnable()
 			if gotWarnable != tt.wantWarnable {
 				t.Errorf("got warnable: %v, want: %v", gotWarnable, tt.wantWarnable)
@@ -406,6 +534,8 @@ func TestHealthMetric(t *testing.T) {
 				applyUpdates:    tt.apply,
 				latestVersion:   tt.cv,
 			}
+			bus := eventbustest.NewBus(t)
+			tr.InitOnce(bus)
 			tr.SetMetricsRegistry(&usermetric.Registry{})
 			if val := tr.metricHealthMessage.Get(metricHealthMessageLabel{Type: MetricLabelWarning}).String(); val != strconv.Itoa(tt.wantMetricCount) {
 				t.Fatalf("metric value: %q, want: %q", val, strconv.Itoa(tt.wantMetricCount))
@@ -429,6 +559,8 @@ func TestNoDERPHomeWarnable(t *testing.T) {
 	ht := &Tracker{
 		testClock: clock,
 	}
+	bus := eventbustest.NewBus(t)
+	ht.InitOnce(bus)
 	ht.SetIPNState("NeedsLogin", true)
 
 	// Advance 30 seconds to get past the "recentlyLoggedIn" check.
@@ -449,6 +581,8 @@ func TestNoDERPHomeWarnable(t *testing.T) {
 // I hit: https://github.com/tailscale/tailscale/issues/14798
 func TestNoDERPHomeWarnableManual(t *testing.T) {
 	ht := &Tracker{}
+	bus := eventbustest.NewBus(t)
+	ht.InitOnce(bus)
 	ht.SetIPNState("NeedsLogin", true)
 
 	// Avoid wantRunning:
@@ -463,6 +597,8 @@ func TestNoDERPHomeWarnableManual(t *testing.T) {
 
 func TestControlHealth(t *testing.T) {
 	ht := Tracker{}
+	bus := eventbustest.NewBus(t)
+	ht.InitOnce(bus)
 	ht.SetIPNState("NeedsLogin", true)
 	ht.GotStreamedMapResponse()
 
@@ -621,6 +757,8 @@ func TestControlHealthNotifies(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ht := Tracker{}
+			bus := eventbustest.NewBus(t)
+			ht.InitOnce(bus)
 			ht.SetIPNState("NeedsLogin", true)
 			ht.GotStreamedMapResponse()
 
@@ -644,6 +782,8 @@ func TestControlHealthNotifies(t *testing.T) {
 
 func TestControlHealthIgnoredOutsideMapPoll(t *testing.T) {
 	ht := Tracker{}
+	bus := eventbustest.NewBus(t)
+	ht.InitOnce(bus)
 	ht.SetIPNState("NeedsLogin", true)
 
 	gotNotified := false
@@ -672,6 +812,8 @@ func TestControlHealthIgnoredOutsideMapPoll(t *testing.T) {
 // when the details of the [tailcfg.DisplayMessage] are different.
 func TestCurrentStateETagControlHealth(t *testing.T) {
 	ht := Tracker{}
+	bus := eventbustest.NewBus(t)
+	ht.InitOnce(bus)
 	ht.SetIPNState("NeedsLogin", true)
 	ht.GotStreamedMapResponse()
 
@@ -779,6 +921,8 @@ func TestCurrentStateETagWarnable(t *testing.T) {
 		ht := &Tracker{
 			testClock: clock,
 		}
+		bus := eventbustest.NewBus(t)
+		ht.InitOnce(bus)
 		ht.SetIPNState("NeedsLogin", true)
 		ht.GotStreamedMapResponse()
 		return ht

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -207,6 +207,7 @@ type LocalBackend struct {
 	eventClient              *eventbus.Client
 	clientVersionSub         *eventbus.Subscriber[tailcfg.ClientVersion]
 	autoUpdateSub            *eventbus.Subscriber[controlclient.AutoUpdate]
+	healthChangeSub          *eventbus.Subscriber[health.Change]
 	subsDoneCh               chan struct{}       // closed when consumeEventbusTopics returns
 	health                   *health.Tracker     // always non-nil
 	polc                     policyclient.Client // always non-nil
@@ -217,7 +218,6 @@ type LocalBackend struct {
 	pushDeviceToken          syncs.AtomicValue[string]
 	backendLogID             logid.PublicID
 	unregisterNetMon         func()
-	unregisterHealthWatch    func()
 	unregisterSysPolicyWatch func()
 	portpoll                 *portlist.Poller // may be nil
 	portpollOnce             sync.Once        // guards starting readPoller
@@ -544,6 +544,7 @@ func NewLocalBackend(logf logger.Logf, logID logid.PublicID, sys *tsd.System, lo
 	b.eventClient = b.Sys().Bus.Get().Client("ipnlocal.LocalBackend")
 	b.clientVersionSub = eventbus.Subscribe[tailcfg.ClientVersion](b.eventClient)
 	b.autoUpdateSub = eventbus.Subscribe[controlclient.AutoUpdate](b.eventClient)
+	b.healthChangeSub = eventbus.Subscribe[health.Change](b.eventClient)
 	nb := newNodeBackend(ctx, b.sys.Bus.Get())
 	b.currentNodeAtomic.Store(nb)
 	nb.ready()
@@ -597,8 +598,6 @@ func NewLocalBackend(logf logger.Logf, logID logid.PublicID, sys *tsd.System, lo
 	b.linkChange(&netmon.ChangeDelta{New: netMon.InterfaceState()})
 	b.unregisterNetMon = netMon.RegisterChangeCallback(b.linkChange)
 
-	b.unregisterHealthWatch = b.health.RegisterWatcher(b.onHealthChange)
-
 	if tunWrap, ok := b.sys.Tun.GetOK(); ok {
 		tunWrap.PeerAPIPort = b.GetPeerAPIPort
 	} else {
@@ -636,6 +635,8 @@ func (b *LocalBackend) consumeEventbusTopics() {
 			b.onClientVersion(&clientVersion)
 		case au := <-b.autoUpdateSub.Events():
 			b.onTailnetDefaultAutoUpdate(au.Value)
+		case change := <-b.healthChangeSub.Events():
+			b.onHealthChange(change)
 		}
 	}
 }
@@ -1164,7 +1165,6 @@ func (b *LocalBackend) Shutdown() {
 	b.stopOfflineAutoUpdate()
 
 	b.unregisterNetMon()
-	b.unregisterHealthWatch()
 	b.unregisterSysPolicyWatch()
 	if cc != nil {
 		cc.Shutdown()

--- a/tsd/tsd.go
+++ b/tsd/tsd.go
@@ -91,6 +91,9 @@ func NewSystemWithBus(bus *eventbus.Bus) *System {
 	}
 	sys := new(System)
 	sys.Set(bus)
+
+	sys.healthTracker.InitOnce(bus)
+
 	return sys
 }
 

--- a/util/eventbus/eventbustest/eventbustest.go
+++ b/util/eventbus/eventbustest/eventbustest.go
@@ -100,7 +100,7 @@ func Expect(tw *Watcher, filters ...any) error {
 		case <-time.After(tw.TimeOut):
 			return fmt.Errorf(
 				"timed out waiting for event, saw %d events, %d was expected",
-				eventCount, head)
+				eventCount, len(filters))
 		case <-tw.chDone:
 			return errors.New("watcher closed while waiting for events")
 		}
@@ -138,7 +138,7 @@ func ExpectExactly(tw *Watcher, filters ...any) error {
 		case <-time.After(tw.TimeOut):
 			return fmt.Errorf(
 				"timed out waiting for event, saw %d events, %d was expected",
-				eventCount, pos)
+				eventCount, len(filters))
 		case <-tw.chDone:
 			return errors.New("watcher closed while waiting for events")
 		}


### PR DESCRIPTION
The Tracker was using direct callbacks to ipnlocal. This PR moves those
to be triggered via the eventbus.

Additionally, the eventbus is now closed on exit from tailscaled
explicitly.

Updates #15160

Signed-off-by: Claus Lensbøl <claus@tailscale.com>

This should not be merged until target branch is main.
