### PR TITLE
cmd/k8s-operator: use stable image for k8s-nameserver

### DIFF
--- a/cmd/k8s-operator/nameserver.go
+++ b/cmd/k8s-operator/nameserver.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/yaml"
+
 	tsoperator "tailscale.com/k8s-operator"
 	tsapi "tailscale.com/k8s-operator/apis/v1alpha1"
 	"tailscale.com/kube/kubetypes"
@@ -45,10 +46,7 @@ const (
 	messageMultipleDNSConfigsPresent = "Multiple DNSConfig resources found in cluster. Please ensure no more than one is present."
 
 	defaultNameserverImageRepo = "tailscale/k8s-nameserver"
-	// TODO (irbekrm): once we start publishing nameserver images for stable
-	// track, replace 'unstable' here with the version of this operator
-	// instance.
-	defaultNameserverImageTag = "unstable"
+	defaultNameserverImageTag  = "stable"
 )
 
 // NameserverReconciler knows how to create nameserver resources in cluster in

--- a/cmd/k8s-operator/nameserver_test.go
+++ b/cmd/k8s-operator/nameserver_test.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
+
 	operatorutils "tailscale.com/k8s-operator"
 	tsapi "tailscale.com/k8s-operator/apis/v1alpha1"
 	"tailscale.com/tstest"
@@ -182,7 +183,7 @@ func TestNameserverReconciler(t *testing.T) {
 			dnsCfg.Spec.Nameserver.Image = nil
 		})
 		expectReconciled(t, reconciler, "", "test")
-		wantsDeploy.Spec.Template.Spec.Containers[0].Image = "tailscale/k8s-nameserver:unstable"
+		wantsDeploy.Spec.Template.Spec.Containers[0].Image = "tailscale/k8s-nameserver:stable"
 		expectEqual(t, fc, wantsDeploy)
 	})
 }


### PR DESCRIPTION
This commit modifies the kubernetes operator to use the "stable" version of `k8s-nameserver` by default.

Updates: https://github.com/tailscale/corp/issues/19028