### PR TITLE
tailcfg: add a node attribute to explicitly disable netmap caching

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -2785,6 +2785,12 @@ const (
 	// discard existing cached maps, and will not store any.
 	NodeAttrCacheNetworkMaps NodeCapability = "cache-network-maps"
 
+	// NodeAttrDisableCacheNetworkMaps indicates that the node should not cache
+	// network maps (as per [NodeAttrCacheNetworkMaps]) when it normally would.
+	// This attribute exists to allow the policy document to override the default.
+	// When set, it takes precedence over [NodeAttrCacheNetworkMaps].
+	NodeAttrDisableCacheNetworkMaps NodeCapability = "disable-cache-network-maps"
+
 	// NodeAttrDisableLinuxCGNATDropRule tells Linux clients to not insert a
 	// blanket firewall DROP rule for inbound traffic from the CGNAT IP range
 	// that does not originate from the Tailscale network interface.


### PR DESCRIPTION
Add a new tailcfg.NodeCapability (NodeAttrDisableCacheNetworkMaps) to allow the
policy document to override whether a node will receive the cache-network-maps
attribute by default. The client does not interpret this attribute directly, it
is used to influence decisions by the control plane.

As of 2026-06-01, cache-network-maps is only sent when explicitly requested by
the policy. In a future version, we will send it by default for clients with a
sufficient capability version (to be added in a future commit), except to
ephemeral nodes, unless the policy sets disable-cached-network-maps.

Updates #12639
Updates tailscale/projects#28

Change-Id: I6376376d7898f7da8db977e457dcd45df9deef41
Signed-off-by: M. J. Fromberger <fromberger@tailscale.com>
