### PR TITLE
util/eventbus: fix flakes in eventbustest tests

### DIFF
--- a/util/eventbus/eventbustest/eventbustest_test.go
+++ b/util/eventbus/eventbustest/eventbustest_test.go
@@ -108,10 +108,11 @@ func TestExpectFilter(t *testing.T) {
 		},
 	}
 
-	bus := eventbustest.NewBus(t)
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			bus := eventbustest.NewBus(t)
+			t.Cleanup(bus.Close)
+
 			if *doDebug {
 				eventbustest.LogAllEvents(t, bus)
 			}
@@ -241,10 +242,11 @@ func TestExpectEvents(t *testing.T) {
 		},
 	}
 
-	bus := eventbustest.NewBus(t)
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			bus := eventbustest.NewBus(t)
+			t.Cleanup(bus.Close)
+
 			tw := eventbustest.NewWatcher(t, bus)
 			// TODO(cmol): When synctest is out of experimental, use that instead:
 			// https://go.dev/blog/synctest
@@ -374,10 +376,11 @@ func TestExpectExactlyEventsFilter(t *testing.T) {
 		},
 	}
 
-	bus := eventbustest.NewBus(t)
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			bus := eventbustest.NewBus(t)
+			t.Cleanup(bus.Close)
+
 			tw := eventbustest.NewWatcher(t, bus)
 			// TODO(cmol): When synctest is out of experimental, use that instead:
 			// https://go.dev/blog/synctest


### PR DESCRIPTION
When tests run in parallel, events from multiple tests on the same bus can
intercede with each other. This is working as intended, but for the test cases
we want to control exactly what goes through the bus.

To fix that, allocate a fresh bus for each subtest.

Fixes #17197

Change-Id: I53f285ebed8da82e72a2ed136a61884667ef9a5e
Signed-off-by: M. J. Fromberger <fromberger@tailscale.com>
