### PR TITLE
k8s-operator/reconciler: add metrics & logging for PeerRelay

### DIFF
--- a/k8s-operator/reconciler/peerrelay/peerrelay.go
+++ b/k8s-operator/reconciler/peerrelay/peerrelay.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"sync"
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -31,6 +32,8 @@ import (
 	"tailscale.com/k8s-operator/reconciler"
 	"tailscale.com/kube/kubetypes"
 	"tailscale.com/tstime"
+	"tailscale.com/util/clientmetric"
+	"tailscale.com/util/set"
 )
 
 type (
@@ -42,6 +45,10 @@ type (
 		tailscaleNamespace string
 		logger             *zap.SugaredLogger
 		clock              tstime.Clock
+
+		// Metrics related fields
+		mu         sync.Mutex
+		peerRelays set.Slice[types.UID]
 	}
 
 	// The ReconcilerOptions type contains configuration values for the Reconciler.
@@ -65,6 +72,12 @@ const (
 	ReasonEndpointsInvalid = "EndpointsInvalid"
 	ReasonEndpointsPending = "EndpointsPending"
 	ReasonReady            = "PeerRelayReady"
+)
+
+var (
+	// gaugePeerRelayResources tracks the overall number of PeerRelay resources currently managed by this operator
+	// instance.
+	gaugePeerRelayResources = clientmetric.NewGauge(kubetypes.MetricPeerRelayCount)
 )
 
 // NewReconciler returns a new instance of the Reconciler type. It watches specifically for changes to PeerRelay
@@ -113,27 +126,40 @@ func enqueuePeerRelayForService(_ context.Context, o client.Object) []reconcile.
 // one LoadBalancer Service exists per replica. On delete, all managed Services are removed before the finalizer is
 // released.
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	logger := r.logger.With("PeerRelay", req.Name)
+	logger.Debug("starting reconcile")
+	defer logger.Debug("reconcile finished")
+
 	var pr tsapi.PeerRelay
 	err := r.Get(ctx, req.NamespacedName, &pr)
 	switch {
 	case apierrors.IsNotFound(err):
+		logger.Debug("PeerRelay not found, assuming it was deleted")
 		return reconcile.Result{}, nil
 	case err != nil:
 		return reconcile.Result{}, fmt.Errorf("failed to get PeerRelay %q: %w", req.NamespacedName, err)
 	}
 
 	if !pr.DeletionTimestamp.IsZero() {
-		return r.delete(ctx, &pr)
+		return r.delete(ctx, logger, &pr)
 	}
 
-	return r.createOrUpdate(ctx, &pr)
+	return r.createOrUpdate(ctx, logger, &pr)
 }
 
-func (r *Reconciler) createOrUpdate(ctx context.Context, pr *tsapi.PeerRelay) (reconcile.Result, error) {
+func (r *Reconciler) createOrUpdate(ctx context.Context, logger *zap.SugaredLogger, pr *tsapi.PeerRelay) (reconcile.Result, error) {
 	reconciler.SetFinalizer(pr)
 	if err := r.Update(ctx, pr); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to add finalizer to PeerRelay %q: %w", pr.Name, err)
 	}
+
+	r.mu.Lock()
+	if !r.peerRelays.Contains(pr.UID) {
+		r.peerRelays.Add(pr.UID)
+		logger.Infof("now managing PeerRelay %q", pr.Name)
+	}
+	r.mu.Unlock()
+	gaugePeerRelayResources.Set(int64(r.peerRelays.Len()))
 
 	replicas := int32(1)
 	if pr.Spec.Replicas != nil {
@@ -142,23 +168,23 @@ func (r *Reconciler) createOrUpdate(ctx context.Context, pr *tsapi.PeerRelay) (r
 
 	for i := int32(0); i < replicas; i++ {
 		desired := r.peerRelayService(pr, i)
-		if err := r.ensureService(ctx, desired); err != nil {
+		if err := r.ensureService(ctx, logger, desired); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to apply Service %q: %w", desired.Name, err)
 		}
 	}
 
-	if err := r.deleteServicesFrom(ctx, pr, replicas); err != nil {
+	if err := r.deleteServicesFrom(ctx, logger, pr, replicas); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to clean up scaled-down Services for PeerRelay %q: %w", pr.Name, err)
 	}
 
-	if err := r.updateEndpoints(ctx, pr, replicas); err != nil {
+	if err := r.updateEndpoints(ctx, logger, pr, replicas); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to update endpoints for PeerRelay %q: %w", pr.Name, err)
 	}
 
 	return reconcile.Result{}, nil
 }
 
-func (r *Reconciler) updateEndpoints(ctx context.Context, pr *tsapi.PeerRelay, replicas int32) error {
+func (r *Reconciler) updateEndpoints(ctx context.Context, logger *zap.SugaredLogger, pr *tsapi.PeerRelay, replicas int32) error {
 	var list corev1.ServiceList
 	if err := r.List(ctx, &list, client.InNamespace(r.tailscaleNamespace), client.MatchingLabels(peerRelayLabels(pr.Name))); err != nil {
 		return fmt.Errorf("failed to list Services: %w", err)
@@ -189,12 +215,12 @@ func (r *Reconciler) updateEndpoints(ctx context.Context, pr *tsapi.PeerRelay, r
 	joined := errors.Join(errs...)
 	switch {
 	case len(errs) > 0:
-		operatorutils.SetPeerRelayCondition(pr, tsapi.PeerRelayReady, metav1.ConditionFalse, ReasonEndpointsInvalid, joined.Error(), r.clock, r.logger)
+		operatorutils.SetPeerRelayCondition(pr, tsapi.PeerRelayReady, metav1.ConditionFalse, ReasonEndpointsInvalid, joined.Error(), r.clock, logger)
 	case int32(len(endpoints)) < replicas:
 		message := fmt.Sprintf("%d of %d replicas have a public IP", len(endpoints), replicas)
-		operatorutils.SetPeerRelayCondition(pr, tsapi.PeerRelayReady, metav1.ConditionFalse, ReasonEndpointsPending, message, r.clock, r.logger)
+		operatorutils.SetPeerRelayCondition(pr, tsapi.PeerRelayReady, metav1.ConditionFalse, ReasonEndpointsPending, message, r.clock, logger)
 	default:
-		operatorutils.SetPeerRelayCondition(pr, tsapi.PeerRelayReady, metav1.ConditionTrue, ReasonReady, ReasonReady, r.clock, r.logger)
+		operatorutils.SetPeerRelayCondition(pr, tsapi.PeerRelayReady, metav1.ConditionTrue, ReasonReady, ReasonReady, r.clock, logger)
 	}
 
 	if err := r.Status().Update(ctx, pr); err != nil {
@@ -204,8 +230,10 @@ func (r *Reconciler) updateEndpoints(ctx context.Context, pr *tsapi.PeerRelay, r
 	return joined
 }
 
-func (r *Reconciler) delete(ctx context.Context, pr *tsapi.PeerRelay) (reconcile.Result, error) {
-	if err := r.deleteServicesFrom(ctx, pr, 0); err != nil {
+func (r *Reconciler) delete(ctx context.Context, logger *zap.SugaredLogger, pr *tsapi.PeerRelay) (reconcile.Result, error) {
+	logger.Infof("deleting PeerRelay %q", pr.Name)
+
+	if err := r.deleteServicesFrom(ctx, logger, pr, 0); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to delete Services for PeerRelay %q: %w", pr.Name, err)
 	}
 
@@ -214,14 +242,20 @@ func (r *Reconciler) delete(ctx context.Context, pr *tsapi.PeerRelay) (reconcile
 		return reconcile.Result{}, fmt.Errorf("failed to remove finalizer from PeerRelay %q: %w", pr.Name, err)
 	}
 
+	r.mu.Lock()
+	r.peerRelays.Remove(pr.UID)
+	r.mu.Unlock()
+	gaugePeerRelayResources.Set(int64(r.peerRelays.Len()))
+
 	return reconcile.Result{}, nil
 }
 
-func (r *Reconciler) ensureService(ctx context.Context, desired *corev1.Service) error {
+func (r *Reconciler) ensureService(ctx context.Context, logger *zap.SugaredLogger, desired *corev1.Service) error {
 	var existing corev1.Service
 	err := r.Get(ctx, types.NamespacedName{Namespace: desired.Namespace, Name: desired.Name}, &existing)
 	switch {
 	case apierrors.IsNotFound(err):
+		logger.Debugf("creating Service %q", desired.Name)
 		if err = r.Create(ctx, desired); err != nil {
 			return fmt.Errorf("failed to create Service: %w", err)
 		}
@@ -245,7 +279,7 @@ func (r *Reconciler) ensureService(ctx context.Context, desired *corev1.Service)
 	return nil
 }
 
-func (r *Reconciler) deleteServicesFrom(ctx context.Context, pr *tsapi.PeerRelay, fromIdx int32) error {
+func (r *Reconciler) deleteServicesFrom(ctx context.Context, logger *zap.SugaredLogger, pr *tsapi.PeerRelay, fromIdx int32) error {
 	var list corev1.ServiceList
 	if err := r.List(ctx, &list, client.InNamespace(r.tailscaleNamespace), client.MatchingLabels(peerRelayLabels(pr.Name))); err != nil {
 		return fmt.Errorf("failed to list Services: %w", err)
@@ -258,6 +292,7 @@ func (r *Reconciler) deleteServicesFrom(ctx context.Context, pr *tsapi.PeerRelay
 			continue
 		}
 
+		logger.Debugf("deleting Service %q", svc.Name)
 		if err := r.Delete(ctx, svc); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to delete Service %q: %w", svc.Name, err)
 		}

--- a/kube/kubetypes/types.go
+++ b/kube/kubetypes/types.go
@@ -34,6 +34,7 @@ const (
 	MetricProxyGroupIngressCount         = "k8s_proxygroup_ingress_resources"
 	MetricProxyGroupAPIServerCount       = "k8s_proxygroup_kube_apiserver_resources"
 	MetricTailnetCount                   = "k8s_tailnet_resources"
+	MetricPeerRelayCount                 = "k8s_peerrelay_resources"
 
 	// Keys that containerboot writes to state file that can be used to determine its state.
 	// fields set in Tailscale state Secret. These are mostly used by the Tailscale Kubernetes operator to determine


### PR DESCRIPTION
This commit modifies the `PeerRelay` reconciler to use a logger annotated with the name of the `PeerRelay` resource that has been modified. It also includes a gauge metric for the number of `PeerRelay` CRDs that have been deployed.

Updates: https://github.com/tailscale/corp/issues/34524