### PR TITLE
ipn: add support for HTTP Redirects

### DIFF
--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -242,6 +242,7 @@ var _HTTPHandlerCloneNeedsRegeneration = HTTPHandler(struct {
 	Proxy         string
 	Text          string
 	AcceptAppCaps []tailcfg.PeerCapability
+	Redirect      string
 }{})
 
 // Clone makes a deep copy of WebServerConfig.

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -896,12 +896,22 @@ func (v HTTPHandlerView) AcceptAppCaps() views.Slice[tailcfg.PeerCapability] {
 	return views.SliceOf(v.ж.AcceptAppCaps)
 }
 
+// Redirect, if not empty, is the target URL to redirect requests to.
+// By default, we redirect with HTTP 302 (Found) status.
+// If Redirect starts with '<httpcode>:', then we use that status instead.
+//
+// The target URL supports the following expansion variables:
+//   - ${HOST}: replaced with the request's Host header value
+//   - ${REQUEST_URI}: replaced with the request's full URI (path and query string)
+func (v HTTPHandlerView) Redirect() string { return v.ж.Redirect }
+
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _HTTPHandlerViewNeedsRegeneration = HTTPHandler(struct {
 	Path          string
 	Proxy         string
 	Text          string
 	AcceptAppCaps []tailcfg.PeerCapability
+	Redirect      string
 }{})
 
 // View returns a read-only view of WebServerConfig.

--- a/ipn/serve.go
+++ b/ipn/serve.go
@@ -162,8 +162,17 @@ type HTTPHandler struct {
 
 	AcceptAppCaps []tailcfg.PeerCapability `json:",omitempty"` // peer capabilities to forward in grant header, e.g. example.com/cap/mon
 
+	// Redirect, if not empty, is the target URL to redirect requests to.
+	// By default, we redirect with HTTP 302 (Found) status.
+	// If Redirect starts with '<httpcode>:', then we use that status instead.
+	//
+	// The target URL supports the following expansion variables:
+	//   - ${HOST}: replaced with the request's Host header value
+	//   - ${REQUEST_URI}: replaced with the request's full URI (path and query string)
+	Redirect string `json:",omitempty"`
+
 	// TODO(bradfitz): bool to not enumerate directories? TTL on mapping for
-	// temporary ones? Error codes? Redirects?
+	// temporary ones? Error codes?
 }
 
 // WebHandlerExists reports whether if the ServeConfig Web handler exists for


### PR DESCRIPTION
Adds a new Redirect field to HTTPHandler for serving HTTP redirects from the Tailscale serve config. The redirect URL supports template variables ${HOST} and ${REQUEST_URI} that are resolved per request.

Updates #11252
Updates #11330