### PR TITLE
[release-branch] cmd/k8s-operator: watch ProxyGroups for HA Services with a Service handler

### DIFF
--- a/cmd/k8s-operator/operator.go
+++ b/cmd/k8s-operator/operator.go
@@ -507,12 +507,13 @@ func runReconcilers(opts reconcilerOpts) {
 	}
 
 	ingressSvcFromEpsFilter := handler.EnqueueRequestsFromMapFunc(ingressSvcFromEps(mgr.GetClient(), opts.log.Named("service-pg-reconciler")))
+	servicesProxyGroupFilter := handler.EnqueueRequestsFromMapFunc(servicesFromIngressProxyGroup(mgr.GetClient(), opts.log))
 	err = builder.
 		ControllerManagedBy(mgr).
 		For(&corev1.Service{}, builder.WithPredicates(serviceManagedResourceFilterPredicate())).
 		Named("service-pg-reconciler").
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(HAServicesFromSecret(mgr.GetClient(), startlog))).
-		Watches(&tsapi.ProxyGroup{}, ingressProxyGroupFilter).
+		Watches(&tsapi.ProxyGroup{}, servicesProxyGroupFilter).
 		Watches(&discoveryv1.EndpointSlice{}, ingressSvcFromEpsFilter).
 		Complete(&HAServiceReconciler{
 			recorder:    eventRecorder,
@@ -1656,6 +1657,37 @@ func ingressesFromIngressProxyGroup(cl client.Client, logger *zap.SugaredLogger)
 		}
 		reqs := make([]reconcile.Request, 0)
 		for _, svc := range ingList.Items {
+			reqs = append(reqs, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: svc.Namespace,
+					Name:      svc.Name,
+				},
+			})
+		}
+		return reqs
+	}
+}
+
+// servicesFromIngressProxyGroup is an event handler for ingress ProxyGroups. It returns reconcile requests for all
+// user-created Services that should be exposed on this ProxyGroup.
+func servicesFromIngressProxyGroup(cl client.Client, logger *zap.SugaredLogger) handler.MapFunc {
+	return func(ctx context.Context, o client.Object) []reconcile.Request {
+		pg, ok := o.(*tsapi.ProxyGroup)
+		if !ok {
+			logger.Warn("ProxyGroup handler triggered for an object that is not a ProxyGroup")
+			return nil
+		}
+
+		if pg.Spec.Type != tsapi.ProxyGroupTypeIngress {
+			return nil
+		}
+		svcList := &corev1.ServiceList{}
+		if err := cl.List(ctx, svcList, client.MatchingFields{indexIngressProxyGroup: pg.Name}); err != nil {
+			logger.Infof("error listing Services: %v, skipping a reconcile for event on ProxyGroup %s", err, pg.Name)
+			return nil
+		}
+		reqs := make([]reconcile.Request, 0)
+		for _, svc := range svcList.Items {
 			reqs = append(reqs, reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Namespace: svc.Namespace,

--- a/cmd/k8s-operator/operator_test.go
+++ b/cmd/k8s-operator/operator_test.go
@@ -2095,6 +2095,58 @@ func TestIgnorePGService(t *testing.T) {
 	findNoGenName(t, fc, "default", "test", "svc")
 }
 
+// Regression test: the service-pg-reconciler used to watch ProxyGroups with
+// ingressesFromIngressProxyGroup, which lists Ingresses and returns Ingress
+// keys. Fed to the Service reconciler those keys never match a Service, so a
+// ProxyGroup becoming Available did not re-enqueue the HA Services waiting on
+// it and provisioning only happened on the next operator restart (full
+// re-list).
+func Test_servicesFromIngressProxyGroup(t *testing.T) {
+	ingressPG := &tsapi.ProxyGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "ingress-pg"},
+		Spec:       tsapi.ProxyGroupSpec{Type: tsapi.ProxyGroupTypeIngress},
+	}
+	egressPG := &tsapi.ProxyGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "egress-pg"},
+		Spec:       tsapi.ProxyGroupSpec{Type: tsapi.ProxyGroupTypeEgress},
+	}
+	svcForIngressPG := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "svc-1",
+			Namespace:   "ns-1",
+			Annotations: map[string]string{AnnotationProxyGroup: "ingress-pg"},
+		},
+	}
+	svcForOtherPG := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "svc-2",
+			Namespace:   "ns-2",
+			Annotations: map[string]string{AnnotationProxyGroup: "other-pg"},
+		},
+	}
+	fc := fake.NewClientBuilder().
+		WithScheme(tsapi.GlobalScheme).
+		WithObjects(svcForIngressPG, svcForOtherPG).
+		WithIndex(new(corev1.Service), indexIngressProxyGroup, indexPGIngresses).
+		Build()
+	zl := zap.Must(zap.NewDevelopment())
+	h := servicesFromIngressProxyGroup(fc, zl.Sugar())
+
+	// An event on an ingress ProxyGroup enqueues only the Services that are
+	// annotated for it.
+	gotReqs := h(t.Context(), ingressPG)
+	wantReqs := []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: "ns-1", Name: "svc-1"}}}
+	if diff := cmp.Diff(gotReqs, wantReqs); diff != "" {
+		t.Errorf("servicesFromIngressProxyGroup(ingress-pg) mismatch (-got +want):\n%s", diff)
+	}
+
+	// An egress ProxyGroup is handled by a different reconciler and must not
+	// enqueue anything here.
+	if gotReqs := h(t.Context(), egressPG); len(gotReqs) != 0 {
+		t.Errorf("servicesFromIngressProxyGroup(egress-pg) = %v, want none", gotReqs)
+	}
+}
+
 func toFQDN(t *testing.T, s string) dnsname.FQDN {
 	t.Helper()
 	fqdn, err := dnsname.ToFQDN(s)


### PR DESCRIPTION
The service-pg-reconciler reconciles Services annotated for an ingress ProxyGroup, but its ProxyGroup watch reused ingressProxyGroupFilter, which is ingressesFromIngressProxyGroup. That handler lists Ingresses and returns Ingress keys, so when a ProxyGroup became Available the requests it produced never matched a Service and the reconciler's Get just came back NotFound.

This fixes this by adding servicesFromIngressProxyGroup, which lists the Services indexed for the ProxyGroup and returns their keys, matching what the egress path already does with egressSvcsFromEgressProxyGroup.

Fixes #20944

(cherry picked from commit 1de85e19729d5cb00090585327b4a7757ded7b81)