### PR TITLE
cmd/tailscale: use advertise tags from prefs for OAuth and id federation

### DIFF
--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -641,7 +641,7 @@ func runUp(ctx context.Context, cmd string, args []string, upArgs upArgsT) (retE
 				}
 			}
 
-			authKey, err = f(ctx, clientSecret, strings.Split(upArgs.advertiseTags, ","))
+			authKey, err = f(ctx, clientSecret, prefs.AdvertiseTags)
 			if err != nil {
 				return err
 			}
@@ -654,7 +654,7 @@ func runUp(ctx context.Context, cmd string, args []string, upArgs upArgsT) (retE
 				return err
 			}
 
-			authKey, err = f(ctx, prefs.ControlURL, upArgs.clientID, idToken, upArgs.audience, strings.Split(upArgs.advertiseTags, ","))
+			authKey, err = f(ctx, prefs.ControlURL, upArgs.clientID, idToken, upArgs.audience, prefs.AdvertiseTags)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Use the parsed and validated advertise tags value from prefs instead of doing a strings.Split on the raw tags value as an input to the OAuth and identity federation auth key generation methods.

The previous strings.Split method would return an array with a single empty string element which would pass downstream length checks on the tags argument before eventually failing with a confusing message when hitting the API.

Fixes https://github.com/tailscale/tailscale/issues/18617