### PR TITLE
cmd/tailscale/cli: add `tailscale exit-node suggest --force-probe`

### DIFF
--- a/client/local/local.go
+++ b/client/local/local.go
@@ -1512,6 +1512,26 @@ func (lc *Client) SuggestExitNode(ctx context.Context) (apitype.ExitNodeSuggesti
 	return decodeJSON[apitype.ExitNodeSuggestionResponse](body)
 }
 
+// SuggestExitNodeWithProbe requests an exit node suggestion based on an immediate routecheck probe
+// and returns the exit node's details.
+// If the timeout is 0, any probes will immediately timeout.
+// If the timeout is positive, probes will take that duration before timing out.
+// If the timeout is negative, probes will use the default routecheck timeout.
+func (lc *Client) SuggestExitNodeWithProbe(ctx context.Context, timeout time.Duration) (apitype.ExitNodeSuggestionResponse, error) {
+	if !buildfeatures.HasRouteCheck {
+		return apitype.ExitNodeSuggestionResponse{}, feature.ErrUnavailable
+	}
+	v := url.Values{"probe": {"true"}}
+	if timeout >= 0 {
+		v.Set("timeout", timeout.String())
+	}
+	body, err := lc.send(ctx, "POST", "/localapi/v0/suggest-exit-node?"+v.Encode(), 200, nil)
+	if err != nil {
+		return apitype.ExitNodeSuggestionResponse{}, err
+	}
+	return decodeJSON[apitype.ExitNodeSuggestionResponse](body)
+}
+
 // CheckSOMarkInUse reports whether the socket mark option is in use. This will only
 // be true if tailscale is running on Linux and tailscaled uses SO_MARK.
 func (lc *Client) CheckSOMarkInUse(ctx context.Context) (bool, error) {

--- a/cmd/tailscale/cli/exitnode.go
+++ b/cmd/tailscale/cli/exitnode.go
@@ -15,7 +15,9 @@ import (
 
 	"github.com/kballard/go-shellquote"
 	"github.com/peterbourgon/ff/v3/ffcli"
+	"tailscale.com/client/tailscale/apitype"
 	"tailscale.com/envknob"
+	"tailscale.com/feature/buildfeatures"
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/tailcfg"
 	"tailscale.com/util/slicesx"
@@ -43,6 +45,13 @@ func exitNodeCmd() *ffcli.Command {
 				ShortUsage: "tailscale exit-node suggest",
 				ShortHelp:  "Suggest the best available exit node",
 				Exec:       runExitNodeSuggest,
+				FlagSet: (func() *flag.FlagSet {
+					fs := newFlagSet("suggest")
+					if buildfeatures.HasRouteCheck {
+						fs.BoolVar(&exitNodeArgs.probe, "force-probe", false, hidden+"perform a routecheck probe before suggesting")
+					}
+					return fs
+				})(),
 			}},
 			(func() []*ffcli.Command {
 				if !envknob.UseWIPCode() {
@@ -68,6 +77,7 @@ func exitNodeCmd() *ffcli.Command {
 
 var exitNodeArgs struct {
 	filter string
+	probe  bool
 }
 
 func exitNodeSetUse(wantOn bool) func(ctx context.Context, args []string) error {
@@ -148,7 +158,13 @@ func runExitNodeList(ctx context.Context, args []string) error {
 // runExitNodeSuggest returns a suggested exit node ID to connect to and shows the chosen exit node tailcfg.StableNodeID.
 // If there are no derp based exit nodes to choose from or there is a failure in finding a suggestion, the command will return an error indicating so.
 func runExitNodeSuggest(ctx context.Context, args []string) error {
-	res, err := localClient.SuggestExitNode(ctx)
+	suggestExitNode := localClient.SuggestExitNode
+	if exitNodeArgs.probe {
+		suggestExitNode = func(ctx context.Context) (apitype.ExitNodeSuggestionResponse, error) {
+			return localClient.SuggestExitNodeWithProbe(ctx, -1)
+		}
+	}
+	res, err := suggestExitNode(ctx)
 	if err != nil {
 		return fmt.Errorf("suggest exit node: %w", err)
 	}

--- a/cmd/tailscale/cli/jsonoutput/jsonformat.go
+++ b/cmd/tailscale/cli/jsonoutput/jsonformat.go
@@ -1,0 +1,73 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package jsonoutput
+
+import (
+	"errors"
+	"flag"
+	"io"
+	"strconv"
+	"strings"
+)
+
+var _ flag.Value = new(Format)
+
+type Format string
+
+func (f *Format) String() string {
+	if f == nil {
+		return ""
+	}
+	return string(*f)
+}
+
+func (f *Format) Set(s string) error {
+	*f = Format(s)
+	return nil
+}
+
+func (f *Format) isJSON() bool {
+	return *f == "json" || *f == "json-line"
+}
+
+func (f *Format) Bool() flag.Value {
+	return &formatBool{f}
+}
+
+type formatBool struct {
+	*Format
+}
+
+func (f *formatBool) String() string {
+	return strconv.FormatBool(f.isJSON())
+}
+
+func (f *formatBool) Set(s string) error {
+	// Delegate to a FlagSet to parse this as a BoolVar.
+	var b bool
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	fs.BoolVar(&b, "bool", false, "")
+	fs.SetOutput(io.Discard) // silence
+	if err := fs.Parse([]string{"-bool=" + s}); err != nil {
+		// Unwrap the header added by FlagSet.failf:
+		// `invalid boolean value "invalid" for -bool: `
+		bits := strings.SplitN(err.Error(), ": ", 2)
+		return errors.New(bits[len(bits)-1])
+	}
+
+	if isJSON := f.isJSON(); b == isJSON {
+		return nil // no change
+	}
+
+	if !b {
+		*f.Format = ""
+	} else {
+		*f.Format = "json"
+	}
+	return nil
+}
+
+func (f *formatBool) IsBoolFlag() bool {
+	return true
+}

--- a/cmd/tailscale/cli/routecheck.go
+++ b/cmd/tailscale/cli/routecheck.go
@@ -13,12 +13,13 @@ import (
 	"slices"
 	"strings"
 	"text/tabwriter"
-	"time"
 
 	jsonv2 "github.com/go-json-experiment/json"
 	"github.com/go-json-experiment/json/jsontext"
 	"github.com/peterbourgon/ff/v3/ffcli"
 
+	"tailscale.com/cmd/tailscale/cli/jsonoutput"
+	"tailscale.com/cmd/tailscale/tsroutecheckjsonv0"
 	"tailscale.com/net/routecheck"
 	"tailscale.com/tstime"
 )
@@ -41,16 +42,19 @@ var routecheckCmd = func() *ffcli.Command {
 var routecheckFlagSet = func() *flag.FlagSet {
 	fs := newFlagSet("routecheck")
 	fs.BoolVar(&routecheckArgs.probe, "probe", false, "probe now to generate a new reachability report")
-	fs.StringVar(&routecheckArgs.format, "format", "", `output format: empty (for human-readable), "json" or "json-line"`)
+	fs.Var(&routecheckArgs.format, "format", `output format: empty (for human-readable), "json" or "json-line"`)
+	fs.Var(routecheckArgs.format.Bool(), "json", "output in JSON format")
 	return fs
 }()
 
 var routecheckArgs struct {
 	probe  bool
-	format string
+	format jsonoutput.Format
 }
 
 func runRoutecheck(ctx context.Context, args []string) error {
+	fmt.Printf("format: %q\n", routecheckArgs.format)
+	return nil
 	routeCheck := localClient.RouteCheck
 	if routecheckArgs.probe {
 		routeCheck = localClient.RouteCheckProbe
@@ -67,7 +71,7 @@ func runRoutecheck(ctx context.Context, args []string) error {
 
 func printRouteCheckReport(rp *routecheck.Report) error {
 	var enc *jsontext.Encoder
-	switch routecheckArgs.format {
+	switch routecheckArgs.format.String() {
 	case "":
 	case "json":
 		enc = jsontext.NewEncoder(Stdout, jsontext.WithIndent("\t"))
@@ -90,10 +94,7 @@ func printRouteCheckReport(rp *routecheck.Report) error {
 	}
 
 	if enc != nil {
-		out := struct {
-			Done   time.Time                   `json:"done"`
-			Routes routecheck.RoutablePrefixes `json:"routes"`
-		}{
+		out := tsroutecheckjsonv0.ReportResponse{
 			Done:   rp.Done,
 			Routes: routes,
 		}

--- a/cmd/tailscale/tsroutecheckjsonv0/tsroutecheck.go
+++ b/cmd/tailscale/tsroutecheckjsonv0/tsroutecheck.go
@@ -1,0 +1,28 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !ts_omit_routecheck
+
+// Package tsroutecheckjsonv0 provides types for unmarshalling the JSON output of the
+// "tailscale routecheck --json" command:
+//
+//   - [ReportResponse] will unmarshal the output of "tailscale routecheck --json"
+//
+// # WARNING: unstable
+//
+// Format is "v0" and is subject to change.
+// There is no guarantee of backwards or forwards compatibility.
+package tsroutecheckjsonv0
+
+import (
+	"time"
+
+	"tailscale.com/net/routecheck"
+)
+
+// ReportResponse is the JSON form of [routecheck.Report].
+// Experimental: This output is not yet stable: tailscale/tailscale#17366.
+type ReportResponse struct {
+	Done   time.Time                   `json:"done"`
+	Routes routecheck.RoutablePrefixes `json:"routes"`
+}

--- a/feature/routecheck/localapi.go
+++ b/feature/routecheck/localapi.go
@@ -4,12 +4,15 @@
 package routecheck
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"time"
 
 	jsonv2 "github.com/go-json-experiment/json"
 	jsonv1 "github.com/go-json-experiment/json/v1"
 
+	"tailscale.com/ipn/ipnlocal"
 	"tailscale.com/ipn/localapi"
 	"tailscale.com/net/routecheck"
 	"tailscale.com/util/def"
@@ -18,6 +21,7 @@ import (
 
 func init() {
 	localapi.Register("routecheck", serveRouteCheck)
+	localapi.HookRouteCheckRefresh.Set(routeCheckRefresh)
 }
 
 // ServeRouteCheck handles the API endpoint that serves the routecheck Report.
@@ -60,4 +64,18 @@ func serveRouteCheck(h *localapi.Handler, w http.ResponseWriter, r *http.Request
 
 func clampRouteCheckTimeout(timeout time.Duration) time.Duration {
 	return min(max(0, timeout), 60*time.Second) // clamp to [0s, 60s]
+}
+
+// routeCheckRefresh is a localapi hook for refreshing the [routecheck.Client.Report].
+// If the timeout is 0, all probes will timeout immediately.
+// If the timeout is negative, then all probes will use the [DefaultTimeout].
+func routeCheckRefresh(b *ipnlocal.LocalBackend, ctx context.Context, timeout time.Duration) error {
+	rc := ClientFor(b)
+	if rc == nil {
+		return errors.New("routecheck is not enabled")
+	}
+	if timeout < 0 {
+		timeout = routecheck.DefaultTimeout
+	}
+	return rc.Refresh(ctx, clampRouteCheckTimeout(timeout))
 }

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -7,6 +7,7 @@ package localapi
 import (
 	"bytes"
 	"cmp"
+	"context"
 	"crypto/subtle"
 	"encoding/json"
 	"errors"
@@ -1814,16 +1815,68 @@ func dnsMessageTypeForString(s string) (t dnsmessage.Type, err error) {
 	return 0, errors.New("unknown DNS message type: " + s)
 }
 
+// HookRouteCheckRefresh is the hook to request a refresh of the routecheck Report
+// for this LocalBackend.
+// It is used by serveSuggestExitNode to probe for reachable exit nodes
+// before it makes a suggestion.
+var HookRouteCheckRefresh feature.Hook[func(*ipnlocal.LocalBackend, context.Context, time.Duration) error]
+
 // serveSuggestExitNode serves a POST endpoint for returning a suggested exit node.
+// If the probe query parameter is true,
+// then a new routecheck report will be probed
+// so that the suggested exit node isn’t based on stale reachability data.
+// Combined with probe=true:
+// if the timeout query parameter is 0, any probes will immediately timeout;
+// if the timeout is positive, probes will take that duration before timing out;
+// if the timeout is negative, probes will use the default routecheck timeout.
 func (h *Handler) serveSuggestExitNode(w http.ResponseWriter, r *http.Request) {
 	if !buildfeatures.HasUseExitNode {
 		http.Error(w, feature.ErrUnavailable.Error(), http.StatusNotImplemented)
 		return
 	}
-	if r.Method != httpm.GET {
-		http.Error(w, "only GET allowed", http.StatusMethodNotAllowed)
+
+	switch r.Method {
+	case httpm.GET:
+		// The GET method is inappropriate because it isn’t cacheable.
+		// However, we retain it for backwards compatibility.
+		//
+		// The original implementation used to only allow GET requests,
+		// but since this endpoint powers the `tailscale exit-node suggest` command
+		// whose results can change based on the shape of the network,
+		// it was never a proper GET method in the first place.
+		//
+		// Now that the suggestions are backed by routecheck
+		// and we provide the user the ability to trigger a probe,
+		// this is obviously a POST method because it has side-effects.
+		// However, we don’t want to break existing clients,
+		// so we silently support the old GET method
+		// without the extra query parameters.
+		//
+		// This is also why the default case returns a "want POST" error
+		// and not an "only POST allowed" like the other endpoints.
+		// We still accept GET requests but we don’t want them.
+	case httpm.POST:
+		if !def.Bool(r.FormValue("probe"), false) {
+			break
+		}
+		timeout := def.Duration(r.FormValue("timeout"), -1)
+
+		// Force routecheck to probe for a new report
+		// and use it to suggest an exit node.
+		routecheckRefresh := HookRouteCheckRefresh.GetOrNil()
+		if routecheckRefresh == nil {
+			break
+		}
+		if err := routecheckRefresh(h.b, r.Context(), timeout); err != nil {
+			WriteErrorJSON(w, err)
+			return
+		}
+	default:
+		// Discourage the GET method:
+		http.Error(w, "want POST", http.StatusMethodNotAllowed)
 		return
 	}
+
 	res, err := h.b.SuggestExitNode()
 	if err != nil {
 		WriteErrorJSON(w, err)


### PR DESCRIPTION
Add a new `--force-probe` flag to `tailscale exit-node suggest` that waits for a routecheck.Refresh to finish before suggesting an exit node.

This flag is currently hidden from the help text, but this flag is a hint to the user that exit-node suggestions are based on routecheck reachability reports.

Updates #17366
Updates tailscale/corp#33033

### Tips

- This is a stacked PR within the [sfllaw/routecheck-for-reachability](https://github.com/tailscale/tailscale/tree/sfllaw/routecheck-for-reachability) branch.