### PR TITLE
cmd/k8s-operator: sort StaticEndpoints slice for deterministic output

### DIFF
--- a/cmd/k8s-operator/proxygroup.go
+++ b/cmd/k8s-operator/proxygroup.go
@@ -1100,6 +1100,14 @@ func (r *ProxyGroupReconciler) findStaticEndpoints(ctx context.Context, existing
 		}
 	}
 
+	// Sort for a deterministic result regardless of node list order. Without
+	// this, the slice can oscillate between reconciles when both addresses are
+	// already known, causing spurious config Secret writes and an infinite
+	// reconcile loop.
+	slices.SortFunc(endpoints, func(a, b netip.AddrPort) int {
+		return a.Compare(b)
+	})
+
 	if len(endpoints) == 0 {
 		return nil, &FindStaticEndpointErr{msg: fmt.Sprintf("failed to find any `status.addresses` of type %q on nodes using configured Selectors on `spec.staticEndpoints.nodePort.selectors` for ProxyClass %q", corev1.NodeExternalIP, proxyClass.Name)}
 	}

--- a/cmd/k8s-operator/proxygroup_test.go
+++ b/cmd/k8s-operator/proxygroup_test.go
@@ -2184,3 +2184,71 @@ func testCasesForLEStagingTests() []leStagingTestCase {
 		},
 	}
 }
+
+func TestFindStaticEndpoints_OrderStability(t *testing.T) {
+	const port = uint16(30001)
+
+	ip1 := netip.MustParseAddr("10.0.0.1")
+	ip2 := netip.MustParseAddr("10.0.0.2")
+	ap1 := netip.AddrPortFrom(ip1, port)
+	ap2 := netip.AddrPortFrom(ip2, port)
+
+	// "anode" sorts before "znode" alphabetically, so the fake client returns
+	// [anode, znode]. ip2 is on anode and ip1 is on znode, so naive node-order
+	// iteration produces [ip2, ip1]. The fix must sort and return [ip1, ip2].
+	nodes := []corev1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "anode", Labels: map[string]string{"foo": "bar"}},
+			Status:     corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: ip2.String()}}},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "znode", Labels: map[string]string{"foo": "bar"}},
+			Status:     corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: ip1.String()}}},
+		},
+	}
+
+	objs := make([]client.Object, len(nodes))
+	for i := range nodes {
+		objs[i] = &nodes[i]
+	}
+	fc := fake.NewClientBuilder().WithScheme(tsapi.GlobalScheme).WithObjects(objs...).Build()
+
+	zl, _ := zap.NewDevelopment()
+	r := &ProxyGroupReconciler{Client: fc}
+
+	pc := &tsapi.ProxyClass{
+		Spec: tsapi.ProxyClassSpec{
+			StaticEndpoints: &tsapi.StaticEndpointsConfig{
+				NodePort: &tsapi.NodePortConfig{
+					Ports:    []tsapi.PortRange{{Port: port}},
+					Selector: map[string]string{"foo": "bar"},
+				},
+			},
+		},
+	}
+
+	// Call twice with the same nodes — both calls must return the same sorted
+	// slice, regardless of which currAddrs were stored after the first call.
+	for range 2 {
+		// On the second iteration, simulate a stored config with the
+		// "wrong" order [ip2, ip1] to confirm sorting overrides it.
+		existingCfg := ipn.ConfigVAlpha{StaticEndpoints: []netip.AddrPort{ap2, ap1}}
+		cfgB, err := json.Marshal(existingCfg)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		existingSecret := &corev1.Secret{
+			Data: map[string][]byte{tsoperator.TailscaledConfigFileName(106): cfgB},
+		}
+
+		got, err := r.findStaticEndpoints(context.Background(), existingSecret, pc, port, zl.Sugar())
+		if err != nil {
+			t.Fatalf("findStaticEndpoints: %v", err)
+		}
+
+		want := []netip.AddrPort{ap1, ap2}
+		if !slices.Equal(got, want) {
+			t.Errorf("got %v, want %v — result must be sorted regardless of node list or stored order", got, want)
+		}
+	}
+}


### PR DESCRIPTION
`findStaticEndpoints` builds its result by iterating nodes.Items, which has no guaranteed ordering across Kubernetes API calls. When both addresses are already known (the steady state), the two-element slice can be returned in a different order on successive reconciles.

The `DeepEqual` guard before writing the config Secret is order-sensitive, so each flip is treated as a change: the Secret is written, that write fires a watch event, the watch event re-enqueues the ProxyGroup, and the cycle repeats indefinitely at roughly one reconcile per second per ProxyGroup.

Every 60-90s, kubelet picks up the changed Secret and tailscaled performs a hot config reload, transiently disrupting active connections routed through the proxy.

Fix by sorting the endpoints slice before returning it, producing a stable result regardless of node list order.

Fixes #19700

RELNOTE: fix ProxyGroup reconcile loop caused by non-deterministic StaticEndpoints ordering, which disrupted proxy connections every ~60s