### PR TITLE
cmd/k8s-operator: display Tailnet status with kubectl

### DIFF
--- a/cmd/k8s-operator/deploy/crds/tailscale.com_tailnets.yaml
+++ b/cmd/k8s-operator/deploy/crds/tailscale.com_tailnets.yaml
@@ -19,6 +19,10 @@ spec:
         - jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
+        - description: Status of the deployed Tailnet resources.
+          jsonPath: .status.conditions[?(@.type == "TailnetReady")].reason
+          name: Status
+          type: string
       name: v1alpha1
       schema:
         openAPIV3Schema:

--- a/cmd/k8s-operator/deploy/manifests/operator.yaml
+++ b/cmd/k8s-operator/deploy/manifests/operator.yaml
@@ -5122,6 +5122,10 @@ spec:
             - jsonPath: .metadata.creationTimestamp
               name: Age
               type: date
+            - description: Status of the deployed Tailnet resources.
+              jsonPath: .status.conditions[?(@.type == "TailnetReady")].reason
+              name: Status
+              type: string
           name: v1alpha1
           schema:
             openAPIV3Schema:

--- a/k8s-operator/apis/v1alpha1/types_tailnet.go
+++ b/k8s-operator/apis/v1alpha1/types_tailnet.go
@@ -18,6 +18,7 @@ var TailnetKind = "Tailnet"
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,shortName=tn
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=`.status.conditions[?(@.type == "TailnetReady")].reason`,description="Status of the deployed Tailnet resources."
 
 type Tailnet struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
This commit modifies the `Tailnet` CRD to display its status when it is queried using `kubectl get tailnets` and associated commands. This allows users to see the status of their tailnets at a glance.

Updates: https://github.com/tailscale/corp/issues/34561