### PR TITLE
tka: rename a mutex to `mu` instead of single-letter `l`

### DIFF
--- a/tka/tailchonk_test.go
+++ b/tka/tailchonk_test.go
@@ -496,7 +496,7 @@ func (c *compactingChonkFake) PurgeAUMs(hashes []AUMHash) error {
 
 // Avoid go vet complaining about copying a lock value
 func cloneMem(src, dst *Mem) {
-	dst.l = sync.RWMutex{}
+	dst.mu = sync.RWMutex{}
 	dst.aums = src.aums
 	dst.parentIndex = src.parentIndex
 	dst.lastActiveAncestor = src.lastActiveAncestor


### PR DESCRIPTION
See http://go/no-ell

Updates #cleanup

Change-Id: I88ecd9db847e04237c1feab9dfcede5ca1050cc5