### PR TITLE
logpolicy/logpolicy: respect NoLogsNoSupport envknob

### DIFF
--- a/logpolicy/logpolicy.go
+++ b/logpolicy/logpolicy.go
@@ -868,7 +868,7 @@ type TransportOptions struct {
 // New returns an HTTP Transport particularly suited to uploading logs
 // to the given host name. See [DialContext] for details on how it works.
 func (opts TransportOptions) New() http.RoundTripper {
-	if testenv.InTest() {
+	if testenv.InTest() || envknob.NoLogsNoSupport() {
 		return noopPretendSuccessTransport{}
 	}
 	if opts.NetMon == nil {


### PR DESCRIPTION
Hello, we embedd tailscale in our codebase and we noticed that the logs are still shipped (or at least connection established to `log.tailscale.io`), regardless of the `TS_NO_LOGS_NO_SUPPORT` env var (docs ref: https://tailscale.com/kb/1011/log-mesh-traffic?q=no+logs+no+support#opting-out-of-client-logging )

We fixed it in our fork, but I think it's also worth contributing upstream, hence the PR.