### PR TITLE
net/dns: preserve Docker DNS for single-label names

### DIFF
--- a/net/dns/manager.go
+++ b/net/dns/manager.go
@@ -357,6 +357,9 @@ func (m *Manager) compileConfig(cfg Config) (rcfg resolver.Config, ocfg OSConfig
 		rcfg.Routes = routes
 		rcfg.Routes["."] = cfg.DefaultResolvers
 		ocfg.Nameservers = cfg.serviceIPs(m.knobs)
+		// Preserve Docker's 127.0.0.11 for single-label names without
+		// replacing DefaultResolvers. See issue #15401.
+		m.setSingleLabelResolversFromBase(&rcfg)
 		return rcfg, ocfg, nil
 	}
 
@@ -476,6 +479,26 @@ func (m *Manager) compileConfig(cfg Config) (rcfg resolver.Config, ocfg OSConfig
 	}
 
 	return rcfg, ocfg, nil
+}
+
+// dockerEmbeddedDNS is Docker's embedded DNS on user-defined networks.
+// It resolves container/Compose names; other queries go to ExtServers.
+var dockerEmbeddedDNS = netip.AddrFrom4([4]byte{127, 0, 0, 11})
+
+// setSingleLabelResolversFromBase sets SingleLabelResolvers when the
+// pre-Tailscale base config includes 127.0.0.11. GetBaseConfig errors are
+// ignored; this is best-effort and must not fail DNS configuration.
+func (m *Manager) setSingleLabelResolversFromBase(rcfg *resolver.Config) {
+	base, err := m.os.GetBaseConfig()
+	if err != nil {
+		return
+	}
+	for _, ip := range base.Nameservers {
+		if ip == dockerEmbeddedDNS {
+			rcfg.SingleLabelResolvers = []*dnstype.Resolver{{Addr: ip.String()}}
+			return
+		}
+	}
 }
 
 func (m *Manager) disableSplitDNSOptimization() bool {

--- a/net/dns/manager_test.go
+++ b/net/dns/manager_test.go
@@ -344,6 +344,85 @@ func TestManager(t *testing.T) {
 			},
 		},
 		{
+			// With DefaultResolvers and base 127.0.0.11, keep DefaultResolvers
+			// as Routes["."] and expose 127.0.0.11 only via SingleLabelResolvers.
+			// Issue #15401.
+			name: "corp-magic-docker-single-label",
+			in: Config{
+				DefaultResolvers: mustRes("1.1.1.1", "9.9.9.9"),
+				SearchDomains:    fqdns("tailscale.com", "universe.tf"),
+				Routes:           upstreams("ts.com", ""),
+				Hosts: hosts(
+					"dave.ts.com.", "1.2.3.4",
+					"bradfitz.ts.com.", "2.3.4.5"),
+			},
+			bs: OSConfig{
+				Nameservers: mustIPs("127.0.0.11"),
+			},
+			os: OSConfig{
+				Nameservers:   serviceAddr46,
+				SearchDomains: fqdns("tailscale.com", "universe.tf"),
+			},
+			rs: resolver.Config{
+				Routes: upstreams(".", "1.1.1.1", "9.9.9.9"),
+				Hosts: hosts(
+					"dave.ts.com.", "1.2.3.4",
+					"bradfitz.ts.com.", "2.3.4.5"),
+				LocalDomains:         fqdns("ts.com."),
+				SingleLabelResolvers: mustRes("127.0.0.11"),
+			},
+		},
+		{
+			// Base nameserver other than 127.0.0.11 must not set SingleLabelResolvers.
+			name: "corp-magic-non-docker-base",
+			in: Config{
+				DefaultResolvers: mustRes("1.1.1.1", "9.9.9.9"),
+				SearchDomains:    fqdns("tailscale.com", "universe.tf"),
+				Routes:           upstreams("ts.com", ""),
+				Hosts: hosts(
+					"dave.ts.com.", "1.2.3.4",
+					"bradfitz.ts.com.", "2.3.4.5"),
+			},
+			bs: OSConfig{
+				Nameservers: mustIPs("8.8.8.8"),
+			},
+			os: OSConfig{
+				Nameservers:   serviceAddr46,
+				SearchDomains: fqdns("tailscale.com", "universe.tf"),
+			},
+			rs: resolver.Config{
+				Routes: upstreams(".", "1.1.1.1", "9.9.9.9"),
+				Hosts: hosts(
+					"dave.ts.com.", "1.2.3.4",
+					"bradfitz.ts.com.", "2.3.4.5"),
+				LocalDomains: fqdns("ts.com."),
+			},
+		},
+		{
+			// No DefaultResolvers: 127.0.0.11 is blended into Routes["."] as
+			// before; SingleLabelResolvers stays unset.
+			name: "magic-only-docker-base-no-global",
+			in: Config{
+				SearchDomains: fqdns("tailscale.com"),
+				Routes:        upstreams("ts.com", ""),
+				Hosts: hosts(
+					"dave.ts.com.", "1.2.3.4"),
+			},
+			bs: OSConfig{
+				Nameservers: mustIPs("127.0.0.11"),
+			},
+			os: OSConfig{
+				Nameservers:   serviceAddr46,
+				SearchDomains: fqdns("tailscale.com"),
+			},
+			rs: resolver.Config{
+				Routes: upstreams(".", "127.0.0.11"),
+				Hosts: hosts(
+					"dave.ts.com.", "1.2.3.4"),
+				LocalDomains: fqdns("ts.com."),
+			},
+		},
+		{
 			name: "corp-magic-split",
 			in: Config{
 				DefaultResolvers: mustRes("1.1.1.1", "9.9.9.9"),

--- a/net/dns/resolver/forwarder.go
+++ b/net/dns/resolver/forwarder.go
@@ -345,6 +345,10 @@ type forwarder struct {
 	// queries directly - but we didn't configure it with any upstream resolvers.
 	// That's an error, but not a health error if the user has disabled CorpDNS.
 	acceptDNS bool
+
+	// singleLabelResolvers are used for single-label queries when set.
+	// See [Config.SingleLabelResolvers].
+	singleLabelResolvers []resolverAndDelay
 }
 
 func (f *forwarder) probeLocks() {
@@ -461,7 +465,9 @@ func cloudResolvers() []resolverAndDelay {
 // Resolver.SetConfig on reconfig.
 //
 // The memory referenced by routesBySuffix should not be modified.
-func (f *forwarder) setRoutes(routesBySuffix map[dnsname.FQDN][]*dnstype.Resolver, acceptDNS bool) {
+// singleLabel, if non-empty, is used for single-label queries; see
+// [Config.SingleLabelResolvers].
+func (f *forwarder) setRoutes(routesBySuffix map[dnsname.FQDN][]*dnstype.Resolver, acceptDNS bool, singleLabel []*dnstype.Resolver) {
 	routes := make([]route, 0, len(routesBySuffix))
 
 	cloudHostFallback := cloudResolvers()
@@ -498,6 +504,7 @@ func (f *forwarder) setRoutes(routesBySuffix map[dnsname.FQDN][]*dnstype.Resolve
 	f.acceptDNS = acceptDNS
 	f.routes = routes
 	f.cloudHostFallback = cloudHostFallback
+	f.singleLabelResolvers = resolversWithDelays(singleLabel)
 }
 
 var stdNetPacketListener nettype.PacketListenerWithNetIP = nettype.MakePacketListenerWithNetIP(new(net.ListenConfig))
@@ -1101,10 +1108,16 @@ func applySchemes(logf logger.Logf, rrs []resolverAndDelay, schemes views.Map[st
 }
 
 // resolvers returns the resolvers to use for domain.
-func (f *forwarder) resolvers(domain dnsname.FQDN) []resolverAndDelay {
+//
+// Routes are tried most-specific first; a matching non-"." route wins.
+// At the "." route, if allowSingleLabel is set, single-label names may use
+// SingleLabelResolvers instead of the default resolvers. Peer/Exit DNS
+// passes allowSingleLabel=false.
+func (f *forwarder) resolvers(domain dnsname.FQDN, allowSingleLabel bool) []resolverAndDelay {
 	f.mu.Lock()
 	routes := f.routes
 	cloudHostFallback := f.cloudHostFallback
+	singleLabel := f.singleLabelResolvers
 	schemes := f.schemeCacheLocked()
 	f.mu.Unlock()
 
@@ -1112,10 +1125,24 @@ func (f *forwarder) resolvers(domain dnsname.FQDN) []resolverAndDelay {
 		if route.Suffix != "." && !route.Suffix.Contains(domain) {
 			continue
 		}
+
+		if route.Suffix != "." {
+			resolved := applySchemes(f.logf, route.Resolvers, schemes)
+			// If scheme resolution filtered out all resolvers from a non-empty
+			// route, fall through to the next matching route. If the resolvers
+			// were configured to be empty allow resolved to be empty.
+			if len(resolved) > 0 || len(route.Resolvers) == 0 {
+				return resolved
+			}
+			continue
+		}
+
+		// Catch-all "." route: prefer SingleLabelResolvers for local
+		// single-label queries so DefaultResolvers are not used for those.
+		if allowSingleLabel && domain.NumLabels() == 1 && len(singleLabel) > 0 {
+			return applySchemes(f.logf, singleLabel, schemes)
+		}
 		resolved := applySchemes(f.logf, route.Resolvers, schemes)
-		// If scheme resolution filtered out all resolvers from a non-empty
-		// route, fall through to the next matching route. If the resolvers
-		// were configured to be empty allow resolved to be empty.
 		if len(resolved) > 0 || len(route.Resolvers) == 0 {
 			return resolved
 		}
@@ -1123,10 +1150,9 @@ func (f *forwarder) resolvers(domain dnsname.FQDN) []resolverAndDelay {
 	return cloudHostFallback // or nil if no fallback
 }
 
-// GetUpstreamResolvers returns the resolvers that would be used to resolve
-// the given FQDN.
+// GetUpstreamResolvers returns the resolvers used for a local query for name.
 func (f *forwarder) GetUpstreamResolvers(name dnsname.FQDN) []*dnstype.Resolver {
-	resolvers := f.resolvers(name)
+	resolvers := f.resolvers(name, true)
 	upstreamResolvers := make([]*dnstype.Resolver, 0, len(resolvers))
 	for _, r := range resolvers {
 		upstreamResolvers = append(upstreamResolvers, r.name)
@@ -1200,8 +1226,10 @@ type forwardQuery struct {
 // non-nil error (without sending to the channel).
 //
 // If resolvers is non-empty, it's used explicitly (notably, for exit
-// node DNS proxy queries), otherwise f.resolvers is used.
-func (f *forwarder) forwardWithDestChan(ctx context.Context, query packet, responseChan chan<- packet, resolvers ...resolverAndDelay) error {
+// node DNS proxy queries that already chose an upstream). Otherwise
+// f.resolvers is used. allowSingleLabel enables SingleLabelResolvers for
+// local queries; peer/Exit DNS must pass false.
+func (f *forwarder) forwardWithDestChan(ctx context.Context, query packet, responseChan chan<- packet, allowSingleLabel bool, resolvers ...resolverAndDelay) error {
 	metricDNSFwd.Add(1)
 	domain, typ, err := nameFromQuery(query.bs)
 	if err != nil {
@@ -1238,7 +1266,7 @@ func (f *forwarder) forwardWithDestChan(ctx context.Context, query packet, respo
 	clampEDNSSize(query.bs, maxResponseBytes)
 
 	if len(resolvers) == 0 {
-		resolvers = f.resolvers(domain)
+		resolvers = f.resolvers(domain, allowSingleLabel)
 		if len(resolvers) == 0 {
 			// No upstream resolver for this name isn't a forwarder failure:
 			// it's split DNS / a name we weren't asked to handle. Count it

--- a/net/dns/resolver/forwarder_test.go
+++ b/net/dns/resolver/forwarder_test.go
@@ -596,7 +596,7 @@ func runTestQueryWithFamily(tb testing.TB, request []byte, family string, modify
 	rchan := make(chan packet, 1)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	tb.Cleanup(cancel)
-	err = fwd.forwardWithDestChan(ctx, rpkt, rchan, resolvers...)
+	err = fwd.forwardWithDestChan(ctx, rpkt, rchan, true, resolvers...)
 	select {
 	case res := <-rchan:
 		return res.bs, err
@@ -1272,7 +1272,7 @@ func TestForwarderNetstackUpstream(t *testing.T) {
 			defer cancel()
 
 			start := time.Now()
-			err = fwd.forwardWithDestChan(ctx, rpkt, rchan,
+			err = fwd.forwardWithDestChan(ctx, rpkt, rchan, true,
 				resolverAndDelay{name: &dnstype.Resolver{Addr: netstackUpstream.String()}})
 			if err != nil {
 				t.Fatalf("forwardWithDestChan: %v", err)
@@ -1364,7 +1364,7 @@ func TestForwarderNetstackUpstreamTruncated(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	if err := fwd.forwardWithDestChan(ctx, rpkt, rchan,
+	if err := fwd.forwardWithDestChan(ctx, rpkt, rchan, true,
 		resolverAndDelay{name: &dnstype.Resolver{Addr: netstackUpstream.String()}}); err != nil {
 		t.Fatalf("forwardWithDestChan: %v", err)
 	}
@@ -1776,7 +1776,7 @@ func TestForwarderHealthOnContextExpiry(t *testing.T) {
 				cancel()
 			}()
 
-			fwd.forwardWithDestChan(ctx, rpkt, responseChan, resolvers...)
+			fwd.forwardWithDestChan(ctx, rpkt, responseChan, true, resolvers...)
 
 			if got := ht.IsUnhealthy(dnsForwarderFailing); got != tt.wantUnhealthy {
 				t.Errorf("IsUnhealthy = %v, want %v", got, tt.wantUnhealthy)
@@ -1820,7 +1820,7 @@ func TestForwarderHealthNoUpstreamResolvers(t *testing.T) {
 			// Buffered so the SERVFAIL response can be sent without a reader.
 			responseChan := make(chan packet, 1)
 
-			if err := fwd.forwardWithDestChan(context.Background(), rpkt, responseChan); err != nil {
+			if err := fwd.forwardWithDestChan(context.Background(), rpkt, responseChan, true); err != nil {
 				t.Fatalf("forwardWithDestChan: %v", err)
 			}
 
@@ -1956,9 +1956,117 @@ func TestResolversCustomScheme(t *testing.T) {
 				}
 			}
 
-			fwd.setRoutes(tt.routes, false)
+			fwd.setRoutes(tt.routes, false, nil)
 
-			got := fwd.resolvers(tt.domain)
+			got := fwd.resolvers(tt.domain, true)
+			var gotAddrs []string
+			for _, r := range got {
+				gotAddrs = append(gotAddrs, r.name.Addr)
+			}
+			if !slices.Equal(gotAddrs, tt.wantAddrs) {
+				t.Errorf("got %v, want %v", gotAddrs, tt.wantAddrs)
+			}
+		})
+	}
+}
+
+// TestResolversSingleLabel covers SingleLabelResolvers selection for issue #15401.
+func TestResolversSingleLabel(t *testing.T) {
+	t.Parallel()
+	docker := []*dnstype.Resolver{{Addr: "127.0.0.11"}}
+	// Use documentation IPs so resolversWithDelays does not upgrade them to DoH.
+	defaultRes := []*dnstype.Resolver{{Addr: "192.0.2.1"}}
+	splitRes := []*dnstype.Resolver{{Addr: "198.51.100.1"}}
+	specificRes := []*dnstype.Resolver{{Addr: "203.0.113.1"}}
+
+	tests := []struct {
+		name             string
+		domain           dnsname.FQDN
+		routes           map[dnsname.FQDN][]*dnstype.Resolver
+		singleLabel      []*dnstype.Resolver
+		allowSingleLabel bool
+		wantAddrs        []string
+	}{
+		{
+			name:             "local-single-label-with-docker",
+			domain:           "database.",
+			routes:           map[dnsname.FQDN][]*dnstype.Resolver{".": defaultRes},
+			singleLabel:      docker,
+			allowSingleLabel: true,
+			wantAddrs:        []string{"127.0.0.11"},
+		},
+		{
+			name:             "peer-single-label-skips-docker",
+			domain:           "database.",
+			routes:           map[dnsname.FQDN][]*dnstype.Resolver{".": defaultRes},
+			singleLabel:      docker,
+			allowSingleLabel: false,
+			wantAddrs:        []string{"192.0.2.1"},
+		},
+		{
+			name:   "specific-single-label-route-beats-docker",
+			domain: "database.",
+			routes: map[dnsname.FQDN][]*dnstype.Resolver{
+				"database.": specificRes,
+				".":         defaultRes,
+			},
+			singleLabel:      docker,
+			allowSingleLabel: true,
+			wantAddrs:        []string{"203.0.113.1"},
+		},
+		{
+			name:             "multi-label-uses-default",
+			domain:           "example.com.",
+			routes:           map[dnsname.FQDN][]*dnstype.Resolver{".": defaultRes},
+			singleLabel:      docker,
+			allowSingleLabel: true,
+			wantAddrs:        []string{"192.0.2.1"},
+		},
+		{
+			name:   "split-dns-multi-label",
+			domain: "internal.example.com.",
+			routes: map[dnsname.FQDN][]*dnstype.Resolver{
+				".":                     defaultRes,
+				"internal.example.com.": splitRes,
+			},
+			singleLabel:      docker,
+			allowSingleLabel: true,
+			wantAddrs:        []string{"198.51.100.1"},
+		},
+		{
+			name:             "single-label-without-docker-uses-default",
+			domain:           "database.",
+			routes:           map[dnsname.FQDN][]*dnstype.Resolver{".": defaultRes},
+			singleLabel:      nil,
+			allowSingleLabel: true,
+			wantAddrs:        []string{"192.0.2.1"},
+		},
+		{
+			name:             "two-label-not-treated-as-docker",
+			domain:           "database.proxy.",
+			routes:           map[dnsname.FQDN][]*dnstype.Resolver{".": defaultRes},
+			singleLabel:      docker,
+			allowSingleLabel: true,
+			wantAddrs:        []string{"192.0.2.1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logf := tstest.WhileTestRunningLogger(t)
+			bus := eventbustest.NewBus(t)
+			netMon, err := netmon.New(bus, logf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var dialer tsdial.Dialer
+			dialer.SetNetMon(netMon)
+			dialer.SetBus(bus)
+
+			fwd := newForwarder(logf, netMon, nil, &dialer, health.NewTracker(bus), nil)
+			fwd.setRoutes(tt.routes, true, tt.singleLabel)
+
+			got := fwd.resolvers(tt.domain, tt.allowSingleLabel)
 			var gotAddrs []string
 			for _, r := range got {
 				gotAddrs = append(gotAddrs, r.name.Addr)

--- a/net/dns/resolver/tsdns.go
+++ b/net/dns/resolver/tsdns.go
@@ -107,6 +107,10 @@ type Config struct {
 	// "node.tailnet.ts.net" is in SubdomainHosts, the query resolves
 	// to the IPs for "node.tailnet.ts.net".
 	SubdomainHosts set.Set[dnsname.FQDN]
+	// SingleLabelResolvers, if non-empty, are used for single-label queries
+	// that miss MagicDNS/Hosts and do not match a more-specific non-"."
+	// route. Applied only for local queries, not peer/Exit DNS.
+	SingleLabelResolvers []*dnstype.Resolver
 }
 
 // WriteToBufioWriter write a debug version of c for logs to w, omitting
@@ -131,6 +135,10 @@ func (c *Config) WriteToBufioWriter(w *bufio.Writer) {
 	w.WriteString("]")
 	if arpa > 0 {
 		fmt.Fprintf(w, "+%darpa", arpa)
+	}
+	if len(c.SingleLabelResolvers) > 0 {
+		w.WriteString(" SingleLabelResolvers:")
+		WriteDNSResolvers(w, c.SingleLabelResolvers)
 	}
 	if c := cloudenv.Get(); c != "" {
 		fmt.Fprintf(w, ", cloud=%q", string(c))
@@ -360,7 +368,7 @@ func (r *Resolver) SetConfig(cfg Config) error {
 		}
 	}
 
-	r.forwarder.setRoutes(cfg.Routes, cfg.AcceptDNS)
+	r.forwarder.setRoutes(cfg.Routes, cfg.AcceptDNS, cfg.SingleLabelResolvers)
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -423,7 +431,7 @@ func (r *Resolver) Query(ctx context.Context, bs []byte, family string, from net
 		ctx, cancel := context.WithTimeout(ctx, dnsQueryTimeout)
 		defer close(responses)
 		defer cancel()
-		err = r.forwarder.forwardWithDestChan(ctx, packet{bs, family, from}, responses)
+		err = r.forwarder.forwardWithDestChan(ctx, packet{bs, family, from}, responses, true)
 		if err != nil {
 			return nil, err
 		}
@@ -523,7 +531,8 @@ func (r *Resolver) HandlePeerDNSQuery(ctx context.Context, q []byte, from netip.
 			}}
 		}
 
-		err = r.forwarder.forwardWithDestChan(ctx, packet{q, "tcp", from}, ch, resolvers...)
+		// Exit/peer DNS must not use SingleLabelResolvers.
+		err = r.forwarder.forwardWithDestChan(ctx, packet{q, "tcp", from}, ch, false, resolvers...)
 		if err != nil {
 			metricDNSExitProxyErrorForward.Add(1)
 			return nil, err


### PR DESCRIPTION
## Summary

Preserve Docker's embedded DNS resolver for local single-label queries when
Tailscale is using configured default DNS resolvers.

When Docker's pre-Tailscale resolver is 127.0.0.11, accept-dns can replace the
container's resolver path with Tailscale DNS. With global/default resolvers
configured, Docker Compose service names can then be sent to those upstream
resolvers and return NXDOMAIN.

This keeps the configured DefaultResolvers as the normal catch-all while using
the Docker resolver only for eligible local single-label queries. More-specific
split DNS routes continue to take precedence, and peer/Exit DNS queries do not
use the special resolver.

Updates #15401

## Tests

- `./tool/go test ./net/dns -count=1 -timeout 180s`
- `./tool/go test ./net/dns/resolver -count=1 -timeout 180s`
- `./tool/go vet ./net/dns ./net/dns/resolver`