### PR TITLE
.github: double the timeout for `go vet` in CI

### DIFF
--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   vet:
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     steps:
       - name: Check out code


### PR DESCRIPTION
The job is consistently failing on main when it hits the 5 minute timeout; let's double it to get useful results.

Updates #cleanup