### PR TITLE
testcontrol: send updates for new DNS records or app capabilities

### DIFF
--- a/tsnet/tsnet_test.go
+++ b/tsnet/tsnet_test.go
@@ -1194,10 +1194,8 @@ func TestListenService(t *testing.T) {
 					tt.extraSetup(t, control)
 				}
 
-				// Force netmap updates to avoid race conditions. The nodes need to
-				// see our control updates before we can start the test.
-				must.Do(control.ForceNetmapUpdate(ctx, serviceHost.lb.NodeKey()))
-				must.Do(control.ForceNetmapUpdate(ctx, serviceClient.lb.NodeKey()))
+				// Wait until both nodes have up-to-date netmaps before
+				// proceeding with the test.
 				netmapUpToDate := func(s *Server) bool {
 					nm := s.lb.NetMap()
 					return slices.ContainsFunc(nm.DNS.ExtraRecords, func(r tailcfg.DNSRecord) bool {


### PR DESCRIPTION
Two methods were recently added to the testcontrol.Server type: AddDNSRecords and SetGlobalAppCaps. These two methods should trigger netmap updates for all nodes connected to the Server instance, the way that other state-change methods do (see SetNodeCapMap, for example).

This will also allow us to get rid of Server.ForceNetmapUpdate, which was a band-aid fix to force the netmap updates which should have been triggered by the aforementioned methods.

Fixes tailscale/corp#37102