### PR TITLE
ssh/tailssh: skip pre-auth policy validation 

### DIFF
--- a/ssh/tailssh/auditd_linux.go
+++ b/ssh/tailssh/auditd_linux.go
@@ -123,7 +123,7 @@ func sendAuditMessage(logf logger.Logf, msgType uint16, message string) {
 
 // logSSHLogin logs an SSH login event to auditd with whois information.
 func logSSHLogin(logf logger.Logf, c *conn) {
-	if c == nil || c.info == nil || c.localUser == nil {
+	if c == nil {
 		return
 	}
 

--- a/ssh/tailssh/incubator.go
+++ b/ssh/tailssh/incubator.go
@@ -1099,7 +1099,7 @@ func (ss *sshSession) startWithStdPipes() (err error) {
 	return ss.cmd.Start()
 }
 
-func envForUser(u *userMeta) []string {
+func envForUser(u userMeta) []string {
 	return []string{
 		fmt.Sprintf("SHELL=%s", u.LoginShell()),
 		fmt.Sprintf("USER=%s", u.Username),

--- a/ssh/tailssh/incubator_plan9.go
+++ b/ssh/tailssh/incubator_plan9.go
@@ -400,7 +400,7 @@ func (ss *sshSession) startWithStdPipes() (err error) {
 	return ss.cmd.Start()
 }
 
-func envForUser(u *userMeta) []string {
+func envForUser(u userMeta) []string {
 	return []string{
 		fmt.Sprintf("user=%s", u.Username),
 		fmt.Sprintf("home=%s", u.HomeDir),

--- a/ssh/tailssh/tailssh_test.go
+++ b/ssh/tailssh/tailssh_test.go
@@ -64,31 +64,20 @@ func TestMatchRule(t *testing.T) {
 	tests := []struct {
 		name          string
 		rule          *tailcfg.SSHRule
-		ci            *sshConnInfo
+		ci            sshConnInfo
 		wantErr       error
 		wantUser      string
 		wantAcceptEnv []string
 	}{
 		{
-			name: "invalid-conn",
-			rule: &tailcfg.SSHRule{
-				Action:     someAction,
-				Principals: []*tailcfg.SSHPrincipal{{Any: true}},
-				SSHUsers: map[string]string{
-					"*": "ubuntu",
-				},
-			},
-			wantErr: errInvalidConn,
-		},
-		{
 			name:    "nil-rule",
-			ci:      &sshConnInfo{},
+			ci:      sshConnInfo{},
 			rule:    nil,
 			wantErr: errNilRule,
 		},
 		{
 			name:    "nil-action",
-			ci:      &sshConnInfo{},
+			ci:      sshConnInfo{},
 			rule:    &tailcfg.SSHRule{},
 			wantErr: errNilAction,
 		},
@@ -98,7 +87,7 @@ func TestMatchRule(t *testing.T) {
 				Action:      someAction,
 				RuleExpires: ptr.To(time.Unix(100, 0)),
 			},
-			ci:      &sshConnInfo{},
+			ci:      sshConnInfo{},
 			wantErr: errRuleExpired,
 		},
 		{
@@ -108,7 +97,7 @@ func TestMatchRule(t *testing.T) {
 				SSHUsers: map[string]string{
 					"*": "ubuntu",
 				}},
-			ci:      &sshConnInfo{},
+			ci:      sshConnInfo{},
 			wantErr: errPrincipalMatch,
 		},
 		{
@@ -117,7 +106,7 @@ func TestMatchRule(t *testing.T) {
 				Action:     someAction,
 				Principals: []*tailcfg.SSHPrincipal{{Any: true}},
 			},
-			ci:      &sshConnInfo{sshUser: "alice"},
+			ci:      sshConnInfo{sshUser: "alice"},
 			wantErr: errUserMatch,
 		},
 		{
@@ -129,7 +118,7 @@ func TestMatchRule(t *testing.T) {
 					"*": "ubuntu",
 				},
 			},
-			ci:       &sshConnInfo{sshUser: "alice"},
+			ci:       sshConnInfo{sshUser: "alice"},
 			wantUser: "ubuntu",
 		},
 		{
@@ -144,7 +133,7 @@ func TestMatchRule(t *testing.T) {
 					"*": "ubuntu",
 				},
 			},
-			ci:       &sshConnInfo{sshUser: "alice"},
+			ci:       sshConnInfo{sshUser: "alice"},
 			wantUser: "ubuntu",
 		},
 		{
@@ -157,7 +146,7 @@ func TestMatchRule(t *testing.T) {
 					"alice": "thealice",
 				},
 			},
-			ci:       &sshConnInfo{sshUser: "alice"},
+			ci:       sshConnInfo{sshUser: "alice"},
 			wantUser: "thealice",
 		},
 		{
@@ -171,7 +160,7 @@ func TestMatchRule(t *testing.T) {
 				},
 				AcceptEnv: []string{"EXAMPLE", "?_?", "TEST_*"},
 			},
-			ci:            &sshConnInfo{sshUser: "alice"},
+			ci:            sshConnInfo{sshUser: "alice"},
 			wantUser:      "thealice",
 			wantAcceptEnv: []string{"EXAMPLE", "?_?", "TEST_*"},
 		},
@@ -181,7 +170,7 @@ func TestMatchRule(t *testing.T) {
 				Principals: []*tailcfg.SSHPrincipal{{Any: true}},
 				Action:     &tailcfg.SSHAction{Reject: true},
 			},
-			ci: &sshConnInfo{sshUser: "alice"},
+			ci: sshConnInfo{sshUser: "alice"},
 		},
 		{
 			name: "match-principal-node-ip",
@@ -190,7 +179,7 @@ func TestMatchRule(t *testing.T) {
 				Principals: []*tailcfg.SSHPrincipal{{NodeIP: "1.2.3.4"}},
 				SSHUsers:   map[string]string{"*": "ubuntu"},
 			},
-			ci:       &sshConnInfo{src: netip.MustParseAddrPort("1.2.3.4:30343")},
+			ci:       sshConnInfo{src: netip.MustParseAddrPort("1.2.3.4:30343")},
 			wantUser: "ubuntu",
 		},
 		{
@@ -200,7 +189,7 @@ func TestMatchRule(t *testing.T) {
 				Principals: []*tailcfg.SSHPrincipal{{Node: "some-node-ID"}},
 				SSHUsers:   map[string]string{"*": "ubuntu"},
 			},
-			ci:       &sshConnInfo{node: (&tailcfg.Node{StableID: "some-node-ID"}).View()},
+			ci:       sshConnInfo{node: (&tailcfg.Node{StableID: "some-node-ID"}).View()},
 			wantUser: "ubuntu",
 		},
 		{
@@ -210,7 +199,7 @@ func TestMatchRule(t *testing.T) {
 				Principals: []*tailcfg.SSHPrincipal{{UserLogin: "foo@bar.com"}},
 				SSHUsers:   map[string]string{"*": "ubuntu"},
 			},
-			ci:       &sshConnInfo{uprof: tailcfg.UserProfile{LoginName: "foo@bar.com"}},
+			ci:       sshConnInfo{uprof: tailcfg.UserProfile{LoginName: "foo@bar.com"}},
 			wantUser: "ubuntu",
 		},
 		{
@@ -222,7 +211,7 @@ func TestMatchRule(t *testing.T) {
 					"*": "=",
 				},
 			},
-			ci:       &sshConnInfo{sshUser: "alice"},
+			ci:       sshConnInfo{sshUser: "alice"},
 			wantUser: "alice",
 		},
 	}
@@ -254,7 +243,7 @@ func TestEvalSSHPolicy(t *testing.T) {
 	tests := []struct {
 		name          string
 		policy        *tailcfg.SSHPolicy
-		ci            *sshConnInfo
+		ci            sshConnInfo
 		wantResult    evalResult
 		wantUser      string
 		wantAcceptEnv []string
@@ -298,7 +287,7 @@ func TestEvalSSHPolicy(t *testing.T) {
 					},
 				},
 			},
-			ci:            &sshConnInfo{sshUser: "alice"},
+			ci:            sshConnInfo{sshUser: "alice"},
 			wantUser:      "thealice",
 			wantAcceptEnv: []string{"EXAMPLE", "?_?", "TEST_*"},
 			wantResult:    accepted,
@@ -308,7 +297,7 @@ func TestEvalSSHPolicy(t *testing.T) {
 			policy: &tailcfg.SSHPolicy{
 				Rules: []*tailcfg.SSHRule{},
 			},
-			ci:            &sshConnInfo{sshUser: "alice"},
+			ci:            sshConnInfo{sshUser: "alice"},
 			wantUser:      "",
 			wantAcceptEnv: nil,
 			wantResult:    rejected,
@@ -349,7 +338,7 @@ func TestEvalSSHPolicy(t *testing.T) {
 					},
 				},
 			},
-			ci:            &sshConnInfo{sshUser: "alice"},
+			ci:            sshConnInfo{sshUser: "alice"},
 			wantUser:      "",
 			wantAcceptEnv: nil,
 			wantResult:    rejectedUser,
@@ -1100,7 +1089,7 @@ func TestSSH(t *testing.T) {
 		t.Fatal(err)
 	}
 	sc.localUser = um
-	sc.info = &sshConnInfo{
+	sc.info = sshConnInfo{
 		sshUser: "test",
 		src:     netip.MustParseAddrPort("1.2.3.4:32342"),
 		dst:     netip.MustParseAddrPort("1.2.3.5:22"),
@@ -1318,76 +1307,72 @@ func TestStdOsUserUserAssumptions(t *testing.T) {
 	}
 }
 
-func TestOnPolicyChangeHandlesNilLocalUser(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		srv := &server{
-			logf: tstest.WhileTestRunningLogger(t),
-			lb: &localState{
-				sshEnabled:   true,
-				matchingRule: newSSHRule(&tailcfg.SSHAction{Accept: true}),
-			},
-		}
-		c := &conn{
-			srv:  srv,
-			info: &sshConnInfo{sshUser: "alice"},
-		}
-		srv.activeConns = map[*conn]bool{c: true}
+func TestOnPolicyChangeDefersValidationOnEmptyLocalUser(t *testing.T) {
+	tests := []struct {
+		name                   string
+		sshRule                *tailcfg.SSHRule
+		wantCancelOnValidation bool
+	}{
+		{
+			name:                   "defer-then-accept-when-allowed",
+			sshRule:                newSSHRule(&tailcfg.SSHAction{Accept: true}),
+			wantCancelOnValidation: false,
+		},
+		{
+			name:                   "defer-then-reject-when-not-allowed",
+			sshRule:                newSSHRule(&tailcfg.SSHAction{Reject: true}),
+			wantCancelOnValidation: true,
+		},
+	}
 
-		srv.OnPolicyChange()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 
-		synctest.Wait()
-	})
-}
-
-func TestRaceWriteAndReadConnInfoAndLocalUser(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		srv := &server{
-			logf: tstest.WhileTestRunningLogger(t),
-			lb: &localState{
-				sshEnabled:   true,
-				matchingRule: newSSHRule(&tailcfg.SSHAction{Accept: true}),
-			},
-		}
-		c := &conn{
-			srv:  srv,
-			info: &sshConnInfo{sshUser: "alice"},
-		}
-		srv.activeConns = map[*conn]bool{c: true}
-
-		fakeClientAuth := func() {
-			c.mu.Lock()
-			c.info = &sshConnInfo{sshUser: "alice"}
-			c.mu.Unlock()
-
-			c.mu.Lock()
-			c.localUser = &userMeta{User: user.User{Username: currentUser}}
-			c.mu.Unlock()
-		}
-
-		// Simulate a race between clientAuth() writing and OnPolicyChange reading a connection's info and localUser.
-		done := make(chan struct{})
-		go func() {
-			for i := 0; i < 100; i++ {
-				select {
-				case <-done:
-					return
-				default:
-					fakeClientAuth()
+			synctest.Test(t, func(t *testing.T) {
+				srv := &server{
+					logf: tstest.WhileTestRunningLogger(t),
+					lb: &localState{
+						sshEnabled:   true,
+						matchingRule: tt.sshRule,
+					},
 				}
-			}
-		}()
-
-		go func() {
-			for i := 0; i < 100; i++ {
-				select {
-				case <-done:
-					return
-				default:
-					srv.OnPolicyChange()
+				c := &conn{
+					srv:  srv,
+					info: sshConnInfo{sshUser: "alice"},
 				}
-			}
-		}()
-	})
+				srv.activeConns = map[*conn]bool{c: true}
+				ctx, cancel := context.WithCancelCause(context.Background())
+				ss := &sshSession{ctx: ctx, cancelCtx: cancel}
+				c.sessions = []*sshSession{ss}
+
+				srv.OnPolicyChange()
+				synctest.Wait()
+				select {
+				case <-ctx.Done():
+					t.Fatal("expected deferral of cancellation decision while localUser unset but session got canceled")
+				default:
+				}
+
+				c.mu.Lock()
+				c.info.isSet = true
+				c.localUser = userMeta{User: user.User{Username: currentUser}}
+				c.mu.Unlock()
+
+				srv.OnPolicyChange()
+				synctest.Wait()
+				select {
+				case <-ctx.Done():
+					if !tt.wantCancelOnValidation {
+						t.Fatal("valid session shouldn't have been canceled")
+					}
+				default:
+					if tt.wantCancelOnValidation {
+						t.Fatal("invalid session should have been canceled but it wasn't")
+					}
+				}
+			})
+		})
+	}
 }
 
 func mockRecordingServer(t *testing.T, handleRecord http.HandlerFunc) *httptest.Server {

--- a/ssh/tailssh/user.go
+++ b/ssh/tailssh/user.go
@@ -36,15 +36,15 @@ func (u *userMeta) GroupIds() ([]string, error) {
 	return osuser.GetGroupIds(&u.User)
 }
 
-// userLookup is like os/user.Lookup but it returns a *userMeta wrapper
+// userLookup is like os/user.Lookup but it returns a userMeta wrapper
 // around a *user.User with extra fields.
-func userLookup(username string) (*userMeta, error) {
+func userLookup(username string) (userMeta, error) {
 	u, s, err := osuser.LookupByUsernameWithShell(username)
 	if err != nil {
-		return nil, err
+		return userMeta{}, err
 	}
 
-	return &userMeta{User: *u, loginShellCached: s}, nil
+	return userMeta{User: *u, loginShellCached: s}, nil
 }
 
 func (u *userMeta) LoginShell() string {


### PR DESCRIPTION
When the OnPolicyChange handler is called before authentication has completed, the localUser field on the connection may not have been populated yet, which leads to a nil pointer dereference when OnPolicyChange tries to read it. 

In order to avoid this, we skip the validation when the localUser is empty (something we're already doing when the info field is empty). The authentication will check compliance with the policy once it completes.

Updates tailscale/corp#36268