### PR TITLE
wgengine/router: enable src_valid_mark sysctl for rp_filter compatibility

### DIFF
--- a/wgengine/router/osrouter/router_linux.go
+++ b/wgengine/router/osrouter/router_linux.go
@@ -503,6 +503,14 @@ func (r *linuxRouter) Set(cfg *router.Config) error {
 			// Only update state on success to keep it in sync with actual rules
 			r.connmarkEnabled = true
 		}
+		// Enable src_valid_mark so the kernel uses the packet's fwmark
+		// during the rp_filter reverse-path check. Without this, the
+		// connmark restore in mangle/PREROUTING is ineffective — rp_filter
+		// does its routing lookup with fwmark=0, ignoring the restored
+		// bypass mark, and drops reply packets as martians.
+		if err := writeSysctl("net.ipv4.conf.all.src_valid_mark", "1"); err != nil {
+			r.logf("warning: failed to enable src_valid_mark: %v", err)
+		}
 	default:
 		r.logf("disabling connmark-based rp_filter workaround")
 		if err := r.nfr.DelConnmarkSaveRule(); err != nil {


### PR DESCRIPTION
The connmark save/restore rules in mangle/PREROUTING restore the Tailscale bypass fwmark (0x80000) onto reply packets so that rp_filter's reverse-path check routes through the main table instead of table 52. However, the kernel only uses the packet's fwmark during the rp_filter lookup when net.ipv4.conf.all.src_valid_mark=1.

On systems where this sysctl defaults to 0 (including GCP VMs), rp_filter performs its lookup with fwmark=0, hits rule 5270 then table 52 and routes to 0.0.0.0/0 dev tailscale0, and drops every reply packet arriving on the physical interface as a martian. This breaks all connectivity when using an exit node: DERP, DNS, control plane, and even the cloud metadata service.

Set src_valid_mark=1 when enabling the connmark rules so the rp_filter workaround actually works in these cases.

Updates #3310
Updates tailscale/corp#37846