### PR TITLE
ipn/ipnlocal: fix reporting of active ipnext extensions

### DIFF
--- a/ipn/ipnlocal/extension_host.go
+++ b/ipn/ipnlocal/extension_host.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"reflect"
 	"slices"
 	"strings"
@@ -269,7 +268,10 @@ func (h *ExtensionHost) init() {
 	// Report active extensions to the log.
 	// TODO(nickkhyl): update client metrics to include the active/failed/skipped extensions.
 	h.mu.Lock()
-	extensionNames := slices.Collect(maps.Keys(h.extensionsByName))
+	var extensionNames []string
+	for _, ext := range h.activeExtensions {
+		extensionNames = append(extensionNames, ext.Name())
+	}
 	h.mu.Unlock()
 	h.logf("active extensions: %v", strings.Join(extensionNames, ", "))
 


### PR DESCRIPTION
We borked this in 30a89ad3781aa99ee8b92e1ecfdab0f90034a02c and started including skipped extensions (e.g., `conn25` when `TAILSCALE_USE_WIP_CODE != 1`) in the list of active ones.

This doesn't seem to have any impact other than on logging, though.

Updates #cleanup