### PR TITLE
tsnet: add test reproducing permanent leak when Close() races Start()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -106,7 +106,7 @@ require (
 	github.com/tailscale/ts-gokrazy v0.0.0-20260429180033-fe741c6deb44
 	github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976
 	github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6
-	github.com/tailscale/wireguard-go v0.0.0-20260527010701-b48af7099cad
+	github.com/tailscale/wireguard-go v0.0.0-20260603160903-21fba1928adc
 	github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e
 	github.com/tc-hib/winres v0.2.1
 	github.com/tcnksm/go-httpstat v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1175,8 +1175,8 @@ github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976 h1:U
 github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976/go.mod h1:agQPE6y6ldqCOui2gkIh7ZMztTkIQKH049tv8siLuNQ=
 github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6 h1:l10Gi6w9jxvinoiq15g8OToDdASBni4CyJOdHY1Hr8M=
 github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6/go.mod h1:ZXRML051h7o4OcI0d3AaILDIad/Xw0IkXaHM17dic1Y=
-github.com/tailscale/wireguard-go v0.0.0-20260527010701-b48af7099cad h1:Ky26FR5yZ5IKEB0xtm5A8xSTb06ImY7kxBFrvgOmJSg=
-github.com/tailscale/wireguard-go v0.0.0-20260527010701-b48af7099cad/go.mod h1:6SerzcvHWQchKO2BfNdmquA77CHSECZuFl+D9fp4RnI=
+github.com/tailscale/wireguard-go v0.0.0-20260603160903-21fba1928adc h1:1B91UC28clVitP/4BMYzVTYKI6XnHOzeBIhrcKn3Mj8=
+github.com/tailscale/wireguard-go v0.0.0-20260603160903-21fba1928adc/go.mod h1:6SerzcvHWQchKO2BfNdmquA77CHSECZuFl+D9fp4RnI=
 github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e h1:zOGKqN5D5hHhiYUp091JqK7DPCqSARyUfduhGUY8Bek=
 github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e/go.mod h1:orPd6JZXXRyuDusYilywte7k094d7dycXXU5YnWsrwg=
 github.com/tc-hib/winres v0.2.1 h1:YDE0FiP0VmtRaDn7+aaChp1KiF4owBiJa5l964l5ujA=

--- a/tsnet/leakrepro.md
+++ b/tsnet/leakrepro.md
@@ -92,11 +92,11 @@ is collected), so it is **red on today's code and green once fixed**.
 
 ### Interpreting the output
 
-The race is probabilistic (~5–10% per attempt on the tail of `start()`), so a
+The race is probabilistic (~45–55% per attempt on the tail of `start()`), so a
 single `Close()` rarely shows it. The test reports, e.g.:
 
 ```
-FINAL: 2/45 Servers leaked, 0/45 Close() panics; heapInuse 2 -> 21 MiB
+FINAL: 12/20 Servers leaked, 1/20 Close() panics; heapInuse 36 -> 340 MiB
 ```
 
 It reproduces on every run (a few leaks each), and in a process that restarts

--- a/tsnet/leakrepro.md
+++ b/tsnet/leakrepro.md
@@ -1,0 +1,128 @@
+# Permanent `tsnet.Server` leak: `Close()` racing an in-flight `Start()`
+
+This documents the bug reproduced by `tsnet/leakrepro_test.go`
+(`TestLeak_CloseRacingStart`).
+
+## Summary
+
+A `tsnet.Server` — and the whole subsystem graph it owns: the `netstack.Impl`,
+the `wgengine` engine, the `magicsock.Conn`, the wireguard device and its 64 KiB
+packet-buffer pools, and the netmap — is **never garbage collected** after
+`Close()` when `Close()` raced an in-flight `Start()`. The orphaned objects
+accumulate for the life of the process, so a program that brings tsnet servers
+up and tears them down repeatedly (e.g. a supervisor that restarts a failing
+instance on a deadline) grows without bound.
+
+The leak is invisible to the usual checks: no goroutine is leaked, and
+`go test -race` is silent (this is a logical teardown race, not a data race).
+The only external symptom is steadily climbing RSS.
+
+## Root cause
+
+`Server.start()` creates the heavy subsystems but assigns them to `Server`
+fields only late:
+
+- `netstack.Create(...)` (`tsnet.go:868`) immediately does
+  `stacksForMetrics.Store(ns)` (`wgengine/netstack/netstack.go:445`).
+- `s.netstack = ns` isn't until `tsnet.go:886`; `s.lb = lb` at `:937`.
+
+`Server.close()` (`tsnet.go:614`) tears a subsystem down **only if its field is
+non-nil**, and it cancels `s.shutdownCtx`, which the in-flight `start()` is
+using:
+
+```go
+if s.shutdownCancel != nil { s.shutdownCancel() } // tsnet.go:645
+if s.netstack != nil       { s.netstack.Close() } // :648  (Impl.Close does stacksForMetrics.Delete)
+if s.lb != nil             { s.lb.Shutdown() }     // :651
+if s.netMon != nil         { s.netMon.Close() }    // :654
+```
+
+Nothing makes `start()` notice that a `close()` already ran, and the netstack is
+**not** registered in `start()`'s error-cleanup `closePool`. So when `Close()`
+lands while `start()` is mid-flight, `close()` snapshots `s.netstack` / `s.lb` /
+`s.netMon` as nil and skips them, while `start()` goes on to create and store the
+subsystems. The result is orphaned forever:
+
+- the `netstack.Impl` stays in the package-global `netstack.stacksForMetrics`
+  map (its `Impl.Close()`, which would call `stacksForMetrics.Delete`, never
+  runs);
+- `magicsock`'s per-endpoint timers keep running and are held alive by the
+  runtime timer heap;
+- the `wgengine` stays registered as a `netMon` change callback.
+
+(There is also a narrower window: a `Close()` landing in *very* early `start()`,
+before `s.sys` is initialized, nil-panics in `close()` at `tsnet.go:667`,
+`s.sys.Bus.Get().Close()`. The same coordination fix covers both.)
+
+## This is not the wireguard-go finalizer leak
+
+This branch is current `main` plus the proposed non-leaking wireguard-go
+(`github.com/tailscale/wireguard-go@v0.0.0-20260603160903-21fba1928adc`). The
+test still fails on it, so that wireguard-go fix is **necessary but not
+sufficient** — this leak lives entirely in `tailscale.com/tsnet` and is not
+addressed by the wireguard-go change.
+
+## Why a real tailnet is required
+
+The vulnerable window is the wall-clock duration of `start()`. Against an
+in-process test control server `start()` finishes in tens of milliseconds, so
+the window is essentially never hit and the leak does not appear. Against a real
+control server `start()` takes hundreds of milliseconds to seconds (DERP connect
++ login), so a `Close()` fired during it reliably lands in the window. This is
+exactly the production scenario: a startup deadline (or context cancellation)
+firing `Close()` while a slow connect is still in progress.
+
+That is why the test is gated on `TS_AUTHKEY` and connects to a real control
+server.
+
+## Running it
+
+```
+TS_AUTHKEY=tskey-auth-... go test ./tsnet/ -run TestLeak_CloseRacingStart -v
+```
+
+- Optionally set `TS_CONTROL_URL` to point at a specific control server.
+- Use an **ephemeral** auth key; the test registers nodes named `leakrepro-N`.
+
+The test loops, launching `Up()` in a goroutine and calling `Close()` a short,
+swept delay later so some iterations land inside `start()`. It detects leaks with
+a `weak.Pointer[Server]`: a Server that is collected after `Close()` is healthy;
+one that survives GC is orphaned. It asserts the correct invariant (every Server
+is collected), so it is **red on today's code and green once fixed**.
+
+### Interpreting the output
+
+The race is probabilistic (~5–10% per attempt on the tail of `start()`), so a
+single `Close()` rarely shows it. The test reports, e.g.:
+
+```
+FINAL: 2/45 Servers leaked, 0/45 Close() panics; heapInuse 2 -> 21 MiB
+```
+
+It reproduces on every run (a few leaks each), and in a process that restarts
+repeatedly it accumulates without bound — the production symptom is hundreds of
+orphaned `Impl`s in `stacksForMetrics` and RSS that climbs for as long as the
+process runs.
+
+The test self-calibrates to the machine: it first times `Start()`'s build phase
+(the vulnerable window, whose absolute position scales with how fast this
+machine reaches control), then sweeps the `Close()` delay across that interval —
+so it works on a fast workstation and a slow CI box alike. If a run still
+observes 0 leaks, raise `iters` for denser sampling.
+
+The detection deliberately keys only on Go GC of the in-process `*Server`, never
+on tailnet state, so neither node-name collisions nor a flaky registration can
+produce a false positive or false negative.
+
+## Suggested fix direction
+
+Make `Close()` and `start()` coordinate so subsystems can't be orphaned:
+
+- a "closing" state that `start()` checks (and unwinds what it has already
+  built) after each subsystem it creates; and/or
+- register the netstack in `start()`'s `closePool`, and have `close()` wait for
+  an in-flight `start()` to finish rather than snapshotting nil fields and
+  returning.
+
+Either approach also fixes the early-`start()` `close()` nil-panic at
+`tsnet.go:667`.

--- a/tsnet/leakrepro_test.go
+++ b/tsnet/leakrepro_test.go
@@ -1,0 +1,180 @@
+package tsnet
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+	"weak"
+
+	"tailscale.com/ipn/store/mem"
+)
+
+// TestLeak_CloseRacingStart reproduces a permanent leak: a tsnet.Server — and
+// everything it owns (netstack.Impl, wgengine, magicsock.Conn, the wireguard
+// device + its 64 KiB buffer pools, the netmap) — is never collected after
+// Close() when Close() raced an in-flight Start().
+//
+// Mechanism. Server.start() creates the netstack early (netstack.Create does
+// stacksForMetrics.Store(ns)) and only later finishes wiring the server up.
+// Server.close() tears a subsystem down only if its field is non-nil
+// (if s.netstack != nil { s.netstack.Close() }, etc.) and Close() also cancels
+// s.shutdownCtx, which an in-flight start() is using. Nothing makes start()
+// notice a Close() already ran, and the netstack is not registered in start()'s
+// error-cleanup pool. So a Close() landing during start() can leave the
+// netstack/engine/magicsock orphaned: the netstack stays in the package-global
+// netstack.stacksForMetrics map, magicsock's per-endpoint timers keep running
+// (runtime timer heap), and the engine stays registered as a netMon callback.
+//
+// Why a real tailnet is required. The vulnerable window is the wall-clock
+// duration of start(). Against an in-process test control server start()
+// finishes in tens of ms, so the window is almost never hit. Against a real
+// control server start() takes ~hundreds of ms to seconds (DERP + login), so a
+// Close() fired during it lands in the window — which is what happens in
+// production when a startup deadline fires Close() while a slow connect is in
+// flight.
+//
+// This test sweeps the close delay across iterations and reports which delays
+// orphan the Server (never collected) and which crash Close() (an even-earlier
+// window: Close() before start() initialized s.sys nil-panics in close()).
+//
+//	TS_AUTHKEY=tskey-auth-... go test ./tsnet/ -run TestLeak_CloseRacingStart -v
+func TestLeak_CloseRacingStart(t *testing.T) {
+	authKey := os.Getenv("TS_AUTHKEY")
+	if authKey == "" {
+		t.Skip("set TS_AUTHKEY to an ephemeral auth key to run the real-tailnet repro")
+	}
+	controlURL := os.Getenv("TS_CONTROL_URL")
+
+	// Calibrate to this machine. The vulnerable window is the synchronous build
+	// phase of start(); its absolute position scales with how fast this machine
+	// reaches a real control server, so a hardcoded close delay only works on
+	// one machine. Time Start() (which blocks through start()) once, then sweep
+	// the close delay across that interval. Calibrating on the first (typically
+	// slowest) build is conservative: later, faster builds fall inside [0,build].
+	calibrate := func() time.Duration {
+		s := &Server{
+			Dir: t.TempDir(), Hostname: "leakrepro-cal",
+			AuthKey: authKey, ControlURL: controlURL,
+			Ephemeral: true, Store: new(mem.Store),
+		}
+		t0 := time.Now()
+		s.Start() // blocks through doInit -> start(): the synchronous build
+		d := time.Since(t0)
+		s.Close()
+		return d
+	}
+	build := calibrate()
+	if build < 50*time.Millisecond {
+		build = 50 * time.Millisecond
+	}
+	upTimeout := min(max(4*build, 2*time.Second), 8*time.Second)
+	const iters = 60
+	t.Logf("calibration: Start() build ~%s; sweeping close delay across [0, %s] over %d iters (upTimeout %s)",
+		build, time.Duration(float64(build)*1.1), iters, upTimeout)
+
+	heapMB := func() float64 {
+		runtime.GC()
+		var m runtime.MemStats
+		runtime.ReadMemStats(&m)
+		return float64(m.HeapInuse) / (1 << 20)
+	}
+
+	type result struct {
+		delay   time.Duration
+		leaked  bool
+		crashed bool
+	}
+	var results []result
+	var wps []weak.Pointer[Server]
+
+	run := func(i int, delay time.Duration) (wp weak.Pointer[Server], crashed bool) {
+		s := &Server{
+			Dir:        t.TempDir(),
+			Hostname:   fmt.Sprintf("leakrepro-%d", i),
+			AuthKey:    authKey,
+			ControlURL: controlURL,
+			Ephemeral:  true,
+			Store:      new(mem.Store),
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), upTimeout)
+		defer cancel()
+
+		done := make(chan struct{})
+		go func() {
+			defer func() { recover(); close(done) }() // Up may observe the torn-down server
+			s.Up(ctx)
+		}()
+
+		time.Sleep(delay)
+		func() {
+			defer func() {
+				if recover() != nil {
+					crashed = true // Close() raced an even-earlier start() and nil-panicked
+				}
+			}()
+			s.Close()
+		}()
+		<-done
+		return weak.Make(s), crashed
+	}
+
+	baseMB := heapMB()
+	for i := 0; i < iters; i++ {
+		// Sweep the close delay uniformly across the build window (slightly past
+		// it). Per-iteration variance in start() duration fills the gaps, so
+		// some iterations reliably land in the orphan window.
+		delay := time.Duration(float64(build) * 1.1 * float64(i) / float64(iters))
+		wp, crashed := run(i, delay)
+		wps = append(wps, wp)
+		results = append(results, result{delay: delay, crashed: crashed})
+	}
+
+	// Settle, then see which Servers never collected.
+	for i := 0; i < 10; i++ {
+		runtime.GC()
+	}
+	time.Sleep(3 * time.Second)
+	for i := 0; i < 6; i++ {
+		runtime.GC()
+	}
+	leaked := 0
+	crashed := 0
+	for i := range results {
+		results[i].leaked = wps[i].Value() != nil
+		if results[i].leaked {
+			leaked++
+		}
+		if results[i].crashed {
+			crashed++
+		}
+	}
+
+	for _, r := range results {
+		status := "collected"
+		if r.crashed {
+			status = "Close() PANICKED"
+		} else if r.leaked {
+			status = "LEAKED (never collected)"
+		}
+		t.Logf("  closeDelay=%5s -> %s", r.delay, status)
+	}
+	t.Logf("FINAL: %d/%d Servers leaked, %d/%d Close() panics; heapInuse %.0f -> %.0f MiB",
+		leaked, iters, crashed, iters, baseMB, heapMB())
+
+	// A correct tsnet would collect every Server after Close(); on buggy code
+	// some are permanently orphaned. The race is probabilistic (~5-10% per
+	// attempt here), so a single Close() rarely shows it, but it reliably
+	// reproduces across the sweep and accumulates without bound in a process
+	// that restarts repeatedly (the production symptom). If a run happens to
+	// observe 0, increase iters or re-center the delay range on your start()
+	// duration.
+	if leaked > 0 {
+		t.Errorf("LEAK: %d/%d tsnet.Servers were never collected after Close() — orphaned by Close() racing an in-flight Start()", leaked, iters)
+	}
+	if crashed > 0 {
+		t.Errorf("PANIC: %d/%d Close() calls nil-panicked racing an even-earlier Start()", crashed, iters)
+	}
+}

--- a/tsnet/leakrepro_test.go
+++ b/tsnet/leakrepro_test.go
@@ -12,6 +12,8 @@ import (
 	"tailscale.com/ipn/store/mem"
 )
 
+const ITERS = 20
+
 // TestLeak_CloseRacingStart reproduces a permanent leak: a tsnet.Server — and
 // everything it owns (netstack.Impl, wgengine, magicsock.Conn, the wireguard
 // device + its 64 KiB buffer pools, the netmap) — is never collected after
@@ -56,7 +58,7 @@ func TestLeak_CloseRacingStart(t *testing.T) {
 	// slowest) build is conservative: later, faster builds fall inside [0,build].
 	calibrate := func() time.Duration {
 		s := &Server{
-			Dir: t.TempDir(), Hostname: "leakrepro-cal",
+			Dir: t.TempDir(), Hostname: "lkleakrepro",
 			AuthKey: authKey, ControlURL: controlURL,
 			Ephemeral: true, Store: new(mem.Store),
 		}
@@ -67,13 +69,12 @@ func TestLeak_CloseRacingStart(t *testing.T) {
 		return d
 	}
 	build := calibrate()
-	if build < 50*time.Millisecond {
+	/*if build < 50*time.Millisecond {  // lk wtf claude
 		build = 50 * time.Millisecond
-	}
+	}*/
 	upTimeout := min(max(4*build, 2*time.Second), 8*time.Second)
-	const iters = 60
 	t.Logf("calibration: Start() build ~%s; sweeping close delay across [0, %s] over %d iters (upTimeout %s)",
-		build, time.Duration(float64(build)*1.1), iters, upTimeout)
+		build, time.Duration(float64(build)/2), ITERS, upTimeout)
 
 	heapMB := func() float64 {
 		runtime.GC()
@@ -122,11 +123,12 @@ func TestLeak_CloseRacingStart(t *testing.T) {
 	}
 
 	baseMB := heapMB()
-	for i := 0; i < iters; i++ {
-		// Sweep the close delay uniformly across the build window (slightly past
-		// it). Per-iteration variance in start() duration fills the gaps, so
+	for i := 0; i < ITERS; i++ {
+		// Sweep the close delay uniformly across half of the build window.
+		// The first half is empirically more likely to trigger the error
+		// Per-iteration variance in start() duration fills the gaps, so
 		// some iterations reliably land in the orphan window.
-		delay := time.Duration(float64(build) * 1.1 * float64(i) / float64(iters))
+		delay := time.Duration(float64(build) * float64(i) / float64(ITERS) / 2)
 		wp, crashed := run(i, delay)
 		wps = append(wps, wp)
 		results = append(results, result{delay: delay, crashed: crashed})
@@ -162,19 +164,19 @@ func TestLeak_CloseRacingStart(t *testing.T) {
 		t.Logf("  closeDelay=%5s -> %s", r.delay, status)
 	}
 	t.Logf("FINAL: %d/%d Servers leaked, %d/%d Close() panics; heapInuse %.0f -> %.0f MiB",
-		leaked, iters, crashed, iters, baseMB, heapMB())
+		leaked, ITERS, crashed, ITERS, baseMB, heapMB())
 
 	// A correct tsnet would collect every Server after Close(); on buggy code
-	// some are permanently orphaned. The race is probabilistic (~5-10% per
+	// some are permanently orphaned. The race is probabilistic (~45-55% per
 	// attempt here), so a single Close() rarely shows it, but it reliably
 	// reproduces across the sweep and accumulates without bound in a process
 	// that restarts repeatedly (the production symptom). If a run happens to
 	// observe 0, increase iters or re-center the delay range on your start()
 	// duration.
 	if leaked > 0 {
-		t.Errorf("LEAK: %d/%d tsnet.Servers were never collected after Close() — orphaned by Close() racing an in-flight Start()", leaked, iters)
+		t.Errorf("LEAK: %d/%d tsnet.Servers were never collected after Close() — orphaned by Close() racing an in-flight Start()", leaked, ITERS)
 	}
 	if crashed > 0 {
-		t.Errorf("PANIC: %d/%d Close() calls nil-panicked racing an even-earlier Start()", crashed, iters)
+		t.Errorf("PANIC: %d/%d Close() calls nil-panicked racing an even-earlier Start()", crashed, ITERS)
 	}
 }


### PR DESCRIPTION

@bradfitz - I took your [PR for wireguard-go](https://github.com/tailscale/wireguard-go/pull/66), applied it to a local branch, rebuilt github.com/tailscale/tailscale `main` but pulling in your fixed wireguard-go, and retested my failing test of Aperture (bork3d instance config that causes it that instance and its tsnet to crash-loop - as stated elsewhere, we should not be doing THAT, that is not under dispute).  Lo and behold, I still had a huge memory leak in the long-running Aperture supervisor process.  So I set claude to it again, and this is what it produced:

This PR adds tsnet/leakrepro_test.go (TestLeak_CloseRacingStart) and an analysis write-up (tsnet/leakrepro.md) for a permanent leak: a tsnet.Server, and the whole subsystem graph it owns (the netstack.Impl, the wgengine engine, the magicsock.Conn, the wireguard device and its 64 KiB packet-buffer pools, and the netmap), is never collected after close() when Close() raced an in-flight Start(). The orphaned objects accumulate for the life of the process, so a program that brings tsnet servers up and tears them down repeatedly grows without bound. No goroutine is leaked and `go test -race` is silent, so the only external symptom is steadily climbing RSS.
    
start() creates the netstack early -- netstack.Create does stacksForMetrics.Store(ns) -- but assigns the heavy subsystems to Server fields late (s.netstack = ns at tsnet.go:886, s.lb = lb at :937). close() (tsnet.go:614) tears a subsystem down only if its field is non-nil (if s.netstack != nil { s.netstack.Close() }, likewise s.lb and s.netMon) and it cancels s.shutdownCtx, which the in-flight start() is using. Nothing makes start() notice that a close() already ran, and the netstack is not registered in start()'s error-cleanup pool. So a Close() landing during start() snapshots those fields as nil and skips them, while start() finishes creating and storing the subsystems -- orphaning them forever: the Impl stays in the package-global netstack.stacksForMetrics map (Impl.Close, which would stacksForMetrics.Delete, never runs), magicsock's per-endpoint timers keep running (held by the runtime timer heap), and the wgengine stays registered as a netMon change callback.  (A Close() in very early start(), before s.sys is set, also nil-panics in close() at tsnet.go:667; the same coordination fix covers both.)
    
This branch is current main plus the proposed non-leaking wireguard-go (github.com/tailscale/wireguard-go@v0.0.0-20260603160903-21fba1928adc); the test still fails, so that wireguard-go fix is necessary but not sufficient -- this leak is entirely in tailscale.com/tsnet.
    
The vulnerable window is the wall-clock duration of start(). Against in-process test control start() finishes in tens of ms and the window is essentially never hit; against a real control server start() takes hundreds of ms to seconds (DERP + login), so a Close() fired during it lands in it. That is the production scenario -- a startup deadline or context cancellation firing Close() while a slow connect is in flight -- and it is why the test needs a real tailnet and is gated on a (reusable, ephemeral, for easiest cleanup) TS_AUTHKEY:
    
      TS_AUTHKEY=tskey-auth-... go test ./tsnet/ -run TestLeak_CloseRacingStart -v
    
Because the window's absolute position scales with machine speed, the test self-calibrates: it first times Start()'s synchronous build, then sweeps the Close() delay across half of that interval (launching Up() in a goroutine and closing a swept delay later), so it reproduces on a fast workstation and a slow CI box alike. "Half" is chosen because the majority of failures happen at the beginning of start().  It registers ephemeral nodes named lkleakrepro-N and uses a weak.Pointer[Server] to detect Servers never collected after Close() -- it keys only on Go GC of the in-process *Server, never on tailnet state, so name collisions or a flaky registration can't cause a false result. It asserts the correct invariant -- every Server is collected -- so it is red today and green once fixed. The race is probabilistic (40+ percent per attempt), so it reports e.g. "12/20 Servers leaked"; it reproduces every run and accumulates without bound under repeated restarts. If a run observes 0, raise iters for denser sampling. See tsnet/leakrepro.md for the full analysis and a suggested fiix (have Close() and start() coordinate via a "closing" state and/or register the netstack in start()'s closePool, instead of close() snapshotting nil fields).

Updates tailscale/corp#42776