### PR TITLE
wgengine/netstack: fix windowsPingOutputIsSuccess for non-English locales

### DIFF
--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -2259,14 +2259,23 @@ func (ns *Impl) ExpVar() expvar.Var {
 // success ping response for ip.
 //
 // See https://github.com/tailscale/tailscale/issues/13654
+// See https://github.com/tailscale/tailscale/issues/18852
 //
 // TODO(bradfitz,nickkhyl): delete this and use the proper Windows APIs.
 func windowsPingOutputIsSuccess(ip netip.Addr, b []byte) bool {
-	// Look for a line that contains " <ip>: " and then three equal signs.
+	// Look for a line that contains the target IP and three equal signs.
 	// As a special case, the 2nd equal sign may be a '<' character
 	// for sub-millisecond pings.
-	// This heuristic seems to match the ping.exe output in any language.
-	sub := fmt.Appendf(nil, " %s: ", ip)
+	//
+	// Previously this looked for " <ip>: " which worked for English and
+	// German but failed for Chinese, Japanese, Korean, and other locales
+	// where the IP is not directly followed by ": ". For example:
+	//   English: "Reply from 1.2.3.4: bytes=32 time=7ms TTL=64"
+	//   Chinese: "来自 1.2.3.4 的回复: 字节=32 时间<1ms TTL=128"
+	// We now just check that the line contains the IP and has three
+	// equal-sign-like characters, which is sufficient to identify a
+	// successful reply line in any locale.
+	ipBytes := []byte(ip.String())
 
 	eqSigns := func(bb []byte) (n int) {
 		for _, b := range bb {
@@ -2280,7 +2289,7 @@ func windowsPingOutputIsSuccess(ip netip.Addr, b []byte) bool {
 	for len(b) > 0 {
 		var line []byte
 		line, b, _ = bytes.Cut(b, []byte("\n"))
-		if _, rest, ok := bytes.Cut(line, sub); ok && eqSigns(rest) == 3 {
+		if bytes.Contains(line, ipBytes) && eqSigns(line) == 3 {
 			return true
 		}
 	}

--- a/wgengine/netstack/netstack_userping_test.go
+++ b/wgengine/netstack/netstack_userping_test.go
@@ -55,6 +55,42 @@ Ca. Zeitangaben in Millisek.:
 `,
 		},
 		{
+			name: "success_chinese",
+			ip:   "10.0.0.1",
+			want: true,
+			out: "正在 Ping 10.0.0.1 具有 32 字节的数据:\r\n" +
+				"来自 10.0.0.1 的回复: 字节=32 时间=7ms TTL=64\r\n" +
+				"\r\n" +
+				"10.0.0.1 的 Ping 统计信息:\r\n" +
+				"    数据包: 已发送 = 1，已接收 = 1，丢失 = 0 (0% 丢失)，\r\n" +
+				"往返行程的估计时间(以毫秒为单位):\r\n" +
+				"    最短 = 7ms，最长 = 7ms，平均 = 7ms\r\n",
+		},
+		{
+			name: "success_chinese_sub_millisecond",
+			ip:   "10.0.0.1",
+			want: true,
+			out: "正在 Ping 10.0.0.1 具有 32 字节的数据:\r\n" +
+				"来自 10.0.0.1 的回复: 字节=32 时间<1ms TTL=64\r\n" +
+				"\r\n" +
+				"10.0.0.1 的 Ping 统计信息:\r\n" +
+				"    数据包: 已发送 = 1，已接收 = 1，丢失 = 0 (0% 丢失)，\r\n" +
+				"往返行程的估计时间(以毫秒为单位):\r\n" +
+				"    最短 = 7ms，最长 = 7ms，平均 = 7ms\r\n",
+		},
+		{
+			name: "success_japanese",
+			ip:   "10.0.0.1",
+			want: true,
+			out: "10.0.0.1 に ping を送信しています 32 バイトのデータ:\r\n" +
+				"10.0.0.1 からの応答: バイト数 =32 時間 =7ms TTL=64\r\n" +
+				"\r\n" +
+				"10.0.0.1 の ping 統計:\r\n" +
+				"    パケット数: 送信 = 1、受信 = 1、損失 = 0 (0% の損失)、\r\n" +
+				"ラウンド トリップの概算時間 (ミリ秒):\r\n" +
+				"    最小 = 7ms、最大 = 7ms、平均 = 7ms\r\n",
+		},
+		{
 			name: "unreachable",
 			ip:   "10.0.0.6",
 			want: false,
@@ -64,6 +100,16 @@ Reply from 10.0.108.189: Destination host unreachable
 Ping statistics for 10.0.0.6:
 	Packets: Sent = 1, Received = 1, Lost = 0 (0% loss),
 `,
+		},
+		{
+			name: "unreachable_chinese",
+			ip:   "10.0.0.6",
+			want: false,
+			out: "正在 Ping 10.0.0.6 具有 32 字节的数据:\r\n" +
+				"来自 10.0.108.189 的回复: 无法访问目标主机。\r\n" +
+				"\r\n" +
+				"10.0.0.6 的 Ping 统计信息:\r\n" +
+				"    数据包: 已发送 = 1，已接收 = 1，丢失 = 0 (0% 丢失)，\r\n",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #18852

The `windowsPingOutputIsSuccess` function parsed ping.exe output by looking for `" <ip>: "` in each line — that is, a space, the target IP, a colon, and another space. This works for English (`Reply from 1.2.3.4: bytes=32 ...`) and German (`Antwort von 1.2.3.4: Bytes=32 ...`), but not for Chinese, Japanese, Korean, and other locales where the IP is not immediately followed by `: `.

For example, on Chinese Windows:
```
来自 127.0.0.1 的回复: 字节=32 时间<1ms TTL=128
```
The IP is followed by ` 的回复: ` instead of `: `, so the pattern never matches and the function incorrectly reports ping failure. This breaks subnet routing for users with non-English Windows locales.

The fix: instead of requiring `" <ip>: "`, just check that the line contains the IP address (anywhere) and has three `=`-like characters. A successful reply line always has `bytes=`, `time=` (or `time<`), and `TTL=` regardless of locale, while non-reply lines (statistics header, summary) either don't contain the target IP or don't have three `=` signs.

Added test cases for Chinese (including sub-millisecond), Japanese, and Chinese unreachable output.

Signed-off-by: mango766 <mango766@users.noreply.github.com>