### PR TITLE
util/cibuild, cache_key_test: skip TestTsgoRevInCacheKey outside Tailscale CI

### DIFF
--- a/cache_key_test.go
+++ b/cache_key_test.go
@@ -21,8 +21,8 @@ import (
 func TestTsgoRevInCacheKey(t *testing.T) {
 	goRoot := goEnv(t, "GOROOT")
 	isTsgo := strings.Contains(goRoot, "/.cache/tsgo/")
-	if !cibuild.On() && !isTsgo {
-		t.Skip("skipping; not in CI and not using the Tailscale Go toolchain")
+	if !cibuild.OnTailscaleCI() && !isTsgo {
+		t.Skip("skipping; not in Tailscale CI and not using the Tailscale Go toolchain")
 	}
 
 	rev := strings.TrimSpace(GoToolchainRev)

--- a/util/cibuild/cibuild.go
+++ b/util/cibuild/cibuild.go
@@ -12,3 +12,15 @@ func On() bool {
 	// https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
 	return os.Getenv("GITHUB_ACTIONS") != "" || os.Getenv("CI") == "true"
 }
+
+// OnTailscaleCI reports whether the current binary is executing on
+// tailscale/tailscale's own GitHub Actions CI, as opposed to a fork's CI
+// or an unrelated downstream CI (such as a Linux distribution's package
+// build infrastructure) that also sets the generic CI=true environment
+// variable.
+func OnTailscaleCI() bool {
+	// GITHUB_REPOSITORY_OWNER is set by GitHub Actions to the owner of
+	// the repository whose workflow is running. For pull requests, this
+	// is the base repository's owner, not the fork's.
+	return os.Getenv("GITHUB_REPOSITORY_OWNER") == "tailscale"
+}


### PR DESCRIPTION
cibuild.On() returns true for any CI environment that sets CI=true,
including Alpine Linux's package build CI. TestTsgoRevInCacheKey was
guarded by cibuild.On() (or use of tsgo), so it ran under Alpine's CI
with stock Go, where go.toolchain.rev isn't blended into build cache
keys, and unsurprisingly failed.

Add cibuild.OnTailscaleCI, which keys off GITHUB_REPOSITORY_OWNER to
distinguish tailscale/tailscale's own GitHub Actions CI from arbitrary
downstream CI, and use it in TestTsgoRevInCacheKey.

Fixes #19754
