### PR TITLE
cmd/testwrapper: fail when shard test discovery fails

### DIFF
--- a/cmd/testwrapper/testwrapper.go
+++ b/cmd/testwrapper/testwrapper.go
@@ -176,26 +176,34 @@ var debug = os.Getenv("TS_TESTWRAPPER_DEBUG") != ""
 // testsForShard returns the test names in pkg that belong to the given shard
 // spec (e.g. "2/3"). It uses "go list -json" to find test source files (no
 // compilation) and scans them for top-level test function names, assigning
-// each to a shard by hashing. Returns nil if the spec is invalid or if
-// listing fails (the main run will surface the error).
+// each to a shard by hashing.
+//
+// An empty result means the shard legitimately has no tests, and the caller
+// skips the package without running "go test" at all. Every way discovery can
+// come up short of that must therefore be an error, or the skip silently
+// reports success for tests that were never run.
 func testsForShard(ctx context.Context, pkg, shardSpec string) ([]string, error) {
 	a, b, ok := strings.Cut(shardSpec, "/")
 	if !ok {
-		return nil, nil
+		return nil, fmt.Errorf("invalid shard spec %q, want N/M", shardSpec)
 	}
 	wantShard, err := strconv.Atoi(a)
 	if err != nil || wantShard < 1 {
-		return nil, nil
+		return nil, fmt.Errorf("invalid shard number in shard spec %q", shardSpec)
 	}
 	shards, err := strconv.Atoi(b)
 	if err != nil || shards < 1 {
-		return nil, nil
+		return nil, fmt.Errorf("invalid shard count in shard spec %q", shardSpec)
+	}
+	if wantShard > shards {
+		return nil, fmt.Errorf("shard %d out of range in shard spec %q", wantShard, shardSpec)
 	}
 
-	out, err := exec.CommandContext(ctx, "go", "list", "-json", pkg).Output()
+	list := exec.CommandContext(ctx, "go", "list", "-json", pkg)
+	list.Stderr = os.Stderr
+	out, err := list.Output()
 	if err != nil {
-		// Errors will be surfaced by the main test run.
-		return nil, nil
+		return nil, fmt.Errorf("go list -json %s: %w", pkg, err)
 	}
 
 	type pkgJSON struct {
@@ -211,12 +219,12 @@ func testsForShard(ctx context.Context, pkg, shardSpec string) ([]string, error)
 	for dec.More() {
 		var p pkgJSON
 		if err := dec.Decode(&p); err != nil {
-			break
+			return nil, fmt.Errorf("decoding go list -json output for %s: %w", pkg, err)
 		}
 		for _, f := range append(p.TestGoFiles, p.XTestGoFiles...) {
 			names, err := testFuncNames(filepath.Join(p.Dir, f))
 			if err != nil {
-				continue
+				return nil, fmt.Errorf("scanning test names: %w", err)
 			}
 			for _, name := range names {
 				if seen[name] {

--- a/cmd/testwrapper/testwrapper_test.go
+++ b/cmd/testwrapper/testwrapper_test.go
@@ -356,6 +356,53 @@ func TestBuildError(t *testing.T) {
 	}
 }
 
+// TestShard covers TS_TEST_SHARD. When the wrapper can't work out which tests
+// the shard should run, it has to fail: it never starts "go test" for a shard
+// that comes up empty, so treating a discovery failure as an empty shard
+// reports success for tests that never ran. A shard that legitimately holds no
+// tests is still a successful skip.
+func TestShard(t *testing.T) {
+	t.Parallel()
+
+	// A package with exactly one test, for the cases that must still pass.
+	// Which of the two shards it lands in depends on the name hash, so both
+	// are expected to succeed, one running it and one skipping it.
+	onefile := filepath.Join(t.TempDir(), "one_test.go")
+	src := []byte("package one_test\n\nimport \"testing\"\n\nfunc TestOne(t *testing.T) {}\n")
+	if err := os.WriteFile(onefile, src, 0o644); err != nil {
+		t.Fatalf("writing package: %s", err)
+	}
+
+	for _, tt := range []struct {
+		name     string
+		shard    string
+		pkg      string
+		wantCode int
+	}{
+		{"malformed", "bogus", "./doesnotexist", 1},
+		{"zero-shard", "0/3", "./doesnotexist", 1},
+		{"out-of-range", "2/1", "./doesnotexist", 1},
+		{"listing-fails", "1/3", "./doesnotexist", 1},
+		{"valid-first", "1/2", onefile, 0},
+		{"valid-second", "2/2", onefile, 0},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := cmdTestwrapper(t, tt.pkg)
+			cmd.Env = append(cmd.Env, "TS_TEST_SHARD="+tt.shard)
+			out, err := cmd.CombinedOutput()
+			code, ok := errExitCode(err)
+			if err == nil {
+				code, ok = 0, true
+			}
+			if !ok || code != tt.wantCode {
+				t.Fatalf("TS_TEST_SHARD=%s testwrapper %s: got exit code %d, want %d (err: %v, output: %s)", tt.shard, tt.pkg, code, tt.wantCode, err, out)
+			}
+		})
+	}
+}
+
 func TestTimeout(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #20797.

## What is wrong

With `TS_TEST_SHARD` set, `testsForShard` returns `(nil, nil)` when the shard spec is invalid and when `go list -json` fails. That is the exact same result a valid shard with no assigned tests produces, and `runTests` turns an empty result into `outcomeSkip` and returns **before** `go test` is started, so `main` prints `[skipped/no tests]` and exits 0.

The doc comment said the errors would be surfaced by the main test run. In that path there is no main test run, because the skip happens first.

## Evidence

Against `cfe32b8be`, using a package that does not resolve:

```
$ ./tool/go run ./cmd/testwrapper ./nosuchpkg
FAIL	./nosuchpkg [setup failed]
exit status 1

$ TS_TEST_SHARD=1/3 ./tool/go run ./cmd/testwrapper ./nosuchpkg
?	./nosuchpkg [skipped/no tests]
$ echo $?
0
```

`TS_TEST_SHARD` is set on the `test` and `race-root-integration` matrices in `.github/workflows/test.yml`, so this is the shape CI runs in. Same exit 0 for `TS_TEST_SHARD=bogus` and `TS_TEST_SHARD=2/1`, on every package in the run.

## What this changes

Every discovery path now returns an error, so an empty result only ever means the shard legitimately has no tests, which stays a successful skip. That covers:

- a spec that is not `N/M`, or has an unparseable/`< 1` number
- `N > M`, which parsed fine and then matched no test name
- `go list -json` failing
- the JSON decode and test-name scan errors, which quietly dropped whatever they could not read

`go list`'s stderr goes to `os.Stderr` so its own message still reaches the log. `main` already treats a non-`ExitError` from `runTests` as a package fatal and honors an `ExitError`'s code, so no plumbing was needed on that side.

The package-list sharding path (`sharded:1/2`, `testwrapper.go:759`) already fails loudly via `log.Fatalf`. This puts test-name sharding on the same footing.

## Test

`TestShard` in `cmd/testwrapper/testwrapper_test.go` runs the built wrapper with each bad spec plus a listing failure and asserts exit 1, and runs both halves of a valid `1/2`/`2/2` split over a one-test package to assert those still exit 0. It fails on all four failure cases without the change (verified by reverting `testwrapper.go` and re-running), passes with it.

Local: `./tool/go build ./...`, `./tool/go test ./cmd/testwrapper/...`, `./tool/go test -race ./cmd/testwrapper`, `./tool/go vet ./cmd/testwrapper`, `gofmt` all clean.

---

apologies if anything here is off, i worked through the logic myself and talked the design decisions over with claude code. freshman in college, happy to be corrected on any of it, just trying to be useful :)