### PR TITLE
go.mod: bump staticcheck in prep for Go 1.27, address fallout

### DIFF
--- a/cmd/gitops-pusher/gitops-pusher.go
+++ b/cmd/gitops-pusher/gitops-pusher.go
@@ -83,13 +83,11 @@ func apply(cache *Cache, tailnet string) func(context.Context, []string) error {
 		}
 
 		if cache.PrevETag != controlEtag {
-			if err := modifiedExternallyError(); err != nil {
-				if *failOnManualEdits {
-					return err
-				} else {
-					fmt.Println(err)
-				}
+			err := modifiedExternallyError()
+			if *failOnManualEdits {
+				return err
 			}
+			fmt.Println(err)
 		}
 
 		if err := applyNewACL(ctx, tailnet, *policyFname, controlEtag); err != nil {
@@ -129,13 +127,11 @@ func test(cache *Cache, tailnet string) func(context.Context, []string) error {
 		}
 
 		if cache.PrevETag != controlEtag {
-			if err := modifiedExternallyError(); err != nil {
-				if *failOnManualEdits {
-					return err
-				} else {
-					fmt.Println(err)
-				}
+			err := modifiedExternallyError()
+			if *failOnManualEdits {
+				return err
 			}
+			fmt.Println(err)
 		}
 
 		if err := testNewACLs(ctx, tailnet, *policyFname); err != nil {

--- a/cmd/k8s-proxy/k8s-proxy.go
+++ b/cmd/k8s-proxy/k8s-proxy.go
@@ -312,7 +312,7 @@ func run(logger *zap.SugaredLogger) error {
 			hz := healthz.RegisterHealthHandlers(mux, v4, v6, logger.Infof)
 			group.Go(func() error {
 				err := hz.MonitorHealth(ctx, lc)
-				if err == nil || errors.Is(err, context.Canceled) {
+				if errors.Is(err, context.Canceled) {
 					return nil
 				}
 				return err

--- a/flake.nix
+++ b/flake.nix
@@ -173,4 +173,4 @@
     });
   };
 }
-# nix-direnv cache busting line: sha256-SeMc9PQ3acMyeFDVQr/lretHtGrBJxhM4sgBg2l4t1w=
+# nix-direnv cache busting line: sha256-UtF02Eci8QMxcWnBZLWH2BB0StvjK5xuLYxTiTLnkuM=

--- a/flakehashes.json
+++ b/flakehashes.json
@@ -4,7 +4,7 @@
     "sri": "sha256-TwIaPmGVHO9ZwdaO/jDStgWGQtKa4smS3er1i5aTNTw="
   },
   "vendor": {
-    "goModSum": "sha256-TaLLNRjwO2f7afsQ9Ao3/YnK3R6//ft+xHRNHoNeaKI=",
-    "sri": "sha256-SeMc9PQ3acMyeFDVQr/lretHtGrBJxhM4sgBg2l4t1w="
+    "goModSum": "sha256-3nkxkCXpFxJcZlTRk6JvopImrYnb/qvWhhmzjUI7m7o=",
+    "sri": "sha256-UtF02Eci8QMxcWnBZLWH2BB0StvjK5xuLYxTiTLnkuM="
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -139,7 +139,7 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gvisor.dev/gvisor v0.0.0-20260224225140-573d5e7127a8
 	helm.sh/helm/v3 v3.19.0
-	honnef.co/go/tools v0.7.0
+	honnef.co/go/tools v0.8.0-rc.1
 	k8s.io/api v0.34.0
 	k8s.io/apimachinery v0.34.0
 	k8s.io/apiserver v0.34.0

--- a/go.sum
+++ b/go.sum
@@ -1803,8 +1803,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.7.0 h1:w6WUp1VbkqPEgLz4rkBzH/CSU6HkoqNLp6GstyTx3lU=
-honnef.co/go/tools v0.7.0/go.mod h1:pm29oPxeP3P82ISxZDgIYeOaf9ta6Pi0EWvCFoLG2vc=
+honnef.co/go/tools v0.8.0-rc.1 h1:wqMm2kjcEXMOr+6yau+pdKqJKe6l2N1aKPkpini+Kzk=
+honnef.co/go/tools v0.8.0-rc.1/go.mod h1:XA+OnlRA9EDh/ukGvXMNSZNKGwFQJ+5dER0ioUkOxks=
 howett.net/plist v1.0.0 h1:7CrbWYbPPO/PyNy38b2EB/+gYbjCe2DXBxgtOOZbSQM=
 howett.net/plist v1.0.0/go.mod h1:lqaXoTrLY4hg8tnEzNru53gicrbv7rrk+2xJA/7hw9g=
 k8s.io/api v0.34.0 h1:L+JtP2wDbEYPUeNGbeSa/5GwFtIA662EmT2YSLOkAVE=

--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -221,14 +221,13 @@ func (s *localListener) Run() {
 		s.closeListener.Store(ln.Close)
 
 		s.logf("listening on %v", s.ap)
+		// handleListenersAccept always returns a non-nil error.
 		err = s.handleListenersAccept(ln)
 		if s.ctx.Err() != nil {
 			// context canceled, we're done
 			return
 		}
-		if err != nil {
-			s.logf("localListener accept error, retrying: %v", err)
-		}
+		s.logf("localListener accept error, retrying: %v", err)
 	}
 }
 

--- a/shell.nix
+++ b/shell.nix
@@ -16,4 +16,4 @@
 ) {
   src =  ./.;
 }).shellNix
-# nix-direnv cache busting line: sha256-SeMc9PQ3acMyeFDVQr/lretHtGrBJxhM4sgBg2l4t1w=
+# nix-direnv cache busting line: sha256-UtF02Eci8QMxcWnBZLWH2BB0StvjK5xuLYxTiTLnkuM=

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -2,6 +2,14 @@
 checks = [
 	"SA*", "-SA1019", "-SA2001", "-SA9003", # SA* are mostly legit code errors
 
+	# SA4023 (comparison always/never true) misfires on cross-platform
+	# code: per-GOOS stub functions that always return an error on the
+	# GOOS being analyzed make correct nil checks look constant. And
+	# lint:ignore directives can't help, as they'd be flagged as
+	# unmatched on the other GOOSes. Disabled 2026-07-31 with the bump
+	# to staticcheck v0.8.0-rc.1, which made the check smarter.
+	"-SA4023",
+
 	# S1?? are "code simplifications" which we consider unnecessary
 
 	# ST1??? are stylistic issues, some of which are generally accepted


### PR DESCRIPTION
Go 1.27 requires this new v0.8.0-rc.1.

But staticcheck 0.8's SA4023 gets stricter and points out that
modifiedExternallyError and handleListenersAccept always return
non-nil errors, and that MonitorHealth's callers don't need a separate
nil check before errors.Is. Simplify all three call sites; no behavior
change.

But then a handful of other places that SA4023 is angry about are
wrong (because it's not considering build tags) and can't be addressed
by ignore directives (again not considering build tags), so we just
disable SA4023 for now.

Updates #20220
