### PR TITLE
ipn/ipnlocal: remove android from goosGetsLegacyNetmapNotify

### DIFF
--- a/ipn/ipnlocal/bus.go
+++ b/ipn/ipnlocal/bus.go
@@ -26,8 +26,7 @@ import (
 // other geese where this is false.
 const goosGetsLegacyNetmapNotify = runtime.GOOS == "windows" ||
 	runtime.GOOS == "darwin" ||
-	runtime.GOOS == "ios" ||
-	runtime.GOOS == "android"
+	runtime.GOOS == "ios"
 
 type rateLimitingBusSender struct {
 	fn              func(*ipn.Notify) (keepGoing bool)


### PR DESCRIPTION
The android client was converted in https://github.com/tailscale/tailscale-android/pull/797

Updates #12542
