### PR TITLE
go.mod,go.sum: bump wireguard-go to fix AllowedIPs mem leak

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -173,4 +173,4 @@
     });
   };
 }
-# nix-direnv cache busting line: sha256-kRkKLGNZwgw26eIzj+tWfYlDoIfX9TF2ril8Kj3KfGE=
+# nix-direnv cache busting line: sha256-zhqsqZG3LyclwUjtj9b3EbhabiV8a4L+OS6OVTNmdF4=

--- a/flakehashes.json
+++ b/flakehashes.json
@@ -4,7 +4,7 @@
     "sri": "sha256-X5BJTH4gdjaww4wQZUQ8b2Yy0xztHYVPzsg/YXfmCPs="
   },
   "vendor": {
-    "goModSum": "sha256-D1DT6B8EuSHWnWGWgtT0FPHw2hwrvq/SBdzt3kO7Z/o=",
-    "sri": "sha256-kRkKLGNZwgw26eIzj+tWfYlDoIfX9TF2ril8Kj3KfGE="
+    "goModSum": "sha256-sDInhpMWKPo0YvyTPKCM4lLnoS/72tRN/tJbzd5xHmI=",
+    "sri": "sha256-zhqsqZG3LyclwUjtj9b3EbhabiV8a4L+OS6OVTNmdF4="
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -126,7 +126,7 @@ require (
 	github.com/tailscale/ts-gokrazy v0.0.0-20260630224145-b83088f2e52e
 	github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976
 	github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6
-	github.com/tailscale/wireguard-go v0.0.0-20260813211458-aa425f19bcbf
+	github.com/tailscale/wireguard-go v0.0.0-20260821191448-23d18d66172c
 	github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e
 	github.com/tc-hib/winres v0.2.1
 	github.com/tcnksm/go-httpstat v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1217,8 +1217,8 @@ github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976 h1:U
 github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976/go.mod h1:agQPE6y6ldqCOui2gkIh7ZMztTkIQKH049tv8siLuNQ=
 github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6 h1:l10Gi6w9jxvinoiq15g8OToDdASBni4CyJOdHY1Hr8M=
 github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6/go.mod h1:ZXRML051h7o4OcI0d3AaILDIad/Xw0IkXaHM17dic1Y=
-github.com/tailscale/wireguard-go v0.0.0-20260813211458-aa425f19bcbf h1:TQTeMPbY+rI4jMtp2p1kPTzBlv8yloP4fy6nb5l+D38=
-github.com/tailscale/wireguard-go v0.0.0-20260813211458-aa425f19bcbf/go.mod h1:6SerzcvHWQchKO2BfNdmquA77CHSECZuFl+D9fp4RnI=
+github.com/tailscale/wireguard-go v0.0.0-20260821191448-23d18d66172c h1:rjqTtbumXpM5B1UR7u+dsOaI9wRetOfIDan5kJJrgn8=
+github.com/tailscale/wireguard-go v0.0.0-20260821191448-23d18d66172c/go.mod h1:6SerzcvHWQchKO2BfNdmquA77CHSECZuFl+D9fp4RnI=
 github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e h1:zOGKqN5D5hHhiYUp091JqK7DPCqSARyUfduhGUY8Bek=
 github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e/go.mod h1:orPd6JZXXRyuDusYilywte7k094d7dycXXU5YnWsrwg=
 github.com/tc-hib/winres v0.2.1 h1:YDE0FiP0VmtRaDn7+aaChp1KiF4owBiJa5l964l5ujA=

--- a/shell.nix
+++ b/shell.nix
@@ -16,4 +16,4 @@
 ) {
   src =  ./.;
 }).shellNix
-# nix-direnv cache busting line: sha256-kRkKLGNZwgw26eIzj+tWfYlDoIfX9TF2ril8Kj3KfGE=
+# nix-direnv cache busting line: sha256-zhqsqZG3LyclwUjtj9b3EbhabiV8a4L+OS6OVTNmdF4=


### PR DESCRIPTION
Pulls in https://github.com/tailscale/wireguard-go/pull/85 which fixes an unbounded memory leak in mkIPInCIDRsTestFunc. It used a package-level placeholder Peer, and AllowedIPs.Insert threads every trie node onto that peer's trieEntries list, so each call leaked its whole trie. SetAllowedIPs calls it on every netmap update, so peer churn accumulated trie nodes until the client OOMed.

Fixes tailscale/corp#47010