### PR TITLE
wgengine/magicsock: trigger TSMP disco advert on disco open failure

### DIFF
--- a/wgengine/magicsock/endpoint.go
+++ b/wgengine/magicsock/endpoint.go
@@ -23,6 +23,8 @@ import (
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
 	"tailscale.com/disco"
+	"tailscale.com/envknob"
+	"tailscale.com/feature/buildfeatures"
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/net/packet"
 	"tailscale.com/net/stun"
@@ -2111,4 +2113,34 @@ func (de *endpoint) setDERPHome(regionID uint16) {
 	if de.c.relayManager.hasPeerRelayServers.Load() {
 		de.c.relayManager.handleDERPHomeChange(de.publicKey, regionID)
 	}
+}
+
+// maybeSendTSMPDiscoAdvert conditionally emits an event indicating that we
+// should send our DiscoKey to the first node address of the [endpoint].
+//
+// The event is suppressed if less than [discoKeyAdvertisementInterval] has
+// passed since the last DiscoKey was sent, or netmap caching is disabled on
+// this node.
+func (de *endpoint) maybeSendTSMPDiscoAdvert(now mono.Time) {
+	if !buildfeatures.HasCacheNetMap ||
+		!envknob.BoolDefaultTrue("TS_USE_CACHED_NETMAP") {
+		return
+	}
+
+	de.mu.Lock()
+	defer de.mu.Unlock()
+
+	if !de.nodeAddr.IsValid() {
+		return
+	}
+
+	if !de.lastDiscoKeyAdvertisement.IsZero() && now.Sub(de.lastDiscoKeyAdvertisement) < discoKeyAdvertisementInterval {
+		return
+	}
+
+	de.lastDiscoKeyAdvertisement = now
+	de.c.tsmpDiscoKeyAvailablePub.Publish(NewDiscoKeyAvailable{
+		NodeFirstAddr: de.nodeAddr,
+		NodeID:        de.nodeID,
+	})
 }

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -2178,6 +2178,35 @@ func packetLooksLike(msg []byte) (t packetLooksLikeType, isGeneveEncap bool) {
 	}
 }
 
+// handleDiscoOpenFailOrUnknownSenderLocked handles a failed disco message open
+// operation, or a disco message from an unknown sender public key.
+func (c *Conn) handleDiscoOpenFailOrUnknownSenderLocked(src epAddr, derpNodeSrc key.NodePublic) {
+	// Provide the sender of the disco message that failed to open with our
+	// current disco key if they appear to be a known node key.
+	var (
+		ep *endpoint
+		ok bool
+	)
+	if !derpNodeSrc.IsZero() {
+		// The node is unambiguous, as the disco message arrived over DERP,
+		// and DERP src is node key.
+		ep, ok = c.peerMap.endpointForNodeKey(derpNodeSrc)
+	} else {
+		// The node is ambiguous, but we make it unambiguous through [epAddr]
+		// lookup in the [peerMap]. The sender of the disco message that
+		// failed to open was sourced from [epAddr], which can map to an
+		// [endpoint]. Writes into the [peerMap] by [epAddr] only occur upon
+		// successful disco transaction over the address, or a
+		// WireGuard-authenticated round trip of [lazyEndpoint] through
+		// wireguard-go. Since we've arrived here due to disco open failure,
+		// this is likely the latter.
+		ep, ok = c.peerMap.endpointForEpAddr(src)
+	}
+	if ok {
+		ep.maybeSendTSMPDiscoAdvert(mono.Now())
+	}
+}
+
 // handleDiscoMessage handles a discovery message. The caller is assumed to have
 // verified 'msg' returns [packetLooksLikeDisco] from packetLooksLike().
 //
@@ -2233,6 +2262,7 @@ func (c *Conn) handleDiscoMessage(msg []byte, src epAddr, shouldBeRelayHandshake
 		if debugDisco() {
 			c.logf("magicsock: disco: ignoring disco-looking frame, don't know of key %v", sender.ShortString())
 		}
+		c.handleDiscoOpenFailOrUnknownSenderLocked(src, derpNodeSrc)
 		return
 	}
 
@@ -2266,6 +2296,7 @@ func (c *Conn) handleDiscoMessage(msg []byte, src epAddr, shouldBeRelayHandshake
 		}
 
 		metricRecvDiscoBadKey.Add(1)
+		c.handleDiscoOpenFailOrUnknownSenderLocked(src, derpNodeSrc)
 		return
 	}
 
@@ -2677,8 +2708,6 @@ func (c *Conn) enqueueCallMeMaybe(derpAddr netip.AddrPort, de *endpoint) {
 		go c.ReSTUN("refresh-for-peering")
 		return
 	}
-
-	c.maybeSendTSMPDiscoAdvert(de)
 
 	eps := make([]netip.AddrPort, 0, len(c.lastEndpoints))
 	for _, ep := range c.lastEndpoints {
@@ -4550,48 +4579,4 @@ func (c *Conn) HandleDiscoKeyAdvertisement(node tailcfg.NodeView, update packet.
 type NewDiscoKeyAvailable struct {
 	NodeFirstAddr netip.Addr
 	NodeID        tailcfg.NodeID
-}
-
-// maybeSendTSMPDiscoAdvert conditionally emits an event indicating that we
-// should send our DiscoKey to the first node address of the magicksock endpoint.
-//
-// The event is suppressed if we are communicating over a non-DERP path, or
-// less than [discoKeyAdvertisementInterval] has passed since the last DiscoKey
-// was sent, or netmap caching is disabled on this node.
-//
-// We do not need the Conn to be locked, but the endpoint should be.
-func (c *Conn) maybeSendTSMPDiscoAdvert(de *endpoint) {
-	if !buildfeatures.HasCacheNetMap || !envknob.BoolDefaultTrue("TS_USE_CACHED_NETMAP") {
-		return
-	}
-
-	// Disable TSMP disco advert by default, unless network map caching is
-	// enabled for the local node. Caching network maps on the remote node is
-	// what really matters in terms of handling a TSMP disco advert and applying
-	// it in a useful way, but the TSMP disco advert implementation as it exists
-	// here has pathological behaviors. Therefore, it should be disabled for
-	// almost all tailnets, and we lean on the network map caching control knob
-	// for this purpose. See #20081.
-	if c.controlKnobs == nil || !c.controlKnobs.CacheNetworkMaps.Load() {
-		return
-	}
-
-	de.mu.Lock()
-	defer de.mu.Unlock()
-
-	if !de.nodeAddr.IsValid() {
-		return
-	}
-
-	now := mono.Now()
-	if now.Sub(de.lastDiscoKeyAdvertisement) <= discoKeyAdvertisementInterval ||
-		(!de.lastDiscoKeyAdvertisement.IsZero() && !de.bestAddr.isZero()) {
-		return
-	}
-
-	de.lastDiscoKeyAdvertisement = now
-	c.tsmpDiscoKeyAvailablePub.Publish(NewDiscoKeyAvailable{
-		NodeFirstAddr: de.nodeAddr,
-		NodeID:        de.nodeID,
-	})
 }

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -4548,35 +4548,27 @@ func TestSendingTSMPDiscoTimer(t *testing.T) {
 		t.Errorf("Original disco key %s, does not match %s", discoKey.ShortString(), ep.discoShort())
 	}
 
+	now := mono.Now()
 	// Only one gets through, second is rate limited.
-	conn.maybeSendTSMPDiscoAdvert(ep)
-	conn.maybeSendTSMPDiscoAdvert(ep)
+	ep.maybeSendTSMPDiscoAdvert(now)
+	ep.maybeSendTSMPDiscoAdvert(now)
 	if err := eventbustest.ExpectExactly(tw, eventbustest.Type[NewDiscoKeyAvailable]()); err != nil {
 		t.Errorf("expected only one event, got: %s", err)
 	}
 
-	// Reset to get the event firing again.
-	ep.mu.Lock()
-	ep.lastDiscoKeyAdvertisement = 0
-	ep.mu.Unlock()
-	conn.maybeSendTSMPDiscoAdvert(ep)
+	// Move clock forwards by [discoKeyAdvertisementInterval], advertisement should fire.
+	now = now.Add(discoKeyAdvertisementInterval + time.Nanosecond)
+	ep.maybeSendTSMPDiscoAdvert(now)
 	if err := eventbustest.Expect(tw, eventbustest.Type[NewDiscoKeyAvailable]()); err != nil {
 		t.Errorf("expected only one event, got: %s", err)
 	}
 
-	// With a direct bestAddr and a non-zero lastDiscoKeyAdvertisement past the
-	// rate-limit interval. No advert should be sent due to the active bestAddr.
-	ep.mu.Lock()
-	ep.lastDiscoKeyAdvertisement = mono.Now().Add(-discoKeyAdvertisementInterval - time.Second)
-	ep.bestAddr = addrQuality{epAddr: epAddr{ap: netip.MustParseAddrPort("1.2.3.4:567")}}
-	ep.mu.Unlock()
-	conn.maybeSendTSMPDiscoAdvert(ep)
-
-	// Simulating restart should send an advert.
+	// Simulate restart by setting lastDiscoKeyAdvertisement to zero. Advertisement
+	// should fire.
 	ep.mu.Lock()
 	ep.lastDiscoKeyAdvertisement = 0
 	ep.mu.Unlock()
-	conn.maybeSendTSMPDiscoAdvert(ep)
+	ep.maybeSendTSMPDiscoAdvert(now)
 	if err := eventbustest.ExpectExactly(tw, eventbustest.Type[NewDiscoKeyAvailable]()); err != nil {
 		t.Errorf("expected only one event, got: %s", err)
 	}
@@ -4611,7 +4603,7 @@ func TestSendingTSMPDiscoCachingDisabled(t *testing.T) {
 			// direct bestAddr would otherwise advertise; the only thing
 			// suppressing it here is the disabled caching knob. On early
 			// return the timestamp is left untouched (zero).
-			conn.maybeSendTSMPDiscoAdvert(ep)
+			ep.maybeSendTSMPDiscoAdvert(mono.Now())
 
 			ep.mu.Lock()
 			defer ep.mu.Unlock()
@@ -4619,64 +4611,5 @@ func TestSendingTSMPDiscoCachingDisabled(t *testing.T) {
 				t.Errorf("lastDiscoKeyAdvertisement = %v; want zero (advert should have been suppressed)", ep.lastDiscoKeyAdvertisement)
 			}
 		})
-	}
-}
-
-// TestSendingTSMPDiscoPeerRelaySuppressed verifies that maybeSendTSMPDiscoAdvert
-// suppresses the advert when the bestAddr is a peer relay path (a non-zero
-// addrQuality whose epAddr has a VNI set), even though such a path is not
-// direct. Suppression is observed via lastDiscoKeyAdvertisement remaining
-// unchanged, since a fired advert would overwrite it with the current time.
-func TestSendingTSMPDiscoPeerRelaySuppressed(t *testing.T) {
-	conn := newTestConn(t)
-	t.Cleanup(func() { conn.Close() })
-
-	// maybeSendTSMPDiscoAdvert only advertises when netmap caching is enabled.
-	conn.controlKnobs = new(controlknobs.Knobs)
-	conn.controlKnobs.CacheNetworkMaps.Store(true)
-
-	peerKey := key.NewNode().Public()
-	ep := &endpoint{
-		nodeID:    1,
-		publicKey: peerKey,
-		nodeAddr:  netip.MustParseAddr("100.64.0.1"),
-	}
-	discoKey := key.NewDisco().Public()
-	ep.disco.Store(&endpointDisco{
-		key:   discoKey,
-		short: discoKey.ShortString(),
-	})
-	ep.c = conn
-	conn.mu.Lock()
-	nodeView := (&tailcfg.Node{
-		Key: ep.publicKey,
-		Addresses: []netip.Prefix{
-			netip.MustParsePrefix("100.64.0.1/32"),
-		},
-	}).View()
-	conn.peersByID = map[tailcfg.NodeID]tailcfg.NodeView{nodeView.ID(): nodeView}
-	conn.mu.Unlock()
-
-	conn.peerMap.upsertEndpoint(ep, key.DiscoPublic{})
-
-	// A peer relay bestAddr: an epAddr with a VNI set. It is past the
-	// rate-limit interval with a non-zero lastDiscoKeyAdvertisement, so the
-	// only thing suppressing the advert is the active (non-zero) bestAddr.
-	var vni packet.VirtualNetworkID
-	vni.Set(7)
-	lastAdvert := mono.Now().Add(-discoKeyAdvertisementInterval - time.Second)
-	ep.mu.Lock()
-	ep.lastDiscoKeyAdvertisement = lastAdvert
-	ep.bestAddr = addrQuality{epAddr: epAddr{ap: netip.MustParseAddrPort("1.2.3.4:567"), vni: vni}}
-	ep.mu.Unlock()
-
-	conn.maybeSendTSMPDiscoAdvert(ep)
-
-	// A fired advert would have overwritten lastDiscoKeyAdvertisement with the
-	// current time; confirm it was left untouched, indicating suppression.
-	ep.mu.Lock()
-	defer ep.mu.Unlock()
-	if ep.lastDiscoKeyAdvertisement != lastAdvert {
-		t.Errorf("lastDiscoKeyAdvertisement = %v; want unchanged %v (advert should have been suppressed)", ep.lastDiscoKeyAdvertisement, lastAdvert)
 	}
 }


### PR DESCRIPTION
The trigger is now self-extinguishing, since we cease to advertise our
key once disco opens succeed, avoiding the pathalogical case of TSMP
disco advert over WireGuard keeping wireguard-go and magicsock bound
in a never-ending packet scheduling loop.

Updates #20081
Updates #20156