### PR TITLE
ipn/ipnlocal: reject auto-update without update checks

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -5069,6 +5069,11 @@ func (b *LocalBackend) checkFunnelEnabledLocked(p *ipn.Prefs) error {
 }
 
 func (b *LocalBackend) checkAutoUpdatePrefsLocked(p *ipn.Prefs) error {
+	// Apply requires Check: applying updates you never check for is
+	// contradictory (see AutoUpdatePrefs).
+	if p.AutoUpdate.Apply.EqualBool(true) && !p.AutoUpdate.Check {
+		return errors.New("Auto-updates require update checks to be enabled.")
+	}
 	if !buildfeatures.HasClientUpdate {
 		if p.AutoUpdate.Apply.EqualBool(true) {
 			return errors.New("Auto-update support is disabled in this build")

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -6631,6 +6631,29 @@ func TestEnableAutoUpdates(t *testing.T) {
 	}
 }
 
+func TestAutoUpdateApplyRequiresCheck(t *testing.T) {
+	lb := newTestLocalBackend(t)
+
+	// Enabling auto-updates while update checks are disabled violates the
+	// AutoUpdatePrefs invariant ("Check must also be set when Apply is set")
+	// and must be rejected instead of silently accepted. See #17770.
+	_, err := lb.EditPrefs(&ipn.MaskedPrefs{
+		AutoUpdateSet: ipn.AutoUpdatePrefsMask{
+			CheckSet: true,
+			ApplySet: true,
+		},
+		Prefs: ipn.Prefs{
+			AutoUpdate: ipn.AutoUpdatePrefs{
+				Check: false,
+				Apply: opt.NewBool(true),
+			},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "update checks") {
+		t.Fatalf("enabling auto-updates with update checks disabled: got error %v; want an error requiring update checks", err)
+	}
+}
+
 func TestReadWriteRouteInfo(t *testing.T) {
 	// set up a backend with more than one profile
 	b := newTestBackend(t)


### PR DESCRIPTION
AutoUpdatePrefs documents that Check must be set when Apply is set, but checkAutoUpdatePrefsLocked never enforced it, so
"tailscale set --update-check=false --auto-update=true" was silently accepted. Reject that combination.

Fixes #17770