### PR TITLE
cmd/tailscaled: keep handling FreeBSD subnets in netstack by default

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -733,6 +733,19 @@ func handleSubnetsInNetstack() bool {
 		// Enable on Windows and tailscaled-on-macOS (this doesn't
 		// affect the GUI clients).
 		return true
+	case "freebsd":
+		// FreeBSD can route subnets in the kernel and SNAT them with pf,
+		// but that is not yet the safe default: the pf NAT rule we install
+		// never matches (evaluated but never translating), and inserting the
+		// pf anchor at runtime cannot preserve the contents of tables an
+		// existing ruleset references.
+		//
+		// Keep handling subnets in netstack, which does its own SNAT in
+		// userspace and touches no system state, and let the kernel path be
+		// opted into with TS_DEBUG_NETSTACK_SUBNETS=false. Only that path can
+		// serve --snat-subnet-routes=false, which netstack cannot do because
+		// it must rewrite the source address.
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
This keeps FreeBSD subnet routing in netstack by default. After more testing the argument for it is **narrower than this description originally claimed**, so, rewritten:

### Why keep netstack as the default

1. **Behavior compatibility.** Moving to the kernel path changes behavior for every existing FreeBSD subnet router in one release: pf becomes load-bearing, tailscaled starts editing the main pf ruleset at runtime, and `--snat-subnet-routes` starts meaning something. That is a rollout decision, not a bug fix, and defaults should not flip out from under existing users as a side effect of a feature branch.
2. **The runtime pf main-ruleset reload has a real hazard** (#20733): reconstructing the ruleset from `pfctl -s` output empties any pf table the operator populates out-of-band, silently breaking the rules that reference it.

The kernel path stays reachable via `TS_DEBUG_NETSTACK_SUBNETS=false`, which is also the only way to get `--snat-subnet-routes=false`, since netstack must rewrite the source address.

### Correction from the original description

I originally cited `pfctl -s info | grep translate` reading 0 as evidence the kernel SNAT rule never matches. **That was a misreading.** That counter stays 0 even while the rule demonstrably translates; the per-rule `Packets:` counter is the meaningful one. The kernel path's actual defect was the `-> (self)` round-robin bug, found and fixed in #20738 -- with that fix the kernel path passes both the single-flow and multi-flow vmtests.

So this PR is a policy position, not a correctness one. If you'd rather land #20738 and ship the kernel path as the default, I have no data against that -- close this and I'll rerun our fleet validation on that basis.

With this commit, `TestSubnetRouterFreeBSD` passes deterministically (the netstack path has no per-flow address roulette).

Split out per @bradfitz's request in #19312.