### PR TITLE
fuzz: hide external test files from go-118-fuzz-build during fuzzer builds

### DIFF
--- a/fuzz/oss-fuzz.sh
+++ b/fuzz/oss-fuzz.sh
@@ -23,7 +23,20 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.." # repository root
 # The copy is also rebuilt below against the same toolchain, so this script stays correct as
 # tailscale's required Go version changes without editing anything here.
 tmpdir=$(mktemp -d)
-trap 'rm -rf "$tmpdir"' EXIT
+
+# Sibling _test.go files hidden from go-118-fuzz-build_v2 during a build;
+# restored by the EXIT trap below. See build_fuzzer.
+hidden_test_files=()
+
+restore_hidden_test_files() {
+	local f
+	for f in "${hidden_test_files[@]:+${hidden_test_files[@]}}"; do
+		mv "$f.__hidden__" "$f"
+	done
+	hidden_test_files=()
+}
+
+trap 'restore_hidden_test_files; rm -rf "$tmpdir"' EXIT
 
 # Pin go-118-fuzz-build to an immutable commit. Fetch by SHA rather than tracking the v2
 # branch so upstream rewrites can't silently change or break this build.
@@ -59,26 +72,55 @@ prepare() {
 	GOFLAGS=-mod=mod go get github.com/AdamKorcz/go-118-fuzz-build/testing@$fuzzbuild_ref
 }
 
+# Wraps compile_native_go_fuzzer_v2, working around go-118-fuzz-build_v2
+# (fc5dc53b) overlaying every sibling _test.go in the fuzzer's directory onto a
+# virtual non-test path (<base>_libFuzzer.go). Siblings declaring an external
+# test package (package foo_test) then collide with the fuzzer's package
+# ("found packages foo (..) and foo_test (..) in ..."). Such files are a
+# different package and can never be referenced from the fuzzer, so hide them
+# for the duration of the build and restore them afterwards.
+#
+# Rather than inferring each file's package by grepping its package clause or
+# function signature (order- and formatting-dependent), ask `go list` directly:
+# .XTestGoFiles are exactly the external-package (_test) files that collide, so
+# hide precisely those. Internal test files (.TestGoFiles, same package as the
+# fuzzer) stay put because they may define helpers the fuzz target calls.
+build_fuzzer() {
+	local path=$1 function=$2 name=$3
+	local dir rel f
+	# Use the same -tags gofuzz view as compile_native_go_fuzzer_v2 so the
+	# hidden file set matches what the build actually sees.
+	dir=$(go list -tags gofuzz -f '{{.Dir}}' "$path")
+	while IFS= read -r rel; do
+		[ -n "$rel" ] || continue
+		f="$dir/$rel"
+		mv "$f" "$f.__hidden__"
+		hidden_test_files+=("$f")
+	done < <(go list -tags gofuzz -f '{{range .XTestGoFiles}}{{.}}{{"\n"}}{{end}}' "$path")
+	compile_native_go_fuzzer_v2 "$path" "$function" "$name"
+	restore_hidden_test_files
+}
+
 build_fuzzers() {
-	compile_native_go_fuzzer_v2 tailscale.com/disco FuzzDiscoParse disco_parse_fuzzer
-	compile_native_go_fuzzer_v2 tailscale.com/net/stun FuzzParseResponse stun_parser_response_fuzzer
-	compile_native_go_fuzzer_v2 tailscale.com/net/stun FuzzParseBindingRequest stun_parser_request_fuzzer
-	compile_native_go_fuzzer_v2 tailscale.com/net/dns/resolver FuzzClampEDNSSize dns_clamp_edns_size
-	compile_native_go_fuzzer_v2 tailscale.com/net/traffic FuzzNodeHasherCompare traffic_node_hasher_compare
-	compile_native_go_fuzzer_v2 tailscale.com/net/traffic FuzzSortNodes traffic_sort_nodes
+	build_fuzzer tailscale.com/disco FuzzDiscoParse disco_parse_fuzzer
+	build_fuzzer tailscale.com/net/stun FuzzParseResponse stun_parser_response_fuzzer
+	build_fuzzer tailscale.com/net/stun FuzzParseBindingRequest stun_parser_request_fuzzer
+	build_fuzzer tailscale.com/net/dns/resolver FuzzClampEDNSSize dns_clamp_edns_size
+	build_fuzzer tailscale.com/net/traffic FuzzNodeHasherCompare traffic_node_hasher_compare
+	build_fuzzer tailscale.com/net/traffic FuzzSortNodes traffic_sort_nodes
 
-	compile_native_go_fuzzer_v2 tailscale.com/tailcfg FuzzNodeIsRouter tailcfg_node_isrouter
+	build_fuzzer tailscale.com/tailcfg FuzzNodeIsRouter tailcfg_node_isrouter
 
-	compile_native_go_fuzzer_v2 tailscale.com/types/geo FuzzPointSphericalAngleTo geo_spherical_angle_to
+	build_fuzzer tailscale.com/types/geo FuzzPointSphericalAngleTo geo_spherical_angle_to
 
-	compile_native_go_fuzzer_v2 tailscale.com/util/cobs FuzzRoundtrip cobs_roundtrip
-	compile_native_go_fuzzer_v2 tailscale.com/util/cobs FuzzMostlyBijective cobs_mostly_bijective
-	compile_native_go_fuzzer_v2 tailscale.com/util/def FuzzBool def_bool
-	compile_native_go_fuzzer_v2 tailscale.com/util/def FuzzDuration def_duration
-	compile_native_go_fuzzer_v2 tailscale.com/util/nocasemaps FuzzAppendToLower nocase_append_tolower
-	compile_native_go_fuzzer_v2 tailscale.com/util/safediff FuzzDiff safediff_diff
+	build_fuzzer tailscale.com/util/cobs FuzzRoundtrip cobs_roundtrip
+	build_fuzzer tailscale.com/util/cobs FuzzMostlyBijective cobs_mostly_bijective
+	build_fuzzer tailscale.com/util/def FuzzBool def_bool
+	build_fuzzer tailscale.com/util/def FuzzDuration def_duration
+	build_fuzzer tailscale.com/util/nocasemaps FuzzAppendToLower nocase_append_tolower
+	build_fuzzer tailscale.com/util/safediff FuzzDiff safediff_diff
 
-	compile_native_go_fuzzer_v2 tailscale.com/wgengine/netlog FuzzQuotedLen netlog_quoted_len
+	build_fuzzer tailscale.com/wgengine/netlog FuzzQuotedLen netlog_quoted_len
 }
 
 prepare

--- a/tailcfg/fuzz_test.go
+++ b/tailcfg/fuzz_test.go
@@ -24,7 +24,7 @@ func FuzzNodeIsRouter(f *testing.F) {
 		for p := range strings.FieldsSeq(prefixes) {
 			pfx, err := netip.ParsePrefix(p)
 			if err != nil {
-				t.Skipf("%q: %v", prefixes, err)
+				continue // t.Skipf unsupported by go-118-fuzz-build
 			}
 			out = append(out, pfx)
 		}


### PR DESCRIPTION
`go-118-fuzz-build` overlays every sibling _test.go in the fuzzer's directory onto a non-test path (<base>_libFuzzer.go). Sibling test files declaring an external test package (package foo_test) then collide with the fuzzer's package, failing the build with "found packages foo and foo_test". Example failure can be seen here: https://github.com/google/oss-fuzz/actions/runs/33556755938/job/100019346580?pr=15996

One possible fix would be to stop using external _test package for our tests, but this change attempts to address this issue without changing our test packaging structure.

This change wraps each compile_native_go_fuzzer_v2 call in `build_fuzzer`, which hides the files in `go list .XTestGoFiles` for the build. Internal test files stay visible since the fuzz target may use their helpers.

Updates https://github.com/tailscale/corp/issues/46608
