### PR TITLE
wf/firewall: correct IPv6 link-local range from ff80::/10 to fe80::/10

### DIFF
--- a/wf/firewall.go
+++ b/wf/firewall.go
@@ -18,7 +18,7 @@ import (
 
 // Known addresses.
 var (
-	linkLocalRange           = netip.MustParsePrefix("ff80::/10")
+	linkLocalRange           = netip.MustParsePrefix("fe80::/10")
 	linkLocalDHCPMulticast   = netip.MustParseAddr("ff02::1:2")
 	siteLocalDHCPMulticast   = netip.MustParseAddr("ff05::1:3")
 	linkLocalRouterMulticast = netip.MustParseAddr("ff02::2")


### PR DESCRIPTION
Fixes #17833

The link-local range was incorrectly defined as `ff80::/10` when it should be `fe80::/10` per RFC 4291.