### PR TITLE
net/dns, ipn/ipnlocal, tailcfg, util/dns: add nodecap to resolve subdomains

### DIFF
--- a/ipn/ipnlocal/state_test.go
+++ b/ipn/ipnlocal/state_test.go
@@ -1300,8 +1300,9 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 				Routes:           routesWithQuad100(),
 			},
 			wantDNSCfg: &dns.Config{
-				Routes: map[dnsname.FQDN][]*dnstype.Resolver{},
-				Hosts:  hostsFor(node1),
+				Routes:         map[dnsname.FQDN][]*dnstype.Resolver{},
+				Hosts:          hostsFor(node1),
+				SubdomainHosts: map[dnsname.FQDN]bool{},
 			},
 		},
 		{
@@ -1356,8 +1357,9 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 				Routes:           routesWithQuad100(),
 			},
 			wantDNSCfg: &dns.Config{
-				Routes: map[dnsname.FQDN][]*dnstype.Resolver{},
-				Hosts:  hostsFor(node2),
+				Routes:         map[dnsname.FQDN][]*dnstype.Resolver{},
+				Hosts:          hostsFor(node2),
+				SubdomainHosts: map[dnsname.FQDN]bool{},
 			},
 		},
 		{
@@ -1404,8 +1406,9 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 				Routes:           routesWithQuad100(),
 			},
 			wantDNSCfg: &dns.Config{
-				Routes: map[dnsname.FQDN][]*dnstype.Resolver{},
-				Hosts:  hostsFor(node1),
+				Routes:         map[dnsname.FQDN][]*dnstype.Resolver{},
+				Hosts:          hostsFor(node1),
+				SubdomainHosts: map[dnsname.FQDN]bool{},
 			},
 		},
 		{
@@ -1436,8 +1439,9 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 				Routes:           routesWithQuad100(),
 			},
 			wantDNSCfg: &dns.Config{
-				Routes: map[dnsname.FQDN][]*dnstype.Resolver{},
-				Hosts:  hostsFor(node3),
+				Routes:         map[dnsname.FQDN][]*dnstype.Resolver{},
+				Hosts:          hostsFor(node3),
+				SubdomainHosts: map[dnsname.FQDN]bool{},
 			},
 		},
 		{
@@ -1500,8 +1504,9 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 				Routes:           routesWithQuad100(),
 			},
 			wantDNSCfg: &dns.Config{
-				Routes: map[dnsname.FQDN][]*dnstype.Resolver{},
-				Hosts:  hostsFor(node1),
+				Routes:         map[dnsname.FQDN][]*dnstype.Resolver{},
+				Hosts:          hostsFor(node1),
+				SubdomainHosts: map[dnsname.FQDN]bool{},
 			},
 		},
 		{
@@ -1529,8 +1534,9 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 				Routes:           routesWithQuad100(),
 			},
 			wantDNSCfg: &dns.Config{
-				Routes: map[dnsname.FQDN][]*dnstype.Resolver{},
-				Hosts:  hostsFor(node1),
+				Routes:         map[dnsname.FQDN][]*dnstype.Resolver{},
+				Hosts:          hostsFor(node1),
+				SubdomainHosts: map[dnsname.FQDN]bool{},
 			},
 		},
 		{
@@ -1560,8 +1566,9 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 				Routes:           routesWithQuad100(),
 			},
 			wantDNSCfg: &dns.Config{
-				Routes: map[dnsname.FQDN][]*dnstype.Resolver{},
-				Hosts:  hostsFor(node1),
+				Routes:         map[dnsname.FQDN][]*dnstype.Resolver{},
+				Hosts:          hostsFor(node1),
+				SubdomainHosts: map[dnsname.FQDN]bool{},
 			},
 		},
 		{

--- a/net/dns/config.go
+++ b/net/dns/config.go
@@ -48,6 +48,11 @@ type Config struct {
 	// it to resolve, you also need to add appropriate routes to
 	// Routes.
 	Hosts map[dnsname.FQDN][]netip.Addr
+	// SubdomainHosts is a set of FQDNs from Hosts that should also
+	// resolve subdomain queries to the same IPs. For example, if
+	// "node.tailnet.ts.net" is in SubdomainHosts, then queries for
+	// "anything.node.tailnet.ts.net" will resolve to node's IPs.
+	SubdomainHosts map[dnsname.FQDN]bool
 	// OnlyIPv6, if true, uses the IPv6 service IP (for MagicDNS)
 	// instead of the IPv4 version (100.100.100.100).
 	OnlyIPv6 bool

--- a/net/dns/dns_clone.go
+++ b/net/dns/dns_clone.go
@@ -6,6 +6,7 @@
 package dns
 
 import (
+	"maps"
 	"net/netip"
 
 	"tailscale.com/types/dnstype"
@@ -43,6 +44,7 @@ func (src *Config) Clone() *Config {
 			dst.Hosts[k] = append([]netip.Addr{}, src.Hosts[k]...)
 		}
 	}
+	dst.SubdomainHosts = maps.Clone(src.SubdomainHosts)
 	return dst
 }
 
@@ -52,6 +54,7 @@ var _ConfigCloneNeedsRegeneration = Config(struct {
 	Routes           map[dnsname.FQDN][]*dnstype.Resolver
 	SearchDomains    []dnsname.FQDN
 	Hosts            map[dnsname.FQDN][]netip.Addr
+	SubdomainHosts   map[dnsname.FQDN]bool
 	OnlyIPv6         bool
 }{})
 

--- a/net/dns/dns_view.go
+++ b/net/dns/dns_view.go
@@ -123,6 +123,14 @@ func (v ConfigView) Hosts() views.MapSlice[dnsname.FQDN, netip.Addr] {
 	return views.MapSliceOf(v.ж.Hosts)
 }
 
+// SubdomainHosts is a set of FQDNs from Hosts that should also
+// resolve subdomain queries to the same IPs. For example, if
+// "node.tailnet.ts.net" is in SubdomainHosts, then queries for
+// "anything.node.tailnet.ts.net" will resolve to node's IPs.
+func (v ConfigView) SubdomainHosts() views.Map[dnsname.FQDN, bool] {
+	return views.MapOf(v.ж.SubdomainHosts)
+}
+
 // OnlyIPv6, if true, uses the IPv6 service IP (for MagicDNS)
 // instead of the IPv4 version (100.100.100.100).
 func (v ConfigView) OnlyIPv6() bool           { return v.ж.OnlyIPv6 }
@@ -134,5 +142,6 @@ var _ConfigViewNeedsRegeneration = Config(struct {
 	Routes           map[dnsname.FQDN][]*dnstype.Resolver
 	SearchDomains    []dnsname.FQDN
 	Hosts            map[dnsname.FQDN][]netip.Addr
+	SubdomainHosts   map[dnsname.FQDN]bool
 	OnlyIPv6         bool
 }{})

--- a/net/dns/manager.go
+++ b/net/dns/manager.go
@@ -291,6 +291,7 @@ func (m *Manager) compileConfig(cfg Config) (rcfg resolver.Config, ocfg OSConfig
 	// authoritative suffixes, even if we don't propagate MagicDNS to
 	// the OS.
 	rcfg.Hosts = cfg.Hosts
+	rcfg.SubdomainHosts = cfg.SubdomainHosts
 	routes := map[dnsname.FQDN][]*dnstype.Resolver{} // assigned conditionally to rcfg.Routes below.
 	var propagateHostsToOS bool
 	for suffix, resolvers := range cfg.Routes {

--- a/net/dns/resolver/tsdns_test.go
+++ b/net/dns/resolver/tsdns_test.go
@@ -429,6 +429,59 @@ func TestResolveLocal(t *testing.T) {
 	}
 }
 
+func TestResolveLocalSubdomain(t *testing.T) {
+	r := newResolver(t)
+	defer r.Close()
+
+	// Configure with SubdomainHosts set for test1.ipn.dev
+	cfg := Config{
+		Hosts: map[dnsname.FQDN][]netip.Addr{
+			"test1.ipn.dev.": {testipv4},
+			"test2.ipn.dev.": {testipv6},
+		},
+		LocalDomains: []dnsname.FQDN{"ipn.dev."},
+		SubdomainHosts: map[dnsname.FQDN]bool{
+			"test1.ipn.dev.": true, // test1 allows subdomain resolution
+			// test2 does NOT allow subdomain resolution
+		},
+	}
+	r.SetConfig(cfg)
+
+	tests := []struct {
+		name  string
+		qname dnsname.FQDN
+		qtype dns.Type
+		ip    netip.Addr
+		code  dns.RCode
+	}{
+		// Exact matches still work
+		{"exact-ipv4", "test1.ipn.dev.", dns.TypeA, testipv4, dns.RCodeSuccess},
+		{"exact-ipv6", "test2.ipn.dev.", dns.TypeAAAA, testipv6, dns.RCodeSuccess},
+
+		// Subdomain of test1 resolves (test1 has SubdomainHosts set)
+		{"subdomain-ipv4", "foo.test1.ipn.dev.", dns.TypeA, testipv4, dns.RCodeSuccess},
+		{"subdomain-deep", "bar.foo.test1.ipn.dev.", dns.TypeA, testipv4, dns.RCodeSuccess}, // Multi-level subdomain
+
+		// Subdomain of test2 does NOT resolve (test2 lacks SubdomainHosts)
+		{"subdomain-no-cap", "foo.test2.ipn.dev.", dns.TypeAAAA, netip.Addr{}, dns.RCodeNameError},
+
+		// Non-existent parent still returns NXDOMAIN
+		{"subdomain-no-parent", "foo.test3.ipn.dev.", dns.TypeA, netip.Addr{}, dns.RCodeNameError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip, code := r.resolveLocal(tt.qname, tt.qtype)
+			if code != tt.code {
+				t.Errorf("code = %v; want %v", code, tt.code)
+			}
+			if ip != tt.ip {
+				t.Errorf("ip = %v; want %v", ip, tt.ip)
+			}
+		})
+	}
+}
+
 func TestResolveLocalReverse(t *testing.T) {
 	r := newResolver(t)
 	defer r.Close()

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -2707,6 +2707,12 @@ const (
 	// server to answer AAAA queries about its peers. See tailscale/tailscale#1152.
 	NodeAttrMagicDNSPeerAAAA NodeCapability = "magicdns-aaaa"
 
+	// NodeAttrDNSSubdomainResolve indicates that subdomains of this node's
+	// MagicDNS name should resolve to the same IP addresses as the node itself.
+	// For example, if node "myserver.tailnet.ts.net" has this capability,
+	// then "anything.myserver.tailnet.ts.net" will resolve to myserver's IPs.
+	NodeAttrDNSSubdomainResolve NodeCapability = "dns-subdomain-resolve"
+
 	// NodeAttrTrafficSteering configures the node to use the traffic
 	// steering subsystem for via routes. See tailscale/corp#29966.
 	NodeAttrTrafficSteering NodeCapability = "traffic-steering"

--- a/util/dnsname/dnsname.go
+++ b/util/dnsname/dnsname.go
@@ -94,6 +94,22 @@ func (f FQDN) Contains(other FQDN) bool {
 	return strings.HasSuffix(other.WithTrailingDot(), cmp)
 }
 
+// Parent returns the parent domain by stripping the first label.
+// For "foo.bar.baz.", it returns "bar.baz."
+// Returns empty FQDN for root or single-label domains.
+func (f FQDN) Parent() FQDN {
+	s := f.WithTrailingDot()
+	idx := strings.Index(s, ".")
+	if idx < 0 || idx+1 >= len(s) {
+		return ""
+	}
+	rest := s[idx+1:]
+	if rest == "." || rest == "" {
+		return ""
+	}
+	return FQDN(rest)
+}
+
 // ValidLabel reports whether label is a valid DNS label. All errors are
 // [vizerror.Error].
 func ValidLabel(label string) error {

--- a/util/dnsname/dnsname_test.go
+++ b/util/dnsname/dnsname_test.go
@@ -123,6 +123,34 @@ func TestFQDNContains(t *testing.T) {
 	}
 }
 
+func TestFQDNParent(t *testing.T) {
+	tests := []struct {
+		in   string
+		want FQDN
+	}{
+		{"", ""},
+		{".", ""},
+		{"com.", ""},
+		{"foo.com.", "com."},
+		{"www.foo.com.", "foo.com."},
+		{"a.b.c.d.", "b.c.d."},
+		{"sub.node.tailnet.ts.net.", "node.tailnet.ts.net."},
+	}
+
+	for _, test := range tests {
+		t.Run(test.in, func(t *testing.T) {
+			in, err := ToFQDN(test.in)
+			if err != nil {
+				t.Fatalf("ToFQDN(%q): %v", test.in, err)
+			}
+			got := in.Parent()
+			if got != test.want {
+				t.Errorf("ToFQDN(%q).Parent() = %q, want %q", test.in, got, test.want)
+			}
+		})
+	}
+}
+
 func TestSanitizeLabel(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
    net/dns,ipn/ipnlocal: add nodecap to resolve subdomains

    This adds a new node capability 'dns-subdomain-resolve' that signals
    that all of hosts' subdomains should resolve to the same IP address.
    It allows wildcard matching on any node marked with this capability.

    This change also includes an util/dnsname utility function that lets
    us access the parent of a full qualified domain name. MagicDNS takes
    this function and recursively searchs for a matching real node name.

    One important thing to observe is that, in this context, a subdomain
    can have multiple sub labels. This means that for a given node named
    machine, both my.machine and be.my.machine will be a positive match.

    Fixes #1196