### PR TITLE
go.mod: bump wireguard-go

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -164,4 +164,4 @@
     });
   };
 }
-# nix-direnv cache busting line: sha256-IMoaOKTujfjg/2wmxLa/7u2LqGC5KIwTffYsho67c1c=
+# nix-direnv cache busting line: sha256-w6MF0pKV6zfeVorfrxMm2AXR0uDgw5sG3zl5Ugm6SCU=

--- a/flakehashes.json
+++ b/flakehashes.json
@@ -4,7 +4,7 @@
     "sri": "sha256-cY5yryX+p/xtoTv+WZEKFagiIl0OREHnJY1Bk5VpVVc="
   },
   "vendor": {
-    "goModSum": "sha256-HP8oKLJ046u4msMKK6kUBwcTJvdQ5Sq73EhJQbcbzzg=",
-    "sri": "sha256-IMoaOKTujfjg/2wmxLa/7u2LqGC5KIwTffYsho67c1c="
+    "goModSum": "sha256-n22/ZMRK+Wm2z0bdnhKTjC8rO+8KG9wnVYMevQy7lsg=",
+    "sri": "sha256-w6MF0pKV6zfeVorfrxMm2AXR0uDgw5sG3zl5Ugm6SCU="
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,7 @@ require (
 	github.com/tailscale/ts-gokrazy v0.0.0-20260604151927-fc3a567bcf75
 	github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976
 	github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6
-	github.com/tailscale/wireguard-go v0.0.0-20260611001507-ffb138071028
+	github.com/tailscale/wireguard-go v0.0.0-20260622164646-ae172d45f0f7
 	github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e
 	github.com/tc-hib/winres v0.2.1
 	github.com/tcnksm/go-httpstat v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1180,8 +1180,8 @@ github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976 h1:U
 github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976/go.mod h1:agQPE6y6ldqCOui2gkIh7ZMztTkIQKH049tv8siLuNQ=
 github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6 h1:l10Gi6w9jxvinoiq15g8OToDdASBni4CyJOdHY1Hr8M=
 github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6/go.mod h1:ZXRML051h7o4OcI0d3AaILDIad/Xw0IkXaHM17dic1Y=
-github.com/tailscale/wireguard-go v0.0.0-20260611001507-ffb138071028 h1:7JTeI5o1zX1On3qkbpjD7Z6d0Cs2WXQ+QjY/aCY8FVM=
-github.com/tailscale/wireguard-go v0.0.0-20260611001507-ffb138071028/go.mod h1:6SerzcvHWQchKO2BfNdmquA77CHSECZuFl+D9fp4RnI=
+github.com/tailscale/wireguard-go v0.0.0-20260622164646-ae172d45f0f7 h1:u/nUghv4ajOqL+HelhnXtYifN4NHN3NuvQPeZRAds3s=
+github.com/tailscale/wireguard-go v0.0.0-20260622164646-ae172d45f0f7/go.mod h1:6SerzcvHWQchKO2BfNdmquA77CHSECZuFl+D9fp4RnI=
 github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e h1:zOGKqN5D5hHhiYUp091JqK7DPCqSARyUfduhGUY8Bek=
 github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e/go.mod h1:orPd6JZXXRyuDusYilywte7k094d7dycXXU5YnWsrwg=
 github.com/tc-hib/winres v0.2.1 h1:YDE0FiP0VmtRaDn7+aaChp1KiF4owBiJa5l964l5ujA=

--- a/shell.nix
+++ b/shell.nix
@@ -16,4 +16,4 @@
 ) {
   src =  ./.;
 }).shellNix
-# nix-direnv cache busting line: sha256-IMoaOKTujfjg/2wmxLa/7u2LqGC5KIwTffYsho67c1c=
+# nix-direnv cache busting line: sha256-w6MF0pKV6zfeVorfrxMm2AXR0uDgw5sG3zl5Ugm6SCU=


### PR DESCRIPTION
Fix leaking peers that failed to complete the handshake.

Updates #20183

Change-Id: I84f7ea0484f05b090d963a7d12c135a66a6a6964