### PR TITLE
ipn/ipnlocal: skip AuthKey use if profiles exist

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -2478,7 +2478,9 @@ func (b *LocalBackend) startLocked(opts ipn.Options) error {
 
 	if b.state != ipn.Running && b.conf == nil && opts.AuthKey == "" {
 		sysak, _ := b.polc.GetString(pkey.AuthKey, "")
-		if sysak != "" {
+		if sysak != "" && len(b.pm.Profiles()) > 0 && b.state != ipn.NeedsLogin {
+			logf("not setting opts.AuthKey from syspolicy; login profiles exist, state=%v", b.state)
+		} else if sysak != "" {
 			logf("setting opts.AuthKey by syspolicy, len=%v", len(sysak))
 			opts.AuthKey = strings.TrimSpace(sysak)
 		}


### PR DESCRIPTION
If any profiles exist and an Authkey is provided via syspolicy, the AuthKey is ignored on backend start, preventing re-auth attempts. This is useful for one-time device provisioning scenarios, skipping authKey use after initial setup when the authKey may no longer be valid.

Following the [syspolicy docs](https://tailscale.com/docs/features/tailscale-system-policies#set-an-auth-key), this is the correct approach for the moment. Going forward, layering in support for a new policy, `AuthOnce`, rather than checking for existing profiles may be helpful.

<img width="756" height="392" alt="image" src="https://github.com/user-attachments/assets/672ba039-924a-4633-aedb-bd1980c1d0b5" />

updates #18618