### PR TITLE
scripts/installer.sh: make dnf5 install script idempotent

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -603,7 +603,7 @@ main() {
 				$SUDO dnf config-manager --add-repo "https://pkgs.tailscale.com/$TRACK/$OS/$VERSION/tailscale.repo"
 			elif [ "$DNF_VERSION" = "5" ]; then
 				# Already installed config-manager, above.
-				$SUDO dnf config-manager addrepo --from-repofile="https://pkgs.tailscale.com/$TRACK/$OS/$VERSION/tailscale.repo"
+				$SUDO dnf config-manager addrepo --overwrite --from-repofile="https://pkgs.tailscale.com/$TRACK/$OS/$VERSION/tailscale.repo"
 			else
 				echo "unexpected: unknown dnf version $DNF_VERSION"
 				exit 1


### PR DESCRIPTION
`dnf config-manager addrepo` will fail if the Tailscale repo is already installed. Without the --overwrite flag, the installer will error out instead of succeeding like with dnf3.

Fixes #18491