### PR TITLE
cmd/tailscale/tailscaled: fix linux panic on install-system-daemon

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -235,7 +235,7 @@ store state on filesystem.`)
 	if len(os.Args) > 1 {
 		sub := os.Args[1]
 		if fp, ok := subCommands[sub]; ok {
-			if fp == nil {
+			if *fp == nil {
 				log.SetFlags(0)
 				log.Fatalf("%s not available on %v", sub, runtime.GOOS)
 			}


### PR DESCRIPTION
`subCommands[sub]` returns a pointer variable, which will never be `nil` here; in order to check if the requested subcommand has been defined, we must dereference the returned pointer variable to see whether the value it points to is `nil`.

On Linux `tailscaled install-system-daemon` panics when it subsequently attempts to execute the `nil` function instead of returning an error message saying the command is not available, e.g.:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xffaa1f]
```