### PR TITLE
portlist: add mutex to Poller to fix data race

### DIFF
--- a/feature/portlist/portlist.go
+++ b/feature/portlist/portlist.go
@@ -111,6 +111,7 @@ func (e *Extension) runPollLoop() {
 	defer close(e.pollerDone)
 
 	var poller portlist.Poller
+	defer poller.Close()
 
 	ticker, tickerChannel := e.sb.Clock().NewTicker(portlist.PollInterval())
 	defer ticker.Stop()

--- a/portlist/poller.go
+++ b/portlist/poller.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 // This file contains the code related to the Poller type and its methods.
-// The hot loop to keep efficient is Poller.Run.
+// The hot loop to keep efficient is Poller.Poll.
 
 package portlist
 
@@ -30,11 +30,13 @@ func PollInterval() time.Duration {
 }
 
 // Poller scans the systems for listening ports periodically and sends
-// the results to C.
+// the results to its caller via Poll.
+//
+// Poller is safe for concurrent use.
 type Poller struct {
 	// IncludeLocalhost controls whether services bound to localhost are included.
 	//
-	// This field should only be changed before calling Run.
+	// This field should only be changed before calling Poll.
 	IncludeLocalhost bool
 
 	// os, if non-nil, is an OS-specific implementation of the portlist getting
@@ -47,7 +49,9 @@ type Poller struct {
 	initOnce sync.Once // guards init of os
 	initErr  error
 
-	// scatch is memory for Poller.getList to reuse between calls.
+	mu sync.Mutex // guards scratch and prev
+
+	// scratch is memory for Poller.getListLocked to reuse between calls.
 	scratch []Port
 
 	prev List // most recent data, not aliasing scratch
@@ -87,7 +91,9 @@ func (p *Poller) init() {
 }
 
 // Close closes the Poller.
+// It is safe to call Close concurrently with Poll.
 func (p *Poller) Close() error {
+	p.initOnce.Do(p.init)
 	if p.initErr != nil {
 		return p.initErr
 	}
@@ -99,12 +105,19 @@ func (p *Poller) Close() error {
 
 // Poll returns the list of listening ports, if changed from
 // a previous call as indicated by the changed result.
+//
+// The returned ports slice is owned by the caller and will not be
+// modified by subsequent calls to Poll.
 func (p *Poller) Poll() (ports []Port, changed bool, err error) {
 	p.initOnce.Do(p.init)
 	if p.initErr != nil {
 		return nil, false, fmt.Errorf("error initializing poller: %w", p.initErr)
 	}
-	pl, err := p.getList()
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	pl, err := p.getListLocked()
 	if err != nil {
 		return nil, false, err
 	}
@@ -115,7 +128,9 @@ func (p *Poller) Poll() (ports []Port, changed bool, err error) {
 	return p.prev, true, nil
 }
 
-func (p *Poller) getList() (List, error) {
+// getListLocked fetches the current list of ports using p.scratch as
+// a reusable buffer. p.mu must be held.
+func (p *Poller) getListLocked() (List, error) {
 	var err error
 	p.scratch, err = p.os.AppendListeningPorts(p.scratch[:0])
 	return p.scratch, err

--- a/portlist/portlist_test.go
+++ b/portlist/portlist_test.go
@@ -6,6 +6,7 @@ package portlist
 import (
 	"net"
 	"runtime"
+	"sync"
 	"testing"
 
 	"tailscale.com/tstest"
@@ -205,6 +206,44 @@ func TestClose(t *testing.T) {
 	}
 }
 
+func TestConcurrentPoll(t *testing.T) {
+	maybeSkip(t)
+
+	var p Poller
+	p.IncludeLocalhost = true
+
+	// Do an initial poll to initialize.
+	if _, _, err := p.Poll(); err != nil {
+		t.Skipf("skipping due to poll error: %v", err)
+	}
+	defer p.Close()
+
+	// Run multiple goroutines calling Poll concurrently to verify
+	// there are no data races on the Poller's internal state.
+	const goroutines = 4
+	const iterations = 10
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				ports, changed, err := p.Poll()
+				if err != nil {
+					t.Errorf("Poll: %v", err)
+					return
+				}
+				// Access the returned data to ensure it's not
+				// aliased with the Poller's internal state.
+				if changed {
+					_ = List(ports).String()
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
 func BenchmarkGetList(b *testing.B) {
 	benchmarkGetList(b, false)
 }
@@ -223,7 +262,7 @@ func benchmarkGetList(b *testing.B, incremental bool) {
 	}
 	b.Cleanup(func() { p.Close() })
 	for range b.N {
-		pl, err := p.getList()
+		pl, err := p.getListLocked()
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
## Summary
- Adds `sync.Mutex` to `Poller` to protect `scratch` and `prev` fields from concurrent access
- Fixes stale documentation referencing removed `Run` method and `C` channel
- Adds `defer poller.Close()` in `feature/portlist` to prevent resource leaks
- Adds `TestConcurrentPoll` to verify no races under concurrent `Poll()` calls

Fixes #7520

## Details

The original issue reported a data race where `b.hostinfo.Services` was written by one goroutine while being read concurrently by another. The `LocalBackend`-level race has since been fixed by proper mutex usage and `hostInfoWithServicesLocked()`. However, the `Poller` type itself had no synchronization — its `scratch` and `prev` fields could race if `Poll()` were called concurrently or alongside `Close()`.

This PR adds a `sync.Mutex` to `Poller`:
- The mutex is acquired in `Poll()` around the `getListLocked()`/`setPrev()` critical section
- `Close()` now calls `initOnce.Do(p.init)` to ensure safe concurrent use with `Poll()`

## Test plan
- [x] `TestConcurrentPoll` — runs 4 goroutines calling `Poll()` 10 times concurrently
- [x] All existing tests pass with `-race` flag enabled
- [x] Updated benchmark to use renamed `getListLocked()` method