### PR TITLE
prober: fix race condition in TestExcludeInRunAll

### DIFF
--- a/prober/prober_test.go
+++ b/prober/prober_test.go
@@ -793,9 +793,14 @@ func TestExcludeInRunAll(t *testing.T) {
 		},
 	}
 
-	p.Run("includedProbe", probeInterval, nil, FuncProbe(func(context.Context) error { return nil }))
-	p.Run("excludedProbe", probeInterval, nil, FuncProbe(func(context.Context) error { return nil }))
-	p.Run("excludedOtherProbe", probeInterval, nil, FuncProbe(func(context.Context) error { return nil }))
+	includedProbe := p.Run("includedProbe", probeInterval, nil, FuncProbe(func(context.Context) error { return nil }))
+	excludedProbe := p.Run("excludedProbe", probeInterval, nil, FuncProbe(func(context.Context) error { return nil }))
+	excludedOtherProbe := p.Run("excludedOtherProbe", probeInterval, nil, FuncProbe(func(context.Context) error { return nil }))
+
+	// Wait for all probes to complete their initial run
+	<-includedProbe.stopped
+	<-excludedProbe.stopped
+	<-excludedOtherProbe.stopped
 
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)


### PR DESCRIPTION
The test was making HTTP requests before waiting for probes to complete their initial run in "once" mode. This created a race where sometimes the probe's previous state was empty (0 results) and sometimes it had one result, causing inconsistent RecentResults and PreviousSuccessRatio values.

Fixed by waiting for all probes to complete via their stopped channels before making HTTP requests, matching the pattern used in other tests like TestProberRunHandler and TestRunAllHandler.

Fixes #18806