### PR TITLE
tstest/integration: clear SSH_CLIENT env to prevent false positive detection

### DIFF
--- a/tstest/integration/integration.go
+++ b/tstest/integration/integration.go
@@ -1044,6 +1044,9 @@ func (n *TestNode) Tailscale(arg ...string) *exec.Cmd {
 	cmd.Env = append(os.Environ(),
 		"TS_DEBUG_UP_FLAG_GOOS="+n.upFlagGOOS,
 		"TS_LOGS_DIR="+n.env.t.TempDir(),
+		"SSH_CLIENT=",     // Clear SSH_CLIENT to prevent isSSHOverTailscale() false positives in tests
+		"SSH_CONNECTION=", // just in case
+		"SSH_AUTH_SOCK=",  // just in case
 	)
 	if *verboseTailscale {
 		cmd.Stdout = os.Stdout


### PR DESCRIPTION
When running integration tests over SSH (e.g., in remote development
environments), the SSH_CLIENT environment variable is set. This causes
isSSHOverTailscale() to incorrectly detect an SSH session and change
behavior.

Clear SSH_CLIENT in the test node environment to prevent these false
positives.

Fixes #19393
