### PR TITLE
cmd/tailscale/cli: add service support to tailscale ip

### DIFF
--- a/cmd/tailscale/cli/ip.go
+++ b/cmd/tailscale/cli/ip.go
@@ -17,9 +17,9 @@ import (
 
 var ipCmd = &ffcli.Command{
 	Name:       "ip",
-	ShortUsage: "tailscale ip [-1] [-4] [-6] [peer hostname or ip address]",
+	ShortUsage: "tailscale ip [-1] [-4] [-6] [peer or service hostname or ip address]",
 	ShortHelp:  "Show Tailscale IP addresses",
-	LongHelp:   "Show Tailscale IP addresses for peer. Peer defaults to the current machine.",
+	LongHelp:   "Show Tailscale IP addresses for peer or service. Peer defaults to the current machine.",
 	Exec:       runIP,
 	FlagSet: (func() *flag.FlagSet {
 		fs := newFlagSet("ip")
@@ -79,10 +79,20 @@ func runIP(ctx context.Context, args []string) error {
 			return err
 		}
 		peer, ok := peerMatchingIP(st, ip)
-		if !ok {
-			return fmt.Errorf("no peer found with IP %v", ip)
+		if ok {
+			ips = peer.TailscaleIPs
+		} else {
+			// No peer matched; check if the IP belongs to a service.
+			serviceIPs, err := serviceAddrsMatchingIP(ctx, ip)
+			if err != nil {
+				return err
+			}
+			if serviceIPs != nil {
+				ips = serviceIPs
+			} else {
+				return fmt.Errorf("no peer or service found with IP %v", ip)
+			}
 		}
-		ips = peer.TailscaleIPs
 	}
 	if len(ips) == 0 {
 		return fmt.Errorf("no current Tailscale IPs; state: %v", st.BackendState)
@@ -107,6 +117,25 @@ func runIP(ctx context.Context, args []string) error {
 		}
 	}
 	return nil
+}
+
+// serviceAddrsMatchingIP checks whether ipStr matches a service's VIP address
+// and returns the service's addresses if so.
+func serviceAddrsMatchingIP(ctx context.Context, ipStr string) ([]netip.Addr, error) {
+	ip, err := netip.ParseAddr(ipStr)
+	if err != nil {
+		return nil, nil
+	}
+	services, err := localClient.GetServices(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, svc := range services {
+		if slices.Contains(svc.Addrs, ip) {
+			return svc.Addrs, nil
+		}
+	}
+	return nil, nil
 }
 
 func peerMatchingIP(st *ipnstate.Status, ipStr string) (ps *ipnstate.PeerStatus, ok bool) {


### PR DESCRIPTION
Fixes #20035

## Testing

### Service by short domain

```
14:59 $ tailscale ip dev-mysql-us-east-2
100.81.49.134
fd7a:115c:a1e0::8701:319e
```

### Service by full domain

```
14:59 $ tailscale ip dev-mysql-us-east-2.HIDDEN.ts.net
100.81.49.134
fd7a:115c:a1e0::8701:319e
```

### Service by IPv4

```
14:59 $ tailscale ip 100.81.49.134
100.81.49.134
fd7a:115c:a1e0::8701:319e
```

### Service by IPv6

```
14:59 $ tailscale ip fd7a:115c:a1e0::8701:319e
100.81.49.134
fd7a:115c:a1e0::8701:319e
```

### With `--4` Flag

```
14:59 $ tailscale ip --4 dev-mysql-us-east-2
100.81.49.134
```

### With `--6` Flag

```
15:03 $ tailscale ip --6 dev-mysql-us-east-2
fd7a:115c:a1e0::8701:319e
```

### Other

- Verified service lookups by IP with `--4` and `--6` flags work
- Verified service lookups with full fqdn with `--4` and `--6` flags work
- Verified changes don't break peer (machine) lookups