### PR TITLE
ipn/store/kubestore: don't load write replica certs in memory

### DIFF
--- a/ipn/store/kubestore/store_kube_test.go
+++ b/ipn/store/kubestore/store_kube_test.go
@@ -688,7 +688,7 @@ func TestNewWithClient(t *testing.T) {
 			},
 		},
 		{
-			name:     "load_select_certs_in_read_write_mode",
+			name:     "do_not_load_certs_in_read_write_mode",
 			certMode: "rw",
 			stateSecretContents: map[string][]byte{
 				"foo": []byte("bar"),
@@ -704,11 +704,7 @@ func TestNewWithClient(t *testing.T) {
 				}, "4"),
 			},
 			wantMemoryStoreContents: map[ipn.StateKey][]byte{
-				"foo":                        []byte("bar"),
-				"app1.tailnetxyz.ts.net.crt": []byte(testCert + "1"),
-				"app1.tailnetxyz.ts.net.key": []byte(testKey + "1"),
-				"app2.tailnetxyz.ts.net.crt": []byte(testCert + "2"),
-				"app2.tailnetxyz.ts.net.key": []byte(testKey + "2"),
+				"foo": []byte("bar"),
 			},
 		},
 		{


### PR DESCRIPTION
Fixes a bug where, for kube HA proxies, TLS certs for the replica responsible for cert issuance where loaded in memory on startup, although the in-memory store was not updated after renewal (to avoid failing re-issuance for re-created Ingresses). Now the 'write' replica always reads certs from the kube Secret.

Updates tailscale/tailscale#18394