### PR TITLE
control/controlclient: fix canSkipStatus online conditions

### DIFF
--- a/control/controlclient/auto.go
+++ b/control/controlclient/auto.go
@@ -674,17 +674,16 @@ func canSkipStatus(s1, s2 *Status) bool {
 		// we can't skip it.
 		return false
 	}
-	if s1.Err != nil || s1.URL != "" || s1.LoggedIn {
-		// If s1 has an error, a URL, or LoginFinished set, we shouldn't skip it,
-		// lest the error go away in s2 or in-between. We want to make sure all
-		// the subsystems see it. Plus there aren't many of these, so not worth
-		// skipping.
+	if s1.Err != nil || s1.URL != "" {
+		// If s1 has an error or an URL, we shouldn't skip it, lest the error go
+		// away in s2 or in-between. We want to make sure all the subsystems see
+		// it. Plus there aren't many of these, so not worth skipping.
 		return false
 	}
 	if !s1.Persist.Equals(s2.Persist) || s1.LoggedIn != s2.LoggedIn || s1.InMapPoll != s2.InMapPoll || s1.URL != s2.URL {
-		// If s1 has a different Persist, LoginFinished, Synced, or URL than s2,
-		// don't skip it. We only care about skipping the typical
-		// entries where the only difference is the NetMap.
+		// If s1 has a different Persist, has changed login state, changed map
+		// poll state, or has a new login URL, don't skip it. We only care about
+		// skipping the typical entries where the only difference is the NetMap.
 		return false
 	}
 	// If nothing above precludes it, and both s1 and s2 have NetMaps, then

--- a/control/controlclient/controlclient_test.go
+++ b/control/controlclient/controlclient_test.go
@@ -98,6 +98,7 @@ func TestCanSkipStatus(t *testing.T) {
 	nm1 := &netmap.NetworkMap{}
 	nm2 := &netmap.NetworkMap{}
 
+	commonPersist := new(persist.Persist).View()
 	tests := []struct {
 		name   string
 		s1, s2 *Status
@@ -165,8 +166,8 @@ func TestCanSkipStatus(t *testing.T) {
 		},
 		{
 			name: "skip",
-			s1:   &Status{NetMap: nm1},
-			s2:   &Status{NetMap: nm2},
+			s1:   &Status{NetMap: nm1, LoggedIn: true, InMapPoll: true, Persist: commonPersist},
+			s2:   &Status{NetMap: nm2, LoggedIn: true, InMapPoll: true, Persist: commonPersist},
 			want: true,
 		},
 	}


### PR DESCRIPTION
concurrent netmaps that if the first is logged in, it is never skipped. This should have been covered be the skip test case, but that case wasn't updated to include level set state.

Updates #12639
Updates #17869