### PR TITLE
wgengine/magicsock: don't add DERP addrs to endpointState

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -2539,10 +2539,7 @@ func (c *Conn) handlePingLocked(dm *disco.Ping, src epAddr, di *discoInfo, derpN
 	// Remember this route if not present.
 	var dup bool
 	if isDerp {
-		if ep, ok := c.peerMap.endpointForNodeKey(derpNodeSrc); ok {
-			if ep.addCandidateEndpoint(src.ap, dm.TxID) {
-				return
-			}
+		if _, ok := c.peerMap.endpointForNodeKey(derpNodeSrc); ok {
 			numNodes = 1
 		}
 	} else {


### PR DESCRIPTION
endpointState is used for tracking UDP direct connection candidate addresses. If it contains a DERP addr, then direct connection path discovery will always send a wasteful disco ping over it. Additionally, CLI "tailscale ping" via peer relay will race over DERP, leading to a misleading result if pong arrives via DERP first.

Disco pongs arriving via DERP never influence path selection. Disco ping/pong via DERP only serves "tailscale ping" reporting.

Updates #17121