### PR TITLE
tstest/integration/vms: skip cloud-init package updates

### DIFF
--- a/tstest/integration/vms/distros.go
+++ b/tstest/integration/vms/distros.go
@@ -35,11 +35,10 @@ func (d *Distro) InstallPre() string {
 		return ` - [ dnf, install, "-y", iptables ]`
 
 	case "apt":
-		return ` - [ apt-get, update ]
- - [ apt-get, "-y", install, curl, "apt-transport-https", gnupg2 ]`
+		return ` - [ apt-get, "-y", install, curl, "apt-transport-https", gnupg2 ]`
 
 	case "apk":
-		return ` - [ apk, "-U", add, curl, "ca-certificates", iptables, ip6tables ]
+		return ` - [ apk, add, curl, "ca-certificates", iptables, ip6tables ]
  - [ modprobe, tun ]`
 	}
 


### PR DESCRIPTION
The package updates started getting really slow yesterday. We can do better, but attempt a band aid fix for now, as the test is failing about a third of the time on PR CI.

Updates tailscale/corp#40465

Change-Id: Icf53292ba83dd1ed76b9bdf9fb94a8f6fb448c07