### PR TITLE
cmd/k8s-operator: fixes helm template for oauth secret volume mount (#18230)

### DIFF
--- a/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
+++ b/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
@@ -34,17 +34,11 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if or .Values.oauth.clientSecret .Values.oauth.audience }}
       volumes:
-        {{- if .Values.oauth.clientSecret }}
+        {{- if .Values.oauthSecretVolume }}
         - name: oauth
-          {{- with .Values.oauthSecretVolume }}
-          {{- toYaml . | nindent 10 }}
-          {{- else }}
-          secret:
-            secretName: operator-oauth
-          {{- end }}
-        {{- else }}
+          {{- toYaml .Values.oauthSecretVolume | nindent 10 }}
+        {{- else if .Values.oauth.audience }}
         - name: oidc-jwt
           projected:
             defaultMode: 420
@@ -53,8 +47,11 @@ spec:
                 audience: {{ .Values.oauth.audience }}
                 expirationSeconds: 3600
                 path: token
+        {{- else }}
+        - name: oauth
+          secret:
+            secretName: operator-oauth
         {{- end }}
-      {{- end }}
       containers:
         - name: operator
           {{- with .Values.operatorConfig.securityContext }}
@@ -85,7 +82,7 @@ spec:
               value: {{ .Values.loginServer }}
             - name: OPERATOR_INGRESS_CLASS_NAME
               value: {{ .Values.ingressClass.name }}
-            {{- if .Values.oauth.clientSecret }}
+            {{- if .Values.oauthSecretVolume }}
             - name: CLIENT_ID_FILE
               value: /oauth/client_id
             - name: CLIENT_SECRET_FILE
@@ -93,6 +90,11 @@ spec:
             {{- else if .Values.oauth.audience }}
             - name: CLIENT_ID
               value: {{ .Values.oauth.clientId }}
+            {{- else }}
+            - name: CLIENT_ID_FILE
+              value: /oauth/client_id
+            - name: CLIENT_SECRET_FILE
+              value: /oauth/client_secret
             {{- end }}
             {{- $proxyTag := printf ":%s" ( .Values.proxyConfig.image.tag | default .Chart.AppVersion )}}
             - name: PROXY_IMAGE
@@ -118,18 +120,20 @@ spec:
             {{- with .Values.operatorConfig.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- if or .Values.oauth.clientSecret .Values.oauth.audience }}
           volumeMounts:
-          {{- if .Values.oauth.clientSecret }}
-          - name: oauth
-            mountPath: /oauth
-            readOnly: true
-          {{- else }}
-          - name: oidc-jwt
-            mountPath: /var/run/secrets/tailscale/serviceaccount
-            readOnly: true
-          {{- end }}
-          {{- end }}
+            {{- if .Values.oauthSecretVolume }}
+            - name: oauth
+              mountPath: /oauth
+              readOnly: true
+            {{- else if .Values.oauth.audience }}
+            - name: oidc-jwt
+              mountPath: /var/run/secrets/tailscale/serviceaccount
+              readOnly: true
+            {{- else }}
+            - name: oauth
+              mountPath: /oauth
+              readOnly: true
+            {{- end }}
       {{- with .Values.operatorConfig.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/cmd/k8s-operator/deploy/chart/templates/oauth-secret.yaml
+++ b/cmd/k8s-operator/deploy/chart/templates/oauth-secret.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) Tailscale Inc & AUTHORS
 # SPDX-License-Identifier: BSD-3-Clause
 
-{{ if and .Values.oauth .Values.oauth.clientId .Values.oauth.clientSecret -}}
+{{ if and .Values.oauth .Values.oauth.clientId (not .Values.oauth.audience) -}}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
Fixes #18228

(cherry picked from commit https://github.com/tailscale/tailscale/commit/b21cba0921dfd4c8ac9cf4fa7210879d0ea7cf34)