### PR TITLE
control/controlclient: fix a nil-indirection bug in DERP key pruning

### DIFF
--- a/control/controlclient/map.go
+++ b/control/controlclient/map.go
@@ -521,7 +521,7 @@ func (ms *mapSession) removeUnwantedDiscoUpdatesFromFullNetmapUpdate(resp *tailc
 
 		// Overwrite the key and last seen in the full netmap update.
 		peer.DiscoKey = existingNode.DiscoKey()
-		*peer.LastSeen = existingNode.LastSeen().Get()
+		peer.LastSeen = new(existingNode.LastSeen().Get())
 	}
 }
 

--- a/control/controlclient/map.go
+++ b/control/controlclient/map.go
@@ -521,7 +521,11 @@ func (ms *mapSession) removeUnwantedDiscoUpdatesFromFullNetmapUpdate(resp *tailc
 
 		// Overwrite the key and last seen in the full netmap update.
 		peer.DiscoKey = existingNode.DiscoKey()
-		peer.LastSeen = new(existingNode.LastSeen().Get())
+		if t, ok := existingNode.LastSeen().GetOk(); ok {
+			peer.LastSeen = new(t)
+		} else {
+			peer.LastSeen = nil
+		}
 	}
 }
 


### PR DESCRIPTION
Upon deciding to update the LastSeen timestamp, we weren't checking that the
field we are replacing into was non-nil. Rather than add an additional check,
just allocate a fresh pointer for the updated time.

Updates #19564

Change-Id: I589ebe65175fc7677c04a31dd6c4670e2531ee62
Signed-off-by: M. J. Fromberger <fromberger@tailscale.com>
