### PR TITLE
wgengine/magicsock: minor tidies in Test_endpoint_maybeProbeUDPLifetimeLocked

### DIFF
--- a/wgengine/magicsock/endpoint_test.go
+++ b/wgengine/magicsock/endpoint_test.go
@@ -173,130 +173,110 @@ func Test_endpoint_maybeProbeUDPLifetimeLocked(t *testing.T) {
 		wantMaybe                bool
 	}{
 		{
-			"nil probeUDPLifetime",
-			higher,
-			&lower,
-			func() *probeUDPLifetime {
+			name:        "nil probeUDPLifetime",
+			localDisco:  higher,
+			remoteDisco: &lower,
+			probeUDPLifetimeFn: func() *probeUDPLifetime {
 				return nil
 			},
-			addr,
-			func(lifetime *probeUDPLifetime) time.Duration {
-				return 0
-			},
-			false,
+			bestAddr: addr,
 		},
 		{
-			"local higher disco key",
-			higher,
-			&lower,
-			newProbeUDPLifetime,
-			addr,
-			func(lifetime *probeUDPLifetime) time.Duration {
-				return 0
-			},
-			false,
+			name:               "local higher disco key",
+			localDisco:         higher,
+			remoteDisco:        &lower,
+			probeUDPLifetimeFn: newProbeUDPLifetime,
+			bestAddr:           addr,
 		},
 		{
-			"remote no disco key",
-			higher,
-			nil,
-			newProbeUDPLifetime,
-			addr,
-			func(lifetime *probeUDPLifetime) time.Duration {
-				return 0
-			},
-			false,
+			name:               "remote no disco key",
+			localDisco:         higher,
+			remoteDisco:        nil,
+			probeUDPLifetimeFn: newProbeUDPLifetime,
+			bestAddr:           addr,
 		},
 		{
-			"invalid bestAddr",
-			lower,
-			&higher,
-			newProbeUDPLifetime,
-			addrQuality{},
-			func(lifetime *probeUDPLifetime) time.Duration {
-				return 0
-			},
-			false,
+			name:               "invalid bestAddr",
+			localDisco:         lower,
+			remoteDisco:        &higher,
+			probeUDPLifetimeFn: newProbeUDPLifetime,
+			bestAddr:           addrQuality{},
 		},
 		{
-			"cycle started too recently",
-			lower,
-			&higher,
-			func() *probeUDPLifetime {
-				l := newProbeUDPLifetime()
-				l.cycleActive = false
-				l.cycleStartedAt = time.Now()
-				return l
+			name:        "cycle started too recently",
+			localDisco:  lower,
+			remoteDisco: &higher,
+			probeUDPLifetimeFn: func() *probeUDPLifetime {
+				lt := newProbeUDPLifetime()
+				lt.cycleActive = false
+				lt.cycleStartedAt = time.Now()
+				return lt
 			},
-			addr,
-			func(lifetime *probeUDPLifetime) time.Duration {
-				return 0
-			},
-			false,
+			bestAddr: addr,
 		},
 		{
-			"maybe cliff 0 cycle not active",
-			lower,
-			&higher,
-			func() *probeUDPLifetime {
-				l := newProbeUDPLifetime()
-				l.cycleActive = false
-				l.cycleStartedAt = time.Now().Add(-l.config.CycleCanStartEvery).Add(-time.Second)
-				return l
+			name:        "maybe cliff 0 cycle not active",
+			localDisco:  lower,
+			remoteDisco: &higher,
+			probeUDPLifetimeFn: func() *probeUDPLifetime {
+				lt := newProbeUDPLifetime()
+				lt.cycleActive = false
+				lt.cycleStartedAt = time.Now().Add(-lt.config.CycleCanStartEvery).Add(-time.Second)
+				return lt
 			},
-			addr,
-			func(lifetime *probeUDPLifetime) time.Duration {
+			bestAddr: addr,
+			wantAfterInactivityForFn: func(lifetime *probeUDPLifetime) time.Duration {
 				return lifetime.config.Cliffs[0] - udpLifetimeProbeCliffSlack
 			},
-			true,
+			wantMaybe: true,
 		},
 		{
-			"maybe cliff 0",
-			lower,
-			&higher,
-			func() *probeUDPLifetime {
-				l := newProbeUDPLifetime()
-				l.cycleActive = true
-				l.currentCliff = 0
-				return l
+			name:        "maybe cliff 0",
+			localDisco:  lower,
+			remoteDisco: &higher,
+			probeUDPLifetimeFn: func() *probeUDPLifetime {
+				lt := newProbeUDPLifetime()
+				lt.cycleActive = true
+				lt.currentCliff = 0
+				return lt
 			},
-			addr,
-			func(lifetime *probeUDPLifetime) time.Duration {
+			bestAddr: addr,
+			wantAfterInactivityForFn: func(lifetime *probeUDPLifetime) time.Duration {
 				return lifetime.config.Cliffs[0] - udpLifetimeProbeCliffSlack
 			},
-			true,
+			wantMaybe: true,
 		},
 		{
-			"maybe cliff 1",
-			lower,
-			&higher,
-			func() *probeUDPLifetime {
-				l := newProbeUDPLifetime()
-				l.cycleActive = true
-				l.currentCliff = 1
-				return l
+			name:        "maybe cliff 1",
+			localDisco:  lower,
+			remoteDisco: &higher,
+			probeUDPLifetimeFn: func() *probeUDPLifetime {
+				lt := newProbeUDPLifetime()
+				lt.cycleActive = true
+				lt.currentCliff = 1
+				return lt
 			},
-			addr,
-			func(lifetime *probeUDPLifetime) time.Duration {
+			bestAddr: addr,
+			wantAfterInactivityForFn: func(lifetime *probeUDPLifetime) time.Duration {
 				return lifetime.config.Cliffs[1] - udpLifetimeProbeCliffSlack
 			},
-			true,
+			wantMaybe: true,
 		},
 		{
-			"maybe cliff 2",
-			lower,
-			&higher,
-			func() *probeUDPLifetime {
-				l := newProbeUDPLifetime()
-				l.cycleActive = true
-				l.currentCliff = 2
-				return l
+			name:        "maybe cliff 2",
+			localDisco:  lower,
+			remoteDisco: &higher,
+			probeUDPLifetimeFn: func() *probeUDPLifetime {
+				lt := newProbeUDPLifetime()
+				lt.cycleActive = true
+				lt.currentCliff = 2
+				return lt
 			},
-			addr,
-			func(lifetime *probeUDPLifetime) time.Duration {
+			bestAddr: addr,
+			wantAfterInactivityForFn: func(lifetime *probeUDPLifetime) time.Duration {
 				return lifetime.config.Cliffs[2] - udpLifetimeProbeCliffSlack
 			},
-			true,
+			wantMaybe: true,
 		},
 	}
 	for _, tt := range tests {
@@ -316,7 +296,10 @@ func Test_endpoint_maybeProbeUDPLifetimeLocked(t *testing.T) {
 			p := tt.probeUDPLifetimeFn()
 			de.probeUDPLifetime = p
 			gotAfterInactivityFor, gotMaybe := de.maybeProbeUDPLifetimeLocked()
-			wantAfterInactivityFor := tt.wantAfterInactivityForFn(p)
+			var wantAfterInactivityFor time.Duration
+			if tt.wantAfterInactivityForFn != nil {
+				wantAfterInactivityFor = tt.wantAfterInactivityForFn(p)
+			}
 			if gotAfterInactivityFor != wantAfterInactivityFor {
 				t.Errorf("maybeProbeUDPLifetimeLocked() gotAfterInactivityFor = %v, want %v", gotAfterInactivityFor, wantAfterInactivityFor)
 			}


### PR DESCRIPTION
* Remove a couple of single-letter `l` variables (http://go/no-ell)
* Use named struct parameters in the test cases for readability
* Delete `wantAfterInactivityForFn` parameter when it returns the default zero

Updates #cleanup