### PR TITLE
net/udprelay: remove tailscaled_peer_relay_endpoints_total

### DIFF
--- a/net/udprelay/metrics_test.go
+++ b/net/udprelay/metrics_test.go
@@ -22,19 +22,10 @@ func TestMetrics(t *testing.T) {
 	want := []string{
 		"tailscaled_peer_relay_forwarded_packets_total",
 		"tailscaled_peer_relay_forwarded_bytes_total",
-		"tailscaled_peer_relay_endpoints_total",
 	}
 	slices.Sort(have)
 	slices.Sort(want)
 	c.Assert(have, qt.CmpEquals(), want)
-
-	// Validate addEndpoints.
-	m.addEndpoints(1)
-	c.Assert(m.endpoints.Value(), qt.Equals, int64(1))
-	c.Assert(cMetricEndpoints.Value(), qt.Equals, int64(1))
-	m.addEndpoints(-1)
-	c.Assert(m.endpoints.Value(), qt.Equals, int64(0))
-	c.Assert(cMetricEndpoints.Value(), qt.Equals, int64(0))
 
 	// Validate countForwarded.
 	m.countForwarded(true, true, 1, 1)

--- a/net/udprelay/server.go
+++ b/net/udprelay/server.go
@@ -673,7 +673,6 @@ func (s *Server) endpointGCLoop() {
 		defer s.mu.Unlock()
 		for k, v := range s.serverEndpointByDisco {
 			if v.isExpired(now, s.bindLifetime, s.steadyStateLifetime) {
-				s.metrics.addEndpoints(-1)
 				delete(s.serverEndpointByDisco, k)
 				s.serverEndpointByVNI.Delete(v.vni)
 			}
@@ -969,7 +968,6 @@ func (s *Server) AllocateEndpoint(discoA, discoB key.DiscoPublic) (endpoint.Serv
 	s.serverEndpointByVNI.Store(e.vni, e)
 
 	s.logf("allocated endpoint vni=%d lamportID=%d disco[0]=%v disco[1]=%v", e.vni, e.lamportID, pair.Get()[0].ShortString(), pair.Get()[1].ShortString())
-	s.metrics.addEndpoints(1)
 	return endpoint.ServerEndpoint{
 		ServerDisco:         s.discoPublic,
 		ClientDisco:         pair.Get(),


### PR DESCRIPTION
This gauge will be reworked to include endpoint state in future.

Updates https://github.com/tailscale/corp/issues/30820

Change-Id: I66f349d89422b46eec4ecbaf1a99ad656c7301f9
Signed-off-by: Alex Valiushko <alexvaliushko@tailscale.com>