### PR TITLE
net/dns: make MagicDNS IPv6 registration opt-out now, not opt-in

### DIFF
--- a/net/dns/config.go
+++ b/net/dns/config.go
@@ -73,11 +73,9 @@ func (c *Config) serviceIPs(knobs *controlknobs.Knobs) []netip.Addr {
 		return []netip.Addr{tsaddr.TailscaleServiceIPv6()}
 	}
 
-	// TODO(bradfitz,mikeodr,raggi): include IPv6 here too; tailscale/tailscale#15404
-	// And add a controlknobs knob to disable dual stack.
-	//
-	// For now, opt-in for testing.
-	if magicDNSDualStack() {
+	// See https://github.com/tailscale/tailscale/issues/15404 for the background
+	// on the opt-in debug knob and the controlknob opt-out.
+	if magicDNSDualStack() || !knobs.ShouldForceRegisterMagicDNSIPv4Only() {
 		return []netip.Addr{
 			tsaddr.TailscaleServiceIP(),
 			tsaddr.TailscaleServiceIPv6(),

--- a/net/dns/manager_tcp_test.go
+++ b/net/dns/manager_tcp_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	dns "golang.org/x/net/dns/dnsmessage"
+	"tailscale.com/control/controlknobs"
 	"tailscale.com/health"
 	"tailscale.com/net/netmon"
 	"tailscale.com/net/tsdial"
@@ -93,7 +94,8 @@ func TestDNSOverTCP(t *testing.T) {
 	bus := eventbustest.NewBus(t)
 	dialer := tsdial.NewDialer(netmon.NewStatic())
 	dialer.SetBus(bus)
-	m := NewManager(t.Logf, &f, health.NewTracker(bus), dialer, nil, nil, "", bus)
+	cknobs := &controlknobs.Knobs{}
+	m := NewManager(t.Logf, &f, health.NewTracker(bus), dialer, nil, cknobs, "", bus)
 	m.resolver.TestOnlySetHook(f.SetResolver)
 	m.Set(Config{
 		Hosts: hosts(

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -179,7 +179,8 @@ type CapabilityVersion int
 //   - 130: 2025-10-06: client can send key.HardwareAttestationPublic and key.HardwareAttestationKeySignature in MapRequest
 //   - 131: 2025-11-25: client respects [NodeAttrDefaultAutoUpdate]
 //   - 132: 2026-02-13: client respects [NodeAttrDisableHostsFileUpdates]
-const CurrentCapabilityVersion CapabilityVersion = 132
+//   - 133: 2026-02-17: client understands [NodeAttrForceRegisterMagicDNSIPv4Only]; MagicDNS IPv6 registered w/ OS by default
+const CurrentCapabilityVersion CapabilityVersion = 133
 
 // ID is an integer ID for a user, node, or login allocated by the
 // control plane.
@@ -2748,6 +2749,12 @@ const (
 	// primary domain takes precedence over MagicDNS. As of 2026-02-12, it is only
 	// used on Windows.
 	NodeAttrDisableHostsFileUpdates NodeCapability = "disable-hosts-file-updates"
+
+	// NodeAttrForceRegisterMagicDNSIPv4Only forces the client to only register
+	// its MagicDNS IPv4 address with systemd/etc, and not both its IPv4 and IPv6 addresses.
+	// See https://github.com/tailscale/tailscale/issues/15404.
+	// TODO(bradfitz): remove this a few releases after 2026-02-16.
+	NodeAttrForceRegisterMagicDNSIPv4Only NodeCapability = "force-register-magicdns-ipv4-only"
 )
 
 // SetDNSRequest is a request to add a DNS record.


### PR DESCRIPTION
This adds a new ControlKnob to make MagicDNS IPv6 registration
(telling systemd/etc) opt-out rather than opt-in.

Updates #15404
