### PR TITLE
wgengine/magicsock: refresh stalled peer-relay paths

### DIFF
--- a/wgengine/magicsock/endpoint.go
+++ b/wgengine/magicsock/endpoint.go
@@ -113,7 +113,7 @@ func (de *endpoint) udpRelayEndpointReady(maybeBest addrQuality) {
 	de.mu.Lock()
 	defer de.mu.Unlock()
 	now := mono.Now()
-	curBestAddrTrusted := now.Before(de.trustBestAddrUntil)
+	curBestAddrTrusted := de.bestAddrTrustedLocked(now)
 	sameRelayServer := de.bestAddr.vni.IsSet() && maybeBest.relayServerDisco.Compare(de.bestAddr.relayServerDisco) == 0
 
 	if !curBestAddrTrusted ||
@@ -576,7 +576,7 @@ func (de *endpoint) DstToBytes() []byte  { return packIPPort(de.fakeWGAddr) }
 func (de *endpoint) addrForSendLocked(now mono.Time) (udpAddr epAddr, derpAddr netip.AddrPort, sendWGPing bool) {
 	udpAddr = de.bestAddr.epAddr
 
-	if udpAddr.ap.IsValid() && !now.After(de.trustBestAddrUntil) {
+	if udpAddr.ap.IsValid() && !now.After(de.trustBestAddrUntil) && !de.peerRelayWGReceiveStalledLocked(now) {
 		return udpAddr, netip.AddrPort{}, false
 	}
 
@@ -889,7 +889,7 @@ func (de *endpoint) setHeartbeatDisabled(v bool) {
 func (de *endpoint) discoverUDPRelayPathsLocked(now mono.Time) {
 	de.lastUDPRelayPathDiscovery = now
 	lastBest := de.bestAddr
-	lastBestIsTrusted := mono.Now().Before(de.trustBestAddrUntil)
+	lastBestIsTrusted := de.bestAddrTrustedLocked(now)
 	de.c.relayManager.startUDPRelayPathDiscoveryFor(de, lastBest, lastBestIsTrusted)
 }
 
@@ -926,10 +926,45 @@ func (de *endpoint) wantUDPRelayPathDiscoveryLocked(now mono.Time) bool {
 	if now.After(de.trustBestAddrUntil) {
 		return true
 	}
+	if de.peerRelayWGReceiveStalledLocked(now) {
+		return true
+	}
 	if !de.lastUDPRelayPathDiscovery.IsZero() && now.Sub(de.lastUDPRelayPathDiscovery) >= upgradeUDPRelayInterval {
 		return true
 	}
 	return false
+}
+
+// bestAddrTrustedLocked reports whether de.bestAddr should be considered
+// trusted for path-selection decisions.
+//
+// A peer-relay path can keep answering disco while the WireGuard session over
+// that relay has stopped receiving. In that case, do not let the disco trust
+// window suppress relay re-handshake/VNI refresh.
+func (de *endpoint) bestAddrTrustedLocked(now mono.Time) bool {
+	if !now.Before(de.trustBestAddrUntil) {
+		return false
+	}
+	return !de.peerRelayWGReceiveStalledLocked(now)
+}
+
+// peerRelayWGReceiveStalledLocked reports whether recent externally-triggered
+// send activity over a peer-relay bestAddr has not been matched by inbound
+// WireGuard traffic for a session window.
+//
+// de.mu must be held.
+func (de *endpoint) peerRelayWGReceiveStalledLocked(now mono.Time) bool {
+	if !de.bestAddr.vni.IsSet() || de.lastSendExt.IsZero() {
+		return false
+	}
+	if now.Sub(de.lastSendExt) > sessionActiveTimeout {
+		return false
+	}
+	lastRecvWG := de.lastRecvWG.LoadAtomic()
+	if lastRecvWG.IsZero() {
+		lastRecvWG = de.bestAddrAt
+	}
+	return !lastRecvWG.IsZero() && now.Sub(lastRecvWG) > sessionActiveTimeout
 }
 
 // wantFullPingLocked reports whether we should ping to all our peers looking for

--- a/wgengine/magicsock/endpoint_test.go
+++ b/wgengine/magicsock/endpoint_test.go
@@ -397,6 +397,9 @@ func Test_endpoint_udpRelayEndpointReady(t *testing.T) {
 		name               string
 		curBestAddr        addrQuality
 		trustBestAddrUntil mono.Time
+		lastSendExt        mono.Time
+		lastRecvWG         mono.Time
+		bestAddrAt         mono.Time
 		maybeBest          addrQuality
 		wantBestAddr       addrQuality
 	}{
@@ -429,6 +432,16 @@ func Test_endpoint_udpRelayEndpointReady(t *testing.T) {
 			wantBestAddr:       peerRelayAddrQuality,
 		},
 		{
+			name:               "maybeBest-diff-relay-higher-latency-wg-stalled",
+			curBestAddr:        peerRelayAddrQuality,
+			trustBestAddrUntil: mono.Now().Add(1 * time.Hour),
+			lastSendExt:        mono.Now().Add(-time.Second),
+			lastRecvWG:         mono.Now().Add(-(sessionActiveTimeout + time.Second)),
+			bestAddrAt:         mono.Now().Add(-2 * sessionActiveTimeout),
+			maybeBest:          peerRelayAddrQualityHigherLatencyDiffServer,
+			wantBestAddr:       peerRelayAddrQualityHigherLatencyDiffServer,
+		},
+		{
 			name:               "maybeBest-diff-relay-lower-latency-trusted",
 			curBestAddr:        peerRelayAddrQuality,
 			trustBestAddrUntil: mono.Now().Add(1 * time.Hour),
@@ -448,8 +461,11 @@ func Test_endpoint_udpRelayEndpointReady(t *testing.T) {
 			de := &endpoint{
 				c:                  &Conn{logf: func(msg string, args ...any) { return }},
 				bestAddr:           tt.curBestAddr,
+				bestAddrAt:         tt.bestAddrAt,
 				trustBestAddrUntil: tt.trustBestAddrUntil,
 			}
+			de.lastSendExt = tt.lastSendExt
+			de.lastRecvWG.StoreAtomic(tt.lastRecvWG)
 			de.udpRelayEndpointReady(tt.maybeBest)
 			if de.bestAddr != tt.wantBestAddr {
 				t.Errorf("de.bestAddr = %v, want %v", de.bestAddr, tt.wantBestAddr)
@@ -685,5 +701,116 @@ func Test_endpoint_handlePongConnLocked(t *testing.T) {
 				}
 			})
 		})
+	}
+}
+
+func Test_endpoint_peerRelayWGReceiveStall(t *testing.T) {
+	now := mono.Now()
+	relayAddr := epAddr{ap: netip.MustParseAddrPort("192.0.2.1:77")}
+	relayAddr.vni.Set(1)
+
+	tests := []struct {
+		name          string
+		lastSendExt   mono.Time
+		lastRecvWG    mono.Time
+		bestAddrAt    mono.Time
+		wantStalled   bool
+		wantDiscovery bool
+		wantTrusted   bool
+	}{
+		{
+			name:          "recent-send-no-recent-recv",
+			lastSendExt:   now.Add(-time.Second),
+			lastRecvWG:    now.Add(-(sessionActiveTimeout + time.Second)),
+			bestAddrAt:    now.Add(-2 * sessionActiveTimeout),
+			wantStalled:   true,
+			wantDiscovery: true,
+			wantTrusted:   false,
+		},
+		{
+			name:          "recent-send-never-recv",
+			lastSendExt:   now.Add(-time.Second),
+			bestAddrAt:    now.Add(-(sessionActiveTimeout + time.Second)),
+			wantStalled:   true,
+			wantDiscovery: true,
+			wantTrusted:   false,
+		},
+		{
+			name:        "recent-send-recent-recv",
+			lastSendExt: now.Add(-time.Second),
+			lastRecvWG:  now.Add(-time.Second),
+			bestAddrAt:  now.Add(-2 * sessionActiveTimeout),
+			wantTrusted: true,
+		},
+		{
+			name:        "idle-send",
+			lastSendExt: now.Add(-(sessionActiveTimeout + time.Second)),
+			lastRecvWG:  now.Add(-2 * sessionActiveTimeout),
+			bestAddrAt:  now.Add(-2 * sessionActiveTimeout),
+			wantTrusted: true,
+		},
+		{
+			name:        "fresh-best-addr-never-recv",
+			lastSendExt: now.Add(-time.Second),
+			bestAddrAt:  now.Add(-time.Second),
+			wantTrusted: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Conn{logf: func(msg string, args ...any) {}}
+			c.relayManager.hasPeerRelayServers.Store(true)
+			de := &endpoint{
+				c:                         c,
+				relayCapable:              true,
+				bestAddr:                  addrQuality{epAddr: relayAddr},
+				bestAddrAt:                tt.bestAddrAt,
+				trustBestAddrUntil:        now.Add(time.Hour),
+				lastUDPRelayPathDiscovery: now.Add(-discoverUDPRelayPathsInterval),
+			}
+			de.lastSendExt = tt.lastSendExt
+			de.lastRecvWG.StoreAtomic(tt.lastRecvWG)
+
+			if got := de.peerRelayWGReceiveStalledLocked(now); got != tt.wantStalled {
+				t.Errorf("peerRelayWGReceiveStalledLocked = %v, want %v", got, tt.wantStalled)
+			}
+			if got := de.wantUDPRelayPathDiscoveryLocked(now); got != tt.wantDiscovery {
+				t.Errorf("wantUDPRelayPathDiscoveryLocked = %v, want %v", got, tt.wantDiscovery)
+			}
+			if got := de.bestAddrTrustedLocked(now); got != tt.wantTrusted {
+				t.Errorf("bestAddrTrustedLocked = %v, want %v", got, tt.wantTrusted)
+			}
+		})
+	}
+}
+
+func Test_endpoint_addrForSendLocked_peerRelayWGReceiveStalled(t *testing.T) {
+	now := mono.Now()
+	relayAddr := epAddr{ap: netip.MustParseAddrPort("192.0.2.1:77")}
+	relayAddr.vni.Set(1)
+	derpAddr := netip.MustParseAddrPort("127.3.3.40:123")
+
+	de := &endpoint{
+		bestAddr:           addrQuality{epAddr: relayAddr},
+		bestAddrAt:         now.Add(-2 * sessionActiveTimeout),
+		derpAddr:           derpAddr,
+		trustBestAddrUntil: now.Add(time.Hour),
+	}
+	de.lastSendExt = now.Add(-time.Second)
+	de.lastRecvWG.StoreAtomic(now.Add(-(sessionActiveTimeout + time.Second)))
+
+	de.mu.Lock()
+	gotUDPAddr, gotDERPAddr, gotSendWGPing := de.addrForSendLocked(now)
+	de.mu.Unlock()
+
+	if gotUDPAddr != relayAddr {
+		t.Errorf("udpAddr = %v, want %v", gotUDPAddr, relayAddr)
+	}
+	if gotDERPAddr != derpAddr {
+		t.Errorf("derpAddr = %v, want %v", gotDERPAddr, derpAddr)
+	}
+	if gotSendWGPing {
+		t.Errorf("sendWGPing = true, want false")
 	}
 }

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -2319,7 +2319,7 @@ func (c *Conn) handleDiscoMessage(msg []byte, src epAddr, shouldBeRelayHandshake
 		ep.mu.Lock()
 		relayCapable := ep.relayCapable
 		lastBest := ep.bestAddr
-		lastBestIsTrusted := mono.Now().Before(ep.trustBestAddrUntil)
+		lastBestIsTrusted := ep.bestAddrTrustedLocked(mono.Now())
 		ep.mu.Unlock()
 		if isVia && !relayCapable {
 			c.logf("magicsock: disco: ignoring %s from %v; %v is not known to be relay capable", msgType, sender.ShortString(), sender.ShortString())


### PR DESCRIPTION
Updates peer-relay bestAddr trust so a relay path that still answers disco but has stopped receiving WireGuard traffic does not suppress rediscovery. If we recently sent externally triggered WireGuard traffic over a peer relay and the last WireGuard receive is older than sessionActiveTimeout, treat the bestAddr as untrusted and trigger UDP relay path discovery or refresh.

https://github.com/tailscale/corp/issues/42978