### PR TITLE
tstest/integration: wait for the daemon to exit after killing it

### DIFF
--- a/tstest/integration/integration.go
+++ b/tstest/integration/integration.go
@@ -1019,7 +1019,12 @@ func (n *TestNode) StartDaemonAsIPNGOOS(ipnGOOS string) *Daemon {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("starting tailscaled: %v", err)
 	}
-	t.Cleanup(func() { cmd.Process.Kill() })
+	// Wait too: Kill only requests termination, and Windows holds the executable
+	// until the process is gone. See #21099.
+	t.Cleanup(func() {
+		cmd.Process.Kill()
+		cmd.Process.Wait()
+	})
 	return &Daemon{
 		Process: cmd.Process,
 		node:    n,


### PR DESCRIPTION
Updates #21099

On Windows, integration tests sometimes fail during cleanup because something still has the test's copy of tailscaled.exe open when t.TempDir() tries to delete it. Go only retries for 2s before giving up, so this deletes the staged binaries first and waits longer.