### PR TITLE
cmd/k8s-operator: rename 'l' variables

### DIFF
--- a/cmd/k8s-operator/operator.go
+++ b/cmd/k8s-operator/operator.go
@@ -636,7 +636,7 @@ func runReconcilers(opts reconcilerOpts) {
 			recorder:    eventRecorder,
 			tsNamespace: opts.tailscaleNamespace,
 			Client:      mgr.GetClient(),
-			l:           opts.log.Named("recorder-reconciler"),
+			log:         opts.log.Named("recorder-reconciler"),
 			clock:       tstime.DefaultClock{},
 			tsClient:    opts.tsClient,
 			loginServer: opts.loginServer,
@@ -691,7 +691,7 @@ func runReconcilers(opts reconcilerOpts) {
 		Complete(&ProxyGroupReconciler{
 			recorder: eventRecorder,
 			Client:   mgr.GetClient(),
-			l:        opts.log.Named("proxygroup-reconciler"),
+			log:      opts.log.Named("proxygroup-reconciler"),
 			clock:    tstime.DefaultClock{},
 			tsClient: opts.tsClient,
 

--- a/cmd/k8s-operator/proxygroup.go
+++ b/cmd/k8s-operator/proxygroup.go
@@ -80,7 +80,7 @@ var (
 // ProxyGroupReconciler ensures cluster resources for a ProxyGroup definition.
 type ProxyGroupReconciler struct {
 	client.Client
-	l        *zap.SugaredLogger
+	log      *zap.SugaredLogger
 	recorder record.EventRecorder
 	clock    tstime.Clock
 	tsClient tsClient
@@ -101,7 +101,7 @@ type ProxyGroupReconciler struct {
 }
 
 func (r *ProxyGroupReconciler) logger(name string) *zap.SugaredLogger {
-	return r.l.With("ProxyGroup", name)
+	return r.log.With("ProxyGroup", name)
 }
 
 func (r *ProxyGroupReconciler) Reconcile(ctx context.Context, req reconcile.Request) (_ reconcile.Result, err error) {

--- a/cmd/k8s-operator/proxygroup_test.go
+++ b/cmd/k8s-operator/proxygroup_test.go
@@ -670,7 +670,7 @@ func TestProxyGroupWithStaticEndpoints(t *testing.T) {
 						t.Logf("created node %q with data", n.name)
 					}
 
-					reconciler.l = zl.Sugar().With("TestName", tt.name).With("Reconcile", i)
+					reconciler.log = zl.Sugar().With("TestName", tt.name).With("Reconcile", i)
 					pg.Spec.Replicas = r.replicas
 					pc.Spec.StaticEndpoints = r.staticEndpointConfig
 
@@ -784,7 +784,7 @@ func TestProxyGroupWithStaticEndpoints(t *testing.T) {
 					Client:   fc,
 					tsClient: tsClient,
 					recorder: fr,
-					l:        zl.Sugar().With("TestName", tt.name).With("Reconcile", "cleanup"),
+					log:      zl.Sugar().With("TestName", tt.name).With("Reconcile", "cleanup"),
 					clock:    cl,
 				}
 
@@ -845,7 +845,7 @@ func TestProxyGroup(t *testing.T) {
 		Client:   fc,
 		tsClient: tsClient,
 		recorder: fr,
-		l:        zl.Sugar(),
+		log:      zl.Sugar(),
 		clock:    cl,
 	}
 	crd := &apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: serviceMonitorCRD}}
@@ -1049,7 +1049,7 @@ func TestProxyGroupTypes(t *testing.T) {
 		tsNamespace:  tsNamespace,
 		tsProxyImage: testProxyImage,
 		Client:       fc,
-		l:            zl.Sugar(),
+		log:          zl.Sugar(),
 		tsClient:     &fakeTSClient{},
 		clock:        tstest.NewClock(tstest.ClockOpts{}),
 	}
@@ -1289,24 +1289,24 @@ func TestKubeAPIServerStatusConditionFlow(t *testing.T) {
 		tsNamespace:  tsNamespace,
 		tsProxyImage: testProxyImage,
 		Client:       fc,
-		l:            zap.Must(zap.NewDevelopment()).Sugar(),
+		log:          zap.Must(zap.NewDevelopment()).Sugar(),
 		tsClient:     &fakeTSClient{},
 		clock:        tstest.NewClock(tstest.ClockOpts{}),
 	}
 
 	expectReconciled(t, r, "", pg.Name)
 	pg.ObjectMeta.Finalizers = append(pg.ObjectMeta.Finalizers, FinalizerName)
-	tsoperator.SetProxyGroupCondition(pg, tsapi.ProxyGroupAvailable, metav1.ConditionFalse, reasonProxyGroupCreating, "", 0, r.clock, r.l)
-	tsoperator.SetProxyGroupCondition(pg, tsapi.ProxyGroupReady, metav1.ConditionFalse, reasonProxyGroupCreating, "", 1, r.clock, r.l)
+	tsoperator.SetProxyGroupCondition(pg, tsapi.ProxyGroupAvailable, metav1.ConditionFalse, reasonProxyGroupCreating, "", 0, r.clock, r.log)
+	tsoperator.SetProxyGroupCondition(pg, tsapi.ProxyGroupReady, metav1.ConditionFalse, reasonProxyGroupCreating, "", 1, r.clock, r.log)
 	expectEqual(t, fc, pg, omitPGStatusConditionMessages)
 
 	// Set kube-apiserver valid.
 	mustUpdateStatus(t, fc, "", pg.Name, func(p *tsapi.ProxyGroup) {
-		tsoperator.SetProxyGroupCondition(p, tsapi.KubeAPIServerProxyValid, metav1.ConditionTrue, reasonKubeAPIServerProxyValid, "", 1, r.clock, r.l)
+		tsoperator.SetProxyGroupCondition(p, tsapi.KubeAPIServerProxyValid, metav1.ConditionTrue, reasonKubeAPIServerProxyValid, "", 1, r.clock, r.log)
 	})
 	expectReconciled(t, r, "", pg.Name)
-	tsoperator.SetProxyGroupCondition(pg, tsapi.KubeAPIServerProxyValid, metav1.ConditionTrue, reasonKubeAPIServerProxyValid, "", 1, r.clock, r.l)
-	tsoperator.SetProxyGroupCondition(pg, tsapi.ProxyGroupReady, metav1.ConditionFalse, reasonProxyGroupCreating, "", 1, r.clock, r.l)
+	tsoperator.SetProxyGroupCondition(pg, tsapi.KubeAPIServerProxyValid, metav1.ConditionTrue, reasonKubeAPIServerProxyValid, "", 1, r.clock, r.log)
+	tsoperator.SetProxyGroupCondition(pg, tsapi.ProxyGroupReady, metav1.ConditionFalse, reasonProxyGroupCreating, "", 1, r.clock, r.log)
 	expectEqual(t, fc, pg, omitPGStatusConditionMessages)
 
 	// Set available.
@@ -1318,17 +1318,17 @@ func TestKubeAPIServerStatusConditionFlow(t *testing.T) {
 			TailnetIPs: []string{"1.2.3.4", "::1"},
 		},
 	}
-	tsoperator.SetProxyGroupCondition(pg, tsapi.ProxyGroupAvailable, metav1.ConditionTrue, reasonProxyGroupAvailable, "", 0, r.clock, r.l)
-	tsoperator.SetProxyGroupCondition(pg, tsapi.ProxyGroupReady, metav1.ConditionFalse, reasonProxyGroupCreating, "", 1, r.clock, r.l)
+	tsoperator.SetProxyGroupCondition(pg, tsapi.ProxyGroupAvailable, metav1.ConditionTrue, reasonProxyGroupAvailable, "", 0, r.clock, r.log)
+	tsoperator.SetProxyGroupCondition(pg, tsapi.ProxyGroupReady, metav1.ConditionFalse, reasonProxyGroupCreating, "", 1, r.clock, r.log)
 	expectEqual(t, fc, pg, omitPGStatusConditionMessages)
 
 	// Set kube-apiserver configured.
 	mustUpdateStatus(t, fc, "", pg.Name, func(p *tsapi.ProxyGroup) {
-		tsoperator.SetProxyGroupCondition(p, tsapi.KubeAPIServerProxyConfigured, metav1.ConditionTrue, reasonKubeAPIServerProxyConfigured, "", 1, r.clock, r.l)
+		tsoperator.SetProxyGroupCondition(p, tsapi.KubeAPIServerProxyConfigured, metav1.ConditionTrue, reasonKubeAPIServerProxyConfigured, "", 1, r.clock, r.log)
 	})
 	expectReconciled(t, r, "", pg.Name)
-	tsoperator.SetProxyGroupCondition(pg, tsapi.KubeAPIServerProxyConfigured, metav1.ConditionTrue, reasonKubeAPIServerProxyConfigured, "", 1, r.clock, r.l)
-	tsoperator.SetProxyGroupCondition(pg, tsapi.ProxyGroupReady, metav1.ConditionTrue, reasonProxyGroupReady, "", 1, r.clock, r.l)
+	tsoperator.SetProxyGroupCondition(pg, tsapi.KubeAPIServerProxyConfigured, metav1.ConditionTrue, reasonKubeAPIServerProxyConfigured, "", 1, r.clock, r.log)
+	tsoperator.SetProxyGroupCondition(pg, tsapi.ProxyGroupReady, metav1.ConditionTrue, reasonProxyGroupReady, "", 1, r.clock, r.log)
 	expectEqual(t, fc, pg, omitPGStatusConditionMessages)
 }
 
@@ -1342,7 +1342,7 @@ func TestKubeAPIServerType_DoesNotOverwriteServicesConfig(t *testing.T) {
 		tsNamespace:  tsNamespace,
 		tsProxyImage: testProxyImage,
 		Client:       fc,
-		l:            zap.Must(zap.NewDevelopment()).Sugar(),
+		log:          zap.Must(zap.NewDevelopment()).Sugar(),
 		tsClient:     &fakeTSClient{},
 		clock:        tstest.NewClock(tstest.ClockOpts{}),
 	}
@@ -1427,7 +1427,7 @@ func TestIngressAdvertiseServicesConfigPreserved(t *testing.T) {
 		tsNamespace:  tsNamespace,
 		tsProxyImage: testProxyImage,
 		Client:       fc,
-		l:            zap.Must(zap.NewDevelopment()).Sugar(),
+		log:          zap.Must(zap.NewDevelopment()).Sugar(),
 		tsClient:     &fakeTSClient{},
 		clock:        tstest.NewClock(tstest.ClockOpts{}),
 	}
@@ -1902,7 +1902,7 @@ func TestProxyGroupLetsEncryptStaging(t *testing.T) {
 				defaultProxyClass: tt.defaultProxyClass,
 				Client:            fc,
 				tsClient:          &fakeTSClient{},
-				l:                 zl.Sugar(),
+				log:               zl.Sugar(),
 				clock:             cl,
 			}
 

--- a/cmd/k8s-operator/sts_test.go
+++ b/cmd/k8s-operator/sts_test.go
@@ -71,11 +71,11 @@ func Test_applyProxyClassToStatefulSet(t *testing.T) {
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsUser: ptr.To(int64(0)),
 					},
-					ImagePullSecrets: []corev1.LocalObjectReference{{Name: "docker-creds"}},
-					NodeName:         "some-node",
-					NodeSelector:     map[string]string{"beta.kubernetes.io/os": "linux"},
-					Affinity:         &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{}}},
-					Tolerations:      []corev1.Toleration{{Key: "", Operator: "Exists"}},
+					ImagePullSecrets:  []corev1.LocalObjectReference{{Name: "docker-creds"}},
+					NodeName:          "some-node",
+					NodeSelector:      map[string]string{"beta.kubernetes.io/os": "linux"},
+					Affinity:          &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{}}},
+					Tolerations:       []corev1.Toleration{{Key: "", Operator: "Exists"}},
 					PriorityClassName: "high-priority",
 					TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
 						{

--- a/cmd/k8s-operator/tsrecorder.go
+++ b/cmd/k8s-operator/tsrecorder.go
@@ -54,7 +54,7 @@ var gaugeRecorderResources = clientmetric.NewGauge(kubetypes.MetricRecorderCount
 // Recorder CRs.
 type RecorderReconciler struct {
 	client.Client
-	l           *zap.SugaredLogger
+	log         *zap.SugaredLogger
 	recorder    record.EventRecorder
 	clock       tstime.Clock
 	tsNamespace string
@@ -66,7 +66,7 @@ type RecorderReconciler struct {
 }
 
 func (r *RecorderReconciler) logger(name string) *zap.SugaredLogger {
-	return r.l.With("Recorder", name)
+	return r.log.With("Recorder", name)
 }
 
 func (r *RecorderReconciler) Reconcile(ctx context.Context, req reconcile.Request) (_ reconcile.Result, err error) {

--- a/cmd/k8s-operator/tsrecorder_test.go
+++ b/cmd/k8s-operator/tsrecorder_test.go
@@ -52,7 +52,7 @@ func TestRecorder(t *testing.T) {
 		Client:      fc,
 		tsClient:    tsClient,
 		recorder:    fr,
-		l:           zl.Sugar(),
+		log:         zl.Sugar(),
 		clock:       cl,
 		loginServer: tsLoginServer,
 	}


### PR DESCRIPTION
Single letter 'l' variables can eventually become confusing when they're rendered in some fonts that make them similar to 1 or I.

Updates #cleanup