### PR TITLE
scripts/installer.sh: fix Debian version detection for Parrot OS

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -80,7 +80,8 @@ main() {
 				if [ -z "${VERSION_ID:-}" ]; then
 					# rolling release. If you haven't kept current, that's on you.
 					APT_KEY_TYPE="keyring"
-				# Parrot Security is a special case that uses ID=debian
+				# Parrot 6 is a special case that uses ID=debian. Parrot 5 and
+				# Parrot 7 use ID=parrot and are handled in the parrot case below.
 				elif [ "$NAME" = "Parrot Security" ]; then
 					# All versions new enough to have this behaviour prefer keyring
 					# and their VERSION_ID is not consistent with Debian.
@@ -133,7 +134,59 @@ main() {
 					APT_KEY_TYPE="keyring"
 				fi
 				;;
-			parrot|mendel)
+			parrot)
+				OS="debian"
+				PACKAGETYPE="apt"
+				# Parrot uses its own codenames, so VERSION_CODENAME can't be
+				# used to pick a Debian release: Parrot 7.3 reports "echo", not
+				# "trixie". Parrot 7 and later do report the Debian release they
+				# are based on in DEBIAN_VERSION_FULL, but earlier releases don't,
+				# so fall back to mapping Parrot's own major version. Note that
+				# /etc/debian_version is not usable here either, as Parrot sets it
+				# to its own version ("6.4") or to a non-version string ("parrot").
+				DEBIAN_MAJOR="${DEBIAN_VERSION_FULL:-}"
+				DEBIAN_MAJOR="${DEBIAN_MAJOR%%.*}"
+				if [ -z "$DEBIAN_MAJOR" ]; then
+					# Parrot's major version tracks Debian's: Parrot 5 is
+					# based on Debian 11, 6 on 12, and 7 on 13. Match on
+					# the known versions so that an absent or unparseable
+					# VERSION_ID falls through to the newest release rather
+					# than erroring on a numeric comparison.
+					case "$VERSION_MAJOR" in
+						1|2|3|4)
+							DEBIAN_MAJOR="10"
+							;;
+						5)
+							DEBIAN_MAJOR="11"
+							;;
+						6)
+							DEBIAN_MAJOR="12"
+							;;
+						*)
+							DEBIAN_MAJOR="13"
+							;;
+					esac
+				fi
+				case "$DEBIAN_MAJOR" in
+					10)
+						VERSION="buster"
+						APT_KEY_TYPE="legacy"
+						;;
+					11)
+						VERSION="bullseye"
+						APT_KEY_TYPE="keyring"
+						;;
+					12)
+						VERSION="bookworm"
+						APT_KEY_TYPE="keyring"
+						;;
+					*)
+						VERSION="trixie"
+						APT_KEY_TYPE="keyring"
+						;;
+				esac
+				;;
+			mendel)
 				OS="debian"
 				PACKAGETYPE="apt"
 				if [ "$VERSION_MAJOR" -lt 5 ]; then


### PR DESCRIPTION
Fixes #20960.

## The bug

Parrot sets `ID=parrot`, which reaches the case shared with Mendel:

```sh
parrot|mendel)
        if [ "$VERSION_MAJOR" -lt 5 ]; then
                VERSION="buster"
        else
                VERSION="bullseye"   # every Parrot >= 5
        fi
```

So Parrot 6 (Debian 12) and Parrot 7 (Debian 13) are both configured with
the **bullseye** repository — one and two releases behind their actual base.
That matches the report in #20960: `Installing Tailscale for debian bullseye`
on a Debian 13 host.

## Why the obvious fixes don't work

Parrot can't be treated like the other Debian derivatives:

- **`VERSION_CODENAME` is Parrot's own codename**, not Debian's. Parrot 7.3
  reports `echo`; Parrot 5.3 reports `ara`. Neither is a Debian suite.
- **`/etc/debian_version` is not a Debian version on Parrot.** It is `parrot`
  on 5.3 and `6.4` on 6.3 — Parrot's own version, not Debian's.

Parrot 7 and later *do* publish `DEBIAN_VERSION_FULL` (`13.5` on 7.3), which
is authoritative, so this prefers it and falls back to mapping Parrot's major
version for older releases that lack it.

This also updates the comment in the `debian)` branch, which says Parrot
"doesn't specify the Debian version they're based off in os-release" — true
when it was written for Parrot 6, no longer true as of Parrot 7.

## Evidence

`/etc/os-release` taken from the published `parrotsec/core` images. Note that
`ID` changed across releases (`parrot` → `debian` → `parrot`), which is how
Parrot 7 regressed into the stale branch after #14487 added the Parrot 6
special case under `debian)`:

| image | `ID` | `NAME` | `VERSION_ID` | `DEBIAN_VERSION_FULL` | `/etc/debian_version` | Debian base |
|---|---|---|---|---|---|---|
| `parrotsec/core:5.3` | `parrot` | Parrot OS | `5.3` | – | `parrot` | 11 bullseye |
| `parrotsec/core:6.3` | `debian` | Parrot Security | `6.4` | – | `6.4` | 12 bookworm |
| `parrotsec/core:7.3` | `parrot` | Parrot Security | `7.3` | `13.5` | `13.1` | 13 trixie |

Parrot 6 reports `ID=debian` and so is still handled by the existing
`NAME = "Parrot Security"` case; it is unaffected by this change.

## Testing

I ran the script's detection logic against `os-release` fixtures taken
verbatim from those images, stopping before installation, and diffed the
result against `main`:

| fixture | before | after |
|---|---|---|
| parrot 5.3 | bullseye | bullseye |
| parrot 6.4 (`ID=debian`) | bookworm | bookworm |
| **parrot 7.3** | **bullseye** | **trixie** |
| parrot 4.11 | buster | buster |
| debian 13 | trixie | trixie |
| ubuntu 24.04 | noble | noble |
| mendel 5 | bullseye | bullseye |

Only Parrot results change; Mendel, Debian and Ubuntu are byte-identical.
`sh -n`, `dash -n` and `bash --posix -n` all pass, and `shellcheck -s sh`
reports no new findings (the two pre-existing infos at lines 54 and 461 are
unchanged).

The fallback uses a `case` rather than a numeric `if` chain so that an absent
or unparseable `VERSION_ID` resolves to the newest release instead of
emitting `[: : integer expression expected`, which the current code does.

`parrotsec/core:latest` is already in the `installer.yml` matrix, so CI
exercises this path end-to-end.

## Note on repository availability

`https://pkgs.tailscale.com/stable/debian/dists/trixie/Release` is published
and current (`Date: Mon, 24 Aug 2026`), so the new mapping points at a
repository that exists.

## Open question

Parrot 8, if it moves back to `ID=debian`, would hit the hardcoded `bookworm`
in the `debian)` branch and regress the same way. I kept this change scoped to
the reported bug, but I'm happy to route both paths through the shared
`DEBIAN_VERSION_FULL` logic if you'd prefer that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9g6a9TV4QsLbwGt92SD8v
