### PR TITLE
cmd/tailscale/cli: fix capitalisation of flags

### DIFF
--- a/cmd/tailscale/cli/appcroutes.go
+++ b/cmd/tailscale/cli/appcroutes.go
@@ -28,9 +28,9 @@ var appcRoutesCmd = &ffcli.Command{
 	ShortHelp:  "Print the current app connector routes",
 	FlagSet: (func() *flag.FlagSet {
 		fs := newFlagSet("appc-routes")
-		fs.BoolVar(&appcRoutesArgs.all, "all", false, "Print learned domains and routes and extra policy configured routes.")
-		fs.BoolVar(&appcRoutesArgs.domainMap, "map", false, "Print the map of learned domains: [routes].")
-		fs.BoolVar(&appcRoutesArgs.n, "n", false, "Print the total number of routes this node advertises.")
+		fs.BoolVar(&appcRoutesArgs.all, "all", false, "print learned domains and routes and extra policy configured routes.")
+		fs.BoolVar(&appcRoutesArgs.domainMap, "map", false, "print the map of learned domains: [routes].")
+		fs.BoolVar(&appcRoutesArgs.n, "n", false, "print the total number of routes this node advertises.")
 		return fs
 	})(),
 	LongHelp: strings.TrimSpace(`

--- a/cmd/tailscale/cli/configure-kube.go
+++ b/cmd/tailscale/cli/configure-kube.go
@@ -44,7 +44,7 @@ See: https://tailscale.com/s/k8s-auth-proxy
 `),
 		FlagSet: (func() *flag.FlagSet {
 			fs := newFlagSet("kubeconfig")
-			fs.BoolVar(&configureKubeconfigArgs.http, "http", false, "Use HTTP instead of HTTPS to connect to the auth proxy. Ignored if you include a scheme in the hostname argument.")
+			fs.BoolVar(&configureKubeconfigArgs.http, "http", false, "use HTTP instead of HTTPS to connect to the auth proxy. Ignored if you include a scheme in the hostname argument.")
 			return fs
 		})(),
 		Exec: runConfigureKubeconfig,

--- a/cmd/tailscale/cli/configure_linux.go
+++ b/cmd/tailscale/cli/configure_linux.go
@@ -33,7 +33,7 @@ func systrayConfigCmd() *ffcli.Command {
 		FlagSet: (func() *flag.FlagSet {
 			fs := newFlagSet("systray")
 			fs.StringVar(&configSystrayArgs.initSystem, "enable-startup", "",
-				"Install startup script for init system. Currently supported systems are [systemd, freedesktop].")
+				"install startup script for init system. Currently supported systems are [systemd, freedesktop].")
 			return fs
 		})(),
 	}

--- a/cmd/tailscale/cli/debug.go
+++ b/cmd/tailscale/cli/debug.go
@@ -258,7 +258,7 @@ func debugCmd() *ffcli.Command {
 				ShortHelp:  "Print prefs",
 				FlagSet: (func() *flag.FlagSet {
 					fs := newFlagSet("prefs")
-					fs.BoolVar(&prefsArgs.pretty, "pretty", false, "If true, pretty-print output")
+					fs.BoolVar(&prefsArgs.pretty, "pretty", false, "if true, pretty-print output")
 					return fs
 				})(),
 			},

--- a/cmd/tailscale/cli/set.go
+++ b/cmd/tailscale/cli/set.go
@@ -77,7 +77,7 @@ func newSetFlagSet(goos string, setArgs *setArgsT) *flag.FlagSet {
 	setf.BoolVar(&setArgs.acceptRoutes, "accept-routes", acceptRouteDefault(goos), "accept routes advertised by other Tailscale nodes")
 	setf.BoolVar(&setArgs.acceptDNS, "accept-dns", true, "accept DNS configuration from the admin panel")
 	setf.StringVar(&setArgs.exitNodeIP, "exit-node", "", "Tailscale exit node (IP, base name, or auto:any) for internet traffic, or empty string to not use an exit node")
-	setf.BoolVar(&setArgs.exitNodeAllowLANAccess, "exit-node-allow-lan-access", false, "Allow direct access to the local network when routing traffic via an exit node")
+	setf.BoolVar(&setArgs.exitNodeAllowLANAccess, "exit-node-allow-lan-access", false, "allow direct access to the local network when routing traffic via an exit node")
 	setf.BoolVar(&setArgs.shieldsUp, "shields-up", false, "don't allow incoming connections")
 	setf.BoolVar(&setArgs.runSSH, "ssh", false, "run an SSH server, permitting access per tailnet admin's declared policy")
 	setf.StringVar(&setArgs.hostname, "hostname", "", "hostname to use instead of the one provided by the OS")

--- a/cmd/tailscale/cli/status.go
+++ b/cmd/tailscale/cli/status.go
@@ -54,7 +54,7 @@ https://github.com/tailscale/tailscale/blob/main/ipn/ipnstate/ipnstate.go
 		fs.BoolVar(&statusArgs.self, "self", true, "show status of local machine")
 		fs.BoolVar(&statusArgs.peers, "peers", true, "show status of peers")
 		fs.StringVar(&statusArgs.listen, "listen", "127.0.0.1:8384", "listen address for web mode; use port 0 for automatic")
-		fs.BoolVar(&statusArgs.browser, "browser", true, "Open a browser in web mode")
+		fs.BoolVar(&statusArgs.browser, "browser", true, "open a browser in web mode")
 		fs.BoolVar(&statusArgs.header, "header", false, "show column headers in table format")
 		return fs
 	})(),

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -110,7 +110,7 @@ func newUpFlagSet(goos string, upArgs *upArgsT, cmd string) *flag.FlagSet {
 	upf.BoolVar(&upArgs.acceptDNS, "accept-dns", true, "accept DNS configuration from the admin panel")
 	upf.Var(notFalseVar{}, "host-routes", hidden+"install host routes to other Tailscale nodes (must be true as of Tailscale 1.67+)")
 	upf.StringVar(&upArgs.exitNodeIP, "exit-node", "", "Tailscale exit node (IP, base name, or auto:any) for internet traffic, or empty string to not use an exit node")
-	upf.BoolVar(&upArgs.exitNodeAllowLANAccess, "exit-node-allow-lan-access", false, "Allow direct access to the local network when routing traffic via an exit node")
+	upf.BoolVar(&upArgs.exitNodeAllowLANAccess, "exit-node-allow-lan-access", false, "allow direct access to the local network when routing traffic via an exit node")
 	upf.BoolVar(&upArgs.shieldsUp, "shields-up", false, "don't allow incoming connections")
 	upf.BoolVar(&upArgs.runSSH, "ssh", false, "run an SSH server, permitting access per tailnet admin's declared policy")
 	upf.StringVar(&upArgs.advertiseTags, "advertise-tags", "", "comma-separated ACL tags to request (e.g. \"tag:eng,tag:montreal,tag:ssh\"); the \"tag:\" prefix is optional and added automatically when omitted (e.g. \"eng,montreal,ssh\")")


### PR DESCRIPTION
Most of our flag descriptions start with a lowercase word (except proper nouns); fix the handful which do not.

Fixes #20230