### PR TITLE
all: use `bart.Lite` instead of `bart.Table` where appropriate

### DIFF
--- a/cmd/natc/natc.go
+++ b/cmd/natc/natc.go
@@ -82,14 +82,14 @@ func main() {
 		log.Fatalf("site-id must be in the range [0, 65535]")
 	}
 
-	var ignoreDstTable *bart.Table[bool]
+	var ignoreDstTable *bart.Lite
 	for s := range strings.SplitSeq(*ignoreDstPfxStr, ",") {
 		s := strings.TrimSpace(s)
 		if s == "" {
 			continue
 		}
 		if ignoreDstTable == nil {
-			ignoreDstTable = &bart.Table[bool]{}
+			ignoreDstTable = &bart.Lite{}
 		}
 		pfx, err := netip.ParsePrefix(s)
 		if err != nil {
@@ -98,7 +98,7 @@ func main() {
 		if pfx.Masked() != pfx {
 			log.Fatalf("prefix %v is not normalized (bits are set outside the mask)", pfx)
 		}
-		ignoreDstTable.Insert(pfx, true)
+		ignoreDstTable.Insert(pfx)
 	}
 	ts := &tsnet.Server{
 		Hostname: *hostname,
@@ -276,7 +276,7 @@ type connector struct {
 	// and if any of the ip addresses in response to the lookup match any 'ignore destinations' prefix we will
 	// return a dns response that contains the ip addresses we discovered with the lookup (ie not the
 	// natc behavior, which would return a dummy ip address pointing at natc).
-	ignoreDsts *bart.Table[bool]
+	ignoreDsts *bart.Lite
 
 	// ipPool contains the per-peer IPv4 address assignments.
 	ipPool ippool.IPPool
@@ -538,7 +538,7 @@ func (c *connector) ignoreDestination(dstAddrs []netip.Addr) bool {
 		return false
 	}
 	for _, a := range dstAddrs {
-		if _, ok := c.ignoreDsts.Lookup(a); ok {
+		if c.ignoreDsts.Contains(a) {
 			return true
 		}
 	}

--- a/cmd/natc/natc_test.go
+++ b/cmd/natc/natc_test.go
@@ -268,13 +268,13 @@ func TestDNSResponse(t *testing.T) {
 				},
 			},
 		},
-		ignoreDsts: &bart.Table[bool]{},
+		ignoreDsts: &bart.Lite{},
 		routes:     routes,
 		v6ULA:      v6ULA,
 		ipPool:     &ippool.SingleMachineIPPool{IPSet: addrPool},
 		dnsAddr:    dnsAddr,
 	}
-	c.ignoreDsts.Insert(netip.MustParsePrefix("8.8.4.4/32"), true)
+	c.ignoreDsts.Insert(netip.MustParsePrefix("8.8.4.4/32"))
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -411,9 +411,9 @@ func TestDNSResponse(t *testing.T) {
 }
 
 func TestIgnoreDestination(t *testing.T) {
-	ignoreDstTable := &bart.Table[bool]{}
-	ignoreDstTable.Insert(netip.MustParsePrefix("192.168.1.0/24"), true)
-	ignoreDstTable.Insert(netip.MustParsePrefix("10.0.0.0/8"), true)
+	ignoreDstTable := &bart.Lite{}
+	ignoreDstTable.Insert(netip.MustParsePrefix("192.168.1.0/24"))
+	ignoreDstTable.Insert(netip.MustParsePrefix("10.0.0.0/8"))
 
 	c := &connector{
 		ignoreDsts: ignoreDstTable,

--- a/net/ipset/ipset.go
+++ b/net/ipset/ipset.go
@@ -20,13 +20,6 @@ func FalseContainsIPFunc() func(ip netip.Addr) bool {
 
 func emptySet(ip netip.Addr) bool { return false }
 
-func bartLookup(t *bart.Table[struct{}]) func(netip.Addr) bool {
-	return func(ip netip.Addr) bool {
-		_, ok := t.Lookup(ip)
-		return ok
-	}
-}
-
 func prefixContainsLoop(addrs []netip.Prefix) func(netip.Addr) bool {
 	return func(ip netip.Addr) bool {
 		for _, p := range addrs {
@@ -81,11 +74,11 @@ func NewContainsIPFunc(addrs views.Slice[netip.Prefix]) func(ip netip.Addr) bool
 		}
 		pathForTest("bart")
 		// Built a bart table.
-		t := &bart.Table[struct{}]{}
+		t := &bart.Lite{}
 		for _, p := range addrs.All() {
-			t.Insert(p, struct{}{})
+			t.Insert(p)
 		}
-		return bartLookup(t)
+		return t.Contains
 	}
 	// Fast paths for 1 and 2 IPs:
 	if addrs.Len() == 1 {

--- a/wgengine/pendopen.go
+++ b/wgengine/pendopen.go
@@ -101,7 +101,7 @@ var (
 	appleIPRange = netip.MustParsePrefix("17.0.0.0/8")
 	canonicalIPs = sync.OnceValue(func() (checkIPFunc func(netip.Addr) bool) {
 		// https://bgp.he.net/AS41231#_prefixes
-		t := &bart.Table[bool]{}
+		t := &bart.Lite{}
 		for s := range strings.FieldsSeq(`
 			91.189.89.0/24
 			91.189.91.0/24
@@ -115,12 +115,9 @@ var (
 			185.125.188.0/23
 			185.125.190.0/24
 			194.169.254.0/24`) {
-			t.Insert(netip.MustParsePrefix(s), true)
+			t.Insert(netip.MustParsePrefix(s))
 		}
-		return func(ip netip.Addr) bool {
-			v, _ := t.Lookup(ip)
-			return v
-		}
+		return t.Contains
 	})
 )
 


### PR DESCRIPTION
When we don't care about the payload value and are just checking whether a set contains an IP/prefix, we can use `bart.Lite` for the same lookup times but a lower memory footprint.

Fixes #19075