### PR TITLE
go.mod: bump wireguard-go

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -164,4 +164,4 @@
     });
   };
 }
-# nix-direnv cache busting line: sha256-fapCfxqqfM3YzrAd4IWUYcPSxjDg5YWYd9/BcorEeEY=
+# nix-direnv cache busting line: sha256-Sd2iLJ7eDfDYdIRuW4xuiKgzhQWJWGAnz97FJWrVRlE=

--- a/flakehashes.json
+++ b/flakehashes.json
@@ -4,7 +4,7 @@
     "sri": "sha256-HeD70CytKL0Ks/VDqMU73bN8fxpWkNc6mNgNr9PEO7k="
   },
   "vendor": {
-    "goModSum": "sha256-0xd1a5cWavgyO5ifCQJX2YzDJoxGFZX2IsbF6YIGtME=",
-    "sri": "sha256-fapCfxqqfM3YzrAd4IWUYcPSxjDg5YWYd9/BcorEeEY="
+    "goModSum": "sha256-OmQBjUQQ74uvSTpxPXopKRgMp91RGcuPDq1Ka3twSKc=",
+    "sri": "sha256-Sd2iLJ7eDfDYdIRuW4xuiKgzhQWJWGAnz97FJWrVRlE="
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -103,7 +103,7 @@ require (
 	github.com/tailscale/ts-gokrazy v0.0.0-20260429180033-fe741c6deb44
 	github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976
 	github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6
-	github.com/tailscale/wireguard-go v0.0.0-20260618005210-c32c33ada7f2
+	github.com/tailscale/wireguard-go v0.0.0-20260622165914-65d8d42c9a5a
 	github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e
 	github.com/tc-hib/winres v0.2.1
 	github.com/tcnksm/go-httpstat v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1155,8 +1155,8 @@ github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976 h1:U
 github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976/go.mod h1:agQPE6y6ldqCOui2gkIh7ZMztTkIQKH049tv8siLuNQ=
 github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6 h1:l10Gi6w9jxvinoiq15g8OToDdASBni4CyJOdHY1Hr8M=
 github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6/go.mod h1:ZXRML051h7o4OcI0d3AaILDIad/Xw0IkXaHM17dic1Y=
-github.com/tailscale/wireguard-go v0.0.0-20260618005210-c32c33ada7f2 h1:3+YAskVNeyawqRBgkVNEHSWwifTwkDu7EqP/XpO6dLI=
-github.com/tailscale/wireguard-go v0.0.0-20260618005210-c32c33ada7f2/go.mod h1:6SerzcvHWQchKO2BfNdmquA77CHSECZuFl+D9fp4RnI=
+github.com/tailscale/wireguard-go v0.0.0-20260622165914-65d8d42c9a5a h1:lUrrnYQmT/tqANWUCsz7i6ogQDlJKGgMjtFmPC6UPwo=
+github.com/tailscale/wireguard-go v0.0.0-20260622165914-65d8d42c9a5a/go.mod h1:6SerzcvHWQchKO2BfNdmquA77CHSECZuFl+D9fp4RnI=
 github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e h1:zOGKqN5D5hHhiYUp091JqK7DPCqSARyUfduhGUY8Bek=
 github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e/go.mod h1:orPd6JZXXRyuDusYilywte7k094d7dycXXU5YnWsrwg=
 github.com/tc-hib/winres v0.2.1 h1:YDE0FiP0VmtRaDn7+aaChp1KiF4owBiJa5l964l5ujA=

--- a/shell.nix
+++ b/shell.nix
@@ -16,4 +16,4 @@
 ) {
   src =  ./.;
 }).shellNix
-# nix-direnv cache busting line: sha256-fapCfxqqfM3YzrAd4IWUYcPSxjDg5YWYd9/BcorEeEY=
+# nix-direnv cache busting line: sha256-Sd2iLJ7eDfDYdIRuW4xuiKgzhQWJWGAnz97FJWrVRlE=


### PR DESCRIPTION
Fix leaking peers that failed to complete the handshake.

Updates #20183

Change-Id: I6b968aa41057c752f6181661da7f6b616a6a6964