### PR TITLE
cmd/k8s-operator: allow custom annotations on deployment

### DIFF
--- a/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
+++ b/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
@@ -6,6 +6,9 @@ kind: Deployment
 metadata:
   name: operator
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.annotations }}
+  annotations: {{- toYaml .Values.annotations | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   strategy:

--- a/cmd/k8s-operator/deploy/chart/values.yaml
+++ b/cmd/k8s-operator/deploy/chart/values.yaml
@@ -55,6 +55,9 @@ operatorConfig:
 
   resources: {}
 
+  # Specifies annotations for deployment
+  annotations: {}
+
   podAnnotations: {}
   podLabels: {}
 


### PR DESCRIPTION
Fixes #17188