### PR TITLE
tka: consolidate all the limits into a single file

### DIFF
--- a/tka/key.go
+++ b/tka/key.go
@@ -104,8 +104,6 @@ func (k Key) Ed25519() (ed25519.PublicKey, error) {
 	}
 }
 
-const maxMetaBytes = 512
-
 func (k Key) StaticValidate() error {
 	if k.Votes > 4096 {
 		return fmt.Errorf("excessive key weight: %d > 4096", k.Votes)

--- a/tka/limits.go
+++ b/tka/limits.go
@@ -1,0 +1,24 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package tka
+
+const (
+	// Upper bound on checkpoint elements, chosen arbitrarily. Intended
+	// to cap the size of large AUMs.
+	maxDisablementSecrets = 32
+	maxKeys               = 512
+
+	// Max amount of metadata that can be associated with a key, chosen arbitrarily.
+	// Intended to avoid people abusing TKA as a key-value score.
+	maxMetaBytes = 512
+
+	// Max iterations searching for any intersection during the sync process.
+	maxSyncIter = 2000
+
+	// Max iterations searching for a head intersection during the sync process.
+	maxSyncHeadIntersectionIter = 400
+
+	// Limit on scanning AUM trees, chosen arbitrarily.
+	maxScanIterations = 2000
+)

--- a/tka/state.go
+++ b/tka/state.go
@@ -248,13 +248,6 @@ func (s State) applyVerifiedAUM(update AUM) (State, error) {
 	}
 }
 
-// Upper bound on checkpoint elements, chosen arbitrarily. Intended to
-// cap out insanely large AUMs.
-const (
-	maxDisablementSecrets = 32
-	maxKeys               = 512
-)
-
 // staticValidateCheckpoint validates that the state is well-formed for
 // inclusion in a checkpoint AUM.
 func (s *State) staticValidateCheckpoint() error {

--- a/tka/sync.go
+++ b/tka/sync.go
@@ -11,13 +11,6 @@ import (
 	"os"
 )
 
-const (
-	// Max iterations searching for any intersection.
-	maxSyncIter = 2000
-	// Max iterations searching for a head intersection.
-	maxSyncHeadIntersectionIter = 400
-)
-
 // ErrNoIntersection is returned when a shared AUM could
 // not be determined when evaluating a remote sync offer.
 var ErrNoIntersection = errors.New("no intersection")

--- a/tka/tka.go
+++ b/tka/tka.go
@@ -31,9 +31,6 @@ var cborDecOpts = cbor.DecOptions{
 	MaxMapPairs:      1024,
 }
 
-// Arbitrarily chosen limit on scanning AUM trees.
-const maxScanIterations = 2000
-
 // Authority is a Tailnet Key Authority. This type is the main coupling
 // point to the rest of the tailscale client.
 //


### PR DESCRIPTION
This makes the limits easier to find and change, rather than scattering them across the TKA code.

Updates #cleanup