### PR TITLE
.github/workflows: limit vet to the tailscale.com module

### DIFF
--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -36,4 +36,8 @@ jobs:
 
       - name: Run 'go vet'
         working-directory: src
-        run: ./tool/go vet -vettool=/tmp/vettool tailscale.com/...
+        # Must use ./... instead of tailscale.com/... because the latter will
+        # include the v2 go client (tailscale.com/client/tailscale/v2) if it's
+        # a dependency in our go.mod file. Possibly a go vet bug, but avoid
+        # cross-repo vetting for now so we can safely add the dependency.
+        run: ./tool/go vet -vettool=/tmp/vettool ./...


### PR DESCRIPTION
This repo's module is tailscale.com, and the tailscale-client-go-v2 repo uses tailscale.com/client/tailscale/v2. It seems from #19010 that if we have the client module as a dependency in this module, go vet will start to consider the client module as part of tailscale.com/...

I'm not sure if this is a bug in go vet, but for now let's take the easy fix and specify ./... instead. In my testing, it seems like this is sufficient to make sure it just walks the file hierarchy and doesn't find the client module as a sub-path.

Updates tailscale/corp#38418