### PR TITLE
net/sockopts: fix TestSetBufferSize on machines with high default buffer sizes

### DIFF
--- a/net/sockopts/sockopts_unix_test.go
+++ b/net/sockopts/sockopts_unix_test.go
@@ -47,15 +47,15 @@ func TestSetBufferSize(t *testing.T) {
 
 	newRcv, newSnd := getBufs()
 
-	if curRcv > newRcv {
-		t.Errorf("SO_RCVBUF decreased: %v -> %v", curRcv, newRcv)
+	if newRcv < 7<<20 {
+		t.Errorf("SO_RCVBUF (%v) is below target (%v)", newRcv, 7<<20)
 	}
-	if curSnd > newSnd {
-		t.Errorf("SO_SNDBUF decreased: %v -> %v", curSnd, newSnd)
+	if newSnd < 7<<20 {
+		t.Errorf("SO_SNDBUF (%v) is below target (%v)", newSnd, 7<<20)
 	}
 
 	// On many systems we may not increase the value, particularly running as a
 	// regular user, so log the information for manual verification.
 	t.Logf("SO_RCVBUF: %v -> %v", curRcv, newRcv)
-	t.Logf("SO_SNDBUF: %v -> %v", curRcv, newRcv)
+	t.Logf("SO_SNDBUF: %v -> %v", curSnd, newSnd)
 }


### PR DESCRIPTION
Fixes #15994

## Problem
The test `TestSetBufferSize` was failing on machines where the system default socket buffer size is already higher than Tailscale's target (7MB). The previous assertion checked `cur > new` (buffer decreased), which would fail when the kernel doesn't increase an already-large buffer to exactly 7MB.

## Root Cause
On systems with `net.core.wmem_default` higher than 7MB, calling `setsockopt` with a lower value may not increase the buffer further (expected), but the test incorrectly treated this as a failure.

## Solution
Changed the assertion from:
- `if curRcv > newRcv` (fail if buffer decreased from current)
- → `if newRcv < 7<<20` (fail only if buffer is below target minimum)

This correctly handles systems with high default buffers — the buffer being larger than 7MB is the desired outcome.

## Additional Fix
Also fixed a pre-existing typo in the SO_SNDBUF log line where `curRcv` was logged instead of `curSnd`.

cc @tailscale/maintainers-net