### PR TITLE
magicsock: fix deadlock in SetStaticEndpoints

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -1015,6 +1015,7 @@ func (c *Conn) setEndpoints(endpoints []tailcfg.Endpoint) (changed bool) {
 func (c *Conn) SetStaticEndpoints(ep views.Slice[netip.AddrPort]) {
 	c.mu.Lock()
 	if reflect.DeepEqual(c.staticEndpoints.AsSlice(), ep.AsSlice()) {
+		c.mu.Unlock()
 		return
 	}
 	c.staticEndpoints = ep


### PR DESCRIPTION
updates tailscale/corp#32600

A localAPI/cli call to reload-config can end up leaving magicsock's mutex
locked.   We were missing an unlock for the early exit where there's no change in
the static endpoints when the disk-based config is loaded.  This is not likely
the root cause of the linked issue - just noted during investigation.