### PR TITLE
wgengine/router,feature/relayserver: automatically open peer relay ports

### DIFF
--- a/feature/relayserver/relayserver.go
+++ b/feature/relayserver/relayserver.go
@@ -100,7 +100,7 @@ type extension struct {
 	logf         logger.Logf
 	ec           *eventbus.Client
 	respPub      *eventbus.Publisher[magicsock.UDPRelayAllocResp]
-	relayPortPub *eventbus.Publisher[router.RelayPortUpdate]
+	relayPortPub *eventbus.Publisher[router.RelayPortUpdate] // subscribed by (already running) wgengine/router/osrouter
 
 	mu                            syncs.Mutex                 // guards the following fields
 	shutdown                      bool                        // true if Shutdown() has been called

--- a/feature/relayserver/relayserver.go
+++ b/feature/relayserver/relayserver.go
@@ -26,6 +26,7 @@ import (
 	"tailscale.com/types/views"
 	"tailscale.com/util/eventbus"
 	"tailscale.com/wgengine/magicsock"
+	"tailscale.com/wgengine/router"
 )
 
 // featureName is the name of the feature implemented by this package.
@@ -75,6 +76,7 @@ func newExtension(logf logger.Logf, sb ipnext.SafeBackend) (ipnext.Extension, er
 	}
 	e.ec = sb.Sys().Bus.Get().Client("relayserver.extension")
 	e.respPub = eventbus.Publish[magicsock.UDPRelayAllocResp](e.ec)
+	e.relayPortPub = eventbus.Publish[router.RelayPortUpdate](e.ec)
 	eventbus.SubscribeFunc(e.ec, e.onDERPMapView)
 	eventbus.SubscribeFunc(e.ec, e.onAllocReq)
 	return e, nil
@@ -87,15 +89,18 @@ type relayServer interface {
 	GetSessions() []status.ServerSession
 	SetDERPMapView(tailcfg.DERPMapView)
 	SetStaticAddrPorts(addrPorts views.Slice[netip.AddrPort])
+	PortV4() uint16
+	PortV6() uint16
 }
 
 // extension is an [ipnext.Extension] managing the relay server on platforms
 // that import this package.
 type extension struct {
-	newServerFn func(logf logger.Logf, port uint16, onlyStaticAddrPorts bool) (relayServer, error) // swappable for tests
-	logf        logger.Logf
-	ec          *eventbus.Client
-	respPub     *eventbus.Publisher[magicsock.UDPRelayAllocResp]
+	newServerFn  func(logf logger.Logf, port uint16, onlyStaticAddrPorts bool) (relayServer, error) // swappable for tests
+	logf         logger.Logf
+	ec           *eventbus.Client
+	respPub      *eventbus.Publisher[magicsock.UDPRelayAllocResp]
+	relayPortPub *eventbus.Publisher[router.RelayPortUpdate]
 
 	mu                            syncs.Mutex                 // guards the following fields
 	shutdown                      bool                        // true if Shutdown() has been called
@@ -181,6 +186,12 @@ func (e *extension) tryStartRelayServerLocked() {
 	}
 	e.rs = rs
 	e.rs.SetDERPMapView(e.derpMapView)
+	if p := e.rs.PortV4(); p != 0 {
+		go e.relayPortPub.Publish(router.RelayPortUpdate{UDPPort: p, EndpointNetwork: "udp4"})
+	}
+	if p := e.rs.PortV6(); p != 0 {
+		go e.relayPortPub.Publish(router.RelayPortUpdate{UDPPort: p, EndpointNetwork: "udp6"})
+	}
 }
 
 func (e *extension) relayServerShouldBeRunningLocked() bool {
@@ -232,6 +243,12 @@ func (e *extension) profileStateChanged(_ ipn.LoginProfileView, prefs ipn.PrefsV
 
 func (e *extension) stopRelayServerLocked() {
 	if e.rs != nil {
+		if e.rs.PortV4() != 0 {
+			go e.relayPortPub.Publish(router.RelayPortUpdate{UDPPort: 0, EndpointNetwork: "udp4"})
+		}
+		if e.rs.PortV6() != 0 {
+			go e.relayPortPub.Publish(router.RelayPortUpdate{UDPPort: 0, EndpointNetwork: "udp6"})
+		}
 		e.rs.Close()
 	}
 	e.rs = nil

--- a/feature/relayserver/relayserver_test.go
+++ b/feature/relayserver/relayserver_test.go
@@ -19,6 +19,8 @@ import (
 	"tailscale.com/types/key"
 	"tailscale.com/types/logger"
 	"tailscale.com/types/views"
+	"tailscale.com/util/eventbus/eventbustest"
+	"tailscale.com/wgengine/router"
 )
 
 func Test_extension_profileStateChanged(t *testing.T) {
@@ -246,6 +248,8 @@ func mockRelayServerNotZeroVal() *mockRelayServer {
 type mockRelayServer struct {
 	set       bool
 	addrPorts views.Slice[netip.AddrPort]
+	portV4    uint16
+	portV6    uint16
 }
 
 func (m *mockRelayServer) Close() error { return nil }
@@ -257,6 +261,8 @@ func (m *mockRelayServer) SetDERPMapView(tailcfg.DERPMapView)  { return }
 func (m *mockRelayServer) SetStaticAddrPorts(aps views.Slice[netip.AddrPort]) {
 	m.addrPorts = aps
 }
+func (m *mockRelayServer) PortV4() uint16 { return m.portV4 }
+func (m *mockRelayServer) PortV6() uint16 { return m.portV6 }
 
 type mockSafeBackend struct {
 	sys *tsd.System
@@ -370,4 +376,47 @@ func Test_extension_handleRelayServerLifetimeLocked(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_extension_relayPortUpdates(t *testing.T) {
+	sys := tsd.NewSystem()
+	bus := sys.Bus.Get()
+	tw := eventbustest.NewWatcher(t, bus)
+
+	ipne, err := newExtension(logger.Discard, mockSafeBackend{sys})
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := ipne.(*extension)
+	e.newServerFn = func(logf logger.Logf, port uint16, onlyStaticAddrPorts bool) (relayServer, error) {
+		return &mockRelayServer{portV4: 1234, portV6: 5678}, nil
+	}
+	defer e.Shutdown()
+
+	// Use order-independent collector since events are dispatched concurrently.
+	expectRelayPortUpdates := func(phase string, want map[string]uint16) {
+		t.Helper()
+		got := make(map[string]uint16)
+		collector := func(ev router.RelayPortUpdate) (bool, error) {
+			got[ev.EndpointNetwork] = ev.UDPPort
+			return len(got) == len(want), nil
+		}
+		if err := eventbustest.Expect(tw, collector); err != nil {
+			t.Fatalf("%s: %v", phase, err)
+		}
+		for net := range want {
+			if got[net] != want[net] {
+				t.Errorf("%s: network %s: got port %d, want %d", phase, net, got[net], want[net])
+			}
+		}
+	}
+
+	// Start the relay server. Expect port updates for both families.
+	e.port = new(uint16(1))
+	e.handleRelayServerLifetimeLocked()
+	expectRelayPortUpdates("start", map[string]uint16{"udp4": 1234, "udp6": 5678})
+
+	// Stop the relay server. Expect clearing updates.
+	e.stopRelayServerLocked()
+	expectRelayPortUpdates("stop", map[string]uint16{"udp4": 0, "udp6": 0})
 }

--- a/net/udprelay/server.go
+++ b/net/udprelay/server.go
@@ -1132,6 +1132,12 @@ func (s *Server) getDERPMap() *tailcfg.DERPMap {
 	return s.derpMap
 }
 
+// PortV4 returns the UDP port the server is listening on for IPv4.
+func (s *Server) PortV4() uint16 { return s.uc4Port }
+
+// PortV6 returns the UDP port the server is listening on for IPv6.
+func (s *Server) PortV6() uint16 { return s.uc6Port }
+
 // SetStaticAddrPorts sets addr:port pairs the [Server] will advertise
 // as candidates it is potentially reachable over, in combination with
 // dynamically discovered pairs. This replaces any previously-provided static

--- a/wgengine/router/osrouter/router_linux.go
+++ b/wgengine/router/osrouter/router_linux.go
@@ -92,6 +92,8 @@ type linuxRouter struct {
 	cgnatMode         linuxfw.CGNATMode
 	magicsockPortV4   uint16
 	magicsockPortV6   uint16
+	relayPortV4       uint16
+	relayPortV6       uint16
 }
 
 func newUserspaceRouter(logf logger.Logf, tunDev tun.Device, netMon *netmon.Monitor, health *health.Tracker, bus *eventbus.Bus) (router.Router, error) {
@@ -129,6 +131,12 @@ func newUserspaceRouterAdvanced(logf logger.Logf, tunname string, netMon *netmon
 		r.logf("portUpdate(port=%v, network=%s)", pu.UDPPort, pu.EndpointNetwork)
 		if err := r.updateMagicsockPort(pu.UDPPort, pu.EndpointNetwork); err != nil {
 			r.logf("updateMagicsockPort(port=%v, network=%s) failed: %v", pu.UDPPort, pu.EndpointNetwork, err)
+		}
+	})
+	eventbus.SubscribeFunc(ec, func(pu router.RelayPortUpdate) {
+		r.logf("relayPortUpdate(port=%v, network=%s)", pu.UDPPort, pu.EndpointNetwork)
+		if err := r.updateRelayPort(pu.UDPPort, pu.EndpointNetwork); err != nil {
+			r.logf("updateRelayPort(port=%v, network=%s) failed: %v", pu.UDPPort, pu.EndpointNetwork, err)
 		}
 	})
 	r.eventClient = ec
@@ -676,6 +684,55 @@ func (r *linuxRouter) updateMagicsockPort(port uint16, network string) error {
 	return nil
 }
 
+// updateRelayPort updates the firewall rule for the relay server port.
+func (r *linuxRouter) updateRelayPort(port uint16, network string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.nfr == nil {
+		if err := r.setupNetfilterLocked(r.netfilterKind); err != nil {
+			return fmt.Errorf("could not setup netfilter: %w", err)
+		}
+	}
+
+	var relayPort *uint16
+	switch network {
+	case "udp4":
+		relayPort = &r.relayPortV4
+	case "udp6":
+		if !r.getV6FilteringAvailable() {
+			return nil
+		}
+		relayPort = &r.relayPortV6
+	default:
+		return fmt.Errorf("unsupported network %s", network)
+	}
+
+	// set the port, we'll make the firewall rule when netfilter turns back on
+	if r.netfilterMode == netfilterOff {
+		*relayPort = port
+		return nil
+	}
+
+	if *relayPort == port {
+		return nil
+	}
+
+	if *relayPort != 0 {
+		if err := r.nfr.DelMagicsockPortRule(*relayPort, network); err != nil {
+			return fmt.Errorf("del relay port rule: %w", err)
+		}
+	}
+
+	if port != 0 {
+		if err := r.nfr.AddMagicsockPortRule(port, network); err != nil {
+			return fmt.Errorf("add relay port rule: %w", err)
+		}
+	}
+
+	*relayPort = port
+	return nil
+}
+
 // setNetfilterModeLocked switches the router to the given netfilter
 // mode. Netfilter state is created or deleted appropriately to
 // reflect the new mode, and r.snatSubnetRoutes is updated to reflect
@@ -752,6 +809,16 @@ func (r *linuxRouter) setNetfilterModeLocked(mode preftype.NetfilterMode) error 
 					return fmt.Errorf("could not add magicsock port rule v6: %w", err)
 				}
 			}
+			if r.relayPortV4 != 0 {
+				if err := r.nfr.AddMagicsockPortRule(r.relayPortV4, "udp4"); err != nil {
+					return fmt.Errorf("could not add relay port rule v4: %w", err)
+				}
+			}
+			if r.relayPortV6 != 0 && r.getV6FilteringAvailable() {
+				if err := r.nfr.AddMagicsockPortRule(r.relayPortV6, "udp6"); err != nil {
+					return fmt.Errorf("could not add relay port rule v6: %w", err)
+				}
+			}
 			r.snatSubnetRoutes = false
 		case netfilterOn:
 			if err := r.nfr.DelHooks(r.logf); err != nil {
@@ -790,6 +857,16 @@ func (r *linuxRouter) setNetfilterModeLocked(mode preftype.NetfilterMode) error 
 			if r.magicsockPortV6 != 0 && r.getV6FilteringAvailable() {
 				if err := r.nfr.AddMagicsockPortRule(r.magicsockPortV6, "udp6"); err != nil {
 					return fmt.Errorf("could not add magicsock port rule v6: %w", err)
+				}
+			}
+			if r.relayPortV4 != 0 {
+				if err := r.nfr.AddMagicsockPortRule(r.relayPortV4, "udp4"); err != nil {
+					return fmt.Errorf("could not add relay port rule v4: %w", err)
+				}
+			}
+			if r.relayPortV6 != 0 && r.getV6FilteringAvailable() {
+				if err := r.nfr.AddMagicsockPortRule(r.relayPortV6, "udp6"); err != nil {
+					return fmt.Errorf("could not add relay port rule v6: %w", err)
 				}
 			}
 			r.snatSubnetRoutes = false

--- a/wgengine/router/osrouter/router_linux_test.go
+++ b/wgengine/router/osrouter/router_linux_test.go
@@ -1550,3 +1550,52 @@ func TestUpdateMagicsockPortChange(t *testing.T) {
 			oldPortRule, nfr.ipt4["filter/ts-input"])
 	}
 }
+
+func TestUpdateRelayPortChange(t *testing.T) {
+	nfr := &fakeIPTablesRunner{
+		t:    t,
+		ipt4: make(map[string][]string),
+		ipt6: make(map[string][]string),
+	}
+	nfr.ipt4["filter/ts-input"] = []string{}
+
+	r := &linuxRouter{
+		logf:          logger.Discard,
+		health:        new(health.Tracker),
+		netfilterMode: netfilterOn,
+		nfr:           nfr,
+	}
+
+	// Setting a relay port adds a rule.
+	if err := r.updateRelayPort(12345, "udp4"); err != nil {
+		t.Fatalf("failed to set initial relay port: %v", err)
+	}
+	wantRule := buildMagicsockPortRule(12345)
+	if !slices.Contains(nfr.ipt4["filter/ts-input"], wantRule) {
+		t.Errorf("firewall rule for relay port 12345 not found.\nExpected: %s\nActual rules: %v",
+			wantRule, nfr.ipt4["filter/ts-input"])
+	}
+
+	// Changing the port removes the old rule and adds the new one.
+	if err := r.updateRelayPort(54321, "udp4"); err != nil {
+		t.Fatalf("failed to update relay port: %v", err)
+	}
+	newRule := buildMagicsockPortRule(54321)
+	if !slices.Contains(nfr.ipt4["filter/ts-input"], newRule) {
+		t.Errorf("firewall rule for NEW relay port 54321 not found.\nExpected: %s\nActual rules: %v",
+			newRule, nfr.ipt4["filter/ts-input"])
+	}
+	if slices.Contains(nfr.ipt4["filter/ts-input"], wantRule) {
+		t.Errorf("firewall rule for OLD relay port 12345 still exists.\nFound: %s\nAll rules: %v",
+			wantRule, nfr.ipt4["filter/ts-input"])
+	}
+
+	// Setting port 0 removes the rule.
+	if err := r.updateRelayPort(0, "udp4"); err != nil {
+		t.Fatalf("failed to clear relay port: %v", err)
+	}
+	if slices.Contains(nfr.ipt4["filter/ts-input"], newRule) {
+		t.Errorf("firewall rule for relay port 54321 still exists after clearing.\nAll rules: %v",
+			nfr.ipt4["filter/ts-input"])
+	}
+}

--- a/wgengine/router/router.go
+++ b/wgengine/router/router.go
@@ -56,6 +56,14 @@ type PortUpdate struct {
 	EndpointNetwork string // either "udp4" or "udp6".
 }
 
+// RelayPortUpdate is an eventbus value, reporting the port and address family
+// the UDP relay server is currently listening on, so it can be threaded
+// through firewalls.
+type RelayPortUpdate struct {
+	UDPPort         uint16
+	EndpointNetwork string // either "udp4" or "udp6".
+}
+
 // HookNewUserspaceRouter is the registration point for router implementations
 // to register a constructor for userspace routers. It's meant for implementations
 // in wgengine/router/osrouter.


### PR DESCRIPTION
This adds a new event type, router.RelayPortUpdate, published from
feature/relayserver and consumed in wgengine/router to open peer relay
ports in ts-input chain we install in netfilter.

Fixes #19735