### PR TITLE
ipn/ipnlocal: always set X-Forwarded-Proto on proxied requests

### DIFF
--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -1066,8 +1066,13 @@ func isGRPCContentType(contentType string) bool {
 
 func addProxyForwardedHeaders(r *httputil.ProxyRequest) {
 	r.Out.Header.Set("X-Forwarded-Host", r.In.Host)
+	// Set X-Forwarded-Proto unconditionally: the outbound request starts as a
+	// copy of the inbound one, so leaving it alone for plaintext requests would
+	// pass a client-supplied value through to the backend.
 	if r.In.TLS != nil {
 		r.Out.Header.Set("X-Forwarded-Proto", "https")
+	} else {
+		r.Out.Header.Set("X-Forwarded-Proto", "http")
 	}
 	if c, ok := serveHTTPContextKey.ValueOk(r.Out.Context()); ok {
 		r.Out.Header.Set("X-Forwarded-For", c.SrcAddr.Addr().String())

--- a/ipn/ipnlocal/serve_test.go
+++ b/ipn/ipnlocal/serve_test.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
 	"net/netip"
 	"net/url"
 	"os"
@@ -828,6 +829,75 @@ func TestServeHTTPProxyHeaders(t *testing.T) {
 			h := w.Result().Header
 			for _, c := range tt.wantHeaders {
 				if got := h.Get(c.header); got != c.want {
+					t.Errorf("invalid %q header; want=%q, got=%q", c.header, c.want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestAddProxyForwardedHeaders(t *testing.T) {
+	tests := []struct {
+		name      string
+		tls       bool
+		inHeader  http.Header
+		wantProto string
+	}{
+		{
+			name:      "https",
+			tls:       true,
+			wantProto: "https",
+		},
+		{
+			name:      "http",
+			wantProto: "http",
+		},
+		{
+			name:      "http-with-client-supplied-proto",
+			inHeader:  http.Header{"X-Forwarded-Proto": []string{"https"}},
+			wantProto: "http",
+		},
+		{
+			name:      "https-with-client-supplied-proto",
+			tls:       true,
+			inHeader:  http.Header{"X-Forwarded-Proto": []string{"gopher"}},
+			wantProto: "https",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := &http.Request{
+				Method: "GET",
+				Host:   "example.ts.net",
+				URL:    &url.URL{Path: "/"},
+				Header: http.Header{
+					"X-Forwarded-For":  []string{"9.9.9.9"},
+					"X-Forwarded-Host": []string{"evil.example"},
+				},
+			}
+			for k, vv := range tt.inHeader {
+				in.Header[k] = vv
+			}
+			if tt.tls {
+				in.TLS = &tls.ConnectionState{ServerName: "example.ts.net"}
+			}
+			in = in.WithContext(serveHTTPContextKey.WithValue(in.Context(), &serveHTTPContext{
+				DestPort: 80,
+				SrcAddr:  netip.MustParseAddrPort("100.150.151.152:1234"),
+			}))
+			out := in.Clone(in.Context())
+
+			addProxyForwardedHeaders(&httputil.ProxyRequest{In: in, Out: out})
+
+			for _, c := range []struct {
+				header string
+				want   string
+			}{
+				{"X-Forwarded-Proto", tt.wantProto},
+				{"X-Forwarded-For", "100.150.151.152"},
+				{"X-Forwarded-Host", "example.ts.net"},
+			} {
+				if got := out.Header.Get(c.header); got != c.want {
 					t.Errorf("invalid %q header; want=%q, got=%q", c.header, c.want, got)
 				}
 			}


### PR DESCRIPTION
When tailscale serve proxies to a local backend, addProxyForwardedHeaders overwrites X-Forwarded-Host and X-Forwarded-For but only writes X-Forwarded-Proto when the inbound connection was TLS. The proxy runs in Rewrite mode, so the outbound request starts as a clone of the inbound one and whatever the client sent survives unless we replace it. On a plaintext serve, say `tailscale serve --http=80 proxy 3000`, that means any peer able to reach the port can send `X-Forwarded-Proto: https` and have the backend read it as though we set it. I noticed it reading the function next to addTailscaleIdentityHeaders, which deletes the headers it is about to write for exactly this reason. Our docs point backend authors at these headers, and frameworks such as Django and Rails will treat a request as secure on the strength of that one value. Setting it from the scheme we actually observed is what httputil.ProxyRequest.SetXForwarded does for the same three headers, so TLS requests are unchanged and plaintext ones now say http.