### PR TITLE
go.mod: bump golang.org/x/image@v0.41.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -164,4 +164,4 @@
     });
   };
 }
-# nix-direnv cache busting line: sha256-O8fayMGE9gM/2IamN1AP6Mk8GQTEYGtEeF35iebRkVs=
+# nix-direnv cache busting line: sha256-2J5X1EddqDfr1X2lk7fZL0/eFbwDbfwuBS9K6JGZQv0=

--- a/flakehashes.json
+++ b/flakehashes.json
@@ -4,7 +4,7 @@
     "sri": "sha256-uskKJHUzzIQ74VuzoQKrlz+6tCY/YKnv+BjJduPwt6Q="
   },
   "vendor": {
-    "goModSum": "sha256-hCboT8GUclGQNy2K6bBLNl602T2dJ45DO3BTMRlRvfg=",
-    "sri": "sha256-O8fayMGE9gM/2IamN1AP6Mk8GQTEYGtEeF35iebRkVs="
+    "goModSum": "sha256-RDqwsAxOB4md+lrJ1mYoVDJwqka0zJB040lEY+05hWA=",
+    "sri": "sha256-2J5X1EddqDfr1X2lk7fZL0/eFbwDbfwuBS9K6JGZQv0="
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -494,7 +494,7 @@ require (
 	gitlab.com/digitalxero/go-conventional-commit v1.0.7 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20240314144324-c7f7c6466f7f // indirect
-	golang.org/x/image v0.27.0 // indirect
+	golang.org/x/image v0.41.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1359,8 +1359,8 @@ golang.org/x/exp/typeparams v0.0.0-20240314144324-c7f7c6466f7f h1:phY1HzDcf18Aq9
 golang.org/x/exp/typeparams v0.0.0-20240314144324-c7f7c6466f7f/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
-golang.org/x/image v0.27.0 h1:C8gA4oWU/tKkdCfYT6T2u4faJu3MeNS5O8UPWlPF61w=
-golang.org/x/image v0.27.0/go.mod h1:xbdrClrAUway1MUTEZDq9mz/UpRwYAkFFNUslZtcB+g=
+golang.org/x/image v0.41.0 h1:8wS72eGJMJaBxK6okTzd4WaXumUlTVlb753MlsSvTCo=
+golang.org/x/image v0.41.0/go.mod h1:uIc348UZMSvS5Z65CVZ7iDPaNobNFEPeJ4kbqTOszmA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/shell.nix
+++ b/shell.nix
@@ -16,4 +16,4 @@
 ) {
   src =  ./.;
 }).shellNix
-# nix-direnv cache busting line: sha256-O8fayMGE9gM/2IamN1AP6Mk8GQTEYGtEeF35iebRkVs=
+# nix-direnv cache busting line: sha256-2J5X1EddqDfr1X2lk7fZL0/eFbwDbfwuBS9K6JGZQv0=


### PR DESCRIPTION
Bump golang.org/x/image@v0.41.0 to resolve govulncheck

Updates #cleanup