### PR TITLE
Add support for operator priorityClassName

### DIFF
--- a/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
+++ b/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
@@ -29,6 +29,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.operatorConfig.priorityClassName }}
+      priorityClassName: {{ .Values.operatorConfig.priorityClassName }}
+      {{- end }}
       serviceAccountName: operator
       {{- with .Values.operatorConfig.podSecurityContext }}
       securityContext:

--- a/cmd/k8s-operator/deploy/chart/values.yaml
+++ b/cmd/k8s-operator/deploy/chart/values.yaml
@@ -57,6 +57,8 @@ operatorConfig:
 
   podAnnotations: {}
   podLabels: {}
+  
+  priorityClassName: ""
 
   serviceAccountAnnotations: {}
   # eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/tailscale-operator-role


### PR DESCRIPTION
The operator does not support setting a priority class name.

As we use the tailscale proxy for cluster access, we want to support setting a priority class name so that during cluster outages, we can prioritize it's quick return.