### PR TITLE
cmd/tailscale/cli: warn that "serve status --json" is internal state

### DIFF
--- a/cmd/tailscale/cli/serve_legacy.go
+++ b/cmd/tailscale/cli/serve_legacy.go
@@ -625,6 +625,13 @@ func (e *serveEnv) runServeStatus(ctx context.Context, args []string) error {
 		}
 		j = append(j, '\n')
 		e.stdout().Write(j)
+		// The JSON output is Tailscale's internal runtime representation, not a
+		// supported declarative configuration format. Warn on stderr (so it
+		// doesn't corrupt the JSON on stdout) and point users at the
+		// declarative get-config/set-config commands. See tailscale/corp#39789.
+		fmt.Fprint(e.stderr(), "Warning: the output of \"tailscale serve status --json\" reflects internal runtime state and is not a supported configuration format.\n"+
+			"To view or manage your serve configuration declaratively, use \"tailscale serve get-config\" and \"tailscale serve set-config\".\n"+
+			"See https://tailscale.com/kb/1242/tailscale-serve for details.\n")
 		return nil
 	}
 	printFunnelStatus(ctx)

--- a/cmd/tailscale/cli/serve_legacy_test.go
+++ b/cmd/tailscale/cli/serve_legacy_test.go
@@ -6,6 +6,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -965,4 +966,50 @@ func anyErr() func(error) string {
 
 func cmd(s string) []string {
 	return strings.Fields(s)
+}
+
+// TestServeStatusJSONWarning verifies that "serve status --json" prints a
+// warning to stderr explaining that the JSON is internal runtime state and
+// pointing users to the declarative get-config/set-config commands, while
+// keeping stdout as clean, parseable JSON. See tailscale/corp#39789.
+func TestServeStatusJSONWarning(t *testing.T) {
+	lc := &fakeLocalServeClient{
+		config: &ipn.ServeConfig{
+			TCP: map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}},
+		},
+	}
+	var stdout, stderr bytes.Buffer
+	e := &serveEnv{
+		lc:         lc,
+		json:       true,
+		testStdout: &stdout,
+		testStderr: &stderr,
+	}
+	if err := e.runServeStatus(context.Background(), nil); err != nil {
+		t.Fatalf("runServeStatus: %v", err)
+	}
+
+	// stdout must remain valid, parseable JSON (no warning mixed in), so that
+	// existing `--json | jq` pipelines keep working.
+	var sc ipn.ServeConfig
+	if err := json.Unmarshal(stdout.Bytes(), &sc); err != nil {
+		t.Errorf("stdout is not valid JSON: %v\nstdout:\n%s", err, stdout.Bytes())
+	}
+	if strings.Contains(stdout.String(), "Warning") {
+		t.Errorf("warning leaked into stdout JSON:\n%s", stdout.String())
+	}
+
+	// stderr must carry the warning, name both declarative commands, and link
+	// to the serve KB.
+	errOut := stderr.String()
+	for _, want := range []string{
+		"internal",
+		"get-config",
+		"set-config",
+		"tailscale.com/kb/1242/tailscale-serve",
+	} {
+		if !strings.Contains(errOut, want) {
+			t.Errorf("stderr missing %q; got:\n%s", want, errOut)
+		}
+	}
 }


### PR DESCRIPTION
Users have been treating the output of "tailscale serve status --json" as a supported declarative configuration format, when it is really Tailscale's internal runtime representation of the serve config.

Print a warning to stderr (so it does not corrupt the JSON on stdout, which is commonly piped to tools like jq) explaining this and pointing users at the declarative "serve get-config" and "serve set-config" commands instead.

Fixes tailscale/corp#39789

Change-Id: I8894f0d6f709819c401c8a7c7ba09fccbdb35b3b