### PR TITLE
feature/conn25: use traffic steering to select connector

### DIFF
--- a/feature/conn25/conn25.go
+++ b/feature/conn25/conn25.go
@@ -9,7 +9,6 @@ package conn25
 
 import (
 	"bytes"
-	"cmp"
 	"container/list"
 	"context"
 	"encoding/json"
@@ -35,6 +34,7 @@ import (
 	"tailscale.com/ipn/ipnlocal"
 	"tailscale.com/ipn/localapi"
 	"tailscale.com/net/packet"
+	"tailscale.com/net/traffic"
 	"tailscale.com/net/tsaddr"
 	"tailscale.com/net/tstun"
 	"tailscale.com/tailcfg"
@@ -1680,14 +1680,14 @@ func isPeerEligibleConnector(peer tailcfg.NodeView) bool {
 	return isConn
 }
 
-func sortByPreference(ns []tailcfg.NodeView) {
+func sortByPreference(self tailcfg.NodeView, ns []tailcfg.NodeView) {
 	// The ordering of the nodes is semantic (callers use the first node they can
-	// get a peer api url for). We don't (currently 2026-02-27) have any
-	// preference over which node is chosen as long as it's consistent.  In the
-	// future we anticipate integrating with traffic steering.
-	slices.SortFunc(ns, func(a, b tailcfg.NodeView) int {
-		return cmp.Compare(a.ID(), b.ID())
-	})
+	// get a peer api url for).
+	if !self.Valid() {
+		return
+	}
+	scores := traffic.ScoresFor(self.ID(), ns)
+	scores.SortNodes(ns)
 }
 
 // pickConnector returns peers the backend knows about that match the app, in order of preference to use as
@@ -1708,6 +1708,6 @@ func pickConnector(nb ipnext.NodeBackend, app appctype.Conn25Attr) []tailcfg.Nod
 		}
 		return false
 	})
-	sortByPreference(matches)
+	sortByPreference(nb.Self(), matches)
 	return matches
 }

--- a/feature/conn25/conn25_test.go
+++ b/feature/conn25/conn25_test.go
@@ -1579,6 +1579,7 @@ type testNodeBackend struct {
 	ipnext.NodeBackend
 	peers      []tailcfg.NodeView
 	peerAPIURL string // should be per peer but there's only one peer in our test so this is ok for now
+	self       tailcfg.NodeView
 }
 
 func (nb *testNodeBackend) AppendMatchingPeers(base []tailcfg.NodeView, pred func(tailcfg.NodeView) bool) []tailcfg.NodeView {
@@ -1596,6 +1597,10 @@ func (nb *testNodeBackend) PeerHasPeerAPI(p tailcfg.NodeView) bool {
 
 func (nb *testNodeBackend) PeerAPIBase(p tailcfg.NodeView) string {
 	return nb.peerAPIURL
+}
+
+func (nb *testNodeBackend) Self() tailcfg.NodeView {
+	return nb.self
 }
 
 type testProfileServices struct {
@@ -3256,25 +3261,33 @@ func TestPickConnector(t *testing.T) {
 
 	nvWithConnectorSet := func(id tailcfg.NodeID, isConnector bool, tags ...string) tailcfg.NodeView {
 		return (&tailcfg.Node{
-			ID:       id,
-			Tags:     tags,
-			Hostinfo: (&tailcfg.Hostinfo{AppConnector: opt.NewBool(isConnector)}).View(),
-			Online:   new(true),
+			ID:   id,
+			Tags: tags,
+			Hostinfo: (&tailcfg.Hostinfo{
+				AppConnector: opt.NewBool(isConnector),
+				Location:     &tailcfg.Location{Priority: 100000 - int(id)},
+			}).View(),
+			Online: new(true),
 		}).View()
 	}
 
 	nvWithOnlineSet := func(id tailcfg.NodeID, online bool, tags ...string) tailcfg.NodeView {
 		return (&tailcfg.Node{
-			ID:       id,
-			Tags:     tags,
-			Hostinfo: (&tailcfg.Hostinfo{AppConnector: opt.NewBool(true)}).View(),
-			Online:   new(online),
+			ID:   id,
+			Tags: tags,
+			Hostinfo: (&tailcfg.Hostinfo{
+				AppConnector: opt.NewBool(true),
+				Location:     &tailcfg.Location{Priority: 100000 - int(id)},
+			}).View(),
+			Online: new(online),
 		}).View()
 	}
 
 	nv := func(id tailcfg.NodeID, tags ...string) tailcfg.NodeView {
 		return nvWithConnectorSet(id, true, tags...)
 	}
+
+	self := (&tailcfg.Node{ID: 100}).View()
 
 	for _, tt := range []struct {
 		name       string
@@ -3391,7 +3404,7 @@ func TestPickConnector(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			got := pickConnector(&testNodeBackend{peers: tt.candidates}, tt.app)
+			got := pickConnector(&testNodeBackend{self: self, peers: tt.candidates}, tt.app)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Fatalf("PickConnectors (-want, +got):\n%s", diff)
 			}


### PR DESCRIPTION
Use whatever traffic steering's notion of the best connector for the
client is, rather than picking arbitrarily.

Fixes tailscale/corp#46766

Signed-off-by: Fran Bull <fran@tailscale.com>