### PR TITLE
scripts/installer: handle Solus (eopkg) and AerynOS (moss)

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -351,6 +351,22 @@ main() {
 				echo "https://github.com/tailscale-dev/deck-tailscale"
 				exit 1
 				;;
+			solus)
+				echo "Solus packages and maintains its own Tailscale build."
+				echo "Please install it with the native package manager:"
+				echo
+				echo "    sudo eopkg install tailscale"
+				echo
+				exit 1
+				;;
+			aerynos|serpentos)
+				echo "AerynOS packages and maintains its own Tailscale build."
+				echo "Please install it with the native package manager:"
+				echo
+				echo "    sudo moss install tailscale"
+				echo
+				exit 1
+				;;
 			kde-linux)
 				echo "The maintainers of KDE Linux provide documentation on multiple ways to install Tailscale. These instructions are not officially supported by Tailscale:"
 				echo "https://linux.kde.org/docs/more-software/#tailscale"

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -732,8 +732,10 @@ main() {
 			set -x
 			if [ -n "$TAILSCALE_VERSION" ]; then
 				echo "Warning: Solus maintains their own Tailscale package. Version pinning may not work as expected, as the target version may no longer be available."
+				$SUDO eopkg install -y "tailscale-$TAILSCALE_VERSION"
+			else
+				$SUDO eopkg install -y tailscale
 			fi
-			$SUDO eopkg install -y tailscale
 			$SUDO systemctl enable --now tailscaled
 			set +x
 			;;
@@ -741,8 +743,10 @@ main() {
 			set -x
 			if [ -n "$TAILSCALE_VERSION" ]; then
 				echo "Warning: AerynOS maintains their own Tailscale package. Version pinning may not work as expected, as the target version may no longer be available."
+				$SUDO moss install -y "tailscale-$TAILSCALE_VERSION"
+			else
+				$SUDO moss install -y tailscale
 			fi
-			$SUDO moss install -y tailscale
 			$SUDO systemctl enable --now tailscaled
 			set +x
 			;;

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -352,20 +352,14 @@ main() {
 				exit 1
 				;;
 			solus)
-				echo "Solus packages and maintains its own Tailscale build."
-				echo "Please install it with the native package manager:"
-				echo
-				echo "    sudo eopkg install tailscale"
-				echo
-				exit 1
+				OS="$ID"
+				VERSION="$VERSION_ID"
+				PACKAGETYPE="eopkg"
 				;;
 			aerynos|serpentos)
-				echo "AerynOS packages and maintains its own Tailscale build."
-				echo "Please install it with the native package manager:"
-				echo
-				echo "    sudo moss install tailscale"
-				echo
-				exit 1
+				OS="$ID"
+				VERSION="$VERSION_ID"
+				PACKAGETYPE="moss"
 				;;
 			kde-linux)
 				echo "The maintainers of KDE Linux provide documentation on multiple ways to install Tailscale. These instructions are not officially supported by Tailscale:"
@@ -732,6 +726,24 @@ main() {
 			else
 				$SUDO emerge --ask=n net-vpn/tailscale
 			fi
+			set +x
+			;;
+		eopkg)
+			set -x
+			if [ -n "$TAILSCALE_VERSION" ]; then
+				echo "Warning: Solus maintains their own Tailscale package. Version pinning may not work as expected, as the target version may no longer be available."
+			fi
+			$SUDO eopkg install -y tailscale
+			$SUDO systemctl enable --now tailscaled
+			set +x
+			;;
+		moss)
+			set -x
+			if [ -n "$TAILSCALE_VERSION" ]; then
+				echo "Warning: AerynOS maintains their own Tailscale package. Version pinning may not work as expected, as the target version may no longer be available."
+			fi
+			$SUDO moss install -y tailscale
+			$SUDO systemctl enable --now tailscaled
 			set +x
 			;;
 		appstore)

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -457,6 +457,12 @@ main() {
 		gentoo)
 			# Rolling release, no version checking needed.
 			;;
+		solus)
+			# Rolling release, no version checking needed.
+			;;
+		aerynos|serpentos)
+			# Rolling release, no version checking needed.
+			;;
 		freebsd)
 			if [ "$VERSION" != "12" ] && \
 			   [ "$VERSION" != "13" ] && \


### PR DESCRIPTION
Per #19364, the installer fails on Solus and AerynOS because both distros maintain their own Tailscale builds and don't ship any of the supported package managers (apt/dnf/yum/zypper/pacman/apk/etc.) that the script currently recognises.

Detect both `ID=solus` and `ID=aerynos` (also `serpentos`, the upstream identifier) in the os-release switch and print a short message pointing users at `eopkg install tailscale` / `moss install tailscale` respectively. This mirrors the existing nixos / steamos / kde-linux paths.

Closes #19364