### PR TITLE
net/dnscache: fix case where Resolver could return zero IP with single IPv6 address

### DIFF
--- a/net/dnscache/dnscache.go
+++ b/net/dnscache/dnscache.go
@@ -205,6 +205,9 @@ func (r *Resolver) LookupIP(ctx context.Context, host string) (ip, v6 netip.Addr
 			}
 			allIPs = append(allIPs, naIP)
 		}
+		if !ip.IsValid() && v6.IsValid() {
+			ip = v6
+		}
 		r.dlogf("returning %d static results", len(allIPs))
 		return
 	}


### PR DESCRIPTION
The controlhttp dialer with a ControlDialPlan IPv6 entry was hitting a
case where the dnscache Resolver was returning an netip.Addr zero
value, where it should've been returning the IPv6 address.

We then tried to dial "invalid IP:80", which would immediately fail,
at least locally.

Mostly this was causing spammy logs when debugging other stuff.

Updates tailscale/corp#32534
