### PR TITLE
cmd/k8s-operator: default to stable image

### DIFF
--- a/cmd/k8s-operator/deploy/chart/Chart.yaml
+++ b/cmd/k8s-operator/deploy/chart/Chart.yaml
@@ -26,4 +26,4 @@ maintainers:
 version: 0.1.0
 
 # appVersion will be set to Tailscale repo tag at release time.
-appVersion: "unstable"
+appVersion: "stable"

--- a/cmd/k8s-operator/deploy/manifests/operator.yaml
+++ b/cmd/k8s-operator/deploy/manifests/operator.yaml
@@ -5323,7 +5323,7 @@ spec:
                     - name: CLIENT_SECRET_FILE
                       value: /oauth/client_secret
                     - name: PROXY_IMAGE
-                      value: tailscale/tailscale:unstable
+                      value: tailscale/tailscale:stable
                     - name: PROXY_TAGS
                       value: tag:k8s
                     - name: APISERVER_PROXY
@@ -5338,7 +5338,7 @@ spec:
                       valueFrom:
                         fieldRef:
                             fieldPath: metadata.uid
-                  image: tailscale/k8s-operator:unstable
+                  image: tailscale/k8s-operator:stable
                   imagePullPolicy: Always
                   name: operator
                   volumeMounts:


### PR DESCRIPTION
This commit modifies the helm/static manifest configuration for the k8s-operator to prefer the stable image tag. This avoids making those using static manifests seeing unstable behavior by default if they do not manually make the change.

This is managed for us when using helm but not when generating the static manifests.

Updates https://github.com/tailscale/tailscale/issues/10655