### PR TITLE
words: add 'cat' to the list of scales

### DIFF
--- a/words/scales.txt
+++ b/words/scales.txt
@@ -510,3 +510,4 @@ luma
 spectrum
 roygbiv
 pride
+cat


### PR DESCRIPTION
"cat" is a common usage shortening of "category" when referring to either ethernet cable specifications or the Saffir-Simpson Hurricane Wind Scale.