### PR TITLE
util/cloudenv: add TS_DISABLE_CLOUD_DETECTION env var

### DIFF
--- a/util/cloudenv/cloudenv.go
+++ b/util/cloudenv/cloudenv.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"tailscale.com/envknob"
 	"tailscale.com/feature/buildfeatures"
 	"tailscale.com/syncs"
 	"tailscale.com/types/lazy"
@@ -52,7 +53,7 @@ const (
 // ResolverIP returns the cloud host's recursive DNS server or the
 // empty string if not available.
 func (c Cloud) ResolverIP() string {
-	if !buildfeatures.HasCloud {
+	if !buildfeatures.HasCloud || disableCloudDetection() {
 		return ""
 	}
 	switch c {
@@ -94,9 +95,11 @@ func (c Cloud) HasInternalTLD() bool {
 
 var cloudAtomic syncs.AtomicValue[Cloud]
 
+var disableCloudDetection = envknob.RegisterBool("TS_DISABLE_CLOUD_DETECTION")
+
 // Get returns the current cloud, or the empty string if unknown.
 func Get() Cloud {
-	if !buildfeatures.HasCloud {
+	if !buildfeatures.HasCloud || disableCloudDetection() {
 		return ""
 	}
 	if c, ok := cloudAtomic.LoadOk(); ok {


### PR DESCRIPTION
# Why

On our use case we have a very restrictive rules for the peer relay device, and this includes blocking access to the metadata endpoints. While is a minor problem, the attempts for the tailscale pod to reach the metadata endpoint create a bit of noise on our cilium logs which would be nice to remove with this flag.

# What

Add TS_DISABLE_CLOUD_DETECTION environment variable to disable cloud detection at runtime. The check follows the same pattern as HasCloud build flag

# References

Fixes https://github.com/tailscale/tailscale/issues/18771