### PR TITLE
tstest/natlab/vmtest: skipe tests marked as flakey

### DIFF
--- a/tstest/natlab/vmtest/vmtest_test.go
+++ b/tstest/natlab/vmtest/vmtest_test.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"tailscale.com/client/local"
-	"tailscale.com/cmd/testwrapper/flakytest"
 	"tailscale.com/ipn"
 	"tailscale.com/net/udprelay/status"
 	"tailscale.com/tailcfg"
@@ -1158,15 +1157,16 @@ func TestCachedNetmapAfterRestart(t *testing.T) {
 // The test has two modes, pinging from the offline node to the online node,
 // and pinging from the online node to the offline node.
 //
-// TODO(cmol): The online -> offline test is flakey for now. The TSMP disco
-// key exchange currently relies on disco ping messages being sent. These will
-// however not be sent if there is not endpoints on the online node which is
-// possible in the event where a node has registered but not finished STUN.
+// TODO(cmol): The online -> offline test is skipped for now (as of 2026-06-12).
+// The TSMP disco key exchange currently relies on disco ping messages being
+// sent. These will however not be sent if there is not endpoints on the online
+// node which is possible in the event where a node has registered but not
+// finished STUN.
 func TestDirectConnectionWithCachedNetmapOnOneNode(t *testing.T) {
 	for _, testPingFrom := range []string{"offline", "online"} {
 		t.Run(fmt.Sprintf("ping_from_%s", testPingFrom), func(t *testing.T) {
 			if testPingFrom == "online" {
-				flakytest.Mark(t, "https://github.com/tailscale/tailscale/issues/19843")
+				t.Skip("https://github.com/tailscale/tailscale/issues/19843")
 			}
 			env := vmtest.New(t)
 
@@ -1252,12 +1252,12 @@ func TestDirectConnectionWithCachedNetmapOnOneNode(t *testing.T) {
 // WireGuard tunnel after both restarted while the control server is
 // unreachable. After restart one node must use only its on-disk cached
 // netmaps to re-connect and ping the other node.
-// TODO(cmol): The test is flakey for now. The TSMP disco key exchange
-// currently relies on disco ping messages being sent. These will however not
-// be sent if there is not endpoints on the online node which is possible in
-// the event where a node has registered but not finished STUN.
+// TODO(cmol): The test is skipped for now (as of 2026-06-12). The TSMP disco
+// key exchange currently relies on disco ping messages being sent. These will
+// however not be sent if there is not endpoints on the online node which is
+// possible in the event where a node has registered but not finished STUN.
 func TestDirectConnectionWithCachedNetmapOnTwoNodes(t *testing.T) {
-	flakytest.Mark(t, "https://github.com/tailscale/tailscale/issues/19843")
+	t.Skip("https://github.com/tailscale/tailscale/issues/19843")
 	env := vmtest.New(t)
 
 	aNet := env.AddNetwork("1.0.0.1", "192.168.1.1/24", vnet.EasyNAT)


### PR DESCRIPTION
Flakeytest seems to not work on vmtest. We have a few PRs that will fix
the problem on these tests, so skip to unblock.

Updates #19843

Signed-off-by: Claus Lensbøl <claus@tailscale.com>
