### PR TITLE
derper: ensure cert.Leaf is intialized

### DIFF
--- a/cmd/derper/cert.go
+++ b/cmd/derper/cert.go
@@ -123,6 +123,9 @@ func NewManualCertManager(certdir, hostname string) (certProvider, error) {
 	if err := x509Cert.VerifyHostname(hostname); err != nil {
 		return nil, fmt.Errorf("cert invalid for hostname %q: %w", hostname, err)
 	}
+	if cert.Leaf == nil {
+		cert.Leaf = x509Cert
+	}
 	if hostnameIP != nil {
 		// If the hostname is an IP address, print out information on how to
 		// confgure this in the derpmap.


### PR DESCRIPTION
On different build chains, cert.Leaf is not always initialized.  This leads to test failures.

Initialize cert.Leaf manually during testing to avoid such failures. This has no runtime performance impact, since the code is only called during testing.

I ran into this issue while packaging this for Debian.  Something about the golang build chain is subtly different, and causes test failures there.  This resolves that test failure, though.