### PR TITLE
cmd/tsconnect/{,wasmbuild}: allow passing version stamps via env

### DIFF
--- a/cmd/tsconnect/common.go
+++ b/cmd/tsconnect/common.go
@@ -244,7 +244,7 @@ func buildWasm(dev bool) ([]byte, error) {
 		}
 		// Omit long paths and debug symbols in release builds, to reduce the
 		// generated WASM binary size.
-		args = append(args, "-trimpath", "-ldflags", wasmbuild.ProdLDFlags)
+		args = append(args, "-trimpath", "-ldflags", wasmbuild.ProdLDFlags())
 	} else if *devControl != "" {
 		args = append(args, "-ldflags", fmt.Sprintf("-X 'main.ControlURL=%v'", *devControl))
 	}

--- a/cmd/tsconnect/wasmbuild/wasmbuild.go
+++ b/cmd/tsconnect/wasmbuild/wasmbuild.go
@@ -87,7 +87,19 @@ func init() {
 // ProdLDFlags is the -ldflags value used in production wasm builds.
 // -s strips the symbol table, -w strips DWARF, both to shrink the
 // shipped artifact.
-const ProdLDFlags = "-s -w"
+//
+// It also sets the version stamps to VERSION_LONG and VERSION_SHORT,
+// if those env variables are present.
+func ProdLDFlags() string {
+	ldflags := "-s -w"
+	if long := os.Getenv("VERSION_LONG"); long != "" {
+		ldflags += " -X tailscale.com/version.longStamp=" + long
+	}
+	if short := os.Getenv("VERSION_SHORT"); short != "" {
+		ldflags += " -X tailscale.com/version.shortStamp=" + short
+	}
+	return ldflags
+}
 
 // BuildInfoFile is the basename of the JSON manifest that build-pkg
 // writes alongside main.wasm, recording the sha256 of the raw
@@ -144,7 +156,7 @@ func ProdCommand(goBin, outputPath string) *exec.Cmd {
 	cmd := exec.Command(goBin, "build",
 		"-tags", Tags(),
 		"-trimpath",
-		"-ldflags", ProdLDFlags,
+		"-ldflags", ProdLDFlags(),
 		"-o", outputPath,
 		"tailscale.com/cmd/tsconnect/wasm",
 	)


### PR DESCRIPTION
When the wasmbuild is run from external workflows, it can't derive the version stamps from its build context. Allow setting the ProdLDFlags version.longStamp and version.shortStamp from the VERSION_LONG and VERSION_SHORT environment variables when present. This way, if the wasmbuild caller already knows them (e.g. from mkversion), it can pass them in.

This avoids "x.y.z-ERR-BuildInfo" showing up in the admin console's machine version column.

Updates #19707

Also see https://github.com/tailscale/corp/pull/47344 for the corp side change taking advantage of this in the tsconnect build script.

The Go client builds avoid this situation with gocross, which we could theoretically introduce for tsconnect too, but that would be a more extensive lift.