### PR TITLE
cmd/k8s-operator: add .gitignore for generated chart CRDs

### DIFF
--- a/cmd/k8s-operator/deploy/chart/templates/.gitignore
+++ b/cmd/k8s-operator/deploy/chart/templates/.gitignore
@@ -1,0 +1,10 @@
+# Don't add helm chart CRDs to git. Canonical CRD files live in
+# cmd/k8s-operator/deploy/crds.
+#
+# Generate for local usage with:
+# go run tailscale.com/cmd/k8s-operator/generate helmcrd
+/connector.yaml
+/dnsconfig.yaml
+/proxyclass.yaml
+/proxygroup.yaml
+/recorder.yaml

--- a/cmd/k8s-operator/generate/main.go
+++ b/cmd/k8s-operator/generate/main.go
@@ -41,11 +41,16 @@ func main() {
 	if len(os.Args) < 2 {
 		log.Fatalf("usage ./generate [staticmanifests|helmcrd]")
 	}
-	repoRoot := "../../"
+	gitOut, err := exec.Command("git", "rev-parse", "--show-toplevel").CombinedOutput()
+	if err != nil {
+		log.Fatalf("error determining git root: %v: %s", err, gitOut)
+	}
+
+	repoRoot := strings.TrimSpace(string(gitOut))
 	switch os.Args[1] {
 	case "helmcrd": // insert CRDs to Helm templates behind a installCRDs=true conditional check
 		log.Print("Adding CRDs to Helm templates")
-		if err := generate("./"); err != nil {
+		if err := generate(repoRoot); err != nil {
 			log.Fatalf("error adding CRDs to Helm templates: %v", err)
 		}
 		return

--- a/cmd/k8s-operator/operator.go
+++ b/cmd/k8s-operator/operator.go
@@ -67,6 +67,9 @@ import (
 // Generate static manifests for deploying Tailscale operator on Kubernetes from the operator's Helm chart.
 //go:generate go run tailscale.com/cmd/k8s-operator/generate staticmanifests
 
+// Generate the helm chart's CRDs (which are ignored from git).
+//go:generate go run tailscale.com/cmd/k8s-operator/generate helmcrd
+
 // Generate CRD API docs.
 //go:generate go run github.com/elastic/crd-ref-docs --renderer=markdown --source-path=../../k8s-operator/apis/ --config=../../k8s-operator/api-docs-config.yaml --output-path=../../k8s-operator/api.md
 


### PR DESCRIPTION
Add a .gitignore for the chart version of the CRDs that we never commit, because the static manifest CRD files are the canonical version. This makes it easier to deploy the CRDs via the helm chart in a way that reflects the production workflow without making the git checkout "dirty".

Given that the chart CRDs are ignored, we can also now safely generate them for the kube-generate-all Makefile target without being a nuisance to the state of the git checkout. Added a slightly more robust repo root detection to the generation logic to make sure the command works from the context of both the Makefile and the image builder command we run for releases in corp.

Updates tailscale/corp#32085

Change-Id: Id44a4707c183bfaf95a160911ec7a42ffb1a1287