### PR TITLE
net/dns: use the correct separator for multiple servers in the same NRPT rule on Windows

### DIFF
--- a/net/dns/nrpt_windows.go
+++ b/net/dns/nrpt_windows.go
@@ -318,7 +318,7 @@ func (db *nrptRuleDatabase) writeNRPTRule(ruleID string, servers, doms []string)
 		}
 		defer key.Close()
 
-		if err := writeNRPTValues(key, strings.Join(servers, "; "), doms); err != nil {
+		if err := writeNRPTValues(key, strings.Join(servers, ";"), doms); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
If an NRPT rule lists more than one server, those servers should be separated by a semicolon (`;`), rather than a semicolon followed by a space (`; `). Otherwise, Windows fails to parse the created registry value, and DNS resolution may fail.

https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gpnrpt/06088ca3-4cf1-48fa-8837-ca8d853ee1e8

Fixes #19040
Updates #15404 (enabled MagicDNS IPv6 by default, adding a second server and triggering the issue)