### PR TITLE
all: fix typos in comments

### DIFF
--- a/cmd/tailscale/cli/serve_v2.go
+++ b/cmd/tailscale/cli/serve_v2.go
@@ -1096,7 +1096,7 @@ func isRemote(target string) bool {
 		target = "tmp://" + target
 	}
 
-	// make sure we can parse the target, wether it's a full URL or just a host:port
+	// make sure we can parse the target, whether it's a full URL or just a host:port
 	u, err := url.ParseRequestURI(target)
 	if err != nil {
 		// If we can't parse the target, it doesn't matter if it's remote or not

--- a/drive/driveimpl/remote_impl.go
+++ b/drive/driveimpl/remote_impl.go
@@ -415,7 +415,7 @@ var writeMethods = map[string]bool{
 	"DELETE":    true,
 }
 
-// canSudo checks wether we can sudo -u the configured executable as the
+// canSudo checks whether we can sudo -u the configured executable as the
 // configured user by attempting to call the executable with the '-h' flag to
 // print help.
 func (s *userServer) canSudo() bool {

--- a/ipn/ipnlocal/network-lock.go
+++ b/ipn/ipnlocal/network-lock.go
@@ -407,7 +407,7 @@ func (b *LocalBackend) tkaSyncLocked(ourNodeKey key.NodePublic) error {
 	// has updates for us, or we have updates for the control plane.
 	//
 	// TODO(tom): Do we want to keep processing even if the Inform fails? Need
-	// to think through if theres holdback concerns here or not.
+	// to think through if there's holdback concerns here or not.
 	if len(offerResp.MissingAUMs) > 0 {
 		aums := make([]tka.AUM, len(offerResp.MissingAUMs))
 		for i, a := range offerResp.MissingAUMs {

--- a/ipn/ipnserver/server.go
+++ b/ipn/ipnserver/server.go
@@ -429,7 +429,7 @@ func (s *Server) addActiveHTTPRequest(req *http.Request, actor ipnauth.Actor) (o
 	if len(s.activeReqs) == 1 {
 		if envknob.GOOS() == "windows" && !actor.IsLocalSystem() {
 			// Tell the LocalBackend about the identity we're now running as,
-			// unless its the SYSTEM user. That user is not a real account and
+			// unless it's the SYSTEM user. That user is not a real account and
 			// doesn't have a home directory.
 			lb.SetCurrentUser(actor)
 		}

--- a/net/socks5/socks5_test.go
+++ b/net/socks5/socks5_test.go
@@ -222,7 +222,7 @@ func TestUDP(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		_, err = conn.Write(append([]byte{socks5Version, byte(udpAssociate), 0x00}, targetAddrPkt...)) // client reqeust
+		_, err = conn.Write(append([]byte{socks5Version, byte(udpAssociate), 0x00}, targetAddrPkt...)) // client request
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/safesocket/safesocket_darwin.go
+++ b/safesocket/safesocket_darwin.go
@@ -102,8 +102,8 @@ func SetCredentials(token string, port int) {
 
 // InitListenerDarwin initializes the listener for the CLI commands
 // and localapi HTTP server and sets the port/token.  This will override
-// any credentials set explicitly via SetCredentials().  Calling this mulitple times
-// has no effect.  The listener and it's corresponding token/port is initialized only once.
+// any credentials set explicitly via SetCredentials().  Calling this multiple times
+// has no effect.  The listener and its corresponding token/port is initialized only once.
 func InitListenerDarwin(sharedDir string) (*net.Listener, error) {
 	ssd.mu.Lock()
 	defer ssd.mu.Unlock()

--- a/tka/chaintest_test.go
+++ b/tka/chaintest_test.go
@@ -203,9 +203,9 @@ func (c *testChain) buildChain() {
 	}
 
 	// AUMs with a parent need to know their hash, so we
-	// only compute AUMs who's parents have been computed
+	// only compute AUMs whose parents have been computed
 	// each iteration. Since at least the genesis AUM
-	// had no parent, theres always a path to completion
+	// had no parent, there's always a path to completion
 	// in O(n+1) where n is the number of AUMs.
 	c.AUMs = make(map[string]AUM, len(c.Nodes))
 	c.AUMHashes = make(map[string]AUMHash, len(c.Nodes))

--- a/tka/tailchonk.go
+++ b/tka/tailchonk.go
@@ -715,7 +715,7 @@ func markActiveChain(storage Chonk, verdict map[AUMHash]retainState, minChain in
 
 		parent, hasParent := next.Parent()
 		if !hasParent {
-			// Genesis AUM (beginning of time). The chain isnt long enough to need truncating.
+			// Genesis AUM (beginning of time). The chain isn't long enough to need truncating.
 			return h, nil
 		}
 

--- a/tka/tailchonk_test.go
+++ b/tka/tailchonk_test.go
@@ -309,7 +309,7 @@ func TestMarkDescendantAUMs(t *testing.T) {
 	}
 	for _, h := range []AUMHash{hs["genesis"], hs["B"], hs["D"]} {
 		if (verdict[h] & retainStateLeaf) != 0 {
-			t.Errorf("%v was marked as a descendant and shouldnt be", h)
+			t.Errorf("%v was marked as a descendant and shouldn't be", h)
 		}
 	}
 }

--- a/tstest/natlab/vnet/conf.go
+++ b/tstest/natlab/vnet/conf.go
@@ -349,7 +349,7 @@ func (n *Network) SetBlackholedIPv4(v bool) {
 	n.breakWAN4 = v
 }
 
-// SetPostConnectControlBlackhole sets wether the network should blackhole all
+// SetPostConnectControlBlackhole sets whether the network should blackhole all
 // traffic to the control server after the clients have connected.
 func (n *Network) SetPostConnectControlBlackhole(v bool) {
 	n.postConnectBlackholeControl = v

--- a/tstest/natlab/vnet/vnet.go
+++ b/tstest/natlab/vnet/vnet.go
@@ -579,7 +579,7 @@ func (n *network) MACOfIP(ip netip.Addr) (_ MAC, ok bool) {
 	return MAC{}, false
 }
 
-// SetControlBlackholed sets wether traffic to control should be blackholed for the
+// SetControlBlackholed sets whether traffic to control should be blackholed for the
 // network.
 func (n *network) SetControlBlackholed(v bool) {
 	n.blackholeControl = v

--- a/tstest/tailmac/README.md
+++ b/tstest/tailmac/README.md
@@ -53,7 +53,7 @@ All vm images, restore images, block device files, save states, and other suppor
 
 Each vm gets its own directory.  These can be archived for posterity to preserve a particular image and/or state.
 The mere existence of a directory containing all of the required files in ~/VM.bundle is sufficient for tailmac to 
-be able to see and run it.  ~/VM.bundle and it's contents *is* tailmac's state.  No other state is maintained elsewhere.
+be able to see and run it.  ~/VM.bundle and its contents *is* tailmac's state.  No other state is maintained elsewhere.
 
 Each vm has its own custom configuration which can be modified while the vm is idle.  It's simple JSON - you may
 modify this directly, or using 'tailmac configure'.

--- a/types/key/nl.go
+++ b/types/key/nl.go
@@ -119,7 +119,7 @@ type NLPublic struct {
 // NLPublicFromEd25519Unsafe converts an ed25519 public key into
 // a type of NLPublic.
 //
-// New uses of this function should be avoided, as its possible to
+// New uses of this function should be avoided, as it's possible to
 // accidentally construct an NLPublic from a non network-lock key.
 func NLPublicFromEd25519Unsafe(public ed25519.PublicKey) NLPublic {
 	var out NLPublic

--- a/wgengine/magicsock/endpoint.go
+++ b/wgengine/magicsock/endpoint.go
@@ -80,7 +80,7 @@ type endpoint struct {
 	lastSendAny               mono.Time      // last time there were outgoing packets sent this peer from any trigger, internal or external to magicsock
 	lastFullPing              mono.Time      // last time we pinged all disco or wireguard only endpoints
 	lastUDPRelayPathDiscovery mono.Time      // last time we ran UDP relay path discovery
-	sentDiscoKeyAdvertisement bool           // wether we sent a TSMPDiscoAdvertisement or not to this endpoint
+	sentDiscoKeyAdvertisement bool           // whether we sent a TSMPDiscoAdvertisement or not to this endpoint
 	derpAddr                  netip.AddrPort // fallback/bootstrap path, if non-zero (non-zero for well-behaved clients)
 
 	bestAddr           addrQuality // best non-DERP path; zero if none; mutate via setBestAddrLocked()


### PR DESCRIPTION
Fix its/it's, who's/whose, wether/whether, missing apostrophes
in contractions, and other misspellings across the codebase.

Updates #cleanup
