### PR TITLE
feature/conn25,ipn/ipnlocal: remove UseWIPCode() guards

### DIFF
--- a/feature/conn25/api.go
+++ b/feature/conn25/api.go
@@ -12,24 +12,17 @@ import (
 	"slices"
 	"strings"
 
-	"tailscale.com/envknob"
 	"tailscale.com/ipn/ipnlocal"
 	"tailscale.com/ipn/localapi"
 	"tailscale.com/types/appctype"
 	"tailscale.com/util/dnsname"
 	"tailscale.com/util/httpm"
 	"tailscale.com/util/mak"
-	"tailscale.com/util/testenv"
 )
 
 // serveLocalAPIStateGet serves the localapi endpoint /conn25/state.
 // See also [*Conn25.GetActiveState].
 func serveLocalAPIStateGet(h *localapi.Handler, w http.ResponseWriter, r *http.Request) {
-	// TODO(tailscale/corp#39033): Remove for alpha release.
-	if !envknob.UseWIPCode() && !testenv.InTest() {
-		w.WriteHeader(http.StatusNotImplemented)
-		return
-	}
 	if !h.PermitRead {
 		http.Error(w, "conn25/state access denied", http.StatusForbidden)
 		return
@@ -54,12 +47,6 @@ func serveLocalAPIStateGet(h *localapi.Handler, w http.ResponseWriter, r *http.R
 // serveC2NStateGet serves the C2N endpoint /conn25/state.
 // See also [*Conn25.GetActiveState].
 func serveC2NStateGet(b *ipnlocal.LocalBackend, w http.ResponseWriter, r *http.Request) {
-	// TODO(tailscale/corp#39033): Remove for alpha release.
-	if !envknob.UseWIPCode() && !testenv.InTest() {
-		w.WriteHeader(http.StatusNotImplemented)
-		return
-	}
-
 	logf := b.Logger()
 	logf("c2n: GET /conn25/state received")
 

--- a/feature/conn25/conn25.go
+++ b/feature/conn25/conn25.go
@@ -26,7 +26,6 @@ import (
 	"go4.org/netipx"
 	"golang.org/x/net/dns/dnsmessage"
 	"tailscale.com/appc"
-	"tailscale.com/envknob"
 	"tailscale.com/feature"
 	"tailscale.com/ipn"
 	"tailscale.com/ipn/ipnext"
@@ -45,7 +44,6 @@ import (
 	"tailscale.com/util/dnsname"
 	"tailscale.com/util/mak"
 	"tailscale.com/util/set"
-	"tailscale.com/util/testenv"
 	"tailscale.com/wgengine/filter"
 )
 
@@ -90,11 +88,6 @@ func init() {
 }
 
 func handleConnectorTransitIP(h ipnlocal.PeerAPIHandler, w http.ResponseWriter, r *http.Request) {
-	// TODO(tailscale/corp#39033): Remove for alpha release.
-	if !envknob.UseWIPCode() && !testenv.InTest() {
-		w.WriteHeader(http.StatusNotImplemented)
-		return
-	}
 	e, ok := ipnlocal.GetExt[*extension](h.LocalBackend())
 	if !ok {
 		http.Error(w, "miswired", http.StatusInternalServerError)
@@ -107,10 +100,6 @@ func handleConnectorTransitIP(h ipnlocal.PeerAPIHandler, w http.ResponseWriter, 
 }
 
 func handleHookReplyToDNSQueries(h ipnlocal.PeerAPIHandler) bool {
-	// TODO(tailscale/corp#39033): Remove for alpha release.
-	if !envknob.UseWIPCode() && !testenv.InTest() {
-		return false
-	}
 	e, ok := ipnlocal.GetExt[*extension](h.LocalBackend())
 	if !ok {
 		return false
@@ -135,11 +124,6 @@ func (e *extension) Name() string {
 
 // Init implements [ipnext.Extension].
 func (e *extension) Init(host ipnext.Host) error {
-	// TODO(tailscale/corp#39033): Remove for alpha release.
-	if !envknob.UseWIPCode() && !testenv.InTest() {
-		return ipnext.SkipExtension
-	}
-
 	if e.ctxCancel != nil {
 		return nil
 	}

--- a/ipn/ipnlocal/node_backend.go
+++ b/ipn/ipnlocal/node_backend.go
@@ -16,7 +16,6 @@ import (
 
 	"go4.org/netipx"
 	"tailscale.com/appc"
-	"tailscale.com/envknob"
 	"tailscale.com/feature/buildfeatures"
 	"tailscale.com/ipn"
 	"tailscale.com/net/dns"
@@ -1557,7 +1556,7 @@ func dnsConfigForNetmap(nm *netmap.NetworkMap, peers map[tailcfg.NodeID]tailcfg.
 	// TODO(tailscale/corp#37125): make this a hook the extension can add
 	// to reduce dependency from ipnlocal to appc.
 	var conn25AppRoutes map[string][]*dnstype.Resolver
-	if (envknob.UseWIPCode() || testenv.InTest()) && buildfeatures.HasConn25 && !prefs.AppConnector().Advertise {
+	if buildfeatures.HasConn25 && !prefs.AppConnector().Advertise {
 		conn25AppRoutes = appc.AppDNSRoutes(nm.HasCap, nm.SelfNode)
 	}
 


### PR DESCRIPTION
Removing this check installs conn25 instance-level hooks whenever the feature is built in. init-level hooks were always installed, but used this guard to exit early.

Now all hooks, both instance-level and init-level rely on netmap configuration (populated tailscale.com/app-connectors-experimental node attribute, with non-empty apps) to not exit early.

The conn25-shutoff feature flag tells control not to send that node attribute.

Fixes tailscale/corp#39033