### PR TITLE
tstest/integration: deflake TestC2NDebugNetmap, disable service collection

### DIFF
--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -1784,7 +1784,9 @@ func TestPeerRelayPing(t *testing.T) {
 func TestC2NDebugNetmap(t *testing.T) {
 	tstest.Shard(t)
 	tstest.Parallel(t)
-	env := NewTestEnv(t)
+	env := NewTestEnv(t, ConfigureControl(func(s *testcontrol.Server) {
+		s.CollectServices = "false"
+	}))
 
 	var testNodes []*TestNode
 	var nodes []*tailcfg.Node

--- a/tstest/integration/testcontrol/testcontrol.go
+++ b/tstest/integration/testcontrol/testcontrol.go
@@ -35,6 +35,7 @@ import (
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/key"
 	"tailscale.com/types/logger"
+	"tailscale.com/types/opt"
 	"tailscale.com/types/ptr"
 	"tailscale.com/util/httpm"
 	"tailscale.com/util/mak"
@@ -68,6 +69,10 @@ type Server struct {
 
 	// DefaultNodeCapabilities overrides the capability map sent to each client.
 	DefaultNodeCapabilities *tailcfg.NodeCapMap
+
+	// CollectServices, if non-empty, sets whether the control server asks
+	// for service updates. If empty, the default is "true".
+	CollectServices opt.Bool
 
 	// ExplicitBaseURL or HTTPTestServer must be set.
 	ExplicitBaseURL string           // e.g. "http://127.0.0.1:1234" with no trailing URL
@@ -1096,7 +1101,7 @@ func (s *Server) MapResponse(req *tailcfg.MapRequest) (res *tailcfg.MapResponse,
 		Node:            node,
 		DERPMap:         s.DERPMap,
 		Domain:          domain,
-		CollectServices: "true",
+		CollectServices: cmp.Or(s.CollectServices, "true"),
 		PacketFilter:    packetFilterWithIngress(s.PeerRelayGrants),
 		DNSConfig:       dns,
 		ControlTime:     &t,


### PR DESCRIPTION
Fixes #17298
