### PR TITLE
cmd/k8s-operator/generate: skip tests if no network or Helm is down

### DIFF
--- a/cmd/k8s-operator/generate/main.go
+++ b/cmd/k8s-operator/generate/main.go
@@ -144,7 +144,7 @@ func generate(baseDir string) error {
 		if _, err := file.Write([]byte(helmConditionalEnd)); err != nil {
 			return fmt.Errorf("error writing helm if-statement end: %w", err)
 		}
-		return nil
+		return file.Close()
 	}
 	for _, crd := range []struct {
 		crdPath, templatePath string


### PR DESCRIPTION
Updates helm/helm#31434
