### PR TITLE
net/tstun: do not filter TSMPDiscoAdvert inbound

### DIFF
--- a/net/tstun/wrap.go
+++ b/net/tstun/wrap.go
@@ -22,7 +22,6 @@ import (
 	"github.com/tailscale/wireguard-go/tun"
 	"go4.org/mem"
 	"tailscale.com/disco"
-	"tailscale.com/envknob"
 	"tailscale.com/feature"
 	"tailscale.com/feature/buildfeatures"
 	"tailscale.com/net/batching"
@@ -1106,8 +1105,7 @@ func (t *Wrapper) filterPacketInboundFromWireGuard(p *packet.Parsed, captHook pa
 			t.injectOutboundPong(p, pingReq)
 			return filter.DropSilently, gro
 		} else if discoKeyAdvert, ok := p.AsTSMPDiscoAdvertisement(); ok {
-			if buildfeatures.HasCacheNetMap && envknob.BoolDefaultTrue("TS_USE_CACHED_NETMAP") &&
-				!discoKeyAdvert.Key.IsZero() {
+			if !discoKeyAdvert.Key.IsZero() {
 				t.discoKeyAdvertisementPub.Publish(events.DiscoKeyAdvertisement{
 					Src: discoKeyAdvert.Src,
 					Key: discoKeyAdvert.Key,


### PR DESCRIPTION
The messages needs to be received so that a node not participating in
caching can talk to a node that is participating in caching but is
unable to share its key over control.

Fixes #21008

Signed-off-by: Claus Lensbøl <claus@tailscale.com>
