### PR TITLE
tstest/natlab: test that a peer's name doesn't shadow a bare upstream name

### DIFF
--- a/tstest/natlab/vmtest/dns_test.go
+++ b/tstest/natlab/vmtest/dns_test.go
@@ -584,3 +584,77 @@ func assertResolverState(t *testing.T, env *vmtest.Env, n *vmtest.Node, want, no
 		t.Fatalf("%v\nwant all of %q and none of %q in resolver state:\n%s", err, want, notWant, last)
 	}
 }
+
+// TestBareNameNotHijackedByPeer checks that a bare, unqualified name owned by
+// the tailnet's global nameserver still reaches that nameserver when a tailnet
+// device shares the name. With MagicDNS off only suffixed names should be
+// answered locally, but quad-100 answered the bare name itself. Issue 20789.
+//
+// The lookup uses "tailscale dns query", which asks for exactly the name given:
+// getent would let a search domain complete it and pass on a different name.
+func TestBareNameNotHijackedByPeer(t *testing.T) {
+	// Only vnet's second DNS server answers this name, so an answer proves the
+	// query was forwarded. Its address is outside the 100.64.x.y block
+	// testcontrol assigns nodes, so it can't be mistaken for a Tailscale IP.
+	const (
+		upstreamName = vnet.SplitDNSBareName
+		upstreamIP   = vnet.SplitDNSBareAddr
+	)
+
+	env := vmtest.New(t,
+		vmtest.SameTailnetUser(), // so the colliding peer is visible in the netmap
+		vmtest.ControlDNS("tailnet.test", &tailcfg.DNSConfig{
+			// No Proxied: MagicDNS off. No Domains: nothing can complete a bare
+			// name into something else. Resolvers is the tailnet's global
+			// nameserver, which owns upstreamName.
+			Resolvers: []*dnstype.Resolver{{Addr: vnet.FakeSplitDNSIPv4().String()}},
+		}))
+
+	lan := env.AddNetwork("2.1.1.1", "192.168.1.1/24", vnet.EasyNAT)
+	client := env.AddNode("client", lan, vmtest.OS(vmtest.Ubuntu2404))
+	// The collision is the whole test: this node's MagicDNS name matches the
+	// upstream record. Nothing runs on it.
+	peer := env.AddNode(upstreamName, lan, vmtest.OS(vmtest.Ubuntu2404))
+
+	env.Start()
+
+	// A mangled or renamed peer would make the lookup below pass without
+	// exercising the collision at all.
+	peerSt := env.Status(peer)
+	if want := upstreamName + ".tailnet.test"; strings.TrimSuffix(peerSt.Self.DNSName, ".") != want {
+		t.Fatalf("peer DNSName = %q, want %q", peerSt.Self.DNSName, want)
+	}
+	// What a hijacked answer would look like, so the check below can name it.
+	var peerIP string // IPv4: the query below asks for an A record
+	for _, a := range peerSt.Self.TailscaleIPs {
+		if a.Is4() {
+			peerIP = a.String()
+			break
+		}
+	}
+	if peerIP == "" {
+		t.Fatalf("peer has no IPv4 TailscaleIP in status (got %v)", peerSt.Self.TailscaleIPs)
+	}
+
+	// Retried because tailscaled applies the DNS config asynchronously after
+	// coming up.
+	if err := tstest.WaitFor(30*time.Second, func() error {
+		out, err := env.SSHExec(client, "tailscale dns query "+upstreamName)
+		if err != nil {
+			return fmt.Errorf("tailscale dns query %s: %v (%s)", upstreamName, err, strings.TrimSpace(out))
+		}
+		// Checked first: the failure is a well-formed A record for the wrong
+		// address, which "missing upstreamIP" alone wouldn't convey.
+		if strings.Contains(out, peerIP) {
+			return fmt.Errorf("query for %s was answered with the peer's Tailscale IP %s, "+
+				"want it forwarded to the global nameserver:\n%s", upstreamName, peerIP, strings.TrimSpace(out))
+		}
+		if !strings.Contains(out, upstreamIP) {
+			return fmt.Errorf("query for %s = %q, want it to contain %s", upstreamName, strings.TrimSpace(out), upstreamIP)
+		}
+		return nil
+	}); err != nil {
+		out, _ := env.SSHExec(client, "resolvectl status; cat /etc/resolv.conf")
+		t.Fatalf("%v\nclient resolver state:\n%s", err, out)
+	}
+}

--- a/tstest/natlab/vmtest/dns_test.go
+++ b/tstest/natlab/vmtest/dns_test.go
@@ -29,7 +29,10 @@ import (
 //     have plumbed MagicDNS routes and search domains into
 //     systemd-resolved.
 //   - A peer added by control resolves by FQDN and by short name,
-//     and its IP reverse-resolves (PTR) to its name.
+//     and its IP reverse-resolves (PTR) to its name. The short name
+//     resolves both via a search domain and asked of quad-100
+//     verbatim, which is the half [TestBareNameNotHijackedByPeer]
+//     requires to stay off when MagicDNS is disabled.
 //   - A peer renamed by control resolves under its new name only:
 //     the old name must stop resolving, and PTR must track the new
 //     name. When a node is renamed in the admin console, the control
@@ -91,6 +94,11 @@ func TestMagicDNS(t *testing.T) {
 	dt.wantResolves("renamee.tailnet.test", "100.64.7.7")
 	dt.wantResolves("renamee", "100.64.7.7") // via search domain
 	dt.wantResolves("100.64.7.7", "renamee.tailnet.test")
+	// Also as a single label, which the search domain above hides:
+	// getent passes "renamee.tailnet.test" to quad-100, not "renamee".
+	// This is the enabled-MagicDNS counterpart of
+	// [TestBareNameNotHijackedByPeer].
+	dt.wantQueryResolves("renamee", "100.64.7.7")
 
 	// Rename the peer, sending the same delta shape production
 	// control sends: the full node again with only the Name changed.
@@ -116,9 +124,9 @@ func TestMagicDNS(t *testing.T) {
 	dt.wantNXDOMAIN("renamed.tailnet.test")
 }
 
-// dnsTester asserts DNS state in a guest via libc lookups (getent),
-// retrying for a bit because tailscaled applies netmap and DNS config
-// changes asynchronously.
+// dnsTester asserts DNS state in a guest, retrying for a bit because
+// tailscaled applies netmap and DNS config changes asynchronously.
+// Lookups go through libc (getent) unless noted.
 type dnsTester struct {
 	t    *testing.T
 	env  *vmtest.Env
@@ -140,6 +148,27 @@ func (dt *dnsTester) wantResolves(name, want string) {
 		}
 		if !strings.Contains(out, want) {
 			return fmt.Errorf("getent hosts %s = %q, want it to contain %q", name, strings.TrimSpace(out), want)
+		}
+		return nil
+	}); err != nil {
+		out, _ := dt.env.SSHExec(dt.node, "resolvectl status; cat /etc/resolv.conf")
+		dt.t.Fatalf("%v\nresolver state:\n%s", err, out)
+	}
+}
+
+// wantQueryResolves is [dnsTester.wantResolves] via "tailscale dns
+// query", which asks quad-100 for exactly the name given. Use it when
+// the name must stay unqualified: getent would let a search domain
+// complete it and resolve a different name.
+func (dt *dnsTester) wantQueryResolves(name, want string) {
+	dt.t.Helper()
+	if err := tstest.WaitFor(30*time.Second, func() error {
+		out, err := dt.env.SSHExec(dt.node, "tailscale dns query "+name)
+		if err != nil {
+			return fmt.Errorf("tailscale dns query %s: %v (%s)", name, err, strings.TrimSpace(out))
+		}
+		if !strings.Contains(out, want) {
+			return fmt.Errorf("tailscale dns query %s = %q, want it to contain %q", name, strings.TrimSpace(out), want)
 		}
 		return nil
 	}); err != nil {

--- a/tstest/natlab/vnet/vip.go
+++ b/tstest/natlab/vnet/vip.go
@@ -42,15 +42,23 @@ const (
 	SplitDNSDomain = "split-dns.example"
 	SplitDNSName   = "internal." + SplitDNSDomain
 	SplitDNSAddr   = "10.99.1.1"
+
+	// SplitDNSBareName is a single label, for tests that need an
+	// upstream-only answer for a name no search domain has completed. Being
+	// outside SplitDNSDomain, it is reached by a resolver pointed at
+	// [FakeSplitDNSIPv4], not by a route for that domain.
+	SplitDNSBareName = "bare-upstream-only"
+	SplitDNSBareAddr = "10.99.1.2"
 )
 
 // splitDNSZone holds the names served only by fakeSplitDNS.
 var splitDNSZone = map[string]netip.Addr{
-	SplitDNSName: netip.MustParseAddr(SplitDNSAddr),
+	SplitDNSName:     netip.MustParseAddr(SplitDNSAddr),
+	SplitDNSBareName: netip.MustParseAddr(SplitDNSBareAddr),
 }
 
 // FakeSplitDNSIPv4 returns the IPv4 address of the secondary (split-DNS) fake
-// DNS server. It answers only [SplitDNSName], with [SplitDNSAddr].
+// DNS server. It answers only [SplitDNSName] and [SplitDNSBareName].
 func FakeSplitDNSIPv4() netip.Addr { return fakeSplitDNS.v4 }
 
 // FakeSplitDNSIPv6 returns the IPv6 address of the secondary (split-DNS) fake

--- a/tstest/natlab/vnet/vnet_test.go
+++ b/tstest/natlab/vnet/vnet_test.go
@@ -97,6 +97,16 @@ func TestPacketSideEffects(t *testing.T) {
 					),
 				},
 				{
+					// Single labels too: the parser produces them with no dots
+					// at all, so they key the zone map like any other name.
+					name: "split-dns-answers-bare-name",
+					pkt:  mkDNSReqTo(FakeSplitDNSIPv4(), SplitDNSBareName),
+					check: all(
+						numPkts(1),
+						pktSubstr("IP="+SplitDNSBareAddr),
+					),
+				},
+				{
 					// The default DNS server must NOT answer the split zone;
 					// that's what makes the answer above meaningful.
 					name: "default-dns-does-not-answer-split-zone",


### PR DESCRIPTION
With MagicDNS off, only suffixed names should be answered locally, but since v1.102 quad-100 also answers a bare, unqualified name whenever a tailnet device shares that name. It returns the device's Tailscale IP instead of forwarding to the tailnet's global nameserver, leaving the upstream record unreachable.

`TestBareNameNotHijackedByPeer` configures a global nameserver owning a single-label name, adds a peer named to collide with it, and asserts the client's lookup returns the upstream address. It queries via "tailscale dns query" so the name stays a single label; a search domain completing it would resolve a different name and pass regardless.

Add `SplitDNSBareName` to vnet's split-DNS zone to serve that name, and a packet-level case asserting the fake server answers it.

Note: this currently (intentionally) fails on main and passes on v1.98.4.

Updates #20789