### PR TITLE
cmd/printdep: add --next flag to use rc Go build hash instead

### DIFF
--- a/assert_ts_toolchain_match.go
+++ b/assert_ts_toolchain_match.go
@@ -17,6 +17,9 @@ func init() {
 		panic("binary built with tailscale_go build tag but failed to read build info or find tailscale.toolchain.rev in build info")
 	}
 	want := strings.TrimSpace(GoToolchainRev)
+	if os.Getenv("TS_GO_NEXT") == "1" {
+		want = strings.TrimSpace(GoToolchainNextRev)
+	}
 	if tsRev != want {
 		if os.Getenv("TS_PERMIT_TOOLCHAIN_MISMATCH") == "1" {
 			fmt.Fprintf(os.Stderr, "tailscale.toolchain.rev = %q, want %q; but ignoring due to TS_PERMIT_TOOLCHAIN_MISMATCH=1\n", tsRev, want)

--- a/cmd/printdep/printdep.go
+++ b/cmd/printdep/printdep.go
@@ -19,6 +19,7 @@ var (
 	goToolchain    = flag.Bool("go", false, "print the supported Go toolchain git hash (a github.com/tailscale/go commit)")
 	goToolchainURL = flag.Bool("go-url", false, "print the URL to the tarball of the Tailscale Go toolchain")
 	alpine         = flag.Bool("alpine", false, "print the tag of alpine docker image")
+	next           = flag.Bool("next", false, "if set, modifies --go or --go-url to use the upcoming/unreleased/rc Go release version instead")
 )
 
 func main() {
@@ -27,8 +28,12 @@ func main() {
 		fmt.Println(strings.TrimSpace(ts.AlpineDockerTag))
 		return
 	}
+	goRev := strings.TrimSpace(ts.GoToolchainRev)
+	if *next {
+		goRev = strings.TrimSpace(ts.GoToolchainNextRev)
+	}
 	if *goToolchain {
-		fmt.Println(strings.TrimSpace(ts.GoToolchainRev))
+		fmt.Println(goRev)
 	}
 	if *goToolchainURL {
 		switch runtime.GOOS {
@@ -36,6 +41,6 @@ func main() {
 		default:
 			log.Fatalf("unsupported GOOS %q", runtime.GOOS)
 		}
-		fmt.Printf("https://github.com/tailscale/go/releases/download/build-%s/%s-%s.tar.gz\n", strings.TrimSpace(ts.GoToolchainRev), runtime.GOOS, runtime.GOARCH)
+		fmt.Printf("https://github.com/tailscale/go/releases/download/build-%s/%s-%s.tar.gz\n", goRev, runtime.GOOS, runtime.GOARCH)
 	}
 }

--- a/version-embed.go
+++ b/version-embed.go
@@ -26,6 +26,12 @@ var AlpineDockerTag string
 //go:embed go.toolchain.rev
 var GoToolchainRev string
 
+// GoToolchainNextRev is like GoToolchainRev, but when using the
+// "go.toolchain.next.rev" when TS_GO_NEXT=1 is set in the environment.
+//
+//go:embed go.toolchain.next.rev
+var GoToolchainNextRev string
+
 //lint:ignore U1000 used by tests + assert_ts_toolchain_match.go w/ right build tags
 func tailscaleToolchainRev() (gitHash string, ok bool) {
 	bi, ok := debug.ReadBuildInfo()


### PR DESCRIPTION
Updates tailscale/corp#36382
