### PR TITLE
ipn/ipnlocal, tka: compact TKA state after every sync

### DIFF
--- a/tka/builder_test.go
+++ b/tka/builder_test.go
@@ -28,7 +28,7 @@ func TestAuthorityBuilderAddKey(t *testing.T) {
 	pub, priv := testingKey25519(t, 1)
 	key := Key{Kind: Key25519, Public: pub, Votes: 2}
 
-	storage := &Mem{}
+	storage := ChonkMem()
 	a, _, err := Create(storage, State{
 		Keys:               []Key{key},
 		DisablementSecrets: [][]byte{DisablementKDF([]byte{1, 2, 3})},
@@ -62,7 +62,7 @@ func TestAuthorityBuilderMaxKey(t *testing.T) {
 	pub, priv := testingKey25519(t, 1)
 	key := Key{Kind: Key25519, Public: pub, Votes: 2}
 
-	storage := &Mem{}
+	storage := ChonkMem()
 	a, _, err := Create(storage, State{
 		Keys:               []Key{key},
 		DisablementSecrets: [][]byte{DisablementKDF([]byte{1, 2, 3})},
@@ -109,7 +109,7 @@ func TestAuthorityBuilderRemoveKey(t *testing.T) {
 	pub2, _ := testingKey25519(t, 2)
 	key2 := Key{Kind: Key25519, Public: pub2, Votes: 1}
 
-	storage := &Mem{}
+	storage := ChonkMem()
 	a, _, err := Create(storage, State{
 		Keys:               []Key{key, key2},
 		DisablementSecrets: [][]byte{DisablementKDF([]byte{1, 2, 3})},
@@ -155,7 +155,7 @@ func TestAuthorityBuilderSetKeyVote(t *testing.T) {
 	pub, priv := testingKey25519(t, 1)
 	key := Key{Kind: Key25519, Public: pub, Votes: 2}
 
-	storage := &Mem{}
+	storage := ChonkMem()
 	a, _, err := Create(storage, State{
 		Keys:               []Key{key},
 		DisablementSecrets: [][]byte{DisablementKDF([]byte{1, 2, 3})},
@@ -191,7 +191,7 @@ func TestAuthorityBuilderSetKeyMeta(t *testing.T) {
 	pub, priv := testingKey25519(t, 1)
 	key := Key{Kind: Key25519, Public: pub, Votes: 2, Meta: map[string]string{"a": "b"}}
 
-	storage := &Mem{}
+	storage := ChonkMem()
 	a, _, err := Create(storage, State{
 		Keys:               []Key{key},
 		DisablementSecrets: [][]byte{DisablementKDF([]byte{1, 2, 3})},
@@ -227,7 +227,7 @@ func TestAuthorityBuilderMultiple(t *testing.T) {
 	pub, priv := testingKey25519(t, 1)
 	key := Key{Kind: Key25519, Public: pub, Votes: 2}
 
-	storage := &Mem{}
+	storage := ChonkMem()
 	a, _, err := Create(storage, State{
 		Keys:               []Key{key},
 		DisablementSecrets: [][]byte{DisablementKDF([]byte{1, 2, 3})},
@@ -275,7 +275,7 @@ func TestAuthorityBuilderCheckpointsAfterXUpdates(t *testing.T) {
 	pub, priv := testingKey25519(t, 1)
 	key := Key{Kind: Key25519, Public: pub, Votes: 2}
 
-	storage := &Mem{}
+	storage := ChonkMem()
 	a, _, err := Create(storage, State{
 		Keys:               []Key{key},
 		DisablementSecrets: [][]byte{DisablementKDF([]byte{1, 2, 3})},

--- a/tka/chaintest_test.go
+++ b/tka/chaintest_test.go
@@ -285,25 +285,25 @@ func (c *testChain) makeAUM(v *testchainNode) AUM {
 
 // Chonk returns a tailchonk containing all AUMs.
 func (c *testChain) Chonk() Chonk {
-	var out Mem
+	out := ChonkMem()
 	for _, update := range c.AUMs {
 		if err := out.CommitVerifiedAUMs([]AUM{update}); err != nil {
 			panic(err)
 		}
 	}
-	return &out
+	return out
 }
 
 // ChonkWith returns a tailchonk containing the named AUMs.
 func (c *testChain) ChonkWith(names ...string) Chonk {
-	var out Mem
+	out := ChonkMem()
 	for _, name := range names {
 		update := c.AUMs[name]
 		if err := out.CommitVerifiedAUMs([]AUM{update}); err != nil {
 			panic(err)
 		}
 	}
-	return &out
+	return out
 }
 
 type testchainOpt struct {

--- a/tka/key_test.go
+++ b/tka/key_test.go
@@ -72,7 +72,7 @@ func TestNLPrivate(t *testing.T) {
 	// Test that key.NLPrivate implements Signer by making a new
 	// authority.
 	k := Key{Kind: Key25519, Public: pub.Verifier(), Votes: 1}
-	_, aum, err := Create(&Mem{}, State{
+	_, aum, err := Create(ChonkMem(), State{
 		Keys:               []Key{k},
 		DisablementSecrets: [][]byte{bytes.Repeat([]byte{1}, 32)},
 	}, p)

--- a/tka/sync_test.go
+++ b/tka/sync_test.go
@@ -346,7 +346,7 @@ func TestSyncSimpleE2E(t *testing.T) {
 		optKey("key", key, priv),
 		optSignAllUsing("key"))
 
-	nodeStorage := &Mem{}
+	nodeStorage := ChonkMem()
 	node, err := Bootstrap(nodeStorage, c.AUMs["G1"])
 	if err != nil {
 		t.Fatalf("node Bootstrap() failed: %v", err)

--- a/tka/tailchonk_test.go
+++ b/tka/tailchonk_test.go
@@ -35,7 +35,7 @@ func randHash(t *testing.T, seed int64) [blake2s.Size]byte {
 }
 
 func TestImplementsChonk(t *testing.T) {
-	impls := []Chonk{&Mem{}, &FS{}}
+	impls := []Chonk{ChonkMem(), &FS{}}
 	t.Logf("chonks: %v", impls)
 }
 
@@ -229,7 +229,7 @@ func TestMarkActiveChain(t *testing.T) {
 			verdict := make(map[AUMHash]retainState, len(tc.chain))
 
 			// Build the state of the tailchonk for tests.
-			storage := &Mem{}
+			storage := ChonkMem()
 			var prev AUMHash
 			for i := range tc.chain {
 				if !prev.IsZero() {
@@ -608,7 +608,7 @@ func TestCompactLongButYoung(t *testing.T) {
 	ourKey := Key{Kind: Key25519, Public: ourPriv.Public().Verifier(), Votes: 1}
 	someOtherKey := Key{Kind: Key25519, Public: key.NewNLPrivate().Public().Verifier(), Votes: 1}
 
-	storage := &Mem{}
+	storage := ChonkMem()
 	auth, _, err := Create(storage, State{
 		Keys:               []Key{ourKey, someOtherKey},
 		DisablementSecrets: [][]byte{DisablementKDF(bytes.Repeat([]byte{0xa5}, 32))},

--- a/tka/tka_test.go
+++ b/tka/tka_test.go
@@ -253,7 +253,7 @@ func TestOpenAuthority(t *testing.T) {
 	}
 
 	// Construct the state of durable storage.
-	chonk := &Mem{}
+	chonk := ChonkMem()
 	err := chonk.CommitVerifiedAUMs([]AUM{g1, i1, l1, i2, i3, l2, l3, g2, l4})
 	if err != nil {
 		t.Fatal(err)
@@ -275,7 +275,7 @@ func TestOpenAuthority(t *testing.T) {
 }
 
 func TestOpenAuthority_EmptyErrors(t *testing.T) {
-	_, err := Open(&Mem{})
+	_, err := Open(ChonkMem())
 	if err == nil {
 		t.Error("Expected an error initializing an empty authority, got nil")
 	}
@@ -319,7 +319,7 @@ func TestCreateBootstrapAuthority(t *testing.T) {
 	pub, priv := testingKey25519(t, 1)
 	key := Key{Kind: Key25519, Public: pub, Votes: 2}
 
-	a1, genesisAUM, err := Create(&Mem{}, State{
+	a1, genesisAUM, err := Create(ChonkMem(), State{
 		Keys:               []Key{key},
 		DisablementSecrets: [][]byte{DisablementKDF([]byte{1, 2, 3})},
 	}, signer25519(priv))
@@ -327,7 +327,7 @@ func TestCreateBootstrapAuthority(t *testing.T) {
 		t.Fatalf("Create() failed: %v", err)
 	}
 
-	a2, err := Bootstrap(&Mem{}, genesisAUM)
+	a2, err := Bootstrap(ChonkMem(), genesisAUM)
 	if err != nil {
 		t.Fatalf("Bootstrap() failed: %v", err)
 	}
@@ -366,7 +366,7 @@ func TestAuthorityInformNonLinear(t *testing.T) {
 		optKey("key", key, priv),
 		optSignAllUsing("key"))
 
-	storage := &Mem{}
+	storage := ChonkMem()
 	a, err := Bootstrap(storage, c.AUMs["G1"])
 	if err != nil {
 		t.Fatalf("Bootstrap() failed: %v", err)
@@ -411,7 +411,7 @@ func TestAuthorityInformLinear(t *testing.T) {
 		optKey("key", key, priv),
 		optSignAllUsing("key"))
 
-	storage := &Mem{}
+	storage := ChonkMem()
 	a, err := Bootstrap(storage, c.AUMs["G1"])
 	if err != nil {
 		t.Fatalf("Bootstrap() failed: %v", err)
@@ -444,7 +444,7 @@ func TestInteropWithNLKey(t *testing.T) {
 	pub2 := key.NewNLPrivate().Public()
 	pub3 := key.NewNLPrivate().Public()
 
-	a, _, err := Create(&Mem{}, State{
+	a, _, err := Create(ChonkMem(), State{
 		Keys: []Key{
 			{
 				Kind:   Key25519,

--- a/tstest/chonktest/tailchonk_test.go
+++ b/tstest/chonktest/tailchonk_test.go
@@ -18,7 +18,7 @@ func TestImplementsChonk(t *testing.T) {
 		{
 			name: "Mem",
 			newChonk: func(t *testing.T) tka.Chonk {
-				return &tka.Mem{}
+				return tka.ChonkMem()
 			},
 		},
 		{
@@ -42,7 +42,7 @@ func TestImplementsCompactableChonk(t *testing.T) {
 		{
 			name: "Mem",
 			newChonk: func(t *testing.T) tka.CompactableChonk {
-				return &tka.Mem{}
+				return tka.ChonkMem()
 			},
 		},
 		{


### PR DESCRIPTION
Previously a TKA compaction would only run when a node starts, which means a long-running node could use unbounded storage as it accumulates ever-increasing amounts of TKA state. This patch changes TKA so it runs a compaction after every sync.

Updates https://github.com/tailscale/corp/issues/33537

---

I know we discussed running a compact after every checkpoint AUM, but we may save multiple AUMs in a single operation, and it didn't seem worth checking if any of them are checkpoints before running the compact – it's cheap and quick, and a no-op in most cases.