### PR TITLE
cmd/k8s-proxy: set tsnet.Server.Port from PORT env var

### DIFF
--- a/cmd/k8s-proxy/k8s-proxy.go
+++ b/cmd/k8s-proxy/k8s-proxy.go
@@ -72,6 +72,7 @@ func run(logger *zap.SugaredLogger) error {
 		configPath = os.Getenv("TS_K8S_PROXY_CONFIG")
 		podUID     = os.Getenv("POD_UID")
 		podIP      = os.Getenv("POD_IP")
+		port       = os.Getenv("PORT")
 	)
 	if configPath == "" {
 		return errors.New("TS_K8S_PROXY_CONFIG unset")
@@ -176,11 +177,21 @@ func run(logger *zap.SugaredLogger) error {
 		authKey = *cfg.Parsed.AuthKey
 	}
 
+	var tsPort uint16
+	if port != "" {
+		p, err := strconv.ParseUint(port, 10, 16)
+		if err != nil {
+			return fmt.Errorf("invalid PORT %q: %w", port, err)
+		}
+		tsPort = uint16(p)
+	}
+
 	ts := &tsnet.Server{
 		Logf:     logger.Named("tsnet").Debugf,
 		UserLogf: logger.Named("tsnet").Infof,
 		Store:    st,
 		AuthKey:  authKey,
+		Port:     tsPort,
 	}
 
 	if cfg.Parsed.ServerURL != nil {


### PR DESCRIPTION
The k8s-operator sets the PORT environment variable on k8s-proxy pods and creates NodePort services targeting that port for static endpoints. However, the k8s-proxy binary never passes PORT to tsnet.Server.Port, so magicsock binds to a random port instead. Inbound WireGuard packets arriving via the NodePort are dropped because nothing is listening on the expected port, and direct connections are never established.

The static endpoint addresses are correctly advertised to the coordination server (via TS_DEBUG_PRETENDPOINT), so peers attempt direct connections to the NodePort -- but the handshake never completes and traffic falls back to DERP.

Contributes to #13358