### PR TITLE
kube/certs: widen runCertLoop per-call timeout to 30m

### DIFF
--- a/kube/certs/certs.go
+++ b/kube/certs/certs.go
@@ -136,11 +136,10 @@ func (cm *CertManager) runCertLoop(ctx context.Context, domain string) {
 			// node's HTTPS endpoint share the same state/renewal lock mechanism,
 			// so we should not run into redundant issuances during concurrent
 			// renewal checks.
-
-			// An issuance holds a shared lock, so we need to avoid a situation
-			// where other services cannot issue certs because a single one is
-			// holding the lock.
-			ctxT, cancel := context.WithTimeout(ctx, time.Second*300)
+			//
+			// Long enough to cover queue contention behind tailscaled's
+			// shared cert mutex; if it fires, something is wedged.
+			ctxT, cancel := context.WithTimeout(ctx, 30*time.Minute)
 			_, _, err := cm.lc.CertPair(ctxT, domain)
 			cancel()
 			if err != nil {


### PR DESCRIPTION
All issuances serialise through a single mutex in tailscaled. The old 300s timeout fired while a predecessor was legitimately mid-ACME, causing the queued loop to advance retryCount on a non-failure. 30m covers ~15 queued flows and works as a wedge detector against true hangs.

It should also be noted that this is a temporary fix while we build parallelisation of certificate requests into IPN.

Updates #20288