### PR TITLE
gokrazy: add check for qemu

### DIFF
--- a/gokrazy/Makefile
+++ b/gokrazy/Makefile
@@ -9,5 +9,6 @@ qemu: image
 
 # For natlab integration tests:
 natlab:
+	@command -v qemu-img > /dev/null 2>&1 || { echo >&2 "please install qemu"; exit 1; }
 	go run build.go --build --app=natlabapp
 	qemu-img convert -O qcow2 natlabapp.img natlabapp.qcow2


### PR DESCRIPTION
This is a small quality-of-life change for natlab tests. Running the tests without qemu results in an error reading something like 'qemu-img: file not found', which is not too helpful if you don't know the underlying infrastructure. With this change, the error now reads 'please install qemu'.

Updates #cleanup