### PR TITLE
client/tailscale/apitype: add structures to support new /dns/composite endpoint

### DIFF
--- a/client/tailscale/apitype/controltype.go
+++ b/client/tailscale/apitype/controltype.go
@@ -4,7 +4,10 @@
 package apitype
 
 // DNSConfig is the DNS configuration for a tailnet
-// used in /tailnet/{tailnet}/dns/config.
+// used in /tailnet/{tailnet}/dns/config, an endpoint
+// that is similar to /tailnet/{tailnet}/dns/composite,
+// but it's not publicly documented and has fields and
+// names that align more closely to internal backend use.
 type DNSConfig struct {
 	// Resolvers are the global DNS resolvers to use
 	// overriding the local OS configuration.
@@ -35,18 +38,51 @@ type DNSConfig struct {
 	Nameservers []string `json:"nameservers"`
 }
 
+// DNSComposite is the DNS configuration for a tailnet
+// used in /tailnet/{tailnet}/dns/composite, an endpoint
+// that is similar to /tailnet/{tailnet}/dns/config, but
+// it's publicly documented has more user-friendly names.
+type DNSComposite struct {
+	// Nameservers are the global DNS resolvers to use.
+	// If Preferences.OverrideLocalDNS is true, the resolvers here
+	// will override the local OS configuration. Otherwise,
+	// these resolvers will be used as fallback resolvers.
+	Nameservers []DNSResolver `json:"nameservers"`
+
+	// SplitDNS map DNS name suffixes to a set of DNS resolvers,
+	// used for Split DNS and other advanced routing overlays.
+	SplitDNS map[string][]DNSResolver `json:"splitDNS"`
+
+	// SearchPaths are the search domain paths to use.
+	SearchPaths []string `json:"searchPaths"`
+
+	// Preferences encapsulate other options for
+	// DNS configuration.
+	Preferences DNSPreferences `json:"preferences"`
+}
+
+type DNSPreferences struct {
+	// OverrideLocalDNS controls whether the resolvers
+	// in Nameservers override the local resolvers, or
+	// are instead used as fallback resolvers.
+	OverrideLocalDNS bool `json:"overrideLocalDNS"`
+
+	// MagicDNS means MagicDNS is enabled.
+	MagicDNS bool `json:"magicDNS"`
+}
+
 // DNSResolver is a DNS resolver in a DNS configuration.
 type DNSResolver struct {
-	// Addr is the address of the DNS resolver.
+	// Address is the address of the DNS resolver.
 	// It is usually an IP address or a DoH URL.
 	// See dnstype.Resolver.Addr for full details.
-	Addr string `json:"addr"`
+	Address string `json:"address"`
+
+	// UseWithExitNode signals this resolver should be used
+	// even when a tailscale exit node is configured on a device.
+	UseWithExitNode bool `json:"useWithExitNode"`
 
 	// BootstrapResolution is an optional suggested resolution for
 	// the DoT/DoH resolver.
 	BootstrapResolution []string `json:"bootstrapResolution,omitempty"`
-
-	// UseWithExitNode signals this resolver should be used
-	// even when a tailscale exit node is configured on a device.
-	UseWithExitNode bool `json:"useWithExitNode,omitempty"`
 }


### PR DESCRIPTION
The /dns/composite endpoint backed by these new structures is meant to support all possible DNS configurations in a single place. It is similar to /dns/config (undocumented) except that the field names and structure are designed to be user-facing, intending to match the experience of other endpoints and the UI panel as closely as possible.

More immediately, it gives a place in the public API to expose useWithExitNode in resolvers. The current finer-grained endpoints (/dns/nameservers, e.g.) can't support this flag or richer configuration because resolvers are treated as address strings instead of objects.

DNSResolver.Addr is changed to DNSResolver.Address since now the field name will be user-facing. This breaks consumers of /dns/config, but since the only consumer is the admin panel, the break can be accounted for.

DNSResolver.UseWithExitNode is no longer omitempty as the API should marshal an explicit value in responses.

Updates tailscale/corp#32129
Updates #8237

---
Opening in draft because we have to confirm naming choices