### PR TITLE
tailcfg, control/controlclient: start moving MapResponse.DefaultAutoUpdate to a nodeattr

### DIFF
--- a/cmd/vet/jsontags_allowlist
+++ b/cmd/vet/jsontags_allowlist
@@ -107,7 +107,7 @@ OmitEmptyShouldBeOmitZero	tailscale.com/tailcfg.MapResponse.ClientVersion
 OmitEmptyShouldBeOmitZero	tailscale.com/tailcfg.MapResponse.CollectServices
 OmitEmptyShouldBeOmitZero	tailscale.com/tailcfg.MapResponse.ControlDialPlan
 OmitEmptyShouldBeOmitZero	tailscale.com/tailcfg.MapResponse.Debug
-OmitEmptyShouldBeOmitZero	tailscale.com/tailcfg.MapResponse.DefaultAutoUpdate
+OmitEmptyShouldBeOmitZero	tailscale.com/tailcfg.MapResponse.DeprecatedDefaultAutoUpdate
 OmitEmptyShouldBeOmitZero	tailscale.com/tailcfg.MapResponse.DERPMap
 OmitEmptyShouldBeOmitZero	tailscale.com/tailcfg.MapResponse.DNSConfig
 OmitEmptyShouldBeOmitZero	tailscale.com/tailcfg.MapResponse.Node

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -7,6 +7,8 @@ package feature
 import (
 	"errors"
 	"reflect"
+
+	"tailscale.com/util/testenv"
 )
 
 var ErrUnavailable = errors.New("feature not included in this build")
@@ -53,6 +55,19 @@ func (h *Hook[Func]) Set(f Func) {
 	}
 	h.f = f
 	h.ok = true
+}
+
+// SetForTest sets the hook function for tests, blowing
+// away any previous value. It will panic if called from
+// non-test code.
+//
+// It returns a restore function that resets the hook
+// to its previous value.
+func (h *Hook[Func]) SetForTest(f Func) (restore func()) {
+	testenv.AssertInTest()
+	old := *h
+	h.f, h.ok = f, true
+	return func() { *h = old }
 }
 
 // Get returns the hook function, or panics if it hasn't been set.

--- a/feature/hooks.go
+++ b/feature/hooks.go
@@ -6,6 +6,8 @@ package feature
 import (
 	"net/http"
 	"net/url"
+	"os"
+	"sync"
 
 	"tailscale.com/types/logger"
 	"tailscale.com/types/persist"
@@ -15,9 +17,16 @@ import (
 // to conditionally initialize.
 var HookCanAutoUpdate Hook[func() bool]
 
+var testAllowAutoUpdate = sync.OnceValue(func() bool {
+	return os.Getenv("TS_TEST_ALLOW_AUTO_UPDATE") == "1"
+})
+
 // CanAutoUpdate reports whether the current binary is built with auto-update
 // support and, if so, whether the current platform supports it.
 func CanAutoUpdate() bool {
+	if testAllowAutoUpdate() {
+		return true
+	}
 	if f, ok := HookCanAutoUpdate.GetOk(); ok {
 		return f()
 	}

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -177,7 +177,8 @@ type CapabilityVersion int
 //   - 128: 2025-10-02: can handle C2N /debug/health.
 //   - 129: 2025-10-04: Fixed sleep/wake deadlock in magicsock when using peer relay (PR #17449)
 //   - 130: 2025-10-06: client can send key.HardwareAttestationPublic and key.HardwareAttestationKeySignature in MapRequest
-const CurrentCapabilityVersion CapabilityVersion = 130
+//   - 131: 2025-11-25: client respects [NodeAttrDefaultAutoUpdate]
+const CurrentCapabilityVersion CapabilityVersion = 131
 
 // ID is an integer ID for a user, node, or login allocated by the
 // control plane.
@@ -2149,12 +2150,14 @@ type MapResponse struct {
 	// or nothing to report.
 	ClientVersion *ClientVersion `json:",omitempty"`
 
-	// DefaultAutoUpdate is the default node auto-update setting for this
+	// DeprecatedDefaultAutoUpdate is the default node auto-update setting for this
 	// tailnet. The node is free to opt-in or out locally regardless of this
-	// value. This value is only used on first MapResponse from control, the
-	// auto-update setting doesn't change if the tailnet admin flips the
-	// default after the node registered.
-	DefaultAutoUpdate opt.Bool `json:",omitempty"`
+	// value. Once this value has been set and stored in the client, future
+	// changes from the control plane are ignored.
+	//
+	// Deprecated: use NodeAttrDefaultAutoUpdate instead. See
+	// https://github.com/tailscale/tailscale/issues/11502.
+	DeprecatedDefaultAutoUpdate opt.Bool `json:"DefaultAutoUpdate,omitempty"`
 }
 
 // DisplayMessage represents a health state of the node from the control plane's
@@ -2721,6 +2724,14 @@ const (
 	// default behavior is to trust the control plane when it claims that a
 	// node is no longer online, but that is not a reliable signal.
 	NodeAttrClientSideReachability = "client-side-reachability"
+
+	// NodeAttrDefaultAutoUpdate advertises the default node auto-update setting
+	// for this tailnet. The node is free to opt-in or out locally regardless of
+	// this value. Once this has been set and stored in the client, future
+	// changes from the control plane are ignored.
+	//
+	// The value of the key in [NodeCapMap] is a JSON boolean.
+	NodeAttrDefaultAutoUpdate NodeCapability = "default-auto-update"
 )
 
 // SetDNSRequest is a request to add a DNS record.

--- a/tstest/integration/integration.go
+++ b/tstest/integration/integration.go
@@ -576,6 +576,7 @@ type TestNode struct {
 	stateFile    string
 	upFlagGOOS   string // if non-empty, sets TS_DEBUG_UP_FLAG_GOOS for cmd/tailscale CLI
 	encryptState bool
+	allowUpdates bool
 
 	mu        sync.Mutex
 	onLogLine []func([]byte)
@@ -840,6 +841,9 @@ func (n *TestNode) StartDaemonAsIPNGOOS(ipnGOOS string) *Daemon {
 		"TS_DISABLE_PORTMAPPER=1", // shouldn't be needed; test is all localhost
 		"TS_DEBUG_LOG_RATE=all",
 	)
+	if n.allowUpdates {
+		cmd.Env = append(cmd.Env, "TS_TEST_ALLOW_AUTO_UPDATE=1")
+	}
 	if n.env.loopbackPort != nil {
 		cmd.Env = append(cmd.Env, "TS_DEBUG_NETSTACK_LOOPBACK_PORT="+strconv.Itoa(*n.env.loopbackPort))
 	}

--- a/types/netmap/nodemut.go
+++ b/types/netmap/nodemut.go
@@ -177,5 +177,5 @@ func mapResponseContainsNonPatchFields(res *tailcfg.MapResponse) bool {
 		// function is called, so it should never be set anyway. But for
 		// completedness, and for tests, check it too:
 		res.PeersChanged != nil ||
-		res.DefaultAutoUpdate != ""
+		res.DeprecatedDefaultAutoUpdate != ""
 }


### PR DESCRIPTION
And fix up the TestAutoUpdateDefaults integration tests as they
weren't testing reality: the DefaultAutoUpdate is supposed to only be
relevant on the first MapResponse in the stream, but the tests weren't
testing that. They were instead injecting a 2nd+ MapResponse.

This changes the test control server to add a hook to modify the first
map response, and then makes the test control when the node goes up
and down to make new map responses.

Also, the test now runs on macOS where the auto-update feature being
disabled would've previously t.Skipped the whole test.

Updates #11502
