### PR TITLE
tsnet: don't panic in Close when Start failed before s.sys was set

### DIFF
--- a/tsnet/tsnet.go
+++ b/tsnet/tsnet.go
@@ -666,7 +666,16 @@ func (s *Server) close() {
 	}
 
 	wg.Wait()
-	s.sys.Bus.Get().Close()
+	// s.sys is only assigned partway through doInit, so it is still nil if
+	// Start failed before that point. Close is reachable in that state --
+	// Start is idempotent via initOnce and returns the stored initErr, so
+	// callers that `defer Close()` before checking the error land here.
+	// Use GetOK rather than Get so an unset Bus cannot panic either.
+	if s.sys != nil {
+		if bus, ok := s.sys.Bus.GetOK(); ok && bus != nil {
+			bus.Close()
+		}
+	}
 }
 
 func (s *Server) doInit() {

--- a/tsnet/tsnet_test.go
+++ b/tsnet/tsnet_test.go
@@ -3925,3 +3925,14 @@ func TestListenMultipleEphemeralPorts(t *testing.T) {
 		testMultipleEphemeral(t, lt)
 	})
 }
+
+// TestCloseBeforeStart verifies that Close on a Server whose Start never ran
+// (or failed early) does not panic. s.sys is assigned partway through doInit,
+// so it is still nil in that state, and close previously dereferenced
+// s.sys.Bus unconditionally.
+func TestCloseBeforeStart(t *testing.T) {
+	s := &Server{}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}


### PR DESCRIPTION
### Problem

`Server.close()` dereferences `s.sys.Bus` unconditionally:

```go
wg.Wait()
s.sys.Bus.Get().Close()
```

`s.sys` is only assigned partway through `doInit`, so it is still `nil` when `Start` fails before that point, and `Close` then panics with a nil pointer dereference.

`Close` is reachable in that state. `Start` is idempotent via `initOnce` and returns the stored `initErr`, so callers that `defer Close()` before checking the error land in `close()` with `s.sys == nil`:

```go
s := &tsnet.Server{...}
defer s.Close()      // panics if Start failed early
if err := s.Start(); err != nil {
    return err
}
```

Every other resource released a few lines above is already nil-guarded — `s.dialer`, `s.localAPIListener`, `s.loopbackListener`. This line was the outlier.

### Real-world impact

This is reachable from [libtailscale](https://github.com/tailscale/libtailscale) / TailscaleKit. When a tsnet start fails on darwin, the framework calls close on the way out, and the nil dereference surfaces to the app as `EXC_BAD_ACCESS` — which masks the underlying start error and makes the original failure much harder to diagnose.

### Fix

Guard on `s.sys`, and use `GetOK` rather than `Get` so an unset `Bus` returns `ok=false` instead of panicking via `SubSystem.Get`, which does:

```go
func (p *SubSystem[T]) Get() T {
	if !p.set {
		panic(fmt.Sprintf("%v is not set", reflect.TypeFor[T]().String()))
	}
	return p.v
}
```

In practice `tsd.NewSystem()` always sets `Bus`, so the `s.sys != nil` check is what fixes the crash; `GetOK` is defence in depth for any future path that builds a `System` without one.

### Test

Adds `TestCloseBeforeStart`. Verified it actually reproduces the bug — on `main` without this change:

```
--- FAIL: TestCloseBeforeStart (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference
FAIL	tailscale.com/tsnet
```

With the change:

```
ok  	tailscale.com/tsnet	0.571s
```

`gofmt`, `go build ./tsnet/` and `go vet ./tsnet/` are clean.

### Notes

We currently carry this as a local patch to the module cache when building TailscaleKit, which has to be re-applied on every dependency bump — upstreaming removes that. Happy to adjust the shape of the guard (plain `Get()` under the nil check, or hoisting it into a helper) if you'd prefer something more minimal.