### PR TITLE
words: 33 tails and 26 scales

### DIFF
--- a/words/scales.txt
+++ b/words/scales.txt
@@ -454,9 +454,7 @@ wyrm
 tilapia
 leaffish
 gourami
-betta
 artichoke
-goby
 fir
 larch
 lydian
@@ -475,4 +473,3 @@ smelt
 rattlesnake
 armadillo
 bonytongue
-arowana

--- a/words/tails.txt
+++ b/words/tails.txt
@@ -774,14 +774,11 @@ lemming
 worm
 hornbill
 crane
-saola
 mudskipper
 leaffish
 bagrid
 gourami
-betta
 stomatopod
-goby
 piranha
 seagull
 dinosaur
@@ -790,7 +787,6 @@ bichir
 reedfish
 tarpon
 egret
-stork
 pomfret
 snakebird
 anhinga
@@ -803,4 +799,3 @@ komodo
 rattlesnake
 softshell
 bonytongue
-arowana


### PR DESCRIPTION
Some memorable details:

- [Hornbill](https://en.wikipedia.org/wiki/Hornbill) females lay their eggs in a walled-off cavity, and fully depend on the male to feed her through a small hole for the entire period of incubation
- [Saola](https://en.wikipedia.org/wiki/Saola) are such a rare and elusive mammal, their most recent conclusive observation was a photo from 2013 (and they might've gone extinct by now...)
- [Bagrids](https://en.wikipedia.org/wiki/Bagridae), [gourami](https://en.wikipedia.org/wiki/Gouramis), [Gobies](https://en.wikipedia.org/wiki/Gobioidei), [Pomfrets](https://en.wikipedia.org/wiki/Pomfret) are generic species/genuses that I traced up from their Vietnamese friends (respectively: cá lăng, cá tai tượng, cá bống, cá chim)
- [Bichirs](https://en.wikipedia.org/wiki/Bichir) and reedfish are only found in Africa
- Stomatopod is another name for [mantis shrimps](https://en.wikipedia.org/wiki/Mantis_shrimp). I thought they should be included somewhere because they're really cool
- TIL there is/was an entire [basa fish war](https://en.wikipedia.org/wiki/Basa_(fish)#%22Catfish_war%22_in_the_U.S.) in the US between Vietnamese importers and American fishers. Well basa is a staple now I think
- No idea why egret and stork are in scales.txt, but I copied them to tails.txt
- [Anhingas/snakebirds](https://en.wikipedia.org/wiki/Anhingidae) are other words for the darters
- Colorful species of [bettas](https://en.wikipedia.org/wiki/Betta) are usually pitted against each other in fish gladiator games - a faint childhood memory
- Yes, cisco is a [fish](https://en.wikipedia.org/wiki/Cisco_(fish))
- The lydian scale is used in Toto - Africa
- [Bony-tongues/Arowana](https://en.wikipedia.org/wiki/Arowana) are also called dragonfish in SE/E Asia due to their golden scales, and are considered exotic pets