### PR TITLE
scripts/installer.sh: update KDE Linux link

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -353,7 +353,7 @@ main() {
 				;;
 			kde-linux)
 				echo "The maintainers of KDE Linux provide documentation on multiple ways to install Tailscale. These instructions are not officially supported by Tailscale:"
-				echo "https://kde.org/linux/docs/more-software/#tailscale"
+				echo "https://linux.kde.org/docs/more-software/#tailscale"
 				exit 1
 				;;
 


### PR DESCRIPTION
The old website [migrated](https://invent.kde.org/kde-linux/kde-linux/-/commit/804434ed37ce47e53757a94812bb338123f49840) to a [new one](https://linux.kde.org/) (`kde.org/linux` -> `linux.kde.org`).

cc @Erisa 