### PR TITLE
version: parse Void Linux version strings

### DIFF
--- a/version/cmp.go
+++ b/version/cmp.go
@@ -103,6 +103,11 @@ func parse(version string) (parsed, bool) {
 		}
 	}
 
+	// Ignore trailer like '_1 (Void Linux)'.
+	if rest[0] == '_' && strings.HasSuffix(rest, " (Void Linux)") {
+		return ret, true
+	}
+
 	// Optional extraCommits, if the next bit can be completely
 	// consumed as an integer.
 	if rest[0] != '-' {

--- a/version/cmp_test.go
+++ b/version/cmp_test.go
@@ -33,6 +33,8 @@ func TestParse(t *testing.T) {
 		{"borkbork", parsed{}, false},
 		{"1a.2.3", parsed{}, false},
 		{"", parsed{}, false},
+		{"1.96.2_1 (Void Linux)", parsed{Major: 1, Minor: 96, Patch: 2}, true},
+		{"1.46.0_2 (Void Linux)", parsed{Major: 1, Minor: 46, Patch: 0}, true},
 	}
 
 	for _, test := range tests {
@@ -71,6 +73,7 @@ func TestAtLeast(t *testing.T) {
 		{"date.20200612", "date.20200612", true},
 		{"date.20200701", "date.20200612", true},
 		{"date.20200501", "date.20200612", false},
+		{"1.96.2_1 (Void Linux)", "1.42", true},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
We have ~2.5k nodes running Void Linux, which report a version string like `1.96.2_1 (Void Linux)`. Previously these versions would fail to parse, because we only expect a hyphen and `extraCommits` after the major/minor/patch numbers.

Fix the version parsing logic to handle this case.

Updates #19148