### PR TITLE
version/distro: require /etc/synoinfo.conf for Synology detection

### DIFF
--- a/version/distro/distro.go
+++ b/version/distro/distro.go
@@ -73,7 +73,7 @@ func haveDir(file string) bool {
 
 func linuxDistro() Distro {
 	switch {
-	case haveDir("/usr/syno"):
+	case haveDir("/usr/syno") && have("/etc/synoinfo.conf"):
 		return Synology
 	case have("/usr/local/bin/freenas-debug"):
 		// TrueNAS Scale runs on debian


### PR DESCRIPTION
The Synology check was only looking for the `/usr/syno` directory, but that can exist on regular Debian systems too (some packages create it), so Tailscale ends up misidentifying Debian as Synology.

`/etc/synoinfo.conf` is a Synology-specific file that's always present on DSM and never on standard Linux distros, so requiring both makes the check reliable.

Fixes #14901