### PR TITLE
util/cobs: add new package for frame encoding

### DIFF
--- a/util/cobs/cobs.go
+++ b/util/cobs/cobs.go
@@ -1,0 +1,271 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Package cobs implements Consistent Overhead Byte Stuffing (COBS),
+// a technique for reliable packet framing over serial byte streams.
+//
+// COBS transforms any arbitrary payload such that the zero byte is guaranteed
+// to never appear in the encoded output. A zero byte can then be appended
+// as an unambiguous frame delimiter without colliding with the payload data.
+//
+// The encoding has the following properties:
+//
+//   - Lossless and reversible. Decoding recovers the original payload exactly.
+//
+//   - Non-zero payload bytes are never modified. Only zero bytes are removed
+//     from the encoded form and replaced by length-prefix overhead bytes.
+//
+//   - The zero byte is guaranteed to never appear in encoded output, so a
+//     trailing null terminator byte can be used to delimit frames in a byte stream.
+//
+//   - Overhead is tightly bounded in the worst case, unlike PPP byte stuffing
+//     (up to 100% expansion) or HDLC bit stuffing (up to 20% expansion).
+//     For n > 0 payload bytes, encoded size is at most n + ⌈n/254⌉ bytes.
+//     An empty payload encodes to a single byte.
+//
+//   - Longer frames add at most one overhead byte per 254 bytes of data
+//     (about 0.4% for large frames, rounded up to whole bytes).
+//     This makes maximum frame size predictable, which matters for devices with
+//     fixed MTUs or hard transmission-time limits.
+//
+// Framing convention: AppendEncode produces COBS-encoded payload only;
+// callers typically append a null delimiter when writing to the wire.
+// AppendDecode expects the input without the delimiter.
+//
+// See https://www.stuartcheshire.org/papers/COBSforToN.pdf
+package cobs
+
+import (
+	"bytes"
+	"cmp"
+	"encoding/binary"
+	"errors"
+	"slices"
+)
+
+// MaxEncodedLen is the longest possible length for a COBS-encoded output
+// for some payload of length n. The encoded length does not include
+// the trailing null terminator byte.
+//
+// Invariant: len(AppendEncode(nil, dec)) <= MaxEncodedLen(len(dec))
+func MaxEncodedLen(n int) int {
+	n = max(n, 0)
+	return n + max(1, (n+253)/254)
+}
+
+// MinDecodedLen is the shortest possible length for a decoded payload
+// from a COBS-encoded input of a length of n,
+// where n does not include the trailing null terminator byte.
+//
+// Invariant: len(AppendDecode(nil, enc)) >= MinDecodedLen(len(enc))
+func MinDecodedLen(n int) int {
+	n = max(n, 0)
+	return n - (n+254)/255
+}
+
+// AppendEncode appends the encoded bytes of src to the end of dst.
+// The COBS-encoded output never contains null bytes and
+// therefore also lacks a trailing null terminator byte;
+// use [AppendNull] to append the trailing null terminator byte if needed.
+//
+// The src and dst buffers may exactly overlap. For example, it is valid to do:
+//
+//	b = AppendEncode(b[:0], b)
+func AppendEncode(dst, src []byte) []byte {
+	// Forward encoding is only safe if dst and src do not overlap.
+	// Reverse encoding is always safe, but is ~2-8x slower
+	// (but can avoid the need for allocating an intermediate buffer).
+	if cap(dst) == len(dst) || cap(src) == 0 || &dst[:cap(dst)][len(dst)] != &src[:cap(src)][0] {
+		return appendEncodeForward(dst, src)
+	} else {
+		return appendEncodeReverse(dst, src)
+	}
+}
+
+func appendEncodeForward(dst, src []byte) []byte {
+	dst = slices.Grow(dst, MaxEncodedLen(len(src)))
+	for {
+		numNonZero := bytes.IndexByte(src, '\x00')
+		if numNonZero < 0 {
+			numNonZero = len(src)
+		}
+
+		// As a space optimization, the last empty block may be dropped
+		// if it follows a full block.
+		elideLastEmpty := numNonZero > 0 && numNonZero%254 == 0 && numNonZero == len(src)
+
+		// Emit zero or more full blocks, followed by a non-full block.
+		for ; numNonZero >= 254; numNonZero -= 254 {
+			dst = append(append(dst, 254+1), src[:254]...)
+			src = src[254:]
+		}
+		if !elideLastEmpty {
+			dst = append(append(dst, byte(numNonZero+1)), src[:numNonZero]...)
+			src = src[numNonZero:]
+		}
+
+		// Finished block, check termination condition and strip zero
+		// that is implicitly encoded by previous non-full block.
+		if len(src) == 0 {
+			break
+		}
+		if len(src) > 0 && src[0] == '\x00' {
+			src = src[1:]
+		}
+
+		// As a runtime optimization, specially handle many consecutive zeros.
+		for len(src) >= 8 && binary.LittleEndian.Uint64(src) == 0x0000000000000000 {
+			dst = binary.LittleEndian.AppendUint64(dst, 0x0101010101010101)
+			src = src[8:]
+		}
+	}
+	return dst
+}
+
+func appendEncodeReverse(dst, src []byte) []byte {
+	// In order to handle appending into an overlapping buffer,
+	// first count the number of overhead bytes,
+	// and then encode the input in reverse.
+
+	// Extend the dst for the number of overhead bytes.
+	numPrefix := len(dst)
+	numOverhead := numOverhead(src)
+	dst = slices.Grow(dst, len(src)+numOverhead)
+	dst = dst[:len(dst)+len(src)+numOverhead]
+
+	// Process the buffers in reverse order.
+	dstIdx := len(dst)
+	srcIdx := len(src)
+	for dstIdx > numPrefix {
+		// As a runtime optimization, specially handle many consecutive zeros.
+		for srcIdx >= 8 && binary.LittleEndian.Uint64(src[srcIdx-8:]) == 0x0000000000000000 {
+			binary.LittleEndian.PutUint64(dst[dstIdx-8:], 0x0101010101010101)
+			dstIdx -= 8
+			srcIdx -= 8
+		}
+
+		// Emit one or more blocks in reverse.
+		numNonZero := srcIdx - (bytes.LastIndexByte(src[:srcIdx], '\x00') + len("\x00"))
+		hasZero := srcIdx-numNonZero > 0 && src[srcIdx-numNonZero-1] == '\x00'
+		for {
+			copyLen := 0
+			if numNonZero > 0 {
+				copyLen = cmp.Or(numNonZero%254, 254)
+			}
+			// Since a full block lacks a subsequent zero,
+			// we may need to manually inject an empty block if
+			// the following source byte is a zero byte.
+			if copyLen == 254 && srcIdx < len(src) && src[srcIdx] == '\x00' {
+				dst[dstIdx-1] = 0x01
+				dstIdx--
+			}
+			copy(dst[dstIdx-copyLen:dstIdx], src[srcIdx-copyLen:srcIdx])
+			dstIdx -= copyLen
+			srcIdx -= copyLen
+			numNonZero -= copyLen
+			dst[dstIdx-1] = byte(copyLen + 1)
+			dstIdx -= 1
+			if numNonZero == 0 {
+				break
+			}
+		}
+		if hasZero {
+			srcIdx--
+		}
+	}
+
+	return dst
+}
+
+// numOverhead computes the exact number of overhead bytes
+// needed to be added to COBS-encode the src.
+// It assumes the optimization where a last empty block is elided
+// if it immediately follows a final full block of non-zero bytes.
+// The count does not include any trailing null terminator byte.
+func numOverhead(src []byte) (n int) {
+	n++ // mandatory leading overhead byte
+	for len(src) > 0 {
+		// Trim leading zeros as they take up no overhead.
+		for len(src) >= 8 && binary.LittleEndian.Uint64(src) == 0 {
+			src = src[8:]
+		}
+		for len(src) > 0 && src[0] == 0 {
+			src = src[1:]
+		}
+
+		// Long runs of non-zero bytes require an overhead byte.
+		numNonZero := bytes.IndexByte(src, '\x00')
+		if numNonZero < 0 {
+			numNonZero = len(src)
+		}
+		n += numNonZero / 254 // each full group of 254 needs an overhead byte (except last)
+		src = src[numNonZero:]
+		if numNonZero > 0 && numNonZero%254 == 0 && len(src) == 0 {
+			n-- // exact final group of 254 does not need extra overhead byte
+		}
+	}
+	return n
+}
+
+var errUnexpectedEOF = errors.New("cobs: unexpected truncation")
+var errUnexpectedNull = errors.New("cobs: unexpected null byte")
+
+// AppendDecode appends the decoded bytes of src to the end of dst.
+// The COBS-encoded src must not contain the trailing null terminator byte;
+// use [TrimNull] to remove the trailing null terminator byte if needed.
+// It reports an error if the src contains invalid COBS.
+//
+// The src and dst buffers may exactly overlap. For example, it is valid to do:
+//
+//	b, _ = AppendDecode(b[:0], b)
+func AppendDecode(dst, src []byte) ([]byte, error) {
+	// Unlike AppendEncode, decoding in a forward direction is still safe
+	// when dst overlaps with src since the output is guaranteed to always
+	// be smaller than the input. Thus, the dst pointer will never run past
+	// src pointer and corrupt the input.
+
+	dst = slices.Grow(dst, len(src))
+	if len(src) == 0 {
+		return dst, errUnexpectedEOF
+	}
+	for len(src) > 0 {
+		// Performance optimization for many zeros.
+		// Leave at least one byte afterwards since the following logic
+		// expects to find another overhead byte.
+		// Also, the very last overhead byte does not emit a zero.
+		for len(src) > 8 && binary.LittleEndian.Uint64(src) == 0x0101010101010101 {
+			dst = binary.LittleEndian.AppendUint64(dst, 0x0000000000000000)
+			src = src[8:]
+		}
+
+		switch n := src[0]; {
+		case int(n) > len(src):
+			return dst, errUnexpectedEOF
+		case n == '\x00' || bytes.IndexByte(src[1:n], '\x00') >= 0:
+			return dst, errUnexpectedNull
+		default:
+			dst = append(dst, src[1:n]...)
+			if n-1 < 254 {
+				dst = append(dst, 0)
+			}
+			src = src[n:]
+		}
+	}
+	return TrimNull(dst), nil // trim implicit trailing null byte
+}
+
+// AppendNull appends a trailing null terminator byte if it does not already exist.
+func AppendNull(dst []byte) []byte {
+	if len(dst) > 0 && dst[len(dst)-len("\x00")] == '\x00' {
+		return dst
+	}
+	return append(dst, '\x00')
+}
+
+// TrimNull removes a trailing null terminator byte if it exists.
+func TrimNull(dst []byte) []byte {
+	if len(dst) > 0 && dst[len(dst)-len("\x00")] == '\x00' {
+		return dst[:len(dst)-len("\x00")]
+	}
+	return dst
+}

--- a/util/cobs/cobs.go
+++ b/util/cobs/cobs.go
@@ -1,0 +1,282 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Package cobs implements Consistent Overhead Byte Stuffing (COBS),
+// a technique for reliable packet framing over serial byte streams.
+//
+// COBS transforms any arbitrary payload such that the zero byte is guaranteed
+// to never appear in the encoded output. A zero byte can then be appended
+// as an unambiguous frame delimiter without colliding with the payload data.
+//
+// The encoding has the following properties:
+//
+//   - Lossless and reversible. Decoding recovers the original payload exactly.
+//
+//   - Non-zero payload bytes are never modified. Only zero bytes are removed
+//     from the encoded form and replaced by length-prefix overhead bytes.
+//
+//   - The zero byte is guaranteed to never appear in encoded output, so a
+//     trailing null terminator byte can be used to delimit frames in a byte stream.
+//
+//   - Overhead is tightly bounded in the worst case, unlike PPP byte stuffing
+//     (up to 100% expansion) or HDLC bit stuffing (up to 20% expansion).
+//     For n > 0 payload bytes, encoded size is at most n + ⌈n/254⌉ bytes.
+//     An empty payload encodes to a single byte.
+//
+//   - Longer frames add at most one overhead byte per 254 bytes of data
+//     (about 0.4% for large frames, rounded up to whole bytes).
+//     This makes maximum frame size predictable, which matters for devices with
+//     fixed MTUs or hard transmission-time limits.
+//
+// Framing convention: AppendEncode produces COBS-encoded payload only;
+// callers typically append a null delimiter when writing to the wire.
+// AppendDecode expects the input without the delimiter.
+//
+// See https://www.stuartcheshire.org/papers/COBSforToN.pdf
+package cobs
+
+import (
+	"bytes"
+	"cmp"
+	"encoding/binary"
+	"errors"
+	"slices"
+)
+
+// MaxEncodedLen is the longest possible length for a COBS-encoded output
+// for some payload of length n. The encoded length does not include
+// the trailing null terminator byte.
+//
+// Invariant: len(AppendEncode(nil, dec)) <= MaxEncodedLen(len(dec))
+func MaxEncodedLen(n int) int {
+	n = max(n, 0)
+	return n + max(1, (n+253)/254)
+}
+
+// MinDecodedLen is the shortest possible length for a decoded payload
+// from a COBS-encoded input of a length of n,
+// where n does not include the trailing null terminator byte.
+//
+// Invariant: len(AppendDecode(nil, enc)) >= MinDecodedLen(len(enc))
+func MinDecodedLen(n int) int {
+	n = max(n, 0)
+	return n - (n+254)/255
+}
+
+// AppendEncode appends the encoded bytes of src to the end of dst.
+// The COBS-encoded output never contains null bytes and
+// therefore also lacks a trailing null terminator byte;
+// use [AppendNull] to append the trailing null terminator byte if needed.
+//
+// The src and dst buffers may exactly overlap. For example, it is valid to do:
+//
+//	b = AppendEncode(b[:0], b)
+func AppendEncode(dst, src []byte) []byte {
+	// Forward encoding is only safe if dst and src do not overlap.
+	// Reverse encoding is always safe, but is ~2-8x slower
+	// (but can avoid the need for allocating an intermediate buffer).
+	if cap(dst) == len(dst) || cap(src) == 0 || &dst[:cap(dst)][len(dst)] != &src[:cap(src)][0] {
+		return appendEncodeForward(dst, src)
+	} else {
+		return appendEncodeReverse(dst, src)
+	}
+}
+
+func appendEncodeForward(dst, src []byte) []byte {
+	dst = slices.Grow(dst, MaxEncodedLen(len(src)))
+	for {
+		numNonZero := bytes.IndexByte(src, '\x00')
+		if numNonZero < 0 {
+			numNonZero = len(src)
+		}
+
+		// As a space optimization, the last empty block may be dropped
+		// if it follows a full block.
+		elideLastEmpty := numNonZero > 0 && numNonZero%254 == 0 && numNonZero == len(src)
+
+		// Emit zero or more full blocks, followed by a non-full block.
+		for ; numNonZero >= 254; numNonZero -= 254 {
+			dst = append(append(dst, 254+1), src[:254]...)
+			src = src[254:]
+		}
+		if !elideLastEmpty {
+			dst = append(append(dst, byte(numNonZero+1)), src[:numNonZero]...)
+			src = src[numNonZero:]
+		}
+
+		// Finished block, check termination condition and strip zero
+		// that is implicitly encoded by previous non-full block.
+		if len(src) == 0 {
+			break
+		}
+		if len(src) > 0 && src[0] == '\x00' {
+			src = src[1:]
+		}
+
+		// As a runtime optimization, specially handle many consecutive zeros.
+		for len(src) >= 8 && binary.LittleEndian.Uint64(src) == 0x0000000000000000 {
+			dst = binary.LittleEndian.AppendUint64(dst, 0x0101010101010101)
+			src = src[8:]
+		}
+	}
+	return dst
+}
+
+func appendEncodeReverse(dst, src []byte) []byte {
+	// In order to handle appending into an overlapping buffer,
+	// first count the number of overhead bytes,
+	// and then encode the input in reverse.
+
+	// Extend the dst for the number of overhead bytes.
+	numPrefix := len(dst)
+	numOverhead := numOverhead(src)
+	dst = slices.Grow(dst, len(src)+numOverhead)
+	dst = dst[:len(dst)+len(src)+numOverhead]
+
+	// Process the buffers in reverse order.
+	dstIdx := len(dst)
+	srcIdx := len(src)
+	for dstIdx > numPrefix {
+		// As a runtime optimization, specially handle many consecutive zeros.
+		for srcIdx >= 8 && binary.LittleEndian.Uint64(src[srcIdx-8:]) == 0x0000000000000000 {
+			binary.LittleEndian.PutUint64(dst[dstIdx-8:], 0x0101010101010101)
+			dstIdx -= 8
+			srcIdx -= 8
+		}
+
+		// Emit one or more blocks in reverse.
+		numNonZero := srcIdx - (bytes.LastIndexByte(src[:srcIdx], '\x00') + len("\x00"))
+		hasZero := srcIdx-numNonZero > 0 && src[srcIdx-numNonZero-1] == '\x00'
+		for {
+			copyLen := 0
+			if numNonZero > 0 {
+				copyLen = cmp.Or(numNonZero%254, 254)
+			}
+			// Since a full block lacks a subsequent zero,
+			// we may need to manually inject an empty block if
+			// the following source byte is a zero byte.
+			if copyLen == 254 && srcIdx < len(src) && src[srcIdx] == '\x00' {
+				dst[dstIdx-1] = 0x01
+				dstIdx--
+			}
+			copy(dst[dstIdx-copyLen:dstIdx], src[srcIdx-copyLen:srcIdx])
+			dstIdx -= copyLen
+			srcIdx -= copyLen
+			numNonZero -= copyLen
+			dst[dstIdx-1] = byte(copyLen + 1)
+			dstIdx -= 1
+			if numNonZero == 0 {
+				break
+			}
+		}
+		if hasZero {
+			srcIdx--
+		}
+	}
+
+	return dst
+}
+
+// numOverhead computes the exact number of overhead bytes
+// needed to be added to COBS-encode the src.
+// It assumes the optimization where a last empty block is elided
+// if it immediately follows a final full block of non-zero bytes.
+// The count does not include any trailing null terminator byte.
+func numOverhead(src []byte) (n int) {
+	n++ // mandatory leading overhead byte
+	for len(src) > 0 {
+		// Trim leading zeros as they take up no overhead.
+		for len(src) >= 8 && binary.LittleEndian.Uint64(src) == 0 {
+			src = src[8:]
+		}
+		for len(src) > 0 && src[0] == 0 {
+			src = src[1:]
+		}
+
+		// Long runs of non-zero bytes require an overhead byte.
+		numNonZero := bytes.IndexByte(src, '\x00')
+		if numNonZero < 0 {
+			numNonZero = len(src)
+		}
+		n += numNonZero / 254 // each full group of 254 needs an overhead byte (except last)
+		src = src[numNonZero:]
+		if numNonZero > 0 && numNonZero%254 == 0 && len(src) == 0 {
+			n-- // exact final group of 254 does not need extra overhead byte
+		}
+	}
+	return n
+}
+
+var errUnexpectedEOF = errors.New("cobs: unexpected truncation")
+var errUnexpectedNull = errors.New("cobs: unexpected null byte")
+
+// AppendDecode appends the decoded bytes of src to the end of dst.
+// The COBS-encoded src must not contain the trailing null terminator byte;
+// use [TrimNull] to remove the trailing null terminator byte if needed.
+// It reports an error if the src contains invalid COBS.
+//
+// The src and dst buffers may exactly overlap. For example, it is valid to do:
+//
+//	b, _ = AppendDecode(b[:0], b)
+func AppendDecode(dst, src []byte) ([]byte, error) {
+	// Unlike AppendEncode, decoding in a forward direction is still safe
+	// when dst overlaps with src since the output is guaranteed to always
+	// be smaller than the input. Thus, the dst pointer will never run past
+	// src pointer and corrupt the input.
+
+	dst = slices.Grow(dst, len(src))
+	if len(src) == 0 {
+		return dst, errUnexpectedEOF
+	}
+	for len(src) > 0 {
+		// Performance optimization for many zeros.
+		// Leave at least one byte afterwards since the following logic
+		// expects to find another overhead byte.
+		// Also, the very last overhead byte does not emit a zero.
+		for len(src) > 8 && binary.LittleEndian.Uint64(src) == 0x0101010101010101 {
+			dst = binary.LittleEndian.AppendUint64(dst, 0x0000000000000000)
+			src = src[8:]
+		}
+
+		switch n := src[0]; {
+		case int(n) > len(src):
+			return dst, errUnexpectedEOF
+		case n == '\x00' || bytes.IndexByte(src[1:n], '\x00') >= 0:
+			return dst, errUnexpectedNull
+		default:
+			dst = append(dst, src[1:n]...)
+			if n-1 < 254 {
+				dst = append(dst, 0)
+			}
+			src = src[n:]
+		}
+	}
+	return TrimNull(dst), nil // trim implicit trailing null byte
+}
+
+// AppendNull appends a trailing null terminator byte if it does not already exist.
+func AppendNull(dst []byte) []byte {
+	if len(dst) > 0 && dst[len(dst)-len("\x00")] == '\x00' {
+		return dst
+	}
+	return append(dst, '\x00')
+}
+
+// TrimNull removes a trailing null terminator byte if it exists.
+func TrimNull(dst []byte) []byte {
+	if len(dst) > 0 && dst[len(dst)-len("\x00")] == '\x00' {
+		return dst[:len(dst)-len("\x00")]
+	}
+	return dst
+}
+
+// FrameLen reports the length of a COBS-encoded frame at the start of b
+// by searching for the next trailing null terminator.
+// The reported length includes the null terminator.
+// If the null terminator could not be found, then it reports -1.
+func FrameLen(b []byte) int {
+	if i := bytes.IndexByte(b, '\x00'); i >= 0 {
+		return i + len("\x00")
+	}
+	return -1
+}

--- a/util/cobs/cobs_test.go
+++ b/util/cobs/cobs_test.go
@@ -1,0 +1,320 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package cobs
+
+import (
+	"bytes"
+	"encoding/hex"
+	"math/rand/v2"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"tailscale.com/util/must"
+)
+
+var x = func(s string) []byte { return must.Get(hex.DecodeString(s)) }
+var n = func(s string, n int) string { return strings.Repeat(s, n) }
+var tests = []struct {
+	decoded    []byte
+	encoded    []byte
+	errDecoded error // non-nil implies that encode tests are skipped
+	padEncoded bool  // whether there is a trailing empty block after full block
+}{
+	{decoded: x(n("00", 1)), encoded: x(n("01", 2))},
+	{decoded: x("11" + n("00", 8)), encoded: x("02" + "11" + n("01", 8))},
+	{decoded: x("11" + n("00", 8) + "22"), encoded: x("02" + "11" + n("01", 7) + "02" + "22")},
+	{decoded: x(n("00", 8) + "11" + n("00", 8)), encoded: x(n("01", 8) + "02" + "11" + n("01", 8))},
+	{decoded: x(n("01", 253)), encoded: x("FE" + n("01", 253))},
+	{decoded: x(n("01", 254)), encoded: x("FF" + n("01", 254))},
+	{decoded: x(n("01", 254)), encoded: x("FF" + n("01", 254) + "01"), padEncoded: true},
+	{decoded: x(n("01", 255)), encoded: x("FF" + n("01", 254) + "02" + "01")},
+	{decoded: x(n("01", 254) + "00"), encoded: x("FF" + n("01", 254) + "0101")},
+	{decoded: x(n("01", 508)), encoded: x("FF" + n("01", 254) + "FF" + n("01", 254))},
+	{decoded: x(n("01", 509)), encoded: x("FF" + n("01", 254) + "FF" + n("01", 254) + "02" + "01")},
+	{decoded: x(n("01", 253) + "FF"), encoded: x("FF" + n("01", 253) + "FF")},
+
+	// Test examples from https://en.wikipedia.org/wiki/Consistent_Overhead_Byte_Stuffing.
+	{decoded: x(""), encoded: x("01")},
+	{decoded: x("00"), encoded: x("0101")},
+	{decoded: x("01"), encoded: x("0201")},
+	{decoded: x("0000"), encoded: x("010101")},
+	{decoded: x("001100"), encoded: x("01021101")},
+	{decoded: x("11220033"), encoded: x("0311220233")},
+	{decoded: x("11223344"), encoded: x("0511223344")},
+	{decoded: x("11000000"), encoded: x("0211010101")},
+	{decoded: x("010203" + n("FF", 249) + "FDFE"), encoded: x("FF010203" + n("FF", 249) + "FDFE")},
+	{decoded: x("010203" + n("FF", 249) + "FDFE"), encoded: x("FF010203" + n("FF", 249) + "FDFE01"), padEncoded: true},
+	{decoded: x("000102" + n("FF", 249) + "FCFDFE"), encoded: x("01FF0102" + n("FF", 249) + "FCFDFE")},
+	{decoded: x("010203" + n("FF", 249) + "FDFEFF"), encoded: x("FF010203" + n("FF", 249) + "FDFE02FF")},
+	{decoded: x("020304" + n("FF", 249) + "FEFF00"), encoded: x("FF020304" + n("FF", 249) + "FEFF0101")},
+	{decoded: x("030405" + n("FF", 249) + "FF0001"), encoded: x("FE030405" + n("FF", 249) + "FF0201")},
+
+	// Test boundary conditions of optimization for consecutive zeros.
+	{decoded: x(n("00", 7)), encoded: x(n("01", 7) + "01")},
+	{decoded: x(n("00", 7) + "FF"), encoded: x(n("01", 7) + "02FF")},
+	{decoded: x(n("00", 8)), encoded: x(n("01", 8) + "01")},
+	{decoded: x(n("00", 8) + "FF"), encoded: x(n("01", 8) + "02FF")},
+	{decoded: x(n("00", 9)), encoded: x(n("01", 9) + "01")},
+	{decoded: x(n("00", 9) + "FF"), encoded: x(n("01", 9) + "02FF")},
+	{decoded: x(n("00", 15)), encoded: x(n("01", 15) + "01")},
+	{decoded: x(n("00", 15) + "FF"), encoded: x(n("01", 15) + "02FF")},
+	{decoded: x(n("00", 16)), encoded: x(n("01", 16) + "01")},
+	{decoded: x(n("00", 16) + "FF"), encoded: x(n("01", 16) + "02FF")},
+	{decoded: x(n("00", 17)), encoded: x(n("01", 17) + "01")},
+	{decoded: x(n("00", 17) + "FF"), encoded: x(n("01", 17) + "02FF")},
+
+	// Test detection of invalid COBS-encoded inputs.
+	{decoded: x(n("00", 1000)), encoded: x(n("01", 1001))},
+	{decoded: x(""), encoded: x(""), errDecoded: errUnexpectedEOF},
+	{decoded: x(""), encoded: x("02"), errDecoded: errUnexpectedEOF},
+	{decoded: x("0100"), encoded: x("020102"), errDecoded: errUnexpectedEOF},
+	{decoded: x(""), encoded: x("0301"), errDecoded: errUnexpectedEOF},
+	{decoded: x(""), encoded: x("00"), errDecoded: errUnexpectedNull},
+	{decoded: x("00"), encoded: x("0100"), errDecoded: errUnexpectedNull},
+	{decoded: x(""), encoded: x("0200"), errDecoded: errUnexpectedNull},
+	{decoded: x("0100"), encoded: x("020100"), errDecoded: errUnexpectedNull},
+}
+
+func Test(t *testing.T) {
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			t.Run("MaxEncodedLen", func(t *testing.T) {
+				if tt.errDecoded != nil || tt.padEncoded {
+					t.SkipNow() // padded encodings are not produced by AppendEncode
+				}
+				got := MaxEncodedLen(len(tt.decoded))
+				if got < len(tt.encoded) {
+					t.Errorf("MaxEncodedLen(%d) = %d, want >= %d", len(tt.decoded), got, len(tt.encoded))
+				}
+			})
+
+			t.Run("MinDecodedLen", func(t *testing.T) {
+				if tt.errDecoded != nil {
+					t.SkipNow()
+				}
+				got := MinDecodedLen(len(tt.encoded))
+				if got > len(tt.decoded) {
+					t.Errorf("MinDecodedLen(%d) = %d, want <= %d", len(tt.encoded), got, len(tt.decoded))
+				}
+			})
+
+			t.Run("numOverhead", func(t *testing.T) {
+				if tt.errDecoded != nil {
+					t.SkipNow()
+				}
+				got := numOverhead(tt.decoded)
+				if tt.padEncoded {
+					got++
+				}
+				want := len(tt.encoded) - len(tt.decoded)
+				if got != want {
+					t.Errorf("numOverhead = %d, want %d", got, want)
+				}
+			})
+
+			t.Run("AppendEncode", func(t *testing.T) {
+				if tt.errDecoded != nil {
+					t.SkipNow()
+				}
+				for _, prefix := range []string{"", "prefix"} {
+					t.Run("Prefix:"+prefix, func(t *testing.T) {
+						for _, overlap := range []bool{false, true} {
+							t.Run("Overlap:"+strconv.FormatBool(overlap), func(t *testing.T) {
+								dst := []byte(prefix)
+								src := tt.decoded
+								if overlap {
+									dst = append(dst, src...)
+									src = dst[len(prefix):]
+								}
+								dst = AppendEncode(dst[:len(prefix)], src)
+								if tt.padEncoded {
+									dst = append(dst, 0x01)
+								}
+								if d := cmp.Diff(dst, append([]byte(prefix), tt.encoded...)); d != "" {
+									t.Errorf("AppendEncode mismatch (-got +want):\n%s", d)
+								}
+							})
+						}
+					})
+				}
+			})
+
+			t.Run("AppendDecode", func(t *testing.T) {
+				for _, prefix := range []string{"", "prefix"} {
+					t.Run("Prefix:"+prefix, func(t *testing.T) {
+						for _, overlap := range []bool{false, true} {
+							t.Run("Overlap:"+strconv.FormatBool(overlap), func(t *testing.T) {
+								dst := []byte(prefix)
+								src := tt.encoded
+								if overlap {
+									dst = append(dst, src...)
+									src = dst[len(prefix):]
+								}
+								dst, err := AppendDecode(dst[:len(prefix)], src)
+								if d := cmp.Diff(dst, append([]byte(prefix), tt.decoded...)); d != "" {
+									t.Errorf("AppendDecode mismatch (-got +want):\n%s", d)
+								}
+								if err != tt.errDecoded {
+									t.Errorf("AppendDecode error = %v, want %v", err, tt.errDecoded)
+								}
+							})
+						}
+					})
+				}
+			})
+		})
+	}
+}
+
+// encodeNaive is a straightforward translation of COBS from the C code
+// in the appendix of the paper by Stuart Cheshire and Mary Baker.
+//
+// This is used as the reference implementation by fuzzing to ensure
+// that [appendEncodeForward] and [appendEncodeReverse] are consistent.
+func encodeNaive(src []byte) (dst []byte) {
+	codeIdxPrev := len(dst)
+	codeIdxCurr := len(dst)
+	code := 0x01
+	dst = append(dst, 0) // placeholder for first block's code byte
+
+	finishBlock := func() {
+		dst[codeIdxCurr] = byte(code)
+		codeIdxPrev = codeIdxCurr
+		codeIdxCurr = len(dst)
+		code = 0x01
+		dst = append(dst, 0) // placeholder for next block's code byte
+	}
+
+	for _, b := range src {
+		if b == 0 {
+			finishBlock()
+		} else {
+			dst = append(dst, b)
+			code++
+			if code == 0xff {
+				finishBlock()
+			}
+		}
+	}
+	dst[codeIdxCurr] = byte(code) // final block, no trailing placeholder needed
+
+	// Optional space optimization: We can elide a final empty block
+	// if the previous block was a full group of non-zeros.
+	// The paper does not implement this part, but this is necessary
+	// since [appendEncodeForward] and [appendEncodeReverse] do this.
+	if code == 0x01 && dst[codeIdxPrev] == 0xff {
+		dst = dst[:len(dst)-1]
+	}
+
+	return dst
+}
+
+func FuzzRoundtrip(f *testing.F) {
+	for _, tt := range tests {
+		f.Add(tt.decoded)
+	}
+	f.Fuzz(func(t *testing.T, wantDecoded []byte) {
+		var seed [32]byte
+		copy(seed[:], wantDecoded)
+		rn := rand.New(rand.NewChaCha8(seed))
+
+		prefixLen := min(rn.IntN(len(wantDecoded)+1), 8)
+		gotDecoded := slices.Grow(bytes.Clone(wantDecoded), rn.IntN(numOverhead(wantDecoded[prefixLen:])+1))
+		wantEncoded := append(bytes.Clone(wantDecoded[:prefixLen]), encodeNaive(wantDecoded[prefixLen:])...)
+
+		gotEncodedForward := appendEncodeForward(slices.Clip(gotDecoded[:prefixLen]), gotDecoded[prefixLen:])
+		if string(gotEncodedForward) != string(wantEncoded) {
+			t.Errorf("EncodeForward(%d:%x) = %x, want %x", prefixLen, wantDecoded, gotEncodedForward, wantEncoded)
+		}
+
+		gotEncodedReverse := appendEncodeReverse(gotDecoded[:prefixLen], gotDecoded[prefixLen:])
+		if string(gotEncodedReverse) != string(wantEncoded) {
+			t.Errorf("EncodeReverse(%d:%x) = %x, want %x", prefixLen, wantDecoded, gotEncodedReverse, wantEncoded)
+		}
+
+		gotOverhead := numOverhead(wantDecoded[prefixLen:])
+		wantOverhead := len(wantEncoded) - len(wantDecoded)
+		if gotOverhead != wantOverhead {
+			t.Errorf("numOverhead(%x) = %d, want %d", wantDecoded[prefixLen:], gotOverhead, wantOverhead)
+		}
+
+		gotDecoded = must.Get(AppendDecode(wantEncoded[:prefixLen], wantEncoded[prefixLen:]))
+		if string(gotDecoded) != string(wantDecoded) {
+			t.Errorf("Decode(Encode(%d:%x)) != %x", prefixLen, wantDecoded, gotDecoded)
+		}
+	})
+}
+
+func FuzzMostlyBijective(f *testing.F) {
+	for _, tt := range tests {
+		f.Add(tt.encoded)
+	}
+	f.Fuzz(func(t *testing.T, wantEncoded []byte) {
+		// There is mostly a bijective mapping for the COBS-encoding
+		// such that there is exactly only one valid COBS-encoded blob
+		// for every possible non-encoded blob.
+		// The only exception is a trailing empty block following
+		// a full block of non-zeros.
+		decoded, err := AppendDecode(nil, wantEncoded) // must never panic
+		if err == nil {
+			gotEncoded := AppendEncode(nil, decoded)
+			if string(gotEncoded) != string(wantEncoded) && string(gotEncoded)+"\x01" != string(wantEncoded) {
+				t.Errorf("Encode(Decode(%x)) != %x", wantEncoded, gotEncoded)
+			}
+		}
+	})
+}
+
+func Benchmark(b *testing.B) {
+	const length = 1 << 20
+	out := make([]byte, MaxEncodedLen(length))
+	testdata := []struct {
+		name    string
+		encoded []byte
+		decoded []byte
+	}{{
+		name:    "Zeros",
+		decoded: bytes.Repeat([]byte{0x00}, length),
+	}, {
+		name:    "NonZeros",
+		decoded: bytes.Repeat([]byte{0xFF}, length),
+	}, {
+		name: "Random",
+		decoded: func() []byte {
+			b := make([]byte, length)
+			must.Get(new(rand.ChaCha8).Read(b))
+			return b
+		}(),
+	}}
+	for _, tt := range testdata {
+		tt.encoded = AppendEncode(nil, tt.decoded)
+		if string(must.Get(AppendDecode(out[:0], tt.encoded))) != string(tt.decoded) {
+			b.Fatal("Decode(Encode(...)) roundtrip mismatch")
+		}
+		b.Run("EncodeForward/"+tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(length)
+			for b.Loop() {
+				out = appendEncodeForward(out[:0], tt.decoded)
+			}
+		})
+		b.Run("EncodeReverse/"+tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(length)
+			for b.Loop() {
+				out = appendEncodeReverse(out[:0], tt.decoded)
+			}
+		})
+		b.Run("DecodeForward/"+tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(length)
+			for b.Loop() {
+				out = must.Get(AppendDecode(out[:0], tt.encoded))
+			}
+		})
+	}
+}

--- a/util/cobs/example_test.go
+++ b/util/cobs/example_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package cobs
+
+import (
+	"bytes"
+	"fmt"
+
+	"tailscale.com/util/must"
+)
+
+func Example() {
+	// Frames is a list of frames that may contain null bytes.
+	// Trivially joining the frames with a null byte would lead to
+	// ambiguity when parsing as null bytes within the frame itself
+	// cannot be distinguished from nulls used to mark frame boundaries.
+	frames := [][]byte{
+		[]byte("Hello world!"),
+		[]byte(""),
+		[]byte("\x00\x00\x00"),
+		[]byte("Fizz\x00Buzz"),
+	}
+
+	// COBS encoding ensures that each frame never contains null bytes.
+	for i, frame := range frames {
+		frames[i] = AppendEncode(frame[:0], frame)
+	}
+
+	// Since the COBS-encoded frame lacks null bytes,
+	// we can trivially join the frames together using a null byte.
+	stream := bytes.Join(frames, []byte("\x00"))
+
+	// Print out the COBS-encoded stream.
+	fmt.Printf("COBS-encoded stream:\n\t%q\n\n", stream)
+
+	// When decoding, the frame boundaries can be trivially detected
+	// by splitting upon the null byte.
+	frames = bytes.Split(stream, []byte("\x00"))
+
+	// However, each individual frame is still COBS-encoded,
+	// so we need to decode each one back to the original frame payload.
+	for i, frame := range frames {
+		frames[i] = must.Get(AppendDecode(frame[:0], frame))
+	}
+
+	// Print out each COBS-decoded frame to verify that it matches.
+	fmt.Println("COBS-decoded frames:")
+	for _, frame := range frames {
+		fmt.Printf("\t%q\n", frame)
+	}
+
+	// Output:
+	// COBS-encoded stream:
+	// 	"\rHello world!\x00\x01\x00\x01\x01\x01\x01\x00\x05Fizz\x05Buzz"
+	//
+	// COBS-decoded frames:
+	// 	"Hello world!"
+	// 	""
+	// 	"\x00\x00\x00"
+	// 	"Fizz\x00Buzz"
+}


### PR DESCRIPTION
Package cobs implements Consistent Overhead Byte Stuffing (COBS), a technique for reliable packet framing over serial byte streams.

This has future utility for storing a sequence of arbitrary log entries on disk without needing to depend on intrinsic framing within the log entries themselves (e.g., JSON or CBOR).

While more complicated, COBS is superior to offset-based framing mechanisms as the null byte can be trivially used to demarcate the boundaries of a frame. This makes COBS more resistant against bit-corruption where a single corrupted offset can make everything else in the file unreadable. COBS makes it possible to resynchronize framing after a corrupted section by simply searching for the next null.

Performance:

	Benchmark/Encode/Zeros-32                   5503            189170 ns/op        5543.05 MB/s           0 B/op          0 allocs/op
	Benchmark/Decode/Zeros-32                  16462             73713 ns/op        14225.08 MB/s          0 B/op          0 allocs/op
	Benchmark/Encode/NonZeros-32                3825            279864 ns/op        3746.73 MB/s           0 B/op          0 allocs/op
	Benchmark/Decode/NonZeros-32               36648             33899 ns/op        30932.39 MB/s          0 B/op          0 allocs/op
	Benchmark/Encode/Random-32                  3256            389780 ns/op        2690.17 MB/s           0 B/op          0 allocs/op
	Benchmark/Decode/Random-32                 26456             43616 ns/op        24040.82 MB/s          0 B/op          0 allocs/op

Encode performance is notably slower than Decode presumably because it relies on reverse encoding, which is done to make it possible to perform COBS encoding into the same buffer as the source, and thus avoiding an intermediate allocation. Speeds of GB/s is still plenty fast enough and still magnitudes faster than JSON or CBOR encoding.

Updates #17242
Updates tailscale/corp#21363