### PR TITLE
Add --strip option to build_dist

### DIFF
--- a/build_dist.sh
+++ b/build_dist.sh
@@ -51,6 +51,13 @@ while [ "$#" -gt 1 ]; do
 		ldflags="$ldflags -w -s"
 		tags="${tags:+$tags,},$(GOOS= GOARCH= $go run ./cmd/featuretags --min)"
 		;;
+	--strip)
+		# --min overrides your flags, when you're using custom tags and want to
+		# additionally strip symbols to help reduce the size, this is the easiest
+		# way to do it.
+		shift
+		ldflags="$ldflags -w -s"
+		;;
 	--box)
 		if [ ! -z "${TAGS:-}" ]; then
 			echo "set either --box or \$TAGS, but not both"


### PR DESCRIPTION
Add support for --strip option to strip symbols.

Building a rather custom binary with custom flags needs some additional work, and thought to contribute this back up.

This resolves #19963