### PR TITLE
cmd/tailscaled: only warn about unsupported attestation when enabled

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -923,7 +923,9 @@ func handleTPMFlags() {
 	case !args.hardwareAttestation.set:
 		policyHWAttestation, _ := policyclient.Get().GetBoolean(pkey.HardwareAttestation, false)
 		if err := canUseHardwareAttestation(); err != nil {
-			log.Printf("[unexpected] policy requires hardware attestation, but device does not support it: %v", err)
+			if policyHWAttestation {
+				log.Printf("[unexpected] policy requires hardware attestation, but device does not support it: %v", err)
+			}
 			args.hardwareAttestation.v = false
 		} else {
 			args.hardwareAttestation.v = policyHWAttestation


### PR DESCRIPTION
We don't need to log if the policy doesn't actually say that hardware attestation must be enabled.

Updates #cleanup
Updates https://tailscale.atlassian.net/browse/ESC-24