### PR TITLE
cmd/tailscale/cli: add "status --routes" to show advertised subnet routes

### DIFF
--- a/cmd/tailscale/cli/status.go
+++ b/cmd/tailscale/cli/status.go
@@ -28,7 +28,7 @@ import (
 
 var statusCmd = &ffcli.Command{
 	Name:       "status",
-	ShortUsage: "tailscale status [--active] [--web] [--json]",
+	ShortUsage: "tailscale status [--active] [--web] [--json] [--routes]",
 	ShortHelp:  "Show state of tailscaled and its connections",
 	LongHelp: strings.TrimSpace(`
 
@@ -56,6 +56,7 @@ https://github.com/tailscale/tailscale/blob/main/ipn/ipnstate/ipnstate.go
 		fs.StringVar(&statusArgs.listen, "listen", "127.0.0.1:8384", "listen address for web mode; use port 0 for automatic")
 		fs.BoolVar(&statusArgs.browser, "browser", true, "open a browser in web mode")
 		fs.BoolVar(&statusArgs.header, "header", false, "show column headers in table format")
+		fs.BoolVar(&statusArgs.routes, "routes", false, "show subnet routes advertised by each node, and only list nodes advertising routes")
 		return fs
 	})(),
 }
@@ -69,6 +70,7 @@ var statusArgs struct {
 	self    bool   // in CLI mode, show status of local machine
 	peers   bool   // in CLI mode, show status of peer machines
 	header  bool   // in CLI mode, show column headers in table format
+	routes  bool   // in CLI mode, show advertised subnet routes, listing only nodes that advertise some
 }
 
 const mullvadTCD = "mullvad.ts.net."
@@ -157,8 +159,13 @@ func runStatus(ctx context.Context, args []string) error {
 	w := tabwriter.NewWriter(Stdout, 0, 0, 2, ' ', 0)
 	f := func(format string, a ...any) { fmt.Fprintf(w, format, a...) }
 	if statusArgs.header {
-		fmt.Fprintln(w, "IP\tHostname\tOwner\tOS\tStatus\t")
-		fmt.Fprintln(w, "--\t--------\t-----\t--\t------\t")
+		if statusArgs.routes {
+			fmt.Fprintln(w, "IP\tHostname\tOwner\tOS\tRoutes")
+			fmt.Fprintln(w, "--\t--------\t-----\t--\t------")
+		} else {
+			fmt.Fprintln(w, "IP\tHostname\tOwner\tOS\tStatus\t")
+			fmt.Fprintln(w, "--\t--------\t-----\t--\t------\t")
+		}
 	}
 
 	printPS := func(ps *ipnstate.PeerStatus) {
@@ -168,6 +175,12 @@ func runStatus(ctx context.Context, args []string) error {
 			ownerLogin(st, ps),
 			ps.OS,
 		)
+		if statusArgs.routes {
+			// No trailing tab: tabwriter pads all but the last cell, and the
+			// routes column is wide enough that padding it looks bad.
+			f("%s\n", strings.Join(advertisedRoutes(ps), " "))
+			return
+		}
 		relay := ps.Relay
 		anyTraffic := ps.TxBytes != 0 || ps.RxBytes != 0
 		var offline string
@@ -211,7 +224,9 @@ func runStatus(ctx context.Context, args []string) error {
 	}
 
 	if statusArgs.self && st.Self != nil {
-		printPS(st.Self)
+		if !statusArgs.routes || len(advertisedRoutes(st.Self)) > 0 {
+			printPS(st.Self)
+		}
 	}
 
 	locBasedExitNode := false
@@ -232,6 +247,9 @@ func runStatus(ctx context.Context, args []string) error {
 		ipnstate.SortPeers(peers)
 		for _, ps := range peers {
 			if statusArgs.active && !ps.Active {
+				continue
+			}
+			if statusArgs.routes && len(advertisedRoutes(ps)) == 0 {
 				continue
 			}
 			printPS(ps)
@@ -311,6 +329,26 @@ func ownerLogin(st *ipnstate.Status, ps *ipnstate.PeerStatus) string {
 		return u.LoginName[:i+1]
 	}
 	return u.LoginName
+}
+
+// advertisedRoutes returns the subnet routes ps advertises: its AllowedIPs
+// minus the single-address prefixes covering its own Tailscale IPs.
+func advertisedRoutes(ps *ipnstate.PeerStatus) []string {
+	if ps.AllowedIPs == nil {
+		return nil
+	}
+	self := make(map[netip.Addr]bool, len(ps.TailscaleIPs))
+	for _, ip := range ps.TailscaleIPs {
+		self[ip] = true
+	}
+	var routes []string
+	for _, p := range ps.AllowedIPs.All() {
+		if p.IsSingleIP() && self[p.Addr()] {
+			continue
+		}
+		routes = append(routes, p.String())
+	}
+	return routes
 }
 
 func firstIPString(v []netip.Addr) string {

--- a/cmd/tailscale/cli/status_test.go
+++ b/cmd/tailscale/cli/status_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package cli
+
+import (
+	"net/netip"
+	"slices"
+	"testing"
+
+	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/types/views"
+)
+
+func TestAdvertisedRoutes(t *testing.T) {
+	prefixes := func(ss ...string) *views.Slice[netip.Prefix] {
+		ps := make([]netip.Prefix, 0, len(ss))
+		for _, s := range ss {
+			ps = append(ps, netip.MustParsePrefix(s))
+		}
+		v := views.SliceOf(ps)
+		return &v
+	}
+	addrs := func(ss ...string) []netip.Addr {
+		as := make([]netip.Addr, 0, len(ss))
+		for _, s := range ss {
+			as = append(as, netip.MustParseAddr(s))
+		}
+		return as
+	}
+
+	tests := []struct {
+		name string
+		ps   *ipnstate.PeerStatus
+		want []string
+	}{
+		{
+			name: "no AllowedIPs",
+			ps:   &ipnstate.PeerStatus{TailscaleIPs: addrs("100.64.0.1")},
+			want: nil,
+		},
+		{
+			name: "only self IPs",
+			ps: &ipnstate.PeerStatus{
+				TailscaleIPs: addrs("100.64.0.1", "fd7a:115c:a1e0::1"),
+				AllowedIPs:   prefixes("100.64.0.1/32", "fd7a:115c:a1e0::1/128"),
+			},
+			want: nil,
+		},
+		{
+			name: "subnet router",
+			ps: &ipnstate.PeerStatus{
+				TailscaleIPs: addrs("100.64.0.1", "fd7a:115c:a1e0::1"),
+				AllowedIPs:   prefixes("100.64.0.1/32", "fd7a:115c:a1e0::1/128", "192.0.2.0/24"),
+			},
+			want: []string{"192.0.2.0/24"},
+		},
+		{
+			name: "exit node",
+			ps: &ipnstate.PeerStatus{
+				TailscaleIPs: addrs("100.64.0.1"),
+				AllowedIPs:   prefixes("100.64.0.1/32", "0.0.0.0/0", "::/0"),
+			},
+			want: []string{"0.0.0.0/0", "::/0"},
+		},
+		{
+			name: "other node's single IP is a route, not self",
+			ps: &ipnstate.PeerStatus{
+				TailscaleIPs: addrs("100.64.0.1"),
+				AllowedIPs:   prefixes("100.64.0.1/32", "100.64.0.2/32"),
+			},
+			want: []string{"100.64.0.2/32"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := advertisedRoutes(tt.ps); !slices.Equal(got, tt.want) {
+				t.Errorf("advertisedRoutes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Finding which nodes in a tailnet advertise subnet routes, or act as exit nodes, currently means reaching for `--json` and a JSON processor. The incantation I had been keeping in my shell history:

    tailscale status --json | jq -r '.Peer[] | select(.AllowedIPs | length > 2) | "\(.HostName): \(.AllowedIPs)"'

That works, but it needs jq, it needs a reader who knows that "more than two AllowedIPs" is a proxy for "advertises something", and the output is raw JSON arrays rather than the familiar status table.

This adds a `--routes` flag to `tailscale status`. It reuses the existing status table, replacing the Status column with a Routes column and listing only the nodes that advertise at least one route:

    $ tailscale status --routes --header
    IP              Hostname          Owner           OS       Routes
    --              --------          -----           --       ------
    100.64.0.10     branch-router-1   tagged-devices  freebsd  192.0.2.0/24
    100.64.0.11     branch-router-2   tagged-devices  linux    198.51.100.0/24 203.0.113.0/24
    100.64.0.12     exit-node-1       tagged-devices  linux    0.0.0.0/0 ::/0
    100.64.0.13     app-host-proxy    tagged-devices  linux    100.64.0.20/32 fd7a:115c:a1e0::14/128
    100.64.0.14     lab-router        tagged-devices  linux    192.0.2.128/25

A node's advertised routes are computed as its `AllowedIPs` minus the single-address prefixes covering its own Tailscale IPs. Subtracting by address rather than by count is deliberate: a node can advertise another node's /32, as `app-host-proxy` does above, and that is a real route worth showing. A `len(AllowedIPs) > 2` heuristic would also mis-handle nodes with only one Tailscale address.

The flag composes with the existing ones: `--header` adds column headers, and `--peers=false` / `--self=false` narrow the set of nodes as usual. `--json` output is unchanged, since it already includes `AllowedIPs`.

## Testing

- New table test `TestAdvertisedRoutes` covering the subnet-router, exit-node, self-addresses-only, and other-node-single-IP cases.
- Verified by hand against a ~50 node tailnet with a mix of FreeBSD and Linux subnet routers and exit nodes; output matches the jq pipeline above.
- `go build ./cmd/tailscale/...`, `go vet ./cmd/tailscale/cli/`, `go test -race ./cmd/tailscale/cli/`, `gofmt -l`, and `make depaware` all pass. No new imports, so `depaware.txt` is unchanged.

## Open question

Nodes advertising many routes overflow one terminal line; one node on my tailnet advertises 14 prefixes. This keeps them space-joined on a single row. Happy to switch to one route per line, or to truncate with a count, if reviewers prefer.