### PR TITLE
ssh/tailssh: dissallow purely numeric usernames for SSH

### DIFF
--- a/ssh/tailssh/tailssh.go
+++ b/ssh/tailssh/tailssh.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -62,6 +63,8 @@ var (
 	// hookSSHLoginSuccess is called after successful SSH authentication.
 	// It is set by platform-specific code (e.g., auditd_linux.go).
 	hookSSHLoginSuccess feature.Hook[func(logf logger.Logf, c *conn)]
+
+	uidRegex = regexp.MustCompile("^[0-9]+$")
 )
 
 const (
@@ -338,6 +341,10 @@ func (c *conn) clientAuth(cm ssh.ConnMetadata) (perms *ssh.Permissions, retErr e
 
 	if c.insecureSkipTailscaleAuth {
 		return &ssh.Permissions{}, nil
+	}
+
+	if uidRegex.MatchString(cm.User()) {
+		return nil, c.errBanner(fmt.Sprintf("rejecting username %q. Usernames that consist of only digits are not allowed as they are ambiguous with numerical UIDs", cm.User()), nil)
 	}
 
 	if err := c.setInfo(cm); err != nil {

--- a/ssh/tailssh/tailssh_test.go
+++ b/ssh/tailssh/tailssh_test.go
@@ -832,6 +832,17 @@ func TestSSHAuthFlow(t *testing.T) {
 			wantBanners: []string{`tailscale: tailnet policy does not permit you to SSH as user "alice"` + "\n"},
 		},
 		{
+			name:    "digit-only-username",
+			sshUser: "321",
+			state: &localState{
+				sshEnabled:   true,
+				varRoot:      varRoot,
+				matchingRule: bobRule,
+			},
+			authErr:     true,
+			wantBanners: []string{`tailscale: rejecting username "321". Usernames that consist of only digits are not allowed as they are ambiguous with numerical UIDs` + "\n"},
+		},
+		{
 			name: "accept",
 			state: &localState{
 				sshEnabled:   true,


### PR DESCRIPTION
Dissallow purely numeric usernames for SSH as these are ambiguous with numeric UID values.

Updates https://github.com/tailscale/corp/issues/43245


(cherry picked from commit f368a96e01711c65a7fe12c7e932ef7cd40a9bca)