### PR TITLE
appc,ipn/ipnlocal: receive AppConnector updates via the event bus

### DIFF
--- a/appc/appconnector.go
+++ b/appc/appconnector.go
@@ -134,8 +134,9 @@ type AppConnector struct {
 	updatePub       *eventbus.Publisher[appctype.RouteUpdate]
 	storePub        *eventbus.Publisher[appctype.RouteInfo]
 
-	// storeRoutesFunc will be called to persist routes if it is not nil.
-	storeRoutesFunc func(*appctype.RouteInfo) error
+	// hasStoredRoutes records whether the connector was initialized with
+	// persisted route information.
+	hasStoredRoutes bool
 
 	// mu guards the fields that follow
 	mu sync.Mutex
@@ -168,16 +169,14 @@ type Config struct {
 	EventBus *eventbus.Bus
 
 	// RouteAdvertiser allows the connector to update the set of advertised routes.
-	// It must be non-nil.
 	RouteAdvertiser RouteAdvertiser
 
 	// RouteInfo, if non-nil, use used as the initial set of routes for the
 	// connector.  If nil, the connector starts empty.
 	RouteInfo *appctype.RouteInfo
 
-	// StoreRoutesFunc, if non-nil, is called when the connector's routes
-	// change, to allow the routes to be persisted.
-	StoreRoutesFunc func(*appctype.RouteInfo) error
+	// HasStoredRoutes indicates that the connector should assume stored routes.
+	HasStoredRoutes bool
 }
 
 // NewAppConnector creates a new AppConnector.
@@ -197,7 +196,7 @@ func NewAppConnector(c Config) *AppConnector {
 		updatePub:       eventbus.Publish[appctype.RouteUpdate](ec),
 		storePub:        eventbus.Publish[appctype.RouteInfo](ec),
 		routeAdvertiser: c.RouteAdvertiser,
-		storeRoutesFunc: c.StoreRoutesFunc,
+		hasStoredRoutes: c.HasStoredRoutes,
 	}
 	if c.RouteInfo != nil {
 		ac.domains = c.RouteInfo.Domains
@@ -216,13 +215,19 @@ func NewAppConnector(c Config) *AppConnector {
 
 // ShouldStoreRoutes returns true if the appconnector was created with the controlknob on
 // and is storing its discovered routes persistently.
-func (e *AppConnector) ShouldStoreRoutes() bool {
-	return e.storeRoutesFunc != nil
-}
+func (e *AppConnector) ShouldStoreRoutes() bool { return e.hasStoredRoutes }
 
 // storeRoutesLocked takes the current state of the AppConnector and persists it
-func (e *AppConnector) storeRoutesLocked() error {
+func (e *AppConnector) storeRoutesLocked() {
 	if e.storePub.ShouldPublish() {
+		// log write rate and write size
+		numRoutes := int64(len(e.controlRoutes))
+		for _, rs := range e.domains {
+			numRoutes += int64(len(rs))
+		}
+		e.writeRateMinute.update(numRoutes)
+		e.writeRateDay.update(numRoutes)
+
 		e.storePub.Publish(appctype.RouteInfo{
 			// Clone here, as the subscriber will handle these outside our lock.
 			Control:   slices.Clone(e.controlRoutes),
@@ -230,24 +235,6 @@ func (e *AppConnector) storeRoutesLocked() error {
 			Wildcards: slices.Clone(e.wildcards),
 		})
 	}
-	if !e.ShouldStoreRoutes() {
-		return nil
-	}
-
-	// log write rate and write size
-	numRoutes := int64(len(e.controlRoutes))
-	for _, rs := range e.domains {
-		numRoutes += int64(len(rs))
-	}
-	e.writeRateMinute.update(numRoutes)
-	e.writeRateDay.update(numRoutes)
-
-	// TODO(creachdair): Remove this once it's delivered over the event bus.
-	return e.storeRoutesFunc(&appctype.RouteInfo{
-		Control:   e.controlRoutes,
-		Domains:   e.domains,
-		Wildcards: e.wildcards,
-	})
 }
 
 // ClearRoutes removes all route state from the AppConnector.
@@ -257,7 +244,8 @@ func (e *AppConnector) ClearRoutes() error {
 	e.controlRoutes = nil
 	e.domains = nil
 	e.wildcards = nil
-	return e.storeRoutesLocked()
+	e.storeRoutesLocked()
+	return nil
 }
 
 // UpdateDomainsAndRoutes starts an asynchronous update of the configuration
@@ -329,9 +317,9 @@ func (e *AppConnector) updateDomains(domains []string) {
 		}
 	}
 
-	// Everything left in oldDomains is a domain we're no longer tracking
-	// and if we are storing route info we can unadvertise the routes
-	if e.ShouldStoreRoutes() {
+	// Everything left in oldDomains is a domain we're no longer tracking and we
+	// can unadvertise the routes.
+	if e.hasStoredRoutes {
 		toRemove := []netip.Prefix{}
 		for _, addrs := range oldDomains {
 			for _, a := range addrs {
@@ -369,11 +357,10 @@ func (e *AppConnector) updateRoutes(routes []netip.Prefix) {
 
 	var toRemove []netip.Prefix
 
-	// If we're storing routes and know e.controlRoutes is a good
-	// representation of what should be in AdvertisedRoutes we can stop
-	// advertising routes that used to be in e.controlRoutes but are not
-	// in routes.
-	if e.ShouldStoreRoutes() {
+	// If we know e.controlRoutes is a good representation of what should be in
+	// AdvertisedRoutes we can stop advertising routes that used to be in
+	// e.controlRoutes but are not in routes.
+	if e.hasStoredRoutes {
 		toRemove = routesWithout(e.controlRoutes, routes)
 	}
 
@@ -406,9 +393,7 @@ nextRoute:
 	})
 
 	e.controlRoutes = routes
-	if err := e.storeRoutesLocked(); err != nil {
-		e.logf("failed to store route info: %v", err)
-	}
+	e.storeRoutesLocked()
 }
 
 // Domains returns the currently configured domain list.
@@ -507,9 +492,7 @@ func (e *AppConnector) scheduleAdvertisement(domain string, routes ...netip.Pref
 				e.logf("[v2] advertised route for %v: %v", domain, addr)
 			}
 		}
-		if err := e.storeRoutesLocked(); err != nil {
-			e.logf("failed to store route info: %v", err)
-		}
+		e.storeRoutesLocked()
 	})
 }
 

--- a/appc/appconnector.go
+++ b/appc/appconnector.go
@@ -187,8 +187,6 @@ func NewAppConnector(c Config) *AppConnector {
 		panic("missing logger")
 	case c.EventBus == nil:
 		panic("missing event bus")
-	case c.RouteAdvertiser == nil:
-		panic("missing route advertiser")
 	}
 	ec := c.EventBus.Client("appc.AppConnector")
 
@@ -342,11 +340,13 @@ func (e *AppConnector) updateDomains(domains []string) {
 		}
 
 		if len(toRemove) != 0 {
-			e.queue.Add(func() {
-				if err := e.routeAdvertiser.UnadvertiseRoute(toRemove...); err != nil {
-					e.logf("failed to unadvertise routes on domain removal: %v: %v: %v", slicesx.MapKeys(oldDomains), toRemove, err)
-				}
-			})
+			if ra := e.routeAdvertiser; ra != nil {
+				e.queue.Add(func() {
+					if err := e.routeAdvertiser.UnadvertiseRoute(toRemove...); err != nil {
+						e.logf("failed to unadvertise routes on domain removal: %v: %v: %v", slicesx.MapKeys(oldDomains), toRemove, err)
+					}
+				})
+			}
 			e.updatePub.Publish(appctype.RouteUpdate{Unadvertise: toRemove})
 		}
 	}
@@ -390,14 +390,16 @@ nextRoute:
 		}
 	}
 
-	e.queue.Add(func() {
-		if err := e.routeAdvertiser.AdvertiseRoute(routes...); err != nil {
-			e.logf("failed to advertise routes: %v: %v", routes, err)
-		}
-		if err := e.routeAdvertiser.UnadvertiseRoute(toRemove...); err != nil {
-			e.logf("failed to unadvertise routes: %v: %v", toRemove, err)
-		}
-	})
+	if e.routeAdvertiser != nil {
+		e.queue.Add(func() {
+			if err := e.routeAdvertiser.AdvertiseRoute(routes...); err != nil {
+				e.logf("failed to advertise routes: %v: %v", routes, err)
+			}
+			if err := e.routeAdvertiser.UnadvertiseRoute(toRemove...); err != nil {
+				e.logf("failed to unadvertise routes: %v: %v", toRemove, err)
+			}
+		})
+	}
 	e.updatePub.Publish(appctype.RouteUpdate{
 		Advertise:   routes,
 		Unadvertise: toRemove,
@@ -485,9 +487,11 @@ func (e *AppConnector) isAddrKnownLocked(domain string, addr netip.Addr) bool {
 // associated with the given domain.
 func (e *AppConnector) scheduleAdvertisement(domain string, routes ...netip.Prefix) {
 	e.queue.Add(func() {
-		if err := e.routeAdvertiser.AdvertiseRoute(routes...); err != nil {
-			e.logf("failed to advertise routes for %s: %v: %v", domain, routes, err)
-			return
+		if e.routeAdvertiser != nil {
+			if err := e.routeAdvertiser.AdvertiseRoute(routes...); err != nil {
+				e.logf("failed to advertise routes for %s: %v: %v", domain, routes, err)
+				return
+			}
 		}
 		e.updatePub.Publish(appctype.RouteUpdate{Advertise: routes})
 		e.mu.Lock()

--- a/appc/appconnector_test.go
+++ b/appc/appconnector_test.go
@@ -26,24 +26,15 @@ import (
 	"tailscale.com/util/slicesx"
 )
 
-func fakeStoreRoutes(*appctype.RouteInfo) error { return nil }
-
 func TestUpdateDomains(t *testing.T) {
 	ctx := t.Context()
 	bus := eventbustest.NewBus(t)
 	for _, shouldStore := range []bool{false, true} {
-		var a *AppConnector
-		if shouldStore {
-			a = NewAppConnector(Config{
-				Logf:            t.Logf,
-				EventBus:        bus,
-				RouteAdvertiser: &appctest.RouteCollector{},
-				RouteInfo:       &appctype.RouteInfo{},
-				StoreRoutesFunc: fakeStoreRoutes,
-			})
-		} else {
-			a = NewAppConnector(Config{Logf: t.Logf, EventBus: bus, RouteAdvertiser: &appctest.RouteCollector{}})
-		}
+		a := NewAppConnector(Config{
+			Logf:            t.Logf,
+			EventBus:        bus,
+			HasStoredRoutes: shouldStore,
+		})
 		t.Cleanup(a.Close)
 
 		a.UpdateDomains([]string{"example.com"})
@@ -76,18 +67,12 @@ func TestUpdateRoutes(t *testing.T) {
 	for _, shouldStore := range []bool{false, true} {
 		w := eventbustest.NewWatcher(t, bus)
 		rc := &appctest.RouteCollector{}
-		var a *AppConnector
-		if shouldStore {
-			a = NewAppConnector(Config{
-				Logf:            t.Logf,
-				EventBus:        bus,
-				RouteAdvertiser: rc,
-				RouteInfo:       &appctype.RouteInfo{},
-				StoreRoutesFunc: fakeStoreRoutes,
-			})
-		} else {
-			a = NewAppConnector(Config{Logf: t.Logf, EventBus: bus, RouteAdvertiser: rc})
-		}
+		a := NewAppConnector(Config{
+			Logf:            t.Logf,
+			EventBus:        bus,
+			RouteAdvertiser: rc,
+			HasStoredRoutes: shouldStore,
+		})
 		t.Cleanup(a.Close)
 
 		a.updateDomains([]string{"*.example.com"})
@@ -149,18 +134,12 @@ func TestUpdateRoutesUnadvertisesContainedRoutes(t *testing.T) {
 	for _, shouldStore := range []bool{false, true} {
 		w := eventbustest.NewWatcher(t, bus)
 		rc := &appctest.RouteCollector{}
-		var a *AppConnector
-		if shouldStore {
-			a = NewAppConnector(Config{
-				Logf:            t.Logf,
-				EventBus:        bus,
-				RouteAdvertiser: rc,
-				RouteInfo:       &appctype.RouteInfo{},
-				StoreRoutesFunc: fakeStoreRoutes,
-			})
-		} else {
-			a = NewAppConnector(Config{Logf: t.Logf, EventBus: bus, RouteAdvertiser: rc})
-		}
+		a := NewAppConnector(Config{
+			Logf:            t.Logf,
+			EventBus:        bus,
+			RouteAdvertiser: rc,
+			HasStoredRoutes: shouldStore,
+		})
 		t.Cleanup(a.Close)
 
 		mak.Set(&a.domains, "example.com", []netip.Addr{netip.MustParseAddr("192.0.2.1")})
@@ -190,18 +169,12 @@ func TestDomainRoutes(t *testing.T) {
 	for _, shouldStore := range []bool{false, true} {
 		w := eventbustest.NewWatcher(t, bus)
 		rc := &appctest.RouteCollector{}
-		var a *AppConnector
-		if shouldStore {
-			a = NewAppConnector(Config{
-				Logf:            t.Logf,
-				EventBus:        bus,
-				RouteAdvertiser: rc,
-				RouteInfo:       &appctype.RouteInfo{},
-				StoreRoutesFunc: fakeStoreRoutes,
-			})
-		} else {
-			a = NewAppConnector(Config{Logf: t.Logf, EventBus: bus, RouteAdvertiser: rc})
-		}
+		a := NewAppConnector(Config{
+			Logf:            t.Logf,
+			EventBus:        bus,
+			RouteAdvertiser: rc,
+			HasStoredRoutes: shouldStore,
+		})
 		t.Cleanup(a.Close)
 		a.updateDomains([]string{"example.com"})
 		if err := a.ObserveDNSResponse(dnsResponse("example.com.", "192.0.0.8")); err != nil {
@@ -232,18 +205,12 @@ func TestObserveDNSResponse(t *testing.T) {
 	for _, shouldStore := range []bool{false, true} {
 		w := eventbustest.NewWatcher(t, bus)
 		rc := &appctest.RouteCollector{}
-		var a *AppConnector
-		if shouldStore {
-			a = NewAppConnector(Config{
-				Logf:            t.Logf,
-				EventBus:        bus,
-				RouteAdvertiser: rc,
-				RouteInfo:       &appctype.RouteInfo{},
-				StoreRoutesFunc: fakeStoreRoutes,
-			})
-		} else {
-			a = NewAppConnector(Config{Logf: t.Logf, EventBus: bus, RouteAdvertiser: rc})
-		}
+		a := NewAppConnector(Config{
+			Logf:            t.Logf,
+			EventBus:        bus,
+			RouteAdvertiser: rc,
+			HasStoredRoutes: shouldStore,
+		})
 		t.Cleanup(a.Close)
 
 		// a has no domains configured, so it should not advertise any routes
@@ -346,18 +313,12 @@ func TestWildcardDomains(t *testing.T) {
 	for _, shouldStore := range []bool{false, true} {
 		w := eventbustest.NewWatcher(t, bus)
 		rc := &appctest.RouteCollector{}
-		var a *AppConnector
-		if shouldStore {
-			a = NewAppConnector(Config{
-				Logf:            t.Logf,
-				EventBus:        bus,
-				RouteAdvertiser: rc,
-				RouteInfo:       &appctype.RouteInfo{},
-				StoreRoutesFunc: fakeStoreRoutes,
-			})
-		} else {
-			a = NewAppConnector(Config{Logf: t.Logf, EventBus: bus, RouteAdvertiser: rc})
-		}
+		a := NewAppConnector(Config{
+			Logf:            t.Logf,
+			EventBus:        bus,
+			RouteAdvertiser: rc,
+			HasStoredRoutes: shouldStore,
+		})
 		t.Cleanup(a.Close)
 
 		a.updateDomains([]string{"*.example.com"})
@@ -522,18 +483,12 @@ func TestUpdateRouteRouteRemoval(t *testing.T) {
 			}
 		}
 
-		var a *AppConnector
-		if shouldStore {
-			a = NewAppConnector(Config{
-				Logf:            t.Logf,
-				EventBus:        bus,
-				RouteAdvertiser: rc,
-				RouteInfo:       &appctype.RouteInfo{},
-				StoreRoutesFunc: fakeStoreRoutes,
-			})
-		} else {
-			a = NewAppConnector(Config{Logf: t.Logf, EventBus: bus, RouteAdvertiser: rc})
-		}
+		a := NewAppConnector(Config{
+			Logf:            t.Logf,
+			EventBus:        bus,
+			RouteAdvertiser: rc,
+			HasStoredRoutes: shouldStore,
+		})
 		t.Cleanup(a.Close)
 
 		// nothing has yet been advertised
@@ -584,18 +539,12 @@ func TestUpdateDomainRouteRemoval(t *testing.T) {
 			}
 		}
 
-		var a *AppConnector
-		if shouldStore {
-			a = NewAppConnector(Config{
-				Logf:            t.Logf,
-				EventBus:        bus,
-				RouteAdvertiser: rc,
-				RouteInfo:       &appctype.RouteInfo{},
-				StoreRoutesFunc: fakeStoreRoutes,
-			})
-		} else {
-			a = NewAppConnector(Config{Logf: t.Logf, EventBus: bus, RouteAdvertiser: rc})
-		}
+		a := NewAppConnector(Config{
+			Logf:            t.Logf,
+			EventBus:        bus,
+			RouteAdvertiser: rc,
+			HasStoredRoutes: shouldStore,
+		})
 		t.Cleanup(a.Close)
 
 		assertRoutes("appc init", []netip.Prefix{}, []netip.Prefix{})
@@ -665,18 +614,12 @@ func TestUpdateWildcardRouteRemoval(t *testing.T) {
 			}
 		}
 
-		var a *AppConnector
-		if shouldStore {
-			a = NewAppConnector(Config{
-				Logf:            t.Logf,
-				EventBus:        bus,
-				RouteAdvertiser: rc,
-				RouteInfo:       &appctype.RouteInfo{},
-				StoreRoutesFunc: fakeStoreRoutes,
-			})
-		} else {
-			a = NewAppConnector(Config{Logf: t.Logf, EventBus: bus, RouteAdvertiser: rc})
-		}
+		a := NewAppConnector(Config{
+			Logf:            t.Logf,
+			EventBus:        bus,
+			RouteAdvertiser: rc,
+			HasStoredRoutes: shouldStore,
+		})
 		t.Cleanup(a.Close)
 
 		assertRoutes("appc init", []netip.Prefix{}, []netip.Prefix{})
@@ -842,8 +785,7 @@ func TestUpdateRoutesDeadlock(t *testing.T) {
 		Logf:            t.Logf,
 		EventBus:        bus,
 		RouteAdvertiser: rc,
-		RouteInfo:       &appctype.RouteInfo{},
-		StoreRoutesFunc: fakeStoreRoutes,
+		HasStoredRoutes: true,
 	})
 	t.Cleanup(a.Close)
 

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -588,6 +588,8 @@ func (b *LocalBackend) consumeEventbusTopics(ec *eventbus.Client) func(*eventbus
 	autoUpdateSub := eventbus.Subscribe[controlclient.AutoUpdate](ec)
 	healthChangeSub := eventbus.Subscribe[health.Change](ec)
 	changeDeltaSub := eventbus.Subscribe[netmon.ChangeDelta](ec)
+	routeUpdateSub := eventbus.Subscribe[appctype.RouteUpdate](ec)
+	storeRoutesSub := eventbus.Subscribe[appctype.RouteInfo](ec)
 
 	var portlist <-chan PortlistServices
 	if buildfeatures.HasPortList {
@@ -608,9 +610,25 @@ func (b *LocalBackend) consumeEventbusTopics(ec *eventbus.Client) func(*eventbus
 				b.onHealthChange(change)
 			case changeDelta := <-changeDeltaSub.Events():
 				b.linkChange(&changeDelta)
+
 			case pl := <-portlist:
 				if buildfeatures.HasPortList { // redundant, but explicit for linker deadcode and humans
 					b.setPortlistServices(pl)
+				}
+			case ru := <-routeUpdateSub.Events():
+				if err := b.AdvertiseRoute(ru.Advertise...); err != nil {
+					b.logf("appc: failed to advertise routes: %v: %v", ru.Advertise, err)
+				}
+				if err := b.UnadvertiseRoute(ru.Unadvertise...); err != nil {
+					b.logf("appc: failed to unadvertise routes: %v: %v", ru.Unadvertise, err)
+				}
+			case ri := <-storeRoutesSub.Events():
+				// Whether or not routes should be stored can change over time.
+				shouldStoreRoutes := b.ControlKnobs().AppCStoreRoutes.Load()
+				if shouldStoreRoutes {
+					if err := b.storeRouteInfo(ri); err != nil {
+						b.logf("appc: failed to store route info: %v", err)
+					}
 				}
 			}
 		}
@@ -4824,35 +4842,27 @@ func (b *LocalBackend) reconfigAppConnectorLocked(nm *netmap.NetworkMap, prefs i
 		}
 	}()
 
+	// App connectors have been disabled.
 	if !prefs.AppConnector().Advertise {
 		b.appConnector.Close() // clean up a previous connector (safe on nil)
 		b.appConnector = nil
 		return
 	}
 
-	shouldAppCStoreRoutes := b.ControlKnobs().AppCStoreRoutes.Load()
-	if b.appConnector == nil || b.appConnector.ShouldStoreRoutes() != shouldAppCStoreRoutes {
-		var ri *appctype.RouteInfo
-		var storeFunc func(*appctype.RouteInfo) error
-		if shouldAppCStoreRoutes {
-			var err error
-			ri, err = b.readRouteInfoLocked()
-			if err != nil {
-				ri = &appctype.RouteInfo{}
-				if err != ipn.ErrStateNotExist {
-					b.logf("Unsuccessful Read RouteInfo: ", err)
-				}
-			}
-			storeFunc = b.storeRouteInfo
+	// We don't (yet) have an app connector configured, or the configured
+	// connector has a different route persistence setting.
+	shouldStoreRoutes := b.ControlKnobs().AppCStoreRoutes.Load()
+	if b.appConnector == nil || (shouldStoreRoutes != b.appConnector.ShouldStoreRoutes()) {
+		ri, err := b.readRouteInfoLocked()
+		if err != nil && err != ipn.ErrStateNotExist {
+			b.logf("Unsuccessful Read RouteInfo: %v", err)
 		}
-
 		b.appConnector.Close() // clean up a previous connector (safe on nil)
 		b.appConnector = appc.NewAppConnector(appc.Config{
 			Logf:            b.logf,
 			EventBus:        b.sys.Bus.Get(),
-			RouteAdvertiser: b,
 			RouteInfo:       ri,
-			StoreRoutesFunc: storeFunc,
+			HasStoredRoutes: shouldStoreRoutes,
 		})
 	}
 	if nm == nil {
@@ -6963,9 +6973,9 @@ func (b *LocalBackend) ObserveDNSResponse(res []byte) error {
 // ErrDisallowedAutoRoute is returned by AdvertiseRoute when a route that is not allowed is requested.
 var ErrDisallowedAutoRoute = errors.New("route is not allowed")
 
-// AdvertiseRoute implements the appc.RouteAdvertiser interface. It sets a new
-// route advertisement if one is not already present in the existing routes.
-// If the route is disallowed, ErrDisallowedAutoRoute is returned.
+// AdvertiseRoute implements the appctype.RouteAdvertiser interface. It sets a
+// new route advertisement if one is not already present in the existing
+// routes.  If the route is disallowed, ErrDisallowedAutoRoute is returned.
 func (b *LocalBackend) AdvertiseRoute(ipps ...netip.Prefix) error {
 	finalRoutes := b.Prefs().AdvertiseRoutes().AsSlice()
 	var newRoutes []netip.Prefix
@@ -7021,8 +7031,8 @@ func coveredRouteRangeNoDefault(finalRoutes []netip.Prefix, ipp netip.Prefix) bo
 	return false
 }
 
-// UnadvertiseRoute implements the appc.RouteAdvertiser interface. It removes
-// a route advertisement if one is present in the existing routes.
+// UnadvertiseRoute implements the appctype.RouteAdvertiser interface. It
+// removes a route advertisement if one is present in the existing routes.
 func (b *LocalBackend) UnadvertiseRoute(toRemove ...netip.Prefix) error {
 	currentRoutes := b.Prefs().AdvertiseRoutes().AsSlice()
 	finalRoutes := currentRoutes[:0]
@@ -7050,7 +7060,7 @@ func namespaceKeyForCurrentProfile(pm *profileManager, key ipn.StateKey) ipn.Sta
 
 const routeInfoStateStoreKey ipn.StateKey = "_routeInfo"
 
-func (b *LocalBackend) storeRouteInfo(ri *appctype.RouteInfo) error {
+func (b *LocalBackend) storeRouteInfo(ri appctype.RouteInfo) error {
 	if !buildfeatures.HasAppConnectors {
 		return feature.ErrUnavailable
 	}

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -616,6 +616,11 @@ func (b *LocalBackend) consumeEventbusTopics(ec *eventbus.Client) func(*eventbus
 					b.setPortlistServices(pl)
 				}
 			case ru := <-routeUpdateSub.Events():
+				// TODO(creachadair, 2025-10-02): It is currently possible for updates produced under
+				// one profile to arrive and be applied after a switch to another profile.
+				// We need to find a way to ensure that changes to the backend state are applied
+				// consistently in the presnce of profile changes, which currently may not happen in
+				// a single atomic step.  See: https://github.com/tailscale/tailscale/issues/17414
 				if err := b.AdvertiseRoute(ru.Advertise...); err != nil {
 					b.logf("appc: failed to advertise routes: %v: %v", ru.Advertise, err)
 				}

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -75,8 +75,6 @@ import (
 	"tailscale.com/wgengine/wgcfg"
 )
 
-func fakeStoreRoutes(*appctype.RouteInfo) error { return nil }
-
 func inRemove(ip netip.Addr) bool {
 	for _, pfx := range removeFromDefaultRoute {
 		if pfx.Contains(ip) {
@@ -2312,14 +2310,9 @@ func TestOfferingAppConnector(t *testing.T) {
 		if b.OfferingAppConnector() {
 			t.Fatal("unexpected offering app connector")
 		}
-		rc := &appctest.RouteCollector{}
-		if shouldStore {
-			b.appConnector = appc.NewAppConnector(appc.Config{
-				Logf: t.Logf, EventBus: bus, RouteAdvertiser: rc, RouteInfo: &appctype.RouteInfo{}, StoreRoutesFunc: fakeStoreRoutes,
-			})
-		} else {
-			b.appConnector = appc.NewAppConnector(appc.Config{Logf: t.Logf, EventBus: bus, RouteAdvertiser: rc})
-		}
+		b.appConnector = appc.NewAppConnector(appc.Config{
+			Logf: t.Logf, EventBus: bus, HasStoredRoutes: shouldStore,
+		})
 		if !b.OfferingAppConnector() {
 			t.Fatal("unexpected not offering app connector")
 		}
@@ -2370,6 +2363,7 @@ func TestObserveDNSResponse(t *testing.T) {
 	for _, shouldStore := range []bool{false, true} {
 		b := newTestBackend(t)
 		bus := b.sys.Bus.Get()
+		w := eventbustest.NewWatcher(t, bus)
 
 		// ensure no error when no app connector is configured
 		if err := b.ObserveDNSResponse(dnsResponse("example.com.", "192.0.0.8")); err != nil {
@@ -2377,27 +2371,29 @@ func TestObserveDNSResponse(t *testing.T) {
 		}
 
 		rc := &appctest.RouteCollector{}
-		if shouldStore {
-			b.appConnector = appc.NewAppConnector(appc.Config{
-				Logf:            t.Logf,
-				EventBus:        bus,
-				RouteAdvertiser: rc,
-				RouteInfo:       &appctype.RouteInfo{},
-				StoreRoutesFunc: fakeStoreRoutes,
-			})
-		} else {
-			b.appConnector = appc.NewAppConnector(appc.Config{Logf: t.Logf, EventBus: bus, RouteAdvertiser: rc})
-		}
-		b.appConnector.UpdateDomains([]string{"example.com"})
-		b.appConnector.Wait(context.Background())
+		a := appc.NewAppConnector(appc.Config{
+			Logf:            t.Logf,
+			EventBus:        bus,
+			RouteAdvertiser: rc,
+			HasStoredRoutes: shouldStore,
+		})
+		a.UpdateDomains([]string{"example.com"})
+		a.Wait(t.Context())
+		b.appConnector = a
 
 		if err := b.ObserveDNSResponse(dnsResponse("example.com.", "192.0.0.8")); err != nil {
 			t.Errorf("ObserveDNSResponse: %v", err)
 		}
-		b.appConnector.Wait(context.Background())
+		a.Wait(t.Context())
 		wantRoutes := []netip.Prefix{netip.MustParsePrefix("192.0.0.8/32")}
 		if !slices.Equal(rc.Routes(), wantRoutes) {
 			t.Fatalf("got routes %v, want %v", rc.Routes(), wantRoutes)
+		}
+
+		if err := eventbustest.Expect(w,
+			eqUpdate(appctype.RouteUpdate{Advertise: mustPrefix("192.0.0.8/32")}),
+		); err != nil {
+			t.Error(err)
 		}
 	}
 }
@@ -2549,7 +2545,7 @@ func TestBackfillAppConnectorRoutes(t *testing.T) {
 
 	// Store the test IP in profile data, but not in Prefs.AdvertiseRoutes.
 	b.ControlKnobs().AppCStoreRoutes.Store(true)
-	if err := b.storeRouteInfo(&appctype.RouteInfo{
+	if err := b.storeRouteInfo(appctype.RouteInfo{
 		Domains: map[string][]netip.Addr{
 			"example.com": {ip},
 		},
@@ -5502,10 +5498,10 @@ func TestReadWriteRouteInfo(t *testing.T) {
 	b.pm.currentProfile = prof1.View()
 
 	// set up routeInfo
-	ri1 := &appctype.RouteInfo{}
+	ri1 := appctype.RouteInfo{}
 	ri1.Wildcards = []string{"1"}
 
-	ri2 := &appctype.RouteInfo{}
+	ri2 := appctype.RouteInfo{}
 	ri2.Wildcards = []string{"2"}
 
 	// read before write
@@ -7056,4 +7052,42 @@ func toStrings[T ~string](in []T) []string {
 		out[i] = string(v)
 	}
 	return out
+}
+
+type textUpdate struct {
+	Advertise   []string
+	Unadvertise []string
+}
+
+func routeUpdateToText(u appctype.RouteUpdate) textUpdate {
+	var out textUpdate
+	for _, p := range u.Advertise {
+		out.Advertise = append(out.Advertise, p.String())
+	}
+	for _, p := range u.Unadvertise {
+		out.Unadvertise = append(out.Unadvertise, p.String())
+	}
+	return out
+}
+
+func mustPrefix(ss ...string) (out []netip.Prefix) {
+	for _, s := range ss {
+		out = append(out, netip.MustParsePrefix(s))
+	}
+	return
+}
+
+// eqUpdate generates an eventbus test filter that matches an appctype.RouteUpdate
+// message equal to want, or reports an error giving a human-readable diff.
+//
+// TODO(creachadair): This is copied from the appc test package, but we can't
+// put it into the appctest package because the appc tests depend on it and
+// that makes a cycle. Clean up those tests and put this somewhere common.
+func eqUpdate(want appctype.RouteUpdate) func(appctype.RouteUpdate) error {
+	return func(got appctype.RouteUpdate) error {
+		if diff := cmp.Diff(routeUpdateToText(got), routeUpdateToText(want)); diff != "" {
+			return fmt.Errorf("wrong update (-got, +want):\n%s", diff)
+		}
+		return nil
+	}
 }


### PR DESCRIPTION
This is the main substance of the change from #17180.

There are multiple commits in this PR for convenience in review.
They are set up so they could be separately merged, but I would be inclined to
squash them since they are all closely related and should ideally travel
together. If we _do_ want to separate them, they will need a bit more
splitting.

---

## Order of Commits

(1) ipn/ipnlocal: add subscribers for AppConnector events

(2) appc: make the RouteAdvertiser field optional

Now that events are published for route updates and storage, the
RouteAdvertiser is no longer required. We cannot yet remove it because the
tests still depend on it to verify correctness. We will need to separately
update the test fixtures to remove that dependency, then we can remove the
field entirely.

(3) appc: remove the StoreRoutesFunc callback

RouteInfo is now published via the event bus and handled by the local backend,
so we do not need a callback to do that. However, we still need a flag to tell
us whether to treat the route info the connector has as "definitive" for
filtering purposes. Do this with a new hasStoredRoutes flag rather than using
the presence or absence of the callback itself as the signal.

(4) appc: update tests to not require a StoreRoutesFunc

Now that we no longer need a callback, the construction of AppConnector values
in the tests can be simplified.

(5) ipn/ipnlocal: update tests to check event subscriptions

Update the tests to simplify the construction of AppConnector values now that a
store callback is no longer required.

Also fix a couple of pre-existing racy tests that were hidden by not being
concurrent in the same way production is.

Add code to check that the expected events are being delivered to the backend.
As in the AppConnector itself, these tests still rely on the RouteAdvertiser to
check correctness, and will need to be updated with a bus fixture separately.

Updates #15160
Updates #17192

Change-Id: Id39525c0f02184e88feaf0d8a3c05504850e47ee
