### PR TITLE
Fix endpointslice reconciler contention

### DIFF
--- a/cmd/k8s-operator/deploy/chart/templates/operator-rbac.yaml
+++ b/cmd/k8s-operator/deploy/chart/templates/operator-rbac.yaml
@@ -98,7 +98,7 @@ rules:
   verbs: ["create","delete","deletecollection","get","list","patch","update","watch"]
 - apiGroups: ["discovery.k8s.io"]
   resources: ["endpointslices"]
-  verbs: ["get", "list", "watch", "create", "update", "deletecollection"]
+  verbs: ["get", "list", "watch", "create", "patch", "update", "deletecollection"]
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["roles", "rolebindings"]
   verbs: ["get", "create", "patch", "update", "list", "watch", "deletecollection"]

--- a/cmd/k8s-operator/deploy/manifests/operator.yaml
+++ b/cmd/k8s-operator/deploy/manifests/operator.yaml
@@ -6783,6 +6783,7 @@ rules:
         - list
         - watch
         - create
+        - patch
         - update
         - deletecollection
     - apiGroups:

--- a/cmd/k8s-operator/egress-eps.go
+++ b/cmd/k8s-operator/egress-eps.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/netip"
 	"reflect"
+	"slices"
 	"strings"
 
 	"go.uber.org/zap"
@@ -18,6 +19,9 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	discoveryac "k8s.io/client-go/applyconfigurations/discovery/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -75,7 +79,6 @@ func (er *egressEpsReconciler) Reconcile(ctx context.Context, req reconcile.Requ
 	// wasteful. Once we have a Ready condition for ExternalName Services for ProxyGroup, use the condition to
 	// determine if a reconcile is needed.
 
-	oldEps := eps.DeepCopy()
 	tailnetSvc := tailnetSvcName(svc)
 	lg = lg.With("tailnet-service-name", tailnetSvc)
 
@@ -104,7 +107,7 @@ func (er *egressEpsReconciler) Reconcile(ctx context.Context, req reconcile.Requ
 	if err := er.List(ctx, podList, client.MatchingLabels(pgLabels(proxyGroupName, nil))); err != nil {
 		return res, fmt.Errorf("error listing Pods for ProxyGroup %s: %w", proxyGroupName, err)
 	}
-	newEndpoints := make([]discoveryv1.Endpoint, 0)
+	newEndpoints := make([]*discoveryac.EndpointApplyConfiguration, 0)
 	for _, pod := range podList.Items {
 		ready, err := er.podIsReadyToRouteTraffic(ctx, pod, &cfg, tailnetSvc, eps.AddressType, lg)
 		if err != nil {
@@ -120,27 +123,62 @@ func (er *egressEpsReconciler) Reconcile(ctx context.Context, req reconcile.Requ
 		if podIP == "" {
 			continue // Pod doesn't have an IP for this address family
 		}
-		newEndpoints = append(newEndpoints, discoveryv1.Endpoint{
-			Hostname:  (*string)(&pod.UID),
-			Addresses: []string{podIP},
-			Conditions: discoveryv1.EndpointConditions{
-				Ready:       new(true),
-				Serving:     new(true),
-				Terminating: new(false),
-			},
-		})
+		newEndpoints = append(newEndpoints, discoveryac.Endpoint().
+			WithHostname(string(pod.UID)).
+			WithAddresses(podIP).
+			WithConditions(discoveryac.EndpointConditions().
+				WithReady(true).
+				WithServing(true).
+				WithTerminating(false)))
 	}
-	// Note that Endpoints are being overwritten with the currently valid endpoints so we don't need to explicitly
-	// run a cleanup for deleted Pods etc.
-	eps.Endpoints = newEndpoints
-	if !reflect.DeepEqual(eps, oldEps) {
-		lg.Info("Updating EndpointSlice to ensure traffic is routed to ready proxy Pods")
-		if err = er.Update(ctx, eps); err != nil {
-			return res, fmt.Errorf("error updating EndpointSlice: %w", err)
-		}
+	// Endpoints must be in a deterministic order. EndpointSlice.Endpoints is a
+	// +listType=atomic field, so Server-Side Apply (below) compares the whole
+	// list as a single value. Sort by the endpoint's address so an
+	// unchanged set of ready Pods always produces an identical apply.
+	slices.SortFunc(newEndpoints, func(a, b *discoveryac.EndpointApplyConfiguration) int {
+		return strings.Compare(firstAddress(a), firstAddress(b))
+	})
+
+	// Apply only the Endpoints field under this reconciler's own field manager.
+	// The egress Services reconciler owns labels/addressType/ports on the same
+	// slice via its own field manager- see (tailscale/tailscale#20916).
+	desired := discoveryac.EndpointSlice(eps.Name, eps.Namespace).
+		WithEndpoints(newEndpoints...)
+	u, err := applyConfigToUnstructured(desired)
+	if err != nil {
+		return res, err
+	}
+	if err := er.Patch(ctx, u, client.Apply, client.FieldOwner(egressEpsFieldOwner), client.ForceOwnership); err != nil {
+		return res, fmt.Errorf("error applying EndpointSlice endpoints: %w", err)
 	}
 
 	return res, nil
+}
+
+// applyConfigToUnstructured converts a typed apply configuration into an
+// *unstructured.Unstructured suitable for a server-side-apply Patch
+// (client.Apply) on controller-runtime v0.19.4, which has no typed
+// client.Client.Apply method.
+// TODO(beckypauley): remove when upgraded to v0.23.
+func applyConfigToUnstructured(ac any) (*unstructured.Unstructured, error) {
+	contents, err := runtime.DefaultUnstructuredConverter.ToUnstructured(ac)
+	if err != nil {
+		return nil, fmt.Errorf("error converting apply configuration to unstructured: %w", err)
+	}
+	return &unstructured.Unstructured{Object: contents}, nil
+}
+
+// egressEpsFieldOwner is the field manager used by the egress EndpointSlices
+// reconciler when it Server-Side Applies the Endpoints of a slice.
+const egressEpsFieldOwner = "tailscale-egress-eps-reconciler"
+
+// firstAddress returns the endpoint's first address, or the empty string if it
+// has none, for use as a stable sort key.
+func firstAddress(e *discoveryac.EndpointApplyConfiguration) string {
+	if e == nil || len(e.Addresses) == 0 {
+		return ""
+	}
+	return e.Addresses[0]
 }
 
 func podIPForFamily(pod *corev1.Pod, addrType discoveryv1.AddressType) (string, error) {

--- a/cmd/k8s-operator/egress-eps.go
+++ b/cmd/k8s-operator/egress-eps.go
@@ -148,6 +148,17 @@ func (er *egressEpsReconciler) Reconcile(ctx context.Context, req reconcile.Requ
 	if err != nil {
 		return res, err
 	}
+	// When no Pods are ready, apply an explicit empty endpoints list rather than
+	// omitting the field. The apply configuration's endpoints field is
+	// omitempty, so WithEndpoints of an empty set drops it entirely, which under
+	// Server-Side Apply relinquishes ownership. This may have little impact in
+	// practice, but is safer given the potential for resource contention on
+	// endpointslices.
+	if len(newEndpoints) == 0 {
+		if err := unstructured.SetNestedField(u.Object, []any{}, "endpoints"); err != nil {
+			return res, fmt.Errorf("error setting empty endpoints: %w", err)
+		}
+	}
 	if err := er.Patch(ctx, u, client.Apply, client.FieldOwner(egressEpsFieldOwner), client.ForceOwnership); err != nil {
 		return res, fmt.Errorf("error applying EndpointSlice endpoints: %w", err)
 	}

--- a/cmd/k8s-operator/egress-eps_test.go
+++ b/cmd/k8s-operator/egress-eps_test.go
@@ -61,6 +61,7 @@ func TestTailscaleEgressEndpointSlices(t *testing.T) {
 		WithScheme(tsapi.GlobalScheme).
 		WithObjects(svc, cm).
 		WithStatusSubresource(svc).
+		WithInterceptorFuncs(ssaMergeInterceptor()).
 		Build()
 	zl, err := zap.NewDevelopment()
 	if err != nil {

--- a/cmd/k8s-operator/egress-services.go
+++ b/cmd/k8s-operator/egress-services.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/storage/names"
+	discoveryac "k8s.io/client-go/applyconfigurations/discovery/v1"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -243,36 +244,45 @@ func addrTypesForClusterIPSvc(clusterIPSvc *corev1.Service) ([]discoveryv1.Addre
 	return addrTypes, nil
 }
 
-// ensureEndpointSlices ensures that EndpointSlices exist for the egress service
-// for each IP family supported by the cluster, and that their ports are up to
-// date.
+// egressSvcsFieldOwner is the field manager used by the egress Services
+// reconciler when it Server-Side Applies EndpointSlices. It must differ from the
+// egress EndpointSlices reconciler's field owner so that each reconciler owns a
+// disjoint set of fields on the shared slice.
+const egressSvcsFieldOwner = "tailscale-egress-svcs-reconciler"
+
+// ensureEndpointSlices ensures that an EndpointSlice exists for the egress
+// service for each IP family supported by the cluster, with up to date labels,
+// address type and ports.
+//
+// It runs on every reconcile so that a deleted EndpointSlice is recreated (see
+// tailscale/tailscale#20322) and slices are backfilled for existing services
+// when new IP families appear.
 func (esr *egressSvcsReconciler) ensureEndpointSlices(ctx context.Context, svc, clusterIPSvc *corev1.Service, lg *zap.SugaredLogger) error {
 	crl := egressSvcEpsLabels(svc, clusterIPSvc)
+	ports := epsPortsFromSvc(clusterIPSvc)
 	// Only create EndpointSlices for IP families supported by the cluster.
 	addrTypes, err := addrTypesForClusterIPSvc(clusterIPSvc)
 	if err != nil {
 		return err
 	}
 	for _, addrType := range addrTypes {
-		eps := &discoveryv1.EndpointSlice{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-%s", clusterIPSvc.Name, strings.ToLower(string(addrType))),
-				Namespace: esr.tsNamespace,
-				Labels:    crl,
-			},
-			AddressType: addrType,
-			Ports:       epsPortsFromSvc(clusterIPSvc),
+		name := fmt.Sprintf("%s-%s", clusterIPSvc.Name, strings.ToLower(string(addrType)))
+		// Set only the fields this reconciler owns (labels, address type, ports).
+		// (A typed EndpointSlice cannot beused here because its Endpoints field lacks
+		// omitempty and would marshal as "endpoints: null", claiming ownership and clobbering them.)
+		// Required to avoid optimistic lock errors seen in tailscale/tailscale#20916.
+		desired := discoveryac.EndpointSlice(name, esr.tsNamespace).
+			WithLabels(crl).
+			WithAddressType(addrType).
+			WithPorts(ports...)
+		u, err := applyConfigToUnstructured(desired)
+		if err != nil {
+			return err
 		}
-		if _, err := createOrUpdate(ctx, esr.Client, esr.tsNamespace, eps, func(e *discoveryv1.EndpointSlice) {
-			e.Labels = eps.Labels
-			e.AddressType = eps.AddressType
-			e.Ports = eps.Ports
-			for _, p := range e.Endpoints {
-				p.Conditions.Ready = nil
-			}
-		}); err != nil {
-			return fmt.Errorf("error ensuring %s EndpointSlice: %w", addrType, err)
+		if err := esr.Patch(ctx, u, client.Apply, client.FieldOwner(egressSvcsFieldOwner), client.ForceOwnership); err != nil {
+			return fmt.Errorf("error applying %s EndpointSlice: %w", addrType, err)
 		}
+		lg.Debugf("applied %s EndpointSlice %s", addrType, name)
 	}
 	return nil
 }
@@ -799,14 +809,14 @@ func tailnetSvcName(extNSvc *corev1.Service) string {
 }
 
 // epsPortsFromSvc takes the ClusterIP Service created for an egress service and
-// returns its Port array in a form that can be used for an EndpointSlice.
-func epsPortsFromSvc(svc *corev1.Service) (ep []discoveryv1.EndpointPort) {
+// returns its Port array as EndpointSlice port apply configurations, for use in
+// a Server-Side Apply of the EndpointSlice.
+func epsPortsFromSvc(svc *corev1.Service) (ep []*discoveryac.EndpointPortApplyConfiguration) {
 	for _, p := range svc.Spec.Ports {
-		ep = append(ep, discoveryv1.EndpointPort{
-			Protocol: &p.Protocol,
-			Port:     &p.TargetPort.IntVal,
-			Name:     &p.Name,
-		})
+		ep = append(ep, discoveryac.EndpointPort().
+			WithProtocol(p.Protocol).
+			WithPort(p.TargetPort.IntVal).
+			WithName(p.Name))
 	}
 	return ep
 }

--- a/cmd/k8s-operator/egress-services.go
+++ b/cmd/k8s-operator/egress-services.go
@@ -268,7 +268,7 @@ func (esr *egressSvcsReconciler) ensureEndpointSlices(ctx context.Context, svc, 
 	for _, addrType := range addrTypes {
 		name := fmt.Sprintf("%s-%s", clusterIPSvc.Name, strings.ToLower(string(addrType)))
 		// Set only the fields this reconciler owns (labels, address type, ports).
-		// (A typed EndpointSlice cannot beused here because its Endpoints field lacks
+		// (A typed EndpointSlice cannot be used here because its Endpoints field lacks
 		// omitempty and would marshal as "endpoints: null", claiming ownership and clobbering them.)
 		// Required to avoid optimistic lock errors seen in tailscale/tailscale#20916.
 		desired := discoveryac.EndpointSlice(name, esr.tsNamespace).

--- a/cmd/k8s-operator/egress-services_test.go
+++ b/cmd/k8s-operator/egress-services_test.go
@@ -53,6 +53,7 @@ func TestTailscaleEgressServices(t *testing.T) {
 		WithStatusSubresource(pg).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Create: clusterIPInterceptor("10.96.0.1"),
+			Patch:  ssaMergeInterceptor().Patch,
 		}).
 		Build()
 	zl, err := zap.NewDevelopment()
@@ -345,6 +346,7 @@ func TestTailscaleEgressServicesDualStack(t *testing.T) {
 		WithStatusSubresource(pg).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Create: clusterIPInterceptor("10.96.0.1", "fd00::1"),
+			Patch:  ssaMergeInterceptor().Patch,
 		}).
 		Build()
 	zl, err := zap.NewDevelopment()

--- a/cmd/k8s-operator/testutils_test.go
+++ b/cmd/k8s-operator/testutils_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"tailscale.com/client/tailscale/v2"
 
@@ -765,6 +766,60 @@ func expectMissing[T any, O ptrObject[T]](t *testing.T, client client.Client, ns
 	}, obj)
 	if !apierrors.IsNotFound(err) {
 		t.Fatalf("%s %s/%s unexpectedly present, wanted missing", reflect.TypeOf(obj).Elem().Name(), ns, name)
+	}
+}
+
+// ssaMergeInterceptor emulates the operator's egress Server-Side Apply against
+// the fake client so tests pass on both controller-runtime v0.19 (whose fake
+// client rejects apply patches outright) and v0.23.
+// TODO(beckypauley): this can be removed on release version after 1.102.x as
+// will be using controller-urntime v0.23 (includes fake client support).
+func ssaMergeInterceptor() interceptor.Funcs {
+	return interceptor.Funcs{
+		Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			if patch.Type() != types.ApplyPatchType {
+				return cl.Patch(ctx, obj, patch, opts...)
+			}
+			applied, ok := obj.(*unstructured.Unstructured)
+			if !ok {
+				return fmt.Errorf("ssaMergeInterceptor: expected *unstructured.Unstructured apply, got %T", obj)
+			}
+			// Fields owned by each egress field manager. Keep in sync with
+			// egressEpsReconciler.Reconcile and ensureEndpointSlices.
+			var ownedFields [][]string
+			switch fm := (&client.PatchOptions{}).ApplyOptions(opts).FieldManager; fm {
+			case egressEpsFieldOwner:
+				ownedFields = [][]string{{"endpoints"}}
+			case egressSvcsFieldOwner:
+				ownedFields = [][]string{{"metadata", "labels"}, {"addressType"}, {"ports"}}
+			default:
+				return fmt.Errorf("ssaMergeInterceptor: unexpected field manager %q", fm)
+			}
+
+			existing := &unstructured.Unstructured{}
+			existing.SetGroupVersionKind(applied.GroupVersionKind())
+			switch err := cl.Get(ctx, client.ObjectKeyFromObject(applied), existing); {
+			case apierrors.IsNotFound(err):
+				return cl.Create(ctx, applied.DeepCopy())
+			case err != nil:
+				return err
+			}
+
+			for _, fp := range ownedFields {
+				val, found, err := unstructured.NestedFieldNoCopy(applied.Object, fp...)
+				if err != nil {
+					return err
+				}
+				if !found {
+					unstructured.RemoveNestedField(existing.Object, fp...)
+					continue
+				}
+				if err := unstructured.SetNestedField(existing.Object, val, fp...); err != nil {
+					return err
+				}
+			}
+			return cl.Update(ctx, existing)
+		},
 	}
 }
 


### PR DESCRIPTION
cmd/k8s-operator: avoid EndpointSlice reconciler contention

The egress Services and egress EndpointSlice reconcilers both update the
same EndpointSlice. Concurrent full-object updates can race, resulting in
optimistic-lock errors and causing TailscaleEgressSvcConfigured to flap or
get stuck as False. In some cases this can prevent egress ProxyGroup
Services from becoming configured (see https://github.com/tailscale/tailscale/issues/20916).

Use Server-Side Apply with separate field managers for the two reconcilers.
The egress Services reconciler owns labels, address type and ports, while
the egress EndpointSlice reconciler owns endpoints. This allows both
reconcilers to update their fields independently without contending on the
whole object.

Sort endpoints by address before applying them so that the EndpointSlice
endpoints list has deterministic ordering and does not produce updates when
only endpoint order changes. Add the EndpointSlice patch RBAC permission
required for Server-Side Apply.

Fixes #20916