### PR TITLE
ipn/ipnlocal: preserve half-closed TCP forwarding

### DIFF
--- a/ipn/ipnlocal/serve.go
+++ b/ipn/ipnlocal/serve.go
@@ -8,6 +8,7 @@
 package ipnlocal
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"crypto/tls"
@@ -566,7 +567,7 @@ func (c *serviceMeteredConn) CloseWrite() error {
 	if cw, ok := c.Conn.(interface{ CloseWrite() error }); ok {
 		return cw.CloseWrite()
 	}
-	return nil
+	return errors.ErrUnsupported
 }
 
 // meteredConnForService wraps c to count peer bytes against the per-Service
@@ -779,26 +780,57 @@ func (b *LocalBackend) forwardTCPWithProxyProtocol(conn, backConn net.Conn, prox
 		proxyHeader, err = header.Format()
 		if err != nil {
 			b.logf("localbackend: failed to format proxy protocol header for port %v (from %v) to %s: %v", dport, srcAddr, backDst, err)
+			return err
 		}
 	}
 
-	errc := make(chan error, 1)
-	go func() {
-		if len(proxyHeader) > 0 {
-			if _, err := backConn.Write(proxyHeader); err != nil {
+	// Both pumps report exactly once into a channel large enough that neither
+	// can be left blocked while the owner handles the other pump's result.
+	errc := make(chan error, 2)
+	pump := func(dst, src net.Conn, prefix []byte) {
+		if len(prefix) > 0 {
+			if _, err := io.Copy(dst, bytes.NewReader(prefix)); err != nil {
 				errc <- err
-				backConn.Close()
 				return
 			}
 		}
-		_, err := io.Copy(backConn, conn)
-		errc <- err
-	}()
-	go func() {
-		_, err := io.Copy(conn, backConn)
-		errc <- err
-	}()
-	return <-errc
+		if _, err := io.Copy(dst, src); err != nil {
+			errc <- err
+			return
+		}
+		cw, ok := dst.(interface{ CloseWrite() error })
+		if !ok {
+			errc <- errors.ErrUnsupported
+			return
+		}
+		errc <- cw.CloseWrite()
+	}
+
+	go pump(backConn, conn, proxyHeader)
+	go pump(conn, backConn, nil)
+
+	firstErr := <-errc
+	if firstErr != nil {
+		// A hard failure must unblock the other pump before we wait for it.
+		conn.Close()
+		backConn.Close()
+	}
+	secondErr := <-errc
+	// Final full closes release both descriptors after both pumps have exited.
+	conn.Close()
+	backConn.Close()
+	var result error
+	if firstErr != nil {
+		result = firstErr
+	} else {
+		result = secondErr
+	}
+	// Historically the handler reports an unsupported half-close (for example,
+	// on Unix sockets) as a cleanly handled connection-local termination.
+	if errors.Is(result, errors.ErrUnsupported) {
+		return nil
+	}
+	return result
 }
 
 func (b *LocalBackend) getServeHandler(r *http.Request) (_ ipn.HTTPHandlerView, at string, ok bool) {

--- a/ipn/ipnlocal/serve_test.go
+++ b/ipn/ipnlocal/serve_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"cmp"
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -25,9 +26,11 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/pires/go-proxyproto"
 	"tailscale.com/control/controlclient"
 	"tailscale.com/health"
 	"tailscale.com/ipn"
@@ -47,6 +50,258 @@ import (
 	"tailscale.com/wgengine"
 	"tailscale.com/wgengine/filter"
 )
+
+func TestServiceMeteredConnCloseWriteUnsupported(t *testing.T) {
+	a, b := net.Pipe()
+	defer a.Close()
+	defer b.Close()
+	c := &serviceMeteredConn{Conn: a}
+	if err := c.CloseWrite(); !errors.Is(err, errors.ErrUnsupported) {
+		t.Fatalf("CloseWrite error = %v, want errors.ErrUnsupported", err)
+	}
+}
+
+func TestForwardTCPWithProxyProtocolHalfClose(t *testing.T) {
+	const (
+		requestSize  = 8 << 20
+		responseSize = 1 << 20
+	)
+	request := bytes.Repeat([]byte("request-payload-"), requestSize/len("request-payload-")+1)[:requestSize]
+	response := bytes.Repeat([]byte("response-payload-"), responseSize/len("response-payload-")+1)[:responseSize]
+	requestDigest := sha256.Sum256(request)
+	responseDigest := sha256.Sum256(response)
+
+	frontLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer frontLn.Close()
+	backendLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer backendLn.Close()
+
+	client, err := net.Dial("tcp", frontLn.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	serveConn, err := frontLn.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serveConn.Close()
+
+	backConn, err := net.Dial("tcp", backendLn.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer backConn.Close()
+	backend, err := backendLn.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer backend.Close()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for _, c := range []net.Conn{client, serveConn, backConn, backend} {
+		if err := c.SetDeadline(deadline); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	src := netip.MustParseAddrPort("192.0.2.10:4242")
+	dst := backendLn.Addr().(*net.TCPAddr)
+	b := newTestBackend(t)
+	destIP := netip.AddrFrom4([4]byte{127, 0, 0, 1})
+	if self := b.currentNode().Self(); self.Valid() {
+		destIP = nodeIP(self, netip.Addr.Is4)
+	}
+	wantHeader, err := (&proxyproto.Header{
+		Version:           2,
+		Command:           proxyproto.PROXY,
+		TransportProtocol: proxyproto.TCPv4,
+		SourceAddr:        net.TCPAddrFromAddrPort(src),
+		DestinationAddr:   &net.TCPAddr{IP: destIP.AsSlice(), Port: dst.Port},
+	}).Format()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type backendResult struct {
+		header        []byte
+		requestDigest [sha256.Size]byte
+		requestBytes  int
+		err           error
+	}
+	backendDone := make(chan backendResult, 1)
+	go func() {
+		gotHeader := make([]byte, len(wantHeader))
+		if _, err := io.ReadFull(backend, gotHeader); err != nil {
+			backendDone <- backendResult{err: fmt.Errorf("read PROXY v2 header: %w", err)}
+			return
+		}
+		gotRequest, err := io.ReadAll(backend)
+		result := backendResult{
+			header:        gotHeader,
+			requestDigest: sha256.Sum256(gotRequest),
+			requestBytes:  len(gotRequest),
+			err:           err,
+		}
+		if err == nil {
+			if _, err = backend.Write(response); err == nil {
+				err = backend.(*net.TCPConn).CloseWrite()
+			}
+			result.err = err
+		}
+		backendDone <- result
+	}()
+
+	forwardDone := make(chan error, 1)
+	go func() {
+		forwardDone <- b.forwardTCPWithProxyProtocol(serveConn, backConn, 2, src, 443, backendLn.Addr().String())
+	}()
+
+	if _, err := client.Write(request); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.(*net.TCPConn).CloseWrite(); err != nil {
+		t.Fatal(err)
+	}
+	gotResponse, err := io.ReadAll(client)
+	if err != nil {
+		t.Fatalf("read response after request half-close: %v", err)
+	}
+	if got, want := len(gotResponse), len(response); got != want {
+		t.Fatalf("response bytes = %d, want %d", got, want)
+	}
+	if got := sha256.Sum256(gotResponse); got != responseDigest {
+		t.Fatalf("response digest = %x, want %x", got, responseDigest)
+	}
+
+	result := <-backendDone
+	if result.err != nil {
+		t.Fatalf("backend: %v", result.err)
+	}
+	if !bytes.Equal(result.header, wantHeader) {
+		t.Fatalf("PROXY v2 header = %x, want %x", result.header, wantHeader)
+	}
+	if result.requestBytes != len(request) || result.requestDigest != requestDigest {
+		t.Fatalf("request = %d bytes/%x, want %d bytes/%x", result.requestBytes, result.requestDigest, len(request), requestDigest)
+	}
+	if err := <-forwardDone; err != nil {
+		t.Fatalf("forward: %v", err)
+	}
+}
+
+type pumpTestConn struct {
+	net.Conn
+	closeWriteErr error
+	readErr       error
+	closed        chan struct{}
+	closeOnce     sync.Once
+}
+
+func (c *pumpTestConn) Read(p []byte) (int, error) {
+	if c.readErr != nil {
+		return 0, c.readErr
+	}
+	return c.Conn.Read(p)
+}
+
+func (c *pumpTestConn) CloseWrite() error { return c.closeWriteErr }
+
+func (c *pumpTestConn) Close() error {
+	c.closeOnce.Do(func() { close(c.closed) })
+	return c.Conn.Close()
+}
+
+func TestForwardTCPHardFailureClosesBothAndWaits(t *testing.T) {
+	errCloseWrite := errors.New("injected CloseWrite failure")
+	errCopy := errors.New("injected copy failure")
+	tests := []struct {
+		name            string
+		connCloseWrite  error
+		backCloseWrite  error
+		connRead        error
+		closeClientPeer bool
+		closeBackPeer   bool
+		want            error
+	}{
+		{
+			name:           "client_direction_unsupported",
+			connCloseWrite: errors.ErrUnsupported,
+			closeBackPeer:  true,
+		},
+		{
+			name:            "backend_direction_unsupported",
+			backCloseWrite:  errors.ErrUnsupported,
+			closeClientPeer: true,
+		},
+		{
+			name:            "CloseWrite_error",
+			backCloseWrite:  errCloseWrite,
+			closeClientPeer: true,
+			want:            errCloseWrite,
+		},
+		{
+			name:     "copy_error",
+			connRead: errCopy,
+			want:     errCopy,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			connRaw, clientPeer := net.Pipe()
+			backRaw, backPeer := net.Pipe()
+			defer clientPeer.Close()
+			defer backPeer.Close()
+			conn := &pumpTestConn{
+				Conn:          connRaw,
+				closeWriteErr: tt.connCloseWrite,
+				readErr:       tt.connRead,
+				closed:        make(chan struct{}),
+			}
+			backConn := &pumpTestConn{
+				Conn:          backRaw,
+				closeWriteErr: tt.backCloseWrite,
+				closed:        make(chan struct{}),
+			}
+			if tt.closeClientPeer {
+				clientPeer.Close()
+			}
+			if tt.closeBackPeer {
+				backPeer.Close()
+			}
+
+			done := make(chan error, 1)
+			go func() {
+				done <- (&LocalBackend{}).forwardTCPWithProxyProtocol(conn, backConn, 0, netip.AddrPort{}, 0, "")
+			}()
+
+			select {
+			case err := <-done:
+				if tt.want == nil && err != nil || tt.want != nil && !errors.Is(err, tt.want) {
+					t.Fatalf("forward error = %v, want %v", err, tt.want)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("forward did not wait for and release both pumps")
+			}
+			for name, closed := range map[string]<-chan struct{}{
+				"client":  conn.closed,
+				"backend": backConn.closed,
+			} {
+				select {
+				case <-closed:
+				default:
+					t.Errorf("%s connection was not fully closed", name)
+				}
+			}
+		})
+	}
+}
 
 func TestExpandProxyArg(t *testing.T) {
 	type res struct {

--- a/net/tsdial/tsdial.go
+++ b/net/tsdial/tsdial.go
@@ -125,6 +125,16 @@ func (c sysConn) Close() error {
 	return nil
 }
 
+// CloseWrite closes the write half of the underlying connection without
+// removing it from the dialer's active connection tracking.
+func (c sysConn) CloseWrite() error {
+	cw, ok := c.Conn.(interface{ CloseWrite() error })
+	if !ok {
+		return errors.ErrUnsupported
+	}
+	return cw.CloseWrite()
+}
+
 // SetTUNName sets the name of the tun device in use ("tailscale0", "utun6",
 // etc). This is needed on some platforms to set sockopts to bind
 // to the same interface index.

--- a/net/tsdial/tsdial_test.go
+++ b/net/tsdial/tsdial_test.go
@@ -6,6 +6,7 @@ package tsdial
 import (
 	"context"
 	"errors"
+	"io"
 	"net"
 	"net/netip"
 	"sync/atomic"
@@ -231,4 +232,73 @@ func (c *closingPipeConn) Close() error {
 		close(c.closed)
 	}
 	return c.Conn.Close()
+}
+
+func TestSystemDialCloseWritePreservesTracking(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	serverConn := make(chan net.Conn, 1)
+	go func() {
+		c, err := ln.Accept()
+		if err == nil {
+			serverConn <- c
+		}
+	}()
+
+	d := &Dialer{}
+	d.SetSystemDialerForTest((&net.Dialer{}).DialContext)
+	c, err := d.SystemDial(context.Background(), "tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	peer := <-serverConn
+	defer peer.Close()
+
+	cw, ok := c.(interface{ CloseWrite() error })
+	if !ok {
+		t.Fatal("SystemDial connection does not expose CloseWrite")
+	}
+	if err := cw.CloseWrite(); err != nil {
+		t.Fatalf("CloseWrite: %v", err)
+	}
+	if got := len(d.activeSysConns); got != 1 {
+		t.Fatalf("active system connections after CloseWrite = %d, want 1", got)
+	}
+
+	if err := peer.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 1)
+	if n, err := peer.Read(buf); n != 0 || err != io.EOF {
+		t.Fatalf("peer Read after CloseWrite = %d, %v; want 0, EOF", n, err)
+	}
+}
+
+func TestSystemDialCloseWriteUnsupported(t *testing.T) {
+	a, b := net.Pipe()
+	defer b.Close()
+	d := &Dialer{}
+	d.SetSystemDialerForTest(func(context.Context, string, string) (net.Conn, error) {
+		return a, nil
+	})
+	c, err := d.SystemDial(context.Background(), "tcp", "unused")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	cw, ok := c.(interface{ CloseWrite() error })
+	if !ok {
+		t.Fatal("SystemDial connection does not expose CloseWrite")
+	}
+	if err := cw.CloseWrite(); !errors.Is(err, errors.ErrUnsupported) {
+		t.Fatalf("CloseWrite error = %v, want errors.ErrUnsupported", err)
+	}
+	if got := len(d.activeSysConns); got != 1 {
+		t.Fatalf("active system connections after unsupported CloseWrite = %d, want 1", got)
+	}
 }


### PR DESCRIPTION
Updates #20880. Supersedes #20879 with DCO sign-off and an issue-linked commit.

## Problem

`Dialer.SystemDial` wraps outbound connections in `sysConn`, which hides an underlying TCP `CloseWrite`. The Serve TCP forwarder also returned when the first `io.Copy` completed. A client that sent a request and then half-closed could therefore fail to deliver FIN to a backend that waits for EOF before producing its response.

## State machine

- `sysConn` and the per-Service metering wrapper forward `CloseWrite`; unsupported transports return `errors.ErrUnsupported`.
- A `sysConn` remains actively tracked after a write-half close, so link changes and shutdown can still fully close it.
- The client-to-backend pump writes the PROXY header once, before payload.
- Two pumps report once each through a capacity-2 channel. Clean EOF half-closes only the destination and waits for the reverse flow.
- Copy, header, unsupported, or `CloseWrite` failures fully close both sides to release the other pump; the owner waits for both pumps and finally closes both connections.

## Tests

Base RED:
- `go test ./net/tsdial -run TestSystemDialCloseWrite -count=1` (no exposed `CloseWrite`)
- `go test ./ipn/ipnlocal -run "Test(ServiceMeteredConnCloseWriteUnsupported|ForwardTCPWithProxyProtocolHalfClose)$" -count=1` (unsupported was silently accepted; EOF-gated response timed out)

Patched GREEN:
- `go test ./net/tsdial ./ipn/ipnlocal -count=3`
- focused tests under `go test -race`
- `go vet ./net/tsdial ./ipn/ipnlocal`

The TCP oracle sends 8 MiB, immediately half-closes, validates an exact PROXY v2 header and request SHA-256, gates a 1 MiB response on backend EOF, and validates response SHA-256 plus final EOF. Failure tests cover unsupported half-close in both directions, copy failure, and `CloseWrite` failure with full-close/pump-exit assertions.

A separate rootless-Podman application trace using a locally built image from this tree confirmed the backend received exactly 8 MiB and EOF and emitted exactly 1 MiB. That larger application chain still returned zero response bytes to its final client after an independent agent-restart stage, so I am not presenting that external trace as a fully passing end-to-end result; the package-level real-TCP/PROXY-v2 oracle above is green.

Base: `cfe32b8be6a33f8e24fbc369cbfbf7c729d9e042`
Head: `b32a93e5fd1a4bef1c9d679ab6debb01639706d5`
Tree: `4392ba00687f3781b232a1ec8267ec1b7aa7b0bb`