### PR TITLE
control/controlclient: add PersistView.Valid() check in NetmapFromMapResponseForDebug

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -1196,6 +1196,9 @@ func NetmapFromMapResponseForDebug(ctx context.Context, pr persist.PersistView, 
 	if resp.Node == nil {
 		return nil, errors.New("MapResponse lacks Node")
 	}
+	if !pr.Valid() {
+		return nil, errors.New("PersistView invalid")
+	}
 
 	nu := &rememberLastNetmapUpdater{}
 	sess := newMapSession(pr.PrivateNodeKey(), nu, nil)


### PR DESCRIPTION
We were seeing some panics from nodes:

    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xd42570]
    goroutine 362555 [running]:
    tailscale.com/types/persist.PersistView.PrivateNodeKey(...)
            tailscale.com@v1.89.0-pre.0.20250926180200-7cbf56345bb3/types/persist/persist_view.go:89
    tailscale.com/control/controlclient.NetmapFromMapResponseForDebug({0x1bac2e0, 0xc0a8692380}, {0xc0de5da0c0?}, 0xc0de66fd40)
            tailscale.com@v1.89.0-pre.0.20250926180200-7cbf56345bb3/control/controlclient/direct.go:1175 +0x90
    tailscale.com/ipn/ipnlocal.handleC2NDebugNetMap(0xc0b3f5af08, {0x1baa520, 0xc0a887b0c0}, 0xc0a869a280)
            tailscale.com@v1.89.0-pre.0.20250926180200-7cbf56345bb3/ipn/ipnlocal/c2n.go:186 +0x405
    tailscale.com/ipn/ipnlocal.(*LocalBackend).handleC2N(0xc0b3f5af08, {0x1baa520, 0xc0a887b0c0}, 0xc0a869a280)
            tailscale.com@v1.89.0-pre.0.20250926180200-7cbf56345bb3/ipn/ipnlocal/c2n.go:121 +0x155
    net/http.HandlerFunc.ServeHTTP(0x1bac150?, {0x1baa520?, 0xc0a887b0c0?}, 0xc049d47b20?)
            net/http/server.go:2322 +0x29
    tailscale.com/control/controlclient.answerC2NPing(0xc0d9808f20, {0x1b90f40, 0xc0c3bd0db0}, 0xc0b1c84ea0, 0xc0a29b3c80)
            tailscale.com@v1.89.0-pre.0.20250926180200-7cbf56345bb3/control/controlclient/direct.go:1454 +0x455
    tailscale.com/control/controlclient.(*Direct).answerPing(0xc09b173b88, 0xc0a29b3c80)
            tailscale.com@v1.89.0-pre.0.20250926180200-7cbf56345bb3/control/controlclient/direct.go:1398 +0x127
    created by tailscale.com/control/controlclient.(*Direct).sendMapRequest in goroutine 361922
            tailscale.com@v1.89.0-pre.0.20250926180200-7cbf56345bb3/control/controlclient/direct.go:1104 +0x20e5

Updates tailscale/corp#31367
Updates tailscale/corp#32095