### PR TITLE
clientupdate, cmd/tailscale/cli: support updating to release-candidates

### DIFF
--- a/cmd/tailscale/cli/update.go
+++ b/cmd/tailscale/cli/update.go
@@ -22,8 +22,11 @@ import (
 func init() {
 	maybeUpdateCmd = func() *ffcli.Command { return updateCmd }
 
-	clientupdateLatestTailscaleVersion.Set(func() (string, error) {
-		return clientupdate.LatestTailscaleVersion(clientupdate.CurrentTrack)
+	clientupdateLatestTailscaleVersion.Set(func(track string) (string, error) {
+		if track == "" {
+			return clientupdate.LatestTailscaleVersion(clientupdate.CurrentTrack)
+		}
+		return clientupdate.LatestTailscaleVersion(track)
 	})
 }
 
@@ -50,7 +53,7 @@ var updateCmd = &ffcli.Command{
 			distro.Get() != distro.Synology &&
 			runtime.GOOS != "freebsd" &&
 			runtime.GOOS != "darwin" {
-			fs.StringVar(&updateArgs.track, "track", "", `which track to check for updates: "stable" or "unstable" (dev); empty means same as current`)
+			fs.StringVar(&updateArgs.track, "track", "", `which track to check for updates: "stable", "release-candidate", or "unstable" (dev); empty means same as current`)
 			fs.StringVar(&updateArgs.version, "version", "", `explicit version to update/downgrade to`)
 		}
 		return fs

--- a/cmd/tailscale/cli/version.go
+++ b/cmd/tailscale/cli/version.go
@@ -24,6 +24,7 @@ var versionCmd = &ffcli.Command{
 		fs.BoolVar(&versionArgs.daemon, "daemon", false, "also print local node's daemon version")
 		fs.BoolVar(&versionArgs.json, "json", false, "output in JSON format")
 		fs.BoolVar(&versionArgs.upstream, "upstream", false, "fetch and print the latest upstream release version from pkgs.tailscale.com")
+		fs.StringVar(&versionArgs.track, "track", "", `which track to check for updates: "stable", "release-candidate", or "unstable" (dev); empty means same as current`)
 		return fs
 	})(),
 	Exec: runVersion,
@@ -33,9 +34,10 @@ var versionArgs struct {
 	daemon   bool // also check local node's daemon version
 	json     bool
 	upstream bool
+	track    string
 }
 
-var clientupdateLatestTailscaleVersion feature.Hook[func() (string, error)]
+var clientupdateLatestTailscaleVersion feature.Hook[func(string) (string, error)]
 
 func runVersion(ctx context.Context, args []string) error {
 	if len(args) > 0 {
@@ -57,7 +59,7 @@ func runVersion(ctx context.Context, args []string) error {
 		if !ok {
 			return fmt.Errorf("fetching latest version not supported in this build")
 		}
-		upstreamVer, err = f()
+		upstreamVer, err = f(versionArgs.track)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Adds a new track for release candidates. Supports querying by track in version and updating to RCs in update for supported platforms.

updates #18193