### PR TITLE
cmd/k8s-operator: filter Services without ProxyGroup annotation

### DIFF
--- a/cmd/k8s-operator/operator.go
+++ b/cmd/k8s-operator/operator.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	kzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -292,6 +293,20 @@ func serviceManagedResourceFilterPredicate() predicate.Predicate {
 	})
 }
 
+// Check to verify that either the new OR old object had the ProxyGroup annotation, allowing
+// either cleanup (if on old, but not new) or skip (on neither)
+func serviceHasProxyGroupAnnotationPredicate() predicate.Predicate {
+	has := func(o client.Object) bool {
+		return o != nil && o.GetAnnotations()[AnnotationProxyGroup] != ""
+	}
+	return predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return has(e.Object) },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return has(e.Object) },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return has(e.ObjectOld) || has(e.ObjectNew) },
+		GenericFunc: func(e event.GenericEvent) bool { return has(e.Object) },
+	}
+}
+
 type (
 	ClientProvider interface {
 		For(tailnet string) (tsclient.Client, error)
@@ -495,7 +510,10 @@ func runReconcilers(opts reconcilerOpts) {
 	ingressSvcFromEpsFilter := handler.EnqueueRequestsFromMapFunc(ingressSvcFromEps(mgr.GetClient(), opts.log.Named("service-pg-reconciler")))
 	err = builder.
 		ControllerManagedBy(mgr).
-		For(&corev1.Service{}, builder.WithPredicates(serviceManagedResourceFilterPredicate())).
+		For(&corev1.Service{}, builder.WithPredicates(
+			serviceManagedResourceFilterPredicate(),
+			serviceHasProxyGroupAnnotationPredicate(),
+		)).
 		Named("service-pg-reconciler").
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(HAServicesFromSecret(mgr.GetClient(), startlog))).
 		Watches(&tsapi.ProxyGroup{}, ingressProxyGroupFilter).

--- a/cmd/k8s-operator/svc-for-pg_test.go
+++ b/cmd/k8s-operator/svc-for-pg_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"tailscale.com/client/tailscale/v2"
 
 	tsoperator "tailscale.com/k8s-operator"
@@ -465,6 +466,37 @@ func TestIgnoreRegularService(t *testing.T) {
 		if len(tsSvcs) > 0 {
 			t.Fatal("unexpected Tailscale Services found")
 		}
+	}
+}
+
+func TestServiceHasProxyGroupAnnotationPredicate(t *testing.T) {
+	p := serviceHasProxyGroupAnnotationPredicate()
+	with := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Annotations: map[string]string{AnnotationProxyGroup: "pg"},
+	}}
+	without := &corev1.Service{}
+
+	// Update must pass if either side has the annotation, so removal events
+	// still reach Reconcile and the finalizer cleanup path can run.
+	for _, tc := range []struct {
+		name string
+		got  bool
+		want bool
+	}{
+		{"create_with_annotation", p.Create(event.CreateEvent{Object: with}), true},
+		{"create_without_annotation", p.Create(event.CreateEvent{Object: without}), false},
+		{"delete_with_annotation", p.Delete(event.DeleteEvent{Object: with}), true},
+		{"delete_without_annotation", p.Delete(event.DeleteEvent{Object: without}), false},
+		{"update_annotation_removed", p.Update(event.UpdateEvent{ObjectOld: with, ObjectNew: without}), true},
+		{"update_annotation_added", p.Update(event.UpdateEvent{ObjectOld: without, ObjectNew: with}), true},
+		{"update_both_have_annotation", p.Update(event.UpdateEvent{ObjectOld: with, ObjectNew: with}), true},
+		{"update_neither_has_annotation", p.Update(event.UpdateEvent{ObjectOld: without, ObjectNew: without}), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Fatalf("predicate returned %v, want %v", tc.got, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
I've been wondering about these log messages that seem very noisy and conceptually don't make sense to me for a bit but one of my co-workers noticed them today as well and asked about it and so it prompted me to try and get rid of them.

For instance. we have a service that _does_ leverage Tailscale to create an externalName service.  But that service doesn't have the proxygroup annotation. (we could put it on an egressproxy, but it didn't really seem to buy us much). Anytime that service updates, Tailscale logs:

```
"[unexpected] no ProxyGroup annotation, skipping Tailscale Service provisioning"
```

As I said, that _isn't_ actually unexpected, but also, this seemed more like a debug log than an info log (although, maybe it should be a warning level? not sure why yall dont use warning on these `unexpected` errors).  Originally I was going to just look at switching it to Debug but then I realized it might be unexpected because of wher eit sits in the workflow, and so upon looking further it seems like there may have been an expectation that this was only services that were annotated, but I couldn't find anything that was doing that check.

Then as I was working on the implementation to not reconcile the service it wasn't annotated I realized that
it would then also skip a service that had its annotation removed, and wondered if it was already
skipping them.  Looking through the flow it _seems_ that the finalizer sits after the annotation check thus
leaving Services that have been un-annotated to not be reconciled.

This check should allow the predicate filter to not skip over that use case, but also stop throwing
and `unexpected` info log on every service that changes even if it is actually expected (by the operators)
for that service to not have an annotation.

There didn't seem to be any tests that would have caught this, so I also added those.

Followup: I think Ingress has the same problem, but wasn't going to try to fix that without checking on this first.

Fixes: #19922

RELNOTE: k8s-operator: clean up Tailscale Service when ProxyGroup annotation is removed.