### PR TITLE
staticcheck.conf: enable ST1000 to check package docs

### DIFF
--- a/cmd/natc/ippool/ippool.go
+++ b/cmd/natc/ippool/ippool.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-// ippool implements IP address storage, creation, and retrieval for cmd/natc
+// Package ippool implements IP address storage, creation, and retrieval for cmd/natc.
 package ippool
 
 import (

--- a/feature/buildfeatures/buildfeatures.go
+++ b/feature/buildfeatures/buildfeatures.go
@@ -3,8 +3,8 @@
 
 //go:generate go run gen.go
 
-// The buildfeatures package contains boolean constants indicating which
-// features were included in the binary (via build tags), for use in dead code
-// elimination when using separate build tag protected files is impractical
-// or undesirable.
+// Package buildfeatures contains boolean constants indicating which features
+// were included in the binary (via build tags), for use in dead code
+// elimination when using separate build tag protected files is impractical or
+// undesirable.
 package buildfeatures

--- a/feature/condregister/condregister.go
+++ b/feature/condregister/condregister.go
@@ -1,9 +1,9 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-// The condregister package registers all conditional features guarded
-// by build tags. It is one central package that callers can empty import
-// to ensure all conditional features are registered.
+// Package condregister registers all conditional features guarded by build
+// tags. It is one central package that callers can empty import to ensure all
+// conditional features are registered.
 package condregister
 
 import (

--- a/feature/doctor/doctor.go
+++ b/feature/doctor/doctor.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-// The doctor package registers the "doctor" problem diagnosis support into the
+// Package doctor registers the "doctor" problem diagnosis support into the
 // rest of Tailscale.
 package doctor
 

--- a/feature/featuretags/featuretags.go
+++ b/feature/featuretags/featuretags.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-// The featuretags package is a registry of all the ts_omit-able build tags.
+// Package featuretags is a registry of all the ts_omit-able build tags.
 package featuretags
 
 import "tailscale.com/util/set"

--- a/k8s-operator/api.md
+++ b/k8s-operator/api.md
@@ -6,6 +6,7 @@
 
 ## tailscale.com/v1alpha1
 
+Package v1alpha1 documents the k8s-operator API.
 
 ### Resource Types
 - [Connector](#connector)

--- a/k8s-operator/apis/v1alpha1/doc.go
+++ b/k8s-operator/apis/v1alpha1/doc.go
@@ -3,6 +3,7 @@
 
 //go:build !plan9
 
+// Package v1alpha1 documents the k8s-operator API.
 // +kubebuilder:object:generate=true
 // +groupName=tailscale.com
 package v1alpha1

--- a/k8s-operator/sessionrecording/ws/conn.go
+++ b/k8s-operator/sessionrecording/ws/conn.go
@@ -3,7 +3,7 @@
 
 //go:build !plan9
 
-// package ws has functionality to parse 'kubectl exec/attach' sessions streamed using
+// Package ws has functionality to parse 'kubectl exec/attach' sessions streamed using
 // WebSocket protocol.
 package ws
 

--- a/net/netmon/netmon.go
+++ b/net/netmon/netmon.go
@@ -1,9 +1,9 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-// Package monitor provides facilities for monitoring network
-// interface and route changes. It primarily exists to know when
-// portable devices move between different networks.
+// Package netmon provides facilities for monitoring network interface and
+// route changes. It primarily exists to know when portable devices move
+// between different networks.
 package netmon
 
 import (

--- a/net/stun/stun.go
+++ b/net/stun/stun.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-// Package STUN generates STUN request packets and parses response packets.
+// Package stun generates STUN request packets and parses response packets.
 package stun
 
 import (

--- a/net/tstun/tun.go
+++ b/net/tstun/tun.go
@@ -3,8 +3,8 @@
 
 //go:build !wasm && !tamago && !aix && !solaris && !illumos
 
-// Package tun creates a tuntap device, working around OS-specific
-// quirks if necessary.
+// Package tstun creates a tuntap device, working around OS-specific quirks if
+// necessary.
 package tstun
 
 import (

--- a/portlist/portlist.go
+++ b/portlist/portlist.go
@@ -3,8 +3,8 @@
 
 // This file is just the types. The bulk of the code is in poller.go.
 
-// The portlist package contains code that checks what ports are open and
-// listening on the current machine.
+// Package portlist contains code that checks what ports are open and listening
+// on the current machine.
 package portlist
 
 import (

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -17,7 +17,7 @@ checks = [
 	# https://github.com/golang/go/wiki/CodeReviewComments, then it
 	# may be an acceptable check.
 
-	# TODO(crawshaw): enable when we have docs? "ST1000", # missing package docs
+	"ST1000", # missing package docs
 	"ST1001", # discourage dot imports
 
 	"QF1004", # Use `strings.ReplaceAll` instead of `strings.Replace` with `n == 1`

--- a/tstest/deptest/deptest.go
+++ b/tstest/deptest/deptest.go
@@ -1,9 +1,9 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-// The deptest package contains a shared implementation of negative
-// dependency tests for other packages, making sure we don't start
-// depending on certain packages.
+// Package deptest contains a shared implementation of negative dependency
+// tests for other packages, making sure we don't start depending on certain
+// packages.
 package deptest
 
 import (

--- a/tstest/tkatest/tkatest.go
+++ b/tstest/tkatest/tkatest.go
@@ -1,8 +1,8 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-// tkatest has functions for creating a mock control server that responds
-// to TKA endpoints.
+// Package tkatest has functions for creating a mock control server that
+// responds to TKA endpoints.
 package tkatest
 
 import (

--- a/types/appctype/appconnector.go
+++ b/types/appctype/appconnector.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-// Package appcfg contains an experimental configuration structure for
+// Package appctype contains an experimental configuration structure for
 // "tailscale.com/app-connectors" capmap extensions.
 package appctype
 

--- a/util/ctxkey/key.go
+++ b/util/ctxkey/key.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-// ctxkey provides type-safe key-value pairs for use with [context.Context].
+// Package ctxkey provides type-safe key-value pairs for use with [context.Context].
 //
 // Example usage:
 //

--- a/util/goroutines/goroutines.go
+++ b/util/goroutines/goroutines.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-// The goroutines package contains utilities for tracking and getting active goroutines.
+// Package goroutines contains utilities for tracking and getting active goroutines.
 package goroutines
 
 import (

--- a/util/nocasemaps/nocase.go
+++ b/util/nocasemaps/nocase.go
@@ -1,8 +1,8 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-// nocasemaps provides efficient functions to set and get entries in Go maps
-// keyed by a string, where the string is always lower-case.
+// Package nocasemaps provides efficient functions to set and get entries in Go
+// maps keyed by a string, where the string is always lower-case.
 package nocasemaps
 
 import (

--- a/util/osshare/filesharingstatus_noop.go
+++ b/util/osshare/filesharingstatus_noop.go
@@ -3,6 +3,8 @@
 
 //go:build !windows
 
+//lint:file-ignore ST1000 see filesharingstatus_windows.go
+
 package osshare
 
 import (

--- a/util/winutil/authenticode/mksyscall.go
+++ b/util/winutil/authenticode/mksyscall.go
@@ -1,6 +1,8 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+//lint:file-ignore ST1000 see authenticode_windows.go
+
 package authenticode
 
 //go:generate go run golang.org/x/sys/windows/mkwinsyscall -output zsyscall_windows.go mksyscall.go

--- a/util/winutil/gp/mksyscall.go
+++ b/util/winutil/gp/mksyscall.go
@@ -1,6 +1,8 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+//lint:file-ignore ST1000 see gp_windows.go
+
 package gp
 
 //go:generate go run golang.org/x/sys/windows/mkwinsyscall -output zsyscall_windows.go mksyscall.go

--- a/util/winutil/s4u/mksyscall.go
+++ b/util/winutil/s4u/mksyscall.go
@@ -1,6 +1,8 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+//lint:file-ignore ST1000 see s4u_windows.go
+
 package s4u
 
 //go:generate go run golang.org/x/sys/windows/mkwinsyscall -output zsyscall_windows.go mksyscall.go

--- a/util/winutil/winenv/mksyscall.go
+++ b/util/winutil/winenv/mksyscall.go
@@ -1,6 +1,8 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+//lint:file-ignore ST1000 see winenv_windows.go
+
 package winenv
 
 //go:generate go run golang.org/x/sys/windows/mkwinsyscall -output zsyscall_windows.go mksyscall.go


### PR DESCRIPTION
Fix the small number of existing violations of this check, and enable it for
future runs. The fixes needed were:

 - Clean up a few misspelled package names (probably renames).
 - Clean up a few lexical nits ("Package x" instead of "The x package").
 - Add lint directives to some files affected by build tag variance.
 - Add a missing package comment and re-generate the k8s docs.

The lint overrides are a little ugly, but there are only a few places where we
need them, and it's probably worthwhile to enable the check on the rest of the
repo. Rather than replicate the docs around the build tag, I made the lint
diagnotics reference the "correct" file.

Change-Id: I0d97f2f468542af456a0396cf9a023f04f23e436
Signed-off-by: M. J. Fromberger <fromberger@tailscale.com>
