### PR TITLE
derp/derphttp: reject invalid DERP node hostname before proxy CONNECT

### DIFF
--- a/derp/derphttp/derphttp_client.go
+++ b/derp/derphttp/derphttp_client.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"go4.org/mem"
+	"golang.org/x/net/http/httpguts"
 	"tailscale.com/derp"
 	"tailscale.com/derp/derpconst"
 	"tailscale.com/envknob"
@@ -845,6 +846,15 @@ func firstStr(a, b string) string {
 
 // dialNodeUsingProxy connects to n using a CONNECT to the HTTP(s) proxy in proxyURL.
 func (c *Client) dialNodeUsingProxy(ctx context.Context, n *tailcfg.DERPNode, proxyURL *url.URL) (_ net.Conn, err error) {
+	// n.HostName comes from the control-supplied DERP map and is written
+	// verbatim into the CONNECT request line and Host header below. Reject
+	// anything that isn't a valid host value so a hostname carrying CR/LF (or
+	// other control bytes) can't inject extra headers or a second request into
+	// the proxy connection.
+	if !httpguts.ValidHostHeader(n.HostName) {
+		return nil, fmt.Errorf("derphttp: invalid DERP node hostname %q", n.HostName)
+	}
+
 	pu := proxyURL
 	var proxyConn net.Conn
 	if pu.Scheme == "https" {

--- a/derp/derphttp/derphttp_proxy_test.go
+++ b/derp/derphttp/derphttp_proxy_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package derphttp
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"tailscale.com/net/netmon"
+	"tailscale.com/tailcfg"
+	"tailscale.com/types/key"
+)
+
+// TestDialNodeUsingProxyRejectsInvalidHostname checks that a control-supplied
+// DERP hostname containing CR/LF is rejected before it can be written into the
+// proxy CONNECT request line. The guard fires before the proxy is dialed, so
+// the bogus proxy address here is never contacted.
+func TestDialNodeUsingProxyRejectsInvalidHostname(t *testing.T) {
+	c := NewRegionClient(key.NewNode(), t.Logf, netmon.NewStatic(),
+		func() *tailcfg.DERPRegion { return nil })
+	defer c.Close()
+
+	n := &tailcfg.DERPNode{
+		HostName: "127.0.0.1\r\nX-Injected: 1",
+		DERPPort: 443,
+	}
+	proxyURL := &url.URL{Scheme: "http", Host: "127.0.0.1:1"}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := c.dialNodeUsingProxy(ctx, n, proxyURL)
+	if err == nil {
+		t.Fatal("dialNodeUsingProxy accepted a hostname containing CRLF")
+	}
+	if !strings.Contains(err.Error(), "invalid DERP node hostname") {
+		t.Fatalf("got error %v, want an invalid-hostname error", err)
+	}
+}


### PR DESCRIPTION
When a DERP client reaches a node through an HTTP(s) proxy, dialNodeUsingProxy writes the CONNECT request by hand and puts net.JoinHostPort(n.HostName, port) into both the request line and the Host header. n.HostName comes straight from the DERP map that the control server sends, and net.JoinHostPort does no sanitizing, so a node whose hostname carries a CR/LF gets those bytes written verbatim into the plaintext bytes we send to the proxy. That lets whoever populated the DERP map fold extra headers, or a second pipelined request, into the connection to the operator's proxy, which is a different trust domain than the control plane, and it matters most for people pointed at a self-hosted or third-party control server. I noticed it while reading the proxy dial path next to the DERPPort handling and checking what validation the hostname gets before it hits the wire, which is none. The fix rejects the hostname with httpguts.ValidHostHeader at the top of dialNodeUsingProxy, before the proxy is even dialed, so a control-char host never reaches the write while normal DNS names and bracketed IPv6 literals still pass. I kept it in that one function since the other raw CONNECT writers in the tree either go over a verified TLS ServerName first (net/ace) or target the internal log server, so this is the only spot a control-supplied host reaches the proxy unchecked.