### PR TITLE
feature/conn25: expire connector state

### DIFF
--- a/feature/conn25/conn25.go
+++ b/feature/conn25/conn25.go
@@ -9,6 +9,7 @@ package conn25
 
 import (
 	"bytes"
+	"container/list"
 	"context"
 	"encoding/json"
 	"errors"
@@ -143,6 +144,7 @@ func (e *extension) Init(host ipnext.Host) error {
 	e.ctxCancel = cancel
 	go e.sendLoop(ctx)
 	dph.StartFlowExpirySweepers(ctx)
+	e.conn25.connector.startExpirySweeper(ctx)
 	return nil
 }
 
@@ -415,8 +417,9 @@ func (e *extension) extraWireGuardAllowedIPs(k key.NodePublic) views.Slice[netip
 }
 
 type appAddr struct {
-	app  string
-	addr netip.Addr
+	app         string
+	addr        netip.Addr
+	expiryEntry *list.Element
 }
 
 // Conn25 holds state for routing traffic for a domain via a connector.
@@ -457,8 +460,10 @@ func newConn25(logf logger.Logf) *Conn25 {
 		getIPSets:   getIPSets,
 	}
 	c.connector = &connector{
-		logf:      logf,
-		getIPSets: getIPSets,
+		logf:        logf,
+		getIPSets:   getIPSets,
+		clock:       tstime.StdClock{},
+		expiryQueue: list.New(),
 	}
 	return c
 }
@@ -575,7 +580,17 @@ func (c *connector) handleTransitIPRequest(n tailcfg.NodeView, peerV4 netip.Addr
 		peerMap = make(map[netip.Addr]appAddr)
 		c.transitIPs[peerAddr] = peerMap
 	}
-	peerMap[tipr.TransitIP] = appAddr{addr: tipr.DestinationIP, app: tipr.App}
+	// if there's already an entry for this peer+transitIP, clean up the expiryQueue entry
+	if prev, ok := peerMap[tipr.TransitIP]; ok && prev.expiryEntry != nil {
+		c.expiryQueue.Remove(prev.expiryEntry)
+	}
+	// create a new expiryQueue entry
+	elem := c.expiryQueue.PushBack(&transitIPExpiryEntry{
+		peerIP:    peerAddr,
+		transitIP: tipr.TransitIP,
+		createdAt: c.clock.Now(),
+	})
+	peerMap[tipr.TransitIP] = appAddr{addr: tipr.DestinationIP, app: tipr.App, expiryEntry: elem}
 	return TransitIPResponse{}
 }
 
@@ -1425,15 +1440,31 @@ func rewriteHTTPSResponse(hdr dnsmessage.Header, questions []dnsmessage.Question
 	return b.Finish()
 }
 
+// connectorTransitIPExpiry is the minimum length of time a peer+transitIP -> dstIP mapping will be held in the connector.
+// The longer this time is the larger the map will be in memory.
+// The shorter this time is the more often a client will try to use a mapping, find it doesn't exist anymore and have to re-register.
+// We are not (yet 2026-08-12) tracking either of those things, this is a guess at a reasonable duration.
+const connectorTransitIPExpiry = time.Hour
+
 type connector struct {
 	logf      logger.Logf
 	getIPSets func() ipSets
+	clock     tstime.Clock
 
 	// Remember to add new fields to [connector.reset] if needed.
 	mu sync.Mutex // protects the fields below
 	// transitIPs is a map of connector client peer IP -> client transitIPs that we update as connector client peers instruct us to, and then use to route traffic to its destination on behalf of connector clients.
 	// Note that each peer could potentially have two maps: one for its IPv4 address, and one for its IPv6 address. The transit IPs map for a given peer IP will contain transit IPs of the same family as the peer's IP.
 	transitIPs map[netip.Addr]map[netip.Addr]appAddr
+	// expiryQueue is processed by the goroutine from [connector.startExpirySweeper] so
+	// that transitIPs doesn't grow indefinitely.
+	expiryQueue *list.List
+}
+
+type transitIPExpiryEntry struct {
+	peerIP    netip.Addr
+	transitIP netip.Addr
+	createdAt time.Time
 }
 
 // realIPForTransitIPConnection is part of the implementation of the [Conn25Datapath] interface for dataflow lookups.
@@ -1441,11 +1472,7 @@ type connector struct {
 func (c *connector) realIPForTransitIPConnection(srcIP netip.Addr, transitIP netip.Addr) (netip.Addr, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	v, ok := c.lookupBySrcIPAndTransitIP(srcIP, transitIP)
-	if ok {
-		return v.addr, true
-	}
-	return netip.Addr{}, false
+	return c.lookupAddrBySrcIPAndTransitIP(srcIP, transitIP)
 }
 
 const packetFilterAllowReason = "app connector transit IP"
@@ -1465,13 +1492,84 @@ func (c *connector) packetFilterAllow(p packet.Parsed) (bool, string) {
 	return false, ""
 }
 
-func (c *connector) lookupBySrcIPAndTransitIP(srcIP, transitIP netip.Addr) (appAddr, bool) {
+func (c *connector) lookupAddrBySrcIPAndTransitIP(srcIP, transitIP netip.Addr) (netip.Addr, bool) {
 	m, ok := c.transitIPs[srcIP]
 	if !ok || m == nil {
-		return appAddr{}, false
+		return netip.Addr{}, false
 	}
 	v, ok := m[transitIP]
-	return v, ok
+	return v.addr, ok
+}
+
+// expireTransitIPs expires entries in the connector's transitIPs map that are
+// past their expiry time.
+// While the client keeps track of the datapath flow table and makes sure not
+// to expire state for flows that are in use, the connector just expires
+// peer+transitIP -> dstIP state at minimum 1 hour [connectorTransitIPExpiry]
+// after it is registered.
+// If a client tries to use a mapping that is expired the connector will send a
+// TSMP error and the client will reregister the mapping.
+// If this causes too much reregistry we can extend the expiry time or we may
+// have to track flows or similar.
+func (c *connector) expireTransitIPs(now time.Time) int {
+	removed := 0
+
+	// doChunk takes the chunk size and returns the number of removed entries and
+	// whether there's still work to do.
+	// Used to allow other goroutines a chance to grab the mutex while we work.
+	doChunk := func(n int) (int, bool) {
+		nRemoved := 0
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		for i := 0; i < n; i++ {
+			front := c.expiryQueue.Front()
+			if front == nil {
+				return nRemoved, true
+			}
+			e := front.Value.(*transitIPExpiryEntry)
+			if now.Sub(e.createdAt) < connectorTransitIPExpiry {
+				// the list is ordered by createdAt there will be no entries to expire after this
+				return nRemoved, true
+			}
+			c.expiryQueue.Remove(front)
+			peerMap, ok := c.transitIPs[e.peerIP]
+			if !ok {
+				continue
+			}
+			delete(peerMap, e.transitIP)
+			nRemoved++
+			if len(peerMap) == 0 {
+				delete(c.transitIPs, e.peerIP)
+			}
+		}
+		return nRemoved, false
+	}
+
+	// handle at most 100,000 entries, don't just keep going if we have an
+	// unexpectedly large number of expiries, we will handle the backlog over time.
+	for i := 0; i < 1000; i++ {
+		nRemoved, finished := doChunk(100)
+		removed += nRemoved
+		if finished {
+			break
+		}
+	}
+	return removed
+}
+
+func (c *connector) startExpirySweeper(ctx context.Context) {
+	ticker, tickerCh := c.clock.NewTicker(5 * time.Minute)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-tickerCh:
+				c.expireTransitIPs(c.clock.Now())
+			}
+		}
+	}()
 }
 
 // reset clears all internal state of [connector], that are not configuration
@@ -1481,6 +1579,7 @@ func (c *connector) reset() {
 	defer c.mu.Unlock()
 
 	c.transitIPs = make(map[netip.Addr]map[netip.Addr]appAddr)
+	c.expiryQueue = list.New()
 }
 
 type addrs struct {

--- a/feature/conn25/conn25_test.go
+++ b/feature/conn25/conn25_test.go
@@ -4,6 +4,7 @@
 package conn25
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -382,8 +383,7 @@ func TestHandleConnectorTransitIPRequest(t *testing.T) {
 								i, j, len(wantLookup))
 						}
 						pip, tip, wantDip := wantLookup[0], wantLookup[1], wantLookup[2]
-						aa, _ := c.connector.lookupBySrcIPAndTransitIP(pip, tip)
-						gotDip := aa.addr
+						gotDip, _ := c.connector.lookupAddrBySrcIPAndTransitIP(pip, tip)
 						if gotDip != wantDip {
 							t.Errorf("wrong result on lookup[%d][%d] ([%v], [%v]): got [%v] expected [%v]",
 								i, j, pip, tip, gotDip, wantDip)
@@ -2649,6 +2649,103 @@ func TestConnectorRealIPForTransitIPConnection(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConnectorExpireTransitIPs(t *testing.T) {
+	const appName = "app"
+
+	peerA := netip.MustParseAddr("100.101.101.101")
+	peerANode := (&tailcfg.Node{ID: 1, Addresses: []netip.Prefix{netip.PrefixFrom(peerA, 32)}}).View()
+
+	peerB := netip.MustParseAddr("100.101.101.102")
+	peerBNode := (&tailcfg.Node{ID: 2, Addresses: []netip.Prefix{netip.PrefixFrom(peerB, 32)}}).View()
+
+	tipOne := netip.MustParseAddr("0.0.0.1")
+	tipTwo := netip.MustParseAddr("0.0.0.2")
+	tipThree := netip.MustParseAddr("0.0.0.3")
+	tipFour := netip.MustParseAddr("0.0.0.4")
+
+	c := newConn25(logger.Discard)
+	c.reconfig(&config{
+		isConfigured: true,
+		appsByName:   map[string]appctype.Conn25Attr{appName: {}},
+	})
+	clock := tstest.NewClock(tstest.ClockOpts{Start: time.Now()})
+	// this would be a data race if we had started the sweeper, but we haven't.
+	c.connector.clock = clock
+
+	register := func(peer tailcfg.NodeView, tip, dst netip.Addr) {
+		c.handleConnectorTransitIPRequest(peer, ConnectorTransitIPRequest{
+			TransitIPs: []TransitIPRequest{{TransitIP: tip, DestinationIP: dst, App: appName}},
+		})
+	}
+
+	register(peerANode, tipOne, netip.MustParseAddr("10.0.0.1"))
+	register(peerANode, tipFour, netip.MustParseAddr("10.0.0.4"))
+	register(peerBNode, tipThree, netip.MustParseAddr("10.0.0.3"))
+
+	clock.Advance(30 * time.Minute)
+	register(peerANode, tipTwo, netip.MustParseAddr("10.0.0.2"))
+	// write over the tipFour mapping, with a different dst
+	register(peerANode, tipFour, netip.MustParseAddr("10.0.0.5"))
+
+	// advance past the hour expiry time of peerA+tipOne and peerB+tipThree
+	// the peerA+tipTwo and the updated peerA+tipFour registrations are still within expiry
+	clock.Advance(31 * time.Minute)
+	if got := c.connector.expireTransitIPs(clock.Now()); got != 2 {
+		t.Fatalf("expireTransitIPs removed %d mappings, want 2", got)
+	}
+
+	c.connector.mu.Lock()
+	if _, ok := c.connector.transitIPs[peerA][tipOne]; ok {
+		t.Fatalf("expected tipOne %v to be removed from the map", tipOne)
+	}
+	if _, ok := c.connector.transitIPs[peerA][tipTwo]; !ok {
+		t.Fatalf("expected tipTwo %v to remain in the map", tipTwo)
+	}
+	if _, ok := c.connector.transitIPs[peerB]; ok {
+		t.Fatalf("expected peerB sub-map to be pruned after its only mapping expired")
+	}
+	c.connector.mu.Unlock()
+
+	// advance another 30 mins, expire the other two mappings
+	clock.Advance(30 * time.Minute)
+	if got := c.connector.expireTransitIPs(clock.Now()); got != 2 {
+		t.Fatalf("expireTransitIPs removed %d mappings, want 2", got)
+	}
+	c.connector.mu.Lock()
+	if c.connector.expiryQueue.Len() != 0 {
+		t.Fatalf("queue should be all done now")
+	}
+	if _, ok := c.connector.transitIPs[peerA]; ok {
+		t.Fatalf("expected peerA sub-map to be pruned after all mappings expired")
+	}
+	c.connector.mu.Unlock()
+
+	uint32ToIPv4 := func(n uint32) netip.Addr {
+		var buf [4]byte
+		binary.BigEndian.PutUint32(buf[:], n)
+		return netip.AddrFrom4(buf)
+	}
+	var i uint32
+	for i = 0; i < 100003; i++ {
+		tip := uint32ToIPv4(i + 10)
+		dst := uint32ToIPv4(i + 100014)
+		register(peerANode, tip, dst)
+	}
+	// go past expiry time out
+	clock.Advance(61 * time.Minute)
+	if got := c.connector.expireTransitIPs(clock.Now()); got != 100000 {
+		t.Fatalf("expireTransitIPs removed %d mappings, want 100000, the limit for one run", got)
+	}
+	c.connector.mu.Lock()
+	if c.connector.expiryQueue.Len() != 3 {
+		t.Fatalf("expected 3 items remaining in queue")
+	}
+	if len(c.connector.transitIPs[peerA]) != 3 {
+		t.Fatalf("expected 3 items remaining in peerA transitIPs")
+	}
+	c.connector.mu.Unlock()
 }
 
 func TestIsKnownTransitIP(t *testing.T) {


### PR DESCRIPTION
The connector struct holds a map of peer+transitIP -> destinationIP that it uses for routing traffic. The client registers new entries in the map over the peer API.

Stop the transitIPs map from growing indefinitely by expiring entries after 1 hour.

Updates tailscale/corp#38261