### PR TITLE
types/key: add NodePrivate.Raw32 and DiscoPrivateFromRaw32

### DIFF
--- a/types/key/disco.go
+++ b/types/key/disco.go
@@ -42,6 +42,16 @@ func NewDisco() DiscoPrivate {
 	return ret
 }
 
+// DiscoPrivateFromRaw32 parses a 32-byte raw value as a DiscoPrivate.
+func DiscoPrivateFromRaw32(raw mem.RO) DiscoPrivate {
+	if raw.Len() != 32 {
+		panic("input has wrong size")
+	}
+	var ret DiscoPrivate
+	raw.Copy(ret.k[:])
+	return ret
+}
+
 // IsZero reports whether k is the zero value.
 func (k DiscoPrivate) IsZero() bool {
 	return k.Equal(DiscoPrivate{})

--- a/types/key/node.go
+++ b/types/key/node.go
@@ -61,6 +61,9 @@ func NewNode() NodePrivate {
 	return ret
 }
 
+// Raw32 returns k as 32 raw bytes.
+func (k NodePrivate) Raw32() [32]byte { return k.k }
+
 // NodePrivateFromRaw32 parses a 32-byte raw value as a NodePrivate.
 //
 // Deprecated: only needed to cast from legacy node private key types,


### PR DESCRIPTION
Raw byte accessors for key types, mirroring existing patterns
(NodePublic.Raw32 and DiscoPublicFromRaw32 already exist).

NodePrivate.Raw32 returns the raw 32 bytes of a node private key.
DiscoPrivateFromRaw32 parses a 32-byte raw value as a DiscoPrivate.

Updates tailscale/corp#24454
