### PR TITLE
tstest: explain what happens if you don't set a Start in ClockOpts

### DIFF
--- a/tstest/clock.go
+++ b/tstest/clock.go
@@ -20,6 +20,9 @@ type ClockOpts struct {
 	// to Clock.Now. If you are passing a value here, set an explicit
 	// timezone, otherwise the test may be non-deterministic when TZ environment
 	// variable is set to different values. The default time is in UTC.
+	//
+	// If you do not pass an explicit Start time, the clock will start at the
+	// current UTC time.
 	Start time.Time
 
 	// Step is the amount of time the Clock will advance whenever Clock.Now is


### PR DESCRIPTION
While working on #19444, I assumed that omitting `Start` would return a clock that started at January 1, year 1, because that's the zero value for a `time.Time`, but actually it uses the current UTC time instead.

This behaviour is non-obvious, so document it.

Updates #cleanup