### PR TITLE
util/clientmetric: fix regression causing Metric.v to be uninitialised

### DIFF
--- a/util/clientmetric/clientmetric.go
+++ b/util/clientmetric/clientmetric.go
@@ -133,15 +133,18 @@ func (m *Metric) Publish() {
 	metrics[m.name] = m
 	sortedDirty = true
 
+	if m.f == nil {
+		if len(valFreeList) == 0 {
+			valFreeList = make([]int64, 256)
+		}
+		m.v = &valFreeList[0]
+		valFreeList = valFreeList[1:]
+	}
+
 	if buildfeatures.HasLogTail {
 		if m.f != nil {
 			lastLogVal = append(lastLogVal, scanEntry{f: m.f})
 		} else {
-			if len(valFreeList) == 0 {
-				valFreeList = make([]int64, 256)
-			}
-			m.v = &valFreeList[0]
-			valFreeList = valFreeList[1:]
 			lastLogVal = append(lastLogVal, scanEntry{v: m.v})
 		}
 	}


### PR DESCRIPTION
m.v was uninitialised when Tailscale is built with `ts_omit_logtail`
Fixes #17918 