### PR TITLE
logpolicy: expose certain metrics as clientmetrics

### DIFF
--- a/logpolicy/logpolicy.go
+++ b/logpolicy/logpolicy.go
@@ -662,6 +662,9 @@ func (opts Options) init(disableLogging bool) (*logtail.Config, *Policy) {
 		}
 	}
 	lw := logtail.NewLogger(conf, opts.Logf)
+	if conf.MetricsDelta != nil {
+		exportClientMetrics(lw)
+	}
 
 	var logOutput io.Writer = lw
 

--- a/logpolicy/logtail_metrics.go
+++ b/logpolicy/logtail_metrics.go
@@ -1,0 +1,29 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !ts_omit_logtail && !ts_omit_clientmetrics
+
+package logpolicy
+
+import (
+	"expvar"
+
+	"tailscale.com/logtail"
+	"tailscale.com/util/clientmetric"
+)
+
+func exportClientMetrics(logger *logtail.Logger) {
+	if m, _ := logger.ExpVar().(interface{ Get(string) expvar.Var }); m != nil {
+		if m2, _ := m.Get("buffer").(interface{ Get(string) expvar.Var }); m2 != nil {
+			if v, _ := m2.Get("counter_filched_bytes").(*expvar.Int); v != nil {
+				clientmetric.NewCounterFunc("logtail_filched_bytes", v.Value)
+			}
+			if v, _ := m2.Get("counter_dropped_bytes").(*expvar.Int); v != nil {
+				clientmetric.NewCounterFunc("logtail_dropped_bytes", v.Value)
+			}
+			if v, _ := m2.Get("gauge_stored_bytes").(*expvar.Int); v != nil {
+				clientmetric.NewGaugeFunc("logtail_stored_bytes", v.Value)
+			}
+		}
+	}
+}

--- a/logpolicy/logtail_nometrics.go
+++ b/logpolicy/logtail_nometrics.go
@@ -1,0 +1,10 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build ts_omit_logtail || ts_omit_clientmetrics
+
+package logpolicy
+
+import "tailscale.com/logtail"
+
+func exportClientMetrics(logger *logtail.Logger) {}


### PR DESCRIPTION
This allows us to detect how often we are actually filching (and therefore whether to maintain this feature).
It also reports the storage size and amount of dropped bytes.

Updates tailscale/corp#21363