### PR TITLE
ipn/ipn{local,state}: add a status indicator for a cached netmap

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1314,6 +1314,7 @@ func (b *LocalBackend) UpdateStatus(sb *ipnstate.StatusBuilder) {
 			s.CurrentTailnet.MagicDNSSuffix = nm.MagicDNSSuffix()
 			s.CurrentTailnet.MagicDNSEnabled = nm.DNS.Proxied
 			s.CurrentTailnet.Name = nm.Domain
+			s.UsingCachedNetworkMap = nm.Cached
 			if prefs := b.pm.CurrentPrefs(); prefs.Valid() {
 				if !prefs.RouteAll() && nm.AnyPeersAdvertiseRoutes() {
 					s.Health = append(s.Health, healthmsg.WarnAcceptRoutesOff)

--- a/ipn/ipnstate/ipnstate.go
+++ b/ipn/ipnstate/ipnstate.go
@@ -48,6 +48,12 @@ type Status struct {
 	TailscaleIPs []netip.Addr // Tailscale IP(s) assigned to this node
 	Self         *PeerStatus
 
+	// UsingCachedNetworkMap is whether Self has a network map that was loaded
+	// from a local cache. If false, either Self has no network map (for
+	// example, if the node is not running), or its network map was received
+	// directly from the control plane.
+	UsingCachedNetworkMap bool
+
 	// ExitNodeStatus describes the current exit node.
 	// If nil, an exit node is not in use.
 	ExitNodeStatus *ExitNodeStatus `json:"ExitNodeStatus,omitempty"`


### PR DESCRIPTION
WIP. Questions to answer:

1. Should this be part of PeerStatus instead?
   Pro: It is a property of Self, which is a PeerStatus.
   Con: We do not have this information for non-self peers

2. Should this be a Boolean or an enumeration?
   For example, should it be "" to mean no network map, "cached" to indicate a
   cached network map, or "control" for a network map received from control.

3. Should we take into account whether there is an active control connection?
   I think probably not, but could be convinced otherwise.

---
Add a new UsingCachedNetworkMap flag to the ipnstate.Status message.
Populate it as true when self has a network map that was loaded from cache,
vs. being directly provided by the control plane.

Updates #12639

Change-Id: I0fd5b1d6ec8df5cec5d4a3fa6b263293124780d1
