### PR TITLE
util/linuxfw: fix 32-bit arm regression with iptables

### DIFF
--- a/util/linuxfw/iptables.go
+++ b/util/linuxfw/iptables.go
@@ -1,9 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build linux && (arm64 || amd64) && !ts_omit_iptables
-
-// TODO(#8502): add support for more architectures
+//go:build linux && !ts_omit_iptables
 
 package linuxfw
 

--- a/util/linuxfw/iptables_disabled.go
+++ b/util/linuxfw/iptables_disabled.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build (linux && !(arm64 || amd64)) || ts_omit_iptables
+//go:build linux && ts_omit_iptables
 
 package linuxfw
 


### PR DESCRIPTION
This fixes a regression from dd615c8fdd that moved the
newIPTablesRunner constructor from a any-Linux-GOARCH file to one that
was only amd64 and arm64, thus breaking iptables on other platforms
(notably 32-bit "arm", as seen on older Pis running Buster with
iptables)

Tested by hand on a Raspberry Pi 2 w/ Buster + iptables for now, for
lack of automated 32-bit arm tests at the moment. But filed #17629.

Fixes #17623
Updates #17629
