### PR TITLE
wgengine/magicsoc,net/tstun: put disco key advertisement behind a nob

### DIFF
--- a/net/tstun/wrap.go
+++ b/net/tstun/wrap.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tailscale/wireguard-go/tun"
 	"go4.org/mem"
 	"tailscale.com/disco"
+	"tailscale.com/envknob"
 	"tailscale.com/feature/buildfeatures"
 	"tailscale.com/net/packet"
 	"tailscale.com/net/packet/checksum"
@@ -1157,10 +1158,12 @@ func (t *Wrapper) filterPacketInboundFromWireGuard(p *packet.Parsed, captHook pa
 			t.injectOutboundPong(p, pingReq)
 			return filter.DropSilently, gro
 		} else if discoKeyAdvert, ok := p.AsTSMPDiscoAdvertisement(); ok {
-			t.discoKeyAdvertisementPub.Publish(DiscoKeyAdvertisement{
-				Src: discoKeyAdvert.Src,
-				Key: discoKeyAdvert.Key,
-			})
+			if buildfeatures.HasCacheNetMap && envknob.Bool("TS_USE_CACHED_NETMAP") {
+				t.discoKeyAdvertisementPub.Publish(DiscoKeyAdvertisement{
+					Src: discoKeyAdvert.Src,
+					Key: discoKeyAdvert.Key,
+				})
+			}
 			return filter.DropSilently, gro
 		} else if data, ok := p.AsTSMPPong(); ok {
 			if f := t.OnTSMPPongReceived; f != nil {

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -4299,6 +4299,10 @@ type NewDiscoKeyAvailable struct {
 //
 // We do not need the Conn to be locked, but the endpoint should be.
 func (c *Conn) maybeSendTSMPDiscoAdvert(de *endpoint) {
+	if !buildfeatures.HasCacheNetMap || !envknob.Bool("TS_USE_CACHED_NETMAP") {
+		return
+	}
+
 	de.mu.Lock()
 	defer de.mu.Unlock()
 	if !de.sentDiscoKeyAdvertisement {


### PR DESCRIPTION
To be less spammy in stable, add a nob that disables the creation and
processing of TSMPDiscoKeyAdvertisements until we have a proper rollout
mechanism.

Updates #12639

Signed-off-by: Claus Lensbøl <claus@tailscale.com>
