### PR TITLE
cmd/tailscale/cli: fix panic in netcheck with mismatched DERP region IDs

### DIFF
--- a/cmd/tailscale/cli/netcheck.go
+++ b/cmd/tailscale/cli/netcheck.go
@@ -180,7 +180,11 @@ func printReport(dm *tailcfg.DERPMap, report *netcheck.Report) error {
 		printf("\t* Nearest DERP: unknown (no response to latency probes)\n")
 	} else {
 		if report.PreferredDERP != 0 {
-			printf("\t* Nearest DERP: %v\n", dm.Regions[report.PreferredDERP].RegionName)
+			if region, ok := dm.Regions[report.PreferredDERP]; ok {
+				printf("\t* Nearest DERP: %v\n", region.RegionName)
+			} else {
+				printf("\t* Nearest DERP: %v (region not found in map)\n", report.PreferredDERP)
+			}
 		} else {
 			printf("\t* Nearest DERP: [none]\n")
 		}


### PR DESCRIPTION
### Summary
Fixes a nil pointer dereference panic in tailscale netcheck when the DERP map key doesn't match the region's RegionID field.
### Background
Users can configure custom DERP regions in ACLs. When the map key differs from the RegionID value, tailscale netcheck crashes:
```
  "derpMap": {
      "Regions": {
          "901": {                    // Map key is 901
              "RegionID": 903,        // But RegionID is 903
              "RegionName": "SHANGHAI",
              "Nodes": [...]
          }
      }
  }
```

  In this case:
  - The netcheck report uses PreferredDERP: 903 (the actual RegionID from the node configuration)
  - But dm.Regions[903] doesn't exist (the map only has key 901)
  - Accessing dm.Regions[903].RegionName dereferences nil and panics
### Error
```
  panic: runtime error: invalid memory address or nil pointer dereference
  tailscale.com/cmd/tailscale/cli.printReport(...)
      cmd/tailscale/cli/netcheck.go:183
```

### Changes
cmd/tailscale/cli/netcheck.go:183-187
  - Added map existence check before accessing region
  - Display region ID with helpful message when not found in map
  
### Result
```
Report:
        * Time: 2025-10-17T05:40:40.495553072Z
        * UDP: true
        * IPv4: yes, xxx.xxx.xxx.xxxx:10161
        * IPv6: yes, [abcd:abcd:abcd:abcd:abcd:abcd:abcd:abcd]:57016
        * MappingVariesByDestIP: false
        * PortMapping: 
        * Nearest DERP: 903 (region not found in map)
        * DERP latency:
                - tok: 44.2ms  (Tokyo)
                - hkg: 58.7ms  (Hong Kong)
```