### PR TITLE
docs/windows/policy: use a separate value to track the configuration state of EnableDNSRegistration

### DIFF
--- a/docs/windows/policy/tailscale.admx
+++ b/docs/windows/policy/tailscale.admx
@@ -231,7 +231,7 @@
         <string>never</string>
       </disabledValue>
     </policy>
-    <policy name="DNSRegistration" class="Machine" displayName="$(string.DNSRegistration)" explainText="$(string.DNSRegistration_Help)" presentation="$(presentation.DNSRegistration)" key="Software\Policies\Tailscale" valueName="EnableDNSRegistration">
+    <policy name="DNSRegistration" class="Machine" displayName="$(string.DNSRegistration)" explainText="$(string.DNSRegistration_Help)" presentation="$(presentation.DNSRegistration)" key="Software\Policies\Tailscale" valueName="DNSRegistrationConfigured">
       <parentCategory ref="Settings_Category" />
       <supportedOn ref="SINCE_V1_84" />
       <elements>


### PR DESCRIPTION
Policy editors, such as `gpedit.msc` and `gpme.msc`, rely on both the presence and the value of the registry value to determine whether a policy is enabled. Unless an `enabledValue` is specified explicitly, it defaults to `REG_DWORD` `1`.

Therefore, we cannot rely on the same registry value to track the policy configuration state when it is already used by a policy option, such as a dropdown. Otherwise, while the policy setting will be written and function correctly, it will appear as `Not Configured` in the policy editor due to the value mismatch (for example, `REG_SZ always` vs `REG_DWORD 1`).

In this PR, we update the `DNSRegistration` policy setting to use the `DNSRegistrationConfigured` registry value for tracking. This change has no effect on the client side and exists solely to satisfy ADMX and policy editor requirements.

Updates #14917