### PR TITLE
wgengine, net/dns: retry DNS config on config failure after major link change

### DIFF
--- a/net/dns/manager.go
+++ b/net/dns/manager.go
@@ -38,9 +38,6 @@ import (
 
 var (
 	errFullQueue = errors.New("request queue full")
-	// ErrNoDNSConfig is returned by RecompileDNSConfig when the Manager
-	// has no existing DNS configuration.
-	ErrNoDNSConfig = errors.New("no DNS configuration")
 )
 
 // maxActiveQueries returns the maximal number of DNS requests that can
@@ -142,29 +139,6 @@ func (m *Manager) ProbeLocks() {
 	}
 }
 
-// RecompileDNSConfig recompiles the last attempted DNS configuration, which has
-// the side effect of re-querying the OS's interface nameservers.  This should be used
-// on platforms where the interface nameservers can change.  Darwin, for example,
-// where the nameservers aren't always available when we process a major interface
-// change event, or platforms where the nameservers may change while tunnel is up.
-//
-// This should be called if it is determined that [OSConfigurator.GetBaseConfig] may
-// give a better or different result than when [Manager.Set] was last called.  The
-// logic for making that determination is up to the caller.
-//
-// It returns [ErrNoDNSConfig] if [Manager.Set] has never been called.
-func (m *Manager) RecompileDNSConfig() error {
-	if !buildfeatures.HasDNS {
-		return nil
-	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.config != nil {
-		return m.setLocked(*m.config)
-	}
-	return ErrNoDNSConfig
-}
-
 func (m *Manager) Set(cfg Config) error {
 	if !buildfeatures.HasDNS {
 		return nil
@@ -193,12 +167,6 @@ func (m *Manager) setLocked(cfg Config) error {
 	}))
 
 	rcfg, ocfg, err := m.compileConfig(cfg)
-	if err != nil {
-		// On a compilation failure, set m.config set for later reuse by
-		// [Manager.RecompileDNSConfig] and return the error.
-		m.config = &cfg
-		return err
-	}
 
 	m.logf("Resolvercfg: %v", logger.ArgWriter(func(w *bufio.Writer) {
 		rcfg.WriteToBufioWriter(w)
@@ -215,10 +183,12 @@ func (m *Manager) setLocked(cfg Config) error {
 		return err
 	}
 
-	m.health.SetHealthy(osConfigurationSetWarnable)
+	if err == nil {
+		m.health.SetHealthy(osConfigurationSetWarnable)
+	}
 	m.config = &cfg
 
-	return nil
+	return err
 }
 
 func (m *Manager) setDNSLocked(ocfg OSConfig) error {
@@ -411,8 +381,8 @@ func (m *Manager) compileConfig(cfg Config) (rcfg resolver.Config, ocfg OSConfig
 	// If the OS can't do native split-DNS, read out the underlying resolver
 	// config and blend it into our config. On iOS, [OSConfigurator.GetBaseConfig]
 	// has a tendency to temporarily fail if called immediately following an
-	// interface change. These failures should be retried if/when the OS indicates
-	// that the DNS configuration has changed via [RecompileDNSConfig].
+	// interface change.  Errors here indicate that this operation should be
+	// retried.
 	base, err := m.os.GetBaseConfig()
 	if err != nil {
 		if (isIOS || isNoopManager(m.os)) && err == ErrGetBaseConfigNotSupported {
@@ -422,8 +392,23 @@ func (m *Manager) compileConfig(cfg Config) (rcfg resolver.Config, ocfg OSConfig
 			ocfg.MatchDomains = cfg.matchDomains()
 			return rcfg, ocfg, nil
 		}
+		// We couldn't read the OS's base resolver config. This happens
+		// transiently on Apple platforms right after a link change, before
+		// the OS has populated the new interface's resolvers.
+		//
+		// Rather than abort the whole apply, we apply the rest of the config
+		// (MagicDNS hosts and the tailnet split routes) but with NO default
+		// ("." ) resolver. Aborting would leave the forwarder's previous "."
+		// route in place, pointing at the prior network's now-unreachable
+		// resolver, which black-holes all non-tailnet DNS until something
+		// re-drives the config. With no default resolver, queries we don't
+		// otherwise handle fail fast with SERVFAIL (the client retries)
+		// instead of being sent to a dead or incorrect upstream.  We return the
+		// error here so that the caller knows to retry.
 		m.health.SetUnhealthy(osConfigurationReadWarnable, health.Args{health.ArgError: err.Error()})
-		return resolver.Config{}, OSConfig{}, err
+		m.logf("dns: GetBaseConfig failed (%v); applying config with no default resolver rather than retaining the previous one", err)
+		delete(rcfg.Routes, ".")
+		return rcfg, ocfg, err
 	}
 	m.health.SetHealthy(osConfigurationReadWarnable)
 

--- a/net/dns/manager_test.go
+++ b/net/dns/manager_test.go
@@ -6,7 +6,6 @@ package dns
 import (
 	"bytes"
 	"context"
-	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -1111,56 +1110,6 @@ func upstreams(strs ...string) (ret map[dnsname.FQDN][]*dnstype.Resolver) {
 		}
 	}
 	return ret
-}
-
-func TestConfigRecompilation(t *testing.T) {
-	fakeErr := errors.New("fake os configurator error")
-	f := &fakeOSConfigurator{}
-	f.GetBaseConfigErr = &fakeErr
-	f.BaseConfig = OSConfig{
-		Nameservers: mustIPs("1.1.1.1"),
-	}
-
-	config := Config{
-		Routes:        upstreams("ts.net", "69.4.2.0", "foo.ts.net", ""),
-		SearchDomains: fqdns("foo.ts.net"),
-	}
-
-	bus := eventbustest.NewBus(t)
-	dialer := tsdial.NewDialer(netmon.NewStatic())
-	dialer.SetBus(bus)
-	m := NewManager(t.Logf, f, health.NewTracker(bus), dialer, nil, nil, "darwin", bus)
-
-	var managerConfig *resolver.Config
-	m.resolver.TestOnlySetHook(func(cfg resolver.Config) {
-		managerConfig = &cfg
-	})
-
-	// Initial set should error out and store the config
-	if err := m.Set(config); err == nil {
-		t.Fatalf("Want non-nil error.  Got nil")
-	}
-	if m.config == nil {
-		t.Fatalf("Want persisted config.  Got nil.")
-	}
-	if managerConfig != nil {
-		t.Fatalf("Want nil managerConfig.  Got %v", managerConfig)
-	}
-
-	// Clear the error.  We should take the happy path now and
-	// set m.manager's Config.
-	f.GetBaseConfigErr = nil
-
-	// Recompilation without an error should succeed and set m.config and m.manager's [resolver.Config]
-	if err := m.RecompileDNSConfig(); err != nil {
-		t.Fatalf("Want nil error.  Got err %v", err)
-	}
-	if m.config == nil {
-		t.Fatalf("Want non-nil config.  Got nil")
-	}
-	if managerConfig == nil {
-		t.Fatalf("Want non nil managerConfig.  Got nil")
-	}
 }
 
 func TestTrampleRetrample(t *testing.T) {

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -47,6 +47,7 @@ import (
 	"tailscale.com/types/key"
 	"tailscale.com/types/logger"
 	"tailscale.com/types/views"
+	"tailscale.com/util/backoff"
 	"tailscale.com/util/checkchange"
 	"tailscale.com/util/clientmetric"
 	"tailscale.com/util/eventbus"
@@ -75,7 +76,9 @@ type userspaceEngine struct {
 	logf           logger.Logf
 	wgLogger       *wglog.Logger // a wireguard-go logging wrapper
 	reqCh          chan struct{}
-	waitCh         chan struct{} // chan is closed when first Close call completes; contrast with closing bool
+	waitCh         chan struct{}      // chan is closed when first Close call completes; contrast with closing bool
+	ctx            context.Context    // canceled by Close; used to interrupt background retries (e.g. DNS reapply)
+	ctxCancel      context.CancelFunc // cancels ctx
 	timeNow        func() mono.Time
 	tundev         *tstun.Wrapper
 	wgdev          *device.Device
@@ -135,6 +138,9 @@ type userspaceEngine struct {
 	statusCallback StatusCallback
 	endpoints      []tailcfg.Endpoint
 	pendOpen       map[flowtrackTuple]*pendingOpenFlow // see pendopen.go
+
+	linkChangeGen      uint64         // bumped on every major-link-change that triggers a DNS reconfiguration
+	dnsConfigurationWG sync.WaitGroup // tracks background DNS reapply retries; awaited by Close after ctxCancel
 
 	// pongCallback is the map of response handlers waiting for disco or TSMP
 	// pong callbacks. The map key is a random slice of bytes.
@@ -361,12 +367,15 @@ func NewUserspaceEngine(logf logger.Logf, conf Config) (_ Engine, reterr error) 
 		rtr = router.ConsolidatingRoutes(logf, rtr)
 	}
 
+	ctx, ctxCancel := context.WithCancel(context.Background())
 	e := &userspaceEngine{
 		eventBus:       conf.EventBus,
 		timeNow:        mono.Now,
 		logf:           logf,
 		reqCh:          make(chan struct{}, 1),
 		waitCh:         make(chan struct{}),
+		ctx:            ctx,
+		ctxCancel:      ctxCancel,
 		tundev:         tsTUNDev,
 		router:         rtr,
 		dialer:         conf.Dialer,
@@ -986,6 +995,10 @@ func (e *userspaceEngine) getStatusCallback() StatusCallback {
 
 var ErrEngineClosing = errors.New("engine closing; no status")
 
+// errDNSReapplyRetry is a non-nil sentinel passed to backoff.BackOff to make
+// it sleep between DNS reapply retries. It is never returned to callers.
+var errDNSReapplyRetry = errors.New("dns reapply retry")
+
 func (e *userspaceEngine) PeerByKey(pubKey key.NodePublic) (_ wgint.Peer, ok bool) {
 	e.wgLock.Lock()
 	dev := e.wgdev
@@ -1112,6 +1125,12 @@ func (e *userspaceEngine) Close() {
 	e.closing = true
 	e.mu.Unlock()
 
+	// Cancel any background work (e.g. the DNS reapply retry loop) and wait
+	// for it to finish before tearing down the subsystems it uses, so it
+	// can't call into e.dns after e.dns.Down below.
+	e.ctxCancel()
+	e.dnsConfigurationWG.Wait()
+
 	e.magicConn.Close()
 	if e.netMonOwned {
 		e.netMon.Close()
@@ -1164,25 +1183,22 @@ func (e *userspaceEngine) linkChange(delta *netmon.ChangeDelta) {
 	// are not currently on) breaks DNS resolution system-wide.  There are notable
 	// timing issues here with Darwin's network stack.  It is not guaranteed that
 	// the forward resolver will be available immediately after the interface
-	// comes up.  We leave it to the network extension to also poke magicDNS directly
-	// via [dns.Manager.RecompileDNSConfig] when it detects any change in the
-	// nameservers.
-	//
+	// comes up.
+
 	// TODO: On Android, Darwin-tailscaled, and openbsd, why do we need this?
 	if delta.RebindLikelyRequired && up {
 		switch runtime.GOOS {
 		case "linux", "android", "ios", "darwin", "openbsd":
-			e.wgLock.Lock()
-			dnsCfg := e.lastDNSConfig
-			e.wgLock.Unlock()
-			if dnsCfg.Valid() {
-				if err := e.dns.Set(*dnsCfg.AsStruct()); err != nil {
-					e.logf("wgengine: error setting DNS config after major link change: %v", err)
-				} else if err := e.reconfigureVPNIfNecessary(); err != nil {
-					e.logf("wgengine: error reconfiguring VPN after major link change: %v", err)
-				} else {
-					e.logf("wgengine: set DNS config again after major link change")
-				}
+			// Bump the generation first so any retry loop from a prior
+			// link change exits, then attempt the reapply once inline
+			// (the common case where the OS is already settled). If it
+			// fails, kick off a background retry.
+			gen := e.nextLinkChangeGen()
+			if err := e.reconfigureDNSOnLinkChange(); err != nil {
+				e.logf("dns: error setting DNS config after major link change: %v.  Will retry.", err)
+				e.retryDNSReconfiguration(gen)
+			} else {
+				e.logf("dns: set DNS config again after major link change")
 			}
 		}
 	}
@@ -1204,6 +1220,69 @@ func (e *userspaceEngine) linkChange(delta *netmon.ChangeDelta) {
 		}
 		e.magicConn.ReSTUN(why)
 	}
+}
+
+// nextLinkChangeGen bumps and returns the DNS-reapply generation counter. A
+// background retry loop started for a given generation exits once a newer
+// generation is observed, ensuring only the most recent link change's retry
+// stays active. See linkChange and retryDNSReapply.
+func (e *userspaceEngine) nextLinkChangeGen() uint64 {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.linkChangeGen++
+	return e.linkChangeGen
+}
+
+func (e *userspaceEngine) reconfigureDNSOnLinkChange() error {
+	e.wgLock.Lock()
+	dnsCfg := e.lastDNSConfig
+	e.wgLock.Unlock()
+	if !dnsCfg.Valid() {
+		return nil
+	}
+	if err := e.dns.Set(*dnsCfg.AsStruct()); err != nil {
+		return err
+	}
+	return e.reconfigureVPNIfNecessary()
+}
+
+// retryDNSReconfiguration retries reconfigureDNSOnLinkChange in the background until it
+// succeeds, the engine closes, or a newer link change supersedes gen (see
+// linkChangeGen). It runs detached from the linkChangeQueue so it never
+// blocks Close's drain of that queue.
+//
+// The reapply can fail transiently right after a link change because the OS
+// hasn't finished bringing the new interface (and its resolvers) up. On the
+// affected platforms (notably Apple netext, where MagicDNS is ~always the
+// default resolver), a failure leaves the forwarder pointed at the previous
+// network's resolver, breaking DNS system-wide until something else re-drives
+// the config. Retrying closes that gap.
+func (e *userspaceEngine) retryDNSReconfiguration(gen uint64) {
+	e.dnsConfigurationWG.Add(1)
+	go func() {
+		defer e.dnsConfigurationWG.Done()
+		bo := backoff.NewBackoff("dns-reapply", e.logf, 5*time.Second)
+		for {
+			// Sleep before retrying; the first inline attempt already
+			// failed by the time we get here. BackOff returns immediately
+			// if the engine's ctx is canceled.
+			bo.BackOff(e.ctx, errDNSReapplyRetry)
+
+			e.mu.Lock()
+			superseded := e.linkChangeGen != gen
+			e.mu.Unlock()
+			if e.ctx.Err() != nil || superseded {
+				return
+			}
+
+			if err := e.reconfigureDNSOnLinkChange(); err != nil {
+				e.logf("dns: error setting DNS config on retry: %v.  Retrying again.", err)
+				continue
+			}
+			e.logf("dns: set DNS config after major link change (on retry)")
+			return
+		}
+	}()
 }
 
 func (e *userspaceEngine) SetSelfNode(self tailcfg.NodeView) {

--- a/wgengine/userspace_test.go
+++ b/wgengine/userspace_test.go
@@ -4,6 +4,7 @@
 package wgengine
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -521,6 +522,225 @@ func TestLinkChangeReapplyPreservesMagicDNSRoutes(t *testing.T) {
 	if !slices.Equal(initial, after) {
 		t.Errorf("resolver LocalDomains changed after linkChange:\n  initial: %s\n  after:   %s",
 			logger.AsJSON(initial), logger.AsJSON(after))
+	}
+}
+
+// retryDNSOSConfigurator is a dns.OSConfigurator (SplitDNS=false) whose
+// GetBaseConfig can be made to fail a settable number of times and to return a
+// settable nameserver. It simulates the transient "no resolvers found" failure
+// that can occur right after a link change while the OS is still bringing the
+// new interface up.
+type retryDNSOSConfigurator struct {
+	mu            sync.Mutex
+	failsLeft     int
+	baseNS        netip.Addr
+	getBaseCnt    int
+	firstCallCh   chan struct{} // closed on first GetBaseConfig call after notifyFirstCall
+	firstCallDone bool
+}
+
+func (c *retryDNSOSConfigurator) SetDNS(dns.OSConfig) error { return nil }
+func (c *retryDNSOSConfigurator) SupportsSplitDNS() bool    { return false }
+func (c *retryDNSOSConfigurator) Close() error              { return nil }
+
+func (c *retryDNSOSConfigurator) GetBaseConfig() (dns.OSConfig, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.getBaseCnt++
+	if c.firstCallCh != nil && !c.firstCallDone {
+		c.firstCallDone = true
+		close(c.firstCallCh)
+	}
+	if c.failsLeft > 0 {
+		c.failsLeft--
+		return dns.OSConfig{}, fmt.Errorf("getDNSServers failed: Fallthrough, no resolvers found")
+	}
+	return dns.OSConfig{Nameservers: []netip.Addr{c.baseNS}}, nil
+}
+
+// arm updates the nameserver GetBaseConfig will return and how many upcoming
+// calls should fail first.
+func (c *retryDNSOSConfigurator) arm(baseNS netip.Addr, fails int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.baseNS = baseNS
+	c.failsLeft = fails
+}
+
+func (c *retryDNSOSConfigurator) calls() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.getBaseCnt
+}
+
+// notifyFirstCall returns a channel that is closed the first time
+// GetBaseConfig is called after this method returns.
+func (c *retryDNSOSConfigurator) notifyFirstCall() <-chan struct{} {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ch := make(chan struct{})
+	c.firstCallCh = ch
+	c.firstCallDone = false
+	return ch
+}
+
+// splitDNSConfig is a DNS config with a route that has upstream resolvers,
+// which forces net/dns.Manager.compileConfig down the path that reads
+// GetBaseConfig to build the "." (default) route.
+func splitDNSConfig() *dns.Config {
+	return &dns.Config{
+		Routes: map[dnsname.FQDN][]*dnstype.Resolver{
+			"ts.net.": {{Addr: "1.2.3.4"}},
+		},
+		SearchDomains: []dnsname.FQDN{"ts.net."},
+	}
+}
+
+// TestLinkChangeDNSReapplyRetry is a regression test for the bug where a
+// transient GetBaseConfig failure during the major-link-change DNS reapply
+// left the forwarder pointed at the previous network's resolver until the
+// tunnel was toggled. The reapply must retry until it succeeds and installs
+// the new base resolver.
+func TestLinkChangeDNSReapplyRetry(t *testing.T) {
+	switch runtime.GOOS {
+	case "linux", "android", "darwin", "ios", "openbsd":
+	default:
+		t.Skipf("linkChange DNS reapply path not exercised on %s", runtime.GOOS)
+	}
+
+	oldNS := netip.MustParseAddr("192.168.0.1")
+	newNS := netip.MustParseAddr("10.0.1.1")
+	// Initially healthy so the first Reconfig installs the old network's
+	// resolver as the "." route.
+	osCfg := &retryDNSOSConfigurator{baseNS: oldNS}
+
+	bus := eventbustest.NewBus(t)
+	e, err := NewUserspaceEngine(t.Logf, Config{
+		HealthTracker: health.NewTracker(bus),
+		Metrics:       new(usermetric.Registry),
+		EventBus:      bus,
+		DNS:           osCfg,
+		RespondToPing: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(e.Close)
+
+	var (
+		mu   sync.Mutex
+		last resolver.Config
+	)
+	e.(*userspaceEngine).dns.Resolver().TestOnlySetHook(func(cfg resolver.Config) {
+		mu.Lock()
+		defer mu.Unlock()
+		last = cfg
+	})
+	defaultRoute := func() []*dnstype.Resolver {
+		mu.Lock()
+		defer mu.Unlock()
+		return last.Routes["."]
+	}
+
+	if err := e.Reconfig(&wgcfg.Config{}, &router.Config{}, splitDNSConfig()); err != nil {
+		t.Fatalf("Reconfig: %v", err)
+	}
+	if got := defaultRoute(); len(got) != 1 || got[0].Addr != oldNS.String() {
+		t.Fatalf("initial default route = %v; want [%s]", got, oldNS)
+	}
+
+	// Simulate a network transition: the new network's resolver is newNS,
+	// but GetBaseConfig fails transiently the first couple of times (as it
+	// does on Apple platforms right after a link change).
+	osCfg.arm(newNS, 2)
+
+	cd, err := netmon.NewChangeDelta(nil, &netmon.State{HaveV4: true}, 0, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cd.RebindLikelyRequired = true
+	e.(*userspaceEngine).linkChange(cd)
+
+	// The inline reapply fails, and so does the first retry; the retry loop
+	// must keep going until GetBaseConfig succeeds and the "." route points
+	// at the new base nameserver rather than staying stuck at oldNS.
+	wantAddr := newNS.String()
+	deadline := time.Now().Add(2 * time.Second)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for range ticker.C {
+		routes := defaultRoute()
+		if len(routes) == 1 && routes[0].Addr == wantAddr {
+			break // recovered
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("default route never updated to %q; got %v (GetBaseConfig calls=%d)",
+				wantAddr, routes, osCfg.calls())
+		}
+	}
+}
+
+// TestLinkChangeDNSReapplyRetryStopsOnClose verifies that the background DNS
+// reapply retry loop exits promptly when the engine is closed, rather than
+// spinning or calling into a torn-down dns.Manager.
+func TestLinkChangeDNSReapplyRetryStopsOnClose(t *testing.T) {
+	switch runtime.GOOS {
+	case "linux", "android", "darwin", "ios", "openbsd":
+	default:
+		t.Skipf("linkChange DNS reapply path not exercised on %s", runtime.GOOS)
+	}
+
+	osCfg := &retryDNSOSConfigurator{baseNS: netip.MustParseAddr("192.168.0.1")}
+	started := osCfg.notifyFirstCall() // closed when the first GetBaseConfig call is made
+
+	bus := eventbustest.NewBus(t)
+	e, err := NewUserspaceEngine(t.Logf, Config{
+		HealthTracker: health.NewTracker(bus),
+		Metrics:       new(usermetric.Registry),
+		EventBus:      bus,
+		DNS:           osCfg,
+		RespondToPing: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := e.Reconfig(&wgcfg.Config{}, &router.Config{}, splitDNSConfig()); err != nil {
+		t.Fatalf("Reconfig: %v", err)
+	}
+
+	// Make GetBaseConfig fail forever so the retry loop never succeeds on
+	// its own; only Close should stop it.
+	osCfg.arm(netip.MustParseAddr("10.0.1.1"), 1<<30)
+
+	cd, err := netmon.NewChangeDelta(nil, &netmon.State{HaveV4: true}, 0, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cd.RebindLikelyRequired = true
+	e.(*userspaceEngine).linkChange(cd) // starts a retry loop that will keep failing
+
+	// wait for retry loop to have made its first call
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	select {
+	case <-started:
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for first GetBaseConfig call in retry loop")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		e.Close()
+		close(done)
+	}()
+
+	ctx, cancel = context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatal("Close hung, likely blocked by the DNS reapply retry loop")
 	}
 }
 


### PR DESCRIPTION
On a major link change GetBaseConfig can fail transiently right after the interface changes if it is called before the OS has populated the new interface's resolvers. A failed DNS config will leave the forwarder pointed at the prior network's now unreachable resolver.   This results in a short period where all DNS queries fail with timeouts rather than failing fast with a SERVFAIL.

We now retry the DNS configuration with a capped backoff until it succeeds, is superseded by a newer link change, or the engine closes. The retry runs detached from the linkChangeQueue and is awaited by Close. This eliminates the need for the racy RecompileDNSConfig call from the front-end.

When we cannot fetch the interface's nameservers , we clear the dns route so we fail fast with SERVFAIL.  This is more consistent with the expected behaviour in this state.   We configure what we can, and propagate the error so that magicsock knows DNS is still in a partially configured/broken state so it can retry.

This is difficult to reproduce on macOS directly since the GetBaseConfig errors are seemingly network related.  It was primarily tested by simulating repeated artificial failures in the getDNSServers path.

This is a breaking change in corp.  [This patch](https://github.com/tailscale/corp/pull/45338) removes the RecompileDNSConfig invocation from the macOS and iOS clients.