### PR TITLE
cmd/k8s-operator: treat NotFound as success when removing finalizer

### DIFF
--- a/cmd/k8s-operator/ingress.go
+++ b/cmd/k8s-operator/ingress.go
@@ -111,7 +111,11 @@ func (a *IngressReconciler) maybeCleanup(ctx context.Context, logger *zap.Sugare
 
 	ing.Finalizers = append(ing.Finalizers[:ix], ing.Finalizers[ix+1:]...)
 	if err := a.Update(ctx, ing); err != nil {
-		return fmt.Errorf("failed to remove finalizer: %w", err)
+		if apierrors.IsNotFound(err) {
+			logger.Debugf("ingress already deleted, finalizer removal not needed")
+		} else {
+			return fmt.Errorf("failed to remove finalizer: %w", err)
+		}
 	}
 
 	// Unlike most log entries in the reconcile loop, this will get printed

--- a/cmd/k8s-operator/svc.go
+++ b/cmd/k8s-operator/svc.go
@@ -175,7 +175,11 @@ func (a *ServiceReconciler) maybeCleanup(ctx context.Context, logger *zap.Sugare
 
 	svc.Finalizers = append(svc.Finalizers[:ix], svc.Finalizers[ix+1:]...)
 	if err := a.Update(ctx, svc); err != nil {
-		return fmt.Errorf("failed to remove finalizer: %w", err)
+		if apierrors.IsNotFound(err) {
+			logger.Debugf("service already deleted, finalizer removal not needed")
+		} else {
+			return fmt.Errorf("failed to remove finalizer: %w", err)
+		}
 	}
 
 	// Unlike most log entries in the reconcile loop, this will get printed


### PR DESCRIPTION
When an external controller (e.g. FluxCD ResourceSet) deletes an Ingress or Service between Cleanup() completing and the subsequent Update() call to remove the finalizer, the operator enters an infinite retry loop logging "failed to remove finalizer: ... not found".

This is safe to ignore; Cleanup() has already removed the Tailscale device from the API, and the resource no longer exists, so there's nothing left to finalize. This change treats IsNotFound on the finalizer-removal Update() as success in both ingress.go and svc.go.