### PR TITLE
tailcfg,types/netmap: add (Visible) Services to SelfNode Caps

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -2447,6 +2447,18 @@ type Oauth2Token struct {
 // These are also referred to as "Node Attributes" in the ACL policy file.
 type NodeCapability string
 
+// NodeCapabilityPrefix is a prefix for [NodeCapMap] keys that share a common
+// namespace, where each entry represents a distinct named instance (e.g. one
+// per service). The full key is formed by concatenating the prefix with the
+// instance name.
+type NodeCapabilityPrefix string
+
+// ToAttribute returns the full [NodeCapability] key for the given value under
+// this prefix, of the form prefix+value.
+func (p NodeCapabilityPrefix) ToAttribute(value string) NodeCapability {
+	return NodeCapability(string(p) + value)
+}
+
 const (
 	CapabilityFileSharing        NodeCapability = "https://tailscale.com/cap/file-sharing"
 	CapabilityAdmin              NodeCapability = "https://tailscale.com/cap/is-admin"
@@ -2778,6 +2790,14 @@ const (
 	// absent (or removed), a node that supports netmap caching will ignore and
 	// discard existing cached maps, and will not store any.
 	NodeAttrCacheNetworkMaps NodeCapability = "cache-network-maps"
+)
+
+const (
+	// NodeAttrPrefixServices is the prefix for per-service [NodeCapMap]
+	// entries describing Services visible (accessible) to this node. The full
+	// key for a service named "svc:foo" is NodeAttrPrefixServices+"foo".
+	// Each value under such a key is of type [ServiceDetails].
+	NodeAttrPrefixServices NodeCapabilityPrefix = "services/"
 )
 
 // SetDNSRequest is a request to add a DNS record.
@@ -3317,6 +3337,19 @@ const LBHeader = "Ts-Lb"
 // correspond to those IPs. Any services that don't correspond to a service
 // this client is hosting can be ignored.
 type ServiceIPMappings map[ServiceName][]netip.Addr
+
+// ServiceDetails describes a Service visible to this node.
+// It is the value type stored under [NodeAttrPrefixServices]+serviceName keys in [NodeCapMap].
+type ServiceDetails struct {
+	// Name is the name of the Service, of the form "svc:dns-label".
+	Name ServiceName
+
+	// Addrs are the IP addresses (IPv4 and IPv6) assigned to this Service.
+	Addrs []netip.Addr `json:",omitempty"`
+
+	// Ports are the protocol/port combinations the Service accepts.
+	Ports []ProtoPortRange `json:",omitempty"`
+}
 
 // ClientAuditAction represents an auditable action that a client can report to the
 // control plane.  These actions must correspond to the supported actions

--- a/types/netmap/netmap.go
+++ b/types/netmap/netmap.go
@@ -146,6 +146,27 @@ func (nm *NetworkMap) GetIPVIPServiceMap() IPServiceMappings {
 	return res
 }
 
+// Services returns the Services visible (accessible) to this node,
+// decoded from [tailcfg.NodeAttrPrefixServices]+serviceName entries in the
+// self node's CapMap. Returns nil if nm is nil or SelfNode is invalid.
+func (nm *NetworkMap) Services() map[tailcfg.ServiceName]tailcfg.ServiceDetails {
+	if nm == nil || !nm.SelfNode.Valid() {
+		return nil
+	}
+	result := make(map[tailcfg.ServiceName]tailcfg.ServiceDetails)
+	for cap := range nm.SelfNode.CapMap().All() {
+		if !strings.HasPrefix(string(cap), string(tailcfg.NodeAttrPrefixServices)) {
+			continue
+		}
+		svcs, err := tailcfg.UnmarshalNodeCapViewJSON[tailcfg.ServiceDetails](nm.SelfNode.CapMap(), cap)
+		if err != nil || len(svcs) < 1 {
+			continue
+		}
+		result[svcs[0].Name] = svcs[0]
+	}
+	return result
+}
+
 // SelfNodeOrZero returns the self node, or a zero value if nm is nil.
 func (nm *NetworkMap) SelfNodeOrZero() tailcfg.NodeView {
 	if nm == nil {


### PR DESCRIPTION
## tailcfg,types/netmap: add (Visible) Services to SelfNode Caps

Updates [#40052](https://github.com/tailscale/corp/issues/40052)

Adds support for receiving information about services accessible to the node (per the Tailnet's ACL) via node capabilities in the netmap.

The structure is a capability key PER SERVICE where the key is `services/${SERVICE_NAME}`.

The reasoning behind this is that we want to support single-service updates in the future without rebuilding the whole netmap, and it is assumed that we will build support for replacing entire entries in NodeMapCap, but not patching their inner contents. See also: [Slack Thread](https://tailscale.slack.com/archives/C06DR3S42DV/p1775832951646049)

```
/ # tailscale debug netmap | jq '.SelfNode.CapMap | with_entries(select(.key | startswith("services/")))'
{
  "services/demo-mysql-service": [
    {
      "Name": "svc:demo-mysql-service",
      "Addrs": [
        "100.109.199.45",
        "fd7a:115c:a1e0::f601:c72d"
      ],
      "Ports": [
        "tcp:3306"
      ]
    }
  ],
  "services/demo-ssh-service": [
    {
      "Name": "svc:demo-ssh-service",
      "Addrs": [
        "100.127.62.65",
        "fd7a:115c:a1e0::a001:3e41"
      ],
      "Ports": [
        "tcp:22"
      ]
    }
  ]
}
```