### PR TITLE
ipn/store, feature/condregister: permit callers to empty import optonal ipn stores

### DIFF
--- a/feature/condregister/maybe_store_aws.go
+++ b/feature/condregister/maybe_store_aws.go
@@ -5,19 +5,4 @@
 
 package condregister
 
-import (
-	"tailscale.com/ipn"
-	"tailscale.com/ipn/store"
-	"tailscale.com/ipn/store/awsstore"
-	"tailscale.com/types/logger"
-)
-
-func init() {
-	store.Register("arn:", func(logf logger.Logf, arg string) (ipn.StateStore, error) {
-		ssmARN, opts, err := awsstore.ParseARNAndOpts(arg)
-		if err != nil {
-			return nil, err
-		}
-		return awsstore.New(logf, ssmARN, opts...)
-	})
-}
+import _ "tailscale.com/ipn/store/awsstore"

--- a/feature/condregister/maybe_store_kube.go
+++ b/feature/condregister/maybe_store_kube.go
@@ -5,18 +5,4 @@
 
 package condregister
 
-import (
-	"strings"
-
-	"tailscale.com/ipn"
-	"tailscale.com/ipn/store"
-	"tailscale.com/ipn/store/kubestore"
-	"tailscale.com/types/logger"
-)
-
-func init() {
-	store.Register("kube:", func(logf logger.Logf, path string) (ipn.StateStore, error) {
-		secretName := strings.TrimPrefix(path, "kube:")
-		return kubestore.New(logf, secretName)
-	})
-}
+import _ "tailscale.com/ipn/store/kubestore"

--- a/ipn/store/awsstore/store_aws.go
+++ b/ipn/store/awsstore/store_aws.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build linux && !ts_omit_aws
+//go:build !ts_omit_aws
 
 // Package awsstore contains an ipn.StateStore implementation using AWS SSM.
 package awsstore
@@ -20,9 +20,20 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	ssmTypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"tailscale.com/ipn"
+	"tailscale.com/ipn/store"
 	"tailscale.com/ipn/store/mem"
 	"tailscale.com/types/logger"
 )
+
+func init() {
+	store.Register("arn:", func(logf logger.Logf, arg string) (ipn.StateStore, error) {
+		ssmARN, opts, err := ParseARNAndOpts(arg)
+		if err != nil {
+			return nil, err
+		}
+		return New(logf, ssmARN, opts...)
+	})
+}
 
 const (
 	parameterNameRxStr = `^parameter(/.*)`

--- a/ipn/store/awsstore/store_aws_test.go
+++ b/ipn/store/awsstore/store_aws_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build linux && !ts_omit_aws
+//go:build !ts_omit_aws
 
 package awsstore
 

--- a/ipn/store/kubestore/store_kube.go
+++ b/ipn/store/kubestore/store_kube.go
@@ -16,6 +16,7 @@ import (
 
 	"tailscale.com/envknob"
 	"tailscale.com/ipn"
+	"tailscale.com/ipn/store"
 	"tailscale.com/ipn/store/mem"
 	"tailscale.com/kube/kubeapi"
 	"tailscale.com/kube/kubeclient"
@@ -24,6 +25,13 @@ import (
 	"tailscale.com/util/dnsname"
 	"tailscale.com/util/mak"
 )
+
+func init() {
+	store.Register("kube:", func(logf logger.Logf, path string) (ipn.StateStore, error) {
+		secretName := strings.TrimPrefix(path, "kube:")
+		return New(logf, secretName)
+	})
+}
 
 const (
 	// timeout is the timeout for a single state update that includes calls to the API server to write or read a


### PR DESCRIPTION
This permits other programs (in other repos) to conditionally
import ipn/store/awsstore and/or ipn/store/kubestore and have them
register themselves, rather than feature/condregister doing it.

Updates tailscale/corp#32922
