### PR TITLE
net/netcheck: respect DERPRegion.Avoid flag after full netcheck

### DIFF
--- a/net/netcheck/netcheck.go
+++ b/net/netcheck/netcheck.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"net/netip"
 	"runtime"
+	"slices"
 	"sort"
 	"sync"
 	"syscall"
@@ -1399,17 +1400,36 @@ func (c *Client) addReportHistoryAndSetPreferredDERP(rs *reportState, r *Report,
 		}
 	}
 
+	// Exclude avoided DERP regions, unless they’re the only ones with latencies.
+	candidates := make([]int, 0, len(r.RegionLatency))
+	// Collect regions that have DERPRegion.Avoid set to false.
+	// If the DERPRegion isn’t defined, assume the zero value.
+	regions := dm.Regions()
+	for regionID := range r.RegionLatency {
+		if region := regions.Get(regionID); !region.Valid() || !region.Avoid() {
+			candidates = append(candidates, regionID)
+		}
+	}
+	if len(candidates) == 0 {
+		candidates = slices.Collect(maps.Keys(r.RegionLatency))
+	}
+
 	// Then, pick which currently-alive DERP server from the
 	// current report has the best latency over the past maxAge.
 	var (
 		bestAny             time.Duration // global minimum
 		oldRegionCurLatency time.Duration // latency of old PreferredDERP
 	)
-	for regionID, d := range r.RegionLatency {
+	for _, regionID := range candidates {
 		// Scale this report's latency by any scores provided by the
 		// server; we did this for the bestRecent map above, but we
 		// don't mutate the actual reports in-place (in case scores
 		// change), so we need to do it here as well.
+		d, ok := r.RegionLatency[regionID]
+		if !ok {
+			continue
+		}
+
 		if score := scores.Get(regionID); score > 0 {
 			d = time.Duration(float64(d) * score)
 		}

--- a/net/netcheck/netcheck_test.go
+++ b/net/netcheck/netcheck_test.go
@@ -199,6 +199,7 @@ func TestAddReportHistoryAndSetPreferredDERP(t *testing.T) {
 		name        string
 		steps       []step
 		homeParams  *tailcfg.DERPHomeParams
+		derpRegions map[int]*tailcfg.DERPRegion
 		opts        *GetReportOpts
 		forcedDERP  int // if non-zero, force this DERP to be the preferred one
 		wantDERP    int // want PreferredDERP on final step
@@ -280,6 +281,18 @@ func TestAddReportHistoryAndSetPreferredDERP(t *testing.T) {
 			},
 			wantPrevLen: 2,
 			wantDERP:    2, // 2 got fast enough
+		},
+		{
+			name: "preferred_derp_hysteresis_avoid_d2",
+			derpRegions: map[int]*tailcfg.DERPRegion{
+				2: {Avoid: true}, // d2
+			},
+			steps: []step{
+				{0 * time.Second, report("d1", 4, "d2", 5)},
+				{1 * time.Second, report("d1", 4, "d2", 1)},
+			},
+			wantPrevLen: 2,
+			wantDERP:    1, // 2 got fast enough, but is avoided
 		},
 		{
 			name: "derp_home_params",
@@ -451,6 +464,33 @@ func TestAddReportHistoryAndSetPreferredDERP(t *testing.T) {
 			wantPrevLen: 3,
 			wantDERP:    0,
 		},
+		{
+			name: "avoid_all",
+			derpRegions: map[int]*tailcfg.DERPRegion{
+				1: {Avoid: true}, // d1
+				2: {Avoid: true}, // d2
+				3: {Avoid: true}, // d3
+				4: {Avoid: true}, // d4
+			},
+			steps: []step{
+				{0 * time.Second, report("d1", 3, "d2", 2, "d3", 4, "d4", 5)},
+			},
+			wantPrevLen: 1,
+			wantDERP:    2, // all regions are avoided and 2 is best
+		},
+		{
+			name: "avoid_all_but_one",
+			derpRegions: map[int]*tailcfg.DERPRegion{
+				1: {Avoid: true}, // d1
+				2: {Avoid: true}, // d2
+				4: {Avoid: true}, // d4
+			},
+			steps: []step{
+				{0 * time.Second, report("d1", 3, "d2", 2, "d3", 4, "d4", 5)},
+			},
+			wantPrevLen: 1,
+			wantDERP:    3, // 3 is the only one not avoided
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -459,7 +499,10 @@ func TestAddReportHistoryAndSetPreferredDERP(t *testing.T) {
 				TimeNow:            func() time.Time { return fakeTime },
 				ForcePreferredDERP: tt.forcedDERP,
 			}
-			dm := &tailcfg.DERPMap{HomeParams: tt.homeParams}
+			dm := &tailcfg.DERPMap{
+				HomeParams: tt.homeParams,
+				Regions:    tt.derpRegions,
+			}
 			rs := &reportState{
 				c:     c,
 				start: fakeTime,


### PR DESCRIPTION
The DERPRegion.Avoid flag signals to the client that it should not pick this DERP region as its home region, unless it has no other choice.

Although this was respected during an incremental netcheck and also on the initial netcheck, it wasn’t in subsequent full netchecks. In the following example, derp-2 and derp-8 should both be avoided:

	netcheck: report: udp=true v6=false v6os=false mapvarydest=false portmap= v4a=192.0.2.108:41641 derp=1 derpdist=1v4:23ms,2v4:67ms,8v4:75ms
	netcheck: report: udp=true v6=false v6os=false mapvarydest= portmap= v4a=192.0.2.108:41641 derp=1 derpdist=1v4:23ms
	netcheck: report: udp=true v6=false v6os=false mapvarydest=false portmap= v4a=192.0.2.108:41641 derp=2 derpdist=1v4:24ms,2v4:9ms,8v4:75ms
	magicsock: home DERP changing from derp-1 [23ms] to derp-2 [9ms]
	magicsock: home is now derp-2 (sfo)
	netcheck: report: udp=true v6=false v6os=false mapvarydest=false portmap= v4a=192.0.2.108:41641 derp=2 derpdist=1v4:23ms,2v4:8ms

This patch rectifies this by first picking a DERP home from non-avoided regions that have latency measurements in the netcheck report. If no such regions exist, the client falls back on the regions for which it does have measurements.

Updates #8603
Updates #13969
Updates tailscale/corp#24697