### PR TITLE
ipn/ipnlocal,cmd/tailscale/cli: add Funnel BYODomain support

### DIFF
--- a/cmd/tailscale/cli/serve_legacy.go
+++ b/cmd/tailscale/cli/serve_legacy.go
@@ -173,6 +173,7 @@ type serveEnv struct {
 	subcmd           serveMode                // subcommand
 	yes              bool                     // update without prompt
 	service          tailcfg.ServiceName      // service name
+	host             string                   // BYO ("bring your own") domain, overrides node DNSName
 	tun              bool                     // redirect traffic to OS for service
 	allServices      bool                     // apply config file to all services
 	acceptAppCaps    []tailcfg.PeerCapability // app capabilities to forward

--- a/cmd/tailscale/cli/serve_v2.go
+++ b/cmd/tailscale/cli/serve_v2.go
@@ -245,6 +245,7 @@ func newServeV2Command(e *serveEnv, subcmd serveMode) *ffcli.Command {
 				fs.Var(&serviceNameFlag{Value: &e.service}, "service", "Serve for a service with distinct virtual IP instead on node itself.")
 				fs.BoolVar(&e.tun, "tun", false, "Forward all traffic to the local machine (default false), only supported for services. Refer to docs for more information.")
 			}
+			fs.StringVar(&e.host, "host", "", "Serve under the given external hostname (e.g. --host=foo.com) instead of this node's MagicDNS name. Requires CNAMEing the hostname to this node and is intended for use with `tailscale funnel`; the TLS cert is obtained via TLS-ALPN-01.")
 			fs.UintVar(&e.tcp, "tcp", 0, "Expose a TCP forwarder to forward raw TCP packets at the specified port")
 			fs.UintVar(&e.tlsTerminatedTCP, "tls-terminated-tcp", 0, "Expose a TCP forwarder to forward TLS-terminated TCP packets at the specified port")
 			fs.UintVar(&e.proxyProtocol, "proxy-protocol", 0, "PROXY protocol version (1 or 2) for TCP forwarding")
@@ -404,6 +405,9 @@ func (e *serveEnv) runServeCombined(subcmd serveMode) execFunc {
 		if forService && funnel {
 			return errors.New("Error: --service flag is not supported with funnel")
 		}
+		if e.host != "" && forService {
+			return errors.New("Error: --host and --service are mutually exclusive")
+		}
 
 		if funnel {
 			// verify node has funnel capabilities
@@ -479,6 +483,15 @@ func (e *serveEnv) runServeCombined(subcmd serveMode) execFunc {
 		if forService {
 			svcName = e.service
 			dnsName = e.service.String()
+		}
+		// BYO ("bring your own") domain. The user has CNAMEd e.host to
+		// this node, and wants the serve config and any cert issued for
+		// it to be keyed under that hostname rather than the node's own
+		// MagicDNS name. tailscaled obtains the cert via TLS-ALPN-01
+		// (see ipn/ipnlocal/cert.go) over the same TLS path that will
+		// eventually serve real traffic.
+		if e.host != "" {
+			dnsName = e.host
 		}
 		tagged := st.Self.Tags != nil && st.Self.Tags.Len() > 0
 		if forService && !tagged && !turnOff {

--- a/cmd/tailscale/cli/serve_v2_test.go
+++ b/cmd/tailscale/cli/serve_v2_test.go
@@ -862,6 +862,33 @@ func TestServeDevConfigMutations(t *testing.T) {
 			}},
 		},
 		{
+			// BYO ("bring your own") domain: --host overrides the node's
+			// DNSName as the serve config key. The ServeConfig entries
+			// are keyed under foo.com:443 rather than foo.test.ts.net:443.
+			name: "funnel_byo_host",
+			steps: []step{{
+				command: cmd("funnel --bg --host=foo.com 3000"),
+				want: &ipn.ServeConfig{
+					TCP: map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}},
+					Web: map[ipn.HostPort]*ipn.WebServerConfig{
+						"foo.com:443": {Handlers: map[string]*ipn.HTTPHandler{
+							"/": {Proxy: "http://127.0.0.1:3000"},
+						}},
+					},
+					AllowFunnel: map[ipn.HostPort]bool{"foo.com:443": true},
+				},
+			}},
+		},
+		{
+			// --host and --service both override the dnsName, so they
+			// are not allowed together.
+			name: "host_and_service_are_mutually_exclusive",
+			steps: []step{{
+				command: cmd("serve --bg --host=foo.com --service=svc:foo --http=80 text:foo"),
+				wantErr: anyErr(),
+			}},
+		},
+		{
 			name: "forward_grant_header",
 			steps: []step{
 				{

--- a/ipn/ipnlocal/cert.go
+++ b/ipn/ipnlocal/cert.go
@@ -110,8 +110,13 @@ func (b *LocalBackend) GetCertPEM(ctx context.Context, domain string) (*TLSCertK
 //
 //   - An exact CertDomain (e.g., "node.ts.net")
 //   - A wildcard domain (e.g., "*.node.ts.net")
+//   - A user-brought ("BYO") domain referenced by this node's serve config
+//     (e.g., "foo.com" when ServeConfig.Web has a "foo.com:443" key).
 //
 // The wildcard format requires the NodeAttrDNSSubdomainResolve capability.
+// ts.net domains are issued via dns-01 against control's DNSimple-backed
+// zone. BYO domains are issued via tls-alpn-01 directly against the
+// public ACME directory (typically Let's Encrypt).
 func (b *LocalBackend) GetCertPEMWithValidity(ctx context.Context, domain string, minValidity time.Duration) (*TLSCertKeyPair, error) {
 	b.mu.Lock()
 	getCertForTest := b.getCertForTest
@@ -609,14 +614,27 @@ var getCertPEM = func(ctx context.Context, b *LocalBackend, cs certStore, logf l
 	}
 	traceACME(order)
 
+	// Tailscale-managed (ts.net) domains use dns-01 because control owns
+	// the ts.net DNS zone. User-supplied ("BYO") domains use tls-alpn-01,
+	// because we don't have API access to the user's DNS provider but we
+	// do already terminate TLS on the user's tailscaled — the same path
+	// that will eventually serve the production cert can also serve the
+	// challenge cert.
+	challengeType := b.preferredChallengeType(domain)
+
 	for _, aurl := range order.AuthzURLs {
 		az, err := ac.GetAuthorization(ctx, aurl)
 		if err != nil {
 			return nil, err
 		}
 		traceACME(az)
+		var solved bool
 		for _, ch := range az.Challenges {
-			if ch.Type == "dns-01" {
+			if ch.Type != challengeType {
+				continue
+			}
+			switch ch.Type {
+			case "dns-01":
 				rec, err := ac.DNS01ChallengeRecord(ch.Token)
 				if err != nil {
 					return nil, err
@@ -636,20 +654,44 @@ var getCertPEM = func(ctx context.Context, b *LocalBackend, cs certStore, logf l
 					logf("TXT record already existed for %s", key)
 				} else {
 					logf("starting SetDNS call for %s...", key)
-					err = b.SetDNS(ctx, key, rec)
-					if err != nil {
+					if err := b.SetDNS(ctx, key, rec); err != nil {
 						return nil, fmt.Errorf("SetDNS %q => %q: %w", key, rec, err)
 					}
 					logf("did SetDNS for %s", key)
 				}
-
-				chal, err := ac.Accept(ctx, ch)
-				if err != nil {
-					return nil, fmt.Errorf("Accept: %v", err)
+			case "tls-alpn-01":
+				// The challenge cert must be served over TLS for the
+				// authorization identifier (which equals the SAN of the
+				// production cert we are trying to issue) and must stay
+				// installed until the ACME server finishes validation,
+				// so the deferred cleanup fires at the end of
+				// getCertPEM rather than the end of the loop iteration.
+				// installALPN is provided by serve.go; the hook is
+				// unset in builds without serve (ts_omit_serve), in
+				// which case this challenge type is unavailable.
+				installALPN, ok := hookServeInstallALPNChallengeCert.GetOk()
+				if !ok {
+					return nil, errors.New("tls-alpn-01 challenges require serve support, which is not compiled into this build")
 				}
-				traceACME(chal)
-				break
+				cert, err := ac.TLSALPN01ChallengeCert(ch.Token, az.Identifier.Value)
+				if err != nil {
+					return nil, fmt.Errorf("TLSALPN01ChallengeCert: %w", err)
+				}
+				defer installALPN(az.Identifier.Value, &cert)()
+				logf("installed tls-alpn-01 challenge cert for %s", az.Identifier.Value)
+			default:
+				continue
 			}
+			chal, err := ac.Accept(ctx, ch)
+			if err != nil {
+				return nil, fmt.Errorf("Accept: %v", err)
+			}
+			traceACME(chal)
+			solved = true
+			break
+		}
+		if !solved {
+			return nil, fmt.Errorf("ACME server did not offer a %q challenge for %q", challengeType, az.Identifier.Value)
 		}
 	}
 
@@ -900,6 +942,7 @@ func validLookingCertDomain(name string) bool {
 //
 //   - "node.ts.net" -> "node.ts.net" (exact CertDomain match)
 //   - "*.node.ts.net" -> "*.node.ts.net" (explicit wildcard, requires NodeAttrDNSSubdomainResolve)
+//   - "foo.com" -> "foo.com" (user-brought "BYO" domain referenced by the node's serve config)
 //
 // Subdomain requests like "app.node.ts.net" are rejected; callers should
 // request "*.node.ts.net" explicitly for subdomain coverage.
@@ -914,7 +957,7 @@ func (b *LocalBackend) resolveCertDomain(domain string) (string, error) {
 		return "", errors.New("no netmap available")
 	}
 	certDomains := nm.DNS.CertDomains
-	if len(certDomains) == 0 {
+	if len(certDomains) == 0 && !b.serveConfigHasHost(domain) {
 		return "", errors.New("your Tailscale account does not support getting TLS certs")
 	}
 
@@ -934,7 +977,61 @@ func (b *LocalBackend) resolveCertDomain(domain string) (string, error) {
 		return domain, nil
 	}
 
+	// Bring-your-own-domain: the node's serve config references the
+	// domain as a Funnel target (e.g. "foo.com:443"), so we'll obtain a
+	// cert for it via TLS-ALPN-01 in getCertPEM. resolveCertDomain only
+	// validates that the domain is legitimately associated with this
+	// node; the challenge choice happens later.
+	if b.serveConfigHasHost(domain) {
+		return domain, nil
+	}
+
 	return "", fmt.Errorf("invalid domain %q; must be one of %q", domain, certDomains)
+}
+
+// serveConfigHasHost reports whether the local serve config has any Web
+// entry whose hostname (the SNI portion of the HostPort key) matches
+// host. It is used by resolveCertDomain to allow cert issuance for
+// user-brought ("BYO") domains that are not in the netmap's CertDomains
+// list.
+func (b *LocalBackend) serveConfigHasHost(host string) bool {
+	if host == "" {
+		return false
+	}
+	b.mu.Lock()
+	sc := b.serveConfig
+	b.mu.Unlock()
+	if !sc.Valid() {
+		return false
+	}
+	for hp := range sc.Webs() {
+		h, _, err := net.SplitHostPort(string(hp))
+		if err == nil && h == host {
+			return true
+		}
+	}
+	return false
+}
+
+// preferredChallengeType returns the ACME challenge type to attempt for
+// the given domain.
+//
+// ts.net (Tailscale-managed) domains use dns-01 because control owns
+// the ts.net zone and can publish the challenge TXT record. Any other
+// domain is treated as user-brought ("BYO") and uses tls-alpn-01,
+// which is satisfied by the user's own tailscaled serving the
+// challenge cert over the same TLS path that will eventually serve
+// the production cert (typically via Funnel).
+func (b *LocalBackend) preferredChallengeType(domain string) string {
+	nm := b.NetMapNoPeers()
+	if nm == nil {
+		return "tls-alpn-01"
+	}
+	base := strings.TrimPrefix(domain, "*.")
+	if slices.Contains(nm.DNS.CertDomains, base) || slices.Contains(nm.DNS.CertDomains, domain) {
+		return "dns-01"
+	}
+	return "tls-alpn-01"
 }
 
 // handleC2NTLSCertStatus returns info about the last TLS certificate issued for the

--- a/ipn/ipnlocal/cert_test.go
+++ b/ipn/ipnlocal/cert_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"tailscale.com/envknob"
+	"tailscale.com/ipn"
 	"tailscale.com/ipn/store/mem"
 	"tailscale.com/tailcfg"
 	"tailscale.com/tstest"
@@ -217,6 +218,80 @@ func TestResolveCertDomain(t *testing.T) {
 				t.Errorf("resolveCertDomain(%q) = %q, want %q", tt.domain, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestResolveCertDomainBYO covers user-brought ("BYO") domains: ones
+// not in DNS.CertDomains but referenced by the node's serve config.
+// These are valid targets for cert issuance via TLS-ALPN-01.
+func TestResolveCertDomainBYO(t *testing.T) {
+	b := newTestLocalBackend(t)
+
+	b.mu.Lock()
+	b.currentNode().SetNetMap(&netmap.NetworkMap{
+		SelfNode: (&tailcfg.Node{}).View(),
+		DNS:      tailcfg.DNSConfig{CertDomains: []string{"node.ts.net"}},
+	})
+	b.mu.Unlock()
+
+	// Without a serve-config entry, the BYO host is rejected.
+	if _, err := b.resolveCertDomain("foo.com"); err == nil {
+		t.Fatalf("resolveCertDomain(foo.com) before serve config: want error, got nil")
+	}
+
+	// Install a serve config that references foo.com:443.
+	conf := &ipn.ServeConfig{
+		Web: map[ipn.HostPort]*ipn.WebServerConfig{
+			"foo.com:443": {Handlers: map[string]*ipn.HTTPHandler{"/": {Proxy: "http://127.0.0.1:8080"}}},
+		},
+	}
+	b.mu.Lock()
+	b.serveConfig = conf.View()
+	b.mu.Unlock()
+
+	got, err := b.resolveCertDomain("foo.com")
+	if err != nil {
+		t.Fatalf("resolveCertDomain(foo.com): %v", err)
+	}
+	if got != "foo.com" {
+		t.Errorf("resolveCertDomain(foo.com) = %q, want %q", got, "foo.com")
+	}
+
+	// ts.net still routes through the existing exact-match path.
+	got, err = b.resolveCertDomain("node.ts.net")
+	if err != nil {
+		t.Fatalf("resolveCertDomain(node.ts.net): %v", err)
+	}
+	if got != "node.ts.net" {
+		t.Errorf("resolveCertDomain(node.ts.net) = %q, want node.ts.net", got)
+	}
+}
+
+// TestPreferredChallengeType checks that ts.net-managed domains route
+// to dns-01 (control owns the zone) while BYO domains route to
+// tls-alpn-01 (served by tailscaled directly).
+func TestPreferredChallengeType(t *testing.T) {
+	b := newTestLocalBackend(t)
+	b.mu.Lock()
+	b.currentNode().SetNetMap(&netmap.NetworkMap{
+		SelfNode: (&tailcfg.Node{}).View(),
+		DNS:      tailcfg.DNSConfig{CertDomains: []string{"node.ts.net"}},
+	})
+	b.mu.Unlock()
+
+	tests := []struct {
+		domain string
+		want   string
+	}{
+		{"node.ts.net", "dns-01"},
+		{"*.node.ts.net", "dns-01"},
+		{"foo.com", "tls-alpn-01"},
+		{"unrelated.example", "tls-alpn-01"},
+	}
+	for _, tt := range tests {
+		if got := b.preferredChallengeType(tt.domain); got != tt.want {
+			t.Errorf("preferredChallengeType(%q) = %q, want %q", tt.domain, got, tt.want)
+		}
 	}
 }
 

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -10,6 +10,7 @@ import (
 	"cmp"
 	"context"
 	"crypto/sha256"
+	"crypto/tls"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -5017,6 +5018,22 @@ var (
 
 	hookServeSetTCPPortsInterceptedFromNetmapAndPrefsLocked feature.Hook[func(b *LocalBackend, prefs ipn.PrefsView) (handlePorts []uint16)]
 	hookServeClearVIPServicesTCPPortsInterceptedLocked      feature.Hook[func(*LocalBackend)]
+
+	// hookServeInstallALPNChallengeCert installs a TLS-ALPN-01 ACME
+	// challenge certificate for the given domain into the serve
+	// package's process-wide map. The returned cleanup func removes it.
+	// It is set by serve.go's init() so that the cert acquisition path
+	// in cert.go can drive a tls-alpn-01 challenge through the same TLS
+	// listener that serves real traffic. The hook is unset (and the
+	// challenge type is therefore unavailable) when ts_omit_serve is on.
+	hookServeInstallALPNChallengeCert feature.Hook[func(domain string, cert *tls.Certificate) (cleanup func())]
+
+	// hookServeLookupALPNChallengeCert returns the TLS-ALPN-01 challenge
+	// cert installed for the given domain, or nil if none is in flight.
+	// It is set by serve.go's init() and read from serve.go's TLS
+	// terminator GetCertificate callback when a ClientHello arrives with
+	// the "acme-tls/1" ALPN.
+	hookServeLookupALPNChallengeCert feature.Hook[func(domain string) *tls.Certificate]
 )
 
 func (b *LocalBackend) handleDriveConn(conn net.Conn) error {

--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -60,6 +60,8 @@ func init() {
 	hookServeClearVIPServicesTCPPortsInterceptedLocked.Set(func(b *LocalBackend) {
 		b.setVIPServicesTCPPortsInterceptedLocked(nil)
 	})
+	hookServeInstallALPNChallengeCert.Set(installALPNChallengeCert)
+	hookServeLookupALPNChallengeCert.Set(lookupALPNChallengeCert)
 
 	hookMaybeMutateHostinfoLocked.Add(maybeUpdateHostinfoServicesHashLocked)
 	hookMaybeMutateHostinfoLocked.Add(maybeUpdateHostinfoFunnelLocked)
@@ -67,9 +69,59 @@ func init() {
 	RegisterC2N("GET /vip-services", handleC2NVIPServicesGet)
 }
 
+// TLS-ALPN-01 ACME challenge state.
+//
+// alpnChallengeCerts holds per-domain challenge certificates produced
+// during an in-flight TLS-ALPN-01 ACME issuance. Entries are installed
+// by cert.go (via the hookServeInstallALPNChallengeCert hook) just
+// before the ACME server is told to validate, and cleared when the
+// returned cleanup func runs at the end of getCertPEM. The TLS
+// terminator consults this map in getTLSServeCertForPort when a
+// ClientHello arrives whose ALPN list contains "acme-tls/1".
+//
+// Because this state lives in serve.go it is only present in builds
+// that have serve compiled in (i.e. not ts_omit_serve). The hooks in
+// local.go are unset when serve is omitted, so cert.go's tls-alpn-01
+// path errors out cleanly in that case.
+var (
+	alpnChallengeMu    sync.RWMutex
+	alpnChallengeCerts = map[string]*tls.Certificate{}
+)
+
+// installALPNChallengeCert registers cert as the TLS-ALPN-01 challenge
+// response to serve for the given domain, and returns a cleanup func
+// that the caller must invoke once the challenge is no longer active
+// (typically deferred for the lifetime of the ACME order).
+func installALPNChallengeCert(domain string, cert *tls.Certificate) (cleanup func()) {
+	alpnChallengeMu.Lock()
+	alpnChallengeCerts[domain] = cert
+	alpnChallengeMu.Unlock()
+	return func() {
+		alpnChallengeMu.Lock()
+		delete(alpnChallengeCerts, domain)
+		alpnChallengeMu.Unlock()
+	}
+}
+
+// lookupALPNChallengeCert returns the TLS-ALPN-01 challenge certificate
+// installed for domain, or nil if none is currently in flight.
+func lookupALPNChallengeCert(domain string) *tls.Certificate {
+	alpnChallengeMu.RLock()
+	defer alpnChallengeMu.RUnlock()
+	return alpnChallengeCerts[domain]
+}
+
 const (
 	contentTypeHeader   = "Content-Type"
 	grpcBaseContentType = "application/grpc"
+
+	// acmeTLSALPNProto is the ALPN protocol name used for the
+	// TLS-ALPN-01 ACME challenge (RFC 8737). It matches
+	// tailscale.com/tempfork/acme.ALPNProto, redeclared here so this
+	// file does not import the acme package; the dep audit
+	// (TestOmitACME) requires that nothing pulled into a ts_omit_acme
+	// build references tempfork/acme.
+	acmeTLSALPNProto = "acme-tls/1"
 )
 
 // ErrETagMismatch signals that the given
@@ -577,6 +629,12 @@ func (b *LocalBackend) tcpHandlerForVIPService(dstAddr, srcAddr netip.AddrPort) 
 			// in the hostname. How to store the TLS cert is still being discussed.
 			hs.TLSConfig = &tls.Config{
 				GetCertificate: b.getTLSServeCertForPort(dport, dstSvc),
+				// "acme-tls/1" lets in-flight TLS-ALPN-01 ACME
+				// challenges complete handshakes against this same
+				// listener. http.Server.ServeTLS prepends "h2" and
+				// appends "http/1.1" if missing, so real client
+				// protocol selection is unchanged.
+				NextProtos: []string{acmeTLSALPNProto},
 			}
 			return func(c net.Conn) error {
 				return hs.ServeTLS(netutil.NewOneConnListener(c, nil), "", "")
@@ -655,6 +713,8 @@ func (b *LocalBackend) tcpHandlerForServe(dport uint16, srcAddr netip.AddrPort, 
 		if tcph.HTTPS() {
 			hs.TLSConfig = &tls.Config{
 				GetCertificate: b.getTLSServeCertForPort(dport, ""),
+				// See the matching comment in tcpHandlerForVIPService.
+				NextProtos: []string{acmeTLSALPNProto},
 			}
 			return func(c net.Conn) error {
 				return hs.ServeTLS(netutil.NewOneConnListener(c, nil), "", "")
@@ -1310,6 +1370,19 @@ func (b *LocalBackend) getTLSServeCertForPort(port uint16, forVIPService tailcfg
 	return func(hi *tls.ClientHelloInfo) (*tls.Certificate, error) {
 		if hi == nil || hi.ServerName == "" {
 			return nil, errors.New("no SNI ServerName")
+		}
+		// TLS-ALPN-01 ACME challenge intercept. When a BYO domain is
+		// being issued, the ACME validator connects to this same TLS
+		// listener with ALPN "acme-tls/1"; cert.go has already stashed
+		// a challenge cert keyed by the authorization identifier (SNI).
+		// Returning it completes the validation. If the ALPN is offered
+		// but no challenge is in flight, reject the handshake so we
+		// never accidentally serve a production cert under that ALPN.
+		if slices.Contains(hi.SupportedProtos, acmeTLSALPNProto) {
+			if cert := lookupALPNChallengeCert(hi.ServerName); cert != nil {
+				return cert, nil
+			}
+			return nil, fmt.Errorf("no TLS-ALPN-01 challenge in progress for %q", hi.ServerName)
 		}
 		_, ok := b.webServerConfig(hi.ServerName, forVIPService, port)
 		if !ok {


### PR DESCRIPTION
This starts to let users serve their own domain (e.g. foo.com) through
Funnel by CNAMEing it to their node's MagicDNS name, rather than being
limited to NODE.TAILNET.ts.net.

Backend (ipn/ipnlocal):
 - serve.go: a process-wide map of pending TLS-ALPN-01 challenge certs
   keyed by SNI, plus install/lookup helpers. Exposed to cert.go via two
   feature.Hook entries declared in local.go so the state only links in
   when serve is compiled in (i.e. not ts_omit_serve).
 - cert.go: resolveCertDomain accepts a non-ts.net domain when the local
   serve config references it as a Web host. getCertPEM dispatches to
   dns-01 (ts.net, control-managed zone) or tls-alpn-01 (BYO) based on
   whether the domain matches DNS.CertDomains. The tls-alpn-01 case
   installs the challenge cert via hookServeInstallALPNChallengeCert and
   defers its cleanup until the ACME order completes.
 - serve.go: getTLSServeCertForPort peeks ClientHelloInfo.SupportedProtos
   for "acme-tls/1" and returns the stashed challenge cert, refusing the
   handshake if the ALPN is offered without an in-flight challenge.
   NextProtos on the HTTPS TLS configs gain "acme-tls/1"; ServeTLS still
   prepends "h2" and appends "http/1.1" so real-client protocol
   selection is unchanged.

CLI (cmd/tailscale/cli):
 - New --host flag on `tailscale serve` / `tailscale funnel`. When set,
   the serve config Web and AllowFunnel entries are keyed under the
   given hostname (e.g. foo.com:443) rather than the node's own
   DNSName. Mutually exclusive with --service.

Tests added for resolveCertDomain BYO acceptance, preferredChallengeType
dispatch, --host serve-config shape, and the --host/--service mutual
exclusion.

Updates tailscale/corp#41736
