### PR TITLE
feature/tpm: disable dictionary attack protection on sealing key

### DIFF
--- a/feature/tpm/attestation.go
+++ b/feature/tpm/attestation.go
@@ -59,10 +59,12 @@ func newAttestationKey() (ak *attestationKey, retErr error) {
 						SensitiveDataOrigin: true,
 						UserWithAuth:        true,
 						AdminWithPolicy:     true,
-						NoDA:                true,
-						FixedTPM:            true,
-						FixedParent:         true,
-						SignEncrypt:         true,
+						// We don't set an authorization policy on this key, so
+						// DA isn't helpful.
+						NoDA:        true,
+						FixedTPM:    true,
+						FixedParent: true,
+						SignEncrypt: true,
 					},
 					Parameters: tpm2.NewTPMUPublicParms(
 						tpm2.TPMAlgECC,

--- a/feature/tpm/tpm.go
+++ b/feature/tpm/tpm.go
@@ -414,6 +414,9 @@ func tpmSeal(logf logger.Logf, data []byte) (*tpmSealedData, error) {
 					FixedTPM:     true,
 					FixedParent:  true,
 					UserWithAuth: true,
+					// We don't set an authorization policy on this key, so DA
+					// isn't helpful.
+					NoDA: true,
 				},
 			}),
 		}


### PR DESCRIPTION
DA protection is not super helpful because we don't set an authorization password on the key. But if authorization fails for other reasons (like TPM being reset), we will eventually cause DA lockout with tailscaled trying to load the key. DA lockout then leads to (1) issues for other processes using the TPM and (2) the underlying authorization error being masked in logs.

Updates #17654