### PR TITLE
wgengine/magicsock: reset endpoint trust on rekey

### DIFF
--- a/wgengine/magicsock/endpoint.go
+++ b/wgengine/magicsock/endpoint.go
@@ -1524,8 +1524,13 @@ func (de *endpoint) updateFromNode(n tailcfg.NodeView, heartbeatDisabled bool, p
 		de.updateDiscoKey(key)
 		de.debugUpdates.Add(EndpointChange{
 			When: time.Now(),
-			What: "updateFromNode-resetLocked",
+			What: "updateFromNode-disco-key-changed",
 		})
+		// The peer rotated its disco key, so any path we currently trust to it is stale.
+		// Invalidate path discovery state so we re-probe, but keep bestAddr so data
+		// keeps flowing until a fresh path is confirmed.
+		de.trustBestAddrUntil = 0
+		de.invalidateDiscoPathLocked()
 	}
 	if n.HomeDERP() == 0 {
 		if de.derpAddr.IsValid() {
@@ -2081,9 +2086,17 @@ func (de *endpoint) stopAndReset() {
 // DERP-only endpoint. It does not stop the endpoint's heartbeat
 // timer, if one is running.
 func (de *endpoint) resetLocked() {
+	de.clearBestAddrLocked()
+	de.invalidateDiscoPathLocked()
+}
+
+// invalidateDiscoPathLocked discards in-flight disco/relay state that was
+// established against the peer's current disco identity, so that path
+// discovery re-runs from scratch.
+func (de *endpoint) invalidateDiscoPathLocked() {
 	de.lastSendExt = 0
 	de.lastFullPing = 0
-	de.clearBestAddrLocked()
+	de.lastUDPRelayPathDiscovery = 0
 	for _, es := range de.endpointState {
 		es.lastPing = 0
 	}

--- a/wgengine/magicsock/endpoint_test.go
+++ b/wgengine/magicsock/endpoint_test.go
@@ -600,6 +600,81 @@ func Test_endpoint_sendDiscoPingsLocked_neverDirectUDP(t *testing.T) {
 	}
 }
 
+func Test_endpoint_updateFromNodeAfterDiscoKeyChange(t *testing.T) {
+	relayAddr := epAddr{ap: netip.MustParseAddrPort("192.0.2.2:77")}
+	relayAddr.vni.Set(1)
+	directAddr := epAddr{ap: netip.MustParseAddrPort("192.0.2.1:7")}
+
+	for _, tc := range []struct {
+		name       string
+		bestAddr   epAddr
+		keyChanges bool
+	}{
+		{
+			name:       "relay-bestaddr-key-changed",
+			bestAddr:   relayAddr,
+			keyChanges: true,
+		},
+		{
+			name:       "direct-bestaddr-key-changed",
+			bestAddr:   directAddr,
+			keyChanges: true,
+		},
+		{
+			name:       "relay-bestaddr-key-unchanged",
+			bestAddr:   relayAddr,
+			keyChanges: false,
+		},
+		{
+			name:       "direct-bestaddr-key-unchanged",
+			bestAddr:   directAddr,
+			keyChanges: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			now := mono.Now()
+			c := &Conn{
+				logf: func(msg string, args ...any) {},
+			}
+			c.discoAtomic.Set(key.NewDisco())
+			c.relayManager.hasPeerRelayServers.Store(true)
+
+			oldKey := key.NewDisco().Public()
+			de := &endpoint{
+				c:                  c,
+				publicKey:          key.NewNode().Public(),
+				bestAddr:           addrQuality{epAddr: tc.bestAddr},
+				trustBestAddrUntil: now.Add(time.Hour),
+				sentPing:           make(map[stun.TxID]sentPing),
+				endpointState:      make(map[netip.AddrPort]*endpointState),
+				debugUpdates:       ringlog.New[EndpointChange](10),
+			}
+			de.lastUDPRelayPathDiscovery = mono.Now()
+			de.disco.Store(&endpointDisco{key: oldKey, short: oldKey.ShortString()})
+
+			incomingKey := oldKey
+			if tc.keyChanges {
+				incomingKey = key.NewDisco().Public()
+			}
+			nv := (&tailcfg.Node{
+				ID:       1,
+				Key:      key.NewNode().Public(),
+				DiscoKey: incomingKey,
+				HomeDERP: 1,
+				Cap:      121, // capVerIsRelayCapable
+			}).View()
+			de.updateFromNode(nv, false, false)
+
+			de.mu.Lock()
+			got := de.wantUDPRelayPathDiscoveryLocked(now)
+			de.mu.Unlock()
+			if got != tc.keyChanges {
+				t.Errorf("wantUDPRelayPathDiscoveryLocked = %v, want %v", got, tc.keyChanges)
+			}
+		})
+	}
+}
+
 func Test_endpoint_handlePongConnLocked(t *testing.T) {
 	goodLatency := 50 * time.Millisecond
 	badLatency := 100 * time.Millisecond


### PR DESCRIPTION
Invalidate the trust window so we re-run path discovery
instead of coasting on the dead path until trust lapses on its own.


Partially reverts 85bb5f8 removal of resetLocked within updateFromNode.

Fixes #20268