### PR TITLE
wgengine/magicsock: distribute disco pubkey via DERP

### DIFF
--- a/wgengine/magicsock/endpoint.go
+++ b/wgengine/magicsock/endpoint.go
@@ -377,11 +377,19 @@ func (de *endpoint) setProbeUDPLifetimeConfigLocked(desired *ProbeUDPLifetimeCon
 	p.resetCycleEndpointLocked()
 }
 
+type discoKeySource int
+
+const (
+	derpDiscoKeySource discoKeySource = iota
+	controlDiscoKeySource
+)
+
 // endpointDisco is the current disco key and short string for an endpoint. This
 // structure is immutable.
 type endpointDisco struct {
-	key   key.DiscoPublic // for discovery messages.
-	short string          // ShortString of discoKey.
+	key    key.DiscoPublic // for discovery messages.
+	short  string          // ShortString of discoKey.
+	source discoKeySource
 }
 
 type sentPing struct {
@@ -1484,14 +1492,23 @@ func (de *endpoint) setLastPing(ipp netip.AddrPort, now mono.Time) {
 
 // updateDiscoKey replaces the disco key for de. If the key is a zero value key,
 // set the key to nil.
-func (de *endpoint) updateDiscoKey(key key.DiscoPublic) {
+func (de *endpoint) updateDiscoKey(key key.DiscoPublic, source discoKeySource) {
 	if key.IsZero() {
 		de.disco.Store(nil)
 	} else {
-		de.disco.Store(&endpointDisco{
-			key:   key,
-			short: key.ShortString(),
-		})
+		for {
+			prev := de.disco.Load()
+			if prev != nil && prev.source == derpDiscoKeySource && source == controlDiscoKeySource {
+				return
+			}
+			if de.disco.CompareAndSwap(prev, &endpointDisco{
+				key:    key,
+				short:  key.ShortString(),
+				source: source,
+			}) {
+				return
+			}
+		}
 	}
 }
 
@@ -1521,7 +1538,7 @@ func (de *endpoint) updateFromNode(n tailcfg.NodeView, heartbeatDisabled bool, p
 	if discoKey != n.DiscoKey() {
 		de.c.logf("[v1] magicsock: disco: node %s changed from %s to %s", de.publicKey.ShortString(), discoKey, n.DiscoKey())
 		key := n.DiscoKey()
-		de.updateDiscoKey(key)
+		de.updateDiscoKey(key, controlDiscoKeySource)
 		de.debugUpdates.Add(EndpointChange{
 			When: time.Now(),
 			What: "updateFromNode-resetLocked",

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -2223,11 +2223,20 @@ func (c *Conn) handleDiscoMessage(msg []byte, src epAddr, shouldBeRelayHandshake
 	case c.peerMap.knownPeerDiscoKey(sender):
 		di = c.discoInfoForKnownPeerLocked(sender)
 	default:
-		metricRecvDiscoBadPeer.Add(1)
-		if debugDisco() {
-			c.logf("magicsock: disco: ignoring disco-looking frame, don't know of key %v", sender.ShortString())
+		if !derpNodeSrc.IsZero() {
+			// The node key is unambiguous since the disco message arrived via
+			// DERP. Trust that it's the node's new disco key.
+			di = c.handleDiscoKeyUpdateLocked(derpNodeSrc, sender)
+			if di == nil {
+				return
+			}
+		} else {
+			metricRecvDiscoBadPeer.Add(1)
+			if debugDisco() {
+				c.logf("magicsock: disco: ignoring disco-looking frame, don't know of key %v", sender.ShortString())
+			}
+			return
 		}
-		return
 	}
 
 	isDERP := src.ap.Addr() == tailcfg.DerpMagicIPAddr
@@ -3275,7 +3284,7 @@ func (c *Conn) upsertPeerLocked(n tailcfg.NodeView, flags debugFlags, entriesPer
 		ep.nodeAddr = n.Addresses().At(0).Addr()
 	}
 	ep.initFakeUDPAddr()
-	ep.updateDiscoKey(n.DiscoKey())
+	ep.updateDiscoKey(n.DiscoKey(), controlDiscoKeySource)
 
 	if debugPeerMap() {
 		c.logEndpointCreated(n)
@@ -4490,6 +4499,20 @@ func (c *Conn) PeerRelays() set.Set[netip.Addr] {
 	return servers
 }
 
+func (c *Conn) handleDiscoKeyUpdateLocked(nk key.NodePublic, newDisco key.DiscoPublic) *discoInfo {
+	ep, ok := c.peerMap.endpointForNodeKey(nk)
+	if !ok {
+		return nil
+	}
+	ep.mu.Lock()
+	ep.lastUDPRelayPathDiscovery = 0
+	ep.lastFullPing = 0
+	ep.mu.Unlock()
+	ep.updateDiscoKey(newDisco, derpDiscoKeySource)
+	c.peerMap.upsertEndpoint(ep, key.DiscoPublic{})
+	return c.discoInfoForKnownPeerLocked(newDisco)
+}
+
 // HandleDiscoKeyAdvertisement processes a TSMP disco key update.
 // The update may be solicited (in response to a request) or unsolicited.
 // node is the Tailscale tailcfg.NodeView of the peer that sent the update.
@@ -4519,7 +4542,7 @@ func (c *Conn) HandleDiscoKeyAdvertisement(node tailcfg.NodeView, update packet.
 		return
 	}
 	c.discoInfoForKnownPeerLocked(discoKey)
-	ep.updateDiscoKey(discoKey)
+	ep.updateDiscoKey(discoKey, controlDiscoKeySource)
 	c.peerMap.upsertEndpoint(ep, oldDiscoKey)
 	c.logf("magicsock: updated disco key for peer %v to %v", nodeKey.ShortString(), discoKey.ShortString())
 	metricTSMPDiscoKeyAdvertisementApplied.Add(1)
@@ -4555,6 +4578,7 @@ type NewDiscoKeyAvailable struct {
 //
 // We do not need the Conn to be locked, but the endpoint should be.
 func (c *Conn) maybeSendTSMPDiscoAdvert(de *endpoint) {
+	return
 	if !buildfeatures.HasCacheNetMap || !envknob.BoolDefaultTrue("TS_USE_CACHED_NETMAP") {
 		return
 	}


### PR DESCRIPTION
A proof of concept with known bugs, just a quick demonstration.

WireGuard-authenticated TSMP disco key advertisement has some nice security properties, but it also adds quite a bit of complexity.

In addition to complexity, TSMP disco key advert over WireGuard does not work for peer relays in many cases, where participating clients never speak WireGuard with the relay, just disco.

This commit does something much simpler: it handles disco messages received via DERP from unknown disco public keys as disco key updates. The WireGuard node key is unambiguous by nature of DERP framing/reception, and the disco public key is in the disco message header.

This PoC assumes we trust DERP for disco public key distribution. Tailscale clients must cryptographically prove their WireGuard node key identity at DERP connect time, but that is only proven to DERP, not end-to-end. In many ways this is similar to control, and control is trusted for disco public key distribution already.