### PR TITLE
logpolicy: fix nil pointer dereference with invalid TS_LOG_TARGET

### DIFF
--- a/logpolicy/logpolicy.go
+++ b/logpolicy/logpolicy.go
@@ -640,10 +640,16 @@ func (opts Options) init(disableLogging bool) (*logtail.Config, *Policy) {
 
 		logHost := logtail.DefaultHost
 		if val := getLogTarget(); val != "" {
-			opts.Logf("You have enabled a non-default log target. Doing without being told to by Tailscale staff or your network administrator will make getting support difficult.")
-			conf.BaseURL = val
-			u, _ := url.Parse(val)
-			logHost = u.Host
+			u, err := url.Parse(val)
+			if err != nil {
+				opts.Logf("logpolicy: invalid TS_LOG_TARGET %q: %v; using default log host", val, err)
+			} else if u.Host == "" {
+				opts.Logf("logpolicy: invalid TS_LOG_TARGET %q: missing host; using default log host", val)
+			} else {
+				opts.Logf("You have enabled a non-default log target. Doing without being told to by Tailscale staff or your network administrator will make getting support difficult.")
+				conf.BaseURL = val
+				logHost = u.Host
+			}
 		}
 
 		if conf.HTTPC == nil {


### PR DESCRIPTION
When TS_LOG_TARGET is set to an invalid URL, url.Parse returns an error and nil pointer, which caused a panic when accessing u.Host.

Now we check the error from url.Parse and log a helpful message while falling back to the default log host.

Fixes #17792