### PR TITLE
Dockerfile: strip symbol table to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ ENV VERSION_GIT_HASH=$VERSION_GIT_HASH
 ARG TARGETARCH
 
 RUN GOARCH=$TARGETARCH go install -ldflags="\
+      -s \
       -X tailscale.com/version.longStamp=$VERSION_LONG \
       -X tailscale.com/version.shortStamp=$VERSION_SHORT \
       -X tailscale.com/version.gitCommitStamp=$VERSION_GIT_HASH" \


### PR DESCRIPTION
### Summary


Add -s to -ldflags in go install to strip the symbol table and debug information from the built binary, reducing the final container image size.


```diff
$ docker image ls
- before-tailscale    latest    31389fc78830   15 minutes ago   161MB
+ after-tailscale     latest    3b6294110eb3   15 minutes ago   114MB
```

### Details

This flag omit the symbol table and debug information.
It should be harmless unless you use the nm or objdump commands on a daily basis.
The contents of the stack trace output will not change either.

cf. https://pkg.go.dev/cmd/link
> -s
	Omit the symbol table and debug information.
	Implies the -w flag, which can be negated with -w=0.