### PR TITLE
wgengine/netlog: strip dot suffix from node name

### DIFF
--- a/wgengine/netlog/record.go
+++ b/wgengine/netlog/record.go
@@ -9,6 +9,7 @@ import (
 	"cmp"
 	"net/netip"
 	"slices"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -169,7 +170,10 @@ func (nu nodeUser) toNode() netlogtype.Node {
 	if !nu.Valid() {
 		return netlogtype.Node{}
 	}
-	n := netlogtype.Node{NodeID: nu.StableID(), Name: nu.Name()}
+	n := netlogtype.Node{
+		NodeID: nu.StableID(),
+		Name:   strings.TrimSuffix(nu.Name(), "."),
+	}
 	var ipv4, ipv6 netip.Addr
 	for _, addr := range nu.Addresses().All() {
 		switch {

--- a/wgengine/netlog/record_test.go
+++ b/wgengine/netlog/record_test.go
@@ -53,7 +53,7 @@ func TestToMessage(t *testing.T) {
 		selfNode: nodeUser{NodeView: (&tailcfg.Node{
 			ID:        123456,
 			StableID:  "n123456CNTL",
-			Name:      "src.tail123456.ts.net",
+			Name:      "src.tail123456.ts.net.",
 			Addresses: []netip.Prefix{prefix("100.1.2.3")},
 			Tags:      []string{"tag:src"},
 		}).View()},
@@ -64,14 +64,14 @@ func TestToMessage(t *testing.T) {
 			addr("100.1.2.4"): {NodeView: (&tailcfg.Node{
 				ID:        123457,
 				StableID:  "n123457CNTL",
-				Name:      "dst1.tail123456.ts.net",
+				Name:      "dst1.tail123456.ts.net.",
 				Addresses: []netip.Prefix{prefix("100.1.2.4")},
 				Tags:      []string{"tag:dst1"},
 			}).View()},
 			addr("100.1.2.5"): {NodeView: (&tailcfg.Node{
 				ID:        123458,
 				StableID:  "n123458CNTL",
-				Name:      "dst2.tail123456.ts.net",
+				Name:      "dst2.tail123456.ts.net.",
 				Addresses: []netip.Prefix{prefix("100.1.2.5")},
 				Tags:      []string{"tag:dst2"},
 			}).View()},
@@ -163,7 +163,7 @@ func TestToNode(t *testing.T) {
 		{
 			node: &tailcfg.Node{
 				StableID:  "n123456CNTL",
-				Name:      "test.tail123456.ts.net",
+				Name:      "test.tail123456.ts.net.",
 				Addresses: []netip.Prefix{prefix("100.1.2.3")},
 				Tags:      []string{"tag:dupe", "tag:test", "tag:dupe"},
 				User:      12345, // should be ignored


### PR DESCRIPTION
The REST API does not return a node name
with a trailing dot, while the internal node name
reported in the netmap does have one.

In order to be consistent with the API,
strip the dot when recording node information.

Updates tailscale/corp#33352