### PR TITLE
tka: move RemoveAll() to CompactableChonk

### DIFF
--- a/tka/tailchonk.go
+++ b/tka/tailchonk.go
@@ -58,10 +58,6 @@ type Chonk interface {
 	// as a hint to pick the correct chain in the event that the Chonk stores
 	// multiple distinct chains.
 	LastActiveAncestor() (*AUMHash, error)
-
-	// RemoveAll permanently and completely clears the TKA state. This should
-	// be called when the user disables Tailnet Lock.
-	RemoveAll() error
 }
 
 // CompactableChonk implementation are extensions of Chonk, which are
@@ -80,6 +76,10 @@ type CompactableChonk interface {
 	// PurgeAUMs permanently and irrevocably deletes the specified
 	// AUMs from storage.
 	PurgeAUMs(hashes []AUMHash) error
+
+	// RemoveAll permanently and completely clears the TKA state. This should
+	// be called when the user disables Tailnet Lock.
+	RemoveAll() error
 }
 
 // Mem implements in-memory storage of TKA state, suitable for


### PR DESCRIPTION
I added a RemoveAll() method on tka.Chonk in #17946, but it's only used in the node to purge local AUMs. We don't need it in the SQLite storage, which currently implements tka.Chonk, so move it to CompactableChonk instead.

Also add some automated tests, as a safety net.

Updates tailscale/corp#33599