### PR TITLE
util/eventbus: when ts_omit_debugeventbus is set, don't import tsweb

### DIFF
--- a/util/eventbus/debughttp_off.go
+++ b/util/eventbus/debughttp_off.go
@@ -5,9 +5,7 @@
 
 package eventbus
 
-import "tailscale.com/tsweb"
-
-func registerHTTPDebugger(d *Debugger, td *tsweb.DebugHandler) {
+func registerHTTPDebugger(d *Debugger, tsWebDebugHandler any) {
 	// The event bus debugging UI uses html/template, which uses
 	// reflection for method lookups. This forces the compiler to
 	// retain a lot more code and information to make dynamic method


### PR DESCRIPTION
I'm trying to remove the "regexp" and "regexp/syntax" packages from
our minimal builds. But tsweb pulls in regexp (via net/http/pprof etc)
and util/eventbus was importing the tsweb for no reason.

Updates #12614
