### PR TITLE
ipn/ipnlocal: rename misnamed DisablePortMapperForTest to DisablePortPollerForTest

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1503,9 +1503,7 @@ func (b *LocalBackend) PeerCaps(src netip.Addr) tailcfg.PeerCapMap {
 }
 
 func (b *LocalBackend) GetFilterForTest() *filter.Filter {
-	if !testenv.InTest() {
-		panic("GetFilterForTest called outside of test")
-	}
+	testenv.AssertInTest()
 	nb := b.currentNode()
 	return nb.filterAtomic.Load()
 }
@@ -2304,9 +2302,10 @@ func (b *LocalBackend) SetControlClientGetterForTesting(newControlClient func(co
 	b.ccGen = newControlClient
 }
 
-// DisablePortMapperForTest disables the portmapper for tests.
+// DisablePortPollerForTest disables the port list poller for tests.
 // It must be called before Start.
-func (b *LocalBackend) DisablePortMapperForTest() {
+func (b *LocalBackend) DisablePortPollerForTest() {
+	testenv.AssertInTest()
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.portpoll = nil
@@ -2315,6 +2314,7 @@ func (b *LocalBackend) DisablePortMapperForTest() {
 // PeersForTest returns all the current peers, sorted by Node.ID,
 // for integration tests in another repo.
 func (b *LocalBackend) PeersForTest() []tailcfg.NodeView {
+	testenv.AssertInTest()
 	return b.currentNode().PeersForTest()
 }
 
@@ -4030,6 +4030,7 @@ func (b *LocalBackend) resolveBestProfileLocked() (_ ipn.LoginProfileView, isBac
 // It is used for testing only, and will be removed along with the rest of the
 // "current user" functionality as we progress on the multi-user improvements (tailscale/corp#18342).
 func (b *LocalBackend) CurrentUserForTest() (ipn.WindowsUserID, ipnauth.Actor) {
+	testenv.AssertInTest()
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.pm.CurrentUserID(), b.currentUser

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -5816,7 +5816,7 @@ func newLocalBackendWithSysAndTestControl(t *testing.T, enableLogging bool, sys 
 		t.Fatalf("NewLocalBackend: %v", err)
 	}
 	t.Cleanup(b.Shutdown)
-	b.DisablePortMapperForTest()
+	b.DisablePortPollerForTest()
 
 	b.SetControlClientGetterForTesting(func(opts controlclient.Options) (controlclient.Client, error) {
 		return newControl(t, opts), nil

--- a/ipn/ipnlocal/state_test.go
+++ b/ipn/ipnlocal/state_test.go
@@ -358,7 +358,7 @@ func TestStateMachine(t *testing.T) {
 		t.Fatalf("NewLocalBackend: %v", err)
 	}
 	t.Cleanup(b.Shutdown)
-	b.DisablePortMapperForTest()
+	b.DisablePortPollerForTest()
 
 	var cc, previousCC *mockControl
 	b.SetControlClientGetterForTesting(func(opts controlclient.Options) (controlclient.Client, error) {

--- a/ipn/lapitest/backend.go
+++ b/ipn/lapitest/backend.go
@@ -45,7 +45,7 @@ func newBackend(opts *options) *ipnlocal.LocalBackend {
 		tb.Fatalf("NewLocalBackend: %v", err)
 	}
 	tb.Cleanup(b.Shutdown)
-	b.DisablePortMapperForTest()
+	b.DisablePortPollerForTest()
 	b.SetControlClientGetterForTesting(opts.MakeControlClient)
 	return b
 }


### PR DESCRIPTION
I think this was originally a brain-o in 9380e2dfc61a720d. It's
disabling the port _poller_, listing what open ports (i.e. services)
are open, not PMP/PCP/UPnP port mapping.

While there, drop in some more testenv.AssertInTest() in a few places.

Updates #cleanup
