### PR TITLE
net/dns/resolver, types/dnstype: support custom DoH resolvers

### DIFF
--- a/net/dns/resolver/doh_test.go
+++ b/net/dns/resolver/doh_test.go
@@ -49,9 +49,9 @@ func TestDoH(t *testing.T) {
 
 	for _, urlBase := range prefixes {
 		t.Run(urlBase, func(t *testing.T) {
-			c, ok := f.getKnownDoHClientForProvider(urlBase)
-			if !ok {
-				t.Fatal("expected DoH")
+			c, err := f.getDoHClient(urlBase, nil)
+			if err != nil {
+				t.Fatal(err)
 			}
 			res, err := f.sendDoH(context.Background(), urlBase, c, someDNSQuestion(t))
 			if err != nil {

--- a/net/dns/resolver/forwarder.go
+++ b/net/dns/resolver/forwarder.go
@@ -19,6 +19,7 @@ import (
 	"net/netip"
 	"net/url"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -311,7 +312,11 @@ type forwarder struct {
 
 	mu syncs.Mutex // guards following
 
-	dohClient map[string]*http.Client // urlBase -> client
+	// dohClient caches HTTP clients used to dial DoH resolvers.
+	// The cached entry records the IPs the client was built with so the
+	// entry is discarded if a later config provides different IPs for
+	// the same URL.
+	dohClient map[string]dohClientEntry // urlBase -> entry
 
 	// routes are per-suffix resolvers to use, with
 	// the most specific routes first.
@@ -512,31 +517,76 @@ func (f *forwarder) packetListener(ip netip.Addr) (nettype.PacketListenerWithNet
 	return nettype.MakePacketListenerWithNetIP(lc), nil
 }
 
-// getKnownDoHClientForProvider returns an HTTP client for a specific DoH
-// provider named by its DoH base URL (like "https://dns.google/dns-query").
+// dohClientEntry is a cached HTTP client for a DoH resolver, tagged with
+// the IPs it was built with so the cache can be invalidated if a later
+// config provides different IPs for the same URL.
+type dohClientEntry struct {
+	c   *http.Client
+	ips []netip.Addr
+}
+
+// getDoHClient returns an HTTP client to dial the DoH resolver at urlBase.
+// The only failure mode is urlBase failing to parse.
 //
-// The returned client race/Happy Eyeballs dials all IPs for urlBase (usually
-// 4), as statically known by the publicdns package.
-func (f *forwarder) getKnownDoHClientForProvider(urlBase string) (c *http.Client, ok bool) {
+// The IPs used to dial come from one of three sources, in priority order:
+//
+//  1. bootstrap, when non-nil. Typically supplied via
+//     [dnstype.Resolver.BootstrapResolution]. When non-empty those IPs are
+//     dialed; when explicitly empty (non-nil but len 0) the client skips
+//     publicdns and falls through to dial-time resolution.
+//  2. The publicdns package, when urlBase is a well-known DoH provider
+//     (e.g. https://dns.google/dns-query) and bootstrap was nil.
+//  3. Resolved at dial time by [tsdial.Dialer.UserDial]: in-memory MagicDNS
+//     first (so tailnet hostnames like https://coredns.foo.ts.net work
+//     without configuration), then the system resolver. UserDial routes
+//     Tailscale-internal addresses through the peer dialer automatically.
+//
+// In cases 1 (non-empty) and 2 the returned client race/Happy Eyeballs
+// dials all of the IPs in parallel. In case 3, system DNS may return
+// multiple IPs and the same race applies; a MagicDNS hit is single-IP per
+// tailnet name and only that address is dialed.
+//
+// Cached clients are invalidated when the effective IPs change for the
+// same URL.
+func (f *forwarder) getDoHClient(urlBase string, bootstrap []netip.Addr) (c *http.Client, err error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if c, ok := f.dohClient[urlBase]; ok {
-		return c, true
+
+	// bootstrap takes precedence when set at all. nil means "fall back to
+	// publicdns"; an explicitly empty list means "skip publicdns" and is
+	// preserved as a len-0 slice so the static-IP branch below is bypassed.
+	ips := bootstrap
+	if ips == nil {
+		ips = publicdns.DoHIPsOfBase(urlBase)
 	}
-	allIPs := publicdns.DoHIPsOfBase(urlBase)
-	if len(allIPs) == 0 {
-		return nil, false
-	}
-	dohURL, err := url.Parse(urlBase)
-	if err != nil {
-		return nil, false
+	if len(ips) == 0 {
+		metricDNSFwdDoHAutoResolve.Add(1)
 	}
 
-	dialer := dnscache.Dialer(f.getDialerType(), &dnscache.Resolver{
-		SingleHost:             dohURL.Hostname(),
-		SingleHostStaticResult: allIPs,
-		Logf:                   f.logf,
-	})
+	if ent, ok := f.dohClient[urlBase]; ok && slices.Equal(ent.ips, ips) {
+		return ent.c, nil
+	}
+
+	dohURL, err := url.Parse(urlBase)
+	if err != nil {
+		return nil, fmt.Errorf("parsing DoH URL %q: %w", urlBase, err)
+	}
+
+	var dialer netx.DialFunc
+	if len(ips) > 0 {
+		// Static-IP path: known provider or caller-supplied bootstrap.
+		dialer = dnscache.Dialer(f.getDialerType(), &dnscache.Resolver{
+			SingleHost:             dohURL.Hostname(),
+			SingleHostStaticResult: ips,
+			Logf:                   f.logf,
+		})
+	} else {
+		// Auto-resolve path: UserDial handles MagicDNS, system DNS, and
+		// tailnet-aware routing in one step.
+		f.logf("doh: building auto-resolve client for %q", urlBase)
+		dialer = f.dialer.UserDial
+	}
+
 	tlsConfig := &tls.Config{
 		// Enforce TLS 1.3, as all of our supported DNS-over-HTTPS servers are compatible with it
 		// (see tailscale.com/net/dns/publicdns/publicdns.go).
@@ -559,11 +609,8 @@ func (f *forwarder) getKnownDoHClientForProvider(urlBase string) (c *http.Client
 			TLSClientConfig: tlsConfig,
 		},
 	}
-	if f.dohClient == nil {
-		f.dohClient = map[string]*http.Client{}
-	}
-	f.dohClient[urlBase] = c
-	return c, true
+	mak.Set(&f.dohClient, urlBase, dohClientEntry{c: c, ips: ips})
+	return c, nil
 }
 
 const dohType = "application/dns-message"
@@ -641,24 +688,19 @@ func (f *forwarder) send(ctx context.Context, fq *forwardQuery, rr resolverAndDe
 		return res, nil
 	}
 	if strings.HasPrefix(rr.name.Addr, "https://") {
-		// Only known DoH providers are supported currently. Specifically, we
-		// only support DoH providers where we can TCP connect to them on port
-		// 443 at the same IP address they serve normal UDP DNS from (1.1.1.1,
-		// 8.8.8.8, 9.9.9.9, etc.) That's why OpenDNS and custom DoH providers
-		// aren't currently supported. There's no backup DNS resolution path for
-		// them.
 		urlBase := rr.name.Addr
-		if hc, ok := f.getKnownDoHClientForProvider(urlBase); ok {
-			res, err := f.sendDoH(ctx, urlBase, hc, fq.packet)
-			if err != nil {
-				return nil, err
-			}
-			// Check response size and set TC flag if needed (only for UDP queries)
-			res = checkResponseSizeAndSetTC(res, fq.packet, fq.family, f.logf)
-			return res, nil
+		hc, err := f.getDoHClient(urlBase, rr.name.BootstrapResolution)
+		if err != nil {
+			metricDNSFwdErrorType.Add(1)
+			return nil, err
 		}
-		metricDNSFwdErrorType.Add(1)
-		return nil, fmt.Errorf("arbitrary https:// resolvers not supported yet")
+		res, err := f.sendDoH(ctx, urlBase, hc, fq.packet)
+		if err != nil {
+			return nil, err
+		}
+		// Check response size and set TC flag if needed (only for UDP queries)
+		res = checkResponseSizeAndSetTC(res, fq.packet, fq.family, f.logf)
+		return res, nil
 	}
 	if strings.HasPrefix(rr.name.Addr, "tls://") {
 		metricDNSFwdErrorType.Add(1)

--- a/net/dns/resolver/forwarder_test.go
+++ b/net/dns/resolver/forwarder_test.go
@@ -209,11 +209,11 @@ func TestGetRCode(t *testing.T) {
 
 var testDNS = flag.Bool("test-dns", false, "run tests that require a working DNS server")
 
-func TestGetKnownDoHClientForProvider(t *testing.T) {
+func TestGetDoHClient_KnownProvider(t *testing.T) {
 	var fwd forwarder
-	c, ok := fwd.getKnownDoHClientForProvider("https://dns.google/dns-query")
-	if !ok {
-		t.Fatal("not found")
+	c, err := fwd.getDoHClient("https://dns.google/dns-query", nil)
+	if err != nil {
+		t.Fatal(err)
 	}
 	if !*testDNS {
 		t.Skip("skipping without --test-dns")
@@ -224,6 +224,109 @@ func TestGetKnownDoHClientForProvider(t *testing.T) {
 	}
 	defer res.Body.Close()
 	t.Logf("Got: %+v", res)
+}
+
+func TestGetDoHClient_Bootstrap(t *testing.T) {
+	const url = "https://doh.example.com/dns-query"
+	ipsA := []netip.Addr{netip.MustParseAddr("203.0.113.10"), netip.MustParseAddr("2001:db8::1")}
+	ipsB := []netip.Addr{netip.MustParseAddr("203.0.113.20")}
+
+	var fwd forwarder
+
+	c1, err := fwd.getDoHClient(url, ipsA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c1 == nil {
+		t.Fatal("nil client")
+	}
+
+	// Same IPs => cached client is reused.
+	c2, _ := fwd.getDoHClient(url, ipsA)
+	if c1 != c2 {
+		t.Error("expected cached client to be reused for unchanged bootstrap IPs")
+	}
+
+	// Different IPs => client is rebuilt.
+	c3, _ := fwd.getDoHClient(url, ipsB)
+	if c3 == c1 {
+		t.Error("expected client to be rebuilt when bootstrap IPs change")
+	}
+}
+
+func TestGetDoHClient_BootstrapOverridesKnownProvider(t *testing.T) {
+	// Supplying bootstrap IPs for a publicdns-known URL takes precedence
+	// over the publicdns table. The cached client built with bootstrap IPs
+	// must be a different client than the one built from publicdns alone.
+	var fwd forwarder
+	override := []netip.Addr{netip.MustParseAddr("203.0.113.99")}
+
+	cBootstrap, err := fwd.getDoHClient("https://dns.google/dns-query", override)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cPublic, err := fwd.getDoHClient("https://dns.google/dns-query", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cBootstrap == cPublic {
+		t.Error("expected bootstrap-overridden client to differ from publicdns-only client")
+	}
+}
+
+func TestGetDoHClient_ExplicitEmptyBootstrapForcesAutoResolve(t *testing.T) {
+	// An explicitly-empty (but non-nil) BootstrapResolution for a
+	// publicdns-known URL skips the publicdns table and falls through to
+	// auto-resolve. The resulting client must differ from the publicdns one.
+	fwd := forwarder{logf: t.Logf}
+
+	cPublic, err := fwd.getDoHClient("https://dns.google/dns-query", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cAuto, err := fwd.getDoHClient("https://dns.google/dns-query", []netip.Addr{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cAuto == cPublic {
+		t.Error("expected explicit-empty bootstrap to force a distinct (auto-resolve) client")
+	}
+}
+
+func TestGetDoHClient_AutoResolve(t *testing.T) {
+	// An unknown DoH URL with no bootstrap IPs still returns a client; the
+	// hostname is resolved at dial time via the auto-resolve chain.
+	const url = "https://doh.example.com/dns-query"
+	fwd := forwarder{logf: t.Logf}
+
+	c1, err := fwd.getDoHClient(url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c1 == nil {
+		t.Fatal("nil client")
+	}
+
+	// Cached on repeat call.
+	c2, _ := fwd.getDoHClient(url, nil)
+	if c1 != c2 {
+		t.Error("expected cached client to be reused")
+	}
+
+	// Supplying bootstrap IPs later promotes the cached entry to the
+	// static-IP path and rebuilds the client.
+	ips := []netip.Addr{netip.MustParseAddr("203.0.113.10")}
+	c3, _ := fwd.getDoHClient(url, ips)
+	if c3 == c1 {
+		t.Error("expected client to be rebuilt when bootstrap IPs are added")
+	}
+}
+
+func TestGetDoHClient_InvalidURL(t *testing.T) {
+	var fwd forwarder
+	if _, err := fwd.getDoHClient("https://[invalid", nil); err == nil {
+		t.Error("expected an error for an unparseable URL")
+	}
 }
 
 func BenchmarkNameFromQuery(b *testing.B) {

--- a/net/dns/resolver/tsdns.go
+++ b/net/dns/resolver/tsdns.go
@@ -1438,6 +1438,10 @@ var (
 	metricDNSFwdDoHErrorTransport = clientmetric.NewCounter("dns_query_fwd_doh_error_transport")
 	metricDNSFwdDoHErrorBody      = clientmetric.NewCounter("dns_query_fwd_doh_error_body")
 
+	// metricDNSFwdDoHAutoResolve counts DoH queries whose server hostname
+	// was resolved at dial time (no publicdns match, no BootstrapResolution).
+	metricDNSFwdDoHAutoResolve = clientmetric.NewCounter("dns_query_fwd_doh_auto_resolve")
+
 	metricDNSResolveLocal             = clientmetric.NewCounter("dns_resolve_local")
 	metricDNSResolveLocalErrorOnion   = clientmetric.NewCounter("dns_resolve_local_error_onion")
 	metricDNSResolveLocalErrorMissing = clientmetric.NewCounter("dns_resolve_local_error_missing")

--- a/types/dnstype/dnstype.go
+++ b/types/dnstype/dnstype.go
@@ -17,24 +17,33 @@ type Resolver struct {
 	//  - A plain IP address for a "classic" UDP+TCP DNS resolver.
 	//    This is the common format as sent by the control plane.
 	//  - An IP:port, for tests.
-	//  - "https://resolver.com/path" for DNS over HTTPS; currently
-	//    as of 2022-09-08 only used for certain well-known resolvers
-	//    (see the publicdns package) for which the IP addresses to dial DoH are
-	//    known ahead of time, so bootstrap DNS resolution is not required.
+	//  - "https://resolver.com/path" for DNS over HTTPS. The IPs to dial come
+	//    from BootstrapResolution when that field is set, otherwise from the
+	//    publicdns package when the URL is a well-known provider, otherwise
+	//    resolved at dial time via in-memory MagicDNS or the system resolver.
+	//    See BootstrapResolution for the nil-vs-empty distinction.
 	//  - "http://node-address:port/path" for DNS over HTTP over WireGuard. This
 	//    is implemented in the PeerAPI for exit nodes and app connectors.
 	//  - [TODO] "tls://resolver.com" for DNS over TCP+TLS
 	Addr string `json:",omitempty"`
 
-	// BootstrapResolution is an optional suggested resolution for the
-	// DoT/DoH resolver, if the resolver URL does not reference an IP
-	// address directly.
-	// BootstrapResolution may be empty, in which case clients should
-	// look up the DoT/DoH server using their local "classic" DNS
-	// resolver.
+	// BootstrapResolution lists IP addresses to use to reach the DoT/DoH
+	// resolver, overriding any IPs that the client would otherwise infer
+	// from Addr.
 	//
-	// As of 2022-09-08, BootstrapResolution is not yet used.
-	BootstrapResolution []netip.Addr `json:",omitempty"`
+	// The field carries three distinguishable states:
+	//
+	//   - nil (field absent): the client falls back to its own resolution.
+	//     For DoH, that means the publicdns package when Addr is a
+	//     well-known provider, else resolution at dial time.
+	//   - non-empty: the listed IPs are used directly, taking precedence
+	//     over publicdns and any dial-time resolution.
+	//   - explicit empty list: the client uses dial-time resolution even
+	//     if Addr would otherwise match a well-known provider.
+	//
+	// To preserve the nil-vs-empty distinction on the wire, this field is
+	// intentionally not tagged `omitempty`.
+	BootstrapResolution []netip.Addr
 
 	// UseWithExitNode designates that this resolver should continue to be used when an
 	// exit node is in use. Normally, DNS resolution is delegated to the exit node but
@@ -71,6 +80,7 @@ func (r *Resolver) Equal(other *Resolver) bool {
 	}
 
 	return r.Addr == other.Addr &&
+		(r.BootstrapResolution == nil) == (other.BootstrapResolution == nil) &&
 		slices.Equal(r.BootstrapResolution, other.BootstrapResolution) &&
 		r.UseWithExitNode == other.UseWithExitNode
 }

--- a/types/dnstype/dnstype_test.go
+++ b/types/dnstype/dnstype_test.go
@@ -69,6 +69,33 @@ func TestResolverEqual(t *testing.T) {
 			want: false,
 		},
 		{
+			// nil and an explicitly-empty slice are distinct on the wire:
+			// nil means "fall back to the client's own resolution" while
+			// an empty list means "skip the client's static-IP fallback".
+			name: "not-equal-bootstrap-nil-vs-empty",
+			a: &Resolver{
+				Addr:                "dns.example.com",
+				BootstrapResolution: nil,
+			},
+			b: &Resolver{
+				Addr:                "dns.example.com",
+				BootstrapResolution: []netip.Addr{},
+			},
+			want: false,
+		},
+		{
+			name: "equal-bootstrap-both-empty",
+			a: &Resolver{
+				Addr:                "dns.example.com",
+				BootstrapResolution: []netip.Addr{},
+			},
+			b: &Resolver{
+				Addr:                "dns.example.com",
+				BootstrapResolution: []netip.Addr{},
+			},
+			want: true,
+		},
+		{
 			name: "equal-UseWithExitNode",
 			a:    &Resolver{Addr: "dns.example.com", UseWithExitNode: true},
 			b:    &Resolver{Addr: "dns.example.com", UseWithExitNode: true},


### PR DESCRIPTION
Currently, the forwarder refuses any `https://` resolver not in the publicdns table with `arbitrary https:// resolvers not supported yet`. This wires up `dnstype.Resolver.BootstrapResolution` (defined in 2022, never consulted) and uses `tsdial.Dialer.UserDial` to resolve at dial time when no static IPs are configured.

Closes #15724, #17560 (client side portion)
Updates #74, #16278, #14707 (DoH portion).

Alternative implementation of #17559. @sailorfrag's comment on that PR suggested an IP-hint approach with a lookup fallback rather than a recursive sub-resolver, which is what this PR does. Diff is about half the size and reuses existing primitives (`UserDial`) instead of adding new ones.

IP selection for `https://` resolvers, in priority order:

1. `BootstrapResolution` when non-nil. Non-empty IPs are dialed directly. An explicit empty list (non-nil, len 0) skips publicdns and falls through to (3).
2. publicdns table when the URL matches a known provider.
3. Dial-time via `UserDial`: in-memory MagicDNS first, then system DNS. Tailnet IPs route through the peer dialer automatically, so something like `https://coredns.foo.ts.net` works without any configuration.

The publicdns path is unchanged in shape: same IPs, same dialer, same Happy Eyeballs race, same idle-conn timeout, same cache. `resolversWithDelays` is also untouched, so IP-shaped resolvers still get the DoH-plus-UDP-companion treatment.  While unlikely to happen anytime soon, the ability to override the entries from the publicdns table is intentional, so that if bootstrap ips do need to change for those resolvers, its at least _possible_ for the control plane to resolve that issue without a client change.  The ability to skip publicdns is also intentional, so one may more easily test the behaviors of what happens with the automatic lookup while using common public DoH resolvers. 

Bits worth flagging:

- `getKnownDoHClientForProvider` becomes `getDoHClient(urlBase, bootstrap)`. Returns `(*http.Client, error)` since the only failure is `url.Parse`.
- The `dohClient` cache stores the IPs each entry was built with, so a config that changes bootstrap IPs for a URL rebuilds the client on the next query.
- Dropped `omitempty` on `BootstrapResolution` to preserve the nil-vs-empty distinction across JSON. `Resolver.Equal` updated to match. No other in-tree caller appears to depend on the omit-on-empty.
- New `dns_query_fwd_doh_auto_resolve` clientmetric counts queries that took the dial-time path.
- One log line per distinct URL on first auto-resolve client construction, so logs show which URLs are using the new path.

Behavior change: a non-publicdns `https://` URL with no bootstrap IPs used to fail fast with `arbitrary https:// resolvers not supported yet`. Now it tries to dial. A typo'd URL still fails, just later and with a less specific error (TLS, timeout, refused... but the same warning as any resolver which is non-functional today). Setting `BootstrapResolution` constrains the new path to known IPs if that matters. Captive-portal behavior for a DoH-only global resolver is the same either way.

DoT (`tls://`) and `http://hostname:port` aren't touched here. Each is a separate change with its own dial machinery, happy to send follow-ups if there's interest.

## Test plan

- `go test ./net/dns/... ./types/dnstype/...` passes
- `go vet ./...` clean
- Manually verified with a custom DoH resolver pointing at an in-tailnet CoreDNS, configured via split DNS.

New tests:

- `TestGetDoHClient_Bootstrap`, `_BootstrapOverridesKnownProvider`, `_ExplicitEmptyBootstrapForcesAutoResolve`, `_AutoResolve`, `_InvalidURL`
- Two new cases in `TestResolverEqual` covering nil-vs-empty `BootstrapResolution`
