### PR TITLE
types/netmap,client/local: modify services format in local api

### DIFF
--- a/client/local/local.go
+++ b/client/local/local.go
@@ -1424,12 +1424,11 @@ func (lc *Client) GetAppConnectorRouteInfo(ctx context.Context) (appctype.RouteI
 }
 
 // GetServices returns the Services visible to this node,
-// including their names, IP addresses, and ports, keyed by service name
-// without the "svc:" prefix.
-func (lc *Client) GetServices(ctx context.Context) (map[string]tailcfg.ServiceDetails, error) {
+// including their names, IP addresses, and ports, keyed by service name.
+func (lc *Client) GetServices(ctx context.Context) (map[tailcfg.ServiceName]tailcfg.ServiceDetails, error) {
 	body, err := lc.get200(ctx, "/localapi/v0/services")
 	if err != nil {
 		return nil, err
 	}
-	return decodeJSON[map[string]tailcfg.ServiceDetails](body)
+	return decodeJSON[map[tailcfg.ServiceName]tailcfg.ServiceDetails](body)
 }

--- a/types/netmap/netmap.go
+++ b/types/netmap/netmap.go
@@ -148,16 +148,17 @@ func (nm *NetworkMap) GetIPVIPServiceMap() IPServiceMappings {
 
 // Services returns the Services visible (accessible) to this node,
 // decoded from [tailcfg.NodeAttrPrefixServices] entries in the self node's
-// CapMap. The returned map is keyed by service name without the "svc:" prefix.
-// It returns nil if nm is nil or SelfNode is invalid.
+// CapMap. The returned map is keyed by [tailcfg.ServiceDetails.Name],
+// which is the canonical service name. It returns nil if nm is nil
+// or SelfNode is invalid.
 //
 // TODO(adrianosela): cache the result of decoding the capmap so
 // we don't have to decode it multiple times after each netmap update.
-func (nm *NetworkMap) Services() map[string]tailcfg.ServiceDetails {
+func (nm *NetworkMap) Services() map[tailcfg.ServiceName]tailcfg.ServiceDetails {
 	if nm == nil || !nm.SelfNode.Valid() {
 		return nil
 	}
-	result := make(map[string]tailcfg.ServiceDetails)
+	result := make(map[tailcfg.ServiceName]tailcfg.ServiceDetails)
 	for cap := range nm.SelfNode.CapMap().All() {
 		if !strings.HasPrefix(string(cap), string(tailcfg.NodeAttrPrefixServices)) {
 			continue
@@ -168,7 +169,7 @@ func (nm *NetworkMap) Services() map[string]tailcfg.ServiceDetails {
 		}
 		// NOTE(adrianosela): the NodeCapMap key suffix is opaque and MUST not
 		// be parsed or relied upon (so we extract name from the inner field).
-		result[svcs[0].Name.WithoutPrefix()] = svcs[0]
+		result[svcs[0].Name] = svcs[0]
 	}
 	return result
 }


### PR DESCRIPTION
Reverting back to the previous format (including
the "svc:" prefix in the map's keys).

Note that the /services endpoint in localapi, along with any software that relies on this is unreleased so this does not break any clients.

Updates tailscale/corp#40052