### PR TITLE
cmd/tsconnect: bundle pkg.d.ts into tsconnect

### DIFF
--- a/cmd/tsconnect/build-pkg.go
+++ b/cmd/tsconnect/build-pkg.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/tailscale/hujson"
 	"tailscale.com/cmd/tsconnect/wasmbuild"
@@ -51,6 +52,9 @@ func runBuildPkg() {
 	log.Printf("Generating types...\n")
 	if err := runYarn("pkg-types"); err != nil {
 		log.Fatalf("Type generation failed: %v", err)
+	}
+	if err := copyTypeDeclarations(); err != nil {
+		log.Fatalf("Cannot copy generated types: %v", err)
 	}
 
 	if err := updateVersion(); err != nil {
@@ -116,4 +120,19 @@ func copyReadme() error {
 		return fmt.Errorf("Could not read README.pkg.md: %w", err)
 	}
 	return os.WriteFile(path.Join(*pkgDir, "README.md"), readmeBytes, 0644)
+}
+
+// copyTypeDeclarations copies pkg.d.ts into pkgDir
+// if pkgDir differs from the local default ./pkg.
+func copyTypeDeclarations() error {
+	const src = "pkg/pkg.d.ts"
+	dst := path.Join(*pkgDir, "pkg.d.ts")
+	if filepath.Clean(src) == filepath.Clean(dst) {
+		return nil
+	}
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dst, data, 0644)
 }


### PR DESCRIPTION
Once the pkg-types script has generated pkg.d.ts and checked them against the tsconfig.json and node_modules in cmd/tsconnect, copy them into the pkgDir so they get bundled into the package.

Updates #19707 

We already do something similar to ensure that the README ends up in the package. I did consider changing the output path of the type declaration generation to the pkgDir. This results in the validation run into trouble since dts-bundle-generator makes assumptions about the placement of tsconfig.json and node_modules relative to pkg.d.ts. So just copying over pkg.d.ts once all is done seems simplest.
