### PR TITLE
ipn/ipnlocal,tsd: add NoiseRoundTripper to tsd.Sys

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -536,6 +536,8 @@ func NewLocalBackend(logf logger.Logf, logID logid.PublicID, sys *tsd.System, lo
 		needsCaptiveDetection: make(chan bool),
 	}
 
+	sys.NoiseRoundTripper.Set(noiseRoundTripper{b})
+
 	nb := newNodeBackend(ctx, b.logf, b.sys.Bus.Get())
 	b.currentNodeAtomic.Store(nb)
 	nb.ready()
@@ -7272,6 +7274,15 @@ func (b *LocalBackend) DoNoiseRequest(req *http.Request) (*http.Response, error)
 		return nil, errors.New("no client")
 	}
 	return cc.DoNoiseRequest(req)
+}
+
+// noiseRoundTripper adapts LocalBackend.DoNoiseRequest to http.RoundTripper.
+type noiseRoundTripper struct {
+	lb *LocalBackend
+}
+
+func (n noiseRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return n.lb.DoNoiseRequest(req)
 }
 
 // ActiveSSHConns returns the number of active SSH connections,

--- a/tsd/tsd.go
+++ b/tsd/tsd.go
@@ -20,6 +20,7 @@ package tsd
 import (
 	"crypto/x509"
 	"fmt"
+	"net/http"
 	"reflect"
 
 	"tailscale.com/control/controlknobs"
@@ -63,6 +64,10 @@ type System struct {
 	DriveForRemote SubSystem[drive.FileSystemForRemote]
 	PolicyClient   SubSystem[policyclient.Client]
 	HealthTracker  SubSystem[*health.Tracker]
+
+	// NoiseRoundTripper, if set, provides an http.RoundTripper that
+	// sends requests over the control plane Noise connection.
+	NoiseRoundTripper SubSystem[http.RoundTripper]
 
 	// ExtraRootCAs, if non-nil, specifies additional trusted root CAs
 	// beyond the system roots. On Android, this includes user-installed


### PR DESCRIPTION
Adds a new NoiseRoundTripper field to tsd.Sys
to expose an http.RoundTripper to make requests
over the control plane Noise connection.

This will be used in PAM use cases soon.

Updates tailscale/corp#41800