### PR TITLE
go.mod: bump wireguard-go for memory leak fix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -164,4 +164,4 @@
     });
   };
 }
-# nix-direnv cache busting line: sha256-N9feTY91Q2WUin3De5NYEy/R1ZyuE5cjx49lc1i3nSQ=
+# nix-direnv cache busting line: sha256-nFJHR6CG8VykddaOGEqA3NYiT3wtoFSFAShxX2tuGds=

--- a/flakehashes.json
+++ b/flakehashes.json
@@ -4,7 +4,7 @@
     "sri": "sha256-cY5yryX+p/xtoTv+WZEKFagiIl0OREHnJY1Bk5VpVVc="
   },
   "vendor": {
-    "goModSum": "sha256-/CvlMPHEbBEpHd/fTRfxSYUMLaNdDrMi1d8hvoXoSw0=",
-    "sri": "sha256-N9feTY91Q2WUin3De5NYEy/R1ZyuE5cjx49lc1i3nSQ="
+    "goModSum": "sha256-xIZX/er9CK0Y3Psn7ys/4BZ+DyTQzjajB2mMXxa9bpo=",
+    "sri": "sha256-nFJHR6CG8VykddaOGEqA3NYiT3wtoFSFAShxX2tuGds="
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,7 @@ require (
 	github.com/tailscale/ts-gokrazy v0.0.0-20260604151927-fc3a567bcf75
 	github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976
 	github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6
-	github.com/tailscale/wireguard-go v0.0.0-20260527010701-b48af7099cad
+	github.com/tailscale/wireguard-go v0.0.0-20260604164555-58f7aaceb304
 	github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e
 	github.com/tc-hib/winres v0.2.1
 	github.com/tcnksm/go-httpstat v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1181,8 +1181,8 @@ github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976 h1:U
 github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976/go.mod h1:agQPE6y6ldqCOui2gkIh7ZMztTkIQKH049tv8siLuNQ=
 github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6 h1:l10Gi6w9jxvinoiq15g8OToDdASBni4CyJOdHY1Hr8M=
 github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6/go.mod h1:ZXRML051h7o4OcI0d3AaILDIad/Xw0IkXaHM17dic1Y=
-github.com/tailscale/wireguard-go v0.0.0-20260527010701-b48af7099cad h1:Ky26FR5yZ5IKEB0xtm5A8xSTb06ImY7kxBFrvgOmJSg=
-github.com/tailscale/wireguard-go v0.0.0-20260527010701-b48af7099cad/go.mod h1:6SerzcvHWQchKO2BfNdmquA77CHSECZuFl+D9fp4RnI=
+github.com/tailscale/wireguard-go v0.0.0-20260604164555-58f7aaceb304 h1:01sTzkN5Vu4Ucs0XU25+wVat5vmFrSDR5JkMOJ8xQj0=
+github.com/tailscale/wireguard-go v0.0.0-20260604164555-58f7aaceb304/go.mod h1:6SerzcvHWQchKO2BfNdmquA77CHSECZuFl+D9fp4RnI=
 github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e h1:zOGKqN5D5hHhiYUp091JqK7DPCqSARyUfduhGUY8Bek=
 github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e/go.mod h1:orPd6JZXXRyuDusYilywte7k094d7dycXXU5YnWsrwg=
 github.com/tc-hib/winres v0.2.1 h1:YDE0FiP0VmtRaDn7+aaChp1KiF4owBiJa5l964l5ujA=

--- a/shell.nix
+++ b/shell.nix
@@ -16,4 +16,4 @@
 ) {
   src =  ./.;
 }).shellNix
-# nix-direnv cache busting line: sha256-N9feTY91Q2WUin3De5NYEy/R1ZyuE5cjx49lc1i3nSQ=
+# nix-direnv cache busting line: sha256-nFJHR6CG8VykddaOGEqA3NYiT3wtoFSFAShxX2tuGds=


### PR DESCRIPTION
Updates tailscale/corp#42776
