### PR TITLE
cmd/tailscale: allow IPv6 localhost serve targets

### DIFF
--- a/cmd/tailscale/cli/serve_legacy.go
+++ b/cmd/tailscale/cli/serve_legacy.go
@@ -499,13 +499,12 @@ func expandProxyTarget(source string) (string, error) {
 	switch host {
 	case "localhost", "127.0.0.1":
 		host = "127.0.0.1"
+	case "::1":
+		// ok
 	default:
-		return "", fmt.Errorf("only localhost or 127.0.0.1 proxies are currently supported")
+		return "", fmt.Errorf("only localhost, 127.0.0.1, or ::1 proxies are currently supported")
 	}
-	url := u.Scheme + "://" + host
-	if u.Port() != "" {
-		url += ":" + u.Port()
-	}
+	url := u.Scheme + "://" + net.JoinHostPort(host, u.Port())
 	url += u.Path
 	return url, nil
 }
@@ -541,11 +540,11 @@ func (e *serveEnv) handleTCPServe(ctx context.Context, srcType string, srcPort u
 	}
 
 	switch host {
-	case "localhost", "127.0.0.1":
+	case "localhost", "127.0.0.1", "::1":
 		// ok
 	default:
 		fmt.Fprintf(Stderr, "error: invalid TCP source %q\n", dest)
-		fmt.Fprint(Stderr, "must be one of: localhost or 127.0.0.1\n\n", dest)
+		fmt.Fprint(Stderr, "must be one of: localhost, 127.0.0.1, or ::1\n\n", dest)
 		return errHelp
 	}
 
@@ -563,7 +562,10 @@ func (e *serveEnv) handleTCPServe(ctx context.Context, srcType string, srcPort u
 		sc = new(ipn.ServeConfig)
 	}
 
-	fwdAddr := "127.0.0.1:" + dstPortStr
+	if host == "localhost" {
+		host = "127.0.0.1"
+	}
+	fwdAddr := net.JoinHostPort(host, dstPortStr)
 
 	dnsName, err := e.getSelfDNSName(ctx)
 	if err != nil {

--- a/cmd/tailscale/cli/serve_legacy_test.go
+++ b/cmd/tailscale/cli/serve_legacy_test.go
@@ -328,6 +328,18 @@ func TestServeConfigMutations(t *testing.T) {
 		},
 	})
 	add(step{reset: true})
+	add(step{ // support IPv6 localhost proxy
+		command: cmd("https / http://[::1]:3000"),
+		want: &ipn.ServeConfig{
+			TCP: map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}},
+			Web: map[ipn.HostPort]*ipn.WebServerConfig{
+				"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
+					"/": {Proxy: "http://[::1]:3000"},
+				}},
+			},
+		},
+	})
+	add(step{reset: true})
 	add(step{ // support path in proxy
 		command: cmd("https / http://127.0.0.1:3000/foo/bar"),
 		want: &ipn.ServeConfig{
@@ -364,6 +376,17 @@ func TestServeConfigMutations(t *testing.T) {
 			TCP: map[uint16]*ipn.TCPPortHandler{
 				443: {
 					TCPForward:   "127.0.0.1:5432",
+					TerminateTLS: "foo.test.ts.net",
+				},
+			},
+		},
+	})
+	add(step{
+		command: cmd("tls-terminated-tcp:443 tcp://[::1]:8443"),
+		want: &ipn.ServeConfig{
+			TCP: map[uint16]*ipn.TCPPortHandler{
+				443: {
+					TCPForward:   "[::1]:8443",
 					TerminateTLS: "foo.test.ts.net",
 				},
 			},

--- a/cmd/tailscale/cli/serve_v2_test.go
+++ b/cmd/tailscale/cli/serve_v2_test.go
@@ -413,6 +413,29 @@ func TestServeDevConfigMutations(t *testing.T) {
 			},
 		},
 		{
+			name: "IPv6_localhost",
+			steps: []step{{
+				command: cmd("serve --bg --https=443 http://[::1]:3000"),
+				want: &ipn.ServeConfig{
+					TCP: map[uint16]*ipn.TCPPortHandler{443: {HTTPS: true}},
+					Web: map[ipn.HostPort]*ipn.WebServerConfig{
+						"foo.test.ts.net:443": {Handlers: map[string]*ipn.HTTPHandler{
+							"/": {Proxy: "http://[::1]:3000"},
+						}},
+					},
+				},
+			}},
+		},
+		{
+			name: "IPv6_localhost_TCP",
+			steps: []step{{
+				command: cmd("serve --tcp=5432 --bg tcp://[::1]:3000"),
+				want: &ipn.ServeConfig{
+					TCP: map[uint16]*ipn.TCPPortHandler{5432: {TCPForward: "[::1]:3000"}},
+				},
+			}},
+		},
+		{
 			name: "path_in_dest",
 			steps: []step{{
 				command: cmd("serve --bg --https=443 http://127.0.0.1:3000/foo/bar"),

--- a/ipn/serve.go
+++ b/ipn/serve.go
@@ -831,7 +831,7 @@ func ExpandProxyTargetValue(target string, supportedSchemes []string, defaultSch
 		return "", fmt.Errorf("invalid port %q", u.Port())
 	}
 
-	u.Host = fmt.Sprintf("%s:%d", u.Hostname(), port)
+	u.Host = net.JoinHostPort(u.Hostname(), strconv.Itoa(int(port)))
 
 	return u.String(), nil
 }

--- a/ipn/serve_test.go
+++ b/ipn/serve_test.go
@@ -285,6 +285,8 @@ func TestExpandProxyTargetDev(t *testing.T) {
 	}{
 		{name: "port-only", input: "8080", expected: "http://127.0.0.1:8080"},
 		{name: "hostname-and-port", input: "localhost:8080", expected: "http://localhost:8080"},
+		{name: "IPv6-localhost", input: "http://[::1]:8080", expected: "http://[::1]:8080"},
+		{name: "IPv6-localhost-path", input: "http://[::1]:8080/foo", expected: "http://[::1]:8080/foo"},
 		{name: "no-change", input: "http://127.0.0.1:8080", expected: "http://127.0.0.1:8080"},
 		{name: "include-path", input: "http://127.0.0.1:8080/foo", expected: "http://127.0.0.1:8080/foo"},
 		{name: "https-scheme", input: "https://localhost:8080", expected: "https://localhost:8080"},


### PR DESCRIPTION
Use net.JoinHostPort when expanding proxy targets so IPv6 loopback addresses retain the required brackets. Accept ::1 as an HTTP and TCP destination in both current and legacy serve implementations.

Fixes #8702