### PR TITLE
cmd/k8s-operator/deploy/chart: support nameOverride and fullnameOverride

### DIFF
--- a/cmd/k8s-operator/deploy/chart/templates/_helpers.tpl
+++ b/cmd/k8s-operator/deploy/chart/templates/_helpers.tpl
@@ -1,0 +1,40 @@
+{{/*
+Copyright (c) Tailscale Inc & contributors
+SPDX-License-Identifier: BSD-3-Clause
+*/}}
+
+{{/*
+Create a default fully qualified app name, truncated at 63 chars because some
+Kubernetes name fields are limited to this (by the DNS naming spec).
+
+For backwards compatibility with existing installations, this defaults to the
+historical hardcoded name "operator" unless nameOverride or fullnameOverride
+is set.
+*/}}
+{{- define "tailscale-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else if .Values.nameOverride }}
+{{- $name := .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- else }}
+{{- "operator" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Name for cluster-scoped operator resources. Defaults to the historical
+hardcoded name "tailscale-operator" unless nameOverride or fullnameOverride is
+set, in which case the fullname is used instead.
+*/}}
+{{- define "tailscale-operator.clusterResourceName" -}}
+{{- if or .Values.fullnameOverride .Values.nameOverride }}
+{{- include "tailscale-operator.fullname" . }}
+{{- else }}
+{{- "tailscale-operator" }}
+{{- end }}
+{{- end }}

--- a/cmd/k8s-operator/deploy/chart/templates/apiserverproxy-rbac.yaml
+++ b/cmd/k8s-operator/deploy/chart/templates/apiserverproxy-rbac.yaml
@@ -27,7 +27,7 @@ metadata:
 subjects:
 {{- if eq (toString .Values.apiServerProxyConfig.mode) "true" }}
 - kind: ServiceAccount
-  name: operator
+  name: {{ include "tailscale-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
 - kind: ServiceAccount

--- a/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
+++ b/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
@@ -4,7 +4,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: operator
+  name: {{ include "tailscale-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
   {{- if .Values.annotations }}
   annotations: {{- toYaml .Values.annotations | nindent 4 }}
@@ -15,7 +15,7 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      app: operator
+      app: {{ include "tailscale-operator.fullname" . }}
   template:
     metadata:
       {{- with .Values.operatorConfig.podAnnotations }}
@@ -23,7 +23,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        app: operator
+        app: {{ include "tailscale-operator.fullname" . }}
         {{- with .Values.operatorConfig.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -32,7 +32,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: operator
+      serviceAccountName: {{ include "tailscale-operator.fullname" . }}
       {{- with .Values.operatorConfig.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -53,7 +53,7 @@ spec:
         {{- else }}
         - name: oauth
           secret:
-            secretName: operator-oauth
+            secretName: {{ include "tailscale-operator.fullname" . }}-oauth
         {{- end }}
       containers:
         - name: operator
@@ -74,7 +74,7 @@ spec:
             - name: OPERATOR_HOSTNAME
               value: {{ .Values.operatorConfig.hostname }}
             - name: OPERATOR_SECRET
-              value: operator
+              value: {{ include "tailscale-operator.fullname" . }}
             - name: OPERATOR_LOGGING
               value: {{ .Values.operatorConfig.logging }}
             - name: OPERATOR_NAMESPACE

--- a/cmd/k8s-operator/deploy/chart/templates/oauth-secret.yaml
+++ b/cmd/k8s-operator/deploy/chart/templates/oauth-secret.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: operator-oauth
+  name: {{ include "tailscale-operator.fullname" . }}-oauth
   namespace: {{ .Release.Namespace }}
 stringData:
   client_id: {{ .Values.oauth.clientId }}

--- a/cmd/k8s-operator/deploy/chart/templates/operator-rbac.yaml
+++ b/cmd/k8s-operator/deploy/chart/templates/operator-rbac.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: operator
+  name: {{ include "tailscale-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
   {{- with .Values.operatorConfig.serviceAccountAnnotations }}
   annotations:
@@ -14,7 +14,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: tailscale-operator
+  name: {{ include "tailscale-operator.clusterResourceName" . }}
 rules:
 - apiGroups: [""]
   resources: ["nodes"]
@@ -60,20 +60,20 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: tailscale-operator
+  name: {{ include "tailscale-operator.clusterResourceName" . }}
 subjects:
 - kind: ServiceAccount
-  name: operator
+  name: {{ include "tailscale-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: tailscale-operator
+  name: {{ include "tailscale-operator.clusterResourceName" . }}
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: operator
+  name: {{ include "tailscale-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups: [""]
@@ -81,7 +81,7 @@ rules:
   verbs: ["create","delete","deletecollection","get","list","patch","update","watch"]
 - apiGroups: [""]
   resources: ["serviceaccounts/token"]
-  resourceNames: ["operator"]
+  resourceNames: ["{{ include "tailscale-operator.fullname" . }}"]
   verbs: ["create"]
 - apiGroups: [""]
   resources: ["pods"]
@@ -105,13 +105,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: operator
+  name: {{ include "tailscale-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
-  name: operator
+  name: {{ include "tailscale-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: operator
+  name: {{ include "tailscale-operator.fullname" . }}
   apiGroup: rbac.authorization.k8s.io

--- a/cmd/k8s-operator/deploy/chart/values.yaml
+++ b/cmd/k8s-operator/deploy/chart/values.yaml
@@ -1,9 +1,34 @@
 # Copyright (c) Tailscale Inc & contributors
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Operator oauth credentials. If unset a Secret named operator-oauth must be
-# precreated or oauthSecretVolume needs to be adjusted. This block will be
-# overridden by oauthSecretVolume, if set.
+# nameOverride and fullnameOverride customize the names of the resources
+# created by this chart. fullnameOverride is used verbatim as the resource
+# name and takes precedence. nameOverride is combined with the release name
+# instead, producing resources named "<release-name>-<nameOverride>".
+#
+# If neither is set, resources use "operator" for namespaced resources,
+# "tailscale-operator" for cluster-scoped ones.
+#
+# The Secret the operator stores its tailnet device state in also follows
+# this name. Changing these values on an existing installation therefore
+# gives the operator a fresh state Secret and it will re-register as a new
+# device on the tailnet; the old Secret and device are left behind.
+#
+# Changing these on an existing installation also changes the operator
+# Deployment's pod selector, which Kubernetes treats as immutable, so
+# "helm upgrade" will fail. Delete the existing Deployment (or uninstall and
+# reinstall the chart) first.
+#
+# Similarly, if you precreate the oauth credentials Secret instead of setting
+# the oauth block below, its name must be "<fullname>-oauth", so
+# "myname-oauth" when fullnameOverride is set to "myname". The operator's Pod
+# will not start if that Secret is missing.
+nameOverride: ""
+fullnameOverride: ""
+
+# Operator oauth credentials. If unset a Secret named <fullname>-oauth
+# (operator-oauth by default) must be precreated or oauthSecretVolume needs to
+# be adjusted. This block will be overridden by oauthSecretVolume, if set.
 oauth:
   # The Client ID the operator will authenticate with.
   clientId: ""


### PR DESCRIPTION
The Helm chart hardcoded the operator's Deployment, ServiceAccount, Role, and RoleBinding names to "operator", which is confusing when the chart is installed in a namespace not obviously related to Tailscale, and offered no way to customize them.

Adds a standard _helpers.tpl with name/fullname template functions and use them for the operator's resources, including the oauth Secret and the cluster-scoped ClusterRole/ClusterRoleBinding. When neither nameOverride nor fullnameOverride is set, the fullname resolves to the historical hardcoded names rather than the release name, so existing installations upgrade with no resource renames; rendering with default values is byte-identical to before.

Fixes tailscale/tailscale#18232