### PR TITLE
[DRAFT] appc,wgengine: sketch how connectors 2025 hooks into the datapath

### DIFF
--- a/appc/conn25_datapath.go
+++ b/appc/conn25_datapath.go
@@ -1,0 +1,238 @@
+package appc
+
+import (
+	"log"
+	"net/netip"
+
+	"tailscale.com/net/flowtrack"
+	"tailscale.com/net/packet"
+	"tailscale.com/net/packet/checksum"
+	"tailscale.com/wgengine"
+	"tailscale.com/wgengine/filter"
+)
+
+////////// TESTING VARIABLES ///////////////
+
+var (
+	magicIPs   = netip.MustParsePrefix("172.16.25.0/24")
+	transitIPs = netip.MustParsePrefix("169.254.25.0/24")
+)
+
+///////// END TESTING VARIABLES ////////////
+
+// datapathHandler is the main implementation of DatapathHandler.
+type datapathHandler struct {
+	conn25             *Conn25
+	clientFlowTable    *FlowTable
+	connectorFlowTable *FlowTable
+}
+
+func NewDatpathHooks() wgengine.AppConnectorPacketHooks {
+	return &datapathHandler{
+		conn25:             &Conn25{},
+		clientFlowTable:    NewFlowTable(0),
+		connectorFlowTable: NewFlowTable(0),
+	}
+}
+
+func (dh *datapathHandler) HandlePacketsFromTunDevice(p *packet.Parsed) filter.Response {
+	log.Printf("Handling packet from tun device: %s", p.String())
+	// Connector-bound traffic.
+	if dh.dstIPIsMagicIP(p) {
+		if err := dh.processClientToConnector(p); err != nil {
+			// TODO: log error? return error?
+			// Packets with a destination Magic IP, that we don't know
+			// what to do with, should be dropped.
+			// Perhaps we implement an ICMP error here, while dropping from
+			// the original datapath.
+			return filter.Drop
+		}
+		return filter.Accept
+	}
+
+	// Return traffic from external application.
+	if dh.selfIsConnector() {
+		if err := dh.processConnectorToClient(p); err != nil {
+			switch err {
+			case nil, FlowNotFoundError:
+				// If we don't have a record of the flow, it could be normal
+				// traffic. We don't know if it's interesting connector return
+				// traffic unless we check the table, since it is not expected
+				// to have a Transit IP on it yet.
+				return filter.Accept
+			default:
+				return filter.Drop
+			}
+		}
+	}
+
+	return filter.Accept
+}
+
+func (dh *datapathHandler) HandlePacketsFromWireguard(p *packet.Parsed) filter.Response {
+	log.Printf("Handling packet from wireguard: %s", p.String())
+	// Return traffic from connector, source is a Transit IP.
+	if dh.srcIsTransitIP(p) {
+		if err := dh.processClientFromConnector(p); err != nil {
+			// TODO: log error? return error?
+			// Packets coming in from wireguard with a source
+			// transit IP that don't have an entry in the flow table should
+			// be dropped.
+			return filter.Drop
+		}
+		return filter.Accept
+	}
+
+	// Outgoing traffic for an external application. Destination is Transit IP.
+	if dh.selfIsConnector() && dh.dstIPIsTransitIP(p) {
+		if err := dh.processConnectorFromClient(p); err != nil {
+			// TODO: log or return error?
+			// Packets coming in from wireguard with a destination transit IP
+			// that error should be dropped.
+			return filter.Drop
+		}
+	}
+	return filter.Accept
+}
+
+func (dh *datapathHandler) dnatAction(to netip.Addr) PacketAction {
+	return PacketAction(func(p *packet.Parsed) { checksum.UpdateDstAddr(p, to) })
+}
+
+func (dh *datapathHandler) snatAction(to netip.Addr) PacketAction {
+	return PacketAction(func(p *packet.Parsed) { checksum.UpdateSrcAddr(p, to) })
+}
+
+// processClientToConnector consults the flow table to determine which connector to send the packet to,
+// and if this is a new flow, runs the connector selection algorithm, and installs a new flow.
+// If the packet is valid, we DNAT from the Magic IP to the Transit IP.
+// If there is no flow or the packet is otherwise invalid, we drop the packet.
+func (dh *datapathHandler) processClientToConnector(p *packet.Parsed) error {
+	log.Printf("Proccessing on client to connector: %s", p.String())
+	existing, err := dh.clientFlowTable.LookupFromTunDevice(flowtrack.MakeTuple(p.IPProto, p.Src, p.Dst))
+	switch err {
+	case nil:
+		existing.Action(p)
+		log.Printf("Post-processing (existing) on client to connector: %s", p.String())
+		return nil
+	case FlowNotFoundError:
+		magicIP := p.Dst.Addr()
+		transitIP, err := dh.conn25.ClientTransitIPForMagicIP(magicIP)
+		if err != nil {
+			return err
+		}
+		entry, err := dh.clientFlowTable.NewFlowFromTunDevice(
+			FlowData{
+				Tuple:  flowtrack.MakeTuple(p.IPProto, p.Src, p.Dst),
+				Action: dh.dnatAction(transitIP),
+			},
+			FlowData{
+				Tuple:  flowtrack.MakeTuple(p.IPProto, netip.AddrPortFrom(transitIP, p.Dst.Port()), p.Src),
+				Action: dh.snatAction(magicIP),
+			},
+		)
+		if err != nil {
+			return err
+		}
+		entry.Action(p)
+		log.Printf("Post-processing (new) on client to connector: %s", p.String())
+		return nil
+	default:
+		return err
+	}
+}
+
+// processClientFromConnector consults the flow table to validate that the packet should
+// be forwarded back to the local network stack.
+// We SNAT the Transit IP back to the Magic IP.
+// If there is no flow or the packet is otherwise invalid, we drop the packet.
+func (dh *datapathHandler) processClientFromConnector(p *packet.Parsed) error {
+	log.Printf("Proccessing on client from connector: %s", p.String())
+	existing, err := dh.clientFlowTable.LookupFromWireguard(flowtrack.MakeTuple(p.IPProto, p.Src, p.Dst))
+	switch err {
+	case nil:
+		existing.Action(p)
+		log.Printf("Post-processing (existing) on client from connector: %s", p.String())
+		return nil
+	default:
+		return err
+	}
+}
+
+// processConnectorFromClient consults the flow table to see if this packet is part of
+// an existing outbound flow to an application, or a new flow should be installed.
+// If the packet is valid, we DNAT from the Transit IP to the external application IP.
+// If there is no flow or the packet is otherwise invalid, we drop the packet.
+func (dh *datapathHandler) processConnectorFromClient(p *packet.Parsed) error {
+	log.Printf("Proccessing on connector from client: %s", p.String())
+	existing, err := dh.connectorFlowTable.LookupFromWireguard(flowtrack.MakeTuple(p.IPProto, p.Src, p.Dst))
+	switch err {
+	case nil:
+		existing.Action(p)
+		log.Printf("Post-processing (new) on connector from client: %s", p.String())
+		return nil
+	case FlowNotFoundError:
+		transitIP := p.Dst.Addr()
+		realIP, err := dh.conn25.ConnectorRealIPForTransitIPConnection(p.Src.Addr(), transitIP)
+		if err != nil {
+			return err
+		}
+		entry, err := dh.connectorFlowTable.NewFlowFromWireguard(
+			FlowData{
+				Tuple:  flowtrack.MakeTuple(p.IPProto, p.Src, p.Dst),
+				Action: dh.dnatAction(realIP),
+			},
+			FlowData{
+				Tuple:  flowtrack.MakeTuple(p.IPProto, netip.AddrPortFrom(realIP, p.Dst.Port()), p.Src),
+				Action: dh.snatAction(transitIP),
+			},
+		)
+		if err != nil {
+			return err
+		}
+		entry.Action(p)
+		log.Printf("Post-processing (existing) on connector from client: %s", p.String())
+		return nil
+	default:
+		return err
+	}
+}
+
+// processConnectorToClient consults the flow table on a connector to determine which client
+// to send the return traffic to.
+// If the packet is valid, we SNAT the external application IP to the Transit IP.
+// If there is no flow or the packet is otherwise invalid, we drop the packet.
+func (dh *datapathHandler) processConnectorToClient(p *packet.Parsed) error {
+	log.Printf("Proccessing on connector to client: %s", p.String())
+	existing, err := dh.connectorFlowTable.LookupFromTunDevice(flowtrack.MakeTuple(p.IPProto, p.Src, p.Dst))
+	switch err {
+	case nil:
+		existing.Action(p)
+		log.Printf("Post-processing (existing) on connector to client: %s", p.String())
+		return nil
+	default:
+		return err
+	}
+}
+
+// dstIPIsMagicIP returns whether the destination IP address in p is Magic IP,
+// which could indicate interesting traffic for outbound traffic from a client to a connector.
+func (dh *datapathHandler) dstIPIsMagicIP(p *packet.Parsed) bool {
+	// TODO: implement for real
+	return magicIPs.Contains(p.Dst.Addr())
+}
+
+func (dh *datapathHandler) srcIsTransitIP(p *packet.Parsed) bool {
+	// TODO: implement for real
+	return transitIPs.Contains(p.Src.Addr())
+}
+
+func (dh *datapathHandler) dstIPIsTransitIP(p *packet.Parsed) bool {
+	// TODO: implement for real
+	return transitIPs.Contains(p.Dst.Addr())
+}
+
+// selfIsConnector returns whether this client is running on an app connector.
+func (dh *datapathHandler) selfIsConnector() bool {
+	return dh.conn25.SelfIsConnector()
+}

--- a/appc/conn25_flowtable.go
+++ b/appc/conn25_flowtable.go
@@ -1,0 +1,117 @@
+package appc
+
+import (
+	"errors"
+	"sync"
+
+	"tailscale.com/net/flowtrack"
+	"tailscale.com/net/packet"
+)
+
+type PacketAction func(*packet.Parsed)
+
+type FlowData struct {
+	Tuple  flowtrack.Tuple
+	Action PacketAction
+}
+
+type Origin uint8
+
+const (
+	FromTun Origin = iota
+	FromWireguard
+)
+
+type cachedFlow struct {
+	flow   FlowData
+	paired flowtrack.Tuple // tuple for the other direction
+	allow  Origin          // which lookup is allowed to hit this entry
+}
+
+var (
+	FlowNotFoundError   = errors.New("flow not found")
+	WrongDirectionError = errors.New("flow exists but wrong direction for lookup")
+)
+
+type FlowTable struct {
+	mu  sync.Mutex
+	lru flowtrack.Cache[cachedFlow] // guarded by mu
+}
+
+func NewFlowTable(maxEntries int) *FlowTable {
+	t := &FlowTable{}
+	t.lru.MaxEntries = maxEntries
+	return t
+}
+
+func opposite(o Origin) Origin {
+	if o == FromTun {
+		return FromWireguard
+	}
+	return FromTun
+}
+
+// LookupFromTunDevice looks up a flow action that is valid to run for packets
+// observed on the tun-device path.
+func (t *FlowTable) LookupFromTunDevice(k flowtrack.Tuple) (FlowData, error) {
+	return t.lookup(k, FromTun)
+}
+
+// LookupFromWireguard looks up a flow action that is valid to run for packets
+// observed on the wireguard path.
+func (t *FlowTable) LookupFromWireguard(k flowtrack.Tuple) (FlowData, error) {
+	return t.lookup(k, FromWireguard)
+}
+
+func (t *FlowTable) lookup(k flowtrack.Tuple, want Origin) (FlowData, error) {
+	t.mu.Lock()
+	v, ok := t.lru.Get(k)
+	if !ok {
+		t.mu.Unlock()
+		return FlowData{}, FlowNotFoundError
+	}
+	if v.allow != want {
+		t.mu.Unlock()
+		return FlowData{}, WrongDirectionError
+	}
+	out := v.flow // copy
+	t.mu.Unlock()
+	return out, nil
+}
+
+// NewFlowFromTunDevice installs (or overwrites) both the forward and return entries.
+// The forward tuple is tagged as FromTun, and the return tuple is tagged as FromWireguard.
+// If overwriting, it removes the old paired tuple for the forward key to avoid stale reverse mappings.
+func (t *FlowTable) NewFlowFromTunDevice(fwd, ret FlowData) (FlowData, error) {
+	return t.newFlow(FromTun, fwd, ret)
+}
+
+// NewFlowFromWireguard installs (or overwrites) both the forward and return entries,
+// but tags the forward tuple as FromWireguard and the return tuple as FromTun.
+// (Whether you *want* to allow installs from this direction is a separate policy question.)
+func (t *FlowTable) NewFlowFromWireguard(fwd, ret FlowData) (FlowData, error) {
+	return t.newFlow(FromWireguard, fwd, ret)
+}
+
+func (t *FlowTable) newFlow(primaryAllow Origin, fwd, ret FlowData) (FlowData, error) {
+	t.mu.Lock()
+
+	// If overwriting an existing primary entry, remove its previously-paired mapping so
+	// we don't leave stale reverse tuples around.
+	if old, ok := t.lru.Get(fwd.Tuple); ok && old != nil {
+		t.lru.Remove(old.paired)
+	}
+
+	t.lru.Add(fwd.Tuple, cachedFlow{
+		flow:   fwd,
+		paired: ret.Tuple, allow: primaryAllow,
+	})
+	t.lru.Add(ret.Tuple, cachedFlow{
+		flow:   ret,
+		paired: fwd.Tuple,
+		allow:  opposite(primaryAllow),
+	})
+
+	t.mu.Unlock()
+	return fwd, nil
+}

--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -27,6 +27,7 @@ import (
 	"syscall"
 	"time"
 
+	"tailscale.com/appc"
 	"tailscale.com/cmd/tailscaled/childproc"
 	"tailscale.com/control/controlclient"
 	"tailscale.com/envknob"
@@ -741,14 +742,15 @@ var tstunNew = tstun.New
 
 func tryEngine(logf logger.Logf, sys *tsd.System, name string) (onlyNetstack bool, err error) {
 	conf := wgengine.Config{
-		ListenPort:    args.port,
-		NetMon:        sys.NetMon.Get(),
-		HealthTracker: sys.HealthTracker.Get(),
-		Metrics:       sys.UserMetricsRegistry(),
-		Dialer:        sys.Dialer.Get(),
-		SetSubsystem:  sys.Set,
-		ControlKnobs:  sys.ControlKnobs(),
-		EventBus:      sys.Bus.Get(),
+		ListenPort:              args.port,
+		NetMon:                  sys.NetMon.Get(),
+		HealthTracker:           sys.HealthTracker.Get(),
+		Metrics:                 sys.UserMetricsRegistry(),
+		Dialer:                  sys.Dialer.Get(),
+		SetSubsystem:            sys.Set,
+		ControlKnobs:            sys.ControlKnobs(),
+		EventBus:                sys.Bus.Get(),
+		AppConnectorPacketHooks: appc.NewDatpathHooks(),
 	}
 	if f, ok := hookSetWgEnginConfigDrive.GetOk(); ok {
 		f(&conf, logf)

--- a/net/packet/capture.go
+++ b/net/packet/capture.go
@@ -45,7 +45,8 @@ type CaptureSink interface {
 	RegisterOutput(w io.Writer) (unregister func())
 }
 
-// CaptureMeta contains metadata that is used when debugging.
+// CaptureMeta contains metadata that is used when debugging, and
+// for some filtering decisions.
 type CaptureMeta struct {
 	DidSNAT     bool           // SNAT was performed & the address was updated.
 	OriginalSrc netip.AddrPort // The source address before SNAT was performed.

--- a/net/packet/packet.go
+++ b/net/packet/packet.go
@@ -60,7 +60,8 @@ type Parsed struct {
 	// TCPFlags is the packet's TCP flag bits. Valid iff IPProto == TCP.
 	TCPFlags TCPFlag
 
-	// CaptureMeta contains metadata that is used when debugging.
+	// CaptureMeta contains metadata that is used when debugging, and
+	// for some filtering decisions.
 	CaptureMeta CaptureMeta
 }
 

--- a/net/tstun/wrap.go
+++ b/net/tstun/wrap.go
@@ -171,6 +171,9 @@ type Wrapper struct {
 	// PreFilterPacketInboundFromWireGuard is the inbound filter function that runs before the main filter
 	// and therefore sees the packets that may be later dropped by it.
 	PreFilterPacketInboundFromWireGuard FilterFunc
+	// PostFilterPacketInboundFromWireGuardAppConector runs after the filter, but before PostFilterPacketInboundFromWireGuard.
+	// Non-app connector traffic is passed along. Invalid app connector traffic is dropped.
+	PostFilterPacketInboundFromWireGuardAppConector FilterFunc
 	// PostFilterPacketInboundFromWireGuard is the inbound filter function that runs after the main filter.
 	PostFilterPacketInboundFromWireGuard GROFilterFunc
 	// PreFilterPacketOutboundToWireGuardNetstackIntercept is a filter function that runs before the main filter
@@ -183,6 +186,10 @@ type Wrapper struct {
 	// packets which it handles internally. If both this and PreFilterFromTunToNetstack
 	// filter functions are non-nil, this filter runs second.
 	PreFilterPacketOutboundToWireGuardEngineIntercept FilterFunc
+	// PreFilterPacketOutboundToWireGuardAppConnectorIntercept runs after PreFilterPacketOutboundToWireGuardEngineIntercept
+	// for app connector specific traffic. Non-app connector traffic is passed along. Invalid app connector traffic is
+	// dropped.
+	PreFilterPacketOutboundToWireGuardAppConnectorIntercept FilterFunc
 	// PostFilterPacketOutboundToWireGuard is the outbound filter function that runs after the main filter.
 	PostFilterPacketOutboundToWireGuard FilterFunc
 
@@ -872,6 +879,12 @@ func (t *Wrapper) filterPacketOutboundToWireGuard(p *packet.Parsed, pc *peerConf
 			return res, gro
 		}
 	}
+	if t.PreFilterPacketOutboundToWireGuardAppConnectorIntercept != nil {
+		// TODO(mzb): write good comment hereHandled by userspaceEngine.
+		if res := t.PreFilterPacketOutboundToWireGuardAppConnectorIntercept(p, t); res.IsDrop() {
+			return res, gro
+		}
+	}
 
 	// If the outbound packet is to a jailed peer, use our jailed peer
 	// packet filter.
@@ -1232,6 +1245,13 @@ func (t *Wrapper) filterPacketInboundFromWireGuard(p *packet.Parsed, captHook pa
 		}
 
 		return filter.Drop, gro
+	}
+
+	if t.PostFilterPacketInboundFromWireGuardAppConector != nil {
+		// TODO(mzb): write a good comment here
+		if res := t.PostFilterPacketInboundFromWireGuardAppConector(p, t); res.IsDrop() {
+			return res, gro
+		}
 	}
 
 	if t.PostFilterPacketInboundFromWireGuard != nil {

--- a/types/appctype/appconnector.go
+++ b/types/appctype/appconnector.go
@@ -74,6 +74,10 @@ type AppConnectorAttr struct {
 	Connectors []string `json:"connectors,omitempty"`
 }
 
+// AppConnectorExperimentalAttr is the same as AppConnectorAttr
+// as it is being developed.
+type AppConnectorExperimentalAttr = AppConnectorAttr
+
 // RouteInfo is a data structure used to persist the in memory state of an AppConnector
 // so that we can know, even after a restart, which routes came from ACLs and which were
 // learned from domains.

--- a/types/appctype/conn25.go
+++ b/types/appctype/conn25.go
@@ -1,0 +1,7 @@
+package appctype
+
+const AppConnectorExperimentalCap = "tailscale.com/app-connectors-experimental"
+
+// AppConnectorExperimentalAttr is the same as AppConnectorAttr
+// as it is being developed.
+type Conn25Attr = AppConnectorAttr

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -165,6 +165,9 @@ type userspaceEngine struct {
 	// networkLogger logs statistics about network connections.
 	networkLogger netlog.Logger
 
+	// appConnectorPacketHooks are the packet hooks for app connectors.
+	appConnectorPacketHooks AppConnectorPacketHooks
+
 	// Lock ordering: magicsock.Conn.mu, wgLock, then mu.
 }
 
@@ -173,6 +176,11 @@ type BIRDClient interface {
 	EnableProtocol(proto string) error
 	DisableProtocol(proto string) error
 	Close() error
+}
+
+type AppConnectorPacketHooks interface {
+	HandlePacketsFromTunDevice(*packet.Parsed) filter.Response
+	HandlePacketsFromWireguard(*packet.Parsed) filter.Response
 }
 
 // Config is the engine configuration.
@@ -247,6 +255,10 @@ type Config struct {
 	// TODO(creachadair): As of 2025-03-19 this is optional, but is intended to
 	// become required non-nil.
 	EventBus *eventbus.Bus
+
+	// AppConnectorPacketHooks, if non-nil, is used to hook packets for App Connector
+	// handling logic.
+	AppConnectorPacketHooks AppConnectorPacketHooks
 }
 
 // NewFakeUserspaceEngine returns a new userspace engine for testing.
@@ -348,19 +360,20 @@ func NewUserspaceEngine(logf logger.Logf, conf Config) (_ Engine, reterr error) 
 	}
 
 	e := &userspaceEngine{
-		eventBus:       conf.EventBus,
-		timeNow:        mono.Now,
-		logf:           logf,
-		reqCh:          make(chan struct{}, 1),
-		waitCh:         make(chan struct{}),
-		tundev:         tsTUNDev,
-		router:         rtr,
-		dialer:         conf.Dialer,
-		confListenPort: conf.ListenPort,
-		birdClient:     conf.BIRDClient,
-		controlKnobs:   conf.ControlKnobs,
-		reconfigureVPN: conf.ReconfigureVPN,
-		health:         conf.HealthTracker,
+		eventBus:                conf.EventBus,
+		timeNow:                 mono.Now,
+		logf:                    logf,
+		reqCh:                   make(chan struct{}, 1),
+		waitCh:                  make(chan struct{}),
+		tundev:                  tsTUNDev,
+		router:                  rtr,
+		dialer:                  conf.Dialer,
+		confListenPort:          conf.ListenPort,
+		birdClient:              conf.BIRDClient,
+		controlKnobs:            conf.ControlKnobs,
+		reconfigureVPN:          conf.ReconfigureVPN,
+		health:                  conf.HealthTracker,
+		appConnectorPacketHooks: conf.AppConnectorPacketHooks,
 	}
 
 	if e.birdClient != nil {
@@ -433,6 +446,20 @@ func NewUserspaceEngine(logf logger.Logf, conf Config) (_ Engine, reterr error) 
 		e.tundev.PostFilterPacketInboundFromWireGuard = echoRespondToAll
 	}
 	e.tundev.PreFilterPacketOutboundToWireGuardEngineIntercept = e.handleLocalPackets
+
+	e.tundev.PreFilterPacketOutboundToWireGuardAppConnectorIntercept = func(p *packet.Parsed, _ *tstun.Wrapper) filter.Response {
+		if e.appConnectorPacketHooks.HandlePacketsFromTunDevice != nil {
+			return e.appConnectorPacketHooks.HandlePacketsFromTunDevice(p)
+		}
+		return filter.Accept
+	}
+
+	e.tundev.PostFilterPacketInboundFromWireGuardAppConector = func(p *packet.Parsed, _ *tstun.Wrapper) filter.Response {
+		if e.appConnectorPacketHooks.HandlePacketsFromWireguard != nil {
+			return e.appConnectorPacketHooks.HandlePacketsFromWireguard(p)
+		}
+		return filter.Accept
+	}
 
 	if buildfeatures.HasDebug && envknob.BoolDefaultTrue("TS_DEBUG_CONNECT_FAILURES") {
 		if e.tundev.PreFilterPacketInboundFromWireGuard != nil {


### PR DESCRIPTION
In this (DRAFT, not meant to be merged) PR, one can find a few things:

- Sketch of next-gen connectors datapath actions in appc/conn25_datapath.go.
  - 2-way NATing of MagicIP <> TransitIP in the client
  - 2-way NATing of TransitIP <> RealIP in the connector
- FlowTable caching layer in appc/conn25_flowtable.go.
   - leverages existing `net/flowtrack` package for `Tuple` and `Cache` types
- Datapath integration via `tstun.Wrapper` hooks.
  - `wgengine` defines a new interface:
    ```
    type AppConnectorPacketHooks interface {                      
      HandlePacketsFromTunDevice(*packet.Parsed) filter.Response
      HandlePacketsFromWireguard(*packet.Parsed) filter.Response
    }
    ```
  - `wgengine.userspaceEngine`, since it creates the `tstun.Wrapper`, gets hooked up with the implementation when it is created inside of `tryEngine()` in cmd/tailscaled, then connects the implementation to the tstun.Wrapper's filter hooks.
- Stub methods (names can be changed) for what the appc datapath handler needs from the state management system:
  ```
  func (c *Conn25) ClientTransitIPForMagicIP(magic netip.Addr) (netip.Addr, error)
  func (c *Conn25) ConnectorRealIPForTransitIPConnection(clientSrc, transitIP netip.Addr) (netip.Addr, error)
  func (c *Conn25) SelfIsConnector() bool
  ``` 

In this sketch, the MagicIP range (172.16.25.0/24) gets translated to the TransitIP range (169.254.25.0/24) by simply mutating the first two octets. All TransitIPs get translated to the same real/public IP address where `icanhazip.com` is currently hosted. This is all so we can do this on the client:
```
root@vm1:~/tailscale# curl -H "Host: icanhazip.com" 172.16.25.1
68.237.121.242
```

 If you want to get this running yourself, you need some extra setup:
 
 - A node to run a client, and another one for the connector.
 - On the client node (after tailscale is running):
   - Install the route to the MagicIP space, e.g. `ip route add 172.16.25.0/24 dev tailscale0`
 - On the connector:
   - `tailscaled` run in environment with `MZB_SELF_IS_CONNECTOR=true`
   - The connector advertising the TransitIP range so that it shows up in AllowedIPs.
   - The connector advertising the real/public IP so that is shows up in AllowedIPs.
   - ip masquerading on the connector node (should get for free by advertising routes).
   - ip forwarding on the connector node.


This work also uncovered a bunch of things we would need to make this merge-able:
- Better tstun.Wrapper hook integration (tailscale/corp#35985)
  - We currently use `PreFilterPacketOutboundToWireGuardEngineIntercept` and `PreFilterPacketInboundFromWireGuard`, however we likely want to differentiate which ones we use on the connector vs client, as NATing logic may be pre- or post- filter depending on context. More info in ticket.
  - There's also some gymnastics we have to do interact with existing hooks, that could be cleaned up. More info in ticket.
- Deal with link local blocking for TransitIPs (tailscale/corp#35989)
- TransitIPs into wireguard peer AllowedIPs on client (tailscale/corp#35991)
  - This branch needed to advertise the TransitIPs from the connectors so the client can seem them and plumb them into their wireguard peers' allowed IP lists. We don't want that long term.
- Internet IPs into wireguard "local" allowed IPs on connector (tailscale/corp#35994)
  - This branch needed to advertise the internet (/0) on the connector so that the connector can allow the traffic post-DNAT coming in from wireguard. We don't want that long term.
- Unit tests for datapath handler (tailscale/corp#35995)

Updates tailscale/corp#34249