### PR TITLE
client/systray: change systray to start after graphical.target

### DIFF
--- a/client/systray/tailscale-systray.service
+++ b/client/systray/tailscale-systray.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Tailscale System Tray
-After=systemd.service
+After=graphical.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
The service was starting after systemd itself, and while this
surprisingly worked for some situations, it broke for others.

Change it to start after a GUI has been initialized.

Updates #17656

Signed-off-by: Claus Lensbøl <claus@tailscale.com>
