### PR TITLE
netmon: use State.AnyInterfaceUp in ChangeDelta

### DIFF
--- a/net/netmon/netmon.go
+++ b/net/netmon/netmon.go
@@ -201,12 +201,7 @@ func (cd *ChangeDelta) AnyInterfaceUp() bool {
 	if cd.new == nil {
 		return false
 	}
-	for _, ifi := range cd.new.Interface {
-		if ifi.IsUp() {
-			return true
-		}
-	}
-	return false
+	return cd.new.AnyInterfaceUp()
 }
 
 // isInterestingInterfaceChange reports whether any interfaces have changed in a meaningful way.


### PR DESCRIPTION
fixes tailscale/corp#37048

We're duplicating logic in AnyInterfaceUp in the ChangeDelta and we're duplicating it wrong.  The new State has the logic for this based on the HaveV6 and HaveV4 flags.   Ranging over the interfaces includes the tun which is incorrect.