### PR TITLE
net/tstun: add TSMPDiscoAdvertisement to TSMPPing

### DIFF
--- a/net/packet/tsmp_test.go
+++ b/net/packet/tsmp_test.go
@@ -4,8 +4,14 @@
 package packet
 
 import (
+	"bytes"
+	"encoding/hex"
 	"net/netip"
+	"slices"
 	"testing"
+
+	"go4.org/mem"
+	"tailscale.com/types/key"
 )
 
 func TestTailscaleRejectedHeader(t *testing.T) {
@@ -69,5 +75,64 @@ func TestTailscaleRejectedHeader(t *testing.T) {
 		if back != tt.h {
 			t.Errorf("%v. %q parsed back as %q", i, tt.h, back)
 		}
+	}
+}
+
+func TestTSMPDiscoKeyAdvertisementMarshal(t *testing.T) {
+	var (
+		// IPv4: Ver(4)Len(5), TOS, Len(53), ID, Flags, TTL(64), Proto(99), Cksum
+		headerV4, _ = hex.DecodeString("45000035000000004063705d")
+		// IPv6: Ver(6)TCFlow, Len(33), NextHdr(99), HopLim(64)
+		headerV6, _ = hex.DecodeString("6000000000216340")
+
+		packetType = []byte{'a'}
+		testKey    = bytes.Repeat([]byte{'a'}, 32)
+
+		// IPs
+		srcV4 = netip.MustParseAddr("1.2.3.4")
+		dstV4 = netip.MustParseAddr("4.3.2.1")
+		srcV6 = netip.MustParseAddr("2001:db8::1")
+		dstV6 = netip.MustParseAddr("2001:db8::2")
+	)
+
+	join := func(parts ...[]byte) []byte {
+		return bytes.Join(parts, nil)
+	}
+
+	tests := []struct {
+		name string
+		tka  TSMPDiscoKeyAdvertisement
+		want []byte
+	}{
+		{
+			name: "v4Header",
+			tka: TSMPDiscoKeyAdvertisement{
+				Src: srcV4,
+				Dst: dstV4,
+				Key: key.DiscoPublicFromRaw32(mem.B(testKey)),
+			},
+			want: join(headerV4, srcV4.AsSlice(), dstV4.AsSlice(), packetType, testKey),
+		},
+		{
+			name: "v6Header",
+			tka: TSMPDiscoKeyAdvertisement{
+				Src: srcV6,
+				Dst: dstV6,
+				Key: key.DiscoPublicFromRaw32(mem.B(testKey)),
+			},
+			want: join(headerV6, srcV6.AsSlice(), dstV6.AsSlice(), packetType, testKey),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.tka.Marshal()
+			if err != nil {
+				t.Errorf("error mashalling TSMPDiscoAdvertisement: %s", err)
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("error mashalling TSMPDiscoAdvertisement, expected: \n%x, \ngot:\n%x", tt.want, got)
+			}
+		})
 	}
 }

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -211,7 +211,7 @@ func newMagicStackWithKey(t testing.TB, logf logger.Logf, ln nettype.PacketListe
 	}
 
 	tun := tuntest.NewChannelTUN()
-	tsTun := tstun.Wrap(logf, tun.TUN(), &reg)
+	tsTun := tstun.Wrap(logf, tun.TUN(), &reg, bus)
 	tsTun.SetFilter(filter.NewAllowAllForTest(logf))
 	tsTun.Start()
 
@@ -1771,7 +1771,6 @@ func TestEndpointSetsEqual(t *testing.T) {
 			t.Errorf("%q vs %q = %v; want %v", tt.a, tt.b, got, tt.want)
 		}
 	}
-
 }
 
 func TestBetterAddr(t *testing.T) {
@@ -1915,7 +1914,6 @@ func TestBetterAddr(t *testing.T) {
 			t.Errorf("[%d] betterAddr(%+v, %+v) and betterAddr(%+v, %+v) both unexpectedly true", i, tt.a, tt.b, tt.b, tt.a)
 		}
 	}
-
 }
 
 func epFromTyped(eps []tailcfg.Endpoint) (ret []netip.AddrPort) {
@@ -3138,7 +3136,6 @@ func TestMaybeRebindOnError(t *testing.T) {
 					t.Errorf("expected at least 5 seconds between %s and %s", lastRebindTime, newTime)
 				}
 			}
-
 		})
 	})
 }

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -320,9 +320,9 @@ func NewUserspaceEngine(logf logger.Logf, conf Config) (_ Engine, reterr error) 
 
 	var tsTUNDev *tstun.Wrapper
 	if conf.IsTAP {
-		tsTUNDev = tstun.WrapTAP(logf, conf.Tun, conf.Metrics)
+		tsTUNDev = tstun.WrapTAP(logf, conf.Tun, conf.Metrics, conf.EventBus)
 	} else {
-		tsTUNDev = tstun.Wrap(logf, conf.Tun, conf.Metrics)
+		tsTUNDev = tstun.Wrap(logf, conf.Tun, conf.Metrics, conf.EventBus)
 	}
 	closePool.add(tsTUNDev)
 
@@ -1430,6 +1430,7 @@ func (e *userspaceEngine) Ping(ip netip.Addr, pingType tailcfg.PingType, size in
 		e.magicConn.Ping(peer, res, size, cb)
 	case "TSMP":
 		e.sendTSMPPing(ip, peer, res, cb)
+		e.sendTSMPDiscoAdvertisement(ip)
 	case "ICMP":
 		e.sendICMPEchoRequest(ip, peer, res, cb)
 	}
@@ -1548,6 +1549,29 @@ func (e *userspaceEngine) sendTSMPPing(ip netip.Addr, peer tailcfg.NodeView, res
 
 	tsmpPing := packet.Generate(iph, tsmpPayload[:])
 	e.tundev.InjectOutbound(tsmpPing)
+}
+
+func (e *userspaceEngine) sendTSMPDiscoAdvertisement(ip netip.Addr) {
+	srcIP, err := e.mySelfIPMatchingFamily(ip)
+	if err != nil {
+		e.logf("getting matching node: %s", err)
+		return
+	}
+	tdka := packet.TSMPDiscoKeyAdvertisement{
+		Src: srcIP,
+		Dst: ip,
+		Key: e.magicConn.DiscoPublicKey(),
+	}
+	payload, err := tdka.Marshal()
+	if err != nil {
+		e.logf("error generating TSMP Advertisement: %s", err)
+		metricTSMPDiscoKeyAdvertisementError.Add(1)
+	} else if err := e.tundev.InjectOutbound(payload); err != nil {
+		e.logf("error sending TSMP Advertisement: %s", err)
+		metricTSMPDiscoKeyAdvertisementError.Add(1)
+	} else {
+		metricTSMPDiscoKeyAdvertisementSent.Add(1)
+	}
 }
 
 func (e *userspaceEngine) setTSMPPongCallback(data [8]byte, cb func(packet.TSMPPongReply)) {
@@ -1716,6 +1740,9 @@ var (
 
 	metricNumMajorChanges = clientmetric.NewCounter("wgengine_major_changes")
 	metricNumMinorChanges = clientmetric.NewCounter("wgengine_minor_changes")
+
+	metricTSMPDiscoKeyAdvertisementSent  = clientmetric.NewCounter("magicsock_tsmp_disco_key_advertisement_sent")
+	metricTSMPDiscoKeyAdvertisementError = clientmetric.NewCounter("magicsock_tsmp_disco_key_advertisement_error")
 )
 
 func (e *userspaceEngine) InstallCaptureHook(cb packet.CaptureCallback) {


### PR DESCRIPTION
Adds two new types of TSMP messages for advertising and soliciting disco keys to/from a peer, and implements the advertising triggered by a TSMP ping.

Needed as part of the effort to cache the netmap and still let clients connect without control being reachable.

Updates #12639