### PR TITLE
cmd/tailscale/cli/jsonoutput: rename exported identifiers

### DIFF
--- a/cmd/tailscale/cli/jsonoutput/example_schemaversion_test.go
+++ b/cmd/tailscale/cli/jsonoutput/example_schemaversion_test.go
@@ -11,15 +11,15 @@ import (
 )
 
 var args struct {
-	json jsonoutput.JSONSchemaVersion
+	json jsonoutput.SchemaVersion
 }
 
-func ExampleJSONSchemaVersion() {
-	fs := flag.NewFlagSet("ExampleJSONSchemaVersion", flag.ExitOnError)
+func ExampleSchemaVersion() {
+	fs := flag.NewFlagSet("ExampleSchemaVersion", flag.ExitOnError)
 	fs.Var(&args.json, "json", "output in JSON format")
 
 	fs.Parse([]string{"-json=2"})
-	fmt.Printf(`{set: %t, value: %d}`, args.json.IsSet, args.json.Value)
+	fmt.Printf(`{set: %t, value: %d}`, args.json.IsSet, args.json.Version)
 	// Output:
 	// {set: true, value: 2}
 }

--- a/cmd/tailscale/cli/jsonoutput/jsonoutput.go
+++ b/cmd/tailscale/cli/jsonoutput/jsonoutput.go
@@ -8,7 +8,7 @@
 // Historically we only used a boolean -json flag, so changing the output
 // could break scripts that rely on the existing format.
 //
-// This package provides a [JSONSchemaVersion] flag type that allows callers
+// This package provides a [SchemaVersion] flag type that allows callers
 // to pass either a boolean or a version number and get a consistent output.
 // We'll bump the version when we make a breaking change
 // that's likely to break scripts that rely on the existing output,
@@ -27,32 +27,32 @@ import (
 	"strconv"
 )
 
-var _ flag.Value = &JSONSchemaVersion{}
+var _ flag.Value = &SchemaVersion{}
 
-// JSONSchemaVersion implements the [flag.Value] interface,
+// SchemaVersion implements the [flag.Value] interface,
 // tracking whether the flag has been set or cleared, and its value when set.
-type JSONSchemaVersion struct {
+type SchemaVersion struct {
 	// IsSet tracks if the flag was set or cleared.
 	// This flag is true when set by -name or -name=true or -name=INT,
 	// otherwise it is false when cleared by -name=false.
 	IsSet bool
 
-	// Value tracks the desired schema version, as set by the -name=INT flag.
+	// Version tracks the desired schema version, as set by the -name=INT flag.
 	// The version defaults to 1 when implicitly set by -name or -name=true.
-	Value int
+	Version int
 }
 
 // String returns the default value which is printed in the CLI help text.
-func (v *JSONSchemaVersion) String() string {
+func (v *SchemaVersion) String() string {
 	if v.IsSet {
-		return strconv.Itoa(v.Value)
+		return strconv.Itoa(v.Version)
 	} else {
 		return "(not set)"
 	}
 }
 
 // Set is called when the user passes the flag as a command-line argument.
-func (v *JSONSchemaVersion) Set(s string) error {
+func (v *SchemaVersion) Set(s string) error {
 	if v.IsSet {
 		return errors.New("received multiple instances of --json; only pass it once")
 	}
@@ -63,7 +63,7 @@ func (v *JSONSchemaVersion) Set(s string) error {
 	// This ensures that any existing scripts will continue to get their
 	// current output.
 	if s == "true" {
-		v.Value = 1
+		v.Version = 1
 		return nil
 	}
 
@@ -71,14 +71,14 @@ func (v *JSONSchemaVersion) Set(s string) error {
 	if err != nil {
 		return fmt.Errorf("invalid integer value passed to --json: %q", s)
 	}
-	v.Value = version
+	v.Version = version
 	return nil
 }
 
 // IsBoolFlag reports that this [flag.Value] can be set without an argument.
 // This is the magic interface that makes -name equivalent to -name=true
 // rather than using the next command-line argument.
-func (v *JSONSchemaVersion) IsBoolFlag() bool {
+func (v *SchemaVersion) IsBoolFlag() bool {
 	return true
 }
 

--- a/cmd/tailscale/cli/tailnet-lock.go
+++ b/cmd/tailscale/cli/tailnet-lock.go
@@ -195,7 +195,7 @@ func runTailnetLockInit(ctx context.Context, args []string) error {
 }
 
 var nlStatusArgs struct {
-	json jsonoutput.JSONSchemaVersion
+	json jsonoutput.SchemaVersion
 }
 
 var tlStatusCmd = &ffcli.Command{
@@ -221,10 +221,10 @@ func runTailnetLockStatus(ctx context.Context, args []string) error {
 	}
 
 	if nlStatusArgs.json.IsSet {
-		if nlStatusArgs.json.Value == 1 {
+		if nlStatusArgs.json.Version == 1 {
 			return jsonoutput.PrintNetworkLockStatusJSONV1(os.Stdout, st)
 		} else {
-			return fmt.Errorf("unrecognised version: %d", nlStatusArgs.json.Value)
+			return fmt.Errorf("unrecognised version: %d", nlStatusArgs.json.Version)
 		}
 	}
 
@@ -604,7 +604,7 @@ func runTailnetLockDisablementKDF(ctx context.Context, args []string) error {
 
 var nlLogArgs struct {
 	limit int
-	json  jsonoutput.JSONSchemaVersion
+	json  jsonoutput.SchemaVersion
 }
 
 var tlLogCmd = &ffcli.Command{
@@ -712,12 +712,12 @@ func runTailnetLockLog(ctx context.Context, args []string) error {
 	return printTailnetLockLog(updates, out, nlLogArgs.json, useColor)
 }
 
-func printTailnetLockLog(updates []ipnstate.NetworkLockUpdate, out io.Writer, jsonSchema jsonoutput.JSONSchemaVersion, useColor bool) error {
+func printTailnetLockLog(updates []ipnstate.NetworkLockUpdate, out io.Writer, jsonSchema jsonoutput.SchemaVersion, useColor bool) error {
 	if jsonSchema.IsSet {
-		if jsonSchema.Value == 1 {
+		if jsonSchema.Version == 1 {
 			return jsonoutput.PrintNetworkLockLogJSONV1(out, updates)
 		} else {
-			return fmt.Errorf("unrecognised version: %d", jsonSchema.Value)
+			return fmt.Errorf("unrecognised version: %d", jsonSchema.Version)
 		}
 	}
 

--- a/cmd/tailscale/cli/tailnet-lock_test.go
+++ b/cmd/tailscale/cli/tailnet-lock_test.go
@@ -85,7 +85,7 @@ func TestTailnetLockLogOutput(t *testing.T) {
 		t.Parallel()
 
 		var outBuf bytes.Buffer
-		json := jsonoutput.JSONSchemaVersion{}
+		json := jsonoutput.SchemaVersion{}
 		useColor := false
 
 		printTailnetLockLog(updates, &outBuf, json, useColor)
@@ -189,9 +189,9 @@ KeyID: tlpub:0202
 		t.Parallel()
 
 		var outBuf bytes.Buffer
-		json := jsonoutput.JSONSchemaVersion{
-			IsSet: true,
-			Value: 1,
+		json := jsonoutput.SchemaVersion{
+			IsSet:   true,
+			Version: 1,
 		}
 		useColor := false
 


### PR DESCRIPTION
Since we don’t think anyone has actually imported the [jsonoutput](https://pkg.go.dev/tailscale.com@v1.100.0/cmd/tailscale/cli/jsonoutput) package yet, we still have a chance to rename its fundamental types:

1. Rename the `JSONSchemaVersion` struct to `SchemaVersion` because it is a [flag.Value](https://pkg.go.dev/flag#Value) that can represent any schema version.

2. Rename the `JSONSchemaVersion.Value` field to `SchemaVersion.Version` so the struct reads better:
   ``` go
   if args.json.IsSet && args.json.Version == 1 {
   	// ...
   }
   ```

Updates #17613

### Commentary

I know the whole point of this package is to provide a stable interface for third-parties like Headscale to unmarshal the output of commands like `tailscale dns status --json` with [jsonoutput.DNSStatusResult](https://pkg.go.dev/tailscale.com@v1.100.0/cmd/tailscale/cli/jsonoutput#DNSStatusResult).

Which is why it’s important that we choose good names now, before it’s too late. Currently, there are no known importers of this package by third parties according to pkg.go.dev ([link](https://pkg.go.dev/tailscale.com/cmd/tailscale/cli/jsonoutput?tab=importedby)). The only use is our own implementation of `tailscale lock`.