### PR TITLE
control/controlclient: restore aggressive Direct.Close teardown

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -64,7 +64,7 @@ import (
 
 // Direct is the client that connects to a tailcontrol server for a node.
 type Direct struct {
-	httpc                 *http.Client // HTTP client used to talk to tailcontrol
+	httpc                 *http.Client // HTTP client used to do TLS requests to control (just https://controlplane.tailscale.com/key?v=123)
 	interceptedDial       *atomic.Bool // if non-nil, pointer to bool whether ScreenTime intercepted our dial
 	dialer                *tsdial.Dialer
 	dnsCache              *dnscache.Resolver
@@ -97,7 +97,7 @@ type Direct struct {
 	serverNoiseKey  key.MachinePublic
 
 	sfGroup     singleflight.Group[struct{}, *ts2021.Client] // protects noiseClient creation.
-	noiseClient *ts2021.Client
+	noiseClient *ts2021.Client                               // also protected by mu
 
 	persist                 persist.PersistView
 	authKey                 string

--- a/util/set/handle.go
+++ b/util/set/handle.go
@@ -9,20 +9,28 @@ package set
 type HandleSet[T any] map[Handle]T
 
 // Handle is an opaque comparable value that's used as the map key in a
-// HandleSet. The only way to get one is to call HandleSet.Add.
+// HandleSet.
 type Handle struct {
 	v *byte
 }
 
+// NewHandle returns a new handle value.
+func NewHandle() Handle {
+	return Handle{new(byte)}
+}
+
 // Add adds the element (map value) e to the set.
 //
-// It returns the handle (map key) with which e can be removed, using a map
-// delete.
+// It returns a new handle (map key) with which e can be removed, using a map
+// delete or the [HandleSet.Delete] method.
 func (s *HandleSet[T]) Add(e T) Handle {
-	h := Handle{new(byte)}
+	h := NewHandle()
 	if *s == nil {
 		*s = make(HandleSet[T])
 	}
 	(*s)[h] = e
 	return h
 }
+
+// Delete removes the element with handle h from the set.
+func (s HandleSet[T]) Delete(h Handle) { delete(s, h) }


### PR DESCRIPTION
In the earlier http2 package migration (1d93bdce20ddd2, #17394) I had
removed Direct.Close's tracking of the connPool, thinking it wasn't
necessary.

Some tests (in another repo) are strict and like it to tear down the
world and wait, to check for leaked goroutines. And they caught this
letting some goroutines idle past Close, even if they'd eventually
close down on their own.

This restores the connPool accounting and the aggressife close.

Updates #17305
Updates #17394
