### PR TITLE
cmd/tailscale/cli: add --owner flag to hide the status owner column

### DIFF
--- a/cmd/tailscale/cli/status.go
+++ b/cmd/tailscale/cli/status.go
@@ -56,6 +56,7 @@ https://github.com/tailscale/tailscale/blob/main/ipn/ipnstate/ipnstate.go
 		fs.StringVar(&statusArgs.listen, "listen", "127.0.0.1:8384", "listen address for web mode; use port 0 for automatic")
 		fs.BoolVar(&statusArgs.browser, "browser", true, "open a browser in web mode")
 		fs.BoolVar(&statusArgs.header, "header", false, "show column headers in table format")
+		fs.BoolVar(&statusArgs.owner, "owner", true, "show owner column in table format")
 		return fs
 	})(),
 }
@@ -69,6 +70,7 @@ var statusArgs struct {
 	self    bool   // in CLI mode, show status of local machine
 	peers   bool   // in CLI mode, show status of peer machines
 	header  bool   // in CLI mode, show column headers in table format
+	owner   bool   // in CLI mode, show the owner column in table format
 }
 
 const mullvadTCD = "mullvad.ts.net."
@@ -157,17 +159,21 @@ func runStatus(ctx context.Context, args []string) error {
 	w := tabwriter.NewWriter(Stdout, 0, 0, 2, ' ', 0)
 	f := func(format string, a ...any) { fmt.Fprintf(w, format, a...) }
 	if statusArgs.header {
-		fmt.Fprintln(w, "IP\tHostname\tOwner\tOS\tStatus\t")
-		fmt.Fprintln(w, "--\t--------\t-----\t--\t------\t")
+		if statusArgs.owner {
+			fmt.Fprintln(w, "IP\tHostname\tOwner\tOS\tStatus\t")
+			fmt.Fprintln(w, "--\t--------\t-----\t--\t------\t")
+		} else {
+			fmt.Fprintln(w, "IP\tHostname\tOS\tStatus\t")
+			fmt.Fprintln(w, "--\t--------\t--\t------\t")
+		}
 	}
 
 	printPS := func(ps *ipnstate.PeerStatus) {
-		f("%s\t%s\t%s\t%s\t",
-			firstIPString(ps.TailscaleIPs),
-			dnsOrQuoteHostname(st, ps),
-			ownerLogin(st, ps),
-			ps.OS,
-		)
+		f("%s\t%s\t", firstIPString(ps.TailscaleIPs), dnsOrQuoteHostname(st, ps))
+		if statusArgs.owner {
+			f("%s\t", ownerLogin(st, ps))
+		}
+		f("%s\t", ps.OS)
 		relay := ps.Relay
 		anyTraffic := ps.TxBytes != 0 || ps.RxBytes != 0
 		var offline string


### PR DESCRIPTION
On a single-user tailnet the Owner column of `tailscale status` repeats the same login on every row and pushes the Status column towards the right edge of the terminal, where the long status text wraps. This adds an `--owner` bool flag, defaulting to `true`, so `tailscale status --owner=false` drops the column. The default output is unchanged; the flag follows the existing `--self`, `--peers` and `--header` bool flags.

I considered hiding the column automatically when every row has the same owner, but that would change the column count of the default output on single-user tailnets and break positional parsers, which docs/cli.md asks to avoid. An explicit flag keeps the default stable.

## Before

```console
$ tailscale status --header
IP              Hostname   Owner   OS     Status
--              --------   -----   --     ------
100.64.0.1      laptop     user@   macOS  -
100.64.0.2      server     user@   linux  active; direct 192.0.2.10:41641, tx 1234 rx 5678
100.64.0.3      phone      user@   iOS    offline, last seen 2h ago
```

## After

```console
$ tailscale status --owner=false --header
IP              Hostname   OS     Status
--              --------   --     ------
100.64.0.1      laptop     macOS  -
100.64.0.2      server     linux  active; direct 192.0.2.10:41641, tx 1234 rx 5678
100.64.0.3      phone      iOS    offline, last seen 2h ago
```

Updates #12885
