### PR TITLE
build_dist.sh: keep --extra-small making a usable build, add --min

### DIFF
--- a/build_dist.sh
+++ b/build_dist.sh
@@ -41,6 +41,14 @@ while [ "$#" -gt 1 ]; do
 		fi
 		shift
 		ldflags="$ldflags -w -s"
+		tags="${tags:+$tags,},$(GOOS= GOARCH= $go run ./cmd/featuretags --min --add=osrouter)"
+		;;
+	--min)
+	    # --min is like --extra-small but even smaller, removing all features,
+		# even if it results in a useless binary (e.g. removing both netstack +
+		# osrouter). It exists for benchmarking purposes only.
+		shift
+		ldflags="$ldflags -w -s"
 		tags="${tags:+$tags,},$(GOOS= GOARCH= $go run ./cmd/featuretags --min)"
 		;;
 	--box)


### PR DESCRIPTION
Historically, and until recently, --extra-small produced a usable build.

When I recently made osrouter be modular in 39e35379d41fc788 (which is
useful in, say, tsnet builds) after also making netstack modular, that
meant --min now lacked both netstack support for routing and system
support for routing, making no way to get packets into
wireguard. That's not a nice default to users.  (we've documented
build_dist.sh in our KB)

Restore --extra-small to making a usable build, and add --min for
benchmarking purposes.

Updates #12614
