### PR TITLE
net/tsdial: don't touch the peerapi transport in Close when omitted

### DIFF
--- a/net/tsdial/tsdial.go
+++ b/net/tsdial/tsdial.go
@@ -204,7 +204,9 @@ func (d *Dialer) Close() error {
 		c.Close()
 	}
 	d.activeSysConns = nil
-	d.PeerAPITransport().CloseIdleConnections()
+	if buildfeatures.HasPeerAPIClient {
+		d.PeerAPITransport().CloseIdleConnections()
+	}
 	return nil
 }
 


### PR DESCRIPTION
Dialer.Close unconditionally called PeerAPITransport, which panics
when the binary is built with the ts_omit_peerapiclient build tag,
so any such binary crashed on shutdown. Skip the idle connection
cleanup in that case; there is no peerapi transport to clean up.

Updates #12614
