### PR TITLE
Synology: Update start-stop-status to add GOMEMLIMIT for memory constrained devices

### DIFF
--- a/release/dist/synology/files/scripts/start-stop-status
+++ b/release/dist/synology/files/scripts/start-stop-status
@@ -28,6 +28,13 @@ if [ "${SYNOPKG_DSM_VERSION_MAJOR}" -eq "6" ]; then
     chown -R tailscale:tailscale "${PKGVAR}/"
 fi
 
+# for smaller synology units with less than 512MB of memory, set a GOMEMLIMIT for all child processes
+# to 128MiB to prevent constant swapping. 
+MEM_TOTAL_KB=$(awk '/MemTotal:/ { print $2 }' /proc/meminfo)
+if [ "$MEM_TOTAL_KB" -lt 524288 ]; then
+    export GOMEMLIMIT=128MiB
+fi
+
 start_daemon() {
     local ts=$(date --iso-8601=second)
     echo "${ts} Starting ${SERVICE_NAME} with: ${SERVICE_COMMAND}" >${LOG_FILE}


### PR DESCRIPTION
On devices with <512MB of memory, the default Golang GC profile results in memory consumption which results in heavy swapping of the `tailscaled` process. This results in a significant performance degradation (~1-2MB/s) and high IOWAIT due to the hard faults. 

This restores performance to the expected levels of 15-20MB/s. 

Used a global export rather than an inline setting so it is propagated to all child processes. 

Tested on a DS120j device. 