### PR TITLE
go.mod: bump wireguard-go

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -164,4 +164,4 @@
     });
   };
 }
-# nix-direnv cache busting line: sha256-ksHhfpx3ydAsTc6bD2vgZ8GMx+6OjXJlrb+HM+tFj8w=
+# nix-direnv cache busting line: sha256-KW95JUwXKC/6iD3IF97qimJunlY/W0SzolwI4NS2wNI=

--- a/flakehashes.json
+++ b/flakehashes.json
@@ -4,7 +4,7 @@
     "sri": "sha256-cY5yryX+p/xtoTv+WZEKFagiIl0OREHnJY1Bk5VpVVc="
   },
   "vendor": {
-    "goModSum": "sha256-GKa57o9/Mze6Bk4Tj+B0mDxzBCmSd6vZxxNFwVkPsRc=",
-    "sri": "sha256-ksHhfpx3ydAsTc6bD2vgZ8GMx+6OjXJlrb+HM+tFj8w="
+    "goModSum": "sha256-nKS9TyacLwgG/vhjHKkiEQ2dXg+/h0S0aykpIJfl/Cg=",
+    "sri": "sha256-KW95JUwXKC/6iD3IF97qimJunlY/W0SzolwI4NS2wNI="
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -106,7 +106,7 @@ require (
 	github.com/tailscale/ts-gokrazy v0.0.0-20260429180033-fe741c6deb44
 	github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976
 	github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6
-	github.com/tailscale/wireguard-go v0.0.0-20260611164920-3aa5c949d6f7
+	github.com/tailscale/wireguard-go v0.0.0-20260622165919-27488b260371
 	github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e
 	github.com/tc-hib/winres v0.2.1
 	github.com/tcnksm/go-httpstat v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1174,8 +1174,8 @@ github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976 h1:U
 github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976/go.mod h1:agQPE6y6ldqCOui2gkIh7ZMztTkIQKH049tv8siLuNQ=
 github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6 h1:l10Gi6w9jxvinoiq15g8OToDdASBni4CyJOdHY1Hr8M=
 github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6/go.mod h1:ZXRML051h7o4OcI0d3AaILDIad/Xw0IkXaHM17dic1Y=
-github.com/tailscale/wireguard-go v0.0.0-20260611164920-3aa5c949d6f7 h1:vaSUkHrw9kuJjqY27sOZfcUUrJvd2rDVca2PePyMeD4=
-github.com/tailscale/wireguard-go v0.0.0-20260611164920-3aa5c949d6f7/go.mod h1:6SerzcvHWQchKO2BfNdmquA77CHSECZuFl+D9fp4RnI=
+github.com/tailscale/wireguard-go v0.0.0-20260622165919-27488b260371 h1:HQ/c63t3lNJQtFo2meEA+zb57FVPIOW9EKtyBrH8KKA=
+github.com/tailscale/wireguard-go v0.0.0-20260622165919-27488b260371/go.mod h1:6SerzcvHWQchKO2BfNdmquA77CHSECZuFl+D9fp4RnI=
 github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e h1:zOGKqN5D5hHhiYUp091JqK7DPCqSARyUfduhGUY8Bek=
 github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e/go.mod h1:orPd6JZXXRyuDusYilywte7k094d7dycXXU5YnWsrwg=
 github.com/tc-hib/winres v0.2.1 h1:YDE0FiP0VmtRaDn7+aaChp1KiF4owBiJa5l964l5ujA=

--- a/shell.nix
+++ b/shell.nix
@@ -16,4 +16,4 @@
 ) {
   src =  ./.;
 }).shellNix
-# nix-direnv cache busting line: sha256-ksHhfpx3ydAsTc6bD2vgZ8GMx+6OjXJlrb+HM+tFj8w=
+# nix-direnv cache busting line: sha256-KW95JUwXKC/6iD3IF97qimJunlY/W0SzolwI4NS2wNI=


### PR DESCRIPTION
Fix leaking peers that failed to complete the handshake.

Updates #20183