### PR TITLE
client/web: send QNAP auth checks to localhost, not the request host

### DIFF
--- a/client/web/qnap.go
+++ b/client/web/qnap.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 )
@@ -55,10 +56,15 @@ func qnapAuthn(r *http.Request) (string, *qnapAuthResponse, error) {
 	return "", nil, fmt.Errorf("not authenticated by any mechanism")
 }
 
-// qnapAuthnURL returns the auth URL to use by inferring where the UI is
-// running based on the request URL. This is necessary because QNAP has so
-// many options, see https://github.com/tailscale/tailscale/issues/7108
+// qnapAuthnURL returns the auth URL to use by inferring the scheme and port
+// the UI is running on from the request URL. This is necessary because QNAP has
+// so many options, see https://github.com/tailscale/tailscale/issues/7108
 // and https://github.com/tailscale/tailscale/issues/6903
+//
+// Only the scheme and port are taken from requestUrl. authLogin.cgi is served
+// by the QNAP web server on this same device, and the host in requestUrl comes
+// from the client's Host header, so it must not be used to decide where the
+// user's credentials get sent.
 func qnapAuthnURL(requestUrl string, query url.Values) string {
 	in, err := url.Parse(requestUrl)
 	scheme := ""
@@ -71,7 +77,10 @@ func qnapAuthnURL(requestUrl string, query url.Values) string {
 		host = "localhost"
 	} else {
 		scheme = in.Scheme
-		host = in.Host
+		host = "localhost"
+		if port := in.Port(); port != "" {
+			host = net.JoinHostPort(host, port)
+		}
 	}
 
 	u := url.URL{

--- a/client/web/web_test.go
+++ b/client/web/web_test.go
@@ -53,17 +53,32 @@ func TestQnapAuthnURL(t *testing.T) {
 		{
 			name: "IP-http",
 			in:   "http://10.1.20.4:80/",
-			want: "http://10.1.20.4:80/cgi-bin/authLogin.cgi?qtoken=token",
+			want: "http://localhost:80/cgi-bin/authLogin.cgi?qtoken=token",
 		},
 		{
 			name: "IP6-https",
 			in:   "https://[ff7d:0:1:2::1]/",
-			want: "https://[ff7d:0:1:2::1]/cgi-bin/authLogin.cgi?qtoken=token",
+			want: "https://localhost/cgi-bin/authLogin.cgi?qtoken=token",
 		},
 		{
 			name: "hostname-https",
 			in:   "https://qnap.example.com/",
-			want: "https://qnap.example.com/cgi-bin/authLogin.cgi?qtoken=token",
+			want: "https://localhost/cgi-bin/authLogin.cgi?qtoken=token",
+		},
+		{
+			name: "attacker-supplied-host",
+			in:   "http://evil.example.com/cgi-bin/qpkg/Tailscale/index.cgi/api/data",
+			want: "http://localhost/cgi-bin/authLogin.cgi?qtoken=token",
+		},
+		{
+			name: "attacker-supplied-host-and-port",
+			in:   "https://evil.example.com:8443/",
+			want: "https://localhost:8443/cgi-bin/authLogin.cgi?qtoken=token",
+		},
+		{
+			name: "attacker-supplied-userinfo-host",
+			in:   "http://localhost@evil.example.com/",
+			want: "http://localhost/cgi-bin/authLogin.cgi?qtoken=token",
 		},
 		{
 			name: "invalid-URL",


### PR DESCRIPTION
The web client's QNAP authorization path asks the NAS itself whether the logged-in user is an admin, and qnapAuthnURL works out where to send that question by copying the host out of the incoming request URL. On QNAP the client runs as a CGI script under QTS (tailscale web --cgi, LoginServerMode), and net/http/cgi builds r.URL from the HTTP_HOST parameter, so that host is just the client's Host header; a request arriving with Host: evil.example sends the NAS_USER and qtoken cookie values to http://evil.example/cgi-bin/authLogin.cgi, over a client with InsecureSkipVerify set. Whatever answers then decides the outcome, because authorizeQNAP only reads authPassed and isAdmin out of the XML, and that bool is the only gate on /api/ requests for distro.QNAP, while requireTailscaleIP, which would otherwise catch a request aimed at an unexpected name, only runs in ManageServerMode. That makes it a Host header SSRF that lands as an authentication bypass: an unauthenticated request carrying made-up cookie values authenticates as an admin, and a genuine user's session token leaks to whoever they were tricked into naming. I noticed it reading the two distro auth helpers side by side, since the Synology one execs a local binary and so has no remote endpoint to redirect. The fix keeps inferring the scheme and port from the request, which is the reason the inference exists (#7108, #6903), but always points the credential check at localhost, matching what the function already does when it cannot parse the URL; three cases in the existing table test asserted the old host-from-request behavior, so those expectations move too and three attacker-controlled hosts are added alongside them. To confirm the impact rather than just the URL, I bound a server to this machine's LAN address that always replies authPassed=1/isAdmin=1 and set the request host to it: beforehand authorizeQNAP returned true with a junk qtoken and the attacker server logged the credentials, and afterwards the request goes to localhost and fails closed.