### PR TITLE
various: allow tailscaled shutdown via LocalAPI

### DIFF
--- a/client/local/local.go
+++ b/client/local/local.go
@@ -1368,3 +1368,9 @@ func (lc *Client) SuggestExitNode(ctx context.Context) (apitype.ExitNodeSuggesti
 	}
 	return decodeJSON[apitype.ExitNodeSuggestionResponse](body)
 }
+
+// ShutdownTailscaled requests a graceful shutdown of tailscaled.
+func (lc *Client) ShutdownTailscaled(ctx context.Context) error {
+	_, err := lc.send(ctx, "POST", "/localapi/v0/shutdown", 200, nil)
+	return err
+}

--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -547,7 +547,7 @@ func startIPNServer(ctx context.Context, logf logger.Logf, logID logid.PublicID,
 		}
 	}()
 
-	srv := ipnserver.New(logf, logID, sys.NetMon.Get())
+	srv := ipnserver.New(logf, logID, sys.Bus.Get(), sys.NetMon.Get())
 	if debugMux != nil {
 		debugMux.HandleFunc("/debug/ipn", srv.ServeHTMLStatus)
 	}

--- a/cmd/tsconnect/wasm/wasm_js.go
+++ b/cmd/tsconnect/wasm/wasm_js.go
@@ -138,7 +138,7 @@ func newIPN(jsConfig js.Value) map[string]any {
 	sys.Tun.Get().Start()
 
 	logid := lpc.PublicID
-	srv := ipnserver.New(logf, logid, sys.NetMon.Get())
+	srv := ipnserver.New(logf, logid, sys.Bus.Get(), sys.NetMon.Get())
 	lb, err := ipnlocal.NewLocalBackend(logf, logid, sys, controlclient.LoginEphemeral)
 	if err != nil {
 		log.Fatalf("ipnlocal.NewLocalBackend: %v", err)

--- a/ipn/lapitest/server.go
+++ b/ipn/lapitest/server.go
@@ -236,7 +236,7 @@ func (s *Server) Close() {
 func newUnstartedIPNServer(opts *options) *ipnserver.Server {
 	opts.TB().Helper()
 	lb := opts.Backend()
-	server := ipnserver.New(opts.Logf(), logid.PublicID{}, lb.NetMon())
+	server := ipnserver.New(opts.Logf(), logid.PublicID{}, lb.EventBus(), lb.NetMon())
 	server.SetLocalBackend(lb)
 	return server
 }

--- a/util/syspolicy/pkey/pkey.go
+++ b/util/syspolicy/pkey/pkey.go
@@ -47,6 +47,13 @@ const (
 	// An empty string or a zero duration disables automatic reconnection.
 	ReconnectAfter Key = "ReconnectAfter"
 
+	// AllowTailscaledRestart is a boolean key that controls whether users with write access
+	// to the LocalAPI are allowed to shutdown tailscaled with the intention of restarting it.
+	// On Windows, tailscaled will be restarted automatically by the service process
+	// (see babysitProc in cmd/tailscaled/tailscaled_windows.go).
+	// On other platforms, it is the client's responsibility to restart tailscaled.
+	AllowTailscaledRestart Key = "AllowTailscaledRestart"
+
 	// ExitNodeID is the exit node's node id. default ""; if blank, no exit node is forced.
 	// Exit node ID takes precedence over exit node IP.
 	// To find the node ID, go to /api.md#device.

--- a/util/syspolicy/policy_keys.go
+++ b/util/syspolicy/policy_keys.go
@@ -17,6 +17,7 @@ var implicitDefinitions = []*setting.Definition{
 	// Device policy settings (can only be configured on a per-device basis):
 	setting.NewDefinition(pkey.AllowedSuggestedExitNodes, setting.DeviceSetting, setting.StringListValue),
 	setting.NewDefinition(pkey.AllowExitNodeOverride, setting.DeviceSetting, setting.BooleanValue),
+	setting.NewDefinition(pkey.AllowTailscaledRestart, setting.DeviceSetting, setting.BooleanValue),
 	setting.NewDefinition(pkey.AlwaysOn, setting.DeviceSetting, setting.BooleanValue),
 	setting.NewDefinition(pkey.AlwaysOnOverrideWithReason, setting.DeviceSetting, setting.BooleanValue),
 	setting.NewDefinition(pkey.ApplyUpdates, setting.DeviceSetting, setting.PreferenceOptionValue),


### PR DESCRIPTION
A customer wants to allow their employees to restart `tailscaled` at will, when access rights and MDM policy allow it, as a way to fully reset client state and re-create the tunnel in case of connectivity issues.

On Windows, the main `tailscaled` process runs as a child of a service process. The service restarts the child when it exits (or crashes) until the service itself is stopped. Regular (non-admin) users can't stop the service, and allowing them to do so isn't ideal, especially in managed or multi-user environments.

In this PR, we add a LocalAPI endpoint that instructs `ipnserver.Server`, and by extension the `tailscaled` process, to shut down. The service then restarts the child `tailscaled`. Shutting down `tailscaled` requires LocalAPI write access and an enabled policy setting.

Updates tailscale/corp#32674
Updates tailscale/corp#32675