### PR TITLE
ipn/ipnlocal: report VIP service ports from the store before first netmap

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -367,9 +367,11 @@ type LocalBackend struct {
 	capForcedNetfilter string // TODO(nickkhyl): move to nodeBackend
 
 	// ServeConfig fields. (also guarded by mu)
-	lastServeConfJSON mem.RO                   // last JSON that was parsed into serveConfig
-	serveConfig       ipn.ServeConfigView      // or !Valid if none
-	ipVIPServiceMap   netmap.IPServiceMappings // map of VIPService IPs to their corresponding service names; TODO(nickkhyl): move to nodeBackend
+	lastServeConfJSON     mem.RO                   // last JSON that was parsed into serveConfig
+	serveConfig           ipn.ServeConfigView      // or !Valid if none
+	serveConfigLoadedOnce sync.Once                // latches serveConfigLoaded to true the first time reloadServeConfigLocked consults the store
+	serveConfigLoaded     bool                     // whether reloadServeConfigLocked has consulted the store yet; until then serveConfig may be stale/empty even if one is persisted. Set only via serveConfigLoadedOnce; never reset.
+	ipVIPServiceMap       netmap.IPServiceMappings // map of VIPService IPs to their corresponding service names; TODO(nickkhyl): move to nodeBackend
 
 	webClient          webClient
 	webClientListeners map[netip.AddrPort]*localListener // listeners for local web client traffic

--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -502,11 +502,45 @@ func (b *LocalBackend) HandleIngressTCPConn(ingressPeer tailcfg.NodeView, target
 	handler(c)
 }
 
+// serveConfigFromStoreLocked reads and parses the current profile's persisted
+// serve config directly from the state store, without touching b.serveConfig,
+// b.lastServeConfJSON, the cert refresh loop, or any other in-memory state. It
+// returns an invalid view if there is no current profile, nothing is stored, or
+// the stored config doesn't parse.
+//
+// b.mu must be held.
+func (b *LocalBackend) serveConfigFromStoreLocked() ipn.ServeConfigView {
+	pid := b.pm.CurrentProfile().ID()
+	if pid == "" {
+		return ipn.ServeConfigView{}
+	}
+	confj, err := b.store.ReadState(ipn.ServeConfigKey(pid))
+	if err != nil {
+		return ipn.ServeConfigView{}
+	}
+	var conf ipn.ServeConfig
+	if err := json.Unmarshal(confj, &conf); err != nil {
+		return ipn.ServeConfigView{}
+	}
+	return conf.View()
+}
+
 func (b *LocalBackend) vipServicesFromPrefsLocked(prefs ipn.PrefsView) []*tailcfg.VIPService {
 	// keyed by service name
 	var services map[tailcfg.ServiceName]*tailcfg.VIPService
-	if b.serveConfig.Valid() {
-		for svc, config := range b.serveConfig.Services().All() {
+
+	sc := b.serveConfig
+	if !sc.Valid() && !b.serveConfigLoaded {
+		// We have no valid serve config in memory and reloadServeConfigLocked
+		// hasn't consulted the store yet, so b.serveConfig may be empty even though a config is
+		// persisted. If an inbound c2n GET /vip-services races that first reload
+		// we'd report advertised services with no ports, which control will
+		// caches and make service host restart fail.
+		sc = b.serveConfigFromStoreLocked()
+	}
+
+	if sc.Valid() {
+		for svc, config := range sc.Services().All() {
 			mak.Set(&services, svc, &tailcfg.VIPService{
 				Name:  svc,
 				Ports: config.ServicePortRange(),
@@ -1536,6 +1570,15 @@ func (b *LocalBackend) reloadServeConfigLocked(prefs ipn.PrefsView) {
 		b.serveConfig = ipn.ServeConfigView{}
 		return
 	}
+
+	// We're past the gate and committed to consulting the store, so latch
+	// serveConfigLoaded one-way (sync.Once): from here on b.serveConfig
+	// authoritatively reflects the store — including "no config persisted",
+	// which falls through as a ReadState error below — and reload keeps it
+	// fresh, so the report path can trust it and stop reading the store. This
+	// must cover the no-config path too; otherwise nodes that never use serve
+	// would re-read the store on every report.
+	b.serveConfigLoadedOnce.Do(func() { b.serveConfigLoaded = true })
 
 	confKey := ipn.ServeConfigKey(b.pm.CurrentProfile().ID())
 	// TODO(maisem,bradfitz): prevent reading the config from disk

--- a/ipn/ipnlocal/serve_test.go
+++ b/ipn/ipnlocal/serve_test.go
@@ -1148,6 +1148,154 @@ func newTestBackend(t *testing.T, opts ...any) *LocalBackend {
 	return b
 }
 
+// TestVIPServicesReportStableAcrossReload checks the invariant the startup-race
+// fix establishes: the VIP services a node reports — the list control fetches via
+// c2n GET /vip-services AND the Hostinfo.ServicesHash derived from it
+// (vipServiceHash) — are identical before the first netmap has loaded serveConfig
+// into memory and after. That stability is the whole point: the node never emits
+// a port-less report for control to cache, so control never sees a
+// port-less<->ported ServicesHash transition. Before the fix the pre-reload
+// report dropped the ports, so the hash changed across reload and these
+// assertions fail.
+//
+// vipServicesFromPrefsLocked + vipServiceHash are exactly the two surfaces that
+// reach control: VIPServices() (the c2n answer) and maybeUpdateHostinfoServicesHashLocked
+// (the Hostinfo hash) both go through them.
+func TestVIPServicesReportStableAcrossReload(t *testing.T) {
+	tcp443 := tailcfg.ProtoPortRange{Proto: 6, Ports: tailcfg.PortRange{First: 443, Last: 443}}
+	served := &ipn.ServeConfig{
+		Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
+			"svc:abc": {TCP: map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}}},
+		},
+	}
+	tests := []struct {
+		name      string
+		advertise []string
+		conf      *ipn.ServeConfig
+		wantPorts bool
+	}{
+		{"served-and-advertised", []string{"svc:abc"}, served, true},
+		// The fix must not be gated on AdvertiseServices: a served-but-not-yet-
+		// advertised service must still report its ports consistently.
+		{"served-not-advertised", nil, served, true},
+		// Legitimately port-less (advertised but nothing served): must stay
+		// consistent across reload, just with no ports.
+		{"advertised-not-served", []string{"svc:abc"}, &ipn.ServeConfig{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := newTestBackend(t)
+			pid := b.pm.CurrentProfile().ID()
+			prefs := (&ipn.Prefs{AdvertiseServices: tt.advertise}).View()
+			if err := b.store.WriteState(ipn.ServeConfigKey(pid), must.Get(json.Marshal(tt.conf))); err != nil {
+				t.Fatal(err)
+			}
+
+			report := func() ([]*tailcfg.VIPService, string) {
+				list := b.vipServicesFromPrefsLocked(prefs)
+				return list, vipServiceHash(b.logf, list)
+			}
+
+			// Pre-reload: serveConfig not loaded, latch unset — the state an
+			// early c2n and the initial Hostinfo hash observe on restart.
+			b.serveConfig = ipn.ServeConfigView{}
+			beforeList, beforeHash := report()
+
+			// The first netmap arrives: reloadServeConfigLocked loads the config
+			// and latches serveConfigLoaded.
+			b.reloadServeConfigLocked(b.pm.CurrentPrefs())
+			afterList, afterHash := report()
+
+			if beforeHash != afterHash {
+				t.Errorf("ServicesHash changed across reload:\n before=%s %+v\n after =%s %+v",
+					beforeHash, beforeList, afterHash, afterList)
+			}
+			if !reflect.DeepEqual(beforeList, afterList) {
+				t.Errorf("VIP services list changed across reload:\n before=%+v\n after =%+v", beforeList, afterList)
+			}
+			gotPorts := len(afterList) == 1 && len(afterList[0].Ports) == 1 && afterList[0].Ports[0] == tcp443
+			if gotPorts != tt.wantPorts {
+				t.Errorf("reported with ports=%v, want %v: %+v", gotPorts, tt.wantPorts, afterList)
+			}
+		})
+	}
+}
+
+// TestVIPServicesC2NReportsPorts drives the real c2n GET /vip-services handler
+// and checks that the response control actually receives carries the service
+// ports — and the same ServicesHash — in every in-memory state the handler can
+// run in: before the first netmap has loaded serveConfig (a restart racing the
+// netmap; the store fallback must kick in) and after (steady state, from memory).
+// Both must equal the canonical answer, so control never sees a
+// port-less<->ported ServicesHash transition. Before the fix the not-yet-loaded
+// state answered port-less.
+func TestVIPServicesC2NReportsPorts(t *testing.T) {
+	conf := &ipn.ServeConfig{
+		Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
+			"svc:abc": {TCP: map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}}},
+		},
+	}
+
+	// answerC2N runs the real handler against b and returns the decoded response.
+	answerC2N := func(t *testing.T, b *LocalBackend) tailcfg.C2NVIPServicesResponse {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		handleC2NVIPServicesGet(b, rec, httptest.NewRequest("GET", "/vip-services", nil))
+		var res tailcfg.C2NVIPServicesResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &res); err != nil {
+			t.Fatalf("decoding c2n response: %v", err)
+		}
+		return res
+	}
+
+	// newBackend returns a fresh backend with the serve config persisted on disk
+	// (but not yet loaded into memory).
+	newBackend := func(t *testing.T) *LocalBackend {
+		t.Helper()
+		b := newTestBackend(t)
+		if err := b.store.WriteState(ipn.ServeConfigKey(b.pm.CurrentProfile().ID()), must.Get(json.Marshal(conf))); err != nil {
+			t.Fatal(err)
+		}
+		return b
+	}
+
+	// The canonical answer is the steady state, with serveConfig fully loaded.
+	ref := newBackend(t)
+	ref.reloadServeConfigLocked(ref.pm.CurrentPrefs())
+	want := answerC2N(t, ref)
+	if len(want.VIPServices) != 1 || len(want.VIPServices[0].Ports) == 0 {
+		t.Fatalf("reference c2n answer = %+v; want svc:abc with ports", want.VIPServices)
+	}
+
+	tests := []struct {
+		name  string
+		setup func(b *LocalBackend) // arrange the in-memory serveConfig before the c2n
+	}{
+		{
+			// Restart before the first netmap: config on disk, serveConfig empty
+			// in memory, latch unset. The store fallback must kick in.
+			name:  "not-yet-loaded",
+			setup: func(b *LocalBackend) { b.serveConfig = ipn.ServeConfigView{} },
+		},
+		{
+			// Steady state after the first netmap: serveConfig loaded in memory.
+			name:  "already-loaded",
+			setup: func(b *LocalBackend) { b.reloadServeConfigLocked(b.pm.CurrentPrefs()) },
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := newBackend(t)
+			tt.setup(b)
+			got := answerC2N(t, b)
+			if got.ServicesHash != want.ServicesHash || !reflect.DeepEqual(got.VIPServices, want.VIPServices) {
+				t.Errorf("c2n answer differs from the canonical (loaded) answer:\n got =%s %+v\n want=%s %+v",
+					got.ServicesHash, got.VIPServices, want.ServicesHash, want.VIPServices)
+			}
+		})
+	}
+}
+
 func TestServeFileOrDirectory(t *testing.T) {
 	td := t.TempDir()
 	writeFile := func(suffix, contents string) {


### PR DESCRIPTION
### What happens

`tailscale serve` config is persisted on disk but isn't loaded into memory until
the first netmap arrives — `reloadServeConfigLocked` is gated on `Self().Valid()`.
On a node that doesn't restore a cached netmap, there's a window at startup where
`serveConfig` is empty, and that window is where this bug lives.

During that window the node reports its VIP services to control.
`vipServicesFromPrefsLocked` builds that list from the (empty) `serveConfig` plus
the advertised service names, so it emits *names with no ports*. That port-less
list goes out two ways that derive from the same function: the
`Hostinfo.ServicesHash`, and the answer to control's `c2n GET /vip-services`
fetch. The c2n is answered on a separate goroutine (`answerPing`) that's started
*before* the netmap is applied, so on a large/slow tailnet it wins the race and
reads the still-empty config. Control caches that port-less config.

Why it doesn't recover on its own: the client's Hostinfo update is *one-shot and
edge-triggered*. After the netmap lands, `reloadServeConfigLocked` loads the
config and `maybeUpdateHostinfoServicesHashLocked` recomputes the hash; because
the ported hash differs from the recorded port-less one, the client sends a
corrected Hostinfo *once* and records the ported hash. It does not send again
unless the hash changes again. So when the in-flight port-less fetch lands a
moment later and overwrites control's *stored* hash to port-less, the client's
recorded hash already equals its current (ported) hash — there is nothing to
re-trigger a send. Control is left stuck on the port-less config until the
service config actually changes (which would produce a new hash and a fresh
send). That's the "advertising but configuration missing" the customer saw, with
Serve proxies returning "no TCP handler."

### The fix

The real problem is that the node *reports* port-less while it actually has a
config on disk. This PR makes `vipServicesFromPrefsLocked` fall back to reading
the persisted config directly (`serveConfigFromStoreLocked`) when `serveConfig`
hasn't been loaded yet. Since both the c2n answer and the `Hostinfo.ServicesHash`
come from that one function, the node reports its real ports from its very first
message — its recorded hash is the ported hash from the start, control never
caches a port-less config, and the one-shot/edge-triggered update never has a
divergence to fix.

We chose this over a control-side fix (refusing a ported→port-less transition)
because a node legitimately tearing down its serve config produces an *identical*
port-less report — control can't tell the two apart. Fixing it at the source is
both simpler and unambiguous. A control-side re-reconcile would additionally help
un-upgraded clients, but would link two logically identical operations (C2N from startup 
hostinfo update and first netmap response).

### Why it's safe and narrowly scoped

- The fallback is gated by a *write-once `serveConfigLoaded` latch*, guarded by
  the same lock as `serveConfig`. The moment `reloadServeConfigLocked` consults
  the store, the latch is set and the fallback never runs again — so there are no
  per-call store reads in steady state, including for the majority of nodes that
  never use serve. A node that genuinely has no config keeps reporting empty; we
  don't resurrect a stale one.
- It only changes *what we report*, not *when* `serveConfig` is populated. All
  serving machinery — `tcpHandlerForVIPService`, listeners, port intercepts, cert
  refresh — stays netmap-gated exactly as before.
- *Containerized clients are unaffected.* containerboot pushes serve config
  through `SetServeConfig` after the netmap and unsets+reapplies on every startup,
  so any real change rides the existing `SetServeConfig`→hash→c2n path and
  converges via containerboot. The fallback only restores the already-in-effect
  config during the startup window, and the latch guarantees no store re-read
  afterward, so a stale mounted-file config can't be resurrected. (Containers are
  also less exposed to begin with — that unset+reapply churns the hash and
  triggers re-fetches that self-heal.)

Fixes tailscale/corp#44108