### PR TITLE
k8s-operator: allow annotationless resources under proxy group policy

### DIFF
--- a/cmd/k8s-operator/e2e/proxygrouppolicy_test.go
+++ b/cmd/k8s-operator/e2e/proxygrouppolicy_test.go
@@ -146,6 +146,63 @@ func TestProxyGroupPolicy(t *testing.T) {
 		t.Fatal("expected error when creating ingress")
 	}
 
+	// Ordinary resources without annotations must remain admissible while the
+	// deny-all policy rejects unauthorized proxy-group annotations.
+	annotationlessService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "annotationless-service",
+			Namespace: pgPolicyNs.Name,
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{
+				{
+					Port:     80,
+					Protocol: corev1.ProtocolTCP,
+					Name:     "http",
+				},
+			},
+		},
+	}
+	createAndCleanup(t, kubeClient, annotationlessService)
+
+	annotationlessTSService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "annotationless-ts-service",
+			Namespace: pgPolicyNs.Name,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:              corev1.ServiceTypeLoadBalancer,
+			LoadBalancerClass: new("tailscale"),
+			Ports: []corev1.ServicePort{
+				{
+					Port:     80,
+					Protocol: corev1.ProtocolTCP,
+					Name:     "http",
+				},
+			},
+		},
+	}
+	createAndCleanup(t, kubeClient, annotationlessTSService)
+
+	annotationlessIngress := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "annotationless-ingress",
+			Namespace: pgPolicyNs.Name,
+		},
+		Spec: networkingv1.IngressSpec{
+			DefaultBackend: &networkingv1.IngressBackend{
+				Service: &networkingv1.IngressServiceBackend{
+					Name: "nginx",
+					Port: networkingv1.ServiceBackendPort{
+						Number: 80,
+					},
+				},
+			},
+		},
+	}
+	createAndCleanup(t, kubeClient, annotationlessIngress)
+
 	// Add policy to allow ingress/egress using the "test" proxy-group. This should be merged with the deny-all
 	// policy so they do not conflict.
 	allowTestPolicy := &tsapi.ProxyGroupPolicy{

--- a/k8s-operator/reconciler/proxygrouppolicy/proxygrouppolicy.go
+++ b/k8s-operator/reconciler/proxygrouppolicy/proxygrouppolicy.go
@@ -188,7 +188,7 @@ const (
 	// Empty allowlist behavior:
 	//   If the list is empty, any present annotation will fail membership,
 	//   effectively acting as "deny-all".
-	ingressCEL = `request.kind.kind != "Ingress" || !("tailscale.com/proxy-group" in object.metadata.annotations) || object.metadata.annotations["tailscale.com/proxy-group"] in [%s]`
+	ingressCEL = `request.kind.kind != "Ingress" || !has(object.metadata.annotations) || !("tailscale.com/proxy-group" in object.metadata.annotations) || object.metadata.annotations["tailscale.com/proxy-group"] in [%s]`
 
 	// ingressServiceCEL enforces proxy-group annotation rules for Services
 	// that are using the tailscale load balancer.
@@ -202,7 +202,7 @@ const (
 	//   - If annotation is present → must be in allowlist
 	//
 	// This makes ingress policy apply ONLY to tailscale Services.
-	ingressServiceCEL = `request.kind.kind != "Service" || !((has(object.spec.loadBalancerClass) && object.spec.loadBalancerClass == "tailscale") || ("tailscale.com/expose" in object.metadata.annotations && object.metadata.annotations["tailscale.com/expose"] == "true")) || (!("tailscale.com/proxy-group" in object.metadata.annotations) || object.metadata.annotations["tailscale.com/proxy-group"] in [%s])`
+	ingressServiceCEL = `request.kind.kind != "Service" || !((has(object.spec.loadBalancerClass) && object.spec.loadBalancerClass == "tailscale") || (has(object.metadata.annotations) && "tailscale.com/expose" in object.metadata.annotations && object.metadata.annotations["tailscale.com/expose"] == "true")) || (!has(object.metadata.annotations) || !("tailscale.com/proxy-group" in object.metadata.annotations) || object.metadata.annotations["tailscale.com/proxy-group"] in [%s])`
 	// egressCEL enforces proxy-group annotation rules for Services that
 	// are NOT using the tailscale load balancer.
 	//
@@ -220,7 +220,7 @@ const (
 	//
 	// This expression is mutually exclusive with ingressServiceCEL,
 	// preventing policy conflicts.
-	egressCEL = `((has(object.spec.loadBalancerClass) && object.spec.loadBalancerClass == "tailscale") || ("tailscale.com/expose" in object.metadata.annotations && object.metadata.annotations["tailscale.com/expose"] == "true")) || !("tailscale.com/proxy-group" in object.metadata.annotations) || object.metadata.annotations["tailscale.com/proxy-group"] in [%s]`
+	egressCEL = `((has(object.spec.loadBalancerClass) && object.spec.loadBalancerClass == "tailscale") || (has(object.metadata.annotations) && "tailscale.com/expose" in object.metadata.annotations && object.metadata.annotations["tailscale.com/expose"] == "true")) || !has(object.metadata.annotations) || !("tailscale.com/proxy-group" in object.metadata.annotations) || object.metadata.annotations["tailscale.com/proxy-group"] in [%s]`
 )
 
 func (r *Reconciler) generateIngressPolicy(ctx context.Context, namespace string, names set.Set[string]) (*admr.ValidatingAdmissionPolicy, error) {


### PR DESCRIPTION
## Problem

`ProxyGroupPolicy` generates validating admission policies that directly access the optional `metadata.annotations` map. For annotationless Services and Ingresses, the CEL expressions evaluate to an error; because the policies use `failurePolicy: Fail`, Kubernetes rejects otherwise ordinary create and update requests.

## Change

- Guard the annotations map before checking the expose and proxy-group annotations.
- Preserve deny-all and allowlist behavior when a proxy-group annotation is present.
- Cover annotationless ClusterIP Services, Tailscale LoadBalancer Services, and Ingresses in the existing end-to-end scenario.

## Tests

- `./tool/go test ./k8s-operator/reconciler/proxygrouppolicy`
- `./tool/go test -count=1 -run '^TestProxyGroupPolicy$' -v ./cmd/k8s-operator/e2e` (compiled successfully; runtime scenario skipped because no tailnet client was configured)
- `make kube-generate-all` (no generated diff)
- `./tool/go run github.com/golangci/golangci-lint/cmd/golangci-lint run --new-from-rev=upstream/main`
- `./tool/go vet ./k8s-operator/reconciler/proxygrouppolicy ./cmd/k8s-operator/e2e`

Fixes #20906