### PR TITLE
tempfork: suppress staticcheck warnings

### DIFF
--- a/tempfork/staticcheck.conf
+++ b/tempfork/staticcheck.conf
@@ -1,0 +1,2 @@
+# suppress staticcheck warnings that stem from the upstream source.
+checks = ["inherit", "-U1000", "-SA4006", "-SA4011", "-SA9001"]


### PR DESCRIPTION
Add a staticcheck.conf to the tempfork directory to suppress noisy warnings.

Fixes #18813