### PR TITLE
k8s-operator: send operator logs to tailscale

### DIFF
--- a/cmd/k8s-operator/logger.go
+++ b/cmd/k8s-operator/logger.go
@@ -1,0 +1,26 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !plan9
+
+package main
+
+import (
+	"io"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	kzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// wrapZapCore returns a zapcore.Core implementation that splits the core chain using zapcore.NewTee. This causes
+// logs to be simultaneously written to both the original core and the provided io.Writer implementation.
+func wrapZapCore(core zapcore.Core, writer io.Writer) zapcore.Core {
+	encoder := &kzap.KubeAwareEncoder{
+		Encoder: zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+	}
+
+	// We use a tee logger here so that logs are written to stdout/stderr normally while at the same time being
+	// sent upstream.
+	return zapcore.NewTee(core, zapcore.NewCore(encoder, zapcore.AddSync(writer), zap.DebugLevel))
+}

--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -495,14 +495,14 @@ func (s *Server) TailscaleIPs() (ip4, ip6 netip.Addr) {
 	return ip4, ip6
 }
 
-// Logtailf returns a [logger.Logf] that outputs to Tailscale's logging service and will be only visible to Tailscale's
+// LogtailWriter returns an [io.Writer] that writes to Tailscale's logging service and will be only visible to Tailscale's
 // support team. Logs written there cannot be retrieved by the user. This method always returns a non-nil value.
-func (s *Server) Logtailf() logger.Logf {
+func (s *Server) LogtailWriter() io.Writer {
 	if s.logtail == nil {
-		return logger.Discard
+		return io.Discard
 	}
 
-	return s.logtail.Logf
+	return s.logtail
 }
 
 func (s *Server) getAuthKey() string {


### PR DESCRIPTION
This commit modifies the k8s operator to wrap its logger using the logtail
logger provided via the tsnet server. This causes any logs written by
the operator to make their way to Tailscale in the same fashion as
wireguard logs to be used by support.

This functionality can also be opted-out of entirely using the
"TS_NO_LOGS_NO_SUPPORT" environment variable.

Updates https://github.com/tailscale/corp/issues/32037