### PR TITLE
util/limiter: don't panic on Allow for a zero-value limiter

### DIFF
--- a/util/limiter/limiter.go
+++ b/util/limiter/limiter.go
@@ -131,6 +131,13 @@ func (lm *Limiter[K]) allowBucketLocked(b *bucket, now time.Time) bool {
 }
 
 func (lm *Limiter[K]) updateBucketLocked(b *bucket, now time.Time) {
+	if lm.RefillInterval <= 0 {
+		// No refill rate configured (e.g. the zero-value limiter, which
+		// is documented to reject all requests). Tokens never regenerate,
+		// so there's nothing to update, and dividing by the interval below
+		// would panic.
+		return
+	}
 	now = now.Truncate(lm.RefillInterval)
 	if now.Before(b.lastUpdate) {
 		return

--- a/util/limiter/limiter_test.go
+++ b/util/limiter/limiter_test.go
@@ -180,6 +180,13 @@ func TestDumpHTMLEmpty(t *testing.T) {
 	new(Limiter[string]).DumpHTML(io.Discard, false) // should not panic
 }
 
+func TestZeroValueRejects(t *testing.T) {
+	// The zero value is documented to be a valid limiter that rejects
+	// all requests. With no RefillInterval set it must not panic.
+	var lm Limiter[string]
+	denied(t, &lm, "foo", 3, time.Now())
+}
+
 func allowed(t *testing.T, limiter *Limiter[string], key string, count int, now time.Time) {
 	t.Helper()
 	for i := range count {


### PR DESCRIPTION
The `Limiter` type doc says:

> The zero value is a valid limiter that rejects all requests. A useful limiter must specify a Size, Max and RefillInterval.

But calling `Allow` on a zero-value `Limiter` panics instead of rejecting:

```
panic: runtime error: integer divide by zero
    tailscale.com/util/limiter.(*Limiter[...]).updateBucketLocked .../util/limiter/limiter.go:139
    tailscale.com/util/limiter.(*Limiter[...]).allowBucketLocked .../util/limiter/limiter.go:124
    tailscale.com/util/limiter.(*Limiter[...]).allow .../util/limiter/limiter.go:104
```

A fresh bucket starts at `cur = Max` (0 for the zero value), so `allowBucketLocked` sees `cur <= 0` and calls `updateBucketLocked`, which does `int64(timeDelta / lm.RefillInterval)`. `RefillInterval` is 0 for the zero value, so the division panics.

This is the same class of bug as #18396 ("don't panic when dumping a new Limiter"), which fixed the `DumpHTML` path but not the `Allow` path.

Fix: return early from `updateBucketLocked` when `RefillInterval <= 0`. With no refill rate there is nothing to refill, so the bucket stays at 0 tokens and `Allow` rejects the request, matching the documented behavior. Configured limiters (`RefillInterval > 0`) are unaffected.

Added `TestZeroValueRejects`, which panics before this change and passes after. `go test ./util/limiter/`, `go vet`, and `gofmt` are clean.