### PR TITLE
.github/workflows: run vet on GitHub-hosted runners

### DIFF
--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -14,14 +14,16 @@ on:
       - main
       - "release-branch/*"
     paths:
+      - .github/workflows/vet.yml
       - "**.go"
   pull_request:
     paths:
+      - .github/workflows/vet.yml
       - "**.go"
 
 jobs:
   vet:
-    runs-on: [ self-hosted, linux ]
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     steps:


### PR DESCRIPTION
The github-ci-vm machine that runs our self-hosted CI for this repo is only designed for the `vm` job in test.yml. That uses a different cache dir which is causing github-ci-vm's small disk to fill up. Switch to ubuntu 24.04 like the rest of our CI for this repo that doesn't require anything special.

Updates tailscale/corp#40465