### PR TITLE
all: rename NetworkLock functions/types to TailnetLock

### DIFF
--- a/client/local/tailnetlock.go
+++ b/client/local/tailnetlock.go
@@ -18,17 +18,22 @@ import (
 	"tailscale.com/types/tkatype"
 )
 
-// NetworkLockStatus fetches information about the tailnet key authority, if one is configured.
-func (lc *Client) NetworkLockStatus(ctx context.Context) (*ipnstate.NetworkLockStatus, error) {
+// TailnetLockStatus fetches information about the tailnet key authority, if one is configured.
+func (lc *Client) TailnetLockStatus(ctx context.Context) (*ipnstate.TailnetLockStatus, error) {
 	body, err := lc.send(ctx, "GET", "/localapi/v0/tka/status", 200, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error: %w", err)
 	}
-	return decodeJSON[*ipnstate.NetworkLockStatus](body)
+	return decodeJSON[*ipnstate.TailnetLockStatus](body)
 }
 
-// NetworkLockInit initializes the tailnet key authority.
-func (lc *Client) NetworkLockInit(ctx context.Context, keys []tka.Key, disablementValues [][]byte, supportDisablement []byte) (*ipnstate.NetworkLockStatus, error) {
+// Deprecated: use [Client.TailnetLockStatus] instead.
+func (lc *Client) NetworkLockStatus(ctx context.Context) (*ipnstate.TailnetLockStatus, error) {
+	return lc.TailnetLockStatus(ctx)
+}
+
+// TailnetLockInit initializes the tailnet key authority.
+func (lc *Client) TailnetLockInit(ctx context.Context, keys []tka.Key, disablementValues [][]byte, supportDisablement []byte) (*ipnstate.TailnetLockStatus, error) {
 	var b bytes.Buffer
 	type initRequest struct {
 		Keys               []tka.Key
@@ -44,12 +49,17 @@ func (lc *Client) NetworkLockInit(ctx context.Context, keys []tka.Key, disableme
 	if err != nil {
 		return nil, fmt.Errorf("error: %w", err)
 	}
-	return decodeJSON[*ipnstate.NetworkLockStatus](body)
+	return decodeJSON[*ipnstate.TailnetLockStatus](body)
 }
 
-// NetworkLockWrapPreauthKey wraps a pre-auth key with information to
+// Deprecated: use [Client.TailnetLockInit] instead.
+func (lc *Client) NetworkLockInit(ctx context.Context, keys []tka.Key, disablementValues [][]byte, supportDisablement []byte) (*ipnstate.TailnetLockStatus, error) {
+	return lc.TailnetLockInit(ctx, keys, disablementValues, supportDisablement)
+}
+
+// TailnetLockWrapPreauthKey wraps a pre-auth key with information to
 // enable unattended bringup in the locked tailnet.
-func (lc *Client) NetworkLockWrapPreauthKey(ctx context.Context, preauthKey string, tkaKey key.NLPrivate) (string, error) {
+func (lc *Client) TailnetLockWrapPreauthKey(ctx context.Context, preauthKey string, tkaKey key.NLPrivate) (string, error) {
 	encodedPrivate, err := tkaKey.MarshalText()
 	if err != nil {
 		return "", err
@@ -71,8 +81,13 @@ func (lc *Client) NetworkLockWrapPreauthKey(ctx context.Context, preauthKey stri
 	return string(body), nil
 }
 
-// NetworkLockModify adds and/or removes key(s) to the tailnet key authority.
-func (lc *Client) NetworkLockModify(ctx context.Context, addKeys, removeKeys []tka.Key) error {
+// Deprecated: use [Client.TailnetLockWrapPreauthKey] instead.
+func (lc *Client) NetworkLockWrapPreauthKey(ctx context.Context, preauthKey string, tkaKey key.NLPrivate) (string, error) {
+	return lc.TailnetLockWrapPreauthKey(ctx, preauthKey, tkaKey)
+}
+
+// TailnetLockModify adds and/or removes key(s) to the tailnet key authority.
+func (lc *Client) TailnetLockModify(ctx context.Context, addKeys, removeKeys []tka.Key) error {
 	var b bytes.Buffer
 	type modifyRequest struct {
 		AddKeys    []tka.Key
@@ -89,9 +104,14 @@ func (lc *Client) NetworkLockModify(ctx context.Context, addKeys, removeKeys []t
 	return nil
 }
 
-// NetworkLockSign signs the specified node-key and transmits that signature to the control plane.
+// Deprecated: use [Client.TailnetLockModify] instead.
+func (lc *Client) NetworkLockModify(ctx context.Context, addKeys, removeKeys []tka.Key) error {
+	return lc.TailnetLockModify(ctx, addKeys, removeKeys)
+}
+
+// TailnetLockSign signs the specified node-key and transmits that signature to the control plane.
 // rotationPublic, if specified, must be an ed25519 public key.
-func (lc *Client) NetworkLockSign(ctx context.Context, nodeKey key.NodePublic, rotationPublic []byte) error {
+func (lc *Client) TailnetLockSign(ctx context.Context, nodeKey key.NodePublic, rotationPublic []byte) error {
 	var b bytes.Buffer
 	type signRequest struct {
 		NodeKey        key.NodePublic
@@ -108,8 +128,13 @@ func (lc *Client) NetworkLockSign(ctx context.Context, nodeKey key.NodePublic, r
 	return nil
 }
 
-// NetworkLockAffectedSigs returns all signatures signed by the specified keyID.
-func (lc *Client) NetworkLockAffectedSigs(ctx context.Context, keyID tkatype.KeyID) ([]tkatype.MarshaledSignature, error) {
+// Deprecated: use [Client.TailnetLockSign] instead.
+func (lc *Client) NetworkLockSign(ctx context.Context, nodeKey key.NodePublic, rotationPublic []byte) error {
+	return lc.TailnetLockSign(ctx, nodeKey, rotationPublic)
+}
+
+// TailnetLockAffectedSigs returns all signatures signed by the specified keyID.
+func (lc *Client) TailnetLockAffectedSigs(ctx context.Context, keyID tkatype.KeyID) ([]tkatype.MarshaledSignature, error) {
 	body, err := lc.send(ctx, "POST", "/localapi/v0/tka/affected-sigs", 200, bytes.NewReader(keyID))
 	if err != nil {
 		return nil, fmt.Errorf("error: %w", err)
@@ -117,19 +142,29 @@ func (lc *Client) NetworkLockAffectedSigs(ctx context.Context, keyID tkatype.Key
 	return decodeJSON[[]tkatype.MarshaledSignature](body)
 }
 
-// NetworkLockLog returns up to maxEntries number of changes to tailnet-lock state.
-func (lc *Client) NetworkLockLog(ctx context.Context, maxEntries int) ([]ipnstate.NetworkLockUpdate, error) {
+// Deprecated: use [Client.TailnetLockAffectedSigs] instead.
+func (lc *Client) NetworkLockAffectedSigs(ctx context.Context, keyID tkatype.KeyID) ([]tkatype.MarshaledSignature, error) {
+	return lc.TailnetLockAffectedSigs(ctx, keyID)
+}
+
+// TailnetLockLog returns up to maxEntries number of changes to tailnet-lock state.
+func (lc *Client) TailnetLockLog(ctx context.Context, maxEntries int) ([]ipnstate.TailnetLockUpdate, error) {
 	v := url.Values{}
 	v.Set("limit", fmt.Sprint(maxEntries))
 	body, err := lc.send(ctx, "GET", "/localapi/v0/tka/log?"+v.Encode(), 200, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error %w: %s", err, body)
 	}
-	return decodeJSON[[]ipnstate.NetworkLockUpdate](body)
+	return decodeJSON[[]ipnstate.TailnetLockUpdate](body)
 }
 
-// NetworkLockForceLocalDisable forcibly shuts down tailnet lock on this node.
-func (lc *Client) NetworkLockForceLocalDisable(ctx context.Context) error {
+// Deprecated: use [Client.TailnetLockLog] instead.
+func (lc *Client) NetworkLockLog(ctx context.Context, maxEntries int) ([]ipnstate.TailnetLockUpdate, error) {
+	return lc.TailnetLockLog(ctx, maxEntries)
+}
+
+// TailnetLockForceLocalDisable forcibly shuts down tailnet lock on this node.
+func (lc *Client) TailnetLockForceLocalDisable(ctx context.Context) error {
 	// This endpoint expects an empty JSON stanza as the payload.
 	var b bytes.Buffer
 	if err := json.NewEncoder(&b).Encode(struct{}{}); err != nil {
@@ -142,9 +177,14 @@ func (lc *Client) NetworkLockForceLocalDisable(ctx context.Context) error {
 	return nil
 }
 
-// NetworkLockVerifySigningDeeplink verifies the tailnet lock deeplink contained
+// Deprecated: use [Client.TailnetLockForceLocalDisable] instead.
+func (lc *Client) NetworkLockForceLocalDisable(ctx context.Context) error {
+	return lc.TailnetLockForceLocalDisable(ctx)
+}
+
+// TailnetLockVerifySigningDeeplink verifies the tailnet lock deeplink contained
 // in url and returns information extracted from it.
-func (lc *Client) NetworkLockVerifySigningDeeplink(ctx context.Context, url string) (*tka.DeeplinkValidationResult, error) {
+func (lc *Client) TailnetLockVerifySigningDeeplink(ctx context.Context, url string) (*tka.DeeplinkValidationResult, error) {
 	vr := struct {
 		URL string
 	}{url}
@@ -157,8 +197,13 @@ func (lc *Client) NetworkLockVerifySigningDeeplink(ctx context.Context, url stri
 	return decodeJSON[*tka.DeeplinkValidationResult](body)
 }
 
-// NetworkLockGenRecoveryAUM generates an AUM for recovering from a tailnet-lock key compromise.
-func (lc *Client) NetworkLockGenRecoveryAUM(ctx context.Context, removeKeys []tkatype.KeyID, forkFrom tka.AUMHash) ([]byte, error) {
+// Deprecated: use [Client.TailnetLockVerifySigningDeeplink] instead.
+func (lc *Client) NetworkLockVerifySigningDeeplink(ctx context.Context, url string) (*tka.DeeplinkValidationResult, error) {
+	return lc.TailnetLockVerifySigningDeeplink(ctx, url)
+}
+
+// TailnetLockGenRecoveryAUM generates an AUM for recovering from a tailnet-lock key compromise.
+func (lc *Client) TailnetLockGenRecoveryAUM(ctx context.Context, removeKeys []tkatype.KeyID, forkFrom tka.AUMHash) ([]byte, error) {
 	vr := struct {
 		Keys     []tkatype.KeyID
 		ForkFrom string
@@ -172,8 +217,13 @@ func (lc *Client) NetworkLockGenRecoveryAUM(ctx context.Context, removeKeys []tk
 	return body, nil
 }
 
-// NetworkLockCosignRecoveryAUM co-signs a recovery AUM using the node's tailnet lock key.
-func (lc *Client) NetworkLockCosignRecoveryAUM(ctx context.Context, aum tka.AUM) ([]byte, error) {
+// Deprecated: use [Client.TailnetLockGenRecoveryAUM] instead.
+func (lc *Client) NetworkLockGenRecoveryAUM(ctx context.Context, removeKeys []tkatype.KeyID, forkFrom tka.AUMHash) ([]byte, error) {
+	return lc.TailnetLockGenRecoveryAUM(ctx, removeKeys, forkFrom)
+}
+
+// TailnetLockCosignRecoveryAUM co-signs a recovery AUM using the node's tailnet lock key.
+func (lc *Client) TailnetLockCosignRecoveryAUM(ctx context.Context, aum tka.AUM) ([]byte, error) {
 	r := bytes.NewReader(aum.Serialize())
 	body, err := lc.send(ctx, "POST", "/localapi/v0/tka/cosign-recovery-aum", 200, r)
 	if err != nil {
@@ -183,8 +233,13 @@ func (lc *Client) NetworkLockCosignRecoveryAUM(ctx context.Context, aum tka.AUM)
 	return body, nil
 }
 
-// NetworkLockSubmitRecoveryAUM submits a recovery AUM to the control plane.
-func (lc *Client) NetworkLockSubmitRecoveryAUM(ctx context.Context, aum tka.AUM) error {
+// Deprecated: use [Client.TailnetLockCosignRecoveryAUM] instead.
+func (lc *Client) NetworkLockCosignRecoveryAUM(ctx context.Context, aum tka.AUM) ([]byte, error) {
+	return lc.TailnetLockCosignRecoveryAUM(ctx, aum)
+}
+
+// TailnetLockSubmitRecoveryAUM submits a recovery AUM to the control plane.
+func (lc *Client) TailnetLockSubmitRecoveryAUM(ctx context.Context, aum tka.AUM) error {
 	r := bytes.NewReader(aum.Serialize())
 	_, err := lc.send(ctx, "POST", "/localapi/v0/tka/submit-recovery-aum", 200, r)
 	if err != nil {
@@ -193,10 +248,20 @@ func (lc *Client) NetworkLockSubmitRecoveryAUM(ctx context.Context, aum tka.AUM)
 	return nil
 }
 
-// NetworkLockDisable shuts down tailnet-lock across the tailnet.
-func (lc *Client) NetworkLockDisable(ctx context.Context, secret []byte) error {
+// Deprecated: use [Client.TailnetLockSubmitRecoveryAUM] instead.
+func (lc *Client) NetworkLockSubmitRecoveryAUM(ctx context.Context, aum tka.AUM) error {
+	return lc.TailnetLockSubmitRecoveryAUM(ctx, aum)
+}
+
+// TailnetLockDisable shuts down tailnet-lock across the tailnet.
+func (lc *Client) TailnetLockDisable(ctx context.Context, secret []byte) error {
 	if _, err := lc.send(ctx, "POST", "/localapi/v0/tka/disable", 200, bytes.NewReader(secret)); err != nil {
 		return fmt.Errorf("error: %w", err)
 	}
 	return nil
+}
+
+// Deprecated: use [Client.TailnetLockDisable] instead.
+func (lc *Client) NetworkLockDisable(ctx context.Context, secret []byte) error {
+	return lc.TailnetLockDisable(ctx, secret)
 }

--- a/cmd/tailscale/cli/jsonoutput/tailnet-lock-log.go
+++ b/cmd/tailscale/cli/jsonoutput/tailnet-lock-log.go
@@ -16,7 +16,7 @@ import (
 	"tailscale.com/tka"
 )
 
-// PrintNetworkLockLogJSONV1 prints the stored TKA state as a JSON object to the CLI,
+// PrintTailnetLockLogJSONV1 prints the stored TKA state as a JSON object to the CLI,
 // in a stable "v1" format.
 //
 // This format includes:
@@ -24,7 +24,7 @@ import (
 //   - the AUM hash as a base32-encoded string
 //   - the raw AUM as base64-encoded bytes
 //   - the expanded AUM, which prints named fields for consumption by other tools
-func PrintNetworkLockLogJSONV1(out io.Writer, updates []ipnstate.NetworkLockUpdate) error {
+func PrintTailnetLockLogJSONV1(out io.Writer, updates []ipnstate.TailnetLockUpdate) error {
 	messages := make([]logMessageV1, len(updates))
 
 	for i, update := range updates {
@@ -57,9 +57,9 @@ func PrintNetworkLockLogJSONV1(out io.Writer, updates []ipnstate.NetworkLockUpda
 	return enc.Encode(result)
 }
 
-// toLogMessageV1 converts a [tka.AUM] and [ipnstate.NetworkLockUpdate] to the
+// toLogMessageV1 converts a [tka.AUM] and [ipnstate.TailnetLockUpdate] to the
 // JSON output returned by the CLI.
-func toLogMessageV1(aum tka.AUM, update ipnstate.NetworkLockUpdate) logMessageV1 {
+func toLogMessageV1(aum tka.AUM, update ipnstate.TailnetLockUpdate) logMessageV1 {
 	expandedAUM := expandedAUMV1{}
 	expandedAUM.MessageKind = aum.MessageKind.String()
 	if len(aum.PrevAUMHash) > 0 {

--- a/cmd/tailscale/cli/jsonoutput/tailnet-lock-status.go
+++ b/cmd/tailscale/cli/jsonoutput/tailnet-lock-status.go
@@ -15,9 +15,9 @@ import (
 	"tailscale.com/tka"
 )
 
-// PrintNetworkLockStatusJSONV1 prints the current Tailnet Lock status
+// PrintTailnetLockStatusJSONV1 prints the current Tailnet Lock status
 // as a JSON object to the CLI, in a stable "v1" format.
-func PrintNetworkLockStatusJSONV1(out io.Writer, status *ipnstate.NetworkLockStatus) error {
+func PrintTailnetLockStatusJSONV1(out io.Writer, status *ipnstate.TailnetLockStatus) error {
 	responseEnvelope := ResponseEnvelope{
 		SchemaVersion: "1",
 	}
@@ -46,7 +46,7 @@ func PrintNetworkLockStatusJSONV1(out io.Writer, status *ipnstate.NetworkLockSta
 	return enc.Encode(result)
 }
 
-func toTailnetLockDisabledStatusV1(status *ipnstate.NetworkLockStatus) tailnetLockDisabledStatusV1 {
+func toTailnetLockDisabledStatusV1(status *ipnstate.TailnetLockStatus) tailnetLockDisabledStatusV1 {
 	out := tailnetLockDisabledStatusV1{
 		tailnetLockStatusV1Base: tailnetLockStatusV1Base{
 			Enabled: status.Enabled,
@@ -61,7 +61,7 @@ func toTailnetLockDisabledStatusV1(status *ipnstate.NetworkLockStatus) tailnetLo
 	return out
 }
 
-func toTailnetLockEnabledStatusV1(status *ipnstate.NetworkLockStatus) tailnetLockEnabledStatusV1 {
+func toTailnetLockEnabledStatusV1(status *ipnstate.TailnetLockStatus) tailnetLockEnabledStatusV1 {
 	out := tailnetLockEnabledStatusV1{
 		tailnetLockStatusV1Base: tailnetLockStatusV1Base{
 			Enabled: status.Enabled,

--- a/cmd/tailscale/cli/tailnet-lock.go
+++ b/cmd/tailscale/cli/tailnet-lock.go
@@ -109,7 +109,7 @@ tailnet lock. We recommend setting this flag.
 }
 
 func runTailnetLockInit(ctx context.Context, args []string) error {
-	st, err := localClient.NetworkLockStatus(ctx)
+	st, err := localClient.TailnetLockStatus(ctx)
 	if err != nil {
 		return fixTailscaledConnectError(err)
 	}
@@ -183,9 +183,9 @@ func runTailnetLockInit(ctx context.Context, args []string) error {
 		fmt.Fprintln(&successMsg, "A disablement secret for Tailscale support has been generated and transmitted to Tailscale.")
 	}
 
-	// The state returned by NetworkLockInit likely doesn't contain the initialized state,
+	// The state returned by TailnetLockInit likely doesn't contain the initialized state,
 	// because that has to tick through from netmaps.
-	if _, err := localClient.NetworkLockInit(ctx, keys, disablementValues, supportDisablement); err != nil {
+	if _, err := localClient.TailnetLockInit(ctx, keys, disablementValues, supportDisablement); err != nil {
 		return err
 	}
 
@@ -215,14 +215,14 @@ func runTailnetLockStatus(ctx context.Context, args []string) error {
 		return fmt.Errorf("tailscale lock status: unexpected argument")
 	}
 
-	st, err := localClient.NetworkLockStatus(ctx)
+	st, err := localClient.TailnetLockStatus(ctx)
 	if err != nil {
 		return fixTailscaledConnectError(err)
 	}
 
 	if nlStatusArgs.json.IsSet {
 		if nlStatusArgs.json.Version == 1 {
-			return jsonoutput.PrintNetworkLockStatusJSONV1(os.Stdout, st)
+			return jsonoutput.PrintTailnetLockStatusJSONV1(os.Stdout, st)
 		} else {
 			return fmt.Errorf("unrecognised version: %d", nlStatusArgs.json.Version)
 		}
@@ -332,7 +332,7 @@ func runTailnetLockRemove(ctx context.Context, args []string) error {
 	if len(removeKeys) == 0 {
 		return fmt.Errorf("missing argument, expected one or more tailnet lock keys")
 	}
-	st, err := localClient.NetworkLockStatus(ctx)
+	st, err := localClient.TailnetLockStatus(ctx)
 	if err != nil {
 		return fixTailscaledConnectError(err)
 	}
@@ -359,7 +359,7 @@ func runTailnetLockRemove(ctx context.Context, args []string) error {
 		// Resign affected signatures for each of the keys we are removing.
 		for _, k := range removeKeys {
 			kID, _ := k.ID() // err already checked above
-			sigs, err := localClient.NetworkLockAffectedSigs(ctx, kID)
+			sigs, err := localClient.TailnetLockAffectedSigs(ctx, kID)
 			if err != nil {
 				return fmt.Errorf("affected sigs for key %X: %w", kID, err)
 			}
@@ -374,10 +374,10 @@ func runTailnetLockRemove(ctx context.Context, args []string) error {
 					return fmt.Errorf("failed decoding pubkey for signature: %w", err)
 				}
 
-				// Safety: NetworkLockAffectedSigs() verifies all signatures before
+				// Safety: TailnetLockAffectedSigs() verifies all signatures before
 				// successfully returning.
 				rotationKey, _ := sig.UnverifiedWrappingPublic()
-				if err := localClient.NetworkLockSign(ctx, nodeKey, []byte(rotationKey)); err != nil {
+				if err := localClient.TailnetLockSign(ctx, nodeKey, []byte(rotationKey)); err != nil {
 					return fmt.Errorf("failed to sign %v: %w", nodeKey, err)
 				}
 			}
@@ -396,7 +396,7 @@ of the Tailscale network. Proceed with caution.
 		}
 	}
 
-	return localClient.NetworkLockModify(ctx, nil, removeKeys)
+	return localClient.TailnetLockModify(ctx, nil, removeKeys)
 }
 
 // parseTLArgs parses a slice of strings into slices of tka.Key & disablement
@@ -455,7 +455,7 @@ func runTailnetLockAdd(ctx context.Context, addArgs []string) error {
 		return fmt.Errorf("missing argument, expected one or more tailnet lock keys")
 	}
 
-	st, err := localClient.NetworkLockStatus(ctx)
+	st, err := localClient.TailnetLockStatus(ctx)
 	if err != nil {
 		return fixTailscaledConnectError(err)
 	}
@@ -463,7 +463,7 @@ func runTailnetLockAdd(ctx context.Context, addArgs []string) error {
 		return errors.New("tailnet lock is not enabled")
 	}
 
-	if err := localClient.NetworkLockModify(ctx, addKeys, nil); err != nil {
+	if err := localClient.TailnetLockModify(ctx, addKeys, nil); err != nil {
 		return err
 	}
 	return nil
@@ -519,7 +519,7 @@ func runTailnetLockSign(ctx context.Context, args []string) error {
 		}
 	}
 
-	err := localClient.NetworkLockSign(ctx, nodeKey, []byte(rotationKey.Verifier()))
+	err := localClient.TailnetLockSign(ctx, nodeKey, []byte(rotationKey.Verifier()))
 	// Provide a better help message for when someone clicks through the signing flow
 	// on the wrong device.
 	if err != nil && strings.Contains(err.Error(), tsconst.TailnetLockNotTrustedMsg) {
@@ -557,7 +557,7 @@ func runTailnetLockDisable(ctx context.Context, args []string) error {
 	if len(secrets) != 1 {
 		return errors.New("usage: tailscale lock disable <disablement-secret>")
 	}
-	return localClient.NetworkLockDisable(ctx, secrets[0])
+	return localClient.TailnetLockDisable(ctx, secrets[0])
 }
 
 var tlLocalDisableCmd = &ffcli.Command{
@@ -579,7 +579,7 @@ that are locked out.
 }
 
 func runTailnetLockLocalDisable(ctx context.Context, args []string) error {
-	return localClient.NetworkLockForceLocalDisable(ctx)
+	return localClient.TailnetLockForceLocalDisable(ctx)
 }
 
 var tlDisablementKDFCmd = &ffcli.Command{
@@ -621,7 +621,7 @@ var tlLogCmd = &ffcli.Command{
 	})(),
 }
 
-func nlDescribeUpdate(update ipnstate.NetworkLockUpdate, color bool) (string, error) {
+func nlDescribeUpdate(update ipnstate.TailnetLockUpdate, color bool) (string, error) {
 	terminalYellow := ""
 	terminalClear := ""
 	if color {
@@ -694,7 +694,7 @@ func nlDescribeUpdate(update ipnstate.NetworkLockUpdate, color bool) (string, er
 }
 
 func runTailnetLockLog(ctx context.Context, args []string) error {
-	st, err := localClient.NetworkLockStatus(ctx)
+	st, err := localClient.TailnetLockStatus(ctx)
 	if err != nil {
 		return fixTailscaledConnectError(err)
 	}
@@ -702,7 +702,7 @@ func runTailnetLockLog(ctx context.Context, args []string) error {
 		return errors.New("Tailnet Lock is not enabled")
 	}
 
-	updates, err := localClient.NetworkLockLog(ctx, nlLogArgs.limit)
+	updates, err := localClient.TailnetLockLog(ctx, nlLogArgs.limit)
 	if err != nil {
 		return fixTailscaledConnectError(err)
 	}
@@ -715,7 +715,7 @@ func runTailnetLockLog(ctx context.Context, args []string) error {
 func printTailnetLockLog(updates []ipnstate.NetworkLockUpdate, out io.Writer, jsonSchema jsonoutput.SchemaVersion, useColor bool) error {
 	if jsonSchema.IsSet {
 		if jsonSchema.Version == 1 {
-			return jsonoutput.PrintNetworkLockLogJSONV1(out, updates)
+			return jsonoutput.PrintTailnetLockLogJSONV1(out, updates)
 		} else {
 			return fmt.Errorf("unrecognised version: %d", jsonSchema.Version)
 		}
@@ -772,11 +772,11 @@ func wrapAuthKey(ctx context.Context, keyStr string, status *ipnstate.Status) er
 		Meta:   m,
 	}
 
-	wrapped, err := localClient.NetworkLockWrapPreauthKey(ctx, keyStr, priv)
+	wrapped, err := localClient.TailnetLockWrapPreauthKey(ctx, keyStr, priv)
 	if err != nil {
 		return fmt.Errorf("wrapping failed: %w", err)
 	}
-	if err := localClient.NetworkLockModify(ctx, []tka.Key{k}, nil); err != nil {
+	if err := localClient.TailnetLockModify(ctx, []tka.Key{k}, nil); err != nil {
 		return fmt.Errorf("add key failed: %w", err)
 	}
 
@@ -852,7 +852,7 @@ func runTailnetLockRevokeKeys(ctx context.Context, args []string) error {
 			}
 		}
 
-		aumBytes, err := localClient.NetworkLockGenRecoveryAUM(ctx, keyIDs, forkFrom)
+		aumBytes, err := localClient.TailnetLockGenRecoveryAUM(ctx, keyIDs, forkFrom)
 		if err != nil {
 			return fmt.Errorf("generation of recovery AUM failed: %w", err)
 		}
@@ -874,7 +874,7 @@ func runTailnetLockRevokeKeys(ctx context.Context, args []string) error {
 	}
 
 	if tlRevokeKeysArgs.cosign {
-		aumBytes, err := localClient.NetworkLockCosignRecoveryAUM(ctx, recoveryAUM)
+		aumBytes, err := localClient.TailnetLockCosignRecoveryAUM(ctx, recoveryAUM)
 		if err != nil {
 			return fmt.Errorf("co-signing recovery AUM failed: %w", err)
 		}
@@ -890,7 +890,7 @@ Alternatively if you are done with co-signing, complete recovery by running the 
 	}
 
 	if tlRevokeKeysArgs.finish {
-		if err := localClient.NetworkLockSubmitRecoveryAUM(ctx, recoveryAUM); err != nil {
+		if err := localClient.TailnetLockSubmitRecoveryAUM(ctx, recoveryAUM); err != nil {
 			return fmt.Errorf("submitting recovery AUM failed: %w", err)
 		}
 		fmt.Println("Recovery completed.")

--- a/cmd/tailscale/cli/tailnet-lock_test.go
+++ b/cmd/tailscale/cli/tailnet-lock_test.go
@@ -63,7 +63,7 @@ func TestTailnetLockLogOutput(t *testing.T) {
 		Votes: &votes,
 	}
 
-	updates := []ipnstate.NetworkLockUpdate{
+	updates := []ipnstate.TailnetLockUpdate{
 		{
 			Hash:   aum3.Hash(),
 			Change: aum3.MessageKind.String(),
@@ -226,12 +226,12 @@ func TestTailnetLockStatusOutput(t *testing.T) {
 	t.Run("json-1", func(t *testing.T) {
 		for _, tt := range []struct {
 			Name   string
-			Status ipnstate.NetworkLockStatus
+			Status ipnstate.TailnetLockStatus
 			Want   string
 		}{
 			{
 				Name:   "tailnet-lock-disabled",
-				Status: ipnstate.NetworkLockStatus{Enabled: false},
+				Status: ipnstate.TailnetLockStatus{Enabled: false},
 				Want: `{
   "SchemaVersion": "1",
   "Enabled": false
@@ -240,7 +240,7 @@ func TestTailnetLockStatusOutput(t *testing.T) {
 			},
 			{
 				Name: "tailnet-lock-disabled-with-keys",
-				Status: ipnstate.NetworkLockStatus{
+				Status: ipnstate.TailnetLockStatus{
 					Enabled:   false,
 					NodeKey:   &nodeKey1,
 					PublicKey: trustedNlPub,
@@ -255,7 +255,7 @@ func TestTailnetLockStatusOutput(t *testing.T) {
 			},
 			{
 				Name: "tailnet-lock-enabled",
-				Status: ipnstate.NetworkLockStatus{
+				Status: ipnstate.TailnetLockStatus{
 					Enabled:          true,
 					Head:             &head,
 					PublicKey:        nlPub,
@@ -355,9 +355,9 @@ func TestTailnetLockStatusOutput(t *testing.T) {
 				t.Parallel()
 
 				var outBuf bytes.Buffer
-				err := jsonoutput.PrintNetworkLockStatusJSONV1(&outBuf, &tt.Status)
+				err := jsonoutput.PrintTailnetLockStatusJSONV1(&outBuf, &tt.Status)
 				if err != nil {
-					t.Fatalf("PrintNetworkLockStatusJSONV1: %v", err)
+					t.Fatalf("PrintTailnetLockStatusJSONV1: %v", err)
 				}
 
 				if diff := cmp.Diff(outBuf.String(), tt.Want); diff != "" {

--- a/cmd/tl-longchain/tl-longchain.go
+++ b/cmd/tl-longchain/tl-longchain.go
@@ -45,7 +45,7 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	st, err := lc.NetworkLockStatus(ctx)
+	st, err := lc.TailnetLockStatus(ctx)
 	if err != nil {
 		log.Fatalf("could not get Tailnet Lock status: %v", err)
 	}

--- a/feature/tailnetlock/tailnetlock.go
+++ b/feature/tailnetlock/tailnetlock.go
@@ -41,8 +41,8 @@ func handleC2NDebugTKALog(b *ipnlocal.LocalBackend, w http.ResponseWriter, r *ht
 		}
 	}
 
-	updates, err := b.NetworkLockLog(limit)
-	if ipnlocal.IsNetworkLockNotActive(err) {
+	updates, err := b.TailnetLockLog(limit)
+	if ipnlocal.IsTailnetLockNotActive(err) {
 		http.Error(w, "tailnet lock not active", http.StatusBadRequest)
 		return
 	} else if err != nil {
@@ -50,5 +50,5 @@ func handleC2NDebugTKALog(b *ipnlocal.LocalBackend, w http.ResponseWriter, r *ht
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	jsonoutput.PrintNetworkLockLogJSONV1(w, updates)
+	jsonoutput.PrintTailnetLockLogJSONV1(w, updates)
 }

--- a/feature/tailnetlock/tailnetlock_test.go
+++ b/feature/tailnetlock/tailnetlock_test.go
@@ -57,7 +57,7 @@ func TestHandleC2NDebugTKA(t *testing.T) {
 		return sb.String()
 	}
 
-	// matches [jsonoutput.PrintNetworkLockLogJSONV1]
+	// matches [jsonoutput.PrintTailnetLockLogJSONV1]
 	type response struct {
 		SchemaVersion string
 		Messages      []any

--- a/ipn/ipnlocal/tailnet-lock.go
+++ b/ipn/ipnlocal/tailnet-lock.go
@@ -49,11 +49,16 @@ var (
 	errTailnetLockNotActive = errors.New("tailnet-lock is not active")
 )
 
-// IsNetworkLockNotActive reports whether the given error indicates that
+// IsTailnetLockNotActive reports whether the given error indicates that
 // tailnet-lock is not active. Stop-gap for feature/tailnetlock to check this
 // until all of this is code is moved to the feature.
-func IsNetworkLockNotActive(err error) bool {
+func IsTailnetLockNotActive(err error) bool {
 	return errors.Is(err, errTailnetLockNotActive)
+}
+
+// Deprecated: use [IsTailnetLockNotActive] instead.
+func IsNetworkLockNotActive(err error) bool {
+	return IsTailnetLockNotActive(err)
 }
 
 type tkaState struct {
@@ -519,9 +524,9 @@ func (b *LocalBackend) tkaBootstrapFromGenesisLocked(g tkatype.MarshaledAUM, per
 	return nil
 }
 
-// NetworkLockStatus returns a structure describing the state of the
+// TailnetLockStatus returns a structure describing the state of the
 // tailnet key authority, if any.
-func (b *LocalBackend) NetworkLockStatus() *ipnstate.NetworkLockStatus {
+func (b *LocalBackend) TailnetLockStatus() *ipnstate.TailnetLockStatus {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -536,13 +541,13 @@ func (b *LocalBackend) NetworkLockStatus() *ipnstate.NetworkLockStatus {
 	}
 
 	if nlPriv.IsZero() {
-		return &ipnstate.NetworkLockStatus{
+		return &ipnstate.TailnetLockStatus{
 			Enabled: false,
 			NodeKey: nodeKey,
 		}
 	}
 	if b.tka == nil {
-		return &ipnstate.NetworkLockStatus{
+		return &ipnstate.TailnetLockStatus{
 			Enabled:   false,
 			NodeKey:   nodeKey,
 			PublicKey: nlPriv.Public(),
@@ -590,7 +595,7 @@ func (b *LocalBackend) NetworkLockStatus() *ipnstate.NetworkLockStatus {
 
 	stateID1, _ := b.tka.authority.StateIDs()
 
-	return &ipnstate.NetworkLockStatus{
+	return &ipnstate.TailnetLockStatus{
 		Enabled:          true,
 		Head:             &head,
 		PublicKey:        nlPriv.Public(),
@@ -602,6 +607,11 @@ func (b *LocalBackend) NetworkLockStatus() *ipnstate.NetworkLockStatus {
 		VisiblePeers:     visible,
 		StateID:          stateID1,
 	}
+}
+
+// Deprecated: use [LocalBackend.TailnetLockStatus] instead.
+func (b *LocalBackend) NetworkLockStatus() *ipnstate.TailnetLockStatus {
+	return b.TailnetLockStatus()
 }
 
 func tkaStateFromPeer(p tailcfg.NodeView) ipnstate.TKAPeer {
@@ -624,7 +634,7 @@ func tkaStateFromPeer(p tailcfg.NodeView) ipnstate.TKAPeer {
 	return fp
 }
 
-// NetworkLockInit enables tailnet-lock for the tailnet, with the tailnets'
+// TailnetLockInit enables tailnet-lock for the tailnet, with the tailnets'
 // key authority initialized to trust the provided keys.
 //
 // Initialization involves two RPCs with control, termed 'begin' and 'finish'.
@@ -633,7 +643,7 @@ func tkaStateFromPeer(p tailcfg.NodeView) ipnstate.TKAPeer {
 // needing signatures is returned as a response.
 // The Finish RPC submits signatures for all these nodes, at which point
 // Control has everything it needs to atomically enable tailnet lock.
-func (b *LocalBackend) NetworkLockInit(keys []tka.Key, disablementValues [][]byte, supportDisablement []byte) error {
+func (b *LocalBackend) TailnetLockInit(keys []tka.Key, disablementValues [][]byte, supportDisablement []byte) error {
 	var ourNodeKey key.NodePublic
 	var nlPriv key.NLPrivate
 
@@ -698,15 +708,25 @@ func (b *LocalBackend) NetworkLockInit(keys []tka.Key, disablementValues [][]byt
 	return err
 }
 
-// NetworkLockAllowed reports whether the node is allowed to use Tailnet Lock.
-func (b *LocalBackend) NetworkLockAllowed() bool {
+// Deprecated: use [LocalBackend.TailnetLockInit] instead.
+func (b *LocalBackend) NetworkLockInit(keys []tka.Key, disablementValues [][]byte, supportDisablement []byte) error {
+	return b.TailnetLockInit(keys, disablementValues, supportDisablement)
+}
+
+// TailnetLockAllowed reports whether the node is allowed to use Tailnet Lock.
+func (b *LocalBackend) TailnetLockAllowed() bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.capTailnetLock
 }
 
+// Deprecated: use [LocalBackend.TailnetLockAllowed] instead.
+func (b *LocalBackend) NetworkLockAllowed() bool {
+	return b.TailnetLockAllowed()
+}
+
 // Only use is in tests.
-func (b *LocalBackend) NetworkLockVerifySignatureForTest(nks tkatype.MarshaledSignature, nodeKey key.NodePublic) error {
+func (b *LocalBackend) TailnetLockVerifySignatureForTest(nks tkatype.MarshaledSignature, nodeKey key.NodePublic) error {
 	testenv.AssertInTest()
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -716,8 +736,13 @@ func (b *LocalBackend) NetworkLockVerifySignatureForTest(nks tkatype.MarshaledSi
 	return b.tka.authority.NodeKeyAuthorized(nodeKey, nks)
 }
 
+// Deprecated: use [LocalBackend.TailnetLockVerifySignatureForTest] instead.
+func (b *LocalBackend) NetworkLockVerifySignatureForTest(nks tkatype.MarshaledSignature, nodeKey key.NodePublic) error {
+	return b.TailnetLockVerifySignatureForTest(nks, nodeKey)
+}
+
 // Only use is in tests.
-func (b *LocalBackend) NetworkLockKeyTrustedForTest(keyID tkatype.KeyID) bool {
+func (b *LocalBackend) TailnetLockKeyTrustedForTest(keyID tkatype.KeyID) bool {
 	testenv.AssertInTest()
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -727,9 +752,14 @@ func (b *LocalBackend) NetworkLockKeyTrustedForTest(keyID tkatype.KeyID) bool {
 	return b.tka.authority.KeyTrusted(keyID)
 }
 
-// NetworkLockForceLocalDisable shuts down TKA locally, and denylists the current
+// Deprecated: use [LocalBackend.TailnetLockKeyTrustedForTest] instead.
+func (b *LocalBackend) NetworkLockKeyTrustedForTest(keyID tkatype.KeyID) bool {
+	return b.TailnetLockKeyTrustedForTest(keyID)
+}
+
+// TailnetLockForceLocalDisable shuts down TKA locally, and denylists the current
 // TKA from being initialized locally in future.
-func (b *LocalBackend) NetworkLockForceLocalDisable() error {
+func (b *LocalBackend) TailnetLockForceLocalDisable() error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.tka == nil {
@@ -753,9 +783,14 @@ func (b *LocalBackend) NetworkLockForceLocalDisable() error {
 	return nil
 }
 
-// NetworkLockSign signs the given node-key and submits it to the control plane.
+// Deprecated: use [LocalBackend.TailnetLockForceLocalDisable] instead.
+func (b *LocalBackend) NetworkLockForceLocalDisable() error {
+	return b.TailnetLockForceLocalDisable()
+}
+
+// TailnetLockSign signs the given node-key and submits it to the control plane.
 // rotationPublic, if specified, must be an ed25519 public key.
-func (b *LocalBackend) NetworkLockSign(nodeKey key.NodePublic, rotationPublic []byte) error {
+func (b *LocalBackend) TailnetLockSign(nodeKey key.NodePublic, rotationPublic []byte) error {
 	ourNodeKey, sig, err := func(nodeKey key.NodePublic, rotationPublic []byte) (key.NodePublic, tka.NodeKeySignature, error) {
 		b.mu.Lock()
 		defer b.mu.Unlock()
@@ -803,8 +838,13 @@ func (b *LocalBackend) NetworkLockSign(nodeKey key.NodePublic, rotationPublic []
 	return nil
 }
 
-// NetworkLockModify adds and/or removes keys in the tailnet's key authority.
-func (b *LocalBackend) NetworkLockModify(addKeys, removeKeys []tka.Key) (err error) {
+// Deprecated: use [LocalBackend.TailnetLockSign] instead.
+func (b *LocalBackend) NetworkLockSign(nodeKey key.NodePublic, rotationPublic []byte) error {
+	return b.TailnetLockSign(nodeKey, rotationPublic)
+}
+
+// TailnetLockModify adds and/or removes keys in the tailnet's key authority.
+func (b *LocalBackend) TailnetLockModify(addKeys, removeKeys []tka.Key) (err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("modify tailnet-lock keys: %w", err)
@@ -883,8 +923,13 @@ func (b *LocalBackend) NetworkLockModify(addKeys, removeKeys []tka.Key) (err err
 	return nil
 }
 
-// NetworkLockDisable disables tailnet-lock using the provided disablement secret.
-func (b *LocalBackend) NetworkLockDisable(secret []byte) error {
+// Deprecated: use [LocalBackend.TailnetLockModify] instead.
+func (b *LocalBackend) NetworkLockModify(addKeys, removeKeys []tka.Key) (err error) {
+	return b.TailnetLockModify(addKeys, removeKeys)
+}
+
+// TailnetLockDisable disables tailnet-lock using the provided disablement secret.
+func (b *LocalBackend) TailnetLockDisable(secret []byte) error {
 	var (
 		ourNodeKey key.NodePublic
 		head       tka.AUMHash
@@ -915,8 +960,13 @@ func (b *LocalBackend) NetworkLockDisable(secret []byte) error {
 	return err
 }
 
-// NetworkLockLog returns the changelog of TKA state up to maxEntries in size.
-func (b *LocalBackend) NetworkLockLog(maxEntries int) ([]ipnstate.NetworkLockUpdate, error) {
+// Deprecated: use [LocalBackend.TailnetLockDisable] instead.
+func (b *LocalBackend) NetworkLockDisable(secret []byte) error {
+	return b.TailnetLockDisable(secret)
+}
+
+// TailnetLockLog returns the changelog of TKA state up to maxEntries in size.
+func (b *LocalBackend) TailnetLockLog(maxEntries int) ([]ipnstate.TailnetLockUpdate, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -924,7 +974,7 @@ func (b *LocalBackend) NetworkLockLog(maxEntries int) ([]ipnstate.NetworkLockUpd
 		return nil, errTailnetLockNotActive
 	}
 
-	var out []ipnstate.NetworkLockUpdate
+	var out []ipnstate.TailnetLockUpdate
 	cursor := b.tka.authority.Head()
 	for range maxEntries {
 		aum, err := b.tka.storage.AUM(cursor)
@@ -935,7 +985,7 @@ func (b *LocalBackend) NetworkLockLog(maxEntries int) ([]ipnstate.NetworkLockUpd
 			return out, fmt.Errorf("reading AUM (%v): %w", cursor, err)
 		}
 
-		update := ipnstate.NetworkLockUpdate{
+		update := ipnstate.TailnetLockUpdate{
 			Hash:   cursor,
 			Change: aum.MessageKind.String(),
 			Raw:    aum.Serialize(),
@@ -952,9 +1002,14 @@ func (b *LocalBackend) NetworkLockLog(maxEntries int) ([]ipnstate.NetworkLockUpd
 	return out, nil
 }
 
-// NetworkLockAffectedSigs returns the signatures which would be invalidated
+// Deprecated: use [LocalBackend.TailnetLockLog] instead.
+func (b *LocalBackend) NetworkLockLog(maxEntries int) ([]ipnstate.TailnetLockUpdate, error) {
+	return b.TailnetLockLog(maxEntries)
+}
+
+// TailnetLockAffectedSigs returns the signatures which would be invalidated
 // by removing trust in the specified KeyID.
-func (b *LocalBackend) NetworkLockAffectedSigs(keyID tkatype.KeyID) ([]tkatype.MarshaledSignature, error) {
+func (b *LocalBackend) TailnetLockAffectedSigs(keyID tkatype.KeyID) ([]tkatype.MarshaledSignature, error) {
 	var (
 		ourNodeKey key.NodePublic
 		err        error
@@ -1010,12 +1065,17 @@ func (b *LocalBackend) NetworkLockAffectedSigs(keyID tkatype.KeyID) ([]tkatype.M
 	return resp.Signatures, nil
 }
 
-// NetworkLockGenerateRecoveryAUM generates an AUM which retroactively removes trust in the
+// Deprecated: use [LocalBackend.TailnetLockAffectedSigs] instead.
+func (b *LocalBackend) NetworkLockAffectedSigs(keyID tkatype.KeyID) ([]tkatype.MarshaledSignature, error) {
+	return b.TailnetLockAffectedSigs(keyID)
+}
+
+// TailnetLockGenerateRecoveryAUM generates an AUM which retroactively removes trust in the
 // specified keys. This AUM is signed by the current node and returned.
 //
 // If forkFrom is specified, it is used as the parent AUM to fork from. If the zero value,
 // the parent AUM is determined automatically.
-func (b *LocalBackend) NetworkLockGenerateRecoveryAUM(removeKeys []tkatype.KeyID, forkFrom tka.AUMHash) (*tka.AUM, error) {
+func (b *LocalBackend) TailnetLockGenerateRecoveryAUM(removeKeys []tkatype.KeyID, forkFrom tka.AUMHash) (*tka.AUM, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.tka == nil {
@@ -1043,12 +1103,17 @@ func (b *LocalBackend) NetworkLockGenerateRecoveryAUM(removeKeys []tkatype.KeyID
 	return aum, nil
 }
 
-// NetworkLockCosignRecoveryAUM co-signs the provided recovery AUM and returns
+// Deprecated: use [LocalBackend.TailnetLockGenerateRecoveryAUM] instead.
+func (b *LocalBackend) NetworkLockGenerateRecoveryAUM(removeKeys []tkatype.KeyID, forkFrom tka.AUMHash) (*tka.AUM, error) {
+	return b.TailnetLockGenerateRecoveryAUM(removeKeys, forkFrom)
+}
+
+// TailnetLockCosignRecoveryAUM co-signs the provided recovery AUM and returns
 // the updated structure.
 //
 // The recovery AUM provided should be the output from a previous call to
-// NetworkLockGenerateRecoveryAUM or NetworkLockCosignRecoveryAUM.
-func (b *LocalBackend) NetworkLockCosignRecoveryAUM(aum *tka.AUM) (*tka.AUM, error) {
+// [LocalBackend.TailnetLockGenerateRecoveryAUM] or [LocalBackend.TailnetLockCosignRecoveryAUM].
+func (b *LocalBackend) TailnetLockCosignRecoveryAUM(aum *tka.AUM) (*tka.AUM, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.tka == nil {
@@ -1077,7 +1142,12 @@ func (b *LocalBackend) NetworkLockCosignRecoveryAUM(aum *tka.AUM) (*tka.AUM, err
 	return aum, nil
 }
 
-func (b *LocalBackend) NetworkLockSubmitRecoveryAUM(aum *tka.AUM) error {
+// Deprecated: use [LocalBackend.TailnetLockCosignRecoveryAUM] instead.
+func (b *LocalBackend) NetworkLockCosignRecoveryAUM(aum *tka.AUM) (*tka.AUM, error) {
+	return b.TailnetLockCosignRecoveryAUM(aum)
+}
+
+func (b *LocalBackend) TailnetLockSubmitRecoveryAUM(aum *tka.AUM) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.tka == nil {
@@ -1097,15 +1167,20 @@ func (b *LocalBackend) NetworkLockSubmitRecoveryAUM(aum *tka.AUM) error {
 	return err
 }
 
+// Deprecated: use [LocalBackend.TailnetLockSubmitRecoveryAUM] instead.
+func (b *LocalBackend) NetworkLockSubmitRecoveryAUM(aum *tka.AUM) error {
+	return b.TailnetLockSubmitRecoveryAUM(aum)
+}
+
 var tkaSuffixEncoder = base64.RawStdEncoding
 
-// NetworkLockWrapPreauthKey wraps a pre-auth key with information to
+// TailnetLockWrapPreauthKey wraps a pre-auth key with information to
 // enable unattended bringup in the locked tailnet.
 //
 // The provided trusted tailnet-lock key is used to sign
 // a SigCredential structure, which is encoded along with the
 // private key and appended to the pre-auth key.
-func (b *LocalBackend) NetworkLockWrapPreauthKey(preauthKey string, tkaKey key.NLPrivate) (string, error) {
+func (b *LocalBackend) TailnetLockWrapPreauthKey(preauthKey string, tkaKey key.NLPrivate) (string, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.tka == nil {
@@ -1131,9 +1206,14 @@ func (b *LocalBackend) NetworkLockWrapPreauthKey(preauthKey string, tkaKey key.N
 	return fmt.Sprintf("%s--TL%s-%s", preauthKey, tkaSuffixEncoder.EncodeToString(sig.Serialize()), tkaSuffixEncoder.EncodeToString(priv)), nil
 }
 
-// NetworkLockVerifySigningDeeplink asks the authority to verify the given deeplink
+// Deprecated: use [LocalBackend.TailnetLockWrapPreauthKey] instead.
+func (b *LocalBackend) NetworkLockWrapPreauthKey(preauthKey string, tkaKey key.NLPrivate) (string, error) {
+	return b.TailnetLockWrapPreauthKey(preauthKey, tkaKey)
+}
+
+// TailnetLockVerifySigningDeeplink asks the authority to verify the given deeplink
 // URL. See the comment for ValidateDeeplink for details.
-func (b *LocalBackend) NetworkLockVerifySigningDeeplink(url string) tka.DeeplinkValidationResult {
+func (b *LocalBackend) TailnetLockVerifySigningDeeplink(url string) tka.DeeplinkValidationResult {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.tka == nil {
@@ -1141,6 +1221,11 @@ func (b *LocalBackend) NetworkLockVerifySigningDeeplink(url string) tka.Deeplink
 	}
 
 	return b.tka.authority.ValidateDeeplink(url)
+}
+
+// Deprecated: use [LocalBackend.TailnetLockVerifySigningDeeplink] instead.
+func (b *LocalBackend) NetworkLockVerifySigningDeeplink(url string) tka.DeeplinkValidationResult {
+	return b.TailnetLockVerifySigningDeeplink(url)
 }
 
 func signNodeKey(nodeInfo tailcfg.TKASignInfo, signer key.NLPrivate) (*tka.NodeKeySignature, error) {

--- a/ipn/ipnlocal/tailnet-lock_test.go
+++ b/ipn/ipnlocal/tailnet-lock_test.go
@@ -641,7 +641,7 @@ func TestTKAFilterNetmap(t *testing.T) {
 		return node, nodeSig
 	}
 
-	preauth, err := b.NetworkLockWrapPreauthKey("tskey-auth-k7UagY1CNTRL-ZZZZZ", nlPriv)
+	preauth, err := b.TailnetLockWrapPreauthKey("tskey-auth-k7UagY1CNTRL-ZZZZZ", nlPriv)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -791,11 +791,11 @@ func TestTKADisable(t *testing.T) {
 	b := newLocalBackendForTKA(t, temp, client, pm, authority, chonk)
 
 	// Test that we get an error for an incorrect disablement secret.
-	if err := b.NetworkLockDisable([]byte{1, 2, 3, 4}); err == nil || err.Error() != "incorrect disablement secret" {
-		t.Errorf("NetworkLockDisable(<bad secret>).err = %v, want 'incorrect disablement secret'", err)
+	if err := b.TailnetLockDisable([]byte{1, 2, 3, 4}); err == nil || err.Error() != "incorrect disablement secret" {
+		t.Errorf("TailnetLockDisable(<bad secret>).err = %v, want 'incorrect disablement secret'", err)
 	}
-	if err := b.NetworkLockDisable(disablementSecret); err != nil {
-		t.Errorf("NetworkLockDisable() failed: %v", err)
+	if err := b.TailnetLockDisable(disablementSecret); err != nil {
+		t.Errorf("TailnetLockDisable() failed: %v", err)
 	}
 }
 
@@ -834,8 +834,8 @@ func TestTKASign(t *testing.T) {
 
 	b := newLocalBackendForTKA(t, varRoot, client, pm, authority, chonk)
 
-	if err := b.NetworkLockSign(toSign.Public(), nil); err != nil {
-		t.Errorf("NetworkLockSign() failed: %v", err)
+	if err := b.TailnetLockSign(toSign.Public(), nil); err != nil {
+		t.Errorf("TailnetLockSign() failed: %v", err)
 	}
 }
 
@@ -894,8 +894,8 @@ func TestTKAForceDisable(t *testing.T) {
 	b.pm = pm
 	b.mu.Unlock()
 
-	if err := b.NetworkLockForceLocalDisable(); err != nil {
-		t.Fatalf("NetworkLockForceLocalDisable() failed: %v", err)
+	if err := b.TailnetLockForceLocalDisable(); err != nil {
+		t.Fatalf("TailnetLockForceLocalDisable() failed: %v", err)
 	}
 	if b.tka != nil {
 		t.Fatal("tka was not shut down")
@@ -1000,14 +1000,14 @@ func TestTKAAffectedSigs(t *testing.T) {
 			defer ts.Close()
 			b := newLocalBackendForTKA(t, varRoot, client, pm, authority, chonk)
 
-			sigs, err := b.NetworkLockAffectedSigs(nlPriv.KeyID())
+			sigs, err := b.TailnetLockAffectedSigs(nlPriv.KeyID())
 			switch {
 			case tc.wantErr == "" && err != nil:
-				t.Errorf("NetworkLockAffectedSigs() failed: %v", err)
+				t.Errorf("TailnetLockAffectedSigs() failed: %v", err)
 			case tc.wantErr != "" && err == nil:
-				t.Errorf("NetworkLockAffectedSigs().err = nil, want %q", tc.wantErr)
+				t.Errorf("TailnetLockAffectedSigs().err = nil, want %q", tc.wantErr)
 			case tc.wantErr != "" && err.Error() != tc.wantErr:
-				t.Errorf("NetworkLockAffectedSigs().err = %q, want %q", err.Error(), tc.wantErr)
+				t.Errorf("TailnetLockAffectedSigs().err = %q, want %q", err.Error(), tc.wantErr)
 			}
 
 			if tc.wantErr == "" {
@@ -1064,24 +1064,24 @@ func TestTKARecoverCompromisedKeyFlow(t *testing.T) {
 	defer ts.Close()
 	b := newLocalBackendForTKA(t, varRoot, client, pm, authority, chonk)
 
-	aum, err := b.NetworkLockGenerateRecoveryAUM([]tkatype.KeyID{compromisedPriv.KeyID()}, tka.AUMHash{})
+	aum, err := b.TailnetLockGenerateRecoveryAUM([]tkatype.KeyID{compromisedPriv.KeyID()}, tka.AUMHash{})
 	if err != nil {
-		t.Fatalf("NetworkLockGenerateRecoveryAUM() failed: %v", err)
+		t.Fatalf("TailnetLockGenerateRecoveryAUM() failed: %v", err)
 	}
 
 	// Cosign using the cosigning key.
 	{
 		pm := setupProfileManager(t, nodePriv, cosignPriv)
 		b := newLocalBackendForTKA(t, varRoot, client, pm, authority, chonk)
-		if aum, err = b.NetworkLockCosignRecoveryAUM(aum); err != nil {
-			t.Fatalf("NetworkLockCosignRecoveryAUM() failed: %v", err)
+		if aum, err = b.TailnetLockCosignRecoveryAUM(aum); err != nil {
+			t.Fatalf("TailnetLockCosignRecoveryAUM() failed: %v", err)
 		}
 	}
 
 	// Finally, submit the recovery AUM. Validation is done
 	// in the fake control handler.
-	if err := b.NetworkLockSubmitRecoveryAUM(aum); err != nil {
-		t.Errorf("NetworkLockSubmitRecoveryAUM() failed: %v", err)
+	if err := b.TailnetLockSubmitRecoveryAUM(aum); err != nil {
+		t.Errorf("TailnetLockSubmitRecoveryAUM() failed: %v", err)
 	}
 }
 

--- a/ipn/ipnlocal/tailnetlock_disabled.go
+++ b/ipn/ipnlocal/tailnetlock_disabled.go
@@ -26,6 +26,11 @@ func (b *LocalBackend) tkaSyncIfNeeded(nm *netmap.NetworkMap, prefs ipn.PrefsVie
 
 func (b *LocalBackend) tkaFilterNetmapLocked(nm *netmap.NetworkMap) {}
 
-func (b *LocalBackend) NetworkLockStatus() *ipnstate.NetworkLockStatus {
-	return &ipnstate.NetworkLockStatus{Enabled: false}
+func (b *LocalBackend) TailnetLockStatus() *ipnstate.TailnetLockStatus {
+	return &ipnstate.TailnetLockStatus{Enabled: false}
+}
+
+// Deprecated: use [LocalBackend.TailnetLockStatus] instead.
+func (b *LocalBackend) NetworkLockStatus() *ipnstate.TailnetLockStatus {
+	return b.TailnetLockStatus()
 }

--- a/ipn/ipnstate/ipnstate.go
+++ b/ipn/ipnstate/ipnstate.go
@@ -107,10 +107,10 @@ type TKAPeer struct {
 	NodeKeySignature tka.NodeKeySignature
 }
 
-// NetworkLockStatus represents whether tailnet-lock is enabled,
+// TailnetLockStatus represents whether tailnet-lock is enabled,
 // along with details about the locally-known state of the tailnet
 // key authority.
-type NetworkLockStatus struct {
+type TailnetLockStatus struct {
 	// Enabled is true if tailnet lock is enabled.
 	Enabled bool
 
@@ -151,8 +151,11 @@ type NetworkLockStatus struct {
 	StateID uint64
 }
 
-// NetworkLockUpdate describes a change to tailnet-lock state.
-type NetworkLockUpdate struct {
+// Deprecated: use [TailnetLockStatus] instead.
+type NetworkLockStatus = TailnetLockStatus
+
+// TailnetLockUpdate describes a change to tailnet-lock state.
+type TailnetLockUpdate struct {
 	Hash   [32]byte
 	Change string // values of tka.AUMKind.String()
 
@@ -160,6 +163,9 @@ type NetworkLockUpdate struct {
 	// form to avoid transitive dependences bloating this package.
 	Raw []byte
 }
+
+// Deprecated: use [TailnetLockUpdate] instead.
+type NetworkLockUpdate = TailnetLockUpdate
 
 // TailnetStatus is information about a Tailscale network ("tailnet").
 type TailnetStatus struct {

--- a/ipn/localapi/localapi.go
+++ b/ipn/localapi/localapi.go
@@ -440,7 +440,7 @@ func (h *Handler) serveBugReport(w http.ResponseWriter, r *http.Request) {
 	h.logf.JSON(1, "UserBugReportOS", osdiag.SupportInfo(osdiag.LogSupportInfoReasonBugReport))
 
 	// Tailnet Lock details
-	st := h.b.NetworkLockStatus()
+	st := h.b.TailnetLockStatus()
 	if st.Enabled {
 		h.logf.JSON(1, "UserBugReportTailnetLockStatus", st)
 		if st.NodeKeySignature != nil {

--- a/ipn/localapi/tailnetlock.go
+++ b/ipn/localapi/tailnetlock.go
@@ -43,7 +43,7 @@ func (h *Handler) serveTKAStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	j, err := json.MarshalIndent(h.b.NetworkLockStatus(), "", "\t")
+	j, err := json.MarshalIndent(h.b.TailnetLockStatus(), "", "\t")
 	if err != nil {
 		http.Error(w, "JSON encoding error", http.StatusInternalServerError)
 		return
@@ -72,7 +72,7 @@ func (h *Handler) serveTKASign(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.b.NetworkLockSign(req.NodeKey, req.RotationPublic); err != nil {
+	if err := h.b.TailnetLockSign(req.NodeKey, req.RotationPublic); err != nil {
 		http.Error(w, "signing failed: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -101,17 +101,17 @@ func (h *Handler) serveTKAInit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !h.b.NetworkLockAllowed() {
+	if !h.b.TailnetLockAllowed() {
 		http.Error(w, "Tailnet Lock is not supported on your pricing plan", http.StatusForbidden)
 		return
 	}
 
-	if err := h.b.NetworkLockInit(req.Keys, req.DisablementValues, req.SupportDisablement); err != nil {
+	if err := h.b.TailnetLockInit(req.Keys, req.DisablementValues, req.SupportDisablement); err != nil {
 		http.Error(w, "initialization failed: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	j, err := json.MarshalIndent(h.b.NetworkLockStatus(), "", "\t")
+	j, err := json.MarshalIndent(h.b.TailnetLockStatus(), "", "\t")
 	if err != nil {
 		http.Error(w, "JSON encoding error", http.StatusInternalServerError)
 		return
@@ -140,7 +140,7 @@ func (h *Handler) serveTKAModify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.b.NetworkLockModify(req.AddKeys, req.RemoveKeys); err != nil {
+	if err := h.b.TailnetLockModify(req.AddKeys, req.RemoveKeys); err != nil {
 		http.Error(w, "tailnet-lock modify failed: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -172,7 +172,7 @@ func (h *Handler) serveTKAWrapPreauthKey(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	wrappedKey, err := h.b.NetworkLockWrapPreauthKey(req.TSKey, priv)
+	wrappedKey, err := h.b.TailnetLockWrapPreauthKey(req.TSKey, priv)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -200,7 +200,7 @@ func (h *Handler) serveTKAVerifySigningDeeplink(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	res := h.b.NetworkLockVerifySigningDeeplink(req.URL)
+	res := h.b.TailnetLockVerifySigningDeeplink(req.URL)
 	j, err := json.MarshalIndent(res, "", "\t")
 	if err != nil {
 		http.Error(w, "JSON encoding error", http.StatusInternalServerError)
@@ -227,7 +227,7 @@ func (h *Handler) serveTKADisable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.b.NetworkLockDisable(secret); err != nil {
+	if err := h.b.TailnetLockDisable(secret); err != nil {
 		http.Error(w, "tailnet-lock disable failed: "+err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -251,7 +251,7 @@ func (h *Handler) serveTKALocalDisable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.b.NetworkLockForceLocalDisable(); err != nil {
+	if err := h.b.TailnetLockForceLocalDisable(); err != nil {
 		http.Error(w, "tailnet-lock local disable failed: "+err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -274,7 +274,7 @@ func (h *Handler) serveTKALog(w http.ResponseWriter, r *http.Request) {
 		limit = int(lm)
 	}
 
-	updates, err := h.b.NetworkLockLog(limit)
+	updates, err := h.b.TailnetLockLog(limit)
 	if err != nil {
 		http.Error(w, "reading log failed: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -300,7 +300,7 @@ func (h *Handler) serveTKAAffectedSigs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sigs, err := h.b.NetworkLockAffectedSigs(keyID)
+	sigs, err := h.b.TailnetLockAffectedSigs(keyID)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -343,7 +343,7 @@ func (h *Handler) serveTKAGenerateRecoveryAUM(w http.ResponseWriter, r *http.Req
 		}
 	}
 
-	res, err := h.b.NetworkLockGenerateRecoveryAUM(req.Keys, forkFrom)
+	res, err := h.b.TailnetLockGenerateRecoveryAUM(req.Keys, forkFrom)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -374,7 +374,7 @@ func (h *Handler) serveTKACosignRecoveryAUM(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	res, err := h.b.NetworkLockCosignRecoveryAUM(&aum)
+	res, err := h.b.TailnetLockCosignRecoveryAUM(&aum)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -405,7 +405,7 @@ func (h *Handler) serveTKASubmitRecoveryAUM(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	if err := h.b.NetworkLockSubmitRecoveryAUM(&aum); err != nil {
+	if err := h.b.TailnetLockSubmitRecoveryAUM(&aum); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
To avoid breaking downstream code, add deprecated aliases for all the old names.

Updates tailscale/corp#37904