### PR TITLE
util/httpm: open .git/index to defeat Go test caching

### DIFF
--- a/util/httpm/httpm_test.go
+++ b/util/httpm/httpm_test.go
@@ -24,6 +24,13 @@ func TestUsedConsistently(t *testing.T) {
 		t.Skipf("skipping test since .git doesn't exist: %v", err)
 	}
 
+	// Open .git/index so Go's test cache tracks it as an input.
+	// The index file changes on git reset, checkout, pull, etc.,
+	// so the cache is properly invalidated when moving between commits.
+	if f, err := os.Open(filepath.Join(rootDir, ".git", "index")); err == nil {
+		f.Close()
+	}
+
 	cmd := exec.Command("git", "grep", "-l", "-F", "http.Method")
 	cmd.Dir = rootDir
 	matches, _ := cmd.Output()


### PR DESCRIPTION
TestUsedConsistently shells out to git grep to find forbidden
http.Method* uses across the repo. Since the test itself doesn't
open any repo files, Go's test cache considers it unchanged
between commits and serves stale passing results even when new
violations are introduced.

Fix by opening .git/index, which makes Go's test cache track it
as an input. The index file changes on git reset, checkout, pull,
etc., so the cache is properly invalidated when moving between
commits.

Updates tailscale/corp#40359
