### PR TITLE
types/netlogtype: remove CBOR representation

### DIFF
--- a/types/netlogtype/netlogtype.go
+++ b/types/netlogtype/netlogtype.go
@@ -12,20 +12,17 @@ import (
 	"tailscale.com/types/ipproto"
 )
 
-// TODO(joetsai): Remove "omitempty" if "omitzero" is ever supported in both
-// the v1 and v2 "json" packages.
-
 // Message is the log message that captures network traffic.
 type Message struct {
-	NodeID tailcfg.StableNodeID `json:"nodeId" cbor:"0,keyasint"` // e.g., "n123456CNTRL"
+	NodeID tailcfg.StableNodeID `json:"nodeId"` // e.g., "n123456CNTRL"
 
-	Start time.Time `json:"start" cbor:"12,keyasint"` // inclusive
-	End   time.Time `json:"end"   cbor:"13,keyasint"` // inclusive
+	Start time.Time `json:"start"` // inclusive
+	End   time.Time `json:"end"`   // inclusive
 
-	VirtualTraffic  []ConnectionCounts `json:"virtualTraffic,omitempty"  cbor:"14,keyasint,omitempty"`
-	SubnetTraffic   []ConnectionCounts `json:"subnetTraffic,omitempty"   cbor:"15,keyasint,omitempty"`
-	ExitTraffic     []ConnectionCounts `json:"exitTraffic,omitempty"     cbor:"16,keyasint,omitempty"`
-	PhysicalTraffic []ConnectionCounts `json:"physicalTraffic,omitempty" cbor:"17,keyasint,omitempty"`
+	VirtualTraffic  []ConnectionCounts `json:"virtualTraffic,omitempty"`
+	SubnetTraffic   []ConnectionCounts `json:"subnetTraffic,omitempty"`
+	ExitTraffic     []ConnectionCounts `json:"exitTraffic,omitempty"`
+	PhysicalTraffic []ConnectionCounts `json:"physicalTraffic,omitempty"`
 }
 
 const (
@@ -51,18 +48,6 @@ const (
 	// this object is nested within an array.
 	// It assumes that netip.Addr never has IPv6 zones.
 	MaxConnectionCountsJSONSize = len(maxJSONConnCounts)
-
-	maxCBORConnCounts = "\xbf" + maxCBORConn + maxCBORCounts + "\xff"
-	maxCBORConn       = "\x00" + maxCBORProto + "\x01" + maxCBORAddrPort + "\x02" + maxCBORAddrPort
-	maxCBORProto      = "\x18\xff"
-	maxCBORAddrPort   = "\x52\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
-	maxCBORCounts     = "\x0c" + maxCBORCount + "\x0d" + maxCBORCount + "\x0e" + maxCBORCount + "\x0f" + maxCBORCount
-	maxCBORCount      = "\x1b\xff\xff\xff\xff\xff\xff\xff\xff"
-
-	// MaxConnectionCountsCBORSize is the maximum size of a ConnectionCounts
-	// when it is serialized as CBOR.
-	// It assumes that netip.Addr never has IPv6 zones.
-	MaxConnectionCountsCBORSize = len(maxCBORConnCounts)
 )
 
 // ConnectionCounts is a flattened struct of both a connection and counts.
@@ -73,19 +58,19 @@ type ConnectionCounts struct {
 
 // Connection is a 5-tuple of proto, source and destination IP and port.
 type Connection struct {
-	Proto ipproto.Proto  `json:"proto,omitzero,omitempty" cbor:"0,keyasint,omitempty"`
-	Src   netip.AddrPort `json:"src,omitzero,omitempty"   cbor:"1,keyasint,omitempty"`
-	Dst   netip.AddrPort `json:"dst,omitzero,omitempty"   cbor:"2,keyasint,omitempty"`
+	Proto ipproto.Proto  `json:"proto,omitzero"`
+	Src   netip.AddrPort `json:"src,omitzero"`
+	Dst   netip.AddrPort `json:"dst,omitzero"`
 }
 
 func (c Connection) IsZero() bool { return c == Connection{} }
 
 // Counts are statistics about a particular connection.
 type Counts struct {
-	TxPackets uint64 `json:"txPkts,omitzero,omitempty"  cbor:"12,keyasint,omitempty"`
-	TxBytes   uint64 `json:"txBytes,omitzero,omitempty" cbor:"13,keyasint,omitempty"`
-	RxPackets uint64 `json:"rxPkts,omitzero,omitempty"  cbor:"14,keyasint,omitempty"`
-	RxBytes   uint64 `json:"rxBytes,omitzero,omitempty" cbor:"15,keyasint,omitempty"`
+	TxPackets uint64 `json:"txPkts,omitzero"`
+	TxBytes   uint64 `json:"txBytes,omitzero"`
+	RxPackets uint64 `json:"rxPkts,omitzero"`
+	RxBytes   uint64 `json:"rxBytes,omitzero"`
 }
 
 func (c Counts) IsZero() bool { return c == Counts{} }

--- a/types/netlogtype/netlogtype_test.go
+++ b/types/netlogtype/netlogtype_test.go
@@ -11,7 +11,6 @@ import (
 	"net/netip"
 	"testing"
 
-	"github.com/fxamacker/cbor/v2"
 	"github.com/google/go-cmp/cmp"
 	"tailscale.com/util/must"
 )
@@ -31,11 +30,5 @@ func TestMaxSize(t *testing.T) {
 	outJSON := must.Get(json.Marshal(cc))
 	if string(outJSON) != maxJSONConnCounts {
 		t.Errorf("JSON mismatch (-got +want):\n%s", cmp.Diff(string(outJSON), maxJSONConnCounts))
-	}
-
-	outCBOR := must.Get(cbor.Marshal(cc))
-	maxCBORConnCountsAlt := "\xa7" + maxCBORConnCounts[1:len(maxCBORConnCounts)-1] // may use a definite encoding of map
-	if string(outCBOR) != maxCBORConnCounts && string(outCBOR) != maxCBORConnCountsAlt {
-		t.Errorf("CBOR mismatch (-got +want):\n%s", cmp.Diff(string(outCBOR), maxCBORConnCounts))
 	}
 }


### PR DESCRIPTION
Remove CBOR representation since it was never used. We should support CBOR in the future, but for remove it for now so that it is less work to add more fields.

Also, rely on just omitzero for JSON now that it is supported in Go 1.24.

Updates tailscale/corp#33352