### PR TITLE
cmd/k8s-operator,k8s-operator/reconciler: add PeerRelay e2e test

### DIFF
--- a/cmd/k8s-operator/e2e/peerrelay_test.go
+++ b/cmd/k8s-operator/e2e/peerrelay_test.go
@@ -1,0 +1,216 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"tailscale.com/ipn"
+	tsapi "tailscale.com/k8s-operator/apis/v1alpha1"
+	"tailscale.com/kube/kubetypes"
+	"tailscale.com/tstest"
+)
+
+const peerRelayServerPort uint16 = 41641
+
+// See [TestMain] for test requirements.
+func TestPeerRelay(t *testing.T) {
+	if tnClient == nil {
+		t.Skip("TestPeerRelay requires a working tailnet client")
+	}
+	t.Parallel()
+
+	pr := &tsapi.PeerRelay{
+		ObjectMeta: metav1.ObjectMeta{Name: generateName("peer-relay")},
+		Spec: tsapi.PeerRelaySpec{
+			ProxyClass: "default",
+		},
+	}
+	createAndCleanup(t, kubeClient, pr)
+
+	waitForPeerRelayConditionSet(t, pr.Name)
+	verifyPeerRelayReplica(t, pr.Name, 0)
+}
+
+// See [TestMain] for test requirements.
+func TestPeerRelayHA(t *testing.T) {
+	if tnClient == nil {
+		t.Skip("TestPeerRelayHA requires a working tailnet client")
+	}
+	t.Parallel()
+
+	const replicas int32 = 3
+	pr := &tsapi.PeerRelay{
+		ObjectMeta: metav1.ObjectMeta{Name: generateName("peer-relay-ha")},
+		Spec: tsapi.PeerRelaySpec{
+			Replicas:   new(replicas),
+			ProxyClass: "default",
+		},
+	}
+	createAndCleanup(t, kubeClient, pr)
+
+	waitForPeerRelayConditionSet(t, pr.Name)
+
+	for i := int32(0); i < replicas; i++ {
+		verifyPeerRelayReplica(t, pr.Name, i)
+	}
+}
+
+func verifyPeerRelayReplica(t *testing.T, prName string, replica int32) {
+	t.Helper()
+
+	verifyPeerRelayConfigSecret(t, prName, replica)
+
+	deviceID, tailnetIPs := waitForPeerRelayDeviceInfo(t, prName, replica)
+
+	wantHostname := fmt.Sprintf("%s-%d", prName, replica)
+	if err := tstest.WaitFor(2*time.Minute, func() error {
+		dev, err := tsClient.Devices().Get(t.Context(), deviceID)
+		if err != nil {
+			return fmt.Errorf("get device %s: %w", deviceID, err)
+		}
+		if dev.Hostname != wantHostname {
+			return fmt.Errorf("device %s hostname = %q, want %q", deviceID, dev.Hostname, wantHostname)
+		}
+
+		if !dev.ConnectedToControl {
+			return fmt.Errorf("device %s not connected to control", deviceID)
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatalf("verifying device %s via tsClient: %v", deviceID, err)
+	}
+
+	t.Logf("PeerRelay %s replica %d: device %s, tailnet IPs %v", prName, replica, deviceID, tailnetIPs)
+}
+
+func verifyPeerRelayConfigSecret(t *testing.T, prName string, replica int32) {
+	t.Helper()
+
+	var secrets corev1.SecretList
+	if err := kubeClient.List(t.Context(), &secrets,
+		client.InNamespace("tailscale"),
+		client.MatchingLabels{
+			"tailscale.com/parent-resource-type": "peerrelay",
+			"tailscale.com/parent-resource":      prName,
+			kubetypes.LabelSecretType:            kubetypes.LabelSecretTypeConfig,
+			"tailscale.com/peer-relay-replica":   strconv.FormatInt(int64(replica), 10),
+		},
+	); err != nil {
+		t.Fatalf("listing config Secret for PeerRelay %s replica %d: %v", prName, replica, err)
+	}
+	if len(secrets.Items) == 0 {
+		t.Fatalf("no config Secret for PeerRelay %s replica %d", prName, replica)
+	}
+	s := secrets.Items[0]
+
+	var confBody []byte
+	for name, body := range s.Data {
+		if strings.HasPrefix(name, "cap-") && strings.HasSuffix(name, ".hujson") {
+			confBody = body
+			break
+		}
+	}
+	if len(confBody) == 0 {
+		var keys []string
+		for k := range s.Data {
+			keys = append(keys, k)
+		}
+		t.Fatalf("config Secret %s has no cap-<v>.hujson data key: got %v", s.Name, keys)
+	}
+
+	var conf ipn.ConfigVAlpha
+	if err := json.Unmarshal(confBody, &conf); err != nil {
+		t.Fatalf("config Secret %s: parsing config: %v", s.Name, err)
+	}
+	if conf.RelayServerPort == nil {
+		t.Fatalf("config Secret %s: RelayServerPort not set; tailscaled would not run as a peer relay", s.Name)
+	}
+	if *conf.RelayServerPort != peerRelayServerPort {
+		t.Fatalf("config Secret %s: RelayServerPort = %d, want %d", s.Name, *conf.RelayServerPort, peerRelayServerPort)
+	}
+}
+
+// waitForPeerRelayConditionSet waits for the reconciler to stamp a PeerRelayReady condition that
+// reflects the current generation. It deliberately does not assert the condition's status: the
+// condition only goes True once every replica's LoadBalancer Service has an external address, and
+// the kind cluster these tests run in has no cloud controller to assign one, so it is always False
+// here. Once the suite can run against a cluster with a real LoadBalancer implementation this
+// should assert metav1.ConditionTrue.
+func waitForPeerRelayConditionSet(t *testing.T, prName string) {
+	t.Helper()
+	if err := tstest.WaitFor(3*time.Minute, func() error {
+		pr := &tsapi.PeerRelay{}
+		if err := kubeClient.Get(t.Context(), client.ObjectKey{Name: prName}, pr); err != nil {
+			return err
+		}
+		for _, c := range pr.Status.Conditions {
+			if c.Type != string(tsapi.PeerRelayReady) {
+				continue
+			}
+			if c.ObservedGeneration != pr.Generation {
+				return fmt.Errorf("PeerRelay %s condition observedGeneration=%d, spec generation=%d",
+					prName, c.ObservedGeneration, pr.Generation)
+			}
+			return nil
+		}
+		return fmt.Errorf("PeerRelay %s has no PeerRelayReady condition yet", prName)
+	}); err != nil {
+		t.Fatalf("waiting for PeerRelay %s status: %v", prName, err)
+	}
+}
+
+func waitForPeerRelayDeviceInfo(t *testing.T, prName string, replica int32) (deviceID string, tailnetIPs []string) {
+	t.Helper()
+	if err := tstest.WaitFor(5*time.Minute, func() error {
+		var secrets corev1.SecretList
+		if err := kubeClient.List(t.Context(), &secrets,
+			client.InNamespace("tailscale"),
+			client.MatchingLabels{
+				"tailscale.com/parent-resource-type": "peerrelay",
+				"tailscale.com/parent-resource":      prName,
+				kubetypes.LabelSecretType:            kubetypes.LabelSecretTypeState,
+				"tailscale.com/peer-relay-replica":   strconv.FormatInt(int64(replica), 10),
+			},
+		); err != nil {
+			return err
+		}
+		if len(secrets.Items) == 0 {
+			return fmt.Errorf("no state Secret for PeerRelay %s replica %d yet", prName, replica)
+		}
+
+		s := secrets.Items[0]
+		deviceID = string(s.Data[kubetypes.KeyDeviceID])
+		if deviceID == "" {
+			return fmt.Errorf("state Secret %s has no device_id yet", s.Name)
+		}
+
+		rawIPs := s.Data[kubetypes.KeyDeviceIPs]
+		if len(rawIPs) == 0 {
+			return fmt.Errorf("state Secret %s has no device_ips yet", s.Name)
+		}
+
+		if err := json.Unmarshal(rawIPs, &tailnetIPs); err != nil {
+			return fmt.Errorf("state Secret %s device_ips %q: %w", s.Name, string(rawIPs), err)
+		}
+		if len(tailnetIPs) == 0 {
+			return fmt.Errorf("state Secret %s has empty device_ips list", s.Name)
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatalf("waiting for state Secret for PeerRelay %s replica %d: %v", prName, replica, err)
+	}
+	return deviceID, tailnetIPs
+}

--- a/k8s-operator/reconciler/peerrelay/authkey.go
+++ b/k8s-operator/reconciler/peerrelay/authkey.go
@@ -34,15 +34,10 @@ func (r *Reconciler) peerRelayTags(pr *tsapi.PeerRelay) []string {
 // needed. A new key is minted if the config Secret doesn't exist yet, or if the replica has
 // requested a reissue via its state Secret. An existing key is retained while the device hasn't
 // authed or a reissue is in progress.
-func (r *Reconciler) getAuthKey(ctx context.Context, pr *tsapi.PeerRelay, idx int32) (*string, error) {
-	tsClient, err := r.tsClients.For(pr.Spec.Tailnet)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve Tailscale API client for tailnet %q: %w", pr.Spec.Tailnet, err)
-	}
-
+func (r *Reconciler) getAuthKey(ctx context.Context, tsClient tsclient.Client, pr *tsapi.PeerRelay, idx int32) (*string, error) {
 	var existingCfgSecret *corev1.Secret
 	cfgSecret := &corev1.Secret{}
-	err = r.Get(ctx, types.NamespacedName{Namespace: r.tailscaleNamespace, Name: configSecretName(pr.Name, idx)}, cfgSecret)
+	err := r.Get(ctx, types.NamespacedName{Namespace: r.tailscaleNamespace, Name: configSecretName(pr.Name, idx)}, cfgSecret)
 	switch {
 	case apierrors.IsNotFound(err):
 	case err != nil:

--- a/k8s-operator/reconciler/peerrelay/peerrelay.go
+++ b/k8s-operator/reconciler/peerrelay/peerrelay.go
@@ -464,12 +464,17 @@ func (r *Reconciler) deleteServicesFrom(ctx context.Context, logger *zap.Sugared
 }
 
 func (r *Reconciler) ensureConfigSecret(ctx context.Context, logger *zap.SugaredLogger, pr *tsapi.PeerRelay, idx int32, endpoint *tsapi.PeerRelayEndpoint) error {
-	authKey, err := r.getAuthKey(ctx, pr, idx)
+	tsClient, err := r.tsClients.For(pr.Spec.Tailnet)
+	if err != nil {
+		return fmt.Errorf("failed to resolve Tailscale API client for tailnet %q: %w", pr.Spec.Tailnet, err)
+	}
+
+	authKey, err := r.getAuthKey(ctx, tsClient, pr, idx)
 	if err != nil {
 		return err
 	}
 
-	desired, err := r.peerRelayConfigSecret(pr, idx, endpoint, authKey)
+	desired, err := r.peerRelayConfigSecret(pr, idx, endpoint, authKey, tsClient.LoginURL())
 	if err != nil {
 		return fmt.Errorf("failed to build config Secret: %w", err)
 	}

--- a/k8s-operator/reconciler/peerrelay/peerrelay_test.go
+++ b/k8s-operator/reconciler/peerrelay/peerrelay_test.go
@@ -944,12 +944,13 @@ func TestReconciler_TailscaledConfig(t *testing.T) {
 		).
 		Build()
 
+	const testLoginURL = "https://control.example.test"
 	r := peerrelay.NewReconciler(peerrelay.ReconcilerOptions{
 		Client:             fc,
 		TailscaleNamespace: tailscaleNamespace,
 		ProxyImage:         testProxyImage,
 		DefaultTags:        []string{"tag:test-peer-relay"},
-		Clients:            &fakeClientProvider{client: &fakeTSClient{}},
+		Clients:            &fakeClientProvider{client: &fakeTSClient{loginURL: testLoginURL}},
 		Resolver:           testResolver,
 		Logger:             logger.Sugar(),
 	})
@@ -969,6 +970,9 @@ func TestReconciler_TailscaledConfig(t *testing.T) {
 	if got0.Hostname == nil || *got0.Hostname != "test-0" {
 		t.Errorf("replica 0: expected hostname=test-0, got %v", got0.Hostname)
 	}
+	if got0.ServerURL == nil || *got0.ServerURL != testLoginURL {
+		t.Errorf("replica 0: expected ServerURL=%q, got %v", testLoginURL, got0.ServerURL)
+	}
 
 	got1 := readTailscaledConfig(t, fc, "peerrelay-test-1-config")
 	if got1.RelayServerPort == nil || *got1.RelayServerPort != 41641 {
@@ -977,6 +981,9 @@ func TestReconciler_TailscaledConfig(t *testing.T) {
 	// Replica 1's LB has not been provisioned yet, so no static endpoints.
 	if len(got1.RelayServerStaticEndpoints) != 0 {
 		t.Errorf("replica 1: expected no RelayServerStaticEndpoints, got %v", got1.RelayServerStaticEndpoints)
+	}
+	if got1.ServerURL == nil || *got1.ServerURL != testLoginURL {
+		t.Errorf("replica 1: expected ServerURL=%q, got %v", testLoginURL, got1.ServerURL)
 	}
 }
 
@@ -1035,6 +1042,8 @@ func (p *fakeClientProvider) For(_ string) (tsclient.Client, error) { return p.c
 type fakeTSClient struct {
 	tsclient.Client
 
+	loginURL string
+
 	mu            sync.Mutex
 	keyCalls      []tailscaleclient.CreateKeyRequest
 	deviceDeletes []string
@@ -1043,6 +1052,7 @@ type fakeTSClient struct {
 
 func (c *fakeTSClient) Keys() tsclient.KeyResource       { return (*fakeKeys)(c) }
 func (c *fakeTSClient) Devices() tsclient.DeviceResource { return (*fakeDevices)(c) }
+func (c *fakeTSClient) LoginURL() string                 { return c.loginURL }
 
 func (c *fakeTSClient) CreateAuthKeyCalls() []tailscaleclient.CreateKeyRequest {
 	c.mu.Lock()

--- a/k8s-operator/reconciler/peerrelay/statefulset.go
+++ b/k8s-operator/reconciler/peerrelay/statefulset.go
@@ -33,7 +33,7 @@ func peerRelayHostname(pr *tsapi.PeerRelay, idx int32) string {
 	return fmt.Sprintf("%s-%d", prefix, idx)
 }
 
-func peerRelayTailscaledConfig(pr *tsapi.PeerRelay, idx int32, endpoint *tsapi.PeerRelayEndpoint, authKey *string) ipn.ConfigVAlpha {
+func peerRelayTailscaledConfig(pr *tsapi.PeerRelay, idx int32, endpoint *tsapi.PeerRelayEndpoint, authKey *string, loginServer string) ipn.ConfigVAlpha {
 	conf := ipn.ConfigVAlpha{
 		Version:         "alpha0",
 		AcceptDNS:       "false",
@@ -42,6 +42,10 @@ func peerRelayTailscaledConfig(pr *tsapi.PeerRelay, idx int32, endpoint *tsapi.P
 		Hostname:        new(peerRelayHostname(pr, idx)),
 		RelayServerPort: new(uint16(servicePort)),
 		AuthKey:         authKey,
+	}
+
+	if loginServer != "" {
+		conf.ServerURL = &loginServer
 	}
 
 	if endpoint != nil {
@@ -55,13 +59,13 @@ func peerRelayTailscaledConfig(pr *tsapi.PeerRelay, idx int32, endpoint *tsapi.P
 	return conf
 }
 
-func (r *Reconciler) peerRelayConfigSecret(pr *tsapi.PeerRelay, idx int32, endpoint *tsapi.PeerRelayEndpoint, authKey *string) (*corev1.Secret, error) {
+func (r *Reconciler) peerRelayConfigSecret(pr *tsapi.PeerRelay, idx int32, endpoint *tsapi.PeerRelayEndpoint, authKey *string, loginServer string) (*corev1.Secret, error) {
 	labels := peerRelayServiceLabels(pr.Name, idx)
 	return tailscaled.NewConfigSecret(tailscaled.ConfigSecretOptions{
 		Name:      configSecretName(pr.Name, idx),
 		Namespace: r.tailscaleNamespace,
 		Labels:    labels,
-		Config:    peerRelayTailscaledConfig(pr, idx, endpoint, authKey),
+		Config:    peerRelayTailscaledConfig(pr, idx, endpoint, authKey, loginServer),
 	})
 }
 


### PR DESCRIPTION
This commit adds a new end-to-end test for the `PeerRelay` custom resource.

This test is currently quite limited due to the fact that we are running our tests within a kind cluster within github actions. This means it's not really possible to give the peer relays a proper public IP address via the `LoadBalancer` type services that we spin up.

That being said, we intend to expand our e2e test suite with actual real clusters in future so this can be expanded upon at a later date.

For now, this test spins up a single and multi-replica deployment of a peer relay and confirms that it has been registered with control and is configured to act as a peer relay.

This test also caught a small bug where the server URL was not being passed into the peer relay's configuration, which has been fixed here.

Closes: https://github.com/tailscale/corp/issues/45731
Closes: https://github.com/tailscale/corp/issues/45737