### PR TITLE
net/socks5: guard udpClientAddr with a mutex

### DIFF
--- a/net/socks5/socks5.go
+++ b/net/socks5/socks5.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"slices"
 	"strconv"
+	"sync"
 	"time"
 
 	"tailscale.com/types/logger"
@@ -151,8 +152,25 @@ type Conn struct {
 	clientConn net.Conn
 	request    *request
 
-	udpClientAddr  net.Addr
+	// mu guards udpClientAddr, which is written by the client-to-target
+	// goroutine in handleUDPRequest and read by the per-target
+	// target-to-client goroutines in handleUDPResponse.
+	mu            sync.Mutex
+	udpClientAddr net.Addr
+
 	udpTargetConns map[socksAddr]net.Conn
+}
+
+func (c *Conn) setUDPClientAddr(addr net.Addr) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.udpClientAddr = addr
+}
+
+func (c *Conn) udpClient() net.Addr {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.udpClientAddr
 }
 
 // Run starts the new connection.
@@ -411,7 +429,7 @@ func (c *Conn) handleUDPRequest(
 	if err != nil {
 		return fmt.Errorf("read from client: %w", err)
 	}
-	c.udpClientAddr = addr
+	c.setUDPClientAddr(addr)
 	req, data, err := parseUDPRequest(buf[:n])
 	if err != nil {
 		return fmt.Errorf("parse udp request: %w", err)
@@ -451,7 +469,7 @@ func (c *Conn) handleUDPResponse(
 	}
 	data := append(pkt, buf[:n]...)
 	// use addr from client to send back
-	nn, err := clientConn.WriteTo(data, c.udpClientAddr)
+	nn, err := clientConn.WriteTo(data, c.udpClient())
 	if err != nil {
 		return fmt.Errorf("write to client: %w", err)
 	}

--- a/net/socks5/socks5.go
+++ b/net/socks5/socks5.go
@@ -131,7 +131,7 @@ func (s *Server) Serve(ln net.Listener) error {
 		}
 		go func() {
 			defer c.Close()
-			conn := &Conn{logf: s.Logf, clientConn: c, srv: s}
+			conn := &Conn{logf: s.logf, clientConn: c, srv: s}
 			err := conn.Run()
 			if err != nil {
 				s.logf("client connection failed: %v", err)

--- a/net/socks5/socks5_race_test.go
+++ b/net/socks5/socks5_race_test.go
@@ -1,0 +1,107 @@
+package socks5
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+)
+
+// TestUDPConcurrentClientAddrRace hammers the UDP associate path with
+// back-to-back requests to several targets without waiting for each
+// response, so the client->target goroutine keeps writing udpClientAddr
+// while the per-target target->client goroutines read it.
+func TestUDPConcurrentClientAddrRace(t *testing.T) {
+	const echoServers = 4
+	echo := make([]net.PacketConn, echoServers)
+	for i := range echo {
+		ln, err := net.ListenPacket("udp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		go udpEchoServer(ln)
+		echo[i] = ln
+	}
+	defer func() {
+		for _, l := range echo {
+			l.Close()
+		}
+	}()
+
+	socks5ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := socks5ln.Addr().(*net.TCPAddr).Port
+	go socks5Server(socks5ln)
+
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if _, err := conn.Write([]byte{socks5Version, 0x01, noAuthRequired}); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 1024)
+	if _, err := conn.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+	target := socksAddr{addrType: ipv4, addr: "0.0.0.0", port: 0}
+	tp, err := target.marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := conn.Write(append([]byte{socks5Version, byte(udpAssociate), 0x00}, tp...)); err != nil {
+		t.Fatal(err)
+	}
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxyAddr, err := parseSocksAddr(bytes.NewReader(buf[3:n]))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ua, err := net.ResolveUDPAddr("udp", proxyAddr.hostPort())
+	if err != nil {
+		t.Fatal(err)
+	}
+	uc, err := net.DialUDP("udp", nil, ua)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer uc.Close()
+
+	// Drain responses in the background; we don't care about ordering.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		b := make([]byte, 2048)
+		for {
+			if _, err := uc.Read(b); err != nil {
+				return
+			}
+		}
+	}()
+
+	// Fire without waiting, so writes and reads of udpClientAddr overlap.
+	for round := 0; round < 200; round++ {
+		for i := range echo {
+			p := echo[i].LocalAddr().(*net.UDPAddr).Port
+			a := socksAddr{addrType: ipv4, addr: "127.0.0.1", port: uint16(p)}
+			pkt, err := (&udpRequest{addr: a}).marshal()
+			if err != nil {
+				t.Fatal(err)
+			}
+			pkt = append(pkt, fmt.Appendf(nil, "r%d-%d", round, i)...)
+			if _, err := uc.Write(pkt); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	uc.Close()
+	wg.Wait()
+}


### PR DESCRIPTION
`udpClientAddr` was written by the client-to-target goroutine in `handleUDPRequest` and read by the per-target target-to-client goroutines in `handleUDPResponse`, with no synchronisation. Without a happens-before edge, both the `net.Addr` field and the `net.UDPAddr` behind it are published unsafely, so a response can be sent to a stale or torn client address.

Guarded with a mutex, and added a test that keeps requests in flight to several targets so the writer and readers overlap — the existing `TestUDP` is sequential and never triggers it.

`udpTargetConns` is deliberately left alone: it is written and read only on the client-to-target goroutine, so there is no race there.

Fixes #21048

---

Stacked on #21049 — that fix has to land first, otherwise the new test hits the nil `logf` panic instead of the race. Once #PR1 merges this rebases down to a single commit.
