### PR TITLE
go.toolchain.rev: update to Go 1.25.5 (#18123)

### DIFF
--- a/gokrazy/natlabapp/builddir/tailscale.com/go.mod
+++ b/gokrazy/natlabapp/builddir/tailscale.com/go.mod
@@ -1,6 +1,6 @@
 module gokrazy/build/tsapp
 
-go 1.23.1
+go 1.25.5
 
 replace tailscale.com => ../../../..
 

--- a/gokrazy/tsapp/builddir/tailscale.com/go.mod
+++ b/gokrazy/tsapp/builddir/tailscale.com/go.mod
@@ -1,6 +1,6 @@
 module gokrazy/build/tsapp
 
-go 1.23.1
+go 1.25.5
 
 replace tailscale.com => ../../../..
 


### PR DESCRIPTION
I'm not sure this is the correct action since it looks like most `gokrazy` mod files haven't been touched in a while. I think this will help my workflow (`go` updates these two mod files to be helpful, resulting in a dirty tree).

Will mark it "draft", pending guidance.

Updates #18122