### PR TITLE
ipn/ipnauth: fix a null pointer panic in GetConnIdentity

### DIFF
--- a/ipn/ipnauth/ipnauth_unix_creds.go
+++ b/ipn/ipnauth/ipnauth_unix_creds.go
@@ -18,12 +18,13 @@ import (
 func GetConnIdentity(_ logger.Logf, c net.Conn) (ci *ConnIdentity, err error) {
 	ci = &ConnIdentity{conn: c, notWindows: true}
 	_, ci.isUnixSock = c.(*net.UnixConn)
-	if ci.creds, err = peercred.Get(c); ci.creds != nil {
+	if creds, err := peercred.Get(c); err == nil {
+		ci.creds = creds
 		ci.pid, _ = ci.creds.PID()
 	} else if err == peercred.ErrNotImplemented {
 		// peercred.Get is not implemented on this OS (such as OpenBSD)
 		// Just leave creds as nil, as documented.
-	} else if err != nil {
+	} else {
 		return nil, err
 	}
 	return ci, nil


### PR DESCRIPTION
When running integration tests on macOS, we get a panic from a nil pointer dereference when calling `ci.creds.PID()`.

This panic occurs because the `ci.creds != nil` check is insufficient after a recent refactoring (c45f881) that changed `ci.creds` from a pointer to the `PeerCreds` interface. Now `ci.creds` always compares as non-nil, so we enter this block even when the underlying value is nil.

The integration tests fail on macOS when `peercred.Get()` returns the error `unix.GetsockoptInt: socket is not connected`. This error isn't new, and the previous code was ignoring it correctly.

Since we trust that `peercred` returns either a usable value or an error, checking for a nil error is a sufficient and correct gate to prevent the method call and avoid the panic.

Fixes #17421