### PR TITLE
cmd/tailscaled/tailscale-online.target: add systemd online target

### DIFF
--- a/cmd/tailscaled/tailscale-online.target
+++ b/cmd/tailscaled/tailscale-online.target
@@ -1,0 +1,4 @@
+[Unit]
+Description=Tailscale is online
+Requires=tailscale-wait-online.service
+After=tailscale-wait-online.service

--- a/cmd/tailscaled/tailscale-wait-online.service
+++ b/cmd/tailscaled/tailscale-wait-online.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Wait for Tailscale to be online
+After=tailscaled.service
+Requires=tailscaled.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/tailscale wait
+RemainAfterExit=yes
+
+[Install]
+WantedBy=tailscale-online.target


### PR DESCRIPTION
Using the new wait command from #18574 provide a tailscale-online.target that has a similar usage model to the conventional `network-online.target`.

Updates #3340
Updates #11504