### PR TITLE
tool/gocross: respect TS_GO_NEXT=1 in gocross too

### DIFF
--- a/tool/gocross/toolchain.go
+++ b/tool/gocross/toolchain.go
@@ -43,7 +43,11 @@ findTopLevel:
 		}
 	}
 
-	return readRevFile(filepath.Join(d, "go.toolchain.rev"))
+	revFile := "go.toolchain.rev"
+	if os.Getenv("TS_GO_NEXT") == "1" {
+		revFile = "go.toolchain.next.rev"
+	}
+	return readRevFile(filepath.Join(d, revFile))
 }
 
 func readRevFile(path string) (string, error) {


### PR DESCRIPTION
The gocross-wrapper.sh bash script already checks TS_GO_NEXT (as of
a374cc344e48) to select go.toolchain.next.rev over go.toolchain.rev,
but when TS_USE_GOCROSS=1 the Go binary itself was hardcoded to read
go.toolchain.rev. This makes gocross also respect the TS_GO_NEXT=1
environment variable.

Updates tailscale/corp#36382
