### PR TITLE
cmd/tailscale/cli: reduce strength of lose-ssh risk warning

### DIFF
--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -385,7 +385,7 @@ func updatePrefs(prefs, curPrefs *ipn.Prefs, env upCheckEnv) (simpleUp bool, jus
 	}
 
 	if env.upArgs.forceReauth && isSSHOverTailscale() {
-		if err := presentRiskToUser(riskLoseSSH, `You are connected over Tailscale; this action will result in your SSH session disconnecting.`, env.upArgs.acceptedRisks); err != nil {
+		if err := presentRiskToUser(riskLoseSSH, `You are connected over Tailscale; this action may result in your SSH session disconnecting.`, env.upArgs.acceptedRisks); err != nil {
 			return false, nil, err
 		}
 	}


### PR DESCRIPTION
Ideally we would remove this warning entirely, as it is now possible to reauthenticate without losing connectivty. However, it is still possible to lose SSH connectivity if the user changes the ownership of the machine when they do a force-reauth, and we have no way of knowing if they are going to do that before they do it.

For now, let's just reduce the strength of the warning to warn them that they "may" lose their connection, rather than they "will".

Updates tailscale/corp#32429