### PR TITLE
scripts/installer.sh: add openSUSE Slowroll as a Tumbleweed derivative

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -266,7 +266,7 @@ main() {
 				VERSION="leap/$VERSION_ID"
 				PACKAGETYPE="zypper"
 				;;
-			opensuse-tumbleweed)
+			opensuse-tumbleweed|opensuse-slowroll)
 				OS="opensuse"
 				VERSION="tumbleweed"
 				PACKAGETYPE="zypper"


### PR DESCRIPTION
https://en.opensuse.org/Portal:Slowroll
> openSUSE Slowroll uses a modified version of [openSUSE Tumbleweed](https://en.opensuse.org/Portal:Tumbleweed) to give a little more stability to users who don‘t want the bleeding edge but also don’t want to wait 12 months for a minor release or 3 to 4 years for a major release like [openSUSE Leap](https://en.opensuse.org/Portal:Leap). With big updates once per month, and continuous bug fixes and security fixes as they come in, Slowroll finds a perfect balance for those who simply don’t want to be forced to choose!

Fixes: #14927