### PR TITLE
feature/tpm: use withSRK to probe TPM availability

### DIFF
--- a/feature/tpm/tpm.go
+++ b/feature/tpm/tpm.go
@@ -59,7 +59,22 @@ func tpmSupported() bool {
 	if hi == nil {
 		return false
 	}
-	return hi.FamilyIndicator == "2.0"
+	if hi.FamilyIndicator != "2.0" {
+		return false
+	}
+
+	tpm, err := open()
+	if err != nil {
+		return false
+	}
+	defer tpm.Close()
+
+	if err := withSRK(logger.Discard, tpm, func(srk tpm2.AuthHandle) error {
+		return nil
+	}); err != nil {
+		return false
+	}
+	return true
 }
 
 var verboseTPM = envknob.RegisterBool("TS_DEBUG_TPM")

--- a/feature/tpm/tpm_test.go
+++ b/feature/tpm/tpm_test.go
@@ -146,6 +146,18 @@ func BenchmarkInfo(b *testing.B) {
 	b.StopTimer()
 }
 
+func BenchmarkTPMSupported(b *testing.B) {
+	b.StopTimer()
+	skipWithoutTPM(b)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if !tpmSupported() {
+			b.Fatalf("tpmSupported returned false")
+		}
+	}
+	b.StopTimer()
+}
+
 func BenchmarkStore(b *testing.B) {
 	skipWithoutTPM(b)
 	b.StopTimer()


### PR DESCRIPTION
On some platforms e.g. ChromeOS the owner hierarchy might not always be available to us. To avoid stale sealing exceptions later we probe to confirm it's working rather than rely solely on family indicator status.

Updates #17622