### PR TITLE
ipn/ipnlocal: avoid deadlocks during shutdown

### DIFF
--- a/ipn/ipnlocal/cert.go
+++ b/ipn/ipnlocal/cert.go
@@ -125,15 +125,18 @@ func (b *LocalBackend) getACMETLSALPNProto(hi *tls.ClientHelloInfo) (string, boo
 // changes, so the cert refresh loop can be (re)started or stopped.
 // b.mu must be held.
 func (b *LocalBackend) updateCertRefreshLoopLocked() {
+	if b.shutdownCalled {
+		return
+	}
 	if f, ok := HookUpdateCertRefreshLoop.GetOk(); ok {
 		f(b, b.state, b.serveConfig)
 	}
 }
 
-// shutdownCertRefreshLoopLocked is called from
-// [LocalBackend.Shutdown] to cancel the cert refresh loop.
-// b.mu must be held.
-func (b *LocalBackend) shutdownCertRefreshLoopLocked() {
+// shutdownCertRefreshLoop is called from [LocalBackend.Shutdown] to cancel the
+// cert refresh loop. It must be called without b.mu held because it waits for
+// the loop, which can be blocked acquiring b.mu.
+func (b *LocalBackend) shutdownCertRefreshLoop() {
 	if f, ok := HookShutdownCertRefreshLoop.GetOk(); ok {
 		f(b)
 	}

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -253,7 +253,8 @@ type LocalBackend struct {
 	// exposeRemoteWebClientAtomicBool controls whether the web client is exposed over
 	// Tailscale on port 5252.
 	exposeRemoteWebClientAtomicBool atomic.Bool // TODO(nickkhyl): move to nodeBackend
-	shutdownCalled                  bool        // if Shutdown has been called
+	shutdownOnce                    sync.Once   // guards execution of Shutdown
+	shutdownCalled                  bool        // if Shutdown has been called; guarded by mu
 	debugSink                       packet.CaptureSink
 	sockstatLogger                  *sockstatlog.Logger
 
@@ -1291,6 +1292,10 @@ func (b *LocalBackend) ClearCaptureSink() {
 // Shutdown halts the backend and all its sub-components. The backend
 // can no longer be used after Shutdown returns.
 func (b *LocalBackend) Shutdown() {
+	b.shutdownOnce.Do(b.shutdown)
+}
+
+func (b *LocalBackend) shutdown() {
 	defer b.CheckDeadlocks()()
 
 	// Close the [eventbus.Client] to wait for subscribers to
@@ -1305,13 +1310,7 @@ func (b *LocalBackend) Shutdown() {
 	b.em.close()
 
 	b.mu.Lock()
-	if b.shutdownCalled {
-		b.mu.Unlock()
-		return
-	}
 	b.shutdownCalled = true
-
-	b.shutdownCertRefreshLoopLocked()
 
 	b.stopReconnectTimerLocked()
 
@@ -1330,10 +1329,8 @@ func (b *LocalBackend) Shutdown() {
 		b.mu.Lock()
 	}
 	cc := b.cc
-	if b.sshServer != nil {
-		b.sshServer.Shutdown()
-		b.sshServer = nil
-	}
+	sshServer := b.sshServer
+	b.sshServer = nil
 	b.closePeerAPIListenersLocked()
 	if b.debugSink != nil {
 		b.e.InstallCaptureHook(nil)
@@ -1345,6 +1342,15 @@ func (b *LocalBackend) Shutdown() {
 	}
 	b.appConnector.Close()
 	b.mu.Unlock()
+
+	// These shutdown methods wait for goroutines that can acquire b.mu. The
+	// state gates above prevent either subsystem from restarting after the
+	// mutex is released.
+	b.shutdownCertRefreshLoop()
+	if sshServer != nil {
+		sshServer.Shutdown()
+	}
+
 	b.webClientShutdown()
 
 	if b.sockstatLogger != nil {
@@ -8111,6 +8117,9 @@ func (b *LocalBackend) ActiveSSHConns() int {
 func (b *LocalBackend) sshServerOrInit() (_ SSHServer, err error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	if b.shutdownCalled {
+		return nil, errShutdown
+	}
 	if b.sshServer != nil {
 		return b.sshServer, nil
 	}

--- a/ipn/ipnlocal/shutdown_test.go
+++ b/ipn/ipnlocal/shutdown_test.go
@@ -1,0 +1,84 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package ipnlocal
+
+import (
+	"errors"
+	"net"
+	"sync/atomic"
+	"testing"
+
+	"tailscale.com/ipn"
+)
+
+type shutdownTestSSHServer struct {
+	b     *LocalBackend
+	calls atomic.Int32
+	t     *testing.T
+}
+
+func (s *shutdownTestSSHServer) HandleSSHConn(net.Conn) error { return nil }
+func (s *shutdownTestSSHServer) NumActiveConns() int          { return 0 }
+func (s *shutdownTestSSHServer) OnPolicyChange()              {}
+
+func (s *shutdownTestSSHServer) Shutdown() {
+	s.calls.Add(1)
+	if !s.b.mu.TryLock() {
+		s.t.Error("LocalBackend.mu held while shutting down SSH server")
+		return
+	}
+	s.b.mu.Unlock()
+	s.b.NodeKey() // do something that requires the lock
+}
+
+func TestShutdownReleasesMutexBeforeWaitingForSubsystems(t *testing.T) {
+	b := newTestLocalBackend(t)
+	ssh := &shutdownTestSSHServer{b: b, t: t}
+	b.mu.Lock()
+	b.sshServer = ssh
+	b.mu.Unlock()
+
+	var certShutdownCalls atomic.Int32
+	restore := HookShutdownCertRefreshLoop.SetForTest(func(b *LocalBackend) {
+		certShutdownCalls.Add(1)
+		if !b.mu.TryLock() {
+			t.Error("LocalBackend.mu held while shutting down cert refresh loop")
+			return
+		}
+		b.mu.Unlock()
+		b.ServeConfig()
+	})
+	t.Cleanup(restore)
+
+	b.Shutdown()
+	b.Shutdown()
+
+	if got := certShutdownCalls.Load(); got != 1 {
+		t.Errorf("cert refresh shutdown called %d times; want 1", got)
+	}
+	if got := ssh.calls.Load(); got != 1 {
+		t.Errorf("SSH shutdown called %d times; want 1", got)
+	}
+	if _, err := b.sshServerOrInit(); !errors.Is(err, errShutdown) {
+		t.Errorf("sshServerOrInit after Shutdown = %v; want %v", err, errShutdown)
+	}
+}
+
+func TestCertRefreshLoopDoesNotRestartAfterShutdown(t *testing.T) {
+	b := newTestLocalBackend(t)
+	var updates atomic.Int32
+	restore := HookUpdateCertRefreshLoop.SetForTest(func(*LocalBackend, ipn.State, ipn.ServeConfigView) {
+		updates.Add(1)
+	})
+	t.Cleanup(restore)
+
+	b.Shutdown()
+	b.mu.Lock()
+	b.updateCertRefreshLoopLocked()
+	b.mu.Unlock()
+
+	if got := updates.Load(); got != 0 {
+		t.Errorf("cert refresh loop restarted %d times after Shutdown; want 0", got)
+	}
+}


### PR DESCRIPTION
LocalBackend.Shutdown waits for the ACME refresh loop and active SSH
sessions. Both can be blocked acquiring LocalBackend.mu, so waiting while
holding that mutex deadlocks shutdown.

Detach the SSH server under the mutex, then stop both subsystems after
releasing it. Prevent their work from restarting once shutdown begins, and
serialize repeated Shutdown calls with sync.Once.

Add regression tests that verify subsystem shutdown runs without
LocalBackend.mu held.

Updates tailscale/corp#45964
