### PR TITLE
appc: reproduce route coalescing issue

### DIFF
--- a/appc/appconnector_test.go
+++ b/appc/appconnector_test.go
@@ -164,6 +164,39 @@ func TestUpdateRoutesUnadvertisesContainedRoutes(t *testing.T) {
 	}
 }
 
+func TestUpdateRoutesCoalescesAllCoveredRoutes(t *testing.T) {
+	ctx := t.Context()
+	rc := &appctest.RouteCollector{}
+	a := NewAppConnector(Config{
+		Logf:            t.Logf,
+		EventBus:        eventbustest.NewBus(t),
+		RouteAdvertiser: rc,
+	})
+	t.Cleanup(a.Close)
+
+	discovered := prefixes("192.0.2.1/32", "192.0.2.2/32", "192.0.2.3/32")
+	a.domains = map[string][]netip.Addr{
+		"example.com": {
+			netip.MustParseAddr("192.0.2.1"),
+			netip.MustParseAddr("192.0.2.2"),
+			netip.MustParseAddr("192.0.2.3"),
+		},
+	}
+	rc.SetRoutes(slices.Clone(discovered))
+
+	want := prefixes("192.0.2.0/24")
+	a.updateRoutes(want)
+	a.Wait(ctx)
+
+	if got := rc.Routes(); !slices.Equal(got, want) {
+		t.Errorf("routes = %v, want %v", got, want)
+	}
+
+	if got := slices.Clone(rc.RemovedRoutes()); !slices.Equal(got, discovered) {
+		t.Errorf("removed routes = %v, want %v", got, discovered)
+	}
+}
+
 func TestDomainRoutes(t *testing.T) {
 	bus := eventbustest.NewBus(t)
 	for _, shouldStore := range []bool{false, true} {


### PR DESCRIPTION
> [!WARNING]
> **This is a repro of the behavior and not an attempt at a fix**

Today when you change from using domain discovery to a preset app for app connectors, we only coalesce the first route that matches the broader CIDR range. 

According to documentation at https://tailscale.com/docs/reference/best-practices/app-connectors#route-coalescing This is not intended functionality.
> For example, if the app connector previously discovered 192.0.2.5/32 and 192.0.2.67/32, and you update the [access control policy](https://tailscale.com/docs/features/access-control) to include 192.0.2.0/24, the connector replaces both /32 routes with the single 192.0.2.0/24 entry.

https://github.com/tailscale/tailscale/blob/86e5d3873aa96403d42e35ddd9247834c309691b/appc/appconnector.go#L345-L348

This Draft PR is a reproduction of the bug

## Test Results
```
go test ./appc/... -run TestUpdateRoutesCoalescesAllCoveredRoutes -v
=== RUN   TestUpdateRoutesCoalescesAllCoveredRoutes
    appconnector_test.go:192: routes = [192.0.2.2/32 192.0.2.3/32 192.0.2.0/24], want [192.0.2.0/24]
    appconnector_test.go:196: removed routes = [192.0.2.1/32], want [192.0.2.1/32 192.0.2.2/32 192.0.2.3/32]
--- FAIL: TestUpdateRoutesCoalescesAllCoveredRoutes (0.00s)
```

Addresses #20956