### PR TITLE
tailcfg: add peerRelay bool to hostinfo

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -5671,6 +5671,10 @@ func (b *LocalBackend) applyPrefsToHostinfoLocked(hi *tailcfg.Hostinfo, prefs ip
 	}
 	hi.SSH_HostKeys = sshHostKeys
 
+	if buildfeatures.HasRelayServer {
+		hi.PeerRelay = prefs.RelayServerPort().Valid()
+	}
+
 	for _, f := range hookMaybeMutateHostinfoLocked {
 		f(b, hi, prefs)
 	}

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -887,6 +887,7 @@ type Hostinfo struct {
 	UserspaceRouter opt.Bool       `json:",omitzero"` // if the client's subnet router is running in userspace (netstack) mode
 	AppConnector    opt.Bool       `json:",omitzero"` // if the client is running the app-connector service
 	ServicesHash    string         `json:",omitzero"` // opaque hash of the most recent list of tailnet services, change in hash indicates config should be fetched via c2n
+	PeerRelay       bool           `json:",omitzero"` // if the client is willing to relay traffic for other peers
 	ExitNodeID      StableNodeID   `json:",omitzero"` // the client’s selected exit node, empty when unselected.
 
 	// Location represents geographical location data about a

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -186,6 +186,7 @@ var _HostinfoCloneNeedsRegeneration = Hostinfo(struct {
 	UserspaceRouter opt.Bool
 	AppConnector    opt.Bool
 	ServicesHash    string
+	PeerRelay       bool
 	ExitNodeID      StableNodeID
 	Location        *Location
 	TPM             *TPMInfo

--- a/tailcfg/tailcfg_test.go
+++ b/tailcfg/tailcfg_test.go
@@ -67,6 +67,7 @@ func TestHostinfoEqual(t *testing.T) {
 		"UserspaceRouter",
 		"AppConnector",
 		"ServicesHash",
+		"PeerRelay",
 		"ExitNodeID",
 		"Location",
 		"TPM",
@@ -242,6 +243,16 @@ func TestHostinfoEqual(t *testing.T) {
 		{
 			&Hostinfo{AppConnector: opt.Bool("true")},
 			&Hostinfo{AppConnector: opt.Bool("false")},
+			false,
+		},
+		{
+			&Hostinfo{PeerRelay: true},
+			&Hostinfo{PeerRelay: true},
+			true,
+		},
+		{
+			&Hostinfo{PeerRelay: true},
+			&Hostinfo{PeerRelay: false},
 			false,
 		},
 		{

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -606,6 +606,9 @@ func (v HostinfoView) AppConnector() opt.Bool { return v.ж.AppConnector }
 // opaque hash of the most recent list of tailnet services, change in hash indicates config should be fetched via c2n
 func (v HostinfoView) ServicesHash() string { return v.ж.ServicesHash }
 
+// if the client is willing to relay traffic for other peers
+func (v HostinfoView) PeerRelay() bool { return v.ж.PeerRelay }
+
 // the client’s selected exit node, empty when unselected.
 func (v HostinfoView) ExitNodeID() StableNodeID { return v.ж.ExitNodeID }
 
@@ -664,6 +667,7 @@ var _HostinfoViewNeedsRegeneration = Hostinfo(struct {
 	UserspaceRouter opt.Bool
 	AppConnector    opt.Bool
 	ServicesHash    string
+	PeerRelay       bool
 	ExitNodeID      StableNodeID
 	Location        *Location
 	TPM             *TPMInfo


### PR DESCRIPTION
This commit adds a bool named PeerRelay to Hostinfo, to identify the host's status of acting as a peer relay. Considering the RelayServerPort number can be 0, I just made this a bool in stead of a port number. If the port info is needed in future this would also help indicating if the port was set to 0 (meaning any port in peer relay context).

Updates tailscale/corp##35862