### PR TITLE
wgengine/router/osrouter: native FreeBSD subnet routing via PF (opt-in)

### DIFF
--- a/cmd/tailscale/cli/set.go
+++ b/cmd/tailscale/cli/set.go
@@ -117,6 +117,8 @@ func newSetFlagSet(goos string, setArgs *setArgsT) *flag.FlagSet {
 		setf.BoolVar(&setArgs.snat, "snat-subnet-routes", true, "source NAT traffic to local routes advertised with --advertise-routes")
 		setf.BoolVar(&setArgs.statefulFiltering, "stateful-filtering", false, "apply stateful filtering to forwarded packets (subnet routers, exit nodes, and so on)")
 		setf.StringVar(&setArgs.netfilterMode, "netfilter-mode", defaultNetfilterMode(), "netfilter mode (one of on, nodivert, off)")
+	case "freebsd":
+		setf.BoolVar(&setArgs.snat, "snat-subnet-routes", true, "source NAT traffic to local routes advertised with --advertise-routes")
 	case "windows":
 		setf.BoolVar(&setArgs.forceDaemon, "unattended", false, "run in \"Unattended Mode\" where Tailscale keeps running even after the current GUI user logs out (Windows-only)")
 	}

--- a/cmd/tailscale/cli/up.go
+++ b/cmd/tailscale/cli/up.go
@@ -128,6 +128,8 @@ func newUpFlagSet(goos string, upArgs *upArgsT, cmd string) *flag.FlagSet {
 		upf.BoolVar(&upArgs.snat, "snat-subnet-routes", true, "source NAT traffic to local routes advertised with --advertise-routes")
 		upf.BoolVar(&upArgs.statefulFiltering, "stateful-filtering", false, "apply stateful filtering to forwarded packets (subnet routers, exit nodes, and so on)")
 		upf.StringVar(&upArgs.netfilterMode, "netfilter-mode", defaultNetfilterMode(), "netfilter mode (one of on, nodivert, off)")
+	case "freebsd":
+		upf.BoolVar(&upArgs.snat, "snat-subnet-routes", true, "source NAT traffic to local routes advertised with --advertise-routes")
 	case "windows":
 		upf.BoolVar(&upArgs.forceDaemon, "unattended", false, "run in \"Unattended Mode\" where Tailscale keeps running even after the current GUI user logs out (Windows-only)")
 	}
@@ -361,14 +363,15 @@ func prefsFromUpArgs(upArgs upArgsT, warnf logger.Logf, st *ipnstate.Status, goo
 	prefs.AppConnector.Advertise = upArgs.advertiseConnector
 	prefs.PostureChecking = upArgs.postureChecking
 
-	if goos == "linux" {
+	if goos == "linux" || goos == "freebsd" {
 		prefs.NoSNAT = !upArgs.snat
 		// We want to make sure user is aware setting --snat-subnet-routes=false with --advertise-exit-node would break exitnode,
 		// but we won't prevent them from doing it since there are current dependencies on that combination. (as of 2026-03-25)
 		if prefs.NoSNAT && prefs.AdvertisesExitNode() {
 			warnf("--snat-subnet-routes=false is set with --advertise-exit-node; internet traffic through this exit node may not work as expected")
 		}
-
+	}
+	if goos == "linux" {
 		// Backfills for NoStatefulFiltering occur when loading a profile; just set it explicitly here.
 		prefs.NoStatefulFiltering.Set(!upArgs.statefulFiltering)
 		v, warning, err := netfilterModeFromFlag(upArgs.netfilterMode)
@@ -1122,8 +1125,10 @@ func applyImplicitPrefs(prefs, oldPrefs *ipn.Prefs, env upCheckEnv) {
 
 func flagAppliesToOS(flag, goos string) bool {
 	switch flag {
-	case "netfilter-mode", "snat-subnet-routes", "stateful-filtering":
+	case "netfilter-mode", "stateful-filtering":
 		return goos == "linux"
+	case "snat-subnet-routes":
+		return goos == "linux" || goos == "freebsd"
 	case "unattended":
 		return goos == "windows"
 	}

--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -782,6 +782,19 @@ func handleSubnetsInNetstack() bool {
 		// Enable on Windows and tailscaled-on-macOS (this doesn't
 		// affect the GUI clients).
 		return true
+	case "freebsd":
+		// FreeBSD can route subnets in the kernel and SNAT them with pf,
+		// but that is not yet the safe default: the pf NAT rule we install
+		// never matches (evaluated but never translating), and inserting the
+		// pf anchor at runtime cannot preserve the contents of tables an
+		// existing ruleset references.
+		//
+		// Keep handling subnets in netstack, which does its own SNAT in
+		// userspace and touches no system state, and let the kernel path be
+		// opted into with TS_DEBUG_NETSTACK_SUBNETS=false. Only that path can
+		// serve --snat-subnet-routes=false, which netstack cannot do because
+		// it must rewrite the source address.
+		return true
 	}
 	return false
 }

--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -778,9 +778,9 @@ func handleSubnetsInNetstack() bool {
 		return true
 	}
 	switch runtime.GOOS {
-	case "windows", "darwin", "freebsd", "openbsd", "solaris", "illumos":
+	case "windows", "darwin", "openbsd", "solaris", "illumos":
 		// Enable on Windows and tailscaled-on-macOS (this doesn't
-		// affect the GUI clients), and on FreeBSD.
+		// affect the GUI clients).
 		return true
 	}
 	return false

--- a/ipn/ipn_view.go
+++ b/ipn/ipn_view.go
@@ -388,7 +388,7 @@ func (v PrefsView) Sync() opt.Bool { return v.ж.Sync }
 // network to route Tailscale traffic back to the subnet relay
 // machine.
 //
-// Linux-only.
+// Linux and FreeBSD only.
 func (v PrefsView) NoSNAT() bool { return v.ж.NoSNAT }
 
 // NoStatefulFiltering specifies whether to apply stateful filtering when

--- a/ipn/prefs.go
+++ b/ipn/prefs.go
@@ -224,7 +224,7 @@ type Prefs struct {
 	// network to route Tailscale traffic back to the subnet relay
 	// machine.
 	//
-	// Linux-only.
+	// Linux and FreeBSD only.
 	NoSNAT bool
 
 	// NoStatefulFiltering specifies whether to apply stateful filtering when

--- a/tstest/natlab/vmtest/cloudinit.go
+++ b/tstest/natlab/vmtest/cloudinit.go
@@ -248,9 +248,6 @@ func (e *Env) generateFreeBSDUserData(n *Node) string {
 	ud.WriteString("  - \"chmod +x /usr/local/bin/tailscaled /usr/local/bin/tailscale /usr/local/bin/tta\"\n")
 
 	// Enable IP forwarding for subnet routers.
-	// This is currently a noop as of 2026-04-08 because FreeBSD uses
-	// gvisor netstack for subnet routing until
-	// https://github.com/tailscale/tailscale/issues/5573 etc are fixed.
 	if n.advertiseRoutes != "" {
 		ud.WriteString("  - \"sysctl net.inet.ip.forwarding=1\"\n")
 		ud.WriteString("  - \"sysctl net.inet6.ip6.forwarding=1\"\n")

--- a/tstest/natlab/vmtest/pfsnat_test.go
+++ b/tstest/natlab/vmtest/pfsnat_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package vmtest_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"tailscale.com/tstest/natlab/vmtest"
+	"tailscale.com/tstest/natlab/vnet"
+)
+
+// TestSubnetRouterFreeBSDManyFlows runs the standard subnet-router topology
+// against a FreeBSD router with SNAT left at its default (true) and makes
+// several sequential HTTP requests, so that each request opens a fresh flow
+// through the router's SNAT path.
+//
+// A single-flow test cannot catch a NAT rule whose translation address is
+// wrong on average but right occasionally: PF's "-> (self)" round-robins new
+// states across every address on the machine, so one request has decent odds
+// of drawing the working (egress interface) address while most flows hang.
+// Multiple fresh flows make that failure deterministic. PF state is dumped
+// along the way so a failure shows which address each flow was translated to.
+func TestSubnetRouterFreeBSDManyFlows(t *testing.T) {
+	env := vmtest.New(t)
+
+	clientNet := env.AddNetwork("2.1.1.1", "192.168.1.1/24", "2000:1::1/64", vnet.EasyNAT)
+	internalNet := env.AddNetwork("10.0.0.1/24", "2000:2::1/64")
+
+	client := env.AddNode("client", clientNet,
+		vmtest.OS(vmtest.Gokrazy))
+	sr := env.AddNode("subnet-router", clientNet, internalNet,
+		vmtest.OS(vmtest.FreeBSD150),
+		vmtest.AdvertiseRoutes("10.0.0.0/24"))
+	backend := env.AddNode("backend", internalNet,
+		vmtest.OS(vmtest.Gokrazy),
+		vmtest.DontJoinTailnet(),
+		vmtest.WebServer(8080))
+
+	env.Start()
+	env.ApproveRoutes(sr, "10.0.0.0/24")
+
+	dump := func(label string) {
+		t.Logf("========== PF STATE: %s ==========", label)
+		for _, c := range []struct{ what, cmd string }{
+			{"pf info", "pfctl -s info | head -8"},
+			{"main nat ruleset", "pfctl -s nat"},
+			{"anchor nat (verbose, w/ counters)", "pfctl -a tailscale -vsn"},
+			{"state table (port 8080)", "pfctl -s state | grep 8080"},
+			{"interfaces", "ifconfig -a | grep -E '^[a-z]|inet '"},
+		} {
+			out, err := env.SSHExec(sr, c.cmd)
+			if err != nil {
+				t.Logf("--- %s: error: %v\n%s", c.what, err, out)
+				continue
+			}
+			t.Logf("--- %s:\n%s", c.what, strings.TrimRight(out, "\n"))
+		}
+	}
+
+	dump("after start, before traffic")
+
+	// Each request opens a fresh flow. A flow whose SNAT translation address
+	// is not routable from the backend blackholes at SYN, so count failures
+	// too, and record what the backend reported as the source it saw.
+	srcSeen := map[string]int{}
+	var okCount, failCount int
+	targetURL := fmt.Sprintf("http://%s:8080/", backend.LanIP(internalNet))
+	for i := range 8 {
+		res, err := env.HTTPGetStatus(client, targetURL)
+		if err != nil {
+			failCount++
+			t.Logf("request %d: FAILED: %v", i+1, err)
+			continue
+		}
+		okCount++
+		t.Logf("request %d response: %q", i+1, res.Body)
+		if _, src, ok := strings.Cut(res.Body, " from "); ok {
+			srcSeen[strings.TrimSpace(src)]++
+		}
+	}
+
+	dump("after traffic")
+
+	t.Logf("results: %d ok, %d failed; source addresses seen by backend:", okCount, failCount)
+	for src, n := range srcSeen {
+		t.Logf("    %-20s %d requests", src, n)
+	}
+	if failCount > 0 {
+		t.Errorf("%d of 8 requests failed: some flows were translated to an address the backend cannot route back to", failCount)
+	}
+	if len(srcSeen) > 1 {
+		t.Errorf("backend saw %d distinct source addresses %v, want 1: SNAT translation address is unstable across flows", len(srcSeen), srcSeen)
+	}
+}

--- a/wgengine/router/osrouter/router_darwin.go
+++ b/wgengine/router/osrouter/router_darwin.go
@@ -1,0 +1,12 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package osrouter
+
+import "tailscale.com/wgengine/router"
+
+func init() {
+	router.HookNewUserspaceRouter.Set(func(opts router.NewOpts) (router.Router, error) {
+		return newUserspaceBSDRouter(opts.Logf, opts.Tun, opts.NetMon, opts.Health)
+	})
+}

--- a/wgengine/router/osrouter/router_freebsd.go
+++ b/wgengine/router/osrouter/router_freebsd.go
@@ -4,24 +4,255 @@
 package osrouter
 
 import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/tailscale/wireguard-go/tun"
+	"tailscale.com/health"
 	"tailscale.com/net/netmon"
 	"tailscale.com/types/logger"
 	"tailscale.com/wgengine/router"
 )
 
 func init() {
+	router.HookNewUserspaceRouter.Set(func(opts router.NewOpts) (router.Router, error) {
+		return newFreeBSDRouter(opts.Logf, opts.Tun, opts.NetMon, opts.Health)
+	})
 	router.HookCleanUp.Set(func(logf logger.Logf, netMon *netmon.Monitor, ifName string) {
 		cleanUp(logf, ifName)
 	})
 }
 
+// freebsdRouter extends the shared BSD userspace router with FreeBSD-specific
+// IP forwarding and PF-based NAT for native subnet routing.
+type freebsdRouter struct {
+	*userspaceBSDRouter
+	snatSubnetRoutes bool
+}
+
+func newFreeBSDRouter(logf logger.Logf, tundev tun.Device, netMon *netmon.Monitor, health *health.Tracker) (router.Router, error) {
+	bsd, err := newUserspaceBSDRouter(logf, tundev, netMon, health)
+	if err != nil {
+		return nil, err
+	}
+	return &freebsdRouter{userspaceBSDRouter: bsd}, nil
+}
+
+func (r *freebsdRouter) Set(cfg *router.Config) (reterr error) {
+	if cfg == nil {
+		cfg = &shutdownConfig
+	}
+
+	setErr := func(err error) {
+		if reterr == nil {
+			reterr = err
+		}
+	}
+
+	// Base address and route management.
+	if err := r.userspaceBSDRouter.Set(cfg); err != nil {
+		setErr(err)
+	}
+
+	// Enable IP forwarding when advertising subnet routes.
+	if len(cfg.SubnetRoutes) > 0 {
+		r.enableIPForwarding()
+	}
+
+	// Manage PF NAT rules for subnet routing.
+	switch {
+	case cfg.SNATSubnetRoutes == r.snatSubnetRoutes:
+		// No change needed.
+	case cfg.SNATSubnetRoutes:
+		if err := r.addPFNATRules(); err != nil {
+			r.logf("adding PF NAT rules: %v", err)
+			setErr(err)
+		}
+	default:
+		if err := r.delPFNATRules(); err != nil {
+			r.logf("removing PF NAT rules: %v", err)
+			setErr(err)
+		}
+	}
+	r.snatSubnetRoutes = cfg.SNATSubnetRoutes
+
+	return reterr
+}
+
+func (r *freebsdRouter) enableIPForwarding() {
+	for _, kv := range []string{
+		"net.inet.ip.forwarding=1",
+		"net.inet6.ip6.forwarding=1",
+	} {
+		if out, err := cmd("sysctl", kv).CombinedOutput(); err != nil {
+			r.logf("warning: sysctl %s: %v (%s)", kv, err, strings.TrimSpace(string(out)))
+		}
+	}
+}
+
+// pfAnchorName is the PF anchor used for all Tailscale NAT/filter rules.
+// Using an anchor keeps our rules isolated from the user's existing PF
+// configuration; we only ever flush or modify rules inside this anchor.
+const pfAnchorName = "tailscale"
+
+// addPFNATRules configures PF to masquerade traffic from Tailscale addresses
+// leaving via non-Tailscale interfaces. This is the FreeBSD equivalent of the
+// Linux iptables MASQUERADE rule used for subnet routing.
+//
+// Rules are loaded into the "tailscale" PF anchor so that any pre-existing
+// user rules in the main ruleset are left untouched.
+func (r *freebsdRouter) addPFNATRules() error {
+	// Ensure the PF kernel module is loaded.
+	cmd("kldload", "pf").CombinedOutput() // may already be loaded
+
+	// Enable PF (idempotent; returns error if already enabled).
+	cmd("pfctl", "-e").CombinedOutput()
+
+	// Ensure the main ruleset references our anchor so PF evaluates it.
+	// We add both a nat-anchor (for NAT rules) and an anchor (for filter
+	// rules, currently just "pass" to avoid blocking) if not already present.
+	if err := ensurePFAnchorRef(); err != nil {
+		return fmt.Errorf("ensuring PF anchor reference: %w", err)
+	}
+
+	// Load rules into the tailscale anchor.
+	// Traffic from Tailscale CGNAT (100.64.0.0/10) or ULA (fd7a:115c:a1e0::/48)
+	// addresses exiting any non-Tailscale interface is source-NATed to the
+	// outgoing interface's address so that return traffic routes back through
+	// this node.
+	rules := fmt.Sprintf(
+		"nat on ! %s inet from 100.64.0.0/10 to any -> (self)\n"+
+			"nat on ! %s inet6 from fd7a:115c:a1e0::/48 to any -> (self)\n",
+		r.tunname, r.tunname,
+	)
+
+	pfctl := exec.Command("pfctl", "-a", pfAnchorName, "-f", "-")
+	pfctl.Stdin = strings.NewReader(rules)
+	out, err := pfctl.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("pfctl -a %s -f: %v (%s)", pfAnchorName, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// getPFMainRuleset reads the current main PF filter and NAT rules.
+func getPFMainRuleset() (filterRules, natRules string) {
+	if out, err := cmd("pfctl", "-s", "rules").CombinedOutput(); err == nil {
+		filterRules = string(out)
+	}
+	if out, err := cmd("pfctl", "-s", "nat").CombinedOutput(); err == nil {
+		natRules = string(out)
+	}
+	return
+}
+
+// loadPFMainRuleset replaces the main PF ruleset with the given combined
+// NAT + filter rules.
+func loadPFMainRuleset(rules string) error {
+	pfctl := exec.Command("pfctl", "-f", "-")
+	pfctl.Stdin = strings.NewReader(rules)
+	out, err := pfctl.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("pfctl -f: %v (%s)", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// ensurePFAnchorRef makes sure the main PF ruleset contains nat-anchor and
+// anchor references for "tailscale". Without these, PF won't evaluate our
+// anchor even if it has rules loaded.
+//
+// We read the current main ruleset and prepend the references only if they're
+// not already present, then reload the combined ruleset.
+func ensurePFAnchorRef() error {
+	filterRules, natRules := getPFMainRuleset()
+
+	var additions string
+	natAnchorRef := fmt.Sprintf("nat-anchor \"%s\"", pfAnchorName)
+	anchorRef := fmt.Sprintf("anchor \"%s\"", pfAnchorName)
+
+	if !strings.Contains(natRules, natAnchorRef) {
+		additions += natAnchorRef + "\n"
+	}
+	if !strings.Contains(filterRules, anchorRef) {
+		additions += anchorRef + "\n"
+	}
+	if additions == "" {
+		return nil // already present
+	}
+
+	// Prepend our anchor references so they're evaluated, then include
+	// all existing rules so we don't disrupt the user's configuration.
+	return loadPFMainRuleset(additions + natRules + filterRules)
+}
+
+// removePFAnchorRef removes the nat-anchor and anchor references for
+// "tailscale" from the main PF ruleset via read-modify-write, leaving
+// all other rules intact.
+func removePFAnchorRef() error {
+	filterRules, natRules := getPFMainRuleset()
+
+	natAnchorRef := fmt.Sprintf("nat-anchor \"%s\"", pfAnchorName)
+	anchorRef := fmt.Sprintf("anchor \"%s\"", pfAnchorName)
+
+	newNat := removeLines(natRules, natAnchorRef)
+	newFilter := removeLines(filterRules, anchorRef)
+
+	if newNat == natRules && newFilter == filterRules {
+		return nil // nothing to remove
+	}
+
+	return loadPFMainRuleset(newNat + newFilter)
+}
+
+// removeLines removes all lines from s that contain substr.
+func removeLines(s, substr string) string {
+	var b strings.Builder
+	for line := range strings.SplitSeq(s, "\n") {
+		if strings.Contains(line, substr) {
+			continue
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// delPFNATRules flushes rules inside the tailscale PF anchor and removes
+// the anchor references from the main ruleset.
+func (r *freebsdRouter) delPFNATRules() error {
+	// Flush rules inside the anchor.
+	if out, err := cmd("pfctl", "-a", pfAnchorName, "-F", "all").CombinedOutput(); err != nil {
+		return fmt.Errorf("pfctl -a %s -F all: %v (%s)", pfAnchorName, err, strings.TrimSpace(string(out)))
+	}
+	// Remove the anchor references from the main ruleset.
+	if err := removePFAnchorRef(); err != nil {
+		return fmt.Errorf("removing PF anchor reference: %w", err)
+	}
+	return nil
+}
+
+func (r *freebsdRouter) Close() error {
+	cleanUp(r.logf, r.tunname)
+	return nil
+}
+
 func cleanUp(logf logger.Logf, interfaceName string) {
+	// Flush only the tailscale PF anchor, leaving user rules intact.
+	if out, err := cmd("pfctl", "-a", pfAnchorName, "-F", "all").CombinedOutput(); err != nil {
+		logf("pfctl flush anchor %s: %v (%s)", pfAnchorName, err, strings.TrimSpace(string(out)))
+	}
+	// Remove the anchor references from the main ruleset.
+	if err := removePFAnchorRef(); err != nil {
+		logf("removing PF anchor ref: %v", err)
+	}
+
 	// If the interface was left behind, ifconfig down will not remove it.
 	// In fact, this will leave a system in a tainted state where starting tailscaled
 	// will result in "interface tailscale0 already exists"
 	// until the defunct interface is ifconfig-destroyed.
-	ifup := []string{"ifconfig", interfaceName, "destroy"}
-	if out, err := cmd(ifup...).CombinedOutput(); err != nil {
+	if out, err := cmd("ifconfig", interfaceName, "destroy").CombinedOutput(); err != nil {
 		logf("ifconfig destroy: %v\n%s", err, out)
 	}
 }

--- a/wgengine/router/osrouter/router_freebsd.go
+++ b/wgengine/router/osrouter/router_freebsd.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net"
 	"os/exec"
+	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/tailscale/wireguard-go/tun"
@@ -237,9 +239,43 @@ func ensurePFAnchorRef() error {
 		return nil // already present
 	}
 
+	// "pfctl -sn"/"-sr" print only a table's name, never the addresses it
+	// holds, so a ruleset reconstructed from them re-declares every table
+	// as empty. Reloading it would silently drop the contents of any table
+	// the operator populates out-of-band (a "persist file" table, "pfctl -T
+	// add", etc.), breaking whatever rules reference it. There is no way to
+	// insert an anchor reference into a running ruleset without a reload, so
+	// refuse rather than clobber, and tell the operator how to fix it
+	// permanently.
+	if t := pfTablesReferenced(natRules + filterRules); len(t) > 0 {
+		return fmt.Errorf("refusing to reload main PF ruleset: it references table(s) %s "+
+			"whose contents cannot be preserved across a reload; add %q and %q to "+
+			"/etc/pf.conf instead",
+			strings.Join(t, ", "), natAnchorRef, anchorRef)
+	}
+
 	// Prepend our anchor references so they're evaluated, then include
 	// all existing rules so we don't disrupt the user's configuration.
 	return loadPFMainRuleset(additions + natRules + filterRules)
+}
+
+// pfTableRx matches a table reference in "pfctl -sn"/"-sr" output, e.g. the
+// "<zabbix_proxies>" in "pass in on em0 from <zabbix_proxies> to any".
+var pfTableRx = regexp.MustCompile(`<([a-zA-Z0-9_.:-]+)>`)
+
+// pfTablesReferenced returns the sorted, deduplicated names of PF tables
+// referenced by the given ruleset text.
+func pfTablesReferenced(rules string) []string {
+	seen := map[string]bool{}
+	var names []string
+	for _, m := range pfTableRx.FindAllStringSubmatch(rules, -1) {
+		if !seen[m[1]] {
+			seen[m[1]] = true
+			names = append(names, m[1])
+		}
+	}
+	slices.Sort(names)
+	return names
 }
 
 // removePFAnchorRef removes the nat-anchor and anchor references for

--- a/wgengine/router/osrouter/router_freebsd.go
+++ b/wgengine/router/osrouter/router_freebsd.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync/atomic"
 
 	"github.com/tailscale/wireguard-go/tun"
 	"tailscale.com/health"
@@ -256,8 +257,21 @@ func ensurePFAnchorRef() error {
 
 	// Prepend our anchor references so they're evaluated, then include
 	// all existing rules so we don't disrupt the user's configuration.
-	return loadPFMainRuleset(additions + natRules + filterRules)
+	if err := loadPFMainRuleset(additions + natRules + filterRules); err != nil {
+		return err
+	}
+	addedPFAnchorRef.Store(true)
+	return nil
 }
+
+// addedPFAnchorRef records whether this process inserted the "tailscale"
+// anchor references into the main PF ruleset. removePFAnchorRef only removes
+// references we added: an operator who configured them statically in
+// /etc/pf.conf (the durable setup the ensurePFAnchorRef error recommends)
+// must not have tailscaled strip them from the running ruleset, drifting it
+// from their config, on every shutdown. This is process-local by design; a
+// fresh process (including the startup cleanUp hook) never removes them.
+var addedPFAnchorRef atomic.Bool
 
 // pfTableRx matches a table reference in "pfctl -sn"/"-sr" output, e.g. the
 // "<zabbix_proxies>" in "pass in on em0 from <zabbix_proxies> to any".
@@ -281,7 +295,17 @@ func pfTablesReferenced(rules string) []string {
 // removePFAnchorRef removes the nat-anchor and anchor references for
 // "tailscale" from the main PF ruleset via read-modify-write, leaving
 // all other rules intact.
+//
+// It only removes references this process added (see addedPFAnchorRef), and
+// even then leaves them in place if the ruleset now references PF tables,
+// since the reload cannot preserve their contents (see ensurePFAnchorRef).
+// Skipped removal is not an error: callers flush the anchor's contents first,
+// and a reference to an empty anchor has no effect on traffic.
 func removePFAnchorRef() error {
+	if !addedPFAnchorRef.Load() {
+		return nil
+	}
+
 	filterRules, natRules := getPFMainRuleset()
 
 	natAnchorRef := fmt.Sprintf("nat-anchor \"%s\"", pfAnchorName)
@@ -294,7 +318,15 @@ func removePFAnchorRef() error {
 		return nil // nothing to remove
 	}
 
-	return loadPFMainRuleset(newNat + newFilter)
+	if len(pfTablesReferenced(natRules+filterRules)) > 0 {
+		return nil // reload would empty the tables; leave the inert refs
+	}
+
+	if err := loadPFMainRuleset(newNat + newFilter); err != nil {
+		return err
+	}
+	addedPFAnchorRef.Store(false)
+	return nil
 }
 
 // removeLines removes all lines from s that contain substr.

--- a/wgengine/router/osrouter/router_freebsd.go
+++ b/wgengine/router/osrouter/router_freebsd.go
@@ -5,6 +5,7 @@ package osrouter
 
 import (
 	"fmt"
+	"net"
 	"os/exec"
 	"strings"
 
@@ -121,11 +122,19 @@ func (r *freebsdRouter) addPFNATRules() error {
 	// addresses exiting any non-Tailscale interface is source-NATed to the
 	// outgoing interface's address so that return traffic routes back through
 	// this node.
-	rules := fmt.Sprintf(
-		"nat on ! %s inet from 100.64.0.0/10 to any -> (self)\n"+
-			"nat on ! %s inet6 from fd7a:115c:a1e0::/48 to any -> (self)\n",
-		r.tunname, r.tunname,
-	)
+	//
+	// This must be one rule per interface translating to that interface's own
+	// address. A single "nat on ! tailscale0 ... -> (self)" rule looks
+	// equivalent but is not: "(self)" is a round-robin pool of every address
+	// on the machine (including tailscale0's own address and loopback), and
+	// pf deals each new state the next address in the pool. Flows translated
+	// to an address that isn't the egress interface's get replies that the
+	// far end cannot route back, so roughly (N-1)/N of connections through
+	// the subnet router silently hang at SYN.
+	rules, err := r.buildPFNATRules()
+	if err != nil {
+		return fmt.Errorf("building PF NAT rules: %w", err)
+	}
 
 	pfctl := exec.Command("pfctl", "-a", pfAnchorName, "-f", "-")
 	pfctl.Stdin = strings.NewReader(rules)
@@ -134,6 +143,52 @@ func (r *freebsdRouter) addPFNATRules() error {
 		return fmt.Errorf("pfctl -a %s -f: %v (%s)", pfAnchorName, err, strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+// buildPFNATRules returns the NAT rules for the tailscale anchor: one rule
+// per up, non-loopback, non-Tailscale interface, translating to that
+// interface's own address. Rules are emitted per address family only for
+// interfaces that hold a usable address of that family, since "-> (ifname)"
+// on an interface with no address of the packet's family cannot translate.
+//
+// The interface set is sampled when SNAT is enabled; interfaces added later
+// are not covered until SNAT is toggled or tailscaled restarts.
+func (r *freebsdRouter) buildPFNATRules() (string, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	for _, iface := range ifaces {
+		if iface.Name == r.tunname ||
+			iface.Flags&net.FlagLoopback != 0 ||
+			iface.Flags&net.FlagUp == 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		var has4, has6 bool
+		for _, a := range addrs {
+			ipn, ok := a.(*net.IPNet)
+			if !ok {
+				continue
+			}
+			if ip4 := ipn.IP.To4(); ip4 != nil {
+				has4 = true
+			} else if !ipn.IP.IsLinkLocalUnicast() {
+				has6 = true
+			}
+		}
+		if has4 {
+			fmt.Fprintf(&b, "nat on %s inet from 100.64.0.0/10 to any -> (%s)\n", iface.Name, iface.Name)
+		}
+		if has6 {
+			fmt.Fprintf(&b, "nat on %s inet6 from fd7a:115c:a1e0::/48 to any -> (%s)\n", iface.Name, iface.Name)
+		}
+	}
+	return b.String(), nil
 }
 
 // getPFMainRuleset reads the current main PF filter and NAT rules.

--- a/wgengine/router/osrouter/router_freebsd_test.go
+++ b/wgengine/router/osrouter/router_freebsd_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package osrouter
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestPFTablesReferenced(t *testing.T) {
+	tests := []struct {
+		name  string
+		rules string
+		want  []string
+	}{
+		{"empty", "", nil},
+		{
+			// What a bare FreeBSD box looks like: only our anchor refs.
+			"anchors only",
+			"nat-anchor \"tailscale\"\nanchor \"tailscale\"\n",
+			nil,
+		},
+		{
+			"no tables",
+			"scrub in all fragment reassemble\npass in all flags S/SA keep state\n",
+			nil,
+		},
+		{
+			// pfctl emits automatic tables like this for interface groups; a
+			// reload without table preservation would empty them too.
+			"automatic table",
+			"block drop in log inet from <__automatic_591ee83a_0> to any\n",
+			[]string{"__automatic_591ee83a_0"},
+		},
+		{
+			"named table",
+			"pass out log on em0 proto tcp from <zabbix_proxies> to any port = ssh\n",
+			[]string{"zabbix_proxies"},
+		},
+		{
+			"deduplicated and sorted",
+			"pass in log from <trusted> to any\n" +
+				"pass in log from <admins> to any\n" +
+				"pass out log from any to <trusted>\n",
+			[]string{"admins", "trusted"},
+		},
+		{
+			"names with punctuation",
+			"pass in log from <fw-cluster.v4> to any\npass in log from <mon_hosts> to any\n",
+			[]string{"fw-cluster.v4", "mon_hosts"},
+		},
+		{
+			// A bare "<" with no closing ">" is not a table reference.
+			"unclosed angle bracket",
+			"pass in all # < not a table\n",
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pfTablesReferenced(tt.rules); !slices.Equal(got, tt.want) {
+				t.Errorf("pfTablesReferenced() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/wgengine/router/osrouter/router_userspace_bsd.go
+++ b/wgengine/router/osrouter/router_userspace_bsd.go
@@ -22,12 +22,6 @@ import (
 	"tailscale.com/wgengine/router"
 )
 
-func init() {
-	router.HookNewUserspaceRouter.Set(func(opts router.NewOpts) (router.Router, error) {
-		return newUserspaceBSDRouter(opts.Logf, opts.Tun, opts.NetMon, opts.Health)
-	})
-}
-
 type userspaceBSDRouter struct {
 	logf    logger.Logf
 	netMon  *netmon.Monitor
@@ -37,7 +31,7 @@ type userspaceBSDRouter struct {
 	routes  map[netip.Prefix]bool
 }
 
-func newUserspaceBSDRouter(logf logger.Logf, tundev tun.Device, netMon *netmon.Monitor, health *health.Tracker) (router.Router, error) {
+func newUserspaceBSDRouter(logf logger.Logf, tundev tun.Device, netMon *netmon.Monitor, health *health.Tracker) (*userspaceBSDRouter, error) {
 	tunname, err := tundev.Name()
 	if err != nil {
 		return nil, err

--- a/wgengine/router/router.go
+++ b/wgengine/router/router.go
@@ -131,8 +131,11 @@ type Config struct {
 	// flow logging and is otherwise ignored.
 	SubnetRoutes []netip.Prefix
 
+	// SNATSubnetRoutes enables SNAT for traffic to local subnets.
+	// Implemented on Linux (iptables/nftables) and FreeBSD (PF).
+	SNATSubnetRoutes bool
+
 	// Linux-only things below, ignored on other platforms.
-	SNATSubnetRoutes    bool                   // SNAT traffic to local subnets
 	StatefulFiltering   bool                   // Apply stateful filtering to inbound connections
 	NetfilterMode       preftype.NetfilterMode // how much to manage netfilter rules
 	NetfilterKind       string                 // what kind of netfilter to use ("nftables", "iptables", or "" to auto-detect)


### PR DESCRIPTION
Native FreeBSD subnet routing via PF, as an opt-in. Supersedes #19312 (and my draft PRs #20733, #20734, #20738 against its branch), rebased onto main as one reviewable stack per conversation with @bradfitz at Tailscale Up.

**What ships enabled: nothing changes.** FreeBSD subnet routing stays in netstack (userspace SNAT, no pf involvement), so existing FreeBSD subnet routers upgrade without a behavior change. The kernel path -- required for `--snat-subnet-routes=false`, which netstack cannot honor -- is opted into with `TS_DEBUG_NETSTACK_SUBNETS=false`.

Commits, in order:

1. **Native FreeBSD routing, no-snat support** (@bradfitz's c02a3202 from #19312, rebased; his authorship preserved). The vmtest-harness parts of the original commit were dropped -- main's harness has since grown equivalents of all of them.
2. **SNAT to the egress interface address, not `(self)`.** PF's `(self)` is a round-robin pool of every address on the machine, dealt per new state, so roughly (N-1)/N of flows through the subnet router silently hung at SYN. One rule per egress interface instead. Receipts in the commit message; this was the bug behind the branch's maddening test flakiness.
3. **Don't clobber PF tables when adding anchor refs.** `pfctl -s` output names tables but never their contents, so the runtime ruleset reload silently emptied any operator-populated table, leaving rules that reference it matching nothing while still looking correct. Detect and refuse, pointing at the durable fix (anchor refs in /etc/pf.conf).
4. **Only remove PF anchor refs this process added.** Shutdown previously stripped statically-configured refs from the running ruleset and hit the same table clobber. Ownership semantics first identified by @overhacked on their fork; independent implementation.
5. **Keep FreeBSD subnets in netstack by default** -- the compatibility position above, kept as its own commit so flipping the default later stays a one-commit decision.
6. **Multi-flow SNAT vmtest.** Fails 4/8 against the `(self)` rule, with the pf state table naming each wrong translation address; passes 8/8 with per-interface rules and under netstack. No harness changes needed -- main's HTTPGetStatus/SSHExec cover it.

**Testing:** `TestSubnetRouterFreeBSD` (28.8s) and `TestSubnetRouterFreeBSDManyFlows` (8/8) pass on this branch under the natlab vmtests. The kernel path has no CI coverage yet -- exercising it needs TS_DEBUG_NETSTACK_SUBNETS plumbing into the vmtest VMs -- but it is what we run in production on 18 FreeBSD firewalls with `--snat-subnet-routes=false` (static pf.conf anchors, Ansible-managed), which is where this stack's fixes came from.

Independent of this stack: #20732 (FreeBSD IP-forwarding health check).

Updates #5573
