### PR TITLE
net/netcheck,wgengine/magicsock: don't rebind when IPv4 was never probed

### DIFF
--- a/net/netcheck/netcheck.go
+++ b/net/netcheck/netcheck.go
@@ -98,6 +98,12 @@ type Report struct {
 	OSHasIPv6   bool      // could bind a socket to ::1
 	ICMPv4      bool      // an ICMPv4 round trip completed
 
+	// IPv4SendAttempted is whether an IPv4 STUN send was attempted. It is
+	// false when the probe plan held no IPv4 probes, as when the link has no
+	// usable IPv4 address. IPv4CanSend reports a send failure only when this
+	// is true.
+	IPv4SendAttempted bool
+
 	// MappingVariesByDestIP is whether STUN results depend which
 	// STUN server you're talking to (on IPv4).
 	MappingVariesByDestIP opt.Bool
@@ -1630,16 +1636,20 @@ func (rs *reportState) runProbe(ctx context.Context, dm *tailcfg.DERPMap, probe 
 	}
 
 	n, err := rs.c.SendPacket(req, addr)
+
+	rs.mu.Lock()
+	if probe.proto == probeIPv4 {
+		rs.report.IPv4SendAttempted = true
+	}
 	if n == len(req) && err == nil || neterror.TreatAsLostUDP(err) {
-		rs.mu.Lock()
 		switch probe.proto {
 		case probeIPv4:
 			rs.report.IPv4CanSend = true
 		case probeIPv6:
 			rs.report.IPv6CanSend = true
 		}
-		rs.mu.Unlock()
 	}
+	rs.mu.Unlock()
 
 	c.vlogf("sent to %v", addr)
 }

--- a/net/netcheck/netcheck_test.go
+++ b/net/netcheck/netcheck_test.go
@@ -6,15 +6,18 @@ package netcheck
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"net"
 	"net/http"
 	"net/netip"
 	"reflect"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -157,6 +160,81 @@ func TestWorksWhenUDPBlocked(t *testing.T) {
 
 	if !reflect.DeepEqual(r, want) {
 		t.Errorf("mismatch\n got: %+v\nwant: %+v\n", r, want)
+	}
+}
+
+// TestIPv4SendAttempted checks that IPv4SendAttempted separates an IPv4 STUN
+// send that failed from one that was never planned. The no_v4_node case stands
+// in for a link with no usable IPv4 address, which empties p4 at the same gate
+// in makeProbePlan; TestMakeProbePlan covers that half.
+func TestIPv4SendAttempted(t *testing.T) {
+	tests := []struct {
+		name        string
+		stunAddr    string
+		sendErr     error
+		linuxOnly   bool
+		wantAttempt bool
+		wantCanSend bool
+	}{
+		{
+			name:        "v4_send_ok",
+			stunAddr:    "127.0.0.1:3478",
+			wantAttempt: true,
+			wantCanSend: true,
+		},
+		{
+			name:        "v4_send_fails",
+			stunAddr:    "127.0.0.1:3478",
+			sendErr:     errors.New("sendto: network is unreachable"),
+			wantAttempt: true,
+			wantCanSend: false,
+		},
+		{
+			// TreatAsLostUDP counts an OUTPUT firewall reject (EPERM) as sent,
+			// not as a send failure. Preserving the behavior described in
+			// #16755.
+			name:        "v4_send_eperm",
+			stunAddr:    "127.0.0.1:3478",
+			sendErr:     &net.OpError{Op: "write", Err: syscall.EPERM},
+			linuxOnly:   true,
+			wantAttempt: true,
+			wantCanSend: true,
+		},
+		{
+			name:        "no_v4_node",
+			stunAddr:    "[::1]:3478",
+			wantAttempt: false,
+			wantCanSend: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.linuxOnly && runtime.GOOS != "linux" {
+				t.Skipf("TreatAsLostUDP only tolerates EPERM on linux")
+			}
+			// Each case waits out stunProbeTimeout.
+			t.Parallel()
+
+			c := newTestClient(t)
+			c.SendPacket = func(pkt []byte, dst netip.AddrPort) (int, error) {
+				if tt.sendErr != nil {
+					return 0, tt.sendErr
+				}
+				return len(pkt), nil
+			}
+
+			r, err := c.GetReport(t.Context(), stuntest.DERPMapOf(tt.stunAddr), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := r.IPv4SendAttempted; got != tt.wantAttempt {
+				t.Errorf("IPv4SendAttempted = %v; want %v", got, tt.wantAttempt)
+			}
+			if got := r.IPv4CanSend; got != tt.wantCanSend {
+				t.Errorf("IPv4CanSend = %v; want %v", got, tt.wantCanSend)
+			}
+		})
 	}
 }
 

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -235,6 +235,8 @@ type Conn struct {
 	// noV4Send is whether IPv4 UDP is known to be unable to transmit
 	// at all. This could happen if the socket is in an invalid state
 	// (as can happen on darwin after a network link status change).
+	// It stays false when netcheck attempted no IPv4 send, so a link
+	// without IPv4 is not mistaken for a broken socket.
 	noV4Send atomic.Bool
 
 	// networkUp is whether the network is up (some interface is up
@@ -1056,7 +1058,9 @@ func (c *Conn) updateNetInfo(ctx context.Context) (*netcheck.Report, error) {
 	c.lastNetCheckReport.Store(report)
 	c.noV4.Store(!report.IPv4)
 	c.noV6.Store(!report.IPv6)
-	c.noV4Send.Store(!report.IPv4CanSend)
+	// !IPv4CanSend alone says nothing when no IPv4 probe was planned; acting
+	// on it rebinds on every netcheck forever on links without IPv4.
+	c.noV4Send.Store(report.IPv4SendAttempted && !report.IPv4CanSend)
 
 	ni := &tailcfg.NetInfo{
 		DERPLatency:           map[string]float64{},

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -3498,6 +3498,49 @@ func TestMaybeRebindOnError(t *testing.T) {
 	})
 }
 
+// TestUpdateNetInfoNoV4Send checks that a netcheck which attempted no IPv4
+// send leaves noV4Send clear. Setting it makes updateEndpoints rebind on every
+// netcheck for as long as the link has no IPv4, dropping DERP conns each time.
+func TestUpdateNetInfoNoV4Send(t *testing.T) {
+	tests := []struct {
+		name     string
+		stunAddr string
+		sendErr  error
+		want     bool
+	}{
+		// The IPv4 socket was exercised and failed, which is what a rebind
+		// exists to recover from.
+		{"v4_send_fails", "127.0.0.1:3478", errors.New("sendto: network is unreachable"), true},
+		{"v4_send_ok", "127.0.0.1:3478", nil, false},
+		// No DERP node has an IPv4 address, so no IPv4 probe is planned and
+		// the IPv4 socket is never exercised.
+		{"no_v4_probe", "[::1]:3478", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Each case waits out netcheck's STUN probe timeout.
+			t.Parallel()
+
+			conn := newTestConn(t)
+			conn.SetDERPMapWithoutReSTUN(stuntest.DERPMapOf(tt.stunAddr))
+			conn.netChecker.SendPacket = func(pkt []byte, dst netip.AddrPort) (int, error) {
+				if tt.sendErr != nil {
+					return 0, tt.sendErr
+				}
+				return len(pkt), nil
+			}
+
+			if _, err := conn.updateNetInfo(t.Context()); err != nil {
+				t.Fatal(err)
+			}
+			if got := conn.noV4Send.Load(); got != tt.want {
+				t.Errorf("noV4Send = %v; want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func newTestConnAndRegistry(t *testing.T) (*Conn, *usermetric.Registry) {
 	t.Helper()
 	bus := eventbus.New()


### PR DESCRIPTION
## What this does

Adds `netcheck.Report.IPv4SendAttempted`, recording whether an IPv4 STUN send was actually tried, and changes magicsock to set `noV4Send` only when a send was tried and failed.

Fixes #16755
Updates #19791

## Why

On a host with no usable IPv4 address, `makeProbePlan` gates IPv4 probes on `ifState.HaveV4` and plans none. `Report.IPv4CanSend` is written `true` in exactly one place, in `runProbe` after a send, so it can never become true on such a host. magicsock stored `noV4Send = !report.IPv4CanSend` and `updateEndpoints` read that as "the IPv4 socket cannot transmit", so every netcheck called `Rebind()`. From an IPv6-only EKS pod on #16755:

```
magicsock: last netcheck reported send error. Rebinding.
Rebind; defIf="v4if0", ips=[169.254.172.3/22 fe80::683a:f1ff:fec8:1aa5/64]
magicsock: closing connection to derp-12 (rebind-default-route-change), age 23s
```

Periodic re-STUN is suppressed once the node has been idle past `sessionActiveTimeout`, so the loop runs at 20-26s intervals precisely while there is traffic. Where the default route sits on an interface that does not hold the socket's address, each cycle also closes every DERP connection and new connections stall while the loop runs.

Reported on IPv6-only VMs (#16755), Google Cloud Run (#19791, #20330), and IPv6-only EKS pods where `aws-vpc-cni` provides IPv4 egress through a link-local address. The thread on #16755 has a measurement of 12 rebinds in 5 minutes against 0 once the link is made to report IPv4.

The rebind exists for #2994, where a socket is left bound to a departed interface after a network reconfiguration. That case is unaffected: the link still has a usable IPv4 address, so probes are planned, the send is attempted and fails, and `noV4Send` is still set.

## Tests

Two new tests, both mutation-checked with `go test -overlay` (working tree left untouched):

- `TestIPv4SendAttempted` (net/netcheck) covers send-ok, send-failed, EPERM and no-IPv4-node. Dropping the `runProbe` change fails the first three; dropping the `TreatAsLostUDP` tolerance fails the EPERM case.
- `TestUpdateNetInfoNoV4Send` (wgengine/magicsock) asserts `noV4Send` end to end through `updateNetInfo`. Restoring `noV4Send = !report.IPv4CanSend` fails `no_v4_probe` with `noV4Send = true; want false`.

`netmon.Monitor` exposes no way to inject interface state, so the new tests reach the empty IPv4 probe set through a DERP node without an IPv4 address rather than through `HaveV4`. The existing `TestMakeProbePlan/only_v6_initial` covers the other half, that `HaveV4 == false` yields a plan with no IPv4 probes.

Also run locally: `go test -race -count=2` over net/netcheck and wgengine/magicsock, `go test -race` over cmd/tailscale/cli and ipn/ipnlocal (the other `netcheck.Report` consumers), `staticcheck` for darwin/arm64, windows/amd64 and linux/amd64, `make depaware`, `go mod tidy` with no diff, and cross-builds for plan9, solaris, illumos, aix, js/wasm, windows amd64 and arm64, darwin, freebsd, openbsd and linux/arm.
