### PR TITLE
ipn/ipnlocal, cmd/tailscale: use wildcard. prefix for cert filenames

### DIFF
--- a/cmd/tailscale/cli/cert.go
+++ b/cmd/tailscale/cli/cert.go
@@ -108,8 +108,9 @@ func runCert(ctx context.Context, args []string) error {
 		log.SetFlags(0)
 	}
 	if certArgs.certFile == "" && certArgs.keyFile == "" {
-		certArgs.certFile = domain + ".crt"
-		certArgs.keyFile = domain + ".key"
+		fileBase := strings.Replace(domain, "*.", "wildcard_.", 1)
+		certArgs.certFile = fileBase + ".crt"
+		certArgs.keyFile = fileBase + ".key"
 	}
 	certPEM, keyPEM, err := localClient.CertPairWithValidity(ctx, domain, certArgs.minValidity)
 	if err != nil {

--- a/ipn/ipnlocal/cert_test.go
+++ b/ipn/ipnlocal/cert_test.go
@@ -139,7 +139,7 @@ func TestResolveCertDomain(t *testing.T) {
 			domain:      "*.unrelated.ts.net",
 			certDomains: []string{"node.ts.net"},
 			hasCap:      true,
-			wantErr:     `invalid domain "*.unrelated.ts.net"; parent domain must be one of ["node.ts.net"]`,
+			wantErr:     `invalid domain "*.unrelated.ts.net"; wildcard certificates are not enabled for this domain`,
 		},
 		{
 			name:        "subdomain_unrelated_rejected",


### PR DESCRIPTION
    ipn/ipnlocal, cmd/tailscale: use wildcard. prefix for cert filenames

    Stop stripping the "*." prefix from wildcard domains when used
    as storage keys. Instead, escape the "*" to "wildcard" only at
    the filesystem boundary in certFile and keyFile. This prevents
    wildcard and non-wildcard certs from colliding in storage.

    Updates #1196
    Updates #7081

    Signed-off-by: Fernando Serboncini <fserb@tailscale.com>