### PR TITLE
cmd/testwrapper: print unit for package duration

### DIFF
--- a/cmd/testwrapper/testwrapper.go
+++ b/cmd/testwrapper/testwrapper.go
@@ -267,7 +267,7 @@ func main() {
 		if cached {
 			lastCol = "(cached)"
 		} else {
-			lastCol = fmt.Sprintf("%.3f", testDur.Seconds())
+			lastCol = fmt.Sprintf("%.3fs", testDur.Seconds())
 		}
 		fmt.Printf("%s\t%s\t%v\n", outcome, pkg, lastCol)
 	}


### PR DESCRIPTION
Include the unit (s) when printing the time taken to test each package.

Updates #cleanup