### PR TITLE
feature/conn25: return unavailable from connector PeerAPI when conn25

### DIFF
--- a/feature/conn25/conn25.go
+++ b/feature/conn25/conn25.go
@@ -100,6 +100,9 @@ func handleConnectorTransitIP(h ipnlocal.PeerAPIHandler, w http.ResponseWriter, 
 		http.Error(w, "miswired", http.StatusInternalServerError)
 		return
 	}
+	if !e.conn25.isConfigured() {
+		http.Error(w, "conn25 not configured", http.StatusServiceUnavailable)
+	}
 	e.handleConnectorTransitIP(h, w, r)
 }
 


### PR DESCRIPTION
not configured

We want all hooks and handlers to do as little as possible if the node is not configured for conn25 or has no configured apps.

Updates tailscale/corp#39033