### PR TITLE
.github/workflows: try using a DevDrive on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -238,6 +238,14 @@ jobs:
           - key: "win-shard-2-2"
             shard: "2/2"
     steps:
+    - uses: samypr100/setup-dev-drive@30f0f98ae5636b2b6501e181dfb3631b9974818d # v4.0.0
+      with:
+        drive-size: 4GB
+        drive-format: ReFS
+        drive-type: Dynamic
+        drive-path: "dev_drive.vhdx"
+        mount-path: ${{ github.workspace }}
+
     - name: checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:


### PR DESCRIPTION
At least locally on my Windows laptop, this makes the build take a
quarter of the time.

Updates tailscale/corp#28679
