### PR TITLE
control/controlhttp: smuggle ts2021 handshake init in TLS ALPN list

### DIFF
--- a/control/controlhttp/alpn_test.go
+++ b/control/controlhttp/alpn_test.go
@@ -1,0 +1,277 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package controlhttp
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+
+	"tailscale.com/control/controlbase"
+	"tailscale.com/control/controlhttp/controlhttpcommon"
+	"tailscale.com/control/controlhttp/controlhttpserver"
+	"tailscale.com/health"
+	"tailscale.com/types/key"
+	"tailscale.com/util/eventbus/eventbustest"
+)
+
+type alpnServerResult struct {
+	conn    *controlbase.Conn // non-nil if the smuggled ALPN handshake was used
+	viaALPN bool
+	err     error
+}
+
+// startALPNServer starts a TLS listener that accepts ts2021 connections via
+// the smuggled ALPN handshake, falling back to serving the regular HTTP
+// upgrade handler for clients that don't use it.
+func startALPNServer(t *testing.T, serverKey key.MachinePrivate, earlyWrite func(int, io.Writer) error) (addr *net.TCPAddr, results chan alpnServerResult) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+
+	results = make(chan alpnServerResult, 1)
+	base := tlsConfig(t)
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				cbConn, tlsConn, err := controlhttpserver.AcceptALPNTLS(ctx, c, base, serverKey, earlyWrite)
+				if err != nil {
+					results <- alpnServerResult{err: err}
+					return
+				}
+				if cbConn != nil {
+					results <- alpnServerResult{conn: cbConn, viaALPN: true}
+					return
+				}
+				// Client didn't smuggle a handshake; serve the HTTP
+				// upgrade handler on the TLS conn.
+				srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					cbConn, err := controlhttpserver.AcceptHTTP(ctx, w, r, serverKey, earlyWrite)
+					results <- alpnServerResult{conn: cbConn, err: err}
+				})}
+				srv.Serve(newOneConnListener(tlsConn, ln.Addr()))
+			}()
+		}
+	}()
+	return ln.Addr().(*net.TCPAddr), results
+}
+
+// oneConnListener is a net.Listener that returns a single conn and then
+// ErrClosed on subsequent Accepts.
+type oneConnListener struct {
+	conn net.Conn
+	addr net.Addr
+	ch   chan net.Conn
+}
+
+func newOneConnListener(c net.Conn, addr net.Addr) *oneConnListener {
+	ch := make(chan net.Conn, 1)
+	ch <- c
+	close(ch)
+	return &oneConnListener{conn: c, addr: addr, ch: ch}
+}
+
+func (l *oneConnListener) Accept() (net.Conn, error) {
+	c, ok := <-l.ch
+	if !ok {
+		return nil, net.ErrClosed
+	}
+	return c, nil
+}
+
+func (l *oneConnListener) Close() error   { return nil }
+func (l *oneConnListener) Addr() net.Addr { return l.addr }
+
+func newALPNTestDialer(t *testing.T, clientKey key.MachinePrivate, serverPub key.MachinePublic) *Dialer {
+	return &Dialer{
+		Hostname:             "localhost",
+		MachineKey:           clientKey,
+		ControlKey:           serverPub,
+		ProtocolVersion:      1,
+		Logf:                 t.Logf,
+		omitCertErrorLogging: true,
+		HealthTracker:        health.NewTracker(eventbustest.NewBus(t)),
+		proxyFunc:            func(*http.Request) (*url.URL, error) { return nil, nil },
+	}
+}
+
+func testALPNRoundTrip(t *testing.T, conn *ClientConn, results chan alpnServerResult, wantViaALPN bool) {
+	t.Helper()
+	res := <-results
+	if res.err != nil {
+		t.Fatalf("server accept: %v", res.err)
+	}
+	defer res.conn.Close()
+	if res.viaALPN != wantViaALPN {
+		t.Errorf("server got conn viaALPN=%v; want %v", res.viaALPN, wantViaALPN)
+	}
+
+	// Verify data flows both ways over the Noise conn.
+	const c2s = "hello from client"
+	const s2c = "hello from server"
+	errc := make(chan error, 1)
+	go func() {
+		buf := make([]byte, len(c2s))
+		if _, err := io.ReadFull(res.conn, buf); err != nil {
+			errc <- err
+			return
+		}
+		if string(buf) != c2s {
+			errc <- fmt.Errorf("server read %q; want %q", buf, c2s)
+			return
+		}
+		_, err := io.WriteString(res.conn, s2c)
+		errc <- err
+	}()
+	if _, err := io.WriteString(conn, c2s); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+	buf := make([]byte, len(s2c))
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		t.Fatalf("client read: %v", err)
+	}
+	if string(buf) != s2c {
+		t.Fatalf("client read %q; want %q", buf, s2c)
+	}
+	if err := <-errc; err != nil {
+		t.Fatalf("server I/O: %v", err)
+	}
+}
+
+// TestALPNHandshake verifies that a client can smuggle its Noise handshake
+// initiation in the TLS ClientHello ALPN list and speak ts2021 directly over
+// the TLS stream, with no HTTP layer.
+func TestALPNHandshake(t *testing.T) {
+	client, server := key.NewMachine(), key.NewMachine()
+
+	const earlyWriteMsg = "Hello, world!"
+	earlyWrite := func(protocolVersion int, w io.Writer) error {
+		if protocolVersion != 1 {
+			return fmt.Errorf("unexpected protocol version %d", protocolVersion)
+		}
+		_, err := io.WriteString(w, earlyWriteMsg)
+		return err
+	}
+
+	addr, results := startALPNServer(t, server, earlyWrite)
+
+	a := newALPNTestDialer(t, client, server.Public())
+	u := &url.URL{
+		Scheme: "https",
+		Host:   net.JoinHostPort("localhost", strconv.Itoa(addr.Port)),
+		Path:   serverUpgradePath,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	conn, err := a.dialURL(ctx, u, netip.Addr{}, "")
+	if err != nil {
+		t.Fatalf("dialURL: %v", err)
+	}
+	defer conn.Close()
+
+	if peer := conn.Peer(); peer != server.Public() {
+		t.Fatalf("client got peer %v; want %v", peer, server.Public())
+	}
+	buf := make([]byte, len(earlyWriteMsg))
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		t.Fatalf("reading early write: %v", err)
+	}
+	if string(buf) != earlyWriteMsg {
+		t.Fatalf("early write = %q; want %q", buf, earlyWriteMsg)
+	}
+
+	testALPNRoundTrip(t, conn, results, true)
+}
+
+// TestALPNFallback verifies that when the server doesn't understand the
+// smuggled ALPN handshake, the client falls back to the regular HTTP upgrade
+// on the same TLS connection.
+func TestALPNFallback(t *testing.T) {
+	client, server := key.NewMachine(), key.NewMachine()
+
+	results := make(chan alpnServerResult, 1)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cbConn, err := controlhttpserver.AcceptHTTP(context.Background(), w, r, server, nil)
+		results <- alpnServerResult{conn: cbConn, err: err}
+	})
+
+	httpsLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	httpsServer := &http.Server{
+		Handler:   handler,
+		TLSConfig: tlsConfig(t),
+	}
+	go httpsServer.ServeTLS(httpsLn, "", "")
+	defer httpsServer.Close()
+
+	a := newALPNTestDialer(t, client, server.Public())
+	var dials int
+	a.Dialer = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		dials++
+		return stdDialer.DialContext(ctx, network, addr)
+	}
+	u := &url.URL{
+		Scheme: "https",
+		Host:   net.JoinHostPort("localhost", strconv.Itoa(httpsLn.Addr().(*net.TCPAddr).Port)),
+		Path:   serverUpgradePath,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	conn, err := a.dialURL(ctx, u, netip.Addr{}, "")
+	if err != nil {
+		t.Fatalf("dialURL: %v", err)
+	}
+	defer conn.Close()
+
+	if peer := conn.Peer(); peer != server.Public() {
+		t.Fatalf("client got peer %v; want %v", peer, server.Public())
+	}
+
+	// The fallback must happen over the same TCP connection, not a redial.
+	if dials != 1 {
+		t.Errorf("made %d TCP dials; want 1 (in-connection fallback)", dials)
+	}
+
+	testALPNRoundTrip(t, conn, results, false)
+}
+
+// TestALPNHandshakeEncoding verifies that the encoded handshake round-trips
+// and fits in an ALPN protocol name (max 255 bytes).
+func TestALPNHandshakeEncoding(t *testing.T) {
+	client, server := key.NewMachine(), key.NewMachine()
+	init, _, err := controlbase.ClientDeferred(client, server.Public(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	enc := controlhttpcommon.EncodeALPNHandshake(init)
+	if len(enc) > 255 {
+		t.Errorf("encoded ALPN entry is %d bytes; must be <= 255", len(enc))
+	}
+	got, ok := controlhttpcommon.DecodeALPNHandshake([]string{"http/1.1", enc})
+	if !ok {
+		t.Fatal("DecodeALPNHandshake failed")
+	}
+	if !bytes.Equal(got, init) {
+		t.Errorf("decoded handshake doesn't match original")
+	}
+}

--- a/control/controlhttp/client.go
+++ b/control/controlhttp/client.go
@@ -20,6 +20,7 @@
 package controlhttp
 
 import (
+	"bufio"
 	"cmp"
 	"context"
 	"crypto/tls"
@@ -348,9 +349,22 @@ func (a *Dialer) dialURL(ctx context.Context, u *url.URL, optAddr netip.Addr, op
 	if err != nil {
 		return nil, err
 	}
-	netConn, err := a.tryURLUpgrade(ctx, u, optAddr, optACEHost, init)
-	if err != nil {
-		return nil, err
+	var netConn net.Conn
+	if u.Scheme == "https" && optACEHost == "" && !a.proxyApplies(u) {
+		netConn, err = a.tryALPNUpgrade(ctx, u, optAddr, init)
+		if err != nil {
+			// Maybe a middlebox didn't like our unusual ALPN protocol
+			// list. Retry below with the regular HTTP upgrade path on a
+			// fresh connection.
+			a.logf("controlhttp: ALPN upgrade to %v failed, falling back to HTTP upgrade: %v", u, err)
+			netConn = nil
+		}
+	}
+	if netConn == nil {
+		netConn, err = a.tryURLUpgrade(ctx, u, optAddr, optACEHost, init)
+		if err != nil {
+			return nil, err
+		}
 	}
 	cbConn, err := cont(ctx, netConn)
 	if err != nil {
@@ -360,6 +374,160 @@ func (a *Dialer) dialURL(ctx context.Context, u *url.URL, optAddr netip.Addr, op
 	return &ClientConn{
 		Conn: cbConn,
 	}, nil
+}
+
+// tlsClientConfig returns the TLS client configuration to use for
+// connections to the control server, extending base (which may be nil).
+//
+// The returned config demotes all cert verification errors to log messages.
+// We don't actually care about the TLS security (because we just do the
+// Noise crypto atop whatever connection we get, including HTTP port 80
+// plaintext) so this permits middleboxes to MITM their users. All they'll
+// see is some Noise.
+func (a *Dialer) tlsClientConfig(base *tls.Config) *tls.Config {
+	if base != nil && a.ExtraRootCAs != nil {
+		base.RootCAs = a.ExtraRootCAs
+	}
+	conf := tlsdial.Config(a.HealthTracker, base)
+	if !conf.InsecureSkipVerify {
+		panic("unexpected") // should be set by tlsdial.Config
+	}
+	verify := conf.VerifyConnection
+	if verify == nil {
+		panic("unexpected") // should be set by tlsdial.Config
+	}
+	conf.VerifyConnection = func(cs tls.ConnectionState) error {
+		if err := verify(cs); err != nil && a.Logf != nil && !a.omitCertErrorLogging {
+			a.Logf("warning: TLS cert verificication for %q failed: %v", a.Hostname, err)
+		}
+		return nil // regardless
+	}
+	return conf
+}
+
+// proxyApplies reports whether an HTTP proxy would be used for a request to u.
+func (a *Dialer) proxyApplies(u *url.URL) bool {
+	if !buildfeatures.HasUseProxy {
+		return false
+	}
+	proxyFunc := a.getProxyFunc()
+	if proxyFunc == nil {
+		return false
+	}
+	proxyURL, err := proxyFunc(&http.Request{URL: u})
+	if err != nil {
+		// Assume a proxy is needed; the HTTP upgrade path will surface
+		// the error properly.
+		return true
+	}
+	return proxyURL != nil
+}
+
+// tryALPNUpgrade dials a TLS connection to u (an https URL) and tries to
+// negotiate speaking ts2021 directly over the TLS stream by smuggling the
+// Noise handshake initiation message in the ALPN protocol list of the
+// ClientHello (see controlhttpcommon.ALPNHandshakePrefix).
+//
+// If the server takes the offer, the returned conn carries the Noise
+// protocol directly, with no HTTP layer, and the first bytes the server
+// sends are its Noise handshake response. If the server instead negotiates
+// http/1.1 (or nothing), tryALPNUpgrade falls back to the regular HTTP
+// upgrade request over the same TLS connection.
+//
+// This exists to save a round trip: a server-side TLS stack capable of
+// sending application data in its first flight (0.5-RTT data) can complete
+// the Noise handshake in the same round trip as the TLS handshake, matching
+// the latency of the plaintext port 80 path.
+//
+// If optAddr is valid, then no DNS is used and the connection will be made
+// to the provided address.
+func (a *Dialer) tryALPNUpgrade(ctx context.Context, u *url.URL, optAddr netip.Addr, init []byte) (_ net.Conn, retErr error) {
+	var dns *dnscache.Resolver
+	if optAddr.IsValid() {
+		dns = &dnscache.Resolver{
+			SingleHostStaticResult: []netip.Addr{optAddr},
+			SingleHost:             u.Hostname(),
+			Logf:                   a.Logf, // not a.logf method; we want to propagate nil-ness
+		}
+	} else {
+		dns = a.resolver()
+	}
+	var dialer netx.DialFunc
+	if a.Dialer != nil {
+		dialer = a.Dialer
+	} else {
+		dialer = stdDialer.DialContext
+	}
+
+	tcpConn, err := dnscache.Dialer(dialer, dns)(ctx, "tcp", u.Host)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if retErr != nil {
+			tcpConn.Close()
+		}
+	}()
+
+	tlsConf := a.tlsClientConfig(nil)
+	tlsConf.ServerName = u.Hostname()
+	// Offer to speak ts2021 directly over TLS, smuggling our handshake
+	// initiation in a pseudo protocol entry. Also offer http/1.1 so that
+	// servers unaware of the smuggled handshake negotiate that rather than
+	// failing the TLS handshake with no_application_protocol upon finding
+	// no mutual protocol.
+	tlsConf.NextProtos = []string{
+		controlhttpcommon.UpgradeHeaderValue,
+		controlhttpcommon.EncodeALPNHandshake(init),
+		"http/1.1",
+	}
+
+	tlsConn := tls.Client(tcpConn, tlsConf)
+	stop := context.AfterFunc(ctx, func() { tlsConn.Close() })
+	defer stop()
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		return nil, err
+	}
+	if tlsConn.ConnectionState().NegotiatedProtocol == controlhttpcommon.UpgradeHeaderValue {
+		// The server read our handshake initiation out of the ClientHello.
+		// The TLS stream now carries Noise directly, starting with the
+		// server's handshake response.
+		return tlsConn, nil
+	}
+
+	// The server didn't take the ALPN offer (presumably an older server).
+	// Fall back to the HTTP/1.1 upgrade over this same connection.
+	if deadline, ok := ctx.Deadline(); ok {
+		if err := tlsConn.SetDeadline(deadline); err != nil {
+			return nil, err
+		}
+		defer tlsConn.SetDeadline(time.Time{})
+	}
+	req := &http.Request{
+		Method: "POST",
+		URL:    u,
+		Header: http.Header{
+			"Upgrade":                             []string{controlhttpcommon.UpgradeHeaderValue},
+			"Connection":                          []string{"upgrade"},
+			controlhttpcommon.HandshakeHeaderName: []string{base64.StdEncoding.EncodeToString(init)},
+		},
+	}
+	if err := req.Write(tlsConn); err != nil {
+		return nil, err
+	}
+	br := bufio.NewReader(tlsConn)
+	resp, err := http.ReadResponse(br, req)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body.Close() // a 101 response has no body
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		return nil, fmt.Errorf("unexpected HTTP response: %s", resp.Status)
+	}
+	if next := resp.Header.Get("Upgrade"); next != controlhttpcommon.UpgradeHeaderValue {
+		return nil, fmt.Errorf("server switched to unexpected protocol %q", next)
+	}
+	return netutil.NewDrainBufConn(tlsConn, br), nil
 }
 
 // resolver returns a.DNSCache if non-nil or a new *dnscache.Resolver
@@ -479,27 +647,7 @@ func (a *Dialer) tryURLUpgrade(ctx context.Context, u *url.URL, optAddr netip.Ad
 	// Disable HTTP2, since h2 can't do protocol switching.
 	tr.TLSClientConfig.NextProtos = []string{}
 	tr.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
-	if a.ExtraRootCAs != nil {
-		tr.TLSClientConfig.RootCAs = a.ExtraRootCAs
-	}
-	tr.TLSClientConfig = tlsdial.Config(a.HealthTracker, tr.TLSClientConfig)
-	if !tr.TLSClientConfig.InsecureSkipVerify {
-		panic("unexpected") // should be set by tlsdial.Config
-	}
-	verify := tr.TLSClientConfig.VerifyConnection
-	if verify == nil {
-		panic("unexpected") // should be set by tlsdial.Config
-	}
-	// Demote all cert verification errors to log messages. We don't actually
-	// care about the TLS security (because we just do the Noise crypto atop whatever
-	// connection we get, including HTTP port 80 plaintext) so this permits
-	// middleboxes to MITM their users. All they'll see is some Noise.
-	tr.TLSClientConfig.VerifyConnection = func(cs tls.ConnectionState) error {
-		if err := verify(cs); err != nil && a.Logf != nil && !a.omitCertErrorLogging {
-			a.Logf("warning: TLS cert verificication for %q failed: %v", a.Hostname, err)
-		}
-		return nil // regardless
-	}
+	tr.TLSClientConfig = a.tlsClientConfig(tr.TLSClientConfig)
 
 	tr.DialTLSContext = dnscache.TLSDialer(dialer, dns, tr.TLSClientConfig)
 	tr.DisableCompression = true

--- a/control/controlhttp/controlhttpcommon/controlhttpcommon.go
+++ b/control/controlhttp/controlhttpcommon/controlhttpcommon.go
@@ -5,6 +5,11 @@
 // by the controlhttp client and controlhttpserver packages.
 package controlhttpcommon
 
+import (
+	"encoding/base64"
+	"strings"
+)
+
 // UpgradeHeader is the value of the Upgrade HTTP header used to
 // indicate the Tailscale control protocol.
 const UpgradeHeaderValue = "tailscale-control-protocol"
@@ -13,3 +18,47 @@ const UpgradeHeaderValue = "tailscale-control-protocol"
 // optionally contain base64-encoded initial handshake
 // payload, to save an RTT.
 const HandshakeHeaderName = "X-Tailscale-Handshake"
+
+// ALPNHandshakePrefix is the prefix of a pseudo ALPN protocol name used to
+// smuggle the client's Noise handshake initiation message inside a TLS
+// ClientHello, saving a round trip versus sending an HTTP upgrade request
+// inside the TLS session. The bytes following the prefix are the initiation
+// message, encoded with base64.RawStdEncoding.
+//
+// A client offering such an entry also offers UpgradeHeaderValue as a regular
+// ALPN protocol. A server that understands the smuggled handshake negotiates
+// UpgradeHeaderValue, after which the TLS stream carries the Noise protocol
+// directly (no HTTP layer), starting with the server's handshake response.
+// Servers that don't understand it negotiate another protocol (or none), and
+// the client falls back to the HTTP upgrade path over the same connection.
+//
+// The Noise initiation message is not secret; it's sent in cleartext HTTP
+// headers on the port 80 dial path already, so exposing it in the ClientHello
+// reveals nothing new.
+const ALPNHandshakePrefix = "x-ts-handshake."
+
+// EncodeALPNHandshake encodes init as an ALPN pseudo protocol name.
+//
+// The result must not exceed 255 bytes, the maximum length of an ALPN
+// protocol name. The 101-byte ts2021 initiation message encodes to 150
+// bytes, comfortably under the limit.
+func EncodeALPNHandshake(init []byte) string {
+	return ALPNHandshakePrefix + base64.RawStdEncoding.EncodeToString(init)
+}
+
+// DecodeALPNHandshake returns the Noise handshake initiation message
+// smuggled in the provided ALPN protocol names, if any.
+func DecodeALPNHandshake(protos []string) (init []byte, ok bool) {
+	for _, p := range protos {
+		b64, found := strings.CutPrefix(p, ALPNHandshakePrefix)
+		if !found {
+			continue
+		}
+		init, err := base64.RawStdEncoding.DecodeString(b64)
+		if err != nil {
+			return nil, false
+		}
+		return init, true
+	}
+	return nil, false
+}

--- a/control/controlhttp/controlhttpserver/alpn.go
+++ b/control/controlhttp/controlhttpserver/alpn.go
@@ -1,0 +1,99 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !ios
+
+package controlhttpserver
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"time"
+
+	"tailscale.com/control/controlbase"
+	"tailscale.com/control/controlhttp/controlhttpcommon"
+	"tailscale.com/types/key"
+)
+
+// AcceptALPNTLS terminates TLS on conn using base and, if the client
+// smuggled a Noise handshake initiation message in the ALPN protocol list of
+// its ClientHello (see controlhttpcommon.ALPNHandshakePrefix), completes the
+// ts2021 handshake directly over the TLS stream, with no HTTP layer.
+//
+// It returns exactly one of:
+//   - a completed control connection, if the client smuggled a handshake
+//   - the handshaken TLS connection, if the client didn't; the caller should
+//     serve HTTP over it, including the /ts2021 upgrade handler
+//   - an error, in which case conn has been closed
+//
+// The provided ctx bounds the TLS and Noise handshakes as in AcceptHTTP.
+// earlyWrite is as in AcceptHTTP.
+//
+// TODO(bradfitz): with stock crypto/tls, the server's Handshake doesn't
+// return until the client's Finished message arrives, so the Noise response
+// goes out one round trip later than necessary. A TLS stack capable of
+// 0.5-RTT writes (sending application data in the server's first flight)
+// would let the Noise response ride along with the TLS ServerHello flight,
+// making this path as fast as the plaintext port 80 path.
+func AcceptALPNTLS(ctx context.Context, conn net.Conn, base *tls.Config, private key.MachinePrivate, earlyWrite func(protocolVersion int, w io.Writer) error) (_ *controlbase.Conn, _ *tls.Conn, retErr error) {
+	defer func() {
+		if retErr != nil {
+			conn.Close()
+		}
+	}()
+
+	var init []byte
+	conf := base.Clone()
+	conf.GetConfigForClient = func(chi *tls.ClientHelloInfo) (*tls.Config, error) {
+		smuggled, ok := controlhttpcommon.DecodeALPNHandshake(chi.SupportedProtos)
+		if !ok {
+			return nil, nil
+		}
+		init = smuggled
+		c2 := base.Clone()
+		c2.NextProtos = []string{controlhttpcommon.UpgradeHeaderValue}
+		return c2, nil
+	}
+
+	tlsConn := tls.Server(conn, conf)
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		return nil, nil, fmt.Errorf("TLS handshake failed: %w", err)
+	}
+	if tlsConn.ConnectionState().NegotiatedProtocol != controlhttpcommon.UpgradeHeaderValue {
+		return nil, tlsConn, nil
+	}
+	if init == nil {
+		return nil, nil, errors.New("ts2021 ALPN protocol negotiated without a smuggled handshake")
+	}
+
+	// Cork writes so the Noise handshake response and any early payload
+	// go out in a single TLS record.
+	cwc := newWriteCorkingConn(tlsConn)
+
+	nc, err := controlbase.Server(ctx, cwc, private, init)
+	if err != nil {
+		return nil, nil, fmt.Errorf("noise handshake failed: %w", err)
+	}
+
+	if earlyWrite != nil {
+		if deadline, ok := ctx.Deadline(); ok {
+			if err := tlsConn.SetDeadline(deadline); err != nil {
+				return nil, nil, fmt.Errorf("setting conn deadline: %w", err)
+			}
+			defer tlsConn.SetDeadline(time.Time{})
+		}
+		if err := earlyWrite(nc.ProtocolVersion(), nc); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	if err := cwc.uncork(); err != nil {
+		return nil, nil, err
+	}
+
+	return nc, nil, nil
+}


### PR DESCRIPTION
The ts2021 dialer prefers plaintext port 80 because it saves a round
trip: the Noise handshake initiation rides along in the HTTP upgrade
request's X-Tailscale-Handshake header. Over port 443, that request
can only be sent after the TLS handshake completes, costing an extra
round trip versus port 80.

Teach the client to instead smuggle the Noise initiation message in
the TLS ClientHello itself, as a pseudo ALPN protocol entry with an
"x-ts-handshake." prefix. The initiation message is not secret (it is
already sent in cleartext on the port 80 path), and it fits within
ALPN's 255 byte protocol name limit. A server that understands the
smuggled handshake negotiates the "tailscale-control-protocol" ALPN
protocol and the TLS stream then carries Noise directly, with no HTTP
layer at all. The client also offers http/1.1 so that older servers
negotiate that instead of failing the handshake, in which case the
client falls back to the regular HTTP upgrade over the same
connection at no extra cost.

For now the server's Noise response still waits for the client's TLS
Finished message, because crypto/tls's server Handshake doesn't
support 0.5-RTT writes. Once the server can send application data in
its first flight, the Noise handshake will complete in the same round
trip as the TLS handshake, matching port 80 latency and letting us
prefer the TLS path.

Updates #21022
