### PR TITLE
cmd/hello: remove hello.ipn.dev

### DIFF
--- a/cmd/hello/hello.go
+++ b/cmd/hello/hello.go
@@ -9,7 +9,6 @@ import (
 	"crypto/tls"
 	_ "embed"
 	"encoding/json"
-	"errors"
 	"flag"
 	"html/template"
 	"log"
@@ -76,22 +75,7 @@ func main() {
 			hs := &http.Server{
 				Addr: *httpsAddr,
 				TLSConfig: &tls.Config{
-					GetCertificate: func(hi *tls.ClientHelloInfo) (*tls.Certificate, error) {
-						switch hi.ServerName {
-						case "hello.ts.net":
-							return localClient.GetCertificate(hi)
-						case "hello.ipn.dev":
-							c, err := tls.LoadX509KeyPair(
-								"/etc/hello/hello.ipn.dev.crt",
-								"/etc/hello/hello.ipn.dev.key",
-							)
-							if err != nil {
-								return nil, err
-							}
-							return &c, nil
-						}
-						return nil, errors.New("invalid SNI name")
-					},
+					GetCertificate: localClient.GetCertificate,
 				},
 				IdleTimeout:       30 * time.Second,
 				ReadHeaderTimeout: 20 * time.Second,
@@ -155,8 +139,7 @@ func tailscaleIP(who *apitype.WhoIsResponse) string {
 func root(w http.ResponseWriter, r *http.Request) {
 	if r.TLS == nil && *httpsAddr != "" {
 		host := r.Host
-		if strings.Contains(r.Host, "100.101.102.103") ||
-			strings.Contains(r.Host, "hello.ipn.dev") {
+		if strings.Contains(r.Host, "100.101.102.103") {
 			host = "hello.ts.net"
 		}
 		http.Redirect(w, r, "https://"+host, http.StatusFound)
@@ -164,10 +147,6 @@ func root(w http.ResponseWriter, r *http.Request) {
 	}
 	if r.RequestURI != "/" {
 		http.Redirect(w, r, "/", http.StatusFound)
-		return
-	}
-	if r.TLS != nil && *httpsAddr != "" && strings.Contains(r.Host, "hello.ipn.dev") {
-		http.Redirect(w, r, "https://hello.ts.net", http.StatusFound)
 		return
 	}
 	tmpl, err := getTmpl()


### PR DESCRIPTION
This change removes logic related to the hello.ipn.dev domain, whic is no longer supported.

Fixes #19566