### PR TITLE
go.mod: bump github.com/go4org/hashtriemap for slight speed boost

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -173,4 +173,4 @@
     });
   };
 }
-# nix-direnv cache busting line: sha256-5In+C38s6liec6DYKUjDz+Dv1sJ9xe6OcWMoJ/lyocw=
+# nix-direnv cache busting line: sha256-h3KPqXE1Wvl1nfUmus0zWowaiqBIxz6eJT/+dIBEkOM=

--- a/flakehashes.json
+++ b/flakehashes.json
@@ -4,7 +4,7 @@
     "sri": "sha256-X5BJTH4gdjaww4wQZUQ8b2Yy0xztHYVPzsg/YXfmCPs="
   },
   "vendor": {
-    "goModSum": "sha256-OefvSpd8k/1dHUTZ9krIeE7QDGIWqdrD6GQMDV6l5WA=",
-    "sri": "sha256-5In+C38s6liec6DYKUjDz+Dv1sJ9xe6OcWMoJ/lyocw="
+    "goModSum": "sha256-oET+wIOTwJUXSMCN1Ro5dxVkqe10N8zpQU7tR/YrPfY=",
+    "sri": "sha256-h3KPqXE1Wvl1nfUmus0zWowaiqBIxz6eJT/+dIBEkOM="
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68
 	github.com/go-logr/zapr v1.3.0
 	github.com/go-ole/go-ole v1.3.0
-	github.com/go4org/hashtriemap v0.0.0-20251130024219-545ba229f689
+	github.com/go4org/hashtriemap v0.0.0-20260824042624-45fcf11fca0e
 	github.com/go4org/plan9netshell v0.0.0-20250324183649-788daa080737
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/gokrazy/breakglass v0.0.0-20251229072214-9dbc0478d486

--- a/go.sum
+++ b/go.sum
@@ -486,8 +486,8 @@ github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9L
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/go-xmlfmt/xmlfmt v1.1.2 h1:Nea7b4icn8s57fTx1M5AI4qQT5HEM3rVUO8MuE6g80U=
 github.com/go-xmlfmt/xmlfmt v1.1.2/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=
-github.com/go4org/hashtriemap v0.0.0-20251130024219-545ba229f689 h1:0psnKZ+N2IP43/SZC8SKx6OpFJwLmQb9m9QyV9BC2f8=
-github.com/go4org/hashtriemap v0.0.0-20251130024219-545ba229f689/go.mod h1:OGmRfY/9QEK2P5zCRtmqfbCF283xPkU2dvVA4MvbvpI=
+github.com/go4org/hashtriemap v0.0.0-20260824042624-45fcf11fca0e h1:ZpjpNPLAkPzo4kGjruw82H26Dsec83ZmR5iiLfcbuTE=
+github.com/go4org/hashtriemap v0.0.0-20260824042624-45fcf11fca0e/go.mod h1:OGmRfY/9QEK2P5zCRtmqfbCF283xPkU2dvVA4MvbvpI=
 github.com/go4org/plan9netshell v0.0.0-20250324183649-788daa080737 h1:cf60tHxREO3g1nroKr2osU3JWZsJzkfi7rEg+oAB0Lo=
 github.com/go4org/plan9netshell v0.0.0-20250324183649-788daa080737/go.mod h1:MIS0jDzbU/vuM9MC4YnBITCv+RYuTRq8dJzmCrFsK9g=
 github.com/gobuffalo/flect v1.0.3 h1:xeWBM2nui+qnVvNM4S3foBhCAL2XgPU+a7FdpelbTq4=

--- a/shell.nix
+++ b/shell.nix
@@ -16,4 +16,4 @@
 ) {
   src =  ./.;
 }).shellNix
-# nix-direnv cache busting line: sha256-5In+C38s6liec6DYKUjDz+Dv1sJ9xe6OcWMoJ/lyocw=
+# nix-direnv cache busting line: sha256-h3KPqXE1Wvl1nfUmus0zWowaiqBIxz6eJT/+dIBEkOM=


### PR DESCRIPTION
(bumping in oss mostly to get it into corp, and we require them to be in sync
for now. But we do use this in derpserver too.)

Updates tailscale/corp#46884
