### PR TITLE
cmd/k8s-operator: set a max backoff for egress Pod readiness checks

### DIFF
--- a/cmd/k8s-operator/egress-pod-readiness.go
+++ b/cmd/k8s-operator/egress-pod-readiness.go
@@ -149,7 +149,7 @@ func (er *egressPodsReconciler) Reconcile(ctx context.Context, req reconcile.Req
 			}
 
 			var routesSetup bool
-			bo := backoff.NewBackoff(s.Name, ll.Infof, er.maxBackoff)
+			bo := backoff.NewBackoff(s.Name, ll.Debugf, er.maxBackoff)
 			for range numCalls(pgReplicas(pg)) {
 				if ctx.Err() != nil {
 					errChan <- nil

--- a/cmd/k8s-operator/egress-pod-readiness_test.go
+++ b/cmd/k8s-operator/egress-pod-readiness_test.go
@@ -17,6 +17,8 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -144,7 +146,14 @@ func TestEgressPodReadiness(t *testing.T) {
 			state: map[string][]fakeResponse{hep: resps},
 		}
 		rec.httpClient = &httpCl
+		// Backing off between health checks is routine during a rollout and must not be logged at info level.
+		core, logs := observer.New(zapcore.InfoLevel)
+		rec.logger = zap.New(core).Sugar()
+		defer func() { rec.logger = zl.Sugar() }()
 		expectReconciled(t, rec, "operator-ns", pod.Name)
+		if n := logs.FilterMessageSnippet("backoff").Len(); n != 0 {
+			t.Errorf("got %d info-level backoff log entries, want 0", n)
+		}
 
 		// Pod should have readiness gate condition set.
 		podSetReady(pod, cl)

--- a/cmd/k8s-operator/operator.go
+++ b/cmd/k8s-operator/operator.go
@@ -642,6 +642,7 @@ func runReconcilers(opts reconcilerOpts) {
 			clock:       tstime.DefaultClock{},
 			logger:      opts.log.Named("egress-pods-readiness-reconciler"),
 			httpClient:  http.DefaultClient,
+			maxBackoff:  500 * time.Millisecond,
 		})
 	if err != nil {
 		startlog.Fatalf("could not create egress Pods readiness reconciler: %v", err)


### PR DESCRIPTION
The egress Pod readiness reconciler builds its health check backoff from `er.maxBackoff`, but nothing ever set that field, so `backoff.NewBackoff` got a zero limit. Every failed check slept 0 ms and logged `backoff: 0 msec` at info level, once per attempt, per Service, per Pod: a flood during a ProxyGroup rollout, and no pause between attempts. Unset since #14792, it surfaced when #20667 wired the reconciler up.

This sets `maxBackoff` to 500 ms in operator.go and logs the backoff at debug level, since the wait is routine. The waits are wall-clock time inside Reconcile and the attempt count grows with replicas, so the cap is kept small; bounding the total independently of replicas would be a follow-up. The eventually-healthy test now asserts no backoff line reaches info level.

Fixes #21079
