### PR TITLE
wgengine/netlog: fix send to closed channel in test

### DIFF
--- a/wgengine/netlog/netlog_test.go
+++ b/wgengine/netlog/netlog_test.go
@@ -182,6 +182,7 @@ func TestUpdateRace(t *testing.T) {
 	group.Wait()
 	logger.mu.Lock()
 	close(logger.recordsChan)
+	logger.recordsChan = nil
 	logger.mu.Unlock()
 }
 


### PR DESCRIPTION
Fixes #17922
