### PR TITLE
control/controlclient: replay user profiles on delta peer upserts

### DIFF
--- a/control/controlclient/map.go
+++ b/control/controlclient/map.go
@@ -368,28 +368,55 @@ func (ms *mapSession) tryHandleIncrementally(res *tailcfg.MapResponse) bool {
 			return false
 		}
 	}
-	// Same shape for UserProfiles: deliver any new/updated profiles before
-	// the peer mutations that may reference them, so bus consumers never
-	// see a UserID for which a profile hasn't been published. The values
-	// are read from ms.lastUserProfile (just populated by
+	mutations, mutationsOK := netmap.MutationsFromMapResponse(res, time.Now())
+
+	// Same shape for UserProfiles: deliver profiles before the peer
+	// mutations that may reference them, so bus consumers never see a
+	// UserID for which a profile hasn't been published.
+	//
+	// Besides the new/updated profiles carried by the response, also
+	// replay the profiles of upserted peers' users from
+	// ms.lastUserProfile. A full netmap keeps only the profiles of users
+	// with a currently visible peer (see [mapSession.addUserProfile]), so
+	// a peer returning via delta upsert can reference a user the updater
+	// has since dropped, and control (mapver 5+) does not resend
+	// unchanged profiles. Without the replay, WhoIs on the returned peer
+	// fails at the user profile lookup until the next full netmap.
+	//
+	// The values are read from ms.lastUserProfile (just populated by
 	// updateStateFromResponse) so views are shared with mapSession's
 	// store; downstream consumers can use [UserProfileView.Equal] for
 	// dedup without copying.
-	if len(res.UserProfiles) > 0 {
+	var profiles map[tailcfg.UserID]tailcfg.UserProfileView
+	addProfile := func(id tailcfg.UserID) {
+		if id == 0 {
+			return
+		}
+		if up, ok := ms.lastUserProfile[id]; ok {
+			mak.Set(&profiles, id, up)
+		}
+	}
+	for _, up := range res.UserProfiles {
+		addProfile(up.ID)
+	}
+	if mutationsOK {
+		for _, m := range mutations {
+			if up, ok := m.(netmap.NodeMutationUpsert); ok {
+				addProfile(up.Node.User())
+				addProfile(up.Node.Sharer())
+			}
+		}
+	}
+	if len(profiles) > 0 {
 		upu, ok := ms.netmapUpdater.(UserProfileUpdater)
 		if !ok {
 			return false
-		}
-		profiles := make(map[tailcfg.UserID]tailcfg.UserProfileView, len(res.UserProfiles))
-		for _, up := range res.UserProfiles {
-			profiles[up.ID] = ms.lastUserProfile[up.ID]
 		}
 		if !upu.UpdateUserProfiles(profiles) {
 			return false
 		}
 	}
-	mutations, ok := netmap.MutationsFromMapResponse(res, time.Now())
-	if !ok {
+	if !mutationsOK {
 		return false
 	}
 	if len(mutations) > 0 {

--- a/control/controlclient/map_test.go
+++ b/control/controlclient/map_test.go
@@ -956,6 +956,105 @@ func TestExistingPeerReplacementHandledIncrementally(t *testing.T) {
 	}
 }
 
+type profileRecordingUpdater struct {
+	countingDeltaNetmapUpdater
+	profiles        []map[tailcfg.UserID]tailcfg.UserProfileView
+	profilesAtDelta int
+}
+
+func (nu *profileRecordingUpdater) UpdateUserProfiles(profiles map[tailcfg.UserID]tailcfg.UserProfileView) bool {
+	nu.profiles = append(nu.profiles, profiles)
+	return true
+}
+
+func (nu *profileRecordingUpdater) UpdateNetmapDelta(muts []netmap.NodeMutation) bool {
+	nu.profilesAtDelta = len(nu.profiles)
+	return nu.countingDeltaNetmapUpdater.UpdateNetmapDelta(muts)
+}
+
+// TestUpsertReplaysUserProfiles verifies that a peer upsert delivered as a
+// delta also replays the peer's user and sharer profiles from the map
+// session's profile store, even when the MapResponse carries no UserProfiles
+// (control only resends changed profiles). A full netmap installed while the
+// user had no visible peers drops the profile downstream, and without the
+// replay a WhoIs on the returned peer fails at the user profile lookup.
+func TestUpsertReplaysUserProfiles(t *testing.T) {
+	nu := &profileRecordingUpdater{}
+	ms := newTestMapSession(t, nu)
+	ctx := t.Context()
+
+	peer := &tailcfg.Node{
+		ID:         1,
+		StableID:   "peer",
+		Name:       "peer.example.ts.net.",
+		User:       100,
+		Sharer:     200,
+		Key:        key.NewNode().Public(),
+		DiscoKey:   key.NewDisco().Public(),
+		Addresses:  []netip.Prefix{netip.MustParsePrefix("100.64.0.1/32")},
+		AllowedIPs: []netip.Prefix{netip.MustParsePrefix("100.64.0.1/32")},
+		Hostinfo:   (&tailcfg.Hostinfo{}).View(),
+	}
+	if err := ms.handleNonKeepAliveMapResponse(ctx, &tailcfg.MapResponse{
+		Node:  &tailcfg.Node{Name: "self.example.ts.net."},
+		Peers: []*tailcfg.Node{peer},
+		UserProfiles: []tailcfg.UserProfile{
+			{ID: 0, LoginName: "invalid@example.com"},
+			{ID: 100, LoginName: "user@example.com"},
+			{ID: 200, LoginName: "sharer@example.com"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := nu.full.Load(); got != 1 {
+		t.Fatalf("full updates after initial response = %d; want 1", got)
+	}
+
+	// An upsert with no UserProfiles in the response must still deliver
+	// both profiles, before the delta lands.
+	replacement := peer.Clone()
+	replacement.AllowedIPs = append(replacement.AllowedIPs, netip.MustParsePrefix("100.64.0.2/32"))
+	if err := ms.handleNonKeepAliveMapResponse(ctx, &tailcfg.MapResponse{
+		PeersChanged: []*tailcfg.Node{replacement},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := nu.full.Load(); got != 1 {
+		t.Fatalf("full updates after peer upsert = %d; want 1", got)
+	}
+	if got := nu.delta.Load(); got != 1 {
+		t.Fatalf("delta updates after peer upsert = %d; want 1", got)
+	}
+	if got := len(nu.profiles); got != 2 {
+		t.Fatalf("UpdateUserProfiles calls = %d; want 2 (one initial, one replayed)", got)
+	}
+	if got := nu.profilesAtDelta; got != 2 {
+		t.Errorf("profiles delivered before delta = %d; want 2", got)
+	}
+	replayed := nu.profiles[1]
+	if _, ok := replayed[0]; ok {
+		t.Error("replayed profiles contains zero user ID")
+	}
+	for _, id := range []tailcfg.UserID{100, 200} {
+		up, ok := replayed[id]
+		if !ok || !up.Valid() {
+			t.Errorf("replayed profiles missing valid profile for user %d", id)
+		}
+	}
+
+	// A patch-only change (no upsert) must not replay any profiles.
+	patched := replacement.Clone()
+	patched.Endpoints = eps("10.0.0.1:1111")
+	if err := ms.handleNonKeepAliveMapResponse(ctx, &tailcfg.MapResponse{
+		PeersChanged: []*tailcfg.Node{patched},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(nu.profiles); got != 2 {
+		t.Errorf("UpdateUserProfiles calls after patch-only change = %d; want still 2", got)
+	}
+}
+
 // tests (*mapSession).patchifyPeersChanged; smaller tests are in TestPeerChangeDiff
 func TestPatchifyPeersChanged(t *testing.T) {
 	hi := (&tailcfg.Hostinfo{}).View()


### PR DESCRIPTION
A full netmap carries only the profiles of users with a currently
visible peer (netmapForResponse), and nodeBackend replaces its live
profile set wholesale on every full netmap install. A full netmap that
arrives while a user has no visible peer therefore drops that user's
profile downstream.

When a peer of that user later returns as an incremental upsert,
control does not resend the profile, because MapResponse.UserProfiles
has carried only new or updated profiles since mapver 5. The upsert
indexes the node by address and key, so WireGuard admits its traffic,
but WhoIs then fails one step later at the user profile lookup,
surfacing as "peerapi: unknown peer" until the next full netmap. It is
a second, independent cause of the symptom fixed by the recent index
eviction change.

mapSession.lastUserProfile holds the profile the whole time, so when
handling a response incrementally, also deliver the profiles of
upserted peers' users (and sharers) from that store, before the
mutations that reference them.

Updates tailscale/corp#47435
