### PR TITLE
feature/conn25: add app name to DoH query string

### DIFF
--- a/feature/conn25/conn25.go
+++ b/feature/conn25/conn25.go
@@ -17,6 +17,7 @@ import (
 	"iter"
 	"net/http"
 	"net/netip"
+	"net/url"
 	"slices"
 	"strings"
 	"sync"
@@ -180,7 +181,7 @@ func (e *extension) installHooks(dph *datapathHandler) error {
 		if urlBase == "" {
 			return "", nil
 		}
-		return urlBase + "/dns-query", nil
+		return fmt.Sprintf("%s/dns-query?app=%s", urlBase, url.QueryEscape(app.Name)), nil
 	}); err != nil {
 		return fmt.Errorf("could not register DNS resolver scheme: %w", err)
 	}


### PR DESCRIPTION
To prepare for enforcing permission to access an app, it is extremely helpful if the client reports which app it expects the query is for, instead of making the connector check all possible matching apps.

Updates tailscale/corp#40076

Change-Id: Ib41e0af4c0134d06dc4acda97a39c0a3adb88968