### PR TITLE
ipn/ipnauth, safesocket: defer named pipe client's token retrieval util ipnserver needs it

### DIFF
--- a/safesocket/pipe_windows_test.go
+++ b/safesocket/pipe_windows_test.go
@@ -58,9 +58,14 @@ func TestExpectedWindowsTypes(t *testing.T) {
 		if wcc.winioPipeConn.Fd() == 0 {
 			t.Error("accepted conn had unexpected zero fd")
 		}
-		if wcc.token == 0 {
+		tok, err := wcc.Token()
+		if err != nil {
+			t.Errorf("failed to retrieve client token: %v", err)
+		}
+		if tok == 0 {
 			t.Error("accepted conn had unexpected zero token")
 		}
+		tok.Close()
 
 		s.Write([]byte("hello"))
 


### PR DESCRIPTION
An error returned by `net.Listener.Accept()` causes the owning `http.Server` to shut down. With the deprecation of `net.Error.Temporary()`, there's no way for the `http.Server` to test whether the returned error is temporary / retryable or not (see golang/go#66252).

Because of that, errors returned by `(*safesocket.winIOPipeListener).Accept()` cause the LocalAPI server (aka `ipnserver.Server`) to shut down, and `tailscaled` process to exit.

While this might be acceptable in the case of non-recoverable errors, such as programmer errors, we shouldn't shut down the entire `tailscaled` process for client- or connection-specific errors, such as when we couldn't obtain the client's access token because the client attempts to connect at the Anonymous impersonation level. Instead, the LocalAPI server should gracefully handle these errors by denying access and returning a 401 Unauthorized to the client.

In tailscale/tscert#15, we fixed a known bug where Caddy and other apps using `tscert` would attempt to connect at the Anonymous impersonation level and fail. However, we should also fix this on the `tailscaled` side to prevent a potential DoS, where a local app could deliberately open the Tailscale LocalAPI named pipe at the Anonymous impersonation level and cause `tailscaled` to exit.

In this PR, we defer token retrieval until `(*WindowsClientConn).Token()` is called and propagate the returned token or error via `ipnauth.GetConnIdentity()` to `ipnserver`, which handles it the same way as other `ipnauth`-related errors.

Fixes #18212
Fixes tailscale/tscert#13