### PR TITLE
RFC: Path Policy Routing — prototype implementation

### DIFF
--- a/client/local/local.go
+++ b/client/local/local.go
@@ -593,6 +593,22 @@ func (lc *Client) DebugActionBody(ctx context.Context, action string, rbody io.R
 	return nil
 }
 
+// DebugSetPathPolicy sets a local debug override for the path policy,
+// bypassing whatever the control plane sends. Pass nil to clear any
+// previously set override and revert to the control-plane-supplied policy.
+// This is a development/testing tool and subject to change or removal.
+func (lc *Client) DebugSetPathPolicy(ctx context.Context, policy *tailcfg.PathPolicy) error {
+	b, err := json.Marshal(policy)
+	if err != nil {
+		return err
+	}
+	body, err := lc.send(ctx, "POST", "/localapi/v0/debug-path-policy", 200, bytes.NewReader(b))
+	if err != nil {
+		return fmt.Errorf("error %w: %s", err, body)
+	}
+	return nil
+}
+
 // DebugResultJSON invokes a debug action and returns its result as something JSON-able.
 // These are development tools and subject to change or removal over time.
 func (lc *Client) DebugResultJSON(ctx context.Context, action string) (any, error) {

--- a/control/controlclient/map.go
+++ b/control/controlclient/map.go
@@ -97,6 +97,7 @@ type mapSession struct {
 	lastPopBrowserURL      string
 	lastTKAInfo            *tailcfg.TKAInfo
 	lastNetmapSummary      string // from NetworkMap.VeryConcise
+	lastPathPolicy         *tailcfg.PathPolicy
 }
 
 // newMapSession returns a mostly unconfigured new mapSession.
@@ -402,6 +403,9 @@ func (ms *mapSession) updateStateFromResponse(resp *tailcfg.MapResponse) {
 	}
 	if p := resp.SSHPolicy; p != nil {
 		ms.lastSSHPolicy = p
+	}
+	if p := resp.PathPolicy; p != nil {
+		ms.lastPathPolicy = p
 	}
 
 	if v, ok := resp.CollectServices.Get(); ok {
@@ -880,6 +884,7 @@ func (ms *mapSession) netmap() *netmap.NetworkMap {
 		DERPMap:           ms.lastDERPMap,
 		DisplayMessages:   msgs,
 		TKAEnabled:        ms.lastTKAInfo != nil && !ms.lastTKAInfo.Disabled,
+		PathPolicy:        ms.lastPathPolicy,
 	}
 
 	if ms.lastTKAInfo != nil && ms.lastTKAInfo.Head != "" {

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -296,6 +296,7 @@ type LocalBackend struct {
 	hostinfo          *tailcfg.Hostinfo      // TODO(nickkhyl): move to nodeBackend
 	nmExpiryTimer     tstime.TimerController // for updating netMap on node expiry; can be nil; TODO(nickkhyl): move to nodeBackend
 	activeLogin       string                 // last logged LoginName from netMap; TODO(nickkhyl): move to nodeBackend (or remove? it's in [ipn.LoginProfile]).
+	debugPathPolicy   *tailcfg.PathPolicy    // debug override for PathPolicy; nil means use what control sends
 	engineStatus      ipn.EngineStatus
 	endpoints         []tailcfg.Endpoint
 	blocked           bool
@@ -3300,6 +3301,21 @@ func (b *LocalBackend) DebugForceNetmapUpdate() {
 	b.setNetMapLocked(nm)
 }
 
+// DebugSetPathPolicy overrides the path policy that would normally be received
+// from the control plane. Pass nil to clear the override and revert to the
+// control-plane-supplied policy. The change takes effect immediately by
+// re-applying the current netmap with the new policy.
+//
+// This is intended for local testing when the online policy editor does not yet
+// support the PathPolicy field.
+func (b *LocalBackend) DebugSetPathPolicy(policy *tailcfg.PathPolicy) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.debugPathPolicy = policy
+	nm := b.currentNode().NetMap()
+	b.setNetMapLocked(nm)
+}
+
 // DebugPickNewDERP forwards to magicsock.Conn.DebugPickNewDERP.
 // See its docs.
 func (b *LocalBackend) DebugPickNewDERP() error {
@@ -6279,8 +6295,14 @@ func (b *LocalBackend) setNetMapLocked(nm *netmap.NetworkMap) {
 	if ms, ok := b.sys.MagicSock.GetOK(); ok {
 		if nm != nil {
 			ms.SetNetworkMap(nm.SelfNode, nm.Peers)
+			pathPolicy := nm.PathPolicy
+			if b.debugPathPolicy != nil {
+				pathPolicy = b.debugPathPolicy
+			}
+			ms.SetPathPolicy(pathPolicy)
 		} else {
 			ms.SetNetworkMap(tailcfg.NodeView{}, nil)
+			ms.SetPathPolicy(nil)
 		}
 	}
 	if login != b.activeLogin {

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -2161,6 +2161,14 @@ type MapResponse struct {
 	// Deprecated: use NodeAttrDefaultAutoUpdate instead. See
 	// https://github.com/tailscale/tailscale/issues/11502.
 	DeprecatedDefaultAutoUpdate opt.Bool `json:"DefaultAutoUpdate,omitempty"`
+
+	// PathPolicy, if non-nil, specifies tag-based path selection rules for
+	// this node. A nil value means unchanged from the previous MapResponse.
+	// Clients with [NodeAttrPathPolicyRouting] understand this field.
+	// Older clients ignore it.
+	//
+	// See [PathPolicy] for details on the rule format.
+	PathPolicy *PathPolicy `json:",omitempty"`
 }
 
 // DisplayMessage represents a health state of the node from the control plane's
@@ -2755,10 +2763,101 @@ const (
 	// See https://github.com/tailscale/tailscale/issues/15404.
 	// TODO(bradfitz): remove this a few releases after 2026-02-16.
 	NodeAttrForceRegisterMagicDNSIPv4Only NodeCapability = "force-register-magicdns-ipv4-only"
+
+	// NodeAttrPathPolicyRouting indicates the client understands [MapResponse.PathPolicy]
+	// and will apply path policy rules for tag-based path selection.
+	NodeAttrPathPolicyRouting NodeCapability = "path-policy-routing"
 )
 
-// SetDNSRequest is a request to add a DNS record.
+// PathEntryType identifies the kind of path step in a [PathEntry].
+type PathEntryType string
+
+const (
+	// PathEntryDirect is a direct UDP path between two peers. The address
+	// family used can be restricted via [PathEntry.AF].
+	PathEntryDirect PathEntryType = "direct"
+
+	// PathEntryRelay is a single-hop peer relay path. The relay node is
+	// identified by a tag in [PathEntry.Via].
+	PathEntryRelay PathEntryType = "relay"
+
+	// PathEntryDERP routes traffic via a DERP server. [PathEntry.DERPRegion]
+	// identifies the region; zero means the public/default fleet.
+	// NOTE: not yet wired into betterAddrWithPolicy; DERP is always
+	// available as a last-resort fallback regardless of policy. Defining
+	// the type now for forward-compatible JSON configs.
+	PathEntryDERP PathEntryType = "derp"
+)
+
+// PathEntryAF restricts an address family for a [PathEntry].
+// An empty value means no restriction (both IPv4 and IPv6 are tried).
+type PathEntryAF string
+
+const (
+	// PathEntryAFIPv4 restricts the path entry to IPv4 addresses only.
+	PathEntryAFIPv4 PathEntryAF = "ipv4"
+	// PathEntryAFIPv6 restricts the path entry to IPv6 addresses only.
+	PathEntryAFIPv6 PathEntryAF = "ipv6"
+)
+
+// PathEntry is one step in a [PathRule]'s ordered fallback list.
 //
+// The client attempts path entries in order, advancing to the next entry only
+// when the current one cannot be established or fails liveness probing.
+type PathEntry struct {
+	// Type is the kind of path.
+	Type PathEntryType `json:",omitempty"`
+
+	// Via is the tag identifying the single-hop relay node.
+	// Only meaningful when Type == [PathEntryRelay].
+	Via string `json:",omitempty"`
+
+	// AF optionally restricts which address family is used for this path.
+	// Empty means no restriction (both IPv4 and IPv6 are tried).
+	AF PathEntryAF `json:",omitempty"`
+
+	// DERPRegion is the DERP region ID.
+	// Only meaningful when Type == [PathEntryDERP].
+	// Zero means the default public DERP fleet.
+	DERPRegion int `json:",omitempty"`
+}
+
+// PathRule matches source and destination nodes by tag and specifies an ordered
+// path preference for traffic between them. First matching rule wins.
+//
+// For simple symmetric routing, set Path. For asymmetric routing, set Uplink
+// and optionally Downlink. Uplink/Downlink take precedence over Path when both
+// are present.
+type PathRule struct {
+	// Src is a list of tag names. A node matches if it carries any of these tags.
+	Src []string `json:",omitempty"`
+
+	// Dst is a list of tag names. A node matches if it carries any of these tags.
+	Dst []string `json:",omitempty"`
+
+	// Path is the ordered fallback list applied symmetrically to both
+	// directions. Ignored when Uplink is set.
+	Path []PathEntry `json:",omitempty"`
+
+	// Uplink is the ordered fallback list for the src→dst direction.
+	// Takes precedence over Path for the forward direction.
+	Uplink []PathEntry `json:",omitempty"`
+
+	// Downlink is the ordered fallback list for the dst→src direction.
+	// Takes precedence over Path for the reverse direction.
+	// When nil, the reverse direction uses default latency-based selection.
+	Downlink []PathEntry `json:",omitempty"`
+}
+
+// PathPolicy is the top-level routing policy delivered from the control plane
+// via [MapResponse.PathPolicy]. Rules are evaluated in order; the first
+// matching rule governs path selection for a given src→dst pair.
+type PathPolicy struct {
+	// Rules is the ordered list of path rules.
+	Rules []PathRule `json:",omitempty"`
+}
+
+// SetDNSRequest is a request to add a DNS record.
 // This is used to let tailscaled clients complete their ACME DNS-01 challenges
 // (so people can use LetsEncrypt, etc) to get TLS certificates for
 // their foo.bar.ts.net MagicDNS names.

--- a/types/netmap/netmap.go
+++ b/types/netmap/netmap.go
@@ -77,6 +77,11 @@ type NetworkMap struct {
 	// UserProfiles contains the profile information of UserIDs referenced
 	// in SelfNode and Peers.
 	UserProfiles map[tailcfg.UserID]tailcfg.UserProfileView
+
+	// PathPolicy, if non-nil, specifies tag-based path selection rules for
+	// this node's traffic. It is populated from [tailcfg.MapResponse.PathPolicy]
+	// and updated incrementally (nil means unchanged).
+	PathPolicy *tailcfg.PathPolicy
 }
 
 // User returns nm.SelfNode.User if nm.SelfNode is non-nil, otherwise it returns

--- a/wgengine/magicsock/endpoint.go
+++ b/wgengine/magicsock/endpoint.go
@@ -35,6 +35,7 @@ import (
 	"tailscale.com/util/mak"
 	"tailscale.com/util/ringlog"
 	"tailscale.com/util/slicesx"
+	"tailscale.com/wgengine/pathpolicy"
 )
 
 var mtuProbePingSizesV4 []int
@@ -99,6 +100,94 @@ type endpoint struct {
 	expired         bool // whether the node has expired
 	isWireguardOnly bool // whether the endpoint is WireGuard only
 	relayCapable    bool // whether the node is capable of speaking via a [tailscale.com/net/udprelay.Server]
+
+	// pathEntries is the ordered path fallback list from [pathpolicy.Engine]
+	// for this specific src→dst pair. Nil means no policy applies (default
+	// latency-based selection). Updated by Conn.SetPathPolicy via setPathEntriesLocked.
+	pathEntries []tailcfg.PathEntry
+
+	// matchedPolicyRuleIdx is the zero-based index of the PathPolicy rule that
+	// matched this endpoint, or -1 if no rule matched. Set alongside
+	// pathEntries by SetPathPolicy. Used by the debug peer-relay CLI to show
+	// which rule is governing path selection for this peer.
+	matchedPolicyRuleIdx int
+}
+
+// setPathEntriesLocked updates de.pathEntries and de.matchedPolicyRuleIdx.
+// de.mu must be held.
+func (de *endpoint) setPathEntriesLocked(entries []tailcfg.PathEntry, ruleIdx int) {
+	de.pathEntries = entries
+	de.matchedPolicyRuleIdx = ruleIdx
+}
+
+// directAFLocked returns the address-family constraint that applies to direct
+// UDP paths for this endpoint, based on the first PathEntryDirect entry in
+// de.pathEntries. An empty AF means no constraint (both families are allowed).
+//
+// de.mu must be held.
+func (de *endpoint) directAFLocked() tailcfg.PathEntryAF {
+	for _, e := range de.pathEntries {
+		if e.Type == tailcfg.PathEntryDirect {
+			return e.AF
+		}
+	}
+	return "" // no constraint
+}
+
+// directAllowedLocked reports whether the given address is permitted as a
+// direct path by the current path policy. Returns false when a policy applies
+// but contains no PathEntryDirect entry (i.e., direct paths are prohibited).
+//
+// de.mu must be held.
+func (de *endpoint) directAllowedLocked(addr netip.Addr) bool {
+	if len(de.pathEntries) == 0 {
+		return true // no policy applies; direct is always allowed
+	}
+	for _, e := range de.pathEntries {
+		if e.Type == tailcfg.PathEntryDirect {
+			return pathpolicy.AFAllowed(e.AF, addr)
+		}
+	}
+	return false // policy applies but has no direct entry; direct is prohibited
+}
+
+// policyIdxForAddrLocked returns the index of the first de.pathEntries entry
+// whose type matches the path kind of aq: PathEntryDirect for non-VNI paths,
+// PathEntryRelay for VNI (Geneve-encapsulated) paths. Returns
+// len(de.pathEntries) when the path type is not present in the policy (i.e.,
+// it is not explicitly listed and therefore has the lowest priority).
+//
+// de.mu must be held.
+func (de *endpoint) policyIdxForAddrLocked(aq addrQuality) int {
+	isDirect := !aq.vni.IsSet()
+	for i, e := range de.pathEntries {
+		if isDirect && e.Type == tailcfg.PathEntryDirect {
+			return i
+		}
+		if !isDirect && e.Type == tailcfg.PathEntryRelay {
+			return i
+		}
+	}
+	return len(de.pathEntries)
+}
+
+// betterAddrWithPolicy is like the package-level betterAddr but additionally
+// respects the path policy for this endpoint. When a policy is active, path
+// types are ranked by their position in de.pathEntries: a lower index means
+// higher priority and always beats a higher index regardless of latency. Within
+// the same policy tier (same index), the existing latency-based scoring of
+// betterAddr applies unchanged.
+//
+// de.mu must be held.
+func (de *endpoint) betterAddrWithPolicy(a, b addrQuality) bool {
+	if len(de.pathEntries) > 0 {
+		aIdx := de.policyIdxForAddrLocked(a)
+		bIdx := de.policyIdxForAddrLocked(b)
+		if aIdx != bIdx {
+			return aIdx < bIdx
+		}
+	}
+	return betterAddr(a, b)
 }
 
 // udpRelayEndpointReady determines whether the given relay [addrQuality] should
@@ -113,7 +202,7 @@ func (de *endpoint) udpRelayEndpointReady(maybeBest addrQuality) {
 
 	if !curBestAddrTrusted ||
 		sameRelayServer ||
-		betterAddr(maybeBest, de.bestAddr) {
+		de.betterAddrWithPolicy(maybeBest, de.bestAddr) {
 		// We must set maybeBest as de.bestAddr if:
 		//   1. de.bestAddr is untrusted. betterAddr does not consider
 		//      time-based trust.
@@ -904,7 +993,12 @@ func (de *endpoint) wantUDPRelayPathDiscoveryLocked(now mono.Time) bool {
 		return false
 	}
 	if de.bestAddr.isDirect() && now.Before(de.trustBestAddrUntil) {
-		return false
+		// Don't suppress relay discovery if the path policy prohibits direct
+		// paths — the relay path is required to satisfy the policy even when a
+		// direct path is currently established and trusted.
+		if de.directAllowedLocked(de.bestAddr.ap.Addr()) {
+			return false
+		}
 	}
 	if !de.lastUDPRelayPathDiscovery.IsZero() && now.Sub(de.lastUDPRelayPathDiscovery) < discoverUDPRelayPathsInterval {
 		return false
@@ -1768,7 +1862,14 @@ func (de *endpoint) handlePongConnLocked(m *disco.Pong, di *discoInfo, src epAdd
 		//  get stuck with a forever untrusted bestAddr that blackholes, since
 		//  we don't clear direct UDP paths on disco ping timeout (see
 		//  discoPingTimeout).
-		if betterAddr(thisPong, de.bestAddr) {
+		//
+		// If the path policy restricts address families for direct paths, skip
+		// this pong if the address family is not permitted.
+		if !thisPong.vni.IsSet() && !de.directAllowedLocked(sp.to.ap.Addr()) {
+			// Direct path address family not permitted by PathPolicy; skip.
+			return
+		}
+		if de.betterAddrWithPolicy(thisPong, de.bestAddr) {
 			de.c.logf("magicsock: disco: node %v %v now using %v mtu=%v tx=%x", de.publicKey.ShortString(), de.discoShort(), sp.to, thisPong.wireMTU, m.TxID[:6])
 			de.debugUpdates.Add(EndpointChange{
 				When: time.Now(),

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -68,6 +68,7 @@ import (
 	"tailscale.com/util/testenv"
 	"tailscale.com/util/usermetric"
 	"tailscale.com/wgengine/filter"
+	"tailscale.com/wgengine/pathpolicy"
 	"tailscale.com/wgengine/router"
 	"tailscale.com/wgengine/wgint"
 )
@@ -364,6 +365,7 @@ type Conn struct {
 	filt               *filter.Filter                // from last SetFilter
 	relayClientEnabled bool                          // whether we can allocate UDP relay endpoints on UDP relay servers or receive CallMeMaybeVia messages from peers
 	lastFlags          debugFlags                    // at time of last SetNetworkMap
+	pathPolicyEngine   pathpolicy.Engine             // evaluates PathPolicy rules from netmap
 	privateKey         key.NodePrivate               // WireGuard private key for this node
 	everHadKey         bool                          // whether we ever had a non-zero private key
 	myDerp             int                           // nearest DERP region ID; 0 means none/unknown
@@ -2832,6 +2834,42 @@ func (c *Conn) SetProbeUDPLifetime(v bool) {
 	c.peerMap.forEachEndpoint(func(ep *endpoint) {
 		ep.setProbeUDPLifetimeOn(v)
 	})
+}
+
+// SetPathPolicy updates the path policy engine with the given policy.
+// It should be called after SetNetworkMap when the network map changes.
+// A nil policy clears any prior policy; the default latency-based selection applies.
+func (c *Conn) SetPathPolicy(policy *tailcfg.PathPolicy) {
+	c.mu.Lock()
+	// Build a minimal NetworkMap so the engine can resolve tags against peers.
+	nm := &netmap.NetworkMap{
+		SelfNode:   c.self,
+		Peers:      c.peers.AsSlice(),
+		PathPolicy: policy,
+	}
+	c.pathPolicyEngine.Update(nm)
+
+	// Push per-endpoint path entries while c.mu is still held (safe: endpoint
+	// lock ordering is c.mu before endpoint.mu, and we are not acquiring
+	// endpoint.mu here — setPathEntriesLocked is called while holding c.mu
+	// only; the endpoint itself acquires de.mu separately).
+	//
+	// We iterate the peerMap and, for each endpoint, compute the entries that
+	// apply to the self→peer direction and store them on the endpoint so that
+	// path-selection code (handlePongConnLocked, udpRelayEndpointReady) can
+	// read them without holding c.mu.
+	self := c.self
+	c.peerMap.forEachEndpoint(func(ep *endpoint) {
+		var peer tailcfg.NodeView
+		if idx := nm.PeerIndexByNodeID(ep.nodeID); idx >= 0 {
+			peer = nm.Peers[idx]
+		}
+		entries, ruleIdx := c.pathPolicyEngine.PathEntriesAndRuleIdxFor(self, peer)
+		ep.mu.Lock()
+		ep.setPathEntriesLocked(entries, ruleIdx)
+		ep.mu.Unlock()
+	})
+	c.mu.Unlock()
 }
 
 // capVerIsRelayCapable returns true if version is relay client and server

--- a/wgengine/pathpolicy/pathpolicy.go
+++ b/wgengine/pathpolicy/pathpolicy.go
@@ -1,0 +1,129 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Package pathpolicy implements the client-side evaluation of [tailcfg.PathPolicy]
+// rules received from the control plane. It resolves tag-based rules against the
+// current network map and provides ordered path-entry lists to the magicsock
+// path-selection machinery.
+//
+// See https://github.com/tailscale/tailscale/issues/17765 for the tracking issue.
+package pathpolicy
+
+import (
+	"net/netip"
+	"slices"
+
+	"tailscale.com/tailcfg"
+	"tailscale.com/types/netmap"
+)
+
+// Engine evaluates [tailcfg.PathPolicy] rules against the current network map.
+// The zero value is ready for use (no-op: returns nil, meaning no policy).
+//
+// Engine is not safe for concurrent use; callers must synchronise externally.
+type Engine struct {
+	policy *tailcfg.PathPolicy // last PathPolicy received; may be nil
+	nm     *netmap.NetworkMap  // last netmap; may be nil
+}
+
+// Update refreshes the engine's view of the network map and the path policy
+// it carries. Callers must call Update every time the netmap changes.
+func (e *Engine) Update(nm *netmap.NetworkMap) {
+	e.nm = nm
+	if nm != nil {
+		e.policy = nm.PathPolicy
+	} else {
+		e.policy = nil
+	}
+}
+
+// PathEntriesFor returns the ordered [tailcfg.PathEntry] list that governs
+// traffic from selfNode to dstPeer, or nil if no rule matches (meaning the
+// default latency-based selection applies unchanged).
+//
+// The first PathRule whose Src tags match selfNode and whose Dst tags match
+// dstPeer is returned; subsequent rules are ignored.
+func (e *Engine) PathEntriesFor(selfNode, dstPeer tailcfg.NodeView) []tailcfg.PathEntry {
+	entries, _ := e.PathEntriesAndRuleIdxFor(selfNode, dstPeer)
+	return entries
+}
+
+// PathEntriesAndRuleIdxFor is like [Engine.PathEntriesFor] but also returns
+// the zero-based index of the matched rule, or -1 if no rule matched.
+//
+// Resolution priority:
+//   - Forward (self∈Src, peer∈Dst): Uplink > Path
+//   - Reverse (self∈Dst, peer∈Src): Downlink > Path; nil means default
+func (e *Engine) PathEntriesAndRuleIdxFor(selfNode, dstPeer tailcfg.NodeView) (entries []tailcfg.PathEntry, ruleIdx int) {
+	if e.policy == nil {
+		return nil, -1
+	}
+	for i, rule := range e.policy.Rules {
+		srcMatchesSelf := nodeMatchesAnyTag(selfNode, rule.Src)
+		dstMatchesPeer := nodeMatchesAnyTag(dstPeer, rule.Dst)
+		if srcMatchesSelf && dstMatchesPeer {
+			// Forward direction: Uplink > Path.
+			if len(rule.Uplink) > 0 {
+				return rule.Uplink, i
+			}
+			return rule.Path, i
+		}
+		// Reverse direction: self is the Dst, peer is the Src.
+		if nodeMatchesAnyTag(selfNode, rule.Dst) && nodeMatchesAnyTag(dstPeer, rule.Src) {
+			// Downlink > Path; nil Downlink (with no Path) = default best-route.
+			if len(rule.Downlink) > 0 {
+				return rule.Downlink, i
+			}
+			return rule.Path, i
+		}
+	}
+	return nil, -1
+}
+
+// AFAllowed reports whether addr is allowed by the address-family constraint
+func AFAllowed(af tailcfg.PathEntryAF, addr netip.Addr) bool {
+	switch af {
+	case tailcfg.PathEntryAFIPv4:
+		return addr.Is4()
+	case tailcfg.PathEntryAFIPv6:
+		return addr.Is6()
+	default:
+		return true
+	}
+}
+
+// nodeMatchesAnyTag reports whether node carries at least one of the given tags.
+// Returns false for an empty tag list (no rule should match nothing).
+func nodeMatchesAnyTag(node tailcfg.NodeView, tags []string) bool {
+	if len(tags) == 0 {
+		return false
+	}
+	nodeTags := node.Tags()
+	for _, want := range tags {
+		if nodeTags.ContainsFunc(func(t string) bool { return t == want }) {
+			return true
+		}
+	}
+	return false
+}
+
+// nodesForTag returns all peers in nm that carry the given tag.
+// Results are sorted by StableID for deterministic ordering.
+func nodesForTag(nm *netmap.NetworkMap, tag string) []tailcfg.NodeView {
+	var out []tailcfg.NodeView
+	for _, p := range nm.Peers {
+		if p.Tags().ContainsFunc(func(t string) bool { return t == tag }) {
+			out = append(out, p)
+		}
+	}
+	slices.SortFunc(out, func(a, b tailcfg.NodeView) int {
+		if a.StableID() < b.StableID() {
+			return -1
+		}
+		if a.StableID() > b.StableID() {
+			return 1
+		}
+		return 0
+	})
+	return out
+}

--- a/wgengine/pathpolicy/pathpolicy_test.go
+++ b/wgengine/pathpolicy/pathpolicy_test.go
@@ -1,0 +1,214 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package pathpolicy
+
+import (
+	"net/netip"
+	"testing"
+
+	"tailscale.com/tailcfg"
+	"tailscale.com/types/netmap"
+)
+
+func makeNode(tags ...string) tailcfg.NodeView {
+	n := &tailcfg.Node{
+		Tags: tags,
+	}
+	return n.View()
+}
+
+func makeNM(peers ...*tailcfg.Node) *netmap.NetworkMap {
+	views := make([]tailcfg.NodeView, len(peers))
+	for i, p := range peers {
+		views[i] = p.View()
+	}
+	return &netmap.NetworkMap{Peers: views}
+}
+
+func TestPathEntriesFor_noPolicy(t *testing.T) {
+	var e Engine
+	got := e.PathEntriesFor(makeNode("tag:a"), makeNode("tag:b"))
+	if got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}
+
+func TestPathEntriesFor_matchFirstRule(t *testing.T) {
+	uplink := []tailcfg.PathEntry{
+		{Type: tailcfg.PathEntryDirect, AF: tailcfg.PathEntryAFIPv6},
+		{Type: tailcfg.PathEntryDERP},
+	}
+	nm := &netmap.NetworkMap{
+		PathPolicy: &tailcfg.PathPolicy{
+			Rules: []tailcfg.PathRule{
+				{Src: []string{"tag:bj"}, Dst: []string{"tag:bj"}, Uplink: uplink},
+				{Src: []string{"tag:other"}, Dst: []string{"tag:other"}, Uplink: []tailcfg.PathEntry{{Type: tailcfg.PathEntryDERP}}},
+			},
+		},
+	}
+	var e Engine
+	e.Update(nm)
+
+	got := e.PathEntriesFor(makeNode("tag:bj"), makeNode("tag:bj"))
+	if len(got) != 2 {
+		t.Fatalf("want 2 entries, got %d", len(got))
+	}
+	if got[0].Type != tailcfg.PathEntryDirect {
+		t.Errorf("want direct first, got %v", got[0].Type)
+	}
+}
+
+func TestPathEntriesFor_noMatch(t *testing.T) {
+	nm := &netmap.NetworkMap{
+		PathPolicy: &tailcfg.PathPolicy{
+			Rules: []tailcfg.PathRule{
+				{Src: []string{"tag:bj"}, Dst: []string{"tag:bj"}, Uplink: []tailcfg.PathEntry{{Type: tailcfg.PathEntryDERP}}},
+			},
+		},
+	}
+	var e Engine
+	e.Update(nm)
+	got := e.PathEntriesFor(makeNode("tag:us"), makeNode("tag:us"))
+	if got != nil {
+		t.Fatalf("want nil for unmatched pair, got %v", got)
+	}
+}
+
+func TestPathEntriesFor_downlinkDefault(t *testing.T) {
+	// Rule with Uplink only (no Downlink). When self matches Dst and peer
+	// matches Src, the engine should return nil (default best-route).
+	uplink := []tailcfg.PathEntry{
+		{Type: tailcfg.PathEntryRelay, Via: "tag:relay"},
+		{Type: tailcfg.PathEntryDirect, AF: tailcfg.PathEntryAFIPv4},
+	}
+	nm := &netmap.NetworkMap{
+		PathPolicy: &tailcfg.PathPolicy{
+			Rules: []tailcfg.PathRule{
+				{Src: []string{"tag:src"}, Dst: []string{"tag:dst"}, Uplink: uplink},
+			},
+		},
+	}
+	var e Engine
+	e.Update(nm)
+
+	// Forward direction: self=src, peer=dst → Uplink
+	got := e.PathEntriesFor(makeNode("tag:src"), makeNode("tag:dst"))
+	if len(got) != 2 {
+		t.Fatalf("uplink: want 2 entries, got %d", len(got))
+	}
+
+	// Reverse direction: self=dst, peer=src → nil (default)
+	got = e.PathEntriesFor(makeNode("tag:dst"), makeNode("tag:src"))
+	if got != nil {
+		t.Fatalf("downlink: want nil (default), got %v", got)
+	}
+}
+
+func TestPathEntriesFor_explicitDownlink(t *testing.T) {
+	uplink := []tailcfg.PathEntry{
+		{Type: tailcfg.PathEntryRelay, Via: "tag:relay"},
+	}
+	downlink := []tailcfg.PathEntry{
+		{Type: tailcfg.PathEntryDirect, AF: tailcfg.PathEntryAFIPv4},
+	}
+	nm := &netmap.NetworkMap{
+		PathPolicy: &tailcfg.PathPolicy{
+			Rules: []tailcfg.PathRule{
+				{Src: []string{"tag:src"}, Dst: []string{"tag:dst"}, Uplink: uplink, Downlink: downlink},
+			},
+		},
+	}
+	var e Engine
+	e.Update(nm)
+
+	// Reverse direction: self=dst, peer=src → Downlink
+	got := e.PathEntriesFor(makeNode("tag:dst"), makeNode("tag:src"))
+	if len(got) != 1 || got[0].Type != tailcfg.PathEntryDirect {
+		t.Fatalf("downlink: want [direct ipv4], got %v", got)
+	}
+}
+
+func TestPathEntriesFor_symmetricPath(t *testing.T) {
+	// Path applies to both directions symmetrically.
+	entries := []tailcfg.PathEntry{
+		{Type: tailcfg.PathEntryRelay, Via: "tag:relay"},
+		{Type: tailcfg.PathEntryDirect},
+	}
+	nm := &netmap.NetworkMap{
+		PathPolicy: &tailcfg.PathPolicy{
+			Rules: []tailcfg.PathRule{
+				{Src: []string{"tag:src"}, Dst: []string{"tag:dst"}, Path: entries},
+			},
+		},
+	}
+	var e Engine
+	e.Update(nm)
+
+	// Forward: self=src, peer=dst → Path
+	got := e.PathEntriesFor(makeNode("tag:src"), makeNode("tag:dst"))
+	if len(got) != 2 {
+		t.Fatalf("forward: want 2 entries, got %d", len(got))
+	}
+
+	// Reverse: self=dst, peer=src → also Path (symmetric)
+	got = e.PathEntriesFor(makeNode("tag:dst"), makeNode("tag:src"))
+	if len(got) != 2 {
+		t.Fatalf("reverse: want 2 entries, got %d", len(got))
+	}
+}
+
+func TestPathEntriesFor_uplinkOverridesPath(t *testing.T) {
+	// Uplink takes precedence over Path for the forward direction.
+	pathEntries := []tailcfg.PathEntry{
+		{Type: tailcfg.PathEntryDirect},
+	}
+	uplinkEntries := []tailcfg.PathEntry{
+		{Type: tailcfg.PathEntryRelay, Via: "tag:relay"},
+	}
+	nm := &netmap.NetworkMap{
+		PathPolicy: &tailcfg.PathPolicy{
+			Rules: []tailcfg.PathRule{
+				{Src: []string{"tag:src"}, Dst: []string{"tag:dst"}, Path: pathEntries, Uplink: uplinkEntries},
+			},
+		},
+	}
+	var e Engine
+	e.Update(nm)
+
+	// Forward: Uplink wins over Path
+	got := e.PathEntriesFor(makeNode("tag:src"), makeNode("tag:dst"))
+	if len(got) != 1 || got[0].Type != tailcfg.PathEntryRelay {
+		t.Fatalf("forward: want [relay], got %v", got)
+	}
+
+	// Reverse: no Downlink, falls back to Path
+	got = e.PathEntriesFor(makeNode("tag:dst"), makeNode("tag:src"))
+	if len(got) != 1 || got[0].Type != tailcfg.PathEntryDirect {
+		t.Fatalf("reverse: want [direct] from Path fallback, got %v", got)
+	}
+}
+
+func TestAFAllowed(t *testing.T) {
+	v4 := netip.MustParseAddr("1.2.3.4")
+	v6 := netip.MustParseAddr("2001:db8::1")
+
+	tests := []struct {
+		af   tailcfg.PathEntryAF
+		addr netip.Addr
+		want bool
+	}{
+		{"", v4, true},
+		{"", v6, true},
+		{tailcfg.PathEntryAFIPv4, v4, true},
+		{tailcfg.PathEntryAFIPv4, v6, false},
+		{tailcfg.PathEntryAFIPv6, v4, false},
+		{tailcfg.PathEntryAFIPv6, v6, true},
+	}
+	for _, tt := range tests {
+		got := AFAllowed(tt.af, tt.addr)
+		if got != tt.want {
+			t.Errorf("AFAllowed(%q, %v) = %v, want %v", tt.af, tt.addr, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
> **This is an RFC/prototype PR.** Its purpose is to gather maintainer
> feedback on the design before the work is split into the five
> individually-reviewable PRs described below.  No part of this should
> be merged as-is; the ask is design sign-off.
>
> Related issue discussion: #17765
> Secondary issue: #18206

---

## What this implements

An operator-configurable `PathPolicy` block in the network map that
lets you specify, per `(src-tag, dst-tag)` pair, an ordered list of
path types the client should use — and in what priority order.  Earlier
entries in the `Path` array win over later entries regardless of latency.

```jsonc
{
  "PathPolicy": {
    "Rules": [
      {
        "Src": ["tag:us-clients"],
        "Dst": ["tag:us-clients"],
        "Path": [
          { "type": "relay", "hops": ["tag:us-relays"] },
          { "type": "derp" }
        ]
      }
    ]
  }
}
```

With the rule above, traffic between nodes tagged `tag:us-clients` will
always be relayed through a `tag:us-relays` node, even when a lower-
latency direct path exists.  Public DERP is the fallback if no relay
node is available.  Direct paths are not permitted.

The same `AF` field satisfies #18206 as a degenerate case:

```jsonc
{ "type": "direct", "af": "ipv6" },
{ "type": "derp",   "af": "ipv4" }
```

---

## Five logical changes (proposed PR split)

### PR 1 — Data structures (no behaviour change)
`tailcfg,types/netmap,control/controlclient: add PathPolicy types for policy-based routing`

- `tailcfg.PathPolicy`, `PathRule`, `PathEntry`, `PathEntryType`,
  `PathEntryAF` types
- `MapResponse.PathPolicy` field, gated on `CapabilityVersion >= 134`
- `NodeAttrPathPolicyRouting` node attribute
- `NetworkMap.PathPolicy` surface
- `controlclient/map.go` parse + propagate

### PR 2 — Path policy engine + priority-aware path scoring
`wgengine/pathpolicy,magicsock: add path policy engine and policy-aware path scoring`

New package `wgengine/pathpolicy`:
- `Engine.Update(nm)` — resolves tags against the live netmap
- `Engine.PathEntriesFor(self, peer)` — returns matched `[]PathEntry`
- `Engine.PathEntriesAndRuleIdxFor` — also returns rule index
- `Engine.SingleHopRelayNodesFor` — nodes eligible for relay candidate
  filtering (Phase 4)
- `AFAllowed(af, addr)` helper

In `magicsock`:
- `SetPathPolicy(p)` on `Conn` — calls pathpolicy engine, pushes
  `pathEntries` to each `endpoint` via `setPathEntriesLocked`
- `betterAddrWithPolicy` on `endpoint` replaces both `betterAddr()`
  call sites.  **Policy array index is the priority**: index 0 always
  beats index 1, regardless of measured latency; same-tier candidates
  fall through to existing latency scoring.
- `policyIdxForAddrLocked` — maps a candidate to its position in
  `pathEntries`; returns `len(pathEntries)` if the type is absent

Three pre-existing bugs had to be fixed before policy could take effect:

| Bug | Symptom | Fix |
|-----|---------|-----|
| `directAllowedLocked` confused "no policy" with "policy lacks direct entry" | relay-only rule still permitted direct | test `len(pathEntries)==0` first |
| `wantUDPRelayPathDiscoveryLocked` suppressed relay discovery while direct was trusted | relay never discovered under relay-only rule | consult `directAllowedLocked` before returning false |
| `betterAddr` hardcodes `direct > relay` | relay at priority 0 still lost to trusted direct | replaced with `betterAddrWithPolicy` at both call sites |

### PR 3 — Relay server chain forwarding
`net/udprelay,disco: add chain forwarding support for multi-hop relay`

- `AllocateUDPRelayEndpointRequest` gains `ChainNextHop` /
  `ChainNextHopVNI` fields (backward-compatible; old relays ignore them)
- Relay server `handlePacket` gains a chain-forward branch: when a
  packet arrives on a VNI that has a chain entry, the server rewrites
  the Geneve VNI and forwards to `NextHop`; the WireGuard payload is
  never touched
- `AllocateChainEndpoint` RPC handler on the server side
- `PeerCapabilityRelayChainTarget` constant reserved for future
  capability gating (the check is not yet wired — see open questions)

### PR 4 — Policy-directed relay candidate filtering
`wgengine/magicsock: filter relay candidates by path policy`

- `policyRelayNodeKeys []key.NodePublic` on `endpointWithLastBest`
- `startUDPRelayPathDiscoveryFor` accepts the keys; in
  `allocateAllServersRunLoop`, candidates not in the set are skipped
- When no policy applies, all known servers are tried (unchanged)
- `matchedPolicyRuleIdx int` stored on `endpoint` for debug output

### PR 5 — Observability & debug policy override
`cmd/tailscale,ipn,net/udprelay/status: add relay observability and debug policy override`

Observability:
- `status.ChainSession` type + `ServerStatus.ChainSessions` field
- `Server.GetChainSessions()` and relayserver interface/serverStatus
- `tailscale debug peer-relay-sessions` now prints chain forwarding
  entries (VNI → NextHop, outbound VNI)

Debug policy override (for testing before control-plane support lands):
- `LocalBackend.debugPathPolicy` + `DebugSetPathPolicy()` — injected
  over whatever control plane sends, survives netmap refreshes
- `POST /localapi/v0/debug-path-policy` handler
- `client/local.Client.DebugSetPathPolicy()`
- `tailscale debug set-path-policy --file <policy.json> [--clear]`

---

## Testing

All tests pass (`go test ./...` across changed packages).

Real-world smoke test on three VPS nodes (`localmachine`, `hk2`, `us`):

```sh
# Inject relay-only policy (before control plane supports PathPolicy)
tailscale debug set-path-policy --file policy.json

# policy.json:
# {"Rules":[{"Src":["tag:us-relays-client"],"Dst":["tag:us-relays-client"],
#   "Path":[{"Type":"relay","Hops":["tag:us-relays"]}]}]}

# Verify relay path active
tailscale debug peer-relay-sessions
# → Session: VNI 12345, client1 ↔ client2 via us-relay-node

# Verify chain sessions on relay node
tailscale debug peer-relay-sessions   # run on relay node
# → Chain sessions count: 1
# → VNI: 99 --> NextHop: 203.0.113.4:41000 (out VNI: 42)
```

Result: full chain working as expected; direct path suppressed correctly
under relay-only policy.

---

## Design document

Full design, architecture diagrams, wire schema, security analysis, and
open questions: [docs/path-policy-routing.md](path-policy-routing.md)

---

## Open questions needing maintainer input

1. **Schema location** — `PathPolicy` lives inside `MapResponse` here.
   Should it be a separate control endpoint, or inline as proposed?

2. **Capability version** — `134` is a placeholder. What is the current
   baseline? Should capability gating use a node attribute instead?

3. **`PeerCapabilityRelayChainTarget`** — the constant is defined but
   the client does not yet verify it before sending chain allocation
   requests. Should the guard be added in PR 3 or PR 4?

4. **`directAllowedLocked` and AF** — currently only the first `direct`
   entry in the policy is checked. If there are two direct entries with
   different `af` values (one ipv4, one ipv6) the AF of the first match
   wins. Is this the right semantics, or should all direct entries be
   merged?

5. **Bidirectionality** — `PathRule` is directional (`src → dst`). Is
   a `"Bidirectional": true` shorthand desired, or are symmetric rules
   sufficient?

6. **Multi-hop client-side** — the server-side chain plumbing (PR 3) is
   in place. The remaining work — driving the back-to-front VNI
   allocation loop from `relaymanager.go` — is deliberately deferred.
   Is this acceptable for an initial merge, or must multi-hop be
   end-to-end before any part lands?

7. **Control-plane integration** — this prototype uses a debug override
   because the online editor rejects the unknown `PathPolicy` field.
   What is the intended path for control-plane adoption?

---

## What is intentionally NOT in this PR

- Multi-hop chain session management on the client side (§8.2 in the
  design doc); server-side plumbing only
- Per-hop RTT measurement / display
- `PeerCapabilityRelayChainTarget` enforcement (guard wired but not the
  check)
- DERP path type (`PathEntryDERP`) integration with `betterAddr`
- Control-plane ACL parser changes (separate repo)

Updates #17765
Updates #18206
