### PR TITLE
netmon: more descriptive netcheck

### DIFF
--- a/net/netmon/netmon.go
+++ b/net/netmon/netmon.go
@@ -441,14 +441,12 @@ func (m *Monitor) GatewayAndSelfIP() (gw, myIP netip.Addr, ok bool) {
 		return m.gw, m.gwSelfIP, true
 	}
 	gw, myIP, ok = LikelyHomeRouterIP()
-	changed := false
 	if ok {
-		changed = m.gw != gw || m.gwSelfIP != myIP
+		if m.gw != gw || m.gwSelfIP != myIP {
+			m.logf("gateway and self IP changed: gw=%v -> %v self=%v -> %v", m.gw, gw, m.gwSelfIP, myIP)
+		}
 		m.gw, m.gwSelfIP = gw, myIP
 		m.gwValid = true
-	}
-	if changed {
-		m.logf("gateway and self IP changed: gw=%v self=%v", m.gw, m.gwSelfIP)
 	}
 	return gw, myIP, ok
 }


### PR DESCRIPTION
tailscale netcheck will report when the "gateway and self IP changed". However, it does not say what the previous reported IPs were.  This makes understanding what is going on more difficult.

Report both original and "changed" IPs when this scenario occurs. Additionally, simplify the logic ever so slightly.