### PR TITLE
util/winutil: fix a typo where we repeat we repeat ourselves

### DIFF
--- a/util/winutil/winutil_windows.go
+++ b/util/winutil/winutil_windows.go
@@ -163,7 +163,7 @@ func getRegStringsInternal(subKey, name string) ([]string, error) {
 	return val, nil
 }
 
-// SetRegStrings sets a MULTI_SZ value in the in the local machine path
+// SetRegStrings sets a MULTI_SZ value in the local machine path
 // to the strings specified by values.
 func SetRegStrings(name string, values []string) error {
 	return setRegStringsInternal(regBase, name, values)


### PR DESCRIPTION
Found with the regex `\b([A-Za-z]+ [A-Za-z]+) \1\b`.

Updates #cleanup