### PR TITLE
ipnauth: set isUnixSock in the ts_omit_unixsocketidentity GetConnIdentity

### DIFF
--- a/ipn/ipnauth/ipnauth_omit_unixsocketidentity.go
+++ b/ipn/ipnauth/ipnauth_omit_unixsocketidentity.go
@@ -15,7 +15,9 @@ import (
 // based on the user who owns the other end of the connection.
 // and couldn't. The returned connIdentity has NotWindows set to true.
 func GetConnIdentity(_ logger.Logf, c net.Conn) (ci *ConnIdentity, err error) {
-	return &ConnIdentity{conn: c, notWindows: true}, nil
+	ci = &ConnIdentity{conn: c, notWindows: true}
+	_, ci.isUnixSock = c.(*net.UnixConn)
+	return ci, nil
 }
 
 // WindowsToken is unsupported when GOOS != windows and always returns


### PR DESCRIPTION
With the ts_omit_unixsocketidentity build tag, which featuretags --min and build_dist.sh --extra-small set, the local API denies every request with 'status access denied', so the CLI cannot talk to the daemon at all in these builds.

Root cause: the ts_omit_unixsocketidentity variant of GetConnIdentity never performs the *net.UnixConn type assertion, so ConnIdentity.isUnixSock stays false. ipnserver's Permissions() only grants local API access to unix socket connections, returning (false, false) otherwise, so with this build tag every connection is treated as having no permissions.

The intent is clearly the opposite: actor.go says 'Everybody is an admin if support for unix socket identities is omitted for the build.' The fix mirrors the type assertion from the peercred variant so the omitted-identity build behaves as intended.

Reproduced with a mipsel --min build: tailscale status returned 'status access denied' before this fix and works normally after it.

Assisted by Hermes
