### PR TITLE
tsnet: make ListenService examples consistent with other tsnet examples

### DIFF
--- a/tsnet/example_tsnet_listen_service_multiple_ports_test.go
+++ b/tsnet/example_tsnet_listen_service_multiple_ports_test.go
@@ -19,21 +19,19 @@ import (
 // Service on multiple ports. In this example, we run an HTTPS server on 443 and
 // an HTTP server handling pprof requests to the same runtime on 6060.
 func ExampleServer_ListenService_multiplePorts() {
-	s := &tsnet.Server{
-		Hostname: "tsnet-services-demo",
+	srv := &tsnet.Server{
+		Hostname: "shu",
 	}
-	defer s.Close()
 
-	ln, err := s.ListenService("svc:my-service", tsnet.ServiceModeHTTP{
+	ln, err := srv.ListenService("svc:my-service", tsnet.ServiceModeHTTP{
 		HTTPS: true,
 		Port:  443,
 	})
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer ln.Close()
 
-	pprofLn, err := s.ListenService("svc:my-service", tsnet.ServiceModeTCP{
+	pprofLn, err := srv.ListenService("svc:my-service", tsnet.ServiceModeTCP{
 		Port: 6060,
 	})
 	if err != nil {

--- a/tsnet/example_tsnet_test.go
+++ b/tsnet/example_tsnet_test.go
@@ -205,19 +205,17 @@ func ExampleServer_ListenFunnel_funnelOnly() {
 
 // ExampleServer_ListenService demonstrates how to advertise an HTTPS Service.
 func ExampleServer_ListenService() {
-	s := &tsnet.Server{
-		Hostname: "tsnet-services-demo",
+	srv := &tsnet.Server{
+		Hostname: "atum",
 	}
-	defer s.Close()
 
-	ln, err := s.ListenService("svc:my-service", tsnet.ServiceModeHTTP{
+	ln, err := srv.ListenService("svc:my-service", tsnet.ServiceModeHTTP{
 		HTTPS: true,
 		Port:  443,
 	})
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer ln.Close()
 
 	log.Printf("Listening on https://%v\n", ln.FQDN)
 	log.Fatal(http.Serve(ln, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -238,19 +236,17 @@ func ExampleServer_ListenService_reverseProxy() {
 		Host:   targetAddress,
 	})
 
-	s := &tsnet.Server{
-		Hostname: "tsnet-services-demo",
+	srv := &tsnet.Server{
+		Hostname: "tefnut",
 	}
-	defer s.Close()
 
-	ln, err := s.ListenService("svc:my-service", tsnet.ServiceModeHTTP{
+	ln, err := srv.ListenService("svc:my-service", tsnet.ServiceModeHTTP{
 		HTTPS: true,
 		Port:  443,
 	})
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer ln.Close()
 
 	log.Printf("Listening on https://%v\n", ln.FQDN)
 	log.Fatal(http.Serve(ln, reverseProxy))


### PR DESCRIPTION
The `ListenService` examples I added in https://github.com/tailscale/tailscale/pull/18433 are slightly inconsistent with other examples in `tsnet`. @bkouchi pointed this out in [DOCS-4443](https://tailscale.atlassian.net/browse/DOCS-4443?focusedCommentId=313578&sourceType=mention):
> There is some inconsistency in conventions in the examples.
> 
> New proposed method uses s. Other examples use srv. (As an English-speaking dev, srv does help communicate a server variable better.)
>
> New proposed method uses tsnet-services-demo. Other examples use pop culture references: “gaga”, “aran”?

[DOCS-4443]: https://tailscale.atlassian.net/browse/DOCS-4443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Fixes tailscale/corp#36365