### PR TITLE
cmd/k8s-operator: read deployment annotations from operatorConfig

### DIFF
--- a/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
+++ b/cmd/k8s-operator/deploy/chart/templates/deployment.yaml
@@ -6,8 +6,9 @@ kind: Deployment
 metadata:
   name: {{ include "tailscale-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
-  {{- if .Values.annotations }}
-  annotations: {{- toYaml .Values.annotations | nindent 4 }}
+  {{- with .Values.operatorConfig.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   replicas: 1


### PR DESCRIPTION
`values.yaml` defines the deployment annotations at `operatorConfig.annotations`, but `templates/deployment.yaml` reads `.Values.annotations`. Setting the documented value has no effect - the annotations are dropped without warning.

Introduced in 819f3ba7 (#17143). That commit's `values.yaml` hunk added the key under `operatorConfig`, while the template was written against the top level.

Verified against the released 1.102.2 chart:

```
helm template x tailscale-operator --set operatorConfig.annotations.foo=bar
```

Before this change the operator Deployment renders no `annotations`. After it, `foo: bar` appears. With nothing set, no empty `annotations` key is emitted.
