### PR TITLE
Update JetKVM move /etc/init.d to /userdata/init.d for persistence

### DIFF
--- a/cmd/tailscale/cli/configure-jetkvm.go
+++ b/cmd/tailscale/cli/configure-jetkvm.go
@@ -48,9 +48,12 @@ func runConfigureJetKVM(ctx context.Context, args []string) error {
 	if runtime.GOOS != "linux" || distro.Get() != distro.JetKVM {
 		return errors.New("only implemented on JetKVM")
 	}
-	err := os.WriteFile("/etc/init.d/S22tailscale", bytes.TrimLeft([]byte(`
+	if err := os.MkdirAll("/userdata/init.d", 0755); err != nil {
+		return errors.New("unable to create /userdata/init.d")
+	}
+	err := os.WriteFile("/userdata/init.d/S22tailscale", bytes.TrimLeft([]byte(`
 #!/bin/sh
-# /etc/init.d/S22tailscale
+# /userdata/init.d/S22tailscale
 # Start/stop tailscaled
 
 case "$1" in


### PR DESCRIPTION
Resolve #16524 by moving /etc/init.d files to /userdata/init.d. This change supports JetKVM's recently published [release v0.27](https://github.com/jetkvm/rv1106-system/releases/tag/v0.2.7) which incorporates https://github.com/jetkvm/rv1106-system/pull/34.

Would any reviewers be able to tell me how to test this? Thank you! 