### PR TITLE
net/portmapper: add UPnP-IGD release timeout

### DIFF
--- a/net/portmapper/portmapper.go
+++ b/net/portmapper/portmapper.go
@@ -395,7 +395,9 @@ func (c *Client) listenPacket(ctx context.Context, network, addr string) (nettyp
 func (c *Client) invalidateMappingsLocked(releaseOld bool) {
 	if c.mapping != nil {
 		if releaseOld {
-			c.mapping.Release(context.Background())
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			c.mapping.Release(ctx)
 		}
 		c.mapping = nil
 	}


### PR DESCRIPTION
Smallest possible change that could help mitigate a deadlock if a release
is hanging.

Updates tailscale/corp#33619

Signed-off-by: Claus Lensbøl <claus@tailscale.com>
