### PR TITLE
.github/workflows: fix timeouts by caching packages for golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -29,10 +29,10 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
           go-version-file: go.mod
-          cache: false
+          cache: true
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0


### PR DESCRIPTION
Recently, the golangci-lint workflow has been taking longer and longer to complete, causing it to timeout after the default of 5 minutes.

    Running error: context loading failed: failed to load packages: failed to load packages: failed to load with go/packages: context deadline exceeded
    Timeout exceeded: try increasing it by passing --timeout option

This PR upgrades actions/setup-go to version 6, the latest, and enables caching for Go modules and build outputs. This should speed up linting because most packages won’t have to be downloaded over and over again.

Fixes #18366