### PR TITLE
ipn/ipnlocal: fix panic in driveTransport on network error

### DIFF
--- a/ipn/ipnlocal/drive_test.go
+++ b/ipn/ipnlocal/drive_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !ts_omit_drive
+
+package ipnlocal
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestDriveTransportRoundTrip_NetworkError tests that driveTransport.RoundTrip
+// doesn't panic when the underlying transport returns a nil response with an
+// error.
+//
+// See: https://github.com/tailscale/tailscale/issues/17306
+func TestDriveTransportRoundTrip_NetworkError(t *testing.T) {
+	b := newTestLocalBackend(t)
+
+	testErr := errors.New("network connection failed")
+	mockTransport := &mockRoundTripper{
+		err: testErr,
+	}
+	dt := &driveTransport{
+		b:  b,
+		tr: mockTransport,
+	}
+
+	req := httptest.NewRequest("GET", "http://100.64.0.1:1234/some/path", nil)
+	resp, err := dt.RoundTrip(req)
+	if err == nil {
+		t.Fatal("got nil error, expected non-nil")
+	} else if !errors.Is(err, testErr) {
+		t.Errorf("got error %v, expected %v", err, testErr)
+	}
+	if resp != nil {
+		t.Errorf("wanted nil response, got %v", resp)
+	}
+}
+
+type mockRoundTripper struct {
+	err error
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return nil, m.err
+}


### PR DESCRIPTION
When the underlying transport returns a network error, the RoundTrip method returns (nil, error). The defer was attempting to access resp without checking if it was nil first, causing a panic. Fix this by checking for nil in the defer.

Also changes driveTransport.tr from *http.Transport to http.RoundTripper and adds a test.

Fixes #17306