### PR TITLE
Show per-subnet metrics in /metrics and usermetrics endpoints

### DIFF
--- a/cmd/tailscale/cli/get.go
+++ b/cmd/tailscale/cli/get.go
@@ -184,6 +184,8 @@ func prefValue(flagName string, prefs *ipn.Prefs, st *ipnstate.Status) any {
 			return false
 		}
 		return true
+	case "collect-load-metrics":
+		return prefs.CollectLoadMetrics.EqualBool(true)
 	case "netfilter-mode":
 		return prefs.NetfilterMode.String()
 	case "unattended":

--- a/cmd/tailscale/cli/set.go
+++ b/cmd/tailscale/cli/set.go
@@ -65,6 +65,7 @@ type setArgsT struct {
 	remoteConfig               bool
 	snat                       bool
 	statefulFiltering          bool
+	collectLoadMetrics         bool
 	sync                       bool
 	netfilterMode              string
 	relayServerPort            string
@@ -116,6 +117,7 @@ func newSetFlagSet(goos string, setArgs *setArgsT) *flag.FlagSet {
 	case "linux":
 		setf.BoolVar(&setArgs.snat, "snat-subnet-routes", true, "source NAT traffic to local routes advertised with --advertise-routes")
 		setf.BoolVar(&setArgs.statefulFiltering, "stateful-filtering", false, "apply stateful filtering to forwarded packets (subnet routers, exit nodes, and so on)")
+		setf.BoolVar(&setArgs.collectLoadMetrics, "collect-load-metrics", false, "collect per-route load metrics for routes advertised with --advertise-routes; not supported on App Connectors")
 		setf.StringVar(&setArgs.netfilterMode, "netfilter-mode", defaultNetfilterMode(), "netfilter mode (one of on, nodivert, off)")
 	case "windows":
 		setf.BoolVar(&setArgs.forceDaemon, "unattended", false, "run in \"Unattended Mode\" where Tailscale keeps running even after the current GUI user logs out (Windows-only)")
@@ -167,6 +169,7 @@ func runSet(ctx context.Context, args []string) (retErr error) {
 			PostureChecking:     setArgs.reportPosture,
 			RemoteConfig:        setArgs.remoteConfig,
 			NoStatefulFiltering: opt.NewBool(!setArgs.statefulFiltering),
+			CollectLoadMetrics:  opt.NewBool(setArgs.collectLoadMetrics),
 		},
 	}
 

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -916,6 +916,7 @@ func init() {
 	addPrefFlagMapping("shields-up", "ShieldsUp")
 	addPrefFlagMapping("snat-subnet-routes", "NoSNAT")
 	addPrefFlagMapping("stateful-filtering", "NoStatefulFiltering")
+	addPrefFlagMapping("collect-load-metrics", "CollectLoadMetrics")
 	addPrefFlagMapping("exit-node-allow-lan-access", "ExitNodeAllowLANAccess")
 	addPrefFlagMapping("unattended", "ForceDaemon")
 	addPrefFlagMapping("operator", "OperatorUser")

--- a/ipn/conf.go
+++ b/ipn/conf.go
@@ -42,6 +42,7 @@ type ConfigVAlpha struct {
 
 	NetfilterMode       *string  `json:",omitempty"` // "on", "off", "nodivert"
 	NoStatefulFiltering opt.Bool `json:",omitempty"`
+	CollectLoadMetrics  opt.Bool `json:",omitempty"` // per-route subnet load metrics; defaults to off
 
 	PostureChecking opt.Bool         `json:",omitempty"`
 	RunSSHServer    opt.Bool         `json:",omitempty"` // Tailscale SSH
@@ -142,6 +143,10 @@ func (c *ConfigVAlpha) ToPrefs() (MaskedPrefs, error) {
 	if c.NoStatefulFiltering != "" {
 		mp.NoStatefulFiltering = c.NoStatefulFiltering
 		mp.NoStatefulFilteringSet = true
+	}
+	if c.CollectLoadMetrics != "" {
+		mp.CollectLoadMetrics = c.CollectLoadMetrics
+		mp.CollectLoadMetricsSet = true
 	}
 
 	if c.NetfilterMode != nil {

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -96,6 +96,7 @@ var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	Sync                       opt.Bool
 	NoSNAT                     bool
 	NoStatefulFiltering        opt.Bool
+	CollectLoadMetrics         opt.Bool
 	NetfilterMode              preftype.NetfilterMode
 	OperatorUser               string
 	ProfileName                string

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -404,6 +404,25 @@ func (v PrefsView) NoSNAT() bool { return v.ж.NoSNAT }
 // Linux-only.
 func (v PrefsView) NoStatefulFiltering() opt.Bool { return v.ж.NoStatefulFiltering }
 
+// CollectLoadMetrics specifies whether to collect per-route load metrics
+// for the subnet routes advertised in AdvertiseRoutes. The default is not
+// to collect them.
+//
+// When enabled, forwarded bytes and packets are counted per advertised
+// route and exposed as tailscaled_subnet_forwarded_{bytes,packets}_total.
+// This adds a longest-prefix lookup to the packet path of a subnet router,
+// so it is opt-in.
+//
+// It is not supported on App Connectors, which advertise a route per
+// resolved DNS address and would therefore produce unbounded metric
+// cardinality.
+//
+// This is an opt.Bool so that "never set" is distinguishable from
+// "explicitly disabled".
+//
+// Linux-only.
+func (v PrefsView) CollectLoadMetrics() opt.Bool { return v.ж.CollectLoadMetrics }
+
 // NetfilterMode specifies how much to manage netfilter rules for
 // Tailscale, if at all.
 func (v PrefsView) NetfilterMode() preftype.NetfilterMode { return v.ж.NetfilterMode }
@@ -513,6 +532,7 @@ var _PrefsViewNeedsRegeneration = Prefs(struct {
 	Sync                       opt.Bool
 	NoSNAT                     bool
 	NoStatefulFiltering        opt.Bool
+	CollectLoadMetrics         opt.Bool
 	NetfilterMode              preftype.NetfilterMode
 	OperatorUser               string
 	ProfileName                string

--- a/ipn/ipnlocal/loadmetrics_test.go
+++ b/ipn/ipnlocal/loadmetrics_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package ipnlocal
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+
+	"tailscale.com/ipn"
+	"tailscale.com/types/opt"
+)
+
+func TestCheckCollectLoadMetrics(t *testing.T) {
+	tests := []struct {
+		name    string
+		prefs   *ipn.Prefs
+		wantErr string // substring; "" means the prefs must be accepted
+	}{
+		{
+			name:  "unset is always fine",
+			prefs: &ipn.Prefs{},
+		},
+		{
+			name:  "explicitly disabled is always fine",
+			prefs: &ipn.Prefs{CollectLoadMetrics: opt.NewBool(false)},
+		},
+		{
+			name: "disabled on an App Connector is fine",
+			prefs: &ipn.Prefs{
+				CollectLoadMetrics: opt.NewBool(false),
+				AppConnector:       ipn.AppConnectorPrefs{Advertise: true},
+			},
+		},
+		{
+			name: "enabled on an App Connector is rejected",
+			prefs: &ipn.Prefs{
+				CollectLoadMetrics: opt.NewBool(true),
+				AppConnector:       ipn.AppConnectorPrefs{Advertise: true},
+			},
+			wantErr: "not supported on App Connectors",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkCollectLoadMetrics(tt.prefs)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("checkCollectLoadMetrics() = %v; want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("checkCollectLoadMetrics() = nil; want error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("checkCollectLoadMetrics() = %v; want error containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestCheckCollectLoadMetricsPlatform covers the platform gate: the counting
+// hook is only wired up on Linux, so accepting the pref elsewhere would leave
+// it silently inert.
+func TestCheckCollectLoadMetricsPlatform(t *testing.T) {
+	p := &ipn.Prefs{CollectLoadMetrics: opt.NewBool(true)}
+	err := checkCollectLoadMetrics(p)
+	if runtime.GOOS == "linux" {
+		if err != nil {
+			t.Fatalf("checkCollectLoadMetrics() on linux = %v; want nil", err)
+		}
+		return
+	}
+	if err == nil {
+		t.Fatalf("checkCollectLoadMetrics() on %s = nil; want an error", runtime.GOOS)
+	}
+	if !strings.Contains(err.Error(), "Linux") {
+		t.Errorf("checkCollectLoadMetrics() on %s = %v; want the error to mention Linux", runtime.GOOS, err)
+	}
+}
+
+// TestCheckPrefsRejectsLoadMetricsOnAppConnector verifies the check is actually
+// reached through checkPrefsLocked, which is the shared gate for tailscale set,
+// tailscale up, and config-file loads.
+func TestCheckPrefsRejectsLoadMetricsOnAppConnector(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("pref is Linux-only; running on %s", runtime.GOOS)
+	}
+	b := newTestLocalBackend(t)
+
+	p := &ipn.Prefs{
+		ControlURL:         ipn.DefaultControlURL,
+		CollectLoadMetrics: opt.NewBool(true),
+		AppConnector:       ipn.AppConnectorPrefs{Advertise: true},
+	}
+	err := b.CheckPrefs(p)
+	if err == nil {
+		t.Fatal("CheckPrefs accepted load metrics on an App Connector; want an error")
+	}
+	if !strings.Contains(err.Error(), "not supported on App Connectors") {
+		t.Errorf("CheckPrefs error = %v; want it to mention App Connectors", err)
+	}
+}

--- a/ipn/ipnlocal/loadmetrics_test.go
+++ b/ipn/ipnlocal/loadmetrics_test.go
@@ -4,12 +4,27 @@
 package ipnlocal
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 
+	"tailscale.com/health"
 	"tailscale.com/ipn"
+	"tailscale.com/ipn/conffile"
+	"tailscale.com/ipn/store/mem"
+	"tailscale.com/net/netmon"
+	"tailscale.com/net/tsdial"
+	"tailscale.com/tailcfg"
+	"tailscale.com/tsd"
+	"tailscale.com/types/logger"
+	"tailscale.com/types/logid"
 	"tailscale.com/types/opt"
+	"tailscale.com/types/persist"
+	"tailscale.com/util/eventbus/eventbustest"
+	"tailscale.com/wgengine"
 )
 
 func TestCheckCollectLoadMetrics(t *testing.T) {
@@ -104,3 +119,145 @@ func TestCheckPrefsRejectsLoadMetricsOnAppConnector(t *testing.T) {
 		t.Errorf("CheckPrefs error = %v; want it to mention App Connectors", err)
 	}
 }
+
+// TestConfigFileRejectsLoadMetricsOnAppConnector checks the config-file paths.
+// checkPrefsLocked is the shared gate for tailscale set and tailscale up, but
+// initPrefsFromConfig and setConfigLocked both went straight from
+// conf.Parsed.ToPrefs to SetPrefs/setPrefsLocked, so the check never ran and a
+// config file could turn on load metrics on an App Connector.
+func TestConfigFileRejectsLoadMetricsOnAppConnector(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("pref is Linux-only; running on %s", runtime.GOOS)
+	}
+	conf := &conffile.Config{
+		Path: "/dev/null",
+		Parsed: ipn.ConfigVAlpha{
+			Version:            "alpha0",
+			CollectLoadMetrics: "true",
+			AppConnector:       &ipn.AppConnectorPrefs{Advertise: true},
+		},
+	}
+	sys := tsd.NewSystem()
+	sys.Set(new(mem.Store))
+	eng, err := wgengine.NewFakeUserspaceEngine(logger.Discard, sys.Set,
+		sys.HealthTracker.Get(), sys.UserMetricsRegistry(), sys.Bus.Get())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(eng.Close)
+	if _, ok := sys.Engine.GetOK(); !ok {
+		sys.Set(eng)
+	}
+	if _, ok := sys.Dialer.GetOK(); !ok {
+		sys.Set(tsdial.NewDialer(netmon.NewStatic()))
+	}
+	sys.InitialConfig = conf
+
+	// An invalid config file must fail startup, the same way a config with
+	// unmasked AdvertiseRoutes already does, rather than silently starting with
+	// 4 series per DNS-discovered /32.
+	b, err := NewLocalBackend(logger.Discard, logid.PublicID{}, sys, 0)
+	if err == nil {
+		t.Cleanup(b.Shutdown)
+		if got := b.Prefs().CollectLoadMetrics(); got.EqualBool(true) {
+			t.Errorf("CollectLoadMetrics = %v after a config file that also advertises an "+
+				"App Connector; want it rejected or cleared", got)
+		}
+		return
+	}
+	if !strings.Contains(err.Error(), "not supported on App Connectors") {
+		t.Errorf("NewLocalBackend error = %v; want it to mention App Connectors", err)
+	}
+}
+
+// TestReloadConfigRejectsLoadMetricsOnAppConnector is the runtime counterpart:
+// ReloadConfig -> setConfigLocked.
+func TestReloadConfigRejectsLoadMetricsOnAppConnector(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("pref is Linux-only; running on %s", runtime.GOOS)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tailscale.conf")
+
+	initial := ipn.ConfigVAlpha{Version: "alpha0", Hostname: ptrTo("h1")}
+	writeConf(t, path, initial)
+	sys := tsd.NewSystem()
+	sys.InitialConfig = &conffile.Config{Path: path, Parsed: initial}
+	b := newTestLocalBackendWithSys(t, sys)
+
+	// Now turn on the disallowed combination and reload.
+	writeConf(t, path, ipn.ConfigVAlpha{
+		Version:            "alpha0",
+		Hostname:           ptrTo("h1"),
+		CollectLoadMetrics: "true",
+		AppConnector:       &ipn.AppConnectorPrefs{Advertise: true},
+	})
+	if _, err := b.ReloadConfig(); err == nil {
+		if got := b.Prefs().CollectLoadMetrics(); got.EqualBool(true) {
+			t.Errorf("ReloadConfig accepted load metrics on an App Connector and left "+
+				"CollectLoadMetrics = %v", got)
+		}
+	}
+}
+
+// TestPersistedBadLoadMetricsPrefsSelfHeal covers the secondary wedge:
+// checkCollectLoadMetrics is a whole-prefs invariant, so once prefs hold the
+// disallowed combination every later EditPrefs fails, even unrelated ones like
+// setting a hostname. Loading such prefs must clear the pref instead, following
+// the AutoUpdate.Apply precedent in loadSavedPrefs.
+func TestPersistedBadLoadMetricsPrefsSelfHeal(t *testing.T) {
+	store := new(mem.Store)
+	pm, err := newProfileManagerWithGOOS(store, logger.Discard,
+		health.NewTracker(eventbustest.NewBus(t)), "linux")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Persist the disallowed combination, as an older client or a config file
+	// written before the check existed could have.
+	p := pm.CurrentPrefs().AsStruct()
+	p.ControlURL = ipn.DefaultControlURL
+	p.Persist = &persist.Persist{NodeID: "node-1", UserProfile: tailcfg.UserProfile{
+		ID: 1, LoginName: "user@example.com",
+	}}
+	p.CollectLoadMetrics = opt.NewBool(true)
+	p.AppConnector = ipn.AppConnectorPrefs{Advertise: true}
+	if err := pm.SetPrefs(p.View(), ipn.NetworkProfile{}); err != nil {
+		t.Fatalf("SetPrefs: %v", err)
+	}
+	if !pm.CurrentPrefs().CollectLoadMetrics().EqualBool(true) {
+		t.Fatal("SetPrefs did not persist CollectLoadMetrics")
+	}
+
+	// Reloading must self-heal rather than leave prefs unable to be edited.
+	pm2, err := newProfileManagerWithGOOS(store, logger.Discard,
+		health.NewTracker(eventbustest.NewBus(t)), "linux")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := pm2.CurrentPrefs()
+	if got.CollectLoadMetrics().EqualBool(true) {
+		t.Error("the disallowed CollectLoadMetrics+AppConnector combination survived a " +
+			"reload; every later EditPrefs would fail")
+	}
+	if !got.AppConnector().Advertise {
+		t.Error("AppConnector.Advertise was cleared; the load metrics pref is the one to drop")
+	}
+	// And the healed prefs pass the gate, so EditPrefs is not wedged.
+	if err := checkCollectLoadMetrics(got.AsStruct()); err != nil {
+		t.Errorf("healed prefs still fail the check: %v", err)
+	}
+}
+
+func writeConf(t *testing.T, path string, c ipn.ConfigVAlpha) {
+	t.Helper()
+	b, err := json.Marshal(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, b, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func ptrTo[T any](v T) *T { return &v }

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -6553,6 +6553,7 @@ func (b *LocalBackend) routerConfigLocked(cfg *wgcfg.Config, prefs ipn.PrefsView
 		Routes:              b.currentNode().osRoutes(),
 		NetfilterKind:       netfilterKind,
 		RemoveCGNATDropRule: nm.HasCap(tailcfg.NodeAttrDisableLinuxCGNATDropRule),
+		CollectLoadMetrics:  prefs.CollectLoadMetrics().EqualBool(true),
 	}
 
 	if buildfeatures.HasSynology && distro.Get() == distro.Synology {

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1030,6 +1030,9 @@ func (b *LocalBackend) initPrefsFromConfig(conf *conffile.Config) error {
 		return fmt.Errorf("error parsing config to prefs: %w", err)
 	}
 	p.ApplyEdits(&mp)
+	if err := b.checkConfigPrefsLocked(p); err != nil {
+		return err
+	}
 	if err := b.pm.SetPrefs(p.View(), ipn.NetworkProfile{}); err != nil {
 		return err
 	}
@@ -1037,6 +1040,27 @@ func (b *LocalBackend) initPrefsFromConfig(conf *conffile.Config) error {
 	b.setStaticEndpointsFromConfigLocked(conf)
 	b.conf = conf
 	return nil
+}
+
+// checkConfigPrefsLocked validates prefs that came from a config file.
+//
+// It cannot use [LocalBackend.checkPrefsLocked], which starts by rejecting any
+// reconfiguration while a config file is in use — true by construction here, so
+// calling it would fail every config load. The checks below are the ones that
+// describe combinations of prefs that no source may produce, as opposed to the
+// ones that reject a *user* changing prefs out from under a config file.
+//
+// b.mu must be held.
+func (b *LocalBackend) checkConfigPrefsLocked(p *ipn.Prefs) error {
+	syncs.RequiresMutex(&b.mu)
+	var errs []error
+	if err := checkAdvertiseRoutes(p); err != nil {
+		errs = append(errs, err)
+	}
+	if err := checkCollectLoadMetrics(p); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
 }
 
 func (b *LocalBackend) setStaticEndpointsFromConfigLocked(conf *conffile.Config) {
@@ -1085,6 +1109,9 @@ func (b *LocalBackend) setConfigLocked(conf *conffile.Config) error {
 		return fmt.Errorf("error parsing config to prefs: %w", err)
 	}
 	p.ApplyEdits(&mp)
+	if err := b.checkConfigPrefsLocked(p); err != nil {
+		return err
+	}
 	b.setStaticEndpointsFromConfigLocked(conf)
 	b.setPrefsLocked(p)
 

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -4971,6 +4971,9 @@ func (b *LocalBackend) checkPrefsLocked(p *ipn.Prefs) error {
 	if err := checkAdvertiseRoutes(p); err != nil {
 		errs = append(errs, err)
 	}
+	if err := checkCollectLoadMetrics(p); err != nil {
+		errs = append(errs, err)
+	}
 	return errors.Join(errs...)
 }
 
@@ -5078,6 +5081,26 @@ func checkAdvertiseRoutes(p *ipn.Prefs) error {
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// checkCollectLoadMetrics validates the CollectLoadMetrics pref.
+//
+// Per-route load metrics are rejected on App Connectors: those advertise a
+// route per resolved DNS address, so the number of series would grow with
+// end-user browsing rather than with admin configuration. They are also
+// rejected off Linux, where nothing on the packet path honors the pref, so
+// accepting it would leave it silently inert.
+func checkCollectLoadMetrics(p *ipn.Prefs) error {
+	if !p.CollectLoadMetrics.EqualBool(true) {
+		return nil
+	}
+	if buildfeatures.HasAppConnectors && p.AppConnector.Advertise {
+		return errors.New("load metrics are not supported on App Connectors: this node advertises routes dynamically per resolved DNS address, which would produce unbounded metric cardinality. Support for App Connectors is planned; for now use network flow logs for per-destination visibility on this node")
+	}
+	if runtime.GOOS != "linux" {
+		return fmt.Errorf("load metrics are only supported on Linux, not %s", runtime.GOOS)
+	}
+	return nil
 }
 
 // SetUseExitNodeEnabled turns on or off the most recently selected exit node.

--- a/ipn/ipnlocal/profiles.go
+++ b/ipn/ipnlocal/profiles.go
@@ -716,6 +716,18 @@ func (pm *profileManager) loadSavedPrefs(k ipn.StateKey) (ipn.PrefsView, error) 
 	if savedPrefs.AutoUpdate.Apply.EqualBool(true) && !feature.CanAutoUpdate() {
 		savedPrefs.AutoUpdate.Apply.Clear()
 	}
+	// Same problem, same fix: CollectLoadMetrics is rejected on App Connectors
+	// and off Linux, and checkCollectLoadMetrics validates the whole prefs, so
+	// prefs holding the disallowed combination make every later EditPrefs fail,
+	// even unrelated ones. Prefs written by an older client, or by a config
+	// file from before the check existed, can hold it.
+	//
+	// Clear the load-metrics pref rather than the thing it conflicts with: it
+	// is the opt-in extra, and being an App Connector is the node's job.
+	if err := checkCollectLoadMetrics(savedPrefs); err != nil {
+		pm.logf("clearing CollectLoadMetrics from saved prefs: %v", err)
+		savedPrefs.CollectLoadMetrics.Clear()
+	}
 
 	return savedPrefs.View(), nil
 }

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -241,6 +241,25 @@ type Prefs struct {
 	// Linux-only.
 	NoStatefulFiltering opt.Bool `json:",omitempty"`
 
+	// CollectLoadMetrics specifies whether to collect per-route load metrics
+	// for the subnet routes advertised in AdvertiseRoutes. The default is not
+	// to collect them.
+	//
+	// When enabled, forwarded bytes and packets are counted per advertised
+	// route and exposed as tailscaled_subnet_forwarded_{bytes,packets}_total.
+	// This adds a longest-prefix lookup to the packet path of a subnet router,
+	// so it is opt-in.
+	//
+	// It is not supported on App Connectors, which advertise a route per
+	// resolved DNS address and would therefore produce unbounded metric
+	// cardinality.
+	//
+	// This is an opt.Bool so that "never set" is distinguishable from
+	// "explicitly disabled".
+	//
+	// Linux-only.
+	CollectLoadMetrics opt.Bool `json:",omitempty"`
+
 	// NetfilterMode specifies how much to manage netfilter rules for
 	// Tailscale, if at all.
 	NetfilterMode preftype.NetfilterMode
@@ -379,6 +398,7 @@ type MaskedPrefs struct {
 	SyncSet                       bool                `json:",omitzero"`
 	NoSNATSet                     bool                `json:",omitempty"`
 	NoStatefulFilteringSet        bool                `json:",omitempty"`
+	CollectLoadMetricsSet         bool                `json:",omitempty"`
 	NetfilterModeSet              bool                `json:",omitempty"`
 	OperatorUserSet               bool                `json:",omitempty"`
 	ProfileNameSet                bool                `json:",omitempty"`
@@ -600,6 +620,10 @@ func (p *Prefs) pretty(goos string) string {
 			bb, _ := p.NoStatefulFiltering.Get()
 			fmt.Fprintf(&sb, "statefulFiltering=%v ", !bb)
 		}
+		if p.CollectLoadMetrics.EqualBool(true) {
+			// Only print when enabled; it is off by default.
+			fmt.Fprint(&sb, "loadMetrics=true ")
+		}
 	}
 	if len(p.AdvertiseTags) > 0 {
 		fmt.Fprintf(&sb, "tags=%s ", strings.Join(p.AdvertiseTags, ","))
@@ -684,6 +708,7 @@ func (p *Prefs) Equals(p2 *Prefs) bool {
 		p.ShieldsUp == p2.ShieldsUp &&
 		p.NoSNAT == p2.NoSNAT &&
 		p.NoStatefulFiltering == p2.NoStatefulFiltering &&
+		p.CollectLoadMetrics == p2.CollectLoadMetrics &&
 		p.NetfilterMode == p2.NetfilterMode &&
 		p.OperatorUser == p2.OperatorUser &&
 		p.Hostname == p2.Hostname &&

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -60,6 +60,7 @@ func TestPrefsEqual(t *testing.T) {
 		"Sync",
 		"NoSNAT",
 		"NoStatefulFiltering",
+		"CollectLoadMetrics",
 		"NetfilterMode",
 		"OperatorUser",
 		"ProfileName",

--- a/net/packet/packet.go
+++ b/net/packet/packet.go
@@ -461,6 +461,24 @@ func (q *Parsed) Buffer() []byte {
 	return q.b
 }
 
+// TotalLen returns the on-wire length of the packet in bytes: the IPv4 Total
+// Length field, or the IPv6 payload length plus the fixed header.
+//
+// This is not the same as len(q.Buffer()), which includes any trailing slack in
+// the buffer the packet was decoded from. Use TotalLen for anything that
+// accounts for bytes; wireguard-go and the TUN read path both hand up
+// full-MTU buffers holding a shorter packet.
+//
+// It returns 0 unless q decoded as IPv4 or IPv6, and is clamped to the
+// buffer length so a packet truncated below its claimed length never reports
+// more bytes than are present.
+func (q *Parsed) TotalLen() int {
+	if q.IPVersion == 0 {
+		return 0
+	}
+	return min(q.length, len(q.b))
+}
+
 // Payload returns the payload of the IP subprotocol section.
 // This is a read-only view; that is, q retains the ownership of the buffer.
 func (q *Parsed) Payload() []byte {

--- a/net/packet/packet_test.go
+++ b/net/packet/packet_test.go
@@ -806,6 +806,80 @@ func BenchmarkDecode(b *testing.B) {
 	}
 }
 
+// TestTotalLen checks that TotalLen reports the on-wire packet length rather
+// than the length of the buffer the packet was decoded from. Byte accounting
+// depends on this: the TUN write path is handed full-MTU buffers holding a
+// shorter packet, so len(Buffer()) would over-count the slack.
+func TestTotalLen(t *testing.T) {
+	const slack = 500
+
+	tests := []struct {
+		name string
+		buf  []byte
+		want int
+	}{
+		{"udp4", udp4RequestBuffer, len(udp4RequestBuffer)},
+		{"udp6", udp6RequestBuffer, len(udp6RequestBuffer)},
+		{"tcp4", tcp4PacketBuffer, len(tcp4PacketBuffer)},
+		{"tcp6", tcp6RequestBuffer, len(tcp6RequestBuffer)},
+		{"icmp4", icmp4RequestBuffer, len(icmp4RequestBuffer)},
+		{"icmp6", icmp6PacketBuffer, len(icmp6PacketBuffer)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var p Parsed
+			p.Decode(tt.buf)
+			if got := p.TotalLen(); got != tt.want {
+				t.Errorf("TotalLen() on an exact buffer = %d, want %d", got, tt.want)
+			}
+
+			// The same packet in a buffer with trailing slack must report the
+			// same length, not the buffer's.
+			padded := make([]byte, len(tt.buf)+slack)
+			copy(padded, tt.buf)
+			p.Decode(padded)
+			if got := p.TotalLen(); got != tt.want {
+				t.Errorf("TotalLen() with %d bytes of slack = %d, want %d", slack, got, tt.want)
+			}
+			if got := len(p.Buffer()); got == tt.want {
+				t.Errorf("test is not exercising slack: len(Buffer()) = %d", got)
+			}
+		})
+	}
+
+	t.Run("undecodable is zero", func(t *testing.T) {
+		var p Parsed
+		p.Decode(unknownPacketBuffer)
+		if got := p.TotalLen(); got != 0 {
+			t.Errorf("TotalLen() on an undecodable packet = %d, want 0", got)
+		}
+	})
+
+	t.Run("stale length is cleared", func(t *testing.T) {
+		// Decode does not zero length on an early bail-out, so a Parsed
+		// reused across packets (as the pool-backed ones on the packet path
+		// are) must not report the previous packet's length.
+		var p Parsed
+		p.Decode(udp4RequestBuffer)
+		p.Decode(unknownPacketBuffer)
+		if got := p.TotalLen(); got != 0 {
+			t.Errorf("TotalLen() after reuse on an undecodable packet = %d, want 0", got)
+		}
+	})
+
+	t.Run("truncated is clamped to the buffer", func(t *testing.T) {
+		// A packet claiming more bytes than it has must never report more
+		// than are present.
+		var p Parsed
+		p.Decode(udp4RequestBuffer[:len(udp4RequestBuffer)-4])
+		if got := p.TotalLen(); got > len(udp4RequestBuffer)-4 {
+			t.Errorf("TotalLen() on a truncated packet = %d, want at most %d",
+				got, len(udp4RequestBuffer)-4)
+		}
+	})
+}
+
 func TestMarshalRequest(t *testing.T) {
 	// Too small to hold our packets, but only barely.
 	var small [20]byte

--- a/net/tstun/subnetmetrics.go
+++ b/net/tstun/subnetmetrics.go
@@ -4,12 +4,15 @@
 package tstun
 
 import (
+	"cmp"
 	"expvar"
 	"net/netip"
+	"slices"
 	"sync/atomic"
 
 	"github.com/gaissmai/bart"
 	"tailscale.com/feature/buildfeatures"
+	"tailscale.com/net/tsaddr"
 	"tailscale.com/util/clientmetric"
 	"tailscale.com/util/usermetric"
 )
@@ -35,6 +38,16 @@ const (
 	packetsHelp = "Packets forwarded on behalf of tailnet peers for each advertised subnet route. " +
 		`Direction is from the subnet router's point of view: "tx" was sent into the subnet, ` +
 		`"rx" was received from the subnet and returned to the peer.`
+
+	// maxRetainedRoutes caps how many routes' counters are kept alive for the
+	// process's lifetime; see subnetCounters.counters for why retention is
+	// needed and evictRetainedLocked for what happens past the cap.
+	//
+	// A subnet router's advertised set is admin-configured and small; the cap
+	// only matters if it churns unexpectedly. 4 KiB of routeCounters is a few
+	// hundred KiB, and at the cap the labeled series are still bounded by the
+	// advertised set, not by this.
+	maxRetainedRoutes = 4096
 )
 
 // Aggregate node-level clientmetrics, registered over the same [expvar.Int]
@@ -57,6 +70,11 @@ type routeCounters struct {
 	rxBytes   expvar.Int
 	txPackets expvar.Int
 	rxPackets expvar.Int
+
+	// lastActiveSeq is the value of subnetCounters.seq when this route was
+	// last advertised. Eviction drops the least recently advertised routes
+	// first. Only ever accessed from setRoutes.
+	lastActiveSeq uint64
 }
 
 // add records a packet of size bytes in the given direction.
@@ -78,6 +96,12 @@ func (rc *routeCounters) add(bytes int, rx bool) {
 // lookup plus atomic adds: no allocation, no label formatting, and no map
 // hashing per packet.
 //
+// A subnetCounters lives for the lifetime of the [Wrapper] once created, even
+// while the feature is disabled: the aggregate clientmetrics it registers
+// values with cannot be unregistered individually, and both metric views are
+// counters, which must never decrease. Disabling clears the lookup table
+// instead, which is what the packet path checks.
+//
 // It is not safe to call setRoutes concurrently with itself; the engine calls
 // it only from Reconfig. Lookups are safe concurrently with setRoutes.
 type subnetCounters struct {
@@ -87,23 +111,38 @@ type subnetCounters struct {
 	// table maps an address to the counters for the most specific advertised
 	// route containing it. setRoutes swaps in a wholly new table rather than
 	// mutating the published one, so the packet path needs no locking.
+	//
+	// It is nil when no countable route is advertised, which is how the packet
+	// path skips its work: see [Wrapper.subnetCountersActive].
 	table atomicPrefixTable
 
-	// counters holds the counters for every route advertised during this
-	// process's lifetime, including withdrawn ones.
+	// counters holds the counters for every route advertised recently,
+	// including withdrawn ones, up to maxRetainedRoutes entries.
 	//
-	// Entries are never removed. Withdrawn routes must stay registered with
-	// the aggregate clientmetrics, because those are counters and dropping a
-	// route's contribution would make them decrease. Retaining the entry also
-	// means a route that is withdrawn and later re-advertised resumes its
-	// previous total instead of resetting. The labeled usermetric series *are*
-	// removed on withdrawal, so per-route cardinality tracks the advertised
-	// set. Only ever accessed from setRoutes.
+	// Withdrawn routes are retained because they must stay registered with the
+	// aggregate clientmetrics: those are counters, and dropping a route's
+	// contribution would make them decrease. Retaining the entry also means a
+	// route that is withdrawn and later re-advertised resumes its previous
+	// total instead of resetting. The labeled usermetric series *are* removed
+	// on withdrawal, so per-route cardinality tracks the advertised set.
+	//
+	// Only ever accessed from setRoutes.
 	counters map[netip.Prefix]*routeCounters
+
+	// evicted accumulates the totals of routes dropped from counters once it
+	// reached maxRetainedRoutes. It stays registered with the aggregates
+	// forever, so eviction preserves their value; only the per-route breakdown
+	// of those bytes is lost, and an evicted route has not been advertised for
+	// at least maxRetainedRoutes reconfigs. Only ever accessed from setRoutes.
+	evicted routeCounters
 
 	// active is the set of currently advertised routes, i.e. those with live
 	// labeled series. Only ever accessed from setRoutes.
 	active map[netip.Prefix]bool
+
+	// seq increments on every setRoutes call and orders routes by how recently
+	// they were advertised, for eviction. Only ever accessed from setRoutes.
+	seq uint64
 }
 
 // atomicPrefixTable is an atomically-swappable longest-prefix-match table.
@@ -117,13 +156,13 @@ func (a *atomicPrefixTable) store(t *bart.Table[*routeCounters]) {
 }
 
 // newSubnetCounters returns a subnetCounters that publishes its per-route
-// series into reg.
+// series into reg. It starts with no routes, i.e. inactive.
 func newSubnetCounters(reg *usermetric.Registry) *subnetCounters {
 	sc := &subnetCounters{
 		counters: map[netip.Prefix]*routeCounters{},
 		active:   map[netip.Prefix]bool{},
 	}
-	sc.table.store(&bart.Table[*routeCounters]{})
+	sc.registerAggregate(&sc.evicted)
 	if buildfeatures.HasUserMetrics {
 		sc.bytesTotal = usermetric.NewMultiLabelMapWithRegistry[subnetRouteLabels](
 			reg, "tailscaled_subnet_forwarded_bytes_total", "counter", bytesHelp)
@@ -139,12 +178,39 @@ func newSubnetCounters(reg *usermetric.Registry) *subnetCounters {
 // exit-node traffic to 0.0.0.0/0 would be misleading. This mirrors the
 // Bits() > 0 check the network flow logger uses when classifying subnet
 // traffic.
-func countableRoute(p netip.Prefix) bool { return p.IsValid() && p.Bits() > 0 }
+//
+// 4via6 routes are excluded too, for M1. Their prefixes live inside
+// fd7a:115c:a1e0::/48, so both endpoints of 4via6 traffic are Tailscale
+// addresses and countSubnetRouteTraffic's "exactly one Tailscale endpoint"
+// test never admits such a packet. Admitting the route anyway would publish
+// four series that can never move, which reads to an operator as an idle
+// router rather than an unsupported route type. Counting 4via6 properly needs
+// attribution on the translated v4 address, which is a later milestone.
+func countableRoute(p netip.Prefix) bool {
+	return p.IsValid() && p.Bits() > 0 && !tsaddr.IsViaPrefix(p)
+}
+
+// anyCountableRoute reports whether routes contains at least one route that
+// would get counters, i.e. whether counting should be active at all.
+func anyCountableRoute(routes []netip.Prefix) bool {
+	for _, p := range routes {
+		if countableRoute(p) {
+			return true
+		}
+	}
+	return false
+}
 
 // setRoutes updates the set of advertised routes being counted.
+//
+// Passing no countable routes deactivates counting without discarding any
+// retained totals: the lookup table is cleared and the labeled series are
+// removed, but the [expvar.Int] values stay registered with the aggregates so
+// neither metric view decreases.
 func (sc *subnetCounters) setRoutes(routes []netip.Prefix) {
+	sc.seq++
 	next := make(map[netip.Prefix]bool, len(routes))
-	tbl := &bart.Table[*routeCounters]{}
+	var tbl *bart.Table[*routeCounters]
 
 	for _, p := range routes {
 		if !countableRoute(p) {
@@ -160,10 +226,14 @@ func (sc *subnetCounters) setRoutes(routes []netip.Prefix) {
 			sc.counters[p] = rc
 			sc.registerAggregate(rc)
 		}
+		rc.lastActiveSeq = sc.seq
 		if !sc.active[p] {
 			sc.setSeries(p, rc)
 		}
 		next[p] = true
+		if tbl == nil {
+			tbl = &bart.Table[*routeCounters]{}
+		}
 		tbl.Insert(p, rc)
 	}
 
@@ -175,7 +245,56 @@ func (sc *subnetCounters) setRoutes(routes []netip.Prefix) {
 	}
 
 	sc.active = next
+	sc.evictRetained()
 	sc.table.store(tbl)
+}
+
+// evictRetained drops the least recently advertised retained routes once
+// counters exceeds maxRetainedRoutes, folding their totals into sc.evicted so
+// that the aggregate clientmetrics keep their value.
+//
+// Currently advertised routes are never evicted: the cap is on retention of
+// withdrawn routes, and the advertised set is bounded by admin configuration.
+func (sc *subnetCounters) evictRetained() {
+	if len(sc.counters) <= maxRetainedRoutes {
+		return
+	}
+	// Evict down to half the cap so this runs amortized-rarely rather than on
+	// every reconfig once at the cap.
+	target := maxRetainedRoutes / 2
+	type candidate struct {
+		p   netip.Prefix
+		seq uint64
+	}
+	cands := make([]candidate, 0, len(sc.counters))
+	for p, rc := range sc.counters {
+		if sc.active[p] {
+			continue
+		}
+		cands = append(cands, candidate{p, rc.lastActiveSeq})
+	}
+	// Oldest first.
+	slices.SortFunc(cands, func(a, b candidate) int { return cmp.Compare(a.seq, b.seq) })
+	for _, c := range cands {
+		if len(sc.counters) <= target {
+			break
+		}
+		rc := sc.counters[c.p]
+		// Fold the evicted totals into the residual counter, which stays
+		// registered with the aggregates, then drop the entry. rc's own values
+		// are still in the aggregates' registered set with no way to remove
+		// them, so zero them out to avoid double counting: nothing references
+		// rc after this, so no further adds can land on it.
+		sc.evicted.txBytes.Add(rc.txBytes.Value())
+		sc.evicted.rxBytes.Add(rc.rxBytes.Value())
+		sc.evicted.txPackets.Add(rc.txPackets.Value())
+		sc.evicted.rxPackets.Add(rc.rxPackets.Value())
+		rc.txBytes.Set(0)
+		rc.rxBytes.Set(0)
+		rc.txPackets.Set(0)
+		rc.rxPackets.Set(0)
+		delete(sc.counters, c.p)
+	}
 }
 
 // registerAggregate adds rc's counters to the node-level clientmetrics.
@@ -214,9 +333,14 @@ func (sc *subnetCounters) deleteSeries(p netip.Prefix) {
 }
 
 // forAddr returns the counters for the most specific advertised route
-// containing addr, or nil if addr is not within any advertised route.
+// containing addr, or nil if addr is not within any advertised route or
+// counting is currently inactive.
 func (sc *subnetCounters) forAddr(addr netip.Addr) *routeCounters {
-	rc, _ := sc.table.load().Lookup(addr)
+	tbl := sc.table.load()
+	if tbl == nil {
+		return nil
+	}
+	rc, _ := tbl.Lookup(addr)
 	return rc
 }
 
@@ -228,4 +352,22 @@ func (sc *subnetCounters) forRoute(p netip.Prefix) *routeCounters {
 		return nil
 	}
 	return sc.counters[p]
+}
+
+// retainedForRoute returns the counters retained for exactly p whether or not
+// it is currently advertised, or nil if p has never been advertised (or was
+// evicted). For tests.
+func (sc *subnetCounters) retainedForRoute(p netip.Prefix) *routeCounters {
+	return sc.counters[p.Masked()]
+}
+
+// aggregateTxBytesForTest returns the sum of tx bytes across every retained
+// route plus the residual from evicted ones, i.e. what the aggregate
+// clientmetric should read for this instance.
+func (sc *subnetCounters) aggregateTxBytesForTest() int64 {
+	total := sc.evicted.txBytes.Value()
+	for _, rc := range sc.counters {
+		total += rc.txBytes.Value()
+	}
+	return total
 }

--- a/net/tstun/subnetmetrics.go
+++ b/net/tstun/subnetmetrics.go
@@ -1,0 +1,231 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package tstun
+
+import (
+	"expvar"
+	"net/netip"
+	"sync/atomic"
+
+	"github.com/gaissmai/bart"
+	"tailscale.com/feature/buildfeatures"
+	"tailscale.com/util/clientmetric"
+	"tailscale.com/util/usermetric"
+)
+
+// subnetRouteLabels are the Prometheus labels for the per-route subnet
+// forwarding counters.
+type subnetRouteLabels struct {
+	// Route is the advertised route the traffic was attributed to,
+	// e.g. "10.1.0.0/16".
+	Route string `prom:"route"`
+	// Direction is "tx" or "rx", from the subnet router's point of view.
+	// See the metric help text for the exact meaning.
+	Direction string `prom:"direction"`
+}
+
+const (
+	directionTx = "tx"
+	directionRx = "rx"
+
+	bytesHelp = "Bytes forwarded on behalf of tailnet peers for each advertised subnet route. " +
+		`Direction is from the subnet router's point of view: "tx" was sent into the subnet, ` +
+		`"rx" was received from the subnet and returned to the peer.`
+	packetsHelp = "Packets forwarded on behalf of tailnet peers for each advertised subnet route. " +
+		`Direction is from the subnet router's point of view: "tx" was sent into the subnet, ` +
+		`"rx" was received from the subnet and returned to the peer.`
+)
+
+// Aggregate node-level clientmetrics, registered over the same [expvar.Int]
+// values that back the labeled usermetrics. clientmetrics cannot express
+// labels, so these are sums across every advertised route.
+var (
+	cMetricSubnetForwardedTxBytes   = clientmetric.NewAggregateCounter("subnet_forwarded_tx_bytes")
+	cMetricSubnetForwardedRxBytes   = clientmetric.NewAggregateCounter("subnet_forwarded_rx_bytes")
+	cMetricSubnetForwardedTxPackets = clientmetric.NewAggregateCounter("subnet_forwarded_tx_packets")
+	cMetricSubnetForwardedRxPackets = clientmetric.NewAggregateCounter("subnet_forwarded_rx_packets")
+)
+
+// routeCounters holds the four counters for a single advertised route.
+//
+// The same [expvar.Int] values are referenced by the labeled usermetric maps
+// and by the aggregate clientmetrics, so one atomic add on the packet path
+// updates both metric systems.
+type routeCounters struct {
+	txBytes   expvar.Int
+	rxBytes   expvar.Int
+	txPackets expvar.Int
+	rxPackets expvar.Int
+}
+
+// add records a packet of size bytes in the given direction.
+func (rc *routeCounters) add(bytes int, rx bool) {
+	if rx {
+		rc.rxBytes.Add(int64(bytes))
+		rc.rxPackets.Add(1)
+		return
+	}
+	rc.txBytes.Add(int64(bytes))
+	rc.txPackets.Add(1)
+}
+
+// subnetCounters counts forwarded traffic per advertised subnet route.
+//
+// Routes are resolved to their [routeCounters] once, when the set of
+// advertised routes changes, and the resulting pointers are stored as the
+// prefix table's values. The packet path is then a single longest-prefix
+// lookup plus atomic adds: no allocation, no label formatting, and no map
+// hashing per packet.
+//
+// It is not safe to call setRoutes concurrently with itself; the engine calls
+// it only from Reconfig. Lookups are safe concurrently with setRoutes.
+type subnetCounters struct {
+	bytesTotal   *usermetric.MultiLabelMap[subnetRouteLabels]
+	packetsTotal *usermetric.MultiLabelMap[subnetRouteLabels]
+
+	// table maps an address to the counters for the most specific advertised
+	// route containing it. setRoutes swaps in a wholly new table rather than
+	// mutating the published one, so the packet path needs no locking.
+	table atomicPrefixTable
+
+	// counters holds the counters for every route advertised during this
+	// process's lifetime, including withdrawn ones.
+	//
+	// Entries are never removed. Withdrawn routes must stay registered with
+	// the aggregate clientmetrics, because those are counters and dropping a
+	// route's contribution would make them decrease. Retaining the entry also
+	// means a route that is withdrawn and later re-advertised resumes its
+	// previous total instead of resetting. The labeled usermetric series *are*
+	// removed on withdrawal, so per-route cardinality tracks the advertised
+	// set. Only ever accessed from setRoutes.
+	counters map[netip.Prefix]*routeCounters
+
+	// active is the set of currently advertised routes, i.e. those with live
+	// labeled series. Only ever accessed from setRoutes.
+	active map[netip.Prefix]bool
+}
+
+// atomicPrefixTable is an atomically-swappable longest-prefix-match table.
+type atomicPrefixTable struct {
+	v atomic.Pointer[bart.Table[*routeCounters]]
+}
+
+func (a *atomicPrefixTable) load() *bart.Table[*routeCounters] { return a.v.Load() }
+func (a *atomicPrefixTable) store(t *bart.Table[*routeCounters]) {
+	a.v.Store(t)
+}
+
+// newSubnetCounters returns a subnetCounters that publishes its per-route
+// series into reg.
+func newSubnetCounters(reg *usermetric.Registry) *subnetCounters {
+	sc := &subnetCounters{
+		counters: map[netip.Prefix]*routeCounters{},
+		active:   map[netip.Prefix]bool{},
+	}
+	sc.table.store(&bart.Table[*routeCounters]{})
+	if buildfeatures.HasUserMetrics {
+		sc.bytesTotal = usermetric.NewMultiLabelMapWithRegistry[subnetRouteLabels](
+			reg, "tailscaled_subnet_forwarded_bytes_total", "counter", bytesHelp)
+		sc.packetsTotal = usermetric.NewMultiLabelMapWithRegistry[subnetRouteLabels](
+			reg, "tailscaled_subnet_forwarded_packets_total", "counter", packetsHelp)
+	}
+	return sc
+}
+
+// countableRoute reports whether a route should get its own counters.
+//
+// Exit routes are excluded: they are not subnet routes, and attributing all
+// exit-node traffic to 0.0.0.0/0 would be misleading. This mirrors the
+// Bits() > 0 check the network flow logger uses when classifying subnet
+// traffic.
+func countableRoute(p netip.Prefix) bool { return p.IsValid() && p.Bits() > 0 }
+
+// setRoutes updates the set of advertised routes being counted.
+func (sc *subnetCounters) setRoutes(routes []netip.Prefix) {
+	next := make(map[netip.Prefix]bool, len(routes))
+	tbl := &bart.Table[*routeCounters]{}
+
+	for _, p := range routes {
+		if !countableRoute(p) {
+			continue
+		}
+		p = p.Masked()
+		if next[p] {
+			continue
+		}
+		rc, ok := sc.counters[p]
+		if !ok {
+			rc = new(routeCounters)
+			sc.counters[p] = rc
+			sc.registerAggregate(rc)
+		}
+		if !sc.active[p] {
+			sc.setSeries(p, rc)
+		}
+		next[p] = true
+		tbl.Insert(p, rc)
+	}
+
+	// Remove the labeled series for routes that are no longer advertised.
+	for p := range sc.active {
+		if !next[p] {
+			sc.deleteSeries(p)
+		}
+	}
+
+	sc.active = next
+	sc.table.store(tbl)
+}
+
+// registerAggregate adds rc's counters to the node-level clientmetrics.
+func (sc *subnetCounters) registerAggregate(rc *routeCounters) {
+	if !buildfeatures.HasClientMetrics {
+		return
+	}
+	cMetricSubnetForwardedTxBytes.Register(&rc.txBytes)
+	cMetricSubnetForwardedRxBytes.Register(&rc.rxBytes)
+	cMetricSubnetForwardedTxPackets.Register(&rc.txPackets)
+	cMetricSubnetForwardedRxPackets.Register(&rc.rxPackets)
+}
+
+// setSeries publishes the labeled usermetric series for p.
+func (sc *subnetCounters) setSeries(p netip.Prefix, rc *routeCounters) {
+	if !buildfeatures.HasUserMetrics {
+		return
+	}
+	route := p.String()
+	sc.bytesTotal.Set(subnetRouteLabels{route, directionTx}, &rc.txBytes)
+	sc.bytesTotal.Set(subnetRouteLabels{route, directionRx}, &rc.rxBytes)
+	sc.packetsTotal.Set(subnetRouteLabels{route, directionTx}, &rc.txPackets)
+	sc.packetsTotal.Set(subnetRouteLabels{route, directionRx}, &rc.rxPackets)
+}
+
+// deleteSeries removes the labeled usermetric series for a withdrawn route.
+func (sc *subnetCounters) deleteSeries(p netip.Prefix) {
+	if !buildfeatures.HasUserMetrics {
+		return
+	}
+	route := p.String()
+	sc.bytesTotal.Delete(subnetRouteLabels{route, directionTx})
+	sc.bytesTotal.Delete(subnetRouteLabels{route, directionRx})
+	sc.packetsTotal.Delete(subnetRouteLabels{route, directionTx})
+	sc.packetsTotal.Delete(subnetRouteLabels{route, directionRx})
+}
+
+// forAddr returns the counters for the most specific advertised route
+// containing addr, or nil if addr is not within any advertised route.
+func (sc *subnetCounters) forAddr(addr netip.Addr) *routeCounters {
+	rc, _ := sc.table.load().Lookup(addr)
+	return rc
+}
+
+// forRoute returns the counters registered for exactly p, or nil if p is not
+// currently advertised.
+func (sc *subnetCounters) forRoute(p netip.Prefix) *routeCounters {
+	p = p.Masked()
+	if !sc.active[p] {
+		return nil
+	}
+	return sc.counters[p]
+}

--- a/net/tstun/subnetmetrics.go
+++ b/net/tstun/subnetmetrics.go
@@ -112,9 +112,12 @@ type subnetCounters struct {
 	// route containing it. setRoutes swaps in a wholly new table rather than
 	// mutating the published one, so the packet path needs no locking.
 	//
-	// It is nil when no countable route is advertised, which is how the packet
-	// path skips its work: see [Wrapper.subnetCountersActive].
-	table atomicPrefixTable
+	// It holds nil when no countable route is advertised, which is how the
+	// packet path skips its work. It is owned by the [Wrapper] rather than
+	// stored inline here so that the packet path reaches it with a single
+	// atomic load, without first loading the subnetCounters: a node that has
+	// not opted in must pay no more than one nil check per packet.
+	table *atomicPrefixTable
 
 	// counters holds the counters for every route advertised recently,
 	// including withdrawn ones, up to maxRetainedRoutes entries.
@@ -156,9 +159,11 @@ func (a *atomicPrefixTable) store(t *bart.Table[*routeCounters]) {
 }
 
 // newSubnetCounters returns a subnetCounters that publishes its per-route
-// series into reg. It starts with no routes, i.e. inactive.
-func newSubnetCounters(reg *usermetric.Registry) *subnetCounters {
+// series into reg and its lookup table into table. It starts with no routes,
+// i.e. inactive.
+func newSubnetCounters(reg *usermetric.Registry, table *atomicPrefixTable) *subnetCounters {
 	sc := &subnetCounters{
+		table:    table,
 		counters: map[netip.Prefix]*routeCounters{},
 		active:   map[netip.Prefix]bool{},
 	}

--- a/net/tstun/subnetmetrics.go
+++ b/net/tstun/subnetmetrics.go
@@ -41,7 +41,7 @@ const (
 
 	// maxRetainedRoutes caps how many routes' counters are kept alive for the
 	// process's lifetime; see subnetCounters.counters for why retention is
-	// needed and evictRetainedLocked for what happens past the cap.
+	// needed and evictRetained for what happens past the cap.
 	//
 	// A subnet router's advertised set is admin-configured and small; the cap
 	// only matters if it churns unexpectedly. 4 KiB of routeCounters is a few
@@ -186,7 +186,7 @@ func newSubnetCounters(reg *usermetric.Registry, table *atomicPrefixTable) *subn
 //
 // 4via6 routes are excluded too, for M1. Their prefixes live inside
 // fd7a:115c:a1e0::/48, so both endpoints of 4via6 traffic are Tailscale
-// addresses and countSubnetRouteTraffic's "exactly one Tailscale endpoint"
+// addresses and countSubnetRouteParsed's "exactly one Tailscale endpoint"
 // test never admits such a packet. Admitting the route anyway would publish
 // four series that can never move, which reads to an operator as an idle
 // router rather than an unsupported route type. Counting 4via6 properly needs

--- a/net/tstun/subnetmetrics_test.go
+++ b/net/tstun/subnetmetrics_test.go
@@ -325,3 +325,54 @@ func TestWrapperSubnetRouteCountingOffByDefault(t *testing.T) {
 		t.Errorf("subnetCounters is non-nil with no routes set: %v series", seriesCount(sc))
 	}
 }
+
+// TestSubnetCountersAggregateAgreement checks that the unlabeled clientmetric
+// aggregates move by the same amounts as the labeled series, since both are
+// fed from the same backing values.
+//
+// The aggregates are process-global and other tests in this package register
+// counters with them, so this compares deltas rather than absolute values.
+func TestSubnetCountersAggregateAgreement(t *testing.T) {
+	sc := newSubnetCounters(new(usermetric.Registry))
+	sc.setRoutes(mustPrefixes(t, []string{"10.1.0.0/16", "192.168.0.0/24"}))
+
+	base := [4]int64{
+		cMetricSubnetForwardedTxBytes.Value(),
+		cMetricSubnetForwardedRxBytes.Value(),
+		cMetricSubnetForwardedTxPackets.Value(),
+		cMetricSubnetForwardedRxPackets.Value(),
+	}
+
+	sc.forAddr(netip.MustParseAddr("10.1.2.3")).add(1000, false)
+	sc.forAddr(netip.MustParseAddr("10.1.2.4")).add(64, true)
+	sc.forAddr(netip.MustParseAddr("192.168.0.9")).add(500, false)
+
+	// Summing the per-route series gives what the aggregates should have
+	// gained, because both read the same expvar.Int values.
+	var want [4]int64
+	for _, route := range []string{"10.1.0.0/16", "192.168.0.0/24"} {
+		txB, rxB, txP, rxP := routeCountsFor(t, sc, route)
+		want[0] += txB
+		want[1] += rxB
+		want[2] += txP
+		want[3] += rxP
+	}
+
+	got := [4]int64{
+		cMetricSubnetForwardedTxBytes.Value() - base[0],
+		cMetricSubnetForwardedRxBytes.Value() - base[1],
+		cMetricSubnetForwardedTxPackets.Value() - base[2],
+		cMetricSubnetForwardedRxPackets.Value() - base[3],
+	}
+	names := [4]string{
+		"subnet_forwarded_tx_bytes",
+		"subnet_forwarded_rx_bytes",
+		"subnet_forwarded_tx_packets",
+		"subnet_forwarded_rx_packets",
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("%s gained %d, want %d (sum of the labeled series)", names[i], got[i], want[i])
+		}
+	}
+}

--- a/net/tstun/subnetmetrics_test.go
+++ b/net/tstun/subnetmetrics_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	tsmetrics "tailscale.com/metrics"
+	"tailscale.com/util/eventbus/eventbustest"
 	"tailscale.com/util/usermetric"
 )
 
@@ -219,5 +220,108 @@ func BenchmarkSubnetCountersAdd(b *testing.B) {
 		if rc := sc.forAddr(addr); rc != nil {
 			rc.add(1500, false)
 		}
+	}
+}
+
+// TestWrapperSubnetRouteCountingTx checks that traffic entering the TUN from a
+// tailnet peer, bound for a host inside an advertised subnet, is counted as tx:
+// the router is sending it into the subnet on the peer's behalf.
+func TestWrapperSubnetRouteCountingTx(t *testing.T) {
+	bus := eventbustest.NewBus(t)
+	_, tun := newFakeTUN(t.Logf, bus, false)
+	defer tun.Close()
+
+	if tun.subnetCounters() != nil {
+		t.Fatal("counting is enabled before SetSubnetRoutes; want disabled by default")
+	}
+	tun.SetSubnetRoutes([]netip.Prefix{netip.MustParsePrefix("10.1.0.0/16")})
+	sc := tun.subnetCounters()
+	if sc == nil {
+		t.Fatal("counting still disabled after SetSubnetRoutes")
+	}
+
+	pkt := udp4("100.64.0.1", "10.1.2.3", 123, 456)
+	if _, err := tun.tdevWrite([][]byte{pkt}, 0); err != nil {
+		t.Fatalf("tdevWrite: %v", err)
+	}
+
+	txBytes, rxBytes, txPackets, rxPackets := routeCountsFor(t, sc, "10.1.0.0/16")
+	if txPackets != 1 {
+		t.Errorf("txPackets = %d, want 1", txPackets)
+	}
+	if txBytes != int64(len(pkt)) {
+		t.Errorf("txBytes = %d, want %d", txBytes, len(pkt))
+	}
+	if rxPackets != 0 || rxBytes != 0 {
+		t.Errorf("rx counters moved on a tx packet: rxBytes=%d rxPackets=%d", rxBytes, rxPackets)
+	}
+
+	// Traffic to an address outside every advertised route (exit node traffic)
+	// must not be counted.
+	if _, err := tun.tdevWrite([][]byte{udp4("100.64.0.1", "192.0.2.7", 1, 2)}, 0); err != nil {
+		t.Fatalf("tdevWrite: %v", err)
+	}
+	if _, _, gotTx, _ := routeCountsFor(t, sc, "10.1.0.0/16"); gotTx != 1 {
+		t.Errorf("txPackets = %d after an unrouted packet, want still 1", gotTx)
+	}
+
+	// Traffic between two tailnet addresses is the node's own, not forwarded.
+	if _, err := tun.tdevWrite([][]byte{udp4("100.64.0.1", "100.64.0.2", 1, 2)}, 0); err != nil {
+		t.Fatalf("tdevWrite: %v", err)
+	}
+	if _, _, gotTx, _ := routeCountsFor(t, sc, "10.1.0.0/16"); gotTx != 1 {
+		t.Errorf("txPackets = %d after tailnet-only traffic, want still 1", gotTx)
+	}
+}
+
+// TestWrapperSubnetRouteCountingRx checks that traffic read out of the TUN
+// toward a tailnet peer is counted as rx: the router received it from the
+// subnet and is returning it to the peer.
+func TestWrapperSubnetRouteCountingRx(t *testing.T) {
+	bus := eventbustest.NewBus(t)
+	chtun, tun := newChannelTUN(t.Logf, bus, false)
+	defer tun.Close()
+
+	tun.SetSubnetRoutes([]netip.Prefix{netip.MustParsePrefix("10.1.0.0/16")})
+	sc := tun.subnetCounters()
+	if sc == nil {
+		t.Fatal("counting disabled after SetSubnetRoutes")
+	}
+
+	pkt := udp4("10.1.2.3", "100.64.0.1", 456, 123)
+	go func() { chtun.Outbound <- pkt }()
+
+	var buf [MaxPacketSize]byte
+	buffs := [][]byte{buf[:]}
+	sizes := make([]int, 1)
+	if _, err := tun.Read(buffs, sizes, 0); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	txBytes, rxBytes, txPackets, rxPackets := routeCountsFor(t, sc, "10.1.0.0/16")
+	if rxPackets != 1 {
+		t.Errorf("rxPackets = %d, want 1", rxPackets)
+	}
+	if rxBytes != int64(len(pkt)) {
+		t.Errorf("rxBytes = %d, want %d", rxBytes, len(pkt))
+	}
+	if txPackets != 0 || txBytes != 0 {
+		t.Errorf("tx counters moved on an rx packet: txBytes=%d txPackets=%d", txBytes, txPackets)
+	}
+}
+
+// TestWrapperSubnetRouteCountingOffByDefault verifies that traffic is not
+// counted, and no series exist, until routes are set.
+func TestWrapperSubnetRouteCountingOffByDefault(t *testing.T) {
+	bus := eventbustest.NewBus(t)
+	_, tun := newFakeTUN(t.Logf, bus, false)
+	defer tun.Close()
+
+	pkt := udp4("100.64.0.1", "10.1.2.3", 123, 456)
+	if _, err := tun.tdevWrite([][]byte{pkt}, 0); err != nil {
+		t.Fatalf("tdevWrite: %v", err)
+	}
+	if sc := tun.subnetCounters(); sc != nil {
+		t.Errorf("subnetCounters is non-nil with no routes set: %v series", seriesCount(sc))
 	}
 }

--- a/net/tstun/subnetmetrics_test.go
+++ b/net/tstun/subnetmetrics_test.go
@@ -274,6 +274,42 @@ func TestWrapperSubnetRouteCountingTx(t *testing.T) {
 	}
 }
 
+// TestWrapperSubnetRouteCountingBufferSlack checks that only the decoded
+// packet length is counted, not the slack in the buffer holding it.
+//
+// wireguard-go hands Write a full-MTU buffer per packet with the payload at
+// [PacketStartOffset:PacketStartOffset+n], so buffs[i][offset:] runs to the end
+// of the buffer. Counting len(b) there would attribute every trailing byte of
+// slack to the route and report a bogus mean packet size.
+func TestWrapperSubnetRouteCountingBufferSlack(t *testing.T) {
+	bus := eventbustest.NewBus(t)
+	_, tun := newFakeTUN(t.Logf, bus, false)
+	defer tun.Close()
+
+	tun.SetSubnetRoutes([]netip.Prefix{netip.MustParsePrefix("10.1.0.0/16")})
+	sc := tun.subnetCounters()
+	if sc == nil {
+		t.Fatal("counting disabled after SetSubnetRoutes")
+	}
+
+	pkt := udp4("100.64.0.1", "10.1.2.3", 123, 456)
+	buf := make([]byte, PacketStartOffset+MaxPacketSize)
+	copy(buf[PacketStartOffset:], pkt)
+
+	if _, err := tun.tdevWrite([][]byte{buf}, PacketStartOffset); err != nil {
+		t.Fatalf("tdevWrite: %v", err)
+	}
+
+	txBytes, _, txPackets, _ := routeCountsFor(t, sc, "10.1.0.0/16")
+	if txPackets != 1 {
+		t.Errorf("txPackets = %d, want 1", txPackets)
+	}
+	if txBytes != int64(len(pkt)) {
+		t.Errorf("txBytes = %d, want %d (the packet length, not the %d-byte buffer)",
+			txBytes, len(pkt), len(buf)-PacketStartOffset)
+	}
+}
+
 // TestWrapperSubnetRouteCountingRx checks that traffic read out of the TUN
 // toward a tailnet peer is counted as rx: the router received it from the
 // subnet and is returning it to the peer.

--- a/net/tstun/subnetmetrics_test.go
+++ b/net/tstun/subnetmetrics_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package tstun
+
+import (
+	"net/netip"
+	"testing"
+
+	"tailscale.com/util/usermetric"
+)
+
+// routeCountsFor returns the four counter values for the given route, or
+// zeroes if the route is not being counted.
+func routeCountsFor(t *testing.T, sc *subnetCounters, route string) (txBytes, rxBytes, txPackets, rxPackets int64) {
+	t.Helper()
+	pfx := netip.MustParsePrefix(route)
+	rc := sc.forRoute(pfx)
+	if rc == nil {
+		return 0, 0, 0, 0
+	}
+	return rc.txBytes.Value(), rc.rxBytes.Value(), rc.txPackets.Value(), rc.rxPackets.Value()
+}
+
+func TestSubnetCountersAttribution(t *testing.T) {
+	tests := []struct {
+		name string
+		// routes advertised by this node.
+		routes []string
+		// remote is the non-Tailscale endpoint of the packet.
+		remote string
+		// wantRoute is the route the traffic should be attributed to,
+		// or "" if the packet should not be counted at all.
+		wantRoute string
+	}{
+		{
+			name:      "within advertised prefix",
+			routes:    []string{"10.1.0.0/16"},
+			remote:    "10.1.2.3",
+			wantRoute: "10.1.0.0/16",
+		},
+		{
+			name:      "outside all prefixes is not counted",
+			routes:    []string{"10.1.0.0/16"},
+			remote:    "192.0.2.5",
+			wantRoute: "",
+		},
+		{
+			name:      "longest prefix wins",
+			routes:    []string{"10.0.0.0/8", "10.1.0.0/16"},
+			remote:    "10.1.2.3",
+			wantRoute: "10.1.0.0/16",
+		},
+		{
+			name:      "less specific route still matches outside the specific one",
+			routes:    []string{"10.0.0.0/8", "10.1.0.0/16"},
+			remote:    "10.9.9.9",
+			wantRoute: "10.0.0.0/8",
+		},
+		{
+			name:      "IPv4 exit route is excluded",
+			routes:    []string{"0.0.0.0/0"},
+			remote:    "192.0.2.5",
+			wantRoute: "",
+		},
+		{
+			name:      "IPv6 exit route is excluded",
+			routes:    []string{"::/0"},
+			remote:    "2001:db8::1",
+			wantRoute: "",
+		},
+		{
+			name:      "IPv6 subnet route",
+			routes:    []string{"2001:db8::/32"},
+			remote:    "2001:db8::1",
+			wantRoute: "2001:db8::/32",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := newSubnetCounters(new(usermetric.Registry))
+			sc.setRoutes(mustPrefixes(t, tt.routes))
+
+			remote := netip.MustParseAddr(tt.remote)
+			got := sc.forAddr(remote)
+
+			if tt.wantRoute == "" {
+				if got != nil {
+					t.Fatalf("forAddr(%v) = counters for a route; want no match", remote)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("forAddr(%v) = no match; want counters for %v", remote, tt.wantRoute)
+			}
+			want := sc.forRoute(netip.MustParsePrefix(tt.wantRoute))
+			if want == nil {
+				t.Fatalf("route %v has no counters registered", tt.wantRoute)
+			}
+			if got != want {
+				t.Errorf("forAddr(%v) attributed to the wrong route; want %v", remote, tt.wantRoute)
+			}
+		})
+	}
+}
+
+func mustPrefixes(t *testing.T, ss []string) []netip.Prefix {
+	t.Helper()
+	ps := make([]netip.Prefix, 0, len(ss))
+	for _, s := range ss {
+		ps = append(ps, netip.MustParsePrefix(s))
+	}
+	return ps
+}

--- a/net/tstun/subnetmetrics_test.go
+++ b/net/tstun/subnetmetrics_test.go
@@ -4,10 +4,14 @@
 package tstun
 
 import (
+	"expvar"
+	"fmt"
 	"net/netip"
 	"testing"
 
 	tsmetrics "tailscale.com/metrics"
+	"tailscale.com/net/packet"
+	"tailscale.com/net/tsaddr"
 	"tailscale.com/util/eventbus/eventbustest"
 	"tailscale.com/util/usermetric"
 )
@@ -205,20 +209,424 @@ func TestSubnetCountersNoAllocs(t *testing.T) {
 	}
 }
 
+// TestSubnetCountersDisableEnableCycle checks that toggling the feature off and
+// back on does not reset the labeled counters. Prometheus counters must never
+// decrease: a reset produces a phantom rate() spike and false alerts.
+//
+// tailscale down/up, a profile switch, and Reconfig(&router.Config{}) from
+// enterStateLocked all drive an empty route set through this path.
+func TestSubnetCountersDisableEnableCycle(t *testing.T) {
+	bus := eventbustest.NewBus(t)
+	_, tun := newFakeTUN(t.Logf, bus, false)
+	defer tun.Close()
+
+	routes := []netip.Prefix{netip.MustParsePrefix("10.1.0.0/16")}
+	tun.SetSubnetRoutes(routes)
+	sc := tun.subnetCounters()
+	if sc == nil {
+		t.Fatal("counting disabled after SetSubnetRoutes")
+	}
+	sc.forAddr(netip.MustParseAddr("10.1.2.3")).add(1000000, false)
+
+	// The labeled series and the aggregates must agree here, before the toggle.
+	if got := labeledSeriesValue(t, sc, "10.1.0.0/16", directionTx, true); got != 1000000 {
+		t.Fatalf("labeled tx_bytes before the toggle = %d, want 1000000", got)
+	}
+
+	// Disable, then re-enable with the same route.
+	tun.SetSubnetRoutes(nil)
+	tun.SetSubnetRoutes(routes)
+
+	sc2 := tun.subnetCounters()
+	if sc2 == nil {
+		t.Fatal("counting disabled after re-enabling")
+	}
+	if got := labeledSeriesValue(t, sc2, "10.1.0.0/16", directionTx, true); got != 1000000 {
+		t.Errorf("labeled tx_bytes after a disable/enable cycle = %d, want 1000000 retained "+
+			"(a Prometheus counter must never decrease)", got)
+	}
+	if txBytes, _, _, _ := routeCountsFor(t, sc2, "10.1.0.0/16"); txBytes != 1000000 {
+		t.Errorf("route tx_bytes after a disable/enable cycle = %d, want 1000000 retained", txBytes)
+	}
+}
+
+// labeledSeriesValue returns the value published under the given labels, or -1
+// if there is no such series.
+func labeledSeriesValue(t *testing.T, sc *subnetCounters, route, direction string, bytes bool) int64 {
+	t.Helper()
+	m := sc.packetsTotal
+	if bytes {
+		m = sc.bytesTotal
+	}
+	got := int64(-1)
+	m.Do(func(kv tsmetrics.KeyValue[subnetRouteLabels]) {
+		if kv.Key.Route != route || kv.Key.Direction != direction {
+			return
+		}
+		iv, ok := kv.Value.(*expvar.Int)
+		if !ok {
+			t.Fatalf("series %v/%v has value type %T, want *expvar.Int", route, direction, kv.Value)
+		}
+		got = iv.Value()
+	})
+	return got
+}
+
+// TestSubnetCountersDisabledCountsNothing checks that while the feature is
+// disabled no traffic is counted, and that withdrawn routes' labeled series are
+// removed even though their totals are retained.
+func TestSubnetCountersDisabledCountsNothing(t *testing.T) {
+	bus := eventbustest.NewBus(t)
+	_, tun := newFakeTUN(t.Logf, bus, false)
+	defer tun.Close()
+
+	routes := []netip.Prefix{netip.MustParsePrefix("10.1.0.0/16")}
+	tun.SetSubnetRoutes(routes)
+	sc := tun.subnetCounters()
+	pkt := udp4("100.64.0.1", "10.1.2.3", 123, 456)
+	if _, err := tun.tdevWrite([][]byte{pkt}, 0); err != nil {
+		t.Fatalf("tdevWrite: %v", err)
+	}
+	_, _, want, _ := routeCountsFor(t, sc, "10.1.0.0/16")
+	if want != 1 {
+		t.Fatalf("txPackets while enabled = %d, want 1", want)
+	}
+
+	tun.SetSubnetRoutes(nil)
+
+	// Nothing is counted while disabled, and no series remain published.
+	for range 5 {
+		if _, err := tun.tdevWrite([][]byte{pkt}, 0); err != nil {
+			t.Fatalf("tdevWrite: %v", err)
+		}
+	}
+	if got := seriesCount(sc); got != 0 {
+		t.Errorf("series count while disabled = %d, want 0", got)
+	}
+	// forRoute reports only advertised routes, so the withdrawn one is gone
+	// from there; the retained totals must be untouched by the 5 packets.
+	if got := sc.forRoute(netip.MustParsePrefix("10.1.0.0/16")); got != nil {
+		t.Error("a withdrawn route still resolves via forRoute")
+	}
+	rc := sc.retainedForRoute(netip.MustParsePrefix("10.1.0.0/16"))
+	if rc == nil {
+		t.Fatal("the withdrawn route's counters were discarded, not retained")
+	}
+	if got := rc.txPackets.Value(); got != 1 {
+		t.Errorf("retained txPackets after 5 packets while disabled = %d, want still 1", got)
+	}
+}
+
+// TestSubnetCountersNoAggregateLeak checks that repeatedly enabling and
+// disabling does not leak expvar values into the process-global aggregate
+// clientmetrics. AggregateCounter has no unregister-one API and Value() is
+// O(n) over the registered set, on every scrape and every logtail delta.
+func TestSubnetCountersNoAggregateLeak(t *testing.T) {
+	bus := eventbustest.NewBus(t)
+	_, tun := newFakeTUN(t.Logf, bus, false)
+	defer tun.Close()
+
+	routes := []netip.Prefix{netip.MustParsePrefix("10.1.0.0/16")}
+	tun.SetSubnetRoutes(routes)
+	base := aggregateRegisteredCount()
+
+	for range 10 {
+		tun.SetSubnetRoutes(nil)
+		tun.SetSubnetRoutes(routes)
+	}
+	if got := aggregateRegisteredCount() - base; got != 0 {
+		t.Errorf("10 disable/enable cycles registered %d additional values with the "+
+			"aggregate clientmetrics, want 0", got)
+	}
+}
+
+// aggregateRegisteredCount returns how many expvar values are registered with
+// the four aggregate clientmetrics.
+func aggregateRegisteredCount() int {
+	return cMetricSubnetForwardedTxBytes.RegisteredCountForTest() +
+		cMetricSubnetForwardedRxBytes.RegisteredCountForTest() +
+		cMetricSubnetForwardedTxPackets.RegisteredCountForTest() +
+		cMetricSubnetForwardedRxPackets.RegisteredCountForTest()
+}
+
+// TestSubnetCountersRetentionBound checks that the retained-counter map is
+// bounded. Retention is deliberate (a withdrawn route must keep contributing to
+// the aggregates, which are counters) but unbounded retention lets an
+// unexpectedly churning route set grow memory without limit.
+func TestSubnetCountersRetentionBound(t *testing.T) {
+	sc := newSubnetCounters(new(usermetric.Registry))
+
+	// Churn far more distinct routes than the cap, counting a byte on each so
+	// that eviction has to preserve something.
+	const n = maxRetainedRoutes * 3
+	var wantTotal int64
+	for i := range n {
+		p := netip.MustParsePrefix(fmt.Sprintf("10.%d.%d.0/24", i/256, i%256))
+		sc.setRoutes([]netip.Prefix{p})
+		sc.forAddr(p.Addr().Next()).add(100, false)
+		wantTotal += 100
+	}
+
+	if got := len(sc.counters); got > maxRetainedRoutes {
+		t.Errorf("after %d single-route reconfigs, retained %d routeCounters, want at most %d",
+			n, got, maxRetainedRoutes)
+	}
+	// Eviction must not lose counted bytes: the aggregate is a counter.
+	if got := sc.aggregateTxBytesForTest(); got != wantTotal {
+		t.Errorf("total tx bytes across retained plus evicted = %d, want %d "+
+			"(eviction must not make the aggregate decrease)", got, wantTotal)
+	}
+}
+
+// TestSubnetCountersExitNodeOnlyNotEnabled checks that a node advertising only
+// exit routes does not install the counting hook: it would publish zero series
+// while paying a decode and a lookup on every packet.
+func TestSubnetCountersExitNodeOnlyNotEnabled(t *testing.T) {
+	bus := eventbustest.NewBus(t)
+	_, tun := newFakeTUN(t.Logf, bus, false)
+	defer tun.Close()
+
+	tun.SetSubnetRoutes([]netip.Prefix{
+		netip.MustParsePrefix("0.0.0.0/0"),
+		netip.MustParsePrefix("::/0"),
+	})
+	if tun.SubnetRouteCountingEnabledForTest() {
+		t.Error("counting is enabled for an exit-node-only route set; want disabled")
+	}
+}
+
+// TestSubnetCountersViaRouteExcluded checks that 4via6 routes get no series.
+// Both endpoints of 4via6 traffic are inside the Tailscale ULA range, so
+// countSubnetRouteTraffic can never attribute a packet to one, and publishing
+// four permanently-zero series would read as "this route is idle".
+func TestSubnetCountersViaRouteExcluded(t *testing.T) {
+	sc := newSubnetCounters(new(usermetric.Registry))
+	// 4via6 form of 10.1.0.0/16 through site 7.
+	via := netip.MustParsePrefix("fd7a:115c:a1e0:b1a:0:7:a01:0/112")
+	if !tsaddr.IsViaPrefix(via) {
+		t.Fatalf("%v is not a via prefix; fix the test fixture", via)
+	}
+	sc.setRoutes([]netip.Prefix{via})
+	if got := seriesCount(sc); got != 0 {
+		t.Errorf("a 4via6 route published %d series, want 0 (they could never move)", got)
+	}
+	if sc.forAddr(via.Addr().Next()) != nil {
+		t.Error("a 4via6 route is present in the lookup table")
+	}
+}
+
+// TestWrapperSubnetRouteCountingOwnTraffic checks that traffic the node
+// originates itself toward an address inside one of its own advertised prefixes
+// is not counted. Only forwarded traffic belongs in these counters, and such a
+// packet has exactly one Tailscale endpoint, so the endpoint test alone admits
+// it -- with the direction inverted, since it is egress being counted as rx.
+func TestWrapperSubnetRouteCountingOwnTraffic(t *testing.T) {
+	bus := eventbustest.NewBus(t)
+	chtun, tun := newChannelTUN(t.Logf, bus, false)
+	defer tun.Close()
+
+	const selfIP = "100.64.0.1"
+	tun.SetSelfTailscaleAddrs(netip.MustParseAddr(selfIP), netip.Addr{})
+	tun.SetSubnetRoutes([]netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")})
+	sc := tun.subnetCounters()
+	if sc == nil {
+		t.Fatal("counting disabled after SetSubnetRoutes")
+	}
+
+	// The node's own egress to a host inside its advertised prefix. This
+	// leaves via the TUN read path, where forwarded return traffic is rx.
+	go func() { chtun.Outbound <- udp4(selfIP, "10.1.2.3", 123, 456) }()
+
+	var buf [MaxPacketSize]byte
+	buffs := [][]byte{buf[:]}
+	sizes := make([]int, 1)
+	if _, err := tun.Read(buffs, sizes, 0); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	txBytes, rxBytes, txPackets, rxPackets := routeCountsFor(t, sc, "10.0.0.0/8")
+	if rxPackets != 0 || rxBytes != 0 {
+		t.Errorf("the node's own egress was counted as rx: rxBytes=%d rxPackets=%d; want 0, 0",
+			rxBytes, rxPackets)
+	}
+	if txPackets != 0 || txBytes != 0 {
+		t.Errorf("the node's own egress was counted as tx: txBytes=%d txPackets=%d; want 0, 0",
+			txBytes, txPackets)
+	}
+}
+
+// TestWrapperSubnetRouteCountingForwardedStillCounted is the companion to
+// TestWrapperSubnetRouteCountingOwnTraffic: excluding the node's own traffic
+// must not also exclude the forwarded traffic these counters exist for.
+func TestWrapperSubnetRouteCountingForwardedStillCounted(t *testing.T) {
+	bus := eventbustest.NewBus(t)
+	chtun, tun := newChannelTUN(t.Logf, bus, false)
+	defer tun.Close()
+
+	tun.SetSelfTailscaleAddrs(netip.MustParseAddr("100.64.0.1"), netip.Addr{})
+	tun.SetSubnetRoutes([]netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")})
+	sc := tun.subnetCounters()
+
+	// Forwarded: from a subnet host, to a *peer*, not to this node.
+	pkt := udp4("10.1.2.3", "100.64.0.2", 456, 123)
+	go func() { chtun.Outbound <- pkt }()
+
+	var buf [MaxPacketSize]byte
+	buffs := [][]byte{buf[:]}
+	sizes := make([]int, 1)
+	if _, err := tun.Read(buffs, sizes, 0); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	_, rxBytes, _, rxPackets := routeCountsFor(t, sc, "10.0.0.0/8")
+	if rxPackets != 1 || rxBytes != int64(len(pkt)) {
+		t.Errorf("forwarded traffic: rxBytes=%d rxPackets=%d; want %d, 1", rxBytes, rxPackets, len(pkt))
+	}
+}
+
+// TestWrapperSubnetRouteCountingStalePacket checks that the Read hook does not
+// attribute traffic using addresses left over from a previous packet. Parsed is
+// pool-reused across the loop and Decode does not clear Src/Dst when it bails
+// out early, so a hook that reads them without an IPVersion check can count a
+// stale address.
+func TestWrapperSubnetRouteCountingStalePacket(t *testing.T) {
+	bus := eventbustest.NewBus(t)
+	chtun, tun := newChannelTUN(t.Logf, bus, false)
+	defer tun.Close()
+
+	tun.SetSelfTailscaleAddrs(netip.MustParseAddr("100.64.0.1"), netip.Addr{})
+	tun.SetSubnetRoutes([]netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")})
+	sc := tun.subnetCounters()
+
+	// A real forwarded packet, then a garbage one in the same batch. The
+	// second must not be counted against the first's route.
+	good := udp4("10.1.2.3", "100.64.0.2", 456, 123)
+	junk := []byte{0x45, 0x74, 0x63, 0x70} // decodes as IPVersion 0
+	go func() {
+		chtun.Outbound <- good
+		chtun.Outbound <- junk
+	}()
+
+	var bufs [2][MaxPacketSize]byte
+	buffs := [][]byte{bufs[0][:], bufs[1][:]}
+	sizes := make([]int, 2)
+	for range 2 {
+		if _, err := tun.Read(buffs, sizes, 0); err != nil {
+			t.Fatalf("Read: %v", err)
+		}
+	}
+
+	_, rxBytes, _, rxPackets := routeCountsFor(t, sc, "10.0.0.0/8")
+	if rxPackets != 1 || rxBytes != int64(len(good)) {
+		t.Errorf("after one good and one undecodable packet: rxBytes=%d rxPackets=%d; want %d, 1",
+			rxBytes, rxPackets, len(good))
+	}
+}
+
+// TestSubnetCountersHotPathNoAllocs pins the real hooks, not just the
+// forAddr+add pair, to zero allocations. A prefix.String() creeping back into
+// countSubnetRouteTraffic would allocate twice per packet.
+func TestSubnetCountersHotPathNoAllocs(t *testing.T) {
+	bus := eventbustest.NewBus(t)
+	_, tun := newFakeTUN(t.Logf, bus, false)
+	defer tun.Close()
+
+	tun.SetSelfTailscaleAddrs(netip.MustParseAddr("100.64.0.1"), netip.Addr{})
+	tun.SetSubnetRoutes(mustPrefixes(t, []string{"10.0.0.0/8", "10.1.0.0/16", "192.168.0.0/24"}))
+
+	pkt := udp4("100.64.0.2", "10.1.2.3", 123, 456)
+	buf := make([]byte, PacketStartOffset+MaxPacketSize)
+	copy(buf[PacketStartOffset:], pkt)
+
+	// The tdevWrite/injectedRead hook, including its decode and the active
+	// check the packet path actually runs.
+	if got := testing.AllocsPerRun(1000, func() {
+		if sc := tun.subnetCountersActive(); sc != nil {
+			tun.countSubnetRoutePacket(sc, buf[PacketStartOffset:], false)
+		}
+	}); got != 0 {
+		t.Errorf("countSubnetRoutePacket allocated %v times per run, want 0", got)
+	}
+
+	// And the Read hook, which counts an already-decoded packet.
+	var p packet.Parsed
+	p.Decode(buf[PacketStartOffset:])
+	if got := testing.AllocsPerRun(1000, func() {
+		if sc := tun.subnetCountersActive(); sc != nil {
+			tun.countSubnetRouteParsed(sc, &p, true)
+		}
+	}); got != 0 {
+		t.Errorf("countSubnetRouteParsed allocated %v times per run, want 0", got)
+	}
+
+	// The disabled path must be free too: nodes that have not opted in pay
+	// only the nil check.
+	tun.SetSubnetRoutes(nil)
+	if got := testing.AllocsPerRun(1000, func() {
+		if sc := tun.subnetCountersActive(); sc != nil {
+			t.Fatal("counting is still active after SetSubnetRoutes(nil)")
+		}
+	}); got != 0 {
+		t.Errorf("the disabled check allocated %v times per run, want 0", got)
+	}
+}
+
 func BenchmarkSubnetCountersAdd(b *testing.B) {
 	b.ReportAllocs()
 	sc := newSubnetCounters(new(usermetric.Registry))
-	sc.setRoutes([]netip.Prefix{
-		netip.MustParsePrefix("10.0.0.0/8"),
-		netip.MustParsePrefix("10.1.0.0/16"),
-		netip.MustParsePrefix("192.168.0.0/24"),
-		netip.MustParsePrefix("172.16.0.0/12"),
-		netip.MustParsePrefix("10.2.0.0/16"),
-	})
+	sc.setRoutes(benchRoutes)
 	addr := netip.MustParseAddr("10.1.2.3")
 	for range b.N {
 		if rc := sc.forAddr(addr); rc != nil {
 			rc.add(1500, false)
+		}
+	}
+}
+
+var benchRoutes = []netip.Prefix{
+	netip.MustParsePrefix("10.0.0.0/8"),
+	netip.MustParsePrefix("10.1.0.0/16"),
+	netip.MustParsePrefix("192.168.0.0/24"),
+	netip.MustParsePrefix("172.16.0.0/12"),
+	netip.MustParsePrefix("10.2.0.0/16"),
+}
+
+// BenchmarkSubnetCountersHook measures the whole per-packet hook as the write
+// path runs it: the active check, the decode, the forwarded-traffic tests, the
+// lookup, and the adds.
+func BenchmarkSubnetCountersHook(b *testing.B) {
+	b.ReportAllocs()
+	bus := eventbustest.NewBus(b)
+	_, tun := newFakeTUN(b.Logf, bus, false)
+	defer tun.Close()
+
+	tun.SetSelfTailscaleAddrs(netip.MustParseAddr("100.64.0.1"), netip.Addr{})
+	tun.SetSubnetRoutes(benchRoutes)
+
+	pkt := udp4("100.64.0.2", "10.1.2.3", 123, 456)
+	buf := make([]byte, PacketStartOffset+MaxPacketSize)
+	copy(buf[PacketStartOffset:], pkt)
+	body := buf[PacketStartOffset:]
+
+	for range b.N {
+		if sc := tun.subnetCountersActive(); sc != nil {
+			tun.countSubnetRoutePacket(sc, body, false)
+		}
+	}
+}
+
+// BenchmarkSubnetCountersHookDisabled measures what a node that has not opted
+// in pays: the nil check and nothing else.
+func BenchmarkSubnetCountersHookDisabled(b *testing.B) {
+	b.ReportAllocs()
+	bus := eventbustest.NewBus(b)
+	_, tun := newFakeTUN(b.Logf, bus, false)
+	defer tun.Close()
+
+	pkt := udp4("100.64.0.2", "10.1.2.3", 123, 456)
+	for range b.N {
+		if sc := tun.subnetCountersActive(); sc != nil {
+			tun.countSubnetRoutePacket(sc, pkt, false)
 		}
 	}
 }

--- a/net/tstun/subnetmetrics_test.go
+++ b/net/tstun/subnetmetrics_test.go
@@ -402,7 +402,7 @@ func TestSubnetCountersExitNodeOnlyNotEnabled(t *testing.T) {
 
 // TestSubnetCountersViaRouteExcluded checks that 4via6 routes get no series.
 // Both endpoints of 4via6 traffic are inside the Tailscale ULA range, so
-// countSubnetRouteTraffic can never attribute a packet to one, and publishing
+// countSubnetRouteParsed can never attribute a packet to one, and publishing
 // four permanently-zero series would read as "this route is idle".
 func TestSubnetCountersViaRouteExcluded(t *testing.T) {
 	sc := newTestSubnetCounters()
@@ -530,7 +530,7 @@ func TestWrapperSubnetRouteCountingStalePacket(t *testing.T) {
 
 // TestSubnetCountersHotPathNoAllocs pins the real hooks, not just the
 // forAddr+add pair, to zero allocations. A prefix.String() creeping back into
-// countSubnetRouteTraffic would allocate twice per packet.
+// countSubnetRouteParsed would allocate twice per packet.
 func TestSubnetCountersHotPathNoAllocs(t *testing.T) {
 	bus := eventbustest.NewBus(t)
 	_, tun := newFakeTUN(t.Logf, bus, false)

--- a/net/tstun/subnetmetrics_test.go
+++ b/net/tstun/subnetmetrics_test.go
@@ -7,6 +7,7 @@ import (
 	"net/netip"
 	"testing"
 
+	tsmetrics "tailscale.com/metrics"
 	"tailscale.com/util/usermetric"
 )
 
@@ -112,4 +113,111 @@ func mustPrefixes(t *testing.T, ss []string) []netip.Prefix {
 		ps = append(ps, netip.MustParsePrefix(s))
 	}
 	return ps
+}
+
+func TestSubnetCountersDirections(t *testing.T) {
+	sc := newSubnetCounters(new(usermetric.Registry))
+	sc.setRoutes(mustPrefixes(t, []string{"10.1.0.0/16"}))
+
+	// Two packets into the subnet, one back out of it.
+	sc.forAddr(netip.MustParseAddr("10.1.2.3")).add(100, false)
+	sc.forAddr(netip.MustParseAddr("10.1.2.4")).add(200, false)
+	sc.forAddr(netip.MustParseAddr("10.1.2.3")).add(50, true)
+
+	txBytes, rxBytes, txPackets, rxPackets := routeCountsFor(t, sc, "10.1.0.0/16")
+	if txBytes != 300 {
+		t.Errorf("txBytes = %d, want 300", txBytes)
+	}
+	if rxBytes != 50 {
+		t.Errorf("rxBytes = %d, want 50", rxBytes)
+	}
+	if txPackets != 2 {
+		t.Errorf("txPackets = %d, want 2", txPackets)
+	}
+	if rxPackets != 1 {
+		t.Errorf("rxPackets = %d, want 1", rxPackets)
+	}
+}
+
+func TestSubnetCountersRouteWithdrawal(t *testing.T) {
+	reg := new(usermetric.Registry)
+	sc := newSubnetCounters(reg)
+
+	sc.setRoutes(mustPrefixes(t, []string{"10.1.0.0/16", "192.168.0.0/24"}))
+	sc.forAddr(netip.MustParseAddr("10.1.2.3")).add(100, false)
+
+	if got := seriesCount(sc); got != 8 {
+		t.Fatalf("after advertising 2 routes, series count = %d, want 8", got)
+	}
+
+	// Withdraw one route; its series must go away, the other must remain.
+	sc.setRoutes(mustPrefixes(t, []string{"10.1.0.0/16"}))
+	if got := seriesCount(sc); got != 4 {
+		t.Errorf("after withdrawing 1 of 2 routes, series count = %d, want 4", got)
+	}
+	if sc.forRoute(netip.MustParsePrefix("192.168.0.0/24")) != nil {
+		t.Error("withdrawn route still resolves via forRoute")
+	}
+	if sc.forAddr(netip.MustParseAddr("192.168.0.5")) != nil {
+		t.Error("withdrawn route still matches in the lookup table")
+	}
+
+	// A re-advertised route resumes its previous total rather than resetting,
+	// keeping the aggregate clientmetrics monotonic.
+	sc.setRoutes(mustPrefixes(t, []string{"10.1.0.0/16", "192.168.0.0/24"}))
+	if txBytes, _, _, _ := routeCountsFor(t, sc, "10.1.0.0/16"); txBytes != 100 {
+		t.Errorf("txBytes after re-advertise = %d, want 100 retained", txBytes)
+	}
+
+	// Churning the same route set repeatedly must not grow the series count.
+	for range 20 {
+		sc.setRoutes(mustPrefixes(t, []string{"10.1.0.0/16"}))
+		sc.setRoutes(mustPrefixes(t, []string{"10.1.0.0/16", "192.168.0.0/24"}))
+	}
+	if got := seriesCount(sc); got != 8 {
+		t.Errorf("after 20 churn cycles, series count = %d, want 8 (leak)", got)
+	}
+}
+
+// seriesCount returns the number of labeled series currently published.
+func seriesCount(sc *subnetCounters) int {
+	var n int
+	sc.bytesTotal.Do(func(tsmetrics.KeyValue[subnetRouteLabels]) { n++ })
+	sc.packetsTotal.Do(func(tsmetrics.KeyValue[subnetRouteLabels]) { n++ })
+	return n
+}
+
+// TestSubnetCountersNoAllocs pins the hot path to zero allocations. The naive
+// implementation formats the prefix into a label value on every packet, which
+// costs two allocations and roughly 4.7x the time; see the design doc.
+func TestSubnetCountersNoAllocs(t *testing.T) {
+	sc := newSubnetCounters(new(usermetric.Registry))
+	sc.setRoutes(mustPrefixes(t, []string{"10.0.0.0/8", "10.1.0.0/16", "192.168.0.0/24"}))
+	addr := netip.MustParseAddr("10.1.2.3")
+
+	if got := testing.AllocsPerRun(1000, func() {
+		if rc := sc.forAddr(addr); rc != nil {
+			rc.add(1500, false)
+		}
+	}); got != 0 {
+		t.Errorf("counting a packet allocated %v times per run, want 0", got)
+	}
+}
+
+func BenchmarkSubnetCountersAdd(b *testing.B) {
+	b.ReportAllocs()
+	sc := newSubnetCounters(new(usermetric.Registry))
+	sc.setRoutes([]netip.Prefix{
+		netip.MustParsePrefix("10.0.0.0/8"),
+		netip.MustParsePrefix("10.1.0.0/16"),
+		netip.MustParsePrefix("192.168.0.0/24"),
+		netip.MustParsePrefix("172.16.0.0/12"),
+		netip.MustParsePrefix("10.2.0.0/16"),
+	})
+	addr := netip.MustParseAddr("10.1.2.3")
+	for range b.N {
+		if rc := sc.forAddr(addr); rc != nil {
+			rc.add(1500, false)
+		}
+	}
 }

--- a/net/tstun/subnetmetrics_test.go
+++ b/net/tstun/subnetmetrics_test.go
@@ -16,6 +16,12 @@ import (
 	"tailscale.com/util/usermetric"
 )
 
+// newTestSubnetCounters returns a standalone subnetCounters with its own
+// registry and lookup table, for tests that don't need a whole Wrapper.
+func newTestSubnetCounters() *subnetCounters {
+	return newSubnetCounters(new(usermetric.Registry), new(atomicPrefixTable))
+}
+
 // routeCountsFor returns the four counter values for the given route, or
 // zeroes if the route is not being counted.
 func routeCountsFor(t *testing.T, sc *subnetCounters, route string) (txBytes, rxBytes, txPackets, rxPackets int64) {
@@ -85,7 +91,7 @@ func TestSubnetCountersAttribution(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sc := newSubnetCounters(new(usermetric.Registry))
+			sc := newTestSubnetCounters()
 			sc.setRoutes(mustPrefixes(t, tt.routes))
 
 			remote := netip.MustParseAddr(tt.remote)
@@ -121,7 +127,7 @@ func mustPrefixes(t *testing.T, ss []string) []netip.Prefix {
 }
 
 func TestSubnetCountersDirections(t *testing.T) {
-	sc := newSubnetCounters(new(usermetric.Registry))
+	sc := newTestSubnetCounters()
 	sc.setRoutes(mustPrefixes(t, []string{"10.1.0.0/16"}))
 
 	// Two packets into the subnet, one back out of it.
@@ -145,8 +151,7 @@ func TestSubnetCountersDirections(t *testing.T) {
 }
 
 func TestSubnetCountersRouteWithdrawal(t *testing.T) {
-	reg := new(usermetric.Registry)
-	sc := newSubnetCounters(reg)
+	sc := newTestSubnetCounters()
 
 	sc.setRoutes(mustPrefixes(t, []string{"10.1.0.0/16", "192.168.0.0/24"}))
 	sc.forAddr(netip.MustParseAddr("10.1.2.3")).add(100, false)
@@ -196,7 +201,7 @@ func seriesCount(sc *subnetCounters) int {
 // implementation formats the prefix into a label value on every packet, which
 // costs two allocations and roughly 4.7x the time; see the design doc.
 func TestSubnetCountersNoAllocs(t *testing.T) {
-	sc := newSubnetCounters(new(usermetric.Registry))
+	sc := newTestSubnetCounters()
 	sc.setRoutes(mustPrefixes(t, []string{"10.0.0.0/8", "10.1.0.0/16", "192.168.0.0/24"}))
 	addr := netip.MustParseAddr("10.1.2.3")
 
@@ -354,7 +359,7 @@ func aggregateRegisteredCount() int {
 // the aggregates, which are counters) but unbounded retention lets an
 // unexpectedly churning route set grow memory without limit.
 func TestSubnetCountersRetentionBound(t *testing.T) {
-	sc := newSubnetCounters(new(usermetric.Registry))
+	sc := newTestSubnetCounters()
 
 	// Churn far more distinct routes than the cap, counting a byte on each so
 	// that eviction has to preserve something.
@@ -400,7 +405,7 @@ func TestSubnetCountersExitNodeOnlyNotEnabled(t *testing.T) {
 // countSubnetRouteTraffic can never attribute a packet to one, and publishing
 // four permanently-zero series would read as "this route is idle".
 func TestSubnetCountersViaRouteExcluded(t *testing.T) {
-	sc := newSubnetCounters(new(usermetric.Registry))
+	sc := newTestSubnetCounters()
 	// 4via6 form of 10.1.0.0/16 through site 7.
 	via := netip.MustParsePrefix("fd7a:115c:a1e0:b1a:0:7:a01:0/112")
 	if !tsaddr.IsViaPrefix(via) {
@@ -573,7 +578,7 @@ func TestSubnetCountersHotPathNoAllocs(t *testing.T) {
 
 func BenchmarkSubnetCountersAdd(b *testing.B) {
 	b.ReportAllocs()
-	sc := newSubnetCounters(new(usermetric.Registry))
+	sc := newTestSubnetCounters()
 	sc.setRoutes(benchRoutes)
 	addr := netip.MustParseAddr("10.1.2.3")
 	for range b.N {
@@ -777,7 +782,7 @@ func TestWrapperSubnetRouteCountingOffByDefault(t *testing.T) {
 // The aggregates are process-global and other tests in this package register
 // counters with them, so this compares deltas rather than absolute values.
 func TestSubnetCountersAggregateAgreement(t *testing.T) {
-	sc := newSubnetCounters(new(usermetric.Registry))
+	sc := newTestSubnetCounters()
 	sc.setRoutes(mustPrefixes(t, []string{"10.1.0.0/16", "192.168.0.0/24"}))
 
 	base := [4]int64{

--- a/net/tstun/wrap.go
+++ b/net/tstun/wrap.go
@@ -1615,6 +1615,13 @@ type selfTailscaleAddrs struct {
 // traffic from the node's own; a4 and a6 are typically
 // [tsaddr.FirstTailscaleAddrs] of the node's wireguard config addresses.
 // Callers may pass invalid addresses for either family.
+//
+// The engine calls this and SetSubnetRoutes from the same Reconfig, in that
+// order, so the addresses are in place before a route becomes countable. A
+// reconfig that changes both leaves a window of a few instructions where the
+// counters see the new addresses with the old routes; the consequence is at
+// most a handful of packets attributed as forwarded when they were the node's
+// own, which is not worth a lock on the packet path to close.
 func (t *Wrapper) SetSelfTailscaleAddrs(a4, a6 netip.Addr) {
 	if old := t.selfAddrs.Load(); old != nil && old.v4 == a4 && old.v6 == a6 {
 		return

--- a/net/tstun/wrap.go
+++ b/net/tstun/wrap.go
@@ -925,8 +925,12 @@ func (t *Wrapper) Read(buffs [][]byte, sizes []int, offset int) (int, error) {
 		// Traffic leaving the TUN toward a tailnet peer: on a subnet router
 		// this is a response coming back out of the subnet, so it is rx.
 		// p is already decoded here, so attribute it without re-parsing.
+		//
+		// p.TotalLen() rather than len(p.Buffer()): the buffers this path
+		// gets are exactly sized today, but the decoded length is the
+		// authoritative byte count and does not depend on that staying true.
 		if sc := t.subnetRouteCounters.Load(); sc != nil {
-			sc.countSubnetRouteTraffic(p.Src.Addr(), p.Dst.Addr(), len(p.Buffer()), true)
+			sc.countSubnetRouteTraffic(p.Src.Addr(), p.Dst.Addr(), p.TotalLen(), true)
 		}
 
 		// Make sure to do SNAT after filtering, so that any flow tracking in
@@ -1609,7 +1613,10 @@ func (t *Wrapper) countSubnetRoutePacket(b []byte, rx bool) {
 	if p.IPVersion == 0 {
 		return
 	}
-	sc.countSubnetRouteTraffic(p.Src.Addr(), p.Dst.Addr(), len(b), rx)
+	// p.TotalLen(), not len(b): b may have trailing slack. wireguard-go hands
+	// Write a full-MTU buffer per packet, so buffs[i][offset:] in tdevWrite
+	// runs to the end of that buffer rather than to the end of the packet.
+	sc.countSubnetRouteTraffic(p.Src.Addr(), p.Dst.Addr(), p.TotalLen(), rx)
 }
 
 var (

--- a/net/tstun/wrap.go
+++ b/net/tstun/wrap.go
@@ -222,10 +222,19 @@ type Wrapper struct {
 	connCounter syncs.AtomicValue[netlogfunc.ConnectionCounter]
 
 	// subnetRouteCounters counts forwarded traffic per advertised subnet
-	// route. It is nil until SetSubnetRoutes is called with a non-empty set
-	// of routes, so nodes that are not subnet routers, and nodes that have
-	// not opted in, pay only a nil load on the packet path.
+	// route. It is nil until SetSubnetRoutes is called with at least one
+	// countable route, so nodes that are not subnet routers, and nodes that
+	// have not opted in, pay only a nil load on the packet path.
+	//
+	// Once created it stays non-nil, because it owns registrations that cannot
+	// be undone; use [Wrapper.subnetCountersActive] on the packet path, which
+	// also covers the currently-disabled case.
 	subnetRouteCounters atomic.Pointer[subnetCounters]
+
+	// selfAddrs holds this node's own Tailscale addresses, used by the subnet
+	// counters to tell forwarded traffic from the node's own. Nil until
+	// SetSelfTailscaleAddrs is called.
+	selfAddrs atomic.Pointer[selfTailscaleAddrs]
 
 	captureHook syncs.AtomicValue[packet.CaptureCallback]
 
@@ -697,13 +706,15 @@ type SetIPer interface {
 	SetIP(ipV4, ipV6 netip.Addr) error
 }
 
-// SetWGConfig is called when a new NetworkMap is received. Its only
-// remaining job is updating the TAP device's IP addresses; the
-// per-peer route attributes arrive via [Wrapper.SetPeerRoutes].
+// SetWGConfig is called when a new NetworkMap is received. It records this
+// node's own Tailscale addresses and updates the TAP device's IP addresses;
+// the per-peer route attributes arrive via [Wrapper.SetPeerRoutes].
 func (t *Wrapper) SetWGConfig(wcfg *wgcfg.Config) {
+	a4, a6 := tsaddr.FirstTailscaleAddrs(slices.All(wcfg.Addresses))
+	t.SetSelfTailscaleAddrs(a4, a6)
 	if t.isTAP {
 		if sip, ok := t.tdev.(SetIPer); ok {
-			sip.SetIP(tsaddr.FirstTailscaleAddrs(slices.All(wcfg.Addresses)))
+			sip.SetIP(a4, a6)
 		}
 	}
 }
@@ -925,12 +936,8 @@ func (t *Wrapper) Read(buffs [][]byte, sizes []int, offset int) (int, error) {
 		// Traffic leaving the TUN toward a tailnet peer: on a subnet router
 		// this is a response coming back out of the subnet, so it is rx.
 		// p is already decoded here, so attribute it without re-parsing.
-		//
-		// p.TotalLen() rather than len(p.Buffer()): the buffers this path
-		// gets are exactly sized today, but the decoded length is the
-		// authoritative byte count and does not depend on that staying true.
-		if sc := t.subnetRouteCounters.Load(); sc != nil {
-			sc.countSubnetRouteTraffic(p.Src.Addr(), p.Dst.Addr(), p.TotalLen(), true)
+		if sc := t.subnetCountersActive(); sc != nil {
+			t.countSubnetRouteParsed(sc, p, true)
 		}
 
 		// Make sure to do SNAT after filtering, so that any flow tracking in
@@ -1111,9 +1118,9 @@ func (t *Wrapper) injectedRead(res tunInjectedRead, outBuffs [][]byte, sizes []i
 	}
 	// Injected packets travel the same direction as Read: out to a tailnet
 	// peer, i.e. rx from the subnet router's point of view.
-	if sc := t.subnetRouteCounters.Load(); sc != nil {
+	if sc := t.subnetCountersActive(); sc != nil {
 		for i := range n {
-			t.countSubnetRoutePacket(outBuffs[i][offset:offset+sizes[i]], true)
+			t.countSubnetRoutePacket(sc, outBuffs[i][offset:offset+sizes[i]], true)
 		}
 	}
 
@@ -1310,9 +1317,9 @@ func (t *Wrapper) tdevWrite(buffs [][]byte, offset int) (int, error) {
 	}
 	// Traffic entering the TUN from a tailnet peer: on a subnet router this is
 	// sent onward into the subnet, so it is tx.
-	if sc := t.subnetRouteCounters.Load(); sc != nil {
+	if sc := t.subnetCountersActive(); sc != nil {
 		for i := range buffs {
-			t.countSubnetRoutePacket(buffs[i][offset:], false)
+			t.countSubnetRoutePacket(sc, buffs[i][offset:], false)
 		}
 	}
 	return t.tdev.Write(buffs, offset)
@@ -1543,80 +1550,145 @@ func (t *Wrapper) SetConnectionCounter(fn netlogfunc.ConnectionCounter) {
 // SetSubnetRoutes sets the advertised subnet routes for which forwarded
 // traffic is counted, enabling per-route load metrics.
 //
-// Passing an empty or nil slice disables counting, so callers gate the feature
-// simply by not supplying routes. Counting is deliberately independent of
-// network flow logging, so it works with flow logging off.
+// Passing no countable routes — an empty slice, or only exit and 4via6 routes —
+// disables counting, so callers gate the feature simply by not supplying
+// routes. Counting is deliberately independent of network flow logging, so it
+// works with flow logging off.
+//
+// Disabling does not discard what has been counted. Both metric views are
+// counters, so a re-advertised route resumes its previous total rather than
+// resetting: see [subnetCounters] for why the instance outlives a disable.
 func (t *Wrapper) SetSubnetRoutes(routes []netip.Prefix) {
 	if !buildfeatures.HasUserMetrics && !buildfeatures.HasClientMetrics {
 		return
 	}
 	sc := t.subnetRouteCounters.Load()
 	if sc == nil {
-		if len(routes) == 0 {
+		if !anyCountableRoute(routes) {
+			// Never enabled and nothing to enable it for. Don't create the
+			// counters at all, so nodes that are not subnet routers, and nodes
+			// that have not opted in, publish no series and pay only a nil
+			// load on the packet path.
 			return
 		}
 		sc = newSubnetCounters(t.usermetrics)
 		t.subnetRouteCounters.Store(sc)
 	}
 	sc.setRoutes(routes)
-	if len(routes) == 0 {
-		t.subnetRouteCounters.Store(nil)
-	}
 }
 
-// subnetCounters returns the active per-route counters, or nil if per-route
-// counting is disabled.
+// subnetCounters returns the per-route counters, or nil if they were never
+// enabled. They may be present but inactive; see [Wrapper.subnetCountersActive].
 func (t *Wrapper) subnetCounters() *subnetCounters {
 	return t.subnetRouteCounters.Load()
+}
+
+// subnetCountersActive returns the per-route counters if traffic should be
+// counted right now, or nil if per-route counting is disabled or no countable
+// route is advertised.
+//
+// This is the packet path's gate: two nil-able atomic loads, no decode and no
+// lookup when counting is off.
+func (t *Wrapper) subnetCountersActive() *subnetCounters {
+	sc := t.subnetRouteCounters.Load()
+	if sc == nil || sc.table.load() == nil {
+		return nil
+	}
+	return sc
 }
 
 // SubnetRouteCountingEnabledForTest reports whether per-route subnet load
 // metrics are currently being collected.
 func (t *Wrapper) SubnetRouteCountingEnabledForTest() bool {
-	return t.subnetRouteCounters.Load() != nil
+	return t.subnetCountersActive() != nil
 }
 
-// countSubnetRouteTraffic attributes a packet to an advertised subnet route,
-// if it is forwarded traffic for one.
+// selfTailscaleAddrs holds this node's own Tailscale addresses, so that the
+// subnet counters can tell traffic the node forwards from traffic it
+// originates or terminates itself.
+type selfTailscaleAddrs struct {
+	v4, v6 netip.Addr
+}
+
+// SetSelfTailscaleAddrs tells the Wrapper this node's own Tailscale addresses.
+//
+// It is used only by the per-route subnet counters, to distinguish forwarded
+// traffic from the node's own; a4 and a6 are typically
+// [tsaddr.FirstTailscaleAddrs] of the node's wireguard config addresses.
+// Callers may pass invalid addresses for either family.
+func (t *Wrapper) SetSelfTailscaleAddrs(a4, a6 netip.Addr) {
+	if old := t.selfAddrs.Load(); old != nil && old.v4 == a4 && old.v6 == a6 {
+		return
+	}
+	t.selfAddrs.Store(&selfTailscaleAddrs{v4: a4, v6: a6})
+}
+
+// isSelfTailscaleAddr reports whether a is one of this node's own Tailscale
+// addresses.
+//
+// It reports false when the addresses are unknown, which counts a packet the
+// same way it was counted before the addresses were plumbed through. In
+// practice they are set alongside the routes, from the same Reconfig.
+func (t *Wrapper) isSelfTailscaleAddr(a netip.Addr) bool {
+	s := t.selfAddrs.Load()
+	return s != nil && (a == s.v4 || a == s.v6)
+}
+
+// IsSelfTailscaleAddrForTest reports whether the Wrapper considers a to be one
+// of this node's own Tailscale addresses.
+func (t *Wrapper) IsSelfTailscaleAddrForTest(a netip.Addr) bool {
+	return t.isSelfTailscaleAddr(a)
+}
+
+// countSubnetRouteParsed attributes an already-decoded packet to an advertised
+// subnet route, if it is traffic this node forwards on a peer's behalf.
 //
 // rx reports the direction from the subnet router's point of view: true when
 // the packet was received from the subnet on its way to a tailnet peer, false
 // when it is being sent into the subnet on a peer's behalf.
 //
-// Only traffic with exactly one Tailscale endpoint is counted: that is what
-// makes it forwarded traffic rather than the node's own. Addresses outside
-// every advertised route are not counted, which excludes exit node traffic.
-func (sc *subnetCounters) countSubnetRouteTraffic(src, dst netip.Addr, bytes int, rx bool) {
+// Addresses outside every advertised route are not counted, which excludes exit
+// node traffic.
+func (t *Wrapper) countSubnetRouteParsed(sc *subnetCounters, p *packet.Parsed, rx bool) {
+	if p.IPVersion == 0 {
+		// Decode bailed out. Src and Dst are not cleared on that path and p is
+		// pool-reused across packets, so they may hold a previous packet's
+		// addresses; counting them would attribute traffic to the wrong route.
+		return
+	}
+	src, dst := p.Src.Addr(), p.Dst.Addr()
 	srcIsTS := tsaddr.IsTailscaleIP(src)
 	dstIsTS := tsaddr.IsTailscaleIP(dst)
 	if srcIsTS == dstIsTS {
+		// Both endpoints on the tailnet, or neither: not subnet forwarding.
 		return
 	}
-	remote := dst
+	remote, tailnetEnd := dst, src
 	if dstIsTS {
-		remote = src
+		remote, tailnetEnd = src, dst
+	}
+	// Exactly one Tailscale endpoint is necessary but not sufficient: it is
+	// equally true of traffic the node itself originates toward, or receives
+	// from, a host inside one of its own advertised prefixes. Requiring the
+	// tailnet end to be a *peer* is what makes the packet forwarded — and
+	// keeps the node's own traffic from being counted in the opposite
+	// direction from the one it actually travelled.
+	if t.isSelfTailscaleAddr(tailnetEnd) {
+		return
 	}
 	if rc := sc.forAddr(remote); rc != nil {
-		rc.add(bytes, rx)
+		// p.TotalLen(), not len(p.Buffer()): the buffer may have trailing
+		// slack, e.g. the full-MTU buffers wireguard-go hands Write.
+		rc.add(p.TotalLen(), rx)
 	}
 }
 
 // countSubnetRoutePacket decodes just enough of b to attribute it to an
-// advertised subnet route. It is a no-op when per-route counting is disabled.
-func (t *Wrapper) countSubnetRoutePacket(b []byte, rx bool) {
-	sc := t.subnetRouteCounters.Load()
-	if sc == nil {
-		return
-	}
+// advertised subnet route.
+func (t *Wrapper) countSubnetRoutePacket(sc *subnetCounters, b []byte, rx bool) {
 	var p packet.Parsed
 	p.Decode(b)
-	if p.IPVersion == 0 {
-		return
-	}
-	// p.TotalLen(), not len(b): b may have trailing slack. wireguard-go hands
-	// Write a full-MTU buffer per packet, so buffs[i][offset:] in tdevWrite
-	// runs to the end of that buffer rather than to the end of the packet.
-	sc.countSubnetRouteTraffic(p.Src.Addr(), p.Dst.Addr(), p.TotalLen(), rx)
+	t.countSubnetRouteParsed(sc, &p, rx)
 }
 
 var (

--- a/net/tstun/wrap.go
+++ b/net/tstun/wrap.go
@@ -223,13 +223,18 @@ type Wrapper struct {
 
 	// subnetRouteCounters counts forwarded traffic per advertised subnet
 	// route. It is nil until SetSubnetRoutes is called with at least one
-	// countable route, so nodes that are not subnet routers, and nodes that
-	// have not opted in, pay only a nil load on the packet path.
+	// countable route, and stays non-nil afterwards even while counting is
+	// disabled, because it owns registrations that cannot be undone.
 	//
-	// Once created it stays non-nil, because it owns registrations that cannot
-	// be undone; use [Wrapper.subnetCountersActive] on the packet path, which
-	// also covers the currently-disabled case.
+	// The packet path does not read it: it reads subnetRouteTable, which is
+	// non-nil exactly when traffic should be counted. So a node that is not a
+	// subnet router, or has not opted in, pays a single nil atomic load.
 	subnetRouteCounters atomic.Pointer[subnetCounters]
+
+	// subnetRouteTable is the published lookup table of subnetRouteCounters,
+	// or nil when no countable route is advertised. See
+	// [Wrapper.subnetCountersActive].
+	subnetRouteTable atomicPrefixTable
 
 	// selfAddrs holds this node's own Tailscale addresses, used by the subnet
 	// counters to tell forwarded traffic from the node's own. Nil until
@@ -936,8 +941,8 @@ func (t *Wrapper) Read(buffs [][]byte, sizes []int, offset int) (int, error) {
 		// Traffic leaving the TUN toward a tailnet peer: on a subnet router
 		// this is a response coming back out of the subnet, so it is rx.
 		// p is already decoded here, so attribute it without re-parsing.
-		if sc := t.subnetCountersActive(); sc != nil {
-			t.countSubnetRouteParsed(sc, p, true)
+		if tbl := t.subnetCountersActive(); tbl != nil {
+			t.countSubnetRouteParsed(tbl, p, true)
 		}
 
 		// Make sure to do SNAT after filtering, so that any flow tracking in
@@ -1118,9 +1123,9 @@ func (t *Wrapper) injectedRead(res tunInjectedRead, outBuffs [][]byte, sizes []i
 	}
 	// Injected packets travel the same direction as Read: out to a tailnet
 	// peer, i.e. rx from the subnet router's point of view.
-	if sc := t.subnetCountersActive(); sc != nil {
+	if tbl := t.subnetCountersActive(); tbl != nil {
 		for i := range n {
-			t.countSubnetRoutePacket(sc, outBuffs[i][offset:offset+sizes[i]], true)
+			t.countSubnetRoutePacket(tbl, outBuffs[i][offset:offset+sizes[i]], true)
 		}
 	}
 
@@ -1317,9 +1322,9 @@ func (t *Wrapper) tdevWrite(buffs [][]byte, offset int) (int, error) {
 	}
 	// Traffic entering the TUN from a tailnet peer: on a subnet router this is
 	// sent onward into the subnet, so it is tx.
-	if sc := t.subnetCountersActive(); sc != nil {
+	if tbl := t.subnetCountersActive(); tbl != nil {
 		for i := range buffs {
-			t.countSubnetRoutePacket(sc, buffs[i][offset:], false)
+			t.countSubnetRoutePacket(tbl, buffs[i][offset:], false)
 		}
 	}
 	return t.tdev.Write(buffs, offset)
@@ -1567,11 +1572,10 @@ func (t *Wrapper) SetSubnetRoutes(routes []netip.Prefix) {
 		if !anyCountableRoute(routes) {
 			// Never enabled and nothing to enable it for. Don't create the
 			// counters at all, so nodes that are not subnet routers, and nodes
-			// that have not opted in, publish no series and pay only a nil
-			// load on the packet path.
+			// that have not opted in, publish no series.
 			return
 		}
-		sc = newSubnetCounters(t.usermetrics)
+		sc = newSubnetCounters(t.usermetrics, &t.subnetRouteTable)
 		t.subnetRouteCounters.Store(sc)
 	}
 	sc.setRoutes(routes)
@@ -1583,18 +1587,13 @@ func (t *Wrapper) subnetCounters() *subnetCounters {
 	return t.subnetRouteCounters.Load()
 }
 
-// subnetCountersActive returns the per-route counters if traffic should be
-// counted right now, or nil if per-route counting is disabled or no countable
-// route is advertised.
+// subnetCountersActive returns the lookup table to attribute packets with, or
+// nil if per-route counting is disabled or no countable route is advertised.
 //
-// This is the packet path's gate: two nil-able atomic loads, no decode and no
+// This is the packet path's gate: one nil-able atomic load, no decode and no
 // lookup when counting is off.
-func (t *Wrapper) subnetCountersActive() *subnetCounters {
-	sc := t.subnetRouteCounters.Load()
-	if sc == nil || sc.table.load() == nil {
-		return nil
-	}
-	return sc
+func (t *Wrapper) subnetCountersActive() *bart.Table[*routeCounters] {
+	return t.subnetRouteTable.load()
 }
 
 // SubnetRouteCountingEnabledForTest reports whether per-route subnet load
@@ -1649,7 +1648,7 @@ func (t *Wrapper) IsSelfTailscaleAddrForTest(a netip.Addr) bool {
 //
 // Addresses outside every advertised route are not counted, which excludes exit
 // node traffic.
-func (t *Wrapper) countSubnetRouteParsed(sc *subnetCounters, p *packet.Parsed, rx bool) {
+func (t *Wrapper) countSubnetRouteParsed(tbl *bart.Table[*routeCounters], p *packet.Parsed, rx bool) {
 	if p.IPVersion == 0 {
 		// Decode bailed out. Src and Dst are not cleared on that path and p is
 		// pool-reused across packets, so they may hold a previous packet's
@@ -1676,7 +1675,7 @@ func (t *Wrapper) countSubnetRouteParsed(sc *subnetCounters, p *packet.Parsed, r
 	if t.isSelfTailscaleAddr(tailnetEnd) {
 		return
 	}
-	if rc := sc.forAddr(remote); rc != nil {
+	if rc, ok := tbl.Lookup(remote); ok {
 		// p.TotalLen(), not len(p.Buffer()): the buffer may have trailing
 		// slack, e.g. the full-MTU buffers wireguard-go hands Write.
 		rc.add(p.TotalLen(), rx)
@@ -1685,10 +1684,10 @@ func (t *Wrapper) countSubnetRouteParsed(sc *subnetCounters, p *packet.Parsed, r
 
 // countSubnetRoutePacket decodes just enough of b to attribute it to an
 // advertised subnet route.
-func (t *Wrapper) countSubnetRoutePacket(sc *subnetCounters, b []byte, rx bool) {
+func (t *Wrapper) countSubnetRoutePacket(tbl *bart.Table[*routeCounters], b []byte, rx bool) {
 	var p packet.Parsed
 	p.Decode(b)
-	t.countSubnetRouteParsed(sc, &p, rx)
+	t.countSubnetRouteParsed(tbl, &p, rx)
 }
 
 var (

--- a/net/tstun/wrap.go
+++ b/net/tstun/wrap.go
@@ -221,9 +221,19 @@ type Wrapper struct {
 	// connCounter maintains per-connection counters.
 	connCounter syncs.AtomicValue[netlogfunc.ConnectionCounter]
 
+	// subnetRouteCounters counts forwarded traffic per advertised subnet
+	// route. It is nil until SetSubnetRoutes is called with a non-empty set
+	// of routes, so nodes that are not subnet routers, and nodes that have
+	// not opted in, pay only a nil load on the packet path.
+	subnetRouteCounters atomic.Pointer[subnetCounters]
+
 	captureHook syncs.AtomicValue[packet.CaptureCallback]
 
 	metrics *metrics
+
+	// usermetrics is the registry the per-route subnet counters publish into
+	// when they are first enabled by SetSubnetRoutes.
+	usermetrics *usermetric.Registry
 
 	eventClient              *eventbus.Client
 	discoKeyAdvertisementPub *eventbus.Publisher[events.DiscoKeyAdvertisement]
@@ -303,6 +313,7 @@ func wrap(logf logger.Logf, tdev tun.Device, isTAP bool, m *usermetric.Registry,
 		filterFlags: filter.LogAccepts | filter.LogDrops,
 		startCh:     make(chan struct{}),
 		metrics:     registerMetrics(m),
+		usermetrics: m,
 	}
 
 	if buildfeatures.HasTUNDevStats {
@@ -911,6 +922,12 @@ func (t *Wrapper) Read(buffs [][]byte, sizes []int, offset int) (int, error) {
 				updateConnCounter(update, p.Buffer(), false)
 			}
 		}
+		// Traffic leaving the TUN toward a tailnet peer: on a subnet router
+		// this is a response coming back out of the subnet, so it is rx.
+		// p is already decoded here, so attribute it without re-parsing.
+		if sc := t.subnetRouteCounters.Load(); sc != nil {
+			sc.countSubnetRouteTraffic(p.Src.Addr(), p.Dst.Addr(), len(p.Buffer()), true)
+		}
 
 		// Make sure to do SNAT after filtering, so that any flow tracking in
 		// the filter sees the original source address. See #12133.
@@ -1086,6 +1103,13 @@ func (t *Wrapper) injectedRead(res tunInjectedRead, outBuffs [][]byte, sizes []i
 			for i := 0; i < n; i++ {
 				updateConnCounter(update, outBuffs[i][offset:offset+sizes[i]], false)
 			}
+		}
+	}
+	// Injected packets travel the same direction as Read: out to a tailnet
+	// peer, i.e. rx from the subnet router's point of view.
+	if sc := t.subnetRouteCounters.Load(); sc != nil {
+		for i := range n {
+			t.countSubnetRoutePacket(outBuffs[i][offset:offset+sizes[i]], true)
 		}
 	}
 
@@ -1278,6 +1302,13 @@ func (t *Wrapper) tdevWrite(buffs [][]byte, offset int) (int, error) {
 			for i := range buffs {
 				updateConnCounter(update, buffs[i][offset:], true)
 			}
+		}
+	}
+	// Traffic entering the TUN from a tailnet peer: on a subnet router this is
+	// sent onward into the subnet, so it is tx.
+	if sc := t.subnetRouteCounters.Load(); sc != nil {
+		for i := range buffs {
+			t.countSubnetRoutePacket(buffs[i][offset:], false)
 		}
 	}
 	return t.tdev.Write(buffs, offset)
@@ -1503,6 +1534,76 @@ func (t *Wrapper) SetConnectionCounter(fn netlogfunc.ConnectionCounter) {
 	if buildfeatures.HasNetLog {
 		t.connCounter.Store(fn)
 	}
+}
+
+// SetSubnetRoutes sets the advertised subnet routes for which forwarded
+// traffic is counted, enabling per-route load metrics.
+//
+// Passing an empty or nil slice disables counting, so callers gate the feature
+// simply by not supplying routes. Counting is deliberately independent of
+// network flow logging, so it works with flow logging off.
+func (t *Wrapper) SetSubnetRoutes(routes []netip.Prefix) {
+	if !buildfeatures.HasUserMetrics && !buildfeatures.HasClientMetrics {
+		return
+	}
+	sc := t.subnetRouteCounters.Load()
+	if sc == nil {
+		if len(routes) == 0 {
+			return
+		}
+		sc = newSubnetCounters(t.usermetrics)
+		t.subnetRouteCounters.Store(sc)
+	}
+	sc.setRoutes(routes)
+	if len(routes) == 0 {
+		t.subnetRouteCounters.Store(nil)
+	}
+}
+
+// subnetCounters returns the active per-route counters, or nil if per-route
+// counting is disabled.
+func (t *Wrapper) subnetCounters() *subnetCounters {
+	return t.subnetRouteCounters.Load()
+}
+
+// countSubnetRouteTraffic attributes a packet to an advertised subnet route,
+// if it is forwarded traffic for one.
+//
+// rx reports the direction from the subnet router's point of view: true when
+// the packet was received from the subnet on its way to a tailnet peer, false
+// when it is being sent into the subnet on a peer's behalf.
+//
+// Only traffic with exactly one Tailscale endpoint is counted: that is what
+// makes it forwarded traffic rather than the node's own. Addresses outside
+// every advertised route are not counted, which excludes exit node traffic.
+func (sc *subnetCounters) countSubnetRouteTraffic(src, dst netip.Addr, bytes int, rx bool) {
+	srcIsTS := tsaddr.IsTailscaleIP(src)
+	dstIsTS := tsaddr.IsTailscaleIP(dst)
+	if srcIsTS == dstIsTS {
+		return
+	}
+	remote := dst
+	if dstIsTS {
+		remote = src
+	}
+	if rc := sc.forAddr(remote); rc != nil {
+		rc.add(bytes, rx)
+	}
+}
+
+// countSubnetRoutePacket decodes just enough of b to attribute it to an
+// advertised subnet route. It is a no-op when per-route counting is disabled.
+func (t *Wrapper) countSubnetRoutePacket(b []byte, rx bool) {
+	sc := t.subnetRouteCounters.Load()
+	if sc == nil {
+		return
+	}
+	var p packet.Parsed
+	p.Decode(b)
+	if p.IPVersion == 0 {
+		return
+	}
+	sc.countSubnetRouteTraffic(p.Src.Addr(), p.Dst.Addr(), len(b), rx)
 }
 
 var (

--- a/net/tstun/wrap.go
+++ b/net/tstun/wrap.go
@@ -1566,6 +1566,12 @@ func (t *Wrapper) subnetCounters() *subnetCounters {
 	return t.subnetRouteCounters.Load()
 }
 
+// SubnetRouteCountingEnabledForTest reports whether per-route subnet load
+// metrics are currently being collected.
+func (t *Wrapper) SubnetRouteCountingEnabledForTest() bool {
+	return t.subnetRouteCounters.Load() != nil
+}
+
 // countSubnetRouteTraffic attributes a packet to an advertised subnet route,
 // if it is forwarded traffic for one.
 //

--- a/util/clientmetric/clientmetric.go
+++ b/util/clientmetric/clientmetric.go
@@ -280,6 +280,17 @@ func (c *AggregateCounter) Register(counter *expvar.Int) {
 	c.counters.Add(counter)
 }
 
+// RegisteredCountForTest returns how many counters are registered with c.
+//
+// Value() is O(this), on every scrape and every logtail delta, so callers that
+// register counters over a process's lifetime use it to assert they aren't
+// leaking. There is no unregister-one API.
+func (c *AggregateCounter) RegisteredCountForTest() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.counters)
+}
+
 // UnregisterAll unregisters all counters resulting in it
 // starting back down at zero. This is to ensure monotonicity
 // and respect the semantics of the counter.

--- a/util/clientmetric/omit.go
+++ b/util/clientmetric/omit.go
@@ -13,6 +13,8 @@ func (*Metric) Value() int64           { return 0 }
 func (*Metric) Register(expvarInt any) {}
 func (*Metric) UnregisterAll()         {}
 
+func (*Metric) RegisteredCountForTest() int { return 0 }
+
 type MetricUpdate struct {
 	Name  string `json:"name"`
 	Type  string `json:"type"`

--- a/util/usermetric/omit.go
+++ b/util/usermetric/omit.go
@@ -25,5 +25,6 @@ func NewMultiLabelMapWithRegistry[T comparable](m *Registry, name string, promTy
 
 func (*noopMap[T]) Add(T, int64) {}
 func (*noopMap[T]) Set(T, any)   {}
+func (*noopMap[T]) Delete(T)     {}
 
 func (r *Registry) Handler(any, any) {} // no-op HTTP handler

--- a/wgengine/router/router.go
+++ b/wgengine/router/router.go
@@ -128,8 +128,15 @@ type Config struct {
 	// SubnetRoutes is the list of subnets that this node is
 	// advertising to other Tailscale nodes.
 	// As of 2023-10-11, this field is only used for network
-	// flow logging and is otherwise ignored.
+	// flow logging and is otherwise ignored. As of 2026-07-28, it is
+	// additionally used for per-route load metrics when CollectLoadMetrics
+	// is set.
 	SubnetRoutes []netip.Prefix
+
+	// CollectLoadMetrics is whether to count forwarded bytes and packets per
+	// entry in SubnetRoutes. It is opt-in because it adds a longest-prefix
+	// lookup to the packet path.
+	CollectLoadMetrics bool
 
 	// Linux-only things below, ignored on other platforms.
 	SNATSubnetRoutes    bool                   // SNAT traffic to local subnets

--- a/wgengine/router/router_test.go
+++ b/wgengine/router/router_test.go
@@ -14,7 +14,8 @@ import (
 func TestConfigEqual(t *testing.T) {
 	testedFields := []string{
 		"LocalAddrs", "Routes", "LocalRoutes", "NewMTU",
-		"SubnetRoutes", "SNATSubnetRoutes", "StatefulFiltering",
+		"SubnetRoutes", "CollectLoadMetrics",
+		"SNATSubnetRoutes", "StatefulFiltering",
 		"NetfilterMode", "NetfilterKind", "RemoveCGNATDropRule",
 	}
 	configType := reflect.TypeFor[Config]()

--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -813,6 +813,14 @@ func (e *userspaceEngine) Reconfig(cfg *wgcfg.Config, routerCfg *router.Config, 
 	defer e.wgLock.Unlock()
 	e.tundev.SetWGConfig(cfg)
 
+	// Per-route load metrics are opt-in, so pass no routes when they are
+	// disabled; that leaves the counting hook uninstalled entirely.
+	if routerCfg.CollectLoadMetrics {
+		e.tundev.SetSubnetRoutes(routerCfg.SubnetRoutes)
+	} else {
+		e.tundev.SetSubnetRoutes(nil)
+	}
+
 	e.mu.Lock()
 	self := e.selfNode
 	e.mu.Unlock()

--- a/wgengine/userspace_test.go
+++ b/wgengine/userspace_test.go
@@ -687,3 +687,94 @@ func TestReconfigSubnetRouteLoadMetrics(t *testing.T) {
 		t.Error("per-route counting stayed enabled after opting out")
 	}
 }
+
+// TestReconfigSubnetRouteLoadMetricsTransitions drives the empty -> non-empty
+// -> empty -> non-empty transitions of the advertised set through Reconfig.
+//
+// Reconfig(&router.Config{}) happens for real, from enterStateLocked, and any
+// netmap update that transiently yields no SubnetRoutes has the same shape.
+func TestReconfigSubnetRouteLoadMetricsTransitions(t *testing.T) {
+	bus := eventbustest.NewBus(t)
+	ht := health.NewTracker(bus)
+	reg := new(usermetric.Registry)
+	e, err := NewFakeUserspaceEngine(t.Logf, 0, ht, reg, bus)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(e.Close)
+
+	ue := e.(*userspaceEngine)
+	routes := []netip.Prefix{netip.MustParsePrefix("10.1.0.0/16")}
+	on := func(rs []netip.Prefix) *router.Config {
+		return &router.Config{SubnetRoutes: rs, CollectLoadMetrics: true}
+	}
+
+	// Opted in, but with no routes yet: nothing to count.
+	if err := ue.Reconfig(&wgcfg.Config{}, on(nil), &dns.Config{}); err != nil {
+		t.Fatalf("Reconfig: %v", err)
+	}
+	if ue.tundev.SubnetRouteCountingEnabledForTest() {
+		t.Error("counting is enabled with an empty route set")
+	}
+
+	// Routes arrive.
+	if err := ue.Reconfig(&wgcfg.Config{}, on(routes), &dns.Config{}); err != nil {
+		t.Fatalf("Reconfig: %v", err)
+	}
+	if !ue.tundev.SubnetRouteCountingEnabledForTest() {
+		t.Fatal("counting is disabled after routes were advertised")
+	}
+
+	// A transient empty netmap, e.g. the reset from enterStateLocked. This must
+	// not decrease any counter, so the instance survives; it just goes inactive.
+	if err := ue.Reconfig(&wgcfg.Config{}, &router.Config{}, &dns.Config{}); err != nil {
+		t.Fatalf("Reconfig: %v", err)
+	}
+	if ue.tundev.SubnetRouteCountingEnabledForTest() {
+		t.Error("counting stayed active across a reset to an empty config")
+	}
+
+	// And back: still counting, and the route is countable again.
+	if err := ue.Reconfig(&wgcfg.Config{}, on(routes), &dns.Config{}); err != nil {
+		t.Fatalf("Reconfig: %v", err)
+	}
+	if !ue.tundev.SubnetRouteCountingEnabledForTest() {
+		t.Error("counting did not come back after routes were re-advertised")
+	}
+}
+
+// TestReconfigSubnetRouteLoadMetricsSelfAddrs verifies that the engine tells
+// the wrapper this node's own Tailscale addresses, which is what lets the
+// subnet counters exclude traffic the node originates itself.
+func TestReconfigSubnetRouteLoadMetricsSelfAddrs(t *testing.T) {
+	bus := eventbustest.NewBus(t)
+	ht := health.NewTracker(bus)
+	reg := new(usermetric.Registry)
+	e, err := NewFakeUserspaceEngine(t.Logf, 0, ht, reg, bus)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(e.Close)
+
+	ue := e.(*userspaceEngine)
+	self4 := netip.MustParseAddr("100.64.0.1")
+	self6 := netip.MustParseAddr("fd7a:115c:a1e0::1")
+	cfg := &wgcfg.Config{Addresses: []netip.Prefix{
+		netip.PrefixFrom(self4, 32),
+		netip.PrefixFrom(self6, 128),
+	}}
+	if err := ue.Reconfig(cfg, &router.Config{
+		SubnetRoutes:       []netip.Prefix{netip.MustParsePrefix("10.1.0.0/16")},
+		CollectLoadMetrics: true,
+	}, &dns.Config{}); err != nil {
+		t.Fatalf("Reconfig: %v", err)
+	}
+	for _, a := range []netip.Addr{self4, self6} {
+		if !ue.tundev.IsSelfTailscaleAddrForTest(a) {
+			t.Errorf("the wrapper does not know %v is one of this node's own addresses", a)
+		}
+	}
+	if ue.tundev.IsSelfTailscaleAddrForTest(netip.MustParseAddr("100.64.0.2")) {
+		t.Error("the wrapper thinks a peer address is one of this node's own")
+	}
+}

--- a/wgengine/userspace_test.go
+++ b/wgengine/userspace_test.go
@@ -643,3 +643,47 @@ func TestDERPAppNamePlumbing(t *testing.T) {
 		t.Fatal("timeout waiting for engine to connect to the test DERP server")
 	}
 }
+
+// TestReconfigSubnetRouteLoadMetrics verifies that the CollectLoadMetrics
+// opt-in reaches the TUN wrapper, and that per-route counting stays off
+// without it.
+func TestReconfigSubnetRouteLoadMetrics(t *testing.T) {
+	bus := eventbustest.NewBus(t)
+	ht := health.NewTracker(bus)
+	reg := new(usermetric.Registry)
+	e, err := NewFakeUserspaceEngine(t.Logf, 0, ht, reg, bus)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(e.Close)
+
+	ue := e.(*userspaceEngine)
+	routes := []netip.Prefix{netip.MustParsePrefix("10.1.0.0/16")}
+
+	// Opted out: no counting, even though routes are advertised.
+	if err := ue.Reconfig(&wgcfg.Config{}, &router.Config{SubnetRoutes: routes}, &dns.Config{}); err != nil {
+		t.Fatalf("Reconfig: %v", err)
+	}
+	if got := ue.tundev.SubnetRouteCountingEnabledForTest(); got {
+		t.Error("per-route counting is enabled without CollectLoadMetrics")
+	}
+
+	// Opted in: counting enabled.
+	if err := ue.Reconfig(&wgcfg.Config{}, &router.Config{
+		SubnetRoutes:       routes,
+		CollectLoadMetrics: true,
+	}, &dns.Config{}); err != nil {
+		t.Fatalf("Reconfig: %v", err)
+	}
+	if got := ue.tundev.SubnetRouteCountingEnabledForTest(); !got {
+		t.Error("per-route counting is disabled with CollectLoadMetrics set")
+	}
+
+	// Opting back out disables it again.
+	if err := ue.Reconfig(&wgcfg.Config{}, &router.Config{SubnetRoutes: routes}, &dns.Config{}); err != nil {
+		t.Fatalf("Reconfig: %v", err)
+	}
+	if got := ue.tundev.SubnetRouteCountingEnabledForTest(); got {
+		t.Error("per-route counting stayed enabled after opting out")
+	}
+}


### PR DESCRIPTION
closes M1 of https://github.com/tailscale/corp/issues/45684

Subnet router operators cannot see how much traffic each router forwards, or which
advertised subnet drives it. They want route popularity and router load (capacity,
whether to add HA peers). No client metric today is labeled by route or CIDR.

Adjacent data exists but doesn't answer it: tailscaled_{inbound,outbound}_bytes_total
is labeled by transport (path="derp"), not route; tailscaled_advertised_routes
is a bare count. Network flow logs do compute per-subnet counts, but
withinRoutesLocked (wgengine/netlog/netlog.go:455) returns a bool — the matched
prefix is discarded — and flow logging is often off.



```
tailscaled_subnet_forwarded_bytes_total{route="10.1.0.0/16",direction="tx"}
tailscaled_subnet_forwarded_packets_total{route="10.1.0.0/16",direction="rx"}
```


Both directions, both bytes and packets — four series per route. Plus clientmetric
aggregates subnet_forwarded_{tx,rx}_{bytes,packets}.

Direction, from the router's view, stated in help text because it's ambiguous:
tx is sent into the subnet on a peer's behalf ("traffic pulled through this
route"); rx is received from the subnet and returned to the peer.

Where. The three updateConnCounter chokepoints in net/tstun/wrap.go (1015,
1190, 1381) already decode every packet; add a per-route hook there, independent of
HasNetLog. tstun.Wrapper doesn't know advertised routes, so push them in from
userspaceEngine.Reconfig (wgengine/userspace.go:829), which already has
routerCfg.SubnetRoutes and already calls SetWGConfig — add SetSubnetRoutes
beside it.

Attribution: packet has one tailnet and one non-tailnet endpoint;
longest-prefix-match the non-tailnet address against advertised routes; on hit,
count. On miss, skip — that's exit-node traffic, out of scope. Exit routes excluded.

Cardinality: 4x route count, bounded by admin config. Withdrawn routes have their
series removed.