### PR TITLE
feature/conn25: don't pre-size flow table maps

### DIFF
--- a/feature/conn25/flowtable.go
+++ b/feature/conn25/flowtable.go
@@ -128,13 +128,19 @@ func WithMaxRemovedFlowsPerSweep(maxPer int) FlowTableOption {
 // NewFlowTable returns a [FlowTable] with maxEntries maximum entries.
 // A maxEntries of 0 indicates no maximum. See also [FlowTable].
 func NewFlowTable(maxEntries int, opts ...FlowTableOption) *FlowTable {
+	// Note: the maps below are deliberately not pre-sized to maxEntries.
+	// maxEntries is only an upper bound, enforced at insertion time; most
+	// nodes have far fewer concurrent flows. Pre-sizing to a large bound
+	// (e.g. the 100k-entry connector table) allocates ~8 MiB of map
+	// buckets per map up front, which alone nearly consumed the iOS
+	// Network Extension's 50 MiB jetsam limit (2x tables x 2 maps each).
 	ft := &FlowTable{
 		maxEntries:         maxEntries,
 		idleTimeout:        DefaultFlowIdleTimeout,
 		sweepInterval:      DefaultFlowSweepInterval,
 		maxRemovedPerSweep: DefaultMaxRemovedFlowsPerSweep,
-		fromTunCache:       make(map[flowtrack.Tuple]*list.Element, maxEntries),
-		fromWGCache:        make(map[flowtrack.Tuple]*list.Element, maxEntries),
+		fromTunCache:       make(map[flowtrack.Tuple]*list.Element),
+		fromWGCache:        make(map[flowtrack.Tuple]*list.Element),
 		lru:                list.New(),
 	}
 


### PR DESCRIPTION
NewFlowTable pre-sized its two per-direction lookup maps to maxEntries. The datapath handler creates a client table (10k flows) and a connector table (100k flows) unconditionally at extension init, so every client paid ~15.8 MiB of empty map buckets up front (measured on device, and reproducible with a benchmark: 2x100k + 2x10k maps keyed by the 38-byte flowtrack.Tuple).

On iOS the Network Extension has a hard 50 MiB jetsam limit. On large tailnets the netmap and derived engine state need ~18 MiB of live heap on top of the baseline, and this pre-allocation pushed the process over the limit: the extension was killed (per-process-limit) seconds after connecting, in a relaunch loop, making such tailnets unusable on iOS.

maxEntries is still enforced as a bound at insertion time; the maps now grow on demand instead. On an iPhone 14 Pro Max joining a ~600 node tailnet this took peak live heap during netmap ingest from 36.8 MiB to 24.3 MiB and the extension now connects and stays up with ~18 MiB of headroom instead of being killed at 50 MiB.

Fixes https://github.com/tailscale/corp/issues/46408
Updates https://github.com/tailscale/corp/issues/18514