### PR TITLE
cli: add --device-attrs flag and LocalAPI client for device posture attributes

### DIFF
--- a/client/local/local.go
+++ b/client/local/local.go
@@ -847,6 +847,18 @@ func (lc *Client) SetUDPGROForwarding(ctx context.Context) error {
 	return nil
 }
 
+// SetDeviceAttrs updates device posture attributes for the current node via the LocalAPI.
+//
+// This calls the experimental endpoint /localapi/v0/alpha-set-device-attrs with a PATCH
+// request body of type tailcfg.AttrUpdate (map[string]any). Attributes set to nil are
+// deleted server-side. Numeric values are interpreted as float64 by the server.
+func (lc *Client) SetDeviceAttrs(ctx context.Context, attrs tailcfg.AttrUpdate) error {
+	// Endpoint is currently gated behind buildfeatures.HasDebug on the daemon.
+	// If unavailable, this will likely return 404.
+	_, err := lc.send(ctx, "PATCH", "/localapi/v0/alpha-set-device-attrs", 200, jsonBody(attrs))
+	return err
+}
+
 // CheckPrefs validates the provided preferences, without making any changes.
 //
 // The CLI uses this before a Start call to fail fast if the preferences won't

--- a/cmd/tailscale/cli/attrs.go
+++ b/cmd/tailscale/cli/attrs.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"tailscale.com/tailcfg"
+)
+
+// parseDeviceAttrs parses a comma-separated list of key=value pairs into an AttrUpdate.
+// Supported value types:
+// - booleans: true/false (case-insensitive)
+// - numbers: integers or floats parsed into float64
+// - strings: any other token (used as-is)
+// - deletion: key= (empty value) encodes as nil
+func parseDeviceAttrs(s string) (tailcfg.AttrUpdate, error) {
+	attrs := make(tailcfg.AttrUpdate)
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return attrs, nil
+	}
+	parts := strings.Split(s, ",")
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		key, val, ok := strings.Cut(p, "=")
+		if !ok {
+			return nil, fmt.Errorf("missing '=' in %q", p)
+		}
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return nil, fmt.Errorf("empty key in %q", p)
+		}
+		val = strings.TrimSpace(val)
+		if val == "" {
+			attrs[key] = nil // delete
+			continue
+		}
+		switch strings.ToLower(val) {
+		case "true":
+			attrs[key] = true
+			continue
+		case "false":
+			attrs[key] = false
+			continue
+		}
+		if i, err := strconv.ParseInt(val, 10, 64); err == nil {
+			attrs[key] = float64(i)
+			continue
+		}
+		if f, err := strconv.ParseFloat(val, 64); err == nil {
+			attrs[key] = f
+			continue
+		}
+		attrs[key] = val
+	}
+	return attrs, nil
+}

--- a/cmd/tailscale/cli/set.go
+++ b/cmd/tailscale/cli/set.go
@@ -65,6 +65,7 @@ type setArgsT struct {
 	statefulFiltering      bool
 	netfilterMode          string
 	relayServerPort        string
+	deviceAttrs            string
 }
 
 func newSetFlagSet(goos string, setArgs *setArgsT) *flag.FlagSet {
@@ -86,6 +87,7 @@ func newSetFlagSet(goos string, setArgs *setArgsT) *flag.FlagSet {
 	setf.BoolVar(&setArgs.reportPosture, "report-posture", false, "allow management plane to gather device posture information")
 	setf.BoolVar(&setArgs.runWebClient, "webclient", false, "expose the web interface for managing this node over Tailscale at port 5252")
 	setf.StringVar(&setArgs.relayServerPort, "relay-server-port", "", "UDP port number (0 will pick a random unused port) for the relay server to bind to, on all interfaces, or empty string to disable relay server functionality")
+	setf.StringVar(&setArgs.deviceAttrs, "device-attrs", "", hidden+"comma-separated device attributes to set (key=val,...) ? val can be a bool, number, string; use key= to delete")
 
 	ffcomplete.Flag(setf, "exit-node", func(args []string) ([]string, ffcomplete.ShellCompDirective, error) {
 		st, err := localClient.Status(context.Background())
@@ -185,6 +187,22 @@ func runSet(ctx context.Context, args []string) (retErr error) {
 		}
 	}
 
+	// If device attributes were provided, apply them first. This is independent
+	// of preference edits, and we shouldn't require other flags to be set.
+	if setArgs.deviceAttrs != "" {
+		attrs, err := parseDeviceAttrs(setArgs.deviceAttrs)
+		if err != nil {
+			return fmt.Errorf("invalid --device-attrs: %w", err)
+		}
+		if len(attrs) == 0 {
+			// No-op if it parses to empty (e.g., just commas)
+		} else {
+			if err := localClient.SetDeviceAttrs(ctx, attrs); err != nil {
+				return fmt.Errorf("setting device attributes: %w", err)
+			}
+		}
+	}
+
 	warnOnAdvertiseRoutes(ctx, &maskedPrefs.Prefs)
 	if err := checkExitNodeRisk(ctx, &maskedPrefs.Prefs, setArgs.acceptedRisks); err != nil {
 		return err
@@ -200,6 +218,10 @@ func runSet(ctx context.Context, args []string) (retErr error) {
 		}
 	})
 	if maskedPrefs.IsEmpty() {
+		// If no prefs were changed but device attributes were provided, we are done.
+		if setArgs.deviceAttrs != "" {
+			return nil
+		}
 		return flag.ErrHelp
 	}
 
@@ -262,6 +284,8 @@ func runSet(ctx context.Context, args []string) (retErr error) {
 
 	return nil
 }
+
+// parseDeviceAttrs is defined in attrs.go for reuse by up.go and set.go
 
 // calcAdvertiseRoutesForSet returns the new value for Prefs.AdvertiseRoutes based on the
 // current value, the flags passed to "tailscale set".

--- a/cmd/tailscale/cli/set_device_attrs_test.go
+++ b/cmd/tailscale/cli/set_device_attrs_test.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"reflect"
+	"strings"
+	"tailscale.com/tailcfg"
+	"testing"
+)
+
+func TestParseDeviceAttrs(t *testing.T) {
+	tests := []struct {
+		in   string
+		want tailcfg.AttrUpdate
+		err  string
+	}{
+		{"", tailcfg.AttrUpdate{}, ""},
+		{"env=prod", tailcfg.AttrUpdate{"env": "prod"}, ""},
+		{"secure=true", tailcfg.AttrUpdate{"secure": true}, ""},
+		{"secure=false", tailcfg.AttrUpdate{"secure": false}, ""},
+		{"maxAge=3600", tailcfg.AttrUpdate{"maxAge": float64(3600)}, ""},
+		{"ratio=0.25", tailcfg.AttrUpdate{"ratio": 0.25}, ""},
+		{"deprecated=", tailcfg.AttrUpdate{"deprecated": nil}, ""},
+		{"a=1,b=true,c=hi,d=", tailcfg.AttrUpdate{"a": float64(1), "b": true, "c": "hi", "d": nil}, ""},
+		{"noval", nil, "missing '='"},
+		{"=x", nil, "empty key"},
+	}
+	for _, tt := range tests {
+		got, err := parseDeviceAttrs(tt.in)
+		if tt.err != "" {
+			if err == nil || !strings.Contains(err.Error(), tt.err) {
+				t.Fatalf("parseDeviceAttrs(%q) error=%v; want substring %q", tt.in, err, tt.err)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("parseDeviceAttrs(%q) unexpected error: %v", tt.in, err)
+		}
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Fatalf("parseDeviceAttrs(%q)\n got=%v\nwant=%v", tt.in, got, tt.want)
+		}
+	}
+}

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -655,6 +655,7 @@ func runUp(ctx context.Context, cmd string, args []string, upArgs upArgsT) (retE
 	go func() {
 		var printed bool // whether we've yet printed anything to stdout or stderr
 		lastURLPrinted := ""
+		_ = lastURLPrinted
 
 		// If we're doing a force-reauth, we need to get two notifications:
 		//


### PR DESCRIPTION
cli: add --device-attrs flag and LocalAPI client for device posture attributes

- Add --device-attrs to `tailscale set`
- Parse key=val pairs using shared parser (attrs.go).
- Apply device attributes once the daemon reports Running (or immediately on the justEdit path). Non-fatal on failure.
- Mark `device-attrs` as prefless so it doesn’t affect accidental revert checks.

Add unit tests for the device-attrs parser.