### PR TITLE
wgengine/magicsock: increase discoKeyAdvertisementInterval to 2 minutes

### DIFF
--- a/wgengine/magicsock/endpoint.go
+++ b/wgengine/magicsock/endpoint.go
@@ -43,7 +43,7 @@ var mtuProbePingSizesV6 []int
 // discoKeyAdvertisementInterval tells how often a disco update via TSMP can
 // happen. The update is triggered via enqueueCallMeMaybe, and thus it will
 // only be sent if the magicsock is in a state to send out CallMeMaybe.
-const discoKeyAdvertisementInterval = time.Second * 60
+const discoKeyAdvertisementInterval = time.Minute * 2
 
 func init() {
 	for _, m := range tstun.WireMTUsToProbe {


### PR DESCRIPTION
The 1 minute timeout was hitting timers inside wireguard-go, leading
stale connections hanging forever. Increasing the timeout to 2 minutes
makes a small subset of cached connections establish direct connections
slightly slower.

Updates to wireguard-go will allow a better hook for when to send these
messages in the future. This change only makes fixes the error mode but
if we have better triggers coming in wireguard-go, we should be using
those.

Updates #20081

Signed-off-by: Claus Lensbøl <claus@tailscale.com>
