### PR TITLE
.github/workflows: enable natlab in CI

### DIFF
--- a/.github/workflows/natlab-integrationtest.yml
+++ b/.github/workflows/natlab-integrationtest.yml
@@ -7,9 +7,15 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  push:
+    branches:
+      - "main"
+      - "release-branch/*"
   pull_request:
-    paths:
-      - "tstest/integration/nat/nat_test.go"
+    # all PRs on all branches
+  merge_group:
+    branches:
+      - "main"
 jobs:
   natlab-integrationtest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
After fixing the flakey tests in #18811 and #18814 we can enable running
the natlab testsuite running on CI generally.

Fixes #18810

Signed-off-by: Claus Lensbøl <claus@tailscale.com>
