### PR TITLE
wgengine/router/osrouter: fix linux magicsock port changing

### DIFF
--- a/wgengine/router/osrouter/router_linux.go
+++ b/wgengine/router/osrouter/router_linux.go
@@ -581,7 +581,7 @@ func (r *linuxRouter) updateMagicsockPort(port uint16, network string) error {
 	}
 
 	if port != 0 {
-		if err := r.nfr.AddMagicsockPortRule(*magicsockPort, network); err != nil {
+		if err := r.nfr.AddMagicsockPortRule(port, network); err != nil {
 			return fmt.Errorf("add magicsock port rule: %w", err)
 		}
 	}


### PR DESCRIPTION
Fixes #17837

Use the new port parameter instead of the old magicsockPort variable when updating firewall rules.