### PR TITLE
appc,feature/conn25,types/appctype: configure and check self-routed domains

### DIFF
--- a/appc/conn25.go
+++ b/appc/conn25.go
@@ -5,18 +5,19 @@ package appc
 
 import (
 	"cmp"
+	"fmt"
 	"slices"
+	"strings"
 
 	"tailscale.com/ipn/ipnext"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/appctype"
+	"tailscale.com/util/dnsname"
 	"tailscale.com/util/mak"
 	"tailscale.com/util/set"
 )
 
-const AppConnectorsExperimentalAttrName = "tailscale.com/app-connectors-experimental"
-
-func isEligibleConnector(peer tailcfg.NodeView) bool {
+func isPeerEligibleConnector(peer tailcfg.NodeView) bool {
 	if !peer.Valid() || !peer.Hostinfo().Valid() {
 		return false
 	}
@@ -39,7 +40,7 @@ func sortByPreference(ns []tailcfg.NodeView) {
 func PickConnector(nb ipnext.NodeBackend, app appctype.Conn25Attr) []tailcfg.NodeView {
 	appTagsSet := set.SetOf(app.Connectors)
 	matches := nb.AppendMatchingPeers(nil, func(n tailcfg.NodeView) bool {
-		if !isEligibleConnector(n) {
+		if !isPeerEligibleConnector(n) {
 			return false
 		}
 		for _, t := range n.Tags().All() {
@@ -53,28 +54,79 @@ func PickConnector(nb ipnext.NodeBackend, app appctype.Conn25Attr) []tailcfg.Nod
 	return matches
 }
 
-// PickSplitDNSPeers looks at the netmap peers capabilities and finds which peers
-// want to be connectors for which domains.
-func PickSplitDNSPeers(hasCap func(c tailcfg.NodeCapability) bool, self tailcfg.NodeView, peers map[tailcfg.NodeID]tailcfg.NodeView) map[string][]tailcfg.NodeView {
-	var m map[string][]tailcfg.NodeView
-	if !hasCap(AppConnectorsExperimentalAttrName) {
-		return m
-	}
-	apps, err := tailcfg.UnmarshalNodeCapViewJSON[appctype.AppConnectorAttr](self.CapMap(), AppConnectorsExperimentalAttrName)
-	if err != nil {
-		return m
-	}
-	tagToDomain := make(map[string][]string)
+// NormalizeDNSName normalizes the DNS name to a lower-case [dnsname.FQDN].
+func NormalizeDNSName(name string) (dnsname.FQDN, error) {
+	// note that appconnector does this same thing, tsdns has its own custom lower casing
+	// it might be good to unify in a function in dnsname package.
+	return dnsname.ToFQDN(strings.ToLower(name))
+}
+
+// ConnectorSelfRoutedDomains returns the set of domains from all apps that could potentially
+// apply to self, if self is an eligible connector. self does not have reliable information to
+// determine if it is an eligible connector. So callers of this method are expected to make
+// that determination separately.
+func ConnectorSelfRoutedDomains(self tailcfg.NodeView, apps []appctype.Conn25Attr) (set.Set[dnsname.FQDN], error) {
+	selfTags := set.SetOf(self.Tags().AsSlice())
+
+	selfRoutedDomains := set.Set[dnsname.FQDN]{}
 	for _, app := range apps {
-		for _, tag := range app.Connectors {
-			tagToDomain[tag] = append(tagToDomain[tag], app.Domains...)
+		if !slices.ContainsFunc(app.Connectors, selfTags.Contains) {
+			continue
+		}
+		for _, d := range app.Domains {
+			fqdn, err := NormalizeDNSName(d)
+			if err != nil {
+				return nil, fmt.Errorf("could not normalize domain %q: %w", d, err)
+			}
+			selfRoutedDomains.Add(fqdn)
 		}
 	}
+	return selfRoutedDomains, nil
+}
+
+// PickSplitDNSPeers looks at the netmap peers capabilities and finds which peers
+// want to be connectors for which domains.
+func PickSplitDNSPeers(hasCap func(c tailcfg.NodeCapability) bool, self tailcfg.NodeView, peers map[tailcfg.NodeID]tailcfg.NodeView, isSelfEligibleConnector bool) (map[dnsname.FQDN][]tailcfg.NodeView, error) {
+	if !hasCap(appctype.AppConnectorsExperimentalAttrName) {
+		return nil, nil
+	}
+	apps, err := tailcfg.UnmarshalNodeCapViewJSON[appctype.Conn25Attr](self.CapMap(), appctype.AppConnectorsExperimentalAttrName)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(apps) == 0 {
+		return nil, nil
+	}
+
+	var selfRoutedDomains set.Set[dnsname.FQDN]
+	if isSelfEligibleConnector {
+		selfRoutedDomains, err = ConnectorSelfRoutedDomains(self, apps)
+		if err != nil {
+			return nil, err
+		}
+	}
+	tagToDomain := make(map[string][]dnsname.FQDN)
+	for _, app := range apps {
+		for _, tag := range app.Connectors {
+			for _, d := range app.Domains {
+				fqdn, err := NormalizeDNSName(d)
+				if err != nil {
+					return nil, err
+				}
+				if selfRoutedDomains != nil && selfRoutedDomains.Contains(fqdn) {
+					continue
+				}
+				tagToDomain[tag] = append(tagToDomain[tag], fqdn)
+			}
+		}
+	}
+
 	// NodeIDs are Comparable, and we have a map of NodeID to NodeView anyway, so
 	// use a Set of NodeIDs to deduplicate, and populate into a []NodeView later.
-	var work map[string]set.Set[tailcfg.NodeID]
+	var work map[dnsname.FQDN]set.Set[tailcfg.NodeID]
 	for _, peer := range peers {
-		if !isEligibleConnector(peer) {
+		if !isPeerEligibleConnector(peer) {
 			continue
 		}
 		for _, t := range peer.Tags().All() {
@@ -90,6 +142,7 @@ func PickSplitDNSPeers(hasCap func(c tailcfg.NodeCapability) bool, self tailcfg.
 
 	// Populate m. Make a []tailcfg.NodeView from []tailcfg.NodeID using the peers map.
 	// And sort it to our preference.
+	var m map[dnsname.FQDN][]tailcfg.NodeView
 	for domain, ids := range work {
 		nodes := make([]tailcfg.NodeView, 0, ids.Len())
 		for id := range ids {
@@ -98,5 +151,5 @@ func PickSplitDNSPeers(hasCap func(c tailcfg.NodeCapability) bool, self tailcfg.
 		sortByPreference(nodes)
 		mak.Set(&m, domain, nodes)
 	}
-	return m
+	return m, nil
 }

--- a/appc/conn25_test.go
+++ b/appc/conn25_test.go
@@ -13,6 +13,7 @@ import (
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/appctype"
 	"tailscale.com/types/opt"
+	"tailscale.com/util/dnsname"
 )
 
 func TestPickSplitDNSPeers(t *testing.T) {
@@ -47,17 +48,21 @@ func TestPickSplitDNSPeers(t *testing.T) {
 	nvp4 := makeNodeView(4, "p4", []string{"tag:two", "tag:three2", "tag:four2"})
 
 	for _, tt := range []struct {
-		name   string
-		want   map[string][]tailcfg.NodeView
-		peers  []tailcfg.NodeView
-		config []tailcfg.RawMessage
+		name                string
+		peers               []tailcfg.NodeView
+		config              []tailcfg.RawMessage
+		isEligibleConnector bool
+		selfTags            []string
+		want                map[dnsname.FQDN][]tailcfg.NodeView
+		wantErr             bool
 	}{
 		{
 			name: "empty",
 		},
 		{
-			name:   "bad-config", // bad config should return a nil map rather than error.
-			config: []tailcfg.RawMessage{tailcfg.RawMessage(`hey`)},
+			name:    "bad-config",
+			config:  []tailcfg.RawMessage{tailcfg.RawMessage(`hey`)},
+			wantErr: true,
 		},
 		{
 			name:   "no-peers",
@@ -102,13 +107,92 @@ func TestPickSplitDNSPeers(t *testing.T) {
 				nvp4,
 				makeNodeView(5, "p5", nil),
 			},
-			want: map[string][]tailcfg.NodeView{
+			want: map[dnsname.FQDN][]tailcfg.NodeView{
 				// p5 has no matching tags and so doesn't appear
-				"example.com":       {nvp1},
-				"a.example.com":     {nvp3, nvp4},
-				"woo.b.example.com": {nvp2, nvp3, nvp4},
-				"hoo.b.example.com": {nvp3, nvp4},
-				"c.example.com":     {nvp2, nvp4},
+				"example.com.":       {nvp1},
+				"a.example.com.":     {nvp3, nvp4},
+				"woo.b.example.com.": {nvp2, nvp3, nvp4},
+				"hoo.b.example.com.": {nvp3, nvp4},
+				"c.example.com.":     {nvp2, nvp4},
+			},
+		},
+		{
+			name: "self-connector-exclude-self-domains",
+			config: []tailcfg.RawMessage{
+				tailcfg.RawMessage(appOneBytes),
+				tailcfg.RawMessage(appTwoBytes),
+				tailcfg.RawMessage(appThreeBytes),
+				tailcfg.RawMessage(appFourBytes),
+			},
+			peers: []tailcfg.NodeView{
+				nvp1,
+				nvp2,
+				nvp3,
+				nvp4,
+			},
+			isEligibleConnector: true,
+			selfTags:            []string{"tag:three1"},
+			want: map[dnsname.FQDN][]tailcfg.NodeView{
+				// woo.b.example.com and hoo.b.example.com are covered
+				// by tag:three1, and so is this self-node.
+				// So those domains should not be routed to peers.
+				// woo.b.example.com is also covered by another tag,
+				// but still not included since this connector can route to it.
+				"example.com.":   {nvp1},
+				"a.example.com.": {nvp3, nvp4},
+				"c.example.com.": {nvp2, nvp4},
+			},
+		},
+		{
+			name: "self-connector-no-matching-tag-include-all-domains",
+			config: []tailcfg.RawMessage{
+				tailcfg.RawMessage(appOneBytes),
+				tailcfg.RawMessage(appTwoBytes),
+				tailcfg.RawMessage(appThreeBytes),
+				tailcfg.RawMessage(appFourBytes),
+			},
+			peers: []tailcfg.NodeView{
+				nvp1,
+				nvp2,
+				nvp3,
+				nvp4,
+			},
+			isEligibleConnector: true,
+			selfTags:            []string{"tag:unrelated"},
+			want: map[dnsname.FQDN][]tailcfg.NodeView{
+				// Self has prefs set but no tags matching any app,
+				// so no domains are self-routed and all appear.
+				"example.com.":       {nvp1},
+				"a.example.com.":     {nvp3, nvp4},
+				"woo.b.example.com.": {nvp2, nvp3, nvp4},
+				"hoo.b.example.com.": {nvp3, nvp4},
+				"c.example.com.":     {nvp2, nvp4},
+			},
+		},
+		{
+			name: "self-not-connector-but-tagged-include-self-domains",
+			config: []tailcfg.RawMessage{
+				tailcfg.RawMessage(appOneBytes),
+				tailcfg.RawMessage(appTwoBytes),
+				tailcfg.RawMessage(appThreeBytes),
+				tailcfg.RawMessage(appFourBytes),
+			},
+			peers: []tailcfg.NodeView{
+				nvp1,
+				nvp2,
+				nvp3,
+				nvp4,
+			},
+			selfTags: []string{"tag:three1"},
+			want: map[dnsname.FQDN][]tailcfg.NodeView{
+				// Even though this self node has a tag for an app
+				// it doesn't have Hostinfo.AppConnector == true, so
+				// should still route through other connectors.
+				"example.com.":       {nvp1},
+				"a.example.com.":     {nvp3, nvp4},
+				"woo.b.example.com.": {nvp2, nvp3, nvp4},
+				"hoo.b.example.com.": {nvp3, nvp4},
+				"c.example.com.":     {nvp2, nvp4},
 			},
 		},
 	} {
@@ -116,19 +200,26 @@ func TestPickSplitDNSPeers(t *testing.T) {
 			selfNode := &tailcfg.Node{}
 			if tt.config != nil {
 				selfNode.CapMap = tailcfg.NodeCapMap{
-					tailcfg.NodeCapability(AppConnectorsExperimentalAttrName): tt.config,
+					tailcfg.NodeCapability(appctype.AppConnectorsExperimentalAttrName): tt.config,
 				}
 			}
+			selfNode.Tags = append(selfNode.Tags, tt.selfTags...)
 			selfView := selfNode.View()
 			peers := map[tailcfg.NodeID]tailcfg.NodeView{}
 			for _, p := range tt.peers {
 				peers[p.ID()] = p
 			}
-			got := PickSplitDNSPeers(func(_ tailcfg.NodeCapability) bool {
+			got, err := PickSplitDNSPeers(func(_ tailcfg.NodeCapability) bool {
 				return true
-			}, selfView, peers)
+			}, selfView, peers, tt.isEligibleConnector)
+			if tt.wantErr && (err == nil) {
+				t.Error("expected error in PickSplitDNSPeers but got none")
+			}
+			if !tt.wantErr && (err != nil) {
+				t.Errorf("unexpected error in PickSplitDNSPeers: %v", err)
+			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("got %v, want %v", got, tt.want)
+				t.Errorf("got %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/feature/conn25/conn25.go
+++ b/feature/conn25/conn25.go
@@ -16,8 +16,6 @@ import (
 	"io"
 	"net/http"
 	"net/netip"
-	"slices"
-	"strings"
 	"sync"
 
 	"go4.org/netipx"
@@ -60,12 +58,6 @@ func jsonDecode(target any, rc io.ReadCloser) error {
 	}
 	err = json.Unmarshal(respBs, &target)
 	return err
-}
-
-func normalizeDNSName(name string) (dnsname.FQDN, error) {
-	// note that appconnector does this same thing, tsdns has its own custom lower casing
-	// it might be good to unify in a function in dnsname package.
-	return dnsname.ToFQDN(strings.ToLower(name))
 }
 
 func init() {
@@ -265,7 +257,9 @@ func (e *extension) handleConnectorTransitIP(h ipnlocal.PeerAPIHandler, w http.R
 }
 
 func (e *extension) onSelfChange(selfNode tailcfg.NodeView) {
-	err := e.conn25.reconfig(selfNode)
+	//TODO(mzb): Clean this up when we re-examine need for extension and conn25.
+	isEligibleConnector := e.host.Profiles().CurrentPrefs().AppConnector().Advertise
+	err := e.conn25.reconfig(selfNode, isEligibleConnector)
 	if err != nil {
 		e.conn25.client.logf("error during Reconfig onSelfChange: %v", err)
 		return
@@ -310,8 +304,8 @@ func ipSetFromIPRanges(rs []netipx.IPRange) (*netipx.IPSet, error) {
 	return b.IPSet()
 }
 
-func (c *Conn25) reconfig(selfNode tailcfg.NodeView) error {
-	cfg, err := configFromNodeView(selfNode)
+func (c *Conn25) reconfig(selfNode tailcfg.NodeView, isEligibleConnector bool) error {
+	cfg, err := configFromNodeView(selfNode, isEligibleConnector)
 	if err != nil {
 		return err
 	}
@@ -483,8 +477,6 @@ type ConnectorTransitIPResponse struct {
 	TransitIPs []TransitIPResponse `json:"transitIPs,omitempty"`
 }
 
-const AppConnectorsExperimentalAttrName = "tailscale.com/app-connectors-experimental"
-
 // config holds the config from the policy and lookups derived from that.
 // config is not safe for concurrent use.
 type config struct {
@@ -497,15 +489,18 @@ type config struct {
 	magicIPSet        netipx.IPSet
 }
 
-func configFromNodeView(n tailcfg.NodeView) (config, error) {
-	apps, err := tailcfg.UnmarshalNodeCapViewJSON[appctype.Conn25Attr](n.CapMap(), AppConnectorsExperimentalAttrName)
+func configFromNodeView(n tailcfg.NodeView, isEligibleConnector bool) (config, error) {
+	if !n.HasCap(appctype.AppConnectorsExperimentalAttrName) {
+		return config{}, nil
+	}
+
+	apps, err := tailcfg.UnmarshalNodeCapViewJSON[appctype.Conn25Attr](n.CapMap(), appctype.AppConnectorsExperimentalAttrName)
 	if err != nil {
 		return config{}, err
 	}
 	if len(apps) == 0 {
 		return config{}, nil
 	}
-	selfTags := set.SetOf(n.Tags().AsSlice())
 	cfg := config{
 		isConfigured:      true,
 		apps:              apps,
@@ -513,17 +508,22 @@ func configFromNodeView(n tailcfg.NodeView) (config, error) {
 		appNamesByDomain:  map[dnsname.FQDN][]string{},
 		selfRoutedDomains: set.Set[dnsname.FQDN]{},
 	}
+
+	if isEligibleConnector {
+		selfRoutedDomains, err := appc.ConnectorSelfRoutedDomains(n, apps)
+		if err != nil {
+			return config{}, err
+		}
+		cfg.selfRoutedDomains = selfRoutedDomains
+	}
+
 	for _, app := range apps {
-		selfMatchesTags := slices.ContainsFunc(app.Connectors, selfTags.Contains)
 		for _, d := range app.Domains {
-			fqdn, err := normalizeDNSName(d)
+			fqdn, err := appc.NormalizeDNSName(d)
 			if err != nil {
 				return config{}, err
 			}
 			mak.Set(&cfg.appNamesByDomain, fqdn, append(cfg.appNamesByDomain[fqdn], app.Name))
-			if selfMatchesTags {
-				cfg.selfRoutedDomains.Add(fqdn)
-			}
 		}
 		mak.Set(&cfg.appsByName, app.Name, app)
 	}
@@ -618,9 +618,17 @@ func (c *client) reconfig(newCfg config) error {
 	return nil
 }
 
+// isConnectorDomain determines if domain is routed through a connector peer,
+// and that it should not be handled by the self node, which could also
+// be a connector for the domain.
 func (c *client) isConnectorDomain(domain dnsname.FQDN) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	if c.config.selfRoutedDomains.Contains(domain) {
+		return false
+	}
+
 	appNames, ok := c.config.appNamesByDomain[domain]
 	return ok && len(appNames) > 0
 }
@@ -656,6 +664,7 @@ func (c *client) reserveAddresses(domain dnsname.FQDN, dst netip.Addr) (addrs, e
 		app:     app,
 		domain:  domain,
 	}
+
 	if err := c.assignments.insert(as); err != nil {
 		return addrs{}, err
 	}
@@ -842,7 +851,7 @@ func (c *client) mapDNSResponse(buf []byte) []byte {
 	if question.Class != dnsmessage.ClassINET {
 		return buf
 	}
-	queriedDomain, err := normalizeDNSName(question.Name.String())
+	queriedDomain, err := appc.NormalizeDNSName(question.Name.String())
 	if err != nil {
 		return buf
 	}
@@ -896,7 +905,7 @@ func (c *client) mapDNSResponse(buf []byte) []byte {
 				return makeServFail(c.logf, hdr, question)
 			}
 		case dnsmessage.TypeA:
-			domain, err := normalizeDNSName(h.Name.String())
+			domain, err := appc.NormalizeDNSName(h.Name.String())
 			if err != nil {
 				c.logf("bad dnsname: %v", err)
 				return makeServFail(c.logf, hdr, question)

--- a/feature/conn25/conn25_test.go
+++ b/feature/conn25/conn25_test.go
@@ -428,7 +428,7 @@ func TestReserveIPs(t *testing.T) {
 func TestReconfig(t *testing.T) {
 	rawCfg := `{"name":"app1","connectors":["tag:woo"],"domains":["example.com"]}`
 	capMap := tailcfg.NodeCapMap{
-		tailcfg.NodeCapability(AppConnectorsExperimentalAttrName): []tailcfg.RawMessage{
+		tailcfg.NodeCapability(appctype.AppConnectorsExperimentalAttrName): []tailcfg.RawMessage{
 			tailcfg.RawMessage(rawCfg),
 		},
 	}
@@ -438,7 +438,7 @@ func TestReconfig(t *testing.T) {
 		CapMap: capMap,
 	}).View()
 
-	err := c.reconfig(sn)
+	err := c.reconfig(sn, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -454,6 +454,7 @@ func TestConfigReconfig(t *testing.T) {
 		rawCfg                string
 		cfg                   []appctype.Conn25Attr
 		tags                  []string
+		isEligibleConnector   bool
 		wantErr               bool
 		wantAppsByDomain      map[dnsname.FQDN][]string
 		wantSelfRoutedDomains set.Set[dnsname.FQDN]
@@ -469,7 +470,8 @@ func TestConfigReconfig(t *testing.T) {
 				{Name: "one", Domains: []string{"a.example.com"}, Connectors: []string{"tag:one"}},
 				{Name: "two", Domains: []string{"b.example.com"}, Connectors: []string{"tag:two"}},
 			},
-			tags: []string{"tag:one"},
+			tags:                []string{"tag:one"},
+			isEligibleConnector: true,
 			wantAppsByDomain: map[dnsname.FQDN][]string{
 				"a.example.com.": {"one"},
 				"b.example.com.": {"two"},
@@ -477,7 +479,41 @@ func TestConfigReconfig(t *testing.T) {
 			wantSelfRoutedDomains: set.SetOf([]dnsname.FQDN{"a.example.com."}),
 		},
 		{
-			name: "more-complex",
+			name: "more-complex-with-connector-self-routed-domains",
+			cfg: []appctype.Conn25Attr{
+				{Name: "one", Domains: []string{"1.a.example.com", "1.b.example.com"}, Connectors: []string{"tag:one", "tag:onea"}},
+				{Name: "two", Domains: []string{"2.b.example.com", "2.c.example.com"}, Connectors: []string{"tag:two", "tag:twoa"}},
+				{Name: "three", Domains: []string{"1.b.example.com", "1.c.example.com"}, Connectors: []string{}},
+				{Name: "four", Domains: []string{"4.b.example.com", "4.d.example.com"}, Connectors: []string{"tag:four"}},
+			},
+			tags:                []string{"tag:onea", "tag:four", "tag:unrelated"},
+			isEligibleConnector: true,
+			wantAppsByDomain: map[dnsname.FQDN][]string{
+				"1.a.example.com.": {"one"},
+				"1.b.example.com.": {"one", "three"},
+				"1.c.example.com.": {"three"},
+				"2.b.example.com.": {"two"},
+				"2.c.example.com.": {"two"},
+				"4.b.example.com.": {"four"},
+				"4.d.example.com.": {"four"},
+			},
+			wantSelfRoutedDomains: set.SetOf([]dnsname.FQDN{"1.a.example.com.", "1.b.example.com.", "4.b.example.com.", "4.d.example.com."}),
+		},
+		{
+			name: "connector-no-matching-tag-no-self-routed-domains",
+			cfg: []appctype.Conn25Attr{
+				{Name: "one", Domains: []string{"a.example.com"}, Connectors: []string{"tag:one"}},
+				{Name: "two", Domains: []string{"b.example.com"}, Connectors: []string{"tag:two"}},
+			},
+			tags:                []string{"tag:unrelated"},
+			isEligibleConnector: true,
+			wantAppsByDomain: map[dnsname.FQDN][]string{
+				"a.example.com.": {"one"},
+				"b.example.com.": {"two"},
+			},
+		},
+		{
+			name: "non-connector-no-self-routed-domains",
 			cfg: []appctype.Conn25Attr{
 				{Name: "one", Domains: []string{"1.a.example.com", "1.b.example.com"}, Connectors: []string{"tag:one", "tag:onea"}},
 				{Name: "two", Domains: []string{"2.b.example.com", "2.c.example.com"}, Connectors: []string{"tag:two", "tag:twoa"}},
@@ -494,7 +530,6 @@ func TestConfigReconfig(t *testing.T) {
 				"4.b.example.com.": {"four"},
 				"4.d.example.com.": {"four"},
 			},
-			wantSelfRoutedDomains: set.SetOf([]dnsname.FQDN{"1.a.example.com.", "1.b.example.com.", "4.b.example.com.", "4.d.example.com."}),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -510,13 +545,13 @@ func TestConfigReconfig(t *testing.T) {
 				}
 			}
 			capMap := tailcfg.NodeCapMap{
-				tailcfg.NodeCapability(AppConnectorsExperimentalAttrName): cfg,
+				tailcfg.NodeCapability(appctype.AppConnectorsExperimentalAttrName): cfg,
 			}
 			sn := (&tailcfg.Node{
 				CapMap: capMap,
 				Tags:   tt.tags,
 			}).View()
-			c, err := configFromNodeView(sn)
+			c, err := configFromNodeView(sn, tt.isEligibleConnector)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("wantErr: %t, err: %v", tt.wantErr, err)
 			}
@@ -541,8 +576,9 @@ func makeSelfNode(t *testing.T, attrs []appctype.Conn25Attr, tags []string) tail
 		cfg = append(cfg, tailcfg.RawMessage(bs))
 	}
 	capMap := tailcfg.NodeCapMap{
-		tailcfg.NodeCapability(AppConnectorsExperimentalAttrName): cfg,
+		tailcfg.NodeCapability(appctype.AppConnectorsExperimentalAttrName): cfg,
 	}
+
 	return (&tailcfg.Node{
 		CapMap: capMap,
 		Tags:   tags,
@@ -680,10 +716,12 @@ func makeDNSResponseForSections(t *testing.T, questions []dnsmessage.Question, a
 
 func TestMapDNSResponseAssignsAddrs(t *testing.T) {
 	for _, tt := range []struct {
-		name          string
-		domain        string
-		addrs         []*dnsmessage.AResource
-		wantByMagicIP map[netip.Addr]addrs
+		name                string
+		domain              string
+		addrs               []*dnsmessage.AResource
+		selfTags            []string
+		isEligibleConnector bool
+		wantByMagicIP       map[netip.Addr]addrs
 	}{
 		{
 			name:   "one-ip-matches",
@@ -732,6 +770,48 @@ func TestMapDNSResponseAssignsAddrs(t *testing.T) {
 				{A: [4]byte{2, 0, 0, 0}},
 			},
 		},
+		{
+			name:                "exclude-connector-self-routed-domain",
+			domain:              "example.com.",
+			addrs:               []*dnsmessage.AResource{{A: [4]byte{1, 0, 0, 0}}},
+			selfTags:            []string{"tag:woo"},
+			isEligibleConnector: true,
+		},
+		{
+			name:     "tagged-but-not-connector-rewrites",
+			domain:   "example.com.",
+			addrs:    []*dnsmessage.AResource{{A: [4]byte{1, 0, 0, 0}}},
+			selfTags: []string{"tag:woo"},
+			// isEligibleConnector is false: tag matches but prefs not set,
+			// so DNS response should be rewritten normally.
+			wantByMagicIP: map[netip.Addr]addrs{
+				netip.MustParseAddr("100.64.0.0"): {
+					domain:  "example.com.",
+					dst:     netip.MustParseAddr("1.0.0.0"),
+					magic:   netip.MustParseAddr("100.64.0.0"),
+					transit: netip.MustParseAddr("100.64.0.40"),
+					app:     "app1",
+				},
+			},
+		},
+		{
+			name:                "connector-no-matching-tag-rewrites",
+			domain:              "example.com.",
+			addrs:               []*dnsmessage.AResource{{A: [4]byte{1, 0, 0, 0}}},
+			selfTags:            []string{"tag:unrelated"},
+			isEligibleConnector: true,
+			// isEligibleConnector is true but tag doesn't match the app,
+			// so DNS response should be rewritten normally.
+			wantByMagicIP: map[netip.Addr]addrs{
+				netip.MustParseAddr("100.64.0.0"): {
+					domain:  "example.com.",
+					dst:     netip.MustParseAddr("1.0.0.0"),
+					magic:   netip.MustParseAddr("100.64.0.0"),
+					transit: netip.MustParseAddr("100.64.0.40"),
+					app:     "app1",
+				},
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			dnsResp := makeDNSResponse(t, tt.domain, tt.addrs)
@@ -741,9 +821,9 @@ func TestMapDNSResponseAssignsAddrs(t *testing.T) {
 				Domains:       []string{"example.com"},
 				MagicIPPool:   []netipx.IPRange{rangeFrom("0", "10"), rangeFrom("20", "30")},
 				TransitIPPool: []netipx.IPRange{rangeFrom("40", "50")},
-			}}, []string{})
+			}}, tt.selfTags)
 			c := newConn25(logger.Discard)
-			c.reconfig(sn)
+			c.reconfig(sn, tt.isEligibleConnector)
 
 			c.mapDNSResponse(dnsResp)
 			if diff := cmp.Diff(tt.wantByMagicIP, c.client.assignments.byMagicIP, cmpopts.EquateComparable(addrs{}, netip.Addr{})); diff != "" {
@@ -887,7 +967,7 @@ func TestAddressAssignmentIsHandled(t *testing.T) {
 		Connectors: []string{"tag:woo"},
 		Domains:    []string{"example.com"},
 	}}, []string{})
-	err := ext.conn25.reconfig(sn)
+	err := ext.conn25.reconfig(sn, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1208,7 +1288,7 @@ func TestMapDNSResponseRewritesResponses(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			c := newConn25(logger.Discard)
-			if err := c.reconfig(sn); err != nil {
+			if err := c.reconfig(sn, false); err != nil {
 				t.Fatal(err)
 			}
 			bs := c.mapDNSResponse(tt.toMap)
@@ -1281,7 +1361,7 @@ func TestHandleAddressAssignmentStoresTransitIPs(t *testing.T) {
 			Domains:    []string{"hoo.example.com"},
 		},
 	}, []string{})
-	err := ext.conn25.reconfig(sn)
+	err := ext.conn25.reconfig(sn, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1491,7 +1571,7 @@ func TestClientTransitIPForMagicIP(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			c := newConn25(t.Logf)
-			if err := c.reconfig(sn); err != nil {
+			if err := c.reconfig(sn, false); err != nil {
 				t.Fatal(err)
 			}
 			c.client.assignments.insert(addrs{
@@ -1564,7 +1644,7 @@ func TestConnectorRealIPForTransitIPConnection(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			c := newConn25(t.Logf)
-			if err := c.reconfig(sn); err != nil {
+			if err := c.reconfig(sn, true); err != nil {
 				t.Fatal(err)
 			}
 			c.connector.transitIPs = map[netip.Addr]map[netip.Addr]appAddr{}

--- a/ipn/ipnlocal/dnsconfig_test.go
+++ b/ipn/ipnlocal/dnsconfig_test.go
@@ -10,11 +10,11 @@ import (
 	"reflect"
 	"testing"
 
-	"tailscale.com/appc"
 	"tailscale.com/ipn"
 	"tailscale.com/net/dns"
 	"tailscale.com/tailcfg"
 	"tailscale.com/tstest"
+	"tailscale.com/types/appctype"
 	"tailscale.com/types/dnstype"
 	"tailscale.com/types/netmap"
 	"tailscale.com/types/opt"
@@ -396,12 +396,12 @@ func TestDNSConfigForNetmap(t *testing.T) {
 					Name:      "a",
 					Addresses: ipps("100.101.101.101"),
 					CapMap: tailcfg.NodeCapMap{
-						tailcfg.NodeCapability(appc.AppConnectorsExperimentalAttrName): []tailcfg.RawMessage{
+						tailcfg.NodeCapability(appctype.AppConnectorsExperimentalAttrName): []tailcfg.RawMessage{
 							tailcfg.RawMessage(`{"name":"app1","connectors":["tag:woo"],"domains":["example.com"]}`),
 						},
 					},
 				}).View(),
-				AllCaps: set.Of(tailcfg.NodeCapability(appc.AppConnectorsExperimentalAttrName)),
+				AllCaps: set.Of(tailcfg.NodeCapability(appctype.AppConnectorsExperimentalAttrName)),
 			},
 			peers: nodeViews([]*tailcfg.Node{
 				{
@@ -443,12 +443,12 @@ func TestDNSConfigForNetmap(t *testing.T) {
 					Name:      "a",
 					Addresses: ipps("100.101.101.101"),
 					CapMap: tailcfg.NodeCapMap{
-						tailcfg.NodeCapability(appc.AppConnectorsExperimentalAttrName): []tailcfg.RawMessage{
+						tailcfg.NodeCapability(appctype.AppConnectorsExperimentalAttrName): []tailcfg.RawMessage{
 							tailcfg.RawMessage(`{"name":"app1","connectors":["tag:woo"],"domains":["example.com"]}`),
 						},
 					},
 				}).View(),
-				AllCaps: set.Of(tailcfg.NodeCapability(appc.AppConnectorsExperimentalAttrName)),
+				AllCaps: set.Of(tailcfg.NodeCapability(appctype.AppConnectorsExperimentalAttrName)),
 			},
 			peers: nodeViews([]*tailcfg.Node{
 				{

--- a/ipn/ipnlocal/node_backend.go
+++ b/ipn/ipnlocal/node_backend.go
@@ -863,9 +863,11 @@ func dnsConfigForNetmap(nm *netmap.NetworkMap, peers map[tailcfg.NodeID]tailcfg.
 	// Add split DNS routes, with no regard to exit node configuration.
 	addSplitDNSRoutes(nm.DNS.Routes)
 
-	// Add split DNS routes for conn25
-	conn25DNSTargets := appc.PickSplitDNSPeers(nm.HasCap, nm.SelfNode, peers)
-	if conn25DNSTargets != nil {
+	// Add split DNS routes for conn25.
+	conn25DNSTargets, err := appc.PickSplitDNSPeers(nm.HasCap, nm.SelfNode, peers, prefs.AppConnector().Advertise)
+	if err != nil {
+		logf("error picking split dns peers for app connectors: %v", err)
+	} else {
 		var m map[string][]*dnstype.Resolver
 		for domain, candidateSplitDNSPeers := range conn25DNSTargets {
 			for _, peer := range candidateSplitDNSPeers {
@@ -873,7 +875,7 @@ func dnsConfigForNetmap(nm *netmap.NetworkMap, peers map[tailcfg.NodeID]tailcfg.
 				if base == "" {
 					continue
 				}
-				mak.Set(&m, domain, []*dnstype.Resolver{{Addr: fmt.Sprintf("%s/dns-query", base)}})
+				mak.Set(&m, string(domain), []*dnstype.Resolver{{Addr: fmt.Sprintf("%s/dns-query", base)}})
 				break // Just make one resolver for the first peer we can get a peerAPIBase for.
 			}
 		}

--- a/types/appctype/appconnector.go
+++ b/types/appctype/appconnector.go
@@ -1,14 +1,13 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-// Package appcfg contains an experimental configuration structure for
+// Package appctype contains an experimental configuration structure for
 // "tailscale.com/app-connectors" capmap extensions.
 package appctype
 
 import (
 	"net/netip"
 
-	"go4.org/netipx"
 	"tailscale.com/tailcfg"
 )
 
@@ -93,18 +92,4 @@ type RouteInfo struct {
 type RouteUpdate struct {
 	Advertise   []netip.Prefix
 	Unadvertise []netip.Prefix
-}
-
-type Conn25Attr struct {
-	// Name is the name of this collection of domains.
-	Name string `json:"name,omitempty"`
-	// Domains enumerates the domains serviced by the specified app connectors.
-	// Domains can be of the form: example.com, or *.example.com.
-	Domains []string `json:"domains,omitempty"`
-	// Connectors enumerates the app connectors which service these domains.
-	// These can either be "*" to match any advertising connector, or a
-	// tag of the form tag:<tag-name>.
-	Connectors    []string         `json:"connectors,omitempty"`
-	MagicIPPool   []netipx.IPRange `json:"magicIPPool,omitempty"`
-	TransitIPPool []netipx.IPRange `json:"transitIPPool,omitempty"`
 }

--- a/types/appctype/conn25.go
+++ b/types/appctype/conn25.go
@@ -1,0 +1,22 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package appctype
+
+import "go4.org/netipx"
+
+const AppConnectorsExperimentalAttrName = "tailscale.com/app-connectors-experimental"
+
+type Conn25Attr struct {
+	// Name is the name of this collection of domains.
+	Name string `json:"name,omitempty"`
+	// Domains enumerates the domains serviced by the specified app connectors.
+	// Domains can be of the form: example.com, or *.example.com.
+	Domains []string `json:"domains,omitempty"`
+	// Connectors enumerates the app connectors which service these domains.
+	// These can either be "*" to match any advertising connector, or a
+	// tag of the form tag:<tag-name>.
+	Connectors    []string         `json:"connectors,omitempty"`
+	MagicIPPool   []netipx.IPRange `json:"magicIPPool,omitempty"`
+	TransitIPPool []netipx.IPRange `json:"transitIPPool,omitempty"`
+}


### PR DESCRIPTION
For Connectors 2025, determine if a self node is configured as a connector and what domains it is a connector for. Don't install Split DNS routes to other connectors for those domains, and don't alter DNS responses for those domains.

A self node is a connector for a domain if it has tags that overlap with tags in the configured policy, and --advertise-connector=true in the prefs (not in the Hostinfo from the netmap).

Because Split DNS configuration logic is still in the appc package, the shared function ConnectorSelfRoutedDomains lives there, and is called from feature/conn25. The plan is to move everything to feature/conn25 in future PRs.

Also standardize all storage of domains in any part of the configuration to be normalized dnsname.FQDNs, instead of plain strings.

Also cleanup the appctype package so that the attribute and attribute name types are deduplicated and stored in their own file to help disambiguate Connectors 2025 types from legacy App Connectors types.

Updates tailscale/corp#37424
Fixes tailscale/corp#39317