### PR TITLE
.github/workflows: double the timeout for golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -35,9 +35,13 @@ jobs:
           cache: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.4.0
 
           # Show only new issues if it's a pull request.
           only-new-issues: true
+
+          # Loading packages with a cold cache takes a while:
+          args: --timeout=10m
+          


### PR DESCRIPTION
Recently, the golangci-lint workflow has been taking longer and longer to complete, causing it to timeout after the default of 5 minutes.

    Running error: context loading failed: failed to load packages: failed to load packages: failed to load with go/packages: context deadline exceeded
    Timeout exceeded: try increasing it by passing --timeout option

Although PR #18398 enabled the Go module cache, bootstrapping with a cold cache still takes too long.

<img width="709" height="573" alt="Failed golangci-lint run doesn’t update module cache" src="https://github.com/user-attachments/assets/8795777d-0804-43b1-969f-105c3cffbc87" />

This PR doubles the default 5 minute timeout for golangci-lint to 10 minutes so that golangci-lint can finish downloading all of its dependencies.

Note that this doesn’t affect the 5 minute timeout configured in .golangci.yml, since running golangci-lint on your local instance should still be plenty fast.

Fixes #18366