### PR TITLE
words: redress historical wrongs against the tuatara

### DIFF
--- a/words/scales.txt
+++ b/words/scales.txt
@@ -57,7 +57,6 @@ moth
 eagle
 woodpecker
 morpho
-tautara
 anoles
 theropod
 owl


### PR DESCRIPTION
b5a41ff381bf originally added both tuatara and mispelled tautara,
one as a tail and one as a scale.

f174ecb6fdab added tuatara as a scale, not noticing the tautara
imposter.

Fixes #20522
