### PR TITLE
tailcfg/peercap, types/appctype: prepare for conn25 grants

### DIFF
--- a/tailcfg/peercap/peercap.go
+++ b/tailcfg/peercap/peercap.go
@@ -12,6 +12,18 @@ package peercap
 // or "tailscale.com/cap/webui".
 type Cap string
 
+// Prefix is a prefix for [tailscale.com/tailcfg.PeerCapMap] keys that share a
+// common namespace, where each entry represents a distinct named instance (e.g.
+// one per App definition). The full key is formed by concatenating the prefix
+// with the instance name.
+type Prefix string
+
+// ToAttribute returns the full [Cap] key for the given value under this prefix,
+// of the form prefix+value.
+func (p Prefix) ToAttribute(value string) Cap {
+	return Cap(string(p) + value)
+}
+
 const (
 	// FileSharingTarget grants the current node the ability to send
 	// files to the peer which has this capability.
@@ -53,4 +65,15 @@ const (
 	// capabilities, such as the ability to add user groups to the OIDC
 	// claim
 	TsIDP Cap = "tailscale.com/cap/tsidp"
+)
+
+const (
+	// Conn25Prefix is the prefix for per-app [Cap] names that grant a peer
+	// access to an app provided by a conn25 app connector.
+	// Actual capabilities look like "tailscale.com/cap/conn25/example" for
+	// an app named "example".
+	// Each value under such a key is a [tailscale.com/tailcfg.ProtoPortRange].
+	// If multiple values are present, the union of all protocol/port
+	// combinations described shall be permitted.
+	Conn25Prefix Prefix = "tailscale.com/cap/conn25/"
 )

--- a/types/appctype/appconnector.go
+++ b/types/appctype/appconnector.go
@@ -107,6 +107,11 @@ type Conn25Attr struct {
 	// These can either be "*" to match any advertising connector, or a
 	// tag of the form tag:<tag-name>.
 	Connectors []string `json:"connectors,omitempty"`
+	// TemporaryUnsafeBypassFilter indicates that the connector should not look
+	// for peer capabilities when determining authorization to use an app. This
+	// is a temporary measure during development and will be removed without
+	// warning.
+	TemporaryUnsafeBypassFilter bool `json:"temporaryUnsafeBypassFilter,omitzero"`
 }
 
 type Conn25PoolsAttr struct {


### PR DESCRIPTION
This change contains the protocol changes needed to support describing authorization for conn25 apps. As a temporary transition measure during development, app configurations can disable authorization enforcement.

Updates tailscale/corp#40076

Change-Id: I3183c10374aacb0048f6632c384f71f758c20f2f