### PR TITLE
cmd/vet/jsontags: fix a typo in an error message

### DIFF
--- a/cmd/vet/jsontags/report.go
+++ b/cmd/vet/jsontags/report.go
@@ -80,9 +80,9 @@ const (
 func (k ReportKind) message() string {
 	switch k {
 	case OmitEmptyUnsupportedInV1:
-		return "uses `omitempty` on an unspported type in json/v1; should probably use `omitzero` instead"
+		return "uses `omitempty` on an unsupported type in json/v1; should probably use `omitzero` instead"
 	case OmitEmptyUnsupportedInV2:
-		return "uses `omitempty` on an unspported type in json/v2; should probably use `omitzero` instead"
+		return "uses `omitempty` on an unsupported type in json/v2; should probably use `omitzero` instead"
 	case OmitEmptyShouldBeOmitZero:
 		return "should use `omitzero` instead of `omitempty`"
 	case OmitEmptyShouldBeOmitZeroButHasIsZero:


### PR DESCRIPTION
Updates #17945