### PR TITLE
net/dns/openresolv: handle exit code 2 from resolvconf -i (no interfaces) [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/net/dns/openresolv.go
+++ b/net/dns/openresolv.go
@@ -77,6 +77,12 @@ func (m openresolvManager) GetBaseConfig() (OSConfig, error) {
 	// which we'll exploit later.
 	bs, err := exec.Command("resolvconf", "-i").CombinedOutput()
 	if err != nil {
+		// openresolv exits with status 2 when no interfaces are
+		// configured. In that case there is no base config to
+		// blend, so return an empty OSConfig rather than failing.
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 2 {
+			return OSConfig{}, nil
+		}
 		return OSConfig{}, err
 	}
 


### PR DESCRIPTION
When openresolv has no configured interfaces, `resolvconf -i` returns
exit code 2. The `GetBaseConfig` method in the openresolv manager treats any
non-nil error from `resolvconf -i` as a fatal error, causing DNS configuration
to fail with "error: exit status 2".

Fix this by treating exit code 2 as "no interfaces configured" and returning an
empty `OSConfig` instead of an error.

Fixes #20825