### PR TITLE
derp/derpserver,cmd/derper: use slices.Clip for cert chain copies

### DIFF
--- a/cmd/derper/cert.go
+++ b/cmd/derper/cert.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"time"
 
 	"golang.org/x/crypto/acme"
@@ -158,10 +159,9 @@ func (m *manualCertManager) getCertificate(hi *tls.ClientHelloInfo) (*tls.Certif
 
 	// Return a shallow copy of the cert with a capacity-clamped chain
 	// so callers can never mutate the manager's long-lived certificate.
-	certCopy := new(tls.Certificate)
-	*certCopy = *m.cert
-	certCopy.Certificate = certCopy.Certificate[:len(certCopy.Certificate):len(certCopy.Certificate)]
-	return certCopy, nil
+	certCopy := *m.cert
+	certCopy.Certificate = slices.Clip(certCopy.Certificate)
+	return &certCopy, nil
 }
 
 func (m *manualCertManager) HTTPHandler(fallback http.Handler) http.Handler {

--- a/derp/derpserver/derpserver.go
+++ b/derp/derpserver/derpserver.go
@@ -744,8 +744,7 @@ func (s *Server) ModifyTLSConfigToAddMetaCert(c *tls.Config) {
 		// cached value. Return a shallow copy with the meta cert
 		// appended to a freshly allocated chain slice.
 		certCopy := *cert
-		chain := cert.Certificate
-		certCopy.Certificate = append(chain[:len(chain):len(chain)], s.MetaCert())
+		certCopy.Certificate = append(slices.Clip(cert.Certificate), s.MetaCert())
 		return &certCopy, nil
 	}
 }


### PR DESCRIPTION
Replace the hand-rolled three-index slice expressions with slices.Clip in ModifyTLSConfigToAddMetaCert and manualCertManager.getCertificate, per review feedback. No behavior change: slices.Clip is defined as s[:len(s):len(s)].

Updates #20352