### PR TITLE
ipn/localapi: fix debug derp TLS check for sha256-raw CertName

### DIFF
--- a/ipn/localapi/debugderp.go
+++ b/ipn/localapi/debugderp.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/netip"
 	"strconv"
+	"strings"
 	"time"
 
 	"tailscale.com/derp/derphttp"
@@ -22,10 +23,27 @@ import (
 	"tailscale.com/net/netaddr"
 	"tailscale.com/net/netns"
 	"tailscale.com/net/stun"
+	"tailscale.com/net/tlsdial"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/key"
 	"tailscale.com/types/nettype"
 )
+
+// tlsConfigForNode builds a *tls.Config for connecting to a DERP node,
+// mirroring the logic in derphttp.Client.tlsClient so that sha256-raw cert
+// pinning and domain-fronting CertName values are handled correctly.
+func tlsConfigForNode(node *tailcfg.DERPNode) *tls.Config {
+	conf := tlsdial.Config(nil, nil)
+	conf.ServerName = node.HostName
+	if node.CertName != "" {
+		if suf, ok := strings.CutPrefix(node.CertName, "sha256-raw:"); ok {
+			tlsdial.SetConfigExpectedCertHash(conf, suf)
+		} else {
+			tlsdial.SetConfigExpectedCert(conf, node.CertName)
+		}
+	}
+	return conf
+}
 
 func (h *Handler) serveDebugDERPRegion(w http.ResponseWriter, r *http.Request) {
 	if !h.PermitWrite {
@@ -100,9 +118,7 @@ func (h *Handler) serveDebugDERPRegion(w http.ResponseWriter, r *http.Request) {
 			defer conn.Close()
 
 			// Upgrade to TLS and verify that works properly.
-			tlsConn := tls.Client(conn, &tls.Config{
-				ServerName: cmp.Or(derpNode.CertName, derpNode.HostName),
-			})
+			tlsConn := tls.Client(conn, tlsConfigForNode(derpNode))
 			if err := tlsConn.HandshakeContext(ctx); err != nil {
 				st.Errors = append(st.Errors, fmt.Sprintf("Error upgrading connection to node %q @ %q to TLS over IPv4: %v", derpNode.HostName, addr, err))
 			} else {
@@ -119,12 +135,7 @@ func (h *Handler) serveDebugDERPRegion(w http.ResponseWriter, r *http.Request) {
 			defer conn.Close()
 
 			// Upgrade to TLS and verify that works properly.
-			tlsConn := tls.Client(conn, &tls.Config{
-				ServerName: cmp.Or(derpNode.CertName, derpNode.HostName),
-				// TODO(andrew-d): we should print more
-				// detailed failure information on if/why TLS
-				// verification fails
-			})
+			tlsConn := tls.Client(conn, tlsConfigForNode(derpNode))
 			if err := tlsConn.HandshakeContext(ctx); err != nil {
 				st.Errors = append(st.Errors, fmt.Sprintf("Error upgrading connection to node %q @ %q to TLS over IPv6: %v", derpNode.HostName, addr, err))
 			} else {

--- a/ipn/localapi/debugderp_test.go
+++ b/ipn/localapi/debugderp_test.go
@@ -1,0 +1,189 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !ts_omit_debug
+
+package localapi
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"tailscale.com/tailcfg"
+)
+
+// selfSignedCert generates an ephemeral self-signed ECDSA cert for addr
+// (an IP or DNS name) and returns the tls.Certificate and its SHA-256 hex
+// fingerprint.
+func selfSignedCert(t *testing.T, addr string) (tls.Certificate, string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: addr},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	if ip := net.ParseIP(addr); ip != nil {
+		tmpl.IPAddresses = []net.IP{ip}
+	} else {
+		tmpl.DNSNames = []string{addr}
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fingerprint := fmt.Sprintf("%x", sha256.Sum256(derBytes))
+	return tlsCert, fingerprint
+}
+
+// startTLSServer starts a minimal TLS listener that accepts one connection,
+// performs the handshake, then closes. It returns the listener address.
+func startTLSServer(t *testing.T, cert tls.Certificate) string {
+	t.Helper()
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				_ = c.(*tls.Conn).Handshake()
+			}(conn)
+		}
+	}()
+	return ln.Addr().String()
+}
+
+// dialTLS opens a TCP connection to addr and performs a TLS handshake using cfg.
+func dialTLS(t *testing.T, addr string, cfg *tls.Config) error {
+	t.Helper()
+	conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	tlsConn := tls.Client(conn, cfg)
+	defer tlsConn.Close()
+	return tlsConn.HandshakeContext(t.Context())
+}
+
+// TestTLSConfigForNode_Sha256Raw verifies that tlsConfigForNode correctly
+// handles a "sha256-raw:<hex>" CertName: the TLS handshake must succeed when
+// the server presents the pinned cert and fail when it presents a different one.
+func TestTLSConfigForNode_Sha256Raw(t *testing.T) {
+	cert, fp := selfSignedCert(t, "127.0.0.1")
+	addr := startTLSServer(t, cert)
+
+	host, _, _ := net.SplitHostPort(addr)
+
+	node := &tailcfg.DERPNode{
+		HostName: host,
+		CertName: "sha256-raw:" + fp,
+	}
+	cfg := tlsConfigForNode(node)
+
+	// Must succeed: correct cert and correct hash.
+	if err := dialTLS(t, addr, cfg); err != nil {
+		t.Errorf("expected success with correct sha256-raw pin, got: %v", err)
+	}
+
+	// Must fail: wrong hash.
+	wrongNode := &tailcfg.DERPNode{
+		HostName: host,
+		CertName: "sha256-raw:" + "deadbeef" + fp[8:],
+	}
+	if err := dialTLS(t, addr, tlsConfigForNode(wrongNode)); err == nil {
+		t.Error("expected failure with wrong hash, but handshake succeeded")
+	}
+}
+
+// TestTLSConfigForNode_OldBehaviorFails demonstrates the original bug:
+// passing CertName directly as ServerName to stock tls.Config fails when
+// CertName is a sha256-raw fingerprint.
+func TestTLSConfigForNode_OldBehaviorFails(t *testing.T) {
+	cert, fp := selfSignedCert(t, "127.0.0.1")
+	addr := startTLSServer(t, cert)
+
+	// Reproduce the old code: ServerName = cmp.Or(CertName, HostName)
+	oldCfg := &tls.Config{
+		ServerName: "sha256-raw:" + fp,
+	}
+	if err := dialTLS(t, addr, oldCfg); err == nil {
+		t.Error("old behavior unexpectedly succeeded; test is no longer meaningful")
+	}
+}
+
+// TestTLSConfigForNode_PlainCertName verifies that a non-sha256-raw CertName
+// is handled via SetConfigExpectedCert (domain fronting path).
+func TestTLSConfigForNode_PlainCertName(t *testing.T) {
+	const domain = "example.tailscale.com"
+	cert, _ := selfSignedCert(t, domain)
+	addr := startTLSServer(t, cert)
+
+	host, _, _ := net.SplitHostPort(addr)
+	node := &tailcfg.DERPNode{
+		HostName: host,
+		CertName: domain,
+	}
+	cfg := tlsConfigForNode(node)
+
+	// The cert is self-signed (not in any system trust store), so Verify will
+	// fail – but NOT with a hostname mismatch; the error should mention the
+	// untrusted issuer, not "not example.tailscale.com".
+	err := dialTLS(t, addr, cfg)
+	if err == nil {
+		// Acceptable if a custom root happens to be trusted (unlikely in CI).
+		return
+	}
+	if errStr := err.Error(); !contains(errStr, "certificate") {
+		t.Errorf("unexpected error (wanted cert trust error): %v", err)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsStr(s, sub))
+}
+
+func containsStr(s, sub string) bool {
+	for i := range len(s) - len(sub) + 1 {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Background

#15579 identified two separate bugs affecting self-hosted DERP servers with `sha256-raw:` cert pinning:

1. `tailscaled` failing with `"unexpected multiple certs presented"` — fixed by #16016
2. `tailscale debug derp` always failing with a TLS hostname mismatch error — **not fixed by #16016**

#15580 proposed fixes for both, but was closed by its author in favor of #16016. Since #16016 only addressed `net/tlsdial` and `derp/derphttp`, the `debugderp.go` code path remained broken. This PR fixes the remaining issue.

## Root Cause

`serveDebugDERPRegion` constructs its TLS config as:

```go
tls.Client(conn, &tls.Config{
    ServerName: cmp.Or(derpNode.CertName, derpNode.HostName),
})
```

When `CertName` is `"sha256-raw:<hex>"`, this passes the raw fingerprint string as `ServerName` to the stock Go TLS verifier, which treats it as a hostname. The handshake always fails:

```
tls: failed to verify certificate: x509: certificate is valid for
example.com, not sha256-raw:dc888990...
```

This is different from the code path used by the real DERP client (`derphttp.Client.tlsClient`), which calls `tlsdial.SetConfigExpectedCertHash` to perform hash-based verification instead.

## Fix

Extract a `tlsConfigForNode` helper that mirrors `derphttp.Client.tlsClient`:

- Uses `tlsdial.Config` as the base
- Dispatches to `SetConfigExpectedCertHash` for `sha256-raw:` CertNames
- Dispatches to `SetConfigExpectedCert` for plain domain CertNames
- Falls back to `HostName` when CertName is empty

## Testing

Added `ipn/localapi/debugderp_test.go` with three tests:

- `TestTLSConfigForNode_Sha256Raw`: starts a local TLS server with a self-signed cert, verifies handshake succeeds with the correct hash and fails with a wrong hash
- `TestTLSConfigForNode_OldBehaviorFails`: demonstrates that the original code was broken
- `TestTLSConfigForNode_PlainCertName`: verifies the plain domain CertName path

Also verified manually by building and running the patched `tailscaled` against a self-hosted DERP server configured with `sha256-raw:` cert pinning. Before the fix, `tailscale debug derp` reported a TLS error; after, it reports a successful connection.

Updates #15579
