### PR TITLE
cmd/k8s-operator: bracket IPv6 ClusterIPs in ingress proxy URLs

### DIFF
--- a/cmd/k8s-operator/ingress.go
+++ b/cmd/k8s-operator/ingress.go
@@ -8,6 +8,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/netip"
 	"slices"
 	"strings"
 	"sync"
@@ -364,7 +365,7 @@ func handlersForIngress(ctx context.Context, ing *networkingv1.Ingress, cl clien
 			proto = "https+insecure://"
 		}
 		mak.Set(&handlers, path, &ipn.HTTPHandler{
-			Proxy: proto + svc.Spec.ClusterIP + ":" + fmt.Sprint(port) + path,
+			Proxy: proto + ipPortPath(svc.Spec.ClusterIP, port, path),
 		})
 	}
 	addIngressBackend(ing.Spec.DefaultBackend, "/")
@@ -407,4 +408,14 @@ func hostnameForIngress(ing *networkingv1.Ingress) string {
 		return hostname
 	}
 	return ing.Namespace + "-" + ing.Name + "-ingress"
+}
+
+// ipPortPath formats an IP address with port and path for use in a URL.
+// IPv6 addresses are wrapped in brackets as required by RFC 3986.
+func ipPortPath(ip string, port int32, path string) string {
+	host := ip
+	if addr, err := netip.ParseAddr(ip); err == nil && addr.Is6() {
+		host = "[" + ip + "]"
+	}
+	return host + ":" + fmt.Sprint(port) + path
 }


### PR DESCRIPTION
Fixes #19338

When building proxy target URLs for Kubernetes Ingress backends, the operator
concatenates ClusterIP and port without brackets:

```
http://fd00:100:96:43::bef2:80/
```

For IPv6 addresses this is invalid per RFC 3986. Go 1.26 tightened URL parsing,
so these now fail with `invalid port ":100:96:43::bef2:80" after host`.

The same class of bug was already fixed for porttrack in `87bf76d`.

## Fix

Add `ipPortPath()` helper that wraps IPv6 addresses in brackets:

```
http://[fd00:100:96:43::bef2]:80/
```

Uses `netip.ParseAddr` for robust IPv6 detection.

Signed-off-by: yanhu <huangfuyang900204@gmail.com>