### PR TITLE
cmd/tailscale/cli: sanitize peer DNSName in ssh_known_hosts generation

### DIFF
--- a/cmd/tailscale/cli/ssh.go
+++ b/cmd/tailscale/cli/ssh.go
@@ -179,6 +179,9 @@ func genKnownHosts(st *ipnstate.Status) []byte {
 	var buf bytes.Buffer
 	for _, k := range st.Peers() {
 		ps := st.Peer[k]
+		if strings.ContainsAny(ps.DNSName, "\n\r") { // invalid; avoid known_hosts injection
+			continue
+		}
 		for _, hk := range ps.SSH_HostKeys {
 			hostKey := strings.TrimSpace(hk)
 			if strings.ContainsAny(hostKey, "\n\r") { // invalid

--- a/cmd/tailscale/cli/ssh_test.go
+++ b/cmd/tailscale/cli/ssh_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package cli
+
+import (
+	"net/netip"
+	"strings"
+	"testing"
+
+	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/types/key"
+)
+
+// TestGenKnownHostsDNSNameInjection verifies that a peer whose DNSName
+// contains newline characters (as could be supplied by a malicious
+// coordination server via Node.Name) does not inject additional lines into
+// the generated ssh_known_hosts file.
+func TestGenKnownHostsDNSNameInjection(t *testing.T) {
+	nk := key.NewNode().Public()
+	st := &ipnstate.Status{
+		Peer: map[key.NodePublic]*ipnstate.PeerStatus{
+			nk: {
+				DNSName:      "node.attacker.net\n* ssh-ed25519 AAAAattackerkey",
+				TailscaleIPs: []netip.Addr{netip.MustParseAddr("100.64.0.1")},
+				SSH_HostKeys: []string{"ssh-ed25519 AAAAlegitkey"},
+			},
+		},
+	}
+
+	got := string(genKnownHosts(st))
+
+	if strings.Contains(got, "* ssh-ed25519 AAAAattackerkey") {
+		t.Errorf("known_hosts output contains injected wildcard line:\n%s", got)
+	}
+}


### PR DESCRIPTION
genKnownHosts wrote ps.DNSName as the first field of each ssh_known_hosts line without checking for newline characters, while the adjacent hostKey was explicitly newline-checked. ps.DNSName is populated from the control-server supplied Node.Name, which is not validated anywhere in the control client pipeline. A malicious coordination server could set Node.Name to embed a newline plus a wildcard entry (e.g. "* ssh-ed25519 <attacker key>"), which OpenSSH honors for every host, silently enabling MITM of all subsequent 'tailscale ssh' sessions.

Skip any peer whose DNSName contains a newline or carriage return before writing known_hosts lines, mirroring the existing hostKey guard.

Fixes tailscale/vulntriage#349