### PR TITLE
tstest/integration: run multi-node Windows tests with userspace peers

### DIFF
--- a/tstest/integration/capmap_test.go
+++ b/tstest/integration/capmap_test.go
@@ -5,7 +5,6 @@ package integration
 
 import (
 	"errors"
-	"runtime"
 	"testing"
 	"time"
 
@@ -15,9 +14,6 @@ import (
 
 // TestPeerCapMap tests that the node capability map (CapMap) is included in peer information.
 func TestPeerCapMap(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
-	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 
@@ -100,9 +96,6 @@ func TestPeerCapMap(t *testing.T) {
 
 // TestSetNodeCapMap tests that SetNodeCapMap updates are propagated to peers.
 func TestSetNodeCapMap(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
-	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 

--- a/tstest/integration/exec_notwindows.go
+++ b/tstest/integration/exec_notwindows.go
@@ -1,0 +1,18 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !windows
+
+package integration
+
+import (
+	"os"
+	"os/exec"
+)
+
+// setNewProcessGroup is a no-op; only Windows needs its own process group.
+func setNewProcessGroup(cmd *exec.Cmd) {}
+
+func interruptProcess(process *os.Process) error {
+	return process.Signal(os.Interrupt)
+}

--- a/tstest/integration/exec_windows.go
+++ b/tstest/integration/exec_windows.go
@@ -1,0 +1,28 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build windows
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// setNewProcessGroup gives cmd its own process group since CTRL_BREAK targets a whole group.
+func setNewProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.CREATE_NEW_PROCESS_GROUP}
+}
+
+// interruptProcess interrupts process via CTRL_BREAK, which its Go runtime maps to SIGINT.
+func interruptProcess(process *os.Process) error {
+	if err := windows.GenerateConsoleCtrlEvent(windows.CTRL_BREAK_EVENT, uint32(process.Pid)); err != nil {
+		return fmt.Errorf("GenerateConsoleCtrlEvent: %w", err)
+	}
+	return nil
+}

--- a/tstest/integration/integration.go
+++ b/tstest/integration/integration.go
@@ -502,8 +502,6 @@ func (lc *LogCatcher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // or more nodes.
 type TestEnv struct {
 	t                      testing.TB
-	tunMode                bool
-	windowsService         bool // run tailscaled as a Windows service
 	cli                    string
 	daemon                 string
 	loopbackPort           *int
@@ -545,11 +543,6 @@ func (f ConfigureControl) ModifyTestEnv(te *TestEnv) {
 // NewTestEnv starts a bunch of services and returns a new test environment.
 // NewTestEnv arranges for the environment's resources to be cleaned up on exit.
 func NewTestEnv(t testing.TB, opts ...TestEnvOpt) *TestEnv {
-	if runtime.GOOS == "windows" {
-		if !*runWindowsServiceTests {
-			t.Skip("Windows service tests disabled (--run-windows-service-tests=false)")
-		}
-	}
 	derpMap := RunDERPAndSTUN(t, logger.Discard, "127.0.0.1")
 	logc := new(LogCatcher)
 	control := &testcontrol.Server{
@@ -561,7 +554,6 @@ func NewTestEnv(t testing.TB, opts ...TestEnvOpt) *TestEnv {
 	binaries := GetBinaries(t)
 	e := &TestEnv{
 		t:                 t,
-		windowsService:    runtime.GOOS == "windows",
 		cli:               binaries.Tailscale.Path,
 		daemon:            binaries.Tailscaled.Path,
 		LogCatcher:        logc,
@@ -603,34 +595,96 @@ type TestNode struct {
 	upFlagGOOS   string // if non-empty, sets TS_DEBUG_UP_FLAG_GOOS for cmd/tailscale CLI
 	encryptState bool
 	allowUpdates bool
+	tunMode      bool // TUN rather than userspace networking
 
 	mu        sync.Mutex
 	onLogLine []func([]byte)
 	lc        *local.Client
 }
 
+// writeBlankEnvFile writes an empty env file for the node and returns its path.
+func (n *TestNode) writeBlankEnvFile() string {
+	t := n.env.t
+	t.Helper()
+	path := filepath.Join(n.dir, "tailscaled-env.txt")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+	return path
+}
+
+// TestNodeOpt represents an option that can be passed to NewTestNode.
+type TestNodeOpt interface {
+	modifyTestNode(*TestNode)
+}
+
+type tunModeOpt bool
+
+func (o tunModeOpt) modifyTestNode(n *TestNode) { n.tunMode = bool(o) }
+
+// TUNMode specifies whether TUN or userspace networking mode should be used
+// by the node. Currently, only one node can run in TUN mode at a time.
+// On Windows, TUN mode currently requires running as a service.
+func TUNMode(v bool) TestNodeOpt { return tunModeOpt(v) }
+
+// tunSlot is the node running in TUN mode, or nil, as a host has room for only one.
+var tunSlot syncs.AtomicValue[*TestNode]
+
+// defaultTUNMode reports whether a node should run in TUN mode unless told otherwise.
+func defaultTUNMode() bool {
+	return runtime.GOOS == "windows" && *runWindowsServiceTests && tunSlot.Load() == nil
+}
+
+// takeTUNSlot claims the sole TUN-mode slot for n, failing the test if it's taken.
+func takeTUNSlot(t testing.TB, n *TestNode) {
+	t.Helper()
+	if runtime.GOOS == "windows" && !*runWindowsServiceTests {
+		t.Skip("TUN mode requires running as a Windows service (re-run with --run-windows-service-tests)")
+	}
+	if !tunSlot.CompareAndSwap(nil, n) {
+		t.Fatal("only one node can run in TUN mode at a time")
+	}
+	t.Cleanup(n.releaseTUNSlot)
+}
+
+// releaseTUNSlot frees the TUN-mode slot so a later node in the test can take it.
+func (n *TestNode) releaseTUNSlot() {
+	tunSlot.CompareAndSwap(n, nil)
+}
+
 // NewTestNode allocates a temp directory for a new test node.
 // The node is not started automatically.
-func NewTestNode(t *testing.T, env *TestEnv) *TestNode {
+func NewTestNode(t *testing.T, env *TestEnv, opts ...TestNodeOpt) *TestNode {
 	dir := t.TempDir()
-	sockFile := filepath.Join(dir, "tailscale.sock")
-	if len(sockFile) >= 104 {
-		// Maximum length for a unix socket on darwin. Try something else.
-		sockFile = filepath.Join(os.TempDir(), rands.HexString(8)+".sock")
-		t.Cleanup(func() { os.Remove(sockFile) })
-	}
-	stateFile := filepath.Join(dir, "tailscaled.state") // matches what cmd/tailscaled uses
-	if env.windowsService {
-		// A LocalSystem service ignores --socket/--statedir and uses the
-		// default pipe and state path; point the harness at those.
-		sockFile = paths.DefaultTailscaledSocket()
-		stateFile = paths.DefaultTailscaledStateFile()
-	}
 	n := &TestNode{
-		env:       env,
-		dir:       dir,
-		sockFile:  sockFile,
-		stateFile: stateFile,
+		env:     env,
+		dir:     dir,
+		tunMode: defaultTUNMode(),
+	}
+	for _, o := range opts {
+		o.modifyTestNode(n)
+	}
+	if n.tunMode {
+		takeTUNSlot(t, n)
+	}
+
+	n.stateFile = filepath.Join(dir, "tailscaled.state") // matches what cmd/tailscaled uses
+	switch {
+	case runtime.GOOS != "windows":
+		n.sockFile = filepath.Join(dir, "tailscale.sock")
+		if len(n.sockFile) >= 104 {
+			// Maximum length for a unix socket on darwin. Try something else.
+			sockFile := filepath.Join(os.TempDir(), rands.HexString(8)+".sock")
+			n.sockFile = sockFile
+			t.Cleanup(func() { os.Remove(sockFile) })
+		}
+	case n.tunMode:
+		// A LocalSystem service ignores --socket and --statedir.
+		n.sockFile = paths.DefaultTailscaledSocket()
+		n.stateFile = paths.DefaultTailscaledStateFile()
+	default:
+		// safesocket on Windows needs a named pipe, not a file path.
+		n.sockFile = `\\.\pipe\tailscale-test-` + rands.HexString(8)
 	}
 
 	// Look for a data race or panic.
@@ -794,23 +848,44 @@ func (op *nodeOutputParser) parseLinesLocked() {
 type Daemon struct {
 	Process *os.Process
 
+	// node is the daemon's node, whose TUN slot MustCleanShutdown releases.
+	node *TestNode
+
 	// svc is set when the daemon is a Windows service (no owned Process);
 	// MustCleanShutdown then stops it via the SCM.
 	svc *TestNode
 }
 
 func (d *Daemon) MustCleanShutdown(t testing.TB) {
+	defer d.node.releaseTUNSlot()
 	if d.svc != nil {
+		// A service is stopped via the SCM, not by interrupting its process.
 		d.svc.stopService()
-		return
+	} else if err := interruptProcess(d.Process); err != nil {
+		t.Errorf("interrupting tailscaled: %v; killing", err)
+		d.Process.Kill()
 	}
-	d.Process.Signal(os.Interrupt)
-	ps, err := d.Process.Wait()
-	if err != nil {
-		t.Fatalf("tailscaled Wait: %v", err)
+	type waitResult struct {
+		ps  *os.ProcessState
+		err error
 	}
-	if ps.ExitCode() != 0 {
-		t.Errorf("tailscaled ExitCode = %d; want 0", ps.ExitCode())
+	done := make(chan waitResult, 1)
+	go func() {
+		ps, err := d.Process.Wait()
+		done <- waitResult{ps, err}
+	}()
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("tailscaled Wait: %v", got.err)
+		}
+		if got.ps.ExitCode() != 0 {
+			t.Errorf("tailscaled ExitCode = %d; want 0", got.ps.ExitCode())
+		}
+	case <-time.After(30 * time.Second):
+		t.Error("tailscaled did not exit within 30s of being asked to stop; killing")
+		d.Process.Kill()
+		<-done
 	}
 }
 
@@ -882,7 +957,7 @@ func (n *TestNode) StartDaemonAsIPNGOOS(ipnGOOS string) *Daemon {
 		t.Fatalf("awaitTailscaledRunnable: %v", err)
 	}
 
-	if n.env.windowsService {
+	if runtime.GOOS == "windows" && n.tunMode {
 		// TODO(#20443): plumb service logs here so races/panics/DEBUG-ADDR are seen in service mode.
 		n.tailscaledParser = &nodeOutputParser{n: n}
 		return n.startWindowsServiceDaemon()
@@ -895,10 +970,15 @@ func (n *TestNode) StartDaemonAsIPNGOOS(ipnGOOS string) *Daemon {
 		"--socks5-server=localhost:0",
 		"--debug=localhost:0",
 	)
+	if runtime.GOOS == "windows" {
+		// On Windows, tailscaled defaults to a fixed port (41641).
+		// Force a random port to avoid collisions when running multiple test nodes.
+		cmd.Args = append(cmd.Args, "--port=0")
+	}
 	if *verboseTailscaled {
 		cmd.Args = append(cmd.Args, "-verbose=2")
 	}
-	if !n.env.tunMode {
+	if !n.tunMode {
 		cmd.Args = append(cmd.Args,
 			"--tun=userspace-networking",
 		)
@@ -916,7 +996,18 @@ func (n *TestNode) StartDaemonAsIPNGOOS(ipnGOOS string) *Daemon {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = io.MultiWriter(cmd.Stderr, os.Stderr)
 	}
-	if runtime.GOOS != "windows" {
+	if runtime.GOOS == "windows" {
+		// On Windows, tailscaled always reads environment variables from
+		// %programdata%\Tailscale\tailscaled-env.txt if the file exists and
+		// TS_DEBUG_ENV_FILE isn't set.
+		//
+		// Therefore, to prevent tailscaled from reading environment variables
+		// from the global file, we need to point it to an empty file.
+		// The environment variables to be used by the daemon are instead passed
+		// via cmd.Env.
+		cmd.Env = append(cmd.Env, "TS_DEBUG_ENV_FILE="+n.writeBlankEnvFile())
+		setNewProcessGroup(cmd)
+	} else {
 		pr, pw, err := os.Pipe()
 		if err != nil {
 			t.Fatal(err)
@@ -931,6 +1022,7 @@ func (n *TestNode) StartDaemonAsIPNGOOS(ipnGOOS string) *Daemon {
 	t.Cleanup(func() { cmd.Process.Kill() })
 	return &Daemon{
 		Process: cmd.Process,
+		node:    n,
 	}
 }
 

--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -89,8 +89,7 @@ func TestTUNMode(t *testing.T) {
 	tstest.RequireRoot(t)
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
-	env.tunMode = true
-	n1 := NewTestNode(t, env)
+	n1 := NewTestNode(t, env, TUNMode(true))
 	d1 := n1.StartDaemon()
 
 	n1.AwaitResponding()
@@ -877,9 +876,6 @@ func TestConfigFileAuthKey(t *testing.T) {
 }
 
 func TestTwoNodes(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
-	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 
@@ -918,10 +914,11 @@ func TestTwoNodes(t *testing.T) {
 		os.WriteFile("n2.log", cleanLog(n2), 0666)
 	})
 
-	n1Socks := n1.AwaitSocksAddr(n1SocksAddrCh)
-	n2Socks := n1.AwaitSocksAddr(n2SocksAddrCh)
-	t.Logf("node1 SOCKS5 addr: %v", n1Socks)
-	t.Logf("node2 SOCKS5 addr: %v", n2Socks)
+	if runtime.GOOS != "windows" {
+		// TODO(yaruk): the service node has no stderr to scrape the address from; see #20443.
+		t.Logf("node1 SOCKS5 addr: %v", n1.AwaitSocksAddr(n1SocksAddrCh))
+		t.Logf("node2 SOCKS5 addr: %v", n1.AwaitSocksAddr(n2SocksAddrCh))
+	}
 
 	n1.AwaitListening()
 	t.Logf("n1 is listening")
@@ -965,9 +962,6 @@ func TestTwoNodes(t *testing.T) {
 // tests two nodes where the first gets a incremental MapResponse (with only
 // PeersRemoved set) saying that the second node disappeared.
 func TestIncrementalMapUpdatePeersRemoved(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
-	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 
@@ -1055,9 +1049,6 @@ func TestIncrementalMapUpdatePeersRemoved(t *testing.T) {
 // This covers VIP additions at runtime, where the VIP route is not reachable
 // before the map mutation but is reachable over TSMP afterward.
 func TestIncrementalMapUpdatePeerAllowedIPsReachability(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
-	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 
@@ -1353,14 +1344,12 @@ func TestOneNodeUpWindowsStyle(t *testing.T) {
 // jailed node cannot initiate connections to the other node however the other
 // node can initiate connections to the jailed node.
 func TestClientSideJailing(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
-	}
 	flakytest.Mark(t, "https://github.com/tailscale/tailscale/issues/17419")
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 	registerNode := func() (*TestNode, key.NodePublic) {
-		n := NewTestNode(t, env)
+		// The dial being tested only reaches the listener in userspace networking mode.
+		n := NewTestNode(t, env, TUNMode(false))
 		n.StartDaemon()
 		n.AwaitListening()
 		n.MustUp()
@@ -1468,9 +1457,6 @@ func TestClientSideJailing(t *testing.T) {
 // TestNATPing creates two nodes, n1 and n2, sets up masquerades for both and
 // tries to do bi-directional pings between them.
 func TestNATPing(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
-	}
 	flakytest.Mark(t, "https://github.com/tailscale/tailscale/issues/12169")
 	tstest.Parallel(t)
 	for _, v6 := range []bool{false, true} {
@@ -1599,9 +1585,6 @@ func TestNATPing(t *testing.T) {
 }
 
 func TestLogoutRemovesAllPeers(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
-	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 	// Spin up some nodes.
@@ -1800,8 +1783,7 @@ func testAutoUpdateDefaults(t *testing.T, useCap bool) {
 func TestDNSOverTCPIntervalResolver(t *testing.T) {
 	tstest.RequireRoot(t)
 	env := NewTestEnv(t)
-	env.tunMode = true
-	n1 := NewTestNode(t, env)
+	n1 := NewTestNode(t, env, TUNMode(true))
 	d1 := n1.StartDaemon()
 
 	n1.AwaitResponding()
@@ -1870,11 +1852,10 @@ func TestNetstackTCPLoopback(t *testing.T) {
 	tstest.RequireRoot(t)
 
 	env := NewTestEnv(t)
-	env.tunMode = true
 	loopbackPort := 5201
 	env.loopbackPort = &loopbackPort
 	loopbackPortStr := strconv.Itoa(loopbackPort)
-	n1 := NewTestNode(t, env)
+	n1 := NewTestNode(t, env, TUNMode(true))
 	d1 := n1.StartDaemon()
 
 	n1.AwaitResponding()
@@ -2009,10 +1990,9 @@ func TestNetstackUDPLoopback(t *testing.T) {
 	tstest.RequireRoot(t)
 
 	env := NewTestEnv(t)
-	env.tunMode = true
 	loopbackPort := 5201
 	env.loopbackPort = &loopbackPort
-	n1 := NewTestNode(t, env)
+	n1 := NewTestNode(t, env, TUNMode(true))
 	d1 := n1.StartDaemon()
 
 	n1.AwaitResponding()
@@ -2211,9 +2191,6 @@ func TestEncryptStateMigration(t *testing.T) {
 // relay between all 3 nodes, and "tailscale debug peer-relay-sessions" returns
 // expected values.
 func TestPeerRelayPing(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
-	}
 	flakytest.Mark(t, "https://github.com/tailscale/tailscale/issues/17251")
 	tstest.Parallel(t)
 
@@ -2354,9 +2331,6 @@ func TestPeerRelayPing(t *testing.T) {
 }
 
 func TestC2NDebugNetmap(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
-	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t, ConfigureControl(func(s *testcontrol.Server) {
 		s.CollectServices = opt.False
@@ -2495,13 +2469,10 @@ func TestC2NDebugNetmap(t *testing.T) {
 }
 
 func TestTailnetLock(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
-	}
 	// If you run `tailscale lock log` on a node where Tailnet Lock isn't
 	// enabled, you get an error explaining that.
 	t.Run("log-when-not-enabled", func(t *testing.T) {
-		t.Parallel()
+		tstest.Parallel(t)
 
 		env := NewTestEnv(t)
 		n1 := NewTestNode(t, env)
@@ -2538,7 +2509,7 @@ func TestTailnetLock(t *testing.T) {
 	// the signed nodes can talk to each other but the unsigned node cannot
 	// talk to anybody.
 	t.Run("node-connectivity", func(t *testing.T) {
-		t.Parallel()
+		tstest.Parallel(t)
 
 		env := NewTestEnv(t)
 		env.Control.DefaultNodeCapabilities = &tailcfg.NodeCapMap{
@@ -2613,7 +2584,7 @@ func TestTailnetLock(t *testing.T) {
 	t.Run("no-keys-is-error", func(t *testing.T) {
 		for _, verb := range []string{"add", "remove", "revoke-keys"} {
 			t.Run(verb, func(t *testing.T) {
-				t.Parallel()
+				tstest.Parallel(t)
 
 				env := NewTestEnv(t)
 				n1 := NewTestNode(t, env)
@@ -2639,12 +2610,10 @@ func TestTailnetLock(t *testing.T) {
 }
 
 func TestNodeWithBadStateFile(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("service harness can't seed a corrupt state file before start; see #20750")
-	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
-	n1 := NewTestNode(t, env)
+	// A userspace node keeps its state in the test's temp dir, where the corrupt file can be seeded.
+	n1 := NewTestNode(t, env, TUNMode(false))
 	if err := os.WriteFile(n1.stateFile, []byte("bad json"), 0644); err != nil {
 		t.Fatal(err)
 	}

--- a/tstest/integration/service_notwindows.go
+++ b/tstest/integration/service_notwindows.go
@@ -6,7 +6,7 @@
 package integration
 
 // Non-Windows stubs for the Windows service backend; never called, since
-// windowsService is only set on Windows.
+// callers are guarded by runtime.GOOS == "windows".
 
 func (n *TestNode) startWindowsServiceDaemon() *Daemon {
 	n.env.t.Fatal("Windows service daemon is only supported on Windows")

--- a/tstest/integration/service_windows.go
+++ b/tstest/integration/service_windows.go
@@ -47,20 +47,27 @@ func (n *TestNode) startWindowsServiceDaemon() *Daemon {
 	if out, err := exec.CommandContext(t.Context(), n.env.daemon, "install-system-daemon").CombinedOutput(); err != nil {
 		t.Fatalf("install-system-daemon: %v\n%s", err, out)
 	}
-	// Teardown (LIFO): stop, uninstall, then wipe state for the next test.
+	var proc *os.Process
+	// Teardown: stop, wait for the process to exit so it releases the files below,
+	// uninstall, then wipe state for the next test.
 	t.Cleanup(func() {
 		n.stopService()
+		if proc != nil {
+			proc.Wait()
+		}
 		n.uninstallService()
 		n.cleanupServiceState()
 	})
 
-	n.startService()
+	proc = n.startService()
 	n.waitServiceReady(90 * time.Second)
-	return &Daemon{svc: n}
+	return &Daemon{node: n, svc: n, Process: proc}
 }
 
-// startService starts the service and waits for the SCM to report it Running.
-func (n *TestNode) startService() {
+// startService starts the service, waits for the SCM to report it Running, and
+// returns its process. Holding the process open keeps its PID from being reused,
+// so waiting on it can't wait on an unrelated process.
+func (n *TestNode) startService() *os.Process {
 	t := n.env.t
 	t.Helper()
 	m := connectSCM(t)
@@ -73,7 +80,12 @@ func (n *TestNode) startService() {
 	if err := s.Start(); err != nil {
 		t.Fatalf("start service %q: %v", serviceName, err)
 	}
-	n.waitServiceState(s, svc.Running, 60*time.Second)
+	st := n.waitServiceState(s, svc.Running, 60*time.Second)
+	p, err := os.FindProcess(int(st.ProcessId))
+	if err != nil {
+		t.Fatalf("open service process %d: %v", st.ProcessId, err)
+	}
+	return p
 }
 
 // stopService requests a stop and waits until the service is Stopped, failing
@@ -169,7 +181,7 @@ func (n *TestNode) waitServiceReady(timeout time.Duration) {
 }
 
 // waitServiceState polls s until it reaches want, failing the test on timeout.
-func (n *TestNode) waitServiceState(s *mgr.Service, want svc.State, timeout time.Duration) {
+func (n *TestNode) waitServiceState(s *mgr.Service, want svc.State, timeout time.Duration) svc.Status {
 	t := n.env.t
 	t.Helper()
 	deadline := time.Now().Add(timeout)
@@ -179,11 +191,12 @@ func (n *TestNode) waitServiceState(s *mgr.Service, want svc.State, timeout time
 			t.Fatalf("query service %q: %v", serviceName, err)
 		}
 		if st.State == want {
-			return
+			return st
 		}
 		time.Sleep(time.Second)
 	}
 	t.Fatalf("service %q did not reach state %d within %v", serviceName, want, timeout)
+	panic("unreachable")
 }
 
 // waitServiceGone polls until the service no longer exists.

--- a/tstest/integration/whois_test.go
+++ b/tstest/integration/whois_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"runtime"
 	"testing"
 	"time"
 
@@ -22,16 +21,14 @@ import (
 // netstack forwards the connection to localhost, and the listener
 // calls WhoIs on n2's LocalAPI to identify the remote peer as n1.
 func TestUserspaceWhoIsProxyMap(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("multiple nodes need the userspace-peer harness; see #20711")
-	}
 	tstest.Parallel(t)
 	env := NewTestEnv(t)
 
 	n1 := NewTestNode(t, env)
 	d1 := n1.StartDaemon()
 
-	n2 := NewTestNode(t, env)
+	// The WhoIs forwarding being tested only happens in userspace networking mode.
+	n2 := NewTestNode(t, env, TUNMode(false))
 	d2 := n2.StartDaemon()
 
 	n1.AwaitListening()

--- a/tstest/privileges_notwindows.go
+++ b/tstest/privileges_notwindows.go
@@ -1,0 +1,11 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !windows
+
+package tstest
+
+import "os"
+
+// hasSuperuserPrivileges reports whether the current process runs as root.
+func hasSuperuserPrivileges() bool { return os.Getuid() == 0 }

--- a/tstest/privileges_windows.go
+++ b/tstest/privileges_windows.go
@@ -1,0 +1,18 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build windows
+
+package tstest
+
+import "golang.org/x/sys/windows"
+
+// hasSuperuserPrivileges reports whether the current process is elevated.
+func hasSuperuserPrivileges() bool {
+	token, err := windows.OpenCurrentProcessToken()
+	if err != nil {
+		return false
+	}
+	defer token.Close()
+	return token.IsElevated()
+}

--- a/tstest/tstest.go
+++ b/tstest/tstest.go
@@ -12,7 +12,6 @@ package tstest
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"tailscale.com/envknob"
@@ -77,11 +76,12 @@ func Parallel(t interface{ Parallel() }) {
 	}
 }
 
-// RequireRoot skips the test if the current user is not root.
+// RequireRoot skips the test if the current process lacks superuser privileges,
+// meaning root on most platforms and an elevated process on Windows.
 func RequireRoot(tb testenv.TB) {
 	tb.Helper()
-	if os.Getuid() != 0 {
-		tb.Skip("skipping test; requires root")
+	if !hasSuperuserPrivileges() {
+		tb.Skip("skipping test; requires superuser privileges")
 	}
 }
 


### PR DESCRIPTION
Updates #20711

Follow-up to #20464 AND builds on #20565.
  
#20565 runs the Windows integration tests against the real service by default, but only single-node tests can run since a Windows host has room for exactly one service. Tests needing a second node are skipped.

This PR adds the peer harness: the first node in a test takes the service, and any additional node runs as a userspace networking child process. A test can also request a peer explicitly with `AsPeer()`, which `TestUserspaceWhoIsProxyMap` needs because the proxymap forwarding it tests only happens in userspace mode.

Also this PR Un-skips 7 tests: TestTwoNodes, TestIncrementalMapUpdatePeersRemoved, TestPeerCapMap, TestSetNodeCapMap, TestC2NDebugNetmap, TestUserspaceWhoIsProxyMap, and TestNodeWithBadStateFile.