### PR TITLE
cmd/tailscale: add serve and funnel redirect flags

### DIFF
--- a/cmd/tailscale/cli/serve_legacy.go
+++ b/cmd/tailscale/cli/serve_legacy.go
@@ -170,6 +170,7 @@ type serveEnv struct {
 	tcp              uint                     // TCP port
 	tlsTerminatedTCP uint                     // a TLS terminated TCP port
 	proxyProtocol    uint                     // PROXY protocol version (1 or 2)
+	redirect         string                   // HTTP redirect target
 	subcmd           serveMode                // subcommand
 	yes              bool                     // update without prompt
 	service          tailcfg.ServiceName      // service name

--- a/cmd/tailscale/cli/serve_v2.go
+++ b/cmd/tailscale/cli/serve_v2.go
@@ -238,6 +238,7 @@ func newServeV2Command(e *serveEnv, subcmd serveMode) *ffcli.Command {
 		FlagSet: e.newFlags("serve-set", func(fs *flag.FlagSet) {
 			fs.Var(&e.bg, "bg", "Run the command as a background process (default false, when --service is set defaults to true).")
 			fs.StringVar(&e.setPath, "set-path", "", "Appends the specified path to the base URL for accessing the underlying service")
+			fs.StringVar(&e.redirect, "redirect", "", "Redirect HTTP requests to the specified URL (optionally prefixed with a status code, e.g. 301:https://${HOST}${REQUEST_URI})")
 			fs.UintVar(&e.https, "https", 0, "Expose an HTTPS server at the specified port (default mode)")
 			if subcmd == serve {
 				fs.UintVar(&e.http, "http", 0, "Expose an HTTP server at the specified port")
@@ -347,6 +348,12 @@ func (e *serveEnv) validateArgs(subcmd serveMode, args []string) error {
 	if len(args) == 0 && e.tun {
 		return nil
 	}
+	if e.redirect != "" && len(args) == 0 {
+		return nil
+	}
+	if e.redirect != "" && len(args) > 0 {
+		return errors.New("cannot specify both --redirect and a target")
+	}
 	if len(args) == 0 {
 		return flag.ErrHelp
 	}
@@ -429,6 +436,14 @@ func (e *serveEnv) runServeCombined(subcmd serveMode) execFunc {
 
 		if (srvType == serveTypeHTTP || srvType == serveTypeHTTPS) && e.proxyProtocol != 0 {
 			return fmt.Errorf("PROXY protocol is only supported for TCP forwarding, not HTTP/HTTPS")
+		}
+		if e.redirect != "" {
+			if srvType != serveTypeHTTP && srvType != serveTypeHTTPS {
+				return fmt.Errorf("--redirect is only supported for HTTP/HTTPS handlers")
+			}
+			if len(e.acceptAppCaps) > 0 {
+				return fmt.Errorf("--redirect cannot be combined with --accept-app-caps")
+			}
 		}
 		// Validate PROXY protocol version
 		if e.proxyProtocol != 0 && e.proxyProtocol != 1 && e.proxyProtocol != 2 {
@@ -993,6 +1008,8 @@ func (e *serveEnv) messageForPort(sc *ipn.ServeConfig, st *ipnstate.Status, dnsN
 			return "path", h.Path
 		case h.Proxy != "":
 			return "proxy", h.Proxy
+		case h.Redirect != "":
+			return "redirect", h.Redirect
 		case h.Text != "":
 			return "text", "\"" + elipticallyTruncate(h.Text, 20) + "\""
 		}
@@ -1157,6 +1174,8 @@ func (e *serveEnv) shouldWarnRemoteDestCompatibility(ctx context.Context, target
 func (e *serveEnv) applyWebServe(sc *ipn.ServeConfig, dnsName string, srvPort uint16, useTLS bool, mount, target, mds string, caps []tailcfg.PeerCapability) error {
 	h := new(ipn.HTTPHandler)
 	switch {
+	case e.redirect != "":
+		h.Redirect = e.redirect
 	case strings.HasPrefix(target, "text:"):
 		text := strings.TrimPrefix(target, "text:")
 		if text == "" {

--- a/cmd/tailscale/cli/serve_v2_test.go
+++ b/cmd/tailscale/cli/serve_v2_test.go
@@ -88,6 +88,36 @@ func TestServeDevConfigMutations(t *testing.T) {
 			}},
 		},
 		{
+			name: "funnel_redirect",
+			steps: []step{{
+				command: cmd("funnel --bg --redirect=301:https://${HOST}${REQUEST_URI}"),
+				want: &ipn.ServeConfig{
+					TCP: map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}},
+					Web: map[ipn.HostPort]*ipn.WebServerConfig{
+						"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
+							"/": {Redirect: "301:https://${HOST}${REQUEST_URI}"},
+						}},
+					},
+					AllowFunnel: map[ipn.HostPort]bool{"foo.test.ts.net:443": true},
+				},
+			}},
+		},
+		{
+			name: "funnel_redirect_set_path",
+			steps: []step{{
+				command: cmd("funnel --bg --set-path=/old --redirect=301:https://${HOST}/new"),
+				want: &ipn.ServeConfig{
+					TCP: map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}},
+					Web: map[ipn.HostPort]*ipn.WebServerConfig{
+						"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
+							"/old": {Redirect: "301:https://${HOST}/new"},
+						}},
+					},
+					AllowFunnel: map[ipn.HostPort]bool{"foo.test.ts.net:443": true},
+				},
+			}},
+		},
+		{
 			name: "serve_background",
 			steps: []step{{
 				command: cmd("serve --bg localhost:3000"),
@@ -124,6 +154,48 @@ func TestServeDevConfigMutations(t *testing.T) {
 					Web: map[ipn.HostPort]*ipn.WebServerConfig{
 						"foo.test.ts.net:80": {Handlers: map[string]*ipn.HTTPHandler{
 							"/": {Proxy: "http://localhost:3000"},
+						}},
+					},
+				},
+			}},
+		},
+		{
+			name: "http_redirect_explicit_status",
+			steps: []step{{
+				command: cmd("serve --bg --http=80 --redirect=301:https://${HOST}${REQUEST_URI}"),
+				want: &ipn.ServeConfig{
+					TCP: map[uint16]*ipn.TCPPortHandler{80: {HTTP: true}},
+					Web: map[ipn.HostPort]*ipn.WebServerConfig{
+						"foo.test.ts.net:80": {Handlers: map[string]*ipn.HTTPHandler{
+							"/": {Redirect: "301:https://${HOST}${REQUEST_URI}"},
+						}},
+					},
+				},
+			}},
+		},
+		{
+			name: "http_redirect_default_status",
+			steps: []step{{
+				command: cmd("serve --bg --http=80 --redirect=https://${HOST}${REQUEST_URI}"),
+				want: &ipn.ServeConfig{
+					TCP: map[uint16]*ipn.TCPPortHandler{80: {HTTP: true}},
+					Web: map[ipn.HostPort]*ipn.WebServerConfig{
+						"foo.test.ts.net:80": {Handlers: map[string]*ipn.HTTPHandler{
+							"/": {Redirect: "https://${HOST}${REQUEST_URI}"},
+						}},
+					},
+				},
+			}},
+		},
+		{
+			name: "http_redirect_set_path",
+			steps: []step{{
+				command: cmd("serve --bg --http=80 --set-path=/old --redirect=301:https://${HOST}/new"),
+				want: &ipn.ServeConfig{
+					TCP: map[uint16]*ipn.TCPPortHandler{80: {HTTP: true}},
+					Web: map[ipn.HostPort]*ipn.WebServerConfig{
+						"foo.test.ts.net:80": {Handlers: map[string]*ipn.HTTPHandler{
+							"/old": {Redirect: "301:https://${HOST}/new"},
 						}},
 					},
 				},
@@ -855,6 +927,76 @@ func TestServeDevConfigMutations(t *testing.T) {
 			}},
 		},
 		{
+			name: "advertise_service_redirect",
+			initialState: fakeLocalServeClient{
+				statusWithoutPeers: &ipnstate.Status{
+					BackendState: ipn.Running.String(),
+					Self: &ipnstate.PeerStatus{
+						DNSName: "foo.test.ts.net",
+						CapMap: tailcfg.NodeCapMap{
+							tailcfg.NodeAttrFunnel:                            nil,
+							tailcfg.CapabilityFunnelPorts + "?ports=443,8443": nil,
+						},
+						Tags: ptrToReadOnlySlice([]string{"some-tag"}),
+					},
+					CurrentTailnet: &ipnstate.TailnetStatus{MagicDNSSuffix: "test.ts.net"},
+				},
+				SOMarkInUse: true,
+			},
+			steps: []step{{
+				command: cmd("serve --service=svc:foo --http=80 --redirect=301:https://${HOST}${REQUEST_URI}"),
+				want: &ipn.ServeConfig{
+					Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
+						"svc:foo": {
+							TCP: map[uint16]*ipn.TCPPortHandler{
+								80: {HTTP: true},
+							},
+							Web: map[ipn.HostPort]*ipn.WebServerConfig{
+								"foo.test.ts.net:80": {Handlers: map[string]*ipn.HTTPHandler{
+									"/": {Redirect: "301:https://${HOST}${REQUEST_URI}"},
+								}},
+							},
+						},
+					},
+				},
+			}},
+		},
+		{
+			name: "advertise_service_redirect_set_path",
+			initialState: fakeLocalServeClient{
+				statusWithoutPeers: &ipnstate.Status{
+					BackendState: ipn.Running.String(),
+					Self: &ipnstate.PeerStatus{
+						DNSName: "foo.test.ts.net",
+						CapMap: tailcfg.NodeCapMap{
+							tailcfg.NodeAttrFunnel:                            nil,
+							tailcfg.CapabilityFunnelPorts + "?ports=443,8443": nil,
+						},
+						Tags: ptrToReadOnlySlice([]string{"some-tag"}),
+					},
+					CurrentTailnet: &ipnstate.TailnetStatus{MagicDNSSuffix: "test.ts.net"},
+				},
+				SOMarkInUse: true,
+			},
+			steps: []step{{
+				command: cmd("serve --service=svc:foo --http=80 --set-path=/old --redirect=301:https://${HOST}/new"),
+				want: &ipn.ServeConfig{
+					Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
+						"svc:foo": {
+							TCP: map[uint16]*ipn.TCPPortHandler{
+								80: {HTTP: true},
+							},
+							Web: map[ipn.HostPort]*ipn.WebServerConfig{
+								"foo.test.ts.net:80": {Handlers: map[string]*ipn.HTTPHandler{
+									"/old": {Redirect: "301:https://${HOST}/new"},
+								}},
+							},
+						},
+					},
+				},
+			}},
+		},
+		{
 			name: "advertise_service_from_untagged_node",
 			steps: []step{{
 				command: cmd("serve --service=svc:foo --http=80 text:foo"),
@@ -987,6 +1129,42 @@ func TestServeDevConfigMutations(t *testing.T) {
 			steps: []step{{
 				command: cmd("serve --https=443 --proxy-protocol=1 --bg http://localhost:3000"),
 				wantErr: anyErr(),
+			}},
+		},
+		{
+			name: "redirect_with_target",
+			steps: []step{{
+				command: cmd("serve --bg --http=80 --redirect=https://${HOST}${REQUEST_URI} localhost:3000"),
+				wantErr: func(err error) (badErrMsg string) {
+					if err == nil || !strings.Contains(err.Error(), "cannot specify both --redirect and a target") {
+						return fmt.Sprintf("wanted redirect target combination error, got %v", err)
+					}
+					return ""
+				},
+			}},
+		},
+		{
+			name: "redirect_with_tcp",
+			steps: []step{{
+				command: cmd("serve --bg --tcp=80 --redirect=https://${HOST}${REQUEST_URI}"),
+				wantErr: func(err error) (badErrMsg string) {
+					if err == nil || !strings.Contains(err.Error(), "--redirect is only supported for HTTP/HTTPS handlers") {
+						return fmt.Sprintf("wanted redirect protocol error, got %v", err)
+					}
+					return ""
+				},
+			}},
+		},
+		{
+			name: "redirect_with_accept_app_caps",
+			steps: []step{{
+				command: cmd("serve --bg --http=80 --accept-app-caps=example.com/cap/foo --redirect=https://${HOST}${REQUEST_URI}"),
+				wantErr: func(err error) (badErrMsg string) {
+					if err == nil || !strings.Contains(err.Error(), "--redirect cannot be combined with --accept-app-caps") {
+						return fmt.Sprintf("wanted redirect accept-app-caps error, got %v", err)
+					}
+					return ""
+				},
 			}},
 		},
 	}
@@ -1441,6 +1619,35 @@ func TestMessageForPort(t *testing.T) {
 				"",
 				"https://foo.test.ts.net:80/",
 				"|-- proxy http://127.0.0.1:3000",
+				"",
+				fmt.Sprintf(msgRunningInBackground, "Serve"),
+				fmt.Sprintf(msgDisableProxy, "serve", "http", 80),
+			}, "\n"),
+		},
+		{
+			name:   "serve-http-redirect",
+			subcmd: serve,
+			serveConfig: &ipn.ServeConfig{
+				TCP: map[uint16]*ipn.TCPPortHandler{
+					80: {HTTP: true},
+				},
+				Web: map[ipn.HostPort]*ipn.WebServerConfig{
+					"foo.test.ts.net:80": {
+						Handlers: map[string]*ipn.HTTPHandler{
+							"/": {Redirect: "301:https://${HOST}${REQUEST_URI}"},
+						},
+					},
+				},
+			},
+			status:  &ipnstate.Status{CurrentTailnet: &ipnstate.TailnetStatus{MagicDNSSuffix: "test.ts.net"}},
+			dnsName: "foo.test.ts.net",
+			srvType: serveTypeHTTP,
+			srvPort: 80,
+			expected: strings.Join([]string{
+				msgServeAvailable,
+				"",
+				"http://foo.test.ts.net/",
+				"|-- redirect 301:https://${HOST}${REQUEST_URI}",
 				"",
 				fmt.Sprintf(msgRunningInBackground, "Serve"),
 				fmt.Sprintf(msgDisableProxy, "serve", "http", 80),


### PR DESCRIPTION
## Summary

Add `--redirect` support to both `tailscale serve` and `tailscale funnel`.

## Supported behavior

- Optional redirect status codes (for example `301:`)
- `${HOST}` and `${REQUEST_URI}` template variables
- Custom mount paths via `--set-path`
- Service mode via `--service` (Serve only)
- Funnel mode via `tailscale funnel`

## Tests

- Standard Serve redirects
- Service redirects
- Funnel redirects
- Redirects with custom mount paths
- Invalid flag combinations

## Examples

HTTP → HTTPS on the same host:

- `tailscale serve --http=80 --bg --redirect=301:https://${HOST}${REQUEST_URI}`

Redirect to another host:

- `tailscale serve --bg --redirect=301:https://example.com${REQUEST_URI}`

Service redirect:

- `tailscale serve --service=svc:example --bg --redirect=301:https://example.com${REQUEST_URI}`

Funnel redirect:

- `tailscale funnel --bg --redirect=301:https://example.com${REQUEST_URI}`

Path-specific redirect:

- `tailscale funnel --bg --set-path=/old --redirect=301:https://${HOST}/new`

## Note

`tailscale funnel --service=...` remains unsupported.

Updates #11330