### PR TITLE
tka/sync: improve the signature of SeedAUMs

### DIFF
--- a/tka/sync.go
+++ b/tka/sync.go
@@ -260,16 +260,22 @@ func (a *Authority) MissingAUMs(storage Chonk, remoteOffer SyncOffer) ([]AUM, er
 	panic("unreachable")
 }
 
-// seedNode is an authority-chonk pair that can be seeded by [SeedAUMs].
-type seedNode struct {
+// SeedNode is an authority-chonk pair that can be seeded by [SeedAUMs].
+type SeedNode struct {
 	authority *Authority
 	storage   Chonk
 }
 
 // CreateSeedNode creates a node for use with [SeedAUMs].
-func CreateSeedNode(t testenv.TB, authority *Authority, storage Chonk) seedNode {
+func CreateSeedNode(t testenv.TB, authority *Authority, storage Chonk) SeedNode {
 	t.Helper()
-	return seedNode{authority, storage}
+	return SeedNode{authority, storage}
+}
+
+type SeedAUMConfig struct {
+	Count  int
+	Signer Signer
+	Nodes  []SeedNode
 }
 
 // SeedAUMs generates many AUMs by repeatedly adding and removing keys
@@ -279,20 +285,20 @@ func CreateSeedNode(t testenv.TB, authority *Authority, storage Chonk) seedNode 
 // than one, you can build up a long sync history.
 //
 // This is only for use in testing.
-func SeedAUMs(t testenv.TB, count int, signer Signer, nodes ...seedNode) {
+func SeedAUMs(t testenv.TB, config SeedAUMConfig) {
 	t.Helper()
 
-	if len(nodes) == 0 {
+	if len(config.Nodes) == 0 {
 		panic("called SeedAUMs without any nodes")
 	}
-	primaryNode := nodes[0]
+	primaryNode := config.Nodes[0]
 
 	// The key that we'll repeatedly add/remove in the TKA.
 	key := Key{Kind: Key25519, Public: []byte{1, 1, 1}, Votes: 1}
 
-	for i := 0; i < count/2; i++ {
+	for i := 0; i < config.Count/2; i++ {
 		for _, action := range []string{"add", "remove"} {
-			updater := primaryNode.authority.NewUpdater(signer)
+			updater := primaryNode.authority.NewUpdater(config.Signer)
 			if action == "add" {
 				if err := updater.AddKey(key); err != nil {
 					t.Fatalf("error from updater.AddKey: %v")
@@ -307,7 +313,7 @@ func SeedAUMs(t testenv.TB, count int, signer Signer, nodes ...seedNode) {
 				t.Fatalf("error from authority.Finalize: %v", err)
 			}
 
-			for _, n := range nodes {
+			for _, n := range config.Nodes {
 				if err := n.authority.Inform(n.storage, aum); err != nil {
 					t.Fatalf("error from authority.Inform: %v", err)
 				}

--- a/tka/sync_test.go
+++ b/tka/sync_test.go
@@ -462,7 +462,11 @@ func TestSyncFromFarBehind(t *testing.T) {
 	// 1. Generate enough history to trigger checkpoints.
 	persistentNode := CreateSeedNode(t, persistentAuthority, persistentStorage)
 	compactingNode := CreateSeedNode(t, compactingAuthority, compactingStorage)
-	SeedAUMs(t, checkpointEvery*2, signer1, persistentNode, compactingNode)
+	SeedAUMs(t, SeedAUMConfig{
+		Count:  checkpointEvery * 2,
+		Signer: signer1,
+		Nodes:  []SeedNode{persistentNode, compactingNode},
+	})
 
 	t.Logf("genesis and first batch of AUMs: persistent = %d, compacting = %d", persistentSize(), compactingSize())
 
@@ -483,7 +487,10 @@ func TestSyncFromFarBehind(t *testing.T) {
 	//
 	// If you keep increasing this number, eventually the sync will fail because you
 	// hit the hard-coded limits on iteration during the sync process.
-	SeedAUMs(t, compactingSize()-persistentSize()+800, signer1, persistentNode)
+	SeedAUMs(t, SeedAUMConfig{
+		Count:  compactingSize() - persistentSize() + 800,
+		Signer: signer1, Nodes: []SeedNode{persistentNode},
+	})
 
 	t.Logf("post-compacting and extra AUMs:  persistent = %d, compacting = %d", persistentSize(), compactingSize())
 
@@ -550,7 +557,11 @@ func TestSyncFromFarBehindFork(t *testing.T) {
 	// 1. Generate enough history to trigger checkpoints.
 	persistentNode := CreateSeedNode(t, persistentAuthority, persistentStorage)
 	compactingNode := CreateSeedNode(t, compactingAuthority, compactingStorage)
-	SeedAUMs(t, checkpointEvery*2, winningSigner, persistentNode, compactingNode)
+	SeedAUMs(t, SeedAUMConfig{
+		Count:  checkpointEvery * 2,
+		Signer: winningSigner,
+		Nodes:  []SeedNode{persistentNode, compactingNode},
+	})
 
 	t.Logf("genesis and first batch of AUMs: persistent = %d, compacting = %d", persistentSize(), compactingSize())
 
@@ -567,7 +578,11 @@ func TestSyncFromFarBehindFork(t *testing.T) {
 
 	// 2. Advance the node state slightly beyond the control plane, using the
 	// losing signer.
-	SeedAUMs(t, 1, losingSigner, compactingNode)
+	SeedAUMs(t, SeedAUMConfig{
+		Count:  1,
+		Signer: losingSigner,
+		Nodes:  []SeedNode{compactingNode},
+	})
 
 	// 3. Advance the control plane far beyond the node, using the winning signer.
 	//
@@ -578,7 +593,11 @@ func TestSyncFromFarBehindFork(t *testing.T) {
 	//
 	// If you keep increasing this number, eventually the sync will fail because you
 	// hit the hard-coded limits on iteration during the sync process.
-	SeedAUMs(t, compactingSize()-persistentSize()+800, winningSigner, persistentNode)
+	SeedAUMs(t, SeedAUMConfig{
+		Count:  compactingSize() - persistentSize() + 800,
+		Signer: winningSigner,
+		Nodes:  []SeedNode{persistentNode},
+	})
 
 	t.Logf("post-compacting and extra AUMs:  persistent = %d, compacting = %d", persistentSize(), compactingSize())
 


### PR DESCRIPTION
I wrote this function two hours ago, tried to use it in corp, and immediately found myself confused about the meaning of the arguments. Time for named parameters!

Updates tailscale/corp#40404