### PR TITLE
ci: validate Dockerfile builds for amd64, arm64, and riscv64

### DIFF
--- a/.github/workflows/docker-file-build.yml
+++ b/.github/workflows/docker-file-build.yml
@@ -1,5 +1,5 @@
 name: "Dockerfile build"
-on: 
+on:
   push:
     branches:
     - main
@@ -7,7 +7,15 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [linux/amd64, linux/arm64, linux/riscv64]
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
     - name: "Build Docker image"
-      run: docker build .
+      run: docker buildx build --platform ${{ matrix.platform }} .


### PR DESCRIPTION
This PR updates the Dockerfile build verification workflow to test
across three platforms (linux/amd64, linux/arm64, linux/riscv64) using
Docker Buildx and QEMU, instead of only building for the native runner
architecture.

The `golang:1.26-alpine` base image already supports riscv64, and all
Tailscale Go binaries compile cleanly for this target. I verified the
binaries build and run correctly on native riscv64 hardware using
[RISE riscv64 runners](https://gitlab.com/riseproject/riscv64-ci-images)
(GitHub-hosted runners with the `ubuntu-24.04-riscv` label, provided by
the RISE Project):
[successful CI run](https://github.com/gounthar/tailscale/actions/runs/23348389031).

This is a step towards publishing riscv64 Docker images as requested in
#17812. The existing Dockerfile and base image already support the
architecture; this PR ensures the build stays green before any release
pipeline changes.

Ref #17812