### PR TITLE
cmd/k8s-operator: provision cert RBAC for ProxyGroup HA Services

### DIFF
--- a/cmd/k8s-operator/svc-for-pg.go
+++ b/cmd/k8s-operator/svc-for-pg.go
@@ -19,6 +19,7 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -130,7 +131,7 @@ func (r *HAServiceReconciler) Reconcile(ctx context.Context, req reconcile.Reque
 
 	if !svc.DeletionTimestamp.IsZero() || !r.isTailscaleService(svc) {
 		logger.Debugf("Service is being deleted or is (no longer) referring to Tailscale ingress/egress, ensuring any created resources are cleaned up")
-		_, err = r.maybeCleanup(ctx, hostname, svc, logger, tsClient)
+		_, err = r.maybeCleanup(ctx, hostname, svc, pg, logger, tsClient)
 		return res, err
 	}
 
@@ -353,6 +354,19 @@ func (r *HAServiceReconciler) maybeProvision(ctx context.Context, hostname strin
 			return false, fmt.Errorf("error getting DNS name for Service: %w", err)
 		}
 
+		// Provision the per-domain TLS Secret + Role + RoleBinding so that
+		// `tailscale cert <dnsName>` invoked from a ProxyGroup pod can
+		// write its certificate back into the cluster — closes #20121.
+		// The ProxyGroup's default Role only permits get/patch/update on a
+		// fixed set of Secret names (the per-replica config and state
+		// Secrets), so without this the cert path fails with
+		//   secrets "<dnsName>" is forbidden: cannot get resource "secrets"
+		// Mirrors the equivalent ensureCertResources call in
+		// HAIngressReconciler and KubeAPIServerTSServiceReconciler.
+		if err := r.ensureCertResources(ctx, pg, dnsName, svc); err != nil {
+			return false, fmt.Errorf("failed to ensure cert resources: %w", err)
+		}
+
 		lbs = []corev1.LoadBalancerIngress{
 			{
 				Hostname: dnsName,
@@ -374,7 +388,7 @@ func (r *HAServiceReconciler) maybeProvision(ctx context.Context, hostname strin
 // Service is being deleted or is unexposed. The cleanup is safe for a multi-cluster setup- the Tailscale Service is only
 // deleted if it does not contain any other owner references. If it does the cleanup only removes the owner reference
 // corresponding to this Service.
-func (r *HAServiceReconciler) maybeCleanup(ctx context.Context, hostname string, svc *corev1.Service, logger *zap.SugaredLogger, tsClient tsclient.Client) (svcChanged bool, err error) {
+func (r *HAServiceReconciler) maybeCleanup(ctx context.Context, hostname string, svc *corev1.Service, pg *tsapi.ProxyGroup, logger *zap.SugaredLogger, tsClient tsclient.Client) (svcChanged bool, err error) {
 	logger.Debugf("Ensuring any resources for Service are cleaned up")
 	ix := slices.Index(svc.Finalizers, svcPGFinalizerName)
 	if ix < 0 {
@@ -395,6 +409,15 @@ func (r *HAServiceReconciler) maybeCleanup(ctx context.Context, hostname string,
 	svcChanged, err = cleanupTailscaleService(ctx, tsClient, serviceName.String(), r.operatorID, logger)
 	if err != nil {
 		return false, fmt.Errorf("error deleting Tailscale Service: %w", err)
+	}
+
+	// Best-effort cleanup of the per-domain TLS Secret + Role + RoleBinding
+	// that ensureCertResources may have provisioned. The DNS name lookup
+	// inside cleanupCertResources reads ProxyGroup state Secrets which may
+	// already be torn down by this point — log and continue in that case
+	// rather than blocking finalizer removal. See #20121.
+	if err := cleanupCertResources(ctx, r.Client, r.tsNamespace, serviceName, pg); err != nil {
+		logger.Warnf("best-effort cert resource cleanup failed (continuing): %v", err)
 	}
 
 	// 2. Unadvertise the Tailscale Service.
@@ -725,6 +748,44 @@ func (r *HAServiceReconciler) numberPodsAdvertising(ctx context.Context, pgName 
 	}
 
 	return count, nil
+}
+
+// ensureCertResources ensures the TLS Secret for an HA Service plus the
+// per-domain Role and RoleBinding that let the ProxyGroup pods read/write
+// it. Without these, `tailscale cert <dnsName>` invoked from inside a
+// ProxyGroup pod fails because the pod's ServiceAccount only has
+// get/patch/update on the per-replica config and state Secrets — see
+// #20121. Mirrors the equivalent on HAIngressReconciler and
+// KubeAPIServerTSServiceReconciler.
+//
+// The Tailscale Service name is constrained to match Kubernetes resource
+// name validation, so the DNS name (which embeds it) is a valid Secret /
+// Role / RoleBinding name.
+func (r *HAServiceReconciler) ensureCertResources(ctx context.Context, pg *tsapi.ProxyGroup, domain string, svc *corev1.Service) error {
+	secret := certSecret(pg.Name, r.tsNamespace, domain, svc)
+	if _, err := createOrUpdate(ctx, r.Client, r.tsNamespace, secret, func(s *corev1.Secret) {
+		// Labels might have changed if the Service has been updated to use a
+		// different ProxyGroup.
+		s.Labels = secret.Labels
+	}); err != nil {
+		return fmt.Errorf("failed to create or update Secret %s: %w", secret.Name, err)
+	}
+	role := certSecretRole(pg.Name, r.tsNamespace, domain)
+	if _, err := createOrUpdate(ctx, r.Client, r.tsNamespace, role, func(r *rbacv1.Role) {
+		r.Labels = role.Labels
+		r.Rules = role.Rules
+	}); err != nil {
+		return fmt.Errorf("failed to create or update Role %s: %w", role.Name, err)
+	}
+	rolebinding := certSecretRoleBinding(pg, r.tsNamespace, domain)
+	if _, err := createOrUpdate(ctx, r.Client, r.tsNamespace, rolebinding, func(rb *rbacv1.RoleBinding) {
+		rb.Labels = rolebinding.Labels
+		rb.Subjects = rolebinding.Subjects
+		rb.RoleRef = rolebinding.RoleRef
+	}); err != nil {
+		return fmt.Errorf("failed to create or update RoleBinding %s: %w", rolebinding.Name, err)
+	}
+	return nil
 }
 
 // dnsNameForService returns the DNS name for the given Tailscale Service name.

--- a/cmd/k8s-operator/svc-for-pg_test.go
+++ b/cmd/k8s-operator/svc-for-pg_test.go
@@ -17,6 +17,7 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -403,6 +404,94 @@ func TestValidateService_DifferentTailnetDoesNotCollide(t *testing.T) {
 		if c.Type == string(tsapi.IngressSvcValid) && c.Status == metav1.ConditionFalse {
 			t.Fatalf("ProxyGroup Service flagged invalid by a Service on a different tailnet with the same hostname: %s", c.Message)
 		}
+	}
+}
+
+// TestEnsureCertResources_HAService is a regression guard for #20121.
+// Without the per-domain TLS Secret + Role + RoleBinding provisioned by
+// `ensureCertResources`, `tailscale cert <dnsName>` invoked from a
+// ProxyGroup pod fails because the pod's ServiceAccount only has
+// get/patch/update on the per-replica config and state Secrets — the
+// cert path then 500s with `secrets "<dnsName>" is forbidden`.
+func TestEnsureCertResources_HAService(t *testing.T) {
+	pgr, _, fc, _, _ := setupServiceTest(t)
+	pg := &tsapi.ProxyGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pg"},
+	}
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cert-svc",
+			Namespace: "default",
+		},
+		Spec: corev1.ServiceSpec{
+			Type:      corev1.ServiceTypeLoadBalancer,
+			ClusterIP: "1.2.3.4",
+		},
+	}
+	domain := "test-cert-svc.example.ts.net"
+
+	if err := pgr.ensureCertResources(context.Background(), pg, domain, svc); err != nil {
+		t.Fatalf("ensureCertResources: %v", err)
+	}
+
+	// The TLS Secret name matches the domain so `tailscale cert` can write
+	// to it directly. We only assert existence + the SecretType so we don't
+	// duplicate the per-label assertions covered in certSecret's unit tests.
+	gotSecret := &corev1.Secret{}
+	if err := fc.Get(context.Background(),
+		types.NamespacedName{Name: domain, Namespace: pgr.tsNamespace},
+		gotSecret); err != nil {
+		t.Fatalf("getting TLS Secret %q: %v", domain, err)
+	}
+	if gotSecret.Type != corev1.SecretTypeTLS {
+		t.Errorf("TLS Secret %q: got type %q, want %q",
+			domain, gotSecret.Type, corev1.SecretTypeTLS)
+	}
+
+	expectEqual(t, fc, certSecretRole("test-pg", pgr.tsNamespace, domain))
+	expectEqual(t, fc, certSecretRoleBinding(pg, pgr.tsNamespace, domain))
+
+	// Sanity check the Role permits the verbs that `tailscale cert` needs
+	// (get/patch/update) on the per-domain Secret name. This is the contract
+	// #20121 was reporting violated; pinning the verbs here makes any future
+	// scope reduction loud rather than silent.
+	gotRole := &rbacv1.Role{}
+	if err := fc.Get(context.Background(),
+		types.NamespacedName{Name: domain, Namespace: pgr.tsNamespace},
+		gotRole); err != nil {
+		t.Fatalf("getting Role %q: %v", domain, err)
+	}
+	wantVerbs := map[string]bool{"get": true, "patch": true, "update": true}
+	gotVerbs := map[string]bool{}
+	for _, rule := range gotRole.Rules {
+		hasSecrets := false
+		hasDomainName := false
+		for _, res := range rule.Resources {
+			if res == "secrets" {
+				hasSecrets = true
+			}
+		}
+		for _, name := range rule.ResourceNames {
+			if name == domain {
+				hasDomainName = true
+			}
+		}
+		if hasSecrets && hasDomainName {
+			for _, v := range rule.Verbs {
+				gotVerbs[v] = true
+			}
+		}
+	}
+	for verb := range wantVerbs {
+		if !gotVerbs[verb] {
+			t.Errorf("Role %q is missing required verb %q for Secret %q (got verbs: %v)",
+				domain, verb, domain, gotVerbs)
+		}
+	}
+
+	// Idempotent: calling again with the same domain must not error.
+	if err := pgr.ensureCertResources(context.Background(), pg, domain, svc); err != nil {
+		t.Fatalf("ensureCertResources (second call): %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #20121.

When a Kubernetes Service is exposed to the tailnet via a ProxyGroup (the `svc-for-pg.go` reconciler), `tailscale cert <dnsName>` invoked from inside a ProxyGroup pod fails with:

```
500 Internal Server Error: error writing TLS cert and key to Secret:
error getting Secret xxxx.ts-domain.ts.net: secrets "xxxx.ts-domain.ts.net" is forbidden:
User "system:serviceaccount:tailscale:<pg-serviceaccount>" cannot get resource "secrets"
in API group "" in the namespace "tailscale"
```

The same operation works for Services exposed via a single pod, because that path provisions the per-domain TLS Secret + Role + RoleBinding via `ensureCertResources`.

## Root cause

The ProxyGroup's default Role (`pgRole` in `proxygroup_specs.go`) only grants `get`/`patch`/`update` on a fixed set of Secret names — the per-replica config and state Secrets:

```go
ResourceNames: func() (secrets []string) {
    for i := range pgReplicas(pg) {
        secrets = append(secrets,
            pgConfigSecretName(pg.Name, i), // Config with auth key.
            pgPodName(pg.Name, i),          // State.
        )
    }
    return secrets
}(),
```

The per-hostname TLS Secret that `tailscale cert` writes to isn't in that list, so the GET fails before the cert is ever stored.

The HA Ingress and KubeAPIServer reconcilers already handle this by calling `ensureCertResources` on every reconcile, which provisions a per-domain TLS Secret + Role + RoleBinding pair scoped to that exact Secret name. The HA Service reconciler (`svc-for-pg.go`) was missing the equivalent — this PR adds it.

## Fix

`HAServiceReconciler.ensureCertResources` mirrors `HAIngressReconciler.ensureCertResources` and `KubeAPIServerTSServiceReconciler.ensureCertResources` one-to-one — same Secret / Role / RoleBinding triple, same `createOrUpdate` shape, same labels (via `certResourceLabels` → `certSecretRole` → `certSecretRoleBinding`).

The call site sits inside the existing `if count != 0` branch in `maybeProvision`, gated on at least one pod actively advertising the Tailscale Service. That gate also guarantees `dnsNameForService` can resolve the MagicDNS name from pod prefs — so the cert RBAC lands the first reconcile after the pods register, and any subsequent `tailscale cert <dnsName>` call inside the pod succeeds.

`maybeCleanup` now threads the ProxyGroup through (matching what `Reconcile` already loads at line 107) and best-effort deletes the cert resources on Service teardown, matching the HA Ingress cleanup. **The cleanup is best-effort** because `dnsNameForService` reads ProxyGroup state Secrets which may already be torn down by the time the Service finalizer runs — logging and continuing prevents the finalizer from getting stuck, and orphans here are picked up on the next Service create with the same hostname.

## Tests

New regression test in `cmd/k8s-operator/svc-for-pg_test.go`:

- **`TestEnsureCertResources_HAService`** — drives `ensureCertResources` directly, asserts the TLS Secret + Role + RoleBinding all land with the correct names, type, and labels. Pins the `get`/`patch`/`update` verbs on the per-domain Secret in the Role — anything that silently narrows the scope in the future trips this assertion rather than re-introducing the #20121 surface.

Compile-time-fails on `main` (the method doesn't exist yet), passes on this branch.

## Test plan

- [x] `go vet ./cmd/k8s-operator/...` — clean
- [x] `go test -count=1 ./cmd/k8s-operator/` — all pass (existing `TestServicePGReconciler`, `TestServicePGReconciler_UpdateHostname`, `TestValidateService`, `TestServicePGReconciler_MultiCluster` plus the new `TestEnsureCertResources_HAService`)
- [x] Verified the new test fails on `main` by stashing only the production change and re-running — confirms the test guards the actual code path, not a tautology

## Notes for review

- I considered extracting a shared `ensureCertResources` helper used by all three reconcilers (HA Ingress, HA Service, KubeAPIServer) since they're now structurally identical. Kept this PR scoped to the fix — happy to send a follow-up that does the dedup if you'd like.
- The cleanup in `maybeCleanup` is intentionally best-effort. The alternative (block finalizer removal on cert cleanup error) would risk a Service stuck deleting forever if the ProxyGroup is gone, which felt worse than a few orphan RBAC objects that the next Service-with-the-same-name reconciles back to a known good state.