### PR TITLE
CODEOWNERS: remove blocking reviews

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,12 +1,4 @@
 /tailcfg/ @tailscale/control-protocol-owners
 
-# Kubernetes / containers
-/k8s-operator/        @tailscale/k8s-devs
-/kube/                @tailscale/k8s-devs
-/cmd/k8s-operator/    @tailscale/k8s-devs
-/cmd/k8s-proxy/       @tailscale/k8s-devs
-/cmd/k8s-nameserver/  @tailscale/k8s-devs
-/cmd/containerboot/   @tailscale/k8s-devs
-/cmd/sync-containers/ @tailscale/k8s-devs
-/ipn/store/kubestore/ @tailscale/k8s-devs
-/docs/k8s/            @tailscale/k8s-devs
+# Do not add to this list without wide discussion.
+# See https://github.com/tailscale/corp/issues/13972


### PR DESCRIPTION
We aren't supposed to be using CODEOWNERS as blocking
reviews, blocking global cleanups.

(This is why we want to move to go/policybot)

Updates tailscale/corp#13972
