### PR TITLE
k8s-operator: reset service status before append

### DIFF
--- a/cmd/k8s-operator/operator_test.go
+++ b/cmd/k8s-operator/operator_test.go
@@ -173,6 +173,10 @@ func TestLoadBalancerClass(t *testing.T) {
 			},
 		},
 	}
+
+	// Perform an additional reconciliation loop here to ensure resources don't change through side effects. Mainly
+	// to prevent infinite reconciliation
+	expectReconciled(t, sr, "default", "test")
 	expectEqual(t, fc, want)
 
 	// Turn the service back into a ClusterIP service, which should make the


### PR DESCRIPTION
This commit fixes an issue within the service reconciler where we end
up in a constant reconciliation loop. When reconciling, the loadbalancer
status is appended to but not reset between each reconciliation, leading
to an ever growing slice of duplicate statuses.

Fixes https://github.com/tailscale/tailscale/issues/17105
Fixes https://github.com/tailscale/tailscale/issues/17107