### PR TITLE
.github/workflows: pin the google/oss-fuzz GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -613,7 +613,9 @@ jobs:
     steps:
     - name: build fuzzers
       id: build
-      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      # As of 21 October 2025, this repo doesn't tag releases, so this commit
+      # hash is just the tip of master.
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@1242ccb5b6352601e73c00f189ac2ae397242264
       # continue-on-error makes steps.build.conclusion be 'success' even if
       # steps.build.outcome is 'failure'. This means this step does not
       # contribute to the job's overall pass/fail evaluation.
@@ -643,7 +645,9 @@ jobs:
       # report a failure because TS_FUZZ_CURRENTLY_BROKEN is set to the wrong
       # value.
       if: steps.build.outcome == 'success'
-      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      # As of 21 October 2025, this repo doesn't tag releases, so this commit
+      # hash is just the tip of master.
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@1242ccb5b6352601e73c00f189ac2ae397242264
       with:
         oss-fuzz-project-name: 'tailscale'
         fuzz-seconds: 150


### PR DESCRIPTION
This is breaking builds, e.g. on #17591

Updates https://github.com/tailscale/corp/issues/31017