### PR TITLE
cmd/tailscale/cli: handle kubeconfig stat errors

### DIFF
--- a/cmd/tailscale/cli/configure-kube.go
+++ b/cmd/tailscale/cli/configure-kube.go
@@ -56,7 +56,14 @@ func kubeconfigPath() string {
 	if kubeconfig := os.Getenv("KUBECONFIG"); kubeconfig != "" {
 		var out string
 		for _, out = range filepath.SplitList(kubeconfig) {
-			if info, err := os.Stat(out); !os.IsNotExist(err) && !info.IsDir() {
+			info, err := os.Stat(out)
+			if err != nil {
+				if !os.IsNotExist(err) {
+					break
+				}
+				continue
+			}
+			if !info.IsDir() {
 				break
 			}
 		}

--- a/cmd/tailscale/cli/configure-kube_test.go
+++ b/cmd/tailscale/cli/configure-kube_test.go
@@ -304,10 +304,18 @@ func TestCheckKubeconfigWritable(t *testing.T) {
 		if runtime.GOOS == "windows" {
 			t.Skip("directory mode permissions are not enforced the same way on Windows")
 		}
-		if os.Getuid() == 0 {
-			t.Skip("root bypasses directory permission checks")
-		}
 		dir := t.TempDir()
+		loop := filepath.Join(dir, "loop")
+		if err := os.Symlink(filepath.Base(loop), loop); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("KUBECONFIG", loop)
+		if got := kubeconfigPath(); got != loop {
+			t.Errorf("kubeconfigPath() = %q, want %q", got, loop)
+		}
+		if os.Getuid() == 0 {
+			return // root bypasses the remaining file permission check
+		}
 		sub := filepath.Join(dir, "ro")
 		if err := os.Mkdir(sub, 0500); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
`KUBECONFIG` is a path-like list. `kubeconfigPath` calls `os.Stat` for each entry, but any non-`ENOENT` failure returns a nil `FileInfo` that the current condition dereferences. The command therefore panics before `checkKubeconfigWritable` can return its contextual access error.

Handle the `os.Stat` outcomes separately: continue past missing entries, select successful non-directory entries, and preserve an entry with another error so the existing writability check reports it.

Reproduction on `e1e5325c22a46a9df2e76d725f01f92065885138`:

- A self-referential `KUBECONFIG` symlink makes `os.Stat` return `ELOOP` with a nil `FileInfo`.
- Before the fix, `TestCheckKubeconfigWritable/unwritable-dir` panics at `configure-kube.go:59`.
- After the fix, `./tool/go test ./cmd/tailscale/cli -run '^TestCheckKubeconfigWritable$' -count=1` passes.

Pull request #11604 introduced the list selection. Pull request #20009 and issue #20007 concern the later writability check but do not report this nil dereference. Focused issue and pull-request searches found no same-root duplicate.

Updates #11604

### Disclosure

Investigated thoroughly with GPT-5.6 (high reasoning effort), using [Oh My Pi](https://github.com/can1357/oh-my-pi) as the agent framework.

This report is not generic or unreviewed AI-generated output. Its claims were checked against the cited evidence, and it includes the relevant detail intended to help maintainers resolve the issue.

If reports like this are not useful to the project, please let me know and I will refrain from submitting similar ones. My intent is to help without wasting maintainer time or energy or discouraging their work.

Thank you for your work.