### PR TITLE
cli: remove legacy funnel command

### DIFF
--- a/cmd/tailscale/cli/funnel.go
+++ b/cmd/tailscale/cli/funnel.go
@@ -7,11 +7,9 @@ package cli
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"net"
 	"strconv"
-	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"tailscale.com/ipn"
@@ -24,106 +22,7 @@ func init() {
 
 var funnelCmd = func() *ffcli.Command {
 	se := &serveEnv{lc: &localClient}
-	// previously used to serve legacy newFunnelCommand unless useWIPCode is true
-	// change is limited to make a revert easier and full cleanup to come after the release.
-	// TODO(tylersmalley): cleanup and removal of newFunnelCommand as of 2023-10-16
 	return newServeV2Command(se, funnel)
-}
-
-// newFunnelCommand returns a new "funnel" subcommand using e as its environment.
-// The funnel subcommand is used to turn on/off the Funnel service.
-// Funnel is off by default.
-// Funnel allows you to publish a 'tailscale serve' server publicly, open to the
-// entire internet.
-// newFunnelCommand shares the same serveEnv as the "serve" subcommand. See
-// newServeCommand and serve.go for more details.
-func newFunnelCommand(e *serveEnv) *ffcli.Command {
-	return &ffcli.Command{
-		Name:      "funnel",
-		ShortHelp: "Turn on/off Funnel service",
-		ShortUsage: strings.Join([]string{
-			"tailscale funnel <serve-port> {on|off}",
-			"tailscale funnel status [--json]",
-		}, "\n"),
-		LongHelp: strings.Join([]string{
-			"Funnel allows you to publish a 'tailscale serve'",
-			"server publicly, open to the entire internet.",
-			"",
-			"Turning off Funnel only turns off serving to the internet.",
-			"It does not affect serving to your tailnet.",
-		}, "\n"),
-		Exec: e.runFunnel,
-		Subcommands: []*ffcli.Command{
-			{
-				Name:       "status",
-				Exec:       e.runServeStatus,
-				ShortUsage: "tailscale funnel status [--json]",
-				ShortHelp:  "Show current serve/funnel status",
-				FlagSet: e.newFlags("funnel-status", func(fs *flag.FlagSet) {
-					fs.BoolVar(&e.json, "json", false, "output JSON")
-				}),
-			},
-		},
-	}
-}
-
-// runFunnel is the entry point for the "tailscale funnel" subcommand and
-// manages turning on/off funnel. Funnel is off by default.
-//
-// Note: funnel is only supported on single DNS name for now. (2022-11-15)
-func (e *serveEnv) runFunnel(ctx context.Context, args []string) error {
-	if len(args) != 2 {
-		return flag.ErrHelp
-	}
-
-	var on bool
-	switch args[1] {
-	case "on", "off":
-		on = args[1] == "on"
-	default:
-		return flag.ErrHelp
-	}
-	sc, err := e.lc.GetServeConfig(ctx)
-	if err != nil {
-		return err
-	}
-	if sc == nil {
-		sc = new(ipn.ServeConfig)
-	}
-
-	port64, err := strconv.ParseUint(args[0], 10, 16)
-	if err != nil {
-		return err
-	}
-	port := uint16(port64)
-
-	if on {
-		// Don't block from turning off existing Funnel if
-		// network configuration/capabilities have changed.
-		// Only block from starting new Funnels.
-		if err := e.verifyFunnelEnabled(ctx, port); err != nil {
-			return err
-		}
-	}
-
-	st, err := e.getLocalClientStatusWithoutPeers(ctx)
-	if err != nil {
-		return fmt.Errorf("getting client status: %w", err)
-	}
-	dnsName := strings.TrimSuffix(st.Self.DNSName, ".")
-	hp := ipn.HostPort(dnsName + ":" + strconv.Itoa(int(port)))
-	if on == sc.AllowFunnel[hp] {
-		printFunnelWarning(sc)
-		// Nothing to do.
-		return nil
-	}
-	sc.SetFunnel(dnsName, port, on)
-
-	if err := e.lc.SetServeConfig(ctx, sc); err != nil {
-		return err
-	}
-	printFunnelWarning(sc)
-	return nil
 }
 
 // verifyFunnelEnabled verifies that the self node is allowed to use Funnel.

--- a/cmd/tailscale/cli/serve_legacy.go
+++ b/cmd/tailscale/cli/serve_legacy.go
@@ -39,8 +39,6 @@ func init() {
 
 var serveCmd = func() *ffcli.Command {
 	se := &serveEnv{lc: &localClient}
-	// previously used to serve legacy newFunnelCommand unless useWIPCode is true
-	// change is limited to make a revert easier and full cleanup to come after the release.
 	// TODO(tylersmalley): cleanup and removal of newServeLegacyCommand as of 2023-10-16
 	return newServeV2Command(se, serve)
 }

--- a/cmd/tailscale/cli/serve_legacy_test.go
+++ b/cmd/tailscale/cli/serve_legacy_test.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/peterbourgon/ff/v3/ffcli"
 	"tailscale.com/client/local"
 	"tailscale.com/ipn"
 	"tailscale.com/ipn/ipnstate"
@@ -73,29 +72,6 @@ func TestServeConfigMutations(t *testing.T) {
 		_, _, s.line, _ = runtime.Caller(1)
 		steps = append(steps, s)
 	}
-
-	// funnel
-	add(step{reset: true})
-	add(step{
-		command: cmd("funnel 443 on"),
-		want:    &ipn.ServeConfig{AllowFunnel: map[ipn.HostPort]bool{"foo.test.ts.net:443": true}},
-	})
-	add(step{
-		command: cmd("funnel 443 on"),
-		want:    nil, // nothing to save
-	})
-	add(step{
-		command: cmd("funnel 443 off"),
-		want:    &ipn.ServeConfig{},
-	})
-	add(step{
-		command: cmd("funnel 443 off"),
-		want:    nil, // nothing to save
-	})
-	add(step{
-		command: cmd("funnel"),
-		wantErr: exactErr(flag.ErrHelp, "flag.ErrHelp"),
-	})
 
 	// https
 	add(step{reset: true})
@@ -508,53 +484,10 @@ func TestServeConfigMutations(t *testing.T) {
 			},
 		},
 	})
-	add(step{
-		command: cmd("funnel 443 on"),
-		want: &ipn.ServeConfig{
-			AllowFunnel: map[ipn.HostPort]bool{"foo.test.ts.net:443": true},
-			TCP:         map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}},
-			Web: map[ipn.HostPort]*ipn.WebServerConfig{
-				"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
-					"/": {Proxy: "http://127.0.0.1:3000"},
-				}},
-			},
-		},
-	})
-	add(step{ // serving on secondary port doesn't change funnel
+	add(step{ // serving on a secondary port preserves the primary handler
 		command: cmd("https:8443 /bar localhost:3001"),
 		want: &ipn.ServeConfig{
-			AllowFunnel: map[ipn.HostPort]bool{"foo.test.ts.net:443": true},
-			TCP:         map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}, 8443: {HTTPS: true}},
-			Web: map[ipn.HostPort]*ipn.WebServerConfig{
-				"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
-					"/": {Proxy: "http://127.0.0.1:3000"},
-				}},
-				"foo.test.ts.net:8443": {Handlers: map[string]*ipn.HTTPHandler{
-					"/bar": {Proxy: "http://127.0.0.1:3001"},
-				}},
-			},
-		},
-	})
-	add(step{ // turn funnel on for secondary port
-		command: cmd("funnel 8443 on"),
-		want: &ipn.ServeConfig{
-			AllowFunnel: map[ipn.HostPort]bool{"foo.test.ts.net:443": true, "foo.test.ts.net:8443": true},
-			TCP:         map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}, 8443: {HTTPS: true}},
-			Web: map[ipn.HostPort]*ipn.WebServerConfig{
-				"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
-					"/": {Proxy: "http://127.0.0.1:3000"},
-				}},
-				"foo.test.ts.net:8443": {Handlers: map[string]*ipn.HTTPHandler{
-					"/bar": {Proxy: "http://127.0.0.1:3001"},
-				}},
-			},
-		},
-	})
-	add(step{ // turn funnel off for primary port 443
-		command: cmd("funnel 443 off"),
-		want: &ipn.ServeConfig{
-			AllowFunnel: map[ipn.HostPort]bool{"foo.test.ts.net:8443": true},
-			TCP:         map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}, 8443: {HTTPS: true}},
+			TCP: map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}, 8443: {HTTPS: true}},
 			Web: map[ipn.HostPort]*ipn.WebServerConfig{
 				"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
 					"/": {Proxy: "http://127.0.0.1:3000"},
@@ -568,8 +501,7 @@ func TestServeConfigMutations(t *testing.T) {
 	add(step{ // remove secondary port
 		command: cmd("https:8443 /bar off"),
 		want: &ipn.ServeConfig{
-			AllowFunnel: map[ipn.HostPort]bool{"foo.test.ts.net:8443": true},
-			TCP:         map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}},
+			TCP: map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}},
 			Web: map[ipn.HostPort]*ipn.WebServerConfig{
 				"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
 					"/": {Proxy: "http://127.0.0.1:3000"},
@@ -580,8 +512,7 @@ func TestServeConfigMutations(t *testing.T) {
 	add(step{ // start a tcp forwarder on 8443
 		command: cmd("tcp:8443 tcp://localhost:5432"),
 		want: &ipn.ServeConfig{
-			AllowFunnel: map[ipn.HostPort]bool{"foo.test.ts.net:8443": true},
-			TCP:         map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}, 8443: {TCPForward: "127.0.0.1:5432"}},
+			TCP: map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}, 8443: {TCPForward: "127.0.0.1:5432"}},
 			Web: map[ipn.HostPort]*ipn.WebServerConfig{
 				"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
 					"/": {Proxy: "http://127.0.0.1:3000"},
@@ -592,21 +523,13 @@ func TestServeConfigMutations(t *testing.T) {
 	add(step{ // remove primary port http handler
 		command: cmd("https:443 / off"),
 		want: &ipn.ServeConfig{
-			AllowFunnel: map[ipn.HostPort]bool{"foo.test.ts.net:8443": true},
-			TCP:         map[uint16]*ipn.TCPPortHandler{8443: {TCPForward: "127.0.0.1:5432"}},
+			TCP: map[uint16]*ipn.TCPPortHandler{8443: {TCPForward: "127.0.0.1:5432"}},
 		},
 	})
 	add(step{ // remove tcp forwarder
 		command: cmd("tls-terminated-tcp:8443 off"),
-		want: &ipn.ServeConfig{
-			AllowFunnel: map[ipn.HostPort]bool{"foo.test.ts.net:8443": true},
-		},
-	})
-	add(step{ // turn off funnel
-		command: cmd("funnel 8443 off"),
 		want:    &ipn.ServeConfig{},
 	})
-
 	// tricky steps
 	add(step{reset: true})
 	add(step{ // a directory with a trailing slash mount point
@@ -713,15 +636,8 @@ func TestServeConfigMutations(t *testing.T) {
 			testStderr:  io.Discard,
 		}
 		lastCount := lc.setCount
-		var cmd *ffcli.Command
-		var args []string
-		if st.command[0] == "funnel" {
-			cmd = newFunnelCommand(e)
-			args = st.command[1:]
-		} else {
-			cmd = newServeLegacyCommand(e)
-			args = st.command
-		}
+		cmd := newServeLegacyCommand(e)
+		args := st.command
 		if cmd.FlagSet == nil {
 			cmd.FlagSet = flag.NewFlagSet(cmd.Name, flag.ContinueOnError)
 			cmd.FlagSet.SetOutput(Stdout)

--- a/cmd/tailscale/cli/serve_v2.go
+++ b/cmd/tailscale/cli/serve_v2.go
@@ -344,6 +344,10 @@ func (e *serveEnv) validateArgs(subcmd serveMode, args []string) error {
 		fmt.Fprint(e.stderr(), "\nPlease see https://tailscale.com/kb/1242/tailscale-serve for more information.\n")
 		return errHelpFunc(subcmd)
 	}
+	if subcmd == funnel && len(args) == 1 && args[0] == "on" {
+		fmt.Fprintln(e.stderr(), "Error: `on` is not a valid Funnel target. Use `tailscale funnel --bg <target>` instead.")
+		return errHelpFunc(subcmd)
+	}
 	if len(args) == 0 && e.tun {
 		return nil
 	}

--- a/cmd/tailscale/cli/serve_v2_test.go
+++ b/cmd/tailscale/cli/serve_v2_test.go
@@ -1834,6 +1834,19 @@ func TestIsLegacyInvocation(t *testing.T) {
 	}
 }
 
+func TestValidateFunnelArgsRejectsLegacyOnTarget(t *testing.T) {
+	var stderr bytes.Buffer
+	e := &serveEnv{testStderr: &stderr}
+
+	err := e.validateArgs(funnel, []string{"on"})
+	if err == nil {
+		t.Fatal("validateArgs unexpectedly accepted the legacy on target")
+	}
+	if got := stderr.String(); !strings.Contains(got, "tailscale funnel --bg <target>") {
+		t.Fatalf("error output did not explain the current syntax: %q", got)
+	}
+}
+
 func TestSetServe(t *testing.T) {
 	e := &serveEnv{}
 	magicDNSSuffix := "test.ts.net"


### PR DESCRIPTION
## What changed

I removed the unused legacy `newFunnelCommand` and `runFunnel` implementation. The production command already uses the current serve and funnel CLI, so keeping the old implementation only left a second behavior path in the tree and kept obsolete stateful tests alive.

I also made the remaining ambiguous `tailscale funnel ... on` form fail with a clear message pointing to `tailscale funnel --bg <target>`. The existing legacy invocation translation remains covered for the two-argument form, while the old command-specific tests were removed from the legacy test suite.

This follows the cleanup direction in #19803. The legacy `on` form does not silently create a tailnet-only configuration anymore.

## Validation

- `go test ./cmd/tailscale/cli -run 'TestIsLegacyInvocation|TestValidateFunnelArgsRejectsLegacyOnTarget|TestServeConfigMutations|TestServeDevConfigMutations' -count=1`
- `git diff --check`

Both passed locally. Let me know what you think.

Closes #19803