### PR TITLE
util/eventbus: allow test expectations reporting only an error

### DIFF
--- a/util/eventbus/eventbustest/eventbustest_test.go
+++ b/util/eventbus/eventbustest/eventbustest_test.go
@@ -55,6 +55,27 @@ func TestExpectFilter(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:   "filter-with-nil-error",
+			events: []int{1, 2, 3},
+			expectFunc: func(event EventFoo) error {
+				if event.Value > 10 {
+					return fmt.Errorf("value > 10: %d", event.Value)
+				}
+				return nil
+			},
+		},
+		{
+			name:   "filter-with-non-nil-error",
+			events: []int{100, 200, 300},
+			expectFunc: func(event EventFoo) error {
+				if event.Value > 10 {
+					return fmt.Errorf("value > 10: %d", event.Value)
+				}
+				return nil
+			},
+			wantErr: true,
+		},
+		{
 			name:   "first event has to be func",
 			events: []int{24, 42},
 			expectFunc: func(event EventFoo) (bool, error) {


### PR DESCRIPTION
Extend the Expect method of a Watcher to allow filter functions that report
only an error value, and which "pass" when the reported error is nil.

Updates #15160

Change-Id: I582d804554bd1066a9e499c1f3992d068c9e8148
Signed-off-by: M. J. Fromberger <fromberger@tailscale.com>
