### PR TITLE
cmd/cigocacher: make --stats flag best-effort

### DIFF
--- a/cmd/cigocacher/cigocacher.go
+++ b/cmd/cigocacher/cigocacher.go
@@ -103,9 +103,19 @@ func main() {
 		}
 		stats, err := fetchStats(httpClient(srvHost, *srvHostDial), *srvURL, tk)
 		if err != nil {
-			log.Fatalf("error fetching gocached stats: %v", err)
+			// Errors that are not due to misconfiguration are non-fatal so we
+			// don't fail builds if e.g. cigocached is down.
+			//
+			// Print error as JSON so it can still be piped through jq.
+			statsErr := map[string]any{
+				"error": fmt.Sprintf("fetching gocached stats: %v", err),
+			}
+			b, _ := jsonv1.Marshal(statsErr)
+			fmt.Println(string(b))
+		} else {
+			fmt.Println(stats)
 		}
-		fmt.Println(stats)
+
 		return
 	}
 


### PR DESCRIPTION
--auth is already best-effort, but we saw some CI failures due to failing to fetch stats when cigocached was overwhelmed recently. Make sure it fails more gracefully in the absence of cigocached like the rest of cigocacher already does.

Updates tailscale/corp#37059

Change-Id: I0703b30b1c5a7f8c649879a87e6bcd2278610208