### PR TITLE
tka: remove an unused Mem.Orphans() method

### DIFF
--- a/tka/tailchonk.go
+++ b/tka/tailchonk.go
@@ -127,19 +127,6 @@ func (c *Mem) AUM(hash AUMHash) (AUM, error) {
 	return aum, nil
 }
 
-// Orphans returns all AUMs which do not have a parent.
-func (c *Mem) Orphans() ([]AUM, error) {
-	c.l.RLock()
-	defer c.l.RUnlock()
-	out := make([]AUM, 0, 6)
-	for _, a := range c.aums {
-		if _, ok := a.Parent(); !ok {
-			out = append(out, a)
-		}
-	}
-	return out, nil
-}
-
 // ChildAUMs returns all AUMs with a specified previous
 // AUM hash.
 func (c *Mem) ChildAUMs(prevAUMHash AUMHash) ([]AUM, error) {

--- a/tka/tailchonk_test.go
+++ b/tka/tailchonk_test.go
@@ -73,33 +73,6 @@ func TestTailchonk_AUMMissing(t *testing.T) {
 	}
 }
 
-func TestTailchonkMem_Orphans(t *testing.T) {
-	chonk := Mem{}
-
-	parentHash := randHash(t, 1)
-	orphan := AUM{MessageKind: AUMNoOp}
-	aums := []AUM{
-		orphan,
-		// A parent is specified, so we shouldnt see it in GetOrphans()
-		{
-			MessageKind: AUMRemoveKey,
-			KeyID:       []byte{3, 4},
-			PrevAUMHash: parentHash[:],
-		},
-	}
-	if err := chonk.CommitVerifiedAUMs(aums); err != nil {
-		t.Fatalf("CommitVerifiedAUMs failed: %v", err)
-	}
-
-	stored, err := chonk.Orphans()
-	if err != nil {
-		t.Fatalf("Orphans failed: %v", err)
-	}
-	if diff := cmp.Diff([]AUM{orphan}, stored); diff != "" {
-		t.Errorf("stored AUM differs (-want, +got):\n%s", diff)
-	}
-}
-
 func TestTailchonk_ReadChainFromHead(t *testing.T) {
 	for _, chonk := range []Chonk{&Mem{}, &FS{base: t.TempDir()}} {
 


### PR DESCRIPTION
This method was added in cca25f6 in the initial in-memory implementation of Chonk, but it's not part of the Chonk interface and isn't implemented or used anywhere else. Let's get rid of it.

Updates https://github.com/tailscale/corp/issues/33465