### PR TITLE
derp: fix an unchecked error in a test

### DIFF
--- a/derp/derphttp/derphttp_test.go
+++ b/derp/derphttp/derphttp_test.go
@@ -620,6 +620,9 @@ func TestURLDial(t *testing.T) {
 	}
 	netMon := netmon.NewStatic()
 	c, err := derphttp.NewClient(key.NewNode(), "https://"+hostname+"/", t.Logf, netMon)
+	if err != nil {
+		t.Errorf("NewClient: %v", err)
+	}
 	defer c.Close()
 
 	if err := c.Connect(context.Background()); err != nil {


### PR DESCRIPTION
Found by staticcheck, the test was calling derphttp.NewClient but not checking
its error result before doing other things to it.

Change-Id: I4ade35a7de7c473571f176e747866bc0ab5774db
Signed-off-by: M. J. Fromberger <fromberger@tailscale.com>
