### PR TITLE
feat: ignore-routes

### DIFF
--- a/cmd/tailscale/cli/cli_test.go
+++ b/cmd/tailscale/cli/cli_test.go
@@ -1051,6 +1051,9 @@ func TestPrefFlagMapping(t *testing.T) {
 		case "AutoExitNode":
 			// Handled by tailscale {set,up} --exit-node=auto:any.
 			continue
+		case "IgnoredRoutes":
+			// Handled by tailscale {set,up} --ignore-routes.
+			continue
 		}
 		t.Errorf("unexpected new ipn.Pref field %q is not handled by up.go (see addPrefFlagMapping and checkForAccidentalSettingReverts)", prefName)
 	}

--- a/cmd/tailscale/cli/get.go
+++ b/cmd/tailscale/cli/get.go
@@ -203,6 +203,15 @@ func prefValue(flagName string, prefs *ipn.Prefs, st *ipnstate.Status) any {
 			parts[i] = ep.String()
 		}
 		return strings.Join(parts, ",")
+	case "ignore-routes":
+		var sb strings.Builder
+		for i, r := range prefs.IgnoredRoutes {
+			if i > 0 {
+				sb.WriteByte(',')
+			}
+			sb.WriteString(r.String())
+		}
+		return sb.String()
 	default:
 		return nil
 	}

--- a/cmd/tailscale/cli/set.go
+++ b/cmd/tailscale/cli/set.go
@@ -69,6 +69,7 @@ type setArgsT struct {
 	netfilterMode              string
 	relayServerPort            string
 	relayServerStaticEndpoints string
+	ignoredRoutes              string
 }
 
 func newSetFlagSet(goos string, setArgs *setArgsT) *flag.FlagSet {
@@ -93,6 +94,7 @@ func newSetFlagSet(goos string, setArgs *setArgsT) *flag.FlagSet {
 	setf.BoolVar(&setArgs.sync, "sync", false, hidden+"actively sync configuration from the control plane (set to false only for network failure testing)")
 	setf.StringVar(&setArgs.relayServerPort, "relay-server-port", "", "UDP port number (0 will pick a random unused port) for the relay server to bind to, on all interfaces, or empty string to disable relay server functionality")
 	setf.StringVar(&setArgs.relayServerStaticEndpoints, "relay-server-static-endpoints", "", "static IP:port endpoints to advertise as candidates for relay connections (comma-separated, e.g. \"[2001:db8::1]:40000,192.0.2.1:40000\") or empty string to not advertise any static endpoints")
+	setf.StringVar(&setArgs.ignoredRoutes, "ignore-routes", "", "routes to ignore on current node when installing routing rules (comma-separated, e.g. \"10.0.0.0/8,192.168.0.0/24\") or empty string to not ignore any routes")
 
 	ffcomplete.Flag(setf, "exit-node", func(args []string) ([]string, ffcomplete.ShellCompDirective, error) {
 		st, err := localClient.Status(context.Background())
@@ -264,6 +266,20 @@ func runSet(ctx context.Context, args []string) (retErr error) {
 		endpoints := endpointsSet.Slice()
 		slices.SortFunc(endpoints, netip.AddrPort.Compare)
 		maskedPrefs.Prefs.RelayServerStaticEndpoints = endpoints
+	}
+
+	if setArgs.ignoredRoutes != "" {
+		var ignoredRoutes []netip.Prefix
+		for s := range strings.SplitSeq(setArgs.ignoredRoutes, ",") {
+			prefix, err := netip.ParsePrefix(s)
+			if err != nil {
+				return fmt.Errorf("failed to parse ignore-routes entry %q: %w", s, err)
+			}
+			ignoredRoutes = append(ignoredRoutes, prefix)
+		}
+		slices.SortFunc(ignoredRoutes, netip.Prefix.Compare)
+		maskedPrefs.Prefs.IgnoredRoutes = ignoredRoutes
+		maskedPrefs.IgnoredRoutesSet = true
 	}
 
 	checkPrefs := curPrefs.Clone()

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -930,6 +930,7 @@ func init() {
 	addPrefFlagMapping("relay-server-port", "RelayServerPort")
 	addPrefFlagMapping("sync", "Sync")
 	addPrefFlagMapping("relay-server-static-endpoints", "RelayServerStaticEndpoints")
+	addPrefFlagMapping("ignore-routes", "IgnoredRoutes")
 }
 
 func addPrefFlagMapping(flagName string, prefNames ...string) {

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -52,6 +52,7 @@ func (src *Prefs) Clone() *Prefs {
 	*dst = *src
 	dst.AdvertiseTags = append(src.AdvertiseTags[:0:0], src.AdvertiseTags...)
 	dst.AdvertiseRoutes = append(src.AdvertiseRoutes[:0:0], src.AdvertiseRoutes...)
+	dst.IgnoredRoutes = append(src.IgnoredRoutes[:0:0], src.IgnoredRoutes...)
 	dst.AdvertiseServices = append(src.AdvertiseServices[:0:0], src.AdvertiseServices...)
 	if src.DriveShares != nil {
 		dst.DriveShares = make([]*drive.Share, len(src.DriveShares))
@@ -92,6 +93,7 @@ var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	ForceDaemon                bool
 	Egg                        bool
 	AdvertiseRoutes            []netip.Prefix
+	IgnoredRoutes              []netip.Prefix
 	AdvertiseServices          []string
 	Sync                       opt.Bool
 	NoSNAT                     bool

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -364,6 +364,16 @@ func (v PrefsView) AdvertiseRoutes() views.Slice[netip.Prefix] {
 	return views.SliceOf(v.ж.AdvertiseRoutes)
 }
 
+// IgnoredRoutes specifies CIDR prefixes whose routes should be carved
+// out when installing routes from other nodes (e.g., exit nodes or
+// subnet routers). If a route advertised by another node overlaps with
+// any prefix in this list, that route will be carved out. This option
+// applies to advertised routes and exit nodes, allows excluding certain
+// routes despite the network configuration.
+func (v PrefsView) IgnoredRoutes() views.Slice[netip.Prefix] {
+	return views.SliceOf(v.ж.IgnoredRoutes)
+}
+
 // AdvertiseServices specifies the list of services that this
 // node can serve as a destination for. Note that an advertised
 // service must still go through the approval process from the
@@ -509,6 +519,7 @@ var _PrefsViewNeedsRegeneration = Prefs(struct {
 	ForceDaemon                bool
 	Egg                        bool
 	AdvertiseRoutes            []netip.Prefix
+	IgnoredRoutes              []netip.Prefix
 	AdvertiseServices          []string
 	Sync                       opt.Bool
 	NoSNAT                     bool

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -6500,6 +6500,36 @@ func magicDNSRootDomains(nm *netmap.NetworkMap) []dnsname.FQDN {
 	return nil
 }
 
+// carveIgnoredRoutes returns routes with any ignored subnets carved out.
+func carveIgnoredRoutes(routes, ignored []netip.Prefix) []netip.Prefix {
+	if len(ignored) == 0 {
+		return routes
+	}
+
+	var ret []netip.Prefix
+	for _, r := range routes {
+		var b netipx.IPSetBuilder
+		b.AddPrefix(r)
+
+		for _, ig := range ignored {
+			if r.Overlaps(ig) {
+				b.RemovePrefix(ig)
+			}
+		}
+
+		set, err := b.IPSet()
+		if err != nil {
+			// Should not happen normally, just pass route without changes
+			ret = append(ret, r)
+			continue
+		}
+
+		ret = append(ret, set.Prefixes()...)
+	}
+
+	return ret
+}
+
 // routerConfig produces a router.Config from a wireguard config and IPN prefs.
 //
 // b.mu must be held.
@@ -6607,6 +6637,9 @@ func (b *LocalBackend) routerConfigLocked(cfg *wgcfg.Config, prefs ipn.PrefsView
 	if extensionRoutesFx, ok := b.extHost.hooks.ExtraRouterConfigRoutes.GetOk(); ok {
 		rs.Routes = extensionRoutesFx().AppendTo(rs.Routes)
 	}
+
+	// Carve out routes that overlap with user-specified ignored subnets.
+	rs.Routes = carveIgnoredRoutes(rs.Routes, prefs.IgnoredRoutes().AsSlice())
 
 	return rs
 }

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -189,6 +189,102 @@ func TestShrinkDefaultRoute(t *testing.T) {
 	}
 }
 
+func TestFilterIgnoredRoutes(t *testing.T) {
+	pp := netip.MustParsePrefix
+
+	// Checks that no route overlaps with any ignored prefix
+	assertNoOverlap := func(got []netip.Prefix, ignored []netip.Prefix) {
+		for _, r := range got {
+			for _, ig := range ignored {
+				if r.Overlaps(ig) {
+					t.Errorf("route %s overlaps with ignored %s", r, ig)
+				}
+			}
+		}
+	}
+
+	tests := []struct {
+		name    string
+		routes  []netip.Prefix
+		ignored []netip.Prefix
+		want    []netip.Prefix
+	}{
+		{
+			name:    "no-ignored",
+			routes:  []netip.Prefix{pp("10.0.0.0/24"), pp("192.168.1.0/24")},
+			ignored: nil,
+			want:    []netip.Prefix{pp("10.0.0.0/24"), pp("192.168.1.0/24")},
+		},
+		{
+			name:    "no-routes",
+			routes:  nil,
+			ignored: []netip.Prefix{pp("10.0.0.0/8")},
+			want:    nil,
+		},
+		{
+			name:    "exact-match",
+			routes:  []netip.Prefix{pp("10.0.0.0/24"), pp("192.168.1.0/24"), pp("172.16.0.0/16")},
+			ignored: []netip.Prefix{pp("192.168.1.0/24")},
+			want:    []netip.Prefix{pp("10.0.0.0/24"), pp("172.16.0.0/16")},
+		},
+		{
+			name:    "supernet-ignore",
+			routes:  []netip.Prefix{pp("10.0.0.0/24"), pp("10.0.1.0/24"), pp("192.168.1.0/24")},
+			ignored: []netip.Prefix{pp("10.0.0.0/16")},
+			want:    []netip.Prefix{pp("192.168.1.0/24")},
+		},
+		{
+			name:    "subnet-ignore",
+			routes:  []netip.Prefix{pp("10.0.0.0/24"), pp("10.0.1.0/24"), pp("192.168.1.0/24")},
+			ignored: []netip.Prefix{pp("10.0.0.0/8")},
+			want:    []netip.Prefix{pp("192.168.1.0/24")},
+		},
+		{
+			name:    "overlap-v6",
+			routes:  []netip.Prefix{pp("fd7a:115c:a1e0:ab12::/64"), pp("fd7a:115c:a1e1::/48")},
+			ignored: []netip.Prefix{pp("fd7a:115c:a1e0:ab12::/64")},
+			want:    []netip.Prefix{pp("fd7a:115c:a1e1::/48")},
+		},
+		{
+			name:    "multiple-ignored",
+			routes:  []netip.Prefix{pp("10.0.0.0/24"), pp("172.16.0.0/16"), pp("192.168.1.0/24"), pp("100.64.0.1/32")},
+			ignored: []netip.Prefix{pp("10.0.0.0/8"), pp("192.168.0.0/16")},
+			want:    []netip.Prefix{pp("172.16.0.0/16"), pp("100.64.0.1/32")},
+		},
+		{
+			name:    "all-filtered",
+			routes:  []netip.Prefix{pp("10.0.0.0/24"), pp("192.168.1.0/24")},
+			ignored: []netip.Prefix{pp("10.0.0.0/8"), pp("192.168.0.0/16")},
+			want:    nil,
+		},
+		{
+			name:    "carve-default-route",
+			routes:  []netip.Prefix{pp("0.0.0.0/0"), pp("::/0")},
+			ignored: []netip.Prefix{pp("192.168.1.0/24"), pp("fd7a:115c:a1e0:ab12::/64")},
+			want:    []netip.Prefix{pp("0.0.0.0/1"), pp("128.0.0.0/2"), pp("192.0.0.0/9"), pp("192.128.0.0/11"), pp("192.160.0.0/13"), pp("192.168.0.0/24"), pp("192.168.2.0/23"), pp("192.168.4.0/22"), pp("192.168.8.0/21"), pp("192.168.16.0/20"), pp("192.168.32.0/19"), pp("192.168.64.0/18"), pp("192.168.128.0/17"), pp("192.169.0.0/16"), pp("192.170.0.0/15"), pp("192.172.0.0/14"), pp("192.176.0.0/12"), pp("192.192.0.0/10"), pp("193.0.0.0/8"), pp("194.0.0.0/7"), pp("196.0.0.0/6"), pp("200.0.0.0/5"), pp("208.0.0.0/4"), pp("224.0.0.0/3"), pp("::/1"), pp("8000::/2"), pp("c000::/3"), pp("e000::/4"), pp("f000::/5"), pp("f800::/6"), pp("fc00::/8"), pp("fd00::/10"), pp("fd40::/11"), pp("fd60::/12"), pp("fd70::/13"), pp("fd78::/15"), pp("fd7a::/20"), pp("fd7a:1000::/24"), pp("fd7a:1100::/26"), pp("fd7a:1140::/28"), pp("fd7a:1150::/29"), pp("fd7a:1158::/30"), pp("fd7a:115c::/33"), pp("fd7a:115c:8000::/35"), pp("fd7a:115c:a000::/40"), pp("fd7a:115c:a100::/41"), pp("fd7a:115c:a180::/42"), pp("fd7a:115c:a1c0::/43"), pp("fd7a:115c:a1e0::/49"), pp("fd7a:115c:a1e0:8000::/51"), pp("fd7a:115c:a1e0:a000::/53"), pp("fd7a:115c:a1e0:a800::/55"), pp("fd7a:115c:a1e0:aa00::/56"), pp("fd7a:115c:a1e0:ab00::/60"), pp("fd7a:115c:a1e0:ab10::/63"), pp("fd7a:115c:a1e0:ab13::/64"), pp("fd7a:115c:a1e0:ab14::/62"), pp("fd7a:115c:a1e0:ab18::/61"), pp("fd7a:115c:a1e0:ab20::/59"), pp("fd7a:115c:a1e0:ab40::/58"), pp("fd7a:115c:a1e0:ab80::/57"), pp("fd7a:115c:a1e0:ac00::/54"), pp("fd7a:115c:a1e0:b000::/52"), pp("fd7a:115c:a1e0:c000::/50"), pp("fd7a:115c:a1e1::/48"), pp("fd7a:115c:a1e2::/47"), pp("fd7a:115c:a1e4::/46"), pp("fd7a:115c:a1e8::/45"), pp("fd7a:115c:a1f0::/44"), pp("fd7a:115c:a200::/39"), pp("fd7a:115c:a400::/38"), pp("fd7a:115c:a800::/37"), pp("fd7a:115c:b000::/36"), pp("fd7a:115c:c000::/34"), pp("fd7a:115d::/32"), pp("fd7a:115e::/31"), pp("fd7a:1160::/27"), pp("fd7a:1180::/25"), pp("fd7a:1200::/23"), pp("fd7a:1400::/22"), pp("fd7a:1800::/21"), pp("fd7a:2000::/19"), pp("fd7a:4000::/18"), pp("fd7a:8000::/17"), pp("fd7b::/16"), pp("fd7c::/14"), pp("fd80::/9"), pp("fe00::/7")},
+		},
+		{
+			name:    "carve-supernet",
+			routes:  []netip.Prefix{pp("123.45.0.0/16")},
+			ignored: []netip.Prefix{pp("123.45.67.0/24")},
+			want:    []netip.Prefix{pp("123.45.0.0/18"), pp("123.45.64.0/23"), pp("123.45.66.0/24"), pp("123.45.68.0/22"), pp("123.45.72.0/21"), pp("123.45.80.0/20"), pp("123.45.96.0/19"), pp("123.45.128.0/17")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := carveIgnoredRoutes(tt.routes, tt.ignored)
+			assertNoOverlap(got, tt.ignored)
+
+			tsaddr.SortPrefixes(got)
+			tsaddr.SortPrefixes(tt.want)
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got = %v; want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestPeerAPIBase(t *testing.T) {
 	tests := []struct {
 		name string

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -203,6 +203,14 @@ type Prefs struct {
 	// node.
 	AdvertiseRoutes []netip.Prefix
 
+	// IgnoredRoutes specifies CIDR prefixes whose routes should be
+	// carved out when installing routes from other nodes (e.g., exit nodes
+	// or subnet routers). If a route advertised by another node overlaps
+	// with any prefix in this list, that route will be carved out. This
+	// option applies to advertised routes and exit nodes, allows excluding
+	// certain routes despite the network configuration.
+	IgnoredRoutes []netip.Prefix
+
 	// AdvertiseServices specifies the list of services that this
 	// node can serve as a destination for. Note that an advertised
 	// service must still go through the approval process from the
@@ -375,6 +383,7 @@ type MaskedPrefs struct {
 	ForceDaemonSet                bool                `json:",omitempty"`
 	EggSet                        bool                `json:",omitempty"`
 	AdvertiseRoutesSet            bool                `json:",omitempty"`
+	IgnoredRoutesSet              bool                `json:",omitempty"`
 	AdvertiseServicesSet          bool                `json:",omitempty"`
 	SyncSet                       bool                `json:",omitzero"`
 	NoSNATSet                     bool                `json:",omitempty"`
@@ -689,6 +698,7 @@ func (p *Prefs) Equals(p2 *Prefs) bool {
 		p.Hostname == p2.Hostname &&
 		p.ForceDaemon == p2.ForceDaemon &&
 		slices.Equal(p.AdvertiseRoutes, p2.AdvertiseRoutes) &&
+		slices.Equal(p.IgnoredRoutes, p2.IgnoredRoutes) &&
 		slices.Equal(p.AdvertiseTags, p2.AdvertiseTags) &&
 		slices.Equal(p.AdvertiseServices, p2.AdvertiseServices) &&
 		p.Persist.Equals(p2.Persist) &&

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -56,6 +56,7 @@ func TestPrefsEqual(t *testing.T) {
 		"ForceDaemon",
 		"Egg",
 		"AdvertiseRoutes",
+		"IgnoredRoutes",
 		"AdvertiseServices",
 		"Sync",
 		"NoSNAT",


### PR DESCRIPTION
This feature adds support for ignore-routes.

Why? When your node is configured to use an exit node or advertised routes, (sometimes) there are cases when you can not just accept the exit node or the advertised routes.

Consider an example:
I have 2 primary nodes:
- global - hosted VPS for all VPN traffic forwarding (almost 0.0.0.0/0).
- homelab - single host in home network that I use to access computers on my home network (192.168.0.0/24).

If I use exit node, then traffic won't flow to the homelab as 192.168.0.0/24 subnet. If I use exit node (global + homelab) when once I enter the home network with my laptop running tailscale - entire networking is messed up and no device can connect to my laptop and routing breaks.

This feature allows you to:
- Ignore certain local routes (line 192.168.0.0/24) - this fixes the issue when users of tailscale could not connect to the node running tailscale in the local entwork and issues when users can not connect to local docker ports (just ignore the 172.x.x.x/y)
- Ignore certain configuration despite the network configuration. Strange but working example: imagine if you need to use an exit node, but still want some traffic to flow using the default route (for example, when you need to use your residential IP to access certain services, but everything else should go through the VPN).

I've tested it bu starting 2 ALpine VMs, joining tailnet, enabling exit node on node1 and carving out the 192.168.0.0/24 on node2. In this configuration I can connect to node2 from the local network.

Updates #20588