### PR TITLE
wgengine/magicsock: only run derpActiveFunc after connecting to DERP

### DIFF
--- a/wgengine/magicsock/derp.go
+++ b/wgengine/magicsock/derp.go
@@ -436,7 +436,14 @@ func (c *Conn) derpWriteChanForRegion(regionID int, peer key.NodePublic) chan de
 
 	go c.runDerpReader(ctx, regionID, dc, wg, startGate)
 	go c.runDerpWriter(ctx, dc, ch, wg, startGate)
-	go c.derpActiveFunc()
+	go func() {
+		select {
+		case <-ctx.Done():
+			return
+		case <-startGate:
+			c.derpActiveFunc()
+		}
+	}()
 
 	return ad.writeCh
 }


### PR DESCRIPTION
derpActiveFunc was being called immediately as a bare goroutine, before startGate was resolved. For the firstDerp case, startGate is c.derpStarted which only closes after dc.Connect() completes, so derpActiveFunc was firing before the DERP connection existed.

We now block it with the same logic used by runDerpReader and by runDerpWriter.

Updates: #18810