### PR TITLE
cmd/k8s-operator,ipn/ipnlocal: allow opting out of ACME order 'replaces' extension

### DIFF
--- a/cmd/k8s-operator/proxygroup_specs.go
+++ b/cmd/k8s-operator/proxygroup_specs.go
@@ -182,6 +182,14 @@ func pgStatefulSet(pg *tsapi.ProxyGroup, namespace, image, tsFirewallMode string
 				Name:  "TS_EXPERIMENTAL_VERSIONED_CONFIG_DIR",
 				Value: "/etc/tsconfig/$(POD_NAME)",
 			},
+			{
+				// This ensures that cert renewals can succeed if ACME account
+				// keys have changed since issuance. We cannot guarantee or
+				// validate that the account key has not changed, see
+				// https://github.com/tailscale/tailscale/issues/18251
+				Name:  "TS_DEBUG_ACME_FORCE_RENEWAL",
+				Value: "true",
+			},
 		}
 
 		if port != nil {
@@ -346,6 +354,14 @@ func kubeAPIServerStatefulSet(pg *tsapi.ProxyGroup, namespace, image string, por
 											Namespace: namespace,
 											Name:      "$(POD_NAME)-config",
 										}.String(),
+									},
+									{
+										// This ensures that cert renewals can succeed if ACME account
+										// keys have changed since issuance. We cannot guarantee or
+										// validate that the account key has not changed, see
+										// https://github.com/tailscale/tailscale/issues/18251
+										Name:  "TS_DEBUG_ACME_FORCE_RENEWAL",
+										Value: "true",
 									},
 								}
 

--- a/cmd/k8s-operator/sts.go
+++ b/cmd/k8s-operator/sts.go
@@ -671,6 +671,14 @@ func (a *tailscaleSTSReconciler) reconcileSTS(ctx context.Context, logger *zap.S
 			Name:  "TS_EXPERIMENTAL_VERSIONED_CONFIG_DIR",
 			Value: "/etc/tsconfig/$(POD_NAME)",
 		},
+		corev1.EnvVar{
+			// This ensures that cert renewals can succeed if ACME account
+			// keys have changed since issuance. We cannot guarantee or
+			// validate that the account key has not changed, see
+			// https://github.com/tailscale/tailscale/issues/18251
+			Name:  "TS_DEBUG_ACME_FORCE_RENEWAL",
+			Value: "true",
+		},
 	)
 
 	if sts.ForwardClusterTrafficViaL7IngressProxy {

--- a/cmd/k8s-operator/testutils_test.go
+++ b/cmd/k8s-operator/testutils_test.go
@@ -92,6 +92,7 @@ func expectedSTS(t *testing.T, cl client.Client, opts configOpts) *appsv1.Statef
 			{Name: "POD_UID", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{APIVersion: "", FieldPath: "metadata.uid"}, ResourceFieldRef: nil, ConfigMapKeyRef: nil, SecretKeyRef: nil}},
 			{Name: "TS_KUBE_SECRET", Value: "$(POD_NAME)"},
 			{Name: "TS_EXPERIMENTAL_VERSIONED_CONFIG_DIR", Value: "/etc/tsconfig/$(POD_NAME)"},
+			{Name: "TS_DEBUG_ACME_FORCE_RENEWAL", Value: "true"},
 		},
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: ptr.To(true),
@@ -287,6 +288,7 @@ func expectedSTSUserspace(t *testing.T, cl client.Client, opts configOpts) *apps
 			{Name: "POD_UID", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{APIVersion: "", FieldPath: "metadata.uid"}, ResourceFieldRef: nil, ConfigMapKeyRef: nil, SecretKeyRef: nil}},
 			{Name: "TS_KUBE_SECRET", Value: "$(POD_NAME)"},
 			{Name: "TS_EXPERIMENTAL_VERSIONED_CONFIG_DIR", Value: "/etc/tsconfig/$(POD_NAME)"},
+			{Name: "TS_DEBUG_ACME_FORCE_RENEWAL", Value: "true"},
 			{Name: "TS_SERVE_CONFIG", Value: "/etc/tailscaled/$(POD_NAME)/serve-config"},
 			{Name: "TS_INTERNAL_APP", Value: opts.app},
 		},

--- a/ipn/ipnlocal/cert.go
+++ b/ipn/ipnlocal/cert.go
@@ -551,8 +551,11 @@ var getCertPEM = func(ctx context.Context, b *LocalBackend, cs certStore, logf l
 	// If we have a previous cert, include it in the order. Assuming we're
 	// within the ARI renewal window this should exclude us from LE rate
 	// limits.
+	// Note that this order extension will fail renewals if the ACME account key has changed
+	// since the last issuance, see
+	// https://github.com/tailscale/tailscale/issues/18251
 	var opts []acme.OrderOption
-	if previous != nil {
+	if previous != nil && !envknob.Bool("TS_DEBUG_ACME_FORCE_RENEWAL") {
 		prevCrt, err := previous.parseCertificate()
 		if err == nil {
 			opts = append(opts, acme.WithOrderReplacesCert(prevCrt))


### PR DESCRIPTION
See #18251 for lengthy context.

This PR:

- adds a new config knob `TS_DEBUG_ACME_FORCE_RENEWAL` that, when set to "true", disables using the [ARI Orders 'replaces' extension](https://datatracker.ietf.org/doc/rfc9773/)
- enables the new config knob for all Kubernetes operator proxies

This is done to prevent a situation where, after account key deletion and recreation, no previously issued certs can be renewed - this edge case can be quite easily hit in Kubernetes operator setups where the account keys and certs are stored in different Kubernetes Secrets whose lifecycle is managed by separate flows.

This does mean that Kubernetes proxy cert renewals won't count as [ARI renewals](https://datatracker.ietf.org/doc/rfc9773/), however that should not, in practice, make a difference to the scale at which users today can set up things. The rate limits for certs that we see our users hit are [more than 50 unique certs per tailnet DNS name per week](https://letsencrypt.org/docs/rate-limits/#new-certificates-per-registered-domain), [more than 5 for the same DNS name per week](https://letsencrypt.org/docs/rate-limits/#new-certificates-per-exact-set-of-identifiers). Although ARI makes _renewal_ orders, made within the set renewal window, exempt from these rate limits, folks would need to carefully time their initial  deployments, to ensure that the initial cert issuance does not hit rate limits. I don't think this is feasible for our Kubernetes users' setups, usually cluster apps are expected to be applied at once and our API does not really encourage or make it easy for folks to do something like that (we don't make it easy to share account keys across clusters, for example).

I think long term, we should look for a better solution:

- maybe there is some way how we can check locally if an existing cert is for a given account
- (probably not good enough?) we could just compare creation timestamps to see whether account key is likely newer than a cert

If we made the 'replaces' extension safer to use, we could then opt back to use it in the operator and also make it so that the ACME account key is less likely to get deleted, for example, we could have one that's shared across all ProxyGroups (will also need to take into account work on multi-tailnet cluster support)

However, for now, we already have users who are unable to renew, so we need a quick solution.

cc @awly 


Updates #18251