### PR TITLE
scripts/installer.sh: skip OpenRC setup when rc-update is absent

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -693,8 +693,12 @@ main() {
 			else
 				$SUDO apk add tailscale
 			fi
-			$SUDO rc-update add tailscale
-			$SUDO rc-service tailscale start
+			if type rc-update >/dev/null; then
+				$SUDO rc-update add tailscale
+				$SUDO rc-service tailscale start
+			else
+				echo "OpenRC not found, skipping service setup; start tailscaled with your init system"
+			fi
 			set +x
 			;;
 		xbps)


### PR DESCRIPTION
Alpine does not always ship OpenRC, so `rc-update add tailscale` fails with `rc-update: not found` straight after a successful `apk add`. The installer then exits 127, leaving tailscaled installed but never enabled, and printing what looks like a failed install.

Guard both OpenRC commands with the same `type` check the rest of the script already uses for setup-apkrepos, dnf-3 and gpg.

Reproduced on stock `alpine:latest`, which has no openrc. With the fix the installer exits 0 and `tailscale --version` works; with openrc installed, `rc-update add` still puts tailscale in the sysinit runlevel. The installer CI matrix already covers these images, but `continue-on-error: true` on the install step hides the non-zero exit.

Fixes #20549
