### PR TITLE
.github/workflows: fix `-run='^$'` quoting when skipping all tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,7 +183,7 @@ jobs:
         TS_TEST_SHARD: ${{ matrix.shard }}
     - name: bench all
       working-directory: src
-      run: ./tool/go test ${{matrix.buildflags}} -bench=. -benchtime=1x -run=^$ $(for x in $(git grep -l "^func Benchmark" | xargs dirname | sort | uniq); do echo "./$x"; done)
+      run: ./tool/go test ${{matrix.buildflags}} -bench=. -benchtime=1x -run='^$' $(for x in $(git grep -l '^func Benchmark' | xargs dirname | sort | uniq); do echo "./$x"; done)
       env:
         GOARCH: ${{ matrix.goarch }}
     - name: check that no tracked files changed
@@ -261,6 +261,7 @@ jobs:
         cigocached-host: ${{ vars.CIGOCACHED_AZURE_HOST }}
 
     - name: test
+      shell: bash
       if: matrix.key != 'win-bench' # skip on bench builder
       working-directory: src
       run: ./tool/go run ./cmd/testwrapper sharded:${{ matrix.shard }}
@@ -268,9 +269,10 @@ jobs:
         NOPWSHDEBUG: "true" # to quiet tool/gocross/gocross-wrapper.ps1 in CI
 
     - name: bench all
+      shell: bash
       if: matrix.key == 'win-bench'
       working-directory: src
-      run: ./tool/go test ./... -bench=. -benchtime=1x -run="^$"
+      run: ./tool/go test -bench=. -benchtime=1x -run='^$' $(for x in $(git grep -l '^func Benchmark' | xargs dirname | sort | uniq); do echo "./$x"; done)
       env:
         NOPWSHDEBUG: "true" # to quiet tool/gocross/gocross-wrapper.ps1 in CI
 


### PR DESCRIPTION
This bug was surfaced by #19960 because benchmarks shouldn’t have run TestListenService, but they did because PowerShell interpreted match empty string `"^$"` as beginning of string `'^'`.

This patch has the Windows build run `./tool/go` binaries with bash.

Updates #18884
Updates #19960