### PR TITLE
client/local: suppress version warning for matching long builds

### DIFF
--- a/client/local/local.go
+++ b/client/local/local.go
@@ -155,8 +155,11 @@ func (lc *Client) DoLocalRequest(req *http.Request) (*http.Response, error) {
 func (lc *Client) doLocalRequestNiceError(req *http.Request) (*http.Response, error) {
 	res, err := lc.DoLocalRequest(req)
 	if err == nil {
-		if server := res.Header.Get("Tailscale-Version"); server != "" && server != envknob.IPCVersion() && onVersionMismatch != nil {
-			onVersionMismatch(envknob.IPCVersion(), server)
+		if server := res.Header.Get("Tailscale-Version"); server != "" && onVersionMismatch != nil {
+			client := envknob.IPCVersion()
+			if shouldWarnVersionMismatch(client, server) {
+				onVersionMismatch(client, server)
+			}
 		}
 		if res.StatusCode == 403 {
 			all, _ := io.ReadAll(res.Body)
@@ -233,6 +236,18 @@ func errorMessageFromBody(body []byte) string {
 }
 
 var onVersionMismatch func(clientVer, serverVer string)
+
+func shouldWarnVersionMismatch(clientVer, serverVer string) bool {
+	if clientVer == serverVer {
+		return false
+	}
+	// version.Short is a prefix of version.Long for the same build, for example:
+	//  "1.96.5" -> "1.96.5-t4ee448d3a-g74ffbefc2"
+	//  "1.99.0-dev20260519" -> "1.99.0-dev20260519-tabcd12345"
+	// Treat that as compatible, but keep warning for different dev dates,
+	// commits, or release versions.
+	return !strings.HasPrefix(serverVer, clientVer+"-") && !strings.HasPrefix(clientVer, serverVer+"-")
+}
 
 // SetVersionMismatchHandler sets f as the version mismatch handler
 // to be called when the client (the current process) has a version

--- a/client/local/local_test.go
+++ b/client/local/local_test.go
@@ -112,6 +112,66 @@ func TestUserDialSelf(t *testing.T) {
 	}
 }
 
+func TestShouldWarnVersionMismatch(t *testing.T) {
+	tests := []struct {
+		name   string
+		client string
+		server string
+		want   bool
+	}{
+		{
+			name:   "exact match",
+			client: "1.96.5-t4ee448d3a-g74ffbefc2",
+			server: "1.96.5-t4ee448d3a-g74ffbefc2",
+			want:   false,
+		},
+		{
+			name:   "short client long server",
+			client: "1.96.5",
+			server: "1.96.5-t4ee448d3a-g74ffbefc2",
+			want:   false,
+		},
+		{
+			name:   "long client short server",
+			client: "1.96.5-t4ee448d3a-g74ffbefc2",
+			server: "1.96.5",
+			want:   false,
+		},
+		{
+			name:   "short client different patch",
+			client: "1.96.5",
+			server: "1.96.6-t4ee448d3a-g74ffbefc2",
+			want:   true,
+		},
+		{
+			name:   "same short version different long builds",
+			client: "1.96.5-t4ee448d3a-g74ffbefc2",
+			server: "1.96.5-t111111111-g222222222",
+			want:   true,
+		},
+		{
+			name:   "same dev short and long",
+			client: "1.99.0-dev20260519",
+			server: "1.99.0-dev20260519-tabcd12345",
+			want:   false,
+		},
+		{
+			name:   "different dev dates",
+			client: "1.99.0-dev20260519",
+			server: "1.99.0-dev20260520-tabcd12345",
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldWarnVersionMismatch(tt.client, tt.server); got != tt.want {
+				t.Errorf("shouldWarnVersionMismatch(%q, %q) = %v, want %v", tt.client, tt.server, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDeps(t *testing.T) {
 	deptest.DepChecker{
 		BadDeps: map[string]string{


### PR DESCRIPTION
The CLI currently warns when the client reports a short version and the daemon reports the matching long build version, for example:

```text
Warning: client version "1.96.5" != tailscaled server version "1.96.5-t4ee448d3a-g74ffbefc2"
```

That looks like a real client/server mismatch, but it is only a `version.Short` vs `version.Long` difference from the same build.

This change treats those short/long pairs as compatible when one version is the other plus a build suffix. It still warns for different release versions, different dev dates, or different long build identifiers.

Fixes #19708

Tested:
- `./tool/go test ./client/local`
