### PR TITLE
.github: drop branches filter with single asterisk from workflows

### DIFF
--- a/.github/workflows/docker-file-build.yml
+++ b/.github/workflows/docker-file-build.yml
@@ -4,8 +4,6 @@ on:
     branches:
     - main
   pull_request:
-    branches:
-      - "*"
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -10,8 +10,6 @@ on:
       - scripts/installer.sh
       - .github/workflows/installer.yml
   pull_request:
-    branches:
-      - "*"
     paths:
       - scripts/installer.sh
       - .github/workflows/installer.yml

--- a/.github/workflows/request-dataplane-review.yml
+++ b/.github/workflows/request-dataplane-review.yml
@@ -2,8 +2,6 @@ name: request-dataplane-review
 
 on:
   pull_request:
-    branches:
-      - "*"
     paths:
       - ".github/workflows/request-dataplane-review.yml"
       - "**/*derp*"

--- a/.github/workflows/webclient.yml
+++ b/.github/workflows/webclient.yml
@@ -3,8 +3,6 @@ on:
   workflow_dispatch:
   # For now, only run on requests, not the main branches.
   pull_request:
-    branches:
-      - "*"
     paths:
       - "client/web/**"
       - ".github/workflows/webclient.yml"


### PR DESCRIPTION
Drop usage of the branches filter with a single asterisk as this matches against zero or more characters but not a forward slash, resulting in PRs to branch names with forwards slashes in them not having these workflow run against them as expected.

Updates https://github.com/tailscale/corp/issues/33523