### PR TITLE
tsweb/varz: add goamd64_capable and goamd64_compiled default metrics

### DIFF
--- a/tsweb/varz/goamd64_linux_amd64.go
+++ b/tsweb/varz/goamd64_linux_amd64.go
@@ -1,0 +1,88 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !android
+
+package varz
+
+import (
+	"bytes"
+	"expvar"
+	"os"
+	"runtime/debug"
+	"strings"
+)
+
+func init() {
+	var capable any = hostGOAMD64Level()
+	expvar.Publish("gauge_goamd64_capable", expvar.Func(func() any { return capable }))
+	var compiled any = compiledGOAMD64Level()
+	expvar.Publish("gauge_goamd64_compiled", expvar.Func(func() any { return compiled }))
+}
+
+// goamd64LevelFlags maps each x86-64 microarchitecture level to the
+// /proc/cpuinfo flag names it requires beyond the previous level.
+// It matches the per-level feature checks in Go's runtime/asm_amd64.s.
+// Note that /proc/cpuinfo spells SSE3 as "pni" and LZCNT as "abm",
+// and the kernel clears the AVX and AVX-512 flags when the OS lacks
+// XSAVE support, so OSXSAVE needs no separate check.
+var goamd64LevelFlags = [...][]string{
+	2: {"cx16", "lahf_lm", "popcnt", "pni", "sse4_1", "sse4_2", "ssse3"},
+	3: {"abm", "avx", "avx2", "bmi1", "bmi2", "f16c", "fma", "movbe"},
+	4: {"avx512f", "avx512bw", "avx512cd", "avx512dq", "avx512vl"},
+}
+
+// hostGOAMD64Level returns the maximum GOAMD64 microarchitecture
+// level (1-4) that the host CPU supports, regardless of what level
+// this binary was compiled for. It returns 0 on error.
+func hostGOAMD64Level() int {
+	cpuinfo, err := os.ReadFile("/proc/cpuinfo")
+	if err != nil {
+		return 0
+	}
+	for line := range bytes.Lines(cpuinfo) {
+		name, rest, ok := bytes.Cut(line, []byte(":"))
+		if ok && string(bytes.TrimSpace(name)) == "flags" {
+			return goamd64Level(strings.Fields(string(rest)))
+		}
+	}
+	return 0
+}
+
+// goamd64Level returns the maximum GOAMD64 level (1-4) supported by
+// a CPU with the given /proc/cpuinfo flags.
+func goamd64Level(flags []string) int {
+	has := make(map[string]bool, len(flags))
+	for _, f := range flags {
+		has[f] = true
+	}
+	level := 1
+	for next := 2; next < len(goamd64LevelFlags); next++ {
+		for _, f := range goamd64LevelFlags[next] {
+			if !has[f] {
+				return level
+			}
+		}
+		level = next
+	}
+	return level
+}
+
+// compiledGOAMD64Level returns the GOAMD64 microarchitecture level
+// (1-4) that this binary was compiled for, as recorded in its build
+// info. It returns 0 if unknown.
+func compiledGOAMD64Level() int {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return 0
+	}
+	for _, s := range bi.Settings {
+		if s.Key == "GOAMD64" {
+			if v, ok := strings.CutPrefix(s.Value, "v"); ok && len(v) == 1 && v[0] >= '1' && v[0] <= '4' {
+				return int(v[0] - '0')
+			}
+			return 0
+		}
+	}
+	return 0
+}

--- a/tsweb/varz/goamd64_linux_amd64_test.go
+++ b/tsweb/varz/goamd64_linux_amd64_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !android
+
+package varz
+
+import (
+	"strings"
+	"testing"
+)
+
+const v4Flags = "fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov " +
+	"pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm " +
+	"constant_tsc rep_good nopl xtopology nonstop_tsc cpuid aperfmperf " +
+	"tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic " +
+	"movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor " +
+	"lahf_lm abm 3dnowprefetch invpcid_single pti fsgsbase tsc_adjust bmi1 " +
+	"avx2 smep bmi2 erms invpcid avx512f avx512dq rdseed adx smap clflushopt " +
+	"clwb avx512cd avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves"
+
+func withoutFlags(flags string, remove ...string) []string {
+	var out []string
+	fs := strings.Fields(flags)
+Outer:
+	for _, f := range fs {
+		for _, r := range remove {
+			if f == r {
+				continue Outer
+			}
+		}
+		out = append(out, f)
+	}
+	return out
+}
+
+func TestGoAMD64Level(t *testing.T) {
+	tests := []struct {
+		name  string
+		flags []string
+		want  int
+	}{
+		{"v4", withoutFlags(v4Flags), 4},
+		{"v3_no_avx512vl", withoutFlags(v4Flags, "avx512vl"), 3},
+		{"v3_no_avx512", withoutFlags(v4Flags, "avx512f", "avx512dq", "avx512cd", "avx512bw", "avx512vl"), 3},
+		{"v2_no_avx2", withoutFlags(v4Flags, "avx512f", "avx2"), 2},
+		{"v2_no_abm", withoutFlags(v4Flags, "avx512bw", "abm"), 2},
+		{"v1_no_popcnt", withoutFlags(v4Flags, "avx2", "popcnt"), 1},
+		{"v1_no_sse42", withoutFlags(v4Flags, "sse4_2"), 1},
+		{"empty", nil, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := goamd64Level(tt.flags); got != tt.want {
+				t.Errorf("goamd64Level = %d; want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHostGOAMD64Level(t *testing.T) {
+	got := hostGOAMD64Level()
+	t.Logf("hostGOAMD64Level = %d", got)
+	if got < 0 || got > 4 {
+		t.Errorf("out of range [0,4]")
+	}
+}
+
+func TestCompiledGOAMD64Level(t *testing.T) {
+	got := compiledGOAMD64Level()
+	t.Logf("compiledGOAMD64Level = %d", got)
+	if got < 1 || got > 4 {
+		t.Errorf("got %d; want in range [1,4] since test binaries have build info", got)
+	}
+}


### PR DESCRIPTION
To decide whether we can bump GOAMD64 for our production binaries, we
first need to know what x86-64 microarchitecture levels the fleet's
CPUs actually support. Add two gauges to the default metric set on
linux/amd64: goamd64_capable, the maximum GOAMD64 level the host CPU
supports per /proc/cpuinfo, and goamd64_compiled, the level the
running binary was built with per its build info. Both are computed
once at init and report 0 on error.

The per-level feature lists match the checks in Go's
runtime/asm_amd64.s.

Updates tailscale/corp#47099
