### PR TITLE
types/key: rename NLPublic/Private to TLPublic/Private

### DIFF
--- a/client/local/tailnetlock.go
+++ b/client/local/tailnetlock.go
@@ -59,7 +59,7 @@ func (lc *Client) NetworkLockInit(ctx context.Context, keys []tka.Key, disableme
 
 // TailnetLockWrapPreauthKey wraps a pre-auth key with information to
 // enable unattended bringup in the locked tailnet.
-func (lc *Client) TailnetLockWrapPreauthKey(ctx context.Context, preauthKey string, tkaKey key.NLPrivate) (string, error) {
+func (lc *Client) TailnetLockWrapPreauthKey(ctx context.Context, preauthKey string, tkaKey key.TLPrivate) (string, error) {
 	encodedPrivate, err := tkaKey.MarshalText()
 	if err != nil {
 		return "", err
@@ -68,7 +68,7 @@ func (lc *Client) TailnetLockWrapPreauthKey(ctx context.Context, preauthKey stri
 	var b bytes.Buffer
 	type wrapRequest struct {
 		TSKey  string
-		TKAKey string // key.NLPrivate.MarshalText
+		TKAKey string // key.TLPrivate.MarshalText
 	}
 	if err := json.NewEncoder(&b).Encode(wrapRequest{TSKey: preauthKey, TKAKey: string(encodedPrivate)}); err != nil {
 		return "", err
@@ -82,7 +82,7 @@ func (lc *Client) TailnetLockWrapPreauthKey(ctx context.Context, preauthKey stri
 }
 
 // Deprecated: use [Client.TailnetLockWrapPreauthKey] instead.
-func (lc *Client) NetworkLockWrapPreauthKey(ctx context.Context, preauthKey string, tkaKey key.NLPrivate) (string, error) {
+func (lc *Client) NetworkLockWrapPreauthKey(ctx context.Context, preauthKey string, tkaKey key.TLPrivate) (string, error) {
 	return lc.TailnetLockWrapPreauthKey(ctx, preauthKey, tkaKey)
 }
 

--- a/cmd/tailscale/cli/tailnet-lock.go
+++ b/cmd/tailscale/cli/tailnet-lock.go
@@ -408,7 +408,7 @@ of the Tailscale network. Proceed with caution.
 
 // parseTLArgs parses a slice of strings into slices of tka.Key & disablement
 // values/secrets.
-// The keys encoded in args should be specified using their key.NLPublic.MarshalText
+// The keys encoded in args should be specified using their [key.TLPublic.MarshalText]
 // representation with an optional '?<votes>' suffix.
 // Disablement values or secrets must be encoded in hex with a prefix of 'disablement:' or
 // 'disablement-secret:'.
@@ -430,7 +430,7 @@ func parseTLArgs(args []string, parseKeys, parseDisablements bool) (keys []tka.K
 			return nil, nil, fmt.Errorf("parsing argument %d: expected value with \"disablement:\" or \"disablement-secret:\" prefix, got %q", i+1, a)
 		}
 
-		var nlpk key.NLPublic
+		var nlpk key.TLPublic
 		spl := strings.SplitN(a, "?", 2)
 		if err := nlpk.UnmarshalText([]byte(spl[0])); err != nil {
 			return nil, nil, fmt.Errorf("parsing key %d: %v", i+1, err)
@@ -511,7 +511,7 @@ func runTailnetLockSign(ctx context.Context, args []string) error {
 
 	var (
 		nodeKey     key.NodePublic
-		rotationKey key.NLPublic
+		rotationKey key.TLPublic
 	)
 
 	if len(args) == 0 || len(args) > 2 {
@@ -764,7 +764,7 @@ func wrapAuthKey(ctx context.Context, keyStr string, status *ipnstate.Status) er
 	// Generate a separate tailnet-lock key just for the credential signature.
 	// We use the free-form meta strings to mark a little bit of metadata about this
 	// key.
-	priv := key.NewNLPrivate()
+	priv := key.NewTLPrivate()
 	m := map[string]string{
 		"purpose":            "pre-auth key",
 		"wrapper_stableid":   string(status.Self.ID),

--- a/cmd/tailscale/cli/tailnet-lock_test.go
+++ b/cmd/tailscale/cli/tailnet-lock_test.go
@@ -217,9 +217,9 @@ func TestTailnetLockStatusOutput(t *testing.T) {
 	nodeKey2 := key.NodePublicFromRaw32(mem.B(bytes.Repeat([]byte{2}, 32)))
 	nodeKey3 := key.NodePublicFromRaw32(mem.B(bytes.Repeat([]byte{3}, 32)))
 
-	nlPub := key.NLPublicFromEd25519Unsafe(bytes.Repeat([]byte{4}, 32))
+	nlPub := key.TLPublicFromEd25519Unsafe(bytes.Repeat([]byte{4}, 32))
 
-	trustedNlPub := key.NLPublicFromEd25519Unsafe(bytes.Repeat([]byte{5}, 32))
+	trustedNlPub := key.TLPublicFromEd25519Unsafe(bytes.Repeat([]byte{5}, 32))
 
 	tailnetIPv4_A, tailnetIPv6_A := netip.MustParseAddr("100.99.99.99"), netip.MustParseAddr("fd7a:115c:a1e0::701:b62a")
 	tailnetIPv4_B, tailnetIPv6_B := netip.MustParseAddr("100.88.88.88"), netip.MustParseAddr("fd7a:115c:a1e0::4101:512f")

--- a/cmd/tl-longchain/tl-longchain.go
+++ b/cmd/tl-longchain/tl-longchain.go
@@ -78,7 +78,7 @@ func print(info string, nodeKey key.NodePublic, sig tka.NodeKeySignature) {
 	if ln := chainLength(sig); ln > *maxRotations {
 		log.Printf("%s: chain length %d, printing command to re-sign", info, ln)
 		wrapping, _ := sig.UnverifiedWrappingPublic()
-		fmt.Printf("tailscale lock sign %s %s\n", nodeKey, key.NLPublicFromEd25519Unsafe(wrapping).CLIString())
+		fmt.Printf("tailscale lock sign %s %s\n", nodeKey, key.TLPublicFromEd25519Unsafe(wrapping).CLIString())
 	} else {
 		log.Printf("%s: does not need re-signing", info)
 	}

--- a/cmd/vet/jsontags/iszero.go
+++ b/cmd/vet/jsontags/iszero.go
@@ -46,6 +46,8 @@ var PureIsZeroMethodsInTailscaleModule = map[string]set.Set[string]{
 	"tailscale.com/types/key": set.Of(
 		"NLPrivate",
 		"NLPublic",
+		"TLPrivate",
+		"TLPublic",
 		"DERPMesh",
 		"MachinePrivate",
 		"MachinePublic",

--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -749,7 +749,7 @@ func (c *Direct) doLogin(ctx context.Context, opt loginOpt) (mustRegen bool, new
 		oldNodeKey = persist.OldPrivateNodeKey.Public()
 	}
 	if persist.NetworkLockKey.IsZero() {
-		persist.NetworkLockKey = key.NewNLPrivate()
+		persist.NetworkLockKey = key.NewTLPrivate()
 	}
 
 	nlPub := persist.NetworkLockKey.Public()

--- a/feature/tailnetlock/tailnetlock_test.go
+++ b/feature/tailnetlock/tailnetlock_test.go
@@ -22,7 +22,7 @@ func TestHandleC2NDebugTKA(t *testing.T) {
 			return nil, nil
 		}
 
-		signerKey := key.NewNLPrivate()
+		signerKey := key.NewTLPrivate()
 		key1 := tka.Key{Kind: tka.Key25519, Public: signerKey.Public().Verifier(), Votes: 2}
 		state := tka.CreateStateForTest(key1)
 
@@ -34,7 +34,7 @@ func TestHandleC2NDebugTKA(t *testing.T) {
 
 		for range length - 1 {
 			updater := authority.NewUpdater(signerKey)
-			key2 := tka.Key{Kind: tka.Key25519, Public: key.NewNLPrivate().Public().Verifier(), Votes: 2}
+			key2 := tka.Key{Kind: tka.Key25519, Public: key.NewTLPrivate().Public().Verifier(), Votes: 2}
 			updater.AddKey(key2)
 			aums := must.Get(updater.Finalize(chonk))
 			must.Do(authority.Inform(chonk, aums))

--- a/ipn/ipnlocal/extension_host_test.go
+++ b/ipn/ipnlocal/extension_host_test.go
@@ -618,7 +618,7 @@ func TestExtensionHostProfileStateChangeCallback(t *testing.T) {
 						NodeID:            "12345",
 						PrivateNodeKey:    key.NewNode(),
 						OldPrivateNodeKey: key.NewNode(),
-						NetworkLockKey:    key.NewNLPrivate(),
+						NetworkLockKey:    key.NewTLPrivate(),
 						UserProfile: tailcfg.UserProfile{
 							ID:            12345,
 							LoginName:     "test@example.com",
@@ -635,7 +635,7 @@ func TestExtensionHostProfileStateChangeCallback(t *testing.T) {
 						NodeID:            "12345",
 						PrivateNodeKey:    key.NodePrivate{}, // stripped
 						OldPrivateNodeKey: key.NodePrivate{}, // stripped
-						NetworkLockKey:    key.NLPrivate{},   // stripped
+						NetworkLockKey:    key.TLPrivate{},   // stripped
 						UserProfile: tailcfg.UserProfile{
 							ID:            12345,
 							LoginName:     "test@example.com",
@@ -690,7 +690,7 @@ func TestExtensionHostProfileStateChangeCallback(t *testing.T) {
 							NodeID:            "12345",
 							PrivateNodeKey:    key.NewNode(),
 							OldPrivateNodeKey: key.NewNode(),
-							NetworkLockKey:    key.NewNLPrivate(),
+							NetworkLockKey:    key.NewTLPrivate(),
 							UserProfile: tailcfg.UserProfile{
 								ID:            12345,
 								LoginName:     "test@example.com",
@@ -706,7 +706,7 @@ func TestExtensionHostProfileStateChangeCallback(t *testing.T) {
 							NodeID:            "12345",
 							PrivateNodeKey:    key.NewNode(),
 							OldPrivateNodeKey: key.NewNode(),
-							NetworkLockKey:    key.NewNLPrivate(),
+							NetworkLockKey:    key.NewTLPrivate(),
 							UserProfile: tailcfg.UserProfile{
 								ID:            12345,
 								LoginName:     "test@example.com",
@@ -727,7 +727,7 @@ func TestExtensionHostProfileStateChangeCallback(t *testing.T) {
 							NodeID:            "12345",
 							PrivateNodeKey:    key.NodePrivate{}, // stripped
 							OldPrivateNodeKey: key.NodePrivate{}, // stripped
-							NetworkLockKey:    key.NLPrivate{},   // stripped
+							NetworkLockKey:    key.TLPrivate{},   // stripped
 							UserProfile: tailcfg.UserProfile{
 								ID:            12345,
 								LoginName:     "test@example.com",

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -1418,7 +1418,7 @@ func stripKeysFromPrefs(p ipn.PrefsView) ipn.PrefsView {
 	p2 := p.AsStruct()
 	p2.Persist.PrivateNodeKey = key.NodePrivate{}
 	p2.Persist.OldPrivateNodeKey = key.NodePrivate{}
-	p2.Persist.NetworkLockKey = key.NLPrivate{}
+	p2.Persist.NetworkLockKey = key.TLPrivate{}
 	p2.Persist.AttestationKey = nil
 	return p2.View()
 }

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -8824,7 +8824,7 @@ func TestStripKeysFromPrefs(t *testing.T) {
 		"Notify.Prefs.ж.Persist.NetworkLockKey": func() ipn.Notify {
 			return ipn.Notify{
 				Prefs: new((&ipn.Prefs{
-					Persist: &persist.Persist{NetworkLockKey: key.NewNLPrivate()},
+					Persist: &persist.Persist{NetworkLockKey: key.NewTLPrivate()},
 				}).View()),
 			}
 		},

--- a/ipn/ipnlocal/tailnet-lock.go
+++ b/ipn/ipnlocal/tailnet-lock.go
@@ -583,7 +583,7 @@ func (b *LocalBackend) TailnetLockStatus() *ipnstate.TailnetLockStatus {
 
 	var (
 		nodeKey *key.NodePublic
-		nlPriv  key.NLPrivate
+		nlPriv  key.TLPrivate
 	)
 	if p := b.pm.CurrentPrefs(); p.Valid() && p.Persist().Valid() && !p.Persist().PrivateNodeKey().IsZero() {
 		nkp := p.Persist().PublicNodeKey()
@@ -624,7 +624,7 @@ func (b *LocalBackend) TailnetLockStatus() *ipnstate.TailnetLockStatus {
 	for i, k := range keys {
 		outKeys[i] = ipnstate.TKAKey{
 			Kind:     k.Kind.String(),
-			Key:      key.NLPublicFromEd25519Unsafe(k.Public),
+			Key:      key.TLPublicFromEd25519Unsafe(k.Public),
 			Metadata: k.Meta,
 			Votes:    k.Votes,
 		}
@@ -696,7 +696,7 @@ func tkaStateFromPeer(p tailcfg.NodeView) ipnstate.TKAPeer {
 // Control has everything it needs to atomically enable tailnet lock.
 func (b *LocalBackend) TailnetLockInit(keys []tka.Key, disablementValues [][]byte, supportDisablement []byte) error {
 	var ourNodeKey key.NodePublic
-	var nlPriv key.NLPrivate
+	var nlPriv key.TLPrivate
 
 	b.mu.Lock()
 	if p := b.pm.CurrentPrefs(); p.Valid() && p.Persist().Valid() && !p.Persist().PrivateNodeKey().IsZero() {
@@ -838,7 +838,7 @@ func (b *LocalBackend) TailnetLockSign(nodeKey key.NodePublic, rotationPublic []
 		b.mu.Lock()
 		defer b.mu.Unlock()
 
-		var nlPriv key.NLPrivate
+		var nlPriv key.TLPrivate
 		if p := b.pm.CurrentPrefs(); p.Valid() && p.Persist().Valid() {
 			nlPriv = p.Persist().NetworkLockKey()
 		}
@@ -905,7 +905,7 @@ func (b *LocalBackend) TailnetLockModify(addKeys, removeKeys []tka.Key) (err err
 		return errors.New("no node-key: is tailscale logged in?")
 	}
 
-	var nlPriv key.NLPrivate
+	var nlPriv key.TLPrivate
 	if p := b.pm.CurrentPrefs(); p.Valid() && p.Persist().Valid() {
 		nlPriv = p.Persist().NetworkLockKey()
 	}
@@ -1124,7 +1124,7 @@ func (b *LocalBackend) TailnetLockGenerateRecoveryAUM(removeKeys []tkatype.KeyID
 	if b.tka == nil {
 		return nil, errTailnetLockNotActive
 	}
-	var nlPriv key.NLPrivate
+	var nlPriv key.TLPrivate
 	if p := b.pm.CurrentPrefs(); p.Valid() && p.Persist().Valid() {
 		nlPriv = p.Persist().NetworkLockKey()
 	}
@@ -1162,7 +1162,7 @@ func (b *LocalBackend) TailnetLockCosignRecoveryAUM(aum *tka.AUM) (*tka.AUM, err
 	if b.tka == nil {
 		return nil, errTailnetLockNotActive
 	}
-	var nlPriv key.NLPrivate
+	var nlPriv key.TLPrivate
 	if p := b.pm.CurrentPrefs(); p.Valid() && p.Persist().Valid() {
 		nlPriv = p.Persist().NetworkLockKey()
 	}
@@ -1223,7 +1223,7 @@ var tkaSuffixEncoder = base64.RawStdEncoding
 // The provided trusted tailnet-lock key is used to sign
 // a SigCredential structure, which is encoded along with the
 // private key and appended to the pre-auth key.
-func (b *LocalBackend) TailnetLockWrapPreauthKey(preauthKey string, tkaKey key.NLPrivate) (string, error) {
+func (b *LocalBackend) TailnetLockWrapPreauthKey(preauthKey string, tkaKey key.TLPrivate) (string, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.tka == nil {
@@ -1250,7 +1250,7 @@ func (b *LocalBackend) TailnetLockWrapPreauthKey(preauthKey string, tkaKey key.N
 }
 
 // Deprecated: use [LocalBackend.TailnetLockWrapPreauthKey] instead.
-func (b *LocalBackend) NetworkLockWrapPreauthKey(preauthKey string, tkaKey key.NLPrivate) (string, error) {
+func (b *LocalBackend) NetworkLockWrapPreauthKey(preauthKey string, tkaKey key.TLPrivate) (string, error) {
 	return b.TailnetLockWrapPreauthKey(preauthKey, tkaKey)
 }
 
@@ -1271,7 +1271,7 @@ func (b *LocalBackend) NetworkLockVerifySigningDeeplink(url string) tka.Deeplink
 	return b.TailnetLockVerifySigningDeeplink(url)
 }
 
-func signNodeKey(nodeInfo tailcfg.TKASignInfo, signer key.NLPrivate) (*tka.NodeKeySignature, error) {
+func signNodeKey(nodeInfo tailcfg.TKASignInfo, signer key.TLPrivate) (*tka.NodeKeySignature, error) {
 	p, err := nodeInfo.NodePublic.MarshalBinary()
 	if err != nil {
 		return nil, err

--- a/ipn/ipnlocal/tailnet-lock_test.go
+++ b/ipn/ipnlocal/tailnet-lock_test.go
@@ -105,7 +105,7 @@ func newLocalBackendForTKA(t *testing.T, varRoot string, client *http.Client, pm
 	}
 }
 
-func setupProfileManager(t *testing.T, nodePriv key.NodePrivate, nlPriv key.NLPrivate) *profileManager {
+func setupProfileManager(t *testing.T, nodePriv key.NodePrivate, nlPriv key.TLPrivate) *profileManager {
 	t.Helper()
 	pm := must.Get(newProfileManager(new(mem.Store), t.Logf, health.NewTracker(eventbustest.NewBus(t))))
 	must.Do(pm.SetPrefs((&ipn.Prefs{
@@ -134,7 +134,7 @@ func TestTKAEnablementFlow(t *testing.T) {
 
 	// Make a fake TKA authority, getting a usable genesis AUM which
 	// our mock server can communicate.
-	nlPriv := key.NewNLPrivate()
+	nlPriv := key.NewTLPrivate()
 	key := tka.Key{Kind: tka.Key25519, Public: nlPriv.Public().Verifier(), Votes: 2}
 	state := tka.CreateStateForTest(key)
 	chonk := tka.ChonkMem()
@@ -215,7 +215,7 @@ func TestTKADisablementFlow(t *testing.T) {
 
 	// Make a fake TKA authority, to seed local state.
 	disablementSecret := bytes.Repeat([]byte{0xa5}, 32)
-	nlPriv := key.NewNLPrivate()
+	nlPriv := key.NewTLPrivate()
 	key := tka.Key{Kind: tka.Key25519, Public: nlPriv.Public().Verifier(), Votes: 2}
 
 	pm := setupProfileManager(t, nodePriv, nlPriv)
@@ -299,7 +299,7 @@ func TestTKADisablementFlow(t *testing.T) {
 }
 
 func TestTKASync(t *testing.T) {
-	someKeyPriv := key.NewNLPrivate()
+	someKeyPriv := key.NewTLPrivate()
 	someKey := tka.Key{Kind: tka.Key25519, Public: someKeyPriv.Public().Verifier(), Votes: 1}
 
 	type tkaSyncScenario struct {
@@ -374,7 +374,7 @@ func TestTKASync(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			nodePriv := key.NewNode()
-			nlPriv := key.NewNLPrivate()
+			nlPriv := key.NewTLPrivate()
 			pm := setupProfileManager(t, nodePriv, nlPriv)
 
 			// Setup the tka authority on the control plane.
@@ -450,11 +450,11 @@ func TestTKASync(t *testing.T) {
 // Whenever we run a TKA sync and get new state from control, we compact the
 // local state.
 func TestTKASyncTriggersCompact(t *testing.T) {
-	someKeyPriv := key.NewNLPrivate()
+	someKeyPriv := key.NewTLPrivate()
 	someKey := tka.Key{Kind: tka.Key25519, Public: someKeyPriv.Public().Verifier(), Votes: 1}
 
 	nodePriv := key.NewNode()
-	nlPriv := key.NewNLPrivate()
+	nlPriv := key.NewTLPrivate()
 	pm := setupProfileManager(t, nodePriv, nlPriv)
 
 	// Create a clock, and roll it back by 30 days.
@@ -583,7 +583,7 @@ func TestTKASyncTriggersCompact(t *testing.T) {
 }
 
 func TestTKAFilterNetmap(t *testing.T) {
-	nlPriv := key.NewNLPrivate()
+	nlPriv := key.NewTLPrivate()
 	nlKey := tka.Key{Kind: tka.Key25519, Public: nlPriv.Public().Verifier(), Votes: 2}
 	state := tka.CreateStateForTest(nlKey)
 	storage := tka.ChonkMem()
@@ -610,13 +610,13 @@ func TestTKAFilterNetmap(t *testing.T) {
 	n4Sig.Signature[3] = 42 // mess up the signature
 	n4Sig.Signature[4] = 42 // mess up the signature
 
-	n5nl := key.NewNLPrivate()
+	n5nl := key.NewTLPrivate()
 	n5InitialSig, err := signNodeKey(tailcfg.TKASignInfo{NodePublic: n5.Public(), RotationPubkey: n5nl.Public().Verifier()}, nlPriv)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	resign := func(nl key.NLPrivate, currentSig tkatype.MarshaledSignature) (key.NodePrivate, tkatype.MarshaledSignature) {
+	resign := func(nl key.TLPrivate, currentSig tkatype.MarshaledSignature) (key.NodePrivate, tkatype.MarshaledSignature) {
 		nk := key.NewNode()
 		sig, err := tka.ResignNKS(nl, nk.Public(), currentSig)
 		if err != nil {
@@ -736,7 +736,7 @@ func TestTKADisable(t *testing.T) {
 
 	// Make a fake TKA authority, to seed local state.
 	disablementSecret := bytes.Repeat([]byte{0xa5}, 32)
-	nlPriv := key.NewNLPrivate()
+	nlPriv := key.NewTLPrivate()
 	key := tka.Key{Kind: tka.Key25519, Public: nlPriv.Public().Verifier(), Votes: 2}
 
 	pm := setupProfileManager(t, nodePriv, nlPriv)
@@ -802,7 +802,7 @@ func TestTKADisable(t *testing.T) {
 func TestTKASign(t *testing.T) {
 	nodePriv := key.NewNode()
 	toSign := key.NewNode()
-	nlPriv := key.NewNLPrivate()
+	nlPriv := key.NewTLPrivate()
 
 	pm := setupProfileManager(t, nodePriv, nlPriv)
 
@@ -843,7 +843,7 @@ func TestTKAForceDisable(t *testing.T) {
 	nodePriv := key.NewNode()
 
 	// Make a fake TKA authority, to seed local state.
-	nlPriv := key.NewNLPrivate()
+	nlPriv := key.NewTLPrivate()
 	key := tka.Key{Kind: tka.Key25519, Public: nlPriv.Public().Verifier(), Votes: 2}
 	state := tka.CreateStateForTest(key)
 
@@ -920,7 +920,7 @@ func TestTKAForceDisable(t *testing.T) {
 func TestTKAAffectedSigs(t *testing.T) {
 	nodePriv := key.NewNode()
 	// toSign := key.NewNode()
-	nlPriv := key.NewNLPrivate()
+	nlPriv := key.NewTLPrivate()
 
 	pm := setupProfileManager(t, nodePriv, nlPriv)
 
@@ -934,7 +934,7 @@ func TestTKAAffectedSigs(t *testing.T) {
 		t.Fatalf("tka.Create() failed: %v", err)
 	}
 
-	untrustedKey := key.NewNLPrivate()
+	untrustedKey := key.NewTLPrivate()
 	tcs := []struct {
 		name    string
 		makeSig func() *tka.NodeKeySignature
@@ -1024,9 +1024,9 @@ func TestTKAAffectedSigs(t *testing.T) {
 
 func TestTKARecoverCompromisedKeyFlow(t *testing.T) {
 	nodePriv := key.NewNode()
-	nlPriv := key.NewNLPrivate()
-	cosignPriv := key.NewNLPrivate()
-	compromisedPriv := key.NewNLPrivate()
+	nlPriv := key.NewTLPrivate()
+	cosignPriv := key.NewTLPrivate()
+	compromisedPriv := key.NewTLPrivate()
 
 	pm := setupProfileManager(t, nodePriv, nlPriv)
 

--- a/ipn/ipnstate/ipnstate.go
+++ b/ipn/ipnstate/ipnstate.go
@@ -93,7 +93,7 @@ type Status struct {
 // TKAKey describes a key trusted by tailnet lock.
 type TKAKey struct {
 	Kind     string
-	Key      key.NLPublic
+	Key      key.TLPublic
 	Metadata map[string]string
 	Votes    uint
 }
@@ -121,7 +121,7 @@ type TailnetLockStatus struct {
 
 	// PublicKey describes the node's tailnet-lock public key.
 	// It may be zero if the node has not logged in.
-	PublicKey key.NLPublic
+	PublicKey key.TLPublic
 
 	// NodeKey describes the node's current node-key. This field is not
 	// populated if the node is not operating (i.e. waiting for a login).

--- a/ipn/localapi/tailnetlock.go
+++ b/ipn/localapi/tailnetlock.go
@@ -159,14 +159,14 @@ func (h *Handler) serveTKAWrapPreauthKey(w http.ResponseWriter, r *http.Request)
 
 	type wrapRequest struct {
 		TSKey  string
-		TKAKey string // key.NLPrivate.MarshalText
+		TKAKey string // key.TLPrivate.MarshalText
 	}
 	var req wrapRequest
 	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 12*1024)).Decode(&req); err != nil {
 		http.Error(w, "invalid JSON body", http.StatusBadRequest)
 		return
 	}
-	var priv key.NLPrivate
+	var priv key.TLPrivate
 	if err := priv.UnmarshalText([]byte(req.TKAKey)); err != nil {
 		http.Error(w, "invalid JSON body", http.StatusBadRequest)
 		return

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -1307,7 +1307,7 @@ type RegisterRequest struct {
 
 	NodeKey    key.NodePublic
 	OldNodeKey key.NodePublic
-	NLKey      key.NLPublic
+	NLKey      key.TLPublic
 	Auth       *RegisterResponseAuth `json:",omitempty"`
 	// Expiry optionally specifies the requested key expiry.
 	// The server policy may override.

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -380,7 +380,7 @@ var _RegisterRequestCloneNeedsRegeneration = RegisterRequest(struct {
 	Version          CapabilityVersion
 	NodeKey          key.NodePublic
 	OldNodeKey       key.NodePublic
-	NLKey            key.NLPublic
+	NLKey            key.TLPublic
 	Auth             *RegisterResponseAuth
 	Expiry           time.Time
 	Followup         string

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -1343,7 +1343,7 @@ func (v *RegisterRequestView) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 func (v RegisterRequestView) Version() CapabilityVersion     { return v.ж.Version }
 func (v RegisterRequestView) NodeKey() key.NodePublic        { return v.ж.NodeKey }
 func (v RegisterRequestView) OldNodeKey() key.NodePublic     { return v.ж.OldNodeKey }
-func (v RegisterRequestView) NLKey() key.NLPublic            { return v.ж.NLKey }
+func (v RegisterRequestView) NLKey() key.TLPublic            { return v.ж.NLKey }
 func (v RegisterRequestView) Auth() RegisterResponseAuthView { return v.ж.Auth.View() }
 
 // Expiry optionally specifies the requested key expiry.
@@ -1406,7 +1406,7 @@ var _RegisterRequestViewNeedsRegeneration = RegisterRequest(struct {
 	Version          CapabilityVersion
 	NodeKey          key.NodePublic
 	OldNodeKey       key.NodePublic
-	NLKey            key.NLPublic
+	NLKey            key.TLPublic
 	Auth             *RegisterResponseAuth
 	Expiry           time.Time
 	Followup         string

--- a/tka/disabled_stub.go
+++ b/tka/disabled_stub.go
@@ -150,7 +150,7 @@ func DecodeWrappedAuthkey(wrappedAuthKey string, logf logger.Logf) (authKey stri
 	return wrappedAuthKey, false, nil, nil
 }
 
-func ResignNKS(priv key.NLPrivate, nodeKey key.NodePublic, oldNKS tkatype.MarshaledSignature) (tkatype.MarshaledSignature, error) {
+func ResignNKS(priv key.TLPrivate, nodeKey key.NodePublic, oldNKS tkatype.MarshaledSignature) (tkatype.MarshaledSignature, error) {
 	return nil, nil
 }
 

--- a/tka/key_test.go
+++ b/tka/key_test.go
@@ -65,11 +65,11 @@ func TestVerify25519(t *testing.T) {
 	}
 }
 
-func TestNLPrivate(t *testing.T) {
-	p := key.NewNLPrivate()
+func TestTLPrivate(t *testing.T) {
+	p := key.NewTLPrivate()
 	pub := p.Public()
 
-	// Test that key.NLPrivate implements Signer by making a new
+	// Test that key.TLPrivate implements Signer by making a new
 	// authority.
 	k := Key{Kind: Key25519, Public: pub.Verifier(), Votes: 1}
 	state := CreateStateForTest(k)

--- a/tka/sig.go
+++ b/tka/sig.go
@@ -122,11 +122,11 @@ func (s NodeKeySignature) String() string {
 			b.WriteString(indent + "Pubkey: " + pubKey + "\n")
 		}
 		if len(sig.KeyID) > 0 {
-			keyID := key.NLPublicFromEd25519Unsafe(sig.KeyID).CLIString()
+			keyID := key.TLPublicFromEd25519Unsafe(sig.KeyID).CLIString()
 			b.WriteString(indent + "KeyID: " + keyID + "\n")
 		}
 		if len(sig.WrappingPubkey) > 0 {
-			pubKey := key.NLPublicFromEd25519Unsafe(sig.WrappingPubkey).CLIString()
+			pubKey := key.TLPublicFromEd25519Unsafe(sig.WrappingPubkey).CLIString()
 			b.WriteString(indent + "WrappingPubkey: " + pubKey + "\n")
 		}
 		if sig.Nested != nil {
@@ -357,7 +357,7 @@ func (s *NodeKeySignature) rotationDetails() (*RotationDetails, error) {
 // The signature itself is a SigRotation signature, which embeds the old signature
 // and certifies the new node-key as a replacement for the old by signing the new
 // signature with RotationPubkey (which is the node's own tailnet-lock key).
-func ResignNKS(priv key.NLPrivate, nodeKey key.NodePublic, oldNKS tkatype.MarshaledSignature) (tkatype.MarshaledSignature, error) {
+func ResignNKS(priv key.TLPrivate, nodeKey key.NodePublic, oldNKS tkatype.MarshaledSignature) (tkatype.MarshaledSignature, error) {
 	var oldSig NodeKeySignature
 	if err := oldSig.Unserialize(oldNKS); err != nil {
 		return nil, fmt.Errorf("decoding NKS: %w", err)
@@ -393,7 +393,7 @@ func ResignNKS(priv key.NLPrivate, nodeKey key.NodePublic, oldNKS tkatype.Marsha
 
 // maybeTrimRotationSignatureChain truncates rotation signature chain to ensure
 // it contains no more than 15 node keys.
-func maybeTrimRotationSignatureChain(sig NodeKeySignature, priv key.NLPrivate) (NodeKeySignature, error) {
+func maybeTrimRotationSignatureChain(sig NodeKeySignature, priv key.TLPrivate) (NodeKeySignature, error) {
 	if sig.SigKind != SigRotation {
 		return sig, nil
 	}

--- a/tka/sig_test.go
+++ b/tka/sig_test.go
@@ -506,7 +506,7 @@ func TestResignNKS(t *testing.T) {
 	authKey := Key{Kind: Key25519, Public: authPub, Votes: 2}
 
 	// Node's own tailnet lock key used to sign rotation signatures.
-	tlPriv := key.NewNLPrivate()
+	tlPriv := key.NewTLPrivate()
 
 	// The original (oldest) node key, signed by a signing node.
 	origNode := key.NewNode()

--- a/tka/tailchonk_test.go
+++ b/tka/tailchonk_test.go
@@ -219,7 +219,7 @@ func BenchmarkTailchonkFSOpenLongChain(b *testing.B) {
 	// size does not depend on checkpoint cadence.
 	const targetAUMs = maxScanIterations
 
-	signer := key.NewNLPrivate()
+	signer := key.NewTLPrivate()
 	trustedKey := Key{Kind: Key25519, Public: signer.Public().Verifier(), Votes: 1}
 	storage := ChonkMem()
 	authority, _, err := Create(storage, CreateStateForTest(trustedKey), signer)
@@ -694,9 +694,9 @@ func TestCompact(t *testing.T) {
 }
 
 func TestCompactLongButYoung(t *testing.T) {
-	ourPriv := key.NewNLPrivate()
+	ourPriv := key.NewTLPrivate()
 	ourKey := Key{Kind: Key25519, Public: ourPriv.Public().Verifier(), Votes: 1}
-	someOtherKey := Key{Kind: Key25519, Public: key.NewNLPrivate().Public().Verifier(), Votes: 1}
+	someOtherKey := Key{Kind: Key25519, Public: key.NewTLPrivate().Public().Verifier(), Votes: 1}
 	state := CreateStateForTest(ourKey, someOtherKey)
 
 	storage := ChonkMem()

--- a/tka/tka_test.go
+++ b/tka/tka_test.go
@@ -492,10 +492,10 @@ func TestAuthorityInformLinear(t *testing.T) {
 }
 
 func TestInteropWithNLKey(t *testing.T) {
-	priv1 := key.NewNLPrivate()
+	priv1 := key.NewTLPrivate()
 	pub1 := priv1.Public()
-	pub2 := key.NewNLPrivate().Public()
-	pub3 := key.NewNLPrivate().Public()
+	pub2 := key.NewTLPrivate().Public()
+	pub3 := key.NewTLPrivate().Public()
 
 	state := CreateStateForTest(
 		Key{Kind: Key25519, Votes: 1, Public: pub1.KeyID()},

--- a/tsnet/tailnetlock_test.go
+++ b/tsnet/tailnetlock_test.go
@@ -123,7 +123,7 @@ func setupTailnetLockedServer(t *testing.T, ctx context.Context, extraTrustedKey
 // (unexported) signNodeKey in ipn/ipnlocal/tailnet-lock.go, replicated
 // here so tsnet tests can mint valid signatures without cyclically
 // depending on ipnlocal internals.
-func signNodeKeyForTest(t *testing.T, nodeKey key.NodePublic, nlPriv key.NLPrivate) tkatype.MarshaledSignature {
+func signNodeKeyForTest(t *testing.T, nodeKey key.NodePublic, nlPriv key.TLPrivate) tkatype.MarshaledSignature {
 	t.Helper()
 	pub, err := nodeKey.MarshalBinary()
 	if err != nil {
@@ -151,7 +151,7 @@ func signNodeKeyForTest(t *testing.T, nodeKey key.NodePublic, nlPriv key.NLPriva
 // [LocalBackend.UpdateNetmapDelta]. That makes the absence-of-fixture
 // assertion race-free without having to wait a fixed timeout for
 // "nothing to happen".
-func signedMarkerPeer(t *testing.T, nlPriv key.NLPrivate) *tailcfg.Node {
+func signedMarkerPeer(t *testing.T, nlPriv key.TLPrivate) *tailcfg.Node {
 	t.Helper()
 	markerKey := key.NewNode().Public()
 	markerAddr := netip.MustParsePrefix("100.64.99.250/32")
@@ -178,7 +178,7 @@ func signedMarkerPeer(t *testing.T, nlPriv key.NLPrivate) *tailcfg.Node {
 // [LocalBackend.NetMapWithPeers]. markerNL must be a private NL key
 // whose public verifier is trusted by the tailnet-lock state on s
 // (e.g. an extra key passed to [setupTailnetLockedServer]).
-func injectPeersChangedAndAssertFiltered(t *testing.T, ctx context.Context, s *Server, control *testcontrol.Server, dst key.NodePublic, badPeer *tailcfg.Node, markerNL key.NLPrivate) {
+func injectPeersChangedAndAssertFiltered(t *testing.T, ctx context.Context, s *Server, control *testcontrol.Server, dst key.NodePublic, badPeer *tailcfg.Node, markerNL key.TLPrivate) {
 	t.Helper()
 	marker := signedMarkerPeer(t, markerNL)
 	if !control.AddRawMapResponse(dst, &tailcfg.MapResponse{
@@ -243,7 +243,7 @@ func TestTailnetLockFiltersUnsignedDeltaPeer(t *testing.T) {
 
 	// Trust an extra NL key the test holds so it can mint signed marker
 	// peers for delta-sync below.
-	markerNL := key.NewNLPrivate()
+	markerNL := key.NewTLPrivate()
 	s1, control, s1Key := setupTailnetLockedServer(t, ctx, tka.Key{
 		Kind:   tka.Key25519,
 		Public: markerNL.Public().Verifier(),
@@ -297,7 +297,7 @@ func TestTailnetLockFiltersUnsignedDeltaPeerReplacement(t *testing.T) {
 	// Trust an extra NL key the test holds, so the test can mint valid
 	// signatures for the fake peer without colluding with the node's
 	// own NL private key (which lives only in s1's prefs).
-	testNL := key.NewNLPrivate()
+	testNL := key.NewTLPrivate()
 	s1, control, s1Key := setupTailnetLockedServer(t, ctx, tka.Key{
 		Kind:   tka.Key25519,
 		Public: testNL.Public().Verifier(),
@@ -372,7 +372,7 @@ func TestTailnetLockFiltersDeltaPeerWithInvalidSignature(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 120*time.Second)
 	defer cancel()
 
-	testNL := key.NewNLPrivate()
+	testNL := key.NewTLPrivate()
 	s1, control, s1Key := setupTailnetLockedServer(t, ctx, tka.Key{
 		Kind:   tka.Key25519,
 		Public: testNL.Public().Verifier(),

--- a/tstest/integration/integration.go
+++ b/tstest/integration/integration.go
@@ -1271,9 +1271,9 @@ func (n *TestNode) PublicKey() string {
 	return st.Self.PublicKey
 }
 
-// NLPublicKey returns the hex-encoded tailnet lock public key of
+// TLPublicKey returns the hex-encoded tailnet lock public key of
 // this node, e.g. `tlpub:123456abc`
-func (n *TestNode) NLPublicKey() string {
+func (n *TestNode) TLPublicKey() string {
 	tb := n.env.t
 	tb.Helper()
 	cmd := n.Tailscale("lock", "status", "--json")
@@ -1288,6 +1288,11 @@ func (n *TestNode) NLPublicKey() string {
 		tb.Fatalf("decoding `tailscale lock status` JSON: %v\njson:\n%s", err, out)
 	}
 	return st.PublicKey
+}
+
+// Deprecated: use [TestNode.TLPublicKey] instead.
+func (n *TestNode) NLPublicKey() string {
+	return n.TLPublicKey()
 }
 
 // trafficTrap is an HTTP proxy handler to note whether any

--- a/tstest/integration/integration_test.go
+++ b/tstest/integration/integration_test.go
@@ -2533,7 +2533,7 @@ func TestTailnetLock(t *testing.T) {
 		initCmd := signing1.Tailscale("lock", "init",
 			"--gen-disablements", "10",
 			"--confirm",
-			signing1.NLPublicKey(), signing2.NLPublicKey(),
+			signing1.TLPublicKey(), signing2.TLPublicKey(),
 		)
 		out, err := initCmd.CombinedOutput()
 		if err != nil {

--- a/types/key/tl.go
+++ b/types/key/tl.go
@@ -13,37 +13,46 @@ import (
 )
 
 const (
-	// nlPrivateHexPrefix is the prefix used to identify a
+	// tlPrivateHexPrefix is the prefix used to identify a
 	// hex-encoded tailnet-lock key.
-	nlPrivateHexPrefix = "nlpriv:"
+	//
+	// "nl" is a reference to "Network Lock", the pre-release name for
+	// Tailnet Lock.
+	tlPrivateHexPrefix = "nlpriv:"
 
-	// nlPublicHexPrefix is the prefix used to identify the public
+	// tlPublicHexPrefix is the prefix used to identify the public
 	// side of a hex-encoded tailnet-lock key.
-	nlPublicHexPrefix = "nlpub:"
+	//
+	// "nl" is a reference to "Network Lock", the pre-release name for
+	// Tailnet Lock.
+	tlPublicHexPrefix = "nlpub:"
 
-	// nlPublicHexPrefixCLI is the prefix used for tailnet-lock keys
+	// tlPublicHexPrefixCLI is the prefix used for tailnet-lock keys
 	// when shown on the CLI.
 	// It's not practical for us to change the prefix everywhere due to
 	// compatibility with existing clients, but we can support both prefixes
 	// as well as use the CLI form when presenting to the user.
-	nlPublicHexPrefixCLI = "tlpub:"
+	tlPublicHexPrefixCLI = "tlpub:"
 )
 
-// NLPrivate is a node-managed tailnet-lock key, used for signing
+// TLPrivate is a node-managed tailnet-lock key, used for signing
 // node-key signatures and authority update messages.
-type NLPrivate struct {
+type TLPrivate struct {
 	_ structs.Incomparable // because == isn't constant-time
 	k [ed25519.PrivateKeySize]byte
 }
 
+// Deprecated: use [TLPrivate] instead.
+type NLPrivate = TLPrivate
+
 // IsZero reports whether k is the zero value.
-func (k NLPrivate) IsZero() bool {
-	empty := NLPrivate{}
+func (k TLPrivate) IsZero() bool {
+	empty := TLPrivate{}
 	return subtle.ConstantTimeCompare(k.k[:], empty.k[:]) == 1
 }
 
-// NewNLPrivate creates and returns a new tailnet-lock key.
-func NewNLPrivate() NLPrivate {
+// NewTLPrivate creates and returns a new tailnet-lock key.
+func NewTLPrivate() TLPrivate {
 	// ed25519.GenerateKey 'clamps' the key, not that it
 	// matters given we don't do Diffie-Hellman.
 	_, priv, err := ed25519.GenerateKey(nil) // nil == crypto/rand
@@ -51,40 +60,45 @@ func NewNLPrivate() NLPrivate {
 		panic(err)
 	}
 
-	var out NLPrivate
+	var out TLPrivate
 	copy(out.k[:], priv)
 	return out
 }
 
+// Deprecated: use [NewTLPrivate] instead.
+func NewNLPrivate() TLPrivate {
+	return NewTLPrivate()
+}
+
 // MarshalText implements encoding.TextUnmarshaler.
-func (k *NLPrivate) UnmarshalText(b []byte) error {
-	return parseHex(k.k[:], mem.B(b), mem.S(nlPrivateHexPrefix))
+func (k *TLPrivate) UnmarshalText(b []byte) error {
+	return parseHex(k.k[:], mem.B(b), mem.S(tlPrivateHexPrefix))
 }
 
 // AppendText implements encoding.TextAppender.
-func (k NLPrivate) AppendText(b []byte) ([]byte, error) {
-	return appendHexKey(b, nlPrivateHexPrefix, k.k[:]), nil
+func (k TLPrivate) AppendText(b []byte) ([]byte, error) {
+	return appendHexKey(b, tlPrivateHexPrefix, k.k[:]), nil
 }
 
 // MarshalText implements encoding.TextMarshaler.
-func (k NLPrivate) MarshalText() ([]byte, error) {
+func (k TLPrivate) MarshalText() ([]byte, error) {
 	return k.AppendText(nil)
 }
 
 // Equal reports whether k and other are the same key.
-func (k NLPrivate) Equal(other NLPrivate) bool {
+func (k TLPrivate) Equal(other TLPrivate) bool {
 	return subtle.ConstantTimeCompare(k.k[:], other.k[:]) == 1
 }
 
 // Public returns the public component of this key.
-func (k NLPrivate) Public() NLPublic {
-	var out NLPublic
+func (k TLPrivate) Public() TLPublic {
+	var out TLPublic
 	copy(out.k[:], ed25519.PrivateKey(k.k[:]).Public().(ed25519.PublicKey))
 	return out
 }
 
 // KeyID returns an identifier for this key.
-func (k NLPrivate) KeyID() tkatype.KeyID {
+func (k TLPrivate) KeyID() tkatype.KeyID {
 	// The correct way to compute this is:
 	// return tka.Key{
 	// 	Kind:   tka.Key25519,
@@ -99,7 +113,7 @@ func (k NLPrivate) KeyID() tkatype.KeyID {
 }
 
 // SignAUM implements tka.Signer.
-func (k NLPrivate) SignAUM(sigHash tkatype.AUMSigHash) ([]tkatype.Signature, error) {
+func (k TLPrivate) SignAUM(sigHash tkatype.AUMSigHash) ([]tkatype.Signature, error) {
 	return []tkatype.Signature{{
 		KeyID:     k.KeyID(),
 		Signature: ed25519.Sign(ed25519.PrivateKey(k.k[:]), sigHash[:]),
@@ -107,44 +121,52 @@ func (k NLPrivate) SignAUM(sigHash tkatype.AUMSigHash) ([]tkatype.Signature, err
 }
 
 // SignNKS signs the tka.NodeKeySignature identified by sigHash.
-func (k NLPrivate) SignNKS(sigHash tkatype.NKSSigHash) ([]byte, error) {
+func (k TLPrivate) SignNKS(sigHash tkatype.NKSSigHash) ([]byte, error) {
 	return ed25519.Sign(ed25519.PrivateKey(k.k[:]), sigHash[:]), nil
 }
 
-// NLPublic is the public portion of a NLPrivate.
-type NLPublic struct {
+// TLPublic is the public portion of a [TLPrivate].
+type TLPublic struct {
 	k [ed25519.PublicKeySize]byte
 }
 
-// NLPublicFromEd25519Unsafe converts an ed25519 public key into
-// a type of NLPublic.
+// Deprecated: use [TLPublic] instead.
+type NLPublic = TLPublic
+
+// TLPublicFromEd25519Unsafe converts an ed25519 public key into
+// a type of [TLPublic].
 //
 // New uses of this function should be avoided, as it's possible to
-// accidentally construct an NLPublic from a non tailnet-lock key.
-func NLPublicFromEd25519Unsafe(public ed25519.PublicKey) NLPublic {
-	var out NLPublic
+// accidentally construct an TLPublic from a non tailnet-lock key.
+func TLPublicFromEd25519Unsafe(public ed25519.PublicKey) TLPublic {
+	var out TLPublic
 	copy(out.k[:], public)
 	return out
+}
+
+// Deprecated: use [TLPublicFromEd25519Unsafe] instead.
+func NLPublicFromEd25519Unsafe(public ed25519.PublicKey) TLPublic {
+	return TLPublicFromEd25519Unsafe(public)
 }
 
 // UnmarshalText implements encoding.TextUnmarshaler. This function
 // is able to decode both the CLI form (tlpub:<hex>) & the
 // regular form (nlpub:<hex>).
-func (k *NLPublic) UnmarshalText(b []byte) error {
-	if mem.HasPrefix(mem.B(b), mem.S(nlPublicHexPrefix)) {
-		return parseHex(k.k[:], mem.B(b), mem.S(nlPublicHexPrefix))
+func (k *TLPublic) UnmarshalText(b []byte) error {
+	if mem.HasPrefix(mem.B(b), mem.S(tlPublicHexPrefix)) {
+		return parseHex(k.k[:], mem.B(b), mem.S(tlPublicHexPrefix))
 	}
-	return parseHex(k.k[:], mem.B(b), mem.S(nlPublicHexPrefixCLI))
+	return parseHex(k.k[:], mem.B(b), mem.S(tlPublicHexPrefixCLI))
 }
 
 // AppendText implements encoding.TextAppender.
-func (k NLPublic) AppendText(b []byte) ([]byte, error) {
-	return appendHexKey(b, nlPublicHexPrefix, k.k[:]), nil
+func (k TLPublic) AppendText(b []byte) ([]byte, error) {
+	return appendHexKey(b, tlPublicHexPrefix, k.k[:]), nil
 }
 
 // MarshalText implements encoding.TextMarshaler, emitting a
 // representation of the form nlpub:<hex>.
-func (k NLPublic) MarshalText() ([]byte, error) {
+func (k TLPublic) MarshalText() ([]byte, error) {
 	return k.AppendText(nil)
 }
 
@@ -152,27 +174,27 @@ func (k NLPublic) MarshalText() ([]byte, error) {
 // with tailnet lock commands, of the form tlpub:<hex> instead of
 // the nlpub:<hex> form emitted by MarshalText. Both forms can
 // be decoded by UnmarshalText.
-func (k NLPublic) CLIString() string {
-	return string(appendHexKey(nil, nlPublicHexPrefixCLI, k.k[:]))
+func (k TLPublic) CLIString() string {
+	return string(appendHexKey(nil, tlPublicHexPrefixCLI, k.k[:]))
 }
 
 // Verifier returns a ed25519.PublicKey that can be used to
 // verify signatures.
-func (k NLPublic) Verifier() ed25519.PublicKey {
+func (k TLPublic) Verifier() ed25519.PublicKey {
 	return ed25519.PublicKey(k.k[:])
 }
 
 // IsZero reports whether k is the zero value.
-func (k NLPublic) IsZero() bool {
-	return k.Equal(NLPublic{})
+func (k TLPublic) IsZero() bool {
+	return k.Equal(TLPublic{})
 }
 
 // Equal reports whether k and other are the same key.
-func (k NLPublic) Equal(other NLPublic) bool {
+func (k TLPublic) Equal(other TLPublic) bool {
 	return subtle.ConstantTimeCompare(k.k[:], other.k[:]) == 1
 }
 
 // KeyID returns a tkatype.KeyID that can be used with a tka.Authority.
-func (k NLPublic) KeyID() tkatype.KeyID {
+func (k TLPublic) KeyID() tkatype.KeyID {
 	return k.k[:]
 }

--- a/types/key/tl_test.go
+++ b/types/key/tl_test.go
@@ -8,41 +8,41 @@ import (
 	"testing"
 )
 
-func TestNLPrivate(t *testing.T) {
-	p := NewNLPrivate()
+func TestTLPrivate(t *testing.T) {
+	p := NewTLPrivate()
 
 	encoded, err := p.MarshalText()
 	if err != nil {
 		t.Fatal(err)
 	}
-	var decoded NLPrivate
+	var decoded TLPrivate
 	if err := decoded.UnmarshalText(encoded); err != nil {
 		t.Fatal(err)
 	}
 	if !bytes.Equal(decoded.k[:], p.k[:]) {
-		t.Error("decoded and generated NLPrivate bytes differ")
+		t.Error("decoded and generated TLPrivate bytes differ")
 	}
 
-	// Test NLPublic
+	// Test TLPublic
 	pub := p.Public()
 	encoded, err = pub.MarshalText()
 	if err != nil {
 		t.Fatal(err)
 	}
-	var decodedPub NLPublic
+	var decodedPub TLPublic
 	if err := decodedPub.UnmarshalText(encoded); err != nil {
 		t.Fatal(err)
 	}
 	if !bytes.Equal(decodedPub.k[:], pub.k[:]) {
-		t.Error("decoded and generated NLPublic bytes differ")
+		t.Error("decoded and generated TLPublic bytes differ")
 	}
 
 	// Test decoding with CLI prefix: 'nlpub:' => 'tlpub:'
-	decodedPub = NLPublic{}
+	decodedPub = TLPublic{}
 	if err := decodedPub.UnmarshalText([]byte(pub.CLIString())); err != nil {
 		t.Fatal(err)
 	}
 	if !bytes.Equal(decodedPub.k[:], pub.k[:]) {
-		t.Error("decoded and generated NLPublic bytes differ (CLI prefix)")
+		t.Error("decoded and generated TLPublic bytes differ (CLI prefix)")
 	}
 }

--- a/types/key/util.go
+++ b/types/key/util.go
@@ -129,7 +129,7 @@ func PrivateTypesForTest() set.Set[reflect.Type] {
 		reflect.TypeFor[DiscoPrivate](),
 		reflect.TypeFor[MachinePrivate](),
 		reflect.TypeFor[NodePrivate](),
-		reflect.TypeFor[NLPrivate](),
+		reflect.TypeFor[TLPrivate](),
 		reflect.TypeFor[HardwareAttestationKey](),
 	)
 }

--- a/types/persist/persist.go
+++ b/types/persist/persist.go
@@ -27,7 +27,7 @@ type Persist struct {
 
 	// NetworkLockKey is the node's Tailnet Lock private key.
 	// "Network Lock" was the pre-release name for Tailnet Lock.
-	NetworkLockKey key.NLPrivate
+	NetworkLockKey key.TLPrivate
 
 	NodeID         tailcfg.StableNodeID
 	AttestationKey key.HardwareAttestationKey `json:",omitzero"`

--- a/types/persist/persist_clone.go
+++ b/types/persist/persist_clone.go
@@ -33,7 +33,7 @@ var _PersistCloneNeedsRegeneration = Persist(struct {
 	PrivateNodeKey        key.NodePrivate
 	OldPrivateNodeKey     key.NodePrivate
 	UserProfile           tailcfg.UserProfile
-	NetworkLockKey        key.NLPrivate
+	NetworkLockKey        key.TLPrivate
 	NodeID                tailcfg.StableNodeID
 	AttestationKey        key.HardwareAttestationKey
 	DisallowedTKAStateIDs []string

--- a/types/persist/persist_test.go
+++ b/types/persist/persist_test.go
@@ -28,7 +28,7 @@ func TestPersistEqual(t *testing.T) {
 	}
 
 	k1 := key.NewNode()
-	nl1 := key.NewNLPrivate()
+	nl1 := key.NewTLPrivate()
 	tests := []struct {
 		a, b *Persist
 		want bool
@@ -86,7 +86,7 @@ func TestPersistEqual(t *testing.T) {
 		},
 		{
 			&Persist{NetworkLockKey: nl1},
-			&Persist{NetworkLockKey: key.NewNLPrivate()},
+			&Persist{NetworkLockKey: key.NewTLPrivate()},
 			false,
 		},
 		{

--- a/types/persist/persist_view.go
+++ b/types/persist/persist_view.go
@@ -94,7 +94,7 @@ func (v PersistView) UserProfile() tailcfg.UserProfileView { return v.ж.UserPro
 
 // NetworkLockKey is the node's Tailnet Lock private key.
 // "Network Lock" was the pre-release name for Tailnet Lock.
-func (v PersistView) NetworkLockKey() key.NLPrivate        { return v.ж.NetworkLockKey }
+func (v PersistView) NetworkLockKey() key.TLPrivate        { return v.ж.NetworkLockKey }
 func (v PersistView) NodeID() tailcfg.StableNodeID         { return v.ж.NodeID }
 func (v PersistView) AttestationKey() tailcfg.StableNodeID { panic("unsupported") }
 
@@ -112,7 +112,7 @@ var _PersistViewNeedsRegeneration = Persist(struct {
 	PrivateNodeKey        key.NodePrivate
 	OldPrivateNodeKey     key.NodePrivate
 	UserProfile           tailcfg.UserProfile
-	NetworkLockKey        key.NLPrivate
+	NetworkLockKey        key.TLPrivate
 	NodeID                tailcfg.StableNodeID
 	AttestationKey        key.HardwareAttestationKey
 	DisallowedTKAStateIDs []string


### PR DESCRIPTION
The NL prefix is one of the last references to the "Network Lock" name which we're cleaning up.

Updates tailscale/corp#37904