### PR TITLE
cmd/tailscale: add event bus queue depth debugging

### DIFF
--- a/client/local/local.go
+++ b/client/local/local.go
@@ -446,6 +446,11 @@ func (lc *Client) EventBusGraph(ctx context.Context) ([]byte, error) {
 	return lc.get200(ctx, "/localapi/v0/debug-bus-graph")
 }
 
+// EventBusQueues returns a JSON snapshot of event bus queue depths per client.
+func (lc *Client) EventBusQueues(ctx context.Context) ([]byte, error) {
+	return lc.get200(ctx, "/localapi/v0/debug-bus-queues")
+}
+
 // StreamBusEvents returns an iterator of Tailscale bus events as they arrive.
 // Each pair is a valid event and a nil error, or a zero event a non-nil error.
 // In case of error, the iterator ends after the pair reporting the error.

--- a/cmd/tailscale/cli/debug.go
+++ b/cmd/tailscale/cli/debug.go
@@ -125,6 +125,12 @@ func debugCmd() *ffcli.Command {
 				})(),
 			},
 			{
+				Name:       "daemon-bus-queues",
+				ShortUsage: "tailscale debug daemon-bus-queues",
+				Exec:       runDaemonBusQueues,
+				ShortHelp:  "Print event bus queue depths per client",
+			},
+			{
 				Name:       "metrics",
 				ShortUsage: "tailscale debug metrics",
 				Exec:       runDaemonMetrics,
@@ -837,6 +843,15 @@ func runDaemonBusGraph(ctx context.Context, args []string) error {
 	} else {
 		fmt.Print(string(graph))
 	}
+	return nil
+}
+
+func runDaemonBusQueues(ctx context.Context, args []string) error {
+	data, err := localClient.EventBusQueues(ctx)
+	if err != nil {
+		return err
+	}
+	fmt.Print(string(data))
 	return nil
 }
 


### PR DESCRIPTION
Under extremely high load it appears we may have some retention issues as a result of queue depth build up, but there is currently no direct way to observe this. The scenario does not trigger the slow subscriber log message, and the event stream debugging endpoint produces a saturating volume of information.

Updates tailscale/corp#36904