### PR TITLE
control/controlclient: reset control transport on new STUN IP

### DIFF
--- a/control/controlclient/auto.go
+++ b/control/controlclient/auto.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/netip"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -142,6 +143,8 @@ type Auto struct {
 	loggedIn       bool        // true if currently logged in
 	loginGoal      *LoginGoal  // non-nil if some login activity is desired
 	inMapPoll      bool        // true once we get the first MapResponse in a stream; false when HTTP response ends
+
+	lastSTUNIPs map[netip.Addr]bool
 
 	authCtx    context.Context // context used for auth requests
 	mapCtx     context.Context // context used for netmap and update requests
@@ -301,6 +304,26 @@ func (c *Auto) restartMap() {
 	c.mu.Unlock()
 
 	c.logf("[v1] restartMap: synced=%v", synced)
+	c.updateControl()
+}
+
+// restartMapWithNewNoiseClient restarts map polling over a fresh transport.
+// An upstream NAT change can leave the old TCP connection blackholed without
+// changing any local interface.
+func (c *Auto) restartMapWithNewNoiseClient() {
+	nc := c.direct.takeNoiseClient()
+
+	c.mu.Lock()
+	c.cancelMapCtxLocked()
+	synced := c.inMapPoll
+	c.mu.Unlock()
+
+	if nc != nil {
+		if err := nc.Close(); err != nil {
+			c.logf("closing stale control connection: %v", err)
+		}
+	}
+	c.logf("[v1] restartMap: new STUN IP; synced=%v", synced)
 	c.updateControl()
 }
 
@@ -885,10 +908,46 @@ func (c *Auto) SetExpirySooner(ctx context.Context, expiry time.Time) error {
 //
 // It does not retain the provided slice.
 func (c *Auto) UpdateEndpoints(endpoints []tailcfg.Endpoint) {
-	changed := c.direct.SetEndpoints(endpoints)
-	if changed {
-		c.updateControl()
+	if !c.direct.SetEndpoints(endpoints) {
+		return
 	}
+	if c.noteSTUNEndpointIPs(endpoints) {
+		c.restartMapWithNewNoiseClient()
+		return
+	}
+	c.updateControl()
+}
+
+// noteSTUNEndpointIPs reports whether endpoints contain a new public IPv4
+// address. The first non-empty set establishes a baseline. Empty results and
+// port-only changes leave an existing control connection alone.
+func (c *Auto) noteSTUNEndpointIPs(endpoints []tailcfg.Endpoint) bool {
+	current := make(map[netip.Addr]bool)
+	for _, ep := range endpoints {
+		if ep.Type != tailcfg.EndpointSTUN {
+			continue
+		}
+		if ip := ep.Addr.Addr().Unmap(); ip.Is4() {
+			current[ip] = true
+		}
+	}
+	if len(current) == 0 {
+		return false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var hasNewIP bool
+	for ip := range current {
+		if !c.lastSTUNIPs[ip] {
+			hasNewIP = true
+			break
+		}
+	}
+	hadBaseline := len(c.lastSTUNIPs) != 0
+	c.lastSTUNIPs = current
+	return hadBaseline && hasNewIP && !c.closed
 }
 
 // SetDiscoPublicKey sets the client's Disco public to key and sends the change

--- a/control/controlclient/auto_test.go
+++ b/control/controlclient/auto_test.go
@@ -5,10 +5,14 @@ package controlclient
 
 import (
 	"context"
+	"net/http"
+	"net/netip"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"tailscale.com/control/ts2021"
 	"tailscale.com/tailcfg"
 )
 
@@ -63,4 +67,135 @@ func TestMapRoutineStateUpdateUserProfilesConcurrentCancelMapCtx(t *testing.T) {
 	}
 	c.observerQueue.Shutdown()
 	c.mapCancel()
+}
+
+func TestSTUNEndpointIPChange(t *testing.T) {
+	stun := func(addr string) tailcfg.Endpoint {
+		return tailcfg.Endpoint{
+			Addr: netip.MustParseAddrPort(addr),
+			Type: tailcfg.EndpointSTUN,
+		}
+	}
+	local := func(addr string) tailcfg.Endpoint {
+		return tailcfg.Endpoint{
+			Addr: netip.MustParseAddrPort(addr),
+			Type: tailcfg.EndpointLocal,
+		}
+	}
+
+	c := new(Auto)
+	tests := []struct {
+		name      string
+		endpoints []tailcfg.Endpoint
+		want      bool
+	}{
+		{"local-only", []tailcfg.Endpoint{local("192.0.2.10:41641")}, false},
+		{"initial", []tailcfg.Endpoint{stun("198.51.100.10:41641")}, false},
+		{"new-port", []tailcfg.Endpoint{stun("198.51.100.10:51234")}, false},
+		{"IPv6-only", []tailcfg.Endpoint{stun("[2001:db8::10]:41641")}, false},
+		{"new-IP", []tailcfg.Endpoint{
+			stun("198.51.100.10:51234"),
+			stun("203.0.113.20:42345"),
+		}, true},
+		{"same-IPs", []tailcfg.Endpoint{
+			stun("198.51.100.10:59999"),
+			stun("203.0.113.20:42999"),
+		}, false},
+		{"remove-old-IP", []tailcfg.Endpoint{stun("203.0.113.20:42999")}, false},
+		{"empty", nil, false},
+		{"new-IP-after-empty", []tailcfg.Endpoint{
+			stun("192.0.2.30:41641"),
+			stun("203.0.113.20:42999"),
+		}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := c.noteSTUNEndpointIPs(tt.endpoints); got != tt.want {
+				t.Errorf("noteSTUNEndpointIPs = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	c.closed = true
+	if c.noteSTUNEndpointIPs([]tailcfg.Endpoint{stun("192.0.2.31:41641")}) {
+		t.Error("closed client requested a reset")
+	}
+}
+
+type closeRecorder struct {
+	closed atomic.Bool
+}
+
+func (*closeRecorder) RoundTrip(*http.Request) (*http.Response, error) {
+	panic("unexpected RoundTrip")
+}
+
+func (r *closeRecorder) CloseIdleConnections() {
+	r.closed.Store(true)
+}
+
+// Regression test for the WAN-failover case in tailscale/tailscale#12021:
+// finding a new STUN IP must replace the cached Noise client even while paused.
+func TestUpdateEndpointsResetsNoiseClientOnNewSTUNIP(t *testing.T) {
+	stun := func(addr string) tailcfg.Endpoint {
+		return tailcfg.Endpoint{
+			Addr: netip.MustParseAddrPort(addr),
+			Type: tailcfg.EndpointSTUN,
+		}
+	}
+
+	tr := new(closeRecorder)
+	nc := &ts2021.Client{Client: &http.Client{Transport: tr}}
+	d := &Direct{logf: t.Logf, noiseClient: nc}
+	oldMapCtx, oldMapCancel := context.WithCancel(t.Context())
+	c := &Auto{
+		direct:    d,
+		logf:      t.Logf,
+		updateCh:  make(chan struct{}, 1),
+		mapCtx:    oldMapCtx,
+		mapCancel: oldMapCancel,
+		paused:    true,
+	}
+	t.Cleanup(func() { c.mapCancel() })
+	drainUpdate := func() {
+		t.Helper()
+		select {
+		case <-c.updateCh:
+		default:
+			t.Fatal("control update was not queued")
+		}
+	}
+
+	c.UpdateEndpoints([]tailcfg.Endpoint{stun("198.51.100.10:41641")})
+	drainUpdate()
+	c.UpdateEndpoints([]tailcfg.Endpoint{stun("198.51.100.10:51234")})
+	drainUpdate()
+	if tr.closed.Load() {
+		t.Fatal("port-only change closed the Noise client")
+	}
+
+	c.UpdateEndpoints([]tailcfg.Endpoint{
+		stun("198.51.100.10:51234"),
+		stun("203.0.113.20:42345"),
+	})
+
+	select {
+	case <-oldMapCtx.Done():
+	default:
+		t.Error("old map context was not canceled")
+	}
+	select {
+	case <-c.mapCtx.Done():
+		t.Error("new map context is already canceled")
+	default:
+	}
+	if !tr.closed.Load() {
+		t.Error("old Noise client was not closed")
+	}
+	if d.noiseClient != nil {
+		t.Error("old Noise client was retained")
+	}
+	if got := len(c.updateCh); got != 1 {
+		t.Errorf("queued updates = %d, want 1", got)
+	}
 }

--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -477,6 +477,18 @@ func (c *Direct) Close() error {
 	return nil
 }
 
+// takeNoiseClient removes and returns the current Noise client without closing
+// it. A concurrent getNoiseClient still creating a client is safe:
+// ts2021.NewClient does not dial, so it has no connection to the old path.
+func (c *Direct) takeNoiseClient() *ts2021.Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	nc := c.noiseClient
+	c.noiseClient = nil
+	return nc
+}
+
 // SetHostinfo clones the provided Hostinfo and remembers it for the
 // next update. It reports whether the Hostinfo has changed.
 func (c *Direct) SetHostinfo(hi *tailcfg.Hostinfo) bool {


### PR DESCRIPTION
I ran into this with the Home Assistant add-on during a wired-to-cellular
failover. Magicsock found the new cellular endpoint, but the control connection
stayed stuck on the old path until tailscaled was restarted.

This keeps track of the public IPv4 addresses seen in STUN endpoints. The first
result establishes a baseline. If a new address shows up later, the Noise
client is reset and map polling starts again on the current network path. Port
changes, IPv6 endpoints, removals, and empty results don't trigger a reset.

With this change, control reconnected in about a second during the same
handover and the node stayed online without a restart.

Tested:

- `go test ./control/controlclient ./control/ts2021`
- focused tests repeated 100 times
- `go test ./control/...`
- live wired-to-cellular handover

Updates #12021