### PR TITLE
wgengine/magicsock: make debugNeverDirectUDP influence remote peer de…

### DIFF
--- a/wgengine/magicsock/debugknobs.go
+++ b/wgengine/magicsock/debugknobs.go
@@ -62,7 +62,8 @@ var (
 	//
 	//lint:ignore U1000 used on Linux/Darwin only
 	debugPMTUD = envknob.RegisterBool("TS_DEBUG_PMTUD")
-	// debugNeverDirectUDP disables the use of direct UDP connections, forcing
+	// debugNeverDirectUDP disables the use of direct UDP connections by
+	// suppressing/dropping inbound/outbound [disco.Ping] messages, forcing
 	// all peer communication over DERP or peer relay.
 	debugNeverDirectUDP = envknob.RegisterBool("TS_DEBUG_NEVER_DIRECT_UDP")
 	// Hey you! Adding a new debugknob? Make sure to stub it out in the

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -2555,6 +2555,10 @@ func (c *Conn) handlePingLocked(dm *disco.Ping, src epAddr, di *discoInfo, derpN
 
 	// This is a naked [disco.Ping] without a VNI.
 
+	if debugNeverDirectUDP() && !isDerp {
+		return
+	}
+
 	// If we can figure out with certainty which node key this disco
 	// message is for, eagerly update our [epAddr]<>node and disco<>node
 	// mappings to make p2p path discovery faster in simple


### PR DESCRIPTION
…cisions

By dropping inbound disco.Ping messages received over direct UDP paths.

Fixes #18560