### PR TITLE
wgengine/magicsock, net/netcheck: fix two unsynchronized reads flagged by the race detector

### DIFF
--- a/net/netcheck/netcheck.go
+++ b/net/netcheck/netcheck.go
@@ -1268,6 +1268,9 @@ func (c *Client) measureICMPLatency(ctx context.Context, reg *tailcfg.DERPRegion
 }
 
 func (c *Client) logConciseReport(r *Report, dm *tailcfg.DERPMap) {
+	c.mu.Lock()
+	forcePreferredDERP := c.ForcePreferredDERP
+	c.mu.Unlock()
 	c.logf("[v1] report: %v", logger.ArgWriter(func(w *bufio.Writer) {
 		fmt.Fprintf(w, "udp=%v", r.UDP)
 		if !r.IPv4 {
@@ -1296,8 +1299,8 @@ func (c *Client) logConciseReport(r *Report, dm *tailcfg.DERPMap) {
 		if r.CaptivePortal != "" {
 			fmt.Fprintf(w, " captiveportal=%v", r.CaptivePortal)
 		}
-		if c.ForcePreferredDERP != 0 {
-			fmt.Fprintf(w, " force=%v", c.ForcePreferredDERP)
+		if forcePreferredDERP != 0 {
+			fmt.Fprintf(w, " force=%v", forcePreferredDERP)
 		}
 		fmt.Fprintf(w, " derp=%v", r.PreferredDERP)
 		if r.PreferredDERP != 0 {

--- a/wgengine/magicsock/derp.go
+++ b/wgengine/magicsock/derp.go
@@ -203,7 +203,7 @@ func (c *Conn) maybeSetNearestDERP(report *netcheck.Report, force bool) (preferr
 	if preferredDERP != myDerp {
 		c.logf(
 			"magicsock: home DERP changing from derp-%d [%dms] to derp-%d [%dms] (forced=%t)",
-			c.myDerp, report.RegionLatency[myDerp].Milliseconds(), preferredDERP, report.RegionLatency[preferredDERP].Milliseconds(), force)
+			myDerp, report.RegionLatency[myDerp].Milliseconds(), preferredDERP, report.RegionLatency[preferredDERP].Milliseconds(), force)
 	}
 	if !c.setNearestDERP(preferredDERP) {
 		preferredDERP = 0


### PR DESCRIPTION
Two same-class data races, both hit by a downstream project whose agent drives `ForceSetNearestDERP` / `SetForcePreferredDERP` concurrently with live netchecks (tailscale's in-tree tests don't exercise those calls concurrently, so upstream CI never sees them):

**1. `wgengine/magicsock.maybeSetNearestDERP` (derp.go:206)** — the function snapshots `myDerp := c.myDerp` under `c.mu`, but the "home DERP changing" log line re-reads `c.myDerp` without the lock, racing the locked write in `setNearestDERP` from a concurrently-completing netcheck goroutine:

```
WARNING: DATA RACE
Write at 0x… by goroutine A:
  magicsock.(*Conn).setNearestDERP()       derp.go:273
  magicsock.(*Conn).maybeSetNearestDERP()  derp.go:208
  magicsock.(*Conn).updateNetInfo()        magicsock.go:1046
  …(*Conn).ReSTUN goroutine…
Previous read at 0x… by goroutine B:
  magicsock.(*Conn).maybeSetNearestDERP()  derp.go:206
  magicsock.(*Conn).ForceSetNearestDERP()  derp.go:228
```

Fix: use the snapshot the function already took (which is also what the surrounding comparisons and the `HomeDERPChanged` publish use).

**2. `net/netcheck.logConciseReport` (netcheck.go:1296-1297)** — `SetForcePreferredDERP` writes `c.ForcePreferredDERP` under `c.mu`, but `logConciseReport` reads it (twice, inside a lazily-evaluated `logger.ArgWriter` closure) without the lock:

```
WARNING: DATA RACE
Write at 0x… by goroutine A:
  netcheck.(*Client).SetForcePreferredDERP()  netcheck.go:787
  magicsock.(*Conn).DebugForcePreferDERP()    magicsock.go:3991
Previous read at 0x… by goroutine B:
  netcheck.(*Client).logConciseReport()       netcheck.go:1296
  netcheck.(*Client).finishAndStoreReport()   netcheck.go:1029
```

Fix: snapshot the value under the lock before building the log line. The other reads (`addReportHistoryAndSetPreferredDERP`) already run under `c.mu`; `logConciseReport`'s only caller (`finishAndStoreReport`) does not hold the lock, so locking inside is safe.

Both observed on v1.98.1 and still present on main. Log-line-only changes; no behavior change.