### PR TITLE
cmd/containerboot: fix error handling for egress

### DIFF
--- a/cmd/containerboot/egressservices.go
+++ b/cmd/containerboot/egressservices.go
@@ -478,7 +478,8 @@ func (ep *egressProxy) tailnetTargetIPsForSvc(svc egressservices.Config, n ipn.N
 	}
 	egressAddrs, err := resolveTailnetFQDN(n.NetMap, svc.TailnetTarget.FQDN)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching backend addresses for %q: %w", svc.TailnetTarget.FQDN, err)
+		log.Printf("error fetching backend addresses for %q: %v", svc.TailnetTarget.FQDN, err)
+		return addrs, nil
 	}
 	if len(egressAddrs) == 0 {
 		log.Printf("tailnet target %q does not have any backend addresses, skipping", svc.TailnetTarget.FQDN)


### PR DESCRIPTION
We are seeing issues where egress proxy pods exit due to "error fetching backend addresses" where a Tailscale FQDN in the egress is incorrect or not found.  This error should be logged, but should not exit on incorrect configuration.

Fixes https://github.com/tailscale/tailscale/issues/18631