### PR TITLE
logtail: add Config.Disabled to suppress the startup banner, make tests fast

### DIFF
--- a/logtail/config.go
+++ b/logtail/config.go
@@ -64,4 +64,12 @@ type Config struct {
 	// being included in the logs. The sequence number is incremented for each
 	// log message sent, but is not persisted across process restarts.
 	IncludeProcSequence bool
+
+	// Disabled, if true, causes the returned [Logger] to start in the
+	// disabled state, dropping entries without buffering or uploading
+	// (equivalent to calling [Logger.SetEnabled] with false immediately).
+	// It applies before the internal startup banner is written, so no
+	// log entries are emitted until [Logger.SetEnabled] is called with
+	// true. The process-wide [Disable] kill switch still takes precedence.
+	Disabled bool
 }

--- a/logtail/logtail.go
+++ b/logtail/logtail.go
@@ -132,6 +132,7 @@ func NewLogger(cfg Config, logf tslogger.Logf) *Logger {
 	}
 	logger.SetSockstatsLabel(sockstats.LabelLogtailLogger)
 	logger.compressLogs = cfg.CompressLogs
+	logger.disabled.Store(cfg.Disabled)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	logger.uploadCancel = cancel

--- a/logtail/logtail_test.go
+++ b/logtail/logtail_test.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"strings"
 	"sync"
@@ -20,6 +19,7 @@ import (
 	"time"
 
 	"github.com/go-json-experiment/json/jsontext"
+	"tailscale.com/net/memnet"
 	"tailscale.com/tstest"
 	"tailscale.com/tstime"
 	"tailscale.com/util/eventbus/eventbustest"
@@ -30,6 +30,7 @@ import (
 // test in this package. Config.BaseURL defaults to https://log.tailscale.com
 // and Config.HTTPC defaults to http.DefaultClient, so a test that forgets to
 // override either can otherwise silently hit the real logtail server.
+// Tests that need an HTTP server should use memnet (see newTestLogtailServer).
 func TestMain(m *testing.M) {
 	tr := http.DefaultTransport.(*http.Transport)
 	orig := tr.DialContext
@@ -38,25 +39,19 @@ func TestMain(m *testing.M) {
 		if err == nil && (host == "127.0.0.1" || host == "::1" || host == "localhost") {
 			return orig(ctx, network, addr)
 		}
-		return nil, fmt.Errorf("logtail tests: refusing to dial non-localhost address %q; use httptest.Server or a custom Config.HTTPC", addr)
+		return nil, fmt.Errorf("logtail tests: refusing to dial non-localhost address %q; use memnet or a custom Config.HTTPC", addr)
 	}
 	os.Exit(m.Run())
 }
 
-func TestFastShutdown(t *testing.T) {
+func TestFastShutdown(t *testing.T) { synctest.Test(t, synctestFastShutdown) }
+
+func synctestFastShutdown(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	testServ := httptest.NewServer(http.HandlerFunc(
-		func(w http.ResponseWriter, r *http.Request) {}))
-	defer testServ.Close()
-
-	logger := NewLogger(Config{
-		BaseURL: testServ.URL,
-		Bus:     eventbustest.NewBus(t),
-	}, t.Logf)
-	err := logger.Shutdown(ctx)
-	if err != nil {
+	_, logger := newTestLogtailServer(t)
+	if err := logger.Shutdown(ctx); err != nil {
 		t.Error(err)
 	}
 }
@@ -65,49 +60,60 @@ func TestFastShutdown(t *testing.T) {
 const logLines = 3
 
 type LogtailTestServer struct {
-	srv      *httptest.Server // Log server
 	uploaded chan []byte
 }
 
-func NewLogtailTestHarness(t *testing.T) (*LogtailTestServer, *Logger) {
-	ts := LogtailTestServer{}
+// newTestLogtailServer wires up an in-memory HTTP server (via memnet) and a
+// *Logger whose HTTPC dials it. Lives inside the caller's synctest bubble so
+// the default FlushDelay and any other fake timers advance automatically.
+func newTestLogtailServer(t *testing.T) (*LogtailTestServer, *Logger) {
+	ts := &LogtailTestServer{
+		// max channel backlog = 1 "started" + #logLines x "log line" + 1 "closed"
+		uploaded: make(chan []byte, 2+logLines),
+	}
 
-	// max channel backlog = 1 "started" + #logLines x "log line" + 1 "closed"
-	ts.uploaded = make(chan []byte, 2+logLines)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Error("failed to read HTTP request")
+		}
+		ts.uploaded <- body
+	})
 
-	ts.srv = httptest.NewServer(http.HandlerFunc(
-		func(w http.ResponseWriter, r *http.Request) {
-			body, err := io.ReadAll(r.Body)
-			if err != nil {
-				t.Error("failed to read HTTP request")
-			}
-			ts.uploaded <- body
-		}))
-
-	t.Cleanup(ts.srv.Close)
+	ln := memnet.Listen("logtail-test:0")
+	httpsrv := &http.Server{Handler: handler}
+	go httpsrv.Serve(ln)
+	t.Cleanup(func() {
+		httpsrv.Close()
+		ln.Close()
+	})
 
 	logger := NewLogger(Config{
-		BaseURL: ts.srv.URL,
+		BaseURL: "http://" + ln.Addr().String(),
 		Bus:     eventbustest.NewBus(t),
+		HTTPC: &http.Client{
+			Transport: &http.Transport{DialContext: ln.Dial},
+		},
 	}, t.Logf)
 
-	// There is always an initial "logtail started" message
+	// There is always an initial "logtail started" message.
 	body := <-ts.uploaded
 	if !strings.Contains(string(body), "started") {
 		t.Errorf("unknown start logging statement: %q", string(body))
 	}
-
-	return &ts, logger
+	return ts, logger
 }
 
-func TestDrainPendingMessages(t *testing.T) {
-	ts, logger := NewLogtailTestHarness(t)
+func TestDrainPendingMessages(t *testing.T) { synctest.Test(t, synctestDrainPendingMessages) }
+
+func synctestDrainPendingMessages(t *testing.T) {
+	ts, logger := newTestLogtailServer(t)
 
 	for range logLines {
 		logger.Write([]byte("log line"))
 	}
 
-	// all of the "log line" messages usually arrive at once, but poll if needed.
+	// All the "log line" messages usually arrive at once, but poll if needed.
 	var body strings.Builder
 	for i := 0; i <= logLines; i++ {
 		body.WriteString(string(<-ts.uploaded))
@@ -115,17 +121,17 @@ func TestDrainPendingMessages(t *testing.T) {
 		if count == logLines {
 			break
 		}
-		// if we never find count == logLines, the test will eventually time out.
 	}
 
-	err := logger.Shutdown(context.Background())
-	if err != nil {
+	if err := logger.Shutdown(context.Background()); err != nil {
 		t.Error(err)
 	}
 }
 
-func TestEncodeAndUploadMessages(t *testing.T) {
-	ts, logger := NewLogtailTestHarness(t)
+func TestEncodeAndUploadMessages(t *testing.T) { synctest.Test(t, synctestEncodeAndUploadMessages) }
+
+func synctestEncodeAndUploadMessages(t *testing.T) {
+	ts, logger := newTestLogtailServer(t)
 
 	tests := []struct {
 		name string
@@ -166,8 +172,7 @@ func TestEncodeAndUploadMessages(t *testing.T) {
 		}
 	}
 
-	err := logger.Shutdown(context.Background())
-	if err != nil {
+	if err := logger.Shutdown(context.Background()); err != nil {
 		t.Error(err)
 	}
 }

--- a/logtail/logtail_test.go
+++ b/logtail/logtail_test.go
@@ -7,11 +7,16 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
+	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/go-json-experiment/json/jsontext"
@@ -20,6 +25,23 @@ import (
 	"tailscale.com/util/eventbus/eventbustest"
 	"tailscale.com/util/must"
 )
+
+// TestMain installs a safety net that refuses non-localhost dials for any
+// test in this package. Config.BaseURL defaults to https://log.tailscale.com
+// and Config.HTTPC defaults to http.DefaultClient, so a test that forgets to
+// override either can otherwise silently hit the real logtail server.
+func TestMain(m *testing.M) {
+	tr := http.DefaultTransport.(*http.Transport)
+	orig := tr.DialContext
+	tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, _, err := net.SplitHostPort(addr)
+		if err == nil && (host == "127.0.0.1" || host == "::1" || host == "localhost") {
+			return orig(ctx, network, addr)
+		}
+		return nil, fmt.Errorf("logtail tests: refusing to dial non-localhost address %q; use httptest.Server or a custom Config.HTTPC", addr)
+	}
+	os.Exit(m.Run())
+}
 
 func TestFastShutdown(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -318,6 +340,59 @@ func TestLoggerWriteResult(t *testing.T) {
 	}
 	if got, want := string(back), `{"logtail":{"client_time":"1970-01-01T00:02:03Z"},"v":1,"text":"foo"}`+"\n"; got != want {
 		t.Errorf("mismatch.\n got: %#q\nwant: %#q", back, want)
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestNewLoggerDisabled(t *testing.T) { synctest.Test(t, synctestNewLoggerDisabled) }
+
+func synctestNewLoggerDisabled(t *testing.T) {
+	// When Config.Disabled is true, NewLogger must not emit the usual
+	// "logtail started" banner: the logger should start in the disabled
+	// state before the internal startup write, so nothing ever lands
+	// in the buffer for the upload goroutine to drain.
+	buf := NewMemoryBuffer(100)
+
+	// Any HTTP attempt indicates the banner leaked into the buffer and
+	// the upload goroutine tried to ship it. Report it once (so the
+	// retry spin doesn't drown the log), then block on the request
+	// context so synctest.Wait sees a durable block and Shutdown's
+	// uploadCancel can unblock us cleanly.
+	var once sync.Once
+	httpc := &http.Client{
+		Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			once.Do(func() {
+				t.Errorf("unexpected HTTP request while Disabled=true: %s", r.URL)
+			})
+			<-r.Context().Done()
+			return nil, r.Context().Err()
+		}),
+	}
+
+	logger := NewLogger(Config{
+		BaseURL:  "http://logtail.test.invalid",
+		HTTPC:    httpc,
+		Bus:      eventbustest.NewBus(t),
+		Buffer:   buf,
+		Disabled: true,
+	}, t.Logf)
+	defer func() {
+		// Pass an already-cancelled context so Shutdown invokes
+		// uploadCancel immediately; otherwise on the regression path
+		// (Disabled=false) the upload goroutine stays in its retry
+		// loop and synctest.Test never returns.
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		logger.Shutdown(ctx)
+	}()
+
+	synctest.Wait()
+
+	if back, _ := buf.TryReadLine(); len(back) != 0 {
+		t.Errorf("Disabled logger buffered a startup entry: %q", back)
 	}
 }
 


### PR DESCRIPTION
Two commits

----

logtail: add Config.Disabled to suppress the startup banner

NewLogger unconditionally writes a "logtail started" banner before
it returns, which callers that later call Logger.SetEnabled(false)
have no way to suppress: the banner is already buffered for upload
by the time the caller gets the logger back.

Add Config.Disabled so callers that know up front they want the
logger to start disabled (e.g. Android's remote-logging opt-out)
can seed the state before NewLogger's internal Write. The process-
wide Disable kill switch still takes precedence; SetEnabled can
still flip the state at runtime.

Updates #13174

-----

TestEncodeAndUploadMessages waited on the default 2s FlushDelay,
making the logtail package the slowest non-integration test in
the tree (~2s real time). Switch the shared harness from an
httptest.Server-on-loopback to a memnet.Listener-backed *http.Server
and run the tests inside synctest.Test, so fake time advances the
flush timer instantly.

Drops the net/http/httptest dependency from these tests. Combined
with the TestMain non-localhost dial guard added in the previous
commit, no test in this package can accidentally reach the real
log.tailscale.com server. Whole package now runs in ~7ms.

Updates tailscale/corp#28679
