### PR TITLE
Fix removeDerpPeerRoute() by removing route when regionID is matched, instead of regionID and derphttp.Client match

### DIFF
--- a/wgengine/magicsock/derp.go
+++ b/wgengine/magicsock/derp.go
@@ -50,11 +50,10 @@ type derpRoute struct {
 }
 
 // removeDerpPeerRoute removes a DERP route entry previously added by addDerpPeerRoute.
-func (c *Conn) removeDerpPeerRoute(peer key.NodePublic, regionID tailcfg.DERPRegionID, dc *derphttp.Client) {
+func (c *Conn) removeDerpPeerRoute(peer key.NodePublic, regionID tailcfg.DERPRegionID) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	r2 := derpRoute{regionID, dc}
-	if r, ok := c.derpRoute[peer]; ok && r == r2 {
+	if r, ok := c.derpRoute[peer]; ok && r.regionID == regionID {
 		delete(c.derpRoute, peer)
 	}
 }
@@ -566,7 +565,7 @@ func (c *Conn) runDerpReader(ctx context.Context, regionID tailcfg.DERPRegionID,
 			// Forget that all these peers have routes.
 			for peer := range peerPresent {
 				delete(peerPresent, peer)
-				c.removeDerpPeerRoute(peer, regionID, dc)
+				c.removeDerpPeerRoute(peer, regionID)
 			}
 			if err == derphttp.ErrClientClosed {
 				return
@@ -662,7 +661,7 @@ func (c *Conn) runDerpReader(ctx context.Context, regionID tailcfg.DERPRegionID,
 				c.logf("[unexpected] magicsock: derp-%d peer %s gone, reason %v, removing route",
 					regionID, key.NodePublic(m.Peer).ShortString(), m.Reason)
 			}
-			c.removeDerpPeerRoute(key.NodePublic(m.Peer), regionID, dc)
+			c.removeDerpPeerRoute(key.NodePublic(m.Peer), regionID)
 			continue
 		default:
 			// Ignore.


### PR DESCRIPTION
WIP