### PR TITLE
ipn/ipnlocal: allow switching service TUN mode

### DIFF
--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -1810,21 +1810,6 @@ func validateServeConfigUpdate(existing, incoming ipn.ServeConfigView) error {
 			}
 		}
 
-		existingHasTCP := existingSvcCfg.TCP().Len() > 0
-		existingHasWeb := existingSvcCfg.Web().Len() > 0
-
-		// A Service cannot turn on TUN mode if TCP or web handlers exist.
-		if incomingSvcCfg.Tun() && (existingHasTCP || existingHasWeb) {
-			return fmt.Errorf("cannot turn on TUN mode with existing TCP or web handlers for %s", svcName)
-		}
-
-		incomingHasTCP := incomingSvcCfg.TCP().Len() > 0
-		incomingHasWeb := incomingSvcCfg.Web().Len() > 0
-
-		// A Service cannot add TCP or web handlers if TUN mode is enabled.
-		if (incomingHasTCP || incomingHasWeb) && existingSvcCfg.Tun() {
-			return fmt.Errorf("cannot add TCP or web handlers as TUN mode is enabled for %s", svcName)
-		}
 	}
 
 	return nil

--- a/ipn/ipnlocal/serve_test.go
+++ b/ipn/ipnlocal/serve_test.go
@@ -1949,8 +1949,8 @@ func TestValidateServeConfigUpdate(t *testing.T) {
 			wantError: true,
 		},
 		{
-			name:        "tun-mode-with-handlers",
-			description: "Services cannot enable TUN mode if L4 or L7 handlers already exist",
+			name:        "replace-handlers-with-tun-mode",
+			description: "replacing L4 or L7 handlers with TUN mode should work",
 			existing: &ipn.ServeConfig{
 				Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
 					"svc:foo": {
@@ -1974,11 +1974,11 @@ func TestValidateServeConfigUpdate(t *testing.T) {
 					},
 				},
 			},
-			wantError: true,
+			wantError: false,
 		},
 		{
-			name:        "handlers-with-tun-mode",
-			description: "Services cannot add L4 or L7 handlers if TUN mode is already enabled",
+			name:        "replace-tun-mode-with-handlers",
+			description: "replacing TUN mode with L4 or L7 handlers should work",
 			existing: &ipn.ServeConfig{
 				Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
 					"svc:foo": {
@@ -2002,7 +2002,7 @@ func TestValidateServeConfigUpdate(t *testing.T) {
 					},
 				},
 			},
-			wantError: true,
+			wantError: false,
 		},
 	}
 


### PR DESCRIPTION
## Summary

- allow a service's replacement config to switch between TUN mode and TCP or web handlers
- keep rejecting an incoming service config that combines TUN mode with handlers
- cover replacements in both directions in `TestValidateServeConfigUpdate`

Fixes #20683

## Tests

- `./tool/go test ./ipn/ipnlocal ./cmd/tailscale/cli`
- `./tool/go vet ./ipn/ipnlocal`
- `git diff --check origin/main...HEAD`