### PR TITLE
sessionrecording: close idle connections after upload

### DIFF
--- a/sessionrecording/connect.go
+++ b/sessionrecording/connect.go
@@ -38,6 +38,9 @@ const (
 // in tests.
 var uploadAckWindow = 30 * time.Second
 
+// idleConnTimeout is the idle timeout for connections to the recorder.
+var idleConnTimeout = 30 * time.Second
+
 // ConnectToRecorder connects to the recorder at any of the provided addresses.
 // It returns the first successful response, or a multierr if all attempts fail.
 //
@@ -233,6 +236,7 @@ func connectV1(ctx context.Context, hc *http.Client, ap netip.AddrPort) (io.Writ
 	// errChan is used to indicate the result of the request.
 	errChan := make(chan error, 1)
 	go func() {
+		defer hc.CloseIdleConnections()
 		defer close(errChan)
 		resp, err := hc.Do(req)
 		if err != nil {
@@ -291,6 +295,7 @@ func connectV2(ctx context.Context, hc *http.Client, ap netip.AddrPort) (io.Writ
 	acks := make(chan int64)
 	// Read acks from the response and send them to the acks channel.
 	go func() {
+		defer hc.CloseIdleConnections()
 		defer close(errChan)
 		defer close(acks)
 		defer resp.Body.Close()
@@ -393,6 +398,7 @@ func clientHTTP1(dialCtx context.Context, dial netx.DialFunc) *http.Client {
 		}()
 		return dial(perAttemptCtx, network, addr)
 	}
+	tr.IdleConnTimeout = idleConnTimeout
 	return &http.Client{Transport: tr}
 }
 
@@ -417,6 +423,7 @@ func clientHTTP2(dialCtx context.Context, dial netx.DialFunc) *http.Client {
 				}()
 				return dial(perAttemptCtx, network, addr)
 			},
+			IdleConnTimeout: idleConnTimeout,
 		},
 	}
 }


### PR DESCRIPTION
The SSH server creates a new client for every connection to the recorder. If we don't close this connection explicitly once it's idle after the upload stream is closed, it stays open and holds on to a port on the server. This leads to port exhaustion on the server in the medium to long run.
    
To avoid this, close the idle connections explicitly. As an extra step of precaution, set an idleConnTimeout of 30 seconds on both the HTTP1 and HTTP2 recorder clients.

Updates tailscale/corp#43742

(cherry-picked from #20184)