### PR TITLE
tstest/natlab/vmtest: add split-DNS routing test

### DIFF
--- a/tstest/natlab/vmtest/dns_test.go
+++ b/tstest/natlab/vmtest/dns_test.go
@@ -6,6 +6,7 @@ package vmtest_test
 import (
 	"fmt"
 	"net/netip"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -161,5 +162,320 @@ func (dt *dnsTester) wantNXDOMAIN(name string) {
 		return nil
 	}); err != nil {
 		dt.t.Fatal(err)
+	}
+}
+
+func TestSplitDNS(t *testing.T) {
+	testSplitDNS(t, vmtest.DNSDefault, "systemd-resolved")
+}
+
+func TestSplitDNSDirect(t *testing.T) {
+	testSplitDNS(t, vmtest.DNSDirect, "direct")
+}
+
+// testSplitDNS checks that a Tailscale node sends DNS queries to the right
+// place. "Split DNS" means the tailnet can say "queries for domain X go to
+// resolver Y", instead of every query going to the machine's default DNS
+// server. Control sends that policy as DNSConfig.Routes: a map of domain
+// suffix to the resolver(s) for it.
+//
+// A route's resolver list can also be empty, which means something different:
+// don't forward those queries anywhere, let tailscaled's own resolver
+// (100.100.100.100, "quad-100") answer them from what it knows -- the tailnet's
+// MagicDNS names and any extra records control sent.
+//
+// So there are four ways a lookup can be resolved, and this test covers all
+// four. Each is one row of the checks table below:
+//
+//  1. forwarded: a domain routed to a specific resolver goes to that resolver.
+//  2. local: a domain routed with an empty resolver list is answered by
+//     quad-100 from an extra record control sent.
+//  3. magicdns: a peer's tailnet name is answered by quad-100 from the netmap.
+//  4. default: a domain with no route at all still goes to the machine's normal
+//     DNS server, i.e. Tailscale doesn't hijack unrelated lookups.
+//
+// Here quad-100 is the one that forwards case 1, on both DNS backends: this
+// config mixes routes with different resolvers (one forwarded, two local), and
+// tailscaled only lets the OS resolver do the forwarding when every route shares
+// a single resolver set. [TestSplitDNSOSForwarded] covers that other
+// arrangement. What the two backends differ in here is how a query reaches
+// quad-100: systemd-resolved is told to match just the routed suffixes onto the
+// Tailscale link, so case 4 never goes near quad-100, whereas the "direct"
+// backend can't express that, so the OS points everything at quad-100 and
+// tailscaled forwards case 4 onward itself.
+//
+// dnsMode picks the backend; wantBackend is asserted so a pass can't come from
+// the wrong one.
+func testSplitDNS(t *testing.T, dnsMode vmtest.DNSMode, wantBackend string) {
+	t.Helper()
+
+	// ---- Setup: the DNS policy we'll hand to the node, and what each case
+	// ---- should resolve to.
+
+	// Case 1 (forwarded). vnet runs a second DNS server that is the *only*
+	// thing serving fwdName. If the node resolves fwdName correctly, the query
+	// must have been forwarded to that server -- nothing else could have
+	// answered it. That's what makes this a real test of split DNS.
+	fwdDomain := vnet.SplitDNSDomain()
+	fwdName, fwdIP := vnet.SplitDNSName()
+	fwdResolver := vnet.FakeSplitDNSIPv4()
+
+	// Case 2 (local). A route with no resolvers, plus an extra record for a name
+	// in it. localIP is arbitrary -- the checks only resolve names, never connect
+	// -- but it's in the tailnet range and outside the 100.64.x.y block
+	// testcontrol assigns nodes, so an answer can only have come from the extra
+	// record.
+	const localDomain = "local.example"
+	const localName = "host." + localDomain
+	const localIP = "100.99.99.99"
+
+	// Case 3 (magicdns). The peer's node name becomes its guest hostname, and
+	// control appends the tailnet's MagicDNS domain, so its name is predictable.
+	const magicDNSDomain = "tailnet.test"
+	const peerNodeName = "peer"
+	const wantPeerName = peerNodeName + "." + magicDNSDomain
+
+	// Case 4 (default) uses a name that only vnet's *default* DNS server serves;
+	// see the checks table.
+
+	env := vmtest.New(t,
+		vmtest.SameTailnetUser(), // so the peer is visible and its MagicDNS name resolves
+		vmtest.ControlDNS(magicDNSDomain, &tailcfg.DNSConfig{
+			Proxied: true, // turn on MagicDNS (needed for case 3)
+			// Search domains, so the bare name "host" also resolves as
+			// host.local.example.
+			Domains: []string{localDomain},
+			Routes: map[string][]*dnstype.Resolver{
+				fwdDomain:   {{Addr: fwdResolver.String()}}, // case 1: forward here
+				localDomain: nil,                            // case 2: answer locally
+			},
+			ExtraRecords: []tailcfg.DNSRecord{
+				{Name: localName, Type: "A", Value: localIP}, // case 2's answer
+			},
+		}))
+
+	// Two nodes: client is the one we run lookups on; peer exists only so there's
+	// a tailnet name to look up (case 3). Nothing runs on peer.
+	lan := env.AddNetwork("2.1.1.1", "192.168.1.1/24", vnet.EasyNAT)
+	client := env.AddNode("client", lan,
+		vmtest.OS(vmtest.Ubuntu2404),
+		vmtest.WithDNSMode(dnsMode))
+	peer := env.AddNode(peerNodeName, lan,
+		vmtest.OS(vmtest.Ubuntu2404))
+
+	env.Start()
+
+	// Last bit of setup: read the peer's tailnet name and IP, which are case 3's
+	// lookup and expected answer. We check the name matches what control should
+	// have assigned rather than just using whatever it reports, so that if
+	// MagicDNS naming changes, this fails loudly instead of quietly resolving
+	// some other name and still passing.
+	peerSt := env.Status(peer)
+	peerName := strings.TrimSuffix(peerSt.Self.DNSName, ".")
+	if peerName != wantPeerName {
+		t.Fatalf("peer DNSName = %q, want %q", peerName, wantPeerName)
+	}
+	var peerIP string // IPv4, since the lookups below ask for A records only
+	for _, a := range peerSt.Self.TailscaleIPs {
+		if a.Is4() {
+			peerIP = a.String()
+			break
+		}
+	}
+	if peerIP == "" {
+		t.Fatalf("peer has no IPv4 TailscaleIP in status (got %v)", peerSt.Self.TailscaleIPs)
+	}
+
+	// ---- Checks start here.
+
+	// First, confirm the client picked the DNS backend this run is meant to
+	// exercise, so the lookups below can't pass via the other backend.
+	env.AssertDNSBackend(client, wantBackend)
+
+	// Also confirm the machine's resolver points at quad-100 and was *not* handed
+	// the split resolver: this config landed in the "quad-100 forwards"
+	// arrangement described above, not the OS-forwarded one.
+	assertResolverState(t, env, client,
+		[]string{"100.100.100.100"},
+		[]string{fwdResolver.String()})
+
+	// Then resolve each name on the client and confirm the answer, which tells us
+	// the query went where it should have.
+	//
+	// We use "getent ahostsv4" (A records only) rather than "getent hosts":
+	// dualstack-web.example.com has both A and AAAA, and "hosts" can return
+	// either family.
+	checks := []struct {
+		name string // what to look up on the client
+		want string // the answer proving it was resolved by the right thing
+		what string // which of the four cases this is, for failure messages
+	}{
+		// Only vnet's second DNS server serves this name, so getting the right
+		// answer proves the query was forwarded there.
+		{fwdName, fwdIP.String(), "1. forwarded: routed domain went to its designated resolver"},
+		// Served by quad-100 from control's extra record, not forwarded anywhere.
+		{localName, localIP, "2. local: empty-resolver route answered by quad-100"},
+		// Same answer, but looked up as a bare name to check the search domain.
+		{"host", localIP, "2. local: bare name completed by the " + localDomain + " search domain"},
+		// quad-100 answers tailnet names from the netmap.
+		{peerName, peerIP, "3. magicdns: peer's tailnet name resolved to its tailnet IP"},
+		// No route covers this, so it must still reach the normal DNS server
+		// (here vnet's default one, standing in for the internet).
+		{"dualstack-web.example.com", "5.0.0.100", "4. default: unrouted name still resolved normally"},
+	}
+
+	for _, c := range checks {
+		// Retry: tailscaled applies DNS config to the OS resolver
+		// asynchronously after coming up.
+		if err := tstest.WaitFor(30*time.Second, func() error {
+			out, err := env.SSHExec(client, "getent ahostsv4 "+c.name)
+			if err != nil {
+				return fmt.Errorf("getent ahostsv4 %s (%s): %v (%s)", c.name, c.what, err, strings.TrimSpace(out))
+			}
+			if !strings.Contains(out, c.want) {
+				return fmt.Errorf("getent ahostsv4 %s (%s) = %q, want it to contain %s", c.name, c.what, strings.TrimSpace(out), c.want)
+			}
+			return nil
+		}); err != nil {
+			out, _ := env.SSHExec(client, "resolvectl status; cat /etc/resolv.conf")
+			t.Fatalf("%v\nclient resolver state:\n%s", err, out)
+		}
+	}
+}
+
+// TestSplitDNSOSForwarded covers the other way Tailscale can implement a
+// split-DNS route: letting the OS resolver forward the routed domain straight to
+// its designated resolver, with quad-100 out of the query path entirely.
+//
+// tailscaled only does this when the OS resolver supports split DNS *and* every
+// route shares one resolver set, since a single set is all it can hand the OS
+// (see compileConfig in net/dns/manager.go). So unlike [testSplitDNS], the
+// config here has exactly one route and no MagicDNS: nothing needs answering
+// locally, so there's nothing for quad-100 to do. systemd-resolved then gets the
+// split resolver as its nameserver, with the routed domain as a match domain.
+//
+// The lookup is the same shape as testSplitDNS case 1, but it proves more here:
+// with quad-100 not in the path, an answer means systemd-resolved sent the query
+// to the split resolver itself.
+//
+// There is no "direct" variant of this test. The direct backend rewrites
+// resolv.conf, which can't express "this domain goes elsewhere", so it reports
+// SupportsSplitDNS() == false and tailscaled always falls back to forwarding via
+// quad-100 -- which is what [TestSplitDNSDirect] covers.
+func TestSplitDNSOSForwarded(t *testing.T) {
+	// ---- Setup.
+
+	// The routed domain and the resolver that serves it. Only vnet's second DNS
+	// server answers this name, so resolving it proves the query got there.
+	fwdDomain := vnet.SplitDNSDomain()
+	fwdName, fwdIP := vnet.SplitDNSName()
+	fwdResolver := vnet.FakeSplitDNSIPv4()
+
+	// systemd-resolved sends queries for a match domain out the link it
+	// programmed them on -- the Tailscale interface -- so the split resolver has
+	// to be reachable over the tailnet, as it would be in a real deployment
+	// (a resolver inside a subnet-routed network). Advertise a route covering
+	// fwdResolver from a second node and accept it on the client.
+	fwdResolverRoute := netip.PrefixFrom(fwdResolver, 32).String()
+
+	env := vmtest.New(t,
+		// No Proxied/MagicDNS and no empty-resolver routes: a single route with a
+		// single resolver is what makes tailscaled hand the split to the OS.
+		vmtest.ControlDNS("tailnet.test", &tailcfg.DNSConfig{
+			Routes: map[string][]*dnstype.Resolver{
+				fwdDomain: {{Addr: fwdResolver.String()}},
+			},
+		}))
+
+	lan := env.AddNetwork("2.1.1.1", "192.168.1.1/24", vnet.EasyNAT)
+	client := env.AddNode("client", lan,
+		vmtest.OS(vmtest.Ubuntu2404))
+	// This node exists only to make fwdResolver routable over the tailnet; no
+	// DNS server runs on it. vnet answers the queries once they're on the wire.
+	resolverRouter := env.AddNode("resolver-router", lan,
+		vmtest.OS(vmtest.Ubuntu2404),
+		vmtest.AdvertiseRoutes(fwdResolverRoute))
+
+	env.Start()
+
+	// ApproveRoutes also turns on accept-routes on the other nodes, so the
+	// client installs the route to fwdResolver.
+	env.ApproveRoutes(resolverRouter, fwdResolverRoute)
+
+	// ---- Checks start here.
+
+	env.AssertDNSBackend(client, "systemd-resolved")
+
+	// The resolver state is the direct evidence for this branch: systemd-resolved
+	// was given the split resolver as its server for the routed domain, and
+	// quad-100 is nowhere in the query path. Asserting this is what separates
+	// this test from [testSplitDNS] -- the lookup below would also pass if
+	// quad-100 were doing the forwarding.
+	assertResolverState(t, env, client,
+		[]string{fwdResolver.String(), "~" + fwdDomain},
+		[]string{"100.100.100.100"})
+
+	// And it works end to end: the OS resolves the name, which only the split
+	// resolver serves.
+	if err := tstest.WaitFor(30*time.Second, func() error {
+		out, err := env.SSHExec(client, "getent ahostsv4 "+fwdName)
+		if err != nil {
+			return fmt.Errorf("getent ahostsv4 %s: %v (%s)", fwdName, err, strings.TrimSpace(out))
+		}
+		if !strings.Contains(out, fwdIP.String()) {
+			return fmt.Errorf("getent ahostsv4 %s = %q, want it to contain %s", fwdName, strings.TrimSpace(out), fwdIP)
+		}
+		return nil
+	}); err != nil {
+		out, _ := env.SSHExec(client, "resolvectl status; cat /etc/resolv.conf; ip route")
+		t.Fatalf("%v\nclient resolver state:\n%s", err, out)
+	}
+}
+
+// assertResolverState fails the test unless the node's OS resolver state has
+// every string in want and none in notWant, retrying while tailscaled applies
+// its config asynchronously.
+//
+// notWant is how each caller pins down which of tailscaled's two split-DNS
+// arrangements ran: they answer queries identically, so the resolver that is
+// *absent* identifies the branch as much as the one that's there.
+//
+// It reads both resolvectl and resolv.conf because the backends record state in
+// different places: systemd-resolved keeps servers and domains per-link, with
+// resolv.conf just the 127.0.0.53 stub, while the direct backend writes
+// resolv.conf itself and leaves resolved masked and not running.
+//
+// Each want and notWant is matched as a whitespace-separated token, so pass
+// exactly what appears in the output: a bare resolver address, or a routing-only
+// ("match") domain with resolvectl's "~" prefix and no trailing dot. The
+// resolvectl queries are scoped to tailscale0, so a match can't come from
+// another link; if the interface is ever named otherwise, resolvectl errors and
+// the assertion fails rather than silently matching elsewhere.
+func assertResolverState(t *testing.T, env *vmtest.Env, n *vmtest.Node, want, notWant []string) {
+	t.Helper()
+	// Keep resolvectl's stderr: it's how resolved being absent (expected under
+	// the direct backend) or broken (not) shows up in the failure dump.
+	const cmd = "resolvectl dns tailscale0 2>&1; resolvectl domain tailscale0 2>&1; cat /etc/resolv.conf 2>&1"
+	var last string
+	if err := tstest.WaitFor(30*time.Second, func() error {
+		out, err := env.SSHExec(n, cmd)
+		last = out
+		if err != nil {
+			return fmt.Errorf("%s: %v (%s)", cmd, err, strings.TrimSpace(out))
+		}
+		got := strings.Fields(out)
+		for _, w := range want {
+			if !slices.Contains(got, w) {
+				return fmt.Errorf("resolver state is missing %q", w)
+			}
+		}
+		for _, w := range notWant {
+			if slices.Contains(got, w) {
+				return fmt.Errorf("resolver state unexpectedly has %q", w)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("%v\nwant all of %q and none of %q in resolver state:\n%s", err, want, notWant, last)
 	}
 }

--- a/tstest/natlab/vmtest/dns_test.go
+++ b/tstest/natlab/vmtest/dns_test.go
@@ -6,6 +6,7 @@ package vmtest_test
 import (
 	"fmt"
 	"net/netip"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -161,5 +162,425 @@ func (dt *dnsTester) wantNXDOMAIN(name string) {
 		return nil
 	}); err != nil {
 		dt.t.Fatal(err)
+	}
+}
+
+// TestSplitDNS runs the split-DNS checks against the systemd-resolved backend,
+// which Ubuntu uses by default.
+func TestSplitDNS(t *testing.T) {
+	testSplitDNS(t, vmtest.DNSDefault, "systemd-resolved")
+}
+
+// TestSplitDNSDirect runs the same checks against the "direct" backend, which
+// tailscaled uses when it has to write /etc/resolv.conf itself.
+func TestSplitDNSDirect(t *testing.T) {
+	testSplitDNS(t, vmtest.DNSDirect, "direct")
+}
+
+// testSplitDNS checks that a node resolves each kind of name via the right
+// resolver: see the checks table below, which has a row per kind. The mixed
+// routes leave no single resolver set to hand the OS, so quad-100 does the
+// forwarding; [TestSplitDNSOSForwarded] covers the other arrangement.
+//
+// dnsMode picks the DNS backend; wantBackend is asserted so a pass can't come
+// from the wrong one.
+func testSplitDNS(t *testing.T, dnsMode vmtest.DNSMode, wantBackend string) {
+	t.Helper()
+
+	// vnet's second DNS server is the *only* thing serving fwdName, so an
+	// answer means the query was forwarded there.
+	const (
+		fwdDomain = vnet.SplitDNSDomain
+		fwdName   = vnet.SplitDNSName
+		fwdIP     = vnet.SplitDNSAddr
+	)
+	fwdResolver := vnet.FakeSplitDNSIPv4()
+
+	// A route with no resolvers, plus an extra record for a name in it. localIP
+	// is never connected to, only resolved; it's outside the 100.64.x.y block
+	// testcontrol assigns nodes, so an answer can only have come from the extra
+	// record.
+	const (
+		localDomain = "local.example"
+		localName   = "host." + localDomain
+		localIP     = "100.99.99.99"
+	)
+
+	// The peer's node name becomes its guest hostname, and control appends the
+	// tailnet's MagicDNS domain, so its name is predictable.
+	const (
+		magicDNSDomain = "tailnet.test"
+		peerNodeName   = "peer"
+		wantPeerName   = peerNodeName + "." + magicDNSDomain
+	)
+
+	env := vmtest.New(t,
+		vmtest.SameTailnetUser(), // so the peer is visible and its MagicDNS name resolves
+		vmtest.ControlDNS(magicDNSDomain, &tailcfg.DNSConfig{
+			Proxied: true, // turn on MagicDNS, so the peer's tailnet name resolves
+			// Search domains, so the bare name "host" also resolves as
+			// host.local.example.
+			Domains: []string{localDomain},
+			// These routes don't share a resolver set, so quad-100 does the
+			// forwarding. Proxied also adds a nil-resolver route per MagicDNS
+			// root domain, so the sets differ regardless.
+			Routes: map[string][]*dnstype.Resolver{
+				fwdDomain:   {{Addr: fwdResolver.String()}}, // forward here
+				localDomain: nil,                            // answer locally
+			},
+			ExtraRecords: []tailcfg.DNSRecord{
+				{Name: localName, Type: "A", Value: localIP}, // the local answer
+			},
+		}))
+
+	// Two nodes: client is the one we run lookups on; peer exists only so
+	// there's a tailnet name to look up. Nothing runs on peer.
+	lan := env.AddNetwork("2.1.1.1", "192.168.1.1/24", vnet.EasyNAT)
+	client := env.AddNode("client", lan,
+		vmtest.OS(vmtest.Ubuntu2404),
+		vmtest.WithDNSMode(dnsMode))
+	peer := env.AddNode(peerNodeName, lan,
+		vmtest.OS(vmtest.Ubuntu2404))
+
+	env.Start()
+
+	// The peer's lookup and expected answer. Checking the name against what
+	// control should have assigned, rather than trusting whatever it reports,
+	// means a MagicDNS naming change fails here instead of quietly resolving
+	// some other name and passing.
+	peerSt := env.Status(peer)
+	peerName := strings.TrimSuffix(peerSt.Self.DNSName, ".")
+	if peerName != wantPeerName {
+		t.Fatalf("peer DNSName = %q, want %q", peerName, wantPeerName)
+	}
+	var peerIP string // IPv4, since the lookups below ask for A records only
+	for _, a := range peerSt.Self.TailscaleIPs {
+		if a.Is4() {
+			peerIP = a.String()
+			break
+		}
+	}
+	if peerIP == "" {
+		t.Fatalf("peer has no IPv4 TailscaleIP in status (got %v)", peerSt.Self.TailscaleIPs)
+	}
+
+	env.AssertDNSBackend(client, wantBackend)
+
+	// The OS was pointed at quad-100 and *not* handed the split resolver, i.e.
+	// quad-100 is doing the forwarding.
+	assertResolverState(t, env, client,
+		[]string{"100.100.100.100"},
+		[]string{fwdResolver.String()})
+
+	// "getent ahostsv4" (A only) rather than "getent hosts":
+	// dualstack-web.example.com has both A and AAAA, and "hosts" can return
+	// either family.
+	checks := []struct {
+		name string // what to look up on the client
+		want string // the answer proving it was resolved by the right thing
+		what string // which of the four cases this is, for failure messages
+	}{
+		{
+			name: fwdName,
+			want: fwdIP,
+			what: "forwarded: routed domain went to its designated resolver",
+		},
+		{
+			name: localName,
+			want: localIP,
+			what: "local: empty-resolver route answered by quad-100",
+		},
+		// Same answer, but looked up as a bare name to check the search domain.
+		{
+			name: "host",
+			want: localIP,
+			what: "local: bare name completed by the " + localDomain + " search domain",
+		},
+		// quad-100 answers tailnet names from the netmap.
+		{
+			name: peerName,
+			want: peerIP,
+			what: "magicdns: peer's tailnet name resolved to its tailnet IP",
+		},
+		// No route covers this, so it must still reach the normal DNS server
+		// (here vnet's default one, standing in for the internet).
+		{
+			name: "dualstack-web.example.com",
+			want: "5.0.0.100",
+			what: "default: unrouted name still resolved normally",
+		},
+	}
+
+	for _, c := range checks {
+		// Retry: tailscaled applies DNS config to the OS resolver
+		// asynchronously after coming up.
+		if err := tstest.WaitFor(30*time.Second, func() error {
+			out, err := env.SSHExec(client, "getent ahostsv4 "+c.name)
+			if err != nil {
+				return fmt.Errorf("getent ahostsv4 %s (%s): %v (%s)", c.name, c.what, err, strings.TrimSpace(out))
+			}
+			if !strings.Contains(out, c.want) {
+				return fmt.Errorf("getent ahostsv4 %s (%s) = %q, want it to contain %s", c.name, c.what, strings.TrimSpace(out), c.want)
+			}
+			return nil
+		}); err != nil {
+			out, _ := env.SSHExec(client, "resolvectl status; cat /etc/resolv.conf")
+			t.Fatalf("%v\nclient resolver state:\n%s", err, out)
+		}
+	}
+}
+
+// TestSplitDNSOSForwarded checks the other way tailscaled can implement a routed
+// domain: handing the OS resolver the domain's resolver directly, with quad-100
+// out of the query path. It does that only when every route shares one resolver
+// set, hence the single route and no MagicDNS here.
+//
+// There is no "direct" variant. That backend only rewrites resolv.conf, so it
+// reports SupportsSplitDNS() == false and always forwards via quad-100, which
+// [TestSplitDNSDirect] covers.
+func TestSplitDNSOSForwarded(t *testing.T) {
+	// Only vnet's second DNS server answers fwdName, so an answer means the query
+	// got there.
+	const (
+		fwdDomain = vnet.SplitDNSDomain
+		fwdName   = vnet.SplitDNSName
+		fwdIP     = vnet.SplitDNSAddr
+	)
+	fwdResolver := vnet.FakeSplitDNSIPv4()
+
+	// systemd-resolved sends match-domain queries out the link it programmed them
+	// on -- the Tailscale interface -- so the split resolver has to be reachable
+	// over the tailnet, as it would be in a real deployment. Advertise a route
+	// covering it from a second node.
+	fwdResolverRoute := netip.PrefixFrom(fwdResolver, 32).String()
+
+	env := vmtest.New(t,
+		vmtest.ControlDNS("tailnet.test", &tailcfg.DNSConfig{
+			Routes: map[string][]*dnstype.Resolver{
+				fwdDomain: {{Addr: fwdResolver.String()}},
+			},
+		}))
+
+	lan := env.AddNetwork("2.1.1.1", "192.168.1.1/24", vnet.EasyNAT)
+	client := env.AddNode("client", lan,
+		vmtest.OS(vmtest.Ubuntu2404))
+	// This node exists only to make fwdResolver routable over the tailnet; no
+	// DNS server runs on it. vnet answers the queries once they're on the wire.
+	resolverRouter := env.AddNode("resolver-router", lan,
+		vmtest.OS(vmtest.Ubuntu2404),
+		vmtest.AdvertiseRoutes(fwdResolverRoute))
+
+	env.Start()
+
+	// ApproveRoutes also turns on accept-routes on the other nodes, so the
+	// client installs the route to fwdResolver.
+	env.ApproveRoutes(resolverRouter, fwdResolverRoute)
+
+	env.AssertDNSBackend(client, "systemd-resolved")
+
+	// This is what separates this test from [testSplitDNS]: systemd-resolved holds
+	// the split resolver itself and quad-100 is absent. The lookup below would
+	// pass either way.
+	assertResolverState(t, env, client,
+		[]string{fwdResolver.String(), "~" + fwdDomain},
+		[]string{"100.100.100.100"})
+
+	// The route from resolverRouter is what makes the lookup below work: with the
+	// split resolver on tailscale0, resolved sends the query out that link, and
+	// without a route there it times out rather than falling back to the LAN.
+	// Assert the route landed, so a lookup failure points here instead of at the
+	// resolver config. Retried because the client installs it asynchronously
+	// after ApproveRoutes.
+	if err := tstest.WaitFor(30*time.Second, func() error {
+		cmd := "ip route get " + fwdResolver.String()
+		out, err := env.SSHExec(client, cmd)
+		if err != nil {
+			return fmt.Errorf("%s: %v (%s)", cmd, err, strings.TrimSpace(out))
+		}
+		if !strings.Contains(out, "dev tailscale0") {
+			return fmt.Errorf("%s = %q, want it to go via tailscale0", cmd, strings.TrimSpace(out))
+		}
+		return nil
+	}); err != nil {
+		out, _ := env.SSHExec(client, "ip route; tailscale status")
+		t.Fatalf("%v\nclient routes:\n%s", err, out)
+	}
+
+	// And it works end to end.
+	if err := tstest.WaitFor(30*time.Second, func() error {
+		out, err := env.SSHExec(client, "getent ahostsv4 "+fwdName)
+		if err != nil {
+			return fmt.Errorf("getent ahostsv4 %s: %v (%s)", fwdName, err, strings.TrimSpace(out))
+		}
+		if !strings.Contains(out, fwdIP) {
+			return fmt.Errorf("getent ahostsv4 %s = %q, want it to contain %s", fwdName, strings.TrimSpace(out), fwdIP)
+		}
+		return nil
+	}); err != nil {
+		out, _ := env.SSHExec(client, "resolvectl status; cat /etc/resolv.conf; ip route")
+		t.Fatalf("%v\nclient resolver state:\n%s", err, out)
+	}
+}
+
+// TestSplitDNSNoMagicDNS covers split DNS on a tailnet with MagicDNS turned off,
+// the one combination the tests above leave out. [testSplitDNS] has mixed
+// resolver sets but MagicDNS on; [TestSplitDNSOSForwarded] has MagicDNS off but
+// a single resolver set. Both conditions together take a distinct path through
+// compileConfig: with no MagicDNS route to scope to, tailscaled reads the OS's
+// base resolver config to use as quad-100's fallback.
+//
+// systemd-resolved has no base config to give -- it answers
+// ErrGetBaseConfigNotSupported -- so this exercises what tailscaled does when
+// that read fails. The lookups matter less than the resolver state assertion:
+// if applying the config fails, tailscaled leaves whatever it installed last in
+// place, so the failure shows up as stale OS resolver state rather than as an
+// error the guest can see.
+func TestSplitDNSNoMagicDNS(t *testing.T) {
+	// Only vnet's second DNS server answers fwdName, so an answer means the
+	// query was forwarded there.
+	const (
+		fwdDomain = vnet.SplitDNSDomain
+		fwdName   = vnet.SplitDNSName
+		fwdIP     = vnet.SplitDNSAddr
+	)
+	fwdResolver := vnet.FakeSplitDNSIPv4()
+
+	// A second route with a different resolver, so no single resolver set can
+	// be handed to the OS. Nothing is ever looked up in it; with MagicDNS off
+	// there is no nil-resolver root domain route to force the split, so this
+	// route is what does it.
+	const otherDomain = "other.example"
+	otherResolver := "10.0.0.2"
+
+	// An extra record, and a search domain so the bare name resolves too.
+	// localIP is outside the 100.64.x.y block testcontrol assigns nodes, so an
+	// answer can only have come from the extra record.
+	const (
+		localDomain = "local.example"
+		localName   = "host." + localDomain
+		localIP     = "100.99.99.99"
+	)
+
+	env := vmtest.New(t,
+		vmtest.ControlDNS("tailnet.test", &tailcfg.DNSConfig{
+			// Proxied is deliberately absent: MagicDNS off. That is what
+			// separates this test from [testSplitDNS].
+			Domains: []string{localDomain},
+			Routes: map[string][]*dnstype.Resolver{
+				fwdDomain:   {{Addr: fwdResolver.String()}},
+				otherDomain: {{Addr: otherResolver}},
+				localDomain: nil,
+			},
+			ExtraRecords: []tailcfg.DNSRecord{
+				{Name: localName, Type: "A", Value: localIP},
+			},
+		}))
+
+	client := env.AddNode("client",
+		env.AddNetwork("2.1.1.1", "192.168.1.1/24", vnet.EasyNAT),
+		vmtest.OS(vmtest.Ubuntu2404))
+
+	env.Start()
+
+	env.AssertDNSBackend(client, "systemd-resolved")
+
+	// The OS points at quad-100 for the routed domains and was not handed the
+	// split resolvers. A failed config apply leaves stale state here, which is
+	// the symptom this test is really after.
+	//
+	// localDomain has no "~": it's a search domain (see Domains above), which
+	// resolved lists bare, unlike the routing-only domains.
+	assertResolverState(t, env, client,
+		[]string{"100.100.100.100", "~" + fwdDomain, "~" + otherDomain, localDomain},
+		[]string{fwdResolver.String(), otherResolver})
+
+	checks := []struct {
+		name string // what to look up on the client
+		want string // the answer proving the right resolver handled it
+		what string // for failure messages
+	}{
+		{
+			name: fwdName,
+			want: fwdIP,
+			what: "forwarded: routed domain went to its designated resolver",
+		},
+		{
+			name: localName,
+			want: localIP,
+			what: "local: empty-resolver route answered by quad-100",
+		},
+		{
+			name: "host",
+			want: localIP,
+			what: "local: bare name completed by the " + localDomain + " search domain",
+		},
+		{
+			name: "dualstack-web.example.com",
+			want: "5.0.0.100",
+			what: "default: unrouted name still resolved normally",
+		},
+	}
+
+	for _, c := range checks {
+		// Retry: tailscaled applies DNS config to the OS resolver
+		// asynchronously after coming up.
+		if err := tstest.WaitFor(30*time.Second, func() error {
+			out, err := env.SSHExec(client, "getent ahostsv4 "+c.name)
+			if err != nil {
+				return fmt.Errorf("getent ahostsv4 %s (%s): %v (%s)", c.name, c.what, err, strings.TrimSpace(out))
+			}
+			if !strings.Contains(out, c.want) {
+				return fmt.Errorf("getent ahostsv4 %s (%s) = %q, want it to contain %s", c.name, c.what, strings.TrimSpace(out), c.want)
+			}
+			return nil
+		}); err != nil {
+			out, _ := env.SSHExec(client, "resolvectl status; cat /etc/resolv.conf")
+			t.Fatalf("%v\nclient resolver state:\n%s", err, out)
+		}
+	}
+}
+
+// assertResolverState fails the test unless the node's OS resolver state has
+// every string in want and none in notWant, retrying while tailscaled applies
+// its config asynchronously. notWant matters because the two split-DNS
+// arrangements answer queries identically: the resolver that is *absent*
+// identifies which one ran.
+//
+// It reads both resolvectl and resolv.conf because the backends record state in
+// different places: systemd-resolved keeps servers and domains per-link, with
+// resolv.conf just the 127.0.0.53 stub, while the direct backend writes
+// resolv.conf itself and leaves resolved masked.
+//
+// Each want and notWant is matched as a whitespace-separated token, so pass
+// exactly what appears in the output: a bare resolver address, or a routing-only
+// ("match") domain with resolvectl's "~" prefix and no trailing dot. The
+// resolvectl queries are scoped to tailscale0, so a match can't come from
+// another link.
+func assertResolverState(t *testing.T, env *vmtest.Env, n *vmtest.Node, want, notWant []string) {
+	t.Helper()
+	// Keep resolvectl's stderr: it's how resolved being absent (expected under
+	// the direct backend) or broken (not) shows up in the failure dump.
+	const cmd = "resolvectl dns tailscale0 2>&1; resolvectl domain tailscale0 2>&1; cat /etc/resolv.conf 2>&1"
+	var last string
+	if err := tstest.WaitFor(30*time.Second, func() error {
+		out, err := env.SSHExec(n, cmd)
+		last = out
+		if err != nil {
+			return fmt.Errorf("%s: %v (%s)", cmd, err, strings.TrimSpace(out))
+		}
+		got := strings.Fields(out)
+		for _, w := range want {
+			if !slices.Contains(got, w) {
+				return fmt.Errorf("resolver state is missing %q", w)
+			}
+		}
+		for _, w := range notWant {
+			if slices.Contains(got, w) {
+				return fmt.Errorf("resolver state unexpectedly has %q", w)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("%v\nwant all of %q and none of %q in resolver state:\n%s", err, want, notWant, last)
 	}
 }

--- a/tstest/natlab/vnet/vip.go
+++ b/tstest/natlab/vnet/vip.go
@@ -23,11 +23,48 @@ var (
 	fakeFiles             = newVIP("files.tailscale", 6)      // serves binary files (tta, tailscale, tailscaled) to VMs
 	fakeACME              = newVIP("acme.example", 7)         // fake ACME CA for vmtests
 
+	// fakeSplitDNS is a second DNS server, distinct from fakeDNS, serving only
+	// splitDNSZone.
+	fakeSplitDNS = newVIP("split-dns", "4.11.4.12", "2411::412")
+
 	// FakeDualStackWeb is a dual-stack webserver VIP used by
 	// TestExitNodeV4Only to verify that traffic works through an
 	// IPv4-only exit node even when DNS returns both A and AAAA.
 	FakeDualStackWeb = newVIP("dualstack-web.example.com", "5.0.0.100", "2052::5:100")
 )
+
+// splitDNSDomain and splitDNSName describe the zone served *only* by
+// fakeSplitDNS, never by the default fakeDNS. An answer for splitDNSName
+// therefore proves a split-DNS route to fakeSplitDNS was honored. Names here
+// are in DNS wire format, as the query parser produces them: no trailing dot.
+const (
+	splitDNSDomain = "split-dns.example"
+	splitDNSName   = "internal." + splitDNSDomain
+)
+
+// splitDNSZone holds the names served only by fakeSplitDNS.
+var splitDNSZone = map[string]netip.Addr{
+	splitDNSName: netip.MustParseAddr("10.99.1.1"),
+}
+
+// SplitDNSDomain returns the DNS suffix served only by the fake split-DNS
+// server. Point a DNS route for this suffix at [FakeSplitDNSIPv4] to verify
+// split-DNS routing.
+func SplitDNSDomain() string { return splitDNSDomain }
+
+// SplitDNSName returns a name in [SplitDNSDomain] served only by the fake
+// split-DNS server, along with the address it resolves to.
+func SplitDNSName() (name string, addr netip.Addr) {
+	return splitDNSName, splitDNSZone[splitDNSName]
+}
+
+// FakeSplitDNSIPv4 returns the IPv4 address of the secondary (split-DNS) fake
+// DNS server. It answers only [SplitDNSName].
+func FakeSplitDNSIPv4() netip.Addr { return fakeSplitDNS.v4 }
+
+// FakeSplitDNSIPv6 returns the IPv6 address of the secondary (split-DNS) fake
+// DNS server.
+func FakeSplitDNSIPv6() netip.Addr { return fakeSplitDNS.v6 }
 
 type virtualIP struct {
 	name string // for DNS

--- a/tstest/natlab/vnet/vip.go
+++ b/tstest/natlab/vnet/vip.go
@@ -23,11 +23,39 @@ var (
 	fakeFiles             = newVIP("files.tailscale", 6)      // serves binary files (tta, tailscale, tailscaled) to VMs
 	fakeACME              = newVIP("acme.example", 7)         // fake ACME CA for vmtests
 
+	// fakeSplitDNS is a second DNS server, distinct from fakeDNS, serving only
+	// splitDNSZone.
+	fakeSplitDNS = newVIP("split-dns", "4.11.4.12", "2411::412")
+
 	// FakeDualStackWeb is a dual-stack webserver VIP used by
 	// TestExitNodeV4Only to verify that traffic works through an
 	// IPv4-only exit node even when DNS returns both A and AAAA.
 	FakeDualStackWeb = newVIP("dualstack-web.example.com", "5.0.0.100", "2052::5:100")
 )
+
+// The zone served *only* by fakeSplitDNS, never by the default fakeDNS. An
+// answer of SplitDNSAddr for SplitDNSName therefore proves a split-DNS route to
+// fakeSplitDNS was honored; point a route for SplitDNSDomain at
+// [FakeSplitDNSIPv4] to verify that. Names are in DNS wire format, as the query
+// parser produces them: no trailing dot.
+const (
+	SplitDNSDomain = "split-dns.example"
+	SplitDNSName   = "internal." + SplitDNSDomain
+	SplitDNSAddr   = "10.99.1.1"
+)
+
+// splitDNSZone holds the names served only by fakeSplitDNS.
+var splitDNSZone = map[string]netip.Addr{
+	SplitDNSName: netip.MustParseAddr(SplitDNSAddr),
+}
+
+// FakeSplitDNSIPv4 returns the IPv4 address of the secondary (split-DNS) fake
+// DNS server. It answers only [SplitDNSName], with [SplitDNSAddr].
+func FakeSplitDNSIPv4() netip.Addr { return fakeSplitDNS.v4 }
+
+// FakeSplitDNSIPv6 returns the IPv6 address of the secondary (split-DNS) fake
+// DNS server.
+func FakeSplitDNSIPv6() netip.Addr { return fakeSplitDNS.v6 }
 
 type virtualIP struct {
 	name string // for DNS

--- a/tstest/natlab/vnet/vnet.go
+++ b/tstest/natlab/vnet/vnet.go
@@ -2498,7 +2498,7 @@ func isDNSRequest(pkt gopacket.Packet) bool {
 	if !ok {
 		return false
 	}
-	if !fakeDNS.Match(f.dst) {
+	if !fakeDNS.Match(f.dst) && !fakeSplitDNS.Match(f.dst) {
 		// TODO(bradfitz): maybe support configs where DNS is local in the LAN
 		return false
 	}
@@ -2547,6 +2547,10 @@ func (s *Server) createDNSResponse(pkt gopacket.Packet) ([]byte, error) {
 		ResponseCode: layers.DNSResponseCodeNoErr,
 	}
 
+	// Which of the two fake DNS servers was addressed; they serve disjoint
+	// name sets. See splitDNSZone.
+	toSplitDNS := fakeSplitDNS.Match(flow.dst)
+
 	var names []string
 	for _, q := range dnsLayer.Questions {
 		response.QDCount++
@@ -2561,6 +2565,21 @@ func (s *Server) createDNSResponse(pkt gopacket.Packet) ([]byte, error) {
 
 		names = append(names, q.Type.String()+"/"+string(q.Name))
 		if q.Class != layers.DNSClassIN {
+			continue
+		}
+
+		if toSplitDNS {
+			// The secondary server serves only its own zone, and only A records.
+			if addr, ok := splitDNSZone[string(q.Name)]; ok && q.Type == layers.DNSTypeA {
+				response.ANCount++
+				response.Answers = append(response.Answers, layers.DNSResourceRecord{
+					Name:  q.Name,
+					Type:  q.Type,
+					Class: q.Class,
+					IP:    addr.AsSlice(),
+					TTL:   60,
+				})
+			}
 			continue
 		}
 

--- a/tstest/natlab/vnet/vnet.go
+++ b/tstest/natlab/vnet/vnet.go
@@ -2498,7 +2498,7 @@ func isDNSRequest(pkt gopacket.Packet) bool {
 	if !ok {
 		return false
 	}
-	if !fakeDNS.Match(f.dst) {
+	if !fakeDNS.Match(f.dst) && !fakeSplitDNS.Match(f.dst) {
 		// TODO(bradfitz): maybe support configs where DNS is local in the LAN
 		return false
 	}
@@ -2547,6 +2547,10 @@ func (s *Server) createDNSResponse(pkt gopacket.Packet) ([]byte, error) {
 		ResponseCode: layers.DNSResponseCodeNoErr,
 	}
 
+	// Which of the two fake DNS servers was addressed; they serve disjoint
+	// name sets. See [splitDNSZone].
+	toSplitDNS := fakeSplitDNS.Match(flow.dst)
+
 	var names []string
 	for _, q := range dnsLayer.Questions {
 		response.QDCount++
@@ -2561,6 +2565,21 @@ func (s *Server) createDNSResponse(pkt gopacket.Packet) ([]byte, error) {
 
 		names = append(names, q.Type.String()+"/"+string(q.Name))
 		if q.Class != layers.DNSClassIN {
+			continue
+		}
+
+		if toSplitDNS {
+			// The secondary server serves only its own zone, and only A records.
+			if addr, ok := splitDNSZone[string(q.Name)]; ok && q.Type == layers.DNSTypeA {
+				response.ANCount++
+				response.Answers = append(response.Answers, layers.DNSResourceRecord{
+					Name:  q.Name,
+					Type:  q.Type,
+					Class: q.Class,
+					IP:    addr.AsSlice(),
+					TTL:   60,
+				})
+			}
 			continue
 		}
 

--- a/tstest/natlab/vnet/vnet_test.go
+++ b/tstest/natlab/vnet/vnet_test.go
@@ -86,6 +86,27 @@ func TestPacketSideEffects(t *testing.T) {
 					),
 				},
 				{
+					// The secondary DNS server answers its own zone. A test that
+					// routes a domain here and gets this answer has proven the
+					// split-DNS route was honored.
+					name: "split-dns-answers-own-zone",
+					pkt:  mkDNSReqTo(FakeSplitDNSIPv4(), splitDNSTestName()),
+					check: all(
+						numPkts(1),
+						pktSubstr("IP="+splitDNSTestAddr()),
+					),
+				},
+				{
+					// The default DNS server must NOT answer the split zone;
+					// that's what makes the answer above meaningful.
+					name: "default-dns-does-not-answer-split-zone",
+					pkt:  mkDNSReqTo(FakeDNSIPv4(), splitDNSTestName()),
+					check: all(
+						numPkts(1),
+						noPktSubstr("IP="+splitDNSTestAddr()),
+					),
+				},
+				{
 					name: "syslog-v4",
 					pkt:  mkSyslogPacket(clientIPv4(1), "<6>2024-08-30T10:36:06-07:00 natlabapp tailscaled[1]: 2024/08/30 10:36:06 some-message"),
 					check: all(
@@ -289,6 +310,50 @@ func mkAllNodesPing(srcMAC MAC, srcIP netip.Addr) []byte {
 	return mkEth(macAllNodes, srcMAC, ethType6, mustPacket(ip, icmp))
 }
 
+// splitDNSTestName and splitDNSTestAddr return the name served only by the
+// secondary (split-DNS) fake DNS server, and the address it resolves to.
+func splitDNSTestName() string {
+	name, _ := SplitDNSName()
+	return name
+}
+
+func splitDNSTestAddr() string {
+	_, addr := SplitDNSName()
+	return addr.String()
+}
+
+// mkDNSReqTo builds an A-record query for name over IPv4, sent to the given DNS
+// server address. It's like mkDNSReq but lets a test aim at the secondary
+// (split-DNS) server and ask for an arbitrary name.
+func mkDNSReqTo(dst netip.Addr, name string) []byte {
+	eth := &layers.Ethernet{
+		SrcMAC:       nodeMac(1).HWAddr(),
+		DstMAC:       routerMac(1).HWAddr(),
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+	ip := &layers.IPv4{
+		Version:  4,
+		Protocol: layers.IPProtocolUDP,
+		SrcIP:    clientIPv4(1).AsSlice(),
+		TTL:      64,
+		DstIP:    dst.AsSlice(),
+	}
+	udp := &layers.UDP{
+		SrcPort: 12345,
+		DstPort: 53,
+	}
+	udp.SetNetworkLayerForChecksum(ip)
+	dns := &layers.DNS{
+		ID: 790,
+		Questions: []layers.DNSQuestion{{
+			Name:  []byte(name),
+			Type:  layers.DNSTypeA,
+			Class: layers.DNSClassIN,
+		}},
+	}
+	return mustPacket(eth, ip, udp, dns)
+}
+
 // mkDNSReq makes a DNS request to "control.tailscale" using the source IPs as
 // defined in this test file.
 //
@@ -473,6 +538,21 @@ func pktSubstr(sub string) func(*sideEffects) error {
 			}
 		}
 		return fmt.Errorf("packet summary with substring %q not found", sub)
+	}
+}
+
+// noPktSubstr returns a side effect checker func that checks that no received
+// packet's summary contains the given substring. It's the counterpart to
+// pktSubstr, for asserting an answer was *not* given.
+func noPktSubstr(sub string) func(*sideEffects) error {
+	return func(se *sideEffects) error {
+		for _, pkt := range se.got {
+			pkt := gopacket.NewPacket(pkt.eth, layers.LayerTypeEthernet, gopacket.Lazy)
+			if got := pkt.String(); strings.Contains(got, sub) {
+				return fmt.Errorf("packet summary unexpectedly contains %q: %s", sub, got)
+			}
+		}
+		return nil
 	}
 }
 

--- a/tstest/natlab/vnet/vnet_test.go
+++ b/tstest/natlab/vnet/vnet_test.go
@@ -86,6 +86,27 @@ func TestPacketSideEffects(t *testing.T) {
 					),
 				},
 				{
+					// The secondary DNS server answers its own zone. A test that
+					// routes a domain here and gets this answer has proven the
+					// split-DNS route was honored.
+					name: "split-dns-answers-own-zone",
+					pkt:  mkDNSReqTo(FakeSplitDNSIPv4(), SplitDNSName),
+					check: all(
+						numPkts(1),
+						pktSubstr("IP="+SplitDNSAddr),
+					),
+				},
+				{
+					// The default DNS server must NOT answer the split zone;
+					// that's what makes the answer above meaningful.
+					name: "default-dns-does-not-answer-split-zone",
+					pkt:  mkDNSReqTo(FakeDNSIPv4(), SplitDNSName),
+					check: all(
+						numPkts(1),
+						noPktSubstr("IP="+SplitDNSAddr),
+					),
+				},
+				{
 					name: "syslog-v4",
 					pkt:  mkSyslogPacket(clientIPv4(1), "<6>2024-08-30T10:36:06-07:00 natlabapp tailscaled[1]: 2024/08/30 10:36:06 some-message"),
 					check: all(
@@ -289,6 +310,38 @@ func mkAllNodesPing(srcMAC MAC, srcIP netip.Addr) []byte {
 	return mkEth(macAllNodes, srcMAC, ethType6, mustPacket(ip, icmp))
 }
 
+// mkDNSReqTo builds an A-record query for name over IPv4, sent to the given DNS
+// server address. It's like mkDNSReq but lets a test aim at the secondary
+// (split-DNS) server and ask for an arbitrary name.
+func mkDNSReqTo(dst netip.Addr, name string) []byte {
+	eth := &layers.Ethernet{
+		SrcMAC:       nodeMac(1).HWAddr(),
+		DstMAC:       routerMac(1).HWAddr(),
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+	ip := &layers.IPv4{
+		Version:  4,
+		Protocol: layers.IPProtocolUDP,
+		SrcIP:    clientIPv4(1).AsSlice(),
+		TTL:      64,
+		DstIP:    dst.AsSlice(),
+	}
+	udp := &layers.UDP{
+		SrcPort: 12345,
+		DstPort: 53,
+	}
+	udp.SetNetworkLayerForChecksum(ip)
+	dns := &layers.DNS{
+		ID: 790,
+		Questions: []layers.DNSQuestion{{
+			Name:  []byte(name),
+			Type:  layers.DNSTypeA,
+			Class: layers.DNSClassIN,
+		}},
+	}
+	return mustPacket(eth, ip, udp, dns)
+}
+
 // mkDNSReq makes a DNS request to "control.tailscale" using the source IPs as
 // defined in this test file.
 //
@@ -473,6 +526,21 @@ func pktSubstr(sub string) func(*sideEffects) error {
 			}
 		}
 		return fmt.Errorf("packet summary with substring %q not found", sub)
+	}
+}
+
+// noPktSubstr returns a side effect checker func that checks that no received
+// packet's summary contains the given substring. It's the counterpart to
+// pktSubstr, for asserting an answer was *not* given.
+func noPktSubstr(sub string) func(*sideEffects) error {
+	return func(se *sideEffects) error {
+		for _, pkt := range se.got {
+			pkt := gopacket.NewPacket(pkt.eth, layers.LayerTypeEthernet, gopacket.Lazy)
+			if got := pkt.String(); strings.Contains(got, sub) {
+				return fmt.Errorf("packet summary unexpectedly contains %q: %s", sub, got)
+			}
+		}
+		return nil
 	}
 }
 


### PR DESCRIPTION
Add split-DNS coverage to natlab.

`vnet` gains a second fake DNS server (4.11.4.12) serving a zone the default one doesn't, so resolving a name in that zone proves the query was forwarded there. Two packet-level tests assert each server's behavior.

`tailscaled` implements a split-DNS route two ways, and a vmtest covers each. When the OS resolver supports split DNS and every route shares one resolver set, `tailscaled` hands the OS that resolver and quad-100 leaves the query path; `TestSplitDNSOSForwarded` covers this, reaching the resolver over a subnet route as a real deployment would. Otherwise the OS points at quad-100, which forwards per-domain itself; `TestSplitDNS` covers this on both the systemd-resolved and direct backends (`WithDNSMode`/`AssertDNSBackend`), along with the other ways a lookup resolves - answered locally by quad-100 from an ExtraRecord or the netmap, a bare name completed by a search domain, and an unrouted name still going to the machine's normal resolver.

Both arrangements produce the same answers, so each test also asserts the guest's resolver state to prove which one it exercised.

Fixes tailscale/corp#44798