### PR TITLE
ipn/ipnserver: allow localapi access when unixsocketidentity is omitted

### DIFF
--- a/ipn/ipnserver/server.go
+++ b/ipn/ipnserver/server.go
@@ -348,6 +348,10 @@ func (a *actor) Permissions(operatorUID string) (read, write bool) {
 	case "js", "plan9":
 		return true, true
 	}
+	// Without unix socket identity support, all local users are treated as fully trusted.
+	if runtime.GOOS != "windows" && !buildfeatures.HasUnixSocketIdentity {
+		return true, true
+	}
 	if a.ci.IsUnixSock() {
 		return true, !a.ci.IsReadonlyConn(operatorUID, logger.Discard)
 	}

--- a/ipn/ipnserver/server_omit_unixsocketidentity_test.go
+++ b/ipn/ipnserver/server_omit_unixsocketidentity_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !windows && ts_omit_unixsocketidentity
+
+package ipnserver
+
+import (
+	"testing"
+
+	"tailscale.com/ipn/ipnauth"
+)
+
+func TestActorPermissionsWithoutUnixSocketIdentity(t *testing.T) {
+	a := &actor{
+		ci: &ipnauth.ConnIdentity{},
+	}
+
+	read, write := a.Permissions("")
+	if !read || !write {
+		t.Fatalf("Permissions() = (%v, %v), want (true, true)", read, write)
+	}
+}


### PR DESCRIPTION
When ts_omit_unixsocketidentity is enabled on non-Windows builds,
actor.Permissions would deny LocalAPI access because the connection
identity no longer reports a Unix socket.

Match the existing omitted-feature policy used elsewhere in ipnserver
and treat all local users as fully trusted in that build mode.

Also add a regression test for the omitted-feature build.

Tested with:
  go test -tags ts_omit_unixsocketidentity ./ipn/ipnserver -run TestActorPermissionsWithoutUnixSocketIdentity

Fixes #17873

Signed-off-by: Kareem <16564633+kahoon@users.noreply.github.com>
