### PR TITLE
logtail: add support for authenticated log uploads

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -704,6 +704,7 @@ func getLocalBackend(ctx context.Context, logf logger.Logf, logID logid.PublicID
 	lb.SetVarRoot(opts.VarRoot)
 	if logPol != nil {
 		lb.SetLogFlusher(logPol.Logtail.StartFlush)
+		lb.SetLogUploader(logPol.Logtail)
 	}
 	if root := lb.TailscaleVarRoot(); root != "" {
 		dnsfallback.SetCachePath(filepath.Join(root, "derpmap.cached.json"), logf)

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -53,6 +53,7 @@ import (
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/log/sockstatlog"
 	"tailscale.com/logpolicy"
+	"tailscale.com/logtail"
 	"tailscale.com/net/dns"
 	"tailscale.com/net/dnscache"
 	"tailscale.com/net/dnsfallback"
@@ -242,6 +243,11 @@ type LocalBackend struct {
 	unregisterSysPolicyWatch func()
 	varRoot                  string         // or empty if SetVarRoot never called
 	logFlushFunc             func()         // or nil if SetLogFlusher wasn't called
+	// logUploader is the process-wide logtail logger for tailscaled's main
+	// log stream. Set via [LocalBackend.SetLogUploader]. May be nil.
+	logUploader *logtail.Logger
+	// logAuth caches tokens for authenticated log uploads (formain logs and netlog).
+	logAuth logAuthCache
 	em                       *expiryManager // non-nil; TODO(nickkhyl): move to nodeBackend
 	sshAtomicBool            atomic.Bool    // TODO(nickkhyl): move to nodeBackend
 	// webClientAtomicBool controls whether the web client is running. This should
@@ -624,6 +630,7 @@ func NewLocalBackend(logf logger.Logf, logID logid.PublicID, sys *tsd.System, lo
 		captiveCtx:            captiveCtx,
 		captiveCancel:         nil, // so that we start checkCaptivePortalLoop when Running
 		needsCaptiveDetection: make(chan bool),
+		logAuth:               logAuthCache{logf: logf},
 	}
 
 	sys.NoiseRoundTripper.Set(noiseRoundTripper{b})
@@ -6240,6 +6247,18 @@ func (b *LocalBackend) SetLogFlusher(flushFunc func()) {
 	b.logFlushFunc = flushFunc
 }
 
+// SetLogUploader sets the process-wide logtail logger used for tailscaled's
+// main log stream. It enables authenticated log uploads when the node is in a
+// tailnet (see [LocalBackend.updateLogUploadAuth]).
+//
+// It should only be called before the LocalBackend is used.
+func (b *LocalBackend) SetLogUploader(lg *logtail.Logger) {
+	if !buildfeatures.HasLogTail {
+		return
+	}
+	b.logUploader = lg
+}
+
 // TryFlushLogs calls the log flush function. It returns false if a log flush
 // function was never initialized with SetLogFlusher.
 //
@@ -7400,6 +7419,14 @@ func (b *LocalBackend) setNetMapLocked(nm *netmap.NetworkMap) {
 		b.setDebugLogsByCapabilityLocked(caps)
 	}
 
+	// Authenticated log uploads: annotate main logger with node auth ID
+	// and cache any tokens from NodeAttrLogUploadAuth.
+	// Upon logout, shutdown, or a profile switch,
+	// it clears the node auth ID via the presence of a nil netmap.
+	if buildfeatures.HasLogTail {
+		b.updateLogUploadAuth(nm)
+	}
+
 	// See the netns package for documentation on what these capability do.
 	netns.SetBindToInterfaceByRoute(b.logf, nm.HasCap(tailcfg.CapabilityBindToInterfaceByRoute))
 	if runtime.GOOS == "android" {
@@ -8131,6 +8158,16 @@ func (s netLogNodeSource) NetLogIDs() (nodeID, domainID logid.PrivateID, logExit
 		return logid.PrivateID{}, logid.PrivateID{}, false, false
 	}
 	return nodeID, domainID, nm.SelfNode.HasCap(tailcfg.NodeAttrLogExitFlows), true
+}
+
+// LogUploadAuth implements [wgengine.NetLogSource].
+func (s netLogNodeSource) LogUploadAuth() (authID string, authToken func() string) {
+	nm := s.b.NetMap()
+	if nm == nil || !nm.SelfNode.Valid() {
+		return "", nil
+	}
+	authID = logtail.FormatAuthID(int64(nm.SelfNode.ID()))
+	return authID, s.b.logAuth.tokenFunc(authID)
 }
 
 // Compile-time assertion that netLogNodeSource implements

--- a/ipn/ipnlocal/logauth.go
+++ b/ipn/ipnlocal/logauth.go
@@ -1,0 +1,104 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package ipnlocal
+
+import (
+	"fmt"
+	"sync"
+
+	"tailscale.com/feature/buildfeatures"
+	"tailscale.com/tailcfg"
+	"tailscale.com/types/logger"
+	"tailscale.com/types/netmap"
+	"tailscale.com/util/mak"
+)
+
+type logAuthID string
+type logAuthToken string
+
+// logAuthCache caches log upload auth tokens keyed by auth ID ("nodeid:<nodeID>").
+// Tokens arrive proactively from control via [tailcfg.NodeAttrLogUploadAuth]
+// on netmap updates; the client does not refresh them itself.
+//
+// All methods are safe for concurrent use.
+type logAuthCache struct {
+	logf logger.Logf
+
+	mu     sync.Mutex
+	tokens map[logAuthID]logAuthToken
+}
+
+// storeToken stores token for authID.
+func (c *logAuthCache) storeToken(id logAuthID, tok logAuthToken) {
+	if id == "" || tok == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	mak.Set(&c.tokens, id, tok)
+}
+
+// loadToken returns the cached bearer token for authID, or "" if none.
+// An empty result means the uploader proceeds unauthenticated (matching
+// historical logtail behavior when no auth is available).
+func (c *logAuthCache) loadToken(id logAuthID) logAuthToken {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.tokens[id]
+}
+
+// updateLogUploadAuth applies netmap-driven log upload authentication
+// to the main tailscaled [logtail.Logger] and updates the token cache.
+//
+// When nm is nil or lacks a self node, new log entries are stamped with an
+// empty auth ID, but previously cached tokens are retained so buffered logs
+// from the prior node can still upload with Authorization.
+//
+// When CapMap carries [tailcfg.NodeAttrLogUploadAuth], the token is cached.
+// Control is expected to push a refreshed token via netmap
+// before the previous one expires.
+//
+// Even when a new auth token arrives as a concise netmap delta
+// with just the self CapMap for the [tailcfg.NodeAttrLogUploadAuth],
+// the LocalBackend still triggers a full netmap install.
+// Note that peer deltas cannot carry this attribute.
+func (b *LocalBackend) updateLogUploadAuth(nm *netmap.NetworkMap) {
+	if !buildfeatures.HasLogTail {
+		return
+	}
+
+	lg := b.logUploader
+	if lg == nil || nm == nil || !nm.SelfNode.Valid() {
+		if lg != nil {
+			lg.SetAuthID("")
+		}
+		return
+	}
+
+	// Configure the logger to log under the context of the current node.
+	authID := formatAuthID(nm.SelfNode.ID())
+	lg.SetAuthID(string(authID))
+	lg.RegisterAuthToken(string(authID), func() string {
+		return string(b.logAuth.loadToken(authID))
+	})
+
+	// Cache any token provided in the netmap CapMap.
+	tokens, err := tailcfg.UnmarshalNodeCapViewJSON[string](nm.SelfNode.CapMap(), tailcfg.NodeAttrLogUploadAuth)
+	if err != nil {
+		b.logf("logauth: CapMap %s: %v", tailcfg.NodeAttrLogUploadAuth, err)
+		return
+	}
+	for _, tok := range tokens {
+		if tok != "" {
+			b.logAuth.storeToken(authID, logAuthToken(tok))
+		}
+	}
+}
+
+// formatAuthID returns the canonical auth ID for authenticated log uploads:
+// "nodeid:<nodeID>". A node ID change implies a tailnet change, so the auth ID
+// does not include a separate tailnet component.
+func formatAuthID(nodeID tailcfg.NodeID) logAuthID {
+	return logAuthID(fmt.Sprintf("nodeid:%d", nodeID))
+}

--- a/ipn/ipnlocal/logauth_test.go
+++ b/ipn/ipnlocal/logauth_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package ipnlocal
+
+import (
+	"context"
+	"testing"
+
+	"tailscale.com/logtail"
+	"tailscale.com/tailcfg"
+	"tailscale.com/types/netmap"
+)
+
+func TestLogAuthCachePutAndToken(t *testing.T) {
+	c := &logAuthCache{logf: t.Logf}
+	authID := formatAuthID(2)
+	const tok = "test-jwt-token"
+	c.storeToken(authID, tok)
+	if got := c.loadToken(authID); got != tok {
+		t.Errorf("token = %q; want %q", got, tok)
+	}
+	if got := c.loadToken("missing"); got != "" {
+		t.Errorf("missing authID token = %q; want empty", got)
+	}
+}
+
+func TestUpdateLogUploadAuth(t *testing.T) {
+	lg := logtail.NewLogger(logtail.Config{
+		BaseURL: "http://127.0.0.1:1", // never dialed; we only check SetAuthID
+		HTTPC:   nil,
+	}, t.Logf)
+	// Immediately shut down the upload goroutine to avoid noise.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_ = lg.Shutdown(ctx)
+
+	b := &LocalBackend{
+		logf:        t.Logf,
+		logUploader: lg,
+		logAuth:     logAuthCache{logf: t.Logf},
+	}
+
+	const tok = "eyJ.test.jwt"
+	node := &tailcfg.Node{
+		ID: 42,
+		CapMap: tailcfg.NodeCapMap{
+			tailcfg.NodeAttrLogUploadAuth: {tailcfg.RawMessage(`"` + tok + `"`)},
+		},
+	}
+	nm := &netmap.NetworkMap{
+		SelfNode: node.View(),
+	}
+	b.updateLogUploadAuth(nm)
+	wantID := formatAuthID(42)
+	if got := b.logAuth.loadToken(wantID); got != tok {
+		t.Errorf("cached token = %q; want %q", got, tok)
+	}
+
+	// A later netmap can push a refreshed token for the same auth ID.
+	const tok2 = "eyJ.refreshed.jwt"
+	node2 := &tailcfg.Node{
+		ID: 42,
+		CapMap: tailcfg.NodeCapMap{
+			tailcfg.NodeAttrLogUploadAuth: {tailcfg.RawMessage(`"` + tok2 + `"`)},
+		},
+	}
+	nm2 := &netmap.NetworkMap{
+		SelfNode: node2.View(),
+	}
+	b.updateLogUploadAuth(nm2)
+	if got := b.logAuth.loadToken(wantID); got != tok2 {
+		t.Errorf("after refresh push, token = %q; want %q", got, tok2)
+	}
+
+	// Logout / nil netmap: clear SetAuthID but keep cached tokens for buffered logs.
+	b.updateLogUploadAuth(nil)
+	if got := b.logAuth.loadToken(wantID); got != tok2 {
+		t.Errorf("after logout, cached token = %q; want retained %q", got, tok2)
+	}
+}
+
+func TestFormatAuthID(t *testing.T) {
+	const want = "nodeid:456"
+	got := formatAuthID(456)
+	if got != want {
+		t.Errorf("formatAuthID = %q; want %q", got, want)
+	}
+}

--- a/logtail/logtail.go
+++ b/logtail/logtail.go
@@ -38,6 +38,7 @@ import (
 	tslogger "tailscale.com/types/logger"
 	"tailscale.com/types/logid"
 	"tailscale.com/util/eventbus"
+	"tailscale.com/util/mak"
 	"tailscale.com/util/set"
 	"tailscale.com/util/truncate"
 	"tailscale.com/util/zstdframe"
@@ -162,6 +163,11 @@ func NewLogger(cfg Config, logf tslogger.Logf) *Logger {
 // Zero-valued fields are omitted when an entry is uploaded. [UploadLogs] fills
 // in any fields the caller leaves zero from its [Config] (e.g. ClientTime and
 // ProcID), so most callers can leave this empty.
+//
+// AuthID is used only while an entry is buffered.
+// [Logger] writes it into each entry from [Logger.SetAuthID] and
+// strips it before the HTTP POST so it never appears
+// in the payload the log server receives.
 type Logtail struct {
 	// ClientTime is the time the entry was generated. If zero, [UploadLogs]
 	// fills it with the current time unless Config.SkipClientTime is set.
@@ -171,6 +177,9 @@ type Logtail struct {
 	// ProcSeq is an ephemeral per-process sequence number; see
 	// Config.IncludeProcSequence.
 	ProcSeq uint64 `json:"proc_seq,omitzero"`
+	// AuthID is an opaque authentication ID (see [Logger.SetAuthID]).
+	// It is stripped before upload and is not part of the log payload.
+	AuthID string `json:"auth_id,omitzero"`
 }
 
 // LogEntry is a single log entry to be uploaded via [UploadLogs].
@@ -244,7 +253,9 @@ func UploadLogs[T any](ctx context.Context, conf Config, entries iter.Seq[LogEnt
 		}
 		// upload is synchronous, so it is safe to reuse body's backing array
 		// for the next batch once upload returns.
-		if _, err := lg.upload(ctx, out, origlen); err != nil {
+		// UploadLogs does not use auth IDs; callers that need authenticated
+		// uploads should use [Logger] with [Logger.SetAuthID].
+		if _, err := lg.upload(ctx, out, origlen, ""); err != nil {
 			return err
 		}
 		body = body[:len("[")]
@@ -326,6 +337,28 @@ type Logger struct {
 	// Disable kill switch, which takes precedence. Toggled by SetEnabled.
 	disabled atomic.Bool
 
+	// authID is the current authentication ID to stamp onto new log entries
+	// (see [Logger.SetAuthID]). Empty string means unauthenticated.
+	authID atomic.Value // string
+
+	// authTokens maps authID to a function that returns the Authorization
+	// token to use when uploading a batch for that authID.
+	// Guarded by authTokensMu.
+	authTokensMu sync.Mutex
+	authTokens   map[string]func() string
+
+	// linePending is a line from Buffer.TryReadLine that was pulled into a
+	// drain but belongs to the next upload batch (different auth_id).
+	//
+	// It aliases the buffer's returned slice. Buffer documents that the
+	// slice is only valid until the next TryReadLine; that is safe here
+	// because nextDrainLine is the sole TryReadLine call site, and it
+	// always returns a non-nil linePending (clearing the field) before
+	// calling TryReadLine again. Owned by the uploading goroutine.
+	linePending []byte           // owned by [Logger.uploading] goroutine for use by [Logger.drainPending]
+	lineBuf     bytes.Buffer     // owned by [Logger.uploading] goroutine for use by [Logger.appendEntry]
+	lineDec     jsontext.Decoder // owned by [Logger.uploading] goroutine for use by [Logger.appendEntry]
+
 	writeLock    sync.Mutex // guards procSequence, flushTimer, buffer.Write calls
 	procSequence uint64
 	flushTimer   tstime.TimerController // used when flushDelay is >0
@@ -367,6 +400,56 @@ func (lg *Logger) SetNetMon(lm *netmon.Monitor) {
 // SetSockstatsLabel sets the label used in sockstat logs to identify network traffic from this logger.
 func (lg *Logger) SetSockstatsLabel(label sockstats.Label) {
 	lg.sockstatsLabel.Store(label)
+}
+
+// SetAuthID specifies an arbitrary authentication ID
+// (e.g., "nodeid:456") to annotate every subsequent log entry.
+// This is deliberately an opaque ID to allow the application-layer
+// decide how to associate particular authentication tokens
+// to authentication IDs (see [Logger.RegisterAuthToken]).
+//
+// This ID is not uploaded as part of the log entry payload,
+// but used at the moment of uploading to determine
+// the authentication token to use when uploading.
+//
+// It is safe to concurrently call this method with other Logger methods.
+func (lg *Logger) SetAuthID(id string) {
+	lg.authID.Store(id)
+}
+
+// getAuthID returns the auth ID set by [Logger.SetAuthID].
+func (lg *Logger) getAuthID() string {
+	v, _ := lg.authID.Load().(string)
+	return v
+}
+
+// RegisterAuthToken registers a dynamically-derived authToken to be called
+// for uploading logs for a particular authID (see [Logger.SetAuthID]),
+// replacing any previously registered authToken for the given authID.
+// If authToken is nil or returns an empty string, then no authorization
+// token is specified when uploading logs. It is permitted to register
+// an authToken for an empty authID.
+//
+// It is safe to concurrently call this method with other Logger methods.
+func (lg *Logger) RegisterAuthToken(authID string, authToken func() string) {
+	lg.authTokensMu.Lock()
+	defer lg.authTokensMu.Unlock()
+	if authToken != nil {
+		mak.Set(&lg.authTokens, authID, authToken)
+	} else {
+		delete(lg.authTokens, authID)
+	}
+}
+
+// lookupAuthToken returns the Authorization token for authID, or "" if none.
+func (lg *Logger) lookupAuthToken(authID string) string {
+	lg.authTokensMu.Lock()
+	fn := lg.authTokens[authID]
+	lg.authTokensMu.Unlock()
+	if fn == nil {
+		return ""
+	}
+	return fn()
 }
 
 // PrivateID returns the logger's private log ID.
@@ -438,8 +521,14 @@ func (lg *Logger) drainBlock() (shuttingDown bool) {
 
 // drainPending drains and encodes a batch of logs from the buffer for upload.
 // If no logs are available, drainPending blocks until logs are available.
+//
+// Every entry in the returned batch shares the same authID (the value of
+// /logtail/auth_id when the entry was written). Entries with a different
+// auth_id are held for a subsequent batch. Auth IDs are stripped from the
+// body so they are never uploaded.
+//
 // The returned buffer is only valid until the next call to drainPending.
-func (lg *Logger) drainPending() (b []byte) {
+func (lg *Logger) drainPending() (b []byte, authID string) {
 	b = lg.drainBuf[:0]
 	b = append(b, '[')
 	defer func() {
@@ -459,21 +548,25 @@ func (lg *Logger) drainPending() (b []byte) {
 		// that is up to maxSize if we happen to encounter one.
 		maxLen /= lowMemRatio
 	}
+	var batchAuthID string
+	var haveBatchAuthID bool
 	for len(b) < maxLen {
-		line, err := lg.buffer.TryReadLine()
+		line, err := lg.nextDrainLine()
 		switch {
 		case err == io.EOF:
-			return b
+			return b, batchAuthID
 		case err != nil:
+			// Synthesized error entries inherit the batch authID if any so far,
+			// otherwise an empty authID (unauthenticated).
 			b = append(b, '{')
-			b = lg.appendMetadata(b, false, true, 0, 0, "reading ringbuffer: "+err.Error(), nil, 0)
+			b = lg.appendMetadata(b, false, true, 0, 0, "", "reading ringbuffer: "+err.Error(), nil, 0)
 			b = bytes.TrimRight(b, ",")
 			b = append(b, '}')
-			return b
+			return b, batchAuthID
 		case line == nil:
 			// If we read at least some log entries, return immediately.
 			if len(b) > len("[") {
-				return b
+				return b, batchAuthID
 			}
 
 			// We're about to block. If we're holding on to too much memory
@@ -484,22 +577,37 @@ func (lg *Logger) drainPending() (b []byte) {
 			}
 
 			if shuttingDown := lg.drainBlock(); shuttingDown {
-				return b
+				return b, batchAuthID
 			}
 			continue
 		}
 
-		switch {
-		case len(line) == 0:
+		if len(line) == 0 {
 			continue
-		case line[0] == '{' && jsontext.Value(line).IsValid():
-			// This is already a valid JSON object, so just append it.
-			// This may exceed maxLen, but should be no larger than maxSize
-			// so long as logic writing into the buffer enforces the limit.
-			b = append(b, line...)
-		default:
-			// This is probably a log added to stderr by filch
-			// outside of the logtail logger. Encode it.
+		}
+
+		// This may exceed maxLen, but should be no larger than maxSize
+		// so long as logic writing into the buffer enforces the limit.
+		next, entryAuthID, valid := lg.appendEntry(b, line)
+		if !valid {
+			// Non-JSON (or otherwise unparseable) line.
+			// Typically raw stderr captured by filch outside logtail.
+			// There is no right auth ID to use, so use the current
+			// SetAuthID as a chronologically likely guess.
+			entryAuthID = lg.getAuthID()
+		}
+		if haveBatchAuthID && entryAuthID != batchAuthID {
+			// Different auth ID: hold this line for the next batch.
+			// Leave b unchanged (do not assign next).
+			// See [Logger.linePending] for why it is safe not to copy the line.
+			lg.linePending = line
+			return b, batchAuthID
+		}
+
+		b = next
+		if !valid {
+			// Commit the RAW line only after the auth batch check so we
+			// do not print/encode twice when the line is held for later.
 			if !lg.explainedRaw {
 				fmt.Fprintf(lg.stderr, "RAW-STDERR: ***\n")
 				fmt.Fprintf(lg.stderr, "RAW-STDERR: *** Lines prefixed with RAW-STDERR below bypassed logtail and probably come from a previous run of the program\n")
@@ -507,15 +615,102 @@ func (lg *Logger) drainPending() (b []byte) {
 				fmt.Fprintf(lg.stderr, "RAW-STDERR:\n")
 				lg.explainedRaw = true
 			}
-			fmt.Fprintf(lg.stderr, "RAW-STDERR: %s", b)
+			fmt.Fprintf(lg.stderr, "RAW-STDERR: %s", line)
 			// Do not add a client time, as it could be really old.
 			// Do not include instance key or ID either,
 			// since this came from a different instance.
-			b = lg.appendText(b, line, true, 0, 0, 0)
+			// Do not stamp auth_id into the body since the batch's
+			// Authorization header carries entryAuthID from getAuthID above.
+			b = lg.appendText(b, line, true, 0, 0, "", 0)
+		}
+		if !haveBatchAuthID {
+			batchAuthID = entryAuthID
+			haveBatchAuthID = true
 		}
 		b = append(b, ',')
 	}
-	return b
+	return b, batchAuthID
+}
+
+// nextDrainLine returns the next line to drain: either a previously held
+// pending line, or a fresh line from the buffer.
+//
+// See [Logger.linePending] for the lifetime invariant with TryReadLine.
+func (lg *Logger) nextDrainLine() ([]byte, error) {
+	if line := lg.linePending; line != nil {
+		lg.linePending = nil
+		return line, nil
+	}
+	return lg.buffer.TryReadLine()
+}
+
+// appendEntry appends a JSON log entry in src to dst if it is valid.
+// If /logtail/auth_id is populated, it extracts it out of the log entry.
+// If valid is false, then out is identical to dst.
+func (lg *Logger) appendEntry(dst, src []byte) (out []byte, authID string, valid bool) {
+	lg.lineBuf = *bytes.NewBuffer(src)
+	defer func() { lg.lineBuf = bytes.Buffer{} }() // avoid pinning src
+	dec := &lg.lineDec
+	dec.Reset(&lg.lineBuf)
+
+	// Scan through the JSON entry, identifying the offsets
+	// for the /logtail/auth_id field, so that we can strip it out later.
+	var startAuthIDOffset, endAuthIDOffset int64
+	if tok, err := dec.ReadToken(); err != nil || tok.Kind() != '{' {
+		return dst, "", false
+	}
+	for dec.PeekKind() != '}' {
+		switch tok, err := dec.ReadToken(); {
+		case err != nil:
+			return dst, "", false
+		case tok.String() == "logtail":
+			if tok, err := dec.ReadToken(); err != nil || tok.Kind() != '{' {
+				return dst, "", false
+			}
+			for dec.PeekKind() != '}' {
+				startOffset := dec.InputOffset()
+				switch tok, err := dec.ReadToken(); {
+				case err != nil:
+					return dst, "", false
+				case tok.String() == "auth_id":
+					tok, err := dec.ReadToken()
+					if err != nil || tok.Kind() != '"' {
+						return dst, "", false
+					}
+					authID = tok.String()
+					startAuthIDOffset = startOffset
+					endAuthIDOffset = dec.InputOffset()
+
+					// If this is the first member and there is a following member,
+					// then we need to strip the subsequent comma.
+					// We check n == 2 since we already read one member.
+					if _, n := dec.StackIndex(dec.StackDepth()); n == 2 && dec.PeekKind() != '}' {
+						endAuthIDOffset += int64(len(dec.UnreadBuffer()) - len(bytes.TrimLeft(dec.UnreadBuffer(), " \n\r\t")) + len(","))
+					}
+				default:
+					if err := dec.SkipValue(); err != nil {
+						return dst, "", false
+					}
+				}
+			}
+			if tok, err := dec.ReadToken(); err != nil || tok.Kind() != '}' {
+				return dst, "", false
+			}
+		default:
+			if err := dec.SkipValue(); err != nil {
+				return dst, "", false
+			}
+		}
+	}
+	if tok, err := dec.ReadToken(); err != nil || tok.Kind() != '}' {
+		return dst, "", false
+	}
+	if _, err := dec.ReadValue(); err != io.EOF {
+		return dst, "", false // implies trailing data after JSON object
+	}
+
+	// Append the log entry, stripping out /logtail/auth_id field if present.
+	return append(append(dst, src[:startAuthIDOffset]...), src[endAuthIDOffset:]...), authID, true
 }
 
 // This is the goroutine that repeatedly uploads logs in the background.
@@ -523,7 +718,7 @@ func (lg *Logger) uploading(ctx context.Context) {
 	defer close(lg.shutdownDone)
 
 	for {
-		body := lg.drainPending()
+		body, authID := lg.drainPending()
 		origlen := -1 // sentinel value: uncompressed
 		// Don't attempt to compress tiny bodies; not worth the CPU cycles.
 		if lg.compressLogs && len(body) > 256 {
@@ -543,7 +738,7 @@ func (lg *Logger) uploading(ctx context.Context) {
 		var numFailures int
 		var firstFailure time.Time
 		for len(body) > 0 && ctx.Err() == nil {
-			retryAfter, err := lg.upload(ctx, body, origlen)
+			retryAfter, err := lg.upload(ctx, body, origlen, authID)
 			if err != nil {
 				numFailures++
 				firstFailure = lg.clock.Now()
@@ -638,7 +833,10 @@ func (lg *Logger) awaitInternetUp(ctx context.Context) {
 // upload uploads body to the log server.
 // origlen indicates the pre-compression body length.
 // origlen of -1 indicates that the body is not compressed.
-func (lg *Logger) upload(ctx context.Context, body []byte, origlen int) (retryAfter time.Duration, err error) {
+// authID is the authentication ID shared by every entry in body
+// (already stripped from the JSON); when a non-empty token is registered,
+// then the request includes an Authorization: Bearer header.
+func (lg *Logger) upload(ctx context.Context, body []byte, origlen int, authID string) (retryAfter time.Duration, err error) {
 	lg.uploadCalls.Add(1)
 	startUpload := time.Now()
 
@@ -657,6 +855,13 @@ func (lg *Logger) upload(ctx context.Context, body []byte, origlen int) (retryAf
 	if origlen != -1 {
 		req.Header.Add("Content-Encoding", "zstd")
 		req.Header.Add("Orig-Content-Length", strconv.Itoa(origlen))
+	}
+	if token := lg.lookupAuthToken(authID); token != "" {
+		// TODO: If authID is non-empty, but the token is empty,
+		// then it implies that we might have just logged in as a node,
+		// but not yet received a full netmap with the token.
+		// Perhaps wait a bit before checking again?
+		req.Header.Set("Authorization", "Bearer "+token)
 	}
 	if runtime.GOOS == "js" {
 		// We once advertised we'd accept optional client certs (for internal use)
@@ -803,9 +1008,8 @@ func (lg *Logger) sendLocked(jsonBlob []byte) (int, error) {
 // appendMetadata appends optional "logtail", "metrics", and "v" JSON members.
 // This assumes dst is already within a JSON object.
 // Each member is comma-terminated.
-func (lg *Logger) appendMetadata(dst []byte, skipClientTime, skipMetrics bool, procID uint32, procSequence uint64, errDetail string, errData jsontext.Value, level int) []byte {
-	// Append optional logtail metadata.
-	if !skipClientTime || procID != 0 || procSequence != 0 || errDetail != "" || errData != nil {
+func (lg *Logger) appendMetadata(dst []byte, skipClientTime, skipMetrics bool, procID uint32, procSequence uint64, authID, errDetail string, errData jsontext.Value, level int) []byte {
+	if !skipClientTime || procID != 0 || procSequence != 0 || errDetail != "" || errData != nil || authID != "" {
 		dst = append(dst, `"logtail":{`...)
 		if !skipClientTime {
 			dst = append(dst, `"client_time":"`...)
@@ -820,6 +1024,11 @@ func (lg *Logger) appendMetadata(dst []byte, skipClientTime, skipMetrics bool, p
 		if procSequence != 0 {
 			dst = append(dst, `"proc_seq":`...)
 			dst = strconv.AppendUint(dst, procSequence, 10)
+			dst = append(dst, ',')
+		}
+		if authID != "" {
+			dst = append(dst, `"auth_id":`...)
+			dst, _ = jsontext.AppendQuote(dst, authID)
 			dst = append(dst, ',')
 		}
 		if errDetail != "" || errData != nil {
@@ -863,10 +1072,10 @@ func (lg *Logger) appendMetadata(dst []byte, skipClientTime, skipMetrics bool, p
 }
 
 // appendText appends a raw text message in the Tailscale JSON log entry format.
-func (lg *Logger) appendText(dst, src []byte, skipClientTime bool, procID uint32, procSequence uint64, level int) []byte {
+func (lg *Logger) appendText(dst, src []byte, skipClientTime bool, procID uint32, procSequence uint64, authID string, level int) []byte {
 	dst = slices.Grow(dst, len(src))
 	dst = append(dst, '{')
-	dst = lg.appendMetadata(dst, skipClientTime, false, procID, procSequence, "", nil, level)
+	dst = lg.appendMetadata(dst, skipClientTime, false, procID, procSequence, authID, "", nil, level)
 	if len(src) == 0 {
 		dst = bytes.TrimRight(dst, ",")
 		return append(dst, "}\n"...)
@@ -905,7 +1114,7 @@ func (lg *Logger) appendTextOrJSONLocked(dst, src []byte, level int) []byte {
 		lg.procSequence++
 	}
 	if len(src) == 0 || src[0] != '{' {
-		return lg.appendText(dst, src, lg.skipClientTime, lg.procID, lg.procSequence, level)
+		return lg.appendText(dst, src, lg.skipClientTime, lg.procID, lg.procSequence, lg.getAuthID(), level)
 	}
 
 	// Check whether the input is a valid JSON object and
@@ -953,7 +1162,7 @@ func (lg *Logger) appendTextOrJSONLocked(dst, src []byte, level int) []byte {
 
 	// Treat invalid JSON as a raw text message.
 	if !validJSON {
-		return lg.appendText(dst, src, lg.skipClientTime, lg.procID, lg.procSequence, level)
+		return lg.appendText(dst, src, lg.skipClientTime, lg.procID, lg.procSequence, lg.getAuthID(), level)
 	}
 
 	// Check whether the JSON payload is too large.
@@ -967,7 +1176,7 @@ func (lg *Logger) appendTextOrJSONLocked(dst, src []byte, level int) []byte {
 		errData := appendTruncatedString(nil, src, maxLen/len(`\uffff`)) // escaping could increase size
 
 		dst = append(dst, '{')
-		dst = lg.appendMetadata(dst, lg.skipClientTime, true, lg.procID, lg.procSequence, errDetail, errData, level)
+		dst = lg.appendMetadata(dst, lg.skipClientTime, true, lg.procID, lg.procSequence, lg.getAuthID(), errDetail, errData, level)
 		dst = bytes.TrimRight(dst, ",")
 		return append(dst, "}\n"...)
 	}
@@ -984,7 +1193,7 @@ func (lg *Logger) appendTextOrJSONLocked(dst, src []byte, level int) []byte {
 	}
 	dst = slices.Grow(dst, len(src))
 	dst = append(dst, '{')
-	dst = lg.appendMetadata(dst, lg.skipClientTime, true, lg.procID, lg.procSequence, errDetail, errData, level)
+	dst = lg.appendMetadata(dst, lg.skipClientTime, true, lg.procID, lg.procSequence, lg.getAuthID(), errDetail, errData, level)
 	if logtailValLength > 0 {
 		// Exclude original logtail member from the message.
 		dst = appendWithoutNewline(dst, src[len("{"):logtailKeyOffset])

--- a/logtail/logtail_omit.go
+++ b/logtail/logtail_omit.go
@@ -24,6 +24,7 @@ type Logtail struct {
 	ClientTime time.Time `json:"client_time,omitzero"`
 	ProcID     uint32    `json:"proc_id,omitzero"`
 	ProcSeq    uint64    `json:"proc_seq,omitzero"`
+	AuthID     string    `json:"auth_id,omitzero"`
 }
 
 type LogEntry[T any] struct {
@@ -55,6 +56,9 @@ func (l *Logger) SetSockstatsLabel(label any) {}
 
 func (l *Logger) PrivateID() logid.PrivateID { return logid.PrivateID{} }
 func (l *Logger) StartFlush()                {}
+
+func (*Logger) SetAuthID(id string)                                  {}
+func (*Logger) RegisterAuthToken(authID string, authToken func() string) {}
 
 func RegisterLogTap(dst chan<- string) (unregister func()) {
 	return func() {}

--- a/logtail/logtail_test.go
+++ b/logtail/logtail_test.go
@@ -586,6 +586,146 @@ type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
 
+func TestAppendEntry(t *testing.T) {
+	var lg Logger
+
+	tests := []struct {
+		in         string
+		want       string
+		wantAuthID string
+		wantValid  bool
+	}{
+		{``, ``, ``, false},
+		{`fizz`, ``, ``, false},
+		{` {} `, ` {} `, ``, true},
+		{` { "logtail": {} } `, ` { "logtail": {} } `, ``, true},
+		{` { "logtail": { "auth_id" : "foo" } } `, ` { "logtail": { } } `, `foo`, true},
+		{` { "logtail": { "before" : "value" , "auth_id" : "foo" } } `, ` { "logtail": { "before" : "value" } } `, `foo`, true},
+		{` { "logtail": { "auth_id" : "foo"   ,  "after" : "value" } } `, ` { "logtail": {  "after" : "value" } } `, `foo`, true},
+		{`{"logtail":{"auth_id":"foo","after":"value"}}`, `{"logtail":{"after":"value"}}`, `foo`, true},
+		{` { "logtail": { "before" : "value" , "auth_id" : "foo" , "after" : "value" } , "fizz":"buzz"} `, ` { "logtail": { "before" : "value" , "after" : "value" } , "fizz":"buzz"} `, `foo`, true},
+	}
+	for _, tt := range tests {
+		got, gotAuthID, gotValid := lg.appendEntry(nil, []byte(tt.in))
+		if string(got) != tt.want || gotAuthID != tt.wantAuthID || gotValid != tt.wantValid {
+			t.Errorf("appendEntry(%q) = (%q, %q, %v), want (%q, %q, %v)", tt.in, got, gotAuthID, gotValid, tt.want, tt.wantAuthID, tt.wantValid)
+		}
+	}
+
+}
+
+func TestDrainPendingBatchesByAuthID(t *testing.T) {
+	buf := NewMemoryBuffer(100)
+	lg := &Logger{
+		clock:  tstest.NewClock(tstest.ClockOpts{Start: time.Unix(123, 0)}),
+		buffer: buf,
+	}
+	lg.SetAuthID("auth-a")
+	must.Get(lg.Write([]byte("a1")))
+	must.Get(lg.Write([]byte("a2")))
+	lg.SetAuthID("auth-b")
+	must.Get(lg.Write([]byte("b1")))
+
+	body1, id1 := lg.drainPending()
+	if id1 != "auth-a" {
+		t.Errorf("first batch authID = %q; want auth-a", id1)
+	}
+	if strings.Contains(string(body1), "auth_id") {
+		t.Errorf("first batch still has auth_id: %s", body1)
+	}
+	if !strings.Contains(string(body1), "a1") || !strings.Contains(string(body1), "a2") {
+		t.Errorf("first batch missing a-entries: %s", body1)
+	}
+	if strings.Contains(string(body1), "b1") {
+		t.Errorf("first batch leaked b-entry: %s", body1)
+	}
+
+	body2, id2 := lg.drainPending()
+	if id2 != "auth-b" {
+		t.Errorf("second batch authID = %q; want auth-b", id2)
+	}
+	if !strings.Contains(string(body2), "b1") {
+		t.Errorf("second batch missing b1: %s", body2)
+	}
+	if strings.Contains(string(body2), "auth_id") {
+		t.Errorf("second batch still has auth_id: %s", body2)
+	}
+}
+
+func TestUploadAuthorizationHeader(t *testing.T) { synctest.Test(t, synctestUploadAuthorizationHeader) }
+
+func synctestUploadAuthorizationHeader(t *testing.T) {
+	type capture struct {
+		auth string
+		body []byte
+	}
+	uploaded := make(chan capture, 8)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		uploaded <- capture{auth: r.Header.Get("Authorization"), body: body}
+	})
+	ln := memnet.Listen("logtail-test:0")
+	httpsrv := &http.Server{Handler: handler}
+	go httpsrv.Serve(ln)
+	t.Cleanup(func() {
+		httpsrv.Close()
+		ln.Close()
+	})
+
+	// Disable startup banner so it doesn't consume a capture.
+	envknob.Setenv("TS_DEBUG_LOGTAIL", "")
+	logger := NewLogger(Config{
+		BaseURL: "http://" + ln.Addr().String(),
+		HTTPC:   &http.Client{Transport: &http.Transport{DialContext: ln.Dial}},
+		Bus:     eventbustest.NewBus(t),
+	}, t.Logf)
+
+	const authID = "nodeid:8"
+	const token = "test-jwt-token"
+	logger.SetAuthID(authID)
+	logger.RegisterAuthToken(authID, func() string { return token })
+	io.WriteString(logger, "authed log")
+
+	got := <-uploaded
+	if want := "Bearer " + token; got.auth != want {
+		t.Errorf("Authorization = %q; want %q", got.auth, want)
+	}
+	if strings.Contains(string(got.body), "auth_id") {
+		t.Errorf("uploaded body still has auth_id: %s", got.body)
+	}
+	if !strings.Contains(string(got.body), "authed log") {
+		t.Errorf("uploaded body missing text: %s", got.body)
+	}
+
+	// Empty token: no Authorization header.
+	logger.SetAuthID("other")
+	logger.RegisterAuthToken("other", func() string { return "" })
+	io.WriteString(logger, "no auth")
+	got = <-uploaded
+	if got.auth != "" {
+		t.Errorf("expected no Authorization, got %q", got.auth)
+	}
+
+	if err := logger.Shutdown(context.Background()); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestRegisterAuthTokenNilClears(t *testing.T) {
+	lg := &Logger{}
+	lg.RegisterAuthToken("id", func() string { return "tok" })
+	if got := lg.lookupAuthToken("id"); got != "tok" {
+		t.Errorf("got %q; want tok", got)
+	}
+	lg.RegisterAuthToken("id", nil)
+	if got := lg.lookupAuthToken("id"); got != "" {
+		t.Errorf("after nil register got %q; want empty", got)
+	}
+}
+
 func TestNewLoggerDisabled(t *testing.T) { synctest.Test(t, synctestNewLoggerDisabled) }
 
 func synctestNewLoggerDisabled(t *testing.T) {
@@ -676,6 +816,7 @@ func TestAppendMetadata(t *testing.T) {
 		skipMetrics    bool
 		procID         uint32
 		procSeq        uint64
+		authID         string
 		errDetail      string
 		errData        jsontext.Value
 		level          int
@@ -689,15 +830,17 @@ func TestAppendMetadata(t *testing.T) {
 		{skipClientTime: true, skipMetrics: true, procSeq: 2, want: `"logtail":{"proc_seq":2},`},
 		{skipClientTime: true, skipMetrics: true, procID: 1, procSeq: 2, want: `"logtail":{"proc_id":1,"proc_seq":2},`},
 		{skipMetrics: true, procID: 1, procSeq: 2, want: `"logtail":{"client_time":"2000-01-01T00:00:00Z","proc_id":1,"proc_seq":2},`},
+		{skipClientTime: true, skipMetrics: true, authID: "nodeid:abc", want: `"logtail":{"auth_id":"nodeid:abc"},`},
+		{skipClientTime: true, skipMetrics: true, authID: `quote"and\slash`, want: `"logtail":{"auth_id":"quote\"and\\slash"},`},
 		{skipClientTime: true, skipMetrics: true, errDetail: "error", want: `"logtail":{"error":{"detail":"error"}},`},
 		{skipClientTime: true, skipMetrics: true, errData: jsontext.Value("null"), want: `"logtail":{"error":{"bad_data":null}},`},
 		{skipClientTime: true, skipMetrics: true, level: 5, want: `"v":5,`},
-		{procID: 1, procSeq: 2, errDetail: "error", errData: jsontext.Value(`["something","bad","happened"]`), level: 2,
-			want: `"logtail":{"client_time":"2000-01-01T00:00:00Z","proc_id":1,"proc_seq":2,"error":{"detail":"error","bad_data":["something","bad","happened"]}},"metrics":"metrics","v":2,`},
+		{procID: 1, procSeq: 2, authID: "nodeid:xyz", errDetail: "error", errData: jsontext.Value(`["something","bad","happened"]`), level: 2,
+			want: `"logtail":{"client_time":"2000-01-01T00:00:00Z","proc_id":1,"proc_seq":2,"auth_id":"nodeid:xyz","error":{"detail":"error","bad_data":["something","bad","happened"]}},"metrics":"metrics","v":2,`},
 	} {
-		got := string(lg.appendMetadata(nil, tt.skipClientTime, tt.skipMetrics, tt.procID, tt.procSeq, tt.errDetail, tt.errData, tt.level))
+		got := string(lg.appendMetadata(nil, tt.skipClientTime, tt.skipMetrics, tt.procID, tt.procSeq, tt.authID, tt.errDetail, tt.errData, tt.level))
 		if got != tt.want {
-			t.Errorf("appendMetadata(%v, %v, %v, %v, %v, %v, %v):\n\tgot  %s\n\twant %s", tt.skipClientTime, tt.skipMetrics, tt.procID, tt.procSeq, tt.errDetail, tt.errData, tt.level, got, tt.want)
+			t.Errorf("appendMetadata(%v, %v, %v, %v, %q, %v, %v, %v):\n\tgot  %s\n\twant %s", tt.skipClientTime, tt.skipMetrics, tt.procID, tt.procSeq, tt.authID, tt.errDetail, tt.errData, tt.level, got, tt.want)
 		}
 		gotObj := "{" + strings.TrimSuffix(got, ",") + "}"
 		if !jsontext.Value(gotObj).IsValid() {
@@ -717,23 +860,26 @@ func TestAppendText(t *testing.T) {
 		skipClientTime bool
 		procID         uint32
 		procSeq        uint64
+		authID         string
 		level          int
 		want           string
 	}{
 		{want: `{"logtail":{"client_time":"2000-01-01T00:00:00Z"},"metrics":"metrics"}`},
 		{skipClientTime: true, want: `{"metrics":"metrics"}`},
 		{skipClientTime: true, procID: 1, procSeq: 2, want: `{"logtail":{"proc_id":1,"proc_seq":2},"metrics":"metrics"}`},
+		{skipClientTime: true, authID: "nodeid:abc", want: `{"logtail":{"auth_id":"nodeid:abc"},"metrics":"metrics"}`},
 		{text: "fizz buzz", want: `{"logtail":{"client_time":"2000-01-01T00:00:00Z"},"metrics":"metrics","text":"fizz buzz"}`},
+		{text: "fizz buzz", authID: "nodeid:xyz", want: `{"logtail":{"client_time":"2000-01-01T00:00:00Z","auth_id":"nodeid:xyz"},"metrics":"metrics","text":"fizz buzz"}`},
 		{text: "\b\f\n\r\t\"\\", want: `{"logtail":{"client_time":"2000-01-01T00:00:00Z"},"metrics":"metrics","text":"\b\f\n\r\t\"\\"}`},
 		{text: "x" + strings.Repeat("😐", maxSize), want: `{"logtail":{"client_time":"2000-01-01T00:00:00Z"},"metrics":"metrics","text":"x` + strings.Repeat("😐", 1023) + `…+1044484"}`},
 	} {
-		got := string(lg.appendText(nil, []byte(tt.text), tt.skipClientTime, tt.procID, tt.procSeq, tt.level))
+		got := string(lg.appendText(nil, []byte(tt.text), tt.skipClientTime, tt.procID, tt.procSeq, tt.authID, tt.level))
 		if !strings.HasSuffix(got, "\n") {
 			t.Errorf("`%s` does not end with a newline", got)
 		}
 		got = got[:len(got)-1]
 		if got != tt.want {
-			t.Errorf("appendText(%v, %v, %v, %v, %v):\n\tgot  %s\n\twant %s", tt.text[:min(len(tt.text), 256)], tt.skipClientTime, tt.procID, tt.procSeq, tt.level, got, tt.want)
+			t.Errorf("appendText(%v, %v, %v, %v, %q, %v):\n\tgot  %s\n\twant %s", tt.text[:min(len(tt.text), 256)], tt.skipClientTime, tt.procID, tt.procSeq, tt.authID, tt.level, got, tt.want)
 		}
 		if !jsontext.Value(got).IsValid() {
 			t.Errorf("`%s`.IsValid() = false, want true", got)
@@ -748,14 +894,17 @@ func TestAppendTextOrJSON(t *testing.T) {
 	lg.lowMem = true
 
 	for _, tt := range []struct {
-		in    string
-		level int
-		want  string
+		in     string
+		authID string
+		level  int
+		want   string
 	}{
 		{want: `{"logtail":{"client_time":"2000-01-01T00:00:00Z"},"metrics":"metrics"}`},
 		{in: "[]", want: `{"logtail":{"client_time":"2000-01-01T00:00:00Z"},"metrics":"metrics","text":"[]"}`},
 		{level: 1, want: `{"logtail":{"client_time":"2000-01-01T00:00:00Z"},"metrics":"metrics","v":1}`},
 		{in: `{}`, want: `{"logtail":{"client_time":"2000-01-01T00:00:00Z"}}`},
+		{in: `{}`, authID: "nodeid:abc", want: `{"logtail":{"client_time":"2000-01-01T00:00:00Z","auth_id":"nodeid:abc"}}`},
+		{in: "hello", authID: "nodeid:abc", want: `{"logtail":{"client_time":"2000-01-01T00:00:00Z","auth_id":"nodeid:abc"},"metrics":"metrics","text":"hello"}`},
 		{in: `{}{}`, want: `{"logtail":{"client_time":"2000-01-01T00:00:00Z"},"metrics":"metrics","text":"{}{}"}`},
 		{in: "{\n\"fizz\"\n:\n\"buzz\"\n}", want: `{"logtail":{"client_time":"2000-01-01T00:00:00Z"},"fizz":"buzz"}`},
 		{in: `{ "logtail" : "duplicate" }`, want: `{"logtail":{"client_time":"2000-01-01T00:00:00Z","error":{"detail":"duplicate logtail member","bad_data":"duplicate"}}}`},
@@ -764,6 +913,7 @@ func TestAppendTextOrJSON(t *testing.T) {
 		{in: `{ "fizz" : "buzz" , "logtail" : "duplicate" , "wizz" : "wuzz" }`, want: `{"logtail":{"client_time":"2000-01-01T00:00:00Z","error":{"detail":"duplicate logtail member","bad_data":"duplicate"}}, "fizz" : "buzz" , "wizz" : "wuzz"}`},
 		{in: `{"long":"` + strings.Repeat("a", maxSize) + `"}`, want: `{"logtail":{"client_time":"2000-01-01T00:00:00Z","error":{"detail":"entry too large: 262155 bytes","bad_data":"{\"long\":\"` + strings.Repeat("a", 43681) + `…+218465"}}}`},
 	} {
+		lg.SetAuthID(tt.authID)
 		got := string(lg.appendTextOrJSONLocked(nil, []byte(tt.in), tt.level))
 		if !strings.HasSuffix(got, "\n") {
 			t.Errorf("`%s` does not end with a newline", got)
@@ -786,7 +936,7 @@ func TestAppendTextAllocs(t *testing.T) {
 	procID := uint32(0x24d32ee9)
 	procSequence := uint64(0x12346)
 	must.Do(tstest.MinAllocsPerRun(t, 0, func() {
-		sink = lg.appendText(sink[:0], inBuf, false, procID, procSequence, 0)
+		sink = lg.appendText(sink[:0], inBuf, false, procID, procSequence, "", 0)
 	}))
 }
 

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -189,7 +189,8 @@ type CapabilityVersion int
 //   - 140: 2026-05-27: Client understands [NodeAttrDisableUDPGRO], [NodeAttrDisableUDPGSO], [NodeAttrDisableTUNUDPGRO], [NodeAttrDisableTUNTCPGRO]
 //   - 141: 2026-05-28: Client understands [NodeAttrNeverGSOEqualTail]
 //   - 142: 2026-07-06: Client understands c2n /remoteapi/localapi/* proxy
-const CurrentCapabilityVersion CapabilityVersion = 142
+//   - 143: 2026-07-13: Client understands [NodeAttrLogUploadAuth] for authenticated log uploads
+const CurrentCapabilityVersion CapabilityVersion = 143
 
 // ID is an integer ID for a user, node, or login allocated by the
 // control plane.
@@ -2658,6 +2659,13 @@ const (
 
 	// NodeAttrLogExitFlows enables exit node destinations in network flow logs.
 	NodeAttrLogExitFlows NodeCapability = "log-exit-flows"
+
+	// NodeAttrLogUploadAuth specifies the HTTP Authorization token
+	// to use when uploading logs. The CapMap value is a JSON string containing
+	// the token. Control pushes a refreshed token via netmap CapMap updates before
+	// the previous token expires. The client caches the latest value and
+	// do not fetch refreshes themselves.
+	NodeAttrLogUploadAuth NodeCapability = "log-upload-auth"
 
 	// NodeAttrAutoExitNode permits the automatic exit nodes feature.
 	NodeAttrAutoExitNode NodeCapability = "auto-exit-node"

--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -935,6 +935,10 @@ func (s *Server) start() (reterr error) {
 	}
 	lb.SetTCPHandlerForFunnelFlow(s.getTCPHandlerForFunnelFlow)
 	lb.SetVarRoot(s.rootPath)
+	if s.logtail != nil {
+		lb.SetLogUploader(s.logtail)
+		lb.SetLogFlusher(s.logtail.StartFlush)
+	}
 	s.logf("tsnet starting with hostname %q, varRoot %q", s.hostname, s.rootPath)
 	s.lb = lb
 	if err := ns.Start(lb); err != nil {

--- a/wgengine/netlog/netlog.go
+++ b/wgengine/netlog/netlog.go
@@ -62,6 +62,11 @@ type NodeSource interface {
 	// its owning user profile.
 	// ok is false if no node is known to own addr.
 	NodeByAddr(addr netip.Addr) (node tailcfg.NodeView, user tailcfg.UserProfileView, ok bool)
+
+	// LogUploadAuth returns the opaque auth ID and a token function for
+	// authenticated log uploads. authID is empty when not in a tailnet
+	// context; authToken may be nil.
+	LogUploadAuth() (authID string, authToken func() string)
 }
 
 // Logger logs statistics about every connection.
@@ -164,6 +169,14 @@ func (nl *Logger) Startup(logf logger.Logf, source NodeSource, nodeLogID, domain
 		IncludeProcSequence: true,
 	}, logf)
 	logger.SetSockstatsLabel(sockstats.LabelNetlogLogger)
+
+	// Network flow logging is always tied to a single tailnet+node for the
+	// lifetime of this logger instance. Register auth once at construction;
+	// there is no need to clear it (the logger is shut down on identity change).
+	if authID, authToken := source.LogUploadAuth(); authID != "" {
+		logger.SetAuthID(authID)
+		logger.RegisterAuthToken(authID, authToken)
+	}
 
 	// Register the connection tracker into the TUN device.
 	tun = cmp.Or[Device](tun, noopDevice{})

--- a/wgengine/netlog/netlog_test.go
+++ b/wgengine/netlog/netlog_test.go
@@ -38,6 +38,8 @@ type fakeNodeSource struct {
 	byAddr   map[netip.Addr]nodeAndUser
 }
 
+func (s *fakeNodeSource) LogUploadAuth() (string, func() string) { return "", nil }
+
 func (s *fakeNodeSource) SelfNode() (tailcfg.NodeView, tailcfg.UserProfileView) {
 	return s.self, s.selfUser
 }

--- a/wgengine/netlog_hooks.go
+++ b/wgengine/netlog_hooks.go
@@ -35,6 +35,12 @@ type NetLogSource interface {
 	// along with whether exit node flows should be logged.
 	// ok is false if network flow logging should not run.
 	NetLogIDs() (nodeID, domainID logid.PrivateID, logExitFlows bool, ok bool)
+
+	// LogUploadAuth returns the opaque auth ID and a token function for
+	// authenticated log uploads (see logtail.Logger.SetAuthID and
+	// RegisterAuthToken). authID is empty when there is no self node;
+	// authToken may be nil.
+	LogUploadAuth() (authID string, authToken func() string)
 }
 
 // NetLogger is the engine's handle on the network flow logger


### PR DESCRIPTION
Control via tailcfg.NodeAttrLogUploadAuth may notify the node that there is an authorization token to use when uploading logs. If specified, then the logtail.Logger will use that token when uploading.

Unfortunately, there is a time-of-use and time-of-check discrepency that complicates logging. When logs are written under the context of being for a particular node, we cannot store the token, as it may be invalid by the time that the logs are uploaded.

Instead, we add Logger.SetAuthID to annotate subsequent log entries with an identifier for the token to later use.
Only when we upload do we strip out the auth ID, lookup the auth token to use, and then perform the upload.

We assume that control will notify the client of new tokens well before they expire. Fetching a refreshed token is not the job of the client.

Updates tailscale/corp#39092