### PR TITLE
feat: respect endpoint-url path for ts2021 endpoint

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/http"
 	"net/netip"
+	"net/url"
 	"os"
 	"reflect"
 	"runtime"
@@ -836,7 +837,11 @@ func (c *Direct) doLogin(ctx context.Context, opt loginOpt) (mustRegen bool, new
 	if err != nil {
 		return regen, opt.URL, nil, fmt.Errorf("getNoiseClient: %w", err)
 	}
-	url := fmt.Sprintf("%s/machine/register", c.serverURL)
+	serverUrlParsed, err := url.Parse(c.serverURL)
+	if err != nil {
+		return regen, opt.URL, nil, fmt.Errorf("getNoiseClient: failed parse server url: %w", err)
+	}
+	url := fmt.Sprintf("%s://%s/machine/register", serverUrlParsed.Scheme, serverUrlParsed.Host)
 	url = strings.Replace(url, "http:", "https:", 1)
 
 	bodyData, err := encode(request)
@@ -1190,7 +1195,11 @@ func (c *Direct) sendMapRequest(ctx context.Context, isStreaming bool, nu Netmap
 	if err != nil {
 		return fmt.Errorf("getNoiseClient: %w", err)
 	}
-	url := fmt.Sprintf("%s/machine/map", serverURL)
+	serverUrlParsed, err := url.Parse(serverURL)
+	if err != nil {
+		return fmt.Errorf("getNoiseClient: failed parse server url: %w", err)
+	}
+	url := fmt.Sprintf("%s://%s/machine/map", serverUrlParsed.Scheme, serverUrlParsed.Host)
 	url = strings.Replace(url, "http:", "https:", 1)
 
 	// Create a watchdog timer that breaks the connection if we don't receive a

--- a/control/controlhttp/client.go
+++ b/control/controlhttp/client.go
@@ -251,12 +251,12 @@ func (a *Dialer) dialHostOpt(ctx context.Context, optAddr netip.Addr, optACEHost
 	u80 := &url.URL{
 		Scheme: "http",
 		Host:   net.JoinHostPort(a.Hostname, strDef(a.HTTPPort, "80")),
-		Path:   serverUpgradePath,
+		Path:   appendServerBasePath(a.BasePath, serverUpgradePath),
 	}
 	u443 := &url.URL{
 		Scheme: "https",
 		Host:   net.JoinHostPort(a.Hostname, strDef(a.HTTPSPort, "443")),
-		Path:   serverUpgradePath,
+		Path:   appendServerBasePath(a.BasePath, serverUpgradePath),
 	}
 	if a.HTTPSPort == NoPort || optACEHost != "" {
 		u443 = nil

--- a/control/controlhttp/client_common.go
+++ b/control/controlhttp/client_common.go
@@ -4,6 +4,8 @@
 package controlhttp
 
 import (
+	"strings"
+
 	"tailscale.com/control/controlbase"
 )
 
@@ -14,4 +16,20 @@ import (
 type ClientConn struct {
 	// Conn is the noise connection.
 	*controlbase.Conn
+}
+
+// Appends server base path to the left, the same way as
+// `/base + /endpoint`.
+func appendServerBasePath(serverPath string, urlPath string) string {
+	serverPath = strings.TrimSuffix(serverPath, "/")
+	serverPath = strings.TrimPrefix(serverPath, "/")
+
+	if serverPath == "" {
+		return urlPath
+	}
+
+	urlPath = strings.TrimSuffix(urlPath, "/")
+	urlPath = strings.TrimPrefix(urlPath, "/")
+
+	return "/" + serverPath + "/" + urlPath
 }

--- a/control/controlhttp/client_js.go
+++ b/control/controlhttp/client_js.go
@@ -41,7 +41,7 @@ func (d *Dialer) Dial(ctx context.Context) (*ClientConn, error) {
 	wsURL := &url.URL{
 		Scheme: wsScheme,
 		Host:   host,
-		Path:   serverUpgradePath,
+		Path:   appendServerBasePath(d.BasePath, serverUpgradePath),
 		// Can't set HTTP headers on the websocket request, so we have to to send
 		// the handshake via an HTTP header.
 		RawQuery: url.Values{

--- a/control/controlhttp/constants.go
+++ b/control/controlhttp/constants.go
@@ -109,6 +109,10 @@ type Dialer struct {
 	// If nil, tstime.StdClock is used.
 	// This exists primarily for tests.
 	Clock tstime.Clock
+
+	// Base path for Control API endpoint requests, extracted from the
+	// taislcale endpoint URL.
+	BasePath string
 }
 
 func strDef(v1, v2 string) string {

--- a/control/controlhttp/http_test.go
+++ b/control/controlhttp/http_test.go
@@ -235,6 +235,7 @@ func testControlHTTP(t *testing.T, param httpTestParam) {
 		testFallbackDelay:    fallbackDelay,
 		Clock:                clock,
 		HealthTracker:        health.NewTracker(eventbustest.NewBus(t)),
+		BasePath:             "",
 	}
 
 	if param.httpInDial {
@@ -794,6 +795,7 @@ func runDialPlanTest(t *testing.T, plan *tailcfg.ControlDialPlan, want []netip.A
 		testFallbackDelay:    50 * time.Millisecond,
 		Clock:                clock,
 		HealthTracker:        health.NewTracker(bus),
+		BasePath:             "",
 	}
 
 	start := time.Now()

--- a/control/ts2021/client.go
+++ b/control/ts2021/client.go
@@ -239,6 +239,11 @@ func (nc *Client) dial(ctx context.Context) (*Conn, error) {
 		timeoutSec = 5
 	}
 
+	serverURL, err := url.Parse(nc.opts.ServerURL)
+	if err != nil {
+		return nil, err
+	}
+
 	timeout := time.Duration(timeoutSec * float64(time.Second))
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -258,6 +263,7 @@ func (nc *Client) dial(ctx context.Context) (*Conn, error) {
 		HealthTracker:   nc.opts.HealthTracker,
 		ExtraRootCAs:    nc.opts.ExtraRootCAs,
 		Clock:           tstime.StdClock{},
+		BasePath:        serverURL.Path,
 	}
 	clientConn, err := chd.Dial(ctx)
 	if err != nil {


### PR DESCRIPTION
Solves #20610 

This PR adds support for respect endpoint-url path for `/ts2021` endpoint, but does not alter the noise protocol endpoint paths.

Configurations without path keep working as usual.