### PR TITLE
cmd/tailscale/cli: add a debug command to print the statedir

### DIFF
--- a/cmd/tailscale/cli/debug.go
+++ b/cmd/tailscale/cli/debug.go
@@ -387,6 +387,12 @@ func debugCmd() *ffcli.Command {
 					return fs
 				})(),
 			},
+			{
+				Name:       "statedir",
+				ShortUsage: "tailscale debug statedir",
+				ShortHelp:  "Print the location of the state directory (if any)",
+				Exec:       runPrintStateDir,
+			},
 			ccall(debugPeerRelayCmd),
 		}...),
 	}
@@ -1406,4 +1412,23 @@ func runTestRisk(ctx context.Context, args []string) error {
 	}
 	fmt.Println("did-test-risky-action")
 	return nil
+}
+
+func runPrintStateDir(ctx context.Context, args []string) error {
+	if len(args) > 0 {
+		return errors.New("unexpected arguments")
+	}
+	v, err := localClient.DebugResultJSON(ctx, "statedir")
+	if err != nil {
+		return err
+	}
+	statedir, ok := v.(string)
+	if ok && statedir != "" {
+		fmt.Println(statedir)
+		return nil
+	} else if ok && statedir == "" {
+		return errors.New("no statedir is set")
+	} else {
+		return fmt.Errorf("got unexpected response from debug API: %v", v)
+	}
 }

--- a/ipn/localapi/debug.go
+++ b/ipn/localapi/debug.go
@@ -234,6 +234,13 @@ func (h *Handler) serveDebug(w http.ResponseWriter, r *http.Request) {
 		}
 	case "rotate-disco-key":
 		err = h.b.DebugRotateDiscoKey()
+	case "statedir":
+		root := h.b.TailscaleVarRoot()
+		w.Header().Set("Content-Type", "application/json")
+		err = json.NewEncoder(w).Encode(root)
+		if err == nil {
+			return
+		}
 	case "":
 		err = fmt.Errorf("missing parameter 'action'")
 	default:


### PR DESCRIPTION
Example:

```console
$ tailscale debug statedir
/tmp/ts/node1
```

Updates #18019