### PR TITLE
types/persist: add a comment explaining "NetworkLockKey"

### DIFF
--- a/types/persist/persist.go
+++ b/types/persist/persist.go
@@ -24,9 +24,13 @@ type Persist struct {
 	PrivateNodeKey    key.NodePrivate
 	OldPrivateNodeKey key.NodePrivate // needed to request key rotation
 	UserProfile       tailcfg.UserProfile
-	NetworkLockKey    key.NLPrivate
-	NodeID            tailcfg.StableNodeID
-	AttestationKey    key.HardwareAttestationKey `json:",omitzero"`
+
+	// NetworkLockKey is the node's Tailnet Lock private key.
+	// "Network Lock" was the pre-release name for Tailnet Lock.
+	NetworkLockKey key.NLPrivate
+
+	NodeID         tailcfg.StableNodeID
+	AttestationKey key.HardwareAttestationKey `json:",omitzero"`
 
 	// DisallowedTKAStateIDs stores the tka.State.StateID values which
 	// this node will not operate tailnet lock on. This is used to

--- a/types/persist/persist_view.go
+++ b/types/persist/persist_view.go
@@ -91,6 +91,9 @@ func (v PersistView) PrivateNodeKey() key.NodePrivate { return v.ж.PrivateNodeK
 // needed to request key rotation
 func (v PersistView) OldPrivateNodeKey() key.NodePrivate   { return v.ж.OldPrivateNodeKey }
 func (v PersistView) UserProfile() tailcfg.UserProfileView { return v.ж.UserProfile.View() }
+
+// NetworkLockKey is the node's Tailnet Lock private key.
+// "Network Lock" was the pre-release name for Tailnet Lock.
 func (v PersistView) NetworkLockKey() key.NLPrivate        { return v.ж.NetworkLockKey }
 func (v PersistView) NodeID() tailcfg.StableNodeID         { return v.ж.NodeID }
 func (v PersistView) AttestationKey() tailcfg.StableNodeID { panic("unsupported") }


### PR DESCRIPTION
Changing the name to "TailnetLockKey" would be clearer but introduces more risk; this is an easy and low-stakes improvement.

Updates tailscale/corp#37904