### PR TITLE
all: fix typos where we repeat repeat ourselves

### DIFF
--- a/cmd/tailscale/cli/jsonoutput/tailnet-lock-status.go
+++ b/cmd/tailscale/cli/jsonoutput/tailnet-lock-status.go
@@ -148,7 +148,7 @@ type tailnetLockEnabledStatusV1 struct {
 	TrustedKeys []tkaKeyV1
 
 	// VisiblePeers describes peers which are visible in the netmap that
-	// have valid Tailnet Lock signatures signatures.
+	// have valid Tailnet Lock signatures.
 	VisiblePeers []tkaTrustedPeerV1
 
 	// FilteredPeers describes peers which were removed from the netmap

--- a/cmd/tailscaled/install_darwin.go
+++ b/cmd/tailscaled/install_darwin.go
@@ -123,7 +123,7 @@ func installSystemDaemonDarwin(args []string) (err error) {
 		return err
 	}
 
-	// Do not overwrite targetBin with the binary file if it it's already
+	// Do not overwrite targetBin with the binary file if it's already
 	// pointing to it. This is primarily to handle Homebrew that writes
 	// /usr/local/bin/tailscaled is a symlink to the actual binary.
 	if !same {

--- a/cmd/testwrapper/testwrapper.go
+++ b/cmd/testwrapper/testwrapper.go
@@ -789,7 +789,7 @@ func main() {
 		for tr := range ch {
 			// Go assigns the package name "command-line-arguments" when you
 			// `go test FILE` rather than `go test PKG`. It's more
-			// convenient for us to to specify files in tests, so fix tr.pkg
+			// convenient for us to specify files in tests, so fix tr.pkg
 			// so that subsequent testwrapper attempts run correctly.
 			if tr.pkg == "command-line-arguments" {
 				tr.pkg = packages[0]

--- a/derp/README.md
+++ b/derp/README.md
@@ -39,7 +39,7 @@ geographic regions to make sure users have low latency to their DERP home.
 Regions generally have multiple nodes per region "meshed" (routing to each
 other) together for redundancy: it allows for cloud failures or upgrades without
 kicking users out to a higher latency region. Instead, clients will reconnect to
-the next node in the region. Each node in the region is required to to be meshed
+the next node in the region. Each node in the region is required to be meshed
 with every other node in the region and forward packets to the other nodes in
 the region. Packets are forwarded only one hop within the region. There is no
 routing between regions. The assumption is that the mesh TCP connections are

--- a/derp/derp_client.go
+++ b/derp/derp_client.go
@@ -69,7 +69,7 @@ type clientOpt struct {
 func MeshKey(k key.DERPMesh) ClientOpt { return clientOptFunc(func(o *clientOpt) { o.MeshKey = k }) }
 
 // IsProber returns a ClientOpt to pass to the DERP server during connect to
-// declare that this client is a a prober.
+// declare that this client is a prober.
 func IsProber(v bool) ClientOpt { return clientOptFunc(func(o *clientOpt) { o.IsProber = v }) }
 
 // ServerPublicKey returns a ClientOpt to declare that the server's DERP public key is known.

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -784,7 +784,7 @@ func (b *LocalBackend) onHomeDERPUpdate(du magicsock.HomeDERPChanged) {
 // In practice, it is possible that one profile with a homeDERP of 0 (no-derp)
 // got switched before setting any home DERP or that DERP IDs match across
 // DERP maps. Since the risk of this happening is small and the consequences
-// of this is is just a possible less optimal DERP until the next reSTUN,
+// of this is just a possible less optimal DERP until the next reSTUN,
 // accept this possibility.
 func (b *LocalBackend) onHomeDERPUpdateLocked(du magicsock.HomeDERPChanged) {
 	cn := b.currentNode()

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -8301,7 +8301,7 @@ func TestDisplayMessageIPNBus(t *testing.T) {
 					if ok {
 						if diff := cmp.Diff(tt.wantWarning, got, cmpopts.IgnoreFields(health.UnhealthyState{}, "ETag")); diff != "" {
 							t.Errorf("unexpected warning details (-want/+got):\n%s", diff)
-							return true // we failed the test so tell the watcher we've seen what we need to to stop it waiting
+							return true // we failed the test so tell the watcher we've seen what we need to stop it waiting
 						}
 					} else {
 						got := slices.Collect(maps.Keys(n.Health.Warnings))

--- a/ipn/ipnstate/ipnstate.go
+++ b/ipn/ipnstate/ipnstate.go
@@ -137,7 +137,7 @@ type TailnetLockStatus struct {
 	TrustedKeys []TKAKey
 
 	// VisiblePeers describes peers which are visible in the netmap that
-	// have valid Tailnet Lock signatures signatures.
+	// have valid Tailnet Lock signatures.
 	VisiblePeers []*TKAPeer
 
 	// FilteredPeers describes peers which were removed from the netmap

--- a/ipn/localapi/cert.go
+++ b/ipn/localapi/cert.go
@@ -40,7 +40,7 @@ func (h *Handler) serveCert(w http.ResponseWriter, r *http.Request) {
 	pair, err := h.b.GetCertPEMWithValidity(r.Context(), domain, minValidity)
 	if err != nil {
 		// TODO(bradfitz): 500 is a little lazy here. The errors returned from
-		// GetCertPEM (and everywhere) should carry info info to get whether
+		// GetCertPEM (and everywhere) should carry info to get whether
 		// they're 400 vs 403 vs 500 at minimum. And then we should have helpers
 		// (in tsweb probably) to return an error that looks at the error value
 		// to determine the HTTP status code.

--- a/ipn/store/awsstore/store_aws.go
+++ b/ipn/store/awsstore/store_aws.go
@@ -79,7 +79,7 @@ type awsStore struct {
 //
 // Note that we store the entire store in a single parameter
 // key, therefore if the state is above 8kb, it can cause
-// Tailscaled to only only store new state in-memory and
+// Tailscaled to only store new state in-memory and
 // restarting Tailscaled can fail until you delete your state
 // from the AWS Parameter Store.
 //

--- a/net/dns/resolver/forwarder.go
+++ b/net/dns/resolver/forwarder.go
@@ -1349,8 +1349,7 @@ func (f *forwarder) forwardWithDestChan(ctx context.Context, query packet, respo
 
 			// If we haven't got an error or a successful response,
 			// include all resolvers in the error message so we can
-			// at least see what what servers we're trying to
-			// query.
+			// at least see what servers we're trying to query.
 			var resolverAddrs []string
 			for _, rr := range resolvers {
 				resolverAddrs = append(resolverAddrs, rr.name.Addr)

--- a/net/netmon/netmon.go
+++ b/net/netmon/netmon.go
@@ -267,7 +267,7 @@ func (cd *ChangeDelta) AnyInterfaceUp() bool {
 
 // isInterestingInterfaceChange reports whether any interfaces have changed in a meaningful way.
 // This excludes interfaces that are not interesting per IsInterestingInterface and
-// filters out changes to interface IPs that that are uninteresting (e.g. link-local addresses).
+// filters out changes to interface IPs that are uninteresting (e.g. link-local addresses).
 func (cd *ChangeDelta) isInterestingInterfaceChange() bool {
 	// If there is no old state, everything is considered changed.
 	if cd.old == nil {

--- a/net/packet/header.go
+++ b/net/packet/header.go
@@ -45,7 +45,7 @@ type HeaderChecksummer interface {
 	Header
 
 	// WriteCheck writes the correct checksum into buf, which should
-	// be be the already-marshalled header and payload.
+	// be the already-marshalled header and payload.
 	WriteChecksum(buf []byte)
 }
 

--- a/types/opt/bool.go
+++ b/types/opt/bool.go
@@ -13,7 +13,7 @@ import (
 // is either "true", "false", or the empty string to mean unset.
 //
 // As a special case, the underlying string may also be the string
-// "unset" as as a synonym for the empty string. This lets the
+// "unset" as a synonym for the empty string. This lets the
 // explicit unset value be exchanged over an encoding/json "omitempty"
 // field without it being dropped.
 type Bool string

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -1020,7 +1020,7 @@ func (e *userspaceEngine) Reconfig(cfg *wgcfg.Config, routerCfg *router.Config, 
 	}
 
 	// We've historically re-set DNS even after just a router change. While
-	// refactoring in tailscale/tailscale#17448 and and
+	// refactoring in tailscale/tailscale#17448 and
 	// tailscale/tailscale#17499, I'm erring on the side of keeping that
 	// historical quirk for now (2025-10-08), lest it's load bearing in
 	// unexpected ways


### PR DESCRIPTION
Found with the regex `\b([A-Za-z]+) \1\b`.

Updates #cleanup