### PR TITLE
net/dns/resolver: defer to split DNS routes for reverse queries

### DIFF
--- a/net/dns/resolver/forwarder.go
+++ b/net/dns/resolver/forwarder.go
@@ -1010,6 +1010,20 @@ func (f *forwarder) resolvers(domain dnsname.FQDN) []resolverAndDelay {
 	return cloudHostFallback // or nil if no fallback
 }
 
+// reports whether the forwarder has a non-catch-all route
+// (not the "." suffix) that matches the given domain.
+func (f *forwarder) hasSpecificRouteFor(domain dnsname.FQDN) bool {
+	f.mu.Lock()
+	routes := f.routes
+	f.mu.Unlock()
+	for _, route := range routes {
+		if route.Suffix != "." && route.Suffix.Contains(domain) {
+			return true
+		}
+	}
+	return false
+}
+
 // GetUpstreamResolvers returns the resolvers that would be used to resolve
 // the given FQDN.
 func (f *forwarder) GetUpstreamResolvers(name dnsname.FQDN) []*dnstype.Resolver {

--- a/net/dns/resolver/tsdns.go
+++ b/net/dns/resolver/tsdns.go
@@ -847,6 +847,13 @@ func (r *Resolver) resolveLocalReverse(name dnsname.FQDN) (dnsname.FQDN, dns.RCo
 		return "", dns.RCodeRefused
 	}
 
+	// If the forwarder has a specific split DNS route for this reverse
+	// DNS name, defer to it rather than answering from MagicDNS. The
+	// user has explicitly configured an upstream for this zone.
+	if r.forwarder != nil && r.forwarder.hasSpecificRouteFor(name) {
+		return "", dns.RCodeRefused
+	}
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/net/dns/resolver/tsdns_test.go
+++ b/net/dns/resolver/tsdns_test.go
@@ -514,6 +514,64 @@ func TestResolveLocalReverse(t *testing.T) {
 	}
 }
 
+// tests that when a split DNS route is configured for a reverse DNS zone,
+// PTR queries are forwarded to the configured upstream resolver rather than
+// being answered locally by MagicDNS.
+// See https://github.com/tailscale/tailscale/issues/18370
+func TestResolveLocalReverseSplitDNS(t *testing.T) {
+	r := newResolver(t)
+	defer r.Close()
+
+	// Configure with:
+	// - Hosts mapping 1.2.3.4 -> test1.ipn.dev (MagicDNS)
+	// - A split DNS route for 3.2.1.in-addr.arpa -> upstream resolver
+	// The split DNS route should take priority over the MagicDNS answer.
+	r.SetConfig(Config{
+		Hosts: map[dnsname.FQDN][]netip.Addr{
+			"test1.ipn.dev.": {testipv4},
+			"test2.ipn.dev.": {testipv6},
+		},
+		LocalDomains: []dnsname.FQDN{"ipn.dev."},
+		Routes: map[dnsname.FQDN][]*dnstype.Resolver{
+			"3.2.1.in-addr.arpa.": {
+				{Addr: "100.100.100.100:53"},
+			},
+		},
+	})
+
+	tests := []struct {
+		name string
+		q    dnsname.FQDN
+		want dnsname.FQDN
+		code dns.RCode
+	}{
+		// PTR for 1.2.3.4 falls within the 3.2.1.in-addr.arpa split DNS route,
+		// so it should be forwarded (RCodeRefused) not answered locally.
+		{"ipv4_split_dns", testipv4Arpa, "", dns.RCodeRefused},
+		// PTR for an IP not in ipToHost but within the split DNS route
+		// should also be forwarded.
+		{"ipv4_split_dns_unknown", dnsname.FQDN("5.3.2.1.in-addr.arpa."), "", dns.RCodeRefused},
+		// PTR for an IP outside any split DNS route and not in ipToHost
+		// should still be refused (forwarded to default upstream).
+		{"ipv4_no_route", dnsname.FQDN("2.3.4.5.in-addr.arpa."), "", dns.RCodeRefused},
+		// The Tailscale service IP should still resolve locally even if
+		// its reverse zone has a split DNS route.
+		{"magicdns", dnsname.FQDN("100.100.100.100.in-addr.arpa."), dnsSymbolicFQDN, dns.RCodeSuccess},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, code := r.resolveLocalReverse(tt.q)
+			if code != tt.code {
+				t.Errorf("code = %v; want %v", code, tt.code)
+			}
+			if name != tt.want {
+				t.Errorf("name = %v; want %v", name, tt.want)
+			}
+		})
+	}
+}
+
 func ipv6Works() bool {
 	c, err := net.Listen("tcp", "[::1]:0")
 	if err != nil {


### PR DESCRIPTION
When a user configures a split DNS route for a reverse DNS zone (e.g. `76.100.in-addr.arpa`), PTR queries for IPs in that range were being answered locally by MagicDNS instead of being forwarded to the configured upstream resolver (the resolver was checking the local `ipToHost` map before considering forwarder routes).


This PR makes  `resolveLocalReverse` check if the forwarder has a specific (non-catch-all) route for the query name, and returns `RCodeRefused` if so, allowing the query to be forwarded.   
                    
## Changes 
                                                                                                                         
  - Added `hasSpecificRouteFor` method to forwarder to check for                                                                             
    non-catch-all routes
  - Modified `resolveLocalReverse` to check forwarder routes before                                                                          
    local resolution                                        
  - Added `TestResolveLocalReverseSplitDNS` regression test                                                                                  

Fixes #18370