### PR TITLE
tool/gocross: update gocross-wrapper.ps1 to use absolute path for res…

### DIFF
--- a/tool/gocross/gocross-wrapper.ps1
+++ b/tool/gocross/gocross-wrapper.ps1
@@ -114,7 +114,12 @@ $bootstrapScriptBlock = {
                     New-Item -Force -Path $toolchain -ItemType Directory | Out-Null
                     Start-ChildScope -ScriptBlock {
                         Set-Location -LiteralPath $toolchain
-                        tar --strip-components=1 -xf "$toolchain.tar.gz"
+
+                        # Using an absolute path to the tar that ships with Windows
+                        # to avoid conflicts with others (eg msys2).
+                        $system32 = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::System)
+                        $tar = Join-Path $system32 'tar.exe' -Resolve
+                        & $tar --strip-components=1 -xf "$toolchain.tar.gz"
                         if ($LASTEXITCODE -ne 0) {
                             throw "tar failed with exit code $LASTEXITCODE"
                         }


### PR DESCRIPTION
…olving tar

gocross-wrapper.ps1 is written to use the version of tar that ships with Windows; we want to avoid conflicts with any other tar on the PATH, such ones installed by MSYS and/or Cygwin.

Updates https://github.com/tailscale/corp/issues/29940