### PR TITLE
tailcfg: fix ClientVersion.UrgentSecurityUpdate doc comment

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -2270,7 +2270,7 @@ type ClientVersion struct {
 
 	// UrgentSecurityUpdate is set when the client is missing an important
 	// security update. That update may be in LatestVersion or earlier.
-	// UrgentSecurityUpdate should not be set if RunningLatest is false.
+	// UrgentSecurityUpdate should not be set if RunningLatest is true.
 	UrgentSecurityUpdate bool `json:",omitempty"`
 
 	// Notify is whether the client should do an OS-specific notification about


### PR DESCRIPTION
Changes "UrgentSecurityUpdate should not be set if RunningLatest is **false**." -> "UrgentSecurityUpdate should not be set if RunningLatest is **true**."

Updates #cleanup