### PR TITLE
.: permit running binary built with TS_GO_NEXT=1

### DIFF
--- a/assert_ts_toolchain_match.go
+++ b/assert_ts_toolchain_match.go
@@ -17,10 +17,10 @@ func init() {
 		panic("binary built with tailscale_go build tag but failed to read build info or find tailscale.toolchain.rev in build info")
 	}
 	want := strings.TrimSpace(GoToolchainRev)
-	if os.Getenv("TS_GO_NEXT") == "1" {
-		want = strings.TrimSpace(GoToolchainNextRev)
-	}
-	if tsRev != want {
+	// Also permit the "next" toolchain rev, which is used in the main branch and will eventually become the new "current" rev.
+	// This allows building with TS_GO_NEXT=1 and then running the resulting binary without TS_GO_NEXT=1.
+	wantAlt := strings.TrimSpace(GoToolchainNextRev)
+	if tsRev != want && tsRev != wantAlt {
 		if os.Getenv("TS_PERMIT_TOOLCHAIN_MISMATCH") == "1" {
 			fmt.Fprintf(os.Stderr, "tailscale.toolchain.rev = %q, want %q; but ignoring due to TS_PERMIT_TOOLCHAIN_MISMATCH=1\n", tsRev, want)
 			return


### PR DESCRIPTION
The old check was too aggressive and required TS_GO_NEXT=1 at runtime
as well, which is too strict and onerous.

This is a sanity check only (and an outdated one, at that); it's okay for
it to be slightly loose and permit two possible values. If either is working,
we're already way past the old bug that this was introduced to catch.

Updates tailscale/corp#36382
