### PR TITLE
net/netcheck: mark address family sendable on STUN response

### DIFF
--- a/net/netcheck/netcheck.go
+++ b/net/netcheck/netcheck.go
@@ -707,6 +707,9 @@ func (rs *reportState) addNodeLatency(node *tailcfg.DERPNode, ipp netip.AddrPort
 
 	switch {
 	case ipp.Addr().Is6():
+		// Receiving a STUN response proves that the corresponding probe was
+		// sent, even if the response races SendPacket returning in runProbe.
+		ret.IPv6CanSend = true
 		updateLatency(ret.RegionV6Latency, node.RegionID, d)
 		ret.IPv6 = true
 		ret.GlobalV6 = ipp
@@ -714,6 +717,7 @@ func (rs *reportState) addNodeLatency(node *tailcfg.DERPNode, ipp netip.AddrPort
 		// TODO: track MappingVariesByDestIP for IPv6
 		// too? Would be sad if so, but who knows.
 	case ipp.Addr().Is4():
+		ret.IPv4CanSend = true
 		updateLatency(ret.RegionV4Latency, node.RegionID, d)
 		ret.IPv4 = true
 		mak.Set(&ret.GlobalV4Counters, ipp, ret.GlobalV4Counters[ipp]+1)

--- a/net/netcheck/netcheck_test.go
+++ b/net/netcheck/netcheck_test.go
@@ -108,6 +108,28 @@ func TestMultiGlobalAddressMapping(t *testing.T) {
 	}
 }
 
+func TestSTUNResponseProvesCanSend(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		addr string
+		got  func(*Report) bool
+	}{
+		{"IPv4", "192.0.2.1:1234", func(r *Report) bool { return r.IPv4CanSend }},
+		{"IPv6", "[2001:db8::1]:1234", func(r *Report) bool { return r.IPv6CanSend }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			rs := &reportState{
+				c:      newTestClient(t),
+				report: newReport(),
+			}
+			rs.addNodeLatency(&tailcfg.DERPNode{RegionID: 1}, netip.MustParseAddrPort(test.addr), time.Millisecond)
+			if !test.got(rs.report) {
+				t.Errorf("STUN response from %v did not set %sCanSend", test.addr, test.name)
+			}
+		})
+	}
+}
+
 func TestWorksWhenUDPBlocked(t *testing.T) {
 	blackhole, err := net.ListenPacket("udp4", "127.0.0.1:0")
 	if err != nil {


### PR DESCRIPTION
runProbe records IPv4CanSend or IPv6CanSend after SendPacket returns
successfully. A sufficiently fast STUN response can be received and
processed before that return, however, and the report can be cloned in
the intervening window. That produces a contradictory report with UDP
and a valid mapping, but CanSend false. Magicsock treats that as a
send failure and unnecessarily rebinds, perturbing tailcat tests.

A received STUN response itself proves that its address family sent
successfully, so also mark the family sendable while recording the
response.

Before this, the tailcat test flaked after ~3700 runs under
flakestress. Now it can run 30 minutes (12,203 successful runs).

Updates tailscale/tailcat#73
