### PR TITLE
build_docker.sh: support including extra files

### DIFF
--- a/build_docker.sh
+++ b/build_docker.sh
@@ -38,6 +38,7 @@ TARGET="${TARGET:-${DEFAULT_TARGET}}"
 TAGS="${TAGS:-${DEFAULT_TAGS}}"
 BASE="${BASE:-${DEFAULT_BASE}}"
 PLATFORM="${PLATFORM:-}" # default to all platforms
+FILES="${FILES:-}" # default to no extra files
 # OCI annotations that will be added to the image.
 # https://github.com/opencontainers/image-spec/blob/main/annotations.md
 ANNOTATIONS="${ANNOTATIONS:-${DEFAULT_ANNOTATIONS}}"
@@ -62,6 +63,7 @@ case "$TARGET" in
       --push="${PUSH}" \
       --target="${PLATFORM}" \
       --annotations="${ANNOTATIONS}" \
+      --files="${FILES}" \
       /usr/local/bin/containerboot
     ;;
   k8s-operator)
@@ -80,6 +82,7 @@ case "$TARGET" in
       --push="${PUSH}" \
       --target="${PLATFORM}" \
       --annotations="${ANNOTATIONS}" \
+      --files="${FILES}" \
       /usr/local/bin/operator
     ;;
   k8s-nameserver)
@@ -98,6 +101,7 @@ case "$TARGET" in
       --push="${PUSH}" \
       --target="${PLATFORM}" \
       --annotations="${ANNOTATIONS}" \
+      --files="${FILES}" \
       /usr/local/bin/k8s-nameserver
     ;;
   tsidp)
@@ -116,6 +120,7 @@ case "$TARGET" in
       --push="${PUSH}" \
       --target="${PLATFORM}" \
       --annotations="${ANNOTATIONS}" \
+      --files="${FILES}" \
       /usr/local/bin/tsidp
     ;;
   k8s-proxy)
@@ -134,6 +139,7 @@ case "$TARGET" in
       --push="${PUSH}" \
       --target="${PLATFORM}" \
       --annotations="${ANNOTATIONS}" \
+      --files="${FILES}" \
       /usr/local/bin/k8s-proxy
     ;;
   *)


### PR DESCRIPTION
mkctr already has support for including extra files in the built container image. Wire up a new optional environment variable to thread that through to mkctr. The operator e2e tests will use this to bake additional trusted CAs into the test image without significantly departing from the normal build or deployment process for our containers.

Updates tailscale/corp#32085

Change-Id: Ica94ed270da13782c4f5524fdc949f9218f79477