### PR TITLE
net/udprelay: apply netns Control func to server socket(s)

### DIFF
--- a/net/udprelay/server_linux.go
+++ b/net/udprelay/server_linux.go
@@ -12,11 +12,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func listenControl(_ string, _ string, c syscall.RawConn) error {
+func trySetReusePort(_ string, _ string, c syscall.RawConn) {
 	c.Control(func(fd uintptr) {
 		unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
 	})
-	return nil
 }
 
 func isReusableSocket(uc *net.UDPConn) bool {

--- a/net/udprelay/server_notlinux.go
+++ b/net/udprelay/server_notlinux.go
@@ -10,9 +10,7 @@ import (
 	"syscall"
 )
 
-func listenControl(_ string, _ string, _ syscall.RawConn) error {
-	return nil
-}
+func trySetReusePort(_ string, _ string, _ syscall.RawConn) {}
 
 func isReusableSocket(*net.UDPConn) bool {
 	return false


### PR DESCRIPTION
To prevent peer relay servers from sending packets *over* Tailscale.

Updates tailscale/corp#35651