### PR TITLE
tool/gocross, pull-toolchain.sh: support a "next" Go toolchain

### DIFF
--- a/go.toolchain.next.branch
+++ b/go.toolchain.next.branch
@@ -1,0 +1,1 @@
+tailscale.go1.26

--- a/go.toolchain.next.rev
+++ b/go.toolchain.next.rev
@@ -1,0 +1,1 @@
+07d023ba9bb6d17a84b492f1524fabfa69a31bda

--- a/pull-toolchain.sh
+++ b/pull-toolchain.sh
@@ -1,20 +1,33 @@
 #!/bin/sh
 # Retrieve the latest Go toolchain.
+# Set TS_GO_NEXT=1 to update go.toolchain.next.rev instead.
 #
 set -eu
 cd "$(dirname "$0")"
 
-read -r go_branch <go.toolchain.branch
-upstream=$(git ls-remote https://github.com/tailscale/go "$go_branch" | awk '{print $1}')
-current=$(cat go.toolchain.rev)
-if [ "$upstream" != "$current" ]; then
-	echo "$upstream" >go.toolchain.rev
+if [ "${TS_GO_NEXT:-}" = "1" ]; then
+    go_toolchain_branch_file="go.toolchain.next.branch"
+    go_toolchain_rev_file="go.toolchain.next.rev"
+else
+    go_toolchain_branch_file="go.toolchain.branch"
+    go_toolchain_rev_file="go.toolchain.rev"
 fi
 
-./tool/go version 2>/dev/null | awk '{print $3}' | sed 's/^go//' > go.toolchain.version
+read -r go_branch <"$go_toolchain_branch_file"
+upstream=$(git ls-remote https://github.com/tailscale/go "$go_branch" | awk '{print $1}')
+current=$(cat "$go_toolchain_rev_file")
+if [ "$upstream" != "$current" ]; then
+	echo "$upstream" >"$go_toolchain_rev_file"
+fi
 
-./update-flake.sh
+# Only update go.toolchain.version and go.toolchain.rev.sri for the main toolchain,
+# skipping it if TS_GO_NEXT=1. Those two files are only used by Nix, and as of 2026-01-26
+# don't yet support TS_GO_NEXT=1 with flake.nix or in our corp CI.
+if [ "${TS_GO_NEXT:-}" != "1" ]; then
+    ./tool/go version 2>/dev/null | awk '{print $3}' | sed 's/^go//' > go.toolchain.version
+    ./update-flake.sh
+fi
 
-if [ -n "$(git diff-index --name-only HEAD -- go.toolchain.rev go.toolchain.rev.sri go.toolchain.version)" ]; then
+if [ -n "$(git diff-index --name-only HEAD -- "$go_toolchain_rev_file" go.toolchain.rev.sri go.toolchain.version)" ]; then
     echo "pull-toolchain.sh: changes imported. Use git commit to make them permanent." >&2
 fi

--- a/tool/gocross/gocross-wrapper.sh
+++ b/tool/gocross/gocross-wrapper.sh
@@ -4,7 +4,7 @@
 #
 # gocross-wrapper.sh is a wrapper that can be aliased to 'go', which
 # transparently runs the version of github.com/tailscale/go as specified repo's
-# go.toolchain.rev file.
+# go.toolchain.rev file (or go.toolchain.next.rev if TS_GO_NEXT=1).
 #
 # It also conditionally (if TS_USE_GOCROSS=1) builds gocross and uses it as a go
 # wrapper to inject certain go flags.
@@ -19,6 +19,12 @@ if [[ "${OSTYPE:-}" == "cygwin" || "${OSTYPE:-}" == "msys" ]]; then
     hash pwsh 2>/dev/null || { echo >&2 "This operation requires PowerShell Core."; exit 1; }
     pwsh -NoProfile -ExecutionPolicy Bypass "${BASH_SOURCE%/*}/gocross-wrapper.ps1" "$@"
     exit
+fi
+
+if [[ "${TS_GO_NEXT:-}" == "1" ]]; then
+    go_toolchain_rev_file="go.toolchain.next.rev"
+else
+    go_toolchain_rev_file="go.toolchain.rev"
 fi
 
 # Locate a bootstrap toolchain and (re)build gocross if necessary. We run all of
@@ -45,7 +51,7 @@ cd "$repo_root"
 # https://github.com/tailscale/go release artifact to download.
 toolchain=""
 
-read -r REV <go.toolchain.rev
+read -r REV <"$go_toolchain_rev_file"
 case "$REV" in
 /*)
     toolchain="$REV"
@@ -148,7 +154,7 @@ unset GOROOT
 # gocross is opt-in as of 2025-06-16. See tailscale/corp#26717
 # and comment above in this file.
 if [ "${TS_USE_GOCROSS:-}" != "1" ]; then
-    read -r REV <"${repo_root}/go.toolchain.rev"
+    read -r REV <"${repo_root}/$go_toolchain_rev_file"
     case "$REV" in
     /*)
         toolchain="$REV"


### PR DESCRIPTION
When TS_GO_NEXT=1 is set, update/use the
go.toolchain.next.{branch,rev} files instead.

This lets us do test deploys of Go release candidates on some
backends, without affecting all backends.

Updates tailscale/corp#36382
