### PR TITLE
Fixes #17675 - Improves log suppression in Synology NAS

### DIFF
--- a/release/dist/synology/files/scripts/start-stop-status
+++ b/release/dist/synology/files/scripts/start-stop-status
@@ -31,8 +31,10 @@ fi
 start_daemon() {
     local ts=$(date --iso-8601=second)
     echo "${ts} Starting ${SERVICE_NAME} with: ${SERVICE_COMMAND}" >${LOG_FILE}
-    STATE_DIRECTORY=${PKGVAR} ${SERVICE_COMMAND} 2>&1 | sed -u '1,200p;201s,.*,[further tailscaled logs suppressed],p;d' >>${LOG_FILE} &
-    # We pipe tailscaled's output to sed, so "$!" retrieves the PID of sed not tailscaled.
+    STATE_DIRECTORY=${PKGVAR} ${SERVICE_COMMAND} 2>&1 | stdbuf -o0 \
+        awk 'BEGIN{t=systime()} (t==0){next} (systime()-t<600){print; next} {t=0; print "[further tailscaled logs suppressed]"}' \
+        >>${LOG_FILE} &
+    # We pipe tailscaled's output to awk, so "$!" retrieves the PID of awk not tailscaled.
     # Use jobs -p to retrieve the PID of the most recent process group leader.
     jobs -p >"${PID_FILE}"
 }


### PR DESCRIPTION
Fixes #17675 by changing the Synology logging logic to keep the first 10 minutes of the logs instead of keeping the first 200 lines.

Improves the fix made in https://github.com/tailscale/tailscale-synology/pull/110