### PR TITLE
util/eventbus: check for extra events in a test stream

### DIFF
--- a/util/eventbus/eventbustest/eventbustest.go
+++ b/util/eventbus/eventbustest/eventbustest.go
@@ -119,14 +119,6 @@ func Expect(tw *Watcher, filters ...any) error {
 // you are testing for the absence of events, call [synctest.Wait] after
 // actions that would publish an event, but before calling ExpectExactly.
 func ExpectExactly(tw *Watcher, filters ...any) error {
-	if len(filters) == 0 {
-		select {
-		case event := <-tw.events:
-			return fmt.Errorf("saw event type %s, expected none", reflect.TypeOf(event))
-		case <-time.After(100 * time.Second): // "indefinitely", to advance a synctest clock
-			return nil
-		}
-	}
 	eventCount := 0
 	for pos, next := range filters {
 		eventFunc := eventFilter(next)
@@ -153,6 +145,12 @@ func ExpectExactly(tw *Watcher, filters ...any) error {
 		case <-tw.chDone:
 			return errors.New("watcher closed while waiting for events")
 		}
+	}
+	select {
+	case event := <-tw.events:
+		return fmt.Errorf("saw event type %s at index %d, expected none", reflect.TypeOf(event), eventCount)
+	case <-time.After(100 * time.Second): // "indefinitely", to advance a synctest clock
+		return nil
 	}
 	return nil
 }


### PR DESCRIPTION
I don't think we did it this way deliberately, but if I am wrong about that,
I'm happy to replace this with some documentation instead.

---

In ExpectExacty, we were correctly checking that there are no further events
when no filters are provided, but were not checking after a non-empty filter
list that there are no additional events. Move the check after the filter loop,
so we get both.

Change-Id: I5c92ac510fce029421d712d7c312545ebe1a63fe
Signed-off-by: M. J. Fromberger <fromberger@tailscale.com>
