### PR TITLE
ipn/ipnlocal: drop stale 1-1 NAT masquerade AllowedIPs on sharee key change

### DIFF
--- a/control/controlclient/map.go
+++ b/control/controlclient/map.go
@@ -1040,7 +1040,10 @@ func peerChangeDiff(was tailcfg.NodeView, n *tailcfg.Node, onFalse func(string))
 			}
 		case "Key":
 			if was.Key() != n.Key {
-				pc().Key = new(n.Key)
+				// Key rotation must keep the full Node so AllowedIPs/Addresses
+				// (1-1 NAT masquerade) are replaced, not left on a Key-only patch.
+				onFalse(field)
+				return nil, false
 			}
 		case "KeyExpiry":
 			if !was.KeyExpiry().Equal(n.KeyExpiry) {

--- a/control/controlclient/map_test.go
+++ b/control/controlclient/map_test.go
@@ -1226,6 +1226,12 @@ func TestPeerChangeDiff(t *testing.T) {
 			want: nil,
 		},
 		{
+			name: "miss-change-key",
+			a:    &tailcfg.Node{ID: 1, Key: key.NewNode().Public()},
+			b:    &tailcfg.Node{ID: 1, Key: key.NewNode().Public()},
+			want: nil,
+		},
+		{
 			name: "miss-change-name",
 			a:    &tailcfg.Node{ID: 1, Name: "foo"},
 			b:    &tailcfg.Node{ID: 1, Name: "bar"},

--- a/ipn/ipnlocal/node_backend.go
+++ b/ipn/ipnlocal/node_backend.go
@@ -859,12 +859,13 @@ func (nb *nodeBackend) ExtraDNSByName(hostname string) (_ netip.Addr, ok bool) {
 
 func (nb *nodeBackend) updatePeersLocked() (discoChanged []key.NodePublic, routeChanged routemanager.PeersWithRouteChanges) {
 	nm := nb.netMap
-	oldIDs := slices.Collect(maps.Keys(nb.peers))
+	oldPeers := maps.Clone(nb.peers)
+	oldIDs := slices.Collect(maps.Keys(oldPeers))
 
 	// Snapshot the previous disco keys (by node key) before the peers
 	// map is repopulated, to detect restarted peers below.
 	var prevDisco map[key.NodePublic]key.DiscoPublic
-	for _, p := range nb.peers {
+	for _, p := range oldPeers {
 		if !p.DiscoKey().IsZero() {
 			mak.Set(&prevDisco, p.Key(), p.DiscoKey())
 		}
@@ -902,10 +903,95 @@ func (nb *nodeBackend) updatePeersLocked() (discoChanged []key.NodePublic, route
 		}
 	}
 	for _, p := range nb.peers {
+		p = nb.reconcileMasqueradeAfterIdentityChangeLocked(oldPeers, p)
+		nb.peers[p.ID()] = p
 		rt.UpsertPeer(p)
 	}
 	res := rt.Commit()
 	return discoChanged, res.AllowedIPs
+}
+
+// dropStaleMasqueradeAllowedIPs removes 1-1 NAT masquerade prefixes that were
+// bound to old's node key and adds n's current Addresses into AllowedIPs.
+func dropStaleMasqueradeAllowedIPs(old, n tailcfg.NodeView) tailcfg.NodeView {
+	if !old.Valid() || !n.Valid() {
+		return n
+	}
+	oldSelf := make(set.Set[netip.Addr], old.Addresses().Len())
+	for _, a := range old.Addresses().All() {
+		if a.IsSingleIP() {
+			oldSelf.Add(a.Addr())
+		}
+	}
+	newSelf := make(set.Set[netip.Addr], n.Addresses().Len())
+	for _, a := range n.Addresses().All() {
+		if a.IsSingleIP() {
+			newSelf.Add(a.Addr())
+		}
+	}
+	var aips []netip.Prefix
+	changed := false
+	for _, aip := range n.AllowedIPs().All() {
+		if oldSelf.Contains(aip.Addr()) && !newSelf.Contains(aip.Addr()) {
+			changed = true
+			continue
+		}
+		aips = append(aips, aip)
+	}
+	for _, a := range n.Addresses().All() {
+		if !slices.Contains(aips, a) {
+			aips = append(aips, a)
+			changed = true
+		}
+	}
+	if !changed {
+		return n
+	}
+	nn := n.AsStruct()
+	nn.AllowedIPs = aips
+	return nn.View()
+}
+
+// reconcileMasqueradeAfterIdentityChangeLocked returns p with stale 1-1 NAT
+// masquerade AllowedIPs dropped when the sharee node key/ID changed.
+func (nb *nodeBackend) reconcileMasqueradeAfterIdentityChangeLocked(oldPeers map[tailcfg.NodeID]tailcfg.NodeView, p tailcfg.NodeView) tailcfg.NodeView {
+	if old, ok := oldPeers[p.ID()]; ok {
+		if old.Key() != p.Key() {
+			return dropStaleMasqueradeAllowedIPs(old, p)
+		}
+		return p
+	}
+	for id, old := range oldPeers {
+		if _, still := nb.peers[id]; still {
+			continue
+		}
+		if old.Key() == p.Key() {
+			continue
+		}
+		if !masqueradeIPOverlap(old, p) {
+			continue
+		}
+		p = dropStaleMasqueradeAllowedIPs(old, p)
+	}
+	return p
+}
+
+func masqueradeIPOverlap(old, n tailcfg.NodeView) bool {
+	if !old.Valid() || !n.Valid() {
+		return false
+	}
+	oldSelf := make(set.Set[netip.Addr], old.Addresses().Len())
+	for _, a := range old.Addresses().All() {
+		if a.IsSingleIP() {
+			oldSelf.Add(a.Addr())
+		}
+	}
+	for _, aip := range n.AllowedIPs().All() {
+		if oldSelf.Contains(aip.Addr()) {
+			return true
+		}
+	}
+	return false
 }
 
 // recordTSMPLearnedDisco notes that a peer's new disco key was learned via
@@ -1109,15 +1195,35 @@ func (nb *nodeBackend) UpdateNetmapDelta(muts []netmap.NodeMutation) (res netmap
 		res.ChangedAllowedIPs = rt.Commit().AllowedIPs
 	}()
 
+	oldPeers := maps.Clone(nb.peers)
+	var removed []tailcfg.NodeView
+	for _, m := range muts {
+		if r, ok := m.(netmap.NodeMutationRemove); ok {
+			if old, ok := oldPeers[r.NodeIDBeingMutated()]; ok {
+				removed = append(removed, old)
+			}
+		}
+	}
+
 	for _, m := range muts {
 		switch m := m.(type) {
 		case netmap.NodeMutationUpsert:
-			nid := m.Node.ID()
+			node := m.Node
+			if old, ok := nb.peers[node.ID()]; ok && old.Key() != node.Key() {
+				node = dropStaleMasqueradeAllowedIPs(old, node)
+			} else if _, exists := nb.peers[node.ID()]; !exists {
+				for _, old := range removed {
+					if masqueradeIPOverlap(old, node) {
+						node = dropStaleMasqueradeAllowedIPs(old, node)
+					}
+				}
+			}
+			nid := node.ID()
 			if old, ok := nb.peers[nid]; ok {
-				if old.Key() == m.Node.Key() {
-					if nb.discoChangedLocked(m.Node.Key(), old.DiscoKey(), m.Node.DiscoKey()) {
+				if old.Key() == node.Key() {
+					if nb.discoChangedLocked(node.Key(), old.DiscoKey(), node.DiscoKey()) {
 						res.DiscoChanged.Make()
-						res.DiscoChanged.Add(m.Node.Key())
+						res.DiscoChanged.Add(node.Key())
 					}
 				} else {
 					delete(nb.tsmpLearnedDisco, old.Key())
@@ -1139,17 +1245,17 @@ func (nb *nodeBackend) UpdateNetmapDelta(muts []netmap.NodeMutation) (res netmap
 				delete(nb.nodeByStableID, old.StableID())
 				nb.removeNodeNameLocked(old.Name())
 			}
-			mak.Set(&nb.peers, nid, m.Node)
-			for _, ipp := range m.Node.Addresses().All() {
+			mak.Set(&nb.peers, nid, node)
+			for _, ipp := range node.Addresses().All() {
 				if ipp.IsSingleIP() {
 					mak.Set(&nb.nodeByAddr, ipp.Addr(), nid)
 				}
 			}
-			mak.Set(&nb.nodeByKey, m.Node.Key(), nid)
-			mak.Set(&nb.nodeByWGString, m.Node.Key().WireGuardGoString(), nid)
-			mak.Set(&nb.nodeByStableID, m.Node.StableID(), nid)
-			nb.addNodeNameLocked(m.Node.Name(), nid)
-			rt.UpsertPeer(m.Node)
+			mak.Set(&nb.nodeByKey, node.Key(), nid)
+			mak.Set(&nb.nodeByWGString, node.Key().WireGuardGoString(), nid)
+			mak.Set(&nb.nodeByStableID, node.StableID(), nid)
+			nb.addNodeNameLocked(node.Name(), nid)
+			rt.UpsertPeer(node)
 			continue
 		case netmap.NodeMutationRemove:
 			nid := m.NodeIDBeingMutated()

--- a/ipn/ipnlocal/node_backend_test.go
+++ b/ipn/ipnlocal/node_backend_test.go
@@ -6,6 +6,7 @@ package ipnlocal
 import (
 	"context"
 	"errors"
+	"fmt"
 	"iter"
 	"maps"
 	"net/netip"
@@ -368,6 +369,112 @@ func TestNodeBackendRouteManager(t *testing.T) {
 	nb.SetNetMap(&netmap.NetworkMap{Peers: []tailcfg.NodeView{p2}})
 	wantPeerFor("100.64.0.3", tailcfg.NodeView{})
 	wantPeerFor("100.64.0.2", p2)
+}
+
+func TestShareeRecreateDropsStaleMasqueradeAllowedIPs(t *testing.T) {
+	nb := newNodeBackend(t.Context(), tstest.WhileTestRunningLogger(t), eventbus.New())
+
+	oldMasq := netip.MustParsePrefix("100.95.94.22/32")
+	newMasq := netip.MustParsePrefix("100.112.44.83/32")
+	vip := netip.MustParsePrefix("100.99.99.99/32")
+
+	sharee := func(id tailcfg.NodeID, k key.NodePublic, addr, allowed netip.Prefix) tailcfg.NodeView {
+		n := &tailcfg.Node{
+			ID:         id,
+			StableID:   tailcfg.StableNodeID(fmt.Sprintf("sharee-%d", id)),
+			Key:        k,
+			User:       7,
+			HomeDERP:   1,
+			Addresses:  []netip.Prefix{addr},
+			AllowedIPs: []netip.Prefix{allowed, vip},
+			Hostinfo:   (&tailcfg.Hostinfo{ShareeNode: true}).View(),
+		}
+		return n.View()
+	}
+
+	oldKey := key.NewNode().Public()
+	oldPeer := sharee(1, oldKey, oldMasq, oldMasq)
+	nb.SetNetMap(&netmap.NetworkMap{Peers: []tailcfg.NodeView{oldPeer}})
+	got, ok := nb.PeerAllowedIPs(oldKey)
+	if !ok || !slices.Contains(got, oldMasq) {
+		t.Fatalf("initial AllowedIPs = %v, %v; want %v", got, ok, oldMasq)
+	}
+
+	t.Run("same_id_key_change", func(t *testing.T) {
+		newKey := key.NewNode().Public()
+		// Control updated Addresses to the new masquerade but left AllowedIPs stale.
+		rotated := sharee(1, newKey, newMasq, oldMasq)
+		deltaRes, handled := nb.UpdateNetmapDelta([]netmap.NodeMutation{
+			netmap.NodeMutationUpsert{Node: rotated},
+		})
+		if !handled {
+			t.Fatal("UpdateNetmapDelta not handled")
+		}
+		if _, ok := nb.PeerAllowedIPs(oldKey); ok {
+			t.Fatal("old node key still has AllowedIPs after key change")
+		}
+		got, ok := nb.PeerAllowedIPs(newKey)
+		if !ok {
+			t.Fatal("new node key missing AllowedIPs")
+		}
+		if slices.Contains(got, oldMasq) {
+			t.Fatalf("AllowedIPs %v still has stale masquerade %v", got, oldMasq)
+		}
+		if !slices.Contains(got, newMasq) {
+			t.Fatalf("AllowedIPs %v missing new masquerade %v", got, newMasq)
+		}
+		if !slices.Contains(got, vip) {
+			t.Fatalf("AllowedIPs %v dropped VIP %v", got, vip)
+		}
+		if v, ok := deltaRes.ChangedAllowedIPs[oldKey]; !ok || v != nil {
+			t.Errorf("ChangedAllowedIPs[%v] = %v, %v; want nil, true", oldKey, v, ok)
+		}
+		if deltaRes.ChangedAllowedIPs[newKey] == nil {
+			t.Errorf("ChangedAllowedIPs missing new key %v", newKey)
+		}
+	})
+
+	t.Run("new_id_replaces_old", func(t *testing.T) {
+		nb := newNodeBackend(t.Context(), tstest.WhileTestRunningLogger(t), eventbus.New())
+		oldKey := key.NewNode().Public()
+		oldPeer := sharee(1, oldKey, oldMasq, oldMasq)
+		nb.SetNetMap(&netmap.NetworkMap{Peers: []tailcfg.NodeView{oldPeer}})
+
+		newKey := key.NewNode().Public()
+		newPeer := sharee(2, newKey, newMasq, oldMasq)
+		deltaRes, handled := nb.UpdateNetmapDelta([]netmap.NodeMutation{
+			netmap.MakeNodeMutationRemove(1),
+			netmap.NodeMutationUpsert{Node: newPeer},
+		})
+		if !handled {
+			t.Fatal("UpdateNetmapDelta not handled")
+		}
+		if _, ok := nb.PeerAllowedIPs(oldKey); ok {
+			t.Fatal("old node key still has AllowedIPs after ID change")
+		}
+		got, ok := nb.PeerAllowedIPs(newKey)
+		if !ok || slices.Contains(got, oldMasq) || !slices.Contains(got, newMasq) {
+			t.Fatalf("AllowedIPs = %v, %v; want %v without %v", got, ok, newMasq, oldMasq)
+		}
+		if v, ok := deltaRes.ChangedAllowedIPs[oldKey]; !ok || v != nil {
+			t.Errorf("ChangedAllowedIPs[%v] = %v, %v; want nil, true", oldKey, v, ok)
+		}
+	})
+
+	t.Run("full_netmap_id_change", func(t *testing.T) {
+		nb := newNodeBackend(t.Context(), tstest.WhileTestRunningLogger(t), eventbus.New())
+		oldKey := key.NewNode().Public()
+		nb.SetNetMap(&netmap.NetworkMap{Peers: []tailcfg.NodeView{sharee(1, oldKey, oldMasq, oldMasq)}})
+		newKey := key.NewNode().Public()
+		nb.SetNetMap(&netmap.NetworkMap{Peers: []tailcfg.NodeView{sharee(2, newKey, newMasq, oldMasq)}})
+		if _, ok := nb.PeerAllowedIPs(oldKey); ok {
+			t.Fatal("old node key still has AllowedIPs after full netmap ID change")
+		}
+		got, ok := nb.PeerAllowedIPs(newKey)
+		if !ok || slices.Contains(got, oldMasq) || !slices.Contains(got, newMasq) {
+			t.Fatalf("AllowedIPs = %v, %v; want %v without %v", got, ok, newMasq, oldMasq)
+		}
+	})
 }
 
 // TestNodeBackendDiscoChanged exercises the full-netmap disco change

--- a/ipn/ipnlocal/state_test.go
+++ b/ipn/ipnlocal/state_test.go
@@ -1623,6 +1623,46 @@ func TestPeerConfigUpdatedOnPeerRouteDelta(t *testing.T) {
 	}
 }
 
+func TestShareeKeyChangeDropsStaleMasqueradeFromPeerConfig(t *testing.T) {
+	connect := &ipn.MaskedPrefs{Prefs: ipn.Prefs{WantRunning: true}, WantRunningSet: true}
+	oldMasq := netip.MustParsePrefix("100.95.94.22/32")
+	newMasq := netip.MustParsePrefix("100.112.44.83/32")
+
+	sharee := makePeer(1, withName("sharee"), withAddresses(oldMasq), withAllowedIPs(oldMasq))
+	nm := buildNetmapWithPeers(
+		makePeer(2, withName("self-other"), withAddresses(netip.MustParsePrefix("100.64.1.2/32"))),
+		sharee,
+	)
+
+	lb, engine, cc := newLocalBackendWithMockEngineAndControl(t, false)
+	mustDo(t)(lb.Start(ipn.Options{}))
+	mustDo2(t)(lb.EditPrefs(connect))
+	cc().authenticated(nm)
+
+	oldKey := sharee.Key()
+	replacement := sharee.AsStruct()
+	replacement.Key = key.NewNode().Public()
+	replacement.Addresses = []netip.Prefix{newMasq}
+	replacement.AllowedIPs = []netip.Prefix{oldMasq}
+	if !lb.UpdateNetmapDelta([]netmap.NodeMutation{netmap.NodeMutationUpsert{Node: replacement.View()}}) {
+		t.Fatal("UpdateNetmapDelta = false, want true")
+	}
+
+	if _, ok := engine.PeerAllowedIPs(oldKey); ok {
+		t.Fatal("old sharee key still in peer config after key change")
+	}
+	ips, ok := engine.PeerAllowedIPs(replacement.Key)
+	if !ok {
+		t.Fatalf("peer config source missing new key %v", replacement.Key.ShortString())
+	}
+	if slices.Contains(ips, oldMasq) {
+		t.Fatalf("AllowedIPs %v still has stale masquerade %v", ips, oldMasq)
+	}
+	if !slices.Contains(ips, newMasq) {
+		t.Fatalf("AllowedIPs %v missing new masquerade %v", ips, newMasq)
+	}
+}
+
 // TestSendPreservesAuthURL tests that wgengine updates arriving in the middle of
 // processing an auth URL doesn't result in the auth URL being cleared.
 func TestSendPreservesAuthURL(t *testing.T) {
@@ -2013,7 +2053,7 @@ func (e *mockEngine) SyncDevicePeer(key.NodePublic)  {}
 func (e *mockEngine) ResetDevicePeer(key.NodePublic) {}
 func (e *mockEngine) SetPeerSessionStateFunc(func(key.NodePublic, wgengine.PeerWireGuardState)) {
 }
-func (e *mockEngine) SetNetLogSource(wgengine.NetLogSource)                            {}
+func (e *mockEngine) SetNetLogSource(wgengine.NetLogSource) {}
 func (e *mockEngine) SetPeerPriorityMessageOnEstablishmentFunc(fn func(key.NodePublic) (msg []byte)) {
 }
 func (e *mockEngine) SetWGPeerLookup(func(wgString string) (tsString string, ok bool)) {}


### PR DESCRIPTION
A sharee that logs out and back in gets a new node key and a new 1-1 NAT masquerade source, but the shared node kept the previous masquerade /32 in AllowedIPs. WireGuard cryptokey routing then drops every TCP packet from the new source with no RST. Disco still ponged and tx/rx counters still moved, so the tunnel looked healthy and the only thing that cleared it was restarting tailscaled.

This drops the stale masquerade prefixes when the sharee node key or ID changes and keeps the current Addresses in AllowedIPs so the new source is admitted. Node key rotations are also no longer collapsed into a Key-only peer patch, which was what left the old /32 attached to the new key. One case is out of scope: the repair reconciles against peers present in the same netmap delta, so a Remove in one message followed by the replacement Upsert in a later one is not covered, and handling that needs retaining recently removed peers for a bounded window. Happy to add it if you want it here.
