### PR TITLE
cmd/tailscale/cli: document why there's no --force-reauth on login

### DIFF
--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -137,6 +137,9 @@ func newUpFlagSet(goos string, upArgs *upArgsT, cmd string) *flag.FlagSet {
 		// Some flags are only for "up", not "login".
 		upf.BoolVar(&upArgs.json, "json", false, "output in JSON format (WARNING: format subject to change)")
 		upf.BoolVar(&upArgs.reset, "reset", false, "reset unspecified settings to their default values")
+
+		// There's no --force-reauth flag on "login" because all login commands
+		// trigger a reauth.
 		upf.BoolVar(&upArgs.forceReauth, "force-reauth", false, "force reauthentication (WARNING: this may bring down the Tailscale connection and thus should not be done remotely over SSH or RDP)")
 		registerAcceptRiskFlag(upf, &upArgs.acceptedRisks)
 	}


### PR DESCRIPTION
I wasn't sure why this was, so let's write it down for the next person.

Slack discussion: https://tailscale.slack.com/archives/C07KTJ5H5DJ/p1766400646518939