### PR TITLE
go.mod,wgengine/magicsock: pull wireguard-go fix for roaming endpoints

### DIFF
--- a/cmd/tta/wgserver_linux.go
+++ b/cmd/tta/wgserver_linux.go
@@ -15,11 +15,12 @@ import (
 	"os/exec"
 	"sync"
 
-	"github.com/tailscale/wireguard-go/conn"
-	"github.com/tailscale/wireguard-go/device"
-	"github.com/tailscale/wireguard-go/tun"
 	"golang.org/x/crypto/curve25519"
-	"tailscale.com/wgengine/wgcfg"
+
+	// Stock wireguard-go to simulate non-Tailscale peers.
+	extwgconn "golang.zx2c4.com/wireguard/conn"
+	extwgdevice "golang.zx2c4.com/wireguard/device"
+	extwgtun "golang.zx2c4.com/wireguard/tun"
 )
 
 func init() {
@@ -28,7 +29,7 @@ func init() {
 
 var (
 	wgServerMu  sync.Mutex
-	wgServerDev *device.Device // retained so the goroutines stay alive
+	wgServerDev *extwgdevice.Device // retained so the goroutines stay alive
 )
 
 // wgServerUpLinux brings up a userspace WireGuard interface on the local VM
@@ -98,16 +99,16 @@ func wgServerUpLinux(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tdev, err := tun.CreateTUN(name, device.DefaultMTU)
+	tdev, err := extwgtun.CreateTUN(name, extwgdevice.DefaultMTU)
 	if err != nil {
 		http.Error(w, "tun.CreateTUN: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	wglog := &device.Logger{
+	wglog := &extwgdevice.Logger{
 		Verbosef: func(string, ...any) {},
 		Errorf:   func(f string, a ...any) { log.Printf("wg-server: "+f, a...) },
 	}
-	dev := wgcfg.NewDevice(tdev, conn.NewDefaultBind(), wglog)
+	dev := extwgdevice.NewDevice(tdev, extwgconn.NewDefaultBind(), wglog)
 
 	uapi := fmt.Sprintf("private_key=%s\nlisten_port=%s\npublic_key=%s\nallowed_ip=%s\n",
 		hex.EncodeToString(priv[:]), listenPort,

--- a/flake.nix
+++ b/flake.nix
@@ -164,4 +164,4 @@
     });
   };
 }
-# nix-direnv cache busting line: sha256-mbxLXR2TBgiwyVGfLmMR5xWk+0f66mPDas95Wla70Lk=
+# nix-direnv cache busting line: sha256-fapCfxqqfM3YzrAd4IWUYcPSxjDg5YWYd9/BcorEeEY=

--- a/flakehashes.json
+++ b/flakehashes.json
@@ -4,7 +4,7 @@
     "sri": "sha256-HeD70CytKL0Ks/VDqMU73bN8fxpWkNc6mNgNr9PEO7k="
   },
   "vendor": {
-    "goModSum": "sha256-IbxUmMBapp3G2WIK+gqfmQd1tLCVoHMYBHLPZ5ZjDIU=",
-    "sri": "sha256-mbxLXR2TBgiwyVGfLmMR5xWk+0f66mPDas95Wla70Lk="
+    "goModSum": "sha256-0xd1a5cWavgyO5ifCQJX2YzDJoxGFZX2IsbF6YIGtME=",
+    "sri": "sha256-fapCfxqqfM3YzrAd4IWUYcPSxjDg5YWYd9/BcorEeEY="
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -103,7 +103,7 @@ require (
 	github.com/tailscale/ts-gokrazy v0.0.0-20260429180033-fe741c6deb44
 	github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976
 	github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6
-	github.com/tailscale/wireguard-go v0.0.0-20260427181203-e3ac4a0afb4e
+	github.com/tailscale/wireguard-go v0.0.0-20260618005210-c32c33ada7f2
 	github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e
 	github.com/tc-hib/winres v0.2.1
 	github.com/tcnksm/go-httpstat v0.2.0
@@ -124,6 +124,7 @@ require (
 	golang.org/x/time v0.12.0
 	golang.org/x/tools v0.44.0
 	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2
+	golang.zx2c4.com/wireguard v0.0.0-20260522210424-ecfc5a8d5446
 	golang.zx2c4.com/wireguard/windows v0.5.3
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gvisor.dev/gvisor v0.0.0-20260224225140-573d5e7127a8

--- a/go.sum
+++ b/go.sum
@@ -1155,8 +1155,8 @@ github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976 h1:U
 github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976/go.mod h1:agQPE6y6ldqCOui2gkIh7ZMztTkIQKH049tv8siLuNQ=
 github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6 h1:l10Gi6w9jxvinoiq15g8OToDdASBni4CyJOdHY1Hr8M=
 github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6/go.mod h1:ZXRML051h7o4OcI0d3AaILDIad/Xw0IkXaHM17dic1Y=
-github.com/tailscale/wireguard-go v0.0.0-20260427181203-e3ac4a0afb4e h1:GexFR7ak1iz26fxg8HWCpOEqAOL8UEZJ7J3JxeCalDs=
-github.com/tailscale/wireguard-go v0.0.0-20260427181203-e3ac4a0afb4e/go.mod h1:6SerzcvHWQchKO2BfNdmquA77CHSECZuFl+D9fp4RnI=
+github.com/tailscale/wireguard-go v0.0.0-20260618005210-c32c33ada7f2 h1:3+YAskVNeyawqRBgkVNEHSWwifTwkDu7EqP/XpO6dLI=
+github.com/tailscale/wireguard-go v0.0.0-20260618005210-c32c33ada7f2/go.mod h1:6SerzcvHWQchKO2BfNdmquA77CHSECZuFl+D9fp4RnI=
 github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e h1:zOGKqN5D5hHhiYUp091JqK7DPCqSARyUfduhGUY8Bek=
 github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e/go.mod h1:orPd6JZXXRyuDusYilywte7k094d7dycXXU5YnWsrwg=
 github.com/tc-hib/winres v0.2.1 h1:YDE0FiP0VmtRaDn7+aaChp1KiF4owBiJa5l964l5ujA=
@@ -1606,6 +1606,8 @@ golang.org/x/xerrors v0.0.0-20240716161551-93cc26a95ae9 h1:LLhsEBxRTBLuKlQxFBYUO
 golang.org/x/xerrors v0.0.0-20240716161551-93cc26a95ae9/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=
 golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 h1:B82qJJgjvYKsXS9jeunTOisW56dUokqW/FOteYJJ/yg=
 golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2/go.mod h1:deeaetjYA+DHMHg+sMSMI58GrEteJUUzzw7en6TJQcI=
+golang.zx2c4.com/wireguard v0.0.0-20260522210424-ecfc5a8d5446 h1:cqHQ3AycTHvM2R7ikgyX57D+XvtcSnGylsLkOVhta/w=
+golang.zx2c4.com/wireguard v0.0.0-20260522210424-ecfc5a8d5446/go.mod h1:rpwXGsirqLqN2L0JDJQlwOboGHmptD5ZD6T2VmcqhTw=
 golang.zx2c4.com/wireguard/windows v0.5.3 h1:On6j2Rpn3OEMXqBq00QEDC7bWSZrPIHKIus8eIuExIE=
 golang.zx2c4.com/wireguard/windows v0.5.3/go.mod h1:9TEe8TJmtwyQebdFwAkEWOPr3prrtqm+REGFifP60hI=
 gomodules.xyz/jsonpatch/v2 v2.4.0 h1:Ci3iUJyx9UeRx7CeFN8ARgGbkESwJK+KB9lLcWxY/Zw=

--- a/shell.nix
+++ b/shell.nix
@@ -16,4 +16,4 @@
 ) {
   src =  ./.;
 }).shellNix
-# nix-direnv cache busting line: sha256-mbxLXR2TBgiwyVGfLmMR5xWk+0f66mPDas95Wla70Lk=
+# nix-direnv cache busting line: sha256-fapCfxqqfM3YzrAd4IWUYcPSxjDg5YWYd9/BcorEeEY=

--- a/util/linuxfw/fake_netfilter.go
+++ b/util/linuxfw/fake_netfilter.go
@@ -94,8 +94,8 @@ func (f *FakeNetfilterRunner) ClampMSSToPMTU(tun string, addr netip.Addr) error 
 func (f *FakeNetfilterRunner) GetClampedAddrs() []netip.Addr {
 	return f.clampedAddrs
 }
-func (f *FakeNetfilterRunner) AddMagicsockPortRule(port uint16, network string) error   { return nil }
-func (f *FakeNetfilterRunner) DelMagicsockPortRule(port uint16, network string) error   { return nil }
+func (f *FakeNetfilterRunner) AddMagicsockPortRule(port uint16, network string) error { return nil }
+func (f *FakeNetfilterRunner) DelMagicsockPortRule(port uint16, network string) error { return nil }
 func (f *FakeNetfilterRunner) DeletePortMapRuleForSvc(svc, tun string, targetIP netip.Addr, pm PortMap) error {
 	return nil
 }

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -39,6 +39,9 @@ import (
 	"go4.org/mem"
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv4"
+	extwgconn "golang.zx2c4.com/wireguard/conn"
+	extwgdevice "golang.zx2c4.com/wireguard/device"
+	extwgtest "golang.zx2c4.com/wireguard/tun/tuntest"
 	"tailscale.com/control/controlknobs"
 	"tailscale.com/derp/derpserver"
 	"tailscale.com/disco"
@@ -2250,17 +2253,20 @@ func TestSetNetworkMapWithNoPeers(t *testing.T) {
 }
 
 // newWireguard starts up a new wireguard-go device attached to a test tun, and
-// returns the device, tun and endpoint port. To add peers call device.IpcSet with UAPI instructions.
-func newWireguard(t *testing.T, uapi string, aips []netip.Prefix) (*device.Device, *tuntest.ChannelTUN, uint16) {
-	wgtun := tuntest.NewChannelTUN()
+// returns the device, tun and endpoint port. To add peers call device.IpcSet
+// with UAPI instructions.
+//
+// This uses stock wireguard-go to simulate a non-Tailscale peer.
+func newWireguard(t *testing.T, uapi string, aips []netip.Prefix) (*extwgdevice.Device, *extwgtest.ChannelTUN, uint16) {
+	wgtun := extwgtest.NewChannelTUN()
 	wglogf := func(f string, args ...any) {
 		t.Logf("wg-go: "+f, args...)
 	}
-	wglog := device.Logger{
+	wglog := extwgdevice.Logger{
 		Verbosef: func(string, ...any) {},
 		Errorf:   wglogf,
 	}
-	wgdev := wgcfg.NewDevice(wgtun.TUN(), wgconn.NewDefaultBind(), &wglog)
+	wgdev := extwgdevice.NewDevice(wgtun.TUN(), extwgconn.NewDefaultBind(), &wglog)
 
 	if err := wgdev.IpcSet(uapi); err != nil {
 		t.Fatal(err)

--- a/wgengine/wgcfg/device.go
+++ b/wgengine/wgcfg/device.go
@@ -15,9 +15,7 @@ import (
 
 // NewDevice returns a wireguard-go Device configured for Tailscale use.
 func NewDevice(tunDev tun.Device, bind conn.Bind, logger *device.Logger) *device.Device {
-	ret := device.NewDevice(tunDev, bind, logger)
-	ret.DisableSomeRoamingForBrokenMobileSemantics()
-	return ret
+	return device.NewDevice(tunDev, bind, logger)
 }
 
 // ReconfigDevice replaces the existing device configuration with cfg.


### PR DESCRIPTION
Bumps wireguard-go pin to include the roaming endpoints fix, and two internal enhancements.

Pulls stock wireguard-go for non-tailscale simulation in tests, to use its endpoint discovery mechanism.

This is primarily cherry picked from 7d18a06, it differs only in wireguard-go commit.

tailscale/wireguard-go@c32c33ada7f2 immediately follows tailscale/wireguard-go@e3ac4a0afb4e

Updates #20082

Change-Id: I2ff282cb7fe4ab099ce5e780a1d40ae86a6a6964

(cherry picked from commit 7d18a06292e81f73c8face9ae503b9c16914ea55)