### PR TITLE
portlist: skip tests on Linux 6.14.x with /proc/net/tcp bug

### DIFF
--- a/portlist/portlist_test.go
+++ b/portlist/portlist_test.go
@@ -17,6 +17,7 @@ func maybeSkip(t *testing.T) {
 			"https://github.com/tailscale/tailscale/issues/16966",
 			"6.6.102", "6.6.103", "6.6.104",
 			"6.12.42", "6.12.43", "6.12.44", "6.12.45",
+			"6.14.0",
 		)
 	}
 }


### PR DESCRIPTION
PR #18033 skipped tests for the versions of Linux 6.6 and 6.12 that had a regression in /proc/net/tcp that causes seek operations to fail with “illegal seek”.

This PR skips tests for Linux 6.14.0, which is the default Ubuntu kernel, that also contains this regression.

Updates #16966