### PR TITLE
[release-branch] cmd/k8s-operator: return the requeue result from HA Service reconcile

### DIFF
--- a/cmd/k8s-operator/svc-for-pg.go
+++ b/cmd/k8s-operator/svc-for-pg.go
@@ -150,7 +150,7 @@ func (r *HAServiceReconciler) Reconcile(ctx context.Context, req reconcile.Reque
 		res = reconcile.Result{RequeueAfter: requeueInterval()}
 	}
 
-	return reconcile.Result{}, nil
+	return res, nil
 }
 
 // maybeProvision ensures that a Tailscale Service for this Ingress exists and is up to date and that the serve config for the


### PR DESCRIPTION
Fixes a dropped assignment of `res` in HA service reconciler necessary for requeuing.

Fixes #20946

(cherry picked from commit 0ed6af7b72964796e4ca635222b9ef2a2afe35c0)