### PR TITLE
net/portmapper: Stop replacing the internal port with the upnp external port

### DIFF
--- a/net/portmapper/upnp.go
+++ b/net/portmapper/upnp.go
@@ -540,6 +540,7 @@ func (c *Client) getUPnPPortMapping(
 		c.mu.Lock()
 		defer c.mu.Unlock()
 		c.mapping = upnp
+		c.localPort = internal.Port()
 		return upnp.external, true
 	}
 


### PR DESCRIPTION
This causes the UPnP mapping to break in the next recreation of the mapping.

The issue is described in more details on the bug I reported, but I'm pretty sure this line is the culprit.

This line seems like a mistake, it's replacing the `localPort` property of the client, which should be a port in the local machine, with the port returned by `UPnP`, which is a port opened on the public IP. I couldn't see a reason why this would be here.

I recompiled `tailscaled` and I've been running one of my machines with this modified version for the past few days. It has solved the issue for me, and it hasn't given me any other problems.

Fixes #18348