### PR TITLE
util/eventbus/eventbustest: fix typo of test name

### DIFF
--- a/cmd/containerboot/egressservices.go
+++ b/cmd/containerboot/egressservices.go
@@ -570,7 +570,7 @@ func ensureRulesAdded(rulesPerSvc map[string][]rule, nfr linuxfw.NetfilterRunner
 }
 
 // ensureRulesDeleted ensures that the given rules are deleted from the firewall
-// configuration. For any rules that do not exist, calling this funcion is a
+// configuration. For any rules that do not exist, calling this function is a
 // no-op.
 func ensureRulesDeleted(rulesPerSvc map[string][]rule, nfr linuxfw.NetfilterRunner) error {
 	for svc, rules := range rulesPerSvc {

--- a/util/eventbus/eventbustest/examples_test.go
+++ b/util/eventbus/eventbustest/examples_test.go
@@ -157,7 +157,7 @@ func TestExample_Expect_WithMultipleFunctions(t *testing.T) {
 	// OK
 }
 
-func TestExample_ExpectExactly_WithMultipleFuncions(t *testing.T) {
+func TestExample_ExpectExactly_WithMultipleFunctions(t *testing.T) {
 	type eventOfInterest struct {
 		value int
 	}


### PR DESCRIPTION
And another case of the same typo in a comment elsewhere.

Updates #cleanup
