### PR TITLE
wgengine/router/osrouter: fix privileged tests missing fake netfilter runner

### DIFF
--- a/wgengine/router/osrouter/router_linux_test.go
+++ b/wgengine/router/osrouter/router_linux_test.go
@@ -1211,7 +1211,9 @@ func TestRuleDeletedEvent(t *testing.T) {
 }
 
 func TestDelRouteIdempotent(t *testing.T) {
+	fake := NewFakeOS(t)
 	lt, _ := newLinuxRootTest(t)
+	lt.r.nfr = fake.nfr
 	defer lt.Close()
 
 	for _, s := range []string{
@@ -1237,7 +1239,9 @@ func TestDelRouteIdempotent(t *testing.T) {
 }
 
 func TestAddRemoveRules(t *testing.T) {
+	fake := NewFakeOS(t)
 	lt, _ := newLinuxRootTest(t)
+	lt.r.nfr = fake.nfr
 	defer lt.Close()
 	r := lt.r
 


### PR DESCRIPTION
These test failures were never caught by CI because the package in question was missing from our privileged tests list. tailscale/corp#40007 covers improving our process around this.

Fixes #19316