### PR TITLE
scripts/installer.sh: remove an unused PACKAGE_NAME variable

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -534,7 +534,6 @@ main() {
 	[ "$VERSION" != "" ] && OSVERSION="$OSVERSION $VERSION"
 
 	# Prepare package name with optional version
-	PACKAGE_NAME="tailscale"
 	if [ -n "$TAILSCALE_VERSION" ]; then
 		echo "Installing Tailscale $TAILSCALE_VERSION for $OSVERSION, using method $PACKAGETYPE"
 	else


### PR DESCRIPTION
This variable wasn't used in the commit when it was introduced (bd5c509).

Fixes #19841