### PR TITLE
ipn: reject advertised routes with non-address bits set

### DIFF
--- a/ipn/conf.go
+++ b/ipn/conf.go
@@ -4,6 +4,7 @@
 package ipn
 
 import (
+	"errors"
 	"fmt"
 	"net/netip"
 
@@ -102,10 +103,14 @@ func (c *ConfigVAlpha) ToPrefs() (MaskedPrefs, error) {
 		mp.ExitNodeAllowLANAccessSet = true
 	}
 	if c.AdvertiseRoutes != nil {
+		var routeErrs []error
 		for _, route := range c.AdvertiseRoutes {
 			if route != route.Masked() {
-				return mp, fmt.Errorf("route %s has non-address bits set; expected %s", route, route.Masked())
+				routeErrs = append(routeErrs, fmt.Errorf("route %s has non-address bits set; expected %s", route, route.Masked()))
 			}
+		}
+		if err := errors.Join(routeErrs...); err != nil {
+			return mp, err
 		}
 		mp.AdvertiseRoutes = c.AdvertiseRoutes
 		mp.AdvertiseRoutesSet = true

--- a/ipn/conf_test.go
+++ b/ipn/conf_test.go
@@ -4,79 +4,9 @@
 package ipn
 
 import (
-	"encoding/json"
 	"net/netip"
 	"testing"
 )
-
-// TestConfigVAlpha_AdvertiseRoutes_InvalidPrefix tests that ToPrefs rejects
-// advertised route prefixes with non-address bits set (e.g., 10.0.0.1/24
-// instead of 10.0.0.0/24).
-func TestConfigVAlpha_AdvertiseRoutes_InvalidPrefix(t *testing.T) {
-	tests := []struct {
-		name       string
-		jsonConfig string
-		wantErr    bool
-	}{
-		{
-			name: "valid_ipv4",
-			jsonConfig: `{
-				"version": "alpha0",
-				"advertiseRoutes": ["10.0.0.0/24"]
-			}`,
-			wantErr: false,
-		},
-		{
-			name: "valid_ipv6",
-			jsonConfig: `{
-				"version": "alpha0",
-				"advertiseRoutes": ["2a01:4f9:c010:c015::/64"]
-			}`,
-			wantErr: false,
-		},
-		{
-			name: "invalid_ipv4_non_address_bits",
-			jsonConfig: `{
-				"version": "alpha0",
-				"advertiseRoutes": ["10.0.0.1/24"]
-			}`,
-			wantErr: true,
-		},
-		{
-			name: "invalid_ipv6_non_address_bits",
-			jsonConfig: `{
-				"version": "alpha0",
-				"advertiseRoutes": ["2a01:4f9:c010:c015::1/64"]
-			}`,
-			wantErr: true,
-		},
-		{
-			name: "invalid_ipv6_multiple_routes",
-			jsonConfig: `{
-				"version": "alpha0",
-				"advertiseRoutes": [
-					"10.0.0.0/24",
-					"2a01:4f9:c010:c015::1/64"
-				]
-			}`,
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var cfg ConfigVAlpha
-			if err := json.Unmarshal([]byte(tt.jsonConfig), &cfg); err != nil {
-				t.Fatalf("json.Unmarshal() error = %v", err)
-			}
-
-			_, err := cfg.ToPrefs()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("cfg.ToPrefs() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
 
 // TestConfigVAlpha_ToPrefs_AdvertiseRoutes tests that ToPrefs validates routes
 // provided directly as netip.Prefix values (not parsed from JSON).

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -4254,12 +4254,13 @@ func (b *LocalBackend) checkAutoUpdatePrefsLocked(p *ipn.Prefs) error {
 // checkAdvertiseRoutes validates that all advertised routes have
 // properly masked prefixes (no non-address bits set).
 func checkAdvertiseRoutes(p *ipn.Prefs) error {
+	var errs []error
 	for _, route := range p.AdvertiseRoutes {
 		if route != route.Masked() {
-			return fmt.Errorf("route %s has non-address bits set; expected %s", route, route.Masked())
+			errs = append(errs, fmt.Errorf("route %s has non-address bits set; expected %s", route, route.Masked()))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // SetUseExitNodeEnabled turns on or off the most recently selected exit node.

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -7618,9 +7618,6 @@ func TestAdvertiseRoute_InvalidPrefix(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("AdvertiseRoute() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if err != nil {
-				t.Logf("Expected error: %v", err)
-			}
 		})
 	}
 }
@@ -7671,9 +7668,6 @@ func TestEditPrefs_InvalidAdvertiseRoutes(t *testing.T) {
 			_, err := b.EditPrefs(mp)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("EditPrefs() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if err != nil {
-				t.Logf("Expected error: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
ipn: reject advertised routes with non-address bits set

The config file path, EditPrefs local API, and App Connector API were accepting invalid subnet route prefixes with non-address bits set (e.g., 2a01:4f9:c010:c015::1/64 instead of 2a01:4f9:c010:c015::/64). All three paths now reject
prefixes where prefix != prefix.Masked() with an error message indicating the expected masked form.

Updates https://github.com/tailscale/corp/issues/36738