### PR TITLE
util/osuser: extend id command fallback for group IDs to freebsd

### DIFF
--- a/util/osuser/group_ids.go
+++ b/util/osuser/group_ids.go
@@ -23,7 +23,7 @@ func GetGroupIds(user *user.User) ([]string, error) {
 		return nil, nil
 	}
 
-	if runtime.GOOS != "linux" {
+	if runtime.GOOS != "linux" && runtime.GOOS != "freebsd" {
 		return user.GroupIds()
 	}
 
@@ -46,13 +46,24 @@ func getGroupIdsWithId(usernameOrUID string) ([]string, error) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "id", "-Gz", usernameOrUID)
-	out, err := cmd.Output()
+	if runtime.GOOS == "freebsd" {
+		cmd = exec.CommandContext(ctx, "id", "-G", usernameOrUID)
+	}
+
+	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("running 'id' command: %w", err)
 	}
+
 	return parseGroupIds(out), nil
 }
 
 func parseGroupIds(cmdOutput []byte) []string {
-	return strings.Split(strings.Trim(string(cmdOutput), "\n\x00"), "\x00")
+	s := strings.TrimSpace(string(cmdOutput))
+	// Parse NUL-delimited output.
+	if strings.ContainsRune(s, '\x00') {
+		return strings.Split(strings.Trim(s, "\x00"), "\x00")
+	}
+	// Parse whitespace-delimited output.
+	return strings.Fields(s)
 }

--- a/util/osuser/group_ids_test.go
+++ b/util/osuser/group_ids_test.go
@@ -15,7 +15,9 @@ func TestParseGroupIds(t *testing.T) {
 	}{
 		{"5000\x005001\n", []string{"5000", "5001"}},
 		{"5000\n", []string{"5000"}},
-		{"\n", []string{""}},
+		{"\n", []string{}},
+		{"5000 5001 5002\n", []string{"5000", "5001", "5002"}},
+		{"5000\t5001\n", []string{"5000", "5001"}},
 	}
 	for _, test := range tests {
 		actual := parseGroupIds([]byte(test.in))


### PR DESCRIPTION
Users on FreeBSD run into a similar problem as has been reported for Linux #11682 and fixed in #11682: because the tailscaled binaries that we distribute are static and don't link cgo tailscaled fails to fetch group IDs that are returned via NSS when spawning an ssh child process.
    
This change extends the fallback on the 'id' command that was put in place as part of #11682 to FreeBSD. More precisely, we try to fetch the group IDs with the 'id' command first, and only if that fails do we fall back on the logic in the os/user package.
 
Updates #14025 

Reproduced on a FreeBSD 14 VM (UTM) by creating a user `malcolm` with a local group with id 1000 and LDAP-provided group with id 666.

**Before (current behavior)**

Client _without the change_ (installed from package registries or built with CGO_ENABLED=0):

Attempting to access a directory `/srv/repro` owned by the LDAP-provided group with tailscale ssh as user `malcolm` from laptop runs into permission denied.
```
gesa@gesa-tsmbp% tailscale ssh malcolm@freebsd-1 -- 'id -G; cd /srv/repro; pwd'
1000
/home/malcolm
cd: /srv/repro: Permission denied
```
Tailscaled ssh server logs indicate that only the local group ID is forwarded to the child process (`--groups=1000`) 
```
ssh-conn-20260305T134810-90bafe454b: handling conn: 100.106.13.10:61958->malcolm@100.110.106.9:22
ssh-conn-20260305T134810-90bafe454b: starting session: sess-20260305T134811-fe96b70521
ssh-session(sess-20260305T134811-fe96b70521): handling new SSH connection from neinkeinkaffee@github (100.106.13.10) to ssh-user "malcolm"
ssh-session(sess-20260305T134811-fe96b70521): access granted to neinkeinkaffee@github as ssh-user "malcolm"
ssh-session(sess-20260305T134811-fe96b70521): starting non-pty command: [/tmp/tsd be-child ssh --login-shell=/bin/sh --uid=2993 --gid=1000 --groups=1000 --local-user=malcolm --home-dir=/home/malcolm --remote-user=neinkeinkaffee@github --remote-ip=100.106.13.10 --has-tty=false --tty-name= --force-v1-behavior --cmd=id -G; cd /srv/repro; pwd]
ssh-session(sess-20260305T134811-fe96b70521): Session complete
```

**After (behavior with this change)**

Client _with the change_ (built with CGO_ENABLED=0):

Accessing a directory `/srv/repro` owned by the LDAP-provided group with tailscale ssh as user `malcolm` from laptop succeeds.
```
gesa@gesa-tsmbp tailscale % tailscale ssh malcolm@freebsd-2 -- 'id -G; cd /srv/repro; pwd'
1000 666
/srv/repro
```

Tailscaled ssh server logs indicate that both the local and the LDAP-provided group ID are forwarded to the child process (`--groups=1000,666`) 
```
ssh-conn-20260305T135203-b33c099247: handling conn: 100.106.13.10:62210->malcolm@100.96.18.2:22
ssh-conn-20260305T135203-b33c099247: starting session: sess-20260305T135203-51b5e4d83c
ssh-session(sess-20260305T135203-51b5e4d83c): handling new SSH connection from neinkeinkaffee@github (100.106.13.10) to ssh-user "malcolm"
ssh-session(sess-20260305T135203-51b5e4d83c): access granted to neinkeinkaffee@github as ssh-user "malcolm"
ssh-session(sess-20260305T135203-51b5e4d83c): starting non-pty command: [/tmp/tsd1 be-child ssh --login-shell=/bin/sh --uid=2993 --gid=1000 --groups=1000,666 --local-user=malcolm --home-dir=/home/malcolm --remote-user=neinkeinkaffee@github --remote-ip=100.106.13.10 --has-tty=false --tty-name= --force-v1-behavior --cmd=id -G; cd /srv/repro; pwd]
ssh-session(sess-20260305T135203-51b5e4d83c): Session complete
```