### PR TITLE
feature, ipn/ipnlocal: add, use feature.CanSystemdStatus for more DCE

### DIFF
--- a/feature/sdnotify.go
+++ b/feature/sdnotify.go
@@ -23,10 +23,17 @@ var HookSystemdStatus Hook[func(format string, args ...any)]
 // It does nothing on non-Linux systems or if the binary was built without
 // the sdnotify feature.
 func SystemdStatus(format string, args ...any) {
-	if runtime.GOOS != "linux" || !buildfeatures.HasSDNotify {
+	if !CanSystemdStatus { // mid-stack inlining DCE
 		return
 	}
 	if f, ok := HookSystemdStatus.GetOk(); ok {
 		f(format, args...)
 	}
 }
+
+// CanSystemdStatus reports whether the current build has systemd notifications
+// linked in.
+//
+// It's effectively the same as HookSystemdStatus.IsSet(), but a constant for
+// dead code elimination reasons.
+const CanSystemdStatus = runtime.GOOS == "linux" && buildfeatures.HasSDNotify

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -5633,12 +5633,14 @@ func (b *LocalBackend) enterStateLockedOnEntry(newState ipn.State, unlock unlock
 		// Needed so that UpdateEndpoints can run
 		b.e.RequestStatus()
 	case ipn.Running:
-		var addrStrs []string
-		addrs := netMap.GetAddresses()
-		for _, p := range addrs.All() {
-			addrStrs = append(addrStrs, p.Addr().String())
+		if feature.CanSystemdStatus {
+			var addrStrs []string
+			addrs := netMap.GetAddresses()
+			for _, p := range addrs.All() {
+				addrStrs = append(addrStrs, p.Addr().String())
+			}
+			feature.SystemdStatus("Connected; %s; %s", activeLogin, strings.Join(addrStrs, " "))
 		}
-		feature.SystemdStatus("Connected; %s; %s", activeLogin, strings.Join(addrStrs, " "))
 	default:
 		b.logf("[unexpected] unknown newState %#v", newState)
 	}


### PR DESCRIPTION
When systemd notification support was omitted from the build, or on
non-Linux systems, we were unnecessarily emitting code and generating
garbage stringifying addresses upon transition to the Running state.

Updates #12614
