### PR TITLE
FR: Taildrive support on freebsd #19077

### DIFF
--- a/ipn/ipnserver/actor.go
+++ b/ipn/ipnserver/actor.go
@@ -145,7 +145,7 @@ func (a *actor) Username() (string, error) {
 		}
 		defer tok.Close()
 		return tok.Username()
-	case "darwin", "linux", "illumos", "solaris", "openbsd":
+	case "darwin", "linux", "illumos", "solaris", "openbsd", "freebsd":
 		creds := a.ci.Creds()
 		if creds == nil {
 			return "", errors.New("peer credentials not implemented on this OS")


### PR DESCRIPTION
This change adds FreeBSD to the list of platforms that support peer credentials. It fixes `tailscale drive share <SHARE> /path/to/share` on FreeBSD, which was previously failing because the platform was not recognized as supporting peer credentials