### PR TITLE
fix: DNS fails when switching from wifi to mobile data (closes #17747)

### DIFF
--- a/net/dns/manager.go
+++ b/net/dns/manager.go
@@ -396,7 +396,7 @@ func (m *Manager) compileConfig(cfg Config) (rcfg resolver.Config, ocfg OSConfig
 		cfg, err := m.os.GetBaseConfig()
 		if err == nil {
 			baseCfg = &cfg
-		} else if (isApple || isNoopManager(m.os)) && err == ErrGetBaseConfigNotSupported {
+		} else if err == ErrGetBaseConfigNotSupported {
 			// Expected when using noopManager (userspace networking) or on
 			// certain iOS/macOS builds. Continue without base config.
 		} else {

--- a/net/dns/manager_android.go
+++ b/net/dns/manager_android.go
@@ -1,0 +1,52 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package dns
+
+import (
+	"net/netip"
+	"strings"
+
+	"tailscale.com/control/controlknobs"
+	"tailscale.com/health"
+	"tailscale.com/net/netmon"
+	"tailscale.com/types/logger"
+	"tailscale.com/util/eventbus"
+	"tailscale.com/util/syspolicy/policyclient"
+)
+
+// androidManager implements OSConfigurator for Android. Unlike noopManager,
+// it can return the system's current DNS servers via GetBaseConfig by reading
+// the values cached by the Android JNI layer via netmon.UpdateLastKnownDNSServers.
+type androidManager struct{}
+
+func (m androidManager) SetDNS(OSConfig) error  { return nil }
+func (m androidManager) SupportsSplitDNS() bool { return false }
+func (m androidManager) Close() error           { return nil }
+func (m androidManager) GetBaseConfig() (OSConfig, error) {
+	serversStr := netmon.LastKnownDNSServers()
+	if serversStr == "" {
+		return OSConfig{}, ErrGetBaseConfigNotSupported
+	}
+	var nameservers []netip.Addr
+	for _, s := range strings.Split(serversStr, ",") {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if ip, err := netip.ParseAddr(s); err == nil {
+			nameservers = append(nameservers, ip)
+		}
+	}
+	if len(nameservers) == 0 {
+		return OSConfig{}, ErrGetBaseConfigNotSupported
+	}
+	return OSConfig{Nameservers: nameservers}, nil
+}
+
+// NewOSConfigurator creates a new OS configurator for Android.
+//
+// The health tracker and the knobs may be nil and are ignored on this platform.
+func NewOSConfigurator(logger.Logf, *health.Tracker, *eventbus.Bus, policyclient.Client, *controlknobs.Knobs, string) (OSConfigurator, error) {
+	return androidManager{}, nil
+}

--- a/net/dns/manager_default.go
+++ b/net/dns/manager_default.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build (!linux || android) && !freebsd && !openbsd && !windows && !darwin && !illumos && !solaris && !plan9
+//go:build !linux && !android && !freebsd && !openbsd && !windows && !darwin && !illumos && !solaris && !plan9
 
 package dns
 

--- a/net/dns/resolver/forwarder.go
+++ b/net/dns/resolver/forwarder.go
@@ -477,6 +477,9 @@ func (f *forwarder) setRoutes(routesBySuffix map[dnsname.FQDN][]*dnstype.Resolve
 	f.acceptDNS = acceptDNS
 	f.routes = routes
 	f.cloudHostFallback = cloudHostFallback
+	// Clear cached DoH HTTP clients so that stale connections from a
+	// previous network interface are not reused after a network change.
+	f.dohClient = nil
 }
 
 var stdNetPacketListener nettype.PacketListenerWithNetIP = nettype.MakePacketListenerWithNetIP(new(net.ListenConfig))

--- a/net/netmon/interfaces_android.go
+++ b/net/netmon/interfaces_android.go
@@ -19,6 +19,7 @@ import (
 
 var (
 	lastKnownDefaultRouteIfName syncs.AtomicValue[string]
+	lastKnownDNSServers         syncs.AtomicValue[string] // comma-separated DNS server IPs
 )
 
 var procNetRoutePath = "/proc/net/route"
@@ -168,6 +169,23 @@ func UpdateLastKnownDefaultRouteInterface(ifName string) {
 	if old := lastKnownDefaultRouteIfName.Swap(ifName); old != ifName {
 		log.Printf("defaultroute: update from Android, ifName = %s (was %s)", ifName, old)
 	}
+}
+
+// UpdateLastKnownDNSServers is called by libtailscale in the Android app when
+// the connectivity manager detects a network change. The servers parameter is a
+// comma-separated list of DNS server IP addresses (e.g. "8.8.8.8,8.8.4.4").
+// This should be called alongside UpdateLastKnownDefaultRouteInterface before
+// calling Monitor.InjectEvent().
+func UpdateLastKnownDNSServers(servers string) {
+	if old := lastKnownDNSServers.Swap(servers); old != servers {
+		log.Printf("dns: update from Android, servers = %q (was %q)", servers, old)
+	}
+}
+
+// LastKnownDNSServers returns the DNS servers last provided by the Android app
+// via UpdateLastKnownDNSServers as a comma-separated string.
+func LastKnownDNSServers() string {
+	return lastKnownDNSServers.Load()
 }
 
 func defaultRoute() (d DefaultRouteDetails, err error) {

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -1504,16 +1504,32 @@ func (e *userspaceEngine) linkChange(delta *netmon.ChangeDelta) {
 	if delta.RebindLikelyRequired && up {
 		switch runtime.GOOS {
 		case "linux", "android", "ios", "darwin", "openbsd":
-			e.wgLock.Lock()
-			dnsCfg := e.lastDNSConfig
-			e.wgLock.Unlock()
-			if dnsCfg.Valid() {
-				if err := e.dns.Set(*dnsCfg.AsStruct()); err != nil {
-					e.logf("wgengine: error setting DNS config after major link change: %v", err)
-				} else if err := e.reconfigureVPNIfNecessary(); err != nil {
-					e.logf("wgengine: error reconfiguring VPN after major link change: %v", err)
-				} else {
-					e.logf("wgengine: set DNS config again after major link change")
+			// On Android and Darwin, the upstream DNS servers may have changed
+			// along with the network interface (e.g. WiFi to mobile data).
+			// Use RecompileDNSConfig so that GetBaseConfig() is re-invoked to
+			// pick up the new upstream nameservers rather than reusing stale ones.
+			if runtime.GOOS == "android" || runtime.GOOS == "darwin" || runtime.GOOS == "ios" {
+				if err := e.dns.RecompileDNSConfig(); err != nil && err != dns.ErrNoDNSConfig {
+					e.logf("wgengine: error recompiling DNS config after major link change: %v", err)
+				} else if err == nil {
+					if err := e.reconfigureVPNIfNecessary(); err != nil {
+						e.logf("wgengine: error reconfiguring VPN after major link change: %v", err)
+					} else {
+						e.logf("wgengine: recompiled DNS config after major link change")
+					}
+				}
+			} else {
+				e.wgLock.Lock()
+				dnsCfg := e.lastDNSConfig
+				e.wgLock.Unlock()
+				if dnsCfg.Valid() {
+					if err := e.dns.Set(*dnsCfg.AsStruct()); err != nil {
+						e.logf("wgengine: error setting DNS config after major link change: %v", err)
+					} else if err := e.reconfigureVPNIfNecessary(); err != nil {
+						e.logf("wgengine: error reconfiguring VPN after major link change: %v", err)
+					} else {
+						e.logf("wgengine: set DNS config again after major link change")
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Closes #17747

**Summary:** DNS resolution fails on Android when switching between WiFi and mobile data because the DNS forwarder's upstream nameserver configuration becomes stale after a network interface change

**Root cause:** On Android, the DNS OS configurator is a noopManager whose GetBaseConfig() returns ErrGetBaseConfigNotSupported, so the system's current network DNS servers are never captured as fallback routes. When a network switch occurs (WiFi to mobile), userspace.go re-calls dns.Set() with the same cached config at line 1511, but unlike Darwin which has the network extension call RecompileDNSConfig() to re-read OS nameservers, Android has no equivalent mechanism. The forwarder continues using stale upstream resolver addresses from the previous network. Additionally, the 10-minute polling interval in net/netmon/polling.go for Android (line 61-65) means network changes may not be detected promptly if the Android app fails to call InjectEvent() via the connectivity manager callback.

**Approach:** Add a mechanism for Android to provide its current DNS server addresses to tailscale after a network change, similar to how UpdateLastKnownDefaultRouteInterface provides the interface name. Create an UpdateLastKnownDNSServers function in interfaces_android.go that the Android app calls when the connectivity manager detects a network change. Then, in the linkChange handler in userspace.go, call RecompileDNSConfig() on Android (not just dns.Set with stale config) so the forwarder picks up the new upstream resolvers. The noopManager's GetBaseConfig should be enhanced to return the Android-provided DNS servers instead of ErrGetBaseConfigNotSupported.

*Automated fix by BugBot*