### PR TITLE
cmd/containerboot: exit with non-zero code on unexpected tailscaled death

### DIFF
--- a/cmd/containerboot/test_tailscaled.sh
+++ b/cmd/containerboot/test_tailscaled.sh
@@ -35,4 +35,8 @@ fi
 ln -s "$TS_TEST_SOCKET" "$socket"
 trap 'rm -f "$socket"' EXIT
 
+if [[ -n "$TS_TEST_ONLY_ROOT" ]]; then
+	echo $$ > "$TS_TEST_ONLY_ROOT/tmp/tailscaled.pid"
+fi
+
 while sleep 10; do :; done


### PR DESCRIPTION
When tailscaled exits unexpectedly (crashes, killed directly), containerboot now exits with a non-zero code to signal failure to the orchestrator. The reaper now distinguishes between graceful shutdowns which still exit 0, and unexpected exits which propagate the child's exit code or force 1 if the child exited cleanly on its own. Fixes: #17650