### PR TITLE
ipn/ipnlocal: wrap ACME errors with more context

### DIFF
--- a/ipn/ipnlocal/cert.go
+++ b/ipn/ipnlocal/cert.go
@@ -605,14 +605,14 @@ var getCertPEM = func(ctx context.Context, b *LocalBackend, cs certStore, logf l
 	}
 	order, err := ac.AuthorizeOrder(ctx, authzIDs, opts...)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("acme.AuthorizeOrder: %w", err)
 	}
 	traceACME(order)
 
 	for _, aurl := range order.AuthzURLs {
 		az, err := ac.GetAuthorization(ctx, aurl)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("acme.GetAuthorization: %w", err)
 		}
 		traceACME(az)
 		for _, ch := range az.Challenges {
@@ -645,7 +645,7 @@ var getCertPEM = func(ctx context.Context, b *LocalBackend, cs certStore, logf l
 
 				chal, err := ac.Accept(ctx, ch)
 				if err != nil {
-					return nil, fmt.Errorf("Accept: %v", err)
+					return nil, fmt.Errorf("acme.Accept: %w", err)
 				}
 				traceACME(chal)
 				break
@@ -657,14 +657,14 @@ var getCertPEM = func(ctx context.Context, b *LocalBackend, cs certStore, logf l
 	order, err = ac.WaitOrder(ctx, orderURI)
 	if err != nil {
 		if ctx.Err() != nil {
-			return nil, ctx.Err()
+			return nil, fmt.Errorf("timed out waiting for ACME certificate order from LetsEncrypt: %w", ctx.Err())
 		}
 		if oe, ok := err.(*acme.OrderError); ok {
 			logf("acme: WaitOrder: OrderError status %q", oe.Status)
 		} else {
 			logf("acme: WaitOrder error: %v", err)
 		}
-		return nil, err
+		return nil, fmt.Errorf("acme.WaitOrder: %w", err)
 	}
 	traceACME(order)
 
@@ -686,7 +686,7 @@ var getCertPEM = func(ctx context.Context, b *LocalBackend, cs certStore, logf l
 	traceACME(csr)
 	der, _, err := ac.CreateOrderCert(ctx, order.FinalizeURL, csr, true)
 	if err != nil {
-		return nil, fmt.Errorf("CreateOrder: %v", err)
+		return nil, fmt.Errorf("acme.CreateOrderCert: %w", err)
 	}
 	logf("got cert")
 


### PR DESCRIPTION
When `tailscale cert` times out waiting for LetsEncrypt, the error that comes back is a bare `context.DeadlineExceeded`. That's not super helpful if you're trying to figure out what went wrong, because it doesn't tell you it was the cert order that timed out specifically.

This wraps the `WaitOrder` timeout with a message that actually says what happened. Also fixed a few other ACME call sites that were returning bare errors (AuthorizeOrder, GetAuthorization) and switched Accept/CreateOrderCert from `%v` to `%w` so the errors stay unwrappable by callers.

Fixes #14677, related to #10395

**Testing:** Existing cert tests still pass (`go test ./ipn/ipnlocal/... -run Cert`). The timeout path is hard to unit test without a fake ACME server, but the change is straightforward enough that I think it's fine to trust reading the code here.