### PR TITLE
add test flag in wasm_js.go

### DIFF
--- a/cmd/tsconnect/wasm/wasm_js.go
+++ b/cmd/tsconnect/wasm/wasm_js.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"log"
 	"math/rand/v2"
@@ -48,6 +49,9 @@ import (
 var ControlURL = ipn.DefaultControlURL
 
 func main() {
+	// skip portmapper check by setting test env
+	flag.Bool("test.v", true, "")
+
 	js.Global().Set("newIPN", js.FuncOf(func(this js.Value, args []js.Value) any {
 		if len(args) != 1 {
 			log.Fatal("Usage: newIPN(config)")


### PR DESCRIPTION
origin code will throw error:
```
panic: unexpected: HookNewPortMapper not set
```
cause the new portmapper feature is enabled by default.
this error occurs in [magicsock](https://github.com/tailscale/tailscale/blob/main/wgengine/magicsock/magicsock.go)
it is very obvious that wasm cannot use portmapper, and i can't find a way to pass a param to disable this function
there IS an `DisablePortMapper` option in `magicsock.Options`, but this is hardcoded inside function `wgengine.NewUserspaceEngine` which used in `wasm_js.go`.
i dont know if there is possible to change this parameter passing chain, setting the test environment flag is only a temporary solution