### PR TITLE
scripts/installer.sh: add SteamOS handling

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -336,6 +336,11 @@ main() {
 				VERSION="$VERSION_MAJOR"
 				PACKAGETYPE="tdnf"
 				;;
+			steamos)
+				echo "To install Tailscale on SteamOS, please follow the instructions here:"
+				echo "https://github.com/tailscale-dev/deck-tailscale"
+				exit 1
+				;;
 
 			# TODO: wsl?
 			# TODO: synology? qnap?


### PR DESCRIPTION
Tested on my Steam Deck OLED:

```
(deck@steamdeck tailscale)$ ./scripts/installer.sh
To install Tailscale on SteamOS, please follow the instructions here:
https://github.com/tailscale-dev/deck-tailscale
```

Previously it would complain that SteamOS isn't supported, instead we redirect users to the correct instructions.

Fixes #12943