### PR TITLE
wgengine: wait for in-flight linkChange before closing subsystems

### DIFF
--- a/util/execqueue/execqueue.go
+++ b/util/execqueue/execqueue.go
@@ -88,6 +88,36 @@ func (q *ExecQueue) Shutdown() {
 	}
 }
 
+// ShutdownAndWait signals the queue to stop, discards any queued
+// functions that have not started, and waits for the currently
+// executing function, if any, to complete or ctx to expire.
+//
+// It must not be called while holding a lock that a queued function
+// may acquire, or it will not return until ctx expires.
+func (q *ExecQueue) ShutdownAndWait(ctx context.Context) error {
+	q.mu.Lock()
+	q.closed = true
+	if q.cancel != nil {
+		q.cancel()
+	}
+	waitCh := q.doneWaiter
+	if q.inFlight && waitCh == nil {
+		waitCh = make(chan struct{})
+		q.doneWaiter = waitCh
+	}
+	q.mu.Unlock()
+
+	if waitCh == nil {
+		return nil
+	}
+	select {
+	case <-waitCh:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 func (q *ExecQueue) initCtxLocked() {
 	if q.ctx == nil {
 		q.ctx, q.cancel = context.WithCancel(context.Background())

--- a/util/execqueue/execqueue_test.go
+++ b/util/execqueue/execqueue_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
+	"time"
 )
 
 func TestExecQueue(t *testing.T) {
@@ -27,5 +29,57 @@ func TestExecQueueRunSyncLocking(t *testing.T) {
 	q := &ExecQueue{}
 	q.RunSync(t.Context(), func() {
 		q.Shutdown()
+	})
+}
+
+func TestShutdownAndWait(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		q := &ExecQueue{}
+		started := make(chan struct{})
+		release := make(chan struct{})
+		var finished, ranPending atomic.Bool
+		q.Add(func() {
+			close(started)
+			<-release
+			finished.Store(true)
+		})
+		q.Add(func() { ranPending.Store(true) })
+		<-started
+
+		// The fake clock only advances once ShutdownAndWait below is
+		// blocked, so the release cannot fire early.
+		go func() {
+			time.Sleep(time.Second)
+			close(release)
+		}()
+		if err := q.ShutdownAndWait(context.Background()); err != nil {
+			t.Fatalf("ShutdownAndWait: %v", err)
+		}
+		if !finished.Load() {
+			t.Error("ShutdownAndWait returned before the in-flight function completed")
+		}
+		if ranPending.Load() {
+			t.Error("pending function ran after shutdown")
+		}
+	})
+}
+
+func TestShutdownAndWaitTimeout(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		q := &ExecQueue{}
+		started := make(chan struct{})
+		release := make(chan struct{})
+		q.Add(func() {
+			close(started)
+			<-release
+		})
+		<-started
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := q.ShutdownAndWait(ctx); err == nil {
+			t.Error("ShutdownAndWait = nil; want deadline exceeded")
+		}
+		close(release)
 	})
 }

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -1222,9 +1222,14 @@ func (e *userspaceEngine) RequestStatus() {
 
 func (e *userspaceEngine) Close() {
 	e.eventClient.Close()
-	// TODO(cmol): Should we wait for it too?
-	// Same question raised in appconnector.go.
-	e.linkChangeQueue.Shutdown()
+	// eventClient.Close waited for the ChangeDelta subscriber, the sole
+	// producer for linkChangeQueue, to return, so no new work can be
+	// queued. Discard queued linkChanges and wait for an in-flight one
+	// to finish before closing the subsystems it uses.
+	// See tailscale/tailscale#17641.
+	drainCtx, drainCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer drainCancel()
+	e.linkChangeQueue.ShutdownAndWait(drainCtx)
 	e.mu.Lock()
 	if e.closing {
 		e.mu.Unlock()

--- a/wgengine/userspace_test.go
+++ b/wgengine/userspace_test.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/tailscale/wireguard-go/device"
 	"go4.org/mem"
@@ -641,5 +642,42 @@ func TestLinkChangeReapplyPreservesMagicDNSRoutes(t *testing.T) {
 	if !slices.Equal(initial, after) {
 		t.Errorf("resolver LocalDomains changed after linkChange:\n  initial: %s\n  after:   %s",
 			logger.AsJSON(initial), logger.AsJSON(after))
+	}
+}
+
+// TestCloseWaitsForLinkChange tests that Close waits for in-flight
+// linkChangeQueue work to finish before tearing down the subsystems
+// that linkChange uses.
+//
+// See https://github.com/tailscale/tailscale/issues/17641.
+func TestCloseWaitsForLinkChange(t *testing.T) {
+	bus := eventbustest.NewBus(t)
+
+	ht := health.NewTracker(bus)
+	reg := new(usermetric.Registry)
+	e, err := NewFakeUserspaceEngine(t.Logf, 0, ht, reg, bus)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan struct{})
+	e.(*userspaceEngine).linkChangeQueue.Add(func() {
+		close(started)
+		<-release
+		close(done)
+	})
+	<-started
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		close(release)
+	}()
+	e.Close()
+	select {
+	case <-done:
+	default:
+		t.Fatal("Close returned with link change work still in flight")
 	}
 }


### PR DESCRIPTION
`Close` shuts down `linkChangeQueue` and then immediately closes magicConn, dns, wgdev, and tundev. But `ExecQueue.Shutdown` doesn't wait for a function that's already running, so a linkChange that's mid-flight can still call `Rebind`, `ReSTUN`, or `dns.Set` on subsystems that are already gone and panic during shutdown. There was a TODO at exactly this spot asking "Should we wait for it too?" - this is that wait.

The window was originally mitigated in 4c856078e (#17642), which made `eventClient.Close` block until the subscriber returns. But e7f5ca1d5 (#18024) later moved linkChange onto an ExecQueue and the subscriber now only enqueues, so the same race came back one layer down.

The fix adds `ExecQueue.ShutdownAndWait(ctx)`, which discards queued functions that haven't started and waits for the in-flight one, and `Close` now uses it (bounded to 5s) before tearing anything down. Waiting there is safe: the eventbus client is closed first and it's the queue's only producer, so nothing new can arrive during the drain. Shutdown itself stays async because some callers shut down while holding a lock that queued functions acquire (e.g. `AppConnector.Close` holds `e.mu` and `scheduleAdvertisement`'s queued closure takes it), so an unconditional wait there would deadlock.

The wgengine test fails on main (`Close` returns while queued work is still running) and passes with this change. The new execqueue tests use `testing/synctest` for deterministic fake-time coverage of the wait and timeout paths; the wgengine test keeps a small real sleep because `NewFakeUserspaceEngine` spawns socket-read goroutines that block in syscalls, which keeps a synctest bubble's fake clock from ever advancing.

Went with Updates rather than Fixes since the panic in the report isn't deterministically reproducible. `AppConnector.Close` in appc has the same pattern; happy to do that one as a follow-up.

Updates #17641
