### PR TITLE
util/linuxfw: return error instead of nil pointer dereference

### DIFF
--- a/util/linuxfw/nftables_runner.go
+++ b/util/linuxfw/nftables_runner.go
@@ -416,6 +416,9 @@ func (e errorChainNotFound) Error() string {
 // getChainFromTable returns the chain with the given name from the given table.
 // Note that a chain name is unique within a table.
 func getChainFromTable(c *nftables.Conn, table *nftables.Table, name string) (*nftables.Chain, error) {
+	if table == nil {
+		return nil, errors.New("nil table")
+	}
 	chains, err := c.ListChainsOfTableFamily(table.Family)
 	if err != nil {
 		return nil, fmt.Errorf("list chains: %w", err)

--- a/util/linuxfw/nftables_runner.go
+++ b/util/linuxfw/nftables_runner.go
@@ -417,7 +417,7 @@ func (e errorChainNotFound) Error() string {
 // Note that a chain name is unique within a table.
 func getChainFromTable(c *nftables.Conn, table *nftables.Table, name string) (*nftables.Chain, error) {
 	if table == nil {
-		return nil, errors.New("nil table")
+		return nil, fmt.Errorf("could not get chain %q: table not initialized", name)
 	}
 	chains, err := c.ListChainsOfTableFamily(table.Family)
 	if err != nil {


### PR DESCRIPTION
Issue #19737 ran into a nil pointer dereference, the cause of which was fixed by #19761. If we end up on this code path with a nil table again, we should bubble that up as an error (which is logged by the health warning system) rather than failing catastrophically.

Updates #19737.