### PR TITLE
cmd/tailscale/cli: don't emit broken hint for invalid legacy tcp serve args

### DIFF
--- a/cmd/tailscale/cli/serve_v2.go
+++ b/cmd/tailscale/cli/serve_v2.go
@@ -1388,6 +1388,13 @@ func isLegacyInvocation(subcmd serveMode, args []string) (string, bool) {
 	case "http":
 		cmd = append(cmd, fmt.Sprintf("--http %s", srcPortStr))
 	case "tcp", "tls-terminated-tcp":
+		if _, err := strconv.ParseUint(srcPortStr, 10, 16); err != nil {
+			// srcPortStr isn't a valid port number (e.g. user ran
+			// "tailscale serve tcp://localhost:3000" instead of
+			// "tailscale serve tcp:3000 tcp://localhost:3000").
+			// Don't emit a broken hint; let the new code reject it.
+			return "", false
+		}
 		cmd = append(cmd, fmt.Sprintf("--%s %s", srcType, srcPortStr))
 	}
 

--- a/cmd/tailscale/cli/serve_v2_test.go
+++ b/cmd/tailscale/cli/serve_v2_test.go
@@ -1755,6 +1755,13 @@ func TestIsLegacyInvocation(t *testing.T) {
 			args:     []string{"localhost:3000"},
 			expected: false,
 		},
+		{
+			// "tailscale serve tcp://localhost:3000 off" was a common mistake;
+			// the port arg is not a valid port so we should not emit a hint.
+			subcmd:   serve,
+			args:     []string{"tcp://localhost:3000", "off"},
+			expected: false,
+		},
 	}
 
 	for idx, tt := range tests {


### PR DESCRIPTION
When a user ran `tailscale serve tcp://localhost:3000 off`, `isLegacyInvocation` was matching it as a legacy tcp invocation because `strings.Cut` on `tcp://localhost:3000` splits at `:`, giving `srcPortStr = "//localhost:3000"`. It then generated:

```
tailscale serve --bg --tcp //localhost:3000 off
```

Which is invalid because `--tcp` expects a port number, not a URL fragment.

The fix validates that `srcPortStr` is an actual port number for `tcp`/`tls-terminated-tcp` before generating the hint. If it's not, we return `false` and let the new code path handle and reject the args instead of directing users to a command that also fails.

Added a test case covering the original bug.

Fixes #14863