### PR TITLE
net/memnet: allow listener address reuse

### DIFF
--- a/net/memnet/memnet.go
+++ b/net/memnet/memnet.go
@@ -61,6 +61,11 @@ func (m *Network) Listen(network, address string) (net.Listener, error) {
 		}
 		ln := Listen(key)
 		m.lns[key] = ln
+		ln.onClose = func() {
+			m.mu.Lock()
+			delete(m.lns, key)
+			m.mu.Unlock()
+		}
 		return ln, nil
 	}
 }

--- a/net/memnet/memnet_test.go
+++ b/net/memnet/memnet_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package memnet
+
+import "testing"
+
+func TestListenAddressReuse(t *testing.T) {
+	var nw Network
+	ln1, err := nw.Listen("tcp", "127.0.0.1:80")
+	if err != nil {
+		t.Fatalf("listen failed: %v", err)
+	}
+	if _, err := nw.Listen("tcp", "127.0.0.1:80"); err == nil {
+		t.Errorf("listen on in-use address succeeded")
+	}
+	if err := ln1.Close(); err != nil {
+		t.Fatalf("close failed: %v", err)
+	}
+	if _, err := nw.Listen("tcp", "127.0.0.1:80"); err != nil {
+		t.Errorf("listen on same address after close failed: %v", err)
+	}
+}


### PR DESCRIPTION
Listen address reuse is allowed as soon as the previous listener is
closed. There is no attempt made to emulate more complex address reuse
logic.

Updates tailscale/corp#28078

Change-Id: I56be1c4848e7b3f9fc97fd4ef13a2de9dcfab0f2
Signed-off-by: Brian Palmer <brianp@tailscale.com>