### PR TITLE
cmd/k8s-operator: add auth key reissuance to PeerRelay

### DIFF
--- a/k8s-operator/reconciler/peerrelay/authkey.go
+++ b/k8s-operator/reconciler/peerrelay/authkey.go
@@ -6,7 +6,20 @@
 package peerrelay
 
 import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	tailscaleclient "tailscale.com/client/tailscale/v2"
+
 	tsapi "tailscale.com/k8s-operator/apis/v1alpha1"
+	"tailscale.com/k8s-operator/reconciler/tailscaled"
+	"tailscale.com/k8s-operator/tsclient"
+	"tailscale.com/kube/kubetypes"
+	"tailscale.com/tailcfg"
 )
 
 func (r *Reconciler) peerRelayTags(pr *tsapi.PeerRelay) []string {
@@ -15,4 +28,136 @@ func (r *Reconciler) peerRelayTags(pr *tsapi.PeerRelay) []string {
 		return r.defaultTags
 	}
 	return tags
+}
+
+// getAuthKey returns the auth key to embed in a replica's config Secret, or nil if none is
+// needed. A new key is minted if the config Secret doesn't exist yet, or if the replica has
+// requested a reissue via its state Secret. An existing key is retained while the device hasn't
+// authed or a reissue is in progress.
+func (r *Reconciler) getAuthKey(ctx context.Context, pr *tsapi.PeerRelay, idx int32) (*string, error) {
+	tsClient, err := r.tsClients.For(pr.Spec.Tailnet)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve Tailscale API client for tailnet %q: %w", pr.Spec.Tailnet, err)
+	}
+
+	var existingCfgSecret *corev1.Secret
+	cfgSecret := &corev1.Secret{}
+	err = r.Get(ctx, types.NamespacedName{Namespace: r.tailscaleNamespace, Name: configSecretName(pr.Name, idx)}, cfgSecret)
+	switch {
+	case apierrors.IsNotFound(err):
+	case err != nil:
+		return nil, fmt.Errorf("failed to get config Secret: %w", err)
+	default:
+		existingCfgSecret = cfgSecret
+	}
+
+	stateSecret := &corev1.Secret{}
+	if err = r.Get(ctx, types.NamespacedName{Namespace: r.tailscaleNamespace, Name: replicaName(pr.Name, idx)}, stateSecret); err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+
+	var createAuthKey bool
+	var cfgAuthKey *string
+	if existingCfgSecret == nil {
+		createAuthKey = true
+	} else {
+		cfgAuthKey = tailscaled.AuthKeyFromConfigSecret(existingCfgSecret)
+	}
+
+	if !createAuthKey {
+		createAuthKey, err = r.shouldReissueAuthKey(ctx, tsClient, pr, idx, stateSecret, cfgAuthKey)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var authKey *string
+	if createAuthKey {
+		key, err := tailscaled.NewAuthKey(ctx, tsClient, r.peerRelayTags(pr))
+		if err != nil {
+			return nil, err
+		}
+		authKey = &key
+	} else {
+		// Retain auth key if the device hasn't authed yet, or if a reissue is
+		// in progress (device_id is stale during reissue).
+		_, reissueRequested := stateSecret.Data[kubetypes.KeyReissueAuthkey]
+		if tailscaled.DeviceIDFromStateSecret(stateSecret) == "" || reissueRequested {
+			authKey = cfgAuthKey
+		}
+	}
+
+	return authKey, nil
+}
+
+// shouldReissueAuthKey returns true if the replica needs a new auth key. It tracks in-flight
+// reissues via authKeyReissuing to avoid duplicate API calls across reconciles.
+func (r *Reconciler) shouldReissueAuthKey(ctx context.Context, tsClient tsclient.Client, pr *tsapi.PeerRelay, idx int32, stateSecret *corev1.Secret, cfgAuthKey *string) (shouldReissue bool, err error) {
+	name := replicaName(pr.Name, idx)
+
+	r.mu.Lock()
+	reissuing := r.authKeyReissuing[name]
+	r.mu.Unlock()
+
+	if reissuing {
+		_, requestStillPresent := stateSecret.Data[kubetypes.KeyReissueAuthkey]
+		if !requestStillPresent {
+			r.mu.Lock()
+			r.authKeyReissuing[name] = false
+			r.mu.Unlock()
+			r.logger.Debugf("auth key reissue completed for %q", name)
+			return false, nil
+		}
+		r.logger.Debugf("auth key already in process of re-issuance for %q, waiting", name)
+		return false, nil
+	}
+
+	defer func() {
+		r.mu.Lock()
+		r.authKeyReissuing[name] = shouldReissue
+		r.mu.Unlock()
+	}()
+
+	brokenAuthkey, ok := stateSecret.Data[kubetypes.KeyReissueAuthkey]
+	if !ok {
+		return false, nil
+	}
+
+	empty := cfgAuthKey == nil || *cfgAuthKey == ""
+	broken := cfgAuthKey != nil && *cfgAuthKey == string(brokenAuthkey)
+
+	// A new key has been written but the replica hasn't picked it up yet.
+	if !empty && !broken {
+		return false, nil
+	}
+
+	lim := r.authKeyRateLimits[pr.Name]
+	if !lim.Allow() {
+		r.logger.Debugf("auth key re-issuance rate limit exceeded, limit: %.2f, burst: %d, tokens: %.2f",
+			lim.Limit(), lim.Burst(), lim.Tokens())
+		return false, fmt.Errorf("auth key re-issuance rate limit exceeded for PeerRelay %q, will retry with backoff", pr.Name)
+	}
+
+	r.logger.Infof("PeerRelay replica %s failing to auth; attempting cleanup and new key", name)
+	if tsID := stateSecret.Data[kubetypes.KeyDeviceID]; len(tsID) > 0 {
+		if err = r.ensureDeviceDeleted(ctx, tsClient, tailcfg.StableNodeID(tsID)); err != nil {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+func (r *Reconciler) ensureDeviceDeleted(ctx context.Context, tsClient tsclient.Client, id tailcfg.StableNodeID) error {
+	r.logger.Debugf("deleting device %s from control", string(id))
+	err := tsClient.Devices().Delete(ctx, string(id))
+	switch {
+	case tailscaleclient.IsNotFound(err):
+		r.logger.Debugf("device %s not found, likely because it has already been deleted from control", string(id))
+	case err != nil:
+		return fmt.Errorf("error deleting device: %w", err)
+	default:
+		r.logger.Debugf("device %s deleted from control", string(id))
+	}
+	return nil
 }

--- a/k8s-operator/reconciler/peerrelay/peerrelay.go
+++ b/k8s-operator/reconciler/peerrelay/peerrelay.go
@@ -17,9 +17,11 @@ import (
 	"net/netip"
 	"reflect"
 	"slices"
+	"sync"
 	"time"
 
 	"go.uber.org/zap"
+	"golang.org/x/time/rate"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -55,6 +57,10 @@ type (
 		clock              tstime.Clock
 
 		tracker *reconciler.ResourceTracker
+
+		mu                sync.Mutex               // protects following
+		authKeyRateLimits map[string]*rate.Limiter // per-PeerRelay rate limiters for auth key re-issuance.
+		authKeyReissuing  map[string]bool
 	}
 
 	// The ReconcilerOptions type contains configuration values for the Reconciler.
@@ -126,6 +132,8 @@ func NewReconciler(options ReconcilerOptions) *Reconciler {
 		logger:             options.Logger.Named(reconcilerName),
 		clock:              clock,
 		tracker:            reconciler.NewResourceTracker(gaugePeerRelayResources),
+		authKeyRateLimits:  make(map[string]*rate.Limiter),
+		authKeyReissuing:   make(map[string]bool),
 	}
 }
 
@@ -218,6 +226,20 @@ func (r *Reconciler) createOrUpdate(ctx context.Context, logger *zap.SugaredLogg
 	if pr.Spec.Replicas != nil {
 		replicas = *pr.Spec.Replicas
 	}
+
+	r.mu.Lock()
+	if _, ok := r.authKeyRateLimits[pr.Name]; !ok {
+		// Allow every replica to have its auth key re-issued quickly the first
+		// time, but with an overall limit of 1 every 30s after a burst.
+		r.authKeyRateLimits[pr.Name] = rate.NewLimiter(rate.Every(30*time.Second), int(replicas))
+	}
+	for i := int32(0); i < replicas; i++ {
+		name := replicaName(pr.Name, i)
+		if _, ok := r.authKeyReissuing[name]; !ok {
+			r.authKeyReissuing[name] = false
+		}
+	}
+	r.mu.Unlock()
 
 	// Belt-and-braces: CEL on the CRD enforces this at admission, but we also validate here to guard against older
 	// clusters without CEL, resources created before the CRD schema landed, or hand-edited status paths. If the user
@@ -396,6 +418,18 @@ func (r *Reconciler) delete(ctx context.Context, logger *zap.SugaredLogger, pr *
 
 	r.tracker.Remove(pr.UID)
 
+	replicas := int32(1)
+	if pr.Spec.Replicas != nil {
+		replicas = *pr.Spec.Replicas
+	}
+
+	r.mu.Lock()
+	delete(r.authKeyRateLimits, pr.Name)
+	for i := int32(0); i < replicas; i++ {
+		delete(r.authKeyReissuing, replicaName(pr.Name, i))
+	}
+	r.mu.Unlock()
+
 	return reconcile.Result{}, nil
 }
 
@@ -430,7 +464,7 @@ func (r *Reconciler) deleteServicesFrom(ctx context.Context, logger *zap.Sugared
 }
 
 func (r *Reconciler) ensureConfigSecret(ctx context.Context, logger *zap.SugaredLogger, pr *tsapi.PeerRelay, idx int32, endpoint *tsapi.PeerRelayEndpoint) error {
-	authKey, err := r.reuseOrMintAuthKey(ctx, pr, idx)
+	authKey, err := r.getAuthKey(ctx, pr, idx)
 	if err != nil {
 		return err
 	}
@@ -446,41 +480,6 @@ func (r *Reconciler) ensureConfigSecret(ctx context.Context, logger *zap.Sugared
 	}
 
 	return nil
-}
-
-func (r *Reconciler) reuseOrMintAuthKey(ctx context.Context, pr *tsapi.PeerRelay, idx int32) (*string, error) {
-	var existing corev1.Secret
-	err := r.Get(ctx, types.NamespacedName{Namespace: r.tailscaleNamespace, Name: configSecretName(pr.Name, idx)}, &existing)
-	switch {
-	case apierrors.IsNotFound(err):
-		key, err := r.mintAuthKey(ctx, pr)
-		if err != nil {
-			return nil, err
-		}
-		return &key, nil
-	case err != nil:
-		return nil, fmt.Errorf("failed to get config Secret: %w", err)
-	}
-
-	if existingKey := tailscaled.AuthKeyFromConfigSecret(&existing); existingKey != nil {
-		return existingKey, nil
-	}
-
-	key, err := r.mintAuthKey(ctx, pr)
-	if err != nil {
-		return nil, err
-	}
-
-	return &key, nil
-}
-
-func (r *Reconciler) mintAuthKey(ctx context.Context, pr *tsapi.PeerRelay) (string, error) {
-	client, err := r.tsClients.For(pr.Spec.Tailnet)
-	if err != nil {
-		return "", fmt.Errorf("failed to resolve Tailscale API client for tailnet %q: %w", pr.Spec.Tailnet, err)
-	}
-
-	return tailscaled.NewAuthKey(ctx, client, r.peerRelayTags(pr))
 }
 
 func (r *Reconciler) ensureStateSecret(ctx context.Context, logger *zap.SugaredLogger, pr *tsapi.PeerRelay, idx int32) error {


### PR DESCRIPTION
PeerRelay replicas got a single-use auth key minted on config Secret creation and never again, so a replica that lost its login (device deleted, state Secret lost, key expiry) could never re-auth despite containerboot writing the reissue_authkey signal.

Port the shouldReissueAuthKey pattern already used by ProxyGroup and Recorder: track in-flight reissues per replica, rate-limit re-issuance per PeerRelay, and delete the stale device before minting a new key.

Note that this is a lot of duplication now on authkey reissuance. I plan on following this PR up with a dedicated `Reissuer` that each reconciler can use, so that the logic is deduplicated.

Updates #20544