### PR TITLE
ipn/ipnlocal: don't panic if there are no suitable exit nodes

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -7426,6 +7426,16 @@ func suggestExitNodeUsingDERP(report *netcheck.Report, nb *nodeBackend, prevSugg
 		}
 	}
 	bestCandidates := pickWeighted(pickFrom)
+
+	// We may have an empty list of candidates here, if none of the candidates
+	// have home DERP info.
+	//
+	// We know that candidates is non-empty or we'd already have returned, so if
+	// we've filtered everything out of bestCandidates, just use candidates.
+	if len(bestCandidates) == 0 {
+		bestCandidates = candidates
+	}
+
 	chosen := selectNode(views.SliceOf(bestCandidates), prevSuggestion)
 	if !chosen.Valid() {
 		return res, errors.New("chosen candidate invalid: this is a bug")


### PR DESCRIPTION
In suggestExitNodeLocked, if no exit node candidates have a home DERP or valid location info, `bestCandidates` is an empty slice. This slice is passed to `selectNode()` (`randomNode` in prod):

```go
func randomNode(nodes views.Slice[tailcfg.NodeView], …) tailcfg.NodeView {
	…

	return nodes.At(rand.IntN(nodes.Len()))
}
```

An empty slice becomes a call to `rand.IntN(0)`, which panics.

~This patch adds an early return for an empty slice before calling `randomNode()`, preventing the panic. It includes a regression test.~

This patch changes the behaviour, so if we've filtered out all the candidates before calling `selectNode`, reset the list and then pick from any of the available candidates.

This patch also updates our tests to give us more coverage of `randomNode`, so we can spot other potential issues.

Updates #17661

---

I will fully admit I don't fully understand suggested exit nodes, so maybe there's a better approach here – I'm happy to update this patch if reviewers prefer something different.