### PR TITLE
cmd/tailscaled: update documentation url

### DIFF
--- a/cmd/tailscaled/tailscaled.service
+++ b/cmd/tailscaled/tailscaled.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Tailscale node agent
-Documentation=https://tailscale.com/kb/
+Documentation=https://tailscale.com/docs/
 Wants=network-pre.target
 After=network-pre.target NetworkManager.service systemd-resolved.service
 


### PR DESCRIPTION
This updates the URL shown by systemd to the new URL used by the docs after the recent migration.

Fixes #18646