### PR TITLE
Feature/enhanced accept routes

### DIFF
--- a/cmd/tailscale/cli/accept_routes_test.go
+++ b/cmd/tailscale/cli/accept_routes_test.go
@@ -50,6 +50,14 @@ func TestParseAcceptRoutes(t *testing.T) {
 			wantErr:      false,
 		},
 		{
+			name:         "flag without value (backward compat)",
+			input:        "true", // This is what the custom flag sets when used without value
+			goos:         "linux",
+			wantRouteAll: true,
+			wantAccepted: nil,
+			wantErr:      false,
+		},
+		{
 			name:         "single CIDR",
 			input:        "10.0.0.0/8",
 			goos:         "linux",

--- a/cmd/tailscale/cli/accept_routes_test.go
+++ b/cmd/tailscale/cli/accept_routes_test.go
@@ -1,0 +1,146 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package cli
+
+import (
+	"net/netip"
+	"testing"
+)
+
+func TestParseAcceptRoutes(t *testing.T) {
+	tests := []struct {
+		name            string
+		input           string
+		goos            string
+		wantRouteAll    bool
+		wantAccepted    []netip.Prefix
+		wantErr         bool
+	}{
+		{
+			name:         "empty string uses default (linux)",
+			input:        "",
+			goos:         "linux",
+			wantRouteAll: false,
+			wantAccepted: nil,
+			wantErr:      false,
+		},
+		{
+			name:         "empty string uses default (windows)",
+			input:        "",
+			goos:         "windows",
+			wantRouteAll: true,
+			wantAccepted: nil,
+			wantErr:      false,
+		},
+		{
+			name:         "true value",
+			input:        "true",
+			goos:         "linux",
+			wantRouteAll: true,
+			wantAccepted: nil,
+			wantErr:      false,
+		},
+		{
+			name:         "false value",
+			input:        "false",
+			goos:         "linux",
+			wantRouteAll: false,
+			wantAccepted: nil,
+			wantErr:      false,
+		},
+		{
+			name:         "single CIDR",
+			input:        "10.0.0.0/8",
+			goos:         "linux",
+			wantRouteAll: true,
+			wantAccepted: []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")},
+			wantErr:      false,
+		},
+		{
+			name:         "multiple CIDRs",
+			input:        "10.0.0.0/8,192.168.0.0/16",
+			goos:         "linux",
+			wantRouteAll: true,
+			wantAccepted: []netip.Prefix{
+				netip.MustParsePrefix("10.0.0.0/8"),
+				netip.MustParsePrefix("192.168.0.0/16"),
+			},
+			wantErr: false,
+		},
+		{
+			name:         "CIDRs with spaces",
+			input:        "10.0.0.0/8, 192.168.0.0/16 , 172.16.0.0/12",
+			goos:         "linux",
+			wantRouteAll: true,
+			wantAccepted: []netip.Prefix{
+				netip.MustParsePrefix("10.0.0.0/8"),
+				netip.MustParsePrefix("192.168.0.0/16"),
+				netip.MustParsePrefix("172.16.0.0/12"),
+			},
+			wantErr: false,
+		},
+		{
+			name:         "IPv6 CIDR",
+			input:        "fd7a:115c:a1e0::/48",
+			goos:         "linux",
+			wantRouteAll: true,
+			wantAccepted: []netip.Prefix{netip.MustParsePrefix("fd7a:115c:a1e0::/48")},
+			wantErr:      false,
+		},
+		{
+			name:         "mixed IPv4 and IPv6",
+			input:        "10.0.0.0/8,fd7a:115c:a1e0::/48",
+			goos:         "linux",
+			wantRouteAll: true,
+			wantAccepted: []netip.Prefix{
+				netip.MustParsePrefix("10.0.0.0/8"),
+				netip.MustParsePrefix("fd7a:115c:a1e0::/48"),
+			},
+			wantErr: false,
+		},
+		{
+			name:    "invalid CIDR",
+			input:   "10.0.0.0/99",
+			goos:    "linux",
+			wantErr: true,
+		},
+		{
+			name:    "invalid format",
+			input:   "not-a-cidr",
+			goos:    "linux",
+			wantErr: true,
+		},
+		{
+			name:    "empty list",
+			input:   ",,,",
+			goos:    "linux",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotRouteAll, gotAccepted, err := parseAcceptRoutes(tt.input, tt.goos)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseAcceptRoutes() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil {
+				return
+			}
+			if gotRouteAll != tt.wantRouteAll {
+				t.Errorf("parseAcceptRoutes() routeAll = %v, want %v", gotRouteAll, tt.wantRouteAll)
+			}
+			if len(gotAccepted) != len(tt.wantAccepted) {
+				t.Errorf("parseAcceptRoutes() acceptedRoutes length = %v, want %v", len(gotAccepted), len(tt.wantAccepted))
+				return
+			}
+			for i := range gotAccepted {
+				if gotAccepted[i] != tt.wantAccepted[i] {
+					t.Errorf("parseAcceptRoutes() acceptedRoutes[%d] = %v, want %v", i, gotAccepted[i], tt.wantAccepted[i])
+				}
+			}
+		})
+	}
+}

--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -1054,6 +1054,10 @@ func TestPrefFlagMapping(t *testing.T) {
 		case "AutoExitNode":
 			// Handled by tailscale {set,up} --exit-node=auto:any.
 			continue
+		case "AcceptedRoutes":
+			// Handled by tailscale {set,up} --accept-routes when CIDR list is provided.
+			// Only set when user provides specific CIDRs, not for boolean values.
+			continue
 		}
 		t.Errorf("unexpected new ipn.Pref field %q is not handled by up.go (see addPrefFlagMapping and checkForAccidentalSettingReverts)", prefName)
 	}

--- a/cmd/tailscale/cli/set.go
+++ b/cmd/tailscale/cli/set.go
@@ -44,7 +44,7 @@ Only settings explicitly mentioned will be set. There are no default values.`,
 }
 
 type setArgsT struct {
-	acceptRoutes               bool
+	acceptRoutes               string
 	acceptDNS                  bool
 	exitNodeIP                 string
 	exitNodeAllowLANAccess     bool
@@ -74,7 +74,7 @@ func newSetFlagSet(goos string, setArgs *setArgsT) *flag.FlagSet {
 	setf := newFlagSet("set")
 
 	setf.StringVar(&setArgs.profileName, "nickname", "", "nickname for the current account")
-	setf.BoolVar(&setArgs.acceptRoutes, "accept-routes", acceptRouteDefault(goos), "accept routes advertised by other Tailscale nodes")
+	setf.StringVar(&setArgs.acceptRoutes, "accept-routes", "", "accept routes advertised by other Tailscale nodes (true/false) or comma-separated list of CIDR blocks to selectively accept")
 	setf.BoolVar(&setArgs.acceptDNS, "accept-dns", true, "accept DNS configuration from the admin panel")
 	setf.StringVar(&setArgs.exitNodeIP, "exit-node", "", "Tailscale exit node (IP, base name, or auto:any) for internet traffic, or empty string to not use an exit node")
 	setf.BoolVar(&setArgs.exitNodeAllowLANAccess, "exit-node-allow-lan-access", false, "Allow direct access to the local network when routing traffic via an exit node")
@@ -138,13 +138,20 @@ func runSet(ctx context.Context, args []string) (retErr error) {
 		return err
 	}
 
+	// Parse accept-routes flag
+	routeAll, acceptedRoutes, err := parseAcceptRoutes(setArgs.acceptRoutes, effectiveGOOS())
+	if err != nil {
+		return err
+	}
+
 	// Note that even though we set the values here regardless of whether the
 	// user passed the flag, the value is only used if the user passed the flag.
 	// See updateMaskedPrefsFromUpOrSetFlag.
 	maskedPrefs := &ipn.MaskedPrefs{
 		Prefs: ipn.Prefs{
 			ProfileName:            setArgs.profileName,
-			RouteAll:               setArgs.acceptRoutes,
+			RouteAll:               routeAll,
+			AcceptedRoutes:         acceptedRoutes,
 			CorpDNS:                setArgs.acceptDNS,
 			ExitNodeAllowLANAccess: setArgs.exitNodeAllowLANAccess,
 			ShieldsUp:              setArgs.shieldsUp,
@@ -200,6 +207,11 @@ func runSet(ctx context.Context, args []string) (retErr error) {
 			advertiseExitNodeSet = true
 		case "advertise-routes":
 			advertiseRoutesSet = true
+		case "accept-routes":
+			// AcceptedRoutes should only be set when a CIDR list is provided
+			if len(acceptedRoutes) > 0 {
+				maskedPrefs.AcceptedRoutesSet = true
+			}
 		}
 	})
 	if maskedPrefs.IsEmpty() {

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -106,7 +106,7 @@ func newUpFlagSet(goos string, upArgs *upArgsT, cmd string) *flag.FlagSet {
 	upf.StringVar(&upArgs.idTokenOrFile, "id-token", "", `ID token from the identity provider to exchange with the control server for workload identity federation; if it begins with "file:", then it's a path to a file containing the token`)
 
 	upf.StringVar(&upArgs.server, "login-server", ipn.DefaultControlURL, "base URL of control server")
-	upf.BoolVar(&upArgs.acceptRoutes, "accept-routes", acceptRouteDefault(goos), "accept routes advertised by other Tailscale nodes")
+	upf.StringVar(&upArgs.acceptRoutes, "accept-routes", "", "accept routes advertised by other Tailscale nodes (true/false) or comma-separated list of CIDR blocks to selectively accept")
 	upf.BoolVar(&upArgs.acceptDNS, "accept-dns", true, "accept DNS configuration from the admin panel")
 	upf.Var(notFalseVar{}, "host-routes", hidden+"install host routes to other Tailscale nodes (must be true as of Tailscale 1.67+)")
 	upf.StringVar(&upArgs.exitNodeIP, "exit-node", "", "Tailscale exit node (IP, base name, or auto:any) for internet traffic, or empty string to not use an exit node")
@@ -178,7 +178,7 @@ type upArgsT struct {
 	qrFormat               string
 	reset                  bool
 	server                 string
-	acceptRoutes           bool
+	acceptRoutes           string
 	acceptDNS              bool
 	exitNodeIP             string
 	exitNodeAllowLANAccess bool
@@ -219,6 +219,51 @@ func resolveValueFromFile(v string) (string, error) {
 		return strings.TrimSpace(string(b)), nil
 	}
 	return v, nil
+}
+
+// parseAcceptRoutes parses the --accept-routes flag value.
+// It supports:
+//   - "" (empty): use platform default
+//   - "true": accept all routes (RouteAll=true, AcceptedRoutes=nil)
+//   - "false": accept no routes (RouteAll=false, AcceptedRoutes=nil)
+//   - "CIDR,CIDR,...": accept only specific CIDRs (RouteAll=true, AcceptedRoutes=list)
+func parseAcceptRoutes(v string, goos string) (routeAll bool, acceptedRoutes []netip.Prefix, err error) {
+	v = strings.TrimSpace(v)
+
+	// Empty means use default
+	if v == "" {
+		return acceptRouteDefault(goos), nil, nil
+	}
+
+	// Boolean values
+	if v == "true" {
+		return true, nil, nil
+	}
+	if v == "false" {
+		return false, nil, nil
+	}
+
+	// Parse as comma-separated CIDR list
+	cidrs := strings.Split(v, ",")
+	acceptedRoutes = make([]netip.Prefix, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		cidr = strings.TrimSpace(cidr)
+		if cidr == "" {
+			continue
+		}
+		prefix, err := netip.ParsePrefix(cidr)
+		if err != nil {
+			return false, nil, fmt.Errorf("invalid CIDR %q: %w", cidr, err)
+		}
+		acceptedRoutes = append(acceptedRoutes, prefix)
+	}
+	
+	if len(acceptedRoutes) == 0 {
+		return false, nil, fmt.Errorf("--accept-routes: no valid CIDR blocks provided")
+	}
+
+	// When specific CIDRs are provided, set RouteAll=true so the filtering logic activates
+	return true, acceptedRoutes, nil
 }
 
 // resolveValueFromParameterStore resolves a value from AWS Parameter Store if
@@ -330,7 +375,15 @@ func prefsFromUpArgs(upArgs upArgsT, warnf logger.Logf, st *ipnstate.Status, goo
 	prefs := ipn.NewPrefs()
 	prefs.ControlURL = upArgs.server
 	prefs.WantRunning = true
-	prefs.RouteAll = upArgs.acceptRoutes
+
+	// Parse accept-routes flag
+	routeAll, acceptedRoutes, err := parseAcceptRoutes(upArgs.acceptRoutes, goos)
+	if err != nil {
+		return nil, err
+	}
+	prefs.RouteAll = routeAll
+	prefs.AcceptedRoutes = acceptedRoutes
+
 	if distro.Get() == distro.Synology {
 		// ipn.NewPrefs returns a non-zero Netfilter default. But Synology only
 		// supports "off" mode.
@@ -482,6 +535,10 @@ func updatePrefs(prefs, curPrefs *ipn.Prefs, env upCheckEnv) (simpleUp bool, jus
 		visitFlags(func(f *flag.Flag) {
 			updateMaskedPrefsFromUpOrSetFlag(justEditMP, f.Name)
 		})
+		// AcceptedRoutes should only be set when a CIDR list is provided, not for boolean values
+		if len(prefs.AcceptedRoutes) > 0 {
+			justEditMP.AcceptedRoutesSet = true
+		}
 	}
 
 	return simpleUp, justEditMP, nil
@@ -536,7 +593,7 @@ func runUp(ctx context.Context, cmd string, args []string, upArgs upArgsT) (retE
 
 	if distro.Get() == distro.Synology {
 		notSupported := "not supported on Synology; see https://github.com/tailscale/tailscale/issues/1995"
-		if upArgs.acceptRoutes {
+		if upArgs.acceptRoutes != "" && upArgs.acceptRoutes != "false" {
 			return errors.New("--accept-routes is " + notSupported)
 		}
 		if upArgs.exitNodeIP != "" {
@@ -1155,7 +1212,20 @@ func prefsToFlags(env upCheckEnv, prefs *ipn.Prefs) (flagVal map[string]any) {
 		case "login-server":
 			set(prefs.ControlURL)
 		case "accept-routes":
-			set(prefs.RouteAll)
+			if len(prefs.AcceptedRoutes) > 0 {
+				// If specific routes are set, return them as comma-separated list
+				var sb strings.Builder
+				for i, r := range prefs.AcceptedRoutes {
+					if i > 0 {
+						sb.WriteByte(',')
+					}
+					sb.WriteString(r.String())
+				}
+				set(sb.String())
+			} else {
+				// Otherwise return boolean value
+				set(prefs.RouteAll)
+			}
 		case "accept-dns":
 			set(prefs.CorpDNS)
 		case "shields-up":

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -106,7 +106,7 @@ func newUpFlagSet(goos string, upArgs *upArgsT, cmd string) *flag.FlagSet {
 	upf.StringVar(&upArgs.idTokenOrFile, "id-token", "", `ID token from the identity provider to exchange with the control server for workload identity federation; if it begins with "file:", then it's a path to a file containing the token`)
 
 	upf.StringVar(&upArgs.server, "login-server", ipn.DefaultControlURL, "base URL of control server")
-	upf.StringVar(&upArgs.acceptRoutes, "accept-routes", "", "accept routes advertised by other Tailscale nodes (true/false) or comma-separated list of CIDR blocks to selectively accept")
+	upf.Var(acceptRoutesFlag{&upArgs.acceptRoutes}, "accept-routes", "accept routes advertised by other Tailscale nodes (true/false/CIDR list); can be used without value for true")
 	upf.BoolVar(&upArgs.acceptDNS, "accept-dns", true, "accept DNS configuration from the admin panel")
 	upf.Var(notFalseVar{}, "host-routes", hidden+"install host routes to other Tailscale nodes (must be true as of Tailscale 1.67+)")
 	upf.StringVar(&upArgs.exitNodeIP, "exit-node", "", "Tailscale exit node (IP, base name, or auto:any) for internet traffic, or empty string to not use an exit node")
@@ -206,6 +206,36 @@ type upArgsT struct {
 	acceptedRisks          string
 	profileName            string
 	postureChecking        bool
+}
+
+// acceptRoutesFlag is a custom flag type that handles --accept-routes with optional values.
+// It supports the old boolean behavior (--accept-routes without value means true)
+// and the new CIDR list behavior (--accept-routes=10.0.0.0/8,192.168.0.0/16).
+type acceptRoutesFlag struct {
+	v *string
+}
+
+func (f acceptRoutesFlag) String() string {
+	if f.v == nil {
+		return ""
+	}
+	return *f.v
+}
+
+func (f acceptRoutesFlag) Set(s string) error {
+	// When used as a bool flag without a value (--accept-routes), s will be ""
+	// Treat this as "true" for backward compatibility with the old bool behavior
+	if s == "" {
+		*f.v = "true"
+	} else {
+		*f.v = s
+	}
+	return nil
+}
+
+func (f acceptRoutesFlag) IsBoolFlag() bool {
+	// This tells the flag parser that this flag can be used without a value
+	return true
 }
 
 // resolveValueFromFile returns the value as-is, or if it starts with "file:",

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -49,6 +49,7 @@ func (src *Prefs) Clone() *Prefs {
 	dst := new(Prefs)
 	*dst = *src
 	dst.AdvertiseTags = append(src.AdvertiseTags[:0:0], src.AdvertiseTags...)
+	dst.AcceptedRoutes = append(src.AcceptedRoutes[:0:0], src.AcceptedRoutes...)
 	dst.AdvertiseRoutes = append(src.AdvertiseRoutes[:0:0], src.AdvertiseRoutes...)
 	dst.AdvertiseServices = append(src.AdvertiseServices[:0:0], src.AdvertiseServices...)
 	if src.DriveShares != nil {
@@ -73,6 +74,7 @@ func (src *Prefs) Clone() *Prefs {
 var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	ControlURL                 string
 	RouteAll                   bool
+	AcceptedRoutes             []netip.Prefix
 	ExitNodeID                 tailcfg.StableNodeID
 	ExitNodeIP                 netip.Addr
 	AutoExitNode               ExitNodeExpression

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -233,6 +233,16 @@ func (v PrefsView) ControlURL() string { return v.ж.ControlURL }
 // controlled by ExitNodeID/IP below.
 func (v PrefsView) RouteAll() bool { return v.ж.RouteAll }
 
+// AcceptedRoutes specifies a list of specific CIDR blocks to accept
+// from advertised routes. If non-empty, only routes matching these
+// CIDR blocks will be accepted, regardless of the RouteAll setting.
+// This allows selective route acceptance to avoid routing conflicts
+// with local networks. If empty and RouteAll is true, all advertised
+// routes are accepted (backward compatible behavior).
+func (v PrefsView) AcceptedRoutes() views.Slice[netip.Prefix] {
+	return views.SliceOf(v.ж.AcceptedRoutes)
+}
+
 // ExitNodeID and ExitNodeIP specify the node that should be used
 // as an exit node for internet traffic. At most one of these
 // should be non-zero.
@@ -475,6 +485,7 @@ func (v PrefsView) Persist() persist.PersistView { return v.ж.Persist.View() }
 var _PrefsViewNeedsRegeneration = Prefs(struct {
 	ControlURL                 string
 	RouteAll                   bool
+	AcceptedRoutes             []netip.Prefix
 	ExitNodeID                 tailcfg.StableNodeID
 	ExitNodeIP                 netip.Addr
 	AutoExitNode               ExitNodeExpression

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -5790,7 +5790,7 @@ func (b *LocalBackend) authReconfigLocked() {
 		priv = key.NodePrivate{}
 	}
 
-	cfg, err := nmcfg.WGCfg(priv, nm, b.logf, flags, prefs.ExitNodeID())
+	cfg, err := nmcfg.WGCfg(priv, nm, b.logf, flags, prefs.ExitNodeID(), prefs.AcceptedRoutes().AsSlice())
 	if err != nil {
 		b.logf("wgcfg: %v", err)
 		return

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -79,6 +79,14 @@ type Prefs struct {
 	// controlled by ExitNodeID/IP below.
 	RouteAll bool
 
+	// AcceptedRoutes specifies a list of specific CIDR blocks to accept
+	// from advertised routes. If non-empty, only routes matching these
+	// CIDR blocks will be accepted, regardless of the RouteAll setting.
+	// This allows selective route acceptance to avoid routing conflicts
+	// with local networks. If empty and RouteAll is true, all advertised
+	// routes are accepted (backward compatible behavior).
+	AcceptedRoutes []netip.Prefix
+
 	// ExitNodeID and ExitNodeIP specify the node that should be used
 	// as an exit node for internet traffic. At most one of these
 	// should be non-zero.
@@ -355,6 +363,7 @@ type MaskedPrefs struct {
 
 	ControlURLSet                 bool                `json:",omitempty"`
 	RouteAllSet                   bool                `json:",omitempty"`
+	AcceptedRoutesSet             bool                `json:",omitempty"`
 	ExitNodeIDSet                 bool                `json:",omitempty"`
 	ExitNodeIPSet                 bool                `json:",omitempty"`
 	AutoExitNodeSet               bool                `json:",omitempty"`
@@ -662,6 +671,7 @@ func (p *Prefs) Equals(p2 *Prefs) bool {
 
 	return p.ControlURL == p2.ControlURL &&
 		p.RouteAll == p2.RouteAll &&
+		slices.Equal(p.AcceptedRoutes, p2.AcceptedRoutes) &&
 		p.ExitNodeID == p2.ExitNodeID &&
 		p.ExitNodeIP == p2.ExitNodeIP &&
 		p.AutoExitNode == p2.AutoExitNode &&

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -368,7 +368,7 @@ func meshStacks(logf logger.Logf, mutateNetmap func(idx int, nm *netmap.NetworkM
 				peerSet.Add(peer.Key())
 			}
 			m.conn.UpdatePeers(peerSet)
-			wg, err := nmcfg.WGCfg(ms[i].privateKey, nm, logf, 0, "")
+			wg, err := nmcfg.WGCfg(ms[i].privateKey, nm, logf, 0, "", nil)
 			if err != nil {
 				// We're too far from the *testing.T to be graceful,
 				// blow up. Shouldn't happen anyway.
@@ -2349,7 +2349,7 @@ func TestIsWireGuardOnlyPeer(t *testing.T) {
 	}
 	m.conn.SetNetworkMap(nm.SelfNode, nm.Peers)
 
-	cfg, err := nmcfg.WGCfg(m.privateKey, nm, t.Logf, netmap.AllowSubnetRoutes, "")
+	cfg, err := nmcfg.WGCfg(m.privateKey, nm, t.Logf, netmap.AllowSubnetRoutes, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2410,7 +2410,7 @@ func TestIsWireGuardOnlyPeerWithMasquerade(t *testing.T) {
 	}
 	m.conn.SetNetworkMap(nm.SelfNode, nm.Peers)
 
-	cfg, err := nmcfg.WGCfg(m.privateKey, nm, t.Logf, netmap.AllowSubnetRoutes, "")
+	cfg, err := nmcfg.WGCfg(m.privateKey, nm, t.Logf, netmap.AllowSubnetRoutes, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2450,7 +2450,7 @@ func applyNetworkMap(t *testing.T, m *magicStack, nm *netmap.NetworkMap) {
 	m.conn.noV6.Store(true)
 
 	// Turn the network map into a wireguard config (for the tailscale internal wireguard device).
-	cfg, err := nmcfg.WGCfg(m.privateKey, nm, t.Logf, netmap.AllowSubnetRoutes, "")
+	cfg, err := nmcfg.WGCfg(m.privateKey, nm, t.Logf, netmap.AllowSubnetRoutes, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/wgengine/wgcfg/nmcfg/nmcfg.go
+++ b/wgengine/wgcfg/nmcfg/nmcfg.go
@@ -46,7 +46,7 @@ func cidrIsSubnet(node tailcfg.NodeView, cidr netip.Prefix) bool {
 }
 
 // WGCfg returns the NetworkMaps's WireGuard configuration.
-func WGCfg(pk key.NodePrivate, nm *netmap.NetworkMap, logf logger.Logf, flags netmap.WGConfigFlags, exitNode tailcfg.StableNodeID) (*wgcfg.Config, error) {
+func WGCfg(pk key.NodePrivate, nm *netmap.NetworkMap, logf logger.Logf, flags netmap.WGConfigFlags, exitNode tailcfg.StableNodeID, acceptedRoutes []netip.Prefix) (*wgcfg.Config, error) {
 	cfg := &wgcfg.Config{
 		PrivateKey: pk,
 		Addresses:  nm.GetAddresses().AsSlice(),
@@ -114,6 +114,21 @@ func WGCfg(pk key.NodePrivate, nm *netmap.NetworkMap, logf logger.Logf, flags ne
 				if (flags & netmap.AllowSubnetRoutes) == 0 {
 					skippedSubnetRouter = append(skippedSubnetRouter, peer)
 					continue
+				}
+				// If specific routes are configured, only accept routes that match
+				if len(acceptedRoutes) > 0 {
+					accepted := false
+					for _, acceptedRoute := range acceptedRoutes {
+						// Check if the advertised route matches or is contained within an accepted route
+						if acceptedRoute.Contains(allowedIP.Addr()) || allowedIP.Contains(acceptedRoute.Addr()) {
+							accepted = true
+							break
+						}
+					}
+					if !accepted {
+						skippedSubnetRouter = append(skippedSubnetRouter, peer)
+						continue
+					}
 				}
 			}
 			cpeer.AllowedIPs = append(cpeer.AllowedIPs, allowedIP)


### PR DESCRIPTION
(late edit: don't know how to link this to an existing issue... there are _many_ --accept-routes related issues, but I guess this might solve https://github.com/tailscale/tailscale/issues/10206 )

    feat: Add selective route acceptance via CIDR list to --accept-routes

    This commit implements enhanced --accept-routes functionality that allows
    users to specify a comma-separated list of CIDR blocks for selective route
    acceptance, addressing the issue where accepting all routes can cause local
    network access problems.

    Problem:
    When a gateway advertises routes for both remote networks and the local LAN,
    accepting all routes forces local traffic through Tailscale, which can block
    direct local access (e.g., SSH to local IPs). Users need the ability to
    accept only specific advertised routes.

    Solution:
    The --accept-routes parameter now supports three modes:
    1. true - Accept all routes (backward compatible)
    2. false - Accept no routes (backward compatible)
    3. CIDR list - Accept only specified routes (new feature)

    Example usage:
      tailscale up --accept-routes=10.0.0.0/8,172.16.0.0/12
      tailscale set --accept-routes=192.168.1.0/24

    Changes:
    - Added AcceptedRoutes []netip.Prefix field to ipn.Prefs
    - Updated CLI parsing in up.go and set.go to handle string values
    - Added parseAcceptRoutes() function to parse boolean or CIDR list
    - Modified WGCfg() to filter routes based on AcceptedRoutes list
    - Updated all WGCfg() callers to pass acceptedRoutes parameter
    - Added comprehensive test coverage
    - Maintained full backward compatibility

    Files modified:
    - ipn/prefs.go - Added AcceptedRoutes field and updated Equals()
    - ipn/ipn_view.go - Added view accessor for AcceptedRoutes
    - ipn/ipn_clone.go - Added cloning logic for AcceptedRoutes
    - cmd/tailscale/cli/up.go - Changed acceptRoutes to string, added parser
    - cmd/tailscale/cli/set.go - Changed acceptRoutes to string
    - wgengine/wgcfg/nmcfg/nmcfg.go - Added route filtering logic
    - ipn/ipnlocal/local.go - Pass AcceptedRoutes to WGCfg()
    - wgengine/magicsock/magicsock_test.go - Updated test calls

    Files added:
    - cmd/tailscale/cli/accept_routes_test.go - Test coverage
    - FEATURE_ENHANCED_ACCEPT_ROUTES.md - Feature documentation

    Fixes: Issue with local network access when accepting advertised routes

Example. 2 subnets using 172.16.0.0/22 and 172.16.4.0/22 in physically separate locations.  Idea is to connect them together and allow tailscale nodes in each to be able to route to each other (and also see non tailscale nodes).
Problem: Running standard --accept-routes on a node will also add the local CIDR range - disconnecting that node from all other (non-tailscale) nodes on that TV.   In my case, I'm going to demonstrate with my Plex server 'greggplex' - The obvious use case here is my TVs should be able to talk directly to greggplex since there are in the same 172.16.0.0/22 subnet.

```
pgregg@greggplex:~/git/paulgregg/tailscale$ tailscale status --json | jq '.Peer[] | select(.PrimaryRoutes != null) | {HostName: .HostName, PrimaryRoutes: .PrimaryRoutes}'
{
  "HostName": "OPNsense",
  "PrimaryRoutes": [
    "172.16.0.0/22"
  ]
}
{
  "HostName": "ts11mpp",
  "PrimaryRoutes": [
    "172.16.4.0/22"
  ]
}
```
This shows the two subnets advertised by two machines in each network.
In this case, I want greggplex node to see the ts11mpp route, but not the local one it is already on.

Since *I* know I am within 172.16.0.0/22 then I want to explicitly control which routes I accept. This PR implements the ability to list the CIDR blocks for --accept-routes
`tailscale up --accept-routes=172.16.4.0/22 --accept-dns=false --operator=pgregg`

Now when I look in `tailscale debug prefs`:
```
pgregg@greggplex:~/git/paulgregg/tailscale$ tailscale debug prefs 2>&1| less
{
        "ControlURL": "https://controlplane.tailscale.com",
        "RouteAll": true,
        "AcceptedRoutes": [
                "172.16.4.0/22"
        ],
```

The greggplex tailscale is properly connected to 172.16.4.0/22:
```
pgregg@greggplex:~/git/paulgregg/tailscale$ tailscale ping ts11mpp
pong from ts11mpp (100.1.1.1) via DERP(lhr) in 30ms
pong from ts11mpp (100.1.1.1) via 1.2.3.4:41642 in 30ms
and a machine behind ts11mpp:
pgregg@greggplex:~/git/paulgregg/tailscale$ tailscale ping 172.16.4.219
pong from ts11mpp (100.1.1.1) via 1.2.3.4:41642 in 29ms
```











