### PR TITLE
fix: force immediate link-monitor rescan after TUN/router config so DERP receive works at startup

### DIFF
--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -124,6 +124,7 @@ type userspaceEngine struct {
 
 	lastCfgFull        wgcfg.Config
 	lastRouter         *router.Config
+	routerConfigured   bool           // whether the last successfully applied router config was non-empty
 	lastDNSConfig      dns.ConfigView // or invalid if none
 	lastIsSubnetRouter bool           // was the node a primary subnet router in the last run.
 	reconfigureVPN     func() error   // or nil
@@ -1000,6 +1001,13 @@ func (e *userspaceEngine) Reconfig(cfg *wgcfg.Config, routerCfg *router.Config, 
 		if err != nil {
 			return err
 		}
+		routerConfigured := !routerCfg.Equal(&router.Config{})
+		if !e.routerConfigured && routerConfigured {
+			// The TUN interface can gain its addresses after netmon's initial
+			// state snapshot, so rescan it immediately on first bring-up.
+			e.netMon.InjectEvent()
+		}
+		e.routerConfigured = routerConfigured
 	}
 
 	// We've historically re-set DNS even after just a router change. While

--- a/wgengine/userspace_test.go
+++ b/wgengine/userspace_test.go
@@ -125,6 +125,137 @@ func TestUserspaceEngineReconfig(t *testing.T) {
 	}
 }
 
+func TestUserspaceEngineReconfigInjectsNetmonEvent(t *testing.T) {
+	bus := eventbustest.NewBus(t)
+	mon, err := netmon.New(bus, t.Logf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rtr := new(reconfigTestRouter)
+	e, err := NewUserspaceEngine(t.Logf, Config{
+		Router:        rtr,
+		NetMon:        mon,
+		HealthTracker: health.NewTracker(bus),
+		Metrics:       new(usermetric.Registry),
+		EventBus:      bus,
+		RespondToPing: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	changes := make(chan *netmon.ChangeDelta, 4)
+	unregister := mon.RegisterChangeCallback(func(delta *netmon.ChangeDelta) {
+		changes <- delta
+	})
+	t.Cleanup(func() {
+		unregister()
+		e.Close()
+		mon.Close()
+	})
+
+	routerCfg := &router.Config{
+		LocalAddrs: []netip.Prefix{netip.MustParsePrefix("100.64.0.1/32")},
+	}
+	if err := e.Reconfig(&wgcfg.Config{}, routerCfg, &dns.Config{}); err != nil {
+		t.Fatalf("first Reconfig: %v", err)
+	}
+	select {
+	case <-changes:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for link-monitor rescan after first router config")
+	}
+
+	// Let netmon finish its debounce period, while also verifying that the
+	// first Reconfig injected exactly one event.
+	select {
+	case delta := <-changes:
+		t.Fatalf("unexpected additional link-monitor event after first Reconfig: %v", delta)
+	case <-time.After(1100 * time.Millisecond):
+	}
+
+	if err := e.Reconfig(&wgcfg.Config{}, routerCfg, &dns.Config{}); err != ErrNoChanges {
+		t.Fatalf("unchanged Reconfig error = %v, want ErrNoChanges", err)
+	}
+	assertNoNetmonChange(t, changes)
+
+	if err := e.Reconfig(&wgcfg.Config{}, &router.Config{}, &dns.Config{}); err != nil {
+		t.Fatalf("shutdown Reconfig: %v", err)
+	}
+	assertNoNetmonChange(t, changes)
+}
+
+func TestUserspaceEngineReconfigRouterErrorDoesNotInjectNetmonEvent(t *testing.T) {
+	bus := eventbustest.NewBus(t)
+	mon, err := netmon.New(bus, t.Logf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	routerErr := fmt.Errorf("router set failed")
+	rtr := &reconfigTestRouter{setErr: routerErr}
+	e, err := NewUserspaceEngine(t.Logf, Config{
+		Router:        rtr,
+		NetMon:        mon,
+		HealthTracker: health.NewTracker(bus),
+		Metrics:       new(usermetric.Registry),
+		EventBus:      bus,
+		RespondToPing: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	changes := make(chan *netmon.ChangeDelta, 1)
+	unregister := mon.RegisterChangeCallback(func(delta *netmon.ChangeDelta) {
+		changes <- delta
+	})
+	t.Cleanup(func() {
+		unregister()
+		e.Close()
+		mon.Close()
+	})
+
+	routerCfg := &router.Config{
+		LocalAddrs: []netip.Prefix{netip.MustParsePrefix("100.64.0.1/32")},
+	}
+	if err := e.Reconfig(&wgcfg.Config{}, routerCfg, &dns.Config{}); err != routerErr {
+		t.Fatalf("Reconfig error = %v, want %v", err, routerErr)
+	}
+	assertNoNetmonChange(t, changes)
+
+	rtr.setErr = nil
+	routerCfg.LocalAddrs = []netip.Prefix{netip.MustParsePrefix("100.64.0.2/32")}
+	if err := e.Reconfig(&wgcfg.Config{}, routerCfg, &dns.Config{}); err != nil {
+		t.Fatalf("successful Reconfig after router error: %v", err)
+	}
+	select {
+	case <-changes:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for link-monitor rescan after router recovered")
+	}
+}
+
+func assertNoNetmonChange(t *testing.T, changes <-chan *netmon.ChangeDelta) {
+	t.Helper()
+	select {
+	case delta := <-changes:
+		t.Fatalf("unexpected link-monitor event: %v", delta)
+	case <-time.After(250 * time.Millisecond):
+	}
+}
+
+type reconfigTestRouter struct {
+	setErr error
+}
+
+func (*reconfigTestRouter) Up() error    { return nil }
+func (*reconfigTestRouter) Close() error { return nil }
+
+func (r *reconfigTestRouter) Set(cfg *router.Config) error {
+	if cfg == nil {
+		return nil
+	}
+	return r.setErr
+}
+
 func TestUserspaceEngineTSMPLearned(t *testing.T) {
 	bus := eventbustest.NewBus(t)
 


### PR DESCRIPTION
## Summary
In `wgengine/userspace.go`, after the router successfully applies configuration in `Reconfig` (the point where `tailscale0` gains its addresses/routes), call `e.netMon.InjectEvent()` to force an immediate link-monitor rescan rather than waiting for the poll/debounce timer. `InjectEvent` already exists on `netmon.Monitor` (`net/netmon/netmon.go`) and triggers a fresh interface-state poll plus change callbacks, so the existing "major link change -> Rebind + ReSTUN" path in the engine fires within milliseconds of the TUN interface becoming usable, closing the announce-before-rebind window. Guard the injection so it fires only when the router config transitions from unset/empty to configured (first bring-up), not on every no-op or steady-state Reconfig, to avoid spurious rebinds.

## Why this matters
After a Kubernetes pod restart, a tailscaled sidecar intermittently cannot receive DERP traffic for 30-60s even though it can send (peer shows `tx N rx 0`). The reporter captured logs proving the mechanism: tailscaled announces its home DERP to control and reports healthy at ~t+4s, but the link monitor does not notice the newly created/configured `tailscale0` TUN interface until ~t+42s, at which point a "major LinkChange" rebind fires and receive traffic immediately flows. During the gap, DERP accepts inbound packets for the node (no `peer_not_here`) but they are black-holed. The reporter's proposed fix option 2 is to detect the node's own TUN interface immediately upon creation instead of waiting for the link monitor's periodic poll.

See https://github.com/tailscale/tailscale/issues/19422.

## Testing
- Happy path: new engine + first non-empty `Reconfig` triggers exactly one injected link-monitor event; assert via a registered `netmon` change callback in `wgengine/userspace_test.go` that a rescan/change delivery occurs promptly after Reconfig. - Edge case: repeated `Reconfig` with an unchanged router config does not inject additional events (no rebind storm in steady state). - Edge case: `Reconfig` to an empty/shutdown config does not inject an event. - Error path: router `Set` returning an error skips the injection (engine state unchanged, no event fired).

Fixes #19422
