### PR TITLE
logtail: gate "logtail started" behind TS_DEBUG_LOGTAIL envknob

### DIFF
--- a/logtail/logtail.go
+++ b/logtail/logtail.go
@@ -138,7 +138,9 @@ func NewLogger(cfg Config, logf tslogger.Logf) *Logger {
 	logger.uploadCancel = cancel
 
 	go logger.uploading(ctx)
-	logger.Write([]byte("logtail started"))
+	if envknob.Bool("TS_DEBUG_LOGTAIL") {
+		logger.Write([]byte("logtail started"))
+	}
 	return logger
 }
 

--- a/logtail/logtail_test.go
+++ b/logtail/logtail_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/go-json-experiment/json/jsontext"
+	"tailscale.com/envknob"
 	"tailscale.com/net/memnet"
 	"tailscale.com/tstest"
 	"tailscale.com/tstime"
@@ -67,6 +68,8 @@ type LogtailTestServer struct {
 // *Logger whose HTTPC dials it. Lives inside the caller's synctest bubble so
 // the default FlushDelay and any other fake timers advance automatically.
 func newTestLogtailServer(t *testing.T) (*LogtailTestServer, *Logger) {
+	// Enable the logtail started message
+	envknob.Setenv("TS_DEBUG_LOGTAIL", "1")
 	ts := &LogtailTestServer{
 		// max channel backlog = 1 "started" + #logLines x "log line" + 1 "closed"
 		uploaded: make(chan []byte, 2+logLines),


### PR DESCRIPTION
Gates the unnecessary "logtail started" message behind the debug envknob TS_DEBUG_LOGTAIL. This is extra log spam that isn't needed unless we are debugging.

Updates tailscale/corp#40908