### PR TITLE
tstest/natlab/vmtest: use KVM for gokrazy VMs

### DIFF
--- a/tstest/natlab/vmtest/qemu.go
+++ b/tstest/natlab/vmtest/qemu.go
@@ -137,6 +137,7 @@ func (e *Env) startGokrazyQEMU(n *Node) error {
 
 	args := []string{
 		"-M", "microvm,isa-serial=off",
+		"-accel", "kvm",
 		"-m", fmt.Sprintf("%dM", n.os.MemoryMB),
 		"-nodefaults", "-no-user-config", "-nographic",
 		"-kernel", e.gokrazyKernel,


### PR DESCRIPTION
The gokrazy VMs in the natlab vmtests run without a `-accel` flag, so QEMU falls back to TCG software emulation. Under TCG the VMs are slow enough that the tests routinely hang and hit their timeout, which makes anything under `tstest/natlab/vmtest` effectively unrunnable.

Pass `-accel kvm` so the VMs use hardware virtualization, matching what the rest of the natlab QEMU invocations already expect from the host.

Measured on a Linux host with `/dev/kvm` available, running `TestSubnetRouterFreeBSD`:

| | wall clock |
|---|---|
| before (TCG) | 600s, timeout |
| after (KVM) | ~52s |

The slow boot and slow VIP transfers that show up as flakes under TCG also stop reproducing.

This is independent of the FreeBSD subnet-routing work it came out of; it just makes the existing vmtests usable. Split out per @bradfitz's request in #19312.