### PR TITLE
net/udprelay: use GOMAXPROCS instead of NumCPU for socket count

### DIFF
--- a/net/udprelay/server.go
+++ b/net/udprelay/server.go
@@ -651,8 +651,9 @@ func trySetSOMark(logf logger.Logf, netMon *netmon.Monitor, network, address str
 // single packet syscall operations.
 func (s *Server) bindSockets(desiredPort uint16) error {
 	// maxSocketsPerAF is a conservative starting point, but is somewhat
-	// arbitrary.
-	maxSocketsPerAF := min(16, runtime.NumCPU())
+	// arbitrary. Use GOMAXPROCS rather than NumCPU as it is container-aware
+	// and respects CPU limits/quotas set via cgroups.
+	maxSocketsPerAF := min(16, runtime.GOMAXPROCS(0))
 	listenConfig := &net.ListenConfig{
 		Control: func(network, address string, c syscall.RawConn) error {
 			trySetReusePort(network, address, c)


### PR DESCRIPTION
## Why

`NumCPU()` returns the host's CPU count, which in containerized environments is the node's CPU count rather than the container's limit. 

This causes excessive memory allocation in pods with low CPU requests running on large nodes, as each socket's `packetReadLoop` allocates significant buffer memory (~10MB per socket). For example, a pod requesting 0.5 CPU on a 96-core node would create 16 sockets instead of 1.

## What

Replace `runtime.NumCPU()` with `runtime.GOMAXPROCS(0)` in `bindSockets()` to determine the number of UDP sockets per address family.

GOMAXPROCS is container-aware since Go 1.25 and respects CPU limits set via cgroups (see https://go.dev/blog/container-aware-gomaxprocs)



Fixes #18774