### PR TITLE
net/dns: skip DNS base config when using userspace networking

### DIFF
--- a/net/dns/manager.go
+++ b/net/dns/manager.go
@@ -388,9 +388,9 @@ func (m *Manager) compileConfig(cfg Config) (rcfg resolver.Config, ocfg OSConfig
 		cfg, err := m.os.GetBaseConfig()
 		if err == nil {
 			baseCfg = &cfg
-		} else if isApple && err == ErrGetBaseConfigNotSupported {
-			// This is currently (2022-10-13) expected on certain iOS and macOS
-			// builds.
+		} else if (isApple || isNoopManager(m.os)) && err == ErrGetBaseConfigNotSupported {
+			// Expected when using noopManager (userspace networking) or on
+			// certain iOS/macOS builds. Continue without base config.
 		} else {
 			m.health.SetUnhealthy(osConfigurationReadWarnable, health.Args{health.ArgError: err.Error()})
 			return resolver.Config{}, OSConfig{}, err

--- a/net/dns/noop.go
+++ b/net/dns/noop.go
@@ -15,3 +15,8 @@ func (m noopManager) GetBaseConfig() (OSConfig, error) {
 func NewNoopManager() (noopManager, error) {
 	return noopManager{}, nil
 }
+
+func isNoopManager(c OSConfigurator) bool {
+	_, ok := c.(noopManager)
+	return ok
+}


### PR DESCRIPTION
    When tailscaled gets started with userspace networking, it won't
    modify your system's network configuration. For this, it creates
    a noopManager for DNS management. noopManager correctly observes
    that there's no real OS DNS to send queries to. This leads to we
    completely dropping any DNS internal resolution from `dns query`

    This change alters this so that even without a base config we'll
    still allow the internal resolver to handle internal DNS queries

Fixes #18354