### PR TITLE
chore: add repo banner

### DIFF
--- a/.github/assets/banner.svg
+++ b/.github/assets/banner.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="304" viewBox="0 0 1280 304">
+<defs></defs>
+<rect width="1280" height="304" fill="#f3f4f6" />
+<foreignObject x="0" y="0" width="1280" height="304">
+<div xmlns="http://www.w3.org/1999/xhtml" style="width:1280px;height:304px;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:50px 100px;box-sizing:border-box;">
+  <div style="font-family:Inter, system-ui, -apple-system, sans-serif;font-size:149px;font-weight:700;color:#1f2937;line-height:1;text-align:center;white-space:nowrap;">Tailscale</div>
+  <div style="font-family:Inter, system-ui, -apple-system, sans-serif;font-size:27px;font-weight:400;color:#1f2937;line-height:1;text-align:center;white-space:nowrap;margin-top:27px;">The easiest, most secure way to use WireGuard and 2FA.</div>
+</div>
+</foreignObject>
+
+</svg>

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # Tailscale
 
-https://tailscale.com
-
-Private WireGuard® networks made easy
-
-![GitHub Repo Banner](https://ghrb.waren.build/banner?header=Tailscale&subheader=The+easiest%2C+most+secure+way+to+use+WireGuard+and+2FA.&bg=f3f4f6&color=1f2937&support=true)
+![GitHub Repo Banner](.github/assets/banner.svg)
 <!-- Created with GitHub Repo Banner by Waren Gonzaga: https://ghrb.waren.build -->
+
+Private WireGuard® networks made easy - <https://tailscale.com>
 
 ## Overview
 


### PR DESCRIPTION
Preview:

![GitHub Repo Banner](https://ghrb.waren.build/banner?header=Tailscale&subheader=The+easiest%2C+most+secure+way+to+use+WireGuard+and+2FA.&bg=f3f4f6&color=1f2937&support=true)<!-- Created with GitHub Repo Banner by Waren Gonzaga: https://ghrb.waren.build -->

Tool: https://ghrb.waren.build/
A clean SVG version is also available, just let me know.

If you want any further customization, kindly mention me.