### PR TITLE
cmd/testwrapper: add support for the -vet test flag

### DIFF
--- a/cmd/testwrapper/args.go
+++ b/cmd/testwrapper/args.go
@@ -89,6 +89,7 @@ func newTestFlagSet() *flag.FlagSet {
 	// TODO(maisem): figure out what other flags we need to register explicitly.
 	fs.String("exec", "", "Command to run tests with")
 	fs.Bool("race", false, "build with race detector")
+	fs.String("vet", "", "vet checks to run, or 'off' or 'all'")
 	return fs
 }
 


### PR DESCRIPTION
So callers can run testwrapper with -vet=off if they're already
running vet explicitly in a concurrent test job.

Updates tailscale/corp#28679
