### PR TITLE
ipn/ipnstate,types/views: use value views.Slice fields

### DIFF
--- a/client/web/web.go
+++ b/client/web/web.go
@@ -938,7 +938,7 @@ func (s *Server) serveGetNodeData(w http.ResponseWriter, r *http.Request) {
 		data.TailnetName = profile.NetworkProfile.MagicDNSName
 		data.DomainName = profile.NetworkProfile.DisplayNameOrDefault()
 	}
-	if st.Self.Tags != nil {
+	if !st.Self.Tags.IsZero() {
 		data.Tags = st.Self.Tags.AsSlice()
 	}
 	if st.Self.KeyExpiry != nil {
@@ -946,7 +946,7 @@ func (s *Server) serveGetNodeData(w http.ResponseWriter, r *http.Request) {
 	}
 
 	routeApproved := func(route netip.Prefix) bool {
-		if st.Self == nil || st.Self.AllowedIPs == nil {
+		if st.Self == nil {
 			return false
 		}
 		return st.Self.AllowedIPs.ContainsFunc(func(p netip.Prefix) bool {

--- a/client/web/web_test.go
+++ b/client/web/web_test.go
@@ -91,7 +91,7 @@ func TestQnapAuthnURL(t *testing.T) {
 //  2. permissioning of api endpoints based on node capabilities
 func TestServeAPI(t *testing.T) {
 	selfTags := views.SliceOf([]string{"tag:server"})
-	self := &ipnstate.PeerStatus{ID: "self", Tags: &selfTags}
+	self := &ipnstate.PeerStatus{ID: "self", Tags: selfTags}
 	prefs := &ipn.Prefs{}
 
 	remoteUser := &tailcfg.UserProfile{ID: tailcfg.UserID(1)}
@@ -345,7 +345,7 @@ func TestGetTailscaleBrowserSession(t *testing.T) {
 		},
 		{
 			name:        "no-session-tagged-self-node",
-			selfNode:    &ipnstate.PeerStatus{ID: "self", Tags: &tags},
+			selfNode:    &ipnstate.PeerStatus{ID: "self", Tags: tags},
 			remoteAddr:  userANodeIP,
 			wantSession: nil,
 			wantError:   errNoSession,
@@ -1226,7 +1226,7 @@ func TestRequireTailscaleIP(t *testing.T) {
 func TestPeerCapabilities(t *testing.T) {
 	userOwnedStatus := &ipnstate.Status{Self: &ipnstate.PeerStatus{UserID: tailcfg.UserID(1)}}
 	tags := views.SliceOf[string]([]string{"tag:server"})
-	tagOwnedStatus := &ipnstate.Status{Self: &ipnstate.PeerStatus{Tags: &tags}}
+	tagOwnedStatus := &ipnstate.Status{Self: &ipnstate.PeerStatus{Tags: tags}}
 
 	// Testing web.toPeerCapabilities
 	toPeerCapsTests := []struct {

--- a/cmd/containerboot/main.go
+++ b/cmd/containerboot/main.go
@@ -282,9 +282,7 @@ func nodeFromPeerStatus(ps *ipnstate.PeerStatus) *tailcfg.Node {
 	for _, ip := range ps.TailscaleIPs {
 		n.Addresses = append(n.Addresses, netip.PrefixFrom(ip, ip.BitLen()))
 	}
-	if ps.AllowedIPs != nil {
-		n.AllowedIPs = ps.AllowedIPs.AsSlice()
-	}
+	n.AllowedIPs = ps.AllowedIPs.AsSlice()
 	return n
 }
 

--- a/cmd/containerboot/main_test.go
+++ b/cmd/containerboot/main_test.go
@@ -1554,10 +1554,7 @@ func peerStatusFromNode(n tailcfg.NodeView) *ipnstate.PeerStatus {
 			ps.TailscaleIPs = append(ps.TailscaleIPs, p.Addr())
 		}
 	}
-	if n.AllowedIPs().Len() != 0 {
-		v := n.AllowedIPs()
-		ps.AllowedIPs = &v
-	}
+	ps.AllowedIPs = n.AllowedIPs()
 	return ps
 }
 

--- a/cmd/tailscale/cli/configure-kube.go
+++ b/cmd/tailscale/cli/configure-kube.go
@@ -306,11 +306,6 @@ func nodeOrServiceDNSNameFromArg(st *ipnstate.Status, dns *tailcfg.DNSConfig, ar
 	}
 	ipPrefix := netip.PrefixFrom(ip, ip.BitLen())
 	for _, ps := range st.Peer {
-		if ps.AllowedIPs == nil {
-			// Peer with no addresses visible in the tailnet, e.g. a ProxyGroup
-			// whose backing nodes are offline or not yet approved (#20255).
-			continue
-		}
 		for _, allowedIP := range ps.AllowedIPs.All() {
 			if allowedIP == ipPrefix {
 				return rec.Name, nil

--- a/cmd/tailscale/cli/configure-kube_test.go
+++ b/cmd/tailscale/cli/configure-kube_test.go
@@ -354,8 +354,7 @@ func TestNodeOrServiceDNSNameFromArg(t *testing.T) {
 	}
 
 	peerWithService := &ipnstate.PeerStatus{DNSName: "node-a.example.ts.net."}
-	allowed := views.SliceOf([]netip.Prefix{netip.PrefixFrom(svcIP, svcIP.BitLen())})
-	peerWithService.AllowedIPs = &allowed
+	peerWithService.AllowedIPs = views.SliceOf([]netip.Prefix{netip.PrefixFrom(svcIP, svcIP.BitLen())})
 
 	// A peer with no AllowedIPs, as reported for a ProxyGroup whose backing
 	// nodes are offline or not yet approved (issue #20255).

--- a/cmd/tailscale/cli/exitnode_test.go
+++ b/cmd/tailscale/cli/exitnode_test.go
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"net/netip"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -11,7 +12,15 @@ import (
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/key"
+	"tailscale.com/types/views"
 )
+
+// sliceViewComparers compares the views.Slice fields on PeerStatus by their
+// contents, since cmp cannot traverse the views' unexported backing slice.
+var sliceViewComparers = []cmp.Option{
+	cmp.Comparer(func(a, b views.Slice[netip.Prefix]) bool { return views.SliceEqual(a, b) }),
+	cmp.Comparer(func(a, b views.Slice[string]) bool { return views.SliceEqual(a, b) }),
+}
 
 func TestFilterFormatAndSortExitNodes(t *testing.T) {
 	t.Run("without-filter", func(t *testing.T) {
@@ -134,7 +143,7 @@ func TestFilterFormatAndSortExitNodes(t *testing.T) {
 
 		result := filterFormatAndSortExitNodes(ps, "")
 
-		if res := cmp.Diff(result.Countries, want.Countries, cmpopts.IgnoreUnexported(key.NodePublic{})); res != "" {
+		if res := cmp.Diff(result.Countries, want.Countries, append(sliceViewComparers, cmpopts.IgnoreUnexported(key.NodePublic{}))...); res != "" {
 			t.Fatal(res)
 		}
 	})
@@ -229,7 +238,7 @@ func TestFilterFormatAndSortExitNodes(t *testing.T) {
 
 		result := filterFormatAndSortExitNodes(ps, "Pacific")
 
-		if res := cmp.Diff(result.Countries, want.Countries, cmpopts.IgnoreUnexported(key.NodePublic{})); res != "" {
+		if res := cmp.Diff(result.Countries, want.Countries, append(sliceViewComparers, cmpopts.IgnoreUnexported(key.NodePublic{}))...); res != "" {
 			t.Fatal(res)
 		}
 	})

--- a/cmd/tailscale/cli/serve_v2.go
+++ b/cmd/tailscale/cli/serve_v2.go
@@ -480,7 +480,7 @@ func (e *serveEnv) runServeCombined(subcmd serveMode) execFunc {
 			svcName = e.service
 			dnsName = e.service.String()
 		}
-		tagged := st.Self.Tags != nil && st.Self.Tags.Len() > 0
+		tagged := st.Self.Tags.Len() > 0
 		if forService && !tagged && !turnOff {
 			return errors.New("service hosts must be tagged nodes")
 		}

--- a/cmd/tailscale/cli/serve_v2_test.go
+++ b/cmd/tailscale/cli/serve_v2_test.go
@@ -830,7 +830,7 @@ func TestServeDevConfigMutations(t *testing.T) {
 							tailcfg.NodeAttrFunnel:                            nil,
 							tailcfg.CapabilityFunnelPorts + "?ports=443,8443": nil,
 						},
-						Tags: ptrToReadOnlySlice([]string{"some-tag"}),
+						Tags: views.SliceOf([]string{"some-tag"}),
 					},
 					CurrentTailnet: &ipnstate.TailnetStatus{MagicDNSSuffix: "test.ts.net"},
 				},
@@ -2355,11 +2355,6 @@ func exactErrMsg(want error) func(error) string {
 		}
 		return fmt.Sprintf("\ngot:  %v\nwant: %v\n", got, want)
 	}
-}
-
-func ptrToReadOnlySlice[T any](s []T) *views.Slice[T] {
-	vs := views.SliceOf(s)
-	return &vs
 }
 
 func writeTmpServeConfig(t *testing.T, body string) string {

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1653,16 +1653,13 @@ func peerStatusFromNode(ps *ipnstate.PeerStatus, n tailcfg.NodeView) {
 	ps.Created = n.Created()
 	ps.ExitNodeOption = buildfeatures.HasUseExitNode && tsaddr.ContainsExitRoutes(n.AllowedIPs())
 	if n.Tags().Len() != 0 {
-		v := n.Tags()
-		ps.Tags = &v
+		ps.Tags = n.Tags()
 	}
 	if n.PrimaryRoutes().Len() != 0 {
-		v := n.PrimaryRoutes()
-		ps.PrimaryRoutes = &v
+		ps.PrimaryRoutes = n.PrimaryRoutes()
 	}
 	if n.AllowedIPs().Len() != 0 {
-		v := n.AllowedIPs()
-		ps.AllowedIPs = &v
+		ps.AllowedIPs = n.AllowedIPs()
 	}
 
 	if n.Expired() {

--- a/ipn/ipnstate/ipnstate.go
+++ b/ipn/ipnstate/ipnstate.go
@@ -249,16 +249,16 @@ type PeerStatus struct {
 	// TailscaleIPs are the IP addresses assigned to the node.
 	TailscaleIPs []netip.Addr
 	// AllowedIPs are IP addresses allowed to route to this node.
-	AllowedIPs *views.Slice[netip.Prefix] `json:",omitempty"`
+	AllowedIPs views.Slice[netip.Prefix] `json:",omitzero"`
 
 	// Tags are the list of ACL tags applied to this node.
 	// See tailscale.com/tailcfg#Node.Tags for more information.
-	Tags *views.Slice[string] `json:",omitempty"`
+	Tags views.Slice[string] `json:",omitzero"`
 
 	// PrimaryRoutes are the routes this node is currently the primary
 	// subnet router for, as determined by the control plane. It does
 	// not include the IPs in TailscaleIPs.
-	PrimaryRoutes *views.Slice[netip.Prefix] `json:",omitempty"`
+	PrimaryRoutes views.Slice[netip.Prefix] `json:",omitzero"`
 
 	// Endpoints:
 	Addrs     []string
@@ -366,10 +366,6 @@ func (ps *PeerStatus) HasCap(cap tailcfg.NodeCapability) bool {
 // It is the analogue of [tailcfg.Node.IsRouter].
 func (ps *PeerStatus) IsRouter() bool {
 	// TODO(sfllaw): Keep this aligned with dbx.Node.IsSubnetRouter.
-	if ps.AllowedIPs == nil {
-		return false
-	}
-
 	for _, r := range ps.AllowedIPs.All() {
 		if !r.IsSingleIP() || !slices.Contains(ps.TailscaleIPs, r.Addr()) {
 			return true
@@ -380,7 +376,7 @@ func (ps *PeerStatus) IsRouter() bool {
 
 // IsTagged reports whether ps is tagged.
 func (ps *PeerStatus) IsTagged() bool {
-	return ps.Tags != nil && ps.Tags.Len() > 0
+	return ps.Tags.Len() > 0
 }
 
 // StatusBuilder is a request to construct a Status. A new StatusBuilder is
@@ -495,13 +491,13 @@ func (sb *StatusBuilder) AddPeer(peer key.NodePublic, st *PeerStatus) {
 	if v := st.TailscaleIPs; v != nil {
 		e.TailscaleIPs = v
 	}
-	if v := st.PrimaryRoutes; v != nil && !v.IsNil() {
+	if v := st.PrimaryRoutes; !v.IsNil() {
 		e.PrimaryRoutes = v
 	}
-	if v := st.AllowedIPs; v != nil && !v.IsNil() {
+	if v := st.AllowedIPs; !v.IsNil() {
 		e.AllowedIPs = v
 	}
-	if v := st.Tags; v != nil && !v.IsNil() {
+	if v := st.Tags; !v.IsNil() {
 		e.Tags = v
 	}
 	if v := st.OS; v != "" {

--- a/ipn/ipnstate/ipnstate_test.go
+++ b/ipn/ipnstate/ipnstate_test.go
@@ -4,9 +4,11 @@
 package ipnstate_test
 
 import (
+	jsonv1 "encoding/json"
 	"net/netip"
 	"testing"
 
+	jsonv2 "github.com/go-json-experiment/json"
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/types/views"
 )
@@ -28,7 +30,7 @@ func TestPeerStatusIsRouter(t *testing.T) {
 				TailscaleIPs: []netip.Addr{
 					netip.MustParseAddr("100.64.0.1"),
 				},
-				AllowedIPs: new(views.SliceOf([]netip.Prefix{})),
+				AllowedIPs: views.SliceOf([]netip.Prefix{}),
 			},
 			want: false,
 		},
@@ -38,9 +40,9 @@ func TestPeerStatusIsRouter(t *testing.T) {
 				TailscaleIPs: []netip.Addr{
 					netip.MustParseAddr("100.64.0.1"),
 				},
-				AllowedIPs: new(views.SliceOf([]netip.Prefix{
+				AllowedIPs: views.SliceOf([]netip.Prefix{
 					netip.MustParsePrefix("100.64.0.1/32"),
-				})),
+				}),
 			},
 			want: false,
 		},
@@ -50,9 +52,9 @@ func TestPeerStatusIsRouter(t *testing.T) {
 				TailscaleIPs: []netip.Addr{
 					netip.MustParseAddr("fd7a:115c:a1e0::1"),
 				},
-				AllowedIPs: new(views.SliceOf([]netip.Prefix{
+				AllowedIPs: views.SliceOf([]netip.Prefix{
 					netip.MustParsePrefix("fd7a:115c:a1e0::1/128"),
-				})),
+				}),
 			},
 			want: false,
 		},
@@ -63,10 +65,10 @@ func TestPeerStatusIsRouter(t *testing.T) {
 					netip.MustParseAddr("100.64.0.1"),
 					netip.MustParseAddr("fd7a:115c:a1e0::1"),
 				},
-				AllowedIPs: new(views.SliceOf([]netip.Prefix{
+				AllowedIPs: views.SliceOf([]netip.Prefix{
 					netip.MustParsePrefix("100.64.0.1/32"),
 					netip.MustParsePrefix("fd7a:115c:a1e0::1/128"),
-				})),
+				}),
 			},
 			want: false,
 		},
@@ -76,10 +78,10 @@ func TestPeerStatusIsRouter(t *testing.T) {
 				TailscaleIPs: []netip.Addr{
 					netip.MustParseAddr("100.64.0.1"),
 				},
-				AllowedIPs: new(views.SliceOf([]netip.Prefix{
+				AllowedIPs: views.SliceOf([]netip.Prefix{
 					netip.MustParsePrefix("100.64.0.1/32"),
 					netip.MustParsePrefix("0.0.0.0/0"),
-				})),
+				}),
 			},
 			want: true,
 		},
@@ -89,10 +91,10 @@ func TestPeerStatusIsRouter(t *testing.T) {
 				TailscaleIPs: []netip.Addr{
 					netip.MustParseAddr("fd7a:115c:a1e0::1"),
 				},
-				AllowedIPs: new(views.SliceOf([]netip.Prefix{
+				AllowedIPs: views.SliceOf([]netip.Prefix{
 					netip.MustParsePrefix("fd7a:115c:a1e0::1/128"),
 					netip.MustParsePrefix("::/0"),
-				})),
+				}),
 			},
 			want: true,
 		},
@@ -103,12 +105,12 @@ func TestPeerStatusIsRouter(t *testing.T) {
 					netip.MustParseAddr("100.64.0.1"),
 					netip.MustParseAddr("fd7a:115c:a1e0::1"),
 				},
-				AllowedIPs: new(views.SliceOf([]netip.Prefix{
+				AllowedIPs: views.SliceOf([]netip.Prefix{
 					netip.MustParsePrefix("100.64.0.1/32"),
 					netip.MustParsePrefix("fd7a:115c:a1e0::1/128"),
 					netip.MustParsePrefix("0.0.0.0/0"),
 					netip.MustParsePrefix("::/0"),
-				})),
+				}),
 			},
 			want: true,
 		},
@@ -118,10 +120,10 @@ func TestPeerStatusIsRouter(t *testing.T) {
 				TailscaleIPs: []netip.Addr{
 					netip.MustParseAddr("100.64.0.1"),
 				},
-				AllowedIPs: new(views.SliceOf([]netip.Prefix{
+				AllowedIPs: views.SliceOf([]netip.Prefix{
 					netip.MustParsePrefix("100.64.0.1/32"),
 					netip.MustParsePrefix("192.0.2.0/24"),
-				})),
+				}),
 			},
 			want: true,
 		},
@@ -131,10 +133,10 @@ func TestPeerStatusIsRouter(t *testing.T) {
 				TailscaleIPs: []netip.Addr{
 					netip.MustParseAddr("fd7a:115c:a1e0::1"),
 				},
-				AllowedIPs: new(views.SliceOf([]netip.Prefix{
+				AllowedIPs: views.SliceOf([]netip.Prefix{
 					netip.MustParsePrefix("fd7a:115c:a1e0::1/128"),
 					netip.MustParsePrefix("2001:db8::/32"),
-				})),
+				}),
 			},
 			want: true,
 		},
@@ -145,12 +147,12 @@ func TestPeerStatusIsRouter(t *testing.T) {
 					netip.MustParseAddr("100.64.0.1"),
 					netip.MustParseAddr("fd7a:115c:a1e0::1"),
 				},
-				AllowedIPs: new(views.SliceOf([]netip.Prefix{
+				AllowedIPs: views.SliceOf([]netip.Prefix{
 					netip.MustParsePrefix("100.64.0.1/32"),
 					netip.MustParsePrefix("fd7a:115c:a1e0::1/128"),
 					netip.MustParsePrefix("192.0.2.0/24"),
 					netip.MustParsePrefix("2001:db8::/32"),
-				})),
+				}),
 			},
 			want: true,
 		},
@@ -158,6 +160,219 @@ func TestPeerStatusIsRouter(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := tc.status.IsRouter(); got != tc.want {
 				t.Errorf("got %t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPeerStatusSliceViewFieldsJSON verifies the JSON encoding contract of the
+// views.Slice fields on the real PeerStatus type (AllowedIPs, Tags,
+// PrimaryRoutes) under both encoders the views types support: encoding/json
+// (jsonv1) and go-json-experiment/json (jsonv2).
+//
+// These fields were previously *views.Slice with json:",omitempty" and are now
+// views.Slice with json:",omitzero". This is the wire-format contract: these
+// fields are serialized over the LocalAPI and decoded by consumers (the web
+// client, tsnet, containerboot, k8s-operator, etc.) that are decoupled from
+// this type by JSON, so the observable encoding must not change.
+//
+// The contract, for each field:
+//   - a zero (unset/nil) view => key omitted entirely
+//   - a populated view        => key present with a JSON array
+//
+// It marshals the real PeerStatus and inspects only these three keys (via a map
+// decode) so the assertion is robust to the dozens of unrelated PeerStatus
+// fields. See TestPeerStatusSliceViewFieldsJSONMatchesPointerShape for the
+// proof that this matches the previous *views.Slice representation byte-for-byte.
+func TestPeerStatusSliceViewFieldsJSON(t *testing.T) {
+	pfx := func(s string) netip.Prefix { return netip.MustParsePrefix(s) }
+	const (
+		allowed = "AllowedIPs"
+		tags    = "Tags"
+		routes  = "PrimaryRoutes"
+	)
+
+	tests := []struct {
+		name string
+		ps   ipnstate.PeerStatus
+		// want maps each of the three keys to its expected raw JSON value, or
+		// omits the key entirely to assert it is absent from the output.
+		want map[string]string
+	}{
+		{
+			name: "all-unset",
+			ps:   ipnstate.PeerStatus{},
+			want: map[string]string{}, // all three keys absent
+		},
+		{
+			name: "allowed-ips",
+			ps:   ipnstate.PeerStatus{AllowedIPs: views.SliceOf([]netip.Prefix{pfx("100.64.0.1/32"), pfx("0.0.0.0/0")})},
+			want: map[string]string{allowed: `["100.64.0.1/32","0.0.0.0/0"]`},
+		},
+		{
+			name: "tags",
+			ps:   ipnstate.PeerStatus{Tags: views.SliceOf([]string{"tag:server", "tag:prod"})},
+			want: map[string]string{tags: `["tag:server","tag:prod"]`},
+		},
+		{
+			name: "primary-routes",
+			ps:   ipnstate.PeerStatus{PrimaryRoutes: views.SliceOf([]netip.Prefix{pfx("10.0.0.0/24")})},
+			want: map[string]string{routes: `["10.0.0.0/24"]`},
+		},
+		{
+			name: "all-populated",
+			ps: ipnstate.PeerStatus{
+				AllowedIPs:    views.SliceOf([]netip.Prefix{pfx("100.64.0.1/32")}),
+				Tags:          views.SliceOf([]string{"tag:server"}),
+				PrimaryRoutes: views.SliceOf([]netip.Prefix{pfx("10.0.0.0/24")}),
+			},
+			want: map[string]string{
+				allowed: `["100.64.0.1/32"]`,
+				tags:    `["tag:server"]`,
+				routes:  `["10.0.0.0/24"]`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, enc := range []struct {
+				name string
+				fn   func(any) ([]byte, error)
+			}{
+				{"encoding/json", jsonv1.Marshal},
+				{"go-json-experiment/json", func(v any) ([]byte, error) { return jsonv2.Marshal(v) }},
+			} {
+				b, err := enc.fn(tt.ps)
+				if err != nil {
+					t.Fatalf("%s: marshal: %v", enc.name, err)
+				}
+				var obj map[string]jsonv1.RawMessage
+				if err := jsonv1.Unmarshal(b, &obj); err != nil {
+					t.Fatalf("%s: unmarshal to map: %v", enc.name, err)
+				}
+				for _, key := range []string{allowed, tags, routes} {
+					got, present := obj[key]
+					wantVal, wantPresent := tt.want[key]
+					if present != wantPresent {
+						t.Errorf("%s: key %q present=%v, want %v (full: %s)", enc.name, key, present, wantPresent, b)
+						continue
+					}
+					if wantPresent && string(got) != wantVal {
+						t.Errorf("%s: key %q = %s, want %s", enc.name, key, got, wantVal)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestPeerStatusSliceViewFieldsJSONMatchesPointerShape proves that the current
+// value-typed views.Slice fields with json:",omitzero" encode byte-for-byte
+// identically to the previous *views.Slice fields with json:",omitempty",
+// under both encoders. This is the core wire-compatibility guarantee of the
+// pointer->value migration.
+//
+// Empty-but-non-nil views are intentionally excluded: producers must never
+// populate these fields with an empty, non-nil view (peerStatusFromNode guards
+// on Len()!=0), which is exactly the state where the two shapes would diverge.
+func TestPeerStatusSliceViewFieldsJSONMatchesPointerShape(t *testing.T) {
+	type newFields struct {
+		AllowedIPs    views.Slice[netip.Prefix] `json:",omitzero"`
+		Tags          views.Slice[string]       `json:",omitzero"`
+		PrimaryRoutes views.Slice[netip.Prefix] `json:",omitzero"`
+	}
+	type oldFields struct {
+		AllowedIPs    *views.Slice[netip.Prefix] `json:",omitempty"`
+		Tags          *views.Slice[string]       `json:",omitempty"`
+		PrimaryRoutes *views.Slice[netip.Prefix] `json:",omitempty"`
+	}
+	ptr := func(v views.Slice[netip.Prefix]) *views.Slice[netip.Prefix] { return &v }
+	ptrS := func(v views.Slice[string]) *views.Slice[string] { return &v }
+	pfx := func(s string) netip.Prefix { return netip.MustParsePrefix(s) }
+
+	aips := views.SliceOf([]netip.Prefix{pfx("100.64.0.1/32"), pfx("0.0.0.0/0")})
+	tg := views.SliceOf([]string{"tag:server"})
+	rt := views.SliceOf([]netip.Prefix{pfx("10.0.0.0/24")})
+
+	tests := []struct {
+		name string
+		new  newFields
+		old  oldFields
+	}{
+		{"all-unset", newFields{}, oldFields{}},
+		{
+			"all-populated",
+			newFields{AllowedIPs: aips, Tags: tg, PrimaryRoutes: rt},
+			oldFields{AllowedIPs: ptr(aips), Tags: ptrS(tg), PrimaryRoutes: ptr(rt)},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, enc := range []struct {
+				name string
+				fn   func(any) ([]byte, error)
+			}{
+				{"encoding/json", jsonv1.Marshal},
+				{"go-json-experiment/json", func(v any) ([]byte, error) { return jsonv2.Marshal(v) }},
+			} {
+				gotNew, err := enc.fn(tt.new)
+				if err != nil {
+					t.Fatalf("%s new: %v", enc.name, err)
+				}
+				gotOld, err := enc.fn(tt.old)
+				if err != nil {
+					t.Fatalf("%s old: %v", enc.name, err)
+				}
+				if string(gotNew) != string(gotOld) {
+					t.Errorf("%s: value shape diverged from pointer shape:\n old=%s\n new=%s", enc.name, gotOld, gotNew)
+				}
+			}
+		})
+	}
+}
+
+// TestPeerStatusSliceViewFieldsJSONBackCompat verifies that PeerStatus decodes
+// JSON produced by the previous (*views.Slice with omitempty) representation.
+// A peer produced by an older node may include the field as null (the zero
+// value a *views.Slice with omitempty could emit when the pointer was non-nil
+// but the underlying slice was nil), or omit it, or include a populated array.
+// All must decode without error and yield an iterable (never-panicking) view.
+func TestPeerStatusSliceViewFieldsJSONBackCompat(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		wantLen int
+	}{
+		{"field-absent", `{"ID":"n1"}`, 0},
+		{"field-null", `{"ID":"n1","AllowedIPs":null}`, 0},
+		{"field-empty-array", `{"ID":"n1","AllowedIPs":[]}`, 0},
+		{"field-populated", `{"ID":"n1","AllowedIPs":["100.64.0.1/32"]}`, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, dec := range []struct {
+				name string
+				fn   func([]byte, any) error
+			}{
+				{"encoding/json", jsonv1.Unmarshal},
+				{"go-json-experiment/json", func(b []byte, v any) error { return jsonv2.Unmarshal(b, v) }},
+			} {
+				var ps ipnstate.PeerStatus
+				if err := dec.fn([]byte(tt.in), &ps); err != nil {
+					t.Fatalf("%s: unmarshal: %v", dec.name, err)
+				}
+				if got := ps.AllowedIPs.Len(); got != tt.wantLen {
+					t.Errorf("%s: AllowedIPs.Len() = %d, want %d", dec.name, got, tt.wantLen)
+				}
+				// Must be iterable regardless of how it was decoded.
+				n := 0
+				for range ps.AllowedIPs.All() {
+					n++
+				}
+				if n != tt.wantLen {
+					t.Errorf("%s: iterated %d, want %d", dec.name, n, tt.wantLen)
+				}
 			}
 		})
 	}

--- a/tailcfg/tailcfg_test.go
+++ b/tailcfg/tailcfg_test.go
@@ -859,7 +859,7 @@ func peerStatusFromNode(n NodeView) *ipnstate.PeerStatus {
 			ps.TailscaleIPs = append(ps.TailscaleIPs, p.Addr())
 		}
 	}
-	ps.AllowedIPs = new(n.AllowedIPs())
+	ps.AllowedIPs = n.AllowedIPs()
 	return ps
 }
 

--- a/tsconsensus/authorization.go
+++ b/tsconsensus/authorization.go
@@ -118,7 +118,7 @@ func (a *authorization) SelfAllowed() bool {
 	if a.peers == nil {
 		return false
 	}
-	return a.peers.status.Self.Tags != nil && views.SliceContains(*a.peers.status.Self.Tags, a.tag)
+	return views.SliceContains(a.peers.status.Self.Tags, a.tag)
 }
 
 func (a *authorization) AllowedPeers() views.Slice[*ipnstate.PeerStatus] {
@@ -142,7 +142,7 @@ func newPeers(status *ipnstate.Status, tag string) *peers {
 		addrs:  set.Set[netip.Addr]{},
 	}
 	for _, p := range status.Peer {
-		if p.Tags != nil && views.SliceContains(*p.Tags, tag) {
+		if views.SliceContains(p.Tags, tag) {
 			ps.statuses = append(ps.statuses, p)
 			ps.addrs.AddSlice(p.TailscaleIPs)
 		}

--- a/tsconsensus/authorization_test.go
+++ b/tsconsensus/authorization_test.go
@@ -29,7 +29,7 @@ const testTag string = "tag:clusterTag"
 func makeAuthTestPeer(i int, tags views.Slice[string]) *ipnstate.PeerStatus {
 	return &ipnstate.PeerStatus{
 		ID:   tailcfg.StableNodeID(fmt.Sprintf("%d", i)),
-		Tags: &tags,
+		Tags: tags,
 		TailscaleIPs: []netip.Addr{
 			netip.AddrFrom4([4]byte{100, 0, 0, byte(i)}),
 			netip.MustParseAddr(fmt.Sprintf("fd7a:115c:a1e0:0::%d", i)),

--- a/tsconsensus/tsconsensus_test.go
+++ b/tsconsensus/tsconsensus_test.go
@@ -181,20 +181,17 @@ func waitForNodesToBeTaggedInStatus(t testing.TB, ctx context.Context, ts *tsnet
 			t.Fatalf("error getting status: %v", err)
 		}
 		for _, k := range nodeKeys {
-			var tags *views.Slice[string]
+			var tags views.Slice[string]
 			if k == status.Self.PublicKey {
 				tags = status.Self.Tags
 			} else {
 				tags = status.Peer[k].Tags
 			}
 			if tag == "" {
-				if tags != nil && tags.Len() != 0 {
+				if tags.Len() != 0 {
 					return false
 				}
 			} else {
-				if tags == nil {
-					return false
-				}
 				if tags.Len() != 1 || tags.At(0) != tag {
 					return false
 				}

--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -1848,7 +1848,7 @@ func (s *Server) ListenService(name string, mode ServiceMode) (*ServiceListener,
 	}
 
 	st := s.lb.StatusWithoutPeers()
-	if st.Self.Tags == nil || st.Self.Tags.Len() == 0 {
+	if st.Self.Tags.Len() == 0 {
 		return nil, ErrUntaggedServiceHost
 	}
 

--- a/tsnet/tsnet_test.go
+++ b/tsnet/tsnet_test.go
@@ -2457,7 +2457,7 @@ func TestUserMetricsRouteGauges(t *testing.T) {
 		}
 		// Wait for the primary routes to reach our desired routes, which is wantRoutes + 1, because
 		// the PrimaryRoutes list will contain a exit node route, which the metric does not count.
-		return status1.Self.PrimaryRoutes != nil && status1.Self.PrimaryRoutes.Len() == int(wantRoutes)+1
+		return status1.Self.PrimaryRoutes.Len() == int(wantRoutes)+1
 	})
 
 	ctxLc, cancelLc := context.WithTimeout(context.Background(), 5*time.Second)

--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -970,7 +970,7 @@ func TestIncrementalMapUpdatePeerAllowedIPsReachability(t *testing.T) {
 		if !ok {
 			return fmt.Errorf("node 1 doesn't see node 2 as a peer")
 		}
-		if p.AllowedIPs == nil {
+		if p.AllowedIPs.Len() == 0 {
 			return fmt.Errorf("node 1 sees node 2 with no AllowedIPs")
 		}
 		for _, allowedIP := range p.AllowedIPs.All() {

--- a/tstest/natlab/vmtest/vmtest.go
+++ b/tstest/natlab/vmtest/vmtest.go
@@ -1358,24 +1358,18 @@ func (e *Env) DumpStatus(n *Node) {
 		return
 	}
 	var selfAllowed []string
-	if st.Self.AllowedIPs != nil {
-		for i := range st.Self.AllowedIPs.Len() {
-			selfAllowed = append(selfAllowed, st.Self.AllowedIPs.At(i).String())
-		}
+	for i := range st.Self.AllowedIPs.Len() {
+		selfAllowed = append(selfAllowed, st.Self.AllowedIPs.At(i).String())
 	}
 	var selfPrimary []string
-	if st.Self.PrimaryRoutes != nil {
-		for i := range st.Self.PrimaryRoutes.Len() {
-			selfPrimary = append(selfPrimary, st.Self.PrimaryRoutes.At(i).String())
-		}
+	for i := range st.Self.PrimaryRoutes.Len() {
+		selfPrimary = append(selfPrimary, st.Self.PrimaryRoutes.At(i).String())
 	}
 	e.t.Logf("[%s] self: %v, backend=%s, AllowedIPs=%v, PrimaryRoutes=%v", n.name, st.Self.TailscaleIPs, st.BackendState, selfAllowed, selfPrimary)
 	for _, peer := range st.Peer {
 		var aips []string
-		if peer.AllowedIPs != nil {
-			for i := range peer.AllowedIPs.Len() {
-				aips = append(aips, peer.AllowedIPs.At(i).String())
-			}
+		for i := range peer.AllowedIPs.Len() {
+			aips = append(aips, peer.AllowedIPs.At(i).String())
 		}
 		e.t.Logf("[%s] peer %s (%s): AllowedIPs=%v, Online=%v, Relay=%q, CurAddr=%q",
 			n.name, peer.HostName, peer.TailscaleIPs,
@@ -1395,11 +1389,9 @@ func (e *Env) waitForPeerRoute(n *Node, prefix string, timeout time.Duration) bo
 			return false
 		}
 		for _, peer := range st.Peer {
-			if peer.AllowedIPs != nil {
-				for i := range peer.AllowedIPs.Len() {
-					if peer.AllowedIPs.At(i).String() == prefix {
-						return true
-					}
+			for i := range peer.AllowedIPs.Len() {
+				if peer.AllowedIPs.At(i).String() == prefix {
+					return true
 				}
 			}
 		}

--- a/types/views/views.go
+++ b/types/views/views.go
@@ -48,6 +48,12 @@ func (v ByteSlice[T]) IsNil() bool {
 	return v.ж == nil
 }
 
+// IsZero reports whether the ByteSlice is the zero value, with a nil underlying
+// slice. It implements the interface used by encoding/json's "omitzero" option.
+func (v ByteSlice[T]) IsZero() bool {
+	return v.ж == nil
+}
+
 // Mem returns a read-only view of the underlying slice.
 func (v ByteSlice[T]) Mem() mem.RO {
 	return mem.B(v.ж)
@@ -201,6 +207,10 @@ func (v *SliceView[T, V]) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 // IsNil reports whether the underlying slice is nil.
 func (v SliceView[T, V]) IsNil() bool { return v.ж == nil }
 
+// IsZero reports whether the SliceView is the zero value, with a nil underlying
+// slice. It implements the interface used by encoding/json's "omitzero" option.
+func (v SliceView[T, V]) IsZero() bool { return v.ж == nil }
+
 // Len returns the length of the slice.
 func (v SliceView[T, V]) Len() int { return len(v.ж) }
 
@@ -317,6 +327,10 @@ func (v *Slice[T]) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 
 // IsNil reports whether the underlying slice is nil.
 func (v Slice[T]) IsNil() bool { return v.ж == nil }
+
+// IsZero reports whether the Slice is the zero value, with a nil underlying
+// slice. It implements the interface used by encoding/json's "omitzero" option.
+func (v Slice[T]) IsZero() bool { return v.ж == nil }
 
 // Len returns the length of the slice.
 func (v Slice[T]) Len() int { return len(v.ж) }
@@ -578,6 +592,12 @@ func (m MapSlice[K, V]) IsNil() bool {
 	return m.ж == nil
 }
 
+// IsZero reports whether the MapSlice is the zero value, with a nil underlying
+// map. It implements the interface used by encoding/json's "omitzero" option.
+func (m MapSlice[K, V]) IsZero() bool {
+	return m.ж == nil
+}
+
 // Len returns the number of elements in the map.
 func (m MapSlice[K, V]) Len() int { return len(m.ж) }
 
@@ -677,6 +697,12 @@ func (m Map[K, V]) Contains(k K) bool {
 
 // IsNil reports whether the underlying map is nil.
 func (m Map[K, V]) IsNil() bool {
+	return m.ж == nil
+}
+
+// IsZero reports whether the Map is the zero value, with a nil underlying map.
+// It implements the interface used by encoding/json's "omitzero" option.
+func (m Map[K, V]) IsZero() bool {
 	return m.ж == nil
 }
 
@@ -828,6 +854,12 @@ func (m MapFn[K, T, V]) Get(k K) V {
 
 // IsNil reports whether the underlying map is nil.
 func (m MapFn[K, T, V]) IsNil() bool {
+	return m.ж == nil
+}
+
+// IsZero reports whether the MapFn is the zero value, with a nil underlying
+// map. It implements the interface used by encoding/json's "omitzero" option.
+func (m MapFn[K, T, V]) IsZero() bool {
 	return m.ж == nil
 }
 

--- a/types/views/views_test.go
+++ b/types/views/views_test.go
@@ -654,6 +654,153 @@ func TestSliceViewRange(t *testing.T) {
 	}
 }
 
+// TestZeroViewsAreSafe verifies that a zero-value (unset) view behaves like an
+// empty native container: iterating yields nothing, Len is 0, IsNil/IsZero
+// report true, and conversions return nil. This is the structural guarantee
+// that lets callers hold views by value rather than by pointer: a nil *view
+// panics when a value-receiver method is called on it, but a zero view does
+// not. See the PeerStatus.AllowedIPs SIGSEGV that motivated this.
+func TestZeroViewsAreSafe(t *testing.T) {
+	t.Run("Slice", func(t *testing.T) {
+		var v Slice[netip.Prefix]
+		if v.Len() != 0 || !v.IsNil() || !v.IsZero() || v.AsSlice() != nil {
+			t.Errorf("zero Slice not empty: len=%d isNil=%v isZero=%v asSlice=%v", v.Len(), v.IsNil(), v.IsZero(), v.AsSlice())
+		}
+		n := 0
+		for range v.All() {
+			n++
+		}
+		if n != 0 {
+			t.Errorf("All yielded %d elements, want 0", n)
+		}
+		if v.ContainsFunc(func(netip.Prefix) bool { return true }) {
+			t.Error("ContainsFunc = true, want false")
+		}
+		if got := v.IndexFunc(func(netip.Prefix) bool { return true }); got != -1 {
+			t.Errorf("IndexFunc = %d, want -1", got)
+		}
+		if SliceContains(Slice[string]{}, "x") {
+			t.Error("SliceContains = true, want false")
+		}
+	})
+
+	t.Run("SliceView", func(t *testing.T) {
+		var v SliceView[*testStruct, testStructView]
+		if v.Len() != 0 || !v.IsNil() || !v.IsZero() || v.AsSlice() != nil {
+			t.Errorf("zero SliceView not empty: len=%d isNil=%v isZero=%v", v.Len(), v.IsNil(), v.IsZero())
+		}
+		n := 0
+		for range v.All() {
+			n++
+		}
+		if n != 0 {
+			t.Errorf("All yielded %d elements, want 0", n)
+		}
+	})
+
+	t.Run("ByteSlice", func(t *testing.T) {
+		var v ByteSlice[[]byte]
+		if v.Len() != 0 || !v.IsNil() || !v.IsZero() || v.AsSlice() != nil {
+			t.Errorf("zero ByteSlice not empty: len=%d isNil=%v isZero=%v", v.Len(), v.IsNil(), v.IsZero())
+		}
+	})
+
+	t.Run("Map", func(t *testing.T) {
+		var m Map[string, int]
+		if m.Len() != 0 || !m.IsNil() || !m.IsZero() || m.Contains("x") || m.AsMap() != nil {
+			t.Errorf("zero Map not empty: len=%d isNil=%v isZero=%v", m.Len(), m.IsNil(), m.IsZero())
+		}
+		n := 0
+		for range m.All() {
+			n++
+		}
+		if n != 0 {
+			t.Errorf("All yielded %d elements, want 0", n)
+		}
+	})
+
+	t.Run("MapSlice", func(t *testing.T) {
+		var m MapSlice[string, int]
+		if m.Len() != 0 || !m.IsNil() || !m.IsZero() || m.Contains("x") || m.AsMap() != nil {
+			t.Errorf("zero MapSlice not empty: len=%d isNil=%v isZero=%v", m.Len(), m.IsNil(), m.IsZero())
+		}
+		n := 0
+		for range m.All() {
+			n++
+		}
+		if n != 0 {
+			t.Errorf("All yielded %d elements, want 0", n)
+		}
+		if g := m.Get("x"); g.Len() != 0 {
+			t.Errorf("Get on zero MapSlice: len=%d, want 0", g.Len())
+		}
+	})
+
+	t.Run("MapFn", func(t *testing.T) {
+		var m MapFn[string, *testStruct, testStructView]
+		if m.Len() != 0 || !m.IsNil() || !m.IsZero() || m.Contains("x") {
+			t.Errorf("zero MapFn not empty: len=%d isNil=%v isZero=%v", m.Len(), m.IsNil(), m.IsZero())
+		}
+		n := 0
+		for range m.All() {
+			n++
+		}
+		if n != 0 {
+			t.Errorf("All yielded %d elements, want 0", n)
+		}
+	})
+}
+
+// TestSliceOmitZeroJSON locks in the wire format that value-typed view fields
+// rely on: a zero view tagged json:",omitzero" must be omitted (matching the
+// old *views.Slice pointer with omitempty, which omitted a nil pointer), and a
+// populated view must serialize and round-trip its elements. It checks both
+// encoding/json (jsonv1) and go-json-experiment/json (jsonv2).
+func TestSliceOmitZeroJSON(t *testing.T) {
+	type omitZeroStruct struct {
+		Int  int
+		IPs  Slice[netip.Prefix] `json:",omitzero"`
+		Tags Slice[string]       `json:",omitzero"`
+	}
+
+	empty := omitZeroStruct{Int: 5}
+	for _, enc := range []struct {
+		name string
+		fn   func(any) ([]byte, error)
+	}{
+		{"jsonv1", jsonv1.Marshal},
+		{"jsonv2", func(v any) ([]byte, error) { return jsonv2.Marshal(v) }},
+	} {
+		got, err := enc.fn(empty)
+		if err != nil {
+			t.Fatalf("%s: %v", enc.name, err)
+		}
+		if want := `{"Int":5}`; string(got) != want {
+			t.Errorf("%s zero: got %s want %s", enc.name, got, want)
+		}
+	}
+
+	full := omitZeroStruct{
+		Int:  5,
+		IPs:  SliceOf([]netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")}),
+		Tags: SliceOf([]string{"tag:foo"}),
+	}
+	b, err := jsonv1.Marshal(full)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := `{"Int":5,"IPs":["10.0.0.0/8"],"Tags":["tag:foo"]}`; string(b) != want {
+		t.Errorf("full: got %s want %s", b, want)
+	}
+	var back omitZeroStruct
+	if err := jsonv1.Unmarshal(b, &back); err != nil {
+		t.Fatal(err)
+	}
+	if back.IPs.Len() != 1 || back.Tags.Len() != 1 {
+		t.Errorf("round-trip lost elements: %+v", back)
+	}
+}
+
 func TestMapIter(t *testing.T) {
 	m := MapOf(map[string]int{"foo": 1, "bar": 2})
 	var got []string


### PR DESCRIPTION
Change the views.Slice fields in PeerStatus from pointers to values. This avoids a whole class of nil dereference bugs because the values behave more like Go's native slices, but leverages the JSON omitzero semantics to make sure the wire format doesn't change.

Updates #20255