### PR TITLE
ipn/ipnlocal,types/netmap: add caching for services in node cap map

### DIFF
--- a/ipn/ipnlocal/c2n_test.go
+++ b/ipn/ipnlocal/c2n_test.go
@@ -220,6 +220,7 @@ func TestHandleC2NDebugNetmap(t *testing.T) {
 
 			if diff := gcmp.Diff(tt.want, got,
 				gcmp.AllowUnexported(netmap.NetworkMap{}, key.NodePublic{}, views.Slice[tailcfg.FilterRule]{}),
+				cmpopts.IgnoreFields(netmap.NetworkMap{}, "servicesCache"),
 				cmpopts.EquateComparable(key.MachinePublic{}),
 			); diff != "" {
 				t.Errorf("netmap mismatch (-want +got):\n%s", diff)

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -703,7 +703,7 @@ func TestLoadCachedNetMap(t *testing.T) {
 	// stored, modulo uncached fields.
 	nm := clb.currentNode().NetMap()
 	if diff := cmp.Diff(nm, testMap,
-		cmpopts.IgnoreFields(netmap.NetworkMap{}, "Cached", "PacketFilter", "PacketFilterRules"),
+		cmpopts.IgnoreFields(netmap.NetworkMap{}, "Cached", "PacketFilter", "PacketFilterRules", "servicesCache"),
 		cmpopts.EquateComparable(key.NodePublic{}, key.MachinePublic{}),
 	); diff != "" {
 		t.Error(diff)

--- a/ipn/ipnlocal/netmapcache/netmapcache_test.go
+++ b/ipn/ipnlocal/netmapcache/netmapcache_test.go
@@ -262,6 +262,7 @@ func TestInvalidCache(t *testing.T) {
 // network map caching, and thus skipped when comparing test results.
 var skippedMapFields = []string{
 	"Cached",
+	"servicesCache",
 }
 
 // checkFieldCoverage logs an error in t if any of the fields of nm are zero

--- a/types/netmap/netmap.go
+++ b/types/netmap/netmap.go
@@ -17,6 +17,7 @@ import (
 	"tailscale.com/tailcfg"
 	"tailscale.com/tka"
 	"tailscale.com/types/key"
+	"tailscale.com/types/lazy"
 	"tailscale.com/types/views"
 	"tailscale.com/util/set"
 	"tailscale.com/wgengine/filter/filtertype"
@@ -77,6 +78,9 @@ type NetworkMap struct {
 	// UserProfiles contains the profile information of UserIDs referenced
 	// in SelfNode and Peers.
 	UserProfiles map[tailcfg.UserID]tailcfg.UserProfileView
+
+	// servicesCache is the lazily-computed result of Services().
+	servicesCache lazy.SyncValue[map[string]tailcfg.ServiceDetails]
 }
 
 // User returns nm.SelfNode.User if nm.SelfNode is non-nil, otherwise it returns
@@ -150,27 +154,26 @@ func (nm *NetworkMap) GetIPVIPServiceMap() IPServiceMappings {
 // decoded from [tailcfg.NodeAttrPrefixServices] entries in the self node's
 // CapMap. The returned map is keyed by service name without the "svc:" prefix.
 // It returns nil if nm is nil or SelfNode is invalid.
-//
-// TODO(adrianosela): cache the result of decoding the capmap so
-// we don't have to decode it multiple times after each netmap update.
 func (nm *NetworkMap) Services() map[string]tailcfg.ServiceDetails {
 	if nm == nil || !nm.SelfNode.Valid() {
 		return nil
 	}
-	result := make(map[string]tailcfg.ServiceDetails)
-	for cap := range nm.SelfNode.CapMap().All() {
-		if !strings.HasPrefix(string(cap), string(tailcfg.NodeAttrPrefixServices)) {
-			continue
+	return nm.servicesCache.Get(func() map[string]tailcfg.ServiceDetails {
+		result := make(map[string]tailcfg.ServiceDetails)
+		for cap := range nm.SelfNode.CapMap().All() {
+			if !strings.HasPrefix(string(cap), string(tailcfg.NodeAttrPrefixServices)) {
+				continue
+			}
+			svcs, err := tailcfg.UnmarshalNodeCapViewJSON[tailcfg.ServiceDetails](nm.SelfNode.CapMap(), cap)
+			if err != nil || len(svcs) < 1 {
+				continue
+			}
+			// NOTE(adrianosela): the NodeCapMap key suffix is opaque and MUST not
+			// be parsed or relied upon (so we extract name from the inner field).
+			result[svcs[0].Name.WithoutPrefix()] = svcs[0]
 		}
-		svcs, err := tailcfg.UnmarshalNodeCapViewJSON[tailcfg.ServiceDetails](nm.SelfNode.CapMap(), cap)
-		if err != nil || len(svcs) < 1 {
-			continue
-		}
-		// NOTE(adrianosela): the NodeCapMap key suffix is opaque and MUST not
-		// be parsed or relied upon (so we extract name from the inner field).
-		result[svcs[0].Name.WithoutPrefix()] = svcs[0]
-	}
-	return result
+		return result
+	})
 }
 
 // SelfNodeOrZero returns the self node, or a zero value if nm is nil.


### PR DESCRIPTION
Caches the result of extracting services from the netmap's SelfNode capabilities map so we don't have to decode it multiple times after each netmap update.

Updates tailscale/corp#40052