### PR TITLE
build_dist.sh: add -trimpath

### DIFF
--- a/build_dist.sh
+++ b/build_dist.sh
@@ -57,4 +57,4 @@ while [ "$#" -gt 1 ]; do
 	esac
 done
 
-exec $go build ${tags:+-tags=$tags} -ldflags "$ldflags" "$@"
+exec $go build ${tags:+-tags=$tags} -trimpath -ldflags "$ldflags" "$@"


### PR DESCRIPTION
Saves 81KB (20320440 to 20238520 bytes for linux/amd64)

Updates #1278
