### PR TITLE
cmd/tailscale/cli: error when advertising a Service from an untagged node

### DIFF
--- a/cmd/tailscale/cli/serve_legacy_test.go
+++ b/cmd/tailscale/cli/serve_legacy_test.go
@@ -860,6 +860,7 @@ type fakeLocalServeClient struct {
 	setCount             int                       // counts calls to SetServeConfig
 	queryFeatureResponse *mockQueryFeatureResponse // mock response to QueryFeature calls
 	prefs                *ipn.Prefs                // fake preferences, used to test GetPrefs and SetPrefs
+	statusWithoutPeers   *ipnstate.Status          // nil for fakeStatus
 }
 
 // fakeStatus is a fake ipnstate.Status value for tests.
@@ -880,7 +881,10 @@ var fakeStatus = &ipnstate.Status{
 }
 
 func (lc *fakeLocalServeClient) StatusWithoutPeers(ctx context.Context) (*ipnstate.Status, error) {
-	return fakeStatus, nil
+	if lc.statusWithoutPeers == nil {
+		return fakeStatus, nil
+	}
+	return lc.statusWithoutPeers, nil
 }
 
 func (lc *fakeLocalServeClient) GetServeConfig(ctx context.Context) (*ipn.ServeConfig, error) {

--- a/cmd/tailscale/cli/serve_v2.go
+++ b/cmd/tailscale/cli/serve_v2.go
@@ -420,6 +420,10 @@ func (e *serveEnv) runServeCombined(subcmd serveMode) execFunc {
 			svcName = e.service
 			dnsName = e.service.String()
 		}
+		tagged := st.Self.Tags != nil && st.Self.Tags.Len() > 0
+		if forService && !tagged && !turnOff {
+			return errors.New("service hosts must be tagged nodes")
+		}
 		if !forService && srvType == serveTypeTUN {
 			return errors.New("tun mode is only supported for services")
 		}


### PR DESCRIPTION
Service hosts must be tagged nodes, meaning it is only valid to advertise a Service from a machine which has at least one ACL tag.

Fixes tailscale/corp#33197