### PR TITLE
util/dnsname: add utility function ValidLabelLike

### DIFF
--- a/util/dnsname/dnsname.go
+++ b/util/dnsname/dnsname.go
@@ -109,11 +109,19 @@ func (f FQDN) Parent() FQDN {
 // ValidLabel reports whether label is a valid DNS label. All errors are
 // [vizerror.Error].
 func ValidLabel(label string) error {
+	return ValidLabelLike(label, maxLabelLength)
+}
+
+// ValidLabelLike reports whether label contains DNS-valid characters
+// only, adheres to a given maximum length, and starts and ends with
+// a letter or number. For strict DNS-validity use [ValidLabel].
+// All errors are [vizerror.Error].
+func ValidLabelLike(label string, maxLen int) error {
 	if len(label) == 0 {
 		return vizerror.New("empty DNS label")
 	}
-	if len(label) > maxLabelLength {
-		return vizerror.Errorf("%q is too long, max length is %d bytes", label, maxLabelLength)
+	if len(label) > maxLen {
+		return vizerror.Errorf("%q is too long, max length is %d bytes", label, maxLen)
 	}
 	if !isalphanum(label[0]) {
 		return vizerror.Errorf("%q is not a valid DNS label: must start with a letter or number", label)
@@ -121,7 +129,8 @@ func ValidLabel(label string) error {
 	if !isalphanum(label[len(label)-1]) {
 		return vizerror.Errorf("%q is not a valid DNS label: must end with a letter or number", label)
 	}
-	if len(label) < 2 {
+	if len(label) <= 2 {
+		// Return early because we've already checked start and end characters (the only 2) are alphanumeric.
 		return nil
 	}
 	for i := 1; i < len(label)-1; i++ {

--- a/util/dnsname/dnsname_test.go
+++ b/util/dnsname/dnsname_test.go
@@ -245,6 +245,56 @@ func TestTrimSuffix(t *testing.T) {
 	}
 }
 
+func TestValidLabel(t *testing.T) {
+	tests := []struct {
+		label   string
+		wantErr string
+	}{
+		{"", "empty DNS label"},
+		{"example", ""},
+		{" example", `must start with a letter or number`},
+		{"example ", `must end with a letter or number`},
+		{strings.Repeat("a", 63), ""},
+		{strings.Repeat("a", 64), `is too long, max length is 63 bytes`},
+		{"what🤦xx", "contains invalid character"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.label, func(t *testing.T) {
+			err := ValidLabel(test.label)
+			if (err == nil) != (test.wantErr == "") || (err != nil && !strings.Contains(err.Error(), test.wantErr)) {
+				t.Fatalf("ValidLabel(%s)=%v; expected %v", test.label, err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidLabelLike(t *testing.T) {
+	tests := []struct {
+		labelLike string
+		maxLength int
+		wantErr   string
+	}{
+		{"", 63, "empty DNS label"},
+		{"example", 63, ""},
+		{" example", 63, `must start with a letter or number`},
+		{"example ", 63, `must end with a letter or number`},
+		{strings.Repeat("a", 63), 63, ""},
+		{strings.Repeat("a", 64), 63, `is too long, max length is 63 bytes`},
+		{strings.Repeat("a", 65), 64, `is too long, max length is 64 bytes`},
+		{"what🤦xx", 63, "contains invalid character"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.labelLike, func(t *testing.T) {
+			err := ValidLabelLike(test.labelLike, test.maxLength)
+			if (err == nil) != (test.wantErr == "") || (err != nil && !strings.Contains(err.Error(), test.wantErr)) {
+				t.Fatalf("ValidLabelLike(%s)=%v; expected %v", test.labelLike, err, test.wantErr)
+			}
+		})
+	}
+}
+
 func TestValidHostname(t *testing.T) {
 	tests := []struct {
 		hostname string


### PR DESCRIPTION
Adds utility function `ValidLabelLike` which checks whether a string contains only dns-label-valid characters, adheres to a max length, and starts and ends with alphanumerics. This is useful when you want to enforce lengths separately from strict DNS-label validity. 

Adds unit tests for the existing `ValidLabel` and new `ValidLabelLike`

Updates tailscale/corp#45901