### PR TITLE
tool/gocross: retry downloading Go three times

### DIFF
--- a/tool/gocross/gocross-wrapper.sh
+++ b/tool/gocross/gocross-wrapper.sh
@@ -75,7 +75,7 @@ case "$REV" in
             # Go uses the name "amd64".
             HOST_ARCH="amd64"
         fi
-        curl -f -L -o "$toolchain.tar.gz" "https://github.com/tailscale/go/releases/download/build-${REV}/${HOST_OS}-${HOST_ARCH}.tar.gz"
+        curl --retry 3 -f -L -o "$toolchain.tar.gz" "https://github.com/tailscale/go/releases/download/build-${REV}/${HOST_OS}-${HOST_ARCH}.tar.gz"
         mkdir -p "$toolchain"
         (cd "$toolchain" && tar --strip-components=1 -xf "$toolchain.tar.gz")
         echo "$REV" >"$toolchain.extracted"


### PR DESCRIPTION
Occasionally CI jobs will flake because downloading from GitHub fails, for example: https://github.com/tailscale/tailscale/actions/runs/28227841073/job/83624049038?pr=20265

Allow retrying up to 3 times to reduce CI flakiness.

Updates #cleanup