### PR TITLE
ipn,router: support configurable Linux packet marks

### DIFF
--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -1038,6 +1038,11 @@ func TestPrefFlagMapping(t *testing.T) {
 		case "AutoExitNode":
 			// Handled by tailscale {set,up} --exit-node=auto:any.
 			continue
+		case "LinuxPacketMarks":
+			// Linux-only and intentionally not configurable via CLI flags;
+			// the only supported way to set custom marks is the tailscaled
+			// config file.
+			continue
 		}
 		t.Errorf("unexpected new ipn.Pref field %q is not handled by up.go (see addPrefFlagMapping and checkForAccidentalSettingReverts)", prefName)
 	}

--- a/ipn/conf.go
+++ b/ipn/conf.go
@@ -41,6 +41,11 @@ type ConfigVAlpha struct {
 	NetfilterMode       *string  `json:",omitempty"` // "on", "off", "nodivert"
 	NoStatefulFiltering opt.Bool `json:",omitempty"`
 
+	// LinuxPacketMarks configures the Linux firewall mark bits used for
+	// subnet routing and bypass routing. If unset, Tailscale's hardcoded
+	// defaults are used. This is only honored on Linux.
+	LinuxPacketMarks *preftype.LinuxPacketMarks `json:",omitzero"`
+
 	PostureChecking opt.Bool         `json:",omitempty"`
 	RunSSHServer    opt.Bool         `json:",omitempty"` // Tailscale SSH
 	RunWebClient    opt.Bool         `json:",omitempty"`
@@ -131,6 +136,13 @@ func (c *ConfigVAlpha) ToPrefs() (MaskedPrefs, error) {
 		}
 		mp.NetfilterMode = m
 		mp.NetfilterModeSet = true
+	}
+	if c.LinuxPacketMarks != nil {
+		if err := c.LinuxPacketMarks.Validate(); err != nil {
+			return mp, fmt.Errorf("invalid LinuxPacketMarks: %w", err)
+		}
+		mp.LinuxPacketMarks = c.LinuxPacketMarks
+		mp.LinuxPacketMarksSet = true
 	}
 	if c.PostureChecking != "" {
 		mp.PostureChecking = c.PostureChecking.EqualBool(true)

--- a/ipn/conf_test.go
+++ b/ipn/conf_test.go
@@ -6,6 +6,8 @@ package ipn
 import (
 	"net/netip"
 	"testing"
+
+	"tailscale.com/types/preftype"
 )
 
 // TestConfigVAlpha_ToPrefs_AdvertiseRoutes tests that ToPrefs validates routes
@@ -60,6 +62,64 @@ func TestConfigVAlpha_ToPrefs_AdvertiseRoutes(t *testing.T) {
 			_, err := cfg.ToPrefs()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("cfg.ToPrefs() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestConfigVAlpha_ToPrefs_LinuxPacketMarks tests that ToPrefs propagates
+// LinuxPacketMarks (and its corresponding mask bit) when set, and rejects
+// invalid combinations.
+func TestConfigVAlpha_ToPrefs_LinuxPacketMarks(t *testing.T) {
+	tests := []struct {
+		name    string
+		marks   *preftype.LinuxPacketMarks
+		wantSet bool
+		wantErr bool
+	}{
+		{
+			name:    "unset_leaves_mask_clear",
+			marks:   nil,
+			wantSet: false,
+		},
+		{
+			name: "valid_marks_set_mask",
+			marks: &preftype.LinuxPacketMarks{
+				FwmarkMask:      0x1e000000,
+				SubnetRouteMark: 0x08000000,
+				BypassMark:      0x10000000,
+			},
+			wantSet: true,
+		},
+		{
+			name: "invalid_marks_rejected",
+			marks: &preftype.LinuxPacketMarks{
+				FwmarkMask:      0xff0000,
+				SubnetRouteMark: 0x40000,
+				BypassMark:      0x1000000, // not covered by mask
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := ConfigVAlpha{
+				Version:          "alpha0",
+				LinuxPacketMarks: tt.marks,
+			}
+			mp, err := cfg.ToPrefs()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("cfg.ToPrefs() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if mp.LinuxPacketMarksSet != tt.wantSet {
+				t.Errorf("LinuxPacketMarksSet = %v, want %v", mp.LinuxPacketMarksSet, tt.wantSet)
+			}
+			if tt.wantSet && mp.LinuxPacketMarks != tt.marks {
+				t.Errorf("LinuxPacketMarks = %+v, want %+v", mp.LinuxPacketMarks, tt.marks)
 			}
 		})
 	}

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -51,6 +51,9 @@ func (src *Prefs) Clone() *Prefs {
 	dst.AdvertiseTags = append(src.AdvertiseTags[:0:0], src.AdvertiseTags...)
 	dst.AdvertiseRoutes = append(src.AdvertiseRoutes[:0:0], src.AdvertiseRoutes...)
 	dst.AdvertiseServices = append(src.AdvertiseServices[:0:0], src.AdvertiseServices...)
+	if dst.LinuxPacketMarks != nil {
+		dst.LinuxPacketMarks = new(*src.LinuxPacketMarks)
+	}
 	if src.DriveShares != nil {
 		dst.DriveShares = make([]*drive.Share, len(src.DriveShares))
 		for i := range dst.DriveShares {
@@ -101,6 +104,7 @@ var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	AppConnector               AppConnectorPrefs
 	PostureChecking            bool
 	NetfilterKind              string
+	LinuxPacketMarks           *preftype.LinuxPacketMarks
 	DriveShares                []*drive.Share
 	RelayServerPort            *uint16
 	RelayServerStaticEndpoints []netip.AddrPort

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -432,6 +432,15 @@ func (v PrefsView) PostureChecking() bool { return v.ж.PostureChecking }
 // Linux-only.
 func (v PrefsView) NetfilterKind() string { return v.ж.NetfilterKind }
 
+// LinuxPacketMarks configures Linux packet mark values used by Tailscale
+// for subnet routing and bypass routing. When nil, defaults from tsconst
+// are used.
+//
+// Linux-only.
+func (v PrefsView) LinuxPacketMarks() views.ValuePointer[preftype.LinuxPacketMarks] {
+	return views.ValuePointerOf(v.ж.LinuxPacketMarks)
+}
+
 // DriveShares are the configured DriveShares, stored in increasing order
 // by name.
 func (v PrefsView) DriveShares() views.SliceView[*drive.Share, drive.ShareView] {
@@ -503,6 +512,7 @@ var _PrefsViewNeedsRegeneration = Prefs(struct {
 	AppConnector               AppConnectorPrefs
 	PostureChecking            bool
 	NetfilterKind              string
+	LinuxPacketMarks           *preftype.LinuxPacketMarks
 	DriveShares                []*drive.Share
 	RelayServerPort            *uint16
 	RelayServerStaticEndpoints []netip.AddrPort

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1028,12 +1028,22 @@ func (b *LocalBackend) SetIPServiceMappingsForTest(m netmap.IPServiceMappings) {
 // and other state.
 func (b *LocalBackend) setConfigLocked(conf *conffile.Config) error {
 	syncs.RequiresMutex(&b.mu)
+	oldMarks := b.pm.CurrentPrefs().LinuxPacketMarks().Clone()
 	p := b.pm.CurrentPrefs().AsStruct()
 	mp, err := conf.Parsed.ToPrefs()
 	if err != nil {
 		return fmt.Errorf("error parsing config to prefs: %w", err)
 	}
 	p.ApplyEdits(&mp)
+	// LinuxPacketMarks is intentionally applied only at startup: changing
+	// the values at runtime would require atomically rebuilding every
+	// mark-referencing iptables/nftables rule and would leave sockets
+	// already opened with the old bypass SO_MARK desynchronized from the
+	// new value. Reject any reload that would change them; tailscaled
+	// must be restarted to pick up new marks.
+	if !p.LinuxPacketMarks.Equals(oldMarks) {
+		return errors.New(`LinuxPacketMarks cannot be changed via config reload; restart tailscaled to apply`)
+	}
 	b.setStaticEndpointsFromConfigLocked(conf)
 	b.setPrefsLocked(p)
 
@@ -4716,6 +4726,9 @@ func (b *LocalBackend) checkPrefsLocked(p *ipn.Prefs) error {
 	if err := checkAdvertiseRoutes(p); err != nil {
 		errs = append(errs, err)
 	}
+	if err := b.checkLinuxPacketMarksLocked(p); err != nil {
+		errs = append(errs, err)
+	}
 	return errors.Join(errs...)
 }
 
@@ -4823,6 +4836,38 @@ func checkAdvertiseRoutes(p *ipn.Prefs) error {
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// checkLinuxPacketMarksLocked rejects any change to LinuxPacketMarks made via
+// EditPrefs / CheckPrefs (i.e. the LocalAPI path used by `tailscale set`).
+// Custom marks are intentionally only configurable through the tailscaled
+// config file, applied once at startup, because changing them at runtime
+// would (a) leave already-open sockets carrying the old SO_MARK bypass
+// value, and (b) require atomically rebuilding every mark-referencing
+// netfilter and policy-routing rule. The config-file path bypasses this
+// check because [initPrefsFromConfig] goes through [setPrefsLocked]
+// directly; [setConfigLocked] (config reload) enforces the same
+// immutability inline.
+//
+// b.mu must be held.
+func (b *LocalBackend) checkLinuxPacketMarksLocked(p *ipn.Prefs) error {
+	if err := p.LinuxPacketMarks.Validate(); err != nil {
+		return err
+	}
+	curPrefs := b.pm.CurrentPrefs()
+	if !curPrefs.Valid() {
+		// No prior prefs to compare against. Reject any explicit value so the
+		// only way to introduce LinuxPacketMarks remains the config file.
+		if p.LinuxPacketMarks != nil {
+			return errors.New(`LinuxPacketMarks can only be configured via the tailscaled config file`)
+		}
+		return nil
+	}
+	cur := curPrefs.LinuxPacketMarks().Clone()
+	if p.LinuxPacketMarks.Equals(cur) {
+		return nil
+	}
+	return errors.New(`LinuxPacketMarks can only be configured via the tailscaled config file`)
 }
 
 // SetUseExitNodeEnabled turns on or off the most recently selected exit node.
@@ -6200,6 +6245,15 @@ func (b *LocalBackend) routerConfigLocked(cfg *wgcfg.Config, prefs ipn.PrefsView
 		Routes:              peerRoutes(b.logf, cfg.Peers, singleRouteThreshold, prefs.RouteAll()),
 		NetfilterKind:       netfilterKind,
 		RemoveCGNATDropRule: nm.HasCap(tailcfg.NodeAttrDisableLinuxCGNATDropRule),
+	}
+
+	// Add Linux packet marks if configured
+	if pm, ok := prefs.LinuxPacketMarks().GetOk(); ok {
+		rs.LinuxPacketMarks = &router.LinuxPacketMarks{
+			FwmarkMask:      pm.FwmarkMask,
+			SubnetRouteMark: pm.SubnetRouteMark,
+			BypassMark:      pm.BypassMark,
+		}
 	}
 
 	if buildfeatures.HasSynology && distro.Get() == distro.Synology {

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -62,6 +62,7 @@ import (
 	"tailscale.com/types/netmap"
 	"tailscale.com/types/opt"
 	"tailscale.com/types/persist"
+	"tailscale.com/types/preftype"
 	"tailscale.com/types/views"
 	"tailscale.com/util/dnsname"
 	"tailscale.com/util/eventbus"
@@ -8316,6 +8317,199 @@ func TestEditPrefs_InvalidAdvertiseRoutes(t *testing.T) {
 			_, err := b.EditPrefs(mp)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("EditPrefs() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestEditPrefs_RejectsLinuxPacketMarks verifies that LinuxPacketMarks
+// changes via EditPrefs (the path used by `tailscale set` and other
+// LocalAPI consumers) are rejected. The only supported way to configure
+// custom marks is the tailscaled config file, which bypasses this check
+// because [initPrefsFromConfig] / [setConfigLocked] go through
+// [setPrefsLocked] directly.
+func TestEditPrefs_RejectsLinuxPacketMarks(t *testing.T) {
+	valid := &preftype.LinuxPacketMarks{
+		FwmarkMask:      0xff000000,
+		SubnetRouteMark: 0x40000000,
+		BypassMark:      0x80000000,
+	}
+	differs := &preftype.LinuxPacketMarks{
+		FwmarkMask:      0xff00,
+		SubnetRouteMark: 0x4000,
+		BypassMark:      0x8000,
+	}
+	invalid := &preftype.LinuxPacketMarks{
+		FwmarkMask:      0, // fails Validate
+		SubnetRouteMark: 0x40000000,
+		BypassMark:      0x80000000,
+	}
+
+	tests := []struct {
+		name      string
+		curMarks  *preftype.LinuxPacketMarks
+		newMarks  *preftype.LinuxPacketMarks
+		wantErrIs string // empty = expect success; otherwise substring of expected error
+	}{
+		{
+			name:      "set_from_nil_rejected",
+			newMarks:  valid,
+			wantErrIs: "config file",
+		},
+		{
+			name:      "change_rejected",
+			curMarks:  valid,
+			newMarks:  differs,
+			wantErrIs: "config file",
+		},
+		{
+			name:      "clear_rejected",
+			curMarks:  valid,
+			wantErrIs: "config file",
+		},
+		{
+			name:     "same_value_allowed",
+			curMarks: valid,
+			newMarks: valid,
+		},
+		{
+			name: "both_nil_allowed",
+		},
+		{
+			name:      "invalid_rejected",
+			newMarks:  invalid,
+			wantErrIs: "fwmark mask must be non-zero",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := newTestLocalBackend(t)
+			if tt.curMarks != nil {
+				b.mu.Lock()
+				p := b.pm.CurrentPrefs().AsStruct()
+				p.LinuxPacketMarks = tt.curMarks
+				if err := b.pm.SetPrefs(p.View(), ipn.NetworkProfile{}); err != nil {
+					b.mu.Unlock()
+					t.Fatalf("SetPrefs: %v", err)
+				}
+				b.mu.Unlock()
+			}
+			mp := &ipn.MaskedPrefs{
+				Prefs:               ipn.Prefs{LinuxPacketMarks: tt.newMarks},
+				LinuxPacketMarksSet: true,
+			}
+			_, err := b.EditPrefs(mp)
+			if tt.wantErrIs == "" {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("got nil error, want error containing %q", tt.wantErrIs)
+			}
+			if !strings.Contains(err.Error(), tt.wantErrIs) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.wantErrIs)
+			}
+		})
+	}
+}
+
+// TestConfigFile_AllowsLinuxPacketMarks verifies that the config-file path
+// (tested via [initPrefsFromConfig], used at startup) is NOT subject to
+// the EditPrefs rejection — the config file is the sole supported way to
+// set custom packet marks.
+func TestConfigFile_AllowsLinuxPacketMarks(t *testing.T) {
+	b := newTestLocalBackend(t)
+	want := &preftype.LinuxPacketMarks{
+		FwmarkMask:      0xff000000,
+		SubnetRouteMark: 0x40000000,
+		BypassMark:      0x80000000,
+	}
+	conf := &conffile.Config{
+		Parsed: ipn.ConfigVAlpha{
+			Version:          "alpha0",
+			LinuxPacketMarks: want,
+		},
+	}
+	b.mu.Lock()
+	err := b.initPrefsFromConfig(conf)
+	b.mu.Unlock()
+	if err != nil {
+		t.Fatalf("initPrefsFromConfig: %v", err)
+	}
+	got, ok := b.Prefs().LinuxPacketMarks().GetOk()
+	if !ok {
+		t.Fatalf("LinuxPacketMarks not set after config-file load")
+	}
+	if !got.Equals(want) {
+		t.Errorf("LinuxPacketMarks = %+v; want %+v", got, want)
+	}
+}
+
+// TestReloadConfig_RejectsLinuxPacketMarksChange verifies that
+// [LocalBackend.setConfigLocked] (the config-reload path) refuses to
+// change LinuxPacketMarks at runtime, matching the EditPrefs rejection.
+// A reload that doesn't change the marks must still succeed, and the
+// stored prefs must be untouched when the reload errors out.
+func TestReloadConfig_RejectsLinuxPacketMarksChange(t *testing.T) {
+	initial := &preftype.LinuxPacketMarks{
+		FwmarkMask:      0xff000000,
+		SubnetRouteMark: 0x40000000,
+		BypassMark:      0x80000000,
+	}
+	changed := &preftype.LinuxPacketMarks{
+		FwmarkMask:      0xff00,
+		SubnetRouteMark: 0x4000,
+		BypassMark:      0x8000,
+	}
+
+	tests := []struct {
+		name    string
+		updated *preftype.LinuxPacketMarks
+		wantErr bool
+	}{
+		{name: "same_marks_allowed", updated: initial},
+		{name: "different_marks_rejected", updated: changed, wantErr: true},
+		{name: "omitted_in_reload_no_op", updated: nil}, // ToPrefs leaves prefs unchanged
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := newTestLocalBackend(t)
+			initialConf := &conffile.Config{
+				Parsed: ipn.ConfigVAlpha{
+					Version:          "alpha0",
+					LinuxPacketMarks: initial,
+				},
+			}
+			b.mu.Lock()
+			if err := b.initPrefsFromConfig(initialConf); err != nil {
+				b.mu.Unlock()
+				t.Fatalf("initPrefsFromConfig: %v", err)
+			}
+			b.mu.Unlock()
+
+			updatedConf := &conffile.Config{
+				Parsed: ipn.ConfigVAlpha{
+					Version:          "alpha0",
+					LinuxPacketMarks: tt.updated,
+				},
+			}
+			b.mu.Lock()
+			err := b.setConfigLocked(updatedConf)
+			b.mu.Unlock()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("setConfigLocked error = %v, wantErr %v", err, tt.wantErr)
+			}
+			// Prefs should still reflect the initial marks in every case:
+			// either reload succeeded and they matched, or it failed and was
+			// rolled back, or the reload omitted the field entirely.
+			got, ok := b.Prefs().LinuxPacketMarks().GetOk()
+			if !ok {
+				t.Fatalf("LinuxPacketMarks unexpectedly cleared after reload")
+			}
+			if !got.Equals(initial) {
+				t.Errorf("LinuxPacketMarks = %+v; want %+v (unchanged)", got, initial)
 			}
 		})
 	}

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -276,6 +276,13 @@ type Prefs struct {
 	// Linux-only.
 	NetfilterKind string
 
+	// LinuxPacketMarks configures Linux packet mark values used by Tailscale
+	// for subnet routing and bypass routing. When nil, defaults from tsconst
+	// are used.
+	//
+	// Linux-only.
+	LinuxPacketMarks *preftype.LinuxPacketMarks `json:",omitzero"`
+
 	// DriveShares are the configured DriveShares, stored in increasing order
 	// by name.
 	DriveShares []*drive.Share
@@ -383,6 +390,7 @@ type MaskedPrefs struct {
 	AppConnectorSet               bool                `json:",omitempty"`
 	PostureCheckingSet            bool                `json:",omitempty"`
 	NetfilterKindSet              bool                `json:",omitempty"`
+	LinuxPacketMarksSet           bool                `json:",omitzero"`
 	DriveSharesSet                bool                `json:",omitempty"`
 	RelayServerPortSet            bool                `json:",omitempty"`
 	RelayServerStaticEndpointsSet bool                `json:",omitzero"`
@@ -602,6 +610,9 @@ func (p *Prefs) pretty(goos string) string {
 	}
 	if goos == "linux" {
 		fmt.Fprintf(&sb, "nf=%v ", p.NetfilterMode)
+		if m := p.LinuxPacketMarks; m != nil {
+			fmt.Fprintf(&sb, "marks=mask:0x%x,subnet:0x%x,bypass:0x%x ", m.FwmarkMask, m.SubnetRouteMark, m.BypassMark)
+		}
 	}
 	if p.ControlURL != "" && p.ControlURL != DefaultControlURL {
 		fmt.Fprintf(&sb, "url=%q ", p.ControlURL)
@@ -691,6 +702,7 @@ func (p *Prefs) Equals(p2 *Prefs) bool {
 		p.PostureChecking == p2.PostureChecking &&
 		slices.EqualFunc(p.DriveShares, p2.DriveShares, drive.SharesEqual) &&
 		p.NetfilterKind == p2.NetfilterKind &&
+		p.LinuxPacketMarks.Equals(p2.LinuxPacketMarks) &&
 		compareUint16Ptrs(p.RelayServerPort, p2.RelayServerPort) &&
 		slices.Equal(p.RelayServerStaticEndpoints, p2.RelayServerStaticEndpoints)
 }

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -67,6 +67,7 @@ func TestPrefsEqual(t *testing.T) {
 		"AppConnector",
 		"PostureChecking",
 		"NetfilterKind",
+		"LinuxPacketMarks",
 		"DriveShares",
 		"RelayServerPort",
 		"RelayServerStaticEndpoints",
@@ -358,6 +359,36 @@ func TestPrefsEqual(t *testing.T) {
 		{
 			&Prefs{NetfilterKind: "nftables"},
 			&Prefs{NetfilterKind: ""},
+			false,
+		},
+		{
+			&Prefs{LinuxPacketMarks: nil},
+			&Prefs{LinuxPacketMarks: nil},
+			true,
+		},
+		{
+			&Prefs{LinuxPacketMarks: nil},
+			&Prefs{LinuxPacketMarks: &preftype.LinuxPacketMarks{FwmarkMask: 0xff0000}},
+			false,
+		},
+		{
+			&Prefs{LinuxPacketMarks: &preftype.LinuxPacketMarks{FwmarkMask: 0xff0000, SubnetRouteMark: 0x40000, BypassMark: 0x80000}},
+			&Prefs{LinuxPacketMarks: &preftype.LinuxPacketMarks{FwmarkMask: 0xff0000, SubnetRouteMark: 0x40000, BypassMark: 0x80000}},
+			true,
+		},
+		{
+			&Prefs{LinuxPacketMarks: &preftype.LinuxPacketMarks{FwmarkMask: 0xff0000, SubnetRouteMark: 0x40000, BypassMark: 0x80000}},
+			&Prefs{LinuxPacketMarks: &preftype.LinuxPacketMarks{FwmarkMask: 0xff00, SubnetRouteMark: 0x40000, BypassMark: 0x80000}},
+			false,
+		},
+		{
+			&Prefs{LinuxPacketMarks: &preftype.LinuxPacketMarks{FwmarkMask: 0xff0000, SubnetRouteMark: 0x40000, BypassMark: 0x80000}},
+			&Prefs{LinuxPacketMarks: &preftype.LinuxPacketMarks{FwmarkMask: 0xff0000, SubnetRouteMark: 0x50000, BypassMark: 0x80000}},
+			false,
+		},
+		{
+			&Prefs{LinuxPacketMarks: &preftype.LinuxPacketMarks{FwmarkMask: 0xff0000, SubnetRouteMark: 0x40000, BypassMark: 0x80000}},
+			&Prefs{LinuxPacketMarks: &preftype.LinuxPacketMarks{FwmarkMask: 0xff0000, SubnetRouteMark: 0x40000, BypassMark: 0x90000}},
 			false,
 		},
 		{

--- a/types/preftype/linuxpacketmarks.go
+++ b/types/preftype/linuxpacketmarks.go
@@ -1,0 +1,68 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package preftype
+
+import (
+	"errors"
+	"fmt"
+)
+
+// LinuxPacketMarks holds the packet mark configuration for Linux packet
+// marking used in firewall rules and routing. When this struct is nil in Prefs,
+// the default values from tsconst are used.
+type LinuxPacketMarks struct {
+	// FwmarkMask is the mask for reading/writing firewall mark bits on a packet.
+	// Must be non-zero if set. Default is 0xff0000.
+	FwmarkMask uint32
+
+	// SubnetRouteMark is the mark value for packets from Tailscale to subnet
+	// route destinations. Must be non-zero and must be covered by FwmarkMask.
+	// Default is 0x40000.
+	SubnetRouteMark uint32
+
+	// BypassMark is the mark value for packets originated by tailscaled that
+	// must not be routed over the Tailscale network. Must be non-zero, must be
+	// covered by FwmarkMask, and must differ from SubnetRouteMark.
+	// Default is 0x80000.
+	BypassMark uint32
+}
+
+// Validate checks that the mark values are valid.
+// It returns an error if any validation fails.
+func (m *LinuxPacketMarks) Validate() error {
+	if m == nil {
+		return nil
+	}
+	if m.FwmarkMask == 0 {
+		return errors.New("fwmark mask must be non-zero")
+	}
+	if m.SubnetRouteMark == 0 {
+		return errors.New("subnet route mark must be non-zero")
+	}
+	if m.BypassMark == 0 {
+		return errors.New("bypass mark must be non-zero")
+	}
+	if (m.SubnetRouteMark & m.FwmarkMask) != m.SubnetRouteMark {
+		return fmt.Errorf("subnet route mark (0x%x) must be covered by fwmark mask (0x%x)", m.SubnetRouteMark, m.FwmarkMask)
+	}
+	if (m.BypassMark & m.FwmarkMask) != m.BypassMark {
+		return fmt.Errorf("bypass mark (0x%x) must be covered by fwmark mask (0x%x)", m.BypassMark, m.FwmarkMask)
+	}
+	if m.SubnetRouteMark == m.BypassMark {
+		return errors.New("subnet route mark and bypass mark must differ")
+	}
+	return nil
+}
+
+func (m *LinuxPacketMarks) Equals(m2 *LinuxPacketMarks) bool {
+	if m == m2 {
+		return true
+	}
+	if m == nil || m2 == nil {
+		return false
+	}
+	return m.FwmarkMask == m2.FwmarkMask &&
+		m.SubnetRouteMark == m2.SubnetRouteMark &&
+		m.BypassMark == m2.BypassMark
+}

--- a/types/preftype/linuxpacketmarks_test.go
+++ b/types/preftype/linuxpacketmarks_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package preftype
+
+import "testing"
+
+func TestLinuxPacketMarks_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		marks   *LinuxPacketMarks
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "nil_marks_should_be_valid",
+			marks:   nil,
+			wantErr: false,
+		},
+		{
+			name: "valid_marks",
+			marks: &LinuxPacketMarks{
+				FwmarkMask:      0xff0000,
+				SubnetRouteMark: 0x40000,
+				BypassMark:      0x80000,
+			},
+			wantErr: false,
+		},
+		{
+			name: "zero_fwmark_mask",
+			marks: &LinuxPacketMarks{
+				FwmarkMask:      0,
+				SubnetRouteMark: 0x40000,
+				BypassMark:      0x80000,
+			},
+			wantErr: true,
+			errMsg:  "fwmark mask must be non-zero",
+		},
+		{
+			name: "zero_subnet_route_mark",
+			marks: &LinuxPacketMarks{
+				FwmarkMask:      0xff0000,
+				SubnetRouteMark: 0,
+				BypassMark:      0x80000,
+			},
+			wantErr: true,
+			errMsg:  "subnet route mark must be non-zero",
+		},
+		{
+			name: "zero_bypass_mark",
+			marks: &LinuxPacketMarks{
+				FwmarkMask:      0xff0000,
+				SubnetRouteMark: 0x40000,
+				BypassMark:      0,
+			},
+			wantErr: true,
+			errMsg:  "bypass mark must be non-zero",
+		},
+		{
+			name: "subnet_route_mark_not_covered_by_mask",
+			marks: &LinuxPacketMarks{
+				FwmarkMask:      0xff0000,
+				SubnetRouteMark: 0x1000000,
+				BypassMark:      0x80000,
+			},
+			wantErr: true,
+			errMsg:  "subnet route mark (0x1000000) must be covered by fwmark mask (0xff0000)",
+		},
+		{
+			name: "bypass_mark_not_covered_by_mask",
+			marks: &LinuxPacketMarks{
+				FwmarkMask:      0xff0000,
+				SubnetRouteMark: 0x40000,
+				BypassMark:      0x1000000,
+			},
+			wantErr: true,
+			errMsg:  "bypass mark (0x1000000) must be covered by fwmark mask (0xff0000)",
+		},
+		{
+			name: "subnet_and_bypass_marks_are_the_same",
+			marks: &LinuxPacketMarks{
+				FwmarkMask:      0xff0000,
+				SubnetRouteMark: 0x40000,
+				BypassMark:      0x40000,
+			},
+			wantErr: true,
+			errMsg:  "subnet route mark and bypass mark must differ",
+		},
+		{
+			name: "different_valid_marks",
+			marks: &LinuxPacketMarks{
+				FwmarkMask:      0xffff00,
+				SubnetRouteMark: 0x100,
+				BypassMark:      0x200,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.marks.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && err != nil && err.Error() != tt.errMsg {
+				t.Errorf("Validate() error = %q, want %q", err.Error(), tt.errMsg)
+			}
+		})
+	}
+}

--- a/util/linuxfw/fake.go
+++ b/util/linuxfw/fake.go
@@ -138,6 +138,6 @@ func NewFakeIPTablesRunner() NetfilterRunner {
 		v6Available = true
 	}
 
-	iptr := &iptablesRunner{ipt4, ipt6, v6Available, v6Available, v6Available}
+	iptr := &iptablesRunner{ipt4, ipt6, v6Available, v6Available, v6Available, DefaultPacketMarks()}
 	return iptr
 }

--- a/util/linuxfw/fake_netfilter.go
+++ b/util/linuxfw/fake_netfilter.go
@@ -63,6 +63,7 @@ func (f *FakeNetfilterRunner) HasIPV6NAT() bool {
 	return true
 }
 
+func (f *FakeNetfilterRunner) SetPacketMarks(marks PacketMarks)          {}
 func (f *FakeNetfilterRunner) AddBase(tunname string) error              { return nil }
 func (f *FakeNetfilterRunner) DelBase() error                            { return nil }
 func (f *FakeNetfilterRunner) AddChains() error                          { return nil }

--- a/util/linuxfw/iptables.go
+++ b/util/linuxfw/iptables.go
@@ -116,7 +116,9 @@ func newIPTablesRunner(logf logger.Logf) (*iptablesRunner, error) {
 		ipt6:              ipt6,
 		v6Available:       supportsV6,
 		v6NATAvailable:    supportsV6NAT,
-		v6FilterAvailable: supportsV6Filter}, nil
+		v6FilterAvailable: supportsV6Filter,
+		marks:             DefaultPacketMarks(),
+	}, nil
 }
 
 // checkSupportsV6Filter returns whether the system has a "filter" table in the

--- a/util/linuxfw/iptables_runner.go
+++ b/util/linuxfw/iptables_runner.go
@@ -43,6 +43,8 @@ type iptablesRunner struct {
 	v6Available       bool
 	v6NATAvailable    bool
 	v6FilterAvailable bool
+
+	marks PacketMarks
 }
 
 func checkIP6TablesExists() error {
@@ -231,11 +233,11 @@ func (i *iptablesRunner) addBase4(tunname string) error {
 	// POSTROUTING. So instead, we match on the inbound interface in
 	// filter/FORWARD, and set a packet mark that nat/POSTROUTING can
 	// use to effectively run that same test again.
-	args = []string{"-i", tunname, "-j", "MARK", "--set-mark", subnetRouteMark + "/" + fwmarkMask}
+	args = []string{"-i", tunname, "-j", "MARK", "--set-mark", i.marks.SubnetRouteMarkString() + "/" + i.marks.FwmarkMaskString()}
 	if err := i.ipt4.Append("filter", "ts-forward", args...); err != nil {
 		return fmt.Errorf("adding %v in v4/filter/ts-forward: %w", args, err)
 	}
-	args = []string{"-m", "mark", "--mark", subnetRouteMark + "/" + fwmarkMask, "-j", "ACCEPT"}
+	args = []string{"-m", "mark", "--mark", i.marks.SubnetRouteMarkString() + "/" + i.marks.FwmarkMaskString(), "-j", "ACCEPT"}
 	if err := i.ipt4.Append("filter", "ts-forward", args...); err != nil {
 		return fmt.Errorf("adding %v in v4/filter/ts-forward: %w", args, err)
 	}
@@ -337,11 +339,11 @@ func (i *iptablesRunner) addBase6(tunname string) error {
 		return fmt.Errorf("adding %v in v6/filter/ts-input: %w", args, err)
 	}
 
-	args = []string{"-i", tunname, "-j", "MARK", "--set-mark", subnetRouteMark + "/" + fwmarkMask}
+	args = []string{"-i", tunname, "-j", "MARK", "--set-mark", i.marks.SubnetRouteMarkString() + "/" + i.marks.FwmarkMaskString()}
 	if err := i.ipt6.Append("filter", "ts-forward", args...); err != nil {
 		return fmt.Errorf("adding %v in v6/filter/ts-forward: %w", args, err)
 	}
-	args = []string{"-m", "mark", "--mark", subnetRouteMark + "/" + fwmarkMask, "-j", "ACCEPT"}
+	args = []string{"-m", "mark", "--mark", i.marks.SubnetRouteMarkString() + "/" + i.marks.FwmarkMaskString(), "-j", "ACCEPT"}
 	if err := i.ipt6.Append("filter", "ts-forward", args...); err != nil {
 		return fmt.Errorf("adding %v in v6/filter/ts-forward: %w", args, err)
 	}
@@ -430,7 +432,7 @@ func (i *iptablesRunner) DelHooks(logf logger.Logf) error {
 // AddSNATRule adds a netfilter rule to SNAT traffic destined for
 // local subnets.
 func (i *iptablesRunner) AddSNATRule() error {
-	args := []string{"-m", "mark", "--mark", subnetRouteMark + "/" + fwmarkMask, "-j", "MASQUERADE"}
+	args := []string{"-m", "mark", "--mark", i.marks.SubnetRouteMarkString() + "/" + i.marks.FwmarkMaskString(), "-j", "MASQUERADE"}
 	for _, ipt := range i.getNATTables() {
 		if err := ipt.Append("nat", "ts-postrouting", args...); err != nil {
 			return fmt.Errorf("adding %v in nat/ts-postrouting: %w", args, err)
@@ -442,7 +444,7 @@ func (i *iptablesRunner) AddSNATRule() error {
 // DelSNATRule removes the netfilter rule to SNAT traffic destined for
 // local subnets. An error is returned if the rule does not exist.
 func (i *iptablesRunner) DelSNATRule() error {
-	args := []string{"-m", "mark", "--mark", subnetRouteMark + "/" + fwmarkMask, "-j", "MASQUERADE"}
+	args := []string{"-m", "mark", "--mark", i.marks.SubnetRouteMarkString() + "/" + i.marks.FwmarkMaskString(), "-j", "MASQUERADE"}
 	for _, ipt := range i.getNATTables() {
 		if err := ipt.Delete("nat", "ts-postrouting", args...); err != nil {
 			return fmt.Errorf("deleting %v in nat/ts-postrouting: %w", args, err)
@@ -524,10 +526,11 @@ func (i *iptablesRunner) AddConnmarkSaveRule() error {
 			continue
 		}
 		// Look for existing connmark restore rule
+		ctmaskMatch := "ctmask " + i.marks.FwmarkMaskString()
 		for _, rule := range rules {
 			if strings.Contains(rule, "CONNMARK") &&
 				strings.Contains(rule, "restore-mark") &&
-				strings.Contains(rule, "ctmask 0xff0000") {
+				strings.Contains(rule, ctmaskMatch) {
 				// Rules already exist, skip adding
 				return nil
 			}
@@ -538,16 +541,17 @@ func (i *iptablesRunner) AddConnmarkSaveRule() error {
 	// This runs BEFORE routing decision and rp_filter check
 	// The connmark check ensures we only restore when Tailscale has marked the connection,
 	// preventing us from wiping mark bits set by other systems when ct mark is zero.
+	mask := i.marks.FwmarkMaskString()
 	for _, ipt := range i.getTables() {
 		args := []string{
 			"-m", "conntrack",
 			"--ctstate", "ESTABLISHED,RELATED",
 			"-m", "connmark",
-			"!", "--mark", "0x0/" + fwmarkMask, // Only restore if ct mark has Tailscale bits set
+			"!", "--mark", "0x0/" + mask, // Only restore if ct mark has Tailscale bits set
 			"-j", "CONNMARK",
 			"--restore-mark",
-			"--nfmask", fwmarkMask,
-			"--ctmask", fwmarkMask,
+			"--nfmask", mask,
+			"--ctmask", mask,
 		}
 		if err := ipt.Insert("mangle", "PREROUTING", 1, args...); err != nil {
 			return fmt.Errorf("adding %v in mangle/PREROUTING: %w", args, err)
@@ -560,11 +564,11 @@ func (i *iptablesRunner) AddConnmarkSaveRule() error {
 			"-m", "conntrack",
 			"--ctstate", "NEW",
 			"-m", "mark",
-			"!", "--mark", "0x0/" + fwmarkMask,
+			"!", "--mark", "0x0/" + mask,
 			"-j", "CONNMARK",
 			"--save-mark",
-			"--nfmask", fwmarkMask,
-			"--ctmask", fwmarkMask,
+			"--nfmask", mask,
+			"--ctmask", mask,
 		}
 		if err := ipt.Insert("mangle", "OUTPUT", 1, args...); err != nil {
 			return fmt.Errorf("adding %v in mangle/OUTPUT: %w", args, err)
@@ -576,17 +580,18 @@ func (i *iptablesRunner) AddConnmarkSaveRule() error {
 
 // DelConnmarkSaveRule removes conntrack marking rules added by AddConnmarkSaveRule.
 func (i *iptablesRunner) DelConnmarkSaveRule() error {
+	mask := i.marks.FwmarkMaskString()
 	for _, ipt := range i.getTables() {
 		// Delete PREROUTING rule
 		args := []string{
 			"-m", "conntrack",
 			"--ctstate", "ESTABLISHED,RELATED",
 			"-m", "connmark",
-			"!", "--mark", "0x0/" + fwmarkMask,
+			"!", "--mark", "0x0/" + mask,
 			"-j", "CONNMARK",
 			"--restore-mark",
-			"--nfmask", fwmarkMask,
-			"--ctmask", fwmarkMask,
+			"--nfmask", mask,
+			"--ctmask", mask,
 		}
 		if err := ipt.Delete("mangle", "PREROUTING", args...); err != nil {
 			if !isNotExistError(err) {
@@ -600,11 +605,11 @@ func (i *iptablesRunner) DelConnmarkSaveRule() error {
 			"-m", "conntrack",
 			"--ctstate", "NEW",
 			"-m", "mark",
-			"!", "--mark", "0x0/" + fwmarkMask,
+			"!", "--mark", "0x0/" + mask,
 			"-j", "CONNMARK",
 			"--save-mark",
-			"--nfmask", fwmarkMask,
-			"--ctmask", fwmarkMask,
+			"--nfmask", mask,
+			"--ctmask", mask,
 		}
 		if err := ipt.Delete("mangle", "OUTPUT", args...); err != nil {
 			if !isNotExistError(err) {
@@ -732,6 +737,17 @@ func (i *iptablesRunner) DelExternalCGNATRules(mode CGNATMode, tunname string) e
 		}
 	}
 	return nil
+}
+
+// SetPacketMarks updates the packet marks used by the netfilter runner.
+//
+// SetPacketMarks only updates the runner's mark configuration used when
+// constructing future rules. It does not delete or rewrite any rules that
+// were already installed with the previous marks. Callers that want a clean
+// switch (e.g. when prefs change at runtime) are responsible for tearing
+// down the existing rules and reinstalling them outside this call.
+func (i *iptablesRunner) SetPacketMarks(marks PacketMarks) {
+	i.marks = marks
 }
 
 // delTSHook deletes hook in a chain that jumps to a ts-chain. If the hook does not

--- a/util/linuxfw/iptables_runner_test.go
+++ b/util/linuxfw/iptables_runner_test.go
@@ -7,6 +7,7 @@ package linuxfw
 
 import (
 	"net/netip"
+	"slices"
 	"strings"
 	"testing"
 
@@ -465,6 +466,7 @@ func TestAddAndDelConnmarkSaveRule(t *testing.T) {
 			v6Available:       false,
 			v6NATAvailable:    false,
 			v6FilterAvailable: false,
+			marks:             DefaultPacketMarks(),
 		}
 
 		// Add connmark rules should NOT panic with nil ipt6
@@ -503,6 +505,44 @@ func TestAddAndDelConnmarkSaveRule(t *testing.T) {
 			t.Errorf("IPv4 OUTPUT connmark rule still exists after deletion")
 		}
 	})
+}
+
+func TestSetPacketMarks_iptablesRunner(t *testing.T) {
+	iptr := newFakeIPTablesRunner()
+
+	// Defaults shifted up by one byte: a realistic non-default choice for
+	// users avoiding conflicts with other software that uses the third
+	// byte (e.g. Calico). Passes LinuxPacketMarks.Validate.
+	custom := PacketMarks{
+		FwmarkMask:      0xff000000,
+		SubnetRouteMark: 0x40000000,
+		BypassMark:      0x80000000,
+	}
+	iptr.SetPacketMarks(custom)
+
+	if err := iptr.AddChains(); err != nil {
+		t.Fatal(err)
+	}
+	if err := iptr.AddSNATRule(); err != nil {
+		t.Fatal(err)
+	}
+
+	wantMark := custom.SubnetRouteMarkString() + "/" + custom.FwmarkMaskString()
+	wantRule := strings.Join([]string{"-m", "mark", "--mark", wantMark, "-j", "MASQUERADE"}, " ")
+	defaultMark := tsconst.LinuxSubnetRouteMark + "/" + tsconst.LinuxFwmarkMask
+
+	got := iptr.ipt4.(*fakeIPTables).n["nat/ts-postrouting"]
+	if len(got) == 0 {
+		t.Fatalf("no rules in nat/ts-postrouting")
+	}
+	if !slices.Contains(got, wantRule) {
+		t.Errorf("SNAT rule missing custom marks; want substring %q in %v", wantRule, got)
+	}
+	for _, r := range got {
+		if strings.Contains(r, defaultMark) {
+			t.Errorf("SNAT rule unexpectedly contains the default mark %q: %q", defaultMark, r)
+		}
+	}
 }
 
 func TestAddAndDelCGNATRules(t *testing.T) {

--- a/util/linuxfw/linuxfw.go
+++ b/util/linuxfw/linuxfw.go
@@ -61,54 +61,64 @@ const (
 	CGNATModeReturn CGNATMode = "RETURN"
 )
 
-// The following bits are added to packet marks for Tailscale use.
-//
-// We tried to pick bits sufficiently out of the way that it's
-// unlikely to collide with existing uses. We have 4 bytes of mark
-// bits to play with. We leave the lower byte alone on the assumption
-// that sysadmins would use those. Kubernetes uses a few bits in the
-// second byte, so we steer clear of that too.
-//
-// Empirically, most of the documentation on packet marks on the
-// internet gives the impression that the marks are 16 bits
-// wide. Based on this, we theorize that the upper two bytes are
-// relatively unused in the wild, and so we consume bits 16:23 (the
-// third byte).
-//
-// The constants are in the iptables/iproute2 string format for
-// matching and setting the bits, so they can be directly embedded in
-// commands.
-const (
-	fwmarkMask         = tsconst.LinuxFwmarkMask
-	fwmarkMaskNum      = tsconst.LinuxFwmarkMaskNum
-	subnetRouteMark    = tsconst.LinuxSubnetRouteMark
-	subnetRouteMarkNum = tsconst.LinuxSubnetRouteMarkNum
-	bypassMark         = tsconst.LinuxBypassMark
-	bypassMarkNum      = tsconst.LinuxBypassMarkNum
-)
-
-// getTailscaleFwmarkMaskNeg returns the negation of TailscaleFwmarkMask
-// in native byte order.
-func getTailscaleFwmarkMaskNeg() []byte {
-	return nativeEndianUint32(^uint32(fwmarkMaskNum))
-}
-
-// getTailscaleFwmarkMask returns the TailscaleFwmarkMask in native byte order.
-func getTailscaleFwmarkMask() []byte {
-	return nativeEndianUint32(fwmarkMaskNum)
-}
-
-// getTailscaleSubnetRouteMark returns the TailscaleSubnetRouteMark
-// in native byte order.
-func getTailscaleSubnetRouteMark() []byte {
-	return nativeEndianUint32(subnetRouteMarkNum)
-}
-
 // nativeEndianUint32 returns v as a 4-byte slice in the host's native byte order.
 func nativeEndianUint32(v uint32) []byte {
 	b := make([]byte, 4)
 	binary.NativeEndian.PutUint32(b, v)
 	return b
+}
+
+// PacketMarks contains the packet mark configuration to use for
+// firewall rules and routing. It provides methods to format marks
+// for both iptables (string format) and nftables (byte arrays).
+type PacketMarks struct {
+	FwmarkMask      uint32
+	SubnetRouteMark uint32
+	BypassMark      uint32
+}
+
+// DefaultPacketMarks returns the default packet marks from tsconst.
+func DefaultPacketMarks() PacketMarks {
+	return PacketMarks{
+		FwmarkMask:      tsconst.LinuxFwmarkMaskNum,
+		SubnetRouteMark: tsconst.LinuxSubnetRouteMarkNum,
+		BypassMark:      tsconst.LinuxBypassMarkNum,
+	}
+}
+
+// FwmarkMaskString returns the fwmark mask as an iptables-compatible string.
+func (m PacketMarks) FwmarkMaskString() string {
+	return fmt.Sprintf("0x%x", m.FwmarkMask)
+}
+
+// SubnetRouteMarkString returns the subnet route mark as an iptables-compatible string.
+func (m PacketMarks) SubnetRouteMarkString() string {
+	return fmt.Sprintf("0x%x", m.SubnetRouteMark)
+}
+
+// BypassMarkString returns the bypass mark as an iptables-compatible string.
+func (m PacketMarks) BypassMarkString() string {
+	return fmt.Sprintf("0x%x", m.BypassMark)
+}
+
+// FwmarkMaskBytes returns the fwmark mask in native byte order.
+func (m PacketMarks) FwmarkMaskBytes() []byte {
+	return nativeEndianUint32(m.FwmarkMask)
+}
+
+// FwmarkMaskNegBytes returns the negation of the fwmark mask in native byte order.
+func (m PacketMarks) FwmarkMaskNegBytes() []byte {
+	return nativeEndianUint32(^m.FwmarkMask)
+}
+
+// SubnetRouteMarkBytes returns the subnet route mark in native byte order.
+func (m PacketMarks) SubnetRouteMarkBytes() []byte {
+	return nativeEndianUint32(m.SubnetRouteMark)
+}
+
+// BypassMarkBytes returns the bypass mark in native byte order.
+func (m PacketMarks) BypassMarkBytes() []byte {
+	return nativeEndianUint32(m.BypassMark)
 }
 
 // checkIPv6ForTest can be set in tests.
@@ -177,7 +187,7 @@ func CheckIPRuleSupportsV6(logf logger.Logf) error {
 	// Try to actually create & delete one as a test.
 	rule := netlink.NewRule()
 	rule.Priority = 1234
-	rule.Mark = bypassMarkNum
+	rule.Mark = tsconst.LinuxBypassMarkNum
 	rule.Table = 52
 	rule.Family = netlink.FAMILY_V6
 	// First delete the rule unconditionally, and don't check for

--- a/util/linuxfw/nftables_runner.go
+++ b/util/linuxfw/nftables_runner.go
@@ -73,6 +73,7 @@ type nftablesRunner struct {
 	nft6 *nftable // IPv6 tables or nil if the system does not support IPv6
 
 	v6Available bool // whether the host supports IPv6
+	marks       PacketMarks
 }
 
 func (n *nftablesRunner) ensurePreroutingChain(dst netip.Addr) (*nftables.Table, *nftables.Chain, error) {
@@ -605,6 +606,16 @@ type NetfilterRunner interface {
 	// DelExternalCGNATRules removes the rules created by AddExternalCGNATRules,
 	// if they exist.
 	DelExternalCGNATRules(mode CGNATMode, tunname string) error
+
+	// SetPacketMarks updates the packet marks used by the netfilter runner.
+	//
+	// SetPacketMarks only updates the runner's mark configuration used when
+	// constructing future rules. It does not delete or rewrite any rules that
+	// were already installed with the previous marks. Callers that want a
+	// clean switch (e.g. when prefs change at runtime) are responsible for
+	// tearing down the existing rules and reinstalling them outside this
+	// call.
+	SetPacketMarks(marks PacketMarks)
 }
 
 // New creates a NetfilterRunner, auto-detecting whether to use
@@ -670,6 +681,7 @@ func newNfTablesRunnerWithConn(logf logger.Logf, conn *nftables.Conn) *nftablesR
 		nft4:        nft4,
 		nft6:        nft6,
 		v6Available: supportsV6,
+		marks:       DefaultPacketMarks(),
 	}
 }
 
@@ -1326,9 +1338,9 @@ func delReturnCGNATRangeRule(c *nftables.Conn, table *nftables.Table, chain *nft
 
 // createSetSubnetRouteMarkRule creates a rule to set the subnet route
 // mark if the packet is from the given interface.
-func createSetSubnetRouteMarkRule(table *nftables.Table, chain *nftables.Chain, tunname string) (*nftables.Rule, error) {
-	hexTsFwmarkMaskNeg := getTailscaleFwmarkMaskNeg()
-	hexTSSubnetRouteMark := getTailscaleSubnetRouteMark()
+func createSetSubnetRouteMarkRule(table *nftables.Table, chain *nftables.Chain, tunname string, marks PacketMarks) (*nftables.Rule, error) {
+	hexTsFwmarkMaskNeg := marks.FwmarkMaskNegBytes()
+	hexTSSubnetRouteMark := marks.SubnetRouteMarkBytes()
 
 	rule := &nftables.Rule{
 		Table: table,
@@ -1361,8 +1373,8 @@ func createSetSubnetRouteMarkRule(table *nftables.Table, chain *nftables.Chain, 
 
 // addSetSubnetRouteMarkRule adds a rule to set the subnet route mark
 // if the packet is from the given interface.
-func addSetSubnetRouteMarkRule(c *nftables.Conn, table *nftables.Table, chain *nftables.Chain, tunname string) error {
-	rule, err := createSetSubnetRouteMarkRule(table, chain, tunname)
+func addSetSubnetRouteMarkRule(c *nftables.Conn, table *nftables.Table, chain *nftables.Chain, tunname string, marks PacketMarks) error {
+	rule, err := createSetSubnetRouteMarkRule(table, chain, tunname, marks)
 	if err != nil {
 		return fmt.Errorf("create rule: %w", err)
 	}
@@ -1652,6 +1664,17 @@ func (n *nftablesRunner) DelExternalCGNATRules(mode CGNATMode, tunname string) e
 	return nil
 }
 
+// SetPacketMarks updates the packet marks used by the netfilter runner.
+//
+// SetPacketMarks only updates the runner's mark configuration used when
+// constructing future rules. It does not delete or rewrite any rules that
+// were already installed with the previous marks. Callers that want a clean
+// switch (e.g. when prefs change at runtime) are responsible for tearing
+// down the existing rules and reinstalling them outside this call.
+func (n *nftablesRunner) SetPacketMarks(marks PacketMarks) {
+	n.marks = marks
+}
+
 // createAcceptIncomingPacketRule creates a rule to accept incoming packets to
 // the given interface.
 func createAcceptIncomingPacketRule(table *nftables.Table, chain *nftables.Chain, tunname string) *nftables.Rule {
@@ -1714,11 +1737,11 @@ func (n *nftablesRunner) addBase4(tunname string) error {
 		return fmt.Errorf("get forward chain v4: %v", err)
 	}
 
-	if err = addSetSubnetRouteMarkRule(conn, n.nft4.Filter, forwardChain, tunname); err != nil {
+	if err = addSetSubnetRouteMarkRule(conn, n.nft4.Filter, forwardChain, tunname, n.marks); err != nil {
 		return fmt.Errorf("add set subnet route mark rule v4: %w", err)
 	}
 
-	if err = addMatchSubnetRouteMarkRule(conn, n.nft4.Filter, forwardChain, Accept); err != nil {
+	if err = addMatchSubnetRouteMarkRule(conn, n.nft4.Filter, forwardChain, Accept, n.marks); err != nil {
 		return fmt.Errorf("add match subnet route mark rule v4: %w", err)
 	}
 
@@ -1754,11 +1777,11 @@ func (n *nftablesRunner) addBase6(tunname string) error {
 		return fmt.Errorf("get forward chain v6: %w", err)
 	}
 
-	if err = addSetSubnetRouteMarkRule(conn, n.nft6.Filter, forwardChain, tunname); err != nil {
+	if err = addSetSubnetRouteMarkRule(conn, n.nft6.Filter, forwardChain, tunname, n.marks); err != nil {
 		return fmt.Errorf("add set subnet route mark rule v6: %w", err)
 	}
 
-	if err = addMatchSubnetRouteMarkRule(conn, n.nft6.Filter, forwardChain, Accept); err != nil {
+	if err = addMatchSubnetRouteMarkRule(conn, n.nft6.Filter, forwardChain, Accept, n.marks); err != nil {
 		return fmt.Errorf("add match subnet route mark rule v6: %w", err)
 	}
 
@@ -1802,9 +1825,9 @@ func (n *nftablesRunner) DelBase() error {
 
 // createMatchSubnetRouteMarkRule creates a rule that matches packets
 // with the subnet route mark and takes the specified action.
-func createMatchSubnetRouteMarkRule(table *nftables.Table, chain *nftables.Chain, action MatchDecision) (*nftables.Rule, error) {
-	hexTSFwmarkMask := getTailscaleFwmarkMask()
-	hexTSSubnetRouteMark := getTailscaleSubnetRouteMark()
+func createMatchSubnetRouteMarkRule(table *nftables.Table, chain *nftables.Chain, action MatchDecision, marks PacketMarks) (*nftables.Rule, error) {
+	hexTSFwmarkMask := marks.FwmarkMaskBytes()
+	hexTSSubnetRouteMark := marks.SubnetRouteMarkBytes()
 
 	var endAction expr.Any
 	endAction = &expr.Verdict{Kind: expr.VerdictAccept}
@@ -1840,8 +1863,8 @@ func createMatchSubnetRouteMarkRule(table *nftables.Table, chain *nftables.Chain
 
 // addMatchSubnetRouteMarkRule adds a rule that matches packets with
 // the subnet route mark and takes the specified action.
-func addMatchSubnetRouteMarkRule(conn *nftables.Conn, table *nftables.Table, chain *nftables.Chain, action MatchDecision) error {
-	rule, err := createMatchSubnetRouteMarkRule(table, chain, action)
+func addMatchSubnetRouteMarkRule(conn *nftables.Conn, table *nftables.Table, chain *nftables.Chain, action MatchDecision, marks PacketMarks) error {
+	rule, err := createMatchSubnetRouteMarkRule(table, chain, action, marks)
 	if err != nil {
 		return fmt.Errorf("create match subnet route mark rule: %w", err)
 	}
@@ -1865,7 +1888,7 @@ func (n *nftablesRunner) AddSNATRule() error {
 			return fmt.Errorf("get postrouting chain v4: %w", err)
 		}
 
-		if err = addMatchSubnetRouteMarkRule(conn, table.Nat, chain, Masq); err != nil {
+		if err = addMatchSubnetRouteMarkRule(conn, table.Nat, chain, Masq, n.marks); err != nil {
 			return fmt.Errorf("add match subnet route mark rule v4: %w", err)
 		}
 	}
@@ -1877,9 +1900,9 @@ func (n *nftablesRunner) AddSNATRule() error {
 	return nil
 }
 
-func delMatchSubnetRouteMarkMasqRule(conn *nftables.Conn, table *nftables.Table, chain *nftables.Chain) error {
+func delMatchSubnetRouteMarkMasqRule(conn *nftables.Conn, table *nftables.Table, chain *nftables.Chain, marks PacketMarks) error {
 
-	rule, err := createMatchSubnetRouteMarkRule(table, chain, Masq)
+	rule, err := createMatchSubnetRouteMarkRule(table, chain, Masq, marks)
 	if err != nil {
 		return fmt.Errorf("create match subnet route mark rule: %w", err)
 	}
@@ -1910,7 +1933,7 @@ func (n *nftablesRunner) DelSNATRule() error {
 		if err != nil {
 			return fmt.Errorf("get postrouting chain: %w", err)
 		}
-		err = delMatchSubnetRouteMarkMasqRule(conn, table.Nat, chain)
+		err = delMatchSubnetRouteMarkMasqRule(conn, table.Nat, chain, n.marks)
 		if err != nil {
 			return err
 		}
@@ -2125,7 +2148,7 @@ func (n *nftablesRunner) DelStatefulRule(tunname string) error {
 // The conditional check (ct mark & 0xff0000 != 0) prevents the worst case of wiping all
 // mark bits to zero. Perfect bit preservation would require kernel
 // changes to add register-to-register bitwise operations to nftables.
-func makeConnmarkRestoreExprs() []expr.Any {
+func makeConnmarkRestoreExprs(marks PacketMarks) []expr.Any {
 	return []expr.Any{
 		// Load conntrack state into register 1
 		&expr.Ct{
@@ -2157,7 +2180,7 @@ func makeConnmarkRestoreExprs() []expr.Any {
 			SourceRegister: 1,
 			DestRegister:   1,
 			Len:            4,
-			Mask:           getTailscaleFwmarkMask(),
+			Mask:           marks.FwmarkMaskBytes(),
 			Xor:            []byte{0x00, 0x00, 0x00, 0x00},
 		},
 		// Check if masked ct mark is non-zero (critical: prevents wiping marks with 0)
@@ -2177,7 +2200,7 @@ func makeConnmarkRestoreExprs() []expr.Any {
 
 // makeConnmarkSaveExprs creates nftables expressions to save mark to conntrack.
 // Implements: ct state new meta mark & 0xff0000 != 0 ct mark set meta mark & 0xff0000
-func makeConnmarkSaveExprs() []expr.Any {
+func makeConnmarkSaveExprs(marks PacketMarks) []expr.Any {
 	return []expr.Any{
 		// Load conntrack state into register 1
 		&expr.Ct{
@@ -2207,7 +2230,7 @@ func makeConnmarkSaveExprs() []expr.Any {
 			SourceRegister: 1,
 			DestRegister:   1,
 			Len:            4,
-			Mask:           getTailscaleFwmarkMask(),
+			Mask:           marks.FwmarkMaskBytes(),
 			Xor:            []byte{0x00, 0x00, 0x00, 0x00},
 		},
 		// Check if mark is non-zero
@@ -2226,7 +2249,7 @@ func makeConnmarkSaveExprs() []expr.Any {
 			SourceRegister: 1,
 			DestRegister:   1,
 			Len:            4,
-			Mask:           getTailscaleFwmarkMask(),
+			Mask:           marks.FwmarkMaskBytes(),
 			Xor:            []byte{0x00, 0x00, 0x00, 0x00},
 		},
 		// Set conntrack mark from register 1
@@ -2291,7 +2314,7 @@ func (n *nftablesRunner) AddConnmarkSaveRule() error {
 		conn.InsertRule(&nftables.Rule{
 			Table:    mangleTable,
 			Chain:    preroutingChain,
-			Exprs:    makeConnmarkRestoreExprs(),
+			Exprs:    makeConnmarkRestoreExprs(n.marks),
 			UserData: []byte("ts-connmark-restore"),
 		})
 
@@ -2312,7 +2335,7 @@ func (n *nftablesRunner) AddConnmarkSaveRule() error {
 		conn.InsertRule(&nftables.Rule{
 			Table:    mangleTable,
 			Chain:    outputChain,
-			Exprs:    makeConnmarkSaveExprs(),
+			Exprs:    makeConnmarkSaveExprs(n.marks),
 			UserData: []byte("ts-connmark-save"),
 		})
 	}

--- a/util/linuxfw/nftables_runner_test.go
+++ b/util/linuxfw/nftables_runner_test.go
@@ -314,7 +314,7 @@ func TestAddSetSubnetRouteMarkRule(t *testing.T) {
 		Hooknum:  nftables.ChainHookForward,
 		Priority: nftables.ChainPriorityFilter,
 	})
-	err := addSetSubnetRouteMarkRule(testConn, table, chain, "testTunn")
+	err := addSetSubnetRouteMarkRule(testConn, table, chain, "testTunn", DefaultPacketMarks())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -442,7 +442,7 @@ func TestAddMatchSubnetRouteMarkRuleMasq(t *testing.T) {
 		Hooknum:  nftables.ChainHookPostrouting,
 		Priority: nftables.ChainPriorityNATSource,
 	})
-	err := addMatchSubnetRouteMarkRule(testConn, table, chain, Masq)
+	err := addMatchSubnetRouteMarkRule(testConn, table, chain, Masq, DefaultPacketMarks())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -481,7 +481,7 @@ func TestDelMatchSubnetRouteMarkMasqRule(t *testing.T) {
 		Priority: nftables.ChainPriorityNATSource,
 	}
 
-	err := delMatchSubnetRouteMarkMasqRule(conn, table, chain)
+	err := delMatchSubnetRouteMarkMasqRule(conn, table, chain, DefaultPacketMarks())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -513,7 +513,7 @@ func TestAddMatchSubnetRouteMarkRuleAccept(t *testing.T) {
 		Hooknum:  nftables.ChainHookForward,
 		Priority: nftables.ChainPriorityFilter,
 	})
-	err := addMatchSubnetRouteMarkRule(testConn, table, chain, Accept)
+	err := addMatchSubnetRouteMarkRule(testConn, table, chain, Accept, DefaultPacketMarks())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -680,12 +680,12 @@ func findCommonBaseRules(
 	forwChain *nftables.Chain,
 	tunname string) ([]*nftables.Rule, error) {
 	want := []*nftables.Rule{}
-	rule, err := createSetSubnetRouteMarkRule(forwChain.Table, forwChain, tunname)
+	rule, err := createSetSubnetRouteMarkRule(forwChain.Table, forwChain, tunname, DefaultPacketMarks())
 	if err != nil {
 		return nil, fmt.Errorf("create rule: %w", err)
 	}
 	want = append(want, rule)
-	rule, err = createMatchSubnetRouteMarkRule(forwChain.Table, forwChain, Accept)
+	rule, err = createMatchSubnetRouteMarkRule(forwChain.Table, forwChain, Accept, DefaultPacketMarks())
 	if err != nil {
 		return nil, fmt.Errorf("create rule: %w", err)
 	}
@@ -1338,7 +1338,7 @@ func TestMakeConnmarkRestoreExprs(t *testing.T) {
 	testConn.InsertRule(&nftables.Rule{
 		Table: table,
 		Chain: chain,
-		Exprs: makeConnmarkRestoreExprs(),
+		Exprs: makeConnmarkRestoreExprs(DefaultPacketMarks()),
 	})
 	if err := testConn.Flush(); err != nil {
 		t.Fatalf("Flush() failed: %v", err)
@@ -1379,7 +1379,7 @@ func TestMakeConnmarkSaveExprs(t *testing.T) {
 	testConn.InsertRule(&nftables.Rule{
 		Table: table,
 		Chain: chain,
-		Exprs: makeConnmarkSaveExprs(),
+		Exprs: makeConnmarkSaveExprs(DefaultPacketMarks()),
 	})
 	if err := testConn.Flush(); err != nil {
 		t.Fatalf("Flush() failed: %v", err)
@@ -1420,4 +1420,55 @@ func TestGetOrCreateChainNilHooknum(t *testing.T) {
 	if !strings.Contains(err.Error(), "nil hooknum") {
 		t.Fatalf("unexpected error: %v", err)
 	}
+}
+
+// TestSetPacketMarks_nftablesRunner_Exprs verifies that non-default packet
+// marks configured via SetPacketMarks flow through the runner into the
+// nftables rule expressions it produces.
+//
+// AddConnmarkSaveRule (the runner's only rule-installer that consumes
+// n.marks at expression-construction time) calls makeConnmarkRestoreExprs
+// and makeConnmarkSaveExprs with n.marks; exercising those helpers with the
+// runner's stored marks therefore proves the end-to-end path without needing
+// a real netfilter conn. A separate integration test
+// (TestNFTAddAndDelConnmarkRules) covers the wire-level flow under root.
+func TestSetPacketMarks_nftablesRunner_Exprs(t *testing.T) {
+	// Defaults shifted up by one byte: a realistic non-default choice for
+	// users avoiding conflicts with other software that uses the third
+	// byte (e.g. Calico). Passes LinuxPacketMarks.Validate.
+	custom := PacketMarks{
+		FwmarkMask:      0xff000000,
+		SubnetRouteMark: 0x40000000,
+		BypassMark:      0x80000000,
+	}
+	wantMask := custom.FwmarkMaskBytes()
+	defaultMask := DefaultPacketMarks().FwmarkMaskBytes()
+
+	var n nftablesRunner
+	n.SetPacketMarks(custom)
+	if n.marks != custom {
+		t.Fatalf("SetPacketMarks: n.marks = %+v, want %+v", n.marks, custom)
+	}
+
+	check := func(name string, exprs []expr.Any) {
+		t.Helper()
+		var found bool
+		for _, e := range exprs {
+			bw, ok := e.(*expr.Bitwise)
+			if !ok {
+				continue
+			}
+			if bytes.Equal(bw.Mask, wantMask) {
+				found = true
+			}
+			if bytes.Equal(bw.Mask, defaultMask) {
+				t.Errorf("%s: bitwise expression unexpectedly used the default mask %x", name, defaultMask)
+			}
+		}
+		if !found {
+			t.Errorf("%s: no bitwise expression used the custom mask %x", name, wantMask)
+		}
+	}
+	check("makeConnmarkRestoreExprs", makeConnmarkRestoreExprs(n.marks))
+	check("makeConnmarkSaveExprs", makeConnmarkSaveExprs(n.marks))
 }

--- a/util/linuxfw/packet_mark_test.go
+++ b/util/linuxfw/packet_mark_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build linux
+
+package linuxfw
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func nativeBytes(v uint32) []byte {
+	b := make([]byte, 4)
+	binary.NativeEndian.PutUint32(b, v)
+	return b
+}
+
+func TestPacketMarks_ByteConversions(t *testing.T) {
+	// Test that the default marks produce the same byte arrays as the hardcoded ones
+	marks := DefaultPacketMarks()
+
+	tests := []struct {
+		name string
+		got  []byte
+		want []byte
+	}{
+		{
+			name: "FwmarkMaskBytes",
+			got:  marks.FwmarkMaskBytes(),
+			want: nativeBytes(0x00ff0000),
+		},
+		{
+			name: "FwmarkMaskNegBytes",
+			got:  marks.FwmarkMaskNegBytes(),
+			want: nativeBytes(^uint32(0x00ff0000)),
+		},
+		{
+			name: "SubnetRouteMarkBytes",
+			got:  marks.SubnetRouteMarkBytes(),
+			want: nativeBytes(0x00040000),
+		},
+		{
+			name: "BypassMarkBytes",
+			got:  marks.BypassMarkBytes(),
+			want: nativeBytes(0x00080000),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !bytes.Equal(tt.got, tt.want) {
+				t.Errorf("%s = %v, want %v", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPacketMarks_StringConversions(t *testing.T) {
+	marks := DefaultPacketMarks()
+
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{
+			name: "FwmarkMaskString",
+			got:  marks.FwmarkMaskString(),
+			want: "0xff0000",
+		},
+		{
+			name: "SubnetRouteMarkString",
+			got:  marks.SubnetRouteMarkString(),
+			want: "0x40000",
+		},
+		{
+			name: "BypassMarkString",
+			got:  marks.BypassMarkString(),
+			want: "0x80000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("%s = %q, want %q", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPacketMarks_CustomValues(t *testing.T) {
+	// Test with custom mark values
+	marks := PacketMarks{
+		FwmarkMask:      0xffff00,
+		SubnetRouteMark: 0x100,
+		BypassMark:      0x200,
+	}
+
+	if got := marks.FwmarkMaskString(); got != "0xffff00" {
+		t.Errorf("FwmarkMaskString() = %q, want %q", got, "0xffff00")
+	}
+	if got := marks.SubnetRouteMarkString(); got != "0x100" {
+		t.Errorf("SubnetRouteMarkString() = %q, want %q", got, "0x100")
+	}
+	if got := marks.BypassMarkString(); got != "0x200" {
+		t.Errorf("BypassMarkString() = %q, want %q", got, "0x200")
+	}
+
+	if got, want := marks.FwmarkMaskBytes(), nativeBytes(0xffff00); !bytes.Equal(got, want) {
+		t.Errorf("FwmarkMaskBytes() = %v, want %v", got, want)
+	}
+	if got, want := marks.SubnetRouteMarkBytes(), nativeBytes(0x100); !bytes.Equal(got, want) {
+		t.Errorf("SubnetRouteMarkBytes() = %v, want %v", got, want)
+	}
+	if got, want := marks.BypassMarkBytes(), nativeBytes(0x200); !bytes.Equal(got, want) {
+		t.Errorf("BypassMarkBytes() = %v, want %v", got, want)
+	}
+}

--- a/wgengine/router/osrouter/router_linux.go
+++ b/wgengine/router/osrouter/router_linux.go
@@ -27,7 +27,7 @@ import (
 	"tailscale.com/envknob"
 	"tailscale.com/health"
 	"tailscale.com/net/netmon"
-	"tailscale.com/tsconst"
+	"tailscale.com/net/netns"
 	"tailscale.com/types/logger"
 	"tailscale.com/types/opt"
 	"tailscale.com/types/preftype"
@@ -77,8 +77,17 @@ type linuxRouter struct {
 	// ipPolicyPrefBase is the base priority at which ip rules are installed.
 	ipPolicyPrefBase int
 
-	cmd commandRunner
-	nfr linuxfw.NetfilterRunner
+	cmd   commandRunner
+	nfr   linuxfw.NetfilterRunner
+	marks linuxfw.PacketMarks
+
+	// ipRulesInstalled is true once [addIPRules] has been called. IP rules
+	// reference r.marks; installation is deferred from [Up] to the first
+	// [Set] so the rules can be built with marks from prefs rather than the
+	// defaults. Marks are intentionally not mutable at runtime (see
+	// LocalBackend.checkLinuxPacketMarksLocked), so the rules never need
+	// to be rebuilt for the lifetime of this router.
+	ipRulesInstalled bool
 
 	mu                sync.Mutex
 	addrs             map[netip.Prefix]bool
@@ -115,7 +124,8 @@ func newUserspaceRouterAdvanced(logf logger.Logf, tunname string, netMon *netmon
 		netMon:        netMon,
 		health:        health,
 
-		cmd: cmd,
+		cmd:   cmd,
+		marks: linuxfw.DefaultPacketMarks(),
 
 		ipRuleFixLimiter: rate.NewLimiter(rate.Every(5*time.Second), 10),
 		ipPolicyPrefBase: 5200,
@@ -354,9 +364,8 @@ func (r *linuxRouter) Up() error {
 	if err := r.setNetfilterModeLocked(netfilterOff); err != nil {
 		return fmt.Errorf("setting netfilter mode: %w", err)
 	}
-	if err := r.addIPRules(); err != nil {
-		return fmt.Errorf("adding IP rules: %w", err)
-	}
+	// IP rules are installed lazily in [Set], once r.marks has been
+	// populated from prefs.
 	if err := r.upInterface(); err != nil {
 		return fmt.Errorf("bringing interface up: %w", err)
 	}
@@ -410,6 +419,9 @@ func (r *linuxRouter) setupNetfilterLocked(kind string) error {
 		return fmt.Errorf("could not create new netfilter: %w", err)
 	}
 
+	// Apply current packet marks to the new netfilter runner
+	r.nfr.SetPacketMarks(r.marks)
+
 	return nil
 }
 
@@ -420,6 +432,35 @@ func (r *linuxRouter) Set(cfg *router.Config) error {
 	var errs []error
 	if cfg == nil {
 		cfg = &shutdownConfig
+	}
+
+	// Apply packet marks from prefs. Mark changes via the LocalAPI path
+	// (tailscale set) are rejected upstream by
+	// LocalBackend.checkLinuxPacketMarksLocked, and marks are intended to
+	// be configured exclusively via the tailscaled config file applied at
+	// startup. In practice r.marks therefore takes its final value on the
+	// first non-shutdown call to Set and never changes afterward.
+	if cfg.LinuxPacketMarks != nil {
+		r.marks = linuxfw.PacketMarks{
+			FwmarkMask:      cfg.LinuxPacketMarks.FwmarkMask,
+			SubnetRouteMark: cfg.LinuxPacketMarks.SubnetRouteMark,
+			BypassMark:      cfg.LinuxPacketMarks.BypassMark,
+		}
+		netns.SetBypassMark(cfg.LinuxPacketMarks.BypassMark)
+		if r.nfr != nil {
+			r.nfr.SetPacketMarks(r.marks)
+		}
+	}
+
+	// Install IP rules on the first Set call, after r.marks has been
+	// populated from prefs. Done here rather than in [Up] so the rules
+	// reference the user's configured marks rather than the defaults.
+	if !r.ipRulesInstalled {
+		if err := r.addIPRules(); err != nil {
+			errs = append(errs, fmt.Errorf("adding IP rules: %w", err))
+		} else {
+			r.ipRulesInstalled = true
+		}
 	}
 
 	if cfg.NetfilterKind != r.netfilterKind {
@@ -1326,85 +1367,81 @@ var (
 	tailscaleRouteTable = newRouteTable("tailscale", 52)
 )
 
-// baseIPRules are the policy routing rules that Tailscale uses, when not
-// running on a UBNT device.
-//
-// The priority is the value represented here added to r.ipPolicyPrefBase,
-// which is usually 5200.
-//
-// NOTE(apenwarr): We leave spaces between each pref number.
-// This is so the sysadmin can override by inserting rules in
-// between if they want.
-//
-// NOTE(apenwarr): This sequence seems complicated, right?
-// If we could simply have a rule that said "match packets that
-// *don't* have this fwmark", then we would only need to add one
-// link to table 52 and we'd be done. Unfortunately, older kernels
-// and 'ip rule' implementations (including busybox), don't support
-// checking for the lack of a fwmark, only the presence. The technique
-// below works even on very old kernels.
-var baseIPRules = []netlink.Rule{
-	// Packets from us, tagged with our fwmark, first try the kernel's
-	// main routing table.
-	{
-		Priority: 10,
-		Mark:     tsconst.LinuxBypassMarkNum,
-		Table:    mainRouteTable.Num,
-	},
-	// ...and then we try the 'default' table, for correctness,
-	// even though it's been empty on every Linux system I've ever seen.
-	{
-		Priority: 30,
-		Mark:     tsconst.LinuxBypassMarkNum,
-		Table:    defaultRouteTable.Num,
-	},
-	// If neither of those matched (no default route on this system?)
-	// then packets from us should be aborted rather than falling through
-	// to the tailscale routes, because that would create routing loops.
-	{
-		Priority: 50,
-		Mark:     tsconst.LinuxBypassMarkNum,
-		Type:     unix.RTN_UNREACHABLE,
-	},
-	// If we get to this point, capture all packets and send them
-	// through to the tailscale route table. For apps other than us
-	// (ie. with no fwmark set), this is the first routing table, so
-	// it takes precedence over all the others, ie. VPN routes always
-	// beat non-VPN routes.
-	{
-		Priority: 70,
-		Table:    tailscaleRouteTable.Num,
-	},
-	// If that didn't match, then non-fwmark packets fall through to the
-	// usual rules (pref 32766 and 32767, ie. main and default).
-}
-
-// ubntIPRules are the policy routing rules that Tailscale uses, when running
-// on a UBNT device.
-//
-// The priority is the value represented here added to
-// r.ipPolicyPrefBase, which is usually 5200.
-//
-// This represents an experiment that will be used to gather more information.
-// If this goes well, Tailscale may opt to use this for all of Linux.
-var ubntIPRules = []netlink.Rule{
-	// non-fwmark packets fall through to the usual rules (pref 32766 and 32767,
-	// ie. main and default).
-	{
-		Priority: 70,
-		Invert:   true,
-		Mark:     tsconst.LinuxBypassMarkNum,
-		Table:    tailscaleRouteTable.Num,
-	},
-}
-
-// ipRules returns the appropriate list of ip rules to be used by Tailscale. See
-// comments on baseIPRules and ubntIPRules for more details.
-func ipRules() []netlink.Rule {
+// ipRules returns the appropriate list of ip rules to be used by Tailscale.
+// It constructs the rules dynamically using the router's configured packet marks.
+func (r *linuxRouter) ipRules() []netlink.Rule {
 	if getDistroFunc() == distro.UBNT {
-		return ubntIPRules
+		// ubntIPRules are the policy routing rules that Tailscale uses, when running
+		// on a UBNT device.
+		//
+		// The priority is the value represented here added to
+		// r.ipPolicyPrefBase, which is usually 5200.
+		//
+		// This represents an experiment that will be used to gather more information.
+		// If this goes well, Tailscale may opt to use this for all of Linux.
+		return []netlink.Rule{
+			// non-fwmark packets fall through to the usual rules (pref 32766 and 32767,
+			// ie. main and default).
+			{
+				Priority: 70,
+				Invert:   true,
+				Mark:     int(r.marks.BypassMark),
+				Table:    tailscaleRouteTable.Num,
+			},
+		}
 	}
-	return baseIPRules
+
+	// baseIPRules are the policy routing rules that Tailscale uses on most Linux systems.
+	//
+	// The priority is the value represented here added to r.ipPolicyPrefBase,
+	// which is usually 5200.
+	//
+	// NOTE(apenwarr): We leave spaces between each pref number.
+	// This is so the sysadmin can override by inserting rules in
+	// between if they want.
+	//
+	// NOTE(apenwarr): This sequence seems complicated, right?
+	// If we could simply have a rule that said "match packets that
+	// *don't* have this fwmark", then we would only need to add one
+	// link to table 52 and we'd be done. Unfortunately, older kernels
+	// and 'ip rule' implementations (including busybox), don't support
+	// checking for the lack of a fwmark, only the presence. The technique
+	// below works even on very old kernels.
+	return []netlink.Rule{
+		// Packets from us, tagged with our fwmark, first try the kernel's
+		// main routing table.
+		{
+			Priority: 10,
+			Mark:     int(r.marks.BypassMark),
+			Table:    mainRouteTable.Num,
+		},
+		// ...and then we try the 'default' table, for correctness,
+		// even though it's been empty on every Linux system I've ever seen.
+		{
+			Priority: 30,
+			Mark:     int(r.marks.BypassMark),
+			Table:    defaultRouteTable.Num,
+		},
+		// If neither of those matched (no default route on this system?)
+		// then packets from us should be aborted rather than falling through
+		// to the tailscale routes, because that would create routing loops.
+		{
+			Priority: 50,
+			Mark:     int(r.marks.BypassMark),
+			Type:     unix.RTN_UNREACHABLE,
+		},
+		// If we get to this point, capture all packets and send them
+		// through to the tailscale route table. For apps other than us
+		// (ie. with no fwmark set), this is the first routing table, so
+		// it takes precedence over all the others, ie. VPN routes always
+		// beat non-VPN routes.
+		{
+			Priority: 70,
+			Table:    tailscaleRouteTable.Num,
+		},
+		// If that didn't match, then non-fwmark packets fall through to the
+		// usual rules (pref 32766 and 32767, ie. main and default).
+	}
 }
 
 // justAddIPRules adds policy routing rule without deleting any first.
@@ -1417,11 +1454,11 @@ func (r *linuxRouter) justAddIPRules() error {
 	}
 	var errAcc error
 	for _, family := range r.addrFamilies() {
-		for _, ru := range ipRules() {
+		for _, ru := range r.ipRules() {
 			// Note: r is a value type here; safe to mutate it.
 			ru.Family = family.netlinkInt()
 			if ru.Mark != 0 {
-				ru.Mask = tsconst.LinuxFwmarkMaskNum
+				ru.Mask = int(r.marks.FwmarkMask)
 			}
 			ru.Goto = -1
 			ru.SuppressIfgroup = -1
@@ -1446,17 +1483,21 @@ func (r *linuxRouter) addIPRulesWithIPCommand() error {
 	rg := newRunGroup(nil, r.cmd)
 
 	for _, family := range r.addrFamilies() {
-		for _, rule := range ipRules() {
+		for _, rule := range r.ipRules() {
 			args := []string{
 				"ip", family.dashArg(),
 				"rule", "add",
 				"pref", strconv.Itoa(rule.Priority + r.ipPolicyPrefBase),
 			}
 			if rule.Mark != 0 {
+				// netlink.Rule.Mark is int, so on 32-bit platforms a 0x80000000+
+				// bypass mark sign-extends to a negative value; format the
+				// unsigned bit pattern so the resulting "ip rule add ... fwmark"
+				// argument is the same on all platforms.
 				if r.fwmaskWorks() {
-					args = append(args, "fwmark", fmt.Sprintf("0x%x/%s", rule.Mark, tsconst.LinuxFwmarkMask))
+					args = append(args, "fwmark", fmt.Sprintf("0x%x/%s", uint32(rule.Mark), r.marks.FwmarkMaskString()))
 				} else {
-					args = append(args, "fwmark", fmt.Sprintf("0x%x", rule.Mark))
+					args = append(args, "fwmark", fmt.Sprintf("0x%x", uint32(rule.Mark)))
 				}
 			}
 			if rule.Table != 0 {
@@ -1494,7 +1535,7 @@ func (r *linuxRouter) delIPRules() error {
 	}
 	var errAcc error
 	for _, family := range r.addrFamilies() {
-		for _, ru := range ipRules() {
+		for _, ru := range r.ipRules() {
 			// Note: r is a value type here; safe to mutate it.
 			// When deleting rules, we want to be a bit specific (mention which
 			// table we were routing to) but not *too* specific (fwmarks, etc).
@@ -1537,7 +1578,7 @@ func (r *linuxRouter) delIPRulesWithIPCommand() error {
 		// That leaves us some flexibility to change these values in later
 		// versions without having ongoing hacks for every possible
 		// combination.
-		for _, rule := range ipRules() {
+		for _, rule := range r.ipRules() {
 			args := []string{
 				"ip", family.dashArg(),
 				"rule", "del",

--- a/wgengine/router/osrouter/router_linux_test.go
+++ b/wgengine/router/osrouter/router_linux_test.go
@@ -1007,6 +1007,9 @@ func (n *fakeIPTablesRunner) DelExternalCGNATRules(mode linuxfw.CGNATMode, tunna
 func (n *fakeIPTablesRunner) HasIPV6() bool       { return true }
 func (n *fakeIPTablesRunner) HasIPV6NAT() bool    { return true }
 func (n *fakeIPTablesRunner) HasIPV6Filter() bool { return true }
+func (n *fakeIPTablesRunner) SetPacketMarks(marks linuxfw.PacketMarks) {
+	// No-op for testing
+}
 
 // fakeOS implements commandRunner and provides v4 and v6
 // netfilterRunners, but captures changes without touching the OS.
@@ -1506,8 +1509,19 @@ func TestIPRulesForUBNT(t *testing.T) {
 	}
 	defer func() { getDistroFunc = distro.Get }() // Restore original after the test
 
-	expected := ubntIPRules
-	actual := ipRules()
+	r := &linuxRouter{
+		marks: linuxfw.DefaultPacketMarks(),
+	}
+
+	expected := []netlink.Rule{
+		{
+			Priority: 70,
+			Invert:   true,
+			Mark:     int(r.marks.BypassMark),
+			Table:    tailscaleRouteTable.Num,
+		},
+	}
+	actual := r.ipRules()
 
 	if len(expected) != len(actual) {
 		t.Fatalf("Expected %d rules, got %d", len(expected), len(actual))
@@ -1517,6 +1531,58 @@ func TestIPRulesForUBNT(t *testing.T) {
 		if rule != actual[i] {
 			t.Errorf("Rule mismatch at index %d: expected %+v, got %+v", i, rule, actual[i])
 		}
+	}
+}
+
+func TestIPRulesWithCustomMarks(t *testing.T) {
+	// Defaults shifted up by one byte: a realistic non-default choice for
+	// users avoiding conflicts with other software that uses the third
+	// byte (e.g. Calico). Passes preftype.LinuxPacketMarks.Validate.
+	const customBypass uint32 = 0x80000000
+	custom := linuxfw.PacketMarks{
+		FwmarkMask:      0xff000000,
+		SubnetRouteMark: 0x40000000,
+		BypassMark:      customBypass,
+	}
+
+	tests := []struct {
+		name   string
+		distro distro.Distro
+	}{
+		{"base", distro.Debian},
+		{"ubnt", distro.UBNT},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getDistroFunc = func() distro.Distro { return tt.distro }
+			defer func() { getDistroFunc = distro.Get }()
+
+			r := &linuxRouter{marks: custom}
+			rules := r.ipRules()
+			if len(rules) == 0 {
+				t.Fatalf("no rules returned")
+			}
+			var marked int
+			for _, ru := range rules {
+				if ru.Mark == 0 {
+					continue
+				}
+				marked++
+				// Compare via uint32 because customBypass (0x80000000) is a
+				// typed const that overflows int on 32-bit platforms; the
+				// raw netlink rule stores the mark in an int (sign-extended
+				// or wrapped depending on platform).
+				if got, want := uint32(ru.Mark), customBypass; got != want {
+					t.Errorf("rule %+v: Mark=0x%x, want custom bypass mark 0x%x", ru, got, want)
+				}
+				if uint32(ru.Mark) == linuxfw.DefaultPacketMarks().BypassMark {
+					t.Errorf("rule %+v leaks the default BypassMark", ru)
+				}
+			}
+			if marked == 0 {
+				t.Fatalf("no rules referenced the bypass mark; rules=%+v", rules)
+			}
+		})
 	}
 }
 
@@ -1607,5 +1673,110 @@ func TestSetSkipsNetfilterAddonsWhenSetupFails(t *testing.T) {
 	if nfr.addExternalCGNATCalls != 0 {
 		t.Errorf("AddExternalCGNATRules called %d times; want 0 when chain setup failed",
 			nfr.addExternalCGNATCalls)
+	}
+}
+
+// TestUpDoesNotInstallIPRules verifies that [linuxRouter.Up] no longer
+// installs IP rules. Installation is deferred to [linuxRouter.Set] so the
+// rules can be built with marks from prefs rather than the defaults.
+func TestUpDoesNotInstallIPRules(t *testing.T) {
+	bus := eventbus.New()
+	defer bus.Close()
+	mon, err := netmon.New(bus, logger.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mon.Start()
+	defer mon.Close()
+
+	fake := NewFakeOS(t)
+	ht := health.NewTracker(bus)
+	r, err := newUserspaceRouterAdvanced(logger.Discard, "tailscale0", mon, fake, ht, bus)
+	if err != nil {
+		t.Fatalf("newUserspaceRouterAdvanced: %v", err)
+	}
+	lr := r.(*linuxRouter)
+	lr.nfr = fake.nfr
+	defer lr.Close()
+
+	if err := lr.Up(); err != nil {
+		t.Fatalf("Up: %v", err)
+	}
+	if lr.ipRulesInstalled {
+		t.Error("ipRulesInstalled = true after Up; want false")
+	}
+	if len(fake.rules) != 0 {
+		t.Errorf("Up installed %d IP rule(s); want 0: %v", len(fake.rules), fake.rules)
+	}
+}
+
+// TestSetInstallsIPRulesWithCustomMarks verifies that the first
+// [linuxRouter.Set] call installs IP rules referencing the marks supplied
+// in the config (rather than the runner's default marks).
+func TestSetInstallsIPRulesWithCustomMarks(t *testing.T) {
+	bus := eventbus.New()
+	defer bus.Close()
+	mon, err := netmon.New(bus, logger.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mon.Start()
+	defer mon.Close()
+
+	fake := NewFakeOS(t)
+	ht := health.NewTracker(bus)
+	r, err := newUserspaceRouterAdvanced(logger.Discard, "tailscale0", mon, fake, ht, bus)
+	if err != nil {
+		t.Fatalf("newUserspaceRouterAdvanced: %v", err)
+	}
+	lr := r.(*linuxRouter)
+	lr.nfr = fake.nfr
+	// Force fwmask support so the fake's recorded rules are in the
+	// "fwmark X/Y" form regardless of whether the host 'ip' binary
+	// (or the CI Docker image's lack thereof) actually supports masks.
+	lr.fwmaskWorksLazy.Set(true)
+	defer lr.Close()
+
+	if err := lr.Up(); err != nil {
+		t.Fatalf("Up: %v", err)
+	}
+
+	// Custom marks shifted up by one byte (Calico-conflict workaround).
+	custom := linuxfw.PacketMarks{
+		FwmarkMask:      0xff000000,
+		SubnetRouteMark: 0x40000000,
+		BypassMark:      0x80000000,
+	}
+	cfg := &Config{
+		LocalAddrs: mustCIDRs("100.101.102.103/10"),
+		LinuxPacketMarks: &router.LinuxPacketMarks{
+			FwmarkMask:      custom.FwmarkMask,
+			SubnetRouteMark: custom.SubnetRouteMark,
+			BypassMark:      custom.BypassMark,
+		},
+	}
+	if err := lr.Set(cfg); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if !lr.ipRulesInstalled {
+		t.Fatal("ipRulesInstalled = false after Set; want true")
+	}
+
+	// Use the full "fwmark 0x.../0x..." form to avoid substring false
+	// positives between e.g. 0x80000 (default) and 0x80000000 (custom).
+	defaults := linuxfw.DefaultPacketMarks()
+	wantCustom := fmt.Sprintf("fwmark 0x%x/0x%x", custom.BypassMark, custom.FwmarkMask)
+	wantDefault := fmt.Sprintf("fwmark 0x%x/0x%x", defaults.BypassMark, defaults.FwmarkMask)
+	var sawCustom bool
+	for _, rule := range fake.rules {
+		if strings.Contains(rule, wantDefault) {
+			t.Errorf("IP rule references the default fwmark: %q", rule)
+		}
+		if strings.Contains(rule, wantCustom) {
+			sawCustom = true
+		}
+	}
+	if !sawCustom {
+		t.Errorf("custom fwmark %q not found in IP rules: %v", wantCustom, fake.rules)
 	}
 }

--- a/wgengine/router/router.go
+++ b/wgengine/router/router.go
@@ -137,6 +137,19 @@ type Config struct {
 	NetfilterMode       preftype.NetfilterMode // how much to manage netfilter rules
 	NetfilterKind       string                 // what kind of netfilter to use ("nftables", "iptables", or "" to auto-detect)
 	RemoveCGNATDropRule bool                   // whether to remove the firewall rule to drop non-Tailscale inbound traffic from CGNAT IPs
+
+	// LinuxPacketMarks contains the packet mark values to use for Linux
+	// firewall rules and routing. If nil, defaults from tsconst are used.
+	// Only used on Linux.
+	LinuxPacketMarks *LinuxPacketMarks
+}
+
+// LinuxPacketMarks holds the packet mark configuration for Linux.
+// This is a copy of ipn.LinuxPacketMarks to avoid circular imports.
+type LinuxPacketMarks struct {
+	FwmarkMask      uint32
+	SubnetRouteMark uint32
+	BypassMark      uint32
 }
 
 func (a *Config) Equal(b *Config) bool {

--- a/wgengine/router/router_test.go
+++ b/wgengine/router/router_test.go
@@ -15,7 +15,7 @@ func TestConfigEqual(t *testing.T) {
 	testedFields := []string{
 		"LocalAddrs", "Routes", "LocalRoutes", "NewMTU",
 		"SubnetRoutes", "SNATSubnetRoutes", "StatefulFiltering",
-		"NetfilterMode", "NetfilterKind", "RemoveCGNATDropRule",
+		"NetfilterMode", "NetfilterKind", "RemoveCGNATDropRule", "LinuxPacketMarks",
 	}
 	configType := reflect.TypeFor[Config]()
 	configFields := []string{}


### PR DESCRIPTION
This adds support for configuring Linux packet mark values in the
tailscaled config file. The new `LinuxPacketMarks` config field lets Linux
deployments move Tailscale's fwmark mask, subnet-route mark, and bypass mark
away from values reserved by software such as Calico, Cilium, UniFi, or
Android netd.

Packet marks are applied when tailscaled starts. Runtime changes are
intentionally rejected through both config reload and the LocalAPI path used by
`tailscale set`, because changing these values live would leave existing
sockets with stale `SO_MARK` values and would require rebuilding all
mark-referencing iptables/nftables and policy-routing state atomically.

The default packet mark values remain unchanged when `LinuxPacketMarks` is not
set.

Fixes #591
