### PR TITLE
ipn/ipnlocal: remove logs for peer delta cache updates

### DIFF
--- a/ipn/ipnlocal/diskcache.go
+++ b/ipn/ipnlocal/diskcache.go
@@ -32,7 +32,7 @@ func (b *LocalBackend) writePeerDeltaToDiskLocked(update []tailcfg.NodeView, rem
 	} else if err := b.ensureDiskCacheLocked(); err != nil {
 		return err
 	}
-	b.logf("updating netmap peers in disk cache (%d to update, %d to remove)", len(update), len(remove))
+	// Do not log this, we get deltas all the time and it's very noisy.
 	return b.diskCache.cache.UpdatePeers(b.currentNode().Context(), update, remove)
 }
 


### PR DESCRIPTION
Added in #20111, but it is too noisy under real load to be useful.

Updates #12542

Change-Id: Ib99a8966ade0bfa4281fccc057249819cdcdfe83
Signed-off-by: M. J. Fromberger <fromberger@tailscale.com>
