### PR TITLE
ipn/ipnlocal: fix another racy test

### DIFF
--- a/ipn/ipnlocal/peerapi_test.go
+++ b/ipn/ipnlocal/peerapi_test.go
@@ -422,7 +422,7 @@ func TestPeerAPIReplyToDNSQueriesAreObservedWithCNAMEFlattening(t *testing.T) {
 
 		h.ps = &peerAPIServer{b: b}
 		h.ps.b.appConnector.UpdateDomains([]string{"www.example.com"})
-		h.ps.b.appConnector.Wait(ctx)
+		a.Wait(ctx)
 
 		h.ps.resolver = &fakeResolver{build: func(b *dnsmessage.Builder) {
 			b.CNAMEResource(
@@ -463,7 +463,7 @@ func TestPeerAPIReplyToDNSQueriesAreObservedWithCNAMEFlattening(t *testing.T) {
 		if w.Code != http.StatusOK {
 			t.Errorf("unexpected status code: %v", w.Code)
 		}
-		h.ps.b.appConnector.Wait(ctx)
+		a.Wait(ctx)
 
 		wantRoutes := []netip.Prefix{netip.MustParsePrefix("192.0.0.8/32")}
 		if !slices.Equal(rc.Routes(), wantRoutes) {


### PR DESCRIPTION
Some of the test cases access fields of the backend that are supposed to be
locked while the test is running, which can trigger the race detector.  I fixed
a few of these in #17411, but I missed these two cases.

Updates #15160
Updates #17192

Change-Id: I45664d5e34320ecdccd2844e0f8b228145aaf603
Signed-off-by: M. J. Fromberger <fromberger@tailscale.com>
