### PR TITLE
util/eventbus: add a LogAllEvents helper for testing

### DIFF
--- a/util/eventbus/eventbustest/eventbustest_test.go
+++ b/util/eventbus/eventbustest/eventbustest_test.go
@@ -4,6 +4,7 @@
 package eventbustest_test
 
 import (
+	"flag"
 	"fmt"
 	"strings"
 	"testing"
@@ -12,6 +13,8 @@ import (
 	"tailscale.com/util/eventbus"
 	"tailscale.com/util/eventbus/eventbustest"
 )
+
+var doDebug = flag.Bool("debug", false, "Enable debug logging")
 
 type EventFoo struct {
 	Value int
@@ -109,7 +112,11 @@ func TestExpectFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if *doDebug {
+				eventbustest.LogAllEvents(t, bus)
+			}
 			tw := eventbustest.NewWatcher(t, bus)
+
 			// TODO(cmol): When synctest is out of experimental, use that instead:
 			// https://go.dev/blog/synctest
 			tw.TimeOut = 10 * time.Millisecond


### PR DESCRIPTION
When developing (and debugging) tests, it is useful to be able to see all the
traffic that transits the event bus during the execution of a test.

Updates #15160

Change-Id: I929aee62ccf13bdd4bd07d786924ce9a74acd17a
Signed-off-by: M. J. Fromberger <fromberger@tailscale.com>
