### PR TITLE
tstest: fix kernel version parsing for Debian-style version strings

### DIFF
--- a/tstest/kernel_linux.go
+++ b/tstest/kernel_linux.go
@@ -20,8 +20,13 @@ func KernelVersion() (major, minor, patch int) {
 		return 0, 0, 0
 	}
 	release := unix.ByteSliceToString(uname.Release[:])
+	return parseKernelVersion(release)
+}
 
-	// Parse version string (e.g., "5.15.0-...")
+// parseKernelVersion parses a Linux kernel version string like "6.12.73+deb13-amd64"
+// or "5.15.0-76-generic" and returns the major, minor, and patch components.
+// It returns (0, 0, 0) if the version cannot be parsed.
+func parseKernelVersion(release string) (major, minor, patch int) {
 	parts := strings.Split(release, ".")
 	if len(parts) < 3 {
 		return 0, 0, 0
@@ -37,9 +42,12 @@ func KernelVersion() (major, minor, patch int) {
 		return 0, 0, 0
 	}
 
-	// Patch version may have additional info after a hyphen (e.g., "0-76-generic")
-	// Extract just the numeric part before any hyphen
-	patchStr, _, _ := strings.Cut(parts[2], "-")
+	// Patch version may have additional info after a hyphen or plus (e.g., "0-76-generic" or "41+deb13-amd64")
+	// Extract just the numeric part before any hyphen or plus
+	patchStr := parts[2]
+	if idx := strings.IndexAny(patchStr, "-+"); idx != -1 {
+		patchStr = patchStr[:idx]
+	}
 
 	patch, err = strconv.Atoi(patchStr)
 	if err != nil {

--- a/tstest/kernel_linux_test.go
+++ b/tstest/kernel_linux_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build linux
+
+package tstest
+
+import "testing"
+
+func TestParseKernelVersion(t *testing.T) {
+	tests := []struct {
+		release             string
+		major, minor, patch int
+	}{
+		{"5.15.0-76-generic", 5, 15, 0},
+		{"6.12.73+deb13-amd64", 6, 12, 73},
+		{"6.1.0-18-amd64", 6, 1, 0},
+		{"5.4.0", 5, 4, 0},
+		{"6.8.12", 6, 8, 12},
+		{"4.19.0+1", 4, 19, 0},
+		{"6.12.41+deb13-amd64", 6, 12, 41},
+		{"", 0, 0, 0},
+		{"not-a-version", 0, 0, 0},
+		{"1.2", 0, 0, 0},
+		{"a.b.c", 0, 0, 0},
+	}
+	for _, tt := range tests {
+		major, minor, patch := parseKernelVersion(tt.release)
+		if major != tt.major || minor != tt.minor || patch != tt.patch {
+			t.Errorf("parseKernelVersion(%q) = (%d, %d, %d), want (%d, %d, %d)",
+				tt.release, major, minor, patch, tt.major, tt.minor, tt.patch)
+		}
+	}
+}


### PR DESCRIPTION
The kernel version parser used strings.Cut with "-" to handle versions
like "5.4.0-76-generic", but Debian uses "+" in versions like
"6.12.41+deb13-amd64".

Use strings.IndexAny to find the first "-" or "+" and truncate there.

Fixes TestKernelVersion on Debian systems.

Fixes #19395

Co-Authored-By: @bradfitz 