### PR TITLE
net/dns: add CnameHosts field to Config

### DIFF
--- a/net/dns/config.go
+++ b/net/dns/config.go
@@ -48,6 +48,12 @@ type Config struct {
 	// it to resolve, you also need to add appropriate routes to
 	// Routes.
 	Hosts map[dnsname.FQDN][]netip.Addr
+	// CnameHosts maps DNS FQDNs to their CNAME targets.
+	// Targets must be domains that can be resolved via Hosts.
+	// Queries matching entries return a CNAME chain followed by the
+	// resolved A/AAAA record.
+	// Wildcard CNAMEs are supported using "*.domain." as the key.
+	CnameHosts map[dnsname.FQDN]dnsname.FQDN
 	// OnlyIPv6, if true, uses the IPv6 service IP (for MagicDNS)
 	// instead of the IPv4 version (100.100.100.100).
 	OnlyIPv6 bool

--- a/net/dns/dns_clone.go
+++ b/net/dns/dns_clone.go
@@ -6,6 +6,7 @@
 package dns
 
 import (
+	"maps"
 	"net/netip"
 
 	"tailscale.com/types/dnstype"
@@ -43,6 +44,7 @@ func (src *Config) Clone() *Config {
 			dst.Hosts[k] = append([]netip.Addr{}, src.Hosts[k]...)
 		}
 	}
+	dst.CnameHosts = maps.Clone(src.CnameHosts)
 	return dst
 }
 
@@ -52,6 +54,7 @@ var _ConfigCloneNeedsRegeneration = Config(struct {
 	Routes           map[dnsname.FQDN][]*dnstype.Resolver
 	SearchDomains    []dnsname.FQDN
 	Hosts            map[dnsname.FQDN][]netip.Addr
+	CnameHosts       map[dnsname.FQDN]dnsname.FQDN
 	OnlyIPv6         bool
 }{})
 

--- a/net/dns/dns_view.go
+++ b/net/dns/dns_view.go
@@ -123,6 +123,15 @@ func (v ConfigView) Hosts() views.MapSlice[dnsname.FQDN, netip.Addr] {
 	return views.MapSliceOf(v.ж.Hosts)
 }
 
+// CnameHosts maps DNS FQDNs to their CNAME targets.
+// Targets must be domains that can be resolved via Hosts.
+// Queries matching entries return a CNAME chain followed by the
+// resolved A/AAAA record.
+// Wildcard CNAMEs are supported using "*.domain." as the key.
+func (v ConfigView) CnameHosts() views.Map[dnsname.FQDN, dnsname.FQDN] {
+	return views.MapOf(v.ж.CnameHosts)
+}
+
 // OnlyIPv6, if true, uses the IPv6 service IP (for MagicDNS)
 // instead of the IPv4 version (100.100.100.100).
 func (v ConfigView) OnlyIPv6() bool           { return v.ж.OnlyIPv6 }
@@ -134,5 +143,6 @@ var _ConfigViewNeedsRegeneration = Config(struct {
 	Routes           map[dnsname.FQDN][]*dnstype.Resolver
 	SearchDomains    []dnsname.FQDN
 	Hosts            map[dnsname.FQDN][]netip.Addr
+	CnameHosts       map[dnsname.FQDN]dnsname.FQDN
 	OnlyIPv6         bool
 }{})


### PR DESCRIPTION
    A new feature in DNS Config supports CNAME records. It allows users to
    link FQDNs, even those with wildcards, to different destination FQDNs.
    Although the FQDNs in question might be associated with CNAME names, a
    final resolution to an A or AAAA address is required by the DNS server

    Updates #1196