### PR TITLE
net/traffic: fix rendezvous hashing

### DIFF
--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -6270,8 +6270,8 @@ func TestSuggestExitNodeTrafficSteering(t *testing.T) {
 				},
 			},
 			// Change this, if the hashing function changes.
-			wantID:   "stable1",
-			wantName: "peer1",
+			wantID:   "stable4",
+			wantName: "peer4",
 		},
 		{
 			name: "exit-nodes-without-priority-for-suggestions",
@@ -6289,8 +6289,9 @@ func TestSuggestExitNodeTrafficSteering(t *testing.T) {
 						withLocationPriority(1)),
 				},
 			},
-			wantID:   "stable1",
-			wantName: "peer1",
+			// Change this, if the hashing function changes.
+			wantID:   "stable2",
+			wantName: "peer2",
 			wantPri:  0,
 		},
 		{
@@ -6412,8 +6413,8 @@ func TestSuggestExitNodeTrafficSteering(t *testing.T) {
 				},
 			},
 			// Change this, if the hashing function changes.
-			wantID:   "stable2",
-			wantName: "peer2",
+			wantID:   "stable7",
+			wantName: "peer7",
 			wantPri:  2,
 		},
 		{

--- a/net/traffic/traffic.go
+++ b/net/traffic/traffic.go
@@ -116,7 +116,21 @@ func MakeRendezvousHasher(seed tailcfg.NodeID) NodeHasher {
 		// This is cheap because hash/fnv doesn’t need to allocate.
 		h := fnv.New64a()
 		h.Write(b[:])
-		return h.Sum64()
+		v := h.Sum64()
+
+		// After FNV-1a, finalize the result by mixing in some large
+		// numbers. This ensures a small change in the seed/input bits
+		// causes a large perturbation in the output bits, aka the
+		// "Avalanche Effect".
+		// We opted to use the mix13 variant described by David Stafford,
+		// a popular choice in other language libraries.
+		// https://web.archive.org/web/20260406221046/https://zimbry.blogspot.com/2011/09/better-bit-mixing-improving-on.html
+		v ^= v >> 30
+		v *= 0xbf58476d1ce4e5b9
+		v ^= v >> 27
+		v *= 0x94d049bb133111eb
+		v ^= v >> 31
+		return v
 	}
 }
 

--- a/net/traffic/traffic_test.go
+++ b/net/traffic/traffic_test.go
@@ -144,14 +144,6 @@ func FuzzNodeHasherCompare(f *testing.F) {
 // FuzzSortNodes tests that nodes are sorted such that every node
 // with an equal score has an equal chance of being first.
 func FuzzSortNodes(f *testing.F) {
-	nodeIDs := func(nodes []tailcfg.NodeView) []tailcfg.NodeID {
-		nids := make([]tailcfg.NodeID, len(nodes))
-		for i, n := range nodes {
-			nids[i] = n.ID()
-		}
-		return nids
-	}
-
 	for _, seed := range [][]uint64{
 		{0, 0},
 		{1, 2},
@@ -176,7 +168,6 @@ func FuzzSortNodes(f *testing.F) {
 			}
 			clients[i] = n.View()
 		}
-		t.Logf("client node ids: %v", nodeIDs(clients))
 
 		// Smaller number of candidates, crossing some power of
 		// two boundaries to ensure most-significant-bits don't skew
@@ -203,29 +194,25 @@ func FuzzSortNodes(f *testing.F) {
 			}
 		}
 
-		// Map each candidate to the clients that it was the best candidate for, i.e.,
-		//   candidate 1 -> [client 1, client 17, ...]
-		//   candidate 2 -> [client 3, client 14, ...]
-		//   ...
-		best := make(map[tailcfg.NodeID][]tailcfg.NodeID, len(candidates))
+		// Map each candidate to the number of clients that it was the best candidate for
+		best := make(map[tailcfg.NodeID]int, len(candidates))
 		for i := range len(clients) {
 			peers := slices.Clone(candidates)
 			selfID := clients[i].ID()
 			ss := traffic.ScoresFor(selfID, peers)
 			ss.SortNodes(peers)
-			t.Logf("self %s, sorted %v", selfID, nodeIDs(peers))
 			bestID := peers[0].ID()
-			best[bestID] = append(best[bestID], selfID)
+			best[bestID]++
 		}
 
 		// 20% margin off perfect fairness
 		fair := float64(len(clients)) / float64(len(candidates))
 		lo, hi := math.Floor(fair*0.8), math.Ceil(fair*1.2)
 
-		for candidateID, clientIDs := range best {
-			if count := len(clientIDs); float64(count) < lo || float64(count) > hi {
+		for candidateID, count := range best {
+			if float64(count) < lo || float64(count) > hi {
 				t.Logf("total clients %d; total candidates %d; fair %f", len(clients), len(candidates), fair)
-				t.Errorf("%s is best too frequently (%d): %d", candidateID, count, clientIDs)
+				t.Errorf("%s is best too frequently: %d", candidateID, count)
 				t.Fatalf("best map: %v", best)
 			}
 		}

--- a/net/traffic/traffic_test.go
+++ b/net/traffic/traffic_test.go
@@ -5,6 +5,7 @@ package traffic_test
 
 import (
 	"maps"
+	"math"
 	"math/rand/v2"
 	"slices"
 	"testing"
@@ -165,11 +166,23 @@ func FuzzSortNodes(f *testing.F) {
 
 		wantScore := traffic.Score(rnd.IntN(2000))
 
-		// Create a reasonably large tailnet, between 20 and 40 nodes.
+		// Create a reasonably large tailnet.
 		// If the number of nodes is too small, the chances of one node
 		// getting ranked best becomes non-trivial.
-		nodes := make([]tailcfg.NodeView, rnd.IntN(20)+20)
-		for i := range len(nodes) {
+		clients := make([]tailcfg.NodeView, 10_000)
+		for i := range len(clients) {
+			n := tailcfg.Node{
+				ID: tailcfg.NodeID(rnd.Int64()),
+			}
+			clients[i] = n.View()
+		}
+		t.Logf("client node ids: %v", nodeIDs(clients))
+
+		// Smaller number of candidates, crossing some power of
+		// two boundaries to ensure most-significant-bits don't skew
+		// the hash output distribution.
+		candidates := make([]tailcfg.NodeView, rnd.IntN(16)+1)
+		for i := range len(candidates) {
 			n := tailcfg.Node{
 				ID: tailcfg.NodeID(rnd.Int64()),
 				Hostinfo: (&tailcfg.Hostinfo{
@@ -178,35 +191,41 @@ func FuzzSortNodes(f *testing.F) {
 					},
 				}).View(),
 			}
-			nodes[i] = n.View()
+			candidates[i] = n.View()
 		}
-		t.Logf("node ids: %v", nodeIDs(nodes))
 
 		// All scores should be the same.
-		ss := traffic.ScoresFor(nodes[0].ID(), nodes)
-		for _, n := range nodes {
+		ss := traffic.ScoresFor(clients[0].ID(), candidates)
+		for _, n := range candidates {
 			s := ss.Score(n)
 			if s != wantScore {
 				t.Errorf("%s: score %d, want %d", n.ID(), s, wantScore)
 			}
 		}
 
-		// Sort nodes from the point-of-view of each node and ensure that
-		// every node is equally represented by ensuring one node isn’t
-		// sorted highest too often.
-		best := make(map[tailcfg.NodeID][]tailcfg.NodeID, len(nodes))
-		for i := range len(nodes) {
-			peers := slices.Clone(nodes)
-			selfID := peers[i].ID()
+		// Map each candidate to the clients that it was the best candidate for, i.e.,
+		//   candidate 1 -> [client 1, client 17, ...]
+		//   candidate 2 -> [client 3, client 14, ...]
+		//   ...
+		best := make(map[tailcfg.NodeID][]tailcfg.NodeID, len(candidates))
+		for i := range len(clients) {
+			peers := slices.Clone(candidates)
+			selfID := clients[i].ID()
 			ss := traffic.ScoresFor(selfID, peers)
 			ss.SortNodes(peers)
 			t.Logf("self %s, sorted %v", selfID, nodeIDs(peers))
 			bestID := peers[0].ID()
 			best[bestID] = append(best[bestID], selfID)
 		}
-		for nid, selfIDs := range best {
-			if count := len(selfIDs); count > len(nodes)/2 {
-				t.Errorf("%s is best too frequently: %d", nid, selfIDs)
+
+		// 20% margin off perfect fairness
+		fair := float64(len(clients)) / float64(len(candidates))
+		lo, hi := math.Floor(fair*0.8), math.Ceil(fair*1.2)
+
+		for candidateID, clientIDs := range best {
+			if count := len(clientIDs); float64(count) < lo || float64(count) > hi {
+				t.Logf("total clients %d; total candidates %d; fair %f", len(clients), len(candidates), fair)
+				t.Errorf("%s is best too frequently (%d): %d", candidateID, count, clientIDs)
 				t.Fatalf("best map: %v", best)
 			}
 		}


### PR DESCRIPTION
The rendezvous hasher for traffic steering loadbalancing was flawed. By plainly using the FNV-1a hash value, the result often reflected the magnitude of the most significant bits in the hash seed, meaning the hash function was not diffusive (aka missing the Avalanche Effect). Since our loadbalancing algorithm then relies on the magnitude of the hash value in its decision making, our loadbalancing may be skewed.

Popular wisdom seems to be that the output of FNV-1a should be mixed with some large numbers to perturb more output bits. Borrow concepts from other (Rust, Java) libraries by using the mix13 variant of 64-bit finalizers by David Stafford.

Modify the fuzz test that asserts this fairness. Adjust a few constants like client count and candidate count to more closely reflect real-world scenarios and practical probabilities. Tighten the bounds for distribution from 50% to +-20%.

Updates tailscale/corp#46471