### PR TITLE
ipn/ipnlocal: fix deadlock in ipn bus watcher

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -3233,9 +3233,6 @@ func (b *LocalBackend) WatchNotificationsAs(ctx context.Context, actor ipnauth.A
 		if mask&ipn.NotifyInitialDriveShares != 0 && b.DriveSharingEnabled() {
 			ini.DriveShares = b.pm.prefs.DriveShares()
 		}
-		if mask&ipn.NotifyInitialHealthState != 0 {
-			ini.Health = b.HealthTracker().CurrentState()
-		}
 		if mask&ipn.NotifyInitialSuggestedExitNode != 0 {
 			if en, err := b.suggestExitNodeLocked(); err == nil {
 				ini.SuggestedExitNode = &en.ID
@@ -3260,6 +3257,10 @@ func (b *LocalBackend) WatchNotificationsAs(ctx context.Context, actor ipnauth.A
 	}
 	mak.Set(&b.notifyWatchers, sessionID, session)
 	b.mu.Unlock()
+
+	if mask&ipn.NotifyInitialHealthState != 0 && ini != nil {
+		ini.Health = b.HealthTracker().CurrentState()
+	}
 
 	metricCurrentWatchIPNBus.Add(1)
 	defer metricCurrentWatchIPNBus.Add(-1)


### PR DESCRIPTION
fixes tailscale/corp#40401

From an internal stack trace.  We witnessed a slow bus error and a complete lock up of the ipn bus watcher.

Stack showed a b.mu->t.mu and t.mu->b.mu lock ordering issue when setting up the HealthTracker's initial state in the watcher and its timer simultaneously fires.