### PR TITLE
net/netcheck: don't block report on LAN portmap probe

### DIFF
--- a/net/netcheck/netcheck.go
+++ b/net/netcheck/netcheck.go
@@ -595,7 +595,6 @@ type reportState struct {
 	opts        *GetReportOpts
 	incremental bool // doing a lite, follow-up netcheck
 	stopProbeCh chan struct{}
-	waitPortMap sync.WaitGroup
 
 	mu       syncs.Mutex
 	report   *Report                            // to be returned by GetReport
@@ -722,9 +721,10 @@ func (rs *reportState) setOptBool(b *opt.Bool, v bool) {
 	b.Set(v)
 }
 
+// probePortMapServices probes the LAN for UPnP, PCP, and NAT-PMP services and
+// records what it finds on rs.report asynchronously, a slow port mapper may
+// only deliver usable results via [onPortMapChanged] later.
 func (rs *reportState) probePortMapServices() {
-	defer rs.waitPortMap.Done()
-
 	rs.setOptBool(&rs.report.UPnP, false)
 	rs.setOptBool(&rs.report.PMP, false)
 	rs.setOptBool(&rs.report.PCP, false)
@@ -899,7 +899,8 @@ func (c *Client) GetReport(ctx context.Context, dm *tailcfg.DERPMap, opts *GetRe
 	}
 
 	if !c.SkipExternalNetwork && c.PortMapper != nil {
-		rs.waitPortMap.Add(1)
+		// Fire-and-forget: the portmap probe can take ~250ms and we don't
+		// want to block the rest of netcheck on it. See probePortMapServices.
 		go rs.probePortMapServices()
 	}
 
@@ -951,10 +952,6 @@ func (c *Client) GetReport(ctx context.Context, dm *tailcfg.DERPMap, opts *GetRe
 		captivePortalStop()
 	}
 
-	if !c.SkipExternalNetwork && c.PortMapper != nil {
-		rs.waitPortMap.Wait()
-		c.vlogf("portMap done")
-	}
 	rs.stopTimers()
 
 	// Try HTTPS and ICMP latency check if all STUN probes failed due to

--- a/tsnet/tsnet_test.go
+++ b/tsnet/tsnet_test.go
@@ -2298,6 +2298,29 @@ type listenTest struct {
 	tun          *chanTUN // nil for netstack mode
 }
 
+// waitForPeerReachable blocks until s's current netmap contains the given peer
+// with a non-zero HomeDERP and endpoints. It fails the test if the watcher
+// closes first.
+func waitForPeerReachable(t *testing.T, s *Server, peer key.NodePublic) {
+	t.Helper()
+	w := must.Get(s.localClient.WatchIPNBus(t.Context(), ipn.NotifyInitialNetMap))
+	defer w.Close()
+	for {
+		n, err := w.Next()
+		if err != nil {
+			t.Fatalf("waitForPeerReachable(%v): %v", peer.ShortString(), err)
+		}
+		if n.NetMap == nil {
+			continue
+		}
+		for _, p := range n.NetMap.Peers {
+			if p.Key() == peer && p.HomeDERP() != 0 && p.Endpoints().Len() != 0 {
+				return
+			}
+		}
+	}
+}
+
 // setupTwoClientTest creates two tsnet servers for testing.
 // If useTUN is true, s2 uses a chanTUN; otherwise it uses netstack only.
 func setupTwoClientTest(t *testing.T, useTUN bool) *listenTest {
@@ -2341,6 +2364,9 @@ func setupTwoClientTest(t *testing.T, useTUN bool) *listenTest {
 	if len(s2status.TailscaleIPs) > 1 {
 		s2ip6 = s2status.TailscaleIPs[1]
 	}
+
+	waitForPeerReachable(t, s1, s2.lb.NodeKey())
+	waitForPeerReachable(t, s2, s1.lb.NodeKey())
 
 	lc1 := must.Get(s1.LocalClient())
 	must.Get(lc1.Ping(ctx, s2ip4, tailcfg.PingTSMP))


### PR DESCRIPTION
The portmap probe waits up to 250ms for UPnP/PCP/PMP responses from
the LAN gateway. STUN has already produced a usable reflexive address
by then, and if the portmap probe later discovers a usable service
the existing onPortMapChanged hook triggers a fresh netcheck whose
report includes the portmapped endpoint. Blocking the first report
on a LAN-capability probe just adds 250ms of dead time on every node
startup, reconnect, and periodic netcheck on networks without UPnP
(cloud, CI, most enterprise).

Updates #19822

Signed-off-by: James Tucker <james@tailscale.com>