### PR TITLE
client/systray: Update systemd unit to use correct dependencies

### DIFF
--- a/client/systray/tailscale-systray.service
+++ b/client/systray/tailscale-systray.service
@@ -1,6 +1,9 @@
 [Unit]
 Description=Tailscale System Tray
-After=graphical.target
+Documentation=https://tailscale.com/kb/1597/linux-systray
+Requires=dbus.service
+After=dbus.service
+PartOf=default.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
This ensures that D-Bus is active for the unit and will correctly shut down when the default target ends.

Fixes: https://github.com/tailscale/tailscale/issues/18458