### PR TITLE
clientupdate, util/osshare, util/winutil, version: improve Windows GU…

### DIFF
--- a/version/cmdname.go
+++ b/version/cmdname.go
@@ -12,7 +12,7 @@ import (
 	"io"
 	"os"
 	"path"
-	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -30,7 +30,7 @@ func CmdName() string {
 func cmdName(exe string) string {
 	// fallbackName, the lowercase basename of the executable, is what we return if
 	// we can't find the Go module metadata embedded in the file.
-	fallbackName := filepath.Base(strings.TrimSuffix(strings.ToLower(exe), ".exe"))
+	fallbackName := prepExeNameForCmp(exe, runtime.GOARCH)
 
 	var ret string
 	info, err := findModuleInfo(exe)
@@ -45,10 +45,10 @@ func cmdName(exe string) string {
 			break
 		}
 	}
-	if strings.HasPrefix(ret, "wg") && fallbackName == "tailscale-ipn" {
-		// The tailscale-ipn.exe binary for internal build system packaging reasons
-		// has a path of "tailscale.io/win/wg64", "tailscale.io/win/wg32", etc.
-		// Ignore that name and use "tailscale-ipn" instead.
+	if runtime.GOOS == "windows" && strings.HasPrefix(ret, "gui") && checkPreppedExeNameForGUI(fallbackName) {
+		// The GUI binary for internal build system packaging reasons
+		// has a path of "tailscale.io/win/gui".
+		// Ignore that name and use fallbackName instead.
 		return fallbackName
 	}
 	if ret == "" {

--- a/version/exename.go
+++ b/version/exename.go
@@ -1,0 +1,25 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package version
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// prepExeNameForCmp strips any extension and arch suffix from exe, and
+// lowercases it.
+func prepExeNameForCmp(exe, arch string) string {
+	baseNoExt := strings.ToLower(strings.TrimSuffix(filepath.Base(exe), filepath.Ext(exe)))
+	archSuffix := "-" + arch
+	return strings.TrimSuffix(baseNoExt, archSuffix)
+}
+
+func checkPreppedExeNameForGUI(preppedExeName string) bool {
+	return preppedExeName == "tailscale-ipn" || preppedExeName == "tailscale-gui"
+}
+
+func isGUIExeName(exe, arch string) bool {
+	return checkPreppedExeNameForGUI(prepExeNameForCmp(exe, arch))
+}

--- a/version/prop.go
+++ b/version/prop.go
@@ -159,7 +159,9 @@ func IsWindowsGUI() bool {
 		if err != nil {
 			return false
 		}
-		return strings.EqualFold(exe, "tailscale-ipn.exe") || strings.EqualFold(exe, "tailscale-ipn")
+		// It is okay to use GOARCH here because we're checking whether our
+		// _own_ process is the GUI.
+		return isGUIExeName(exe, runtime.GOARCH)
 	})
 }
 

--- a/version/version_internal_test.go
+++ b/version/version_internal_test.go
@@ -25,3 +25,38 @@ func TestIsValidLongWithTwoRepos(t *testing.T) {
 		}
 	}
 }
+
+func TestPrepExeNameForCmp(t *testing.T) {
+	cases := []struct {
+		exe  string
+		want string
+	}{
+		{
+			"tailscale-ipn.exe",
+			"tailscale-ipn",
+		},
+		{
+			"tailscale-gui-amd64.exe",
+			"tailscale-gui",
+		},
+		{
+			"tailscale-gui-amd64",
+			"tailscale-gui",
+		},
+		{
+			"tailscale-ipn",
+			"tailscale-ipn",
+		},
+		{
+			"TaIlScAlE-iPn.ExE",
+			"tailscale-ipn",
+		},
+	}
+
+	for _, c := range cases {
+		got := prepExeNameForCmp(c.exe, "amd64")
+		if got != c.want {
+			t.Errorf("prepExeNameForCmp(%q) = %q; want %q", c.exe, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
…I filename resolution and WinUI build awareness

On Windows arm64 we are going to need to ship two different GUI builds; one for Win10 (GOARCH=386) and one for Win11 (GOARCH=amd64, tags += winui). Due to quirks in MSI packaging, they cannot both share the same filename. This requires some fixes in places where we have hardcoded "tailscale-ipn" as the GUI filename.

We also do some cleanup in clientupdate to ensure that autoupdates will continue to work correctly with the temporary "-winui" package variant.

Fixes #17480
Updates https://github.com/tailscale/corp/issues/29940