### PR TITLE
ipn/ipnlocal: skip TKA bootstrap request if Tailnet Lock is unavailable

### DIFF
--- a/ipn/ipnlocal/network-lock.go
+++ b/ipn/ipnlocal/network-lock.go
@@ -288,6 +288,10 @@ func (b *LocalBackend) tkaSyncIfNeeded(nm *netmap.NetworkMap, prefs ipn.PrefsVie
 		return nil
 	}
 
+	if err := b.CanSupportNetworkLock(); err != nil {
+		return err
+	}
+
 	isEnabled := b.tka != nil
 	wantEnabled := nm.TKAEnabled
 


### PR DESCRIPTION
If you run tailscaled without passing a `--statedir`, Tailnet Lock is unavailable -- we don't have a folder to store the AUMs in.

This causes a lot of unnecessary requests to bootstrap TKA, because every time the node receives a NetMap with some TKA state, it tries to bootstrap, fetches the bootstrap TKA state from the control plane, then fails with the error:

    TKA sync error: bootstrap: network-lock is not supported in this
    configuration, try setting --statedir

We can't prevent the error, but we can skip the control plane request that immediately gets dropped on the floor.

In local testing, a new node joining a tailnet caused *three* control plane requests which were unused.

Updates tailscale/corp#19441