### PR TITLE
cmd/containerboot: avoid blocking service re-advertisement

### DIFF
--- a/cmd/containerboot/serve.go
+++ b/cmd/containerboot/serve.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"sync/atomic"
 	"time"
 
@@ -132,6 +133,8 @@ func refreshAdvertiseServices(ctx context.Context, sc *ipn.ServeConfig, lc klc.L
 	for svc := range sc.Services {
 		svcs = append(svcs, svc.String())
 	}
+	// Keep the prefs order stable across map iterations.
+	slices.Sort(svcs)
 
 	err := services.EnsureServicesAdvertised(ctx, svcs, lc, log.Printf)
 	if err != nil {

--- a/cmd/containerboot/serve_test.go
+++ b/cmd/containerboot/serve_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"testing"
 	"testing/synctest"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"tailscale.com/ipn"
@@ -202,6 +203,7 @@ func TestRefreshAdvertiseServices(t *testing.T) {
 	tests := []struct {
 		name                string
 		sc                  *ipn.ServeConfig
+		currentServices     []string
 		wantServices        []string
 		wantEditPrefsCalled bool
 		wantErr             bool
@@ -248,6 +250,17 @@ func TestRefreshAdvertiseServices(t *testing.T) {
 			wantEditPrefsCalled: true,
 		},
 		{
+			name: "already_advertised",
+			sc: &ipn.ServeConfig{
+				Services: map[tailcfg.ServiceName]*ipn.ServiceConfig{
+					"svc:service-a": {},
+					"svc:service-b": {},
+				},
+			},
+			currentServices: []string{"svc:service-a", "svc:service-b"},
+			wantServices:    []string{"svc:service-a", "svc:service-b"},
+		},
+		{
 			name: "services_with_tcp_and_web",
 			sc: &ipn.ServeConfig{
 				TCP: map[uint16]*ipn.TCPPortHandler{
@@ -261,21 +274,22 @@ func TestRefreshAdvertiseServices(t *testing.T) {
 					"svc:backend":  {},
 				},
 			},
-			wantServices:        []string{"svc:frontend", "svc:backend"},
+			wantServices:        []string{"svc:backend", "svc:frontend"},
 			wantEditPrefsCalled: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Run in a synctest bubble so that the 20 second
-			// post-EditPrefs failover wait in
-			// services.EnsureServicesAdvertised elapses on the fake
-			// clock instead of taking 20 seconds of wall time per
-			// subtest.
 			synctest.Test(t, func(t *testing.T) {
-				fakeLC := &localclient.FakeLocalClient{}
+				fakeLC := &localclient.FakeLocalClient{
+					GetPrefsResult: &ipn.Prefs{AdvertiseServices: tt.currentServices},
+				}
+				start := time.Now()
 				err := refreshAdvertiseServices(t.Context(), tt.sc, fakeLC)
+				if elapsed := time.Since(start); elapsed != 0 {
+					t.Errorf("refreshAdvertiseServices took %v, want no delay", elapsed)
+				}
 
 				if (err != nil) != tt.wantErr {
 					t.Errorf("refreshAdvertiseServices() error = %v, wantErr %v", err, tt.wantErr)
@@ -295,19 +309,8 @@ func TestRefreshAdvertiseServices(t *testing.T) {
 						t.Error("AdvertiseServicesSet should be true")
 					}
 
-					if len(mp.AdvertiseServices) != len(tt.wantServices) {
-						t.Errorf("AdvertiseServices length = %d, want %d", len(mp.Prefs.AdvertiseServices), len(tt.wantServices))
-					}
-
-					advertised := make(map[string]bool)
-					for _, svc := range mp.AdvertiseServices {
-						advertised[svc] = true
-					}
-
-					for _, want := range tt.wantServices {
-						if !advertised[want] {
-							t.Errorf("expected service %q to be advertised, but it wasn't", want)
-						}
+					if diff := cmp.Diff(tt.wantServices, mp.AdvertiseServices); diff != "" {
+						t.Errorf("AdvertiseServices mismatch (-want +got):\n%s", diff)
 					}
 				}
 			})

--- a/kube/localclient/local-client.go
+++ b/kube/localclient/local-client.go
@@ -18,6 +18,7 @@ import (
 type LocalClient interface {
 	WatchIPNBus(ctx context.Context, mask ipn.NotifyWatchOpt) (IPNBusWatcher, error)
 	SetServeConfig(context.Context, *ipn.ServeConfig) error
+	GetPrefs(context.Context) (*ipn.Prefs, error)
 	EditPrefs(ctx context.Context, mp *ipn.MaskedPrefs) (*ipn.Prefs, error)
 	CertDomains(ctx context.Context) ([]string, error)
 	CertIssuer
@@ -45,6 +46,10 @@ type localClient struct {
 
 func (lc *localClient) SetServeConfig(ctx context.Context, config *ipn.ServeConfig) error {
 	return lc.lc.SetServeConfig(ctx, config)
+}
+
+func (lc *localClient) GetPrefs(ctx context.Context) (*ipn.Prefs, error) {
+	return lc.lc.GetPrefs(ctx)
 }
 
 func (lc *localClient) EditPrefs(ctx context.Context, mp *ipn.MaskedPrefs) (*ipn.Prefs, error) {

--- a/kube/services/services.go
+++ b/kube/services/services.go
@@ -8,6 +8,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"tailscale.com/client/local"
@@ -19,37 +20,25 @@ import (
 // EnsureServicesAdvertised is a function that gets called on containerboot
 // startup and ensures that Services get advertised if they exist.
 func EnsureServicesAdvertised(ctx context.Context, services []string, lc localclient.LocalClient, logf logger.Logf) error {
+	prefs, err := lc.GetPrefs(ctx)
+	if err != nil {
+		return fmt.Errorf("error getting prefs: %w", err)
+	}
+	if slices.Equal(prefs.AdvertiseServices, services) {
+		return nil
+	}
+
 	if _, err := lc.EditPrefs(ctx, &ipn.MaskedPrefs{
 		AdvertiseServicesSet: true,
 		Prefs: ipn.Prefs{
 			AdvertiseServices: services,
 		},
 	}); err != nil {
-		// EditPrefs only returns an error if it fails _set_ its local prefs.
-		// If it fails to _persist_ the prefs in state, we don't get an error
-		// and we continue waiting below, as control will failover as usual.
+		// EditPrefs only reports failures to set the local prefs, not failures
+		// to persist them in state.
 		return fmt.Errorf("error setting prefs AdvertiseServices: %w", err)
 	}
-
-	// Services use the same (failover XOR regional routing) mechanism that
-	// HA subnet routers use. Unfortunately we don't yet get a reliable signal
-	// from control that it's responded to our unadvertisement, so the best we
-	// can do is wait for 20 seconds, where 15s is the approximate maximum time
-	// it should take for control to choose a new primary, and 5s is for buffer.
-	//
-	// Note: There is no guarantee that clients have been _informed_ of the new
-	// primary no matter how long we wait. We would need a mechanism to await
-	// netmap updates for peers to know for sure.
-	//
-	// See https://tailscale.com/kb/1115/high-availability for more details.
-	// TODO(tomhjp): Wait for a netmap update instead of sleeping when control
-	// supports that.
-	select {
-	case <-ctx.Done():
-		return nil
-	case <-time.After(20 * time.Second):
-		return nil
-	}
+	return nil
 }
 
 // EnsureServicesNotAdvertised is a function that gets called on containerboot

--- a/kube/services/services_test.go
+++ b/kube/services/services_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"tailscale.com/ipn"
+	"tailscale.com/kube/localclient"
+)
+
+func TestEnsureServicesAdvertised(t *testing.T) {
+	tests := []struct {
+		name      string
+		current   []string
+		want      []string
+		wantEdits int
+	}{
+		{
+			name:      "changed",
+			current:   []string{"svc:old"},
+			want:      []string{"svc:new"},
+			wantEdits: 1,
+		},
+		{
+			name:    "unchanged",
+			current: []string{"svc:one", "svc:two"},
+			want:    []string{"svc:one", "svc:two"},
+		},
+		{
+			name:      "noncanonical_order",
+			current:   []string{"svc:two", "svc:one"},
+			want:      []string{"svc:one", "svc:two"},
+			wantEdits: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				lc := &localclient.FakeLocalClient{
+					GetPrefsResult: &ipn.Prefs{AdvertiseServices: tt.current},
+				}
+				start := time.Now()
+				if err := EnsureServicesAdvertised(t.Context(), tt.want, lc, t.Logf); err != nil {
+					t.Fatal(err)
+				}
+				if elapsed := time.Since(start); elapsed != 0 {
+					t.Errorf("EnsureServicesAdvertised took %v, want no delay", elapsed)
+				}
+				if got := len(lc.EditPrefsCalls); got != tt.wantEdits {
+					t.Errorf("EditPrefs calls = %d, want %d", got, tt.wantEdits)
+				}
+			})
+		})
+	}
+}
+
+func TestEnsureServicesAdvertisedGetPrefsError(t *testing.T) {
+	wantErr := errors.New("get prefs")
+	lc := &getPrefsErrorClient{
+		FakeLocalClient: new(localclient.FakeLocalClient),
+		err:             wantErr,
+	}
+	if err := EnsureServicesAdvertised(t.Context(), []string{"svc:test"}, lc, t.Logf); !errors.Is(err, wantErr) {
+		t.Fatalf("EnsureServicesAdvertised error = %v, want %v", err, wantErr)
+	}
+	if got := len(lc.EditPrefsCalls); got != 0 {
+		t.Errorf("EditPrefs calls = %d, want 0", got)
+	}
+}
+
+type getPrefsErrorClient struct {
+	*localclient.FakeLocalClient
+	err error
+}
+
+func (lc *getPrefsErrorClient) GetPrefs(context.Context) (*ipn.Prefs, error) {
+	return nil, lc.err
+}


### PR DESCRIPTION
Fixes #20958.

Containerboot currently reconciles Tailscale Services synchronously for each relevant IPN notification. Even when advertisement was unchanged, EnsureServicesAdvertised called EditPrefs and then slept for 20 seconds. The unbuffered notification handoff can therefore fall behind tailscaled's bounded watcher queue until tailscaled disconnects it and containerboot exits.

Make advertisement idempotent by comparing the current preferences first. Sort service names derived from the serve-config map so the comparison and stored preference order are stable. A real advertisement update now returns immediately; the 20-second grace period remains unchanged for shutdown unadvertisement, where control-plane failover actually matters.

Tests cover changed, unchanged, noncanonical-order, and GetPrefs-error cases, including a fake-clock regression that took 20 seconds before this change and zero after it.

Tested:
- ./tool/go test ./kube/services ./kube/localclient ./kube/certs ./kube/state
- ./tool/go test -race ./kube/services -run '^TestEnsureServicesAdvertised' -count=10
- Linux amd64 and arm64 containerboot test compilation
- Tailscale custom vet, staticcheck, license headers, and go mod tidy -diff
