### PR TITLE
scripts/installer.sh: handle Zorin OS versions separately from Ubuntu

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -55,7 +55,7 @@ main() {
 		VERSION_MAJOR="${VERSION_ID:-}"
 		VERSION_MAJOR="${VERSION_MAJOR%%.*}"
 		case "$ID" in
-			ubuntu|pop|neon|zorin|tuxedo)
+			ubuntu|pop|neon|tuxedo)
 				OS="ubuntu"
 				if [ "${UBUNTU_CODENAME:-}" != "" ]; then
 				    VERSION="$UBUNTU_CODENAME"
@@ -335,6 +335,16 @@ main() {
 				OS="photon"
 				VERSION="$VERSION_MAJOR"
 				PACKAGETYPE="tdnf"
+				;;
+			zorin)
+				OS="ubuntu"
+				VERSION="$UBUNTU_CODENAME"
+				PACKAGETYPE="apt"
+				if [ "$VERSION_MAJOR" -lt 16 ]; then
+					APT_KEY_TYPE="legacy"
+				else
+					APT_KEY_TYPE="keyring"
+				fi
 				;;
 			steamos)
 				echo "To install Tailscale on SteamOS, please follow the instructions here:"


### PR DESCRIPTION
Their version scheme is different, even though the OS is based on Ubuntu. We need to check Zorin's version numbers to pick the right APT_KEY_TYPE.

Updates #18925