### PR TITLE
control/controlclient,ipn/ipnlocal: replace State enum with boolean flags

### DIFF
--- a/control/controlclient/status.go
+++ b/control/controlclient/status.go
@@ -4,65 +4,12 @@
 package controlclient
 
 import (
-	"encoding/json"
-	"fmt"
 	"reflect"
 
 	"tailscale.com/types/netmap"
 	"tailscale.com/types/persist"
 	"tailscale.com/types/structs"
 )
-
-// State is the high-level state of the client. It is used only in
-// unit tests for proper sequencing, don't depend on it anywhere else.
-//
-// TODO(apenwarr): eliminate the state, as it's now obsolete.
-//
-// apenwarr: Historical note: controlclient.Auto was originally
-// intended to be the state machine for the whole tailscale client, but that
-// turned out to not be the right abstraction layer, and it moved to
-// ipn.Backend. Since ipn.Backend now has a state machine, it would be
-// much better if controlclient could be a simple stateless API. But the
-// current server-side API (two interlocking polling https calls) makes that
-// very hard to implement. A server side API change could untangle this and
-// remove all the statefulness.
-type State int
-
-const (
-	StateNew = State(iota)
-	StateNotAuthenticated
-	StateAuthenticating
-	StateURLVisitRequired
-	StateAuthenticated
-	StateSynchronized // connected and received map update
-)
-
-func (s State) AppendText(b []byte) ([]byte, error) {
-	return append(b, s.String()...), nil
-}
-
-func (s State) MarshalText() ([]byte, error) {
-	return []byte(s.String()), nil
-}
-
-func (s State) String() string {
-	switch s {
-	case StateNew:
-		return "state:new"
-	case StateNotAuthenticated:
-		return "state:not-authenticated"
-	case StateAuthenticating:
-		return "state:authenticating"
-	case StateURLVisitRequired:
-		return "state:url-visit-required"
-	case StateAuthenticated:
-		return "state:authenticated"
-	case StateSynchronized:
-		return "state:synchronized"
-	default:
-		return fmt.Sprintf("state:unknown:%d", int(s))
-	}
-}
 
 type Status struct {
 	_ structs.Incomparable
@@ -76,6 +23,14 @@ type Status struct {
 	// URL, if non-empty, is the interactive URL to visit to finish logging in.
 	URL string
 
+	// LoggedIn, if true, indicates that serveRegister has completed and no
+	// other login change is in progress.
+	LoggedIn bool
+
+	// InMapPoll, if true, indicates that we've received at least one netmap
+	// and are connected to receive updates.
+	InMapPoll bool
+
 	// NetMap is the latest server-pushed state of the tailnet network.
 	NetMap *netmap.NetworkMap
 
@@ -83,25 +38,7 @@ type Status struct {
 	//
 	// TODO(bradfitz,maisem): clarify this.
 	Persist persist.PersistView
-
-	// state is the internal state. It should not be exposed outside this
-	// package, but we have some automated tests elsewhere that need to
-	// use it via the StateForTest accessor.
-	// TODO(apenwarr): Unexport or remove these.
-	state State
 }
-
-// LoginFinished reports whether the controlclient is in its "StateAuthenticated"
-// state where it's in a happy register state but not yet in a map poll.
-//
-// TODO(bradfitz): delete this and everything around Status.state.
-func (s *Status) LoginFinished() bool { return s.state == StateAuthenticated }
-
-// StateForTest returns the internal state of s for tests only.
-func (s *Status) StateForTest() State { return s.state }
-
-// SetStateForTest sets the internal state of s for tests only.
-func (s *Status) SetStateForTest(state State) { s.state = state }
 
 // Equal reports whether s and s2 are equal.
 func (s *Status) Equal(s2 *Status) bool {
@@ -111,15 +48,8 @@ func (s *Status) Equal(s2 *Status) bool {
 	return s != nil && s2 != nil &&
 		s.Err == s2.Err &&
 		s.URL == s2.URL &&
-		s.state == s2.state &&
+		s.LoggedIn == s2.LoggedIn &&
+		s.InMapPoll == s2.InMapPoll &&
 		reflect.DeepEqual(s.Persist, s2.Persist) &&
 		reflect.DeepEqual(s.NetMap, s2.NetMap)
-}
-
-func (s Status) String() string {
-	b, err := json.MarshalIndent(s, "", "\t")
-	if err != nil {
-		panic(err)
-	}
-	return s.state.String() + " " + string(b)
 }

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1623,7 +1623,7 @@ func (b *LocalBackend) SetControlClientStatus(c controlclient.Client, st control
 		b.blockEngineUpdatesLocked(false)
 	}
 
-	if st.LoginFinished() && (wasBlocked || authWasInProgress) {
+	if st.LoggedIn && (wasBlocked || authWasInProgress) {
 		if wasBlocked {
 			// Auth completed, unblock the engine
 			b.blockEngineUpdatesLocked(false)
@@ -1658,8 +1658,8 @@ func (b *LocalBackend) SetControlClientStatus(c controlclient.Client, st control
 			prefs.Persist = st.Persist.AsStruct()
 		}
 	}
-	if st.LoginFinished() {
-		if b.authURL != "" {
+	if st.LoggedIn {
+		if authWasInProgress {
 			b.resetAuthURLLocked()
 			// Interactive login finished successfully (URL visited).
 			// After an interactive login, the user always wants


### PR DESCRIPTION
Remove the State enum (StateNew, StateNotAuthenticated, etc.) from controlclient and replace it with two explicit boolean fields:
- LoginFinished: indicates successful authentication
- Synced: indicates we've received at least one netmap

This makes the state more composable and easier to reason about, as multiple conditions can be true independently rather than being encoded in a single enum value.

The State enum was originally intended as the state machine for the whole client, but that abstraction moved to ipn.Backend long ago. This change continues moving away from the legacy state machine by representing state as a combination of independent facts.

Also adds test helpers in ipnlocal that check independent, observable facts (hasValidNetMap, needsLogin, etc.) rather than relying on derived state enums, making tests more robust.

Updates #12639