### PR TITLE
ipn/ipnlocal: filter unreachable tailnet split-DNS resolvers (opt-in)

### DIFF
--- a/cmd/tailscale/cli/dns-status.go
+++ b/cmd/tailscale/cli/dns-status.go
@@ -84,6 +84,14 @@ var dnsStatusArgs struct {
 	json bool
 }
 
+// dnsResolverKey returns a value comparable across two [jsonoutput.DNSResolverInfo] entries: distinct fields are joined by NUL bytes (which can't appear in Addr or in any IP string), so two infos with the same Addr and BootstrapResolution share a key and no other combination does.
+func dnsResolverKey(r jsonoutput.DNSResolverInfo) string {
+	if len(r.BootstrapResolution) == 0 {
+		return r.Addr
+	}
+	return r.Addr + "\x00" + strings.Join(r.BootstrapResolution, "\x00")
+}
+
 // makeDNSResolverInfo converts a dnstype.Resolver to a jsonoutput.DNSResolverInfo.
 func makeDNSResolverInfo(r *dnstype.Resolver) jsonoutput.DNSResolverInfo {
 	info := jsonoutput.DNSResolverInfo{Addr: r.Addr}
@@ -94,6 +102,20 @@ func makeDNSResolverInfo(r *dnstype.Resolver) jsonoutput.DNSResolverInfo {
 		}
 	}
 	return info
+}
+
+// resolverInfoMap converts a suffix -> resolvers map (as used in [tailcfg.DNSConfig.Routes] and [ipnstate.Status.FilteredSplitDNSRoutes]) into its [jsonoutput] form. Returns nil if src is empty so the JSON encoder can drop the field via omitzero.
+func resolverInfoMap(src map[string][]*dnstype.Resolver) map[string][]jsonoutput.DNSResolverInfo {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string][]jsonoutput.DNSResolverInfo, len(src))
+	for k, v := range src {
+		for _, r := range v {
+			out[k] = append(out[k], makeDNSResolverInfo(r))
+		}
+	}
+	return out
 }
 
 func runDNSStatus(ctx context.Context, args []string) error {
@@ -127,12 +149,8 @@ func runDNSStatus(ctx context.Context, args []string) error {
 			data.Resolvers = append(data.Resolvers, makeDNSResolverInfo(r))
 		}
 
-		data.SplitDNSRoutes = make(map[string][]jsonoutput.DNSResolverInfo)
-		for k, v := range dnsConfig.Routes {
-			for _, r := range v {
-				data.SplitDNSRoutes[k] = append(data.SplitDNSRoutes[k], makeDNSResolverInfo(r))
-			}
-		}
+		data.SplitDNSRoutes = resolverInfoMap(dnsConfig.Routes)
+		data.FilteredSplitDNSRoutes = resolverInfoMap(s.FilteredSplitDNSRoutes)
 
 		for _, r := range dnsConfig.FallbackResolvers {
 			data.FallbackResolvers = append(data.FallbackResolvers, makeDNSResolverInfo(r))
@@ -234,7 +252,18 @@ func formatDNSStatusText(data *jsonoutput.DNSStatusResult, all bool) string {
 		fmt.Fprintf(&sb, "  (no routes configured: split DNS disabled)\n")
 	}
 	for _, k := range slices.Sorted(maps.Keys(data.SplitDNSRoutes)) {
+		// Skip resolvers the local client dropped at reconfig time -- they're not actually installed on the OS, even though the upstream config still lists them. The dropped set stays in --json's FilteredSplitDNSRoutes for diagnostics.
+		var dropped map[string]bool
+		if filtered := data.FilteredSplitDNSRoutes[k]; len(filtered) > 0 {
+			dropped = make(map[string]bool, len(filtered))
+			for _, d := range filtered {
+				dropped[dnsResolverKey(d)] = true
+			}
+		}
 		for _, r := range data.SplitDNSRoutes[k] {
+			if dropped[dnsResolverKey(r)] {
+				continue
+			}
 			fmt.Fprintf(&sb, "  - %-30s -> %v", k, r.Addr)
 			if r.BootstrapResolution != nil {
 				fmt.Fprintf(&sb, " (bootstrap: %v)", r.BootstrapResolution)

--- a/cmd/tailscale/cli/jsonoutput/dns.go
+++ b/cmd/tailscale/cli/jsonoutput/dns.go
@@ -68,6 +68,17 @@ type DNSStatusResult struct {
 	// Tailscale's built-in resolver (100.100.100.100).
 	SplitDNSRoutes map[string][]DNSResolverInfo `json:",omitzero"`
 
+	// FilteredSplitDNSRoutes maps domain suffixes to the resolvers
+	// that the local client decided not to install at netmap
+	// reconfig time. Populated only when
+	// [tailcfg.NodeAttrFilterSplitDNSUnreachableTailscaleResolvers]
+	// is set and at least one resolver was filtered for targeting an
+	// unreachable Tailscale destination. Suffixes whose entire
+	// resolver list was filtered are absent from SplitDNSRoutes;
+	// suffixes with a partial filter are present in both maps with
+	// disjoint resolver lists.
+	FilteredSplitDNSRoutes map[string][]DNSResolverInfo `json:",omitzero"`
+
 	// FallbackResolvers are like Resolvers but only used when
 	// split DNS needs explicit default resolvers.
 	FallbackResolvers []DNSResolverInfo `json:",omitzero"`

--- a/ipn/ipnlocal/dnsconfig.go
+++ b/ipn/ipnlocal/dnsconfig.go
@@ -1,0 +1,155 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package ipnlocal
+
+import (
+	"net/netip"
+	"slices"
+	"strings"
+
+	"github.com/gaissmai/bart"
+	"tailscale.com/net/dns"
+	"tailscale.com/net/tsaddr"
+	"tailscale.com/types/dnstype"
+	"tailscale.com/types/netmap"
+	"tailscale.com/types/views"
+	"tailscale.com/util/dnsname"
+	"tailscale.com/wgengine/wgcfg"
+)
+
+// filterUnreachableSplitDNS removes from dcfg.Routes any resolver whose tailnet-space destination IPs aren't reachable.
+//
+// A destination IP is reachable if it's covered by a peer AllowedIPs entry in cfg, by nm.SelfNode.AllowedIPs (own addresses + approved subnet/app-connector routes; the local node handles those as loopback), or by an advertised 4via6 prefix in nm.SelfNode.Hostinfo.RoutableIPs (netstack handles those as loopback even before control approves the route, per #12016).
+//
+// If a suffix's entire resolver list is filtered out, the suffix is also deleted from dcfg.Routes. dcfg.DefaultResolvers (the "." suffix) is never filtered.
+//
+// AllowedIPs (not the flattened rcfg.Routes) is the source of peer reachability because [peerRoutes] collapses every tailnet IPv6 into one fd7a:115c:a1e0::/48 prefix — a routing-table optimisation that erases the per-destination granularity we need here.
+//
+// Returns a suffix -> filtered-resolvers map for diagnostic surfacing. Keys match the wire format used by [tailcfg.DNSConfig.Routes] (no trailing dot). Returns nil if nothing was filtered.
+func filterUnreachableSplitDNS(dcfg *dns.Config, cfg *wgcfg.Config, nm *netmap.NetworkMap) (filtered map[string][]*dnstype.Resolver) {
+	magicDNSSuffixLower := strings.ToLower(nm.MagicDNSSuffix())
+
+	// routes is the union of every peer's AllowedIPs: the set of tailnet destinations currently reachable through wireguard.
+	routes := &bart.Lite{}
+	for _, p := range cfg.Peers {
+		for _, pfx := range p.AllowedIPs {
+			routes.Insert(pfx)
+		}
+	}
+	// Self addresses and any approved subnet/app-connector routes are reachable as loopback; both live in nm.SelfNode.AllowedIPs. Additionally, 4via6 routes the node advertises function locally even before control approves them — netstack handles them as loopback (see #12016) — so add advertised RoutableIPs in the 4via6 range too.
+	if nm.SelfNode.Valid() {
+		for _, pfx := range nm.SelfNode.AllowedIPs().All() {
+			routes.Insert(pfx)
+		}
+		if hi := nm.SelfNode.Hostinfo(); hi.Valid() {
+			viaRange := tsaddr.TailscaleViaRange()
+			for _, pfx := range hi.RoutableIPs().All() {
+				if viaRange.Contains(pfx.Addr()) {
+					routes.Insert(pfx)
+				}
+			}
+		}
+	}
+
+	// isReachable reports whether ip is reachable: non-Tailscale (out of scope; we don't probe) or a tailnet IP with a covering peer route.
+	isReachable := func(ip netip.Addr) bool {
+		return !tsaddr.IsTailscaleIP(ip) || routes.Contains(ip)
+	}
+
+	// peerIPs is built lazily on the first resolver whose Addr is a URL hostname (vs. an IP form). A config that only uses IP-literal resolvers pays nothing for materialising the per-peer IP slices.
+	var peerIPs map[string][]netip.Addr
+
+	// shouldDrop reports whether to drop r: it has tailnet-intent IPs and none are reachable.
+	shouldDrop := func(r *dnstype.Resolver) bool {
+		if ips := r.BootstrapResolution; len(ips) > 0 {
+			return !slices.ContainsFunc(ips, isReachable)
+		}
+		if ipp, ok := r.IPPort(); ok {
+			return !isReachable(ipp.Addr())
+		}
+		host := strings.ToLower(r.Hostname())
+		if host == "" {
+			return false
+		}
+		if ip, err := netip.ParseAddr(host); err == nil {
+			// URL form with an IP literal as host, e.g. http://100.64.0.5/dns-query.
+			return !isReachable(ip)
+		}
+		if peerIPs == nil {
+			peerIPs = peerIPsFromNetmap(nm)
+		}
+		if found := peerIPs[host]; len(found) > 0 {
+			return !slices.ContainsFunc(found, isReachable)
+		}
+		// Not in netmap. Tailnet-suffixed names are tailnet-intent but unresolvable (peer in the tailnet but no grant exposes it to this node, peer offline, or typo); everything else is non-Tailscale and out of scope.
+		return dnsname.HasSuffix(host, magicDNSSuffixLower)
+	}
+
+	for suffix, rs := range dcfg.Routes {
+		// In-place partition: reuse rs's backing array for survivors; collect drops separately for the diagnostic map.
+		keep := rs[:0]
+		var dropped []*dnstype.Resolver
+		for _, r := range rs {
+			if shouldDrop(r) {
+				dropped = append(dropped, r)
+			} else {
+				keep = append(keep, r)
+			}
+		}
+		if len(dropped) == 0 {
+			continue
+		}
+		if filtered == nil {
+			filtered = make(map[string][]*dnstype.Resolver)
+		}
+		filtered[suffix.WithoutTrailingDot()] = dropped
+		if len(keep) == 0 {
+			delete(dcfg.Routes, suffix)
+		} else {
+			dcfg.Routes[suffix] = keep
+		}
+	}
+	return filtered
+}
+
+// peerIPsFromNetmap returns a map from lowercase, dot-stripped hostname to the IPs control associates with that hostname in nm. Self populates first so a DoH URL like https://self.<magic>/dns-query (a resolver on the local node) resolves to the loopback IPs; peers fill in next; ExtraRecords fill remaining gaps. The first source to claim a name wins.
+func peerIPsFromNetmap(nm *netmap.NetworkMap) map[string][]netip.Addr {
+	m := make(map[string][]netip.Addr, len(nm.Peers)+1)
+	addHostname := func(rawName string, addrPfxs views.Slice[netip.Prefix]) {
+		name := strings.TrimSuffix(strings.ToLower(rawName), ".")
+		if name == "" || addrPfxs.Len() == 0 {
+			return
+		}
+		if _, ok := m[name]; ok {
+			return // first source wins; in real netmaps names are unique anyway
+		}
+		addrs := make([]netip.Addr, 0, addrPfxs.Len())
+		for _, pfx := range addrPfxs.All() {
+			addrs = append(addrs, pfx.Addr())
+		}
+		m[name] = addrs
+	}
+	if nm.SelfNode.Valid() {
+		addHostname(nm.SelfNode.Name(), nm.SelfNode.Addresses())
+	}
+	for _, p := range nm.Peers {
+		addHostname(p.Name(), p.Addresses())
+	}
+	for _, rec := range nm.DNS.ExtraRecords {
+		if rec.Type != "" {
+			continue
+		}
+		name := strings.TrimSuffix(strings.ToLower(rec.Name), ".")
+		if name == "" {
+			continue
+		}
+		if _, ok := m[name]; ok {
+			continue // first source wins
+		}
+		if ip, err := netip.ParseAddr(rec.Value); err == nil {
+			m[name] = []netip.Addr{ip}
+		}
+	}
+	return m
+}

--- a/ipn/ipnlocal/dnsconfig_test.go
+++ b/ipn/ipnlocal/dnsconfig_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"net/netip"
 	"reflect"
+	"slices"
 	"testing"
 
 	"tailscale.com/appc"
@@ -21,6 +22,7 @@ import (
 	"tailscale.com/util/cloudenv"
 	"tailscale.com/util/dnsname"
 	"tailscale.com/util/set"
+	"tailscale.com/wgengine/wgcfg"
 )
 
 func ipps(ippStrs ...string) (ipps []netip.Prefix) {
@@ -551,4 +553,194 @@ func TestAllowExitNodeDNSProxyToServeName(t *testing.T) {
 		}
 	}
 
+}
+
+// mkResolver builds a [dnstype.Resolver] with optional bootstrap IPs. Used by the split-DNS filter tests.
+func mkResolver(addr string, bootstrap ...string) *dnstype.Resolver {
+	r := &dnstype.Resolver{Addr: addr}
+	for _, b := range bootstrap {
+		r.BootstrapResolution = append(r.BootstrapResolution, netip.MustParseAddr(b))
+	}
+	return r
+}
+
+// TestFilterUnreachableSplitDNS exercises the per-resolver reachability filter against a richly-loaded multi-peer netmap that covers every input shape and reachability source the filter sees in practice. One suffix (example.com) carries the bulk of the resolvers so partial-drop assertions verify each lookup path in a single pass; a second suffix (all-dropped.tailnet) has only an unreachable resolver to exercise full-suffix removal.
+//
+// Tailnet shape ("company.ts.net"):
+//   - self: own CGNAT + ULA address, an approved 10.99.0.0/24 subnet in AllowedIPs, and two unapproved-but-advertised 4via6 prefixes in Hostinfo.RoutableIPs (netstack handles these as loopback even pre-approval, per #12016).
+//   - office-coredns: CGNAT-only peer.
+//   - subnet-router: holds only fd7a:115c:a1e0:b1a:0:1:a00:0/104 in cfg.Peers -- 4via6 SiteID=1 covering IPv4 10.0.0.0/8.
+//   - dual-stack-host: CGNAT + tailnet-ULA, both routed in cfg.Peers.
+//   - invisible-peer: in nm.Peers (so hostname lookup finds it) but absent from cfg.Peers because no grant exposes it to the local node.
+func TestFilterUnreachableSplitDNS(t *testing.T) {
+	const magicSuffix = "company.ts.net"
+
+	nm := &netmap.NetworkMap{
+		SelfNode: (&tailcfg.Node{
+			Name:      "self." + magicSuffix + ".",
+			Addresses: ipps("100.97.96.172", "fd7a:115c:a1e0::c83a:307a"),
+			// AllowedIPs is the union of own addresses and *approved* advertised routes.
+			AllowedIPs: ipps("100.97.96.172", "fd7a:115c:a1e0::c83a:307a", "10.99.0.0/24"),
+			Hostinfo: (&tailcfg.Hostinfo{
+				// RoutableIPs is everything advertised, approved or not. The two 4via6 prefixes below are intentionally *not* in AllowedIPs above (control hasn't approved them) -- the filter must still treat them as reachable because netstack handles them as loopback.
+				RoutableIPs: []netip.Prefix{
+					netip.MustParsePrefix("10.99.0.0/24"),
+					netip.MustParsePrefix("fd7a:115c:a1e0:b1a:0:1337:808:808/128"),
+					netip.MustParsePrefix("fd7a:115c:a1e0:b1a:0:1338::/96"),
+				},
+			}).View(),
+		}).View(),
+		DNS: tailcfg.DNSConfig{
+			ExtraRecords: []tailcfg.DNSRecord{
+				// Extra-only hostname pointing at a routed peer IP.
+				{Name: "coredns-extra.company.ts.net", Value: "100.64.0.10"},
+				// Same name as the dual-stack-host peer but pointing at an unrouted IP. Peer's real IPs must win, otherwise the unrouted IP would (incorrectly) filter the resolver.
+				{Name: "dual-stack-host.company.ts.net", Value: "100.96.0.99"},
+				// Non-empty Type: skipped.
+				{Name: "skip-me.company.ts.net", Type: "AAAA", Value: "fd7a:115c:a1e0::dead"},
+			},
+		},
+	}
+	addPeer := func(id tailcfg.NodeID, name string, ips ...string) {
+		nm.Peers = append(nm.Peers, (&tailcfg.Node{
+			ID:        id,
+			Name:      name + "." + magicSuffix + ".",
+			Addresses: ipps(ips...),
+		}).View())
+	}
+	addPeer(1, "office-coredns", "100.64.0.10")
+	addPeer(2, "subnet-router", "100.64.0.20", "fd7a:115c:a1e0::20")
+	addPeer(3, "dual-stack-host", "100.64.0.30", "fd7a:115c:a1e0::30")
+	addPeer(4, "invisible-peer", "100.64.0.99") // in nm.Peers; absent from cfg.Peers below (no grant exposes it)
+
+	cfg := &wgcfg.Config{
+		Peers: []wgcfg.Peer{
+			{AllowedIPs: []netip.Prefix{netip.MustParsePrefix("100.64.0.10/32")}},                                                  // office-coredns
+			{AllowedIPs: []netip.Prefix{netip.MustParsePrefix("fd7a:115c:a1e0:b1a:0:1:a00:0/104")}},                                // subnet-router 4via6 for 10.0.0.0/8
+			{AllowedIPs: []netip.Prefix{netip.MustParsePrefix("100.64.0.30/32"), netip.MustParsePrefix("fd7a:115c:a1e0::30/128")}}, // dual-stack-host
+			// invisible-peer intentionally absent (no grant from local node).
+		},
+	}
+
+	keep := []*dnstype.Resolver{
+		mkResolver("100.64.0.10:53"),                                                  // peer (CGNAT, IP:port)
+		mkResolver("100.64.0.10"),                                                     // peer (bare IP, no port -- common control-plane form)
+		mkResolver("100.97.96.172"),                                                   // self loopback v4
+		mkResolver("fd7a:115c:a1e0::c83a:307a"),                                       // self loopback v6
+		mkResolver("10.99.0.42"),                                                      // RFC1918: always kept (non-tailnet IP, out of scope)
+		mkResolver("8.8.8.8:53"),                                                      // public UDP
+		mkResolver("fd7a:115c:a1e0:b1a:0:1337:808:808"),                               // 4via6 advertised + unapproved (netstack-local per #12016)
+		mkResolver("[fd7a:115c:a1e0:b1a:0:1338:8efb:d6ce]:53"),                        // inside advertised 4via6 /96
+		mkResolver("[fd7a:115c:a1e0:b1a:0:1:a00:5]:53"),                               // 4via6 routed via subnet-router (SiteID 1, encodes 10.0.0.5)
+		mkResolver("[fd7a:115c:a1e0::30]:53"),                                         // dual-stack-host v6
+		mkResolver("http://100.64.0.10/dns-query"),                                    // URL form with IP literal (routed)
+		mkResolver("https://self.company.ts.net/dns-query"),                           // URL hostname -> self loopback
+		mkResolver("https://office-coredns.company.ts.net/dns-query"),                 // URL hostname -> peer
+		mkResolver("https://OFFICE-COREDNS.Company.TS.NET/dns-query"),                 // case-folded peer lookup
+		mkResolver("https://coredns-extra.company.ts.net/dns-query"),                  // URL hostname -> ExtraRecord
+		mkResolver("https://dual-stack-host.company.ts.net/dns-query"),                // peer shadows ExtraRecord (peer IPs are routed)
+		mkResolver("https://coredns.other.ts.net/dns-query"),                          // non-magic suffix -> out of scope
+		mkResolver("https://dns.google/dns-query"),                                    // public hostname -> out of scope
+		mkResolver("https://nope.example.com/dns-query", "100.64.0.10"),               // bootstrap: routed
+		mkResolver("https://nope.example.com/dns-query", "100.64.0.77", "1.1.1.1"),    // bootstrap: unrouted tailnet IP + public -- public makes it reachable
+		mkResolver("https://nope.example.com/dns-query", "100.64.0.77", "100.64.0.10"), // bootstrap: unrouted + routed tailnet -- routed makes it reachable
+		mkResolver("https://[invalid"),                                                // malformed Addr: conservatively kept (no IPs to decide on)
+	}
+	drop := []*dnstype.Resolver{
+		mkResolver("100.64.0.77:53"),                                       // CGNAT IP with no peer
+		mkResolver("100.64.0.77"),                                          // bare CGNAT, no peer
+		mkResolver("fd7a:115c:a1e0::6a3a:dead"),                            // ULA, no peer
+		mkResolver("[fd7a:115c:a1e0:b1a:0:2:a00:5]:53"),                    // 4via6 wrong SiteID (no covering route)
+		mkResolver("http://100.64.0.77/dns-query"),                         // URL form, unrouted IP literal
+		mkResolver("https://invisible-peer.company.ts.net/dns-query"),      // URL hostname -> peer in nm.Peers but not visible to this node (no grant; absent from cfg.Peers)
+		mkResolver("https://nosuchhost.company.ts.net/dns-query"),          // magic suffix, unresolvable
+		mkResolver("https://nope.example.com/dns-query", "100.64.0.77"),    // bootstrap: only unrouted tailnet IP
+	}
+
+	dcfg := &dns.Config{
+		Routes: map[dnsname.FQDN][]*dnstype.Resolver{
+			// slices.Concat returns a fresh slice so the filter's in-place mutation doesn't disturb keep/drop, which are reused below as expected values.
+			dnsname.FQDN("example.com."):         slices.Concat(keep, drop),
+			dnsname.FQDN("all-dropped.tailnet."): {mkResolver("100.64.0.77:53")},
+		},
+	}
+
+	gotFiltered := filterUnreachableSplitDNS(dcfg, cfg, nm)
+
+	wantSurviving := map[string][]*dnstype.Resolver{"example.com": keep}
+	wantFiltered := map[string][]*dnstype.Resolver{
+		"example.com":         drop,
+		"all-dropped.tailnet": {mkResolver("100.64.0.77:53")},
+	}
+
+	gotSurviving := map[string][]*dnstype.Resolver{}
+	for k, v := range dcfg.Routes {
+		gotSurviving[k.WithoutTrailingDot()] = v
+	}
+	if !reflect.DeepEqual(gotSurviving, wantSurviving) {
+		t.Errorf("surviving routes mismatch\n got: %s\nwant: %s", spew(gotSurviving), spew(wantSurviving))
+	}
+	if !reflect.DeepEqual(gotFiltered, wantFiltered) {
+		t.Errorf("filtered mismatch\n got: %s\nwant: %s", spew(gotFiltered), spew(wantFiltered))
+	}
+}
+
+// TestFilterUnreachableSplitDNS_Edges covers configurations missing setup that the comprehensive scenario assumes (empty resolver lists, no MagicDNSSuffix).
+func TestFilterUnreachableSplitDNS_Edges(t *testing.T) {
+	tests := []struct {
+		name         string
+		magicSuffix  string
+		inRoutes     map[string][]*dnstype.Resolver
+		wantRoutes   map[string][]*dnstype.Resolver
+		wantFiltered map[string][]*dnstype.Resolver
+	}{
+		{
+			// Empty resolver list: nothing to filter, suffix preserved as-is.
+			name:        "empty_resolver_list_preserved",
+			magicSuffix: "foo.ts.net",
+			inRoutes:    map[string][]*dnstype.Resolver{"corp.example": {}},
+			wantRoutes:  map[string][]*dnstype.Resolver{"corp.example": {}},
+		},
+		{
+			// No MagicDNSSuffix (no SelfNode): the magic-suffix gating step is skipped, so a tailnet-looking hostname with no netmap entry is kept (treated as public/out-of-scope).
+			name:        "no_magic_suffix_kept",
+			magicSuffix: "",
+			inRoutes:    map[string][]*dnstype.Resolver{"corp.example": {mkResolver("https://coredns.foo.ts.net/dns-query")}},
+			wantRoutes:  map[string][]*dnstype.Resolver{"corp.example": {mkResolver("https://coredns.foo.ts.net/dns-query")}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nm := &netmap.NetworkMap{}
+			if tt.magicSuffix != "" {
+				nm.SelfNode = (&tailcfg.Node{Name: "self." + tt.magicSuffix + "."}).View()
+			}
+			routes := map[dnsname.FQDN][]*dnstype.Resolver{}
+			for k, v := range tt.inRoutes {
+				routes[dnsname.FQDN(k+".")] = v
+			}
+			dcfg := &dns.Config{Routes: routes}
+			cfg := &wgcfg.Config{}
+			gotFiltered := filterUnreachableSplitDNS(dcfg, cfg, nm)
+
+			gotRoutes := map[string][]*dnstype.Resolver{}
+			for k, v := range dcfg.Routes {
+				gotRoutes[k.WithoutTrailingDot()] = v
+			}
+			if !reflect.DeepEqual(gotRoutes, tt.wantRoutes) {
+				t.Errorf("dcfg.Routes mismatch\n got: %s\nwant: %s", spew(gotRoutes), spew(tt.wantRoutes))
+			}
+			if !reflect.DeepEqual(gotFiltered, tt.wantFiltered) {
+				t.Errorf("filtered mismatch\n got: %s\nwant: %s", spew(gotFiltered), spew(tt.wantFiltered))
+			}
+		})
+	}
+}
+
+func spew(m map[string][]*dnstype.Resolver) string {
+	if m == nil {
+		return "nil"
+	}
+	b, _ := json.Marshal(m)
+	return string(b)
 }

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"math"
 	"math/rand/v2"
 	"net"
@@ -411,6 +412,9 @@ type LocalBackend struct {
 	// getCertForTest is used to retrieve TLS certificates in tests.
 	// See [LocalBackend.ConfigureCertsForTest].
 	getCertForTest func(hostname string) (*TLSCertKeyPair, error)
+
+	// filteredSplitDNSRoutes is the result of the most recent [filterUnreachableSplitDNS] call; nil when nothing was filtered.
+	filteredSplitDNSRoutes map[string][]*dnstype.Resolver
 
 	// existsPendingAuthReconfig tracks if a goroutine is waiting to
 	// acquire [LocalBackend]'s mutex inside of [LocalBackend.AuthReconfig].
@@ -1361,6 +1365,10 @@ func (b *LocalBackend) UpdateStatus(sb *ipnstate.StatusBuilder) {
 		if nm != nil {
 			s.CertDomains = append([]string(nil), nm.DNS.CertDomains...)
 			s.MagicDNSSuffix = nm.MagicDNSSuffix()
+			if len(b.filteredSplitDNSRoutes) > 0 {
+				// Shallow clone: resolver pointers are effectively immutable, but a caller mutating the map shouldn't be able to reach back into b.
+				s.FilteredSplitDNSRoutes = maps.Clone(b.filteredSplitDNSRoutes)
+			}
 			if s.CurrentTailnet == nil {
 				s.CurrentTailnet = &ipnstate.TailnetStatus{}
 			}
@@ -5439,6 +5447,12 @@ func (b *LocalBackend) authReconfigLocked() {
 			extras := extraAllowedIPsFn(cfg.Peers[i].PublicKey)
 			cfg.Peers[i].AllowedIPs = extras.AppendTo(cfg.Peers[i].AllowedIPs)
 		}
+	}
+
+	// Opt-in client-side filter; see [filterUnreachableSplitDNS]. The cap is checked against the same nm snapshot we're filtering against, rather than via cn.SelfHasCap (which would re-lock the nodeBackend and could read a newer netmap).
+	b.filteredSplitDNSRoutes = nil
+	if nm.AllCaps.Contains(tailcfg.NodeAttrFilterSplitDNSUnreachableTailscaleResolvers) {
+		b.filteredSplitDNSRoutes = filterUnreachableSplitDNS(dcfg, cfg, nm)
 	}
 
 	err = b.e.Reconfig(cfg, rcfg, dcfg)

--- a/ipn/ipnstate/ipnstate.go
+++ b/ipn/ipnstate/ipnstate.go
@@ -19,6 +19,7 @@ import (
 
 	"tailscale.com/tailcfg"
 	"tailscale.com/tka"
+	"tailscale.com/types/dnstype"
 	"tailscale.com/types/key"
 	"tailscale.com/types/views"
 	"tailscale.com/util/dnsname"
@@ -84,6 +85,9 @@ type Status struct {
 	// version of the Tailscale client that's available. Depending on
 	// the platform and client settings, it may not be available.
 	ClientVersion *tailcfg.ClientVersion
+
+	// FilteredSplitDNSRoutes maps domain suffixes to resolvers the local client dropped from [tailcfg.DNSConfig.Routes] at netmap reconfig time. Non-empty only when [tailcfg.NodeAttrFilterSplitDNSUnreachableTailscaleResolvers] is set.
+	FilteredSplitDNSRoutes map[string][]*dnstype.Resolver `json:",omitempty"`
 }
 
 // TKAKey describes a key trusted by tailnet lock.

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -1115,6 +1115,8 @@ func (h *Handler) serveCertDomains(w http.ResponseWriter, r *http.Request) {
 
 // serveDNSConfig returns the [tailcfg.DNSConfig] from the current netmap.
 // It returns 503 if no netmap has been received yet.
+//
+// Client-side filtering decisions live on [ipnstate.Status] (via /status), not here.
 func (h *Handler) serveDNSConfig(w http.ResponseWriter, r *http.Request) {
 	if !h.PermitRead {
 		http.Error(w, "dns-config access denied", http.StatusForbidden)

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -2660,6 +2660,9 @@ const (
 	// if needed.
 	NodeAttrDisableSplitDNSWhenNoCustomResolvers NodeCapability = "disable-split-dns-when-no-custom-resolvers"
 
+	// NodeAttrFilterSplitDNSUnreachableTailscaleResolvers tells the client to drop a split-DNS resolver from a suffix's resolver list at reconfig time when its destination is in the Tailscale IP space with no covering peer route; a suffix with no surviving resolver is removed entirely so queries fall through to the OS's other resolvers. DefaultResolvers ("." suffix) is untouched. Dropped entries are surfaced as ipnstate.Status.FilteredSplitDNSRoutes (visible via `tailscale dns status`).
+	NodeAttrFilterSplitDNSUnreachableTailscaleResolvers NodeCapability = "filter-split-dns-unreachable-tailscale-resolvers"
+
 	// NodeAttrDisableLocalDNSOverrideViaNRPT indicates that the node's DNS manager should not
 	// create a default (catch-all) Windows NRPT rule when "Override local DNS" is enabled.
 	// Without this rule, Windows 8.1 and newer devices issue parallel DNS requests to DNS servers

--- a/types/dnstype/dnstype.go
+++ b/types/dnstype/dnstype.go
@@ -8,6 +8,7 @@ package dnstype
 
 import (
 	"net/netip"
+	"net/url"
 	"slices"
 )
 
@@ -59,6 +60,18 @@ func (r *Resolver) IPPort() (ipp netip.AddrPort, ok bool) {
 		return ipp, true
 	}
 	return
+}
+
+// Hostname returns the host portion of r.Addr: the URL host for "https://"/"http://"/"tls://" forms, or the IP for any form accepted by [Resolver.IPPort]. Returns "" if r.Addr is empty or malformed. IPs from the IPPort path are canonicalized by [netip.Addr.String], so e.g. an embedded-IPv4 form like "[fd7a:115c:a1e0:b1a:0:1:1.2.3.4]:53" comes back rewritten as "fd7a:115c:a1e0:b1a:0:1:102:304" -- compare by re-parsing the result rather than string-matching against the original. URL-host IPs are returned verbatim from the URL.
+func (r *Resolver) Hostname() string {
+	if ipp, ok := r.IPPort(); ok {
+		return ipp.Addr().String()
+	}
+	// IPPort returns ok=false for empty Addr and for URL forms (h/t prefix); url.Parse handles both safely (empty input parses to an empty URL with empty Hostname).
+	if u, err := url.Parse(r.Addr); err == nil {
+		return u.Hostname()
+	}
+	return ""
 }
 
 // Equal reports whether r and other are equal.

--- a/types/dnstype/dnstype_test.go
+++ b/types/dnstype/dnstype_test.go
@@ -91,3 +91,38 @@ func TestResolverEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestResolverHostname(t *testing.T) {
+	tests := []struct {
+		addr string
+		want string
+	}{
+		{"https://coredns.foo.ts.net:8443/dns-query", "coredns.foo.ts.net"},
+		{"https://coredns.foo.ts.net/dns-query", "coredns.foo.ts.net"},
+		{"http://100.64.0.5:8053/dns-query", "100.64.0.5"},
+		{"http://[fd7a:115c:a1e0::abcd]:8053", "fd7a:115c:a1e0::abcd"},
+		{"tls://dns.example.com:853", "dns.example.com"},
+		{"100.64.0.5:53", "100.64.0.5"},
+		// Embedded-v4 form is canonicalized by netip.ParseAddr to plain hex; that's fine for our callers (they re-parse the result, not string-compare it).
+		{"[fd7a:115c:a1e0:b1a:0:1:1.2.3.4]:53", "fd7a:115c:a1e0:b1a:0:1:102:304"},
+		{"8.8.8.8:53", "8.8.8.8"},
+		// Bare IPs without a port (the common control-plane format).
+		{"100.64.0.5", "100.64.0.5"},
+		{"8.8.8.8", "8.8.8.8"},
+		{"fd7a:115c:a1e0::abcd", "fd7a:115c:a1e0::abcd"},
+		{"2001:db8::1", "2001:db8::1"},
+		// Malformed / empty / unsupported forms.
+		{"https://[invalid", ""},
+		{"not a url", ""},
+		{"corp-resolver.example.com", ""}, // bare hostname, no scheme or port: not a supported Resolver.Addr form
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.addr, func(t *testing.T) {
+			r := &Resolver{Addr: tt.addr}
+			if got := r.Hostname(); got != tt.want {
+				t.Errorf("Hostname(%q) = %q, want %q", tt.addr, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A split-DNS suffix that points at a resolver reachable only over Tailscale -- e.g. `https://coredns.foo.ts.net/dns-query` against a peer hostname, or a 4via6-style address like `[fd7a:115c:a1e0:b1a:0:1:a00:5]:53` -- hangs queries for that suffix when the route to the resolver isn't installed. The OS resolver hands queries to tailscaled, and tailscaled has no working path to the upstream. For broad suffixes like `*.com` this manifests as broken DNS for unrelated names.

Updates #4058 and #12403. Both stay open because this PR is cap-gated; nothing changes for tailnets that don't have the new attribute set. The split-DNS variant of these bugs disappears for opted-in tailnets.

Related to #19789 (custom DoH resolvers). They work well together but neither depends on the other: the 4via6 UDP case is the primary motivation here and works against plain main. The two PRs touch disjoint files; either can merge first.

## How it works

Gated by the new `NodeAttrFilterSplitDNSUnreachableTailscaleResolvers` capability (off by default). When set, `authReconfig` filters `dcfg.Routes` before `wgengine.Reconfig`.

For each resolver, the filter takes the first non-empty of:

1. `BootstrapResolution`, if set.
2. A bare IP, `IP:port`, or `[IPv6]:port` in `Addr`.
3. An IP literal as the URL host (e.g. `https://100.64.0.5/dns-query`).
4. Netmap-derived IPs for a URL hostname -- self addresses, peer addresses, or an `ExtraRecord` value (first source wins).

A resolver is **dropped** iff none of its candidate IPs is reachable. An IP is reachable when either:

- It's a non-Tailscale IP (`tsaddr.IsTailscaleIP` returns false), or
- It's a Tailscale IP covered by one of: a peer `AllowedIPs` entry in the wireguard config about to be installed; `nm.SelfNode.AllowedIPs` (own addresses + approved subnet/app-connector routes, served as loopback); or a 4via6 prefix advertised in `nm.SelfNode.Hostinfo.RoutableIPs` (netstack handles those as loopback even pre-approval, per #12016).

The "non-Tailscale = reachable" rule is deliberate. The filter is built conservatively: it never drops a resolver because of a non-Tailscale destination, even one we'd technically know is unreachable (e.g. an RFC1918 address served via a subnet route that isn't installed). Bringing those into scope would require classifying every non-Tailscale IP against the full route set and getting the call right; the operator put that IP in their config, so we just trust it. Operators who do want such resolvers covered can encode the destination in 4via6 form, which lands in `tsaddr.IsTailscaleIP`'s ULA range.

So a resolver with at least one non-Tailscale IP, or at least one routed tailnet IP, is kept; a resolver whose every candidate is an unrouted tailnet IP is dropped.

A URL hostname that resolves to nothing in the netmap is treated as unreachable iff it's under `nm.MagicDNSSuffix()` (peer in the tailnet but not visible to this node -- no grant exposes it -- or offline, or a typo); anything else is assumed to be a non-tailnet name and kept.

A suffix whose entire resolver list is filtered is removed from `dcfg.Routes` entirely, so tailscaled is never registered as the resolver for that suffix and queries for those names fall through to the OS's other configured resolvers. A suffix with a *partial* filter stays in `dcfg.Routes` with only the surviving resolvers; the dropped ones appear in `FilteredSplitDNSRoutes` (see below) for diagnosis.

`DefaultResolvers` (the `.` suffix) is never filtered -- if an operator sets the global resolver to an unreachable tailnet address, that's their call.

## Worked example

A tailnet `company.ts.net` with one peer `office-coredns` (`100.64.0.10`) routed in `cfg.Peers`, a subnet-router peer carrying only `fd7a:115c:a1e0:b1a:0:1:a00:0/104` (4via6 SiteID 1 covering `10.0.0.0/8`), and an `invisible-peer` (`100.64.0.99`) that's in the tailnet (so it shows up in `nm.Peers`) but no grant exposes it to the local node, so it's absent from `cfg.Peers`. One split-DNS suffix `example.com` with the following resolvers:

| Resolver under `example.com.` | Outcome | Reason |
|---|---|---|
| `100.64.0.10:53` | ✅ kept | peer-covered |
| `100.64.0.77:53` | ❌ dropped | tailnet IP, no peer covers it |
| `[fd7a:115c:a1e0:b1a:0:1:a00:5]:53` | ✅ kept | 4via6 SiteID 1, covered by subnet-router |
| `[fd7a:115c:a1e0:b1a:0:2:a00:5]:53` | ❌ dropped | 4via6 SiteID 2, no covering route |
| `8.8.8.8:53` | ✅ kept | non-Tailscale IP, out of scope |
| `https://office-coredns.company.ts.net/dns-query` | ✅ kept | hostname → peer IPs |
| `https://invisible-peer.company.ts.net/dns-query` | ❌ dropped | hostname resolves to a peer the local node has no grant to reach |
| `https://nosuchhost.company.ts.net/dns-query` | ❌ dropped | tailnet-suffixed hostname with no netmap entry |
| `https://dns.google/dns-query` | ✅ kept | non-magic suffix, out of scope |
| `https://nope.example.com/dns-query` + bootstrap `[100.64.0.77]` | ❌ dropped | only candidate IP is unrouted |

The dropped resolvers land in `Status.FilteredSplitDNSRoutes["example.com"]`. Because at least one survives, the suffix stays in `dcfg.Routes` (with only the survivors) and `*.example.com` queries still reach tailscaled.

`TestFilterUnreachableSplitDNS` extends the same scenario with self-loopback, advertised-but-unapproved 4via6 (per #12016), case folding, ExtraRecord lookup, peer-shadows-ExtraRecord precedence, malformed Addr handling, and bootstrap mixes — see the test for the full set.

## Why this is useful beyond #4058

Split-DNS today is global per tailnet: the same suffix -> resolver mapping is delivered to every node. There's per-user scoping, but no mechanism to scope a split-DNS entry by attributes of the receiving device, and none on the foreseeable control-plane roadmap. That means the same user's Mac and iPhone get the same split-DNS config, even when they should be treated differently.

Routes, on the other hand, are already grant-controlled. By making split-DNS resolver reachability follow route reachability, this change lets an operator scope split-DNS using the route grants they already write -- no new control-plane mechanism, no new policy language, just an opt-in client-side cap. Some uses this opens up:

- **Different device classes for the same user.** Grant the route to the corp CoreDNS to the user's Mac but not their iPhone. The Mac resolves `*.corp.example` through CoreDNS; the iPhone falls through to public DNS for the same suffix.
- **DNS64 carve-outs.** A DNS64-issuing tailnet resolver reached over IPv6 is unusable from a Chrome browser on Chrome OS (Chrome's in-sandbox network stack doesn't follow the system's IPv6 routes). Grant the route only to non-Chrome-OS devices and the DNS suffix effectively disappears on Chrome OS without touching the global split-DNS config.
- **Geo steering.** Region A's nodes have the route to the regional resolver and use it; region B's nodes don't and fall through to their own resolution.
- **Testing and migrations.** Roll out a new in-tailnet resolver behind a route grant; nodes without the grant keep using whatever they had, no DNS-config edit required.

This could in principle live in the control plane instead -- compute the per-device reachable resolver set centrally and ship only the resolvers a given node could actually reach. Doing it client-side gets us the functionality now without a wire-protocol or schema change. Split-DNS isn't directly grant-scoped in the control plane today, but route reachability is; deriving DNS reachability from route reachability turns split-DNS into an implicitly grant-scoped feature downstream of grants, with no new policy plumbing. The cap gates the opt-in so non-opted-in nodes keep today's exact semantics.

## Out of scope

- **Global resolver (`.` suffix).** @awly's reduced repro in #12403 uses Global Nameservers configured to `[100.64.0.1, 8.8.8.8]` with ACLs blocking the first; that's `DefaultResolvers`, not `Routes`. Filtering it would mean silently re-routing every DNS query to the public internet, which is a bigger policy call than the operator opted into.
- **Subnet-routed RFC1918 and other non-Tailscale IPs** like `10.0.0.5:53`. The conservative design above treats every non-Tailscale destination as reachable; use the 4via6 form to pull the destination into `tsaddr.IsTailscaleIP`'s ULA range if you want it in scope.
- **Active probing or per-query state.** Filter runs once per netmap reload. Deterministic, no liveness checks beyond "is the destination covered by a route in the set about to be installed."
- **Text rendering of `FilteredSplitDNSRoutes`** in non-JSON `tailscale dns status` output. JSON has the full set for dashboarding / MDM cases; the text view simply subtracts the filtered entries from `Split DNS Routes` so what's displayed matches what's installed on the OS. A dedicated "filtered out" section in text output is a small follow-up.

## Bits worth flagging

- Adds `dnstype.Resolver.Hostname()` as a sibling to the existing `IPPort()`. Returns the host portion of `Addr` for URL forms (`http://`, `https://`, `tls://`), `host:port`, `[ipv6]:port`, and bare IP literals (v4 or v6). The bare-IP-no-port case is the documented "common format as sent by the control plane" but had no dedicated parser; the new method makes it accessible and `TestResolverHostname` pins the contract (including the embedded-v4-in-v6 canonicalisation surprise).
- Adds `ipnstate.Status.FilteredSplitDNSRoutes`: the suffix -> filtered-resolvers map produced by the most recent reconfig. Surfaced through the existing `/localapi/v0/status` endpoint alongside other client-side diagnostic state (`Health`, `MagicDNSSuffix`, `CertDomains`, etc.). `tailcfg.DNSConfig` and `/localapi/v0/dns-config` are unchanged.
- `tailscale dns status --json` gains a `FilteredSplitDNSRoutes` block mirroring the existing `SplitDNSRoutes` shape, populated from the same `Status()` response the command already loads for `CurrentTailnet` info. No extra roundtrip. The text output subtracts filtered entries from its `Split DNS Routes` section so the on-screen view matches what's actually installed.
- Self-hostname resolves to self's own tailnet addresses for this filter, so a DoH URL like `https://self.<magic>/dns-query` pointing at a resolver running on the local node correctly survives.
- Inside the filter, peer/self/ExtraRecord lookups go through a per-call canonical-name map built **lazily** on the first hostname-addressed resolver. Big tailnets (thousands of peers) pay O(N+M) once, only when needed; an all-IP-literal resolver config pays zero map-build cost. First-source-wins ordering: self -> peer -> ExtraRecord.
- Reachability set is the union of per-peer `AllowedIPs`, **not** the flattened `rcfg.Routes` produced by `peerRoutes()`. `peerRoutes()` collapses every tailnet IPv6 into one `fd7a:115c:a1e0::/48` blanket prefix as soon as any peer has a tailnet v6 address; checking against that would make 4via6 destinations always look "routed" even when no peer actually serves them. A `bart.Lite` trie keeps containment checks O(log N).
- The cap is checked against the same `nm` snapshot the filter consumes (`nm.AllCaps.Contains(...)`), not via `cn.SelfHasCap(...)`. The latter would re-lock `nodeBackend` and could read a slightly newer netmap than the one we're filtering against.
- No `CapabilityVersion` bump: matches the existing `NodeAttr*` constants that ship without one. The check is at netmap-reconfig time, not query time, so old daemons that don't recognise the attribute simply ignore it.

## Test plan

- `go test ./...` passes
- `go vet ./...` clean

New tests:

- `TestFilterUnreachableSplitDNS` -- one richly-loaded scenario based on the example above. ~30 resolvers under a single `example.com` suffix exercise every IP source and reachability case in a single pass (peer / self / approved subnet / unapproved 4via6 / dual-stack / hidden peer / case folding / ExtraRecord / peer-shadows-ExtraRecord / bootstrap with mixed routed/non-Tailscale IPs / non-Tailscale hostnames / non-magic suffix / RFC1918 / malformed Addr / etc.). A second `all-dropped.tailnet` suffix verifies full-suffix removal from `dcfg.Routes`.
- `TestFilterUnreachableSplitDNS_Edges` -- two short cases for configurations that don't fit the comprehensive scenario: an empty resolver list (preserved verbatim) and a netmap with no MagicDNS suffix (suffix-match step skipped).
- `TestResolverHostname` -- 16 rows covering URL forms (`https://` / `http://` / `tls://`, with or without port, bracketed v6 host), `host:port`, `[ipv6]:port`, bare IP literals (v4 and v6 in several shapes), malformed inputs (`https://[invalid`, `not a url`, bare hostname with no scheme/port), and empty `Addr`.