### PR TITLE
cmd/tailscale: add 'force-hostname' flag to allow hostname override

### DIFF
--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -1115,6 +1115,7 @@ func TestUpdatePrefs(t *testing.T) {
 				ExitNodeIDSet:             true,
 				ExitNodeIPSet:             true,
 				HostnameSet:               true,
+				ForceHostnameSet:          true,
 				NetfilterModeSet:          true,
 				NoSNATSet:                 true,
 				NoStatefulFilteringSet:    true,

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -115,6 +115,7 @@ func newUpFlagSet(goos string, upArgs *upArgsT, cmd string) *flag.FlagSet {
 	upf.BoolVar(&upArgs.runSSH, "ssh", false, "run an SSH server, permitting access per tailnet admin's declared policy")
 	upf.StringVar(&upArgs.advertiseTags, "advertise-tags", "", "comma-separated ACL tags to request; each must start with \"tag:\" (e.g. \"tag:eng,tag:montreal,tag:ssh\")")
 	upf.StringVar(&upArgs.hostname, "hostname", "", "hostname to use instead of the one provided by the OS")
+	upf.BoolVar(&upArgs.forceHostname, "force-hostname", false, "if the hostname is already taken (e.g. by an offline node), ask the control server to use it anyway (existing device will be removed)")
 	upf.StringVar(&upArgs.advertiseRoutes, "advertise-routes", "", "routes to advertise to other nodes (comma-separated, e.g. \"10.0.0.0/8,192.168.0.0/24\") or empty string to not advertise routes")
 	upf.BoolVar(&upArgs.advertiseConnector, "advertise-connector", false, "advertise this node as an app connector")
 	upf.BoolVar(&upArgs.advertiseDefaultRoute, "advertise-exit-node", false, "offer to be an exit node for internet traffic for the tailnet")
@@ -200,6 +201,7 @@ type upArgsT struct {
 	clientSecretOrFile     string // "secret" or "file:/path/to/secret"
 	idTokenOrFile          string // "secret" or "file:/path/to/secret"
 	hostname               string
+	forceHostname          bool
 	opUser                 string
 	json                   bool
 	timeout                time.Duration
@@ -349,6 +351,7 @@ func prefsFromUpArgs(upArgs upArgsT, warnf logger.Logf, st *ipnstate.Status, goo
 	prefs.AdvertiseRoutes = routes
 	prefs.AdvertiseTags = tags
 	prefs.Hostname = upArgs.hostname
+	prefs.ForceHostname = upArgs.forceHostname
 	prefs.ForceDaemon = upArgs.forceDaemon
 	prefs.OperatorUser = upArgs.opUser
 	prefs.ProfileName = upArgs.profileName
@@ -886,6 +889,7 @@ func init() {
 	addPrefFlagMapping("accept-routes", "RouteAll")
 	addPrefFlagMapping("advertise-tags", "AdvertiseTags")
 	addPrefFlagMapping("hostname", "Hostname")
+	addPrefFlagMapping("force-hostname", "ForceHostname")
 	addPrefFlagMapping("login-server", "ControlURL")
 	addPrefFlagMapping("netfilter-mode", "NetfilterMode")
 	addPrefFlagMapping("shields-up", "ShieldsUp")
@@ -1152,6 +1156,8 @@ func prefsToFlags(env upCheckEnv, prefs *ipn.Prefs) (flagVal map[string]any) {
 			set(strings.Join(prefs.AdvertiseTags, ","))
 		case "hostname":
 			set(prefs.Hostname)
+		case "force-hostname":
+			set(prefs.ForceHostname)
 		case "operator":
 			set(prefs.OperatorUser)
 		case "advertise-routes":

--- a/cmd/tailscale/cli/up_test.go
+++ b/cmd/tailscale/cli/up_test.go
@@ -25,6 +25,7 @@ var validUpFlags = set.Of(
 	"auth-key",
 	"exit-node",
 	"exit-node-allow-lan-access",
+	"force-hostname",
 	"force-reauth",
 	"host-routes",
 	"hostname",

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -85,6 +85,7 @@ var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	ShieldsUp                  bool
 	AdvertiseTags              []string
 	Hostname                   string
+	ForceHostname              bool
 	NotepadURLs                bool
 	ForceDaemon                bool
 	Egg                        bool

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -325,6 +325,8 @@ func (v PrefsView) AdvertiseTags() views.Slice[string] { return views.SliceOf(v.
 // not set, os.Hostname is used.
 func (v PrefsView) Hostname() string { return v.ж.Hostname }
 
+func (v PrefsView) ForceHostname() bool { return v.ж.ForceHostname }
+
 // NotepadURLs is a debugging setting that opens OAuth URLs in
 // notepad.exe on Windows, rather than loading them in a browser.
 //
@@ -488,6 +490,7 @@ var _PrefsViewNeedsRegeneration = Prefs(struct {
 	ShieldsUp                  bool
 	AdvertiseTags              []string
 	Hostname                   string
+	ForceHostname              bool
 	NotepadURLs                bool
 	ForceDaemon                bool
 	Egg                        bool

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -5632,6 +5632,7 @@ func (b *LocalBackend) applyPrefsToHostinfoLocked(hi *tailcfg.Hostinfo, prefs ip
 	if h := prefs.Hostname(); h != "" {
 		hi.Hostname = h
 	}
+	hi.ForceHostname = prefs.ForceHostname()
 	hi.RoutableIPs = prefs.AdvertiseRoutes().AsSlice()
 	hi.RequestTags = prefs.AdvertiseTags().AsSlice()
 	hi.ShieldsUp = prefs.ShieldsUp()

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -171,6 +171,10 @@ type Prefs struct {
 	// not set, os.Hostname is used.
 	Hostname string
 
+	// ForceHostname, when true, asks the control server to use the requested
+	// hostname even if it is already taken (e.g. by an offline node).
+	ForceHostname bool
+
 	// NotepadURLs is a debugging setting that opens OAuth URLs in
 	// notepad.exe on Windows, rather than loading them in a browser.
 	//
@@ -368,6 +372,7 @@ type MaskedPrefs struct {
 	ShieldsUpSet                  bool                `json:",omitempty"`
 	AdvertiseTagsSet              bool                `json:",omitempty"`
 	HostnameSet                   bool                `json:",omitempty"`
+	ForceHostnameSet              bool                `json:",omitempty"`
 	NotepadURLsSet                bool                `json:",omitempty"`
 	ForceDaemonSet                bool                `json:",omitempty"`
 	EggSet                        bool                `json:",omitempty"`
@@ -680,6 +685,7 @@ func (p *Prefs) Equals(p2 *Prefs) bool {
 		p.NetfilterMode == p2.NetfilterMode &&
 		p.OperatorUser == p2.OperatorUser &&
 		p.Hostname == p2.Hostname &&
+		p.ForceHostname == p2.ForceHostname &&
 		p.ForceDaemon == p2.ForceDaemon &&
 		slices.Equal(p.AdvertiseRoutes, p2.AdvertiseRoutes) &&
 		slices.Equal(p.AdvertiseTags, p2.AdvertiseTags) &&

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -52,6 +52,7 @@ func TestPrefsEqual(t *testing.T) {
 		"ShieldsUp",
 		"AdvertiseTags",
 		"Hostname",
+		"ForceHostname",
 		"NotepadURLs",
 		"ForceDaemon",
 		"Egg",

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -861,6 +861,10 @@ type Hostinfo struct {
 	DeviceModel     string   `json:",omitzero"` // mobile phone model ("Pixel 3a", "iPhone12,3")
 	PushDeviceToken string   `json:",omitzero"` // macOS/iOS APNs device token for notifications (and Android in the future)
 	Hostname        string   `json:",omitzero"` // name of the host the client runs on
+	// ForceHostname, when true, asks the control server to use this hostname
+	// even if it is already taken (e.g. by an offline node). The server may
+	// rename or remove the existing node. See https://github.com/tailscale/tailscale/issues/4778
+	ForceHostname   bool     `json:",omitzero"`
 	ShieldsUp       bool     `json:",omitzero"` // indicates whether the host is blocking incoming connections
 	ShareeNode      bool     `json:",omitzero"` // indicates this node exists in netmap because it's owned by a shared-to user
 	NoLogsNoSupport bool     `json:",omitzero"` // indicates that the user has opted out of sending logs and support

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -163,8 +163,9 @@ var _HostinfoCloneNeedsRegeneration = Hostinfo(struct {
 	Package         string
 	DeviceModel     string
 	PushDeviceToken string
-	Hostname        string
-	ShieldsUp       bool
+	Hostname      string
+	ForceHostname bool
+	ShieldsUp     bool
 	ShareeNode      bool
 	NoLogsNoSupport bool
 	WireIngress     bool

--- a/tailcfg/tailcfg_test.go
+++ b/tailcfg/tailcfg_test.go
@@ -45,6 +45,7 @@ func TestHostinfoEqual(t *testing.T) {
 		"DeviceModel",
 		"PushDeviceToken",
 		"Hostname",
+		"ForceHostname",
 		"ShieldsUp",
 		"ShareeNode",
 		"NoLogsNoSupport",

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -541,6 +541,8 @@ func (v HostinfoView) PushDeviceToken() string { return v.ж.PushDeviceToken }
 // name of the host the client runs on
 func (v HostinfoView) Hostname() string { return v.ж.Hostname }
 
+func (v HostinfoView) ForceHostname() bool { return v.ж.ForceHostname }
+
 // indicates whether the host is blocking incoming connections
 func (v HostinfoView) ShieldsUp() bool { return v.ж.ShieldsUp }
 
@@ -646,6 +648,7 @@ var _HostinfoViewNeedsRegeneration = Hostinfo(struct {
 	DeviceModel     string
 	PushDeviceToken string
 	Hostname        string
+	ForceHostname   bool
 	ShieldsUp       bool
 	ShareeNode      bool
 	NoLogsNoSupport bool

--- a/tstest/integration/testcontrol/testcontrol.go
+++ b/tstest/integration/testcontrol/testcontrol.go
@@ -839,8 +839,8 @@ func (s *Server) serveRegister(w http.ResponseWriter, r *http.Request, mkey key.
 	if !ok {
 		// If ForceHostname is set, remove any existing node with the same
 		// hostname so this registration can take over the name.
-		if req.Hostinfo != nil && req.Hostinfo.ForceHostname() && req.Hostinfo.Hostname() != "" {
-			wantName := req.Hostinfo.Hostname()
+		if req.Hostinfo != nil && req.Hostinfo.ForceHostname && req.Hostinfo.Hostname != "" {
+			wantName := req.Hostinfo.Hostname
 			for existingNk, n := range s.nodes {
 				baseName := n.Name
 				if idx := strings.Index(baseName, "."); idx > 0 {

--- a/tstest/integration/testcontrol/testcontrol.go
+++ b/tstest/integration/testcontrol/testcontrol.go
@@ -837,6 +837,23 @@ func (s *Server) serveRegister(w http.ResponseWriter, r *http.Request, mkey key.
 	_, ok := s.nodes[nk]
 	machineAuthorized := !s.RequireMachineAuth
 	if !ok {
+		// If ForceHostname is set, remove any existing node with the same
+		// hostname so this registration can take over the name.
+		if req.Hostinfo != nil && req.Hostinfo.ForceHostname() && req.Hostinfo.Hostname() != "" {
+			wantName := req.Hostinfo.Hostname()
+			for existingNk, n := range s.nodes {
+				baseName := n.Name
+				if idx := strings.Index(baseName, "."); idx > 0 {
+					baseName = baseName[:idx]
+				}
+				if baseName == wantName {
+					delete(s.nodes, existingNk)
+					delete(s.users, existingNk)
+					delete(s.logins, existingNk)
+					s.nodeKeyAuthed.Delete(existingNk)
+				}
+			}
+		}
 
 		nodeID := len(s.nodes) + 1
 		v4Prefix := netip.PrefixFrom(netaddr.IPv4(100, 64, uint8(nodeID>>8), uint8(nodeID)), 32)


### PR DESCRIPTION
Introduced a new flag 'force-hostname' that enables users to request a specific hostname even if it is already taken by an offline node. This change includes updates to the relevant structures and methods to handle the new flag across the codebase.