### PR TITLE
tsconsensus: fix race condition in TestOnlyTaggedPeersCanBeDialed

### DIFF
--- a/tsconsensus/tsconsensus_test.go
+++ b/tsconsensus/tsconsensus_test.go
@@ -642,7 +642,7 @@ func TestOnlyTaggedPeersCanBeDialed(t *testing.T) {
 
 	// make a StreamLayer for ps[0]
 	ts := ps[0].ts
-	auth := newAuthorization(ts, clusterTag)
+	auth := newAuthorizationForTest(ts, clusterTag)
 
 	port := 19841
 	lns := make([]net.Listener, 3)
@@ -692,10 +692,12 @@ func TestOnlyTaggedPeersCanBeDialed(t *testing.T) {
 	conn.Close()
 
 	_, err = sl.Dial(a2, 2*time.Second)
+	if err == nil {
+		t.Fatal("expected dial error to untagged node, got none")
+	}
 	if err.Error() != "dial: peer is not allowed" {
 		t.Fatalf("expected dial: peer is not allowed, got: %v", err)
 	}
-
 }
 
 func TestOnlyTaggedPeersCanJoin(t *testing.T) {


### PR DESCRIPTION
There's a race condition in `tsconsensus.TestOnlyTaggedPeersCanBeDialed`:
- The test [untags `ps[2]` and waits until `ps[0]` sees this tag dropped from `ps[2]` in the netmap](https://github.com/tailscale/tailscale/blob/d46887031097858c79b102a9fe3f2345bcea084a/tsconsensus/tsconsensus_test.go#L683-L685).
- Later the test [tries to dial `ps[2]` from `ps[0]` and expects the dial to fail](https://github.com/tailscale/tailscale/blob/d46887031097858c79b102a9fe3f2345bcea084a/tsconsensus/tsconsensus_test.go#L694-L697) as authorization to dial [relies on the presence of the tag](https://github.com/tailscale/tailscale/blob/d46887031097858c79b102a9fe3f2345bcea084a/tsconsensus/authorization.go#L127-L132), now removed from `ps[2]`.
- However, the authorization layer caches the status used to consult peer tags. When the dial happens [before the cache times out](https://github.com/tailscale/tailscale/blob/d46887031097858c79b102a9fe3f2345bcea084a/tsconsensus/authorization.go#L43-L45), the test fails.
- Due to [a bug in `testcontrol.Server.UpdateNode`](https://github.com/tailscale/tailscale/issues/18703), which the test uses to remove the tag, netmap updates are not immediately triggered. The test has to wait for the next natural set of netmap updates, which on my machine takes about 22 seconds. As a result, the cache in the authorization layer times out and the test passes.
- If one fixes the bug in `UpdateNode`, then netmap updates happen immediately, the cache is no longer timed out when the dial occurs, and the test fails.

Fixes #18720
Updates #18703