### PR TITLE
util/cloudenv: detect Hetzner Cloud

### DIFF
--- a/util/cloudenv/cloudenv.go
+++ b/util/cloudenv/cloudenv.go
@@ -47,6 +47,7 @@ const (
 	Azure        = Cloud("azure")        // Microsoft Azure
 	GCP          = Cloud("gcp")          // Google Cloud
 	DigitalOcean = Cloud("digitalocean") // DigitalOcean
+	Hetzner      = Cloud("hetzner")      // Hetzner Cloud
 )
 
 // ResolverIP returns the cloud host's recursive DNS server or the
@@ -64,6 +65,8 @@ func (c Cloud) ResolverIP() string {
 		return AzureResolverIP
 	case DigitalOcean:
 		return getDigitalOceanResolver()
+	case Hetzner:
+		return getHetznerResolver()
 	}
 	return ""
 }
@@ -79,6 +82,21 @@ func getDigitalOceanResolver() string {
 	// one of them by sending all traffic there.
 	return digitalOceanResolver.Get(func() string {
 		return digitalOceanResolvers[rand.IntN(len(digitalOceanResolvers))]
+	})
+}
+
+var (
+	// https://docs.hetzner.com/robot/dedicated-server/general-information/recursive-name-servers/
+	// IPv6 resolvers also exist: 2a01:4ff:ff00::add:1, 2a01:4ff:ff00::add:2.
+	hetznerResolvers = []string{"185.12.64.1", "185.12.64.2"}
+	hetznerResolver  lazy.SyncValue[string]
+)
+
+func getHetznerResolver() string {
+	// Randomly select one of the available resolvers so we don't overload
+	// one of them by sending all traffic there.
+	return hetznerResolver.Get(func() string {
+		return hetznerResolvers[rand.IntN(len(hetznerResolvers))]
 	})
 }
 
@@ -127,6 +145,9 @@ func getCloud() Cloud {
 		sysVendor := readFileTrimmed("/sys/class/dmi/id/sys_vendor")
 		if sysVendor == "DigitalOcean" {
 			return DigitalOcean
+		}
+		if sysVendor == "Hetzner" {
+			return Hetzner
 		}
 		// TODO(andrew): "Vultr" is also valid if we need it
 


### PR DESCRIPTION
Detect Hetzner via /sys/class/dmi/id/sys_vendor == "Hetzner" and wire
up Hetzner's public recursive DNS resolvers (185.12.64.1, 185.12.64.2)
for use as a cloud host resolver.

Fixes #20217
