### PR TITLE
flake.nix: update NixOS wiki link

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
 # environment for working on tailscale, for use with "nix develop".
 #
 # For more information about this and why this file is useful, see:
-# https://nixos.wiki/wiki/Flakes
+# https://wiki.nixos.org/wiki/Flakes
 #
 # Also look into direnv: https://direnv.net/, this can make it so that you can
 # automatically get your environment set up when you change folders into the


### PR DESCRIPTION
wiki.nixos.org is and has been the official wiki for quite some time now.