### PR TITLE
util/def: add Int and Float64 default parse helpers

### DIFF
--- a/ipn/ipnlocal/c2n.go
+++ b/ipn/ipnlocal/c2n.go
@@ -11,7 +11,6 @@ import (
 	"path"
 	"reflect"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
@@ -24,6 +23,7 @@ import (
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/netmap"
 	"tailscale.com/util/clientmetric"
+	"tailscale.com/util/def"
 	"tailscale.com/util/goroutines"
 	"tailscale.com/util/httpm"
 	"tailscale.com/util/set"
@@ -277,7 +277,7 @@ func handleC2NDebugComponentLogging(b *LocalBackend, w http.ResponseWriter, r *h
 		return
 	}
 	component := r.FormValue("component")
-	secs, _ := strconv.Atoi(r.FormValue("secs"))
+	secs := def.Int(r.FormValue("secs"), 0)
 	if secs == 0 {
 		secs -= 1
 	}

--- a/ipn/ipnlocal/c2n_pprof.go
+++ b/ipn/ipnlocal/c2n_pprof.go
@@ -10,13 +10,14 @@ import (
 	"net/http"
 	"runtime"
 	"runtime/pprof"
-	"strconv"
+
+	"tailscale.com/util/def"
 )
 
 func init() {
 	c2nLogHeap = func(w http.ResponseWriter, r *http.Request) {
 		// Support same optional gc parameter as net/http/pprof:
-		if gc, _ := strconv.Atoi(r.FormValue("gc")); gc > 0 {
+		if gc := def.Int(r.FormValue("gc"), 0); gc > 0 {
 			runtime.GC()
 		}
 		pprof.WriteHeapProfile(w)
@@ -29,11 +30,11 @@ func init() {
 			http.Error(w, "Unknown profile", http.StatusNotFound)
 			return
 		}
-		gc, _ := strconv.Atoi(r.FormValue("gc"))
+		gc := def.Int(r.FormValue("gc"), 0)
 		if profile == "heap" && gc > 0 {
 			runtime.GC()
 		}
-		debug, _ := strconv.Atoi(r.FormValue("debug"))
+		debug := def.Int(r.FormValue("debug"), 0)
 		if debug != 0 {
 			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		} else {

--- a/ipn/localapi/debug.go
+++ b/ipn/localapi/debug.go
@@ -17,7 +17,6 @@ import (
 	"net/netip"
 	"reflect"
 	"slices"
-	"strconv"
 	"sync"
 	"time"
 
@@ -26,6 +25,7 @@ import (
 	"tailscale.com/feature/buildfeatures"
 	"tailscale.com/ipn"
 	"tailscale.com/types/logger"
+	"tailscale.com/util/def"
 	"tailscale.com/util/eventbus"
 	"tailscale.com/util/httpm"
 )
@@ -81,7 +81,7 @@ func (h *Handler) serveComponentDebugLogging(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	component := r.FormValue("component")
-	secs, _ := strconv.Atoi(r.FormValue("secs"))
+	secs := def.Int(r.FormValue("secs"), 0)
 	err := h.b.SetComponentDebugLogging(component, h.clock.Now().Add(time.Duration(secs)*time.Second))
 	var res struct {
 		Error string

--- a/util/def/def.go
+++ b/util/def/def.go
@@ -32,3 +32,27 @@ func Duration(s string, def time.Duration) time.Duration {
 	}
 	return v
 }
+
+// Int parses s as an int, returning def when s is empty or invalid.
+func Int(s string, def int) int {
+	if s == "" {
+		return def
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return def
+	}
+	return v
+}
+
+// Float64 parses s as a float64, returning def when s is empty or invalid.
+func Float64(s string, def float64) float64 {
+	if s == "" {
+		return def
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return def
+	}
+	return v
+}

--- a/util/def/def.go
+++ b/util/def/def.go
@@ -5,6 +5,7 @@
 package def
 
 import (
+	"math"
 	"strconv"
 	"time"
 )
@@ -45,13 +46,17 @@ func Int(s string, def int) int {
 	return v
 }
 
-// Float64 parses s as a float64, returning def when s is empty or invalid.
+// Float64 parses s as a float64, returning def when s is empty, invalid,
+// or parses to a non-finite value (NaN or Inf).
 func Float64(s string, def float64) float64 {
 	if s == "" {
 		return def
 	}
 	v, err := strconv.ParseFloat(s, 64)
 	if err != nil {
+		return def
+	}
+	if math.IsNaN(v) || math.IsInf(v, 0) {
 		return def
 	}
 	return v

--- a/util/def/def_test.go
+++ b/util/def/def_test.go
@@ -69,6 +69,105 @@ func TestDuration(t *testing.T) {
 	}
 }
 
+func TestInt(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		def  int
+		want int
+	}{
+		{name: "empty_42", in: "", def: 42, want: 42},
+		{name: "empty_zero", in: "", def: 0, want: 0},
+		{name: "valid", in: "123", def: 42, want: 123},
+		{name: "valid_zero", in: "0", def: 42, want: 0},
+		{name: "valid_negative", in: "-7", def: 42, want: -7},
+		{name: "invalid_42", in: "soon", def: 42, want: 42},
+		{name: "invalid_zero", in: "soon", def: 0, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := def.Int(tt.in, tt.def); got != tt.want {
+				t.Errorf("Int(%q, %v) = %v; want %v", tt.in, tt.def, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFloat64(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		def  float64
+		want float64
+	}{
+		{name: "empty_one", in: "", def: 1.5, want: 1.5},
+		{name: "empty_zero", in: "", def: 0, want: 0},
+		{name: "valid", in: "3.14", def: 1.5, want: 3.14},
+		{name: "valid_int", in: "42", def: 1.5, want: 42},
+		{name: "valid_negative", in: "-2.5", def: 1.5, want: -2.5},
+		{name: "valid_zero", in: "0", def: 1.5, want: 0},
+		{name: "invalid_one", in: "soon", def: 1.5, want: 1.5},
+		{name: "invalid_zero", in: "soon", def: 0, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := def.Float64(tt.in, tt.def); got != tt.want {
+				t.Errorf("Float64(%q, %v) = %v; want %v", tt.in, tt.def, got, tt.want)
+			}
+		})
+	}
+}
+
+func FuzzInt(f *testing.F) {
+	for _, tc := range []struct {
+		in  string
+		def int
+	}{
+		{in: "", def: 42},
+		{in: "", def: 0},
+		{in: "123", def: 42},
+		{in: "-7", def: 42},
+		{in: "soon", def: 42},
+	} {
+		f.Add(tc.in, int64(tc.def))
+	}
+	f.Fuzz(func(t *testing.T, in string, fallback int64) {
+		defVal := int(fallback)
+		got := def.Int(in, defVal)
+		want, err := strconv.Atoi(in)
+		if in == "" || err != nil {
+			want = defVal
+		}
+		if got != want {
+			t.Fatalf("Int(%q, %v) = %v; want %v", in, defVal, got, want)
+		}
+	})
+}
+
+func FuzzFloat64(f *testing.F) {
+	for _, tc := range []struct {
+		in  string
+		def float64
+	}{
+		{in: "", def: 1.5},
+		{in: "", def: 0},
+		{in: "3.14", def: 1.5},
+		{in: "soon", def: 1.5},
+	} {
+		f.Add(tc.in, tc.def)
+	}
+	f.Fuzz(func(t *testing.T, in string, fallback float64) {
+		got := def.Float64(in, fallback)
+		want, err := strconv.ParseFloat(in, 64)
+		if in == "" || err != nil {
+			want = fallback
+		}
+		if got != want {
+			t.Fatalf("Float64(%q, %v) = %v; want %v", in, fallback, got, want)
+		}
+	})
+}
+
 func FuzzBool(f *testing.F) {
 	for _, tc := range []struct {
 		in  string

--- a/util/def/def_test.go
+++ b/util/def/def_test.go
@@ -4,6 +4,7 @@
 package def_test
 
 import (
+	"math"
 	"strconv"
 	"testing"
 	"time"
@@ -108,6 +109,9 @@ func TestFloat64(t *testing.T) {
 		{name: "valid_zero", in: "0", def: 1.5, want: 0},
 		{name: "invalid_one", in: "soon", def: 1.5, want: 1.5},
 		{name: "invalid_zero", in: "soon", def: 0, want: 0},
+		{name: "nan", in: "NaN", def: 1.5, want: 1.5},
+		{name: "inf", in: "Inf", def: 1.5, want: 1.5},
+		{name: "neg_inf", in: "-Inf", def: 1.5, want: 1.5},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -159,7 +163,7 @@ func FuzzFloat64(f *testing.F) {
 	f.Fuzz(func(t *testing.T, in string, fallback float64) {
 		got := def.Float64(in, fallback)
 		want, err := strconv.ParseFloat(in, 64)
-		if in == "" || err != nil {
+		if in == "" || err != nil || math.IsNaN(want) || math.IsInf(want, 0) {
 			want = fallback
 		}
 		if got != want {


### PR DESCRIPTION
## Summary

Extends the `util/def` package (added in #20022) with `Int` and `Float64` parsers that follow the same "parse string S as type T, return fallback value V if parsing fails" pattern described in #20018, for the common `int` and `float64` types.

- `def.Int(s string, def int) int` — parses with `strconv.Atoi`, returns `def` when `s` is empty or invalid
- `def.Float64(s string, def float64) float64` — parses with `strconv.ParseFloat`, returns `def` when `s` is empty or invalid

Both include table tests and fuzz tests matching the style of the existing `Bool` and `Duration` tests.

## Testing

- `go test ./util/def -count=1`
- `go test ./util/def -run=Fuzz -fuzz=FuzzInt -fuzztime=5s`
- `go test ./util/def -run=Fuzz -fuzz=FuzzFloat64 -fuzztime=5s`

Updates #20018