### PR TITLE
tstest/integration/testcontrol: expire individual node keys

### DIFF
--- a/tsnet/tsnet_test.go
+++ b/tsnet/tsnet_test.go
@@ -3405,3 +3405,116 @@ func TestListenMultipleEphemeralPorts(t *testing.T) {
 		testMultipleEphemeral(t, lt)
 	})
 }
+
+func TestKeyExtensionAfterRestart(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	controlURL, control := startControl(t)
+	control.RequireAuth = true
+
+	tmp := t.TempDir()
+	tmps := filepath.Join(tmp, "s1")
+	os.MkdirAll(tmps, 0755)
+
+	newServer := func() *Server {
+		return &Server{
+			Dir:        tmps,
+			ControlURL: controlURL,
+			Hostname:   "s1",
+			Logf:       tstest.WhileTestRunningLogger(t),
+		}
+	}
+
+	// Start a node as tnset instance s1.
+	s1 := newServer()
+	if err := s1.Start(); err != nil {
+		t.Fatalf("s1.Start: %v", err)
+	}
+	upErrCh := make(chan error, 1)
+	go func() { _, err := s1.Up(ctx); upErrCh <- err }()
+
+	var initialAuthURL string
+	if err := tstest.WaitFor(10*time.Second, func() error {
+		url := s1.lb.StatusWithoutPeers().AuthURL
+		if url == "" {
+			return errors.New("no AuthURL yet")
+		}
+		initialAuthURL = url
+		return nil
+	}); err != nil {
+		t.Fatalf("waiting for initial AuthURL: %v", err)
+	}
+	if !control.CompleteAuth(initialAuthURL) {
+		t.Fatal("failed to complete initial AuthURL")
+	}
+	if err := <-upErrCh; err != nil {
+		t.Fatalf("s1.Up: %v", err)
+	}
+
+	nodePub := s1.lb.StatusWithoutPeers().Self.PublicKey
+
+	// Expire s1's node key.
+	serverNode := control.Node(nodePub)
+	if serverNode == nil {
+		t.Fatalf("node %v not in control", nodePub)
+	}
+	serverNode.KeyExpiry = time.Now().Add(-time.Minute)
+	control.UpdateNode(serverNode)
+
+	// Wait for s1 to transition away from the Running state.
+	if err := tstest.WaitFor(10*time.Second, func() error {
+		if got := s1.lb.State(); got == ipn.Running {
+			return errors.New("still Running")
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("waiting to transition away from Running: %v", err)
+	}
+
+	if err := s1.Close(); err != nil {
+		t.Fatalf("s1.Close: %v", err)
+	}
+
+	// Restart the node as tsnet instance s2.
+	s2 := newServer()
+	if err := s2.Start(); err != nil {
+		t.Fatalf("s2.Start: %v", err)
+	}
+	s2UpErrCh := make(chan error, 1)
+	go func() { _, err := s2.Up(ctx); s2UpErrCh <- err }()
+
+	// Wait for s2 to transition into the NeedsLogin state.
+	var secondAuthURL string
+	if err := tstest.WaitFor(10*time.Second, func() error {
+		u := s2.lb.StatusWithoutPeers().AuthURL
+		if u == "" {
+			return errors.New("no AuthURL yet")
+		}
+		secondAuthURL = u
+		return nil
+	}); err != nil {
+		t.Fatalf("waiting for s2 AuthURL: %v", err)
+	}
+	// We deliberately do not complete the auth.
+	_ = secondAuthURL
+
+	// Extend the old node key.
+	serverNode.KeyExpiry = time.Now().Add(24 * time.Hour)
+	control.UpdateNode(serverNode)
+
+	// Wait for s2 to receive the netmap with the key extension info
+	// and transition to Running.
+	if err := tstest.WaitFor(15*time.Second, func() error {
+		if got := s2.lb.State(); got != ipn.Running {
+			return fmt.Errorf("in state %v; want Running", got)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("waiting to return to Running after key extension: %v", err)
+	}
+
+	if err := <-s2UpErrCh; err != nil {
+		t.Logf("s2.Up: %v", err)
+	}
+}

--- a/tstest/integration/testcontrol/testcontrol.go
+++ b/tstest/integration/testcontrol/testcontrol.go
@@ -847,7 +847,8 @@ func (s *Server) serveRegister(w http.ResponseWriter, r *http.Request, mkey key.
 	}
 
 	// If this is a followup request, wait until interactive followup URL visit complete.
-	if req.Followup != "" {
+	isFollowup := req.Followup != ""
+	if isFollowup {
 		followupURL, err := url.Parse(req.Followup)
 		if err != nil {
 			panic(err)
@@ -863,18 +864,22 @@ func (s *Server) serveRegister(w http.ResponseWriter, r *http.Request, mkey key.
 		// some follow-ups? For now all are successes.
 	}
 
-	// The in-memory list of nodes, users, and logins is keyed by
-	// the node key.  If the node key changes, update all the data stores
-	// to use the new node key.
+	// On a key rotation (OldNodeKey set and known to s.nodes), stage
+	// the new key as a candidate entry but keep the old key's entry
+	// alive so an in-flight map poll can still receive updates while
+	// the user completes the auth URL.
 	s.mu.Lock()
 	if _, oldNodeKeyOk := s.nodes[req.OldNodeKey]; oldNodeKeyOk {
 		if _, newNodeKeyOk := s.nodes[req.NodeKey]; !newNodeKeyOk {
-			s.nodes[req.OldNodeKey].Key = req.NodeKey
-			s.nodes[req.NodeKey] = s.nodes[req.OldNodeKey]
-
+			cloned := s.nodes[req.OldNodeKey].Clone()
+			cloned.Key = req.NodeKey
+			s.nodes[req.NodeKey] = cloned
 			s.users[req.NodeKey] = s.users[req.OldNodeKey]
 			s.logins[req.NodeKey] = s.logins[req.OldNodeKey]
-
+		}
+		if isFollowup {
+			// The user has completed the auth URL, the new key
+			// is now authoritative. Retire the old key's entry.
 			delete(s.nodes, req.OldNodeKey)
 			delete(s.users, req.OldNodeKey)
 			delete(s.logins, req.OldNodeKey)
@@ -934,11 +939,19 @@ func (s *Server) serveRegister(w http.ResponseWriter, r *http.Request, mkey key.
 		}
 		s.nodes[nk] = node
 	}
+	// Consider a node key expired if allExpired is set or if the nodeKey has
+	// an expiry time in the past. This allows tests to set per-node KeyExpiry
+	// via UpdateNode to simulate an admin-triggered or time-based expiry.
+	nodeKeyExpired := s.allExpired
+	if !nodeKeyExpired && req.OldNodeKey.IsZero() {
+		if n, ok := s.nodes[nk]; ok && !n.KeyExpiry.IsZero() && n.KeyExpiry.Before(time.Now()) {
+			nodeKeyExpired = true
+		}
+	}
 	requireAuth := s.RequireAuth
-	if requireAuth && s.nodeKeyAuthed.Contains(nk) {
+	if requireAuth && s.nodeKeyAuthed.Contains(nk) && !nodeKeyExpired {
 		requireAuth = false
 	}
-	allExpired := s.allExpired
 	s.mu.Unlock()
 
 	authURL := ""
@@ -951,7 +964,7 @@ func (s *Server) serveRegister(w http.ResponseWriter, r *http.Request, mkey key.
 	res, err := s.encode(false, tailcfg.RegisterResponse{
 		User:              *user,
 		Login:             *login,
-		NodeKeyExpired:    allExpired,
+		NodeKeyExpired:    nodeKeyExpired,
 		MachineAuthorized: machineAuthorized,
 		AuthURL:           authURL,
 	})


### PR DESCRIPTION
This amends testcontrol in order to be able to test key extension flows.

With the change, testcontrol considers a node as requiring auth if its node key is expired, so that we return an auth URL in the response.
 
When a register request passes an old and a new node key, we need to keep the old node key around in test control's node registry instead of discarding it, so that we can test that the extending it works.

Updates #19326