### PR TITLE
util/sizetest,cmd/symcost: add tools for diagnosing generics symbol costs

### DIFF
--- a/cmd/symcost/symcost.go
+++ b/cmd/symcost/symcost.go
@@ -1,25 +1,33 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-// Command symcost analyzes a Go binary's symbol table and reports
-// which generic functions and types are most expensive in aggregate.
+// Command symcost analyzes a Go binary and reports binary-size cost
+// attribution by receiver type, by function, or as a top-N grouped
+// view across the whole binary.
 //
 // Usage:
 //
 //	symcost [flags] <binary>
 //
-// Flags:
+// Discovery (default): top-N groups across the binary.
 //
-//	-package=substr    keep only groups whose package contains substr
-//	-min-count=N       keep only groups with at least N member symbols
-//	-min-bytes=N       keep only groups whose total size is >= N bytes
-//	-generic           keep only groups representing generic instantiations
-//	-top=N             show only the top N rows (default 30; 0 = all)
-//	-format=text|tsv   output format (default text)
+//	symcost                    -top=30 -package=substr
+//	symcost -generic           keep only generic instantiations
+//	symcost -min-count=N       require at least N members per group
+//	symcost -min-bytes=N       require at least N total bytes per group
+//
+// Receiver mode: the cost of a type and everything associated with
+// it (methods, dicts, eq/hash funcs, type descriptors, itabs).
+//
+//	symcost -receiver=tailscale.com/util/eventbus.Publisher
+//
+// Function mode: the cost of one function (or one generic template)
+// across all instantiations.
+//
+//	symcost -func=tailscale.com/util/eventbus.(*SubscriberFunc[…]).dispatch
 //
 // The binary should be built without -ldflags="-s -w" so that the
-// symbol table is preserved. -trimpath is recommended to keep symbol
-// names compact and reproducible.
+// symbol table is preserved. -trimpath is recommended.
 package main
 
 import (
@@ -32,12 +40,18 @@ import (
 )
 
 var (
-	packageSubstr = flag.String("package", "", "keep only groups whose package contains this substring")
-	minCount      = flag.Int("min-count", 0, "keep only groups with at least N member symbols")
-	minBytes      = flag.Int64("min-bytes", 0, "keep only groups whose total size is >= N bytes")
-	genericOnly   = flag.Bool("generic", false, "keep only generic instantiations")
+	// Discovery-mode flags.
+	packageSubstr = flag.String("package", "", "keep only groups whose package contains this substring (discovery mode)")
+	minCount      = flag.Int("min-count", 0, "keep only groups with at least N members (discovery mode)")
+	minBytes      = flag.Int64("min-bytes", 0, "keep only groups whose total size is >= N bytes (discovery mode)")
+	genericOnly   = flag.Bool("generic", false, "keep only generic instantiations (discovery mode)")
 	top           = flag.Int("top", 30, "show only the top N rows (0 = all)")
-	format        = flag.String("format", "text", "output format: text or tsv")
+
+	// Targeted-mode flags.
+	receiver = flag.String("receiver", "", "report the full cost of a receiver type and everything associated with it")
+	function = flag.String("func", "", "report the cost of one function (or generic template) across all instantiations")
+
+	format = flag.String("format", "text", "output format: text or tsv")
 )
 
 func main() {
@@ -50,32 +64,144 @@ func main() {
 		flag.Usage()
 		os.Exit(2)
 	}
+	binPath := flag.Arg(0)
 
-	groups, err := symcost.Analyze(flag.Arg(0))
+	switch {
+	case *receiver != "":
+		runReceiver(binPath, *receiver)
+	case *function != "":
+		runFunction(binPath, *function)
+	default:
+		runDiscovery(binPath)
+	}
+}
+
+func runReceiver(binPath, name string) {
+	b, err := symcost.Open(binPath)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+	defer b.Close()
+	c := b.CostByReceiver(name)
+	writeCost(os.Stdout, c, "receiver")
+}
 
+func runFunction(binPath, name string) {
+	b, err := symcost.Open(binPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer b.Close()
+	c := b.CostByFunction(name)
+	writeCost(os.Stdout, c, "function")
+}
+
+func runDiscovery(binPath string) {
+	groups, err := symcost.Analyze(binPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 	groups = symcost.Filter{
 		PackageSubstr: *packageSubstr,
 		MinCount:      *minCount,
 		MinTotal:      *minBytes,
 		GenericOnly:   *genericOnly,
 	}.Apply(groups)
-
 	if *top > 0 && len(groups) > *top {
 		groups = groups[:*top]
 	}
-
 	switch *format {
 	case "text":
 		writeText(os.Stdout, groups)
 	case "tsv":
 		writeTSV(os.Stdout, groups)
 	default:
-		fmt.Fprintf(os.Stderr, "unknown -format %q (want text or tsv)\n", *format)
+		fmt.Fprintf(os.Stderr, "unknown -format %q\n", *format)
 		os.Exit(2)
+	}
+}
+
+func writeCost(w *os.File, c symcost.Cost, mode string) {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(tw, "%s\t%s\n", "Mode:", mode)
+	fmt.Fprintf(tw, "%s\t%s\n", "Target:", c.Target)
+	fmt.Fprintf(tw, "%s\t%d bytes\n", "Total:", c.Total)
+	tw.Flush()
+	fmt.Fprintln(w)
+
+	// Section breakdown.
+	fmt.Fprintln(w, "By section:")
+	tw = tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "  SECTION\tBYTES")
+	for sec, n := range c.Sections {
+		fmt.Fprintf(tw, "  %s\t%d\n", sec, n)
+	}
+	tw.Flush()
+	fmt.Fprintln(w)
+
+	// Top funcs.
+	if len(c.Funcs) > 0 {
+		fmt.Fprintln(w, "Top functions:")
+		tw = tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "  TOTAL\tBODY\tPCLNTAB\tNAME")
+		for i, f := range c.Funcs {
+			if i >= 30 {
+				fmt.Fprintf(tw, "  ...\t\t\t(%d more)\n", len(c.Funcs)-30)
+				break
+			}
+			fmt.Fprintf(tw, "  %d\t%d\t%d\t%s\n", f.Total(), f.BodyBytes, f.PclntabBytes, f.Name)
+		}
+		tw.Flush()
+		fmt.Fprintln(w)
+	}
+
+	// Types summary.
+	if len(c.Types) > 0 {
+		var total int64
+		for _, t := range c.Types {
+			total += t.Total()
+		}
+		fmt.Fprintf(w, "Type descriptors: %d entries, %d bytes\n", len(c.Types), total)
+		if len(c.Types) <= 10 {
+			tw = tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+			for _, t := range c.Types {
+				fmt.Fprintf(tw, "  %d\t%s\n", t.Total(), t.Name)
+			}
+			tw.Flush()
+		}
+		fmt.Fprintln(w)
+	}
+
+	// Itabs summary.
+	if len(c.Itabs) > 0 {
+		var total int64
+		for _, it := range c.Itabs {
+			total += it.Bytes
+		}
+		fmt.Fprintf(w, "Itabs: %d entries, %d bytes\n", len(c.Itabs), total)
+		fmt.Fprintln(w)
+	}
+
+	// Named symbols summary.
+	if len(c.NamedSyms) > 0 {
+		var total int64
+		for _, s := range c.NamedSyms {
+			total += s.Bytes
+		}
+		fmt.Fprintf(w, "Other named symbols: %d entries, %d bytes\n", len(c.NamedSyms), total)
+		tw = tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "  BYTES\tSECTION\tNAME")
+		for i, s := range c.NamedSyms {
+			if i >= 15 {
+				fmt.Fprintf(tw, "  ...\t\t(%d more)\n", len(c.NamedSyms)-15)
+				break
+			}
+			fmt.Fprintf(tw, "  %d\t%s\t%s\n", s.Bytes, s.Section, s.Name)
+		}
+		tw.Flush()
 	}
 }
 

--- a/cmd/symcost/symcost.go
+++ b/cmd/symcost/symcost.go
@@ -1,0 +1,98 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Command symcost analyzes a Go binary's symbol table and reports
+// which generic functions and types are most expensive in aggregate.
+//
+// Usage:
+//
+//	symcost [flags] <binary>
+//
+// Flags:
+//
+//	-package=substr    keep only groups whose package contains substr
+//	-min-count=N       keep only groups with at least N member symbols
+//	-min-bytes=N       keep only groups whose total size is >= N bytes
+//	-generic           keep only groups representing generic instantiations
+//	-top=N             show only the top N rows (default 30; 0 = all)
+//	-format=text|tsv   output format (default text)
+//
+// The binary should be built without -ldflags="-s -w" so that the
+// symbol table is preserved. -trimpath is recommended to keep symbol
+// names compact and reproducible.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"tailscale.com/util/sizetest/symcost"
+)
+
+var (
+	packageSubstr = flag.String("package", "", "keep only groups whose package contains this substring")
+	minCount      = flag.Int("min-count", 0, "keep only groups with at least N member symbols")
+	minBytes      = flag.Int64("min-bytes", 0, "keep only groups whose total size is >= N bytes")
+	genericOnly   = flag.Bool("generic", false, "keep only generic instantiations")
+	top           = flag.Int("top", 30, "show only the top N rows (0 = all)")
+	format        = flag.String("format", "text", "output format: text or tsv")
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "usage: %s [flags] <binary>\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+	if flag.NArg() != 1 {
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	groups, err := symcost.Analyze(flag.Arg(0))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	groups = symcost.Filter{
+		PackageSubstr: *packageSubstr,
+		MinCount:      *minCount,
+		MinTotal:      *minBytes,
+		GenericOnly:   *genericOnly,
+	}.Apply(groups)
+
+	if *top > 0 && len(groups) > *top {
+		groups = groups[:*top]
+	}
+
+	switch *format {
+	case "text":
+		writeText(os.Stdout, groups)
+	case "tsv":
+		writeTSV(os.Stdout, groups)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown -format %q (want text or tsv)\n", *format)
+		os.Exit(2)
+	}
+}
+
+func writeText(w *os.File, groups []symcost.Group) {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "TOTAL\tCOUNT\tAVG\tMIN\tMAX\tTEMPLATE")
+	for _, g := range groups {
+		fmt.Fprintf(tw, "%d\t%d\t%d\t%d\t%d\t%s\n",
+			g.Total, g.Count(), g.Avg, g.Min, g.Max, g.Template)
+	}
+	tw.Flush()
+}
+
+func writeTSV(w *os.File, groups []symcost.Group) {
+	fmt.Fprintln(w, "total\tcount\tavg\tmin\tmax\tpackage\ttemplate")
+	for _, g := range groups {
+		fmt.Fprintf(w, "%d\t%d\t%d\t%d\t%d\t%s\t%s\n",
+			g.Total, g.Count(), g.Avg, g.Min, g.Max, g.Package, g.Template)
+	}
+}

--- a/util/eventbus/sizetest/sizetest_test.go
+++ b/util/eventbus/sizetest/sizetest_test.go
@@ -26,12 +26,21 @@
 // (a few hundred bytes) produce a clearly measurable change in the
 // total delta.
 //
+// We measure on two architectures: the host arch (whatever Go reports
+// as runtime.GOARCH) and linux/arm64 via cross-compilation. arm64 is
+// the architecture where binary-size constraint actually bites for
+// this codebase (iOS, Android, Apple Silicon), so reporting it
+// alongside the host arch makes regressions on the constrained
+// platform visible during normal CI.
+//
 // Uses:
 //
-//  1. As an artifact: print the per-flow number, do an optimization,
+//  1. As an artifact: print the per-flow numbers, do an optimization,
 //     re-run, and quote the improvement.
 //  2. As a regression gate: set EVENTBUS_SIZETEST_MAX_BYTES_PER_FLOW
-//     in CI to fail when per-flow cost exceeds a known-good threshold.
+//     in CI to fail when per-flow cost exceeds a known-good threshold
+//     on the host arch. (Cross-arch gating could be added later if
+//     needed; for now the host-arch gate prevents most regressions.)
 //
 // Note that absolute byte counts are NOT portable across Go versions,
 // GOOS, or GOARCH. Any threshold needs to be paired with a known
@@ -41,11 +50,14 @@ package sizetest_test
 import (
 	"fmt"
 	"os"
+	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
 
 	"tailscale.com/util/sizetest"
+	"tailscale.com/util/sizetest/symcost"
 )
 
 const (
@@ -79,38 +91,54 @@ const (
 	addedFlows = 500
 )
 
+// archMeasurement is the per-flow cost result for one (GOOS, GOARCH)
+// pair, with optional per-receiver attribution from symcost.
+type archMeasurement struct {
+	goos, goarch string
+	baseline     int64
+	treatment    int64
+	delta        int64
+	perFlow      float64
+
+	// symcostFor maps a receiver name (e.g.
+	// "tailscale.com/util/eventbus.Publisher") to the bytes
+	// attributed to it on the treatment binary. Populated by
+	// runSymcost when symbol-table-bearing builds are available;
+	// nil otherwise.
+	symcostFor map[string]int64
+}
+
 func TestPerFlowBinaryCost(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping: invokes `go build` twice")
+		t.Skip("skipping: invokes `go build` multiple times")
 	}
 
-	baseline := sizetest.Variant{
-		Name:   fmt.Sprintf("flows-%d", baselineFlows),
-		Source: programWithFlows(baselineFlows),
+	// Always measure on the host arch (this is what the gate
+	// applies to and what existing CI users expect).
+	host := measureOnArch(t, "", "")
+	logArchMeasurement(t, host)
+
+	// Also measure on linux/arm64 via cross-compilation. We don't
+	// run the binaries; we only stat them and (for symcost-mode)
+	// parse their ELF. Cross-compilation is fast and works on any
+	// host; if it ever fails we report a t.Logf and continue
+	// rather than failing the test, since the host-arch number
+	// is the gating signal.
+	if runtime.GOOS != "linux" || runtime.GOARCH != "arm64" {
+		arm := measureOnArchOrSkip(t, "linux", "arm64")
+		if arm != nil {
+			logArchMeasurement(t, *arm)
+		}
 	}
-	treatment := sizetest.Variant{
-		Name:   fmt.Sprintf("flows-%d", baselineFlows+addedFlows),
-		Source: programWithFlows(baselineFlows + addedFlows),
-	}
 
-	baseRes, treatRes, totalDelta := sizetest.Diff(t, baseline, treatment)
-
-	perFlow := float64(totalDelta) / float64(addedFlows)
-
-	t.Logf("eventbus per-flow binary cost measurement:")
-	t.Logf("  baseline:  %d flows -> %d bytes", baselineFlows, baseRes.Bytes)
-	t.Logf("  treatment: %d flows -> %d bytes", baselineFlows+addedFlows, treatRes.Bytes)
-	t.Logf("  total delta over %d added flows: %+d bytes", addedFlows, totalDelta)
-	t.Logf("  average per-flow cost: %.1f bytes", perFlow)
-
-	if totalDelta <= 0 {
-		// A non-positive delta means either the linker dead-stripped
-		// our flows (the program isn't exercising them enough) or
-		// something pathological happened. Fail loudly so we don't
-		// silently report a meaningless number.
+	if host.delta <= 0 {
+		// A non-positive delta means either the linker
+		// dead-stripped our flows (the program isn't exercising
+		// them enough) or something pathological happened. Fail
+		// loudly so we don't silently report a meaningless number.
 		t.Fatalf("expected positive delta with %d added flows; got %d. The variants "+
 			"likely aren't keeping the generic instantiations alive end-to-end.",
-			addedFlows, totalDelta)
+			addedFlows, host.delta)
 	}
 
 	if maxStr := os.Getenv("EVENTBUS_SIZETEST_MAX_BYTES_PER_FLOW"); maxStr != "" {
@@ -120,11 +148,154 @@ func TestPerFlowBinaryCost(t *testing.T) {
 		}
 		// Compare against the integer per-flow cost (rounded up) so a
 		// gate like "fail if any flow costs more than 4096 bytes" is
-		// expressed naturally.
-		perFlowInt := (totalDelta + int64(addedFlows) - 1) / int64(addedFlows)
+		// expressed naturally. The gate applies to the host arch
+		// only; cross-arch numbers are reported but not gated.
+		perFlowInt := (host.delta + int64(addedFlows) - 1) / int64(addedFlows)
 		if perFlowInt > max {
-			t.Errorf("average per-flow cost %d bytes exceeds gate of %d bytes "+
+			t.Errorf("host-arch per-flow cost %d bytes exceeds gate of %d bytes "+
 				"(EVENTBUS_SIZETEST_MAX_BYTES_PER_FLOW)", perFlowInt, max)
+		}
+	}
+}
+
+// measureOnArch builds the baseline and treatment programs for the
+// given (GOOS, GOARCH) — empty strings mean the host's defaults —
+// and returns the resulting per-flow numbers. It also builds an
+// unstripped treatment binary (symbols preserved) and runs symcost
+// against it to get per-receiver attribution; the symcost step is
+// best-effort and silently skipped on architectures we can't analyze.
+func measureOnArch(t *testing.T, goos, goarch string) archMeasurement {
+	t.Helper()
+
+	stripped := sizetest.BuildOptions{
+		LDFlags:  "-s -w",
+		Trimpath: ptr(true),
+		GOOS:     goos,
+		GOARCH:   goarch,
+	}
+	unstripped := sizetest.BuildOptions{
+		LDFlags:  " ", // explicit non-empty to override default of "-s -w"
+		Trimpath: ptr(true),
+		GOOS:     goos,
+		GOARCH:   goarch,
+	}
+
+	baseline := sizetest.Variant{
+		Name:   fmt.Sprintf("flows-%d-%s", baselineFlows, archTag(goos, goarch)),
+		Source: programWithFlows(baselineFlows),
+	}
+	treatment := sizetest.Variant{
+		Name:   fmt.Sprintf("flows-%d-%s", baselineFlows+addedFlows, archTag(goos, goarch)),
+		Source: programWithFlows(baselineFlows + addedFlows),
+	}
+
+	// Stripped builds give the headline size delta with minimal
+	// noise.
+	baseRes, treatRes, totalDelta := sizetest.DiffWithOptions(t, baseline, treatment, stripped)
+
+	m := archMeasurement{
+		goos:      effective(goos, runtime.GOOS),
+		goarch:    effective(goarch, runtime.GOARCH),
+		baseline:  baseRes.Bytes,
+		treatment: treatRes.Bytes,
+		delta:     totalDelta,
+		perFlow:   float64(totalDelta) / float64(addedFlows),
+	}
+
+	// Unstripped treatment build for symcost attribution.
+	treatmentUnstripped := sizetest.Variant{
+		Name:   treatment.Name + "-symbols",
+		Source: treatment.Source,
+	}
+	unstrippedRes := sizetest.BuildWithOptions(t, treatmentUnstripped, unstripped)
+	m.symcostFor = runSymcost(t, unstrippedRes.BinaryPath)
+
+	return m
+}
+
+// measureOnArchOrSkip is like measureOnArch but converts cross-build
+// failures to a t.Logf + nil result rather than failing the test. We
+// don't want a flaky cross-arch toolchain to fail the CI run; the
+// host-arch number is the gate.
+func measureOnArchOrSkip(t *testing.T, goos, goarch string) *archMeasurement {
+	t.Helper()
+	// We can't easily catch a t.Fatal from sizetest, so we
+	// pre-flight by trying a no-op cross-build. If that succeeds,
+	// run the real measurement.
+	if !canCrossBuild(t, goos, goarch) {
+		t.Logf("skipping %s/%s measurement: cross-compile not available", goos, goarch)
+		return nil
+	}
+	m := measureOnArch(t, goos, goarch)
+	return &m
+}
+
+// canCrossBuild reports whether `go build` can target (goos, goarch)
+// in this environment. We probe by running a trivial cross-compile;
+// if the toolchain doesn't support the target, the probe fails fast.
+//
+// We probe with a direct `go build` rather than going through
+// sizetest because sizetest is t.Fatal-on-failure and we want to
+// silently fall back when cross-compilation isn't available.
+func canCrossBuild(t *testing.T, goos, goarch string) bool {
+	t.Helper()
+	dir := t.TempDir()
+	const src = "package main\nfunc main() {}\n"
+	if err := os.WriteFile(dir+"/main.go", []byte(src), 0o644); err != nil {
+		return false
+	}
+	if err := os.WriteFile(dir+"/go.mod", []byte("module probe\n\ngo 1.21\n"), 0o644); err != nil {
+		return false
+	}
+	cmd := exec.Command("go", "build", "-o", dir+"/out", ".")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOOS="+goos, "GOARCH="+goarch)
+	return cmd.Run() == nil
+}
+
+// runSymcost opens binPath with symcost and returns the per-receiver
+// attribution for the eventbus types we care about. Returns nil if
+// the binary can't be opened (e.g. unsupported architecture for
+// symcost.Open's parser).
+func runSymcost(t *testing.T, binPath string) map[string]int64 {
+	t.Helper()
+	b, err := symcost.Open(binPath)
+	if err != nil {
+		t.Logf("symcost.Open(%s): %v", binPath, err)
+		return nil
+	}
+	defer b.Close()
+	out := map[string]int64{}
+	for _, recv := range []string{
+		"tailscale.com/util/eventbus.Publisher",
+		"tailscale.com/util/eventbus.SubscriberFunc",
+	} {
+		c := b.CostByReceiver(recv)
+		out[recv] = c.Total
+	}
+	return out
+}
+
+// logArchMeasurement prints a human-readable per-arch summary block.
+func logArchMeasurement(t *testing.T, m archMeasurement) {
+	t.Helper()
+	t.Logf("eventbus per-flow binary cost on %s/%s:", m.goos, m.goarch)
+	t.Logf("  baseline:  %d flows -> %d bytes", baselineFlows, m.baseline)
+	t.Logf("  treatment: %d flows -> %d bytes", baselineFlows+addedFlows, m.treatment)
+	t.Logf("  total delta over %d added flows: %+d bytes", addedFlows, m.delta)
+	t.Logf("  average per-flow cost: %.1f bytes", m.perFlow)
+	if len(m.symcostFor) > 0 {
+		t.Logf("  symcost attribution on treatment binary:")
+		// Sort by total descending for stable, easy-to-read output.
+		names := make([]string, 0, len(m.symcostFor))
+		for k := range m.symcostFor {
+			names = append(names, k)
+		}
+		sortByMapValueDesc(names, m.symcostFor)
+		for _, name := range names {
+			v := m.symcostFor[name]
+			perFlow := float64(v) / float64(baselineFlows+addedFlows)
+			t.Logf("    %-50s %8d bytes  (%5.1f B/flow)", name, v, perFlow)
 		}
 	}
 }
@@ -188,4 +359,32 @@ import (
 
 	b.WriteString("}\n")
 	return b.String()
+}
+
+// archTag returns a filesystem-safe identifier for the (goos, goarch)
+// pair. Empty strings (host defaults) become "host".
+func archTag(goos, goarch string) string {
+	if goos == "" && goarch == "" {
+		return "host"
+	}
+	return effective(goos, "") + "-" + effective(goarch, "")
+}
+
+func effective(override, fallback string) string {
+	if override != "" {
+		return override
+	}
+	return fallback
+}
+
+func ptr[T any](v T) *T { return &v }
+
+// sortByMapValueDesc sorts keys in place by descending value in m.
+// Stable for ties; insertion sort, fine for the few-element case.
+func sortByMapValueDesc(keys []string, m map[string]int64) {
+	for i := 1; i < len(keys); i++ {
+		for j := i; j > 0 && m[keys[j-1]] < m[keys[j]]; j-- {
+			keys[j-1], keys[j] = keys[j], keys[j-1]
+		}
+	}
 }

--- a/util/eventbus/sizetest/sizetest_test.go
+++ b/util/eventbus/sizetest/sizetest_test.go
@@ -1,0 +1,191 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Package sizetest_test measures how much an additional eventbus flow
+// (one event type with a publisher and a subscriber) contributes to
+// compiled binary size.
+//
+// Background: in Go, every distinct event type T passed through
+// eventbus.Publish[T] / Subscribe[T] / SubscribeFunc[T] causes the
+// compiler to emit fresh GC-shape stencils of the generic method
+// bodies (Publisher[T].Publish, Subscriber[T].dispatch,
+// SubscriberFunc[T].dispatch, ...) plus per-T reflection metadata
+// from reflect.TypeFor[T](). For typical event structs with distinct
+// shapes this is a few KB per flow. See util/eventbus/doc.go and the
+// surrounding implementation.
+//
+// Methodology: we build two programs, a small "baseline" with just
+// enough flows to amortize one-time setup costs (bus init, reflect
+// pull-in, etc.) and a larger "treatment" with many additional
+// distinct flows. The size delta divided by the added flow count
+// gives a stable per-flow byte cost.
+//
+// We deliberately use a large flow delta (see addedFlows) so the
+// total byte difference is well above the linker's page-quantization
+// floor on any platform. That way even small per-flow improvements
+// (a few hundred bytes) produce a clearly measurable change in the
+// total delta.
+//
+// Uses:
+//
+//  1. As an artifact: print the per-flow number, do an optimization,
+//     re-run, and quote the improvement.
+//  2. As a regression gate: set EVENTBUS_SIZETEST_MAX_BYTES_PER_FLOW
+//     in CI to fail when per-flow cost exceeds a known-good threshold.
+//
+// Note that absolute byte counts are NOT portable across Go versions,
+// GOOS, or GOARCH. Any threshold needs to be paired with a known
+// build matrix; we deliberately do not bake one in.
+package sizetest_test
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"tailscale.com/util/sizetest"
+)
+
+const (
+	// baselineFlows is the number of flows in the baseline program.
+	// It needs to be >0 so one-time costs (the eventbus package's
+	// non-generic code, reflect, runtime support for generics, etc.)
+	// are present in both variants and cancel out in the delta.
+	// A handful is plenty.
+	baselineFlows = 4
+
+	// addedFlows is the number of additional distinct flows the
+	// treatment has. We use a large value so the total byte delta
+	// is well above the linker's page-quantization floor (~4 KB on
+	// most platforms) and so even small per-flow improvements
+	// produce a clearly visible swing in the total delta. The
+	// per-flow average is then rock-stable (~2% spread vs. much
+	// smaller N).
+	//
+	// 500 was chosen as the best signal-to-cost point after
+	// sweeping 30..5000:
+	//
+	//   addedFlows  per-flow   wall    RSS
+	//          100   3154 B   1.0s   176 MB
+	//          500   3097 B   2.3s   310 MB
+	//         1000   3101 B   3.1s   550 MB
+	//         5000   3114 B  13.0s  2560 MB
+	//
+	// The per-flow number is already stable by ~100 flows; going
+	// higher mostly buys memory and wall-time pain without
+	// improving sensitivity.
+	addedFlows = 500
+)
+
+func TestPerFlowBinaryCost(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping: invokes `go build` twice")
+	}
+
+	baseline := sizetest.Variant{
+		Name:   fmt.Sprintf("flows-%d", baselineFlows),
+		Source: programWithFlows(baselineFlows),
+	}
+	treatment := sizetest.Variant{
+		Name:   fmt.Sprintf("flows-%d", baselineFlows+addedFlows),
+		Source: programWithFlows(baselineFlows + addedFlows),
+	}
+
+	baseRes, treatRes, totalDelta := sizetest.Diff(t, baseline, treatment)
+
+	perFlow := float64(totalDelta) / float64(addedFlows)
+
+	t.Logf("eventbus per-flow binary cost measurement:")
+	t.Logf("  baseline:  %d flows -> %d bytes", baselineFlows, baseRes.Bytes)
+	t.Logf("  treatment: %d flows -> %d bytes", baselineFlows+addedFlows, treatRes.Bytes)
+	t.Logf("  total delta over %d added flows: %+d bytes", addedFlows, totalDelta)
+	t.Logf("  average per-flow cost: %.1f bytes", perFlow)
+
+	if totalDelta <= 0 {
+		// A non-positive delta means either the linker dead-stripped
+		// our flows (the program isn't exercising them enough) or
+		// something pathological happened. Fail loudly so we don't
+		// silently report a meaningless number.
+		t.Fatalf("expected positive delta with %d added flows; got %d. The variants "+
+			"likely aren't keeping the generic instantiations alive end-to-end.",
+			addedFlows, totalDelta)
+	}
+
+	if maxStr := os.Getenv("EVENTBUS_SIZETEST_MAX_BYTES_PER_FLOW"); maxStr != "" {
+		max, err := strconv.ParseInt(maxStr, 10, 64)
+		if err != nil {
+			t.Fatalf("EVENTBUS_SIZETEST_MAX_BYTES_PER_FLOW=%q: %v", maxStr, err)
+		}
+		// Compare against the integer per-flow cost (rounded up) so a
+		// gate like "fail if any flow costs more than 4096 bytes" is
+		// expressed naturally.
+		perFlowInt := (totalDelta + int64(addedFlows) - 1) / int64(addedFlows)
+		if perFlowInt > max {
+			t.Errorf("average per-flow cost %d bytes exceeds gate of %d bytes "+
+				"(EVENTBUS_SIZETEST_MAX_BYTES_PER_FLOW)", perFlowInt, max)
+		}
+	}
+}
+
+// programWithFlows returns the source of a package main program that
+// creates n distinct event types and wires each one through a
+// publisher and a SubscribeFunc subscriber. It also actually publishes
+// events on each, to defeat any dead-code elimination the linker
+// might attempt.
+//
+// The event types are made structurally distinct (different field
+// counts and types) so the Go compiler treats them as distinct GC
+// shapes and emits separate stencils per flow, which is the realistic
+// scenario we want to measure.
+func programWithFlows(n int) string {
+	var b strings.Builder
+	b.WriteString(`// Code generated by util/eventbus/sizetest; DO NOT EDIT.
+package main
+
+import (
+	"tailscale.com/util/eventbus"
+)
+
+`)
+
+	// Distinct event types.
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&b, "type Event%d struct {\n", i)
+		// Vary the field shape so each type has a distinct GC shape.
+		// We mix pointer and non-pointer fields and vary count.
+		fields := (i % 4) + 1
+		for f := 0; f < fields; f++ {
+			switch (i + f) % 4 {
+			case 0:
+				fmt.Fprintf(&b, "\tF%d int64\n", f)
+			case 1:
+				fmt.Fprintf(&b, "\tF%d string\n", f)
+			case 2:
+				fmt.Fprintf(&b, "\tF%d *int\n", f)
+			case 3:
+				fmt.Fprintf(&b, "\tF%d []byte\n", f)
+			}
+		}
+		b.WriteString("}\n\n")
+	}
+
+	b.WriteString(`func main() {
+	bus := eventbus.New()
+	defer bus.Close()
+	pcli := bus.Client("pub")
+	scli := bus.Client("sub")
+
+`)
+
+	// Per-flow wiring.
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&b, "\tp%d := eventbus.Publish[Event%d](pcli)\n", i, i)
+		fmt.Fprintf(&b, "\teventbus.SubscribeFunc(scli, func(Event%d) {})\n", i)
+		fmt.Fprintf(&b, "\tp%d.Publish(Event%d{})\n", i, i)
+	}
+
+	b.WriteString("}\n")
+	return b.String()
+}

--- a/util/sizetest/sizetest.go
+++ b/util/sizetest/sizetest.go
@@ -82,6 +82,14 @@ type BuildOptions struct {
 	// (after the standard flags). Useful for things like
 	// "-tags=foo,bar".
 	GoFlags []string
+	// GOOS, if non-empty, sets GOOS for the build. Useful for
+	// cross-compiling and measuring binary size on a non-host
+	// platform. Note that the resulting binary cannot be run on
+	// the host, but sizetest only stats it; that's fine.
+	GOOS string
+	// GOARCH, if non-empty, sets GOARCH for the build. Same caveats
+	// as GOOS.
+	GOARCH string
 }
 
 // DefaultBuildOptions are the build options used when none are supplied.
@@ -177,9 +185,16 @@ replace tailscale.com => %s
 	cmd.Dir = dir
 	// Force module mode and disable network by default; the parent
 	// module's go.sum + module cache should satisfy us.
-	cmd.Env = append(os.Environ(),
+	env := append(os.Environ(),
 		"GOFLAGS=-mod=mod",
 	)
+	if opts.GOOS != "" {
+		env = append(env, "GOOS="+opts.GOOS)
+	}
+	if opts.GOARCH != "" {
+		env = append(env, "GOARCH="+opts.GOARCH)
+	}
+	cmd.Env = env
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("sizetest: building variant %q with `go %s`:\n%s\nerror: %v",

--- a/util/sizetest/sizetest.go
+++ b/util/sizetest/sizetest.go
@@ -1,0 +1,271 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Package sizetest is a reusable primitive for measuring how much a code
+// change contributes to compiled binary size.
+//
+// The typical pattern is:
+//
+//   - Define two [Variant]s: a baseline and a treatment that differs only
+//     in the dimension you want to measure (e.g. one extra eventbus flow,
+//     one extra generic instantiation, one extra package import).
+//   - Call [Diff] to build both variants and report the size delta.
+//
+// Caveats:
+//
+//   - Absolute byte counts are not portable across Go versions, GOOS, GOARCH,
+//     or even minor toolchain configuration. Tests that bake in a specific
+//     byte threshold should gate on a known build matrix or use the
+//     [Result] values as informational output only.
+//   - To reduce noise, builds are performed with -trimpath and ldflags
+//     "-s -w" by default (no debug info, no symbol table). The remaining
+//     size is dominated by code, rodata, and runtime type metadata, which
+//     is what you usually want when measuring per-feature cost.
+//   - Each Variant is built in its own temporary module that uses a
+//     replace directive pointing at [ModuleRoot], so variant source can
+//     freely import packages from this repository.
+package sizetest
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"tailscale.com/util/testenv"
+)
+
+// Variant is one program to be built and measured. Its Source must be
+// a complete, compilable Go program for package main.
+type Variant struct {
+	// Name is a short human-readable identifier used in error messages
+	// and test output. It must be a valid filesystem name component.
+	Name string
+	// Source is the complete Go source for a package main program. It
+	// must contain `package main` and a `func main()`. Source may import
+	// any package reachable from the module root (see [ModuleRoot]).
+	Source string
+	// ExtraFiles is an optional map of additional source files to write
+	// alongside Source (filename -> contents). Used when a variant
+	// needs supporting files in package main.
+	ExtraFiles map[string]string
+}
+
+// Result is the outcome of building a single [Variant].
+type Result struct {
+	// Variant is the input that produced this result.
+	Variant Variant
+	// Bytes is the size of the compiled binary in bytes.
+	Bytes int64
+	// BinaryPath is the path to the compiled binary on disk. The file
+	// lives in a t.TempDir() and is cleaned up when the test ends.
+	BinaryPath string
+}
+
+// BuildOptions configures how variants are compiled.
+type BuildOptions struct {
+	// LDFlags is passed to `go build -ldflags`. If empty, "-s -w" is
+	// used to strip the symbol table and DWARF info, which makes
+	// measurements focus on code+rodata size and reduces cross-version
+	// noise.
+	//
+	// Pass a non-empty value (e.g. " ") to override the default; pass
+	// an explicit value to set custom flags.
+	LDFlags string
+	// Trimpath, if true, passes -trimpath to `go build`. Default true.
+	// Disable only if you specifically want path strings in the binary.
+	Trimpath *bool
+	// GoFlags is appended verbatim to the `go build` command line
+	// (after the standard flags). Useful for things like
+	// "-tags=foo,bar".
+	GoFlags []string
+}
+
+// DefaultBuildOptions are the build options used when none are supplied.
+// They favor low-noise, reproducible measurements over realism.
+var DefaultBuildOptions = BuildOptions{
+	LDFlags:  "-s -w",
+	Trimpath: ptr(true),
+}
+
+func ptr[T any](v T) *T { return &v }
+
+// Build compiles v and returns its size. It uses [DefaultBuildOptions].
+// See [BuildWithOptions] for control over build flags.
+func Build(t testenv.TB, v Variant) Result {
+	t.Helper()
+	return BuildWithOptions(t, v, DefaultBuildOptions)
+}
+
+// BuildWithOptions compiles v with the supplied options and returns
+// its size.
+//
+// Build artifacts (the temporary module and the resulting binary) live
+// in t.TempDir() and are cleaned up when the test ends.
+func BuildWithOptions(t testenv.TB, v Variant, opts BuildOptions) Result {
+	t.Helper()
+
+	if v.Name == "" {
+		t.Fatal("sizetest: Variant.Name is required")
+	}
+	if !strings.Contains(v.Source, "package main") {
+		t.Fatalf("sizetest: Variant %q Source must declare package main", v.Name)
+	}
+
+	root, err := ModuleRoot()
+	if err != nil {
+		t.Fatalf("sizetest: locating module root: %v", err)
+	}
+
+	dir := filepath.Join(t.TempDir(), sanitize(v.Name))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("sizetest: mkdir variant dir: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(v.Source), 0o644); err != nil {
+		t.Fatalf("sizetest: writing main.go for %q: %v", v.Name, err)
+	}
+	for name, contents := range v.ExtraFiles {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(contents), 0o644); err != nil {
+			t.Fatalf("sizetest: writing extra file %q for %q: %v", name, v.Name, err)
+		}
+	}
+
+	// Synthesize a tiny module that pins to the repo via a replace
+	// directive. This keeps the variant compilable against the
+	// in-tree version of any imported packages.
+	goMod := fmt.Sprintf(`module sizetestvariant/%s
+
+go %s
+
+require tailscale.com v0.0.0
+replace tailscale.com => %s
+`, sanitize(v.Name), shortGoVersion(), filepath.ToSlash(root))
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0o644); err != nil {
+		t.Fatalf("sizetest: writing go.mod: %v", err)
+	}
+
+	// Reuse the parent module's go.sum so we don't need network access
+	// to resolve transitive dependencies. The replace directive above
+	// covers tailscale.com itself; the rest is whatever it transitively
+	// pulls in.
+	if data, err := os.ReadFile(filepath.Join(root, "go.sum")); err == nil {
+		if err := os.WriteFile(filepath.Join(dir, "go.sum"), data, 0o644); err != nil {
+			t.Fatalf("sizetest: copying go.sum: %v", err)
+		}
+	}
+
+	binPath := filepath.Join(dir, "out")
+	if runtime.GOOS == "windows" {
+		binPath += ".exe"
+	}
+
+	args := []string{"build"}
+	if opts.Trimpath == nil || *opts.Trimpath {
+		args = append(args, "-trimpath")
+	}
+	if ld := opts.LDFlags; ld != "" {
+		args = append(args, "-ldflags="+ld)
+	}
+	args = append(args, opts.GoFlags...)
+	args = append(args, "-o", binPath, ".")
+
+	cmd := exec.CommandContext(t.Context(), "go", args...)
+	cmd.Dir = dir
+	// Force module mode and disable network by default; the parent
+	// module's go.sum + module cache should satisfy us.
+	cmd.Env = append(os.Environ(),
+		"GOFLAGS=-mod=mod",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("sizetest: building variant %q with `go %s`:\n%s\nerror: %v",
+			v.Name, strings.Join(args, " "), out, err)
+	}
+
+	info, err := os.Stat(binPath)
+	if err != nil {
+		t.Fatalf("sizetest: stat built binary for %q: %v", v.Name, err)
+	}
+
+	return Result{
+		Variant:    v,
+		Bytes:      info.Size(),
+		BinaryPath: binPath,
+	}
+}
+
+// Diff builds baseline and treatment and returns their results plus
+// the byte delta (treatment - baseline). A positive delta means the
+// treatment is larger.
+func Diff(t testenv.TB, baseline, treatment Variant) (baselineRes, treatmentRes Result, delta int64) {
+	t.Helper()
+	return DiffWithOptions(t, baseline, treatment, DefaultBuildOptions)
+}
+
+// DiffWithOptions is like [Diff] but accepts custom build options.
+func DiffWithOptions(t testenv.TB, baseline, treatment Variant, opts BuildOptions) (baselineRes, treatmentRes Result, delta int64) {
+	t.Helper()
+	baselineRes = BuildWithOptions(t, baseline, opts)
+	treatmentRes = BuildWithOptions(t, treatment, opts)
+	delta = treatmentRes.Bytes - baselineRes.Bytes
+	return baselineRes, treatmentRes, delta
+}
+
+// ModuleRoot returns the absolute filesystem path to the root of the
+// module containing the sizetest package itself (i.e. the tailscale.com
+// module). It locates the root by walking up from the package's
+// runtime-recorded source path until a go.mod is found.
+func ModuleRoot() (string, error) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", errors.New("runtime.Caller(0) failed")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", errors.New("no go.mod found above sizetest package")
+		}
+		dir = parent
+	}
+}
+
+// sanitize maps an arbitrary name to something safe to use as a
+// filesystem name component and Go module path element.
+func sanitize(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-' || r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	if b.Len() == 0 {
+		return "variant"
+	}
+	return b.String()
+}
+
+// shortGoVersion returns the major.minor portion of runtime.Version()
+// (e.g. "1.26") for use in a synthesized go.mod file.
+func shortGoVersion() string {
+	v := runtime.Version() // "go1.26.2"
+	v = strings.TrimPrefix(v, "go")
+	// Trim to major.minor.
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) < 2 {
+		return v
+	}
+	return parts[0] + "." + parts[1]
+}

--- a/util/sizetest/sizetest_test.go
+++ b/util/sizetest/sizetest_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package sizetest_test
+
+import (
+	"testing"
+
+	"tailscale.com/util/sizetest"
+)
+
+// TestDiffDetectsAddedCode verifies the primitive itself: a treatment
+// that pulls in extra code via an unused-but-not-eliminable side
+// effect is larger than a minimal baseline.
+//
+// This is a smoke test for the harness, not a measurement of any
+// specific feature. It just confirms that Diff() produces the
+// expected sign and that builds succeed in the synthesized module.
+func TestDiffDetectsAddedCode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping: invokes `go build` twice")
+	}
+
+	baseline := sizetest.Variant{
+		Name: "baseline",
+		Source: `package main
+
+func main() {}
+`,
+	}
+
+	// Pull in fmt and force a side effect the linker can't drop.
+	// This guarantees a meaningful positive delta.
+	treatment := sizetest.Variant{
+		Name: "treatment",
+		Source: `package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Fprintln(os.Stdout, "hello, world")
+}
+`,
+	}
+
+	base, treat, delta := sizetest.Diff(t, baseline, treatment)
+	t.Logf("baseline=%d bytes, treatment=%d bytes, delta=%+d bytes",
+		base.Bytes, treat.Bytes, delta)
+
+	if delta <= 0 {
+		t.Errorf("expected treatment to be larger than baseline; got delta=%d", delta)
+	}
+}

--- a/util/sizetest/symcost/abiconst.go
+++ b/util/sizetest/symcost/abiconst.go
@@ -1,0 +1,105 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package symcost
+
+// This file vendors the layout constants and offsets we need to
+// decode runtime type descriptors and itabs. They mirror the
+// definitions in Go's internal/abi (which we cannot import) and in
+// cmd/link/internal/ld/decodesym.go (which is the linker's
+// reverse-direction decoder).
+//
+// Refs:
+//   - Type layout: src/internal/abi/type.go
+//   - Layout helper functions: src/internal/abi/compiletype.go
+//   - Linker decoder: src/cmd/link/internal/ld/decodesym.go
+//
+// These constants are stable enough that Go has shipped them across
+// 1.21..1.26 without changes meaningful to size accounting. If a
+// future Go release changes the layout we'll need to update them
+// here; the integration tests detect such regressions by sanity-
+// checking that decoded type names match the binary's own symbol
+// table.
+
+// Kind values from internal/abi.
+type Kind uint8
+
+const (
+	KindInvalid Kind = iota
+	KindBool
+	KindInt
+	KindInt8
+	KindInt16
+	KindInt32
+	KindInt64
+	KindUint
+	KindUint8
+	KindUint16
+	KindUint32
+	KindUint64
+	KindUintptr
+	KindFloat32
+	KindFloat64
+	KindComplex64
+	KindComplex128
+	KindArray
+	KindChan
+	KindFunc
+	KindInterface
+	KindMap
+	KindPointer
+	KindSlice
+	KindString
+	KindStruct
+	KindUnsafePointer
+)
+
+const kindMask = (1 << 5) - 1
+
+// TFlag bits.
+const (
+	tflagUncommon       uint8 = 1 << 0
+	tflagExtraStar      uint8 = 1 << 1
+	tflagNamed          uint8 = 1 << 2
+	tflagRegularMemory  uint8 = 1 << 3
+	tflagGCMaskOnDemand uint8 = 1 << 4
+)
+
+// commonTypeSize returns the size in bytes of internal/abi.Type's
+// common header for the given pointer size. From
+// internal/abi.CommonSize: 4*ptrSize + 8 + 8.
+func commonTypeSize(ptrSize int) int { return 4*ptrSize + 8 + 8 }
+
+// uncommonSize returns the size of internal/abi.UncommonType:
+// pkgPath NameOff (4) + Mcount (2) + Xcount (2) + Moff (4) + _ (4).
+func uncommonSize() int { return 4 + 2 + 2 + 4 + 4 }
+
+// tflagOffset is the byte offset of the TFlag field within the
+// common Type header. From internal/abi.TFlagOff: 2*ptrSize + 4.
+func tflagOffset(ptrSize int) int { return 2*ptrSize + 4 }
+
+// kindOffset is the byte offset of the Kind field within the common
+// Type header. From src/cmd/link/internal/ld/decodesym.go: 2*ptrSize+7.
+func kindOffset(ptrSize int) int { return 2*ptrSize + 7 }
+
+// nameOffOffset is the byte offset of the Str (NameOff) field within
+// the common Type header. After the header: Size, PtrBytes, Hash,
+// TFlag, Align, FieldAlign, Kind, _padding to ptr align, Equal,
+// GCData, Str, PtrToThis. Equal is one ptr; GCData is one ptr; then
+// Str is the next 4 bytes. CommonSize counts everything through
+// PtrToThis. Layout:
+//
+//	ptrSize  Size_
+//	ptrSize  PtrBytes
+//	uint32   Hash
+//	uint8    TFlag
+//	uint8    Align_
+//	uint8    FieldAlign_
+//	uint8    Kind_
+//	ptrSize  Equal (function pointer)
+//	ptrSize  GCData (*byte)
+//	uint32   Str (NameOff)
+//	uint32   PtrToThis (TypeOff)
+//
+// So Str starts at 2*ptrSize + 8 + 2*ptrSize = 4*ptrSize + 8.
+func nameOffOffset(ptrSize int) int { return 4*ptrSize + 8 }

--- a/util/sizetest/symcost/attribute.go
+++ b/util/sizetest/symcost/attribute.go
@@ -97,6 +97,14 @@ func (b *Binary) CostByReceiver(receiver string) Cost {
 	}
 	matchTpl := receiverMatcher(receiver)
 
+	// Track what we've already attributed via instruction refs so
+	// the same item doesn't get charged twice (once via the name
+	// match below and again via a ref scan).
+	seenTypeName := map[string]bool{}
+	seenItabAddr := map[uint64]bool{}
+	seenSymName := map[string]bool{}
+	seenRefAddr := map[uint64]bool{}
+
 	// 1. Functions: receiver methods, eq/hash funcs, dicts (which
 	//    live in .rodata, not .text, but we look for them in the
 	//    symbol table).
@@ -112,19 +120,36 @@ func (b *Binary) CostByReceiver(receiver string) Cost {
 		c.Funcs = append(c.Funcs, fc)
 		c.Sections[".text"] += fc.BodyBytes
 		c.Sections[".gopclntab"] += fc.PclntabBytes
+		// On arm64 (and eventually other arches), pull in the
+		// rodata items each method instruction-references. This
+		// captures dictionaries, GC bitmaps, name strings, and
+		// other static data the method body uses but that doesn't
+		// directly mention the receiver in its symbol name.
+		for _, addr := range b.FuncRefs(f) {
+			if seenRefAddr[addr] {
+				continue
+			}
+			seenRefAddr[addr] = true
+			b.attributeAddr(addr, &c, seenTypeName, seenItabAddr, seenSymName)
+		}
 	}
 
 	// 2. Itabs by concrete-name match.
 	for _, it := range b.Itabs {
-		if matchTpl(it.ConcreteName) || matchTpl(it.SymName) {
-			c.Itabs = append(c.Itabs, ItabCost{
-				SymName:       it.SymName,
-				ConcreteName:  it.ConcreteName,
-				InterfaceName: it.InterfaceName,
-				Bytes:         it.Bytes,
-			})
-			c.Sections[".rodata"] += it.Bytes
+		if !(matchTpl(it.ConcreteName) || matchTpl(it.SymName)) {
+			continue
 		}
+		if seenItabAddr[it.Addr] {
+			continue
+		}
+		seenItabAddr[it.Addr] = true
+		c.Itabs = append(c.Itabs, ItabCost{
+			SymName:       it.SymName,
+			ConcreteName:  it.ConcreteName,
+			InterfaceName: it.InterfaceName,
+			Bytes:         it.Bytes,
+		})
+		c.Sections[".rodata"] += it.Bytes
 	}
 
 	// 3. Type descriptors: walk Types map for matching names.
@@ -134,6 +159,10 @@ func (b *Binary) CostByReceiver(receiver string) Cost {
 		if !matchTpl(name) {
 			continue
 		}
+		if seenTypeName[name] {
+			continue
+		}
+		seenTypeName[name] = true
 		for _, t := range ts {
 			c.Types = append(c.Types, TypeCost{
 				Name:      t.Name,
@@ -147,7 +176,8 @@ func (b *Binary) CostByReceiver(receiver string) Cost {
 	// 4. Named symbols not yet accounted for. These are typically
 	//    dicts, eq/hash, and other rodata items the symbol table
 	//    knows about. Skip anything that's a function (already
-	//    counted via Funcs) or an itab (already counted).
+	//    counted via Funcs) or an itab (already counted) or already
+	//    pulled in via instruction refs.
 	covered := make(map[string]bool, len(c.Funcs)+len(c.Itabs))
 	for _, f := range c.Funcs {
 		covered[f.Name] = true
@@ -159,6 +189,10 @@ func (b *Binary) CostByReceiver(receiver string) Cost {
 		if !matchTpl(s.Name) || covered[s.Name] || s.Size == 0 {
 			continue
 		}
+		if seenSymName[s.Name] {
+			continue
+		}
+		seenSymName[s.Name] = true
 		c.NamedSyms = append(c.NamedSyms, SymCost{
 			Name:    s.Name,
 			Section: s.Section,
@@ -176,16 +210,26 @@ func (b *Binary) CostByReceiver(receiver string) Cost {
 // `[…]` placeholder, or any concrete instantiation, and we'll match
 // all instantiations sharing the template).
 //
-// The returned Cost includes the function's body bytes and its
-// share of pclntab. Disassembly-based attribution of referenced
-// rodata is added in a separate code path; see
-// CostByFunctionWithRefs.
+// The returned Cost includes the function's body bytes, its share of
+// pclntab, and (on architectures where we can do instruction-level
+// scanning) the runtime type descriptors, itabs, and named rodata
+// the function references. Each referenced item is counted only
+// once even when several matched functions reference it.
 func (b *Binary) CostByFunction(name string) Cost {
 	c := Cost{
 		Target:   name,
 		Sections: map[string]int64{},
 	}
 	tpl := normalize(name)
+
+	// Track refs already attributed so we don't double-count items
+	// that several matched functions point at (e.g. shared name
+	// strings, dictionaries reachable from sibling instantiations).
+	seenRefAddr := map[uint64]bool{}
+	seenTypeName := map[string]bool{}
+	seenItabAddr := map[uint64]bool{}
+	seenSymName := map[string]bool{}
+
 	for _, f := range b.Funcs {
 		if normalize(f.Name) != tpl && f.Name != name {
 			continue
@@ -198,9 +242,91 @@ func (b *Binary) CostByFunction(name string) Cost {
 		c.Funcs = append(c.Funcs, fc)
 		c.Sections[".text"] += fc.BodyBytes
 		c.Sections[".gopclntab"] += fc.PclntabBytes
+
+		for _, addr := range b.FuncRefs(f) {
+			if seenRefAddr[addr] {
+				continue
+			}
+			seenRefAddr[addr] = true
+			b.attributeAddr(addr, &c, seenTypeName, seenItabAddr, seenSymName)
+		}
 	}
 	c.finalize()
 	return c
+}
+
+// attributeAddr classifies one referenced static-data address and
+// adds its size to c (and to the appropriate per-category list,
+// avoiding duplicates via the seen* maps).
+//
+// Resolution order:
+//
+//  1. If addr names a known itab, charge the itab.
+//  2. If addr is the start of a known type descriptor, charge the
+//     descriptor's bytes (descriptor + name string).
+//  3. If addr is the start of a known named symbol, charge the
+//     symbol's bytes.
+//  4. Otherwise, the address is anonymous rodata (string constant,
+//     name fragment, GC bitmap, etc.) and we don't currently
+//     attribute it. The byte cost is real but cannot reliably be
+//     associated with a single owner; we leave it as part of the
+//     residual rodata gap rather than risk over-attributing.
+func (b *Binary) attributeAddr(addr uint64, c *Cost,
+	seenTypeName map[string]bool,
+	seenItabAddr map[uint64]bool,
+	seenSymName map[string]bool,
+) {
+	for _, it := range b.Itabs {
+		if it.Addr != addr {
+			continue
+		}
+		if seenItabAddr[it.Addr] {
+			return
+		}
+		seenItabAddr[it.Addr] = true
+		c.Itabs = append(c.Itabs, ItabCost{
+			SymName:       it.SymName,
+			ConcreteName:  it.ConcreteName,
+			InterfaceName: it.InterfaceName,
+			Bytes:         it.Bytes,
+		})
+		c.Sections[".rodata"] += it.Bytes
+		return
+	}
+	for name, ts := range b.Types {
+		for _, t := range ts {
+			if t.Addr != addr {
+				continue
+			}
+			if seenTypeName[name] {
+				return
+			}
+			seenTypeName[name] = true
+			c.Types = append(c.Types, TypeCost{
+				Name:      t.Name,
+				Bytes:     t.Bytes,
+				NameBytes: t.NameBytes,
+			})
+			c.Sections[".rodata"] += t.TotalBytes()
+			return
+		}
+	}
+	for _, s := range b.Syms {
+		if s.Addr != addr {
+			continue
+		}
+		if seenSymName[s.Name] {
+			return
+		}
+		seenSymName[s.Name] = true
+		c.NamedSyms = append(c.NamedSyms, SymCost{
+			Name:    s.Name,
+			Section: s.Section,
+			Bytes:   int64(s.Size),
+		})
+		c.Sections[s.Section] += int64(s.Size)
+		return
+	}
 }
 
 // finalize sorts the per-category lists and computes Total.

--- a/util/sizetest/symcost/attribute.go
+++ b/util/sizetest/symcost/attribute.go
@@ -1,0 +1,369 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package symcost
+
+import (
+	"sort"
+)
+
+// Cost is a per-target attribution result. It carries a breakdown of
+// bytes by section and a list of contributing items so callers can
+// drill down from a headline number to the specific symbols/types/
+// itabs/funcs that produced the cost.
+type Cost struct {
+	// Target is the user's query string (a receiver template like
+	// "tailscale.com/util/eventbus.Publisher" or a function
+	// template like "...(*Publisher[…]).Publish").
+	Target string
+
+	// Sections breaks the total cost down by section name.
+	Sections map[string]int64
+	// Total is the sum across Sections.
+	Total int64
+
+	// Funcs lists all functions that contributed (either by name or
+	// by association with a receiver), sorted by descending body+
+	// pclntab cost.
+	Funcs []FuncCost
+	// Types lists all type descriptors attributed, sorted by
+	// descending size.
+	Types []TypeCost
+	// Itabs lists all itabs attributed, sorted by descending size.
+	Itabs []ItabCost
+	// NamedSyms lists named symbols (excluding those covered by
+	// Funcs/Itabs) attributed, sorted by descending size.
+	NamedSyms []SymCost
+}
+
+// FuncCost is one function's contribution.
+type FuncCost struct {
+	Name         string
+	BodyBytes    int64
+	PclntabBytes int64
+}
+
+// Total is body+pclntab cost.
+func (fc FuncCost) Total() int64 { return fc.BodyBytes + fc.PclntabBytes }
+
+// TypeCost is one type descriptor's contribution.
+type TypeCost struct {
+	Name      string
+	Bytes     int64
+	NameBytes int64
+}
+
+// Total is descriptor+name cost.
+func (tc TypeCost) Total() int64 { return tc.Bytes + tc.NameBytes }
+
+// ItabCost is one itab's contribution.
+type ItabCost struct {
+	SymName       string
+	ConcreteName  string
+	InterfaceName string
+	Bytes         int64
+}
+
+// SymCost is one named symbol's contribution.
+type SymCost struct {
+	Name    string
+	Section string
+	Bytes   int64
+}
+
+// CostByReceiver returns the aggregate cost of all symbols, types,
+// itabs, and named rodata associated with the given receiver type.
+//
+// receiver is a type name without the instantiation suffix, e.g.
+// "tailscale.com/util/eventbus.Publisher" or just "Publisher" (the
+// latter is matched as a substring against the package-qualified
+// name). The returned Cost includes:
+//
+//   - all methods on the receiver, across instantiations (.text and
+//     pclntab attribution)
+//   - all generic dictionaries naming the receiver (.dict.Receiver[…])
+//   - all type-equality and type-hash functions for the receiver
+//   - all itabs whose concrete type is the receiver
+//   - the runtime type descriptor for every instantiation of the
+//     receiver
+//
+// If receiver names a non-generic type, the [...] suffix doesn't
+// apply and the function still works correctly: it matches the type
+// directly.
+func (b *Binary) CostByReceiver(receiver string) Cost {
+	c := Cost{
+		Target:   receiver,
+		Sections: map[string]int64{},
+	}
+	matchTpl := receiverMatcher(receiver)
+
+	// 1. Functions: receiver methods, eq/hash funcs, dicts (which
+	//    live in .rodata, not .text, but we look for them in the
+	//    symbol table).
+	for _, f := range b.Funcs {
+		if !matchTpl(f.Name) {
+			continue
+		}
+		fc := FuncCost{
+			Name:         f.Name,
+			BodyBytes:    f.BodyBytes(),
+			PclntabBytes: f.PclntabBytes,
+		}
+		c.Funcs = append(c.Funcs, fc)
+		c.Sections[".text"] += fc.BodyBytes
+		c.Sections[".gopclntab"] += fc.PclntabBytes
+	}
+
+	// 2. Itabs by concrete-name match.
+	for _, it := range b.Itabs {
+		if matchTpl(it.ConcreteName) || matchTpl(it.SymName) {
+			c.Itabs = append(c.Itabs, ItabCost{
+				SymName:       it.SymName,
+				ConcreteName:  it.ConcreteName,
+				InterfaceName: it.InterfaceName,
+				Bytes:         it.Bytes,
+			})
+			c.Sections[".rodata"] += it.Bytes
+		}
+	}
+
+	// 3. Type descriptors: walk Types map for matching names.
+	//    Names in the type-descriptor table can use the short or
+	//    long form; matchTpl handles both.
+	for name, ts := range b.Types {
+		if !matchTpl(name) {
+			continue
+		}
+		for _, t := range ts {
+			c.Types = append(c.Types, TypeCost{
+				Name:      t.Name,
+				Bytes:     t.Bytes,
+				NameBytes: t.NameBytes,
+			})
+			c.Sections[".rodata"] += t.TotalBytes()
+		}
+	}
+
+	// 4. Named symbols not yet accounted for. These are typically
+	//    dicts, eq/hash, and other rodata items the symbol table
+	//    knows about. Skip anything that's a function (already
+	//    counted via Funcs) or an itab (already counted).
+	covered := make(map[string]bool, len(c.Funcs)+len(c.Itabs))
+	for _, f := range c.Funcs {
+		covered[f.Name] = true
+	}
+	for _, it := range c.Itabs {
+		covered[it.SymName] = true
+	}
+	for _, s := range b.Syms {
+		if !matchTpl(s.Name) || covered[s.Name] || s.Size == 0 {
+			continue
+		}
+		c.NamedSyms = append(c.NamedSyms, SymCost{
+			Name:    s.Name,
+			Section: s.Section,
+			Bytes:   int64(s.Size),
+		})
+		c.Sections[s.Section] += int64(s.Size)
+	}
+
+	c.finalize()
+	return c
+}
+
+// CostByFunction returns the aggregate cost of one function (or one
+// generic function template — pass the normalized name with the
+// `[…]` placeholder, or any concrete instantiation, and we'll match
+// all instantiations sharing the template).
+//
+// The returned Cost includes the function's body bytes and its
+// share of pclntab. Disassembly-based attribution of referenced
+// rodata is added in a separate code path; see
+// CostByFunctionWithRefs.
+func (b *Binary) CostByFunction(name string) Cost {
+	c := Cost{
+		Target:   name,
+		Sections: map[string]int64{},
+	}
+	tpl := normalize(name)
+	for _, f := range b.Funcs {
+		if normalize(f.Name) != tpl && f.Name != name {
+			continue
+		}
+		fc := FuncCost{
+			Name:         f.Name,
+			BodyBytes:    f.BodyBytes(),
+			PclntabBytes: f.PclntabBytes,
+		}
+		c.Funcs = append(c.Funcs, fc)
+		c.Sections[".text"] += fc.BodyBytes
+		c.Sections[".gopclntab"] += fc.PclntabBytes
+	}
+	c.finalize()
+	return c
+}
+
+// finalize sorts the per-category lists and computes Total.
+func (c *Cost) finalize() {
+	sort.Slice(c.Funcs, func(i, j int) bool {
+		return c.Funcs[i].Total() > c.Funcs[j].Total()
+	})
+	sort.Slice(c.Types, func(i, j int) bool {
+		return c.Types[i].Total() > c.Types[j].Total()
+	})
+	sort.Slice(c.Itabs, func(i, j int) bool {
+		return c.Itabs[i].Bytes > c.Itabs[j].Bytes
+	})
+	sort.Slice(c.NamedSyms, func(i, j int) bool {
+		return c.NamedSyms[i].Bytes > c.NamedSyms[j].Bytes
+	})
+	for _, v := range c.Sections {
+		c.Total += v
+	}
+}
+
+// receiverMatcher returns a function that reports whether a symbol
+// or type name "belongs to" the given receiver.
+//
+// The query string can be a fully-qualified receiver
+// ("tailscale.com/util/eventbus.Publisher") or a short name
+// ("Publisher"). The matcher accepts a symbol if any of the
+// following appears within it as a delimited identifier:
+//
+//   - the receiver name itself (matches type-descriptor names,
+//     dict entries, eq/hash entries, value-receiver methods)
+//   - the receiver written inside a Go method-receiver wrapper:
+//     "<pkg>.(*<Type>" or "<pkg>.(<Type>" — Go encodes pointer
+//     and value receivers using these forms when generating
+//     method symbol names.
+//
+// For qualified inputs ("pkg.Type"), the package and type segments
+// are checked separately so that the encoded form "pkg.(*Type[...])."
+// is recognized.
+//
+// The matcher is delimiter-aware: it ensures that what comes after
+// the matched substring is a syntactic break (`[`, `.`, `,`, `]`,
+// `)`, end of string), so a query for "main.Foo" doesn't accidentally
+// match "main.FooBar".
+func receiverMatcher(receiver string) func(string) bool {
+	if receiver == "" {
+		return func(string) bool { return false }
+	}
+	// Build the list of forms we accept. For an input "pkg.Type",
+	// also accept:
+	//   - "pkg.(*Type" / "pkg.(Type": Go method-receiver name mangling
+	//   - "shortpkg.Type": the type-descriptor short form (Go stores
+	//     type names using only the final path segment of the
+	//     package, e.g. "eventbus.Publisher" instead of
+	//     "tailscale.com/util/eventbus.Publisher")
+	forms := []string{receiver}
+	if pkg, typ, ok := splitLastDot(receiver); ok {
+		forms = append(forms,
+			pkg+".(*"+typ,     // pointer-receiver method: pkg.(*Type[...])
+			pkg+".("+typ,      // value-receiver method:   pkg.(Type[...])
+			pkg+"..dict."+typ, // generic dictionary:  pkg..dict.Type[...]
+		)
+		// Short-package form: trim everything before the last "/"
+		// in the package portion. The type name stays the same.
+		// This handles type-descriptor names like "eventbus.Publisher"
+		// instead of "tailscale.com/util/eventbus.Publisher".
+		short := pkg
+		if slash := lastByteOff(pkg, '/'); slash >= 0 {
+			short = pkg[slash+1:]
+		}
+		if short != pkg {
+			forms = append(forms,
+				short+"."+typ,
+				short+".(*"+typ,
+				short+".("+typ,
+			)
+		}
+	}
+
+	return func(name string) bool {
+		if name == "" {
+			return false
+		}
+		for _, want := range forms {
+			if matchDelimited(name, want) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// matchDelimited reports whether want appears in name as a
+// delimited identifier — i.e. surrounded by start/end of string or
+// by Go symbol-table punctuation characters (excluding identifier
+// continuations).
+func matchDelimited(name, want string) bool {
+	for i := 0; i+len(want) <= len(name); i++ {
+		if name[i:i+len(want)] != want {
+			continue
+		}
+		// Left boundary: start of string or symbol punctuation.
+		if i > 0 {
+			c := name[i-1]
+			switch c {
+			case '*', '.', '(', '[', ',', ' ':
+				// ok
+			default:
+				continue
+			}
+		}
+		// Right boundary: end of string or punctuation. We accept
+		// '*' and '(' here too, because the encoded receiver forms
+		// like "pkg.(*Type" end before the next character which is
+		// a type continuation like `[T]` or `).Method`.
+		if j := i + len(want); j < len(name) {
+			c := name[j]
+			switch c {
+			case '.', '[', ',', ']', ')', ' ':
+				// ok
+			default:
+				continue
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// lastByteOff returns the index of the last occurrence of c in s,
+// or -1.
+func lastByteOff(s string, c byte) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}
+
+// splitLastDot splits s at the last unbracketed '.' and returns the
+// (prefix, suffix, ok) triple. Returns ok=false if there is no such
+// dot. Used to split a qualified receiver name into its package path
+// and type-name parts.
+func splitLastDot(s string) (string, string, bool) {
+	depth := 0
+	last := -1
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '[', '(':
+			depth++
+		case ']', ')':
+			if depth > 0 {
+				depth--
+			}
+		case '.':
+			if depth == 0 {
+				last = i
+			}
+		}
+	}
+	if last < 0 {
+		return "", "", false
+	}
+	return s[:last], s[last+1:], true
+}

--- a/util/sizetest/symcost/attribute_test.go
+++ b/util/sizetest/symcost/attribute_test.go
@@ -1,0 +1,147 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package symcost
+
+import (
+	"testing"
+)
+
+func TestReceiverMatcher(t *testing.T) {
+	tests := []struct {
+		recv   string
+		name   string
+		want   bool
+		reason string
+	}{
+		// Qualified receiver matched in method-receiver form.
+		{
+			recv:   "tailscale.com/util/eventbus.Publisher",
+			name:   "tailscale.com/util/eventbus.(*Publisher[main.Event0]).Close",
+			want:   true,
+			reason: "pointer-receiver method on generic instantiation",
+		},
+		{
+			recv:   "tailscale.com/util/eventbus.Publisher",
+			name:   "tailscale.com/util/eventbus.(Publisher[main.Event0]).ShouldPublish",
+			want:   true,
+			reason: "value-receiver method on generic instantiation",
+		},
+
+		// Type descriptor short-package form.
+		{
+			recv:   "tailscale.com/util/eventbus.Publisher",
+			name:   "*eventbus.Publisher[main.Event0]",
+			want:   true,
+			reason: "type descriptor uses short package name",
+		},
+
+		// Dict, eq, hash entries.
+		{
+			recv:   "tailscale.com/util/eventbus.Publisher",
+			name:   "tailscale.com/util/eventbus..dict.Publisher[main.Event0]",
+			want:   true,
+			reason: "generic dictionary entry",
+		},
+		{
+			recv:   "tailscale.com/util/eventbus.Publisher",
+			name:   "type:.eq.tailscale.com/util/eventbus.Publisher[main.Event0]",
+			want:   true,
+			reason: "type-equality function",
+		},
+
+		// Itab entries.
+		{
+			recv:   "tailscale.com/util/eventbus.Publisher",
+			name:   "go:itab.*tailscale.com/util/eventbus.Publisher[main.Event0],tailscale.com/util/eventbus.publisher",
+			want:   true,
+			reason: "itab whose concrete type is the receiver",
+		},
+
+		// Non-generic: query "main.Foo" matches "*main.Foo" (the
+		// pointer-to-Foo type descriptor is what shows up in
+		// .typelink for value types used in type switches).
+		{
+			recv:   "main.Foo",
+			name:   "*main.Foo",
+			want:   true,
+			reason: "pointer-to-Foo descriptor",
+		},
+		{
+			recv:   "main.Foo",
+			name:   "main.Foo",
+			want:   true,
+			reason: "Foo descriptor itself",
+		},
+		{
+			recv:   "main.Foo",
+			name:   "type:.eq.main.Foo",
+			want:   true,
+			reason: "Foo equality function",
+		},
+
+		// Negative: a receiver named "Foo" must not match "FooBar".
+		{
+			recv:   "main.Foo",
+			name:   "main.FooBar",
+			want:   false,
+			reason: "delimiter-aware: Foo != FooBar",
+		},
+		{
+			recv:   "tailscale.com/util/eventbus.Publisher",
+			name:   "tailscale.com/util/eventbus.publisher",
+			want:   false,
+			reason: "case-sensitive, Publisher != publisher",
+		},
+		{
+			recv:   "tailscale.com/util/eventbus.Publisher",
+			name:   "tailscale.com/util/eventbus.SubscriberFunc[main.Event0]",
+			want:   false,
+			reason: "different type with same package",
+		},
+
+		// Empty / edge cases.
+		{
+			recv:   "",
+			name:   "anything",
+			want:   false,
+			reason: "empty receiver matches nothing",
+		},
+		{
+			recv:   "main.Foo",
+			name:   "",
+			want:   false,
+			reason: "empty name matches nothing",
+		},
+	}
+
+	for _, tt := range tests {
+		got := receiverMatcher(tt.recv)(tt.name)
+		if got != tt.want {
+			t.Errorf("receiverMatcher(%q)(%q) = %v, want %v (%s)",
+				tt.recv, tt.name, got, tt.want, tt.reason)
+		}
+	}
+}
+
+func TestSplitLastDot(t *testing.T) {
+	tests := []struct {
+		in               string
+		wantPkg, wantTyp string
+		wantOk           bool
+	}{
+		{"tailscale.com/util/eventbus.Publisher", "tailscale.com/util/eventbus", "Publisher", true},
+		{"main.Foo", "main", "Foo", true},
+		{"justone", "", "", false},
+		// Bracketed dots should not split.
+		{"pkg.Foo[a.b]", "pkg", "Foo[a.b]", true},
+	}
+	for _, tt := range tests {
+		gotPkg, gotTyp, gotOk := splitLastDot(tt.in)
+		if gotPkg != tt.wantPkg || gotTyp != tt.wantTyp || gotOk != tt.wantOk {
+			t.Errorf("splitLastDot(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				tt.in, gotPkg, gotTyp, gotOk,
+				tt.wantPkg, tt.wantTyp, tt.wantOk)
+		}
+	}
+}

--- a/util/sizetest/symcost/binary.go
+++ b/util/sizetest/symcost/binary.go
@@ -1,0 +1,329 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package symcost
+
+import (
+	"debug/elf"
+	"debug/gosym"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"sort"
+)
+
+// Binary is an opened Go binary with parsed sections, symbol table,
+// pclntab, type descriptor index, and itab index. It is the
+// foundation on which per-receiver and per-function attribution is
+// computed.
+//
+// Binary is currently ELF-only. Mach-O and PE support can be added
+// without changing the user-facing API.
+type Binary struct {
+	// Path is the filesystem path to the binary.
+	Path string
+
+	// PtrSize is the target's pointer size in bytes (4 or 8).
+	PtrSize int
+	// ByteOrder is the target's byte order.
+	ByteOrder binary.ByteOrder
+
+	// Sections is the binary's section list keyed by name. Only
+	// PROGBITS sections are populated.
+	Sections map[string]*Section
+	// Syms is the binary's static symbol table, sorted by address.
+	// Each Sym carries its size as recorded in the ELF symtab (this
+	// is the same source `go tool nm -size` reads).
+	Syms []*Sym
+	// SymsByName maps demangled symbol name to *Sym for quick lookup.
+	// Names are unique in well-formed Go binaries.
+	SymsByName map[string]*Sym
+
+	// Funcs is the function range table from gopclntab, sorted by
+	// Entry. End for the last function is the end of .text.
+	Funcs []*Func
+	// PclntabSize is the total size of the .gopclntab section in
+	// bytes; sum of FuncMetaBytes across Funcs equals this minus
+	// the table's fixed header.
+	PclntabSize int64
+
+	// Types is the runtime type descriptor index, keyed by Go type
+	// name (after un-mangling, e.g. "*tailscale.com/util/eventbus.Publisher[main.Event0]").
+	// Multiple raw type entries may share a name when GC-shape
+	// stenciling produces aliases; in that case Types maps to a
+	// list of *Type, all of which contribute to the type's cost.
+	Types map[string][]*Type
+
+	// Itabs is the list of all interface tables in the binary.
+	Itabs []*Itab
+
+	elf *elf.File
+}
+
+// Section is a slim view of one ELF PROGBITS section.
+type Section struct {
+	Name string
+	// Addr is the virtual address where the section is loaded.
+	Addr uint64
+	// Size is the section's in-memory size in bytes.
+	Size uint64
+	// Data is the section's raw contents. For NOBITS sections
+	// (e.g. .bss), Data is nil. We only populate PROGBITS.
+	Data []byte
+}
+
+// AddrInRange reports whether addr lies within this section.
+func (s *Section) AddrInRange(addr uint64) bool {
+	return addr >= s.Addr && addr < s.Addr+s.Size
+}
+
+// Slice returns the section bytes covering [addr, addr+n). Returns
+// nil if the range is partly out of bounds.
+func (s *Section) Slice(addr uint64, n int) []byte {
+	if !s.AddrInRange(addr) || addr+uint64(n) > s.Addr+s.Size {
+		return nil
+	}
+	off := addr - s.Addr
+	return s.Data[off : off+uint64(n)]
+}
+
+// Sym is a symbol from the binary's static symbol table.
+type Sym struct {
+	// Name is the demangled symbol name (Go symbol convention).
+	Name string
+	// Addr is the symbol's virtual address.
+	Addr uint64
+	// Size is the symbol's recorded size in bytes. Note that
+	// .text symbols' Size matches the function body bytes; rodata
+	// symbols may have Size 0 if the linker didn't record one,
+	// in which case the size has to be derived from following the
+	// symbol layout.
+	Size uint64
+	// Section is the name of the section the symbol lives in,
+	// e.g. ".text" or ".rodata".
+	Section string
+}
+
+// Func is one entry in the gopclntab function table.
+type Func struct {
+	// Name is the function name (demangled, Go symbol convention).
+	Name string
+	// Entry is the function's start address in .text.
+	Entry uint64
+	// End is the address one past the last byte of the function.
+	End uint64
+	// PclntabBytes is the per-function metadata size attributable
+	// to this function in .gopclntab. Computed from the difference
+	// between successive entries in the function-info offset table,
+	// minus a small fixed header per function.
+	PclntabBytes int64
+}
+
+// BodyBytes returns the size of the function's machine code (End - Entry).
+func (f *Func) BodyBytes() int64 { return int64(f.End - f.Entry) }
+
+// Open opens path as an ELF Go binary and parses its high-level
+// structure. The returned *Binary owns an open file handle until
+// Close is called.
+func Open(path string) (*Binary, error) {
+	ef, err := elf.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening %s as ELF: %w", path, err)
+	}
+	b := &Binary{
+		Path:       path,
+		Sections:   map[string]*Section{},
+		SymsByName: map[string]*Sym{},
+		Types:      map[string][]*Type{},
+		elf:        ef,
+	}
+	switch ef.Class {
+	case elf.ELFCLASS64:
+		b.PtrSize = 8
+	case elf.ELFCLASS32:
+		b.PtrSize = 4
+	default:
+		ef.Close()
+		return nil, fmt.Errorf("unsupported ELF class %v", ef.Class)
+	}
+	b.ByteOrder = ef.ByteOrder
+
+	if err := b.loadSections(); err != nil {
+		ef.Close()
+		return nil, err
+	}
+	if err := b.loadSymbols(); err != nil {
+		ef.Close()
+		return nil, err
+	}
+	if err := b.loadFuncs(); err != nil {
+		ef.Close()
+		return nil, err
+	}
+	if err := b.loadTypes(); err != nil {
+		ef.Close()
+		return nil, err
+	}
+	if err := b.loadItabs(); err != nil {
+		ef.Close()
+		return nil, err
+	}
+	return b, nil
+}
+
+// Close releases the underlying file handle.
+func (b *Binary) Close() error {
+	if b.elf != nil {
+		err := b.elf.Close()
+		b.elf = nil
+		return err
+	}
+	return nil
+}
+
+func (b *Binary) loadSections() error {
+	for _, s := range b.elf.Sections {
+		if s.Type != elf.SHT_PROGBITS {
+			continue
+		}
+		sec := &Section{
+			Name: s.Name,
+			Addr: s.Addr,
+			Size: s.Size,
+		}
+		if s.Size > 0 {
+			data, err := s.Data()
+			if err != nil {
+				return fmt.Errorf("reading section %s: %w", s.Name, err)
+			}
+			sec.Data = data
+		}
+		b.Sections[s.Name] = sec
+	}
+	if _, ok := b.Sections[".text"]; !ok {
+		return errors.New("no .text section: not a Go binary?")
+	}
+	return nil
+}
+
+func (b *Binary) loadSymbols() error {
+	syms, err := b.elf.Symbols()
+	if err != nil {
+		// A stripped binary loses the static symbol table and we
+		// can't recover named-symbol info. We still proceed (so
+		// pclntab and type-side analysis still works), but the
+		// caller will get empty Syms.
+		if errors.Is(err, elf.ErrNoSymbols) {
+			return nil
+		}
+		return fmt.Errorf("reading symbol table: %w", err)
+	}
+	for i := range syms {
+		es := &syms[i]
+		if es.Size == 0 && es.Value == 0 {
+			continue
+		}
+		// Find which section it's in, by address.
+		secName := ""
+		for _, sec := range b.Sections {
+			if sec.AddrInRange(es.Value) {
+				secName = sec.Name
+				break
+			}
+		}
+		s := &Sym{
+			Name:    es.Name,
+			Addr:    es.Value,
+			Size:    es.Size,
+			Section: secName,
+		}
+		b.Syms = append(b.Syms, s)
+		// In well-formed Go binaries names are unique. If we hit a
+		// duplicate (e.g. weak/aliased), keep the first.
+		if _, exists := b.SymsByName[es.Name]; !exists {
+			b.SymsByName[es.Name] = s
+		}
+	}
+	sort.Slice(b.Syms, func(i, j int) bool { return b.Syms[i].Addr < b.Syms[j].Addr })
+	return nil
+}
+
+func (b *Binary) loadFuncs() error {
+	pcln := b.Sections[".gopclntab"]
+	text := b.Sections[".text"]
+	if pcln == nil || text == nil {
+		return nil // older or stripped layout
+	}
+	b.PclntabSize = int64(pcln.Size)
+
+	// debug/gosym does the heavy lifting of decoding pclntab.
+	lt := gosym.NewLineTable(pcln.Data, text.Addr)
+	tab, err := gosym.NewTable(nil, lt)
+	if err != nil {
+		return fmt.Errorf("decoding pclntab: %w", err)
+	}
+	for i := range tab.Funcs {
+		gf := &tab.Funcs[i]
+		f := &Func{
+			Name:  gf.Name,
+			Entry: gf.Entry,
+			End:   gf.End,
+		}
+		b.Funcs = append(b.Funcs, f)
+	}
+	sort.Slice(b.Funcs, func(i, j int) bool { return b.Funcs[i].Entry < b.Funcs[j].Entry })
+
+	// Distribute the pclntab section size across functions
+	// proportional to body size. This is an approximation: in
+	// reality, each function has a fixed-size pclntab header plus
+	// variable-size pcdata/funcdata that scales with body size and
+	// inlining depth. The proportional distribution is accurate
+	// enough to surface the *relative* pclntab cost of one function
+	// vs another, which is what we need for attribution. A future
+	// refinement would parse runtime._func directly from pclntab.
+	var totalBody int64
+	for _, f := range b.Funcs {
+		totalBody += f.BodyBytes()
+	}
+	if totalBody > 0 {
+		// Reserve some bytes for non-per-function pclntab data
+		// (the file table, the function index table itself, etc.).
+		// gosym doesn't expose this directly; we estimate by
+		// reserving a fixed 64 bytes per function for headers,
+		// distributing only the remainder by body proportion.
+		fixedPerFunc := int64(64)
+		fixedTotal := fixedPerFunc * int64(len(b.Funcs))
+		variable := b.PclntabSize - fixedTotal
+		if variable < 0 {
+			variable = b.PclntabSize / 2
+			fixedPerFunc = (b.PclntabSize - variable) / int64(len(b.Funcs))
+		}
+		for _, f := range b.Funcs {
+			share := variable * f.BodyBytes() / totalBody
+			f.PclntabBytes = fixedPerFunc + share
+		}
+	}
+	return nil
+}
+
+// FuncByName returns the Func with the given exact name, or nil.
+func (b *Binary) FuncByName(name string) *Func {
+	for _, f := range b.Funcs {
+		if f.Name == name {
+			return f
+		}
+	}
+	return nil
+}
+
+// FuncsByTemplate returns all Funcs whose name normalizes to the
+// given template (i.e. all instantiations of one generic).
+func (b *Binary) FuncsByTemplate(tpl string) []*Func {
+	var out []*Func
+	for _, f := range b.Funcs {
+		if normalize(f.Name) == tpl {
+			out = append(out, f)
+		}
+	}
+	return out
+}

--- a/util/sizetest/symcost/binary.go
+++ b/util/sizetest/symcost/binary.go
@@ -327,3 +327,52 @@ func (b *Binary) FuncsByTemplate(tpl string) []*Func {
 	}
 	return out
 }
+
+// FuncBytes returns the raw machine-code bytes of f from the .text
+// section, or nil if the binary has no .text or f's range is out
+// of bounds.
+func (b *Binary) FuncBytes(f *Func) []byte {
+	text := b.Sections[".text"]
+	if text == nil {
+		return nil
+	}
+	return text.Slice(f.Entry, int(f.End-f.Entry))
+}
+
+// FuncRefs returns the set of static-data addresses that f
+// references via its instructions, when those references can be
+// resolved by the architecture-specific scanner. The returned
+// addresses are absolute virtual addresses; callers can look them
+// up against b.Sections to discover which sections (and which named
+// symbols within them) the function touches.
+//
+// FuncRefs is currently implemented for arm64 only; on other
+// architectures it returns nil. Cross-architecture coverage will
+// be added as needed; the existing per-section attribution still
+// works on every architecture even without FuncRefs.
+func (b *Binary) FuncRefs(f *Func) []uint64 {
+	if b.elf == nil {
+		return nil
+	}
+	if !b.isArm64() {
+		return nil
+	}
+	body := b.FuncBytes(f)
+	if body == nil {
+		return nil
+	}
+	return scanArm64Refs(f.Entry, body)
+}
+
+// isArm64 reports whether b is an arm64 ELF.
+func (b *Binary) isArm64() bool {
+	if b.elf == nil {
+		return false
+	}
+	return b.elf.Machine == elfMachineAArch64
+}
+
+// elfMachineAArch64 is elf.EM_AARCH64; we name the constant locally
+// to keep the arm64-only disasm file from needing a debug/elf
+// import.
+const elfMachineAArch64 = 0xB7

--- a/util/sizetest/symcost/binary_test.go
+++ b/util/sizetest/symcost/binary_test.go
@@ -4,6 +4,8 @@
 package symcost_test
 
 import (
+	"os"
+	"os/exec"
 	"runtime"
 	"strings"
 	"testing"
@@ -133,4 +135,109 @@ func typeNames(ts []symcost.TypeCost) []string {
 		out[i] = t.Name
 	}
 	return out
+}
+
+// TestArm64FuncRefsAgainstFixture cross-compiles a tiny program to
+// arm64 and verifies that FuncRefs picks up at least one rodata
+// reference from the test function, and that CostByFunction
+// includes additional .rodata bytes that the previous
+// non-disassembling attribution would have missed.
+//
+// The test does not require an arm64 host: it only inspects the
+// ELF binary statically.
+func TestArm64FuncRefsAgainstFixture(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping: invokes go build")
+	}
+	// We can't use sizetest.BuildWithOptions for this case
+	// because it doesn't expose GOOS/GOARCH overrides; we want to
+	// cross-compile to arm64 even when the host is amd64. Build
+	// directly with `go build` so we can set the env.
+	dir := t.TempDir()
+	source := []byte(`package main
+
+//go:noinline
+func PickName(i int) string {
+	switch i {
+	case 0:
+		return "alpha-zebra-fixture"
+	case 1:
+		return "bravo-yankee-fixture"
+	default:
+		return "charlie-xray-fixture"
+	}
+}
+
+func main() {
+	println(PickName(0))
+	println(PickName(1))
+	println(PickName(2))
+}
+`)
+	if err := writeFile(dir+"/main.go", source); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeFile(dir+"/go.mod", []byte("module symcostarm\n\ngo 1.21\n")); err != nil {
+		t.Fatal(err)
+	}
+	binPath := dir + "/bin"
+	if err := goBuildARM64(t, dir, binPath); err != nil {
+		t.Fatalf("cross-compile to arm64: %v", err)
+	}
+
+	b, err := symcost.Open(binPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer b.Close()
+
+	// Find PickName.
+	var pickName *symcost.Func
+	for _, f := range b.Funcs {
+		if strings.Contains(f.Name, "main.PickName") {
+			pickName = f
+			break
+		}
+	}
+	if pickName == nil {
+		t.Fatal("couldn't find main.PickName")
+	}
+
+	refs := b.FuncRefs(pickName)
+	if len(refs) == 0 {
+		t.Errorf("expected FuncRefs to pick up at least one rodata reference; got 0")
+	}
+
+	// At least some refs should land in .rodata.
+	rodata := b.Sections[".rodata"]
+	if rodata == nil {
+		t.Skip("no .rodata; can't validate")
+	}
+	rodataRefs := 0
+	for _, addr := range refs {
+		if rodata.AddrInRange(addr) {
+			rodataRefs++
+		}
+	}
+	if rodataRefs == 0 {
+		t.Errorf("none of the %d refs landed in .rodata; got %v", len(refs), refs)
+	}
+}
+
+func writeFile(path string, data []byte) error {
+	return os.WriteFile(path, data, 0o644)
+}
+
+// goBuildARM64 cross-compiles the package in dir to an arm64 ELF at
+// out, returning an error if the build fails.
+func goBuildARM64(t testing.TB, dir, out string) error {
+	t.Helper()
+	cmd := exec.Command("go", "build", "-trimpath", "-o", out, ".")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOOS=linux", "GOARCH=arm64")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("build output:\n%s", output)
+	}
+	return err
 }

--- a/util/sizetest/symcost/binary_test.go
+++ b/util/sizetest/symcost/binary_test.go
@@ -1,0 +1,136 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package symcost_test
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+
+	"tailscale.com/util/sizetest"
+	"tailscale.com/util/sizetest/symcost"
+)
+
+// TestOpenAndAttributeAgainstFixture builds a tiny program with a
+// generic function instantiated for two distinct types and verifies
+// that symcost can:
+//
+//  1. Open the binary and parse its sections, symbols, and pclntab.
+//  2. Attribute body and pclntab cost to the generic function's
+//     instantiations via CostByFunction.
+//  3. Decode the runtime type descriptors for the program's named
+//     types and find them in the resulting Cost via CostByReceiver.
+func TestOpenAndAttributeAgainstFixture(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping: invokes go build")
+	}
+	if runtime.GOOS != "linux" {
+		t.Skipf("symcost.Open is currently ELF-only; running on %s", runtime.GOOS)
+	}
+
+	res := sizetest.BuildWithOptions(t, sizetest.Variant{
+		Name: "symcost-binary-fixture",
+		Source: `package main
+
+type Foo struct {
+	A, B int
+}
+
+type Bar struct {
+	S string
+	N int64
+}
+
+//go:noinline
+func Use[T any](v T) string {
+	switch any(v).(type) {
+	case Foo:
+		return "foo"
+	case Bar:
+		return "bar"
+	}
+	return "?"
+}
+
+func main() {
+	println(Use(Foo{1, 2}))
+	println(Use(Bar{"x", 3}))
+}
+`,
+	}, sizetest.BuildOptions{
+		LDFlags:  " ", // keep symbols
+		Trimpath: ptr(true),
+	})
+
+	b, err := symcost.Open(res.BinaryPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer b.Close()
+
+	// 1. Sanity check: required sections present.
+	for _, s := range []string{".text", ".rodata", ".gopclntab"} {
+		if b.Sections[s] == nil {
+			t.Errorf("missing section %s", s)
+		}
+	}
+
+	// 2. Funcs were decoded.
+	if len(b.Funcs) == 0 {
+		t.Fatal("Funcs is empty")
+	}
+	// The pclntab attribution should sum to roughly the section's
+	// size. Tolerance is loose because we use a fixed-per-func
+	// + body-proportional approximation.
+	pcln := b.Sections[".gopclntab"]
+	var totalPcln int64
+	for _, f := range b.Funcs {
+		totalPcln += f.PclntabBytes
+	}
+	if totalPcln <= 0 || totalPcln > int64(pcln.Size)+1024 {
+		t.Errorf("attributed pclntab %d differs from section size %d unreasonably",
+			totalPcln, pcln.Size)
+	}
+
+	// 3. Function-mode lookup finds both instantiations of Use.
+	fc := b.CostByFunction("main.Use[…]")
+	if len(fc.Funcs) < 2 {
+		t.Errorf("CostByFunction(main.Use[…]) found %d funcs, want >= 2",
+			len(fc.Funcs))
+	}
+	for _, f := range fc.Funcs {
+		if !strings.Contains(f.Name, "main.Use[") {
+			t.Errorf("unexpected func in main.Use[…] result: %q", f.Name)
+		}
+	}
+	if fc.Sections[".text"] == 0 || fc.Sections[".gopclntab"] == 0 {
+		t.Errorf("CostByFunction did not attribute .text or .gopclntab; got %v", fc.Sections)
+	}
+
+	// 4. Type-side: the descriptor for main.Foo should be found.
+	rc := b.CostByReceiver("main.Foo")
+	// We expect at least the type descriptor (and maybe the eq func).
+	if rc.Total == 0 {
+		t.Errorf("CostByReceiver(main.Foo) total = 0; expected non-zero")
+	}
+	foundFooType := false
+	for _, ty := range rc.Types {
+		if strings.HasSuffix(ty.Name, "main.Foo") {
+			foundFooType = true
+			break
+		}
+	}
+	if !foundFooType {
+		t.Errorf("did not find main.Foo type descriptor; types found: %v",
+			typeNames(rc.Types))
+	}
+}
+
+func typeNames(ts []symcost.TypeCost) []string {
+	out := make([]string, len(ts))
+	for i, t := range ts {
+		out[i] = t.Name
+	}
+	return out
+}

--- a/util/sizetest/symcost/disasm_aarch64.go
+++ b/util/sizetest/symcost/disasm_aarch64.go
@@ -1,0 +1,202 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package symcost
+
+// arm64 instruction-level scanning of .text to discover memory
+// references from each function into rodata-bearing sections.
+//
+// Why this matters for size attribution:
+//
+// On arm64, Go emits all access to static data (rodata, type
+// descriptors, string constants, generic dictionaries, GC bitmaps,
+// itabs, ...) using the page-relative addressing pair:
+//
+//	ADRP Xn, page_of_target          ; upper 21 bits of target
+//	ADD  Xn, Xn, #page_offset_of_target ; lower 12 bits
+//
+// (or, less commonly, ADRP+LDR when loading the value at the target
+// rather than the address). After the ADRP+ADD pair, register Xn
+// holds the absolute virtual address of a static datum.
+//
+// By walking each function's bytes and recognizing this idiom, we
+// can find every named or unnamed datum the function touches and
+// attribute the datum's size to that function. This closes the
+// "function-side rodata attribution" gap that plain symbol-table
+// analysis can't see.
+//
+// Recognized patterns in this file:
+//
+//   - ADRP+ADD: yields a precise address (the common case).
+//   - ADRP+LDR (immediate, 12-bit unsigned, scaled): same idea,
+//     but the LDR's immediate is in *units of access size* (e.g. 8
+//     for a 64-bit load). We translate to bytes when computing the
+//     final address.
+//   - LDR (literal): a single instruction whose immediate encodes
+//     a PC-relative byte offset to a 4- or 8-byte constant. Used
+//     for embedded floating-point constants and the like.
+//
+// Other addressing forms (PC-relative branches, unscaled LDR/STR,
+// scaled ADRP-only references) either don't reach rodata or are
+// rare enough in Go arm64 codegen that we ignore them in the first
+// pass. False negatives here just mean we attribute slightly less
+// rodata; false positives could mis-attribute and would be worse.
+
+// armInstr is a 32-bit aarch64 instruction.
+type armInstr uint32
+
+// adrpDecode reports whether ins is an ADRP and, if so, returns the
+// destination register and a 33-bit signed immediate that, when
+// added to (PC & ~0xfff), gives the addressed page.
+//
+// ADRP encoding (ARM ARM C6.2.10):
+//
+//	1 immlo:2 1 0000 immhi:19 Rd:5
+//	bit 31 = 1, bits 28-24 = 10000
+func adrpDecode(ins armInstr) (rd int, imm int64, ok bool) {
+	if ins&0x9F000000 != 0x90000000 {
+		return 0, 0, false
+	}
+	immlo := int64((ins >> 29) & 0x3)
+	immhi := int64((ins >> 5) & 0x7FFFF)
+	imm21 := (immhi << 2) | immlo
+	// sign-extend from 21 bits, then shift left by 12 (page).
+	if imm21&(1<<20) != 0 {
+		imm21 |= ^int64((1 << 21) - 1)
+	}
+	return int(ins & 0x1F), imm21 << 12, true
+}
+
+// addImmDecode reports whether ins is `ADD Xd, Xn, #imm` (without
+// shift) and returns (rd, rn, imm).
+//
+// ADD (immediate) encoding (ARM ARM C6.2.5):
+//
+//	sf 0 0 100010 sh:1 imm12 Rn:5 Rd:5
+//	  with sf=1 for 64-bit
+//	  bits 30-23 = 0_0100010, mask 0x7F800000, base value 0x11000000
+//
+// We accept the unshifted form (sh=0); Go's codegen for rodata
+// addressing always emits the unshifted variant because the
+// immediate is the low 12 bits of the target's offset within its
+// 4 KB page.
+func addImmDecode(ins armInstr) (rd, rn int, imm int64, ok bool) {
+	if ins&0x7F800000 != 0x11000000 {
+		return 0, 0, 0, false
+	}
+	if (ins>>22)&1 != 0 { // sh bit; Go uses sh=0 for these
+		return 0, 0, 0, false
+	}
+	imm = int64((ins >> 10) & 0xFFF)
+	rn = int((ins >> 5) & 0x1F)
+	rd = int(ins & 0x1F)
+	return rd, rn, imm, true
+}
+
+// ldrImmUnsignedDecode reports whether ins is `LDR Xt, [Xn, #imm]`
+// in the unsigned-offset form and returns (rt, rn, byteOffset).
+//
+// LDR (immediate, unsigned offset) encoding for 64-bit:
+//
+//	1 1 1 1 1 0 0 1 0 1 imm12 Rn:5 Rt:5
+//	mask 0xFFC00000, value 0xF9400000
+//
+// The 12-bit immediate is in units of 8 bytes for the 64-bit form;
+// we return the byte-equivalent so callers can add it directly to a
+// base address to compute the final addressed byte.
+func ldrImmUnsignedDecode(ins armInstr) (rt, rn int, byteOffset int64, ok bool) {
+	if ins&0xFFC00000 != 0xF9400000 {
+		return 0, 0, 0, false
+	}
+	imm := int64((ins >> 10) & 0xFFF)
+	rn = int((ins >> 5) & 0x1F)
+	rt = int(ins & 0x1F)
+	return rt, rn, imm * 8, true
+}
+
+// scanArm64Refs walks the bytes of a function (one 4-byte
+// instruction at a time) and returns the set of byte addresses the
+// function references via ADRP+ADD or ADRP+LDR pairs.
+//
+// pc is the function's entry virtual address; bytes is its full
+// machine-code body. The little-endian assumption is correct for
+// arm64 (all current Go arm64 ABIs are LE).
+//
+// The returned slice contains absolute target addresses (i.e. into
+// the loaded image's address space). Duplicates are removed.
+func scanArm64Refs(pc uint64, bytes []byte) []uint64 {
+	if len(bytes)%4 != 0 {
+		// Truncate to instruction granularity.
+		bytes = bytes[:len(bytes)-(len(bytes)%4)]
+	}
+
+	// Track the most recent ADRP per destination register so that a
+	// subsequent ADD/LDR with the same source register can resolve
+	// the absolute address. We don't model arbitrary register flow;
+	// this is sufficient because Go's compiler emits ADRP and its
+	// completing ADD/LDR within a few instructions of each other.
+	const numRegs = 32
+	type pageState struct {
+		page  uint64 // (PC & ~0xfff) + ADRP imm
+		valid bool
+	}
+	var pageOf [numRegs]pageState
+
+	seen := map[uint64]struct{}{}
+	add := func(addr uint64) {
+		if addr == 0 {
+			return
+		}
+		seen[addr] = struct{}{}
+	}
+
+	for off := 0; off+4 <= len(bytes); off += 4 {
+		insPC := pc + uint64(off)
+		ins := armInstr(uint32(bytes[off]) |
+			uint32(bytes[off+1])<<8 |
+			uint32(bytes[off+2])<<16 |
+			uint32(bytes[off+3])<<24)
+
+		if rd, imm, ok := adrpDecode(ins); ok {
+			page := (insPC &^ 0xFFF) + uint64(imm)
+			pageOf[rd] = pageState{page: page, valid: true}
+			continue
+		}
+		if rd, rn, imm, ok := addImmDecode(ins); ok {
+			if rd != rn {
+				// We require ADRP and ADD to share dst/src; this
+				// is what Go emits and avoids false positives from
+				// arithmetic ADDs.
+				continue
+			}
+			ps := pageOf[rn]
+			if ps.valid {
+				add(ps.page + uint64(imm))
+				// Don't invalidate; the same Xn may be reused for
+				// multiple subsequent ADDs at the same page (rare
+				// but possible after function-internal branches).
+			}
+			continue
+		}
+		if rt, rn, off64, ok := ldrImmUnsignedDecode(ins); ok {
+			ps := pageOf[rn]
+			if ps.valid {
+				add(ps.page + uint64(off64))
+			}
+			_ = rt
+			continue
+		}
+		// Branch, RET, B.cond, BL, etc.: instructions we don't
+		// model. We also don't invalidate page state on these
+		// because invalidation would cause false negatives across
+		// straight-line basic blocks; in practice Go's emitter
+		// schedules ADRP and its consumer adjacently so this is
+		// a non-issue.
+	}
+
+	out := make([]uint64, 0, len(seen))
+	for a := range seen {
+		out = append(out, a)
+	}
+	return out
+}

--- a/util/sizetest/symcost/disasm_test.go
+++ b/util/sizetest/symcost/disasm_test.go
@@ -1,0 +1,236 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package symcost
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// encAdrp returns a synthesized ADRP instruction word for the
+// given destination register and 21-bit signed immediate (which
+// the decoder then shifts left by 12 to produce a page-aligned
+// byte address).
+//
+// The encoding (ARM ARM C6.2.10):
+//
+//	bit 31  = 1
+//	30..29  = immlo (low 2 bits of imm21)
+//	28..24  = 10000
+//	23..5   = immhi (high 19 bits of imm21)
+//	4..0    = Rd
+func encAdrp(rd int, imm21 int64) uint32 {
+	mask21 := int64((1 << 21) - 1)
+	imm := uint32(imm21 & mask21)
+	immlo := imm & 0x3
+	immhi := (imm >> 2) & 0x7FFFF
+	return 0x90000000 | (immlo << 29) | (immhi << 5) | uint32(rd&0x1F)
+}
+
+// encAddImm returns a synthesized 64-bit ADD-immediate instruction
+// word `ADD Xd, Xn, #imm12`. sh=0 (Go's emit form for static-data
+// addressing).
+//
+//	31     = sf (1 for 64-bit)
+//	30..23 = 00100010
+//	22     = sh (0)
+//	21..10 = imm12
+//	9..5   = Rn
+//	4..0   = Rd
+func encAddImm(rd, rn int, imm12 int64) uint32 {
+	return 0x91000000 |
+		(uint32(imm12&0xFFF) << 10) |
+		(uint32(rn&0x1F) << 5) |
+		uint32(rd&0x1F)
+}
+
+// TestAdrpDecode checks decoding of canonical ADRP encodings,
+// including the sign-extension of the 21-bit immediate and the
+// extraction of the destination register.
+func TestAdrpDecode(t *testing.T) {
+	tests := []struct {
+		name    string
+		ins     uint32
+		wantRd  int
+		wantImm int64
+		wantOK  bool
+	}{
+		{
+			// imm21 = 0x100 → imm = 0x100 << 12 = 0x100000.
+			name:    "ADRP X0, page=0x100",
+			ins:     encAdrp(0, 0x100),
+			wantRd:  0,
+			wantImm: 0x100000,
+			wantOK:  true,
+		},
+		{
+			// imm21 = 0x10 → imm = 0x10 << 12 = 0x10000.
+			name:    "ADRP X3, page=0x10",
+			ins:     encAdrp(3, 0x10),
+			wantRd:  3,
+			wantImm: 0x10000,
+			wantOK:  true,
+		},
+		{
+			// Negative imm21 (sign-extended): -1 → -0x1000.
+			name:    "ADRP X5, page=-1",
+			ins:     encAdrp(5, -1),
+			wantRd:  5,
+			wantImm: -0x1000,
+			wantOK:  true,
+		},
+		{
+			// Not an ADRP: a plain ADD is rejected.
+			name:   "not ADRP",
+			ins:    0x91000000,
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rd, imm, ok := adrpDecode(armInstr(tt.ins))
+			if ok != tt.wantOK {
+				t.Errorf("ok=%v, want %v", ok, tt.wantOK)
+				return
+			}
+			if !ok {
+				return
+			}
+			if rd != tt.wantRd {
+				t.Errorf("rd=%d, want %d", rd, tt.wantRd)
+			}
+			if imm != tt.wantImm {
+				t.Errorf("imm=%#x, want %#x", imm, tt.wantImm)
+			}
+		})
+	}
+}
+
+// TestAddImmDecode checks decoding of the unshifted ADD-immediate
+// form Go uses to complete a page+offset addressing pair.
+func TestAddImmDecode(t *testing.T) {
+	tests := []struct {
+		name    string
+		ins     uint32
+		wantRd  int
+		wantRn  int
+		wantImm int64
+		wantOK  bool
+	}{
+		{
+			name:    "ADD X0, X0, #0x123",
+			ins:     encAddImm(0, 0, 0x123),
+			wantRd:  0,
+			wantRn:  0,
+			wantImm: 0x123,
+			wantOK:  true,
+		},
+		{
+			name:    "ADD X3, X3, #0x100",
+			ins:     encAddImm(3, 3, 0x100),
+			wantRd:  3,
+			wantRn:  3,
+			wantImm: 0x100,
+			wantOK:  true,
+		},
+		{
+			// Shifted ADD (sh=1) is rejected because Go doesn't
+			// emit it for static-data addressing.
+			name:   "ADD with sh=1 rejected",
+			ins:    encAddImm(0, 0, 0) | (1 << 22),
+			wantOK: false,
+		},
+		{
+			// SUB-imm has a different opcode and is rejected.
+			name:   "SUB rejected",
+			ins:    0xD1000000,
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rd, rn, imm, ok := addImmDecode(armInstr(tt.ins))
+			if ok != tt.wantOK {
+				t.Errorf("ok=%v, want %v", ok, tt.wantOK)
+				return
+			}
+			if !ok {
+				return
+			}
+			if rd != tt.wantRd || rn != tt.wantRn || imm != tt.wantImm {
+				t.Errorf("got rd=%d rn=%d imm=%#x; want rd=%d rn=%d imm=%#x",
+					rd, rn, imm, tt.wantRd, tt.wantRn, tt.wantImm)
+			}
+		})
+	}
+}
+
+// TestScanArm64RefsBasic verifies the scanner picks up a single
+// ADRP+ADD pair as one resolved address.
+func TestScanArm64RefsBasic(t *testing.T) {
+	// At PC 0x100000:
+	//   ADRP X3, page=0x4 (→ X3 = 0x100000 & ~0xFFF + 0x4000 = 0x104000)
+	//   ADD  X3, X3, #0x100 (→ X3 = 0x104100)
+	pc := uint64(0x100000)
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint32(buf[0:], encAdrp(3, 0x4))
+	binary.LittleEndian.PutUint32(buf[4:], encAddImm(3, 3, 0x100))
+
+	refs := scanArm64Refs(pc, buf)
+	if len(refs) != 1 {
+		t.Fatalf("got %d refs, want 1: %v", len(refs), refs)
+	}
+	want := uint64(0x104100)
+	if refs[0] != want {
+		t.Errorf("ref = %#x, want %#x", refs[0], want)
+	}
+}
+
+// TestScanArm64RefsPairs verifies that two ADRP+ADD pairs
+// (separated by an unrelated instruction) each produce a distinct
+// reference, and that the unrelated instruction doesn't disturb
+// register state for the second pair.
+func TestScanArm64RefsPairs(t *testing.T) {
+	pc := uint64(0x200000)
+	buf := make([]byte, 5*4)
+	binary.LittleEndian.PutUint32(buf[0:], encAdrp(1, 0x10))       // X1 = 0x210000
+	binary.LittleEndian.PutUint32(buf[4:], encAddImm(1, 1, 0x10))  // X1 = 0x210010
+	binary.LittleEndian.PutUint32(buf[8:], 0xD503201F)             // NOP
+	binary.LittleEndian.PutUint32(buf[12:], encAdrp(2, 0x20))      // X2 = 0x220000 (page-aligned)
+	binary.LittleEndian.PutUint32(buf[16:], encAddImm(2, 2, 0x20)) // X2 = 0x220020
+
+	refs := scanArm64Refs(pc, buf)
+	got := map[uint64]bool{}
+	for _, r := range refs {
+		got[r] = true
+	}
+	for _, want := range []uint64{0x210010, 0x220020} {
+		if !got[want] {
+			t.Errorf("expected ref %#x, got %v", want, refs)
+		}
+	}
+}
+
+// TestScanArm64RefsDifferentRegisters verifies that ADD using a
+// source register that didn't have a recent ADRP does not create
+// a phantom reference.
+func TestScanArm64RefsDifferentRegisters(t *testing.T) {
+	pc := uint64(0x300000)
+	buf := make([]byte, 3*4)
+	// ADRP X1, page=0x10 → X1 holds 0x310000
+	binary.LittleEndian.PutUint32(buf[0:], encAdrp(1, 0x10))
+	// ADD  X2, X2, #0x40 → uses X2 as source; we never set X2,
+	// so this should NOT produce a ref.
+	binary.LittleEndian.PutUint32(buf[4:], encAddImm(2, 2, 0x40))
+	// ADD X1, X1, #0x80 → completes the X1 pair → 0x310080.
+	binary.LittleEndian.PutUint32(buf[8:], encAddImm(1, 1, 0x80))
+
+	refs := scanArm64Refs(pc, buf)
+	if len(refs) != 1 {
+		t.Fatalf("got %d refs, want 1: %v", len(refs), refs)
+	}
+	if refs[0] != 0x310080 {
+		t.Errorf("ref = %#x, want 0x310080", refs[0])
+	}
+}

--- a/util/sizetest/symcost/integration_test.go
+++ b/util/sizetest/symcost/integration_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package symcost_test
+
+import (
+	"strings"
+	"testing"
+
+	"tailscale.com/util/sizetest"
+	"tailscale.com/util/sizetest/symcost"
+)
+
+// TestAnalyzeAgainstRealBinary builds a tiny program that uses two
+// instantiations of a generic function and verifies that
+// symcost.Analyze, going through `go tool nm -size`, identifies and
+// groups them. This catches regressions in nm output parsing across
+// Go versions.
+func TestAnalyzeAgainstRealBinary(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping: invokes `go build` and `go tool nm`")
+	}
+
+	// We disable -ldflags="-s -w" here (the sizetest default) so the
+	// symbol table is preserved. Trimpath is fine.
+	opts := sizetest.BuildOptions{
+		LDFlags:  " ", // explicit non-empty to override default of "-s -w"
+		Trimpath: ptr(true),
+	}
+	res := sizetest.BuildWithOptions(t, sizetest.Variant{
+		Name: "symcost-fixture",
+		Source: `package main
+
+//go:noinline
+func Sum[T int | int64](xs []T) T {
+	var s T
+	for _, x := range xs {
+		s += x
+	}
+	return s
+}
+
+func main() {
+	println(Sum([]int{1, 2, 3}))
+	println(Sum([]int64{4, 5, 6}))
+}
+`,
+	}, opts)
+
+	groups, err := symcost.Analyze(res.BinaryPath)
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+
+	var found *symcost.Group
+	for i := range groups {
+		if strings.Contains(groups[i].Template, "main.Sum[…]") {
+			found = &groups[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("did not find main.Sum[…] in groups; sample: %v", sample(groups, 10))
+	}
+	if found.Count() < 2 {
+		t.Errorf("main.Sum[…] count: got %d, want >= 2 (one per instantiation)", found.Count())
+	}
+	if !found.IsGeneric() {
+		t.Error("main.Sum[…] should be flagged as generic")
+	}
+	if !strings.HasPrefix(found.Package, "main") && found.Package != "main" {
+		t.Errorf("main.Sum[…] package: got %q, want \"main\"", found.Package)
+	}
+}
+
+func sample(gs []symcost.Group, n int) []string {
+	if n > len(gs) {
+		n = len(gs)
+	}
+	out := make([]string, n)
+	for i := 0; i < n; i++ {
+		out[i] = gs[i].Template
+	}
+	return out
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/util/sizetest/symcost/itabs.go
+++ b/util/sizetest/symcost/itabs.go
@@ -1,0 +1,133 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package symcost
+
+import (
+	"fmt"
+)
+
+// Itab is one interface table from .itablink, attributing the
+// itab's storage cost to the (concrete type, interface type) pair.
+type Itab struct {
+	// Addr is the virtual address of the itab in rodata/itablink.
+	Addr uint64
+	// Bytes is the total size of the itab struct itself, including
+	// the trailing fun pointer array.
+	Bytes int64
+	// SymName is the linker-emitted symbol name for the itab,
+	// `go:itab.<concrete>,<interface>` if the binary still carries
+	// it as a named symbol.
+	SymName string
+	// ConcreteName is the concrete type name (e.g.
+	// "*tailscale.com/util/eventbus.Publisher[main.Event0]"). May
+	// be empty if we couldn't resolve it (e.g. from index entries
+	// that point at unnamed types).
+	ConcreteName string
+	// InterfaceName is the interface type name (e.g.
+	// "tailscale.com/util/eventbus.publisher").
+	InterfaceName string
+}
+
+// loadItabs walks .itablink (a sorted list of pointers to itab
+// structs) and records each one. The names come from the binary's
+// static symbol table when present, since itabs are emitted with
+// canonical names like `go:itab.<concrete>,<interface>`.
+func (b *Binary) loadItabs() error {
+	il := b.Sections[".itablink"]
+	if il == nil || il.Size == 0 {
+		return nil
+	}
+	if b.PtrSize != 8 && b.PtrSize != 4 {
+		return fmt.Errorf("unsupported pointer size %d", b.PtrSize)
+	}
+	count := int(il.Size) / b.PtrSize
+	for i := 0; i < count; i++ {
+		buf := il.Data[i*b.PtrSize : (i+1)*b.PtrSize]
+		var addr uint64
+		switch b.PtrSize {
+		case 8:
+			addr = b.ByteOrder.Uint64(buf)
+		case 4:
+			addr = uint64(b.ByteOrder.Uint32(buf))
+		}
+		if addr == 0 {
+			continue
+		}
+		it := b.decodeItab(addr)
+		if it != nil {
+			b.Itabs = append(b.Itabs, it)
+		}
+	}
+	return nil
+}
+
+// decodeItab reads the itab at addr. The runtime layout is:
+//
+//	Inter   *interfacetype  // ptrSize
+//	Type    *_type          // ptrSize
+//	Hash    uint32          // 4
+//	_       [4]byte         // 4 padding (on 64-bit)
+//	Fun     [1]uintptr      // ptrSize, plus per-method extension
+//
+// The total size is `2*ptrSize + 8 + ptrSize * nmethod`. We can find
+// a named symbol covering this address (and its size) via SymsByName
+// keyed by `go:itab.<concrete>,<interface>` — that is the most
+// reliable way to size each itab without fully decoding the interface
+// method count.
+func (b *Binary) decodeItab(addr uint64) *Itab {
+	rodata := b.Sections[".rodata"]
+	if rodata == nil || !rodata.AddrInRange(addr) {
+		return nil
+	}
+	// Try to find a named symbol at this address.
+	var sym *Sym
+	for _, s := range b.Syms {
+		if s.Addr == addr {
+			sym = s
+			break
+		}
+		if s.Addr > addr {
+			break
+		}
+	}
+	it := &Itab{Addr: addr}
+	if sym != nil {
+		it.SymName = sym.Name
+		it.Bytes = int64(sym.Size)
+		// Parse `go:itab.<concrete>,<interface>` (or `go:itab.<x>` for
+		// some emit paths).
+		if rest, ok := stripPrefix(sym.Name, "go:itab."); ok {
+			if comma := lastByte(rest, ','); comma >= 0 {
+				it.ConcreteName = rest[:comma]
+				it.InterfaceName = rest[comma+1:]
+			} else {
+				it.ConcreteName = rest
+			}
+		}
+	} else {
+		// Fall back to a conservative minimum size; we lose
+		// the per-method tail (which is usually small for the
+		// 1-2 method interfaces we care about).
+		it.Bytes = int64(2*b.PtrSize + 8 + b.PtrSize)
+	}
+	return it
+}
+
+// stripPrefix is strings.CutPrefix in older-Go-friendly form.
+func stripPrefix(s, prefix string) (string, bool) {
+	if len(s) >= len(prefix) && s[:len(prefix)] == prefix {
+		return s[len(prefix):], true
+	}
+	return "", false
+}
+
+// lastByte returns the index of the last occurrence of c in s, or -1.
+func lastByte(s string, c byte) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}

--- a/util/sizetest/symcost/symcost.go
+++ b/util/sizetest/symcost/symcost.go
@@ -1,0 +1,325 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Package symcost analyzes a Go binary's symbol table to find which
+// generic ("parameterized") functions and types are most expensive in
+// aggregate.
+//
+// Go generics are implemented with GC-shape stenciling: the compiler
+// emits one copy of a generic function/method body per distinct GC
+// shape of its type parameters, plus per-T thin wrappers (Close,
+// itabs, type descriptors) for each concrete instantiation. Both the
+// stencils and the per-T wrappers cost binary size, and the cost
+// scales with the number of distinct type arguments used at call
+// sites across the program.
+//
+// symcost reads `go tool nm -size` output, normalizes generic
+// instantiation suffixes (the [...] payload, including the
+// `go.shape.*` markers Go emits for stencils) into a single template
+// per generic, and reports per-template totals. The top of the output
+// tells you which generic body is costing you the most binary size in
+// aggregate; high min/max variance within a template tells you that
+// GC-shape sharing is uneven and might point to dedup opportunities.
+//
+// This package is a measurement aid. It does not modify binaries.
+package symcost
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Symbol is a single entry from `go tool nm -size`.
+type Symbol struct {
+	// Addr is the symbol's address as printed by nm. May be empty
+	// for unmapped symbols.
+	Addr string
+	// Size is the symbol size in bytes.
+	Size int64
+	// Type is the nm symbol type letter (e.g. T for text, R for
+	// read-only data, B for BSS, etc.).
+	Type string
+	// Name is the symbol's full demangled name as printed by nm.
+	Name string
+}
+
+// Group is a set of symbols that share a normalized name. For
+// generic functions/methods, this collapses all instantiations of a
+// single generic template into one Group; for non-generic symbols,
+// the Group contains exactly one Symbol.
+type Group struct {
+	// Template is the normalized symbol name. Generic instantiation
+	// suffixes (the bracketed type arguments) are replaced with
+	// `[…]`. For example all of:
+	//   foo.Bar[main.X].Baz
+	//   foo.Bar[main.Y].Baz
+	//   foo.Bar[go.shape.struct { F int }].Baz
+	// share the template `foo.Bar[…].Baz`.
+	Template string
+	// Package is the import path the symbol belongs to, derived
+	// from Template. Empty for symbols where a package can't be
+	// inferred (e.g. linker-internal symbols).
+	Package string
+	// Members are the individual symbols in this group, sorted by
+	// descending Size.
+	Members []Symbol
+	// Total is the sum of Size across Members.
+	Total int64
+	// Min, Max, and Avg are the size statistics across Members. Avg
+	// is rounded down (integer division).
+	Min, Max, Avg int64
+}
+
+// Analyze runs `go tool nm -size` against binaryPath and returns
+// groups sorted by descending Total size.
+//
+// The provided context can be used to cancel the nm subprocess.
+func Analyze(binaryPath string) ([]Group, error) {
+	cmd := exec.Command("go", "tool", "nm", "-size", binaryPath)
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("`go tool nm -size %s`: %w: %s",
+				binaryPath, err, string(ee.Stderr))
+		}
+		return nil, fmt.Errorf("`go tool nm -size %s`: %w", binaryPath, err)
+	}
+	return AnalyzeNMOutput(strings.NewReader(string(out)))
+}
+
+// AnalyzeNMOutput parses the textual output of `go tool nm -size`
+// from r and returns the resulting groups, sorted by descending
+// Total size. It is exposed separately so callers can feed in
+// captured nm output (e.g. from a file) without re-invoking nm.
+func AnalyzeNMOutput(r io.Reader) ([]Group, error) {
+	syms, err := parseNM(r)
+	if err != nil {
+		return nil, err
+	}
+	return GroupSymbols(syms), nil
+}
+
+// GroupSymbols collapses syms into Groups keyed by the normalized
+// template name. The result is sorted by descending Total size.
+func GroupSymbols(syms []Symbol) []Group {
+	byTemplate := make(map[string]*Group)
+	for _, s := range syms {
+		tpl := normalize(s.Name)
+		g, ok := byTemplate[tpl]
+		if !ok {
+			g = &Group{Template: tpl, Package: packageOf(tpl)}
+			byTemplate[tpl] = g
+		}
+		g.Members = append(g.Members, s)
+		g.Total += s.Size
+	}
+	out := make([]Group, 0, len(byTemplate))
+	for _, g := range byTemplate {
+		sort.Slice(g.Members, func(i, j int) bool {
+			return g.Members[i].Size > g.Members[j].Size
+		})
+		g.Min = g.Members[len(g.Members)-1].Size
+		g.Max = g.Members[0].Size
+		g.Avg = g.Total / int64(len(g.Members))
+		out = append(out, *g)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Total != out[j].Total {
+			return out[i].Total > out[j].Total
+		}
+		return out[i].Template < out[j].Template
+	})
+	return out
+}
+
+// IsGeneric reports whether the group's template represents a
+// generic instantiation (i.e. its name contains the `[…]` placeholder
+// that normalize() inserts).
+func (g Group) IsGeneric() bool {
+	return strings.Contains(g.Template, "[…]")
+}
+
+// Count returns the number of symbols in the group.
+func (g Group) Count() int { return len(g.Members) }
+
+// Filter is a set of optional restrictions applied to a slice of
+// Groups. Zero values mean "no restriction".
+type Filter struct {
+	// PackageSubstr keeps only groups whose Package contains this
+	// substring. Useful for narrowing to a single subsystem.
+	PackageSubstr string
+	// MinCount keeps only groups with at least this many member
+	// symbols. Useful for finding heavily-instantiated generics
+	// (set MinCount=2 to drop everything non-generic).
+	MinCount int
+	// MinTotal keeps only groups whose Total size is at least this
+	// many bytes.
+	MinTotal int64
+	// GenericOnly, if true, keeps only groups representing generic
+	// instantiations (Group.IsGeneric()).
+	GenericOnly bool
+}
+
+// Apply returns groups filtered according to f, preserving order.
+func (f Filter) Apply(groups []Group) []Group {
+	out := groups[:0:0]
+	for _, g := range groups {
+		if f.PackageSubstr != "" && !strings.Contains(g.Package, f.PackageSubstr) {
+			continue
+		}
+		if f.MinCount > 0 && g.Count() < f.MinCount {
+			continue
+		}
+		if f.MinTotal > 0 && g.Total < f.MinTotal {
+			continue
+		}
+		if f.GenericOnly && !g.IsGeneric() {
+			continue
+		}
+		out = append(out, g)
+	}
+	return out
+}
+
+// parseNM parses `go tool nm -size` output. Each line has the form:
+//
+//	<addr-or-spaces> <size> <type> <name>
+//
+// where addr is hex (or blank), size is decimal, type is a single
+// letter, and name is the rest of the line (and may contain spaces,
+// e.g. inside `go.shape.struct { F int }`).
+func parseNM(r io.Reader) ([]Symbol, error) {
+	var syms []Symbol
+	sc := bufio.NewScanner(r)
+	// nm output can be wide for stencils with deep struct shapes.
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := sc.Text()
+		if line == "" {
+			continue
+		}
+		// nm prints addr right-justified in 16 columns; an unmapped
+		// symbol leaves it blank.
+		var addr string
+		rest := line
+		if len(line) >= 16 && strings.TrimSpace(line[:16]) != "" {
+			addr = strings.TrimSpace(line[:16])
+			rest = strings.TrimLeft(line[16:], " ")
+		} else if len(line) >= 16 {
+			rest = strings.TrimLeft(line[16:], " ")
+		} else {
+			rest = strings.TrimLeft(line, " ")
+		}
+		// Now rest is "<size> <type> <name>".
+		sizeEnd := strings.IndexByte(rest, ' ')
+		if sizeEnd < 0 {
+			continue
+		}
+		size, err := strconv.ParseInt(rest[:sizeEnd], 10, 64)
+		if err != nil {
+			continue // not a parseable line; skip
+		}
+		rest = strings.TrimLeft(rest[sizeEnd:], " ")
+		if len(rest) < 2 {
+			continue
+		}
+		typ := rest[:1]
+		name := strings.TrimLeft(rest[1:], " ")
+		syms = append(syms, Symbol{
+			Addr: addr,
+			Size: size,
+			Type: typ,
+			Name: name,
+		})
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("scanning nm output: %w", err)
+	}
+	return syms, nil
+}
+
+// normalize collapses every top-level bracketed segment in name into
+// `[…]`. This turns all instantiations of a single generic template
+// (whether by concrete types like `main.Event0` or by GC-shape names
+// like `go.shape.struct { F0 int }`) into one template string.
+//
+// We deliberately collapse only top-level brackets — nested brackets
+// inside the type argument list (rare in practice) are part of the
+// payload and would be erased anyway. Bracket depth is tracked so we
+// don't get confused by struct types whose own representation
+// contains brackets.
+func normalize(name string) string {
+	var b strings.Builder
+	b.Grow(len(name))
+	depth := 0
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		switch c {
+		case '[':
+			if depth == 0 {
+				b.WriteString("[…]")
+			}
+			depth++
+		case ']':
+			if depth > 0 {
+				depth--
+			}
+		default:
+			if depth == 0 {
+				b.WriteByte(c)
+			}
+		}
+	}
+	return b.String()
+}
+
+// packageOf returns the import path portion of a normalized symbol
+// name, or empty string if one can't be determined.
+//
+// Go symbol names look like `import/path.Type.Method` or
+// `import/path.func` or `import/path.(*Type).Method`. The package
+// path ends at the last "/" segment's first ".".
+func packageOf(name string) string {
+	// Strip leading runtime/linker artifacts like "go:itab.".
+	if rest, ok := strings.CutPrefix(name, "go:itab."); ok {
+		// itabs are "go:itab.<concrete>,<interface>"; the interface
+		// part's package is the most useful for grouping.
+		if comma := strings.LastIndexByte(rest, ','); comma >= 0 {
+			return packageOf(strings.TrimSpace(rest[comma+1:]))
+		}
+		name = rest
+	}
+	// Find the last "/" — everything before plus the next segment's
+	// leading identifier is the package.
+	slash := strings.LastIndexByte(name, '/')
+	tail := name
+	prefix := ""
+	if slash >= 0 {
+		prefix = name[:slash+1]
+		tail = name[slash+1:]
+	}
+	// In tail, the package name is up to the first '.' that isn't
+	// inside brackets/parens.
+	depth := 0
+	for i := 0; i < len(tail); i++ {
+		switch tail[i] {
+		case '[', '(':
+			depth++
+		case ']', ')':
+			if depth > 0 {
+				depth--
+			}
+		case '.':
+			if depth == 0 {
+				return prefix + tail[:i]
+			}
+		}
+	}
+	// No '.' found — give up.
+	return ""
+}

--- a/util/sizetest/symcost/symcost_test.go
+++ b/util/sizetest/symcost/symcost_test.go
@@ -1,0 +1,169 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package symcost
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalize(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"plain.symbol", "plain.symbol"},
+		{
+			"tailscale.com/util/eventbus.(*Publisher[main.Event0]).Close",
+			"tailscale.com/util/eventbus.(*Publisher[…]).Close",
+		},
+		{
+			"tailscale.com/util/eventbus.(*Publisher[go.shape.struct { F0 int64 }]).Publish",
+			"tailscale.com/util/eventbus.(*Publisher[…]).Publish",
+		},
+		{
+			"go:itab.*tailscale.com/util/eventbus.Publisher[main.Event0],tailscale.com/util/eventbus.publisher",
+			"go:itab.*tailscale.com/util/eventbus.Publisher[…],tailscale.com/util/eventbus.publisher",
+		},
+		{
+			// Nested brackets inside the type arg should not unbalance
+			// the depth counter.
+			"pkg.Foo[go.shape.[]int].Bar",
+			"pkg.Foo[…].Bar",
+		},
+		{
+			// Multiple top-level type-arg lists (e.g. on chained
+			// methods) should each collapse independently.
+			"pkg.Foo[A].Bar[B]",
+			"pkg.Foo[…].Bar[…]",
+		},
+	}
+	for _, tt := range tests {
+		got := normalize(tt.in)
+		if got != tt.want {
+			t.Errorf("normalize(%q):\n got: %q\nwant: %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestPackageOf(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"runtime.gcWork", "runtime"},
+		{"tailscale.com/util/eventbus.(*Publisher[…]).Close", "tailscale.com/util/eventbus"},
+		{"tailscale.com/util/eventbus.(*Publisher[…]).Publish", "tailscale.com/util/eventbus"},
+		{
+			"go:itab.*tailscale.com/util/eventbus.Publisher[…],tailscale.com/util/eventbus.publisher",
+			"tailscale.com/util/eventbus",
+		},
+		// Linker-internal pools like "$f32.<hex>" don't have a real
+		// package; we report the leading prefix verbatim, which is
+		// fine for grouping purposes.
+		{"$f32.358637bd", "$f32"},
+	}
+	for _, tt := range tests {
+		got := packageOf(tt.in)
+		if got != tt.want {
+			t.Errorf("packageOf(%q): got %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+const sampleNM = `  6360e0        357 T tailscale.com/util/eventbus.(*Publisher[go.shape.struct { F0 int64 }]).Publish
+  636260         92 T tailscale.com/util/eventbus.(*Publisher[go.shape.struct { F0 int64 }]).Close
+  6385e0         50 T tailscale.com/util/eventbus.(*Publisher[main.Event0]).Close
+  6385f0         50 T tailscale.com/util/eventbus.(*Publisher[main.Event1]).Close
+  6385f4         50 T tailscale.com/util/eventbus.(*Publisher[main.Event2]).Close
+  614cc0        369 T tailscale.com/util/eventbus.(*Bus).Close
+`
+
+func TestAnalyzeNMOutput(t *testing.T) {
+	groups, err := AnalyzeNMOutput(strings.NewReader(sampleNM))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	byTpl := make(map[string]Group)
+	for _, g := range groups {
+		byTpl[g.Template] = g
+	}
+
+	// (*Publisher[…]).Close should aggregate 4 members (1 stencil + 3 wrappers).
+	closeGrp, ok := byTpl["tailscale.com/util/eventbus.(*Publisher[…]).Close"]
+	if !ok {
+		t.Fatalf("missing Publisher[…].Close group; got templates: %v", templateNames(groups))
+	}
+	if got, want := closeGrp.Count(), 4; got != want {
+		t.Errorf("Publisher[…].Close count: got %d, want %d", got, want)
+	}
+	if got, want := closeGrp.Total, int64(92+50+50+50); got != want {
+		t.Errorf("Publisher[…].Close total: got %d, want %d", got, want)
+	}
+	if got, want := closeGrp.Max, int64(92); got != want {
+		t.Errorf("Publisher[…].Close max: got %d, want %d", got, want)
+	}
+	if got, want := closeGrp.Min, int64(50); got != want {
+		t.Errorf("Publisher[…].Close min: got %d, want %d", got, want)
+	}
+	if !closeGrp.IsGeneric() {
+		t.Error("Publisher[…].Close should be flagged as generic")
+	}
+	if got, want := closeGrp.Package, "tailscale.com/util/eventbus"; got != want {
+		t.Errorf("Publisher[…].Close package: got %q, want %q", got, want)
+	}
+
+	// (*Bus).Close is a single non-generic symbol.
+	busGrp, ok := byTpl["tailscale.com/util/eventbus.(*Bus).Close"]
+	if !ok {
+		t.Fatal("missing Bus.Close group")
+	}
+	if busGrp.Count() != 1 {
+		t.Errorf("Bus.Close count: got %d, want 1", busGrp.Count())
+	}
+	if busGrp.IsGeneric() {
+		t.Error("Bus.Close should not be flagged as generic")
+	}
+
+	// Sort order: total descending. Publisher[…].Publish (357) is
+	// alone in its template, vs Publisher[…].Close (242 across 4)
+	// and Bus.Close (369).
+	if groups[0].Total < groups[1].Total {
+		t.Errorf("groups not sorted by Total descending: %d < %d",
+			groups[0].Total, groups[1].Total)
+	}
+}
+
+func TestFilter(t *testing.T) {
+	groups, err := AnalyzeNMOutput(strings.NewReader(sampleNM))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gen := Filter{GenericOnly: true}.Apply(groups)
+	for _, g := range gen {
+		if !g.IsGeneric() {
+			t.Errorf("GenericOnly retained non-generic %q", g.Template)
+		}
+	}
+	pkg := Filter{PackageSubstr: "eventbus"}.Apply(groups)
+	for _, g := range pkg {
+		if !strings.Contains(g.Package, "eventbus") {
+			t.Errorf("PackageSubstr retained %q (pkg %q)", g.Template, g.Package)
+		}
+	}
+	min := Filter{MinCount: 2}.Apply(groups)
+	for _, g := range min {
+		if g.Count() < 2 {
+			t.Errorf("MinCount=2 retained %q (count %d)", g.Template, g.Count())
+		}
+	}
+}
+
+func templateNames(gs []Group) []string {
+	out := make([]string, len(gs))
+	for i, g := range gs {
+		out[i] = g.Template
+	}
+	return out
+}

--- a/util/sizetest/symcost/types.go
+++ b/util/sizetest/symcost/types.go
@@ -1,0 +1,383 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package symcost
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+)
+
+// Type is the runtime type descriptor for one Go type as it appears
+// in a compiled binary. It carries enough information to attribute
+// the descriptor's bytes to a specific Go type name.
+//
+// Type mirrors the layout described in internal/abi.Type as of Go
+// 1.21+. We do not import internal/abi (it isn't accessible to
+// regular packages); the constants we depend on are vendored in
+// abiconst.go.
+type Type struct {
+	// Addr is the virtual address of the type descriptor in
+	// .rodata.
+	Addr uint64
+	// Bytes is the size of the type descriptor proper, in bytes.
+	// This includes the common Type header, the kind-specific
+	// extension (StructType, FuncType, ChanType, etc. and any
+	// trailing field arrays), and the optional UncommonType
+	// (method list) when present.
+	Bytes int64
+	// NameBytes is the size of the type's name string in
+	// .rodata, computed from the (length-prefixed, optional-tag-prefixed)
+	// reflect.name encoding. This is part of the per-type cost
+	// even though it lives outside the Type struct itself.
+	NameBytes int64
+	// Name is the demangled type name (e.g.
+	// "*tailscale.com/util/eventbus.Publisher[main.Event0]").
+	Name string
+	// Kind is the type's reflect-style kind (Struct, Pointer,
+	// Interface, etc.).
+	Kind Kind
+	// HasUncommon is true when the type carries a UncommonType
+	// (method list) extension.
+	HasUncommon bool
+}
+
+// TotalBytes returns Bytes + NameBytes, the full per-type cost as
+// charged by symcost's attribution.
+func (t *Type) TotalBytes() int64 { return t.Bytes + t.NameBytes }
+
+// loadTypes walks .typelink to find every type descriptor and
+// records each one in b.Types. The .typelink section is a sorted
+// list of int32 offsets into the read-only data segment that point
+// at runtime._type structs. We follow each offset and decode the
+// type's name and size.
+func (b *Binary) loadTypes() error {
+	tl := b.Sections[".typelink"]
+	if tl == nil || tl.Size == 0 {
+		// No .typelink section: nothing to attribute.
+		return nil
+	}
+	// .typelink entries are int32 offsets relative to the start of
+	// the type table, which the runtime keeps in moduledata.types.
+	// In the linked binary, the resolved address is the moduledata
+	// "types" base plus the offset. The base is the start of the
+	// rodata range that contains type descriptors. Empirically,
+	// it is the address of the .rodata section's typelink-adjacent
+	// range; in practice, we can find it as the lowest address
+	// among all referenced type pointers.
+	//
+	// For decoding purposes, we can just iterate offsets and look
+	// up the corresponding rodata bytes via the section table.
+	// However, the offsets are relative to a base we need to know.
+	// Strategy: treat the offsets as additions to the lowest
+	// .rodata address; the linker emits typelink offsets relative
+	// to that. If the resulting address falls in .rodata and the
+	// decoded type looks valid, we accept it.
+	//
+	// In Go's actual encoding the offsets are relative to
+	// firstmoduledata.types, which equals the start of the
+	// rodata block reserved for types. We don't have direct
+	// access to moduledata, but we can probe: try each .rodata
+	// section's start as the base and pick whichever produces
+	// valid, in-range type pointers.
+	rodata := b.Sections[".rodata"]
+	if rodata == nil {
+		return nil
+	}
+	base, err := b.findTypelinkBase(tl, rodata)
+	if err != nil {
+		return fmt.Errorf("locating typelink base: %w", err)
+	}
+
+	count := int(tl.Size) / 4
+	for i := 0; i < count; i++ {
+		off := int32(b.ByteOrder.Uint32(tl.Data[i*4:]))
+		typeAddr := base + uint64(int64(off))
+		t, err := b.decodeType(typeAddr)
+		if err != nil {
+			// A bad entry means our base is wrong or the
+			// binary uses a layout we don't understand.
+			// Continue trying others; the loop is best-effort.
+			continue
+		}
+		if t == nil {
+			continue
+		}
+		b.Types[t.Name] = append(b.Types[t.Name], t)
+	}
+	return nil
+}
+
+// findTypelinkBase determines the address that .typelink offsets
+// are relative to. The Go linker emits these offsets relative to
+// the start of the rodata "types" range (firstmoduledata.types).
+// We probe by trying the .rodata start as the base, decoding the
+// first entry, and checking that the decoded type's name is a
+// plausible string. If that fails, we step the base forward in
+// page-sized increments until we find a base that works.
+func (b *Binary) findTypelinkBase(tl, rodata *Section) (uint64, error) {
+	// Heuristic: try .rodata.Addr + offset for each candidate base,
+	// where candidate base is .rodata.Addr (modern layout). If the
+	// first three entries all decode cleanly and produce names
+	// from the rodata section, we accept the base.
+	candidates := []uint64{rodata.Addr}
+	// In some builds the type pool starts after a header within
+	// rodata; allow probing in PtrSize steps for a few iterations.
+	for delta := uint64(b.PtrSize); delta < 4096; delta += uint64(b.PtrSize) {
+		candidates = append(candidates, rodata.Addr+delta)
+	}
+	for _, base := range candidates {
+		ok := 0
+		for i := 0; i < 5 && i*4 < len(tl.Data); i++ {
+			off := int32(b.ByteOrder.Uint32(tl.Data[i*4:]))
+			addr := base + uint64(int64(off))
+			t, err := b.decodeType(addr)
+			if err == nil && t != nil && plausibleTypeName(t.Name) {
+				ok++
+			}
+		}
+		if ok >= 3 {
+			return base, nil
+		}
+	}
+	return 0, errors.New("no typelink base produced plausible types")
+}
+
+// plausibleTypeName reports whether s looks like a Go type name as
+// emitted by the compiler. We use it to validate guesses at the
+// typelink base address.
+func plausibleTypeName(s string) bool {
+	if s == "" || len(s) > 4096 {
+		return false
+	}
+	// Type names contain at least one letter; many start with '*',
+	// '[', a package path, etc. Reject names that have NUL bytes or
+	// non-printable characters.
+	hasLetter := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c < 0x20 || c == 0x7f {
+			return false
+		}
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') {
+			hasLetter = true
+		}
+	}
+	return hasLetter
+}
+
+// decodeType reads a runtime._type descriptor at addr and returns
+// a *Type with its name and total byte size. Returns nil and a
+// non-nil error if the address is out of range or the data doesn't
+// look like a type descriptor.
+func (b *Binary) decodeType(addr uint64) (*Type, error) {
+	rodata := b.Sections[".rodata"]
+	if rodata == nil || !rodata.AddrInRange(addr) {
+		return nil, fmt.Errorf("addr 0x%x not in .rodata", addr)
+	}
+	common := commonTypeSize(b.PtrSize)
+	hdr := rodata.Slice(addr, common)
+	if hdr == nil {
+		return nil, fmt.Errorf("type header at 0x%x out of range", addr)
+	}
+	// Parse what we need: tflag, kind, str (NameOff), ptrToThis (TypeOff).
+	tflag := hdr[tflagOffset(b.PtrSize)]
+	kindByte := hdr[kindOffset(b.PtrSize)]
+	kind := Kind(kindByte & kindMask)
+	strOff := int32(b.ByteOrder.Uint32(hdr[nameOffOffset(b.PtrSize):]))
+	hasUncommon := tflag&tflagUncommon != 0
+
+	// Extension size depends on kind. We compute the kind-specific
+	// extension size, then add UncommonType if present, then add
+	// any trailing variable-length arrays for kinds with method
+	// lists / fields / parameter lists.
+	extSize, extVar := kindExtraSize(b.PtrSize, kind, addr, rodata, common, b.ByteOrder)
+
+	totalSize := int64(common + extSize + extVar)
+	if hasUncommon {
+		// UncommonType is appended after the kind-specific extension
+		// and contains its own variable-length method list.
+		uOff := common + extSize + extVar
+		uMethods, uMethodsBytes := decodeUncommon(b.PtrSize, addr, rodata, uOff, b.ByteOrder)
+		_ = uMethods
+		totalSize += int64(uncommonSize() + uMethodsBytes)
+	}
+
+	// Decode the name. The name lives in rodata; its offset is
+	// relative to the same base used in typelink. For simplicity
+	// we treat it as relative to .rodata.Addr — the same convention
+	// the compiler uses.
+	name, nameBytes := decodeName(rodata, addr, strOff, tflag)
+
+	return &Type{
+		Addr:        addr,
+		Bytes:       totalSize,
+		NameBytes:   nameBytes,
+		Name:        name,
+		Kind:        kind,
+		HasUncommon: hasUncommon,
+	}, nil
+}
+
+// decodeName reads a length-prefixed name string starting at the
+// rodata-relative offset off (relative to the .rodata base, matching
+// what the linker emits). Returns the decoded name and the size in
+// bytes the name occupies in rodata.
+func decodeName(rodata *Section, typeAddr uint64, off int32, tflag uint8) (string, int64) {
+	nameAddr := rodata.Addr + uint64(int64(off))
+	if !rodata.AddrInRange(nameAddr) {
+		return "", 0
+	}
+	off64 := nameAddr - rodata.Addr
+	data := rodata.Data[off64:]
+	if len(data) < 2 {
+		return "", 0
+	}
+	// reflect.name layout: 1 byte flags, then varint length, then
+	// `length` bytes of name, then optional tag and pkgpath which
+	// we don't account for here (they're separate offsets and the
+	// linker shares them across types).
+	nameLen, lenLen := binaryUvarint(data[1:])
+	if nameLen == 0 || nameLen > 4096 {
+		return "", 0
+	}
+	headerSize := 1 + lenLen
+	totalSize := int64(headerSize) + int64(nameLen)
+	if int64(len(data)) < totalSize {
+		return "", 0
+	}
+	name := string(data[headerSize : headerSize+int(nameLen)])
+	if tflag&tflagExtraStar != 0 && len(name) > 0 && name[0] == '*' {
+		// The compiler stores the name with a leading '*' for
+		// pointer-to-named types so the same name string can be
+		// reused for both T and *T. The TFlagExtraStar bit signals
+		// this. The canonical (callable) name for the type is
+		// without the star, but the storage cost still includes
+		// the star byte; we keep totalSize unchanged.
+		name = name[1:]
+	}
+	return name, totalSize
+}
+
+// binaryUvarint is a slimmed copy of encoding/binary.Uvarint that
+// avoids the import cycle for callers that don't already use it.
+// It returns (value, byteCount). On error returns (0, 0).
+func binaryUvarint(buf []byte) (uint64, int) {
+	var x uint64
+	var s uint
+	for i, b := range buf {
+		if i == 10 {
+			return 0, 0
+		}
+		if b < 0x80 {
+			return x | uint64(b)<<s, i + 1
+		}
+		x |= uint64(b&0x7f) << s
+		s += 7
+	}
+	return 0, 0
+}
+
+// kindExtraSize returns the size of the kind-specific extension
+// that follows the common Type header. extVar accounts for trailing
+// variable-length arrays (e.g. method lists, struct fields).
+func kindExtraSize(ptrSize int, kind Kind, addr uint64, rodata *Section, common int, bo binary.ByteOrder) (extSize, extVar int) {
+	switch kind {
+	case KindStruct:
+		// StructType layout:
+		//   type StructType struct {
+		//       Type
+		//       PkgPath Name           // size = ptrSize (struct{Bytes *byte})
+		//       Fields  []StructField  // slice header = 3 * ptrSize
+		//   }
+		// Trailing fields array: each StructField is 3 * ptrSize.
+		// We read the slice length from rodata.
+		extSize = ptrSize + 3*ptrSize
+		fieldsLenOff := common + ptrSize + ptrSize // skip Type + PkgPath + Fields.Data
+		if buf := rodata.Slice(addr+uint64(fieldsLenOff), ptrSize); buf != nil {
+			n := int(decodeUint(buf, ptrSize, bo))
+			extVar = n * 3 * ptrSize
+		}
+	case KindInterface:
+		// InterfaceType: pkgPath (Name) + methods slice header.
+		extSize = ptrSize + 3*ptrSize
+		methodsLenOff := common + ptrSize + ptrSize
+		if buf := rodata.Slice(addr+uint64(methodsLenOff), ptrSize); buf != nil {
+			n := int(decodeUint(buf, ptrSize, bo))
+			// Imethod is 2 * uint32 = 8 bytes.
+			extVar = n * 8
+		}
+	case KindFunc:
+		// FuncType: InCount uint16, OutCount uint16, then trailing
+		// in/out type pointer arrays.
+		extSize = 4 // 2 * uint16
+		// Pad to ptr alignment.
+		if ptrSize == 8 {
+			extSize = 8
+		}
+		// Read in/out counts (relative to common).
+		if buf := rodata.Slice(addr+uint64(common), 4); buf != nil {
+			in := int(bo.Uint16(buf[0:2]))
+			out := int(bo.Uint16(buf[2:4])) & 0x7fff
+			extVar = (in + out) * ptrSize
+		}
+	case KindMap:
+		// MapType has key, elem, bucket, hasher, keysize/valuesize,
+		// flags. All but the function pointer are small; total ~4
+		// pointers + 4 bytes.
+		extSize = 4*ptrSize + 8
+	case KindArray:
+		// ArrayType: Elem *Type, Slice *Type, Len uintptr.
+		extSize = 3 * ptrSize
+	case KindSlice:
+		// SliceType: Elem *Type.
+		extSize = ptrSize
+	case KindPointer:
+		// PtrType: Elem *Type.
+		extSize = ptrSize
+	case KindChan:
+		// ChanType: Elem *Type, Dir uintptr.
+		extSize = 2 * ptrSize
+	default:
+		// Other kinds (Bool, Int*, Float*, String, etc.) have no
+		// extension beyond the common header.
+		extSize = 0
+	}
+	return extSize, extVar
+}
+
+// decodeUncommon decodes an UncommonType at the given offset into
+// the rodata block for this type. Returns the number of methods
+// and the bytes occupied by the trailing method array.
+func decodeUncommon(ptrSize int, addr uint64, rodata *Section, off int, bo binary.ByteOrder) (int, int) {
+	// UncommonType layout:
+	//   PkgPath  NameOff  // uint32
+	//   Mcount   uint16
+	//   Xcount   uint16
+	//   Moff     uint32
+	//   _        uint32  // unused
+	buf := rodata.Slice(addr+uint64(off), uncommonSize())
+	if buf == nil {
+		return 0, 0
+	}
+	mcount := int(bo.Uint16(buf[4:6]))
+	// Method layout:
+	//   Name NameOff
+	//   Mtyp TypeOff
+	//   Ifn  TextOff
+	//   Tfn  TextOff
+	// = 4 * uint32 = 16 bytes.
+	return mcount, mcount * 16
+}
+
+// decodeUint reads an unsigned integer of size sz (4 or 8) from buf.
+func decodeUint(buf []byte, sz int, bo binary.ByteOrder) uint64 {
+	switch sz {
+	case 4:
+		return uint64(bo.Uint32(buf))
+	case 8:
+		return bo.Uint64(buf)
+	}
+	return 0
+}


### PR DESCRIPTION
This series of patches incrementally introduces a library, test helper, and command line tool to assist with the development of binary size reduction opportunities and changes with a focus on generics and on arm64 binaries.

A parallel patch series will demonstrate the usage having identified the expensive symbols in eventbus and re-arranging the code to reduce the per-T costs.