### PR TITLE
ipn/ipnlocal: make TestStateMachine less flaky

### DIFF
--- a/ipn/ipnlocal/state_test.go
+++ b/ipn/ipnlocal/state_test.go
@@ -698,6 +698,7 @@ func runTestStateMachine(t *testing.T, seamless bool) {
 	notifies.expect(5)
 	b.Logout(context.Background(), ipnauth.Self)
 	{
+		b.awaitNoGoroutinesInTest()
 		nn := notifies.drain(5)
 		previousCC.assertCalls("pause", "Logout", "unpause", "Shutdown")
 		// nn[0] is state notification (Stopped)


### PR DESCRIPTION
TestStateMachine & TestStateMachineSeamless both flake a lot asserting the "Shutdown" call on cc after a Logout. This is because Shutdown is called on a goroutine to avoid a deadlock if it's called while holding the LocalBackend lock (#18052).

This fixes that cause of flakes by waiting for LocalBackend's goroutine tracker to have no goroutines running (so the goroutine that calls Shutdown must have finished).

This does not make TestStateMachine non-flaky because it can flake later in the test, too: the assertion on "unpause" after clearing the netmap between "Start4" and "Start4 -> netmap" sometimes fails.

Test plan: Run with stress before & after patch, flake % should drop a lot with this patch.

Updates tailscale/corp#36230
Updates #19377
Updates #18052