### PR TITLE
hostinfo: improve detection of linux desktops

### DIFF
--- a/hostinfo/hostinfo.go
+++ b/hostinfo/hostinfo.go
@@ -74,13 +74,14 @@ func New() *tailcfg.Hostinfo {
 
 // non-nil on some platforms
 var (
-	osVersion      func() string
-	packageType    func() string
-	distroName     func() string
-	distroVersion  func() string
-	distroCodeName func() string
-	unameMachine   func() string
-	deviceModel    func() string
+	osVersion            func() string
+	packageType          func() string
+	distroName           func() string
+	distroVersion        func() string
+	distroCodeName       func() string
+	unameMachine         func() string
+	deviceModel          func() string
+	systemdLogindDesktop func() bool
 )
 
 func condCall[T any](fn func() T) T {
@@ -232,6 +233,12 @@ func FirewallMode() string {
 	return s
 }
 
+// desktop reports whether the system is running a Linux desktop environment.
+// The result is undefined for non-Linux systems.
+// It checks systemd-logind, and then via reading the list of open unix sockets
+// and seeing if any of them matches names of wayland, x11 or mir.
+// The detection runs for a minute after starting tailscaled, after that the
+// value is cached and returned directly from the cache.
 func desktop() (ret opt.Bool) {
 	if runtime.GOOS != "linux" {
 		return opt.Bool("")
@@ -242,10 +249,19 @@ func desktop() (ret opt.Bool) {
 	}
 
 	seenDesktop := false
-	for lr := range lineiter.File("/proc/net/unix") {
-		line, _ := lr.Value()
-		seenDesktop = seenDesktop || mem.Contains(mem.B(line), mem.S(".X11-unix"))
-		seenDesktop = seenDesktop || mem.Contains(mem.B(line), mem.S("/wayland-1"))
+	if systemdLogindDesktop != nil {
+		seenDesktop = systemdLogindDesktop()
+	}
+	if !seenDesktop {
+		for lr := range lineiter.File("/proc/net/unix") {
+			line, _ := lr.Value()
+			if seenDesktop = mem.Contains(mem.B(line), mem.S(".X11-unix")) ||
+				mem.Contains(mem.B(line), mem.S("/wayland-")) ||
+				mem.Contains(mem.B(line), mem.S("mir_socket")) ||
+				mem.Contains(mem.B(line), mem.S("gamescope-")); seenDesktop {
+				break
+			}
+		}
 	}
 	ret.Set(seenDesktop)
 

--- a/hostinfo/hostinfo_linux.go
+++ b/hostinfo/hostinfo_linux.go
@@ -7,8 +7,12 @@ package hostinfo
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"os"
+	"os/exec"
 	"strings"
+	"time"
 
 	"golang.org/x/sys/unix"
 	"tailscale.com/util/lineiter"
@@ -22,6 +26,7 @@ func init() {
 	distroVersion = distroVersionLinux
 	distroCodeName = distroCodeNameLinux
 	deviceModel = deviceModelLinux
+	systemdLogindDesktop = hasLogindDesktop
 }
 
 var (
@@ -176,4 +181,95 @@ func packageTypeLinux() string {
 		return "snap"
 	}
 	return ""
+}
+
+// hasLogindDesktop calls [systemdLogindFindDesktop] with a 100 millisecond
+// timeout.
+func hasLogindDesktop() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	runner := &osLogindRunner{ctx: ctx}
+	return systemdLogindFindDesktop(runner)
+}
+
+// logindConn is the interface for querying systemd-logind session information.
+// It exists to be able to swap the backend for testing.
+type logindRunner interface {
+	// listSessions returns the raw JSON output of
+	// "loginctl list-sessions --json=short", which is a json blob containing
+	// output like: '[{"session":"8"},{"session":"9"}]'.
+	listSessions() ([]byte, error)
+
+	// getSessionType returns the raw output of
+	// "loginctl show-session <id> --property=Type", which is a single line of
+	// the form "Type=<value>".
+	getSessionType(string) (string, error)
+}
+
+// osLogindRunner implements [logindRunner] by shelling out to the system logind.
+type osLogindRunner struct{ ctx context.Context }
+
+// listSessions implements [logindRunner] using os calls.
+func (r *osLogindRunner) listSessions() ([]byte, error) {
+	path, err := exec.LookPath("loginctl")
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.CommandContext(r.ctx, path, "list-sessions", "--json=short")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}
+
+// getSessionType implements [logindRunner] using os calls.
+func (r *osLogindRunner) getSessionType(session string) (string, error) {
+	path, err := exec.LookPath("loginctl")
+	if err != nil {
+		return "", err
+	}
+	cmd := exec.CommandContext(r.ctx,
+		path, "show-session", session, "--property=Type", "--value")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	return string(output), nil
+}
+
+// systemdLogindFindDesktop reports whether any active logind session has a
+// graphical desktop type (x11, wayland, or mir). On an error or with no types
+// matching the list above, it returns false.
+func systemdLogindFindDesktop(logind logindRunner) bool {
+	sessionJSON, err := logind.listSessions()
+	if err != nil {
+		return false
+	}
+
+	type session struct {
+		Session string `json:"session"`
+	}
+
+	var sessions []session
+	err = json.Unmarshal(sessionJSON, &sessions)
+	if err != nil {
+		return false
+	}
+
+	for _, sess := range sessions {
+		typeString, err := logind.getSessionType(sess.Session)
+		if err != nil {
+			continue
+		}
+
+		switch strings.ToLower(strings.TrimSpace(typeString)) {
+		case "wayland", "x11", "mir":
+			return true
+		}
+	}
+
+	return false
 }

--- a/hostinfo/hostinfo_linux_test.go
+++ b/hostinfo/hostinfo_linux_test.go
@@ -6,6 +6,7 @@
 package hostinfo
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -42,5 +43,143 @@ func TestPackageTypeNotContainer(t *testing.T) {
 	}
 	if got == "container" {
 		t.Fatal("packageType = container; should only happen if build tag ts_package_container is set")
+	}
+}
+
+type fakeLogindRunner struct {
+	sessions     []byte
+	sessionErr   error
+	sessionTypes map[string]string
+}
+
+func (f *fakeLogindRunner) listSessions() ([]byte, error) {
+	return f.sessions, f.sessionErr
+}
+
+func (f *fakeLogindRunner) getSessionType(session string) (string, error) {
+	return f.sessionTypes[session], nil
+}
+
+func TestSystemdLogindFindDesktop(t *testing.T) {
+	tests := []struct {
+		name   string
+		runner *fakeLogindRunner
+		want   bool
+	}{
+		{
+			name: "listSessions-error",
+			runner: &fakeLogindRunner{
+				sessionErr: errors.New("loginctl not found"),
+			},
+			want: false,
+		},
+		{
+			name: "invalid-json",
+			runner: &fakeLogindRunner{
+				sessions: []byte(`not json`),
+			},
+			want: false,
+		},
+		{
+			name: "empty",
+			runner: &fakeLogindRunner{
+				sessions: []byte(`[]`),
+			},
+			want: false,
+		},
+		{
+			name: "x11",
+			runner: &fakeLogindRunner{
+				sessions:     []byte(`[{"session":"1"}]`),
+				sessionTypes: map[string]string{"1": "x11"},
+			},
+			want: true,
+		},
+		{
+			name: "wayland",
+			runner: &fakeLogindRunner{
+				sessions:     []byte(`[{"session":"2"}]`),
+				sessionTypes: map[string]string{"2": "wayland"},
+			},
+			want: true,
+		},
+		{
+			name: "mir",
+			runner: &fakeLogindRunner{
+				sessions:     []byte(`[{"session":"3"}]`),
+				sessionTypes: map[string]string{"3": "mir"},
+			},
+			want: true,
+		},
+		{
+			name: "tty",
+			runner: &fakeLogindRunner{
+				sessions:     []byte(`[{"session":"4"}]`),
+				sessionTypes: map[string]string{"4": "tty"},
+			},
+			want: false,
+		},
+		{
+			name: "unspecified",
+			runner: &fakeLogindRunner{
+				sessions:     []byte(`[{"session":"5"}]`),
+				sessionTypes: map[string]string{"5": "unspecified"},
+			},
+			want: false,
+		},
+		{
+			name: "downcase",
+			runner: &fakeLogindRunner{
+				sessions:     []byte(`[{"session":"6"}]`),
+				sessionTypes: map[string]string{"6": "WaYlAnD"},
+			},
+			want: true,
+		},
+		{
+			name: "malformed",
+			runner: &fakeLogindRunner{
+				sessions:     []byte(`[{"session":"7"}]`),
+				sessionTypes: map[string]string{"7": "TypeWayland"},
+			},
+			want: false,
+		},
+		{
+			name: "multiple-no-desktop",
+			runner: &fakeLogindRunner{
+				sessions: []byte(`[{"session":"8"},{"session":"9"}]`),
+				sessionTypes: map[string]string{
+					"8": "tty",
+					"9": "unspecified",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "multiple-desktop",
+			runner: &fakeLogindRunner{
+				sessions: []byte(`[{"session":"10"},{"session":"11"}]`),
+				sessionTypes: map[string]string{
+					"10": "tty",
+					"11": "wayland",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "alpha-session",
+			runner: &fakeLogindRunner{
+				sessions:     []byte(`[{"session":"someSession"}]`),
+				sessionTypes: map[string]string{"someSession": "wayland"},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := systemdLogindFindDesktop(tt.runner); got != tt.want {
+				t.Errorf("systemdLogindFindDesktop() = %v; want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/hostinfo/hostinfo_test.go
+++ b/hostinfo/hostinfo_test.go
@@ -76,5 +76,4 @@ func TestCustomHostnameFunc(t *testing.T) {
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
-
 }


### PR DESCRIPTION
Our desktop detection was using "wayland-1" as a search string for
detecting wayland desktops, but many desktops use other indexes for the
session. Additionally we did not detect mir or gamescope.

Add a new detection method that leans on systemd-logind (if available)
and fall back to using the existing method of looking for open unix
sockets, but add search strings and tail the index off of the wayland
session detection.

Fixes #20847

Signed-off-by: Claus Lensbøl <claus@tailscale.com>
