### PR TITLE
ipn,ipnlocal: add service prefs types and store

### DIFF
--- a/ipn/ipnlocal/serviceprefs/doc.go
+++ b/ipn/ipnlocal/serviceprefs/doc.go
@@ -1,0 +1,13 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Package serviceprefs stores service preferences for each login profile from a
+// user's last launched service: the last selected client app, the last entered
+// username and database name, and the last used timestamp, keyed by
+// "<service>:<port>".
+//
+// It defines the Store interface with two implementations: a disk backed file
+// store and an in-memory store. The file store uses the in-memory store as a
+// cache. Both use time based retention. Either can be swapped or migrated to a
+// different implementation in the future.
+package serviceprefs

--- a/ipn/ipnlocal/serviceprefs/store.go
+++ b/ipn/ipnlocal/serviceprefs/store.go
@@ -1,0 +1,346 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package serviceprefs
+
+import (
+	"context"
+	"encoding/hex"
+	jsonv1 "encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"tailscale.com/atomicfile"
+	"tailscale.com/ipn"
+	"tailscale.com/tstime"
+	"tailscale.com/types/logger"
+)
+
+// UpdateFunc merges changes into a [ipn.ServicePref]. It receives the current pref (the zero value
+// if the key doesn't exist yet) and returns the pref to store. It should set [ipn.ServicePref.LastUsed],
+// since a pref older than the retention window is cleaned up on save.
+type UpdateFunc func(ipn.ServicePref) ipn.ServicePref
+
+// Store is an interface for storing and retrieving service prefs for different profiles.
+type Store interface {
+	// LoadForProfile retrieves the service prefs for the given profile ID. It returns an empty
+	// map if no prefs are found.
+	LoadForProfile(ctx context.Context, pid ipn.ProfileID) (ipn.ServicePrefs, error)
+
+	// UpdateForProfile atomically reads the pref stored under key, passes it to update, and saves
+	// the result back under the same key. Holding a single lock across the read, update, and save
+	// lets concurrent callers merge different fields of the same pref without losing each other's
+	// writes. It returns the profile's full prefs after the update.
+	UpdateForProfile(ctx context.Context, pid ipn.ProfileID, key string, update UpdateFunc) (ipn.ServicePrefs, error)
+
+	// DeleteForProfile deletes all service prefs for the given profile ID.
+	DeleteForProfile(ctx context.Context, pid ipn.ProfileID) error
+}
+
+var (
+	_ Store = (*FileStore)(nil)
+	_ Store = (*InMemoryStore)(nil)
+)
+
+// FileStore is an implementation of [Store] that persists data to disk in JSON format.
+type FileStore struct {
+	// dir is the directory where the files are stored. This is used to create the directory
+	// if it does not exist.
+	dir string
+
+	// memStore is an in-memory store that holds the service prefs for different profiles. It is used
+	// to cache the data and reduce disk I/O. The in-memory store is initialized with a retention
+	// duration, which is used to automatically clean up service prefs that have not been used within
+	// the specified duration.
+	memStore *InMemoryStore
+
+	// logf logs load-time issues, such as files skipped because they can't be decoded.
+	logf logger.Logf
+
+	// writeMu is a mutex that protects the write operation to ensure that only one write operation
+	// can occur at a time.
+	writeMu sync.Mutex
+}
+
+// NewFileStore creates a new [FileStore] instance. It initializes the in-memory store and loads
+// existing service prefs from disk. A nil clock defaults to [tstime.StdClock]; a nil logf discards logs.
+func NewFileStore(ctx context.Context, dir string, retention time.Duration, clock tstime.Clock, logf logger.Logf) (*FileStore, error) {
+	if logf == nil {
+		logf = logger.Discard
+	}
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, fmt.Errorf("create directory %q: %w", dir, err)
+	}
+	f := &FileStore{
+		dir:      dir,
+		memStore: NewInMemoryStore(retention, clock),
+		logf:     logf,
+	}
+	if err := f.loadAllProfiles(ctx); err != nil {
+		return nil, fmt.Errorf("load service prefs from files: %w", err)
+	}
+	return f, nil
+}
+
+// LoadForProfile retrieves the service prefs for the given profile ID from the in-memory store.
+func (f *FileStore) LoadForProfile(ctx context.Context, pid ipn.ProfileID) (ipn.ServicePrefs, error) {
+	return f.memStore.LoadForProfile(ctx, pid)
+}
+
+// UpdateForProfile atomically merges an update into the pref stored under key for the given profile
+// ID in the in-memory store and then flushes the profile's data to disk.
+//
+// We update memory first, then disk. If the disk write fails the value stays in memory for this
+// run but won't survive a restart. [FileStore.DeleteForProfile] does the reverse for the same reason.
+func (f *FileStore) UpdateForProfile(ctx context.Context, pid ipn.ProfileID, key string, update UpdateFunc) (ipn.ServicePrefs, error) {
+	f.writeMu.Lock()
+	defer f.writeMu.Unlock()
+
+	prefs, err := f.memStore.UpdateForProfile(ctx, pid, key, update)
+	if err != nil {
+		return nil, fmt.Errorf("update service prefs in memory: %w", err)
+	}
+
+	if err := f.flushToDiskLocked(ctx, pid); err != nil {
+		return nil, err
+	}
+	return prefs, nil
+}
+
+// DeleteForProfile deletes all service prefs for the given profile ID from the in-memory store
+// and removes the corresponding file from disk.
+func (f *FileStore) DeleteForProfile(ctx context.Context, pid ipn.ProfileID) error {
+	f.writeMu.Lock()
+	defer f.writeMu.Unlock()
+
+	// Remove the file from disk first, then delete from in-memory store. If the file removal
+	// fails, we don't end up with an inconsistent state where the file is gone but the in-memory
+	// store still has data.
+	filePath := f.filePathForProfile(pid)
+	if err := os.Remove(filePath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove service prefs file %q: %w", filePath, err)
+	}
+	if err := f.memStore.DeleteForProfile(ctx, pid); err != nil {
+		return fmt.Errorf("delete service prefs in memory: %w", err)
+	}
+	return nil
+}
+
+// loadAllProfiles loads all service prefs from disk into the in-memory store. It reads all json
+// files in the directory, decodes the profile ID from the file name, and unmarshals the json data
+// into service prefs. It uses a write lock to ensure that no other write operations occur while
+// loading the data.
+func (f *FileStore) loadAllProfiles(ctx context.Context) error {
+	files, err := os.ReadDir(f.dir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read directory %q: %w", f.dir, err)
+	}
+
+	f.writeMu.Lock()
+	defer f.writeMu.Unlock()
+
+	for _, file := range files {
+		fileName := file.Name()
+		if file.IsDir() || filepath.Ext(fileName) != ".json" {
+			continue
+		}
+		raw, err := hex.DecodeString(strings.TrimSuffix(fileName, ".json"))
+		if err != nil {
+			f.logf("serviceprefs: skipping file with undecodable name %q: %v", fileName, err)
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(f.dir, fileName))
+		if err != nil {
+			return fmt.Errorf("read file %q: %w", fileName, err)
+		}
+		var servicePrefs ipn.ServicePrefs
+		if err := jsonv1.Unmarshal(data, &servicePrefs); err != nil {
+			f.logf("serviceprefs: skipping unparseable file %q: %v", fileName, err)
+			continue
+		}
+		pid := ipn.ProfileID(raw)
+		f.memStore.populateForProfile(pid, servicePrefs)
+		if err := f.removeEmptyFileIfNoPrefsLocked(ctx, pid); err != nil {
+			return fmt.Errorf("remove empty service prefs file for profile %q: %w", pid, err)
+		}
+	}
+	return nil
+}
+
+// removeEmptyFileIfNoPrefsLocked removes the service prefs file for the given profile ID if there are no
+// service prefs in the in-memory store. It assumes that the caller has already acquired a write lock
+// on the [FileStore]. It returns an error if the file removal operation fails.
+func (f *FileStore) removeEmptyFileIfNoPrefsLocked(ctx context.Context, pid ipn.ProfileID) error {
+	servicePrefs, err := f.memStore.LoadForProfile(ctx, pid)
+	if err != nil {
+		return fmt.Errorf("load service prefs for profile %q: %w", pid, err)
+	}
+	if len(servicePrefs) == 0 {
+		filePath := f.filePathForProfile(pid)
+		if err := os.Remove(filePath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove empty service prefs file %q: %w", filePath, err)
+		}
+	}
+	return nil
+}
+
+// flushToDiskLocked flushes the service prefs for the given profile ID from the in-memory store to
+// disk. It marshals the service prefs to json and writes them to a file. If the service prefs are
+// empty, it removes the corresponding file from disk. It assumes that the caller has already acquired
+// a write lock on the [FileStore]. It returns an error if the write or remove operation fails.
+func (f *FileStore) flushToDiskLocked(ctx context.Context, pid ipn.ProfileID) error {
+	servicePrefs, err := f.memStore.LoadForProfile(ctx, pid)
+	if err != nil {
+		return fmt.Errorf("load service prefs for profile %q: %w", pid, err)
+	}
+
+	filePath := f.filePathForProfile(pid)
+	if len(servicePrefs) == 0 {
+		if err := os.Remove(filePath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove empty service prefs file %q: %w", filePath, err)
+		}
+		return nil
+	}
+
+	toBeWritten, err := jsonv1.Marshal(servicePrefs)
+	if err != nil {
+		return fmt.Errorf("marshal service prefs for profile %q: %w", pid, err)
+	}
+	if err := atomicfile.WriteFile(filePath, toBeWritten, 0600); err != nil {
+		return fmt.Errorf("write service prefs to file %q: %w", filePath, err)
+	}
+
+	return nil
+}
+
+// filePathForProfile returns the file path for the given profile ID. It encodes the profile ID
+// as a hex string and appends the ".json" extension to create the file name. The file is stored
+// in the directory specified by the [FileStore]'s dir field.
+func (f *FileStore) filePathForProfile(pid ipn.ProfileID) string {
+	return filepath.Join(f.dir, hex.EncodeToString([]byte(pid))+".json")
+}
+
+// InMemoryStore is an implementation of [Store] that keeps data in memory. It is not persistent and is
+// intended for use in the file store or for testing purposes. It supports a retention duration,
+// which is used to automatically clean up service prefs that have not been used within the specified
+// duration. If the retention duration is set to zero or a negative value, no cleanup will occur.
+type InMemoryStore struct {
+	// retention is the duration after which service prefs that have not been used will be
+	// automatically cleaned up. If the retention duration is set to zero or a negative value,
+	// no cleanup will occur.
+	retention time.Duration
+
+	// clock provides the current time, used to determine the cleanup cutoff. It's injectable so
+	// tests can control time.
+	clock tstime.Clock
+
+	// mu is a read-write mutex that protects the data map to ensure concurrent safety.
+	mu sync.RWMutex
+
+	// data is a map that stores the service prefs for each profile ID. The keys are profile IDs
+	// and the values are the corresponding service prefs.
+	data map[ipn.ProfileID]ipn.ServicePrefs
+}
+
+// NewInMemoryStore creates a new [InMemoryStore] instance with the specified retention duration. The
+// retention duration is used to automatically clean up service prefs that have not been used within
+// the specified duration. If the retention duration is set to zero or a negative value, no cleanup
+// will occur. A nil clock defaults to [tstime.StdClock].
+func NewInMemoryStore(retention time.Duration, clock tstime.Clock) *InMemoryStore {
+	if clock == nil {
+		clock = tstime.StdClock{}
+	}
+	return &InMemoryStore{
+		retention: retention,
+		clock:     clock,
+		data:      make(map[ipn.ProfileID]ipn.ServicePrefs),
+	}
+}
+
+// LoadForProfile retrieves the service prefs for the given profile ID from the in-memory store. It
+// returns an empty map if no prefs are found. It uses a read lock to ensure concurrent safety and returns
+// a clone of the service prefs to avoid callers mutating the internal map.
+func (s *InMemoryStore) LoadForProfile(_ context.Context, pid ipn.ProfileID) (ipn.ServicePrefs, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	servicePrefs, ok := s.data[pid]
+	if !ok {
+		return ipn.ServicePrefs{}, nil
+	}
+
+	// Use a clone to avoid callers mutating our map.
+	return servicePrefs.Clone(), nil
+}
+
+// UpdateForProfile atomically reads the pref stored under key, passes it to update, and saves the
+// result back under the same key. It uses a write lock to ensure concurrent safety. If the profile ID
+// does not exist in the store, it creates a new entry for it. After saving, it calls cleanupLocked
+// to remove any prefs that have not been used within the retention duration.
+//
+// LastUsed is normalized to UTC so the in-memory value matches what we read back from disk.
+func (s *InMemoryStore) UpdateForProfile(_ context.Context, pid ipn.ProfileID, key string, update UpdateFunc) (ipn.ServicePrefs, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	servicePrefs, ok := s.data[pid]
+	if !ok {
+		servicePrefs = ipn.ServicePrefs{}
+	}
+
+	prefs := update(servicePrefs[key])
+	prefs.LastUsed = prefs.LastUsed.UTC()
+
+	servicePrefs[key] = prefs
+	s.data[pid] = servicePrefs
+
+	s.cleanupLocked(pid, s.clock.Now())
+	return servicePrefs.Clone(), nil
+}
+
+// DeleteForProfile deletes all service prefs for the given profile ID from the in-memory store. It
+// uses a write lock to ensure concurrent safety. If the profile ID does not exist in the store, it does
+// nothing and returns nil.
+func (s *InMemoryStore) DeleteForProfile(_ context.Context, pid ipn.ProfileID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.data, pid)
+	return nil
+}
+
+// cleanupLocked removes any service prefs for the given profile ID that have not been used within the
+// retention duration. It uses the provided time to determine the cutoff for cleanup. If the retention
+// duration is set to zero or a negative value, no cleanup will occur. It assumes that the caller has
+// already acquired a write lock on the store.
+func (s *InMemoryStore) cleanupLocked(pid ipn.ProfileID, now time.Time) {
+	if s.retention <= 0 {
+		return
+	}
+	servicePrefs := s.data[pid]
+	cutoff := now.Add(-s.retention)
+	for key, pref := range servicePrefs {
+		if pref.LastUsed.Before(cutoff) {
+			delete(servicePrefs, key)
+		}
+	}
+	if len(servicePrefs) == 0 {
+		delete(s.data, pid)
+	}
+}
+
+// populateForProfile populates the in-memory store with the given service prefs for the specified
+// profile ID. It uses a write lock to ensure concurrent safety and calls cleanupLocked to remove any prefs
+// that have not been used within the retention duration.
+func (s *InMemoryStore) populateForProfile(pid ipn.ProfileID, servicePrefs ipn.ServicePrefs) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[pid] = servicePrefs
+	s.cleanupLocked(pid, s.clock.Now())
+}

--- a/ipn/ipnlocal/serviceprefs/store_test.go
+++ b/ipn/ipnlocal/serviceprefs/store_test.go
@@ -1,0 +1,420 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package serviceprefs
+
+import (
+	"context"
+	"encoding/hex"
+	jsonv1 "encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"tailscale.com/ipn"
+	"tailscale.com/tstest"
+)
+
+var (
+	timeIn2026 = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	timeIn1970 = time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
+)
+
+var cmpOpts = []cmp.Option{cmpopts.EquateApproxTime(0), cmpopts.EquateEmpty()}
+
+func TestInMemoryStoreCleanup(t *testing.T) {
+	pid := ipn.ProfileID("pid")
+	type input struct {
+		key  string
+		pref ipn.ServicePref
+	}
+	tests := []struct {
+		name      string
+		retention time.Duration
+		inputs    []input
+		want      ipn.ServicePrefs
+	}{
+		{
+			name:      "expired_pref_cleaned_up_immediately",
+			retention: 24 * time.Hour,
+			inputs:    []input{{"old", makePref("this-client", timeIn2026.Add(-48*time.Hour))}},
+			want:      ipn.ServicePrefs{},
+		},
+		{
+			name:      "retention_disabled_keeps_ancient_entry",
+			retention: 0,
+			inputs:    []input{{"old", makePref("this-client", timeIn1970)}},
+			want:      ipn.ServicePrefs{"old": makePref("this-client", timeIn1970)},
+		},
+		{
+			name:      "multiple_fresh_entries_kept",
+			retention: 24 * time.Hour,
+			inputs: []input{
+				{"this", makePref("this-client", timeIn2026)},
+				{"that", makePref("that-client", timeIn2026)},
+			},
+			want: ipn.ServicePrefs{
+				"this": makePref("this-client", timeIn2026),
+				"that": makePref("that-client", timeIn2026),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			store := NewInMemoryStore(tt.retention, tstest.NewClock(tstest.ClockOpts{Start: timeIn2026}))
+			for _, in := range tt.inputs {
+				if err := savePref(ctx, store, pid, in.key, in.pref); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got, err := store.LoadForProfile(ctx, pid)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tt.want, got, cmpOpts...); diff != "" {
+				t.Errorf("(-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestInMemoryStoreCleanupOnLaterSave(t *testing.T) {
+	ctx := t.Context()
+	pid := ipn.ProfileID("pid")
+
+	clock := tstest.NewClock(tstest.ClockOpts{Start: timeIn2026})
+	store := NewInMemoryStore(24*time.Hour, clock)
+	if err := savePref(ctx, store, pid, "old", makePref("this-client", timeIn2026)); err != nil {
+		t.Fatal(err)
+	}
+
+	twoDaysLater := timeIn2026.Add(48 * time.Hour)
+	clock.AdvanceTo(twoDaysLater)
+	if err := savePref(ctx, store, pid, "new", makePref("that-client", twoDaysLater)); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.LoadForProfile(ctx, pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := ipn.ServicePrefs{"new": makePref("that-client", twoDaysLater)}
+	if diff := cmp.Diff(want, got, cmpOpts...); diff != "" {
+		t.Errorf("(-want +got):\n%s", diff)
+	}
+}
+
+func TestInMemoryStoreSaveLoadDelete(t *testing.T) {
+	ctx := t.Context()
+	store := NewInMemoryStore(0, nil)
+	pid1 := ipn.ProfileID("pid1")
+	pid2 := ipn.ProfileID("pid2")
+
+	got, err := store.LoadForProfile(ctx, pid1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || len(got) != 0 {
+		t.Errorf("unknown profile: want empty non-nil map, got %#v", got)
+	}
+
+	if err := savePref(ctx, store, pid1, "ssh:22", makePref("terminal", timeIn2026)); err != nil {
+		t.Fatal(err)
+	}
+	if err := savePref(ctx, store, pid2, "db:5432", makePref("psql", timeIn2026)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.DeleteForProfile(ctx, pid1); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := store.LoadForProfile(ctx, pid1); len(got) != 0 {
+		t.Errorf("pid1 not deleted: %v", got)
+	}
+	if got, _ := store.LoadForProfile(ctx, pid2); len(got) != 1 {
+		t.Errorf("pid2 unexpectedly affected: %v", got)
+	}
+}
+
+func TestInMemoryStoreLoadReturnsClone(t *testing.T) {
+	ctx := t.Context()
+	store := NewInMemoryStore(0, nil)
+	pid := ipn.ProfileID("pid")
+	if err := savePref(ctx, store, pid, "k", makePref("a", timeIn2026)); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := store.LoadForProfile(ctx, pid)
+	got["k"] = makePref("MUTATED", timeIn2026)
+	got["injected"] = makePref("x", timeIn2026)
+
+	again, _ := store.LoadForProfile(ctx, pid)
+	want := ipn.ServicePrefs{"k": makePref("a", timeIn2026)}
+	if diff := cmp.Diff(want, again, cmpOpts...); diff != "" {
+		t.Errorf("store mutated through returned map (-want +got):\n%s", diff)
+	}
+}
+
+func TestFileStorePersistsAcrossReopen(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+	pid := ipn.ProfileID("pid")
+
+	store, err := NewFileStore(ctx, dir, 0, nil, t.Logf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := ipn.ServicePrefs{
+		"ssh:22":  makePref("terminal", timeIn2026),
+		"db:5432": {Client: "psql", Username: "rollie", DatabaseName: "prod", LastUsed: timeIn2026},
+	}
+	for k, v := range want {
+		if err := savePref(ctx, store, pid, k, v); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	store2, err := NewFileStore(ctx, dir, 0, nil, t.Logf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := store2.LoadForProfile(ctx, pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(want, got, cmpOpts...); diff != "" {
+		t.Errorf("round-trip mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestFileStorePerProfileIsolation(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+	store, err := NewFileStore(ctx, dir, 0, nil, t.Logf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pidA := ipn.ProfileID("pidA")
+	pidB := ipn.ProfileID("pidB")
+	if err := savePref(ctx, store, pidA, "ssh:22", makePref("a", timeIn2026)); err != nil {
+		t.Fatal(err)
+	}
+	if err := savePref(ctx, store, pidB, "ssh:22", makePref("b", timeIn2026)); err != nil {
+		t.Fatal(err)
+	}
+
+	if !profileFileExists(t, dir, pidA) || !profileFileExists(t, dir, pidB) {
+		t.Fatal("expected a separate file per profile")
+	}
+
+	if err := store.DeleteForProfile(ctx, pidA); err != nil {
+		t.Fatal(err)
+	}
+	if profileFileExists(t, dir, pidA) {
+		t.Error("profile A file was not removed on delete")
+	}
+	if got, _ := store.LoadForProfile(ctx, pidB); len(got) != 1 {
+		t.Errorf("profile B affected by deleting A: %v", got)
+	}
+}
+
+func TestFileStoreExpiredSaveRemovesFile(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+	store, err := NewFileStore(ctx, dir, 24*time.Hour, nil, t.Logf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pid := ipn.ProfileID("pid")
+
+	if err := savePref(ctx, store, pid, "old", makePref("a", timeIn1970)); err != nil {
+		t.Fatal(err)
+	}
+	if profileFileExists(t, dir, pid) {
+		t.Error("expected no file for an emptied profile")
+	}
+	if got, _ := store.LoadForProfile(ctx, pid); len(got) != 0 {
+		t.Errorf("want empty, got %v", got)
+	}
+}
+
+func TestFileStoreCleanupOnLoad(t *testing.T) {
+	pid := ipn.ProfileID("pid")
+	fresh := makePref("fresh", time.Now().UTC().Add(-time.Minute).Truncate(time.Second))
+	tests := []struct {
+		name     string
+		seed     ipn.ServicePrefs
+		want     ipn.ServicePrefs
+		wantFile bool
+	}{
+		{
+			name:     "all_expired_removes_orphan_file",
+			seed:     ipn.ServicePrefs{"ssh:22": makePref("terminal", timeIn1970)},
+			want:     ipn.ServicePrefs{},
+			wantFile: false,
+		},
+		{
+			name:     "fresh_entry_kept_and_file_retained",
+			seed:     ipn.ServicePrefs{"old": makePref("old", timeIn1970), "new": fresh},
+			want:     ipn.ServicePrefs{"new": fresh},
+			wantFile: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			dir := t.TempDir()
+			seedProfileFile(t, dir, pid, tt.seed)
+
+			store, err := NewFileStore(ctx, dir, 24*time.Hour, nil, t.Logf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := store.LoadForProfile(ctx, pid)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tt.want, got, cmpOpts...); diff != "" {
+				t.Errorf("(-want +got):\n%s", diff)
+			}
+			if gotFile := profileFileExists(t, dir, pid); gotFile != tt.wantFile {
+				t.Errorf("file exists = %v, want %v", gotFile, tt.wantFile)
+			}
+		})
+	}
+}
+
+func TestFileStoreConcurrentSaveDelete(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+	store, err := NewFileStore(ctx, dir, 0, nil, t.Logf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pid := ipn.ProfileID("pid")
+
+	var wg sync.WaitGroup
+	for i := range 64 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			switch i % 4 {
+			case 0:
+				_ = store.DeleteForProfile(ctx, pid)
+			case 1:
+				// Concurrent reader: LoadForProfile bypasses writeMu, so this
+				// stresses the read path against writers under -race.
+				_, _ = store.LoadForProfile(ctx, pid)
+			default:
+				_ = savePref(ctx, store, pid, fmt.Sprintf("svc:%d", i), makePref("c", timeIn2026))
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	mem, err := store.LoadForProfile(ctx, pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	disk := readDiskForProfile(t, dir, pid)
+	if diff := cmp.Diff(mem, disk, cmpOpts...); diff != "" {
+		t.Errorf("disk != memory after concurrent ops (-mem +disk):\n%s", diff)
+	}
+}
+
+func TestUpdateForProfileMergesConcurrently(t *testing.T) {
+	// Each goroutine updates a different field of the same key. Because UpdateForProfile reads,
+	// updates, and saves under one lock, no update should clobber another's field.
+	ctx := t.Context()
+	store := NewInMemoryStore(0, nil)
+	pid := ipn.ProfileID("pid")
+
+	setters := []UpdateFunc{
+		func(p ipn.ServicePref) ipn.ServicePref { p.Client = "term"; return p },
+		func(p ipn.ServicePref) ipn.ServicePref { p.Username = "rollie"; return p },
+		func(p ipn.ServicePref) ipn.ServicePref { p.DatabaseName = "prod"; return p },
+	}
+	var wg sync.WaitGroup
+	for _, set := range setters {
+		wg.Add(1)
+		go func(set UpdateFunc) {
+			defer wg.Done()
+			if _, err := store.UpdateForProfile(ctx, pid, "svc:1", set); err != nil {
+				t.Error(err)
+			}
+		}(set)
+	}
+	wg.Wait()
+
+	got, err := store.LoadForProfile(ctx, pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := ipn.ServicePref{Client: "term", Username: "rollie", DatabaseName: "prod"}
+	if diff := cmp.Diff(want, got["svc:1"], cmpOpts...); diff != "" {
+		t.Errorf("merged pref (-want +got):\n%s", diff)
+	}
+}
+
+func makePref(client string, lastUsed time.Time) ipn.ServicePref {
+	return ipn.ServicePref{Client: client, LastUsed: lastUsed}
+}
+
+// savePref stores pref verbatim under key, so tests can seed a known LastUsed. Production callers
+// go through UpdateForProfile directly and set LastUsed to the current time in their merge func.
+func savePref(ctx context.Context, store Store, pid ipn.ProfileID, key string, pref ipn.ServicePref) error {
+	_, err := store.UpdateForProfile(ctx, pid, key, func(ipn.ServicePref) ipn.ServicePref { return pref })
+	return err
+}
+
+func profilePath(dir string, pid ipn.ProfileID) string {
+	return filepath.Join(dir, hex.EncodeToString([]byte(pid))+".json")
+}
+
+func profileFileExists(t *testing.T, dir string, pid ipn.ProfileID) bool {
+	t.Helper()
+	_, err := os.Stat(profilePath(dir, pid))
+	switch {
+	case err == nil:
+		return true
+	case errors.Is(err, os.ErrNotExist):
+		return false
+	default:
+		t.Fatal(err)
+		return false
+	}
+}
+
+func seedProfileFile(t *testing.T, dir string, pid ipn.ProfileID, prefs ipn.ServicePrefs) {
+	t.Helper()
+	data, err := jsonv1.Marshal(prefs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(profilePath(dir, pid), data, 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readDiskForProfile(t *testing.T, dir string, pid ipn.ProfileID) ipn.ServicePrefs {
+	t.Helper()
+	data, err := os.ReadFile(profilePath(dir, pid))
+	if errors.Is(err, os.ErrNotExist) {
+		return ipn.ServicePrefs{}
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	var prefs ipn.ServicePrefs
+	if err := jsonv1.Unmarshal(data, &prefs); err != nil {
+		t.Fatal(err)
+	}
+	return prefs
+}

--- a/ipn/service_prefs.go
+++ b/ipn/service_prefs.go
@@ -1,0 +1,42 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package ipn
+
+import (
+	"maps"
+	"time"
+)
+
+// ServicePrefs maps a service action key to the user's saved preferences for that action.
+// Keys are formatted as "<serviceName>:<port>" (e.g. "svc:my-db:5432").
+type ServicePrefs map[string]ServicePref
+
+// ServicePref captures the saved preferences for one service action.
+type ServicePref struct {
+	// Client is the saved client identifier the user picked in the last service launch,
+	// for example, terminal/putty/iterm2/... for SSH, and dbeaver/psql/mycli/... for
+	// database. Empty means no client has been saved for this action.
+	Client string
+
+	// Username is the saved login name for SSH and future services that require username.
+	// Empty means none saved.
+	Username string
+
+	// DatabaseName is the saved DB name (database service types). Empty means none saved.
+	DatabaseName string
+
+	// LastUsed is when this service action was last launched. Zero means never.
+	// When the macOS and Windows apps generate a "recently used" list, they sort by
+	// LastUsed descending.
+	LastUsed time.Time
+}
+
+// Clone returns a shallow copy of this ServicePrefs, and since ServicePref is a value type,
+// the entries are independent of the source map it's cloning from.
+func (sp ServicePrefs) Clone() ServicePrefs {
+	if sp == nil {
+		return nil
+	}
+	return maps.Clone(sp)
+}

--- a/ipn/service_prefs_test.go
+++ b/ipn/service_prefs_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package ipn
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestServicePrefsClone(t *testing.T) {
+	now := time.Now()
+	src := ServicePrefs{
+		"svc:db:5432": {Client: "psql", DatabaseName: "prod", LastUsed: now},
+		"svc:ssh:22":  {Client: "terminal", Username: "rollie", LastUsed: now},
+	}
+	dst := src.Clone()
+	if !reflect.DeepEqual(src, dst) {
+		t.Fatalf("Clone result not equal to source")
+	}
+	// Mutating dst must not affect src.
+	dst["svc:db:5432"] = ServicePref{Client: "pgcli"}
+	if src["svc:db:5432"].Client != "psql" {
+		t.Errorf("mutating clone leaked into source: %v", src["svc:db:5432"])
+	}
+	// Nil clone returns nil.
+	if got := ServicePrefs(nil).Clone(); got != nil {
+		t.Errorf("(nil).Clone() = %v, want nil", got)
+	}
+}


### PR DESCRIPTION
- Add ipn.ServicePrefs to save user's last selected client, username, database name, and last used timestamp.
- Add a Store interface for the service prefs to read, write and delete service prefs
- Implement a FileStore and InMemoryStore for the Store interface. The FileStore uses the InMemoryStore for caching.
- The FileStore writes per-profile json files and the in-memory store. All reads hit the in-memory store directly.
- The InMemoryStore uses a time based retention to clean up entries not used within a configurable window.

Followed by the next PR: https://github.com/tailscale/tailscale/pull/20446 (local api + client wiring).

Change-Id: Ie1d49ab6c6f1300ea98edc2c1cc249b229983b15
Updates: https://github.com/tailscale/tailscale/issues/20429