### PR TITLE
tstest/natlab: add WAN MTU support, with a repro for #311

### DIFF
--- a/cmd/tta/tta.go
+++ b/cmd/tta/tta.go
@@ -283,6 +283,23 @@ func main() {
 				host, _, _ := net.SplitHostPort(r.RemoteAddr)
 				fmt.Fprintf(w, "Hello world I am %s from %s", name, host)
 			})
+			// /bytes?n=N serves N bytes, for tests that need to move enough
+			// data to fill full-size packets rather than just check
+			// reachability. The body is zeros: the point is the packet sizes
+			// on the wire, and an explicit Content-Length lets the client
+			// tell a truncated transfer from a complete one.
+			mux.HandleFunc("/bytes", func(w http.ResponseWriter, r *http.Request) {
+				n, err := strconv.Atoi(r.URL.Query().Get("n"))
+				if err != nil || n < 0 {
+					http.Error(w, "bad or missing n", http.StatusBadRequest)
+					return
+				}
+				w.Header().Set("Content-Type", "application/octet-stream")
+				w.Header().Set("Content-Length", strconv.Itoa(n))
+				if _, err := io.CopyN(w, zeroReader{}, int64(n)); err != nil {
+					log.Printf("/bytes: writing %d bytes: %v", n, err)
+				}
+			})
 			if err := http.ListenAndServe(":"+port, mux); err != nil {
 				log.Printf("webserver on :%s failed: %v", port, err)
 			}
@@ -663,4 +680,13 @@ func (lb *logBuffer) Write(p []byte) (n int, err error) {
 		return len(p), nil
 	}
 	return lb.buf.Write(p)
+}
+
+// zeroReader is an infinite source of zero bytes, for serving a payload of a
+// requested size without allocating it.
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	clear(p)
+	return len(p), nil
 }

--- a/tstest/natlab/vmtest/mtu_test.go
+++ b/tstest/natlab/vmtest/mtu_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package vmtest_test
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+	"time"
+
+	"tailscale.com/net/tstun"
+	"tailscale.com/tailcfg"
+	"tailscale.com/tstest/natlab/vmtest"
+	"tailscale.com/tstest/natlab/vnet"
+)
+
+// runUnfixedTests gates tests that reproduce a known, still-unfixed defect.
+// They are expected to fail until it is fixed, so they don't run in CI (which
+// discovers and runs every Test* in this package); the flag keeps them one
+// command away locally.
+var runUnfixedTests = flag.Bool("run-unfixed-tests", false,
+	"run tests that reproduce known-unfixed bugs and are expected to fail")
+
+// underlayMTU is the WAN MTU we impose on the path between the two nodes: the
+// MTU of a Tailscale TUN, i.e. what the underlay would be if this tailnet ran
+// over another one.
+const underlayMTU = 1280
+
+// bulkTimeout bounds the test side of a bulk transfer. TTA caps its own
+// upstream fetch at 10s (see [vmtest.Env.HTTPGetN]), so this is deliberately a
+// little longer: it gives TTA time to hit that cap and return what it managed
+// to fetch, which is a more informative failure than a timeout here.
+const bulkTimeout = 20 * time.Second
+
+// TestSmallMTUUnderlayThroughput reproduces the data-plane half of
+// tailscale/tailscale#20668: on a path whose real MTU is smaller than the MTU
+// tailscaled assumes, small packets flow but bulk transfers collapse, and
+// nothing in tailscaled notices.
+//
+// The nodes get a direct UDP path whose MTU is [underlayMTU] (1280). A
+// full-size TUN packet is 1280 bytes, and WireGuard/UDP/IPv4 framing adds 60,
+// so a full-size packet needs 1340 bytes of underlay and does not fit. But
+// tailscaled credits an unprobed path with tstun.SafeWireMTU() (1360, see
+// pingSizeToPktLen in wgengine/magicsock/endpoint.go), so it believes the path
+// is big enough and keeps emitting packets that are silently dropped. Peer MTU
+// discovery is off by default (magicsock.Conn.ShouldPMTUD), and even when on,
+// the probed MTU never reaches the data path (see the TODO in
+// net/tstun/mtu.go's DefaultTUNMTU).
+//
+// This is the asymmetry the reporter saw: `tailscale ping` and interactive use
+// look healthy while downloads are unusable. So the test asserts both halves —
+// that a disco ping succeeds over a direct path, and that a bulk transfer over
+// that same path completes.
+//
+// The bulk transfer is what currently fails. vnet drops the oversized packets
+// without an ICMP "fragmentation needed" (see [vnet.Network.SetMTU]), which
+// models the reporter's case: their packets were fragmented rather than
+// dropped, but either way nothing tells the sender to reduce its packet size.
+//
+// Note that only the node-to-node underlay is constrained. Each node's path to
+// the control plane and DERP is served by vnet's netstack and is unaffected, so
+// a failure here is the peer-to-peer data plane and not a broken control plane.
+func TestSmallMTUUnderlayThroughput(t *testing.T) {
+	if !*runUnfixedTests {
+		t.Skip("skipping test for unfixed bug tailscale/tailscale#20668; set --run-unfixed-tests to run")
+	}
+	env := vmtest.New(t)
+
+	// One network per node, each with an MTU-constrained WAN link, so the
+	// constraint applies in both directions regardless of which side sends.
+	// EasyNAT so the two can still establish a direct path: the point is a
+	// direct path that is too narrow, not the absence of one.
+	addNode := func(name string, num int) *vmtest.Node {
+		nw := env.AddNetwork(
+			fmt.Sprintf("2.%d.%d.%d", num, num, num), // public IP
+			fmt.Sprintf("192.168.%d.1/24", num),
+			vnet.EasyNAT)
+		nw.SetMTU(underlayMTU)
+		return env.AddNode(name, nw,
+			vmtest.OS(vmtest.Gokrazy),
+			vmtest.WebServer(8080))
+	}
+	a := addNode("a", 1)
+	b := addNode("b", 2)
+
+	env.Start()
+
+	// A direct path is a precondition, not the thing under test: over DERP
+	// (TCP to a netstack-terminated VIP) the underlay MTU wouldn't apply and
+	// the test would pass for the wrong reason.
+	if err := env.PingExpect(a, b, vmtest.PingRouteDirect, 60*time.Second); err != nil {
+		t.Fatalf("precondition: want a direct path between the nodes: %v", err)
+	}
+
+	// Small packets fit within the underlay MTU, so this must keep working
+	// even while bulk transfers do not. This is the "pings stay fast while
+	// downloads are unusable" symptom.
+	if err := env.Ping(a, b, tailcfg.PingTSMP, 30*time.Second); err != nil {
+		t.Errorf("small-packet TSMP ping failed; expected small packets to fit under the %d-byte MTU: %v",
+			underlayMTU, err)
+	}
+
+	// Enough data to require many full-size packets (819 of them): a transfer
+	// this size cannot complete if every full-size packet is dropped, but
+	// needs only ~100 KiB/s to finish inside the 10s budget TTA allows, which
+	// vnet clears comfortably.
+	const wantBytes = 1 << 20
+	n, d, err := env.HTTPGetN(a, b, wantBytes, bulkTimeout)
+	if err != nil {
+		t.Errorf("bulk transfer over a %d-byte-MTU path failed after %d of %d bytes: %v\n"+
+			"This is tailscale/tailscale#20668: tailscaled credits an unprobed path with "+
+			"tstun.SafeWireMTU() (%d bytes) and never learns the real one, so every "+
+			"full-size packet is dropped.",
+			underlayMTU, n, wantBytes, err, tstun.SafeWireMTU())
+		return
+	}
+	t.Logf("transferred %d bytes in %v (%.1f Mbit/s)",
+		n, d.Round(time.Millisecond), float64(n)*8/d.Seconds()/1e6)
+}
+
+// TestLargeMTUUnderlayThroughput is the control for
+// [TestSmallMTUUnderlayThroughput]: the same topology and the same transfer,
+// but with an underlay MTU large enough for a full-size packet plus framing.
+// It shares everything with that test except the one variable under study, so
+// if this fails too the fault is in the harness rather than in the MTU
+// handling. Unlike that test it is expected to pass, so it runs in CI.
+func TestLargeMTUUnderlayThroughput(t *testing.T) {
+	env := vmtest.New(t)
+
+	addNode := func(name string, num int) *vmtest.Node {
+		nw := env.AddNetwork(
+			fmt.Sprintf("2.%d.%d.%d", num, num, num),
+			fmt.Sprintf("192.168.%d.1/24", num),
+			vnet.EasyNAT)
+		// 1500, the common Ethernet MTU: comfortably above the 1340 bytes a
+		// full-size TUN packet needs on the wire.
+		nw.SetMTU(1500)
+		return env.AddNode(name, nw,
+			vmtest.OS(vmtest.Gokrazy),
+			vmtest.WebServer(8080))
+	}
+	a := addNode("a", 1)
+	b := addNode("b", 2)
+
+	env.Start()
+
+	if err := env.PingExpect(a, b, vmtest.PingRouteDirect, 60*time.Second); err != nil {
+		t.Fatalf("precondition: want a direct path between the nodes: %v", err)
+	}
+
+	const wantBytes = 1 << 20
+	n, d, err := env.HTTPGetN(a, b, wantBytes, bulkTimeout)
+	if err != nil {
+		t.Fatalf("bulk transfer over a 1500-byte-MTU path failed; "+
+			"the harness itself may be broken: %v", err)
+	}
+	t.Logf("transferred %d bytes in %v (%.1f Mbit/s)",
+		n, d.Round(time.Millisecond), float64(n)*8/d.Seconds()/1e6)
+}

--- a/tstest/natlab/vmtest/mtu_test.go
+++ b/tstest/natlab/vmtest/mtu_test.go
@@ -1,0 +1,137 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package vmtest_test
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+	"time"
+
+	"tailscale.com/net/tstun"
+	"tailscale.com/tailcfg"
+	"tailscale.com/tstest/natlab/vmtest"
+	"tailscale.com/tstest/natlab/vnet"
+)
+
+// runUnfixedTests gates tests that reproduce a known-unfixed defect. CI runs
+// every Test* in this package, so these must opt in to stay out of it.
+var runUnfixedTests = flag.Bool("run-unfixed-tests", false,
+	"run tests that reproduce known-unfixed bugs and are expected to fail")
+
+// underlayMTU is the MTU of a Tailscale TUN: what the underlay looks like when
+// a tailnet runs over another tailnet.
+const underlayMTU = 1280
+
+// bulkTimeout bounds the test side of a bulk transfer. Longer than the 10s cap
+// TTA puts on its own fetch, so TTA reports a partial count rather than us
+// timing out first.
+const bulkTimeout = 20 * time.Second
+
+// TestSmallMTUUnderlayThroughput reproduces the data-plane symptom in #20668:
+// on a path narrower than the MTU tailscaled assumes, pings stay healthy while
+// bulk transfers collapse, and nothing notices. It asserts both halves.
+//
+// A full-size TUN packet is 1280 bytes and WireGuard/UDP/IPv4 framing adds 60,
+// so it needs 1340 bytes of a 1280-byte underlay and doesn't fit. tailscaled
+// sends it anyway: the data path uses tstun.SafeWireMTU() (1360) regardless of
+// the real path MTU.
+//
+// PMTUD doesn't help, which is the useful part. With TS_DEBUG_ENABLE_PMTUD=true
+// throughput is byte-identical: only the 1280-byte probe is answered, so
+// discovery finds the real MTU, but DefaultTUNMTU discards it per its TODO
+// pending PTB generation. Finishing that is #311; see also #9480.
+//
+// Only the node-to-node underlay is constrained; each node's path to control
+// and DERP is netstack-served and unaffected. So a failure here is the data
+// plane, not a broken control plane.
+func TestSmallMTUUnderlayThroughput(t *testing.T) {
+	if !*runUnfixedTests {
+		t.Skip("skipping; fails until peer MTU discovery is plumbed into the data path (#311). Set --run-unfixed-tests to run.")
+	}
+	env := vmtest.New(t)
+
+	// One constrained network per node, so the MTU applies in both directions.
+	// EasyNAT so they can still go direct: the point is a direct path that's
+	// too narrow, not the absence of one.
+	addNode := func(name string, num int) *vmtest.Node {
+		nw := env.AddNetwork(
+			fmt.Sprintf("2.%d.%d.%d", num, num, num), // public IP
+			fmt.Sprintf("192.168.%d.1/24", num),
+			vnet.EasyNAT)
+		nw.SetMTU(underlayMTU)
+		return env.AddNode(name, nw,
+			vmtest.OS(vmtest.Gokrazy),
+			vmtest.WebServer(8080))
+	}
+	a := addNode("a", 1)
+	b := addNode("b", 2)
+
+	env.Start()
+
+	// Precondition, not the thing under test: over DERP the underlay MTU
+	// wouldn't apply and the test would pass for the wrong reason.
+	if err := env.PingExpect(a, b, vmtest.PingRouteDirect, 60*time.Second); err != nil {
+		t.Fatalf("precondition: want a direct path between the nodes: %v", err)
+	}
+
+	// Small packets fit, so this must keep working even while bulk transfers
+	// don't. That asymmetry is the reported symptom.
+	if err := env.Ping(a, b, tailcfg.PingTSMP, 30*time.Second); err != nil {
+		t.Errorf("small-packet TSMP ping failed; expected small packets to fit under the %d-byte MTU: %v",
+			underlayMTU, err)
+	}
+
+	// 819 full-size packets: can't complete if they're all dropped, but needs
+	// only ~100 KiB/s to fit in TTA's 10s budget, which vnet clears easily.
+	const wantBytes = 1 << 20
+	n, d, err := env.HTTPGetN(a, b, wantBytes, bulkTimeout)
+	if err != nil {
+		t.Errorf("bulk transfer over a %d-byte-MTU path failed after %d of %d bytes: %v\n"+
+			"This is #311 (as seen in #20668): the data path uses tstun.SafeWireMTU() "+
+			"(%d bytes) no matter what the real path MTU is, so every full-size packet "+
+			"is dropped. Enabling PMTUD does not change this.",
+			underlayMTU, n, wantBytes, err, tstun.SafeWireMTU())
+		return
+	}
+	t.Logf("transferred %d bytes in %v (%.1f Mbit/s)",
+		n, d.Round(time.Millisecond), float64(n)*8/d.Seconds()/1e6)
+}
+
+// TestLargeMTUUnderlayThroughput is the control for
+// [TestSmallMTUUnderlayThroughput]: identical but for the underlay MTU, so a
+// failure here means the harness is broken rather than the MTU handling. It's
+// expected to pass, so it runs in CI.
+func TestLargeMTUUnderlayThroughput(t *testing.T) {
+	env := vmtest.New(t)
+
+	addNode := func(name string, num int) *vmtest.Node {
+		nw := env.AddNetwork(
+			fmt.Sprintf("2.%d.%d.%d", num, num, num),
+			fmt.Sprintf("192.168.%d.1/24", num),
+			vnet.EasyNAT)
+		// Common Ethernet MTU, well above the 1340 a full-size packet needs.
+		nw.SetMTU(1500)
+		return env.AddNode(name, nw,
+			vmtest.OS(vmtest.Gokrazy),
+			vmtest.WebServer(8080))
+	}
+	a := addNode("a", 1)
+	b := addNode("b", 2)
+
+	env.Start()
+
+	if err := env.PingExpect(a, b, vmtest.PingRouteDirect, 60*time.Second); err != nil {
+		t.Fatalf("precondition: want a direct path between the nodes: %v", err)
+	}
+
+	const wantBytes = 1 << 20
+	n, d, err := env.HTTPGetN(a, b, wantBytes, bulkTimeout)
+	if err != nil {
+		t.Fatalf("bulk transfer over a 1500-byte-MTU path failed; "+
+			"the harness itself may be broken: %v", err)
+	}
+	t.Logf("transferred %d bytes in %v (%.1f Mbit/s)",
+		n, d.Round(time.Millisecond), float64(n)*8/d.Seconds()/1e6)
+}

--- a/tstest/natlab/vmtest/vmtest.go
+++ b/tstest/natlab/vmtest/vmtest.go
@@ -1543,6 +1543,64 @@ func (e *Env) waitForPeerRoute(n *Node, prefix string, timeout time.Duration) bo
 	}
 }
 
+// HTTPGetN fetches wantBytes bytes from the /bytes endpoint of the webserver
+// [WebServer] started on the to node, from the from node, and reports how many
+// bytes arrived and how long it took.
+//
+// Unlike [Env.HTTPGet] it neither buffers the body nor fails the test: it
+// discards the bytes as they arrive, counting them, and returns any error for
+// the caller to interpret. That suits transfers big enough to be worth
+// measuring, and transfers that are expected to fail.
+//
+// A short read is reported as an error along with the partial count, because a
+// transfer that stalls is truncated rather than refused: TTA's /http-get
+// handler has already written a 200 and copied some bytes by the time its own
+// upstream deadline fires. Callers that want to distinguish "moved nothing"
+// from "moved everything slowly" should look at n, not just err.
+//
+// timeout bounds this side of the request only. TTA caps its own upstream fetch
+// at 10 seconds, so that, not timeout, is the real ceiling on how much data one
+// call can move; a timeout longer than it only buys time to read what TTA has
+// already fetched. Size wantBytes to complete well inside 10 seconds.
+func (e *Env) HTTPGetN(from, to *Node, wantBytes int, timeout time.Duration) (n int64, d time.Duration, err error) {
+	e.t.Helper()
+	if to.webServerPort == 0 {
+		e.t.Fatalf("HTTPGetN: node %s has no webserver; pass vmtest.WebServer(port) to AddNode", to.name)
+	}
+	toSt := e.Status(to)
+	if len(toSt.Self.TailscaleIPs) == 0 {
+		e.t.Fatalf("HTTPGetN: node %s has no Tailscale IPs", to.name)
+	}
+	// Escaped because it is nested as a query parameter of TTA's own URL.
+	target := url.QueryEscape(fmt.Sprintf("http://%s:%d/bytes?n=%d",
+		toSt.Self.TailscaleIPs[0], to.webServerPort, wantBytes))
+
+	ctx, cancel := context.WithTimeout(e.t.Context(), timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://unused/http-get?url="+target, nil)
+	if err != nil {
+		return 0, 0, err
+	}
+	t0 := time.Now()
+	res, err := from.agent.HTTPClient.Do(req)
+	if err != nil {
+		return 0, time.Since(t0), err
+	}
+	defer res.Body.Close()
+	n, err = io.Copy(io.Discard, res.Body)
+	d = time.Since(t0)
+	if err != nil {
+		return n, d, fmt.Errorf("after %v and %d of %d bytes: %w", d.Round(time.Millisecond), n, wantBytes, err)
+	}
+	if res.StatusCode != http.StatusOK {
+		return n, d, fmt.Errorf("TTA returned status %d (upstream %q)", res.StatusCode, res.Header.Get("X-Upstream-Status"))
+	}
+	if n != int64(wantBytes) {
+		return n, d, fmt.Errorf("short read: got %d of %d bytes after %v", n, wantBytes, d.Round(time.Millisecond))
+	}
+	return n, d, nil
+}
+
 // HTTPGet makes an HTTP GET request from the given node to the specified URL.
 // The request is proxied through TTA's /http-get handler.
 func (e *Env) HTTPGet(from *Node, targetURL string) string {

--- a/tstest/natlab/vmtest/vmtest.go
+++ b/tstest/natlab/vmtest/vmtest.go
@@ -1543,6 +1543,56 @@ func (e *Env) waitForPeerRoute(n *Node, prefix string, timeout time.Duration) bo
 	}
 }
 
+// HTTPGetN fetches wantBytes bytes from the /bytes endpoint of the webserver
+// [WebServer] started on the to node, from the from node, and reports how many
+// bytes arrived and how long it took.
+//
+// Unlike [Env.HTTPGet] it neither buffers the body nor fails the test: it
+// discards bytes as they arrive, counting them, and returns any error for the
+// caller to interpret. A short read is an error, but n still reports what
+// arrived, since a stalled transfer is truncated rather than refused.
+//
+// timeout bounds this side of the request only. TTA caps its own upstream fetch
+// at 10s, so size wantBytes to complete well inside that.
+func (e *Env) HTTPGetN(from, to *Node, wantBytes int, timeout time.Duration) (n int64, d time.Duration, err error) {
+	e.t.Helper()
+	if to.webServerPort == 0 {
+		e.t.Fatalf("HTTPGetN: node %s has no webserver; pass vmtest.WebServer(port) to AddNode", to.name)
+	}
+	toSt := e.Status(to)
+	if len(toSt.Self.TailscaleIPs) == 0 {
+		e.t.Fatalf("HTTPGetN: node %s has no Tailscale IPs", to.name)
+	}
+	// Escaped because it is nested as a query parameter of TTA's own URL.
+	target := url.QueryEscape(fmt.Sprintf("http://%s:%d/bytes?n=%d",
+		toSt.Self.TailscaleIPs[0], to.webServerPort, wantBytes))
+
+	ctx, cancel := context.WithTimeout(e.t.Context(), timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://unused/http-get?url="+target, nil)
+	if err != nil {
+		return 0, 0, err
+	}
+	t0 := time.Now()
+	res, err := from.agent.HTTPClient.Do(req)
+	if err != nil {
+		return 0, time.Since(t0), err
+	}
+	defer res.Body.Close()
+	n, err = io.Copy(io.Discard, res.Body)
+	d = time.Since(t0)
+	if err != nil {
+		return n, d, fmt.Errorf("after %v and %d of %d bytes: %w", d.Round(time.Millisecond), n, wantBytes, err)
+	}
+	if res.StatusCode != http.StatusOK {
+		return n, d, fmt.Errorf("TTA returned status %d (upstream %q)", res.StatusCode, res.Header.Get("X-Upstream-Status"))
+	}
+	if n != int64(wantBytes) {
+		return n, d, fmt.Errorf("short read: got %d of %d bytes after %v", n, wantBytes, d.Round(time.Millisecond))
+	}
+	return n, d, nil
+}
+
 // HTTPGet makes an HTTP GET request from the given node to the specified URL.
 // The request is proxied through TTA's /http-get handler.
 func (e *Env) HTTPGet(from *Node, targetURL string) string {

--- a/tstest/natlab/vnet/conf.go
+++ b/tstest/natlab/vnet/conf.go
@@ -391,6 +391,7 @@ type Network struct {
 
 	latency  time.Duration // latency applied to interface writes
 	lossRate float64       // chance of packet loss (0.0 to 1.0)
+	mtu      int           // IP MTU of the router's WAN link; 0 means unlimited
 
 	// ...
 	err error // carried error
@@ -399,6 +400,26 @@ type Network struct {
 // SetLatency sets the simulated network latency for this network.
 func (n *Network) SetLatency(d time.Duration) {
 	n.latency = d
+}
+
+// SetMTU sets the IP MTU of this network's WAN link: the largest IP packet, in
+// bytes, that the router will forward to or from the simulated internet. An
+// mtu of 0 (the default) means unlimited.
+//
+// Oversized packets are dropped without an ICMP "fragmentation needed" or
+// "packet too big" reply, and without fragmenting them. That models a path
+// whose MTU cannot be discovered — either because a middlebox swallows the
+// ICMP, or because the sender set DF and nothing told it to back off. It is
+// the pessimal case for a sender that assumes an MTU rather than probing it.
+//
+// Only forwarded node traffic crossing the router's WAN link is constrained.
+// Packets between two nodes on the same LAN segment don't traverse the router,
+// and traffic the router itself originates from its netstack (the fake control
+// plane, DERP, DNS, file servers) is delivered straight to the LAN; neither is
+// affected. So a test can constrain the tailnet underlay between two nodes
+// while leaving each node's path to control and DERP at full size.
+func (n *Network) SetMTU(mtu int) {
+	n.mtu = mtu
 }
 
 // SetPacketLoss sets the packet loss rate for this network 0.0 (no loss) to 1.0 (total loss).
@@ -510,6 +531,7 @@ func (s *Server) initFromConfig(c *Config) error {
 			breakWAN4:  conf.breakWAN4,
 			latency:    conf.latency,
 			lossRate:   conf.lossRate,
+			mtu:        conf.mtu,
 			nodesByIP4: map[netip.Addr]*node{},
 			nodesByMAC: map[MAC]*node{},
 			logf:       logger.WithPrefix(s.logf, fmt.Sprintf("[net-%v] ", conf.mac)),

--- a/tstest/natlab/vnet/conf.go
+++ b/tstest/natlab/vnet/conf.go
@@ -391,6 +391,7 @@ type Network struct {
 
 	latency  time.Duration // latency applied to interface writes
 	lossRate float64       // chance of packet loss (0.0 to 1.0)
+	mtu      int           // IP MTU of the router's WAN link; 0 means unlimited
 
 	// ...
 	err error // carried error
@@ -399,6 +400,22 @@ type Network struct {
 // SetLatency sets the simulated network latency for this network.
 func (n *Network) SetLatency(d time.Duration) {
 	n.latency = d
+}
+
+// SetMTU sets the IP MTU of this network's WAN link: the largest IP packet the
+// router will forward to or from the simulated internet. 0 (the default) means
+// unlimited.
+//
+// Oversized packets are dropped, neither fragmented nor answered with an ICMP
+// "fragmentation needed": the worst case for a sender that assumes an MTU
+// rather than probing it.
+//
+// Only forwarded traffic crossing the WAN link is constrained. Same-LAN packets
+// and traffic the router originates from its netstack (control, DERP, DNS) skip
+// the router's WAN path and are unaffected, so a test can narrow the underlay
+// between two nodes while leaving their paths to control and DERP full-size.
+func (n *Network) SetMTU(mtu int) {
+	n.mtu = mtu
 }
 
 // SetPacketLoss sets the packet loss rate for this network 0.0 (no loss) to 1.0 (total loss).
@@ -510,6 +527,7 @@ func (s *Server) initFromConfig(c *Config) error {
 			breakWAN4:  conf.breakWAN4,
 			latency:    conf.latency,
 			lossRate:   conf.lossRate,
+			mtu:        conf.mtu,
 			nodesByIP4: map[netip.Addr]*node{},
 			nodesByMAC: map[MAC]*node{},
 			logf:       logger.WithPrefix(s.logf, fmt.Sprintf("[net-%v] ", conf.mac)),

--- a/tstest/natlab/vnet/mtu_test.go
+++ b/tstest/natlab/vnet/mtu_test.go
@@ -1,0 +1,186 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package vnet
+
+import (
+	"net/netip"
+	"strings"
+	"testing"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
+
+// testMTU is the WAN MTU used by the tests below. It's the smallest MTU
+// allowed for IPv6, the MTU of a Tailscale TUN, and thus the MTU of a
+// tailnet-over-tailnet underlay: the case that motivated [Network.SetMTU].
+const testMTU = 1280
+
+// payloadOfIPLen returns a UDP payload sized so that the IPv4 packet carrying
+// it is exactly ipLen bytes.
+func payloadOfIPLen(ipLen int) gopacket.Payload {
+	const ipv4AndUDPHeaderLen = 20 + 8
+	return gopacket.Payload(make([]byte, ipLen-ipv4AndUDPHeaderLen))
+}
+
+// mkUDPToWAN makes an ethernet frame from node 1 to its router carrying a UDP
+// packet to dst out on the simulated internet, with a payload sized so the IP
+// packet is exactly ipLen bytes.
+func mkUDPToWAN(dst netip.AddrPort, ipLen int) []byte {
+	eth := &layers.Ethernet{
+		SrcMAC: nodeMac(1).HWAddr(),
+		DstMAC: routerMac(1).HWAddr(),
+	}
+	ip := mkIPLayer(layers.IPProtocolUDP, clientIPv4(1), dst.Addr())
+	udp := &layers.UDP{SrcPort: 41641, DstPort: layers.UDPPort(dst.Port())}
+	return mustPacket(eth, ip, udp, payloadOfIPLen(ipLen))
+}
+
+// wanPeer is net 2's WAN IP:port, which net 1 forwards towards.
+var wanPeer = netip.MustParseAddrPort("2.2.2.2:41641")
+
+// newMTUTestServer builds two networks, each with one node, where net 1 sends
+// and net 2 receives the packets the MTU tests send. mtu1 and mtu2 are the
+// respective WAN MTUs; 0 means unlimited.
+//
+// Net 2 uses a one-to-one NAT because, unlike the other NAT types, it has no
+// stateful firewall: inbound packets are delivered without a prior outbound
+// packet to open a mapping. That way a packet that fails to arrive did so
+// because of the MTU and not for want of NAT state.
+func newMTUTestServer(t *testing.T, mtu1, mtu2 int) *Server {
+	t.Helper()
+	var c Config
+	nw1 := c.AddNetwork("2.1.1.1", "192.168.0.1/24", EasyNAT)
+	nw2 := c.AddNetwork("2.2.2.2", "192.168.1.1/24", One2OneNAT)
+	nw1.SetMTU(mtu1)
+	nw2.SetMTU(mtu2)
+	c.AddNode(nw1)
+	c.AddNode(nw2)
+	s, err := New(&c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(s.Close)
+	// Otherwise background RAs race the packet-count assertions.
+	s.StopUnsolicitedRAsForTest()
+	return s
+}
+
+// TestSetMTU tests that a network with an MTU forwards packets up to that size
+// across its WAN link and silently drops the rest, in both directions.
+func TestSetMTU(t *testing.T) {
+	sizes := []struct {
+		name     string
+		ipLen    int
+		wantDrop bool
+	}{
+		{"under-mtu", testMTU - 100, false},
+		{"exactly-mtu", testMTU, false},
+		{"one-over-mtu", testMTU + 1, true},
+		// The case from tailscale/tailscale#20668: a 1280-byte tailnet TUN
+		// packet plus WireGuard/UDP/IPv4 overhead, crossing an underlay that
+		// is itself a 1280-MTU tailnet.
+		{"nested-tailnet-packet", testMTU + 60, true},
+	}
+	// Constraining the sending vs. the receiving network exercises the egress
+	// and ingress checks respectively. Either way the packet must not arrive.
+	for _, dir := range []struct {
+		name       string
+		mtu1, mtu2 int
+	}{
+		{name: "egress", mtu1: testMTU},
+		{name: "ingress", mtu2: testMTU},
+	} {
+		t.Run(dir.name, func(t *testing.T) {
+			for _, tt := range sizes {
+				t.Run(tt.name, func(t *testing.T) {
+					s := newMTUTestServer(t, dir.mtu1, dir.mtu2)
+					se := newSideEffects(s)
+
+					if err := s.handleEthernetFrameFromVM(mkUDPToWAN(wanPeer, tt.ipLen)); err != nil {
+						t.Fatal(err)
+					}
+
+					if got := anyLogContains(se, "exceeds WAN MTU"); got != tt.wantDrop {
+						t.Errorf("IP length %d: dropped for MTU=%v, want %v; logs:\n%s",
+							tt.ipLen, got, tt.wantDrop, strings.Join(se.logs, "\n"))
+					}
+					// The MTU drop must be what actually keeps the packet off
+					// the far LAN, and an in-size packet must still get there.
+					gotDelivered := len(se.got) > 0
+					if wantDelivered := !tt.wantDrop; gotDelivered != wantDelivered {
+						t.Errorf("IP length %d: delivered=%v, want %v; logs:\n%s",
+							tt.ipLen, gotDelivered, wantDelivered, strings.Join(se.logs, "\n"))
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestSetMTUZeroMeansUnlimited tests that a network with no MTU set forwards
+// arbitrarily large packets, so that SetMTU is opt-in and existing tests are
+// unaffected.
+func TestSetMTUZeroMeansUnlimited(t *testing.T) {
+	s := newMTUTestServer(t, 0, 0)
+	se := newSideEffects(s)
+
+	if err := s.handleEthernetFrameFromVM(mkUDPToWAN(wanPeer, 9000)); err != nil {
+		t.Fatal(err)
+	}
+	if anyLogContains(se, "exceeds WAN MTU") {
+		t.Errorf("packet dropped for MTU on a network with no MTU set; logs:\n%s",
+			strings.Join(se.logs, "\n"))
+	}
+	if len(se.got) == 0 {
+		t.Errorf("9000-byte packet was not delivered; logs:\n%s", strings.Join(se.logs, "\n"))
+	}
+}
+
+// TestSetMTUExemptsSameLAN tests that the MTU constrains only the router's WAN
+// path: two nodes on one segment can exceed it, as on a real LAN whose own MTU
+// is larger than the WAN link's.
+func TestSetMTUExemptsSameLAN(t *testing.T) {
+	var c Config
+	nw := c.AddNetwork("2.1.1.1", "192.168.0.1/24", EasyNAT)
+	nw.SetMTU(testMTU)
+	c.AddNode(nw)
+	c.AddNode(nw)
+	s, err := New(&c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(s.Close)
+	s.StopUnsolicitedRAsForTest()
+	se := newSideEffects(s)
+
+	// Addressed to node 2's MAC, so the router never sees it.
+	eth := &layers.Ethernet{
+		SrcMAC: nodeMac(1).HWAddr(),
+		DstMAC: nodeMac(2).HWAddr(),
+	}
+	ip := mkIPLayer(layers.IPProtocolUDP, clientIPv4(1), clientIPv4(2))
+	udp := &layers.UDP{SrcPort: 41641, DstPort: 41641}
+	frame := mustPacket(eth, ip, udp, payloadOfIPLen(testMTU+500))
+	if err := s.handleEthernetFrameFromVM(frame); err != nil {
+		t.Fatal(err)
+	}
+
+	if anyLogContains(se, "exceeds WAN MTU") {
+		t.Errorf("intra-LAN packet was subject to the WAN MTU; logs:\n%s", strings.Join(se.logs, "\n"))
+	}
+	if len(se.got) == 0 {
+		t.Errorf("intra-LAN oversize packet was not delivered; logs:\n%s", strings.Join(se.logs, "\n"))
+	}
+}
+
+// anyLogContains reports whether any log line recorded in se contains sub.
+func anyLogContains(se *sideEffects, sub string) bool {
+	for _, log := range se.logs {
+		if strings.Contains(log, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/tstest/natlab/vnet/vnet.go
+++ b/tstest/natlab/vnet/vnet.go
@@ -686,6 +686,7 @@ type network struct {
 	blackholeControl bool                 // blackhole control connectivity
 	latency          time.Duration        // latency applied to interface writes
 	lossRate         float64              // probability of dropping a packet (0.0 to 1.0)
+	mtu              int                  // IP MTU of the WAN link; 0 means unlimited
 	nodesByIP4       map[netip.Addr]*node // by LAN IPv4
 	nodesByMAC       map[MAC]*node
 	logf             func(format string, args ...any)
@@ -1542,6 +1543,21 @@ func (n *network) writeEth(res []byte) bool {
 	return false
 }
 
+// exceedsWANMTU reports whether an IP packet of ipLen bytes is too large to
+// cross this network's WAN link, logging it if so. It always reports false if
+// no MTU is configured. See [Network.SetMTU] for why such packets are dropped
+// rather than fragmented or rejected with an ICMP error.
+//
+// ipLen must be the length of the IP packet, excluding any Ethernet header, to
+// match the kernel's definition of an interface MTU.
+func (n *network) exceedsWANMTU(ipLen int, src, dst netip.AddrPort) bool {
+	if n.mtu == 0 || ipLen <= n.mtu {
+		return false
+	}
+	n.logf("dropping packet %v=>%v: IP length %d exceeds WAN MTU %d", src, dst, ipLen, n.mtu)
+	return true
+}
+
 func (n *network) conditionedWrite(nw networkWriter, packet []byte) {
 	if n.lossRate > 0 && rand.Float64() < n.lossRate {
 		// packet lost
@@ -1667,6 +1683,9 @@ func (n *network) HandleUDPPacket(p UDPPacket) {
 		// Blackhole the packet.
 		return
 	}
+	if n.exceedsWANMTU(len(buf), p.Src, p.Dst) {
+		return
+	}
 	dst := n.doNATIn(p.Src, p.Dst)
 	if !dst.IsValid() {
 		n.logf("Warning: NAT dropped packet; no mapping for %v=>%v", p.Src, p.Dst)
@@ -1724,6 +1743,9 @@ func (n *network) HandleTCPPacket(p TCPPacket) {
 		InterfaceIndex: n.wanInterfaceID,
 	}, buf)
 	if p.Dst.Addr().Is4() && n.breakWAN4 {
+		return
+	}
+	if n.exceedsWANMTU(len(buf), p.Src, p.Dst) {
 		return
 	}
 	dst := n.doNATIn(p.Src, p.Dst)
@@ -1968,6 +1990,9 @@ func (n *network) handleTCPPacketForRouter(tcp *layers.TCP, flow ipSrcDst) {
 		Length:         len(buf),
 		InterfaceIndex: n.lanInterfaceID,
 	}, buf)
+	if n.exceedsWANMTU(len(buf), src, dst) {
+		return
+	}
 
 	lanSrc := src
 	src = n.doNATOut(src, dst)
@@ -2067,6 +2092,9 @@ func (n *network) handleUDPPacketForRouter(ep EthernetPacket, udp *layers.UDP, t
 			Length:         len(buf),
 			InterfaceIndex: n.lanInterfaceID,
 		}, buf)
+		if n.exceedsWANMTU(len(buf), src, dst) {
+			return
+		}
 
 		lanSrc := src // the original src, before NAT (for logging only)
 		src = n.doNATOut(src, dst)

--- a/tstest/natlab/vnet/vnet.go
+++ b/tstest/natlab/vnet/vnet.go
@@ -686,6 +686,7 @@ type network struct {
 	blackholeControl bool                 // blackhole control connectivity
 	latency          time.Duration        // latency applied to interface writes
 	lossRate         float64              // probability of dropping a packet (0.0 to 1.0)
+	mtu              int                  // IP MTU of the WAN link; 0 means unlimited
 	nodesByIP4       map[netip.Addr]*node // by LAN IPv4
 	nodesByMAC       map[MAC]*node
 	logf             func(format string, args ...any)
@@ -1542,6 +1543,20 @@ func (n *network) writeEth(res []byte) bool {
 	return false
 }
 
+// exceedsWANMTU reports whether an IP packet of ipLen bytes is too large to
+// cross this network's WAN link, logging it if so, and always false if no MTU
+// is set. See [Network.SetMTU].
+//
+// ipLen excludes any Ethernet header, matching the kernel's definition of an
+// interface MTU.
+func (n *network) exceedsWANMTU(ipLen int, src, dst netip.AddrPort) bool {
+	if n.mtu == 0 || ipLen <= n.mtu {
+		return false
+	}
+	n.logf("dropping packet %v=>%v: IP length %d exceeds WAN MTU %d", src, dst, ipLen, n.mtu)
+	return true
+}
+
 func (n *network) conditionedWrite(nw networkWriter, packet []byte) {
 	if n.lossRate > 0 && rand.Float64() < n.lossRate {
 		// packet lost
@@ -1667,6 +1682,9 @@ func (n *network) HandleUDPPacket(p UDPPacket) {
 		// Blackhole the packet.
 		return
 	}
+	if n.exceedsWANMTU(len(buf), p.Src, p.Dst) {
+		return
+	}
 	dst := n.doNATIn(p.Src, p.Dst)
 	if !dst.IsValid() {
 		n.logf("Warning: NAT dropped packet; no mapping for %v=>%v", p.Src, p.Dst)
@@ -1724,6 +1742,9 @@ func (n *network) HandleTCPPacket(p TCPPacket) {
 		InterfaceIndex: n.wanInterfaceID,
 	}, buf)
 	if p.Dst.Addr().Is4() && n.breakWAN4 {
+		return
+	}
+	if n.exceedsWANMTU(len(buf), p.Src, p.Dst) {
 		return
 	}
 	dst := n.doNATIn(p.Src, p.Dst)
@@ -1968,6 +1989,9 @@ func (n *network) handleTCPPacketForRouter(tcp *layers.TCP, flow ipSrcDst) {
 		Length:         len(buf),
 		InterfaceIndex: n.lanInterfaceID,
 	}, buf)
+	if n.exceedsWANMTU(len(buf), src, dst) {
+		return
+	}
 
 	lanSrc := src
 	src = n.doNATOut(src, dst)
@@ -2067,6 +2091,9 @@ func (n *network) handleUDPPacketForRouter(ep EthernetPacket, udp *layers.UDP, t
 			Length:         len(buf),
 			InterfaceIndex: n.lanInterfaceID,
 		}, buf)
+		if n.exceedsWANMTU(len(buf), src, dst) {
+			return
+		}
 
 		lanSrc := src // the original src, before NAT (for logging only)
 		src = n.doNATOut(src, dst)


### PR DESCRIPTION
`vnet` had no MTU concept, so nothing could exercise a path whose real MTU is smaller than the one `tailscaled` assumes. Adds `Network.SetMTU`, which drops oversized forwarded packets without an ICMP reply (the worst case for a sender that assumes rather than probes), plus a `tta` `/bytes` endpoint and `Env.HTTPGetN` to drive a bulk node-to-node transfer.

Only forwarded traffic crossing the WAN link is constrained - same-LAN packets and netstack-originated traffic (control, DERP, DNS) are unaffected - so a test can narrow the underlay between two nodes while leaving their paths to control and DERP full-size.

## What it shows

| Underlay MTU | PMTUD | Transferred |
|---|---|---|
| 1500 (control) | off | 1048576 / 1048576 - 590ms, 14.2 Mbit/s |
| 1280 | off | **512** / 1048576 |
| 1280 | on | **512** / 1048576 |

Dropped packets are 1340 bytes: a 1280-byte TUN payload plus 60 of framing.

Enabling PMTUD makes no difference, which is the useful part. Probing runs and finds the right answer - only the 1280-byte probe is answered - but `DefaultTUNMTU` discards it and returns `safeTUNMTU` per its TODO, pending PTB generation. So the remaining work in #311 is the plumbing plus PTB, not the probing. Full evidence in [my comment on #311](https://github.com/tailscale/tailscale/issues/311).

## Tests

- `vnet/mtu_test.go` - pure Go, no VMs, ~30ms. Covers egress/ingress, the boundary cases, that 0 means unlimited, and that same-LAN traffic is exempt.
- `TestLargeMTUUnderlayThroughput` - the 1500-byte control. Expected to pass, runs in CI.
- `TestSmallMTUUnderlayThroughput` - the repro. Fails until #311 is fixed, so it's behind `--run-unfixed-tests` (natlab CI discovers every `Test*` in the package, and this would otherwise be permanently red).

Both VM tests verified locally under TCG; the control passes, the repro fails as described. Needs the `run-natlab-tests` label to exercise them in CI.

Updates #311
Updates #20668