### PR TITLE
cmd/k8s-operator,k8s-operator: Ensure that Recorder replicas default to 1

### DIFF
--- a/cmd/k8s-operator/deploy/crds/tailscale.com_recorders.yaml
+++ b/cmd/k8s-operator/deploy/crds/tailscale.com_recorders.yaml
@@ -72,6 +72,7 @@ spec:
                   description: Replicas specifies how many instances of tsrecorder to run. Defaults to 1.
                   type: integer
                   format: int32
+                  default: 1
                   minimum: 0
                 statefulSet:
                   description: |-

--- a/cmd/k8s-operator/deploy/manifests/operator.yaml
+++ b/cmd/k8s-operator/deploy/manifests/operator.yaml
@@ -3355,6 +3355,7 @@ spec:
                                     Required if S3 storage is not set up, to ensure that recordings are accessible.
                                 type: boolean
                             replicas:
+                                default: 1
                                 description: Replicas specifies how many instances of tsrecorder to run. Defaults to 1.
                                 format: int32
                                 minimum: 0

--- a/k8s-operator/api.md
+++ b/k8s-operator/api.md
@@ -904,7 +904,7 @@ _Appears in:_
 | `tags` _[Tags](#tags)_ | Tags that the Tailscale device will be tagged with. Defaults to [tag:k8s].<br />If you specify custom tags here, make sure you also make the operator<br />an owner of these tags.<br />See  https://tailscale.com/kb/1236/kubernetes-operator/#setting-up-the-kubernetes-operator.<br />Tags cannot be changed once a Recorder node has been created.<br />Tag values must be in form ^tag:[a-zA-Z][a-zA-Z0-9-]*$. |  | Pattern: `^tag:[a-zA-Z][a-zA-Z0-9-]*$` <br />Type: string <br /> |
 | `enableUI` _boolean_ | Set to true to enable the Recorder UI. The UI lists and plays recorded sessions.<br />The UI will be served at <MagicDNS name of the recorder>:443. Defaults to false.<br />Corresponds to --ui tsrecorder flag https://tailscale.com/kb/1246/tailscale-ssh-session-recording#deploy-a-recorder-node.<br />Required if S3 storage is not set up, to ensure that recordings are accessible. |  |  |
 | `storage` _[Storage](#storage)_ | Configure where to store session recordings. By default, recordings will<br />be stored in a local ephemeral volume, and will not be persisted past the<br />lifetime of a specific pod. |  |  |
-| `replicas` _integer_ | Replicas specifies how many instances of tsrecorder to run. Defaults to 1. |  | Minimum: 0 <br /> |
+| `replicas` _integer_ | Replicas specifies how many instances of tsrecorder to run. Defaults to 1. | 1 | Minimum: 0 <br /> |
 | `tailnet` _string_ | Tailnet specifies the tailnet this Recorder should join. If blank, the default tailnet is used. When set, this<br />name must match that of a valid Tailnet resource. This field is immutable and cannot be changed once set. |  |  |
 
 

--- a/k8s-operator/apis/v1alpha1/types_recorder.go
+++ b/k8s-operator/apis/v1alpha1/types_recorder.go
@@ -80,6 +80,7 @@ type RecorderSpec struct {
 	// Replicas specifies how many instances of tsrecorder to run. Defaults to 1.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:default=1
 	Replicas *int32 `json:"replicas,omitzero"`
 
 	// Tailnet specifies the tailnet this Recorder should join. If blank, the default tailnet is used. When set, this


### PR DESCRIPTION
When creating a recorder resource with reasonably sound defaults on the operator:

```
apiVersion: tailscale.com/v1alpha1
kind: Recorder
metadata:
  name: recorder
spec:
  enableUI: true
  tags:
    - "tag:k8s-recorder"
```

I was met with the following response by the API Server:

```
The Recorder "recorder" is invalid: spec: Invalid value: "object": no such key: replicas evaluating rule: S3 storage must be used when deploying multiple Recorder replicas
```

This is because we don't explicitly set a default on the `spec.replicas` field, which leads to a [CEL rule](https://github.com/tailscale/tailscale/blob/main/k8s-operator/apis/v1alpha1/types_recorder.go#L48) getting triggered.

To be safe, we should set replicas to 1.

Updates #17965