### PR TITLE
tailcfg: add HardwareAttestationKey to MapRequest

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -1360,6 +1360,13 @@ type MapRequest struct {
 	NodeKey   key.NodePublic
 	DiscoKey  key.DiscoPublic
 
+	// HardwareAttestationKey is the public key of the node's hardware-backed
+	// identity attestation key, if any.
+	HardwareAttestationKey key.HardwareAttestationPublic `json:",omitzero"`
+	// HardwareAttestationKeySignature is the signature of the NodeKey
+	// serialized using MarshalText using its hardware attestation key, if any.
+	HardwareAttestationKeySignature []byte `json:",omitempty"`
+
 	// Stream is whether the client wants to receive multiple MapResponses over
 	// the same HTTP connection.
 	//


### PR DESCRIPTION
Extend MapRequest with HardwareAttestationKey{,Signature} fields that
optionally contain the public component of the hardware attestation key
and a signature of the node's node key using it. This will be used by
control to associate hardware attestation keys with node identities on a
TOFU basis.

Updates tailscale/corp#31269

Signed-off-by: Patrick O'Doherty <patrick@tailscale.com>