### PR TITLE
tka: clarify that this limit is on disablement *values* not *secrets*

### DIFF
--- a/tka/limits.go
+++ b/tka/limits.go
@@ -10,8 +10,8 @@ import (
 const (
 	// Upper bound on checkpoint elements, chosen arbitrarily. Intended
 	// to cap the size of large AUMs.
-	maxDisablementSecrets = 32
-	maxKeys               = 512
+	maxDisablementValues = 32
+	maxKeys              = 512
 
 	// Max amount of metadata that can be associated with a key, chosen arbitrarily.
 	// Intended to avoid people abusing TKA as a key-value score.

--- a/tka/state.go
+++ b/tka/state.go
@@ -261,8 +261,8 @@ func (s *State) staticValidateCheckpoint() error {
 	if len(s.DisablementValues) == 0 {
 		return errors.New("at least one disablement secret required")
 	}
-	if numDS := len(s.DisablementValues); numDS > maxDisablementSecrets {
-		return fmt.Errorf("too many disablement secrets (%d, max %d)", numDS, maxDisablementSecrets)
+	if numDS := len(s.DisablementValues); numDS > maxDisablementValues {
+		return fmt.Errorf("too many disablement values (%d, max %d)", numDS, maxDisablementValues)
 	}
 	for i, ds := range s.DisablementValues {
 		if len(ds) != disablementLength {


### PR DESCRIPTION
Values get written into TKA state; secrets don't.

Updates #cleanup