### PR TITLE
cmd/k8s-operator: reject ProxyGroup names too long for the revision-hash label

### DIFF
--- a/cmd/k8s-operator/proxygroup.go
+++ b/cmd/k8s-operator/proxygroup.go
@@ -263,6 +263,18 @@ func (r *ProxyGroupReconciler) validate(ctx context.Context, pg *tsapi.ProxyGrou
 	}
 
 	var errs []error
+
+	// The ProxyGroup's name is used verbatim as its StatefulSet's name, and the
+	// StatefulSet controller stamps each Pod with a controller-revision-hash
+	// label whose value is "<StatefulSet name>-<10 char revision hash>". Label
+	// values are limited to 63 bytes, so a longer ProxyGroup name means no Pods
+	// can be created at all. Kubernetes reports that as a FailedCreate event
+	// naming metadata.labels, which does not point back at the name, so catch
+	// it here where we can say what actually needs to change.
+	if len(pg.Name) > maxStatefulSetNameLength {
+		errs = append(errs, fmt.Errorf("name is %d characters, but must be at most %d so that the controller-revision-hash label Kubernetes derives for its Pods stays within the 63 byte limit for label values", len(pg.Name), maxStatefulSetNameLength))
+	}
+
 	if isAuthAPIServerProxy(pg) {
 		// Validate that the static ServiceAccount already exists.
 		sa := &corev1.ServiceAccount{}

--- a/cmd/k8s-operator/proxygroup_test.go
+++ b/cmd/k8s-operator/proxygroup_test.go
@@ -11,6 +11,7 @@ import (
 	"net/netip"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -1770,6 +1771,15 @@ func TestValidateProxyGroup(t *testing.T) {
 		"init_container_for_egress_pg": {
 			typ:           tsapi.ProxyGroupTypeEgress,
 			initContainer: true,
+		},
+		"name_at_max_length": {
+			typ:    tsapi.ProxyGroupTypeEgress,
+			pgName: strings.Repeat("a", maxStatefulSetNameLength),
+		},
+		"name_one_over_max_length": {
+			typ:          tsapi.ProxyGroupTypeEgress,
+			pgName:       strings.Repeat("a", maxStatefulSetNameLength+1),
+			expectedErrs: 1,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #19405.

## What breaks today

A ProxyGroup's name is used verbatim as its StatefulSet's name (`proxygroup_specs.go`). The StatefulSet controller stamps every Pod with a `controller-revision-hash` label whose value is `<StatefulSet name>-<10 char revision hash>`, and label **values** are capped at 63 bytes. So a ProxyGroup name longer than 52 characters means no Pods are ever created.

Verified against a live cluster rather than inferred:

| ProxyGroup name | `.status.replicas` | ready | Pods |
|---|---|---|---|
| 52 chars | 1 | 1 | Running |
| 53 chars | **0** | — | **none, ever** |

At 53 characters the StatefulSet emits:

```
Warning  FailedCreate  Create Pod aaa…-0 in StatefulSet aaa… failed error:
Pod "aaa…-0" is invalid: metadata.labels: Invalid value:
"aaa…-654fc4fc48": must be no more than 63 bytes
```

That message names a label the user never set, on a Pod they did not create, and never mentions the ProxyGroup name that caused it. The failure is loud but effectively undiagnosable.

## One correction to the issue

The issue points at `pgPodName`, `pgConfigSecretName` and `pgStateSecretName` producing "pod names of 65+ chars and secret names of 72+ chars". Those are DNS-1123 **subdomains**, capped at 253, so they are all still valid:

| name | pod/hostname | config Secret | revision-hash label |
|---|---|---|---|
| 52 | 54 ok | 61 ok | 63 ok |
| **53** | 55 ok | 62 ok | **64 FAIL** |
| 62 | **64 FAIL** | 71 ok | 74 FAIL |

The binding constraint is the revision-hash label at 53, not the derived object names. The pod hostname does eventually overflow the 63-byte DNS **label** limit, but not until 62 characters, well past where things are already broken. The issue's "~52 chars" figure is exactly right; the stated mechanism is not.

## The change

Validate in `ProxyGroupReconciler.validate()`, so the ProxyGroup reports `ProxyGroupInvalid` with a message naming the actual cause:

```
ProxyGroupInvalid: invalid ProxyGroup spec: name is 53 characters, but must be
at most 52 so that the controller-revision-hash label Kubernetes derives for its
Pods stays within the 63 byte limit for label values
```

This reuses `maxStatefulSetNameLength`, which already encodes this exact limit (`63 - 10 - 1`) with a comment explaining it, and is already applied to the Connector and Ingress paths via `statefulSetNameBase`.

## Why here rather than CRD validation

The issue suggests "CRD-level validation limiting metadata.name to ~52 chars". I tried that first and it does work — `+kubebuilder:validation:XValidation:rule="size(self.metadata.name) <= 52"` on the root type generates correctly under your pinned controller-gen v0.17.0, producing root-level `x-kubernetes-validations` with no webhook needed. Happy to switch to it or add it alongside if you would prefer.

Two reasons I did not lead with it:

1. **It does not help anyone who already has one.** CEL fires on create and update. An existing over-long ProxyGroup sitting broken in a cluster never trips it, and its owner never finds out. The status condition surfaces on the next reconcile.
2. **It is a breaking change on the apply path.** Admission would start rejecting manifests that previously applied, including in GitOps repos. The status condition changes no admission behaviour.

Truncating the derived names was the third option and seems worse: it renames config and state Secrets, which would orphan proxy state.

## Tests

Two cases added to the existing `TestValidateProxyGroup` table, at and one over the limit. Confirmed they fail without the change and pass with it:

```
without: --- FAIL: TestValidateProxyGroup/name_one_over_max_length
with:    --- PASS: TestValidateProxyGroup/name_at_max_length
         --- PASS: TestValidateProxyGroup/name_one_over_max_length
```

`go test ./cmd/k8s-operator/`, `go vet`, and `gofmt` all clean.
