### PR TITLE
control/controlclient: avoid repeated hardware signer prompts

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -119,6 +119,9 @@ type Direct struct {
 	connectionHandleForTest string      // sent in MapRequest.ConnectionHandleForTest
 	streamingMapSession     *mapSession // the one streaming mapSession instance
 
+	hardwareAttestationMu         syncs.Mutex
+	hardwareAttestationSignFailed bool // guarded by hardwareAttestationMu
+
 	controlClientID int64 // Random ID used to differentiate clients for consumers of messages.
 }
 
@@ -1144,19 +1147,7 @@ func (c *Direct) sendMapRequest(ctx context.Context, isStreaming bool, nu Netmap
 	// the key & signature in the map request.
 	if buildfeatures.HasTPM {
 		if k := persist.AsStruct().AttestationKey; k != nil && !k.IsZero() {
-			hwPub := key.HardwareAttestationPublicFromPlatformKey(k)
-			request.HardwareAttestationKey = hwPub
-
-			t := c.clock.Now()
-			msg := fmt.Sprintf("%d|%s", t.Unix(), nodeKey.String())
-			digest := sha256.Sum256([]byte(msg))
-			sig, err := k.Sign(nil, digest[:], crypto.SHA256)
-			if err != nil {
-				c.logf("failed to sign node key with hardware attestation key: %v", err)
-			} else {
-				request.HardwareAttestationKeySignature = sig
-				request.HardwareAttestationKeySignatureTimestamp = t
-			}
+			c.addHardwareAttestation(request, k, nodeKey)
 		}
 	}
 
@@ -1399,6 +1390,34 @@ func (c *Direct) sendMapRequest(ctx context.Context, isStreaming bool, nu Netmap
 		return ctx.Err()
 	}
 	return nil
+}
+
+// addHardwareAttestation signs request with k. If signing fails, it does not
+// try k again for the lifetime of c. Some hardware signers require interactive
+// authorization, so retrying on every map request can repeatedly prompt the
+// user. A newly-created Direct will try the signer again.
+func (c *Direct) addHardwareAttestation(request *tailcfg.MapRequest, k key.HardwareAttestationKey, nodeKey key.NodePublic) {
+	c.hardwareAttestationMu.Lock()
+	defer c.hardwareAttestationMu.Unlock()
+
+	if c.hardwareAttestationSignFailed {
+		return
+	}
+
+	hwPub := key.HardwareAttestationPublicFromPlatformKey(k)
+	request.HardwareAttestationKey = hwPub
+
+	t := c.clock.Now()
+	msg := fmt.Sprintf("%d|%s", t.Unix(), nodeKey.String())
+	digest := sha256.Sum256([]byte(msg))
+	sig, err := k.Sign(nil, digest[:], crypto.SHA256)
+	if err != nil {
+		c.hardwareAttestationSignFailed = true
+		c.logf("failed to sign node key with hardware attestation key; not retrying until the control client restarts: %v", err)
+		return
+	}
+	request.HardwareAttestationKeySignature = sig
+	request.HardwareAttestationKeySignatureTimestamp = t
 }
 
 // NetmapFromMapResponseForDebug returns a NetworkMap from the given MapResponse.

--- a/control/controlclient/hardware_attestation_test.go
+++ b/control/controlclient/hardware_attestation_test.go
@@ -1,0 +1,139 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package controlclient
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"errors"
+	"io"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"tailscale.com/health"
+	"tailscale.com/net/netmon"
+	"tailscale.com/net/tsdial"
+	"tailscale.com/tailcfg"
+	"tailscale.com/tstest/integration/testcontrol"
+	"tailscale.com/tstime"
+	"tailscale.com/types/key"
+	"tailscale.com/types/persist"
+	"tailscale.com/util/eventbus/eventbustest"
+)
+
+type testHardwareAttestationKey struct {
+	private   *ecdsa.PrivateKey
+	signCalls *atomic.Int64
+	fail      bool
+}
+
+func (k *testHardwareAttestationKey) Public() crypto.PublicKey { return &k.private.PublicKey }
+
+func (k *testHardwareAttestationKey) Sign(_ io.Reader, digest []byte, _ crypto.SignerOpts) ([]byte, error) {
+	k.signCalls.Add(1)
+	if k.fail {
+		return nil, errors.New("hardware signer unavailable")
+	}
+	return ecdsa.SignASN1(rand.Reader, k.private, digest)
+}
+
+func (k *testHardwareAttestationKey) MarshalJSON() ([]byte, error) { return []byte(`{}`), nil }
+func (k *testHardwareAttestationKey) UnmarshalJSON([]byte) error   { return nil }
+func (k *testHardwareAttestationKey) Close() error                 { return nil }
+func (k *testHardwareAttestationKey) IsZero() bool                 { return false }
+func (k *testHardwareAttestationKey) Clone() key.HardwareAttestationKey {
+	return &testHardwareAttestationKey{private: k.private, signCalls: k.signCalls, fail: k.fail}
+}
+
+func TestHardwareAttestationSignFailureIsNotRetried(t *testing.T) {
+	control := &testcontrol.Server{Logf: t.Logf}
+	control.HTTPTestServer = httptest.NewUnstartedServer(control)
+	control.HTTPTestServer.Start()
+	t.Cleanup(control.HTTPTestServer.Close)
+
+	bus := eventbustest.NewBus(t)
+	dialer := tsdial.NewDialer(netmon.NewStatic())
+	dialer.SetBus(bus)
+	d, err := NewDirect(Options{
+		Persist: persist.Persist{},
+		GetMachinePrivateKey: func() (key.MachinePrivate, error) {
+			return key.NewMachine(), nil
+		},
+		ServerURL: control.HTTPTestServer.URL,
+		Clock:     tstime.StdClock{},
+		Hostinfo: &tailcfg.Hostinfo{
+			BackendLogID: "test-backend-log-id",
+		},
+		DiscoPublicKey: key.NewDisco().Public(),
+		Logf:           t.Logf,
+		HealthTracker:  health.NewTracker(bus),
+		Dialer:         dialer,
+		Bus:            bus,
+	})
+	if err != nil {
+		t.Fatalf("NewDirect: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	if _, err := d.TryLogin(ctx, LoginEphemeral); err != nil {
+		t.Fatalf("TryLogin: %v", err)
+	}
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var signCalls atomic.Int64
+	p := d.persist.AsStruct()
+	p.AttestationKey = &testHardwareAttestationKey{
+		private:   privateKey,
+		signCalls: &signCalls,
+		fail:      true,
+	}
+	d.persist = p.View()
+
+	for range 2 {
+		if err := d.SendUpdate(ctx); err != nil {
+			t.Fatalf("SendUpdate: %v", err)
+		}
+	}
+	if got, want := signCalls.Load(), int64(1); got != want {
+		t.Fatalf("hardware attestation Sign calls = %d; want %d", got, want)
+	}
+}
+
+func TestHardwareAttestationSuccessSignsEveryRequest(t *testing.T) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var signCalls atomic.Int64
+	k := &testHardwareAttestationKey{private: privateKey, signCalls: &signCalls}
+	d := &Direct{clock: tstime.StdClock{}, logf: t.Logf}
+	nodeKey := key.NewNode().Public()
+
+	for range 2 {
+		request := new(tailcfg.MapRequest)
+		d.addHardwareAttestation(request, k, nodeKey)
+		if request.HardwareAttestationKey.IsZero() {
+			t.Fatal("hardware attestation public key is zero")
+		}
+		if len(request.HardwareAttestationKeySignature) == 0 {
+			t.Fatal("hardware attestation signature is empty")
+		}
+		if request.HardwareAttestationKeySignatureTimestamp.IsZero() {
+			t.Fatal("hardware attestation signature timestamp is zero")
+		}
+	}
+	if got, want := signCalls.Load(), int64(2); got != want {
+		t.Fatalf("hardware attestation Sign calls = %d; want %d", got, want)
+	}
+}


### PR DESCRIPTION
Some hardware-backed signers require interactive authorization. When signing
fails, each map request currently makes another attempt. On macOS, this can
cause repeated System Keychain prompts after an update or reinstall.

The client now remembers the first failure for the lifetime of the `Direct`
client and prevents overlapping signing attempts. A new client tries again.
Successful signing remains unchanged.

This change addresses the repeated signing attempt in the public control
client. It does not delete the attestation key or alter Tailnet authorization.

Tests:

- `go test ./control/controlclient ./ipn/ipnlocal ./types/key`
- `go test -race ./control/controlclient -run '^TestHardwareAttestation' -count=1`

Updates #20537
