### PR TITLE
cmd/containerboot: switch to tsclient QueryDNS to convert FQDN to Tailscale IPs

### DIFF
--- a/cmd/containerboot/egressservices.go
+++ b/cmd/containerboot/egressservices.go
@@ -173,7 +173,7 @@ func (ep *egressProxy) sync(ctx context.Context, n ipn.Notify) error {
 	if err != nil {
 		return fmt.Errorf("error retrieving current egress proxy status: %w", err)
 	}
-	newStatus, err := ep.syncEgressConfigs(cfgs, status, n)
+	newStatus, err := ep.syncEgressConfigs(ctx, cfgs, status, n)
 	if err != nil {
 		return fmt.Errorf("error syncing egress service configs: %w", err)
 	}
@@ -194,7 +194,7 @@ func (ep *egressProxy) addrsHaveChanged(n ipn.Notify) bool {
 // syncEgressConfigs adds and deletes firewall rules to match the desired
 // configuration. It uses the provided status to determine what is currently
 // applied and updates the status after a successful sync.
-func (ep *egressProxy) syncEgressConfigs(cfgs *egressservices.Configs, status *egressservices.Status, n ipn.Notify) (*egressservices.Status, error) {
+func (ep *egressProxy) syncEgressConfigs(ctx context.Context, cfgs *egressservices.Configs, status *egressservices.Status, n ipn.Notify) (*egressservices.Status, error) {
 	if !(wantsServicesConfigured(cfgs) || hasServicesConfigured(status)) {
 		return nil, nil
 	}
@@ -202,7 +202,6 @@ func (ep *egressProxy) syncEgressConfigs(cfgs *egressservices.Configs, status *e
 	// Delete unnecessary services.
 	if err := ep.deleteUnnecessaryServices(cfgs, status); err != nil {
 		return nil, fmt.Errorf("error deleting services: %w", err)
-
 	}
 	newStatus := &egressservices.Status{}
 	if !wantsServicesConfigured(cfgs) {
@@ -213,7 +212,7 @@ func (ep *egressProxy) syncEgressConfigs(cfgs *egressservices.Configs, status *e
 	rulesPerSvcToAdd := make(map[string][]rule, 0)
 	rulesPerSvcToDelete := make(map[string][]rule, 0)
 	for svcName, cfg := range *cfgs {
-		tailnetTargetIPs, err := ep.tailnetTargetIPsForSvc(cfg, n)
+		tailnetTargetIPs, err := ep.tailnetTargetIPsForSvc(ctx, cfg, n)
 		if err != nil {
 			return nil, fmt.Errorf("error determining tailnet target IPs: %w", err)
 		}
@@ -456,7 +455,7 @@ func (ep *egressProxy) setStatus(ctx context.Context, status *egressservices.Sta
 // FQDN, resolve the FQDN and return the resolved IPs. It checks if the
 // netfilter runner supports IPv6 NAT and skips any IPv6 addresses if it
 // doesn't.
-func (ep *egressProxy) tailnetTargetIPsForSvc(svc egressservices.Config, n ipn.Notify) (addrs []netip.Addr, err error) {
+func (ep *egressProxy) tailnetTargetIPsForSvc(ctx context.Context, svc egressservices.Config, n ipn.Notify) (addrs []netip.Addr, err error) {
 	if svc.TailnetTarget.IP != "" {
 		addr, err := netip.ParseAddr(svc.TailnetTarget.IP)
 		if err != nil {
@@ -476,11 +475,8 @@ func (ep *egressProxy) tailnetTargetIPsForSvc(svc egressservices.Config, n ipn.N
 		log.Printf("netmap is not available, unable to determine backend addresses for %s", svc.TailnetTarget.FQDN)
 		return addrs, nil
 	}
-	egressAddrs, err := resolveTailnetFQDN(n.NetMap, svc.TailnetTarget.FQDN)
-	if err != nil {
-		return nil, fmt.Errorf("error fetching backend addresses for %q: %w", svc.TailnetTarget.FQDN, err)
-	}
-	if len(egressAddrs) == 0 {
+	egressAddrs, err := resolveTailnetFQDN(ctx, ep.tsClient, svc.TailnetTarget.FQDN)
+	if err != nil || len(egressAddrs) == 0 {
 		log.Printf("tailnet target %q does not have any backend addresses, skipping", svc.TailnetTarget.FQDN)
 		return addrs, nil
 	}
@@ -532,7 +528,6 @@ func (ep *egressProxy) shouldResync(n ipn.Notify) bool {
 // ensureServiceDeleted ensures that any rules for an egress service are removed
 // from the firewall configuration.
 func ensureServiceDeleted(svcName string, svc *egressservices.ServiceStatus, nfr linuxfw.NetfilterRunner) error {
-
 	// Note that the portmap is needed for iptables based firewall only.
 	// Nftables group rules for a service in a chain, so there is no need to
 	// specify individual portmapping based rules.

--- a/cmd/containerboot/main.go
+++ b/cmd/containerboot/main.go
@@ -127,7 +127,9 @@ import (
 	"syscall"
 	"time"
 
+	"golang.org/x/net/dns/dnsmessage"
 	"golang.org/x/sys/unix"
+	"tailscale.com/client/local"
 	"tailscale.com/client/tailscale"
 	"tailscale.com/ipn"
 	kubeutils "tailscale.com/k8s-operator"
@@ -538,7 +540,7 @@ runLoop:
 					}
 				}
 				if cfg.TailnetTargetFQDN != "" {
-					egressAddrs, err := resolveTailnetFQDN(n.NetMap, cfg.TailnetTargetFQDN)
+					egressAddrs, err := resolveTailnetFQDN(ctx, client, cfg.TailnetTargetFQDN)
 					if err != nil {
 						log.Print(err.Error())
 						break
@@ -894,25 +896,73 @@ func runHTTPServer(mux *http.ServeMux, addr string) (close func() error) {
 
 // resolveTailnetFQDN resolves a tailnet FQDN to a list of IP prefixes, which
 // can be either a peer device or a Tailscale Service.
-func resolveTailnetFQDN(nm *netmap.NetworkMap, fqdn string) ([]netip.Prefix, error) {
+func resolveTailnetFQDN(ctx context.Context, c *local.Client, fqdn string) ([]netip.Prefix, error) {
 	dnsFQDN, err := dnsname.ToFQDN(fqdn)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing %q as FQDN: %w", fqdn, err)
 	}
 
-	// Check all peer devices first.
-	for _, p := range nm.Peers {
-		if strings.EqualFold(p.Name(), dnsFQDN.WithTrailingDot()) {
-			return p.Addresses().AsSlice(), nil
-		}
+	bytes, _, err := c.QueryDNS(ctx, dnsFQDN.WithTrailingDot(), "ALL")
+	if err != nil {
+		return nil, fmt.Errorf("error querying tailscale DNS: %w", err)
 	}
 
-	// If not found yet, check for a matching Tailscale Service.
-	if svcIPs := serviceIPsFromNetMap(nm, dnsFQDN); len(svcIPs) != 0 {
-		return svcIPs, nil
+	addrs, err := processDNSAnswers(bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to process answers from dns response: %w", err)
+	}
+
+	if len(addrs) > 0 {
+		return addrs, nil
 	}
 
 	return nil, fmt.Errorf("could not find Tailscale node or service %q; it either does not exist, or not reachable because of ACLs", fqdn)
+}
+
+func processDNSAnswers(bytes []byte) ([]netip.Prefix, error) {
+	var p dnsmessage.Parser
+	header, err := p.Start(bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse DNS response: %w", err)
+	}
+
+	p.SkipAllQuestions()
+	if header.RCode != dnsmessage.RCodeSuccess {
+		return nil, fmt.Errorf("no answers in response")
+	}
+
+	answers, err := p.AllAnswers()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse DNS answers: %w", err)
+	}
+
+	addrs := []netip.Prefix{}
+	for _, a := range answers {
+		switch body := a.Body.(type) {
+
+		case *dnsmessage.AResource:
+			addr := netip.AddrFrom4(body.A)
+			if !addr.IsValid() {
+				continue
+			}
+			// IPv4 uses /32
+			addrs = append(addrs, netip.PrefixFrom(addr, 32))
+
+		case *dnsmessage.AAAAResource:
+			addr := netip.AddrFrom16(body.AAAA)
+			if !addr.IsValid() {
+				continue
+			}
+			// IPv6 uses /128
+			addrs = append(addrs, netip.PrefixFrom(addr, 128))
+
+		default:
+			// Ignore other record types (CNAME, TXT, etc.)
+			continue
+		}
+	}
+
+	return addrs, nil
 }
 
 // serviceIPsFromNetMap returns all IPs of a Tailscale Service if its FQDN is


### PR DESCRIPTION
Previously, the `resolveTailnetFQDN` function was inspecting the netmap in order to determine the IP addresses to direct traffic to for a given FQDN. This led to problems where some resolution does not work if the way the netmap stores this information changes with time (see https://github.com/tailscale/tailscale/issues/16534).

This PR changes the `resolveTailnetFQDN` function to instead use localapi's DNS to perform resolution (by looking for all A and AAA records for a given fqdn).

Fixes https://github.com/tailscale/tailscale/issues/18262