### PR TITLE
ipn/ipnlocal: don't compact TKA state on startup

### DIFF
--- a/ipn/ipnlocal/network-lock.go
+++ b/ipn/ipnlocal/network-lock.go
@@ -96,10 +96,6 @@ func (b *LocalBackend) initTKALocked() error {
 			return fmt.Errorf("initializing tka: %v", err)
 		}
 
-		if err := authority.Compact(storage, tka.CompactionDefaults); err != nil {
-			b.logf("tka compaction failed: %v", err)
-		}
-
 		b.tka = &tkaState{
 			profile:   cp.ID(),
 			authority: authority,


### PR DESCRIPTION
Compacting on startup means nodes may compact at a different cadence based on whether they're long-running or restarting frequently.

We already compact after every sync, which only occurs when the TKA state has changed. Waiting for TKA changes to trigger compaction on nodes means compaction will occur more consistently across a tailnet.

Updates tailscale/corp#33537