### PR TITLE
kube/certs: discover TLS domains from TCP TerminateTLS handlers (#19020)

### DIFF
--- a/kube/certs/certs.go
+++ b/kube/certs/certs.go
@@ -53,6 +53,7 @@ func (cm *CertManager) EnsureCertLoops(ctx context.Context, sc *ipn.ServeConfig)
 	currentDomains := make(map[string]bool)
 	const httpsPort = "443"
 	for _, service := range sc.Services {
+		// L7 Web handlers (HA Ingress).
 		for hostPort := range service.Web {
 			domain, port, err := net.SplitHostPort(string(hostPort))
 			if err != nil {
@@ -62,6 +63,12 @@ func (cm *CertManager) EnsureCertLoops(ctx context.Context, sc *ipn.ServeConfig)
 				continue
 			}
 			currentDomains[domain] = true
+		}
+		// L4 TCP handlers with TLS termination (kube-apiserver proxy).
+		for _, handler := range service.TCP {
+			if handler != nil && handler.TerminateTLS != "" {
+				currentDomains[handler.TerminateTLS] = true
+			}
 		}
 	}
 	cm.mu.Lock()

--- a/kube/certs/certs_test.go
+++ b/kube/certs/certs_test.go
@@ -128,6 +128,43 @@ func TestEnsureCertLoops(t *testing.T) {
 			updatedGoroutines: 1, // one loop after removing service2
 		},
 		{
+			name: "tcp_terminate_tls",
+			initialConfig: &ipn.ServeConfig{
+				Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
+					"svc:my-apiserver": {
+						TCP: map[uint16]*ipn.TCPPortHandler{
+							443: {
+								TCPForward:   "localhost:80",
+								TerminateTLS: "my-apiserver.tailnetxyz.ts.net",
+							},
+						},
+					},
+				},
+			},
+			initialGoroutines: 1,
+		},
+		{
+			name: "tcp_terminate_tls_and_web",
+			initialConfig: &ipn.ServeConfig{
+				Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
+					"svc:my-apiserver": {
+						TCP: map[uint16]*ipn.TCPPortHandler{
+							443: {
+								TCPForward:   "localhost:80",
+								TerminateTLS: "my-apiserver.tailnetxyz.ts.net",
+							},
+						},
+					},
+					"svc:my-app": {
+						Web: map[ipn.HostPort]*ipn.WebServerConfig{
+							"my-app.tailnetxyz.ts.net:443": {},
+						},
+					},
+				},
+			},
+			initialGoroutines: 2,
+		},
+		{
 			name: "add_domain",
 			initialConfig: &ipn.ServeConfig{
 				Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
@@ -171,6 +208,7 @@ func TestEnsureCertLoops(t *testing.T) {
 								CertDomains: []string{
 									"my-app.tailnetxyz.ts.net",
 									"my-other-app.tailnetxyz.ts.net",
+									"my-apiserver.tailnetxyz.ts.net",
 								},
 							},
 						},


### PR DESCRIPTION
After #18179 switched to L4 TCPForward, EnsureCertLoops found no domains since it only checked service.Web entries. Certs were never provisioned, leaving kube-apiserver ProxyGroups stuck at 0/N ready.

Fixes #19019


(cherry picked from commit a565833998c71517594187befe8a6837520eb4b0)