### PR TITLE
wgengine/router/osrouter: don't clobber PF tables when adding anchor refs

### DIFF
--- a/wgengine/router/osrouter/router_freebsd.go
+++ b/wgengine/router/osrouter/router_freebsd.go
@@ -6,6 +6,8 @@ package osrouter
 import (
 	"fmt"
 	"os/exec"
+	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/tailscale/wireguard-go/tun"
@@ -182,9 +184,43 @@ func ensurePFAnchorRef() error {
 		return nil // already present
 	}
 
+	// "pfctl -sn"/"-sr" print only a table's name, never the addresses it
+	// holds, so a ruleset reconstructed from them re-declares every table
+	// as empty. Reloading it would silently drop the contents of any table
+	// the operator populates out-of-band (a "persist file" table, "pfctl -T
+	// add", etc.), breaking whatever rules reference it. There is no way to
+	// insert an anchor reference into a running ruleset without a reload, so
+	// refuse rather than clobber, and tell the operator how to fix it
+	// permanently.
+	if t := pfTablesReferenced(natRules + filterRules); len(t) > 0 {
+		return fmt.Errorf("refusing to reload main PF ruleset: it references table(s) %s "+
+			"whose contents cannot be preserved across a reload; add %q and %q to "+
+			"/etc/pf.conf instead",
+			strings.Join(t, ", "), natAnchorRef, anchorRef)
+	}
+
 	// Prepend our anchor references so they're evaluated, then include
 	// all existing rules so we don't disrupt the user's configuration.
 	return loadPFMainRuleset(additions + natRules + filterRules)
+}
+
+// pfTableRx matches a table reference in "pfctl -sn"/"-sr" output, e.g. the
+// "<zabbix_proxies>" in "pass in on em0 from <zabbix_proxies> to any".
+var pfTableRx = regexp.MustCompile(`<([a-zA-Z0-9_.:-]+)>`)
+
+// pfTablesReferenced returns the sorted, deduplicated names of PF tables
+// referenced by the given ruleset text.
+func pfTablesReferenced(rules string) []string {
+	seen := map[string]bool{}
+	var names []string
+	for _, m := range pfTableRx.FindAllStringSubmatch(rules, -1) {
+		if !seen[m[1]] {
+			seen[m[1]] = true
+			names = append(names, m[1])
+		}
+	}
+	slices.Sort(names)
+	return names
 }
 
 // removePFAnchorRef removes the nat-anchor and anchor references for

--- a/wgengine/router/osrouter/router_freebsd_test.go
+++ b/wgengine/router/osrouter/router_freebsd_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package osrouter
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestPFTablesReferenced(t *testing.T) {
+	tests := []struct {
+		name  string
+		rules string
+		want  []string
+	}{
+		{"empty", "", nil},
+		{
+			// What a bare FreeBSD box looks like: only our anchor refs.
+			"anchors only",
+			"nat-anchor \"tailscale\"\nanchor \"tailscale\"\n",
+			nil,
+		},
+		{
+			"no tables",
+			"scrub in all fragment reassemble\npass in all flags S/SA keep state\n",
+			nil,
+		},
+		{
+			// pfctl emits automatic tables like this for interface groups; a
+			// reload without table preservation would empty them too.
+			"automatic table",
+			"block drop in log inet from <__automatic_591ee83a_0> to any\n",
+			[]string{"__automatic_591ee83a_0"},
+		},
+		{
+			"named table",
+			"pass out log on em0 proto tcp from <zabbix_proxies> to any port = ssh\n",
+			[]string{"zabbix_proxies"},
+		},
+		{
+			"deduplicated and sorted",
+			"pass in log from <trusted> to any\n" +
+				"pass in log from <admins> to any\n" +
+				"pass out log from any to <trusted>\n",
+			[]string{"admins", "trusted"},
+		},
+		{
+			"names with punctuation",
+			"pass in log from <fw-cluster.v4> to any\npass in log from <mon_hosts> to any\n",
+			[]string{"fw-cluster.v4", "mon_hosts"},
+		},
+		{
+			// A bare "<" with no closing ">" is not a table reference.
+			"unclosed angle bracket",
+			"pass in all # < not a table\n",
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pfTablesReferenced(tt.rules); !slices.Equal(got, tt.want) {
+				t.Errorf("pfTablesReferenced() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`ensurePFAnchorRef` reconstructs the main PF ruleset from `pfctl -s nat` / `pfctl -s rules` output and reloads it with `pfctl -f -`. That output names any table a rule references but never prints its contents, so the reconstructed ruleset re-declares every table as **empty**.

Reloading it silently drops the addresses of any table the operator populates out-of-band:

- `table <foo> persist file "/path"` 
- `pfctl -T add`
- pfctl's own `<__automatic_*>` tables for interface groups

Every rule referencing that table then matches nothing. That is a quiet and security-relevant failure: a ruleset whose `pass ... from <trusted>` rules still *exist* but match no addresses still looks correct in `pfctl -s rules`.

There is no way to insert an anchor reference into a running ruleset without a reload, so this detects the case and refuses, naming the tables at risk and pointing at the durable fix (putting the anchor references in `/etc/pf.conf`, where they survive reboots and pf reloads anyway).

Boxes that already have the anchor references configured are unaffected -- `ensurePFAnchorRef` returns early at `already present` before reaching the check. That is why this has not bitten our fleet: we load the anchors statically via Ansible on 18 FreeBSD firewalls, so the reload path never runs.

### Testing

`pfTablesReferenced` has table-driven tests covering named tables, automatic tables, dedup/sort, punctuation in names, and non-table `<` characters.

Note the tests live in `router_freebsd_test.go`, so they only build under `GOOS=freebsd` and may not be exercised by CI on a Linux runner. I verified the same logic natively as well (8/8), and checked the pattern against two real production rulesets.

Split out per @bradfitz's request in #19312.