### PR TITLE
tool/apidiff: check stable package compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,30 @@ jobs:
           key: ${{ steps.hash.outputs.key }}
           enableCrossOsArchive: true
 
+  apidiff:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    needs: gomod-cache
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: src
+      - name: Checkout base
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+      - name: Restore Go module cache
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: gomodcache
+          key: ${{ needs.gomod-cache.outputs.cache-key }}
+          enableCrossOsArchive: true
+      - name: Check stable APIs
+        working-directory: src
+        run: PATH="$PWD/tool:$PATH" ./tool/go run ./tool/apidiff -base ../base
+
   race-root-integration:
     runs-on: ubuntu-24.04
     needs: gomod-cache

--- a/cmd/tailscale/jsonoutput/jsonoutput.go
+++ b/cmd/tailscale/jsonoutput/jsonoutput.go
@@ -140,6 +140,10 @@ import (
 	"strings"
 )
 
+// packageAPIIsStable marks this package for compatibility checks by tool/apidiff.
+//lint:ignore U1000 read by tool/apidiff
+const packageAPIIsStable = true
+
 var _ flag.Value = &SchemaVersion{}
 
 // SchemaVersion implements the [flag.Value] interface,

--- a/cmd/tailscale/tslockjsonv1/doc.go
+++ b/cmd/tailscale/tslockjsonv1/doc.go
@@ -9,3 +9,7 @@
 //   - [LogResponse] will unmarshal the output of "tailscale lock log --json=1"
 //   - [StatusResponse] will unmarshal the output of "tailscale lock status --json=1".
 package tslockjsonv1
+
+// packageAPIIsStable marks this package for compatibility checks by tool/apidiff.
+//lint:ignore U1000 read by tool/apidiff
+const packageAPIIsStable = true

--- a/tool/apidiff/apidiff.go
+++ b/tool/apidiff/apidiff.go
@@ -1,0 +1,182 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+// apidiff checks packages marked with packageAPIIsStable for incompatible API
+// changes relative to another checkout of this module.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"log"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"golang.org/x/exp/apidiff"
+	"golang.org/x/tools/go/packages"
+)
+
+const stableAPIMarker = "packageAPIIsStable"
+
+var baseDir = flag.String("base", "", "path to the base checkout to compare against")
+
+func main() {
+	flag.Parse()
+	if *baseDir == "" {
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	currentDir, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	incompatible, err := checkCompatible(*baseDir, currentDir)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if len(incompatible) == 0 {
+		return
+	}
+
+	fmt.Fprintln(os.Stderr, "incompatible stable API changes:")
+	for _, change := range incompatible {
+		fmt.Fprintf(os.Stderr, "  - %s\n", change)
+	}
+	os.Exit(1)
+}
+
+type packageTree struct {
+	all    map[string]bool
+	stable map[string]bool
+}
+
+func checkCompatible(oldDir, newDir string) ([]string, error) {
+	oldTree, err := discoverPackages(oldDir)
+	if err != nil {
+		return nil, fmt.Errorf("discover base packages: %w", err)
+	}
+	newTree, err := discoverPackages(newDir)
+	if err != nil {
+		return nil, fmt.Errorf("discover current packages: %w", err)
+	}
+
+	var incompatible []string
+	for pkgPath := range oldTree.stable {
+		switch {
+		case !newTree.all[pkgPath]:
+			incompatible = append(incompatible, fmt.Sprintf("removed package %s", pkgPath))
+		case !newTree.stable[pkgPath]:
+			incompatible = append(incompatible,
+				fmt.Sprintf("%s no longer declares %s", pkgPath, stableAPIMarker))
+		}
+	}
+
+	for pkgPath := range newTree.stable {
+		if !oldTree.all[pkgPath] {
+			continue // A new package cannot break the previous API.
+		}
+		oldPkg, err := loadPackage(oldDir, pkgPath)
+		if err != nil {
+			return nil, fmt.Errorf("load base package %s: %w", pkgPath, err)
+		}
+		newPkg, err := loadPackage(newDir, pkgPath)
+		if err != nil {
+			return nil, fmt.Errorf("load current package %s: %w", pkgPath, err)
+		}
+		for _, change := range apidiff.Changes(oldPkg.Types, newPkg.Types).Changes {
+			if !change.Compatible {
+				incompatible = append(incompatible, pkgPath+": "+change.Message)
+			}
+		}
+	}
+
+	slices.Sort(incompatible)
+	return incompatible, nil
+}
+
+func discoverPackages(dir string) (packageTree, error) {
+	dir, err := filepath.Abs(dir)
+	if err != nil {
+		return packageTree{}, err
+	}
+	pkgs, err := packages.Load(&packages.Config{
+		Dir:  dir,
+		Mode: packages.NeedName | packages.NeedCompiledGoFiles,
+	}, "./...")
+	if err != nil {
+		return packageTree{}, err
+	}
+	if n := packages.PrintErrors(pkgs); n > 0 {
+		return packageTree{}, fmt.Errorf("%d package loading errors", n)
+	}
+
+	tree := packageTree{
+		all:    make(map[string]bool),
+		stable: make(map[string]bool),
+	}
+	for _, pkg := range pkgs {
+		tree.all[pkg.PkgPath] = true
+		marked, err := hasStableAPIMarker(pkg.CompiledGoFiles)
+		if err != nil {
+			return packageTree{}, fmt.Errorf("%s: %w", pkg.PkgPath, err)
+		}
+		if marked {
+			tree.stable[pkg.PkgPath] = true
+		}
+	}
+	return tree, nil
+}
+
+func hasStableAPIMarker(files []string) (bool, error) {
+	for _, filename := range files {
+		f, err := parser.ParseFile(token.NewFileSet(), filename, nil, parser.SkipObjectResolution)
+		if err != nil {
+			return false, err
+		}
+		for _, decl := range f.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				values := spec.(*ast.ValueSpec)
+				for _, name := range values.Names {
+					if name.Name == stableAPIMarker {
+						return true, nil
+					}
+				}
+			}
+		}
+	}
+	return false, nil
+}
+
+func loadPackage(dir, pkgPath string) (*packages.Package, error) {
+	pkgs, err := packages.Load(&packages.Config{
+		Dir: dir,
+		Mode: packages.NeedName |
+			packages.NeedImports |
+			packages.NeedDeps |
+			packages.NeedTypes |
+			packages.NeedTypesSizes,
+	}, pkgPath)
+	if err != nil {
+		return nil, err
+	}
+	if n := packages.PrintErrors(pkgs); n > 0 {
+		return nil, fmt.Errorf("%d package loading errors", n)
+	}
+	if len(pkgs) != 1 {
+		return nil, fmt.Errorf("loaded %d packages, want 1", len(pkgs))
+	}
+	if strings.TrimSpace(pkgs[0].PkgPath) == "" || pkgs[0].Types == nil {
+		return nil, fmt.Errorf("package has incomplete type information")
+	}
+	return pkgs[0], nil
+}

--- a/tool/apidiff/apidiff_test.go
+++ b/tool/apidiff/apidiff_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package main
+
+import (
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestCheckCompatible(t *testing.T) {
+	tests := []struct {
+		name string
+		new  string
+		want []string
+	}{
+		{
+			name: "compatible",
+			new:  "compatible",
+		},
+		{
+			name: "removed field",
+			new:  "breaking",
+			want: []string{"example.com/apidifftest/api: Response.Name: removed"},
+		},
+		{
+			name: "removed marker",
+			new:  "unmarked",
+			want: []string{"example.com/apidifftest/api no longer declares packageAPIIsStable"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := checkCompatible(
+				filepath.Join("testdata", "base"),
+				filepath.Join("testdata", tt.new),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("checkCompatible() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/tool/apidiff/testdata/base/api/api.go
+++ b/tool/apidiff/testdata/base/api/api.go
@@ -1,0 +1,10 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package api
+
+const packageAPIIsStable = true
+
+type Response struct {
+	Name string
+}

--- a/tool/apidiff/testdata/base/go.mod
+++ b/tool/apidiff/testdata/base/go.mod
@@ -1,0 +1,3 @@
+module example.com/apidifftest
+
+go 1.26

--- a/tool/apidiff/testdata/breaking/api/api.go
+++ b/tool/apidiff/testdata/breaking/api/api.go
@@ -1,0 +1,8 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package api
+
+const packageAPIIsStable = true
+
+type Response struct{}

--- a/tool/apidiff/testdata/breaking/go.mod
+++ b/tool/apidiff/testdata/breaking/go.mod
@@ -1,0 +1,3 @@
+module example.com/apidifftest
+
+go 1.26

--- a/tool/apidiff/testdata/compatible/api/api.go
+++ b/tool/apidiff/testdata/compatible/api/api.go
@@ -1,0 +1,11 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package api
+
+const packageAPIIsStable = true
+
+type Response struct {
+	Name  string
+	Count int
+}

--- a/tool/apidiff/testdata/compatible/go.mod
+++ b/tool/apidiff/testdata/compatible/go.mod
@@ -1,0 +1,3 @@
+module example.com/apidifftest
+
+go 1.26

--- a/tool/apidiff/testdata/unmarked/api/api.go
+++ b/tool/apidiff/testdata/unmarked/api/api.go
@@ -1,0 +1,8 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package api
+
+type Response struct {
+	Name string
+}

--- a/tool/apidiff/testdata/unmarked/go.mod
+++ b/tool/apidiff/testdata/unmarked/go.mod
@@ -1,0 +1,3 @@
+module example.com/apidifftest
+
+go 1.26


### PR DESCRIPTION
## Problem

The versioned CLI JSON packages promise importable, stable public types, but CI does not currently detect accidental incompatible Go API changes.

## Solution

- Add an unexported `packageAPIIsStable` sentinel to `jsonoutput` and `tslockjsonv1`.
- Add a Go checker that discovers marked packages in both the base and current trees and compares them with `golang.org/x/exp/apidiff`.
- Treat removing a marked package or removing its marker as incompatible, preventing the check from being bypassed accidentally.
- Run the checker in a pull-request-only CI job against the exact base SHA.
- Cover compatible additions, field removal, and marker removal with regression fixtures.

## Testing

- `PATH="$PWD/tool:$PATH" ./tool/go test ./tool/apidiff ./cmd/tailscale/jsonoutput ./cmd/tailscale/tslockjsonv1`
- `PATH="$PWD/tool:$PATH" ./tool/go vet ./tool/apidiff ./cmd/tailscale/jsonoutput ./cmd/tailscale/tslockjsonv1`
- `PATH="$PWD/tool:$PATH" ./tool/go run github.com/golangci/golangci-lint/cmd/golangci-lint run ./tool/apidiff/...`
- `PATH="$PWD/tool:$PATH" ./tool/go run honnef.co/go/tools/cmd/staticcheck -- ./tool/apidiff ./cmd/tailscale/jsonoutput ./cmd/tailscale/tslockjsonv1`
- `PATH="$PWD/tool:$PATH" ./tool/go test -v -run=TestLicenseHeaders`
- Ran the checker against a clean upstream worktree; it passed.
- Ran the executable against the breaking fixture; it exited 1 and reported `Response.Name: removed`.

Fixes #19985

AI assistance: Codex assisted with implementation and testing.
