### PR TITLE
cmd/k8s-operator: remove early return in ingress matching

### DIFF
--- a/cmd/k8s-operator/operator.go
+++ b/cmd/k8s-operator/operator.go
@@ -1122,7 +1122,7 @@ func serviceHandlerForIngress(cl client.Client, logger *zap.SugaredLogger, ingre
 		reqs := make([]reconcile.Request, 0)
 		for _, ing := range ingList.Items {
 			if ing.Spec.IngressClassName == nil || *ing.Spec.IngressClassName != ingressClassName {
-				return nil
+				continue
 			}
 			if hasProxyGroupAnnotation(&ing) {
 				// We don't want to reconcile backend Services for Ingresses for ProxyGroups.


### PR DESCRIPTION
Fixes #17834

When checking ingresses for service handler reconciliation, an early return prevented matching when multiple ingress classes exist in the cluster.