### PR TITLE
derper: use X-Real-IP header

### DIFF
--- a/cmd/derper/derper.go
+++ b/cmd/derper/derper.go
@@ -25,6 +25,7 @@ import (
 	"math"
 	"net"
 	"net/http"
+	"net/netip"
 	"os"
 	"os/signal"
 	"path"
@@ -98,6 +99,8 @@ var (
 
 	// ACE
 	flagACEEnabled = flag.Bool("ace", false, "whether to enable embedded ACE server [experimental + in-development as of 2025-09-12; not yet documented]")
+
+	acceptProxy = flag.String("accept-proxy", "", "accept X-Real-IP from this IP address [experimental]")
 )
 
 var (
@@ -189,6 +192,16 @@ func main() {
 	serveTLS := tsweb.IsProd443(*addr) || *certMode == "manual"
 
 	s := derpserver.New(cfg.PrivateKey, log.Printf)
+
+	if acceptProxy != "" {
+		netipProxy, err = netip.ParseAddr(acceptProxy)
+
+		if err != nil {
+			log.Fatalf("Invalid accept-proxy ip address:%v", err)
+		}
+		s.AcceptProxy(netipProxy)
+	}
+
 	s.SetVerifyClient(*verifyClients)
 	s.SetTailscaledSocketPath(*socket)
 	s.SetVerifyClientURL(*verifyClientURL)

--- a/derp/derpserver/derpserver.go
+++ b/derp/derpserver/derpserver.go
@@ -181,9 +181,8 @@ type Server struct {
 	verifyClientsURL         string
 	verifyClientsURLFailOpen bool
 
-	// a string prefix, with terminating :, from which to accept X-Real-IP headers from.
-	// specifically, this is matched against AddrPort.String()
-	acceptProxy              string
+	// IP address from which to accept X-Real-IP headers from
+	acceptProxy              netip.Addr
 
 	mu       syncs.Mutex
 	closed   bool
@@ -392,7 +391,6 @@ func New(privateKey key.NodePrivate, logf logger.Logf) *Server {
 		keyOfAddr:           map[netip.AddrPort]key.NodePublic{},
 		clock:               tstime.StdClock{},
 		tcpWriteTimeout:     DefaultTCPWiteTimeout,
-		acceptProxy:         "127.0.0.1:",
 	}
 	s.initMetacert()
 	s.packetsRecvDisco = s.packetsRecvByKind.Get(string(packetKindDisco))
@@ -480,6 +478,10 @@ func (s *Server) SetMeshKey(v string) error {
 	}
 	s.meshKey = k
 	return nil
+}
+
+func (s *Server) AcceptProxy(proxy netip.Addr) {
+	s.acceptProxy = proxy
 }
 
 // SetVerifyClients sets whether this DERP server verifies clients through tailscaled.

--- a/derp/derpserver/derpserver.go
+++ b/derp/derpserver/derpserver.go
@@ -181,6 +181,10 @@ type Server struct {
 	verifyClientsURL         string
 	verifyClientsURLFailOpen bool
 
+	// a string prefix, with terminating :, from which to accept X-Real-IP headers from.
+	// specifically, this is matched against AddrPort.String()
+	acceptProxy              string
+
 	mu       syncs.Mutex
 	closed   bool
 	netConns map[derp.Conn]chan struct{} // chan is closed when conn closes
@@ -388,6 +392,7 @@ func New(privateKey key.NodePrivate, logf logger.Logf) *Server {
 		keyOfAddr:           map[netip.AddrPort]key.NodePublic{},
 		clock:               tstime.StdClock{},
 		tcpWriteTimeout:     DefaultTCPWiteTimeout,
+		acceptProxy:         "127.0.0.1:",
 	}
 	s.initMetacert()
 	s.packetsRecvDisco = s.packetsRecvByKind.Get(string(packetKindDisco))

--- a/derp/derpserver/handler.go
+++ b/derp/derpserver/handler.go
@@ -8,12 +8,9 @@ import (
 	"log"
 	"net/http"
 	"strings"
-	"regexp"
 
 	"tailscale.com/derp"
 )
-
-var IPsanitizer = regexp.MustCompile("[^][a-zA-Z0-9:.]+")
 
 // Handler returns an http.Handler to be mounted at /derp, serving s.
 func Handler(s *Server) http.Handler {
@@ -70,24 +67,44 @@ func Handler(s *Server) http.Handler {
 		}
 
 		var remote_addr = netConn.RemoteAddr().String()
+		defer s.Accept(ctx, netConn, conn, remote_addr)
 
-		if (s.acceptProxy != "") && strings.HasPrefix(remote_addr, s.acceptProxy) {
-			var header_addr = IPsanitizer.ReplaceAllString(r.Header.Get("X-Real-IP"), "")
-
-			if (header_addr != "") {
-				// the port is only used as a key to index the connection.  there is
-				// a chance that two connections from the same remote, one from a proxy,
-				// and another direct, may have the same "remote" port (one, the actual
-				// source port on the derp client, the other the source port used by the
-				// proxy).
-
-				// ports are 16 bits, so that chance is 1 in ~ 2**8, which is
-				// frustratingly likely,  please don't connect to derper that way!
-				remote_addr = header_addr + remote_addr[len(s.acceptProxy)-1:len(remote_addr)]
-			}
+		if s.acceptProxy == nil {
+			return
 		}
 
-		s.Accept(ctx, netConn, conn, remote_addr)
+		remote_host, remote_port, err = net.SplitHostPort(remote_addr)
+		if (err != nil {
+			return
+		}
+
+		// XXX: remove "%zone"
+		remote_netipAddr, err = netip.parseAddr(remote_host)
+		if err != nil) {
+			return
+		}
+
+		if remote_netipAddr != s.acceptProxy {
+			return
+		}
+
+		header_addr, err = netip.parseAddr(r.Header.Get("X-Real-IP"))
+		if err != nil {
+			return
+		}
+
+		// the port is only used as a key to index the connection.  there is
+		// a chance that two connections from the same remote, one from a proxy,
+		// and another direct, may have the same "remote" port (one, the actual
+		// source port on the derp client, the other the source port used by the
+		// proxy).
+
+		// ports are 16 bits, so that chance is 1 in ~ 2**8, which is
+		// frustratingly likely,  please don't connect to derper that way!
+
+		// the port is only used as a key to index the connection.
+		// see the acceptProxy for some caveats
+		remote_addr = fmt.Sprintf("%s:%s", header_addr, remote_port)
 	})
 }
 

--- a/derp/derpserver/handler.go
+++ b/derp/derpserver/handler.go
@@ -8,9 +8,12 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"regexp"
 
 	"tailscale.com/derp"
 )
+
+var IPsanitizer = regexp.MustCompile("[^][a-zA-Z0-9:.]+")
 
 // Handler returns an http.Handler to be mounted at /derp, serving s.
 func Handler(s *Server) http.Handler {
@@ -66,7 +69,25 @@ func Handler(s *Server) http.Handler {
 			ctx = IdealNodeContextKey.WithValue(ctx, v)
 		}
 
-		s.Accept(ctx, netConn, conn, netConn.RemoteAddr().String())
+		var remote_addr = netConn.RemoteAddr().String()
+
+		if (s.acceptProxy != "") && strings.HasPrefix(remote_addr, s.acceptProxy) {
+			var header_addr = IPsanitizer.ReplaceAllString(r.Header.Get("X-Real-IP"), "")
+
+			if (header_addr != "") {
+				// the port is only used as a key to index the connection.  there is
+				// a chance that two connections from the same remote, one from a proxy,
+				// and another direct, may have the same "remote" port (one, the actual
+				// source port on the derp client, the other the source port used by the
+				// proxy).
+
+				// ports are 16 bits, so that chance is 1 in ~ 2**8, which is
+				// frustratingly likely,  please don't connect to derper that way!
+				remote_addr = header_addr + remote_addr[len(s.acceptProxy)-1:len(remote_addr)]
+			}
+		}
+
+		s.Accept(ctx, netConn, conn, remote_addr)
 	})
 }
 


### PR DESCRIPTION
derper uses information about the remote connecting.  When running behind a http(s) proxy, this information is reported incorrectly because the remote is identified as the local machine.

Rectify this by trusting X-Real-IP headers passed from a trusted source (the local host).  Sanitize the IP address as well.

I've been running this for a little over a month without issue. Not all of us self-hosters have a bunch of extra IPs laying around!