### PR TITLE
ssh/tailssh: skip setgroups syscall when effectively a no-op

### DIFF
--- a/ssh/tailssh/incubator.go
+++ b/ssh/tailssh/incubator.go
@@ -1196,12 +1196,70 @@ func setGroups(groupIDs []int) error {
 		groupIDs = groupIDs[:16]
 	}
 
+	// If the process already effectively holds exactly the requested group
+	// memberships, the Setgroups call is a no-op semantically. Skip it: the
+	// syscall itself still requires CAP_SETGID on Linux, which is unavailable
+	// in many sandboxed or rootless environments (user namespaces, gVisor,
+	// etc.) where tailscaled runs as the target user. This mirrors the
+	// conditional skip already used below for Setgid and Setuid in
+	// doDropPrivileges.
+	//
+	// We consider a target satisfied when the access rights granted by the
+	// process's primary GID plus current supplementary groups exactly equal
+	// the access rights that would be granted by the primary GID plus the
+	// requested supplementary groups. That covers both the strict
+	// set-equality case (current supplementary == requested) and the common
+	// "requested set only restates the primary GID" case that arises when
+	// the user has no real secondary group memberships.
+	if effectiveGroupsEqual(groupIDs) {
+		return nil
+	}
+
 	err := syscall.Setgroups(groupIDs)
 	if err != nil && os.Geteuid() != 0 && groupsMatchCurrent(groupIDs) {
 		// If we're not root, ignore a Setgroups failure if all groups are the same.
+		// (Kept as a defense-in-depth fallback; the pre-check above should already
+		// have short-circuited for any case it could recover.)
 		return nil
 	}
 	return err
+}
+
+// effectiveGroupsEqual reports whether the access rights conveyed by the
+// process's primary GID plus its current supplementary groups already equal
+// those that would be conveyed by the primary GID plus the requested
+// supplementary groups. When true, calling syscall.Setgroups(groupIDs) would
+// not change any ACL check outcome and can be safely skipped.
+//
+// Returning false here is always safe (the caller falls through to the
+// syscall); returning true must only happen when skipping the syscall would
+// leave the process with the exact same effective set, never a superset.
+func effectiveGroupsEqual(groupIDs []int) bool {
+	existing, err := syscall.Getgroups()
+	if err != nil {
+		return false
+	}
+	egid := os.Getegid()
+
+	want := make(map[int]struct{}, len(groupIDs)+1)
+	want[egid] = struct{}{}
+	for _, g := range groupIDs {
+		want[g] = struct{}{}
+	}
+	have := make(map[int]struct{}, len(existing)+1)
+	have[egid] = struct{}{}
+	for _, g := range existing {
+		have[g] = struct{}{}
+	}
+	if len(want) != len(have) {
+		return false
+	}
+	for g := range want {
+		if _, ok := have[g]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func groupsMatchCurrent(groupIDs []int) bool {

--- a/ssh/tailssh/privs_test.go
+++ b/ssh/tailssh/privs_test.go
@@ -272,6 +272,168 @@ func maybeValidUID(id int) bool {
 	return true
 }
 
+// TestSetGroupsSkipsSyscallWhenEffectivelyEqual verifies that setGroups
+// short-circuits without invoking syscall.Setgroups when the requested
+// groups would leave the process's effective access rights unchanged. This
+// matters in sandboxed environments (rootless containers, gVisor, etc.)
+// where the process lacks CAP_SETGID and the syscall would fail with
+// EPERM even when the call is a semantic no-op. The test is intentionally
+// non-root-only so we have non-privileged coverage of the fast path.
+//
+// Two skip cases are exercised:
+//
+//   - the requested supplementary set equals the current one (the case the
+//     #6888 EPERM-recovery already covered, now lifted to a pre-check).
+//   - the requested set restates the primary GID and contains no other
+//     entry, while the current supplementary set is empty — the typical
+//     shape we hit when tailscaled runs as the target user but the user
+//     has no real secondary group memberships (the box+gVisor case).
+func TestSetGroupsSkipsSyscallWhenEffectivelyEqual(t *testing.T) {
+	current, err := syscall.Getgroups()
+	if err != nil {
+		t.Fatalf("Getgroups: %v", err)
+	}
+
+	// Case 1: identical set (reversed, to also pin set-equality semantics).
+	reversed := slices.Clone(current)
+	slices.Reverse(reversed)
+	if err := setGroups(reversed); err != nil {
+		t.Fatalf("setGroups(identical current) returned error: %v", err)
+	}
+
+	// Case 2: target equals only the primary GID. This is a no-op when the
+	// current supplementary set is empty, because the primary GID already
+	// grants the same access. We only exercise it when getgroups() is
+	// empty; if the test environment has supplementary groups we'd be
+	// expanding access by skipping, which must NOT happen.
+	if len(current) == 0 {
+		egid := os.Getegid()
+		if err := setGroups([]int{egid}); err != nil {
+			t.Fatalf("setGroups([egid]) returned error: %v", err)
+		}
+	}
+
+	after, err := syscall.Getgroups()
+	if err != nil {
+		t.Fatalf("Getgroups: %v", err)
+	}
+	wantSet := make(map[int]struct{}, len(current))
+	for _, g := range current {
+		wantSet[g] = struct{}{}
+	}
+	gotSet := make(map[int]struct{}, len(after))
+	for _, g := range after {
+		gotSet[g] = struct{}{}
+	}
+	if !reflect.DeepEqual(wantSet, gotSet) {
+		t.Errorf("supplementary groups changed unexpectedly: before=%v after=%v",
+			current, after)
+	}
+}
+
+// TestEffectiveGroupsEqual pins the helper's semantics: it must return
+// true exactly when skipping syscall.Setgroups would leave the
+// (primary GID ∪ supplementary) effective set unchanged. False negatives
+// are merely a missed optimisation; false positives are a correctness
+// hazard (skipping a real privilege drop), so the test is careful to
+// exercise both sides of that line.
+func TestEffectiveGroupsEqual(t *testing.T) {
+	current, err := syscall.Getgroups()
+	if err != nil {
+		t.Fatalf("Getgroups: %v", err)
+	}
+	egid := os.Getegid()
+
+	// Identical supplementary sets (any order) must match.
+	if !effectiveGroupsEqual(current) {
+		t.Errorf("effectiveGroupsEqual(%v) = false; want true (identical)", current)
+	}
+	reversed := slices.Clone(current)
+	slices.Reverse(reversed)
+	if !effectiveGroupsEqual(reversed) {
+		t.Errorf("effectiveGroupsEqual(%v) = false; want true (reordered)", reversed)
+	}
+
+	// The primary GID is implicitly part of the effective set. Asking for
+	// it as a supplementary group when no other supplementary groups exist
+	// must be treated as effectively equal to the current state.
+	if len(current) == 0 {
+		if !effectiveGroupsEqual([]int{egid}) {
+			t.Errorf("effectiveGroupsEqual([egid]) = false; want true (egid covers it)")
+		}
+	}
+
+	// A request that adds a group not currently held (and not the primary
+	// GID) must not be treated as effectively equal: skipping would leave
+	// access strictly narrower than the caller asked for.
+	other := 0xDEAD
+	for _, g := range current {
+		if g == other {
+			other++
+		}
+	}
+	if other == egid {
+		other++
+	}
+	if effectiveGroupsEqual(append(slices.Clone(current), other)) {
+		t.Errorf("effectiveGroupsEqual(current+other) = true; want false (extra group)")
+	}
+
+	// Conversely, a request that drops a real supplementary group (one
+	// that is not the primary GID) must not be treated as effectively
+	// equal: skipping would leave access strictly wider than the caller
+	// asked for, which would defeat the privilege drop.
+	var realSupp int
+	hasRealSupp := false
+	for _, g := range current {
+		if g != egid {
+			realSupp = g
+			hasRealSupp = true
+			break
+		}
+	}
+	if hasRealSupp {
+		without := make([]int, 0, len(current)-1)
+		for _, g := range current {
+			if g != realSupp {
+				without = append(without, g)
+			}
+		}
+		if effectiveGroupsEqual(without) {
+			t.Errorf("effectiveGroupsEqual(current without %d) = true; want false (dropping a real group)",
+				realSupp)
+		}
+	}
+}
+
+// TestGroupsMatchCurrent keeps explicit coverage of the strict
+// set-equality helper that the EPERM-recovery fallback still relies on.
+func TestGroupsMatchCurrent(t *testing.T) {
+	current, err := syscall.Getgroups()
+	if err != nil {
+		t.Fatalf("Getgroups: %v", err)
+	}
+
+	if !groupsMatchCurrent(current) {
+		t.Errorf("groupsMatchCurrent(%v) = false, want true (identical slice)", current)
+	}
+
+	reversed := slices.Clone(current)
+	slices.Reverse(reversed)
+	if !groupsMatchCurrent(reversed) {
+		t.Errorf("groupsMatchCurrent(%v) = false; ordering should not matter", reversed)
+	}
+
+	if got := groupsMatchCurrent(nil); got != (len(current) == 0) {
+		t.Errorf("groupsMatchCurrent(nil) = %v; want %v", got, len(current) == 0)
+	}
+
+	extra := append(slices.Clone(current), 0xDEAD)
+	if groupsMatchCurrent(extra) {
+		t.Errorf("groupsMatchCurrent(%v) = true; want false (extra entry)", extra)
+	}
+}
+
 func maybeValidGID(id int) bool {
 	_, err := user.LookupGroupId(strconv.Itoa(id))
 	if err == nil {


### PR DESCRIPTION
## What

In `ssh/tailssh/incubator.go`, `setGroups` unconditionally invoked `syscall.Setgroups` and attempted to recover from an `EPERM` after the fact via `groupsMatchCurrent`. The sibling `setgid`/`setuid` calls in `doDropPrivileges` already short-circuit when the current effective ID equals the target. `setGroups` did not, leaving an avoidable syscall on every privilege-drop invocation and a non-recoverable failure in environments that strip `CAP_SETGID`.

This PR moves the skip check **in front of** `syscall.Setgroups` and broadens it from strict set-equality on the supplementary list to equality on the *effective* set (primary GID ∪ supplementary). The original post-`EPERM` fallback is retained as defense in depth.

## Why

### Background

`syscall.Setgroups` was added to `doDropPrivileges` in 337c77964 and immediately regressed Tailscale SSH for non-root `tailscaled` deployments (#6888) because Linux's `setgroups(2)` requires `CAP_SETGID` regardless of whether the call would change anything. Commit be67b8e75 (#6888) added the post-call `EPERM`-and-set-equal fallback that the codebase still uses today.

That fallback recovers correctly when the *current* supplementary list already equals the *requested* one. It does not, however, recover when the requested list restates the primary GID but the current supplementary list is empty — even though that is also a semantic no-op for ACL purposes (the primary GID already grants exactly that membership). This shape is what `tailscaled`'s SSH be-child receives when the target user's `/etc/passwd` has a `gid` that is not also listed with the user as a member in `/etc/group`: `getgrouplist(user, primary_gid)` returns `[primary_gid]`, but the running daemon's `getgroups()` returns `[]`. The post-call fallback can't match those, the call hits `EPERM`, and the child exits with the opaque message `operation not permitted`.

### Effect

- **Behaviour-preserving for every case that previously succeeded.** When the requested set is identical to the current supplementary set, the same end state is reached and `assertPrivilegesWereDropped` still verifies it. When the two sets imply different effective access (current and target have a different `primary GID ∪ supplementary` union), the syscall is still issued and any error still propagates exactly as today.
- **Recovers an additional class of unprivileged deployments.** Specifically, deployments where `tailscaled` runs as the target user and the be-child request restates only the primary GID — rootless container runtimes (Podman rootless, k8s `runAsNonRoot`, Docker `--user`), sandbox runtimes that strip `CAP_SETGID` such as gVisor / `runsc` or Kata, and embedded/IoT installs where the daemon and the SSH target share an unprivileged UID. These are the same deployments #6888 targeted; this is a strictly larger superset of cases it can recover from.
- **Removes one syscall on the privilege-drop hot path** in the common case where the daemon is already at the target group state.

### Why the broader check is still safe

`effectiveGroupsEqual` returns true only when `{egid} ∪ existing == {egid} ∪ requested`. That excludes both:

- the *would-add-a-group* direction (skipping would silently deny the caller a supplementary group they explicitly asked for); and
- the *would-drop-a-real-group* direction (skipping would silently retain a supplementary group the caller asked to drop — defeating the privilege drop).

So the only cases short-circuited are those where the syscall would not have changed any ACL check outcome.

## Tests

Three new non-privileged unit tests:

- `TestSetGroupsSkipsSyscallWhenEffectivelyEqual` — end-to-end fast path coverage, for both the identical-set case and the primary-GID-restated case (the gVisor shape).
- `TestEffectiveGroupsEqual` — pins the helper's correctness boundaries, including the two directions that must **not** short-circuit (would-add-a-group and would-drop-a-real-group).
- `TestGroupsMatchCurrent` — explicit coverage of the strict set-equality helper still used by the `EPERM`-recovery fallback.

`TestDoDropPrivileges` is unchanged and continues to require root, per its existing convention.

```
$ ./tool/go test -count=1 -v -run "TestSetGroupsSkipsSyscallWhenEffectivelyEqual|TestEffectiveGroupsEqual|TestGroupsMatchCurrent|TestDoDropPrivileges" ./ssh/tailssh/
=== RUN   TestDoDropPrivileges
    privs_test.go:75: skipping test; requires root
--- SKIP: TestDoDropPrivileges (0.00s)
=== RUN   TestSetGroupsSkipsSyscallWhenEffectivelyEqual
--- PASS: TestSetGroupsSkipsSyscallWhenEffectivelyEqual (0.00s)
=== RUN   TestEffectiveGroupsEqual
--- PASS: TestEffectiveGroupsEqual (0.00s)
=== RUN   TestGroupsMatchCurrent
--- PASS: TestGroupsMatchCurrent (0.00s)
PASS
```

Updates #6888