### PR TITLE
k8s-operator/reconciler/peerrelay: add missing tsclient import

### DIFF
--- a/k8s-operator/reconciler/peerrelay/authkey.go
+++ b/k8s-operator/reconciler/peerrelay/authkey.go
@@ -15,6 +15,7 @@ import (
 
 	tsapi "tailscale.com/k8s-operator/apis/v1alpha1"
 	"tailscale.com/k8s-operator/reconciler/tailscaled"
+	"tailscale.com/k8s-operator/tsclient"
 	"tailscale.com/kube/kubetypes"
 )
 


### PR DESCRIPTION
authkey.go references tsclient.Client in getAuthKey but never imported the package, breaking main.

Updates #20544