### PR TITLE
ipn/ipnlocal/netmapcache: invalidate digest caches when removing objects

### DIFF
--- a/ipn/ipnlocal/netmapcache/netmapcache.go
+++ b/ipn/ipnlocal/netmapcache/netmapcache.go
@@ -277,6 +277,7 @@ func (c *Cache) UpdatePeers(ctx context.Context, update []tailcfg.NodeView, remo
 			errs = append(errs, err)
 		}
 		c.wantKeys.Delete(key)
+		delete(c.lastWrote, key)
 	}
 	return errors.Join(errs...)
 }

--- a/ipn/ipnlocal/netmapcache/netmapcache_test.go
+++ b/ipn/ipnlocal/netmapcache/netmapcache_test.go
@@ -355,6 +355,21 @@ func TestUpdatePeers(t *testing.T) {
 	if diff := diffNetMaps(got, &updated); diff != "" {
 		t.Fatalf("Updated map differs (-got, +want):\n%s", diff)
 	}
+
+	// If we re-apply a previously-removed change, it should be persisted.
+	// See tailscale/tailscale#20795.
+	if err := c.UpdatePeers(t.Context(), []tailcfg.NodeView{testNode2}, nil); err != nil {
+		t.Errorf("UpdatePeers restoring an old peer: %v", err)
+	}
+
+	got2, err := c.Load(t.Context())
+	if err != nil {
+		t.Fatalf("Load netmap failed: %v", err)
+	}
+	updated.Peers = []tailcfg.NodeView{modNode1, testNode2, newNode3} // N.B. sorted
+	if diff := diffNetMaps(got2, &updated); diff != "" {
+		t.Fatalf("Updated map differs (-got, +want):\n%s", diff)
+	}
 }
 
 // skippedMapFields are the names of fields that should not be considered by


### PR DESCRIPTION
Previously, a delta update that drops a peer would not invalidate the digest
cache for that peer after deleting its cache entry. If a subsequent (later)
delta re-adds that peer with the same content, the digest cache would prevent
us from updating the persistent entry.  Add a test to exercise this, and fix
the bug.

Updates #20795

Change-Id: I4a9ef03e8787a330d6395629251ee61ca2221fdd
