### PR TITLE
ipn/ipnlocal: ensure TestServeUnixSocket actually serves a Unix socket

### DIFF
--- a/ipn/ipnlocal/serve_unix_test.go
+++ b/ipn/ipnlocal/serve_unix_test.go
@@ -8,6 +8,7 @@ package ipnlocal
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -100,6 +101,23 @@ func TestServeUnixSocket(t *testing.T) {
 	}
 	if rp.url.Host != "localhost" {
 		t.Errorf("url.Host = %q, want %q", rp.url.Host, "localhost")
+	}
+
+	req := httptest.NewRequest("GET", "http://foo.test.ts.net/", nil)
+	rec := httptest.NewRecorder()
+
+	rp.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatal("unexpected response code:", rec.Code)
+	}
+	resp := rec.Result()
+	defer resp.Body.Close()
+	respB, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal("read error:", err)
+	}
+	if string(respB) != testResponse {
+		t.Fatalf("unexpected response: want: '%s'; got: '%s'", testResponse, string(respB))
 	}
 }
 


### PR DESCRIPTION
The test sets up an HTTP-over-Unix server and a reverse proxy pointed at this server, but prior to this change did not round-trip anything to the backing server. This change ensures that we test code paths which proxy Unix sockets for serve.

Fixes #19232