### PR TITLE
cmd/tailscale/cli: fetch netmap via current-netmap debug action

### DIFF
--- a/cmd/tailscale/cli/debug.go
+++ b/cmd/tailscale/cli/debug.go
@@ -670,18 +670,11 @@ func runNetmap(ctx context.Context, args []string) error {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	var mask ipn.NotifyWatchOpt = ipn.NotifyInitialNetMap
-	watcher, err := localClient.WatchIPNBus(ctx, mask)
+	raw, err := localClient.DebugResultJSON(ctx, "current-netmap")
 	if err != nil {
 		return err
 	}
-	defer watcher.Close()
-
-	n, err := watcher.Next()
-	if err != nil {
-		return err
-	}
-	j, _ := json.MarshalIndent(n.NetMap, "", "\t")
+	j, _ := json.MarshalIndent(raw, "", "\t")
 	fmt.Printf("%s\n", j)
 	return nil
 }


### PR DESCRIPTION
Stop opening an IPN bus subscription with NotifyInitialNetMap purely to
read the current netmap once. Use the LocalAPI debug current-netmap
action (added in 159cf8707) instead, which returns the current netmap
synchronously without subscribing to the bus.

Updates #12542
