### PR TITLE
tstest/natlab/vnet: mark TestPacketSideEffects as flaky

### DIFF
--- a/tstest/natlab/vnet/vnet_test.go
+++ b/tstest/natlab/vnet/vnet_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
+	"tailscale.com/cmd/testwrapper/flakytest"
 	"tailscale.com/util/must"
 )
 
@@ -188,6 +189,7 @@ func TestPacketSideEffects(t *testing.T) {
 			},
 		},
 	}
+	flakytest.Mark(t, "https://github.com/tailscale/tailscale/issues/20019")
 	for _, tt := range tests {
 		t.Run(tt.netName, func(t *testing.T) {
 			s, err := tt.setup()


### PR DESCRIPTION
Updates #20019