### PR TITLE
control/controlhttp: use ws:// when HTTPSPort is NoPort in JS dialer

### DIFF
--- a/control/controlhttp/client_js.go
+++ b/control/controlhttp/client_js.go
@@ -32,7 +32,9 @@ func (d *Dialer) Dial(ctx context.Context) (*ClientConn, error) {
 	host := d.Hostname
 	// If using a custom control server (on a non-standard port), prefer that.
 	// This mirrors the port selection in newNoiseClient from noise.go.
-	if d.HTTPPort != "" && d.HTTPPort != "80" && d.HTTPSPort == "443" {
+	// Also use ws:// when HTTPS is explicitly disabled (NoPort), which happens
+	// for http:// URLs with private hostnames (e.g. http://localhost:31544).
+	if d.HTTPPort != "" && d.HTTPPort != "80" && (d.HTTPSPort == "443" || d.HTTPSPort == NoPort) {
 		wsScheme = "ws"
 		host = net.JoinHostPort(host, d.HTTPPort)
 	}


### PR DESCRIPTION
When HTTPS is explicitly disabled (HTTPSPort == NoPort), the JS WebSocket dialer should use ws:// instead of wss://. This matches the behavior of the non-JS client and fixes connections to development control servers e.g. http://localhost:31544.

Updates tailscale/corp#40944

(cherry-picked from #19671)