### PR TITLE
ipn/serve: validate service paths in HasPathHandler

### DIFF
--- a/ipn/serve.go
+++ b/ipn/serve.go
@@ -231,6 +231,20 @@ func (sc *ServeConfig) HasPathHandler() bool {
 		}
 	}
 
+	if sc.Services != nil {
+		for _, serviceConfig := range sc.Services {
+			if serviceConfig.Web != nil {
+				for _, webServerConfig := range serviceConfig.Web {
+					for _, httpHandler := range webServerConfig.Handlers {
+						if httpHandler.Path != "" {
+							return true
+						}
+					}
+				}
+			}
+		}
+	}
+
 	if sc.Foreground != nil {
 		for _, fgConfig := range sc.Foreground {
 			if fgConfig.HasPathHandler() {

--- a/ipn/serve_test.go
+++ b/ipn/serve_test.go
@@ -117,6 +117,36 @@ func TestHasPathHandler(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "with-service-path-handler",
+			cfg: ServeConfig{
+				Services: map[tailcfg.ServiceName]*ServiceConfig{
+					"svc:foo": {
+						Web: map[HostPort]*WebServerConfig{
+							"foo.test.ts.net:443": {Handlers: map[string]*HTTPHandler{
+								"/": {Path: "/tmp"},
+							}},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "with-service-proxy-handler",
+			cfg: ServeConfig{
+				Services: map[tailcfg.ServiceName]*ServiceConfig{
+					"svc:foo": {
+						Web: map[HostPort]*WebServerConfig{
+							"foo.test.ts.net:443": {Handlers: map[string]*HTTPHandler{
+								"/": {Proxy: "http://127.0.0.1:3000"},
+							}},
+						},
+					},
+				},
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #17839

Check the Services configuration map for path handlers in addition to TCP and Foreground configurations.