### PR TITLE
.github/actions/go-cache: build cigocacher using remote path

### DIFF
--- a/.github/actions/go-cache/action.yml
+++ b/.github/actions/go-cache/action.yml
@@ -31,4 +31,5 @@ runs:
         HOST: ${{ inputs.cigocached-host }}
         CACHE_DIR: ${{ inputs.cache-dir }}
       working-directory: ${{ inputs.checkout-path }}
-      run: .github/actions/go-cache/action.sh
+      # https://github.com/orgs/community/discussions/25910
+      run: $GITHUB_ACTION_PATH/action.sh


### PR DESCRIPTION
If local tailscale/tailscale checkout is not available, build cigocacher using remote path.

I have tested that this works as I want to with our internal repo.

I am not entirely sure this is the best approach. Maybe we could bake cigocher into the images - but I already have to, when using the gocacher action, reference a specific commit SHA from this repo, so then making a change to both cigocacher and the action would require both rebuilding runner images and updating pipelines.

Another alternative could be to [publish this action as a docker image](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsuses) and bake in cigocacher there. We could then have a simple workflow that publishes those images when either cigocacher or any of the actions files change. Not sure if that would make cigocacher available to other steps in the job though.

For now, I'm just allowing to run `go build` with remote path.

Updates tailscale/corp#32493