### PR TITLE
wgengine/magicsock: keep the DERP hedge up until wg data is received

### DIFF
--- a/wgengine/magicsock/endpoint.go
+++ b/wgengine/magicsock/endpoint.go
@@ -85,6 +85,7 @@ type endpoint struct {
 	bestAddr           addrQuality // best non-DERP path; zero if none; mutate via setBestAddrLocked()
 	bestAddrAt         mono.Time   // time best address re-confirmed
 	trustBestAddrUntil mono.Time   // time when bestAddr expires
+	bestAddrConfirmed  bool        // whether non-disco traffic has arrived over bestAddr since it was installed; while false, sends are mirrored to DERP
 	sentPing           map[stun.TxID]sentPing
 	endpointState      map[netip.AddrPort]*endpointState // netip.AddrPort type for key (instead of [epAddr]) as [endpointState] is irrelevant for Geneve-encapsulated paths
 	isCallMeMaybeEP    map[netip.AddrPort]bool
@@ -132,6 +133,14 @@ func (de *endpoint) udpRelayEndpointReady(maybeBest addrQuality) {
 func (de *endpoint) setBestAddrLocked(v addrQuality) {
 	if v.epAddr != de.bestAddr.epAddr {
 		de.probeUDPLifetime.resetCycleEndpointLocked()
+
+		// No data has yet come back over this path carrying real traffic.
+		// Until it proves itself we keep mirroring to DERP.
+		// Cleared by [endpoint.noteRecvActivity].
+		//
+		// The first direct path of a session is exempt, to avoid duplicating
+		// WireGuard handshake and breaking session establishment.
+		de.bestAddrConfirmed = !de.bestAddr.ap.IsValid()
 
 		// Reaching here, if we are upgrading from an invalid (missing) address
 		// to a valid one, record metrics:
@@ -529,8 +538,15 @@ func (de *endpoint) noteRecvActivity(src epAddr, now mono.Time) bool {
 		// kick off discovery disco pings every trustUDPAddrDuration and mirror
 		// to DERP.
 		de.mu.Lock()
-		if de.heartbeatDisabled && de.bestAddr.epAddr == src {
-			de.trustBestAddrUntil = now.Add(trustUDPAddrDuration)
+		if de.bestAddr.epAddr == src {
+			// Non-disco traffic has arrived over bestAddr. Disco is dispatched
+			// before this point (see [Conn.receiveIP]), so this is real data
+			// and the path is carrying packets in both directions. Retire the
+			// DERP hedge. See [endpoint.setBestAddrLocked].
+			de.bestAddrConfirmed = true
+			if de.heartbeatDisabled {
+				de.trustBestAddrUntil = now.Add(trustUDPAddrDuration)
+			}
 		}
 		de.mu.Unlock()
 	}
@@ -578,6 +594,12 @@ func (de *endpoint) addrForSendLocked(now mono.Time) (udpAddr epAddr, derpAddr n
 	udpAddr = de.bestAddr.epAddr
 
 	if udpAddr.ap.IsValid() && !now.After(de.trustBestAddrUntil) {
+		if !de.bestAddrConfirmed && !de.isWireguardOnly {
+			// bestAddr is trusted on the strength of a disco pong alone and
+			// has not yet returned any non-disco traffic. Send to it, but keep
+			// the DERP hedge up until it does. See [endpoint.setBestAddrLocked].
+			return udpAddr, de.derpAddr, false
+		}
 		return udpAddr, netip.AddrPort{}, false
 	}
 
@@ -2032,7 +2054,12 @@ func (de *endpoint) populatePeerStatus(ps *ipnstate.PeerStatus) {
 	ps.LastWrite = de.lastSendExt.WallTime()
 	ps.Active = now.Sub(de.lastSendExt) < sessionActiveTimeout
 
-	if udpAddr, derpAddr, _ := de.addrForSendLocked(now); udpAddr.ap.IsValid() && !derpAddr.IsValid() {
+	udpAddr, derpAddr, _ := de.addrForSendLocked(now)
+	// An unconfirmed path (see [endpoint.setBestAddrLocked]) is still trusted.
+	// DERP mirrors it, while it remains the current address.
+	// An untrusted bestAddr does not.
+	trusted := !now.After(de.trustBestAddrUntil)
+	if udpAddr.ap.IsValid() && (!derpAddr.IsValid() || trusted) {
 		if udpAddr.vni.IsSet() {
 			ps.PeerRelay = udpAddr.String()
 		} else {

--- a/wgengine/magicsock/endpoint_test.go
+++ b/wgengine/magicsock/endpoint_test.go
@@ -725,3 +725,93 @@ func Test_endpoint_handlePongConnLocked(t *testing.T) {
 		})
 	}
 }
+
+func Test_endpoint_bestAddrConfirmed(t *testing.T) {
+	directA := epAddr{ap: netip.MustParseAddrPort("192.0.2.1:7")}
+	directB := epAddr{ap: netip.MustParseAddrPort("192.0.2.2:8")}
+	derpAddr := netip.AddrPortFrom(tailcfg.DerpMagicIPAddr, 1)
+
+	newEndpoint := func() *endpoint {
+		return &endpoint{
+			c:             &Conn{logf: func(string, ...any) {}},
+			derpAddr:      derpAddr,
+			endpointState: make(map[netip.AddrPort]*endpointState),
+			debugUpdates:  ringlog.New[EndpointChange](10),
+		}
+	}
+
+	// mirrorsToDERP reports whether addrForSendLocked hedges to DERP in
+	// addition to sending over bestAddr.
+	mirrorsToDERP := func(t *testing.T, de *endpoint, now mono.Time) bool {
+		t.Helper()
+		udpAddr, derp, _ := de.addrForSendLocked(now)
+		if !udpAddr.ap.IsValid() {
+			t.Fatal("bestAddr unexpectedly invalid")
+		}
+		return derp.IsValid()
+	}
+
+	t.Run("first-direct-path-is-not-hedged", func(t *testing.T) {
+		now := mono.Now()
+		de := newEndpoint()
+		de.setBestAddrLocked(addrQuality{epAddr: directA})
+		de.trustBestAddrUntil = now.Add(trustUDPAddrDuration)
+
+		if !de.bestAddrConfirmed {
+			t.Error("first direct path of a session should install confirmed")
+		}
+		if mirrorsToDERP(t, de, now) {
+			t.Error("first direct path should not mirror to DERP; duplicating the WireGuard handshake breaks session establishment")
+		}
+	})
+
+	t.Run("replacement-path-is-hedged-until-inbound-data", func(t *testing.T) {
+		now := mono.Now()
+		de := newEndpoint()
+		de.setBestAddrLocked(addrQuality{epAddr: directA})
+		de.trustBestAddrUntil = now.Add(trustUDPAddrDuration)
+		de.bestAddrConfirmed = true
+
+		// Displace directA with directB, as handlePongConnLocked does when a
+		// pong arrives while bestAddr is untrusted.
+		de.setBestAddrLocked(addrQuality{epAddr: directB})
+		de.trustBestAddrUntil = now.Add(trustUDPAddrDuration)
+
+		if de.bestAddrConfirmed {
+			t.Error("a path that displaces another should install unconfirmed")
+		}
+		if !mirrorsToDERP(t, de, now) {
+			t.Error("unconfirmed replacement path should mirror to DERP")
+		}
+
+		// Inbound traffic over some other address must not confirm bestAddr.
+		de.noteRecvActivity(directA, now)
+		if de.bestAddrConfirmed {
+			t.Error("inbound over a non-best address should not confirm bestAddr")
+		}
+		if !mirrorsToDERP(t, de, now) {
+			t.Error("hedge should survive inbound over a non-best address")
+		}
+
+		// Inbound traffic over bestAddr retires the hedge.
+		de.noteRecvActivity(directB, now)
+		if !de.bestAddrConfirmed {
+			t.Error("inbound over bestAddr should confirm it")
+		}
+		if mirrorsToDERP(t, de, now) {
+			t.Error("confirmed path should not mirror to DERP")
+		}
+	})
+
+	t.Run("untrusted-path-mirrors-regardless-of-confirmation", func(t *testing.T) {
+		now := mono.Now()
+		de := newEndpoint()
+		de.setBestAddrLocked(addrQuality{epAddr: directA})
+		de.bestAddrConfirmed = true
+		de.trustBestAddrUntil = now.Add(-time.Second)
+
+		if !mirrorsToDERP(t, de, now) {
+			t.Error("untrusted bestAddr should mirror to DERP even once confirmed")
+		}
+	})
+}

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -3164,13 +3164,14 @@ func TestAddrForPingSizeLocked(t *testing.T) {
 	validDerpAddr := netip.MustParseAddrPort("2.2.2.2:222")
 
 	pingTests := []struct {
-		desc            string
-		size            int           // size of ping payload
-		mtu             tstun.WireMTU // The MTU of the path to bestAddr, if any
-		bestAddr        bool          // If the endpoint should have a valid bestAddr
-		bestAddrTrusted bool          // If the bestAddr has not yet expired
-		wantUDP         bool          // Non-zero UDP addr means send to UDP; zero means start discovery
-		wantDERP        bool          // Non-zero DERP addr means send to DERP
+		desc                string
+		size                int           // size of ping payload
+		mtu                 tstun.WireMTU // The MTU of the path to bestAddr, if any
+		bestAddr            bool          // If the endpoint should have a valid bestAddr
+		bestAddrTrusted     bool          // If the bestAddr has not yet expired
+		bestAddrUnconfirmed bool          // If the bestAddr has not yet carried inbound traffic
+		wantUDP             bool          // Non-zero UDP addr means send to UDP; zero means start discovery
+		wantDERP            bool          // Non-zero DERP addr means send to DERP
 	}{
 		{
 			desc:            "ping_size_0_and_invalid_UDP_addr_should_start_discovery_and_send_to_DERP",
@@ -3187,6 +3188,15 @@ func TestAddrForPingSizeLocked(t *testing.T) {
 			bestAddrTrusted: true,
 			wantUDP:         true,
 			wantDERP:        false,
+		},
+		{
+			desc:                "ping_size_0_and_valid_trusted_but_unconfirmed_UDP_addr_should_send_to_both_UDP_and_DERP",
+			size:                0,
+			bestAddr:            true,
+			bestAddrTrusted:     true,
+			bestAddrUnconfirmed: true,
+			wantUDP:             true,
+			wantDERP:            true,
 		},
 		{
 			desc:            "ping_size_0_and_valid_but_expired_UDP_addr_should_send_to_both_UDP_and_DERP",
@@ -3241,8 +3251,9 @@ func TestAddrForPingSizeLocked(t *testing.T) {
 				bestAddr.epAddr.ap = validUdpAddr
 			}
 			ep := &endpoint{
-				derpAddr: validDerpAddr,
-				bestAddr: bestAddr,
+				derpAddr:          validDerpAddr,
+				bestAddr:          bestAddr,
+				bestAddrConfirmed: !test.bestAddrUnconfirmed,
 			}
 			if test.bestAddrTrusted {
 				ep.trustBestAddrUntil = testTime.Add(1 * time.Second)


### PR DESCRIPTION
When a disco pong promotes a new bestAddr over an existing one, all we know about the winner is that a small disco ping round-tripped over it. Nothing has yet come back over it carrying real traffic, and a path can pong while blackholing data. Today the promotion also stops the DERP double-send, so a bad promotion costs connectivity until trustBestAddrUntil lapses 6.5s later.

Track whether non-disco traffic has arrived over bestAddr since it was installed. Until it has, addrForSendLocked keeps mirroring to DERP alongside the direct send, so promoting into a blackhole costs added latency rather than connectivity. The first inbound data packet over bestAddr retires the hedge.

The first direct path of a session is deliberately exempt. It is an upgrade from DERP, which is already carrying traffic and will keep doing so if the upgrade turns out to be bad, so there is nothing to hedge against. Mirroring there is also actively harmful: it lands on the WireGuard handshake, and wireguard-go consumes a duplicated handshake response once and then fails keypair derivation with handshakeZeroed, breaking session establishment. Only valid-to-valid switches, which abandon a path that was working, get the hedge.

This does not change path selection. A dead address that keeps winning betterAddr still keeps winning it. The change removes the connectivity consequence of the re-selection interval rather than shortening it.

---

This is a draft. Rekey during a hedge window can still duplicate a handshake. Collisions are rare, but to close it properly, we need to suppress the mirror for handshake message types in send() (looksLikeInitiationMsg already exists in magicsock.go).

Relay promotions via udpRelayEndpointReady also route through setBestAddrLocked, so they get hedged too. Unclear if this is desirable.