### PR TITLE
ipn: fix the typo causing NoSNAT always set to true

### DIFF
--- a/ipn/conf.go
+++ b/ipn/conf.go
@@ -117,7 +117,7 @@ func (c *ConfigVAlpha) ToPrefs() (MaskedPrefs, error) {
 	}
 	if c.DisableSNAT != "" {
 		mp.NoSNAT = c.DisableSNAT.EqualBool(true)
-		mp.NoSNAT = true
+		mp.NoSNATSet = true
 	}
 	if c.NoStatefulFiltering != "" {
 		mp.NoStatefulFiltering = c.NoStatefulFiltering


### PR DESCRIPTION
As title described.

Fixes #19109