### PR TITLE
ipn/ipnlocal: allow the ingress peer capability for unsigned peers (#…

### DIFF
--- a/ipn/ipnlocal/node_backend.go
+++ b/ipn/ipnlocal/node_backend.go
@@ -419,8 +419,8 @@ func (nb *nodeBackend) PeerCaps(src netip.Addr) tailcfg.PeerCapMap {
 }
 
 // srcIsUnsignedPeerLocked reports whether src is an address of a peer with
-// UnsignedPeerAPIOnly set. Such peers are not covered by tailnet lock and must
-// never be granted peer capabilities.
+// UnsignedPeerAPIOnly set. Such peers are not covered by tailnet lock and may
+// only hold the capabilities permitted by capsAllowedForUnsignedPeer.
 //
 // nb.mu must be held before calling.
 func (nb *nodeBackend) srcIsUnsignedPeerLocked(src netip.Addr) bool {
@@ -432,10 +432,21 @@ func (nb *nodeBackend) srcIsUnsignedPeerLocked(src netip.Addr) bool {
 	return ok && n.UnsignedPeerAPIOnly()
 }
 
-func (nb *nodeBackend) peerCapsLocked(src netip.Addr) tailcfg.PeerCapMap {
-	if nb.srcIsUnsignedPeerLocked(src) {
-		return nil
+// capsAllowedForUnsignedPeer filters caps down to the set that an unsigned
+// (UnsignedPeerAPIOnly) peer may hold. Unsigned peers aren't covered by
+// tailnet lock, so a possibly malicious control server must not be able to
+// grant them capabilities. The sole exception is PeerCapabilityIngress:
+// Tailscale Funnel ingress nodes are unsigned by design, and the capability
+// only permits ingress requests over the PeerAPI, which unsigned peers can
+// already reach.
+func capsAllowedForUnsignedPeer(caps tailcfg.PeerCapMap) tailcfg.PeerCapMap {
+	if vals, ok := caps[tailcfg.PeerCapabilityIngress]; ok {
+		return tailcfg.PeerCapMap{tailcfg.PeerCapabilityIngress: vals}
 	}
+	return nil
+}
+
+func (nb *nodeBackend) peerCapsLocked(src netip.Addr) tailcfg.PeerCapMap {
 	if nb.netMap == nil {
 		return nil
 	}
@@ -451,7 +462,11 @@ func (nb *nodeBackend) peerCapsLocked(src netip.Addr) tailcfg.PeerCapMap {
 		}
 		dst := a.Addr()
 		if dst.BitLen() == src.BitLen() { // match on family
-			return filt.CapsWithValues(src, dst)
+			caps := filt.CapsWithValues(src, dst)
+			if nb.srcIsUnsignedPeerLocked(src) {
+				caps = capsAllowedForUnsignedPeer(caps)
+			}
+			return caps
 		}
 	}
 	return nil
@@ -464,9 +479,6 @@ func (nb *nodeBackend) peerCapsLocked(src netip.Addr) tailcfg.PeerCapMap {
 func (nb *nodeBackend) PeerCapsForIP(src, dst netip.Addr) tailcfg.PeerCapMap {
 	nb.mu.Lock()
 	defer nb.mu.Unlock()
-	if nb.srcIsUnsignedPeerLocked(src) {
-		return nil
-	}
 	if nb.netMap == nil {
 		return nil
 	}
@@ -474,7 +486,11 @@ func (nb *nodeBackend) PeerCapsForIP(src, dst netip.Addr) tailcfg.PeerCapMap {
 	if filt == nil {
 		return nil
 	}
-	return filt.CapsWithValues(src, dst)
+	caps := filt.CapsWithValues(src, dst)
+	if nb.srcIsUnsignedPeerLocked(src) {
+		caps = capsAllowedForUnsignedPeer(caps)
+	}
+	return caps
 }
 
 // PeerCapsForService returns the capabilities that remote src IP has when
@@ -484,9 +500,6 @@ func (nb *nodeBackend) PeerCapsForIP(src, dst netip.Addr) tailcfg.PeerCapMap {
 func (nb *nodeBackend) PeerCapsForService(src netip.Addr, svcName tailcfg.ServiceName) tailcfg.PeerCapMap {
 	nb.mu.Lock()
 	defer nb.mu.Unlock()
-	if nb.srcIsUnsignedPeerLocked(src) {
-		return nil
-	}
 	if nb.netMap == nil {
 		return nil
 	}
@@ -497,7 +510,11 @@ func (nb *nodeBackend) PeerCapsForService(src netip.Addr, svcName tailcfg.Servic
 	addrs := nb.netMap.GetVIPServiceIPMap()[svcName]
 	for _, ip := range addrs {
 		if ip.BitLen() == src.BitLen() {
-			return filt.CapsWithValues(src, ip)
+			caps := filt.CapsWithValues(src, ip)
+			if nb.srcIsUnsignedPeerLocked(src) {
+				caps = capsAllowedForUnsignedPeer(caps)
+			}
+			return caps
 		}
 	}
 	return nil

--- a/tsnet/tsnet_test.go
+++ b/tsnet/tsnet_test.go
@@ -820,9 +820,28 @@ func TestFunnel(t *testing.T) {
 	ctx, dialCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer dialCancel()
 
-	controlURL, _ := startControl(t)
+	controlURL, control := startControl(t)
 	s1, _, _ := startServer(t, ctx, controlURL, "s1")
-	s2, _, _ := startServer(t, ctx, controlURL, "s2")
+	s2, s2ip, s2key := startServer(t, ctx, controlURL, "s2")
+
+	// Real Funnel ingress nodes appear in the target node's netmap as
+	// unsigned (UnsignedPeerAPIOnly) peers. Mark s2 the same way and wait
+	// for s1 to see it, so that this test exercises the same peer
+	// capability checks that production Funnel traffic does.
+	control.SetUnsignedPeerAPIOnly(s2key, true)
+	lc1 := must.Get(s1.LocalClient())
+	if err := tstest.WaitFor(10*time.Second, func() error {
+		res, err := lc1.WhoIs(ctx, s2ip.String())
+		if err != nil {
+			return err
+		}
+		if !res.Node.UnsignedPeerAPIOnly {
+			return errors.New("s1 does not yet see s2 as UnsignedPeerAPIOnly")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	ln := must.Get(s1.ListenFunnel("tcp", ":443"))
 	defer ln.Close()

--- a/tstest/integration/testcontrol/testcontrol.go
+++ b/tstest/integration/testcontrol/testcontrol.go
@@ -153,6 +153,11 @@ type Server struct {
 	// peerIsJailed is the set of peers that are jailed for a node.
 	peerIsJailed map[key.NodePublic]map[key.NodePublic]bool // node => peer => isJailed
 
+	// nodeUnsignedPeerAPIOnly is the set of nodes that appear in other
+	// nodes' netmaps with tailcfg.Node.UnsignedPeerAPIOnly set, as
+	// Tailscale Funnel ingress nodes do.
+	nodeUnsignedPeerAPIOnly map[key.NodePublic]bool
+
 	// masquerades is the set of masquerades that should be applied to
 	// MapResponses sent to clients. It is keyed by the requesting nodes
 	// public key, and then the peer node's public key. The value is the
@@ -680,6 +685,16 @@ func (s *Server) SetJailed(a, b key.NodePublic, jailed bool) {
 	}
 	s.peerIsJailed[a][b] = jailed
 	s.updateLocked("SetJailed", s.nodeIDsLocked(0))
+}
+
+// SetUnsignedPeerAPIOnly sets whether the node with the given key
+// appears in other nodes' netmaps with UnsignedPeerAPIOnly set, as
+// Tailscale Funnel ingress nodes do.
+func (s *Server) SetUnsignedPeerAPIOnly(k key.NodePublic, unsigned bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	mak.Set(&s.nodeUnsignedPeerAPIOnly, k, unsigned)
+	s.updateLocked("SetUnsignedPeerAPIOnly", s.nodeIDsLocked(0))
 }
 
 // SetMasqueradeAddresses sets the masquerade addresses for the server.
@@ -1587,8 +1602,9 @@ var keepAliveMsg = &struct {
 	KeepAlive: true,
 }
 
-func packetFilterWithIngress(addRelayCaps bool) []tailcfg.FilterRule {
+func packetFilterWithIngress(addRelayCaps bool, allowSrcs []string) []tailcfg.FilterRule {
 	out := slices.Clone(tailcfg.FilterAllowAll)
+	out[0].SrcIPs = allowSrcs
 	caps := []tailcfg.PeerCapability{
 		tailcfg.PeerCapabilityIngress,
 	}
@@ -1621,6 +1637,7 @@ func (s *Server) MapResponse(req *tailcfg.MapRequest) (res *tailcfg.MapResponse,
 
 	s.mu.Lock()
 	nodeCapMap := maps.Clone(s.nodeCapMaps[nk])
+	unsignedNodes := maps.Clone(s.nodeUnsignedPeerAPIOnly)
 	var dns *tailcfg.DNSConfig
 	if s.DNSConfig != nil {
 		dns = s.DNSConfig.Clone()
@@ -1640,12 +1657,30 @@ func (s *Server) MapResponse(req *tailcfg.MapRequest) (res *tailcfg.MapResponse,
 		dns.CertDomains = append(dns.CertDomains, node.Hostinfo.Hostname()+"."+magicDNSDomain)
 	}
 
+	// Real control never includes unsigned (UnsignedPeerAPIOnly) peers as
+	// sources in filter rules that permit traffic; clients treat such a
+	// packet filter as invalid and discard it entirely. When any unsigned
+	// nodes exist, enumerate the signed nodes' addresses instead of using
+	// a wildcard.
+	allowSrcs := []string{"*"}
+	if len(unsignedNodes) > 0 {
+		allowSrcs = nil
+		for _, n := range s.AllNodes() {
+			if unsignedNodes[n.Key] {
+				continue
+			}
+			for _, a := range n.Addresses {
+				allowSrcs = append(allowSrcs, a.String())
+			}
+		}
+	}
+
 	res = &tailcfg.MapResponse{
 		Node:            node,
 		DERPMap:         s.DERPMap,
 		Domain:          domain,
 		CollectServices: cmp.Or(s.CollectServices, opt.True),
-		PacketFilter:    packetFilterWithIngress(s.PeerRelayGrants),
+		PacketFilter:    packetFilterWithIngress(s.PeerRelayGrants, allowSrcs),
 		DNSConfig:       dns,
 		SSHPolicy:       sshPolicy,
 		ControlTime:     &t,
@@ -1668,6 +1703,7 @@ func (s *Server) MapResponse(req *tailcfg.MapRequest) (res *tailcfg.MapResponse,
 			}
 		}
 		p.IsJailed = jailed[p.Key]
+		p.UnsignedPeerAPIOnly = unsignedNodes[p.Key]
 
 		s.mu.Lock()
 		peerAddress := s.masquerades[p.Key][node.Key]


### PR DESCRIPTION
0eb38dc2e (#20561) made peer capability resolution return nothing for peers with UnsignedPeerAPIOnly set, so that a possibly malicious control server can't grant capabilities to peers outside the tailnet lock authority. But Tailscale Funnel ingress nodes are unsigned by design, and control intentionally grants them
PeerCapabilityIngress, which the peerapi /v0/ingress handler requires. The result was that every Funnel connection was rejected with a 403 "denied; no ingress cap".

Instead of denying all capabilities to unsigned peers, allowlist PeerCapabilityIngress specifically. It only permits ingress requests over the PeerAPI, which unsigned peers can already reach, and the node only serves them for targets explicitly configured for Funnel.

The tsnet TestFunnel didn't catch the regression because its fake ingress peer was a normal signed peer. Teach testcontrol to mark a node as UnsignedPeerAPIOnly (excluding such nodes from traffic- permitting filter rules, as real control does, so clients don't discard the packet filter) and make TestFunnel use it so the test now exercises the same capability checks as production Funnel traffic.

Updates tailscale/corp#46053
Updates #20739

Change-Id: I3f6b8e2a94d1c07b5a2e9d84f16c30aa79e5d21b


(cherry picked from commit 0dfe672b3260727670c0d9f6835602ca7bdd0fe8)