### PR TITLE
tka: add some more tests for Bootstrap()

### DIFF
--- a/tka/tka_test.go
+++ b/tka/tka_test.go
@@ -5,6 +5,7 @@ package tka
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -342,6 +343,65 @@ func TestCreateBootstrapAuthority(t *testing.T) {
 	}
 	if !a2.KeyTrusted(key.MustID()) {
 		t.Error("a2 did not trust genesis key")
+	}
+}
+
+// Trying to bootstrap an already-bootstrapped Chonk is an error.
+func TestBootstrapChonkMustBeEmpty(t *testing.T) {
+	chonk := ChonkMem()
+
+	pub, priv := testingKey25519(t, 1)
+	key := Key{Kind: Key25519, Public: pub, Votes: 2}
+	state := State{
+		Keys:               []Key{key},
+		DisablementSecrets: [][]byte{DisablementKDF([]byte{1, 2, 3})},
+	}
+
+	// Bootstrap our chonk for the first time, which should succeed.
+	_, _, err := Create(chonk, state, signer25519(priv))
+	if err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+
+	// Bootstrap our chonk for the second time, which should fail, because
+	// it already contains data.
+	_, _, err = Create(chonk, state, signer25519(priv))
+	if wantErr := "tailchonk is not empty"; err == nil || !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("Create() did not fail with expected error: want %q, got %v", wantErr, err)
+	}
+}
+
+func TestBootstrapWithInvalidAUMs(t *testing.T) {
+	for _, tt := range []struct {
+		Name       string
+		GenesisAUM AUM
+		WantErr    string
+	}{
+		{
+			Name:       "invalid-message-kind",
+			GenesisAUM: AUM{MessageKind: AUMNoOp},
+			WantErr:    "bootstrap AUMs must be checkpoint messages",
+		},
+		{
+			Name:       "missing-state",
+			GenesisAUM: AUM{MessageKind: AUMCheckpoint},
+			WantErr:    "bootstrap AUM is missing state",
+		},
+		{
+			Name: "no-disablement-secret",
+			GenesisAUM: AUM{
+				MessageKind: AUMCheckpoint,
+				State:       &State{},
+			},
+			WantErr: "at least one disablement secret required",
+		},
+	} {
+		t.Run(tt.Name, func(t *testing.T) {
+			_, err := Bootstrap(ChonkMem(), tt.GenesisAUM)
+			if err == nil || !strings.Contains(err.Error(), tt.WantErr) {
+				t.Fatalf("Bootstrap() did not fail with expected error: want %q, got %v", tt.WantErr, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This improves our test coverage of the Bootstrap() method, especially around catching AUMs that shouldn't pass validation.

I noticed the lack of test coverage while working on https://github.com/tailscale/corp/pull/35011 – we could definitely add more; this is a small improvement in the meantime.

Updates #cleanup