### PR TITLE
util/ioqueue: new log buffer implementation

### DIFF
--- a/util/ioqueue/ioqueue.go
+++ b/util/ioqueue/ioqueue.go
@@ -1,0 +1,268 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Package ioqueue provides a concurrent byte queue with monotonic offsets.
+//
+// A [Buffer] is an unframed stream of bytes:
+// many writers may append concurrently to a shared write cursor, and
+// many readers may consume from a shared read cursor.
+// It is suitable for buffering data before transmission or processing
+// elsewhere (for example log or telemetry upload),
+// whether the backing store is memory, disk, or a hybrid of the two.
+//
+// # Buffer semantics
+//
+// Unlike [io.Pipe], reads and writes do not block each other.
+// [Buffer.Write] never blocks.
+// [Buffer.Read] and [Buffer.Peek] return immediately with [ErrEmpty]
+// when no data is available.
+// Waiting for progress is explicit via [Buffer.WaitUntil],
+// or helpers such as [WaitLength] and [StreamReader].
+//
+// The queue is logically infinite;
+// implementations and applications are responsible for draining data
+// and/or rejecting writes when resource limits are reached.
+// Message framing (newlines, length prefixes, COBS, and so on)
+// is left to the application.
+//
+// Progress is tracked with monotonic [Buffer.ReadOffset]
+// and [Buffer.WriteOffset] counters.
+// [Buffer.Peek] combined with [Buffer.DiscardUntil]
+// supports commit-after-success consumption
+// (for example peek, upload, then discard).
+// [Buffer.DiscardUntil] is a monotonic advance of the shared read cursor,
+// so concurrent readers
+// (such as an uploader and a size-enforcing discarder)
+// cooperate without exclusive leases.
+// Peek does not reserve data.
+//
+// [Buffer] implements [io.Writer] and [io.Reader].
+// Pairing a buffer with [io.Copy] drains all currently available bytes
+// and stops on [ErrEmpty]
+// (or [io.EOF] if the write side is closed and fully drained).
+// For a blocking stream that waits for more data, use [StreamReader].
+//
+// # Empty vs end-of-stream
+//
+// [ErrEmpty] means the queue is transiently empty;
+// more data may arrive.
+// Close and other lifecycle operations are not part of [Buffer].
+// A concrete type may support closing the write side
+// and return [io.EOF] from Read/Peek once closed and drained,
+// and should unblock [Buffer.WaitUntil] waiters
+// so they do not hang after close.
+//
+// # Helpers
+//
+//   - [WaitLength] waits until the buffer is non-empty
+//     (and optionally until a length and/or delay policy is met),
+//     without reporting which condition fired;
+//     callers re-check buffer state afterward.
+//   - [DiscardOversize] discards from the front of the buffer
+//     until [Buffer.Len] is within a maximum size,
+//     for use by a concurrent size-enforcing drain.
+//   - [StreamReader] adapts a [Buffer] to a blocking [io.Reader]
+//     whose lifetime is bound to a [context.Context]
+//     (and to [io.EOF] from the buffer if the write side is closed).
+package ioqueue
+
+import (
+	"cmp"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+)
+
+// ErrEmpty indicates that the buffer has no data available to read or peek
+// at the current [Buffer.ReadOffset].
+// It is a transient condition: more data may arrive later.
+// Use [Buffer.WaitUntil] to wait for progress,
+// or [StreamReader] for an [io.Reader] that blocks until data is available.
+//
+// ErrEmpty is distinct from [io.EOF].
+// A concrete [Buffer] implementation that supports closing the write side
+// may return [io.EOF] to signal that the buffer is closed for writing
+// and no further bytes will ever be produced
+// (after any remaining buffered data has been consumed).
+var ErrEmpty = errors.New("ioqueue: buffer empty")
+
+// Buffer is an infinitely sized ring buffer.
+// It is the implementation's or application's responsibility to drain
+// and/or avoid writing if it is too full (see [DiscardOversize]).
+//
+// It does not provide any form of message framing,
+// which is the responsibility of the application logic.
+// Common framing techniques include:
+//   - newline-delimited frames,
+//   - length-prefixed frames, or
+//   - null-terminated COBS-encoded frames
+//     (see [tailscale.com/util/cobs]).
+//
+// All methods must be safe for concurrent use.
+//
+// Close and other lifecycle operations are not part of this interface.
+// A concrete implementation may support closing the write side and,
+// once closed and drained,
+// return [io.EOF] from [Buffer.Read] and [Buffer.Peek]
+// instead of [ErrEmpty].
+// Such an implementation should also ensure that
+// [Buffer.WaitUntil] does not block indefinitely after close.
+type Buffer interface {
+	// Len reports the size of the buffer,
+	// which is the number of written, but unread bytes.
+	// It is equivalent to atomically subtracting
+	// the ReadOffset from the WriteOffset.
+	Len() int64
+
+	// WriteOffset is the total number of bytes written.
+	// It is an increasing monotonic counter
+	// and is always greater than or equal to ReadOffset.
+	WriteOffset() int64
+
+	// ReadOffset is the total number of bytes read.
+	// It is an increasing monotonic counter
+	// and is always less than or equal to WriteOffset.
+	ReadOffset() int64
+
+	// Write writes data to the end of the buffer,
+	// atomically incrementing Len and WriteOffset
+	// by the amount of bytes written.
+	// Concurrent Write calls are atomically performed.
+	// Write does not block.
+	Write([]byte) (int, error)
+
+	// Read reads data from the front of the buffer, atomically decrementing
+	// Len and incrementing ReadOffset by the amount of bytes read.
+	// It never reads partially written data for a concurrent Write call.
+	// It fills the buffer with as much data as is available.
+	// Rather than blocking, it returns ErrEmpty when the buffer is empty.
+	// Use WaitUntil to block until data is available.
+	//
+	// A concrete implementation that supports closing the write side
+	// may return io.EOF once the buffer is closed for writing
+	// and no further bytes will ever be produced
+	// (after any remaining data has been read).
+	// ErrEmpty must not be used for that permanent condition.
+	Read([]byte) (int, error)
+
+	// Peek copies data from the front of the buffer into b
+	// without affecting Len or ReadOffset.
+	// It never peeks partially written data for a concurrent Write call.
+	// It fills the buffer with as much data as is available.
+	// If len(b) is greater than Len, then it only copies the available content.
+	// It reports the current ReadOffset and the number of bytes copied into b.
+	// If the number of available bytes is zero, it reports ErrEmpty.
+	//
+	// A concrete implementation that supports closing the write side
+	// may return io.EOF once the buffer is closed for writing
+	// and no further bytes will ever be produced
+	// (when no buffered data remains).
+	//
+	// The content peeked can be later discarded as follows:
+	//
+	//	readOffset, n, err := buf.Peek(b)
+	//	... // make use of b[:n]
+	//	_, err := buf.DiscardUntil(readOffset + n)
+	Peek(b []byte) (readOffset int64, n int64, err error)
+
+	// DiscardUntil discards bytes from the front of the buffer by
+	// incrementing ReadOffset to match the specified readOffset.
+	// If readOffset is less than ReadOffset,
+	// then ReadOffset is not changed and no error is reported.
+	// If readOffset is greater than WriteOffset, then ReadOffset is
+	// set to the current WriteOffset and reports [ErrEmpty]
+	// (or [io.EOF] if the implementation supports closing the write side).
+	// It reports the number of bytes that have been discarded.
+	// If readOffset is less than or equal to WriteOffset,
+	// it should never report [ErrEmpty] or [io.EOF].
+	DiscardUntil(readOffset int64) (n int64, err error)
+
+	// WaitUntil returns a channel that is closed
+	// when the WriteOffset exceeds the specified writeOffset.
+	//
+	// To wait for the buffer to have more than n bytes:
+	//
+	//	<-b.WaitUntil(b.ReadOffset() + n)
+	//
+	// This method is useful for blocking until the buffer contains
+	// more than n bytes to enforce limits on maximum buffer size
+	// or to upload in larger batches for greater efficiency.
+	//
+	// If a concrete implementation supports closing the write side,
+	// it should close outstanding and future WaitUntil channels as needed
+	// so waiters do not block indefinitely after close.
+	WaitUntil(writeOffset int64) <-chan struct{}
+}
+
+var alreadyClosed = func() chan struct{} {
+	c := make(chan struct{})
+	close(c)
+	return c
+}()
+
+// offsetWaiter is a single offset wait registration.
+type offsetWaiter struct {
+	offsetTarget int64
+	done         chan struct{}
+}
+
+// offsetWaiters is a sorted list of offset wait registrations.
+// The zero value is ready for use.
+// Methods assume the caller serializes access (typically via a mutex).
+type offsetWaiters struct{ waiters []offsetWaiter }
+
+// wait returns a channel that is closed when offsetNow exceeds offsetTarget,
+// or immediately if that condition already holds or closed is true.
+// Multiple waiters for the same offsetTarget share one channel.
+func (ws *offsetWaiters) wait(offsetNow, offsetTarget int64, closed bool) <-chan struct{} {
+	if offsetNow > offsetTarget || closed {
+		return alreadyClosed
+	}
+	i, found := slices.BinarySearchFunc(ws.waiters, offsetTarget, func(w offsetWaiter, off int64) int {
+		return cmp.Compare(w.offsetTarget, off)
+	})
+	if !found {
+		ws.waiters = slices.Insert(ws.waiters, i, offsetWaiter{offsetTarget, make(chan struct{})})
+	}
+	return ws.waiters[i].done
+}
+
+// notify closes and removes every waiter satisfied by offsetNow
+// (offsetNow exceeds the waiter's offsetTarget) or by closed.
+func (ws *offsetWaiters) notify(offsetNow int64, closed bool) {
+	for len(ws.waiters) > 0 && (offsetNow > ws.waiters[0].offsetTarget || closed) {
+		close((ws.waiters)[0].done)
+		(ws.waiters)[0].done = nil
+		ws.waiters = ws.waiters[1:]
+	}
+}
+
+var errClosed = errors.New("closed buffer")
+
+type ioqueueError struct {
+	op  string
+	err error
+}
+
+func wrapError(op string, err error) error {
+	if err == nil || err == io.EOF {
+		return err
+	}
+	if e, ok := err.(*ioqueueError); ok {
+		err = e.err // avoid double wrapping
+	}
+	return &ioqueueError{op: op, err: err}
+}
+
+func (e *ioqueueError) Error() string {
+	if e.op == "" {
+		return fmt.Sprintf("ioqueue: %v", e.err)
+	} else {
+		return fmt.Sprintf("ioqueue %s: %v", e.op, e.err)
+	}
+}
+
+func (e *ioqueueError) Unwrap() error {
+	return e.err
+}

--- a/util/ioqueue/ioqueue_test.go
+++ b/util/ioqueue/ioqueue_test.go
@@ -1,0 +1,395 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package ioqueue
+
+import (
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"tailscale.com/util/must"
+)
+
+// writeCloser is the optional write-side close API implemented by
+// concrete buffers (for example [VolatileBuffer.CloseWrite]).
+type writeCloser interface {
+	CloseWrite() error
+}
+
+// testBuffers runs f against each concrete [Buffer] implementation.
+func testBuffers(t *testing.T, f func(t *testing.T, b Buffer)) {
+	t.Helper()
+	t.Run("Volatile", func(t *testing.T) { f(t, new(VolatileBuffer)) })
+	// TODO: t.Run("Durable", func(t *testing.T) { f(t, openTestDurable(t)) })
+}
+
+func TestBufferBasic(t *testing.T) {
+	testBuffers(t, func(t *testing.T, b Buffer) {
+		if b.Len() != 0 || b.ReadOffset() != 0 || b.WriteOffset() != 0 {
+			t.Fatalf("empty: Len=%d ReadOff=%d WriteOff=%d", b.Len(), b.ReadOffset(), b.WriteOffset())
+		}
+
+		const msg = "hello world"
+		n, err := b.Write([]byte(msg))
+		if err != nil || n != len(msg) {
+			t.Fatalf("Write = (%d, %v), want (%d, nil)", n, err, len(msg))
+		}
+		if b.WriteOffset() != int64(len(msg)) || b.ReadOffset() != 0 || b.Len() != int64(len(msg)) {
+			t.Fatalf("after Write: Len=%d ReadOff=%d WriteOff=%d", b.Len(), b.ReadOffset(), b.WriteOffset())
+		}
+
+		p := make([]byte, 5)
+		ro, nn, err := b.Peek(p)
+		if err != nil || ro != 0 || nn != 5 || string(p) != "hello" {
+			t.Fatalf("Peek = (%d, %d, %v, %q), want (0, 5, nil, hello)", ro, nn, err, p)
+		}
+		if b.ReadOffset() != 0 || b.Len() != int64(len(msg)) {
+			t.Fatalf("Peek must not advance offsets: ReadOff=%d Len=%d", b.ReadOffset(), b.Len())
+		}
+
+		dn, err := b.DiscardUntil(5)
+		if err != nil || dn != 5 {
+			t.Fatalf("DiscardUntil(5) = (%d, %v), want (5, nil)", dn, err)
+		}
+		if b.ReadOffset() != 5 || b.Len() != int64(len(msg)-5) {
+			t.Fatalf("after DiscardUntil: ReadOff=%d Len=%d", b.ReadOffset(), b.Len())
+		}
+
+		// DiscardUntil behind the cursor is a no-op.
+		dn, err = b.DiscardUntil(3)
+		if err != nil || dn != 0 || b.ReadOffset() != 5 {
+			t.Fatalf("DiscardUntil(3) = (%d, %v), ReadOff=%d; want (0, nil), 5", dn, err, b.ReadOffset())
+		}
+
+		got := make([]byte, 64)
+		rn, err := b.Read(got)
+		if err != nil || rn != len(msg)-5 || string(got[:rn]) != " world" {
+			t.Fatalf("Read = (%d, %v, %q), want (%d, nil, %q)", rn, err, got[:rn], len(msg)-5, " world")
+		}
+		if b.Len() != 0 || b.ReadOffset() != b.WriteOffset() {
+			t.Fatalf("after full Read: Len=%d ReadOff=%d WriteOff=%d", b.Len(), b.ReadOffset(), b.WriteOffset())
+		}
+
+		_, err = b.Read(got)
+		if !errors.Is(err, ErrEmpty) {
+			t.Fatalf("Read empty = %v, want ErrEmpty", err)
+		}
+	})
+}
+
+func TestBufferDiscardPastEnd(t *testing.T) {
+	testBuffers(t, func(t *testing.T, b Buffer) {
+		if _, err := b.Write([]byte("abc")); err != nil {
+			t.Fatal(err)
+		}
+		n, err := b.DiscardUntil(100)
+		if n != 3 || !errors.Is(err, ErrEmpty) {
+			t.Fatalf("DiscardUntil(100) = (%d, %v), want (3, ErrEmpty)", n, err)
+		}
+		if b.ReadOffset() != 3 || b.WriteOffset() != 3 || b.Len() != 0 {
+			t.Fatalf("offsets after over-discard: ReadOff=%d WriteOff=%d Len=%d", b.ReadOffset(), b.WriteOffset(), b.Len())
+		}
+	})
+}
+
+func TestBufferWaitUntil(t *testing.T) {
+	testBuffers(t, func(t *testing.T, b Buffer) {
+		// WriteOffset (0) does not exceed 0, so must wait.
+		// After a write of 1 byte, WriteOffset=1 exceeds 0.
+		ch := b.WaitUntil(0)
+		select {
+		case <-ch:
+			t.Fatal("WaitUntil(0) on empty buffer closed immediately")
+		default:
+		}
+
+		// Coalesce: same target shares the channel.
+		ch2 := b.WaitUntil(0)
+		if ch != ch2 {
+			t.Fatal("WaitUntil coalescing: expected same channel for same offset")
+		}
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			<-ch
+		}()
+
+		if _, err := b.Write([]byte("x")); err != nil {
+			t.Fatal(err)
+		}
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("WaitUntil(0) did not fire after Write")
+		}
+
+		// Already satisfied after write: WriteOffset=1 > 0.
+		select {
+		case <-b.WaitUntil(0):
+		default:
+			t.Fatal("WaitUntil(0) should be already closed when WriteOffset=1")
+		}
+
+		// Wait for WriteOffset > 10.
+		ch = b.WaitUntil(10)
+		select {
+		case <-ch:
+			t.Fatal("WaitUntil(10) fired too early")
+		default:
+		}
+		if _, err := b.Write(make([]byte, 9)); err != nil { // WriteOffset = 10, not yet >
+			t.Fatal(err)
+		}
+		select {
+		case <-ch:
+			t.Fatal("WaitUntil(10) fired at WriteOffset==10; need strictly greater")
+		default:
+		}
+		if _, err := b.Write([]byte("y")); err != nil { // WriteOffset = 11
+			t.Fatal(err)
+		}
+		select {
+		case <-ch:
+		case <-time.After(time.Second):
+			t.Fatal("WaitUntil(10) did not fire when WriteOffset=11")
+		}
+	})
+}
+
+func TestBufferCloseWrite(t *testing.T) {
+	testBuffers(t, func(t *testing.T, b Buffer) {
+		cw, ok := b.(writeCloser)
+		if !ok {
+			t.Skip("CloseWrite not supported")
+		}
+
+		if _, err := b.Write([]byte("hi")); err != nil {
+			t.Fatal(err)
+		}
+
+		// Waiter past final write offset should unblock on close.
+		ch := b.WaitUntil(100)
+		if err := cw.CloseWrite(); err != nil {
+			t.Fatal(err)
+		}
+		select {
+		case <-ch:
+		case <-time.After(time.Second):
+			t.Fatal("WaitUntil did not unblock after CloseWrite")
+		}
+
+		// Future waiters also unblock immediately.
+		select {
+		case <-b.WaitUntil(1 << 20):
+		default:
+			t.Fatal("WaitUntil after CloseWrite should be already closed")
+		}
+
+		// Data still readable, then EOF.
+		p := make([]byte, 8)
+		n, err := b.Read(p)
+		if err != nil || string(p[:n]) != "hi" {
+			t.Fatalf("Read before drain = (%d, %v, %q)", n, err, p[:n])
+		}
+		n, err = b.Read(p)
+		if n != 0 || !errors.Is(err, io.EOF) {
+			t.Fatalf("Read after drain = (%d, %v), want (0, EOF)", n, err)
+		}
+		_, _, err = b.Peek(p)
+		if !errors.Is(err, io.EOF) {
+			t.Fatalf("Peek after drain = %v, want EOF", err)
+		}
+
+		// Writes rejected.
+		if _, err := b.Write([]byte("x")); !errors.Is(err, errClosed) {
+			t.Fatalf("Write after CloseWrite = %v, want errClosed", err)
+		}
+
+		// Discard past end after close → EOF.
+		if _, err := b.DiscardUntil(b.WriteOffset() + 1); !errors.Is(err, io.EOF) {
+			t.Fatalf("DiscardUntil past end after close = %v, want EOF", err)
+		}
+
+		// Double close.
+		if err := cw.CloseWrite(); !errors.Is(err, errClosed) {
+			t.Fatalf("second CloseWrite = %v, want errClosed", err)
+		}
+	})
+}
+
+func TestBufferPeekDiscardCommit(t *testing.T) {
+	// Pattern from Buffer docs: peek, use, discard until readOffset+n.
+	testBuffers(t, func(t *testing.T, b Buffer) {
+		if _, err := b.Write([]byte("abcdef")); err != nil {
+			t.Fatal(err)
+		}
+
+		buf := make([]byte, 3)
+		ro, n, err := b.Peek(buf)
+		if err != nil || ro != 0 || n != 3 || string(buf) != "abc" {
+			t.Fatalf("Peek = (%d, %d, %v, %q)", ro, n, err, buf)
+		}
+		if _, err := b.DiscardUntil(ro + n); err != nil {
+			t.Fatal(err)
+		}
+
+		ro, n, err = b.Peek(buf)
+		if err != nil || ro != 3 || n != 3 || string(buf) != "def" {
+			t.Fatalf("second Peek = (%d, %d, %v, %q)", ro, n, err, buf)
+		}
+		if _, err := b.DiscardUntil(ro + n); err != nil {
+			t.Fatal(err)
+		}
+		if b.Len() != 0 {
+			t.Fatalf("Len = %d, want 0", b.Len())
+		}
+	})
+}
+
+func TestBufferConcurrent(t *testing.T) {
+	testBuffers(t, func(t *testing.T, b Buffer) {
+		var group sync.WaitGroup
+		defer group.Wait()
+
+		const writers = 4
+		const perWriter = 1000
+		payload := []byte("x")
+
+		errc := make(chan error, writers)
+		for range writers {
+			group.Go(func() {
+				for range perWriter {
+					if _, err := b.Write(payload); err != nil {
+						errc <- err
+						return
+					}
+				}
+				errc <- nil
+			})
+		}
+		for range writers {
+			if err := <-errc; err != nil {
+				t.Fatal(err)
+			}
+		}
+		want := int64(writers * perWriter)
+		if b.WriteOffset() != want || b.Len() != want {
+			t.Fatalf("WriteOffset=%d Len=%d, want %d", b.WriteOffset(), b.Len(), want)
+		}
+
+		// Drain with concurrent Read and DiscardUntil.
+		// Monotonic DiscardUntil makes this safe: readers cooperate on one cursor.
+		done := make(chan struct{})
+		group.Go(func() {
+			defer close(done)
+			p := make([]byte, 16)
+			for b.Len() > 0 {
+				if _, err := b.Read(p); err != nil && !errors.Is(err, ErrEmpty) {
+					t.Errorf("Read: %v", err)
+					return
+				}
+			}
+		})
+		for b.Len() > 0 {
+			if _, err := b.DiscardUntil(b.ReadOffset() + 7); err != nil && !errors.Is(err, ErrEmpty) {
+				t.Fatalf("DiscardUntil: %v", err)
+			}
+		}
+		<-done
+		if b.Len() != 0 || b.ReadOffset() != b.WriteOffset() {
+			t.Fatalf("after concurrent drain: Len=%d ReadOff=%d WriteOff=%d",
+				b.Len(), b.ReadOffset(), b.WriteOffset())
+		}
+	})
+}
+
+func TestVolatileBufferSteadyStateNoAlloc(t *testing.T) {
+	// Sawtooth via public API: write N bytes M times, discard N*M, repeat.
+	// After warm-up, a stable peak must not allocate.
+	var b VolatileBuffer
+	const bytesPerWrite = 1 << 10 // bytes per write
+	const writesPerCycle = 64     // writes per cycle
+	payload := make([]byte, bytesPerWrite)
+	cycle := func() {
+		for range writesPerCycle {
+			must.Get(b.Write(payload))
+		}
+		must.Get(b.DiscardUntil(b.WriteOffset()))
+	}
+	for range 10 {
+		cycle()
+	}
+	if allocs := testing.AllocsPerRun(100, cycle); allocs != 0 {
+		t.Fatalf("steady-state allocs/run = %v, want 0 (len=%d cap=%d)", allocs, len(b.buf), cap(b.buf))
+	}
+}
+
+func TestVolatileBufferTransientShrink(t *testing.T) {
+	// Large write then many small reads: backing store should slide (len drops
+	// while unread is reclaimed) and eventually shrink cap as peakLen decays.
+	var b VolatileBuffer
+	const large = 1 << 20 // 1MiB: enough slides for peak to fall below cap/4
+	must.Get(b.Write(make([]byte, large)))
+	cap0 := cap(b.buf)
+	if cap0 < large {
+		t.Fatalf("cap after write = %d, want >= %d", cap0, large)
+	}
+
+	small := make([]byte, 256)
+	prevCap, prevLen := cap0, len(b.buf)
+	var numSlides, numShrinks int
+	for b.Len() > 0 {
+		must.Get(b.Read(small))
+		c, n := cap(b.buf), len(b.buf)
+		if c > prevCap {
+			t.Fatalf("cap grew during drain: %d → %d", prevCap, c)
+		}
+		if n < prevLen && c == prevCap {
+			numSlides++ // in-place prefix reclaim
+		}
+		if c < prevCap {
+			numShrinks++
+			// Shrink replaces the backing array; no dead prefix remains.
+			if n != int(b.Len()) {
+				t.Fatalf("after shrink: len(buf)=%d, Len()=%d", n, b.Len())
+			}
+		}
+		prevCap, prevLen = c, n
+	}
+	if numSlides == 0 {
+		t.Fatal("expected in-place slides (len drop at constant cap) during drain")
+	}
+	if numShrinks == 0 {
+		t.Fatalf("cap never shrank during small-read drain (start=%d end=%d)", cap0, cap(b.buf))
+	}
+	if cap(b.buf) >= cap0 {
+		t.Fatalf("cap after drain = %d, want < initial %d", cap(b.buf), cap0)
+	}
+	t.Logf("after large drain: numSlides=%d numShrinks=%d cap=%d", numSlides, numShrinks, cap(b.buf))
+
+	// Keep writing and reading one byte so peakLen decays and capacity
+	// ratchets down until the 4KiB shrink floor.
+	one := []byte{0}
+	const maxCycles = 1_000_000
+	for range maxCycles {
+		if cap(b.buf) <= 4<<10 {
+			break
+		}
+		must.Get(b.Write(one))
+		must.Get(b.Read(one))
+		if c := cap(b.buf); c > prevCap {
+			t.Fatalf("cap grew during 1-byte cycles: %d → %d", prevCap, c)
+		} else if c < prevCap {
+			numShrinks++
+		}
+		prevCap = cap(b.buf)
+	}
+	if cap(b.buf) > 4<<10 {
+		t.Fatalf("cap = %d after %d 1-byte cycles, want <= 4KiB", cap(b.buf), maxCycles)
+	}
+	t.Logf("final: numShrinks=%d cap=%d", numShrinks, cap(b.buf))
+}

--- a/util/ioqueue/volatile.go
+++ b/util/ioqueue/volatile.go
@@ -1,0 +1,186 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package ioqueue
+
+import (
+	"io"
+	"math/bits"
+	"sync"
+
+	"tailscale.com/types/bools"
+)
+
+// Statically verify that VolatileBuffer implements Buffer.
+var _ Buffer = (*VolatileBuffer)(nil)
+
+// VolatileBuffer is an in-memory implementation of [Buffer].
+// The zero value is an empty buffer ready for use.
+//
+// Unread data is not durable: it is lost when the process exits.
+// Close the write side with [VolatileBuffer.CloseWrite] to signal
+// that no further bytes will be produced; subsequent [Buffer.Read]
+// and [Buffer.Peek] calls return [io.EOF] once the buffer is drained,
+// and outstanding [Buffer.WaitUntil] waiters are unblocked.
+type VolatileBuffer struct {
+	mu sync.Mutex
+
+	// buf may retain a consumed prefix after reads/discards.
+	// Unread data is always the trailing writeOffset-readOffset bytes.
+	buf         []byte
+	readOffset  int64
+	writeOffset int64
+	peakLen     int64 // decayed by compactLocked
+
+	closedWrite bool
+	waiters     offsetWaiters
+}
+
+// Len reports the size of the buffer,
+// which is the number of written, but unread bytes.
+func (b *VolatileBuffer) Len() int64 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.lenLocked()
+}
+
+func (b *VolatileBuffer) lenLocked() int64 {
+	return b.writeOffset - b.readOffset
+}
+
+// WriteOffset is the total number of bytes written.
+func (b *VolatileBuffer) WriteOffset() int64 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.writeOffset
+}
+
+// ReadOffset is the total number of bytes read.
+func (b *VolatileBuffer) ReadOffset() int64 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.readOffset
+}
+
+// dataLocked returns the unread portion of buf.
+func (b *VolatileBuffer) dataLocked() []byte {
+	n := int(b.writeOffset - b.readOffset)
+	return b.buf[len(b.buf)-n:]
+}
+
+// compactLocked reclaims backing storage after a consume,
+// by sliding data forward or allocating a smaller capacity buffer.
+func (b *VolatileBuffer) compactLocked() {
+	data := b.dataLocked()
+	// If already read data is greater than unread data, then compact.
+	if len(b.buf) > 2*len(data) {
+		b.peakLen = max(b.peakLen, b.lenLocked())
+		// If total capacity is 4x greater than the peak Len,
+		// then allocate smaller capacity, otherwise slide data to front.
+		if int64(cap(b.buf)/4) > b.peakLen && cap(b.buf) > 4<<10 {
+			newCap := 2 << bits.Len(uint(b.peakLen)-1)       // double the peak Len, but round up to power-of-2
+			newCap = max(newCap, 4<<10)                      // minimum buffer capacity to shrink to
+			b.buf = append(make([]byte, 0, newCap), data...) // allocate smaller buffer
+		} else {
+			b.buf = b.buf[:copy(b.buf, data)] // slide data to the front
+		}
+		b.peakLen = b.peakLen * 7 / 8 // reduce peakLen by 12.5%
+	}
+}
+
+// Write writes data to the end of the buffer,
+// atomically incrementing Len and WriteOffset
+// by the amount of bytes written.
+// Write does not block.
+// After [CloseWrite], Write returns an error.
+func (b *VolatileBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closedWrite {
+		return 0, wrapError("write", errClosed)
+	}
+	b.buf = append(b.buf, p...)
+	b.writeOffset += int64(len(p))
+	b.peakLen = max(b.peakLen, b.lenLocked())
+	b.waiters.notify(b.writeOffset, b.closedWrite)
+	return len(p), nil
+}
+
+// Read reads data from the front of the buffer, atomically decrementing
+// Len and incrementing ReadOffset by the amount of bytes read.
+// Rather than blocking, it returns [ErrEmpty] when the buffer is empty.
+// After [CloseWrite], it returns [io.EOF] once drained.
+func (b *VolatileBuffer) Read(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	data := b.dataLocked()
+	if len(data) == 0 {
+		return 0, wrapError("read", bools.IfElse(b.closedWrite, io.EOF, ErrEmpty))
+	}
+	n := copy(p, data)
+	b.readOffset += int64(n)
+	b.compactLocked()
+	return n, nil
+}
+
+// Peek copies data from the front of the buffer into p
+// without affecting Len or ReadOffset.
+// It reports the current ReadOffset and the number of bytes copied.
+// If no bytes are available, it reports [ErrEmpty],
+// or [io.EOF] after [VolatileBuffer.CloseWrite] once drained.
+func (b *VolatileBuffer) Peek(p []byte) (readOffset int64, n int64, err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	readOffset = b.readOffset
+	data := b.dataLocked()
+	if len(data) == 0 {
+		return readOffset, 0, wrapError("peek", bools.IfElse(b.closedWrite, io.EOF, ErrEmpty))
+	}
+	return readOffset, int64(copy(p, data)), nil
+}
+
+// DiscardUntil discards bytes from the front of the buffer by
+// incrementing ReadOffset to match the specified readOffset.
+// See [Buffer.DiscardUntil] for full semantics.
+func (b *VolatileBuffer) DiscardUntil(readOffset int64) (n int64, err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if readOffset <= b.readOffset {
+		return 0, nil
+	}
+	if readOffset > b.writeOffset {
+		err = wrapError("discard", bools.IfElse(b.closedWrite, io.EOF, ErrEmpty))
+	}
+	readOffset = min(readOffset, b.writeOffset)
+	n = readOffset - b.readOffset
+	b.readOffset = readOffset
+	b.compactLocked()
+	return n, err
+}
+
+// WaitUntil returns a channel that is closed when WriteOffset exceeds
+// the specified writeOffset, or when the write side is closed via
+// [CloseWrite] (so waiters do not block indefinitely after close).
+//
+// Multiple waiters for the same writeOffset share one channel.
+func (b *VolatileBuffer) WaitUntil(writeOffset int64) <-chan struct{} {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.waiters.wait(b.writeOffset, writeOffset, b.closedWrite)
+}
+
+// CloseWrite closes the write side of the buffer.
+// After CloseWrite, [Write] fails, [Read]/[Peek] return [io.EOF]
+// once all buffered data has been consumed, and all [WaitUntil]
+// waiters are unblocked.
+// CloseWrite is idempotent and returns an error if already closed.
+func (b *VolatileBuffer) CloseWrite() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closedWrite {
+		return wrapError("close", errClosed)
+	}
+	b.closedWrite = true
+	b.waiters.notify(b.writeOffset, b.closedWrite)
+	return nil
+}


### PR DESCRIPTION
This adds a new ring buffer implementation that aims to replace logtail.Buffer and the on-disk implementation in filch.Filch.

There are several problems with filch.Filch:

* Filching stderr should not be done at the buffer layer. This makes structured representation within the buffer difficult as arbitrary stderr data may unexpectedly appear, which hinders attempts at more structured data.

* Log messages are assumed to be discreet lines rather than arbitrary bytes. This makes it harder to switch the structured representation (e.g., using CBOR instead).

* Data that appears asynchronously through stderr never triggers a wake-up within logtail. Consequently logs may never be uploaded.

* Relatedly, there is no mechanism for notifying that data has newly arrived in the buffer.

* There is no two-stage exfiltration. The TryReadLine method may or may not persist the fact that the data was read. It arbitrarily depends on whether we cross a magical file boundary in the dual-file approach. A failed upload followed by a restart results in dropped logs. A successful upload followed by a restart results in duplicated logs.

The new Buffer interface and VolatileBuffer implementation are a step in the direction to resolving these problems.

* In the future, filching will output to a separate pipe that we explicitly process the data for, before putting it into the log buffer. By processing the data, we can protect against stderr garbage being inserted into the buffer unexpectedly breaking any structure.

* The Buffer.Peek and Buffer.DiscardUntil methods provide a way to exfiltrate in a two-step manner. When uploading, we peek at a chunk of data to upload. When successful, we discard the data, ensuring that the buffer knows not to provide that data again. The Len method can be used to suggest to the logging service the amount of back pressure that exists.

Updates tailscale/corp#21363