### PR TITLE
cmd/testwrapper/flakytest: skip flaky tests if TS_SKIP_FLAKY_TESTS set

### DIFF
--- a/cmd/testwrapper/flakytest/flakytest.go
+++ b/cmd/testwrapper/flakytest/flakytest.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"strconv"
 	"sync"
 	"testing"
 
@@ -60,6 +61,10 @@ func Mark(t testing.TB, issue string) {
 	// And then remove this Logf a month or so after that.
 	t.Logf("flakytest: issue tracking this flaky test: %s", issue)
 
+	if boolEnv("TS_SKIP_FLAKY_TESTS") {
+		t.Skipf("skipping due to TS_SKIP_FLAKY_TESTS")
+	}
+
 	// Record the root test name as flakey.
 	rootFlakesMu.Lock()
 	defer rootFlakesMu.Unlock()
@@ -79,4 +84,13 @@ func Marked(t testing.TB) bool {
 		}
 	}
 	return false
+}
+
+func boolEnv(k string) bool {
+	s := os.Getenv(k)
+	if s == "" {
+		return false
+	}
+	v, _ := strconv.ParseBool(s)
+	return v
 }


### PR DESCRIPTION
This is for a future test scheduler, so it can run potentially flaky
tests separately, doing all the non-flaky ones together in one batch.

Updates tailscale/corp#28679
