### PR TITLE
net/speedtest: mark flaky test, and skip it by default as it's slow

### DIFF
--- a/net/speedtest/speedtest_test.go
+++ b/net/speedtest/speedtest_test.go
@@ -4,12 +4,22 @@
 package speedtest
 
 import (
+	"flag"
 	"net"
 	"testing"
 	"time"
+
+	"tailscale.com/cmd/testwrapper/flakytest"
 )
 
+var manualTest = flag.Bool("do-speedtest", false, "if true, run the speedtest TestDownload test. Otherwise skip it because it's slow and flaky; see https://github.com/tailscale/tailscale/issues/17338")
+
 func TestDownload(t *testing.T) {
+	if !*manualTest {
+		t.Skip("skipping slow test without --do-speedtest")
+	}
+	flakytest.Mark(t, "https://github.com/tailscale/tailscale/issues/17338")
+
 	// start a listener and find the port where the server will be listening.
 	l, err := net.Listen("tcp", ":0")
 	if err != nil {


### PR DESCRIPTION
Updates #17338
