### PR TITLE
cmd/tailscale/cli/serve_v2: improve validation error

### DIFF
--- a/cmd/tailscale/cli/serve_v2.go
+++ b/cmd/tailscale/cli/serve_v2.go
@@ -116,7 +116,7 @@ func (u *acceptAppCapsFlag) Set(s string) error {
 	for _, appCap := range appCaps {
 		appCap = strings.TrimSpace(appCap)
 		if !validAppCap.MatchString(appCap) {
-			return fmt.Errorf("%q does not match the form {domain}/{name}, where domain must be a fully qualified domain name", s)
+			return fmt.Errorf("%q does not match the form {domain}/{name}, where domain must be a fully qualified domain name", appCap)
 		}
 		*u.Value = append(*u.Value, tailcfg.PeerCapability(appCap))
 	}


### PR DESCRIPTION
Specify the app apability that failed the test, instead of the entire comma-separated list.

**Before** 
```
$ tailscale serve --accept-app-caps=ff.com/cap1,BROKEN 3000 
invalid value "ff.com/cap1,BROKEN" for flag -accept-app-caps: "ff.com/cap1,BROKEN" does not 
match the form {domain}/{name}, where domain must be a fully qualified domain
```
**After** 
```
$ tailscale serve --accept-app-caps=ff.com/cap1,BROKEN 3000 
invalid value "ff.com/cap1,BROKEN" for flag -accept-app-caps: "BROKEN" does not match the 
form {domain}/{name}, where domain must be a fully qualified domain
```