### PR TITLE
cmd/tailscale/cli: fix plain TCP serve status

### DIFF
--- a/cmd/tailscale/cli/serve_v2.go
+++ b/cmd/tailscale/cli/serve_v2.go
@@ -1101,16 +1101,19 @@ func (e *serveEnv) messageForPort(sc *ipn.ServeConfig, st *ipnstate.Status, dnsN
 			output.WriteString(fmt.Sprintf("%s %-5s %s\n\n", "|--", t, d))
 		}
 	} else if tcpHandler != nil {
-
-		tlsStatus := "TLS over TCP"
+		var annotations []string
 		if tcpHandler.TerminateTLS != "" {
-			tlsStatus = "TLS terminated"
+			annotations = append(annotations, "TLS terminated")
 		}
 		if ver := tcpHandler.ProxyProtocol; ver != 0 {
-			tlsStatus = fmt.Sprintf("%s, PROXY protocol v%d", tlsStatus, ver)
+			annotations = append(annotations, fmt.Sprintf("PROXY protocol v%d", ver))
 		}
 
-		output.WriteString(fmt.Sprintf("|-- tcp://%s:%d (%s)\n", host, srvPort, tlsStatus))
+		output.WriteString(fmt.Sprintf("|-- tcp://%s:%d", host, srvPort))
+		if len(annotations) != 0 {
+			output.WriteString(fmt.Sprintf(" (%s)", strings.Join(annotations, ", ")))
+		}
+		output.WriteString("\n")
 		for _, a := range ips {
 			ipp := net.JoinHostPort(a.String(), strconv.Itoa(int(srvPort)))
 			output.WriteString(fmt.Sprintf("|-- tcp://%s\n", ipp))

--- a/cmd/tailscale/cli/serve_v2_test.go
+++ b/cmd/tailscale/cli/serve_v2_test.go
@@ -1603,7 +1603,7 @@ func TestMessageForPort(t *testing.T) {
 			expected: strings.Join([]string{
 				msgServeAvailable,
 				"",
-				"|-- tcp://foo.test.ts.net:2200 (TLS over TCP)",
+				"|-- tcp://foo.test.ts.net:2200",
 				"|-- tcp://100.101.101.101:2200",
 				"|-- tcp://[fd7a:115c:a1e0:ab12:4843:cd96:6565:6565]:2200",
 				"|--> tcp://localhost:3000",


### PR DESCRIPTION
Fixes #20367

Plain TCP forwarding currently initializes its output annotation as "TLS over TCP". Build annotations only from configured behavior so plain TCP has no TLS label, while TLS termination and PROXY protocol remain clearly identified.

The existing service TCP output test now covers the reported plain-TCP case.

Testing:
- ./tool/go test ./cmd/tailscale/cli -count=1
- ./tool/go vet ./cmd/tailscale/cli