### PR TITLE
feature/capture,cmd/tailscale: add snapshot length to debug capture

### DIFF
--- a/client/local/local.go
+++ b/client/local/local.go
@@ -1457,13 +1457,20 @@ func (lc *Client) DebugPeerRelaySessions(ctx context.Context) (*status.ServerSta
 
 // StreamDebugCapture streams a pcap-formatted packet capture.
 //
+// snapLen is the maximum number of bytes to capture from each packet; a value
+// <= 0 uses the server default.
+//
 // The provided context does not determine the lifetime of the
 // returned [io.ReadCloser].
 //
 // API maturity: this method is not considered a stable API and is
 // subject to change between releases.
-func (lc *Client) StreamDebugCapture(ctx context.Context) (io.ReadCloser, error) {
-	req, err := http.NewRequestWithContext(ctx, "POST", "http://"+apitype.LocalAPIHost+"/localapi/v0/debug-capture", nil)
+func (lc *Client) StreamDebugCapture(ctx context.Context, snapLen int) (io.ReadCloser, error) {
+	url := "http://" + apitype.LocalAPIHost + "/localapi/v0/debug-capture"
+	if snapLen > 0 {
+		url += "?snaplen=" + strconv.Itoa(snapLen)
+	}
+	req, err := http.NewRequestWithContext(ctx, "POST", url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/tailscale/cli/debug-capture.go
+++ b/cmd/tailscale/cli/debug-capture.go
@@ -30,6 +30,8 @@ func mkDebugCaptureCmd() *ffcli.Command {
 		FlagSet: (func() *flag.FlagSet {
 			fs := newFlagSet("capture")
 			fs.StringVar(&captureArgs.outFile, "o", "", "path to stream the pcap (or - for stdout), leave empty to start wireshark")
+			fs.IntVar(&captureArgs.snapLen, "s", 262144, "snapshot length: bytes to capture from each packet (0 uses the default)")
+			fs.IntVar(&captureArgs.snapLen, "snapshot-length", 262144, "snapshot length: bytes to capture from each packet (0 uses the default)")
 			return fs
 		})(),
 	}
@@ -37,10 +39,11 @@ func mkDebugCaptureCmd() *ffcli.Command {
 
 var captureArgs struct {
 	outFile string
+	snapLen int
 }
 
 func runCapture(ctx context.Context, args []string) error {
-	stream, err := localClient.StreamDebugCapture(ctx)
+	stream, err := localClient.StreamDebugCapture(ctx, captureArgs.snapLen)
 	if err != nil {
 		return err
 	}

--- a/feature/capture/capture.go
+++ b/feature/capture/capture.go
@@ -10,6 +10,7 @@ import (
 	"encoding/binary"
 	"io"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -38,8 +39,10 @@ func serveLocalAPIDebugCapture(h *localapi.Handler, w http.ResponseWriter, r *ht
 	w.WriteHeader(http.StatusOK)
 	w.(http.Flusher).Flush()
 
+	snapLen, _ := strconv.Atoi(r.URL.Query().Get("snaplen"))
+
 	b := h.LocalBackend()
-	s := b.GetOrSetCaptureSink(newSink)
+	s := b.GetOrSetCaptureSink(func() packet.CaptureSink { return newSink(snapLen) })
 
 	unregister := s.RegisterOutput(w)
 
@@ -60,32 +63,42 @@ var bufferPool = sync.Pool{
 
 const flushPeriod = 100 * time.Millisecond
 
-func writePcapHeader(w io.Writer) {
+// defaultSnapLen is the pcap snapshot length used when a capture does not
+// request one. It matches tcpdump's default; Tailscale packets are far smaller,
+// so the default effectively never truncates.
+const defaultSnapLen = 262144
+
+func writePcapHeader(w io.Writer, snapLen int) {
 	binary.Write(w, binary.LittleEndian, uint32(0xA1B2C3D4)) // pcap magic number
 	binary.Write(w, binary.LittleEndian, uint16(2))          // version major
 	binary.Write(w, binary.LittleEndian, uint16(4))          // version minor
 	binary.Write(w, binary.LittleEndian, uint32(0))          // this zone
 	binary.Write(w, binary.LittleEndian, uint32(0))          // zone significant figures
-	binary.Write(w, binary.LittleEndian, uint32(65535))      // max packet len
+	binary.Write(w, binary.LittleEndian, uint32(snapLen))    // snapshot length
 	binary.Write(w, binary.LittleEndian, uint32(147))        // link-layer ID - USER0
 }
 
-func writePktHeader(w *bytes.Buffer, when time.Time, length int) {
+func writePktHeader(w *bytes.Buffer, when time.Time, inclLen, origLen int) {
 	s := when.Unix()
 	us := when.UnixMicro() - (s * 1000000)
 
-	binary.Write(w, binary.LittleEndian, uint32(s))      // timestamp in seconds
-	binary.Write(w, binary.LittleEndian, uint32(us))     // timestamp microseconds
-	binary.Write(w, binary.LittleEndian, uint32(length)) // length present
-	binary.Write(w, binary.LittleEndian, uint32(length)) // total length
+	binary.Write(w, binary.LittleEndian, uint32(s))       // timestamp in seconds
+	binary.Write(w, binary.LittleEndian, uint32(us))      // timestamp microseconds
+	binary.Write(w, binary.LittleEndian, uint32(inclLen)) // number of octets of packet saved
+	binary.Write(w, binary.LittleEndian, uint32(origLen)) // actual length of packet
 }
 
-// newSink creates a new capture sink.
-func newSink() packet.CaptureSink {
+// newSink creates a new capture sink that stores at most snapLen bytes of each
+// captured packet. A snapLen <= 0 uses [defaultSnapLen].
+func newSink(snapLen int) packet.CaptureSink {
+	if snapLen <= 0 {
+		snapLen = defaultSnapLen
+	}
 	ctx, c := context.WithCancel(context.Background())
 	return &Sink{
 		ctx:       ctx,
 		ctxCancel: c,
+		snapLen:   snapLen,
 	}
 }
 
@@ -95,6 +108,10 @@ func newSink() packet.CaptureSink {
 type Sink struct {
 	ctx       context.Context
 	ctxCancel context.CancelFunc
+
+	// snapLen is the maximum number of bytes stored for each captured packet.
+	// It is set once at creation and never mutated afterwards.
+	snapLen int
 
 	mu         sync.Mutex
 	outputs    set.HandleSet[io.Writer]
@@ -116,7 +133,7 @@ func (s *Sink) RegisterOutput(w io.Writer) (unregister func()) {
 	default:
 	}
 
-	writePcapHeader(w)
+	writePcapHeader(w, s.snapLen)
 	s.mu.Lock()
 	hnd := s.outputs.Add(w)
 	s.mu.Unlock()
@@ -188,29 +205,43 @@ func (s *Sink) LogPacket(path packet.CapturePath, when time.Time, data []byte, m
 	}
 
 	extraLen := customDataLen(meta)
-	b := bufferPool.Get().(*bytes.Buffer)
-	b.Reset()
-	b.Grow(16 + extraLen + len(data)) // 16b pcap header + len(metadata) + len(payload)
-	defer bufferPool.Put(b)
+	origLen := extraLen + len(data)
+	inclLen := origLen
+	if s.snapLen > 0 && inclLen > s.snapLen {
+		inclLen = s.snapLen
+	}
 
-	writePktHeader(b, when, len(data)+extraLen)
+	// body holds the record contents (custom metadata followed by the packet
+	// payload) so it can be truncated to the snapshot length before the pcap
+	// record is written.
+	body := bufferPool.Get().(*bytes.Buffer)
+	body.Reset()
+	body.Grow(origLen)
+	defer bufferPool.Put(body)
 
 	// Custom tailscale debugging data
-	binary.Write(b, binary.LittleEndian, uint16(path))
+	binary.Write(body, binary.LittleEndian, uint16(path))
 	if meta.DidSNAT {
-		binary.Write(b, binary.LittleEndian, uint8(meta.OriginalSrc.Addr().BitLen()/8))
-		b.Write(meta.OriginalSrc.Addr().AsSlice())
+		binary.Write(body, binary.LittleEndian, uint8(meta.OriginalSrc.Addr().BitLen()/8))
+		body.Write(meta.OriginalSrc.Addr().AsSlice())
 	} else {
-		binary.Write(b, binary.LittleEndian, uint8(0)) // SNAT addr len == 0
+		binary.Write(body, binary.LittleEndian, uint8(0)) // SNAT addr len == 0
 	}
 	if meta.DidDNAT {
-		binary.Write(b, binary.LittleEndian, uint8(meta.OriginalDst.Addr().BitLen()/8))
-		b.Write(meta.OriginalDst.Addr().AsSlice())
+		binary.Write(body, binary.LittleEndian, uint8(meta.OriginalDst.Addr().BitLen()/8))
+		body.Write(meta.OriginalDst.Addr().AsSlice())
 	} else {
-		binary.Write(b, binary.LittleEndian, uint8(0)) // DNAT addr len == 0
+		binary.Write(body, binary.LittleEndian, uint8(0)) // DNAT addr len == 0
 	}
+	body.Write(data)
 
-	b.Write(data)
+	b := bufferPool.Get().(*bytes.Buffer)
+	b.Reset()
+	b.Grow(16 + inclLen) // 16b pcap header + up to snapLen bytes of the record
+	defer bufferPool.Put(b)
+
+	writePktHeader(b, when, inclLen, origLen)
+	b.Write(body.Bytes()[:inclLen])
 
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/feature/capture/capture_test.go
+++ b/feature/capture/capture_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package capture
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"tailscale.com/net/packet"
+)
+
+func TestSinkSnapLen(t *testing.T) {
+	// A packet with empty CaptureMeta carries 4 bytes of custom metadata, so a
+	// 100-byte payload makes a 104-byte record.
+	const origLen = 104
+
+	tests := []struct {
+		name        string
+		snapLen     int
+		wantHdrSnap uint32
+		wantInclLen uint32
+	}{
+		{name: "truncates", snapLen: 20, wantHdrSnap: 20, wantInclLen: 20},
+		{name: "default_does_not_truncate", snapLen: 0, wantHdrSnap: defaultSnapLen, wantInclLen: origLen},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newSink(tt.snapLen).(*Sink)
+			defer s.Close()
+
+			var buf bytes.Buffer
+			s.RegisterOutput(&buf)
+			s.LogPacket(packet.CapturePath(0), time.Unix(1, 0), make([]byte, 100), packet.CaptureMeta{})
+
+			b := buf.Bytes()
+			// 24-byte global header, then a 16-byte per-packet header, then body.
+			if got := binary.LittleEndian.Uint32(b[16:20]); got != tt.wantHdrSnap {
+				t.Errorf("global header snaplen = %d, want %d", got, tt.wantHdrSnap)
+			}
+			inclLen := binary.LittleEndian.Uint32(b[32:36])
+			if inclLen != tt.wantInclLen {
+				t.Errorf("incl_len = %d, want %d", inclLen, tt.wantInclLen)
+			}
+			if got := binary.LittleEndian.Uint32(b[36:40]); got != origLen {
+				t.Errorf("orig_len = %d, want %d", got, origLen)
+			}
+			if bodyLen := len(b) - 40; bodyLen != int(inclLen) {
+				t.Errorf("stored body = %d bytes, want incl_len %d", bodyLen, inclLen)
+			}
+		})
+	}
+}

--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -2221,7 +2221,7 @@ func (s *Server) GetRootPath() string {
 // in this repository.
 // https://tailscale.com/docs/reference/troubleshooting/network-configuration/inspect-unencrypted-packets
 func (s *Server) CapturePcap(ctx context.Context, pcapFile string) error {
-	stream, err := s.localClient.StreamDebugCapture(ctx)
+	stream, err := s.localClient.StreamDebugCapture(ctx, 0)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
`tailscale debug capture` streamed whole packets into the pcap regardless of size. This adds a snapshot-length flag like tcpdump's `-s`, so you can capture just the headers when troubleshooting.

## What changed

- **`cmd/tailscale`**: new `-s` / `--snapshot-length` flag on `tailscale debug capture` (default 262144, matching tcpdump; `0` uses the default).
- **`client/local`**: `StreamDebugCapture` now takes a `snapLen` and passes it to the daemon as a `?snaplen=` query parameter. (This method is documented as a non-stable API.)
- **`feature/capture`**: the capture sink truncates each pcap record to the snapshot length, advertises it in the pcap file header, and keeps the original length in each per-packet header so truncation is visible to the reader.

The snapshot length is stored on the sink at creation, which matches the existing single-capture model (`GetOrSetCaptureSink` + `ClearCaptureSink` already assume one active capture). Happy to move it per-output if you'd prefer.

Added a unit test asserting a small snaplen truncates the record (`incl_len` capped, `orig_len` preserved, header advertises the snaplen) and that the default does not truncate.

Fixes #20708

---
<sub>Disclosure: prepared with AI assistance.</sub>
