### PR TITLE
ipn/ipnlocal,net/tstun: add TUN Service packet metrics

### DIFF
--- a/ipn/ipnlocal/fortest.go
+++ b/ipn/ipnlocal/fortest.go
@@ -45,6 +45,7 @@ func (f forTest) SetIPServiceMappings(m netmap.IPServiceMappings) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.ipVIPServiceMap = m
+	b.tunServiceMetrics.updateLocked(b)
 	if ns, ok := b.sys.Netstack.GetOK(); ok {
 		ns.UpdateIPServiceMappings(m)
 	}
@@ -124,6 +125,7 @@ func (f forTest) SetServeConfig(sc ipn.ServeConfigView) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.serveConfig = sc
+	b.tunServiceMetrics.updateLocked(b)
 }
 
 // SetNetMap installs nm as the backend's current netmap without going

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -380,6 +380,8 @@ type LocalBackend struct {
 	serveConfig       ipn.ServeConfigView      // or !Valid if none
 	ipVIPServiceMap   netmap.IPServiceMappings // map of VIPService IPs to their corresponding service names; TODO(nickkhyl): move to nodeBackend
 
+	tunServiceMetrics tunServiceMetricsState
+
 	webClient          webClient
 	webClientListeners map[netip.AddrPort]*localListener // listeners for local web client traffic
 
@@ -604,6 +606,8 @@ func NewLocalBackend(logf logger.Logf, logID logid.PublicID, sys *tsd.System, lo
 		loginFlags:   loginFlags,
 		clock:        clock,
 	}
+
+	b.tunServiceMetrics.init(sys)
 
 	sys.NoiseRoundTripper.Set(noiseRoundTripper{b})
 
@@ -7363,6 +7367,7 @@ func (b *LocalBackend) setNetMapLocked(nm *netmap.NetworkMap) {
 	if buildfeatures.HasServe {
 		m := nm.GetIPVIPServiceMap()
 		b.ipVIPServiceMap = m
+		b.tunServiceMetrics.updateLocked(b)
 		if ns, ok := b.sys.Netstack.GetOK(); ok {
 			ns.UpdateIPServiceMappings(m)
 			// In case the prefs reloaded from Profile Manager but didn't change,

--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -585,6 +585,22 @@ func (b *LocalBackend) meteredConnForService(c net.Conn, svc tailcfg.ServiceName
 	}
 }
 
+// ensureServeMetricSeriesLocked initializes metrics for userspace Services.
+// b.mu must be held.
+func (b *LocalBackend) ensureServeMetricSeriesLocked() {
+	if !b.serveConfig.Valid() || b.metrics.serveBytesInbound == nil || b.metrics.serveBytesOutbound == nil {
+		return
+	}
+	for svc, cfg := range b.serveConfig.Services().All() {
+		if svc == "" || cfg.Tun() {
+			continue
+		}
+		key := serveLabels{Service: svc.String()}
+		b.metrics.serveBytesInbound.Add(key, 0)
+		b.metrics.serveBytesOutbound.Add(key, 0)
+	}
+}
+
 // tcpHandlerForVIPService returns a handler for a TCP connection to a VIP service
 // that is being served via the ipn.ServeConfig. It returns nil if the destination
 // address is not a VIP service or if the VIP service does not have a TCP handler set.
@@ -1613,6 +1629,11 @@ func serveSetTCPPortsInterceptedFromNetmapAndPrefsLocked(b *LocalBackend, prefs 
 // the method to only run the reset-logic and not reload the store from memory to ensure
 // foreground sessions are not removed if they are not saved on disk.
 func (b *LocalBackend) reloadServeConfigLocked(prefs ipn.PrefsView) {
+	defer func() {
+		b.ensureServeMetricSeriesLocked()
+		b.tunServiceMetrics.updateLocked(b)
+	}()
+
 	if !b.currentNode().Self().Valid() || !prefs.Valid() || b.pm.CurrentProfile().ID() == "" {
 		// We're not logged in, so we don't have a profile.
 		// Don't try to load the serve config.

--- a/ipn/ipnlocal/serve_metrics_test.go
+++ b/ipn/ipnlocal/serve_metrics_test.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"testing"
 
+	"tailscale.com/ipn"
 	"tailscale.com/tailcfg"
 	"tailscale.com/util/usermetric"
 )
@@ -78,5 +79,35 @@ func TestServiceMeteredConnLabelKeepsPrefix(t *testing.T) {
 	}
 	if v := counterValue(b.metrics.serveBytesInbound, "my-app"); v != -1 {
 		t.Errorf("counter unexpectedly present under prefix-stripped name; got %d", v)
+	}
+}
+
+func TestServeMetricSeriesCreatedFromConfig(t *testing.T) {
+	b := newTestBackend(t)
+	const (
+		serveService = tailcfg.ServiceName("svc:serve")
+		tunService   = tailcfg.ServiceName("svc:tun")
+	)
+	b.mu.Lock()
+	b.serveConfig = (&ipn.ServeConfig{
+		Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
+			serveService: {},
+			tunService:   {Tun: true},
+		},
+	}).View()
+	b.ensureServeMetricSeriesLocked()
+	b.mu.Unlock()
+
+	if got := counterValue(b.metrics.serveBytesInbound, serveService.String()); got != 0 {
+		t.Errorf("initial inbound = %d; want zero-valued series", got)
+	}
+	if got := counterValue(b.metrics.serveBytesOutbound, serveService.String()); got != 0 {
+		t.Errorf("initial outbound = %d; want zero-valued series", got)
+	}
+	if got := counterValue(b.metrics.serveBytesInbound, tunService.String()); got != -1 {
+		t.Errorf("Serve counter for TUN Service = %d; want absent", got)
+	}
+	if got := counterValue(b.metrics.serveBytesOutbound, tunService.String()); got != -1 {
+		t.Errorf("Serve counter for TUN Service = %d; want absent", got)
 	}
 }

--- a/ipn/ipnlocal/tun_service_metrics.go
+++ b/ipn/ipnlocal/tun_service_metrics.go
@@ -1,0 +1,97 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !ts_omit_serve && !ts_omit_usermetrics
+
+package ipnlocal
+
+import (
+	"expvar"
+	"net/netip"
+
+	"github.com/gaissmai/bart"
+	"tailscale.com/net/tstun"
+	"tailscale.com/tailcfg"
+	"tailscale.com/tsd"
+	"tailscale.com/util/usermetric"
+)
+
+// tunServiceMetricsState manages metrics for kernel TUN Service traffic.
+// Counter series are retained for the lifetime of the process.
+type tunServiceMetricsState struct {
+	inbound  *usermetric.MultiLabelMap[serveLabels]
+	outbound *usermetric.MultiLabelMap[serveLabels]
+
+	enabled bool
+}
+
+func (m *tunServiceMetricsState) init(sys *tsd.System) {
+	m.inbound = usermetric.NewMultiLabelMapWithRegistry[serveLabels](
+		sys.UserMetricsRegistry(),
+		"tailscaled_tun_service_inbound_bytes_total",
+		"counter",
+		"IP packet bytes received from peers through TUN-mode Tailscale Services.")
+	m.outbound = usermetric.NewMultiLabelMapWithRegistry[serveLabels](
+		sys.UserMetricsRegistry(),
+		"tailscaled_tun_service_outbound_bytes_total",
+		"counter",
+		"IP packet bytes sent to peers through TUN-mode Tailscale Services.")
+
+	if sys.IsNetstack() {
+		return
+	}
+	if _, ok := sys.Tun.GetOK(); !ok {
+		return
+	}
+	m.enabled = true
+}
+
+// updateLocked updates TUN Service counters. b.mu must be held.
+func (m *tunServiceMetricsState) updateLocked(b *LocalBackend) {
+	if !m.enabled {
+		return
+	}
+
+	var countersByPrefix *bart.Table[tstun.PacketMetricCounters]
+	if b.serveConfig.Valid() {
+		nonTUNServices := make(map[tailcfg.ServiceName]struct{})
+		for service, cfg := range b.serveConfig.Services().All() {
+			if service != "" && !cfg.Tun() {
+				nonTUNServices[service] = struct{}{}
+			}
+		}
+		for ip, service := range b.ipVIPServiceMap {
+			if service == "" {
+				continue
+			}
+			// Userspace Serve Services are counted by tailscaled_serve_*.
+			if _, ok := nonTUNServices[service]; ok {
+				continue
+			}
+
+			key := serveLabels{Service: service.String()}
+			inbound := ensureIntCounter(m.inbound, key)
+			outbound := ensureIntCounter(m.outbound, key)
+			if inbound == nil || outbound == nil {
+				continue
+			}
+			if countersByPrefix == nil {
+				countersByPrefix = new(bart.Table[tstun.PacketMetricCounters])
+			}
+			countersByPrefix.Insert(netip.PrefixFrom(ip, ip.BitLen()), tstun.PacketMetricCounters{
+				Inbound:  inbound,
+				Outbound: outbound,
+			})
+		}
+	}
+
+	if tun, ok := b.sys.Tun.GetOK(); ok {
+		tun.SetPacketMetricCounters(countersByPrefix)
+	}
+}
+
+func ensureIntCounter(m *usermetric.MultiLabelMap[serveLabels], key serveLabels) *expvar.Int {
+	m.Add(key, 0)
+	v, _ := m.Get(key).(*expvar.Int)
+	return v
+}

--- a/ipn/ipnlocal/tun_service_metrics_disabled.go
+++ b/ipn/ipnlocal/tun_service_metrics_disabled.go
@@ -1,0 +1,13 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build ts_omit_serve || ts_omit_usermetrics
+
+package ipnlocal
+
+import "tailscale.com/tsd"
+
+type tunServiceMetricsState struct{}
+
+func (*tunServiceMetricsState) init(*tsd.System)           {}
+func (*tunServiceMetricsState) updateLocked(*LocalBackend) {}

--- a/ipn/ipnlocal/tun_service_metrics_test.go
+++ b/ipn/ipnlocal/tun_service_metrics_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !ts_omit_serve && !ts_omit_usermetrics
+
+package ipnlocal
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/tailscale/wireguard-go/tun/tuntest"
+	"tailscale.com/ipn"
+	"tailscale.com/net/packet"
+	"tailscale.com/tailcfg"
+	"tailscale.com/tsd"
+	"tailscale.com/types/logger"
+	"tailscale.com/types/netmap"
+	"tailscale.com/util/eventbus/eventbustest"
+	"tailscale.com/wgengine"
+	"tailscale.com/wgengine/filter"
+)
+
+func TestTUNServiceMetricsWiring(t *testing.T) {
+	bus := eventbustest.NewBus(t)
+	channelTUN := tuntest.NewChannelTUN()
+	sys := tsd.NewSystemWithBus(bus)
+	engine, err := wgengine.NewUserspaceEngine(logger.Discard, wgengine.Config{
+		Tun:           channelTUN.TUN(),
+		SetSubsystem:  sys.Set,
+		HealthTracker: sys.HealthTracker.Get(),
+		Metrics:       sys.UserMetricsRegistry(),
+		EventBus:      bus,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sys.Set(engine)
+	t.Cleanup(engine.Close)
+
+	tun := sys.Tun.Get()
+	// Match production, where Wrapper can start before LocalBackend.
+	tun.Start()
+	b := newTestLocalBackendWithSys(t, sys)
+	tun.SetFilter(filter.NewAllowAllForTest(t.Logf))
+
+	serviceIP := netip.MustParseAddr("100.64.0.10")
+	peerIP := netip.MustParseAddr("100.64.0.20")
+	const serviceName = tailcfg.ServiceName("svc:foo")
+	b.ForTest().SetIPServiceMappings(netmap.IPServiceMappings{
+		serviceIP: serviceName,
+	})
+	if got := counterValue(b.tunServiceMetrics.inbound, serviceName.String()); got != -1 {
+		t.Fatalf("inbound before ServeConfig load = %d; want absent", got)
+	}
+
+	b.ForTest().SetServeConfig((&ipn.ServeConfig{
+		Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
+			serviceName: {Tun: true},
+		},
+	}).View())
+
+	if got := counterValue(b.tunServiceMetrics.inbound, serviceName.String()); got != 0 {
+		t.Fatalf("initial inbound = %d; want zero-valued series", got)
+	}
+	if got := counterValue(b.tunServiceMetrics.outbound, serviceName.String()); got != 0 {
+		t.Fatalf("initial outbound = %d; want zero-valued series", got)
+	}
+
+	inboundPacket := packet.Generate(packet.UDP4Header{
+		IP4Header: packet.IP4Header{Src: peerIP, Dst: serviceIP},
+		SrcPort:   1234,
+		DstPort:   5678,
+	}, []byte("request"))
+	delivered := make(chan []byte, 1)
+	go func() { delivered <- <-channelTUN.Inbound }()
+	if n, err := tun.Write([][]byte{inboundPacket}, 0); err != nil || n != 1 {
+		t.Fatalf("Write = %d, %v; want 1, nil", n, err)
+	}
+	<-delivered
+	if got := counterValue(b.tunServiceMetrics.inbound, serviceName.String()); got != int64(len(inboundPacket)) {
+		t.Fatalf("inbound = %d; want %d", got, len(inboundPacket))
+	}
+
+	// Removing an assignment stops attribution but keeps the counter series
+	// for the lifetime of the process.
+	b.ForTest().SetIPServiceMappings(nil)
+	go func() { delivered <- <-channelTUN.Inbound }()
+	if n, err := tun.Write([][]byte{inboundPacket}, 0); err != nil || n != 1 {
+		t.Fatalf("Write after mapping removal = %d, %v; want 1, nil", n, err)
+	}
+	<-delivered
+	if got, want := counterValue(b.tunServiceMetrics.inbound, serviceName.String()), int64(len(inboundPacket)); got != want {
+		t.Fatalf("inbound after mapping removal = %d; want %d", got, want)
+	}
+	if got := counterValue(b.tunServiceMetrics.outbound, serviceName.String()); got != 0 {
+		t.Fatalf("outbound after mapping removal = %d; want 0", got)
+	}
+
+	// Userspace Serve Services are excluded.
+	const userspaceService = tailcfg.ServiceName("svc:userspace")
+	b.ForTest().SetServeConfig((&ipn.ServeConfig{
+		Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
+			userspaceService: {Tun: false},
+		},
+	}).View())
+	b.ForTest().SetIPServiceMappings(netmap.IPServiceMappings{
+		serviceIP: userspaceService,
+	})
+	if got := counterValue(b.tunServiceMetrics.inbound, userspaceService.String()); got != -1 {
+		t.Fatalf("inbound for non-TUN Service = %d; want absent", got)
+	}
+
+	// Kubernetes ingress Services do not have ServeConfig entries.
+	const kernelService = tailcfg.ServiceName("svc:kernel")
+	b.ForTest().SetServeConfig((&ipn.ServeConfig{}).View())
+	b.ForTest().SetIPServiceMappings(netmap.IPServiceMappings{
+		serviceIP: kernelService,
+	})
+	if got := counterValue(b.tunServiceMetrics.inbound, kernelService.String()); got != 0 {
+		t.Fatalf("initial inbound for kernel-forwarded Service = %d; want zero-valued series", got)
+	}
+	if got := counterValue(b.tunServiceMetrics.outbound, kernelService.String()); got != 0 {
+		t.Fatalf("initial outbound for kernel-forwarded Service = %d; want zero-valued series", got)
+	}
+
+	kernelPacket := packet.Generate(packet.UDP4Header{
+		IP4Header: packet.IP4Header{Src: peerIP, Dst: serviceIP},
+		SrcPort:   1234,
+		DstPort:   5678,
+	}, []byte("kernel request"))
+	go func() { delivered <- <-channelTUN.Inbound }()
+	if n, err := tun.Write([][]byte{kernelPacket}, 0); err != nil || n != 1 {
+		t.Fatalf("kernel-forwarded Write = %d, %v; want 1, nil", n, err)
+	}
+	<-delivered
+	if got := counterValue(b.tunServiceMetrics.inbound, kernelService.String()); got != int64(len(kernelPacket)) {
+		t.Fatalf("kernel-forwarded inbound = %d; want %d", got, len(kernelPacket))
+	}
+}

--- a/net/tstun/wrap.go
+++ b/net/tstun/wrap.go
@@ -223,6 +223,8 @@ type Wrapper struct {
 
 	captureHook syncs.AtomicValue[packet.CaptureCallback]
 
+	packetMetricCounters atomic.Pointer[bart.Table[PacketMetricCounters]]
+
 	metrics *metrics
 
 	eventClient              *eventbus.Client
@@ -911,6 +913,7 @@ func (t *Wrapper) Read(buffs [][]byte, sizes []int, offset int) (int, error) {
 				updateConnCounter(update, p.Buffer(), false)
 			}
 		}
+		t.countOutboundPacketMetrics(p)
 
 		// Make sure to do SNAT after filtering, so that any flow tracking in
 		// the filter sees the original source address. See #12133.
@@ -1234,8 +1237,17 @@ func (t *Wrapper) Write(buffs [][]byte, offset int) (int, error) {
 	captHook := t.captureHook.Load()
 	pc := t.peerConfig.Load()
 	var buffsGRO *gro.GRO
+	packetCounters := t.packetMetricCounters.Load()
 	for _, buff := range buffs {
 		p.Decode(buff[offset:])
+		var inboundCounter PacketMetricCounter
+		var inboundBytes int64
+		if packetCounters != nil {
+			if counters, ok := packetCounters.Lookup(p.Dst.Addr()); ok && counters.Inbound != nil {
+				inboundCounter = counters.Inbound
+				inboundBytes = int64(len(p.Buffer()))
+			}
+		}
 		pc.dnat(p)
 		if !t.disableFilter {
 			var res filter.Response
@@ -1245,17 +1257,17 @@ func (t *Wrapper) Write(buffs [][]byte, offset int) (int, error) {
 			res, buffsGRO = t.filterPacketInboundFromWireGuard(p, captHook, pc, buffsGRO)
 			if res != filter.Accept {
 				metricPacketInDrop.Add(1)
-			} else {
-				buffs[i] = buff
-				i++
+				continue
 			}
 		}
+		if inboundCounter != nil {
+			inboundCounter.Add(inboundBytes)
+		}
+		buffs[i] = buff
+		i++
 	}
 	if buffsGRO != nil {
 		buffsGRO.Flush()
-	}
-	if t.disableFilter {
-		i = len(buffs)
 	}
 	buffs = buffs[:i]
 
@@ -1523,6 +1535,42 @@ func (t *Wrapper) InstallCaptureHook(cb packet.CaptureCallback) {
 		return
 	}
 	t.captureHook.Store(cb)
+}
+
+// PacketMetricCounter counts IP packet bytes. Add must be safe for concurrent
+// use and cheap enough to call inline while processing packets.
+type PacketMetricCounter interface {
+	Add(int64)
+}
+
+// PacketMetricCounters contains byte counters for packets attributed to an IP
+// prefix. Inbound packets are matched by destination before DNAT and counted
+// after filtering accepts them for delivery to the TUN. Outbound packets are
+// matched by source after filtering and before SNAT. A nil counter disables
+// accounting for that direction.
+type PacketMetricCounters struct {
+	Inbound  PacketMetricCounter
+	Outbound PacketMetricCounter
+}
+
+// SetPacketMetricCounters atomically replaces the prefix-to-counter table used
+// for packet accounting. Each packet is attributed exclusively to the
+// longest-prefix match. The caller must not mutate the table after calling
+// this method. Passing nil disables packet accounting.
+func (t *Wrapper) SetPacketMetricCounters(counters *bart.Table[PacketMetricCounters]) {
+	t.packetMetricCounters.Store(counters)
+}
+
+func (t *Wrapper) countOutboundPacketMetrics(p *packet.Parsed) {
+	countersByPrefix := t.packetMetricCounters.Load()
+	if countersByPrefix == nil {
+		return
+	}
+	counters, ok := countersByPrefix.Lookup(p.Src.Addr())
+	if !ok || counters.Outbound == nil {
+		return
+	}
+	counters.Outbound.Add(int64(len(p.Buffer())))
 }
 
 func updateConnCounter(update netlogfunc.ConnectionCounter, b []byte, receive bool) {

--- a/net/tstun/wrap_test.go
+++ b/net/tstun/wrap_test.go
@@ -7,12 +7,14 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"expvar"
 	"fmt"
 	"net/netip"
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 	"unicode"
@@ -65,6 +67,25 @@ func udp4(src, dst string, sport, dport uint16) []byte {
 		DstPort: dport,
 	}
 	return packet.Generate(header, []byte("udp_payload"))
+}
+
+func udp6(src, dst string, sport, dport uint16) []byte {
+	sip, err := netip.ParseAddr(src)
+	if err != nil {
+		panic(err)
+	}
+	dip, err := netip.ParseAddr(dst)
+	if err != nil {
+		panic(err)
+	}
+	return packet.Generate(packet.UDP6Header{
+		IP6Header: packet.IP6Header{
+			Src: sip,
+			Dst: dip,
+		},
+		SrcPort: sport,
+		DstPort: dport,
+	}, []byte("udp_payload"))
 }
 
 func tcp4syn(src, dst string, sport, dport uint16) []byte {
@@ -197,6 +218,14 @@ func newFakeTUN(logf logger.Logf, bus *eventbus.Bus, secure bool) (*fakeTUN, *Wr
 		tun.disableFilter = true
 	}
 	return ftun.(*fakeTUN), tun
+}
+
+type writeErrorTUN struct {
+	*fakeTUN
+}
+
+func (*writeErrorTUN) Write([][]byte, int) (int, error) {
+	return 0, errors.New("test TUN write error")
 }
 
 func TestReadAndInject(t *testing.T) {
@@ -582,6 +611,49 @@ func BenchmarkWrite(b *testing.B) {
 	}
 }
 
+func packetMetricTableByIP(counters map[netip.Addr]PacketMetricCounters) *bart.Table[PacketMetricCounters] {
+	if len(counters) == 0 {
+		return nil
+	}
+	table := new(bart.Table[PacketMetricCounters])
+	for ip, counters := range counters {
+		table.Insert(netip.PrefixFrom(ip, ip.BitLen()), counters)
+	}
+	return table
+}
+
+func BenchmarkWrapperWritePacketMetrics(b *testing.B) {
+	dstIP := netip.MustParseAddr("1.2.3.4")
+	packet := [][]byte{udp4("5.6.7.8", dstIP.String(), 89, 89)}
+	for _, tt := range []struct {
+		name     string
+		counters *bart.Table[PacketMetricCounters]
+	}{
+		{name: "disabled"},
+		{
+			name: "matched",
+			counters: packetMetricTableByIP(map[netip.Addr]PacketMetricCounters{
+				dstIP: {Inbound: new(expvar.Int), Outbound: new(expvar.Int)},
+			}),
+		},
+	} {
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			bus := eventbustest.NewBus(b)
+			_, tw := newFakeTUN(b.Logf, bus, true)
+			defer tw.Close()
+			tw.SetFilter(filter.NewAllowAllForTest(b.Logf))
+			tw.SetPacketMetricCounters(tt.counters)
+			b.ResetTimer()
+			for range b.N {
+				if _, err := tw.Write(packet, 0); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
 func TestAtomic64Alignment(t *testing.T) {
 	off := unsafe.Offsetof(Wrapper{}.lastActivityAtomic)
 	if off%8 != 0 {
@@ -590,6 +662,209 @@ func TestAtomic64Alignment(t *testing.T) {
 
 	c := new(Wrapper)
 	c.lastActivityAtomic.StoreAtomic(mono.Now())
+}
+
+func TestPacketMetricCounters(t *testing.T) {
+	service4 := netip.MustParseAddr("1.2.3.4")
+	peer4 := netip.MustParseAddr("5.6.7.8")
+	service6 := netip.MustParseAddr("fd7a:115c:a1e0::10")
+	peer6 := netip.MustParseAddr("fd7a:115c:a1e0::20")
+
+	t.Run("inbound_accepted_packets", func(t *testing.T) {
+		bus := eventbustest.NewBus(t)
+		_, tw := newFakeTUN(t.Logf, bus, true)
+		defer tw.Close()
+		tw.SetFilter(filter.NewAllowAllForTest(t.Logf))
+
+		var inbound, outbound expvar.Int
+		tw.SetPacketMetricCounters(packetMetricTableByIP(map[netip.Addr]PacketMetricCounters{
+			service4: {Inbound: &inbound, Outbound: &outbound},
+			service6: {Inbound: &inbound, Outbound: &outbound},
+		}))
+
+		// Attribute the packet before DNAT changes its destination.
+		routes := new(bart.Table[*routemanager.PeerRoute])
+		routes.Insert(netip.PrefixFrom(peer4, peer4.BitLen()), &routemanager.PeerRoute{
+			MasqAddr4: service4,
+		})
+		tw.SetPeerRoutes(netip.MustParseAddr("100.64.0.1"), netip.Addr{}, routes)
+
+		pkt4 := udp4(peer4.String(), service4.String(), 1234, 89)
+		if n, err := tw.Write([][]byte{pkt4}, 0); err != nil || n != 1 {
+			t.Fatalf("Write IPv4 = %d, %v; want 1, nil", n, err)
+		}
+		if got := inbound.Value(); got != int64(len(pkt4)) {
+			t.Fatalf("IPv4 inbound bytes = %d; want %d", got, len(pkt4))
+		}
+
+		pkt6 := udp6(peer6.String(), service6.String(), 1234, 89)
+		if n, err := tw.Write([][]byte{pkt6}, 0); err != nil || n != 1 {
+			t.Fatalf("Write IPv6 = %d, %v; want 1, nil", n, err)
+		}
+		if got, want := inbound.Value(), int64(len(pkt4)+len(pkt6)); got != want {
+			t.Fatalf("IPv6 inbound bytes = %d; want %d", got, want)
+		}
+
+		// Non-initial fragments have no transport header.
+		fragment := udp4(peer4.String(), service4.String(), 1234, 89)
+		binary.BigEndian.PutUint16(fragment[6:8], 16)
+		if n, err := tw.Write([][]byte{fragment}, 0); err != nil || n != 1 {
+			t.Fatalf("Write fragment = %d, %v; want 1, nil", n, err)
+		}
+		if got, want := inbound.Value(), int64(len(pkt4)+len(pkt6)+len(fragment)); got != want {
+			t.Fatalf("fragment inbound bytes = %d; want %d", got, want)
+		}
+
+		tw.SetFilter(filter.NewAllowNone(t.Logf, &netipx.IPSet{}))
+		rejected := udp4(peer4.String(), service4.String(), 1234, 91)
+		if n, err := tw.Write([][]byte{rejected}, 0); err != nil || n != 0 {
+			t.Fatalf("Write rejected = %d, %v; want 0, nil", n, err)
+		}
+		if got, want := inbound.Value(), int64(len(pkt4)+len(pkt6)+len(fragment)); got != want {
+			t.Fatalf("inbound after ACL drop = %d; want %d", got, want)
+		}
+
+		tw.SetFilter(filter.NewAllowAllForTest(t.Logf))
+		tw.PostFilterPacketInboundFromWireGuard = func(*packet.Parsed, *Wrapper, *gro.GRO) (filter.Response, *gro.GRO) {
+			return filter.DropSilently, nil
+		}
+		if n, err := tw.Write([][]byte{pkt4}, 0); err != nil || n != 0 {
+			t.Fatalf("Write intercepted = %d, %v; want 0, nil", n, err)
+		}
+		if got, want := inbound.Value(), int64(len(pkt4)+len(pkt6)+len(fragment)); got != want {
+			t.Fatalf("inbound after interception = %d; want %d", got, want)
+		}
+		tw.PostFilterPacketInboundFromWireGuard = nil
+	})
+
+	t.Run("inbound_tun_write_error", func(t *testing.T) {
+		bus := eventbustest.NewBus(t)
+		tun := &writeErrorTUN{fakeTUN: NewFake().(*fakeTUN)}
+		tw := Wrap(t.Logf, tun, new(usermetric.Registry), bus)
+		defer tw.Close()
+		tw.SetFilter(filter.NewAllowAllForTest(t.Logf))
+
+		var inbound expvar.Int
+		tw.SetPacketMetricCounters(packetMetricTableByIP(map[netip.Addr]PacketMetricCounters{
+			service4: {Inbound: &inbound},
+		}))
+
+		pkt1 := udp4(peer4.String(), service4.String(), 1234, 92)
+		pkt2 := udp4(peer4.String(), service4.String(), 1234, 93)
+		if n, err := tw.Write([][]byte{pkt1, pkt2}, 0); err == nil || n != 2 {
+			t.Fatalf("Write = %d, %v; want 2, error", n, err)
+		}
+		if got, want := inbound.Value(), int64(len(pkt1)+len(pkt2)); got != want {
+			t.Fatalf("inbound bytes = %d; want %d", got, want)
+		}
+	})
+
+	t.Run("longest_prefix_match", func(t *testing.T) {
+		bus := eventbustest.NewBus(t)
+		_, tw := newFakeTUN(t.Logf, bus, true)
+		defer tw.Close()
+		tw.SetFilter(filter.NewAllowAllForTest(t.Logf))
+
+		var hostInbound, routeInbound expvar.Int
+		counters := new(bart.Table[PacketMetricCounters])
+		counters.Insert(netip.MustParsePrefix("1.2.3.0/24"), PacketMetricCounters{Inbound: &routeInbound})
+		counters.Insert(netip.PrefixFrom(service4, service4.BitLen()), PacketMetricCounters{Inbound: &hostInbound})
+		tw.SetPacketMetricCounters(counters)
+
+		hostPacket := udp4(peer4.String(), service4.String(), 1234, 89)
+		routePacket := udp4(peer4.String(), "1.2.3.5", 1234, 89)
+		if n, err := tw.Write([][]byte{hostPacket}, 0); err != nil || n != 1 {
+			t.Fatalf("Write host packet = %d, %v; want 1, nil", n, err)
+		}
+		if n, err := tw.Write([][]byte{routePacket}, 0); err != nil || n != 1 {
+			t.Fatalf("Write route packet = %d, %v; want 1, nil", n, err)
+		}
+		if got, want := hostInbound.Value(), int64(len(hostPacket)); got != want {
+			t.Fatalf("host inbound bytes = %d; want %d", got, want)
+		}
+		if got, want := routeInbound.Value(), int64(len(routePacket)); got != want {
+			t.Fatalf("route inbound bytes = %d; want %d", got, want)
+		}
+	})
+
+	t.Run("outbound_accepted_packets", func(t *testing.T) {
+		bus := eventbustest.NewBus(t)
+		chtun := tuntest.NewChannelTUN()
+		tw := Wrap(t.Logf, chtun.TUN(), new(usermetric.Registry), bus)
+		tw.SetFilter(filter.NewAllowAllForTest(t.Logf))
+		tw.Start()
+		defer tw.Close()
+
+		var inbound, outbound expvar.Int
+		// Counters can be installed after Start.
+		tw.SetPacketMetricCounters(packetMetricTableByIP(map[netip.Addr]PacketMetricCounters{
+			service4: {Inbound: &inbound, Outbound: &outbound},
+		}))
+
+		pkt := udp4(service4.String(), peer4.String(), 89, 1234)
+		go func() { chtun.Outbound <- pkt }()
+		buffs := [][]byte{make([]byte, MaxPacketSize)}
+		sizes := make([]int, 1)
+		if n, err := tw.Read(buffs, sizes, 0); err != nil || n != 1 {
+			t.Fatalf("Read = %d, %v; want 1, nil", n, err)
+		}
+		if got := outbound.Value(); got != int64(len(pkt)) {
+			t.Fatalf("outbound bytes = %d; want %d", got, len(pkt))
+		}
+
+		tw.PreFilterPacketOutboundToWireGuardNetstackIntercept = func(*packet.Parsed, *Wrapper, *gro.GRO) (filter.Response, *gro.GRO) {
+			return filter.DropSilently, nil
+		}
+		go func() { chtun.Outbound <- pkt }()
+		if n, err := tw.Read(buffs, sizes, 0); err != nil || n != 0 {
+			t.Fatalf("Read intercepted = %d, %v; want 0, nil", n, err)
+		}
+		if got := outbound.Value(); got != int64(len(pkt)) {
+			t.Fatalf("outbound after interception = %d; want %d", got, len(pkt))
+		}
+		tw.PreFilterPacketOutboundToWireGuardNetstackIntercept = nil
+
+		tw.SetPacketMetricCounters(nil)
+		go func() { chtun.Outbound <- pkt }()
+		if n, err := tw.Read(buffs, sizes, 0); err != nil || n != 1 {
+			t.Fatalf("Read after removal = %d, %v; want 1, nil", n, err)
+		}
+		if got := outbound.Value(); got != int64(len(pkt)) {
+			t.Fatalf("outbound after removal = %d; want %d", got, len(pkt))
+		}
+	})
+
+	t.Run("concurrent_reconfiguration", func(t *testing.T) {
+		bus := eventbustest.NewBus(t)
+		_, tw := newFakeTUN(t.Logf, bus, true)
+		defer tw.Close()
+		tw.SetFilter(filter.NewAllowAllForTest(t.Logf))
+
+		var inbound, outbound expvar.Int
+		counters := packetMetricTableByIP(map[netip.Addr]PacketMetricCounters{
+			service4: {Inbound: &inbound, Outbound: &outbound},
+		})
+		pkt := udp4(peer4.String(), service4.String(), 1234, 89)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for range 1_000 {
+				tw.SetPacketMetricCounters(counters)
+				tw.SetPacketMetricCounters(nil)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for range 1_000 {
+				if _, err := tw.Write([][]byte{pkt}, 0); err != nil {
+					t.Errorf("Write: %v", err)
+					return
+				}
+			}
+		}()
+		wg.Wait()
+	})
 }
 
 func TestPeerAPIBypass(t *testing.T) {


### PR DESCRIPTION
Tailscale Services using kernel TUN forwarding bypass the userspace Serve connection wrappers, so `tailscaled_serve_*` does not account for their traffic.

This adds `tailscaled_tun_service_{inbound,outbound}_bytes_total`. The metrics are separate because Serve counts stream payload while the TUN path counts IP packet bytes. Userspace Serve Services are excluded to avoid double counting.

Inbound packets are attributed before DNAT and counted after a successful TUN write. Outbound packets are counted after filtering and before SNAT. Configured userspace Serve metrics are initialized at zero so consumers can combine both families before traffic arrives.

The data plane uses an immutable prefix table with longest-prefix matching. Service VIPs are exact host entries today; future routed traffic metrics can reuse the accounting path without changing the Service metric contract.

Draft for feedback on the metric split and accounting boundaries.

Updates #19572
