### PR TITLE
tstest/integration/testcontrol: propagate CapVer

### DIFF
--- a/tstest/integration/testcontrol/testcontrol.go
+++ b/tstest/integration/testcontrol/testcontrol.go
@@ -674,6 +674,7 @@ func (s *Server) serveRegister(w http.ResponseWriter, r *http.Request, mkey key.
 			AllowedIPs:        allowedIPs,
 			Hostinfo:          req.Hostinfo.View(),
 			Name:              req.Hostinfo.Hostname,
+			Cap:               req.Version,
 			Capabilities: []tailcfg.NodeCapability{
 				tailcfg.CapabilityHTTPS,
 				tailcfg.NodeAttrFunnel,
@@ -811,6 +812,7 @@ func (s *Server) serveMap(w http.ResponseWriter, r *http.Request, mkey key.Machi
 		endpoints := filterInvalidIPv6Endpoints(req.Endpoints)
 		node.Endpoints = endpoints
 		node.DiscoKey = req.DiscoKey
+		node.Cap = req.Version
 		if req.Hostinfo != nil {
 			node.Hostinfo = req.Hostinfo.View()
 			if ni := node.Hostinfo.NetInfo(); ni.Valid() {


### PR DESCRIPTION
To support integration testing of client features that rely on it, e.g. peer relay.

Updates tailscale/corp#30903