### PR TITLE
k8s-operator,kube: add metric for Tailnet resources

### DIFF
--- a/kube/kubetypes/types.go
+++ b/kube/kubetypes/types.go
@@ -33,6 +33,7 @@ const (
 	MetricProxyGroupEgressCount          = "k8s_proxygroup_egress_resources"
 	MetricProxyGroupIngressCount         = "k8s_proxygroup_ingress_resources"
 	MetricProxyGroupAPIServerCount       = "k8s_proxygroup_kube_apiserver_resources"
+	MetricTailnetCount                   = "k8s_tailnet_resources"
 
 	// Keys that containerboot writes to state file that can be used to determine its state.
 	// fields set in Tailscale state Secret. These are mostly used by the Tailscale Kubernetes operator to determine


### PR DESCRIPTION
This commit modifies the k8s reconciler for tailnet resources to keep a running gauge metric of the number of `Tailnet` resources in use.

Updates: https://github.com/tailscale/corp/issues/34561

Note, I accidentally made this disappear from the intermediate branch so I'm raising this to merge again.