### PR TITLE
ipn{,/local},cmd/tailscale: add "sync" flag and pref to disable control map poll

### DIFF
--- a/cmd/tailscale/cli/set.go
+++ b/cmd/tailscale/cli/set.go
@@ -63,6 +63,7 @@ type setArgsT struct {
 	reportPosture          bool
 	snat                   bool
 	statefulFiltering      bool
+	sync                   bool
 	netfilterMode          string
 	relayServerPort        string
 }
@@ -85,6 +86,7 @@ func newSetFlagSet(goos string, setArgs *setArgsT) *flag.FlagSet {
 	setf.BoolVar(&setArgs.updateApply, "auto-update", false, "automatically update to the latest available version")
 	setf.BoolVar(&setArgs.reportPosture, "report-posture", false, "allow management plane to gather device posture information")
 	setf.BoolVar(&setArgs.runWebClient, "webclient", false, "expose the web interface for managing this node over Tailscale at port 5252")
+	setf.BoolVar(&setArgs.sync, "sync", false, hidden+"actively sync configuration from the control plane (set to false only for network failure testing)")
 	setf.StringVar(&setArgs.relayServerPort, "relay-server-port", "", "UDP port number (0 will pick a random unused port) for the relay server to bind to, on all interfaces, or empty string to disable relay server functionality")
 
 	ffcomplete.Flag(setf, "exit-node", func(args []string) ([]string, ffcomplete.ShellCompDirective, error) {
@@ -149,6 +151,7 @@ func runSet(ctx context.Context, args []string) (retErr error) {
 			OperatorUser:           setArgs.opUser,
 			NoSNAT:                 !setArgs.snat,
 			ForceDaemon:            setArgs.forceDaemon,
+			Sync:                   opt.NewBool(setArgs.sync),
 			AutoUpdate: ipn.AutoUpdatePrefs{
 				Check: setArgs.updateCheck,
 				Apply: opt.NewBool(setArgs.updateApply),

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -890,6 +890,7 @@ func init() {
 	addPrefFlagMapping("advertise-connector", "AppConnector")
 	addPrefFlagMapping("report-posture", "PostureChecking")
 	addPrefFlagMapping("relay-server-port", "RelayServerPort")
+	addPrefFlagMapping("sync", "Sync")
 }
 
 func addPrefFlagMapping(flagName string, prefNames ...string) {
@@ -925,7 +926,7 @@ func updateMaskedPrefsFromUpOrSetFlag(mp *ipn.MaskedPrefs, flagName string) {
 	if prefs, ok := prefsOfFlag[flagName]; ok {
 		for _, pref := range prefs {
 			f := reflect.ValueOf(mp).Elem()
-			for _, name := range strings.Split(pref, ".") {
+			for name := range strings.SplitSeq(pref, ".") {
 				f = f.FieldByName(name + "Set")
 			}
 			f.SetBool(true)

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -90,6 +90,7 @@ var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	Egg                    bool
 	AdvertiseRoutes        []netip.Prefix
 	AdvertiseServices      []string
+	Sync                   opt.Bool
 	NoSNAT                 bool
 	NoStatefulFiltering    opt.Bool
 	NetfilterMode          preftype.NetfilterMode

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -363,6 +363,12 @@ func (v PrefsView) AdvertiseServices() views.Slice[string] {
 	return views.SliceOf(v.ж.AdvertiseServices)
 }
 
+// Sync is whether this node should sync its configuration from
+// the control plane. If unset, this defaults to true.
+// This exists primarily for testing, to verify that netmap caching
+// and offline operation work correctly.
+func (v PrefsView) Sync() opt.Bool { return v.ж.Sync }
+
 // NoSNAT specifies whether to source NAT traffic going to
 // destinations in AdvertiseRoutes. The default is to apply source
 // NAT, which makes the traffic appear to come from the router
@@ -482,6 +488,7 @@ var _PrefsViewNeedsRegeneration = Prefs(struct {
 	Egg                    bool
 	AdvertiseRoutes        []netip.Prefix
 	AdvertiseServices      []string
+	Sync                   opt.Bool
 	NoSNAT                 bool
 	NoStatefulFiltering    opt.Bool
 	NetfilterMode          preftype.NetfilterMode

--- a/ipn/ipnlocal/profiles_test.go
+++ b/ipn/ipnlocal/profiles_test.go
@@ -1129,10 +1129,12 @@ func TestProfileStateChangeCallback(t *testing.T) {
 			}
 
 			gotChanges := make([]stateChange, 0, len(tt.wantChanges))
-			pm.StateChangeHook = func(profile ipn.LoginProfileView, prefs ipn.PrefsView, sameNode bool) {
+			pm.StateChangeHook = func(profile ipn.LoginProfileView, prefView ipn.PrefsView, sameNode bool) {
+				prefs := prefView.AsStruct()
+				prefs.Sync = prefs.Sync.Normalized()
 				gotChanges = append(gotChanges, stateChange{
 					Profile:  profile.AsStruct(),
-					Prefs:    prefs.AsStruct(),
+					Prefs:    prefs,
 					SameNode: sameNode,
 				})
 			}

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -207,6 +207,12 @@ type Prefs struct {
 	// control server.
 	AdvertiseServices []string
 
+	// Sync is whether this node should sync its configuration from
+	// the control plane. If unset, this defaults to true.
+	// This exists primarily for testing, to verify that netmap caching
+	// and offline operation work correctly.
+	Sync opt.Bool
+
 	// NoSNAT specifies whether to source NAT traffic going to
 	// destinations in AdvertiseRoutes. The default is to apply source
 	// NAT, which makes the traffic appear to come from the router
@@ -364,12 +370,13 @@ type MaskedPrefs struct {
 	EggSet                    bool                `json:",omitempty"`
 	AdvertiseRoutesSet        bool                `json:",omitempty"`
 	AdvertiseServicesSet      bool                `json:",omitempty"`
+	SyncSet                   bool                `json:",omitzero"`
 	NoSNATSet                 bool                `json:",omitempty"`
 	NoStatefulFilteringSet    bool                `json:",omitempty"`
 	NetfilterModeSet          bool                `json:",omitempty"`
 	OperatorUserSet           bool                `json:",omitempty"`
 	ProfileNameSet            bool                `json:",omitempty"`
-	AutoUpdateSet             AutoUpdatePrefsMask `json:",omitempty"`
+	AutoUpdateSet             AutoUpdatePrefsMask `json:",omitzero"`
 	AppConnectorSet           bool                `json:",omitempty"`
 	PostureCheckingSet        bool                `json:",omitempty"`
 	NetfilterKindSet          bool                `json:",omitempty"`
@@ -547,6 +554,9 @@ func (p *Prefs) pretty(goos string) string {
 	if p.LoggedOut {
 		sb.WriteString("loggedout=true ")
 	}
+	if p.Sync.EqualBool(false) {
+		sb.WriteString("sync=false ")
+	}
 	if p.ForceDaemon {
 		sb.WriteString("server=true ")
 	}
@@ -653,6 +663,7 @@ func (p *Prefs) Equals(p2 *Prefs) bool {
 		p.ExitNodeAllowLANAccess == p2.ExitNodeAllowLANAccess &&
 		p.CorpDNS == p2.CorpDNS &&
 		p.RunSSH == p2.RunSSH &&
+		p.Sync.Normalized() == p2.Sync.Normalized() &&
 		p.RunWebClient == p2.RunWebClient &&
 		p.WantRunning == p2.WantRunning &&
 		p.LoggedOut == p2.LoggedOut &&
@@ -956,8 +967,13 @@ func PrefsFromBytes(b []byte, base *Prefs) error {
 	if len(b) == 0 {
 		return nil
 	}
-
 	return json.Unmarshal(b, base)
+}
+
+func (p *Prefs) normalizeOptBools() {
+	if p.Sync == opt.ExplicitlyUnset {
+		p.Sync = ""
+	}
 }
 
 var jsonEscapedZero = []byte(`\u0000`)

--- a/types/opt/bool.go
+++ b/types/opt/bool.go
@@ -83,6 +83,17 @@ func (b *Bool) Scan(src any) error {
 	}
 }
 
+// Normalized returns the normalized form of b, mapping "unset" to ""
+// and leaving other values unchanged.
+func (b Bool) Normalized() Bool {
+	switch b {
+	case ExplicitlyUnset:
+		return Empty
+	default:
+		return b
+	}
+}
+
 // EqualBool reports whether b is equal to v.
 // If b is empty or not a valid bool, it reports false.
 func (b Bool) EqualBool(v bool) bool {

--- a/types/opt/bool_test.go
+++ b/types/opt/bool_test.go
@@ -106,6 +106,8 @@ func TestBoolEqualBool(t *testing.T) {
 	}{
 		{"", true, false},
 		{"", false, false},
+		{"unset", true, false},
+		{"unset", false, false},
 		{"sdflk;", true, false},
 		{"sldkf;", false, false},
 		{"true", true, true},
@@ -118,6 +120,24 @@ func TestBoolEqualBool(t *testing.T) {
 	for _, tt := range tests {
 		if got := tt.b.EqualBool(tt.v); got != tt.want {
 			t.Errorf("(%q).EqualBool(%v) = %v; want %v", string(tt.b), tt.v, got, tt.want)
+		}
+	}
+}
+
+func TestBoolNormalized(t *testing.T) {
+	tests := []struct {
+		in   Bool
+		want Bool
+	}{
+		{"", ""},
+		{"true", "true"},
+		{"false", "false"},
+		{"unset", ""},
+		{"foo", "foo"},
+	}
+	for _, tt := range tests {
+		if got := tt.in.Normalized(); got != tt.want {
+			t.Errorf("(%q).Normalized() = %q; want %q", string(tt.in), string(got), string(tt.want))
 		}
 	}
 }


### PR DESCRIPTION
For manual (human) testing, this lets the user disable control plane
map polls with "tailscale set --sync=false" (which survives restarts)
and "tailscale set --sync" to restore.

A high severity health warning is shown while this is active.

Updates #12639
