### PR TITLE
cmd/k8s-operator: support PROXY protocol for ingress Services

### DIFF
--- a/cmd/k8s-operator/sts.go
+++ b/cmd/k8s-operator/sts.go
@@ -65,6 +65,10 @@ const (
 	AnnotationTailnetTargetIP    = "tailscale.com/tailnet-ip"
 	// MagicDNS name of tailnet node.
 	AnnotationTailnetTargetFQDN = "tailscale.com/tailnet-fqdn"
+	// AnnotationProxyProtocol enables PROXY protocol headers for TCP
+	// connections forwarded by an ingress Service. Supported values are "1"
+	// and "2".
+	AnnotationProxyProtocol = "tailscale.com/proxy-protocol"
 
 	AnnotationProxyGroup = "tailscale.com/proxy-group"
 
@@ -817,6 +821,9 @@ func appInfoForProxy(cfg *tailscaleSTSConfig) (string, error) {
 		return kubetypes.AppEgressProxy, nil
 	}
 	if cfg.ServeConfig != nil {
+		if cfg.proxyType == proxyTypeIngressService {
+			return kubetypes.AppIngressProxy, nil
+		}
 		return kubetypes.AppIngressResource, nil
 	}
 	if cfg.Connector != nil {

--- a/cmd/k8s-operator/svc-for-pg.go
+++ b/cmd/k8s-operator/svc-for-pg.go
@@ -232,10 +232,17 @@ func (r *HAServiceReconciler) maybeProvision(ctx context.Context, hostname strin
 		tags = strings.Split(tstr, ",")
 	}
 
+	ports := []string{"do-not-validate"}
+	if _, ok := serviceProxyProtocolVersion(svc); ok {
+		ports = make([]string, 0, len(svc.Spec.Ports))
+		for _, port := range svc.Spec.Ports {
+			ports = append(ports, fmt.Sprintf("tcp:%d", port.Port))
+		}
+	}
 	tsSvc := tailscale.VIPService{
 		Name:        serviceName.String(),
 		Tags:        tags,
-		Ports:       []string{"do-not-validate"}, // we don't want to validate ports
+		Ports:       ports,
 		Comment:     managedTSServiceComment,
 		Annotations: updatedAnnotations,
 	}
@@ -248,6 +255,7 @@ func (r *HAServiceReconciler) maybeProvision(ctx context.Context, hostname strin
 	// with the same generation number has been reconciled ~more than N times and stop attempting to apply updates.
 	if existingTSSvc == nil ||
 		!reflect.DeepEqual(tsSvc.Tags, existingTSSvc.Tags) ||
+		!reflect.DeepEqual(tsSvc.Ports, existingTSSvc.Ports) ||
 		!ownersAreSetAndEqual(tsSvc, *existingTSSvc) {
 		logger.Infof("Ensuring Tailscale Service exists and is up to date")
 		if err = tsClient.VIPServices().CreateOrUpdate(ctx, tsSvc); err != nil {
@@ -312,14 +320,43 @@ func (r *HAServiceReconciler) maybeProvision(ctx context.Context, hostname strin
 		}
 	}
 
-	existingCfg := cfgs[serviceName.String()]
-	if !reflect.DeepEqual(existingCfg, cfg) {
-		mak.Set(&cfgs, serviceName.String(), cfg)
+	serveCfg, err := serveConfigFromConfigMap(cm)
+	if err != nil {
+		return false, err
+	}
+	proxyProtocol, useProxyProtocol := serviceProxyProtocolVersion(svc)
+	configChanged := false
+	if useProxyProtocol {
+		if _, ok := cfgs[serviceName.String()]; ok {
+			delete(cfgs, serviceName.String())
+			configChanged = true
+		}
+		desired := serviceProxyServeConfig(svc, proxyProtocol, serviceName).Services[serviceName]
+		if !reflect.DeepEqual(serveCfg.Services[serviceName], desired) {
+			mak.Set(&serveCfg.Services, serviceName, desired)
+			configChanged = true
+		}
+	} else {
+		if !reflect.DeepEqual(cfgs[serviceName.String()], cfg) {
+			mak.Set(&cfgs, serviceName.String(), cfg)
+			configChanged = true
+		}
+		if serviceConfigIsTCPForward(serveCfg.Services[serviceName]) {
+			delete(serveCfg.Services, serviceName)
+			configChanged = true
+		}
+	}
+	if configChanged {
 		cfgBytes, err := json.Marshal(cfgs)
 		if err != nil {
 			return false, fmt.Errorf("error marshaling ingress config: %w", err)
 		}
 		mak.Set(&cm.BinaryData, ingressservices.IngressConfigKey, cfgBytes)
+		serveCfgBytes, err := json.Marshal(serveCfg)
+		if err != nil {
+			return false, fmt.Errorf("error marshaling serve config: %w", err)
+		}
+		mak.Set(&cm.BinaryData, serveConfigKey, serveCfgBytes)
 		if err := r.Update(ctx, cm); err != nil {
 			return false, fmt.Errorf("error updating ingress config: %w", err)
 		}
@@ -328,7 +365,11 @@ func (r *HAServiceReconciler) maybeProvision(ctx context.Context, hostname strin
 	logger.Infof("updating AdvertiseServices config")
 	// 4. Update tailscaled's AdvertiseServices config, which should add the Tailscale Service
 	// IPs to the ProxyGroup Pods' AllowedIPs in the next netmap update if approved.
-	if err = r.maybeUpdateAdvertiseServicesConfig(ctx, svc, pg.Name, serviceName, &cfg, true, logger); err != nil {
+	var routeCfg *ingressservices.Config
+	if !useProxyProtocol {
+		routeCfg = &cfg
+	}
+	if err = r.maybeUpdateAdvertiseServicesConfig(ctx, svc, pg.Name, serviceName, routeCfg, true, logger); err != nil {
 		return false, fmt.Errorf("failed to update tailscaled config: %w", err)
 	}
 
@@ -413,13 +454,25 @@ func (r *HAServiceReconciler) maybeCleanup(ctx context.Context, hostname string,
 	if cm == nil || cfgs == nil {
 		return true, nil
 	}
+	serveCfg, err := serveConfigFromConfigMap(cm)
+	if err != nil {
+		return false, err
+	}
 	logger.Infof("Removing Tailscale Service %q from ingress config for ProxyGroup %q", hostname, pgName)
 	delete(cfgs, serviceName.String())
+	if serviceConfigIsTCPForward(serveCfg.Services[serviceName]) {
+		delete(serveCfg.Services, serviceName)
+	}
 	cfgBytes, err := json.Marshal(cfgs)
 	if err != nil {
 		return false, fmt.Errorf("error marshaling ingress config: %w", err)
 	}
 	mak.Set(&cm.BinaryData, ingressservices.IngressConfigKey, cfgBytes)
+	serveCfgBytes, err := json.Marshal(serveCfg)
+	if err != nil {
+		return false, fmt.Errorf("error marshaling serve config: %w", err)
+	}
+	mak.Set(&cm.BinaryData, serveConfigKey, serveCfgBytes)
 	return true, r.Update(ctx, cm)
 }
 
@@ -436,8 +489,25 @@ func (r *HAServiceReconciler) maybeCleanupProxyGroup(ctx context.Context, proxyG
 		return false, fmt.Errorf("failed to find Services for ProxyGroup %q: %w", proxyGroupName, err)
 	}
 
-	ingressConfigChanged := false
-	for tsSvcName, cfg := range config {
+	if cm == nil {
+		return false, nil
+	}
+	serveCfg, err := serveConfigFromConfigMap(cm)
+	if err != nil {
+		return false, err
+	}
+	serviceNames := make(map[string]bool)
+	for tsSvcName := range config {
+		serviceNames[tsSvcName] = true
+	}
+	for serviceName, serviceCfg := range serveCfg.Services {
+		if serviceConfigIsTCPForward(serviceCfg) {
+			serviceNames[serviceName.String()] = true
+		}
+	}
+
+	configChanged := false
+	for tsSvcName := range serviceNames {
 		found := false
 		for _, svc := range svcList.Items {
 			if strings.EqualFold(fmt.Sprintf("svc:%s", nameForService(&svc)), tsSvcName) {
@@ -448,37 +518,74 @@ func (r *HAServiceReconciler) maybeCleanupProxyGroup(ctx context.Context, proxyG
 		if !found {
 			logger.Infof("Tailscale Service %q is not owned by any Service, cleaning up", tsSvcName)
 
-			// Make sure the Tailscale Service is not advertised in tailscaled or serve config.
-			if err = r.maybeUpdateAdvertiseServicesConfig(ctx, nil, proxyGroupName, tailcfg.ServiceName(tsSvcName), &cfg, false, logger); err != nil {
+			// Make sure the Tailscale Service is not advertised in tailscaled.
+			var routeCfg *ingressservices.Config
+			if cfg, ok := config[tsSvcName]; ok {
+				routeCfg = &cfg
+			}
+			if err = r.maybeUpdateAdvertiseServicesConfig(ctx, nil, proxyGroupName, tailcfg.ServiceName(tsSvcName), routeCfg, false, logger); err != nil {
 				return false, fmt.Errorf("failed to update tailscaled config services: %w", err)
 			}
 
-			svcsChanged, err = cleanupTailscaleService(ctx, tsClient, tsSvcName, r.operatorID, logger)
+			changed, err := cleanupTailscaleService(ctx, tsClient, tsSvcName, r.operatorID, logger)
 			if err != nil {
 				return false, fmt.Errorf("deleting Tailscale Service %q: %w", tsSvcName, err)
 			}
+			svcsChanged = svcsChanged || changed
 
-			_, ok := config[tsSvcName]
-			if ok {
-				logger.Infof("Removing Tailscale Service %q from serve config", tsSvcName)
+			if _, ok := config[tsSvcName]; ok {
+				logger.Infof("Removing Tailscale Service %q from ingress config", tsSvcName)
 				delete(config, tsSvcName)
-				ingressConfigChanged = true
+				configChanged = true
+			}
+			serviceName := tailcfg.ServiceName(tsSvcName)
+			if serviceConfigIsTCPForward(serveCfg.Services[serviceName]) {
+				logger.Infof("Removing Tailscale Service %q from serve config", tsSvcName)
+				delete(serveCfg.Services, serviceName)
+				configChanged = true
 			}
 		}
 	}
 
-	if ingressConfigChanged {
+	if configChanged {
 		configBytes, err := json.Marshal(config)
 		if err != nil {
 			return false, fmt.Errorf("marshaling serve config: %w", err)
 		}
 		mak.Set(&cm.BinaryData, ingressservices.IngressConfigKey, configBytes)
+		serveCfgBytes, err := json.Marshal(serveCfg)
+		if err != nil {
+			return false, fmt.Errorf("marshaling serve config: %w", err)
+		}
+		mak.Set(&cm.BinaryData, serveConfigKey, serveCfgBytes)
 		if err := r.Update(ctx, cm); err != nil {
-			return false, fmt.Errorf("updating serve config: %w", err)
+			return false, fmt.Errorf("updating ingress config: %w", err)
 		}
 	}
 
 	return svcsChanged, nil
+}
+
+func serveConfigFromConfigMap(cm *corev1.ConfigMap) (*ipn.ServeConfig, error) {
+	cfg := new(ipn.ServeConfig)
+	if data := cm.BinaryData[serveConfigKey]; len(data) != 0 {
+		if err := json.Unmarshal(data, cfg); err != nil {
+			return nil, fmt.Errorf("error unmarshaling ingress serve config %v: %w", data, err)
+		}
+	}
+	return cfg, nil
+}
+
+func serviceConfigIsTCPForward(cfg *ipn.ServiceConfig) bool {
+	if cfg == nil {
+		return false
+	}
+	for _, handler := range cfg.TCP {
+		if handler != nil && handler.TCPForward != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *HAServiceReconciler) deleteFinalizer(ctx context.Context, svc *corev1.Service, logger *zap.SugaredLogger) error {
@@ -676,13 +783,15 @@ func (r *HAServiceReconciler) maybeUpdateAdvertiseServicesConfig(ctx context.Con
 					logger.Warnf("unable to determine replica name from config Secret name %q, unable to determine if backend routing has been configured", secret.Name)
 					return nil
 				}
-				ready, err := r.backendRoutesSetup(ctx, serviceName.String(), replicaName, cfg, logger)
-				if err != nil {
-					return fmt.Errorf("error checking backend routes: %w", err)
-				}
-				if !ready {
-					logger.Debugf("service %q is not ready to be advertised", serviceName)
-					continue
+				if cfg != nil {
+					ready, err := r.backendRoutesSetup(ctx, serviceName.String(), replicaName, cfg, logger)
+					if err != nil {
+						return fmt.Errorf("error checking backend routes: %w", err)
+					}
+					if !ready {
+						logger.Debugf("service %q is not ready to be advertised", serviceName)
+						continue
+					}
 				}
 
 				conf.AdvertiseServices = append(conf.AdvertiseServices, serviceName.String())

--- a/cmd/k8s-operator/svc-for-pg_test.go
+++ b/cmd/k8s-operator/svc-for-pg_test.go
@@ -24,14 +24,119 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"tailscale.com/client/tailscale/v2"
 
+	"tailscale.com/ipn"
 	tsoperator "tailscale.com/k8s-operator"
 	tsapi "tailscale.com/k8s-operator/apis/v1alpha1"
 	"tailscale.com/k8s-operator/tsclient"
 	"tailscale.com/kube/ingressservices"
 	"tailscale.com/kube/kubetypes"
+	"tailscale.com/tailcfg"
 	"tailscale.com/tstest"
 	"tailscale.com/util/mak"
 )
+
+func TestServicePGReconcilerProxyProtocol(t *testing.T) {
+	svcPGR, stateSecret, fc, ft, _ := setupServiceTest(t)
+	svc, _ := setupTestService(t, "test-svc", "", "1.2.3.4", fc, stateSecret)
+	mustUpdate(t, fc, svc.Namespace, svc.Name, func(s *corev1.Service) {
+		mak.Set(&s.Annotations, AnnotationProxyProtocol, "2")
+		s.Spec.Ports = []corev1.ServicePort{{Port: 49152, Protocol: corev1.ProtocolTCP}}
+	})
+
+	expectReconciled(t, svcPGR, svc.Namespace, svc.Name)
+	serviceName := "svc:default-test-svc"
+	verifyTailscaleService(t, ft, serviceName, []string{"tcp:49152"})
+	verifyTailscaledConfig(t, fc, "test-pg", []string{serviceName})
+	verifyServiceProxyConfig(t, fc, serviceName, "1.2.3.4:49152", 2)
+
+	// Removing the annotation switches the Service back to the L3 forwarding
+	// path and removes the TCP forwarding entry from the shared ServeConfig.
+	mustUpdate(t, fc, svc.Namespace, svc.Name, func(s *corev1.Service) {
+		delete(s.Annotations, AnnotationProxyProtocol)
+	})
+	expectReconciled(t, svcPGR, svc.Namespace, svc.Name)
+	verifyTailscaleService(t, ft, serviceName, []string{"do-not-validate"})
+	verifyNoServiceProxyConfig(t, fc, serviceName)
+
+	// Re-enable the TCP proxy, then ensure Service deletion cleans it out of
+	// both shared ProxyGroup configurations.
+	mustUpdate(t, fc, svc.Namespace, svc.Name, func(s *corev1.Service) {
+		mak.Set(&s.Annotations, AnnotationProxyProtocol, "2")
+	})
+	expectReconciled(t, svcPGR, svc.Namespace, svc.Name)
+	if err := fc.Delete(t.Context(), svc); err != nil {
+		t.Fatal(err)
+	}
+	expectReconciled(t, svcPGR, svc.Namespace, svc.Name)
+	verifyServiceConfigAbsent(t, fc, serviceName)
+}
+
+func verifyServiceProxyConfig(t *testing.T, fc client.Client, serviceName, target string, proxyProtocol int) {
+	t.Helper()
+	cm := new(corev1.ConfigMap)
+	if err := fc.Get(t.Context(), types.NamespacedName{Name: "test-pg-ingress-config", Namespace: "operator-ns"}, cm); err != nil {
+		t.Fatal(err)
+	}
+	serveConfig := new(ipn.ServeConfig)
+	if err := json.Unmarshal(cm.BinaryData[serveConfigKey], serveConfig); err != nil {
+		t.Fatal(err)
+	}
+	handler := serveConfig.Services[tailcfg.ServiceName(serviceName)].TCP[49152]
+	if handler == nil || handler.TCPForward != target || handler.ProxyProtocol != proxyProtocol {
+		t.Fatalf("unexpected TCP handler: %#v", handler)
+	}
+	ingressConfig := ingressservices.Configs{}
+	if err := json.Unmarshal(cm.BinaryData[ingressservices.IngressConfigKey], &ingressConfig); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := ingressConfig[serviceName]; ok {
+		t.Fatalf("Service %q unexpectedly has both TCP and L3 forwarding config", serviceName)
+	}
+}
+
+func verifyNoServiceProxyConfig(t *testing.T, fc client.Client, serviceName string) {
+	t.Helper()
+	cm := new(corev1.ConfigMap)
+	if err := fc.Get(t.Context(), types.NamespacedName{Name: "test-pg-ingress-config", Namespace: "operator-ns"}, cm); err != nil {
+		t.Fatal(err)
+	}
+	serveConfig := new(ipn.ServeConfig)
+	if err := json.Unmarshal(cm.BinaryData[serveConfigKey], serveConfig); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := serveConfig.Services[tailcfg.ServiceName(serviceName)]; ok {
+		t.Fatalf("Service %q still has TCP forwarding config", serviceName)
+	}
+	ingressConfig := ingressservices.Configs{}
+	if err := json.Unmarshal(cm.BinaryData[ingressservices.IngressConfigKey], &ingressConfig); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := ingressConfig[serviceName]; !ok {
+		t.Fatalf("Service %q is missing L3 forwarding config", serviceName)
+	}
+}
+
+func verifyServiceConfigAbsent(t *testing.T, fc client.Client, serviceName string) {
+	t.Helper()
+	cm := new(corev1.ConfigMap)
+	if err := fc.Get(t.Context(), types.NamespacedName{Name: "test-pg-ingress-config", Namespace: "operator-ns"}, cm); err != nil {
+		t.Fatal(err)
+	}
+	serveConfig := new(ipn.ServeConfig)
+	if err := json.Unmarshal(cm.BinaryData[serveConfigKey], serveConfig); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := serveConfig.Services[tailcfg.ServiceName(serviceName)]; ok {
+		t.Fatalf("Service %q still has TCP forwarding config", serviceName)
+	}
+	ingressConfig := ingressservices.Configs{}
+	if err := json.Unmarshal(cm.BinaryData[ingressservices.IngressConfigKey], &ingressConfig); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := ingressConfig[serviceName]; ok {
+		t.Fatalf("Service %q still has L3 forwarding config", serviceName)
+	}
+}
 
 func TestServicePGReconciler(t *testing.T) {
 	svcPGR, stateSecret, fc, ft, _ := setupServiceTest(t)

--- a/cmd/k8s-operator/svc.go
+++ b/cmd/k8s-operator/svc.go
@@ -9,8 +9,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/netip"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -24,10 +26,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"tailscale.com/ipn"
 	tsoperator "tailscale.com/k8s-operator"
 	tsapi "tailscale.com/k8s-operator/apis/v1alpha1"
 	"tailscale.com/kube/kubetypes"
 	"tailscale.com/net/dns/resolvconffile"
+	"tailscale.com/tailcfg"
 	"tailscale.com/tstime"
 	"tailscale.com/util/clientmetric"
 	"tailscale.com/util/dnsname"
@@ -278,7 +282,11 @@ func (a *ServiceReconciler) maybeProvision(ctx context.Context, logger *zap.Suga
 	}
 
 	a.mu.Lock()
-	if shouldExposeClusterIP(svc, a.isDefaultLoadBalancer) {
+	if proxyProtocol, ok := serviceProxyProtocolVersion(svc); ok {
+		sts.ServeConfig = serviceProxyServeConfig(svc, proxyProtocol, "")
+		a.managedIngressProxies.Add(svc.UID)
+		gaugeIngressProxies.Set(int64(a.managedIngressProxies.Len()))
+	} else if shouldExposeClusterIP(svc, a.isDefaultLoadBalancer) {
 		sts.ClusterTargetIP = svc.Spec.ClusterIP
 		a.managedIngressProxies.Add(svc.UID)
 		gaugeIngressProxies.Set(int64(a.managedIngressProxies.Len()))
@@ -395,6 +403,23 @@ func validateService(svc *corev1.Service) []string {
 			violations = append(violations, fmt.Sprintf("parsed IP address in annotation %s: %q is not valid", AnnotationTailnetTargetIP, ipStr))
 		}
 	}
+	if value, ok := svc.Annotations[AnnotationProxyProtocol]; ok {
+		if value != "1" && value != "2" {
+			violations = append(violations, fmt.Sprintf("annotation %s must be either %q or %q", AnnotationProxyProtocol, "1", "2"))
+		}
+		if tailnetTargetAnnotation(svc) != "" || svc.Annotations[AnnotationTailnetTargetFQDN] != "" {
+			violations = append(violations, fmt.Sprintf("annotation %s is only supported for ingress Services", AnnotationProxyProtocol))
+		}
+		if len(svc.Spec.Ports) == 0 {
+			violations = append(violations, fmt.Sprintf("annotation %s requires at least one Service port", AnnotationProxyProtocol))
+		}
+		for _, port := range svc.Spec.Ports {
+			if port.Protocol != corev1.ProtocolTCP {
+				violations = append(violations, fmt.Sprintf("annotation %s is only supported for TCP Service ports", AnnotationProxyProtocol))
+				break
+			}
+		}
+	}
 
 	svcName := nameForService(svc)
 	if err := dnsname.ValidLabel(svcName); err != nil {
@@ -406,6 +431,43 @@ func validateService(svc *corev1.Service) []string {
 	}
 	violations = append(violations, tagViolations(svc)...)
 	return violations
+}
+
+func serviceProxyProtocolVersion(svc *corev1.Service) (version int, ok bool) {
+	if svc == nil {
+		return 0, false
+	}
+	value, ok := svc.Annotations[AnnotationProxyProtocol]
+	if !ok {
+		return 0, false
+	}
+	version, err := strconv.Atoi(value)
+	if err != nil || version < 1 || version > 2 {
+		return 0, false
+	}
+	return version, true
+}
+
+// serviceProxyServeConfig returns a ServeConfig that forwards each exposed TCP
+// port to the Kubernetes Service while prepending a PROXY protocol header. If
+// serviceName is empty, the config is for a single-node ingress proxy;
+// otherwise it is for the named Tailscale Service on an ingress ProxyGroup.
+func serviceProxyServeConfig(svc *corev1.Service, proxyProtocol int, serviceName tailcfg.ServiceName) *ipn.ServeConfig {
+	targetHost := svc.Spec.ClusterIP
+	if svc.Spec.Type == corev1.ServiceTypeExternalName {
+		targetHost = svc.Spec.ExternalName
+	}
+
+	cfg := new(ipn.ServeConfig)
+	for _, port := range svc.Spec.Ports {
+		target := net.JoinHostPort(targetHost, strconv.Itoa(int(port.Port)))
+		if serviceName == "" {
+			cfg.SetTCPForwarding(uint16(port.Port), target, false, proxyProtocol, "")
+		} else {
+			cfg.SetTCPForwardingForService(uint16(port.Port), target, false, serviceName, proxyProtocol, "")
+		}
+	}
+	return cfg
 }
 
 func shouldExpose(svc *corev1.Service, isDefaultLoadBalancer bool) bool {

--- a/cmd/k8s-operator/svc_test.go
+++ b/cmd/k8s-operator/svc_test.go
@@ -8,20 +8,121 @@ package main
 import (
 	"context"
 	"slices"
+	"strings"
 	"testing"
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"tailscale.com/ipn"
 	tsapi "tailscale.com/k8s-operator/apis/v1alpha1"
 	"tailscale.com/k8s-operator/tsclient"
 	"tailscale.com/kube/kubetypes"
 	"tailscale.com/tstest"
 )
+
+func TestServiceProxyProtocol(t *testing.T) {
+	fc := fake.NewClientBuilder().
+		WithScheme(tsapi.GlobalScheme).
+		WithStatusSubresource(new(corev1.Service)).
+		Build()
+	zl := zap.Must(zap.NewDevelopment())
+	sr := &ServiceReconciler{
+		Client: fc,
+		ssr: &tailscaleSTSReconciler{
+			Client:            fc,
+			clients:           tsclient.NewProvider(new(fakeTSClient)),
+			defaultTags:       []string{"tag:k8s"},
+			operatorNamespace: "operator-ns",
+			proxyImage:        "tailscale/tailscale",
+		},
+		logger:   zl.Sugar(),
+		clock:    tstest.NewClock(tstest.ClockOpts{}),
+		recorder: record.NewFakeRecorder(10),
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			UID:       types.UID("1234-UID"),
+			Annotations: map[string]string{
+				AnnotationProxyProtocol: "2",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP:         "10.20.30.40",
+			Type:              corev1.ServiceTypeLoadBalancer,
+			LoadBalancerClass: new("tailscale"),
+			Ports: []corev1.ServicePort{{
+				Port:     49152,
+				Protocol: corev1.ProtocolTCP,
+			}},
+		},
+	}
+	mustCreate(t, fc, svc)
+	expectReconciled(t, sr, svc.Namespace, svc.Name)
+
+	serveConfig := new(ipn.ServeConfig)
+	serveConfig.SetTCPForwarding(49152, "10.20.30.40:49152", false, 2, "")
+	fullName, shortName := findGenName(t, fc, svc.Namespace, svc.Name, "svc")
+	opts := configOpts{
+		replicas:    new(int32(1)),
+		stsName:     shortName,
+		secretName:  fullName,
+		namespace:   svc.Namespace,
+		parentType:  "svc",
+		hostname:    "default-test",
+		serveConfig: serveConfig,
+		app:         kubetypes.AppIngressProxy,
+	}
+	expectEqual(t, fc, expectedSecret(t, fc, opts))
+	expectEqual(t, fc, expectedHeadlessService(shortName, "svc"))
+	expectEqual(t, fc, expectedSTSUserspace(t, fc, opts), removeResourceReqs)
+}
+
+func TestValidateServiceProxyProtocol(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		value     string
+		ports     []corev1.ServicePort
+		tailnetIP string
+		want      string
+	}{
+		{name: "version 1", value: "1", ports: []corev1.ServicePort{{Port: 80, Protocol: corev1.ProtocolTCP}}},
+		{name: "version 2", value: "2", ports: []corev1.ServicePort{{Port: 80, Protocol: corev1.ProtocolTCP}}},
+		{name: "invalid version", value: "3", ports: []corev1.ServicePort{{Port: 80, Protocol: corev1.ProtocolTCP}}, want: "must be either"},
+		{name: "no ports", value: "1", want: "requires at least one"},
+		{name: "UDP", value: "1", ports: []corev1.ServicePort{{Port: 53, Protocol: corev1.ProtocolUDP}}, want: "only supported for TCP"},
+		{name: "egress", value: "1", ports: []corev1.ServicePort{{Port: 80, Protocol: corev1.ProtocolTCP}}, tailnetIP: "100.64.0.1", want: "only supported for ingress"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			annotations := map[string]string{AnnotationProxyProtocol: tt.value}
+			if tt.tailnetIP != "" {
+				annotations[AnnotationTailnetTargetIP] = tt.tailnetIP
+			}
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", Annotations: annotations},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.20.30.40",
+					Ports:     tt.ports,
+				},
+			}
+			violations := strings.Join(validateService(svc), " ")
+			if tt.want == "" && violations != "" {
+				t.Fatalf("unexpected validation errors: %s", violations)
+			}
+			if tt.want != "" && !strings.Contains(violations, tt.want) {
+				t.Fatalf("validation errors %q do not contain %q", violations, tt.want)
+			}
+		})
+	}
+}
 
 func TestService_DefaultProxyClassInitiallyNotReady(t *testing.T) {
 	pc := &tsapi.ProxyClass{

--- a/docs/k8s/operator-architecture.md
+++ b/docs/k8s/operator-architecture.md
@@ -79,6 +79,13 @@ proxy that allows devices anywhere on the tailnet to access the Service.
 The proxy Pod uses `iptables` or `nftables` rules to DNAT traffic bound for the
 proxy's tailnet IP to the Service's internal Cluster IP instead.
 
+For TCP Services whose backends need the original tailnet client address, set
+`tailscale.com/proxy-protocol` to `"1"` or `"2"`. The ingress proxy then uses a
+TCP forwarder instead of DNAT and prepends a PROXY protocol header of the
+selected version to each connection. The Service backend must support and be
+configured to accept that PROXY protocol version. UDP and SCTP ports are not
+supported with this annotation.
+
 ```mermaid
 %%{ init: { 'theme':'neutral' } }%%
 flowchart TD


### PR DESCRIPTION
## Summary

- add the `tailscale.com/proxy-protocol` Service annotation with supported values `1` and `2`
- use tailscaled TCP forwarding for annotated TCP-only ingress Services so PROXY-aware backends can recover the original tailnet client address
- support standalone proxies and ingress ProxyGroups, including transitions back to L3 forwarding and cleanup
- document the opt-in behavior and backend requirement

The default path is unchanged. Services without the annotation continue to use L3 forwarding, and UDP/SCTP Services are rejected when the annotation is set.

Example:

```yaml
metadata:
  annotations:
    tailscale.com/proxy-protocol: "2"
```

The Service backend must be configured to accept the selected PROXY protocol version.

## Testing

- `./tool/go test ./cmd/k8s-operator -count=1`
- `./tool/go vet ./cmd/k8s-operator`

Updates #11024