### PR TITLE
feature/tpm: quiet log output a bit

### DIFF
--- a/feature/tpm/tpm.go
+++ b/feature/tpm/tpm.go
@@ -71,10 +71,16 @@ func info() *tailcfg.TPMInfo {
 
 	tpm, err := open()
 	if err != nil {
-		logf("error opening: %v", err)
+		if !os.IsNotExist(err) || verboseTPM() {
+			// Only log if it's an interesting error, not just "no TPM",
+			// as is very common, especially in VMs.
+			logf("error opening: %v", err)
+		}
 		return nil
 	}
-	logf("successfully opened")
+	if verboseTPM() {
+		logf("successfully opened")
+	}
 	defer tpm.Close()
 
 	info := new(tailcfg.TPMInfo)


### PR DESCRIPTION
I was debugging a customer issue and saw in their 1.88.3 logs:

    TPM: error opening: stat /dev/tpm0: no such file or directory

That's unnecessary output. The lack of TPM will be reported by
them having a nil Hostinfo.TPM, which is plenty elsewhere in logs.

Let's only write out an "error opening" line if it's an interesting
error. (perhaps permissions, or EIO, etc)

Updates #cleanup
