### PR TITLE
ipn/ipnlocal: add h2c proxy support for Connect RPC streaming

### DIFF
--- a/ipn/ipnlocal/serve_test.go
+++ b/ipn/ipnlocal/serve_test.go
@@ -1255,6 +1255,29 @@ func Test_isGRPCContentType(t *testing.T) {
 	}
 }
 
+func Test_isConnectContentType(t *testing.T) {
+	tests := []struct {
+		contentType string
+		want        bool
+	}{
+		{contentType: "application/connect+proto", want: true},
+		{contentType: "application/connect+json", want: true},
+		{contentType: "application/connect+proto; charset=utf-8", want: true},
+		{contentType: "application/connect+json; charset=utf-8", want: true},
+		{contentType: "application/connect+custom", want: true},
+		{contentType: "application/connect"},
+		{contentType: "application/proto"},
+		{contentType: "application/json"},
+		{contentType: "application/grpc"},
+		{contentType: ""},
+	}
+	for _, tt := range tests {
+		if got := isConnectContentType(tt.contentType); got != tt.want {
+			t.Errorf("isConnectContentType(%q) = %v, want %v", tt.contentType, got, tt.want)
+		}
+	}
+}
+
 func TestEncTailscaleHeaderValue(t *testing.T) {
 	tests := []struct {
 		in   string


### PR DESCRIPTION
Fixes #18483

Extend `shouldProxyViaH2C()` to recognize Connect RPC streaming content types (`application/connect+*`) in addition to gRPC.

Connect RPC is a protocol that supports bidirectional streaming over HTTP. Like gRPC, streaming requests require HTTP/2 end-to-end. When proxying to cleartext `http://` backends, this means using h2c transport.

The streaming content types are defined in the [Connect protocol spec](https://connectrpc.com/docs/protocol/) and [connect-go](https://github.com/connectrpc/connect-go/blob/main/protocol_connect.go#L52):
- `application/connect+proto`
- `application/connect+json`
- `application/connect+<anything>`

Unary Connect requests use standard content types (`application/proto`, `application/json`) and work fine over HTTP/1.1, so they are not affected.

Tested with a Connect RPC server with [connect-go](https://github.com/connectrpc/connect-swift) behind Tailscale Ingress (K8s operator) and an iOS client using [connect-swift](https://github.com/connectrpc/connect-swift).