### PR TITLE
cmd/k8s-operator: add priorityClassName support to helm chart

### DIFF
--- a/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
+++ b/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
@@ -146,3 +146,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.operatorConfig.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}

--- a/cmd/k8s-operator/deploy/chart/values.yaml
+++ b/cmd/k8s-operator/deploy/chart/values.yaml
@@ -72,6 +72,8 @@ operatorConfig:
 
   affinity: {}
 
+  priorityClassName: ""
+
   podSecurityContext: {}
 
   securityContext: {}


### PR DESCRIPTION
## Summary
- Adds `priorityClassName` to the operator Helm chart `values.yaml` under `operatorConfig`
- Conditionally renders `priorityClassName` in the deployment template when set
- Follows the existing pattern used by `nodeSelector`, `affinity`, and `tolerations`

This allows users to assign a [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass) to the tailscale-operator deployment, preventing its pods from being preempted by lower-priority workloads.

Fixes #19235

## Tests
- [x] `helm template` with `priorityClassName` unset — field should not appear in rendered output
- [x] `helm template --set operatorConfig.priorityClassName=system-cluster-critical` — field should appear in the pod spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>