### PR TITLE
cmd/tailscale: tidy up the error message when initialization fails

### DIFF
--- a/cmd/tailscale/cli/network-lock.go
+++ b/cmd/tailscale/cli/network-lock.go
@@ -186,7 +186,19 @@ func runNetworkLockInit(ctx context.Context, args []string) error {
 	// The state returned by NetworkLockInit likely doesn't contain the initialized state,
 	// because that has to tick through from netmaps.
 	if _, err := localClient.NetworkLockInit(ctx, keys, disablementValues, supportDisablement); err != nil {
-		return err
+
+		// Tidy up the error before it's printed to the user.
+		//
+		// Parsing the error as a string isn't ideal, but it's hard to treat this as a more
+		// structured error -- it's bubbled through half a dozen layers and been sent across
+		// two HTTP responses. If the error changes and we start missing this branch, it's
+		// not a disaster, because the key information will still be presented.
+		tkaInitPrefix := "error: 500 Internal Server Error: initialization failed: tka init-begin RPC: request returned (403):"
+		if strings.HasPrefix(err.Error(), tkaInitPrefix) {
+			return fmt.Errorf("%s", strings.Replace(err.Error(), tkaInitPrefix, "Initializing Tailnet Lock failed:", 1))
+		} else {
+			return fmt.Errorf("Initializing Tailnet Lock failed: %w", err)
+		}
 	}
 
 	fmt.Print(successMsg.String())


### PR DESCRIPTION
Before:

> error: 500 Internal Server Error: initialization failed: tka init-begin RPC: request returned (403): this is a tagged device; original user not found

After:

> Initializing Tailnet Lock failed: this is a tagged device; original user not found

Reduce the filler text which comes from our many levels of error reporting, and highlight the bit that's actually meaningful to the user.

Updates tailscale/corp#37841