### PR TITLE
release/dist/qnap: keep the codesign hash

### DIFF
--- a/release/dist/qnap/files/scripts/build-qpkg.sh
+++ b/release/dist/qnap/files/scripts/build-qpkg.sh
@@ -4,17 +4,9 @@ set -eu
 
 # Clean up folders and files created during build.
 function cleanup() {
-    rm -rf /Tailscale/$ARCH
-    rm -f /Tailscale/sed*
-    rm -f /Tailscale/qpkg.cfg
-
-    # If this build was signed, a .qpkg.codesigning file will be created as an
-    # artifact of the build
-    # (see https://github.com/qnap-dev/qdk2/blob/93ac75c76941b90ee668557f7ce01e4b23881054/QDK_2.x/bin/qbuild#L992).
-    #
-    # go/client-release doesn't seem to need these, so we delete them here to
-    # avoid uploading them to pkgs.tailscale.com.
-    rm -f /out/*.qpkg.codesigning
+	rm -rf /Tailscale/$ARCH
+	rm -f /Tailscale/sed*
+	rm -f /Tailscale/qpkg.cfg
 }
 trap cleanup EXIT
 
@@ -22,6 +14,6 @@ mkdir -p /Tailscale/$ARCH
 cp /tailscaled /Tailscale/$ARCH/tailscaled
 cp /tailscale /Tailscale/$ARCH/tailscale
 
-sed "s/\$QPKG_VER/$TSTAG-$QNAPTAG/g" /Tailscale/qpkg.cfg.in > /Tailscale/qpkg.cfg
+sed "s/\$QPKG_VER/$TSTAG-$QNAPTAG/g" /Tailscale/qpkg.cfg.in >/Tailscale/qpkg.cfg
 
 qbuild --root /Tailscale --build-arch $ARCH --build-dir /out

--- a/release/dist/qnap/pkgs.go
+++ b/release/dist/qnap/pkgs.go
@@ -118,7 +118,16 @@ func (t *target) buildQPKG(b *dist.Build, qnapBuilds *qnapBuilds, inner *innerPk
 		return nil, fmt.Errorf("docker run %v: %s", err, out)
 	}
 
-	return []string{filePath, filePath + ".md5"}, nil
+	ret := []string{filePath, filePath + ".md5"}
+	// If the build was signed, a .codesigning file is produced containing
+	// the last 32 characters of the base64-encoded CMS signature. This is
+	// used by pkgserve to populate <signature> entries in the QNAP
+	// repository XML.
+	codesigning := filePath + ".codesigning"
+	if _, err := os.Stat(codesigning); err == nil {
+		ret = append(ret, codesigning)
+	}
+	return ret, nil
 }
 
 type qnapBuildsMemoizeKey struct{}


### PR DESCRIPTION
This PR keeps the codesign hash for QNAP builds so we can reuse them on the build side.

It is likely used for hosting our own signed QNAP repository.