### PR TITLE
net/netutil: confine ipForwardingEnabledLinux read with os.OpenInRoot

### DIFF
--- a/net/netutil/ip_forward.go
+++ b/net/netutil/ip_forward.go
@@ -6,10 +6,10 @@ package netutil
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"net/netip"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -198,7 +198,10 @@ const (
 // sysctl (which on Linux just reads from /proc/sys anyway).
 func ipForwardingEnabledLinux(p protocol, iface string) (bool, error) {
 	k := ipForwardSysctlKey(slashFormat, p, iface)
-	bs, err := os.ReadFile(filepath.Join("/proc/sys", k))
+	// Open k under /proc/sys with os.OpenInRoot so a ".." or symlinked
+	// component in the interface name can't read outside /proc/sys. It's
+	// openat-based, so it's also TOCTOU-resistant. See https://go.dev/blog/osroot.
+	f, err := os.OpenInRoot("/proc/sys", k)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// If IPv6 is disabled, sysctl keys like "net.ipv6.conf.all.forwarding" just don't
@@ -211,6 +214,11 @@ func ipForwardingEnabledLinux(p protocol, iface string) (bool, error) {
 			}
 			return false, nil
 		}
+		return false, err
+	}
+	defer f.Close()
+	bs, err := io.ReadAll(f)
+	if err != nil {
 		return false, err
 	}
 


### PR DESCRIPTION
CheckIPForwarding walks the machine's interfaces and, for each one, reads net/ipv4/conf/<iface>/forwarding out of /proc/sys to decide whether subnet routing and exit nodes will work on that link. The interface name comes from netmon and gets interpolated straight into the sysctl path, which ipForwardingEnabledLinux then opens with filepath.Join and os.ReadFile. filepath.Join only cleans the path, so a name that carries a ".." component or a symlinked directory along the way can pull the read outside /proc/sys. That is the same shape #20505 just closed for interfaceV6UsableForTun, and ipForwardingEnabledLinux is the sibling reader still on the old pattern, which is how I noticed it while reading that fix. Opening k under /proc/sys with os.OpenInRoot pins the read to that directory and refuses anything that escapes it, and since it is openat-based it also removes the stat-then-read race. I kept the change inside ipForwardingEnabledLinux and left the missing-knob and no-procfs handling as it was, so the IPv6-disabled and unmounted-procfs cases still return what they did before.
