### PR TITLE
safeweb: fix misspelled Referrer-Policy response header

### DIFF
--- a/safeweb/http.go
+++ b/safeweb/http.go
@@ -6,7 +6,7 @@
 // used in place of an http.Server. A safeweb.Server adds mitigations for
 // Cross-Site Request Forgery (CSRF) attacks, and annotates requests with
 // appropriate Cross-Origin Resource Sharing (CORS), Content-Security-Policy,
-// X-Content-Type-Options, and Referer-Policy headers.
+// X-Content-Type-Options, and Referrer-Policy headers.
 //
 // To use safeweb, the application must separate its "browser" routes from "API"
 // routes, with each on its own http.ServeMux. When serving requests, the
@@ -24,7 +24,7 @@
 // In addition, browser routes will also have the following applied:
 //   - Content-Security-Policy header that disallows inline scripts, framing, and third party resources.
 //   - X-Content-Type-Options header on responses set to "nosniff" to prevent MIME type sniffing attacks.
-//   - Referer-Policy header set to "same-origin" to prevent leaking referrer information to third parties.
+//   - Referrer-Policy header set to "same-origin" to prevent leaking referrer information to third parties.
 //
 // By default the Content-Security-Policy header will disallow inline styles.
 // This can be overridden by setting the CSPAllowInlineStyles field to true in
@@ -376,7 +376,7 @@ func (s *Server) serveAPI(w http.ResponseWriter, r *http.Request) {
 func (s *Server) serveBrowser(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Security-Policy", s.csp)
 	w.Header().Set("X-Content-Type-Options", "nosniff")
-	w.Header().Set("Referer-Policy", "same-origin")
+	w.Header().Set("Referrer-Policy", "same-origin")
 	w.Header().Set("Cross-Origin-Opener-Policy", "same-origin")
 	if s.SecureContext {
 		w.Header().Set("Strict-Transport-Security", cmp.Or(s.StrictTransportSecurityOptions, DefaultStrictTransportSecurityOptions))

--- a/safeweb/http_test.go
+++ b/safeweb/http_test.go
@@ -336,21 +336,21 @@ func TestCSRFCookieSecureMode(t *testing.T) {
 	}
 }
 
-func TestRefererPolicy(t *testing.T) {
+func TestReferrerPolicy(t *testing.T) {
 	tests := []struct {
-		name              string
-		browserRoute      bool
-		wantRefererPolicy bool
+		name               string
+		browserRoute       bool
+		wantReferrerPolicy bool
 	}{
 		{
-			name:              "BrowserMux-gets-Referer-Policy",
-			browserRoute:      true,
-			wantRefererPolicy: true,
+			name:               "BrowserMux-gets-Referrer-Policy",
+			browserRoute:       true,
+			wantReferrerPolicy: true,
 		},
 		{
-			name:              "APIMux-no-Referer-Policy",
-			browserRoute:      false,
-			wantRefererPolicy: false,
+			name:               "APIMux-no-Referrer-Policy",
+			browserRoute:       false,
+			wantReferrerPolicy: false,
 		},
 	}
 
@@ -377,8 +377,8 @@ func TestRefererPolicy(t *testing.T) {
 			s.h.Handler.ServeHTTP(w, req)
 			resp := w.Result()
 
-			if (resp.Header.Get("Referer-Policy") == "") == tt.wantRefererPolicy {
-				t.Fatalf("referer policy want: %v; got: %v", tt.wantRefererPolicy, resp.Header.Get("Referer-Policy"))
+			if (resp.Header.Get("Referrer-Policy") == "") == tt.wantReferrerPolicy {
+				t.Fatalf("referrer policy want: %v; got: %v", tt.wantReferrerPolicy, resp.Header.Get("Referrer-Policy"))
 			}
 		})
 	}


### PR DESCRIPTION
safeweb sets a Referer-Policy header on its browser routes, but the response header browsers actually act on is Referrer-Policy with two r's; the single-r Referer spelling only exists as the old request header. Since the emitted name does not match the spec, browsers ignore it and apply their default policy instead, so the same-origin policy the package documents itself as setting never takes effect. The practical effect is that a browser still sends the serving origin in the Referer header on cross-origin requests, which is the third-party leak this header was added to prevent. I caught it while reading serveBrowser alongside the other security headers and comparing the name against the referrer-policy spec. The change corrects the name in serveBrowser and in the two doc comments that referenced it. The referrer-policy test was checking for the misspelled header, so it passed even though the real header was never set; it now asserts Referrer-Policy and fails without the code fix, leaving valid responses otherwise unchanged.