### PR TITLE
net/portmapper: avoid leaking permanent UPnP mappings

### DIFF
--- a/net/portmapper/select_test.go
+++ b/net/portmapper/select_test.go
@@ -173,7 +173,7 @@ func TestSelectBestService(t *testing.T) {
 			loc := mustParseURL(igd.ts.URL)
 			rootDev := mustParseRootDev(t, rootDesc, loc)
 
-			svc, err := selectBestService(ctx, t.Logf, rootDev, loc)
+			svc, _, err := selectBestService(ctx, t.Logf, rootDev, loc)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/net/portmapper/upnp.go
+++ b/net/portmapper/upnp.go
@@ -287,13 +287,14 @@ func getUPnPRootDevice(ctx context.Context, logf logger.Logf, debug DebugKnobs, 
 }
 
 // selectBestService picks the "best" service from the given UPnP root device
-// to use to create a port mapping. It may return (nil, nil) if no supported
-// service was found in the provided *goupnp.RootDevice.
+// to use to create a port mapping. If selecting the service required querying
+// its external IP, it also returns that address. It may return a nil client if
+// no supported service was found in the provided *goupnp.RootDevice.
 //
 // loc is the parsed location that was used to fetch the given RootDevice.
 //
 // The provided ctx is not retained in the returned upnpClient.
-func selectBestService(ctx context.Context, logf logger.Logf, root *goupnp.RootDevice, loc *url.URL) (client upnpClient, err error) {
+func selectBestService(ctx context.Context, logf logger.Logf, root *goupnp.RootDevice, loc *url.URL) (client upnpClient, externalIP netip.Addr, err error) {
 	method := "none"
 	defer func() {
 		if client == nil {
@@ -339,12 +340,12 @@ func selectBestService(ctx context.Context, logf logger.Logf, root *goupnp.RootD
 	// If we have no clients, then return right now; if we only have one,
 	// just select and return it.
 	if len(clients) == 0 {
-		return nil, nil
+		return nil, netip.Addr{}, nil
 	}
 	if len(clients) == 1 {
 		method = "single"
 		metricUPnPSelectSingle.Add(1)
-		return clients[0], nil
+		return clients[0], netip.Addr{}, nil
 	}
 
 	metricUPnPSelectMultiple.Add(1)
@@ -395,7 +396,7 @@ func selectBestService(ctx context.Context, logf logger.Logf, root *goupnp.RootD
 		if !externalIP.IsPrivate() {
 			method = "ext-public"
 			metricUPnPSelectExternalPublic.Add(1)
-			return svc, nil
+			return svc, externalIP, nil
 		}
 	}
 
@@ -415,11 +416,11 @@ func selectBestService(ctx context.Context, logf logger.Logf, root *goupnp.RootD
 			if hasExtIP {
 				method = "ext-private"
 				metricUPnPSelectExternalPrivate.Add(1)
-				return svc, nil
+				return svc, externalIPs[svc], nil
 			} else if try == 1 {
 				method = "up"
 				metricUPnPSelectUp.Add(1)
-				return svc, nil
+				return svc, netip.Addr{}, nil
 			}
 		}
 	}
@@ -427,7 +428,7 @@ func selectBestService(ctx context.Context, logf logger.Logf, root *goupnp.RootD
 	// Nothing is up, but we have something (length of clients checked
 	// above); just return the first one.
 	metricUPnPSelectNone.Add(1)
-	return clients[0], nil
+	return clients[0], netip.Addr{}, nil
 }
 
 // serviceIsConnected returns whether a given UPnP service is connected, based
@@ -602,7 +603,7 @@ func (c *Client) tryUPnPPortmapWithDevice(
 	// Select the best mapping service from the given root device. This
 	// makes network requests, and can vary from mapping to mapping if the
 	// upstream device's connection status changes.
-	client, err := selectBestService(ctx, c.logf, rootDev, loc)
+	client, externalIP, err := selectBestService(ctx, c.logf, rootDev, loc)
 	if err != nil {
 		return netip.AddrPort{}, nil, err
 	}
@@ -619,6 +620,35 @@ func (c *Client) tryUPnPPortmapWithDevice(
 		})
 
 		return netip.AddrPort{}, nil, fmt.Errorf("no supported UPnP clients")
+	}
+
+	// Obtain and validate the external IP before creating the mapping. In
+	// particular, MikroTik only supports permanent leases, so forgetting a
+	// successfully-created mapping after a later request fails leaks the rule
+	// forever and each retry creates another one.
+	if !externalIP.IsValid() {
+		extIP, err := client.GetExternalIPAddressCtx(ctx)
+		c.vlogf("client.GetExternalIPAddress: %v, %v", extIP, err)
+		if err != nil {
+			return netip.AddrPort{}, nil, err
+		}
+		externalIP, err = netip.ParseAddr(extIP)
+		if err != nil {
+			return netip.AddrPort{}, nil, err
+		}
+	}
+
+	// Do a bit of validation on the external IP; we've seen cases where
+	// UPnP devices return the public IP 0.0.0.0, which obviously doesn't
+	// work as an endpoint.
+	//
+	// See: https://github.com/tailscale/corp/issues/23538
+	if externalIP.IsUnspecified() {
+		c.logf("UPnP returned unspecified external IP %v", externalIP)
+		return netip.AddrPort{}, nil, fmt.Errorf("UPnP returned unspecified external IP")
+	} else if externalIP.IsLoopback() {
+		c.logf("UPnP returned loopback external IP %v", externalIP)
+		return netip.AddrPort{}, nil, fmt.Errorf("UPnP returned loopback external IP")
 	}
 
 	// Start by trying to make a temporary lease with a duration.
@@ -660,30 +690,6 @@ func (c *Client) tryUPnPPortmapWithDevice(
 	}
 	if err != nil {
 		return netip.AddrPort{}, nil, err
-	}
-
-	// TODO cache this ip somewhere?
-	extIP, err := client.GetExternalIPAddressCtx(ctx)
-	c.vlogf("client.GetExternalIPAddress: %v, %v", extIP, err)
-	if err != nil {
-		return netip.AddrPort{}, nil, err
-	}
-	externalIP, err := netip.ParseAddr(extIP)
-	if err != nil {
-		return netip.AddrPort{}, nil, err
-	}
-
-	// Do a bit of validation on the external IP; we've seen cases where
-	// UPnP devices return the public IP 0.0.0.0, which obviously doesn't
-	// work as an endpoint.
-	//
-	// See: https://github.com/tailscale/corp/issues/23538
-	if externalIP.IsUnspecified() {
-		c.logf("UPnP returned unspecified external IP %v", externalIP)
-		return netip.AddrPort{}, nil, fmt.Errorf("UPnP returned unspecified external IP")
-	} else if externalIP.IsLoopback() {
-		c.logf("UPnP returned loopback external IP %v", externalIP)
-		return netip.AddrPort{}, nil, fmt.Errorf("UPnP returned loopback external IP")
 	}
 
 	return netip.AddrPortFrom(externalIP, newPort), client, nil

--- a/net/portmapper/upnp_test.go
+++ b/net/portmapper/upnp_test.go
@@ -517,7 +517,7 @@ func TestGetUPnPClient(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			c, err := selectBestService(ctx, logBuf.Logf, dev, loc)
+			c, _, err := selectBestService(ctx, logBuf.Logf, dev, loc)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -714,6 +714,61 @@ func TestGetUPnPPortMapping_LeaseDuration(t *testing.T) {
 			}
 			t.Logf("external IP: %v", ext)
 		})
+	}
+}
+
+func TestGetUPnPPortMapping_MikroTikDoesNotQueryExternalIPAfterMapping(t *testing.T) {
+	igd, err := NewTestIGD(t, TestIGDOptions{UPnP: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer igd.Close()
+
+	var externalIPRequests atomic.Int32
+	handlers := map[string]any{
+		"AddPortMapping": func(body []byte) (int, string) {
+			var req struct {
+				LeaseDuration string `xml:"NewLeaseDuration"`
+			}
+			if err := xml.Unmarshal(body, &req); err != nil {
+				t.Errorf("bad request: %v", err)
+				return http.StatusBadRequest, "bad request"
+			}
+			if req.LeaseDuration != "0" {
+				return http.StatusOK, testAddPortMappingPermanentLease
+			}
+			return http.StatusOK, testAddPortMappingResponse
+		},
+		"GetExternalIPAddress": func([]byte) (int, string) {
+			if externalIPRequests.Add(1) > 1 {
+				return http.StatusInternalServerError, "too many requests"
+			}
+			return http.StatusOK, testGetExternalIPAddressResponse
+		},
+		"GetStatusInfo":     testGetStatusInfoResponse,
+		"DeletePortMapping": "",
+	}
+	igd.SetUPnPHandler(&upnpServer{
+		t:    t,
+		Desc: mikrotikRootDescXML,
+		Control: map[string]map[string]any{
+			"/upnp/control/yomkmsnooi/wanipconn-1": handlers,
+		},
+	})
+
+	ctx := context.Background()
+	c := newTestClient(t, igd, nil)
+	mustProbeUPnP(t, ctx, c)
+
+	gw, myIP, ok := c.gatewayAndSelfIP()
+	if !ok {
+		t.Fatal("could not get gateway and self IP")
+	}
+	if _, ok := c.getUPnPPortMapping(ctx, gw, netip.AddrPortFrom(myIP, 12345), 0); !ok {
+		t.Fatal("could not get UPnP port mapping")
+	}
+	if got := externalIPRequests.Load(); got != 1 {
+		t.Fatalf("GetExternalIPAddress requests = %d, want 1", got)
 	}
 }
 
@@ -920,8 +975,12 @@ func TestGetUPnPPortMapping_Invalid(t *testing.T) {
 			defer igd.Close()
 
 			// This is a very basic fake UPnP server handler.
+			var addPortMappingRequests atomic.Int32
 			handlers := map[string]any{
-				"AddPortMapping":       testAddPortMappingResponse,
+				"AddPortMapping": func([]byte) (int, string) {
+					addPortMappingRequests.Add(1)
+					return http.StatusOK, testAddPortMappingResponse
+				},
 				"GetExternalIPAddress": makeGetExternalIPAddressResponse(responseAddr),
 				"GetStatusInfo":        testGetStatusInfoResponse,
 				"DeletePortMapping":    "", // Do nothing for test
@@ -952,6 +1011,9 @@ func TestGetUPnPPortMapping_Invalid(t *testing.T) {
 			}
 			if ext.IsValid() {
 				t.Fatalf("expected no external address; got %v", ext)
+			}
+			if got := addPortMappingRequests.Load(); got != 0 {
+				t.Fatalf("AddPortMapping requests = %d, want 0", got)
 			}
 		})
 	}


### PR DESCRIPTION
MikroTik routers only support permanent UPnP leases. Previously, a mapping attempt could proceed as follows:

  1. Add a temporary mapping.
  2. Retry with a permanent mapping after error 725.
  3. Successfully create the permanent mapping.
  4. Fail to query the external IP.
  5. Forget the mapping and retry with another random port.

Each retry left another permanent NAT rule behind.

To prevent this, query and validate the external IP before creating the mapping. When service selection has already queried the address, reuse that result. This leaves no fallible network request after AddPortMapping succeeds.

I tested this on my own MikroTik router running RouterOS 7.23.2. A successful mapping queried the external IP before creating the permanent rule, and a forced external-IP failure created no rule.

Updates #10602

cc @sfllaw who encouraged me to actually try fixing this myself at GopherCon :smile: 