### PR TITLE
cmd/tailscale: Add `tls-terminated-http` for declarative HTTPS to HTTP proxy

### DIFF
--- a/cmd/tailscale/cli/serve_v2.go
+++ b/cmd/tailscale/cli/serve_v2.go
@@ -177,7 +177,7 @@ func serveTypeFromConfString(sp conffile.ServiceProtocol) (st serveType, ok bool
 	switch sp {
 	case conffile.ProtoHTTP:
 		return serveTypeHTTP, true
-	case conffile.ProtoHTTPS, conffile.ProtoHTTPSInsecure, conffile.ProtoFile:
+	case conffile.ProtoHTTPS, conffile.ProtoHTTPSInsecure, conffile.ProtoTLSTerminatedHTTP, conffile.ProtoFile:
 		return serveTypeHTTPS, true
 	case conffile.ProtoTCP:
 		return serveTypeTCP, true
@@ -746,8 +746,13 @@ func (e *serveEnv) runServeGetConfig(ctx context.Context, args []string) (err er
 						return nil, fmt.Errorf("service %q: parse port %q: %w", svcName, portStr, err)
 					}
 
+					protocol := conffile.ServiceProtocol(proto)
+					if config.HTTPS && !config.HTTP {
+						protocol = conffile.ProtoTLSTerminatedHTTP
+					}
+
 					mak.Set(&sdf.Endpoints, &ppr, &conffile.Target{
-						Protocol:         conffile.ServiceProtocol(proto),
+						Protocol:         protocol,
 						Destination:      host,
 						DestinationPorts: tailcfg.PortRange{First: uint16(port), Last: uint16(port)},
 					})
@@ -859,9 +864,15 @@ func (e *serveEnv) runServeSetConfig(ctx context.Context, args []string) (err er
 			serveType, _ := serveTypeFromConfString(ep.Protocol)
 			for port := ppr.Ports.First; port <= ppr.Ports.Last; port++ {
 				var target string
-				if ep.Protocol == conffile.ProtoFile {
+				switch ep.Protocol {
+				case conffile.ProtoFile:
 					target = ep.Destination
-				} else {
+				case conffile.ProtoTLSTerminatedHTTP:
+					// map source port range 1-1 to destination port range
+					destPort := ep.DestinationPorts.First + (port - ppr.Ports.First)
+					portStr := fmt.Sprint(destPort)
+					target = fmt.Sprintf("http://%s", net.JoinHostPort(ep.Destination, portStr))
+				default:
 					// map source port range 1-1 to destination port range
 					destPort := ep.DestinationPorts.First + (port - ppr.Ports.First)
 					portStr := fmt.Sprint(destPort)

--- a/ipn/conffile/serveconf.go
+++ b/ipn/conffile/serveconf.go
@@ -55,13 +55,14 @@ type ServiceDetailsFile struct {
 type ServiceProtocol string
 
 const (
-	ProtoHTTP             ServiceProtocol = "http"
-	ProtoHTTPS            ServiceProtocol = "https"
-	ProtoHTTPSInsecure    ServiceProtocol = "https+insecure"
-	ProtoTCP              ServiceProtocol = "tcp"
-	ProtoTLSTerminatedTCP ServiceProtocol = "tls-terminated-tcp"
-	ProtoFile             ServiceProtocol = "file"
-	ProtoTUN              ServiceProtocol = "TUN"
+	ProtoHTTP              ServiceProtocol = "http"
+	ProtoHTTPS             ServiceProtocol = "https"
+	ProtoHTTPSInsecure     ServiceProtocol = "https+insecure"
+	ProtoTLSTerminatedHTTP ServiceProtocol = "tls-terminated-http"
+	ProtoTCP               ServiceProtocol = "tcp"
+	ProtoTLSTerminatedTCP  ServiceProtocol = "tls-terminated-tcp"
+	ProtoFile              ServiceProtocol = "file"
+	ProtoTUN               ServiceProtocol = "TUN"
 )
 
 // Target is a destination for traffic to go to when it arrives at a Tailscale
@@ -115,7 +116,7 @@ func (t *Target) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 		t.Protocol = ProtoFile
 		t.Destination = target
 		t.DestinationPorts = tailcfg.PortRange{}
-	case ProtoHTTP, ProtoHTTPS, ProtoHTTPSInsecure, ProtoTCP, ProtoTLSTerminatedTCP:
+	case ProtoHTTP, ProtoHTTPS, ProtoHTTPSInsecure, ProtoTLSTerminatedHTTP, ProtoTCP, ProtoTLSTerminatedTCP:
 		host, portRange, err := tailcfg.ParseHostPortRange(rest)
 		if err != nil {
 			return err
@@ -137,7 +138,7 @@ func (t *Target) MarshalText() ([]byte, error) {
 		out = fmt.Sprintf("%s://%s", t.Protocol, t.Destination)
 	case ProtoTUN:
 		out = "TUN"
-	case ProtoHTTP, ProtoHTTPS, ProtoHTTPSInsecure, ProtoTCP, ProtoTLSTerminatedTCP:
+	case ProtoHTTP, ProtoHTTPS, ProtoHTTPSInsecure, ProtoTLSTerminatedHTTP, ProtoTCP, ProtoTLSTerminatedTCP:
 		out = fmt.Sprintf("%s://%s", t.Protocol, net.JoinHostPort(t.Destination, t.DestinationPorts.String()))
 	default:
 		return nil, errors.New("unsupported protocol")


### PR DESCRIPTION
Untested, since there are no test for any of existing the surrounding code either. Although this change works for my use case I can't tell whether any existing flow breaks, or even what they are supposed to be.

Opened most as a reference in case someone else wants to try out while #18381 doesn't receive any attention. I don't think these change, nor the definition of the behavior for all the scenarios, should be defined without Tailscale since it touches the platform API. Happy to discuss those when/if this is reached in the queue. Until then, I'll be using this patch.