### PR TITLE
ipn/desktop: use runtime.Pinner to force heap-allocation of msg

### DIFF
--- a/ipn/desktop/sessions_windows.go
+++ b/ipn/desktop/sessions_windows.go
@@ -510,10 +510,13 @@ func sessionWatcherWndProc(hWnd windows.HWND, msg uint32, wParam, lParam uintptr
 }
 
 func pumpThreadMessages() {
-	var msg _MSG
-	for getMessage(&msg, 0, 0, 0) != 0 {
-		translateMessage(&msg)
-		dispatchMessage(&msg)
+	var p runtime.Pinner
+	defer p.Unpin()
+	msg := &_MSG{}
+	p.Pin(msg)
+	for getMessage(msg, 0, 0, 0) != 0 {
+		translateMessage(msg)
+		dispatchMessage(msg)
 	}
 }
 


### PR DESCRIPTION
[GetMessage](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getmessage) can call back into Go, triggering stack growth and causing the stack to be copied to a new memory region, which invalidates the original stack pointer passed to the syscall. Since `GetMessage` uses that pointer to write the message before returning, this leads to memory corruption.

In this PR, we fix this by using `runtime.Pinner`, which requires the pointer to refer to heap-allocated memory.

Fixes #19263
Fixes #17832