### PR TITLE
wgengine/magicsock: remove misleading unexpected log message

### DIFF
--- a/wgengine/magicsock/endpoint.go
+++ b/wgengine/magicsock/endpoint.go
@@ -1768,11 +1768,6 @@ func (de *endpoint) handlePongConnLocked(m *disco.Pong, di *discoInfo, src epAdd
 		//  we don't clear direct UDP paths on disco ping timeout (see
 		//  discoPingTimeout).
 		if betterAddr(thisPong, de.bestAddr) {
-			if src.vni.IsSet() {
-				// This would be unexpected. Switching to a Geneve-encapsulated
-				// path should only happen in de.relayEndpointReady().
-				de.c.logf("[unexpected] switching to Geneve-encapsulated path %v from %v", thisPong, de.bestAddr)
-			}
 			de.c.logf("magicsock: disco: node %v %v now using %v mtu=%v tx=%x", de.publicKey.ShortString(), de.discoShort(), sp.to, thisPong.wireMTU, m.TxID[:6])
 			de.debugUpdates.Add(EndpointChange{
 				When: time.Now(),


### PR DESCRIPTION
Switching to a Geneve-encapsulated (peer relay) path in endpoint.handlePongConnLocked is expected around port rebinds, which end up clearing endpoint.bestAddr.

Fixes tailscale/corp#33036