### PR TITLE
feature/posture: always report MAC addresses in posture identity

### DIFF
--- a/feature/posture/posture.go
+++ b/feature/posture/posture.go
@@ -89,14 +89,15 @@ func handleC2NPostureIdentityGet(b *ipnlocal.LocalBackend, w http.ResponseWriter
 			b.HealthTracker().SetHealthy(postureSerialWarnable)
 		}
 
-		// TODO(tailscale/corp#21371, 2024-07-10): once this has landed in a stable release
-		// and looks good in client metrics, remove this parameter and always report MAC
-		// addresses.
-		if r.FormValue("hwaddrs") == "true" {
-			res.IfaceHardwareAddrs, err = e.getHardwareAddrs()
-			if err != nil {
-				e.logf("c2n: GetHardwareAddrs returned error: %v", err)
-			}
+		// Hardware addresses are always reported when posture checking
+		// is enabled. Previously, these were only reported when the
+		// control plane sent "?hwaddrs=true" (set when the CrowdStrike
+		// integration was enabled, but not by default), but this was
+		// always the intended steady-state behavior. The control plane
+		// may still send the hwaddrs parameter; it is now ignored.
+		res.IfaceHardwareAddrs, err = e.getHardwareAddrs()
+		if err != nil {
+			e.logf("c2n: GetHardwareAddrs returned error: %v", err)
 		}
 	} else {
 		res.PostureDisabled = true


### PR DESCRIPTION
Previously, hardware addresses were only included in the C2N posture identity response when the control plane sent the "?hwaddrs=true" query parameter, which was only set when the CrowdStrike integration was enabled on the tailnet. This was intended to be temporary while the feature was validated in stable releases (tailscale/corp#21371).

This has been shipping in stable releases since mid-2024, so remove the query parameter gate and always report hardware addresses when posture checking is enabled. The control plane may still send the hwaddrs parameter; it is now ignored.

Updates tailscale/corp#21371