### PR TITLE
tailcfg: extend services model for client application actions

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -3349,17 +3349,49 @@ const LBHeader = "Ts-Lb"
 // this client is hosting can be ignored.
 type ServiceIPMappings map[ServiceName][]netip.Addr
 
+// ServiceAction describes an action that a Tailscale
+// client can invoke for a [ServiceDetails].
+type ServiceAction struct {
+	// Type is the action's identifier i.e. a unique slug corresponding to a well
+	// known action. It drives icon selection and client application matching.
+	Type string
+
+	// Port is the target TCP port for this action. It must match one of
+	// the specific (non-range) TCP ports listed in the enclosing
+	// [ServiceDetails.Ports].
+	Port uint16
+
+	// DisplayName is an optional human-readable label which may be shown
+	// in client menus when there are multiple actions to select from.
+	// If empty, a display name may be inferred from the Type field.
+	DisplayName string `json:",omitzero"`
+}
+
 // ServiceDetails describes a Service visible to this node.
 // It is the value type stored under [NodeAttrPrefixServices]+serviceName keys in [NodeCapMap].
 type ServiceDetails struct {
 	// Name is the name of the Service, of the form "svc:dns-label".
 	Name ServiceName
 
+	// DisplayName is an optional human-readable label for the service.
+	// If empty, Name is used as a fallback by clients.
+	DisplayName string `json:",omitzero"`
+
 	// Addrs are the IP addresses (IPv4 and IPv6) assigned to this Service.
 	Addrs []netip.Addr `json:",omitempty"`
 
 	// Ports are the protocol/port combinations the Service accepts.
 	Ports []ProtoPortRange `json:",omitempty"`
+
+	// Actions is an optional list of actions describing how a client may
+	// interact with this service. Each action maps a [ServiceAction.Type] to a
+	// specific TCP port; the port must match one of the concrete (non-range)
+	// ports listed in Ports.
+	//
+	// Multiple actions may reference the same port. Not every port requires
+	// a corresponding action. When Actions has length zero, clients may infer
+	// default interactions from Ports.
+	Actions []ServiceAction `json:",omitzero"`
 }
 
 // ClientAuditAction represents an auditable action that a client can report to the


### PR DESCRIPTION
## tailcfg: extend services model for client application actions

Border0 made it incredibly easy for client users (users of services a.k.a. sockets) to open their favorite native client application for a given service, based on its type. For example:
- selecting an SSH service would ask you which terminal application to open (iTerm2, Terminal, etc)
- selecting a MySQL service would ask you which mysql client to open (mysql cli, DBeaver, TablePlus, etc)
- selecting a Kubernetes service would configure a new kubernetes context and set the current context to that, etc
- ...

The idea is to extend this same UX to the Tailscale desktop applications (MacOS, Windows, Linux). Currently, services are already being served over the local api, but they lack context of what the application layer protocol is - so that the desktop clients are able to suggest appropriate client applications to open the service with.

For most Border0 services this can be inferred from the port (because the port on the VIP is always the default port for whatever the application layer protocol is), except for some special cases like Kubernetes where the port is 80/443, and we cannot assume its Kubernetes (since 80/443 are just the default http/https ports and don't tell us that its a k8s api server).

For this reason, we are extending services with an `Actions` optional field.

Updates: tailscale/corp#40648