### PR TITLE
k8s-operator: remove minItems=1 from appConnector routes

### DIFF
--- a/cmd/k8s-operator/connector.go
+++ b/cmd/k8s-operator/connector.go
@@ -218,7 +218,7 @@ func (a *ConnectorReconciler) maybeProvisionConnector(ctx context.Context, logge
 	if cn.Spec.AppConnector != nil {
 		sts.Connector.isAppConnector = true
 		if len(cn.Spec.AppConnector.Routes) != 0 {
-			sts.Connector.routes = cn.Spec.AppConnector.Routes.Stringify()
+			sts.Connector.routes = tsapi.Routes(cn.Spec.AppConnector.Routes).Stringify()
 		}
 	}
 

--- a/cmd/k8s-operator/deploy/crds/tailscale.com_connectors.yaml
+++ b/cmd/k8s-operator/deploy/crds/tailscale.com_connectors.yaml
@@ -99,7 +99,6 @@ spec:
                         also dynamically discover other routes.
                         https://tailscale.com/kb/1332/apps-best-practices#preconfiguration
                       type: array
-                      minItems: 1
                       items:
                         type: string
                         format: cidr

--- a/cmd/k8s-operator/deploy/manifests/operator.yaml
+++ b/cmd/k8s-operator/deploy/manifests/operator.yaml
@@ -125,7 +125,6 @@ spec:
                                         items:
                                             format: cidr
                                             type: string
-                                        minItems: 1
                                         type: array
                                 type: object
                             exitNode:

--- a/k8s-operator/api.md
+++ b/k8s-operator/api.md
@@ -53,7 +53,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `routes` _[Routes](#routes)_ | Routes are optional preconfigured routes for the domains routed via the app connector.<br />If not set, routes for the domains will be discovered dynamically.<br />If set, the app connector will immediately be able to route traffic using the preconfigured routes, but may<br />also dynamically discover other routes.<br />https://tailscale.com/kb/1332/apps-best-practices#preconfiguration |  | Format: cidr <br />MinItems: 1 <br />Type: string <br /> |
+| `routes` _[Route](#route) array_ | Routes are optional preconfigured routes for the domains routed via the app connector.<br />If not set, routes for the domains will be discovered dynamically.<br />If set, the app connector will immediately be able to route traffic using the preconfigured routes, but may<br />also dynamically discover other routes.<br />https://tailscale.com/kb/1332/apps-best-practices#preconfiguration |  | Format: cidr <br />Type: string <br /> |
 
 
 
@@ -1049,6 +1049,7 @@ _Validation:_
 - Type: string
 
 _Appears in:_
+- [AppConnector](#appconnector)
 - [Routes](#routes)
 
 
@@ -1065,7 +1066,6 @@ _Validation:_
 - Type: string
 
 _Appears in:_
-- [AppConnector](#appconnector)
 - [SubnetRouter](#subnetrouter)
 
 

--- a/k8s-operator/apis/v1alpha1/types_connector.go
+++ b/k8s-operator/apis/v1alpha1/types_connector.go
@@ -159,7 +159,7 @@ type AppConnector struct {
 	// also dynamically discover other routes.
 	// https://tailscale.com/kb/1332/apps-best-practices#preconfiguration
 	// +optional
-	Routes Routes `json:"routes"`
+	Routes []Route `json:"routes,omitempty"`
 }
 
 type Tags []Tag

--- a/k8s-operator/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/k8s-operator/apis/v1alpha1/zz_generated.deepcopy.go
@@ -18,7 +18,7 @@ func (in *AppConnector) DeepCopyInto(out *AppConnector) {
 	*out = *in
 	if in.Routes != nil {
 		in, out := &in.Routes, &out.Routes
-		*out = make(Routes, len(*in))
+		*out = make([]Route, len(*in))
 		copy(*out, *in)
 	}
 }


### PR DESCRIPTION
- Decouples `AppConnector.Routes` from the shared `Routes` type which enforces `MinItems=1`
- `appConnector: {}` now passes CRD validation through server-side apply
- No impact on `SubnetRouter.AdvertiseRoutes` which keeps `MinItems=1`
Fixes #19195