### PR TITLE
tailcfg: replace int with DERPRegionID for additional type safety

### DIFF
--- a/cmd/stunstamp/stunstamp.go
+++ b/cmd/stunstamp/stunstamp.go
@@ -372,7 +372,7 @@ func isTemporaryOrTimeoutErr(err error) bool {
 }
 
 type nodeMeta struct {
-	regionID   int
+	regionID   tailcfg.DERPRegionID
 	regionCode string
 	hostname   string
 	addr       netip.Addr

--- a/control/controlclient/map.go
+++ b/control/controlclient/map.go
@@ -394,7 +394,7 @@ func upgradeNode(n *tailcfg.Node) {
 			if ip == tailcfg.DerpMagicIP && err == nil {
 				port, err := strconv.Atoi(portStr)
 				if err == nil {
-					n.HomeDERP = port
+					n.HomeDERP = tailcfg.DERPRegionID(port)
 				}
 			}
 		}
@@ -638,7 +638,7 @@ func (ms *mapSession) updateStateFromResponse(resp *tailcfg.MapResponse) {
 		// really the control plane should pick this. This is only a fallback.
 		if hostinfo.IsInVM86() {
 			numCanMeasure := 0
-			lowest := 0
+			var lowest tailcfg.DERPRegionID
 			for rid, r := range dm.Regions {
 				if !r.NoMeasureNoHome {
 					numCanMeasure++

--- a/control/controlclient/map.go
+++ b/control/controlclient/map.go
@@ -393,7 +393,7 @@ func upgradeNode(n *tailcfg.Node) {
 			if ip == tailcfg.DerpMagicIP && err == nil {
 				port, err := strconv.Atoi(portStr)
 				if err == nil {
-					n.HomeDERP = port
+					n.HomeDERP = tailcfg.DERPRegionID(port)
 				}
 			}
 		}
@@ -637,7 +637,7 @@ func (ms *mapSession) updateStateFromResponse(resp *tailcfg.MapResponse) {
 		// really the control plane should pick this. This is only a fallback.
 		if hostinfo.IsInVM86() {
 			numCanMeasure := 0
-			lowest := 0
+			var lowest tailcfg.DERPRegionID
 			for rid, r := range dm.Regions {
 				if !r.NoMeasureNoHome {
 					numCanMeasure++

--- a/control/controlclient/map_test.go
+++ b/control/controlclient/map_test.go
@@ -58,7 +58,7 @@ func TestUpdatePeersStateFromResponse(t *testing.T) {
 			n.LastSeen = &t
 		}
 	}
-	withDERP := func(regionID int) func(*tailcfg.Node) {
+	withDERP := func(regionID tailcfg.DERPRegionID) func(*tailcfg.Node) {
 		return func(n *tailcfg.Node) {
 			n.HomeDERP = regionID
 		}
@@ -1053,7 +1053,7 @@ func first[T any](s []T) T {
 }
 
 func TestDeltaDERPMap(t *testing.T) {
-	regions1 := map[int]*tailcfg.DERPRegion{
+	regions1 := map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 		1: {
 			RegionID: 1,
 			Nodes: []*tailcfg.DERPNode{{
@@ -1067,7 +1067,7 @@ func TestDeltaDERPMap(t *testing.T) {
 	}
 
 	// As above, but with a changed IPv4 addr
-	regions2 := map[int]*tailcfg.DERPRegion{1: regions1[1].Clone()}
+	regions2 := map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{1: regions1[1].Clone()}
 	regions2[1].Nodes[0].IPv4 = "127.0.0.1"
 
 	type step struct {
@@ -1107,10 +1107,10 @@ func TestDeltaDERPMap(t *testing.T) {
 				// Send home params, want to still have the same regions
 				{
 					&tailcfg.DERPMap{HomeParams: &tailcfg.DERPHomeParams{
-						RegionScore: map[int]float64{1: 0.5},
+						RegionScore: map[tailcfg.DERPRegionID]float64{1: 0.5},
 					}},
 					&tailcfg.DERPMap{Regions: regions1, HomeParams: &tailcfg.DERPHomeParams{
-						RegionScore: map[int]float64{1: 0.5},
+						RegionScore: map[tailcfg.DERPRegionID]float64{1: 0.5},
 					}},
 				},
 			},
@@ -1121,24 +1121,24 @@ func TestDeltaDERPMap(t *testing.T) {
 				// Send a DERP map with home params
 				{
 					&tailcfg.DERPMap{Regions: regions1, HomeParams: &tailcfg.DERPHomeParams{
-						RegionScore: map[int]float64{1: 0.5},
+						RegionScore: map[tailcfg.DERPRegionID]float64{1: 0.5},
 					}},
 					&tailcfg.DERPMap{Regions: regions1, HomeParams: &tailcfg.DERPHomeParams{
-						RegionScore: map[int]float64{1: 0.5},
+						RegionScore: map[tailcfg.DERPRegionID]float64{1: 0.5},
 					}},
 				},
 				// Sending a struct with a 'HomeParams' field but nil RegionScore doesn't change home params...
 				{
 					&tailcfg.DERPMap{HomeParams: &tailcfg.DERPHomeParams{RegionScore: nil}},
 					&tailcfg.DERPMap{Regions: regions1, HomeParams: &tailcfg.DERPHomeParams{
-						RegionScore: map[int]float64{1: 0.5},
+						RegionScore: map[tailcfg.DERPRegionID]float64{1: 0.5},
 					}},
 				},
 				// ... but sending one with a non-nil and empty RegionScore field zeroes that out.
 				{
-					&tailcfg.DERPMap{HomeParams: &tailcfg.DERPHomeParams{RegionScore: map[int]float64{}}},
+					&tailcfg.DERPMap{HomeParams: &tailcfg.DERPHomeParams{RegionScore: map[tailcfg.DERPRegionID]float64{}}},
 					&tailcfg.DERPMap{Regions: regions1, HomeParams: &tailcfg.DERPHomeParams{
-						RegionScore: map[int]float64{},
+						RegionScore: map[tailcfg.DERPRegionID]float64{},
 					}},
 				},
 			},

--- a/control/controlclient/map_test.go
+++ b/control/controlclient/map_test.go
@@ -59,7 +59,7 @@ func TestUpdatePeersStateFromResponse(t *testing.T) {
 			n.LastSeen = &t
 		}
 	}
-	withDERP := func(regionID int) func(*tailcfg.Node) {
+	withDERP := func(regionID tailcfg.DERPRegionID) func(*tailcfg.Node) {
 		return func(n *tailcfg.Node) {
 			n.HomeDERP = regionID
 		}
@@ -1054,7 +1054,7 @@ func first[T any](s []T) T {
 }
 
 func TestDeltaDERPMap(t *testing.T) {
-	regions1 := map[int]*tailcfg.DERPRegion{
+	regions1 := map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 		1: {
 			RegionID: 1,
 			Nodes: []*tailcfg.DERPNode{{
@@ -1068,7 +1068,7 @@ func TestDeltaDERPMap(t *testing.T) {
 	}
 
 	// As above, but with a changed IPv4 addr
-	regions2 := map[int]*tailcfg.DERPRegion{1: regions1[1].Clone()}
+	regions2 := map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{1: regions1[1].Clone()}
 	regions2[1].Nodes[0].IPv4 = "127.0.0.1"
 
 	type step struct {
@@ -1108,10 +1108,10 @@ func TestDeltaDERPMap(t *testing.T) {
 				// Send home params, want to still have the same regions
 				{
 					&tailcfg.DERPMap{HomeParams: &tailcfg.DERPHomeParams{
-						RegionScore: map[int]float64{1: 0.5},
+						RegionScore: map[tailcfg.DERPRegionID]float64{1: 0.5},
 					}},
 					&tailcfg.DERPMap{Regions: regions1, HomeParams: &tailcfg.DERPHomeParams{
-						RegionScore: map[int]float64{1: 0.5},
+						RegionScore: map[tailcfg.DERPRegionID]float64{1: 0.5},
 					}},
 				},
 			},
@@ -1122,24 +1122,24 @@ func TestDeltaDERPMap(t *testing.T) {
 				// Send a DERP map with home params
 				{
 					&tailcfg.DERPMap{Regions: regions1, HomeParams: &tailcfg.DERPHomeParams{
-						RegionScore: map[int]float64{1: 0.5},
+						RegionScore: map[tailcfg.DERPRegionID]float64{1: 0.5},
 					}},
 					&tailcfg.DERPMap{Regions: regions1, HomeParams: &tailcfg.DERPHomeParams{
-						RegionScore: map[int]float64{1: 0.5},
+						RegionScore: map[tailcfg.DERPRegionID]float64{1: 0.5},
 					}},
 				},
 				// Sending a struct with a 'HomeParams' field but nil RegionScore doesn't change home params...
 				{
 					&tailcfg.DERPMap{HomeParams: &tailcfg.DERPHomeParams{RegionScore: nil}},
 					&tailcfg.DERPMap{Regions: regions1, HomeParams: &tailcfg.DERPHomeParams{
-						RegionScore: map[int]float64{1: 0.5},
+						RegionScore: map[tailcfg.DERPRegionID]float64{1: 0.5},
 					}},
 				},
 				// ... but sending one with a non-nil and empty RegionScore field zeroes that out.
 				{
-					&tailcfg.DERPMap{HomeParams: &tailcfg.DERPHomeParams{RegionScore: map[int]float64{}}},
+					&tailcfg.DERPMap{HomeParams: &tailcfg.DERPHomeParams{RegionScore: map[tailcfg.DERPRegionID]float64{}}},
 					&tailcfg.DERPMap{Regions: regions1, HomeParams: &tailcfg.DERPHomeParams{
-						RegionScore: map[int]float64{},
+						RegionScore: map[tailcfg.DERPRegionID]float64{},
 					}},
 				},
 			},

--- a/feature/captiveportal/captiveportal.go
+++ b/feature/captiveportal/captiveportal.go
@@ -17,6 +17,7 @@ import (
 	"tailscale.com/ipn/ipnext"
 	"tailscale.com/net/captivedetection"
 	"tailscale.com/syncs"
+	"tailscale.com/tailcfg"
 	"tailscale.com/types/logger"
 	"tailscale.com/util/clientmetric"
 	"tailscale.com/util/eventbus"
@@ -266,7 +267,7 @@ func (e *Extension) performCaptiveDetection(ctx context.Context) {
 
 	d := captivedetection.NewDetector(e.logf)
 	dm := e.host.NodeBackend().DERPMap()
-	preferredDERP := 0
+	var preferredDERP tailcfg.DERPRegionID
 	if mc, ok := e.sb.Sys().MagicSock.GetOK(); ok {
 		if report := mc.GetLastNetcheckReport(ctx); report != nil {
 			preferredDERP = report.PreferredDERP

--- a/feature/captiveportal/netcheckhook/netcheckhook.go
+++ b/feature/captiveportal/netcheckhook/netcheckhook.go
@@ -25,7 +25,7 @@ func init() {
 // the probe if it's unnecessary. Chosen semi-arbitrarily.
 const captivePortalDelay = 200 * time.Millisecond
 
-func startCaptivePortalDetection(ctx context.Context, c *netcheck.Client, dm *tailcfg.DERPMap, preferredDERP int, setCaptivePortal func(bool)) (done <-chan struct{}, stop func()) {
+func startCaptivePortalDetection(ctx context.Context, c *netcheck.Client, dm *tailcfg.DERPMap, preferredDERP tailcfg.DERPRegionID, setCaptivePortal func(bool)) (done <-chan struct{}, stop func()) {
 	logf := c.Logf
 	if logf == nil {
 		logf = log.Printf

--- a/feature/routecheck/routertracker_test.go
+++ b/feature/routecheck/routertracker_test.go
@@ -251,7 +251,7 @@ func makeNode(id tailcfg.NodeID, opts ...nodeOptFunc) *tailcfg.Node {
 		Name:              fmt.Sprintf("node%d", id),
 		Online:            new(true),
 		MachineAuthorized: true,
-		HomeDERP:          int(id),
+		HomeDERP:          tailcfg.DERPRegionID(id),
 		Addresses:         addresses,
 		AllowedIPs:        addresses,
 	}

--- a/feature/routecheck/routertracker_test.go
+++ b/feature/routecheck/routertracker_test.go
@@ -250,7 +250,7 @@ func makeNode(id tailcfg.NodeID, opts ...nodeOptFunc) *tailcfg.Node {
 		Name:              fmt.Sprintf("node%d", id),
 		Online:            new(true),
 		MachineAuthorized: true,
-		HomeDERP:          int(id),
+		HomeDERP:          tailcfg.DERPRegionID(id),
 		Addresses:         addresses,
 		AllowedIPs:        addresses,
 	}

--- a/health/health.go
+++ b/health/health.go
@@ -115,11 +115,11 @@ type Tracker struct {
 	lastMapPollEndedAt          time.Time
 	lastStreamedMapResponse     time.Time
 	lastNoiseDial               time.Time
-	derpHomeRegion              int
+	derpHomeRegion              tailcfg.DERPRegionID
 	derpHomeless                bool
-	derpRegionConnected         map[int]bool
-	derpRegionHealthProblem     map[int]string
-	derpRegionLastFrame         map[int]time.Time
+	derpRegionConnected         map[tailcfg.DERPRegionID]bool
+	derpRegionHealthProblem     map[tailcfg.DERPRegionID]string
+	derpRegionLastFrame         map[tailcfg.DERPRegionID]time.Time
 	derpMap                     *tailcfg.DERPMap // last DERP map from control, could be nil if never received one
 	lastMapRequestHeard         time.Time        // time we got a 200 from control for a MapRequest
 	ipnState                    string
@@ -782,7 +782,7 @@ func (t *Tracker) GetInPollNetMap() bool {
 //
 // The homeless parameter is whether magicsock is running in DERP-disconnected
 // mode, without discovering and maintaining a connection to its home DERP.
-func (t *Tracker) SetMagicSockDERPHome(region int, homeless bool) {
+func (t *Tracker) SetMagicSockDERPHome(region tailcfg.DERPRegionID, homeless bool) {
 	if t.nil() {
 		return
 	}
@@ -809,7 +809,7 @@ func (t *Tracker) NoteMapRequestHeard(mr *tailcfg.MapRequest) {
 	t.selfCheckLocked()
 }
 
-func (t *Tracker) SetDERPRegionConnectedState(region int, connected bool) {
+func (t *Tracker) SetDERPRegionConnectedState(region tailcfg.DERPRegionID, connected bool) {
 	if t.nil() {
 		return
 	}
@@ -821,7 +821,7 @@ func (t *Tracker) SetDERPRegionConnectedState(region int, connected bool) {
 
 // SetDERPRegionHealth sets or clears any problem associated with the
 // provided DERP region.
-func (t *Tracker) SetDERPRegionHealth(region int, problem string) {
+func (t *Tracker) SetDERPRegionHealth(region tailcfg.DERPRegionID, problem string) {
 	if t.nil() {
 		return
 	}
@@ -837,7 +837,7 @@ func (t *Tracker) SetDERPRegionHealth(region int, problem string) {
 
 // NoteDERPRegionReceivedFrame is called to note that a frame was received from
 // the given DERP region at the current time.
-func (t *Tracker) NoteDERPRegionReceivedFrame(region int) {
+func (t *Tracker) NoteDERPRegionReceivedFrame(region tailcfg.DERPRegionID) {
 	if t.nil() {
 		return
 	}
@@ -850,7 +850,7 @@ func (t *Tracker) NoteDERPRegionReceivedFrame(region int) {
 // GetDERPRegionReceivedTime returns the last time that a frame was received
 // from the given DERP region, or the zero time if no communication with that
 // region has occurred.
-func (t *Tracker) GetDERPRegionReceivedTime(region int) time.Time {
+func (t *Tracker) GetDERPRegionReceivedTime(region tailcfg.DERPRegionID) time.Time {
 	if t.nil() {
 		return time.Time{}
 	}
@@ -873,7 +873,7 @@ func (t *Tracker) SetDERPMap(dm *tailcfg.DERPMap) {
 
 // derpRegionNameLocked returns the name of the DERP region with the given ID
 // or the empty string if unknown.
-func (t *Tracker) derpRegionNameLocked(regID int) string {
+func (t *Tracker) derpRegionNameLocked(regID tailcfg.DERPRegionID) string {
 	if t.derpMap == nil {
 		return ""
 	}

--- a/ipn/ipnlocal/diskcache.go
+++ b/ipn/ipnlocal/diskcache.go
@@ -67,7 +67,7 @@ func (b *LocalBackend) patchNetmapHomeDERPLocked(nm *netmap.NetworkMap) *netmap.
 	// Make a shallow copy and mutate a copy of the selfNode.
 	nmCopy := *nm
 	selfNode := nm.SelfNode.AsStruct()
-	selfNode.HomeDERP = int(b.currentNode().homeDERP.Load())
+	selfNode.HomeDERP = tailcfg.DERPRegionID(b.currentNode().homeDERP.Load())
 	nmCopy.SelfNode = selfNode.View()
 	return &nmCopy
 }

--- a/ipn/ipnlocal/diskcache_test.go
+++ b/ipn/ipnlocal/diskcache_test.go
@@ -32,7 +32,7 @@ func newCacheTestNetmap() *netmap.NetworkMap {
 			}).View(),
 		},
 		DERPMap: &tailcfg.DERPMap{
-			Regions: map[int]*tailcfg.DERPRegion{
+			Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 				1:  {},
 				2:  {},
 				3:  {},

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -2044,7 +2044,7 @@ func (b *LocalBackend) setControlClientStatusLocked(c controlclient.Client, st c
 
 		b.e.SetSelfNode(st.NetMap.SelfNode)
 
-		var cachedHome int
+		var cachedHome tailcfg.DERPRegionID
 		if c == nil && st.NetMap.Cached && st.NetMap.SelfNode.Valid() {
 			cachedHome = st.NetMap.SelfNode.HomeDERP()
 		}
@@ -3961,7 +3961,7 @@ func (b *LocalBackend) DebugPickNewDERP() error {
 
 // DebugForcePreferDERP forwards to netcheck.DebugForcePreferDERP.
 // See its docs.
-func (b *LocalBackend) DebugForcePreferDERP(n int) {
+func (b *LocalBackend) DebugForcePreferDERP(n tailcfg.DERPRegionID) {
 	b.sys.MagicSock.Get().DebugForcePreferDERP(n)
 }
 
@@ -8667,7 +8667,7 @@ func (b *LocalBackend) suggestExitNodeLocked() (response apitype.ExitNodeSuggest
 	}
 
 	mc := b.MagicConn()
-	var preferredDERP int
+	var preferredDERP tailcfg.DERPRegionID
 	if lastReport := mc.GetLastNetcheckReport(b.ctx); lastReport != nil {
 		preferredDERP = lastReport.PreferredDERP
 	}
@@ -8735,7 +8735,7 @@ func (b *LocalBackend) refreshAllowedSuggestions() {
 
 // selectRegionFunc returns a DERP region from the slice of candidate regions.
 // The value is returned, not the slice index.
-type selectRegionFunc func(views.Slice[int]) int
+type selectRegionFunc func(views.Slice[tailcfg.DERPRegionID]) tailcfg.DERPRegionID
 
 // selectNodeFunc returns a node from the slice of candidate nodes. The last
 // selected node is provided for when that information is needed to make a better
@@ -8765,7 +8765,7 @@ func fillAllowedSuggestions(polc policyclient.Client) (set.Set[tailcfg.StableNod
 // netcheck and are only used by the DERP-based algorithm.
 //
 // Errors are always logged. Suggestions are logged if they defer from prevSuggestion.
-func suggestExitNode(preferredDERP int, regionLatency map[int]time.Duration, rp RouteCheckReport, nb *nodeBackend, prevSuggestion tailcfg.StableNodeID, selectRegion selectRegionFunc, selectNode selectNodeFunc, allowList set.Set[tailcfg.StableNodeID]) (res apitype.ExitNodeSuggestionResponse, err error) {
+func suggestExitNode(preferredDERP tailcfg.DERPRegionID, regionLatency map[tailcfg.DERPRegionID]time.Duration, rp RouteCheckReport, nb *nodeBackend, prevSuggestion tailcfg.StableNodeID, selectRegion selectRegionFunc, selectNode selectNodeFunc, allowList set.Set[tailcfg.StableNodeID]) (res apitype.ExitNodeSuggestionResponse, err error) {
 	switch {
 	case nb.SelfHasCap(tailcfg.NodeAttrTrafficSteering):
 		// The traffic-steering feature flag is enabled on this tailnet.
@@ -8801,7 +8801,7 @@ func suggestExitNode(preferredDERP int, regionLatency map[int]time.Duration, rp 
 // this means Mullvad). Peers are selected based on having a DERP home that is
 // the lowest latency to this device. For peers without a DERP home, we look for
 // geographic proximity to this device's DERP home.
-func suggestExitNodeUsingDERP(preferredRegionID int, regionLatency map[int]time.Duration, nb *nodeBackend, prevSuggestion tailcfg.StableNodeID, selectRegion selectRegionFunc, selectNode selectNodeFunc, allowList set.Set[tailcfg.StableNodeID]) (res apitype.ExitNodeSuggestionResponse, err error) {
+func suggestExitNodeUsingDERP(preferredRegionID tailcfg.DERPRegionID, regionLatency map[tailcfg.DERPRegionID]time.Duration, nb *nodeBackend, prevSuggestion tailcfg.StableNodeID, selectRegion selectRegionFunc, selectNode selectNodeFunc, allowList set.Set[tailcfg.StableNodeID]) (res apitype.ExitNodeSuggestionResponse, err error) {
 	netMap := nb.NetMap()
 	if preferredRegionID == 0 || netMap == nil || netMap.DERPMap == nil {
 		return res, ErrNoPreferredDERP
@@ -8833,7 +8833,7 @@ func suggestExitNodeUsingDERP(preferredRegionID int, regionLatency map[int]time.
 		return res, nil
 	}
 
-	candidatesByRegion := make(map[int][]tailcfg.NodeView, len(netMap.DERPMap.Regions))
+	candidatesByRegion := make(map[tailcfg.DERPRegionID][]tailcfg.NodeView, len(netMap.DERPMap.Regions))
 	preferredDERP, ok := netMap.DERPMap.Regions[preferredRegionID]
 	if !ok {
 		return res, ErrNoPreferredDERP
@@ -9039,7 +9039,7 @@ func pickWeighted(candidates []tailcfg.NodeView) []tailcfg.NodeView {
 }
 
 // randomRegion is a selectRegionFunc that selects a uniformly random region.
-func randomRegion(regions views.Slice[int]) int {
+func randomRegion(regions views.Slice[tailcfg.DERPRegionID]) tailcfg.DERPRegionID {
 	return regions.At(rand.IntN(regions.Len()))
 }
 
@@ -9060,7 +9060,7 @@ func randomNode(nodes views.Slice[tailcfg.NodeView], prefer tailcfg.StableNodeID
 
 // minLatencyDERPRegion returns the region with the lowest latency value given
 // the per-region latency map. If there are no latency values, it returns 0.
-func minLatencyDERPRegion(regions []int, regionLatency netcheck.RegionLatency) int {
+func minLatencyDERPRegion(regions []tailcfg.DERPRegionID, regionLatency netcheck.RegionLatency) tailcfg.DERPRegionID {
 	min := slices.MinFunc(regions, regionLatency.Compare)
 	latency, ok := regionLatency[min]
 	if !ok || latency == 0 {

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -2056,7 +2056,7 @@ func (b *LocalBackend) setControlClientStatusLocked(c controlclient.Client, st c
 
 		b.e.SetSelfNode(st.NetMap.SelfNode)
 
-		var cachedHome int
+		var cachedHome tailcfg.DERPRegionID
 		if c == nil && st.NetMap.Cached && st.NetMap.SelfNode.Valid() {
 			cachedHome = st.NetMap.SelfNode.HomeDERP()
 		}
@@ -3972,7 +3972,7 @@ func (b *LocalBackend) DebugPickNewDERP() error {
 
 // DebugForcePreferDERP forwards to netcheck.DebugForcePreferDERP.
 // See its docs.
-func (b *LocalBackend) DebugForcePreferDERP(n int) {
+func (b *LocalBackend) DebugForcePreferDERP(n tailcfg.DERPRegionID) {
 	b.sys.MagicSock.Get().DebugForcePreferDERP(n)
 }
 
@@ -8697,7 +8697,7 @@ func (b *LocalBackend) suggestExitNodeLocked() (response apitype.ExitNodeSuggest
 	}
 
 	mc := b.MagicConn()
-	var preferredDERP int
+	var preferredDERP tailcfg.DERPRegionID
 	if lastReport := mc.GetLastNetcheckReport(b.ctx); lastReport != nil {
 		preferredDERP = lastReport.PreferredDERP
 	}
@@ -8765,7 +8765,7 @@ func (b *LocalBackend) refreshAllowedSuggestions() {
 
 // selectRegionFunc returns a DERP region from the slice of candidate regions.
 // The value is returned, not the slice index.
-type selectRegionFunc func(views.Slice[int]) int
+type selectRegionFunc func(views.Slice[tailcfg.DERPRegionID]) tailcfg.DERPRegionID
 
 // selectNodeFunc returns a node from the slice of candidate nodes. The last
 // selected node is provided for when that information is needed to make a better
@@ -8795,7 +8795,7 @@ func fillAllowedSuggestions(polc policyclient.Client) (set.Set[tailcfg.StableNod
 // netcheck and are only used by the DERP-based algorithm.
 //
 // Errors are always logged. Suggestions are logged if they defer from prevSuggestion.
-func suggestExitNode(preferredDERP int, regionLatency map[int]time.Duration, rp RouteCheckReport, nb *nodeBackend, prevSuggestion tailcfg.StableNodeID, selectRegion selectRegionFunc, selectNode selectNodeFunc, allowList set.Set[tailcfg.StableNodeID]) (res apitype.ExitNodeSuggestionResponse, err error) {
+func suggestExitNode(preferredDERP tailcfg.DERPRegionID, regionLatency map[tailcfg.DERPRegionID]time.Duration, rp RouteCheckReport, nb *nodeBackend, prevSuggestion tailcfg.StableNodeID, selectRegion selectRegionFunc, selectNode selectNodeFunc, allowList set.Set[tailcfg.StableNodeID]) (res apitype.ExitNodeSuggestionResponse, err error) {
 	switch {
 	case nb.SelfHasCap(nodecap.TrafficSteering):
 		// The traffic-steering feature flag is enabled on this tailnet.
@@ -8831,7 +8831,7 @@ func suggestExitNode(preferredDERP int, regionLatency map[int]time.Duration, rp 
 // this means Mullvad). Peers are selected based on having a DERP home that is
 // the lowest latency to this device. For peers without a DERP home, we look for
 // geographic proximity to this device's DERP home.
-func suggestExitNodeUsingDERP(preferredRegionID int, regionLatency map[int]time.Duration, nb *nodeBackend, prevSuggestion tailcfg.StableNodeID, selectRegion selectRegionFunc, selectNode selectNodeFunc, allowList set.Set[tailcfg.StableNodeID]) (res apitype.ExitNodeSuggestionResponse, err error) {
+func suggestExitNodeUsingDERP(preferredRegionID tailcfg.DERPRegionID, regionLatency map[tailcfg.DERPRegionID]time.Duration, nb *nodeBackend, prevSuggestion tailcfg.StableNodeID, selectRegion selectRegionFunc, selectNode selectNodeFunc, allowList set.Set[tailcfg.StableNodeID]) (res apitype.ExitNodeSuggestionResponse, err error) {
 	netMap := nb.NetMap()
 	if preferredRegionID == 0 || netMap == nil || netMap.DERPMap == nil {
 		return res, ErrNoPreferredDERP
@@ -8863,7 +8863,7 @@ func suggestExitNodeUsingDERP(preferredRegionID int, regionLatency map[int]time.
 		return res, nil
 	}
 
-	candidatesByRegion := make(map[int][]tailcfg.NodeView, len(netMap.DERPMap.Regions))
+	candidatesByRegion := make(map[tailcfg.DERPRegionID][]tailcfg.NodeView, len(netMap.DERPMap.Regions))
 	preferredDERP, ok := netMap.DERPMap.Regions[preferredRegionID]
 	if !ok {
 		return res, ErrNoPreferredDERP
@@ -9069,7 +9069,7 @@ func pickWeighted(candidates []tailcfg.NodeView) []tailcfg.NodeView {
 }
 
 // randomRegion is a selectRegionFunc that selects a uniformly random region.
-func randomRegion(regions views.Slice[int]) int {
+func randomRegion(regions views.Slice[tailcfg.DERPRegionID]) tailcfg.DERPRegionID {
 	return regions.At(rand.IntN(regions.Len()))
 }
 
@@ -9090,7 +9090,7 @@ func randomNode(nodes views.Slice[tailcfg.NodeView], prefer tailcfg.StableNodeID
 
 // minLatencyDERPRegion returns the region with the lowest latency value given
 // the per-region latency map. If there are no latency values, it returns 0.
-func minLatencyDERPRegion(regions []int, regionLatency netcheck.RegionLatency) int {
+func minLatencyDERPRegion(regions []tailcfg.DERPRegionID, regionLatency netcheck.RegionLatency) tailcfg.DERPRegionID {
 	min := slices.MinFunc(regions, regionLatency.Compare)
 	latency, ok := regionLatency[min]
 	if !ok || latency == 0 {

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -705,7 +705,7 @@ func TestConfigureExitNode(t *testing.T) {
 	clientNetmap := buildNetmapWithPeers(selfNode, exitNode1, exitNode2)
 
 	report := &netcheck.Report{
-		RegionLatency: map[int]time.Duration{
+		RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 			1: 5 * time.Millisecond,
 			2: 10 * time.Millisecond,
 		},
@@ -1544,7 +1544,7 @@ func TestExitNodeNotifyOrder(t *testing.T) {
 	const controlURL = "https://localhost:1/"
 
 	report := &netcheck.Report{
-		RegionLatency: map[int]time.Duration{
+		RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 			1: 5 * time.Millisecond,
 			2: 10 * time.Millisecond,
 		},
@@ -3870,7 +3870,7 @@ func TestUpdateNetmapDeltaAutoExitNode(t *testing.T) {
 	peer1 := makePeer(1, withCap(26), withSuggest(), withOnline(true), withExitRoutes())
 	peer2 := makePeer(2, withCap(26), withSuggest(), withOnline(true), withExitRoutes())
 	derpMap := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			1: {
 				Nodes: []*tailcfg.DERPNode{
 					{
@@ -3890,7 +3890,7 @@ func TestUpdateNetmapDeltaAutoExitNode(t *testing.T) {
 		},
 	}
 	report := &netcheck.Report{
-		RegionLatency: map[int]time.Duration{
+		RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 			1: 10 * time.Millisecond,
 			2: 5 * time.Millisecond,
 			3: 30 * time.Millisecond,
@@ -4059,7 +4059,7 @@ func TestAutoExitNodeSetNetInfoCallback(t *testing.T) {
 		HomeDERP: 2,
 	}
 	defaultDERPMap := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			1: {
 				Nodes: []*tailcfg.DERPNode{
 					{
@@ -4101,7 +4101,7 @@ func TestAutoExitNodeSetNetInfoCallback(t *testing.T) {
 	}
 	b.refreshAutoExitNode = true
 	b.sys.MagicSock.Get().AddNetcheckReportForTest(defaultDERPMap, &netcheck.Report{
-		RegionLatency: map[int]time.Duration{
+		RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 			1: 10 * time.Millisecond,
 			2: 5 * time.Millisecond,
 			3: 30 * time.Millisecond,
@@ -4118,7 +4118,7 @@ func TestSetControlClientStatusAutoExitNode(t *testing.T) {
 	peer1 := makePeer(1, withCap(26), withSuggest(), withExitRoutes(), withOnline(true), withNodeKey())
 	peer2 := makePeer(2, withCap(26), withSuggest(), withExitRoutes(), withOnline(true), withNodeKey())
 	derpMap := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			1: {
 				Nodes: []*tailcfg.DERPNode{
 					{
@@ -4138,7 +4138,7 @@ func TestSetControlClientStatusAutoExitNode(t *testing.T) {
 		},
 	}
 	report := &netcheck.Report{
-		RegionLatency: map[int]time.Duration{
+		RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 			1: 10 * time.Millisecond,
 			2: 5 * time.Millisecond,
 			3: 30 * time.Millisecond,
@@ -5274,7 +5274,7 @@ func makePeer(id tailcfg.NodeID, opts ...peerOptFunc) tailcfg.NodeView {
 		Name:              fmt.Sprintf("peer%d", id),
 		Online:            new(true),
 		MachineAuthorized: true,
-		HomeDERP:          int(id),
+		HomeDERP:          tailcfg.DERPRegionID(id),
 	}
 	for _, opt := range opts {
 		opt(node)
@@ -5288,7 +5288,7 @@ func withName(name string) peerOptFunc {
 	}
 }
 
-func withDERP(region int) peerOptFunc {
+func withDERP(region tailcfg.DERPRegionID) peerOptFunc {
 	return func(n *tailcfg.Node) {
 		n.HomeDERP = region
 	}
@@ -5373,14 +5373,14 @@ func withAllowedIPs(prefixes ...netip.Prefix) peerOptFunc {
 	}
 }
 
-func deterministicRegionForTest(t testing.TB, want views.Slice[int], use int) selectRegionFunc {
+func deterministicRegionForTest(t testing.TB, want views.Slice[tailcfg.DERPRegionID], use tailcfg.DERPRegionID) selectRegionFunc {
 	t.Helper()
 
 	if !views.SliceContains(want, use) {
 		t.Errorf("invalid test: use %v is not in want %v", use, want)
 	}
 
-	return func(got views.Slice[int]) int {
+	return func(got views.Slice[tailcfg.DERPRegionID]) tailcfg.DERPRegionID {
 		if !views.SliceEqualAnyOrder(got, want) {
 			t.Errorf("candidate regions = %v, want %v", got, want)
 		}
@@ -5444,7 +5444,7 @@ func TestSuggestExitNode(t *testing.T) {
 	t.Parallel()
 
 	defaultDERPMap := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			1: {
 				Latitude:  32,
 				Longitude: -97,
@@ -5455,7 +5455,7 @@ func TestSuggestExitNode(t *testing.T) {
 	}
 
 	preferred1Report := &netcheck.Report{
-		RegionLatency: map[int]time.Duration{
+		RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 			1: 10 * time.Millisecond,
 			2: 20 * time.Millisecond,
 			3: 30 * time.Millisecond,
@@ -5463,7 +5463,7 @@ func TestSuggestExitNode(t *testing.T) {
 		PreferredDERP: 1,
 	}
 	noLatency1Report := &netcheck.Report{
-		RegionLatency: map[int]time.Duration{
+		RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 			1: 0,
 			2: 0,
 			3: 0,
@@ -5471,7 +5471,7 @@ func TestSuggestExitNode(t *testing.T) {
 		PreferredDERP: 1,
 	}
 	preferredNoneReport := &netcheck.Report{
-		RegionLatency: map[int]time.Duration{
+		RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 			1: 10 * time.Millisecond,
 			2: 20 * time.Millisecond,
 			3: 30 * time.Millisecond,
@@ -5598,8 +5598,8 @@ func TestSuggestExitNode(t *testing.T) {
 
 		allowPolicy []tailcfg.StableNodeID
 
-		wantRegions []int
-		useRegion   int
+		wantRegions []tailcfg.DERPRegionID
+		useRegion   tailcfg.DERPRegionID
 
 		wantNodes []tailcfg.StableNodeID
 
@@ -5631,7 +5631,7 @@ func TestSuggestExitNode(t *testing.T) {
 			name:        "2-exits-different-regions-unknown-latency",
 			lastReport:  noLatency1Report,
 			netMap:      defaultNetmap,
-			wantRegions: []int{1, 3}, // the only regions with peers
+			wantRegions: []tailcfg.DERPRegionID{1, 3}, // the only regions with peers
 			useRegion:   1,
 			wantName:    "peer2",
 			wantID:      "stable2",
@@ -5639,7 +5639,7 @@ func TestSuggestExitNode(t *testing.T) {
 		{
 			name: "2-derp-exits-different-regions-equal-latency",
 			lastReport: &netcheck.Report{
-				RegionLatency: map[int]time.Duration{
+				RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 					1: 10,
 					2: 20,
 					3: 10,
@@ -5654,7 +5654,7 @@ func TestSuggestExitNode(t *testing.T) {
 					peer3,
 				},
 			},
-			wantRegions: []int{1, 2},
+			wantRegions: []tailcfg.DERPRegionID{1, 2},
 			useRegion:   1,
 			wantName:    "peer1",
 			wantID:      "stable1",
@@ -5885,7 +5885,7 @@ func TestSuggestExitNode(t *testing.T) {
 			// Regression test for https://github.com/tailscale/tailscale/issues/17661
 			name: "exits-no-home-DERP-random-selection",
 			lastReport: &netcheck.Report{
-				RegionLatency: map[int]time.Duration{
+				RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 					1: 10,
 					2: 20,
 					3: 10,
@@ -5900,7 +5900,7 @@ func TestSuggestExitNode(t *testing.T) {
 					emptyLocationPeer10,
 				},
 			},
-			wantRegions: []int{1, 2},
+			wantRegions: []tailcfg.DERPRegionID{1, 2},
 			wantName:    "peer9",
 			wantNodes:   []tailcfg.StableNodeID{"stable9", "stable10"},
 			wantID:      "stable9",
@@ -5912,7 +5912,7 @@ func TestSuggestExitNode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wantRegions := tt.wantRegions
 			if wantRegions == nil {
-				wantRegions = []int{tt.useRegion}
+				wantRegions = []tailcfg.DERPRegionID{tt.useRegion}
 			}
 			selectRegion := deterministicRegionForTest(t, views.SliceOf(wantRegions), tt.useRegion)
 
@@ -5931,8 +5931,8 @@ func TestSuggestExitNode(t *testing.T) {
 			defer nb.shutdown(errShutdown)
 			nb.SetNetMap(tt.netMap)
 
-			var preferredDERP int
-			var regionLatency map[int]time.Duration
+			var preferredDERP tailcfg.DERPRegionID
+			var regionLatency map[tailcfg.DERPRegionID]time.Duration
 			if tt.lastReport != nil {
 				preferredDERP = tt.lastReport.PreferredDERP
 				regionLatency = tt.lastReport.RegionLatency
@@ -5964,7 +5964,7 @@ func TestSuggestExitNodeUsesRecentDERPLatency(t *testing.T) {
 	t.Parallel()
 
 	derpMap := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			1: {Nodes: []*tailcfg.DERPNode{{Name: "1a", RegionID: 1}}},
 			2: {Nodes: []*tailcfg.DERPNode{{Name: "2a", RegionID: 2}}},
 			3: {Nodes: []*tailcfg.DERPNode{{Name: "3a", RegionID: 3}}},
@@ -5991,7 +5991,7 @@ func TestSuggestExitNodeUsesRecentDERPLatency(t *testing.T) {
 	// region 5 (200ms).
 	fullReport := &netcheck.Report{
 		PreferredDERP: 1,
-		RegionLatency: map[int]time.Duration{
+		RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 			1: 10 * time.Millisecond,
 			2: 20 * time.Millisecond,
 			3: 30 * time.Millisecond,
@@ -6002,7 +6002,7 @@ func TestSuggestExitNodeUsesRecentDERPLatency(t *testing.T) {
 	// A later incremental netcheck only re-probed the home and fastest regions, so
 	// it has no latency for regions 4 or 5.
 	incrementalReport := &netcheck.Report{
-		RegionLatency: map[int]time.Duration{
+		RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 			1: 10 * time.Millisecond,
 			2: 20 * time.Millisecond,
 			3: 30 * time.Millisecond,
@@ -6529,20 +6529,20 @@ func TestSuggestExitNodeTrafficSteering(t *testing.T) {
 func TestMinLatencyDERPregion(t *testing.T) {
 	tests := []struct {
 		name          string
-		regions       []int
-		regionLatency map[int]time.Duration
-		wantRegion    int
+		regions       []tailcfg.DERPRegionID
+		regionLatency map[tailcfg.DERPRegionID]time.Duration
+		wantRegion    tailcfg.DERPRegionID
 	}{
 		{
 			name:       "regions-no-latency",
-			regions:    []int{1, 2, 3},
+			regions:    []tailcfg.DERPRegionID{1, 2, 3},
 			wantRegion: 0,
 		},
 		{
 			name:       "regions-different-latency",
-			regions:    []int{1, 2, 3},
+			regions:    []tailcfg.DERPRegionID{1, 2, 3},
 			wantRegion: 2,
-			regionLatency: map[int]time.Duration{
+			regionLatency: map[tailcfg.DERPRegionID]time.Duration{
 				1: 10 * time.Millisecond,
 				2: 5 * time.Millisecond,
 				3: 30 * time.Millisecond,
@@ -6550,9 +6550,9 @@ func TestMinLatencyDERPregion(t *testing.T) {
 		},
 		{
 			name:       "regions-same-latency",
-			regions:    []int{1, 2, 3},
+			regions:    []tailcfg.DERPRegionID{1, 2, 3},
 			wantRegion: 1,
-			regionLatency: map[int]time.Duration{
+			regionLatency: map[tailcfg.DERPRegionID]time.Duration{
 				1: 10 * time.Millisecond,
 				2: 10 * time.Millisecond,
 				3: 10 * time.Millisecond,

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -729,7 +729,7 @@ func TestConfigureExitNode(t *testing.T) {
 	clientNetmap := buildNetmapWithPeers(selfNode, exitNode1, exitNode2)
 
 	report := &netcheck.Report{
-		RegionLatency: map[int]time.Duration{
+		RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 			1: 5 * time.Millisecond,
 			2: 10 * time.Millisecond,
 		},
@@ -1568,7 +1568,7 @@ func TestExitNodeNotifyOrder(t *testing.T) {
 	const controlURL = "https://localhost:1/"
 
 	report := &netcheck.Report{
-		RegionLatency: map[int]time.Duration{
+		RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 			1: 5 * time.Millisecond,
 			2: 10 * time.Millisecond,
 		},
@@ -3894,7 +3894,7 @@ func TestUpdateNetmapDeltaAutoExitNode(t *testing.T) {
 	peer1 := makePeer(1, withCap(26), withSuggest(), withOnline(true), withExitRoutes())
 	peer2 := makePeer(2, withCap(26), withSuggest(), withOnline(true), withExitRoutes())
 	derpMap := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			1: {
 				Nodes: []*tailcfg.DERPNode{
 					{
@@ -3914,7 +3914,7 @@ func TestUpdateNetmapDeltaAutoExitNode(t *testing.T) {
 		},
 	}
 	report := &netcheck.Report{
-		RegionLatency: map[int]time.Duration{
+		RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 			1: 10 * time.Millisecond,
 			2: 5 * time.Millisecond,
 			3: 30 * time.Millisecond,
@@ -4083,7 +4083,7 @@ func TestAutoExitNodeSetNetInfoCallback(t *testing.T) {
 		HomeDERP: 2,
 	}
 	defaultDERPMap := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			1: {
 				Nodes: []*tailcfg.DERPNode{
 					{
@@ -4125,7 +4125,7 @@ func TestAutoExitNodeSetNetInfoCallback(t *testing.T) {
 	}
 	b.refreshAutoExitNode = true
 	b.sys.MagicSock.Get().AddNetcheckReportForTest(defaultDERPMap, &netcheck.Report{
-		RegionLatency: map[int]time.Duration{
+		RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 			1: 10 * time.Millisecond,
 			2: 5 * time.Millisecond,
 			3: 30 * time.Millisecond,
@@ -4142,7 +4142,7 @@ func TestSetControlClientStatusAutoExitNode(t *testing.T) {
 	peer1 := makePeer(1, withCap(26), withSuggest(), withExitRoutes(), withOnline(true), withNodeKey())
 	peer2 := makePeer(2, withCap(26), withSuggest(), withExitRoutes(), withOnline(true), withNodeKey())
 	derpMap := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			1: {
 				Nodes: []*tailcfg.DERPNode{
 					{
@@ -4162,7 +4162,7 @@ func TestSetControlClientStatusAutoExitNode(t *testing.T) {
 		},
 	}
 	report := &netcheck.Report{
-		RegionLatency: map[int]time.Duration{
+		RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 			1: 10 * time.Millisecond,
 			2: 5 * time.Millisecond,
 			3: 30 * time.Millisecond,
@@ -5298,7 +5298,7 @@ func makePeer(id tailcfg.NodeID, opts ...peerOptFunc) tailcfg.NodeView {
 		Name:              fmt.Sprintf("peer%d", id),
 		Online:            new(true),
 		MachineAuthorized: true,
-		HomeDERP:          int(id),
+		HomeDERP:          tailcfg.DERPRegionID(id), // reuse node ID as DERP region ID
 	}
 	for _, opt := range opts {
 		opt(node)
@@ -5312,7 +5312,7 @@ func withName(name string) peerOptFunc {
 	}
 }
 
-func withDERP(region int) peerOptFunc {
+func withDERP(region tailcfg.DERPRegionID) peerOptFunc {
 	return func(n *tailcfg.Node) {
 		n.HomeDERP = region
 	}
@@ -5397,14 +5397,14 @@ func withAllowedIPs(prefixes ...netip.Prefix) peerOptFunc {
 	}
 }
 
-func deterministicRegionForTest(t testing.TB, want views.Slice[int], use int) selectRegionFunc {
+func deterministicRegionForTest(t testing.TB, want views.Slice[tailcfg.DERPRegionID], use tailcfg.DERPRegionID) selectRegionFunc {
 	t.Helper()
 
 	if !views.SliceContains(want, use) {
 		t.Errorf("invalid test: use %v is not in want %v", use, want)
 	}
 
-	return func(got views.Slice[int]) int {
+	return func(got views.Slice[tailcfg.DERPRegionID]) tailcfg.DERPRegionID {
 		if !views.SliceEqualAnyOrder(got, want) {
 			t.Errorf("candidate regions = %v, want %v", got, want)
 		}
@@ -5468,7 +5468,7 @@ func TestSuggestExitNode(t *testing.T) {
 	t.Parallel()
 
 	defaultDERPMap := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			1: {
 				Latitude:  32,
 				Longitude: -97,
@@ -5479,7 +5479,7 @@ func TestSuggestExitNode(t *testing.T) {
 	}
 
 	preferred1Report := &netcheck.Report{
-		RegionLatency: map[int]time.Duration{
+		RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 			1: 10 * time.Millisecond,
 			2: 20 * time.Millisecond,
 			3: 30 * time.Millisecond,
@@ -5487,7 +5487,7 @@ func TestSuggestExitNode(t *testing.T) {
 		PreferredDERP: 1,
 	}
 	noLatency1Report := &netcheck.Report{
-		RegionLatency: map[int]time.Duration{
+		RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 			1: 0,
 			2: 0,
 			3: 0,
@@ -5495,7 +5495,7 @@ func TestSuggestExitNode(t *testing.T) {
 		PreferredDERP: 1,
 	}
 	preferredNoneReport := &netcheck.Report{
-		RegionLatency: map[int]time.Duration{
+		RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 			1: 10 * time.Millisecond,
 			2: 20 * time.Millisecond,
 			3: 30 * time.Millisecond,
@@ -5622,8 +5622,8 @@ func TestSuggestExitNode(t *testing.T) {
 
 		allowPolicy []tailcfg.StableNodeID
 
-		wantRegions []int
-		useRegion   int
+		wantRegions []tailcfg.DERPRegionID
+		useRegion   tailcfg.DERPRegionID
 
 		wantNodes []tailcfg.StableNodeID
 
@@ -5655,7 +5655,7 @@ func TestSuggestExitNode(t *testing.T) {
 			name:        "2-exits-different-regions-unknown-latency",
 			lastReport:  noLatency1Report,
 			netMap:      defaultNetmap,
-			wantRegions: []int{1, 3}, // the only regions with peers
+			wantRegions: []tailcfg.DERPRegionID{1, 3}, // the only regions with peers
 			useRegion:   1,
 			wantName:    "peer2",
 			wantID:      "stable2",
@@ -5663,7 +5663,7 @@ func TestSuggestExitNode(t *testing.T) {
 		{
 			name: "2-derp-exits-different-regions-equal-latency",
 			lastReport: &netcheck.Report{
-				RegionLatency: map[int]time.Duration{
+				RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 					1: 10,
 					2: 20,
 					3: 10,
@@ -5678,7 +5678,7 @@ func TestSuggestExitNode(t *testing.T) {
 					peer3,
 				},
 			},
-			wantRegions: []int{1, 2},
+			wantRegions: []tailcfg.DERPRegionID{1, 2},
 			useRegion:   1,
 			wantName:    "peer1",
 			wantID:      "stable1",
@@ -5909,7 +5909,7 @@ func TestSuggestExitNode(t *testing.T) {
 			// Regression test for https://github.com/tailscale/tailscale/issues/17661
 			name: "exits-no-home-DERP-random-selection",
 			lastReport: &netcheck.Report{
-				RegionLatency: map[int]time.Duration{
+				RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 					1: 10,
 					2: 20,
 					3: 10,
@@ -5924,7 +5924,7 @@ func TestSuggestExitNode(t *testing.T) {
 					emptyLocationPeer10,
 				},
 			},
-			wantRegions: []int{1, 2},
+			wantRegions: []tailcfg.DERPRegionID{1, 2},
 			wantName:    "peer9",
 			wantNodes:   []tailcfg.StableNodeID{"stable9", "stable10"},
 			wantID:      "stable9",
@@ -5936,7 +5936,7 @@ func TestSuggestExitNode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wantRegions := tt.wantRegions
 			if wantRegions == nil {
-				wantRegions = []int{tt.useRegion}
+				wantRegions = []tailcfg.DERPRegionID{tt.useRegion}
 			}
 			selectRegion := deterministicRegionForTest(t, views.SliceOf(wantRegions), tt.useRegion)
 
@@ -5955,8 +5955,8 @@ func TestSuggestExitNode(t *testing.T) {
 			defer nb.shutdown(errShutdown)
 			nb.SetNetMap(tt.netMap)
 
-			var preferredDERP int
-			var regionLatency map[int]time.Duration
+			var preferredDERP tailcfg.DERPRegionID
+			var regionLatency map[tailcfg.DERPRegionID]time.Duration
 			if tt.lastReport != nil {
 				preferredDERP = tt.lastReport.PreferredDERP
 				regionLatency = tt.lastReport.RegionLatency
@@ -5988,7 +5988,7 @@ func TestSuggestExitNodeUsesRecentDERPLatency(t *testing.T) {
 	t.Parallel()
 
 	derpMap := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			1: {Nodes: []*tailcfg.DERPNode{{Name: "1a", RegionID: 1}}},
 			2: {Nodes: []*tailcfg.DERPNode{{Name: "2a", RegionID: 2}}},
 			3: {Nodes: []*tailcfg.DERPNode{{Name: "3a", RegionID: 3}}},
@@ -6015,7 +6015,7 @@ func TestSuggestExitNodeUsesRecentDERPLatency(t *testing.T) {
 	// region 5 (200ms).
 	fullReport := &netcheck.Report{
 		PreferredDERP: 1,
-		RegionLatency: map[int]time.Duration{
+		RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 			1: 10 * time.Millisecond,
 			2: 20 * time.Millisecond,
 			3: 30 * time.Millisecond,
@@ -6026,7 +6026,7 @@ func TestSuggestExitNodeUsesRecentDERPLatency(t *testing.T) {
 	// A later incremental netcheck only re-probed the home and fastest regions, so
 	// it has no latency for regions 4 or 5.
 	incrementalReport := &netcheck.Report{
-		RegionLatency: map[int]time.Duration{
+		RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 			1: 10 * time.Millisecond,
 			2: 20 * time.Millisecond,
 			3: 30 * time.Millisecond,
@@ -6554,20 +6554,20 @@ func TestSuggestExitNodeTrafficSteering(t *testing.T) {
 func TestMinLatencyDERPregion(t *testing.T) {
 	tests := []struct {
 		name          string
-		regions       []int
-		regionLatency map[int]time.Duration
-		wantRegion    int
+		regions       []tailcfg.DERPRegionID
+		regionLatency map[tailcfg.DERPRegionID]time.Duration
+		wantRegion    tailcfg.DERPRegionID
 	}{
 		{
 			name:       "regions-no-latency",
-			regions:    []int{1, 2, 3},
+			regions:    []tailcfg.DERPRegionID{1, 2, 3},
 			wantRegion: 0,
 		},
 		{
 			name:       "regions-different-latency",
-			regions:    []int{1, 2, 3},
+			regions:    []tailcfg.DERPRegionID{1, 2, 3},
 			wantRegion: 2,
-			regionLatency: map[int]time.Duration{
+			regionLatency: map[tailcfg.DERPRegionID]time.Duration{
 				1: 10 * time.Millisecond,
 				2: 5 * time.Millisecond,
 				3: 30 * time.Millisecond,
@@ -6575,9 +6575,9 @@ func TestMinLatencyDERPregion(t *testing.T) {
 		},
 		{
 			name:       "regions-same-latency",
-			regions:    []int{1, 2, 3},
+			regions:    []tailcfg.DERPRegionID{1, 2, 3},
 			wantRegion: 1,
-			regionLatency: map[int]time.Duration{
+			regionLatency: map[tailcfg.DERPRegionID]time.Duration{
 				1: 10 * time.Millisecond,
 				2: 10 * time.Millisecond,
 				3: 10 * time.Millisecond,

--- a/ipn/ipnlocal/netmapcache/netmapcache_test.go
+++ b/ipn/ipnlocal/netmapcache/netmapcache_test.go
@@ -138,7 +138,7 @@ func init() {
 
 		DERPMap: &tailcfg.DERPMap{ // "derp"
 			HomeParams: &tailcfg.DERPHomeParams{
-				RegionScore: map[int]float64{10: 0.31, 20: 0.141, 30: 0.592},
+				RegionScore: map[tailcfg.DERPRegionID]float64{10: 0.31, 20: 0.141, 30: 0.592},
 			},
 			OmitDefaultRegions: true,
 		},

--- a/ipn/ipnlocal/netmapcache/netmapcache_test.go
+++ b/ipn/ipnlocal/netmapcache/netmapcache_test.go
@@ -137,7 +137,7 @@ func init() {
 
 		DERPMap: &tailcfg.DERPMap{ // "derp"
 			HomeParams: &tailcfg.DERPHomeParams{
-				RegionScore: map[int]float64{10: 0.31, 20: 0.141, 30: 0.592},
+				RegionScore: map[tailcfg.DERPRegionID]float64{10: 0.31, 20: 0.141, 30: 0.592},
 			},
 			OmitDefaultRegions: true,
 		},

--- a/ipn/ipnlocal/state_test.go
+++ b/ipn/ipnlocal/state_test.go
@@ -1765,7 +1765,7 @@ func buildNetmapWithPeers(self tailcfg.NodeView, peers ...tailcfg.NodeView) *net
 	}
 
 	derpmap := &tailcfg.DERPMap{
-		Regions: make(map[int]*tailcfg.DERPRegion),
+		Regions: make(map[tailcfg.DERPRegionID]*tailcfg.DERPRegion),
 	}
 	makeDERPRegionForNode := func(n *tailcfg.Node) {
 		if n.HomeDERP == 0 {

--- a/ipn/ipnlocal/state_test.go
+++ b/ipn/ipnlocal/state_test.go
@@ -1766,7 +1766,7 @@ func buildNetmapWithPeers(self tailcfg.NodeView, peers ...tailcfg.NodeView) *net
 	}
 
 	derpmap := &tailcfg.DERPMap{
-		Regions: make(map[int]*tailcfg.DERPRegion),
+		Regions: make(map[tailcfg.DERPRegionID]*tailcfg.DERPRegion),
 	}
 	makeDERPRegionForNode := func(n *tailcfg.Node) {
 		if n.HomeDERP == 0 {

--- a/ipn/ipnstate/ipnstate.go
+++ b/ipn/ipnstate/ipnstate.go
@@ -745,7 +745,7 @@ type PingResult struct {
 
 	// DERPRegionID is non-zero DERP region ID if DERP was used.
 	// It is not currently set for TSMP pings.
-	DERPRegionID int
+	DERPRegionID tailcfg.DERPRegionID
 
 	// DERPRegionCode is the three-letter region code
 	// corresponding to DERPRegionID.

--- a/ipn/ipnstate/ipnstate.go
+++ b/ipn/ipnstate/ipnstate.go
@@ -746,7 +746,7 @@ type PingResult struct {
 
 	// DERPRegionID is non-zero DERP region ID if DERP was used.
 	// It is not currently set for TSMP pings.
-	DERPRegionID int
+	DERPRegionID tailcfg.DERPRegionID
 
 	// DERPRegionCode is the three-letter region code
 	// corresponding to DERPRegionID.

--- a/ipn/localapi/debug.go
+++ b/ipn/localapi/debug.go
@@ -25,6 +25,7 @@ import (
 	"tailscale.com/feature"
 	"tailscale.com/feature/buildfeatures"
 	"tailscale.com/ipn"
+	"tailscale.com/tailcfg"
 	"tailscale.com/types/logger"
 	"tailscale.com/util/eventbus"
 	"tailscale.com/util/httpm"
@@ -216,7 +217,7 @@ func (h *Handler) serveDebug(w http.ResponseWriter, r *http.Request) {
 	case "pick-new-derp":
 		err = h.b.DebugPickNewDERP()
 	case "force-prefer-derp":
-		var n int
+		var n tailcfg.DERPRegionID
 		err = json.NewDecoder(r.Body).Decode(&n)
 		if err != nil {
 			break

--- a/ipn/localapi/debugderp.go
+++ b/ipn/localapi/debugderp.go
@@ -68,7 +68,7 @@ func (h *Handler) serveDebugDERPRegion(w http.ResponseWriter, r *http.Request) {
 	}
 	regStr := r.FormValue("region")
 	var reg *tailcfg.DERPRegion
-	if id, err := strconv.Atoi(regStr); err == nil {
+	if id, err := tailcfg.ParseDERPRegionID(regStr); err == nil {
 		reg = dm.Regions[id]
 	} else {
 		for _, r := range dm.Regions {

--- a/net/captivedetection/captivedetection.go
+++ b/net/captivedetection/captivedetection.go
@@ -73,11 +73,11 @@ const Timeout = 3 * time.Second
 //
 // This function might take a while to return, as it will attempt to detect a captive portal on all available interfaces
 // by performing multiple HTTP requests. It should be called in a separate goroutine if you want to avoid blocking.
-func (d *Detector) Detect(ctx context.Context, netMon *netmon.Monitor, derpMap *tailcfg.DERPMap, preferredDERPRegionID int) (found bool) {
+func (d *Detector) Detect(ctx context.Context, netMon *netmon.Monitor, derpMap *tailcfg.DERPMap, preferredDERPRegionID tailcfg.DERPRegionID) (found bool) {
 	return d.detectCaptivePortalWithGOOS(ctx, netMon, derpMap, preferredDERPRegionID, runtime.GOOS)
 }
 
-func (d *Detector) detectCaptivePortalWithGOOS(ctx context.Context, netMon *netmon.Monitor, derpMap *tailcfg.DERPMap, preferredDERPRegionID int, goos string) (found bool) {
+func (d *Detector) detectCaptivePortalWithGOOS(ctx context.Context, netMon *netmon.Monitor, derpMap *tailcfg.DERPMap, preferredDERPRegionID tailcfg.DERPRegionID, goos string) (found bool) {
 	ifState := netMon.InterfaceState()
 	if !ifState.AnyInterfaceUp() {
 		d.logf("[v2] DetectCaptivePortal: no interfaces up, returning false")

--- a/net/captivedetection/endpoints.go
+++ b/net/captivedetection/endpoints.go
@@ -77,7 +77,7 @@ func (e Endpoint) Equal(other Endpoint) bool {
 // availableEndpoints returns a set of Endpoints which can be used for captive portal detection by performing
 // one or more HTTP requests and looking at the response. The returned Endpoints are ordered by preference,
 // with the most preferred Endpoint being the first in the slice.
-func availableEndpoints(derpMap *tailcfg.DERPMap, preferredDERPRegionID int, logf logger.Logf, goos string) []Endpoint {
+func availableEndpoints(derpMap *tailcfg.DERPMap, preferredDERPRegionID tailcfg.DERPRegionID, logf logger.Logf, goos string) []Endpoint {
 	endpoints := []Endpoint{}
 
 	if derpMap == nil || len(derpMap.Regions) == 0 {

--- a/net/dnsfallback/dnsfallback_test.go
+++ b/net/dnsfallback/dnsfallback_test.go
@@ -33,7 +33,7 @@ func TestCache(t *testing.T) {
 
 	// Write initial cache value
 	initialCache := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			99: {
 				RegionID:   99,
 				RegionCode: "test",
@@ -109,7 +109,7 @@ func TestCacheUnchanged(t *testing.T) {
 
 	// Write initial cache value
 	initialCache := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			99: {
 				RegionID:   99,
 				RegionCode: "test",
@@ -155,7 +155,7 @@ func TestCacheUnchanged(t *testing.T) {
 	// Now, update the cache with something slightly different and verify
 	// that we did re-write the file on-disk.
 	updatedCache := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			99: {
 				RegionID:   99,
 				RegionCode: "test",

--- a/net/netcheck/netcheck.go
+++ b/net/netcheck/netcheck.go
@@ -112,10 +112,10 @@ type Report struct {
 	// Empty means not checked.
 	PCP opt.Bool
 
-	PreferredDERP   int           // or 0 for unknown
-	RegionLatency   RegionLatency // keyed by DERP Region ID
-	RegionV4Latency RegionLatency // keyed by DERP Region ID
-	RegionV6Latency RegionLatency // keyed by DERP Region ID
+	PreferredDERP   tailcfg.DERPRegionID // or 0 for unknown
+	RegionLatency   RegionLatency        // keyed by DERP Region ID
+	RegionV4Latency RegionLatency        // keyed by DERP Region ID
+	RegionV6Latency RegionLatency        // keyed by DERP Region ID
 
 	GlobalV4Counters map[netip.AddrPort]int // number of times the endpoint was observed
 	GlobalV6Counters map[netip.AddrPort]int // number of times the endpoint was observed
@@ -186,7 +186,7 @@ func (r *Report) Clone() *Report {
 }
 
 // RegionLatency is a map of DERP region IDs associated with their measured latencies.
-type RegionLatency map[int]time.Duration
+type RegionLatency map[tailcfg.DERPRegionID]time.Duration
 
 // Compare compares the latency of the regions i and j. It returns
 //
@@ -203,7 +203,7 @@ type RegionLatency map[int]time.Duration
 //	-1 if i is less than j
 //	 0 if i equals j
 //	+1 if i is greater than j
-func (lat RegionLatency) Compare(i, j int) int {
+func (lat RegionLatency) Compare(i, j tailcfg.DERPRegionID) int {
 	iLat, iOK := lat[i]
 	jLat, jOK := lat[j]
 	return cmp.Or(
@@ -259,7 +259,7 @@ type Client struct {
 
 	// if non-zero, force this DERP region to be preferred in all reports where
 	// the DERP is found to be reachable.
-	ForcePreferredDERP int
+	ForcePreferredDERP tailcfg.DERPRegionID
 
 	// For tests
 	testEnoughRegions int
@@ -408,7 +408,7 @@ type probePlan map[string][]probe
 // sortRegions returns the regions of dm first sorted
 // from fastest to slowest (based on the 'last' report),
 // end in regions that have no data.
-func sortRegions(dm *tailcfg.DERPMap, last *Report, preferredDERP int) (prev []*tailcfg.DERPRegion) {
+func sortRegions(dm *tailcfg.DERPMap, last *Report, preferredDERP tailcfg.DERPRegionID) (prev []*tailcfg.DERPRegion) {
 	prev = make([]*tailcfg.DERPRegion, 0, len(dm.Regions))
 	for _, reg := range dm.Regions {
 		if reg.NoMeasureNoHome {
@@ -452,7 +452,7 @@ const numIncrementalRegions = 3
 // TODO(raggi): change from "preferred DERP" from a historical report to "home
 // DERP" as in what DERP is the current home connection, this would further
 // reduce flap events.
-func makeProbePlan(dm *tailcfg.DERPMap, ifState *netmon.State, last *Report, preferredDERP int) (plan probePlan) {
+func makeProbePlan(dm *tailcfg.DERPMap, ifState *netmon.State, last *Report, preferredDERP tailcfg.DERPRegionID) (plan probePlan) {
 	if last == nil || len(last.RegionLatency) == 0 {
 		return makeProbePlanInitial(dm, ifState)
 	}
@@ -631,7 +631,7 @@ func (rs *reportState) anyUDP() bool {
 	return rs.report.UDP
 }
 
-func (rs *reportState) haveRegionLatency(regionID int) bool {
+func (rs *reportState) haveRegionLatency(regionID tailcfg.DERPRegionID) bool {
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
 	_, ok := rs.report.RegionLatency[regionID]
@@ -768,9 +768,9 @@ func (rs *reportState) probePortMapServices() {
 
 func newReport() *Report {
 	return &Report{
-		RegionLatency:   make(map[int]time.Duration),
-		RegionV4Latency: make(map[int]time.Duration),
-		RegionV6Latency: make(map[int]time.Duration),
+		RegionLatency:   make(map[tailcfg.DERPRegionID]time.Duration),
+		RegionV4Latency: make(map[tailcfg.DERPRegionID]time.Duration),
+		RegionV6Latency: make(map[tailcfg.DERPRegionID]time.Duration),
 	}
 }
 
@@ -785,7 +785,7 @@ type GetReportOpts struct {
 	//
 	// If no communication with that region has occurred, or it occurred
 	// too far in the past, this function should return the zero time.
-	GetLastDERPActivity func(int) time.Time
+	GetLastDERPActivity func(tailcfg.DERPRegionID) time.Time
 	// OnlyTCP443 constrains netcheck reporting to measurements over TCP port
 	// 443.
 	OnlyTCP443 bool
@@ -795,14 +795,14 @@ type GetReportOpts struct {
 
 // getLastDERPActivity calls o.GetLastDERPActivity if both o and
 // o.GetLastDERPActivity are non-nil; otherwise it returns the zero time.
-func (o *GetReportOpts) getLastDERPActivity(region int) time.Time {
+func (o *GetReportOpts) getLastDERPActivity(region tailcfg.DERPRegionID) time.Time {
 	if o == nil || o.GetLastDERPActivity == nil {
 		return time.Time{}
 	}
 	return o.GetLastDERPActivity(region)
 }
 
-func (c *Client) SetForcePreferredDERP(region int) {
+func (c *Client) SetForcePreferredDERP(region tailcfg.DERPRegionID) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.ForcePreferredDERP = region
@@ -816,7 +816,7 @@ func (c *Client) SetForcePreferredDERP(region int) {
 // The returned done channel is closed when detection has finished (and
 // setCaptivePortal has been called with the result, if it ran); the returned
 // stop function cancels a detection that has not yet started.
-var HookStartCaptivePortalDetection feature.Hook[func(ctx context.Context, c *Client, dm *tailcfg.DERPMap, preferredDERP int, setCaptivePortal func(bool)) (done <-chan struct{}, stop func())]
+var HookStartCaptivePortalDetection feature.Hook[func(ctx context.Context, c *Client, dm *tailcfg.DERPMap, preferredDERP tailcfg.DERPRegionID, setCaptivePortal func(bool)) (done <-chan struct{}, stop func())]
 
 // GetReport gets a report. The 'opts' argument is optional and can be nil.
 // Callers are discouraged from passing a ctx with an arbitrary deadline as this
@@ -875,7 +875,7 @@ func (c *Client) GetReport(ctx context.Context, dm *tailcfg.DERPMap, opts *GetRe
 	// in captive portal detection and DERP flapping suppression. Ideally this would
 	// be the current active home DERP rather than the last report preferred DERP,
 	// but only the latter is presently available.
-	var preferredDERP int
+	var preferredDERP tailcfg.DERPRegionID
 	if last != nil {
 		preferredDERP = last.PreferredDERP
 	}
@@ -996,7 +996,7 @@ func (c *Client) GetReport(ctx context.Context, dm *tailcfg.DERPMap, opts *GetRe
 		var wg sync.WaitGroup
 		var need []*tailcfg.DERPRegion
 		for rid, reg := range dm.Regions {
-			if !rs.haveRegionLatency(rid) && regionHasDERPNode(reg) && !reg.Avoid && !reg.NoMeasureNoHome {
+			if !rs.haveRegionLatency(tailcfg.DERPRegionID(rid)) && regionHasDERPNode(reg) && !reg.Avoid && !reg.NoMeasureNoHome {
 				need = append(need, reg)
 			}
 		}
@@ -1416,7 +1416,7 @@ func (c *Client) addReportHistoryAndSetPreferredDERP(rs *reportState, r *Report,
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	var prevDERP int
+	var prevDERP tailcfg.DERPRegionID
 	if c.last != nil {
 		prevDERP = c.last.PreferredDERP
 	}
@@ -1428,7 +1428,7 @@ func (c *Client) addReportHistoryAndSetPreferredDERP(rs *reportState, r *Report,
 
 	// Scale each region's best latency by any provided scores from the
 	// DERPMap, for use in comparison below.
-	var scores views.Map[int, float64]
+	var scores views.Map[tailcfg.DERPRegionID, float64]
 	if hp := dm.HomeParams(); hp.Valid() {
 		scores = hp.RegionScore()
 	}
@@ -1522,8 +1522,8 @@ func (c *Client) addReportHistoryAndSetPreferredDERP(rs *reportState, r *Report,
 // bestRecentLatencyLocked returns the lowest latency seen per DERP region across
 // the reports currently retained in history (c.prev), keyed by region ID. These
 // latencies are used for determining preferred DERP and suggesting an exit node.
-func (c *Client) bestRecentLatencyLocked() map[int]time.Duration {
-	best := make(map[int]time.Duration)
+func (c *Client) bestRecentLatencyLocked() map[tailcfg.DERPRegionID]time.Duration {
+	best := make(map[tailcfg.DERPRegionID]time.Duration)
 	for _, pr := range c.prev {
 		for regionID, d := range pr.RegionLatency {
 			if bd, ok := best[regionID]; !ok || d < bd {
@@ -1536,7 +1536,7 @@ func (c *Client) bestRecentLatencyLocked() map[int]time.Duration {
 
 // RecentRegionLatency returns the lowest latency seen per DERP region over the
 // recent history window, keyed by region ID.
-func (c *Client) RecentRegionLatency() map[int]time.Duration {
+func (c *Client) RecentRegionLatency() map[tailcfg.DERPRegionID]time.Duration {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.bestRecentLatencyLocked()
@@ -1551,7 +1551,7 @@ func (c *Client) AddReportHistoryForTest(dm *tailcfg.DERPMap, r *Report, now tim
 	c.addReportHistoryAndSetPreferredDERP(rs, r, dm.View(), now)
 }
 
-func updateLatency(m map[int]time.Duration, regionID int, d time.Duration) {
+func updateLatency(m map[tailcfg.DERPRegionID]time.Duration, regionID tailcfg.DERPRegionID, d time.Duration) {
 	if prev, ok := m[regionID]; !ok || d < prev {
 		m[regionID] = d
 	}
@@ -1751,7 +1751,7 @@ func regionHasDERPNode(r *tailcfg.DERPRegion) bool {
 	return false
 }
 
-func maxDurationValue(m map[int]time.Duration) (max time.Duration) {
+func maxDurationValue(m map[tailcfg.DERPRegionID]time.Duration) (max time.Duration) {
 	for _, v := range m {
 		if v > max {
 			max = v

--- a/net/netcheck/netcheck_test.go
+++ b/net/netcheck/netcheck_test.go
@@ -13,7 +13,6 @@ import (
 	"net/netip"
 	"reflect"
 	"slices"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -163,13 +162,13 @@ func TestWorksWhenUDPBlocked(t *testing.T) {
 func TestAddReportHistoryAndSetPreferredDERP(t *testing.T) {
 	// report returns a *Report from (DERP host, time.Duration)+ pairs.
 	report := func(a ...any) *Report {
-		r := &Report{RegionLatency: map[int]time.Duration{}}
+		r := &Report{RegionLatency: map[tailcfg.DERPRegionID]time.Duration{}}
 		for i := 0; i < len(a); i += 2 {
 			s := a[i].(string)
 			if !strings.HasPrefix(s, "d") {
 				t.Fatalf("invalid derp server key %q", s)
 			}
-			regionID, err := strconv.Atoi(s[1:])
+			regionID, err := tailcfg.ParseDERPRegionID(s[1:])
 			if err != nil {
 				t.Fatalf("invalid derp server key %q", s)
 			}
@@ -185,8 +184,8 @@ func TestAddReportHistoryAndSetPreferredDERP(t *testing.T) {
 		}
 		return r
 	}
-	mkLDAFunc := func(mm map[int]time.Time) func(int) time.Time {
-		return func(region int) time.Time {
+	mkLDAFunc := func(mm map[tailcfg.DERPRegionID]time.Time) func(tailcfg.DERPRegionID) time.Time {
+		return func(region tailcfg.DERPRegionID) time.Time {
 			return mm[region]
 		}
 	}
@@ -200,9 +199,9 @@ func TestAddReportHistoryAndSetPreferredDERP(t *testing.T) {
 		steps       []step
 		homeParams  *tailcfg.DERPHomeParams
 		opts        *GetReportOpts
-		forcedDERP  int // if non-zero, force this DERP to be the preferred one
-		wantDERP    int // want PreferredDERP on final step
-		wantPrevLen int // wanted len(c.prev)
+		forcedDERP  tailcfg.DERPRegionID // if non-zero, force this DERP to be the preferred one
+		wantDERP    tailcfg.DERPRegionID // want PreferredDERP on final step
+		wantPrevLen int                  // wanted len(c.prev)
 	}{
 		{
 			name: "first_reading",
@@ -284,7 +283,7 @@ func TestAddReportHistoryAndSetPreferredDERP(t *testing.T) {
 		{
 			name: "derp_home_params",
 			homeParams: &tailcfg.DERPHomeParams{
-				RegionScore: map[int]float64{
+				RegionScore: map[tailcfg.DERPRegionID]float64{
 					1: 2.0 / 3, // 66%
 				},
 			},
@@ -302,7 +301,7 @@ func TestAddReportHistoryAndSetPreferredDERP(t *testing.T) {
 		{
 			name: "derp_home_params_high_latency",
 			homeParams: &tailcfg.DERPHomeParams{
-				RegionScore: map[int]float64{
+				RegionScore: map[tailcfg.DERPRegionID]float64{
 					1: 2.0 / 3, // 66%
 				},
 			},
@@ -316,7 +315,7 @@ func TestAddReportHistoryAndSetPreferredDERP(t *testing.T) {
 		{
 			name: "derp_home_params_invalid",
 			homeParams: &tailcfg.DERPHomeParams{
-				RegionScore: map[int]float64{
+				RegionScore: map[tailcfg.DERPRegionID]float64{
 					1: 0.0,
 					2: -1.0,
 				},
@@ -335,7 +334,7 @@ func TestAddReportHistoryAndSetPreferredDERP(t *testing.T) {
 				{2 * time.Second, report("d2", 3)},          // (3) d1 gone, but have traffic
 			},
 			opts: &GetReportOpts{
-				GetLastDERPActivity: mkLDAFunc(map[int]time.Time{
+				GetLastDERPActivity: mkLDAFunc(map[tailcfg.DERPRegionID]time.Time{
 					1: startTime.Add(2*time.Second + PreferredDERPFrameTime/2), // within active window of step (3)
 				}),
 			},
@@ -350,7 +349,7 @@ func TestAddReportHistoryAndSetPreferredDERP(t *testing.T) {
 				{2 * time.Second, report("d2", 3)},          // (3) d1 gone, but have traffic
 			},
 			opts: &GetReportOpts{
-				GetLastDERPActivity: mkLDAFunc(map[int]time.Time{
+				GetLastDERPActivity: mkLDAFunc(map[tailcfg.DERPRegionID]time.Time{
 					1: startTime.Add(4*time.Second - PreferredDERPFrameTime - 1), // not within active window of (3)
 				}),
 			},
@@ -393,7 +392,7 @@ func TestAddReportHistoryAndSetPreferredDERP(t *testing.T) {
 				{2 * time.Second, report("d1", 4)},
 			},
 			opts: &GetReportOpts{
-				GetLastDERPActivity: mkLDAFunc(map[int]time.Time{
+				GetLastDERPActivity: mkLDAFunc(map[tailcfg.DERPRegionID]time.Time{
 					1: startTime,
 					2: startTime.Add(time.Second),
 				}),
@@ -409,7 +408,7 @@ func TestAddReportHistoryAndSetPreferredDERP(t *testing.T) {
 				{PreferredDERPFrameTime + time.Second, report("d1", 4)},
 			},
 			opts: &GetReportOpts{
-				GetLastDERPActivity: mkLDAFunc(map[int]time.Time{
+				GetLastDERPActivity: mkLDAFunc(map[tailcfg.DERPRegionID]time.Time{
 					1: startTime,
 					2: startTime,
 				}),
@@ -429,7 +428,7 @@ func TestAddReportHistoryAndSetPreferredDERP(t *testing.T) {
 				{2 * time.Second, report()},
 			},
 			opts: &GetReportOpts{
-				GetLastDERPActivity: mkLDAFunc(map[int]time.Time{
+				GetLastDERPActivity: mkLDAFunc(map[tailcfg.DERPRegionID]time.Time{
 					1: startTime,
 				}),
 			},
@@ -444,7 +443,7 @@ func TestAddReportHistoryAndSetPreferredDERP(t *testing.T) {
 				{2 * derp.KeepAlive, report()},
 			},
 			opts: &GetReportOpts{
-				GetLastDERPActivity: mkLDAFunc(map[int]time.Time{
+				GetLastDERPActivity: mkLDAFunc(map[tailcfg.DERPRegionID]time.Time{
 					1: startTime,
 				}),
 			},
@@ -487,20 +486,20 @@ func TestAddReportHistoryAndSetPreferredDERP(t *testing.T) {
 // reports are incremental.
 func TestRecentReportsRetainFullNetcheck(t *testing.T) {
 	dm := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			1: {RegionID: 1},
 			2: {RegionID: 2},
 			3: {RegionID: 3},
 		},
 	}
-	allRegions := []int{1, 2, 3}
-	incrementalRegions := []int{1, 2} // home + fastest; never includes region 3
+	allRegions := []tailcfg.DERPRegionID{1, 2, 3}
+	incrementalRegions := []tailcfg.DERPRegionID{1, 2} // home + fastest; never includes region 3
 
 	var now time.Time
 	c := &Client{TimeNow: func() time.Time { return now }}
 
-	mkReport := func(regions []int) *Report {
-		r := &Report{RegionLatency: map[int]time.Duration{}}
+	mkReport := func(regions []tailcfg.DERPRegionID) *Report {
+		r := &Report{RegionLatency: map[tailcfg.DERPRegionID]time.Duration{}}
 		for _, rid := range regions {
 			r.RegionLatency[rid] = 10 * time.Millisecond
 		}
@@ -540,11 +539,12 @@ func TestMakeProbePlan(t *testing.T) {
 	// basicMap has 5 regions. each region has a number of nodes
 	// equal to the region number (1 has 1a, 2 has 2a and 2b, etc.)
 	basicMap := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{},
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{},
 	}
-	for rid := 1; rid <= 6; rid++ {
+	for i := range 6 {
+		rid := tailcfg.DERPRegionID(i + 1)
 		var nodes []*tailcfg.DERPNode
-		for nid := 0; nid < rid; nid++ {
+		for nid := range tailcfg.DERPRegionID(rid) {
 			nodes = append(nodes, &tailcfg.DERPNode{
 				Name:     fmt.Sprintf("%d%c", rid, 'a'+rune(nid)),
 				RegionID: rid,
@@ -623,14 +623,14 @@ func TestMakeProbePlan(t *testing.T) {
 			dm:      basicMap,
 			have6if: false,
 			last: &Report{
-				RegionLatency: map[int]time.Duration{
+				RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 					1: 10 * time.Millisecond,
 					2: 20 * time.Millisecond,
 					3: 30 * time.Millisecond,
 					4: 40 * time.Millisecond,
 					// Pretend 5 is missing
 				},
-				RegionV4Latency: map[int]time.Duration{
+				RegionV4Latency: map[tailcfg.DERPRegionID]time.Duration{
 					1: 10 * time.Millisecond,
 					2: 20 * time.Millisecond,
 					3: 30 * time.Millisecond,
@@ -648,14 +648,14 @@ func TestMakeProbePlan(t *testing.T) {
 			dm:      basicMap,
 			have6if: true,
 			last: &Report{
-				RegionLatency: map[int]time.Duration{
+				RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 					1: 10 * time.Millisecond,
 					2: 20 * time.Millisecond,
 					3: 30 * time.Millisecond,
 					4: 40 * time.Millisecond,
 					// Pretend 5 is missing
 				},
-				RegionV4Latency: map[int]time.Duration{
+				RegionV4Latency: map[tailcfg.DERPRegionID]time.Duration{
 					1: 10 * time.Millisecond,
 					2: 20 * time.Millisecond,
 					3: 30 * time.Millisecond,
@@ -675,18 +675,18 @@ func TestMakeProbePlan(t *testing.T) {
 			dm:      basicMap,
 			have6if: true,
 			last: &Report{
-				RegionLatency: map[int]time.Duration{
+				RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 					1: 10 * time.Millisecond,
 					2: 20 * time.Millisecond,
 					3: 30 * time.Millisecond,
 					4: 40 * time.Millisecond,
 					// Pretend 5 is missing
 				},
-				RegionV4Latency: map[int]time.Duration{
+				RegionV4Latency: map[tailcfg.DERPRegionID]time.Duration{
 					1: 10 * time.Millisecond,
 					2: 20 * time.Millisecond,
 				},
-				RegionV6Latency: map[int]time.Duration{
+				RegionV6Latency: map[tailcfg.DERPRegionID]time.Duration{
 					3: 30 * time.Millisecond,
 					4: 40 * time.Millisecond,
 				},
@@ -717,17 +717,17 @@ func TestMakeProbePlan(t *testing.T) {
 			dm:      basicMap,
 			have6if: true,
 			last: &Report{
-				RegionLatency: map[int]time.Duration{
+				RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 					1: 10 * time.Millisecond,
 					2: 20 * time.Millisecond,
 					3: 30 * time.Millisecond,
 					4: 40 * time.Millisecond,
 				},
-				RegionV4Latency: map[int]time.Duration{
+				RegionV4Latency: map[tailcfg.DERPRegionID]time.Duration{
 					1: 10 * time.Millisecond,
 					2: 20 * time.Millisecond,
 				},
-				RegionV6Latency: map[int]time.Duration{
+				RegionV6Latency: map[tailcfg.DERPRegionID]time.Duration{
 					3: 30 * time.Millisecond,
 					4: 40 * time.Millisecond,
 				},
@@ -749,17 +749,17 @@ func TestMakeProbePlan(t *testing.T) {
 			dm:      basicMap,
 			have6if: true,
 			last: &Report{
-				RegionLatency: map[int]time.Duration{
+				RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 					1: 50 * time.Millisecond,
 					2: 20 * time.Millisecond,
 					3: 30 * time.Millisecond,
 					4: 40 * time.Millisecond,
 				},
-				RegionV4Latency: map[int]time.Duration{
+				RegionV4Latency: map[tailcfg.DERPRegionID]time.Duration{
 					1: 50 * time.Millisecond,
 					2: 20 * time.Millisecond,
 				},
-				RegionV6Latency: map[int]time.Duration{
+				RegionV6Latency: map[tailcfg.DERPRegionID]time.Duration{
 					3: 30 * time.Millisecond,
 					4: 40 * time.Millisecond,
 				},
@@ -782,7 +782,7 @@ func TestMakeProbePlan(t *testing.T) {
 				HaveV6: tt.have6if,
 				HaveV4: !tt.no4,
 			}
-			preferredDERP := 0
+			var preferredDERP tailcfg.DERPRegionID
 			if tt.last != nil {
 				preferredDERP = tt.last.PreferredDERP
 			}
@@ -821,7 +821,7 @@ func (p probe) String() string {
 
 func TestLogConciseReport(t *testing.T) {
 	dm := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			1: nil,
 			2: nil,
 			3: nil,
@@ -849,10 +849,10 @@ func TestLogConciseReport(t *testing.T) {
 				UDP:           true,
 				IPv4:          true,
 				PreferredDERP: 1,
-				RegionLatency: map[int]time.Duration{
+				RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 					1: 10 * ms,
 				},
-				RegionV4Latency: map[int]time.Duration{
+				RegionV4Latency: map[tailcfg.DERPRegionID]time.Duration{
 					1: 10 * ms,
 				},
 			},
@@ -864,12 +864,12 @@ func TestLogConciseReport(t *testing.T) {
 				UDP:           true,
 				IPv4:          true,
 				PreferredDERP: 1,
-				RegionLatency: map[int]time.Duration{
+				RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 					1: 10 * ms,
 					2: 20 * ms,
 					3: 30 * ms,
 				},
-				RegionV4Latency: map[int]time.Duration{
+				RegionV4Latency: map[tailcfg.DERPRegionID]time.Duration{
 					1: 10 * ms,
 					2: 20 * ms,
 					3: 30 * ms,
@@ -884,17 +884,17 @@ func TestLogConciseReport(t *testing.T) {
 				IPv4:          true,
 				IPv6:          true,
 				PreferredDERP: 1,
-				RegionLatency: map[int]time.Duration{
+				RegionLatency: map[tailcfg.DERPRegionID]time.Duration{
 					1: 10 * ms,
 					2: 20 * ms,
 					3: 30 * ms,
 				},
-				RegionV4Latency: map[int]time.Duration{
+				RegionV4Latency: map[tailcfg.DERPRegionID]time.Duration{
 					1: 10 * ms,
 					2: 20 * ms,
 					3: 30 * ms,
 				},
-				RegionV6Latency: map[int]time.Duration{
+				RegionV6Latency: map[tailcfg.DERPRegionID]time.Duration{
 					1: 10 * ms,
 					2: 20 * ms,
 					3: 30 * ms,
@@ -937,9 +937,10 @@ func TestLogConciseReport(t *testing.T) {
 
 func TestSortRegions(t *testing.T) {
 	unsortedMap := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{},
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{},
 	}
-	for rid := 1; rid <= 5; rid++ {
+	for i := range 5 {
+		rid := tailcfg.DERPRegionID(i + 1)
 		var nodes []*tailcfg.DERPNode
 		nodes = append(nodes, &tailcfg.DERPNode{
 			Name:     fmt.Sprintf("%da", rid),
@@ -963,8 +964,8 @@ func TestSortRegions(t *testing.T) {
 
 	// Sorting by latency this should result in rid: 5, 2, 1, 3
 	// rid 4 with latency 0 should be at the end
-	want := []int{5, 2, 1, 3, 4}
-	got := make([]int, len(sortedMap))
+	want := []tailcfg.DERPRegionID{5, 2, 1, 3, 4}
+	got := make([]tailcfg.DERPRegionID, len(sortedMap))
 	for i, r := range sortedMap {
 		got[i] = r.RegionID
 	}
@@ -1106,8 +1107,8 @@ func TestRegionLatencyCompare(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		lat  RegionLatency
-		i    int
-		j    int
+		i    tailcfg.DERPRegionID
+		j    tailcfg.DERPRegionID
 		want int
 	}{
 		{

--- a/net/routecheck/routecheck_test.go
+++ b/net/routecheck/routecheck_test.go
@@ -473,7 +473,7 @@ func makeNode(id tailcfg.NodeID, opts ...nodeOptFunc) tailcfg.NodeView {
 		Name:              fmt.Sprintf("node%d", id),
 		Online:            new(true),
 		MachineAuthorized: true,
-		HomeDERP:          int(id),
+		HomeDERP:          tailcfg.DERPRegionID(id),
 		Addresses:         addresses,
 		AllowedIPs:        addresses,
 	}

--- a/net/stun/stuntest/stuntest.go
+++ b/net/stun/stuntest/stuntest.go
@@ -94,10 +94,10 @@ func runSTUN(t testing.TB, pc nettype.PacketConn, stats *stunStats, done chan<- 
 
 func DERPMapOf(stun ...string) *tailcfg.DERPMap {
 	m := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{},
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{},
 	}
 	for i, hostPortStr := range stun {
-		regionID := i + 1
+		regionID := tailcfg.DERPRegionID(i + 1)
 		host, portStr, err := net.SplitHostPort(hostPortStr)
 		if err != nil {
 			panic(fmt.Sprintf("bogus STUN hostport: %q", hostPortStr))

--- a/prober/derp.go
+++ b/prober/derp.go
@@ -199,7 +199,7 @@ func (d *derpProber) probeMapFn(ctx context.Context) error {
 		for _, server := range region.Nodes {
 			labels := Labels{
 				"region":    region.RegionCode,
-				"region_id": strconv.Itoa(region.RegionID),
+				"region_id": region.RegionID.String(),
 				"hostname":  server.HostName,
 			}
 
@@ -643,7 +643,7 @@ func (d *derpProber) ProbeUDP(ipaddr string, port int) ProbeClass {
 }
 
 func (d *derpProber) skipRegion(region *tailcfg.DERPRegion) bool {
-	return d.regionCodeOrID != "" && region.RegionCode != d.regionCodeOrID && strconv.Itoa(region.RegionID) != d.regionCodeOrID
+	return d.regionCodeOrID != "" && region.RegionCode != d.regionCodeOrID && region.RegionID.String() != d.regionCodeOrID
 }
 
 func derpProbeUDP(ctx context.Context, ipStr string, port int) error {

--- a/prober/derp_test.go
+++ b/prober/derp_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestDerpProber(t *testing.T) {
 	dm := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			0: {
 				RegionID:   0,
 				RegionCode: "zero",

--- a/tailcfg/derpmap.go
+++ b/tailcfg/derpmap.go
@@ -4,8 +4,10 @@
 package tailcfg
 
 import (
+	"fmt"
 	"net/netip"
-	"sort"
+	"slices"
+	"strconv"
 
 	"tailscale.com/types/key"
 )
@@ -25,7 +27,7 @@ type DERPMap struct {
 	// It's keyed by the DERPRegion.RegionID.
 	//
 	// The numbers are not necessarily contiguous.
-	Regions map[int]*DERPRegion
+	Regions map[DERPRegionID]*DERPRegion
 
 	// OmitDefaultRegions specifies to not use Tailscale's DERP servers, and only use those
 	// specified in this DERPMap. If there are none set outside of the defaults, this is a noop.
@@ -34,13 +36,13 @@ type DERPMap struct {
 	OmitDefaultRegions bool `json:"omitDefaultRegions,omitempty"`
 }
 
-// / RegionIDs returns the sorted region IDs.
-func (m *DERPMap) RegionIDs() []int {
-	ret := make([]int, 0, len(m.Regions))
+// RegionIDs returns the sorted region IDs.
+func (m *DERPMap) RegionIDs() []DERPRegionID {
+	ret := make([]DERPRegionID, 0, len(m.Regions))
 	for rid := range m.Regions {
 		ret = append(ret, rid)
 	}
-	sort.Ints(ret)
+	slices.Sort(ret)
 	return ret
 }
 
@@ -60,7 +62,48 @@ type DERPHomeParams struct {
 	//
 	// A nil map means no change from the previous value (if any); an empty
 	// non-nil map can be sent to reset all scores back to 1.0.
-	RegionScore map[int]float64 `json:",omitempty"`
+	RegionScore map[DERPRegionID]float64 `json:",omitempty"`
+}
+
+// DERPRegionID is a unique integer for a geographic region.
+//
+// It corresponds to the legacy derpN.tailscale.com hostnames used by older clients.
+// (Older clients will continue to resolve derpN.tailscale.com when contacting peers,
+// rather than use the server-provided DERPMap)
+//
+// It must be non-zero, positive, and guaranteed to fit in a JavaScript number.
+//
+// IDs in range 900-999 are reserved for end users to run their own DERP nodes.
+type DERPRegionID int64
+
+// ParseDERPRegionID parses s and returns a [DERPRegionID].
+// It returns an error if s isn’t a valid region ID.
+func ParseDERPRegionID(s string) (DERPRegionID, error) {
+	id, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	rid := DERPRegionID(id)
+	if !rid.IsValid() {
+		return 0, fmt.Errorf("invalid region ID: %s", s)
+	}
+	return rid, nil
+}
+
+// IsValid reports whether id is non-zero, positive, and fits in a JavaScript number.
+func (id DERPRegionID) IsValid() bool {
+	const maxSafeJavaScriptInteger DERPRegionID = 1<<53 - 1 // Number.MAX_SAFE_INTEGER
+	return id > 0 && id <= maxSafeJavaScriptInteger
+}
+
+// Int64 returns the int64 representation of id.
+func (id DERPRegionID) Int64() int64 {
+	return int64(id)
+}
+
+// String implements the [fmt.Stringer] interface.
+func (id DERPRegionID) String() string {
+	return strconv.FormatInt(int64(id), 10)
 }
 
 // DERPRegion is a geographic region running DERP relay node(s).
@@ -84,7 +127,7 @@ type DERPRegion struct {
 	//
 	// RegionIDs in range 900-999 are reserved for end users to run their
 	// own DERP nodes.
-	RegionID int
+	RegionID DERPRegionID
 
 	// RegionCode is a short name for the region. It's usually a popular
 	// city or airport code in the region: "nyc", "sf", "sin",
@@ -150,7 +193,7 @@ type DERPNode struct {
 
 	// RegionID is the RegionID of the DERPRegion that this node
 	// is running in.
-	RegionID int
+	RegionID DERPRegionID
 
 	// HostName is the DERP node's hostname.
 	//

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -403,7 +403,7 @@ type Node struct {
 	//
 	// HomeDERP may be zero if not (yet) known, but ideally always be non-zero
 	// for magicsock connectivity to function normally.
-	HomeDERP int `json:",omitzero"` // DERP region ID of the node's home DERP
+	HomeDERP DERPRegionID `json:",omitzero"` // DERP region ID of the node's home DERP
 
 	Hostinfo HostinfoView      `json:",omitzero"`
 	Created  time.Time         `json:",omitzero"`
@@ -1108,7 +1108,7 @@ type NetInfo struct {
 	// that are located elsewhere) but PreferredDERP is the region ID
 	// that the node subscribes to traffic at.
 	// Zero means disconnected or unknown.
-	PreferredDERP int `json:",omitzero"`
+	PreferredDERP DERPRegionID `json:",omitzero"`
 
 	// LinkType is the current link type, if known.
 	LinkType string `json:",omitzero"` // "wired", "wifi", "mobile" (LTE, 4G, 3G, etc)
@@ -1963,7 +1963,7 @@ type PingResponse struct {
 
 	// DERPRegionID is non-zero DERP region ID if DERP was used.
 	// It is not currently set for TSMP pings.
-	DERPRegionID int `json:",omitempty"`
+	DERPRegionID DERPRegionID `json:",omitempty"`
 
 	// DERPRegionCode is the three-letter region code
 	// corresponding to DERPRegionID.
@@ -3355,7 +3355,7 @@ type PeerChange struct {
 
 	// DERPRegion, if non-zero, means that NodeID's home DERP
 	// region ID is now this number.
-	DERPRegion int `json:",omitzero"`
+	DERPRegion DERPRegionID `json:",omitzero"`
 
 	// Cap, if non-zero, means that NodeID's capability version has changed.
 	Cap CapabilityVersion `json:",omitzero"`

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -407,7 +407,7 @@ type Node struct {
 	//
 	// HomeDERP may be zero if not (yet) known, but ideally always be non-zero
 	// for magicsock connectivity to function normally.
-	HomeDERP int `json:",omitzero"` // DERP region ID of the node's home DERP
+	HomeDERP DERPRegionID `json:",omitzero"` // DERP region ID of the node's home DERP
 
 	Hostinfo HostinfoView      `json:",omitzero"`
 	Created  time.Time         `json:",omitzero"`
@@ -1112,7 +1112,7 @@ type NetInfo struct {
 	// that are located elsewhere) but PreferredDERP is the region ID
 	// that the node subscribes to traffic at.
 	// Zero means disconnected or unknown.
-	PreferredDERP int `json:",omitzero"`
+	PreferredDERP DERPRegionID `json:",omitzero"`
 
 	// LinkType is the current link type, if known.
 	LinkType string `json:",omitzero"` // "wired", "wifi", "mobile" (LTE, 4G, 3G, etc)
@@ -1945,7 +1945,7 @@ type PingResponse struct {
 
 	// DERPRegionID is non-zero DERP region ID if DERP was used.
 	// It is not currently set for TSMP pings.
-	DERPRegionID int `json:",omitempty"`
+	DERPRegionID DERPRegionID `json:",omitempty"`
 
 	// DERPRegionCode is the three-letter region code
 	// corresponding to DERPRegionID.
@@ -3015,7 +3015,7 @@ type PeerChange struct {
 
 	// DERPRegion, if non-zero, means that NodeID's home DERP
 	// region ID is now this number.
-	DERPRegion int `json:",omitzero"`
+	DERPRegion DERPRegionID `json:",omitzero"`
 
 	// Cap, if non-zero, means that NodeID's capability version has changed.
 	Cap CapabilityVersion `json:",omitzero"`

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -100,7 +100,7 @@ var _NodeCloneNeedsRegeneration = Node(struct {
 	AllowedIPs                    []netip.Prefix
 	Endpoints                     []netip.AddrPort
 	LegacyDERPString              string
-	HomeDERP                      int
+	HomeDERP                      DERPRegionID
 	Hostinfo                      HostinfoView
 	Created                       time.Time
 	Cap                           CapabilityVersion
@@ -217,7 +217,7 @@ var _NetInfoCloneNeedsRegeneration = NetInfo(struct {
 	UPnP                  opt.Bool
 	PMP                   opt.Bool
 	PCP                   opt.Bool
-	PreferredDERP         int
+	PreferredDERP         DERPRegionID
 	LinkType              string
 	DERPLatency           map[string]float64
 	FirewallMode          string
@@ -408,7 +408,7 @@ func (src *DERPHomeParams) Clone() *DERPHomeParams {
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _DERPHomeParamsCloneNeedsRegeneration = DERPHomeParams(struct {
-	RegionScore map[int]float64
+	RegionScore map[DERPRegionID]float64
 }{})
 
 // Clone makes a deep copy of DERPRegion.
@@ -434,7 +434,7 @@ func (src *DERPRegion) Clone() *DERPRegion {
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _DERPRegionCloneNeedsRegeneration = DERPRegion(struct {
-	RegionID        int
+	RegionID        DERPRegionID
 	RegionCode      string
 	RegionName      string
 	Latitude        float64
@@ -454,7 +454,7 @@ func (src *DERPMap) Clone() *DERPMap {
 	*dst = *src
 	dst.HomeParams = src.HomeParams.Clone()
 	if dst.Regions != nil {
-		dst.Regions = map[int]*DERPRegion{}
+		dst.Regions = map[DERPRegionID]*DERPRegion{}
 		for k, v := range src.Regions {
 			if v == nil {
 				dst.Regions[k] = nil
@@ -469,7 +469,7 @@ func (src *DERPMap) Clone() *DERPMap {
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _DERPMapCloneNeedsRegeneration = DERPMap(struct {
 	HomeParams         *DERPHomeParams
-	Regions            map[int]*DERPRegion
+	Regions            map[DERPRegionID]*DERPRegion
 	OmitDefaultRegions bool
 }{})
 
@@ -487,7 +487,7 @@ func (src *DERPNode) Clone() *DERPNode {
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _DERPNodeCloneNeedsRegeneration = DERPNode(struct {
 	Name             string
-	RegionID         int
+	RegionID         DERPRegionID
 	HostName         string
 	CertName         string
 	IPv4             string

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -99,7 +99,7 @@ var _NodeCloneNeedsRegeneration = Node(struct {
 	AllowedIPs                    []netip.Prefix
 	Endpoints                     []netip.AddrPort
 	LegacyDERPString              string
-	HomeDERP                      int
+	HomeDERP                      DERPRegionID
 	Hostinfo                      HostinfoView
 	Created                       time.Time
 	Cap                           CapabilityVersion
@@ -216,7 +216,7 @@ var _NetInfoCloneNeedsRegeneration = NetInfo(struct {
 	UPnP                  opt.Bool
 	PMP                   opt.Bool
 	PCP                   opt.Bool
-	PreferredDERP         int
+	PreferredDERP         DERPRegionID
 	LinkType              string
 	DERPLatency           map[string]float64
 	FirewallMode          string
@@ -407,7 +407,7 @@ func (src *DERPHomeParams) Clone() *DERPHomeParams {
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _DERPHomeParamsCloneNeedsRegeneration = DERPHomeParams(struct {
-	RegionScore map[int]float64
+	RegionScore map[DERPRegionID]float64
 }{})
 
 // Clone makes a deep copy of DERPRegion.
@@ -433,7 +433,7 @@ func (src *DERPRegion) Clone() *DERPRegion {
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _DERPRegionCloneNeedsRegeneration = DERPRegion(struct {
-	RegionID        int
+	RegionID        DERPRegionID
 	RegionCode      string
 	RegionName      string
 	Latitude        float64
@@ -453,7 +453,7 @@ func (src *DERPMap) Clone() *DERPMap {
 	*dst = *src
 	dst.HomeParams = src.HomeParams.Clone()
 	if dst.Regions != nil {
-		dst.Regions = map[int]*DERPRegion{}
+		dst.Regions = map[DERPRegionID]*DERPRegion{}
 		for k, v := range src.Regions {
 			if v == nil {
 				dst.Regions[k] = nil
@@ -468,7 +468,7 @@ func (src *DERPMap) Clone() *DERPMap {
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _DERPMapCloneNeedsRegeneration = DERPMap(struct {
 	HomeParams         *DERPHomeParams
-	Regions            map[int]*DERPRegion
+	Regions            map[DERPRegionID]*DERPRegion
 	OmitDefaultRegions bool
 }{})
 
@@ -486,7 +486,7 @@ func (src *DERPNode) Clone() *DERPNode {
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _DERPNodeCloneNeedsRegeneration = DERPNode(struct {
 	Name             string
-	RegionID         int
+	RegionID         DERPRegionID
 	HostName         string
 	CertName         string
 	IPv4             string

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -230,7 +230,7 @@ func (v NodeView) LegacyDERPString() string { return v.ж.LegacyDERPString }
 //
 // HomeDERP may be zero if not (yet) known, but ideally always be non-zero
 // for magicsock connectivity to function normally.
-func (v NodeView) HomeDERP() int          { return v.ж.HomeDERP }
+func (v NodeView) HomeDERP() DERPRegionID { return v.ж.HomeDERP }
 func (v NodeView) Hostinfo() HostinfoView { return v.ж.Hostinfo }
 func (v NodeView) Created() time.Time     { return v.ж.Created }
 
@@ -393,7 +393,7 @@ var _NodeViewNeedsRegeneration = Node(struct {
 	AllowedIPs                    []netip.Prefix
 	Endpoints                     []netip.AddrPort
 	LegacyDERPString              string
-	HomeDERP                      int
+	HomeDERP                      DERPRegionID
 	Hostinfo                      HostinfoView
 	Created                       time.Time
 	Cap                           CapabilityVersion
@@ -794,7 +794,7 @@ func (v NetInfoView) PCP() opt.Bool { return v.ж.PCP }
 // that are located elsewhere) but PreferredDERP is the region ID
 // that the node subscribes to traffic at.
 // Zero means disconnected or unknown.
-func (v NetInfoView) PreferredDERP() int { return v.ж.PreferredDERP }
+func (v NetInfoView) PreferredDERP() DERPRegionID { return v.ж.PreferredDERP }
 
 // LinkType is the current link type, if known.
 func (v NetInfoView) LinkType() string { return v.ж.LinkType }
@@ -829,7 +829,7 @@ var _NetInfoViewNeedsRegeneration = NetInfo(struct {
 	UPnP                  opt.Bool
 	PMP                   opt.Bool
 	PCP                   opt.Bool
-	PreferredDERP         int
+	PreferredDERP         DERPRegionID
 	LinkType              string
 	DERPLatency           map[string]float64
 	FirewallMode          string
@@ -1499,13 +1499,13 @@ func (v *DERPHomeParamsView) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 //
 // A nil map means no change from the previous value (if any); an empty
 // non-nil map can be sent to reset all scores back to 1.0.
-func (v DERPHomeParamsView) RegionScore() views.Map[int, float64] {
+func (v DERPHomeParamsView) RegionScore() views.Map[DERPRegionID, float64] {
 	return views.MapOf(v.ж.RegionScore)
 }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _DERPHomeParamsViewNeedsRegeneration = DERPHomeParams(struct {
-	RegionScore map[int]float64
+	RegionScore map[DERPRegionID]float64
 }{})
 
 // View returns a read-only view of DERPRegion.
@@ -1587,7 +1587,7 @@ func (v *DERPRegionView) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 //
 // RegionIDs in range 900-999 are reserved for end users to run their
 // own DERP nodes.
-func (v DERPRegionView) RegionID() int { return v.ж.RegionID }
+func (v DERPRegionView) RegionID() DERPRegionID { return v.ж.RegionID }
 
 // RegionCode is a short name for the region. It's usually a popular
 // city or airport code in the region: "nyc", "sf", "sin",
@@ -1646,7 +1646,7 @@ func (v DERPRegionView) Nodes() views.SliceView[*DERPNode, DERPNodeView] {
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _DERPRegionViewNeedsRegeneration = DERPRegion(struct {
-	RegionID        int
+	RegionID        DERPRegionID
 	RegionCode      string
 	RegionName      string
 	Latitude        float64
@@ -1733,7 +1733,7 @@ func (v DERPMapView) HomeParams() DERPHomeParamsView { return v.ж.HomeParams.Vi
 // It's keyed by the DERPRegion.RegionID.
 //
 // The numbers are not necessarily contiguous.
-func (v DERPMapView) Regions() views.MapFn[int, *DERPRegion, DERPRegionView] {
+func (v DERPMapView) Regions() views.MapFn[DERPRegionID, *DERPRegion, DERPRegionView] {
 	return views.MapFnOf(v.ж.Regions, func(t *DERPRegion) DERPRegionView {
 		return t.View()
 	})
@@ -1748,7 +1748,7 @@ func (v DERPMapView) OmitDefaultRegions() bool { return v.ж.OmitDefaultRegions 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _DERPMapViewNeedsRegeneration = DERPMap(struct {
 	HomeParams         *DERPHomeParams
-	Regions            map[int]*DERPRegion
+	Regions            map[DERPRegionID]*DERPRegion
 	OmitDefaultRegions bool
 }{})
 
@@ -1827,7 +1827,7 @@ func (v DERPNodeView) Name() string { return v.ж.Name }
 
 // RegionID is the RegionID of the DERPRegion that this node
 // is running in.
-func (v DERPNodeView) RegionID() int { return v.ж.RegionID }
+func (v DERPNodeView) RegionID() DERPRegionID { return v.ж.RegionID }
 
 // HostName is the DERP node's hostname.
 //
@@ -1891,7 +1891,7 @@ func (v DERPNodeView) CanPort80() bool { return v.ж.CanPort80 }
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _DERPNodeViewNeedsRegeneration = DERPNode(struct {
 	Name             string
-	RegionID         int
+	RegionID         DERPRegionID
 	HostName         string
 	CertName         string
 	IPv4             string

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -231,7 +231,7 @@ func (v NodeView) LegacyDERPString() string { return v.ж.LegacyDERPString }
 //
 // HomeDERP may be zero if not (yet) known, but ideally always be non-zero
 // for magicsock connectivity to function normally.
-func (v NodeView) HomeDERP() int          { return v.ж.HomeDERP }
+func (v NodeView) HomeDERP() DERPRegionID { return v.ж.HomeDERP }
 func (v NodeView) Hostinfo() HostinfoView { return v.ж.Hostinfo }
 func (v NodeView) Created() time.Time     { return v.ж.Created }
 
@@ -394,7 +394,7 @@ var _NodeViewNeedsRegeneration = Node(struct {
 	AllowedIPs                    []netip.Prefix
 	Endpoints                     []netip.AddrPort
 	LegacyDERPString              string
-	HomeDERP                      int
+	HomeDERP                      DERPRegionID
 	Hostinfo                      HostinfoView
 	Created                       time.Time
 	Cap                           CapabilityVersion
@@ -795,7 +795,7 @@ func (v NetInfoView) PCP() opt.Bool { return v.ж.PCP }
 // that are located elsewhere) but PreferredDERP is the region ID
 // that the node subscribes to traffic at.
 // Zero means disconnected or unknown.
-func (v NetInfoView) PreferredDERP() int { return v.ж.PreferredDERP }
+func (v NetInfoView) PreferredDERP() DERPRegionID { return v.ж.PreferredDERP }
 
 // LinkType is the current link type, if known.
 func (v NetInfoView) LinkType() string { return v.ж.LinkType }
@@ -830,7 +830,7 @@ var _NetInfoViewNeedsRegeneration = NetInfo(struct {
 	UPnP                  opt.Bool
 	PMP                   opt.Bool
 	PCP                   opt.Bool
-	PreferredDERP         int
+	PreferredDERP         DERPRegionID
 	LinkType              string
 	DERPLatency           map[string]float64
 	FirewallMode          string
@@ -1500,13 +1500,13 @@ func (v *DERPHomeParamsView) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 //
 // A nil map means no change from the previous value (if any); an empty
 // non-nil map can be sent to reset all scores back to 1.0.
-func (v DERPHomeParamsView) RegionScore() views.Map[int, float64] {
+func (v DERPHomeParamsView) RegionScore() views.Map[DERPRegionID, float64] {
 	return views.MapOf(v.ж.RegionScore)
 }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _DERPHomeParamsViewNeedsRegeneration = DERPHomeParams(struct {
-	RegionScore map[int]float64
+	RegionScore map[DERPRegionID]float64
 }{})
 
 // View returns a read-only view of DERPRegion.
@@ -1588,7 +1588,7 @@ func (v *DERPRegionView) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 //
 // RegionIDs in range 900-999 are reserved for end users to run their
 // own DERP nodes.
-func (v DERPRegionView) RegionID() int { return v.ж.RegionID }
+func (v DERPRegionView) RegionID() DERPRegionID { return v.ж.RegionID }
 
 // RegionCode is a short name for the region. It's usually a popular
 // city or airport code in the region: "nyc", "sf", "sin",
@@ -1647,7 +1647,7 @@ func (v DERPRegionView) Nodes() views.SliceView[*DERPNode, DERPNodeView] {
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _DERPRegionViewNeedsRegeneration = DERPRegion(struct {
-	RegionID        int
+	RegionID        DERPRegionID
 	RegionCode      string
 	RegionName      string
 	Latitude        float64
@@ -1734,7 +1734,7 @@ func (v DERPMapView) HomeParams() DERPHomeParamsView { return v.ж.HomeParams.Vi
 // It's keyed by the DERPRegion.RegionID.
 //
 // The numbers are not necessarily contiguous.
-func (v DERPMapView) Regions() views.MapFn[int, *DERPRegion, DERPRegionView] {
+func (v DERPMapView) Regions() views.MapFn[DERPRegionID, *DERPRegion, DERPRegionView] {
 	return views.MapFnOf(v.ж.Regions, func(t *DERPRegion) DERPRegionView {
 		return t.View()
 	})
@@ -1749,7 +1749,7 @@ func (v DERPMapView) OmitDefaultRegions() bool { return v.ж.OmitDefaultRegions 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _DERPMapViewNeedsRegeneration = DERPMap(struct {
 	HomeParams         *DERPHomeParams
-	Regions            map[int]*DERPRegion
+	Regions            map[DERPRegionID]*DERPRegion
 	OmitDefaultRegions bool
 }{})
 
@@ -1828,7 +1828,7 @@ func (v DERPNodeView) Name() string { return v.ж.Name }
 
 // RegionID is the RegionID of the DERPRegion that this node
 // is running in.
-func (v DERPNodeView) RegionID() int { return v.ж.RegionID }
+func (v DERPNodeView) RegionID() DERPRegionID { return v.ж.RegionID }
 
 // HostName is the DERP node's hostname.
 //
@@ -1892,7 +1892,7 @@ func (v DERPNodeView) CanPort80() bool { return v.ж.CanPort80 }
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _DERPNodeViewNeedsRegeneration = DERPNode(struct {
 	Name             string
-	RegionID         int
+	RegionID         DERPRegionID
 	HostName         string
 	CertName         string
 	IPv4             string

--- a/tstest/integration/integration.go
+++ b/tstest/integration/integration.go
@@ -334,7 +334,7 @@ func RunDERPAndSTUN(t testing.TB, logf logger.Logf, ipAddress string) (derpMap *
 	stunAddr, stunCleanup := stuntest.ServeWithPacketListener(t, nettype.Std{})
 
 	m := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			1: {
 				RegionID:   1,
 				RegionCode: "test",

--- a/tstest/integration/integration.go
+++ b/tstest/integration/integration.go
@@ -335,7 +335,7 @@ func RunDERPAndSTUN(t testing.TB, logf logger.Logf, ipAddress string) (derpMap *
 	stunAddr, stunCleanup := stuntest.ServeWithPacketListener(t, nettype.Std{})
 
 	m := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			1: {
 				RegionID:   1,
 				RegionCode: "test",

--- a/tstest/integration/testcontrol/testcontrol.go
+++ b/tstest/integration/testcontrol/testcontrol.go
@@ -1462,7 +1462,7 @@ func (s *Server) serveMap(w http.ResponseWriter, r *http.Request, mkey key.Machi
 		}
 		endpoints := filterInvalidIPv6Endpoints(req.Endpoints)
 		var hi tailcfg.HostinfoView
-		var newDERP int
+		var newDERP tailcfg.DERPRegionID
 		if req.Hostinfo != nil {
 			hi = req.Hostinfo.View()
 			if ni := hi.NetInfo(); ni.Valid() {

--- a/tstest/integration/testcontrol/testcontrol.go
+++ b/tstest/integration/testcontrol/testcontrol.go
@@ -1445,7 +1445,7 @@ func (s *Server) serveMap(w http.ResponseWriter, r *http.Request, mkey key.Machi
 		}
 		endpoints := filterInvalidIPv6Endpoints(req.Endpoints)
 		var hi tailcfg.HostinfoView
-		var newDERP int
+		var newDERP tailcfg.DERPRegionID
 		if req.Hostinfo != nil {
 			hi = req.Hostinfo.View()
 			if ni := hi.NetInfo(); ni.Valid() {

--- a/tstest/natlab/vmtest/vmtest.go
+++ b/tstest/natlab/vmtest/vmtest.go
@@ -1309,7 +1309,7 @@ func (e *Env) RotateDiscoKey(n *Node) {
 // "force-prefer-derp" debug action, so its reported NetInfo.PreferredDERP is
 // deterministic. The force lives on the long-lived magicsock.Conn and so
 // persists across an in-process profile switch. It fatals the test on error.
-func (e *Env) ForcePreferredDERP(n *Node, region int) {
+func (e *Env) ForcePreferredDERP(n *Node, region tailcfg.DERPRegionID) {
 	e.t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -1802,7 +1802,7 @@ func (e *Env) buildSelfSignedDERPMap() *tailcfg.DERPMap {
 	}
 	src := e.server.ControlServer().DERPMap
 	dm := &tailcfg.DERPMap{
-		Regions: make(map[int]*tailcfg.DERPRegion, len(src.Regions)),
+		Regions: make(map[tailcfg.DERPRegionID]*tailcfg.DERPRegion, len(src.Regions)),
 	}
 	for id, srcRegion := range src.Regions {
 		r := *srcRegion

--- a/tstest/natlab/vnet/vnet.go
+++ b/tstest/natlab/vnet/vnet.go
@@ -987,7 +987,7 @@ var derpHostnames = []string{"derp1.tailscale", "derp2.tailscale"}
 const controlHostname = "control.tailscale"
 
 var derpMap = &tailcfg.DERPMap{
-	Regions: map[int]*tailcfg.DERPRegion{
+	Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 		1: {
 			RegionID:   1,
 			RegionCode: "atlantis",

--- a/types/netmap/nodemut.go
+++ b/types/netmap/nodemut.go
@@ -29,7 +29,7 @@ func (m mutatingNodeID) NodeIDBeingMutated() tailcfg.NodeID { return tailcfg.Nod
 // has changed its DERP home region.
 type NodeMutationDERPHome struct {
 	mutatingNodeID
-	DERPRegion int
+	DERPRegion tailcfg.DERPRegionID
 }
 
 func (m NodeMutationDERPHome) Apply(n *tailcfg.Node) {

--- a/util/deephash/tailscale_types_test.go
+++ b/util/deephash/tailscale_types_test.go
@@ -116,7 +116,7 @@ func getVal() *tailscaleTypes {
 		},
 		&tailcfg.MapResponse{
 			DERPMap: &tailcfg.DERPMap{
-				Regions: map[int]*tailcfg.DERPRegion{
+				Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 					1: {
 						RegionID:   1,
 						RegionCode: "foo",

--- a/wgengine/magicsock/debughttp.go
+++ b/wgengine/magicsock/debughttp.go
@@ -42,7 +42,7 @@ func (c *Conn) ServeHTTPDebug(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "<h2 id=derp><a href=#derp>#</a> DERP</h2><ul>")
 	if c.derpMap != nil {
 		type D struct {
-			regionID   int
+			regionID   tailcfg.DERPRegionID
 			lastWrite  time.Time
 			createTime time.Time
 		}

--- a/wgengine/magicsock/derp.go
+++ b/wgengine/magicsock/derp.go
@@ -45,12 +45,12 @@ const frameReceiveRecordRate = 5 * time.Second
 // current connection for that regionID is dc. (but dc should not be
 // used to write directly; it's owned by the read/write loops)
 type derpRoute struct {
-	regionID int
+	regionID tailcfg.DERPRegionID
 	dc       *derphttp.Client // don't use directly; see comment above
 }
 
 // removeDerpPeerRoute removes a DERP route entry previously added by addDerpPeerRoute.
-func (c *Conn) removeDerpPeerRoute(peer key.NodePublic, regionID int, dc *derphttp.Client) {
+func (c *Conn) removeDerpPeerRoute(peer key.NodePublic, regionID tailcfg.DERPRegionID, dc *derphttp.Client) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	r2 := derpRoute{regionID, dc}
@@ -62,7 +62,7 @@ func (c *Conn) removeDerpPeerRoute(peer key.NodePublic, regionID int, dc *derpht
 // addDerpPeerRoute adds a DERP route entry, noting that peer was seen
 // on DERP node derpID, at least on the connection identified by dc.
 // See issue 150 for details.
-func (c *Conn) addDerpPeerRoute(peer key.NodePublic, regionID int, dc *derphttp.Client) {
+func (c *Conn) addDerpPeerRoute(peer key.NodePublic, regionID tailcfg.DERPRegionID, dc *derphttp.Client) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	mak.Set(&c.derpRoute, peer, derpRoute{regionID, dc})
@@ -79,7 +79,7 @@ func (c *Conn) addDerpPeerRoute(peer key.NodePublic, regionID int, dc *derphttp.
 // first connection.
 //
 // This can also help nodes from a slow or misbehaving control plane.
-func (c *Conn) fallbackDERPRegionForPeer(peer key.NodePublic) (regionID int) {
+func (c *Conn) fallbackDERPRegionForPeer(peer key.NodePublic) (regionID tailcfg.DERPRegionID) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if dr, ok := c.derpRoute[peer]; ok {
@@ -101,7 +101,7 @@ type activeDerp struct {
 }
 
 var (
-	pickDERPFallbackForTests func() int
+	pickDERPFallbackForTests func() tailcfg.DERPRegionID
 	reSTUNHookForTests       func(why string)
 )
 
@@ -111,7 +111,7 @@ var (
 // checks aren't working).
 //
 // c.mu must NOT be held.
-func (c *Conn) pickDERPFallback() int {
+func (c *Conn) pickDERPFallback() tailcfg.DERPRegionID {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -156,7 +156,7 @@ var checkControlHealthDuringNearestDERPInTests = false
 // region that it selected and set (via setNearestDERP).
 //
 // c.mu must NOT be held.
-func (c *Conn) maybeSetNearestDERP(report *netcheck.Report, force bool) (preferredDERP int) {
+func (c *Conn) maybeSetNearestDERP(report *netcheck.Report, force bool) (preferredDERP tailcfg.DERPRegionID) {
 	// Don't change our PreferredDERP if we don't have a connection to
 	// control; if we don't, then we can't inform peers about a DERP home
 	// change, which breaks all connectivity. Even if this DERP region is
@@ -221,14 +221,14 @@ func (c *Conn) maybeSetNearestDERP(report *netcheck.Report, force bool) (preferr
 // into the netmap at the controlClient mapSession level once there is a stable
 // abstraction to use.
 type HomeDERPChanged struct {
-	Old, New int
+	Old, New tailcfg.DERPRegionID
 }
 
-func (c *Conn) ForceSetNearestDERP(regionID int) int {
+func (c *Conn) ForceSetNearestDERP(regionID tailcfg.DERPRegionID) tailcfg.DERPRegionID {
 	return c.maybeSetNearestDERP(&netcheck.Report{PreferredDERP: regionID}, true)
 }
 
-func (c *Conn) derpRegionCodeLocked(regionID int) string {
+func (c *Conn) derpRegionCodeLocked(regionID tailcfg.DERPRegionID) string {
 	if c.derpMap == nil {
 		return ""
 	}
@@ -241,14 +241,14 @@ func (c *Conn) derpRegionCodeLocked(regionID int) string {
 // setHomeDERPGaugeLocked updates the home DERP gauge metric.
 //
 // c.mu must be held.
-func (c *Conn) setHomeDERPGaugeLocked(derpNum int) {
+func (c *Conn) setHomeDERPGaugeLocked(derpNum tailcfg.DERPRegionID) {
 	if c.homeDERPGauge != nil {
 		c.homeDERPGauge.Set(float64(derpNum))
 	}
 }
 
 // c.mu must NOT be held.
-func (c *Conn) setNearestDERP(derpNum int) (wantDERP bool) {
+func (c *Conn) setNearestDERP(derpNum tailcfg.DERPRegionID) (wantDERP bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if !c.wantDerpLocked() {
@@ -306,7 +306,7 @@ func (c *Conn) startDerpHomeConnectLocked() {
 // DERP region ID.
 //
 // c.mu may be held, but does not need to be.
-func (c *Conn) goDerpConnect(regionID int) {
+func (c *Conn) goDerpConnect(regionID tailcfg.DERPRegionID) {
 	if regionID == 0 {
 		return
 	}
@@ -336,7 +336,7 @@ const derpWriteQueueDepth = 32
 //
 // It returns nil if the network is down, the Conn is closed, or the regionID is
 // not known.
-func (c *Conn) derpWriteChanForRegion(regionID int, peer key.NodePublic) chan derpWriteRequest {
+func (c *Conn) derpWriteChanForRegion(regionID tailcfg.DERPRegionID, peer key.NodePublic) chan derpWriteRequest {
 	if c.networkDown() {
 		return nil
 	}
@@ -390,8 +390,8 @@ func (c *Conn) derpWriteChanForRegion(regionID int, peer key.NodePublic) chan de
 	firstDerp := false
 	if c.activeDerp == nil {
 		firstDerp = true
-		c.activeDerp = make(map[int]activeDerp)
-		c.prevDerp = make(map[int]*syncs.WaitGroupChan)
+		c.activeDerp = make(map[tailcfg.DERPRegionID]activeDerp)
+		c.prevDerp = make(map[tailcfg.DERPRegionID]*syncs.WaitGroupChan)
 	}
 
 	// Note that derphttp.NewRegionClient does not dial the server
@@ -481,7 +481,7 @@ func (c *Conn) derpWriteChanForRegion(regionID int, peer key.NodePublic) chan de
 // If there's any change, it logs.
 //
 // c.mu must be held.
-func (c *Conn) setPeerLastDerpLocked(peer key.NodePublic, regionID, homeID int) {
+func (c *Conn) setPeerLastDerpLocked(peer key.NodePublic, regionID, homeID tailcfg.DERPRegionID) {
 	if peer.IsZero() {
 		return
 	}
@@ -517,7 +517,7 @@ func (c *Conn) setPeerLastDerpLocked(peer key.NodePublic, regionID, homeID int) 
 // get at the packet contents they need to call copyBuf to copy it
 // out, which also releases the buffer.
 type derpReadResult struct {
-	regionID int
+	regionID tailcfg.DERPRegionID
 	n        int // length of data received
 	src      key.NodePublic
 	// copyBuf is called to copy the data to dst.  It returns how
@@ -530,7 +530,7 @@ type derpReadResult struct {
 
 // runDerpReader runs in a goroutine for the life of a DERP
 // connection, handling received packets.
-func (c *Conn) runDerpReader(ctx context.Context, regionID int, dc *derphttp.Client, wg *syncs.WaitGroupChan, startGate <-chan struct{}) {
+func (c *Conn) runDerpReader(ctx context.Context, regionID tailcfg.DERPRegionID, dc *derphttp.Client, wg *syncs.WaitGroupChan, startGate <-chan struct{}) {
 	defer wg.Decr()
 	defer dc.Close()
 
@@ -734,7 +734,7 @@ func (c *Conn) processDERPReadResult(dm derpReadResult, b []byte) (n int, ep *en
 	if dm.copyBuf == nil {
 		return 0, nil
 	}
-	var regionID int
+	var regionID tailcfg.DERPRegionID
 	n, regionID = dm.n, dm.regionID
 	ncopy := dm.copyBuf(b)
 	if ncopy != n {
@@ -778,7 +778,7 @@ func (c *Conn) processDERPReadResult(dm derpReadResult, b []byte) (n int, ep *en
 // SendDERPPacketTo sends an arbitrary packet to the given node key via
 // the DERP relay for the given region. It creates the DERP connection
 // to the region if one doesn't already exist.
-func (c *Conn) SendDERPPacketTo(dstKey key.NodePublic, regionID int, pkt []byte) (sent bool, err error) {
+func (c *Conn) SendDERPPacketTo(dstKey key.NodePublic, regionID tailcfg.DERPRegionID, pkt []byte) (sent bool, err error) {
 	return c.sendAddr(
 		netip.AddrPortFrom(tailcfg.DerpMagicIPAddr, uint16(regionID)),
 		dstKey, pkt, false, false)
@@ -823,7 +823,7 @@ func (c *Conn) setDERPMap(dm *tailcfg.DERPMap, doReStun bool) {
 		}
 		dm = &tailcfg.DERPMap{
 			OmitDefaultRegions: true,
-			Regions: map[int]*tailcfg.DERPRegion{
+			Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 				999: {
 					RegionID: 999,
 					Nodes: []*tailcfg.DERPNode{{
@@ -940,7 +940,7 @@ func (c *Conn) maybeCloseDERPsOnRebind(okayLocalIPs []netip.Prefix) {
 // why is a reason for logging.
 //
 // c.mu must be held.
-func (c *Conn) closeOrReconnectDERPLocked(regionID int, why string) {
+func (c *Conn) closeOrReconnectDERPLocked(regionID tailcfg.DERPRegionID, why string) {
 	c.closeDerpLocked(regionID, why)
 	if !c.privateKey.IsZero() && c.myDerp == regionID {
 		c.startDerpHomeConnectLocked()
@@ -949,7 +949,7 @@ func (c *Conn) closeOrReconnectDERPLocked(regionID int, why string) {
 
 // c.mu must be held.
 // It is the responsibility of the caller to call logActiveDerpLocked after any set of closes.
-func (c *Conn) closeDerpLocked(regionID int, why string) {
+func (c *Conn) closeDerpLocked(regionID tailcfg.DERPRegionID, why string) {
 	if ad, ok := c.activeDerp[regionID]; ok {
 		c.logf("magicsock: closing connection to derp-%v (%v), age %v", regionID, why, time.Since(ad.createTime).Round(time.Second))
 		go ad.c.Close()
@@ -967,14 +967,14 @@ func (c *Conn) logActiveDerpLocked() {
 			return
 		}
 		buf.WriteString(":")
-		c.foreachActiveDerpSortedLocked(func(node int, ad activeDerp) {
+		c.foreachActiveDerpSortedLocked(func(node tailcfg.DERPRegionID, ad activeDerp) {
 			fmt.Fprintf(buf, " derp-%d=cr%v,wr%v", node, simpleDur(now.Sub(ad.createTime)), simpleDur(now.Sub(*ad.lastWrite)))
 		})
 	}))
 }
 
 // c.mu must be held.
-func (c *Conn) foreachActiveDerpSortedLocked(fn func(regionID int, ad activeDerp)) {
+func (c *Conn) foreachActiveDerpSortedLocked(fn func(regionID tailcfg.DERPRegionID, ad activeDerp)) {
 	if len(c.activeDerp) < 2 {
 		for id, ad := range c.activeDerp {
 			fn(id, ad)
@@ -1040,7 +1040,7 @@ func (c *Conn) DERPs() int {
 	return len(c.activeDerp)
 }
 
-func (c *Conn) derpRegionCodeOfIDLocked(regionID int) string {
+func (c *Conn) derpRegionCodeOfIDLocked(regionID tailcfg.DERPRegionID) string {
 	if c.derpMap == nil {
 		return ""
 	}

--- a/wgengine/magicsock/derp_test.go
+++ b/wgengine/magicsock/derp_test.go
@@ -23,7 +23,7 @@ func CheckDERPHeuristicTimes(t *testing.T) {
 
 func TestForceSetNearestDERP(t *testing.T) {
 	derpMap := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			7: {
 				RegionID:   7,
 				RegionCode: "test",
@@ -77,7 +77,7 @@ func TestForceSetNearestDERP(t *testing.T) {
 
 func TestSetDERPMapDoReStun(t *testing.T) {
 	derpMap1 := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			1: {
 				RegionID:   1,
 				RegionCode: "cph",
@@ -88,7 +88,7 @@ func TestSetDERPMapDoReStun(t *testing.T) {
 		},
 	}
 	derpMap2 := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			2: {
 				RegionID:   2,
 				RegionCode: "inc",

--- a/wgengine/magicsock/endpoint.go
+++ b/wgengine/magicsock/endpoint.go
@@ -2030,7 +2030,7 @@ func (de *endpoint) populatePeerStatus(ps *ipnstate.PeerStatus) {
 	de.mu.Lock()
 	defer de.mu.Unlock()
 
-	ps.Relay = de.c.derpRegionCodeOfIDLocked(int(de.derpAddr.Port()))
+	ps.Relay = de.c.derpRegionCodeOfIDLocked(tailcfg.DERPRegionID(de.derpAddr.Port()))
 
 	if de.lastSendExt.IsZero() {
 		return

--- a/wgengine/magicsock/endpoint.go
+++ b/wgengine/magicsock/endpoint.go
@@ -2022,7 +2022,7 @@ func (de *endpoint) populatePeerStatus(ps *ipnstate.PeerStatus) {
 	de.mu.Lock()
 	defer de.mu.Unlock()
 
-	ps.Relay = de.c.derpRegionCodeOfIDLocked(int(de.derpAddr.Port()))
+	ps.Relay = de.c.derpRegionCodeOfIDLocked(tailcfg.DERPRegionID(de.derpAddr.Port()))
 
 	if de.lastSendExt.IsZero() {
 		return

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -165,12 +165,12 @@ type Conn struct {
 	derpActiveFunc         func()
 	idleFunc               func() time.Duration // nil means unknown
 	testOnlyPacketListener nettype.PacketListener
-	onDERPRecv             func(int, key.NodePublic, []byte) bool // or nil, see Options.OnDERPRecv
-	netMon                 *netmon.Monitor                        // must be non-nil
-	health                 *health.Tracker                        // or nil
-	extraRootCAs           *x509.CertPool                         // additional trusted root CAs; or nil
-	controlKnobs           *controlknobs.Knobs                    // or nil
-	derpAppName            string                                 // or empty, see Options.DERPAppName
+	onDERPRecv             func(tailcfg.DERPRegionID, key.NodePublic, []byte) bool // or nil, see Options.OnDERPRecv
+	netMon                 *netmon.Monitor                                         // must be non-nil
+	health                 *health.Tracker                                         // or nil
+	extraRootCAs           *x509.CertPool                                          // additional trusted root CAs; or nil
+	controlKnobs           *controlknobs.Knobs                                     // or nil
+	derpAppName            string                                                  // or empty, see Options.DERPAppName
 
 	// ================================================================
 	// No locking required to access these fields, either because
@@ -358,16 +358,16 @@ type Conn struct {
 	self      tailcfg.NodeView                    // from last SetNetworkMap
 	peersByID map[tailcfg.NodeID]tailcfg.NodeView // current peer set, keyed by NodeID. Maintained by SetNetworkMap/UpsertPeer/RemovePeer. Note: per-field NodeMutation patches received in UpdateNetmapDelta are never applied to these snapshots.
 
-	filt               *filter.Filter     // from last SetFilter
-	relayClientEnabled bool               // whether we can allocate UDP relay endpoints on UDP relay servers or receive CallMeMaybeVia messages from peers
-	lastFlags          debugFlags         // at time of last SetNetworkMap
-	privateKey         key.NodePrivate    // WireGuard private key for this node
-	everHadKey         bool               // whether we ever had a non-zero private key
-	myDerp             int                // nearest DERP region ID; 0 means none/unknown
-	homeless           bool               // if true, don't try to find & stay conneted to a DERP home (myDerp will stay 0)
-	derpStarted        chan struct{}      // closed on first connection to DERP; for tests & cleaner Close
-	activeDerp         map[int]activeDerp // DERP regionID -> connection to a node in that region
-	prevDerp           map[int]*syncs.WaitGroupChan
+	filt               *filter.Filter                      // from last SetFilter
+	relayClientEnabled bool                                // whether we can allocate UDP relay endpoints on UDP relay servers or receive CallMeMaybeVia messages from peers
+	lastFlags          debugFlags                          // at time of last SetNetworkMap
+	privateKey         key.NodePrivate                     // WireGuard private key for this node
+	everHadKey         bool                                // whether we ever had a non-zero private key
+	myDerp             tailcfg.DERPRegionID                // nearest DERP region ID; 0 means none/unknown
+	homeless           bool                                // if true, don't try to find & stay conneted to a DERP home (myDerp will stay 0)
+	derpStarted        chan struct{}                       // closed on first connection to DERP; for tests & cleaner Close
+	activeDerp         map[tailcfg.DERPRegionID]activeDerp // DERP regionID -> connection to a node in that region
+	prevDerp           map[tailcfg.DERPRegionID]*syncs.WaitGroupChan
 
 	// derpRoute contains optional alternate routes to use as an
 	// optimization instead of contacting a peer via their home
@@ -380,7 +380,7 @@ type Conn struct {
 
 	// peerLastDerp tracks which DERP node we last used to speak with a
 	// peer. It's only used to quiet logging, so we only log on change.
-	peerLastDerp map[key.NodePublic]int
+	peerLastDerp map[key.NodePublic]tailcfg.DERPRegionID
 
 	// wgPinger is the WireGuard only pinger used for latency measurements.
 	wgPinger lazy.SyncValue[*ping.Pinger]
@@ -522,7 +522,7 @@ type Options struct {
 	// true, the packet is considered handled and is not passed to
 	// WireGuard. The pkt slice is borrowed and must be copied if
 	// the callee needs to retain it.
-	OnDERPRecv func(regionID int, src key.NodePublic, pkt []byte) bool
+	OnDERPRecv func(regionID tailcfg.DERPRegionID, src key.NodePublic, pkt []byte) bool
 }
 
 func (o *Options) logf() logger.Logf {
@@ -584,7 +584,7 @@ func newConn(logf logger.Logf) *Conn {
 		logf:          logf,
 		derpRecvCh:    make(chan derpReadResult, 1), // must be buffered, see issue 3736
 		derpStarted:   make(chan struct{}),
-		peerLastDerp:  make(map[key.NodePublic]int),
+		peerLastDerp:  make(map[key.NodePublic]tailcfg.DERPRegionID),
 		peerMap:       newPeerMap(),
 		discoInfo:     make(map[key.DiscoPublic]*discoInfo),
 		cloudInfo:     cloudinfo.New(logf),
@@ -1223,7 +1223,7 @@ func (c *Conn) populateCLIPingResponseLocked(res *ipnstate.PingResult, latency t
 		}
 		return
 	}
-	regionID := int(ep.ap.Port())
+	regionID := tailcfg.DERPRegionID(ep.ap.Port())
 	res.DERPRegionID = regionID
 	res.DERPRegionCode = c.derpRegionCodeLocked(regionID)
 }
@@ -1674,7 +1674,7 @@ func (c *Conn) sendAddr(addr netip.AddrPort, pubKey key.NodePublic, b []byte, is
 		return c.sendUDP(addr, b, isDisco, isGeneveEncap)
 	}
 
-	regionID := int(addr.Port())
+	regionID := tailcfg.DERPRegionID(addr.Port())
 	ch := c.derpWriteChanForRegion(regionID, pubKey)
 	if ch == nil {
 		metricSendDERPErrorChan.Add(1)
@@ -3983,7 +3983,7 @@ func (c *Conn) UpdateStatus(sb *ipnstate.StatusBuilder) {
 		})
 	}
 
-	c.foreachActiveDerpSortedLocked(func(node int, ad activeDerp) {
+	c.foreachActiveDerpSortedLocked(func(node tailcfg.DERPRegionID, ad activeDerp) {
 		// TODO(bradfitz): add a method to ipnstate.StatusBuilder
 		// to include all the DERP connections we have open
 		// and add it here. See the other caller of foreachActiveDerpSortedLocked.
@@ -4110,7 +4110,7 @@ func (c *Conn) DebugPickNewDERP() error {
 	return errors.New("too few regions")
 }
 
-func (c *Conn) DebugForcePreferDERP(n int) {
+func (c *Conn) DebugForcePreferDERP(n tailcfg.DERPRegionID) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -4377,7 +4377,7 @@ func (c *Conn) AddNetcheckReportForTest(dm *tailcfg.DERPMap, report *netcheck.Re
 // few regions), netcheck's history retains every region measured by the most
 // recent full netcheck, so this can rank regions the latest report did not
 // re-probe. It returns nil if the netcheck client is not yet initialized.
-func (c *Conn) GetDERPRegionLatency() map[int]time.Duration {
+func (c *Conn) GetDERPRegionLatency() map[tailcfg.DERPRegionID]time.Duration {
 	if c.netChecker == nil {
 		return nil
 	}

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -167,12 +167,12 @@ type Conn struct {
 	derpActiveFunc         func()
 	idleFunc               func() time.Duration // nil means unknown
 	testOnlyPacketListener nettype.PacketListener
-	onDERPRecv             func(int, key.NodePublic, []byte) bool // or nil, see Options.OnDERPRecv
-	netMon                 *netmon.Monitor                        // must be non-nil
-	health                 *health.Tracker                        // or nil
-	extraRootCAs           *x509.CertPool                         // additional trusted root CAs; or nil
-	controlKnobs           *controlknobs.Knobs                    // or nil
-	derpAppName            string                                 // or empty, see Options.DERPAppName
+	onDERPRecv             func(tailcfg.DERPRegionID, key.NodePublic, []byte) bool // or nil, see Options.OnDERPRecv
+	netMon                 *netmon.Monitor                                         // must be non-nil
+	health                 *health.Tracker                                         // or nil
+	extraRootCAs           *x509.CertPool                                          // additional trusted root CAs; or nil
+	controlKnobs           *controlknobs.Knobs                                     // or nil
+	derpAppName            string                                                  // or empty, see Options.DERPAppName
 
 	// ================================================================
 	// No locking required to access these fields, either because
@@ -359,16 +359,16 @@ type Conn struct {
 	self      tailcfg.NodeView                    // from last SetNetworkMap
 	peersByID map[tailcfg.NodeID]tailcfg.NodeView // current peer set, keyed by NodeID. Maintained by SetNetworkMap/UpsertPeer/RemovePeer. Note: per-field NodeMutation patches received in UpdateNetmapDelta are never applied to these snapshots.
 
-	filt               *filter.Filter     // from last SetFilter
-	relayClientEnabled bool               // whether we can allocate UDP relay endpoints on UDP relay servers or receive CallMeMaybeVia messages from peers
-	lastFlags          debugFlags         // at time of last SetNetworkMap
-	privateKey         key.NodePrivate    // WireGuard private key for this node
-	everHadKey         bool               // whether we ever had a non-zero private key
-	myDerp             int                // nearest DERP region ID; 0 means none/unknown
-	homeless           bool               // if true, don't try to find & stay conneted to a DERP home (myDerp will stay 0)
-	derpStarted        chan struct{}      // closed on first connection to DERP; for tests & cleaner Close
-	activeDerp         map[int]activeDerp // DERP regionID -> connection to a node in that region
-	prevDerp           map[int]*syncs.WaitGroupChan
+	filt               *filter.Filter                      // from last SetFilter
+	relayClientEnabled bool                                // whether we can allocate UDP relay endpoints on UDP relay servers or receive CallMeMaybeVia messages from peers
+	lastFlags          debugFlags                          // at time of last SetNetworkMap
+	privateKey         key.NodePrivate                     // WireGuard private key for this node
+	everHadKey         bool                                // whether we ever had a non-zero private key
+	myDerp             tailcfg.DERPRegionID                // nearest DERP region ID; 0 means none/unknown
+	homeless           bool                                // if true, don't try to find & stay conneted to a DERP home (myDerp will stay 0)
+	derpStarted        chan struct{}                       // closed on first connection to DERP; for tests & cleaner Close
+	activeDerp         map[tailcfg.DERPRegionID]activeDerp // DERP regionID -> connection to a node in that region
+	prevDerp           map[tailcfg.DERPRegionID]*syncs.WaitGroupChan
 
 	// derpRoute contains optional alternate routes to use as an
 	// optimization instead of contacting a peer via their home
@@ -381,7 +381,7 @@ type Conn struct {
 
 	// peerLastDerp tracks which DERP node we last used to speak with a
 	// peer. It's only used to quiet logging, so we only log on change.
-	peerLastDerp map[key.NodePublic]int
+	peerLastDerp map[key.NodePublic]tailcfg.DERPRegionID
 
 	// wgPinger is the WireGuard only pinger used for latency measurements.
 	wgPinger lazy.SyncValue[*ping.Pinger]
@@ -523,7 +523,7 @@ type Options struct {
 	// true, the packet is considered handled and is not passed to
 	// WireGuard. The pkt slice is borrowed and must be copied if
 	// the callee needs to retain it.
-	OnDERPRecv func(regionID int, src key.NodePublic, pkt []byte) bool
+	OnDERPRecv func(regionID tailcfg.DERPRegionID, src key.NodePublic, pkt []byte) bool
 }
 
 func (o *Options) logf() logger.Logf {
@@ -585,7 +585,7 @@ func newConn(logf logger.Logf) *Conn {
 		logf:          logf,
 		derpRecvCh:    make(chan derpReadResult, 1), // must be buffered, see issue 3736
 		derpStarted:   make(chan struct{}),
-		peerLastDerp:  make(map[key.NodePublic]int),
+		peerLastDerp:  make(map[key.NodePublic]tailcfg.DERPRegionID),
 		peerMap:       newPeerMap(),
 		discoInfo:     make(map[key.DiscoPublic]*discoInfo),
 		cloudInfo:     cloudinfo.New(logf),
@@ -1223,7 +1223,7 @@ func (c *Conn) populateCLIPingResponseLocked(res *ipnstate.PingResult, latency t
 		}
 		return
 	}
-	regionID := int(ep.ap.Port())
+	regionID := tailcfg.DERPRegionID(ep.ap.Port())
 	res.DERPRegionID = regionID
 	res.DERPRegionCode = c.derpRegionCodeLocked(regionID)
 }
@@ -1668,7 +1668,7 @@ func (c *Conn) sendAddr(addr netip.AddrPort, pubKey key.NodePublic, b []byte, is
 		return c.sendUDP(addr, b, isDisco, isGeneveEncap)
 	}
 
-	regionID := int(addr.Port())
+	regionID := tailcfg.DERPRegionID(addr.Port())
 	ch := c.derpWriteChanForRegion(regionID, pubKey)
 	if ch == nil {
 		metricSendDERPErrorChan.Add(1)
@@ -3975,7 +3975,7 @@ func (c *Conn) UpdateStatus(sb *ipnstate.StatusBuilder) {
 		})
 	}
 
-	c.foreachActiveDerpSortedLocked(func(node int, ad activeDerp) {
+	c.foreachActiveDerpSortedLocked(func(node tailcfg.DERPRegionID, ad activeDerp) {
 		// TODO(bradfitz): add a method to ipnstate.StatusBuilder
 		// to include all the DERP connections we have open
 		// and add it here. See the other caller of foreachActiveDerpSortedLocked.
@@ -4102,7 +4102,7 @@ func (c *Conn) DebugPickNewDERP() error {
 	return errors.New("too few regions")
 }
 
-func (c *Conn) DebugForcePreferDERP(n int) {
+func (c *Conn) DebugForcePreferDERP(n tailcfg.DERPRegionID) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -4371,7 +4371,7 @@ func (c *Conn) AddNetcheckReportForTest(dm *tailcfg.DERPMap, report *netcheck.Re
 // few regions), netcheck's history retains every region measured by the most
 // recent full netcheck, so this can rank regions the latest report did not
 // re-probe. It returns nil if the netcheck client is not yet initialized.
-func (c *Conn) GetDERPRegionLatency() map[int]time.Duration {
+func (c *Conn) GetDERPRegionLatency() map[tailcfg.DERPRegionID]time.Duration {
 	if c.netChecker == nil {
 		return nil
 	}

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -128,7 +128,7 @@ func runDERPAndStun(t *testing.T, logf logger.Logf, ln nettype.PacketListener, s
 	stunAddr, stunCleanup := stuntest.ServeWithPacketListener(t, ln)
 
 	m := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			1: {
 				RegionID:   1,
 				RegionCode: "test",
@@ -558,7 +558,7 @@ func TestResetNetInfoLast(t *testing.T) {
 		got <- ni
 	})
 
-	wantCall := func(why string, wantDERP int) {
+	wantCall := func(why string, wantDERP tailcfg.DERPRegionID) {
 		t.Helper()
 		select {
 		case ni := <-got:
@@ -603,7 +603,7 @@ func TestPickDERPFallback(t *testing.T) {
 
 	c := newConn(t.Logf)
 	dm := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			1: {},
 			2: {},
 			3: {},
@@ -630,7 +630,7 @@ func TestPickDERPFallback(t *testing.T) {
 
 	// Test that the pointer value of c is blended in and
 	// distribution over nodes works.
-	got := map[int]int{}
+	got := map[tailcfg.DERPRegionID]int{}
 	for range 50 {
 		c = newConn(t.Logf)
 		c.derpMap = dm
@@ -3268,7 +3268,7 @@ func TestAddrForPingSizeLocked(t *testing.T) {
 
 func TestMaybeSetNearestDERP(t *testing.T) {
 	derpMap := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			1: {
 				RegionID:   1,
 				RegionCode: "test",
@@ -3312,18 +3312,18 @@ func TestMaybeSetNearestDERP(t *testing.T) {
 	}
 
 	// Ensure that our fallback code always picks a deterministic value.
-	tstest.Replace(t, &pickDERPFallbackForTests, func() int { return 31 })
+	tstest.Replace(t, &pickDERPFallbackForTests, func() tailcfg.DERPRegionID { return 31 })
 
 	// Actually test this code path.
 	tstest.Replace(t, &checkControlHealthDuringNearestDERPInTests, true)
 
 	testCases := []struct {
 		name               string
-		old                int
-		reportDERP         int
+		old                tailcfg.DERPRegionID
+		reportDERP         tailcfg.DERPRegionID
 		connectedToControl bool
 		force              bool
-		want               int
+		want               tailcfg.DERPRegionID
 	}{
 		{
 			name:               "connected_with_report_derp",

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -126,7 +126,7 @@ func runDERPAndStun(t *testing.T, logf logger.Logf, ln nettype.PacketListener, s
 	stunAddr, stunCleanup := stuntest.ServeWithPacketListener(t, ln)
 
 	m := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			1: {
 				RegionID:   1,
 				RegionCode: "test",
@@ -556,7 +556,7 @@ func TestResetNetInfoLast(t *testing.T) {
 		got <- ni
 	})
 
-	wantCall := func(why string, wantDERP int) {
+	wantCall := func(why string, wantDERP tailcfg.DERPRegionID) {
 		t.Helper()
 		select {
 		case ni := <-got:
@@ -601,7 +601,7 @@ func TestPickDERPFallback(t *testing.T) {
 
 	c := newConn(t.Logf)
 	dm := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			1: {},
 			2: {},
 			3: {},
@@ -628,7 +628,7 @@ func TestPickDERPFallback(t *testing.T) {
 
 	// Test that the pointer value of c is blended in and
 	// distribution over nodes works.
-	got := map[int]int{}
+	got := map[tailcfg.DERPRegionID]int{}
 	for range 50 {
 		c = newConn(t.Logf)
 		c.derpMap = dm
@@ -3266,7 +3266,7 @@ func TestAddrForPingSizeLocked(t *testing.T) {
 
 func TestMaybeSetNearestDERP(t *testing.T) {
 	derpMap := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			1: {
 				RegionID:   1,
 				RegionCode: "test",
@@ -3310,18 +3310,18 @@ func TestMaybeSetNearestDERP(t *testing.T) {
 	}
 
 	// Ensure that our fallback code always picks a deterministic value.
-	tstest.Replace(t, &pickDERPFallbackForTests, func() int { return 31 })
+	tstest.Replace(t, &pickDERPFallbackForTests, func() tailcfg.DERPRegionID { return 31 })
 
 	// Actually test this code path.
 	tstest.Replace(t, &checkControlHealthDuringNearestDERPInTests, true)
 
 	testCases := []struct {
 		name               string
-		old                int
-		reportDERP         int
+		old                tailcfg.DERPRegionID
+		reportDERP         tailcfg.DERPRegionID
 		connectedToControl bool
 		force              bool
-		want               int
+		want               tailcfg.DERPRegionID
 	}{
 		{
 			name:               "connected_with_report_derp",

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -259,7 +259,7 @@ type Config struct {
 	// true, the packet is considered handled and is not passed to
 	// WireGuard. The pkt slice is borrowed and must be copied if
 	// the callee needs to retain it.
-	OnDERPRecv func(regionID int, src key.NodePublic, pkt []byte) (handled bool)
+	OnDERPRecv func(regionID tailcfg.DERPRegionID, src key.NodePublic, pkt []byte) (handled bool)
 }
 
 // NewFakeUserspaceEngine returns a new userspace engine for testing.

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -260,7 +260,7 @@ type Config struct {
 	// true, the packet is considered handled and is not passed to
 	// WireGuard. The pkt slice is borrowed and must be copied if
 	// the callee needs to retain it.
-	OnDERPRecv func(regionID int, src key.NodePublic, pkt []byte) (handled bool)
+	OnDERPRecv func(regionID tailcfg.DERPRegionID, src key.NodePublic, pkt []byte) (handled bool)
 }
 
 // NewFakeUserspaceEngine returns a new userspace engine for testing.

--- a/wgengine/userspace_test.go
+++ b/wgengine/userspace_test.go
@@ -594,7 +594,7 @@ func TestDERPAppNamePlumbing(t *testing.T) {
 	t.Cleanup(stunCleanup)
 
 	derpMap := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			1: {
 				RegionID:   1,
 				RegionCode: "test",

--- a/wgengine/userspace_test.go
+++ b/wgengine/userspace_test.go
@@ -540,7 +540,7 @@ func TestDERPAppNamePlumbing(t *testing.T) {
 	t.Cleanup(stunCleanup)
 
 	derpMap := &tailcfg.DERPMap{
-		Regions: map[int]*tailcfg.DERPRegion{
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
 			1: {
 				RegionID:   1,
 				RegionCode: "test",


### PR DESCRIPTION
Historically, when DERP regions were switched away from strings to numeric identifiers in PR #14641, `tailcfg.Node.HomeDERP` was declared as an int instead of its own type.

This PR declares a new `tailcfg.DERPRegionID` type, represented by an int64, and converts the following fields to use this type:

- `netcheck.Report.PreferredDERP`
- `netcheck.Report.RegionLatency`
- `netcheck.Report.RegionV4Latency`
- `netcheck.Report.RegionV6Latency`
- `tailcfg.DERPHomeParams.RegionScore`
- `tailcfg.DERPMap.Regions`
- `tailcfg.DERPNode.RegionID`
- `tailcfg.DERPRegion.RegionID`
- `tailcfg.NetInfo.PreferredDERP`
- `tailcfg.Node.HomeDERP`
- `tailcfg.PeerChange.DERPRegion`
- `tailcfg.PingResponse.DERPRegionID`

Note that the original field was an int, while the new field is backed by an int64. This change makes DERPRegionID the same size on both 32-bit and 64-bit architectures.

Fixes: #20165