### PR TITLE
net/dns/resolver: reach netstack-only upstreams over UDP

### DIFF
--- a/net/dns/resolver/forwarder.go
+++ b/net/dns/resolver/forwarder.go
@@ -793,19 +793,8 @@ func (f *forwarder) sendUDP(ctx context.Context, fq *forwardQuery, rr resolverAn
 	metricDNSFwdUDP.Add(1)
 	ctx = sockstats.WithSockStats(ctx, sockstats.LabelDNSForwarderUDP, f.logf)
 
-	ln, err := f.packetListener(ipp.Addr())
+	conn, err := f.dialUDP(ctx, ipp)
 	if err != nil {
-		return nil, err
-	}
-
-	// Specify the exact UDP family to work around https://github.com/golang/go/issues/52264
-	udpFam := "udp4"
-	if ipp.Addr().Is6() {
-		udpFam = "udp6"
-	}
-	conn, err := ln.ListenPacket(ctx, udpFam, ":0")
-	if err != nil {
-		f.logf("ListenPacket failed: %v", err)
 		return nil, err
 	}
 	defer conn.Close()
@@ -886,6 +875,58 @@ func (f *forwarder) sendUDP(ctx context.Context, fq *forwardQuery, rr resolverAn
 	clampEDNSSize(out, maxResponseBytes)
 	metricDNSFwdUDPSuccess.Add(1)
 	return out, nil
+}
+
+// dialUDP returns a UDP conn to ipp, over netstack if that's the only way to
+// reach it. Same dispatch as [tsdial.Dialer.dialOneUser].
+func (f *forwarder) dialUDP(ctx context.Context, ipp netip.AddrPort) (nettype.PacketConn, error) {
+	if f.dialer.UseNetstackForIP != nil && f.dialer.UseNetstackForIP(ipp.Addr()) {
+		if f.dialer.NetstackDialUDP == nil {
+			return nil, errors.New("dialer not initialized correctly: no NetstackDialUDP")
+		}
+		conn, err := f.dialer.NetstackDialUDP(ctx, ipp)
+		if err != nil {
+			return nil, err
+		}
+		return &netstackPacketConn{Conn: conn, peer: ipp}, nil
+	}
+
+	ln, err := f.packetListener(ipp.Addr())
+	if err != nil {
+		return nil, err
+	}
+
+	// Name the family explicitly: netns looks for a "6" in this string to
+	// choose between IP_BOUND_IF and IPV6_BOUND_IF on macOS, and "udp" would
+	// give a v6 socket bound with the v4 option.
+	udpFam := "udp4"
+	if ipp.Addr().Is6() {
+		udpFam = "udp6"
+	}
+	conn, err := ln.ListenPacket(ctx, udpFam, ":0")
+	if err != nil {
+		f.logf("ListenPacket failed: %v", err)
+		return nil, err
+	}
+	return conn, nil
+}
+
+// netstackPacketConn presents a conn already connected to peer as a
+// [nettype.PacketConn].
+type netstackPacketConn struct {
+	net.Conn
+	peer netip.AddrPort
+}
+
+func (c *netstackPacketConn) WriteToUDPAddrPort(b []byte, _ netip.AddrPort) (int, error) {
+	return c.Write(b)
+}
+
+// ReadFromUDPAddrPort returns how much of the datagram fit in b; gVisor drops
+// the rest without erroring, as a kernel socket does.
+func (c *netstackPacketConn) ReadFromUDPAddrPort(b []byte) (int, netip.AddrPort, error) {
+	n, err := c.Read(b)
+	return n, c.peer, err
 }
 
 var optDNSForwardUseRoutes = envknob.RegisterOptBool("TS_DEBUG_DNS_FORWARD_USE_ROUTES")

--- a/net/dns/resolver/forwarder_test.go
+++ b/net/dns/resolver/forwarder_test.go
@@ -1224,19 +1224,12 @@ func newNetstackDialer(tb testing.TB, netMon *netmon.Monitor, bus *eventbus.Bus,
 // tailnet.
 //
 // The two subtests send the same query to the same upstream and differ only in
-// the transport the forwarder picks. sendTCP dials through [tsdial.Dialer]
-// (getDialerType -> UserDial -> dialOneUser), which consults UseNetstackForIP;
-// sendUDP goes straight to a host-stack socket via packetListener and never
-// consults the dialer at all. So TCP passes and UDP fails, and the difference
-// between the two is the whole defect.
+// the transport the forwarder picks; both must consult the dialer, so each
+// asserts on the netstack dial hook. The UDP subtest also bounds elapsed by
+// udpRaceTimeout, since a regression that silently falls back to TCP still
+// produces the right bytes, just two seconds late.
 //
-// Note that this test constructs only a [tsdial.Dialer]. It does not import
-// tsnet, which is why the UDP failure is attributable to the forwarder rather
-// than to tsnet: any userspace networking configuration hits it, including
-// tailscaled --tun=userspace-networking.
-//
-// The UDP subtest is skipped rather than left failing so CI stays green; drop
-// the skip to see the bug. See tailscale/tailscale#20314.
+// See tailscale/tailscale#20314.
 func TestForwarderNetstackUpstream(t *testing.T) {
 	const domain = "netstack-upstream.example.com."
 	request := makeTestRequest(t, domain, dns.TypeA, 0)
@@ -1244,10 +1237,6 @@ func TestForwarderNetstackUpstream(t *testing.T) {
 
 	for _, family := range []string{"tcp", "udp"} {
 		t.Run(family, func(t *testing.T) {
-			if family == "udp" {
-				t.Skip("known failure: sendUDP ignores the netstack dialer; see https://github.com/tailscale/tailscale/issues/20314")
-			}
-
 			var sawUDP, sawTCP atomic.Bool
 			port := runDNSServer(t, nil, response, func(isTCP bool, gotRequest []byte) {
 				if isTCP {
@@ -1321,6 +1310,181 @@ func TestForwarderNetstackUpstream(t *testing.T) {
 				}
 			} else if dials.tcp.Load() == 0 {
 				t.Errorf("forwarder never dialed TCP via netstack")
+			}
+		})
+	}
+}
+
+// TestForwarderNetstackUpstreamTruncated checks that an oversized response
+// from an upstream reached through netstack gets the TC flag, the same as one
+// from a host-stack socket.
+func TestForwarderNetstackUpstreamTruncated(t *testing.T) {
+	const domain = "large-netstack-upstream.example.com."
+	_, largeResponse := makeLargeResponse(t, domain)
+
+	// Advertise an EDNS buffer of maxResponseBytes, so that the TC flag can
+	// only come from read truncation and not from checkResponseSizeAndSetTC
+	// enforcing a smaller limit.
+	request := makeTestRequest(t, domain, dns.TypeA, maxResponseBytes)
+
+	var sawUDP, sawTCP atomic.Bool
+	port := runDNSServer(t, nil, largeResponse, func(isTCP bool, gotRequest []byte) {
+		if isTCP {
+			sawTCP.Store(true)
+		} else {
+			sawUDP.Store(true)
+		}
+		if !bytes.Equal(request, gotRequest) {
+			t.Errorf("invalid request\ngot:  %+v\nwant: %+v", gotRequest, request)
+		}
+	})
+	peer := netip.AddrPortFrom(netip.MustParseAddr("127.0.0.1"), port)
+
+	logf := tstest.WhileTestRunningLogger(t)
+	bus := eventbustest.NewBus(t)
+	netMon, err := netmon.New(bus, logf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer netMon.Close()
+
+	dialer, dials := newNetstackDialer(t, netMon, bus, peer)
+	fwd := newForwarder(logf, netMon, nil, dialer, health.NewTracker(bus), nil)
+	fwd.verboseFwd = true
+	// Without this the forwarder retries over TCP and the client gets the
+	// whole response, as in [TestForwarderTCPFallbackDisabled].
+	setupForwarderWithTCPRetriesDisabled()(fwd)
+
+	rpkt := packet{
+		bs:     request,
+		family: "udp",
+		addr:   netip.MustParseAddrPort("127.0.0.1:12345"),
+	}
+	rchan := make(chan packet, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := fwd.forwardWithDestChan(ctx, rpkt, rchan,
+		resolverAndDelay{name: &dnstype.Resolver{Addr: netstackUpstream.String()}}); err != nil {
+		t.Fatalf("forwardWithDestChan: %v", err)
+	}
+	var got []byte
+	select {
+	case res := <-rchan:
+		got = res.bs
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for response: %v", ctx.Err())
+	}
+	t.Logf("netstack dials udp=%d tcp=%d; upstream saw udp=%v tcp=%v",
+		dials.udp.Load(), dials.tcp.Load(), sawUDP.Load(), sawTCP.Load())
+
+	want := append([]byte(nil), largeResponse[:maxResponseBytes]...)
+	setTCFlagInPacket(want)
+	if !bytes.Equal(got, want) {
+		t.Errorf("invalid response\ngot  (%d): %+v\nwant (%d): %+v", len(got), got, len(want), want)
+	}
+
+	if dials.udp.Load() != 1 {
+		t.Errorf("netstack UDP dials = %d, want 1", dials.udp.Load())
+	}
+	if dials.tcp.Load() != 0 {
+		t.Errorf("netstack TCP dials = %d, want 0 (TCP retries are disabled)", dials.tcp.Load())
+	}
+}
+
+// TestDialUDPDispatch checks that dialUDP uses netstack for an upstream
+// UseNetstackForIP claims, and a host-stack socket for everything else.
+func TestDialUDPDispatch(t *testing.T) {
+	publicUpstream := netip.MustParseAddrPort("8.8.8.8:53")
+
+	tests := []struct {
+		name         string
+		useNetstack  func(netip.Addr) bool
+		noDialUDP    bool // leave NetstackDialUDP nil
+		upstream     netip.AddrPort
+		wantNetstack bool
+		wantErr      bool
+	}{
+		{
+			name:     "no_hooks",
+			upstream: netstackUpstream,
+		},
+		{
+			name:        "hook_declines_public_upstream",
+			useNetstack: func(ip netip.Addr) bool { return ip == netstackUpstream.Addr() },
+			upstream:    publicUpstream,
+		},
+		{
+			name:         "hook_claims_tailnet_upstream",
+			useNetstack:  func(ip netip.Addr) bool { return ip == netstackUpstream.Addr() },
+			upstream:     netstackUpstream,
+			wantNetstack: true,
+		},
+		{
+			name:        "hook_claims_upstream_but_no_dialer",
+			useNetstack: func(netip.Addr) bool { return true },
+			noDialUDP:   true,
+			upstream:    netstackUpstream,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logf := tstest.WhileTestRunningLogger(t)
+			bus := eventbustest.NewBus(t)
+			netMon, err := netmon.New(bus, logf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer netMon.Close()
+
+			// A UDP server that never replies: dialUDP only connects, so
+			// nothing here needs to answer.
+			pc, err := net.ListenPacket("udp4", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer pc.Close()
+
+			var dialedNetstack bool
+			dialer := &tsdial.Dialer{Logf: logf}
+			dialer.SetNetMon(netMon)
+			dialer.SetBus(bus)
+			dialer.UseNetstackForIP = tt.useNetstack
+			if !tt.noDialUDP {
+				dialer.NetstackDialUDP = func(ctx context.Context, dst netip.AddrPort) (net.Conn, error) {
+					dialedNetstack = true
+					var nd net.Dialer
+					return nd.DialContext(ctx, "udp4", pc.LocalAddr().String())
+				}
+			}
+			fwd := newForwarder(logf, netMon, nil, dialer, health.NewTracker(bus), nil)
+
+			conn, err := fwd.dialUDP(context.Background(), tt.upstream)
+			if tt.wantErr {
+				if err == nil {
+					conn.Close()
+					t.Fatal("dialUDP succeeded; want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("dialUDP: %v", err)
+			}
+			defer conn.Close()
+
+			if dialedNetstack != tt.wantNetstack {
+				t.Errorf("dialed via netstack = %v, want %v", dialedNetstack, tt.wantNetstack)
+			}
+			if _, ok := conn.(*netstackPacketConn); ok != tt.wantNetstack {
+				t.Errorf("conn is *netstackPacketConn = %v, want %v", ok, tt.wantNetstack)
+			}
+			// The netstack conn is already connected, so check that sendUDP's
+			// addressed write still reaches it. The host path writes to a real
+			// upstream, which may legitimately fail here.
+			if _, err := conn.WriteToUDPAddrPort([]byte("hello"), tt.upstream); err != nil && tt.wantNetstack {
+				t.Errorf("WriteToUDPAddrPort: %v", err)
 			}
 		})
 	}

--- a/tsnet/dns_split_test.go
+++ b/tsnet/dns_split_test.go
@@ -1,0 +1,178 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package tsnet
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	dns "golang.org/x/net/dns/dnsmessage"
+	"tailscale.com/tailcfg"
+	"tailscale.com/tstest"
+	"tailscale.com/types/dnstype"
+)
+
+// TestSplitDNSToTailnetResolverUDP resolves a split-DNS name over UDP from a
+// node in userspace networking mode, where the upstream resolver is another
+// tailnet node. Neither node has a tun device, so the upstream is reachable
+// only through netstack. See tailscale/tailscale#20314.
+func TestSplitDNSToTailnetResolverUDP(t *testing.T) {
+	lt := setupTwoClientTest(t, false) // netstack on both sides; no tun.
+
+	const domain = "e2e.split.example.com."
+	const suffix = "split.example.com."
+	const upstreamPort = 53
+	wantAddr := netip.MustParseAddr("100.101.102.103")
+
+	// This listener lives inside netstack on s1's tailnet address, so s2 can
+	// only reach it over the tailnet.
+	pc, err := lt.s1.ListenPacket("udp", net.JoinHostPort(lt.s1ip4.String(), fmt.Sprint(upstreamPort)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pc.Close()
+	go serveOneAnswerDNS(pc, wantAddr)
+
+	// Point split DNS for suffix at s1's tailnet address.
+	upstream := netip.AddrPortFrom(lt.s1ip4, upstreamPort)
+	if !lt.control.AddRawMapResponse(lt.s2.lb.NodeKey(), &tailcfg.MapResponse{
+		DNSConfig: &tailcfg.DNSConfig{
+			Proxied: true,
+			Routes: map[string][]*dnstype.Resolver{
+				suffix: {{Addr: upstream.String()}},
+			},
+		},
+	}) {
+		t.Fatal("AddRawMapResponse failed")
+	}
+
+	res := lt.s2.Sys().DNSManager.Get().Resolver()
+	if res == nil {
+		t.Fatal("s2 has no resolver")
+	}
+	query := mustDNSQuery(t, domain)
+	from := netip.MustParseAddrPort("127.0.0.1:12345")
+
+	// Until the split-DNS route lands the resolver answers immediately with
+	// an empty answer section, so wait it out before timing anything below.
+	if err := tstest.WaitFor(60*time.Second, func() error {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		resp, err := res.Query(ctx, query, "udp", from)
+		if err != nil {
+			return err
+		}
+		if _, err := firstAAnswer(resp); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("waiting for split-DNS route to %v to work: %v", upstream, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	start := time.Now()
+	resp, err := res.Query(ctx, query, "udp", from)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	got, err := firstAAnswer(resp)
+	if err != nil {
+		t.Fatalf("parsing response: %v", err)
+	}
+	if got != wantAddr {
+		t.Errorf("answer = %v, want %v", got, wantAddr)
+	}
+	t.Logf("split-DNS query to a tailnet resolver over netstack UDP took %v", elapsed)
+
+	// An answer is also correct if UDP blackholed and the TCP fallback
+	// supplied it, just late: that fallback can't fire before udpRaceTimeout
+	// (2s, net/dns/resolver), so bound the time as well as the bytes.
+	if elapsed >= 2*time.Second {
+		t.Errorf("query took %v (>= 2s): answered by the TCP fallback, not UDP", elapsed)
+	}
+}
+
+// serveOneAnswerDNS answers every A query on pc with addr, until pc is closed.
+func serveOneAnswerDNS(pc net.PacketConn, addr netip.Addr) {
+	buf := make([]byte, 1500)
+	for {
+		n, from, err := pc.ReadFrom(buf)
+		if err != nil {
+			return // listener closed
+		}
+		var p dns.Parser
+		hdr, err := p.Start(buf[:n])
+		if err != nil {
+			continue
+		}
+		q, err := p.Question()
+		if err != nil {
+			continue
+		}
+		b := dns.NewBuilder(nil, dns.Header{ID: hdr.ID, Response: true})
+		b.StartQuestions()
+		b.Question(q)
+		b.StartAnswers()
+		b.AResource(dns.ResourceHeader{
+			Name:  q.Name,
+			Class: dns.ClassINET,
+			TTL:   300,
+		}, dns.AResource{A: addr.As4()})
+		resp, err := b.Finish()
+		if err != nil {
+			continue
+		}
+		pc.WriteTo(resp, from)
+	}
+}
+
+// mustDNSQuery builds an A query for domain.
+func mustDNSQuery(tb testing.TB, domain string) []byte {
+	tb.Helper()
+	b := dns.NewBuilder(nil, dns.Header{RecursionDesired: true})
+	b.StartQuestions()
+	if err := b.Question(dns.Question{
+		Name:  dns.MustNewName(domain),
+		Type:  dns.TypeA,
+		Class: dns.ClassINET,
+	}); err != nil {
+		tb.Fatal(err)
+	}
+	query, err := b.Finish()
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return query
+}
+
+// firstAAnswer returns the address in resp's first answer record, or an error
+// if resp doesn't parse or has no A answer.
+func firstAAnswer(resp []byte) (netip.Addr, error) {
+	var p dns.Parser
+	if _, err := p.Start(resp); err != nil {
+		return netip.Addr{}, err
+	}
+	if err := p.SkipAllQuestions(); err != nil {
+		return netip.Addr{}, err
+	}
+	h, err := p.AnswerHeader()
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("no answer section: %w", err)
+	}
+	if h.Type != dns.TypeA {
+		return netip.Addr{}, fmt.Errorf("answer type = %v, want A", h.Type)
+	}
+	r, err := p.AResource()
+	if err != nil {
+		return netip.Addr{}, err
+	}
+	return netip.AddrFrom4(r.A), nil
+}


### PR DESCRIPTION
`sendTCP` dials through tsdial.Dialer and so honors UseNetstackForIP, but sendUDP opened a host-stack socket via packetListener and never consulted the dialer. In userspace networking mode (tsnet, or tailscaled `--tun=userspace-networking`) there is no tun device, so a split-DNS query to a tailnet resolver blackholed for the full udpRaceTimeout before the TCP fallback answered it.

Add `dialUDP`, which picks between the netstack dialer and the existing packetListener the same way `tsdial.Dialer.dialOneUser` does, and adapt the connected netstack conn to nettype.PacketConn. `sendUDP` is otherwise unchanged, so txid checks, SERVFAIL/REFUSED handling, TC flagging and EDNS clamping are identical on both paths.

Unskips the UDP subtest of `TestForwarderNetstackUpstream`, which now answers in ~300µs rather than 2s, and adds unit tests for the dispatch and for truncation over the netstack path. `TestSplitDNSToTailnetResolverUDP` covers the whole path end to end over real gVisor: two tsnet nodes with no tun, one resolving a split-DNS name whose upstream is the other.

Fixes #20314