### PR TITLE
net/netmon: add TS_INCLUDE_ULA_ENDPOINTS to promote ULA to regular endpoints

### DIFF
--- a/net/netmon/interfaces_test.go
+++ b/net/netmon/interfaces_test.go
@@ -9,6 +9,7 @@ import (
 	"net/netip"
 	"testing"
 
+	"tailscale.com/envknob"
 	"tailscale.com/tstest"
 )
 
@@ -200,6 +201,195 @@ func TestLikelyHomeRouterIP_NoMocks(t *testing.T) {
 	// without any mocks.
 	gw, my, ok := LikelyHomeRouterIP()
 	t.Logf("LikelyHomeRouterIP: gw=%v my=%v ok=%v", gw, my, ok)
+}
+
+// TestLocalAddresses_ULA verifies the handling of IPv6 Unique Local Addresses
+// (ULA, fc00::/7) in LocalAddresses.
+//
+// By default ULA addresses are only used as a fallback when no other addresses
+// are present. Setting TS_INCLUDE_ULA_ENDPOINTS=true promotes them to
+// regular endpoints, enabling direct LAN connectivity without DERP.
+func TestLocalAddresses_ULA(t *testing.T) {
+	ipnet := func(s string) net.Addr {
+		ip, ipnet, err := net.ParseCIDR(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ipnet.IP = ip
+		return ipnet
+	}
+
+	// Interface with both RFC 1918 IPv4 and ULA IPv6, as seen on a
+	// typical LAN with a ULA-only IPv6 setup (no global IPv6 from ISP).
+	mixedIfaces := []Interface{
+		{
+			Interface: &net.Interface{
+				Index: 1,
+				MTU:   1500,
+				Name:  "en0",
+				Flags: net.FlagUp | net.FlagBroadcast | net.FlagMulticast | net.FlagRunning,
+			},
+			AltAddrs: []net.Addr{
+				ipnet("10.0.1.5/16"),
+				ipnet("fd66:6401:8e8a::1/64"),
+			},
+		},
+	}
+
+	t.Run("ULAExcludedByDefaultWhenRFC1918Present", func(t *testing.T) {
+		tstest.Replace(t, &altNetInterfaces, func() ([]Interface, error) {
+			return mixedIfaces, nil
+		})
+		regular, _, err := LocalAddresses()
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []netip.Addr{netip.MustParseAddr("10.0.1.5")}
+		if !addrsEqual(regular, want) {
+			t.Errorf("LocalAddresses() regular = %v; want %v (ULA should be excluded by default)", regular, want)
+		}
+	})
+
+	t.Run("ULAIncludedAsFallbackWhenNoOtherAddresses", func(t *testing.T) {
+		// Simulate an environment with only ULA (e.g. Google Cloud Run).
+		ulaOnlyIfaces := []Interface{
+			{
+				Interface: &net.Interface{
+					Index: 1,
+					MTU:   1500,
+					Name:  "eth0",
+					Flags: net.FlagUp | net.FlagBroadcast | net.FlagMulticast | net.FlagRunning,
+				},
+				AltAddrs: []net.Addr{
+					ipnet("fddf:3978:feb1:d745::1/64"),
+				},
+			},
+		}
+		tstest.Replace(t, &altNetInterfaces, func() ([]Interface, error) {
+			return ulaOnlyIfaces, nil
+		})
+		regular, _, err := LocalAddresses()
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []netip.Addr{netip.MustParseAddr("fddf:3978:feb1:d745::1")}
+		if !addrsEqual(regular, want) {
+			t.Errorf("LocalAddresses() regular = %v; want %v (ULA should be used as fallback)", regular, want)
+		}
+	})
+
+	t.Run("TailscaleULAAlwaysExcluded", func(t *testing.T) {
+		// Tailscale's own ULA range (fd7a:115c:a1e0::/48) must never be
+		// reported as a local endpoint — neither by default nor with the
+		// knob enabled.
+		tsIfaces := []Interface{
+			{
+				Interface: &net.Interface{
+					Index: 1,
+					MTU:   1500,
+					Name:  "en0",
+					Flags: net.FlagUp | net.FlagBroadcast | net.FlagMulticast | net.FlagRunning,
+				},
+				AltAddrs: []net.Addr{
+					ipnet("10.0.1.5/16"),
+					ipnet("fd7a:115c:a1e0::1/128"), // Tailscale ULA — must be excluded
+				},
+			},
+		}
+		want := []netip.Addr{netip.MustParseAddr("10.0.1.5")}
+
+		for _, enabled := range []bool{false, true} {
+			val := ""
+			if enabled {
+				val = "true"
+			}
+			envknob.Setenv("TS_INCLUDE_ULA_ENDPOINTS", val)
+			t.Cleanup(func() { envknob.Setenv("TS_INCLUDE_ULA_ENDPOINTS", "") })
+
+			tstest.Replace(t, &altNetInterfaces, func() ([]Interface, error) {
+				return tsIfaces, nil
+			})
+			regular, _, err := LocalAddresses()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !addrsEqual(regular, want) {
+				t.Errorf("TS_INCLUDE_ULA_ENDPOINTS=%v: LocalAddresses() = %v; want %v (Tailscale ULA should always be excluded)", enabled, regular, want)
+			}
+		}
+	})
+
+	t.Run("TS_INCLUDE_ULA_ENDPOINTSPromotesULAToRegular", func(t *testing.T) {
+		envknob.Setenv("TS_INCLUDE_ULA_ENDPOINTS", "true")
+		t.Cleanup(func() { envknob.Setenv("TS_INCLUDE_ULA_ENDPOINTS", "") })
+
+		tstest.Replace(t, &altNetInterfaces, func() ([]Interface, error) {
+			return mixedIfaces, nil
+		})
+		regular, _, err := LocalAddresses()
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []netip.Addr{
+			netip.MustParseAddr("10.0.1.5"),
+			netip.MustParseAddr("fd66:6401:8e8a::1"),
+		}
+		if !addrsEqual(regular, want) {
+			t.Errorf("LocalAddresses() with TS_INCLUDE_ULA_ENDPOINTS regular = %v; want %v", regular, want)
+		}
+	})
+
+	t.Run("TS_INCLUDE_ULA_ENDPOINTSPreservesIPv4LinkLocalFallback", func(t *testing.T) {
+		envknob.Setenv("TS_INCLUDE_ULA_ENDPOINTS", "true")
+		t.Cleanup(func() { envknob.Setenv("TS_INCLUDE_ULA_ENDPOINTS", "") })
+
+		ulaAndLinkLocalIfaces := []Interface{
+			{
+				Interface: &net.Interface{
+					Index: 1,
+					MTU:   1500,
+					Name:  "eth0",
+					Flags: net.FlagUp | net.FlagBroadcast | net.FlagMulticast | net.FlagRunning,
+				},
+				AltAddrs: []net.Addr{
+					ipnet("169.254.10.20/16"),
+					ipnet("fddf:3978:feb1:d745::1/64"),
+				},
+			},
+		}
+		tstest.Replace(t, &altNetInterfaces, func() ([]Interface, error) {
+			return ulaAndLinkLocalIfaces, nil
+		})
+		regular, _, err := LocalAddresses()
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []netip.Addr{
+			netip.MustParseAddr("169.254.10.20"),
+			netip.MustParseAddr("fddf:3978:feb1:d745::1"),
+		}
+		if !addrsEqual(regular, want) {
+			t.Errorf("LocalAddresses() with TS_INCLUDE_ULA_ENDPOINTS regular = %v; want %v (link-local fallback should be preserved)", regular, want)
+		}
+	})
+}
+
+// addrsEqual reports whether a and b contain the same set of addresses,
+// regardless of order.
+func addrsEqual(a, b []netip.Addr) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	set := make(map[netip.Addr]bool, len(a))
+	for _, ip := range a {
+		set[ip] = true
+	}
+	for _, ip := range b {
+		if !set[ip] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestIsUsableV6(t *testing.T) {

--- a/net/netmon/state.go
+++ b/net/netmon/state.go
@@ -28,6 +28,14 @@ import (
 // same interface and subnet.
 var forceAllIPv6Endpoints = envknob.RegisterBool("TS_DEBUG_FORCE_ALL_IPV6_ENDPOINTS")
 
+// includeULAEndpoints, when true, causes [LocalAddresses] to include IPv6
+// Unique Local Addresses (ULA, fc00::/7) as regular endpoints alongside RFC
+// 1918 IPv4 addresses. This enables direct LAN connections between peers on
+// the same network without requiring a DERP relay when no global IPv6 is
+// available. By default ULA addresses are only used as a fallback when no
+// other addresses are present (e.g. Google Cloud Run).
+var includeULAEndpoints = envknob.RegisterBool("TS_INCLUDE_ULA_ENDPOINTS")
+
 // LoginEndpointForProxyDetermination is the URL used for testing
 // which HTTP proxy the system should use.
 var LoginEndpointForProxyDetermination = "https://controlplane.tailscale.com/"
@@ -54,8 +62,13 @@ func isProblematicInterface(nif *net.Interface) bool {
 
 // LocalAddresses returns the machine's IP addresses, separated by
 // whether they're loopback addresses. If there are no regular addresses
-// it will return any IPv4 linklocal or IPv6 unique local addresses because we
+// it will return any IPv4 link-local or IPv6 unique local addresses because we
 // know of environments where these are used with NAT to provide connectivity.
+//
+// IPv6 Unique Local Addresses (ULA, fc00::/7) can be promoted to regular
+// endpoints via [includeULAEndpoints] (TS_INCLUDE_ULA_ENDPOINTS), which
+// enables direct LAN connectivity between peers on the same network without
+// requiring a DERP relay when no global IPv6 is available.
 func LocalAddresses() (regular, loopback []netip.Addr, err error) {
 	// TODO(crawshaw): don't serve interface addresses that we are routing
 	ifaces, err := netInterfaces()
@@ -63,6 +76,7 @@ func LocalAddresses() (regular, loopback []netip.Addr, err error) {
 		return nil, nil, err
 	}
 	var regular4, regular6, linklocal4, ula6 []netip.Addr
+	var haveUsableNonFallback bool
 	for _, iface := range ifaces {
 		stdIf := iface.Interface
 		if !isUp(stdIf) || isProblematicInterface(stdIf) {
@@ -108,12 +122,26 @@ func LocalAddresses() (regular, loopback []netip.Addr, err error) {
 					// address. We don't want to report all of those
 					// IPv6 LL to Control.
 				} else if ip.Is6() && ip.IsPrivate() {
-					// Google Cloud Run uses NAT with IPv6 Unique
-					// Local Addresses to provide IPv6 connectivity.
-					ula6 = append(ula6, ip)
+					// IPv6 Unique Local Addresses (ULA, fc00::/7).
+					// By default these are only used as a fallback when
+					// no other addresses are available (see below), as in
+					// Google Cloud Run's NAT-based IPv6 connectivity.
+					// Set TS_INCLUDE_ULA_ENDPOINTS=true to treat them
+					// like RFC 1918 IPv4 and include them as regular
+					// endpoints, enabling direct LAN connectivity.
+					curMask, _ := netip.AddrFromSlice(v.IP.Mask(v.Mask))
+					if includeULAEndpoints() {
+						if forceAllIPv6Endpoints() || subnets[curMask] < 2 {
+							regular6 = append(regular6, ip)
+						}
+						mak.Set(&subnets, curMask, subnets[curMask]+1)
+					} else {
+						ula6 = append(ula6, ip)
+					}
 				} else {
 					if ip.Is4() {
 						regular4 = append(regular4, ip)
+						haveUsableNonFallback = true
 					} else {
 						curMask, _ := netip.AddrFromSlice(v.IP.Mask(v.Mask))
 						// Limit the number of addresses reported per subnet for
@@ -124,18 +152,19 @@ func LocalAddresses() (regular, loopback []netip.Addr, err error) {
 							regular6 = append(regular6, ip)
 						}
 						mak.Set(&subnets, curMask, subnets[curMask]+1)
+						haveUsableNonFallback = true
 					}
 				}
 			}
 		}
 	}
-	if len(regular4) == 0 && len(regular6) == 0 {
+	if !haveUsableNonFallback {
 		// if we have no usable IP addresses then be willing to accept
 		// addresses we otherwise wouldn't, like:
 		//   + 169.254.x.x (AWS Lambda and Azure App Services use NAT with these)
 		//   + IPv6 ULA (Google Cloud Run uses these with address translation)
-		regular4 = linklocal4
-		regular6 = ula6
+		regular4 = append(regular4, linklocal4...)
+		regular6 = append(regular6, ula6...)
 	}
 	regular = append(regular4, regular6...)
 	sortIPs(regular)


### PR DESCRIPTION
Implements an opt-in version of #18581
This PR adds an opt-in knob to advertise IPv6 ULA addresses as regular local endpoints.

**Use case:** another VPN can install an overlapping IPv4 subnet that conflicts with the local LAN, making the local IPv4 path unusable even though peers are on the same network. In that setup, local IPv6 ULA connectivity still works, but Tailscale does not currently advertise those addresses as regular endpoints and instead prefers a broken IPv4 LAN path. With TS_INCLUDE_ULA_ENDPOINTS=true, peers on the same LAN can connect directly over IPv6 ULA when local IPv4 is not usable.

**Disclaimer: this PR contains AI generated code reviewed by me, but there still can be issues since Go is not my main language.**

Fun fact: while testing this, I stopped the stock tailscaled on one machine and ran a separate build with this change only on that node. It did not immediately establish a direct connection, but it did advertise its ULA endpoints. After switching back to the stock daemon, magicsock appeared to retain enough state from that bootstrap that the peers then came up on a direct ULA path even without the patched daemon still running.