### PR TITLE
ipn/ipnlocal: do not reset extHost on (*LocalBackend).Shutdown

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1118,8 +1118,6 @@ func (b *LocalBackend) Shutdown() {
 	if b.notifyCancel != nil {
 		b.notifyCancel()
 	}
-	extHost := b.extHost
-	b.extHost = nil
 	b.mu.Unlock()
 	b.webClientShutdown()
 
@@ -1136,7 +1134,7 @@ func (b *LocalBackend) Shutdown() {
 	}
 	b.ctxCancel(errShutdown)
 	b.currentNode().shutdown(errShutdown)
-	extHost.Shutdown()
+	b.extHost.Shutdown()
 	b.e.Close()
 	<-b.e.Done()
 	b.awaitNoGoroutinesInTest()


### PR DESCRIPTION
We made changes to `ipnext` callback registration/unregistration/invocation in #15780 that made resetting `b.exthost` to a `nil`, no-op host in `(*LocalBackend).Shutdown()` unnecessary.

But resetting it is also racy: `b.exthost` must be safe for concurrent use with or without `b.mu` held, so it shouldn't be written after `NewLocalBackend` returns. This PR removes it.

Fixes #17279