### PR TITLE
cmd/tailscale/cli/jsonoutput: extract routecheck’s output format

### DIFF
--- a/cmd/tailscale/cli/jsonoutput/jsonformat.go
+++ b/cmd/tailscale/cli/jsonoutput/jsonformat.go
@@ -1,0 +1,73 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package jsonoutput
+
+import (
+	"errors"
+	"flag"
+	"io"
+	"strconv"
+	"strings"
+)
+
+var _ flag.Value = new(Format)
+
+type Format string
+
+func (f *Format) String() string {
+	if f == nil {
+		return ""
+	}
+	return string(*f)
+}
+
+func (f *Format) Set(s string) error {
+	*f = Format(s)
+	return nil
+}
+
+func (f *Format) isJSON() bool {
+	return *f == "json" || *f == "json-line"
+}
+
+func (f *Format) Bool() flag.Value {
+	return &formatBool{f}
+}
+
+type formatBool struct {
+	*Format
+}
+
+func (f *formatBool) String() string {
+	return strconv.FormatBool(f.isJSON())
+}
+
+func (f *formatBool) Set(s string) error {
+	// Delegate to a FlagSet to parse this as a BoolVar.
+	var b bool
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	fs.BoolVar(&b, "bool", false, "")
+	fs.SetOutput(io.Discard) // silence
+	if err := fs.Parse([]string{"-bool=" + s}); err != nil {
+		// Unwrap the header added by FlagSet.failf:
+		// `invalid boolean value "invalid" for -bool: `
+		bits := strings.SplitN(err.Error(), ": ", 2)
+		return errors.New(bits[len(bits)-1])
+	}
+
+	if isJSON := f.isJSON(); b == isJSON {
+		return nil // no change
+	}
+
+	if !b {
+		*f.Format = ""
+	} else {
+		*f.Format = "json"
+	}
+	return nil
+}
+
+func (f *formatBool) IsBoolFlag() bool {
+	return true
+}

--- a/cmd/tailscale/cli/routecheck.go
+++ b/cmd/tailscale/cli/routecheck.go
@@ -13,12 +13,13 @@ import (
 	"slices"
 	"strings"
 	"text/tabwriter"
-	"time"
 
 	jsonv2 "github.com/go-json-experiment/json"
 	"github.com/go-json-experiment/json/jsontext"
 	"github.com/peterbourgon/ff/v3/ffcli"
 
+	"tailscale.com/cmd/tailscale/cli/jsonoutput"
+	"tailscale.com/cmd/tailscale/tsroutecheckjsonv0"
 	"tailscale.com/net/routecheck"
 	"tailscale.com/tstime"
 )
@@ -41,16 +42,19 @@ var routecheckCmd = func() *ffcli.Command {
 var routecheckFlagSet = func() *flag.FlagSet {
 	fs := newFlagSet("routecheck")
 	fs.BoolVar(&routecheckArgs.probe, "probe", false, "probe now to generate a new reachability report")
-	fs.StringVar(&routecheckArgs.format, "format", "", `output format: empty (for human-readable), "json" or "json-line"`)
+	fs.Var(&routecheckArgs.format, "format", `output format: empty (for human-readable), "json" or "json-line"`)
+	fs.Var(routecheckArgs.format.Bool(), "json", "output in JSON format")
 	return fs
 }()
 
 var routecheckArgs struct {
 	probe  bool
-	format string
+	format jsonoutput.Format
 }
 
 func runRoutecheck(ctx context.Context, args []string) error {
+	fmt.Printf("format: %q\n", routecheckArgs.format)
+	return nil
 	routeCheck := localClient.RouteCheck
 	if routecheckArgs.probe {
 		routeCheck = localClient.RouteCheckProbe
@@ -67,7 +71,7 @@ func runRoutecheck(ctx context.Context, args []string) error {
 
 func printRouteCheckReport(rp *routecheck.Report) error {
 	var enc *jsontext.Encoder
-	switch routecheckArgs.format {
+	switch routecheckArgs.format.String() {
 	case "":
 	case "json":
 		enc = jsontext.NewEncoder(Stdout, jsontext.WithIndent("\t"))
@@ -90,10 +94,7 @@ func printRouteCheckReport(rp *routecheck.Report) error {
 	}
 
 	if enc != nil {
-		out := struct {
-			Done   time.Time                   `json:"done"`
-			Routes routecheck.RoutablePrefixes `json:"routes"`
-		}{
+		out := tsroutecheckjsonv0.ReportResponse{
 			Done:   rp.Done,
 			Routes: routes,
 		}

--- a/cmd/tailscale/tsroutecheckjsonv0/tsroutecheck.go
+++ b/cmd/tailscale/tsroutecheckjsonv0/tsroutecheck.go
@@ -1,0 +1,28 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !ts_omit_routecheck
+
+// Package tsroutecheckjsonv0 provides types for unmarshalling the JSON output of the
+// "tailscale routecheck --json" command:
+//
+//   - [ReportResponse] will unmarshal the output of "tailscale routecheck --json"
+//
+// # WARNING: unstable
+//
+// Format is "v0" and is subject to change.
+// There is no guarantee of backwards or forwards compatibility.
+package tsroutecheckjsonv0
+
+import (
+	"time"
+
+	"tailscale.com/net/routecheck"
+)
+
+// ReportResponse is the JSON form of [routecheck.Report].
+// Experimental: This output is not yet stable: tailscale/tailscale#17366.
+type ReportResponse struct {
+	Done   time.Time                   `json:"done"`
+	Routes routecheck.RoutablePrefixes `json:"routes"`
+}


### PR DESCRIPTION
In PR #19641, we added the `tailscale routecheck` command that supports both `--format=json` and `--format=json-line`. To allow other packages to import and unmarshal that JSON structure, this patch exports that format in the [jsonoutput](https://pkg.go.dev/tailscale.com/cmd/tailscale/cli/jsonoutput) package.

Updates #17366
Updates tailscale/corp#33033

### Tips

- This is a stacked PR within the [sfllaw/routecheck-for-reachability](https://github.com/tailscale/tailscale/tree/sfllaw/routecheck-for-reachability) branch.