### PR TITLE
sessionrecording: fix regression in recent http2 package change

### DIFF
--- a/sessionrecording/connect.go
+++ b/sessionrecording/connect.go
@@ -405,10 +405,7 @@ func clientHTTP2(dialCtx context.Context, dial netx.DialFunc) *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
 			Protocols: &p,
-			// Pretend like we're using TLS, but actually use the provided
-			// DialFunc underneath. This is necessary to convince the transport
-			// to actually dial.
-			DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 				perAttemptCtx, cancel := context.WithTimeout(ctx, perDialAttemptTimeout)
 				defer cancel()
 				go func() {


### PR DESCRIPTION
In 3f5c560fd45664813 I changed to use std net/http's HTTP/2 support,
instead of pulling in x/net/http2.

But I forgot to update DialTLSContext to DialContext, which meant it
was falling back to using the std net.Dialer for its dials, instead
of the passed-in one.

The tests only passed because they were using localhost addresses, so
the std net.Dialer worked. But in prod, where a tsnet Dialer would be
needed, it didn't work, and would time out for 10 seconds before
resorting to the old protocol.

So this fixes the tests to use an isolated in-memory network to prevent
that class of problem in the future. With the test change, the old code
fails and the new code passes.

Thanks to @jasonodonnell for debugging!

Updates #17304
Updates 3f5c560fd45664813
