### PR TITLE
tstest/natlab/vmtest: wait for node to have endpoints before testing

### DIFF
--- a/tstest/natlab/vmtest/vmtest.go
+++ b/tstest/natlab/vmtest/vmtest.go
@@ -32,6 +32,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -52,6 +53,7 @@ import (
 	"tailscale.com/tstest/integration/testcontrol"
 	"tailscale.com/tstest/natlab/vnet"
 	"tailscale.com/types/key"
+	"tailscale.com/types/netmap"
 	"tailscale.com/util/mak"
 )
 
@@ -2126,4 +2128,24 @@ func (e *Env) PingExpect(from, to *Node, wantRoute PingRoute, timeout time.Durat
 // NumNodes returns the current number of nodes configured in the env.
 func (env *Env) NumNodes() int {
 	return len(env.nodes)
+}
+
+func (e *Env) HasEndpointsForOther(probe, other *Node) error {
+	e.t.Helper()
+
+	nm, err := local.GetDebugResultJSON[netmap.NetworkMap](e.t.Context(), probe.Agent().Client, "current-netmap")
+	if err != nil {
+		return fmt.Errorf("[%s] unable to get netmap: %q", probe.name, err)
+	}
+	otherKey := e.Status(other).Self.PublicKey
+
+	i := slices.IndexFunc(nm.Peers, func(p tailcfg.NodeView) bool {
+		return p.Key() == otherKey
+	})
+	if i < 0 {
+		return fmt.Errorf("[%s] peer %s not found", probe.name, other.name)
+	} else if nm.Peers[i].Endpoints().Len() == 0 {
+		return fmt.Errorf("[%s] no endpoints for peer %s", probe.name, other.name)
+	}
+	return nil
 }

--- a/tstest/natlab/vmtest/vmtest_test.go
+++ b/tstest/natlab/vmtest/vmtest_test.go
@@ -1156,18 +1156,9 @@ func TestCachedNetmapAfterRestart(t *testing.T) {
 //
 // The test has two modes, pinging from the offline node to the online node,
 // and pinging from the online node to the offline node.
-//
-// TODO(cmol): The online -> offline test is skipped for now (as of 2026-06-12).
-// The TSMP disco key exchange currently relies on disco ping messages being
-// sent. These will however not be sent if there is not endpoints on the online
-// node which is possible in the event where a node has registered but not
-// finished STUN.
 func TestDirectConnectionWithCachedNetmapOnOneNode(t *testing.T) {
 	for _, testPingFrom := range []string{"offline", "online"} {
 		t.Run(fmt.Sprintf("ping_from_%s", testPingFrom), func(t *testing.T) {
-			if testPingFrom == "online" {
-				t.Skip("https://github.com/tailscale/tailscale/issues/19843")
-			}
 			env := vmtest.New(t)
 
 			aNet := env.AddNetwork("1.0.0.1", "192.168.1.1/24", vnet.EasyNAT)
@@ -1187,6 +1178,7 @@ func TestDirectConnectionWithCachedNetmapOnOneNode(t *testing.T) {
 			}
 			checkInitialMetrics := env.AddStep("Check initial client metrics")
 			cutControlStep := env.AddStep("Cut control server access from a")
+			verifyEndpointsStep := env.AddStep("Wait for endpoints")
 			restartStep := env.AddStep("Restart tailscaled on a")
 			tsmpPingStep := env.AddStep(fmt.Sprintf("%s TSMP (cached netmap, no control)", pStr))
 			discoPingStep := env.AddStep(fmt.Sprintf("%s Disco (want Direct)", pStr))
@@ -1210,6 +1202,22 @@ func TestDirectConnectionWithCachedNetmapOnOneNode(t *testing.T) {
 				}
 			})
 			cutControlStep.End(nil)
+
+			// Wait for endpoints to show up on both nodes to ensure disco pings can
+			// be sent.
+			verifyEndpointsStep.Begin()
+			if err := tstest.WaitFor(15*time.Second, func() error {
+				if err := env.HasEndpointsForOther(a, b); err != nil {
+					return err
+				}
+				if err := env.HasEndpointsForOther(b, a); err != nil {
+					return err
+				}
+				return nil
+			}); err != nil {
+				verifyEndpointsStep.Fatalf("got no endpoints %v", err)
+			}
+			verifyEndpointsStep.End(nil)
 
 			restartStep.Begin()
 			env.RestartTailscaled(a)


### PR DESCRIPTION
WIP, DO NOT MERGE.

Todo:
 - Fix caching on delta updates.
 - Update the double netmap caching offline test to do the same.

The node would restart before it had valid endpoints for the other node
leaving the test to be flakey. Wait for the endpoints to be propagated
to all nodes before restarting.

Updates #19843

Depends on #20111

Signed-off-by: Claus Lensbøl <claus@tailscale.com>
