### PR TITLE
Revert "control/controlclient: back out HW key attestation"

### DIFF
--- a/ipn/ipnlocal/hwattest.go
+++ b/ipn/ipnlocal/hwattest.go
@@ -1,0 +1,48 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !ts_omit_tpm
+
+package ipnlocal
+
+import (
+	"errors"
+
+	"tailscale.com/feature"
+	"tailscale.com/types/key"
+	"tailscale.com/types/logger"
+	"tailscale.com/types/persist"
+)
+
+func init() {
+	feature.HookGenerateAttestationKeyIfEmpty.Set(generateAttestationKeyIfEmpty)
+}
+
+// generateAttestationKeyIfEmpty generates a new hardware attestation key if
+// none exists. It returns true if a new key was generated and stored in
+// p.AttestationKey.
+func generateAttestationKeyIfEmpty(p *persist.Persist, logf logger.Logf) (bool, error) {
+	// attempt to generate a new hardware attestation key if none exists
+	var ak key.HardwareAttestationKey
+	if p != nil {
+		ak = p.AttestationKey
+	}
+
+	if ak == nil || ak.IsZero() {
+		var err error
+		ak, err = key.NewHardwareAttestationKey()
+		if err != nil {
+			if !errors.Is(err, key.ErrUnsupported) {
+				logf("failed to create hardware attestation key: %v", err)
+			}
+		} else if ak != nil {
+			logf("using new hardware attestation key: %v", ak.Public())
+			if p == nil {
+				p = &persist.Persist{}
+			}
+			p.AttestationKey = ak
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1190,6 +1190,7 @@ func stripKeysFromPrefs(p ipn.PrefsView) ipn.PrefsView {
 	p2.Persist.PrivateNodeKey = key.NodePrivate{}
 	p2.Persist.OldPrivateNodeKey = key.NodePrivate{}
 	p2.Persist.NetworkLockKey = key.NLPrivate{}
+	p2.Persist.AttestationKey = nil
 	return p2.View()
 }
 

--- a/ipn/ipnlocal/profiles.go
+++ b/ipn/ipnlocal/profiles.go
@@ -19,7 +19,9 @@ import (
 	"tailscale.com/ipn"
 	"tailscale.com/ipn/ipnext"
 	"tailscale.com/tailcfg"
+	"tailscale.com/types/key"
 	"tailscale.com/types/logger"
+	"tailscale.com/types/persist"
 	"tailscale.com/util/clientmetric"
 	"tailscale.com/util/eventbus"
 )
@@ -654,6 +656,14 @@ func (pm *profileManager) loadSavedPrefs(k ipn.StateKey) (ipn.PrefsView, error) 
 		return ipn.PrefsView{}, err
 	}
 	savedPrefs := ipn.NewPrefs()
+
+	// if supported by the platform, create an empty hardware attestation key to use when deserializing
+	// to avoid type exceptions from json.Unmarshaling into an interface{}.
+	hw, _ := key.NewEmptyHardwareAttestationKey()
+	savedPrefs.Persist = &persist.Persist{
+		AttestationKey: hw,
+	}
+
 	if err := ipn.PrefsFromBytes(bs, savedPrefs); err != nil {
 		return ipn.PrefsView{}, fmt.Errorf("parsing saved prefs: %v", err)
 	}

--- a/ipn/ipnlocal/profiles_test.go
+++ b/ipn/ipnlocal/profiles_test.go
@@ -151,6 +151,7 @@ func TestProfileDupe(t *testing.T) {
 				ID:        tailcfg.UserID(user),
 				LoginName: fmt.Sprintf("user%d@example.com", user),
 			},
+			AttestationKey: nil,
 		}
 	}
 	user1Node1 := newPersist(1, 1)

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -501,7 +501,7 @@ func TestPrefsPretty(t *testing.T) {
 				},
 			},
 			"linux",
-			`Prefs{ra=false dns=false want=false routes=[] nf=off update=off Persist{o=, n=[B1VKl] u=""}}`,
+			`Prefs{ra=false dns=false want=false routes=[] nf=off update=off Persist{o=, n=[B1VKl] u="" ak=-}}`,
 		},
 		{
 			Prefs{

--- a/types/persist/persist_clone.go
+++ b/types/persist/persist_clone.go
@@ -19,6 +19,9 @@ func (src *Persist) Clone() *Persist {
 	}
 	dst := new(Persist)
 	*dst = *src
+	if src.AttestationKey != nil {
+		dst.AttestationKey = src.AttestationKey.Clone()
+	}
 	dst.DisallowedTKAStateIDs = append(src.DisallowedTKAStateIDs[:0:0], src.DisallowedTKAStateIDs...)
 	return dst
 }
@@ -31,5 +34,6 @@ var _PersistCloneNeedsRegeneration = Persist(struct {
 	UserProfile           tailcfg.UserProfile
 	NetworkLockKey        key.NLPrivate
 	NodeID                tailcfg.StableNodeID
+	AttestationKey        key.HardwareAttestationKey
 	DisallowedTKAStateIDs []string
 }{})

--- a/types/persist/persist_test.go
+++ b/types/persist/persist_test.go
@@ -21,7 +21,7 @@ func fieldsOf(t reflect.Type) (fields []string) {
 }
 
 func TestPersistEqual(t *testing.T) {
-	persistHandles := []string{"PrivateNodeKey", "OldPrivateNodeKey", "UserProfile", "NetworkLockKey", "NodeID", "DisallowedTKAStateIDs"}
+	persistHandles := []string{"PrivateNodeKey", "OldPrivateNodeKey", "UserProfile", "NetworkLockKey", "NodeID", "AttestationKey", "DisallowedTKAStateIDs"}
 	if have := fieldsOf(reflect.TypeFor[Persist]()); !reflect.DeepEqual(have, persistHandles) {
 		t.Errorf("Persist.Equal check might be out of sync\nfields: %q\nhandled: %q\n",
 			have, persistHandles)

--- a/types/persist/persist_view.go
+++ b/types/persist/persist_view.go
@@ -89,10 +89,11 @@ func (v *PersistView) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 func (v PersistView) PrivateNodeKey() key.NodePrivate { return v.ж.PrivateNodeKey }
 
 // needed to request key rotation
-func (v PersistView) OldPrivateNodeKey() key.NodePrivate { return v.ж.OldPrivateNodeKey }
-func (v PersistView) UserProfile() tailcfg.UserProfile   { return v.ж.UserProfile }
-func (v PersistView) NetworkLockKey() key.NLPrivate      { return v.ж.NetworkLockKey }
-func (v PersistView) NodeID() tailcfg.StableNodeID       { return v.ж.NodeID }
+func (v PersistView) OldPrivateNodeKey() key.NodePrivate   { return v.ж.OldPrivateNodeKey }
+func (v PersistView) UserProfile() tailcfg.UserProfile     { return v.ж.UserProfile }
+func (v PersistView) NetworkLockKey() key.NLPrivate        { return v.ж.NetworkLockKey }
+func (v PersistView) NodeID() tailcfg.StableNodeID         { return v.ж.NodeID }
+func (v PersistView) AttestationKey() tailcfg.StableNodeID { panic("unsupported") }
 
 // DisallowedTKAStateIDs stores the tka.State.StateID values which
 // this node will not operate network lock on. This is used to
@@ -110,5 +111,6 @@ var _PersistViewNeedsRegeneration = Persist(struct {
 	UserProfile           tailcfg.UserProfile
 	NetworkLockKey        key.NLPrivate
 	NodeID                tailcfg.StableNodeID
+	AttestationKey        key.HardwareAttestationKey
 	DisallowedTKAStateIDs []string
 }{})


### PR DESCRIPTION
https://github.com/tailscale/tailscale/pull/17708 handles the main race condition.
It's possible there are other bugs hidden, but need to re-enable this to test on Windows devices.

Reverts tailscale/tailscale#17664
Updates #15830