### PR TITLE
ipn/desktop, util/syspolicy: add per-user policy store lifecycle mana…

### DIFF
--- a/ipn/desktop/extension.go
+++ b/ipn/desktop/extension.go
@@ -78,8 +78,28 @@ func (e *desktopSessionsExt) Init(host ipnext.Host) (err error) {
 	if err != nil {
 		return fmt.Errorf("session callback registration failed: %w", err)
 	}
+
+	// Register per-user policy stores when users log in and unregister them when they log off.
+	polc := policyclient.Get()
+	unregisterPolicyCb, err := e.sm.RegisterInitCallback(func(session *Session) func() {
+		uid := string(session.User.UserID())
+		if uid == "" {
+			return nil
+		}
+		if err := polc.EnsureUserPolicyStore(uid); err != nil {
+			e.logf("failed to register user policy store for %s: %v", uid, err)
+			return nil
+		}
+		return func() {
+			polc.ReleaseUserPolicyStore(uid)
+		}
+	})
+	if err != nil {
+		return fmt.Errorf("policy init callback registration failed: %w", err)
+	}
+
 	host.Hooks().BackgroundProfileResolvers.Add(e.getBackgroundProfile)
-	e.cleanup = []func(){unregisterSessionCb}
+	e.cleanup = []func(){unregisterSessionCb, unregisterPolicyCb}
 	return nil
 }
 

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -2389,7 +2389,11 @@ func (b *LocalBackend) sysPolicyChangedForSession(sess *watchSession) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	snapshot, err := b.polc.GetPolicySnapshot("")
+	uid := ""
+	if sess.owner != nil {
+		uid = string(sess.owner.UserID())
+	}
+	snapshot, err := b.polc.GetPolicySnapshot(uid)
 	if err != nil || snapshot == nil {
 		return
 	}
@@ -3808,9 +3812,9 @@ func (b *LocalBackend) WatchNotificationsAs(ctx context.Context, actor ipnauth.A
 		}
 		if mask&ipn.NotifySysPolicyChanges != 0 {
 			var err error
-			ini.Policy, err = b.polc.GetPolicySnapshot("")
+			ini.Policy, err = b.polc.GetPolicySnapshot(string(actor.UserID()))
 			if err != nil {
-				b.logf("syspolicy: GetPolicySnapshot(\"\"): %v", err)
+				b.logf("syspolicy: GetPolicySnapshot(%q): %v", actor.UserID(), err)
 			}
 		}
 	}
@@ -3834,12 +3838,11 @@ func (b *LocalBackend) WatchNotificationsAs(ctx context.Context, actor ipnauth.A
 	deadlockDone()
 
 	if mask&ipn.NotifySysPolicyChanges != 0 {
-		if unreg, err := b.polc.RegisterChangeCallback("", func(_ policyclient.PolicyChange) {
+		uid := string(actor.UserID())
+		if unreg, err := b.polc.RegisterChangeCallback(uid, func(_ policyclient.PolicyChange) {
 			b.sysPolicyChangedForSession(session)
 		}); err == nil {
 			defer unreg()
-		} else {
-			b.logf("syspolicy: RegisterChangeCallback(\"\"): %v", err)
 		}
 	}
 

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -7770,6 +7770,43 @@ func TestUpdatePrefsOnSysPolicyChange(t *testing.T) {
 	}
 }
 
+func TestPerUserPolicySnapshots(t *testing.T) {
+	setting.SetDefinitionsForTest(t,
+		setting.NewDefinition(pkey.AdminConsoleVisibility, setting.UserSetting, setting.VisibilityValue),
+	)
+
+	deviceStore := source.NewTestStore(t)
+	rsop.RegisterStoreForTest(t, "TestStore", setting.DeviceScope, deviceStore)
+
+	userStoreA := source.NewTestStoreOf(t,
+		source.TestSettingOf(pkey.AdminConsoleVisibility, "hide"),
+	)
+	rsop.RegisterStoreForTest(t, "UserStoreA", setting.UserScopeOf("S-1-5-21-1001"), userStoreA)
+
+	userStoreB := source.NewTestStoreOf(t,
+		source.TestSettingOf(pkey.AdminConsoleVisibility, "show"),
+	)
+	rsop.RegisterStoreForTest(t, "UserStoreB", setting.UserScopeOf("S-1-5-21-1002"), userStoreB)
+
+	sys := tsd.NewSystem()
+	sys.PolicyClient.Set(testPolicyClient{})
+	lb := newTestLocalBackendWithSys(t, sys)
+
+	actorA := &ipnauth.TestActor{UID: "S-1-5-21-1001"}
+	nwA := newNotificationWatcher(t, lb, actorA)
+	nwA.watch(ipn.NotifySysPolicyChanges, []wantedNotification{
+		wantPolicyWithSetting(pkey.AdminConsoleVisibility, "hide"),
+	})
+	nwA.check()
+
+	actorB := &ipnauth.TestActor{UID: "S-1-5-21-1002"}
+	nwB := newNotificationWatcher(t, lb, actorB)
+	nwB.watch(ipn.NotifySysPolicyChanges, []wantedNotification{
+		wantPolicyWithSetting(pkey.AdminConsoleVisibility, "show"),
+	})
+	nwB.check()
+}
+
 func TestUpdateIngressAndServiceHashLocked(t *testing.T) {
 	prefs := ipn.NewPrefs().View()
 	previousSC := &ipn.ServeConfig{
@@ -8667,6 +8704,10 @@ func (testPolicyClient) RegisterChangeCallback(uid string, cb func(policyclient.
 		cb(change)
 	}), nil
 }
+
+func (testPolicyClient) EnsureUserPolicyStore(uid string) error { return nil }
+
+func (testPolicyClient) ReleaseUserPolicyStore(uid string) {}
 
 type textUpdate struct {
 	Advertise   []string

--- a/util/syspolicy/policyclient/policyclient.go
+++ b/util/syspolicy/policyclient/policyclient.go
@@ -72,6 +72,17 @@ type Client interface {
 	// If uid is empty, returns the default-scope policy. Returns nil, nil if policy
 	// snapshots are not supported.
 	GetPolicySnapshot(uid string) (*PolicySnapshot, error)
+
+	// EnsureUserPolicyStore ensures that a policy store is registered for the user with
+	// the specified Windows SID. It is refcounted, and each call must be balanced by
+	// a ReleaseUserPolicyStore call. It is a no-op on non-Windows platforms or if syspolicy
+	// is omitted from the build.
+	EnsureUserPolicyStore(uid string) error
+
+	// ReleaseUserPolicyStore decrements the refcount for the user's policy store. When
+	// the refcount reaches zero, the store is unregistered and closed. It is a no-op
+	// on non-Windows platforms or if syspolicy is omitted from the build.
+	ReleaseUserPolicyStore(uid string)
 }
 
 // PolicySnapshot is an alias for [setting.Snapshot] unless syspolicy is omitted from the build.
@@ -157,3 +168,7 @@ func (NoPolicyClient) RegisterChangeCallback(uid string, cb func(PolicyChange)) 
 func (NoPolicyClient) GetPolicySnapshot(uid string) (*PolicySnapshot, error) {
 	return nil, nil
 }
+
+func (NoPolicyClient) EnsureUserPolicyStore(uid string) error { return nil }
+
+func (NoPolicyClient) ReleaseUserPolicyStore(uid string) {}

--- a/util/syspolicy/policytest/policytest.go
+++ b/util/syspolicy/policytest/policytest.go
@@ -246,3 +246,7 @@ func (sp Config) SetDebugLoggingEnabled(enabled bool) {}
 func (c Config) GetPolicySnapshot(uid string) (*policyclient.PolicySnapshot, error) {
 	return nil, nil
 }
+
+func (c Config) EnsureUserPolicyStore(uid string) error { return nil }
+
+func (c Config) ReleaseUserPolicyStore(uid string) {}

--- a/util/syspolicy/source/policy_store_windows.go
+++ b/util/syspolicy/source/policy_store_windows.go
@@ -126,6 +126,27 @@ func newPlatformPolicyStore(scope gp.Scope, softwareKey registry.Key, policyLock
 	}
 }
 
+// nopPolicyLock is a lockableCloser that does nothing.
+// Used when no user token is available to create a real GP lock.
+type nopPolicyLock struct{}
+
+func (nopPolicyLock) Lock() error  { return nil }
+func (nopPolicyLock) Unlock()      {}
+func (nopPolicyLock) Close() error { return nil }
+
+func NewUserPlatformPolicyStoreForSID(sid string) (*PlatformPolicyStore, error) {
+	softwareKey, err := registry.OpenKey(registry.USERS, sid+`\`+softwareKeyName, windows.KEY_READ)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open the %s key for user %s: %w", softwareKeyName, sid, err)
+	}
+	return &PlatformPolicyStore{
+		scope:       gp.UserPolicy,
+		softwareKey: softwareKey,
+		done:        make(chan struct{}),
+		policyLock:  nopPolicyLock{},
+	}, nil
+}
+
 // Lock locks the policy store, preventing the system from modifying the policies
 // while they are being read. It is a read lock that may be acquired by multiple goroutines.
 // Each Lock call must be balanced by exactly one Unlock call.

--- a/util/syspolicy/syspolicy.go
+++ b/util/syspolicy/syspolicy.go
@@ -278,3 +278,11 @@ func (globalSyspolicy) GetPolicySnapshot(uid string) (*policyclient.PolicySnapsh
 	}
 	return p.Get(), nil
 }
+
+func (globalSyspolicy) EnsureUserPolicyStore(uid string) error {
+	return ensureUserPolicyStore(uid)
+}
+
+func (globalSyspolicy) ReleaseUserPolicyStore(uid string) {
+	releaseUserPolicyStore(uid)
+}

--- a/util/syspolicy/user_store.go
+++ b/util/syspolicy/user_store.go
@@ -1,0 +1,80 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package syspolicy
+
+import (
+	"fmt"
+	"sync"
+
+	"tailscale.com/util/syspolicy/rsop"
+	"tailscale.com/util/syspolicy/setting"
+	"tailscale.com/util/syspolicy/source"
+)
+
+var (
+	userStoreMu sync.Mutex
+	userStores  map[string]*userPolicyState // keyed by Windows SID
+
+	newUserStore func(uid string) (source.Store, error)
+)
+
+type userPolicyState struct {
+	refcount int
+	store    source.Store
+	reg      *rsop.StoreRegistration
+}
+
+func ensureUserPolicyStore(uid string) error {
+	if newUserStore == nil {
+		return nil // not supported on this platform
+	}
+
+	userStoreMu.Lock()
+	defer userStoreMu.Unlock()
+
+	if ups, ok := userStores[uid]; ok {
+		ups.refcount++
+		return nil
+	}
+
+	store, err := newUserStore(uid)
+	if err != nil {
+		return fmt.Errorf("failed to create user policy store for %s: %w", uid, err)
+	}
+	reg, err := rsop.RegisterStore("Platform", setting.UserScopeOf(uid), store)
+	if err != nil {
+		if c, ok := store.(interface{ Close() error }); ok {
+			c.Close()
+		}
+		return fmt.Errorf("failed to register user policy store for %s: %w", uid, err)
+	}
+	if userStores == nil {
+		userStores = make(map[string]*userPolicyState)
+	}
+	userStores[uid] = &userPolicyState{
+		refcount: 1,
+		store:    store,
+		reg:      reg,
+	}
+	return nil
+}
+
+func releaseUserPolicyStore(uid string) {
+	userStoreMu.Lock()
+	defer userStoreMu.Unlock()
+
+	ups, ok := userStores[uid]
+	if !ok {
+		return
+	}
+	ups.refcount--
+	if ups.refcount > 0 {
+		return
+	}
+	ups.reg.Unregister()
+	if c, ok := ups.store.(interface{ Close() error }); ok {
+		c.Close()
+	}
+	delete(userStores, uid)
+}

--- a/util/syspolicy/user_store_test.go
+++ b/util/syspolicy/user_store_test.go
@@ -1,0 +1,84 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package syspolicy
+
+import (
+	"testing"
+
+	"tailscale.com/util/syspolicy/rsop"
+	"tailscale.com/util/syspolicy/setting"
+	"tailscale.com/util/syspolicy/source"
+)
+
+func TestEnsureUserPolicyStore(t *testing.T) {
+	store := source.NewTestStore(t)
+	newUserStore = func(uid string) (source.Store, error) {
+		return store, nil
+	}
+	t.Cleanup(func() {
+		userStoreMu.Lock()
+		userStores = nil
+		userStoreMu.Unlock()
+	})
+
+	if err := ensureUserPolicyStore("user1"); err != nil {
+		t.Fatal(err)
+	}
+
+	policy, err := rsop.PolicyFor(setting.UserScopeOf("user1"))
+	if err != nil {
+		t.Fatalf("PolicyFor: %v", err)
+	}
+	if policy == nil {
+		t.Fatal("expected non-nil policy for user1")
+	}
+}
+
+func TestEnsureUserPolicyStoreRefcount(t *testing.T) {
+	store := source.NewTestStore(t)
+	newUserStore = func(uid string) (source.Store, error) {
+		return store, nil
+	}
+	t.Cleanup(func() {
+		userStoreMu.Lock()
+		userStores = nil
+		userStoreMu.Unlock()
+	})
+
+	if err := ensureUserPolicyStore("user1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureUserPolicyStore("user1"); err != nil {
+		t.Fatal(err)
+	}
+
+	userStoreMu.Lock()
+	rc := userStores["user1"].refcount
+	userStoreMu.Unlock()
+	if rc != 2 {
+		t.Fatalf("refcount = %d; want 2", rc)
+	}
+
+	releaseUserPolicyStore("user1")
+
+	userStoreMu.Lock()
+	rc = userStores["user1"].refcount
+	userStoreMu.Unlock()
+	if rc != 1 {
+		t.Fatalf("refcount after first release = %d; want 1", rc)
+	}
+
+	releaseUserPolicyStore("user1")
+
+	userStoreMu.Lock()
+	_, exists := userStores["user1"]
+	userStoreMu.Unlock()
+	if exists {
+		t.Fatal("expected user1 store to be removed after final release")
+	}
+}
+
+func TestReleaseUnknownUserIsNoop(t *testing.T) {
+	releaseUserPolicyStore("nonexistent")
+}

--- a/util/syspolicy/user_store_windows.go
+++ b/util/syspolicy/user_store_windows.go
@@ -1,0 +1,14 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build windows
+
+package syspolicy
+
+import "tailscale.com/util/syspolicy/source"
+
+func init() {
+	newUserStore = func(uid string) (source.Store, error) {
+		return source.NewUserPlatformPolicyStoreForSID(uid)
+	}
+}


### PR DESCRIPTION
…gement

This adds refcounted per-user policy store registration so that tailscaled can read per-user group policy settings for each logged in Windows user. Without this, winui would only see device scope policies, since it runs in a separate process and gets policies via ipn bus.

This also updates callsites to pass actor.UserID() so that per-user stores are actually queried.

Updates tailscale/corp#42259