### PR TITLE
ssh/tailssh: set reverse Unix socket owner

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module tailscale.com
 
+// TODO: remove this replace after https://github.com/tailscale/gliderssh/pull/13 merges.
+replace github.com/tailscale/gliderssh => github.com/parsnips/gliderssh v0.3.4-0.20260903233315-8564a8290d49
+
 go 1.27.1
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -981,6 +981,8 @@ github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT9
 github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/palantir/policy-bot v1.41.1 h1:1v/v+fmXhbSyPWOfxhxF1UWmYWuRCNK+VYKIalj+KRY=
 github.com/palantir/policy-bot v1.41.1/go.mod h1:iGHKNjbH341YjtpYUHMAzQy5SjghL3BXplNg6TRRvt0=
+github.com/parsnips/gliderssh v0.3.4-0.20260903233315-8564a8290d49 h1:3M6LuE4mrR77XIRQa5VPHc4a5MfPLqUGWXK8pNl50rk=
+github.com/parsnips/gliderssh v0.3.4-0.20260903233315-8564a8290d49/go.mod h1:wn16Km1EZOX4UEAyaZa3dBwfFGOJ7neck40NcwosJUw=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
@@ -1191,8 +1193,6 @@ github.com/tailscale/certstore v0.1.1-0.20260409135935-3638fb84b77d h1:JcGKBZAL7
 github.com/tailscale/certstore v0.1.1-0.20260409135935-3638fb84b77d/go.mod h1:XrBNfAFN+pwoWuksbFS9Ccxnopa15zJGgXRFN90l3K4=
 github.com/tailscale/depaware v0.0.0-20251001183927-9c2ad255ef3f h1:PDPGJtm9PFBLNudHGwkfUGp/FWvP+kXXJ0D1pB35F40=
 github.com/tailscale/depaware v0.0.0-20251001183927-9c2ad255ef3f/go.mod h1:p9lPsd+cx33L3H9nNoecRRxPssFKUwwI50I3pZ0yT+8=
-github.com/tailscale/gliderssh v0.3.4-0.20260716005906-1a0f895faf28 h1:Azz5ILxxVsHN/KjIu3wkJPAmmtiijucZw4Ax5Ye8n+s=
-github.com/tailscale/gliderssh v0.3.4-0.20260716005906-1a0f895faf28/go.mod h1:wn16Km1EZOX4UEAyaZa3dBwfFGOJ7neck40NcwosJUw=
 github.com/tailscale/go-winio v0.0.0-20231025203758-c4f33415bf55 h1:Gzfnfk2TWrk8Jj4P4c1a3CtQyMaTVCznlkLZI++hok4=
 github.com/tailscale/go-winio v0.0.0-20231025203758-c4f33415bf55/go.mod h1:4k4QO+dQ3R5FofL+SanAUZe+/QfeK0+OIuwDIRu2vSg=
 github.com/tailscale/goexpect v0.0.0-20210902213824-6e8c725cea41 h1:/V2rCMMWcsjYaYO2MeovLw+ClP63OtXgCF2Y1eb8+Ns=

--- a/ssh/tailssh/tailssh.go
+++ b/ssh/tailssh/tailssh.go
@@ -567,6 +567,22 @@ func (c *conn) mayForwardLocalUnixTo(ctx gliderssh.Context, socketPath string) (
 	return nil, gliderssh.ErrRejected
 }
 
+// parseChownID parses the decimal uid or gid in s for use with chown(2). It
+// rejects values that do not fit in an int, which on 32-bit platforms would
+// otherwise wrap negative; in particular 1<<32-1 would wrap to -1, which
+// chown(2) reads as "leave this field unchanged" and would silently leave the
+// socket owned by root.
+func parseChownID(s string) (int, error) {
+	id, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	if uint64(int(id)) != id {
+		return 0, errors.New("does not fit in int")
+	}
+	return int(id), nil
+}
+
 // mayReverseUnixForwardTo is the server-side handler for
 // streamlocal-forward@openssh.com (SSH -R with Unix sockets). It returns a
 // listener for the specified Unix domain socket path if reverse forwarding is
@@ -577,8 +593,23 @@ func (c *conn) mayReverseUnixForwardTo(ctx gliderssh.Context, socketPath string)
 	}
 	if c.finalAction != nil && c.finalAction.AllowRemotePortForwarding {
 		metricRemotePortForward.Add(1)
-		cb := gliderssh.NewReverseUnixForwardingCallback(c.unixForwardingOptions())
-		return cb(ctx, socketPath)
+		opts := c.unixForwardingOptions()
+		if runtime.GOOS == "plan9" {
+			return gliderssh.NewReverseUnixForwardingCallback(opts)(ctx, socketPath)
+		}
+		uid, err := parseChownID(c.localUser.Uid)
+		if err != nil {
+			return nil, fmt.Errorf("invalid local user UID %q: %w", c.localUser.Uid, err)
+		}
+		gid, err := parseChownID(c.localUser.Gid)
+		if err != nil {
+			return nil, fmt.Errorf("invalid local user GID %q: %w", c.localUser.Gid, err)
+		}
+		opts.BindOwner = &gliderssh.UnixSocketOwner{
+			UID: uid,
+			GID: gid,
+		}
+		return gliderssh.NewReverseUnixForwardingCallback(opts)(ctx, socketPath)
 	}
 	return nil, gliderssh.ErrRejected
 }

--- a/ssh/tailssh/tailssh_integration_test.go
+++ b/ssh/tailssh/tailssh_integration_test.go
@@ -23,8 +23,10 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -599,9 +601,27 @@ func TestReverseUnixForwarding(t *testing.T) {
 	}
 	t.Cleanup(func() { ln.Close() })
 
-	// Verify the socket file was created on the server side.
-	if _, err := os.Stat(remoteSocketPath); err != nil {
+	// Verify the socket file was created on the server side and is owned by
+	// the authenticated local user rather than by tailscaled.
+	fi, err := os.Stat(remoteSocketPath)
+	if err != nil {
 		t.Fatalf("reverse forwarded socket not created: %s", err)
+	}
+	lu, err := userLookup("testuser")
+	if err != nil {
+		t.Fatal(err)
+	}
+	uid, err := strconv.ParseUint(lu.Uid, 10, 32)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gid, err := strconv.ParseUint(lu.Gid, 10, 32)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stat := fi.Sys().(*syscall.Stat_t)
+	if stat.Uid != uint32(uid) || stat.Gid != uint32(gid) {
+		t.Errorf("socket owner = %d:%d, want %d:%d", stat.Uid, stat.Gid, uid, gid)
 	}
 
 	// Accept a connection from the tunnel (client side) and write data.


### PR DESCRIPTION
Depends on https://github.com/tailscale/gliderssh/pull/13. The temporary `replace` directive in `go.mod` should be removed after that PR merges.

Reverse Unix forwarding listeners are created by tailscaled, so their default 0600 permissions leave them accessible only to root even though the SSH session runs as the authenticated local user.

Pass the authenticated user UID and GID to gliderssh so it can assign ownership before exposing the socket at the requested path. The gliderssh dependency creates and configures the socket inside a private staging directory, using pinned directory descriptors to prevent path-replacement races during chmod and chown.

Plan 9 continues to report Unix sockets as unsupported before numeric UID/GID parsing. UID and GID values that cannot fit in `int` are rejected on 32-bit platforms.

Fixes #21098

Tests:
- `go test ./ssh/tailssh -count=1`
- `go vet ./ssh/tailssh`
- `docker run --rm -e TAILSCALED_PATH=/tailscaled ssh-ubuntu-focal ./tailssh.test -test.v -test.run "^TestReverseUnixForwarding$"`
- Cross-compilation for Darwin, FreeBSD, OpenBSD, Linux/386, and Plan 9