### PR TITLE
cmd/tailscale/cli: warn if a simple up would change prefs

### DIFF
--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -388,7 +388,8 @@ func updatePrefs(prefs, curPrefs *ipn.Prefs, env upCheckEnv) (simpleUp bool, jus
 	if !env.upArgs.reset {
 		applyImplicitPrefs(prefs, curPrefs, env)
 
-		if err := checkForAccidentalSettingReverts(prefs, curPrefs, env); err != nil {
+		simpleUp, err = checkForAccidentalSettingReverts(prefs, curPrefs, env)
+		if err != nil {
 			return false, nil, err
 		}
 	}
@@ -419,11 +420,6 @@ func updatePrefs(prefs, curPrefs *ipn.Prefs, env upCheckEnv) (simpleUp bool, jus
 	}
 
 	tagsChanged := !reflect.DeepEqual(curPrefs.AdvertiseTags, prefs.AdvertiseTags)
-
-	simpleUp = env.flagSet.NFlag() == 0 &&
-		curPrefs.Persist != nil &&
-		curPrefs.Persist.UserProfile.LoginName != "" &&
-		env.backendState != ipn.NeedsLogin.String()
 
 	justEdit := env.backendState == ipn.Running.String() &&
 		!env.upArgs.forceReauth &&
@@ -966,10 +962,10 @@ type upCheckEnv struct {
 //
 // mp is the mask of settings actually set, where mp.Prefs is the new
 // preferences to set, including any values set from implicit flags.
-func checkForAccidentalSettingReverts(newPrefs, curPrefs *ipn.Prefs, env upCheckEnv) error {
+func checkForAccidentalSettingReverts(newPrefs, curPrefs *ipn.Prefs, env upCheckEnv) (simpleUp bool, err error) {
 	if curPrefs.ControlURL == "" {
 		// Don't validate things on initial "up" before a control URL has been set.
-		return nil
+		return false, nil
 	}
 
 	flagIsSet := map[string]bool{}
@@ -977,10 +973,13 @@ func checkForAccidentalSettingReverts(newPrefs, curPrefs *ipn.Prefs, env upCheck
 		flagIsSet[f.Name] = true
 	})
 
-	if len(flagIsSet) == 0 {
+	if len(flagIsSet) == 0 &&
+		curPrefs.Persist != nil &&
+		curPrefs.Persist.UserProfile.LoginName != "" &&
+		env.backendState != ipn.NeedsLogin.String() {
 		// A bare "tailscale up" is a special case to just
 		// mean bringing the network up without any changes.
-		return nil
+		return true, nil
 	}
 
 	// flagsCur is what flags we'd need to use to keep the exact
@@ -1022,7 +1021,7 @@ func checkForAccidentalSettingReverts(newPrefs, curPrefs *ipn.Prefs, env upCheck
 		missing = append(missing, fmtFlagValueArg(flagName, valCur))
 	}
 	if len(missing) == 0 {
-		return nil
+		return false, nil
 	}
 
 	// Some previously provided flags are missing. This run of 'tailscale
@@ -1055,7 +1054,7 @@ func checkForAccidentalSettingReverts(newPrefs, curPrefs *ipn.Prefs, env upCheck
 		fmt.Fprintf(&sb, " %s", a)
 	}
 	sb.WriteString("\n\n")
-	return errors.New(sb.String())
+	return false, errors.New(sb.String())
 }
 
 // applyImplicitPrefs mutates prefs to add implicit preferences for the user operator.


### PR DESCRIPTION
Updates tailscale/corp#21570

Before:

```
$ tailscale debug prefs | jq -c '{RouteAll,PostureChecking}'
{"RouteAll":true,"PostureChecking":true}
$ tailscale debug set-expire --in=5s
$ tailscale status --json | jq .BackendState
"NeedsLogin"
$ tailscale debug prefs | jq -c '{RouteAll,PostureChecking}'
{"RouteAll":true,"PostureChecking":true}
$ tailscale up
To authenticate, visit:
...
Success.
$ tailscale debug prefs | jq -c '{RouteAll,PostureChecking}'
{"RouteAll":false,"PostureChecking":false}
```

With this patch:

```
$ tailscale debug prefs | jq -c '{RouteAll,PostureChecking}'
{"RouteAll":true,"PostureChecking":true}
$ tailscale debug set-expire --in=5s
$ tailscale status --json | jq .BackendState
"NeedsLogin"
$ tailscale up
Error: changing settings via 'tailscale up' requires mentioning all
non-default flags. To proceed, either re-run your command with --reset or
use the command below to explicitly mention the current value of
all non-default settings:

        tailscale up --accept-routes --report-posture
```

The reason we were trampling prefs before is because we had different notions of "simpleUp" in different places:

`checkForAccidentalSettingsReverts` (which is what prevents settings being trampled by accident) would skip all checks if 0 flags were set.

However, `updatePrefs` (which determines "are we doing a simple up?") would only return `simpleUp=true` if 0 flags were set, _and_ the backend state is not "NeedsLogin".

Therefore if the command is run with 0 flags, but backend state "NeedsLogin", checkForAccidentalSettingsReverts skips all checks and returns no error (because 0 flags) but updatePrefs would return simpleUp=false because the backend state is "NeedsLogin".

The `runUp` command would then, if `updatePrefs` returned ~~`simpleUp=true`~~ `simpleUp=false` and no errors, set the given prefs — which when 0 flags are set, are the default prefs, not the current prefs.

A better fix, long-term, would be for us to be able to correctly handle a simple up in the case where the key has expired. But for now, it is at least better to warn users and bail rather than silently overwriting their prefs.