### PR TITLE
cmd/tailscale/cli: add bind-address and bind-port flags to netcheck command

### DIFF
--- a/cmd/tailscale/cli/netcheck.go
+++ b/cmd/tailscale/cli/netcheck.go
@@ -311,7 +311,7 @@ func createNetcheckBindString(cliAddress string, cliAddressIsSet bool, cliPort i
 	if cliAddressIsSet {
 		addr, err := netip.ParseAddr(cliAddress)
 		if err != nil {
-			return "", fmt.Errorf("invalid bind address: %q (%v)", cliAddress, err)
+			return "", fmt.Errorf("invalid bind address: %q", cliAddress)
 		}
 		return netip.AddrPortFrom(addr, port).String(), nil
 	} else {

--- a/cmd/tailscale/cli/netcheck_test.go
+++ b/cmd/tailscale/cli/netcheck_test.go
@@ -75,13 +75,13 @@ func TestCreateBindStr(t *testing.T) {
 			name:            "badAddr-noPort-noEnv-1",
 			cliAddress:      "678.678.678.678",
 			cliAddressIsSet: true,
-			wantError:       `invalid bind address: "678.678.678.678" (ParseAddr("678.678.678.678"): IPv4 field has value >255)`,
+			wantError:       `invalid bind address: "678.678.678.678"`,
 		},
 		{
 			name:            "badAddr-noPort-noEnv-2",
 			cliAddress:      "lorem ipsum",
 			cliAddressIsSet: true,
-			wantError:       `invalid bind address: "lorem ipsum" (ParseAddr("lorem ipsum"): unable to parse IP)`,
+			wantError:       `invalid bind address: "lorem ipsum"`,
 		},
 		{
 			name:         "noAddr-badPort-noEnv",


### PR DESCRIPTION
Add more explicit `--bind-address` and `--bind-port` flags to the `tailscale netcheck` CLI to give users control over UDP probes' source IP and UDP port.

This was already supported in a less documented manner via the `TS_DEBUG_NETCHECK_UDP_BIND` environment variable. The environment variable reference is preserved and used as a fallback value in the absence of these new CLI flags.

Updates tailscale/corp#36833