### PR TITLE
cmd,osrouter,linuxfw: allow disabling the "allow all inbound" firewall rule

### DIFF
--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -708,6 +708,7 @@ func TestPrefsFromUpArgs(t *testing.T) {
 				WantRunning:         true,
 				NoSNAT:              false,
 				NoStatefulFiltering: "true",
+				AllowAllInbound:     true,
 				NetfilterMode:       preftype.NetfilterOn,
 				CorpDNS:             true,
 				AutoUpdate: ipn.AutoUpdatePrefs{
@@ -726,6 +727,7 @@ func TestPrefsFromUpArgs(t *testing.T) {
 				RouteAll:            true,
 				NoSNAT:              false,
 				NoStatefulFiltering: "true",
+				AllowAllInbound:     true,
 				NetfilterMode:       preftype.NetfilterOn,
 				AutoUpdate: ipn.AutoUpdatePrefs{
 					Check: true,
@@ -744,6 +746,7 @@ func TestPrefsFromUpArgs(t *testing.T) {
 					netip.MustParsePrefix("::/0"),
 				},
 				NoStatefulFiltering: "true",
+				AllowAllInbound:     true,
 				NetfilterMode:       preftype.NetfilterOn,
 				AutoUpdate: ipn.AutoUpdatePrefs{
 					Check: true,
@@ -835,6 +838,7 @@ func TestPrefsFromUpArgs(t *testing.T) {
 				NetfilterMode:       preftype.NetfilterNoDivert,
 				NoSNAT:              true,
 				NoStatefulFiltering: "true",
+				AllowAllInbound:     true,
 				AutoUpdate: ipn.AutoUpdatePrefs{
 					Check: true,
 				},
@@ -852,6 +856,7 @@ func TestPrefsFromUpArgs(t *testing.T) {
 				NetfilterMode:       preftype.NetfilterOff,
 				NoSNAT:              true,
 				NoStatefulFiltering: "true",
+				AllowAllInbound:     true,
 				AutoUpdate: ipn.AutoUpdatePrefs{
 					Check: true,
 				},
@@ -868,6 +873,7 @@ func TestPrefsFromUpArgs(t *testing.T) {
 				WantRunning:         true,
 				NoSNAT:              true,
 				NoStatefulFiltering: "true",
+				AllowAllInbound:     true,
 				AdvertiseRoutes: []netip.Prefix{
 					netip.MustParsePrefix("fd7a:115c:a1e0:b1a::bb:10.0.0.0/112"),
 				},
@@ -887,6 +893,7 @@ func TestPrefsFromUpArgs(t *testing.T) {
 				WantRunning:         true,
 				NoSNAT:              true,
 				NoStatefulFiltering: "true",
+				AllowAllInbound:     true,
 				AdvertiseRoutes: []netip.Prefix{
 					netip.MustParsePrefix("fd7a:115c:a1e0:b1a::aabb:10.0.0.0/112"),
 				},

--- a/cmd/tailscale/cli/set.go
+++ b/cmd/tailscale/cli/set.go
@@ -66,6 +66,7 @@ type setArgsT struct {
 	statefulFiltering          bool
 	sync                       bool
 	netfilterMode              string
+	allowAllInbound            bool
 	relayServerPort            string
 	relayServerStaticEndpoints string
 }
@@ -114,6 +115,7 @@ func newSetFlagSet(goos string, setArgs *setArgsT) *flag.FlagSet {
 	case "linux":
 		setf.BoolVar(&setArgs.snat, "snat-subnet-routes", true, "source NAT traffic to local routes advertised with --advertise-routes")
 		setf.BoolVar(&setArgs.statefulFiltering, "stateful-filtering", false, "apply stateful filtering to forwarded packets (subnet routers, exit nodes, and so on)")
+		setf.BoolVar(&setArgs.allowAllInbound, "allow-all-inbound", true, "allow all inbound traffic in the firewall on the tun interface")
 		setf.StringVar(&setArgs.netfilterMode, "netfilter-mode", defaultNetfilterMode(), "netfilter mode (one of on, nodivert, off)")
 	case "windows":
 		setf.BoolVar(&setArgs.forceDaemon, "unattended", false, "run in \"Unattended Mode\" where Tailscale keeps running even after the current GUI user logs out (Windows-only)")
@@ -163,6 +165,7 @@ func runSet(ctx context.Context, args []string) (retErr error) {
 				Advertise: setArgs.advertiseConnector,
 			},
 			PostureChecking:     setArgs.reportPosture,
+			AllowAllInbound:     setArgs.allowAllInbound,
 			NoStatefulFiltering: opt.NewBool(!setArgs.statefulFiltering),
 		},
 	}

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -901,6 +901,7 @@ func init() {
 	addPrefFlagMapping("shields-up", "ShieldsUp")
 	addPrefFlagMapping("snat-subnet-routes", "NoSNAT")
 	addPrefFlagMapping("stateful-filtering", "NoStatefulFiltering")
+	addPrefFlagMapping("allow-all-inbound", "AllowAllInbound")
 	addPrefFlagMapping("exit-node-allow-lan-access", "ExitNodeAllowLANAccess")
 	addPrefFlagMapping("unattended", "ForceDaemon")
 	addPrefFlagMapping("operator", "OperatorUser")

--- a/cmd/vet/jsontags_allowlist
+++ b/cmd/vet/jsontags_allowlist
@@ -16,6 +16,7 @@ OmitEmptyShouldBeOmitZero	tailscale.com/ipn.ConfigVAlpha.Hostname
 OmitEmptyShouldBeOmitZero	tailscale.com/ipn.ConfigVAlpha.Locked
 OmitEmptyShouldBeOmitZero	tailscale.com/ipn.ConfigVAlpha.NetfilterMode
 OmitEmptyShouldBeOmitZero	tailscale.com/ipn.ConfigVAlpha.NoStatefulFiltering
+OmitEmptyShouldBeOmitZero	tailscale.com/ipn.ConfigVAlpha.AllowAllInbound
 OmitEmptyShouldBeOmitZero	tailscale.com/ipn.ConfigVAlpha.OperatorUser
 OmitEmptyShouldBeOmitZero	tailscale.com/ipn.ConfigVAlpha.PostureChecking
 OmitEmptyShouldBeOmitZero	tailscale.com/ipn.ConfigVAlpha.RunSSHServer
@@ -26,6 +27,7 @@ OmitEmptyShouldBeOmitZero	tailscale.com/ipn.ConfigVAlpha.ShieldsUp
 OmitEmptyShouldBeOmitZero	tailscale.com/ipn.OutgoingFile.PeerID
 OmitEmptyShouldBeOmitZero	tailscale.com/ipn.Prefs.AutoExitNode
 OmitEmptyShouldBeOmitZero	tailscale.com/ipn.Prefs.NoStatefulFiltering
+OmitEmptyShouldBeOmitZero	tailscale.com/ipn.Prefs.AllowAllInbound
 OmitEmptyShouldBeOmitZero	tailscale.com/ipn.Prefs.RelayServerPort
 OmitEmptyShouldBeOmitZero	tailscale.com/ipn/auditlog.transaction.Action
 OmitEmptyShouldBeOmitZero	tailscale.com/ipn/ipnstate.PeerStatus.AllowedIPs
@@ -190,6 +192,7 @@ OmitEmptyUnsupportedInV2	tailscale.com/ipn.MaskedPrefs.NetfilterKindSet
 OmitEmptyUnsupportedInV2	tailscale.com/ipn.MaskedPrefs.NetfilterModeSet
 OmitEmptyUnsupportedInV2	tailscale.com/ipn.MaskedPrefs.NoSNATSet
 OmitEmptyUnsupportedInV2	tailscale.com/ipn.MaskedPrefs.NoStatefulFilteringSet
+OmitEmptyUnsupportedInV2	tailscale.com/ipn.MaskedPrefs.AllowAllInboundSet
 OmitEmptyUnsupportedInV2	tailscale.com/ipn.MaskedPrefs.NotepadURLsSet
 OmitEmptyUnsupportedInV2	tailscale.com/ipn.MaskedPrefs.OperatorUserSet
 OmitEmptyUnsupportedInV2	tailscale.com/ipn.MaskedPrefs.PostureCheckingSet

--- a/ipn/conf.go
+++ b/ipn/conf.go
@@ -40,6 +40,7 @@ type ConfigVAlpha struct {
 
 	NetfilterMode       *string  `json:",omitempty"` // "on", "off", "nodivert"
 	NoStatefulFiltering opt.Bool `json:",omitempty"`
+	AllowAllInbound     opt.Bool `json:",omitempty"`
 
 	PostureChecking opt.Bool         `json:",omitempty"`
 	RunSSHServer    opt.Bool         `json:",omitempty"` // Tailscale SSH
@@ -122,6 +123,10 @@ func (c *ConfigVAlpha) ToPrefs() (MaskedPrefs, error) {
 	if c.NoStatefulFiltering != "" {
 		mp.NoStatefulFiltering = c.NoStatefulFiltering
 		mp.NoStatefulFilteringSet = true
+	}
+	if c.AllowAllInbound != "" {
+		mp.AllowAllInbound = c.AllowAllInbound.EqualBool(true)
+		mp.AllowAllInboundSet = true
 	}
 
 	if c.NetfilterMode != nil {

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -94,6 +94,7 @@ var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	Sync                       opt.Bool
 	NoSNAT                     bool
 	NoStatefulFiltering        opt.Bool
+	AllowAllInbound            bool
 	NetfilterMode              preftype.NetfilterMode
 	OperatorUser               string
 	ProfileName                string

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -395,6 +395,12 @@ func (v PrefsView) NoSNAT() bool { return v.ж.NoSNAT }
 // Linux-only.
 func (v PrefsView) NoStatefulFiltering() opt.Bool { return v.ж.NoStatefulFiltering }
 
+// AllowAllInbound specifies whether or not to add a firewall rule allowing
+// all inbound traffic on the tun interface. The default is to add it.
+//
+// Linux-only.
+func (v PrefsView) AllowAllInbound() bool { return v.ж.AllowAllInbound }
+
 // NetfilterMode specifies how much to manage netfilter rules for
 // Tailscale, if at all.
 func (v PrefsView) NetfilterMode() preftype.NetfilterMode { return v.ж.NetfilterMode }
@@ -496,6 +502,7 @@ var _PrefsViewNeedsRegeneration = Prefs(struct {
 	Sync                       opt.Bool
 	NoSNAT                     bool
 	NoStatefulFiltering        opt.Bool
+	AllowAllInbound            bool
 	NetfilterMode              preftype.NetfilterMode
 	OperatorUser               string
 	ProfileName                string

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -5678,6 +5678,7 @@ func (b *LocalBackend) routerConfigLocked(cfg *wgcfg.Config, prefs ipn.PrefsView
 		SNATSubnetRoutes:  !prefs.NoSNAT(),
 		StatefulFiltering: doStatefulFiltering,
 		NetfilterMode:     prefs.NetfilterMode(),
+		AllowAllInbound:   prefs.AllowAllInbound(),
 		Routes:            peerRoutes(b.logf, cfg.Peers, singleRouteThreshold, prefs.RouteAll()),
 		NetfilterKind:     netfilterKind,
 	}
@@ -5935,7 +5936,9 @@ func (b *LocalBackend) enterStateLocked(newState ipn.State) {
 	case ipn.Stopped, ipn.NoState:
 		// Unconfigure the engine if it has stopped (WantRunning is set to false)
 		// or if we've switched to a different profile and the state is unknown.
-		err := b.e.Reconfig(&wgcfg.Config{}, &router.Config{}, &dns.Config{})
+		err := b.e.Reconfig(&wgcfg.Config{}, &router.Config{
+			AllowAllInbound: true,
+		}, &dns.Config{})
 		if err != nil {
 			b.logf("Reconfig(down): %v", err)
 		}

--- a/ipn/ipnlocal/state_test.go
+++ b/ipn/ipnlocal/state_test.go
@@ -1267,7 +1267,7 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 			// Once started, all configs must be reset and have their zero values.
 			wantState:     ipn.NeedsLogin,
 			wantCfg:       &wgcfg.Config{},
-			wantRouterCfg: &router.Config{},
+			wantRouterCfg: &router.Config{AllowAllInbound: true},
 			wantDNSCfg:    &dns.Config{},
 		},
 		{
@@ -1279,7 +1279,7 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 			// Same if WantRunning is true, but the auth is not completed yet.
 			wantState:     ipn.NeedsLogin,
 			wantCfg:       &wgcfg.Config{},
-			wantRouterCfg: &router.Config{},
+			wantRouterCfg: &router.Config{AllowAllInbound: true},
 			wantDNSCfg:    &dns.Config{},
 		},
 		{
@@ -1298,6 +1298,7 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 			wantRouterCfg: &router.Config{
 				SNATSubnetRoutes: true,
 				NetfilterMode:    preftype.NetfilterOn,
+				AllowAllInbound:  true,
 				LocalAddrs:       node1.SelfNode.Addresses().AsSlice(),
 				Routes:           routesWithQuad100(),
 			},
@@ -1318,7 +1319,7 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 			// After disconnecting, all configs must be reset and have their zero values.
 			wantState:     ipn.Stopped,
 			wantCfg:       &wgcfg.Config{},
-			wantRouterCfg: &router.Config{},
+			wantRouterCfg: &router.Config{AllowAllInbound: true},
 			wantDNSCfg:    &dns.Config{},
 		},
 		{
@@ -1333,7 +1334,7 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 			// and have their zero values until the auth is completed.
 			wantState:     ipn.NeedsLogin,
 			wantCfg:       &wgcfg.Config{},
-			wantRouterCfg: &router.Config{},
+			wantRouterCfg: &router.Config{AllowAllInbound: true},
 			wantDNSCfg:    &dns.Config{},
 		},
 		{
@@ -1355,6 +1356,7 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 			wantRouterCfg: &router.Config{
 				SNATSubnetRoutes: true,
 				NetfilterMode:    preftype.NetfilterOn,
+				AllowAllInbound:  true,
 				LocalAddrs:       node2.SelfNode.Addresses().AsSlice(),
 				Routes:           routesWithQuad100(),
 			},
@@ -1379,7 +1381,7 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 			// and have their zero values until the (non-interactive) login is completed.
 			wantState:     ipn.NoState,
 			wantCfg:       &wgcfg.Config{},
-			wantRouterCfg: &router.Config{},
+			wantRouterCfg: &router.Config{AllowAllInbound: true},
 			wantDNSCfg:    &dns.Config{},
 		},
 		{
@@ -1404,6 +1406,7 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 			wantRouterCfg: &router.Config{
 				SNATSubnetRoutes: true,
 				NetfilterMode:    preftype.NetfilterOn,
+				AllowAllInbound:  true,
 				LocalAddrs:       node1.SelfNode.Addresses().AsSlice(),
 				Routes:           routesWithQuad100(),
 			},
@@ -1437,6 +1440,7 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 			wantRouterCfg: &router.Config{
 				SNATSubnetRoutes: true,
 				NetfilterMode:    preftype.NetfilterOn,
+				AllowAllInbound:  true,
 				LocalAddrs:       node3.SelfNode.Addresses().AsSlice(),
 				Routes:           routesWithQuad100(),
 			},
@@ -1460,7 +1464,7 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 			},
 			wantState:     ipn.NeedsLogin,
 			wantCfg:       &wgcfg.Config{},
-			wantRouterCfg: &router.Config{},
+			wantRouterCfg: &router.Config{AllowAllInbound: true},
 			wantDNSCfg:    &dns.Config{},
 		},
 		{
@@ -1477,7 +1481,7 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 			// Without seamless renewal, even starting a reauth tears down everything:
 			wantState:     ipn.Starting,
 			wantCfg:       &wgcfg.Config{},
-			wantRouterCfg: &router.Config{},
+			wantRouterCfg: &router.Config{AllowAllInbound: true},
 			wantDNSCfg:    &dns.Config{},
 		},
 		{
@@ -1502,6 +1506,7 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 			wantRouterCfg: &router.Config{
 				SNATSubnetRoutes: true,
 				NetfilterMode:    preftype.NetfilterOn,
+				AllowAllInbound:  true,
 				LocalAddrs:       node1.SelfNode.Addresses().AsSlice(),
 				Routes:           routesWithQuad100(),
 			},
@@ -1532,6 +1537,7 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 			wantRouterCfg: &router.Config{
 				SNATSubnetRoutes: true,
 				NetfilterMode:    preftype.NetfilterOn,
+				AllowAllInbound:  true,
 				LocalAddrs:       node1.SelfNode.Addresses().AsSlice(),
 				Routes:           routesWithQuad100(),
 			},
@@ -1564,6 +1570,7 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 			wantRouterCfg: &router.Config{
 				SNATSubnetRoutes: true,
 				NetfilterMode:    preftype.NetfilterOn,
+				AllowAllInbound:  true,
 				LocalAddrs:       node1.SelfNode.Addresses().AsSlice(),
 				Routes:           routesWithQuad100(),
 			},
@@ -1589,7 +1596,7 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 			// Even with seamless, if the key we are using expires, we want to disconnect:
 			wantState:     ipn.NeedsLogin,
 			wantCfg:       &wgcfg.Config{},
-			wantRouterCfg: &router.Config{},
+			wantRouterCfg: &router.Config{AllowAllInbound: true},
 			wantDNSCfg:    &dns.Config{},
 		},
 	}
@@ -1988,7 +1995,9 @@ func (e *mockEngine) RequestStatus() {
 }
 
 func (e *mockEngine) ResetAndStop() (*wgengine.Status, error) {
-	err := e.Reconfig(&wgcfg.Config{}, &router.Config{}, &dns.Config{})
+	err := e.Reconfig(&wgcfg.Config{}, &router.Config{
+		AllowAllInbound: true,
+	}, &dns.Config{})
 	if err != nil {
 		return nil, err
 	}

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -239,6 +239,12 @@ type Prefs struct {
 	// Linux-only.
 	NoStatefulFiltering opt.Bool `json:",omitempty"`
 
+	// AllowAllInbound specifies whether or not to add a firewall rule allowing
+	// all inbound traffic on the tun interface. The default is to add it.
+	//
+	// Linux-only.
+	AllowAllInbound bool
+
 	// NetfilterMode specifies how much to manage netfilter rules for
 	// Tailscale, if at all.
 	NetfilterMode preftype.NetfilterMode
@@ -376,6 +382,7 @@ type MaskedPrefs struct {
 	SyncSet                       bool                `json:",omitzero"`
 	NoSNATSet                     bool                `json:",omitempty"`
 	NoStatefulFilteringSet        bool                `json:",omitempty"`
+	AllowAllInboundSet            bool                `json:",omitempty"`
 	NetfilterModeSet              bool                `json:",omitempty"`
 	OperatorUserSet               bool                `json:",omitempty"`
 	ProfileNameSet                bool                `json:",omitempty"`
@@ -594,6 +601,7 @@ func (p *Prefs) pretty(goos string) string {
 			fmt.Fprintf(&sb, "statefulFiltering=%v ", !bb)
 		}
 	}
+	fmt.Fprintf(&sb, "allow-all-inbound=%v ", p.AllowAllInbound)
 	if len(p.AdvertiseTags) > 0 {
 		fmt.Fprintf(&sb, "tags=%s ", strings.Join(p.AdvertiseTags, ","))
 	}
@@ -676,6 +684,7 @@ func (p *Prefs) Equals(p2 *Prefs) bool {
 		p.NotepadURLs == p2.NotepadURLs &&
 		p.ShieldsUp == p2.ShieldsUp &&
 		p.NoSNAT == p2.NoSNAT &&
+		p.AllowAllInbound == p2.AllowAllInbound &&
 		p.NoStatefulFiltering == p2.NoStatefulFiltering &&
 		p.NetfilterMode == p2.NetfilterMode &&
 		p.OperatorUser == p2.OperatorUser &&
@@ -739,6 +748,7 @@ func NewPrefs() *Prefs {
 		CorpDNS:             true,
 		WantRunning:         false,
 		NetfilterMode:       preftype.NetfilterOn,
+		AllowAllInbound:     true,
 		NoStatefulFiltering: opt.NewBool(true),
 		AutoUpdate: AutoUpdatePrefs{
 			Check: true,

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -60,6 +60,7 @@ func TestPrefsEqual(t *testing.T) {
 		"Sync",
 		"NoSNAT",
 		"NoStatefulFiltering",
+		"AllowAllInbound",
 		"NetfilterMode",
 		"OperatorUser",
 		"ProfileName",
@@ -205,6 +206,17 @@ func TestPrefsEqual(t *testing.T) {
 		{
 			&Prefs{WantRunning: true},
 			&Prefs{WantRunning: true},
+			true,
+		},
+
+		{
+			&Prefs{AllowAllInbound: true},
+			&Prefs{AllowAllInbound: false},
+			false,
+		},
+		{
+			&Prefs{AllowAllInbound: true},
+			&Prefs{AllowAllInbound: true},
 			true,
 		},
 
@@ -512,29 +524,34 @@ func TestPrefsPretty(t *testing.T) {
 		{
 			Prefs{},
 			"linux",
-			"Prefs{ra=false dns=false want=false routes=[] nf=off update=off Persist=nil}",
+			"Prefs{ra=false dns=false want=false routes=[] allow-all-inbound=false nf=off update=off Persist=nil}",
+		},
+		{
+			Prefs{AllowAllInbound: true},
+			"linux",
+			"Prefs{ra=false dns=false want=false routes=[] allow-all-inbound=true nf=off update=off Persist=nil}",
 		},
 		{
 			Prefs{},
 			"windows",
-			"Prefs{ra=false dns=false want=false update=off Persist=nil}",
+			"Prefs{ra=false dns=false want=false allow-all-inbound=false update=off Persist=nil}",
 		},
 		{
 			Prefs{ShieldsUp: true},
 			"windows",
-			"Prefs{ra=false dns=false want=false shields=true update=off Persist=nil}",
+			"Prefs{ra=false dns=false want=false shields=true allow-all-inbound=false update=off Persist=nil}",
 		},
 		{
 			Prefs{},
 			"windows",
-			"Prefs{ra=false dns=false want=false update=off Persist=nil}",
+			"Prefs{ra=false dns=false want=false allow-all-inbound=false update=off Persist=nil}",
 		},
 		{
 			Prefs{
 				NotepadURLs: true,
 			},
 			"windows",
-			"Prefs{ra=false dns=false want=false notepad=true update=off Persist=nil}",
+			"Prefs{ra=false dns=false want=false notepad=true allow-all-inbound=false update=off Persist=nil}",
 		},
 		{
 			Prefs{
@@ -542,7 +559,7 @@ func TestPrefsPretty(t *testing.T) {
 				ForceDaemon: true, // server mode
 			},
 			"windows",
-			"Prefs{ra=false dns=false want=true server=true update=off Persist=nil}",
+			"Prefs{ra=false dns=false want=true server=true allow-all-inbound=false update=off Persist=nil}",
 		},
 		{
 			Prefs{
@@ -551,7 +568,7 @@ func TestPrefsPretty(t *testing.T) {
 				AdvertiseTags: []string{"tag:foo", "tag:bar"},
 			},
 			"darwin",
-			`Prefs{ra=false dns=false want=true tags=tag:foo,tag:bar url="http://localhost:1234" update=off Persist=nil}`,
+			`Prefs{ra=false dns=false want=true allow-all-inbound=false tags=tag:foo,tag:bar url="http://localhost:1234" update=off Persist=nil}`,
 		},
 		{
 			Prefs{
@@ -560,21 +577,21 @@ func TestPrefsPretty(t *testing.T) {
 				},
 			},
 			"linux",
-			`Prefs{ra=false dns=false want=false routes=[] nf=off update=off Persist{o=, n=[B1VKl] u="" ak=-}}`,
+			`Prefs{ra=false dns=false want=false routes=[] allow-all-inbound=false nf=off update=off Persist{o=, n=[B1VKl] u="" ak=-}}`,
 		},
 		{
 			Prefs{
 				ExitNodeIP: netip.MustParseAddr("1.2.3.4"),
 			},
 			"linux",
-			`Prefs{ra=false dns=false want=false exit=1.2.3.4 lan=false routes=[] nf=off update=off Persist=nil}`,
+			`Prefs{ra=false dns=false want=false exit=1.2.3.4 lan=false routes=[] allow-all-inbound=false nf=off update=off Persist=nil}`,
 		},
 		{
 			Prefs{
 				ExitNodeID: tailcfg.StableNodeID("myNodeABC"),
 			},
 			"linux",
-			`Prefs{ra=false dns=false want=false exit=myNodeABC lan=false routes=[] nf=off update=off Persist=nil}`,
+			`Prefs{ra=false dns=false want=false exit=myNodeABC lan=false routes=[] allow-all-inbound=false nf=off update=off Persist=nil}`,
 		},
 		{
 			Prefs{
@@ -582,21 +599,21 @@ func TestPrefsPretty(t *testing.T) {
 				ExitNodeAllowLANAccess: true,
 			},
 			"linux",
-			`Prefs{ra=false dns=false want=false exit=myNodeABC lan=true routes=[] nf=off update=off Persist=nil}`,
+			`Prefs{ra=false dns=false want=false exit=myNodeABC lan=true routes=[] allow-all-inbound=false nf=off update=off Persist=nil}`,
 		},
 		{
 			Prefs{
 				ExitNodeAllowLANAccess: true,
 			},
 			"linux",
-			`Prefs{ra=false dns=false want=false routes=[] nf=off update=off Persist=nil}`,
+			`Prefs{ra=false dns=false want=false routes=[] allow-all-inbound=false nf=off update=off Persist=nil}`,
 		},
 		{
 			Prefs{
 				Hostname: "foo",
 			},
 			"linux",
-			`Prefs{ra=false dns=false want=false routes=[] nf=off host="foo" update=off Persist=nil}`,
+			`Prefs{ra=false dns=false want=false routes=[] allow-all-inbound=false nf=off host="foo" update=off Persist=nil}`,
 		},
 		{
 			Prefs{
@@ -606,7 +623,7 @@ func TestPrefsPretty(t *testing.T) {
 				},
 			},
 			"linux",
-			`Prefs{ra=false dns=false want=false routes=[] nf=off update=check Persist=nil}`,
+			`Prefs{ra=false dns=false want=false routes=[] allow-all-inbound=false nf=off update=check Persist=nil}`,
 		},
 		{
 			Prefs{
@@ -616,7 +633,7 @@ func TestPrefsPretty(t *testing.T) {
 				},
 			},
 			"linux",
-			`Prefs{ra=false dns=false want=false routes=[] nf=off update=on Persist=nil}`,
+			`Prefs{ra=false dns=false want=false routes=[] allow-all-inbound=false nf=off update=on Persist=nil}`,
 		},
 		{
 			Prefs{
@@ -625,7 +642,7 @@ func TestPrefsPretty(t *testing.T) {
 				},
 			},
 			"linux",
-			`Prefs{ra=false dns=false want=false routes=[] nf=off update=off appconnector=advertise Persist=nil}`,
+			`Prefs{ra=false dns=false want=false routes=[] allow-all-inbound=false nf=off update=off appconnector=advertise Persist=nil}`,
 		},
 		{
 			Prefs{
@@ -634,26 +651,26 @@ func TestPrefsPretty(t *testing.T) {
 				},
 			},
 			"linux",
-			`Prefs{ra=false dns=false want=false routes=[] nf=off update=off Persist=nil}`,
+			`Prefs{ra=false dns=false want=false routes=[] allow-all-inbound=false nf=off update=off Persist=nil}`,
 		},
 		{
 			Prefs{
 				NetfilterKind: "iptables",
 			},
 			"linux",
-			`Prefs{ra=false dns=false want=false routes=[] nf=off netfilterKind=iptables update=off Persist=nil}`,
+			`Prefs{ra=false dns=false want=false routes=[] allow-all-inbound=false nf=off netfilterKind=iptables update=off Persist=nil}`,
 		},
 		{
 			Prefs{
 				NetfilterKind: "",
 			},
 			"linux",
-			`Prefs{ra=false dns=false want=false routes=[] nf=off update=off Persist=nil}`,
+			`Prefs{ra=false dns=false want=false routes=[] allow-all-inbound=false nf=off update=off Persist=nil}`,
 		},
 		{
 			Prefs{Sync: "false"},
 			"linux",
-			"Prefs{ra=false dns=false want=false sync=false routes=[] nf=off update=off Persist=nil}",
+			"Prefs{ra=false dns=false want=false sync=false routes=[] allow-all-inbound=false nf=off update=off Persist=nil}",
 		},
 	}
 	for i, tt := range tests {
@@ -901,6 +918,14 @@ func TestMaskedPrefsPretty(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("%d.\n got: %#q\nwant: %#q\n", i, got, tt.want)
 		}
+	}
+}
+
+func TestPrefsAllowAll(t *testing.T) {
+	var p *Prefs
+	p = NewPrefs()
+	if !p.AllowAllInbound {
+		t.Errorf("default should allow all inbound")
 	}
 }
 

--- a/types/prefs/prefs_example/prefs_example_clone.go
+++ b/types/prefs/prefs_example/prefs_example_clone.go
@@ -52,6 +52,7 @@ var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	Egg                    prefs.Item[bool]
 	AdvertiseRoutes        prefs.List[netip.Prefix]
 	NoSNAT                 prefs.Item[bool]
+	AllowAllInbound        prefs.Item[bool]
 	NoStatefulFiltering    prefs.Item[opt.Bool]
 	NetfilterMode          prefs.Item[preftype.NetfilterMode]
 	OperatorUser           prefs.Item[string]

--- a/types/prefs/prefs_example/prefs_example_view.go
+++ b/types/prefs/prefs_example/prefs_example_view.go
@@ -122,6 +122,7 @@ func (v PrefsView) Egg() prefs.Item[bool]                 { return v.ж.Egg }
 // Since the item type (netip.Prefix) is immutable, we can use [prefs.List].
 func (v PrefsView) AdvertiseRoutes() prefs.ListView[netip.Prefix]     { return v.ж.AdvertiseRoutes.View() }
 func (v PrefsView) NoSNAT() prefs.Item[bool]                          { return v.ж.NoSNAT }
+func (v PrefsView) AllowAllInbound() prefs.Item[bool]                 { return v.ж.AllowAllInbound }
 func (v PrefsView) NoStatefulFiltering() prefs.Item[opt.Bool]         { return v.ж.NoStatefulFiltering }
 func (v PrefsView) NetfilterMode() prefs.Item[preftype.NetfilterMode] { return v.ж.NetfilterMode }
 func (v PrefsView) OperatorUser() prefs.Item[string]                  { return v.ж.OperatorUser }
@@ -173,6 +174,7 @@ var _PrefsViewNeedsRegeneration = Prefs(struct {
 	Egg                    prefs.Item[bool]
 	AdvertiseRoutes        prefs.List[netip.Prefix]
 	NoSNAT                 prefs.Item[bool]
+	AllowAllInbound        prefs.Item[bool]
 	NoStatefulFiltering    prefs.Item[opt.Bool]
 	NetfilterMode          prefs.Item[preftype.NetfilterMode]
 	OperatorUser           prefs.Item[string]

--- a/types/prefs/prefs_example/prefs_types.go
+++ b/types/prefs/prefs_example/prefs_types.go
@@ -86,6 +86,7 @@ type Prefs struct {
 	// Since the item type (netip.Prefix) is immutable, we can use [prefs.List].
 	AdvertiseRoutes     prefs.List[netip.Prefix]           `json:",omitzero"`
 	NoSNAT              prefs.Item[bool]                   `json:",omitzero"`
+	AllowAllInbound     prefs.Item[bool]                   `json:",omitzero"`
 	NoStatefulFiltering prefs.Item[opt.Bool]               `json:",omitzero"`
 	NetfilterMode       prefs.Item[preftype.NetfilterMode] `json:",omitzero"`
 	OperatorUser        prefs.Item[string]                 `json:",omitzero"`

--- a/util/linuxfw/fake_netfilter.go
+++ b/util/linuxfw/fake_netfilter.go
@@ -63,21 +63,23 @@ func (f *FakeNetfilterRunner) HasIPV6NAT() bool {
 	return true
 }
 
-func (f *FakeNetfilterRunner) AddBase(tunname string) error              { return nil }
-func (f *FakeNetfilterRunner) DelBase() error                            { return nil }
-func (f *FakeNetfilterRunner) AddChains() error                          { return nil }
-func (f *FakeNetfilterRunner) DelChains() error                          { return nil }
-func (f *FakeNetfilterRunner) AddHooks() error                           { return nil }
-func (f *FakeNetfilterRunner) DelHooks(logf logger.Logf) error           { return nil }
-func (f *FakeNetfilterRunner) AddSNATRule() error                        { return nil }
-func (f *FakeNetfilterRunner) DelSNATRule() error                        { return nil }
-func (f *FakeNetfilterRunner) AddConnmarkSaveRule() error                { return nil }
-func (f *FakeNetfilterRunner) DelConnmarkSaveRule() error                { return nil }
-func (f *FakeNetfilterRunner) AddStatefulRule(tunname string) error      { return nil }
-func (f *FakeNetfilterRunner) DelStatefulRule(tunname string) error      { return nil }
-func (f *FakeNetfilterRunner) AddLoopbackRule(addr netip.Addr) error     { return nil }
-func (f *FakeNetfilterRunner) DelLoopbackRule(addr netip.Addr) error     { return nil }
-func (f *FakeNetfilterRunner) AddDNATRule(origDst, dst netip.Addr) error { return nil }
+func (f *FakeNetfilterRunner) AddBase(tunname string) error                { return nil }
+func (f *FakeNetfilterRunner) DelBase() error                              { return nil }
+func (f *FakeNetfilterRunner) AddAllowAllInboundRule(tunname string) error { return nil }
+func (f *FakeNetfilterRunner) DelAllowAllInboundRule(tunname string) error { return nil }
+func (f *FakeNetfilterRunner) AddChains() error                            { return nil }
+func (f *FakeNetfilterRunner) DelChains() error                            { return nil }
+func (f *FakeNetfilterRunner) AddHooks() error                             { return nil }
+func (f *FakeNetfilterRunner) DelHooks(logf logger.Logf) error             { return nil }
+func (f *FakeNetfilterRunner) AddSNATRule() error                          { return nil }
+func (f *FakeNetfilterRunner) DelSNATRule() error                          { return nil }
+func (f *FakeNetfilterRunner) AddConnmarkSaveRule() error                  { return nil }
+func (f *FakeNetfilterRunner) DelConnmarkSaveRule() error                  { return nil }
+func (f *FakeNetfilterRunner) AddStatefulRule(tunname string) error        { return nil }
+func (f *FakeNetfilterRunner) DelStatefulRule(tunname string) error        { return nil }
+func (f *FakeNetfilterRunner) AddLoopbackRule(addr netip.Addr) error       { return nil }
+func (f *FakeNetfilterRunner) DelLoopbackRule(addr netip.Addr) error       { return nil }
+func (f *FakeNetfilterRunner) AddDNATRule(origDst, dst netip.Addr) error   { return nil }
 func (f *FakeNetfilterRunner) DNATWithLoadBalancer(origDst netip.Addr, dsts []netip.Addr) error {
 	return nil
 }

--- a/util/linuxfw/iptables_runner.go
+++ b/util/linuxfw/iptables_runner.go
@@ -229,12 +229,6 @@ func (i *iptablesRunner) addBase4(tunname string) error {
 		return fmt.Errorf("adding %v in v4/filter/ts-input: %w", args, err)
 	}
 
-	// Explicitly allow all other inbound traffic to the tun interface
-	args = []string{"-i", tunname, "-j", "ACCEPT"}
-	if err := i.ipt4.Append("filter", "ts-input", args...); err != nil {
-		return fmt.Errorf("adding %v in v4/filter/ts-input: %w", args, err)
-	}
-
 	// Forward all traffic from the Tailscale interface, and drop
 	// traffic to the tailscale interface by default. We use packet
 	// marks here so both filter/FORWARD and nat/POSTROUTING can match
@@ -346,13 +340,7 @@ func (i *iptablesRunner) addBase6(tunname string) error {
 	// TODO: only allow traffic from Tailscale's ULA range to come
 	// from tailscale0.
 
-	// Explicitly allow all other inbound traffic to the tun interface
-	args := []string{"-i", tunname, "-j", "ACCEPT"}
-	if err := i.ipt6.Append("filter", "ts-input", args...); err != nil {
-		return fmt.Errorf("adding %v in v6/filter/ts-input: %w", args, err)
-	}
-
-	args = []string{"-i", tunname, "-j", "MARK", "--set-mark", subnetRouteMark + "/" + fwmarkMask}
+	args := []string{"-i", tunname, "-j", "MARK", "--set-mark", subnetRouteMark + "/" + fwmarkMask}
 	if err := i.ipt6.Append("filter", "ts-forward", args...); err != nil {
 		return fmt.Errorf("adding %v in v6/filter/ts-forward: %w", args, err)
 	}
@@ -436,6 +424,42 @@ func (i *iptablesRunner) DelHooks(logf logger.Logf) error {
 	for _, ipt := range i.getNATTables() {
 		if err := delTSHook(ipt, "nat", "POSTROUTING", logf); err != nil {
 			return err
+		}
+	}
+
+	return nil
+}
+
+// AddAllowAllInboundRule adds a netfilter rule to allow all inbound traffic
+// destined for the tun interface
+func (i *iptablesRunner) AddAllowAllInboundRule(tunname string) error {
+	args := []string{"-i", tunname, "-j", "ACCEPT"}
+	if err := i.ipt4.Append("filter", "ts-input", args...); err != nil {
+		return fmt.Errorf("adding %v in v4/filter/ts-input: %w", args, err)
+	}
+
+	if i.HasIPV6Filter() {
+		args = []string{"-i", tunname, "-j", "ACCEPT"}
+		if err := i.ipt6.Append("filter", "ts-input", args...); err != nil {
+			return fmt.Errorf("adding %v in v6/filter/ts-input: %w", args, err)
+		}
+	}
+
+	return nil
+}
+
+// DelAllowAllInboundRule removes the netfilter rule to allow all inbound traffic
+// destined for the tun interface
+func (i *iptablesRunner) DelAllowAllInboundRule(tunname string) error {
+	args := []string{"-i", tunname, "-j", "ACCEPT"}
+	if err := i.ipt4.Delete("filter", "ts-input", args...); err != nil {
+		return fmt.Errorf("deleting %v from v4/filter/ts-input: %w", args, err)
+	}
+
+	if i.HasIPV6Filter() {
+		args = []string{"-i", tunname, "-j", "ACCEPT"}
+		if err := i.ipt6.Delete("filter", "ts-input", args...); err != nil {
+			return fmt.Errorf("deleting %v from v6/filter/ts-input: %w", args, err)
 		}
 	}
 

--- a/util/linuxfw/iptables_runner_test.go
+++ b/util/linuxfw/iptables_runner_test.go
@@ -132,7 +132,6 @@ func TestAddAndDeleteBase(t *testing.T) {
 	}
 
 	tsRulesCommon := []fakeRule{ // table/chain/rule
-		{"filter", "ts-input", []string{"-i", tunname, "-j", "ACCEPT"}},
 		{"filter", "ts-forward", []string{"-i", tunname, "-j", "MARK", "--set-mark", tsconst.LinuxSubnetRouteMark + "/" + tsconst.LinuxFwmarkMask}},
 		{"filter", "ts-forward", []string{"-m", "mark", "--mark", tsconst.LinuxSubnetRouteMark + "/" + tsconst.LinuxFwmarkMask, "-j", "ACCEPT"}},
 		{"filter", "ts-forward", []string{"-o", tunname, "-j", "ACCEPT"}},
@@ -240,6 +239,94 @@ func TestAddAndDelLoopbackRule(t *testing.T) {
 		t.Fatal(err)
 	} else if exist {
 		t.Errorf("rule %s/%s/%s still exists", tsRulesV6.table, tsRulesV6.chain, strings.Join(tsRulesV6.args, " "))
+	}
+
+	if err := iptr.DelChains(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAddAndDelAllowAllInboundRule(t *testing.T) {
+	iptr := newFakeIPTablesRunner()
+	tunname := "tun0"
+
+	if err := iptr.AddChains(); err != nil {
+		t.Fatal(err)
+	}
+
+	rule := fakeRule{"filter", "ts-input", []string{"-i", tunname, "-j", "ACCEPT"}}
+
+	// Add AllowAllInbound rule
+	if err := iptr.AddAllowAllInboundRule(tunname); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that the rule was created for ipt4 and ipt6
+	for _, proto := range []iptablesInterface{iptr.ipt4, iptr.ipt6} {
+		if exist, err := proto.Exists(rule.table, rule.chain, rule.args...); err != nil {
+			t.Fatal(err)
+		} else if !exist {
+			t.Errorf("rule %s/%s/%s doesn't exist", rule.table, rule.chain, strings.Join(rule.args, " "))
+		}
+	}
+
+	// Delete AllowAllInbound rule
+	if err := iptr.DelAllowAllInboundRule(tunname); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that the rule was deleted for ipt4 and ipt6
+	for _, proto := range []iptablesInterface{iptr.ipt4, iptr.ipt6} {
+		if exist, err := proto.Exists(rule.table, rule.chain, rule.args...); err != nil {
+			t.Fatal(err)
+		} else if exist {
+			t.Errorf("rule %s/%s/%s still exists", rule.table, rule.chain, strings.Join(rule.args, " "))
+		}
+	}
+
+	if err := iptr.DelChains(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAddAllowAllInboundRuleAndDelBase(t *testing.T) {
+	iptr := newFakeIPTablesRunner()
+	tunname := "tun0"
+
+	if err := iptr.AddChains(); err != nil {
+		t.Fatal(err)
+	}
+
+	rule := fakeRule{ // table/chain/rule
+		"filter", "ts-input", []string{"-i", tunname, "-j", "ACCEPT"},
+	}
+
+	// Add AllowAllInbound rule
+	if err := iptr.AddAllowAllInboundRule(tunname); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that the rule was created for ipt4 and ipt6
+	for _, proto := range []iptablesInterface{iptr.ipt4, iptr.ipt6} {
+		if exist, err := proto.Exists(rule.table, rule.chain, rule.args...); err != nil {
+			t.Fatal(err)
+		} else if !exist {
+			t.Errorf("rule %s/%s/%s doesn't exist", rule.table, rule.chain, strings.Join(rule.args, " "))
+		}
+	}
+
+	// Delete base rules
+	if err := iptr.DelBase(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that the rule was deleted for ipt4 and ipt6
+	for _, proto := range []iptablesInterface{iptr.ipt4, iptr.ipt6} {
+		if exist, err := proto.Exists(rule.table, rule.chain, rule.args...); err != nil {
+			t.Fatal(err)
+		} else if exist {
+			t.Errorf("rule %s/%s/%s still exists", rule.table, rule.chain, strings.Join(rule.args, " "))
+		}
 	}
 
 	if err := iptr.DelChains(); err != nil {

--- a/util/linuxfw/nftables_runner.go
+++ b/util/linuxfw/nftables_runner.go
@@ -512,6 +512,13 @@ type NetfilterRunner interface {
 	// DelSNATRule removes the rule added by AddSNATRule.
 	DelSNATRule() error
 
+	// AddAllowAllInboundRule adds the netfilter rule to allow all inbound
+	// traffic destined for the Tailscale interface.
+	AddAllowAllInboundRule(tunname string) error
+
+	// DelAllowAllInboundRule removes the rule added by AddAllowAllInboundRule
+	DelAllowAllInboundRule(tunname string) error
+
 	// AddStatefulRule adds a netfilter rule for stateful packet filtering
 	// using conntrack.
 	AddStatefulRule(tunname string) error
@@ -1529,6 +1536,25 @@ func addAcceptIncomingPacketRule(conn *nftables.Conn, table *nftables.Table, cha
 	return nil
 }
 
+func delAcceptIncomingPacketRule(conn *nftables.Conn, table *nftables.Table, chain *nftables.Chain, tunname string) error {
+	rule := createAcceptIncomingPacketRule(table, chain, tunname)
+
+	AllowInboundRule, err := findRule(conn, rule)
+	if err != nil {
+		return fmt.Errorf("find AllowInbound rule: %w", err)
+	}
+
+	if AllowInboundRule != nil {
+		_ = conn.DelRule(AllowInboundRule)
+	}
+
+	if err := conn.Flush(); err != nil {
+		return fmt.Errorf("flush del AllowInbound rule: %w", err)
+	}
+
+	return nil
+}
+
 // AddBase adds some basic processing rules.
 func (n *nftablesRunner) AddBase(tunname string) error {
 	if err := n.addBase4(tunname); err != nil {
@@ -1537,6 +1563,54 @@ func (n *nftablesRunner) AddBase(tunname string) error {
 	if n.HasIPV6() {
 		if err := n.addBase6(tunname); err != nil {
 			return fmt.Errorf("add base v6: %w", err)
+		}
+	}
+	return nil
+}
+
+// AddAllowAllInboundRule adds a netfilter rule to allow all inbound traffic
+// destined for the tun interface
+func (n *nftablesRunner) AddAllowAllInboundRule(tunname string) error {
+	conn := n.conn
+
+	inputChainV4, err := getChainFromTable(conn, n.nft4.Filter, chainNameInput)
+	if err != nil {
+		return fmt.Errorf("get input chain v4: %v", err)
+	}
+	if err = addAcceptIncomingPacketRule(conn, n.nft4.Filter, inputChainV4, tunname); err != nil {
+		return fmt.Errorf("add accept incoming packet rule v4: %w", err)
+	}
+	if n.HasIPV6() {
+		inputChainV6, err := getChainFromTable(conn, n.nft6.Filter, chainNameInput)
+		if err != nil {
+			return fmt.Errorf("get input chain v4: %v", err)
+		}
+		if err = addAcceptIncomingPacketRule(conn, n.nft6.Filter, inputChainV6, tunname); err != nil {
+			return fmt.Errorf("add accept incoming packet rule v6: %w", err)
+		}
+	}
+	return nil
+}
+
+// DelAllowAllInboundRule removes the netfilter rule to allow all inbound traffic
+// destined for the tun interface
+func (n *nftablesRunner) DelAllowAllInboundRule(tunname string) error {
+	conn := n.conn
+
+	inputChainV4, err := getChainFromTable(conn, n.nft4.Filter, chainNameInput)
+	if err != nil {
+		return fmt.Errorf("get input chain v4: %v", err)
+	}
+	if err = delAcceptIncomingPacketRule(conn, n.nft4.Filter, inputChainV4, tunname); err != nil {
+		return fmt.Errorf("del accept incoming packet rule v4: %w", err)
+	}
+	if n.HasIPV6() {
+		inputChainV6, err := getChainFromTable(conn, n.nft6.Filter, chainNameInput)
+		if err != nil {
+			return fmt.Errorf("get input chain v4: %v", err)
+		}
+		if err = delAcceptIncomingPacketRule(conn, n.nft6.Filter, inputChainV6, tunname); err != nil {
+			return fmt.Errorf("del accept incoming packet rule v6: %w", err)
 		}
 	}
 	return nil
@@ -1555,9 +1629,6 @@ func (n *nftablesRunner) addBase4(tunname string) error {
 	}
 	if err = addDropCGNATRangeRule(conn, n.nft4.Filter, inputChain, tunname); err != nil {
 		return fmt.Errorf("add drop cgnat range rule v4: %w", err)
-	}
-	if err = addAcceptIncomingPacketRule(conn, n.nft4.Filter, inputChain, tunname); err != nil {
-		return fmt.Errorf("add accept incoming packet rule v4: %w", err)
 	}
 
 	forwardChain, err := getChainFromTable(conn, n.nft4.Filter, chainNameForward)
@@ -1591,14 +1662,6 @@ func (n *nftablesRunner) addBase4(tunname string) error {
 // addBase6 adds some basic IPv6 processing rules.
 func (n *nftablesRunner) addBase6(tunname string) error {
 	conn := n.conn
-
-	inputChain, err := getChainFromTable(conn, n.nft6.Filter, chainNameInput)
-	if err != nil {
-		return fmt.Errorf("get input chain v4: %v", err)
-	}
-	if err = addAcceptIncomingPacketRule(conn, n.nft6.Filter, inputChain, tunname); err != nil {
-		return fmt.Errorf("add accept incoming packet rule v6: %w", err)
-	}
 
 	forwardChain, err := getChainFromTable(conn, n.nft6.Filter, chainNameForward)
 	if err != nil {

--- a/wgengine/router/osrouter/router_linux.go
+++ b/wgengine/router/osrouter/router_linux.go
@@ -87,6 +87,7 @@ type linuxRouter struct {
 	snatSubnetRoutes  bool
 	statefulFiltering bool
 	connmarkEnabled   bool // whether connmark rules are currently enabled
+	allowAllInbound   bool
 	netfilterMode     preftype.NetfilterMode
 	netfilterKind     string
 	magicsockPortV4   uint16
@@ -108,11 +109,12 @@ func newUserspaceRouter(logf logger.Logf, tunDev tun.Device, netMon *netmon.Moni
 
 func newUserspaceRouterAdvanced(logf logger.Logf, tunname string, netMon *netmon.Monitor, cmd commandRunner, health *health.Tracker, bus *eventbus.Bus) (router.Router, error) {
 	r := &linuxRouter{
-		logf:          logf,
-		tunname:       tunname,
-		netfilterMode: netfilterOff,
-		netMon:        netMon,
-		health:        health,
+		logf:            logf,
+		tunname:         tunname,
+		allowAllInbound: true,
+		netfilterMode:   netfilterOff,
+		netMon:          netMon,
+		health:          health,
 
 		cmd: cmd,
 
@@ -455,6 +457,20 @@ func (r *linuxRouter) Set(cfg *router.Config) error {
 	}
 	r.addrs = newAddrs
 
+	switch {
+	case cfg.AllowAllInbound == r.allowAllInbound:
+		// state is correct, nothing do do
+	case cfg.AllowAllInbound:
+		if err := r.addAllowAllInboundRule(); err != nil {
+			errs = append(errs, err)
+		}
+	default:
+		if err := r.delAllowAllInboundRule(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	r.allowAllInbound = cfg.AllowAllInbound
+
 	// Ensure that the SNAT rule is added or removed as needed.
 	switch {
 	case cfg.SNATSubnetRoutes == r.snatSubnetRoutes:
@@ -692,6 +708,11 @@ func (r *linuxRouter) setNetfilterModeLocked(mode preftype.NetfilterMode) error 
 			if err := r.nfr.AddBase(r.tunname); err != nil {
 				return err
 			}
+			if r.allowAllInbound {
+				if err := r.nfr.AddAllowAllInboundRule(r.tunname); err != nil {
+					return err
+				}
+			}
 			if r.magicsockPortV4 != 0 {
 				if err := r.nfr.AddMagicsockPortRule(r.magicsockPortV4, "udp4"); err != nil {
 					return fmt.Errorf("could not add magicsock port rule v4: %w", err)
@@ -732,6 +753,12 @@ func (r *linuxRouter) setNetfilterModeLocked(mode preftype.NetfilterMode) error 
 			if err := r.nfr.AddBase(r.tunname); err != nil {
 				return err
 			}
+			// AddAllowAllInboundRule adds the allow-all-inbound rule if enabled
+			if r.allowAllInbound {
+				if err := r.nfr.AddAllowAllInboundRule(r.tunname); err != nil {
+					return err
+				}
+			}
 			if r.magicsockPortV4 != 0 {
 				if err := r.nfr.AddMagicsockPortRule(r.magicsockPortV4, "udp4"); err != nil {
 					return fmt.Errorf("could not add magicsock port rule v4: %w", err)
@@ -753,6 +780,11 @@ func (r *linuxRouter) setNetfilterModeLocked(mode preftype.NetfilterMode) error 
 			}
 			if err := r.nfr.AddBase(r.tunname); err != nil {
 				return err
+			}
+			if r.allowAllInbound {
+				if err := r.nfr.AddAllowAllInboundRule(r.tunname); err != nil {
+					return err
+				}
 			}
 			r.snatSubnetRoutes = false
 		}
@@ -1487,6 +1519,32 @@ func (r *linuxRouter) delIPRulesWithIPCommand() error {
 	}
 
 	return rg.ErrAcc
+}
+
+// addAllowAllInboundRule adds a netfilter rule to allow all incoming traffic
+// for the tun interface
+func (r *linuxRouter) addAllowAllInboundRule() error {
+	if r.netfilterMode == netfilterOff {
+		return nil
+	}
+
+	if err := r.nfr.AddAllowAllInboundRule(r.tunname); err != nil {
+		return err
+	}
+	return nil
+}
+
+// delAllowAllInboundRule removes a netfilter rule to allow all incoming traffic
+// for the tun interface
+func (r *linuxRouter) delAllowAllInboundRule() error {
+	if r.netfilterMode == netfilterOff {
+		return nil
+	}
+
+	if err := r.nfr.DelAllowAllInboundRule(r.tunname); err != nil {
+		return err
+	}
+	return nil
 }
 
 // addSNATRule adds a netfilter rule to SNAT traffic destined for

--- a/wgengine/router/osrouter/router_linux_test.go
+++ b/wgengine/router/osrouter/router_linux_test.go
@@ -100,7 +100,7 @@ ip route add 192.168.16.0/24 dev tailscale0 table 52` + basic,
 		},
 
 		{
-			name: "addr-routes-subnet-routes-with-netfilter",
+			name: "addr-routes-subnet-routes-with-netfilter-allow-all",
 			in: &Config{
 				LocalAddrs:        mustCIDRs("100.101.102.104/10"),
 				Routes:            mustCIDRs("100.100.100.100/32", "10.0.0.0/8"),
@@ -108,6 +108,52 @@ ip route add 192.168.16.0/24 dev tailscale0 table 52` + basic,
 				SNATSubnetRoutes:  true,
 				StatefulFiltering: true,
 				NetfilterMode:     netfilterOn,
+				AllowAllInbound:   true,
+			},
+			want: `
+up
+ip addr add 100.101.102.104/10 dev tailscale0
+ip route add 10.0.0.0/8 dev tailscale0 table 52
+ip route add 100.100.100.100/32 dev tailscale0 table 52` + basic +
+				`v4/filter/FORWARD -j ts-forward
+v4/filter/INPUT -j ts-input
+v4/filter/ts-forward -i tailscale0 -j MARK --set-mark 0x40000/0xff0000
+v4/filter/ts-forward -m mark --mark 0x40000/0xff0000 -j ACCEPT
+v4/filter/ts-forward -o tailscale0 -s 100.64.0.0/10 -j DROP
+v4/filter/ts-forward -o tailscale0 -m conntrack ! --ctstate ESTABLISHED,RELATED -j DROP
+v4/filter/ts-forward -o tailscale0 -j ACCEPT
+v4/filter/ts-input -i lo -s 100.101.102.104 -j ACCEPT
+v4/filter/ts-input ! -i tailscale0 -s 100.115.92.0/23 -j RETURN
+v4/filter/ts-input ! -i tailscale0 -s 100.64.0.0/10 -j DROP
+v4/filter/ts-input -i tailscale0 -j ACCEPT
+v4/mangle/OUTPUT -m conntrack --ctstate NEW -m mark ! --mark 0x0/0xff0000 -j CONNMARK --save-mark --nfmask 0xff0000 --ctmask 0xff0000
+v4/mangle/PREROUTING -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark --nfmask 0xff0000 --ctmask 0xff0000
+v4/nat/POSTROUTING -j ts-postrouting
+v4/nat/ts-postrouting -m mark --mark 0x40000/0xff0000 -j MASQUERADE
+v6/filter/FORWARD -j ts-forward
+v6/filter/INPUT -j ts-input
+v6/filter/ts-forward -i tailscale0 -j MARK --set-mark 0x40000/0xff0000
+v6/filter/ts-forward -m mark --mark 0x40000/0xff0000 -j ACCEPT
+v6/filter/ts-forward -o tailscale0 -m conntrack ! --ctstate ESTABLISHED,RELATED -j DROP
+v6/filter/ts-forward -o tailscale0 -j ACCEPT
+v6/filter/ts-input -i tailscale0 -j ACCEPT
+v6/mangle/OUTPUT -m conntrack --ctstate NEW -m mark ! --mark 0x0/0xff0000 -j CONNMARK --save-mark --nfmask 0xff0000 --ctmask 0xff0000
+v6/mangle/PREROUTING -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark --nfmask 0xff0000 --ctmask 0xff0000
+v6/nat/POSTROUTING -j ts-postrouting
+v6/nat/ts-postrouting -m mark --mark 0x40000/0xff0000 -j MASQUERADE
+`,
+		},
+
+		{
+			name: "addr-routes-subnet-routes-with-netfilter-allow-all-false",
+			in: &Config{
+				LocalAddrs:        mustCIDRs("100.101.102.104/10"),
+				Routes:            mustCIDRs("100.100.100.100/32", "10.0.0.0/8"),
+				SubnetRoutes:      mustCIDRs("200.0.0.0/8"),
+				SNATSubnetRoutes:  true,
+				StatefulFiltering: true,
+				NetfilterMode:     netfilterOn,
+				AllowAllInbound:   false,
 			},
 			want: `
 up
@@ -141,6 +187,50 @@ v6/nat/ts-postrouting -m mark --mark 0x40000/0xff0000 -j MASQUERADE
 `,
 		},
 		{
+			name: "addr-routes-subnet-routes-with-netfilter",
+			in: &Config{
+				LocalAddrs:        mustCIDRs("100.101.102.104/10"),
+				Routes:            mustCIDRs("100.100.100.100/32", "10.0.0.0/8"),
+				SubnetRoutes:      mustCIDRs("200.0.0.0/8"),
+				SNATSubnetRoutes:  true,
+				StatefulFiltering: true,
+				NetfilterMode:     netfilterOn,
+				AllowAllInbound:   true,
+			},
+			want: `
+up
+ip addr add 100.101.102.104/10 dev tailscale0
+ip route add 10.0.0.0/8 dev tailscale0 table 52
+ip route add 100.100.100.100/32 dev tailscale0 table 52` + basic +
+				`v4/filter/FORWARD -j ts-forward
+v4/filter/INPUT -j ts-input
+v4/filter/ts-forward -i tailscale0 -j MARK --set-mark 0x40000/0xff0000
+v4/filter/ts-forward -m mark --mark 0x40000/0xff0000 -j ACCEPT
+v4/filter/ts-forward -o tailscale0 -s 100.64.0.0/10 -j DROP
+v4/filter/ts-forward -o tailscale0 -m conntrack ! --ctstate ESTABLISHED,RELATED -j DROP
+v4/filter/ts-forward -o tailscale0 -j ACCEPT
+v4/filter/ts-input -i lo -s 100.101.102.104 -j ACCEPT
+v4/filter/ts-input ! -i tailscale0 -s 100.115.92.0/23 -j RETURN
+v4/filter/ts-input ! -i tailscale0 -s 100.64.0.0/10 -j DROP
+v4/filter/ts-input -i tailscale0 -j ACCEPT
+v4/mangle/OUTPUT -m conntrack --ctstate NEW -m mark ! --mark 0x0/0xff0000 -j CONNMARK --save-mark --nfmask 0xff0000 --ctmask 0xff0000
+v4/mangle/PREROUTING -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark --nfmask 0xff0000 --ctmask 0xff0000
+v4/nat/POSTROUTING -j ts-postrouting
+v4/nat/ts-postrouting -m mark --mark 0x40000/0xff0000 -j MASQUERADE
+v6/filter/FORWARD -j ts-forward
+v6/filter/INPUT -j ts-input
+v6/filter/ts-forward -i tailscale0 -j MARK --set-mark 0x40000/0xff0000
+v6/filter/ts-forward -m mark --mark 0x40000/0xff0000 -j ACCEPT
+v6/filter/ts-forward -o tailscale0 -m conntrack ! --ctstate ESTABLISHED,RELATED -j DROP
+v6/filter/ts-forward -o tailscale0 -j ACCEPT
+v6/filter/ts-input -i tailscale0 -j ACCEPT
+v6/mangle/OUTPUT -m conntrack --ctstate NEW -m mark ! --mark 0x0/0xff0000 -j CONNMARK --save-mark --nfmask 0xff0000 --ctmask 0xff0000
+v6/mangle/PREROUTING -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark --nfmask 0xff0000 --ctmask 0xff0000
+v6/nat/POSTROUTING -j ts-postrouting
+v6/nat/ts-postrouting -m mark --mark 0x40000/0xff0000 -j MASQUERADE
+`,
+		},
+		{
 			name: "addr-routes-subnet-routes-netfilter-no-stateful",
 			in: &Config{
 				LocalAddrs:        mustCIDRs("100.101.102.104/10"),
@@ -149,6 +239,7 @@ v6/nat/ts-postrouting -m mark --mark 0x40000/0xff0000 -j MASQUERADE
 				SNATSubnetRoutes:  true,
 				StatefulFiltering: false,
 				NetfilterMode:     netfilterOn,
+				AllowAllInbound:   true,
 			},
 			want: `
 up
@@ -164,6 +255,7 @@ v4/filter/ts-forward -o tailscale0 -j ACCEPT
 v4/filter/ts-input -i lo -s 100.101.102.104 -j ACCEPT
 v4/filter/ts-input ! -i tailscale0 -s 100.115.92.0/23 -j RETURN
 v4/filter/ts-input ! -i tailscale0 -s 100.64.0.0/10 -j DROP
+v4/filter/ts-input -i tailscale0 -j ACCEPT
 v4/mangle/OUTPUT -m conntrack --ctstate NEW -m mark ! --mark 0x0/0xff0000 -j CONNMARK --save-mark --nfmask 0xff0000 --ctmask 0xff0000
 v4/mangle/PREROUTING -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark --nfmask 0xff0000 --ctmask 0xff0000
 v4/nat/POSTROUTING -j ts-postrouting
@@ -173,6 +265,7 @@ v6/filter/INPUT -j ts-input
 v6/filter/ts-forward -i tailscale0 -j MARK --set-mark 0x40000/0xff0000
 v6/filter/ts-forward -m mark --mark 0x40000/0xff0000 -j ACCEPT
 v6/filter/ts-forward -o tailscale0 -j ACCEPT
+v6/filter/ts-input -i tailscale0 -j ACCEPT
 v6/mangle/OUTPUT -m conntrack --ctstate NEW -m mark ! --mark 0x0/0xff0000 -j CONNMARK --save-mark --nfmask 0xff0000 --ctmask 0xff0000
 v6/mangle/PREROUTING -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark --nfmask 0xff0000 --ctmask 0xff0000
 v6/nat/POSTROUTING -j ts-postrouting
@@ -182,9 +275,10 @@ v6/nat/ts-postrouting -m mark --mark 0x40000/0xff0000 -j MASQUERADE
 		{
 			name: "addr-and-routes-with-netfilter",
 			in: &Config{
-				LocalAddrs:    mustCIDRs("100.101.102.104/10"),
-				Routes:        mustCIDRs("100.100.100.100/32", "10.0.0.0/8"),
-				NetfilterMode: netfilterOn,
+				LocalAddrs:      mustCIDRs("100.101.102.104/10"),
+				Routes:          mustCIDRs("100.100.100.100/32", "10.0.0.0/8"),
+				NetfilterMode:   netfilterOn,
+				AllowAllInbound: true,
 			},
 			want: `
 up
@@ -200,6 +294,7 @@ v4/filter/ts-forward -o tailscale0 -j ACCEPT
 v4/filter/ts-input -i lo -s 100.101.102.104 -j ACCEPT
 v4/filter/ts-input ! -i tailscale0 -s 100.115.92.0/23 -j RETURN
 v4/filter/ts-input ! -i tailscale0 -s 100.64.0.0/10 -j DROP
+v4/filter/ts-input -i tailscale0 -j ACCEPT
 v4/mangle/OUTPUT -m conntrack --ctstate NEW -m mark ! --mark 0x0/0xff0000 -j CONNMARK --save-mark --nfmask 0xff0000 --ctmask 0xff0000
 v4/mangle/PREROUTING -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark --nfmask 0xff0000 --ctmask 0xff0000
 v4/nat/POSTROUTING -j ts-postrouting
@@ -208,6 +303,7 @@ v6/filter/INPUT -j ts-input
 v6/filter/ts-forward -i tailscale0 -j MARK --set-mark 0x40000/0xff0000
 v6/filter/ts-forward -m mark --mark 0x40000/0xff0000 -j ACCEPT
 v6/filter/ts-forward -o tailscale0 -j ACCEPT
+v6/filter/ts-input -i tailscale0 -j ACCEPT
 v6/mangle/OUTPUT -m conntrack --ctstate NEW -m mark ! --mark 0x0/0xff0000 -j CONNMARK --save-mark --nfmask 0xff0000 --ctmask 0xff0000
 v6/mangle/PREROUTING -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark --nfmask 0xff0000 --ctmask 0xff0000
 v6/nat/POSTROUTING -j ts-postrouting
@@ -222,6 +318,7 @@ v6/nat/POSTROUTING -j ts-postrouting
 				SubnetRoutes:     mustCIDRs("200.0.0.0/8"),
 				SNATSubnetRoutes: false,
 				NetfilterMode:    netfilterOn,
+				AllowAllInbound:  true,
 			},
 			want: `
 up
@@ -237,6 +334,7 @@ v4/filter/ts-forward -o tailscale0 -j ACCEPT
 v4/filter/ts-input -i lo -s 100.101.102.104 -j ACCEPT
 v4/filter/ts-input ! -i tailscale0 -s 100.115.92.0/23 -j RETURN
 v4/filter/ts-input ! -i tailscale0 -s 100.64.0.0/10 -j DROP
+v4/filter/ts-input -i tailscale0 -j ACCEPT
 v4/mangle/OUTPUT -m conntrack --ctstate NEW -m mark ! --mark 0x0/0xff0000 -j CONNMARK --save-mark --nfmask 0xff0000 --ctmask 0xff0000
 v4/mangle/PREROUTING -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark --nfmask 0xff0000 --ctmask 0xff0000
 v4/nat/POSTROUTING -j ts-postrouting
@@ -245,6 +343,7 @@ v6/filter/INPUT -j ts-input
 v6/filter/ts-forward -i tailscale0 -j MARK --set-mark 0x40000/0xff0000
 v6/filter/ts-forward -m mark --mark 0x40000/0xff0000 -j ACCEPT
 v6/filter/ts-forward -o tailscale0 -j ACCEPT
+v6/filter/ts-input -i tailscale0 -j ACCEPT
 v6/mangle/OUTPUT -m conntrack --ctstate NEW -m mark ! --mark 0x0/0xff0000 -j CONNMARK --save-mark --nfmask 0xff0000 --ctmask 0xff0000
 v6/mangle/PREROUTING -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark --nfmask 0xff0000 --ctmask 0xff0000
 v6/nat/POSTROUTING -j ts-postrouting
@@ -253,9 +352,10 @@ v6/nat/POSTROUTING -j ts-postrouting
 		{
 			name: "addr-and-routes-with-netfilter-2",
 			in: &Config{
-				LocalAddrs:    mustCIDRs("100.101.102.104/10"),
-				Routes:        mustCIDRs("100.100.100.100/32", "10.0.0.0/8"),
-				NetfilterMode: netfilterOn,
+				LocalAddrs:      mustCIDRs("100.101.102.104/10"),
+				Routes:          mustCIDRs("100.100.100.100/32", "10.0.0.0/8"),
+				NetfilterMode:   netfilterOn,
+				AllowAllInbound: true,
 			},
 			want: `
 up
@@ -271,6 +371,7 @@ v4/filter/ts-forward -o tailscale0 -j ACCEPT
 v4/filter/ts-input -i lo -s 100.101.102.104 -j ACCEPT
 v4/filter/ts-input ! -i tailscale0 -s 100.115.92.0/23 -j RETURN
 v4/filter/ts-input ! -i tailscale0 -s 100.64.0.0/10 -j DROP
+v4/filter/ts-input -i tailscale0 -j ACCEPT
 v4/mangle/OUTPUT -m conntrack --ctstate NEW -m mark ! --mark 0x0/0xff0000 -j CONNMARK --save-mark --nfmask 0xff0000 --ctmask 0xff0000
 v4/mangle/PREROUTING -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark --nfmask 0xff0000 --ctmask 0xff0000
 v4/nat/POSTROUTING -j ts-postrouting
@@ -279,6 +380,7 @@ v6/filter/INPUT -j ts-input
 v6/filter/ts-forward -i tailscale0 -j MARK --set-mark 0x40000/0xff0000
 v6/filter/ts-forward -m mark --mark 0x40000/0xff0000 -j ACCEPT
 v6/filter/ts-forward -o tailscale0 -j ACCEPT
+v6/filter/ts-input -i tailscale0 -j ACCEPT
 v6/mangle/OUTPUT -m conntrack --ctstate NEW -m mark ! --mark 0x0/0xff0000 -j CONNMARK --save-mark --nfmask 0xff0000 --ctmask 0xff0000
 v6/mangle/PREROUTING -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark --nfmask 0xff0000 --ctmask 0xff0000
 v6/nat/POSTROUTING -j ts-postrouting
@@ -288,9 +390,10 @@ v6/nat/POSTROUTING -j ts-postrouting
 		{
 			name: "addr-and-routes-with-half-netfilter",
 			in: &Config{
-				LocalAddrs:    mustCIDRs("100.101.102.104/10"),
-				Routes:        mustCIDRs("100.100.100.100/32", "10.0.0.0/8"),
-				NetfilterMode: netfilterNoDivert,
+				LocalAddrs:      mustCIDRs("100.101.102.104/10"),
+				Routes:          mustCIDRs("100.100.100.100/32", "10.0.0.0/8"),
+				NetfilterMode:   netfilterNoDivert,
+				AllowAllInbound: true,
 			},
 			want: `
 up
@@ -304,17 +407,20 @@ v4/filter/ts-forward -o tailscale0 -j ACCEPT
 v4/filter/ts-input -i lo -s 100.101.102.104 -j ACCEPT
 v4/filter/ts-input ! -i tailscale0 -s 100.115.92.0/23 -j RETURN
 v4/filter/ts-input ! -i tailscale0 -s 100.64.0.0/10 -j DROP
+v4/filter/ts-input -i tailscale0 -j ACCEPT
 v6/filter/ts-forward -i tailscale0 -j MARK --set-mark 0x40000/0xff0000
 v6/filter/ts-forward -m mark --mark 0x40000/0xff0000 -j ACCEPT
 v6/filter/ts-forward -o tailscale0 -j ACCEPT
+v6/filter/ts-input -i tailscale0 -j ACCEPT
 `,
 		},
 		{
 			name: "addr-and-routes-with-netfilter2",
 			in: &Config{
-				LocalAddrs:    mustCIDRs("100.101.102.104/10"),
-				Routes:        mustCIDRs("100.100.100.100/32", "10.0.0.0/8"),
-				NetfilterMode: netfilterOn,
+				LocalAddrs:      mustCIDRs("100.101.102.104/10"),
+				Routes:          mustCIDRs("100.100.100.100/32", "10.0.0.0/8"),
+				NetfilterMode:   netfilterOn,
+				AllowAllInbound: true,
 			},
 			want: `
 up
@@ -330,6 +436,7 @@ v4/filter/ts-forward -o tailscale0 -j ACCEPT
 v4/filter/ts-input -i lo -s 100.101.102.104 -j ACCEPT
 v4/filter/ts-input ! -i tailscale0 -s 100.115.92.0/23 -j RETURN
 v4/filter/ts-input ! -i tailscale0 -s 100.64.0.0/10 -j DROP
+v4/filter/ts-input -i tailscale0 -j ACCEPT
 v4/mangle/OUTPUT -m conntrack --ctstate NEW -m mark ! --mark 0x0/0xff0000 -j CONNMARK --save-mark --nfmask 0xff0000 --ctmask 0xff0000
 v4/mangle/PREROUTING -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark --nfmask 0xff0000 --ctmask 0xff0000
 v4/nat/POSTROUTING -j ts-postrouting
@@ -338,6 +445,7 @@ v6/filter/INPUT -j ts-input
 v6/filter/ts-forward -i tailscale0 -j MARK --set-mark 0x40000/0xff0000
 v6/filter/ts-forward -m mark --mark 0x40000/0xff0000 -j ACCEPT
 v6/filter/ts-forward -o tailscale0 -j ACCEPT
+v6/filter/ts-input -i tailscale0 -j ACCEPT
 v6/mangle/OUTPUT -m conntrack --ctstate NEW -m mark ! --mark 0x0/0xff0000 -j CONNMARK --save-mark --nfmask 0xff0000 --ctmask 0xff0000
 v6/mangle/PREROUTING -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark --nfmask 0xff0000 --ctmask 0xff0000
 v6/nat/POSTROUTING -j ts-postrouting
@@ -346,10 +454,11 @@ v6/nat/POSTROUTING -j ts-postrouting
 		{
 			name: "addr-routes-local-routes-with-netfilter",
 			in: &Config{
-				LocalAddrs:    mustCIDRs("100.101.102.104/10"),
-				Routes:        mustCIDRs("100.100.100.100/32", "0.0.0.0/0"),
-				LocalRoutes:   mustCIDRs("10.0.0.0/8"),
-				NetfilterMode: netfilterOn,
+				LocalAddrs:      mustCIDRs("100.101.102.104/10"),
+				Routes:          mustCIDRs("100.100.100.100/32", "0.0.0.0/0"),
+				LocalRoutes:     mustCIDRs("10.0.0.0/8"),
+				NetfilterMode:   netfilterOn,
+				AllowAllInbound: true,
 			},
 			want: `
 up
@@ -366,6 +475,7 @@ v4/filter/ts-forward -o tailscale0 -j ACCEPT
 v4/filter/ts-input -i lo -s 100.101.102.104 -j ACCEPT
 v4/filter/ts-input ! -i tailscale0 -s 100.115.92.0/23 -j RETURN
 v4/filter/ts-input ! -i tailscale0 -s 100.64.0.0/10 -j DROP
+v4/filter/ts-input -i tailscale0 -j ACCEPT
 v4/mangle/OUTPUT -m conntrack --ctstate NEW -m mark ! --mark 0x0/0xff0000 -j CONNMARK --save-mark --nfmask 0xff0000 --ctmask 0xff0000
 v4/mangle/PREROUTING -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark --nfmask 0xff0000 --ctmask 0xff0000
 v4/nat/POSTROUTING -j ts-postrouting
@@ -374,6 +484,7 @@ v6/filter/INPUT -j ts-input
 v6/filter/ts-forward -i tailscale0 -j MARK --set-mark 0x40000/0xff0000
 v6/filter/ts-forward -m mark --mark 0x40000/0xff0000 -j ACCEPT
 v6/filter/ts-forward -o tailscale0 -j ACCEPT
+v6/filter/ts-input -i tailscale0 -j ACCEPT
 v6/mangle/OUTPUT -m conntrack --ctstate NEW -m mark ! --mark 0x0/0xff0000 -j CONNMARK --save-mark --nfmask 0xff0000 --ctmask 0xff0000
 v6/mangle/PREROUTING -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark --nfmask 0xff0000 --ctmask 0xff0000
 v6/nat/POSTROUTING -j ts-postrouting
@@ -403,6 +514,7 @@ ip route add throw 192.168.0.0/24 table 52` + basic,
 				SubnetRoutes:     mustCIDRs("10.0.0.0/16"),
 				SNATSubnetRoutes: true,
 				NetfilterMode:    netfilterOn,
+				AllowAllInbound:  true,
 			},
 			want: `
 up
@@ -417,6 +529,7 @@ v4/filter/ts-forward -o tailscale0 -j ACCEPT
 v4/filter/ts-input -i lo -s 100.101.102.104 -j ACCEPT
 v4/filter/ts-input ! -i tailscale0 -s 100.115.92.0/23 -j RETURN
 v4/filter/ts-input ! -i tailscale0 -s 100.64.0.0/10 -j DROP
+v4/filter/ts-input -i tailscale0 -j ACCEPT
 v4/mangle/OUTPUT -m conntrack --ctstate NEW -m mark ! --mark 0x0/0xff0000 -j CONNMARK --save-mark --nfmask 0xff0000 --ctmask 0xff0000
 v4/mangle/PREROUTING -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark --nfmask 0xff0000 --ctmask 0xff0000
 v4/nat/POSTROUTING -j ts-postrouting
@@ -426,6 +539,7 @@ v6/filter/INPUT -j ts-input
 v6/filter/ts-forward -i tailscale0 -j MARK --set-mark 0x40000/0xff0000
 v6/filter/ts-forward -m mark --mark 0x40000/0xff0000 -j ACCEPT
 v6/filter/ts-forward -o tailscale0 -j ACCEPT
+v6/filter/ts-input -i tailscale0 -j ACCEPT
 v6/mangle/OUTPUT -m conntrack --ctstate NEW -m mark ! --mark 0x0/0xff0000 -j CONNMARK --save-mark --nfmask 0xff0000 --ctmask 0xff0000
 v6/mangle/PREROUTING -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark --nfmask 0xff0000 --ctmask 0xff0000
 v6/nat/POSTROUTING -j ts-postrouting
@@ -440,6 +554,7 @@ v6/nat/ts-postrouting -m mark --mark 0x40000/0xff0000 -j MASQUERADE
 				SubnetRoutes:     mustCIDRs("10.0.0.0/16"),
 				SNATSubnetRoutes: true,
 				NetfilterMode:    netfilterOn,
+				AllowAllInbound:  true,
 			},
 			want: `
 up
@@ -454,6 +569,7 @@ v4/filter/ts-forward -o tailscale0 -j ACCEPT
 v4/filter/ts-input -i lo -s 100.101.102.104 -j ACCEPT
 v4/filter/ts-input ! -i tailscale0 -s 100.115.92.0/23 -j RETURN
 v4/filter/ts-input ! -i tailscale0 -s 100.64.0.0/10 -j DROP
+v4/filter/ts-input -i tailscale0 -j ACCEPT
 v4/mangle/OUTPUT -m conntrack --ctstate NEW -m mark ! --mark 0x0/0xff0000 -j CONNMARK --save-mark --nfmask 0xff0000 --ctmask 0xff0000
 v4/mangle/PREROUTING -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark --nfmask 0xff0000 --ctmask 0xff0000
 v4/nat/POSTROUTING -j ts-postrouting
@@ -463,6 +579,7 @@ v6/filter/INPUT -j ts-input
 v6/filter/ts-forward -i tailscale0 -j MARK --set-mark 0x40000/0xff0000
 v6/filter/ts-forward -m mark --mark 0x40000/0xff0000 -j ACCEPT
 v6/filter/ts-forward -o tailscale0 -j ACCEPT
+v6/filter/ts-input -i tailscale0 -j ACCEPT
 v6/mangle/OUTPUT -m conntrack --ctstate NEW -m mark ! --mark 0x0/0xff0000 -j CONNMARK --save-mark --nfmask 0xff0000 --ctmask 0xff0000
 v6/mangle/PREROUTING -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark --nfmask 0xff0000 --ctmask 0xff0000
 v6/nat/POSTROUTING -j ts-postrouting
@@ -478,6 +595,7 @@ v6/nat/ts-postrouting -m mark --mark 0x40000/0xff0000 -j MASQUERADE
 				SNATSubnetRoutes:  true,
 				StatefulFiltering: true,
 				NetfilterMode:     netfilterOn,
+				AllowAllInbound:   true,
 			},
 			want: `
 up
@@ -493,6 +611,7 @@ v4/filter/ts-forward -o tailscale0 -j ACCEPT
 v4/filter/ts-input -i lo -s 100.101.102.104 -j ACCEPT
 v4/filter/ts-input ! -i tailscale0 -s 100.115.92.0/23 -j RETURN
 v4/filter/ts-input ! -i tailscale0 -s 100.64.0.0/10 -j DROP
+v4/filter/ts-input -i tailscale0 -j ACCEPT
 v4/mangle/OUTPUT -m conntrack --ctstate NEW -m mark ! --mark 0x0/0xff0000 -j CONNMARK --save-mark --nfmask 0xff0000 --ctmask 0xff0000
 v4/mangle/PREROUTING -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark --nfmask 0xff0000 --ctmask 0xff0000
 v4/nat/POSTROUTING -j ts-postrouting
@@ -503,6 +622,7 @@ v6/filter/ts-forward -i tailscale0 -j MARK --set-mark 0x40000/0xff0000
 v6/filter/ts-forward -m mark --mark 0x40000/0xff0000 -j ACCEPT
 v6/filter/ts-forward -o tailscale0 -m conntrack ! --ctstate ESTABLISHED,RELATED -j DROP
 v6/filter/ts-forward -o tailscale0 -j ACCEPT
+v6/filter/ts-input -i tailscale0 -j ACCEPT
 v6/mangle/OUTPUT -m conntrack --ctstate NEW -m mark ! --mark 0x0/0xff0000 -j CONNMARK --save-mark --nfmask 0xff0000 --ctmask 0xff0000
 v6/mangle/PREROUTING -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark --nfmask 0xff0000 --ctmask 0xff0000
 v6/nat/POSTROUTING -j ts-postrouting
@@ -715,6 +835,28 @@ func (n *fakeIPTablesRunner) EnsureDNATRuleForSvc(svcName string, origDst, dst n
 
 func (n *fakeIPTablesRunner) DeleteDNATRuleForSvc(svcName string, origDst, dst netip.Addr) error {
 	return errors.New("not implemented")
+}
+
+func (n *fakeIPTablesRunner) AddAllowAllInboundRule(tunname string) error {
+	rule := struct{ chain, rule string }{"filter/ts-input", fmt.Sprintf("-i %s -j ACCEPT", tunname)}
+
+	for _, ipt := range []map[string][]string{n.ipt4, n.ipt6} {
+		if err := appendRule(n, ipt, rule.chain, rule.rule); err != nil {
+			return fmt.Errorf("add rule %q to chain %q: %w", rule.rule, rule.chain, err)
+		}
+	}
+	return nil
+}
+
+func (n *fakeIPTablesRunner) DelAllowAllInboundRule(tunname string) error {
+	rule := struct{ chain, rule string }{"filter/ts-input", fmt.Sprintf("-i %s -j ACCEPT", tunname)}
+
+	for _, ipt := range []map[string][]string{n.ipt4, n.ipt6} {
+		if err := deleteRule(n, ipt, rule.chain, rule.rule); err != nil {
+			return fmt.Errorf("del rule %q from chain %q: %w", rule.rule, rule.chain, err)
+		}
+	}
+	return nil
 }
 
 func (n *fakeIPTablesRunner) addBase4(tunname string) error {

--- a/wgengine/router/router.go
+++ b/wgengine/router/router.go
@@ -134,6 +134,7 @@ type Config struct {
 	// Linux-only things below, ignored on other platforms.
 	SNATSubnetRoutes  bool                   // SNAT traffic to local subnets
 	StatefulFiltering bool                   // Apply stateful filtering to inbound connections
+	AllowAllInbound   bool                   // Explicitly allow all inbound traffic on the tun interface
 	NetfilterMode     preftype.NetfilterMode // how much to manage netfilter rules
 	NetfilterKind     string                 // what kind of netfilter to use ("nftables", "iptables", or "" to auto-detect)
 }

--- a/wgengine/router/router_test.go
+++ b/wgengine/router/router_test.go
@@ -15,7 +15,7 @@ func TestConfigEqual(t *testing.T) {
 	testedFields := []string{
 		"LocalAddrs", "Routes", "LocalRoutes", "NewMTU",
 		"SubnetRoutes", "SNATSubnetRoutes", "StatefulFiltering",
-		"NetfilterMode", "NetfilterKind",
+		"AllowAllInbound", "NetfilterMode", "NetfilterKind",
 	}
 	configType := reflect.TypeFor[Config]()
 	configFields := []string{}
@@ -114,6 +114,16 @@ func TestConfigEqual(t *testing.T) {
 		{
 			&Config{SNATSubnetRoutes: false},
 			&Config{SNATSubnetRoutes: false},
+			true,
+		},
+		{
+			&Config{AllowAllInbound: false},
+			&Config{AllowAllInbound: true},
+			false,
+		},
+		{
+			&Config{AllowAllInbound: false},
+			&Config{AllowAllInbound: false},
 			true,
 		},
 		{


### PR DESCRIPTION
Add a `--allow-all-inbound` set flag, which defaults to true, to condition whether or not to add a netfilter rule accepting all traffic on the tun interface.

This allows users who do not desire this behavior to opt-out, removing the necessity of using the current workaround, which consists of setting `--netfilter-mode=[nodivert,off]` and manually linking/hooking the tailscale chains.

This should be a no-op for existing installs, as accepting all traffic on the tun interface is (controversially, see #11717) the default.

Added all the tests I could figure to add, please do recommend other places to add them if necessary.

Updates #11717