### PR TITLE
go.mod,wgengine/magicsock: pull wireguard-go fix for roaming endpoints

### DIFF
--- a/cmd/tta/wgserver_linux.go
+++ b/cmd/tta/wgserver_linux.go
@@ -15,11 +15,12 @@ import (
 	"os/exec"
 	"sync"
 
-	"github.com/tailscale/wireguard-go/conn"
-	"github.com/tailscale/wireguard-go/device"
-	"github.com/tailscale/wireguard-go/tun"
 	"golang.org/x/crypto/curve25519"
-	"tailscale.com/wgengine/wgcfg"
+
+	// Stock wireguard-go to simulate non-Tailscale peers.
+	extwgconn "golang.zx2c4.com/wireguard/conn"
+	extwgdevice "golang.zx2c4.com/wireguard/device"
+	extwgtun "golang.zx2c4.com/wireguard/tun"
 )
 
 func init() {
@@ -28,7 +29,7 @@ func init() {
 
 var (
 	wgServerMu  sync.Mutex
-	wgServerDev *device.Device // retained so the goroutines stay alive
+	wgServerDev *extwgdevice.Device // retained so the goroutines stay alive
 )
 
 // wgServerUpLinux brings up a userspace WireGuard interface on the local VM
@@ -98,16 +99,16 @@ func wgServerUpLinux(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tdev, err := tun.CreateTUN(name, device.DefaultMTU)
+	tdev, err := extwgtun.CreateTUN(name, extwgdevice.DefaultMTU)
 	if err != nil {
 		http.Error(w, "tun.CreateTUN: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	wglog := &device.Logger{
+	wglog := &extwgdevice.Logger{
 		Verbosef: func(string, ...any) {},
 		Errorf:   func(f string, a ...any) { log.Printf("wg-server: "+f, a...) },
 	}
-	dev := wgcfg.NewDevice(tdev, conn.NewDefaultBind(), wglog)
+	dev := extwgdevice.NewDevice(tdev, extwgconn.NewDefaultBind(), wglog)
 
 	uapi := fmt.Sprintf("private_key=%s\nlisten_port=%s\npublic_key=%s\nallowed_ip=%s\n",
 		hex.EncodeToString(priv[:]), listenPort,

--- a/flake.nix
+++ b/flake.nix
@@ -164,4 +164,4 @@
     });
   };
 }
-# nix-direnv cache busting line: sha256-wMxUTBC6kHoMn6SunVXN/QoE6CYFZc0fWHjD6VZj9U4=
+# nix-direnv cache busting line: sha256-ksHhfpx3ydAsTc6bD2vgZ8GMx+6OjXJlrb+HM+tFj8w=

--- a/flakehashes.json
+++ b/flakehashes.json
@@ -4,7 +4,7 @@
     "sri": "sha256-cY5yryX+p/xtoTv+WZEKFagiIl0OREHnJY1Bk5VpVVc="
   },
   "vendor": {
-    "goModSum": "sha256-uAzKq+TPVDZwlsbct/1wIYg9vahUmSJo1Di1TYL0L34=",
-    "sri": "sha256-wMxUTBC6kHoMn6SunVXN/QoE6CYFZc0fWHjD6VZj9U4="
+    "goModSum": "sha256-GKa57o9/Mze6Bk4Tj+B0mDxzBCmSd6vZxxNFwVkPsRc=",
+    "sri": "sha256-ksHhfpx3ydAsTc6bD2vgZ8GMx+6OjXJlrb+HM+tFj8w="
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -106,7 +106,7 @@ require (
 	github.com/tailscale/ts-gokrazy v0.0.0-20260429180033-fe741c6deb44
 	github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976
 	github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6
-	github.com/tailscale/wireguard-go v0.0.0-20260527010701-b48af7099cad
+	github.com/tailscale/wireguard-go v0.0.0-20260611164920-3aa5c949d6f7
 	github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e
 	github.com/tc-hib/winres v0.2.1
 	github.com/tcnksm/go-httpstat v0.2.0
@@ -145,6 +145,8 @@ require (
 )
 
 require github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 // indirect
+
+require golang.zx2c4.com/wireguard v0.0.0-20260522210424-ecfc5a8d5446
 
 require (
 	9fans.net/go v0.0.8-0.20250307142834-96bdba94b63f // indirect

--- a/go.sum
+++ b/go.sum
@@ -1174,8 +1174,8 @@ github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976 h1:U
 github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976/go.mod h1:agQPE6y6ldqCOui2gkIh7ZMztTkIQKH049tv8siLuNQ=
 github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6 h1:l10Gi6w9jxvinoiq15g8OToDdASBni4CyJOdHY1Hr8M=
 github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6/go.mod h1:ZXRML051h7o4OcI0d3AaILDIad/Xw0IkXaHM17dic1Y=
-github.com/tailscale/wireguard-go v0.0.0-20260527010701-b48af7099cad h1:Ky26FR5yZ5IKEB0xtm5A8xSTb06ImY7kxBFrvgOmJSg=
-github.com/tailscale/wireguard-go v0.0.0-20260527010701-b48af7099cad/go.mod h1:6SerzcvHWQchKO2BfNdmquA77CHSECZuFl+D9fp4RnI=
+github.com/tailscale/wireguard-go v0.0.0-20260611164920-3aa5c949d6f7 h1:vaSUkHrw9kuJjqY27sOZfcUUrJvd2rDVca2PePyMeD4=
+github.com/tailscale/wireguard-go v0.0.0-20260611164920-3aa5c949d6f7/go.mod h1:6SerzcvHWQchKO2BfNdmquA77CHSECZuFl+D9fp4RnI=
 github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e h1:zOGKqN5D5hHhiYUp091JqK7DPCqSARyUfduhGUY8Bek=
 github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e/go.mod h1:orPd6JZXXRyuDusYilywte7k094d7dycXXU5YnWsrwg=
 github.com/tc-hib/winres v0.2.1 h1:YDE0FiP0VmtRaDn7+aaChp1KiF4owBiJa5l964l5ujA=
@@ -1623,6 +1623,8 @@ golang.org/x/xerrors v0.0.0-20240716161551-93cc26a95ae9 h1:LLhsEBxRTBLuKlQxFBYUO
 golang.org/x/xerrors v0.0.0-20240716161551-93cc26a95ae9/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=
 golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 h1:B82qJJgjvYKsXS9jeunTOisW56dUokqW/FOteYJJ/yg=
 golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2/go.mod h1:deeaetjYA+DHMHg+sMSMI58GrEteJUUzzw7en6TJQcI=
+golang.zx2c4.com/wireguard v0.0.0-20260522210424-ecfc5a8d5446 h1:cqHQ3AycTHvM2R7ikgyX57D+XvtcSnGylsLkOVhta/w=
+golang.zx2c4.com/wireguard v0.0.0-20260522210424-ecfc5a8d5446/go.mod h1:rpwXGsirqLqN2L0JDJQlwOboGHmptD5ZD6T2VmcqhTw=
 golang.zx2c4.com/wireguard/windows v0.5.3 h1:On6j2Rpn3OEMXqBq00QEDC7bWSZrPIHKIus8eIuExIE=
 golang.zx2c4.com/wireguard/windows v0.5.3/go.mod h1:9TEe8TJmtwyQebdFwAkEWOPr3prrtqm+REGFifP60hI=
 gomodules.xyz/jsonpatch/v2 v2.4.0 h1:Ci3iUJyx9UeRx7CeFN8ARgGbkESwJK+KB9lLcWxY/Zw=

--- a/shell.nix
+++ b/shell.nix
@@ -16,4 +16,4 @@
 ) {
   src =  ./.;
 }).shellNix
-# nix-direnv cache busting line: sha256-wMxUTBC6kHoMn6SunVXN/QoE6CYFZc0fWHjD6VZj9U4=
+# nix-direnv cache busting line: sha256-ksHhfpx3ydAsTc6bD2vgZ8GMx+6OjXJlrb+HM+tFj8w=

--- a/util/linuxfw/fake_netfilter.go
+++ b/util/linuxfw/fake_netfilter.go
@@ -94,8 +94,8 @@ func (f *FakeNetfilterRunner) ClampMSSToPMTU(tun string, addr netip.Addr) error 
 func (f *FakeNetfilterRunner) GetClampedAddrs() []netip.Addr {
 	return f.clampedAddrs
 }
-func (f *FakeNetfilterRunner) AddMagicsockPortRule(port uint16, network string) error   { return nil }
-func (f *FakeNetfilterRunner) DelMagicsockPortRule(port uint16, network string) error   { return nil }
+func (f *FakeNetfilterRunner) AddMagicsockPortRule(port uint16, network string) error { return nil }
+func (f *FakeNetfilterRunner) DelMagicsockPortRule(port uint16, network string) error { return nil }
 func (f *FakeNetfilterRunner) DeletePortMapRuleForSvc(svc, tun string, targetIP netip.Addr, pm PortMap) error {
 	return nil
 }

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -39,6 +39,9 @@ import (
 	"go4.org/mem"
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv4"
+	extwgconn "golang.zx2c4.com/wireguard/conn"
+	extwgdevice "golang.zx2c4.com/wireguard/device"
+	extwgtest "golang.zx2c4.com/wireguard/tun/tuntest"
 	"tailscale.com/control/controlknobs"
 	"tailscale.com/derp/derpserver"
 	"tailscale.com/disco"
@@ -2267,17 +2270,20 @@ func TestSetNetworkMapWithNoPeers(t *testing.T) {
 }
 
 // newWireguard starts up a new wireguard-go device attached to a test tun, and
-// returns the device, tun and endpoint port. To add peers call device.IpcSet with UAPI instructions.
-func newWireguard(t *testing.T, uapi string, aips []netip.Prefix) (*device.Device, *tuntest.ChannelTUN, uint16) {
-	wgtun := tuntest.NewChannelTUN()
+// returns the device, tun and endpoint port. To add peers call device.IpcSet
+// with UAPI instructions.
+//
+// This uses stock wireguard-go to simulate a non-Tailscale peer.
+func newWireguard(t *testing.T, uapi string, aips []netip.Prefix) (*extwgdevice.Device, *extwgtest.ChannelTUN, uint16) {
+	wgtun := extwgtest.NewChannelTUN()
 	wglogf := func(f string, args ...any) {
 		t.Logf("wg-go: "+f, args...)
 	}
-	wglog := device.Logger{
+	wglog := extwgdevice.Logger{
 		Verbosef: func(string, ...any) {},
 		Errorf:   wglogf,
 	}
-	wgdev := wgcfg.NewDevice(wgtun.TUN(), wgconn.NewDefaultBind(), &wglog)
+	wgdev := extwgdevice.NewDevice(wgtun.TUN(), extwgconn.NewDefaultBind(), &wglog)
 
 	if err := wgdev.IpcSet(uapi); err != nil {
 		t.Fatal(err)

--- a/wgengine/wgcfg/device.go
+++ b/wgengine/wgcfg/device.go
@@ -15,9 +15,7 @@ import (
 
 // NewDevice returns a wireguard-go Device configured for Tailscale use.
 func NewDevice(tunDev tun.Device, bind conn.Bind, logger *device.Logger) *device.Device {
-	ret := device.NewDevice(tunDev, bind, logger)
-	ret.DisableSomeRoamingForBrokenMobileSemantics()
-	return ret
+	return device.NewDevice(tunDev, bind, logger)
 }
 
 // ReconfigDevice replaces the existing device configuration with cfg.


### PR DESCRIPTION
Pins wireguard-go to tailscale/wireguard-go@3aa5c94,
a standalone branch release-1.100 with the cherry-picked patch.

Not to be merged in main, a mirror PR is created that pins main to all
new changes including the fix.

Pulls stock wireguard-go for non-tailscale simulation in tests,
to use its endpoint discovery mechanism.

Updates #20082
Mirrors #20118