### PR TITLE
client/systray: set consistent ID for StatusNotifierItem

### DIFF
--- a/client/systray/systray.go
+++ b/client/systray/systray.go
@@ -171,6 +171,11 @@ tailscale systray
 See https://tailscale.com/kb/1597/linux-systray for more information.`)
 	}
 	setAppIcon(disconnected)
+
+	// set initial title, which is used by the systray package as the ID of the StatusNotifierItem.
+	// This value will get overwritten later as the client status changes.
+	systray.SetTitle("tailscale")
+
 	menu.rebuild()
 
 	menu.mu.Lock()


### PR DESCRIPTION
Fixes #18736

I just tested this manually by modifying the fyne.io/systray package to print out the ID it was using to register the StatusNotifierItem.