### PR TITLE
ipn/ipnext: add post-reconfig snapshot hook for extensions

### DIFF
--- a/ipn/ipnext/ipnext.go
+++ b/ipn/ipnext/ipnext.go
@@ -17,6 +17,7 @@ import (
 	"tailscale.com/ipn"
 	"tailscale.com/ipn/ipnauth"
 	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/net/dns"
 	"tailscale.com/tailcfg"
 	"tailscale.com/tsd"
 	"tailscale.com/tstime"
@@ -356,6 +357,28 @@ type ProfileResolver func(ProfileStore) ipn.LoginProfileView
 // returns "" if the profile is new and has not been persisted yet.
 type ProfileStateChangeCallback func(_ ipn.LoginProfileView, _ ipn.PrefsView, sameNode bool)
 
+// ReconfigView is a read-only snapshot of the state applied by a single
+// LocalBackend reconfiguration, passed to [Hooks.Reconfigured] callbacks.
+//
+// It is only valid for the duration of the callback and must not be retained.
+// All fields are read-only; do not mutate anything reachable through them.
+//
+// Kept intentionally minimal; add fields only as consumers need them.
+type ReconfigView struct {
+	// Self is the self node as of this reconfig. It may be invalid.
+	Self tailcfg.NodeView
+
+	// Prefs are the current profile's prefs as of this reconfig.
+	//
+	// Unlike the prefs passed to [ProfileStateChangeCallback], these are not
+	// stripped of private keys, so callbacks must not log or persist them.
+	Prefs ipn.PrefsView
+
+	// DNS is the [dns.Config] that was just applied to the engine. It aliases
+	// the engine's live config, so it must be treated as strictly read-only.
+	DNS dns.ConfigView
+}
+
 // NewControlClientCallback is a function to be called when a new [controlclient.Client]
 // is created and before it is first used. The specified profile represents the node
 // for which the cc is created and is always valid. Its [ipn.LoginProfileView.ID]
@@ -413,6 +436,18 @@ type Hooks struct {
 	// OnSelfChange is called (with LocalBackend.mu held) when the self node
 	// changes, including changing to nothing (an invalid view).
 	OnSelfChange feature.Hooks[func(tailcfg.NodeView)]
+
+	// Reconfigured is called (with LocalBackend.mu held) once per applied
+	// reconfig — after the engine accepts a changed configuration — with a
+	// read-only [ReconfigView] snapshot of the self node, prefs, and applied
+	// dns.Config.
+	//
+	// It fires only when the reconfig actually changed engine state, not on a
+	// no-op reconfig. Callbacks run under LocalBackend.mu and must be cheap and
+	// non-blocking, the same contract as the other b.mu-held hooks in this
+	// struct. The [ReconfigView] and everything reachable through it are
+	// read-only and valid only for the duration of the call.
+	Reconfigured feature.Hooks[func(ReconfigView)]
 
 	// MutateNotifyLocked is called to optionally mutate the provided Notify
 	// before sending it to the IPN bus. It is called with LocalBackend.mu held.

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -6155,6 +6155,20 @@ func (b *LocalBackend) authReconfigLocked() {
 	}
 	b.logf("[v1] authReconfig: ra=%v dns=%v 0x%02x: %v", prefs.RouteAll(), prefs.CorpDNS(), flags, err)
 
+	// Notify extensions of the config that was just applied. This fires only
+	// when the engine accepted a change (not on ErrNoChanges), with b.mu held.
+	// See [ipnext.Hooks.Reconfigured].
+	if hooks := b.extHost.Hooks().Reconfigured; len(hooks) > 0 {
+		rv := ipnext.ReconfigView{
+			Self:  nm.SelfNode,
+			Prefs: prefs,
+			DNS:   dcfg.View(),
+		}
+		for _, f := range hooks {
+			f(rv)
+		}
+	}
+
 	b.initPeerAPIListenerLocked()
 	if buildfeatures.HasAppConnectors {
 		go b.goTracker.Go(b.readvertiseAppConnectorRoutes)

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -42,6 +42,7 @@ import (
 	"tailscale.com/ipn"
 	"tailscale.com/ipn/conffile"
 	"tailscale.com/ipn/ipnauth"
+	"tailscale.com/ipn/ipnext"
 	"tailscale.com/ipn/ipnlocal/netmapcache"
 	"tailscale.com/ipn/store/mem"
 	"tailscale.com/net/netcheck"
@@ -2483,6 +2484,77 @@ func TestSetControlClientStatusSendsFullNetmapAsPeerChanges(t *testing.T) {
 	}
 	b.SetControlClientStatus(b.cc, controlclient.Status{NetMap: nm, LoggedIn: true})
 	nw.check()
+}
+
+// TestReconfiguredHook verifies that the [ipnext.Hooks.Reconfigured] hook fires
+// with a valid snapshot when a reconfig is applied, and does not fire when
+// authReconfigLocked returns early before reaching the engine (e.g. !WantRunning).
+func TestReconfiguredHook(t *testing.T) {
+	b := newTestLocalBackend(t)
+
+	var got []ipnext.ReconfigView
+	b.extHost.Hooks().Reconfigured.Add(func(rv ipnext.ReconfigView) {
+		got = append(got, rv)
+	})
+
+	// A self node and WantRunning prefs with a valid Persist are the minimum
+	// needed for authReconfigLocked to compute a config and call Reconfig.
+	nodeKey := key.NewNode()
+	if err := b.pm.SetPrefs((&ipn.Prefs{
+		WantRunning: true,
+		CorpDNS:     true,
+		Persist: &persist.Persist{
+			PrivateNodeKey: nodeKey,
+			NodeID:         "n1",
+			UserProfile:    tailcfg.UserProfile{ID: 10, LoginName: "self@example.com"},
+		},
+	}).View(), ipn.NetworkProfile{}); err != nil {
+		t.Fatalf("SetPrefs: %v", err)
+	}
+	nm := &netmap.NetworkMap{
+		NodeKey: nodeKey.Public(),
+		SelfNode: (&tailcfg.Node{
+			ID:        1,
+			User:      10,
+			Key:       nodeKey.Public(),
+			Addresses: []netip.Prefix{netip.MustParsePrefix("100.101.102.103/32")},
+		}).View(),
+	}
+	b.mu.Lock()
+	b.setNetMapLocked(nm)
+	b.mu.Unlock()
+
+	// First reconfig applies a change, so the hook fires exactly once.
+	b.authReconfig()
+	if len(got) != 1 {
+		t.Fatalf("after first reconfig: hook fired %d times; want 1", len(got))
+	}
+	rv := got[0]
+	if !rv.Self.Valid() || rv.Self.StableID() != nm.SelfNode.StableID() {
+		t.Errorf("ReconfigView.Self = %v; want self node %v", rv.Self, nm.SelfNode)
+	}
+	if !rv.Prefs.Valid() || !rv.Prefs.WantRunning() {
+		t.Errorf("ReconfigView.Prefs = %v; want valid prefs with WantRunning", rv.Prefs)
+	}
+	if !rv.DNS.Valid() {
+		t.Errorf("ReconfigView.DNS is not valid; want the applied dns.Config")
+	}
+
+	// When WantRunning is false, authReconfigLocked returns early before
+	// touching the engine, so the hook must not fire.
+	got = nil
+	b.mu.Lock()
+	stopped := b.pm.CurrentPrefs().AsStruct()
+	stopped.WantRunning = false
+	if err := b.pm.setPrefsNoPermCheck(stopped.View()); err != nil {
+		b.mu.Unlock()
+		t.Fatalf("setPrefsNoPermCheck: %v", err)
+	}
+	b.authReconfigLocked()
+	b.mu.Unlock()
+	if len(got) != 0 {
+		t.Fatalf("after !WantRunning reconfig: hook fired %d times; want 0", len(got))
+	}
 }
 
 // TestNotifyForSessionUserProfilesGating verifies that


### PR DESCRIPTION
Add a Reconfigured hook that fires once per applied reconfig with a read-only ReconfigView (self node, prefs, applied dns.Config), letting extensions react from one callback instead of caching fragments from OnSelfChange and ProfileStateChange. It also exposes the applied dns.Config, which no existing hook did. DNS is a dns.ConfigView because the value aliases the engine's live config.

Updates #20516