### PR TITLE
util/cloudenv: detect cloud on Windows and BSDs

### DIFF
--- a/util/cloudenv/cloudenv.go
+++ b/util/cloudenv/cloudenv.go
@@ -130,26 +130,38 @@ func readFileTrimmed(name string) string {
 	return strings.TrimSpace(string(v))
 }
 
-// cloudFromSMBIOS reports which cloud we're running in based on the given
-// SMBIOS/DMI identifiers (as exposed by the hardware to the OS), along with
-// whether the caller should probe the metadata server to disambiguate.
+// cloudFromSMBIOS reports which cloud we're running in, based on the
+// SMBIOS/DMI identifiers exposed by the hardware to the OS. It fetches each
+// identifier by calling read with its DMI name ("bios_vendor", "sys_vendor",
+// or "product_name"), reading only as many as needed to decide; read should
+// return the empty string for identifiers that are unavailable.
 //
-// Any identifier that's unavailable should be passed as the empty string.
-func cloudFromSMBIOS(biosVendor, sysVendor, productName string) (c Cloud, hitMetadata bool) {
-	switch {
-	case biosVendor == "Amazon EC2" || strings.HasSuffix(biosVendor, ".amazon"):
+// If c is empty and probeMetadata is true, the identifiers alone were
+// inconclusive and the caller should probe the well-known metadata server to
+// determine the cloud.
+func cloudFromSMBIOS(read func(dmiName string) string) (c Cloud, probeMetadata bool) {
+	biosVendor := read("bios_vendor")
+	if biosVendor == "Amazon EC2" || strings.HasSuffix(biosVendor, ".amazon") {
 		return AWS, false
-	case sysVendor == "DigitalOcean":
+	}
+	switch read("sys_vendor") {
+	case "DigitalOcean":
 		return DigitalOcean, false
-	case sysVendor == "Hetzner":
+	case "Hetzner":
 		return Hetzner, false
+	}
 	// TODO(andrew): "Vultr" is also valid if we need it
-	case productName == "Google Compute Engine":
+	switch read("product_name") {
+	case "Google Compute Engine":
 		return GCP, false
-	case productName == "Google":
+	case "Google":
 		// Old GCP VMs, it seems.
 		return "", true
-	case productName == "Virtual Machine", biosVendor == "Microsoft Corporation":
+	case "Virtual Machine":
+		// Azure, or maybe all Hyper-V?
+		return "", true
+	}
+	if biosVendor == "Microsoft Corporation" {
 		// Azure, or maybe all Hyper-V?
 		return "", true
 	}
@@ -157,18 +169,16 @@ func cloudFromSMBIOS(biosVendor, sysVendor, productName string) (c Cloud, hitMet
 }
 
 func getCloud() Cloud {
-	var hitMetadata bool
+	var probeMetadata bool
 	switch runtime.GOOS {
 	case "android", "ios", "darwin":
 		// Assume these aren't running on a cloud.
 		return ""
 	case "linux":
 		var c Cloud
-		c, hitMetadata = cloudFromSMBIOS(
-			readFileTrimmed("/sys/class/dmi/id/bios_vendor"),
-			readFileTrimmed("/sys/class/dmi/id/sys_vendor"),
-			readFileTrimmed("/sys/class/dmi/id/product_name"),
-		)
+		c, probeMetadata = cloudFromSMBIOS(func(dmiName string) string {
+			return readFileTrimmed("/sys/class/dmi/id/" + dmiName)
+		})
 		if c != "" {
 			return c
 		}
@@ -185,9 +195,9 @@ func getCloud() Cloud {
 		// from WMI on Windows, kenv/sysctl on the BSDs) and feed them to
 		// cloudFromSMBIOS, so we can skip this probe on machines that clearly
 		// aren't on a cloud.
-		hitMetadata = true
+		probeMetadata = true
 	}
-	if !hitMetadata {
+	if !probeMetadata {
 		return ""
 	}
 

--- a/util/cloudenv/cloudenv.go
+++ b/util/cloudenv/cloudenv.go
@@ -130,6 +130,32 @@ func readFileTrimmed(name string) string {
 	return strings.TrimSpace(string(v))
 }
 
+// cloudFromSMBIOS reports which cloud we're running in based on the given
+// SMBIOS/DMI identifiers (as exposed by the hardware to the OS), along with
+// whether the caller should probe the metadata server to disambiguate.
+//
+// Any identifier that's unavailable should be passed as the empty string.
+func cloudFromSMBIOS(biosVendor, sysVendor, productName string) (c Cloud, hitMetadata bool) {
+	switch {
+	case biosVendor == "Amazon EC2" || strings.HasSuffix(biosVendor, ".amazon"):
+		return AWS, false
+	case sysVendor == "DigitalOcean":
+		return DigitalOcean, false
+	case sysVendor == "Hetzner":
+		return Hetzner, false
+	// TODO(andrew): "Vultr" is also valid if we need it
+	case productName == "Google Compute Engine":
+		return GCP, false
+	case productName == "Google":
+		// Old GCP VMs, it seems.
+		return "", true
+	case productName == "Virtual Machine", biosVendor == "Microsoft Corporation":
+		// Azure, or maybe all Hyper-V?
+		return "", true
+	}
+	return "", false
+}
+
 func getCloud() Cloud {
 	var hitMetadata bool
 	switch runtime.GOOS {
@@ -137,39 +163,29 @@ func getCloud() Cloud {
 		// Assume these aren't running on a cloud.
 		return ""
 	case "linux":
-		biosVendor := readFileTrimmed("/sys/class/dmi/id/bios_vendor")
-		if biosVendor == "Amazon EC2" || strings.HasSuffix(biosVendor, ".amazon") {
-			return AWS
-		}
-
-		sysVendor := readFileTrimmed("/sys/class/dmi/id/sys_vendor")
-		if sysVendor == "DigitalOcean" {
-			return DigitalOcean
-		}
-		if sysVendor == "Hetzner" {
-			return Hetzner
-		}
-		// TODO(andrew): "Vultr" is also valid if we need it
-
-		prod := readFileTrimmed("/sys/class/dmi/id/product_name")
-		if prod == "Google Compute Engine" {
-			return GCP
-		}
-		if prod == "Google" { // old GCP VMs, it seems
-			hitMetadata = true
-		}
-		if prod == "Virtual Machine" || biosVendor == "Microsoft Corporation" {
-			// Azure, or maybe all Hyper-V?
-			hitMetadata = true
+		var c Cloud
+		c, hitMetadata = cloudFromSMBIOS(
+			readFileTrimmed("/sys/class/dmi/id/bios_vendor"),
+			readFileTrimmed("/sys/class/dmi/id/sys_vendor"),
+			readFileTrimmed("/sys/class/dmi/id/product_name"),
+		)
+		if c != "" {
+			return c
 		}
 
 	default:
-		// TODO(bradfitz): use Win32_SystemEnclosure from WMI or something on
-		// Windows to see if it's a physical machine and skip the cloud check
-		// early. Otherwise use similar clues as Linux about whether we should
-		// burn up to 2 seconds waiting for a metadata server that might not be
-		// there. And for BSDs, look where the /sys stuff is.
-		return ""
+		// On other operating systems (notably Windows and the BSDs) we don't
+		// yet have a cheap, OS-specific way to read the SMBIOS/DMI clues that
+		// the Linux path above uses, so fall back to probing the metadata
+		// server directly. The probe below is OS-independent and detects AWS,
+		// GCP, and Azure. Get caches the result, so this cost is paid at most
+		// once per process.
+		//
+		// TODO: read the SMBIOS clues on these platforms too (Win32_SystemEnclosure
+		// from WMI on Windows, kenv/sysctl on the BSDs) and feed them to
+		// cloudFromSMBIOS, so we can skip this probe on machines that clearly
+		// aren't on a cloud.
+		hitMetadata = true
 	}
 	if !hitMetadata {
 		return ""

--- a/util/cloudenv/cloudenv_test.go
+++ b/util/cloudenv/cloudenv_test.go
@@ -27,3 +27,35 @@ func TestGetDigitalOceanResolver(t *testing.T) {
 	addr := netip.MustParseAddr(getDigitalOceanResolver())
 	t.Logf("got: %v", addr)
 }
+
+func TestCloudFromSMBIOS(t *testing.T) {
+	tests := []struct {
+		name         string
+		biosVendor   string
+		sysVendor    string
+		productName  string
+		wantCloud    Cloud
+		wantMetadata bool
+	}{
+		{name: "empty"},
+		{name: "aws", biosVendor: "Amazon EC2", wantCloud: AWS},
+		{name: "aws-suffix", biosVendor: "1.0-1.amazon", wantCloud: AWS},
+		{name: "digitalocean", sysVendor: "DigitalOcean", wantCloud: DigitalOcean},
+		{name: "hetzner", sysVendor: "Hetzner", wantCloud: Hetzner},
+		{name: "gcp", productName: "Google Compute Engine", wantCloud: GCP},
+		{name: "gcp-old", productName: "Google", wantMetadata: true},
+		{name: "azure-product", productName: "Virtual Machine", wantMetadata: true},
+		{name: "azure-bios", biosVendor: "Microsoft Corporation", wantMetadata: true},
+		{name: "unknown", biosVendor: "SeaBIOS", sysVendor: "QEMU", productName: "Standard PC"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCloud, gotMetadata := cloudFromSMBIOS(tt.biosVendor, tt.sysVendor, tt.productName)
+			if gotCloud != tt.wantCloud || gotMetadata != tt.wantMetadata {
+				t.Errorf("cloudFromSMBIOS(%q, %q, %q) = (%q, %v); want (%q, %v)",
+					tt.biosVendor, tt.sysVendor, tt.productName,
+					gotCloud, gotMetadata, tt.wantCloud, tt.wantMetadata)
+			}
+		})
+	}
+}

--- a/util/cloudenv/cloudenv_test.go
+++ b/util/cloudenv/cloudenv_test.go
@@ -6,6 +6,7 @@ package cloudenv
 import (
 	"flag"
 	"net/netip"
+	"slices"
 	"testing"
 )
 
@@ -30,31 +31,57 @@ func TestGetDigitalOceanResolver(t *testing.T) {
 
 func TestCloudFromSMBIOS(t *testing.T) {
 	tests := []struct {
-		name         string
-		biosVendor   string
-		sysVendor    string
-		productName  string
-		wantCloud    Cloud
-		wantMetadata bool
+		name        string
+		biosVendor  string
+		sysVendor   string
+		productName string
+		wantCloud   Cloud
+		wantProbe   bool
+		wantReads   []string // identifiers read, in order
 	}{
-		{name: "empty"},
-		{name: "aws", biosVendor: "Amazon EC2", wantCloud: AWS},
-		{name: "aws-suffix", biosVendor: "1.0-1.amazon", wantCloud: AWS},
-		{name: "digitalocean", sysVendor: "DigitalOcean", wantCloud: DigitalOcean},
-		{name: "hetzner", sysVendor: "Hetzner", wantCloud: Hetzner},
-		{name: "gcp", productName: "Google Compute Engine", wantCloud: GCP},
-		{name: "gcp-old", productName: "Google", wantMetadata: true},
-		{name: "azure-product", productName: "Virtual Machine", wantMetadata: true},
-		{name: "azure-bios", biosVendor: "Microsoft Corporation", wantMetadata: true},
-		{name: "unknown", biosVendor: "SeaBIOS", sysVendor: "QEMU", productName: "Standard PC"},
+		{name: "empty", wantReads: []string{"bios_vendor", "sys_vendor", "product_name"}},
+		{name: "aws", biosVendor: "Amazon EC2", wantCloud: AWS,
+			wantReads: []string{"bios_vendor"}},
+		{name: "aws-suffix", biosVendor: "1.0-1.amazon", wantCloud: AWS,
+			wantReads: []string{"bios_vendor"}},
+		{name: "digitalocean", sysVendor: "DigitalOcean", wantCloud: DigitalOcean,
+			wantReads: []string{"bios_vendor", "sys_vendor"}},
+		{name: "hetzner", sysVendor: "Hetzner", wantCloud: Hetzner,
+			wantReads: []string{"bios_vendor", "sys_vendor"}},
+		{name: "gcp", productName: "Google Compute Engine", wantCloud: GCP,
+			wantReads: []string{"bios_vendor", "sys_vendor", "product_name"}},
+		{name: "gcp-old", productName: "Google", wantProbe: true,
+			wantReads: []string{"bios_vendor", "sys_vendor", "product_name"}},
+		{name: "azure-product", productName: "Virtual Machine", wantProbe: true,
+			wantReads: []string{"bios_vendor", "sys_vendor", "product_name"}},
+		{name: "azure-bios", biosVendor: "Microsoft Corporation", wantProbe: true,
+			wantReads: []string{"bios_vendor", "sys_vendor", "product_name"}},
+		{name: "unknown", biosVendor: "SeaBIOS", sysVendor: "QEMU", productName: "Standard PC",
+			wantReads: []string{"bios_vendor", "sys_vendor", "product_name"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotCloud, gotMetadata := cloudFromSMBIOS(tt.biosVendor, tt.sysVendor, tt.productName)
-			if gotCloud != tt.wantCloud || gotMetadata != tt.wantMetadata {
+			var reads []string
+			gotCloud, gotProbe := cloudFromSMBIOS(func(dmiName string) string {
+				reads = append(reads, dmiName)
+				switch dmiName {
+				case "bios_vendor":
+					return tt.biosVendor
+				case "sys_vendor":
+					return tt.sysVendor
+				case "product_name":
+					return tt.productName
+				}
+				t.Errorf("read of unknown DMI identifier %q", dmiName)
+				return ""
+			})
+			if gotCloud != tt.wantCloud || gotProbe != tt.wantProbe {
 				t.Errorf("cloudFromSMBIOS(%q, %q, %q) = (%q, %v); want (%q, %v)",
 					tt.biosVendor, tt.sysVendor, tt.productName,
-					gotCloud, gotMetadata, tt.wantCloud, tt.wantMetadata)
+					gotCloud, gotProbe, tt.wantCloud, tt.wantProbe)
+			}
+			if !slices.Equal(reads, tt.wantReads) {
+				t.Errorf("read %q; want %q", reads, tt.wantReads)
 			}
 		})
 	}


### PR DESCRIPTION
getCloud only read the SMBIOS/DMI strings under /sys on Linux and returned "" for every other GOOS, so AWS (and GCP/Azure) went undetected on Windows and the BSDs. Fall back to the existing OS-independent metadata-server probe on those platforms; it already distinguishes AWS, GCP, and Azure, and Get caches the result so the cost is paid at most once per process.

Also factor the Linux SMBIOS brand matching out into cloudFromSMBIOS so it can be unit tested and later reused once we can read the same clues cheaply on Windows and the BSDs (left as a TODO — a WMI/kenv pre-filter would avoid the one-time cached metadata probe on non-cloud hosts).

Tests:
- `./tool/go test ./util/cloudenv` (new 11-case table test for cloudFromSMBIOS)
- `GOOS=windows`/`GOOS=freebsd` `./tool/go vet ./util/cloudenv`

Updates #4984