### PR TITLE
wgengine/netstack: fix subnet refcount key mismatch for 4via6

### DIFF
--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -680,6 +680,14 @@ func (ns *Impl) addSubnetAddress(ip netip.Addr) {
 func (ns *Impl) removeSubnetAddress(ip netip.Addr) {
 	ns.mu.Lock()
 	defer ns.mu.Unlock()
+	// A decrement with no matching prior increment must not drive the
+	// count negative: a negative count would make a later addSubnetAddress
+	// bring it to 0 instead of 1, so the address would never be
+	// re-registered with netstack and forwarding to it would fail.
+	if ns.connsOpenBySubnetIP[ip] <= 0 {
+		delete(ns.connsOpenBySubnetIP, ip)
+		return
+	}
 	ns.connsOpenBySubnetIP[ip]--
 	// Only unregister address from netstack after last concurrent connection.
 	if ns.connsOpenBySubnetIP[ip] == 0 {
@@ -1560,6 +1568,16 @@ func (ns *Impl) acceptTCP(r *tcp.ForwarderRequest) {
 
 	dstAddrPort := netip.AddrPortFrom(dialIP, reqDetails.LocalPort)
 
+	// subnetAddrKey and removeSubnetAddr capture, before the 4via6 rewrite
+	// of dialIP below, the same address and condition that
+	// wrapTCPProtocolHandler used to call addSubnetAddress for this
+	// connection. The deferred removeSubnetAddress call must use this key
+	// and condition rather than the post-rewrite dialIP/isTailscaleIP:
+	// decrementing a different key than was incremented drives that key's
+	// count negative and leaks the one that was actually incremented.
+	subnetAddrKey := dialIP
+	removeSubnetAddr := !isLocal && !ns.isVIPServiceIP(subnetAddrKey)
+
 	isVia := viaRange.Contains(dialIP)
 	var viaIP netip.Addr
 	if isVia {
@@ -1569,10 +1587,10 @@ func (ns *Impl) acceptTCP(r *tcp.ForwarderRequest) {
 	}
 
 	defer func() {
-		if !isTailscaleIP {
+		if removeSubnetAddr {
 			// if this is a subnet IP, we added this in before the TCP handshake
 			// so netstack is happy TCP-handshaking as a subnet IP
-			ns.removeSubnetAddress(dialIP)
+			ns.removeSubnetAddress(subnetAddrKey)
 		}
 	}()
 

--- a/wgengine/netstack/netstack_test.go
+++ b/wgengine/netstack/netstack_test.go
@@ -2195,3 +2195,44 @@ func TestInjectLoopback(t *testing.T) {
 		t.Errorf("got %q, want %q", got, "loopback test")
 	}
 }
+
+// TestRemoveSubnetAddressUnderflow verifies that a removeSubnetAddress call
+// with no matching prior addSubnetAddress does not drive
+// connsOpenBySubnetIP negative. This is a regression test for
+// https://github.com/tailscale/tailscale/issues/20730, where acceptTCP's
+// deferred removeSubnetAddress call used a different address (the
+// post-4via6-rewrite dialIP) than wrapTCPProtocolHandler's addSubnetAddress
+// call had incremented (the pre-rewrite, on-the-wire destination). The
+// unmatched decrement drove the raw-IPv4 key negative, so a later genuine
+// addSubnetAddress for that key only brought the count to 0 instead of 1,
+// and the address was never re-registered with netstack.
+func TestRemoveSubnetAddressUnderflow(t *testing.T) {
+	ns := makeNetstack(t, nil)
+
+	addr := netip.MustParseAddr("172.16.1.1")
+
+	subnetCount := func() (int, bool) {
+		ns.mu.Lock()
+		defer ns.mu.Unlock()
+		n, ok := ns.connsOpenBySubnetIP[addr]
+		return n, ok
+	}
+
+	// A remove with no matching add must be a no-op, not go negative.
+	ns.removeSubnetAddress(addr)
+	if n, ok := subnetCount(); ok {
+		t.Fatalf("connsOpenBySubnetIP[%v] = %d after unmatched remove; want no entry", addr, n)
+	}
+
+	// A later add must still register the address (count reaches 1).
+	ns.addSubnetAddress(addr)
+	if n, ok := subnetCount(); !ok || n != 1 {
+		t.Fatalf("connsOpenBySubnetIP[%v] = %d (present=%v) after add; want 1", addr, n, ok)
+	}
+
+	// The paired remove drops the entry.
+	ns.removeSubnetAddress(addr)
+	if n, ok := subnetCount(); ok {
+		t.Fatalf("connsOpenBySubnetIP[%v] = %d after paired remove; want no entry", addr, n)
+	}
+}


### PR DESCRIPTION
Motivation

On a userspace subnet router (TS_USERSPACE=true) that advertises both
a raw IPv4 subnet and its 4via6 encoding, forwarded TCP connections to
the raw IPv4 addresses could intermittently fail with "CreateEndpoint
... network is unreachable", while 4via6 connections to the same
subnet kept working. A tailscaled restart temporarily cleared it.

Approach

wrapTCPProtocolHandler increments connsOpenBySubnetIP keyed on the
pre-4via6-rewrite destination address (the on-the-wire address),
gated by "!isLocalIP && !isVIPServiceIP". acceptTCP rewrites dialIP
via tsaddr.UnmapVia for 4via6 destinations before its deferred
removeSubnetAddress call ran, so the decrement used a different key
(the raw IPv4 form) and a different gate ("!isTailscaleIP") than the
increment. Every completed 4via6 connection therefore decremented an
unrelated raw-IPv4 counter. removeSubnetAddress had no floor, so
repeated decrements drove that counter negative; a later genuine
addSubnetAddress for that raw IP then only reached 0 instead of 1, so
the address was never (re-)registered with netstack via
AddProtocolAddress, and CreateEndpoint failed for it.

acceptTCP now captures the key and gate used by the increment
(subnetAddrKey and removeSubnetAddr) before the 4via6 rewrite, and its
deferred cleanup uses those instead of the post-rewrite dialIP and
isTailscaleIP. removeSubnetAddress also gets a defensive floor: a
decrement that finds the count already <= 0 deletes the entry and
returns rather than going negative, so any future unmatched
decrement can't wedge a later add.

The UDP path (wrapUDPProtocolHandler / forwardUDP) has a similar
add/remove asymmetry noted in the issue, but its unmatched decrements
land on local-address keys whose netstack registration doesn't depend
on this refcount, so it does not cause the same failure and is left
untouched here to keep this change minimal.

Validation

go test tailscale.com/wgengine/netstack/... (via ./tool/go) passes,
including the new TestRemoveSubnetAddressUnderflow. Confirmed the new
test is a real regression test: stashing just the netstack.go change
and rerunning it fails with "connsOpenBySubnetIP[172.16.1.1] = -1
after unmatched remove; want no entry"; with the fix restored it
passes. Also ran go vet with the repo's own vet tool
(tailscale.com/cmd/vet) over the package, clean.

This was reproduced and fixed as a targeted unit-level regression
test of the refcounting logic itself, not as a live multi-router
4via6 + raw-IPv4 traffic reproduction (which needs a running userspace
subnet router under sustained mixed traffic, not available in this
environment) - the counter-underflow mechanism described above is
fully exercised and proven by the test.

RELNOTE: fix a userspace subnet router bug where forwarding to a raw
IPv4 subnet address could fail with "network is unreachable" if the
same subnet's 4via6 form was also in use

Updates https://github.com/tailscale/tailscale/issues/20730

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
Assisted-by: claude-sonnet-5 (via Claude Code)

Fixes #20730