### PR TITLE
wgengine/router/osrouter: SNAT to the egress interface address, not (self)

### DIFF
--- a/cmd/tta/tta.go
+++ b/cmd/tta/tta.go
@@ -297,6 +297,17 @@ func main() {
 		w.WriteHeader(resp.StatusCode)
 		io.Copy(w, resp.Body)
 	})
+	ttaMux.HandleFunc("/exec", func(w http.ResponseWriter, r *http.Request) {
+		// Run an arbitrary command via the shell, for test diagnostics that
+		// need to inspect OS state (firewall counters, routing tables, ...)
+		// on a node the harness has no SSH access to.
+		cmd := r.URL.Query().Get("cmd")
+		if cmd == "" {
+			http.Error(w, "missing cmd", http.StatusBadRequest)
+			return
+		}
+		serveCmd(w, "sh", "-c", cmd)
+	})
 	ttaMux.HandleFunc("/fw", addFirewallHandler)
 	ttaMux.HandleFunc("/logs", func(w http.ResponseWriter, r *http.Request) {
 		logBuf.mu.Lock()

--- a/tstest/natlab/vmtest/pfsnat_test.go
+++ b/tstest/natlab/vmtest/pfsnat_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package vmtest_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"tailscale.com/tstest/natlab/vmtest"
+	"tailscale.com/tstest/natlab/vnet"
+)
+
+// TestSubnetRouterFreeBSDManyFlows runs the standard subnet-router topology
+// against a FreeBSD router with SNAT left at its default (true) and makes
+// several sequential HTTP requests, so that each request opens a fresh flow
+// through the router's PF NAT rule.
+//
+// A single-flow test cannot catch a NAT rule whose translation address pool
+// is wrong on average but right occasionally: "-> (self)" round-robins new
+// states across every address on the machine, so one request has decent odds
+// of drawing the working (egress interface) address while most flows hang.
+// Multiple fresh flows make that failure deterministic. PF state is dumped
+// along the way so a failure shows which address each flow was translated to.
+func TestSubnetRouterFreeBSDManyFlows(t *testing.T) {
+	env := vmtest.New(t)
+
+	clientNet := env.AddNetwork("2.1.1.1", "192.168.1.1/24", "2000:1::1/64", vnet.EasyNAT)
+	internalNet := env.AddNetwork("10.0.0.1/24", "2000:2::1/64")
+
+	client := env.AddNode("client", clientNet,
+		vmtest.OS(vmtest.Gokrazy))
+	sr := env.AddNode("subnet-router", clientNet, internalNet,
+		vmtest.OS(vmtest.FreeBSD150),
+		vmtest.AdvertiseRoutes("10.0.0.0/24"))
+	backend := env.AddNode("backend", internalNet,
+		vmtest.OS(vmtest.Gokrazy),
+		vmtest.DontJoinTailnet(),
+		vmtest.WebServer(8080))
+
+	env.Start()
+	env.ApproveRoutes(sr, "10.0.0.0/24")
+
+	dump := func(label string) {
+		t.Logf("========== PF STATE: %s ==========", label)
+		for _, c := range []struct{ what, cmd string }{
+			{"pf info", "pfctl -s info"},
+			{"main nat ruleset", "pfctl -s nat"},
+			{"anchor nat (verbose, w/ counters)", "pfctl -a tailscale -vsn"},
+			{"anchor filter (verbose)", "pfctl -a tailscale -vsr"},
+			{"state table", "pfctl -s state | head -20"},
+			{"interfaces", "ifconfig -a | grep -E '^[a-z]|inet '"},
+			{"routes", "netstat -rn -f inet"},
+			{"forwarding", "sysctl net.inet.ip.forwarding"},
+		} {
+			out, err := env.Exec(sr, c.cmd)
+			if err != nil {
+				t.Logf("--- %s: ERROR %v\n%s", c.what, err, out)
+				continue
+			}
+			t.Logf("--- %s:\n%s", c.what, strings.TrimRight(out, "\n"))
+		}
+	}
+
+	dump("after start, before traffic")
+
+	// Repeat the request several times. "-> (self)" expands to every address
+	// on the box (here: the WAN IP, the LAN IP, the QEMU user-net IP and
+	// 127.0.0.1) and pf's round-robin pool cycles through that list per new
+	// state, so a single successful flow does not prove the translation
+	// address is chosen correctly. A flow translated to a non-LAN address
+	// blackholes (the backend cannot route the reply), so count failures too,
+	// and after each request record what the state table says the flow was
+	// translated to.
+	srcSeen := map[string]int{}
+	var okCount, failCount int
+	srLanIP := sr.LanIP(internalNet).String()
+	for i := range 8 {
+		body, err := env.HTTPGetErr(client, fmt.Sprintf("http://%s:8080/", backend.LanIP(internalNet)))
+		if err != nil {
+			failCount++
+			t.Logf("request %d: FAILED: %v", i+1, err)
+		} else {
+			okCount++
+			t.Logf("request %d response: %q", i+1, body)
+			if _, src, ok := strings.Cut(body, " from "); ok {
+				srcSeen[strings.TrimSpace(src)]++
+			}
+		}
+		if out, err := env.Exec(sr, "pfctl -s state | grep 8080"); err == nil {
+			t.Logf("request %d states:\n%s", i+1, strings.TrimRight(out, "\n"))
+		}
+	}
+
+	dump("after traffic")
+
+	t.Logf("results: %d ok, %d failed; source addresses seen by backend (subnet router LAN IP is %s):", okCount, failCount, srLanIP)
+	for src, n := range srcSeen {
+		t.Logf("    %-20s %d requests", src, n)
+	}
+	if failCount > 0 {
+		t.Errorf("%d of 8 requests failed: \"-> (self)\" round-robin translated some flows to a non-LAN address", failCount)
+	}
+	for src := range srcSeen {
+		if src != srLanIP {
+			t.Errorf("backend saw source %q, want the subnet router's LAN IP %q", src, srLanIP)
+		}
+	}
+}

--- a/tstest/natlab/vmtest/vmtest.go
+++ b/tstest/natlab/vmtest/vmtest.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"net/http"
 	"net/netip"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -567,13 +568,23 @@ func (e *Env) waitForPeerRoute(n *Node, prefix string, timeout time.Duration) bo
 // HTTPGet makes an HTTP GET request from the given node to the specified URL.
 // The request is proxied through TTA's /http-get handler.
 func (e *Env) HTTPGet(from *Node, targetURL string) string {
+	body, err := e.HTTPGetErr(from, targetURL)
+	if err != nil {
+		e.t.Fatalf("HTTPGet from %s to %s: %v", from.name, targetURL, err)
+	}
+	return body
+}
+
+// HTTPGetErr is like HTTPGet but returns an error instead of failing the
+// test, for tests that want to observe request failures.
+func (e *Env) HTTPGetErr(from *Node, targetURL string) (string, error) {
 	for attempt := range 3 {
 		ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
 		reqURL := "http://unused/http-get?url=" + targetURL
 		req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
 		if err != nil {
 			cancel()
-			e.t.Fatalf("HTTPGet: %v", err)
+			return "", err
 		}
 		res, err := from.agent.HTTPClient.Do(req)
 		cancel()
@@ -588,10 +599,33 @@ func (e *Env) HTTPGet(from *Node, targetURL string) string {
 			time.Sleep(2 * time.Second)
 			continue
 		}
-		return string(body)
+		return string(body), nil
 	}
-	e.t.Fatalf("HTTPGet from %s to %s: all attempts failed", from.name, targetURL)
-	return ""
+	return "", fmt.Errorf("all attempts failed")
+}
+
+// Exec runs a shell command on the given node via TTA's /exec handler and
+// returns its combined output. Unlike SSHExec it needs no debug SSH port, so
+// it works on any node running TTA. Intended for test diagnostics that inspect
+// OS state (firewall counters, routing tables, ...).
+func (e *Env) Exec(on *Node, cmd string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	reqURL := "http://unused/exec?cmd=" + url.QueryEscape(cmd)
+	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+	if err != nil {
+		return "", err
+	}
+	res, err := on.agent.HTTPClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+	body, _ := io.ReadAll(res.Body)
+	if ec := res.Header.Get("Exec-Exit-Code"); ec != "" && ec != "0" {
+		return string(body), fmt.Errorf("exit code %s", ec)
+	}
+	return string(body), nil
 }
 
 var buildGokrazy sync.Once

--- a/wgengine/router/osrouter/router_freebsd.go
+++ b/wgengine/router/osrouter/router_freebsd.go
@@ -5,6 +5,7 @@ package osrouter
 
 import (
 	"fmt"
+	"net"
 	"os/exec"
 	"strings"
 
@@ -121,11 +122,19 @@ func (r *freebsdRouter) addPFNATRules() error {
 	// addresses exiting any non-Tailscale interface is source-NATed to the
 	// outgoing interface's address so that return traffic routes back through
 	// this node.
-	rules := fmt.Sprintf(
-		"nat on ! %s inet from 100.64.0.0/10 to any -> (self)\n"+
-			"nat on ! %s inet6 from fd7a:115c:a1e0::/48 to any -> (self)\n",
-		r.tunname, r.tunname,
-	)
+	//
+	// This must be one rule per interface translating to that interface's own
+	// address. A single "nat on ! tailscale0 ... -> (self)" rule looks
+	// equivalent but is not: "(self)" is a round-robin pool of every address
+	// on the machine (including tailscale0's own address and loopback), and
+	// pf deals each new state the next address in the pool. Flows translated
+	// to an address that isn't the egress interface's get replies that the
+	// far end cannot route back, so roughly (N-1)/N of connections through
+	// the subnet router silently hang at SYN.
+	rules, err := r.buildPFNATRules()
+	if err != nil {
+		return fmt.Errorf("building PF NAT rules: %w", err)
+	}
 
 	pfctl := exec.Command("pfctl", "-a", pfAnchorName, "-f", "-")
 	pfctl.Stdin = strings.NewReader(rules)
@@ -134,6 +143,52 @@ func (r *freebsdRouter) addPFNATRules() error {
 		return fmt.Errorf("pfctl -a %s -f: %v (%s)", pfAnchorName, err, strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+// buildPFNATRules returns the NAT rules for the tailscale anchor: one rule
+// per up, non-loopback, non-Tailscale interface, translating to that
+// interface's own address. Rules are emitted per address family only for
+// interfaces that hold a usable address of that family, since "-> (ifname)"
+// on an interface with no address of the packet's family cannot translate.
+//
+// The interface set is sampled when SNAT is enabled; interfaces added later
+// are not covered until SNAT is toggled or tailscaled restarts.
+func (r *freebsdRouter) buildPFNATRules() (string, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	for _, iface := range ifaces {
+		if iface.Name == r.tunname ||
+			iface.Flags&net.FlagLoopback != 0 ||
+			iface.Flags&net.FlagUp == 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		var has4, has6 bool
+		for _, a := range addrs {
+			ipn, ok := a.(*net.IPNet)
+			if !ok {
+				continue
+			}
+			if ip4 := ipn.IP.To4(); ip4 != nil {
+				has4 = true
+			} else if !ipn.IP.IsLinkLocalUnicast() {
+				has6 = true
+			}
+		}
+		if has4 {
+			fmt.Fprintf(&b, "nat on %s inet from 100.64.0.0/10 to any -> (%s)\n", iface.Name, iface.Name)
+		}
+		if has6 {
+			fmt.Fprintf(&b, "nat on %s inet6 from fd7a:115c:a1e0::/48 to any -> (%s)\n", iface.Name, iface.Name)
+		}
+	}
+	return b.String(), nil
 }
 
 // getPFMainRuleset reads the current main PF filter and NAT rules.


### PR DESCRIPTION
The FreeBSD subnet-router NAT rule translates with `-> (self)`:

```
nat on ! tailscale0 inet from 100.64.0.0/10 to any -> (self)
```

In pf, `(self)` is a **round-robin pool of every address on the machine** -- including tailscale0's own address and loopback -- and pf deals each new state the next address in the pool. Only flows that draw the egress interface's address work. A flow translated to any other address gets replies the far end cannot route, and hangs at SYN. With N usable addresses on the box, roughly (N-1)/N of connections through the subnet router silently fail.

### Evidence

vmtest, FreeBSD 15.0 router with 4 addresses (WAN, LAN, QEMU debug NIC, tailscale0), 8 sequential HTTP requests: **exactly half hang, alternating**, and the pf state table names the wrong address each dead flow was translated to:

```
all tcp 10.0.0.102:51100 (100.64.0.1:35132) -> 10.0.0.103:8080  ESTABLISHED:ESTABLISHED
all tcp 10.0.2.15:56553  (100.64.0.1:35148) -> 10.0.0.103:8080  SYN_SENT:CLOSED
all tcp 100.64.0.2:52655 (100.64.0.1:54106) -> 10.0.0.103:8080  SYN_SENT:CLOSED
```

(10.0.0.102 = router LAN IP, works; 10.0.2.15 = QEMU debug NIC; 100.64.0.2 = the router's own tailscale0 address, despite the rule matching `on ! tailscale0` -- the interface match constrains where the rule applies, not the address pool.)

On one of our production FreeBSD firewalls running this branch, the IPv6 twin of this rule shows **55 state creations totalling 117 packets** -- about two packets per state, i.e. SYNs whose replies never came back, in production, today.

This also explains why `TestSubnetRouterFreeBSD` has been maddeningly flaky: a single-request test is a per-run coin flip on which pool address the one flow draws.

### Fix

One rule per up, non-loopback, non-Tailscale interface, translating to that interface's own address (the form FreeBSD firewall operators write by hand), emitted per address family only where the interface holds a usable address of that family:

```
nat on vtnet0 inet from 100.64.0.0/10 to any -> (vtnet0)
nat on vtnet1 inet from 100.64.0.0/10 to any -> (vtnet1)
```

Same 8-request test: **8/8**, backend sees only the router's LAN address, and the LAN interface's rule shows 8 states / 56 packets (healthy flows).

Known limitation, noted in a comment: the interface set is sampled when SNAT is enabled; hot-added interfaces aren't covered until SNAT toggles or tailscaled restarts.

### Second commit: the test

`TestSubnetRouterFreeBSDManyFlows` opens several fresh flows and requires all of them to work. Support pieces: a `/exec` handler in TTA plus `Env.Exec` (run diagnostics on nodes the harness cannot SSH into -- the FreeBSD router here), and `Env.HTTPGetErr` (treat a hung request as data instead of failing the test).

Caveat: this branch carries an older snapshot of the vmtest package, from before main's qemu accel fallback / QMP retry / SSH key generation landed, so vmtests here flake under TCG (gokrazy VMs wedge at 100% CPU). The 4/8-vs-8/8 runs above were done with those harness fixes applied locally; merging current main into this branch brings them all in properly.

Split out per @bradfitz's request in #19312.