### PR TITLE
util/set: add iterator support to Set[T]

### DIFF
--- a/util/set/set.go
+++ b/util/set/set.go
@@ -6,6 +6,7 @@ package set
 
 import (
 	"encoding/json"
+	"iter"
 	"maps"
 	"reflect"
 	"sort"
@@ -31,8 +32,22 @@ func (s Set[T]) Clone() Set[T] {
 	return maps.Clone(s)
 }
 
+// All returns an iterator over all elements in s.
+// The iteration order is not specified
+// and is not guaranteed to be the same from one call to the next.
+func (s Set[T]) All() iter.Seq[T] {
+	return maps.Keys(s)
+}
+
 // Add adds e to s.
 func (s Set[T]) Add(e T) { s[e] = struct{}{} }
+
+// AddSeq adds each element of es to s.
+func (s Set[T]) AddSeq(es iter.Seq[T]) {
+	for e := range es {
+		s.Add(e)
+	}
+}
 
 // AddSlice adds each element of es to s.
 func (s Set[T]) AddSlice(es []T) {
@@ -104,6 +119,27 @@ func genOrderedSwapper(rt reflect.Type) func(reflect.Value) func(i, j int) bool 
 
 // Delete removes e from the set.
 func (s Set[T]) Delete(e T) { delete(s, e) }
+
+// DeleteSeq removes all elements in es from the set.
+func (s Set[T]) DeleteSeq(es iter.Seq[T]) {
+	for e := range es {
+		s.Delete(e)
+	}
+}
+
+// DeleteSlice removes all elements in es from the set.
+func (s Set[T]) DeleteSlice(es []T) {
+	for _, e := range es {
+		s.Delete(e)
+	}
+}
+
+// DeleteSet removes all elements in es from the set.
+func (s Set[T]) DeleteSet(es Set[T]) {
+	for e := range es {
+		s.Delete(e)
+	}
+}
 
 // Contains reports whether s contains e.
 func (s Set[T]) Contains(e T) bool {

--- a/util/set/set_test.go
+++ b/util/set/set_test.go
@@ -50,6 +50,40 @@ func TestSet(t *testing.T) {
 			t.Errorf("slice missing %d (%#v)", e, es)
 		}
 	}
+
+	s.Delete(1)
+	if s.Contains(1) {
+		t.Error("shouldn't have 1")
+	}
+	if !s.Contains(2) {
+		t.Error("missing 2")
+	}
+	if !s.Contains(3) {
+		t.Error("missing 3")
+	}
+	if !s.Contains(4) {
+		t.Error("missing 4")
+	}
+	if s.Len() != 3 {
+		t.Errorf("wrong len %d; want 3", s.Len())
+	}
+
+	s.DeleteSeq(slices.Values([]int{2, 3}))
+	if s.Contains(1) {
+		t.Error("shouldn't have 1")
+	}
+	if s.Contains(2) {
+		t.Error("shouldn't have 2")
+	}
+	if s.Contains(3) {
+		t.Error("shouldn't have 3")
+	}
+	if !s.Contains(4) {
+		t.Error("missing 4")
+	}
+	if s.Len() != 1 {
+		t.Errorf("wrong len %d; want 1", s.Len())
+	}
 }
 
 func TestSetOf(t *testing.T) {


### PR DESCRIPTION
This PR adds:

- [Set.All](https://pkg.go.dev/tailscale.com/util/set#Set.All) which returns an [iter.Seq](https://pkg.go.dev/iter#Seq) to complement [Set.Slice](https://pkg.go.dev/tailscale.com/util/set#Set.Slice).

- [Set.AddSeq](https://pkg.go.dev/tailscale.com/util/set#AddSeq) which adds an [iter.Seq](https://pkg.go.dev/iter#Seq): this deprecates [Set.AddSlice](https://pkg.go.dev/tailscale.com/util/set#Set.AddSlice) and [Set.AddSet](https://pkg.go.dev/tailscale.com/util/set#Set.AddSet).

- [Set.DeleteSeq](https://pkg.go.dev/tailscale.com/util/set#Set.DeleteSeq) which deletes an [iter.Seq](https://pkg.go.dev/iter#Seq) to complement [Set.AddSeq](https://pkg.go.dev/tailscale.com/util/set#Set.AddSeq) and provide the missing method for deleting multiple elements.

In a separate commit, this PR replaces both Set.AddSlice and Set.AddSet with Set.AddSeq. 

Updates #cleanup