### PR TITLE
cmd/{cloner,viewer}: handle maps of views

### DIFF
--- a/cmd/viewer/tests/tests.go
+++ b/cmd/viewer/tests/tests.go
@@ -13,7 +13,7 @@ import (
 	"tailscale.com/types/views"
 )
 
-//go:generate go run tailscale.com/cmd/viewer --type=StructWithPtrs,StructWithoutPtrs,Map,StructWithSlices,OnlyGetClone,StructWithEmbedded,GenericIntStruct,GenericNoPtrsStruct,GenericCloneableStruct,StructWithContainers,StructWithTypeAliasFields,GenericTypeAliasStruct --clone-only-type=OnlyGetClone
+//go:generate go run tailscale.com/cmd/viewer --type=StructWithPtrs,StructWithoutPtrs,Map,StructWithSlices,OnlyGetClone,StructWithEmbedded,GenericIntStruct,GenericNoPtrsStruct,GenericCloneableStruct,StructWithContainers,StructWithTypeAliasFields,GenericTypeAliasStruct,StructWithMapOfViews --clone-only-type=OnlyGetClone
 
 type StructWithoutPtrs struct {
 	Int int
@@ -237,4 +237,8 @@ type integer = constraints.Integer
 type GenericTypeAliasStruct[T integer, T2 views.ViewCloner[T2, V2], V2 views.StructView[T2]] struct {
 	NonCloneable T
 	Cloneable    T2
+}
+
+type StructWithMapOfViews struct {
+	MapOfViews map[string]StructWithoutPtrsView
 }

--- a/cmd/viewer/tests/tests_clone.go
+++ b/cmd/viewer/tests/tests_clone.go
@@ -547,3 +547,20 @@ func _GenericTypeAliasStructCloneNeedsRegeneration[T integer, T2 views.ViewClone
 		Cloneable    T2
 	}{})
 }
+
+// Clone makes a deep copy of StructWithMapOfViews.
+// The result aliases no memory with the original.
+func (src *StructWithMapOfViews) Clone() *StructWithMapOfViews {
+	if src == nil {
+		return nil
+	}
+	dst := new(StructWithMapOfViews)
+	*dst = *src
+	dst.MapOfViews = maps.Clone(src.MapOfViews)
+	return dst
+}
+
+// A compilation failure here means this code must be regenerated, with the command at the top of this file.
+var _StructWithMapOfViewsCloneNeedsRegeneration = StructWithMapOfViews(struct {
+	MapOfViews map[string]StructWithoutPtrsView
+}{})


### PR DESCRIPTION
Instead of trying to call View() on something that's already a View type (or trying to Clone the view unnecessarily), we can re-use the existing View values in a map[T]ViewType.

Fixes #17866