### PR TITLE
net/dns/{publicdns,resolver}: bootstrap NextDNS lower latency IPs

### DIFF
--- a/net/dns/publicdns/publicdns.go
+++ b/net/dns/publicdns/publicdns.go
@@ -108,15 +108,6 @@ func DoHIPsOfBase(dohBase string) []netip.Addr {
 			hexStr = hexStr[:i]
 		}
 
-		// TODO(bradfitz): using the NextDNS anycast addresses works but is not
-		// ideal. Some of their regions have better latency via a non-anycast IP
-		// which we could get by first resolving A/AAAA "dns.nextdns.io" over
-		// DoH using their anycast address. For now we only use the anycast
-		// addresses. The IPv4 IPs we use are just the first one in their ranges.
-		// For IPv6 we put the profile ID in the lower bytes, but that seems just
-		// conventional for them and not required (it'll already be in the DoH path).
-		// (Really we shouldn't use either IPv4 or IPv6 anycast for DoH once we
-		// resolve "dns.nextdns.io".)
 		if b, err := hex.DecodeString(hexStr); err == nil && len(b) <= 12 && len(b) > 0 {
 			return []netip.Addr{
 				nextDNSv4One,
@@ -138,6 +129,23 @@ func DoHIPsOfBase(dohBase string) []netip.Addr {
 		}
 	}
 	return nil
+}
+
+// DoHBootstrapHostname returns the hostname that should be resolved via UDP:53
+// to discover lower-latency unicast addresses for the given provider URL base,
+// or "" if bootstrap resolution is not applicable for that provider.
+//
+// This is provider metadata only — a non-empty return value does not imply that
+// urlBase alone is sufficient to establish a connection. The caller is still
+// responsible for verifying that DoHIPsOfBase(urlBase) returns bootstrap IPs
+// before attempting resolution.
+//
+// This is a pure static mapping; it performs no network I/O.
+func DoHBootstrapHostname(urlBase string) string {
+	if strings.HasPrefix(urlBase, nextDNSBase) {
+		return "dns.nextdns.io."
+	}
+	return ""
 }
 
 // DoHV6 returns the first IPv6 DNS address from a given public DNS provider

--- a/net/dns/publicdns/publicdns_test.go
+++ b/net/dns/publicdns/publicdns_test.go
@@ -151,3 +151,22 @@ func TestDoHIPsOfBase(t *testing.T) {
 		}
 	}
 }
+
+func TestDoHBootstrapHostname(t *testing.T) {
+	tests := []struct {
+		urlBase string
+		want    string
+	}{
+		{"https://dns.nextdns.io/abc123", "dns.nextdns.io."},
+		{"https://dns.nextdns.io/c3a884/with/more/stuff", "dns.nextdns.io."},
+		{"https://cloudflare-dns.com/dns-query", ""},
+		{"https://dns.google/dns-query", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := DoHBootstrapHostname(tt.urlBase)
+		if got != tt.want {
+			t.Errorf("DoHBootstrapHostname(%q) = %q, want %q", tt.urlBase, got, tt.want)
+		}
+	}
+}

--- a/net/dns/resolver/forwarder.go
+++ b/net/dns/resolver/forwarder.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/netip"
@@ -43,7 +44,9 @@ import (
 	"tailscale.com/types/nettype"
 	"tailscale.com/util/cloudenv"
 	"tailscale.com/util/dnsname"
+	"tailscale.com/util/mak"
 	"tailscale.com/util/race"
+	"tailscale.com/util/set"
 	"tailscale.com/version"
 )
 
@@ -308,7 +311,17 @@ type forwarder struct {
 
 	mu syncs.Mutex // guards following
 
-	dohClient map[string]*http.Client // urlBase -> client
+	dohClient              map[string]*http.Client // urlBase -> client
+	dohClientBootstrapping set.Set[string]          // urlBase values with a bootstrap goroutine currently in-flight
+	dohClientNextRetry     map[string]time.Time    // urlBase -> earliest retry time after a failed bootstrap; absent means no retry pending; guarded by mu
+
+	// nextDNSExchangeFunc, if non-nil, replaces the UDP exchangeFn passed to
+	// resolveBootstrapHostname in upgradeBootstrapClient. Only set in tests.
+	nextDNSExchangeFunc func(ctx context.Context, pkt []byte) ([]byte, error)
+
+	// testBootstrapUDPServers, if non-nil, replaces the server list derived
+	// from DoHIPsOfBase in upgradeBootstrapClient. Only set in tests.
+	testBootstrapUDPServers []netip.AddrPort
 
 	// routes are per-suffix resolvers to use, with
 	// the most specific routes first.
@@ -496,37 +509,20 @@ func (f *forwarder) packetListener(ip netip.Addr) (nettype.PacketListenerWithNet
 	return nettype.MakePacketListenerWithNetIP(lc), nil
 }
 
-// getKnownDoHClientForProvider returns an HTTP client for a specific DoH
-// provider named by its DoH base URL (like "https://dns.google/dns-query").
-//
-// The returned client race/Happy Eyeballs dials all IPs for urlBase (usually
-// 4), as statically known by the publicdns package.
-func (f *forwarder) getKnownDoHClientForProvider(urlBase string) (c *http.Client, ok bool) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	if c, ok := f.dohClient[urlBase]; ok {
-		return c, true
-	}
-	allIPs := publicdns.DoHIPsOfBase(urlBase)
-	if len(allIPs) == 0 {
-		return nil, false
-	}
+// buildDoHClient constructs an http.Client that dials urlBase using the given IPs.
+// Used for both the initial anycast client and the upgraded unicast client.
+// It contains no I/O — only struct allocation — so it is safe to call under f.mu.
+func (f *forwarder) buildDoHClient(urlBase string, ips []netip.Addr) (*http.Client, error) {
 	dohURL, err := url.Parse(urlBase)
 	if err != nil {
-		return nil, false
+		return nil, err
 	}
-
 	dialer := dnscache.Dialer(f.getDialerType(), &dnscache.Resolver{
 		SingleHost:             dohURL.Hostname(),
-		SingleHostStaticResult: allIPs,
+		SingleHostStaticResult: ips,
 		Logf:                   f.logf,
 	})
-	tlsConfig := &tls.Config{
-		// Enforce TLS 1.3, as all of our supported DNS-over-HTTPS servers are compatible with it
-		// (see tailscale.com/net/dns/publicdns/publicdns.go).
-		MinVersion: tls.VersionTLS13,
-	}
-	c = &http.Client{
+	return &http.Client{
 		Transport: &http.Transport{
 			ForceAttemptHTTP2: true,
 			IdleConnTimeout:   dohIdleConnTimeout,
@@ -540,14 +536,332 @@ func (f *forwarder) getKnownDoHClientForProvider(urlBase string) (c *http.Client
 				}
 				return dialer(ctx, netw, addr)
 			},
-			TLSClientConfig: tlsConfig,
+			TLSClientConfig: &tls.Config{
+				// Enforce TLS 1.3, as all of our supported DNS-over-HTTPS servers are compatible with it
+				// (see tailscale.com/net/dns/publicdns/publicdns.go).
+				MinVersion: tls.VersionTLS13,
+			},
 		},
+	}, nil
+}
+
+// sendBootstrapDNS sends a single DNS query to server over UDP using
+// Tailscale's packet-listener infrastructure and returns the raw response.
+// It patches a random txid into the query, then verifies the txid and source
+// address in the response. This is a bootstrap-only path — it does not perform
+// RCODE handling or truncated-read recovery.
+func (f *forwarder) sendBootstrapDNS(ctx context.Context, server netip.AddrPort, query []byte) ([]byte, error) {
+	udpFam := "udp4"
+	if server.Addr().Is6() {
+		udpFam = "udp6"
+	}
+	// Copy query and patch in a random txid; UDP has no built-in
+	// request/response binding the way HTTP does.
+	pkt := make([]byte, len(query))
+	copy(pkt, query)
+	txid := uint16(rand.Uint32())
+	binary.BigEndian.PutUint16(pkt[0:2], txid)
+
+	ln, err := f.packetListener(server.Addr())
+	if err != nil {
+		return nil, err
+	}
+	conn, err := ln.ListenPacket(ctx, udpFam, ":0")
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	if deadline, ok := ctx.Deadline(); ok {
+		conn.SetDeadline(deadline)
+	}
+
+	if _, err := conn.WriteToUDPAddrPort(pkt, server); err != nil {
+		return nil, err
+	}
+	buf := make([]byte, 4096)
+	for {
+		n, src, err := conn.ReadFromUDPAddrPort(buf)
+		if err != nil {
+			return nil, err
+		}
+		if n < 2 || src != server || binary.BigEndian.Uint16(buf[:2]) != txid {
+			// Stray packet (wrong source or txid); keep waiting.
+			continue
+		}
+		return buf[:n], nil
+	}
+}
+
+// getKnownDoHClientForProvider returns an HTTP client for a specific DoH
+// provider named by its DoH base URL (like "https://dns.google/dns-query").
+// The candidate IPs come from publicdns.DoHIPsOfBase; TCP-level racing across
+// those IPs is handled by dnscache.Dialer inside the transport.
+//
+// For providers that support bootstrap hostname resolution (currently NextDNS),
+// a background goroutine is launched after the first call to upgrade the cached
+// client from anycast bootstrap IPs to lower-latency unicast IPs resolved via UDP:53.
+func (f *forwarder) getKnownDoHClientForProvider(urlBase string) (c *http.Client, ok bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if c, ok := f.dohClient[urlBase]; ok {
+		// If a previous bootstrap attempt failed, retry on natural traffic once
+		// the cooldown has expired.
+		if bh := publicdns.DoHBootstrapHostname(urlBase); bh != "" {
+			if !f.dohClientBootstrapping.Contains(urlBase) {
+				if retryAt, failed := f.dohClientNextRetry[urlBase]; failed && !time.Now().Before(retryAt) {
+					f.dohClientBootstrapping.Make()
+					f.dohClientBootstrapping.Add(urlBase)
+					go f.upgradeBootstrapClient(urlBase, bh, publicdns.DoHIPsOfBase(urlBase))
+				}
+			}
+		}
+		return c, true
+	}
+	allIPs := publicdns.DoHIPsOfBase(urlBase)
+	if len(allIPs) == 0 {
+		return nil, false
+	}
+	c, err := f.buildDoHClient(urlBase, allIPs)
+	if err != nil {
+		return nil, false
 	}
 	if f.dohClient == nil {
 		f.dohClient = map[string]*http.Client{}
 	}
 	f.dohClient[urlBase] = c
+	// If the provider supports bootstrap hostname resolution, kick off an async
+	// upgrade to unicast IPs. dohClientBootstrapping prevents duplicate goroutines
+	// on concurrent first calls.
+	if bh := publicdns.DoHBootstrapHostname(urlBase); bh != "" {
+		if !f.dohClientBootstrapping.Contains(urlBase) {
+			f.dohClientBootstrapping.Make()
+			f.dohClientBootstrapping.Add(urlBase)
+			go f.upgradeBootstrapClient(urlBase, bh, allIPs)
+		}
+	}
 	return c, true
+}
+
+// upgradeBootstrapClient resolves bootstrapHostname via UDP:53 using the IPs
+// from DoHIPsOfBase, filters the results to global unicast addresses, then
+// swaps a better unicast-first client into the cache. bootstrapIPs are kept
+// as fallback. On any failure the anycast client remains unchanged.
+//
+// It runs in a background goroutine launched by getKnownDoHClientForProvider.
+func (f *forwarder) upgradeBootstrapClient(urlBase, bootstrapHostname string, bootstrapIPs []netip.Addr) {
+	var success bool
+	defer func() {
+		f.mu.Lock()
+		f.dohClientBootstrapping.Delete(urlBase)
+		if !success {
+			mak.Set(&f.dohClientNextRetry, urlBase, time.Now().Add(5*time.Minute))
+		} else {
+			delete(f.dohClientNextRetry, urlBase)
+		}
+		f.mu.Unlock()
+	}()
+
+	ctx, cancel := context.WithTimeout(f.ctx, 5*time.Second)
+	defer cancel()
+
+	// Read both test hooks under mu so they are synchronized with any test
+	// that sets them.
+	f.mu.Lock()
+	var udpServers []netip.AddrPort
+	if f.testBootstrapUDPServers != nil {
+		udpServers = f.testBootstrapUDPServers
+	} else {
+		// DoHIPsOfBase returns the IPs used to dial the DoH endpoint, which
+		// for NextDNS includes profile-specific v6 addresses. Those IPs also
+		// accept UDP:53 queries, so reusing this set as bootstrap targets is
+		// intentional: it avoids a separate API while still reaching valid
+		// recursive resolvers.
+		for _, ip := range publicdns.DoHIPsOfBase(urlBase) {
+			udpServers = append(udpServers, netip.AddrPortFrom(ip, 53))
+		}
+	}
+	exchangeFn := func(ctx context.Context, pkt []byte) ([]byte, error) {
+		var lastErr error
+		for _, server := range udpServers {
+			ipCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+			resp, err := f.sendBootstrapDNS(ipCtx, server, pkt)
+			cancel()
+			if err == nil {
+				return resp, nil
+			}
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			lastErr = err
+		}
+		return nil, lastErr
+	}
+	if f.nextDNSExchangeFunc != nil {
+		exchangeFn = f.nextDNSExchangeFunc
+	}
+	f.mu.Unlock()
+
+	resolved, err := resolveBootstrapHostname(ctx, f.logf, bootstrapHostname, exchangeFn)
+	if err != nil {
+		f.logf("[v1] dns: UDP bootstrap for %s failed: %v", bootstrapHostname, err)
+		return
+	}
+
+	// Only trust addresses that pass IsGlobalUnicast() && !IsPrivate().
+	// This excludes loopback, link-local, RFC1918, and ULA.
+	resolved = filterGlobalUnicastIPs(resolved)
+	if len(resolved) == 0 {
+		return
+	}
+
+	// Unicast IPs first, anycast fallback at the end, no duplicates.
+	combined := combineBootstrapIPs(resolved, bootstrapIPs)
+
+	upgraded, err := f.buildDoHClient(urlBase, combined)
+	if err != nil {
+		return
+	}
+
+	f.mu.Lock()
+	old := f.dohClient[urlBase]
+	f.dohClient[urlBase] = upgraded
+	success = true
+	f.mu.Unlock()
+
+	if old != nil {
+		old.CloseIdleConnections()
+	}
+	f.logf("[v1] dns: UDP bootstrap upgraded %s to unicast IPs: %v", urlBase, resolved)
+}
+
+// resolveBootstrapHostname queries hostname A and AAAA using exchangeFn,
+// which sends one wire-format DNS query and returns the wire-format response.
+// Failure of one record type is non-fatal; an error is returned only if no IPs
+// were collected from either query.
+func resolveBootstrapHostname(ctx context.Context, logf logger.Logf, hostname string, exchangeFn func(context.Context, []byte) ([]byte, error)) ([]netip.Addr, error) {
+	var ips []netip.Addr
+	var lastErr error
+	for _, qtype := range []dns.Type{dns.TypeA, dns.TypeAAAA} {
+		pkt, err := buildDNSQuery(hostname, qtype)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		resp, err := exchangeFn(ctx, pkt)
+		if err != nil {
+			lastErr = err
+			logf("[v1] dns: UDP bootstrap %v lookup for %s failed: %v", qtype, hostname, err)
+			continue
+		}
+		addrs, err := parseDNSResponseIPs(resp)
+		if err != nil {
+			lastErr = err
+			logf("[v1] dns: UDP bootstrap parse error (%v, %s): %v", qtype, hostname, err)
+			continue
+		}
+		ips = append(ips, addrs...)
+	}
+	if len(ips) == 0 {
+		if lastErr != nil {
+			return nil, lastErr
+		}
+		return nil, fmt.Errorf("%s returned no A or AAAA records", hostname)
+	}
+	return ips, nil
+}
+
+// combineBootstrapIPs returns resolved IPs first, bootstrap IPs second, with
+// duplicates removed. This is the dial order the upgraded client will use.
+func combineBootstrapIPs(resolved, bootstrap []netip.Addr) []netip.Addr {
+	combined := make([]netip.Addr, 0, len(resolved)+len(bootstrap))
+	seen := make(map[netip.Addr]bool, len(resolved)+len(bootstrap))
+	for _, ip := range resolved {
+		if !seen[ip] {
+			seen[ip] = true
+			combined = append(combined, ip)
+		}
+	}
+	for _, ip := range bootstrap {
+		if !seen[ip] {
+			seen[ip] = true
+			combined = append(combined, ip)
+		}
+	}
+	return combined
+}
+
+// filterGlobalUnicastIPs returns only addresses that pass IsGlobalUnicast() &&
+// !IsPrivate(). This excludes loopback, link-local, multicast, RFC1918, and ULA.
+// Note: Go's IsGlobalUnicast() is broader than "publicly routable" — it still
+// admits ranges like 100.64.0.0/10 (CGNAT) and documentation ranges. This is a
+// basic sanity check against obviously wrong answers, not a routability guarantee.
+func filterGlobalUnicastIPs(ips []netip.Addr) []netip.Addr {
+	var out []netip.Addr
+	for _, ip := range ips {
+		ip = ip.Unmap()
+		if ip.IsValid() && ip.IsGlobalUnicast() && !ip.IsPrivate() {
+			out = append(out, ip)
+		}
+	}
+	return out
+}
+
+// buildDNSQuery returns a wire-format DNS query for use in UDP bootstrap lookups.
+func buildDNSQuery(name string, qtype dns.Type) ([]byte, error) {
+	b := dns.NewBuilder(nil, dns.Header{RecursionDesired: true})
+	if err := b.StartQuestions(); err != nil {
+		return nil, err
+	}
+	n, err := dns.NewName(name)
+	if err != nil {
+		return nil, err
+	}
+	if err := b.Question(dns.Question{Name: n, Type: qtype, Class: dns.ClassINET}); err != nil {
+		return nil, err
+	}
+	return b.Finish()
+}
+
+// parseDNSResponseIPs extracts A and AAAA records from a DNS wire response.
+// Used only for UDP bootstrap lookups.
+func parseDNSResponseIPs(resp []byte) ([]netip.Addr, error) {
+	var p dns.Parser
+	if _, err := p.Start(resp); err != nil {
+		return nil, err
+	}
+	if err := p.SkipAllQuestions(); err != nil {
+		return nil, err
+	}
+	var ips []netip.Addr
+	for {
+		rh, err := p.AnswerHeader()
+		if err == dns.ErrSectionDone {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		switch rh.Type {
+		case dns.TypeA:
+			r, err := p.AResource()
+			if err != nil {
+				return nil, err
+			}
+			ips = append(ips, netip.AddrFrom4(r.A))
+		case dns.TypeAAAA:
+			r, err := p.AAAAResource()
+			if err != nil {
+				return nil, err
+			}
+			ips = append(ips, netip.AddrFrom16(r.AAAA))
+		default:
+			if err := p.SkipAnswer(); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return ips, nil
 }
 
 const dohType = "application/dns-message"

--- a/net/dns/resolver/forwarder_test.go
+++ b/net/dns/resolver/forwarder_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -18,6 +19,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	dns "golang.org/x/net/dns/dnsmessage"
@@ -223,6 +225,576 @@ func TestGetKnownDoHClientForProvider(t *testing.T) {
 	}
 	defer res.Body.Close()
 	t.Logf("Got: %+v", res)
+}
+
+// makeBootstrapResponse builds a wire-format DNS response containing the given
+// IP addresses as A or AAAA answer records, for use in bootstrap tests.
+func makeBootstrapResponse(t *testing.T, ips []netip.Addr) []byte {
+	t.Helper()
+	b := dns.NewBuilder(nil, dns.Header{Response: true, RecursionAvailable: true})
+	if err := b.StartQuestions(); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.StartAnswers(); err != nil {
+		t.Fatal(err)
+	}
+	for _, ip := range ips {
+		hdr := dns.ResourceHeader{
+			Name:  dns.MustNewName("dns.nextdns.io."),
+			Class: dns.ClassINET,
+			TTL:   300,
+		}
+		if ip.Is4() {
+			hdr.Type = dns.TypeA
+			if err := b.AResource(hdr, dns.AResource{A: ip.As4()}); err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			hdr.Type = dns.TypeAAAA
+			if err := b.AAAAResource(hdr, dns.AAAAResource{AAAA: ip.As16()}); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	msg, err := b.Finish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return msg
+}
+
+// waitForBootstrap polls until the bootstrap goroutine for urlBase completes
+// or the test deadline is exceeded.
+func waitForBootstrap(t *testing.T, fwd *forwarder, urlBase string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		fwd.mu.Lock()
+		done := !fwd.dohClientBootstrapping.Contains(urlBase)
+		fwd.mu.Unlock()
+		if done {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("timed out waiting for bootstrap goroutine to complete")
+}
+
+// newTestForwarder returns a minimal forwarder suitable for bootstrap tests.
+func newTestForwarder(t *testing.T) *forwarder {
+	t.Helper()
+	fwd := &forwarder{logf: t.Logf}
+	fwd.ctx, fwd.ctxCancel = context.WithCancel(context.Background())
+	t.Cleanup(fwd.ctxCancel)
+	return fwd
+}
+
+func TestNextDNSBootstrapSwapsClient(t *testing.T) {
+	fwd := newTestForwarder(t)
+	urlBase := "https://dns.nextdns.io/abc123"
+
+	unicastA := netip.MustParseAddr("1.2.3.4")
+	unicastAAAA := netip.MustParseAddr("2001:db8::1")
+	var callCount atomic.Int32
+	fwd.nextDNSExchangeFunc = func(ctx context.Context, pkt []byte) ([]byte, error) {
+		n := callCount.Add(1)
+		if n == 1 {
+			return makeBootstrapResponse(t, []netip.Addr{unicastA}), nil
+		}
+		return makeBootstrapResponse(t, []netip.Addr{unicastAAAA}), nil
+	}
+
+	first, ok := fwd.getKnownDoHClientForProvider(urlBase)
+	if !ok {
+		t.Fatal("getKnownDoHClientForProvider returned !ok")
+	}
+
+	waitForBootstrap(t, fwd, urlBase)
+
+	fwd.mu.Lock()
+	upgraded := fwd.dohClient[urlBase]
+	fwd.mu.Unlock()
+
+	if upgraded == first {
+		t.Error("client was not replaced after bootstrap")
+	}
+}
+
+func TestNextDNSBootstrapFailureKeepsAnycast(t *testing.T) {
+	fwd := newTestForwarder(t)
+	urlBase := "https://dns.nextdns.io/abc123"
+
+	fwd.nextDNSExchangeFunc = func(ctx context.Context, pkt []byte) ([]byte, error) {
+		return nil, errors.New("injected transport failure")
+	}
+
+	first, ok := fwd.getKnownDoHClientForProvider(urlBase)
+	if !ok {
+		t.Fatal("getKnownDoHClientForProvider returned !ok")
+	}
+
+	waitForBootstrap(t, fwd, urlBase)
+
+	fwd.mu.Lock()
+	current := fwd.dohClient[urlBase]
+	fwd.mu.Unlock()
+
+	if current != first {
+		t.Error("client was swapped despite bootstrap failure")
+	}
+}
+
+func TestNextDNSBootstrapEmptyResultKeepsAnycast(t *testing.T) {
+	fwd := newTestForwarder(t)
+	urlBase := "https://dns.nextdns.io/abc123"
+
+	// Return only private IPs; filterGlobalUnicastIPs will drop them all.
+	fwd.nextDNSExchangeFunc = func(ctx context.Context, pkt []byte) ([]byte, error) {
+		return makeBootstrapResponse(t, []netip.Addr{netip.MustParseAddr("192.168.1.1")}), nil
+	}
+
+	first, ok := fwd.getKnownDoHClientForProvider(urlBase)
+	if !ok {
+		t.Fatal("getKnownDoHClientForProvider returned !ok")
+	}
+
+	waitForBootstrap(t, fwd, urlBase)
+
+	fwd.mu.Lock()
+	current := fwd.dohClient[urlBase]
+	fwd.mu.Unlock()
+
+	if current != first {
+		t.Error("client was swapped despite all resolved IPs being filtered out")
+	}
+}
+
+func TestNextDNSBootstrapNoDuplicateGoroutines(t *testing.T) {
+	fwd := newTestForwarder(t)
+	urlBase := "https://dns.nextdns.io/abc123"
+
+	var callCount atomic.Int32
+	fwd.nextDNSExchangeFunc = func(ctx context.Context, pkt []byte) ([]byte, error) {
+		callCount.Add(1)
+		return makeBootstrapResponse(t, []netip.Addr{netip.MustParseAddr("1.2.3.4")}), nil
+	}
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			fwd.getKnownDoHClientForProvider(urlBase)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	waitForBootstrap(t, fwd, urlBase)
+
+	// Exactly one goroutine should have been launched: 2 calls (A + AAAA).
+	if n := callCount.Load(); n > 2 {
+		t.Errorf("exchange func called %d times, want ≤ 2", n)
+	}
+}
+
+func TestNonNextDNSNoBootstrap(t *testing.T) {
+	fwd := newTestForwarder(t)
+	urlBase := "https://cloudflare-dns.com/dns-query"
+
+	_, ok := fwd.getKnownDoHClientForProvider(urlBase)
+	if !ok {
+		t.Fatal("getKnownDoHClientForProvider returned !ok")
+	}
+
+	fwd.mu.Lock()
+	bootstrapping := len(fwd.dohClientBootstrapping)
+	fwd.mu.Unlock()
+
+	if bootstrapping != 0 {
+		t.Errorf("dohClientBootstrapping non-empty for non-NextDNS provider, len=%d", bootstrapping)
+	}
+}
+
+func TestSendBootstrapDNS(t *testing.T) {
+	// Spin up a local UDP server that echoes back with a controlled response.
+	pc, err := net.ListenPacket("udp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pc.Close()
+	serverAddr := pc.LocalAddr().(*net.UDPAddr)
+	serverAddrPort := netip.AddrPortFrom(netip.MustParseAddr(serverAddr.IP.String()), uint16(serverAddr.Port))
+
+	canned := makeBootstrapResponse(t, []netip.Addr{netip.MustParseAddr("1.2.3.4")})
+
+	// serveOnce reads one packet, patches in the response txid (matching the
+	// request), and sends canned back. tamperTxid overrides the txid written
+	// to the response (to simulate a mismatch).
+	serveOnce := func(tamperTxid uint16, useTamper bool) {
+		buf := make([]byte, 4096)
+		n, addr, err := pc.ReadFrom(buf)
+		if err != nil {
+			return
+		}
+		resp := make([]byte, len(canned))
+		copy(resp, canned)
+		if useTamper {
+			binary.BigEndian.PutUint16(resp[0:2], tamperTxid)
+		} else {
+			// Echo the request txid back.
+			binary.BigEndian.PutUint16(resp[0:2], binary.BigEndian.Uint16(buf[:n]))
+		}
+		pc.WriteTo(resp, addr)
+	}
+
+	fwd := newTestForwarder(t)
+
+	query, err := buildDNSQuery("dns.nextdns.io.", dns.TypeA)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Normal case: response round-trips.
+	go serveOnce(0, false)
+	ctx := context.Background()
+	got, err := fwd.sendBootstrapDNS(ctx, serverAddrPort, query)
+	if err != nil {
+		t.Fatalf("sendBootstrapDNS: %v", err)
+	}
+	if len(got) == 0 {
+		t.Error("got empty response")
+	}
+
+	// Txid mismatch: loop should keep reading until deadline, then return error.
+	go serveOnce(0xdead, true)
+	tctx, tcancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	_, err = fwd.sendBootstrapDNS(tctx, serverAddrPort, query)
+	tcancel()
+	if err == nil {
+		t.Error("expected error on txid mismatch, got nil")
+	}
+
+	// Wrong source: loop should keep reading until deadline, then return error.
+	pc2, err := net.ListenPacket("udp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pc2.Close()
+	go func() {
+		// Read the outgoing request on server1 to learn the client's ephemeral
+		// port, then send a correctly-txid'd response from server2 instead.
+		buf := make([]byte, 4096)
+		n, clientAddr, err := pc.ReadFrom(buf)
+		if err != nil {
+			return
+		}
+		resp := make([]byte, len(canned))
+		copy(resp, canned)
+		binary.BigEndian.PutUint16(resp[0:2], binary.BigEndian.Uint16(buf[:n]))
+		pc2.WriteTo(resp, clientAddr) // wrong source: pc2, not pc (server1)
+	}()
+	tctx, tcancel = context.WithTimeout(context.Background(), 500*time.Millisecond)
+	_, err = fwd.sendBootstrapDNS(tctx, serverAddrPort, query)
+	tcancel()
+	if err == nil {
+		t.Error("expected error on wrong source addr, got nil")
+	}
+}
+
+func TestNextDNSBootstrapIPFallback(t *testing.T) {
+	// First server responds with a wrong txid (sendBootstrapDNS will reject it).
+	// Second server responds correctly. The exchangeFn should fall through to the
+	// second server and the client should be upgraded.
+	bad, err := net.ListenPacket("udp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bad.Close()
+	// Serve bad responses (wrong txid).
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			_, addr, err := bad.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+			bad.WriteTo([]byte{0xde, 0xad}, addr) // too short / wrong txid
+		}
+	}()
+
+	good, err := net.ListenPacket("udp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer good.Close()
+	goodAddr := good.LocalAddr().(*net.UDPAddr)
+	goodAddrPort := netip.AddrPortFrom(netip.MustParseAddr(goodAddr.IP.String()), uint16(goodAddr.Port))
+
+	canned := makeBootstrapResponse(t, []netip.Addr{netip.MustParseAddr("1.2.3.4")})
+
+	// Serve valid responses on the good server.
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, addr, err := good.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+			resp := make([]byte, len(canned))
+			copy(resp, canned)
+			binary.BigEndian.PutUint16(resp[0:2], binary.BigEndian.Uint16(buf[:n]))
+			good.WriteTo(resp, addr)
+		}
+	}()
+
+	badAddr := bad.LocalAddr().(*net.UDPAddr)
+	badAddrPort := netip.AddrPortFrom(netip.MustParseAddr(badAddr.IP.String()), uint16(badAddr.Port))
+
+	fwd := newTestForwarder(t)
+	fwd.testBootstrapUDPServers = []netip.AddrPort{badAddrPort, goodAddrPort}
+
+	urlBase := "https://dns.nextdns.io/abc123"
+	first, ok := fwd.getKnownDoHClientForProvider(urlBase)
+	if !ok {
+		t.Fatal("getKnownDoHClientForProvider returned !ok")
+	}
+
+	waitForBootstrap(t, fwd, urlBase)
+
+	fwd.mu.Lock()
+	upgraded := fwd.dohClient[urlBase]
+	fwd.mu.Unlock()
+
+	if upgraded == first {
+		t.Error("client was not upgraded after fallback bootstrap")
+	}
+}
+
+func TestNextDNSBootstrapRetryAfterFailure(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		urlBase := "https://dns.nextdns.io/abc123"
+
+		var callCount atomic.Int32
+
+		fwd := newTestForwarder(t)
+
+		// First exchange always fails.
+		fwd.nextDNSExchangeFunc = func(ctx context.Context, pkt []byte) ([]byte, error) {
+			callCount.Add(1)
+			return nil, errors.New("injected failure")
+		}
+
+		first, ok := fwd.getKnownDoHClientForProvider(urlBase)
+		if !ok {
+			t.Fatal("getKnownDoHClientForProvider returned !ok")
+		}
+		synctest.Wait() // wait for bootstrap goroutine to finish
+
+		// Confirm failure was recorded.
+		fwd.mu.Lock()
+		_, hasPending := fwd.dohClientNextRetry[urlBase]
+		fwd.mu.Unlock()
+		if !hasPending {
+			t.Fatal("expected dohClientNextRetry entry after failure, got none")
+		}
+		callsBefore := callCount.Load()
+
+		// Call again immediately — cooldown is active, no new goroutine should launch.
+		c2, ok := fwd.getKnownDoHClientForProvider(urlBase)
+		if !ok {
+			t.Fatal("second getKnownDoHClientForProvider returned !ok")
+		}
+		if c2 != first {
+			t.Error("cached client changed unexpectedly during cooldown")
+		}
+		synctest.Wait() // drain any spurious goroutines
+		if callCount.Load() != callsBefore {
+			t.Error("exchange func called during cooldown — unexpected retry goroutine launched")
+		}
+
+		// Now make retries succeed.
+		canned := makeBootstrapResponse(t, []netip.Addr{netip.MustParseAddr("1.2.3.4")})
+		fwd.nextDNSExchangeFunc = func(ctx context.Context, pkt []byte) ([]byte, error) {
+			callCount.Add(1)
+			return canned, nil
+		}
+
+		// Fast-forward the cooldown by moving the retry time to the past.
+		fwd.mu.Lock()
+		fwd.dohClientNextRetry[urlBase] = time.Now().Add(-1 * time.Second)
+		fwd.mu.Unlock()
+
+		// Next call should launch the retry goroutine.
+		_, ok = fwd.getKnownDoHClientForProvider(urlBase)
+		if !ok {
+			t.Fatal("third getKnownDoHClientForProvider returned !ok")
+		}
+		synctest.Wait() // wait for retry goroutine to finish
+
+		fwd.mu.Lock()
+		upgraded := fwd.dohClient[urlBase]
+		_, stillPending := fwd.dohClientNextRetry[urlBase]
+		fwd.mu.Unlock()
+
+		if upgraded == first {
+			t.Error("client was not upgraded after successful retry")
+		}
+		if stillPending {
+			t.Error("dohClientNextRetry entry not cleared after successful retry")
+		}
+	})
+}
+
+func TestCombineBootstrapIPs(t *testing.T) {
+	mustParse := func(s string) netip.Addr { return netip.MustParseAddr(s) }
+
+	resolved := []netip.Addr{mustParse("1.2.3.4"), mustParse("2001:db8::1")}
+	bootstrap := []netip.Addr{mustParse("45.90.28.0"), mustParse("1.2.3.4")} // 1.2.3.4 is a dup
+
+	got := combineBootstrapIPs(resolved, bootstrap)
+	want := []netip.Addr{
+		mustParse("1.2.3.4"),
+		mustParse("2001:db8::1"),
+		mustParse("45.90.28.0"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len(got)=%d, want %d; got=%v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got[%d]=%v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestResolveBootstrapHostnamePartialSuccess(t *testing.T) {
+	mustParse := func(s string) netip.Addr { return netip.MustParseAddr(s) }
+	someA := makeBootstrapResponse(t, []netip.Addr{mustParse("1.2.3.4")})
+	someAAAA := makeBootstrapResponse(t, []netip.Addr{mustParse("2001:db8::1")})
+	empty := makeBootstrapResponse(t, nil)
+	injected := errors.New("injected")
+
+	tests := []struct {
+		name      string
+		responses [2]struct {
+			data []byte
+			err  error
+		}
+		wantIPs []netip.Addr
+		wantErr bool
+	}{
+		{
+			name: "A succeeds AAAA fails",
+			responses: [2]struct {
+				data []byte
+				err  error
+			}{{someA, nil}, {nil, injected}},
+			wantIPs: []netip.Addr{mustParse("1.2.3.4")},
+		},
+		{
+			name: "AAAA succeeds A fails",
+			responses: [2]struct {
+				data []byte
+				err  error
+			}{{nil, injected}, {someAAAA, nil}},
+			wantIPs: []netip.Addr{mustParse("2001:db8::1")},
+		},
+		{
+			name: "both fail",
+			responses: [2]struct {
+				data []byte
+				err  error
+			}{{nil, injected}, {nil, injected}},
+			wantErr: true,
+		},
+		{
+			name: "both succeed with no records",
+			responses: [2]struct {
+				data []byte
+				err  error
+			}{{empty, nil}, {empty, nil}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var call int
+			exchangeFn := func(ctx context.Context, pkt []byte) ([]byte, error) {
+				r := tt.responses[call]
+				call++
+				return r.data, r.err
+			}
+			got, err := resolveBootstrapHostname(context.Background(), t.Logf, "dns.nextdns.io.", exchangeFn)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !slices.Equal(got, tt.wantIPs) {
+				t.Errorf("got %v, want %v", got, tt.wantIPs)
+			}
+		})
+	}
+}
+
+func TestBuildDNSQuery(t *testing.T) {
+	for _, qtype := range []dns.Type{dns.TypeA, dns.TypeAAAA} {
+		pkt, err := buildDNSQuery("dns.nextdns.io.", qtype)
+		if err != nil {
+			t.Fatalf("buildDNSQuery(%v): %v", qtype, err)
+		}
+		var p dns.Parser
+		hdr, err := p.Start(pkt)
+		if err != nil {
+			t.Fatalf("parse header: %v", err)
+		}
+		if !hdr.RecursionDesired {
+			t.Error("RecursionDesired not set")
+		}
+		q, err := p.Question()
+		if err != nil {
+			t.Fatalf("parse question: %v", err)
+		}
+		if q.Type != qtype {
+			t.Errorf("question type = %v, want %v", q.Type, qtype)
+		}
+		if q.Name.String() != "dns.nextdns.io." {
+			t.Errorf("question name = %q, want %q", q.Name.String(), "dns.nextdns.io.")
+		}
+	}
+}
+
+func TestParseDNSResponseIPs(t *testing.T) {
+	mustParse := func(s string) netip.Addr { return netip.MustParseAddr(s) }
+
+	want := []netip.Addr{mustParse("1.2.3.4"), mustParse("2001:db8::1")}
+	resp := makeBootstrapResponse(t, want)
+
+	got, err := parseDNSResponseIPs(resp)
+	if err != nil {
+		t.Fatalf("parseDNSResponseIPs: %v", err)
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	// Empty response should return nil, nil.
+	empty := makeBootstrapResponse(t, nil)
+	got, err = parseDNSResponseIPs(empty)
+	if err != nil {
+		t.Fatalf("parseDNSResponseIPs(empty): %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("empty response: got %v, want empty", got)
+	}
 }
 
 func BenchmarkNameFromQuery(b *testing.B) {


### PR DESCRIPTION
Resolves a TODO left by bradfitz in net/dns/publicdns/publicdns.go (DoHIPsOfBase).

NextDNS DoH clients in the forwarder are seeded with anycast IPs from DoHIPsOfBase. These work but may have higher latency than the lower latency IPs NextDNS assigns per region. The TODO noted that the right fix was to resolve dns.nextdns.io first and use the resulting IPs for DoH instead of anycast.

This adds a background bootstrap that resolves dns.nextdns.io immediately after the first DoH client is built. On success the cached client is atomically replaced with one whose dialer prefers the resolved lower latency IPs, with anycast kept as fallback. On failure the anycast client remains unchanged and a 5-minute cooldown is recorded; the next natural DNS query after the cooldown triggers a retry, so a transient failure at startup does not permanently prevent the optimization.

The bootstrap adapter patches a random txid into each query, verifies it and the source AddrPort on the response, sets a read deadline from the caller's context, and falls back across all IPs from DoHIPsOfBase with a 2-second per-IP timeout inside a 5-second overall context.

Updates #6130
