### PR TITLE
hostinfo: set the `node:osVersion` attribute for Macs on OSS

### DIFF
--- a/hostinfo/hostinfo_darwin.go
+++ b/hostinfo/hostinfo_darwin.go
@@ -8,14 +8,31 @@ package hostinfo
 import (
 	"os"
 	"path/filepath"
+
+	"golang.org/x/sys/unix"
+	"tailscale.com/types/ptr"
 )
 
 func init() {
+	osVersion = lazyOSVersion.Get
 	packageType = packageTypeDarwin
 }
+
+var (
+	lazyOSVersion = &lazyAtomicValue[string]{f: ptr.To(osVersionDarwin)}
+)
 
 func packageTypeDarwin() string {
 	// Using tailscaled or IPNExtension?
 	exe, _ := os.Executable()
 	return filepath.Base(exe)
+}
+
+// Returns the marketing version (e.g., "15.0.1" or "26.0.0")
+func osVersionDarwin() string {
+	version, err := unix.Sysctl("kern.osproductversion")
+	if err != nil {
+		return ""
+	}
+	return version
 }


### PR DESCRIPTION
I've tested with a local build and I can see the new attribute appearing in my list of device attributes:

<img width="266" height="243" alt="Screenshot 2026-01-27 at 14 26 05" src="https://github.com/user-attachments/assets/936e80fc-a77e-46f0-9d5e-85083d99b4dd" />

Updates #18520