### PR TITLE
net/dns, ipn/ipnlocal: fix regressions from change moving away from deephash

### DIFF
--- a/net/dns/config.go
+++ b/net/dns/config.go
@@ -7,6 +7,7 @@ package dns
 import (
 	"bufio"
 	"fmt"
+	"maps"
 	"net/netip"
 	"reflect"
 	"slices"
@@ -190,15 +191,21 @@ func sameResolverNames(a, b []*dnstype.Resolver) bool {
 	return true
 }
 
+// Clone makes a shallow clone of c.
+//
+// The returned Config still references slices and maps from c.
+//
+// TODO(bradfitz): use cmd/{viewer,cloner} for these and make the
+// caller use views instead.
 func (c *Config) Clone() *Config {
 	if c == nil {
 		return nil
 	}
 	return &Config{
 		DefaultResolvers: slices.Clone(c.DefaultResolvers),
-		Routes:           make(map[dnsname.FQDN][]*dnstype.Resolver, len(c.Routes)),
+		Routes:           maps.Clone(c.Routes),
 		SearchDomains:    slices.Clone(c.SearchDomains),
-		Hosts:            make(map[dnsname.FQDN][]netip.Addr, len(c.Hosts)),
+		Hosts:            maps.Clone(c.Hosts),
 		OnlyIPv6:         c.OnlyIPv6,
 	}
 }

--- a/net/dns/config_test.go
+++ b/net/dns/config_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package dns
+
+import (
+	"net/netip"
+	"reflect"
+	"testing"
+
+	"tailscale.com/types/dnstype"
+	"tailscale.com/util/dnsname"
+)
+
+func TestConfigClone(t *testing.T) {
+	tests := []struct {
+		name string
+		conf *Config
+	}{
+		{
+			name: "nil",
+			conf: nil,
+		},
+		{
+			name: "empty",
+			conf: &Config{},
+		},
+		{
+			name: "full",
+			conf: &Config{
+				DefaultResolvers: []*dnstype.Resolver{
+					{
+						Addr:                "abc",
+						BootstrapResolution: []netip.Addr{netip.MustParseAddr("1.2.3.4")},
+						UseWithExitNode:     true,
+					},
+				},
+				Routes: map[dnsname.FQDN][]*dnstype.Resolver{
+					"foo.bar.": {
+						{
+							Addr:                "abc",
+							BootstrapResolution: []netip.Addr{netip.MustParseAddr("1.2.3.4")},
+							UseWithExitNode:     true,
+						},
+					},
+				},
+				SearchDomains: []dnsname.FQDN{"bar.baz."},
+				Hosts: map[dnsname.FQDN][]netip.Addr{
+					"host.bar.": {netip.MustParseAddr("5.6.7.8")},
+				},
+				OnlyIPv6: true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.conf.Clone()
+			if !reflect.DeepEqual(got, tt.conf) {
+				t.Error("Cloned result is not reflect.DeepEqual")
+			}
+			if !got.Equal(tt.conf) {
+				t.Error("Cloned result is not Equal")
+			}
+		})
+	}
+}

--- a/util/checkchange/checkchange.go
+++ b/util/checkchange/checkchange.go
@@ -17,7 +17,7 @@ type EqualCloner[T any] interface {
 //
 // It only modifies *old if they are different. old must be non-nil.
 func Update[T EqualCloner[T]](old *T, new T) (changed bool) {
-	if new.Equal(*old) {
+	if (*old).Equal(new) {
 		return false
 	}
 	*old = new.Clone()


### PR DESCRIPTION
I got sidetracked apparently and never finished writing this Clone
code in https://github.com/tailscale/tailscale/commit/316afe7d02babc24001b23ccfefd28eaa26adb7c (https://github.com/tailscale/tailscale/pull/17448). (It really should use views instead.)

And then I missed one of the users of "routerChanged" that was broken up
into "routerChanged" vs "dnsChanged".

This broke integration tests elsewhere.

Fixes https://github.com/tailscale/tailscale/issues/17506