### PR TITLE
cmd/tailscaled, version/distro: default to userspace-networking on Crostini

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -87,6 +87,16 @@ func defaultTunName() string {
 			// See https://github.com/tailscale/tailscale-synology/issues/35
 			return "tailscale0,userspace-networking"
 		}
+		if buildfeatures.HasNetstack && distro.Get() == distro.Crostini {
+			// cros-garcon NULL-derefs on cold-boot netlink interface
+			// enumeration when tailscale0 is present, preventing the
+			// Crostini container and ChromeOS Terminal from starting
+			// cleanly. Default to userspace-networking until the
+			// upstream ChromiumOS bug is fixed.
+			// See https://github.com/tailscale/tailscale/issues/12090
+			// See https://issuetracker.google.com/issues/517069318
+			return "userspace-networking"
+		}
 	}
 	return "tailscale0"
 }

--- a/ssh/tailssh/user.go
+++ b/ssh/tailssh/user.go
@@ -93,7 +93,7 @@ func defaultPathForUser(u *user.User) string {
 	}
 	isRoot := u.Uid == "0"
 	switch distro.Get() {
-	case distro.Debian:
+	case distro.Debian, distro.Crostini:
 		hi := hostinfo.New()
 		if hi.Distro == "ubuntu" {
 			// distro.Get's Debian includes Ubuntu. But see if it's actually Ubuntu.

--- a/version/distro/distro.go
+++ b/version/distro/distro.go
@@ -19,6 +19,7 @@ type Distro string
 
 const (
 	Debian    = Distro("debian")
+	Crostini  = Distro("crostini") // ChromeOS Crostini Linux container; Debian-based
 	Arch      = Distro("arch")
 	Synology  = Distro("synology")
 	OpenWrt   = Distro("openwrt")
@@ -84,6 +85,11 @@ func linuxDistro() Distro {
 		// Currently supported product families:
 		// - UDM (UniFi Dream Machine, UDM-Pro)
 		return UBNT
+	case have("/opt/google/cros-containers/bin/garcon"):
+		// ChromeOS Crostini ships /opt/google/cros-containers/bin/garcon
+		// in every penguin container. MUST be checked before Debian since
+		// Crostini is Debian-based.
+		return Crostini
 	case have("/etc/debian_version"):
 		return Debian
 	case have("/etc/arch-release"):


### PR DESCRIPTION
## Summary

Picks up from #19488 where I laid out the design. Defaults Crostini to userspace-networking so tailscale0 never gets created and cros-garcon doesn't trip on it during cold-boot netlink enumeration (#12090). Same shape as #9138 (default to userspace-networking on plan9), one platform quirk over.

## Bug

Cold-booting a Chromebook with the Linux container (Crostini) and Tailscale installed causes garcon to NULL-deref when it enumerates network interfaces. tailscale0 in the list, garcon dies, container fails to come up, ChromeOS Terminal won't open. The bug is in cros-garcon's netlink response handling but cros-garcon ships closed-source out of Google so the upstream fix is on an indefinite timeline. Documented since 2024-05 in #12090 with multiple reporters and inconsistent workaround success.

## Patch

Three files, +16/-1.

* `version/distro/distro.go`: add `Crostini` constant. Detect via `/opt/google/cros-containers/bin/garcon`, checked before `/etc/debian_version` since Crostini is Debian-based.
* `cmd/tailscaled/tailscaled.go`: add Crostini case in `defaultTunName()`, guarded by `buildfeatures.HasNetstack` to mirror the existing Synology pattern.
* `ssh/tailssh/user.go`: extend the existing Debian default-PATH case to include Crostini.

Override stays available via `--tun=tailscale0` for ChromeOS builds where cros-garcon gets fixed.

## Tested

On my Chromebook (Crostini, Debian 12 bookworm, aarch64). Pulled the `FLAGS="--tun=userspace-networking"` workaround out of `/etc/default/tailscaled` so the patch had to do the work via distro detection. Cold-booted.

* ChromeOS Terminal opens clean
* tailscaled running with no `--tun` flag in cmdline
* `ip link show tailscale0`: device does not exist (userspace mode confirmed)
* No garcon SEGV in dmesg
* `tailscale status`: connected normally

Fixes #19488
Updates #12090
