### PR TITLE
wgengine/magicsock: do not apply node view updates to a closed Conn

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -2958,7 +2958,12 @@ func (c *Conn) onNodeViewsUpdate(update NodeViewsUpdate) {
 	filt := c.filt
 	self := c.self
 	peers := c.peers
+	isClosed := c.closed
 	c.mu.Unlock() // release c.mu before potentially calling c.updateRelayServersSet which is O(m * n)
+
+	if isClosed {
+		return // nothing to do here, the conn is closed and the update is no longer relevant
+	}
 
 	if peersChanged || relayClientChanged {
 		if !relayClientEnabled {


### PR DESCRIPTION
Fixes #17516

Change-Id: Iae2dab42d6f7bc618478d360a1005537c1fa1bbd
Signed-off-by: M. J. Fromberger <fromberger@tailscale.com>
