### PR TITLE
net/sockopts: skip setsockopt if buffer already large enough

### DIFF
--- a/net/sockopts/sockopts_linux.go
+++ b/net/sockopts/sockopts_linux.go
@@ -20,16 +20,25 @@ import (
 //
 // If pconn is not a [*net.UDPConn], then SetBufferSize is no-op.
 func SetBufferSize(pconn nettype.PacketConn, direction BufferDirection, size int) (errForce error, errPortable error) {
-	opt := syscall.SO_RCVBUFFORCE
+	forceOpt := syscall.SO_RCVBUFFORCE
+	getOpt := syscall.SO_RCVBUF
 	if direction == WriteDirection {
-		opt = syscall.SO_SNDBUFFORCE
+		forceOpt = syscall.SO_SNDBUFFORCE
+		getOpt = syscall.SO_SNDBUF
 	}
 	if c, ok := pconn.(*net.UDPConn); ok {
 		var rc syscall.RawConn
 		rc, errForce = c.SyscallConn()
 		if errForce == nil {
 			rc.Control(func(fd uintptr) {
-				errForce = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, opt, size)
+				// On Linux, getsockopt reports 2x the actual buffer size to
+				// account for kernel bookkeeping overhead. Skip if the buffer
+				// is already at least as large as the requested size.
+				current, err := syscall.GetsockoptInt(int(fd), syscall.SOL_SOCKET, getOpt)
+				if err == nil && current >= size*2 {
+					return
+				}
+				errForce = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, forceOpt, size)
 			})
 		}
 		if errForce != nil {

--- a/net/sockopts/sockopts_unix_test.go
+++ b/net/sockopts/sockopts_unix_test.go
@@ -57,5 +57,5 @@ func TestSetBufferSize(t *testing.T) {
 	// On many systems we may not increase the value, particularly running as a
 	// regular user, so log the information for manual verification.
 	t.Logf("SO_RCVBUF: %v -> %v", curRcv, newRcv)
-	t.Logf("SO_SNDBUF: %v -> %v", curRcv, newRcv)
+	t.Logf("SO_SNDBUF: %v -> %v", curSnd, newSnd)
 }


### PR DESCRIPTION
On Linux, getsockopt reports 2x the actual buffer size to account for
kernel bookkeeping overhead. Check the current buffer size before calling
SetsockoptInt, avoiding unnecessary syscalls when the buffer is already
sufficiently large.

Also fixes a copy-paste bug in TestSetBufferSize where the SO_SNDBUF
log line was printing receive buffer values instead of send buffer
values.

Fixes #15994