### PR TITLE
tstest: add RequireRoot helper

### DIFF
--- a/ssh/tailssh/privs_test.go
+++ b/ssh/tailssh/privs_test.go
@@ -20,6 +20,7 @@ import (
 	"syscall"
 	"testing"
 
+	"tailscale.com/tstest"
 	"tailscale.com/types/logger"
 )
 
@@ -71,9 +72,7 @@ func TestDoDropPrivileges(t *testing.T) {
 		os.Exit(0)
 	}
 
-	if os.Getuid() != 0 {
-		t.Skip("test only works when run as root")
-	}
+	tstest.RequireRoot(t)
 
 	rerunSelf := func(t *testing.T, input SubprocInput) []byte {
 		fpath := filepath.Join(t.TempDir(), "out.json")

--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -73,9 +73,7 @@ func TestMain(m *testing.M) {
 // https://github.com/tailscale/tailscale/issues/7894
 func TestTUNMode(t *testing.T) {
 	tstest.Shard(t)
-	if os.Getuid() != 0 {
-		t.Skip("skipping when not root")
-	}
+	tstest.RequireRoot(t)
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 	env.tunMode = true
@@ -1565,9 +1563,7 @@ func testAutoUpdateDefaults(t *testing.T, useCap bool) {
 // https://github.com/tailscale/corp/issues/22511
 func TestDNSOverTCPIntervalResolver(t *testing.T) {
 	tstest.Shard(t)
-	if os.Getuid() != 0 {
-		t.Skip("skipping when not root")
-	}
+	tstest.RequireRoot(t)
 	env := NewTestEnv(t)
 	env.tunMode = true
 	n1 := NewTestNode(t, env)
@@ -1637,9 +1633,7 @@ func TestDNSOverTCPIntervalResolver(t *testing.T) {
 // directions.
 func TestNetstackTCPLoopback(t *testing.T) {
 	tstest.Shard(t)
-	if os.Getuid() != 0 {
-		t.Skip("skipping when not root")
-	}
+	tstest.RequireRoot(t)
 
 	env := NewTestEnv(t)
 	env.tunMode = true
@@ -1779,9 +1773,7 @@ func TestNetstackTCPLoopback(t *testing.T) {
 // directions.
 func TestNetstackUDPLoopback(t *testing.T) {
 	tstest.Shard(t)
-	if os.Getuid() != 0 {
-		t.Skip("skipping when not root")
-	}
+	tstest.RequireRoot(t)
 
 	env := NewTestEnv(t)
 	env.tunMode = true

--- a/tstest/tstest.go
+++ b/tstest/tstest.go
@@ -95,6 +95,14 @@ func Parallel(t *testing.T) {
 	}
 }
 
+// RequireRoot skips the test if the current user is not root.
+func RequireRoot(tb testing.TB) {
+	tb.Helper()
+	if os.Getuid() != 0 {
+		tb.Skip("skipping test; requires root")
+	}
+}
+
 // SkipOnKernelVersions skips the test if the current
 // kernel version is in the specified list.
 func SkipOnKernelVersions(t testing.TB, issue string, versions ...string) {

--- a/wgengine/router/osrouter/router_linux_test.go
+++ b/wgengine/router/osrouter/router_linux_test.go
@@ -1157,9 +1157,7 @@ func (lt *linuxTest) Close() error {
 }
 
 func newLinuxRootTest(t *testing.T) (*linuxTest, *eventbus.Bus) {
-	if os.Getuid() != 0 {
-		t.Skip("test requires root")
-	}
+	tstest.RequireRoot(t)
 
 	lt := new(linuxTest)
 	lt.tun = createTestTUN(t)


### PR DESCRIPTION
Start using a common helper for tests to declare that they require root.

This is step 1. A later step will then make this helper track which tests were
skipped so a subsequent pass will run these test as root.

Updates tailscale/corp#40007
