### PR TITLE
types/persist: omit Persist.AttestationKey based on IsZero

### DIFF
--- a/types/persist/persist.go
+++ b/types/persist/persist.go
@@ -26,7 +26,7 @@ type Persist struct {
 	UserProfile       tailcfg.UserProfile
 	NetworkLockKey    key.NLPrivate
 	NodeID            tailcfg.StableNodeID
-	AttestationKey    key.HardwareAttestationKey `json:",omitempty"`
+	AttestationKey    key.HardwareAttestationKey `json:",omitzero"`
 
 	// DisallowedTKAStateIDs stores the tka.State.StateID values which
 	// this node will not operate network lock on. This is used to


### PR DESCRIPTION
IsZero is required by the interface, so we should use that before trying to serialize the key.

Updates #35412