### PR TITLE
ipn/ipnlocal/netmapcache: ensure cache updates preserve unchanged data

### DIFF
--- a/ipn/ipnlocal/netmapcache/netmapcache.go
+++ b/ipn/ipnlocal/netmapcache/netmapcache.go
@@ -86,6 +86,7 @@ func (c *Cache) writeJSON(ctx context.Context, key string, v any) error {
 	// this at all?
 	last, ok := c.lastWrote[key]
 	if ok && cacheDigest(j) == last.digest {
+		c.wantKeys.Add(key)
 		return nil
 	}
 

--- a/ipn/ipnlocal/netmapcache/netmapcache_test.go
+++ b/ipn/ipnlocal/netmapcache/netmapcache_test.go
@@ -10,6 +10,7 @@ import (
 	"flag"
 	"fmt"
 	"iter"
+	"maps"
 	"os"
 	"reflect"
 	"slices"
@@ -181,6 +182,24 @@ func TestRoundTrip(t *testing.T) {
 
 		})
 	}
+
+	t.Run("Twice", func(t *testing.T) {
+		// Verify that storing the same network map twice results in no change.
+
+		s := make(testStore)
+		c := netmapcache.NewCache(s)
+		if err := c.Store(t.Context(), testMap); err != nil {
+			t.Fatalf("Store 1 netmap failed: %v", err)
+		}
+		scp := maps.Clone(s) // for comparison, see below
+
+		if err := c.Store(t.Context(), testMap); err != nil {
+			t.Fatalf("Store 2 netmap failed; %v", err)
+		}
+		if diff := cmp.Diff(s, scp); diff != "" {
+			t.Errorf("Updated store (-got, +want):\n%s", diff)
+		}
+	})
 }
 
 func TestInvalidCache(t *testing.T) {


### PR DESCRIPTION
Found by @cmol. When rewriting the same value into the cache, we were dropping
the unchanged keys, resulting in the cache being pruned incorrectly.
Also update the tests to catch this.

Updates #12639

Change-Id: Iab67e444eb7ddc22ccc680baa2f6a741a00eb325
Signed-off-by: M. J. Fromberger <fromberger@tailscale.com>
