### PR TITLE
cmd/tailscale/cli: stop Serve port ranges at 65535

### DIFF
--- a/cmd/tailscale/cli/serve_v2.go
+++ b/cmd/tailscale/cli/serve_v2.go
@@ -953,6 +953,10 @@ func (e *serveEnv) runServeSetConfig(ctx context.Context, args []string) (err er
 				if err != nil {
 					return fmt.Errorf("service %q: %w", name, err)
 				}
+				// Prevent wrapping a maximal uint16 port back to zero.
+				if port == ppr.Ports.Last {
+					break
+				}
 			}
 		}
 		if v, set := details.Advertised.Get(); !set || v {

--- a/cmd/tailscale/cli/serve_v2_test.go
+++ b/cmd/tailscale/cli/serve_v2_test.go
@@ -2621,6 +2621,20 @@ func TestRunServeSetConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("max_port_does_not_wrap", func(t *testing.T) {
+		lc := &fakeLocalServeClient{config: &ipn.ServeConfig{}}
+		e := &serveEnv{lc: lc, allServices: true, testStdout: &bytes.Buffer{}, testStderr: &bytes.Buffer{}}
+		path := writeTmpServeConfig(t, `{"version":"0.0.1","services":{"svc:foo":{"endpoints":{"tcp:65535":"http://localhost:8080"}}}}`)
+
+		if err := e.runServeSetConfig(context.Background(), []string{path}); err != nil {
+			t.Fatal(err)
+		}
+		svc := lc.config.Services[fooSvc]
+		if svc == nil || svc.TCP[65535] == nil || !svc.TCP[65535].HTTP {
+			t.Errorf("svc:foo TCP/65535 HTTP not applied; got %+v", lc.config.Services)
+		}
+	})
+
 	t.Run("new_format_single_service_no_warning", func(t *testing.T) {
 		lc := &fakeLocalServeClient{config: &ipn.ServeConfig{}}
 		var stdout, stderr bytes.Buffer


### PR DESCRIPTION
A declarative Serve source-port range ending at 65535 does not terminate for file and Unix targets. The loop counter is a `uint16`, so it wraps to zero after applying port 65535 and continues through the range again.

Break after applying the range's `Last` port. This preserves the current closed-range behavior while preventing the maximal `uint16` value from wrapping.

Reproduction on `e1e5325c22a46a9df2e76d725f01f92065885138`:

- The existing `TestRunServeSetConfig/new_format_all_no_warning` fixture uses `tcp:65535` with a Unix target.
- Before the fix, the focused test timed out after eight seconds with exit status 124.
- After the fix, `./tool/go test ./cmd/tailscale/cli -run '^TestRunServeSetConfig$' -count=1` passes.

The loop was introduced in #17435, and #19684 later added the Unix target path used by the reproduction. I searched issues and pull requests for port 65535, Serve port ranges, and `set-config`; I found no exact public duplicate or active fix.

Updates #17435

### Disclosure

Investigated thoroughly with GPT-5.6 (high reasoning effort), using [Oh My Pi](https://github.com/can1357/oh-my-pi) as the agent framework.

This report is not generic or unreviewed AI-generated output. Its claims were checked against the cited evidence, and it includes the relevant detail intended to help maintainers resolve the issue.

If reports like this are not useful to the project, please let me know and I will refrain from submitting similar ones. My intent is to help without wasting maintainer time or energy or discouraging their work.

Thank you for your work.