### PR TITLE
{ipn/conffile,cmd,gokrazy}: optional cloud init config

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -223,7 +223,7 @@ func main() {
 	}
 	flag.BoolVar(&printVersion, "version", false, "print version information and exit")
 	flag.BoolVar(&args.disableLogs, "no-logs-no-support", false, "disable log uploads; this also disables any technical support")
-	flag.StringVar(&args.confFile, "config", "", "path to config file, or 'vm:user-data' to use the VM's user-data (EC2)")
+	flag.StringVar(&args.confFile, "config", "", "path to config file, or 'vm:user-data' to use the VM's user-data (EC2); prefix with 'optional:' to boot unconfigured when the source is absent instead of failing")
 	if buildfeatures.HasTPM {
 		flag.Var(&args.hardwareAttestation, "hardware-attestation", `use hardware-backed keys to bind node identity to this device when supported
 by the OS and hardware. Uses TPM 2.0 on Linux and Windows; SecureEnclave on
@@ -431,11 +431,24 @@ func run() (err error) {
 	// Parse config, if specified, to fail early if it's invalid.
 	var conf *conffile.Config
 	if args.confFile != "" {
-		conf, err = conffile.Load(args.confFile)
-		if err != nil {
+		// An "optional:" prefix (e.g. "optional:vm:user-data") means it's fine
+		// for the config source to be absent: boot unconfigured and let the node
+		// be enrolled interactively instead of failing to start. A config that's
+		// present but invalid still fails, even when optional.
+		path := args.confFile
+		optional := false
+		if p, ok := strings.CutPrefix(path, "optional:"); ok {
+			optional, path = true, p
+		}
+		conf, err = conffile.Load(path)
+		switch {
+		case err == nil:
+			sys.InitialConfig = conf
+		case optional && errors.Is(err, conffile.ErrNoConfig):
+			logf("config: none present at %q; continuing unconfigured", path)
+		default:
 			return fmt.Errorf("error reading config file: %w", err)
 		}
-		sys.InitialConfig = conf
 	}
 
 	var netMon *netmon.Monitor

--- a/flake.nix
+++ b/flake.nix
@@ -164,6 +164,10 @@
           # Makefile target that boots the Tailscale appliance under qemu.
           mtools
           dtc
+
+          # awscli2 is used by gokrazy/build.go to import and register the
+          # Tailscale appliance AMI.
+          awscli2.out
         ];
       };
     });

--- a/gokrazy/README.md
+++ b/gokrazy/README.md
@@ -74,3 +74,30 @@ $ aws ec2-instance-connect send-serial-console-ssh-public-key --instance-id i-0b
 }
 $ ssh i-0b4a0eabc43629f13.port0@serial-console.ec2-instance-connect.us-west-2.aws 
 ```
+
+### Configuring the appliance
+
+The appliance's `tailscaled` runs with `-config=optional:vm:user-data`, so a
+single AMI supports two ways of joining a tailnet:
+
+- **Declarative (user-data):** put a Tailscale config (the `alpha0` HuJSON
+  format) in the instance's user-data and the node configures itself on first
+  boot. The minimal config is just an auth key:
+
+  ```json
+  {
+    "Version": "alpha0",
+    "AuthKey": "tskey-auth-..."
+  }
+  ```
+
+  A config present in user-data locks the CLI (`tailscale set`/`up` are
+  rejected) unless it sets `"Locked": false`.
+
+- **Interactive (serial console):** launch the AMI with *no* user-data. The
+  `optional:` prefix means the missing config is not an error, so `tailscaled`
+  boots unconfigured and you can enroll it over the serial console (connect as
+  above, then run `tailscale up` and open the printed login URL).
+
+To require config instead (fail to boot if none is present), build an image
+whose `tailscaled` uses `-config=vm:user-data` without the `optional:` prefix.

--- a/gokrazy/README.md
+++ b/gokrazy/README.md
@@ -92,7 +92,9 @@ single AMI supports two ways of joining a tailnet:
   ```
 
   A config present in user-data locks the CLI (`tailscale set`/`up` are
-  rejected) unless it sets `"Locked": false`.
+  rejected) unless it sets `"Locked": false`. Add `"RemoteConfig": true` to
+  hand full remote management of the node to the tailnet admin (see
+  `Prefs.RemoteConfig`) — appropriate for admin-owned fleet devices.
 
 - **Interactive (serial console):** launch the AMI with *no* user-data. The
   `optional:` prefix means the missing config is not an error, so `tailscaled`

--- a/gokrazy/build.go
+++ b/gokrazy/build.go
@@ -291,23 +291,28 @@ func waitForImportSnapshot(importTaskID string) (snapID string, err error) {
 }
 
 func makeAMI(name, ebsSnapID string) (ami string, err error) {
-	var arch string
+	var arch, bootMode string
 	switch conf.GOARCH() {
 	case "arm64":
-		arch = "arm64"
+		// arm64 instances boot UEFI-only; "uefi-preferred" is rejected.
+		arch, bootMode = "arm64", "uefi"
 	case "amd64":
-		arch = "x86_64"
+		arch, bootMode = "x86_64", "uefi-preferred"
 	default:
 		return "", fmt.Errorf("unknown arch %q", conf.GOARCH())
 	}
 	out, err := exec.Command("aws", "ec2", "register-image",
 		"--name", name,
 		"--architecture", arch,
-		"--root-device-name", "/dev/sda",
+		// register-image defaults to paravirtual; arm64 rejects that
+		// ("supports HVM AMIs only") and amd64 would produce an image that
+		// won't boot on Nitro. Both need HVM.
+		"--virtualization-type", "hvm",
+		"--root-device-name", "/dev/sda1",
 		"--ena-support",
 		"--imds-support", "v2.0",
-		"--boot-mode", "uefi-preferred",
-		"--block-device-mappings", "DeviceName=/dev/sda,Ebs={SnapshotId="+ebsSnapID+"}").CombinedOutput()
+		"--boot-mode", bootMode,
+		"--block-device-mappings", "DeviceName=/dev/sda1,Ebs={SnapshotId="+ebsSnapID+"}").CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("register image: %v: %s", err, out)
 	}

--- a/gokrazy/tsapp-vm.arm64/config.json
+++ b/gokrazy/tsapp-vm.arm64/config.json
@@ -32,6 +32,9 @@
             ]
         },
         "tailscale.com/cmd/tailscaled": {
+            "CommandLineFlags": [
+                "-config=optional:vm:user-data"
+            ],
             "GoBuildTags": [
                 "ts_appliance"
             ]

--- a/gokrazy/tsapp/config.json
+++ b/gokrazy/tsapp/config.json
@@ -32,6 +32,9 @@
             ]
         },
         "tailscale.com/cmd/tailscaled": {
+            "CommandLineFlags": [
+                "-config=optional:vm:user-data"
+            ],
             "GoBuildTags": [
                 "ts_appliance"
             ]

--- a/ipn/conf.go
+++ b/ipn/conf.go
@@ -47,6 +47,7 @@ type ConfigVAlpha struct {
 	RunSSHServer    opt.Bool         `json:",omitempty"` // Tailscale SSH
 	RunWebClient    opt.Bool         `json:",omitempty"`
 	ShieldsUp       opt.Bool         `json:",omitempty"`
+	RemoteConfig    opt.Bool         `json:",omitzero"` // delegate full remote control to the tailnet admin; see Prefs.RemoteConfig
 	AutoUpdate      *AutoUpdatePrefs `json:",omitempty"`
 	ServeConfigTemp *ServeConfig     `json:",omitempty"` // TODO(bradfitz,maisem): make separate stable type for this
 
@@ -166,6 +167,10 @@ func (c *ConfigVAlpha) ToPrefs() (MaskedPrefs, error) {
 	if c.ShieldsUp != "" {
 		mp.ShieldsUp = c.ShieldsUp.EqualBool(true)
 		mp.ShieldsUpSet = true
+	}
+	if c.RemoteConfig != "" {
+		mp.RemoteConfig = c.RemoteConfig.EqualBool(true)
+		mp.RemoteConfigSet = true
 	}
 	if c.AutoUpdate != nil {
 		mp.AutoUpdate = *c.AutoUpdate

--- a/ipn/conf_test.go
+++ b/ipn/conf_test.go
@@ -186,3 +186,28 @@ func TestConfigVAlphaToPrefs(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigVAlphaToPrefsRemoteConfig(t *testing.T) {
+	for name, tt := range map[string]struct {
+		cfg     ConfigVAlpha
+		wantSet bool
+		wantVal bool
+	}{
+		"absent": {ConfigVAlpha{Version: "alpha0"}, false, false},
+		"true":   {ConfigVAlpha{Version: "alpha0", RemoteConfig: "true"}, true, true},
+		"false":  {ConfigVAlpha{Version: "alpha0", RemoteConfig: "false"}, true, false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			mp, err := tt.cfg.ToPrefs()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if mp.RemoteConfigSet != tt.wantSet {
+				t.Errorf("RemoteConfigSet = %v; want %v", mp.RemoteConfigSet, tt.wantSet)
+			}
+			if mp.RemoteConfig != tt.wantVal {
+				t.Errorf("RemoteConfig = %v; want %v", mp.RemoteConfig, tt.wantVal)
+			}
+		})
+	}
+}

--- a/ipn/conffile/conffile.go
+++ b/ipn/conffile/conffile.go
@@ -8,6 +8,7 @@ package conffile
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -40,6 +41,15 @@ func (c *Config) WantRunning() bool {
 // from the VM's metadata service's user-data field.
 const VMUserDataPath = "vm:user-data"
 
+// ErrNoConfig is returned (wrapped) by Load when the config source is absent or
+// unreadable: a missing file, an EC2 instance with no user-data, an unreachable
+// metadata service, or a build without the relevant cloud support. It reports
+// "no config was provided", as distinct from "a config was provided but is
+// invalid" (which Load returns as an unwrapped parse/validate error). Callers
+// that want to boot unconfigured when no config is present (e.g. tailscaled's
+// "optional:" -config prefix) can check for it with errors.Is.
+var ErrNoConfig = errors.New("no config present")
+
 // hujsonStandardize is set to hujson.Standardize by conffile_hujson.go on
 // platforms that support config files.
 var hujsonStandardize func([]byte) ([]byte, error)
@@ -62,7 +72,10 @@ func Load(path string) (*Config, error) {
 		c.Raw, err = os.ReadFile(path)
 	}
 	if err != nil {
-		return nil, err
+		// Read-phase failure: the config source is absent or unreadable.
+		// Wrap ErrNoConfig so callers can distinguish this from a config
+		// that was read but failed to parse below.
+		return nil, fmt.Errorf("%w: %v", ErrNoConfig, err)
 	}
 	if buildfeatures.HasHuJSONConf && hujsonStandardize != nil {
 		c.Std, err = hujsonStandardize(c.Raw)

--- a/ipn/conffile/conffile_test.go
+++ b/ipn/conffile/conffile_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package conffile
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadAbsentIsErrNoConfig verifies that an absent config source (here a
+// missing file, the same read-phase seam the "vm:user-data" 404 goes through)
+// is reported as ErrNoConfig, so callers using tailscaled's "optional:" prefix
+// can boot unconfigured instead of failing.
+func TestLoadAbsentIsErrNoConfig(t *testing.T) {
+	_, err := Load(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	if !errors.Is(err, ErrNoConfig) {
+		t.Fatalf("Load(missing) error = %v; want it to wrap ErrNoConfig", err)
+	}
+}
+
+// TestLoadInvalidIsNotErrNoConfig verifies that a config that is present but
+// invalid is NOT ErrNoConfig, so it stays fatal even in optional mode.
+func TestLoadInvalidIsNotErrNoConfig(t *testing.T) {
+	for name, data := range map[string]string{
+		"malformed":       `{"Version": "alpha0"`, // truncated JSON
+		"unknown-version": `{"Version": "bogus9"}`,
+		"unknown-field":   `{"Version": "alpha0", "Bogus": true}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			p := filepath.Join(t.TempDir(), "bad.json")
+			if err := os.WriteFile(p, []byte(data), 0600); err != nil {
+				t.Fatal(err)
+			}
+			_, err := Load(p)
+			if err == nil {
+				t.Fatalf("Load(%q) succeeded; want an error", data)
+			}
+			if errors.Is(err, ErrNoConfig) {
+				t.Fatalf("Load(%q) error = %v; want a parse error, not ErrNoConfig", data, err)
+			}
+		})
+	}
+}
+
+func TestLoadValid(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "ok.json")
+	if err := os.WriteFile(p, []byte(`{"Version": "alpha0"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	c, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load(valid) error = %v; want nil", err)
+	}
+	if c.Version != "alpha0" {
+		t.Fatalf("Version = %q; want alpha0", c.Version)
+	}
+}


### PR DESCRIPTION
Make it possible to optionally load Tailscale configuration (e.g. Auth key, subnet router, exit node) from cloud init user data and continue if not present.

Updates #1866