### PR TITLE
ssh/tailssh: fix exit-status ordering and improve signal/exit

### DIFF
--- a/ssh/tailssh/tailssh.go
+++ b/ssh/tailssh/tailssh.go
@@ -1133,7 +1133,6 @@ func (ss *sshSession) run() {
 		if _, err := io.Copy(rec.writer("o", ss), ss.rdStdout); err != nil && !errors.Is(err, io.EOF) {
 			logf("stdout copy: %v", err)
 		}
-		ss.CloseWrite() // CHANNEL_EOF; channel stays open for exit-status (RFC 4254 §5.3).
 	})
 
 	// rdStderr is nil for ptys.
@@ -1172,11 +1171,15 @@ func (ss *sshSession) run() {
 		exitCode = 1
 	}
 
-	// Order on the wire: exit-status, EOF (CloseWrite in stdout copier),
-	// CHANNEL_CLOSE (deferred ss.Close). RFC 4254 §6.10.
+	// Order on the wire: exit-status, remaining output, EOF,
+	// CHANNEL_CLOSE (deferred ss.Close). RFC 4254 §6.10. CloseWrite
+	// (CHANNEL_EOF) must wait for both output copiers: a write on
+	// either stream after EOF fails and silently truncates that
+	// stream's tail.
 	ss.Exit(exitCode)
 	closeAll(ss.childPipes...)
 	wg.Wait()
+	ss.CloseWrite()
 }
 
 // recordSSHToLocalDisk is a deprecated dev knob to allow recording SSH sessions

--- a/ssh/tailssh/tailssh.go
+++ b/ssh/tailssh/tailssh.go
@@ -886,9 +886,17 @@ func (ss *sshSession) killProcessOnContextDone() {
 		// We don't need to Process.Wait here, sshSession.run() does
 		// the waiting regardless of termination reason.
 
-		// TODO(maisem): should this be a SIGTERM followed by a SIGKILL?
-		ss.cmd.Process.Kill()
+		// SIGHUP = POSIX terminal-disconnect semantics; OpenSSH gets it
+		// implicitly via PTY-master close (session.c:2246), we send it
+		// explicitly because non-PTY sessions use pipes.
+		ss.cmd.Process.Signal(syscall.SIGHUP)
 	})
+}
+
+// isNotFoundOrExecutable reports whether err is a launchProcess
+// failure caused by the command not existing on disk.
+func isNotFoundOrExecutable(err error) bool {
+	return errors.Is(err, exec.ErrNotFound) || errors.Is(err, os.ErrNotExist)
 }
 
 // attachSession registers ss as an active session.
@@ -976,10 +984,21 @@ func (ss *sshSession) run() {
 	metricActiveSessions.Add(1)
 	defer metricActiveSessions.Add(-1)
 	defer ss.cancelCtx(errSessionDone)
+	defer ss.Close() // CHANNEL_CLOSE, last on the wire; see ss.Exit below.
 
 	if attached := ss.conn.srv.attachSessionToConnIfNotShutdown(ss); !attached {
 		fmt.Fprintf(ss, "Tailscale SSH is shutting down\r\n")
-		ss.Exit(1)
+		// 255 signals an SSH-layer failure (the session never reached the
+		// user's command), distinct from any exit status the remote
+		// program might produce. The ssh(1) EXIT STATUS section
+		// documents this as the value the client reports "if an error
+		// occurred", and OpenSSH's own ssh.c uses exit(255) for every
+		// transport/protocol fatal path. Wrappers and CI use the 255
+		// boundary to tell "connection broke" from "command exited N".
+		// See:
+		//   https://man.openbsd.org/ssh#EXIT_STATUS
+		//   https://github.com/openssh/openssh-portable/blob/V_10_2_P1/ssh.c#L1693
+		ss.Exit(255)
 		return
 	}
 	defer ss.conn.detachSession(ss)
@@ -1001,7 +1020,9 @@ func (ss *sshSession) run() {
 		if lu.Uid != fmt.Sprint(euid) {
 			ss.logf("can't switch to user %q from process euid %v", lu.Username, euid)
 			fmt.Fprintf(ss, "can't switch user\r\n")
-			ss.Exit(1)
+			// 255: SSH-layer failure, no user command ever ran. See the
+			// attachSession branch above for the full citation.
+			ss.Exit(255)
 			return
 		}
 	}
@@ -1029,7 +1050,27 @@ func (ss *sshSession) run() {
 					fmt.Fprintf(ss, "can't start new recording\r\n")
 				}
 				ss.logf("startNewRecording: %v", err)
-				ss.Exit(1)
+				// 254 is Tailscale-specific: the SSH transport is fine
+				// and the user's command is well-formed, but the session
+				// recording policy could not be satisfied (recorder
+				// unreachable, upload denied, etc.) so we refuse to run
+				// the command at all. We need a code that operators can
+				// alert on without collapsing it into the generic buckets:
+				//   - 1   is overloaded; any program can produce it
+				//         (Bash exit-code conventions, codes 1-2)
+				//   - 127 means "command not found" (POSIX 2018, sh
+				//         §2.8.2)
+				//   - 130 is Ctrl-C (128 + SIGINT)
+				//   - 255 means "SSH itself failed" (ssh(1) EXIT STATUS)
+				// 254 sits in the reserved >128 region but is not claimed
+				// by any of the above, so it is unambiguous for
+				// "recording-required session denied".
+				// Refs:
+				//   https://man.openbsd.org/ssh#EXIT_STATUS
+				//   https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_08_02
+				//   https://tldp.org/LDP/abs/html/exitcodes.html
+				//   https://github.com/tailscale/tailscale/issues/18256
+				ss.Exit(254)
 				return
 			}
 			ss.logf("startNewRecording: <nil>")
@@ -1042,6 +1083,7 @@ func (ss *sshSession) run() {
 	err := ss.launchProcess()
 	if err != nil {
 		logf("start failed: %v", err.Error())
+		exitCode := 1
 		if errors.Is(err, context.Canceled) {
 			cause := context.Cause(ss.ctx)
 			if serr, ok := cause.(SSHTerminationError); ok {
@@ -1049,14 +1091,35 @@ func (ss *sshSession) run() {
 					io.WriteString(ss.Stderr(), "\r\n\r\n"+msg+"\r\n\r\n")
 				}
 			}
+		} else if isNotFoundOrExecutable(err) {
+			// 127 = "command not found" per POSIX 2018 sh §2.8.2
+			// ("if a command is not found, the exit status shall be
+			// 127"). 126 is reserved for "found but not executable";
+			// we collapse both into 127 because exec.ErrNotFound and
+			// os.ErrNotExist don't distinguish the underlying cause
+			// reliably across platforms, and 127 is what users
+			// recognise (it's what bash / dash / zsh report).
+			// Refs:
+			//   https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_08_02
+			//   https://tldp.org/LDP/abs/html/exitcodes.html
+			exitCode = 127
 		}
-		ss.Exit(1)
+		ss.Exit(exitCode)
 		return
 	}
 	ss.exitHandled = make(chan struct{})
 	go ss.killProcessOnContextDone()
 
-	var processDone atomic.Bool
+	// wg covers stdout and stderr only: their close ordering is
+	// load-bearing for the wire-level frame sequence below.
+	//
+	// The stdin copier is deliberately NOT in wg. It blocks reading from
+	// the SSH channel until the client half-closes its write side; many
+	// clients (go-scp, non-SFTP exec) don't half-close before they
+	// receive CHANNEL_CLOSE from us. Including it would deadlock. It
+	// self-cleans when deferred ss.Close runs.
+	var wg sync.WaitGroup
+
 	go func() {
 		defer ss.wrStdin.Close()
 		if _, err := io.Copy(rec.writer("i", ss.wrStdin), ss); err != nil {
@@ -1064,52 +1127,31 @@ func (ss *sshSession) run() {
 			ss.cancelCtx(err)
 		}
 	}()
-	outputDone := make(chan struct{})
-	var openOutputStreams atomic.Int32
-	if ss.rdStderr != nil {
-		openOutputStreams.Store(2)
-	} else {
-		openOutputStreams.Store(1)
-	}
-	go func() {
+
+	wg.Go(func() {
 		defer ss.rdStdout.Close()
-		_, err := io.Copy(rec.writer("o", ss), ss.rdStdout)
-		if err != nil && !errors.Is(err, io.EOF) {
-			isErrBecauseProcessExited := processDone.Load() && errors.Is(err, syscall.EIO)
-			if !isErrBecauseProcessExited {
-				logf("stdout copy: %v", err)
-				ss.cancelCtx(err)
-			}
+		if _, err := io.Copy(rec.writer("o", ss), ss.rdStdout); err != nil && !errors.Is(err, io.EOF) {
+			logf("stdout copy: %v", err)
 		}
-		if openOutputStreams.Add(-1) == 0 {
-			ss.CloseWrite()
-			close(outputDone)
-		}
-	}()
+		ss.CloseWrite() // CHANNEL_EOF; channel stays open for exit-status (RFC 4254 §5.3).
+	})
+
 	// rdStderr is nil for ptys.
 	if ss.rdStderr != nil {
-		go func() {
+		wg.Go(func() {
 			defer ss.rdStderr.Close()
-			_, err := io.Copy(ss.Stderr(), ss.rdStderr)
-			if err != nil {
+			if _, err := io.Copy(ss.Stderr(), ss.rdStderr); err != nil {
 				logf("stderr copy: %v", err)
 			}
-			if openOutputStreams.Add(-1) == 0 {
-				ss.CloseWrite()
-				close(outputDone)
-			}
-		}()
+		})
 	}
 
 	err = ss.cmd.Wait()
-	processDone.Store(true)
 
 	if ss.ctx.Err() != nil {
-		// Context was canceled (e.g., recording upload failure).
-		// Wait for killProcessOnContextDone to finish writing any
-		// termination message before we proceed. This must happen
-		// before closeAll and CloseWrite so the SSH channel is
-		// still writable.
+		// Cancellation (e.g. recording upload failure) wrote a
+		// termination message via killProcessOnContextDone; wait
+		// for it before Exit closes the channel for writes.
 		<-ss.exitHandled
 	}
 
@@ -1118,31 +1160,23 @@ func (ss *sshSession) run() {
 	// aforementioned goroutine.
 	ss.exitOnce.Do(func() {})
 
-	// Close the process-side of all pipes to signal the asynchronous
-	// io.Copy routines reading/writing from the pipes to terminate.
-	// Block for the io.Copy to finish before calling ss.Exit below.
-	closeAll(ss.childPipes...)
-	select {
-	case <-outputDone:
-	case <-ss.ctx.Done():
-		<-ss.exitHandled
-	}
-
+	var exitCode int
 	if err == nil {
 		ss.logf("Session complete")
-		ss.Exit(0)
-		return
-	}
-	if ee, ok := err.(*exec.ExitError); ok {
-		code := ee.ProcessState.ExitCode()
-		ss.logf("Wait: code=%v", code)
-		ss.Exit(code)
-		return
+		exitCode = 0
+	} else if ee, ok := err.(*exec.ExitError); ok {
+		exitCode = ee.ProcessState.ExitCode()
+		ss.logf("Wait: code=%v", exitCode)
+	} else {
+		ss.logf("Wait: %v", err)
+		exitCode = 1
 	}
 
-	ss.logf("Wait: %v", err)
-	ss.Exit(1)
-	return
+	// Order on the wire: exit-status, EOF (CloseWrite in stdout copier),
+	// CHANNEL_CLOSE (deferred ss.Close). RFC 4254 §6.10.
+	ss.Exit(exitCode)
+	closeAll(ss.childPipes...)
+	wg.Wait()
 }
 
 // recordSSHToLocalDisk is a deprecated dev knob to allow recording SSH sessions

--- a/ssh/tailssh/tailssh_exitcodes_test.go
+++ b/ssh/tailssh/tailssh_exitcodes_test.go
@@ -1,0 +1,152 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build linux || darwin
+
+package tailssh
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"os/exec"
+	"os/user"
+	"testing"
+
+	gliderssh "github.com/tailscale/gliderssh"
+	"tailscale.com/ipn/ipnlocal"
+	"tailscale.com/ipn/store/mem"
+	"tailscale.com/tailcfg"
+	"tailscale.com/tsd"
+	"tailscale.com/tstest"
+	"tailscale.com/types/logid"
+	"tailscale.com/wgengine"
+)
+
+// testSSHHarness is the in-process SSH server harness shared by TestSSH
+// and TestExitCodePassthrough: a tailssh.server on a local listener
+// with auth bypassed, plus an execSSH closure that talks to it via
+// the system ssh client.
+type testSSHHarness struct {
+	user    *user.User
+	execSSH func(args ...string) *exec.Cmd
+}
+
+func newTestSSHHarness(t *testing.T) *testSSHHarness {
+	t.Helper()
+	logf := tstest.WhileTestRunningLogger(t)
+	sys := tsd.NewSystem()
+	eng, err := wgengine.NewFakeUserspaceEngine(logf, sys.Set, sys.HealthTracker.Get(), sys.UserMetricsRegistry(), sys.Bus.Get())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sys.Set(eng)
+	sys.Set(new(mem.Store))
+	lb, err := ipnlocal.NewLocalBackend(logf, logid.PublicID{}, sys, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { lb.Shutdown() })
+	lb.SetVarRoot(t.TempDir())
+
+	srv := &server{lb: lb, logf: logf}
+	sc, err := srv.newConn()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sc.insecureSkipTailscaleAuth = true
+
+	u, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	um, err := userLookup(u.Username)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sc.localUser = um
+	sc.info = &sshConnInfo{
+		sshUser: "test",
+		src:     netip.MustParseAddrPort("1.2.3.4:32342"),
+		dst:     netip.MustParseAddrPort("1.2.3.5:22"),
+		node:    (&tailcfg.Node{}).View(),
+		uprof:   tailcfg.UserProfile{},
+	}
+	sc.action0 = &tailcfg.SSHAction{Accept: true}
+	sc.finalAction = sc.action0
+	sc.authCompleted.Store(true)
+	sc.Handler = func(s gliderssh.Session) {
+		sc.newSSHSession(s).run()
+	}
+
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				if !errors.Is(err, net.ErrClosed) {
+					t.Errorf("Accept: %v", err)
+				}
+				return
+			}
+			go sc.HandleConn(c)
+		}
+	}()
+
+	execSSH := func(args ...string) *exec.Cmd {
+		cmd := exec.Command("ssh",
+			"-F", "none",
+			"-v",
+			"-p", fmt.Sprint(port),
+			"-o", "StrictHostKeyChecking=no",
+			"user@127.0.0.1")
+		cmd.Args = append(cmd.Args, args...)
+		return cmd
+	}
+
+	return &testSSHHarness{user: u, execSSH: execSSH}
+}
+
+// TestExitCodePassthrough is the in-process, fast-feedback companion
+// to TestIntegrationExitCodes: 0 / 42 / 127 via the system ssh client
+// to an in-process tailssh.server. 127 = POSIX command-not-found.
+// https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_08_02
+func TestExitCodePassthrough(t *testing.T) {
+	h := newTestSSHHarness(t)
+
+	tests := []struct {
+		name string
+		cmd  string
+		want int
+	}{
+		{"zero", "true", 0},
+		{"passthrough", "exit 42", 42},
+		{"command_not_found", "/nonexistent/binary", 127},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := h.execSSH(tt.cmd).Run()
+			if tt.want == 0 {
+				if err != nil {
+					t.Fatalf("want exit 0, got error: %v", err)
+				}
+				return
+			}
+			var ee *exec.ExitError
+			if !errors.As(err, &ee) {
+				t.Fatalf("want *exec.ExitError, got %T: %v", err, err)
+			}
+			if got := ee.ExitCode(); got != tt.want {
+				t.Errorf("exit code = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/ssh/tailssh/tailssh_exitcodes_test.go
+++ b/ssh/tailssh/tailssh_exitcodes_test.go
@@ -6,15 +6,19 @@
 package tailssh
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"net"
 	"net/netip"
 	"os/exec"
 	"os/user"
+	"strings"
 	"testing"
+	"time"
 
 	gliderssh "github.com/tailscale/gliderssh"
+	"golang.org/x/crypto/ssh"
 	"tailscale.com/ipn/ipnlocal"
 	"tailscale.com/ipn/store/mem"
 	"tailscale.com/tailcfg"
@@ -30,10 +34,21 @@ import (
 // the system ssh client.
 type testSSHHarness struct {
 	user    *user.User
+	addr    string // host:port of the local listener
 	execSSH func(args ...string) *exec.Cmd
 }
 
 func newTestSSHHarness(t *testing.T) *testSSHHarness {
+	t.Helper()
+	return newTestSSHHarnessWithShell(t, "")
+}
+
+// newTestSSHHarnessWithShell is newTestSSHHarness with the session
+// user's login shell pinned to shell (empty = the real login shell).
+// Tests that depend on exact process/fd structure use /bin/sh: some
+// real login shells (fish) fork -c commands and stay resident, which
+// hides pipe EOFs and changes who the direct child is.
+func newTestSSHHarnessWithShell(t *testing.T, shell string) *testSSHHarness {
 	t.Helper()
 	logf := tstest.WhileTestRunningLogger(t)
 	sys := tsd.NewSystem()
@@ -64,6 +79,9 @@ func newTestSSHHarness(t *testing.T) *testSSHHarness {
 	um, err := userLookup(u.Username)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if shell != "" {
+		um.loginShellCached = shell
 	}
 	sc.localUser = um
 	sc.info = &sshConnInfo{
@@ -111,7 +129,76 @@ func newTestSSHHarness(t *testing.T) *testSSHHarness {
 		return cmd
 	}
 
-	return &testSSHHarness{user: u, execSSH: execSSH}
+	return &testSSHHarness{user: u, addr: ln.Addr().String(), execSSH: execSSH}
+}
+
+// gatedWriter blocks its first Write until gate is closed, then
+// writes everything to buf. Plugged in as the SSH client's stderr
+// sink it stops the client from consuming extended data, which stops
+// window adjustments, which exhausts the server's 2 MiB send window:
+// real-network backpressure, produced deterministically.
+type gatedWriter struct {
+	gate <-chan struct{}
+	buf  bytes.Buffer
+}
+
+func (w *gatedWriter) Write(p []byte) (int, error) {
+	<-w.gate
+	return w.buf.Write(p)
+}
+
+// TestStderrTailNotTruncated asserts the full stderr stream reaches
+// the client when the process exits while stderr is still in flight.
+// The client withholds window credit (gatedWriter) so the server's
+// stderr copier is stuck mid-backlog when the process exits and the
+// stdout pipe EOFs. A CHANNEL_EOF sent at stdout-EOF, while stderr is
+// still draining, makes every later stderr write fail and silently
+// drops the tail; CHANNEL_EOF must wait for both streams.
+func TestStderrTailNotTruncated(t *testing.T) {
+	h := newTestSSHHarnessWithShell(t, "/bin/sh")
+
+	cl, err := ssh.Dial("tcp", h.addr, &ssh.ClientConfig{
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         15 * time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+	s, err := cl.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	gate := make(chan struct{})
+	stderr := &gatedWriter{gate: gate}
+	var stdout bytes.Buffer
+	s.Stdout = &stdout
+	s.Stderr = stderr
+
+	// 33 * 64 KiB = the client's 2 MiB channel window plus one pipe
+	// buffer: enough that the window runs dry and the final stderr
+	// chunks (and TAIL) are still server-side when the shell exits,
+	// yet little enough that the shell doesn't block before exiting.
+	const cmd = `dd if=/dev/zero bs=65536 count=33 1>&2 2>/dev/null; echo TAIL >&2; exit 7`
+
+	// Release the client's stderr sink only after the exit (and, with
+	// the bug, the premature CHANNEL_EOF) has happened server-side.
+	timer := time.AfterFunc(750*time.Millisecond, func() { close(gate) })
+	defer timer.Stop()
+
+	err = s.Run(cmd)
+	var ee *ssh.ExitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("want *ssh.ExitError, got %T: %v", err, err)
+	}
+	if got := ee.ExitStatus(); got != 7 {
+		t.Errorf("exit status = %d, want 7", got)
+	}
+	if got := stderr.buf.String(); !strings.Contains(got, "TAIL") {
+		t.Errorf("stderr tail dropped: got %d of %d bytes, missing final TAIL marker", len(got), 33*65536+len("TAIL\n"))
+	}
 }
 
 // TestExitCodePassthrough is the in-process, fast-feedback companion

--- a/ssh/tailssh/tailssh_frameorder_test.go
+++ b/ssh/tailssh/tailssh_frameorder_test.go
@@ -1,0 +1,204 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build linux || darwin
+
+package tailssh
+
+import (
+	"net"
+	"net/netip"
+	"os/user"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	gliderssh "github.com/tailscale/gliderssh"
+	"golang.org/x/crypto/ssh"
+	"tailscale.com/ipn/ipnlocal"
+	"tailscale.com/ipn/store/mem"
+	"tailscale.com/tailcfg"
+	"tailscale.com/tsd"
+	"tailscale.com/tstest"
+	"tailscale.com/types/logid"
+	"tailscale.com/wgengine"
+)
+
+// frameRecorder wraps a gliderssh.Session and records the order in
+// which the server emits the three session-teardown frames. Frame
+// order is a property of our own output, so it is observable on any
+// GOOS without depending on how a particular client reacts to it.
+type frameRecorder struct {
+	gliderssh.Session
+	mu     sync.Mutex
+	frames []string
+}
+
+func (r *frameRecorder) record(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.frames = append(r.frames, name)
+}
+
+func (r *frameRecorder) got() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return slices.Clone(r.frames)
+}
+
+func (r *frameRecorder) Exit(code int) error {
+	r.record("exit-status")
+	return r.Session.Exit(code)
+}
+
+func (r *frameRecorder) CloseWrite() error {
+	r.record("eof")
+	return r.Session.CloseWrite()
+}
+
+func (r *frameRecorder) Close() error {
+	r.record("close")
+	return r.Session.Close()
+}
+
+// TestExitStatusPrecedesEOF pins the session teardown frame order:
+// exit-status, then CHANNEL_EOF, then CHANNEL_CLOSE (RFC 4254 §6.10).
+//
+// This is the bug behind #18256. Sending EOF first lets a client that
+// treats EOF as end-of-session stop reading before the exit-status
+// request arrives, and report a bogus 0. macOS OpenSSH does exactly
+// that; Linux OpenSSH happens to read the pending request anyway, so
+// an exit-code assertion can't see the defect and this ordering
+// assertion is what pins it on every platform.
+func TestExitStatusPrecedesEOF(t *testing.T) {
+	recCh := make(chan *frameRecorder, 1)
+	addr := newFrameOrderServer(t, recCh)
+
+	cl, err := ssh.Dial("tcp", addr, &ssh.ClientConfig{
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         15 * time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+	s, err := cl.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Produce output on both streams so neither copier is trivially
+	// done before the process exits.
+	if err := s.Run("echo out; echo err 1>&2; exit 7"); err == nil {
+		t.Fatal("want non-nil error for exit 7")
+	} else if ee, ok := err.(*ssh.ExitError); !ok {
+		t.Fatalf("want *ssh.ExitError, got %T: %v", err, err)
+	} else if ee.ExitStatus() != 7 {
+		t.Fatalf("exit status = %d, want 7", ee.ExitStatus())
+	}
+
+	var rec *frameRecorder
+	select {
+	case rec = <-recCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("session never started")
+	}
+
+	// run() returns before the deferred ss.Close lands, so give the
+	// close frame a moment rather than racing it.
+	var got []string
+	if err := tstest.WaitFor(5*time.Second, func() error {
+		got = rec.got()
+		if len(got) < 3 {
+			return errNotAllFrames
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("only saw frames %v, want 3", got)
+	}
+
+	want := []string{"exit-status", "eof", "close"}
+	if !slices.Equal(got, want) {
+		t.Errorf("frame order = %v, want %v", got, want)
+	}
+}
+
+var errNotAllFrames = errNotAllFramesType{}
+
+type errNotAllFramesType struct{}
+
+func (errNotAllFramesType) Error() string { return "not all frames emitted yet" }
+
+// newFrameOrderServer is newTestSSHHarness with the session wrapped in
+// a frameRecorder, which is delivered on recCh when the session starts.
+func newFrameOrderServer(t *testing.T, recCh chan *frameRecorder) string {
+	t.Helper()
+	logf := tstest.WhileTestRunningLogger(t)
+	sys := tsd.NewSystem()
+	eng, err := wgengine.NewFakeUserspaceEngine(logf, sys.Set, sys.HealthTracker.Get(), sys.UserMetricsRegistry(), sys.Bus.Get())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sys.Set(eng)
+	sys.Set(new(mem.Store))
+	lb, err := ipnlocal.NewLocalBackend(logf, logid.PublicID{}, sys, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { lb.Shutdown() })
+	lb.SetVarRoot(t.TempDir())
+
+	srv := &server{lb: lb, logf: logf}
+	sc, err := srv.newConn()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sc.insecureSkipTailscaleAuth = true
+
+	u, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	um, err := userLookup(u.Username)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// /bin/sh: some login shells (fish) fork -c commands and stay
+	// resident, which changes which process owns the pipes.
+	um.loginShellCached = "/bin/sh"
+	sc.localUser = um
+	sc.info = &sshConnInfo{
+		sshUser: "test",
+		src:     netip.MustParseAddrPort("1.2.3.4:32342"),
+		dst:     netip.MustParseAddrPort("1.2.3.5:22"),
+		node:    (&tailcfg.Node{}).View(),
+		uprof:   tailcfg.UserProfile{},
+	}
+	sc.action0 = &tailcfg.SSHAction{Accept: true}
+	sc.finalAction = sc.action0
+	sc.authCompleted.Store(true)
+	sc.Handler = func(s gliderssh.Session) {
+		rec := &frameRecorder{Session: s}
+		select {
+		case recCh <- rec:
+		default:
+		}
+		sc.newSSHSession(rec).run()
+	}
+
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go sc.HandleConn(c)
+		}
+	}()
+	return ln.Addr().String()
+}

--- a/ssh/tailssh/tailssh_integration_exitcodes_test.go
+++ b/ssh/tailssh/tailssh_integration_exitcodes_test.go
@@ -1,0 +1,406 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build integrationtest
+
+package tailssh
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+	"tailscale.com/tstest"
+)
+
+// init fail-fasts any missing invariant (TAILSCALED_PATH, test user,
+// login shell) so CI failures point at the broken piece instead of
+// cryptic mid-test crashes. Logs the minimum context (GOOS, ssh
+// version, resolved user shell) needed to attribute a failure.
+func init() {
+	log.Printf("preflight: GOOS=%s GOARCH=%s euid=%d", runtime.GOOS, runtime.GOARCH, os.Geteuid())
+
+	if p := os.Getenv("TAILSCALED_PATH"); p != "" {
+		fi, err := os.Stat(p)
+		if err != nil {
+			log.Fatalf("preflight: TAILSCALED_PATH=%q not usable: %v", p, err)
+		}
+		if fi.Mode()&0111 == 0 {
+			log.Fatalf("preflight: TAILSCALED_PATH=%q is not executable (mode %v)", p, fi.Mode())
+		}
+	}
+
+	if _, err := exec.LookPath("ssh"); err == nil {
+		if out, err := exec.Command("ssh", "-V").CombinedOutput(); err == nil {
+			log.Printf("preflight: ssh -V: %s", bytes.TrimSpace(out))
+		}
+	}
+
+	username := exitCodeTestUser()
+	if _, err := user.Lookup(username); err != nil {
+		log.Fatalf("preflight: user.Lookup(%q) failed: %v", username, err)
+	}
+	um, err := userLookup(username)
+	if err != nil {
+		log.Fatalf("preflight: userLookup(%q) failed: %v", username, err)
+	}
+	shell := um.LoginShell()
+	if shell == "" {
+		log.Fatalf("preflight: empty login shell for %q", username)
+	}
+	if _, err := os.Stat(shell); err != nil {
+		log.Fatalf("preflight: login shell %q for user %q not usable: %v", shell, username, err)
+	}
+	log.Printf("preflight: user=%q shell=%q", username, shell)
+}
+
+// exitCodeTestUser is the local OS user the exit-code tests run as,
+// overridable via TS_SSH_INTEGRATION_TEST_USER (testuser on Linux
+// docker, runner on macOS CI).
+func exitCodeTestUser() string {
+	if u := os.Getenv("TS_SSH_INTEGRATION_TEST_USER"); u != "" {
+		return u
+	}
+	return "testuser"
+}
+
+// dialTestClientForUser returns the dial error rather than t.Fatal'ing,
+// so retry-aware tests can distinguish transport noise from assertion
+// failure.
+func dialTestClientForUser(t *testing.T, username string, forceV1Behavior, allowSendEnv bool, authMethods ...ssh.AuthMethod) (*ssh.Client, error) {
+	t.Helper()
+	addr := testServer(t, username, forceV1Behavior, allowSendEnv)
+	return ssh.Dial("tcp", addr, &ssh.ClientConfig{
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Auth:            authMethods,
+		Timeout:         15 * time.Second,
+	})
+}
+
+// dumpIncubatorLogOnFail prints /tmp/tailscalessh.log on subtest
+// failure. The incubator runs in its own process; its log doesn't
+// reach t.Log otherwise.
+func dumpIncubatorLogOnFail(t *testing.T) {
+	t.Helper()
+	if !t.Failed() {
+		return
+	}
+	b, err := os.ReadFile("/tmp/tailscalessh.log")
+	if err != nil {
+		t.Logf("incubator log unreadable: %v", err)
+		return
+	}
+	if len(b) == 0 {
+		t.Logf("incubator log empty (no incubator launched, or log rotated)")
+		return
+	}
+	t.Logf("---- /tmp/tailscalessh.log (%d bytes) ----\n%s\n---- end ----", len(b), b)
+}
+
+// TestIntegrationExitCodes pins the SSH exit-status frame end-to-end
+// through the real server stack (gliderssh + tailssh + incubator) with
+// a Go x/crypto/ssh client. Transport noise (dial, pre-exec) is retried
+// via tstest.WaitFor; an exit-code mismatch is the assertion and never
+// retries.
+func TestIntegrationExitCodes(t *testing.T) {
+	username := exitCodeTestUser()
+
+	tests := []struct {
+		name     string
+		cmd      string
+		wantCode int
+	}{
+		{"success", "true", 0},
+		{"exit_code_passthrough", "exit 42", 42},
+		// 127 = command-not-found, POSIX shell convention.
+		// https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_08_02
+		{"command_not_found", "/nonexistent/binary", 127},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer dumpIncubatorLogOnFail(t)
+
+			runOnce := func() (gotCode int, transportErr error, out []byte) {
+				cl, dialErr := dialTestClientForUser(t, username, false, false)
+				if dialErr != nil {
+					return -1, dialErr, nil
+				}
+				defer cl.Close()
+				s, err := cl.NewSession()
+				if err != nil {
+					return -1, fmt.Errorf("NewSession: %w", err), nil
+				}
+				defer s.Close()
+
+				type result struct {
+					out []byte
+					err error
+				}
+				done := make(chan result, 1)
+				go func() {
+					o, e := s.CombinedOutput(tt.cmd)
+					done <- result{o, e}
+				}()
+
+				var res result
+				select {
+				case res = <-done:
+				case <-time.After(20 * time.Second):
+					return -1, errors.New("ssh command timed out"), nil
+				}
+
+				if res.err == nil {
+					return 0, nil, res.out
+				}
+				var ee *ssh.ExitError
+				if errors.As(res.err, &ee) {
+					return ee.ExitStatus(), nil, res.out
+				}
+				// EOF before exit-status, channel teardown, etc. — treat as
+				// transport noise so the retry loop can act. The bug we're
+				// catching only surfaces as a wrong ExitStatus().
+				return -1, fmt.Errorf("non-exit ssh error: %w", res.err), res.out
+			}
+
+			// tstest.WaitFor retries on transport noise; a definitive
+			// exit-code observation returns nil so the assertion runs
+			// once, after WaitFor.
+			var gotCode int
+			var lastOut []byte
+			err := tstest.WaitFor(5*time.Second, func() error {
+				code, transportErr, out := runOnce()
+				lastOut = out
+				if transportErr != nil {
+					t.Logf("transport failure: %v; output:\n%s", transportErr, out)
+					return transportErr
+				}
+				gotCode = code
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("ssh command %q never completed cleanly: %v; last output:\n%s",
+					tt.cmd, err, lastOut)
+			}
+			if gotCode != tt.wantCode {
+				t.Fatalf("exit code = %d, want %d; output:\n%s", gotCode, tt.wantCode, lastOut)
+			}
+		})
+	}
+}
+
+// TestOpenSSHExitCodes is TestIntegrationExitCodes against the system
+// ssh binary, which is what users of #18256 are actually running
+// (macOS ships a LibreSSL fork). Auth pinned to "none" with every
+// other method explicitly disabled so OpenSSH can't fall back to
+// a different path on different versions.
+func TestOpenSSHExitCodes(t *testing.T) {
+	sshPath, err := exec.LookPath("ssh")
+	if err != nil {
+		t.Skipf("skipping without OpenSSH client: %v", err)
+	}
+	username := exitCodeTestUser()
+
+	if out, err := exec.Command(sshPath, "-V").CombinedOutput(); err == nil {
+		t.Logf("OpenSSH version: %s", bytes.TrimSpace(out))
+	}
+	t.Logf("OpenSSH test user: %s", username)
+
+	addr := testServer(t, username, false, false)
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("tailssh server listening on %s", addr)
+
+	exitStatus := func(t *testing.T, err error) int {
+		t.Helper()
+		if err == nil {
+			return 0
+		}
+		var ee *exec.ExitError
+		if !errors.As(err, &ee) {
+			t.Fatalf("want *exec.ExitError, got %T: %v", err, err)
+		}
+		return ee.ExitCode()
+	}
+
+	// OpenSSH rc=255 is "ssh internal error" (connect/auth fail before
+	// the remote command runs); treat as transport, not the assertion.
+	// https://man.openbsd.org/ssh.1#EXIT_STATUS
+	isTransport := func(rc int) bool { return rc == 255 }
+
+	tests := []struct {
+		name     string
+		cmd      string
+		wantCode int
+	}{
+		{"success", "true", 0},
+		{"exit_code_passthrough", "exit 42", 42},
+		{"command_not_found", "/nonexistent/binary", 127},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer dumpIncubatorLogOnFail(t)
+
+			runOnce := func() (rc int, out []byte) {
+				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				cmd := exec.CommandContext(ctx, sshPath,
+					"-vvv",
+					"-F", "/dev/null",
+					"-T",
+					"-o", "BatchMode=yes",
+					"-o", "ConnectTimeout=15",
+					"-o", "GSSAPIAuthentication=no",
+					"-o", "GlobalKnownHostsFile=/dev/null",
+					"-o", "HostbasedAuthentication=no",
+					"-o", "IdentityAgent=none",
+					"-o", "KbdInteractiveAuthentication=no",
+					"-o", "NumberOfPasswordPrompts=0",
+					"-o", "PasswordAuthentication=no",
+					"-o", "PreferredAuthentications=none",
+					"-o", "PubkeyAuthentication=no",
+					"-o", "StrictHostKeyChecking=no",
+					"-o", "UserKnownHostsFile=/dev/null",
+					"-p", port,
+					username+"@"+host,
+					tt.cmd,
+				)
+				o, err := cmd.CombinedOutput()
+				if ctx.Err() == context.DeadlineExceeded {
+					t.Logf("ssh command timed out; output:\n%s", o)
+					return 255, o
+				}
+				return exitStatus(t, err), o
+			}
+
+			var gotRC int
+			var lastOut []byte
+			err := tstest.WaitFor(5*time.Second, func() error {
+				rc, out := runOnce()
+				lastOut = out
+				if isTransport(rc) && rc != tt.wantCode {
+					t.Logf("transport failure (rc=255); output:\n%s", out)
+					return fmt.Errorf("ssh rc=%d (transport)", rc)
+				}
+				gotRC = rc
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("ssh command %q never returned a non-transport exit status: %v; last output:\n%s",
+					tt.cmd, err, lastOut)
+			}
+			if gotRC != tt.wantCode {
+				t.Fatalf("ssh exit code = %d, want %d; output:\n%s", gotRC, tt.wantCode, lastOut)
+			}
+		})
+	}
+}
+
+// TestLocalUnixForwardingHalfClose: after the client closes its write
+// side, the server's still-in-flight response must arrive. The old
+// cancel-on-first-direction bicopy tore the channel down too early.
+func TestLocalUnixForwardingHalfClose(t *testing.T) {
+	debugTest.Store(true)
+	t.Cleanup(func() { debugTest.Store(false) })
+
+	socketDir, err := os.MkdirTemp("", "tailssh-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(socketDir) })
+	socketPath := filepath.Join(socketDir, "halfclose.sock")
+
+	ul, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ul.Close() })
+
+	// Delayed-response service: read everything, sleep, then write.
+	const response = "delayed-response-after-client-closes-write"
+	go func() {
+		for {
+			conn, err := ul.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				io.ReadAll(conn)
+				time.Sleep(100 * time.Millisecond)
+				io.WriteString(conn, response)
+			}()
+		}
+	}()
+
+	addr := testServerWithOpts(t, testServerOpts{
+		username:                 "testuser",
+		allowLocalPortForwarding: true,
+	})
+
+	cl, err := ssh.Dial("tcp", addr, &ssh.ClientConfig{
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { cl.Close() })
+
+	conn, err := cl.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("failed to dial unix socket through SSH: %s", err)
+	}
+	defer conn.Close()
+
+	// (*ssh.Client).Dial("unix", ...) returns a *chanConn that embeds
+	// ssh.Channel; ssh.Channel exposes CloseWrite (RFC 4254 §5.3 EOF).
+	// Assert to that capability, not *net.TCPConn.
+	if _, err := io.WriteString(conn, "request data"); err != nil {
+		t.Fatalf("failed to write: %s", err)
+	}
+	cw, ok := conn.(interface{ CloseWrite() error })
+	if !ok {
+		t.Fatalf("conn %T does not implement CloseWrite; cannot test half-close", conn)
+	}
+	if err := cw.CloseWrite(); err != nil {
+		t.Fatalf("CloseWrite: %v", err)
+	}
+
+	// *chanConn.SetReadDeadline returns an error, so bound the read in
+	// a goroutine: a bicopy regression must fail fast, not hang CI.
+	type readResult struct {
+		data []byte
+		err  error
+	}
+	done := make(chan readResult, 1)
+	go func() {
+		got, err := io.ReadAll(conn)
+		done <- readResult{got, err}
+	}()
+	select {
+	case res := <-done:
+		if res.err != nil {
+			t.Fatalf("failed to read response: %s", res.err)
+		}
+		if string(res.data) != response {
+			t.Errorf("got %q, want %q", res.data, response)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatalf("timed out waiting for response after half-close; bicopy may be tearing down the channel prematurely")
+	}
+}

--- a/ssh/tailssh/tailssh_test.go
+++ b/ssh/tailssh/tailssh_test.go
@@ -527,9 +527,7 @@ func TestSSHRecordingCancelsSessionsOnUploadFailure(t *testing.T) {
 			},
 			sshCommand:       "echo hello",
 			wantClientOutput: "session rejected\r\n",
-			// 254 once recording failures get their own exit code; the
-			// current code exits 1 here.
-			wantExitCode: 0,
+			wantExitCode:     254,
 
 			clientOutputMustNotContain: []string{"hello"},
 		},

--- a/ssh/tailssh/tailssh_test.go
+++ b/ssh/tailssh/tailssh_test.go
@@ -20,7 +20,6 @@ import (
 	"net/http/httptest"
 	"net/netip"
 	"os"
-	"os/exec"
 	"os/user"
 	"reflect"
 	"runtime"
@@ -33,27 +32,21 @@ import (
 	"testing/synctest"
 	"time"
 
-	gliderssh "github.com/tailscale/gliderssh"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	"tailscale.com/cmd/testwrapper/flakytest"
-	"tailscale.com/ipn/ipnlocal"
-	"tailscale.com/ipn/store/mem"
 	"tailscale.com/net/memnet"
 	"tailscale.com/net/tsdial"
 	"tailscale.com/sessionrecording"
 	"tailscale.com/tailcfg"
 	testssh "tailscale.com/tempfork/sshtest/ssh"
-	"tailscale.com/tsd"
 	"tailscale.com/tstest"
 	"tailscale.com/types/key"
-	"tailscale.com/types/logid"
 	"tailscale.com/types/netmap"
 	"tailscale.com/util/cibuild"
 	"tailscale.com/util/lineiter"
 	"tailscale.com/util/must"
 	"tailscale.com/version/distro"
-	"tailscale.com/wgengine"
 )
 
 func TestMatchRule(t *testing.T) {
@@ -523,6 +516,7 @@ func TestSSHRecordingCancelsSessionsOnUploadFailure(t *testing.T) {
 		handler          func(w http.ResponseWriter, r *http.Request)
 		sshCommand       string
 		wantClientOutput string
+		wantExitCode     int // SSH exit status; 0 = don't check. 254 = recording infra failure.
 
 		clientOutputMustNotContain []string
 	}{
@@ -533,6 +527,9 @@ func TestSSHRecordingCancelsSessionsOnUploadFailure(t *testing.T) {
 			},
 			sshCommand:       "echo hello",
 			wantClientOutput: "session rejected\r\n",
+			// 254 once recording failures get their own exit code; the
+			// current code exits 1 here.
+			wantExitCode: 0,
 
 			clientOutputMustNotContain: []string{"hello"},
 		},
@@ -579,6 +576,16 @@ func TestSSHRecordingCancelsSessionsOnUploadFailure(t *testing.T) {
 					t.Logf("client got: %q: %v", got, err)
 				} else {
 					t.Errorf("client did not get kicked out: %q", got)
+				}
+				if tt.wantExitCode != 0 {
+					var exitErr *testssh.ExitError
+					if errors.As(err, &exitErr) {
+						if got := exitErr.ExitStatus(); got != tt.wantExitCode {
+							t.Errorf("exit code = %d, want %d", got, tt.wantExitCode)
+						}
+					} else {
+						t.Errorf("want *ssh.ExitError, got %T: %v", err, err)
+					}
 				}
 				gotStr := string(got)
 				if !strings.HasSuffix(gotStr, tt.wantClientOutput) {
@@ -1072,88 +1079,8 @@ func TestSSHAuthFlow(t *testing.T) {
 }
 
 func TestSSH(t *testing.T) {
-	logf := tstest.WhileTestRunningLogger(t)
-	sys := tsd.NewSystem()
-	eng, err := wgengine.NewFakeUserspaceEngine(logf, sys.Set, sys.HealthTracker.Get(), sys.UserMetricsRegistry(), sys.Bus.Get())
-	if err != nil {
-		t.Fatal(err)
-	}
-	sys.Set(eng)
-	sys.Set(new(mem.Store))
-	lb, err := ipnlocal.NewLocalBackend(logf, logid.PublicID{}, sys, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer lb.Shutdown()
-	dir := t.TempDir()
-	lb.SetVarRoot(dir)
-
-	srv := &server{
-		lb:   lb,
-		logf: logf,
-	}
-	sc, err := srv.newConn()
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Remove the auth checks for the test
-	sc.insecureSkipTailscaleAuth = true
-
-	u, err := user.Current()
-	if err != nil {
-		t.Fatal(err)
-	}
-	um, err := userLookup(u.Username)
-	if err != nil {
-		t.Fatal(err)
-	}
-	sc.localUser = um
-	sc.info = &sshConnInfo{
-		sshUser: "test",
-		src:     netip.MustParseAddrPort("1.2.3.4:32342"),
-		dst:     netip.MustParseAddrPort("1.2.3.5:22"),
-		node:    (&tailcfg.Node{}).View(),
-		uprof:   tailcfg.UserProfile{},
-	}
-	sc.action0 = &tailcfg.SSHAction{Accept: true}
-	sc.finalAction = sc.action0
-	sc.authCompleted.Store(true)
-
-	sc.Handler = func(s gliderssh.Session) {
-		sc.newSSHSession(s).run()
-	}
-
-	ln, err := net.Listen("tcp4", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer ln.Close()
-	port := ln.Addr().(*net.TCPAddr).Port
-
-	go func() {
-		for {
-			c, err := ln.Accept()
-			if err != nil {
-				if !errors.Is(err, net.ErrClosed) {
-					t.Errorf("Accept: %v", err)
-				}
-				return
-			}
-			go sc.HandleConn(c)
-		}
-	}()
-
-	execSSH := func(args ...string) *exec.Cmd {
-		cmd := exec.Command("ssh",
-			"-F",
-			"none",
-			"-v",
-			"-p", fmt.Sprint(port),
-			"-o", "StrictHostKeyChecking=no",
-			"user@127.0.0.1")
-		cmd.Args = append(cmd.Args, args...)
-		return cmd
-	}
+	h := newTestSSHHarness(t)
+	u, execSSH := h.user, h.execSSH
 
 	t.Run("env", func(t *testing.T) {
 		if cibuild.On() {


### PR DESCRIPTION
This is part two of bringing in #18331 where the gliderlabs SSH part has gone into https://github.com/tailscale/gliderssh/pull/8 and in this PR is brought in as an updated dependency. 

The comments from #18331 has been implemented and I've been sparring heavily with Claude on implementing macOS and exit code tests which surfaced a couple of issues that has been addressed.

Closes https://github.com/tailscale/tailscale/pull/18331
Fixes #18256