### PR TITLE
version: show tailscale/go toolchain git hash in version output

### DIFF
--- a/version/print.go
+++ b/version/print.go
@@ -24,7 +24,14 @@ var stringLazy = sync.OnceValue(func() string {
 	if extraGitCommitStamp != "" {
 		fmt.Fprintf(&ret, "  other commit: %s\n", extraGitCommitStamp)
 	}
-	fmt.Fprintf(&ret, "  go version: %s\n", runtime.Version())
+	if tsGoRev := tailscaleToolchainRev(); tsGoRev != "" {
+		if len(tsGoRev) > 10 {
+			tsGoRev = tsGoRev[:10]
+		}
+		fmt.Fprintf(&ret, "  go version: %s (tailscale/go %s)\n", runtime.Version(), tsGoRev)
+	} else {
+		fmt.Fprintf(&ret, "  go version: %s\n", runtime.Version())
+	}
 	return strings.TrimSpace(ret.String())
 })
 

--- a/version/prop.go
+++ b/version/prop.go
@@ -312,6 +312,11 @@ type Meta struct {
 	// GitCommitTime is the commit time of the git commit in GitCommit.
 	GitCommitTime string `json:"gitCommitTime,omitempty"`
 
+	// TailscaleGoGitHash is the git commit hash from
+	// https://github.com/tailscale/go used to build this binary, if built
+	// with the Tailscale Go toolchain. Otherwise it is empty.
+	TailscaleGoGitHash string `json:"tailscaleGoGitHash,omitempty"`
+
 	// Cap is the current Tailscale capability version. It's a monotonically
 	// incrementing integer that's incremented whenever a new capability is
 	// added.
@@ -324,17 +329,18 @@ var getMeta lazy.SyncValue[Meta]
 func GetMeta() Meta {
 	return getMeta.Get(func() Meta {
 		return Meta{
-			MajorMinorPatch: majorMinorPatch(),
-			Short:           Short(),
-			Long:            Long(),
-			GitCommitTime:   getEmbeddedInfo().commitTime,
-			GitCommit:       gitCommit(),
-			GitDirty:        gitDirty(),
-			OSVariant:       osVariant(),
-			ExtraGitCommit:  extraGitCommitStamp,
-			IsDev:           isDev(),
-			UnstableBranch:  IsUnstableBuild(),
-			Cap:             int(tailcfg.CurrentCapabilityVersion),
+			MajorMinorPatch:    majorMinorPatch(),
+			Short:              Short(),
+			Long:               Long(),
+			GitCommitTime:      getEmbeddedInfo().commitTime,
+			GitCommit:          gitCommit(),
+			GitDirty:           gitDirty(),
+			OSVariant:          osVariant(),
+			ExtraGitCommit:     extraGitCommitStamp,
+			IsDev:              isDev(),
+			UnstableBranch:     IsUnstableBuild(),
+			TailscaleGoGitHash: tailscaleToolchainRev(),
+			Cap:                int(tailcfg.CurrentCapabilityVersion),
 		}
 	})
 }

--- a/version/version.go
+++ b/version/version.go
@@ -146,6 +146,23 @@ var getEmbeddedInfo = sync.OnceValue(func() embeddedInfo {
 	return ret
 })
 
+// tailscaleToolchainRev returns the git hash of the Tailscale Go toolchain
+// used to build this binary, if any. It is read separately from getEmbeddedInfo
+// because that function discards build info when VCS fields are missing (e.g.
+// in test binaries), but the toolchain rev is still present.
+var tailscaleToolchainRev = sync.OnceValue(func() string {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	for _, s := range bi.Settings {
+		if s.Key == "tailscale.toolchain.rev" {
+			return s.Value
+		}
+	}
+	return ""
+})
+
 func gitCommit() string {
 	if gitCommitStamp != "" {
 		return gitCommitStamp

--- a/version/version_internal_test.go
+++ b/version/version_internal_test.go
@@ -3,7 +3,13 @@
 
 package version
 
-import "testing"
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"tailscale.com/util/cibuild"
+)
 
 func TestIsValidLongWithTwoRepos(t *testing.T) {
 	tests := []struct {
@@ -24,6 +30,26 @@ func TestIsValidLongWithTwoRepos(t *testing.T) {
 			t.Errorf("IsValidLongWithTwoRepos(%q) = %v; want %v", tt.long, got, tt.want)
 		}
 	}
+}
+
+func TestTailscaleToolchainRev(t *testing.T) {
+	out, err := exec.Command("go", "env", "GOROOT").Output()
+	if err != nil {
+		t.Fatalf("go env GOROOT: %v", err)
+	}
+	goRoot := strings.TrimSpace(string(out))
+	isTsgo := strings.Contains(goRoot, "/.cache/tsgo/")
+	if !cibuild.On() && !isTsgo {
+		t.Skip("skipping; not in CI and not using the Tailscale Go toolchain")
+	}
+	if !isTailscaleGo {
+		t.Skip("skipping; not built with tailscale_go build tag")
+	}
+	rev := tailscaleToolchainRev()
+	if rev == "" {
+		t.Fatal("tailscale.toolchain.rev is empty in build info; expected non-empty when using tsgo")
+	}
+	t.Logf("tailscale.toolchain.rev = %s", rev)
 }
 
 func TestPrepExeNameForCmp(t *testing.T) {


### PR DESCRIPTION
When built with the Tailscale Go toolchain, include the toolchain's
git revision in the version output. The non-JSON output shows the
first 10 hex digits:

  go version: go1.26.2 (tailscale/go dfe2a5fd8e)

The JSON output includes the full hash as "tailscaleGoGitHash", or
omits the field when not using tsgo.

The toolchain rev is read via a separate sync.OnceValue rather than
piggybacking on getEmbeddedInfo, because that function discards all
data when VCS fields are absent (e.g. in test binaries), while the
tailscale.toolchain.rev setting is still present.

Also add a CI-only test verifying tailscaleToolchainRev is non-empty
when built with the tailscale_go build tag.

Fixes #19374
