### PR TITLE
.github/workflows: only run golang ci lint when go files have changed

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -2,7 +2,11 @@ name: golangci-lint
 on:
   # For now, only lint pull requests, not the main branches.
   pull_request:
-
+    paths:
+      - ".github/workflows/golangci-lint.yml"
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
   # TODO(andrew): enable for main branch after an initial waiting period.
   #push:
   #  branches:


### PR DESCRIPTION
Restrict running the golangci-lint workflow to when the workflow file itself or a .go file, go.mod, or go.sum have actually been modified.

Updates #cleanup