### PR TITLE
ipn/ipnlocal: don't evict another node's index entries on netmap deltas

### DIFF
--- a/ipn/ipnlocal/node_backend.go
+++ b/ipn/ipnlocal/node_backend.go
@@ -795,16 +795,17 @@ func (nb *nodeBackend) addNodeNameLocked(name string, nid tailcfg.NodeID) {
 }
 
 // removeNodeNameLocked removes both the FQDN and short-name keys for the
-// given node from nb.nodeByName. nb.mu must be held.
-func (nb *nodeBackend) removeNodeNameLocked(name string) {
+// given node from nb.nodeByName, unless another node has since claimed
+// them (see [deleteIfOwned]). nb.mu must be held.
+func (nb *nodeBackend) removeNodeNameLocked(name string, nid tailcfg.NodeID) {
 	if name == "" {
 		// We might support name-less nodes in the future; tailscale/corp#43949
 		return
 	}
 	canon := strings.ToLower(strings.TrimSuffix(name, "."))
-	delete(nb.nodeByName, canon)
+	deleteIfOwned(nb.nodeByName, canon, nid)
 	if suffix := nb.netMap.MagicDNSSuffix(); dnsname.HasSuffix(canon, suffix) {
-		delete(nb.nodeByName, dnsname.TrimSuffix(canon, suffix))
+		deleteIfOwned(nb.nodeByName, dnsname.TrimSuffix(canon, suffix), nid)
 	}
 }
 
@@ -1067,6 +1068,22 @@ func (nb *nodeBackend) mergeUserProfiles(profiles map[tailcfg.UserID]tailcfg.Use
 	}
 }
 
+// deleteIfOwned deletes m[k] only if the entry still maps to nid.
+//
+// It exists because a node index entry derived from a node's last-known
+// value may have since been claimed by another node. For example, control
+// can reassign a churning ephemeral peer's Tailscale IP to a newer peer
+// and deliver the new peer's upsert before the old peer's removal, either
+// in an earlier MapResponse or reordered within one batch by the NodeID
+// sort in [netmap.MutationsFromMapResponse]. Deleting unconditionally
+// would then evict the new owner's entry, breaking lookups by IP (WhoIs,
+// and thus PeerAPI and App Connector DNS) until the next full netmap.
+func deleteIfOwned[K comparable](m map[K]tailcfg.NodeID, k K, nid tailcfg.NodeID) {
+	if m[k] == nid {
+		delete(m, k)
+	}
+}
+
 // netmapDeltaResult describes the side effects of applying netmap
 // delta mutations that the caller must propagate.
 type netmapDeltaResult struct {
@@ -1129,15 +1146,17 @@ func (nb *nodeBackend) UpdateNetmapDelta(muts []netmap.NodeMutation) (res netmap
 				// console arrives as an upsert with a new Name, and a
 				// stale nodeByName entry would keep serving MagicDNS
 				// answers for the old name (tailscale/corp#45631).
+				// Evictions are conditional (see [deleteIfOwned]) so
+				// entries already claimed by another node are kept.
 				for _, ipp := range old.Addresses().All() {
 					if ipp.IsSingleIP() {
-						delete(nb.nodeByAddr, ipp.Addr())
+						deleteIfOwned(nb.nodeByAddr, ipp.Addr(), nid)
 					}
 				}
-				delete(nb.nodeByKey, old.Key())
-				delete(nb.nodeByWGString, old.Key().WireGuardGoString())
-				delete(nb.nodeByStableID, old.StableID())
-				nb.removeNodeNameLocked(old.Name())
+				deleteIfOwned(nb.nodeByKey, old.Key(), nid)
+				deleteIfOwned(nb.nodeByWGString, old.Key().WireGuardGoString(), nid)
+				deleteIfOwned(nb.nodeByStableID, old.StableID(), nid)
+				nb.removeNodeNameLocked(old.Name(), nid)
 			}
 			mak.Set(&nb.peers, nid, m.Node)
 			for _, ipp := range m.Node.Addresses().All() {
@@ -1156,14 +1175,14 @@ func (nb *nodeBackend) UpdateNetmapDelta(muts []netmap.NodeMutation) (res netmap
 			if old, ok := nb.peers[nid]; ok {
 				for _, ipp := range old.Addresses().All() {
 					if ipp.IsSingleIP() {
-						delete(nb.nodeByAddr, ipp.Addr())
+						deleteIfOwned(nb.nodeByAddr, ipp.Addr(), nid)
 					}
 				}
-				delete(nb.nodeByKey, old.Key())
-				delete(nb.nodeByWGString, old.Key().WireGuardGoString())
-				delete(nb.nodeByStableID, old.StableID())
+				deleteIfOwned(nb.nodeByKey, old.Key(), nid)
+				deleteIfOwned(nb.nodeByWGString, old.Key().WireGuardGoString(), nid)
+				deleteIfOwned(nb.nodeByStableID, old.StableID(), nid)
 				delete(nb.tsmpLearnedDisco, old.Key())
-				nb.removeNodeNameLocked(old.Name())
+				nb.removeNodeNameLocked(old.Name(), nid)
 				delete(nb.peers, nid)
 				rt.RemovePeer(nid)
 				res.RemovedPeers = append(res.RemovedPeers, old.StableID())

--- a/ipn/ipnlocal/node_backend_test.go
+++ b/ipn/ipnlocal/node_backend_test.go
@@ -6,6 +6,7 @@ package ipnlocal
 import (
 	"context"
 	"errors"
+	"fmt"
 	"iter"
 	"maps"
 	"net/netip"
@@ -670,4 +671,99 @@ func testNodeBackendMagicDNSHosts(t *testing.T, magicDNSEnabled bool) {
 	if fqdn, ok := nb.magicDNSPTR(netip.MustParseAddr("100.64.0.3")); !ok || fqdn != "p3-renamed.example.ts.net." {
 		t.Errorf("magicDNSPTR(100.64.0.3) after rename = %q, %v; want p3's new name", fqdn, ok)
 	}
+}
+
+// TestNodeBackendIndexReuseEviction exercises netmap delta orderings in
+// which one peer's address, name, or key index entry is claimed by a
+// second peer before the first peer's entries are evicted. The eviction
+// must keep the second peer's entries, or lookups by IP (WhoIs, and thus
+// PeerAPI and App Connector DNS) would fail until the next full netmap,
+// even though the peers map and the WireGuard config remain correct.
+func TestNodeBackendIndexReuseEviction(t *testing.T) {
+	addr := netip.MustParseAddr("100.64.0.1")
+	mkPeer := func(id tailcfg.NodeID, a netip.Addr) tailcfg.NodeView {
+		return (&tailcfg.Node{
+			ID:        id,
+			StableID:  tailcfg.StableNodeID(fmt.Sprintf("stable%d", id)),
+			Key:       makeNodeKeyFromID(id),
+			Name:      "runner.example.ts.net.",
+			HomeDERP:  1,
+			Addresses: []netip.Prefix{netip.PrefixFrom(a, a.BitLen())},
+		}).View()
+	}
+	newBackend := func(t *testing.T, initial ...tailcfg.NodeView) *nodeBackend {
+		nb := newNodeBackend(t.Context(), tstest.WhileTestRunningLogger(t), eventbus.New())
+		nb.SetNetMap(&netmap.NetworkMap{Peers: initial})
+		return nb
+	}
+	apply := func(t *testing.T, nb *nodeBackend, muts ...netmap.NodeMutation) {
+		t.Helper()
+		if _, handled := nb.UpdateNetmapDelta(muts); !handled {
+			t.Fatal("UpdateNetmapDelta not handled")
+		}
+	}
+	wantAddr := func(t *testing.T, nb *nodeBackend, a netip.Addr, want tailcfg.NodeID) {
+		t.Helper()
+		got, ok := nb.NodeByAddr(a)
+		if want == 0 {
+			if ok {
+				t.Errorf("NodeByAddr(%v) = %v; want no match", a, got)
+			}
+			return
+		}
+		if !ok || got != want {
+			t.Errorf("NodeByAddr(%v) = %v, %v; want %v", a, got, ok, want)
+		}
+	}
+
+	t.Run("remove-after-reuse", func(t *testing.T) {
+		// Peer 1 owns the address. Control reassigns it (and the
+		// MagicDNS name) to new peer 2 in one delta batch and removes
+		// peer 1 in a later batch, as happens with churning ephemeral
+		// peers. The removal of peer 1 must not evict peer 2's claims.
+		nb := newBackend(t, mkPeer(1, addr))
+		apply(t, nb, netmap.NodeMutationUpsert{Node: mkPeer(2, addr)})
+		apply(t, nb, netmap.MakeNodeMutationRemove(1))
+		wantAddr(t, nb, addr, 2)
+		if nid, ok := nb.NodeByName("runner.example.ts.net"); !ok || nid != 2 {
+			t.Errorf("NodeByName = %v, %v; want 2", nid, ok)
+		}
+		if nid, ok := nb.NodeByKey(makeNodeKeyFromID(2)); !ok || nid != 2 {
+			t.Errorf("NodeByKey(peer 2) = %v, %v; want 2", nid, ok)
+		}
+		if nid, ok := nb.NodeByKey(makeNodeKeyFromID(1)); ok {
+			t.Errorf("NodeByKey(peer 1) = %v; want no match after removal", nid)
+		}
+		// Removing the current owner still evicts.
+		apply(t, nb, netmap.MakeNodeMutationRemove(2))
+		wantAddr(t, nb, addr, 0)
+	})
+
+	t.Run("single-response-sort-order", func(t *testing.T) {
+		// Within one MapResponse, MutationsFromMapResponse sorts by
+		// NodeID, which can order the upsert of the address's new
+		// owner before the removal of its old owner.
+		nb := newBackend(t, mkPeer(10, addr))
+		muts, ok := netmap.MutationsFromMapResponse(&tailcfg.MapResponse{
+			PeersRemoved: []tailcfg.NodeID{10},
+			PeersChanged: []*tailcfg.Node{mkPeer(2, addr).AsStruct()},
+		}, time.Unix(123, 0))
+		if !ok {
+			t.Fatal("MutationsFromMapResponse failed")
+		}
+		apply(t, nb, muts...)
+		wantAddr(t, nb, addr, 2)
+	})
+
+	t.Run("upsert-eviction", func(t *testing.T) {
+		// Peer 2 claims peer 1's address. A later upsert of peer 1
+		// with a new address evicts entries derived from peer 1's old
+		// value, which must not include peer 2's claim.
+		nb := newBackend(t, mkPeer(1, addr))
+		apply(t, nb, netmap.NodeMutationUpsert{Node: mkPeer(2, addr)})
+		addr2 := netip.MustParseAddr("100.64.0.9")
+		apply(t, nb, netmap.NodeMutationUpsert{Node: mkPeer(1, addr2)})
+		wantAddr(t, nb, addr, 2)
+		wantAddr(t, nb, addr2, 1)
+	})
 }


### PR DESCRIPTION
When applying netmap deltas, nodeBackend evicted its index entries
(nodeByAddr, nodeByKey, nodeByWGString, nodeByStableID, nodeByName)
derived from a node's last-known value without checking that the entry
still pointed at that node. Control can reassign a churning ephemeral
peer's Tailscale IP (or MagicDNS name) to a newer peer and deliver the
new peer's upsert before the old peer's removal, either in an earlier
MapResponse or reordered within one batch by the NodeID sort in
netmap.MutationsFromMapResponse. The removal then wiped the new
owner's entry.

The peers map itself stayed correct in every ordering, so WireGuard
kept the peer and handshakes succeeded, but WhoIs lookups by IP failed
until the next full netmap rebuilt the indexes. On App Connectors that
surfaced as "peerapi: unknown peer" and refused DNS connections from
affected clients, with a toggle of Tailscale (forcing a full netmap)
as the only recovery.

Make every index eviction conditional on the entry still mapping to
the node being removed or replaced, and add a regression test covering
the cross-batch, intra-batch, and upsert-eviction orderings.

Updates tailscale/corp#47435
