### PR TITLE
util/set: add OfSliceView constructor and Set.AddSliceView

### DIFF
--- a/util/set/set.go
+++ b/util/set/set.go
@@ -10,6 +10,8 @@ import (
 	"maps"
 	"reflect"
 	"sort"
+
+	"tailscale.com/types/views"
 )
 
 // Set is a set of T.
@@ -24,6 +26,13 @@ func SetOf[T comparable](slice []T) Set[T] {
 func Of[T comparable](slice ...T) Set[T] {
 	s := make(Set[T])
 	s.AddSlice(slice)
+	return s
+}
+
+// OfSliceView returns a new set constructed from the elements in v.
+func OfSliceView[T comparable](v views.Slice[T]) Set[T] {
+	s := make(Set[T], v.Len())
+	s.AddSliceView(v)
 	return s
 }
 
@@ -52,6 +61,13 @@ func (s Set[T]) AddSeq(es iter.Seq[T]) {
 // AddSlice adds each element of es to s.
 func (s Set[T]) AddSlice(es []T) {
 	for _, e := range es {
+		s.Add(e)
+	}
+}
+
+// AddSliceView adds each element of v to s.
+func (s Set[T]) AddSliceView(v views.Slice[T]) {
+	for _, e := range v.All() {
 		s.Add(e)
 	}
 }

--- a/util/set/set_test.go
+++ b/util/set/set_test.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"slices"
 	"testing"
+
+	"tailscale.com/types/views"
 )
 
 func TestSet(t *testing.T) {
@@ -88,6 +90,18 @@ func TestSet(t *testing.T) {
 
 func TestSetOf(t *testing.T) {
 	s := Of(1, 2, 3, 4, 4, 1)
+	if s.Len() != 4 {
+		t.Errorf("wrong len %d; want 4", s.Len())
+	}
+	for _, n := range []int{1, 2, 3, 4} {
+		if !s.Contains(n) {
+			t.Errorf("should contain %d", n)
+		}
+	}
+}
+
+func TestOfSliceView(t *testing.T) {
+	s := OfSliceView(views.SliceOf([]int{1, 2, 3, 4, 4, 1}))
 	if s.Len() != 4 {
 		t.Errorf("wrong len %d; want 4", s.Len())
 	}


### PR DESCRIPTION
Building a Set from a views.Slice previously required set.Of(v.AsSlice()...),
which allocates an intermediate slice copy before allocating the set. Add
OfSliceView and AddSliceView to populate a set directly from the view,
mirroring the existing AddSlice/AddSeq/AddSet family.

Updates tailscale/corp#45499
