### PR TITLE
types/key: add IsZero method to HardwareAttestationKey

### DIFF
--- a/feature/tpm/attestation.go
+++ b/feature/tpm/attestation.go
@@ -262,3 +262,5 @@ func (ak *attestationKey) Clone() key.HardwareAttestationKey {
 		pub:        ak.pub,
 	}
 }
+
+func (ak *attestationKey) IsZero() bool { return !ak.loaded() }

--- a/types/key/hardware_attestation.go
+++ b/types/key/hardware_attestation.go
@@ -32,6 +32,7 @@ type HardwareAttestationKey interface {
 	json.Unmarshaler
 	io.Closer
 	Clone() HardwareAttestationKey
+	IsZero() bool
 }
 
 // HardwareAttestationPublicFromPlatformKey creates a HardwareAttestationPublic


### PR DESCRIPTION
We will need this for unmarshaling node prefs: use the zero HardwareAttestationKey implementation when parsing and later check `IsZero` to see if anything was loaded.

Updates #15830