### PR TITLE
cmd/testwrapper/flakytest: use t.Attr annotation on flaky tests

### DIFF
--- a/cmd/testwrapper/flakytest/flakytest.go
+++ b/cmd/testwrapper/flakytest/flakytest.go
@@ -27,7 +27,7 @@ const FlakyTestLogMessage = "flakytest: this is a known flaky test"
 // starting at 1.
 const FlakeAttemptEnv = "TS_TESTWRAPPER_ATTEMPT"
 
-var issueRegexp = regexp.MustCompile(`\Ahttps://github\.com/tailscale/[a-zA-Z0-9_.-]+/issues/\d+\z`)
+var issueRegexp = regexp.MustCompile(`\Ahttps://github\.com/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+/issues/\d+\z`)
 
 var (
 	rootFlakesMu sync.Mutex
@@ -49,6 +49,15 @@ func Mark(t testing.TB, issue string) {
 		// spamming people running tests without the wrapper)
 		fmt.Fprintf(os.Stderr, "%s: %s\n", FlakyTestLogMessage, issue)
 	}
+	t.Attr("flaky-test-issue-url", issue)
+
+	// The Attr method above also emits human-readable output, so this t.Logf
+	// is somewhat redundant, but we keep it for compatibility with
+	// old test runs, so cmd/testwrapper doesn't need to be modified.
+	// TODO(bradfitz): switch testwrapper to look for Action "attr"
+	// instead:
+	// "Action":"attr","Package":"tailscale.com/cmd/testwrapper/flakytest","Test":"TestMarked_Root","Key":"flaky-test-issue-url","Value":"https://github.com/tailscale/tailscale/issues/0"}
+	// And then remove this Logf a month or so after that.
 	t.Logf("flakytest: issue tracking this flaky test: %s", issue)
 
 	// Record the root test name as flakey.

--- a/cmd/testwrapper/flakytest/flakytest_test.go
+++ b/cmd/testwrapper/flakytest/flakytest_test.go
@@ -14,7 +14,8 @@ func TestIssueFormat(t *testing.T) {
 		want  bool
 	}{
 		{"https://github.com/tailscale/cOrp/issues/1234", true},
-		{"https://github.com/otherproject/corp/issues/1234", false},
+		{"https://github.com/otherproject/corp/issues/1234", true},
+		{"https://not.huyb/tailscale/corp/issues/1234", false},
 		{"https://github.com/tailscale/corp/issues/", false},
 	}
 	for _, testCase := range testCases {


### PR DESCRIPTION
Updates #17460
