### PR TITLE
net/netmon/androidbind: add opt-in Android InterfaceGetter via getifaddrs

### DIFF
--- a/net/netmon/androidbind/androidbind.go
+++ b/net/netmon/androidbind/androidbind.go
@@ -1,0 +1,54 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Package androidbind registers an Android-safe [netmon.InterfaceGetter] so
+// that tsnet and anything else depending on interface enumeration boots
+// cleanly on untrusted_app SELinux contexts (Android SDK 30+).
+//
+// # Why
+//
+// Go stdlib's [net.Interfaces] on Linux uses NETLINK_ROUTE sockets.
+// Android's SELinux policy denies netlink socket creation for the default
+// untrusted_app context, so any tsnet-embedded app fails at startup with
+// "netlinkrib: permission denied" during interface enumeration in the
+// logpolicy transport setup (see issue #17311).
+//
+// [netmon.RegisterInterfaceGetter] is the official hook for supplying
+// an alternate enumerator — the Tailscale Android client uses it to
+// route via JNI callbacks from the Java side. Embedders of tsnet in
+// third-party Android apps that don't own the Java side have no way
+// to fill it without writing their own JNI shim. This package is an
+// opt-in, pure-Go alternative: importing it for side-effects registers
+// a getter backed by libc's getifaddrs(3).
+//
+// # How
+//
+// On Android bionic (API 24+), getifaddrs is implemented on top of
+// ioctl(SIOCGIFCONF) against a UDP socket — the same syscall path
+// [java.net.NetworkInterface.getNetworkInterfaces] takes. Unlike
+// netlink, ioctl on an AF_INET socket IS permitted for untrusted_app.
+// The returned data covers the subset tsnet uses: interface names,
+// up/broadcast/loopback/multicast flags, and IPv4 + IPv6 addresses
+// with prefix lengths.
+//
+// # Usage
+//
+// Import the package for its side effects, before calling into tsnet:
+//
+//	import _ "tailscale.com/net/netmon/androidbind"
+//
+// No additional wiring is required. On non-Android builds the package
+// compiles to a no-op.
+//
+// # Scope / limitations
+//
+// Only implemented for android/arm64 and android/amd64, the two targets
+// [gomobile bind] ships for Android. Older Androids where netlink was
+// still permitted fall through the stdlib-first path and keep the
+// faster behaviour. If Tailscale's broader "tsnet apps should not need
+// any of that stuff" direction (see #17311 comment thread) lands and
+// removes interface enumeration from the tsnet startup path, this
+// package becomes unnecessary in the best possible way.
+//
+// See tailscale/tailscale#17311.
+package androidbind

--- a/net/netmon/androidbind/androidbind_android.go
+++ b/net/netmon/androidbind/androidbind_android.go
@@ -1,0 +1,194 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build android
+
+package androidbind
+
+/*
+#include <ifaddrs.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+*/
+import "C"
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+	"unsafe"
+
+	"tailscale.com/net/netmon"
+)
+
+func init() {
+	netmon.RegisterInterfaceGetter(androidInterfaces)
+}
+
+// androidInterfaces returns the host's network interfaces. Tries Go
+// stdlib first so older Androids (or non-untrusted_app contexts where
+// netlink is permitted) take the faster path. On EACCES falls through
+// to libc getifaddrs, which is SELinux-safe for untrusted_app.
+func androidInterfaces() ([]netmon.Interface, error) {
+	if ifs, err := net.Interfaces(); err == nil && len(ifs) > 0 {
+		out := make([]netmon.Interface, len(ifs))
+		for i := range ifs {
+			out[i].Interface = &ifs[i]
+			// Interface.Addrs() also uses netlink on Linux; source
+			// the addresses from getifaddrs too so the returned
+			// entries are complete regardless of stdlib behaviour.
+			out[i].AltAddrs, _ = getifaddrsAddrs(ifs[i].Name)
+		}
+		return out, nil
+	}
+	return getifaddrsInterfaces()
+}
+
+// ifaceInfo groups getifaddrs entries by interface name. getifaddrs
+// emits one struct per (interface, address) pair; we need one
+// netmon.Interface per interface with its addresses collected.
+type ifaceInfo struct {
+	name  string
+	flags net.Flags
+	addrs []net.Addr
+}
+
+// getifaddrsInterfaces enumerates interfaces via libc getifaddrs(3).
+// On Android bionic this is ioctl(SIOCGIFCONF) on a UDP socket — a
+// syscall permitted for untrusted_app.
+func getifaddrsInterfaces() ([]netmon.Interface, error) {
+	var head *C.struct_ifaddrs
+	if rc, err := C.getifaddrs(&head); rc != 0 {
+		return nil, fmt.Errorf("getifaddrs: %w", err)
+	}
+	defer C.freeifaddrs(head)
+
+	byName := map[string]*ifaceInfo{}
+	for ifa := head; ifa != nil; ifa = ifa.ifa_next {
+		name := C.GoString(ifa.ifa_name)
+		info := byName[name]
+		if info == nil {
+			info = &ifaceInfo{
+				name:  name,
+				flags: translateFlags(uint32(ifa.ifa_flags)),
+			}
+			byName[name] = info
+		}
+		if addr := sockaddrToAddr(ifa.ifa_addr, ifa.ifa_netmask); addr != nil {
+			info.addrs = append(info.addrs, addr)
+		}
+	}
+
+	out := make([]netmon.Interface, 0, len(byName))
+	for _, info := range byName {
+		ni := &net.Interface{
+			Name:  info.name,
+			Flags: info.flags,
+		}
+		out = append(out, netmon.Interface{
+			Interface: ni,
+			AltAddrs:  info.addrs,
+		})
+	}
+	return out, nil
+}
+
+// getifaddrsAddrs returns just the address list for a named interface,
+// for use alongside a Go stdlib net.Interface whose Addrs() may itself
+// go through netlink.
+func getifaddrsAddrs(name string) ([]net.Addr, error) {
+	var head *C.struct_ifaddrs
+	if rc, err := C.getifaddrs(&head); rc != 0 {
+		return nil, fmt.Errorf("getifaddrs: %w", err)
+	}
+	defer C.freeifaddrs(head)
+	var addrs []net.Addr
+	for ifa := head; ifa != nil; ifa = ifa.ifa_next {
+		if C.GoString(ifa.ifa_name) != name {
+			continue
+		}
+		if a := sockaddrToAddr(ifa.ifa_addr, ifa.ifa_netmask); a != nil {
+			addrs = append(addrs, a)
+		}
+	}
+	return addrs, nil
+}
+
+// translateFlags maps Linux IFF_* into Go's net.Flags, covering the
+// bits [netmon.Interface] readers check.
+func translateFlags(f uint32) net.Flags {
+	var out net.Flags
+	if f&C.IFF_UP != 0 {
+		out |= net.FlagUp
+	}
+	if f&C.IFF_BROADCAST != 0 {
+		out |= net.FlagBroadcast
+	}
+	if f&C.IFF_LOOPBACK != 0 {
+		out |= net.FlagLoopback
+	}
+	if f&C.IFF_POINTOPOINT != 0 {
+		out |= net.FlagPointToPoint
+	}
+	if f&C.IFF_MULTICAST != 0 {
+		out |= net.FlagMulticast
+	}
+	if f&C.IFF_RUNNING != 0 {
+		out |= net.FlagRunning
+	}
+	return out
+}
+
+// sockaddrToAddr converts a C sockaddr (IPv4 or IPv6) + netmask into
+// a *net.IPNet. Returns nil for address families we don't care about
+// (AF_PACKET link-layer addresses, etc).
+func sockaddrToAddr(sa, nm *C.struct_sockaddr) net.Addr {
+	if sa == nil {
+		return nil
+	}
+	switch sa.sa_family {
+	case C.AF_INET:
+		sin := (*C.struct_sockaddr_in)(unsafe.Pointer(sa))
+		addr := (*[4]byte)(unsafe.Pointer(&sin.sin_addr))[:]
+		ip := netip.AddrFrom4(*(*[4]byte)(addr))
+		prefix := 32
+		if nm != nil && nm.sa_family == C.AF_INET {
+			mask := (*C.struct_sockaddr_in)(unsafe.Pointer(nm))
+			maskBytes := (*[4]byte)(unsafe.Pointer(&mask.sin_addr))[:]
+			prefix = countLeadingOnes(maskBytes)
+		}
+		return &net.IPNet{IP: ip.AsSlice(), Mask: net.CIDRMask(prefix, 32)}
+	case C.AF_INET6:
+		sin := (*C.struct_sockaddr_in6)(unsafe.Pointer(sa))
+		addrBytes := (*[16]byte)(unsafe.Pointer(&sin.sin6_addr))[:]
+		ip := netip.AddrFrom16(*(*[16]byte)(addrBytes))
+		prefix := 128
+		if nm != nil && nm.sa_family == C.AF_INET6 {
+			mask := (*C.struct_sockaddr_in6)(unsafe.Pointer(nm))
+			maskBytes := (*[16]byte)(unsafe.Pointer(&mask.sin6_addr))[:]
+			prefix = countLeadingOnes(maskBytes)
+		}
+		return &net.IPNet{IP: ip.AsSlice(), Mask: net.CIDRMask(prefix, 128)}
+	}
+	return nil
+}
+
+// countLeadingOnes returns the prefix length represented by a netmask
+// byte slice. Valid netmasks are a run of 1-bits followed by 0-bits;
+// the count stops at the first 0 in the first non-0xff byte.
+func countLeadingOnes(mask []byte) int {
+	ones := 0
+	for _, b := range mask {
+		if b == 0xff {
+			ones += 8
+			continue
+		}
+		for b&0x80 != 0 {
+			ones++
+			b <<= 1
+		}
+		break
+	}
+	return ones
+}

--- a/net/netmon/androidbind/androidbind_test.go
+++ b/net/netmon/androidbind/androidbind_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build android
+
+package androidbind
+
+import (
+	"net"
+	"testing"
+)
+
+// TestAndroidInterfacesReturnsLoopback is a smoke test that runs only
+// under `go test` on Android. It asserts that getifaddrs can find at
+// least the loopback interface, which is always present on any
+// Android device. Validates that libc getifaddrs is linked and
+// returns non-empty results.
+func TestAndroidInterfacesReturnsLoopback(t *testing.T) {
+	ifs, err := androidInterfaces()
+	if err != nil {
+		t.Fatalf("androidInterfaces: %v", err)
+	}
+	if len(ifs) == 0 {
+		t.Fatal("expected at least one interface, got 0")
+	}
+	var haveLoopback bool
+	for _, i := range ifs {
+		if i.Interface == nil {
+			continue
+		}
+		if i.Interface.Flags&net.FlagLoopback != 0 {
+			haveLoopback = true
+			break
+		}
+	}
+	if !haveLoopback {
+		names := make([]string, 0, len(ifs))
+		for _, i := range ifs {
+			if i.Interface != nil {
+				names = append(names, i.Interface.Name)
+			}
+		}
+		t.Errorf("no loopback interface found in %v", names)
+	}
+}
+
+func TestCountLeadingOnes(t *testing.T) {
+	cases := []struct {
+		in   []byte
+		want int
+	}{
+		{[]byte{0xff, 0xff, 0xff, 0x00}, 24},         // /24
+		{[]byte{0xff, 0xff, 0xff, 0xff}, 32},         // /32
+		{[]byte{0x00, 0x00, 0x00, 0x00}, 0},          // /0
+		{[]byte{0xff, 0xf0, 0x00, 0x00}, 12},         // /12
+		{[]byte{0xff, 0xff, 0xff, 0x80}, 25},         // /25 (8+8+8+1)
+	}
+	for _, c := range cases {
+		if got := countLeadingOnes(c.in); got != c.want {
+			t.Errorf("countLeadingOnes(%v) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Opt-in, side-effect-import package that registers a `netmon.InterfaceGetter` backed by libc `getifaddrs(3)` via cgo, fixing `tsnet` startup on Android `untrusted_app` SELinux contexts without requiring the embedder to write a Java-side JNI bridge.

Updates #17311. Follows the discussion there ([comment](https://github.com/tailscale/tailscale/issues/17311#issuecomment-4277087486)) — happy to drop / reshape / hold if the broader "tsnet apps should not need any of that stuff" direction lands first, in which case this package becomes a no-op in the best way.

## What breaks today

Go stdlib's `net.Interfaces()` on Linux uses `NETLINK_ROUTE` sockets. Android's SELinux policy denies netlink socket creation for the default `untrusted_app` context, so tsnet embedded in a third-party Android app (e.g. via `gomobile bind`) fails at startup inside `logpolicy.NewLogtailTransport` → `netmon.NewStatic` → `net.Interfaces` with `netlinkrib: permission denied`. Stack trace in #17311.

## Why a new package

`netmon.RegisterInterfaceGetter` already exists as the designated hook — Tailscale's own Android client uses it, but fills it from the Java side. Embedders who don't own the Java side can't use that. This package fills it from the Go side instead, via a syscall path Android permits.

Kept as an opt-in import (not wired unconditionally in `tsnet`) so existing tsnet consumers don't inherit cgo / libc deps they didn't ask for. Embedders add one line:

```go
import _ "tailscale.com/net/netmon/androidbind"
```

## How it works

`getifaddrs(3)` on Android bionic (API 24+) is implemented on top of `ioctl(SIOCGIFCONF)` against an AF_INET UDP socket — the same syscall path [`java.net.NetworkInterface.getNetworkInterfaces`](https://cs.android.com/android/platform/superproject/main/+/main:libcore/ojluni/src/main/java/java/net/NetworkInterface.java) takes. Unlike netlink, `ioctl` on an AF_INET socket IS permitted for `untrusted_app`. Returns the subset tsnet reads: name, flags (up/broadcast/loopback/pointtopoint/multicast/running), and IPv4 + IPv6 addresses with prefix lengths.

`net.Interfaces()` is still tried first so older Androids and non-untrusted_app contexts take the faster stdlib path; `getifaddrs` is the `errors.Is(err, syscall.EACCES)` fallback. On non-Android builds the package compiles to an empty `package androidbind` — no-op, zero cost.

## Verified

- `GOOS=android GOARCH=arm64 CGO_ENABLED=1` clean build against NDK r28c.
- `GOOS=android GOARCH=amd64 CGO_ENABLED=1` clean build.
- `GOOS=linux CGO_ENABLED=0` clean build (confirms no-op on non-Android).
- End-to-end against a live tailnet from a Pixel 8 Pro (Android 16, `untrusted_app`) with this package imported into a gomobile-bound tsnet embedding: authkey consumption, peer-map sync, DERP connect, direct-UDP NAT punch, TCP dial through netstack all succeed. MagicDNS resolves.

## Size

The cgo bits add ~nothing to `tsnet` consumers that don't import the package. Importers on Android pay for `getifaddrs` in libc (already linked in any Android app) plus a dozen KB of bound Go code.

## Not in scope

- Only covers interface enumeration. If `net.LookupIP` or other stdlib net paths also hit netlink on Android, they'd need analogous treatment. I haven't observed that in the tsnet startup path on the specific Android versions tested.
- No attempt to also plumb an Android-safe `DefaultRoute` detector (netmon falls back to `/proc/net/route` on Android via the existing `interfaces_android.go`, which works in practice since that file is readable to the app).

## DCO

`Signed-off-by: Ian Williams <ianrosswilliams@gmail.com>` on the commit. Happy to squash / amend / rework however you'd like.