### PR TITLE
cmd/cigocacher: make token optional for --stats

### DIFF
--- a/cmd/cigocacher/cigocacher.go
+++ b/cmd/cigocacher/cigocacher.go
@@ -97,11 +97,7 @@ func main() {
 		if *srvURL == "" {
 			log.Fatal("--cigocached-url is empty; cannot fetch stats")
 		}
-		tk := *token
-		if tk == "" {
-			log.Fatal("--token is empty; cannot fetch stats")
-		}
-		stats, err := fetchStats(httpClient(srvHost, *srvHostDial), *srvURL, tk)
+		stats, err := fetchStats(httpClient(srvHost, *srvHostDial), *srvURL, *token)
 		if err != nil {
 			// Errors that are not due to misconfiguration are non-fatal so we
 			// don't fail builds if e.g. cigocached is down.
@@ -336,7 +332,9 @@ func fetchAccessToken(cl *http.Client, idTokenURL, idTokenRequestToken, gocached
 
 func fetchStats(cl *http.Client, baseURL, accessToken string) (string, error) {
 	req, _ := http.NewRequest("GET", baseURL+"/session/stats", nil)
-	req.Header.Set("Authorization", "Bearer "+accessToken)
+	if accessToken != "" {
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+	}
 	resp, err := cl.Do(req)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
In cases where cigocacher is using a proxy that handles the auth, it's possible to fetch stats without knowing our own access token. Don't fail early if the access token isn't passed. If there's no proxy, it will fail with the error from the gocached server.

Updates tailscale/corp#45427