### PR TITLE
cmd/tailscale/cli: allow remote target as service destination

### DIFF
--- a/client/local/local.go
+++ b/client/local/local.go
@@ -1401,6 +1401,23 @@ func (lc *Client) SuggestExitNode(ctx context.Context) (apitype.ExitNodeSuggesti
 	return decodeJSON[apitype.ExitNodeSuggestionResponse](body)
 }
 
+// CheckSOMarkInUse reports whether the socket mark option is in use. This will only
+// be true if tailscale is running on Linux and tailscaled uses SO_MARK.
+func (lc *Client) CheckSOMarkInUse(ctx context.Context) (bool, error) {
+	body, err := lc.get200(ctx, "/localapi/v0/check-so-mark-in-use")
+	if err != nil {
+		return false, err
+	}
+	var res struct {
+		UseSOMark bool `json:"useSoMark"`
+	}
+
+	if err := json.Unmarshal(body, &res); err != nil {
+		return false, fmt.Errorf("invalid JSON from check-so-mark-in-use: %w", err)
+	}
+	return res.UseSOMark, nil
+}
+
 // ShutdownTailscaled requests a graceful shutdown of tailscaled.
 func (lc *Client) ShutdownTailscaled(ctx context.Context) error {
 	_, err := lc.send(ctx, "POST", "/localapi/v0/shutdown", 200, nil)

--- a/cmd/tailscale/cli/serve_legacy.go
+++ b/cmd/tailscale/cli/serve_legacy.go
@@ -149,6 +149,7 @@ type localServeClient interface {
 	IncrementCounter(ctx context.Context, name string, delta int) error
 	GetPrefs(ctx context.Context) (*ipn.Prefs, error)
 	EditPrefs(ctx context.Context, mp *ipn.MaskedPrefs) (*ipn.Prefs, error)
+	CheckSOMarkInUse(ctx context.Context) (bool, error)
 }
 
 // serveEnv is the environment the serve command runs within. All I/O should be

--- a/cmd/tailscale/cli/serve_legacy_test.go
+++ b/cmd/tailscale/cli/serve_legacy_test.go
@@ -860,6 +860,7 @@ type fakeLocalServeClient struct {
 	setCount             int                       // counts calls to SetServeConfig
 	queryFeatureResponse *mockQueryFeatureResponse // mock response to QueryFeature calls
 	prefs                *ipn.Prefs                // fake preferences, used to test GetPrefs and SetPrefs
+	SOMarkInUse          bool                      // fake SO mark in use status
 	statusWithoutPeers   *ipnstate.Status          // nil for fakeStatus
 }
 
@@ -935,6 +936,10 @@ func (lc *fakeLocalServeClient) WatchIPNBus(ctx context.Context, mask ipn.Notify
 
 func (lc *fakeLocalServeClient) IncrementCounter(ctx context.Context, name string, delta int) error {
 	return nil // unused in tests
+}
+
+func (lc *fakeLocalServeClient) CheckSOMarkInUse(ctx context.Context) (bool, error) {
+	return lc.SOMarkInUse, nil
 }
 
 // exactError returns an error checker that wants exactly the provided want error.

--- a/ipn/serve_test.go
+++ b/ipn/serve_test.go
@@ -260,12 +260,16 @@ func TestExpandProxyTargetDev(t *testing.T) {
 		{name: "https+insecure-scheme", input: "https+insecure://localhost:8080", expected: "https+insecure://localhost:8080"},
 		{name: "change-default-scheme", input: "localhost:8080", defaultScheme: "https", expected: "https://localhost:8080"},
 		{name: "change-supported-schemes", input: "localhost:8080", defaultScheme: "tcp", supportedSchemes: []string{"tcp"}, expected: "tcp://localhost:8080"},
+		{name: "remote-target", input: "https://example.com:8080", expected: "https://example.com:8080"},
+		{name: "remote-IP-target", input: "http://120.133.20.2:8080", expected: "http://120.133.20.2:8080"},
+		{name: "remote-target-no-port", input: "https://example.com", expected: "https://example.com"},
 
 		// errors
 		{name: "invalid-port", input: "localhost:9999999", wantErr: true},
+		{name: "invalid-hostname", input: "192.168.1:8080", wantErr: true},
 		{name: "unsupported-scheme", input: "ftp://localhost:8080", expected: "", wantErr: true},
-		{name: "not-localhost", input: "https://tailscale.com:8080", expected: "", wantErr: true},
 		{name: "empty-input", input: "", expected: "", wantErr: true},
+		{name: "localhost-no-port", input: "localhost", expected: "", wantErr: true},
 	}
 
 	for _, tt := range tests {

--- a/net/netns/netns_default.go
+++ b/net/netns/netns_default.go
@@ -20,3 +20,7 @@ func control(logger.Logf, *netmon.Monitor) func(network, address string, c sysca
 func controlC(network, address string, c syscall.RawConn) error {
 	return nil
 }
+
+func UseSocketMark() bool {
+	return false
+}

--- a/net/netns/netns_dw.go
+++ b/net/netns/netns_dw.go
@@ -25,3 +25,7 @@ func parseAddress(address string) (addr netip.Addr, err error) {
 
 	return netip.ParseAddr(host)
 }
+
+func UseSocketMark() bool {
+	return false
+}


### PR DESCRIPTION
This PR enables user to set service backend to remote destinations, that can be a partial URL or a full URL. The commit also prevents user to set remote destinations on linux system when socket mark is not working. For user on any version of mac extension they can't serve a service either. The socket mark usability is determined by a new local api.

Fixes tailscale/corp#24783