### PR TITLE
net/netcheck: honor DERPPort in HTTPS probes

### DIFF
--- a/net/netcheck/netcheck.go
+++ b/net/netcheck/netcheck.go
@@ -85,6 +85,14 @@ const (
 	defaultInitialRetransmitTime = 100 * time.Millisecond
 )
 
+func derpProbeURL(node *tailcfg.DERPNode) string {
+	host := node.HostName
+	if node.DERPPort != 0 && node.DERPPort != 443 {
+		host = net.JoinHostPort(host, fmt.Sprint(node.DERPPort))
+	}
+	return "https://" + host + "/derp/probe"
+}
+
 // Report contains the result of a single netcheck.
 type Report struct {
 	Now         time.Time // the time the report was run
@@ -1072,7 +1080,7 @@ func (c *Client) runHTTPOnlyChecks(ctx context.Context, last *Report, rs *report
 		}
 		wg.Go(func() {
 			node := rg.Nodes[0]
-			req, _ := http.NewRequestWithContext(ctx, "HEAD", "https://"+node.HostName+"/derp/probe", nil)
+			req, _ := http.NewRequestWithContext(ctx, "HEAD", derpProbeURL(node), nil)
 			// One warm-up one to get HTTP connection set
 			// up and get a connection from the browser's
 			// pool.

--- a/net/netcheck/netcheck_test.go
+++ b/net/netcheck/netcheck_test.go
@@ -918,6 +918,44 @@ func TestSortRegions(t *testing.T) {
 	}
 }
 
+func TestDERPProbeURL(t *testing.T) {
+	tests := []struct {
+		name string
+		node *tailcfg.DERPNode
+		want string
+	}{
+		{
+			name: "default port",
+			node: &tailcfg.DERPNode{HostName: "derp.example.com"},
+			want: "https://derp.example.com/derp/probe",
+		},
+		{
+			name: "explicit https port",
+			node: &tailcfg.DERPNode{
+				HostName: "derp.example.com",
+				DERPPort: 443,
+			},
+			want: "https://derp.example.com/derp/probe",
+		},
+		{
+			name: "custom port",
+			node: &tailcfg.DERPNode{
+				HostName: "derp.example.com",
+				DERPPort: 1443,
+			},
+			want: "https://derp.example.com:1443/derp/probe",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := derpProbeURL(tt.node); got != tt.want {
+				t.Fatalf("derpProbeURL() = %q; want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 type RoundTripFunc func(req *http.Request) *http.Response
 
 func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {


### PR DESCRIPTION
DERP connection code now respects DERPPort for WebSocket URLs and proxy CONNECT targets, but the HTTP-only netcheck path still built its /derp/probe URL directly from node.HostName. That made clients probe https://host/derp/probe even when the DERP map specified a custom HTTPS DERP port such as 1443.

Add a small helper for constructing the HTTPS probe URL so custom non-default DERPPort values are included while the default HTTPS port remains omitted. Cover the default, explicit 443, and custom port cases with a unit test.

Follow-up work for #19748