### PR TITLE
control/controlclient: make Observer optional

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -115,6 +115,9 @@ type Direct struct {
 
 // Observer is implemented by users of the control client (such as LocalBackend)
 // to get notified of changes in the control client's status.
+//
+// If an implementation of Observer also implements [NetmapDeltaUpdater], they get
+// delta updates as well as full netmap updates.
 type Observer interface {
 	// SetControlClientStatus is called when the client has a new status to
 	// report. The Client is provided to allow the Observer to track which
@@ -145,6 +148,7 @@ type Options struct {
 
 	// Observer is called when there's a change in status to report
 	// from the control client.
+	// If nil, no status updates are reported.
 	Observer Observer
 
 	// SkipIPForwardingCheck declares that the host's IP

--- a/ipn/ipnlocal/network-lock_test.go
+++ b/ipn/ipnlocal/network-lock_test.go
@@ -41,12 +41,6 @@ import (
 	"tailscale.com/util/set"
 )
 
-type observerFunc func(controlclient.Status)
-
-func (f observerFunc) SetControlClientStatus(_ controlclient.Client, s controlclient.Status) {
-	f(s)
-}
-
 func fakeControlClient(t *testing.T, c *http.Client) (*controlclient.Auto, *eventbus.Bus) {
 	hi := hostinfo.New()
 	ni := tailcfg.NetInfo{LinkType: "wired"}
@@ -64,7 +58,6 @@ func fakeControlClient(t *testing.T, c *http.Client) (*controlclient.Auto, *even
 		},
 		HTTPTestClient:  c,
 		NoiseTestClient: c,
-		Observer:        observerFunc(func(controlclient.Status) {}),
 		Dialer:          dialer,
 		Bus:             bus,
 	}


### PR DESCRIPTION
As a baby step towards eventbus-ifying controlclient, make the
Observer optional.

This also means callers that don't care (like this network lock test,
and some tests in other repos) can omit it, rather than passing in a
no-op one.

Updates #12639
