### PR TITLE
k8s-operator: Fix typos in egress-pod-readiness.go

### DIFF
--- a/cmd/k8s-operator/egress-pod-readiness.go
+++ b/cmd/k8s-operator/egress-pod-readiness.go
@@ -241,7 +241,7 @@ func (er *egressPodsReconciler) lookupPodRouteViaSvc(ctx context.Context, pod *c
 	req.Close = true
 	resp, err := er.httpClient.Do(req)
 	if err != nil {
-		// This is most likely because this is the first Pod and is not yet added to Service endpints. Other
+		// This is most likely because this is the first Pod and is not yet added to service endpints. Other
 		// error types are possible, but checking for those would likely make the system too fragile.
 		return unreachable, nil
 	}


### PR DESCRIPTION
This PR fixes two small spelling mistakes in cmd/k8s-operator/egress-pod-readiness.go.
No behavior or logic is changed.

Updates #cleanup