### PR TITLE
k8s-operator: Support Workload identity federation for Tailnet CRD

### DIFF
--- a/cmd/k8s-operator/deploy/crds/tailscale.com_tailnets.yaml
+++ b/cmd/k8s-operator/deploy/crds/tailscale.com_tailnets.yaml
@@ -65,8 +65,9 @@ spec:
                   properties:
                     secretName:
                       description: |-
-                        The name of the secret containing the OAuth credentials. This secret must contain two fields "client_id" and
-                        "client_secret".
+                        The name of the secret containing the OAuth credentials. The secret must contain a "client_id" field and one of:
+                        "client_secret" for static OAuth credentials, or "jwt" for workload identity federation.
+                        When "jwt" is present, the operator uses the token exchange endpoint to authenticate.
                       type: string
                 loginUrl:
                   description: URL of the control plane to be used by all resources managed by the operator using this Tailnet.

--- a/cmd/k8s-operator/deploy/manifests/operator.yaml
+++ b/cmd/k8s-operator/deploy/manifests/operator.yaml
@@ -6155,8 +6155,9 @@ spec:
                                 properties:
                                     secretName:
                                         description: |-
-                                            The name of the secret containing the OAuth credentials. This secret must contain two fields "client_id" and
-                                            "client_secret".
+                                            The name of the secret containing the OAuth credentials. The secret must contain a "client_id" field and one of:
+                                            "client_secret" for static OAuth credentials, or "jwt" for workload identity federation.
+                                            When "jwt" is present, the operator uses the token exchange endpoint to authenticate.
                                         type: string
                                 required:
                                     - secretName

--- a/k8s-operator/api.md
+++ b/k8s-operator/api.md
@@ -1273,7 +1273,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `secretName` _string_ | The name of the secret containing the OAuth credentials. This secret must contain two fields "client_id" and<br />"client_secret". |  |  |
+| `secretName` _string_ | The name of the secret containing the OAuth credentials. The secret must contain a "client_id" field and one of:<br />"client_secret" for static OAuth credentials, or "jwt" for workload identity federation.<br />When "jwt" is present, the operator uses the token exchange endpoint to authenticate. |  |  |
 
 
 #### TailnetDevice

--- a/k8s-operator/apis/v1alpha1/types_tailnet.go
+++ b/k8s-operator/apis/v1alpha1/types_tailnet.go
@@ -53,8 +53,9 @@ type TailnetSpec struct {
 }
 
 type TailnetCredentials struct {
-	// The name of the secret containing the OAuth credentials. This secret must contain two fields "client_id" and
-	// "client_secret".
+	// The name of the secret containing the OAuth credentials. The secret must contain a "client_id" field and one of:
+	// "client_secret" for static OAuth credentials, or "jwt" for workload identity federation.
+	// When "jwt" is present, the operator uses the token exchange endpoint to authenticate.
 	SecretName string `json:"secretName"`
 }
 

--- a/k8s-operator/reconciler/tailnet/tailnet.go
+++ b/k8s-operator/reconciler/tailnet/tailnet.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"tailscale.com/client/tailscale/v2"
@@ -84,7 +85,10 @@ type (
 	}
 )
 
-const reconcilerName = "tailnet-reconciler"
+const (
+	reconcilerName               = "tailnet-reconciler"
+	indexTailnetCredentialSecret = ".spec.credentials.secretName"
+)
 
 // NewReconciler returns a new instance of the Reconciler type. It watches specifically for changes to Tailnet custom
 // resources. The ReconcilerOptions can be used to modify the behaviour of the Reconciler.
@@ -101,11 +105,45 @@ func NewReconciler(options ReconcilerOptions) *Reconciler {
 
 // Register the Reconciler onto the given manager.Manager implementation.
 func (r *Reconciler) Register(mgr manager.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), new(tsapi.Tailnet), indexTailnetCredentialSecret, indexCredentialSecret); err != nil {
+		return fmt.Errorf("failed setting up credential Secret indexer for Tailnets: %w", err)
+	}
+
 	return builder.
 		ControllerManagedBy(mgr).
 		For(&tsapi.Tailnet{}).
+		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.tailnetsForSecret)).
 		Named(reconcilerName).
 		Complete(r)
+}
+
+func (r *Reconciler) tailnetsForSecret(ctx context.Context, o client.Object) []reconcile.Request {
+	secret, ok := o.(*corev1.Secret)
+	if !ok || secret.Namespace != r.tailscaleNamespace {
+		return nil
+	}
+
+	var tailnets tsapi.TailnetList
+	if err := r.List(ctx, &tailnets, client.MatchingFields{indexTailnetCredentialSecret: secret.Name}); err != nil {
+		r.logger.Infof("error listing Tailnets, skipping a reconcile for event on Secret %s: %v", secret.Name, err)
+		return nil
+	}
+
+	var reqs []reconcile.Request
+	for _, tailnet := range tailnets.Items {
+		reqs = append(reqs, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: tailnet.Name},
+		})
+	}
+	return reqs
+}
+
+func indexCredentialSecret(o client.Object) []string {
+	tailnet, ok := o.(*tsapi.Tailnet)
+	if !ok || tailnet.Spec.Credentials.SecretName == "" {
+		return nil
+	}
+	return []string{tailnet.Spec.Credentials.SecretName}
 }
 
 var (
@@ -243,10 +281,11 @@ func (r *Reconciler) createOrUpdate(ctx context.Context, tailnet *tsapi.Tailnet)
 	return reconcile.Result{}, nil
 }
 
-// Constants for OAuth credential fields within the Secret referenced by the Tailnet.
+// Constants for credential fields within the Secret referenced by the Tailnet.
 const (
 	clientIDKey     = "client_id"
 	clientSecretKey = "client_secret"
+	jwtKey          = "jwt"
 )
 
 func (r *Reconciler) createClient(tailnet *tsapi.Tailnet, secret *corev1.Secret) (tsclient.Client, error) {
@@ -264,14 +303,39 @@ func (r *Reconciler) createClient(tailnet *tsapi.Tailnet, secret *corev1.Secret)
 		return nil, fmt.Errorf("failed to parse base URL %q: %w", baseURL, err)
 	}
 
+	var auth tailscale.Auth
+	if jwt := secret.Data[jwtKey]; len(jwt) > 0 {
+		auth = &tailscale.IdentityFederation{
+			ClientID:    string(secret.Data[clientIDKey]),
+			IDTokenFunc: r.jwtFromSecret(types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}),
+		}
+	} else {
+		auth = &tailscale.OAuth{
+			ClientID:     string(secret.Data[clientIDKey]),
+			ClientSecret: string(secret.Data[clientSecretKey]),
+		}
+	}
+
 	return tsclient.Wrap(&tailscale.Client{
 		BaseURL:   base,
 		UserAgent: "tailscale-k8s-operator",
-		Auth: &tailscale.OAuth{
-			ClientID:     string(secret.Data[clientIDKey]),
-			ClientSecret: string(secret.Data[clientSecretKey]),
-		},
+		Auth:      auth,
 	}), nil
+}
+
+func (r *Reconciler) jwtFromSecret(name types.NamespacedName) func() (string, error) {
+	return func() (string, error) {
+		var secret corev1.Secret
+		if err := r.Get(context.Background(), name, &secret); err != nil {
+			return "", fmt.Errorf("failed to get Secret %q for Tailnet JWT: %w", name, err)
+		}
+
+		jwt := secret.Data[jwtKey]
+		if len(jwt) == 0 {
+			return "", fmt.Errorf("Secret %q does not contain a Tailnet JWT", name)
+		}
+		return string(jwt), nil
+	}
 }
 
 func (r *Reconciler) ensurePermissions(ctx context.Context, tsClient tsclient.Client, tailnet *tsapi.Tailnet) bool {
@@ -317,8 +381,8 @@ func (r *Reconciler) ensureSecret(tailnet *tsapi.Tailnet, secret *corev1.Secret)
 		message = fmt.Sprintf("Secret %q is empty", secret.Name)
 	case len(secret.Data[clientIDKey]) == 0:
 		message = fmt.Sprintf("Secret %q is missing the client_id field", secret.Name)
-	case len(secret.Data[clientSecretKey]) == 0:
-		message = fmt.Sprintf("Secret %q is missing the client_secret field", secret.Name)
+	case len(secret.Data[clientSecretKey]) == 0 && len(secret.Data[jwtKey]) == 0:
+		message = fmt.Sprintf("Secret %q is missing the client_secret or jwt field", secret.Name)
 	}
 
 	if message == "" {

--- a/k8s-operator/reconciler/tailnet/tailnet_internal_test.go
+++ b/k8s-operator/reconciler/tailnet/tailnet_internal_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !plan9
+
+package tailnet
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	tsapi "tailscale.com/k8s-operator/apis/v1alpha1"
+)
+
+func TestJWTFromSecret(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tailnet-credentials",
+			Namespace: "tailscale",
+		},
+		Data: map[string][]byte{jwtKey: []byte("initial-jwt")},
+	}
+	cl := fake.NewClientBuilder().WithScheme(tsapi.GlobalScheme).WithObjects(secret).Build()
+	reconciler := &Reconciler{Client: cl}
+	token := reconciler.jwtFromSecret(types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace})
+
+	got, err := token()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "initial-jwt" {
+		t.Fatalf("got JWT %q, want initial JWT", got)
+	}
+
+	secret.Data[jwtKey] = []byte("refreshed-jwt")
+	if err := cl.Update(t.Context(), secret); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err = token()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "refreshed-jwt" {
+		t.Fatalf("got JWT %q, want refreshed JWT", got)
+	}
+}
+
+func TestTailnetsForSecret(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tailnet-credentials",
+			Namespace: "tailscale",
+		},
+	}
+	tailnets := []tsapi.Tailnet{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "matching"},
+			Spec: tsapi.TailnetSpec{
+				Credentials: tsapi.TailnetCredentials{SecretName: secret.Name},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "other"},
+			Spec: tsapi.TailnetSpec{
+				Credentials: tsapi.TailnetCredentials{SecretName: "other-credentials"},
+			},
+		},
+	}
+	cl := fake.NewClientBuilder().
+		WithScheme(tsapi.GlobalScheme).
+		WithObjects(&tailnets[0], &tailnets[1]).
+		WithIndex(new(tsapi.Tailnet), indexTailnetCredentialSecret, indexCredentialSecret).
+		Build()
+	logger := zap.NewNop().Sugar()
+	reconciler := &Reconciler{Client: cl, logger: logger, tailscaleNamespace: secret.Namespace}
+
+	got := reconciler.tailnetsForSecret(t.Context(), secret)
+	want := []reconcile.Request{{NamespacedName: types.NamespacedName{Name: "matching"}}}
+	if len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("got reconcile requests %v, want %v", got, want)
+	}
+
+	secret.Namespace = "other"
+	if got = reconciler.tailnetsForSecret(t.Context(), secret); got != nil {
+		t.Fatalf("got reconcile requests %v for a Secret outside the operator namespace", got)
+	}
+}

--- a/k8s-operator/reconciler/tailnet/tailnet_test.go
+++ b/k8s-operator/reconciler/tailnet/tailnet_test.go
@@ -141,7 +141,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 		},
 		{
-			Name: "invalid-status-missing-client-secret",
+			Name: "invalid-status-missing-client-secret-and-jwt",
 			Request: reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Name: "test",
@@ -171,7 +171,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 					Type:    string(tsapi.TailnetReady),
 					Status:  metav1.ConditionFalse,
 					Reason:  tailnet.ReasonInvalidSecret,
-					Message: `Secret "test" is missing the client_secret field`,
+					Message: `Secret "test" is missing the client_secret or jwt field`,
 				},
 			},
 		},
@@ -289,6 +289,45 @@ func TestReconciler_Reconcile(t *testing.T) {
 					Status:  metav1.ConditionFalse,
 					Reason:  tailnet.ReasonInvalidOAuth,
 					Message: `failed to list auth keys: EOF`,
+				},
+			},
+		},
+		{
+			Name: "valid with jwt instead of client_secret",
+			Request: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name: "test",
+				},
+			},
+			Tailnet: &tsapi.Tailnet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: tsapi.TailnetSpec{
+					Credentials: tsapi.TailnetCredentials{
+						SecretName: "test",
+					},
+				},
+			},
+			Secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "tailscale",
+				},
+				Data: map[string][]byte{
+					"client_id": []byte("test"),
+					"jwt":       []byte("test-jwt"),
+				},
+			},
+			ClientFunc: func(_ *tsapi.Tailnet, _ *corev1.Secret) tsclient.Client {
+				return &MockTailnetClient{}
+			},
+			ExpectedConditions: []metav1.Condition{
+				{
+					Type:    string(tsapi.TailnetReady),
+					Status:  metav1.ConditionTrue,
+					Reason:  tailnet.ReasonValid,
+					Message: tailnet.ReasonValid,
 				},
 			},
 		},


### PR DESCRIPTION
This adds support for the Tailnet CRD in the Kubernetes operator to authenticate via Workload identity federation.

By supplying a `jwt` as part of the Kubernetes Secret referenced by the Tailnet CRD, the auth tokens are fetched via Workload Federation rather than relying on a static client secret.

Closes #19090 