### PR TITLE
ipn: include `{V4,V6}MasqAddr` in `PeerStatus`

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1365,6 +1365,8 @@ func (b *LocalBackend) populatePeerStatusLocked(sb *ipnstate.StatusBuilder) {
 			SSH_HostKeys:    p.Hostinfo().SSH_HostKeys().AsSlice(),
 			Location:        p.Hostinfo().Location().AsStruct(),
 			Capabilities:    p.Capabilities().AsSlice(),
+			MasqAddrV4:      p.SelfNodeV4MasqAddrForThisPeer().GetOr(netip.Addr{}),
+			MasqAddrV6:      p.SelfNodeV6MasqAddrForThisPeer().GetOr(netip.Addr{}),
 		}
 		for _, f := range b.extHost.Hooks().SetPeerStatus {
 			f(ps, p, cn)

--- a/ipn/ipnstate/ipnstate.go
+++ b/ipn/ipnstate/ipnstate.go
@@ -328,6 +328,16 @@ type PeerStatus struct {
 	KeyExpiry *time.Time `json:",omitempty"`
 
 	Location *tailcfg.Location `json:",omitempty"`
+
+	// MasqAddrV4 holds the IPv4 address that this peer knows the current
+	// node as. It may be empty if the peer knows the current node by its
+	// native IPv4 address.
+	MasqAddrV4 netip.Addr `json:",omitzero"`
+
+	// MasqAddrV6 holds the IPv6 address that this peer knows the current
+	// node as. It may be empty if the peer knows the current node by its
+	// native IPv6 address.
+	MasqAddrV6 netip.Addr `json:",omitzero"`
 }
 
 type TaildropTargetStatus int
@@ -546,6 +556,12 @@ func (sb *StatusBuilder) AddPeer(peer key.NodePublic, st *PeerStatus) {
 		e.TaildropTarget = v
 	}
 	e.Location = st.Location
+	if v := st.MasqAddrV4; v != (netip.Addr{}) {
+		e.MasqAddrV4 = v
+	}
+	if v := st.MasqAddrV6; v != (netip.Addr{}) {
+		e.MasqAddrV6 = v
+	}
 }
 
 type StatusUpdater interface {


### PR DESCRIPTION
To better understand how Tailscale routes traffic to exit nodes, and debug issues related to masquerading and exit nodes it can be useful to know the address Tailscale uses to masquerade node traffic. This commit includes it in `PeerStatus`, such that it is observable with `tailscale status --json`.

The `SelfNode{V4,V6}MasqAddrForThisPeer` method definitions in `tailcfg/tailcfg_view.go` contain more elaborate documentation on when these addresses are populated. However, I don't know whether it's worth duplicating all of this documentation for the added fields to `PeerStatus`.

This is my first contribution to Tailscale and I haven't been hacking on Go in a long time, so any feedback welcome! Also, I want to express my thanks for providing the `flake.nix` which made hacking on this much easier. :smile: 