### PR TITLE
feature/conn25, ipn/ipnlocal: restrict conn25 DNS by peercap

### DIFF
--- a/feature/conn25/conn25.go
+++ b/feature/conn25/conn25.go
@@ -104,12 +104,12 @@ func handleConnectorTransitIP(h ipnlocal.PeerAPIHandler, w http.ResponseWriter, 
 	e.handleConnectorTransitIP(h, w, r)
 }
 
-func handleHookReplyToDNSQueries(h ipnlocal.PeerAPIHandler) bool {
+func handleHookReplyToDNSQueries(h ipnlocal.PeerAPIHandler, r *http.Request) (allowSource bool, allowName ipnlocal.DNSNameFilter) {
 	e, ok := ipnlocal.GetExt[*extension](h.LocalBackend())
 	if !ok {
-		return false
+		return false, nil
 	}
-	return e.handleHookReplyToDNSQueries(h)
+	return e.conn25.handleHookReplyToDNSQueries(h, r)
 }
 
 // extension is an [ipnext.Extension] managing the connector on platforms
@@ -370,13 +370,72 @@ func (e *extension) handleConnectorTransitIP(h ipnlocal.PeerAPIHandler, w http.R
 	w.Write(bs)
 }
 
-func (e *extension) handleHookReplyToDNSQueries(h ipnlocal.PeerAPIHandler) bool {
-	if !e.conn25.isConfigured() {
+func (c *Conn25) handleHookReplyToDNSQueries(h ipnlocal.PeerAPIHandler, r *http.Request) (sourceAllowed bool, nameAllowed ipnlocal.DNSNameFilter) {
+	if !c.prefsAdvertiseConnector.Load() {
+		// We are not a connector.
+		return false, nil
+	}
+
+	cfg, isConfigured := c.getConfig()
+	if !isConfigured {
+		// We have no connector config.
+		return false, nil
+	}
+
+	// Determine which app the query is for
+	var app appctype.Conn25Attr
+	if appName, hasApp := r.URL.Query()["app"]; !hasApp || len(appName) != 1 {
+		return false, nil
+	} else {
+		a, ok := cfg.appsByName[appName[0]]
+		if !ok {
+			// We have no config for the requested app.
+			return false, nil
+		}
+		app = a
+	}
+
+	if !cfg.selfAppNames.Contains(app.Name) {
+		// We are not a connector for the requested app.
+		return false, nil
+	}
+
+	if !app.TemporaryUnsafeBypassFilter && !h.PeerCaps().HasCapability(peercap.Conn25Prefix.ToAttribute(app.Name)) {
+		// The peer does not have access to the requested app.
+		return false, nil
+	}
+
+	return true, makeNameChecker(app)
+}
+
+func makeNameChecker(app appctype.Conn25Attr) ipnlocal.DNSNameFilter {
+	// TODO(tailscale/corp#40076): optimize the comparison; if the func is
+	// generated when the app config is created, that will avoid allocating
+	// temporary instances. Some of the work (e.g. conversion to [dnsname.FQDN])
+	// can also be precomputed.
+	return func(name string) bool {
+		fqdn, err := dnsname.ToFQDN(strings.ToLower(name))
+		if err != nil {
+			return false
+		}
+		for _, domain := range app.Domains {
+			appFQDN, err := dnsname.ToFQDN(strings.TrimPrefix(strings.ToLower(domain), "*."))
+			if err != nil {
+				continue
+			}
+			// Allow both exact matches and suffix matches, even when the app
+			// does not specify a wildcard. This is because of limitations in
+			// the Split DNS implementation: we treat all split DNS rules as
+			// wildcard even when the app specifies exact matching. The conn25
+			// client will only perform address mapping for more strictly
+			// matched names but the connector needs to allow queries for any
+			// subdomain of an exact match.
+			if appFQDN.Contains(fqdn) {
+				return true
+			}
+		}
 		return false
 	}
-	// TODO(tailscale/corp#40076): verify the peer has access to the query's
-	// app (if any) domain.
-	return true
 }
 
 // onSelfChange implements the [ipnext.Hooks.OnSelfChange] hook.

--- a/feature/conn25/conn25_test.go
+++ b/feature/conn25/conn25_test.go
@@ -7,9 +7,11 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/netip"
+	"net/url"
 	"slices"
 	"testing"
 	"time"
@@ -21,6 +23,7 @@ import (
 	"golang.org/x/net/dns/dnsmessage"
 	"tailscale.com/ipn"
 	"tailscale.com/ipn/ipnext"
+	"tailscale.com/ipn/ipnlocal"
 	"tailscale.com/net/dns"
 	"tailscale.com/net/netmon"
 	"tailscale.com/net/packet"
@@ -905,6 +908,13 @@ func mustConfig(t *testing.T, selfNode tailcfg.NodeView) *config {
 	return cfg
 }
 
+var arbitraryPools = appctype.Conn25PoolsAttr{
+	V4MagicIPPool:   []netipx.IPRange{v4RangeFrom("0", "10"), v4RangeFrom("20", "30")},
+	V6MagicIPPool:   []netipx.IPRange{v6RangeFrom("0", "10"), v6RangeFrom("20", "30")},
+	V4TransitIPPool: []netipx.IPRange{v4RangeFrom("40", "50")},
+	V6TransitIPPool: []netipx.IPRange{v6RangeFrom("40", "50")},
+}
+
 func v4RangeFrom(from, to string) netipx.IPRange {
 	return netipx.IPRangeFrom(
 		netip.MustParseAddr("100.64.0."+from),
@@ -1256,12 +1266,7 @@ func TestMapDNSResponseAssignsAddrs(t *testing.T) {
 				Name:       "app1",
 				Connectors: []string{"tag:woo"},
 				Domains:    tt.appDomains,
-			}}, appctype.Conn25PoolsAttr{
-				V4MagicIPPool:   []netipx.IPRange{v4RangeFrom("0", "10"), v4RangeFrom("20", "30")},
-				V6MagicIPPool:   []netipx.IPRange{v6RangeFrom("0", "10"), v6RangeFrom("20", "30")},
-				V4TransitIPPool: []netipx.IPRange{v4RangeFrom("40", "50")},
-				V6TransitIPPool: []netipx.IPRange{v6RangeFrom("40", "50")},
-			}, tt.selfTags)
+			}}, arbitraryPools, tt.selfTags)
 
 			c := newConn25(logger.Discard)
 			cfg := mustConfig(t, sn)
@@ -1290,12 +1295,7 @@ func TestMapDNSResponseSetsExpiryBasedOnTTL(t *testing.T) {
 		Name:       "app1",
 		Connectors: []string{"tag:woo"},
 		Domains:    []string{configuredDomain},
-	}}, appctype.Conn25PoolsAttr{
-		V4MagicIPPool:   []netipx.IPRange{v4RangeFrom("0", "10")},
-		V4TransitIPPool: []netipx.IPRange{v4RangeFrom("40", "50")},
-		V6MagicIPPool:   []netipx.IPRange{netipx.IPRangeFrom(netip.MustParseAddr("2606:4700::6812:100"), netip.MustParseAddr("2606:4700::6812:1ff"))},
-		V6TransitIPPool: []netipx.IPRange{netipx.IPRangeFrom(netip.MustParseAddr("2606:4700::6813:100"), netip.MustParseAddr("2606:4700::6813:1ff"))},
-	}, nil)
+	}}, arbitraryPools, nil)
 
 	c := newConn25(logger.Discard)
 	clock := tstest.NewClock(tstest.ClockOpts{Start: time.Now()})
@@ -1388,12 +1388,7 @@ func TestMapDNSResponsePreservesTTL(t *testing.T) {
 		Name:       "app1",
 		Connectors: []string{"tag:connector"},
 		Domains:    []string{configuredDomain},
-	}}, appctype.Conn25PoolsAttr{
-		V4MagicIPPool:   []netipx.IPRange{v4RangeFrom("0", "10")},
-		V4TransitIPPool: []netipx.IPRange{v4RangeFrom("40", "50")},
-		V6MagicIPPool:   []netipx.IPRange{netipx.IPRangeFrom(netip.MustParseAddr("2606:4700::6812:100"), netip.MustParseAddr("2606:4700::6812:1ff"))},
-		V6TransitIPPool: []netipx.IPRange{netipx.IPRangeFrom(netip.MustParseAddr("2606:4700::6813:100"), netip.MustParseAddr("2606:4700::6813:1ff"))},
-	}, nil)
+	}}, arbitraryPools, nil)
 	cfg := mustConfig(t, sn)
 
 	const wantTTL uint32 = 300
@@ -2298,12 +2293,7 @@ func TestMapDNSResponseDropsUnhandledTypes(t *testing.T) {
 		Name:       "app1",
 		Connectors: []string{"tag:connector"},
 		Domains:    []string{configuredDomain},
-	}}, appctype.Conn25PoolsAttr{
-		V4MagicIPPool:   []netipx.IPRange{v4RangeFrom("0", "10")},
-		V4TransitIPPool: []netipx.IPRange{v4RangeFrom("40", "50")},
-		V6MagicIPPool:   []netipx.IPRange{netipx.IPRangeFrom(netip.MustParseAddr("2606:4700::6812:100"), netip.MustParseAddr("2606:4700::6812:1ff"))},
-		V6TransitIPPool: []netipx.IPRange{netipx.IPRangeFrom(netip.MustParseAddr("2606:4700::6813:100"), netip.MustParseAddr("2606:4700::6813:1ff"))},
-	}, []string{})
+	}}, arbitraryPools, []string{})
 	cfg := mustConfig(t, sn)
 
 	unhandled := []struct {
@@ -3061,12 +3051,7 @@ func TestAddressExpiryDependsOnActiveFlows(t *testing.T) {
 		Name:       "app1",
 		Connectors: []string{"tag:woo"},
 		Domains:    []string{configuredDomain},
-	}}, appctype.Conn25PoolsAttr{
-		V4MagicIPPool:   []netipx.IPRange{v4RangeFrom("0", "10")},
-		V4TransitIPPool: []netipx.IPRange{v4RangeFrom("40", "50")},
-		V6MagicIPPool:   []netipx.IPRange{netipx.IPRangeFrom(netip.MustParseAddr("2606:4700::6812:100"), netip.MustParseAddr("2606:4700::6812:1ff"))},
-		V6TransitIPPool: []netipx.IPRange{netipx.IPRangeFrom(netip.MustParseAddr("2606:4700::6813:100"), netip.MustParseAddr("2606:4700::6813:1ff"))},
-	}, nil)
+	}}, arbitraryPools, nil)
 
 	var ttlSecs uint32 = 300
 	ttlDur := time.Duration(ttlSecs) * time.Second
@@ -3407,6 +3392,401 @@ func TestPickConnector(t *testing.T) {
 			got := pickConnector(&testNodeBackend{self: self, peers: tt.candidates}, tt.app)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Fatalf("PickConnectors (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestMakeNameChecker(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		domains []string
+		queries map[string]bool
+	}{
+		{
+			name:    "single-wildcard",
+			domains: []string{"*.example.com"},
+			queries: map[string]bool{
+				"example.com":           true,
+				"something.example.com": true,
+				"notexample.com":        false,
+				"com":                   false,
+				"tailscale.com":         false,
+			},
+		},
+		{
+			name:    "single-exact",
+			domains: []string{"example.com"},
+			queries: map[string]bool{
+				"example.com":           true,
+				"something.example.com": true,
+				"notexample.com":        false,
+				"com":                   false,
+				"tailscale.com":         false,
+			},
+		},
+		{
+			name:    "exact-and-wildcard",
+			domains: []string{"example.com", "*.example.com"},
+			queries: map[string]bool{
+				"example.com":           true,
+				"something.example.com": true,
+				"notexample.com":        false,
+				"com":                   false,
+				"tailscale.com":         false,
+			},
+		},
+		{
+			name:    "subdomains",
+			domains: []string{"a.example.com", "*.b.example.com"},
+			queries: map[string]bool{
+				"a.example.com":         true,
+				"x.a.example.com":       true,
+				"b.example.com":         true,
+				"x.b.example.com":       true,
+				"example.com":           false,
+				"something.example.com": false,
+				"notexample.com":        false,
+				"com":                   false,
+				"tailscale.com":         false,
+				"a.com":                 false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := appctype.Conn25Attr{
+				Name:       "testApp",
+				Domains:    tt.domains,
+				Connectors: []string{"tag:connector"},
+			}
+
+			checker := makeNameChecker(app)
+
+			for q, want := range tt.queries {
+				got := checker(q)
+				if got != want {
+					t.Errorf("%s: got %v, want %v", q, got, want)
+				}
+			}
+		})
+	}
+}
+
+type fakePeerAPIHandler struct {
+	peerCaps tailcfg.PeerCapMap
+}
+
+func (fakePeerAPIHandler) Peer() tailcfg.NodeView {
+	panic("unimplemented")
+}
+func (m fakePeerAPIHandler) PeerCaps() tailcfg.PeerCapMap {
+	return m.peerCaps
+}
+func (fakePeerAPIHandler) CanDebug() bool {
+	panic("unimplemented")
+}
+func (fakePeerAPIHandler) Self() tailcfg.NodeView {
+	panic("unimplemented")
+}
+func (fakePeerAPIHandler) LocalBackend() *ipnlocal.LocalBackend {
+	panic("unimplemented")
+}
+func (fakePeerAPIHandler) IsSelfUntagged() bool {
+	panic("unimplemented")
+}
+func (fakePeerAPIHandler) RemoteAddr() netip.AddrPort {
+	panic("unimplemented")
+}
+func (fakePeerAPIHandler) Logf(format string, a ...any) {
+	panic("unimplemented")
+}
+
+func TestHandleHookReplyToDNSQueries(t *testing.T) {
+	t.Parallel()
+
+	exampleApp := appctype.Conn25Attr{
+		Name:       "example",
+		Connectors: []string{"tag:example"},
+		Domains:    []string{"example.com", "*.example.com"},
+	}
+	bypassApp := appctype.Conn25Attr{
+		Name:                        "bypass",
+		Connectors:                  []string{"tag:bypass"},
+		Domains:                     []string{"bypass.example.net"},
+		TemporaryUnsafeBypassFilter: true,
+	}
+	exactApp := appctype.Conn25Attr{
+		Name:       "exact",
+		Connectors: []string{"tag:exact"},
+		Domains:    []string{"exact.example.net"},
+	}
+	wildcardApp := appctype.Conn25Attr{
+		Name:       "wildcard",
+		Connectors: []string{"tag:wildcard"},
+		Domains:    []string{"*.wildcard.example.net"},
+	}
+
+	exampleAppPeerCap := tailcfg.PeerCapMap{
+		peercap.Conn25Prefix.ToAttribute("example"): []tailcfg.RawMessage{`"*"`},
+	}
+	// This is to verify that it's not picky about which ports are allowed for
+	// the app.
+	exampleAppPeerCapRestrictive := tailcfg.PeerCapMap{
+		peercap.Conn25Prefix.ToAttribute("example"): []tailcfg.RawMessage{},
+	}
+	exactAppPeerCap := tailcfg.PeerCapMap{
+		peercap.Conn25Prefix.ToAttribute("exact"): []tailcfg.RawMessage{`"*"`},
+	}
+	wildcardAppPeerCap := tailcfg.PeerCapMap{
+		peercap.Conn25Prefix.ToAttribute("wildcard"): []tailcfg.RawMessage{`"*"`},
+	}
+	allAppPeerCap := tailcfg.PeerCapMap{
+		peercap.Conn25Prefix.ToAttribute("example"):  []tailcfg.RawMessage{`"*"`},
+		peercap.Conn25Prefix.ToAttribute("exact"):    []tailcfg.RawMessage{`"*"`},
+		peercap.Conn25Prefix.ToAttribute("wildcard"): []tailcfg.RawMessage{`"*"`},
+	}
+
+	tests := []struct {
+		name                 string
+		noAdvertiseConnector bool
+		apps                 []appctype.Conn25Attr
+		tags                 []string
+		peerCap              tailcfg.PeerCapMap
+		noQueryString        bool
+		requestedApp         string
+		wantSourceAllowed    bool
+		wantNameChecks       map[string]bool // does not need to be exhaustive, TestMakeNameChecker covers this more
+	}{
+		{
+			name:              "normal",
+			apps:              []appctype.Conn25Attr{exampleApp},
+			tags:              []string{"tag:example"},
+			peerCap:           exampleAppPeerCap,
+			requestedApp:      "example",
+			wantSourceAllowed: true,
+			wantNameChecks: map[string]bool{
+				"example.com":              true,
+				"eXaMpLe.CoM":              true,
+				"example.COM":              true,
+				"EXAMPLE.com":              true,
+				"test.example.com":         true,
+				"TEST.Example.Com":         true,
+				"TEST.example.com":         true,
+				"a.b.c.d.example.com":      true,
+				"notexample.com":           false,
+				"example2.com":             false,
+				"example.net":              false,
+				"com":                      false,
+				"exact.example.net":        false,
+				"wildcard.example.net":     false,
+				"foo.wildcard.example.net": false,
+			},
+		},
+		{
+			name:              "exact",
+			apps:              []appctype.Conn25Attr{exactApp},
+			tags:              []string{"tag:exact"},
+			peerCap:           exactAppPeerCap,
+			requestedApp:      "exact",
+			wantSourceAllowed: true,
+			wantNameChecks: map[string]bool{
+				"example.com":                 false,
+				"net":                         false,
+				"exact.example.net":           true,
+				"subdomain.exact.example.net": true,
+				"wildcard.example.net":        false,
+				"foo.wildcard.example.net":    false,
+			},
+		},
+		{
+			name:              "wildcard",
+			apps:              []appctype.Conn25Attr{wildcardApp},
+			tags:              []string{"tag:wildcard"},
+			peerCap:           wildcardAppPeerCap,
+			requestedApp:      "wildcard",
+			wantSourceAllowed: true,
+			wantNameChecks: map[string]bool{
+				"example.com":                 false,
+				"net":                         false,
+				"exact.example.net":           false,
+				"subdomain.exact.example.net": false,
+				"wildcard.example.net":        true,
+				"foo.wildcard.example.net":    true,
+			},
+		},
+		{
+			name:              "multi-example",
+			apps:              []appctype.Conn25Attr{exampleApp, exactApp, wildcardApp},
+			tags:              []string{"tag:example", "tag:exact", "tag:wildcard"},
+			peerCap:           allAppPeerCap,
+			requestedApp:      "example",
+			wantSourceAllowed: true,
+			wantNameChecks: map[string]bool{
+				"example.com":                 true,
+				"subdomain.example.com":       true,
+				"com":                         false,
+				"exact.example.net":           false,
+				"subdomain.exact.example.net": false,
+				"wildcard.example.net":        false,
+				"foo.wildcard.example.net":    false,
+			},
+		},
+		{
+			name:              "multi-exact",
+			apps:              []appctype.Conn25Attr{exampleApp, exactApp, wildcardApp},
+			tags:              []string{"tag:example", "tag:exact", "tag:wildcard"},
+			peerCap:           allAppPeerCap,
+			requestedApp:      "exact",
+			wantSourceAllowed: true,
+			wantNameChecks: map[string]bool{
+				"example.com":                 false,
+				"net":                         false,
+				"exact.example.net":           true,
+				"subdomain.exact.example.net": true,
+				"wildcard.example.net":        false,
+				"foo.wildcard.example.net":    false,
+			},
+		},
+		{
+			name:              "wildcard",
+			apps:              []appctype.Conn25Attr{exampleApp, exactApp, wildcardApp},
+			tags:              []string{"tag:example", "tag:exact", "tag:wildcard"},
+			peerCap:           allAppPeerCap,
+			requestedApp:      "wildcard",
+			wantSourceAllowed: true,
+			wantNameChecks: map[string]bool{
+				"example.com":                 false,
+				"net":                         false,
+				"exact.example.net":           false,
+				"subdomain.exact.example.net": false,
+				"wildcard.example.net":        true,
+				"foo.wildcard.example.net":    true,
+			},
+		},
+		{
+			name:              "restricted-grant",
+			apps:              []appctype.Conn25Attr{exampleApp},
+			tags:              []string{"tag:example"},
+			peerCap:           exampleAppPeerCapRestrictive,
+			requestedApp:      "example",
+			wantSourceAllowed: true,
+			wantNameChecks: map[string]bool{
+				"example.com":                 true,
+				"subdomain.example.com":       true,
+				"com":                         false,
+				"exact.example.net":           false,
+				"subdomain.exact.example.net": false,
+				"wildcard.example.net":        false,
+				"foo.wildcard.example.net":    false,
+			},
+		},
+		{
+			name:                 "not-advertised",
+			noAdvertiseConnector: true,
+			apps:                 []appctype.Conn25Attr{exampleApp},
+			tags:                 []string{"tag:example"},
+			peerCap:              allAppPeerCap,
+			requestedApp:         "example",
+			wantSourceAllowed:    false,
+		},
+		{
+			name:              "no-apps",
+			apps:              []appctype.Conn25Attr{},
+			tags:              []string{"tag:example"},
+			peerCap:           allAppPeerCap,
+			requestedApp:      "example",
+			wantSourceAllowed: false,
+		},
+		{
+			name:              "not-connector-for-app",
+			apps:              []appctype.Conn25Attr{exampleApp, exactApp},
+			tags:              []string{"tag:exact"},
+			peerCap:           allAppPeerCap,
+			requestedApp:      "example",
+			wantSourceAllowed: false,
+		},
+		{
+			name:              "no-permission-for-app",
+			apps:              []appctype.Conn25Attr{exampleApp, exactApp},
+			tags:              []string{"tag:example", "tag:exact"},
+			peerCap:           exampleAppPeerCap,
+			requestedApp:      "exact",
+			wantSourceAllowed: false,
+		},
+		{
+			name:              "bypass-filter",
+			apps:              []appctype.Conn25Attr{exampleApp, bypassApp},
+			tags:              []string{"tag:example", "tag:bypass"},
+			requestedApp:      "bypass",
+			wantSourceAllowed: true,
+			wantNameChecks: map[string]bool{
+				"example.com":                  false,
+				"bypass.example.net":           true,
+				"subdomain.bypass.example.net": true,
+				"example.net":                  false,
+			},
+		},
+		{
+			name:              "bypass-filter-is-selective",
+			apps:              []appctype.Conn25Attr{exampleApp, bypassApp},
+			tags:              []string{"tag:example", "tag:bypass"},
+			requestedApp:      "example",
+			wantSourceAllowed: false,
+		},
+		{
+			name:              "no-query-string",
+			apps:              []appctype.Conn25Attr{exampleApp},
+			tags:              []string{"tag:example"},
+			peerCap:           exampleAppPeerCap,
+			noQueryString:     true,
+			wantSourceAllowed: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newConn25(t.Logf)
+			sn := makeSelfNode(t, tt.apps, arbitraryPools, tt.tags)
+			c.reconfig(mustConfig(t, sn))
+			if !tt.noAdvertiseConnector {
+				c.prefsAdvertiseConnector.Store(true)
+			}
+
+			fph := fakePeerAPIHandler{
+				peerCaps: tt.peerCap,
+			}
+			requestURL := "http://peerapi:1234/dns-query"
+			if !tt.noQueryString {
+				requestURL = fmt.Sprintf("%s?app=%s", requestURL, url.QueryEscape(tt.requestedApp))
+			} else if tt.requestedApp != "" {
+				t.Error("broken test case: noQueryString is true but requestedApp is not empty")
+			}
+			// No body is necessary because the handler is not permitted to look
+			// at the body.
+			r := must.Get(http.NewRequest("POST", requestURL, nil))
+
+			gotSourceAllowed, gotNameAllowed := c.handleHookReplyToDNSQueries(fph, r)
+			if gotSourceAllowed != tt.wantSourceAllowed {
+				t.Errorf("sourceAllowed = %v, want %v", gotSourceAllowed, tt.wantSourceAllowed)
+			}
+			if gotSourceAllowed && gotNameAllowed == nil {
+				t.Error("nameAllowed is nil, want not-nil whenever sourceAllowed is true")
+				return
+			}
+			if !gotSourceAllowed && gotNameAllowed != nil {
+				t.Error("nameAllowed is not nil, want nil whenever sourceAllowed is false")
+				return
+			}
+			if !tt.wantSourceAllowed && len(tt.wantNameChecks) > 0 {
+				// This is redundant: !sourceAllowed implies all names will be rejected
+				t.Error("broken test case: wantSourceAllowed is false but there are name checks")
+			}
+			for name, want := range tt.wantNameChecks {
+				if got := gotNameAllowed(name); got != want {
+					t.Errorf("nameAllowed(%q) = %v, want %v", name, got, want)
+				}
 			}
 		})
 	}

--- a/ipn/ipnlocal/peerapi.go
+++ b/ipn/ipnlocal/peerapi.go
@@ -40,6 +40,7 @@ import (
 	"tailscale.com/types/netmap"
 	"tailscale.com/types/views"
 	"tailscale.com/util/clientmetric"
+	"tailscale.com/util/testenv"
 	"tailscale.com/wgengine/filter"
 )
 
@@ -676,33 +677,89 @@ func (h *peerAPIHandler) handleServeDNSFwd(w http.ResponseWriter, r *http.Reques
 	dh.ServeHTTP(w, r)
 }
 
+// DNSNameFilter allows extensions to conditionally allow PeerAPI DNS queries
+// based on the name being queried, in addition to the source of the query. It
+// is used by [HookReplyToDNSQueries].
+type DNSNameFilter func(name string) (allowed bool)
+
 // HookReplyToDNSQueries allows extensions to register a willingness to allow
-// handling PeerAPI DNS queries for the peer making this request.
-var HookReplyToDNSQueries = feature.Hooks[func(PeerAPIHandler) bool]{
+// handling PeerAPI DNS queries for the peer making this request, optionally
+// depending on the name being queried. The [http.Request.Body] must not be read
+// by the handler.
+// When sourceAllowed is false, the query is disallowed and nameAllowed is
+// ignored (recommendation: nameAllowed should be nil in this case).
+// When sourceAllowed is true, the peer is permitted to send queries but the
+// final decision depends on the name being queried. When nameAllowed is nil,
+// all names are allowed. Otherwise, nameAllowed is called after parsing the
+// query to determine if it should be accepted.
+// While separating the decisions complicates this hook, it permits optimizing
+// the common case where all names are allowed for exit nodes and appc.
+var HookReplyToDNSQueries = feature.Hooks[func(PeerAPIHandler, *http.Request) (sourceAllowed bool, nameAllowed DNSNameFilter)]{
 	offersExitNodeOrAppConnectorAndPeerHasAutogroupInternet,
 }
 
-func (h *peerAPIHandler) replyToDNSQueries() bool {
+// isPeerAPIDNSAllowed determines if any of the default or extension hooks
+// permit PeerAPI DNS lookups for the current request.
+// nameAllowed will never be nil when sourceAllowed is true, as required by
+// [tailscale.com/net/dns/resolver.Resolver.HandlePeerDNSQuery], so it is not
+// quite the same as a [DNSNameFilter].
+func (h *peerAPIHandler) isPeerAPIDNSAllowed(r *http.Request) (sourceAllowed bool, nameAllowed func(string) bool) {
 	if !buildfeatures.HasDNS {
-		return false
+		return false, nil
 	}
-	if h.isSelf {
+	if h.IsSelfUntagged() {
 		// If the peer is owned by the same user, just allow it
 		// without further checks.
-		return true
+		return true, h.allowExitNodeDNSProxyToServeName
 	}
 	if !h.remoteAddr.IsValid() {
 		// This should never be the case if the peerAPIHandler
 		// was wired up correctly, but just in case.
-		return false
+		return false, nil
 	}
 
+	nameFilters := make([]DNSNameFilter, 0, len(HookReplyToDNSQueries))
 	for _, hook := range HookReplyToDNSQueries {
-		if hook(h) {
-			return true
+		allow, allowedName := hook(h, r)
+		if !allow {
+			continue
 		}
+		if allowedName == nil {
+			// Allow all names by default (still subject to names restricted by
+			// the netmap).
+			return true, h.allowExitNodeDNSProxyToServeName
+		}
+		nameFilters = append(nameFilters, allowedName)
 	}
-	return false
+
+	if len(nameFilters) == 0 {
+		return false, nil
+	}
+
+	return true, func(name string) bool {
+		// Always filter out names restricted by the netmap.
+		if !h.allowExitNodeDNSProxyToServeName(name) {
+			return false
+		}
+		// Now, only allow names permitted by at least one extension.
+		for _, f := range nameFilters {
+			if f(name) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// exitNodeDNSFilterForTest overrides
+// peerAPIHandler.allowExitNodeDNSProxyToServeName if set during test execution.
+var exitNodeDNSFilterForTest func(name string) bool
+
+func (h *peerAPIHandler) allowExitNodeDNSProxyToServeName(name string) bool {
+	if testenv.InTest() && exitNodeDNSFilterForTest != nil {
+		return exitNodeDNSFilterForTest(name)
+	}
+	return h.ps.b.allowExitNodeDNSProxyToServeName(name)
 }
 
 // offersExitNodeOrAppConnectorAndPeerHasAutogroupInternet is run as part of
@@ -714,12 +771,12 @@ func (h *peerAPIHandler) replyToDNSQueries() bool {
 //     to peers that have access to a relevant app.
 //
 // Further details about how these are accomplished are in inline comments.
-func offersExitNodeOrAppConnectorAndPeerHasAutogroupInternet(h PeerAPIHandler) bool {
+func offersExitNodeOrAppConnectorAndPeerHasAutogroupInternet(h PeerAPIHandler, _ *http.Request) (bool, DNSNameFilter) {
 	b := h.LocalBackend()
 	if !b.OfferingExitNode() && !b.OfferingAppConnector() {
 		// If we're not an exit node or app connector, this hook
 		// doesn't apply.
-		return false
+		return false, nil
 	}
 	// Otherwise, we're an exit node but the peer is not us, so
 	// we need to check if they're allowed access to the internet.
@@ -736,7 +793,7 @@ func offersExitNodeOrAppConnectorAndPeerHasAutogroupInternet(h PeerAPIHandler) b
 	// in LocalBackend).
 	f := b.currentNode().filter()
 	if f == nil {
-		return false
+		return false, nil
 	}
 	// Note: we check TCP here because the Filter type already had
 	// a CheckTCP method (for unit tests), but it's pretty
@@ -750,7 +807,7 @@ func offersExitNodeOrAppConnectorAndPeerHasAutogroupInternet(h PeerAPIHandler) b
 		dstIP = netip.MustParseAddr("2000::")
 	}
 	verdict := f.CheckTCP(remoteIP, dstIP, 53)
-	return verdict == filter.Accept
+	return verdict == filter.Accept, nil
 }
 
 // handleDNSQuery implements a DoH server (RFC 8484) over the peerapi.
@@ -760,7 +817,8 @@ func (h *peerAPIHandler) handleDNSQuery(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "DNS not wired up", http.StatusNotImplemented)
 		return
 	}
-	if !h.replyToDNSQueries() {
+	sourceAllowed, nameAllowed := h.isPeerAPIDNSAllowed(r)
+	if !sourceAllowed {
 		http.Error(w, "DNS access denied", http.StatusForbidden)
 		return
 	}
@@ -784,7 +842,7 @@ func (h *peerAPIHandler) handleDNSQuery(w http.ResponseWriter, r *http.Request) 
 
 	ctx, cancel := context.WithTimeout(r.Context(), arbitraryTimeout)
 	defer cancel()
-	res, err := h.ps.resolver.HandlePeerDNSQuery(ctx, q, h.remoteAddr, h.ps.b.allowExitNodeDNSProxyToServeName)
+	res, err := h.ps.resolver.HandlePeerDNSQuery(ctx, q, h.remoteAddr, nameAllowed)
 	if err != nil {
 		h.logf("handleDNS fwd error: %v", err)
 		if err := ctx.Err(); err != nil {

--- a/ipn/ipnlocal/peerapi_test.go
+++ b/ipn/ipnlocal/peerapi_test.go
@@ -29,6 +29,7 @@ import (
 	"tailscale.com/types/netmap"
 	"tailscale.com/util/eventbus/eventbustest"
 	"tailscale.com/util/must"
+	"tailscale.com/util/set"
 	"tailscale.com/util/usermetric"
 	"tailscale.com/wgengine"
 	"tailscale.com/wgengine/filter"
@@ -187,69 +188,269 @@ func TestHandlePeerAPI(t *testing.T) {
 	}
 }
 
-func TestPeerAPIReplyToDNSQueries(t *testing.T) {
-	var h peerAPIHandler
+func TestIsPeerAPIDNSAllowed(t *testing.T) {
+	// This test can not be run in parallel because it modifies
+	// HookReplyToDNSQueries and exitNodeDNSFilterForTest.
 
-	h.isSelf = true
-	if !h.replyToDNSQueries() {
-		t.Errorf("for isSelf = false; want true")
-	}
-	h.isSelf = false
-	h.remoteAddr = netip.MustParseAddrPort("100.150.151.152:12345")
+	r := must.Get(http.NewRequest("POST", "http://peerapi:1234/dns-query", nil))
+
+	originalHooks := HookReplyToDNSQueries
+	defer func() { HookReplyToDNSQueries = originalHooks }()
 
 	sys := tsd.NewSystemWithBus(eventbustest.NewBus(t))
-
 	ht := health.NewTracker(sys.Bus.Get())
 	pm := must.Get(newProfileManager(new(mem.Store), t.Logf, ht))
 	reg := new(usermetric.Registry)
 	eng, _ := wgengine.NewFakeUserspaceEngine(logger.Discard, 0, ht, reg, sys.Bus.Get(), sys.Set)
 	sys.Set(pm.Store())
 	sys.Set(eng)
-
 	b := newTestLocalBackendWithSys(t, sys)
 	b.pm = pm
-
-	h.ps = &peerAPIServer{b: b}
-	if h.ps.b.OfferingExitNode() {
-		t.Fatal("unexpectedly offering exit node")
+	if b.OfferingExitNode() {
+		t.Error("unexpectedly offering exit node")
+		return
 	}
-	h.ps.b.pm.SetPrefs((&ipn.Prefs{
-		AdvertiseRoutes: []netip.Prefix{
-			netip.MustParsePrefix("0.0.0.0/0"),
-			netip.MustParsePrefix("::/0"),
+
+	addrSubtests := []struct {
+		name string
+		addr netip.AddrPort
+	}{
+		{
+			name: "v4",
+			addr: netip.MustParseAddrPort("100.150.151.152:12345"),
 		},
-	}).View(), ipn.NetworkProfile{})
-	if !h.ps.b.OfferingExitNode() {
-		t.Fatal("unexpectedly not offering exit node")
+		{
+			name: "v6",
+			addr: netip.MustParseAddrPort("[fe70::1]:12345"),
+		},
 	}
 
-	if h.replyToDNSQueries() {
-		t.Errorf("unexpectedly doing DNS without filter")
+	tests := []struct {
+		name string
+
+		registerExtension bool // add an extra handler in HookReplyToDNSQueries
+		// Only used when registerExtension is true
+		extensionUseNameChecker bool
+		extensionAllowSource    bool
+		extensionApprovedNames  set.Set[string]
+
+		isSelf           bool
+		noOfferExitNode  bool
+		noPacketFilter   bool
+		denyPacketFilter bool
+
+		wantSourceAllowed bool
+		wantNamesAllowed  map[string]bool
+	}{
+		{
+			name:            "self",
+			isSelf:          true,
+			noOfferExitNode: true,
+
+			wantSourceAllowed: true,
+			wantNamesAllowed: map[string]bool{
+				"is-self.example.com": true,
+				"ts.net":              false,
+			},
+		},
+		{
+			name:              "no-exit-node",
+			noOfferExitNode:   true,
+			wantSourceAllowed: false,
+		},
+		{
+			name:              "exit-node-no-packet-filter",
+			noPacketFilter:    true,
+			wantSourceAllowed: false,
+		},
+		{
+			name:              "exit-node-deny-packet-filter",
+			denyPacketFilter:  true,
+			wantSourceAllowed: false,
+		},
+		{
+			name:              "exit-node-allow-packet-filter",
+			wantSourceAllowed: true,
+			wantNamesAllowed: map[string]bool{
+				"exit-node.example.com": true,
+				"ts.net":                false,
+			},
+		},
+		{
+			name:              "extension-deny",
+			registerExtension: true,
+			noOfferExitNode:   true,
+
+			wantSourceAllowed: false,
+		},
+		{
+			name:              "extension-with-exit-node",
+			registerExtension: true,
+
+			wantSourceAllowed: true,
+			wantNamesAllowed: map[string]bool{
+				"exit-node.example.com": true,
+				"ts.net":                false,
+			},
+		},
+		{
+			name:                 "extension-without-name-filter",
+			registerExtension:    true,
+			extensionAllowSource: true,
+			noOfferExitNode:      true,
+
+			wantSourceAllowed: true,
+			wantNamesAllowed: map[string]bool{
+				"exit-node.example.com": true,
+				"ts.net":                false,
+			},
+		},
+		{
+			name: "extension-with-name-filter",
+
+			registerExtension:       true,
+			extensionAllowSource:    true,
+			extensionUseNameChecker: true,
+			extensionApprovedNames:  set.Of("extension.example.com", "blocked.extension.example.com"),
+			noOfferExitNode:         true,
+
+			wantSourceAllowed: true,
+			wantNamesAllowed: map[string]bool{
+				"extension.example.com":         true,
+				"blocked.extension.example.com": false,
+				"exit-node.example.com":         false,
+				"ts.net":                        false,
+			},
+		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if len(tt.extensionApprovedNames) > 0 && !tt.extensionUseNameChecker {
+				t.Error("malformed test: extension has approved names but is not using name checker")
+			}
 
-	h.ps.b.setFilter(filter.NewAllowNone(logger.Discard, new(netipx.IPSet)))
-	if h.replyToDNSQueries() {
-		t.Errorf("unexpectedly doing DNS without filter")
-	}
+			h := peerAPIHandler{
+				ps: &peerAPIServer{
+					b: b,
+				},
+				selfNode: (&tailcfg.Node{}).View(),
+				peerNode: (&tailcfg.Node{}).View(),
+				isSelf:   tt.isSelf,
+			}
 
-	f := filter.NewAllowAllForTest(logger.Discard)
+			var advertiseRoutes []netip.Prefix
+			if !tt.noOfferExitNode {
+				advertiseRoutes = []netip.Prefix{
+					netip.MustParsePrefix("0.0.0.0/0"),
+					netip.MustParsePrefix("::/0"),
+				}
+			}
+			if err := h.ps.b.pm.SetPrefs((&ipn.Prefs{
+				AdvertiseRoutes: advertiseRoutes,
+			}).View(), ipn.NetworkProfile{}); err != nil {
+				t.Errorf("SetPrefs: %v", err)
+				return
+			}
+			if h.ps.b.OfferingExitNode() != !tt.noOfferExitNode {
+				t.Errorf("unexpected: offering exit node = %v, want %v", h.ps.b.OfferingExitNode(), !tt.noOfferExitNode)
+				return
+			}
+			var f *filter.Filter
+			if !tt.noPacketFilter {
+				if tt.denyPacketFilter {
+					f = filter.NewAllowNone(logger.Discard, new(netipx.IPSet))
+				} else {
+					f = filter.NewAllowAllForTest(logger.Discard)
+				}
+			}
+			h.ps.b.setFilter(f)
 
-	h.ps.b.setFilter(f)
-	if !h.replyToDNSQueries() {
-		t.Errorf("unexpectedly deny; wanted to be a DNS server")
-	}
+			var lastExtensionNameCheck string
+			if tt.registerExtension {
+				HookReplyToDNSQueries = slices.Clone(originalHooks)
+				defer func() { HookReplyToDNSQueries = originalHooks }()
 
-	// Also test IPv6.
-	h.remoteAddr = netip.MustParseAddrPort("[fe70::1]:12345")
-	if !h.replyToDNSQueries() {
-		t.Errorf("unexpectedly IPv6 deny; wanted to be a DNS server")
+				extensionNameChecker := func(name string) bool {
+					lastExtensionNameCheck = name
+					return tt.extensionApprovedNames.Contains(name)
+				}
+
+				HookReplyToDNSQueries.Add(func(handler PeerAPIHandler, request *http.Request) (sourceAllowed bool, nameAllowed DNSNameFilter) {
+					if handler != &h {
+						t.Error("unexpected handler")
+					}
+					if request != r {
+						t.Error("unexpected request")
+					}
+					if tt.extensionUseNameChecker {
+						return tt.extensionAllowSource, extensionNameChecker
+					}
+					return tt.extensionAllowSource, nil
+				})
+			}
+
+			var lastNameCheck string
+			exitNodeDNSFilterForTest = func(name string) bool {
+				lastNameCheck = name
+
+				allow, found := tt.wantNamesAllowed[name]
+				if !found {
+					t.Errorf("unexpected name %q caught by filter", name)
+				}
+				return allow
+			}
+			defer func() { exitNodeDNSFilterForTest = nil }()
+
+			for _, tt2 := range addrSubtests {
+				t.Run(tt2.name, func(t *testing.T) {
+					h.remoteAddr = tt2.addr
+
+					sourceAllowed, nameChecker := h.isPeerAPIDNSAllowed(r)
+					if sourceAllowed != tt.wantSourceAllowed {
+						t.Errorf("sourceAllowed = %v, want %v", sourceAllowed, tt.wantSourceAllowed)
+					}
+					if !sourceAllowed {
+						if nameChecker != nil {
+							t.Errorf("nameChecker != nil when source not allowed, want nil")
+						}
+						return
+					}
+					if nameChecker == nil {
+						t.Errorf("nameChecker = nil when source allowed, want not-nil")
+						return
+					}
+
+					for name, want := range tt.wantNamesAllowed {
+						got := nameChecker(name)
+						if got != want {
+							t.Errorf("nameChecker(%q) = %v, want %v", name, got, want)
+						}
+						if lastNameCheck != name {
+							t.Error("lastNameCheck did not update as expected")
+						}
+						if tt.extensionUseNameChecker && lastExtensionNameCheck != name {
+							// Only require the extension to be consulted if the
+							// exitNodeDNSFilterForTest filter would have
+							// allowed it.
+							if want {
+								t.Error("extensionUseNameChecker did not update as expected")
+							}
+						}
+					}
+				})
+			}
+		})
 	}
 }
 
 func TestPeerAPIPrettyReplyCNAME(t *testing.T) {
+	r := must.Get(http.NewRequest("POST", "http://peerapi:1234/dns-query", nil))
 	for _, shouldStore := range []bool{false, true} {
-		var h peerAPIHandler
-		h.remoteAddr = netip.MustParseAddrPort("100.150.151.152:12345")
+		h := peerAPIHandler{
+			remoteAddr: netip.MustParseAddrPort("100.150.151.152:12345"),
+			selfNode:   (&tailcfg.Node{}).View(),
+			peerNode:   (&tailcfg.Node{}).View(),
+		}
 
 		sys := tsd.NewSystemWithBus(eventbustest.NewBus(t))
 
@@ -298,7 +499,7 @@ func TestPeerAPIPrettyReplyCNAME(t *testing.T) {
 		f := filter.NewAllowAllForTest(logger.Discard)
 		h.ps.b.setFilter(f)
 
-		if !h.replyToDNSQueries() {
+		if allowed, _ := h.isPeerAPIDNSAllowed(r); !allowed {
 			t.Errorf("unexpectedly deny; wanted to be a DNS server")
 		}
 
@@ -319,9 +520,13 @@ func TestPeerAPIPrettyReplyCNAME(t *testing.T) {
 }
 
 func TestPeerAPIReplyToDNSQueriesAreObserved(t *testing.T) {
+	r := must.Get(http.NewRequest("POST", "http://peerapi:1234/dns-query", nil))
 	for _, shouldStore := range []bool{false, true} {
-		var h peerAPIHandler
-		h.remoteAddr = netip.MustParseAddrPort("100.150.151.152:12345")
+		h := peerAPIHandler{
+			remoteAddr: netip.MustParseAddrPort("100.150.151.152:12345"),
+			selfNode:   (&tailcfg.Node{}).View(),
+			peerNode:   (&tailcfg.Node{}).View(),
+		}
 
 		sys := tsd.NewSystemWithBus(eventbustest.NewBus(t))
 		bw := eventbustest.NewWatcher(t, sys.Bus.Get())
@@ -369,7 +574,7 @@ func TestPeerAPIReplyToDNSQueriesAreObserved(t *testing.T) {
 		if !h.ps.b.OfferingAppConnector() {
 			t.Fatal("expecting to be offering app connector")
 		}
-		if !h.replyToDNSQueries() {
+		if allowed, _ := h.isPeerAPIDNSAllowed(r); !allowed {
 			t.Errorf("unexpectedly deny; wanted to be a DNS server")
 		}
 
@@ -394,10 +599,14 @@ func TestPeerAPIReplyToDNSQueriesAreObserved(t *testing.T) {
 }
 
 func TestPeerAPIReplyToDNSQueriesAreObservedWithCNAMEFlattening(t *testing.T) {
+	r := must.Get(http.NewRequest("POST", "http://peerapi:1234/dns-query", nil))
 	for _, shouldStore := range []bool{false, true} {
 		ctx := context.Background()
-		var h peerAPIHandler
-		h.remoteAddr = netip.MustParseAddrPort("100.150.151.152:12345")
+		h := peerAPIHandler{
+			remoteAddr: netip.MustParseAddrPort("100.150.151.152:12345"),
+			selfNode:   (&tailcfg.Node{}).View(),
+			peerNode:   (&tailcfg.Node{}).View(),
+		}
 
 		sys := tsd.NewSystemWithBus(eventbustest.NewBus(t))
 		bw := eventbustest.NewWatcher(t, sys.Bus.Get())
@@ -455,7 +664,7 @@ func TestPeerAPIReplyToDNSQueriesAreObservedWithCNAMEFlattening(t *testing.T) {
 		if !h.ps.b.OfferingAppConnector() {
 			t.Fatal("expecting to be offering app connector")
 		}
-		if !h.replyToDNSQueries() {
+		if allowed, _ := h.isPeerAPIDNSAllowed(r); !allowed {
 			t.Errorf("unexpectedly deny; wanted to be a DNS server")
 		}
 


### PR DESCRIPTION
Instead of opening all DNS queries with conn25, only permit clients to access domains of the apps that they have permission to use. Previous changes ensure that clients report which app they are making a DNS query for, simplifying the check.

Updates tailscale/corp#40076
Updates tailscale/corp#47585

Change-Id: I40fee220b3f190b2a0db9b3e6cc79f323ef16b73

cc @tendstofortytwo 