### PR TITLE
cmd/containerboot: make the boot map-response timeout configurable

### DIFF
--- a/cmd/containerboot/main.go
+++ b/cmd/containerboot/main.go
@@ -105,6 +105,9 @@
 //     containerboot instance is not running in Kubernetes, autoadvertise any services
 //     defined in the devices serve config, and unadvertise on shutdown. Defaults
 //     to `true`, but can be disabled to allow user specific advertisement configuration.
+//   - TS_BOOT_TIMEOUT: if set, overrides the default 60s timeout for the
+//     initial map response wait during boot. Accepts any time.Duration
+//     string (e.g. "90s", "3m").
 //
 // When running on Kubernetes, containerboot defaults to storing state in the
 // "tailscale" kube secret. To store state on local disk instead, set
@@ -357,7 +360,7 @@ func run() error {
 	// bootCtx is used for all setup stuff until we're in steady
 	// state, so that if something is hanging we eventually time out
 	// and crashloop the container.
-	bootCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	bootCtx, cancel := context.WithTimeout(ctx, cfg.BootCtxTimeout)
 	defer cancel()
 
 	var tailscaledConfigAuthkey string

--- a/cmd/containerboot/settings.go
+++ b/cmd/containerboot/settings.go
@@ -16,6 +16,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"time"
 
 	"tailscale.com/ipn/conffile"
 	"tailscale.com/kube/kubeclient"
@@ -86,7 +87,8 @@ type settings struct {
 	// logic),  'ro' (for Pods that shold never attempt to issue/renew
 	// certs) and 'rw' for Pods that should manage the TLS certs shared
 	// amongst the replicas.
-	CertShareMode string
+	CertShareMode  string
+	BootCtxTimeout time.Duration
 }
 
 func configFromEnv() (*settings, error) {
@@ -135,6 +137,7 @@ func configFromEnv() (*settings, error) {
 		EgressProxiesCfgPath:                  os.Getenv("TS_EGRESS_PROXIES_CONFIG_PATH"),
 		IngressProxiesCfgPath:                 os.Getenv("TS_INGRESS_PROXIES_CONFIG_PATH"),
 		PodUID:                                os.Getenv("POD_UID"),
+		BootCtxTimeout:                        def.Duration(os.Getenv("TS_BOOT_TIMEOUT"), 60*time.Second),
 	}
 
 	podIPs, ok := os.LookupEnv("POD_IPS")
@@ -348,6 +351,13 @@ func (s *settings) validate() error {
 	}
 	if s.IngressProxiesCfgPath != "" && !(s.InKubernetes && s.KubeSecret != "") {
 		return errors.New("TS_INGRESS_PROXIES_CONFIG_PATH is only supported for Tailscale running on Kubernetes")
+	}
+
+	// Error out when passed a malformed duration in `TS_BOOT_TIMEOUT` env var.
+	if v := os.Getenv("TS_BOOT_TIMEOUT"); v != "" {
+		if _, err := time.ParseDuration(v); err != nil {
+			return fmt.Errorf("error parsing TS_BOOT_TIMEOUT value %q: %w", v, err)
+		}
 	}
 	return nil
 }

--- a/cmd/containerboot/settings_test.go
+++ b/cmd/containerboot/settings_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 func Test_parseAcceptDNS(t *testing.T) {
@@ -325,5 +326,44 @@ func TestHandlesKubeIPV6(t *testing.T) {
 
 	if parsed.Port() != 9002 {
 		t.Errorf("expected port 9002 but got %d", parsed.Port())
+	}
+}
+
+func TestBootCtxTimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		// value is the TS_BOOT_TIMEOUT value to set; unset is true to leave
+		// the env var absent entirely.
+		value string
+		unset bool
+		// want is the expected BootCtxTimeout when wantErr is false.
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "unset_defaults_to_60s", unset: true, want: 60 * time.Second},
+		{name: "empty_defaults_to_60s", value: "", want: 60 * time.Second},
+		{name: "valid_override", value: "3m", want: 3 * time.Minute},
+		{name: "invalid_value_is_rejected", value: "90", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("TS_BOOT_TIMEOUT", tt.value)
+			if tt.unset {
+				os.Unsetenv("TS_BOOT_TIMEOUT")
+			}
+			cfg, err := configFromEnv()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("configFromEnv() succeeded, want error for TS_BOOT_TIMEOUT=%q", tt.value)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.BootCtxTimeout != tt.want {
+				t.Errorf("BootCtxTimeout = %v, want %v", cfg.BootCtxTimeout, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
containerboot waits up to 60s for the initial map response before failing. Slow map responses (>60s seen in production) leaves containerboot to timeout and fail.

Add a TS_BOOT_TIMEOUT env var to override the default. Falls back to 60s when unset.

Fixes #20912