### PR TITLE
feature/tpm: check IsZero in clone instead of just nil

### DIFF
--- a/feature/tpm/attestation.go
+++ b/feature/tpm/attestation.go
@@ -274,7 +274,7 @@ func (ak *attestationKey) Close() error {
 }
 
 func (ak *attestationKey) Clone() key.HardwareAttestationKey {
-	if ak == nil {
+	if ak.IsZero() {
 		return nil
 	}
 

--- a/feature/tpm/tpm.go
+++ b/feature/tpm/tpm.go
@@ -35,12 +35,15 @@ import (
 	"tailscale.com/util/testenv"
 )
 
-var infoOnce = sync.OnceValue(info)
+var (
+	infoOnce         = sync.OnceValue(info)
+	tpmSupportedOnce = sync.OnceValue(tpmSupported)
+)
 
 func init() {
 	feature.Register("tpm")
-	feature.HookTPMAvailable.Set(tpmSupported)
-	feature.HookHardwareAttestationAvailable.Set(tpmSupported)
+	feature.HookTPMAvailable.Set(tpmSupportedOnce)
+	feature.HookHardwareAttestationAvailable.Set(tpmSupportedOnce)
 
 	hostinfo.RegisterHostinfoNewHook(func(hi *tailcfg.Hostinfo) {
 		hi.TPM = infoOnce()


### PR DESCRIPTION
The key.NewEmptyHardwareAttestationKey hook returns a non-nil empty attestationKey, which means that the nil check in Clone doesn't trigger and proceeds to try and clone an empty key. Check IsZero instead to reduce log spam from Clone.

As a drive-by, make tpmAvailable check a sync.Once because the result won't change.

Updates #17882