### PR TITLE
ipn/ipnserver, client/local: extend operator access across a CLI invocation

### DIFF
--- a/client/local/local.go
+++ b/client/local/local.go
@@ -95,6 +95,13 @@ type Client struct {
 	// different operating system, such as in integration tests.
 	OmitAuth bool
 
+	// CIID optionally specifies a client invocation ID: an opaque
+	// random string identifying one invocation of a CLI command or
+	// GUI action, sent with each request in the
+	// [apitype.RequestCIIDHeader] header. See that constant's docs
+	// for details. If empty, no such header is sent.
+	CIID string
+
 	// tsClient does HTTP requests to the local Tailscale daemon.
 	// It's lazily initialized on first use.
 	tsClient     *http.Client
@@ -146,6 +153,9 @@ func (lc *Client) defaultDialer(ctx context.Context, network, addr string) (net.
 // subject to change between releases.
 func (lc *Client) DoLocalRequest(req *http.Request) (*http.Response, error) {
 	req.Header.Set("Tailscale-Cap", strconv.Itoa(int(tailcfg.CurrentCapabilityVersion)))
+	if lc.CIID != "" {
+		req.Header.Set(apitype.RequestCIIDHeader, lc.CIID)
+	}
 	lc.tsClientOnce.Do(func() {
 		lc.tsClient = &http.Client{
 			Transport: cmp.Or(lc.Transport, http.RoundTripper(

--- a/client/tailscale/apitype/apitype.go
+++ b/client/tailscale/apitype/apitype.go
@@ -30,6 +30,20 @@ const RequestReasonHeader = "X-Tailscale-Reason"
 // See tailscale/corp#26146.
 var RequestReasonKey = ctxkey.New(RequestReasonHeader, "")
 
+// RequestCIIDHeader is the header used to pass an optional client
+// invocation ID ("CIID") on LocalAPI requests. A CIID is an opaque
+// random string generated once per CLI invocation (or equivalent GUI
+// action) and sent on every LocalAPI request made by that invocation,
+// letting tailscaled correlate the requests.
+//
+// tailscaled uses it to briefly extend a caller's write access to
+// later requests in the same invocation after a profile switch drops
+// the operator preference that had been granting that access, as
+// happens during "tailscale login".
+//
+// See tailscale/tailscale#18294.
+const RequestCIIDHeader = "X-Tailscale-Ciid"
+
 // WhoIsResponse is the JSON type returned by tailscaled debug server's /whois?ip=$IP handler.
 // In successful whois responses, Node and UserProfile are never nil.
 type WhoIsResponse struct {

--- a/cmd/tailscale/cli/cli.go
+++ b/cmd/tailscale/cli/cli.go
@@ -8,6 +8,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -91,6 +92,10 @@ func CleanUpArgs(args []string) []string {
 
 var localClient = local.Client{
 	Socket: paths.DefaultTailscaledSocket(),
+	// CIID is a random client invocation ID identifying this CLI
+	// invocation across its LocalAPI requests.
+	// See [apitype.RequestCIIDHeader] for details.
+	CIID: rand.Text(),
 }
 
 // RunWithContext runs the CLI. The args do not include the binary name.

--- a/ipn/ipnserver/actor.go
+++ b/ipn/ipnserver/actor.go
@@ -123,6 +123,19 @@ func (a *actor) pid() int {
 	return a.ci.Pid()
 }
 
+// unixUserID returns the Unix user ID of the connected client if the
+// connection is over a Unix socket with known peer credentials.
+func (a *actor) unixUserID() (uid string, ok bool) {
+	if a.ci == nil || !a.ci.IsUnixSock() {
+		return "", false
+	}
+	creds := a.ci.Creds()
+	if creds == nil {
+		return "", false
+	}
+	return creds.UserID()
+}
+
 // ClientID implements [ipnauth.Actor].
 func (a *actor) ClientID() (_ ipnauth.ClientID, ok bool) {
 	return a.clientID, a.clientID != ipnauth.NoClientID

--- a/ipn/ipnserver/ciid_test.go
+++ b/ipn/ipnserver/ciid_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package ipnserver
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestCIIDWriteGrants(t *testing.T) {
+	s := new(Server)
+
+	if s.ciidWriteAllowed("ciid1", "1000") {
+		t.Error("ciidWriteAllowed with no grants = true; want false")
+	}
+
+	s.noteCIIDWriteAccess("ciid1", "1000")
+	if !s.ciidWriteAllowed("ciid1", "1000") {
+		t.Error("ciidWriteAllowed after grant = false; want true")
+	}
+	if s.ciidWriteAllowed("ciid1", "1001") {
+		t.Error("ciidWriteAllowed with wrong uid = true; want false")
+	}
+	if s.ciidWriteAllowed("ciid2", "1000") {
+		t.Error("ciidWriteAllowed with unknown CIID = true; want false")
+	}
+
+	// Backdate the grant and verify it no longer applies and that
+	// a later note prunes it.
+	s.ciidGrants["ciid1"] = ciidGrant{uid: "1000", expiry: time.Now().Add(-time.Second)}
+	if s.ciidWriteAllowed("ciid1", "1000") {
+		t.Error("ciidWriteAllowed with expired grant = true; want false")
+	}
+	s.noteCIIDWriteAccess("ciid2", "1000")
+	if _, ok := s.ciidGrants["ciid1"]; ok {
+		t.Error("expired grant not pruned by noteCIIDWriteAccess")
+	}
+}
+
+func TestCIIDWriteGrantsBounded(t *testing.T) {
+	s := new(Server)
+	for i := range maxCIIDGrants {
+		s.noteCIIDWriteAccess(fmt.Sprintf("ciid%d", i), "1000")
+	}
+	s.noteCIIDWriteAccess("one-too-many", "1000")
+	if got := len(s.ciidGrants); got != maxCIIDGrants {
+		t.Errorf("len(ciidGrants) = %v; want %v", got, maxCIIDGrants)
+	}
+	if s.ciidWriteAllowed("one-too-many", "1000") {
+		t.Error("grant added beyond maxCIIDGrants")
+	}
+	// Refreshing an existing grant is still allowed at capacity.
+	s.noteCIIDWriteAccess("ciid0", "1000")
+	if !s.ciidWriteAllowed("ciid0", "1000") {
+		t.Error("existing grant not refreshable at capacity")
+	}
+}

--- a/ipn/ipnserver/server.go
+++ b/ipn/ipnserver/server.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 	"unicode"
 
 	"tailscale.com/client/tailscale/apitype"
@@ -51,8 +52,9 @@ type Server struct {
 	// lock order: mu, then LocalBackend.mu
 	mu            sync.Mutex
 	activeReqs    map[*http.Request]ipnauth.Actor
-	backendWaiter waiterSet // of LocalBackend waiters
-	zeroReqWaiter waiterSet // of blockUntilZeroConnections waiters
+	backendWaiter waiterSet            // of LocalBackend waiters
+	zeroReqWaiter waiterSet            // of blockUntilZeroConnections waiters
+	ciidGrants    map[string]ciidGrant // CIID => write grant; see noteCIIDWriteAccess
 }
 
 func (s *Server) mustBackend() *ipnlocal.LocalBackend {
@@ -217,6 +219,15 @@ func (s *Server) serveHTTP(w http.ResponseWriter, r *http.Request) {
 		if actor, ok := ci.(*actor); ok {
 			lah.PermitRead, lah.PermitWrite = actor.Permissions(lb.OperatorUserID())
 			lah.PermitCert = actor.CanFetchCerts()
+			if ciid := r.Header.Get(apitype.RequestCIIDHeader); ciid != "" {
+				if uid, ok := actor.unixUserID(); ok {
+					if lah.PermitWrite {
+						s.noteCIIDWriteAccess(ciid, uid)
+					} else if ciidWriteGrantPaths[r.URL.Path] && s.ciidWriteAllowed(ciid, uid) {
+						lah.PermitWrite = true
+					}
+				}
+			}
 		} else if testenv.InTest() {
 			lah.PermitRead, lah.PermitWrite = true, true
 		}
@@ -238,6 +249,64 @@ func (s *Server) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	io.WriteString(w, "<html><title>Tailscale</title><body><h1>Tailscale</h1>This is the local Tailscale daemon.\n")
+}
+
+// ciidGrantDuration is how long a CIID write grant remains valid after
+// the most recent write-permitted request bearing that CIID.
+const ciidGrantDuration = 30 * time.Second
+
+// maxCIIDGrants bounds the number of tracked CIID grants. Grants can
+// only be created by callers that already have write access, so this
+// is just a memory bound, not a security bound.
+const maxCIIDGrants = 100
+
+// ciidGrant is a temporary extension of LocalAPI write access to
+// requests bearing a client invocation ID ("CIID"; see
+// [apitype.RequestCIIDHeader]). It exists so that a single client
+// invocation such as "tailscale login", authorized via the operator
+// preference, doesn't lose access partway through when it switches to
+// a new, empty profile that has no operator set.
+// See tailscale/tailscale#18294.
+type ciidGrant struct {
+	uid    string    // Unix user ID that held write access
+	expiry time.Time // when the grant lapses
+}
+
+// ciidWriteGrantPaths is the set of LocalAPI paths that accept a CIID
+// write grant in lieu of regular write permission. It is limited to
+// the operations that the login flow needs after switching to a new,
+// empty profile. Keep this list minimal.
+var ciidWriteGrantPaths = map[string]bool{
+	"/localapi/v0/check-prefs":       true,
+	"/localapi/v0/start":             true,
+	"/localapi/v0/login-interactive": true,
+}
+
+// noteCIIDWriteAccess records that a request bearing the given CIID
+// from the given Unix user ID was permitted write access, extending
+// that access to near-future requests with the same CIID and uid.
+func (s *Server) noteCIIDWriteAccess(ciid, uid string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	for k, g := range s.ciidGrants {
+		if g.expiry.Before(now) {
+			delete(s.ciidGrants, k)
+		}
+	}
+	if _, ok := s.ciidGrants[ciid]; !ok && len(s.ciidGrants) >= maxCIIDGrants {
+		return
+	}
+	mak.Set(&s.ciidGrants, ciid, ciidGrant{uid: uid, expiry: now.Add(ciidGrantDuration)})
+}
+
+// ciidWriteAllowed reports whether an unexpired write grant exists for
+// the given CIID and Unix user ID.
+func (s *Server) ciidWriteAllowed(ciid, uid string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	g, ok := s.ciidGrants[ciid]
+	return ok && g.uid == uid && !g.expiry.Before(time.Now())
 }
 
 // inUseOtherUserError is the error type for when the server is in use


### PR DESCRIPTION
"tailscale login" first switches to a new empty profile before starting
the login flow. The new profile's prefs have no OperatorUser, and
LocalAPI write permission is recomputed per request from the current
profile's operator pref, so a non-root operator lost write access
partway through the command: the profile switch itself succeeded, then
the following check-prefs request failed with "checkprefs access
denied". This made the long-suggested advice of running "sudo tailscale
set --operator=$USER" not work for logging in.

Rather than copying the operator pref into the new profile (operator is
per-profile by design), have the CLI generate a random client invocation
ID (CCID) per invocation and send it on all its LocalAPI requests. When
tailscaled permits a write for a request bearing a CCID, it records the
(CCID, peer Unix user ID) pair for 30 seconds. Later requests with the
same CCID from the same uid then retain write access for just the
operations the login flow needs after the profile switch: check-prefs,
start, and login-interactive.

The grant is bound to the peer uid, so the CCID is not a bearer token:
it can only extend access that the same local user already demonstrated
having. The profile created by the login ends up with no operator at
all; users who want to keep operating tailscaled without root must set
an operator again ("tailscale up --operator" or "sudo tailscale set
--operator").

Fixes #18294
