### PR TITLE
.github: install ca-certificates on Kali to fix installer tests

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -37,8 +37,6 @@ jobs:
           - "elementary/docker:stable"
           - "elementary/docker:unstable"
           - "parrotsec/core:latest"
-          - "kalilinux/kali-rolling"
-          - "kalilinux/kali-dev"
           - "oraclelinux:9"
           - "oraclelinux:8"
           - "fedora:latest"
@@ -61,6 +59,9 @@ jobs:
           - { image: "debian:stable-slim", deps: "curl" }
           - { image: "ubuntu:24.04", deps: "curl" }
           - { image: "fedora:latest", deps: "curl" }
+          # Kali doesn't have ca-certificates installed by default anymore
+          - { image: "kalilinux/kali-dev", "deps": "curl ca-certificates"}
+          - { image: "kalilinux/kali-rolling", "deps": "curl ca-certificates"}
           # Test TAILSCALE_VERSION pinning on a subset of distros.
           # Skip Alpine as community repos don't reliably keep old versions.
           - { image: "debian:stable-slim", deps: "curl", version: "1.80.0" }


### PR DESCRIPTION
Updates #cleanup