### PR TITLE
net/captivedetection: skip default Tailscale endpoints when OmitDefaultRegions is set

### DIFF
--- a/net/captivedetection/captivedetection_test.go
+++ b/net/captivedetection/captivedetection_test.go
@@ -18,6 +18,7 @@ import (
 	"tailscale.com/derp/derpserver"
 	"tailscale.com/net/netmon"
 	"tailscale.com/syncs"
+	"tailscale.com/tailcfg"
 	"tailscale.com/tstest/nettest"
 	"tailscale.com/util/must"
 )
@@ -34,6 +35,27 @@ func TestAvailableEndpointsAlwaysAtLeastTwo(t *testing.T) {
 		if e.URL.Scheme != "http" {
 			t.Errorf("Expected HTTP URL in Endpoint, got HTTPS")
 		}
+	}
+}
+
+func TestAvailableEndpointsOmitDefaultRegions(t *testing.T) {
+	derpMap := &tailcfg.DERPMap{
+		OmitDefaultRegions: true,
+		Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
+			1: {
+				RegionID: 1,
+				Nodes: []*tailcfg.DERPNode{
+					{Name: "1a", RegionID: 1, HostName: "derp1.example.com", IPv4: "1.2.3.4", CanPort80: true},
+				},
+			},
+		},
+	}
+	endpoints := availableEndpoints(derpMap, 1, t.Logf, runtime.GOOS)
+	if len(endpoints) != 1 {
+		t.Fatalf("got %d endpoints, want 1 (the custom DERP node only): %v", len(endpoints), endpoints)
+	}
+	if got := endpoints[0].Provider; got != DERPMapPreferred {
+		t.Errorf("got endpoint provider %v, want %v", got, DERPMapPreferred)
 	}
 }
 

--- a/net/captivedetection/endpoints.go
+++ b/net/captivedetection/endpoints.go
@@ -113,16 +113,22 @@ func availableEndpoints(derpMap *tailcfg.DERPMap, preferredDERPRegionID tailcfg.
 
 	// Let's also try the default Tailscale coordination server and admin console.
 	// These are likely to be blocked on some networks.
-	appendTailscaleEndpoint := func(urlString string) {
-		u, err := url.Parse(urlString)
-		if err != nil {
-			logf("captivedetection: failed to parse Tailscale URL %q: %v", urlString, err)
-			return
+	//
+	// Skip these if the DERPMap has OmitDefaultRegions set, since that means the
+	// user has explicitly opted out of using Tailscale's default infrastructure,
+	// and we shouldn't be making requests to it either.
+	if !derpMap.OmitDefaultRegions {
+		appendTailscaleEndpoint := func(urlString string) {
+			u, err := url.Parse(urlString)
+			if err != nil {
+				logf("captivedetection: failed to parse Tailscale URL %q: %v", urlString, err)
+				return
+			}
+			endpoints = append(endpoints, Endpoint{u, http.StatusNoContent, "", false, Tailscale})
 		}
-		endpoints = append(endpoints, Endpoint{u, http.StatusNoContent, "", false, Tailscale})
+		appendTailscaleEndpoint("http://controlplane.tailscale.com/generate_204")
+		appendTailscaleEndpoint("http://login.tailscale.com/generate_204")
 	}
-	appendTailscaleEndpoint("http://controlplane.tailscale.com/generate_204")
-	appendTailscaleEndpoint("http://login.tailscale.com/generate_204")
 
 	// Sort the endpoints by provider so that we can prioritize DERP nodes in the preferred region, followed by
 	// any other DERP server elsewhere, then followed by Tailscale endpoints.


### PR DESCRIPTION
Motivation: When a DERPMap has OmitDefaultRegions set (self-hosted-only
DERP deployments), captive portal detection still unconditionally added
http://controlplane.tailscale.com/generate_204 and
http://login.tailscale.com/generate_204 as fallback probe endpoints.
Because detectOnInterface only probes the first 5 endpoints (sorted by
provider preference), any deployment with fewer non-Tailscale endpoints
than that ends up querying these two Tailscale hostnames on every
captive portal check, generating unwanted DNS/HTTP traffic to
infrastructure the deployment explicitly opted out of using. Reported
with a DNS log showing a large volume of queries to these two names.

Approach: In availableEndpoints, only append the two default Tailscale
endpoints when derpMap.OmitDefaultRegions is false. By the point this
check runs, derpMap is guaranteed non-nil, since an earlier check
replaces a nil/empty DERPMap with the static dnsfallback map (which
never sets OmitDefaultRegions). This is a pure function of the DERPMap
input, so the fix is fully covered by a unit test without needing a
live control server or cluster.

This addresses only the OmitDefaultRegions part of the report. The
report's other observation, that captive portal checks recur every 5
minutes more often on IPv6-less Linux hosts, traces to a separate,
unconfirmed root cause in the STUN probe cancellation logic in
net/netcheck and is not addressed here.

Validation: go build ./net/captivedetection/..., go vet
./net/captivedetection/..., gofmt -l (clean), and go test
./net/captivedetection/... -v (all pass). Added
TestAvailableEndpointsOmitDefaultRegions, which fails without this
change (asserting on the previously-included Tailscale endpoints) and
passes with it; confirmed this by temporarily reverting the
endpoints.go change and re-running the test. Also ran the repo's
custom vet tool: ./tool/go vet -vettool=/tmp/vettool
./net/captivedetection/... with no issues. Could not run golangci-lint
locally (the installed binary targets Go 1.26, older than this repo's
required 1.27.1 toolchain), so that check is disclosed rather than
run.

Updates https://github.com/tailscale/tailscale/issues/17223

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
Assisted-by: claude-sonnet-5 (via Claude Code)

Fixes #17223