### PR TITLE
net/dns: use big endian encoding for IPs in network manager

### DIFF
--- a/net/dns/nm.go
+++ b/net/dns/nm.go
@@ -138,7 +138,7 @@ func (m *nmManager) trySet(ctx context.Context, config OSConfig) error {
 	for _, ip := range config.Nameservers {
 		b := ip.As16()
 		if ip.Is4() {
-			dnsv4 = append(dnsv4, binary.NativeEndian.Uint32(b[12:]))
+			dnsv4 = append(dnsv4, binary.BigEndian.Uint32(b[12:]))
 		} else {
 			dnsv6 = append(dnsv6, b[:])
 		}


### PR DESCRIPTION
Fixes #17836

NetworkManager expects IPv4 DNS server addresses in big-endian byte order.