### PR TITLE
net/udprelay: use `mono.Time` instead of `time.Time`

### DIFF
--- a/net/udprelay/server_test.go
+++ b/net/udprelay/server_test.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/crypto/blake2s"
 	"tailscale.com/disco"
 	"tailscale.com/net/packet"
+	"tailscale.com/tstime/mono"
 	"tailscale.com/types/key"
 	"tailscale.com/types/views"
 )
@@ -452,7 +453,7 @@ func Benchmark_blakeMACFromBindMsg(b *testing.B) {
 
 func TestServer_maybeRotateMACSecretLocked(t *testing.T) {
 	s := &Server{}
-	start := time.Now()
+	start := mono.Now()
 	s.maybeRotateMACSecretLocked(start)
 	qt.Assert(t, len(s.macSecrets), qt.Equals, 1)
 	macSecret := s.macSecrets[0]


### PR DESCRIPTION
## Description

This PR tries to evaluate the usage of `mono.Time` in the `udprelay` code over the vanilla `time.Time`. Since the logic that requires time doesn't need wall time, logically the results are the same if only mono time is used.

Fixes: https://github.com/tailscale/tailscale/issues/18064

## Results

When compared, the new implementation in my simple testing yields roughly 10% improvement in `ns/op` on average. As a reference the full benchmark can be found [here](https://gist.github.com/simar7/0e0ef04b7d797c81ba45f9871d72cab9).


| Metric        | Old     | New     | Change            |
| ------------- | ------- | ------- | ----------------- |
| **Avg ns/op** | 70,684  | 63,737  | **≈ 9.8% faster** |
| **B/op**      | 131,225 | 131,226 | same              |
| **allocs/op** | 8       | 8       | same              |


## Testing

The tests pass but I'm still in the process of evaluating this further. I do want to fully make sure that this PR doesn't introduce any unforeseen logical issues with the usage of time. Any feedback here would be welcome. 

I also intentionally didn't include the benchmark test as I felt it was benchmarking the use of `mono.Time` over `time.Time` so maybe it would be best to add a separate benchmark test within the `mono` package to compare it with the vanilla `time` package.



Signed-off-by: Simar <simar@linux.com>