### PR TITLE
CODEOWNERS,.policy.yml: replace CODEOWNERS with a policy-bot policy

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -1,0 +1,57 @@
+# Approval policy for this repository, enforced by policy-bot
+# (https://github.com/palantir/policy-bot) running at
+# https://policybot.corp.ts.net.
+#
+# This file replaces the role GitHub's CODEOWNERS played: when a pull
+# request touches a path covered by a rule below, policy-bot posts a
+# status check that blocks merging until the required reviewers approve.
+#
+# Policy and rule syntax reference:
+#   https://github.com/palantir/policy-bot/blob/develop/README.md
+# Example policy files (team-approval, disapproval, remote, etc.):
+#   https://github.com/palantir/policy-bot/tree/develop/config/policy-examples
+#
+# Do not add to this policy without wide discussion.
+# See https://github.com/tailscale/corp/issues/13972.
+
+policy:
+  approval:
+    - or:
+        - tailcfg changes approved by control-protocol-owners
+        - tailcfg changes overridden by another tailscale/dev
+
+approval_rules:
+  - name: tailcfg changes approved by control-protocol-owners
+    if:
+      changed_files:
+        paths:
+          - "^tailcfg/"
+    requires:
+      count: 1
+      teams:
+        - "tailscale/control-protocol-owners"
+
+  - name: tailcfg changes overridden by another tailscale/dev
+    description: |
+      Any member of @tailscale/dev (other than the PR author) can
+      override the control-protocol-owners requirement by leaving a
+      comment of the form
+
+          policybot-override: <reason>
+
+      on the pull request. The reason can be anything but should
+      explain why the override is appropriate; it stays in the PR
+      conversation as a record. The override comment also counts as
+      that developer's approval.
+    if:
+      changed_files:
+        paths:
+          - "^tailcfg/"
+    requires:
+      count: 1
+      teams:
+        - "tailscale/dev"
+    options:
+      methods:
+        comment_patterns:
+          - '^policybot-override: \S.*'

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,7 @@
-/tailcfg/ @tailscale/control-protocol-owners
-
-# Do not add to this list without wide discussion.
-# See https://github.com/tailscale/corp/issues/13972
+# This repository does NOT use GitHub's CODEOWNERS for review enforcement.
+# Approval policies live in .policy.yml at the repository root and are
+# enforced by policy-bot (https://github.com/palantir/policy-bot).
+#
+# To change required reviewers for a path, edit .policy.yml.
+#
+# See https://github.com/tailscale/corp/issues/13972.


### PR DESCRIPTION
GitHub's built-in CODEOWNERS only supports a hard "block until a team
member reviews" rule, with no way to leave an audit trail when the
requirement is intentionally bypassed. Move review enforcement to
palantir/policy-bot (https://github.com/palantir/policy-bot) running
at https://policybot.corp.ts.net, which lets us express the same
tailcfg/ -> control-protocol-owners rule plus an explicit override:
any other @tailscale/dev member can post

    policybot-override: <reason>

as a PR comment and that comment counts as their approval, with the
reason recorded in the PR conversation as a permanent audit trail.

CODEOWNERS is kept as a one-screen comment so anyone landing on it
expecting the old behavior is directed to .policy.yml.

Updates tailscale/corp#13972
