### PR TITLE
wgengine/{magicsock,userspace}: move portupdates to the eventbus

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -68,6 +68,7 @@ import (
 	"tailscale.com/util/testenv"
 	"tailscale.com/util/usermetric"
 	"tailscale.com/wgengine/filter"
+	"tailscale.com/wgengine/router"
 	"tailscale.com/wgengine/wgint"
 )
 
@@ -180,6 +181,7 @@ type Conn struct {
 	// config changes between magicsock and wireguard.
 	syncPub               *eventbus.Publisher[syncPoint]
 	allocRelayEndpointPub *eventbus.Publisher[UDPRelayAllocReq]
+	portUpdatePub         *eventbus.Publisher[router.PortUpdate]
 
 	// pconn4 and pconn6 are the underlying UDP sockets used to
 	// send/receive packets for wireguard and other magicsock
@@ -394,10 +396,6 @@ type Conn struct {
 	// wgPinger is the WireGuard only pinger used for latency measurements.
 	wgPinger lazy.SyncValue[*ping.Pinger]
 
-	// onPortUpdate is called with the new port when magicsock rebinds to
-	// a new port.
-	onPortUpdate func(port uint16, network string)
-
 	// getPeerByKey optionally specifies a function to look up a peer's
 	// wireguard state by its public key. If nil, it's not used.
 	getPeerByKey func(key.NodePublic) (_ wgint.Peer, ok bool)
@@ -492,10 +490,6 @@ type Options struct {
 	// ControlKnobs are the set of control knobs to use.
 	// If nil, they're ignored and not updated.
 	ControlKnobs *controlknobs.Knobs
-
-	// OnPortUpdate is called with the new port when magicsock rebinds to
-	// a new port.
-	OnPortUpdate func(port uint16, network string)
 
 	// PeerByKeyFunc optionally specifies a function to look up a peer's
 	// WireGuard state by its public key. If nil, it's not used.
@@ -736,6 +730,7 @@ func NewConn(opts Options) (*Conn, error) {
 	cli := c.eventBus.Client("magicsock.Conn")
 	c.syncPub = eventbus.Publish[syncPoint](cli)
 	c.allocRelayEndpointPub = eventbus.Publish[UDPRelayAllocReq](cli)
+	c.portUpdatePub = eventbus.Publish[router.PortUpdate](cli)
 	c.eventSubs = cli.Monitor(c.consumeEventbusTopics(cli))
 
 	c.connCtx, c.connCtxCancel = context.WithCancel(context.Background())
@@ -760,7 +755,6 @@ func NewConn(opts Options) (*Conn, error) {
 
 	c.netMon = opts.NetMon
 	c.health = opts.HealthTracker
-	c.onPortUpdate = opts.OnPortUpdate
 	c.getPeerByKey = opts.PeerByKeyFunc
 
 	if err := c.rebind(keepCurrentPort); err != nil {
@@ -3534,7 +3528,7 @@ func (c *Conn) bindSocket(ruc *RebindingUDPConn, network string, curPortFate cur
 			c.logf("magicsock: unable to bind %v port %d: %v", network, port, err)
 			continue
 		}
-		if c.onPortUpdate != nil {
+		if c.portUpdatePub.ShouldPublish() {
 			_, gotPortStr, err := net.SplitHostPort(pconn.LocalAddr().String())
 			if err != nil {
 				c.logf("could not parse port from %s: %w", pconn.LocalAddr().String(), err)
@@ -3543,7 +3537,10 @@ func (c *Conn) bindSocket(ruc *RebindingUDPConn, network string, curPortFate cur
 				if err != nil {
 					c.logf("could not parse port from %s: %w", gotPort, err)
 				} else {
-					c.onPortUpdate(uint16(gotPort), network)
+					c.portUpdatePub.Publish(router.PortUpdate{
+						UDPPort:         uint16(gotPort),
+						EndpointNetwork: network,
+					})
 				}
 			}
 		}

--- a/wgengine/router/callback.go
+++ b/wgengine/router/callback.go
@@ -56,13 +56,6 @@ func (r *CallbackRouter) Set(rcfg *Config) error {
 	return r.SetBoth(r.rcfg, r.dcfg)
 }
 
-// UpdateMagicsockPort implements the Router interface. This implementation
-// does nothing and returns nil because this router does not currently need
-// to know what the magicsock UDP port is.
-func (r *CallbackRouter) UpdateMagicsockPort(_ uint16, _ string) error {
-	return nil
-}
-
 // SetDNS implements dns.OSConfigurator.
 func (r *CallbackRouter) SetDNS(dcfg dns.OSConfig) error {
 	r.mu.Lock()

--- a/wgengine/router/osrouter/router_openbsd.go
+++ b/wgengine/router/osrouter/router_openbsd.go
@@ -238,13 +238,6 @@ func (r *openbsdRouter) Set(cfg *router.Config) error {
 	return errq
 }
 
-// UpdateMagicsockPort implements the Router interface. This implementation
-// does nothing and returns nil because this router does not currently need
-// to know what the magicsock UDP port is.
-func (r *openbsdRouter) UpdateMagicsockPort(_ uint16, _ string) error {
-	return nil
-}
-
 func (r *openbsdRouter) Close() error {
 	cleanUp(r.logf, r.tunname)
 	return nil

--- a/wgengine/router/osrouter/router_plan9.go
+++ b/wgengine/router/osrouter/router_plan9.go
@@ -115,13 +115,6 @@ func (r *plan9Router) Set(cfg *router.Config) error {
 	return nil
 }
 
-// UpdateMagicsockPort implements the Router interface. This implementation
-// does nothing and returns nil because this router does not currently need
-// to know what the magicsock UDP port is.
-func (r *plan9Router) UpdateMagicsockPort(_ uint16, _ string) error {
-	return nil
-}
-
 func (r *plan9Router) Close() error {
 	// TODO(bradfitz): unbind
 	return nil

--- a/wgengine/router/osrouter/router_userspace_bsd.go
+++ b/wgengine/router/osrouter/router_userspace_bsd.go
@@ -206,13 +206,6 @@ func (r *userspaceBSDRouter) Set(cfg *router.Config) (reterr error) {
 	return reterr
 }
 
-// UpdateMagicsockPort implements the Router interface. This implementation
-// does nothing and returns nil because this router does not currently need
-// to know what the magicsock UDP port is.
-func (r *userspaceBSDRouter) UpdateMagicsockPort(_ uint16, _ string) error {
-	return nil
-}
-
 func (r *userspaceBSDRouter) Close() error {
 	return nil
 }

--- a/wgengine/router/osrouter/router_windows.go
+++ b/wgengine/router/osrouter/router_windows.go
@@ -114,13 +114,6 @@ func hasDefaultRoute(routes []netip.Prefix) bool {
 	return false
 }
 
-// UpdateMagicsockPort implements the Router interface. This implementation
-// does nothing and returns nil because this router does not currently need
-// to know what the magicsock UDP port is.
-func (r *winRouter) UpdateMagicsockPort(_ uint16, _ string) error {
-	return nil
-}
-
 func (r *winRouter) Close() error {
 	r.firewall.clear()
 

--- a/wgengine/router/router.go
+++ b/wgengine/router/router.go
@@ -34,14 +34,6 @@ type Router interface {
 	// implementation should handle gracefully.
 	Set(*Config) error
 
-	// UpdateMagicsockPort tells the OS network stack what port magicsock
-	// is currently listening on, so it can be threaded through firewalls
-	// and such. This is distinct from Set() since magicsock may rebind
-	// ports independently from the Config changing.
-	//
-	// network should be either "udp4" or "udp6".
-	UpdateMagicsockPort(port uint16, network string) error
-
 	// Close closes the router.
 	Close() error
 }
@@ -53,6 +45,14 @@ type NewOpts struct {
 	NetMon *netmon.Monitor // optional
 	Health *health.Tracker // required (but TODO: support optional later)
 	Bus    *eventbus.Bus   // required
+}
+
+// PortUpdate is an eventbus value, reporting the port and address family
+// magicsock is currently listening on, so it can be threaded through firewalls
+// and such.
+type PortUpdate struct {
+	UDPPort         uint16
+	EndpointNetwork string // either "udp4" or "udp6".
 }
 
 // HookNewUserspaceRouter is the registration point for router implementations

--- a/wgengine/router/router_fake.go
+++ b/wgengine/router/router_fake.go
@@ -27,11 +27,6 @@ func (r fakeRouter) Set(cfg *Config) error {
 	return nil
 }
 
-func (r fakeRouter) UpdateMagicsockPort(_ uint16, _ string) error {
-	r.logf("[v1] warning: fakeRouter.UpdateMagicsockPort: not implemented.")
-	return nil
-}
-
 func (r fakeRouter) Close() error {
 	r.logf("[v1] warning: fakeRouter.Close: not implemented.")
 	return nil

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -396,13 +396,6 @@ func NewUserspaceEngine(logf logger.Logf, conf Config) (_ Engine, reterr error) 
 
 		e.RequestStatus()
 	}
-	onPortUpdate := func(port uint16, network string) {
-		e.logf("onPortUpdate(port=%v, network=%s)", port, network)
-
-		if err := e.router.UpdateMagicsockPort(port, network); err != nil {
-			e.logf("UpdateMagicsockPort(port=%v, network=%s) failed: %v", port, network, err)
-		}
-	}
 	magicsockOpts := magicsock.Options{
 		EventBus:       e.eventBus,
 		Logf:           logf,
@@ -414,7 +407,6 @@ func NewUserspaceEngine(logf logger.Logf, conf Config) (_ Engine, reterr error) 
 		HealthTracker:  e.health,
 		Metrics:        conf.Metrics,
 		ControlKnobs:   conf.ControlKnobs,
-		OnPortUpdate:   onPortUpdate,
 		PeerByKeyFunc:  e.PeerByKey,
 	}
 	if buildfeatures.HasLazyWG {


### PR DESCRIPTION
Updates #15160

The changed surfaced a data race that I believe was there before this change.

Signed-off-by: Claus Lensbøl <claus@tailscale.com>
<img width="4134" height="592" alt="2025-10-03-graphviz" src="https://github.com/user-attachments/assets/9b9661e3-b29f-4c11-9b26-f325492f8c22" />
