### PR TITLE
cmd/k8s-proxy: importing feature/condregister on cmd/k8s-proxy

### DIFF
--- a/cmd/k8s-proxy/k8s-proxy.go
+++ b/cmd/k8s-proxy/k8s-proxy.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/utils/strings/slices"
 	"tailscale.com/client/local"
 	"tailscale.com/cmd/k8s-proxy/internal/config"
+	_ "tailscale.com/feature/condregister"
 	"tailscale.com/hostinfo"
 	"tailscale.com/ipn"
 	"tailscale.com/ipn/store"


### PR DESCRIPTION
https://github.com/tailscale/tailscale/pull/17346 moved the kube and aws arn store initializations to feature/condregister, under the assumption that anything using it would use kubestore.New. Unfortunately, cmd/k8s-proxy makes use of store.New, which compares the `<prefix>:` supplied in the provided `path string` argument against known stores. If it doesn't find it, it fallsback to using a FileStore.

Since cmd/k8s-proxy uses store.New to try and initialize a kube store in some cases (without importing feature/condregister), it silently creates a FileStore and that leads to misleading errors further along in execution.

This fixes this issue by importing condregister, and successfully initializes a kube store.

Updates #12614