### PR TITLE
.github: add cigocacher release workflow

### DIFF
--- a/.github/workflows/cigocacher.yml
+++ b/.github/workflows/cigocacher.yml
@@ -1,0 +1,73 @@
+name: Build cigocacher
+
+on:
+  # Released on-demand. The commit will be used as part of the tag, so generally
+  # prefer to release from main where the commit is stable in linear history.
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        GOOS: ["linux", "darwin", "windows"]
+        GOARCH: ["amd64", "arm64"]
+    runs-on: ubuntu-24.04
+    env:
+      GOOS: "${{ matrix.GOOS }}"
+      GOARCH: "${{ matrix.GOARCH }}"
+      CGO_ENABLED: "0"
+    steps:
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - name: Build
+      run: |
+        OUT="cigocacher$(./tool/go env GOEXE)"
+        ./tool/go build -o "${OUT}" ./cmd/cigocacher/
+        tar -zcf cigocacher-${{ matrix.GOOS }}-${{ matrix.GOARCH }}.tar.gz "${OUT}"
+
+    - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+      with:
+        name: cigocacher-${{ matrix.GOOS }}-${{ matrix.GOARCH }}
+        path: cigocacher-${{ matrix.GOOS }}-${{ matrix.GOARCH }}.tar.gz
+
+  release:
+    runs-on: ubuntu-24.04
+    needs: build
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          pattern: 'cigocacher-*'
+          merge-multiple: true
+      # This step is a simplified version of actions/create-release and
+      # actions/upload-release-asset, which are archived and unmaintained.
+      - name: Create release
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const { data: release } = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: `cmd/cigocacher/${{ github.sha }}`,
+              name: `cigocacher-${{ github.sha }}`,
+              draft: false,
+              prerelease: true,
+              target_commitish: `${{ github.sha }}`
+            });
+
+            const files = fs.readdirSync('.').filter(f => f.endsWith('.tar.gz'));
+            
+            for (const file of files) {
+              await github.rest.repos.uploadReleaseAsset({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: release.id,
+                name: file,
+                data: fs.readFileSync(file)
+              });
+              console.log(`Uploaded ${file}`);
+            }


### PR DESCRIPTION
To save rebuilding cigocacher on each CI job, build it on-demand, and publish a release similar to how we publish releases for tool/go to consume. Once the first release is done, we can add a new tool/cigocacher script that pins to a specific release for each branch to download.

Updates tailscale/corp#10808

Change-Id: I7694b2c2240020ba2335eb467522cdd029469b6c