### PR TITLE
cmd/k8s-operator: tolerate 404 from VIP services when validating Tailnet OAuth

### DIFF
--- a/k8s-operator/reconciler/tailnet/mocks_test.go
+++ b/k8s-operator/reconciler/tailnet/mocks_test.go
@@ -8,6 +8,7 @@ package tailnet_test
 import (
 	"context"
 	"io"
+	"net/http"
 
 	"tailscale.com/client/tailscale/v2"
 
@@ -16,9 +17,10 @@ import (
 
 type (
 	MockTailnetClient struct {
-		ErrorOnDevices  bool
-		ErrorOnKeys     bool
-		ErrorOnServices bool
+		ErrorOnDevices     bool
+		ErrorOnKeys        bool
+		ErrorOnServices    bool
+		NotFoundOnServices bool
 	}
 
 	MockDeviceResource struct {
@@ -36,7 +38,8 @@ type (
 	MockVIPServiceResource struct {
 		tsclient.VIPServiceResource
 
-		Error bool
+		Error    bool
+		NotFound bool
 	}
 )
 
@@ -57,6 +60,10 @@ func (m MockDeviceResource) List(_ context.Context, _ ...tailscale.ListDevicesOp
 }
 
 func (m MockVIPServiceResource) List(_ context.Context) ([]tailscale.VIPService, error) {
+	if m.NotFound {
+		return nil, tailscale.APIError{Status: http.StatusNotFound, Message: "not found"}
+	}
+
 	if m.Error {
 		return nil, io.EOF
 	}
@@ -73,7 +80,7 @@ func (m MockTailnetClient) Keys() tsclient.KeyResource {
 }
 
 func (m MockTailnetClient) VIPServices() tsclient.VIPServiceResource {
-	return MockVIPServiceResource{Error: m.ErrorOnServices}
+	return MockVIPServiceResource{Error: m.ErrorOnServices, NotFound: m.NotFoundOnServices}
 }
 
 func (m MockTailnetClient) LoginURL() string {

--- a/k8s-operator/reconciler/tailnet/tailnet.go
+++ b/k8s-operator/reconciler/tailnet/tailnet.go
@@ -288,7 +288,12 @@ func (r *Reconciler) ensurePermissions(ctx context.Context, tsClient tsclient.Cl
 		errs = errors.Join(errs, fmt.Errorf("failed to list auth keys: %w", err))
 	}
 
-	if _, err := tsClient.VIPServices().List(ctx); err != nil {
+	// A 404 from the VIP services endpoint is not an authentication problem: it is returned when the
+	// tailnet has no VIP services defined (or the feature is otherwise unavailable to it), even when the
+	// OAuth credentials are valid. VIP services are only required for ingress ProxyGroups, so we treat a
+	// not-found response as "services unavailable" rather than folding it into the OAuth validity check,
+	// where it would surface as a misleading InvalidOAuth condition.
+	if _, err := tsClient.VIPServices().List(ctx); err != nil && !tailscale.IsNotFound(err) {
 		errs = errors.Join(errs, fmt.Errorf("failed to list tailscale services: %w", err))
 	}
 

--- a/k8s-operator/reconciler/tailnet/tailnet_test.go
+++ b/k8s-operator/reconciler/tailnet/tailnet_test.go
@@ -293,6 +293,45 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 		},
 		{
+			Name: "ready-services-not-found-tolerated",
+			Request: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name: "default",
+				},
+			},
+			Tailnet: &tsapi.Tailnet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+				Spec: tsapi.TailnetSpec{
+					Credentials: tsapi.TailnetCredentials{
+						SecretName: "test",
+					},
+				},
+			},
+			Secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "tailscale",
+				},
+				Data: map[string][]byte{
+					"client_id":     []byte("test"),
+					"client_secret": []byte("test"),
+				},
+			},
+			ClientFunc: func(_ *tsapi.Tailnet, _ *corev1.Secret) tsclient.Client {
+				return &MockTailnetClient{NotFoundOnServices: true}
+			},
+			ExpectedConditions: []metav1.Condition{
+				{
+					Type:    string(tsapi.TailnetReady),
+					Status:  metav1.ConditionTrue,
+					Reason:  tailnet.ReasonValid,
+					Message: tailnet.ReasonValid,
+				},
+			},
+		},
+		{
 			Name: "ready-valid-scopes-correct",
 			Request: reconcile.Request{
 				NamespacedName: types.NamespacedName{


### PR DESCRIPTION

The `Tailnet` reconciler validates OAuth credentials in `ensurePermissions` by issuing
read-only `List` calls to the devices, keys, and VIP services APIs. Previously, **any**
error from these calls was joined together and surfaced as an `InvalidOAuth` condition on
the `Tailnet`.

The VIP services endpoint (`/api/v2/tailnet/-/vip-services`) returns **404** when the tailnet
has no VIP services defined (or the feature is otherwise unavailable to it) — even when the
OAuth credentials are valid and authenticate successfully, and `/devices` and `/keys` both
return 200. As reported in #19471, this marked the `Tailnet` as `NotReady` with
`reason: InvalidOAuth` and a misleading message, sending operators down a credential-rotation
rabbit hole when nothing was actually wrong with their credentials.

Since VIP services are only required for ingress `ProxyGroups`, this treats a not-found
response from the VIP services list as "services unavailable" rather than folding it into the
OAuth-validity check. It reuses the existing `tailscale.IsNotFound` helper — the same idiom
already used in `cmd/k8s-operator/api-server-proxy-pg.go`. Other errors (and 404s from the
`/devices` or `/keys` endpoints) are unaffected and still surface as `InvalidOAuth`.

### Why this approach

The issue lists two acceptable fixes: (1) a distinct condition type (e.g.
`TailnetProbeIncomplete`) naming the failing endpoint, or (2) gracefully tolerating a 404 on
`/vip-services`. This PR takes **option 2** — it's the smaller, lower-risk change, it keeps
the diff to a single guarded condition, it reuses an existing helper, and it matches the
issue's framing of "treat as services not available." Happy to switch to option 1 (a new
condition type) if the maintainers would rather surface non-auth probe failures distinctly.

### Testing

- New table case `ready-services-not-found-tolerated`: a 404 from `VIPServices().List` with
  otherwise-valid credentials now yields `TailnetReady = True` / `TailnetValid`.
- Existing `invalid-status-bad-services-scope` (a non-404 error → `InvalidOAuth`) is unchanged
  and still passes, confirming only not-found responses are tolerated.
- `go test ./k8s-operator/...` — all 8 packages pass. `go vet ./k8s-operator/...` clean.

## Files changed (3, +57/-6)

- `k8s-operator/reconciler/tailnet/tailnet.go` — the one-line guard + explanatory comment
- `k8s-operator/reconciler/tailnet/mocks_test.go` — `NotFoundOnServices` flag → returns
  `tailscale.APIError{Status: 404}`
- `k8s-operator/reconciler/tailnet/tailnet_test.go` — new test case