### PR TITLE
cmd/k8s-operator: add accept-app-caps annotation for Ingress resources

### DIFF
--- a/cmd/k8s-operator/sts.go
+++ b/cmd/k8s-operator/sts.go
@@ -69,8 +69,9 @@ const (
 	AnnotationProxyGroup = "tailscale.com/proxy-group"
 
 	// Annotations settable by users on ingresses.
-	AnnotationFunnel       = "tailscale.com/funnel"
-	AnnotationHTTPRedirect = "tailscale.com/http-redirect"
+	AnnotationFunnel         = "tailscale.com/funnel"
+	AnnotationHTTPRedirect   = "tailscale.com/http-redirect"
+	AnnotationAcceptAppCaps  = "tailscale.com/accept-app-caps"
 
 	// If set to true, set up iptables/nftables rules in the proxy forward
 	// cluster traffic to the tailnet IP of that proxy. This can only be set


### PR DESCRIPTION
## Summary

- Add `tailscale.com/accept-app-caps` annotation on Ingress resources that populates the `AcceptAppCaps` field on `ipn.HTTPHandler` entries in the serve config
- This causes the serve proxy to forward matching peer capabilities in the `Tailscale-App-Capabilities` header to backends
- Both the standard Ingress reconciler and the HA (ProxyGroup) Ingress reconciler benefit since they share `handlersForIngress()`

## Details

The `ipn.HTTPHandler` struct already has an `AcceptAppCaps` field, and the serve proxy already handles forwarding matching peer capabilities in the `Tailscale-App-Capabilities` header to backends. The K8s operator simply never populated this field when building serve configs for Ingress resources.

The annotation accepts a comma-separated list of capability names (e.g. `example.com/cap/monitoring,example.com/cap/admin`). Each capability is validated against the standard `validAppCap` regex (same pattern used in `cmd/tailscale/cli/serve_v2.go`). Invalid capabilities are skipped with a warning event, consistent with the operator's existing soft-validation pattern.

Capabilities are applied per-Ingress (all handlers in a given Ingress get the same set). Users needing per-path granularity can create separate Ingress resources.

## Test plan

- [x] `go build ./cmd/k8s-operator/...` passes
- [x] `go vet ./cmd/k8s-operator/...` passes
- [x] `TestTailscaleIngressWithAcceptAppCaps` — verifies standard Ingress reconciler sets `AcceptAppCaps` on serve config handlers
- [x] `TestParseAcceptAppCaps` — unit tests for parsing: valid single/multiple caps, whitespace handling, invalid caps skipped with warning events
- [x] `TestIngressPGReconciler_AcceptAppCaps` — verifies HA (ProxyGroup) Ingress reconciler sets `AcceptAppCaps` on ConfigMap serve config handlers
- [x] Existing `TestTailscaleIngress`, `TestTailscaleIngressWithHTTPRedirect`, `TestIngressPGReconciler`, `TestIngressPGReconciler_HTTPRedirect` all still pass

Updates https://github.com/tailscale/tailscale/issues/18641

🤖 Generated with [Claude Code](https://claude.com/claude-code)