### PR TITLE
ipn/ipnlocal: add per-service Serve metrics

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -459,6 +459,18 @@ type metrics struct {
 	// approvedRoutes is a metric that reports the number of network routes served by the local node and approved
 	// by the control server.
 	approvedRoutes *usermetric.Gauge
+
+	// serveBytesInbound counts bytes received from peers on Serve connections,
+	// labeled by Tailscale Service name.
+	serveBytesInbound *usermetric.MultiLabelMap[serveLabels]
+
+	// serveBytesOutbound counts bytes sent to peers on Serve connections,
+	// labeled by Tailscale Service name.
+	serveBytesOutbound *usermetric.MultiLabelMap[serveLabels]
+}
+
+type serveLabels struct {
+	Service string `prom:"service"`
 }
 
 // clientGen is a func that creates a control plane client.
@@ -510,6 +522,16 @@ func NewLocalBackend(logf logger.Logf, logID logid.PublicID, sys *tsd.System, lo
 			"tailscaled_advertised_routes", "Number of advertised network routes (e.g. by a subnet router)"),
 		approvedRoutes: sys.UserMetricsRegistry().NewGauge(
 			"tailscaled_approved_routes", "Number of approved network routes (e.g. by a subnet router)"),
+		serveBytesInbound: usermetric.NewMultiLabelMapWithRegistry[serveLabels](
+			sys.UserMetricsRegistry(),
+			"tailscaled_serve_inbound_bytes_total",
+			"counter",
+			"Bytes received from peers on Serve connections, labeled by Tailscale Service name."),
+		serveBytesOutbound: usermetric.NewMultiLabelMapWithRegistry[serveLabels](
+			sys.UserMetricsRegistry(),
+			"tailscaled_serve_outbound_bytes_total",
+			"counter",
+			"Bytes sent to peers on Serve connections, labeled by Tailscale Service name."),
 	}
 
 	b := &LocalBackend{

--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -48,6 +48,7 @@ import (
 	"tailscale.com/util/ctxkey"
 	"tailscale.com/util/mak"
 	"tailscale.com/util/slicesx"
+	"tailscale.com/util/usermetric"
 	"tailscale.com/version"
 )
 
@@ -393,7 +394,27 @@ func (b *LocalBackend) setServeConfigLocked(config *ipn.ServeConfig, etag string
 		}
 	}
 
+	b.evictRemovedServiceMetrics(prevConfig)
+
 	return nil
+}
+
+func (b *LocalBackend) evictRemovedServiceMetrics(prev ipn.ServeConfigView) {
+	if !prev.Valid() || b.metrics.serveBytesInbound == nil {
+		return
+	}
+	stillPresent := func(tailcfg.ServiceName) bool { return false }
+	if b.serveConfig.Valid() {
+		stillPresent = b.serveConfig.Services().Contains
+	}
+	for svc := range prev.Services().All() {
+		if stillPresent(svc) {
+			continue
+		}
+		key := serveLabels{Service: svc.WithoutPrefix()}
+		b.metrics.serveBytesInbound.Delete(key)
+		b.metrics.serveBytesOutbound.Delete(key)
+	}
 }
 
 // ServeConfig provides a view of the current serve mappings.
@@ -534,6 +555,48 @@ func (b *LocalBackend) vipServicesFromPrefsLocked(prefs ipn.PrefsView) []*tailcf
 	return servicesList
 }
 
+type serviceMeteredConn struct {
+	net.Conn
+	inbound, outbound *usermetric.MultiLabelMap[serveLabels]
+	key               serveLabels
+}
+
+func (c *serviceMeteredConn) Read(p []byte) (int, error) {
+	n, err := c.Conn.Read(p)
+	if n > 0 {
+		c.inbound.Add(c.key, int64(n))
+	}
+	return n, err
+}
+
+func (c *serviceMeteredConn) Write(p []byte) (int, error) {
+	n, err := c.Conn.Write(p)
+	if n > 0 {
+		c.outbound.Add(c.key, int64(n))
+	}
+	return n, err
+}
+
+// CloseWrite preserves TCP half-close so *tls.Conn's graceful shutdown works.
+func (c *serviceMeteredConn) CloseWrite() error {
+	if cw, ok := c.Conn.(interface{ CloseWrite() error }); ok {
+		return cw.CloseWrite()
+	}
+	return c.Conn.Close()
+}
+
+func (b *LocalBackend) meteredConnForService(c net.Conn, svc tailcfg.ServiceName) net.Conn {
+	if b.metrics.serveBytesInbound == nil || b.metrics.serveBytesOutbound == nil {
+		return c
+	}
+	return &serviceMeteredConn{
+		Conn:     c,
+		inbound:  b.metrics.serveBytesInbound,
+		outbound: b.metrics.serveBytesOutbound,
+		key:      serveLabels{Service: svc.WithoutPrefix()},
+	}
+}
+
 // tcpHandlerForVIPService returns a handler for a TCP connection to a VIP service
 // that is being served via the ipn.ServeConfig. It returns nil if the destination
 // address is not a VIP service or if the VIP service does not have a TCP handler set.
@@ -579,11 +642,13 @@ func (b *LocalBackend) tcpHandlerForVIPService(dstAddr, srcAddr netip.AddrPort) 
 				GetCertificate: b.getTLSServeCertForPort(dport, dstSvc),
 			}
 			return func(c net.Conn) error {
+				c = b.meteredConnForService(c, dstSvc)
 				return hs.ServeTLS(netutil.NewOneConnListener(c, nil), "", "")
 			}
 		}
 
 		return func(c net.Conn) error {
+			c = b.meteredConnForService(c, dstSvc)
 			return hs.Serve(netutil.NewOneConnListener(c, nil))
 		}
 	}
@@ -591,6 +656,7 @@ func (b *LocalBackend) tcpHandlerForVIPService(dstAddr, srcAddr netip.AddrPort) 
 	if backDst := tcph.TCPForward(); backDst != "" {
 		return func(conn net.Conn) error {
 			defer conn.Close()
+			conn = b.meteredConnForService(conn, dstSvc)
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			backConn, err := b.dialer.SystemDial(ctx, "tcp", backDst)
 			cancel()

--- a/ipn/ipnlocal/serve_test.go
+++ b/ipn/ipnlocal/serve_test.go
@@ -12,9 +12,11 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"errors"
+	"expvar"
 	"fmt"
 	"io"
 	"mime"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/netip"
@@ -40,6 +42,7 @@ import (
 	"tailscale.com/util/mak"
 	"tailscale.com/util/must"
 	"tailscale.com/util/syspolicy/policyclient"
+	"tailscale.com/util/usermetric"
 	"tailscale.com/wgengine"
 	"tailscale.com/wgengine/filter"
 )
@@ -1762,5 +1765,126 @@ func TestValidateServeConfigUpdate(t *testing.T) {
 				t.Error("expected error, got nil;", tt.description)
 			}
 		})
+	}
+}
+
+func counterValue(m *usermetric.MultiLabelMap[serveLabels], svc string) int64 {
+	v, _ := m.Get(serveLabels{Service: svc}).(*expvar.Int)
+	if v == nil {
+		return -1
+	}
+	return v.Value()
+}
+
+func TestServiceMeteredConn(t *testing.T) {
+	b := newTestBackend(t)
+
+	clientSide, serverSide := net.Pipe()
+	defer clientSide.Close()
+	defer serverSide.Close()
+
+	wrapped := b.meteredConnForService(serverSide, tailcfg.ServiceName("svc:foo"))
+
+	const inboundPayload = "hello from client"
+	writeDone := make(chan struct{})
+	go func() {
+		clientSide.Write([]byte(inboundPayload))
+		close(writeDone)
+	}()
+	buf := make([]byte, len(inboundPayload))
+	if _, err := io.ReadFull(wrapped, buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	<-writeDone
+	if got := counterValue(b.metrics.serveBytesInbound, "foo"); got != int64(len(inboundPayload)) {
+		t.Errorf("inbound = %d; want %d", got, len(inboundPayload))
+	}
+
+	const outboundPayload = "hello from server"
+	writeDone = make(chan struct{})
+	go func() {
+		wrapped.Write([]byte(outboundPayload))
+		close(writeDone)
+	}()
+	buf = make([]byte, len(outboundPayload))
+	if _, err := io.ReadFull(clientSide, buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	<-writeDone
+	if got := counterValue(b.metrics.serveBytesOutbound, "foo"); got != int64(len(outboundPayload)) {
+		t.Errorf("outbound = %d; want %d", got, len(outboundPayload))
+	}
+}
+
+func TestServiceMeteredConnLabelStripsPrefix(t *testing.T) {
+	b := newTestBackend(t)
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+	wrapped := b.meteredConnForService(c1, tailcfg.ServiceName("svc:my-app"))
+	go c2.Write([]byte("x"))
+	io.ReadFull(wrapped, make([]byte, 1))
+	if v := counterValue(b.metrics.serveBytesInbound, "my-app"); v != 1 {
+		t.Errorf("inbound for service=\"my-app\" = %d; want 1", v)
+	}
+	if v := counterValue(b.metrics.serveBytesInbound, "svc:my-app"); v != -1 {
+		t.Errorf("counter unexpectedly present under unstripped name; got %d", v)
+	}
+}
+
+func TestEvictRemovedServiceMetrics(t *testing.T) {
+	b := newTestBackend(t)
+	svcIPMap := tailcfg.ServiceIPMappings{
+		"svc:foo": []netip.Addr{netip.MustParseAddr("100.101.101.101")},
+		"svc:bar": []netip.Addr{netip.MustParseAddr("100.99.99.99")},
+	}
+	svcIPMapJSON, err := json.Marshal(svcIPMap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.currentNode().SetNetMap(&netmap.NetworkMap{
+		SelfNode: (&tailcfg.Node{
+			Name: "example.ts.net",
+			CapMap: tailcfg.NodeCapMap{
+				tailcfg.NodeAttrServiceHost: []tailcfg.RawMessage{tailcfg.RawMessage(svcIPMapJSON)},
+			},
+		}).View(),
+	})
+
+	twoServices := &ipn.ServeConfig{
+		Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
+			"svc:foo": {TCP: map[uint16]*ipn.TCPPortHandler{80: {HTTP: true}}},
+			"svc:bar": {TCP: map[uint16]*ipn.TCPPortHandler{80: {HTTP: true}}},
+		},
+	}
+	if err := b.SetServeConfig(twoServices, ""); err != nil {
+		t.Fatalf("SetServeConfig: %v", err)
+	}
+
+	b.metrics.serveBytesInbound.Add(serveLabels{Service: "foo"}, 100)
+	b.metrics.serveBytesOutbound.Add(serveLabels{Service: "foo"}, 50)
+	b.metrics.serveBytesInbound.Add(serveLabels{Service: "bar"}, 200)
+	b.metrics.serveBytesOutbound.Add(serveLabels{Service: "bar"}, 75)
+
+	onlyFoo := &ipn.ServeConfig{
+		Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
+			"svc:foo": {TCP: map[uint16]*ipn.TCPPortHandler{80: {HTTP: true}}},
+		},
+	}
+	if err := b.SetServeConfig(onlyFoo, ""); err != nil {
+		t.Fatalf("SetServeConfig: %v", err)
+	}
+
+	if got := counterValue(b.metrics.serveBytesInbound, "foo"); got != 100 {
+		t.Errorf("svc:foo inbound after eviction = %d; want 100 (preserved)", got)
+	}
+	if got := counterValue(b.metrics.serveBytesOutbound, "foo"); got != 50 {
+		t.Errorf("svc:foo outbound after eviction = %d; want 50 (preserved)", got)
+	}
+	if got := counterValue(b.metrics.serveBytesInbound, "bar"); got != -1 {
+		t.Errorf("svc:bar inbound after eviction = %d; want absent", got)
+	}
+	if got := counterValue(b.metrics.serveBytesOutbound, "bar"); got != -1 {
+		t.Errorf("svc:bar outbound after eviction = %d; want absent", got)
 	}
 }


### PR DESCRIPTION
  Resolves #19572.

  Adds two new metrics: `tailscaled_serve_{in,out}bound_bytes_total{service=...}`.
  The Tailscale Service name is already in scope at TCP-accept time, so the
  counter wraps the peer-facing `net.Conn` once inside `tcpHandlerForVIPService`
  and covers HTTP, HTTPS, and TCP-forward uniformly.
