### PR TITLE
tailcfg: kill off rest of HairPinning symbols

### DIFF
--- a/ipn/ipnlocal/c2n_test.go
+++ b/ipn/ipnlocal/c2n_test.go
@@ -324,7 +324,6 @@ func TestRedactNetmapPrivateKeys(t *testing.T) {
 		f(tailcfg.Location{}, "Priority"):                  false,
 		f(tailcfg.NetInfo{}, "DERPLatency"):                false,
 		f(tailcfg.NetInfo{}, "FirewallMode"):               false,
-		f(tailcfg.NetInfo{}, "HairPinning"):                false,
 		f(tailcfg.NetInfo{}, "HavePortMap"):                false,
 		f(tailcfg.NetInfo{}, "LinkType"):                   false,
 		f(tailcfg.NetInfo{}, "MappingVariesByDestIP"):      false,

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -1018,10 +1018,6 @@ type NetInfo struct {
 	// vary based on the destination IP.
 	MappingVariesByDestIP opt.Bool
 
-	// HairPinning is their router does hairpinning.
-	// It reports true even if there's no NAT involved.
-	HairPinning opt.Bool
-
 	// WorkingIPv6 is whether the host has IPv6 internet connectivity.
 	WorkingIPv6 opt.Bool
 
@@ -1089,8 +1085,8 @@ func (ni *NetInfo) String() string {
 	if ni == nil {
 		return "NetInfo(nil)"
 	}
-	return fmt.Sprintf("NetInfo{varies=%v hairpin=%v ipv6=%v ipv6os=%v udp=%v icmpv4=%v derp=#%v portmap=%v link=%q firewallmode=%q}",
-		ni.MappingVariesByDestIP, ni.HairPinning, ni.WorkingIPv6,
+	return fmt.Sprintf("NetInfo{varies=%v ipv6=%v ipv6os=%v udp=%v icmpv4=%v derp=#%v portmap=%v link=%q firewallmode=%q}",
+		ni.MappingVariesByDestIP, ni.WorkingIPv6,
 		ni.OSHasIPv6, ni.WorkingUDP, ni.WorkingICMPv4,
 		ni.PreferredDERP, ni.portMapSummary(), ni.LinkType, ni.FirewallMode)
 }
@@ -1133,7 +1129,6 @@ func (ni *NetInfo) BasicallyEqual(ni2 *NetInfo) bool {
 		return true
 	}
 	return ni.MappingVariesByDestIP == ni2.MappingVariesByDestIP &&
-		ni.HairPinning == ni2.HairPinning &&
 		ni.WorkingIPv6 == ni2.WorkingIPv6 &&
 		ni.OSHasIPv6 == ni2.OSHasIPv6 &&
 		ni.WorkingUDP == ni2.WorkingUDP &&

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -207,7 +207,6 @@ func (src *NetInfo) Clone() *NetInfo {
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _NetInfoCloneNeedsRegeneration = NetInfo(struct {
 	MappingVariesByDestIP opt.Bool
-	HairPinning           opt.Bool
 	WorkingIPv6           opt.Bool
 	OSHasIPv6             opt.Bool
 	WorkingUDP            opt.Bool

--- a/tailcfg/tailcfg_test.go
+++ b/tailcfg/tailcfg_test.go
@@ -607,7 +607,6 @@ func TestNodeEqual(t *testing.T) {
 func TestNetInfoFields(t *testing.T) {
 	handled := []string{
 		"MappingVariesByDestIP",
-		"HairPinning",
 		"WorkingIPv6",
 		"OSHasIPv6",
 		"WorkingUDP",

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -741,10 +741,6 @@ func (v *NetInfoView) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 // vary based on the destination IP.
 func (v NetInfoView) MappingVariesByDestIP() opt.Bool { return v.ж.MappingVariesByDestIP }
 
-// HairPinning is their router does hairpinning.
-// It reports true even if there's no NAT involved.
-func (v NetInfoView) HairPinning() opt.Bool { return v.ж.HairPinning }
-
 // WorkingIPv6 is whether the host has IPv6 internet connectivity.
 func (v NetInfoView) WorkingIPv6() opt.Bool { return v.ж.WorkingIPv6 }
 
@@ -809,7 +805,6 @@ func (v NetInfoView) String() string       { return v.ж.String() }
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _NetInfoViewNeedsRegeneration = NetInfo(struct {
 	MappingVariesByDestIP opt.Bool
-	HairPinning           opt.Bool
 	WorkingIPv6           opt.Bool
 	OSHasIPv6             opt.Bool
 	WorkingUDP            opt.Bool


### PR DESCRIPTION
It was disabled in May 2024 in #12205 (9eb72bb51).

This removes the unused symbols.

Updates #188
Updates tailscale/corp#19106
Updates tailscale/corp#19116
