### PR TITLE
net/netutil: add test coverage for ipForwardingEnabledLinux per-interface reads

### DIFF
--- a/net/netutil/netutil_test.go
+++ b/net/netutil/netutil_test.go
@@ -119,4 +119,28 @@ func TestIPForwardingEnabledLinux(t *testing.T) {
 	if got {
 		t.Errorf("got true; want false")
 	}
+
+	// The global keys and the per-interface keys for each interface on
+	// the machine should all be readable without error, whatever their
+	// values.
+	for _, p := range []protocol{ipv4, ipv6} {
+		on, err := ipForwardingEnabledLinux(p, "")
+		if err != nil {
+			t.Errorf("global (proto %v): %v", p, err)
+		}
+		t.Logf("global (proto %v) = %v", p, on)
+	}
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, iface := range ifaces {
+		for _, p := range []protocol{ipv4, ipv6} {
+			on, err := ipForwardingEnabledLinux(p, iface.Name)
+			if err != nil {
+				t.Errorf("%s (proto %v): %v", iface.Name, p, err)
+			}
+			t.Logf("%s (proto %v) = %v", iface.Name, p, on)
+		}
+	}
 }


### PR DESCRIPTION
The existing test only exercised the not-found-interface path. Now that
ipForwardingEnabledLinux opens its sysctl key with os.OpenInRoot
(840c6e3d3, #20572), also verify that the global keys and the
per-interface keys for every interface actually present on the machine
can be read without error, for both IPv4 and IPv6.

Updates #20572
