### PR TITLE
feature/conn25: send ICMP errors back to sources

### DIFF
--- a/feature/conn25/conn25.go
+++ b/feature/conn25/conn25.go
@@ -205,11 +205,11 @@ func (e *extension) installHooks(dph *datapathHandler) error {
 
 	// Intercept packets from the tun device and from WireGuard
 	// to perform DNAT and SNAT.
-	tun.PreFilterPacketOutboundToWireGuardAppConnectorIntercept = func(p *packet.Parsed, _ *tstun.Wrapper) filter.Response {
+	tun.PreFilterPacketOutboundToWireGuardAppConnectorIntercept = func(p *packet.Parsed, tun *tstun.Wrapper) filter.Response {
 		if !e.conn25.isConfigured() {
 			return filter.Accept
 		}
-		return dph.HandlePacketFromTunDevice(p)
+		return dph.HandlePacketFromTunDevice(p, tun)
 	}
 	tun.PostFilterPacketInboundFromWireGuardAppConnector = func(p *packet.Parsed, tun *tstun.Wrapper) filter.Response {
 		if !e.conn25.isConfigured() {

--- a/feature/conn25/datapath.go
+++ b/feature/conn25/datapath.go
@@ -204,7 +204,7 @@ func (dh *datapathHandler) HandlePacketFromWireGuard(p *packet.Parsed, tun *tstu
 // that the packet should pass through subsequent stages of the datapath pipeline.
 // Returning [filter.Drop] signals the packet should be dropped. This method handles all
 // packets coming from the tun device, on both connectors, and clients of connectors.
-func (dh *datapathHandler) HandlePacketFromTunDevice(p *packet.Parsed) filter.Response {
+func (dh *datapathHandler) HandlePacketFromTunDevice(p *packet.Parsed, tun *tstun.Wrapper) filter.Response {
 	if !isSupportedProtocol(p.IPProto) {
 		return filter.Accept
 	}
@@ -233,7 +233,9 @@ func (dh *datapathHandler) HandlePacketFromTunDevice(p *packet.Parsed) filter.Re
 	transitIP, err := dh.conn25.ClientTransitIPForMagicIP(magicIP)
 	if err != nil {
 		if errors.Is(err, ErrUnmappedMagicIP) {
-			// TODO(tailscale/corp#34257): This path should deliver an ICMP error to the client.
+			// Couldn't find a mapping. Tell the local application the host is
+			// unreachable so it can recover quickly instead of blackholing.
+			dh.sendICMPHostUnreachable(p, tun)
 			return filter.Drop
 		}
 		dh.debugLogf("error mapping magic IP, passing packet unmodified: %v", err)
@@ -271,6 +273,22 @@ func (dh *datapathHandler) HandlePacketFromTunDevice(p *packet.Parsed) filter.Re
 	})
 	outgoing.Action(p)
 	return filter.Accept
+}
+
+// sendICMPHostUnreachable injects an ICMP "host unreachable" error (or its IPv6
+// equivalent, "address unreachable") back to the local host in response to the
+// tun-device packet p. The error is delivered inbound so the local
+// application that sent p sees it, giving it the chance to recover.
+func (dh *datapathHandler) sendICMPHostUnreachable(p *packet.Parsed, tun *tstun.Wrapper) {
+	// The error appears to come from the unreachable Magic IP, addressed back to
+	// the sender, and embeds data from the invoking packet.
+	errPkt := packet.GenerateICMPHostUnreachable(p.Dst.Addr(), p.Src.Addr(), p)
+	if errPkt == nil {
+		return
+	}
+	if err := tun.InjectInboundCopy(errPkt); err != nil {
+		dh.debugLogf("error injecting ICMP host unreachable packet: %v", err)
+	}
 }
 
 func (dh *datapathHandler) dnatAction(to netip.Addr) PacketAction {

--- a/feature/conn25/datapath_test.go
+++ b/feature/conn25/datapath_test.go
@@ -8,7 +8,9 @@ import (
 	"errors"
 	"net/netip"
 	"testing"
+	"time"
 
+	"github.com/tailscale/wireguard-go/tun/tuntest"
 	"go4.org/netipx"
 	"tailscale.com/net/packet"
 	"tailscale.com/net/tstun"
@@ -123,12 +125,14 @@ func TestHandlePacketFromTunDevice(t *testing.T) {
 				return netip.Addr{}, nil
 			}
 			dph := newDatapathHandler(mock, t.Logf)
+			tun := newFakeTUN(t)
+			defer tun.Close()
 
 			tt.p.IPProto = ipproto.UDP
 			tt.p.IPVersion = 4
 			tt.p.StuffForTesting(40)
 
-			if want, got := tt.expectedFilterResponse, dph.HandlePacketFromTunDevice(tt.p); want != got {
+			if want, got := tt.expectedFilterResponse, dph.HandlePacketFromTunDevice(tt.p, tun); want != got {
 				t.Errorf("unexpected filter response: want %v, got %v", want, got)
 			}
 			if want, got := tt.expectedSrc, tt.p.Src; want != got {
@@ -136,6 +140,95 @@ func TestHandlePacketFromTunDevice(t *testing.T) {
 			}
 			if want, got := tt.expectedDst, tt.p.Dst; want != got {
 				t.Errorf("unexpected packet dst: want %v, got %v", want, got)
+			}
+		})
+	}
+}
+
+// TestUnmappedMagicIPICMPUnreachable verifies that a packet to a Magic IP with
+// no active Transit IP mapping is dropped and an ICMP host-unreachable error is
+// injected back toward the local host, sourced from the Magic IP and addressed
+// to the original sender.
+func TestUnmappedMagicIPICMPUnreachable(t *testing.T) {
+	const clientPort, serverPort = 1234, 80
+
+	tests := []struct {
+		name        string
+		clientSrcIP netip.Addr
+		magicIP     netip.Addr
+		wantProto   ipproto.Proto
+	}{
+		{
+			name:        "ipv4",
+			clientSrcIP: netip.MustParseAddr("100.70.0.1"),
+			magicIP:     netip.MustParseAddr("10.64.0.2"),
+			wantProto:   ipproto.ICMPv4,
+		},
+		{
+			name:        "ipv6",
+			clientSrcIP: netip.MustParseAddr("fd7a:115c:a1e0::1"),
+			magicIP:     netip.MustParseAddr("fd7a:115c:a1e0::2"),
+			wantProto:   ipproto.ICMPv6,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &testConn25{}
+			mock.clientTransitIPForMagicIPFn = func(netip.Addr) (netip.Addr, error) {
+				return netip.Addr{}, ErrUnmappedMagicIP
+			}
+			dph := newDatapathHandler(mock, t.Logf)
+			chtun, tun := newChannelTUN(t)
+			defer tun.Close()
+
+			var raw []byte
+			if tt.magicIP.Is6() {
+				raw = packet.Generate(packet.UDP6Header{
+					IP6Header: packet.IP6Header{Src: tt.clientSrcIP, Dst: tt.magicIP},
+					SrcPort:   clientPort,
+					DstPort:   serverPort,
+				}, []byte("hello"))
+			} else {
+				raw = packet.Generate(packet.UDP4Header{
+					IP4Header: packet.IP4Header{Src: tt.clientSrcIP, Dst: tt.magicIP},
+					SrcPort:   clientPort,
+					DstPort:   serverPort,
+				}, []byte("x"))
+			}
+			var p packet.Parsed
+			p.Decode(raw)
+
+			// HandlePacketFromTunDevice blocks until the injected packet is
+			// read, so drain the channel TUN concurrently.
+			gotInboundPacketChan := make(chan []byte, 1)
+			go func() { gotInboundPacketChan <- <-chtun.Inbound }()
+
+			if got, want := dph.HandlePacketFromTunDevice(&p, tun), filter.Drop; got != want {
+				t.Fatalf("unexpected filter response: got %v, want %v", got, want)
+			}
+
+			var injected packet.Parsed
+			select {
+			case b := <-gotInboundPacketChan:
+				injected.Decode(b)
+			case <-time.After(1 * time.Second):
+				t.Fatal("timed out waiting for injected ICMP packet")
+			}
+
+			if !injected.IsError() {
+				t.Errorf("injected packet is not an ICMP error")
+			}
+			if got := injected.IPProto; got != tt.wantProto {
+				t.Errorf("injected packet proto: got %v, want %v", got, tt.wantProto)
+			}
+			// The error should appear to come from the unreachable Magic IP,
+			// addressed back to the original sender.
+			if got, want := injected.Src.Addr(), tt.magicIP; got != want {
+				t.Errorf("injected packet src: got %v, want %v", got, want)
+			}
+			if got, want := injected.Dst.Addr(), tt.clientSrcIP; got != want {
+				t.Errorf("injected packet dst: got %v, want %v", got, want)
 			}
 		})
 	}
@@ -172,6 +265,40 @@ func newFakeTUN(t *testing.T) *tstun.Wrapper {
 	// Start the TUN device.
 	tun.Start()
 	return tun
+}
+
+// newChannelTUN is like newFakeTUN, but backed by a channel-based TUN device
+// whose Inbound queue captures packets injected toward the local host (e.g. via
+// InjectInboundCopy), so tests can observe them.
+func newChannelTUN(t *testing.T) (*tuntest.ChannelTUN, *tstun.Wrapper) {
+	t.Helper()
+
+	chtun := tuntest.NewChannelTUN()
+	reg := new(usermetric.Registry)
+	bus := eventbustest.NewBus(t)
+	tun := tstun.Wrap(t.Logf, chtun.TUN(), reg, bus)
+
+	protos := views.SliceOf([]ipproto.Proto{
+		ipproto.TCP,
+		ipproto.UDP,
+		ipproto.ICMPv4,
+		ipproto.ICMPv6,
+	})
+	allIPs := netip.MustParsePrefix("0.0.0.0/0")
+	matches := []filter.Match{
+		{
+			IPProto: protos,
+			Srcs:    []netip.Prefix{allIPs},
+			Dsts:    []filtertype.NetPortRange{{Net: allIPs, Ports: filtertype.AllPorts}},
+		},
+	}
+	var sb netipx.IPSetBuilder
+	sb.AddPrefix(allIPs)
+	ipSet, _ := sb.IPSet()
+	tun.SetFilter(filter.New(matches, nil, ipSet, ipSet, nil, t.Logf))
+
+	tun.Start()
+	return chtun, tun
 }
 
 func TestHandlePacketFromWireGuard(t *testing.T) {
@@ -325,6 +452,8 @@ func TestClientFlowCache(t *testing.T) {
 		return transitIP, nil
 	}
 	dph := newDatapathHandler(mock, t.Logf)
+	tun := newFakeTUN(t)
+	defer tun.Close()
 
 	outgoing := packet.Parsed{
 		IPProto:   ipproto.UDP,
@@ -335,7 +464,7 @@ func TestClientFlowCache(t *testing.T) {
 	outgoing.StuffForTesting(40)
 
 	o1 := outgoing
-	if dph.HandlePacketFromTunDevice(&o1) != filter.Accept {
+	if dph.HandlePacketFromTunDevice(&o1, tun) != filter.Accept {
 		t.Errorf("first call to HandlePacketFromTunDevice was not accepted")
 	}
 	if want, got := netip.AddrPortFrom(transitIP, serverPort), o1.Dst; want != got {
@@ -343,7 +472,7 @@ func TestClientFlowCache(t *testing.T) {
 	}
 	// The second call should use the cache.
 	o2 := outgoing
-	if dph.HandlePacketFromTunDevice(&o2) != filter.Accept {
+	if dph.HandlePacketFromTunDevice(&o2, tun) != filter.Accept {
 		t.Errorf("second call to HandlePacketFromTunDevice was not accepted")
 	}
 	if want, got := netip.AddrPortFrom(transitIP, serverPort), o2.Dst; want != got {
@@ -359,9 +488,6 @@ func TestClientFlowCache(t *testing.T) {
 		Dst:       netip.AddrPortFrom(clientSrcIP, clientPort),
 	}
 	incoming.StuffForTesting(40)
-
-	tun := newFakeTUN(t)
-	defer tun.Close()
 
 	if dph.HandlePacketFromWireGuard(incoming, tun) != filter.Accept {
 		t.Errorf("call to HandlePacketFromWireGuard was not accepted")
@@ -428,7 +554,7 @@ func TestConnectorFlowCache(t *testing.T) {
 	}
 	incoming.StuffForTesting(40)
 
-	if dph.HandlePacketFromTunDevice(incoming) != filter.Accept {
+	if dph.HandlePacketFromTunDevice(incoming, tun) != filter.Accept {
 		t.Errorf("call to HandlePacketFromTunDevice was not accepted")
 	}
 	if want, got := netip.AddrPortFrom(transitIP, serverPort), incoming.Src; want != got {

--- a/net/packet/icmp.go
+++ b/net/packet/icmp.go
@@ -7,6 +7,7 @@ import (
 	crand "crypto/rand"
 
 	"encoding/binary"
+	"net/netip"
 )
 
 // ICMPEchoPayload generates a new random ID/Sequence pair, and returns a uint32
@@ -25,4 +26,65 @@ func ICMPEchoPayload(payload []byte) (idSeq uint32, buf []byte) {
 	copy(buf[4:], payload)
 
 	return
+}
+
+// icmpDestUnreachableUnusedLen is the number of unused bytes that both ICMPv4
+// and ICMPv6 "Destination Unreachable" messages have between header and bits
+// from the invoking packet.
+const icmpDestUnreachableUnusedLen = 4
+const minIPv6MTU = 1280 // RFC 2460, section 5
+
+// GenerateICMPHostUnreachable builds an ICMPv4 or ICMPv6 "Destination
+// Unreachable" message according to RFC 792 and RFC 4443, section 3.1.
+// from and to must both be of the same address family; otherwise
+// GenerateICMPHostUnreachable returns nil.
+func GenerateICMPHostUnreachable(from, to netip.Addr, invoking *Parsed) []byte {
+	buf := invoking.Buffer()
+	switch {
+	case from.Is4() && to.Is4():
+		// RFC 792
+		//     0                   1                   2                   3
+		//  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+		// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+		// |     Type      |     Code      |          Checksum             |
+		// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+		// |                             unused                            |
+		// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+		// |      Internet Header + 64 bits of Original Data Datagram      |
+		// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+		ipHeaderLen := len(buf) - len(invoking.Transport())
+		return Generate(ICMP4Header{
+			IP4Header: IP4Header{Src: from, Dst: to},
+			Type:      ICMP4Unreachable,
+			Code:      ICMP4HostUnreachable,
+		}, icmpDestUnreachablePayload(buf, ipHeaderLen+8))
+	case from.Is6() && to.Is6():
+		// RFC 4443, section 3.1
+		//        0                   1                   2                   3
+		//  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+		// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+		// |     Type      |     Code      |          Checksum             |
+		// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+		// |                             Unused                            |
+		// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+		// |                    As much of invoking packet                 |
+		// +                as possible without the ICMPv6 packet          +
+		// |                exceeding the minimum IPv6 MTU                 |
+		maxOrig := minIPv6MTU - (ICMP6Header{}).Len() - icmpDestUnreachableUnusedLen
+		return Generate(ICMP6Header{
+			IP6Header: IP6Header{Src: from, Dst: to},
+			Type:      ICMP6Unreachable,
+			Code:      ICMP6AddressUnreachable,
+		}, icmpDestUnreachablePayload(buf, maxOrig))
+	default:
+		return nil
+	}
+}
+
+// icmpDestUnreachablePayload composes the payload for an ICMP "Destination Unreachable" packet.
+func icmpDestUnreachablePayload(orig []byte, maxOrig int) []byte {
+	n := min(len(orig), maxOrig)
+	payload := make([]byte, icmpDestUnreachableUnusedLen+n)
+	copy(payload[icmpDestUnreachableUnusedLen:], orig[:n])
+	return payload
 }

--- a/net/packet/icmp4.go
+++ b/net/packet/icmp4.go
@@ -49,6 +49,10 @@ type ICMP4Code uint8
 
 const (
 	ICMP4NoCode ICMP4Code = 0
+
+	// ICMP4HostUnreachable is the code used with ICMP4Unreachable to
+	// indicate that the destination host could not be reached.
+	ICMP4HostUnreachable ICMP4Code = 1
 )
 
 // ICMP4Header is an IPv4+ICMPv4 header.

--- a/net/packet/icmp6.go
+++ b/net/packet/icmp6.go
@@ -52,6 +52,11 @@ type ICMP6Code uint8
 
 const (
 	ICMP6NoCode ICMP6Code = 0
+
+	// ICMP6AddressUnreachable is the code used with ICMP6Unreachable to
+	// indicate that the destination address could not be reached. It is
+	// the IPv6 equivalent of ICMP4HostUnreachable.
+	ICMP6AddressUnreachable ICMP6Code = 3
 )
 
 // ICMP6Header is an IPv4+ICMPv4 header.

--- a/net/packet/icmp_test.go
+++ b/net/packet/icmp_test.go
@@ -1,0 +1,190 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package packet
+
+import (
+	"bytes"
+	"net/netip"
+	"testing"
+
+	"tailscale.com/types/ipproto"
+)
+
+func TestGenerateICMPHostUnreachable(t *testing.T) {
+	const (
+		clientPort = 1234
+		serverPort = 80
+	)
+
+	makeInvokingPacket := func(src, dst netip.Addr, payloadLen int) *Parsed {
+		udpPayload := bytes.Repeat([]byte("x"), payloadLen)
+		var invoking []byte
+		if dst.Is6() {
+			invoking = Generate(UDP6Header{
+				IP6Header: IP6Header{Src: src, Dst: dst},
+				SrcPort:   clientPort,
+				DstPort:   serverPort,
+			}, udpPayload)
+		} else {
+			invoking = Generate(UDP4Header{
+				IP4Header: IP4Header{Src: src, Dst: dst},
+				SrcPort:   clientPort,
+				DstPort:   serverPort,
+			}, udpPayload)
+		}
+		var invokingPacket Parsed
+		invokingPacket.Decode(invoking)
+		return &invokingPacket
+	}
+
+	maxEmbeddedV4Length := 28 // IP header (20) + 64 bits (8) of original data datagram
+	// As much of the packet as fits in min IPv6 MTU, which is
+	// 1280 - 40 (IPv6 header) - 4 (ICMPv6 header) - 4 (unused).
+	maxEmbeddedV6Length := minIPv6MTU - 40 - 4 - 4
+
+	tests := []struct {
+		name           string
+		invokingPacket *Parsed
+		wantProto      ipproto.Proto
+		wantType       uint8
+		wantCode       uint8
+		fitsWhole      bool
+	}{
+		{
+			name: "ipv4-fits-whole",
+			invokingPacket: makeInvokingPacket(
+				netip.MustParseAddr("100.70.0.1"),
+				netip.MustParseAddr("10.64.0.2"),
+				0,
+			),
+			wantProto: ipproto.ICMPv4,
+			wantType:  uint8(ICMP4Unreachable),
+			wantCode:  uint8(ICMP4HostUnreachable),
+			fitsWhole: true,
+		},
+		{
+			name: "ipv4-truncated-to-ip-header-plus-8",
+			invokingPacket: makeInvokingPacket(
+				netip.MustParseAddr("100.70.0.1"),
+				netip.MustParseAddr("10.64.0.2"),
+				100,
+			),
+			wantProto: ipproto.ICMPv4,
+			wantType:  uint8(ICMP4Unreachable),
+			wantCode:  uint8(ICMP4HostUnreachable),
+		},
+		{
+			name: "ipv6-fits-whole",
+			invokingPacket: makeInvokingPacket(
+				netip.MustParseAddr("fd7a:115c:a1e0::1"),
+				netip.MustParseAddr("fd7a:115c:a1e0::2"),
+				5,
+			),
+			wantProto: ipproto.ICMPv6,
+			wantType:  uint8(ICMP6Unreachable),
+			wantCode:  uint8(ICMP6AddressUnreachable),
+			fitsWhole: true,
+		},
+		{
+			name: "ipv6-truncated-to-min-mtu",
+			invokingPacket: makeInvokingPacket(
+				netip.MustParseAddr("fd7a:115c:a1e0::1"),
+				netip.MustParseAddr("fd7a:115c:a1e0::2"),
+				minIPv6MTU*2,
+			),
+			wantProto: ipproto.ICMPv6,
+			wantType:  uint8(ICMP6Unreachable),
+			wantCode:  uint8(ICMP6AddressUnreachable),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iDst := tt.invokingPacket.Dst.Addr()
+			iSrc := tt.invokingPacket.Src.Addr()
+			// Error message's src is invoking dst and vice-versa.
+			raw := GenerateICMPHostUnreachable(iDst, iSrc, tt.invokingPacket)
+			if raw == nil {
+				t.Fatal("GenerateICMPHostUnreachable returned nil")
+			}
+
+			var p Parsed
+			p.Decode(raw)
+
+			if !p.IsError() {
+				t.Fatal("wanted an ICMP error")
+			}
+			if got := p.IPProto; got != tt.wantProto {
+				t.Errorf("proto: got %v, want %v", got, tt.wantProto)
+			}
+			if want, got := iDst, p.Src.Addr(); want != got {
+				t.Errorf("src: got %v, want %v", got, want)
+			}
+			if want, got := iSrc, p.Dst.Addr(); want != got {
+				t.Errorf("dst: got %v, want %v", got, want)
+			}
+			var gotType, gotCode uint8
+			if iDst.Is6() {
+				h := p.ICMP6Header()
+				gotType, gotCode = uint8(h.Type), uint8(h.Code)
+			} else {
+				h := p.ICMP4Header()
+				gotType, gotCode = uint8(h.Type), uint8(h.Code)
+			}
+			if gotType != tt.wantType || gotCode != tt.wantCode {
+				t.Errorf("type/code: got %d/%d, want %d/%d", gotType, gotCode, tt.wantType, tt.wantCode)
+			}
+
+			// The ICMP body must be a 4-byte zeroed "unused" field followed by
+			// the embedded invoking packet.
+			body := p.Payload()
+			if len(body) < icmpDestUnreachableUnusedLen {
+				t.Fatalf("ICMP body too short: %d bytes", len(body))
+			}
+			if unused := body[:icmpDestUnreachableUnusedLen]; !bytes.Equal(unused, make([]byte, icmpDestUnreachableUnusedLen)) {
+				t.Errorf("unused field: got % x, want all zero", unused)
+			}
+			embedded := body[icmpDestUnreachableUnusedLen:]
+			if !bytes.HasPrefix(tt.invokingPacket.b, embedded) {
+				t.Errorf("embedded packet is not a prefix of the invoking packet:\n embedded=% x\n orig=% x", embedded, tt.invokingPacket.b[:min(len(tt.invokingPacket.b), len(embedded))])
+			}
+			if !tt.fitsWhole {
+				// embedded should be truncated to the max
+				wantLen := maxEmbeddedV4Length
+				if iSrc.Is6() {
+					wantLen = maxEmbeddedV6Length
+				}
+				if len(embedded) != wantLen {
+					t.Errorf("embedded length: got %d, want %d (orig %d)", len(embedded), wantLen, len(tt.invokingPacket.b))
+				}
+			} else {
+				// should decode to the invoking packet
+				var orig Parsed
+				orig.Decode(embedded)
+				if got := orig.IPProto; got != ipproto.UDP {
+					t.Errorf("embedded proto: got %v, want UDP", got)
+				}
+				if want, got := netip.AddrPortFrom(iSrc, clientPort), orig.Src; want != got {
+					t.Errorf("embedded src: got %v, want %v", got, want)
+				}
+				if want, got := netip.AddrPortFrom(iDst, serverPort), orig.Dst; want != got {
+					t.Errorf("embedded dst: got %v, want %v", got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateICMPHostUnreachableMixedFamily(t *testing.T) {
+	v4 := netip.MustParseAddr("100.70.0.1")
+	v6 := netip.MustParseAddr("fd7a:115c:a1e0::1")
+
+	var empty Parsed
+	if got := GenerateICMPHostUnreachable(v4, v6, &empty); got != nil {
+		t.Errorf("mixed family: got % x, want nil", got)
+	}
+	if got := GenerateICMPHostUnreachable(netip.Addr{}, v4, &empty); got != nil {
+		t.Errorf("invalid from: got % x, want nil", got)
+	}
+}


### PR DESCRIPTION
if we can't find a mapping for the magic IP they're sending traffic to.

Fixes tailscale/corp#34257