### PR TITLE
k8s-operator: make PeerRelay endpoints reachable on EKS by default

### DIFF
--- a/cmd/k8s-operator/deploy/crds/tailscale.com_peerrelays.yaml
+++ b/cmd/k8s-operator/deploy/crds/tailscale.com_peerrelays.yaml
@@ -64,6 +64,15 @@ spec:
                     AWS contains configuration for pinning each replica to a specific AWS Elastic IP and subnet. Only meaningful
                     when running on EKS with the AWS Load Balancer Controller. When set, the per-replica values override any
                     aws-load-balancer-eip-allocations or aws-load-balancer-subnets values supplied via spec.service.annotations.
+
+                    Leave this unset unless the peer relays must be reachable on addresses you control. Pinning a subnet
+                    confines a replica's load balancer to that subnet's availability zone, and an AWS Network Load Balancer
+                    only forwards to targets in a zone that is enabled on it, so a replica whose pod is scheduled into any
+                    other zone stops receiving traffic. Setting this field therefore also requires pinning the pods to the
+                    matching zone with a ProxyClass, as described on ElasticIPs. Without this field the AWS Load Balancer
+                    Controller instead provisions each load balancer across every zone it discovers, and the operator turns on
+                    cross-zone load balancing so the replica is reachable wherever it happens to be scheduled, with no
+                    scheduling constraints needed.
                   type: object
                   required:
                     - elasticIPs
@@ -75,6 +84,19 @@ spec:
                         per replica: replica N uses ElasticIPs[N]. The list must be at least as long as spec.replicas so every replica
                         has a distinct EIP; extra entries are permitted so that scale-up doesn't immediately trip validation.
 
+                        Pinning a subnet enables only that subnet's availability zone on the replica's load balancer, and a Network
+                        Load Balancer only forwards to targets in an enabled zone. Nothing constrains the scheduler to place the
+                        replica's pod in that zone, so a pod scheduled elsewhere, including after a reschedule, becomes unreachable
+                        on its Elastic IP while still appearing healthy.
+
+                        Every replica of a PeerRelay shares one pod template, so a ProxyClass referenced by spec.proxyClass can
+                        confine the pods to a zone but cannot place different replicas in different zones. To use this field
+                        safely, name subnets in a single availability zone and pin the pods to that same zone with a ProxyClass
+                        setting spec.statefulSet.pod.nodeSelector to topology.kubernetes.io/zone. Note that this trades the zone
+                        redundancy that running several replicas would otherwise buy. Spreading replicas across zones with their
+                        own Elastic IPs needs a per-replica scheduling constraint that neither PeerRelay nor ProxyClass can
+                        currently express.
+
                         When set, the reconciler stamps
                         service.beta.kubernetes.io/aws-load-balancer-eip-allocations and
                         service.beta.kubernetes.io/aws-load-balancer-subnets on each per-replica Service, overriding any values in
@@ -82,7 +104,7 @@ spec:
                       type: array
                       minItems: 1
                       items:
-                        description: PeerRelayAWSElasticIP pairs an EIP allocation with the subnet in the same AZ.
+                        description: PeerRelayAWSElasticIP pairs an EIP allocation with the subnet it is attached to.
                         type: object
                         required:
                           - allocationID
@@ -96,9 +118,11 @@ spec:
                             pattern: ^eipalloc-[0-9a-f]+$
                           subnetID:
                             description: |-
-                              SubnetID is the AWS subnet in the same availability zone as AllocationID (e.g. subnet-0123abcd). Stamped as
-                              service.beta.kubernetes.io/aws-load-balancer-subnets on the replica's Service so the NLB is provisioned in
-                              the same AZ as the EIP.
+                              SubnetID is the AWS subnet the replica's load balancer is provisioned in (e.g. subnet-0123abcd). It must be
+                              a public subnet, and no two replicas may name subnets in the same availability zone, since a load balancer
+                              accepts only one Elastic IP per zone. A standard VPC Elastic IP is regional rather than zonal, so it takes
+                              the zone of whichever subnet it is paired with here. Stamped as
+                              service.beta.kubernetes.io/aws-load-balancer-subnets on the replica's Service.
                             type: string
                             pattern: ^subnet-[0-9a-f]+$
                       x-kubernetes-list-type: atomic
@@ -231,9 +255,10 @@ spec:
                   x-kubernetes-list-type: map
                 endpoints:
                   description: |-
-                    Endpoints lists the public address:port pairs each peer relay replica is reachable on. There is one entry
-                    per replica whose LoadBalancer Service has been assigned a public address; entries appear as the underlying
-                    cloud provisions each Service.
+                    Endpoints lists the public address:port pairs each peer relay replica is reachable on. Entries appear as the
+                    underlying cloud provisions each Service. A replica has one entry per address its LoadBalancer Service was
+                    given, which is usually one, but a load balancer spanning several availability zones has an address in each
+                    and every one of them is listed.
                   type: array
                   items:
                     type: object
@@ -257,6 +282,7 @@ spec:
                         format: int32
                   x-kubernetes-list-map-keys:
                     - replica
+                    - address
                   x-kubernetes-list-type: map
       served: true
       storage: true

--- a/cmd/k8s-operator/deploy/manifests/operator.yaml
+++ b/cmd/k8s-operator/deploy/manifests/operator.yaml
@@ -1544,6 +1544,15 @@ spec:
                                     AWS contains configuration for pinning each replica to a specific AWS Elastic IP and subnet. Only meaningful
                                     when running on EKS with the AWS Load Balancer Controller. When set, the per-replica values override any
                                     aws-load-balancer-eip-allocations or aws-load-balancer-subnets values supplied via spec.service.annotations.
+
+                                    Leave this unset unless the peer relays must be reachable on addresses you control. Pinning a subnet
+                                    confines a replica's load balancer to that subnet's availability zone, and an AWS Network Load Balancer
+                                    only forwards to targets in a zone that is enabled on it, so a replica whose pod is scheduled into any
+                                    other zone stops receiving traffic. Setting this field therefore also requires pinning the pods to the
+                                    matching zone with a ProxyClass, as described on ElasticIPs. Without this field the AWS Load Balancer
+                                    Controller instead provisions each load balancer across every zone it discovers, and the operator turns on
+                                    cross-zone load balancing so the replica is reachable wherever it happens to be scheduled, with no
+                                    scheduling constraints needed.
                                 properties:
                                     elasticIPs:
                                         description: |-
@@ -1552,12 +1561,25 @@ spec:
                                             per replica: replica N uses ElasticIPs[N]. The list must be at least as long as spec.replicas so every replica
                                             has a distinct EIP; extra entries are permitted so that scale-up doesn't immediately trip validation.
 
+                                            Pinning a subnet enables only that subnet's availability zone on the replica's load balancer, and a Network
+                                            Load Balancer only forwards to targets in an enabled zone. Nothing constrains the scheduler to place the
+                                            replica's pod in that zone, so a pod scheduled elsewhere, including after a reschedule, becomes unreachable
+                                            on its Elastic IP while still appearing healthy.
+
+                                            Every replica of a PeerRelay shares one pod template, so a ProxyClass referenced by spec.proxyClass can
+                                            confine the pods to a zone but cannot place different replicas in different zones. To use this field
+                                            safely, name subnets in a single availability zone and pin the pods to that same zone with a ProxyClass
+                                            setting spec.statefulSet.pod.nodeSelector to topology.kubernetes.io/zone. Note that this trades the zone
+                                            redundancy that running several replicas would otherwise buy. Spreading replicas across zones with their
+                                            own Elastic IPs needs a per-replica scheduling constraint that neither PeerRelay nor ProxyClass can
+                                            currently express.
+
                                             When set, the reconciler stamps
                                             service.beta.kubernetes.io/aws-load-balancer-eip-allocations and
                                             service.beta.kubernetes.io/aws-load-balancer-subnets on each per-replica Service, overriding any values in
                                             spec.service.annotations.
                                         items:
-                                            description: PeerRelayAWSElasticIP pairs an EIP allocation with the subnet in the same AZ.
+                                            description: PeerRelayAWSElasticIP pairs an EIP allocation with the subnet it is attached to.
                                             properties:
                                                 allocationID:
                                                     description: |-
@@ -1567,9 +1589,11 @@ spec:
                                                     type: string
                                                 subnetID:
                                                     description: |-
-                                                        SubnetID is the AWS subnet in the same availability zone as AllocationID (e.g. subnet-0123abcd). Stamped as
-                                                        service.beta.kubernetes.io/aws-load-balancer-subnets on the replica's Service so the NLB is provisioned in
-                                                        the same AZ as the EIP.
+                                                        SubnetID is the AWS subnet the replica's load balancer is provisioned in (e.g. subnet-0123abcd). It must be
+                                                        a public subnet, and no two replicas may name subnets in the same availability zone, since a load balancer
+                                                        accepts only one Elastic IP per zone. A standard VPC Elastic IP is regional rather than zonal, so it takes
+                                                        the zone of whichever subnet it is paired with here. Stamped as
+                                                        service.beta.kubernetes.io/aws-load-balancer-subnets on the replica's Service.
                                                     pattern: ^subnet-[0-9a-f]+$
                                                     type: string
                                             required:
@@ -1711,9 +1735,10 @@ spec:
                                 x-kubernetes-list-type: map
                             endpoints:
                                 description: |-
-                                    Endpoints lists the public address:port pairs each peer relay replica is reachable on. There is one entry
-                                    per replica whose LoadBalancer Service has been assigned a public address; entries appear as the underlying
-                                    cloud provisions each Service.
+                                    Endpoints lists the public address:port pairs each peer relay replica is reachable on. Entries appear as the
+                                    underlying cloud provisions each Service. A replica has one entry per address its LoadBalancer Service was
+                                    given, which is usually one, but a load balancer spanning several availability zones has an address in each
+                                    and every one of them is listed.
                                 items:
                                     properties:
                                         address:
@@ -1737,6 +1762,7 @@ spec:
                                 type: array
                                 x-kubernetes-list-map-keys:
                                     - replica
+                                    - address
                                 x-kubernetes-list-type: map
                         type: object
                 required:

--- a/k8s-operator/api.md
+++ b/k8s-operator/api.md
@@ -576,14 +576,14 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `elasticIPs` _[PeerRelayAWSElasticIP](#peerrelayawselasticip) array_ | ElasticIPs pins each replica to a specific AWS EIP allocation and subnet. Only meaningful when Network Load<br />Balancers are provisioned by the AWS Load Balancer Controller. ElasticIPs supplies one allocation-subnet pair<br />per replica: replica N uses ElasticIPs[N]. The list must be at least as long as spec.replicas so every replica<br />has a distinct EIP; extra entries are permitted so that scale-up doesn't immediately trip validation.<br />When set, the reconciler stamps<br />service.beta.kubernetes.io/aws-load-balancer-eip-allocations and<br />service.beta.kubernetes.io/aws-load-balancer-subnets on each per-replica Service, overriding any values in<br />spec.service.annotations. |  | MinItems: 1 <br /> |
+| `elasticIPs` _[PeerRelayAWSElasticIP](#peerrelayawselasticip) array_ | ElasticIPs pins each replica to a specific AWS EIP allocation and subnet. Only meaningful when Network Load<br />Balancers are provisioned by the AWS Load Balancer Controller. ElasticIPs supplies one allocation-subnet pair<br />per replica: replica N uses ElasticIPs[N]. The list must be at least as long as spec.replicas so every replica<br />has a distinct EIP; extra entries are permitted so that scale-up doesn't immediately trip validation.<br />Pinning a subnet enables only that subnet's availability zone on the replica's load balancer, and a Network<br />Load Balancer only forwards to targets in an enabled zone. Nothing constrains the scheduler to place the<br />replica's pod in that zone, so a pod scheduled elsewhere, including after a reschedule, becomes unreachable<br />on its Elastic IP while still appearing healthy.<br />Every replica of a PeerRelay shares one pod template, so a ProxyClass referenced by spec.proxyClass can<br />confine the pods to a zone but cannot place different replicas in different zones. To use this field<br />safely, name subnets in a single availability zone and pin the pods to that same zone with a ProxyClass<br />setting spec.statefulSet.pod.nodeSelector to topology.kubernetes.io/zone. Note that this trades the zone<br />redundancy that running several replicas would otherwise buy. Spreading replicas across zones with their<br />own Elastic IPs needs a per-replica scheduling constraint that neither PeerRelay nor ProxyClass can<br />currently express.<br />When set, the reconciler stamps<br />service.beta.kubernetes.io/aws-load-balancer-eip-allocations and<br />service.beta.kubernetes.io/aws-load-balancer-subnets on each per-replica Service, overriding any values in<br />spec.service.annotations. |  | MinItems: 1 <br /> |
 
 
 #### PeerRelayAWSElasticIP
 
 
 
-PeerRelayAWSElasticIP pairs an EIP allocation with the subnet in the same AZ.
+PeerRelayAWSElasticIP pairs an EIP allocation with the subnet it is attached to.
 
 
 
@@ -593,7 +593,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `allocationID` _string_ | AllocationID is the AWS EIP allocation ID (e.g. eipalloc-0123abcd) whose public IP this replica is reachable<br />on. Stamped as service.beta.kubernetes.io/aws-load-balancer-eip-allocations on the replica's Service. |  | Pattern: `^eipalloc-[0-9a-f]+$` <br /> |
-| `subnetID` _string_ | SubnetID is the AWS subnet in the same availability zone as AllocationID (e.g. subnet-0123abcd). Stamped as<br />service.beta.kubernetes.io/aws-load-balancer-subnets on the replica's Service so the NLB is provisioned in<br />the same AZ as the EIP. |  | Pattern: `^subnet-[0-9a-f]+$` <br /> |
+| `subnetID` _string_ | SubnetID is the AWS subnet the replica's load balancer is provisioned in (e.g. subnet-0123abcd). It must be<br />a public subnet, and no two replicas may name subnets in the same availability zone, since a load balancer<br />accepts only one Elastic IP per zone. A standard VPC Elastic IP is regional rather than zonal, so it takes<br />the zone of whichever subnet it is paired with here. Stamped as<br />service.beta.kubernetes.io/aws-load-balancer-subnets on the replica's Service. |  | Pattern: `^subnet-[0-9a-f]+$` <br /> |
 
 
 #### PeerRelayEndpoint
@@ -669,7 +669,7 @@ _Appears in:_
 | `replicas` _integer_ | Replicas specifies how many devices to create. Set this to enable<br />high availability for peer relays.<br />https://tailscale.com/kb/1115/high-availability. Defaults to 1. | 1 | Minimum: 0 <br /> |
 | `tailnet` _string_ | Tailnet specifies the tailnet this PeerRelay should join. If blank, the default tailnet is used. When set, this<br />name must match that of a valid Tailnet resource. This field is immutable and cannot be changed once set. |  |  |
 | `service` _[PeerRelayService](#peerrelayservice)_ | Service contains configuration values to modify the LoadBalancer service used to expose the peer relay. |  |  |
-| `aws` _[PeerRelayAWS](#peerrelayaws)_ | AWS contains configuration for pinning each replica to a specific AWS Elastic IP and subnet. Only meaningful<br />when running on EKS with the AWS Load Balancer Controller. When set, the per-replica values override any<br />aws-load-balancer-eip-allocations or aws-load-balancer-subnets values supplied via spec.service.annotations. |  |  |
+| `aws` _[PeerRelayAWS](#peerrelayaws)_ | AWS contains configuration for pinning each replica to a specific AWS Elastic IP and subnet. Only meaningful<br />when running on EKS with the AWS Load Balancer Controller. When set, the per-replica values override any<br />aws-load-balancer-eip-allocations or aws-load-balancer-subnets values supplied via spec.service.annotations.<br />Leave this unset unless the peer relays must be reachable on addresses you control. Pinning a subnet<br />confines a replica's load balancer to that subnet's availability zone, and an AWS Network Load Balancer<br />only forwards to targets in a zone that is enabled on it, so a replica whose pod is scheduled into any<br />other zone stops receiving traffic. Setting this field therefore also requires pinning the pods to the<br />matching zone with a ProxyClass, as described on ElasticIPs. Without this field the AWS Load Balancer<br />Controller instead provisions each load balancer across every zone it discovers, and the operator turns on<br />cross-zone load balancing so the replica is reachable wherever it happens to be scheduled, with no<br />scheduling constraints needed. |  |  |
 
 
 #### PeerRelayStatus
@@ -686,7 +686,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.3/#condition-v1-meta) array_ |  |  |  |
-| `endpoints` _[PeerRelayEndpoint](#peerrelayendpoint) array_ | Endpoints lists the public address:port pairs each peer relay replica is reachable on. There is one entry<br />per replica whose LoadBalancer Service has been assigned a public address; entries appear as the underlying<br />cloud provisions each Service. |  |  |
+| `endpoints` _[PeerRelayEndpoint](#peerrelayendpoint) array_ | Endpoints lists the public address:port pairs each peer relay replica is reachable on. Entries appear as the<br />underlying cloud provisions each Service. A replica has one entry per address its LoadBalancer Service was<br />given, which is usually one, but a load balancer spanning several availability zones has an address in each<br />and every one of them is listed. |  |  |
 
 
 #### Pod

--- a/k8s-operator/apis/v1alpha1/types_peerrelay.go
+++ b/k8s-operator/apis/v1alpha1/types_peerrelay.go
@@ -96,6 +96,15 @@ type PeerRelaySpec struct {
 	// AWS contains configuration for pinning each replica to a specific AWS Elastic IP and subnet. Only meaningful
 	// when running on EKS with the AWS Load Balancer Controller. When set, the per-replica values override any
 	// aws-load-balancer-eip-allocations or aws-load-balancer-subnets values supplied via spec.service.annotations.
+	//
+	// Leave this unset unless the peer relays must be reachable on addresses you control. Pinning a subnet
+	// confines a replica's load balancer to that subnet's availability zone, and an AWS Network Load Balancer
+	// only forwards to targets in a zone that is enabled on it, so a replica whose pod is scheduled into any
+	// other zone stops receiving traffic. Setting this field therefore also requires pinning the pods to the
+	// matching zone with a ProxyClass, as described on ElasticIPs. Without this field the AWS Load Balancer
+	// Controller instead provisions each load balancer across every zone it discovers, and the operator turns on
+	// cross-zone load balancing so the replica is reachable wherever it happens to be scheduled, with no
+	// scheduling constraints needed.
 	// +optional
 	AWS *PeerRelayAWS `json:"aws,omitzero"`
 }
@@ -114,6 +123,19 @@ type PeerRelayAWS struct {
 	// per replica: replica N uses ElasticIPs[N]. The list must be at least as long as spec.replicas so every replica
 	// has a distinct EIP; extra entries are permitted so that scale-up doesn't immediately trip validation.
 	//
+	// Pinning a subnet enables only that subnet's availability zone on the replica's load balancer, and a Network
+	// Load Balancer only forwards to targets in an enabled zone. Nothing constrains the scheduler to place the
+	// replica's pod in that zone, so a pod scheduled elsewhere, including after a reschedule, becomes unreachable
+	// on its Elastic IP while still appearing healthy.
+	//
+	// Every replica of a PeerRelay shares one pod template, so a ProxyClass referenced by spec.proxyClass can
+	// confine the pods to a zone but cannot place different replicas in different zones. To use this field
+	// safely, name subnets in a single availability zone and pin the pods to that same zone with a ProxyClass
+	// setting spec.statefulSet.pod.nodeSelector to topology.kubernetes.io/zone. Note that this trades the zone
+	// redundancy that running several replicas would otherwise buy. Spreading replicas across zones with their
+	// own Elastic IPs needs a per-replica scheduling constraint that neither PeerRelay nor ProxyClass can
+	// currently express.
+	//
 	// When set, the reconciler stamps
 	// service.beta.kubernetes.io/aws-load-balancer-eip-allocations and
 	// service.beta.kubernetes.io/aws-load-balancer-subnets on each per-replica Service, overriding any values in
@@ -123,16 +145,18 @@ type PeerRelayAWS struct {
 	ElasticIPs []PeerRelayAWSElasticIP `json:"elasticIPs"`
 }
 
-// PeerRelayAWSElasticIP pairs an EIP allocation with the subnet in the same AZ.
+// PeerRelayAWSElasticIP pairs an EIP allocation with the subnet it is attached to.
 type PeerRelayAWSElasticIP struct {
 	// AllocationID is the AWS EIP allocation ID (e.g. eipalloc-0123abcd) whose public IP this replica is reachable
 	// on. Stamped as service.beta.kubernetes.io/aws-load-balancer-eip-allocations on the replica's Service.
 	// +kubebuilder:validation:Pattern=`^eipalloc-[0-9a-f]+$`
 	AllocationID string `json:"allocationID"`
 
-	// SubnetID is the AWS subnet in the same availability zone as AllocationID (e.g. subnet-0123abcd). Stamped as
-	// service.beta.kubernetes.io/aws-load-balancer-subnets on the replica's Service so the NLB is provisioned in
-	// the same AZ as the EIP.
+	// SubnetID is the AWS subnet the replica's load balancer is provisioned in (e.g. subnet-0123abcd). It must be
+	// a public subnet, and no two replicas may name subnets in the same availability zone, since a load balancer
+	// accepts only one Elastic IP per zone. A standard VPC Elastic IP is regional rather than zonal, so it takes
+	// the zone of whichever subnet it is paired with here. Stamped as
+	// service.beta.kubernetes.io/aws-load-balancer-subnets on the replica's Service.
 	// +kubebuilder:validation:Pattern=`^subnet-[0-9a-f]+$`
 	SubnetID string `json:"subnetID"`
 }
@@ -143,11 +167,13 @@ type PeerRelayStatus struct {
 	// +optional
 	Conditions []metav1.Condition `json:"conditions"`
 
-	// Endpoints lists the public address:port pairs each peer relay replica is reachable on. There is one entry
-	// per replica whose LoadBalancer Service has been assigned a public address; entries appear as the underlying
-	// cloud provisions each Service.
+	// Endpoints lists the public address:port pairs each peer relay replica is reachable on. Entries appear as the
+	// underlying cloud provisions each Service. A replica has one entry per address its LoadBalancer Service was
+	// given, which is usually one, but a load balancer spanning several availability zones has an address in each
+	// and every one of them is listed.
 	// +listType=map
 	// +listMapKey=replica
+	// +listMapKey=address
 	// +optional
 	Endpoints []PeerRelayEndpoint `json:"endpoints,omitempty"`
 }

--- a/k8s-operator/reconciler/peerrelay/peerrelay.go
+++ b/k8s-operator/reconciler/peerrelay/peerrelay.go
@@ -270,22 +270,17 @@ func (r *Reconciler) createOrUpdate(ctx context.Context, logger *zap.SugaredLogg
 		return reconcile.Result{}, fmt.Errorf("failed to read endpoints for PeerRelay %q: %w", pr.Name, err)
 	}
 
-	endpointsByReplica := make(map[int32]tsapi.PeerRelayEndpoint, len(endpoints))
+	endpointsByReplica := make(map[int32][]tsapi.PeerRelayEndpoint, len(endpoints))
 	for _, ep := range endpoints {
-		endpointsByReplica[ep.Replica] = ep
+		endpointsByReplica[ep.Replica] = append(endpointsByReplica[ep.Replica], ep)
 	}
 
 	for i := int32(0); i < replicas; i++ {
-		var endpoint *tsapi.PeerRelayEndpoint
-		if ep, ok := endpointsByReplica[i]; ok {
-			endpoint = &ep
-		}
-
 		if err = r.ensureStateSecret(ctx, logger, pr, i); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to apply state Secret for PeerRelay %q replica %d: %w", pr.Name, i, err)
 		}
 
-		if err = r.ensureConfigSecret(ctx, logger, pr, i, endpoint); err != nil {
+		if err = r.ensureConfigSecret(ctx, logger, pr, i, endpointsByReplica[i]); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to apply config Secret for PeerRelay %q replica %d: %w", pr.Name, i, err)
 		}
 	}
@@ -334,28 +329,30 @@ func (r *Reconciler) readEndpoints(ctx context.Context, logger *zap.SugaredLogge
 		return nil, fmt.Errorf("failed to list Services: %w", err)
 	}
 
-	prevByReplica := make(map[int32]tsapi.PeerRelayEndpoint, len(pr.Status.Endpoints))
+	prevByReplica := make(map[int32][]tsapi.PeerRelayEndpoint, len(pr.Status.Endpoints))
 	for _, ep := range pr.Status.Endpoints {
-		prevByReplica[ep.Replica] = ep
+		prevByReplica[ep.Replica] = append(prevByReplica[ep.Replica], ep)
 	}
 
 	var endpoints []tsapi.PeerRelayEndpoint
 	for i := range list.Items {
 		svc := &list.Items[i]
-		var prev *tsapi.PeerRelayEndpoint
+		var prev []tsapi.PeerRelayEndpoint
 		if idx, ok := replicaIndexFromLabels(svc.Labels); ok {
-			if ep, ok := prevByReplica[idx]; ok {
-				prev = &ep
-			}
+			prev = prevByReplica[idx]
 		}
 
-		if endpoint := r.peerRelayEndpoint(ctx, logger, svc, prev); endpoint != nil {
-			endpoints = append(endpoints, *endpoint)
-		}
+		endpoints = append(endpoints, r.peerRelayEndpoints(ctx, logger, svc, prev)...)
 	}
 
+	// Sorted by replica then address so the list is stable across reconciles, which keeps status updates and the
+	// resulting tailscaled config free of spurious churn. status.endpoints is keyed on both fields, so the pair
+	// is unique.
 	slices.SortFunc(endpoints, func(a, b tsapi.PeerRelayEndpoint) int {
-		return cmp.Compare(a.Replica, b.Replica)
+		if c := cmp.Compare(a.Replica, b.Replica); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Address, b.Address)
 	})
 
 	return endpoints, nil
@@ -371,9 +368,14 @@ func (r *Reconciler) writeStatus(ctx context.Context, logger *zap.SugaredLogger,
 		readyReplicas = ss.Status.ReadyReplicas
 	}
 
+	addressed := make(map[int32]struct{}, len(endpoints))
+	for _, ep := range endpoints {
+		addressed[ep.Replica] = struct{}{}
+	}
+
 	switch {
-	case int32(len(endpoints)) < replicas:
-		message := fmt.Sprintf("%d of %d replicas have a public IP", len(endpoints), replicas)
+	case int32(len(addressed)) < replicas:
+		message := fmt.Sprintf("%d of %d replicas have a public IP", len(addressed), replicas)
 		operatorutils.SetPeerRelayCondition(pr, tsapi.PeerRelayReady, metav1.ConditionFalse, ReasonEndpointsPending, message, r.clock, logger)
 	case readyReplicas < replicas:
 		message := fmt.Sprintf("%d of %d pods are ready", readyReplicas, replicas)
@@ -463,7 +465,7 @@ func (r *Reconciler) deleteServicesFrom(ctx context.Context, logger *zap.Sugared
 	return nil
 }
 
-func (r *Reconciler) ensureConfigSecret(ctx context.Context, logger *zap.SugaredLogger, pr *tsapi.PeerRelay, idx int32, endpoint *tsapi.PeerRelayEndpoint) error {
+func (r *Reconciler) ensureConfigSecret(ctx context.Context, logger *zap.SugaredLogger, pr *tsapi.PeerRelay, idx int32, endpoints []tsapi.PeerRelayEndpoint) error {
 	tsClient, err := r.tsClients.For(pr.Spec.Tailnet)
 	if err != nil {
 		return fmt.Errorf("failed to resolve Tailscale API client for tailnet %q: %w", pr.Spec.Tailnet, err)
@@ -474,7 +476,7 @@ func (r *Reconciler) ensureConfigSecret(ctx context.Context, logger *zap.Sugared
 		return err
 	}
 
-	desired, err := r.peerRelayConfigSecret(pr, idx, endpoint, authKey, tsClient.LoginURL())
+	desired, err := r.peerRelayConfigSecret(pr, idx, endpoints, authKey, tsClient.LoginURL())
 	if err != nil {
 		return fmt.Errorf("failed to build config Secret: %w", err)
 	}

--- a/k8s-operator/reconciler/peerrelay/peerrelay_test.go
+++ b/k8s-operator/reconciler/peerrelay/peerrelay_test.go
@@ -46,6 +46,12 @@ func testResolver(_ context.Context, _ string, host string) ([]netip.Addr, error
 	r := map[string][]netip.Addr{
 		"test-0.elb.amazonaws.com": {netip.MustParseAddr("203.0.113.10")},
 		"test-1.elb.amazonaws.com": {netip.MustParseAddr("203.0.113.11")},
+		// A load balancer spread over several availability zones, returned out of order so the reconciler's
+		// sorting is exercised.
+		"multi-az.elb.amazonaws.com": {
+			netip.MustParseAddr("203.0.113.30"),
+			netip.MustParseAddr("203.0.113.20"),
+		},
 	}
 
 	if addrs, ok := r[host]; ok {
@@ -244,6 +250,11 @@ func TestReconciler_Reconcile(t *testing.T) {
 					Annotations: map[string]string{
 						"service.beta.kubernetes.io/aws-load-balancer-scheme":     "internet-facing",
 						"service.beta.kubernetes.io/azure-load-balancer-internal": "false",
+						// A peer relay listens only on UDP, so the load balancer must health check the pod's
+						// /healthz endpoint instead of the port it forwards, which would never answer.
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol": "http",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-port":     "9002",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-path":     "/healthz",
 					},
 				},
 			},
@@ -393,21 +404,85 @@ func TestReconciler_Reconcile(t *testing.T) {
 			ExpectedReadyReason: peerrelay.ReasonEndpointsPending,
 		},
 		{
-			// A hostname-only Service without the EIP annotation is a Service whose backing LB has unstable IPs
-			// (unmanaged AWS NLB, most third-party providers). The reconciler refuses to resolve — advertising a
-			// transient IP would leave peers connecting to a dead endpoint if AWS shifts the underlying A records.
-			// Users get an explicit "pending" state and either add the annotation or accept the LB isn't usable.
-			Name:    "hostname-without-eip-annotation-stays-pending",
+			// Without spec.aws the reconciler pins no subnet, so the AWS Load Balancer Controller spreads the NLB
+			// over every zone it discovers and cross-zone is defaulted on to make all of those addresses reach the
+			// pod. The hostname is still resolved and advertised: an NLB's addresses are fixed for its lifetime
+			// whether or not an Elastic IP was supplied, so there is nothing to be gained by withholding the
+			// endpoint. Replaces an older rule that only resolved when an EIP annotation was present, which left
+			// this configuration permanently pending despite being perfectly reachable.
+			Name:    "unpinned-nlb-resolves-and-enables-cross-zone",
 			Request: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
 			PeerRelay: &tsapi.PeerRelay{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 			},
 			ExistingResources: []client.Object{
 				managedServiceWithLB("test", 0, "", "test-0.elb.amazonaws.com"),
+				managedStatefulSet("test", 1, 1),
 			},
-			ExpectedServices:    []expectedService{{Name: "peerrelay-test-0"}},
-			ExpectedReadyStatus: metav1.ConditionFalse,
-			ExpectedReadyReason: peerrelay.ReasonEndpointsPending,
+			ExpectedServices: []expectedService{
+				{
+					Name: "peerrelay-test-0",
+					Annotations: map[string]string{
+						lbAttributesAnnotation: "load_balancing.cross_zone.enabled=true",
+					},
+					AbsentAnnotations: []string{eipAllocationsAnnotation, subnetsAnnotation},
+				},
+			},
+			ExpectedEndpoints: []tsapi.PeerRelayEndpoint{
+				{Replica: 0, Address: "203.0.113.10", Port: 41641},
+			},
+			ExpectedReadyStatus: metav1.ConditionTrue,
+			ExpectedReadyReason: peerrelay.ReasonReady,
+		},
+		{
+			// Cross-zone is defaulted on even alongside a pinned EIP. It is inert in that case, since pinning a
+			// subnet leaves only one zone enabled on the load balancer, but applying it unconditionally keeps the
+			// annotation set uniform across every replica.
+			Name:    "pinned-eip-still-gets-cross-zone",
+			Request: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
+			PeerRelay: &tsapi.PeerRelay{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: tsapi.PeerRelaySpec{
+					AWS: &tsapi.PeerRelayAWS{
+						ElasticIPs: []tsapi.PeerRelayAWSElasticIP{
+							{AllocationID: "eipalloc-aaaa", SubnetID: "subnet-aaaa"},
+						},
+					},
+				},
+			},
+			ExpectedServices: []expectedService{
+				{
+					Name: "peerrelay-test-0",
+					Annotations: map[string]string{
+						eipAllocationsAnnotation: "eipalloc-aaaa",
+						subnetsAnnotation:        "subnet-aaaa",
+						lbAttributesAnnotation:   "load_balancing.cross_zone.enabled=true",
+					},
+				},
+			},
+		},
+		{
+			// A user-supplied attributes value must survive untouched, including turning cross-zone back off.
+			Name:    "user-attributes-annotation-is-not-overridden",
+			Request: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
+			PeerRelay: &tsapi.PeerRelay{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: tsapi.PeerRelaySpec{
+					Service: &tsapi.PeerRelayService{
+						Annotations: map[string]string{
+							lbAttributesAnnotation: "load_balancing.cross_zone.enabled=false",
+						},
+					},
+				},
+			},
+			ExpectedServices: []expectedService{
+				{
+					Name: "peerrelay-test-0",
+					Annotations: map[string]string{
+						lbAttributesAnnotation: "load_balancing.cross_zone.enabled=false",
+					},
+				},
+			},
 		},
 		{
 			// Mixed batch: one replica has a direct IP, another has only a hostname that resolves (with EIP
@@ -435,6 +510,52 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 			ExpectedReadyStatus: metav1.ConditionTrue,
 			ExpectedReadyReason: peerrelay.ReasonReady,
+		},
+		{
+			// A load balancer spanning several availability zones answers on one address per zone, and every one
+			// of them reaches the replica. All are advertised so a peer can still get through when a zone is
+			// unreachable, and so the user is not paying for addresses nothing uses. status.endpoints is keyed on
+			// replica and address together, so one replica can hold several entries.
+			Name:    "multi-az-lb-advertises-every-address",
+			Request: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
+			PeerRelay: &tsapi.PeerRelay{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			},
+			ExistingResources: []client.Object{
+				managedServiceWithLB("test", 0, "", "multi-az.elb.amazonaws.com"),
+				managedStatefulSet("test", 1, 1),
+			},
+			ExpectedServices: []expectedService{{Name: "peerrelay-test-0"}},
+			ExpectedEndpoints: []tsapi.PeerRelayEndpoint{
+				{Replica: 0, Address: "203.0.113.20", Port: 41641},
+				{Replica: 0, Address: "203.0.113.30", Port: 41641},
+			},
+			ExpectedReadyStatus: metav1.ConditionTrue,
+			ExpectedReadyReason: peerrelay.ReasonReady,
+		},
+		{
+			// Replica 0's load balancer spans two zones and contributes two entries, while replica 1 has no
+			// address yet. There are as many entries as replicas, but only one replica is reachable, so the
+			// PeerRelay must not report ready. Counting entries rather than replicas would let the multi-homed
+			// replica mask the one that peers cannot reach at all.
+			Name:    "multi-az-endpoints-do-not-mask-a-replica-without-one",
+			Request: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
+			PeerRelay: &tsapi.PeerRelay{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec:       tsapi.PeerRelaySpec{Replicas: new(int32(2))},
+			},
+			ExistingResources: []client.Object{
+				managedServiceWithLB("test", 0, "", "multi-az.elb.amazonaws.com"),
+				managedService("test", 1),
+				managedStatefulSet("test", 2, 2),
+			},
+			ExpectedServices: []expectedService{{Name: "peerrelay-test-0"}, {Name: "peerrelay-test-1"}},
+			ExpectedEndpoints: []tsapi.PeerRelayEndpoint{
+				{Replica: 0, Address: "203.0.113.20", Port: 41641},
+				{Replica: 0, Address: "203.0.113.30", Port: 41641},
+			},
+			ExpectedReadyStatus: metav1.ConditionFalse,
+			ExpectedReadyReason: peerrelay.ReasonEndpointsPending,
 		},
 		{
 			// Mid-provisioning: some LBs have addresses, some don't yet. Only the ready ones show up.
@@ -737,6 +858,25 @@ func assertStatefulSet(t *testing.T, fc client.Client, prName string, want *stat
 			t.Errorf("expected container image %q, got %q", want.Image, ss.Spec.Template.Spec.Containers[0].Image)
 		}
 	}
+
+	if len(ss.Spec.Template.Spec.Containers) == 0 {
+		return
+	}
+	c := ss.Spec.Template.Spec.Containers[0]
+
+	// The load balancer health checks /healthz rather than the UDP port it forwards, so containerboot has to be
+	// serving it and the port has to be declared for the check to have anything to talk to.
+	if !slices.ContainsFunc(c.Env, func(e corev1.EnvVar) bool {
+		return e.Name == "TS_ENABLE_HEALTH_CHECK" && e.Value == "true"
+	}) {
+		t.Errorf("expected TS_ENABLE_HEALTH_CHECK=true on the tailscaled container, got env %v", c.Env)
+	}
+
+	if !slices.ContainsFunc(c.Ports, func(p corev1.ContainerPort) bool {
+		return p.ContainerPort == 9002 && p.Protocol == corev1.ProtocolTCP
+	}) {
+		t.Errorf("expected container to declare TCP port 9002 for the health check, got ports %v", c.Ports)
+	}
 }
 
 func assertConfigSecrets(t *testing.T, fc client.Client, prName string, want []string) {
@@ -878,6 +1018,7 @@ func managedServiceWithLB(prName string, idx int, ip, hostname string) *corev1.S
 const (
 	eipAllocationsAnnotation = "service.beta.kubernetes.io/aws-load-balancer-eip-allocations"
 	subnetsAnnotation        = "service.beta.kubernetes.io/aws-load-balancer-subnets"
+	lbAttributesAnnotation   = "service.beta.kubernetes.io/aws-load-balancer-attributes"
 )
 
 func managedStatefulSet(prName string, replicas, ready int32) *appsv1.StatefulSet {
@@ -939,7 +1080,7 @@ func TestReconciler_TailscaledConfig(t *testing.T) {
 		WithStatusSubresource(&tsapi.PeerRelay{}).
 		WithObjects(
 			pr,
-			managedServiceWithLB("test", 0, "1.2.3.4", ""),
+			managedServiceWithLB("test", 0, "", "multi-az.elb.amazonaws.com"),
 			managedService("test", 1),
 		).
 		Build()
@@ -963,7 +1104,12 @@ func TestReconciler_TailscaledConfig(t *testing.T) {
 	if got0.RelayServerPort == nil || *got0.RelayServerPort != 41641 {
 		t.Errorf("replica 0: expected RelayServerPort=41641, got %v", got0.RelayServerPort)
 	}
-	wantEndpoints := []netip.AddrPort{netip.MustParseAddrPort("1.2.3.4:41641")}
+	// The load balancer spans two availability zones, so both of its addresses must reach the config in sorted
+	// order. This is what makes the extra addresses worth paying for, rather than provisioned and unused.
+	wantEndpoints := []netip.AddrPort{
+		netip.MustParseAddrPort("203.0.113.20:41641"),
+		netip.MustParseAddrPort("203.0.113.30:41641"),
+	}
 	if !slices.Equal(got0.RelayServerStaticEndpoints, wantEndpoints) {
 		t.Errorf("replica 0: expected RelayServerStaticEndpoints=%v, got %v", wantEndpoints, got0.RelayServerStaticEndpoints)
 	}

--- a/k8s-operator/reconciler/peerrelay/service.go
+++ b/k8s-operator/reconciler/peerrelay/service.go
@@ -21,6 +21,7 @@ import (
 
 	tsapi "tailscale.com/k8s-operator/apis/v1alpha1"
 	"tailscale.com/k8s-operator/reconciler"
+	"tailscale.com/k8s-operator/reconciler/tailscaled"
 )
 
 const (
@@ -41,6 +42,7 @@ const (
 
 	annotationEIPAllocations = "service.beta.kubernetes.io/aws-load-balancer-eip-allocations"
 	annotationSubnets        = "service.beta.kubernetes.io/aws-load-balancer-subnets"
+	annotationLBAttributes   = "service.beta.kubernetes.io/aws-load-balancer-attributes"
 )
 
 // cloudAnnotations are the cloud-provider-specific annotations applied to every generated LoadBalancer Service to
@@ -51,6 +53,14 @@ var cloudAnnotations = map[string]string{
 	"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "ip",
 	"service.beta.kubernetes.io/aws-load-balancer-scheme":          "internet-facing",
 	"service.beta.kubernetes.io/aws-load-balancer-ip-address-type": "ipv4",
+
+	// AWS: health check the pod over HTTP against containerboot's /healthz rather than the port the Service
+	// forwards. A peer relay listens only on UDP, so the default TCP check against the traffic port can never
+	// succeed and every target reports unhealthy even while relaying fine. /healthz returns 200 once the device
+	// has tailnet addresses, which is the condition that actually matters.
+	"service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol": "http",
+	"service.beta.kubernetes.io/aws-load-balancer-healthcheck-port":     strconv.Itoa(tailscaled.HealthCheckPort),
+	"service.beta.kubernetes.io/aws-load-balancer-healthcheck-path":     "/healthz",
 
 	// Azure: pin the LB to external.
 	"service.beta.kubernetes.io/azure-load-balancer-internal": "false",
@@ -82,6 +92,15 @@ func peerRelayServiceAnnotations(pr *tsapi.PeerRelay, idx int32) map[string]stri
 	}
 
 	maps.Copy(annotations, cloudAnnotations)
+
+	// Unless the user has taken control of the load balancer attributes themselves, default cross-zone on. When no
+	// subnet is pinned the AWS Load Balancer Controller spreads the load balancer over every zone it discovers,
+	// and cross-zone is what lets all of those addresses reach the replica's pod regardless of the zone the
+	// scheduler placed it in. It is inert when spec.aws.elasticIPs pins a subnet, since only one zone is enabled
+	// on that load balancer, so there is no need to special case it.
+	if _, ok := annotations[annotationLBAttributes]; !ok {
+		annotations[annotationLBAttributes] = "load_balancing.cross_zone.enabled=true"
+	}
 
 	// Per-replica AWS pinning always wins over anything in spec.service.annotations or the cloud defaults so users
 	// can rely on spec.aws.elasticIPs being the single source of truth for each replica's EIP + subnet.
@@ -141,27 +160,33 @@ func replicaIndexFromLabels(labels map[string]string) (int32, bool) {
 	return int32(n), true
 }
 
-func (r *Reconciler) peerRelayEndpoint(ctx context.Context, logger *zap.SugaredLogger, svc *corev1.Service, prev *tsapi.PeerRelayEndpoint) *tsapi.PeerRelayEndpoint {
+// peerRelayEndpoints returns one endpoint per public address the Service's load balancer answers on. A load
+// balancer confined to a single subnet has one, while one the cloud spread over several availability zones has an
+// address in each, and every one of them reaches the replica. Advertising all of them means a peer can still get
+// through when a zone becomes unreachable, and means the user is not paying for addresses nothing uses.
+//
+// prev is the set of endpoints last published for this replica, returned unchanged when a lookup fails so a
+// transient DNS error doesn't empty status.endpoints.
+func (r *Reconciler) peerRelayEndpoints(ctx context.Context, logger *zap.SugaredLogger, svc *corev1.Service, prev []tsapi.PeerRelayEndpoint) []tsapi.PeerRelayEndpoint {
 	idx, ok := replicaIndexFromLabels(svc.Labels)
 	if !ok {
 		return nil
 	}
 
+	var endpoints []tsapi.PeerRelayEndpoint
 	for _, ing := range svc.Status.LoadBalancer.Ingress {
 		if ing.IP != "" {
-			return &tsapi.PeerRelayEndpoint{Replica: idx, Address: ing.IP, Port: servicePort}
+			endpoints = append(endpoints, tsapi.PeerRelayEndpoint{Replica: idx, Address: ing.IP, Port: servicePort})
 		}
 	}
-
-	// Just return nil if we're not dealing with AWS fun.
-	if _, ok = svc.Annotations[annotationEIPAllocations]; !ok {
-		return nil
+	if len(endpoints) > 0 {
+		return endpoints
 	}
 
-	// If we were not able to obtain an IP address, we fall back to an IPv4 lookup. This is specifically for the case
-	// of AWS where NLB-backed Service resources are only ever given hostnames. We expect users to also provide
-	// an annotation with their elastic IP allocations so that there is only ever 1 IP address behind the hostname, so
-	// we perform a lookup so that the user doesn't also need to provide that IP address.
+	// No IP was assigned, so fall back to resolving the hostname. This is primarily for AWS, where NLB-backed
+	// Service resources are only ever given hostnames. The addresses behind such a hostname belong to the load
+	// balancer and are fixed for its lifetime, whether they came from spec.aws.elasticIPs or were assigned by
+	// AWS, so we resolve it here rather than making the user supply the address themselves.
 	for _, ing := range svc.Status.LoadBalancer.Ingress {
 		if ing.Hostname == "" {
 			continue
@@ -172,9 +197,10 @@ func (r *Reconciler) peerRelayEndpoint(ctx context.Context, logger *zap.SugaredL
 
 		addrs, err := r.resolver(resolveCtx, "ip4", ing.Hostname)
 		if err != nil || len(addrs) == 0 {
-			logger.Warnf("failed to resolve LoadBalancer hostname %q for Service %q: %v", ing.Hostname, svc.Name, err)
-			// Preserve the previously-known endpoint (if any) so that a failure here doesn't erase status.endpoints.
-			if prev != nil {
+			logger.Debugf("failed to resolve LoadBalancer hostname %q for Service %q: %v", ing.Hostname, svc.Name, err)
+			// Preserve the previously-known endpoints (if any) so that a failure here doesn't erase
+			// status.endpoints.
+			if len(prev) > 0 {
 				return prev
 			}
 
@@ -182,7 +208,11 @@ func (r *Reconciler) peerRelayEndpoint(ctx context.Context, logger *zap.SugaredL
 		}
 
 		slices.SortFunc(addrs, netip.Addr.Compare)
-		return &tsapi.PeerRelayEndpoint{Replica: idx, Address: addrs[0].String(), Port: servicePort}
+		for _, addr := range addrs {
+			endpoints = append(endpoints, tsapi.PeerRelayEndpoint{Replica: idx, Address: addr.String(), Port: servicePort})
+		}
+
+		return endpoints
 	}
 
 	return nil

--- a/k8s-operator/reconciler/peerrelay/statefulset.go
+++ b/k8s-operator/reconciler/peerrelay/statefulset.go
@@ -33,7 +33,7 @@ func peerRelayHostname(pr *tsapi.PeerRelay, idx int32) string {
 	return fmt.Sprintf("%s-%d", prefix, idx)
 }
 
-func peerRelayTailscaledConfig(pr *tsapi.PeerRelay, idx int32, endpoint *tsapi.PeerRelayEndpoint, authKey *string, loginServer string) ipn.ConfigVAlpha {
+func peerRelayTailscaledConfig(pr *tsapi.PeerRelay, idx int32, endpoints []tsapi.PeerRelayEndpoint, authKey *string, loginServer string) ipn.ConfigVAlpha {
 	conf := ipn.ConfigVAlpha{
 		Version:         "alpha0",
 		AcceptDNS:       "false",
@@ -48,24 +48,25 @@ func peerRelayTailscaledConfig(pr *tsapi.PeerRelay, idx int32, endpoint *tsapi.P
 		conf.ServerURL = &loginServer
 	}
 
-	if endpoint != nil {
-		if addr, err := netip.ParseAddr(endpoint.Address); err == nil {
-			conf.RelayServerStaticEndpoints = []netip.AddrPort{
-				netip.AddrPortFrom(addr, uint16(endpoint.Port)),
-			}
+	for _, endpoint := range endpoints {
+		addr, err := netip.ParseAddr(endpoint.Address)
+		if err != nil {
+			continue
 		}
+
+		conf.RelayServerStaticEndpoints = append(conf.RelayServerStaticEndpoints, netip.AddrPortFrom(addr, uint16(endpoint.Port)))
 	}
 
 	return conf
 }
 
-func (r *Reconciler) peerRelayConfigSecret(pr *tsapi.PeerRelay, idx int32, endpoint *tsapi.PeerRelayEndpoint, authKey *string, loginServer string) (*corev1.Secret, error) {
+func (r *Reconciler) peerRelayConfigSecret(pr *tsapi.PeerRelay, idx int32, endpoints []tsapi.PeerRelayEndpoint, authKey *string, loginServer string) (*corev1.Secret, error) {
 	labels := peerRelayServiceLabels(pr.Name, idx)
 	return tailscaled.NewConfigSecret(tailscaled.ConfigSecretOptions{
 		Name:      configSecretName(pr.Name, idx),
 		Namespace: r.tailscaleNamespace,
 		Labels:    labels,
-		Config:    peerRelayTailscaledConfig(pr, idx, endpoint, authKey, loginServer),
+		Config:    peerRelayTailscaledConfig(pr, idx, endpoints, authKey, loginServer),
 	})
 }
 

--- a/k8s-operator/reconciler/tailscaled/statefulset.go
+++ b/k8s-operator/reconciler/tailscaled/statefulset.go
@@ -35,6 +35,15 @@ const (
 
 	// containerName is the single container inside each pod that runs tailscaled.
 	containerName = "tailscaled"
+
+	// HealthCheckPort is the port containerboot serves /healthz on when TS_ENABLE_HEALTH_CHECK is set. It
+	// reports 200 once the device has tailnet addresses and 503 until then, so it is a meaningful readiness
+	// signal for a load balancer fronting the pod.
+	HealthCheckPort = 9002
+
+	// healthCheckPortName names the health check port on the container so a Service or load balancer can refer
+	// to it by name.
+	healthCheckPortName = "healthz"
 )
 
 // StatefulSetOptions describes a StatefulSet of tailscaled pods. The zero value is not valid , Name, Namespace,
@@ -130,7 +139,16 @@ func NewStatefulSet(opts StatefulSetOptions) *appsv1.StatefulSet {
 								Name:  "TS_KUBE_SECRET",
 								Value: "$(POD_NAME)",
 							},
+							{
+								Name:  "TS_ENABLE_HEALTH_CHECK",
+								Value: "true",
+							},
 						},
+						Ports: []corev1.ContainerPort{{
+							Name:          healthCheckPortName,
+							ContainerPort: HealthCheckPort,
+							Protocol:      corev1.ProtocolTCP,
+						}},
 					}},
 				},
 			},


### PR DESCRIPTION
This commit changes how PeerRelay services are exposed on AWS. A Network
Load Balancer only forwards to targets in an availability zone enabled
on it, and spec.aws.elasticIPs pins each service to a single subnet,
which enables just one zone. A replica scheduled anywhere else silently
receives nothing while still reporting PeerRelayReady with an address in
status.endpoints.

Without spec.aws we now leave the subnet unpinned, so the AWS Load
Balancer Controller spreads the load balancer over every zone it finds,
and cross-zone load balancing is on by default so any of its addresses
reach the pod. Hostname resolution is no longer gated on the
eip-allocations annotation, which had left these unpinned services in
EndpointsPending forever, and a failure to resolve now logs at debug
since it is expected while a load balancer provisions.

Such a load balancer has an address per zone, and AWS bills for each, so
every one of them is now advertised rather than only the lowest sorted.
That also lets a peer reach the relay when one zone is unreachable.
status.endpoints gains address as a second list map key so a replica can
hold an entry per address; no field changes, so existing readers of
endpoints[].address keep working. Readiness counts the replicas that
have an endpoint rather than the entries, so a replica with several
addresses cannot mask one that has none.

The CRD docs now describe spec.aws as the exception, note that it also
needs a ProxyClass pinning pods to the zone of the subnets it names, and
drop the claim that an Elastic IP has an availability zone of its own.

Fixes: https://github.com/tailscale/tailscale/issues/20833