### PR TITLE
cmd/containerboot: fix data race in TestContainerBoot

### DIFF
--- a/cmd/containerboot/main_test.go
+++ b/cmd/containerboot/main_test.go
@@ -1288,6 +1288,9 @@ func TestContainerBoot(t *testing.T) {
 					}
 				}
 				if p.Notify != nil && p.Notify.InitialStatus == nil {
+					// Shallow-copy before mutating to avoid a race with
+					// parallel subtests that share the same *ipn.Notify.
+					p.Notify = new(*p.Notify)
 					p.Notify.InitialStatus = statusFromNotify(p.Notify)
 				}
 				env.lapi.Notify(p.Notify)


### PR DESCRIPTION
Parallel subtests share *ipn.Notify pointers (e.g. runningNotify).
When multiple subtests reached the same phase concurrently, they
all wrote to the shared notify's InitialStatus field without
synchronization, triggering the race detector.

Fix by shallow-copying *ipn.Notify before setting InitialStatus,
so each test iteration works on its own copy.

Updates #19380
