### PR TITLE
gokrazy: add arm64 natlab appliance image support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -163,4 +163,4 @@
     });
   };
 }
-# nix-direnv cache busting line: sha256-aZkUnWyQokNw+lxut9Fak3CazmwYE4tXILhzfK4jeK4=
+# nix-direnv cache busting line: sha256-rP2sZu3H6exxwfqe0TSVQP1I0WmOuU6TlJuNLBE/Fjw=

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/godbus/dbus/v5 v5.1.1-0.20230522191255-76236955d466
 	github.com/gokrazy/breakglass v0.0.0-20251229072214-9dbc0478d486
 	github.com/gokrazy/gokrazy v0.0.0-20260123094004-294c93fa173c
+	github.com/gokrazy/kernel.arm64 v0.0.0-20260403054012-807489e0272a
 	github.com/gokrazy/serial-busybox v0.0.0-20250119153030-ac58ba7574e7
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8
 	github.com/golang/snappy v0.0.4

--- a/go.mod.sri
+++ b/go.mod.sri
@@ -1,1 +1,1 @@
-sha256-aZkUnWyQokNw+lxut9Fak3CazmwYE4tXILhzfK4jeK4=
+sha256-rP2sZu3H6exxwfqe0TSVQP1I0WmOuU6TlJuNLBE/Fjw=

--- a/go.sum
+++ b/go.sum
@@ -492,6 +492,8 @@ github.com/gokrazy/gokrazy v0.0.0-20260123094004-294c93fa173c/go.mod h1:NtMkrFeD
 github.com/gokrazy/internal v0.0.0-20200407075822-660ad467b7c9/go.mod h1:LA5TQy7LcvYGQOy75tkrYkFUhbV2nl5qEBP47PSi2JA=
 github.com/gokrazy/internal v0.0.0-20251208203110-3c1aa9087c82 h1:4ghNfD9NaZLpFrqQiBF6mPVFeMYXJSky38ubVA4ic2E=
 github.com/gokrazy/internal v0.0.0-20251208203110-3c1aa9087c82/go.mod h1:dQY4EMkD4L5ZjYJ0SPtpgYbV7MIUMCxNIXiOfnZ6jP4=
+github.com/gokrazy/kernel.arm64 v0.0.0-20260403054012-807489e0272a h1:fa11POmSLo6fkkcqc+RUIyiqGJzBAOHEe/CCHAA/NGc=
+github.com/gokrazy/kernel.arm64 v0.0.0-20260403054012-807489e0272a/go.mod h1:WWx72LXHEesuJxbopusRfSoKJQ6ffdwkT0DZditdrLo=
 github.com/gokrazy/serial-busybox v0.0.0-20250119153030-ac58ba7574e7 h1:gurTGc4sL7Ik+IKZ29rhGgHNZQTXPtEXLw+aM9E+/HE=
 github.com/gokrazy/serial-busybox v0.0.0-20250119153030-ac58ba7574e7/go.mod h1:OYcG5tSb+QrelmUOO4EZVUFcIHyyZb0QDbEbZFUp1TA=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=

--- a/gokrazy/Makefile
+++ b/gokrazy/Makefile
@@ -11,3 +11,8 @@ qemu: image
 natlab:
 	go run build.go --build --app=natlabapp
 	qemu-img convert -O qcow2 natlabapp.img natlabapp.qcow2
+
+# For natlab integration tests on macOS arm64:
+natlab-arm64:
+	go run build.go --build --app=natlabapp.arm64
+	qemu-img convert -O qcow2 natlabapp.arm64.img natlabapp.arm64.qcow2

--- a/gokrazy/natlabapp.arm64/gokrazydeps.go
+++ b/gokrazy/natlabapp.arm64/gokrazydeps.go
@@ -1,0 +1,16 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build for_go_mod_tidy_only
+
+package gokrazydeps
+
+import (
+	_ "github.com/gokrazy/gokrazy"
+	_ "github.com/gokrazy/gokrazy/cmd/dhcp"
+	_ "github.com/gokrazy/kernel.arm64"
+	_ "github.com/gokrazy/serial-busybox"
+	_ "tailscale.com/cmd/tailscale"
+	_ "tailscale.com/cmd/tailscaled"
+	_ "tailscale.com/cmd/tta"
+)

--- a/shell.nix
+++ b/shell.nix
@@ -16,4 +16,4 @@
 ) {
   src =  ./.;
 }).shellNix
-# nix-direnv cache busting line: sha256-aZkUnWyQokNw+lxut9Fak3CazmwYE4tXILhzfK4jeK4=
+# nix-direnv cache busting line: sha256-rP2sZu3H6exxwfqe0TSVQP1I0WmOuU6TlJuNLBE/Fjw=


### PR DESCRIPTION
Add natlabapp.arm64 config and gokrazydeps.go for building a gokrazy
natlab appliance image targeting arm64 (Apple Silicon). This is the
arm64 counterpart to the existing natlabapp (amd64) used by vmtest.

The arm64 image uses github.com/gokrazy/kernel.arm64 and is built
with "make natlab-arm64" in the gokrazy directory.

Updates #13038
