### PR TITLE
flake: fix default devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -132,7 +132,7 @@
     });
 
     devShells = eachSystem (pkgs: {
-      devShell = pkgs.mkShell {
+      default = pkgs.mkShell {
         packages = with pkgs; [
           curl
           git


### PR DESCRIPTION
The devshell had the wrong name expected by the flake compat package causing weird behaviour if you loaded it initiating the wrong go compiler.

Updates #16637