### PR TITLE
derp, cmd/derper: relay client app names to watchers, allow banning them

### DIFF
--- a/cmd/derper/derper.go
+++ b/cmd/derper/derper.go
@@ -79,9 +79,10 @@ var (
 	bootstrapDNS    = flag.String("bootstrap-dns-names", "", "optional comma-separated list of hostnames to make available at /bootstrap-dns")
 	unpublishedDNS  = flag.String("unpublished-bootstrap-dns-names", "", "optional comma-separated list of hostnames to make available at /bootstrap-dns and not publish in the list. If an entry contains a slash, the second part names a DNS record to poll for its TXT record with a `0` to `100` value for rollout percentage.")
 
-	verifyClients   = flag.Bool("verify-clients", false, "verify clients to this DERP server through a local tailscaled instance.")
-	verifyClientURL = flag.String("verify-client-url", "", "if non-empty, an admission controller URL for permitting client connections; see tailcfg.DERPAdmitClientRequest")
-	verifyFailOpen  = flag.Bool("verify-client-url-fail-open", true, "whether we fail open if --verify-client-url is unreachable")
+	verifyClients    = flag.Bool("verify-clients", false, "verify clients to this DERP server through a local tailscaled instance.")
+	verifyClientURL  = flag.String("verify-client-url", "", "if non-empty, an admission controller URL for permitting client connections; see tailcfg.DERPAdmitClientRequest")
+	verifyFailOpen   = flag.Bool("verify-client-url-fail-open", true, "whether we fail open if --verify-client-url is unreachable")
+	disallowAppNames = flag.String("disallow-app-names", "", "optional comma-separated list of client-advertised app names to refuse connections from. Trusted mesh peers are exempt.")
 
 	socket = flag.String("socket", "", "optional alternate path to tailscaled socket (only relevant when using --verify-clients)")
 
@@ -194,6 +195,9 @@ func main() {
 	s.SetTailscaledSocketPath(*socket)
 	s.SetVerifyClientURL(*verifyClientURL)
 	s.SetVerifyClientURLFailOpen(*verifyFailOpen)
+	if *disallowAppNames != "" {
+		s.SetDisallowedAppNames(strings.Split(*disallowAppNames, ","))
+	}
 	s.SetTCPWriteTimeout(*tcpWriteTimeout)
 	if *rateConfigPath != "" {
 		if err := s.LoadAndApplyRateConfig(*rateConfigPath); err != nil {

--- a/derp/client_test.go
+++ b/derp/client_test.go
@@ -7,11 +7,13 @@ import (
 	"bufio"
 	"bytes"
 	"net"
+	"net/netip"
 	"reflect"
 	"sync"
 	"testing"
 	"time"
 
+	"go4.org/mem"
 	"tailscale.com/tstest"
 	"tailscale.com/types/key"
 )
@@ -86,6 +88,82 @@ func TestClientRecv(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("got %#v; want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestClientRecvPeerPresent tests that the client can parse peerPresent
+// frames from servers of various eras: old servers that send fewer fields
+// than the client knows about, and newer servers that send trailing fields
+// the client doesn't know about, which it must ignore. This matters during
+// rollouts of new DERP servers, when a region's meshed nodes and watchers
+// run a mix of versions.
+func TestClientRecvPeerPresent(t *testing.T) {
+	keyb := bytes.Repeat([]byte{1}, KeyLen)
+	k := key.NodePublicFromRaw32(mem.B(keyb))
+	ipPort := []byte{
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 1, 2, 3, 4, // ::ffff:1.2.3.4
+		0x12, 0x34, // port 4660
+	}
+	wantIPPort := netip.MustParseAddrPort("1.2.3.4:4660")
+
+	frame := func(fields ...[]byte) []byte {
+		b := []byte{byte(FramePeerPresent), 0, 0, 0, 0}
+		for _, f := range fields {
+			b = append(b, f...)
+		}
+		b[4] = byte(len(b) - FrameHeaderLen)
+		return b
+	}
+
+	tests := []struct {
+		name  string
+		input []byte
+		want  PeerPresentMessage
+	}{
+		{
+			name:  "key_only_from_ancient_server",
+			input: frame(keyb),
+			want:  PeerPresentMessage{Key: k},
+		},
+		{
+			name:  "ip_port_from_old_server",
+			input: frame(keyb, ipPort),
+			want:  PeerPresentMessage{Key: k, IPPort: wantIPPort},
+		},
+		{
+			name:  "flags_from_current_server",
+			input: frame(keyb, ipPort, []byte{PeerPresentIsRegular}),
+			want:  PeerPresentMessage{Key: k, IPPort: wantIPPort, Flags: PeerPresentIsRegular},
+		},
+		{
+			name: "extra_fields_from_newer_server",
+			// A hypothetical newer server sending fields this client
+			// doesn't know about. They must be ignored.
+			input: frame(keyb, ipPort, []byte{PeerPresentIsRegular},
+				[]byte{3, 'a', 'b', 'c'}, []byte{0xde, 0xad}),
+			want: PeerPresentMessage{Key: k, IPPort: wantIPPort, Flags: PeerPresentIsRegular},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				nc:    dummyNetConn{},
+				br:    bufio.NewReader(bytes.NewReader(tt.input)),
+				logf:  t.Logf,
+				clock: &tstest.Clock{},
+			}
+			m, err := c.Recv()
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, ok := m.(PeerPresentMessage)
+			if !ok {
+				t.Fatalf("message type = %T; want PeerPresentMessage", m)
+			}
+			if got != tt.want {
+				t.Errorf("got %+v; want %+v", got, tt.want)
 			}
 		})
 	}

--- a/derp/client_test.go
+++ b/derp/client_test.go
@@ -138,12 +138,29 @@ func TestClientRecvPeerPresent(t *testing.T) {
 			want:  PeerPresentMessage{Key: k, IPPort: wantIPPort, Flags: PeerPresentIsRegular},
 		},
 		{
+			name:  "app_name_from_current_server",
+			input: frame(keyb, ipPort, []byte{PeerPresentIsRegular}, []byte{3, 'a', 'b', 'c'}),
+			want:  PeerPresentMessage{Key: k, IPPort: wantIPPort, Flags: PeerPresentIsRegular, AppName: "abc"},
+		},
+		{
 			name: "extra_fields_from_newer_server",
 			// A hypothetical newer server sending fields this client
 			// doesn't know about. They must be ignored.
 			input: frame(keyb, ipPort, []byte{PeerPresentIsRegular},
 				[]byte{3, 'a', 'b', 'c'}, []byte{0xde, 0xad}),
-			want: PeerPresentMessage{Key: k, IPPort: wantIPPort, Flags: PeerPresentIsRegular},
+			want: PeerPresentMessage{Key: k, IPPort: wantIPPort, Flags: PeerPresentIsRegular, AppName: "abc"},
+		},
+		{
+			name: "truncated_app_name_ignored",
+			// A buggy or malicious server sending an app name length
+			// that exceeds the frame.
+			input: frame(keyb, ipPort, []byte{PeerPresentIsRegular}, []byte{200, 'a', 'b', 'c'}),
+			want:  PeerPresentMessage{Key: k, IPPort: wantIPPort, Flags: PeerPresentIsRegular},
+		},
+		{
+			name:  "invalid_app_name_ignored",
+			input: frame(keyb, ipPort, []byte{PeerPresentIsRegular}, []byte{3, 0x01, 0x02, 0x03}),
+			want:  PeerPresentMessage{Key: k, IPPort: wantIPPort, Flags: PeerPresentIsRegular},
 		},
 	}
 	for _, tt := range tests {

--- a/derp/derp.go
+++ b/derp/derp.go
@@ -93,9 +93,12 @@ const (
 	// The message is at least 32 bytes (the public key of the peer that's
 	// connected). If there are at least 18 bytes remaining after that, it's the
 	// 16 byte IP + 2 byte BE uint16 port of the client. If there's another byte
-	// remaining after that, it's a PeerPresentFlags byte.
-	// While current servers send 41 bytes, old servers will send fewer, and newer
-	// servers might send more.
+	// remaining after that, it's a PeerPresentFlags byte. If there's another
+	// byte remaining after that, it's the length of the client's advertised
+	// app name (see ClientInfo.AppName), followed by that many bytes of app
+	// name.
+	// While current servers send at least 42 bytes, old servers will send
+	// fewer, and newer servers might send more.
 	FramePeerPresent = FrameType(0x09)
 
 	// FrameWatchConns is how one DERP node in a regional mesh

--- a/derp/derp_client.go
+++ b/derp/derp_client.go
@@ -88,9 +88,27 @@ func CanAckPings(v bool) ClientOpt {
 
 // AppName returns a ClientOpt to set an opaque app name string to
 // advertise to the DERP server for stats purposes. It is sent to the
-// server in the ClientInfo.
+// server in the ClientInfo. The name must be valid per [ValidAppName]
+// or NewClient returns an error.
 func AppName(name string) ClientOpt {
 	return clientOptFunc(func(o *clientOpt) { o.AppName = name })
+}
+
+// MaxAppNameLen is the maximum length in bytes of a [ClientInfo.AppName].
+const MaxAppNameLen = 32
+
+// ValidAppName reports whether name is a valid app name: at most
+// [MaxAppNameLen] bytes of printable ASCII. The empty string is valid.
+func ValidAppName(name string) bool {
+	if len(name) > MaxAppNameLen {
+		return false
+	}
+	for i := range len(name) {
+		if b := name[i]; b < ' ' || b > '~' {
+			return false
+		}
+	}
+	return true
 }
 
 func NewClient(privateKey key.NodePrivate, nc Conn, brw *bufio.ReadWriter, logf logger.Logf, opts ...ClientOpt) (*Client, error) {
@@ -100,6 +118,9 @@ func NewClient(privateKey key.NodePrivate, nc Conn, brw *bufio.ReadWriter, logf 
 			return nil, errors.New("nil ClientOpt")
 		}
 		o.update(&opt)
+	}
+	if !ValidAppName(opt.AppName) {
+		return nil, fmt.Errorf("invalid AppName %.40q", opt.AppName)
 	}
 	return newClient(privateKey, nc, brw, logf, opt)
 }
@@ -191,7 +212,9 @@ type ClientInfo struct {
 	IsProber bool `json:",omitempty"`
 
 	// AppName is an optional opaque app name string the client
-	// advertises to the server for stats purposes.
+	// advertises to the server for stats purposes. It must be
+	// valid per [ValidAppName] or the server rejects the
+	// connection.
 	AppName string `json:",omitempty"`
 }
 
@@ -409,6 +432,10 @@ type PeerPresentMessage struct {
 	IPPort netip.AddrPort
 	// Flags is a bitmask of info about the client.
 	Flags PeerPresentFlags
+	// AppName is the optional app name the client advertised in
+	// its ClientInfo, if any. It's empty if the client didn't
+	// send one or the server is too old to relay it.
+	AppName string
 }
 
 func (PeerPresentMessage) msg() {}
@@ -609,12 +636,27 @@ func (c *Client) recvTimeout(timeout time.Duration) (m ReceivedMessage, err erro
 				binary.BigEndian.Uint16(chunk[ipLen:]),
 			)
 
-			chunk, _, ok = cutLeadingN(remain, 1)
+			chunk, remain, ok = cutLeadingN(remain, 1)
 			if !ok {
 				// Older server which doesn't send PeerPresentFlags.
 				return msg, nil
 			}
 			msg.Flags = PeerPresentFlags(chunk[0])
+
+			chunk, remain, ok = cutLeadingN(remain, 1)
+			if !ok {
+				// Older server which doesn't send the app name.
+				return msg, nil
+			}
+			nameLen := int(chunk[0])
+			chunk, _, ok = cutLeadingN(remain, nameLen)
+			if !ok {
+				c.logf("[unexpected] short peerPresent app name from DERP server")
+				return msg, nil
+			}
+			if name := string(chunk); ValidAppName(name) {
+				msg.AppName = name
+			}
 			return msg, nil
 
 		case FrameRecvPacket:

--- a/derp/derp_test.go
+++ b/derp/derp_test.go
@@ -910,6 +910,76 @@ func TestWatch(t *testing.T) {
 	w3.wantGone(t, c1.pub)
 }
 
+// TestWatchAppName tests that the app name a client advertises in its
+// ClientInfo is relayed to watchers in peerPresent frames.
+func TestWatchAppName(t *testing.T) {
+	ctx := t.Context()
+
+	ts := newTestServer(t, ctx)
+	defer ts.close(t)
+
+	c1 := newTestClient(t, ts, "c1", func(nc net.Conn, priv key.NodePrivate, logf logger.Logf) (*Client, error) {
+		brw := bufio.NewReadWriter(bufio.NewReader(nc), bufio.NewWriter(nc))
+		c, err := derp.NewClient(priv, nc, brw, logf, derp.AppName("test-app"))
+		if err != nil {
+			return nil, err
+		}
+		waitConnect(t, c)
+		return c, nil
+	})
+
+	w := newTestWatcher(t, ts, "w")
+
+	want := map[key.NodePublic]string{
+		c1.pub: "test-app",
+		w.pub:  "",
+	}
+	for len(want) > 0 {
+		m, err := w.c.RecvTimeoutForTest(time.Second)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pp, ok := m.(derp.PeerPresentMessage)
+		if !ok {
+			t.Fatalf("unexpected message type %T", m)
+		}
+		wantName, ok := want[pp.Key]
+		if !ok {
+			t.Fatalf("peer present for unexpected peer %v", ts.keyName(pp.Key))
+		}
+		if pp.AppName != wantName {
+			t.Errorf("peer %v AppName = %q; want %q", ts.keyName(pp.Key), pp.AppName, wantName)
+		}
+		delete(want, pp.Key)
+	}
+}
+
+func TestValidAppName(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"", true},
+		{"some-client", true},
+		{"app with spaces 123!", true},
+		{strings.Repeat("x", 32), true},
+		{strings.Repeat("x", 33), false},
+		{"new\nline", false},
+		{"nul\x00", false},
+		{"emoji🐱", false},
+	}
+	for _, tt := range tests {
+		if got := derp.ValidAppName(tt.name); got != tt.want {
+			t.Errorf("ValidAppName(%q) = %v; want %v", tt.name, got, tt.want)
+		}
+	}
+
+	// NewClient should reject an invalid app name before touching the conn.
+	if _, err := derp.NewClient(key.NewNode(), nil, nil, t.Logf, derp.AppName("emoji🐱")); err == nil {
+		t.Error("NewClient with invalid app name: got nil error; want error")
+	}
+}
+
 func waitConnect(t testing.TB, c *Client) {
 	t.Helper()
 	if m, err := c.Recv(); err != nil {

--- a/derp/derpserver/derpserver.go
+++ b/derp/derpserver/derpserver.go
@@ -190,6 +190,10 @@ type Server struct {
 	verifyClientsURL         string
 	verifyClientsURLFailOpen bool
 
+	// disallowedAppNames, if non-nil, is the set of ClientInfo.AppName
+	// values that are not allowed to connect. Mesh peers are exempt.
+	disallowedAppNames set.Set[string]
+
 	perClientSendQueueDepth int // Sets the client send queue depth for the server.
 	tcpWriteTimeout         time.Duration
 	clock                   tstime.Clock
@@ -499,6 +503,15 @@ func (s *Server) SetVerifyClientURL(v string) {
 // admission controller URL is unreachable.
 func (s *Server) SetVerifyClientURLFailOpen(v bool) {
 	s.verifyClientsURLFailOpen = v
+}
+
+// SetDisallowedAppNames sets the list of client app names (as advertised
+// in their ClientInfo.AppName) that are not allowed to connect.
+// Trusted mesh peers are exempt.
+//
+// It must be called before serving begins.
+func (s *Server) SetDisallowedAppNames(names []string) {
+	s.disallowedAppNames = set.Of(names...)
 }
 
 // SetTailscaledSocketPath sets the unix socket path to use to talk to
@@ -813,7 +826,7 @@ func (s *Server) registerClient(c *sclient) {
 	if c.isNotIdealConn {
 		s.curClientsNotIdeal.Add(1)
 	}
-	s.broadcastPeerStateChangeLocked(c.key, c.remoteIPPort, c.presentFlags(), true)
+	s.broadcastPeerStateChangeLocked(c.key, c.remoteIPPort, c.presentFlags(), c.info.AppName, true)
 }
 
 // broadcastPeerStateChangeLocked enqueues a message to all watchers
@@ -821,13 +834,14 @@ func (s *Server) registerClient(c *sclient) {
 // presence changed.
 //
 // s.mu must be held.
-func (s *Server) broadcastPeerStateChangeLocked(peer key.NodePublic, ipPort netip.AddrPort, flags derp.PeerPresentFlags, present bool) {
+func (s *Server) broadcastPeerStateChangeLocked(peer key.NodePublic, ipPort netip.AddrPort, flags derp.PeerPresentFlags, appName string, present bool) {
 	for w := range s.watchers {
 		w.peerStateChange = append(w.peerStateChange, peerConnState{
 			peer:    peer,
 			present: present,
 			ipPort:  ipPort,
 			flags:   flags,
+			appName: appName,
 		})
 		go w.requestMeshUpdate()
 	}
@@ -865,7 +879,7 @@ func (s *Server) unregisterClient(c *sclient) {
 			delete(s.clientsMesh, c.key)
 			s.notePeerGoneFromRegionLocked(c.key)
 		}
-		s.broadcastPeerStateChangeLocked(c.key, netip.AddrPort{}, 0, false)
+		s.broadcastPeerStateChangeLocked(c.key, netip.AddrPort{}, 0, "", false)
 	} else {
 		c.debugLogf("removed duplicate client")
 		if dup.removeClient(c) {
@@ -1001,6 +1015,7 @@ func (s *Server) addWatcher(c *sclient) {
 			present: true,
 			ipPort:  ac.remoteIPPort,
 			flags:   ac.presentFlags(),
+			appName: ac.info.AppName,
 		})
 	}
 
@@ -1586,6 +1601,10 @@ func (s *Server) verifyClient(ctx context.Context, clientKey key.NodePublic, inf
 		return nil
 	}
 
+	if info != nil && s.disallowedAppNames.Contains(info.AppName) {
+		return fmt.Errorf("disallowed app name %q", info.AppName)
+	}
+
 	// tailscaled-based verification:
 	if s.verifyClientsLocalTailscaled {
 		_, err := s.localClient.WhoIsNodeKey(ctx, clientKey)
@@ -1758,6 +1777,9 @@ func (s *Server) recvClientKey(br *bufio.Reader) (clientKey key.NodePublic, info
 	if err := json.Unmarshal(msg, info); err != nil {
 		return zpub, nil, fmt.Errorf("msg: %v", err)
 	}
+	if !derp.ValidAppName(info.AppName) {
+		return zpub, nil, fmt.Errorf("invalid AppName %.40q", info.AppName)
+	}
 	return clientKey, info, nil
 }
 
@@ -1903,6 +1925,7 @@ type peerConnState struct {
 	ipPort  netip.AddrPort // if present, the peer's IP:port
 	peer    key.NodePublic
 	flags   derp.PeerPresentFlags
+	appName string // if present, the peer's self-reported app name
 	present bool
 }
 
@@ -2118,8 +2141,12 @@ func (c *sclient) sendPong(data [8]byte) error {
 }
 
 const (
-	peerGoneFrameLen    = derp.KeyLen + 1
-	peerPresentFrameLen = derp.KeyLen + 16 + 2 + 1 // 16 byte IP + 2 byte port + 1 byte flags
+	peerGoneFrameLen = derp.KeyLen + 1
+
+	// peerPresentBaseLen is the size of a peerPresent frame before its
+	// variable-length app name suffix: 16 byte IP + 2 byte port + 1 byte
+	// flags + 1 byte app name length.
+	peerPresentBaseLen = derp.KeyLen + 16 + 2 + 1 + 1
 )
 
 // sendPeerGone sends a peerGone frame, without flushing.
@@ -2143,17 +2170,20 @@ func (c *sclient) sendPeerGone(peer key.NodePublic, reason derp.PeerGoneReasonTy
 }
 
 // sendPeerPresent sends a peerPresent frame, without flushing.
-func (c *sclient) sendPeerPresent(peer key.NodePublic, ipPort netip.AddrPort, flags derp.PeerPresentFlags) error {
+func (c *sclient) sendPeerPresent(peer key.NodePublic, ipPort netip.AddrPort, flags derp.PeerPresentFlags, appName string) error {
 	c.setWriteDeadline()
-	if err := derp.WriteFrameHeader(c.bw.bw(), derp.FramePeerPresent, peerPresentFrameLen); err != nil {
+	frameLen := peerPresentBaseLen + len(appName)
+	if err := derp.WriteFrameHeader(c.bw.bw(), derp.FramePeerPresent, uint32(frameLen)); err != nil {
 		return err
 	}
-	payload := make([]byte, peerPresentFrameLen)
+	payload := make([]byte, frameLen)
 	_ = peer.AppendTo(payload[:0])
 	a16 := ipPort.Addr().As16()
 	copy(payload[derp.KeyLen:], a16[:])
 	binary.BigEndian.PutUint16(payload[derp.KeyLen+16:], ipPort.Port())
 	payload[derp.KeyLen+18] = byte(flags)
+	payload[derp.KeyLen+19] = byte(len(appName))
+	copy(payload[derp.KeyLen+20:], appName)
 	_, err := c.bw.Write(payload)
 	return err
 }
@@ -2189,7 +2219,7 @@ func (c *sclient) sendMeshUpdates() error {
 		for _, pcs := range batch {
 			var err error
 			if pcs.present {
-				err = c.sendPeerPresent(pcs.peer, pcs.ipPort, pcs.flags)
+				err = c.sendPeerPresent(pcs.peer, pcs.ipPort, pcs.flags, pcs.appName)
 			} else {
 				err = c.sendPeerGone(pcs.peer, derp.PeerGoneReasonDisconnected)
 			}

--- a/derp/derpserver/derpserver_test.go
+++ b/derp/derpserver/derpserver_test.go
@@ -12,14 +12,17 @@ import (
 	"crypto/x509"
 	"encoding/asn1"
 	"encoding/binary"
+	"encoding/json"
 	"expvar"
 	"fmt"
 	"log"
 	"net"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"testing/synctest"
@@ -129,6 +132,72 @@ func TestIsMeshPeer(t *testing.T) {
 				t.Errorf("%f allocations, want %f", allocs, tt.wantAllocs)
 			}
 		})
+	}
+}
+
+func TestVerifyClientDisallowedAppNames(t *testing.T) {
+	ctx := t.Context()
+	s := &Server{}
+	if err := s.SetMeshKey(testMeshKey); err != nil {
+		t.Fatal(err)
+	}
+	s.SetDisallowedAppNames([]string{"badapp", "worseapp"})
+
+	k := key.NewNode().Public()
+	ip := netip.MustParseAddr("2.3.4.5")
+
+	if err := s.verifyClient(ctx, k, &derp.ClientInfo{AppName: "badapp"}, ip); err == nil {
+		t.Error("disallowed app name: got nil error; want error")
+	}
+	if err := s.verifyClient(ctx, k, &derp.ClientInfo{AppName: "goodapp"}, ip); err != nil {
+		t.Errorf("allowed app name: unexpected error: %v", err)
+	}
+	if err := s.verifyClient(ctx, k, &derp.ClientInfo{}, ip); err != nil {
+		t.Errorf("empty app name: unexpected error: %v", err)
+	}
+
+	// Trusted mesh peers are exempt.
+	mk, err := key.ParseDERPMesh(testMeshKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.verifyClient(ctx, k, &derp.ClientInfo{AppName: "badapp", MeshKey: mk}, ip); err != nil {
+		t.Errorf("mesh peer with disallowed app name: unexpected error: %v", err)
+	}
+}
+
+func TestRecvClientKeyAppName(t *testing.T) {
+	serverPriv := key.NewNode()
+	s := New(serverPriv, t.Logf)
+	defer s.Close()
+
+	tests := []struct {
+		appName string
+		wantErr bool
+	}{
+		{"some-client", false},
+		{"", false},
+		{strings.Repeat("x", derp.MaxAppNameLen+1), true},
+		{"new\nline", true},
+	}
+	for _, tt := range tests {
+		clientPriv := key.NewNode()
+		msg, err := json.Marshal(derp.ClientInfo{AppName: tt.appName})
+		if err != nil {
+			t.Fatal(err)
+		}
+		payload := clientPriv.Public().AppendTo(nil)
+		payload = append(payload, clientPriv.SealTo(serverPriv.Public(), msg)...)
+
+		var buf bytes.Buffer
+		bw := bufio.NewWriter(&buf)
+		if err := derp.WriteFrame(bw, derp.FrameClientInfo, payload); err != nil {
+			t.Fatal(err)
+		}
+		_, _, err = s.recvClientKey(bufio.NewReader(&buf))
+		if gotErr := err != nil; gotErr != tt.wantErr {
+			t.Errorf("recvClientKey with AppName %.40q: err = %v; wantErr = %v", tt.appName, err, tt.wantErr)
+		}
 	}
 }
 


### PR DESCRIPTION
Clients can advertise an opaque app name in their ClientInfo but the
server previously did nothing with it.

Constrain app names to at most 32 bytes of printable ASCII, enforced
both in derp.NewClient and by the server when it parses the ClientInfo.

Extend the peerPresent frame, following its existing pattern of
appending optional fields, with a length-prefixed app name after the
flags byte, so trusted mesh watchers (other DERP nodes and stats
tools) can attribute connections by app. Old clients ignore the extra
bytes; old servers send frames without them.

Also add a derper --disallow-app-names flag taking a comma-separated
list of app names whose connections are refused, except for trusted
mesh peers.

Updates tailscale/corp#24454
