### PR TITLE
cmd/containerboot: allow all extra args by passing to `set`

### DIFF
--- a/cmd/containerboot/main.go
+++ b/cmd/containerboot/main.go
@@ -42,7 +42,7 @@
 //   - TS_TAILNET_TARGET_FQDN: proxy all incoming non-Tailscale traffic to the given
 //     destination defined by a MagicDNS name.
 //   - TS_TAILSCALED_EXTRA_ARGS: extra arguments to 'tailscaled'.
-//   - TS_EXTRA_ARGS: extra arguments to 'tailscale up'.
+//   - TS_EXTRA_ARGS: extra arguments to 'tailscale set'.
 //   - TS_USERSPACE: run with userspace networking (the default)
 //     instead of kernel networking.
 //   - TS_STATE_DIR: the directory in which to store tailscaled

--- a/cmd/containerboot/main_test.go
+++ b/cmd/containerboot/main_test.go
@@ -688,7 +688,8 @@ func TestContainerBoot(t *testing.T) {
 					{
 						WantCmds: []string{
 							"/usr/bin/tailscaled --socket=/tmp/tailscaled.sock --state=mem: --statedir=/tmp --tun=userspace-networking --experiments=widgets",
-							"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --widget=rotated",
+							"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false",
+							"/usr/bin/tailscale --socket=/tmp/tailscaled.sock set --widget=rotated",
 						},
 					}, {
 						Notify: runningNotify,
@@ -705,7 +706,8 @@ func TestContainerBoot(t *testing.T) {
 					{
 						WantCmds: []string{
 							"/usr/bin/tailscaled --socket=/tmp/tailscaled.sock --state=mem: --statedir=/tmp --tun=userspace-networking",
-							"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false --accept-routes",
+							"/usr/bin/tailscale --socket=/tmp/tailscaled.sock up --accept-dns=false",
+							"/usr/bin/tailscale --socket=/tmp/tailscaled.sock set --accept-routes",
 						},
 					}, {
 						Notify: runningNotify,


### PR DESCRIPTION
This commit changes the arguments provided by environment variable `TS_EXTRA_ARGS` to be applied with `tailscale set` rather than `tailscale up` (as used for explicitly named args), as this command admits arguments that `up` does not, such as `--auto-update`.

This aligns the documentation (and behaviour) of `TS_EXTRA_ARGS` with that shown on DockerHub, and closes #18437.