### PR TITLE
cmd/testwrapper: make test tolerant of a GOEXPERIMENT being set

### DIFF
--- a/cmd/testwrapper/testwrapper_test.go
+++ b/cmd/testwrapper/testwrapper_test.go
@@ -220,11 +220,14 @@ func TestCached(t *testing.T) {
 
 	// Construct our trivial package.
 	pkgDir := t.TempDir()
+	goVersion := runtime.Version()
+	goVersion = strings.TrimPrefix(goVersion, "go")
+	goVersion, _, _ = strings.Cut(goVersion, "-X:") // map 1.26.1-X:nogreenteagc to 1.26.1
+
 	goMod := fmt.Sprintf(`module example.com
 
 go %s
-`, runtime.Version()[2:]) // strip leading "go"
-
+`, goVersion)
 	test := `package main
 import "testing"
 


### PR DESCRIPTION
Otherwise it generates an syntactically invalid go.mod file
and subsequently fails.

Updates #18884
