### PR TITLE
control/controlclient: remove some public API, move to Options & test-only

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -146,6 +146,14 @@ type Options struct {
 	ControlKnobs         *controlknobs.Knobs // or nil to ignore
 	Bus                  *eventbus.Bus       // non-nil, for setting up publishers
 
+	SkipStartForTests bool // if true, don't call [Auto.Start] to avoid any background goroutines (for tests only)
+
+	// StartPaused indicates whether the client should start in a paused state
+	// where it doesn't do network requests. This primarily exists for testing
+	// but not necessarily "go test" tests, so it isn't restricted to only
+	// being used in tests.
+	StartPaused bool
+
 	// Observer is called when there's a change in status to report
 	// from the control client.
 	// If nil, no status updates are reported.

--- a/ipn/ipnlocal/network-lock_test.go
+++ b/ipn/ipnlocal/network-lock_test.go
@@ -60,9 +60,11 @@ func fakeControlClient(t *testing.T, c *http.Client) (*controlclient.Auto, *even
 		NoiseTestClient: c,
 		Dialer:          dialer,
 		Bus:             bus,
+
+		SkipStartForTests: true,
 	}
 
-	cc, err := controlclient.NewNoStart(opts)
+	cc, err := controlclient.New(opts)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Includes adding StartPaused, which will be used in a future change to
enable netmap caching testing.

Updates #12639
