### PR TITLE
tailcfg: bump tailcfg.CapabilityVersion for conn25

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -189,7 +189,8 @@ type CapabilityVersion int
 //   - 140: 2026-05-27: Client understands [NodeAttrDisableUDPGRO], [NodeAttrDisableUDPGSO], [NodeAttrDisableTUNUDPGRO], [NodeAttrDisableTUNTCPGRO]
 //   - 141: 2026-05-28: Client understands [NodeAttrNeverGSOEqualTail]
 //   - 142: 2026-07-06: Client understands c2n /remoteapi/localapi/* proxy
-const CurrentCapabilityVersion CapabilityVersion = 142
+//   - 143: 2026-07-22: Client correctly ignores conn25 node attributes when not enabled by environment variable
+const CurrentCapabilityVersion CapabilityVersion = 143
 
 // ID is an integer ID for a user, node, or login allocated by the
 // control plane.


### PR DESCRIPTION
We have some client builds on the unstable track where the conn25 code doesn't run if the TAILSCALE_USE_WIP_CODE env var is not set. But the split DNS routes for conn25 configured domains do get installed. This means that users running those builds would get traffic for configured domains black holed if the env var is not set.

This issue was fixed in 425a916ce.

Bump tailcfg.CapabilityVersion, and then a corresponding change to the control server to not send conn25 config to lower versions will avoid this issue for those users.

Updates tailscale/corp#45363