### PR TITLE
net/netmon, wgengine/router/osrouter: replace src_valid_mark with per…

### DIFF
--- a/net/netmon/netmon_linux.go
+++ b/net/netmon/netmon_linux.go
@@ -37,6 +37,23 @@ type RuleDeleted struct {
 	Priority uint32
 }
 
+// LinkChanged reports that an interface was added, removed, or changed
+// administrative state. The Tailscale interface is filtered out at publish
+// time so subscribers never see it.
+type LinkChanged struct {
+	// Name is the interface name. Empty if the netlink message did not
+	// carry an IFLA_IFNAME attribute (e.g. some RTM_DELLINK messages).
+	Name string
+	// Index is the system-wide interface index.
+	Index uint32
+	// Up is true when the interface is administratively up after the
+	// reported change. Always false for delete events.
+	Up bool
+	// Deleted is true if this event reports that the interface was removed
+	// (RTM_DELLINK). For RTM_NEWLINK, Deleted is false.
+	Deleted bool
+}
+
 // nlConn wraps a *netlink.Conn and returns a monitor.Message
 // instead of a netlink.Message. Currently, messages are discarded,
 // but down the line, when messages trigger different logic depending
@@ -45,6 +62,7 @@ type RuleDeleted struct {
 type nlConn struct {
 	busClient    *eventbus.Client
 	rulesDeleted *eventbus.Publisher[RuleDeleted]
+	linksChanged *eventbus.Publisher[LinkChanged]
 	logf         logger.Logf
 	conn         *netlink.Conn
 	buffered     []netlink.Message
@@ -54,6 +72,12 @@ type nlConn struct {
 	// by RTM_NEWADDR messages and de-populated by RTM_DELADDR. See
 	// issue #4282.
 	addrCache map[uint32]map[netip.Addr]bool
+
+	// linkNames remembers the last known name for each interface index so
+	// RTM_DELLINK messages (which often arrive without IFLA_IFNAME) can be
+	// resolved back to a name, and so renames can be reported as
+	// remove+add by the subscriber.
+	linkNames map[uint32]string
 }
 
 func newOSMon(bus *eventbus.Bus, logf logger.Logf, m *Monitor) (osMon, error) {
@@ -64,7 +88,8 @@ func newOSMon(bus *eventbus.Bus, logf logger.Logf, m *Monitor) (osMon, error) {
 		// but all reachability would.
 		Groups: unix.RTMGRP_IPV4_IFADDR | unix.RTMGRP_IPV6_IFADDR |
 			unix.RTMGRP_IPV4_ROUTE | unix.RTMGRP_IPV6_ROUTE |
-			unix.RTMGRP_IPV4_RULE, // no IPV6_RULE in x/sys/unix
+			unix.RTMGRP_IPV4_RULE | // no IPV6_RULE in x/sys/unix
+			unix.RTMGRP_LINK,
 	})
 	if err != nil {
 		// Google Cloud Run does not implement NETLINK_ROUTE RTMGRP support
@@ -75,9 +100,11 @@ func newOSMon(bus *eventbus.Bus, logf logger.Logf, m *Monitor) (osMon, error) {
 	return &nlConn{
 		busClient:    client,
 		rulesDeleted: eventbus.Publish[RuleDeleted](client),
+		linksChanged: eventbus.Publish[LinkChanged](client),
 		logf:         logf,
 		conn:         conn,
 		addrCache:    make(map[uint32]map[netip.Addr]bool),
+		linkNames:    make(map[uint32]string),
 	}, nil
 }
 
@@ -249,8 +276,58 @@ func (c *nlConn) Receive() (message, error) {
 		}
 		return ignoreMessage{}, nil
 	case unix.RTM_NEWLINK, unix.RTM_DELLINK:
-		// This is an unhandled message, but don't print an error.
-		// See https://github.com/tailscale/tailscale/issues/6806
+		var rmsg rtnetlink.LinkMessage
+		if err := rmsg.UnmarshalBinary(msg.Data); err != nil {
+			c.logf("failed to parse type %v: %v", msg.Header.Type, err)
+			return unspecifiedMessage{}, nil
+		}
+		deleted := msg.Header.Type == unix.RTM_DELLINK
+		name := ""
+		if rmsg.Attributes != nil {
+			name = rmsg.Attributes.Name
+		}
+		// IFLA_IFNAME is sometimes absent on RTM_DELLINK; fall back to the
+		// name we remembered from the last RTM_NEWLINK for this index.
+		if name == "" {
+			if prev, ok := c.linkNames[rmsg.Index]; ok {
+				name = prev
+			}
+		}
+		// IFF_UP from netdevice(7); see linux/if.h.
+		up := !deleted && rmsg.Flags&unix.IFF_UP != 0
+		// Update the index→name cache. If the name changed for an existing
+		// index this is effectively a rename; we publish a Deleted event for
+		// the old name first so subscribers can treat rename as remove+add.
+		if deleted {
+			delete(c.linkNames, rmsg.Index)
+		} else if name != "" {
+			if old, ok := c.linkNames[rmsg.Index]; ok && old != name {
+				if debugNetlinkMessages() {
+					c.logf("RTM_NEWLINK: rename %s -> %s (idx=%d)", old, name, rmsg.Index)
+				}
+				c.linksChanged.Publish(LinkChanged{
+					Name:    old,
+					Index:   rmsg.Index,
+					Deleted: true,
+				})
+			}
+			c.linkNames[rmsg.Index] = name
+		}
+
+		if debugNetlinkMessages() {
+			typ := "RTM_NEWLINK"
+			if deleted {
+				typ = "RTM_DELLINK"
+			}
+			c.logf("%s: name=%s idx=%d up=%v", typ, name, rmsg.Index, up)
+		}
+
+		c.linksChanged.Publish(LinkChanged{
+			Name:    name,
+			Index:   rmsg.Index,
+			Up:      up,
+			Deleted: deleted,
+		})
 		return unspecifiedMessage{}, nil
 	default:
 		c.logf("unhandled netlink msg type %+v, %q", msg.Header, msg.Data)

--- a/net/netmon/state.go
+++ b/net/netmon/state.go
@@ -580,6 +580,20 @@ func isTailscaleInterface(name string, ips []netip.Prefix) bool {
 		strings.HasPrefix(name, "tailscale") // TODO: use --tun flag value, etc; see TODO in method doc
 }
 
+// IsTailscaleInterfaceName reports whether name looks like a Tailscale-managed
+// network interface, based purely on the name. It is the name-only counterpart
+// of [isTailscaleInterface] for callers that don't have the interface's IPs
+// handy (e.g. reacting to a netlink RTM_DELLINK).
+func IsTailscaleInterfaceName(name string) bool {
+	if name == "" {
+		return false
+	}
+	if tsIfName, err := TailscaleInterfaceName(); err == nil {
+		return name == tsIfName
+	}
+	return name == "Tailscale" || strings.HasPrefix(name, "tailscale")
+}
+
 // getPAC, if non-nil, returns the current PAC file URL.
 var getPAC func() string
 

--- a/wgengine/router/osrouter/router_linux.go
+++ b/wgengine/router/osrouter/router_linux.go
@@ -12,6 +12,7 @@ import (
 	"net/netip"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -92,6 +93,12 @@ type linuxRouter struct {
 	cgnatMode         linuxfw.CGNATMode
 	magicsockPortV4   uint16
 	magicsockPortV6   uint16
+
+	// rpfIifLinks tracks the set of non-Tailscale interface names for which
+	// we have installed pref-rpfIif rules diverting reverse-path-filter
+	// lookups to the main routing table. Keyed by interface name. See
+	// installRPFIifRules / [linuxRouter.onLinkChanged].
+	rpfIifLinks map[string]bool
 }
 
 func newUserspaceRouter(logf logger.Logf, tunDev tun.Device, netMon *netmon.Monitor, health *health.Tracker, bus *eventbus.Bus) (router.Router, error) {
@@ -119,6 +126,7 @@ func newUserspaceRouterAdvanced(logf logger.Logf, tunname string, netMon *netmon
 
 		ipRuleFixLimiter: rate.NewLimiter(rate.Every(5*time.Second), 10),
 		ipPolicyPrefBase: 5200,
+		rpfIifLinks:      map[string]bool{},
 	}
 	ec := bus.Client("router-linux")
 	r.rulesAddedPub = eventbus.Publish[AddIPRules](ec)
@@ -130,6 +138,9 @@ func newUserspaceRouterAdvanced(logf logger.Logf, tunname string, netMon *netmon
 		if err := r.updateMagicsockPort(pu.UDPPort, pu.EndpointNetwork); err != nil {
 			r.logf("updateMagicsockPort(port=%v, network=%s) failed: %v", pu.UDPPort, pu.EndpointNetwork, err)
 		}
+	})
+	eventbus.SubscribeFunc(ec, func(lc netmon.LinkChanged) {
+		r.onLinkChanged(lc)
 	})
 	r.eventClient = ec
 
@@ -324,7 +335,9 @@ type AddIPRules struct{}
 // about the priority number. We could just do this in response to any netlink
 // change. Filtering by known priority ranges cuts back on some logspam.
 func (r *linuxRouter) onIPRuleDeleted(table uint8, priority uint32) {
-	if int(priority) < r.ipPolicyPrefBase || int(priority) >= (r.ipPolicyPrefBase+100) {
+	loPri := r.ipPolicyPrefBase + rpfIifPriorityOffset
+	hiPri := r.ipPolicyPrefBase + 100
+	if int(priority) < loPri || int(priority) >= hiPri {
 		// Not our rule.
 		return
 	}
@@ -344,6 +357,12 @@ func (r *linuxRouter) onIPRuleDeleted(table uint8, priority uint32) {
 		if r.ruleRestorePending.Swap(false) && !r.closed.Load() {
 			r.logf("somebody (likely systemd-networkd) deleted ip rules; restoring Tailscale's")
 			r.justAddIPRules()
+			r.mu.Lock()
+			// Drop the bookkeeping for any rules that might have been
+			// flushed; reseeding will reinstall them and re-populate the map.
+			r.rpfIifLinks = map[string]bool{}
+			r.seedRPFIifRulesLocked()
+			r.mu.Unlock()
 		}
 	})
 }
@@ -357,6 +376,7 @@ func (r *linuxRouter) Up() error {
 	if err := r.addIPRules(); err != nil {
 		return fmt.Errorf("adding IP rules: %w", err)
 	}
+	r.seedRPFIifRulesLocked()
 	if err := r.upInterface(); err != nil {
 		return fmt.Errorf("bringing interface up: %w", err)
 	}
@@ -377,6 +397,14 @@ func (r *linuxRouter) Close() error {
 	if err := r.nfr.DelConnmarkSaveRule(); err != nil {
 		r.logf("warning: failed to delete connmark rules: %v", err)
 	}
+
+	// Remove the per-interface rp_filter diversion rules we installed.
+	for name := range r.rpfIifLinks {
+		if err := r.delRPFIifRule(name); err != nil {
+			r.logf("warning: failed to remove rp_filter iif rule for %q: %v", name, err)
+		}
+	}
+	r.rpfIifLinks = nil
 
 	if err := r.downInterface(); err != nil {
 		return err
@@ -488,8 +516,8 @@ func (r *linuxRouter) Set(cfg *router.Config) error {
 	r.updateStatefulFilteringWithDockerWarning(cfg)
 
 	// Connmark rules for rp_filter compatibility.
-	// Always enabled when netfilter is ON to handle all rp_filter=1 scenarios
-	// (normal operation, exit nodes, subnet routers, and clients using exit nodes).
+	// Enabled when netfilter is ON to handle rp_filter=1 scenarios where packets
+	// would be dropped due to device mismatch during reverse path filtering.
 	// Gate on r.netfilterMode (actual state) rather than cfg.NetfilterMode
 	// (desired state) so we don't call into the runner when chain setup failed.
 	netfilterOn := r.netfilterMode == netfilterOn
@@ -504,14 +532,6 @@ func (r *linuxRouter) Set(cfg *router.Config) error {
 		} else {
 			// Only update state on success to keep it in sync with actual rules
 			r.connmarkEnabled = true
-		}
-		// Enable src_valid_mark so the kernel uses the packet's fwmark
-		// during the rp_filter reverse-path check. Without this, the
-		// connmark restore in mangle/PREROUTING is ineffective — rp_filter
-		// does its routing lookup with fwmark=0, ignoring the restored
-		// bypass mark, and drops reply packets as martians.
-		if err := writeSysctl("net.ipv4.conf.all.src_valid_mark", "1"); err != nil {
-			r.logf("warning: failed to enable src_valid_mark: %v", err)
 		}
 	default:
 		r.logf("disabling connmark-based rp_filter workaround")
@@ -1158,7 +1178,10 @@ func (r *linuxRouter) enableIPForwarding() {
 }
 
 func writeSysctl(key, val string) error {
-	fn := "/proc/sys/" + strings.Replace(key, ".", "/", -1)
+	// Convert sysctl key (e.g. "net.ipv4.ip_forward") to path components
+	components := strings.Split(key, ".")
+	// Build path using filepath.Join for proper path construction
+	fn := filepath.Join(append([]string{"/proc/sys"}, components...)...)
 	if err := os.WriteFile(fn, []byte(val), 0644); err != nil {
 		return fmt.Errorf("sysctl(%v=%v): %v", key, val, err)
 	}
@@ -1553,6 +1576,193 @@ func (r *linuxRouter) delIPRulesWithIPCommand() error {
 	}
 
 	return rg.ErrAcc
+}
+
+// rpfIifPriorityOffset is the offset, relative to r.ipPolicyPrefBase, of the
+// per-interface rules that divert reverse-path-filter lookups to the main
+// routing table. Sits below pref 10 (the lowest baseIPRules entry) so the
+// catch-all → tailscale table never gets consulted for replies arriving on a
+// physical NIC. See [linuxRouter.installRPFIifRule] for context.
+const rpfIifPriorityOffset = -10
+
+// rpfIifEligible reports whether the named interface is one we should install
+// a per-iif rp_filter diversion rule for. The loopback interface is excluded:
+// the kernel uses LOOPBACK_IFINDEX as the iif of locally-originated packets,
+// so an "iif lo lookup main" rule would silently divert tailscaled's own
+// outbound traffic away from table 52 — exactly the opposite of what the
+// catch-all at pref 5270 is meant to do.
+func (r *linuxRouter) rpfIifEligible(name string) bool {
+	if name == "" || name == "lo" {
+		return false
+	}
+	if netmon.IsTailscaleInterfaceName(name) {
+		return false
+	}
+	return true
+}
+
+// onLinkChanged is the callback invoked when netmon publishes a link change.
+// It installs (or removes) a per-interface rule that diverts reverse-path
+// filter lookups for that interface to the main routing table, so the
+// tailscale table's catch-all default route can't accidentally cause
+// martian-source drops on replies arriving via the physical NIC.
+func (r *linuxRouter) onLinkChanged(lc netmon.LinkChanged) {
+	if !r.rpfIifEligible(lc.Name) {
+		return
+	}
+	if !r.ipRuleAvailable || r.useIPCommand() {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed.Load() {
+		return
+	}
+
+	switch {
+	case lc.Deleted, !lc.Up:
+		if !r.rpfIifLinks[lc.Name] {
+			return
+		}
+		if err := r.delRPFIifRule(lc.Name); err != nil {
+			r.logf("warning: rp_filter iif rule cleanup for %q failed: %v", lc.Name, err)
+		}
+		delete(r.rpfIifLinks, lc.Name)
+	default:
+		if r.rpfIifLinks[lc.Name] {
+			return
+		}
+		if err := r.addRPFIifRule(lc.Name); err != nil {
+			r.logf("warning: rp_filter iif rule install for %q failed: %v", lc.Name, err)
+			return
+		}
+		r.rpfIifLinks[lc.Name] = true
+	}
+}
+
+// seedRPFIifRulesLocked installs an rp_filter diversion rule for every
+// non-Tailscale link the netmon currently knows about. Called once at startup
+// so we don't have to wait for an RTM_NEWLINK to install rules for interfaces
+// that already exist.
+//
+// linuxRouter.mu must be held.
+func (r *linuxRouter) seedRPFIifRulesLocked() {
+	if !r.ipRuleAvailable || r.useIPCommand() || r.netMon == nil {
+		return
+	}
+	// Clear any stale rules left over from a previous tailscaled run that
+	// crashed without cleanup, so we don't pile up duplicates.
+	r.flushRPFIifRulesLocked()
+	st := r.netMon.InterfaceState()
+	if st == nil {
+		return
+	}
+	for name, ifc := range st.Interface {
+		if !r.rpfIifEligible(name) {
+			continue
+		}
+		if !ifc.IsUp() {
+			continue
+		}
+		if r.rpfIifLinks[name] {
+			continue
+		}
+		if err := r.addRPFIifRule(name); err != nil {
+			r.logf("warning: rp_filter iif rule install for %q failed: %v", name, err)
+			continue
+		}
+		r.rpfIifLinks[name] = true
+	}
+}
+
+// flushRPFIifRulesLocked deletes any kernel rules at our rpfIif priority
+// regardless of which interface they reference. This sweeps up rules that may
+// have been left behind by a previous tailscaled process.
+//
+// linuxRouter.mu must be held.
+func (r *linuxRouter) flushRPFIifRulesLocked() {
+	pri := r.ipPolicyPrefBase + rpfIifPriorityOffset
+	for _, family := range r.rpfIifAddrFamilies() {
+		rules, err := netlink.RuleList(family.netlinkInt())
+		if err != nil {
+			continue
+		}
+		for _, ru := range rules {
+			if ru.Priority != pri || ru.IifName == "" {
+				continue
+			}
+			ru.Family = family.netlinkInt()
+			if err := netlink.RuleDel(&ru); err != nil && !errors.Is(err, errENOENT) {
+				r.logf("warning: failed to delete stale rp_filter iif rule for %q: %v", ru.IifName, err)
+			}
+		}
+	}
+}
+
+// rpfIifAddrFamilies returns the address families to install per-iif
+// rp_filter diversion rules for. Unlike [linuxRouter.addrFamilies], it does
+// not consult r.nfr (which is nil until Set() runs and netfilter is set up);
+// rpfIif rules are managed independently of netfilter and may be installed
+// before the first Set().
+func (r *linuxRouter) rpfIifAddrFamilies() []addrFamily {
+	if r.v6Available {
+		return []addrFamily{v4, v6}
+	}
+	return []addrFamily{v4}
+}
+
+// addRPFIifRule installs the per-interface main-table diversion rule for the
+// given interface name, in every address family supported by the host.
+func (r *linuxRouter) addRPFIifRule(name string) error {
+	pri := r.ipPolicyPrefBase + rpfIifPriorityOffset
+	var errAcc error
+	for _, family := range r.rpfIifAddrFamilies() {
+		ru := &netlink.Rule{
+			Priority:          pri,
+			Family:            family.netlinkInt(),
+			IifName:           name,
+			Table:             mainRouteTable.Num,
+			Mark:              -1,
+			Mask:              -1,
+			Goto:              -1,
+			SuppressIfgroup:   -1,
+			SuppressPrefixlen: -1,
+			Flow:              -1,
+		}
+		if err := netlink.RuleAdd(ru); err != nil && !errors.Is(err, errEEXIST) {
+			if errAcc == nil {
+				errAcc = err
+			}
+		}
+	}
+	return errAcc
+}
+
+// delRPFIifRule removes the per-interface rule installed by addRPFIifRule.
+func (r *linuxRouter) delRPFIifRule(name string) error {
+	pri := r.ipPolicyPrefBase + rpfIifPriorityOffset
+	var errAcc error
+	for _, family := range r.rpfIifAddrFamilies() {
+		ru := &netlink.Rule{
+			Priority:          pri,
+			Family:            family.netlinkInt(),
+			IifName:           name,
+			Table:             mainRouteTable.Num,
+			Mark:              -1,
+			Mask:              -1,
+			Goto:              -1,
+			SuppressIfgroup:   -1,
+			SuppressPrefixlen: -1,
+			Flow:              -1,
+		}
+		if err := netlink.RuleDel(ru); err != nil && !errors.Is(err, errENOENT) {
+			if errAcc == nil {
+				errAcc = err
+			}
+		}
+	}
+	return errAcc
 }
 
 // addSNATRule adds a netfilter rule to SNAT traffic destined for

--- a/wgengine/router/osrouter/router_linux.go
+++ b/wgengine/router/osrouter/router_linux.go
@@ -28,10 +28,12 @@ import (
 	"tailscale.com/envknob"
 	"tailscale.com/health"
 	"tailscale.com/net/netmon"
+	"tailscale.com/net/tsaddr"
 	"tailscale.com/tsconst"
 	"tailscale.com/types/logger"
 	"tailscale.com/types/opt"
 	"tailscale.com/types/preftype"
+	"tailscale.com/types/views"
 	"tailscale.com/util/eventbus"
 	"tailscale.com/util/linuxfw"
 	"tailscale.com/version/distro"
@@ -94,10 +96,17 @@ type linuxRouter struct {
 	magicsockPortV4   uint16
 	magicsockPortV6   uint16
 
+	// rpfIifEnabled is true when the host is using a Tailscale exit node
+	// (i.e., cfg.Routes contains a default route), which is the only
+	// configuration where the catch-all "lookup table 52" rule causes
+	// rp_filter on the physical NIC to misresolve reply traffic. See
+	// [linuxRouter.setRPFIifEnabledLocked].
+	rpfIifEnabled bool
+
 	// rpfIifLinks tracks the set of non-Tailscale interface names for which
 	// we have installed pref-rpfIif rules diverting reverse-path-filter
-	// lookups to the main routing table. Keyed by interface name. See
-	// installRPFIifRules / [linuxRouter.onLinkChanged].
+	// lookups to the main routing table. Keyed by interface name. Empty
+	// unless rpfIifEnabled is true. See [linuxRouter.onLinkChanged].
 	rpfIifLinks map[string]bool
 }
 
@@ -360,8 +369,10 @@ func (r *linuxRouter) onIPRuleDeleted(table uint8, priority uint32) {
 			r.mu.Lock()
 			// Drop the bookkeeping for any rules that might have been
 			// flushed; reseeding will reinstall them and re-populate the map.
-			r.rpfIifLinks = map[string]bool{}
-			r.seedRPFIifRulesLocked()
+			if r.rpfIifEnabled {
+				r.rpfIifLinks = map[string]bool{}
+				r.seedRPFIifRulesLocked()
+			}
 			r.mu.Unlock()
 		}
 	})
@@ -376,7 +387,11 @@ func (r *linuxRouter) Up() error {
 	if err := r.addIPRules(); err != nil {
 		return fmt.Errorf("adding IP rules: %w", err)
 	}
-	r.seedRPFIifRulesLocked()
+	// Sweep up any pref-rpfIif rules left behind by a previous tailscaled
+	// process that crashed without cleanup. We don't install rules here;
+	// that happens via Set() once we know whether this host is using an
+	// exit node.
+	r.flushRPFIifRulesLocked()
 	if err := r.upInterface(); err != nil {
 		return fmt.Errorf("bringing interface up: %w", err)
 	}
@@ -398,13 +413,11 @@ func (r *linuxRouter) Close() error {
 		r.logf("warning: failed to delete connmark rules: %v", err)
 	}
 
-	// Remove the per-interface rp_filter diversion rules we installed.
-	for name := range r.rpfIifLinks {
-		if err := r.delRPFIifRule(name); err != nil {
-			r.logf("warning: failed to remove rp_filter iif rule for %q: %v", name, err)
-		}
-	}
+	// Remove any per-interface rp_filter diversion rules we installed,
+	// regardless of bookkeeping state.
+	r.flushRPFIifRulesLocked()
 	r.rpfIifLinks = nil
+	r.rpfIifEnabled = false
 
 	if err := r.downInterface(); err != nil {
 		return err
@@ -477,6 +490,15 @@ func (r *linuxRouter) Set(cfg *router.Config) error {
 		errs = append(errs, err)
 	}
 	r.routes = newRoutes
+
+	// rp_filter diversion rules are only needed when this host is using an
+	// exit node — that's the only configuration where table 52 contains a
+	// route (0.0.0.0/0 dev tailscale0) that competes with the physical
+	// interface during reverse-path filtering. Outside that case the rules
+	// are unneeded; on a subnet router or exit-node server they actively
+	// break forwarding by short-circuiting the FIB lookup for traffic
+	// destined to a Tailscale CGNAT peer away from table 52.
+	r.setRPFIifEnabledLocked(tsaddr.ContainsExitRoute(views.SliceOf(cfg.Routes)))
 
 	newAddrs, err := cidrDiff("addr", r.addrs, cfg.LocalAddrs, r.addAddress, r.delAddress, r.logf)
 	if err != nil {
@@ -1616,7 +1638,7 @@ func (r *linuxRouter) onLinkChanged(lc netmon.LinkChanged) {
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if r.closed.Load() {
+	if r.closed.Load() || !r.rpfIifEnabled {
 		return
 	}
 
@@ -1641,10 +1663,30 @@ func (r *linuxRouter) onLinkChanged(lc netmon.LinkChanged) {
 	}
 }
 
+// setRPFIifEnabledLocked turns the per-interface rp_filter diversion rules on
+// or off based on whether this host is using a Tailscale exit node. Idempotent.
+//
+// linuxRouter.mu must be held.
+func (r *linuxRouter) setRPFIifEnabledLocked(enabled bool) {
+	if enabled == r.rpfIifEnabled {
+		return
+	}
+	r.rpfIifEnabled = enabled
+	if !r.ipRuleAvailable || r.useIPCommand() {
+		return
+	}
+	if enabled {
+		r.seedRPFIifRulesLocked()
+		return
+	}
+	r.flushRPFIifRulesLocked()
+	r.rpfIifLinks = map[string]bool{}
+}
+
 // seedRPFIifRulesLocked installs an rp_filter diversion rule for every
-// non-Tailscale link the netmon currently knows about. Called once at startup
-// so we don't have to wait for an RTM_NEWLINK to install rules for interfaces
-// that already exist.
+// non-Tailscale link the netmon currently knows about. Called when this host
+// starts using an exit node so we don't have to wait for an RTM_NEWLINK to
+// install rules for interfaces that already exist.
 //
 // linuxRouter.mu must be held.
 func (r *linuxRouter) seedRPFIifRulesLocked() {

--- a/wgengine/router/osrouter/router_linux_test.go
+++ b/wgengine/router/osrouter/router_linux_test.go
@@ -1639,6 +1639,10 @@ func TestRPFIifRuleLifecycle(t *testing.T) {
 	// command, so we exercise the real installer.
 	r.cmd = osCommandRunner{}
 	r.ipRuleAvailable = true
+	// Pretend the host is using an exit node so the rules are active.
+	r.mu.Lock()
+	r.rpfIifEnabled = true
+	r.mu.Unlock()
 
 	const fakeIface = "tstest-rpfiif0"
 	r.onLinkChanged(netmon.LinkChanged{Name: fakeIface, Index: 9999, Up: true})
@@ -1692,6 +1696,7 @@ func TestRPFIifEligible(t *testing.T) {
 			r := &linuxRouter{
 				logf:             logger.Discard,
 				rpfIifLinks:      map[string]bool{},
+				rpfIifEnabled:    true,
 				ipPolicyPrefBase: 5200,
 				ipRuleAvailable:  true,
 				cmd:              fakeCmdRunner{},
@@ -1701,6 +1706,26 @@ func TestRPFIifEligible(t *testing.T) {
 				t.Errorf("rpfIifLinks = %v; want empty for ineligible iface %q", r.rpfIifLinks, name)
 			}
 		})
+	}
+}
+
+// TestRPFIifGatedOnExitNodeUse verifies that LinkChanged events are ignored
+// unless the host is using an exit node. Subnet routers and exit-node servers
+// must not get pref-rpfIif rules installed because those rules short-circuit
+// the FIB lookup for forwarded traffic destined to a Tailscale CGNAT peer
+// away from table 52.
+func TestRPFIifGatedOnExitNodeUse(t *testing.T) {
+	r := &linuxRouter{
+		logf:             logger.Discard,
+		rpfIifLinks:      map[string]bool{},
+		ipPolicyPrefBase: 5200,
+		ipRuleAvailable:  true,
+		cmd:              fakeCmdRunner{},
+		// rpfIifEnabled defaults to false: not using an exit node.
+	}
+	r.onLinkChanged(netmon.LinkChanged{Name: "eth0", Index: 1, Up: true})
+	if len(r.rpfIifLinks) != 0 {
+		t.Errorf("rpfIifLinks = %v; want empty when rpfIifEnabled is false", r.rpfIifLinks)
 	}
 }
 

--- a/wgengine/router/osrouter/router_linux_test.go
+++ b/wgengine/router/osrouter/router_linux_test.go
@@ -1609,3 +1609,104 @@ func TestSetSkipsNetfilterAddonsWhenSetupFails(t *testing.T) {
 			nfr.addExternalCGNATCalls)
 	}
 }
+
+// TestRPFIifRuleLifecycle verifies that a non-Tailscale link going up causes
+// an iif diversion rule to be installed at pref ipPolicyPrefBase + rpfIifPriorityOffset
+// pointing to the main routing table, and that going down (or being deleted)
+// removes it.
+func TestRPFIifRuleLifecycle(t *testing.T) {
+	tstest.RequireRoot(t)
+
+	bus := eventbustest.NewBus(t)
+	mon, err := netmon.New(bus, logger.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mon.Start()
+	defer mon.Close()
+
+	fake := NewFakeOS(t)
+	ht := health.NewTracker(bus)
+	rr, err := newUserspaceRouterAdvanced(t.Logf, "tailscale0", mon, fake, ht, bus)
+	if err != nil {
+		t.Fatalf("newUserspaceRouterAdvanced: %v", err)
+	}
+	r := rr.(*linuxRouter)
+	r.nfr = fake.nfr
+	defer r.Close()
+
+	// Force the netlink path even though tests usually use the fake "ip"
+	// command, so we exercise the real installer.
+	r.cmd = osCommandRunner{}
+	r.ipRuleAvailable = true
+
+	const fakeIface = "tstest-rpfiif0"
+	r.onLinkChanged(netmon.LinkChanged{Name: fakeIface, Index: 9999, Up: true})
+	if !r.rpfIifLinks[fakeIface] {
+		t.Fatalf("rpfIifLinks missing %q after up event: %v", fakeIface, r.rpfIifLinks)
+	}
+
+	// Confirm a rule exists at the expected priority for that iif.
+	pri := r.ipPolicyPrefBase + rpfIifPriorityOffset
+	rules, err := netlink.RuleList(netlink.FAMILY_V4)
+	if err != nil {
+		t.Fatalf("RuleList: %v", err)
+	}
+	found := false
+	for _, ru := range rules {
+		if ru.Priority == pri && ru.IifName == fakeIface {
+			found = true
+			if ru.Table != 254 { // main
+				t.Errorf("rule for %q points at table %d; want main (254)", fakeIface, ru.Table)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("no rule at priority %d for iif %q after onLinkChanged Up", pri, fakeIface)
+	}
+
+	r.onLinkChanged(netmon.LinkChanged{Name: fakeIface, Index: 9999, Deleted: true})
+	if r.rpfIifLinks[fakeIface] {
+		t.Errorf("rpfIifLinks still contains %q after delete event", fakeIface)
+	}
+
+	rules, err = netlink.RuleList(netlink.FAMILY_V4)
+	if err != nil {
+		t.Fatalf("RuleList post-delete: %v", err)
+	}
+	for _, ru := range rules {
+		if ru.Priority == pri && ru.IifName == fakeIface {
+			t.Errorf("rule at priority %d for iif %q still present after delete event", pri, fakeIface)
+		}
+	}
+}
+
+// TestRPFIifEligible verifies that LinkChanged events for ineligible
+// interfaces (Tailscale, loopback, empty name) never produce an iif diversion
+// rule. Loopback is the most important case: lo is the iif of every
+// locally-originated packet (LOOPBACK_IFINDEX), so a rule on it would divert
+// tailscaled's own outbound traffic away from table 52.
+func TestRPFIifEligible(t *testing.T) {
+	for _, name := range []string{"tailscale0", "lo", ""} {
+		t.Run(name, func(t *testing.T) {
+			r := &linuxRouter{
+				logf:             logger.Discard,
+				rpfIifLinks:      map[string]bool{},
+				ipPolicyPrefBase: 5200,
+				ipRuleAvailable:  true,
+				cmd:              fakeCmdRunner{},
+			}
+			r.onLinkChanged(netmon.LinkChanged{Name: name, Index: 1, Up: true})
+			if len(r.rpfIifLinks) != 0 {
+				t.Errorf("rpfIifLinks = %v; want empty for ineligible iface %q", r.rpfIifLinks, name)
+			}
+		})
+	}
+}
+
+// fakeCmdRunner exists only so that useIPCommand() returns true and the
+// onLinkChanged path early-returns without attempting netlink.
+type fakeCmdRunner struct{}
+
+func (fakeCmdRunner) run(...string) error              { return nil }
+func (fakeCmdRunner) output(...string) ([]byte, error) { return nil, nil }


### PR DESCRIPTION
…-iif rules

The previous rp_filter workaround wrote net.ipv4.conf.all.src_valid_mark=1 unconditionally at startup, which globally changes the kernel's reverse-path lookup behavior for every fwmark + policy-routing user on the host. Other subsystems (split-tunnel VPNs, multi-WAN PBR, custom QoS) were silently broken by Tailscale flipping a global sysctl, and persistent sysctl.conf configuration could not override it because tailscaled rewrote it on every startup.

Replace it with a structural fix: install per-interface ip rules at ipPolicyPrefBase + rpfIifPriorityOffset (= pref 5190) that divert reverse-path-filter lookups for non-Tailscale interfaces directly to the main routing table. Outbound routing (iif=0) keeps falling through to the existing pref-5270 catch-all into table 52, so exit-node functionality is preserved. rp_filter on the physical NIC now consults main, finds the reply matches the underlay default route, and passes — without ever touching the sysctl.

netmon now decodes RTM_NEWLINK / RTM_DELLINK and publishes a LinkChanged event on the eventbus. The router subscribes and installs/removes the iif rule for each non-Tailscale link, seeds rules at startup from netMon.InterfaceState(), and reseeds them when ip rules are deleted (e.g. by systemd-networkd). The connmark save/restore rules in mangle/PREROUTING are retained as defense-in-depth.

The TS_DISABLE_SRC_VALID_MARK envknob and src-valid-mark-required health warnable are removed; neither is meaningful under the new mechanism.

Updates #19796