### PR TITLE
cmd/mkpkg: add changelog support for deb and rpm packages

### DIFF
--- a/cmd/mkpkg/main.go
+++ b/cmd/mkpkg/main.go
@@ -63,6 +63,7 @@ func main() {
 	replaces := flag.String("replaces", "", "package which this package replaces, if any")
 	depends := flag.String("depends", "", "comma-separated list of packages this package depends on")
 	recommends := flag.String("recommends", "", "comma-separated list of packages this package recommends")
+	changelog := flag.String("changelog", "", "path to changelog.yaml file")
 	flag.Parse()
 
 	filesList, err := parseFiles(*regularFiles, files.TypeFile)
@@ -88,6 +89,7 @@ func main() {
 		Description: *description,
 		Homepage:    "https://www.tailscale.com",
 		License:     "MIT",
+		Changelog:   *changelog,
 		Overridables: nfpm.Overridables{
 			Contents: contents,
 			Scripts: nfpm.Scripts{


### PR DESCRIPTION
Add a `—changelog` flag that accepts a path to a changelog.yaml file in the format expected by goreleaser/chglog. When provided, the changelog is automatically included in the package: deb packages include it as /usr/share/doc/<package>/changelog.Debian.gz, and rpm packages include it as changelog metadata in the package header.

The changelog flag is optional and only applies when a valid YAML file path is provided.

Updates #314

————
I haven’t checked in with anyone yet about the approach, but would be very happy to chat with stakeholders. As mentioned above, the changelog format is a structured YAML file and so far it looks like someone would be on the hook for converting whatever internal change log representation Tailscale has (as referenced in https://tailscale.com/changelog) into this YAML format. I’m happy to take additional action to make this a useful PR, but would need guidance about the overall internal workflow.

Here is the sample changelog.yaml that I tested with:
```
- deb:
    urgency: medium
    distributions:
      - unstable
  semver: "1.90.6-1"
  date: "2025-10-31T00:00:00Z"
  packager: "Tailscale Inc <info@tailscale.com>"
  urgency: "medium"
  distribution: "unstable"
  changes:
    - note: "App connectors: Routes no longer stall and fail to apply when updated repeatedly in a short period of time"
    - note: "Linux: Tailscale SSH no longer hangs for 10s when connecting to tsrecorder. This affected tailnets that use Tailscale SSH recording"
```

After building and installing a test tailscale Debian package with `mkpkg` using the following command:
```
./mkpkg \
  --out=tailscale_1.90.6_arm.deb \
  --name=tailscale \
  --version=1.90.6 \
  --type=deb \
  --arch=arm64 \
  --files="$HOME/go/bin/linux_arm/tailscale:/usr/bin/tailscaled" \
  --changelog=./tmp/changelog.yaml \
  --description="The easiest, most secure, cross platform way to use WireGuard + oauth2 + 2FA/SSO"
```

I confirmed the change log is present in the apt database:
```
~ apt changelog tailscale

tailscale (1.90.6-1) unstable; urgency=medium
  * App connectors: Routes no longer stall and fail to apply when updated repeatedly in a short period of time
  * Linux: Tailscale SSH no longer hangs for 10s when connecting to tsrecorder. This affected tailnets that use Tailscale SSH recording

 -- Tailscale Inc <info@tailscale.com>  Fri, 31 Oct 2025 12:00:00 +0000
```
