### PR TITLE
tsconsensus: add unit tests for helper functions

### DIFF
--- a/tsconsensus/http_test.go
+++ b/tsconsensus/http_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package tsconsensus
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// errorReader is a reader that returns an error after reading n bytes
+type errorReader struct {
+	n    int
+	err  error
+	read int
+}
+
+func (er *errorReader) Read(p []byte) (n int, err error) {
+	if er.read >= er.n {
+		return 0, er.err
+	}
+	toRead := er.n - er.read
+	if toRead > len(p) {
+		toRead = len(p)
+	}
+	er.read += toRead
+	return toRead, nil
+}
+
+func TestReadAllMaxBytes(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   io.Reader
+		wantLen int
+		wantErr bool
+	}{
+		{
+			name:    "small data",
+			input:   strings.NewReader("hello world"),
+			wantLen: 11,
+			wantErr: false,
+		},
+		{
+			name:    "exactly at limit",
+			input:   bytes.NewReader(make([]byte, maxBodyBytes)),
+			wantLen: maxBodyBytes,
+			wantErr: false,
+		},
+		{
+			name:    "over limit - should truncate to maxBodyBytes+1",
+			input:   bytes.NewReader(make([]byte, maxBodyBytes+100)),
+			wantLen: maxBodyBytes + 1,
+			wantErr: false,
+		},
+		{
+			name:    "reader error",
+			input:   &errorReader{n: 5, err: errors.New("read error")},
+			wantLen: 5,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := readAllMaxBytes(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("readAllMaxBytes() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if len(got) != tt.wantLen {
+				t.Fatalf("readAllMaxBytes() got %d bytes, want %d", len(got), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestCommandClientURL(t *testing.T) {
+	tests := []struct {
+		name string
+		port uint16
+		host string
+		path string
+		want string
+	}{
+		{
+			name: "basic url",
+			port: 6271,
+			host: "192.168.1.1",
+			path: "/join",
+			want: "http://192.168.1.1:6271/join",
+		},
+		{
+			name: "with ipv6",
+			port: 8080,
+			host: "fd7a:115c:a1e0::1",
+			path: "/executeCommand",
+			want: "http://fd7a:115c:a1e0::1:8080/executeCommand",
+		},
+		{
+			name: "empty path",
+			port: 3000,
+			host: "localhost",
+			path: "",
+			want: "http://localhost:3000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cc := &commandClient{port: tt.port}
+			got := cc.url(tt.host, tt.path)
+			if got != tt.want {
+				t.Fatalf("url() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/tsconsensus/tsconsensus_test.go
+++ b/tsconsensus/tsconsensus_test.go
@@ -762,3 +762,93 @@ func TestFollowOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// Unit tests (non-integration)
+
+func TestAddrFromServerAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "valid ipv4 with port",
+			input:   "192.168.1.1:8080",
+			want:    "192.168.1.1",
+			wantErr: false,
+		},
+		{
+			name:    "valid ipv6 with port",
+			input:   "[fd7a:115c:a1e0::1]:8080",
+			want:    "fd7a:115c:a1e0::1",
+			wantErr: false,
+		},
+		{
+			name:    "invalid format - no port",
+			input:   "192.168.1.1",
+			wantErr: true,
+		},
+		{
+			name:    "invalid format - not an address",
+			input:   "not-an-address:8080",
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := addrFromServerAddress(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("addrFromServerAddress() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got.String() != tt.want {
+				t.Fatalf("addrFromServerAddress() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRaftAddr(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		port uint16
+		want string
+	}{
+		{
+			name: "ipv4 address",
+			host: "100.64.0.1",
+			port: 6270,
+			want: "100.64.0.1:6270",
+		},
+		{
+			name: "ipv6 address",
+			host: "fd7a:115c:a1e0::1",
+			port: 8080,
+			want: "[fd7a:115c:a1e0::1]:8080",
+		},
+		{
+			name: "default port",
+			host: "192.168.1.1",
+			port: DefaultConfig().RaftPort,
+			want: "192.168.1.1:6270",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{RaftPort: tt.port}
+			addr := netip.MustParseAddr(tt.host)
+			got := raftAddr(addr, cfg)
+			if got != tt.want {
+				t.Fatalf("raftAddr() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds non-integration unit tests to address issue #18022.

The existing tests are integration tests that spin up full tsnet.Server instances and occasionally timeout in CI. These new unit tests are fast (<10ms) and test isolated functions:

- readAllMaxBytes: tests size limiting behavior
- commandClient.url: tests URL construction
- addrFromServerAddress: tests address parsing
- raftAddr: tests raft address formatting

These tests provide baseline coverage to prevent bitrot when integration tests fail to run.

Fixes #18022