### PR TITLE
tsnet: fall back to 'tsnet' when os.Executable fails on darwin

### DIFF
--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -618,10 +618,15 @@ func (s *Server) start() (reterr error) {
 			// directory and hostname when they're not supplied. But we can fall
 			// back to "tsnet" as well.
 			exe = "tsnet"
-		case "ios":
+		case "ios", "darwin":
 			// When compiled as a framework (via TailscaleKit in libtailscale),
-			// os.Executable() returns an error, so fall back to "tsnet" there
-			// too.
+			// os.Executable() returns an error on iOS. The same failure occurs
+			// on macOS (darwin) when the framework is loaded in a process
+			// launched by a debugger or certain host environments (e.g. Xcode),
+			// where the OS does not expose a resolvable executable path to the
+			// embedded Go runtime. Fall back to "tsnet" in both cases — the
+			// value is only used as a default hostname/directory when neither
+			// Server.Hostname nor Server.Dir is set.
 			exe = "tsnet"
 		default:
 			return err


### PR DESCRIPTION
Fixes #19050

## Problem

`tsnet.Server.start()` calls `os.Executable()` to determine default values for `Server.Hostname` and `Server.Dir` when neither is set by the caller. On iOS this already has a fallback because `os.Executable()` fails when the Go runtime is embedded in a framework via TailscaleKit.

The same failure occurs on **macOS (darwin)** when the framework is hosted in a process launched by a debugger or certain host environments (e.g. Xcode's debug launcher). In that case, the OS does not expose a resolvable executable path to the embedded Go runtime, and `os.Executable()` returns an error. This causes `start()` to return:

```
tsnet: cannot find executable path
```

...even though both `Server.Hostname` and `Server.Dir` are explicitly set by the caller and the executable path is not needed at all.

## Fix

Extend the existing `ios` case to also cover `darwin`. The fallback value (`"tsnet"`) is only used as a default for `Server.Hostname` and `Server.Dir` — if the caller has set both fields, this code path is never reached in the first place, so there is no behavioral change for well-configured servers.