### PR TITLE
net/dns/resolver: only accept UDP replies from the queried resolver

### DIFF
--- a/net/dns/resolver/forwarder.go
+++ b/net/dns/resolver/forwarder.go
@@ -33,6 +33,7 @@ import (
 	"tailscale.com/health"
 	"tailscale.com/net/dns/publicdns"
 	"tailscale.com/net/dnscache"
+	"tailscale.com/net/netaddr"
 	"tailscale.com/net/neterror"
 	"tailscale.com/net/netmon"
 	"tailscale.com/net/netx"
@@ -114,10 +115,9 @@ const (
 
 // txid identifies a DNS transaction.
 //
-// As the standard DNS Request ID is only 16 bits, we extend it:
-// the lower 32 bits are the zero-extended bits of the DNS Request ID;
-// the upper 32 bits are the CRC32 checksum of the first question in the request.
-// This makes probability of txid collision negligible.
+// It holds the 16-bit DNS Request ID, zero-extended. It used to also carry a
+// CRC32 of the first question in the upper bits, but that was dropped (see
+// getTxID), so on its own it is weak evidence that a reply belongs to a query.
 type txid uint64
 
 // getTxID computes the txid of the given DNS packet.
@@ -824,17 +824,31 @@ func (f *forwarder) sendUDP(ctx context.Context, fq *forwardQuery, rr resolverAn
 
 	// The 1 extra byte is to detect packet truncation.
 	out := make([]byte, maxResponseBytes+1)
-	n, _, err := conn.ReadFromUDPAddrPort(out)
-	if err != nil {
-		if err := ctx.Err(); err != nil {
-			return nil, err
+
+	// A reply is only an answer to our query if it came back from the address
+	// we sent the query to. Anything else is some other host racing the
+	// resolver for our ephemeral port, so drop it and keep reading; the
+	// context deadline closes conn and ends the loop. See RFC 5452, section
+	// 9.1.
+	wantSrc := netaddr.Unmap(ipp)
+	var n int
+	for {
+		var src netip.AddrPort
+		var err error
+		n, src, err = conn.ReadFromUDPAddrPort(out)
+		if err != nil {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			if !neterror.PacketWasTruncated(err) {
+				metricDNSFwdUDPErrorRead.Add(1)
+				return nil, err
+			}
 		}
-		if neterror.PacketWasTruncated(err) {
-			err = nil
-		} else {
-			metricDNSFwdUDPErrorRead.Add(1)
-			return nil, err
+		if netaddr.Unmap(src) == wantSrc {
+			break
 		}
+		metricDNSFwdUDPErrorSrcAddr.Add(1)
 	}
 	truncated := n > maxResponseBytes
 	if truncated {

--- a/net/dns/resolver/forwarder_test.go
+++ b/net/dns/resolver/forwarder_test.go
@@ -1655,3 +1655,54 @@ func TestResolversCustomScheme(t *testing.T) {
 		})
 	}
 }
+
+// TestForwarderUDPResponseSourceAddr checks that a UDP reply is only treated as
+// the answer when it comes back from the address the query was sent to. A
+// packet carrying the right transaction ID from anywhere else must be dropped
+// and the real reply used instead.
+func TestForwarderUDPResponseSourceAddr(t *testing.T) {
+	const domain = "spoofed.example.com."
+
+	upstream, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer upstream.Close()
+
+	// A second socket, on a different port, stands in for any host that can
+	// reach the forwarder's ephemeral port but is not the resolver we asked.
+	offPath, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer offPath.Close()
+
+	request := makeTestRequest(t, domain, dns.TypeA, 0)
+	realResponse := makeTestResponse(t, domain, dns.RCodeSuccess, netip.MustParseAddr("1.2.3.4"))
+	spoofedResponse := makeTestResponse(t, domain, dns.RCodeSuccess, netip.MustParseAddr("6.6.6.6"))
+
+	// Give both replies the transaction ID of the query, so the only thing
+	// separating them is the address they arrive from.
+	copy(realResponse[:2], request[:2])
+	copy(spoofedResponse[:2], request[:2])
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, maxResponseBytes)
+		n, src, err := upstream.ReadFromUDPAddrPort(buf)
+		if err != nil || n < headerBytes {
+			return
+		}
+		offPath.WriteToUDPAddrPort(spoofedResponse, src)
+		time.Sleep(50 * time.Millisecond)
+		upstream.WriteToUDPAddrPort(realResponse, src)
+	}()
+	t.Cleanup(func() { <-done })
+
+	port := uint16(upstream.LocalAddr().(*net.UDPAddr).Port)
+	res := mustRunTestQuery(t, request, nil, port)
+	if !bytes.Equal(res, realResponse) {
+		t.Errorf("got response %x, want %x", res, realResponse)
+	}
+}

--- a/net/dns/resolver/tsdns.go
+++ b/net/dns/resolver/tsdns.go
@@ -1459,6 +1459,7 @@ var (
 	metricDNSFwdUDPErrorServer  = clientmetric.NewCounter("dns_query_fwd_udp_error_server")
 	metricDNSFwdUDPErrorRefused = clientmetric.NewCounter("dns_query_fwd_udp_error_refused")
 	metricDNSFwdUDPErrorTxID    = clientmetric.NewCounter("dns_query_fwd_udp_error_txid")
+	metricDNSFwdUDPErrorSrcAddr = clientmetric.NewCounter("dns_query_fwd_udp_error_srcaddr")
 	metricDNSFwdUDPErrorRead    = clientmetric.NewCounter("dns_query_fwd_udp_error_read")
 	metricDNSFwdUDPSuccess      = clientmetric.NewCounter("dns_query_fwd_udp_success")
 


### PR DESCRIPTION
The forwarder sends each upstream query from a fresh unconnected UDP socket and then takes the first datagram that lands on it, dropping the source address that ReadFromUDPAddrPort hands back. All that ties a reply to its query is getTxID, which is just the 16-bit DNS Request ID now that the CRC32 of the question is gone, and the bytes go back to the client without any question matching. So anything that can reach that ephemeral port with a matching ID gets its answer treated as the resolver's, and because only one read happens the genuine reply is never looked at. What makes it worth closing is that skipping the source check means an off-path attacker never has to forge the resolver's address, which is the part BCP38 egress filtering would normally stop. I noticed it while reading sendUDP next to the PCP path in portmapper, which loops on the same kind of socket and compares src against the gateway before trusting a packet. sendUDP now does the same and keeps reading until the datagram comes from the resolver it queried, with the context deadline still ending the loop the way it did before. I also corrected the txid doc comment, which still described the old 64-bit form and overstates what the ID alone proves.