### PR TITLE
cmd/k8s-operator: clean up HA Service when proxy-group annotation removed

### DIFF
--- a/cmd/k8s-operator/e2e/svc_test.go
+++ b/cmd/k8s-operator/e2e/svc_test.go
@@ -1,0 +1,133 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"tailscale.com/client/tailscale/v2"
+	tsapi "tailscale.com/k8s-operator/apis/v1alpha1"
+	"tailscale.com/tstest"
+)
+
+// TestHAServiceCleanupOnAnnotationRemoved checks that removing the
+// tailscale.com/proxy-group annotation from a Service that is exposed on a
+// ProxyGroup cleans up the corresponding Tailscale Service and removes the
+// operator's finalizer, rather than leaking the Tailscale Service and wedging
+// the Service on delete.
+func TestHAServiceCleanupOnAnnotationRemoved(t *testing.T) {
+	if tsClient == nil {
+		t.Skip("TestHAServiceCleanupOnAnnotationRemoved requires a working tailnet client")
+	}
+	t.Parallel()
+
+	nginx := nginxDeployment(ns)
+	createAndCleanup(t, kubeClient, nginx)
+
+	pg := &tsapi.ProxyGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: generateName("ingress"),
+		},
+		Spec: tsapi.ProxyGroupSpec{
+			Type: tsapi.ProxyGroupTypeIngress,
+		},
+	}
+	createAndCleanup(t, kubeClient, pg)
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generateName("test-svc"),
+			Namespace: ns,
+			Annotations: map[string]string{
+				"tailscale.com/proxy-group": pg.Name,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:              corev1.ServiceTypeLoadBalancer,
+			LoadBalancerClass: new("tailscale"),
+			Selector: map[string]string{
+				"app.kubernetes.io/name": nginx.Name,
+			},
+			Ports: []corev1.ServicePort{
+				{Name: "http", Protocol: "TCP", Port: 80},
+			},
+		},
+	}
+	createAndCleanup(t, kubeClient, svc)
+
+	// The Tailscale Service is named after the Service's hostname, which
+	// defaults to <namespace>-<name>.
+	tsSvcName := fmt.Sprintf("svc:%s-%s", ns, svc.Name)
+
+	forceReconcile := triggerReconcile(t,
+		client.ObjectKey{Namespace: ns, Name: svc.Name},
+		&corev1.Service{}, 30*time.Second)
+
+	// Wait for the Service to be exposed and the Tailscale Service to exist.
+	if err := tstest.WaitFor(5*time.Minute, func() error {
+		forceReconcile()
+		readySvc := &corev1.Service{ObjectMeta: objectMeta(ns, svc.Name)}
+		if err := get(t.Context(), kubeClient, readySvc); err != nil {
+			return err
+		}
+		for _, cond := range readySvc.Status.Conditions {
+			if cond.Type == string(tsapi.IngressSvcConfigured) && cond.Status == metav1.ConditionTrue {
+				if _, err := tsClient.VIPServices().Get(t.Context(), tsSvcName); err != nil {
+					return fmt.Errorf("Tailscale Service %q not created yet: %w", tsSvcName, err)
+				}
+				return nil
+			}
+		}
+		return fmt.Errorf("Service is not ready yet")
+	}); err != nil {
+		t.Fatalf("error waiting for the Service to become ready: %v", err)
+	}
+
+	// Remove the ProxyGroup annotation.
+	readySvc := &corev1.Service{ObjectMeta: objectMeta(ns, svc.Name)}
+	if err := get(t.Context(), kubeClient, readySvc); err != nil {
+		t.Fatalf("getting Service: %v", err)
+	}
+	delete(readySvc.Annotations, "tailscale.com/proxy-group")
+	if err := kubeClient.Update(t.Context(), readySvc); err != nil {
+		t.Fatalf("removing proxy-group annotation: %v", err)
+	}
+
+	// The Tailscale Service must be cleaned up and the finalizer removed.
+	if err := tstest.WaitFor(5*time.Minute, func() error {
+		forceReconcile()
+		if _, err := tsClient.VIPServices().Get(t.Context(), tsSvcName); err == nil {
+			return fmt.Errorf("Tailscale Service %q still exists", tsSvcName)
+		} else if !tailscale.IsNotFound(err) {
+			return fmt.Errorf("unexpected error getting Tailscale Service %q: %w", tsSvcName, err)
+		}
+		cur := &corev1.Service{ObjectMeta: objectMeta(ns, svc.Name)}
+		if err := get(t.Context(), kubeClient, cur); err != nil {
+			return err
+		}
+		for _, f := range cur.Finalizers {
+			if isServicePGFinalizerE2E(f) {
+				return fmt.Errorf("service-pg finalizer %q not removed yet", f)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("error waiting for cleanup after annotation removal: %v", err)
+	}
+}
+
+// isServicePGFinalizerE2E reports whether f is one of the HA Service
+// reconciler's finalizers (either the ProxyGroup-encoded form or the bare
+// legacy form). Kept local to the e2e package to avoid importing package main.
+func isServicePGFinalizerE2E(f string) bool {
+	_, name, ok := strings.Cut(f, "/")
+	return ok && name == "service-pg-finalizer"
+}

--- a/cmd/k8s-operator/svc-for-pg.go
+++ b/cmd/k8s-operator/svc-for-pg.go
@@ -48,6 +48,41 @@ const (
 	reasonIngressSvcNoBackendsConfigured = "IngressSvcNoBackendsConfigured"
 )
 
+// finalizerForProxyGroup returns the finalizer to set on a Service exposed on
+// the named ProxyGroup. The ProxyGroup name is encoded into the finalizer's DNS
+// subdomain prefix (e.g. "my-pg.tailscale.com/service-pg-finalizer") so that
+// cleanup can recover it after the tailscale.com/proxy-group annotation has been
+// removed from the Service, which is otherwise the only place it is recorded.
+// The name is placed in the prefix rather than the name part because a
+// finalizer's name part is limited to 63 characters whereas the prefix (a DNS
+// subdomain) allows 253, comfortably fitting any ProxyGroup name.
+func finalizerForProxyGroup(pgName string) string {
+	return pgName + "." + svcPGFinalizerName
+}
+
+// isServicePGFinalizer reports whether f is one of this reconciler's finalizers,
+// in either the ProxyGroup-encoded form or the bare legacy form set by older
+// operators.
+func isServicePGFinalizer(f string) bool {
+	return f == svcPGFinalizerName || strings.HasSuffix(f, "."+svcPGFinalizerName)
+}
+
+// proxyGroupFromServiceFinalizers returns the ProxyGroup name encoded in svc's
+// service-pg finalizer, reporting whether such a finalizer is present. It
+// returns ("", true) for the bare legacy finalizer, which does not encode a
+// ProxyGroup name.
+func proxyGroupFromServiceFinalizers(svc *corev1.Service) (pgName string, ok bool) {
+	for _, f := range svc.Finalizers {
+		if f == svcPGFinalizerName {
+			return "", true
+		}
+		if pgName, ok = strings.CutSuffix(f, "."+svcPGFinalizerName); ok {
+			return pgName, true
+		}
+	}
+	return "", false
+}
+
 var gaugePGServiceResources = clientmetric.NewGauge(kubetypes.MetricServicePGResourceCount)
 
 // HAServiceReconciler is a controller that reconciles Tailscale Kubernetes
@@ -99,7 +134,20 @@ func (r *HAServiceReconciler) Reconcile(ctx context.Context, req reconcile.Reque
 
 	pgName := svc.Annotations[AnnotationProxyGroup]
 	if pgName == "" {
-		return res, nil
+		// If we hold a finalizer, the annotation was removed after we
+		// provisioned this Service and we still need to clean up; recover the
+		// ProxyGroup name from the finalizer it was encoded into.
+		recovered, ok := proxyGroupFromServiceFinalizers(svc)
+		if !ok {
+			return res, nil
+		}
+		if recovered == "" {
+			// Bare legacy finalizer from an older operator; it does not encode
+			// the ProxyGroup name so there is nothing to clean up against.
+			logger.Warnf("ProxyGroup annotation removed but finalizer %q does not record a ProxyGroup; unable to clean up Tailscale Service, remove the finalizer manually if the Service is stuck", svcPGFinalizerName)
+			return res, nil
+		}
+		pgName = recovered
 	}
 
 	logger = logger.With("ProxyGroup", pgName)
@@ -130,7 +178,7 @@ func (r *HAServiceReconciler) Reconcile(ctx context.Context, req reconcile.Reque
 
 	if !svc.DeletionTimestamp.IsZero() || !r.isTailscaleService(svc) {
 		logger.Debugf("Service is being deleted or is (no longer) referring to Tailscale ingress/egress, ensuring any created resources are cleaned up")
-		_, err = r.maybeCleanup(ctx, hostname, svc, logger, tsClient)
+		_, err = r.maybeCleanup(ctx, hostname, pgName, svc, logger, tsClient)
 		return res, err
 	}
 
@@ -176,13 +224,19 @@ func (r *HAServiceReconciler) maybeProvision(ctx context.Context, hostname strin
 		return false, nil
 	}
 
-	if !slices.Contains(svc.Finalizers, svcPGFinalizerName) {
-		// This log line is printed exactly once during initial provisioning,
-		// because once the finalizer is in place this block gets skipped. So,
-		// this is a nice place to tell the operator that the high level,
-		// multi-reconcile operation is underway.
-		logger.Infof("exposing Service over tailscale")
-		svc.Finalizers = append(svc.Finalizers, svcPGFinalizerName)
+	wantFinalizer := finalizerForProxyGroup(pg.Name)
+	if !slices.Contains(svc.Finalizers, wantFinalizer) {
+		if !slices.ContainsFunc(svc.Finalizers, isServicePGFinalizer) {
+			// This log line is printed exactly once during initial provisioning,
+			// because once the finalizer is in place this block gets skipped. So,
+			// this is a nice place to tell the operator that the high level,
+			// multi-reconcile operation is underway.
+			logger.Infof("exposing Service over tailscale")
+		}
+		// Drop any bare legacy finalizer set by an older operator; it does not
+		// encode the ProxyGroup name needed for cleanup.
+		svc.Finalizers = slices.DeleteFunc(svc.Finalizers, isServicePGFinalizer)
+		svc.Finalizers = append(svc.Finalizers, wantFinalizer)
 		if err := r.Update(ctx, svc); err != nil {
 			return false, fmt.Errorf("failed to add finalizer: %w", err)
 		}
@@ -374,10 +428,9 @@ func (r *HAServiceReconciler) maybeProvision(ctx context.Context, hostname strin
 // Service is being deleted or is unexposed. The cleanup is safe for a multi-cluster setup- the Tailscale Service is only
 // deleted if it does not contain any other owner references. If it does the cleanup only removes the owner reference
 // corresponding to this Service.
-func (r *HAServiceReconciler) maybeCleanup(ctx context.Context, hostname string, svc *corev1.Service, logger *zap.SugaredLogger, tsClient tsclient.Client) (svcChanged bool, err error) {
+func (r *HAServiceReconciler) maybeCleanup(ctx context.Context, hostname, pgName string, svc *corev1.Service, logger *zap.SugaredLogger, tsClient tsclient.Client) (svcChanged bool, err error) {
 	logger.Debugf("Ensuring any resources for Service are cleaned up")
-	ix := slices.Index(svc.Finalizers, svcPGFinalizerName)
-	if ix < 0 {
+	if !slices.ContainsFunc(svc.Finalizers, isServicePGFinalizer) {
 		logger.Debugf("no finalizer, nothing to do")
 		return false, nil
 	}
@@ -398,7 +451,6 @@ func (r *HAServiceReconciler) maybeCleanup(ctx context.Context, hostname string,
 	}
 
 	// 2. Unadvertise the Tailscale Service.
-	pgName := svc.Annotations[AnnotationProxyGroup]
 	if err = r.maybeUpdateAdvertiseServicesConfig(ctx, svc, pgName, serviceName, nil, false, logger); err != nil {
 		return false, fmt.Errorf("failed to update tailscaled config services: %w", err)
 	}
@@ -482,9 +534,7 @@ func (r *HAServiceReconciler) maybeCleanupProxyGroup(ctx context.Context, proxyG
 }
 
 func (r *HAServiceReconciler) deleteFinalizer(ctx context.Context, svc *corev1.Service, logger *zap.SugaredLogger) error {
-	svc.Finalizers = slices.DeleteFunc(svc.Finalizers, func(f string) bool {
-		return f == svcPGFinalizerName
-	})
+	svc.Finalizers = slices.DeleteFunc(svc.Finalizers, isServicePGFinalizer)
 	logger.Debugf("ensure %q finalizer is removed", svcPGFinalizerName)
 
 	if err := r.Update(ctx, svc); err != nil {

--- a/cmd/k8s-operator/svc-for-pg_test.go
+++ b/cmd/k8s-operator/svc-for-pg_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"net/netip"
+	"slices"
 	"testing"
 	"time"
 
@@ -549,4 +550,102 @@ func setupTestService(t *testing.T, svcName string, hostname string, clusterIP s
 	mustCreate(t, fc, eps)
 
 	return svc, eps
+}
+
+// TestServicePGReconciler_CleanupOnAnnotationRemoved is a regression test for
+// the case where the tailscale.com/proxy-group annotation is removed from a
+// Service that was previously exposed on a ProxyGroup. The reconciler must
+// clean up the Tailscale Service and remove its finalizer even though the
+// annotation (the only in-object record of the ProxyGroup) is gone, otherwise
+// the Tailscale Service leaks and the Service wedges forever on delete.
+func TestServicePGReconciler_CleanupOnAnnotationRemoved(t *testing.T) {
+	svcPGR, stateSecret, fc, ft, _ := setupServiceTest(t)
+
+	svc, _ := setupTestService(t, "test-service", "", "4.1.6.7", fc, stateSecret)
+	expectReconciled(t, svcPGR, "default", svc.Name)
+
+	verifyTailscaleService(t, ft, fmt.Sprintf("svc:default-%s", svc.Name), []string{"do-not-validate"})
+
+	// The finalizer must encode the ProxyGroup name so cleanup can recover it
+	// once the annotation is gone.
+	got := &corev1.Service{}
+	if err := fc.Get(t.Context(), types.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}, got); err != nil {
+		t.Fatalf("getting Service: %v", err)
+	}
+	wantFinalizer := "test-pg.tailscale.com/service-pg-finalizer"
+	if !slices.Contains(got.Finalizers, wantFinalizer) {
+		t.Fatalf("finalizers = %v, want to contain %q", got.Finalizers, wantFinalizer)
+	}
+
+	// Remove the ProxyGroup annotation.
+	mustUpdate(t, fc, svc.Namespace, svc.Name, func(s *corev1.Service) {
+		delete(s.Annotations, AnnotationProxyGroup)
+	})
+	expectReconciled(t, svcPGR, "default", svc.Name)
+
+	// The Tailscale Service must be cleaned up.
+	if _, err := ft.VIPServices().Get(t.Context(), fmt.Sprintf("svc:default-%s", svc.Name)); err == nil {
+		t.Fatalf("Tailscale Service svc:default-%s not cleaned up after annotation removal", svc.Name)
+	} else if !tailscale.IsNotFound(err) {
+		t.Fatalf("unexpected error getting Tailscale Service: %v", err)
+	}
+
+	// The finalizer must be removed so the Service does not wedge on delete.
+	if err := fc.Get(t.Context(), types.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}, got); err != nil {
+		t.Fatalf("getting Service: %v", err)
+	}
+	if slices.ContainsFunc(got.Finalizers, isServicePGFinalizer) {
+		t.Fatalf("service-pg finalizer not removed after annotation removal, finalizers = %v", got.Finalizers)
+	}
+}
+
+// TestServicePGReconciler_MigratesLegacyFinalizer verifies that a Service
+// carrying the bare legacy finalizer (set by an older operator) is migrated to
+// the ProxyGroup-encoded finalizer on reconcile, so a later annotation removal
+// remains recoverable.
+func TestServicePGReconciler_MigratesLegacyFinalizer(t *testing.T) {
+	svcPGR, stateSecret, fc, ft, _ := setupServiceTest(t)
+
+	svc, _ := setupTestService(t, "test-service", "", "4.1.6.7", fc, stateSecret)
+	mustUpdate(t, fc, svc.Namespace, svc.Name, func(s *corev1.Service) {
+		s.Finalizers = append(s.Finalizers, svcPGFinalizerName)
+	})
+
+	expectReconciled(t, svcPGR, "default", svc.Name)
+	verifyTailscaleService(t, ft, fmt.Sprintf("svc:default-%s", svc.Name), []string{"do-not-validate"})
+
+	got := &corev1.Service{}
+	if err := fc.Get(t.Context(), types.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}, got); err != nil {
+		t.Fatalf("getting Service: %v", err)
+	}
+	if slices.Contains(got.Finalizers, svcPGFinalizerName) {
+		t.Fatalf("bare legacy finalizer not migrated, finalizers = %v", got.Finalizers)
+	}
+	wantFinalizer := "test-pg.tailscale.com/service-pg-finalizer"
+	if !slices.Contains(got.Finalizers, wantFinalizer) {
+		t.Fatalf("finalizers = %v, want to contain %q", got.Finalizers, wantFinalizer)
+	}
+}
+
+func TestProxyGroupFromServiceFinalizers(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		finalizers []string
+		wantPG     string
+		wantOK     bool
+	}{
+		{"encoded", []string{"test-pg.tailscale.com/service-pg-finalizer"}, "test-pg", true},
+		{"legacy_bare", []string{"tailscale.com/service-pg-finalizer"}, "", true},
+		{"none", []string{"tailscale.com/finalizer"}, "", false},
+		{"empty", nil, "", false},
+		{"encoded_among_others", []string{"tailscale.com/finalizer", "my-pg.tailscale.com/service-pg-finalizer"}, "my-pg", true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Finalizers: tt.finalizers}}
+			gotPG, gotOK := proxyGroupFromServiceFinalizers(svc)
+			if gotPG != tt.wantPG || gotOK != tt.wantOK {
+				t.Errorf("proxyGroupFromServiceFinalizers() = (%q, %v), want (%q, %v)", gotPG, gotOK, tt.wantPG, tt.wantOK)
+			}
+		})
+	}
 }


### PR DESCRIPTION
When the `tailscale.com/proxy-group` annotation is removed from a Service that was exposed on a ProxyGroup, the HA Service reconciler returned early on the empty annotation before reaching its cleanup path. The Tailscale Service is left advertised and the operator's finalizer is never removed, so the Tailscale Service leaked and the Kubernetes Service wedged forever in `Terminating` once deleted.

The annotation is the only place the ProxyGroup name is recorded, and it is gone by the time cleanup needs it. This commit encodes the ProxyGroup name in the finalizer, which survives any modification of the resources annotations. On reconcile, an empty annotation with our finalizer present now recovers the ProxyGroup name from the finalizer and runs cleanup. Services carrying the bare legacy finalizer are migrated to the encoded form while the annotation is still present.

Updates #19922