### PR TITLE
tool/gocross: fix gocross-wrapper.ps1 toolchain staleness check for rc versions

### DIFF
--- a/tool/gocross/gocross-wrapper.ps1
+++ b/tool/gocross/gocross-wrapper.ps1
@@ -152,7 +152,7 @@ $bootstrapScriptBlock = {
     if (Test-Path -LiteralPath $toolchain -PathType Container -ErrorAction SilentlyContinue) {
         $goMod = Join-Path $repoRoot 'go.mod' -Resolve
         $goLine = Get-Content -LiteralPath $goMod | Select-String -Pattern '^go (.*)$' -List
-        $wantGoMinor = $goLine.Matches.Groups[1].Value.split('.')[1]
+        $wantGoMinor = $goLine.Matches.Groups[1].Value.split('.')[1] -replace 'rc.*', ''
         $versionFile = Join-Path $toolchain 'VERSION'
         if (Test-Path -LiteralPath $versionFile -PathType Leaf -ErrorAction SilentlyContinue) {
             try {


### PR DESCRIPTION
The check strips the rc suffix from the installed toolchain's minor
version (VERSION file, e.g. "go1.27rc2" becomes 27) but not from
go.mod's go directive ("1.27rc2" stays 27rc2). The string comparison
27 -lt 27rc2 is then true, so the wrapper considered an up-to-date rc
toolchain stale and tried to delete it while its go.exe was running,
failing with access denied and breaking the gocross build on Windows.
Strip the rc suffix from both sides.

Updates #20220
