### PR TITLE
tka: don't panic if no clock set in tka.Mem

### DIFF
--- a/tka/tailchonk.go
+++ b/tka/tailchonk.go
@@ -193,7 +193,7 @@ updateLoop:
 	for _, aum := range updates {
 		aumHash := aum.Hash()
 		c.aums[aumHash] = aum
-		c.commitTimes[aumHash] = c.clock.Now()
+		c.commitTimes[aumHash] = c.now()
 
 		parent, ok := aum.Parent()
 		if ok {
@@ -207,6 +207,16 @@ updateLoop:
 	}
 
 	return nil
+}
+
+// now returns the current time, optionally using the overridden
+// clock if set.
+func (c *Mem) now() time.Time {
+	if c.clock == nil {
+		return time.Now()
+	} else {
+		return c.clock.Now()
+	}
 }
 
 // RemoveAll permanently and completely clears the TKA state.


### PR DESCRIPTION
This is causing confusing panics in tailscale/corp#34485. We'll keep using the tka.ChonkMem constructor as much as we can, but don't panic if you create a tka.Mem directly -- we know what the sensible thing is.

Updates #cleanup

Change-Id: I49309f5f403fc26ce4f9a6cf0edc8eddf6a6f3a4