### PR TITLE
ipn,client/systray: add peer online/offline status notifications

### DIFF
--- a/cmd/tailscale/cli/set.go
+++ b/cmd/tailscale/cli/set.go
@@ -69,6 +69,7 @@ type setArgsT struct {
 	netfilterMode              string
 	relayServerPort            string
 	relayServerStaticEndpoints string
+	notifyPeerStatus           bool
 }
 
 func newSetFlagSet(goos string, setArgs *setArgsT) *flag.FlagSet {
@@ -92,6 +93,7 @@ func newSetFlagSet(goos string, setArgs *setArgsT) *flag.FlagSet {
 	setf.BoolVar(&setArgs.sync, "sync", false, hidden+"actively sync configuration from the control plane (set to false only for network failure testing)")
 	setf.StringVar(&setArgs.relayServerPort, "relay-server-port", "", "UDP port number (0 will pick a random unused port) for the relay server to bind to, on all interfaces, or empty string to disable relay server functionality")
 	setf.StringVar(&setArgs.relayServerStaticEndpoints, "relay-server-static-endpoints", "", "static IP:port endpoints to advertise as candidates for relay connections (comma-separated, e.g. \"[2001:db8::1]:40000,192.0.2.1:40000\") or empty string to not advertise any static endpoints")
+	setf.BoolVar(&setArgs.notifyPeerStatus, "notify-peer-status", false, "send desktop notifications when a peer's online status changes")
 
 	ffcomplete.Flag(setf, "exit-node", func(args []string) ([]string, ffcomplete.ShellCompDirective, error) {
 		st, err := localClient.Status(context.Background())
@@ -165,6 +167,7 @@ func runSet(ctx context.Context, args []string) (retErr error) {
 			},
 			PostureChecking:     setArgs.reportPosture,
 			NoStatefulFiltering: opt.NewBool(!setArgs.statefulFiltering),
+			NotifyPeerStatus:    setArgs.notifyPeerStatus,
 		},
 	}
 

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -885,6 +885,7 @@ func init() {
 	addPrefFlagMapping("relay-server-port", "RelayServerPort")
 	addPrefFlagMapping("sync", "Sync")
 	addPrefFlagMapping("relay-server-static-endpoints", "RelayServerStaticEndpoints")
+	addPrefFlagMapping("notify-peer-status", "NotifyPeerStatus")
 }
 
 func addPrefFlagMapping(flagName string, prefNames ...string) {

--- a/ipn/backend.go
+++ b/ipn/backend.go
@@ -85,6 +85,8 @@ const (
 	NotifyHealthActions NotifyWatchOpt = 1 << 9 // if set, include PrimaryActions in health.State. Otherwise append the action URL to the text
 
 	NotifyInitialSuggestedExitNode NotifyWatchOpt = 1 << 10 // if set, the first Notify message (sent immediately) will contain the current SuggestedExitNode if available
+
+	NotifyPeerOnlineStatusChanges NotifyWatchOpt = 1 << 11 // if set, send notifications when peer online status changes
 )
 
 // Notify is a communication from a backend (e.g. tailscaled) to a frontend
@@ -161,6 +163,11 @@ type Notify struct {
 	// be the best exit node for the current network conditions.
 	SuggestedExitNode *tailcfg.StableNodeID `json:",omitzero"`
 
+	// PeerOnlineStatusChanges, if non-nil, contains changes in peer online status.
+	// This is sent when a peer's online status changes (e.g., device goes offline
+	// or comes back online). The map is keyed by peer node public key.
+	PeerOnlineStatusChanges map[key.NodePublic]*ipnstate.PeerOnlineStatusChange `json:",omitzero"`
+
 	// type is mirrored in xcode/IPN/Core/LocalAPI/Model/LocalAPIModel.swift
 }
 
@@ -202,6 +209,10 @@ func (n Notify) String() string {
 	}
 	if n.SuggestedExitNode != nil {
 		fmt.Fprintf(&sb, "SuggestedExitNode=%v ", *n.SuggestedExitNode)
+	}
+	if len(n.PeerOnlineStatusChanges) > 0 {
+		sb.WriteString("PeerOnlineStatusChanges{...")
+		fmt.Fprintf(&sb, " count=%d}", len(n.PeerOnlineStatusChanges))
 	}
 
 	s := sb.String()

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -104,6 +104,7 @@ var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	DriveShares                []*drive.Share
 	RelayServerPort            *uint16
 	RelayServerStaticEndpoints []netip.AddrPort
+	NotifyPeerStatus           bool
 	AllowSingleHosts           marshalAsTrueInJSON
 	Persist                    *persist.Persist
 }{})

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -453,6 +453,10 @@ func (v PrefsView) RelayServerStaticEndpoints() views.Slice[netip.AddrPort] {
 	return views.SliceOf(v.ж.RelayServerStaticEndpoints)
 }
 
+// NotifyPeerStatus specifies whether to send desktop notifications when
+// a peer's online status changes.
+func (v PrefsView) NotifyPeerStatus() bool { return v.ж.NotifyPeerStatus }
+
 // AllowSingleHosts was a legacy field that was always true
 // for the past 4.5 years. It controlled whether Tailscale
 // peers got /32 or /128 routes for each other.
@@ -506,6 +510,7 @@ var _PrefsViewNeedsRegeneration = Prefs(struct {
 	DriveShares                []*drive.Share
 	RelayServerPort            *uint16
 	RelayServerStaticEndpoints []netip.AddrPort
+	NotifyPeerStatus           bool
 	AllowSingleHosts           marshalAsTrueInJSON
 	Persist                    *persist.Persist
 }{})

--- a/ipn/ipnlocal/bus.go
+++ b/ipn/ipnlocal/bus.go
@@ -157,5 +157,6 @@ func isNotableNotify(n *ipn.Notify) bool {
 		len(n.IncomingFiles) > 0 ||
 		len(n.OutgoingFiles) > 0 ||
 		n.FilesWaiting != nil ||
-		n.SuggestedExitNode != nil
+		n.SuggestedExitNode != nil ||
+		len(n.PeerOnlineStatusChanges) > 0
 }

--- a/ipn/ipnlocal/bus_test.go
+++ b/ipn/ipnlocal/bus_test.go
@@ -54,6 +54,10 @@ func TestIsNotableNotify(t *testing.T) {
 				rf.SetString("foo")
 			case reflect.Slice:
 				rf.Set(reflect.MakeSlice(rf.Type(), 1, 1))
+			case reflect.Map:
+				m := reflect.MakeMap(rf.Type())
+				m.SetMapIndex(reflect.Zero(rf.Type().Key()), reflect.Zero(rf.Type().Elem()))
+				rf.Set(m)
 			default:
 				t.Errorf("unhandled field kind %v for %q", rf.Kind(), sf.Name)
 			}

--- a/ipn/ipnstate/ipnstate.go
+++ b/ipn/ipnstate/ipnstate.go
@@ -346,6 +346,20 @@ const (
 	TaildropTargetOwnedByOtherUser
 )
 
+// PeerOnlineStatusChange describes a change in a peer's online status.
+// This is sent via ipn.Notify when a peer goes online or offline.
+type PeerOnlineStatusChange struct {
+	// NodeKey is the peer's public node key.
+	NodeKey key.NodePublic
+
+	// Online is the peer's new online status.
+	Online bool
+
+	// LastSeen is the last time the peer was seen by the control server.
+	// This is only populated when Online is false.
+	LastSeen *time.Time
+}
+
 // HasCap reports whether ps has the given capability.
 func (ps *PeerStatus) HasCap(cap tailcfg.NodeCapability) bool {
 	return ps.CapMap.Contains(cap)

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -291,6 +291,10 @@ type Prefs struct {
 	// non-nil.
 	RelayServerStaticEndpoints []netip.AddrPort `json:",omitempty"`
 
+	// NotifyPeerStatus specifies whether to send desktop notifications when
+	// a peer's online status changes.
+	NotifyPeerStatus bool
+
 	// AllowSingleHosts was a legacy field that was always true
 	// for the past 4.5 years. It controlled whether Tailscale
 	// peers got /32 or /128 routes for each other.
@@ -386,6 +390,7 @@ type MaskedPrefs struct {
 	DriveSharesSet                bool                `json:",omitempty"`
 	RelayServerPortSet            bool                `json:",omitempty"`
 	RelayServerStaticEndpointsSet bool                `json:",omitzero"`
+	NotifyPeerStatusSet           bool                `json:",omitempty"`
 }
 
 // SetsInternal reports whether mp has any of the Internal*Set field bools set
@@ -628,6 +633,9 @@ func (p *Prefs) pretty(goos string) string {
 	if buildfeatures.HasRelayServer && len(p.RelayServerStaticEndpoints) > 0 {
 		fmt.Fprintf(&sb, "relayServerStaticEndpoints=%v ", p.RelayServerStaticEndpoints)
 	}
+	if p.NotifyPeerStatus {
+		sb.WriteString("notifyPeerStatus=true ")
+	}
 	if p.Persist != nil {
 		sb.WriteString(p.Persist.Pretty())
 	} else {
@@ -693,7 +701,8 @@ func (p *Prefs) Equals(p2 *Prefs) bool {
 		slices.EqualFunc(p.DriveShares, p2.DriveShares, drive.SharesEqual) &&
 		p.NetfilterKind == p2.NetfilterKind &&
 		compareUint16Ptrs(p.RelayServerPort, p2.RelayServerPort) &&
-		slices.Equal(p.RelayServerStaticEndpoints, p2.RelayServerStaticEndpoints)
+		slices.Equal(p.RelayServerStaticEndpoints, p2.RelayServerStaticEndpoints) &&
+		p.NotifyPeerStatus == p2.NotifyPeerStatus
 }
 
 func (au AutoUpdatePrefs) Pretty() string {

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -70,6 +70,7 @@ func TestPrefsEqual(t *testing.T) {
 		"DriveShares",
 		"RelayServerPort",
 		"RelayServerStaticEndpoints",
+		"NotifyPeerStatus",
 		"AllowSingleHosts",
 		"Persist",
 	}
@@ -389,6 +390,16 @@ func TestPrefsEqual(t *testing.T) {
 			&Prefs{RelayServerStaticEndpoints: aps("[2001:db8::1]:40000", "192.0.2.2:40000")},
 			&Prefs{RelayServerStaticEndpoints: aps("[2001:db8::1]:40000", "192.0.2.1:40000")},
 			false,
+		},
+		{
+			&Prefs{NotifyPeerStatus: true},
+			&Prefs{NotifyPeerStatus: false},
+			false,
+		},
+		{
+			&Prefs{NotifyPeerStatus: true},
+			&Prefs{NotifyPeerStatus: true},
+			true,
 		},
 	}
 	for i, tt := range tests {


### PR DESCRIPTION
Add desktop notifications when peers go online or offline, addressing feature request #14737.

This adds:
- NotifyPeerStatus preference to enable/disable notifications
- --notify-peer-status CLI flag for tailscale set
- PeerOnlineStatusChange struct to represent status changes
- Change detection logic in nodeBackend.peerOnlineStatusChanges()
- NotifyPeerOnlineStatusChanges watch option for IPN bus subscribers
- Linux systray integration with D-Bus notifications
- Menu toggle for enabling/disabling notifications

The IPN bus infrastructure is cross-platform, allowing macOS, Windows, and mobile clients to consume peer status changes via their native notification systems.

Fixes #14737