### PR TITLE
proxymap: overwrite on register, check ownership on unregister

### DIFF
--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -695,8 +695,8 @@ func (b *LocalBackend) tcpHandlerForServe(dport uint16, srcAddr netip.AddrPort, 
 				})
 			}
 
-			// TODO(bradfitz): do the RegisterIPPortIdentity and
-			// UnregisterIPPortIdentity stuff that netstack does
+			// TODO(bradfitz): do the RegisterIPPortIdentity stuff
+			// that netstack does
 			return b.forwardTCPWithProxyProtocol(conn, backConn, tcph.ProxyProtocol(), srcAddr, dport, backDst)
 		}
 	}

--- a/proxymap/proxymap.go
+++ b/proxymap/proxymap.go
@@ -59,24 +59,31 @@ type mappingKey struct {
 //
 // The proto is the network protocol that is being proxied; it must be "tcp" or
 // "udp" (not e.g. "tcp4", "udp6", etc.)
-func (m *Mapper) RegisterIPPortIdentity(proto string, ipport netip.AddrPort, tsIP netip.Addr) error {
+//
+// If an entry already exists for this (proto, ipport), it is overwritten.
+// This happens when the kernel reuses the same local ephemeral port for a
+// connection to a different destination (valid 4-tuple reuse, unique at
+// the socket layer) while a previous registration's owning goroutine has
+// not yet unregistered it. Under high-concurrency subnet routing with
+// many distinct backend destinations, such reuse is common: the map
+// occupancy approaches (concurrent connections / ephemeral port range).
+// The overwrite keeps WhoIs pointing at the most recent live connection.
+//
+// The returned unregister func removes the registration. It is a no-op if
+// the entry has since been overwritten by another registration, so that a
+// goroutine holding a stale unregister cannot delete a live entry.
+func (m *Mapper) RegisterIPPortIdentity(proto string, ipport netip.AddrPort, tsIP netip.Addr) (unregister func()) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	k := mappingKey{proto, ipport}
-	if v, ok := m.m[k]; ok {
-		return fmt.Errorf("proxymap: RegisterIPPortIdentity: already registered: %v/%v=>%v", k.proto, k.ap, v)
-	}
 	mak.Set(&m.m, k, tsIP)
-	return nil
-}
-
-// UnregisterIPPortIdentity removes a temporary IP:port registration
-// made previously by RegisterIPPortIdentity.
-func (m *Mapper) UnregisterIPPortIdentity(proto string, ipport netip.AddrPort) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	k := mappingKey{proto, ipport}
-	delete(m.m, k) // safe to delete from a nil map
+	return func() {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		if m.m[k] == tsIP {
+			delete(m.m, k)
+		}
+	}
 }
 
 var whoIsSleeps = [...]time.Duration{

--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -1659,11 +1659,8 @@ func (ns *Impl) forwardTCP(getClient func(...tcpip.SettableSocketOption) *gonet.
 
 	backendLocalAddr := backend.LocalAddr().(*net.TCPAddr)
 	backendLocalIPPort := netaddr.Unmap(backendLocalAddr.AddrPort())
-	if err := ns.pm.RegisterIPPortIdentity("tcp", backendLocalIPPort, clientRemoteIP); err != nil {
-		ns.logf("netstack: could not register TCP mapping %s: %v", backendLocalIPPort, err)
-		return
-	}
-	defer ns.pm.UnregisterIPPortIdentity("tcp", backendLocalIPPort)
+	unregister := ns.pm.RegisterIPPortIdentity("tcp", backendLocalIPPort, clientRemoteIP)
+	defer unregister()
 
 	// If we get here, either the getClient call below will succeed and
 	// return something we can Close, or it will fail and will properly
@@ -1972,11 +1969,9 @@ func (ns *Impl) forwardUDP(client *gonet.UDPConn, clientAddr, dstAddr netip.Addr
 	if !backendLocalIPPort.IsValid() {
 		ns.logf("could not get backend local IP:port from %v:%v", backendLocalAddr.IP, backendLocalAddr.Port)
 	}
+	unregister := func() {}
 	if isLocal {
-		if err := ns.pm.RegisterIPPortIdentity("udp", backendLocalIPPort, clientAddr.Addr()); err != nil {
-			ns.logf("netstack: could not register UDP mapping %s: %v", backendLocalIPPort, err)
-			return
-		}
+		unregister = ns.pm.RegisterIPPortIdentity("udp", backendLocalIPPort, clientAddr.Addr())
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -1991,9 +1986,7 @@ func (ns *Impl) forwardUDP(client *gonet.UDPConn, clientAddr, dstAddr netip.Addr
 		idleTimeout = 30 * time.Second
 	}
 	timer := time.AfterFunc(idleTimeout, func() {
-		if isLocal {
-			ns.pm.UnregisterIPPortIdentity("udp", backendLocalIPPort)
-		}
+		unregister()
 		ns.logf("netstack: UDP session between %s and %s timed out", backendListenAddr, backendRemoteAddr)
 		cancel()
 		client.Close()


### PR DESCRIPTION
The proxymap is keyed on (proto, localIP:localPort), but the kernel allocates ephemeral ports on 4-tuple uniqueness. When the kernel reuses the same local port for a connection to a different destination — which is valid and common — the map sees a false collision.

Under high-concurrency subnet routing with many distinct backend destinations, this is the common case rather than an edge case: with N concurrent connections across a ~28k ephemeral port range, roughly N/28k of new registrations hit an existing entry. forwardTCP treats the error as fatal, returns handled=false, and the caller sends RST to the client SYN. The client sees ECONNREFUSED on a connection that would have succeeded.

This change makes Register overwrite unconditionally. The kernel already guarantees 4-tuple uniqueness (the dial would have failed with EADDRINUSE otherwise), so every collision Register previously reported was a false positive — there is nothing to guard against.

Unregister now takes the tsIP and only deletes if the entry is still owned by that address. This prevents a race where connection A registers, connection B overwrites, A closes and its defer deletes B's live entry. With the ownership check, A's defer is a no-op and B's defer correctly deletes when B closes.

WhoIs always returns the most-recent live connection's owner, which is the correct answer when two live connections share a local port (different destinations).

Updates #1616