### PR TITLE
.github/actions/go-cache: check for pre-built cigocacher

### DIFF
--- a/.github/actions/go-cache/action.sh
+++ b/.github/actions/go-cache/action.sh
@@ -23,22 +23,27 @@ if [ -z "${URL:-}" ]; then
     exit 0
 fi
 
-GOPATH=$(command -v go || true)
-if [ -z "${GOPATH}" ]; then
-  if [ ! -f "tool/go" ]; then
-    echo "Go not available, unable to proceed"
-    exit 1
-  fi
-  GOPATH="./tool/go"
-fi
+BIN_PATH="$(PATH="$PATH:$HOME/bin" command -v cigocacher || true)"
+if [ -z "${BIN_PATH}" ]; then
+  echo "cigocacher not found in PATH, attempting to build or fetch it"
 
-BIN_PATH="${RUNNER_TEMP:-/tmp}/cigocacher$(${GOPATH} env GOEXE)"
-if [ -d "cmd/cigocacher" ]; then
-  echo "cmd/cigocacher found locally, building from local source"
-  "${GOPATH}" build -o "${BIN_PATH}" ./cmd/cigocacher
-else
-  echo "cmd/cigocacher not found locally, fetching from tailscale.com/cmd/cigocacher"
-  "${GOPATH}" build -o "${BIN_PATH}" tailscale.com/cmd/cigocacher
+  GOPATH=$(command -v go || true)
+  if [ -z "${GOPATH}" ]; then
+    if [ ! -f "tool/go" ]; then
+      echo "Go not available, unable to proceed"
+      exit 1
+    fi
+    GOPATH="./tool/go"
+  fi
+
+  BIN_PATH="${RUNNER_TEMP:-/tmp}/cigocacher$(${GOPATH} env GOEXE)"
+  if [ -d "cmd/cigocacher" ]; then
+    echo "cmd/cigocacher found locally, building from local source"
+    "${GOPATH}" build -o "${BIN_PATH}" ./cmd/cigocacher
+  else
+    echo "cmd/cigocacher not found locally, fetching from tailscale.com/cmd/cigocacher"
+    "${GOPATH}" build -o "${BIN_PATH}" tailscale.com/cmd/cigocacher
+  fi
 fi
 
 CIGOCACHER_TOKEN="$("${BIN_PATH}" --auth --cigocached-url "${URL}" --cigocached-host "${HOST}" )"


### PR DESCRIPTION
Some CI runner images now have cigocacher baked in. Skip building if it's already present.

Updates tailscale/corp#35667

Change-Id: I5ea0d606d44b1373bc1c8f7bca4ab780e763e2a9