### PR TITLE
ipn/ipnlocal: reduce excessive logging of exit node suggestions

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -8730,6 +8730,8 @@ func fillAllowedSuggestions(polc policyclient.Client) (set.Set[tailcfg.StableNod
 // preferredDERP is this device's home DERP region (0 if unknown) and
 // regionLatency is the best recent latency to each DERP region; both come from
 // netcheck and are only used by the DERP-based algorithm.
+//
+// Errors are always logged. Suggestions are logged if they defer from prevSuggestion.
 func suggestExitNode(preferredDERP int, regionLatency map[int]time.Duration, nb *nodeBackend, prevSuggestion tailcfg.StableNodeID, selectRegion selectRegionFunc, selectNode selectNodeFunc, allowList set.Set[tailcfg.StableNodeID]) (res apitype.ExitNodeSuggestionResponse, err error) {
 	switch {
 	case nb.SelfHasCap(tailcfg.NodeAttrTrafficSteering):
@@ -8744,8 +8746,10 @@ func suggestExitNode(preferredDERP int, regionLatency map[int]time.Duration, nb 
 	if err != nil {
 		nb.logf("netmap: suggested exit node: %v", err)
 	} else {
-		name, _, _ := strings.Cut(res.Name, ".")
-		nb.logf("netmap: suggested exit node: %s (%s)", name, res.ID)
+		if res.ID != prevSuggestion {
+			name, _, _ := strings.Cut(res.Name, ".")
+			nb.logf("netmap: suggested exit node: %s (%s)", name, res.ID)
+		}
 	}
 	return res, err
 }


### PR DESCRIPTION
The logging added in 12188c0 was generating excessive spam in
backend logs. This may have been exacerbated by
tailscale GUI<->backend architecture on certain platforms like
Windows, where the GUI polls for exit node suggestions rather
than listening on the IPN bus.

Change this to log on error or if the current suggestion differs
from the previous suggestion.

Updates tailscale/corp#43691