### PR TITLE
ipn,linuxfw: apply ordered CGNAT firewall rules from node app capability

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -5586,6 +5586,99 @@ func peerRoutes(logf logger.Logf, peers []wgcfg.Peer, cgnatThreshold int, routeA
 	return routes
 }
 
+// Hopefully change this to something like "cgnat-rules" or "tailscale.com/cap/cgnat-rules".
+// The current control plane ACL validation does not allow end users to add node app capability
+// that does not start with a domain name or start with tailscale.com.
+const cgnatRulesCapability tailcfg.NodeCapability = "ysun.co/tscgnat"
+
+type cgnatRuleJSON struct {
+	CIDR    string `json:"cidr"`
+	Verdict string `json:"verdict"`
+	Chain   string `json:"chain,omitempty"`
+}
+
+func parseCGNATRule(logf logger.Logf, raw cgnatRuleJSON) (router.CGNATRule, bool) {
+	pfx, err := netip.ParsePrefix(raw.CIDR)
+	if err != nil {
+		logf("[unexpected] ignoring invalid %q prefix %q: %v", cgnatRulesCapability, raw.CIDR, err)
+		return router.CGNATRule{}, false
+	}
+	pfx = pfx.Masked()
+	if !pfx.Addr().Is4() {
+		logf("[unexpected] ignoring non-IPv4 %q prefix %q", cgnatRulesCapability, pfx)
+		return router.CGNATRule{}, false
+	}
+	cgnat := tsaddr.CGNATRange()
+	if !cgnat.Contains(pfx.Addr()) || !cgnat.Contains(netipx.PrefixLastIP(pfx)) {
+		logf("[unexpected] ignoring out-of-range %q prefix %q", cgnatRulesCapability, pfx)
+		return router.CGNATRule{}, false
+	}
+
+	verdict := strings.ToLower(strings.TrimSpace(raw.Verdict))
+	var parsedVerdict router.CGNATRuleVerdict
+	switch verdict {
+	case string(router.CGNATRuleVerdictDrop):
+		parsedVerdict = router.CGNATRuleVerdictDrop
+	case string(router.CGNATRuleVerdictAccept):
+		parsedVerdict = router.CGNATRuleVerdictAccept
+	default:
+		logf("[unexpected] ignoring %q rule with unsupported verdict %q", cgnatRulesCapability, raw.Verdict)
+		return router.CGNATRule{}, false
+	}
+
+	chain := strings.ToLower(strings.TrimSpace(raw.Chain))
+	var parsedChain router.CGNATRuleChain
+	switch chain {
+	case "", string(router.CGNATRuleChainBoth):
+		parsedChain = router.CGNATRuleChainBoth
+	case string(router.CGNATRuleChainInput):
+		parsedChain = router.CGNATRuleChainInput
+	case string(router.CGNATRuleChainForward):
+		parsedChain = router.CGNATRuleChainForward
+	default:
+		logf("[unexpected] ignoring %q rule with unsupported chain %q", cgnatRulesCapability, raw.Chain)
+		return router.CGNATRule{}, false
+	}
+
+	return router.CGNATRule{Prefix: pfx, Verdict: parsedVerdict, Chain: parsedChain}, true
+}
+
+func cgnatRulesFromCapability(logf logger.Logf, selfNode tailcfg.NodeView) []router.CGNATRule {
+	if !selfNode.Valid() {
+		return nil
+	}
+
+	rawRules, err := tailcfg.UnmarshalNodeCapViewJSON[cgnatRuleJSON](selfNode.CapMap(), cgnatRulesCapability)
+	if err != nil {
+		logf("[unexpected] failed to unmarshal %q capability: %v; falling back to default CGNAT drop", cgnatRulesCapability, err)
+		return nil
+	}
+	if len(rawRules) == 0 {
+		return nil
+	}
+
+	rules := make([]router.CGNATRule, 0, len(rawRules))
+	for _, raw := range rawRules {
+		rule, ok := parseCGNATRule(logf, raw)
+		if !ok {
+			logf("[unexpected] rejecting all %q rules due to invalid entry; falling back to default CGNAT drop", cgnatRulesCapability)
+			return nil
+		}
+		rules = append(rules, rule)
+	}
+
+	seen := make(map[router.CGNATRule]bool, len(rules))
+	deduped := rules[:0]
+	for _, rule := range rules {
+		if seen[rule] {
+			continue
+		}
+		seen[rule] = true
+		deduped = append(deduped, rule)
+	}
+	return deduped
+}
+
 // routerConfig produces a router.Config from a wireguard config and IPN prefs.
 //
 // b.mu must be held.
@@ -5620,6 +5713,10 @@ func (b *LocalBackend) routerConfigLocked(cfg *wgcfg.Config, prefs ipn.PrefsView
 		NetfilterMode:     prefs.NetfilterMode(),
 		Routes:            peerRoutes(b.logf, cfg.Peers, singleRouteThreshold, prefs.RouteAll()),
 		NetfilterKind:     netfilterKind,
+	}
+
+	if nm != nil {
+		rs.CGNATRules = cgnatRulesFromCapability(b.logf, nm.SelfNode)
 	}
 
 	if buildfeatures.HasSynology && distro.Get() == distro.Synology {

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -75,6 +75,7 @@ import (
 	"tailscale.com/wgengine"
 	"tailscale.com/wgengine/filter"
 	"tailscale.com/wgengine/filter/filtertype"
+	"tailscale.com/wgengine/router"
 	"tailscale.com/wgengine/wgcfg"
 )
 
@@ -309,6 +310,122 @@ func TestPeerRoutes(t *testing.T) {
 			got := peerRoutes(t.Logf, tt.peers, 2, true)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("got = %v; want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCGNATRulesFromCapability(t *testing.T) {
+	mustRaw := func(v any) tailcfg.RawMessage {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("json.Marshal(%v): %v", v, err)
+		}
+		return tailcfg.RawMessage(b)
+	}
+
+	tests := []struct {
+		name string
+		caps []tailcfg.RawMessage
+		want []router.CGNATRule
+	}{
+		{
+			name: "ordered-object-entries",
+			caps: []tailcfg.RawMessage{
+				mustRaw(map[string]string{"cidr": "100.100.0.0/24", "verdict": "accept", "chain": "input"}),
+				mustRaw(map[string]string{"cidr": "100.64.0.0/10", "verdict": "drop"}),
+			},
+			want: []router.CGNATRule{
+				{Prefix: netip.MustParsePrefix("100.100.0.0/24"), Verdict: router.CGNATRuleVerdictAccept, Chain: router.CGNATRuleChainInput},
+				{Prefix: netip.MustParsePrefix("100.64.0.0/10"), Verdict: router.CGNATRuleVerdictDrop, Chain: router.CGNATRuleChainBoth},
+			},
+		},
+		{
+			name: "multiple-object-entries",
+			caps: []tailcfg.RawMessage{
+				mustRaw(map[string]string{"cidr": "100.101.0.0/16", "verdict": "accept", "chain": "forward"}),
+				mustRaw(map[string]string{"cidr": "100.64.0.0/10", "verdict": "drop", "chain": "both"}),
+			},
+			want: []router.CGNATRule{
+				{Prefix: netip.MustParsePrefix("100.101.0.0/16"), Verdict: router.CGNATRuleVerdictAccept, Chain: router.CGNATRuleChainForward},
+				{Prefix: netip.MustParsePrefix("100.64.0.0/10"), Verdict: router.CGNATRuleVerdictDrop, Chain: router.CGNATRuleChainBoth},
+			},
+		},
+		{
+			name: "array-entry-rejected",
+			caps: []tailcfg.RawMessage{
+				mustRaw([]map[string]string{
+					{"cidr": "100.101.0.0/16", "verdict": "accept", "chain": "forward"},
+					{"cidr": "100.64.0.0/10", "verdict": "drop", "chain": "both"},
+				}),
+			},
+			want: nil,
+		},
+		{
+			name: "duplicates-removed",
+			caps: []tailcfg.RawMessage{
+				mustRaw(map[string]string{"cidr": "100.100.0.0/32", "verdict": "accept", "chain": "both"}),
+				mustRaw(map[string]string{"cidr": "100.64.0.0/10", "verdict": "drop", "chain": "both"}),
+				mustRaw(map[string]string{"cidr": "100.64.0.0/10", "verdict": "drop", "chain": "both"}),
+			},
+			want: []router.CGNATRule{
+				{Prefix: netip.MustParsePrefix("100.100.0.0/32"), Verdict: router.CGNATRuleVerdictAccept, Chain: router.CGNATRuleChainBoth},
+				{Prefix: netip.MustParsePrefix("100.64.0.0/10"), Verdict: router.CGNATRuleVerdictDrop, Chain: router.CGNATRuleChainBoth},
+			},
+		},
+		{
+			name: "invalid-entry-fails-closed",
+			caps: []tailcfg.RawMessage{
+				mustRaw(map[string]string{"cidr": "100.0.0.0/9", "verdict": "drop", "chain": "both"}),
+			},
+			want: nil,
+		},
+		{
+			name: "bad-verdict-fails-closed",
+			caps: []tailcfg.RawMessage{
+				mustRaw(map[string]string{"cidr": "100.100.0.0/24", "verdict": "queue", "chain": "both"}),
+			},
+			want: nil,
+		},
+		{
+			name: "bad-chain-fails-closed",
+			caps: []tailcfg.RawMessage{
+				mustRaw(map[string]string{"cidr": "100.100.0.0/24", "verdict": "drop", "chain": "output"}),
+			},
+			want: nil,
+		},
+		{
+			name: "malformed-json-fails-closed",
+			caps: []tailcfg.RawMessage{
+				tailcfg.RawMessage(`{"cidr":"not a prefix"`),
+			},
+			want: nil,
+		},
+		{
+			name: "raw-array-entry-fails-closed",
+			caps: []tailcfg.RawMessage{
+				tailcfg.RawMessage(`[
+					{"cidr":"100.100.20.0/24","verdict":"accept"},
+					{"cidr":"100.64.0.0/10","verdict":"drop"}
+				]`),
+			},
+			want: nil,
+		},
+		{
+			name: "valid-then-invalid-fails-closed",
+			caps: []tailcfg.RawMessage{
+				mustRaw(map[string]string{"cidr": "100.100.0.0/24", "verdict": "drop", "chain": "both"}),
+				mustRaw(map[string]string{"cidr": "10.0.0.0/8", "verdict": "drop", "chain": "both"}),
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := (&tailcfg.Node{CapMap: tailcfg.NodeCapMap{cgnatRulesCapability: tt.caps}}).View()
+			if got := cgnatRulesFromCapability(t.Logf, node); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("got %v; want %v", got, tt.want)
 			}
 		})
 	}

--- a/util/linuxfw/cgnat_rule.go
+++ b/util/linuxfw/cgnat_rule.go
@@ -1,0 +1,95 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build linux
+
+package linuxfw
+
+import (
+	"net/netip"
+
+	"tailscale.com/net/tsaddr"
+)
+
+// CGNATRuleVerdict describes what action to take for a CGNAT firewall rule.
+type CGNATRuleVerdict string
+
+const (
+	CGNATRuleVerdictDrop   CGNATRuleVerdict = "drop"
+	CGNATRuleVerdictAccept CGNATRuleVerdict = "accept"
+)
+
+// CGNATRuleChain describes which base chain(s) a CGNAT firewall rule applies to.
+type CGNATRuleChain string
+
+const (
+	CGNATRuleChainInput   CGNATRuleChain = "input"
+	CGNATRuleChainForward CGNATRuleChain = "forward"
+	CGNATRuleChainBoth    CGNATRuleChain = "both"
+)
+
+// CGNATRule is a Linux firewall base rule for CGNAT source matching.
+type CGNATRule struct {
+	Prefix  netip.Prefix
+	Verdict CGNATRuleVerdict
+	Chain   CGNATRuleChain
+}
+
+func cgnatRulesOrDefault(rules []CGNATRule) []CGNATRule {
+	if len(rules) != 0 {
+		return rules
+	}
+	return []CGNATRule{{
+		Prefix:  tsaddr.CGNATRange(),
+		Verdict: CGNATRuleVerdictDrop,
+		Chain:   CGNATRuleChainBoth,
+	}}
+}
+
+func cgnatInputRulesOrDefault(rules []CGNATRule) []CGNATRule {
+	filtered := make([]CGNATRule, 0, len(rules))
+	seen := make(map[CGNATRule]bool, len(rules))
+	for _, rule := range rules {
+		if !cgnatRuleAppliesToInput(rule.Chain) || seen[rule] {
+			continue
+		}
+		seen[rule] = true
+		filtered = append(filtered, rule)
+	}
+	if len(filtered) != 0 {
+		return filtered
+	}
+	return []CGNATRule{{
+		Prefix:  tsaddr.CGNATRange(),
+		Verdict: CGNATRuleVerdictDrop,
+		Chain:   CGNATRuleChainInput,
+	}}
+}
+
+func cgnatForwardRulesOrDefault(rules []CGNATRule) []CGNATRule {
+	filtered := make([]CGNATRule, 0, len(rules))
+	seen := make(map[CGNATRule]bool, len(rules))
+	for _, rule := range rules {
+		if !cgnatRuleAppliesToForward(rule.Chain) || seen[rule] {
+			continue
+		}
+		seen[rule] = true
+		filtered = append(filtered, rule)
+	}
+	if len(filtered) != 0 {
+		return filtered
+	}
+	return []CGNATRule{{
+		Prefix:  tsaddr.CGNATRange(),
+		Verdict: CGNATRuleVerdictDrop,
+		Chain:   CGNATRuleChainForward,
+	}}
+}
+
+func cgnatRuleAppliesToInput(chain CGNATRuleChain) bool {
+	return chain == CGNATRuleChainBoth || chain == CGNATRuleChainInput
+}
+
+func cgnatRuleAppliesToForward(chain CGNATRuleChain) bool {
+	return chain == CGNATRuleChainBoth || chain == CGNATRuleChainForward
+}

--- a/util/linuxfw/fake_netfilter.go
+++ b/util/linuxfw/fake_netfilter.go
@@ -63,7 +63,9 @@ func (f *FakeNetfilterRunner) HasIPV6NAT() bool {
 	return true
 }
 
-func (f *FakeNetfilterRunner) AddBase(tunname string) error              { return nil }
+func (f *FakeNetfilterRunner) AddBase(tunname string, cgnatRules []CGNATRule) error {
+	return nil
+}
 func (f *FakeNetfilterRunner) DelBase() error                            { return nil }
 func (f *FakeNetfilterRunner) AddChains() error                          { return nil }
 func (f *FakeNetfilterRunner) DelChains() error                          { return nil }

--- a/util/linuxfw/iptables_runner.go
+++ b/util/linuxfw/iptables_runner.go
@@ -199,8 +199,8 @@ func (i *iptablesRunner) AddChains() error {
 
 // AddBase adds some basic processing rules to be supplemented by
 // later calls to other helpers.
-func (i *iptablesRunner) AddBase(tunname string) error {
-	if err := i.addBase4(tunname); err != nil {
+func (i *iptablesRunner) AddBase(tunname string, cgnatRules []CGNATRule) error {
+	if err := i.addBase4(tunname, cgnatRules); err != nil {
 		return err
 	}
 	if i.HasIPV6Filter() {
@@ -213,10 +213,22 @@ func (i *iptablesRunner) AddBase(tunname string) error {
 
 // addBase4 adds some basic IPv4 processing rules to be
 // supplemented by later calls to other helpers.
-func (i *iptablesRunner) addBase4(tunname string) error {
-	// Only allow CGNAT range traffic to come from tailscale0. There
-	// is an exception carved out for ranges used by ChromeOS, for
-	// which we fall out of the Tailscale chain.
+func iptablesTargetFromCGNATVerdict(v CGNATRuleVerdict) (string, bool) {
+	switch v {
+	case CGNATRuleVerdictDrop:
+		return "DROP", true
+	case CGNATRuleVerdictAccept:
+		return "ACCEPT", true
+	default:
+		return "", false
+	}
+}
+
+func (i *iptablesRunner) addBase4(tunname string, cgnatRules []CGNATRule) error {
+	// Apply configured CGNAT source-prefix verdicts for traffic not
+	// arriving from tailscale0. There is an exception carved out for
+	// ranges used by ChromeOS, for which we fall out of the Tailscale
+	// chain.
 	//
 	// Note, this will definitely break nodes that end up using the
 	// CGNAT range for other purposes :(.
@@ -224,9 +236,15 @@ func (i *iptablesRunner) addBase4(tunname string) error {
 	if err := i.ipt4.Append("filter", "ts-input", args...); err != nil {
 		return fmt.Errorf("adding %v in v4/filter/ts-input: %w", args, err)
 	}
-	args = []string{"!", "-i", tunname, "-s", tsaddr.CGNATRange().String(), "-j", "DROP"}
-	if err := i.ipt4.Append("filter", "ts-input", args...); err != nil {
-		return fmt.Errorf("adding %v in v4/filter/ts-input: %w", args, err)
+	for _, rule := range cgnatInputRulesOrDefault(cgnatRules) {
+		target, ok := iptablesTargetFromCGNATVerdict(rule.Verdict)
+		if !ok {
+			return fmt.Errorf("unsupported CGNAT rule verdict %q", rule.Verdict)
+		}
+		args = []string{"!", "-i", tunname, "-s", rule.Prefix.String(), "-j", target}
+		if err := i.ipt4.Append("filter", "ts-input", args...); err != nil {
+			return fmt.Errorf("adding %v in v4/filter/ts-input: %w", args, err)
+		}
 	}
 
 	// Explicitly allow all other inbound traffic to the tun interface
@@ -254,9 +272,15 @@ func (i *iptablesRunner) addBase4(tunname string) error {
 	if err := i.ipt4.Append("filter", "ts-forward", args...); err != nil {
 		return fmt.Errorf("adding %v in v4/filter/ts-forward: %w", args, err)
 	}
-	args = []string{"-o", tunname, "-s", tsaddr.CGNATRange().String(), "-j", "DROP"}
-	if err := i.ipt4.Append("filter", "ts-forward", args...); err != nil {
-		return fmt.Errorf("adding %v in v4/filter/ts-forward: %w", args, err)
+	for _, rule := range cgnatForwardRulesOrDefault(cgnatRules) {
+		target, ok := iptablesTargetFromCGNATVerdict(rule.Verdict)
+		if !ok {
+			return fmt.Errorf("unsupported CGNAT rule verdict %q", rule.Verdict)
+		}
+		args = []string{"-o", tunname, "-s", rule.Prefix.String(), "-j", target}
+		if err := i.ipt4.Append("filter", "ts-forward", args...); err != nil {
+			return fmt.Errorf("adding %v in v4/filter/ts-forward: %w", args, err)
+		}
 	}
 	args = []string{"-o", tunname, "-j", "ACCEPT"}
 	if err := i.ipt4.Append("filter", "ts-forward", args...); err != nil {

--- a/util/linuxfw/iptables_runner_test.go
+++ b/util/linuxfw/iptables_runner_test.go
@@ -120,7 +120,7 @@ func TestAddAndDeleteBase(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := iptr.AddBase(tunname); err != nil {
+	if err := iptr.AddBase(tunname, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -173,6 +173,108 @@ func TestAddAndDeleteBase(t *testing.T) {
 
 	if err := iptr.DelChains(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestAddBaseWithCGNATRules(t *testing.T) {
+	iptr := newFakeIPTablesRunner()
+	tunname := "tun0"
+	if err := iptr.AddChains(); err != nil {
+		t.Fatal(err)
+	}
+
+	rules := []CGNATRule{
+		{Prefix: netip.MustParsePrefix("100.81.0.0/16"), Verdict: CGNATRuleVerdictDrop, Chain: CGNATRuleChainBoth},
+		{Prefix: netip.MustParsePrefix("100.85.0.0/16"), Verdict: CGNATRuleVerdictDrop, Chain: CGNATRuleChainBoth},
+	}
+	if err := iptr.AddBase(tunname, rules); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, r := range rules {
+		if exists, err := iptr.ipt4.Exists("filter", "ts-input", "!", "-i", tunname, "-s", r.Prefix.String(), "-j", "DROP"); err != nil {
+			t.Fatal(err)
+		} else if !exists {
+			t.Errorf("ts-input drop rule for %s doesn't exist", r.Prefix)
+		}
+		if exists, err := iptr.ipt4.Exists("filter", "ts-forward", "-o", tunname, "-s", r.Prefix.String(), "-j", "DROP"); err != nil {
+			t.Fatal(err)
+		} else if !exists {
+			t.Errorf("ts-forward drop rule for %s doesn't exist", r.Prefix)
+		}
+	}
+
+	if exists, err := iptr.ipt4.Exists("filter", "ts-input", "!", "-i", tunname, "-s", tsaddr.CGNATRange().String(), "-j", "DROP"); err != nil {
+		t.Fatal(err)
+	} else if exists {
+		t.Errorf("unexpected default CGNAT ts-input drop rule was installed")
+	}
+	if exists, err := iptr.ipt4.Exists("filter", "ts-forward", "-o", tunname, "-s", tsaddr.CGNATRange().String(), "-j", "DROP"); err != nil {
+		t.Fatal(err)
+	} else if exists {
+		t.Errorf("unexpected default CGNAT ts-forward drop rule was installed")
+	}
+}
+
+func TestAddBaseWithCGNATRulesChainAndVerdict(t *testing.T) {
+	iptr := newFakeIPTablesRunner()
+	tunname := "tun0"
+	if err := iptr.AddChains(); err != nil {
+		t.Fatal(err)
+	}
+
+	rules := []CGNATRule{
+		{Prefix: netip.MustParsePrefix("100.100.0.0/24"), Verdict: CGNATRuleVerdictAccept, Chain: CGNATRuleChainInput},
+		{Prefix: netip.MustParsePrefix("100.64.0.0/10"), Verdict: CGNATRuleVerdictDrop, Chain: CGNATRuleChainForward},
+	}
+	if err := iptr.AddBase(tunname, rules); err != nil {
+		t.Fatal(err)
+	}
+
+	if exists, err := iptr.ipt4.Exists("filter", "ts-input", "!", "-i", tunname, "-s", "100.100.0.0/24", "-j", "ACCEPT"); err != nil {
+		t.Fatal(err)
+	} else if !exists {
+		t.Fatalf("missing input accept rule")
+	}
+	if exists, err := iptr.ipt4.Exists("filter", "ts-forward", "-o", tunname, "-s", "100.100.0.0/24", "-j", "ACCEPT"); err != nil {
+		t.Fatal(err)
+	} else if exists {
+		t.Fatalf("unexpected forward accept rule")
+	}
+
+	if exists, err := iptr.ipt4.Exists("filter", "ts-forward", "-o", tunname, "-s", "100.64.0.0/10", "-j", "DROP"); err != nil {
+		t.Fatal(err)
+	} else if !exists {
+		t.Fatalf("missing forward drop rule")
+	}
+	if exists, err := iptr.ipt4.Exists("filter", "ts-input", "!", "-i", tunname, "-s", "100.64.0.0/10", "-j", "DROP"); err != nil {
+		t.Fatal(err)
+	} else if exists {
+		t.Fatalf("unexpected input drop rule")
+	}
+}
+
+func TestAddBaseWithCGNATRulesPerChainDefault(t *testing.T) {
+	iptr := newFakeIPTablesRunner()
+	tunname := "tun0"
+	if err := iptr.AddChains(); err != nil {
+		t.Fatal(err)
+	}
+
+	rules := []CGNATRule{{Prefix: netip.MustParsePrefix("100.100.0.0/24"), Verdict: CGNATRuleVerdictAccept, Chain: CGNATRuleChainInput}}
+	if err := iptr.AddBase(tunname, rules); err != nil {
+		t.Fatal(err)
+	}
+
+	if exists, err := iptr.ipt4.Exists("filter", "ts-input", "!", "-i", tunname, "-s", "100.100.0.0/24", "-j", "ACCEPT"); err != nil {
+		t.Fatal(err)
+	} else if !exists {
+		t.Fatalf("missing explicit input rule")
+	}
+	if exists, err := iptr.ipt4.Exists("filter", "ts-forward", "-o", tunname, "-s", tsaddr.CGNATRange().String(), "-j", "DROP"); err != nil {
+		t.Fatal(err)
+	} else if !exists {
+		t.Fatalf("missing default forward drop rule")
 	}
 }
 

--- a/util/linuxfw/nftables_runner.go
+++ b/util/linuxfw/nftables_runner.go
@@ -7,10 +7,8 @@ package linuxfw
 
 import (
 	"encoding/binary"
-	"encoding/hex"
 	"errors"
 	"fmt"
-	"net"
 	"net/netip"
 	"reflect"
 	"strings"
@@ -499,7 +497,7 @@ type NetfilterRunner interface {
 	DelChains() error
 
 	// AddBase adds rules reused by different other rules.
-	AddBase(tunname string) error
+	AddBase(tunname string, cgnatRules []CGNATRule) error
 
 	// DelBase removes rules added by AddBase.
 	DelBase() error
@@ -1153,6 +1151,17 @@ func maskof(pfx netip.Prefix) []byte {
 	return mask
 }
 
+func nftVerdictFromCGNATVerdict(v CGNATRuleVerdict) (expr.VerdictKind, bool) {
+	switch v {
+	case CGNATRuleVerdictDrop:
+		return expr.VerdictDrop, true
+	case CGNATRuleVerdictAccept:
+		return expr.VerdictAccept, true
+	default:
+		return 0, false
+	}
+}
+
 // createRangeRule creates a rule that matches packets with source IP from the give
 // range (like CGNAT range or ChromeOSVM range) and the interface is not the tunname,
 // and makes the given decision. Only IPv4 is supported.
@@ -1216,10 +1225,14 @@ func addReturnChromeOSVMRangeRule(c *nftables.Conn, table *nftables.Table, chain
 	return nil
 }
 
-// addDropCGNATRangeRule adds a rule to drop if the source IP is in the
-// CGNAT range.
-func addDropCGNATRangeRule(c *nftables.Conn, table *nftables.Table, chain *nftables.Chain, tunname string) error {
-	rule, err := createRangeRule(table, chain, tunname, tsaddr.CGNATRange(), expr.VerdictDrop)
+// addCGNATRangeRule adds a rule to match packets from a configured CGNAT source
+// prefix on ts-input.
+func addCGNATRangeRule(c *nftables.Conn, table *nftables.Table, chain *nftables.Chain, tunname string, cgnatRule CGNATRule) error {
+	verdict, ok := nftVerdictFromCGNATVerdict(cgnatRule.Verdict)
+	if !ok {
+		return fmt.Errorf("unsupported CGNAT rule verdict %q", cgnatRule.Verdict)
+	}
+	rule, err := createRangeRule(table, chain, tunname, cgnatRule.Prefix, verdict)
 	if err != nil {
 		return fmt.Errorf("create rule: %w", err)
 	}
@@ -1281,18 +1294,13 @@ func addSetSubnetRouteMarkRule(c *nftables.Conn, table *nftables.Table, chain *n
 	return nil
 }
 
-// createDropOutgoingPacketFromCGNATRangeRuleWithTunname creates a rule to drop
-// outgoing packets from the CGNAT range.
-func createDropOutgoingPacketFromCGNATRangeRuleWithTunname(table *nftables.Table, chain *nftables.Chain, tunname string) (*nftables.Rule, error) {
-	_, ipNet, err := net.ParseCIDR(tsaddr.CGNATRange().String())
-	if err != nil {
-		return nil, fmt.Errorf("parse cidr: %v", err)
+// createOutgoingPacketFromCGNATRangeRuleWithTunname creates a rule to match
+// outgoing packets from a configured CGNAT source prefix on ts-forward.
+func createOutgoingPacketFromCGNATRangeRuleWithTunname(table *nftables.Table, chain *nftables.Chain, tunname string, cgnatRule CGNATRule) (*nftables.Rule, error) {
+	verdict, ok := nftVerdictFromCGNATVerdict(cgnatRule.Verdict)
+	if !ok {
+		return nil, fmt.Errorf("unsupported CGNAT rule verdict %q", cgnatRule.Verdict)
 	}
-	mask, err := hex.DecodeString(ipNet.Mask.String())
-	if err != nil {
-		return nil, fmt.Errorf("decode mask: %v", err)
-	}
-	netip := ipNet.IP.Mask(ipNet.Mask).To4()
 	saddrExpr, err := newLoadSaddrExpr(nftables.TableFamilyIPv4, 1)
 	if err != nil {
 		return nil, fmt.Errorf("newLoadSaddrExpr: %v", err)
@@ -1312,27 +1320,36 @@ func createDropOutgoingPacketFromCGNATRangeRuleWithTunname(table *nftables.Table
 				SourceRegister: 1,
 				DestRegister:   1,
 				Len:            4,
-				Mask:           mask,
+				Mask:           maskof(cgnatRule.Prefix),
 				Xor:            []byte{0x00, 0x00, 0x00, 0x00},
 			},
 			&expr.Cmp{
 				Op:       expr.CmpOpEq,
 				Register: 1,
-				Data:     netip,
+				Data:     cgnatRule.Prefix.Addr().AsSlice(),
 			},
 			&expr.Counter{},
 			&expr.Verdict{
-				Kind: expr.VerdictDrop,
+				Kind: verdict,
 			},
 		},
 	}
 	return rule, nil
 }
 
-// addDropOutgoingPacketFromCGNATRangeRuleWithTunname adds a rule to drop
-// outgoing packets from the CGNAT range.
-func addDropOutgoingPacketFromCGNATRangeRuleWithTunname(conn *nftables.Conn, table *nftables.Table, chain *nftables.Chain, tunname string) error {
-	rule, err := createDropOutgoingPacketFromCGNATRangeRuleWithTunname(table, chain, tunname)
+// createDropOutgoingPacketFromCGNATRangeRuleWithTunname creates a legacy DROP
+// rule for the provided prefix.
+func createDropOutgoingPacketFromCGNATRangeRuleWithTunname(table *nftables.Table, chain *nftables.Chain, tunname string, pfx netip.Prefix) (*nftables.Rule, error) {
+	return createOutgoingPacketFromCGNATRangeRuleWithTunname(table, chain, tunname, CGNATRule{
+		Prefix:  pfx,
+		Verdict: CGNATRuleVerdictDrop,
+		Chain:   CGNATRuleChainBoth,
+	})
+}
+
+// addOutgoingPacketFromCGNATRangeRuleWithTunname adds a ts-forward CGNAT rule.
+func addOutgoingPacketFromCGNATRangeRuleWithTunname(conn *nftables.Conn, table *nftables.Table, chain *nftables.Chain, tunname string, cgnatRule CGNATRule) error {
+	rule, err := createOutgoingPacketFromCGNATRangeRuleWithTunname(table, chain, tunname, cgnatRule)
 	if err != nil {
 		return fmt.Errorf("create rule: %w", err)
 	}
@@ -1530,8 +1547,8 @@ func addAcceptIncomingPacketRule(conn *nftables.Conn, table *nftables.Table, cha
 }
 
 // AddBase adds some basic processing rules.
-func (n *nftablesRunner) AddBase(tunname string) error {
-	if err := n.addBase4(tunname); err != nil {
+func (n *nftablesRunner) AddBase(tunname string, cgnatRules []CGNATRule) error {
+	if err := n.addBase4(tunname, cgnatRules); err != nil {
 		return fmt.Errorf("add base v4: %w", err)
 	}
 	if n.HasIPV6() {
@@ -1543,7 +1560,7 @@ func (n *nftablesRunner) AddBase(tunname string) error {
 }
 
 // addBase4 adds some basic IPv4 processing rules.
-func (n *nftablesRunner) addBase4(tunname string) error {
+func (n *nftablesRunner) addBase4(tunname string, cgnatRules []CGNATRule) error {
 	conn := n.conn
 
 	inputChain, err := getChainFromTable(conn, n.nft4.Filter, chainNameInput)
@@ -1553,8 +1570,10 @@ func (n *nftablesRunner) addBase4(tunname string) error {
 	if err = addReturnChromeOSVMRangeRule(conn, n.nft4.Filter, inputChain, tunname); err != nil {
 		return fmt.Errorf("add return chromeos vm range rule v4: %w", err)
 	}
-	if err = addDropCGNATRangeRule(conn, n.nft4.Filter, inputChain, tunname); err != nil {
-		return fmt.Errorf("add drop cgnat range rule v4: %w", err)
+	for _, cgnatRule := range cgnatInputRulesOrDefault(cgnatRules) {
+		if err = addCGNATRangeRule(conn, n.nft4.Filter, inputChain, tunname, cgnatRule); err != nil {
+			return fmt.Errorf("add cgnat ts-input rule v4: %w", err)
+		}
 	}
 	if err = addAcceptIncomingPacketRule(conn, n.nft4.Filter, inputChain, tunname); err != nil {
 		return fmt.Errorf("add accept incoming packet rule v4: %w", err)
@@ -1573,8 +1592,10 @@ func (n *nftablesRunner) addBase4(tunname string) error {
 		return fmt.Errorf("add match subnet route mark rule v4: %w", err)
 	}
 
-	if err = addDropOutgoingPacketFromCGNATRangeRuleWithTunname(conn, n.nft4.Filter, forwardChain, tunname); err != nil {
-		return fmt.Errorf("add drop outgoing packet from cgnat range rule v4: %w", err)
+	for _, cgnatRule := range cgnatForwardRulesOrDefault(cgnatRules) {
+		if err = addOutgoingPacketFromCGNATRangeRuleWithTunname(conn, n.nft4.Filter, forwardChain, tunname, cgnatRule); err != nil {
+			return fmt.Errorf("add cgnat ts-forward rule v4: %w", err)
+		}
 	}
 
 	if err = addAcceptOutgoingPacketRule(conn, n.nft4.Filter, forwardChain, tunname); err != nil {

--- a/util/linuxfw/nftables_runner_test.go
+++ b/util/linuxfw/nftables_runner_test.go
@@ -283,7 +283,7 @@ func TestAddDropCGNATRangeRule(t *testing.T) {
 		Hooknum:  nftables.ChainHookInput,
 		Priority: nftables.ChainPriorityFilter,
 	})
-	err := addDropCGNATRangeRule(testConn, table, chain, "testTunn")
+	err := addCGNATRangeRule(testConn, table, chain, "testTunn", CGNATRule{Prefix: tsaddr.CGNATRange(), Verdict: CGNATRuleVerdictDrop, Chain: CGNATRuleChainBoth})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -347,7 +347,7 @@ func TestAddDropOutgoingPacketFromCGNATRangeRuleWithTunname(t *testing.T) {
 		Hooknum:  nftables.ChainHookForward,
 		Priority: nftables.ChainPriorityFilter,
 	})
-	err := addDropOutgoingPacketFromCGNATRangeRuleWithTunname(testConn, table, chain, "testTunn")
+	err := addOutgoingPacketFromCGNATRangeRuleWithTunname(testConn, table, chain, "testTunn", CGNATRule{Prefix: tsaddr.CGNATRange(), Verdict: CGNATRuleVerdictDrop, Chain: CGNATRuleChainBoth})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -672,7 +672,7 @@ func findV4BaseRules(
 		return nil, fmt.Errorf("create rule: %w", err)
 	}
 	want = append(want, rule)
-	rule, err = createDropOutgoingPacketFromCGNATRangeRuleWithTunname(forwChain.Table, forwChain, tunname)
+	rule, err = createDropOutgoingPacketFromCGNATRangeRuleWithTunname(forwChain.Table, forwChain, tunname, tsaddr.CGNATRange())
 	if err != nil {
 		return nil, fmt.Errorf("create rule: %w", err)
 	}
@@ -740,7 +740,7 @@ func TestNFTAddAndDelNetfilterBase(t *testing.T) {
 		t.Fatalf("AddChains() failed: %v", err)
 	}
 	defer runner.DelChains()
-	if err := runner.AddBase("testTunn"); err != nil {
+	if err := runner.AddBase("testTunn", nil); err != nil {
 		t.Fatalf("AddBase() failed: %v", err)
 	}
 
@@ -784,6 +784,129 @@ func TestNFTAddAndDelNetfilterBase(t *testing.T) {
 	}
 	for _, chain := range chains {
 		checkChainRules(t, conn, chain, 0)
+	}
+}
+
+func TestNFTAddBaseWithCGNATRules(t *testing.T) {
+	conn := newSysConn(t)
+	runner := newFakeNftablesRunnerWithConn(t, conn, true)
+
+	if err := runner.AddChains(); err != nil {
+		t.Fatalf("AddChains() failed: %v", err)
+	}
+	defer runner.DelChains()
+
+	rules := []CGNATRule{
+		{Prefix: netip.MustParsePrefix("100.81.0.0/16"), Verdict: CGNATRuleVerdictDrop, Chain: CGNATRuleChainBoth},
+		{Prefix: netip.MustParsePrefix("100.85.0.0/16"), Verdict: CGNATRuleVerdictDrop, Chain: CGNATRuleChainBoth},
+	}
+	if err := runner.AddBase("testTunn", rules); err != nil {
+		t.Fatalf("AddBase() failed: %v", err)
+	}
+
+	inputV4, forwardV4, _, err := getTsChains(conn, nftables.TableFamilyIPv4)
+	if err != nil {
+		t.Fatalf("getTsChains() failed: %v", err)
+	}
+	checkChainRules(t, conn, inputV4, 2+len(rules))
+	checkChainRules(t, conn, forwardV4, 3+len(rules))
+
+	for _, r := range rules {
+		inRule, err := createRangeRule(inputV4.Table, inputV4, "testTunn", r.Prefix, expr.VerdictDrop)
+		if err != nil {
+			t.Fatalf("createRangeRule(%s) failed: %v", r.Prefix, err)
+		}
+		if _, err := findRule(conn, inRule); err != nil {
+			t.Fatalf("missing ts-input drop rule for %s: %v", r.Prefix, err)
+		}
+
+		fwRule, err := createOutgoingPacketFromCGNATRangeRuleWithTunname(forwardV4.Table, forwardV4, "testTunn", r)
+		if err != nil {
+			t.Fatalf("createOutgoingPacketFromCGNATRangeRuleWithTunname(%s) failed: %v", r.Prefix, err)
+		}
+		if _, err := findRule(conn, fwRule); err != nil {
+			t.Fatalf("missing ts-forward drop rule for %s: %v", r.Prefix, err)
+		}
+	}
+
+}
+
+func TestNFTAddBaseWithCGNATRulesChainAndVerdict(t *testing.T) {
+	conn := newSysConn(t)
+	runner := newFakeNftablesRunnerWithConn(t, conn, true)
+
+	if err := runner.AddChains(); err != nil {
+		t.Fatalf("AddChains() failed: %v", err)
+	}
+	defer runner.DelChains()
+
+	rules := []CGNATRule{
+		{Prefix: netip.MustParsePrefix("100.100.0.0/24"), Verdict: CGNATRuleVerdictAccept, Chain: CGNATRuleChainInput},
+		{Prefix: netip.MustParsePrefix("100.64.0.0/10"), Verdict: CGNATRuleVerdictDrop, Chain: CGNATRuleChainForward},
+	}
+	if err := runner.AddBase("testTunn", rules); err != nil {
+		t.Fatalf("AddBase() failed: %v", err)
+	}
+
+	inputV4, forwardV4, _, err := getTsChains(conn, nftables.TableFamilyIPv4)
+	if err != nil {
+		t.Fatalf("getTsChains() failed: %v", err)
+	}
+	checkChainRules(t, conn, inputV4, 3)
+	checkChainRules(t, conn, forwardV4, 4)
+
+	inAccept, err := createRangeRule(inputV4.Table, inputV4, "testTunn", netip.MustParsePrefix("100.100.0.0/24"), expr.VerdictAccept)
+	if err != nil {
+		t.Fatalf("createRangeRule(input accept) failed: %v", err)
+	}
+	if _, err := findRule(conn, inAccept); err != nil {
+		t.Fatalf("missing input accept rule: %v", err)
+	}
+
+
+	forwardDrop, err := createOutgoingPacketFromCGNATRangeRuleWithTunname(forwardV4.Table, forwardV4, "testTunn", CGNATRule{Prefix: netip.MustParsePrefix("100.64.0.0/10"), Verdict: CGNATRuleVerdictDrop, Chain: CGNATRuleChainForward})
+	if err != nil {
+		t.Fatalf("createOutgoingPacketFromCGNATRangeRuleWithTunname(forward drop) failed: %v", err)
+	}
+	if _, err := findRule(conn, forwardDrop); err != nil {
+		t.Fatalf("missing forward drop rule: %v", err)
+	}
+
+}
+
+func TestNFTAddBaseWithCGNATRulesPerChainDefault(t *testing.T) {
+	conn := newSysConn(t)
+	runner := newFakeNftablesRunnerWithConn(t, conn, true)
+
+	if err := runner.AddChains(); err != nil {
+		t.Fatalf("AddChains() failed: %v", err)
+	}
+	defer runner.DelChains()
+
+	rules := []CGNATRule{{Prefix: netip.MustParsePrefix("100.100.0.0/24"), Verdict: CGNATRuleVerdictAccept, Chain: CGNATRuleChainInput}}
+	if err := runner.AddBase("testTunn", rules); err != nil {
+		t.Fatalf("AddBase() failed: %v", err)
+	}
+
+	inputV4, forwardV4, _, err := getTsChains(conn, nftables.TableFamilyIPv4)
+	if err != nil {
+		t.Fatalf("getTsChains() failed: %v", err)
+	}
+
+	inAccept, err := createRangeRule(inputV4.Table, inputV4, "testTunn", netip.MustParsePrefix("100.100.0.0/24"), expr.VerdictAccept)
+	if err != nil {
+		t.Fatalf("createRangeRule(input accept) failed: %v", err)
+	}
+	if _, err := findRule(conn, inAccept); err != nil {
+		t.Fatalf("missing input accept rule: %v", err)
+	}
+
+	forwardDrop, err := createOutgoingPacketFromCGNATRangeRuleWithTunname(forwardV4.Table, forwardV4, "testTunn", CGNATRule{Prefix: tsaddr.CGNATRange(), Verdict: CGNATRuleVerdictDrop, Chain: CGNATRuleChainForward})
+	if err != nil {
+		t.Fatalf("createOutgoingPacketFromCGNATRangeRuleWithTunname(forward drop) failed: %v", err)
+	}
+	if _, err := findRule(conn, forwardDrop); err != nil {
+		t.Fatalf("missing default forward drop rule: %v", err)
 	}
 }
 
@@ -847,7 +970,7 @@ func TestNFTAddAndDelLoopbackRule(t *testing.T) {
 	checkChainRules(t, conn, inputV4, 0)
 	checkChainRules(t, conn, inputV6, 0)
 
-	runner.AddBase("testTunn")
+	runner.AddBase("testTunn", nil)
 	defer runner.DelBase()
 	checkChainRules(t, conn, inputV4, 3)
 	checkChainRules(t, conn, inputV6, 3)

--- a/wgengine/router/osrouter/router_linux.go
+++ b/wgengine/router/osrouter/router_linux.go
@@ -12,6 +12,7 @@ import (
 	"net/netip"
 	"os"
 	"os/exec"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -89,6 +90,7 @@ type linuxRouter struct {
 	connmarkEnabled   bool // whether connmark rules are currently enabled
 	netfilterMode     preftype.NetfilterMode
 	netfilterKind     string
+	cgnatRules        []linuxfw.CGNATRule
 	magicsockPortV4   uint16
 	magicsockPortV6   uint16
 }
@@ -172,6 +174,18 @@ func newUserspaceRouterAdvanced(logf logger.Logf, tunname string, netMon *netmon
 	r.fixupWSLMTU()
 
 	return r, nil
+}
+
+func toLinuxFWCGNATRules(rules []router.CGNATRule) []linuxfw.CGNATRule {
+	ret := make([]linuxfw.CGNATRule, 0, len(rules))
+	for _, r := range rules {
+		ret = append(ret, linuxfw.CGNATRule{
+			Prefix:  r.Prefix,
+			Verdict: linuxfw.CGNATRuleVerdict(r.Verdict),
+			Chain:   linuxfw.CGNATRuleChain(r.Chain),
+		})
+	}
+	return ret
 }
 
 // ipCmdSupportsFwmask returns true if the system 'ip' binary supports using a
@@ -433,8 +447,31 @@ func (r *linuxRouter) Set(cfg *router.Config) error {
 		}
 	}
 
+	prevCGNATRules := slices.Clone(r.cgnatRules)
+	r.cgnatRules = slices.Clone(toLinuxFWCGNATRules(cfg.CGNATRules))
+	prevMode := r.netfilterMode
+
 	if err := r.setNetfilterModeLocked(cfg.NetfilterMode); err != nil {
 		errs = append(errs, err)
+	}
+	modeChanged := prevMode != r.netfilterMode
+	if !modeChanged && r.netfilterMode != netfilterOff && !slices.Equal(prevCGNATRules, r.cgnatRules) {
+		if err := r.nfr.DelBase(); err != nil {
+			errs = append(errs, fmt.Errorf("could not update netfilter base rules: %w", err))
+		} else if err := r.nfr.AddBase(r.tunname, r.cgnatRules); err != nil {
+			errs = append(errs, fmt.Errorf("could not update netfilter base rules: %w", err))
+		} else {
+			for addr := range r.addrs {
+				if err := r.addLoopbackRule(addr.Addr()); err != nil {
+					errs = append(errs, fmt.Errorf("could not restore loopback rule: %w", err))
+				}
+			}
+			// DelBase flushes the Tailscale chains, so mark non-base rule state as
+			// absent and let the existing reconciliation logic below restore them.
+			r.snatSubnetRoutes = false
+			r.statefulFiltering = false
+			r.connmarkEnabled = false
+		}
 	}
 
 	newLocalRoutes, err := cidrDiff("localRoute", r.localRoutes, cfg.LocalRoutes, r.addThrowRoute, r.delThrowRoute, r.logf)
@@ -689,7 +726,7 @@ func (r *linuxRouter) setNetfilterModeLocked(mode preftype.NetfilterMode) error 
 			if err := r.nfr.AddChains(); err != nil {
 				return err
 			}
-			if err := r.nfr.AddBase(r.tunname); err != nil {
+			if err := r.nfr.AddBase(r.tunname, r.cgnatRules); err != nil {
 				return err
 			}
 			if r.magicsockPortV4 != 0 {
@@ -729,7 +766,7 @@ func (r *linuxRouter) setNetfilterModeLocked(mode preftype.NetfilterMode) error 
 				return err
 			}
 			// AddBase adds base ts rules
-			if err := r.nfr.AddBase(r.tunname); err != nil {
+			if err := r.nfr.AddBase(r.tunname, r.cgnatRules); err != nil {
 				return err
 			}
 			if r.magicsockPortV4 != 0 {
@@ -751,7 +788,7 @@ func (r *linuxRouter) setNetfilterModeLocked(mode preftype.NetfilterMode) error 
 			if err := r.nfr.AddHooks(); err != nil {
 				return err
 			}
-			if err := r.nfr.AddBase(r.tunname); err != nil {
+			if err := r.nfr.AddBase(r.tunname, r.cgnatRules); err != nil {
 				return err
 			}
 			r.snatSubnetRoutes = false

--- a/wgengine/router/osrouter/router_linux_test.go
+++ b/wgengine/router/osrouter/router_linux_test.go
@@ -557,6 +557,70 @@ v6/nat/ts-postrouting -m mark --mark 0x40000/0xff0000 -j MASQUERADE
 	}
 }
 
+func TestCGNATRuleUpdatePreservesNetfilterState(t *testing.T) {
+	bus := eventbus.New()
+	defer bus.Close()
+	mon, err := netmon.New(bus, logger.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mon.Start()
+	defer mon.Close()
+
+	fake := NewFakeOS(t)
+	ht := health.NewTracker(bus)
+	r, err := newUserspaceRouterAdvanced(t.Logf, "tailscale0", mon, fake, ht, bus)
+	if err != nil {
+		t.Fatalf("failed to create router: %v", err)
+	}
+	lr := r.(*linuxRouter)
+	lr.nfr = fake.nfr
+	if err := lr.Up(); err != nil {
+		t.Fatalf("failed to up router: %v", err)
+	}
+
+	cfg1 := &Config{
+		LocalAddrs:        mustCIDRs("100.101.102.104/10"),
+		Routes:            mustCIDRs("100.100.100.100/32"),
+		SubnetRoutes:      mustCIDRs("10.0.0.0/16"),
+		SNATSubnetRoutes:  true,
+		StatefulFiltering: true,
+		NetfilterMode:     netfilterOn,
+		CGNATRules: []router.CGNATRule{{
+			Prefix:  netip.MustParsePrefix("100.64.0.0/10"),
+			Verdict: router.CGNATRuleVerdictDrop,
+			Chain:   router.CGNATRuleChainBoth,
+		}},
+	}
+	if err := lr.Set(cfg1); err != nil {
+		t.Fatalf("initial Set failed: %v", err)
+	}
+
+	cfg2 := cfg1.Clone()
+	cfg2.CGNATRules = []router.CGNATRule{
+		{Prefix: netip.MustParsePrefix("100.100.0.0/24"), Verdict: router.CGNATRuleVerdictAccept, Chain: router.CGNATRuleChainInput},
+		{Prefix: netip.MustParsePrefix("100.64.0.0/10"), Verdict: router.CGNATRuleVerdictDrop, Chain: router.CGNATRuleChainBoth},
+	}
+	if err := lr.Set(cfg2); err != nil {
+		t.Fatalf("CGNAT-only update Set failed: %v", err)
+	}
+
+	got := fake.String()
+	for _, want := range []string{
+		"v4/filter/ts-input -i lo -s 100.101.102.104 -j ACCEPT",
+		"v4/nat/ts-postrouting -m mark --mark 0x40000/0xff0000 -j MASQUERADE",
+		"v4/filter/ts-forward -o tailscale0 -m conntrack ! --ctstate ESTABLISHED,RELATED -j DROP",
+		"v4/mangle/OUTPUT -m conntrack --ctstate NEW -m mark ! --mark 0x0/0xff0000 -j CONNMARK --save-mark --nfmask 0xff0000 --ctmask 0xff0000",
+		"v4/mangle/PREROUTING -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark --nfmask 0xff0000 --ctmask 0xff0000",
+		"v4/filter/ts-input ! -i tailscale0 -s 100.100.0.0/24 -j ACCEPT",
+		"v4/filter/ts-forward -o tailscale0 -s 100.64.0.0/10 -j DROP",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing rule after CGNAT-only update: %s\nstate:\n%s", want, got)
+		}
+	}
+}
+
 type fakeIPTablesRunner struct {
 	t    *testing.T
 	ipt4 map[string][]string
@@ -665,8 +729,8 @@ func (n *fakeIPTablesRunner) AddLoopbackRule(addr netip.Addr) error {
 	return insertRule(n, curIPT, "filter/ts-input", newRule)
 }
 
-func (n *fakeIPTablesRunner) AddBase(tunname string) error {
-	if err := n.addBase4(tunname); err != nil {
+func (n *fakeIPTablesRunner) AddBase(tunname string, cgnatRules []linuxfw.CGNATRule) error {
+	if err := n.addBase4(tunname, cgnatRules); err != nil {
 		return err
 	}
 	if n.HasIPV6() {
@@ -717,22 +781,87 @@ func (n *fakeIPTablesRunner) DeleteDNATRuleForSvc(svcName string, origDst, dst n
 	return errors.New("not implemented")
 }
 
-func (n *fakeIPTablesRunner) addBase4(tunname string) error {
+func (n *fakeIPTablesRunner) addBase4(tunname string, cgnatRules []linuxfw.CGNATRule) error {
 	curIPT := n.ipt4
 	newRules := []struct{ chain, rule string }{
 		{"filter/ts-input", fmt.Sprintf("! -i %s -s %s -j RETURN", tunname, tsaddr.ChromeOSVMRange().String())},
-		{"filter/ts-input", fmt.Sprintf("! -i %s -s %s -j DROP", tunname, tsaddr.CGNATRange().String())},
-		{"filter/ts-forward", fmt.Sprintf("-i %s -j MARK --set-mark %s/%s", tunname, tsconst.LinuxSubnetRouteMark, tsconst.LinuxFwmarkMask)},
-		{"filter/ts-forward", fmt.Sprintf("-m mark --mark %s/%s -j ACCEPT", tsconst.LinuxSubnetRouteMark, tsconst.LinuxFwmarkMask)},
-		{"filter/ts-forward", fmt.Sprintf("-o %s -s %s -j DROP", tunname, tsaddr.CGNATRange().String())},
-		{"filter/ts-forward", fmt.Sprintf("-o %s -j ACCEPT", tunname)},
 	}
+	for _, rule := range linuxfwInputRulesOrDefault(cgnatRules) {
+		target := strings.ToUpper(string(rule.Verdict))
+		newRules = append(newRules,
+			struct{ chain, rule string }{"filter/ts-input", fmt.Sprintf("! -i %s -s %s -j %s", tunname, rule.Prefix.String(), target)},
+		)
+	}
+	newRules = append(newRules,
+		struct{ chain, rule string }{"filter/ts-forward", fmt.Sprintf("-i %s -j MARK --set-mark %s/%s", tunname, tsconst.LinuxSubnetRouteMark, tsconst.LinuxFwmarkMask)},
+		struct{ chain, rule string }{"filter/ts-forward", fmt.Sprintf("-m mark --mark %s/%s -j ACCEPT", tsconst.LinuxSubnetRouteMark, tsconst.LinuxFwmarkMask)},
+	)
+	for _, rule := range linuxfwForwardRulesOrDefault(cgnatRules) {
+		target := strings.ToUpper(string(rule.Verdict))
+		newRules = append(newRules,
+			struct{ chain, rule string }{"filter/ts-forward", fmt.Sprintf("-o %s -s %s -j %s", tunname, rule.Prefix.String(), target)},
+		)
+	}
+	newRules = append(newRules, struct{ chain, rule string }{"filter/ts-forward", fmt.Sprintf("-o %s -j ACCEPT", tunname)})
 	for _, rule := range newRules {
 		if err := appendRule(n, curIPT, rule.chain, rule.rule); err != nil {
 			return fmt.Errorf("add rule %q to chain %q: %w", rule.rule, rule.chain, err)
 		}
 	}
 	return nil
+}
+
+func linuxfwRulesOrDefault(rules []linuxfw.CGNATRule) []linuxfw.CGNATRule {
+	if len(rules) > 0 {
+		return rules
+	}
+	return []linuxfw.CGNATRule{{
+		Prefix:  tsaddr.CGNATRange(),
+		Verdict: linuxfw.CGNATRuleVerdictDrop,
+		Chain:   linuxfw.CGNATRuleChainBoth,
+	}}
+}
+
+func linuxfwInputRulesOrDefault(rules []linuxfw.CGNATRule) []linuxfw.CGNATRule {
+	filtered := make([]linuxfw.CGNATRule, 0, len(rules))
+	for _, rule := range rules {
+		if ruleAppliesToInput(rule.Chain) {
+			filtered = append(filtered, rule)
+		}
+	}
+	if len(filtered) > 0 {
+		return filtered
+	}
+	return []linuxfw.CGNATRule{{
+		Prefix:  tsaddr.CGNATRange(),
+		Verdict: linuxfw.CGNATRuleVerdictDrop,
+		Chain:   linuxfw.CGNATRuleChainInput,
+	}}
+}
+
+func linuxfwForwardRulesOrDefault(rules []linuxfw.CGNATRule) []linuxfw.CGNATRule {
+	filtered := make([]linuxfw.CGNATRule, 0, len(rules))
+	for _, rule := range rules {
+		if ruleAppliesToForward(rule.Chain) {
+			filtered = append(filtered, rule)
+		}
+	}
+	if len(filtered) > 0 {
+		return filtered
+	}
+	return []linuxfw.CGNATRule{{
+		Prefix:  tsaddr.CGNATRange(),
+		Verdict: linuxfw.CGNATRuleVerdictDrop,
+		Chain:   linuxfw.CGNATRuleChainForward,
+	}}
+}
+
+func ruleAppliesToInput(chain linuxfw.CGNATRuleChain) bool {
+	return chain == linuxfw.CGNATRuleChainBoth || chain == linuxfw.CGNATRuleChainInput
+}
+
+func ruleAppliesToForward(chain linuxfw.CGNATRuleChain) bool {
+	return chain == linuxfw.CGNATRuleChainBoth || chain == linuxfw.CGNATRuleChainForward
 }
 
 func (n *fakeIPTablesRunner) addBase6(tunname string) error {

--- a/wgengine/router/router_test.go
+++ b/wgengine/router/router_test.go
@@ -15,7 +15,7 @@ func TestConfigEqual(t *testing.T) {
 	testedFields := []string{
 		"LocalAddrs", "Routes", "LocalRoutes", "NewMTU",
 		"SubnetRoutes", "SNATSubnetRoutes", "StatefulFiltering",
-		"NetfilterMode", "NetfilterKind",
+		"NetfilterMode", "NetfilterKind", "CGNATRules",
 	}
 	configType := reflect.TypeFor[Config]()
 	configFields := []string{}
@@ -146,6 +146,16 @@ func TestConfigEqual(t *testing.T) {
 			&Config{NewMTU: 1280},
 			&Config{NewMTU: 0},
 			false,
+		},
+		{
+			&Config{CGNATRules: []CGNATRule{{Prefix: netip.MustParsePrefix("100.64.0.0/10"), Verdict: CGNATRuleVerdictDrop, Chain: CGNATRuleChainBoth}}},
+			&Config{CGNATRules: []CGNATRule{{Prefix: netip.MustParsePrefix("100.64.0.0/10"), Verdict: CGNATRuleVerdictAccept, Chain: CGNATRuleChainBoth}}},
+			false,
+		},
+		{
+			&Config{CGNATRules: []CGNATRule{{Prefix: netip.MustParsePrefix("100.100.0.0/24"), Verdict: CGNATRuleVerdictAccept, Chain: CGNATRuleChainInput}}},
+			&Config{CGNATRules: []CGNATRule{{Prefix: netip.MustParsePrefix("100.100.0.0/24"), Verdict: CGNATRuleVerdictAccept, Chain: CGNATRuleChainInput}}},
+			true,
 		},
 	}
 	for i, tt := range tests {


### PR DESCRIPTION
add `ysun.co/tscgnat` (see inline comments) node app capability entries as a ordered slice of [{cidr, chain, verdict}] and inject the rules into firewall instead of dropping entire 100.64/10

rational here: https://github.com/tailscale/tailscale/issues/18758#issuecomment-3927300455

closes https://github.com/tailscale/tailscale/issues/1381 https://github.com/tailscale/tailscale/issues/3104 https://github.com/tailscale/tailscale/issues/12555 https://github.com/tailscale/tailscale/issues/18758 

tested in my tailnet ~10 machines affected by this and working fine 
- https://github.com/stepbrobd/dotfiles/commit/ef0cac02a82ec4969bff02b850cdbf6d3c9f1bd5
- https://github.com/stepbrobd/dotfiles/commit/6e95bb5e74f98c8fcd94b993a6f9fc6af8eaaf90