### PR TITLE
cmd,internal,feature: add workload idenity support to gitops pusher

### DIFF
--- a/feature/identityfederation/identityfederation.go
+++ b/feature/identityfederation/identityfederation.go
@@ -24,6 +24,7 @@ import (
 func init() {
 	feature.Register("identityfederation")
 	tailscale.HookResolveAuthKeyViaWIF.Set(resolveAuthKey)
+	tailscale.HookExchangeJWTForTokenViaWIF.Set(exchangeJWTForToken)
 }
 
 // resolveAuthKey uses OIDC identity federation to exchange the provided ID token and client ID for an authkey.

--- a/internal/client/tailscale/identityfederation.go
+++ b/internal/client/tailscale/identityfederation.go
@@ -9,11 +9,19 @@ import (
 	"tailscale.com/feature"
 )
 
-// HookResolveAuthKeyViaWIF resolves to [identityfederation.ResolveAuthKey] when the
+// HookResolveAuthKeyViaWIF resolves to [identityfederation.resolveAuthKey] when the
 // corresponding feature tag is enabled in the build process.
 //
 // baseURL is the URL of the control server used for token exchange and authkey generation.
-// clientID is the federated client ID used for token exchange, the format is <tailnet ID>/<oauth client ID>
+// clientID is the federated client ID used for token exchange
 // idToken is the Identity token from the identity provider
 // tags is the list of tags to be associated with the auth key
 var HookResolveAuthKeyViaWIF feature.Hook[func(ctx context.Context, baseURL, clientID, idToken string, tags []string) (string, error)]
+
+// HookExchangeJWTForTokenViaWIF resolves to [identityfederation.exchangeJWTForToken] when the
+// corresponding feature tag is enabled in the build process.
+//
+// baseURL is the URL of the control server used for token exchange
+// clientID is the federated client ID used for token exchange
+// idToken is the Identity token from the identity provider
+var HookExchangeJWTForTokenViaWIF feature.Hook[func(ctx context.Context, baseURL, clientID, idToken string) (string, error)]


### PR DESCRIPTION
Add support for authenticating the gitops-pusher using workload identity federation.

Updates https://github.com/tailscale/corp/issues/34172