### PR TITLE
kube/certs: adopt Let's Encrypt's recommended cert-issuance retry schedule

### DIFF
--- a/kube/certs/certs.go
+++ b/kube/certs/certs.go
@@ -94,22 +94,47 @@ func (cm *CertManager) EnsureCertLoops(ctx context.Context, sc *ipn.ServeConfig)
 	return nil
 }
 
+// nextRetryInterval returns the wait time before the next cert-issuance retry
+// after retryCount consecutive failures. It implements the schedule Let's
+// Encrypt recommends in its rate-limit adjustment guidance: 1 minute, then 10
+// minutes, then 100 minutes, then 24 hours; any further retries stay at 24
+// hours. Counts at or below 1 are treated as the first retry.
+//
+// Per LE's published guidance, the slow ramp matches the observation that
+// repeated cert-issuance failures are usually persistent (DNS / CAA / rate
+// limits) rather than transient, so retrying aggressively just burns the
+// 50-certs-per-168h-per-registered-domain window without improving recovery
+// time.
+func nextRetryInterval(retryCount int) time.Duration {
+	schedule := [...]time.Duration{
+		1 * time.Minute,
+		10 * time.Minute,
+		100 * time.Minute,
+		24 * time.Hour,
+	}
+	if retryCount < 1 {
+		retryCount = 1
+	}
+	if retryCount-1 >= len(schedule) {
+		return schedule[len(schedule)-1]
+	}
+	return schedule[retryCount-1]
+}
+
 // runCertLoop:
 // - calls localAPI certificate endpoint to ensure that certs are issued for the
 // given domain name
 // - calls localAPI certificate endpoint daily to ensure that certs are renewed
-// - if certificate issuance failed retries after an exponential backoff period
-// starting at 1 minute and capped at 24 hours. Reset the backoff once issuance succeeds.
+// - if certificate issuance fails, retries on the schedule recommended by Let's
+// Encrypt's rate-limit adjustment guidance (1 minute, 10 minutes, 100 minutes,
+// then 24 hours for any further retries). The backoff resets once issuance
+// succeeds. See [nextRetryInterval] for details.
 // Note that renewal check also happens when the node receives an HTTPS request and it is possible that certs get
 // renewed at that point. Renewal here is needed to prevent the shared certs from expiry in edge cases where the 'write'
 // replica does not get any HTTPS requests.
 // https://letsencrypt.org/docs/integration-guide/#retrying-failures
 func (cm *CertManager) runCertLoop(ctx context.Context, domain string) {
-	const (
-		normalInterval   = 24 * time.Hour  // regular renewal check
-		initialRetry     = 1 * time.Minute // initial backoff after a failure
-		maxRetryInterval = 24 * time.Hour  // max backoff period
-	)
+	const normalInterval = 24 * time.Hour // regular renewal check
 
 	if err := cm.waitForCertDomain(ctx, domain); err != nil {
 		// Best-effort, log and continue with the issuing loop.
@@ -154,15 +179,7 @@ func (cm *CertManager) runCertLoop(ctx context.Context, domain string) {
 				nextInterval = normalInterval
 			} else {
 				retryCount++
-				// Calculate backoff: initialRetry * 2^(retryCount-1)
-				// For retryCount=1: 1min * 2^0 = 1min
-				// For retryCount=2: 1min * 2^1 = 2min
-				// For retryCount=3: 1min * 2^2 = 4min
-				backoff := initialRetry * time.Duration(1<<(retryCount-1))
-				if backoff > maxRetryInterval {
-					backoff = maxRetryInterval
-				}
-				nextInterval = backoff
+				nextInterval = nextRetryInterval(retryCount)
 				cm.logf("Error refreshing certificate for %s (retry %d): %v. Will retry in %v\n",
 					domain, retryCount, err, nextInterval)
 			}

--- a/kube/certs/certs_test.go
+++ b/kube/certs/certs_test.go
@@ -14,6 +14,29 @@ import (
 	"tailscale.com/tailcfg"
 )
 
+// TestNextRetryInterval verifies that the cert-issuance retry schedule matches
+// Let's Encrypt's recommended `1m → 10m → 100m → 24h` ramp and caps at 24h for
+// any additional retries.
+func TestNextRetryInterval(t *testing.T) {
+	tests := []struct {
+		retryCount int
+		want       time.Duration
+	}{
+		{retryCount: 0, want: 1 * time.Minute},   // defensive: treat as first retry
+		{retryCount: 1, want: 1 * time.Minute},
+		{retryCount: 2, want: 10 * time.Minute},
+		{retryCount: 3, want: 100 * time.Minute},
+		{retryCount: 4, want: 24 * time.Hour},
+		{retryCount: 5, want: 24 * time.Hour},    // capped
+		{retryCount: 100, want: 24 * time.Hour},  // still capped
+	}
+	for _, tt := range tests {
+		if got := nextRetryInterval(tt.retryCount); got != tt.want {
+			t.Errorf("nextRetryInterval(%d) = %v, want %v", tt.retryCount, got, tt.want)
+		}
+	}
+}
+
 // TestEnsureCertLoops tests that the certManager correctly starts and stops
 // update loops for certs when the serve config changes. It tracks goroutine
 // count and uses that as a validator that the expected number of cert loops are


### PR DESCRIPTION

When TLS certificate issuance fails for an HA Ingress write replica, `runCertLoop` retried on an exponential backoff: `1m → 2m → 4m → 8m → 16m → 32m → … → 24h` (cap). Under a genuine Let's Encrypt rate-limit (50 certs per registered domain per 168 hours), this burns ~9 attempts inside the first ~17 hours, accomplishing nothing while making us a noisy neighbour.

Let's Encrypt's [rate-limit adjustment guidance](https://isrg.formstack.com/forms/rate_limit_adjustment_request) publishes a slower schedule:

> `1 minute → 10 minutes → 100 minutes → 24 hours`

LE's stated rationale: *"there's no point in attempting issuance hundreds of times per hour, since repeated failures are likely to be persistent."* Issuance failures are usually persistent (DNS / CAA / rate limits), not transient, so aggressive retries don't help and just consume the issuance quota.

This change replaces the inline `1<<(retryCount-1)` math with a new `nextRetryInterval(retryCount int) time.Duration` helper implementing LE's schedule, capped at 24h for retry counts ≥ 4. The now-unused `initialRetry` and `maxRetryInterval` constants are removed.

This addresses the first of the two concerns in #19895. **The second** — actually parsing and respecting LE's `Retry-After` header on 429 responses — is left for a follow-up because it's not addressable in this layer:

- The `Retry-After` value travels in the HTTP response headers from LE, through `tempfork/acme` (which preserves it on `acme.Error.Header`), into `LocalBackend.GetCertPEMWithValidity`.
- At the localapi boundary, `ipn/localapi` stringifies the error into an `errorJSON.Error` body. The HTTP status survives in `client/local`'s (unexported) `httpStatusError`, but the `Retry-After` header is dropped, and `httpStatusError.HTTPStatus` isn't reachable from outside the package.
- Plumbing the value through cleanly would touch `ipn/ipnlocal/cert.go`, `ipn/localapi/localapi.go`, and `client/local/local.go` to surface either a structured error body or a dedicated response header. Happy to take that on as a follow-up if the design direction is welcome.

The existing `TODO(irbekrm)` at `kube/certs/certs.go:150-151` ("distinguish between LE rate-limit errors and other error types like transient network errors") is left in place — it's still valid future work, and now the schedule we're using for *all* errors is at least the one LE explicitly recommends.

### Testing

- New `TestNextRetryInterval` table-tests the schedule across retryCount `0, 1, 2, 3, 4, 5, 100`.
- Existing `TestEnsureCertLoops` is unaffected and still passes.
- `go test ./kube/certs/...` green; `go vet ./kube/certs/...` clean.
- Downstream importers (`cmd/containerboot`, `cmd/k8s-proxy`) build clean on linux/amd64.

## Files changed (2, +56/-16)

- `kube/certs/certs.go` — new `nextRetryInterval` helper, call site swap, dead constants removed, function-doc updated.
- `kube/certs/certs_test.go` — `TestNextRetryInterval` table test.