### PR TITLE
ipn, ipn/ipnlocal: remove darwin & ios from goosGetsLegacyNetmapNotify

### DIFF
--- a/ipn/backend.go
+++ b/ipn/backend.go
@@ -339,10 +339,10 @@ type Notify struct {
 	//   - On the initial Notify if the watcher requested
 	//     [NotifyInitialNetMap] (any platform).
 	//   - On subsequent Notify messages, only when tailscaled is running
-	//     on Windows, macOS, or iOS. On Linux and other platforms it is
-	//     always nil after the initial notify.
+	//     on Windows. On all other platforms it is always nil after the
+	//     initial notify.
 	//
-	// Deprecated: this field is only populated on Windows, macOS, and iOS and
+	// Deprecated: this field is only populated on Windows and
 	// is slated for removal in favor of [Notify.InitialStatus] +
 	// [Notify.SelfChange] / [Notify.PeerChanges], etc, as this field
 	// doesn't scale.

--- a/ipn/ipnlocal/bus.go
+++ b/ipn/ipnlocal/bus.go
@@ -24,9 +24,7 @@ import (
 // runtime.GOOS is a compile-time constant, so the producer-side code that
 // builds and ships NetMap on the bus is dead-code-eliminated on Linux and
 // other geese where this is false.
-const goosGetsLegacyNetmapNotify = runtime.GOOS == "windows" ||
-	runtime.GOOS == "darwin" ||
-	runtime.GOOS == "ios"
+const goosGetsLegacyNetmapNotify = runtime.GOOS == "windows"
 
 type rateLimitingBusSender struct {
 	fn              func(*ipn.Notify) (keepGoing bool)


### PR DESCRIPTION
The Apple clients' last consumer of the legacy Notify.NetMap field was
converted to peer deltas in tailscale/corp#44962, so tailscaled no
longer needs to build and emit full netmaps on the IPN bus for darwin
and ios. Windows is now the only remaining platform on the legacy path.

Updates #12542
