### PR TITLE
types/geo: add support for ScalarMarshaler and ScalarUnmarshaler

### DIFF
--- a/types/geo/point.go
+++ b/types/geo/point.go
@@ -166,7 +166,7 @@ func (p Point) AppendBinary(b []byte) ([]byte, error) {
 	return b, nil
 }
 
-// MarshalBinary implements [encoding.BinaryMarshaller]. The output matches that
+// MarshalBinary implements [encoding.BinaryMarshaler]. The output matches that
 // of calling [Point.AppendBinary].
 func (p Point) MarshalBinary() ([]byte, error) {
 	var b [8]byte
@@ -223,7 +223,7 @@ func (p Point) AppendText(b []byte) ([]byte, error) {
 	return b, nil
 }
 
-// MarshalText implements [encoding.TextMarshaller]. The output matches that
+// MarshalText implements [encoding.TextMarshaler]. The output matches that
 // of calling [Point.AppendText].
 func (p Point) MarshalText() ([]byte, error) {
 	var b [8]byte

--- a/types/geo/point.go
+++ b/types/geo/point.go
@@ -230,16 +230,34 @@ func (p Point) MarshalText() ([]byte, error) {
 	return p.AppendText(b[:0])
 }
 
-// MarshalUint64 produces the same output as MashalBinary, encoded in a uint64.
-func (p Point) MarshalUint64() (uint64, error) {
+// MarshalScalar implements [encoding.ScalarMarshaler].
+// It produces the same output as MashalBinary, encoded in a uint64.
+func (p Point) MarshalScalar() (uint64, error) {
 	b, err := p.MarshalBinary()
 	return binary.NativeEndian.Uint64(b), err
 }
 
-// UnmarshalUint64 expects input formatted by MarshalUint64.
-func (p *Point) UnmarshalUint64(v uint64) error {
+// UnmarshalScalar implements [encoding.ScalarUnmarshaler].
+// It expects input formatted by MarshalScalar.
+func (p *Point) UnmarshalScalar(v uint64) error {
 	b := binary.NativeEndian.AppendUint64(nil, v)
 	return p.UnmarshalBinary(b)
+}
+
+// MarshalUint64 produces the same output as MashalBinary, encoded in a uint64.
+// Deprecated: this function simply calls [Point.MarshalScalar].
+//
+//go:fix inline
+func (p Point) MarshalUint64() (uint64, error) {
+	return p.MarshalScalar()
+}
+
+// UnmarshalUint64 expects input formatted by MarshalUint64.
+// Deprecated: this function simply calls [Point.UnmarshalScalar].
+//
+//go:fix inline
+func (p *Point) UnmarshalUint64(v uint64) error {
+	return p.UnmarshalScalar(v)
 }
 
 // IsZero reports if p is the zero value.

--- a/types/geo/point_test.go
+++ b/types/geo/point_test.go
@@ -41,7 +41,7 @@ func TestPointZero(t *testing.T) {
 	}
 
 	wantI := uint64(0x00000000)
-	if i, err := zero.MarshalUint64(); err != nil {
+	if i, err := zero.MarshalScalar(); err != nil {
 		t.Errorf("MarshalUint64() err %q, want nil", err)
 	} else if i != wantI {
 		t.Errorf("MarshalUint64 got %v, want %v", i, wantI)
@@ -358,13 +358,13 @@ func TestPoint(t *testing.T) {
 				t.Errorf("UnmarshalBinary: roundtrip failed: %#v != %#v", q, p)
 			}
 
-			i, err := p.MarshalUint64()
+			i, err := p.MarshalScalar()
 			if err != nil {
 				t.Fatalf("MarshalUint64: err %q, expected nil", err)
 			}
 
 			var r geo.Point
-			if err := r.UnmarshalUint64(i); err != nil {
+			if err := r.UnmarshalScalar(i); err != nil {
 				t.Fatalf("UnmarshalUint64: err %r, expected nil", err)
 			}
 			if !q.EqualApprox(r, -1) {
@@ -414,12 +414,12 @@ func TestPointMarshalBinary(t *testing.T) {
 func TestPointMarshalUint64(t *testing.T) {
 	t.Skip("skip")
 	roundtrip := func(p geo.Point) error {
-		i, err := p.MarshalUint64()
+		i, err := p.MarshalScalar()
 		if err != nil {
 			return fmt.Errorf("marshal: %v", err)
 		}
 		var q geo.Point
-		if err := q.UnmarshalUint64(i); err != nil {
+		if err := q.UnmarshalScalar(i); err != nil {
 			return fmt.Errorf("unmarshal: %v", err)
 		}
 		if q != p {


### PR DESCRIPTION
Add support for the still pending encoding.ScalarMarshaler and encoding.ScalarUnmarshaler interfaces, approved in golang/go#56235.

This patch deprecates [geo.Point.MarshalUint64](https://pkg.go.dev/tailscale.com/types/geo#Point.MarshalUint64) in favour of [geo.Point.MarshalScalar](https://pkg.go.dev/tailscale.com/types/geo#Point.MarshalScalar) and also adds an inline directive for go fix. The same applies for the [UnmarshalUint64](https://pkg.go.dev/tailscale.com/types/geo#Point.UnmarshalUint64) and [UnmarshalScalar](https://pkg.go.dev/tailscale.com/types/geo#Point.UnmarshalScalar) methods.

Updates #16583