### PR TITLE
wgengine/magicsock: fix data race in TestSetDERPMapDoReStun

### DIFF
--- a/wgengine/magicsock/derp_test.go
+++ b/wgengine/magicsock/derp_test.go
@@ -106,7 +106,9 @@ func TestSetDERPMapDoReStun(t *testing.T) {
 
 	bus := eventbustest.NewBus(t)
 	ht := health.NewTracker(bus)
-	c := newConn(t.Logf)
+	// Use WhileTestRunningLogger so the goroutine spawned by setDERPMap
+	// (which calls ReSTUN, which logs) doesn't race with test cleanup.
+	c := newConn(tstest.WhileTestRunningLogger(t))
 	ec := bus.Client("magicsock.Conn.Test")
 	c.eventClient = ec
 	c.homeDERPChangedPub = eventbus.Publish[HomeDERPChanged](ec)


### PR DESCRIPTION
SetDERPMap spawns a goroutine that calls ReSTUN, which logs via the
test logger. If the test returns before that goroutine logs, the
goroutine races with testing cleanup.

Use tstest.WhileTestRunningLogger so the goroutine's logf call becomes
a no-op once the test finishes.

Fixes #19829
