### PR TITLE
net/{packet,tstun},wgengine: update disco key when receiving via TSMP

### DIFF
--- a/net/packet/tsmp.go
+++ b/net/packet/tsmp.go
@@ -271,7 +271,7 @@ func (h TSMPPongReply) Marshal(buf []byte) error {
 //   - 'a' (TSMPTypeDiscoAdvertisement)
 //   - 32 disco key bytes
 type TSMPDiscoKeyAdvertisement struct {
-	Src, Dst netip.Addr
+	Src, Dst netip.Addr // Src and Dst are set from the parent IP Header when parsing.
 	Key      key.DiscoPublic
 }
 
@@ -298,7 +298,7 @@ func (ka *TSMPDiscoKeyAdvertisement) Marshal() ([]byte, error) {
 		return []byte{}, fmt.Errorf("expected payload length 33, got %d", len(payload))
 	}
 
-	return Generate(iph, payload), nil
+	return Generate(iph, payload[:]), nil
 }
 
 func (pp *Parsed) AsTSMPDiscoAdvertisement() (tka TSMPDiscoKeyAdvertisement, ok bool) {
@@ -310,6 +310,7 @@ func (pp *Parsed) AsTSMPDiscoAdvertisement() (tka TSMPDiscoKeyAdvertisement, ok 
 		return
 	}
 	tka.Src = pp.Src.Addr()
+	tka.Dst = pp.Dst.Addr()
 	tka.Key = key.DiscoPublicFromRaw32(mem.B(p[1:33]))
 
 	return tka, true

--- a/net/tstun/wrap.go
+++ b/net/tstun/wrap.go
@@ -1126,8 +1126,10 @@ func (t *Wrapper) injectedRead(res tunInjectedRead, outBuffs [][]byte, sizes []i
 	return n, err
 }
 
+// DiscoKeyAdvertisement is a TSMP message used for distributing disco keys.
+// This struct is used an an event on the [eventbus.Bus].
 type DiscoKeyAdvertisement struct {
-	Src netip.Addr
+	Src netip.Addr // Src field is populated by the IP header of the packet, not from the payload itself.
 	Key key.DiscoPublic
 }
 

--- a/net/tstun/wrap_test.go
+++ b/net/tstun/wrap_test.go
@@ -986,7 +986,7 @@ func TestTSMPDisco(t *testing.T) {
 		if tda.Src != src {
 			t.Errorf("Src address did not match, expected %v, got %v", src, tda.Src)
 		}
-		if !reflect.DeepEqual(tda.Key, discoKey.Public()) {
+		if tda.Key.Compare(discoKey.Public()) != 0 {
 			t.Errorf("Key did not match, expected %q, got %q", discoKey.Public(), tda.Key)
 		}
 	})


### PR DESCRIPTION
When receiving a TSMPDiscoAdvertisement from peer, update the discokey
for said peer.

Some parts taken from: https://github.com/tailscale/tailscale/pull/18073/

Updates #12639

Signed-off-by: Claus Lensbøl <claus@tailscale.com>

Co-authored-by: James Tucker <james@tailscale.com>
