### PR TITLE
net/tstun: do not write when Wrapper is closed

### DIFF
--- a/net/tstun/wrap.go
+++ b/net/tstun/wrap.go
@@ -512,8 +512,9 @@ func (t *Wrapper) injectOutbound(r tunInjectedRead) {
 	if t.outboundClosed {
 		return
 	}
-	t.vectorOutbound <- tunVectorReadResult{
-		injected: r,
+	select {
+	case t.vectorOutbound <- tunVectorReadResult{injected: r}:
+	case <-t.closed:
 	}
 }
 
@@ -524,7 +525,10 @@ func (t *Wrapper) sendVectorOutbound(r tunVectorReadResult) {
 	if t.outboundClosed {
 		return
 	}
-	t.vectorOutbound <- r
+	select {
+	case t.vectorOutbound <- r:
+	case <-t.closed:
+	}
 }
 
 // snat does SNAT on p if the destination address requires a different source address.


### PR DESCRIPTION
Two methods could deadlock during shutdown when closing the wrapper.

Ensure that the writers are aware of the wrapper being closed.

Fixes #19037

Signed-off-by: Claus Lensbøl <claus@tailscale.com>
