### PR TITLE
cmd/k8s-operator: ensure CRDs are always generated

### DIFF
--- a/cmd/k8s-operator/deploy/chart/templates/.gitignore
+++ b/cmd/k8s-operator/deploy/chart/templates/.gitignore
@@ -3,11 +3,4 @@
 #
 # Generate for local usage with:
 # go run tailscale.com/cmd/k8s-operator/generate helmcrd
-/connector.yaml
-/dnsconfig.yaml
-/proxyclass.yaml
-/proxygroup.yaml
-/recorder.yaml
-/tailnet.yaml 
-/proxygrouppolicy.yaml
-/peerrelay.yaml
+/tailscale.com_*.yaml

--- a/cmd/k8s-operator/deploy/manifests/operator.yaml
+++ b/cmd/k8s-operator/deploy/manifests/operator.yaml
@@ -4156,6 +4156,142 @@ kind: CustomResourceDefinition
 metadata:
     annotations:
         controller-gen.kubebuilder.io/version: v0.17.0
+    name: proxygrouppolicies.tailscale.com
+spec:
+    group: tailscale.com
+    names:
+        kind: ProxyGroupPolicy
+        listKind: ProxyGroupPolicyList
+        plural: proxygrouppolicies
+        shortNames:
+            - pgp
+        singular: proxygrouppolicy
+    scope: Namespaced
+    versions:
+        - additionalPrinterColumns:
+            - jsonPath: .metadata.creationTimestamp
+              name: Age
+              type: date
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+                properties:
+                    apiVersion:
+                        description: |-
+                            APIVersion defines the versioned schema of this representation of an object.
+                            Servers should convert recognized schemas to the latest internal value, and
+                            may reject unrecognized values.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                    kind:
+                        description: |-
+                            Kind is a string value representing the REST resource this object represents.
+                            Servers may infer this from the endpoint the client submits requests to.
+                            Cannot be updated.
+                            In CamelCase.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                    metadata:
+                        type: object
+                    spec:
+                        description: |-
+                            Spec describes the desired state of the ProxyGroupPolicy.
+                            More info:
+                            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                        properties:
+                            egress:
+                                description: |-
+                                    Names of ProxyGroup resources that can be used by Service resources within this namespace. An empty list
+                                    denotes that no egress via ProxyGroups is allowed within this namespace.
+                                items:
+                                    type: string
+                                type: array
+                            ingress:
+                                description: |-
+                                    Names of ProxyGroup resources that can be used by Ingress resources within this namespace. An empty list
+                                    denotes that no ingress via ProxyGroups is allowed within this namespace.
+                                items:
+                                    type: string
+                                type: array
+                        type: object
+                    status:
+                        description: |-
+                            Status describes the status of the ProxyGroupPolicy. This is set
+                            and managed by the Tailscale operator.
+                        properties:
+                            conditions:
+                                items:
+                                    description: Condition contains details for one aspect of the current state of this API Resource.
+                                    properties:
+                                        lastTransitionTime:
+                                            description: |-
+                                                lastTransitionTime is the last time the condition transitioned from one status to another.
+                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                                            format: date-time
+                                            type: string
+                                        message:
+                                            description: |-
+                                                message is a human readable message indicating details about the transition.
+                                                This may be an empty string.
+                                            maxLength: 32768
+                                            type: string
+                                        observedGeneration:
+                                            description: |-
+                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                                with respect to the current state of the instance.
+                                            format: int64
+                                            minimum: 0
+                                            type: integer
+                                        reason:
+                                            description: |-
+                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                                Producers of specific condition types may define expected values and meanings for this field,
+                                                and whether the values are considered a guaranteed API.
+                                                The value should be a CamelCase string.
+                                                This field may not be empty.
+                                            maxLength: 1024
+                                            minLength: 1
+                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                            type: string
+                                        status:
+                                            description: status of the condition, one of True, False, Unknown.
+                                            enum:
+                                                - "True"
+                                                - "False"
+                                                - Unknown
+                                            type: string
+                                        type:
+                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                            maxLength: 316
+                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                            type: string
+                                    required:
+                                        - lastTransitionTime
+                                        - message
+                                        - reason
+                                        - status
+                                        - type
+                                    type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                    - type
+                                x-kubernetes-list-type: map
+                        type: object
+                required:
+                    - metadata
+                    - spec
+                type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+    annotations:
+        controller-gen.kubebuilder.io/version: v0.17.0
     name: proxygroups.tailscale.com
 spec:
     group: tailscale.com
@@ -4424,142 +4560,6 @@ spec:
                                 type: string
                         type: object
                 required:
-                    - spec
-                type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-    annotations:
-        controller-gen.kubebuilder.io/version: v0.17.0
-    name: proxygrouppolicies.tailscale.com
-spec:
-    group: tailscale.com
-    names:
-        kind: ProxyGroupPolicy
-        listKind: ProxyGroupPolicyList
-        plural: proxygrouppolicies
-        shortNames:
-            - pgp
-        singular: proxygrouppolicy
-    scope: Namespaced
-    versions:
-        - additionalPrinterColumns:
-            - jsonPath: .metadata.creationTimestamp
-              name: Age
-              type: date
-          name: v1alpha1
-          schema:
-            openAPIV3Schema:
-                properties:
-                    apiVersion:
-                        description: |-
-                            APIVersion defines the versioned schema of this representation of an object.
-                            Servers should convert recognized schemas to the latest internal value, and
-                            may reject unrecognized values.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                        type: string
-                    kind:
-                        description: |-
-                            Kind is a string value representing the REST resource this object represents.
-                            Servers may infer this from the endpoint the client submits requests to.
-                            Cannot be updated.
-                            In CamelCase.
-                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                        type: string
-                    metadata:
-                        type: object
-                    spec:
-                        description: |-
-                            Spec describes the desired state of the ProxyGroupPolicy.
-                            More info:
-                            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                        properties:
-                            egress:
-                                description: |-
-                                    Names of ProxyGroup resources that can be used by Service resources within this namespace. An empty list
-                                    denotes that no egress via ProxyGroups is allowed within this namespace.
-                                items:
-                                    type: string
-                                type: array
-                            ingress:
-                                description: |-
-                                    Names of ProxyGroup resources that can be used by Ingress resources within this namespace. An empty list
-                                    denotes that no ingress via ProxyGroups is allowed within this namespace.
-                                items:
-                                    type: string
-                                type: array
-                        type: object
-                    status:
-                        description: |-
-                            Status describes the status of the ProxyGroupPolicy. This is set
-                            and managed by the Tailscale operator.
-                        properties:
-                            conditions:
-                                items:
-                                    description: Condition contains details for one aspect of the current state of this API Resource.
-                                    properties:
-                                        lastTransitionTime:
-                                            description: |-
-                                                lastTransitionTime is the last time the condition transitioned from one status to another.
-                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                            format: date-time
-                                            type: string
-                                        message:
-                                            description: |-
-                                                message is a human readable message indicating details about the transition.
-                                                This may be an empty string.
-                                            maxLength: 32768
-                                            type: string
-                                        observedGeneration:
-                                            description: |-
-                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
-                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                                                with respect to the current state of the instance.
-                                            format: int64
-                                            minimum: 0
-                                            type: integer
-                                        reason:
-                                            description: |-
-                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                                                Producers of specific condition types may define expected values and meanings for this field,
-                                                and whether the values are considered a guaranteed API.
-                                                The value should be a CamelCase string.
-                                                This field may not be empty.
-                                            maxLength: 1024
-                                            minLength: 1
-                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                            type: string
-                                        status:
-                                            description: status of the condition, one of True, False, Unknown.
-                                            enum:
-                                                - "True"
-                                                - "False"
-                                                - Unknown
-                                            type: string
-                                        type:
-                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                                            maxLength: 316
-                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                            type: string
-                                    required:
-                                        - lastTransitionTime
-                                        - message
-                                        - reason
-                                        - status
-                                        - type
-                                    type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                    - type
-                                x-kubernetes-list-type: map
-                        type: object
-                required:
-                    - metadata
                     - spec
                 type: object
           served: true

--- a/cmd/k8s-operator/generate/main.go
+++ b/cmd/k8s-operator/generate/main.go
@@ -20,27 +20,12 @@ import (
 )
 
 const (
-	operatorDeploymentFilesPath         = "cmd/k8s-operator/deploy"
-	connectorCRDPath                    = operatorDeploymentFilesPath + "/crds/tailscale.com_connectors.yaml"
-	proxyClassCRDPath                   = operatorDeploymentFilesPath + "/crds/tailscale.com_proxyclasses.yaml"
-	dnsConfigCRDPath                    = operatorDeploymentFilesPath + "/crds/tailscale.com_dnsconfigs.yaml"
-	recorderCRDPath                     = operatorDeploymentFilesPath + "/crds/tailscale.com_recorders.yaml"
-	proxyGroupCRDPath                   = operatorDeploymentFilesPath + "/crds/tailscale.com_proxygroups.yaml"
-	tailnetCRDPath                      = operatorDeploymentFilesPath + "/crds/tailscale.com_tailnets.yaml"
-	proxyGroupPolicyCRDPath             = operatorDeploymentFilesPath + "/crds/tailscale.com_proxygrouppolicies.yaml"
-	peerRelayCRDPath                    = operatorDeploymentFilesPath + "/crds/tailscale.com_peerrelays.yaml"
-	helmTemplatesPath                   = operatorDeploymentFilesPath + "/chart/templates"
-	connectorCRDHelmTemplatePath        = helmTemplatesPath + "/connector.yaml"
-	proxyClassCRDHelmTemplatePath       = helmTemplatesPath + "/proxyclass.yaml"
-	dnsConfigCRDHelmTemplatePath        = helmTemplatesPath + "/dnsconfig.yaml"
-	recorderCRDHelmTemplatePath         = helmTemplatesPath + "/recorder.yaml"
-	proxyGroupCRDHelmTemplatePath       = helmTemplatesPath + "/proxygroup.yaml"
-	tailnetCRDHelmTemplatePath          = helmTemplatesPath + "/tailnet.yaml"
-	proxyGroupPolicyCRDHelmTemplatePath = helmTemplatesPath + "/proxygrouppolicy.yaml"
-	peerRelayCRDHelmTemplatePath        = helmTemplatesPath + "/peerrelay.yaml"
-
-	helmConditionalStart = "{{ if .Values.installCRDs -}}\n"
-	helmConditionalEnd   = "{{- end -}}"
+	operatorDeploymentFilesPath = "cmd/k8s-operator/deploy"
+	crdsPath                    = operatorDeploymentFilesPath + "/crds"
+	helmTemplatesPath           = operatorDeploymentFilesPath + "/chart/templates"
+	crdFilePrefix               = "tailscale.com_"
+	helmConditionalStart        = "{{ if .Values.installCRDs -}}\n"
+	helmConditionalEnd          = "{{- end -}}"
 )
 
 func main() {
@@ -126,65 +111,69 @@ func main() {
 	}
 }
 
-// generate places tailscale.com CRDs (currently Connector, ProxyClass, DNSConfig, Recorder) into
-// the Helm chart templates behind .Values.installCRDs=true condition (true by
-// default).
-func generate(baseDir string) error {
-	addCRDToHelm := func(crdPath, crdTemplatePath string) error {
-		chartBytes, err := os.ReadFile(filepath.Join(baseDir, crdPath))
-		if err != nil {
-			return fmt.Errorf("error reading CRD contents: %w", err)
-		}
-		// Place a new temporary Helm template file with the templated CRD
-		// contents into Helm templates.
-		file, err := os.Create(filepath.Join(baseDir, crdTemplatePath))
-		if err != nil {
-			return fmt.Errorf("error creating CRD template file: %w", err)
-		}
-		if _, err := file.Write([]byte(helmConditionalStart)); err != nil {
-			return fmt.Errorf("error writing helm if statement start: %w", err)
-		}
-		if _, err := file.Write(chartBytes); err != nil {
-			return fmt.Errorf("error writing chart bytes: %w", err)
-		}
-		if _, err := file.Write([]byte(helmConditionalEnd)); err != nil {
-			return fmt.Errorf("error writing helm if-statement end: %w", err)
-		}
-		return file.Close()
+// crdFiles returns the base filenames of every CRD manifest under crdsPath.
+// It errors when none are found: an empty result would silently produce a
+// chart with no CRDs, which is never intentional.
+func crdFiles(baseDir string) ([]string, error) {
+	entries, err := os.ReadDir(filepath.Join(baseDir, crdsPath))
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", crdsPath, err)
 	}
-	for _, crd := range []struct {
-		crdPath, templatePath string
-	}{
-		{connectorCRDPath, connectorCRDHelmTemplatePath},
-		{proxyClassCRDPath, proxyClassCRDHelmTemplatePath},
-		{dnsConfigCRDPath, dnsConfigCRDHelmTemplatePath},
-		{recorderCRDPath, recorderCRDHelmTemplatePath},
-		{proxyGroupCRDPath, proxyGroupCRDHelmTemplatePath},
-		{tailnetCRDPath, tailnetCRDHelmTemplatePath},
-		{proxyGroupPolicyCRDPath, proxyGroupPolicyCRDHelmTemplatePath},
-		{peerRelayCRDPath, peerRelayCRDHelmTemplatePath},
-	} {
-		if err := addCRDToHelm(crd.crdPath, crd.templatePath); err != nil {
-			return fmt.Errorf("error adding %s CRD to Helm templates: %w", crd.crdPath, err)
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasPrefix(name, crdFilePrefix) || !strings.HasSuffix(name, ".yaml") {
+			continue
+		}
+		names = append(names, name)
+	}
+	if len(names) == 0 {
+		return nil, fmt.Errorf("no %s*.yaml files found in %s; run controller-gen to regenerate", crdFilePrefix, crdsPath)
+	}
+	return names, nil
+}
+
+// generate places every tailscale.com CRD manifest found under crdsPath into
+// the Helm chart templates behind a .Values.installCRDs=true condition (true
+// by default). The generated template file uses the same base filename as the
+// source CRD so no new CRD requires a code change here.
+func generate(baseDir string) error {
+	files, err := crdFiles(baseDir)
+	if err != nil {
+		return err
+	}
+	for _, name := range files {
+		src, err := os.ReadFile(filepath.Join(baseDir, crdsPath, name))
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", name, err)
+		}
+		var buf bytes.Buffer
+		buf.WriteString(helmConditionalStart)
+		buf.Write(src)
+		buf.WriteString(helmConditionalEnd)
+		dst := filepath.Join(baseDir, helmTemplatesPath, name)
+		if err := os.WriteFile(dst, buf.Bytes(), 0o664); err != nil {
+			return fmt.Errorf("writing %s: %w", dst, err)
 		}
 	}
 	return nil
 }
 
+// cleanup removes every CRD template file previously written by generate.
+// It globs helmTemplatesPath rather than re-reading crdsPath so a CRD deleted
+// between generate and cleanup is still tidied up.
 func cleanup(baseDir string) error {
-	log.Print("Cleaning up CRD from Helm templates")
-	for _, path := range []string{
-		connectorCRDHelmTemplatePath,
-		proxyClassCRDHelmTemplatePath,
-		dnsConfigCRDHelmTemplatePath,
-		recorderCRDHelmTemplatePath,
-		proxyGroupCRDHelmTemplatePath,
-		tailnetCRDHelmTemplatePath,
-		proxyGroupPolicyCRDHelmTemplatePath,
-		peerRelayCRDHelmTemplatePath,
-	} {
-		if err := os.Remove(filepath.Join(baseDir, path)); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("error cleaning up %s: %w", path, err)
+	log.Print("Cleaning up CRDs from Helm templates")
+	matches, err := filepath.Glob(filepath.Join(baseDir, helmTemplatesPath, crdFilePrefix+"*.yaml"))
+	if err != nil {
+		return fmt.Errorf("globbing Helm templates: %w", err)
+	}
+	for _, p := range matches {
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("removing %s: %w", p, err)
 		}
 	}
 	return nil

--- a/cmd/k8s-operator/generate/main_test.go
+++ b/cmd/k8s-operator/generate/main_test.go
@@ -20,7 +20,7 @@ import (
 	"tailscale.com/util/cibuild"
 )
 
-func Test_generate(t *testing.T) {
+func TestGenerate(t *testing.T) {
 	nettest.SkipIfNoNetwork(t)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
@@ -46,71 +46,87 @@ func Test_generate(t *testing.T) {
 		t.Skipf("error fetching helm; skipping test in CI: %v, %s", err, out)
 	}
 
-	if err := generate(base); err != nil {
+	if err = generate(base); err != nil {
 		t.Fatalf("CRD template generation: %v", err)
 	}
+
+	crdNames := expectedCRDNames(t, base)
 
 	tempDir := t.TempDir()
 	helmChartTemplatesPath := filepath.Join(base, "cmd/k8s-operator/deploy/chart")
 	helmPackageCmd := exec.Command(helmCLIPath, "package", helmChartTemplatesPath, "--destination", tempDir, "--version", "0.0.1")
 	helmPackageCmd.Stderr = os.Stderr
 	helmPackageCmd.Stdout = os.Stdout
-	if err := helmPackageCmd.Run(); err != nil {
+	if err = helmPackageCmd.Run(); err != nil {
 		t.Fatalf("error packaging Helm chart: %v", err)
 	}
+
 	helmPackagePath := filepath.Join(tempDir, "tailscale-operator-0.0.1.tgz")
 	helmLintCmd := exec.Command(helmCLIPath, "lint", helmPackagePath)
 	helmLintCmd.Stderr = os.Stderr
 	helmLintCmd.Stdout = os.Stdout
-	if err := helmLintCmd.Run(); err != nil {
+	if err = helmLintCmd.Run(); err != nil {
 		t.Fatalf("Helm chart linter failed: %v", err)
 	}
 
-	// Test that default Helm install contains the Connector and ProxyClass CRDs.
 	installContentsWithCRD := bytes.NewBuffer([]byte{})
 	helmTemplateWithCRDCmd := exec.Command(helmCLIPath, "template", helmPackagePath)
 	helmTemplateWithCRDCmd.Stderr = os.Stderr
 	helmTemplateWithCRDCmd.Stdout = installContentsWithCRD
-	if err := helmTemplateWithCRDCmd.Run(); err != nil {
+	if err = helmTemplateWithCRDCmd.Run(); err != nil {
 		t.Fatalf("templating Helm chart with CRDs failed: %v", err)
 	}
-	if !strings.Contains(installContentsWithCRD.String(), "name: connectors.tailscale.com") {
-		t.Errorf("Connector CRD not found in default chart install")
-	}
-	if !strings.Contains(installContentsWithCRD.String(), "name: proxyclasses.tailscale.com") {
-		t.Errorf("ProxyClass CRD not found in default chart install")
-	}
-	if !strings.Contains(installContentsWithCRD.String(), "name: dnsconfigs.tailscale.com") {
-		t.Errorf("DNSConfig CRD not found in default chart install")
-	}
-	if !strings.Contains(installContentsWithCRD.String(), "name: recorders.tailscale.com") {
-		t.Errorf("Recorder CRD not found in default chart install")
-	}
-	if !strings.Contains(installContentsWithCRD.String(), "name: proxygroups.tailscale.com") {
-		t.Errorf("ProxyGroup CRD not found in default chart install")
+
+	for _, name := range crdNames {
+		if !strings.Contains(installContentsWithCRD.String(), "name: "+name) {
+			t.Errorf("%s CRD not found in default chart install", name)
+		}
 	}
 
-	// Test that CRDs can be excluded from Helm chart install
 	installContentsWithoutCRD := bytes.NewBuffer([]byte{})
 	helmTemplateWithoutCRDCmd := exec.Command(helmCLIPath, "template", helmPackagePath, "--set", "installCRDs=false")
 	helmTemplateWithoutCRDCmd.Stderr = os.Stderr
 	helmTemplateWithoutCRDCmd.Stdout = installContentsWithoutCRD
-	if err := helmTemplateWithoutCRDCmd.Run(); err != nil {
+
+	if err = helmTemplateWithoutCRDCmd.Run(); err != nil {
 		t.Fatalf("templating Helm chart without CRDs failed: %v", err)
 	}
-	if strings.Contains(installContentsWithoutCRD.String(), "name: connectors.tailscale.com") {
-		t.Errorf("Connector CRD found in chart install that should not contain a CRD")
+
+	for _, name := range crdNames {
+		if strings.Contains(installContentsWithoutCRD.String(), "name: "+name) {
+			t.Errorf("%s CRD found in chart install that should not contain a CRD", name)
+		}
 	}
-	if strings.Contains(installContentsWithoutCRD.String(), "name: connectors.tailscale.com") {
-		t.Errorf("ProxyClass CRD found in chart install that should not contain a CRD")
+}
+
+func TestCRDsExist(t *testing.T) {
+	base, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
 	}
-	if strings.Contains(installContentsWithoutCRD.String(), "name: dnsconfigs.tailscale.com") {
-		t.Errorf("DNSConfig CRD found in chart install that should not contain a CRD")
+	base = filepath.Join(base, "../../../")
+
+	operatorYAML, err := os.ReadFile(filepath.Join(base, "cmd/k8s-operator/deploy/manifests/operator.yaml"))
+	if err != nil {
+		t.Fatalf("reading operator.yaml: %v", err)
 	}
-	if strings.Contains(installContentsWithoutCRD.String(), "name: recorders.tailscale.com") {
-		t.Errorf("Recorder CRD found in chart install that should not contain a CRD")
+	for _, name := range expectedCRDNames(t, base) {
+		if !bytes.Contains(operatorYAML, []byte("name: "+name)) {
+			t.Errorf("operator.yaml is missing %s; run `go generate ./cmd/k8s-operator/...` to refresh it", name)
+		}
 	}
-	if strings.Contains(installContentsWithoutCRD.String(), "name: proxygroups.tailscale.com") {
-		t.Errorf("ProxyGroup CRD found in chart install that should not contain a CRD")
+}
+
+func expectedCRDNames(t *testing.T, base string) []string {
+	t.Helper()
+	files, err := crdFiles(base)
+	if err != nil {
+		t.Fatalf("discovering CRDs: %v", err)
 	}
+	names := make([]string, 0, len(files))
+	for _, f := range files {
+		plural := strings.TrimSuffix(strings.TrimPrefix(f, crdFilePrefix), ".yaml")
+		names = append(names, plural+".tailscale.com")
+	}
+	return names
 }

--- a/cmd/k8s-operator/generate/main_test.go
+++ b/cmd/k8s-operator/generate/main_test.go
@@ -20,7 +20,7 @@ import (
 	"tailscale.com/util/cibuild"
 )
 
-func Test_generate(t *testing.T) {
+func TestGenerate(t *testing.T) {
 	nettest.SkipIfNoNetwork(t)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
@@ -46,71 +46,87 @@ func Test_generate(t *testing.T) {
 		t.Skipf("error fetching helm; skipping test in CI: %v, %s", err, out)
 	}
 
-	if err := generate(base); err != nil {
+	if err = generate(base); err != nil {
 		t.Fatalf("CRD template generation: %v", err)
 	}
+
+	crdNames := expectedCRDNames(t, base)
 
 	tempDir := t.TempDir()
 	helmChartTemplatesPath := filepath.Join(base, "cmd/k8s-operator/deploy/chart")
 	helmPackageCmd := exec.Command(helmCLIPath, "package", helmChartTemplatesPath, "--destination", tempDir, "--version", "0.0.1")
 	helmPackageCmd.Stderr = os.Stderr
 	helmPackageCmd.Stdout = os.Stdout
-	if err := helmPackageCmd.Run(); err != nil {
+	if err = helmPackageCmd.Run(); err != nil {
 		t.Fatalf("error packaging Helm chart: %v", err)
 	}
+
 	helmPackagePath := filepath.Join(tempDir, "tailscale-operator-0.0.1.tgz")
 	helmLintCmd := exec.Command(helmCLIPath, "lint", helmPackagePath)
 	helmLintCmd.Stderr = os.Stderr
 	helmLintCmd.Stdout = os.Stdout
-	if err := helmLintCmd.Run(); err != nil {
+	if err = helmLintCmd.Run(); err != nil {
 		t.Fatalf("Helm chart linter failed: %v", err)
 	}
 
-	// Test that default Helm install contains the Connector and ProxyClass CRDs.
 	installContentsWithCRD := bytes.NewBuffer([]byte{})
 	helmTemplateWithCRDCmd := exec.Command(helmCLIPath, "template", helmPackagePath)
 	helmTemplateWithCRDCmd.Stderr = os.Stderr
 	helmTemplateWithCRDCmd.Stdout = installContentsWithCRD
-	if err := helmTemplateWithCRDCmd.Run(); err != nil {
+	if err = helmTemplateWithCRDCmd.Run(); err != nil {
 		t.Fatalf("templating Helm chart with CRDs failed: %v", err)
 	}
-	if !strings.Contains(installContentsWithCRD.String(), "name: connectors.tailscale.com") {
-		t.Errorf("Connector CRD not found in default chart install")
-	}
-	if !strings.Contains(installContentsWithCRD.String(), "name: proxyclasses.tailscale.com") {
-		t.Errorf("ProxyClass CRD not found in default chart install")
-	}
-	if !strings.Contains(installContentsWithCRD.String(), "name: dnsconfigs.tailscale.com") {
-		t.Errorf("DNSConfig CRD not found in default chart install")
-	}
-	if !strings.Contains(installContentsWithCRD.String(), "name: recorders.tailscale.com") {
-		t.Errorf("Recorder CRD not found in default chart install")
-	}
-	if !strings.Contains(installContentsWithCRD.String(), "name: proxygroups.tailscale.com") {
-		t.Errorf("ProxyGroup CRD not found in default chart install")
+
+	for _, name := range crdNames {
+		if !strings.Contains(installContentsWithCRD.String(), "name: "+name) {
+			t.Errorf("%s CRD not found in default chart install", name)
+		}
 	}
 
-	// Test that CRDs can be excluded from Helm chart install
 	installContentsWithoutCRD := bytes.NewBuffer([]byte{})
 	helmTemplateWithoutCRDCmd := exec.Command(helmCLIPath, "template", helmPackagePath, "--set", "installCRDs=false")
 	helmTemplateWithoutCRDCmd.Stderr = os.Stderr
 	helmTemplateWithoutCRDCmd.Stdout = installContentsWithoutCRD
-	if err := helmTemplateWithoutCRDCmd.Run(); err != nil {
+
+	if err = helmTemplateWithoutCRDCmd.Run(); err != nil {
 		t.Fatalf("templating Helm chart without CRDs failed: %v", err)
 	}
-	if strings.Contains(installContentsWithoutCRD.String(), "name: connectors.tailscale.com") {
-		t.Errorf("Connector CRD found in chart install that should not contain a CRD")
+
+	for _, name := range crdNames {
+		if strings.Contains(installContentsWithoutCRD.String(), "name: "+name) {
+			t.Errorf("%s CRD found in chart install that should not contain a CRD", name)
+		}
 	}
-	if strings.Contains(installContentsWithoutCRD.String(), "name: connectors.tailscale.com") {
-		t.Errorf("ProxyClass CRD found in chart install that should not contain a CRD")
+}
+
+func Test_CRDsExist(t *testing.T) {
+	base, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
 	}
-	if strings.Contains(installContentsWithoutCRD.String(), "name: dnsconfigs.tailscale.com") {
-		t.Errorf("DNSConfig CRD found in chart install that should not contain a CRD")
+	base = filepath.Join(base, "../../../")
+
+	operatorYAML, err := os.ReadFile(filepath.Join(base, "cmd/k8s-operator/deploy/manifests/operator.yaml"))
+	if err != nil {
+		t.Fatalf("reading operator.yaml: %v", err)
 	}
-	if strings.Contains(installContentsWithoutCRD.String(), "name: recorders.tailscale.com") {
-		t.Errorf("Recorder CRD found in chart install that should not contain a CRD")
+	for _, name := range expectedCRDNames(t, base) {
+		if !bytes.Contains(operatorYAML, []byte("name: "+name)) {
+			t.Errorf("operator.yaml is missing %s; run `go generate ./cmd/k8s-operator/...` to refresh it", name)
+		}
 	}
-	if strings.Contains(installContentsWithoutCRD.String(), "name: proxygroups.tailscale.com") {
-		t.Errorf("ProxyGroup CRD found in chart install that should not contain a CRD")
+}
+
+func expectedCRDNames(t *testing.T, base string) []string {
+	t.Helper()
+	files, err := crdFiles(base)
+	if err != nil {
+		t.Fatalf("discovering CRDs: %v", err)
 	}
+	names := make([]string, 0, len(files))
+	for _, f := range files {
+		plural := strings.TrimSuffix(strings.TrimPrefix(f, crdFilePrefix), ".yaml")
+		names = append(names, plural+".tailscale.com")
+	}
+	return names
 }


### PR DESCRIPTION
This commit modifies the "generate" tool we use on the kubernetes operator that produces helm chart and static manifest assets for CRDs.

Previously, this required always remembering to add new constants to a `main.go` and did not have any mechanism to fail in CI if you forgot to. Now this tool will iterate over all the CRDs and ensures that they're in the places they're expected to be, with a test that will fail if they are not.

This removes the requirement for remembering to add these constants every time you have a new CRD.

Closes: #20594