### PR TITLE
.github,cmd/cigocacher: add flags --version --stats --cigocached-host

### DIFF
--- a/.github/actions/go-cache/action.sh
+++ b/.github/actions/go-cache/action.sh
@@ -7,6 +7,7 @@
 # Usage: ./action.sh
 # Inputs:
 #   URL: The cigocached server URL.
+#   HOST: The cigocached server host to dial.
 # Outputs:
 #   success: Whether cigocacher was set up successfully.
 
@@ -22,57 +23,17 @@ if [ -z "${URL:-}" ]; then
     exit 0
 fi
 
-curl_and_parse() {
-    local jq_filter="$1"
-    local step="$2"
-    shift 2
-    
-    local response
-    local curl_exit
-    response="$(curl -sSL "$@" 2>&1)" || curl_exit="$?"
-    if [ "${curl_exit:-0}" -ne "0" ]; then
-        echo "${step}: ${response}" >&2
-        return 1
-    fi
-    
-    local parsed
-    local jq_exit
-    parsed=$(echo "${response}" | jq -e -r "${jq_filter}" 2>&1) || jq_exit=$?
-    if [ "${jq_exit:-0}" -ne "0" ]; then
-        echo "${step}: Failed to parse JSON response:" >&2
-        echo "${response}" >&2
-        return 1
-    fi
-    
-    echo "${parsed}"
-    return 0
-}
+BIN_PATH="${RUNNER_TEMP:-/tmp}/cigocacher$(go env GOEXE)"
+go build -o "${BIN_PATH}" ./cmd/cigocacher
 
-JWT="$(curl_and_parse ".value" "Fetching GitHub identity JWT" \
-    -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-    "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=gocached")" || exit 0
+CIGOCACHER_TOKEN="$("${BIN_PATH}" --auth --cigocached-url "${URL}" --cigocached-host "${HOST}" )"
+if [ -z "${CIGOCACHER_TOKEN:-}" ]; then
+    echo "Failed to fetch cigocacher token, skipping cigocacher setup"
+    exit 0
+fi
 
-# cigocached serves a TLS cert with an FQDN, but DNS is based on VM name.
-HOST_AND_PORT="${URL#http*://}"
-FIRST_LABEL="${HOST_AND_PORT/.*/}"
-# Save CONNECT_TO for later steps to use.
-echo "CONNECT_TO=${HOST_AND_PORT}:${FIRST_LABEL}:" >> "${GITHUB_ENV}"
-BODY="$(jq -n --arg jwt "$JWT" '{"jwt": $jwt}')"
-CIGOCACHER_TOKEN="$(curl_and_parse ".access_token" "Exchanging token with cigocached" \
-    --connect-to "${HOST_AND_PORT}:${FIRST_LABEL}:" \
-    -H "Content-Type: application/json" \
-    "$URL/auth/exchange-token" \
-    -d "$BODY")" || exit 0
-
-# Wait until we successfully auth before building cigocacher to ensure we know
-# it's worth building.
-# TODO(tomhjp): bake cigocacher into runner image and use it for auth.
 echo "Fetched cigocacher token successfully"
 echo "::add-mask::${CIGOCACHER_TOKEN}"
-echo "CIGOCACHER_TOKEN=${CIGOCACHER_TOKEN}" >> "${GITHUB_ENV}"
 
-BIN_PATH="${RUNNER_TEMP:-/tmp}/cigocacher$(go env GOEXE)"
-
-go build -o "${BIN_PATH}" ./cmd/cigocacher
-echo "GOCACHEPROG=${BIN_PATH} --cache-dir ${CACHE_DIR} --cigocached-url ${URL} --token ${CIGOCACHER_TOKEN}" >> "${GITHUB_ENV}"
+echo "GOCACHEPROG=${BIN_PATH} --cache-dir ${CACHE_DIR} --cigocached-url ${URL} --cigocached-host ${HOST} --token ${CIGOCACHER_TOKEN}" >> "${GITHUB_ENV}"
 echo "success=true" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/go-cache/action.yml
+++ b/.github/actions/go-cache/action.yml
@@ -5,6 +5,9 @@ inputs:
   cigocached-url:
     description: URL of the cigocached server
     required: true
+  cigocached-host:
+    description: Host to dial for the cigocached server
+    required: true
   checkout-path:
     description: Path to cloned repository
     required: true
@@ -25,6 +28,7 @@ runs:
       shell: bash
       env:
         URL: ${{ inputs.cigocached-url }}
+        HOST: ${{ inputs.cigocached-host }}
         CACHE_DIR: ${{ inputs.cache-dir }}
       working-directory: ${{ inputs.checkout-path }}
       run: .github/actions/go-cache/action.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -263,6 +263,7 @@ jobs:
         checkout-path: ${{ github.workspace }}/src
         cache-dir: ${{ github.workspace }}/cigocacher
         cigocached-url: ${{ vars.CIGOCACHED_AZURE_URL }}
+        cigocached-host: ${{ vars.CIGOCACHED_AZURE_HOST }}
 
     - name: test
       if: matrix.key != 'win-bench' # skip on bench builder
@@ -278,10 +279,12 @@ jobs:
       run: go test ./... -bench . -benchtime 1x -run "^$"
 
     - name: Print stats
-      shell: bash
+      shell: pwsh
       if: steps.cigocacher-setup.outputs.success == 'true'
+      env:
+        GOCACHEPROG: ${{ env.GOCACHEPROG }}
       run: |
-        curl -sSL --connect-to "${CONNECT_TO}" -H "Authorization: Bearer ${CIGOCACHER_TOKEN}" "${{ vars.CIGOCACHED_AZURE_URL }}/session/stats" | jq .
+        Invoke-Expression "$env:GOCACHEPROG --stats" | jq .
 
   win-tool-go:
     runs-on: windows-latest

--- a/cmd/cigocacher/http.go
+++ b/cmd/cigocacher/http.go
@@ -32,12 +32,6 @@ func tryReadErrorMessage(res *http.Response) []byte {
 }
 
 func (c *gocachedClient) get(ctx context.Context, actionID string) (outputID string, resp *http.Response, err error) {
-	// TODO(tomhjp): make sure we timeout if cigocached disappears, but for some
-	// reason, this seemed to tank network performance.
-	// // Set a generous upper limit on the time we'll wait for a response. We'll
-	// // shorten this deadline later once we know the content length.
-	// ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	// defer cancel()
 	req, _ := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/action/"+actionID, nil)
 	req.Header.Set("Want-Object", "1") // opt in to single roundtrip protocol
 	if c.accessToken != "" {


### PR DESCRIPTION
Add flags:

* --cigocached-host to support alternative host resolution in other
  environments, like the corp repo.
* --stats to reduce the amount of bash script we need.
* --version to support a caching tool/cigocacher script that will
  download from GitHub releases.

Updates https://github.com/tailscale/corp/issues/10808

Change-Id: Ib2447bc5f79058669a70f2c49cef6aedd7afc049