### PR TITLE
wgengine/magicsock: ignore stale DERP rebind ping failures

### DIFF
--- a/wgengine/magicsock/derp.go
+++ b/wgengine/magicsock/derp.go
@@ -924,13 +924,25 @@ func (c *Conn) maybeCloseDERPsOnRebind(okayLocalIPs []netip.Prefix) {
 			if err := dc.Ping(ctx); err != nil {
 				c.mu.Lock()
 				defer c.mu.Unlock()
-				c.closeOrReconnectDERPLocked(regionID, "rebind-ping-fail")
+				c.closeOrReconnectDERPIfCurrentLocked(regionID, dc, "rebind-ping-fail")
 				return
 			}
 			c.logf("post-rebind ping of DERP region %d okay", regionID)
 		}()
 	}
 	c.logActiveDerpLocked()
+}
+
+// closeOrReconnectDERPIfCurrentLocked closes the DERP connection to regionID
+// if dc is still the active connection for that region.
+//
+// c.mu must be held.
+func (c *Conn) closeOrReconnectDERPIfCurrentLocked(regionID tailcfg.DERPRegionID, dc *derphttp.Client, why string) {
+	ad, ok := c.activeDerp[regionID]
+	if !ok || ad.c != dc {
+		return
+	}
+	c.closeOrReconnectDERPLocked(regionID, why)
 }
 
 // closeOrReconnectDERPLocked closes the DERP connection to the

--- a/wgengine/magicsock/derp_test.go
+++ b/wgengine/magicsock/derp_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"testing"
 
+	"tailscale.com/derp/derphttp"
 	"tailscale.com/health"
 	"tailscale.com/net/netcheck"
 	"tailscale.com/tailcfg"
@@ -18,6 +19,54 @@ import (
 func CheckDERPHeuristicTimes(t *testing.T) {
 	if netcheck.PreferredDERPFrameTime <= frameReceiveRecordRate {
 		t.Errorf("PreferredDERPFrameTime too low; should be at least frameReceiveRecordRate")
+	}
+}
+
+func TestCloseOrReconnectDERPIfCurrentLocked(t *testing.T) {
+	const regionID tailcfg.DERPRegionID = 1
+	tests := []struct {
+		name        string
+		pingCurrent bool
+		wantClosed  bool
+	}{
+		{name: "stale-client"},
+		{name: "current-client", pingCurrent: true, wantClosed: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newConn(t.Logf)
+			staleClient := new(derphttp.Client)
+			currentClient := new(derphttp.Client)
+			cancelCalled := false
+			c.activeDerp = map[tailcfg.DERPRegionID]activeDerp{
+				regionID: {
+					c: currentClient,
+					cancel: func() {
+						cancelCalled = true
+					},
+				},
+			}
+			pingClient := staleClient
+			if tt.pingCurrent {
+				pingClient = currentClient
+			}
+
+			c.mu.Lock()
+			c.closeOrReconnectDERPIfCurrentLocked(regionID, pingClient, "test-ping-failure")
+			ad, ok := c.activeDerp[regionID]
+			c.mu.Unlock()
+
+			if gotClosed := !ok; gotClosed != tt.wantClosed {
+				t.Errorf("DERP connection closed = %v, want %v", gotClosed, tt.wantClosed)
+			}
+			if cancelCalled != tt.wantClosed {
+				t.Errorf("cancel called = %v, want %v", cancelCalled, tt.wantClosed)
+			}
+			if ok && ad.c != currentClient {
+				t.Errorf("active DERP client = %p, want %p", ad.c, currentClient)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

`maybeCloseDERPsOnRebind` pings each active DERP client asynchronously. If a second rebind replaces a client before an earlier ping fails, the old failure currently closes the replacement by region ID.

Guard the close or reconnect with the exact client pointer captured for the ping. The check runs under `Conn.mu`, serializing replacement with handling the ping result. It adds no allocations and no work to successful pings.

Fixes #12959

## Tests

- regression test fails against the old behavior and passes with the guard
- `go test ./wgengine/magicsock`
- `go test -race ./wgengine/magicsock`
- Tailscale custom vet and targeted staticcheck
- regression test repeated 100 times
- cross-compiled package tests for linux/amd64, linux/386, windows/amd64, and js/wasm