### PR TITLE
cmd/k8s-operator: attach egress readiness gate to ProxyGroup Pods

### DIFF
--- a/cmd/k8s-operator/proxygroup_specs.go
+++ b/cmd/k8s-operator/proxygroup_specs.go
@@ -303,6 +303,18 @@ func pgStatefulSet(pg *tsapi.ProxyGroup, namespace, image, tsFirewallMode string
 		// Set the deletion grace period to 6 minutes to ensure that the pre-stop hook has enough time to terminate
 		// gracefully.
 		ss.Spec.Template.DeletionGracePeriodSeconds = new(deletionGracePeriodSeconds)
+
+		// Add a readiness gate so that kubelet does not mark a replica Pod as
+		// ready before egressPodsReconciler has confirmed that cluster traffic
+		// for all egress services is being routed to it. Because StatefulSet
+		// rolling updates only restart the next replica once the previous one
+		// is ready, this prevents a window during updates where every replica
+		// has been recreated but none is yet serving traffic, which would drop
+		// cluster egress traffic. The reconciler sets the corresponding
+		// condition; see egress-pod-readiness.go.
+		tmpl.Spec.ReadinessGates = append(tmpl.Spec.ReadinessGates, corev1.PodReadinessGate{
+			ConditionType: tsEgressReadinessGate,
+		})
 	}
 
 	return ss, nil

--- a/cmd/k8s-operator/proxygroup_test.go
+++ b/cmd/k8s-operator/proxygroup_test.go
@@ -1221,6 +1221,11 @@ func TestProxyGroupTypes(t *testing.T) {
 		if *sts.Spec.Template.DeletionGracePeriodSeconds != deletionGracePeriodSeconds {
 			t.Errorf("unexpected deletion grace period seconds %d, want %d", *sts.Spec.Template.DeletionGracePeriodSeconds, deletionGracePeriodSeconds)
 		}
+		if !slices.ContainsFunc(sts.Spec.Template.Spec.ReadinessGates, func(r corev1.PodReadinessGate) bool {
+			return r.ConditionType == tsEgressReadinessGate
+		}) {
+			t.Errorf("expected egress readiness gate %q to be set, got %v", tsEgressReadinessGate, sts.Spec.Template.Spec.ReadinessGates)
+		}
 	})
 	t.Run("egress_type_no_lifecycle_hook_when_local_addr_port_set", func(t *testing.T) {
 		pg := &tsapi.ProxyGroup{
@@ -1256,6 +1261,11 @@ func TestProxyGroupTypes(t *testing.T) {
 
 		if sts.Spec.Template.Spec.Containers[0].Lifecycle != nil {
 			t.Error("lifecycle hook was set when TS_LOCAL_ADDR_PORT was configured via ProxyClass")
+		}
+		if slices.ContainsFunc(sts.Spec.Template.Spec.ReadinessGates, func(r corev1.PodReadinessGate) bool {
+			return r.ConditionType == tsEgressReadinessGate
+		}) {
+			t.Error("egress readiness gate was set when TS_LOCAL_ADDR_PORT was configured via ProxyClass")
 		}
 	})
 


### PR DESCRIPTION
The egressPodsReconciler (added in https://github.com/tailscale/tailscale/pull/14792) only sets the
tailscale.com/egress-services readiness condition on egress ProxyGroup
replica Pods that declare the corresponding readiness gate. However, the
gate was never actually added to the egress Pod template, so the
reconciler always hit its early-return and the readiness condition was
never set. This commit adds said readiness gate to the egress Pod template.

Updates: #14326