### PR TITLE
.github/workflows: rename tidy workflow to match what it is

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -806,7 +806,7 @@ jobs:
         echo
         git diff --name-only --exit-code || (echo "The files above need updating. Please run 'go generate'."; exit 1)
 
-  go_mod_tidy:
+  make_tidy:
     runs-on: ubuntu-24.04
     needs: gomod-cache
     steps:
@@ -820,7 +820,7 @@ jobs:
         path: gomodcache
         key: ${{ needs.gomod-cache.outputs.cache-key }}
         enableCrossOsArchive: true
-    - name: check that 'go mod tidy' is clean
+    - name: check that 'make tidy' is clean
       working-directory: src
       run: |
         make tidy
@@ -921,7 +921,7 @@ jobs:
       - fuzz
       - depaware
       - go_generate
-      - go_mod_tidy
+      - make_tidy
       - licenses
       - staticcheck
     runs-on: ubuntu-24.04
@@ -967,7 +967,7 @@ jobs:
       - fuzz
       - depaware
       - go_generate
-      - go_mod_tidy
+      - make_tidy
       - licenses
       - staticcheck
     steps:
@@ -991,7 +991,7 @@ jobs:
       - tailscale_go
       - depaware
       - go_generate
-      - go_mod_tidy
+      - make_tidy
       - licenses
       - staticcheck
     steps:


### PR DESCRIPTION
I was confused when everything I was reading in the CI failure was saying `go mod tidy`, but the thing that was actually failing was related to nix flakes. Rename the pipeline and step name to the `make tidy` that it actually runs.

Updates #16637