### PR TITLE
util/zstdframe, util/testenv: don't pool coders within synctest bubbles

### DIFF
--- a/util/testenv/synctest.go
+++ b/util/testenv/synctest.go
@@ -1,0 +1,48 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package testenv
+
+import (
+	"bytes"
+	"flag"
+	"runtime"
+	"sync"
+)
+
+// stackBufPool holds buffers for [InSynctestBubble]'s runtime.Stack calls,
+// which would otherwise allocate on every call: the compiler cannot prove
+// that a stack-allocated buffer does not escape into runtime.Stack. Plain
+// byte arrays, unlike the zstd coders that motivated InSynctestBubble, are
+// safe to share across synctest bubble boundaries.
+var stackBufPool = sync.Pool{New: func() any { return new([128]byte) }}
+
+// InSynctestBubble reports whether the current goroutine is running within a
+// testing/synctest bubble.
+//
+// As of Go 1.26 there is no public API to query bubble membership
+// (internal/synctest.IsInBubble is runtime-internal), so this instead
+// looks for the "synctest bubble N" annotation that the runtime renders
+// in the current goroutine's [runtime.Stack] header. If a future Go
+// release changes that annotation, this reports false; tests that depend
+// on it for correctness (such as tailscale.com/util/zstdframe's) should
+// exercise the misdetection failure mode so the breakage is loud.
+func InSynctestBubble() bool {
+	// Bubbles only exist within tests, so skip the (relatively) expensive
+	// stack header check in non-test binaries. This deliberately does not
+	// use InTest: InSynctestBubble may be reached from package init
+	// functions (before the testing package has registered its flags),
+	// and InTest would permanently latch a false result there. Bubbles
+	// cannot exist during init, so returning false then is correct.
+	if flag.Lookup("test.v") == nil {
+		return false
+	}
+	// The current goroutine's header looks like:
+	//	goroutine 9 [running, synctest bubble 1]:
+	// A 128-byte buffer always fits the header, and runtime.Stack
+	// truncates the rest.
+	buf := stackBufPool.Get().(*[128]byte)
+	defer stackBufPool.Put(buf)
+	n := runtime.Stack(buf[:], false)
+	return bytes.Contains(buf[:n], []byte(" synctest bubble "))
+}

--- a/util/testenv/synctest_test.go
+++ b/util/testenv/synctest_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package testenv_test
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"tailscale.com/util/testenv"
+)
+
+func TestInSynctestBubble(t *testing.T) {
+	if testenv.InSynctestBubble() {
+		t.Error("InSynctestBubble = true outside a bubble")
+	}
+	synctest.Test(t, func(t *testing.T) {
+		if !testenv.InSynctestBubble() {
+			t.Error("InSynctestBubble = false inside a bubble")
+		}
+		// Detection must not depend on the bubble's fake clock still
+		// being near its 2000-01-01 start.
+		time.Sleep(100 * 365 * 24 * time.Hour)
+		if !testenv.InSynctestBubble() {
+			t.Error("InSynctestBubble = false inside a bubble after advancing the fake clock")
+		}
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			if !testenv.InSynctestBubble() {
+				t.Error("InSynctestBubble = false in a goroutine started inside a bubble")
+			}
+		}()
+		<-done
+	})
+	if testenv.InSynctestBubble() {
+		t.Error("InSynctestBubble = true after bubble exited")
+	}
+}
+
+func BenchmarkInSynctestBubble(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		if testenv.InSynctestBubble() {
+			b.Fatal("unexpectedly in bubble")
+		}
+	}
+}

--- a/util/zstdframe/options.go
+++ b/util/zstdframe/options.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/klauspost/compress/zstd"
 	"tailscale.com/util/must"
+	"tailscale.com/util/testenv"
 )
 
 // Option is an option that can be passed to [AppendEncode] or [AppendDecode].
@@ -104,6 +105,17 @@ func (lowMemory) isOption() {}
 // By default, more memory used for better speed.
 func LowMemory(low bool) Option { return lowMemory(low) }
 
+// poolCoders reports whether encoders and decoders should be pooled for
+// reuse across calls.
+//
+// Pooling is disabled within testing/synctest bubbles. The zstd Encoder and
+// Decoder types use channels internally, and the Go runtime kills the
+// process when a channel created within a bubble is used from outside that
+// bubble. A process-wide pool shared between bubbled and non-bubbled
+// goroutines does exactly that, so bubbled goroutines instead construct a
+// fresh coder per call and let the GC reclaim it.
+func poolCoders() bool { return !testenv.InSynctestBubble() }
+
 var encoderPools sync.Map // map[encoderOptions]*sync.Pool -> *zstd.Encoder
 
 type encoderOptions struct {
@@ -133,12 +145,16 @@ func getEncoder(opts ...Option) encoder {
 		}
 	}
 
-	vpool, ok := encoderPools.Load(eopts)
-	if !ok {
-		vpool, _ = encoderPools.LoadOrStore(eopts, new(sync.Pool))
+	var pool *sync.Pool
+	var enc *zstd.Encoder
+	if poolCoders() {
+		vpool, ok := encoderPools.Load(eopts)
+		if !ok {
+			vpool, _ = encoderPools.LoadOrStore(eopts, new(sync.Pool))
+		}
+		pool = vpool.(*sync.Pool)
+		enc, _ = pool.Get().(*zstd.Encoder)
 	}
-	pool := vpool.(*sync.Pool)
-	enc, _ := pool.Get().(*zstd.Encoder)
 	if enc == nil {
 		var noopts int
 		zopts := [...]zstd.EOption{
@@ -167,7 +183,11 @@ func getEncoder(opts ...Option) encoder {
 	return encoder{pool, enc}
 }
 
-func putEncoder(e encoder) { e.pool.Put(e.Encoder) }
+func putEncoder(e encoder) {
+	if e.pool != nil {
+		e.pool.Put(e.Encoder)
+	}
+}
 
 var decoderPools sync.Map // map[decoderOptions]*sync.Pool -> *zstd.Decoder
 
@@ -205,12 +225,16 @@ func getDecoder(opts ...Option) decoder {
 		}
 	}
 
-	vpool, ok := decoderPools.Load(dopts)
-	if !ok {
-		vpool, _ = decoderPools.LoadOrStore(dopts, new(sync.Pool))
+	var pool *sync.Pool
+	var dec *zstd.Decoder
+	if poolCoders() {
+		vpool, ok := decoderPools.Load(dopts)
+		if !ok {
+			vpool, _ = decoderPools.LoadOrStore(dopts, new(sync.Pool))
+		}
+		pool = vpool.(*sync.Pool)
+		dec, _ = pool.Get().(*zstd.Decoder)
 	}
-	pool := vpool.(*sync.Pool)
-	dec, _ := pool.Get().(*zstd.Decoder)
 	if dec == nil {
 		var noopts int
 		zopts := [...]zstd.DOption{
@@ -231,7 +255,11 @@ func getDecoder(opts ...Option) decoder {
 	return decoder{pool, dec, maxSize}
 }
 
-func putDecoder(d decoder) { d.pool.Put(d.Decoder) }
+func putDecoder(d decoder) {
+	if d.pool != nil {
+		d.pool.Put(d.Decoder)
+	}
+}
 
 func (d decoder) DecodeAll(src, dst []byte) ([]byte, error) {
 	// We only configure DecodeAll to enforce MaxDecodedSize by powers-of-two.

--- a/util/zstdframe/synctest_test.go
+++ b/util/zstdframe/synctest_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package zstdframe
+
+import (
+	"bytes"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+// TestSynctestBubbleIsolation verifies that coders used within a
+// testing/synctest bubble do not crash the process when zstdframe is
+// subsequently used outside the bubble (or in another bubble).
+//
+// The zstd Encoder and Decoder types use channels internally, so a pooled
+// coder that was created within a synctest bubble must never be reused
+// outside of it: the runtime kills the process with "fatal error: receive
+// on synctest channel from outside bubble".
+func TestSynctestBubbleIsolation(t *testing.T) {
+	src := []byte("hello, hello, hello, world, world, world")
+
+	// Use the coder pools within a bubble several times to make it very
+	// likely that a bubble-created coder would land in the package-level
+	// pools if pooling were (incorrectly) enabled here.
+	var frame []byte
+	synctest.Test(t, func(t *testing.T) {
+		for range 10 {
+			frame = AppendEncode(nil, src)
+			out, err := AppendDecode(nil, frame)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(out, src) {
+				t.Fatalf("roundtrip inside bubble = %q, want %q", out, src)
+			}
+		}
+		// Bubble detection must not depend on the fake clock still being
+		// near its 2000-01-01 start, so advance it past the real
+		// process start time and use the coders again.
+		time.Sleep(100 * 365 * 24 * time.Hour)
+		frame = AppendEncode(nil, src)
+		if _, err := AppendDecode(nil, frame); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	// Prior to pooling being disabled in tests, this crashed the process
+	// by reusing a pooled coder whose channels were created in the
+	// now-exited bubble above.
+	for range 10 {
+		got := AppendEncode(nil, src)
+		out, err := AppendDecode(nil, got)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(out, src) {
+			t.Fatalf("roundtrip outside bubble = %q, want %q", out, src)
+		}
+	}
+}


### PR DESCRIPTION
The zstd Encoder and Decoder types use channels internally, created
when the coder is constructed. A coder constructed by a goroutine
inside a testing/synctest bubble therefore owns bubble-associated
channels, and if it lands in zstdframe's process-wide pools and is
later reused outside that bubble, the Go runtime kills the process:

    fatal error: receive on synctest channel from outside bubble

This has been crashing test binaries that mix synctest-based tests
with regular tests exercising zstd compression in parallel, taking
out every other test in the package with it.

Add testenv.InSynctestBubble and use it in zstdframe to construct a
fresh coder per call within a bubble instead of using the pools.
Pooling behavior outside of bubbles (including in benchmarks) is
unchanged.

As of Go 1.26 there is no public API to query bubble membership, so
InSynctestBubble looks for the "synctest bubble N" annotation that
the runtime renders in the current goroutine's runtime.Stack header.
That annotation is not covered by the Go compatibility promise, so
tests fail loudly (in util/testenv directly, and in util/zstdframe by
reintroducing the pooled-coder crash) if a future Go release changes
it. The check costs ~2us and runs only in test binaries, detected by
an uncached flag.Lookup("test.v") rather than testenv.InTest: this
path is reachable from package init functions (before testing has
registered its flags), where InTest would permanently latch a false
result into its cache, breaking later InTest and AssertInTest calls.

Fixes tailscale/corp#45861
