### PR TITLE
tstest/integration: run Windows integration tests against the service by default.

### DIFF
--- a/feature/taildrop/integration_test.go
+++ b/feature/taildrop/integration_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"runtime"
 	"testing"
 	"time"
 
@@ -40,6 +41,9 @@ func TestTaildropIntegration_Fresh(t *testing.T) {
 //
 // This exercises an ipnext hook ordering issue we hit earlier.
 func testTaildropIntegration(t *testing.T, freshProfiles bool) {
+	if runtime.GOOS == "windows" {
+		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
+	}
 	tstest.Parallel(t)
 	controlOpt := integration.ConfigureControl(func(s *testcontrol.Server) {
 		s.AllNodesSameUser = true // required for Taildrop

--- a/tstest/integration/capmap_test.go
+++ b/tstest/integration/capmap_test.go
@@ -5,6 +5,7 @@ package integration
 
 import (
 	"errors"
+	"runtime"
 	"testing"
 	"time"
 
@@ -14,6 +15,9 @@ import (
 
 // TestPeerCapMap tests that the node capability map (CapMap) is included in peer information.
 func TestPeerCapMap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
+	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 
@@ -96,6 +100,9 @@ func TestPeerCapMap(t *testing.T) {
 
 // TestSetNodeCapMap tests that SetNodeCapMap updates are propagated to peers.
 func TestSetNodeCapMap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
+	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 

--- a/tstest/integration/integration.go
+++ b/tstest/integration/integration.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -60,8 +61,7 @@ var (
 	verboseTailscaled = flag.Bool("verbose-tailscaled", false, "verbose tailscaled logging")
 	verboseTailscale  = flag.Bool("verbose-tailscale", false, "verbose tailscale CLI logging")
 
-	// runWindowsServiceTests enables the Windows service-mode integration tests.
-	// On by default in CI; tests opt in via NewTestEnv(t, canRunAsServiceOnWindows()).
+	// runWindowsServiceTests enables the Windows service-mode integration tests, on by default in CI.
 	runWindowsServiceTests = flag.Bool("run-windows-service-tests", cibuild.On(), "run Windows service-mode integration tests")
 )
 
@@ -541,37 +541,10 @@ func (f ConfigureControl) ModifyTestEnv(te *TestEnv) {
 	f(te.Control)
 }
 
-// canRunAsServiceOnWindowsOpt is the TestEnvOpt returned by canRunAsServiceOnWindows.
-type canRunAsServiceOnWindowsOpt struct{}
-
-func (canRunAsServiceOnWindowsOpt) ModifyTestEnv(te *TestEnv) {
-	// Only run as a service on Windows; on other platforms the test runs
-	// the normal userspace daemon with a faked Windows GOOS, as it always has.
-	if runtime.GOOS == "windows" {
-		te.windowsService = true
-	}
-}
-
-// canRunAsServiceOnWindows enables the test to run on Windows.
-// TODO(#20464): remove this and explicitly skip tests that need more work
-// before they can run on Windows, instead of requiring tests to opt in with this option.
-func canRunAsServiceOnWindows() TestEnvOpt { return canRunAsServiceOnWindowsOpt{} }
-
 // NewTestEnv starts a bunch of services and returns a new test environment.
 // NewTestEnv arranges for the environment's resources to be cleaned up on exit.
 func NewTestEnv(t testing.TB, opts ...TestEnvOpt) *TestEnv {
-	// Integration tests skip on Windows unless a test opts in via canRunAsServiceOnWindows.
-	// Pre-scan the opts before starting any servers so a skip leaks nothing.
-	canRunAsService := false
-	for _, o := range opts {
-		if _, ok := o.(canRunAsServiceOnWindowsOpt); ok {
-			canRunAsService = true
-		}
-	}
 	if runtime.GOOS == "windows" {
-		if !canRunAsService {
-			t.Skip("integration tests skip on Windows unless the test calls canRunAsServiceOnWindows")
-		}
 		if !*runWindowsServiceTests {
 			t.Skip("Windows service tests disabled (--run-windows-service-tests=false)")
 		}
@@ -587,6 +560,7 @@ func NewTestEnv(t testing.TB, opts ...TestEnvOpt) *TestEnv {
 	binaries := GetBinaries(t)
 	e := &TestEnv{
 		t:                 t,
+		windowsService:    runtime.GOOS == "windows",
 		cli:               binaries.Tailscale.Path,
 		daemon:            binaries.Tailscaled.Path,
 		LogCatcher:        logc,
@@ -966,6 +940,13 @@ func (n *TestNode) MustUp(extraArgs ...string) {
 		"up",
 		"--login-server=" + n.env.ControlURL(),
 		"--reset",
+	}
+	if runtime.GOOS == "windows" {
+		// Windows drops the profile when the last client disconnects, so --unattended keeps it across polls.
+		if !slices.Contains(extraArgs, "--unattended") {
+			args = append(args, "--unattended")
+		}
+		args = append(args, "--timeout=90s")
 	}
 	args = append(args, extraArgs...)
 	cmd := n.Tailscale(args...)

--- a/tstest/integration/integration.go
+++ b/tstest/integration/integration.go
@@ -9,6 +9,7 @@ package integration
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -26,6 +27,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -60,8 +62,7 @@ var (
 	verboseTailscaled = flag.Bool("verbose-tailscaled", false, "verbose tailscaled logging")
 	verboseTailscale  = flag.Bool("verbose-tailscale", false, "verbose tailscale CLI logging")
 
-	// runWindowsServiceTests enables the Windows service-mode integration tests.
-	// On by default in CI; tests opt in via NewTestEnv(t, canRunAsServiceOnWindows()).
+	// runWindowsServiceTests enables the Windows service-mode integration tests, on by default in CI.
 	runWindowsServiceTests = flag.Bool("run-windows-service-tests", cibuild.On(), "run Windows service-mode integration tests")
 )
 
@@ -541,37 +542,10 @@ func (f ConfigureControl) ModifyTestEnv(te *TestEnv) {
 	f(te.Control)
 }
 
-// canRunAsServiceOnWindowsOpt is the TestEnvOpt returned by canRunAsServiceOnWindows.
-type canRunAsServiceOnWindowsOpt struct{}
-
-func (canRunAsServiceOnWindowsOpt) ModifyTestEnv(te *TestEnv) {
-	// Only run as a service on Windows; on other platforms the test runs
-	// the normal userspace daemon with a faked Windows GOOS, as it always has.
-	if runtime.GOOS == "windows" {
-		te.windowsService = true
-	}
-}
-
-// canRunAsServiceOnWindows enables the test to run on Windows.
-// TODO(#20464): remove this and explicitly skip tests that need more work
-// before they can run on Windows, instead of requiring tests to opt in with this option.
-func canRunAsServiceOnWindows() TestEnvOpt { return canRunAsServiceOnWindowsOpt{} }
-
 // NewTestEnv starts a bunch of services and returns a new test environment.
 // NewTestEnv arranges for the environment's resources to be cleaned up on exit.
 func NewTestEnv(t testing.TB, opts ...TestEnvOpt) *TestEnv {
-	// Integration tests skip on Windows unless a test opts in via canRunAsServiceOnWindows.
-	// Pre-scan the opts before starting any servers so a skip leaks nothing.
-	canRunAsService := false
-	for _, o := range opts {
-		if _, ok := o.(canRunAsServiceOnWindowsOpt); ok {
-			canRunAsService = true
-		}
-	}
 	if runtime.GOOS == "windows" {
-		if !canRunAsService {
-			t.Skip("integration tests skip on Windows unless the test calls canRunAsServiceOnWindows")
-		}
 		if !*runWindowsServiceTests {
 			t.Skip("Windows service tests disabled (--run-windows-service-tests=false)")
 		}
@@ -587,6 +561,7 @@ func NewTestEnv(t testing.TB, opts ...TestEnvOpt) *TestEnv {
 	binaries := GetBinaries(t)
 	e := &TestEnv{
 		t:                 t,
+		windowsService:    runtime.GOOS == "windows",
 		cli:               binaries.Tailscale.Path,
 		daemon:            binaries.Tailscaled.Path,
 		LogCatcher:        logc,
@@ -1130,6 +1105,16 @@ func (n *TestNode) TailscaleForOutput(arg ...string) *exec.Cmd {
 // Tailscale returns a command that runs the tailscale CLI with the provided arguments.
 // It does not start the process.
 func (n *TestNode) Tailscale(arg ...string) *exec.Cmd {
+	isUp := len(arg) > 0 && arg[0] == "up"
+	if isUp && cmp.Or(n.upFlagGOOS, runtime.GOOS) == "windows" {
+		isBareUp := len(arg) == 1
+		// --unattended keeps the current profile after the CLI exits; without it
+		// Windows switches to an empty background profile and the node drops to NoState.
+		// TODO(yaruk): also run tests without --unattended; see #20751.
+		if !isBareUp && !slices.Contains(arg, "--unattended") {
+			arg = append(arg, "--unattended")
+		}
+	}
 	cmd := exec.Command(n.env.cli)
 	cmd.Args = append(cmd.Args, "--socket="+n.sockFile)
 	cmd.Args = append(cmd.Args, arg...)

--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -206,6 +206,9 @@ func TestExpectedFeaturesLinked(t *testing.T) {
 }
 
 func TestCollectPanic(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("runs tailscaled directly, bypassing the service, and has a Windows panic-capture race; see #20711")
+	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 	n := NewTestNode(t, env)
@@ -291,7 +294,12 @@ func TestStateSavedOnStart(t *testing.T) {
 	n1.MustDown()
 
 	// And change the hostname to something:
-	if err := n1.Tailscale("up", "--login-server="+n1.env.ControlURL(), "--hostname=foo").Run(); err != nil {
+	upArgs := []string{"up", "--login-server=" + n1.env.ControlURL(), "--hostname=foo"}
+	if runtime.GOOS == "windows" {
+		// Match MustUp so the profile survives the poll disconnect and the revert check holds.
+		upArgs = append(upArgs, "--unattended")
+	}
+	if err := n1.Tailscale(upArgs...).Run(); err != nil {
 		t.Fatalf("up: %v", err)
 	}
 
@@ -497,6 +505,10 @@ func TestOneNodeUpAuth(t *testing.T) {
 			for i, step := range tt.steps {
 				t.Logf("Running step %d", i)
 				cmdArgs := append(step.args, "--login-server="+env.ControlURL())
+				if runtime.GOOS == "windows" {
+					// match MustUp since a differing up would trip the revert check
+					cmdArgs = append(cmdArgs, "--unattended")
+				}
 
 				t.Logf("Running command: %s", strings.Join(cmdArgs, " "))
 
@@ -702,6 +714,10 @@ func TestOneNodeUpInterruptedAuth(t *testing.T) {
 	defer d.MustCleanShutdown(t)
 
 	cmdArgs := []string{"up", "--login-server=" + env.ControlURL()}
+	if runtime.GOOS == "windows" {
+		// match MustUp since a differing up would trip the revert check
+		cmdArgs = append(cmdArgs, "--unattended")
+	}
 
 	// The first time we run the command, we wait for an auth URL to be
 	// printed, and then we cancel the command -- equivalent to ^C.
@@ -791,6 +807,10 @@ func TestOneNodeUpInterruptedDeviceApproval(t *testing.T) {
 	// At this point, we've logged in to control, but our node isn't
 	// approved to connect to the tailnet.
 	cmd1Args := []string{"up", "--login-server=" + env.ControlURL()}
+	if runtime.GOOS == "windows" {
+		// match MustUp since a differing up would trip the revert check
+		cmd1Args = append(cmd1Args, "--unattended")
+	}
 	t.Logf("Running command: %s", strings.Join(cmd1Args, " "))
 	cmd1 := n.Tailscale(cmd1Args...)
 
@@ -845,6 +865,9 @@ func TestOneNodeUpInterruptedDeviceApproval(t *testing.T) {
 }
 
 func TestConfigFileAuthKey(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("--config is unsupported by the Windows service; see #20711")
+	}
 	t.Parallel()
 	const authKey = "opensesame"
 	env := NewTestEnv(t, ConfigureControl(func(control *testcontrol.Server) {
@@ -870,6 +893,9 @@ func TestConfigFileAuthKey(t *testing.T) {
 }
 
 func TestTwoNodes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
+	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 
@@ -955,6 +981,9 @@ func TestTwoNodes(t *testing.T) {
 // tests two nodes where the first gets a incremental MapResponse (with only
 // PeersRemoved set) saying that the second node disappeared.
 func TestIncrementalMapUpdatePeersRemoved(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
+	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 
@@ -1042,6 +1071,9 @@ func TestIncrementalMapUpdatePeersRemoved(t *testing.T) {
 // This covers VIP additions at runtime, where the VIP route is not reachable
 // before the map mutation but is reachable over TSMP afterward.
 func TestIncrementalMapUpdatePeerAllowedIPsReachability(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
+	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 
@@ -1267,6 +1299,9 @@ func TestC2NPingRequest(t *testing.T) {
 // Issue 2434: when "down" (WantRunning false), tailscaled shouldn't
 // be connected to control.
 func TestNoControlConnWhenDown(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("restarting the daemon with preserved state needs harness support; see #20711")
+	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 	n1 := NewTestNode(t, env)
@@ -1316,7 +1351,7 @@ func TestNoControlConnWhenDown(t *testing.T) {
 // without the GUI to kick off a Start.
 func TestOneNodeUpWindowsStyle(t *testing.T) {
 	tstest.Parallel(t)
-	env := NewTestEnv(t, canRunAsServiceOnWindows())
+	env := NewTestEnv(t)
 	n1 := NewTestNode(t, env)
 	n1.upFlagGOOS = "windows"
 
@@ -1334,6 +1369,9 @@ func TestOneNodeUpWindowsStyle(t *testing.T) {
 // jailed node cannot initiate connections to the other node however the other
 // node can initiate connections to the jailed node.
 func TestClientSideJailing(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
+	}
 	flakytest.Mark(t, "https://github.com/tailscale/tailscale/issues/17419")
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
@@ -1446,6 +1484,9 @@ func TestClientSideJailing(t *testing.T) {
 // TestNATPing creates two nodes, n1 and n2, sets up masquerades for both and
 // tries to do bi-directional pings between them.
 func TestNATPing(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
+	}
 	flakytest.Mark(t, "https://github.com/tailscale/tailscale/issues/12169")
 	tstest.Parallel(t)
 	for _, v6 := range []bool{false, true} {
@@ -1574,6 +1615,9 @@ func TestNATPing(t *testing.T) {
 }
 
 func TestLogoutRemovesAllPeers(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
+	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 	// Spin up some nodes.
@@ -1633,6 +1677,9 @@ func TestAutoUpdateDefaults_cap(t *testing.T) { testAutoUpdateDefaults(t, true) 
 // useCap is whether to use NodeAttrDefaultAutoUpdate (as opposed to the old
 // DeprecatedDefaultAutoUpdate top-level MapResponse field).
 func testAutoUpdateDefaults(t *testing.T, useCap bool) {
+	if runtime.GOOS == "windows" {
+		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
+	}
 	t.Cleanup(feature.HookCanAutoUpdate.SetForTest(func() bool { return true }))
 
 	env := NewTestEnv(t)
@@ -2117,6 +2164,9 @@ func TestNetstackUDPLoopback(t *testing.T) {
 }
 
 func TestEncryptStateMigration(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("--encrypt-state is unsupported by the Windows service; see #20711")
+	}
 	if !hostinfo.New().TPM.Present() {
 		t.Skip("TPM not available")
 	}
@@ -2177,6 +2227,9 @@ func TestEncryptStateMigration(t *testing.T) {
 // relay between all 3 nodes, and "tailscale debug peer-relay-sessions" returns
 // expected values.
 func TestPeerRelayPing(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
+	}
 	flakytest.Mark(t, "https://github.com/tailscale/tailscale/issues/17251")
 	tstest.Parallel(t)
 
@@ -2317,6 +2370,9 @@ func TestPeerRelayPing(t *testing.T) {
 }
 
 func TestC2NDebugNetmap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
+	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t, ConfigureControl(func(s *testcontrol.Server) {
 		s.CollectServices = opt.False
@@ -2455,7 +2511,9 @@ func TestC2NDebugNetmap(t *testing.T) {
 }
 
 func TestTailnetLock(t *testing.T) {
-
+	if runtime.GOOS == "windows" {
+		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
+	}
 	// If you run `tailscale lock log` on a node where Tailnet Lock isn't
 	// enabled, you get an error explaining that.
 	t.Run("log-when-not-enabled", func(t *testing.T) {
@@ -2597,6 +2655,9 @@ func TestTailnetLock(t *testing.T) {
 }
 
 func TestNodeWithBadStateFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("needs a userspace peer node; see #20711")
+	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 	n1 := NewTestNode(t, env)

--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -206,6 +206,9 @@ func TestExpectedFeaturesLinked(t *testing.T) {
 }
 
 func TestCollectPanic(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("has a Windows panic-capture race; see #20443")
+	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 	n := NewTestNode(t, env)
@@ -845,6 +848,9 @@ func TestOneNodeUpInterruptedDeviceApproval(t *testing.T) {
 }
 
 func TestConfigFileAuthKey(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("--config is unsupported by the Windows service; see #20871")
+	}
 	t.Parallel()
 	const authKey = "opensesame"
 	env := NewTestEnv(t, ConfigureControl(func(control *testcontrol.Server) {
@@ -870,6 +876,9 @@ func TestConfigFileAuthKey(t *testing.T) {
 }
 
 func TestTwoNodes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
+	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 
@@ -955,6 +964,9 @@ func TestTwoNodes(t *testing.T) {
 // tests two nodes where the first gets a incremental MapResponse (with only
 // PeersRemoved set) saying that the second node disappeared.
 func TestIncrementalMapUpdatePeersRemoved(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
+	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 
@@ -1042,6 +1054,9 @@ func TestIncrementalMapUpdatePeersRemoved(t *testing.T) {
 // This covers VIP additions at runtime, where the VIP route is not reachable
 // before the map mutation but is reachable over TSMP afterward.
 func TestIncrementalMapUpdatePeerAllowedIPsReachability(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
+	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 
@@ -1267,6 +1282,9 @@ func TestC2NPingRequest(t *testing.T) {
 // Issue 2434: when "down" (WantRunning false), tailscaled shouldn't
 // be connected to control.
 func TestNoControlConnWhenDown(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("restarting the daemon with preserved state needs harness support; see #20750")
+	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 	n1 := NewTestNode(t, env)
@@ -1316,7 +1334,7 @@ func TestNoControlConnWhenDown(t *testing.T) {
 // without the GUI to kick off a Start.
 func TestOneNodeUpWindowsStyle(t *testing.T) {
 	tstest.Parallel(t)
-	env := NewTestEnv(t, canRunAsServiceOnWindows())
+	env := NewTestEnv(t)
 	n1 := NewTestNode(t, env)
 	n1.upFlagGOOS = "windows"
 
@@ -1334,6 +1352,9 @@ func TestOneNodeUpWindowsStyle(t *testing.T) {
 // jailed node cannot initiate connections to the other node however the other
 // node can initiate connections to the jailed node.
 func TestClientSideJailing(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
+	}
 	flakytest.Mark(t, "https://github.com/tailscale/tailscale/issues/17419")
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
@@ -1446,6 +1467,9 @@ func TestClientSideJailing(t *testing.T) {
 // TestNATPing creates two nodes, n1 and n2, sets up masquerades for both and
 // tries to do bi-directional pings between them.
 func TestNATPing(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
+	}
 	flakytest.Mark(t, "https://github.com/tailscale/tailscale/issues/12169")
 	tstest.Parallel(t)
 	for _, v6 := range []bool{false, true} {
@@ -1574,6 +1598,9 @@ func TestNATPing(t *testing.T) {
 }
 
 func TestLogoutRemovesAllPeers(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
+	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 	// Spin up some nodes.
@@ -1633,6 +1660,9 @@ func TestAutoUpdateDefaults_cap(t *testing.T) { testAutoUpdateDefaults(t, true) 
 // useCap is whether to use NodeAttrDefaultAutoUpdate (as opposed to the old
 // DeprecatedDefaultAutoUpdate top-level MapResponse field).
 func testAutoUpdateDefaults(t *testing.T, useCap bool) {
+	if runtime.GOOS == "windows" {
+		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
+	}
 	t.Cleanup(feature.HookCanAutoUpdate.SetForTest(func() bool { return true }))
 
 	env := NewTestEnv(t)
@@ -2117,6 +2147,9 @@ func TestNetstackUDPLoopback(t *testing.T) {
 }
 
 func TestEncryptStateMigration(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("--encrypt-state is unsupported by the Windows service; see #20872")
+	}
 	if !hostinfo.New().TPM.Present() {
 		t.Skip("TPM not available")
 	}
@@ -2177,6 +2210,9 @@ func TestEncryptStateMigration(t *testing.T) {
 // relay between all 3 nodes, and "tailscale debug peer-relay-sessions" returns
 // expected values.
 func TestPeerRelayPing(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
+	}
 	flakytest.Mark(t, "https://github.com/tailscale/tailscale/issues/17251")
 	tstest.Parallel(t)
 
@@ -2317,6 +2353,9 @@ func TestPeerRelayPing(t *testing.T) {
 }
 
 func TestC2NDebugNetmap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
+	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t, ConfigureControl(func(s *testcontrol.Server) {
 		s.CollectServices = opt.False
@@ -2455,7 +2494,9 @@ func TestC2NDebugNetmap(t *testing.T) {
 }
 
 func TestTailnetLock(t *testing.T) {
-
+	if runtime.GOOS == "windows" {
+		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
+	}
 	// If you run `tailscale lock log` on a node where Tailnet Lock isn't
 	// enabled, you get an error explaining that.
 	t.Run("log-when-not-enabled", func(t *testing.T) {
@@ -2597,6 +2638,9 @@ func TestTailnetLock(t *testing.T) {
 }
 
 func TestNodeWithBadStateFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("service harness can't seed a corrupt state file before start; see #20750")
+	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 	n1 := NewTestNode(t, env)

--- a/tstest/integration/whois_test.go
+++ b/tstest/integration/whois_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"runtime"
 	"testing"
 	"time"
 
@@ -21,6 +22,9 @@ import (
 // netstack forwards the connection to localhost, and the listener
 // calls WhoIs on n2's LocalAPI to identify the remote peer as n1.
 func TestUserspaceWhoIsProxyMap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
+	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 


### PR DESCRIPTION
Updates #20464

In my previous PR (#20382), the objective was to implement the ability to run windows integration tests against a real LocalSystem tailscaled service. I tested it with a temporary opt-in (canRunAsServiceOnWindows()) that ran a single existing windows integration test against that service, so the other tests stayed skipped and behaviour was unchanged.

Now that the service harness exists, this PR removes that temporary opt-in and runs the windows integration tests against the service by default (which is what #20464 was tracking). Before this, 1 test ran against the service on Windows; now 14 single-node tests do. A windows host only allows one Tailscale service, so a test can run only if it works as a single service node; anything else is explicitly skipped with a plain reason. This PR does that by:

- Removing the canRunAsServiceOnWindows() opt-in gate so windows integration tests are on by default.
- Adding the Windows --unattended flag on up where it was missing.
- Explicitly skipping the tests that can't run as a single service node yet (multi-node/peer tests, --config/--encrypt state tests, the daemon-restart test, and TestCollectPanic), each with a reason and a follow-up issue (#20711).

There will be a follow-up PR for issue #20711  that adds multi-node support. This will un-skip the multi-node tests and the remaining test cases deferred here.

