### PR TITLE
.github/workflows: skip draft PRs for request review workflows

### DIFF
--- a/.github/workflows/request-dataplane-review.yml
+++ b/.github/workflows/request-dataplane-review.yml
@@ -2,6 +2,7 @@ name: request-dataplane-review
 
 on:
   pull_request:
+    types: [ opened, synchronize, reopened, ready_for_review ]
     paths:
       - ".github/workflows/request-dataplane-review.yml"
       - "**/*derp*"
@@ -10,6 +11,7 @@ on:
 
 jobs:
   request-dataplane-review:
+    if: github.event.pull_request.draft == false
     name: Request Dataplane Review
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Skip the "request review" workflows for PRs that are in draft to reduce noise / skip adding reviewers to PRs that are intentionally marked as not ready to review.

<img width="1677" height="445" alt="image" src="https://github.com/user-attachments/assets/9d5430d6-62ae-450c-aa94-a151a95d24d2" />

Updates #cleanup