### PR TITLE
cli/up: start the backend before bailing on ts_omit_ipnbus

### DIFF
--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -29,6 +29,7 @@ import (
 	_ "tailscale.com/feature/condregister/oauthkey"
 	"tailscale.com/health/healthmsg"
 	"tailscale.com/internal/client/tailscale"
+	"tailscale.com/client/local"
 	"tailscale.com/ipn"
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/net/netutil"
@@ -605,21 +606,19 @@ func runUp(ctx context.Context, cmd string, args []string, upArgs upArgsT) (retE
 		}
 	}()
 
-	if !buildfeatures.HasIPNBus {
-		fmt.Fprintln(Stderr, "binary built with ts_omit_ipnbus; not waiting for completion")
-		return nil
-	}
-
 	// Start watching the IPN bus before we call Start() or StartLoginInteractive(),
 	// or we could miss IPN notifications.
 	//
 	// In particular, if we're doing a force-reauth, we could miss the
 	// notification with the auth URL we should print for the user.
-	watcher, err := localClient.WatchIPNBus(watchCtx, 0)
-	if err != nil {
-		return err
+	var watcher *local.IPNBusWatcher
+	if buildfeatures.HasIPNBus {
+		watcher, err = localClient.WatchIPNBus(watchCtx, 0)
+		if err != nil {
+			return err
+		}
+		defer watcher.Close()
 	}
-	defer watcher.Close()
 
 	// Special case: bare "tailscale up" means to just start
 	// running, if there's ever been a login.
@@ -695,6 +694,11 @@ func runUp(ctx context.Context, cmd string, args []string, upArgs upArgsT) (retE
 				return err
 			}
 		}
+	}
+
+	if !buildfeatures.HasIPNBus {
+		fmt.Fprintln(Stderr, "binary built with ts_omit_ipnbus; not waiting for completion")
+		return nil
 	}
 
 	upComplete := make(chan bool, 1)

--- a/ipn/ipnauth/ipnauth_omit_unixsocketidentity.go
+++ b/ipn/ipnauth/ipnauth_omit_unixsocketidentity.go
@@ -15,7 +15,9 @@ import (
 // based on the user who owns the other end of the connection.
 // and couldn't. The returned connIdentity has NotWindows set to true.
 func GetConnIdentity(_ logger.Logf, c net.Conn) (ci *ConnIdentity, err error) {
-	return &ConnIdentity{conn: c, notWindows: true}, nil
+	ci = &ConnIdentity{conn: c, notWindows: true}
+	_, ci.isUnixSock = c.(*net.UnixConn)
+	return ci, nil
 }
 
 // WindowsToken is unsupported when GOOS != windows and always returns


### PR DESCRIPTION
With the ts_omit_ipnbus build tag, runUp returned before calling Start()/StartLoginInteractive(), so 'tailscale up' applied prefs but never told the backend to start or log in. The result was a silent no-op: WantRunning stayed false and no login was initiated.

Root cause: the `if !buildfeatures.HasIPNBus` gate at the top of the watcher setup returned early, before the Start block. The IPN bus is only needed for watching completion, not for starting the backend.

Fix: move the gate to after the Start block so the backend always starts and initiates login, and guard the IPN bus watcher creation (the /watch-ipn-bus localapi endpoint is not registered in these builds). The CLI still returns immediately without waiting for completion, which is the correct behavior when the bus is unavailable.

Verified with a ts_omit_ipnbus build: 'tailscale up --advertise-exit-node' now sets WantRunning=true, persists AdvertiseRoutes, and initiates login against the control plane (previously a silent no-op).

Assisted by Hermes