### PR TITLE
ipn/ipnlocal: disable netmap caching for ios

### DIFF
--- a/ipn/ipnlocal/diskcache.go
+++ b/ipn/ipnlocal/diskcache.go
@@ -1,6 +1,8 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+//go:build !ios
+
 package ipnlocal
 
 import (

--- a/ipn/ipnlocal/diskcache_disabled.go
+++ b/ipn/ipnlocal/diskcache_disabled.go
@@ -1,0 +1,41 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build ios
+
+package ipnlocal
+
+import (
+	"context"
+
+	"tailscale.com/ipn/ipnlocal/netmapcache"
+	"tailscale.com/types/netmap"
+)
+
+// diskCache is the state netmap caching to disk.
+type diskCache struct {
+}
+
+func (b *LocalBackend) writeNetmapToDiskLocked(nm *netmap.NetworkMap) error {
+	return nil // not supported on this platform
+}
+
+func (b *LocalBackend) loadDiskCacheLocked() (om *netmap.NetworkMap, ok bool) {
+	return nil, false // not supported on this platform
+}
+
+// discardDiskCacheLocked removes a cached network map for the current node, if
+// one exists, and disables the cache.
+func (b *LocalBackend) discardDiskCacheLocked() {}
+
+// clearStoreLocked discards all the keys in the specified store.
+func (b *LocalBackend) clearStoreLocked(ctx context.Context, store netmapcache.Store) error {
+	return nil // not supported on this platform
+}
+
+// ClearNetmapCache discards stored netmap caches (if any) for profiles for the
+// current user of b. It also drops any cache from the active backend session,
+// if there is one.
+func (b *LocalBackend) ClearNetmapCache(ctx context.Context) error {
+	return nil // not supported on this platform
+}


### PR DESCRIPTION
WIP, do not merge. Could we do this by setting the ts_omit* tag in the build
instead?

Updates #todo

Change-Id: I3efa627729de23c00022dfc46493ab94921aa68c
Signed-off-by: M. J. Fromberger <fromberger@tailscale.com>
