### PR TITLE
ssh/tailssh: always set a LANG environment variable

### DIFF
--- a/ssh/tailssh/incubator.go
+++ b/ssh/tailssh/incubator.go
@@ -667,6 +667,23 @@ func handleSSHInProcess(dlogf logger.Logf, ia incubatorArgs) error {
 		return err
 	}
 
+	// For each locale environment variable, if we don't have this set in
+	// our environ already, set it. This is technically O(n^2), but there's
+	// usually very few locale environment variables, so it shouldn't be a
+	// problem.
+	root, err := os.OpenRoot("/")
+	if err != nil {
+		return fmt.Errorf("opening root directory: %w", err)
+	}
+	for k, v := range readLocale(root) {
+		found := slices.ContainsFunc(environ, func(kv string) bool {
+			return strings.HasPrefix(kv, k+"=")
+		})
+		if !found {
+			environ = append(environ, k+"="+v)
+		}
+	}
+
 	args := shellArgs(ia.isShell, ia.cmd)
 	dlogf("running %s %q", ia.loginShell, args)
 	cmd := newCommand(ia.hasTTY, ia.loginShell, environ, args)
@@ -844,22 +861,34 @@ func (ss *sshSession) launchProcess() error {
 		return err
 	}
 
-	cmd := ss.cmd
-	cmd.Env = envForUser(ss.conn.localUser)
+	env := envForUser(ss.conn.localUser)
 	for _, kv := range ss.Environ() {
-		if acceptEnvPair(kv) {
-			cmd.Env = append(cmd.Env, kv)
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok {
+			continue
+		}
+		if acceptEnvVar(k) {
+			env[k] = v
 		}
 	}
 
+	// NOTE: these environment variables are actually load-bearing in a
+	// non-obvious way: on Linux distros that compile Bash with the
+	// `SSH_SOURCE_BASHRC` option, the presence of the SSH_CLIENT
+	// environment variable causes Bash to source ~/.bashrc even for
+	// non-interactive shells, which is necessary for things like setting
+	// up the PATH correctly.
 	ci := ss.conn.info
-	cmd.Env = append(cmd.Env,
-		fmt.Sprintf("SSH_CLIENT=%s %d %d", ci.src.Addr(), ci.src.Port(), ci.dst.Port()),
-		fmt.Sprintf("SSH_CONNECTION=%s %d %s %d", ci.src.Addr(), ci.src.Port(), ci.dst.Addr(), ci.dst.Port()),
-	)
+	env["SSH_CLIENT"] = fmt.Sprintf("%s %d %d", ci.src.Addr(), ci.src.Port(), ci.dst.Port())
+	env["SSH_CONNECTION"] = fmt.Sprintf("%s %d %s %d", ci.src.Addr(), ci.src.Port(), ci.dst.Addr(), ci.dst.Port())
 
 	if ss.agentListener != nil {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("SSH_AUTH_SOCK=%s", ss.agentListener.Addr()))
+		env["SSH_AUTH_SOCK"] = ss.agentListener.Addr().String()
+	}
+
+	cmd := ss.cmd
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
 	}
 
 	ptyReq, winCh, isPty := ss.Pty()
@@ -1098,13 +1127,19 @@ func (ss *sshSession) startWithStdPipes() (err error) {
 	return ss.cmd.Start()
 }
 
-func envForUser(u *userMeta) []string {
-	return []string{
-		fmt.Sprintf("SHELL=%s", u.LoginShell()),
-		fmt.Sprintf("USER=%s", u.Username),
-		fmt.Sprintf("HOME=%s", u.HomeDir),
-		fmt.Sprintf("PATH=%s", defaultPathForUser(&u.User)),
+func envForUser(u *userMeta) map[string]string {
+	env := map[string]string{
+		"SHELL": u.LoginShell(),
+		"USER":  u.Username,
+		"HOME":  u.HomeDir,
+		"PATH":  defaultPathForUser(&u.User),
 	}
+	if root, err := os.OpenRoot("/"); err == nil {
+		for k, v := range readLocale(root) {
+			env[k] = v
+		}
+	}
+	return env
 }
 
 // updateStringInSlice mutates ss to change the first occurrence of a
@@ -1118,14 +1153,9 @@ func updateStringInSlice(ss []string, a, b string) {
 	}
 }
 
-// acceptEnvPair reports whether the environment variable key=value pair
-// should be accepted from the client. It uses the same default as OpenSSH
-// AcceptEnv.
-func acceptEnvPair(kv string) bool {
-	k, _, ok := strings.Cut(kv, "=")
-	if !ok {
-		return false
-	}
+// acceptEnvVar reports whether the environment variable "key" should be
+// accepted from the client. It uses the same default as OpenSSH AcceptEnv.
+func acceptEnvVar(k string) bool {
 	return k == "TERM" || k == "LANG" || strings.HasPrefix(k, "LC_")
 }
 

--- a/ssh/tailssh/incubator_plan9.go
+++ b/ssh/tailssh/incubator_plan9.go
@@ -408,14 +408,9 @@ func envForUser(u *userMeta) []string {
 	}
 }
 
-// acceptEnvPair reports whether the environment variable key=value pair
-// should be accepted from the client. It uses the same default as OpenSSH
-// AcceptEnv.
-func acceptEnvPair(kv string) bool {
-	k, _, ok := strings.Cut(kv, "=")
-	if !ok {
-		return false
-	}
-	_ = k
-	return true // permit anything on plan9 during bringup, for debugging at least
+// acceptEnvVar reports whether the environment variable "key" should be
+// accepted from the client. It uses the same default as OpenSSH AcceptEnv.
+func acceptEnvVar(kv string) bool {
+	// Permit anything on plan9 during bringup, for debugging at least
+	return true
 }

--- a/ssh/tailssh/tailssh_test.go
+++ b/ssh/tailssh/tailssh_test.go
@@ -1229,15 +1229,14 @@ func TestAcceptEnvPair(t *testing.T) {
 		in   string
 		want bool
 	}{
-		{"TERM=x", true},
-		{"term=x", false},
-		{"TERM", false},
-		{"LC_FOO=x", true},
-		{"LD_PRELOAD=naah", false},
-		{"TERM=screen-256color", true},
+		{"TERM", true},
+		{"term", false},
+		{"LC_FOO", true},
+		{"LD_PRELOAD", false},
+		{"TERM", true},
 	}
 	for _, tt := range tests {
-		if got := acceptEnvPair(tt.in); got != tt.want {
+		if got := acceptEnvVar(tt.in); got != tt.want {
 			t.Errorf("for %q, got %v; want %v", tt.in, got, tt.want)
 		}
 	}

--- a/ssh/tailssh/user.go
+++ b/ssh/tailssh/user.go
@@ -6,6 +6,7 @@
 package tailssh
 
 import (
+	"bytes"
 	"os"
 	"os/exec"
 	"os/user"
@@ -18,6 +19,7 @@ import (
 	"tailscale.com/envknob"
 	"tailscale.com/hostinfo"
 	"tailscale.com/util/lineiter"
+	"tailscale.com/util/mak"
 	"tailscale.com/util/osuser"
 	"tailscale.com/version/distro"
 )
@@ -150,4 +152,73 @@ func expandDefaultPathTmpl(t string, u *user.User) string {
 		return ""
 	}
 	return p
+}
+
+// runLocaleCommand runs the "locale" command and returns its output. It's a
+// variable so it can be overridden in tests.
+var runLocaleCommand = func() ([]byte, error) {
+	return exec.Command("locale").Output()
+}
+
+var sshDisableLocale = envknob.RegisterBool("TS_SSH_DISABLE_LOCALE")
+
+// readLocale returns the default LANG and LC_* environment variables to use
+// for new sessions, if they can be discovered from the system. The fs argument
+// is used to read configuration files, and may be os.DirFS("/") or a test FS.
+// The returned map is from variable name to value (e.g. "LANG" => "en_US.UTF-8").
+//
+// A nil map means no defaults found or locale support is disabled by envknob.
+func readLocale(root *os.Root) (vars map[string]string) {
+	if sshDisableLocale() {
+		return nil
+	}
+
+	// First off, if we have a default LANG set in a system-wide
+	// configuration file, use that. Note that we intentionally don't have
+	// the leading '/' prefix here since that's added by the Root.
+	for _, fpath := range []string{
+		"etc/locale.conf",
+		"etc/default/locale",
+		"etc/environment",
+	} {
+		fbytes, err := root.ReadFile(fpath)
+		if err != nil {
+			continue
+		}
+
+		for lineb := range lineiter.Bytes(fbytes) {
+			k, v, ok := bytes.Cut(lineb, []byte("="))
+			if !ok {
+				continue
+			}
+			v = bytes.TrimSpace(v)
+			if bytes.Equal(k, []byte("LANG")) || bytes.HasPrefix(k, []byte("LC_")) && len(v) > 0 {
+				ks := string(k)
+				if _, found := vars[ks]; !found {
+					mak.Set(&vars, ks, string(v))
+				}
+			}
+		}
+	}
+
+	// Next, if we're on a system with the "locale" command, try that.
+	out, err := runLocaleCommand()
+	if err != nil {
+		return vars
+	}
+	for line := range lineiter.Bytes(out) {
+		k, v, ok := bytes.Cut(line, []byte("="))
+		if !ok {
+			continue
+		}
+		v = bytes.TrimSpace(v)
+		if bytes.Equal(k, []byte("LANG")) || bytes.HasPrefix(k, []byte("LC_")) && len(v) > 0 {
+			ks := string(k)
+			if _, found := vars[ks]; !found {
+				mak.Set(&vars, ks, string(v))
+			}
+		}
+	}
+
+	return vars
 }


### PR DESCRIPTION
In Tailscale SSH, we clear the local environment before running the incubator process, which means that the incubator starts without a LANG/LC_* environment variable passed from the `tailscaled` parent. In the child, we don't use PAM, and thus never load environment variables specified by pam_env.so. Additionally, our previous implementation of envForUser didn't set a `LANG` variable by default.

On systems where we are capable of using the `login` or `su` commands to create a login shell, the launched shell will read these environment variables (e.g. from /etc/default/locale). However, this doesn't apply in all cases:
  1. Where we handle SSH in-process (handleSSHInProcess), e.g. due to SELinux being enabled.
  2. Where we are able to use `su` or `login`, but where the user's shell *isn't Bash* (see below).

In such cases, we'd launch a process without a LANG/LC_* environment set, possibly mangling output for the user.

One thing I discovered while testing this: on some distros, Bash is compiled with the SSH_SOURCE_BASHRC option. If set, and if the bash process is both the parent shell and the SSH_CLIENT variable is set, Bash loads the ~/.bashrc environment variable *even if it's not an interactive shell*. This is part of the reason that `ssh user@host cmd` works if `cmd` isn't in the system-default $PATH variable.

However, since this is a bash-specific configuration, if the user's shell is set to something else (zsh, etc.), we would never execute the ~/.zshrc file and thus never set LANG (or similar).

(I also added a comment documenting this)

It should essentially always be safe to set the LANG environment variable if not otherwise specified, and it's reset by both the `login` and `su` command (tested on Ubuntu).

Updates #TODO