### PR TITLE
wgengine/magicsock: unblock Conn.Synchronize on Conn.Close

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -663,7 +663,10 @@ func (c *Conn) Synchronize() {
 	}
 	sp := syncPoint(make(chan struct{}))
 	c.syncPub.Publish(sp)
-	sp.Wait()
+	select {
+	case <-sp:
+	case <-c.donec:
+	}
 }
 
 // NewConn creates a magic Conn listening on opts.Port.


### PR DESCRIPTION
I noticed a deadlock in a test in a in-development PR where during a
shutdown storm of things (from a tsnet.Server.Close), LocalBackend was
trying to call magicsock.Conn.Synchronize but the magicsock and/or
eventbus was already shut down and no longer processing events.

Updates #16369
