### PR TITLE
wgengine/magicsock,ipn,client/local,cmd/tailscale/cli: add active-endpoints debug introspection

### DIFF
--- a/client/local/local.go
+++ b/client/local/local.go
@@ -1334,6 +1334,19 @@ func (lc *Client) DebugPeerRelaySessions(ctx context.Context) (*status.ServerSta
 	return decodeJSON[*status.ServerStatus](body)
 }
 
+// DebugActiveEndpoints returns debug information about the active dataplane
+// endpoint state of each peer, as seen by both magicsock and wireguard-go.
+//
+// It is intended for debugging and tests only; its contents are subject to
+// change. See [ipnstate.DebugActiveEndpoints].
+func (lc *Client) DebugActiveEndpoints(ctx context.Context) (*ipnstate.DebugActiveEndpoints, error) {
+	body, err := lc.send(ctx, "GET", "/localapi/v0/debug-active-endpoints", 200, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error %w: %s", err, body)
+	}
+	return decodeJSON[*ipnstate.DebugActiveEndpoints](body)
+}
+
 // StreamDebugCapture streams a pcap-formatted packet capture.
 //
 // The provided context does not determine the lifetime of the

--- a/cmd/tailscale/cli/debug.go
+++ b/cmd/tailscale/cli/debug.go
@@ -344,6 +344,12 @@ func debugCmd() *ffcli.Command {
 				ShortHelp:  "Print debug information about a peer's endpoint changes",
 			},
 			{
+				Name:       "active-endpoints",
+				ShortUsage: "tailscale debug active-endpoints",
+				Exec:       runDebugActiveEndpoints,
+				ShortHelp:  "Print the active dataplane endpoint state of each peer, as seen by both magicsock and wireguard-go",
+			},
+			{
 				Name:       "dial-types",
 				ShortUsage: "tailscale debug dial-types <hostname-or-IP> <port>",
 				Exec:       runDebugDialTypes,
@@ -1282,6 +1288,19 @@ func runPeerEndpointChanges(ctx context.Context, args []string) error {
 	}
 	fmt.Printf("%s", dst.String())
 	return nil
+}
+
+func runDebugActiveEndpoints(ctx context.Context, args []string) error {
+	if len(args) > 0 {
+		return errors.New("unexpected arguments")
+	}
+	res, err := localClient.DebugActiveEndpoints(ctx)
+	if err != nil {
+		return err
+	}
+	e := json.NewEncoder(Stdout)
+	e.SetIndent("", "\t")
+	return e.Encode(res)
 }
 
 func debugControlKnobs(ctx context.Context, args []string) error {

--- a/ipn/ipnlocal/c2n.go
+++ b/ipn/ipnlocal/c2n.go
@@ -63,6 +63,7 @@ func init() {
 		RegisterC2N("/debug/logheap", handleC2NDebugLogHeap)
 		RegisterC2N("/debug/netmap", handleC2NDebugNetMap)
 		RegisterC2N("/debug/health", handleC2NDebugHealth)
+		RegisterC2N("GET /debug/active-endpoints", handleC2NDebugActiveEndpoints)
 	}
 	if runtime.GOOS == "linux" && buildfeatures.HasOSRouter {
 		RegisterC2N("POST /netfilter-kind", handleC2NSetNetfilterKind)
@@ -151,6 +152,22 @@ func handleC2NDebugHealth(b *LocalBackend, w http.ResponseWriter, r *http.Reques
 		st = b.health.CurrentState()
 	}
 	writeJSON(w, st)
+}
+
+// handleC2NDebugActiveEndpoints serves debug information about the active
+// dataplane endpoint state of each peer, as seen by both magicsock and
+// wireguard-go. See [ipnstate.DebugActiveEndpoints].
+func handleC2NDebugActiveEndpoints(b *LocalBackend, w http.ResponseWriter, r *http.Request) {
+	if !buildfeatures.HasDebug {
+		http.Error(w, feature.ErrUnavailable.Error(), http.StatusNotImplemented)
+		return
+	}
+	res, err := b.DebugActiveEndpoints()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, res)
 }
 
 func handleC2NDebugNetMap(b *LocalBackend, w http.ResponseWriter, r *http.Request) {

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -8196,6 +8196,14 @@ func (b *LocalBackend) GetPeerEndpointChanges(ctx context.Context, ip netip.Addr
 	return chs, nil
 }
 
+// DebugActiveEndpoints returns debug information about the active dataplane
+// endpoint state of each peer, as seen by both magicsock and wireguard-go.
+// It is intended for debugging and tests only; see
+// [ipnstate.DebugActiveEndpoints].
+func (b *LocalBackend) DebugActiveEndpoints() (*ipnstate.DebugActiveEndpoints, error) {
+	return b.e.DebugActiveEndpoints()
+}
+
 var breakTCPConns func() error
 
 func (b *LocalBackend) DebugBreakTCPConns() error {

--- a/ipn/ipnlocal/state_test.go
+++ b/ipn/ipnlocal/state_test.go
@@ -1971,6 +1971,10 @@ func (e *mockEngine) PeerByKey(key.NodePublic) (_ wgint.Peer, ok bool) {
 	return wgint.Peer{}, false
 }
 
+func (e *mockEngine) DebugActiveEndpoints() (*ipnstate.DebugActiveEndpoints, error) {
+	return &ipnstate.DebugActiveEndpoints{}, nil
+}
+
 func (e *mockEngine) SetNetworkMap(*netmap.NetworkMap) {}
 
 func (e *mockEngine) UpdateStatus(*ipnstate.StatusBuilder) {}

--- a/ipn/ipnstate/activeendpoints.go
+++ b/ipn/ipnstate/activeendpoints.go
@@ -1,0 +1,153 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package ipnstate
+
+import (
+	"time"
+
+	"tailscale.com/types/key"
+)
+
+// DebugActiveEndpoints describes, per peer, the active dataplane endpoint
+// state as seen by both magicsock and wireguard-go. It is the response type
+// of the "debug-active-endpoints" LocalAPI endpoint, the
+// "/debug/active-endpoints" c2n endpoint, and the
+// "tailscale debug active-endpoints" CLI command.
+//
+// It is a debug API intended for debugging dataplane issues (e.g. a stale
+// wireguard-go peer endpoint black-holing traffic, see
+// tailscale/tailscale#20082) and for test assertions about a client's
+// expected dataplane state. Its contents are subject to change.
+type DebugActiveEndpoints struct {
+	// Peers describes each peer's active endpoint state, sorted by node key.
+	Peers []PeerActiveEndpoints `json:",omitempty"`
+}
+
+// PeerActiveEndpoints describes a single peer's active dataplane endpoint
+// state, as seen by both magicsock and wireguard-go.
+type PeerActiveEndpoints struct {
+	// NodeKey is the peer's node (WireGuard) public key.
+	NodeKey key.NodePublic
+
+	// ShortDisco is the short form of the peer's disco key, if known.
+	ShortDisco string `json:",omitempty"`
+
+	// Magicsock describes the peer's magicsock endpoint state. It is nil
+	// if the peer is not present in magicsock's peer map.
+	Magicsock *MagicsockEndpointState `json:",omitempty"`
+
+	// WireGuard describes the peer's state as seen by wireguard-go. It is
+	// nil if wireguard-go does not currently have the peer configured;
+	// wireguard-go peers are created lazily upon first packet exchanged
+	// with the peer.
+	WireGuard *WireGuardPeerState `json:",omitempty"`
+}
+
+// MagicsockEndpointState describes a peer's active endpoint state as seen by
+// magicsock.
+type MagicsockEndpointState struct {
+	// BestAddr is the current best (non-DERP) path to the peer as
+	// "ip:port", suffixed with ":vni:<n>" if the path traverses a UDP peer
+	// relay. It is empty if magicsock has no UDP path to the peer.
+	BestAddr string `json:",omitempty"`
+
+	// BestAddrTrusted reports whether BestAddr is currently trusted for
+	// sending, i.e. it has been confirmed recently enough via pong
+	// reception. When false and BestAddr is nonempty, magicsock sends to
+	// both BestAddr and DERPAddr while it re-confirms the path.
+	BestAddrTrusted bool `json:",omitzero"`
+
+	// BestAddrAt is the time at which BestAddr was last (re-)confirmed.
+	BestAddrAt time.Time `json:",omitzero"`
+
+	// TrustBestAddrUntil is the time at which trust of BestAddr expires.
+	TrustBestAddrUntil time.Time `json:",omitzero"`
+
+	// DERPAddr is the peer's fallback/bootstrap DERP pseudo-address
+	// ("127.3.3.40:<region-id>"), if any.
+	DERPAddr string `json:",omitempty"`
+
+	// DERPRegion is the peer's home DERP region ID, if any.
+	DERPRegion int `json:",omitzero"`
+
+	// LastSend is the last time a packet was sent to the peer from an
+	// external trigger (wireguard-go or a disco CLI ping), if ever.
+	LastSend time.Time `json:",omitzero"`
+
+	// LastRecv is the last time a UDP packet of any kind, including
+	// disco, was received from the peer, if ever. It does not include
+	// packets received via DERP.
+	LastRecv time.Time `json:",omitzero"`
+
+	// LastRecvWG is the last time a packet destined for wireguard-go
+	// (i.e. data, not disco) was received from the peer, if ever. Unlike
+	// LastRecv it excludes disco traffic, so it answers whether WireGuard
+	// data is still arriving from the peer even while sends to it are
+	// black-holed (tailscale/tailscale#20082).
+	LastRecvWG time.Time `json:",omitzero"`
+
+	// LastFullPing is the last time magicsock pinged all of the peer's
+	// candidate endpoints, if ever.
+	LastFullPing time.Time `json:",omitzero"`
+
+	// EpAddrCount is the number of "ip:port" (+ optional VNI) addresses
+	// mapped to this peer in magicsock's peer map.
+	EpAddrCount int `json:",omitzero"`
+
+	// IsWireGuardOnly is whether the peer is a WireGuard-only peer (it
+	// does not speak disco, e.g. a Mullvad exit node). For such peers
+	// there is no disco path discovery: ShortDisco is empty and
+	// trust/ping-related fields should be interpreted accordingly.
+	IsWireGuardOnly bool `json:",omitzero"`
+
+	// Expired is whether the peer's node key has expired. Magicsock does
+	// not send to or accept new paths from expired peers, so the other
+	// fields describe only historical state.
+	Expired bool `json:",omitzero"`
+}
+
+// Values of [WireGuardPeerState].EndpointType.
+const (
+	// WireGuardEndpointTypeMagicsock indicates wireguard-go holds the
+	// magicsock-managed endpoint for the peer.
+	WireGuardEndpointTypeMagicsock = "magicsock"
+	// WireGuardEndpointTypeOther indicates wireguard-go holds some other
+	// endpoint for the peer, e.g. a stale magicsock lazy endpoint.
+	WireGuardEndpointTypeOther = "other"
+)
+
+// WireGuardPeerState describes a peer's state as seen by wireguard-go. Its
+// presence alone indicates that a wireguard-go peer currently exists;
+// wireguard-go peers are created lazily upon first packet exchanged with the
+// peer.
+type WireGuardPeerState struct {
+	// Endpoint is the string form (DstToString) of the endpoint that
+	// wireguard-go currently holds for the peer, exactly as wireguard-go
+	// would report it. A magicsock-managed endpoint renders as the peer's
+	// node public key in untyped hex; anything else (e.g. magicsock's
+	// lazyEndpoint) renders as "ip:port", suffixed with ":vni:<n>" if the
+	// path traverses a UDP peer relay. It is empty if wireguard-go holds
+	// no endpoint for the peer.
+	Endpoint string `json:",omitempty"`
+
+	// EndpointType classifies the endpoint that wireguard-go currently
+	// holds for the peer, by its concrete type:
+	// [WireGuardEndpointTypeMagicsock] when wireguard-go holds the
+	// magicsock-managed endpoint for the peer, or
+	// [WireGuardEndpointTypeOther] when it holds anything else, which may
+	// indicate a problem, e.g. a stale lazy endpoint black-holing traffic
+	// (tailscale/tailscale#20082). It is empty if wireguard-go holds no
+	// endpoint for the peer.
+	EndpointType string `json:",omitempty"`
+
+	// LastHandshake is the time of the last completed WireGuard handshake
+	// with the peer, if ever.
+	LastHandshake time.Time `json:",omitzero"`
+
+	// RxBytes is the number of bytes received from the peer.
+	RxBytes uint64 `json:",omitzero"`
+
+	// TxBytes is the number of bytes sent to the peer.
+	TxBytes uint64 `json:",omitzero"`
+}

--- a/ipn/localapi/debug.go
+++ b/ipn/localapi/debug.go
@@ -33,6 +33,7 @@ import (
 func init() {
 	Register("component-debug-logging", (*Handler).serveComponentDebugLogging)
 	Register("debug", (*Handler).serveDebug)
+	Register("debug-active-endpoints", (*Handler).serveDebugActiveEndpoints)
 	Register("debug-rotate-disco-key", (*Handler).serveDebugRotateDiscoKey)
 	Register("dev-set-state-store", (*Handler).serveDevSetStateStore)
 	Register("debug-bus-events", (*Handler).serveDebugBusEvents)
@@ -73,6 +74,25 @@ func (h *Handler) serveDebugPeerEndpointChanges(w http.ResponseWriter, r *http.R
 	e := json.NewEncoder(w)
 	e.SetIndent("", "\t")
 	e.Encode(chs)
+}
+
+// serveDebugActiveEndpoints serves debug information about the active
+// dataplane endpoint state of each peer, as seen by both magicsock and
+// wireguard-go. See [ipnstate.DebugActiveEndpoints].
+func (h *Handler) serveDebugActiveEndpoints(w http.ResponseWriter, r *http.Request) {
+	if !h.PermitRead {
+		http.Error(w, "active-endpoints access denied", http.StatusForbidden)
+		return
+	}
+	res, err := h.b.DebugActiveEndpoints()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	e := json.NewEncoder(w)
+	e.SetIndent("", "\t")
+	e.Encode(res)
 }
 
 func (h *Handler) serveComponentDebugLogging(w http.ResponseWriter, r *http.Request) {

--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -40,6 +40,7 @@ import (
 	"tailscale.com/health"
 	"tailscale.com/hostinfo"
 	"tailscale.com/ipn"
+	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/net/tsaddr"
 	"tailscale.com/net/tstun"
 	"tailscale.com/net/udprelay/status"
@@ -175,6 +176,70 @@ func TestControlKnobs(t *testing.T) {
 	}
 	if got, want := m["DisableUPnP"], true; got != want {
 		t.Errorf("control-knobs DisableUPnP = %v; want %v", got, want)
+	}
+}
+
+func TestDebugActiveEndpoints(t *testing.T) {
+	tstest.Parallel(t)
+	env := NewTestEnv(t)
+
+	n1 := NewTestNode(t, env)
+	d1 := n1.StartDaemon()
+	defer d1.MustCleanShutdown(t)
+	n2 := NewTestNode(t, env)
+	d2 := n2.StartDaemon()
+	defer d2.MustCleanShutdown(t)
+
+	n1.AwaitListening()
+	n2.AwaitListening()
+	n1.MustUp()
+	n2.MustUp()
+	n1.AwaitRunning()
+	n2.AwaitRunning()
+
+	n2Key := n2.MustStatus().Self.PublicKey
+	if err := tstest.WaitFor(10*time.Second, func() error {
+		if _, ok := n1.MustStatus().Peer[n2Key]; !ok {
+			return fmt.Errorf("n1 does not see n2 (%v) as a peer yet", n2Key)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := n1.LocalClient().DebugActiveEndpoints(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var peer *ipnstate.PeerActiveEndpoints
+	for i := range res.Peers {
+		if res.Peers[i].NodeKey == n2Key {
+			peer = &res.Peers[i]
+			break
+		}
+	}
+	if peer == nil {
+		t.Fatalf("n2 (%v) not in active-endpoints peers: %+v", n2Key, res.Peers)
+	}
+	if peer.Magicsock == nil {
+		t.Errorf("missing magicsock state for n2: %+v", peer)
+	}
+
+	// And the same via the CLI.
+	cmd := n1.Tailscale("debug", "active-endpoints")
+	cmd.Stdout = nil // in case --verbose-tailscale was set
+	cmd.Stderr = nil // in case --verbose-tailscale was set
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("active-endpoints output:\n%s", out)
+	var res2 ipnstate.DebugActiveEndpoints
+	if err := json.Unmarshal(out, &res2); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(res2.Peers), len(res.Peers); got != want {
+		t.Errorf("CLI reported %d peers; LocalAPI reported %d", got, want)
 	}
 }
 

--- a/wgengine/activeendpoints.go
+++ b/wgengine/activeendpoints.go
@@ -1,0 +1,56 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package wgengine
+
+import (
+	"errors"
+
+	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/wgengine/magicsock"
+	"tailscale.com/wgengine/wgint"
+)
+
+// DebugActiveEndpoints implements [Engine].
+//
+// The set of peers is enumerated from magicsock's peer map (which mirrors the
+// netmap); for each, the corresponding wireguard-go peer is looked up without
+// triggering wireguard-go's lazy on-demand peer creation. wgcfg.ReconfigDevice
+// keeps the device's peers a subset of the configured (netmap) peers, so this
+// covers every wireguard-go peer that can exist.
+func (e *userspaceEngine) DebugActiveEndpoints() (*ipnstate.DebugActiveEndpoints, error) {
+	peers := e.magicConn.DebugActiveEndpoints()
+
+	e.wgLock.Lock()
+	dev := e.wgdev
+	e.wgLock.Unlock()
+	if dev == nil {
+		return nil, errors.New("no wireguard-go device")
+	}
+	for i := range peers {
+		p := &peers[i]
+		// Use LookupActivePeer (not LookupPeer) to avoid lazily
+		// creating a wireguard-go peer for every netmap peer; absence
+		// is itself the signal reported by a nil WireGuard field.
+		wgp, ok := dev.LookupActivePeer(p.NodeKey.Raw32())
+		if !ok {
+			continue
+		}
+		wp := wgint.PeerOf(wgp)
+		st := &ipnstate.WireGuardPeerState{
+			LastHandshake: wp.LastHandshake(),
+			RxBytes:       wp.RxBytes(),
+			TxBytes:       wp.TxBytes(),
+		}
+		if ep := wp.Endpoint(); ep != nil {
+			st.Endpoint = ep.DstToString()
+			if magicsock.IsMagicsockEndpoint(ep) {
+				st.EndpointType = ipnstate.WireGuardEndpointTypeMagicsock
+			} else {
+				st.EndpointType = ipnstate.WireGuardEndpointTypeOther
+			}
+		}
+		p.WireGuard = st
+	}
+	return &ipnstate.DebugActiveEndpoints{Peers: peers}, nil
+}

--- a/wgengine/activeendpoints_test.go
+++ b/wgengine/activeendpoints_test.go
@@ -1,0 +1,128 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package wgengine
+
+import (
+	"encoding/json"
+	"net/netip"
+	"testing"
+
+	"github.com/tailscale/wireguard-go/device"
+	"tailscale.com/health"
+	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/net/dns"
+	"tailscale.com/net/netaddr"
+	"tailscale.com/tailcfg"
+	"tailscale.com/types/key"
+	"tailscale.com/types/netmap"
+	"tailscale.com/util/eventbus/eventbustest"
+	"tailscale.com/util/usermetric"
+	"tailscale.com/wgengine/router"
+	"tailscale.com/wgengine/wgcfg"
+)
+
+func TestDebugActiveEndpoints(t *testing.T) {
+	bus := eventbustest.NewBus(t)
+	ht := health.NewTracker(bus)
+	reg := new(usermetric.Registry)
+	e, err := NewFakeUserspaceEngine(t.Logf, 0, ht, reg, bus)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(e.Close)
+
+	const nodeHex = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	nk := nkFromHex(nodeHex)
+	dk := key.NewDisco().Public()
+	nm := &netmap.NetworkMap{
+		Peers: nodeViews([]*tailcfg.Node{
+			{
+				ID:       1,
+				Key:      nk,
+				DiscoKey: dk,
+			},
+		}),
+	}
+	cfg := &wgcfg.Config{
+		Peers: []wgcfg.Peer{
+			{
+				PublicKey: nk,
+				AllowedIPs: []netip.Prefix{
+					netip.PrefixFrom(netaddr.IPv4(100, 100, 99, 1), 32),
+				},
+			},
+		},
+	}
+	e.SetNetworkMap(nm)
+	// LocalBackend, not the engine, pushes the netmap's peers into
+	// magicsock; do the same here so magicsock knows about the peer.
+	ue := e.(*userspaceEngine)
+	ue.magicConn.SetNetworkMap(tailcfg.NodeView{}, nm.Peers)
+	if err := e.Reconfig(cfg, &router.Config{}, &dns.Config{}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Initially the peer should be known to magicsock, but wireguard-go
+	// should not have created its (lazily-created) peer yet.
+	res, err := e.DebugActiveEndpoints()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Peers) != 1 {
+		t.Fatalf("got %d peers; want 1", len(res.Peers))
+	}
+	p := res.Peers[0]
+	if p.NodeKey != nk {
+		t.Errorf("NodeKey = %v; want %v", p.NodeKey, nk)
+	}
+	if p.Magicsock == nil {
+		t.Error("Magicsock state missing; want present")
+	} else {
+		if p.Magicsock.IsWireGuardOnly {
+			t.Error("IsWireGuardOnly = true; want false for disco-capable peer")
+		}
+		if p.Magicsock.Expired {
+			t.Error("Expired = true; want false")
+		}
+	}
+	if want := dk.ShortString(); p.ShortDisco != want {
+		t.Errorf("ShortDisco = %q; want %q", p.ShortDisco, want)
+	}
+	if p.WireGuard != nil {
+		t.Errorf("WireGuard state = %+v; want nil (peer should not be created yet)", p.WireGuard)
+	}
+
+	// Force wireguard-go to create the peer, as it would upon first
+	// packet exchanged with it, and verify the WireGuard state appears
+	// with a magicsock-managed endpoint.
+	if peer := ue.wgdev.LookupPeer(device.NoisePublicKey(nk.Raw32())); peer == nil {
+		t.Fatal("LookupPeer failed to create peer")
+	}
+	res, err = e.DebugActiveEndpoints()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Peers) != 1 {
+		t.Fatalf("got %d peers; want 1", len(res.Peers))
+	}
+	p = res.Peers[0]
+	if p.WireGuard == nil {
+		t.Fatal("WireGuard state missing; want present after peer creation")
+	}
+	if p.WireGuard.Endpoint != nodeHex {
+		t.Errorf("WireGuard.Endpoint = %q; want %q", p.WireGuard.Endpoint, nodeHex)
+	}
+	if p.WireGuard.EndpointType != ipnstate.WireGuardEndpointTypeMagicsock {
+		t.Errorf("WireGuard.EndpointType = %q; want %q", p.WireGuard.EndpointType, ipnstate.WireGuardEndpointTypeMagicsock)
+	}
+	if !p.WireGuard.LastHandshake.IsZero() {
+		t.Errorf("WireGuard.LastHandshake = %v; want zero", p.WireGuard.LastHandshake)
+	}
+
+	j, err := json.MarshalIndent(res, "", "\t")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("DebugActiveEndpoints JSON:\n%s", j)
+}

--- a/wgengine/magicsock/endpoint_test.go
+++ b/wgengine/magicsock/endpoint_test.go
@@ -687,3 +687,15 @@ func Test_endpoint_handlePongConnLocked(t *testing.T) {
 		})
 	}
 }
+
+func TestIsMagicsockEndpoint(t *testing.T) {
+	if !IsMagicsockEndpoint(&endpoint{}) {
+		t.Error("IsMagicsockEndpoint(*endpoint) = false; want true")
+	}
+	if IsMagicsockEndpoint(&lazyEndpoint{}) {
+		t.Error("IsMagicsockEndpoint(*lazyEndpoint) = true; want false")
+	}
+	if IsMagicsockEndpoint(nil) {
+		t.Error("IsMagicsockEndpoint(nil) = true; want false")
+	}
+}

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -1240,6 +1240,67 @@ func (c *Conn) GetEndpointChanges(peer tailcfg.NodeView) ([]EndpointChange, erro
 	return ep.debugUpdates.GetAll(), nil
 }
 
+// DebugActiveEndpoints returns debug information about the active dataplane
+// endpoint state of each peer known to magicsock, sorted by node key. Only
+// the magicsock-owned fields ([ipnstate.PeerActiveEndpoints].Magicsock and
+// peer identifiers) are populated; the WireGuard field is left nil for the
+// caller (the engine) to fill in.
+//
+// It is intended for debugging and tests only; see
+// [ipnstate.DebugActiveEndpoints].
+func (c *Conn) DebugActiveEndpoints() []ipnstate.PeerActiveEndpoints {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := mono.Now()
+	peers := make([]ipnstate.PeerActiveEndpoints, 0, len(c.peerMap.byNodeKey))
+	for nk, pi := range c.peerMap.byNodeKey {
+		de := pi.ep
+		st := &ipnstate.MagicsockEndpointState{
+			EpAddrCount: len(pi.epAddrs),
+			LastRecv:    de.lastRecvUDPAny.LoadAtomic().WallTime(),
+			LastRecvWG:  de.lastRecvWG.LoadAtomic().WallTime(),
+		}
+		de.mu.Lock()
+		if de.bestAddr.ap.IsValid() {
+			st.BestAddr = de.bestAddr.epAddr.String()
+			st.BestAddrTrusted = now.Before(de.trustBestAddrUntil)
+		}
+		st.BestAddrAt = de.bestAddrAt.WallTime()
+		st.TrustBestAddrUntil = de.trustBestAddrUntil.WallTime()
+		if de.derpAddr.IsValid() {
+			st.DERPAddr = de.derpAddr.String()
+			st.DERPRegion = int(de.derpAddr.Port())
+		}
+		st.LastSend = de.lastSendExt.WallTime()
+		st.LastFullPing = de.lastFullPing.WallTime()
+		st.IsWireGuardOnly = de.isWireguardOnly
+		st.Expired = de.expired
+		de.mu.Unlock()
+		peers = append(peers, ipnstate.PeerActiveEndpoints{
+			NodeKey:    nk,
+			ShortDisco: de.discoShort(),
+			Magicsock:  st,
+		})
+	}
+	slices.SortFunc(peers, func(a, b ipnstate.PeerActiveEndpoints) int {
+		return a.NodeKey.Compare(b.NodeKey)
+	})
+	return peers
+}
+
+// IsMagicsockEndpoint reports whether ep is a magicsock-managed peer endpoint:
+// the [conn.Endpoint] implementation magicsock hands to wireguard-go for a
+// known peer (whose DstToString is the peer's node public key in untyped hex).
+// It returns false for any other [conn.Endpoint] implementation, including
+// magicsock's internal just-in-time lazy endpoint (whose DstToString is an
+// "ip:port", optionally suffixed with ":vni:<n>"); wireguard-go holding such
+// an endpoint for a peer at rest may indicate a problem, e.g. a stale lazy
+// endpoint black-holing traffic (tailscale/tailscale#20082).
+func IsMagicsockEndpoint(ep conn.Endpoint) bool {
+	_, ok := ep.(*endpoint)
+	return ok
+}
+
 // DiscoPublicKey returns the discovery public key.
 func (c *Conn) DiscoPublicKey() key.DiscoPublic {
 	return c.discoAtomic.Public()

--- a/wgengine/wgengine.go
+++ b/wgengine/wgengine.go
@@ -105,6 +105,12 @@ type Engine interface {
 	// If the peer is not found, ok is false.
 	PeerByKey(key.NodePublic) (_ wgint.Peer, ok bool)
 
+	// DebugActiveEndpoints returns debug information about the active
+	// dataplane endpoint state of each peer, as seen by both magicsock
+	// and wireguard-go. It is intended for debugging and tests only; see
+	// [ipnstate.DebugActiveEndpoints].
+	DebugActiveEndpoints() (*ipnstate.DebugActiveEndpoints, error)
+
 	// Close shuts down this wireguard instance, remove any routes
 	// it added, etc. To bring it up again later, you'll need a
 	// new Engine.

--- a/wgengine/wgint/wgint.go
+++ b/wgengine/wgint/wgint.go
@@ -7,10 +7,12 @@ package wgint
 
 import (
 	"reflect"
+	"sync"
 	"sync/atomic"
 	"time"
 	"unsafe"
 
+	"github.com/tailscale/wireguard-go/conn"
 	"github.com/tailscale/wireguard-go/device"
 )
 
@@ -20,6 +22,8 @@ var (
 	offTxBytes   = getPeerStatsOffset("txBytes")
 
 	offHandshakeAttempts = getPeerHandshakeAttemptsOffset()
+
+	offEndpoint, offEndpointVal = getPeerEndpointOffsets()
 )
 
 func getPeerStatsOffset(name string) uintptr {
@@ -48,6 +52,42 @@ func getPeerHandshakeAttemptsOffset() uintptr {
 		panic("unexpected type " + g + " of field handshakeAttempts in device.Peer.timers; want " + w)
 	}
 	return field.Offset + field2.Offset
+}
+
+// getPeerEndpointOffsets returns the offset of the unexported
+// device.Peer.endpoint struct within device.Peer, and the offset of its "val"
+// field (the peer's current [conn.Endpoint]) within that struct. It verifies
+// that the struct's first field is its guarding [sync.Mutex] at offset zero.
+func getPeerEndpointOffsets() (epOff, valOff uintptr) {
+	peerType := reflect.TypeFor[device.Peer]()
+	field, ok := peerType.FieldByName("endpoint")
+	if !ok {
+		panic("no endpoint field in device.Peer")
+	}
+	if field.Type.Kind() != reflect.Struct || field.Type.NumField() == 0 {
+		panic("unexpected type " + field.Type.String() + " of field endpoint in device.Peer")
+	}
+	if mf := field.Type.Field(0); mf.Type != reflect.TypeFor[sync.Mutex]() || mf.Offset != 0 {
+		panic("first field of device.Peer.endpoint is not a sync.Mutex at offset 0")
+	}
+	valField, ok := field.Type.FieldByName("val")
+	if !ok {
+		panic("no val field in device.Peer.endpoint")
+	}
+	if g, w := valField.Type, reflect.TypeFor[conn.Endpoint](); g != w {
+		panic("unexpected type " + g.String() + " of field val in device.Peer.endpoint; want " + w.String())
+	}
+	return field.Offset, valField.Offset
+}
+
+// peerEndpoint returns the peer's current endpoint, holding its lock for the
+// read as wireguard-go's own accesses do.
+func peerEndpoint(peer *device.Peer) conn.Endpoint {
+	ep := unsafe.Add(unsafe.Pointer(peer), offEndpoint)
+	mu := (*sync.Mutex)(ep) // guards the endpoint struct; verified to be its first field
+	mu.Lock()
+	defer mu.Unlock()
+	return *(*conn.Endpoint)(unsafe.Add(ep, offEndpointVal))
 }
 
 // peerLastHandshakeNano returns the last handshake time in nanoseconds since the
@@ -105,4 +145,11 @@ func (p Peer) RxBytes() uint64 { return peerRxBytes(p.p) }
 // and after a successful handshake.
 func (p Peer) HandshakeAttempts() uint32 {
 	return peerHandshakeAttempts(p.p)
+}
+
+// Endpoint returns the peer's current endpoint: the [conn.Endpoint] that
+// wireguard-go uses to transmit to the peer. It is nil if wireguard-go holds
+// no endpoint for the peer.
+func (p Peer) Endpoint() conn.Endpoint {
+	return peerEndpoint(p.p)
 }

--- a/wgengine/wgint/wgint_test.go
+++ b/wgengine/wgint/wgint_test.go
@@ -4,6 +4,7 @@
 package wgint
 
 import (
+	"net/netip"
 	"testing"
 
 	"github.com/tailscale/wireguard-go/device"
@@ -23,4 +24,21 @@ func TestInternalOffsets(t *testing.T) {
 	if got := peerHandshakeAttempts(peer); got != 0 {
 		t.Errorf("PeerHandshakeAttempts = %v, want 0", got)
 	}
+	if got := peerEndpoint(peer); got != nil {
+		t.Errorf("peerEndpoint = %v, want nil", got)
+	}
+	peer.SetEndpointFromPacket(fakeEndpoint{})
+	if got := peerEndpoint(peer); got != (fakeEndpoint{}) {
+		t.Errorf("peerEndpoint = %v, want fakeEndpoint{}", got)
+	}
 }
+
+// fakeEndpoint is a no-op [conn.Endpoint].
+type fakeEndpoint struct{}
+
+func (fakeEndpoint) ClearSrc()           {}
+func (fakeEndpoint) SrcToString() string { return "" }
+func (fakeEndpoint) DstToString() string { return "" }
+func (fakeEndpoint) DstToBytes() []byte  { return nil }
+func (fakeEndpoint) DstIP() netip.Addr   { return netip.Addr{} }
+func (fakeEndpoint) SrcIP() netip.Addr   { return netip.Addr{} }


### PR DESCRIPTION
Add a debug facility that reports, per peer, the active dataplane endpoint state as seen by both magicsock and wireguard-go: magicsock's bestAddr (including relay VNI), whether it is currently trusted, the DERP fallback addr/home region, last send/recv (any and WireGuard-only) activity, full-ping time, WireGuard-only/expired flags, and peer map epAddr counts; plus whether a (lazily-created) wireguard-go peer currently exists, the endpoint it currently holds (string form plus a classification by concrete type: magicsock-managed vs other), and last handshake time and rx/tx byte counters.

wireguard-go can end up holding a stale magicsock lazy endpoint as a peer's TX endpoint, silently black-holing traffic (#20082). Debugging that class of issue previously required manual log spelunking. This surfaces the relevant state via a LocalAPI debug endpoint (debug-active-endpoints), a c2n endpoint (/debug/active-endpoints), and a CLI command (tailscale debug active-endpoints), so both humans and tests can assert a client is in the expected dataplane state.

The wireguard-go side is read via device.LookupActivePeer and wgint (which gains a mutex-guarded accessor for the peer's current conn.Endpoint, layout-checked like its existing stats accessors) rather than the UAPI text protocol, which we deliberately moved off of. Endpoint classification is a type assertion via a new magicsock.IsMagicsockEndpoint helper instead of string comparison.

Updates #20082

Change-Id: Id39cf6fa8255584d0316b44e0a18bf26dc2769a5