### PR TITLE
net/dns: route default resolvers through quad-100 on iOS and Android

### DIFF
--- a/net/dns/manager.go
+++ b/net/dns/manager.go
@@ -334,7 +334,19 @@ func (m *Manager) compileConfig(cfg Config) (rcfg resolver.Config, ocfg OSConfig
 		// TODO: for OSes that support it, pass IP:port and DoH
 		// addresses directly to OS.
 		// https://github.com/tailscale/tailscale/issues/1666
-		ocfg.Nameservers = toIPsOnly(cfg.DefaultResolvers)
+		if m.shouldProxyDefaultResolvers() {
+			// On mobile platforms the OS resolver doesn't reliably fail
+			// over between configured upstreams when one becomes
+			// unreachable (NEDNSSettings on iOS, VpnService DNS on
+			// Android). Route through quad-100 so the Go forwarder races
+			// all servers and returns the first success. See #12677.
+			rcfg.Routes = map[dnsname.FQDN][]*dnstype.Resolver{
+				".": cfg.DefaultResolvers,
+			}
+			ocfg.Nameservers = cfg.serviceIPs(m.knobs)
+		} else {
+			ocfg.Nameservers = toIPsOnly(cfg.DefaultResolvers)
+		}
 		return rcfg, ocfg, nil
 	case cfg.hasDefaultResolvers():
 		// Default resolvers plus other stuff always ends up proxying
@@ -446,6 +458,24 @@ func (m *Manager) compileConfig(cfg Config) (rcfg resolver.Config, ocfg OSConfig
 
 func (m *Manager) disableSplitDNSOptimization() bool {
 	return m.knobs != nil && m.knobs.DisableSplitDNSWhenNoCustomResolvers.Load()
+}
+
+// shouldProxyDefaultResolvers reports whether configured default IP resolvers
+// should be routed through quad-100 (the Go-side forwarder) instead of being
+// handed directly to the OS resolver.
+//
+// On mobile platforms, DNS is configured via thin VPN-service facilities
+// (NEDNSSettings on iOS, VpnService DNS on Android) whose resolvers do not
+// reliably race or fail over between multiple upstreams when one becomes
+// unreachable, breaking redundancy. Routing through quad-100 lets the Go
+// forwarder race all configured servers concurrently and return the first
+// success. See #12677.
+func (m *Manager) shouldProxyDefaultResolvers() bool {
+	switch m.goos {
+	case "ios", "android":
+		return true
+	}
+	return false
 }
 
 // toIPsOnly returns only the IP portion of dnstype.Resolver.

--- a/net/dns/manager.go
+++ b/net/dns/manager.go
@@ -33,6 +33,7 @@ import (
 	"tailscale.com/util/eventbus"
 	"tailscale.com/util/slicesx"
 	"tailscale.com/util/syspolicy/policyclient"
+	"tailscale.com/version"
 )
 
 var (
@@ -335,11 +336,9 @@ func (m *Manager) compileConfig(cfg Config) (rcfg resolver.Config, ocfg OSConfig
 		// addresses directly to OS.
 		// https://github.com/tailscale/tailscale/issues/1666
 		if m.shouldProxyDefaultResolvers() {
-			// On mobile platforms the OS resolver doesn't reliably fail
-			// over between configured upstreams when one becomes
-			// unreachable (NEDNSSettings on iOS, VpnService DNS on
-			// Android). Route through quad-100 so the Go forwarder races
-			// all servers and returns the first success. See #12677.
+			// Route through quad-100 so the Go forwarder races all
+			// configured upstreams and fails over to a healthy server.
+			// See [Manager.shouldProxyDefaultResolvers] and #12677.
 			rcfg.Routes = map[dnsname.FQDN][]*dnstype.Resolver{
 				".": cfg.DefaultResolvers,
 			}
@@ -460,20 +459,33 @@ func (m *Manager) disableSplitDNSOptimization() bool {
 	return m.knobs != nil && m.knobs.DisableSplitDNSWhenNoCustomResolvers.Load()
 }
 
+// isMacGUIVariant reports whether the current binary is a macOS GUI variant
+// (Mac App Store or macsys System Extension) that configures DNS via the
+// Network/System Extension's NEDNSSettings, rather than tailscaled-on-macOS
+// which uses scutil/resolv.conf. It's a var so tests can override it via
+// [tstest.Replace].
+var isMacGUIVariant = version.IsMacGUIVariant
+
 // shouldProxyDefaultResolvers reports whether configured default IP resolvers
 // should be routed through quad-100 (the Go-side forwarder) instead of being
 // handed directly to the OS resolver.
 //
-// On mobile platforms, DNS is configured via thin VPN-service facilities
-// (NEDNSSettings on iOS, VpnService DNS on Android) whose resolvers do not
-// reliably race or fail over between multiple upstreams when one becomes
-// unreachable, breaking redundancy. Routing through quad-100 lets the Go
-// forwarder race all configured servers concurrently and return the first
-// success. See #12677.
+// It returns true on platforms whose DNS is configured via a VPN-service
+// facility (NEDNSSettings on iOS and macOS Network/System Extensions,
+// VpnService DNS on Android), where the OS resolver doesn't reliably race
+// or fail over between multiple upstreams when one becomes unreachable.
+// Routing through quad-100 lets the Go forwarder race all configured
+// servers concurrently and return the first success. See #12677.
+//
+// tailscaled-on-macOS is intentionally excluded: it uses standard macOS
+// DNS plumbing (scutil/resolv.conf), which handles racing on its own and
+// would gain only an extra hop from this indirection.
 func (m *Manager) shouldProxyDefaultResolvers() bool {
 	switch m.goos {
 	case "ios", "android":
 		return true
+	case "darwin":
+		return isMacGUIVariant()
 	}
 	return false
 }

--- a/net/dns/manager_test.go
+++ b/net/dns/manager_test.go
@@ -311,6 +311,74 @@ func TestManager(t *testing.T) {
 			},
 		},
 		{
+			// On mobile platforms, even trivial "default resolvers only"
+			// configs should route through quad-100 so the Go forwarder
+			// handles multi-server fallback instead of relying on the OS
+			// VPN-service DNS facility (NEDNSSettings on iOS, VpnService
+			// DNS on Android), which doesn't reliably race upstreams.
+			// See https://github.com/tailscale/tailscale/issues/12677.
+			name: "corp-ios",
+			in: Config{
+				DefaultResolvers: mustRes("1.1.1.1", "9.9.9.9"),
+				SearchDomains:    fqdns("tailscale.com", "universe.tf"),
+			},
+			goos: "ios",
+			os: OSConfig{
+				Nameservers:   serviceAddr46,
+				SearchDomains: fqdns("tailscale.com", "universe.tf"),
+			},
+			rs: resolver.Config{
+				Routes: upstreams(".", "1.1.1.1", "9.9.9.9"),
+			},
+		},
+		{
+			// Same as corp-ios but with a single resolver, to verify the
+			// quad-100 proxy path is used even when there's only one server.
+			name: "corp-ios-single",
+			in: Config{
+				DefaultResolvers: mustRes("1.1.1.1"),
+				SearchDomains:    fqdns("tailscale.com", "universe.tf"),
+			},
+			goos: "ios",
+			os: OSConfig{
+				Nameservers:   serviceAddr46,
+				SearchDomains: fqdns("tailscale.com", "universe.tf"),
+			},
+			rs: resolver.Config{
+				Routes: upstreams(".", "1.1.1.1"),
+			},
+		},
+		{
+			name: "corp-android",
+			in: Config{
+				DefaultResolvers: mustRes("1.1.1.1", "9.9.9.9"),
+				SearchDomains:    fqdns("tailscale.com", "universe.tf"),
+			},
+			goos: "android",
+			os: OSConfig{
+				Nameservers:   serviceAddr46,
+				SearchDomains: fqdns("tailscale.com", "universe.tf"),
+			},
+			rs: resolver.Config{
+				Routes: upstreams(".", "1.1.1.1", "9.9.9.9"),
+			},
+		},
+		{
+			name: "corp-android-single",
+			in: Config{
+				DefaultResolvers: mustRes("1.1.1.1"),
+				SearchDomains:    fqdns("tailscale.com", "universe.tf"),
+			},
+			goos: "android",
+			os: OSConfig{
+				Nameservers:   serviceAddr46,
+				SearchDomains: fqdns("tailscale.com", "universe.tf"),
+			},
+			rs: resolver.Config{
+				Routes: upstreams(".", "1.1.1.1"),
+			},
+		},
+		{
 			name: "corp-magic",
 			in: Config{
 				DefaultResolvers: mustRes("1.1.1.1", "9.9.9.9"),

--- a/net/dns/manager_test.go
+++ b/net/dns/manager_test.go
@@ -187,14 +187,15 @@ func TestManager(t *testing.T) {
 	// reasonable to make this unsupported as well, in which case
 	// these tests will need tweaking.
 	tests := []struct {
-		name  string
-		in    Config
-		split bool
-		bs    OSConfig
-		os    OSConfig
-		knobs *controlknobs.Knobs
-		rs    resolver.Config
-		goos  string // empty means "linux"
+		name          string
+		in            Config
+		split         bool
+		bs            OSConfig
+		os            OSConfig
+		knobs         *controlknobs.Knobs
+		rs            resolver.Config
+		goos          string // empty means "linux"
+		macGUIVariant bool   // override version.IsMacGUIVariant for the test
 	}{
 		{
 			name: "empty",
@@ -376,6 +377,40 @@ func TestManager(t *testing.T) {
 			},
 			rs: resolver.Config{
 				Routes: upstreams(".", "1.1.1.1"),
+			},
+		},
+		{
+			// macOS Network/System Extension variants (Mac App Store,
+			// macsys) configure DNS via NEDNSSettings, just like iOS,
+			// and have the same multi-server failover problem.
+			name: "corp-macos-gui",
+			in: Config{
+				DefaultResolvers: mustRes("1.1.1.1", "9.9.9.9"),
+				SearchDomains:    fqdns("tailscale.com", "universe.tf"),
+			},
+			goos:          "darwin",
+			macGUIVariant: true,
+			os: OSConfig{
+				Nameservers:   serviceAddr46,
+				SearchDomains: fqdns("tailscale.com", "universe.tf"),
+			},
+			rs: resolver.Config{
+				Routes: upstreams(".", "1.1.1.1", "9.9.9.9"),
+			},
+		},
+		{
+			// tailscaled-on-macOS uses scutil/resolv.conf and is
+			// unaffected by the NEDNSSettings issue; default resolvers
+			// should still be handed straight to the OS.
+			name: "corp-macos-tailscaled",
+			in: Config{
+				DefaultResolvers: mustRes("1.1.1.1", "9.9.9.9"),
+				SearchDomains:    fqdns("tailscale.com", "universe.tf"),
+			},
+			goos: "darwin",
+			os: OSConfig{
+				Nameservers:   mustIPs("1.1.1.1", "9.9.9.9"),
+				SearchDomains: fqdns("tailscale.com", "universe.tf"),
 			},
 		},
 		{
@@ -1045,6 +1080,7 @@ func TestManager(t *testing.T) {
 			if goos == "" {
 				goos = "linux"
 			}
+			tstest.Replace(t, &isMacGUIVariant, func() bool { return test.macGUIVariant })
 			knobs := test.knobs
 			if knobs == nil {
 				knobs = &controlknobs.Knobs{}


### PR DESCRIPTION
When only default IP resolvers are configured (no MagicDNS/routes), compileConfig previously handed the resolver IPs to the OS via NEDNSSettings on iOS and VpnService DNS on Android. Neither reliably races or fails over between configured upstreams when one becomes unreachable, so a single down nameserver breaks DNS for the whole tailnet on the device. Route through quad-100 on mobile so the Go forwarder races all servers and returns the first success.

Updates #12677
Updates #19649