### PR TITLE
cmd/containerboot, net/dns/resolver: remove unused funcs in tests

### DIFF
--- a/cmd/containerboot/main_test.go
+++ b/cmd/containerboot/main_test.go
@@ -1603,12 +1603,6 @@ func (k *kubeServer) serveSecret(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func mustBase64(t *testing.T, v any) string {
-	b := mustJSON(t, v)
-	s := base64.StdEncoding.WithPadding('=').EncodeToString(b)
-	return s
-}
-
 func mustJSON(t *testing.T, v any) []byte {
 	b, err := json.Marshal(v)
 	if err != nil {

--- a/net/dns/resolver/forwarder_test.go
+++ b/net/dns/resolver/forwarder_test.go
@@ -595,12 +595,6 @@ func beVerbose(f *forwarder) {
 	f.verboseFwd = true
 }
 
-// makeTestRequestWithEDNS returns a new TypeTXT request for the given domain with EDNS buffer size.
-// Deprecated: Use makeTestRequest with queryType and ednsSize parameters instead.
-func makeTestRequestWithEDNS(tb testing.TB, domain string, ednsSize uint16) []byte {
-	return makeTestRequest(tb, domain, dns.TypeTXT, ednsSize)
-}
-
 // makeEDNSResponse creates a DNS response of approximately the specified size
 // with TXT records and an OPT record. The response will NOT have the TC flag set
 // (simulating a non-compliant server that doesn't set TC when response exceeds EDNS buffer).


### PR DESCRIPTION
staticcheck was complaining about it on a PR
I sent: https://github.com/tailscale/tailscale/actions/runs/22408882872/job/64876543467?pr=18804

Updates #cleanup
Updates #18157
