### PR TITLE
posture: add HealthTracker for serial number retrieval

### DIFF
--- a/feature/posture/posture.go
+++ b/feature/posture/posture.go
@@ -8,8 +8,10 @@ package posture
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
+	"tailscale.com/health"
 	"tailscale.com/ipn/ipnext"
 	"tailscale.com/ipn/ipnlocal"
 	"tailscale.com/posture"
@@ -24,6 +26,15 @@ func init() {
 	ipnext.RegisterExtension("posture", newExtension)
 	ipnlocal.RegisterC2N("GET /posture/identity", handleC2NPostureIdentityGet)
 }
+
+var postureSerialWarnable = health.Register(&health.Warnable{
+	Code:     "posture-checking-serial-collection-failed",
+	Title:    "Device Posture: serial number collection failed",
+	Severity: health.SeverityMedium,
+	Text: func(args health.Args) string {
+		return fmt.Sprintf("Could not collect device serial numbers for posture checking. (%v)", args[health.ArgError])
+	},
+})
 
 func newExtension(logf logger.Logf, b ipnext.SafeBackend) (ipnext.Extension, error) {
 	e := &extension{
@@ -73,6 +84,9 @@ func handleC2NPostureIdentityGet(b *ipnlocal.LocalBackend, w http.ResponseWriter
 		res.SerialNumbers, err = posture.GetSerialNumbers(b.PolicyClient(), e.logf)
 		if err != nil {
 			e.logf("c2n: GetSerialNumbers returned error: %v", err)
+			b.HealthTracker().SetUnhealthy(postureSerialWarnable, health.Args{health.ArgError: err.Error()})
+		} else {
+			b.HealthTracker().SetHealthy(postureSerialWarnable)
 		}
 
 		// TODO(tailscale/corp#21371, 2024-07-10): once this has landed in a stable release

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -4212,6 +4212,8 @@ func (b *LocalBackend) CurrentUserForTest() (ipn.WindowsUserID, ipnauth.Actor) {
 	return b.pm.CurrentUserID(), b.currentUser
 }
 
+// CheckPrefs validates the provided user modifiable settings for correctness
+// and returns an error if they are invalid for the current backend.
 func (b *LocalBackend) CheckPrefs(p *ipn.Prefs) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/posture/serialnumber_stub.go
+++ b/posture/serialnumber_stub.go
@@ -12,6 +12,7 @@ package posture
 
 import (
 	"errors"
+	"fmt"
 
 	"tailscale.com/types/logger"
 	"tailscale.com/util/syspolicy/policyclient"
@@ -19,5 +20,5 @@ import (
 
 // GetSerialNumber returns client machine serial number(s).
 func GetSerialNumbers(polc policyclient.Client, _ logger.Logf) ([]string, error) {
-	return nil, errors.New("not implemented")
+	return nil, fmt.Errorf("not implemented: %w", errors.ErrUnsupported)
 }


### PR DESCRIPTION
Device posture checking can fail while enabled if tailscaled does not
have access to smbios. Previously, this was only observable by looking
in the tailscaled logs.

This changeset also cleans up some leftovers from prior refactors.

Fixes tailscale/corp#39314