### PR TITLE
net/socks5: preserve half-closed TCP connections

### DIFF
--- a/net/socks5/socks5.go
+++ b/net/socks5/socks5.go
@@ -219,7 +219,11 @@ func (c *Conn) handleTCP() error {
 		c.clientConn.Write(buf)
 		return err
 	}
-	defer srv.Close()
+	closeBoth := func() {
+		c.clientConn.Close()
+		srv.Close()
+	}
+	defer closeBoth()
 
 	localAddr := srv.LocalAddr().String()
 	serverAddr, serverPort, err := splitHostPort(localAddr)
@@ -237,27 +241,47 @@ func (c *Conn) handleTCP() error {
 	}
 	buf, err := res.marshal()
 	if err != nil {
-		res = errorResponse(generalFailure)
-		buf, _ = res.marshal()
+		failure, _ := errorResponse(generalFailure).marshal()
+		io.Copy(c.clientConn, bytes.NewReader(failure))
+		return err
 	}
-	c.clientConn.Write(buf)
+	if _, err := io.Copy(c.clientConn, bytes.NewReader(buf)); err != nil {
+		return fmt.Errorf("write CONNECT response: %w", err)
+	}
 
+	// Each pump reports exactly once into a channel large enough that neither
+	// can block while the owner handles the other pump's result.
 	errc := make(chan error, 2)
-	go func() {
-		_, err := io.Copy(c.clientConn, srv)
+	pump := func(dst, src net.Conn, direction string) {
+		_, err := io.Copy(dst, src)
 		if err != nil {
-			err = fmt.Errorf("from backend to client: %w", err)
+			errc <- fmt.Errorf("%s: %w", direction, err)
+			return
 		}
-		errc <- err
-	}()
-	go func() {
-		_, err := io.Copy(srv, c.clientConn)
-		if err != nil {
-			err = fmt.Errorf("from client to backend: %w", err)
+		cw, ok := dst.(interface{ CloseWrite() error })
+		if !ok {
+			errc <- fmt.Errorf("%s CloseWrite: %w", direction, errors.ErrUnsupported)
+			return
 		}
-		errc <- err
-	}()
-	return <-errc
+		if err := cw.CloseWrite(); err != nil {
+			errc <- fmt.Errorf("%s CloseWrite: %w", direction, err)
+			return
+		}
+		errc <- nil
+	}
+	go pump(c.clientConn, srv, "from backend to client")
+	go pump(srv, c.clientConn, "from client to backend")
+
+	firstErr := <-errc
+	if firstErr != nil {
+		// A full close unblocks the other pump before the owner waits for it.
+		closeBoth()
+	}
+	secondErr := <-errc
+	if firstErr != nil {
+		return firstErr
+	}
+	return secondErr
 }
 
 func (c *Conn) handleUDP() error {

--- a/net/socks5/socks5_test.go
+++ b/net/socks5/socks5_test.go
@@ -5,14 +5,490 @@ package socks5
 
 import (
 	"bytes"
+	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
 	"net"
+	"net/netip"
+	"sync"
 	"testing"
+	"time"
 
 	"golang.org/x/net/proxy"
 )
+
+type trackedTCPConn struct {
+	net.Conn
+	readErr     error
+	readGate    <-chan struct{}
+	readStarted chan struct{}
+	readOnce    sync.Once
+	closed      chan struct{}
+	closeOnce   sync.Once
+}
+
+func newTrackedTCPConn(conn net.Conn) *trackedTCPConn {
+	return &trackedTCPConn{
+		Conn:        conn,
+		readStarted: make(chan struct{}),
+		closed:      make(chan struct{}),
+	}
+}
+
+func (c *trackedTCPConn) Read(p []byte) (int, error) {
+	c.readOnce.Do(func() { close(c.readStarted) })
+	if c.readErr != nil {
+		if c.readGate != nil {
+			<-c.readGate
+		}
+		return 0, c.readErr
+	}
+	return c.Conn.Read(p)
+}
+
+func (c *trackedTCPConn) Close() error {
+	c.closeOnce.Do(func() { close(c.closed) })
+	return c.Conn.Close()
+}
+
+type closeWriteTCPConn struct {
+	*trackedTCPConn
+	closeWriteErr error
+}
+
+func (c *closeWriteTCPConn) CloseWrite() error {
+	if c.closeWriteErr != nil {
+		return c.closeWriteErr
+	}
+	return c.Conn.(*net.TCPConn).CloseWrite()
+}
+
+type writeErrorTCPConn struct {
+	*trackedTCPConn
+	writeErr error
+}
+
+func (c *writeErrorTCPConn) Write([]byte) (int, error) { return 0, c.writeErr }
+
+func tcpConnPair(t *testing.T) (*net.TCPConn, *net.TCPConn) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	accepted := make(chan *net.TCPConn, 1)
+	acceptErr := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			acceptErr <- err
+			return
+		}
+		accepted <- conn.(*net.TCPConn)
+	}()
+	dialed, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case conn := <-accepted:
+		return dialed.(*net.TCPConn), conn
+	case err := <-acceptErr:
+		dialed.Close()
+		t.Fatal(err)
+	case <-time.After(5 * time.Second):
+		dialed.Close()
+		t.Fatal("timed out accepting TCP test connection")
+	}
+	return nil, nil
+}
+
+func readConnectResponse(t *testing.T, conn net.Conn) {
+	t.Helper()
+	var header [3]byte
+	if _, err := io.ReadFull(conn, header[:]); err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	if header != [3]byte{socks5Version, byte(success), 0} {
+		t.Fatalf("CONNECT response = %x, want 050000", header)
+	}
+	if _, err := parseSocksAddr(conn); err != nil {
+		t.Fatalf("parse CONNECT bind address: %v", err)
+	}
+}
+
+func dialSOCKSTCP(t *testing.T, socksServer string, target netip.AddrPort) *net.TCPConn {
+	t.Helper()
+	connRaw, err := net.Dial("tcp", socksServer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn := connRaw.(*net.TCPConn)
+	if err := conn.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		conn.Close()
+		t.Fatal(err)
+	}
+	if _, err := conn.Write([]byte{socks5Version, 1, noAuthRequired}); err != nil {
+		conn.Close()
+		t.Fatal(err)
+	}
+	var greeting [2]byte
+	if _, err := io.ReadFull(conn, greeting[:]); err != nil {
+		conn.Close()
+		t.Fatal(err)
+	}
+	if greeting != [2]byte{socks5Version, noAuthRequired} {
+		conn.Close()
+		t.Fatalf("greeting = %x, want 0500", greeting)
+	}
+	targetAddr := socksAddr{addrType: ipv4, addr: target.Addr().String(), port: uint16(target.Port())}
+	targetBytes, err := targetAddr.marshal()
+	if err != nil {
+		conn.Close()
+		t.Fatal(err)
+	}
+	if _, err := conn.Write(append([]byte{socks5Version, byte(connect), 0}, targetBytes...)); err != nil {
+		conn.Close()
+		t.Fatal(err)
+	}
+	readConnectResponse(t, conn)
+	return conn
+}
+
+func TestTCPHalfCloseReturnsCompleteResponse(t *testing.T) {
+	const (
+		requestSize  = 8 << 20
+		responseSize = 1 << 20
+	)
+	request := bytes.Repeat([]byte("socks5-request-"), requestSize/len("socks5-request-")+1)[:requestSize]
+	response := bytes.Repeat([]byte("socks5-response-"), responseSize/len("socks5-response-")+1)[:responseSize]
+	wantRequestDigest := sha256.Sum256(request)
+	wantResponseDigest := sha256.Sum256(response)
+
+	backendListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { backendListener.Close() })
+
+	type backendResult struct {
+		bytes  int
+		digest [sha256.Size]byte
+		err    error
+	}
+	backendEOF := make(chan backendResult, 1)
+	backendDone := make(chan error, 1)
+	go func() {
+		conn, err := backendListener.Accept()
+		if err != nil {
+			backendDone <- err
+			return
+		}
+		defer conn.Close()
+		got, err := io.ReadAll(conn)
+		backendEOF <- backendResult{bytes: len(got), digest: sha256.Sum256(got), err: err}
+		if err == nil {
+			_, err = conn.Write(response)
+		}
+		if err == nil {
+			err = conn.(*net.TCPConn).CloseWrite()
+		}
+		backendDone <- err
+	}()
+
+	socksListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { socksListener.Close() })
+	server := &Server{Logf: t.Logf}
+	go server.Serve(socksListener)
+
+	clientRaw, err := net.Dial("tcp", socksListener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := clientRaw.(*net.TCPConn)
+	defer client.Close()
+	if err := client.SetDeadline(time.Now().Add(20 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Write([]byte{socks5Version, 1, noAuthRequired}); err != nil {
+		t.Fatal(err)
+	}
+	var greeting [2]byte
+	if _, err := io.ReadFull(client, greeting[:]); err != nil {
+		t.Fatal(err)
+	}
+	if greeting != [2]byte{socks5Version, noAuthRequired} {
+		t.Fatalf("greeting = %x, want 0500", greeting)
+	}
+	backendAddr := backendListener.Addr().(*net.TCPAddr).AddrPort()
+	target := socksAddr{addrType: ipv4, addr: backendAddr.Addr().String(), port: uint16(backendAddr.Port())}
+	targetBytes, err := target.marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Write(append([]byte{socks5Version, byte(connect), 0}, targetBytes...)); err != nil {
+		t.Fatal(err)
+	}
+	var responseHeader [3]byte
+	if _, err := io.ReadFull(client, responseHeader[:]); err != nil {
+		t.Fatal(err)
+	}
+	if responseHeader != [3]byte{socks5Version, byte(success), 0} {
+		t.Fatalf("CONNECT response = %x, want 050000", responseHeader)
+	}
+	if _, err := parseSocksAddr(client); err != nil {
+		t.Fatalf("parse CONNECT bind address: %v", err)
+	}
+
+	if _, err := client.Write(request); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.CloseWrite(); err != nil {
+		t.Fatal(err)
+	}
+	gotBackend := <-backendEOF
+	if gotBackend.err != nil {
+		t.Fatalf("backend read: %v", gotBackend.err)
+	}
+	if gotBackend.bytes != requestSize || gotBackend.digest != wantRequestDigest {
+		t.Fatalf("backend request = %d bytes/%x, want %d bytes/%x", gotBackend.bytes, gotBackend.digest, requestSize, wantRequestDigest)
+	}
+	gotResponse, err := io.ReadAll(client)
+	if err != nil {
+		t.Fatalf("client read response and final EOF: %v", err)
+	}
+	if len(gotResponse) != responseSize || sha256.Sum256(gotResponse) != wantResponseDigest {
+		t.Fatalf("client response = %d bytes/%x, want %d bytes/%x", len(gotResponse), sha256.Sum256(gotResponse), responseSize, wantResponseDigest)
+	}
+	if err := <-backendDone; err != nil {
+		t.Fatalf("backend response: %v", err)
+	}
+}
+
+func TestTCPPumpFailureClosesBothAndWaits(t *testing.T) {
+	errCopy := errors.New("injected copy error")
+	errCloseWrite := errors.New("injected CloseWrite error")
+	tests := []struct {
+		name               string
+		clientUnsupported  bool
+		backendUnsupported bool
+		clientReadErr      error
+		backendReadErr     error
+		clientCloseWrite   error
+		backendCloseWrite  error
+		clientEOF          bool
+		backendEOF         bool
+		want               error
+	}{
+		{name: "client CloseWrite unsupported", clientUnsupported: true, backendEOF: true, want: errors.ErrUnsupported},
+		{name: "backend CloseWrite unsupported", backendUnsupported: true, clientEOF: true, want: errors.ErrUnsupported},
+		{name: "client copy error", clientReadErr: errCopy, want: errCopy},
+		{name: "backend copy error", backendReadErr: errCopy, want: errCopy},
+		{name: "client CloseWrite error", clientCloseWrite: errCloseWrite, backendEOF: true, want: errCloseWrite},
+		{name: "backend CloseWrite error", backendCloseWrite: errCloseWrite, clientEOF: true, want: errCloseWrite},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientPeer, clientRaw := tcpConnPair(t)
+			backendRaw, backendPeer := tcpConnPair(t)
+			defer clientPeer.Close()
+			defer backendPeer.Close()
+
+			clientTrack := newTrackedTCPConn(clientRaw)
+			backendTrack := newTrackedTCPConn(backendRaw)
+			readGate := make(chan struct{})
+			clientTrack.readErr, clientTrack.readGate = tt.clientReadErr, readGate
+			backendTrack.readErr, backendTrack.readGate = tt.backendReadErr, readGate
+
+			var clientConn net.Conn = &closeWriteTCPConn{trackedTCPConn: clientTrack, closeWriteErr: tt.clientCloseWrite}
+			if tt.clientUnsupported {
+				clientConn = clientTrack
+			}
+			var backendConn net.Conn = &closeWriteTCPConn{trackedTCPConn: backendTrack, closeWriteErr: tt.backendCloseWrite}
+			if tt.backendUnsupported {
+				backendConn = backendTrack
+			}
+
+			conn := &Conn{
+				clientConn: clientConn,
+				request:    &request{destination: socksAddr{addrType: ipv4, addr: "127.0.0.1", port: 1}},
+				srv: &Server{Dialer: func(context.Context, string, string) (net.Conn, error) {
+					return backendConn, nil
+				}},
+			}
+			done := make(chan error, 1)
+			go func() { done <- conn.handleTCP() }()
+			readConnectResponse(t, clientPeer)
+
+			if tt.clientReadErr != nil || tt.backendReadErr != nil {
+				close(readGate)
+			}
+			if tt.clientEOF {
+				if err := clientPeer.CloseWrite(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tt.backendEOF {
+				if err := backendPeer.CloseWrite(); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			select {
+			case err := <-done:
+				if !errors.Is(err, tt.want) {
+					t.Fatalf("handleTCP error = %v, want %v", err, tt.want)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("handleTCP did not unblock and wait for both pumps")
+			}
+			for name, closed := range map[string]<-chan struct{}{
+				"client":  clientTrack.closed,
+				"backend": backendTrack.closed,
+			} {
+				select {
+				case <-closed:
+				default:
+					t.Errorf("%s connection was not fully closed", name)
+				}
+			}
+		})
+	}
+}
+
+func TestTCPConnectResponseWriteFailureClosesBeforePumps(t *testing.T) {
+	errWrite := errors.New("injected CONNECT response write error")
+	clientPeer, clientRaw := tcpConnPair(t)
+	backendRaw, backendPeer := tcpConnPair(t)
+	defer clientPeer.Close()
+	defer backendPeer.Close()
+	clientTrack := newTrackedTCPConn(clientRaw)
+	backendTrack := newTrackedTCPConn(backendRaw)
+	conn := &Conn{
+		clientConn: &writeErrorTCPConn{trackedTCPConn: clientTrack, writeErr: errWrite},
+		request:    &request{destination: socksAddr{addrType: ipv4, addr: "127.0.0.1", port: 1}},
+		srv: &Server{Dialer: func(context.Context, string, string) (net.Conn, error) {
+			return &closeWriteTCPConn{trackedTCPConn: backendTrack}, nil
+		}},
+	}
+	if err := conn.handleTCP(); !errors.Is(err, errWrite) {
+		t.Fatalf("handleTCP error = %v, want %v", err, errWrite)
+	}
+	for name, tracked := range map[string]*trackedTCPConn{"client": clientTrack, "backend": backendTrack} {
+		select {
+		case <-tracked.closed:
+		default:
+			t.Errorf("%s connection was not fully closed", name)
+		}
+		select {
+		case <-tracked.readStarted:
+			t.Errorf("%s pump started before CONNECT response succeeded", name)
+		default:
+		}
+	}
+}
+
+func TestTCPResetIsConnectionLocal(t *testing.T) {
+	backendListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer backendListener.Close()
+	backendAddr := backendListener.Addr().(*net.TCPAddr).AddrPort()
+	seen := map[byte]chan struct{}{
+		'B': make(chan struct{}),
+		'S': make(chan struct{}),
+		'N': make(chan struct{}),
+	}
+	brokenClosed := make(chan struct{})
+	go func() {
+		for {
+			conn, err := backendListener.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				var id [1]byte
+				if _, err := io.ReadFull(conn, id[:]); err != nil {
+					return
+				}
+				if event := seen[id[0]]; event != nil {
+					close(event)
+				}
+				if id[0] == 'B' {
+					io.Copy(io.Discard, conn)
+					close(brokenClosed)
+					return
+				}
+				if _, err := conn.Write(id[:]); err != nil {
+					return
+				}
+				io.Copy(conn, conn)
+			}()
+		}
+	}()
+
+	socksListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer socksListener.Close()
+	server := &Server{Logf: func(string, ...any) {}}
+	go server.Serve(socksListener)
+
+	sibling := dialSOCKSTCP(t, socksListener.Addr().String(), backendAddr)
+	defer sibling.Close()
+	if _, err := sibling.Write([]byte{'S'}); err != nil {
+		t.Fatal(err)
+	}
+	<-seen['S']
+	var got [1]byte
+	if _, err := io.ReadFull(sibling, got[:]); err != nil || got[0] != 'S' {
+		t.Fatalf("initial sibling echo = %q, %v", got, err)
+	}
+
+	broken := dialSOCKSTCP(t, socksListener.Addr().String(), backendAddr)
+	if _, err := broken.Write([]byte{'B'}); err != nil {
+		t.Fatal(err)
+	}
+	<-seen['B']
+	if err := broken.SetLinger(0); err != nil {
+		t.Fatal(err)
+	}
+	if err := broken.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-brokenClosed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("reset connection was not reaped")
+	}
+
+	if _, err := sibling.Write([]byte{'X'}); err != nil {
+		t.Fatalf("sibling write after reset: %v", err)
+	}
+	if _, err := io.ReadFull(sibling, got[:]); err != nil || got[0] != 'X' {
+		t.Fatalf("sibling echo after reset = %q, %v", got, err)
+	}
+
+	next := dialSOCKSTCP(t, socksListener.Addr().String(), backendAddr)
+	defer next.Close()
+	if _, err := next.Write([]byte{'N'}); err != nil {
+		t.Fatal(err)
+	}
+	<-seen['N']
+	if _, err := io.ReadFull(next, got[:]); err != nil || got[0] != 'N' {
+		t.Fatalf("subsequent connection echo = %q, %v", got, err)
+	}
+}
 
 func socks5Server(listener net.Listener) {
 	var server Server


### PR DESCRIPTION
## Summary

Preserve TCP half-close semantics in the SOCKS5 CONNECT proxy. A clean EOF in either copy direction now closes only the destination write half and waits for the reverse direction, while copy or `CloseWrite` failures fully close both connections to unblock and reap both pumps.

This is independent of #20881, which addresses the Serve/SystemDial forwarding path. Together, the two paths can preserve an end-to-end request half-close and delayed reverse response, but neither PR depends on the other at the package level.

Fixes #20883.

## Tests

- real-TCP SOCKS5 request: exact 8 MiB, client `CloseWrite`, backend EOF gate, exact 1 MiB response, client final EOF
- unsupported `CloseWrite` on each destination
- copy and `CloseWrite` errors in each direction
- CONNECT response write failure before pump startup
- reset isolation, live sibling, and subsequent connection
- `go test ./net/socks5 -count=3`
- focused `go test -race ... -count=3`
- `go vet ./net/socks5`