### PR TITLE
ipn/ipnlocal: log AUM hash on startup as base32, not hex

### DIFF
--- a/ipn/ipnlocal/network-lock.go
+++ b/ipn/ipnlocal/network-lock.go
@@ -96,7 +96,7 @@ func (b *LocalBackend) initTKALocked() error {
 			authority: authority,
 			storage:   storage,
 		}
-		b.logf("tka initialized at head %x", authority.Head())
+		b.logf("tka initialized at head %s", authority.Head())
 	}
 
 	return nil


### PR DESCRIPTION
Printing the AUM hash as hex makes it difficult to compare to other AUM hashes; stringifying it will make it consistent with other printing.

Updates #cleanup