### PR TITLE
control/controlclient,ipn/ipnlocal,net/dnscache: reset stale connection state on link change

### DIFF
--- a/control/controlclient/auto.go
+++ b/control/controlclient/auto.go
@@ -226,6 +226,17 @@ func (c *Auto) SetPaused(paused bool) {
 	c.unpauseWaiters = nil
 }
 
+// ResetConnections discards cached DNS, HTTP connection, and Noise client
+// state, and cancels in-flight auth/map requests so that retries use
+// fresh connections immediately. It should be called on major link changes.
+func (c *Auto) ResetConnections() {
+	c.direct.ResetConnections()
+	c.mu.Lock()
+	c.cancelAuthCtxLocked()
+	c.cancelMapCtxLocked()
+	c.mu.Unlock()
+}
+
 // StartForTest starts the client's goroutines.
 //
 // It should only be called for clients created with [Options.SkipStartForTests].

--- a/control/controlclient/client.go
+++ b/control/controlclient/client.go
@@ -93,4 +93,8 @@ type Client interface {
 	// ClientID returns the ClientID of a client. This ID is meant to
 	// distinguish one client from another.
 	ClientID() int64
+	// ResetConnections discards cached DNS, HTTP, and Noise connection
+	// state. Called on major link changes to avoid using stale state
+	// from the previous network.
+	ResetConnections()
 }

--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -414,6 +414,21 @@ func (c *Direct) Close() error {
 	return nil
 }
 
+// ResetConnections flushes the DNS cache, closes idle HTTP connections,
+// and tears down the Noise client so that subsequent requests use fresh
+// connections. It should be called on major link changes.
+func (c *Direct) ResetConnections() {
+	c.logf("control: resetting HTTP connections and DNS cache after link change")
+	c.dnsCache.FlushAll()
+	c.httpc.CloseIdleConnections()
+	c.mu.Lock()
+	if c.noiseClient != nil {
+		c.noiseClient.Close()
+		c.noiseClient = nil
+	}
+	c.mu.Unlock()
+}
+
 // SetHostinfo clones the provided Hostinfo and remembers it for the
 // next update. It reports whether the Hostinfo has changed.
 func (c *Direct) SetHostinfo(hi *tailcfg.Hostinfo) bool {

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1003,6 +1003,11 @@ func (b *LocalBackend) linkChange(delta *netmon.ChangeDelta) {
 	b.interfaceState = delta.CurrentState()
 
 	b.pauseOrResumeControlClientLocked()
+	if delta.RebindLikelyRequired {
+		if cc := b.cc; cc != nil {
+			cc.ResetConnections()
+		}
+	}
 	prefs := b.pm.CurrentPrefs()
 	if delta.RebindLikelyRequired && prefs.AutoExitNode().IsSet() {
 		b.refreshAutoExitNode = true

--- a/ipn/ipnlocal/state_test.go
+++ b/ipn/ipnlocal/state_test.go
@@ -337,6 +337,7 @@ func (cc *mockControl) ClientID() int64 {
 }
 
 func (cc *mockControl) SetIPForwardingBroken(bool) {}
+func (cc *mockControl) ResetConnections()             {}
 
 func (b *LocalBackend) nonInteractiveLoginForStateTest() {
 	b.mu.Lock()

--- a/net/dnscache/dnscache.go
+++ b/net/dnscache/dnscache.go
@@ -115,6 +115,14 @@ type ipCacheEntry struct {
 	expires time.Time
 }
 
+// FlushAll clears all cached DNS results, including any "last good"
+// fallback entries retained by UseLastGood.
+func (r *Resolver) FlushAll() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	clear(r.ipCache)
+}
+
 func (r *Resolver) fwd() *net.Resolver {
 	if r.Forward != nil {
 		return r.Forward


### PR DESCRIPTION
When the network changes (e.g., switching WiFi networks), the control client's HTTP transport, DNS cache, and Noise client retain connections and resolved addresses from the previous network. If that network returned bad DNS results, the control client keeps dialing the wrong IP indefinitely, requiring a manual service restart to recover.

Add ResetConnections() to flush the DNS cache, close idle HTTP connections, and tear down the Noise client on major link changes. The Noise client is lazily recreated by getNoiseClient() via singleflight on the next control RPC.

Fixes #19199