### PR TITLE
cmd/k8s-operator: allow VIP ownership reclaim after operator recreation

### DIFF
--- a/cmd/k8s-operator/api-server-proxy-pg_test.go
+++ b/cmd/k8s-operator/api-server-proxy-pg_test.go
@@ -323,13 +323,22 @@ func TestExclusiveOwnerAnnotations(t *testing.T) {
 				},
 			},
 		},
-		"owned_by_another_operator": {
+		"owned_by_another_operator_no_resource": {
 			svc: &tailscale.VIPService{
 				Annotations: map[string]string{
 					ownerAnnotation: `{"ownerRefs":[{"operatorID":"operator-2"}]}`,
 				},
 			},
-			wantErr: "already owned by other operator(s)",
+			wantErr: "does not reference an owning resource",
+		},
+		"operator_recreated_same_pg": {
+			// Different operatorID but same ProxyGroup UID - operator pod was recreated.
+			// Should allow reclaiming ownership.
+			svc: &tailscale.VIPService{
+				Annotations: map[string]string{
+					ownerAnnotation: `{"ownerRefs":[{"operatorID":"old-operator-id","resource":{"kind":"ProxyGroup","name":"pg1","uid":"pg1-uid"}}]}`,
+				},
+			},
 		},
 		"owned_by_an_ingress": {
 			svc: &tailscale.VIPService{

--- a/tool/gocross/gocross-wrapper.ps1
+++ b/tool/gocross/gocross-wrapper.ps1
@@ -114,7 +114,12 @@ $bootstrapScriptBlock = {
                     New-Item -Force -Path $toolchain -ItemType Directory | Out-Null
                     Start-ChildScope -ScriptBlock {
                         Set-Location -LiteralPath $toolchain
-                        tar --strip-components=1 -xf "$toolchain.tar.gz"
+
+                        # Using an absolute path to the tar that ships with Windows
+                        # to avoid conflicts with others (eg msys2).
+                        $system32 = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::System)
+                        $tar = Join-Path $system32 'tar.exe' -Resolve
+                        & $tar --strip-components=1 -xf "$toolchain.tar.gz"
                         if ($LASTEXITCODE -ne 0) {
                             throw "tar failed with exit code $LASTEXITCODE"
                         }


### PR DESCRIPTION
When a k8s-operator pod is recreated, it gets a new Tailscale stable ID. Previously, the reconciler refused to reclaim ownership of existing VIP services because it checked operatorID mismatch before checking if the ProxyGroup UID matched.

Now, if the Resource.UID matches the current ProxyGroup, the operator updates the owner annotation to reclaim ownership.

Fixes #18466