### PR TITLE
net/socks5: compare proxy auth credentials in constant time

### DIFF
--- a/net/socks5/socks5.go
+++ b/net/socks5/socks5.go
@@ -15,6 +15,7 @@ package socks5
 import (
 	"bytes"
 	"context"
+	"crypto/subtle"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -173,7 +174,14 @@ func (c *Conn) Run() error {
 	}
 
 	user, pwd, err := parseClientAuth(c.clientConn)
-	if err != nil || user != c.srv.Username || pwd != c.srv.Password {
+	// Compare both credentials in constant time. The listener is reachable by
+	// any local process, so a data-dependent comparison would let one recover
+	// the username or password a byte at a time by timing the reject. Evaluate
+	// both halves unconditionally so the username result doesn't gate whether
+	// the password is examined.
+	userMatch := subtle.ConstantTimeCompare([]byte(user), []byte(c.srv.Username))
+	pwdMatch := subtle.ConstantTimeCompare([]byte(pwd), []byte(c.srv.Password))
+	if err != nil || userMatch != 1 || pwdMatch != 1 {
 		c.clientConn.Write([]byte{1, 1}) // auth error
 		return err
 	}


### PR DESCRIPTION
The SOCKS5 server authenticates the RFC 1929 username/password handshake by comparing the values the client sends against the configured credentials with plain string equality, which returns as soon as the first byte differs. In tsnet those credentials carry weight: the password is a random 128-bit value generated at startup, and holding it lets a caller dial out through the node to anywhere the tailnet can reach. The listener sits on 127.0.0.1, so any other local process (a different user, a sandboxed helper, a browser's native-messaging host) can open as many connections as it wants and time the auth reject to peel the secret off a byte at a time, with no rate limit or lockout on that path. What tipped me off is that the LocalAPI, which shares the very same tsnet loopback listener, already compares its credential with subtle.ConstantTimeCompare, so the SOCKS5 side reads as an oversight rather than a deliberate difference. I moved both the username and password checks to constant-time compares and evaluate both so the username result doesn't short-circuit the password comparison. Nothing else changes and the existing auth tests still pass.
