### PR TITLE
ipn/ipnlocal: sort app connector routes by full prefix

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -5982,7 +5982,7 @@ func (b *LocalBackend) reconfigAppConnectorLocked(selfNode tailcfg.NodeView, pre
 		}
 	}
 	slices.Sort(domains)
-	slices.SortFunc(routes, func(i, j netip.Prefix) int { return i.Addr().Compare(j.Addr()) })
+	slices.SortFunc(routes, netipx.ComparePrefix)
 	domains = slices.Compact(domains)
 	routes = slices.Compact(routes)
 	b.appConnector.UpdateDomainsAndRoutes(domains, routes)


### PR DESCRIPTION
## What is wrong

`reconfigAppConnectorLocked` collects routes from every matching `AppConnectorAttr`, sorts them, then dedups (`ipn/ipnlocal/local.go:5985`):

```go
slices.SortFunc(routes, func(i, j netip.Prefix) int { return i.Addr().Compare(j.Addr()) })
domains = slices.Compact(domains)
routes = slices.Compact(routes)
```

The comparator only looks at `Prefix.Addr`, but `slices.Compact` drops elements that compare `==`, which covers both the address and the mask length. Prefixes that share an address and differ in bits therefore compare equal to the sort and unequal to `Compact`, so they end up in arbitrary order relative to each other and a duplicate can land on the far side of one.

## Evidence

Against `cfe32b8be`, running the exact sort and Compact from that line:

```
in  [10.0.0.0/8 10.0.0.0/16 10.0.0.0/8]
  current [10.0.0.0/8 10.0.0.0/16 10.0.0.0/8]   <- duplicate /8 survives
  fixed   [10.0.0.0/8 10.0.0.0/16]

in  [10.0.0.0/16 10.0.0.0/8 10.0.0.0/8]
  current [10.0.0.0/16 10.0.0.0/8]
  fixed   [10.0.0.0/8 10.0.0.0/16]
```

The second line shows the other half of it: the result is not canonical. The same set of routes gathered in a different order produces a differently ordered slice.

```
same set, different input order:
  current: [10.0.0.0/8 10.0.0.0/16] vs [10.0.0.0/16 10.0.0.0/8] -> slices.Equal=false
  fixed:   [10.0.0.0/8 10.0.0.0/16] vs [10.0.0.0/8 10.0.0.0/16] -> slices.Equal=true
```

That matters because the slice goes straight to `AppConnector.UpdateDomainsAndRoutes`, and `updateRoutes` short-circuits on `slices.Equal(e.controlRoutes, routes)` (`appc/appconnector.go:354`). An unchanged route set that arrives in a different order reads as changed and falls through to the advertise/unadvertise pass.

## What this changes

Use `netipx.ComparePrefix`, which orders by address family, then mask length, then address, and returns 0 only for prefixes that are `==`. That makes the ordering total and consistent with the equality `Compact` uses, so the dedup is complete and the output is canonical.

It is also the comparator `applyPrefsToHostinfoLocked` already uses for the same job on `RoutableIPs` (`local.go:6643`, from #20759), and `netipx` is already imported here, so this is one line and no new dependency.

## Test

No new test. The behaviour lives behind a netmap capability map and `reconfigAppConnectorLocked` runs asynchronously when the netmap is non-nil, which the comment on `TestBackfillAppConnectorRoutes` already flags as a flakiness source, so a test there would be a lot of machinery around a comparator swap and a fair chance of a flaky test. I verified it by running the old and new sort plus `slices.Compact` over the inputs above, which is what the output in the Evidence section is.

Local: `./tool/go build ./...`, `./tool/go test ./ipn/ipnlocal ./appc`, `./tool/go vet ./ipn/ipnlocal`, `gofmt` clean.

Note: my other open PR (#20878) is sitting on `tailscale-policy-bot` pending maintainer approval, so the full CI matrix has not run on it yet and probably will not here either until someone kicks it. Not re-pushing to chase that.

---

sorry if I got any of this wrong, I worked out the comparator logic myself and used claude code as a sounding board on the reasoning. freshman in college, still learning this stuff, would genuinely like to know if I have misread how the route set gets used :)