### PR TITLE
net/socks5: use the Server logf fallback for Conn

### DIFF
--- a/net/socks5/socks5.go
+++ b/net/socks5/socks5.go
@@ -131,7 +131,7 @@ func (s *Server) Serve(ln net.Listener) error {
 		}
 		go func() {
 			defer c.Close()
-			conn := &Conn{logf: s.Logf, clientConn: c, srv: s}
+			conn := &Conn{logf: s.logf, clientConn: c, srv: s}
 			err := conn.Run()
 			if err != nil {
 				s.logf("client connection failed: %v", err)


### PR DESCRIPTION
`Serve` copied `Server.Logf` into `Conn.logf` directly, so a `Server` with no `Logf` set left `Conn.logf` nil and every error path that logged panicked with a nil func call. `Server.logf` already has the `log.Printf` fallback, so passing the method instead of the field is enough.

Fixes #ISSUE1
