### PR TITLE
CODEOWNERS: auto-request k8s-devs review for Kubernetes/container paths

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,12 @@
 /tailcfg/ @tailscale/control-protocol-owners
+
+# Kubernetes / containers
+/k8s-operator/        @tailscale/k8s-devs
+/kube/                @tailscale/k8s-devs
+/cmd/k8s-operator/    @tailscale/k8s-devs
+/cmd/k8s-proxy/       @tailscale/k8s-devs
+/cmd/k8s-nameserver/  @tailscale/k8s-devs
+/cmd/containerboot/   @tailscale/k8s-devs
+/cmd/sync-containers/ @tailscale/k8s-devs
+/ipn/store/kubestore/ @tailscale/k8s-devs
+/docs/k8s/            @tailscale/k8s-devs


### PR DESCRIPTION
Assign the Kubernetes operator, kube libraries, container build commands, and related paths to @tailscale/k8s-devs.

Updates #cleanup

Change-Id: I9d8c7ebfd9a2b6401dd8cb0ff335151afe58357c