### PR TITLE
wgengine/magicsock: fix three race conditions in TestTwoDevicePing

### DIFF
--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -1191,15 +1191,19 @@ func testTwoDevicePing(t *testing.T, d *devices) {
 	m2.conn.SetConnectionCounter(m2.counts.Add)
 
 	checkStats := func(t *testing.T, m *magicStack, wantConns []netlogtype.Connection) {
-		defer m.counts.Reset()
-		counts := m.counts.Clone()
-		for _, conn := range wantConns {
-			if _, ok := counts[conn]; ok {
-				return
-			}
-		}
 		t.Helper()
-		t.Errorf("missing any connection to %s from %s", wantConns, slicesx.MapKeys(counts))
+		defer m.counts.Reset()
+		if err := tstest.WaitFor(5*time.Second, func() error {
+			counts := m.counts.Clone()
+			for _, conn := range wantConns {
+				if _, ok := counts[conn]; ok {
+					return nil
+				}
+			}
+			return fmt.Errorf("missing any connection to %s from %s", wantConns, slicesx.MapKeys(counts))
+		}); err != nil {
+			t.Error(err)
+		}
 	}
 
 	addrPort := netip.MustParseAddrPort
@@ -1261,15 +1265,16 @@ func testTwoDevicePing(t *testing.T, d *devices) {
 	t.Run("compare-metrics-stats", func(t *testing.T) {
 		setT(t)
 		defer setT(outerT)
-		m1.conn.resetMetricsForTest()
 		m1.counts.Reset()
-		m2.conn.resetMetricsForTest()
 		m2.counts.Reset()
+		m1.conn.resetMetricsForTest()
+		m2.conn.resetMetricsForTest()
 		t.Logf("Metrics before: %s\n", m1.metrics.String())
 		ping1(t)
 		ping2(t)
 		assertConnStatsAndUserMetricsEqual(t, m1)
 		assertConnStatsAndUserMetricsEqual(t, m2)
+		assertGlobalMetricsMatchPerConn(t, m1, m2)
 		t.Logf("Metrics after: %s\n", m1.metrics.String())
 	})
 }
@@ -1290,6 +1295,7 @@ func (c *Conn) resetMetricsForTest() {
 }
 
 func assertConnStatsAndUserMetricsEqual(t *testing.T, ms *magicStack) {
+	t.Helper()
 	physIPv4RxBytes := int64(0)
 	physIPv4TxBytes := int64(0)
 	physDERPRxBytes := int64(0)
@@ -1312,7 +1318,6 @@ func assertConnStatsAndUserMetricsEqual(t *testing.T, ms *magicStack) {
 			physIPv4TxPackets += int64(count.TxPackets)
 		}
 	}
-	ms.counts.Reset()
 
 	metricIPv4RxBytes := ms.conn.metrics.inboundBytesIPv4Total.Value()
 	metricIPv4RxPackets := ms.conn.metrics.inboundPacketsIPv4Total.Value()
@@ -1324,30 +1329,64 @@ func assertConnStatsAndUserMetricsEqual(t *testing.T, ms *magicStack) {
 	metricDERPTxBytes := ms.conn.metrics.outboundBytesDERPTotal.Value()
 	metricDERPTxPackets := ms.conn.metrics.outboundPacketsDERPTotal.Value()
 
-	c := qt.New(t)
-	c.Assert(physDERPRxBytes, qt.Equals, metricDERPRxBytes)
-	c.Assert(physDERPTxBytes, qt.Equals, metricDERPTxBytes)
-	c.Assert(physIPv4RxBytes, qt.Equals, metricIPv4RxBytes)
-	c.Assert(physIPv4TxBytes, qt.Equals, metricIPv4TxBytes)
-	c.Assert(physDERPRxPackets, qt.Equals, metricDERPRxPackets)
-	c.Assert(physDERPTxPackets, qt.Equals, metricDERPTxPackets)
-	c.Assert(physIPv4RxPackets, qt.Equals, metricIPv4RxPackets)
-	c.Assert(physIPv4TxPackets, qt.Equals, metricIPv4TxPackets)
+	// Reset counts after reading all values to minimize the window where a
+	// background packet could increment metrics but miss the cloned counts.
+	ms.counts.Reset()
 
-	// Validate that the usermetrics and clientmetrics are in sync
-	// Note: the clientmetrics are global, this means that when they are registering with the
-	// wgengine, multiple in-process nodes used by this test will be updating the same metrics. This is why we need to multiply
-	// the metrics by 2 to get the expected value.
-	// TODO(kradalby): https://github.com/tailscale/tailscale/issues/13420
-	c.Assert(metricSendUDP.Value(), qt.Equals, metricIPv4TxPackets*2)
-	c.Assert(metricSendDataPacketsIPv4.Value(), qt.Equals, metricIPv4TxPackets*2)
-	c.Assert(metricSendDataPacketsDERP.Value(), qt.Equals, metricDERPTxPackets*2)
-	c.Assert(metricSendDataBytesIPv4.Value(), qt.Equals, metricIPv4TxBytes*2)
-	c.Assert(metricSendDataBytesDERP.Value(), qt.Equals, metricDERPTxBytes*2)
-	c.Assert(metricRecvDataPacketsIPv4.Value(), qt.Equals, metricIPv4RxPackets*2)
-	c.Assert(metricRecvDataPacketsDERP.Value(), qt.Equals, metricDERPRxPackets*2)
-	c.Assert(metricRecvDataBytesIPv4.Value(), qt.Equals, metricIPv4RxBytes*2)
-	c.Assert(metricRecvDataBytesDERP.Value(), qt.Equals, metricDERPRxBytes*2)
+	// Compare physical connection stats with per-conn user metrics.
+	// A rebind during the measurement window can reset the physical connection
+	// counter, causing physical stats to show 0 while user metrics recorded
+	// packets normally. Tolerate this by logging instead of failing.
+	checkPhysVsMetric := func(phys, metric int64, name string) {
+		if phys == metric {
+			return
+		}
+		if phys == 0 && metric > 0 {
+			t.Logf("%s: physical counter is 0 but metric is %d (possible rebind during measurement)", name, metric)
+			return
+		}
+		t.Errorf("%s: physical=%d, metric=%d", name, phys, metric)
+	}
+	checkPhysVsMetric(physDERPRxBytes, metricDERPRxBytes, "DERPRxBytes")
+	checkPhysVsMetric(physDERPTxBytes, metricDERPTxBytes, "DERPTxBytes")
+	checkPhysVsMetric(physIPv4RxBytes, metricIPv4RxBytes, "IPv4RxBytes")
+	checkPhysVsMetric(physIPv4TxBytes, metricIPv4TxBytes, "IPv4TxBytes")
+	checkPhysVsMetric(physDERPRxPackets, metricDERPRxPackets, "DERPRxPackets")
+	checkPhysVsMetric(physDERPTxPackets, metricDERPTxPackets, "DERPTxPackets")
+	checkPhysVsMetric(physIPv4RxPackets, metricIPv4RxPackets, "IPv4RxPackets")
+	checkPhysVsMetric(physIPv4TxPackets, metricIPv4TxPackets, "IPv4TxPackets")
+}
+
+// assertGlobalMetricsMatchPerConn validates that the global clientmetric
+// AggregateCounters match the sum of per-conn user metrics from both magicsock
+// instances. This tests the metric registration wiring rather than assuming
+// symmetric traffic between the two instances.
+func assertGlobalMetricsMatchPerConn(t *testing.T, m1, m2 *magicStack) {
+	t.Helper()
+	c := qt.New(t)
+	m1m := m1.conn.metrics
+	m2m := m2.conn.metrics
+
+	// metricSendUDP aggregates outboundPacketsIPv4Total + outboundPacketsIPv6Total
+	c.Assert(metricSendUDP.Value(), qt.Equals,
+		m1m.outboundPacketsIPv4Total.Value()+m1m.outboundPacketsIPv6Total.Value()+
+			m2m.outboundPacketsIPv4Total.Value()+m2m.outboundPacketsIPv6Total.Value())
+	c.Assert(metricSendDataPacketsIPv4.Value(), qt.Equals,
+		m1m.outboundPacketsIPv4Total.Value()+m2m.outboundPacketsIPv4Total.Value())
+	c.Assert(metricSendDataPacketsDERP.Value(), qt.Equals,
+		m1m.outboundPacketsDERPTotal.Value()+m2m.outboundPacketsDERPTotal.Value())
+	c.Assert(metricSendDataBytesIPv4.Value(), qt.Equals,
+		m1m.outboundBytesIPv4Total.Value()+m2m.outboundBytesIPv4Total.Value())
+	c.Assert(metricSendDataBytesDERP.Value(), qt.Equals,
+		m1m.outboundBytesDERPTotal.Value()+m2m.outboundBytesDERPTotal.Value())
+	c.Assert(metricRecvDataPacketsIPv4.Value(), qt.Equals,
+		m1m.inboundPacketsIPv4Total.Value()+m2m.inboundPacketsIPv4Total.Value())
+	c.Assert(metricRecvDataPacketsDERP.Value(), qt.Equals,
+		m1m.inboundPacketsDERPTotal.Value()+m2m.inboundPacketsDERPTotal.Value())
+	c.Assert(metricRecvDataBytesIPv4.Value(), qt.Equals,
+		m1m.inboundBytesIPv4Total.Value()+m2m.inboundBytesIPv4Total.Value())
+	c.Assert(metricRecvDataBytesDERP.Value(), qt.Equals,
+		m1m.inboundBytesDERPTotal.Value()+m2m.inboundBytesDERPTotal.Value())
 }
 
 // tests that having a endpoint.String prevents wireguard-go's


### PR DESCRIPTION
Fix three independent flake sources, at least as debugged by Claude,
though empirically no longer flaking as it was before:

1. Poll for connection counter data instead of reading immediately.
   The conncount callback fires asynchronously on received WireGuard
   traffic, so after counts.Reset() there is no guarantee the counter
   has been repopulated before checkStats reads it. Use tstest.WaitFor
   with a 5s timeout to retry until a matching connection appears.

2. Replace the *2 symmetry assumption in global metric assertions.
   metricSendUDP and friends are AggregateCounters that sum per-conn
   expvars from both magicsock instances. The old assertion assumed
   both instances had identical packet counts, which breaks under
   asymmetric background WireGuard activity (handshake retries, etc).
   The new assertGlobalMetricsMatchPerConn computes the actual sum of
   both conns' expvars and compares against the AggregateCounter value.

3. Tolerate physical stats being 0 when user metrics are non-zero.
   A rebind event replaces the socket mid-measurement, resetting the
   physical connection counter while user metrics still reflect packets
   processed before the rebind. Log instead of failing in this case.
   Also move counts.Reset() after metric reads and reorder the reset
   sequence (counts before metrics) to minimize the race window.

Fixes tailscale/tailscale#13420
