### PR TITLE
ipn/ipnlocal: log errors when suggesting exit nodes

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -7492,8 +7492,12 @@ func suggestExitNode(report *netcheck.Report, nb *nodeBackend, prevSuggestion ta
 		// it is set in the policy file: tailscale/corp#34401
 		res, err = suggestExitNodeUsingDERP(report, nb, prevSuggestion, selectRegion, selectNode, allowList)
 	}
-	name, _, _ := strings.Cut(res.Name, ".")
-	nb.logf("netmap: suggested exit node: %s (%s)", name, res.ID)
+	if err != nil {
+		nb.logf("netmap: suggested exit node: %v", err)
+	} else {
+		name, _, _ := strings.Cut(res.Name, ".")
+		nb.logf("netmap: suggested exit node: %s (%s)", name, res.ID)
+	}
 	return res, err
 }
 


### PR DESCRIPTION
In PR #18681, we started logging which exit nodes were being suggested. However, we did not log if there were errors encountered. This patch corrects this oversight.

Example logs, emitted by tailscaled, look like this:
```
2026/02/13 15:33:00 logtail started
2026/02/13 15:33:00 netmap: suggested exit node: no network map, try again later
2026/02/13 15:34:00 netmap: traffic steering: exit node scores: 0:exit-gb
2026/02/13 15:34:00 netmap: suggested exit node: exit-gb (ntqLNXkmWH11DEVEL)
```

Updates: tailscale/corp#29964
Updates: tailscale/corp#36446