### PR TITLE
all: specify explicit JSON format for time.Duration

### DIFF
--- a/net/speedtest/speedtest.go
+++ b/net/speedtest/speedtest.go
@@ -24,7 +24,7 @@ const (
 // conduct the test.
 type config struct {
 	Version      int           `json:"version"`
-	TestDuration time.Duration `json:"time"`
+	TestDuration time.Duration `json:"time,format:nano"`
 	Direction    Direction     `json:"direction"`
 }
 

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -2843,7 +2843,7 @@ type SSHAction struct {
 
 	// SessionDuration, if non-zero, is how long the session can stay open
 	// before being forcefully terminated.
-	SessionDuration time.Duration `json:"sessionDuration,omitempty"`
+	SessionDuration time.Duration `json:"sessionDuration,omitempty,format:nano"`
 
 	// AllowAgentForwarding, if true, allows accepted connections to forward
 	// the ssh agent if requested.


### PR DESCRIPTION
These were detected by tailscale/corp#32755.

The default representation of time.Duration has different JSON representation between v1 and v2.
In particular, v2 currently lacks a default representation and requires an explicit format to be specified.

Apply an explicit format flag that uses the v1 representation so that this behavior does not change if serialized with v2.

Updates tailscale/corp#791
