### PR TITLE
Dockerfile,Dockerfile.base: link iptables to legacy binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,8 +73,8 @@ RUN GOARCH=$TARGETARCH go install -ldflags="\
 
 FROM alpine:3.22
 RUN apk add --no-cache ca-certificates iptables iproute2 ip6tables
-RUN ln -s /sbin/iptables-legacy /sbin/iptables
-RUN ln -s /sbin/ip6tables-legacy /sbin/ip6tables
+RUN rm /usr/sbin/iptables && ln -s /usr/sbin/iptables-legacy /usr/sbin/iptables
+RUN rm /usr/sbin/ip6tables && ln -s /usr/sbin/ip6tables-legacy /usr/sbin/ip6tables
 
 COPY --from=build-env /go/bin/* /usr/local/bin/
 # For compat with the previous run.sh, although ideally you should be

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -8,5 +8,5 @@ RUN apk add --no-cache ca-certificates iptables iptables-legacy iproute2 ip6tabl
 # suppport nftables, so link back to legacy for backwards compatibility reasons.
 # TODO(irbekrm): add some way how to determine if we still run on nodes that
 # don't support nftables, so that we can eventually remove these symlinks.
-RUN ln -s /sbin/iptables-legacy /sbin/iptables
-RUN ln -s /sbin/ip6tables-legacy /sbin/ip6tables
+RUN rm /usr/sbin/iptables && ln -s /usr/sbin/iptables-legacy /usr/sbin/iptables
+RUN rm /usr/sbin/ip6tables && ln -s /usr/sbin/ip6tables-legacy /usr/sbin/ip6tables


### PR DESCRIPTION
Re-instate the linking of iptables installed in Tailscale container to the legacy iptables version. In environments where the legacy iptables is not needed, we should be able to run nftables instead, but this will ensure that Tailscale keeps working in environments that don't support nftables, such as some Synology NAS hosts.

I have verified that tailscale/tailscale image built from a base image from this branch has iptables in legacy mode again:

```
/ # iptables --version
iptables v1.8.11 (legacy)
/ # ip6tables --version
ip6tables v1.8.11 (legacy)
```

We should probaby also have a test that verifies this  - I might do that in a separate PR

Updates #17854