### PR TITLE
cmd/derper: only log "self-signed certificate" when cert is actually self-signed

### DIFF
--- a/cmd/derper/cert.go
+++ b/cmd/derper/cert.go
@@ -103,12 +103,14 @@ func NewManualCertManager(certdir, hostname string) (certProvider, error) {
 	keyPath := filepath.Join(certdir, keyname+".key")
 	cert, err := tls.LoadX509KeyPair(crtPath, keyPath)
 	hostnameIP := net.ParseIP(hostname) // or nil if hostname isn't an IP address
+	selfSigned := false
 	if err != nil {
 		// If the hostname is an IP address, automatically create a
 		// self-signed certificate for it.
 		var certp *tls.Certificate
 		if os.IsNotExist(err) && hostnameIP != nil {
 			certp, err = createSelfSignedIPCert(crtPath, keyPath, hostname)
+			selfSigned = true
 		}
 		if err != nil {
 			return nil, fmt.Errorf("can not load x509 key pair for hostname %q: %w", keyname, err)
@@ -123,9 +125,9 @@ func NewManualCertManager(certdir, hostname string) (certProvider, error) {
 	if err := x509Cert.VerifyHostname(hostname); err != nil {
 		return nil, fmt.Errorf("cert invalid for hostname %q: %w", hostname, err)
 	}
-	if hostnameIP != nil {
-		// If the hostname is an IP address, print out information on how to
-		// confgure this in the derpmap.
+	if hostnameIP != nil && selfSigned {
+		// If the hostname is an IP address and we generated a self-signed
+		// certificate, print out information on how to configure this in the derpmap.
 		dn := &tailcfg.DERPNode{
 			Name:     "custom",
 			RegionID: 900,


### PR DESCRIPTION
## Summary

- Fix misleading log message in `cmd/derper/cert.go`: when running `derper` with `-certmode manual` and an IP address as `-hostname`, the message "Using self-signed certificate for IP address" is printed unconditionally whenever the hostname is an IP, even if a valid CA-signed certificate (e.g. a Let's Encrypt IP certificate) was successfully loaded from the certdir
- Add a `selfSigned` boolean flag to only print the self-signed certificate guidance when the certificate was actually auto-generated
- Fix typo in comment: "confgure" -> "configure"

Fixes #18955

## Test plan

- [x] Verified with `derper -certmode manual -hostname <IP>` using a Let's Encrypt IP certificate: log no longer shows "Using self-signed certificate"
- [x] Verified without cert files in certdir: derper auto-generates self-signed cert and correctly logs the message with `CertName` guidance
- [x] Verified the actual served certificate via `openssl s_client` matches the manually provided cert

🤖 Generated with [Claude Code](https://claude.com/claude-code)