### PR TITLE
ipn,tka: improve Tailnet Lock logs

### DIFF
--- a/ipn/ipnlocal/network-lock.go
+++ b/ipn/ipnlocal/network-lock.go
@@ -44,7 +44,7 @@ import (
 
 var (
 	errMissingNetmap        = errors.New("missing netmap: verify that you are logged in")
-	errNetworkLockNotActive = errors.New("network-lock is not active")
+	errNetworkLockNotActive = errors.New("tailnet-lock is not active")
 
 	tkaCompactionDefaults = tka.CompactionOptions{
 		MinChain: 24,                  // Keep at minimum 24 AUMs since head.
@@ -806,7 +806,7 @@ func (b *LocalBackend) NetworkLockSign(nodeKey key.NodePublic, rotationPublic []
 func (b *LocalBackend) NetworkLockModify(addKeys, removeKeys []tka.Key) (err error) {
 	defer func() {
 		if err != nil {
-			err = fmt.Errorf("modify network-lock keys: %w", err)
+			err = fmt.Errorf("modify tailnet-lock keys: %w", err)
 		}
 	}()
 
@@ -1126,7 +1126,7 @@ func (b *LocalBackend) NetworkLockWrapPreauthKey(preauthKey string, tkaKey key.N
 		return "", fmt.Errorf("signing failed: %w", err)
 	}
 
-	b.logf("Generated network-lock credential signature using %s", tkaKey.Public().CLIString())
+	b.logf("Generated tailnet-lock credential signature using %s", tkaKey.Public().CLIString())
 	return fmt.Sprintf("%s--TL%s-%s", preauthKey, tkaSuffixEncoder.EncodeToString(sig.Serialize()), tkaSuffixEncoder.EncodeToString(priv)), nil
 }
 

--- a/ipn/localapi/tailnetlock.go
+++ b/ipn/localapi/tailnetlock.go
@@ -122,7 +122,7 @@ func (h *Handler) serveTKAInit(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) serveTKAModify(w http.ResponseWriter, r *http.Request) {
 	if !h.PermitWrite {
-		http.Error(w, "network-lock modify access denied", http.StatusForbidden)
+		http.Error(w, "tailnet-lock modify access denied", http.StatusForbidden)
 		return
 	}
 	if r.Method != httpm.POST {
@@ -141,7 +141,7 @@ func (h *Handler) serveTKAModify(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.b.NetworkLockModify(req.AddKeys, req.RemoveKeys); err != nil {
-		http.Error(w, "network-lock modify failed: "+err.Error(), http.StatusInternalServerError)
+		http.Error(w, "tailnet-lock modify failed: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
 	w.WriteHeader(204)
@@ -149,7 +149,7 @@ func (h *Handler) serveTKAModify(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) serveTKAWrapPreauthKey(w http.ResponseWriter, r *http.Request) {
 	if !h.PermitWrite {
-		http.Error(w, "network-lock modify access denied", http.StatusForbidden)
+		http.Error(w, "tailnet-lock modify access denied", http.StatusForbidden)
 		return
 	}
 	if r.Method != httpm.POST {
@@ -212,7 +212,7 @@ func (h *Handler) serveTKAVerifySigningDeeplink(w http.ResponseWriter, r *http.R
 
 func (h *Handler) serveTKADisable(w http.ResponseWriter, r *http.Request) {
 	if !h.PermitWrite {
-		http.Error(w, "network-lock modify access denied", http.StatusForbidden)
+		http.Error(w, "tailnet-lock modify access denied", http.StatusForbidden)
 		return
 	}
 	if r.Method != httpm.POST {
@@ -228,7 +228,7 @@ func (h *Handler) serveTKADisable(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.b.NetworkLockDisable(secret); err != nil {
-		http.Error(w, "network-lock disable failed: "+err.Error(), http.StatusBadRequest)
+		http.Error(w, "tailnet-lock disable failed: "+err.Error(), http.StatusBadRequest)
 		return
 	}
 	w.WriteHeader(http.StatusOK)
@@ -236,7 +236,7 @@ func (h *Handler) serveTKADisable(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) serveTKALocalDisable(w http.ResponseWriter, r *http.Request) {
 	if !h.PermitWrite {
-		http.Error(w, "network-lock modify access denied", http.StatusForbidden)
+		http.Error(w, "tailnet-lock modify access denied", http.StatusForbidden)
 		return
 	}
 	if r.Method != httpm.POST {
@@ -252,7 +252,7 @@ func (h *Handler) serveTKALocalDisable(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.b.NetworkLockForceLocalDisable(); err != nil {
-		http.Error(w, "network-lock local disable failed: "+err.Error(), http.StatusBadRequest)
+		http.Error(w, "tailnet-lock local disable failed: "+err.Error(), http.StatusBadRequest)
 		return
 	}
 	w.WriteHeader(http.StatusOK)

--- a/tka/builder.go
+++ b/tka/builder.go
@@ -67,11 +67,11 @@ func (b *UpdateBuilder) AddKey(key Key) error {
 	}
 
 	if _, err := b.state.GetKey(keyID); err == nil {
-		return fmt.Errorf("cannot add key %v: already exists", key)
+		return fmt.Errorf("cannot add key tlpub:%x: already exists", key.Public)
 	}
 
 	if len(b.state.Keys) >= maxKeys {
-		return fmt.Errorf("cannot add key %v: maximum number of keys reached", key)
+		return fmt.Errorf("cannot add key tlpub:%x: maximum number of keys reached", key.Public)
 	}
 
 	return b.mkUpdate(AUM{MessageKind: AUMAddKey, Key: &key})


### PR DESCRIPTION
* Refer to "tailnet-lock" instead of "network-lock" in log messages
* Log keys as `tlpub:<hex>` rather than as Go structs

Updates tailscale/corp#39455
Updates tailscale/corp#37904