### PR TITLE
ssh/tailssh: signal the session's process group, not just the child

### DIFF
--- a/.github/workflows/ssh-integrationtest.yml
+++ b/.github/workflows/ssh-integrationtest.yml
@@ -11,7 +11,7 @@ on:
     paths:
       - "ssh/**"
       - "tempfork/gliderlabs/ssh/**"
-      - ".github/workflows/ssh-integrationtest"
+      - ".github/workflows/ssh-integrationtest.yml"
 jobs:
   ssh-integrationtest:
     runs-on: ubuntu-latest
@@ -37,3 +37,97 @@ jobs:
       - name: Run SSH integration tests (${{ matrix.base }})
         run: |
           docker build --build-arg="BASE=${{ matrix.base }}" -t "${{ matrix.tag }}" ssh/tailssh/testcontainers
+
+  macos-ssh-integrationtest:
+    runs-on: macos-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # Capture runner identity, OpenSSH version, and the test user's
+      # login shell so a future failure can be attributed to a runner
+      # image change without re-running with extra logging.
+      - name: macOS preflight diagnostics
+        run: |
+          set +e
+          echo "=== uname -a ==="
+          uname -a
+          echo "=== sw_vers ==="
+          sw_vers
+          echo "=== id ==="
+          id
+          echo "=== id runner ==="
+          id runner
+          echo "=== ssh -V ==="
+          ssh -V
+          echo "=== dscl . -read /Users/runner UserShell ==="
+          dscl . -read /Users/runner UserShell
+
+      - name: Build test binaries
+        run: |
+          ./tool/go test -tags integrationtest -c ./ssh/tailssh -o /tmp/tailssh.test
+          ./tool/go build -o /tmp/tailscaled ./cmd/tailscaled
+          ls -l /tmp/tailssh.test /tmp/tailscaled
+
+      # The two test steps below are wired with continue-on-error so a
+      # failure in one still lets the other run. The aggregator step at
+      # the end fails the job if either failed. We need both: the Go SSH
+      # client test exercises the wire-level frame ordering, and the
+      # OpenSSH client test exercises the actual binary that users of
+      # #18256 are running.
+
+      - name: Run macOS OpenSSH exit status integration tests
+        id: openssh
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          sudo env \
+            PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH \
+            TAILSCALED_PATH=/tmp/tailscaled \
+            TS_SSH_INTEGRATION_TEST_USER=runner \
+            /tmp/tailssh.test -test.v -test.timeout=5m -test.run '^TestOpenSSHExitCodes$' \
+            2>&1 | tee /tmp/openssh-exitcodes.log
+
+      - name: Run macOS Go SSH exit status integration tests
+        id: gossh
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          sudo env \
+            PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH \
+            TAILSCALED_PATH=/tmp/tailscaled \
+            TS_SSH_INTEGRATION_TEST_USER=runner \
+            /tmp/tailssh.test -test.v -test.timeout=5m -test.run '^TestIntegrationExitCodes$' \
+            2>&1 | tee /tmp/gossh-exitcodes.log
+
+      - name: Collect incubator log
+        if: always()
+        run: |
+          if [ -f /tmp/tailscalessh.log ]; then
+            sudo cp /tmp/tailscalessh.log /tmp/tailscalessh.log.copy || true
+            sudo chmod a+r /tmp/tailscalessh.log.copy || true
+          else
+            echo "no incubator log produced" > /tmp/tailscalessh.log.copy
+          fi
+
+      - name: Upload diagnostic artifacts
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: macos-ssh-integrationtest-logs
+          path: |
+            /tmp/openssh-exitcodes.log
+            /tmp/gossh-exitcodes.log
+            /tmp/tailscalessh.log.copy
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Aggregate test result
+        run: |
+          openssh="${{ steps.openssh.outcome }}"
+          gossh="${{ steps.gossh.outcome }}"
+          echo "OpenSSH test outcome: $openssh"
+          echo "Go SSH test outcome:  $gossh"
+          if [ "$openssh" != "success" ] || [ "$gossh" != "success" ]; then
+            exit 1
+          fi

--- a/ssh/tailssh/incubator.go
+++ b/ssh/tailssh/incubator.go
@@ -601,7 +601,7 @@ func trySU(dlogf logger.Logf, ia incubatorArgs) (handled bool, err error) {
 		return false, nil
 	}
 
-	su := findSU(dlogf, ia)
+	su, cmdFlag := findSU(dlogf, ia)
 	if su == "" {
 		return false, nil
 	}
@@ -623,8 +623,9 @@ func trySU(dlogf logger.Logf, ia incubatorArgs) (handled bool, err error) {
 		ia.localUser,
 	}
 	if ia.cmd != "" {
-		// Note - unlike the login command, su allows using both -l and -c.
-		loginArgs = append(loginArgs, "-c", ia.cmd)
+		// Note - unlike the login command, su allows using both -l and the
+		// command flag. findSU picked which one this su understands.
+		loginArgs = append(loginArgs, cmdFlag, ia.cmd)
 	}
 
 	dlogf("logging in with %+v", loginArgs)
@@ -636,49 +637,58 @@ func trySU(dlogf logger.Logf, ia incubatorArgs) (handled bool, err error) {
 	return true, err
 }
 
-// findSU attempts to find an su command which supports the -l and -c flags.
-// This actually calls the su command, which can cause side effects like
-// triggering pam_mkhomedir. If a suitable su is not available, this returns
-// "".
-func findSU(dlogf logger.Logf, ia incubatorArgs) string {
+// findSU attempts to find an su command which supports the -l flag and a way
+// to pass a command. This actually calls the su command, which can cause side
+// effects like triggering pam_mkhomedir. If a suitable su is not available,
+// this returns "".
+//
+// It also reports which flag to pass the command with. --session-command is
+// preferred over -c: -c runs the command in a new session (setsid), which puts
+// the user's shell outside the incubator's process group, so
+// terminateSession's kill(-pgid) never reaches it. --session-command does the
+// same thing without the setsid, but is util-linux-specific (BusyBox rejects
+// it), so an su that doesn't take it falls back to -c and keeps the
+// pre-existing teardown reach.
+func findSU(dlogf logger.Logf, ia incubatorArgs) (su, cmdFlag string) {
 	// Currently, we only support falling back to su on Linux. This
 	// potentially could work on BSDs as well, but requires testing.
 	if runtime.GOOS != linux {
-		return ""
+		return "", ""
 	}
 
 	// gokrazy doesn't include su. And, if someone installs a breakglass/
 	// debugging package on gokrazy, we don't want to use its su.
 	if distro.Get() == distro.Gokrazy {
-		return ""
+		return "", ""
 	}
 
 	su, err := exec.LookPath("su")
 	if err != nil {
 		dlogf("can't find su command: %v", err)
-		return ""
+		return "", ""
 	}
 
 	_, allowListEnvKeys, err := ia.forwardedEnviron()
 	if err != nil {
-		return ""
+		return "", ""
 	}
 
-	// First try to execute su -w <allow listed env> -l <user> -c true
-	// to make sure su supports the necessary arguments.
-	err = exec.Command(
-		su,
-		"-w", strings.Join(allowListEnvKeys, ","),
-		"-l",
-		ia.localUser,
-		"-c", "true",
-	).Run()
-	if err != nil {
-		dlogf("su check failed: %s", err)
-		return ""
+	// Try to execute su -w <allow listed env> -l <user> <cmdFlag> true to
+	// make sure su supports the necessary arguments.
+	for _, cmdFlag := range []string{"--session-command", "-c"} {
+		err = exec.Command(
+			su,
+			"-w", strings.Join(allowListEnvKeys, ","),
+			"-l",
+			ia.localUser,
+			cmdFlag, "true",
+		).Run()
+		if err == nil {
+			return su, cmdFlag
+		}
+		dlogf("su check with %s failed: %s", cmdFlag, err)
 	}
-
-	return su
+	return "", ""
 }
 
 // handleSSHInProcess is a last resort if we couldn't use login or su. It

--- a/ssh/tailssh/incubator.go
+++ b/ssh/tailssh/incubator.go
@@ -169,6 +169,12 @@ func (ss *sshSession) newIncubatorCommand(logf logger.Logf) (cmd *exec.Cmd, err 
 			return nil, err
 		}
 
+		// Own process group, for the same reason as the incubator cmd
+		// below: terminateSession signals kill(-pgid), and without this
+		// the user shell stays in tailscaled's group, the group signal
+		// finds no such pgid (ESRCH), and grandchildren survive session
+		// teardown.
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 		return cmd, nil
 	}
 
@@ -246,6 +252,12 @@ func (ss *sshSession) newIncubatorCommand(logf logger.Logf) (cmd *exec.Cmd, err 
 	cmd = exec.CommandContext(ss.ctx, ss.conn.srv.tailscaledPath, incubatorArgs...)
 	// The incubator will chdir into the home directory after it drops privileges.
 	cmd.Dir = "/"
+
+	// Own process group so SIGHUP via kill(-pgid) reaches the
+	// grandchild user shell, not just the incubator. The PTY path
+	// overrides this in startWithPTY with Setsid (which also creates
+	// a new pgrp), so the assignment is harmless to overwrite there.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	return cmd, nil
 }
 
@@ -1237,4 +1249,24 @@ func groupsMatchCurrent(groupIDs []int) bool {
 	sort.Ints(groupIDs)
 	sort.Ints(existing)
 	return slices.Equal(groupIDs, existing)
+}
+
+// terminateSession delivers sig to the incubator's process group
+// (kill(-pgid)) so it reaches any user shell the incubator spawned.
+// The incubator is the group leader via Setpgid in newIncubatorCommand
+// or Setsid in startWithPTY. ESRCH maps to nil: the session has exited
+// via cmd.Wait.
+func terminateSession(p *os.Process, sig os.Signal) error {
+	if p == nil {
+		return errors.New("nil process")
+	}
+	ssig, ok := sig.(syscall.Signal)
+	if !ok {
+		return p.Signal(sig)
+	}
+	err := syscall.Kill(-p.Pid, ssig)
+	if errors.Is(err, syscall.ESRCH) {
+		return nil
+	}
+	return err
 }

--- a/ssh/tailssh/incubator_plan9.go
+++ b/ssh/tailssh/incubator_plan9.go
@@ -419,3 +419,13 @@ func acceptEnvPair(kv string) bool {
 	_ = k
 	return true // permit anything on plan9 during bringup, for debugging at least
 }
+
+// terminateSession signals the incubator directly: plan9 has no
+// Unix-style process groups, so the user shell doesn't get the signal
+// here. plan9 is best-effort for tailssh today.
+func terminateSession(p *os.Process, sig os.Signal) error {
+	if p == nil {
+		return errors.New("nil process")
+	}
+	return p.Signal(sig)
+}

--- a/ssh/tailssh/tailssh.go
+++ b/ssh/tailssh/tailssh.go
@@ -886,10 +886,13 @@ func (ss *sshSession) killProcessOnContextDone() {
 		// We don't need to Process.Wait here, sshSession.run() does
 		// the waiting regardless of termination reason.
 
-		// SIGHUP = POSIX terminal-disconnect semantics; OpenSSH gets it
-		// implicitly via PTY-master close (session.c:2246), we send it
-		// explicitly because non-PTY sessions use pipes.
-		ss.cmd.Process.Signal(syscall.SIGHUP)
+		// SIGHUP to the incubator's process group (terminateSession),
+		// so the user's shell (grandchild) gets it too, not just the
+		// incubator. POSIX terminal-disconnect semantics; OpenSSH gets
+		// it implicitly via PTY-master close (session.c:2246).
+		if err := terminateSession(ss.cmd.Process, syscall.SIGHUP); err != nil {
+			ss.logf("terminate session: %v", err)
+		}
 	})
 }
 

--- a/ssh/tailssh/tailssh_integration_exitcodes_test.go
+++ b/ssh/tailssh/tailssh_integration_exitcodes_test.go
@@ -18,6 +18,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -421,5 +422,69 @@ func TestLocalUnixForwardingHalfClose(t *testing.T) {
 		}
 	case <-time.After(15 * time.Second):
 		t.Fatalf("timed out waiting for response after half-close; bicopy may be tearing down the channel prematurely")
+	}
+}
+
+// TestIntegrationSIGHUP asserts session teardown delivers SIGHUP (not
+// SIGKILL): a bash trap writes a marker file, then we tear down and
+// check the file appeared.
+func TestIntegrationSIGHUP(t *testing.T) {
+	debugTest.Store(true)
+	t.Cleanup(func() { debugTest.Store(false) })
+
+	// t.TempDir creates /tmp/<TestName>/NNN, both root-owned, with the
+	// parent at 0700 and the leaf at 0755. The incubator drops
+	// privileges before running the trap, so the > redirect needs the
+	// dropped-privilege shell to traverse the parent and write the
+	// leaf. Open both up; cleanup still runs via t.TempDir.
+	markerDir := t.TempDir()
+	if err := os.Chmod(filepath.Dir(markerDir), 0o755); err != nil {
+		t.Fatalf("chmod parent: %v", err)
+	}
+	if err := os.Chmod(markerDir, 0o777); err != nil {
+		t.Fatalf("chmod marker dir: %v", err)
+	}
+	readyFile := filepath.Join(markerDir, "ready")
+	markerFile := filepath.Join(markerDir, "sighup-received")
+
+	cl := testClient(t, false, false)
+	s, err := cl.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Touch readyFile after installing the trap so the test can wait
+	// on a real condition (trap installed) instead of guessing with a
+	// wall-clock sleep.
+	cmd := fmt.Sprintf(
+		`trap 'echo received > %s; exit 0' HUP; : > %s; sleep 30`,
+		markerFile, readyFile,
+	)
+	if err := s.Start(cmd); err != nil {
+		t.Fatalf("failed to start command: %v", err)
+	}
+
+	if err := tstest.WaitFor(10*time.Second, func() error {
+		_, err := os.Stat(readyFile)
+		return err
+	}); err != nil {
+		t.Fatalf("trap never installed: %v", err)
+	}
+
+	s.Close()
+	cl.Close()
+
+	if err := tstest.WaitFor(10*time.Second, func() error {
+		_, err := os.Stat(markerFile)
+		return err
+	}); err != nil {
+		t.Fatalf("process did not receive SIGHUP: %v", err)
+	}
+	data, err := os.ReadFile(markerFile)
+	if err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "received" {
+		t.Fatalf("marker content = %q, want %q", got, "received")
 	}
 }

--- a/ssh/tailssh/tailssh_termination_test.go
+++ b/ssh/tailssh/tailssh_termination_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build linux || darwin
+
+package tailssh
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+	"tailscale.com/tstest"
+)
+
+// processWithMarkerRunning reports whether any process has marker in
+// its command line. pgrep exits 1 for "no match", which is the only
+// non-error "false" we accept.
+func processWithMarkerRunning(t *testing.T, marker string) bool {
+	t.Helper()
+	err := exec.Command("pgrep", "-f", marker).Run()
+	if err == nil {
+		return true
+	}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) && ee.ExitCode() == 1 {
+		return false
+	}
+	t.Fatalf("pgrep -f %q: %v", marker, err)
+	return false
+}
+
+// TestSessionTerminationKillsProcess asserts that tearing down an SSH
+// session terminates the user's whole process tree, not just the
+// immediate child. The in-process harness has no tailscaledPath, so
+// this exercises the direct-exec (no incubator) path where the user
+// shell spawns grandchildren: tailssh must signal the process group,
+// which requires the direct-path cmd to be its own group leader.
+func TestSessionTerminationKillsProcess(t *testing.T) {
+	h := newTestSSHHarness(t)
+
+	marker := fmt.Sprintf("tailssh-termination-test-%d-%d", os.Getpid(), time.Now().UnixNano())
+	// Two levels deep, on purpose. The outer sh is (or is exec'd over
+	// by) cmd.Process, which exec.CommandContext kills on its own; the
+	// inner sh is a grandchild that only dies if tailssh signals the
+	// whole process group. The loop keeps the inner sh from exec'ing
+	// over itself, so the marker stays in the survivor's argv.
+	cmd := fmt.Sprintf(`/bin/sh -c '/bin/sh -c "while :; do sleep 1; done #%s" & wait'`, marker)
+
+	t.Cleanup(func() {
+		// Don't leave a 30s sleeper behind on failure.
+		exec.Command("pkill", "-f", marker).Run()
+	})
+
+	cl, err := ssh.Dial("tcp", h.addr, &ssh.ClientConfig{
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         15 * time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+	s, err := cl.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Start(cmd); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if err := tstest.WaitFor(10*time.Second, func() error {
+		if !processWithMarkerRunning(t, marker) {
+			return fmt.Errorf("marker process not started yet")
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("marker process never appeared: %v", err)
+	}
+
+	// Tear the whole connection down; the session context cancels and
+	// tailssh must terminate the process tree.
+	s.Close()
+	cl.Close()
+
+	if err := tstest.WaitFor(10*time.Second, func() error {
+		if processWithMarkerRunning(t, marker) {
+			return fmt.Errorf("process still running")
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("user process survived session teardown: %v", err)
+	}
+}


### PR DESCRIPTION
Teardown signalled cmd.Process.Pid, which is the incubator. The user's
shell is a grandchild and never saw it, so any HUP-trapping cleanup the
user installed was silently skipped.

Updates #18256

Signed-off-by: Kristoffer Dalby <kristoffer@tailscale.com>