### PR TITLE
tool/gocross: skip broken TestGocrossWrapper inside `git worktree`

### DIFF
--- a/tool/gocross/gocross_wrapper_test.go
+++ b/tool/gocross/gocross_wrapper_test.go
@@ -6,13 +6,26 @@
 package main
 
 import (
+	"bytes"
+	"go/version"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
+
+	"tailscale.com/util/must"
 )
 
 func TestGocrossWrapper(t *testing.T) {
+	if version.Compare(runtime.Version(), "go1.27") < 0 {
+		gitDir := must.Get(exec.Command("git", "rev-parse", "--git-dir").Output())
+		gitCommonDir := must.Get(exec.Command("git", "rev-parse", "--git-common-dir").Output())
+		if !bytes.Equal(gitDir, gitCommonDir) {
+			t.Skip("skipping within git worktree, see https://go.dev/issue/58218")
+		}
+	}
+
 	for i := range 2 { // once to build gocross; second to test it's cached
 		cmd := exec.Command("./gocross-wrapper.sh", "version")
 		cmd.Env = append(os.Environ(), "CI=true", "NOBASHDEBUG=false", "TS_USE_GOCROSS=1") // for "set -x" verbosity

--- a/tool/gocross/gocross_wrapper_windows_test.go
+++ b/tool/gocross/gocross_wrapper_windows_test.go
@@ -4,13 +4,26 @@
 package main
 
 import (
+	"bytes"
+	"go/version"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
+
+	"tailscale.com/util/must"
 )
 
 func TestGocrossWrapper(t *testing.T) {
+	if version.Compare(runtime.Version(), "go1.27") < 0 {
+		gitDir := must.Get(exec.Command("git", "rev-parse", "--git-dir").Output())
+		gitCommonDir := must.Get(exec.Command("git", "rev-parse", "--git-common-dir").Output())
+		if !bytes.Equal(gitDir, gitCommonDir) {
+			t.Skip("skipping within git worktree, see https://go.dev/issue/58218")
+		}
+	}
+
 	for i := range 2 { // once to build gocross; second to test it's cached
 		cmd := exec.Command("pwsh", "-NoProfile", "-ExecutionPolicy", "Bypass", ".\\gocross-wrapper.ps1", "version")
 		cmd.Env = append(os.Environ(), "CI=true", "NOPWSHDEBUG=false", "TS_USE_GOCROSS=1") // for Set-PSDebug verbosity


### PR DESCRIPTION
TestGocrossWrapper will fail when run inside a git linked worktree because Go 1.26 and earlier cannot get the current revision hash. Since this will be fixed in Go 1.27, see golang/go#58218, this patch skips this test until that release.

Fixes #19217