### PR TITLE
ipn/ipnlocal: log the local and remote TKA HEADs during sync

### DIFF
--- a/ipn/ipnlocal/network-lock.go
+++ b/ipn/ipnlocal/network-lock.go
@@ -299,7 +299,11 @@ func (b *LocalBackend) tkaSyncIfNeeded(nm *netmap.NetworkMap, prefs ipn.PrefsVie
 	wantEnabled := nm.TKAEnabled
 
 	if isEnabled || wantEnabled {
-		b.logf("tkaSyncIfNeeded: isEnabled=%t, wantEnabled=%t, head=%v", isEnabled, wantEnabled, nm.TKAHead)
+		nodeHead := "<not-enabled>"
+		if b.tka != nil {
+			nodeHead = b.tka.authority.Head().String()
+		}
+		b.logf("tkaSyncIfNeeded: isEnabled=%t, wantEnabled=%t, nodeHead=%v, netmapHead=%v", isEnabled, wantEnabled, nodeHead, nm.TKAHead)
 	}
 
 	ourNodeKey, ok := prefs.Persist().PublicNodeKeyOK()


### PR DESCRIPTION
Update this log message to show both the local and remote TKA HEAD; this is useful for debugging issues on nodes that have fallen behind the remote TKA HEAD.

Updates tailscale/corp#39455