### PR TITLE
wgengine/wgcfg: remove unused Config DNS and MTU fields

### DIFF
--- a/wgengine/wgcfg/config.go
+++ b/wgengine/wgcfg/config.go
@@ -19,8 +19,6 @@ import (
 type Config struct {
 	PrivateKey key.NodePrivate
 	Addresses  []netip.Prefix
-	MTU        uint16
-	DNS        []netip.Addr
 	Peers      []Peer
 
 	// NetworkLogging enables network logging.
@@ -38,10 +36,8 @@ func (c *Config) Equal(o *Config) bool {
 		return c == o
 	}
 	return c.PrivateKey.Equal(o.PrivateKey) &&
-		c.MTU == o.MTU &&
 		c.NetworkLogging == o.NetworkLogging &&
 		slices.Equal(c.Addresses, o.Addresses) &&
-		slices.Equal(c.DNS, o.DNS) &&
 		slices.EqualFunc(c.Peers, o.Peers, Peer.Equal)
 }
 

--- a/wgengine/wgcfg/config_test.go
+++ b/wgengine/wgcfg/config_test.go
@@ -14,7 +14,7 @@ func TestConfigEqual(t *testing.T) {
 	rt := reflect.TypeFor[Config]()
 	for sf := range rt.Fields() {
 		switch sf.Name {
-		case "Name", "NodeID", "PrivateKey", "MTU", "Addresses", "DNS", "Peers",
+		case "Name", "NodeID", "PrivateKey", "Addresses", "Peers",
 			"NetworkLogging":
 			// These are compared in [Config.Equal].
 		default:

--- a/wgengine/wgcfg/wgcfg_clone.go
+++ b/wgengine/wgcfg/wgcfg_clone.go
@@ -21,7 +21,6 @@ func (src *Config) Clone() *Config {
 	dst := new(Config)
 	*dst = *src
 	dst.Addresses = append(src.Addresses[:0:0], src.Addresses...)
-	dst.DNS = append(src.DNS[:0:0], src.DNS...)
 	if src.Peers != nil {
 		dst.Peers = make([]Peer, len(src.Peers))
 		for i := range dst.Peers {
@@ -35,8 +34,6 @@ func (src *Config) Clone() *Config {
 var _ConfigCloneNeedsRegeneration = Config(struct {
 	PrivateKey     key.NodePrivate
 	Addresses      []netip.Prefix
-	MTU            uint16
-	DNS            []netip.Addr
 	Peers          []Peer
 	NetworkLogging struct {
 		NodeID             logid.PrivateID


### PR DESCRIPTION
Nothing uses them. DNS and MTU are handled elsewhere.

This is pulled out of a future change that removes wgcfg.Config.Peers,
to make that PR smaller.

Updates #12542
