### PR TITLE
router: add exit node split tunnel option

### DIFF
--- a/README.exit-node-split-tunnel.md
+++ b/README.exit-node-split-tunnel.md
@@ -1,0 +1,181 @@
+# Exit Node Split Tunnel
+
+This fork adds a Linux option for using a Tailscale exit node without letting
+`tailscaled` install its normal policy-routing `ip rule` entries.
+
+The option is useful on routers, especially OpenWrt systems, where Tailscale
+should populate its routing table but another policy-routing system should
+decide which traffic uses that table.
+
+In this mode:
+
+- Tailscale still joins the tailnet normally.
+- Exit-node routes are still installed into Tailscale's Linux route table,
+  table `52`.
+- Tailscale does not install its automatic policy-routing rules for table `52`.
+- You can add your own `ip rule`, `nftables`, `mwan3`, `pbr`, or OpenWrt policy
+  routing rules to send only selected traffic to table `52`.
+
+## Why This Exists
+
+Standard Tailscale exit-node behavior on Linux installs routes into table `52`
+and also installs policy rules that make the host use those routes.
+
+That is correct for normal clients, but it is too broad for router split
+tunneling. For example, on OpenWrt you might want only traffic from one
+interface, VLAN, bridge, or source subnet to use the Tailscale exit node while
+all other traffic continues to use the normal WAN route.
+
+`--exit-node-split-tunnel=true` leaves table `52` available but lets you decide
+which packets should look it up.
+
+## Enable The Option
+
+First select an exit node as usual:
+
+```bash
+sudo tailscale set --exit-node=100.x.y.z
+```
+
+Then enable split-tunnel exit-node mode:
+
+```bash
+sudo tailscale set --exit-node-split-tunnel=true
+```
+
+You can check the current value with:
+
+```bash
+tailscale get exit-node-split-tunnel
+```
+
+Expected output:
+
+```text
+true
+```
+
+The setting is stored in Tailscale preferences, so it survives `tailscaled`
+restarts.
+
+To disable it and return to normal Tailscale exit-node behavior:
+
+```bash
+sudo tailscale set --exit-node-split-tunnel=false
+```
+
+## Cold-Start Configuration
+
+If you need to guarantee that Tailscale never installs its automatic policy
+rules during startup, set the option in the `tailscaled` config file before the
+daemon starts.
+
+Example:
+
+```json
+{
+  "Version": "alpha0",
+  "AuthKey": "file:/path/to/authkey",
+  "Hostname": "openwrt-router",
+  "acceptDNS": false,
+  "exitNode": "100.x.y.z",
+  "exitNodeSplitTunnel": true
+}
+```
+
+Start `tailscaled` with that config:
+
+```bash
+tailscaled --config=/etc/tailscale/tailscaled.json
+```
+
+Replace `100.x.y.z` with the Tailscale IP of your exit node.
+
+## Verify Behavior
+
+After enabling the option, table `52` should contain Tailscale routes:
+
+```bash
+ip route show table 52
+ip -6 route show table 52
+```
+
+With an exit node active, you should normally see default routes like:
+
+```text
+default dev tailscale0
+default dev tailscale0 metric 1024 pref medium
+```
+
+But Tailscale's automatic policy rules should be absent:
+
+```bash
+ip -4 rule show
+ip -6 rule show
+```
+
+On a clean system with split-tunnel mode enabled, IPv4 should look similar to:
+
+```text
+0:      from all lookup local
+32766:  from all lookup main
+32767:  from all lookup default
+```
+
+IPv6 should look similar to:
+
+```text
+0:      from all lookup local
+32766:  from all lookup main
+```
+
+You can also check for common Tailscale rule priorities:
+
+```bash
+ip -4 rule show | grep -E '(^|[[:space:]])(5210|5230|5250|5270|1310|1330|1350|1370):'
+ip -6 rule show | grep -E '(^|[[:space:]])(5210|5230|5250|5270|1310|1330|1350|1370):'
+```
+
+Both commands should produce no output.
+
+## OpenWrt Example
+
+Assume:
+
+- `br-lan` should keep using the normal WAN route.
+- `br-vpn` should use the Tailscale exit node.
+- Tailscale has installed exit-node routes into table `52`.
+
+Add a policy rule for only the selected interface:
+
+```bash
+ip rule add pref 1000 iif br-vpn lookup 52
+```
+
+Check routing decisions:
+
+```bash
+ip route get 1.1.1.1 iif br-vpn
+ip route get 1.1.1.1 iif br-lan
+```
+
+Traffic arriving on `br-vpn` should route through `tailscale0`. Traffic arriving
+on `br-lan` should continue to use the normal WAN route.
+
+For persistent OpenWrt configuration, put the equivalent policy in your normal
+OpenWrt routing stack, such as `pbr`, `mwan3`, hotplug scripts, or custom
+`/etc/config/network` rules.
+
+## Notes And Caveats
+
+- This option is Linux-specific.
+- This option only controls Tailscale's automatic policy-routing rules. It does
+  not disable route installation into table `52`.
+- This option does not create custom split-tunnel rules for you. You must add
+  your own policy routing to select which traffic uses table `52`.
+- If you enable the option on an already-running node, existing Tailscale policy
+  rules are removed.
+- If you disable the option, normal Tailscale policy rules are installed again.
+- This is intended for advanced router and policy-routing setups. For ordinary
+  clients, normal `tailscale set --exit-node=...` behavior is usually the right
+  choice.

--- a/cmd/tailscale/cli/get.go
+++ b/cmd/tailscale/cli/get.go
@@ -145,6 +145,8 @@ func prefValue(flagName string, prefs *ipn.Prefs, st *ipnstate.Status) any {
 		return ""
 	case "exit-node-allow-lan-access":
 		return prefs.ExitNodeAllowLANAccess
+	case "exit-node-split-tunnel":
+		return prefs.ExitNodeSplitTunnel
 	case "shields-up":
 		return prefs.ShieldsUp
 	case "ssh":

--- a/cmd/tailscale/cli/get_test.go
+++ b/cmd/tailscale/cli/get_test.go
@@ -71,6 +71,12 @@ func TestPrefValue(t *testing.T) {
 			want:  true,
 		},
 		{
+			name:  "exit-node-split-tunnel",
+			flag:  "exit-node-split-tunnel",
+			prefs: &ipn.Prefs{ExitNodeSplitTunnel: true},
+			want:  true,
+		},
+		{
 			name:  "shields-up",
 			flag:  "shields-up",
 			prefs: &ipn.Prefs{ShieldsUp: true},

--- a/cmd/tailscale/cli/set.go
+++ b/cmd/tailscale/cli/set.go
@@ -65,6 +65,7 @@ type setArgsT struct {
 	remoteConfig               bool
 	snat                       bool
 	statefulFiltering          bool
+	exitNodeSplitTunnel        bool
 	sync                       bool
 	netfilterMode              string
 	relayServerPort            string
@@ -116,6 +117,7 @@ func newSetFlagSet(goos string, setArgs *setArgsT) *flag.FlagSet {
 	case "linux":
 		setf.BoolVar(&setArgs.snat, "snat-subnet-routes", true, "source NAT traffic to local routes advertised with --advertise-routes")
 		setf.BoolVar(&setArgs.statefulFiltering, "stateful-filtering", false, "apply stateful filtering to forwarded packets (subnet routers, exit nodes, and so on)")
+		setf.BoolVar(&setArgs.exitNodeSplitTunnel, "exit-node-split-tunnel", false, "do not install Tailscale policy-routing rules for exit node traffic")
 		setf.StringVar(&setArgs.netfilterMode, "netfilter-mode", defaultNetfilterMode(), "netfilter mode (one of on, nodivert, off)")
 	case "windows":
 		setf.BoolVar(&setArgs.forceDaemon, "unattended", false, "run in \"Unattended Mode\" where Tailscale keeps running even after the current GUI user logs out (Windows-only)")
@@ -155,6 +157,7 @@ func runSet(ctx context.Context, args []string) (retErr error) {
 			Hostname:               setArgs.hostname,
 			OperatorUser:           setArgs.opUser,
 			NoSNAT:                 !setArgs.snat,
+			ExitNodeSplitTunnel:    setArgs.exitNodeSplitTunnel,
 			ForceDaemon:            setArgs.forceDaemon,
 			Sync:                   opt.NewBool(setArgs.sync),
 			AutoUpdate: ipn.AutoUpdatePrefs{

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -916,6 +916,7 @@ func init() {
 	addPrefFlagMapping("shields-up", "ShieldsUp")
 	addPrefFlagMapping("snat-subnet-routes", "NoSNAT")
 	addPrefFlagMapping("stateful-filtering", "NoStatefulFiltering")
+	addPrefFlagMapping("exit-node-split-tunnel", "ExitNodeSplitTunnel")
 	addPrefFlagMapping("exit-node-allow-lan-access", "ExitNodeAllowLANAccess")
 	addPrefFlagMapping("unattended", "ForceDaemon")
 	addPrefFlagMapping("operator", "OperatorUser")
@@ -1122,7 +1123,7 @@ func applyImplicitPrefs(prefs, oldPrefs *ipn.Prefs, env upCheckEnv) {
 
 func flagAppliesToOS(flag, goos string) bool {
 	switch flag {
-	case "netfilter-mode", "snat-subnet-routes", "stateful-filtering":
+	case "netfilter-mode", "snat-subnet-routes", "stateful-filtering", "exit-node-split-tunnel":
 		return goos == "linux"
 	case "unattended":
 		return goos == "windows"
@@ -1174,6 +1175,8 @@ func prefsToFlags(env upCheckEnv, prefs *ipn.Prefs) (flagVal map[string]any) {
 			set(exitNodeIPStr())
 		case "exit-node-allow-lan-access":
 			set(prefs.ExitNodeAllowLANAccess)
+		case "exit-node-split-tunnel":
+			set(prefs.ExitNodeSplitTunnel)
 		case "advertise-tags":
 			set(strings.Join(prefs.AdvertiseTags, ","))
 		case "hostname":

--- a/ipn/conf.go
+++ b/ipn/conf.go
@@ -31,6 +31,7 @@ type ConfigVAlpha struct {
 
 	ExitNode                   *string  `json:"exitNode,omitempty"` // IP, StableID, or MagicDNS base name
 	AllowLANWhileUsingExitNode opt.Bool `json:"allowLANWhileUsingExitNode,omitempty"`
+	ExitNodeSplitTunnel        opt.Bool `json:"exitNodeSplitTunnel,omitempty"`
 
 	AdvertiseRoutes   []netip.Prefix `json:",omitempty"`
 	AdvertiseExitNode opt.Bool       `json:",omitzero"`
@@ -113,6 +114,10 @@ func (c *ConfigVAlpha) ToPrefs() (MaskedPrefs, error) {
 	if c.AllowLANWhileUsingExitNode != "" {
 		mp.ExitNodeAllowLANAccess = c.AllowLANWhileUsingExitNode.EqualBool(true)
 		mp.ExitNodeAllowLANAccessSet = true
+	}
+	if c.ExitNodeSplitTunnel != "" {
+		mp.ExitNodeSplitTunnel = c.ExitNodeSplitTunnel.EqualBool(true)
+		mp.ExitNodeSplitTunnelSet = true
 	}
 	if c.AdvertiseRoutes != nil {
 		var routeErrs []error

--- a/ipn/conf_test.go
+++ b/ipn/conf_test.go
@@ -211,3 +211,28 @@ func TestConfigVAlphaToPrefsRemoteConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigVAlphaToPrefsExitNodeSplitTunnel(t *testing.T) {
+	for name, tt := range map[string]struct {
+		cfg     ConfigVAlpha
+		wantSet bool
+		wantVal bool
+	}{
+		"absent": {ConfigVAlpha{Version: "alpha0"}, false, false},
+		"true":   {ConfigVAlpha{Version: "alpha0", ExitNodeSplitTunnel: "true"}, true, true},
+		"false":  {ConfigVAlpha{Version: "alpha0", ExitNodeSplitTunnel: "false"}, true, false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			mp, err := tt.cfg.ToPrefs()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if mp.ExitNodeSplitTunnelSet != tt.wantSet {
+				t.Errorf("ExitNodeSplitTunnelSet = %v; want %v", mp.ExitNodeSplitTunnelSet, tt.wantSet)
+			}
+			if mp.ExitNodeSplitTunnel != tt.wantVal {
+				t.Errorf("ExitNodeSplitTunnel = %v; want %v", mp.ExitNodeSplitTunnel, tt.wantVal)
+			}
+		})
+	}
+}

--- a/ipn/ipn_clone.go
+++ b/ipn/ipn_clone.go
@@ -81,6 +81,7 @@ var _PrefsCloneNeedsRegeneration = Prefs(struct {
 	AutoExitNode               ExitNodeExpression
 	InternalExitNodePrior      tailcfg.StableNodeID
 	ExitNodeAllowLANAccess     bool
+	ExitNodeSplitTunnel        bool
 	CorpDNS                    bool
 	RunSSH                     bool
 	RunWebClient               bool

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -291,6 +291,14 @@ func (v PrefsView) InternalExitNodePrior() tailcfg.StableNodeID { return v.ж.In
 // routed directly or via the exit node.
 func (v PrefsView) ExitNodeAllowLANAccess() bool { return v.ж.ExitNodeAllowLANAccess }
 
+// ExitNodeSplitTunnel indicates whether Tailscale should avoid installing
+// Linux policy routing rules for the Tailscale route table. When enabled,
+// Tailscale still populates its routing table, but the host is responsible
+// for adding policy rules that select which traffic uses it.
+//
+// Linux-only.
+func (v PrefsView) ExitNodeSplitTunnel() bool { return v.ж.ExitNodeSplitTunnel }
+
 // CorpDNS specifies whether to install the Tailscale network's
 // DNS configuration, if it exists. It is the internal name for
 // the "tailscale set --accept-dns=" flag.
@@ -498,6 +506,7 @@ var _PrefsViewNeedsRegeneration = Prefs(struct {
 	AutoExitNode               ExitNodeExpression
 	InternalExitNodePrior      tailcfg.StableNodeID
 	ExitNodeAllowLANAccess     bool
+	ExitNodeSplitTunnel        bool
 	CorpDNS                    bool
 	RunSSH                     bool
 	RunWebClient               bool

--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -6538,6 +6538,7 @@ func (b *LocalBackend) routerConfigLocked(cfg *wgcfg.Config, prefs ipn.PrefsView
 		SubnetRoutes:        unmapIPPrefixes(prefs.AdvertiseRoutes().AsSlice()),
 		SNATSubnetRoutes:    !prefs.NoSNAT(),
 		StatefulFiltering:   doStatefulFiltering,
+		ManageIPRules:       !prefs.ExitNodeSplitTunnel(),
 		NetfilterMode:       prefs.NetfilterMode(),
 		Routes:              b.currentNode().osRoutes(),
 		NetfilterKind:       netfilterKind,

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -9782,6 +9782,29 @@ func TestRouterConfigExitNodeBlackhole(t *testing.T) {
 	}
 }
 
+func TestRouterConfigExitNodeSplitTunnel(t *testing.T) {
+	lb := newTestLocalBackend(t)
+	nm := &netmap.NetworkMap{
+		SelfNode: (&tailcfg.Node{
+			Name:      "test-node",
+			Addresses: []netip.Prefix{netip.MustParsePrefix("100.64.1.1/32")},
+		}).View(),
+	}
+	cfg := &wgcfg.Config{}
+
+	prefs := ipn.Prefs{}
+	rcfg := lb.routerConfigLocked(cfg, prefs.View(), nm)
+	if !rcfg.ManageIPRules {
+		t.Errorf("ManageIPRules = false; want true")
+	}
+
+	prefs.ExitNodeSplitTunnel = true
+	rcfg = lb.routerConfigLocked(cfg, prefs.View(), nm)
+	if rcfg.ManageIPRules {
+		t.Errorf("ManageIPRules = true; want false with ExitNodeSplitTunnel")
+	}
+}
+
 func TestApplyPrefsToHostinfoDedup(t *testing.T) {
 	t.Parallel()
 

--- a/ipn/ipnlocal/state_test.go
+++ b/ipn/ipnlocal/state_test.go
@@ -1305,6 +1305,7 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 			},
 			wantRouterCfg: &router.Config{
 				SNATSubnetRoutes: true,
+				ManageIPRules:    true,
 				NetfilterMode:    preftype.NetfilterOn,
 				LocalAddrs:       node1.SelfNode.Addresses().AsSlice(),
 				Routes:           routesWithQuad100(),
@@ -1362,6 +1363,7 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 			},
 			wantRouterCfg: &router.Config{
 				SNATSubnetRoutes: true,
+				ManageIPRules:    true,
 				NetfilterMode:    preftype.NetfilterOn,
 				LocalAddrs:       node2.SelfNode.Addresses().AsSlice(),
 				Routes:           routesWithQuad100(),
@@ -1411,6 +1413,7 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 			},
 			wantRouterCfg: &router.Config{
 				SNATSubnetRoutes: true,
+				ManageIPRules:    true,
 				NetfilterMode:    preftype.NetfilterOn,
 				LocalAddrs:       node1.SelfNode.Addresses().AsSlice(),
 				Routes:           routesWithQuad100(),
@@ -1439,6 +1442,7 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 			},
 			wantRouterCfg: &router.Config{
 				SNATSubnetRoutes: true,
+				ManageIPRules:    true,
 				NetfilterMode:    preftype.NetfilterOn,
 				LocalAddrs:       node3.SelfNode.Addresses().AsSlice(),
 				Routes:           routesWithQuad100(netip.MustParsePrefix("100.64.1.1/32"), netip.MustParsePrefix("100.64.1.2/32")),
@@ -1485,6 +1489,7 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 			},
 			wantRouterCfg: &router.Config{
 				SNATSubnetRoutes: true,
+				ManageIPRules:    true,
 				NetfilterMode:    preftype.NetfilterOn,
 				LocalAddrs:       node1.SelfNode.Addresses().AsSlice(),
 				Routes:           routesWithQuad100(),
@@ -1516,6 +1521,7 @@ func TestEngineReconfigOnStateChange(t *testing.T) {
 			},
 			wantRouterCfg: &router.Config{
 				SNATSubnetRoutes: true,
+				ManageIPRules:    true,
 				NetfilterMode:    preftype.NetfilterOn,
 				LocalAddrs:       node1.SelfNode.Addresses().AsSlice(),
 				Routes:           routesWithQuad100(),

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -129,6 +129,14 @@ type Prefs struct {
 	// routed directly or via the exit node.
 	ExitNodeAllowLANAccess bool
 
+	// ExitNodeSplitTunnel indicates whether Tailscale should avoid installing
+	// Linux policy routing rules for the Tailscale route table. When enabled,
+	// Tailscale still populates its routing table, but the host is responsible
+	// for adding policy rules that select which traffic uses it.
+	//
+	// Linux-only.
+	ExitNodeSplitTunnel bool
+
 	// CorpDNS specifies whether to install the Tailscale network's
 	// DNS configuration, if it exists. It is the internal name for
 	// the "tailscale set --accept-dns=" flag.
@@ -363,6 +371,7 @@ type MaskedPrefs struct {
 	AutoExitNodeSet               bool                `json:",omitempty"`
 	InternalExitNodePriorSet      bool                `json:",omitempty"` // Internal; can't be set by LocalAPI clients
 	ExitNodeAllowLANAccessSet     bool                `json:",omitempty"`
+	ExitNodeSplitTunnelSet        bool                `json:",omitempty"`
 	CorpDNSSet                    bool                `json:",omitempty"`
 	RunSSHSet                     bool                `json:",omitempty"`
 	RunWebClientSet               bool                `json:",omitempty"`
@@ -582,6 +591,9 @@ func (p *Prefs) pretty(goos string) string {
 		} else if !p.ExitNodeID.IsZero() {
 			fmt.Fprintf(&sb, "exit=%v lan=%t ", p.ExitNodeID, p.ExitNodeAllowLANAccess)
 		}
+		if p.ExitNodeSplitTunnel {
+			sb.WriteString("exitSplit=true ")
+		}
 		if p.AutoExitNode.IsSet() {
 			fmt.Fprintf(&sb, "auto=%v ", p.AutoExitNode)
 		}
@@ -674,6 +686,7 @@ func (p *Prefs) Equals(p2 *Prefs) bool {
 		p.AutoExitNode == p2.AutoExitNode &&
 		p.InternalExitNodePrior == p2.InternalExitNodePrior &&
 		p.ExitNodeAllowLANAccess == p2.ExitNodeAllowLANAccess &&
+		p.ExitNodeSplitTunnel == p2.ExitNodeSplitTunnel &&
 		p.CorpDNS == p2.CorpDNS &&
 		p.RunSSH == p2.RunSSH &&
 		p.Sync.Normalized() == p2.Sync.Normalized() &&

--- a/ipn/prefs_test.go
+++ b/ipn/prefs_test.go
@@ -44,6 +44,7 @@ func TestPrefsEqual(t *testing.T) {
 		"AutoExitNode",
 		"InternalExitNodePrior",
 		"ExitNodeAllowLANAccess",
+		"ExitNodeSplitTunnel",
 		"CorpDNS",
 		"RunSSH",
 		"RunWebClient",
@@ -183,6 +184,16 @@ func TestPrefsEqual(t *testing.T) {
 		{
 			&Prefs{ExitNodeAllowLANAccess: true},
 			&Prefs{ExitNodeAllowLANAccess: true},
+			true,
+		},
+		{
+			&Prefs{},
+			&Prefs{ExitNodeSplitTunnel: true},
+			false,
+		},
+		{
+			&Prefs{ExitNodeSplitTunnel: true},
+			&Prefs{ExitNodeSplitTunnel: true},
 			true,
 		},
 
@@ -595,6 +606,13 @@ func TestPrefsPretty(t *testing.T) {
 			},
 			"linux",
 			`Prefs{ra=false dns=false want=false routes=[] nf=off update=off Persist=nil}`,
+		},
+		{
+			Prefs{
+				ExitNodeSplitTunnel: true,
+			},
+			"linux",
+			`Prefs{ra=false dns=false want=false exitSplit=true routes=[] nf=off update=off Persist=nil}`,
 		},
 		{
 			Prefs{

--- a/wgengine/router/osrouter/router_linux.go
+++ b/wgengine/router/osrouter/router_linux.go
@@ -75,6 +75,7 @@ type linuxRouter struct {
 	// restore deleted ip rules.
 	ruleRestorePending atomic.Bool
 	ipRuleFixLimiter   *rate.Limiter
+	ipRulesSet         bool // guarded by mu; whether Tailscale policy-routing rules should be present
 
 	// Various feature checks for the network stack.
 	ipRuleAvailable bool     // whether kernel was built with IP_MULTIPLE_TABLES
@@ -347,6 +348,12 @@ func (r *linuxRouter) onIPRuleDeleted(table uint8, priority uint32) {
 		// Not our rule.
 		return
 	}
+	r.mu.Lock()
+	ipRulesSet := r.ipRulesSet
+	r.mu.Unlock()
+	if !ipRulesSet {
+		return
+	}
 	if r.ruleRestorePending.Swap(true) {
 		// Another timer is already pending.
 		return
@@ -360,7 +367,10 @@ func (r *linuxRouter) onIPRuleDeleted(table uint8, priority uint32) {
 	r.rulesAddedPub.Publish(AddIPRules{})
 
 	time.AfterFunc(rr.Delay()+250*time.Millisecond, func() {
-		if r.ruleRestorePending.Swap(false) && !r.closed.Load() {
+		r.mu.Lock()
+		ipRulesSet := r.ipRulesSet
+		r.mu.Unlock()
+		if r.ruleRestorePending.Swap(false) && !r.closed.Load() && ipRulesSet {
 			r.logf("somebody (likely systemd-networkd) deleted ip rules; restoring Tailscale's")
 			r.justAddIPRules()
 		}
@@ -372,9 +382,6 @@ func (r *linuxRouter) Up() error {
 	defer r.mu.Unlock()
 	if err := r.setNetfilterModeLocked(netfilterOff); err != nil {
 		return fmt.Errorf("setting netfilter mode: %w", err)
-	}
-	if err := r.addIPRules(); err != nil {
-		return fmt.Errorf("adding IP rules: %w", err)
 	}
 	if err := r.upInterface(); err != nil {
 		return fmt.Errorf("bringing interface up: %w", err)
@@ -403,6 +410,7 @@ func (r *linuxRouter) Close() error {
 	if err := r.delIPRules(); err != nil {
 		return err
 	}
+	r.ipRulesSet = false
 	if err := r.setNetfilterModeLocked(netfilterOff); err != nil {
 		return err
 	}
@@ -459,6 +467,10 @@ func (r *linuxRouter) Set(cfg *router.Config) error {
 	}
 
 	if err := r.setNetfilterModeLocked(cfg.NetfilterMode); err != nil {
+		errs = append(errs, err)
+	}
+
+	if err := r.setIPRulesLocked(cfg.ManageIPRules); err != nil {
 		errs = append(errs, err)
 	}
 
@@ -1514,6 +1526,33 @@ func (r *linuxRouter) addIPRules() error {
 	}
 
 	return r.justAddIPRules()
+}
+
+// setIPRulesLocked reconciles whether Tailscale's policy-routing rules are
+// installed. When disabled, Tailscale routes remain in the Tailscale route
+// table, but the host must add its own policy rules to use that table.
+//
+// [linuxRouter.mu] must be held.
+func (r *linuxRouter) setIPRulesLocked(want bool) error {
+	if !r.ipRuleAvailable {
+		r.ipRulesSet = false
+		return nil
+	}
+	if want {
+		if r.ipRulesSet {
+			return nil
+		}
+		if err := r.addIPRules(); err != nil {
+			return fmt.Errorf("adding IP rules: %w", err)
+		}
+		r.ipRulesSet = true
+		return nil
+	}
+	if err := r.delIPRules(); err != nil {
+		return fmt.Errorf("deleting IP rules: %w", err)
+	}
+	r.ipRulesSet = false
+	return nil
 }
 
 // RouteTable is a Linux routing table: both its name and number.

--- a/wgengine/router/osrouter/router_linux_test.go
+++ b/wgengine/router/osrouter/router_linux_test.go
@@ -58,7 +58,7 @@ ip rule add -6 pref 5270 table 52
 			name: "no-config",
 			in:   nil,
 			want: `
-up` + basic,
+up`,
 		},
 		{
 			name: "local-addr-only",
@@ -538,7 +538,12 @@ v6/nat/ts-postrouting -m mark --mark 0x40000/0xff0000 -j MASQUERADE
 
 	testState := func(t *testing.T, i int) {
 		t.Helper()
-		if err := router.Set(states[i].in); err != nil {
+		cfg := states[i].in
+		if cfg != nil {
+			cfg = cfg.Clone()
+			cfg.ManageIPRules = true
+		}
+		if err := router.Set(cfg); err != nil {
 			t.Fatalf("failed to set router config: %v", err)
 		}
 		got := fake.String()
@@ -559,6 +564,56 @@ v6/nat/ts-postrouting -m mark --mark 0x40000/0xff0000 -j MASQUERADE
 		i := rand.Intn(len(states))
 		state := states[i]
 		t.Run(state.name, func(t *testing.T) { testState(t, i) })
+	}
+}
+
+func TestRouterSetWithoutIPRules(t *testing.T) {
+	bus := eventbus.New()
+	defer bus.Close()
+	mon, err := netmon.New(bus, logger.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mon.Start()
+	defer mon.Close()
+
+	fake := NewFakeOS(t)
+	ht := health.NewTracker(bus)
+	router, err := newUserspaceRouterAdvanced(t.Logf, "tailscale0", mon, fake, ht, bus)
+	if err != nil {
+		t.Fatalf("failed to create router: %v", err)
+	}
+	lr := router.(*linuxRouter)
+	lr.nfr = fake.nfr
+	lr.interfaceV6Usable = func() bool { return true }
+	if err := lr.Up(); err != nil {
+		t.Fatalf("failed to up router: %v", err)
+	}
+
+	cfg := &Config{
+		LocalAddrs:    mustCIDRs("100.101.102.103/10"),
+		Routes:        mustCIDRs("100.100.100.100/32", "0.0.0.0/0"),
+		NetfilterMode: netfilterOff,
+		ManageIPRules: true,
+	}
+	if err := lr.Set(cfg); err != nil {
+		t.Fatalf("Set with IP rules: %v", err)
+	}
+	if got := fake.String(); !strings.Contains(got, "ip rule add -4 pref 5270 table 52") {
+		t.Fatalf("expected Tailscale policy rule in OS state, got:\n%s", got)
+	}
+
+	cfg = cfg.Clone()
+	cfg.ManageIPRules = false
+	if err := lr.Set(cfg); err != nil {
+		t.Fatalf("Set without IP rules: %v", err)
+	}
+	got := fake.String()
+	if strings.Contains(got, "ip rule add") {
+		t.Fatalf("unexpected policy rule in OS state, got:\n%s", got)
+	}
+	if !strings.Contains(got, "ip route add 0.0.0.0/0 dev tailscale0 table 52") {
+		t.Fatalf("expected Tailscale route table to remain populated, got:\n%s", got)
 	}
 }
 
@@ -1152,6 +1207,15 @@ func (o *fakeOS) run(args ...string) error {
 				break
 			}
 		}
+		if !found && args[1] == "rule" {
+			for i, el := range *ls {
+				if ruleMatchesDelete(el, rest) {
+					found = true
+					*ls = append((*ls)[:i], (*ls)[i+1:]...)
+					break
+				}
+			}
+		}
 		if !found {
 			o.t.Logf("note: can't delete %q, not present", rest)
 			// 'ip rule del' exits with code 2 when a row is
@@ -1172,6 +1236,27 @@ func (o *fakeOS) run(args ...string) error {
 	}
 
 	return nil
+}
+
+func ruleMatchesDelete(rule, del string) bool {
+	ruleFields := strings.Fields(rule)
+	delFields := strings.Fields(del)
+	pos := 0
+	for _, want := range delFields {
+		found := false
+		for pos < len(ruleFields) {
+			if ruleFields[pos] == want {
+				found = true
+				pos++
+				break
+			}
+			pos++
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 func (o *fakeOS) output(args ...string) ([]byte, error) {

--- a/wgengine/router/router.go
+++ b/wgengine/router/router.go
@@ -134,6 +134,7 @@ type Config struct {
 	// Linux-only things below, ignored on other platforms.
 	SNATSubnetRoutes    bool                   // SNAT traffic to local subnets
 	StatefulFiltering   bool                   // Apply stateful filtering to inbound connections
+	ManageIPRules       bool                   // manage policy-routing rules for the Tailscale route table
 	NetfilterMode       preftype.NetfilterMode // how much to manage netfilter rules
 	NetfilterKind       string                 // what kind of netfilter to use ("nftables", "iptables", or "" to auto-detect)
 	RemoveCGNATDropRule bool                   // whether to remove the firewall rule to drop non-Tailscale inbound traffic from CGNAT IPs

--- a/wgengine/router/router_test.go
+++ b/wgengine/router/router_test.go
@@ -15,7 +15,7 @@ func TestConfigEqual(t *testing.T) {
 	testedFields := []string{
 		"LocalAddrs", "Routes", "LocalRoutes", "NewMTU",
 		"SubnetRoutes", "SNATSubnetRoutes", "StatefulFiltering",
-		"NetfilterMode", "NetfilterKind", "RemoveCGNATDropRule",
+		"ManageIPRules", "NetfilterMode", "NetfilterKind", "RemoveCGNATDropRule",
 	}
 	configType := reflect.TypeFor[Config]()
 	configFields := []string{}
@@ -124,6 +124,16 @@ func TestConfigEqual(t *testing.T) {
 		{
 			&Config{StatefulFiltering: false},
 			&Config{StatefulFiltering: false},
+			true,
+		},
+		{
+			&Config{ManageIPRules: false},
+			&Config{ManageIPRules: true},
+			false,
+		},
+		{
+			&Config{ManageIPRules: true},
+			&Config{ManageIPRules: true},
 			true,
 		},
 


### PR DESCRIPTION
Updates #8843.

This adds a Linux-only exit-node split tunnel preference that lets Tailscale install exit-node routes into table 52 without installing Tailscale's automatic policy-routing ip rules.

This is intended for router setups, especially OpenWrt, where another policy routing system should decide which traffic uses table 52. With this enabled, users can select an exit node normally and then add their own ip rule, mwan3, pbr, nftables, or OpenWrt routing policy to direct only selected traffic through the exit node.

Changes:
- Add persisted `ExitNodeSplitTunnel` prefs/config support.
- Add `tailscale set --exit-node-split-tunnel`.
- Add `tailscale get exit-node-split-tunnel`.
- Thread the preference into Linux router config as `ManageIPRules`.
- Skip and remove Tailscale-managed policy rules when split tunnel mode is enabled, while keeping table 52 routes populated.
- Add Linux router, prefs, config, and CLI tests.
- Add fork README documentation for usage and verification.

Validation:
- `go test ./ipn ./ipn/ipnlocal ./wgengine/router ./cmd/tailscale/cli`
- `go test ./wgengine/router/osrouter`
- Live e2e on Linux: joined a tailnet with an exit node, verified table 52 contained default routes via `tailscale0`, verified `tailscale get exit-node-split-tunnel` returned `true`, and verified Tailscale policy rule priorities were absent for IPv4 and IPv6.
