### PR TITLE
tsweb: add Unwrap to loggingResponseWriter for ResponseController

### DIFF
--- a/tsweb/tsweb.go
+++ b/tsweb/tsweb.go
@@ -687,6 +687,10 @@ func (lg loggingResponseWriter) Flush() {
 	f.Flush()
 }
 
+func (lg *loggingResponseWriter) Unwrap() http.ResponseWriter {
+	return lg.ResponseWriter
+}
+
 // errorHandler is an http.Handler that wraps a ReturnHandler to render the
 // returned errors to the client and pass them back to any logHandlers.
 type errorHandler struct {


### PR DESCRIPTION
The new http.ResponseController type added in Go 1.20: https://go.dev/doc/go1.20#http_responsecontroller requires ResponseWriters that are wrapping the original passed to ServeHTTP to implement an Unwrap method: https://pkg.go.dev/net/http#NewResponseController

With this in place, it is possible to call methods such as Flush and SetReadDeadline on a loggingResponseWriter without needing to implement them there ourselves.

Updates tailscale/corp#34763
Updates tailscale/corp#34813