### PR TITLE
control/controlclient: remove unused reference to mapCtx

### DIFF
--- a/control/controlclient/auto.go
+++ b/control/controlclient/auto.go
@@ -433,7 +433,6 @@ func (mrs mapRoutineState) UpdateFullNetmap(nm *netmap.NetworkMap) {
 	c := mrs.c
 
 	c.mu.Lock()
-	ctx := c.mapCtx
 	c.inMapPoll = true
 	if c.loggedIn {
 		c.state = StateSynchronized
@@ -447,7 +446,7 @@ func (mrs mapRoutineState) UpdateFullNetmap(nm *netmap.NetworkMap) {
 		c.sendStatus("mapRoutine-got-netmap", nil, "", nm)
 	}
 	// Reset the backoff timer if we got a netmap.
-	mrs.bo.BackOff(ctx, nil)
+	mrs.bo.Reset()
 }
 
 func (mrs mapRoutineState) UpdateNetmapDelta(muts []netmap.NodeMutation) bool {

--- a/util/backoff/backoff.go
+++ b/util/backoff/backoff.go
@@ -78,3 +78,9 @@ func (b *Backoff) BackOff(ctx context.Context, err error) {
 	case <-tChannel:
 	}
 }
+
+// Reset resets the backoff schedule, equivalent to calling BackOff with a nil
+// error.
+func (b *Backoff) Reset() {
+	b.n = 0
+}


### PR DESCRIPTION
Updates #cleanup

One less reference to get confused by when tracking where `mapCtx` is used.