### PR TITLE
cmd/k8s-operator: enable IP forwarding without the sysctl binary

### DIFF
--- a/cmd/k8s-operator/deploy/manifests/proxy.yaml
+++ b/cmd/k8s-operator/deploy/manifests/proxy.yaml
@@ -15,7 +15,9 @@ spec:
           securityContext:
             privileged: true
           command: ["/bin/sh", "-c"]
-          args: [sysctl -w net.ipv4.ip_forward=1 && if sysctl net.ipv6.conf.all.forwarding; then sysctl -w net.ipv6.conf.all.forwarding=1; fi]
+          # Write to /proc/sys directly rather than shelling out to sysctl, which
+          # is not present in all base images (e.g. Red Hat's UBI).
+          args: ["echo 1 > /proc/sys/net/ipv4/ip_forward && if [ -e /proc/sys/net/ipv6/conf/all/forwarding ]; then echo 1 > /proc/sys/net/ipv6/conf/all/forwarding; fi"]
       containers:
         - name: tailscale
           resources:

--- a/cmd/k8s-operator/testutils_test.go
+++ b/cmd/k8s-operator/testutils_test.go
@@ -250,7 +250,7 @@ func expectedSTS(t *testing.T, cl client.Client, opts configOpts) *appsv1.Statef
 							Name:    "sysctler",
 							Image:   "tailscale/tailscale",
 							Command: []string{"/bin/sh", "-c"},
-							Args:    []string{"sysctl -w net.ipv4.ip_forward=1 && if sysctl net.ipv6.conf.all.forwarding; then sysctl -w net.ipv6.conf.all.forwarding=1; fi"},
+							Args:    []string{"echo 1 > /proc/sys/net/ipv4/ip_forward && if [ -e /proc/sys/net/ipv6/conf/all/forwarding ]; then echo 1 > /proc/sys/net/ipv6/conf/all/forwarding; fi"},
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: new(true),
 							},


### PR DESCRIPTION
The sysctler init container shells out to sysctl to turn on IP forwarding for non-userspace proxies. That binary ships in the procps-ng package, which Alpine has but Red Hat's UBI does not, so on UBI the init container exits 127 and every proxy Pod is stuck in PodInitializing and never registers a device.

Updates: https://github.com/tailscale/corp/issues/45981
Updates: https://github.com/tailscale/corp/issues/44443