### PR TITLE
flake.nix,nixos/: add tailscale module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -145,6 +145,15 @@
 
     nixosModules = {
       tailscale = import ./nixos/tailscaled-module.nix self;
+      # Module that disables upstream and uses this one
+      override = {
+        config,
+        pkgs,
+        ...
+      }: {
+        imports = [(import ./nixos/tailscaled-module.nix self)];
+        disabledModules = ["services/networking/tailscale.nix"];
+      };
       default = self.nixosModules.tailscale;
     };
 

--- a/nixos/tailscaled-module.nix
+++ b/nixos/tailscaled-module.nix
@@ -17,7 +17,7 @@ self: {
 in {
   # Tailscale config options
   options.services.tailscale = {
-    enable = mkEnabledOption "Enable Tailscale service";
+    enable = mkEnableOption "Enable Tailscale service";
 
     package = mkOption {
       type = types.package;


### PR DESCRIPTION
Pull in base upstream NixOS module to allow for deploying updated Tailscale from this flake.

Fixes #17678