### PR TITLE
ipn/ipnlocal/netmapcache: report the correct error for a missing column

### DIFF
--- a/ipn/ipnlocal/netmapcache/netmapcache.go
+++ b/ipn/ipnlocal/netmapcache/netmapcache.go
@@ -155,7 +155,11 @@ func (s FileStore) List(ctx context.Context, prefix string) iter.Seq2[string, er
 
 // Load implements part of the [Store] interface.
 func (s FileStore) Load(ctx context.Context, key string) ([]byte, error) {
-	return os.ReadFile(filepath.Join(string(s), hex.EncodeToString([]byte(key))))
+	data, err := os.ReadFile(filepath.Join(string(s), hex.EncodeToString([]byte(key))))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("key %q not found: %w", key, ErrKeyNotFound)
+	}
+	return data, err
 }
 
 // Store implements part of the [Store] interface.


### PR DESCRIPTION
The file-based cache implementation was not reporting the correct error when
attempting to load a missing column key. Make it do so, and update the tests to
cover that case.

Updates #12639

Change-Id: Ie2c45a0a7e528d4125f857859c92df807116a56e
Signed-off-by: M. J. Fromberger <fromberger@tailscale.com>
