### PR TITLE
cmd/containerboot: rate-limit IPN bus netmap notifications

### DIFF
--- a/cmd/containerboot/main.go
+++ b/cmd/containerboot/main.go
@@ -306,7 +306,7 @@ func run() error {
 		}
 	}
 
-	w, err := client.WatchIPNBus(bootCtx, ipn.NotifyInitialNetMap|ipn.NotifyInitialPrefs|ipn.NotifyInitialState|ipn.NotifyInitialHealthState)
+	w, err := client.WatchIPNBus(bootCtx, ipn.NotifyInitialNetMap|ipn.NotifyInitialPrefs|ipn.NotifyInitialState|ipn.NotifyInitialHealthState|ipn.NotifyRateLimit)
 	if err != nil {
 		return fmt.Errorf("failed to watch tailscaled for updates: %w", err)
 	}
@@ -346,7 +346,7 @@ func run() error {
 		if err := tailscaleUp(bootCtx, cfg); err != nil {
 			return fmt.Errorf("failed to auth tailscale: %w", err)
 		}
-		w, err = client.WatchIPNBus(bootCtx, ipn.NotifyInitialNetMap|ipn.NotifyInitialState)
+		w, err = client.WatchIPNBus(bootCtx, ipn.NotifyInitialNetMap|ipn.NotifyInitialState|ipn.NotifyRateLimit)
 		if err != nil {
 			return fmt.Errorf("rewatching tailscaled for updates after auth: %w", err)
 		}
@@ -458,7 +458,7 @@ authLoop:
 		}
 	}
 
-	w, err = client.WatchIPNBus(ctx, ipn.NotifyInitialNetMap|ipn.NotifyInitialState)
+	w, err = client.WatchIPNBus(ctx, ipn.NotifyInitialNetMap|ipn.NotifyInitialState|ipn.NotifyRateLimit)
 	if err != nil {
 		return fmt.Errorf("rewatching tailscaled for updates after auth: %w", err)
 	}


### PR DESCRIPTION
CPU profiling a containerboot subnet router on a large tailnet showed roughly 40% of CPU spent in `serveWatchIPNBus` JSON-encoding the full netmap on every update for the containerboot watcher (most of that in `tailcfg.NodeView.MarshalJSON` and the subsequent `encoding/json.appendCompact` re-scan).

containerboot only reads `SelfNode` fields from those notifications (and does a peer lookup when `TailnetTargetFQDN` is set), so it does not need every intermediate netmap delta.

This sets `ipn.NotifyRateLimit` on all three `WatchIPNBus` calls so netmap notifications are coalesced to one per 3s. Initial-state delivery is unaffected — `rateLimitingBusSender` flushes the first send immediately. After this change, `serveWatchIPNBus` dropped from ~6.4s to ~2.0s CPU per 60s sample on the same tailnet.
