### PR TITLE
wgengine/wgcfg: size crypto & per-peer queues by CPU factor

### DIFF
--- a/wgengine/wgcfg/mem_ios.go
+++ b/wgengine/wgcfg/mem_ios.go
@@ -9,8 +9,14 @@ import (
 
 func getDeviceOptions() []device.Option {
 	// iOS has a very restrictive memory limit on network extensions.
-	// Reduce the maximum amount of memory that wireguard-go can allocate
-	// to avoid getting killed.
+	// Reduce the maximum amount of memory that wireguard-go can allocate to
+	// avoid getting killed.
+	//
+	// See _notios.go for a longer explanation of what the Queue{In,Out}boundSize
+	// knobs control and the tradeoffs involved. Eventually Queue{In,Out}boundSize
+	// should be CPU-scaled, and WithPreallocated... removed, but we keep them all
+	// static for now, until the [device.WaitPool] ceiling is eliminated.
+	// (See tailscale/corp#46396).
 	return []device.Option{
 		device.WithQueueStagedSize(64),
 		device.WithQueueOutboundSize(64),

--- a/wgengine/wgcfg/mem_notios.go
+++ b/wgengine/wgcfg/mem_notios.go
@@ -5,9 +5,39 @@
 
 package wgcfg
 
-import "github.com/tailscale/wireguard-go/device"
+import (
+	"runtime"
+
+	"github.com/tailscale/wireguard-go/device"
+)
 
 func getDeviceOptions() []device.Option {
-	// Return nothing in order to use wireguard-go defaults, e.g. [device.DefaultQueueOutboundSize].
-	return nil
+	// wireguard-go is a packet pipeline:
+	//
+	// TUN read -> encrypt -> ordered network write
+	// network read -> decrypt -> ordered TUN write
+	//
+	// The queues that we are sizing in this function sit between head I/O
+	// goroutines and downstream functions. They are buffered channels.
+	//
+	// The head I/O ops tend to "run ahead" the downstream functions, especially
+	// when head I/O ops utilize segmentation offloading, where a single head I/O
+	// op can contain about 45 packets at a typical MTU, which is equivalent to
+	// 45 crypto ops.
+	//
+	// Small queues park I/O goroutines and hurt throughput; large queues allow
+	// more packet batches and their associated memory to remain outstanding. We
+	// have to find a balance. Crypto goroutines are sized to [runtime.NumCPU]
+	// in wireguard-go, so we start there, and apply a benchmark-backed scaling
+	// factor to reduce head I/O goroutines parking around bursts.
+	const cpuScalingFactor = 4
+	// maxQueueSize was the previous static default, prior to creation of the
+	// [device.Option].
+	const maxQueueSize = 1024
+	return []device.Option{
+		// TODO: make cgroup-aware with runtime.GOMAXPROCS(0).
+		// See tailscale/corp#47966.
+		device.WithQueueInboundSize(min(maxQueueSize, runtime.NumCPU()*cpuScalingFactor)),
+		device.WithQueueOutboundSize(min(maxQueueSize, runtime.NumCPU()*cpuScalingFactor)),
+	}
 }


### PR DESCRIPTION
To better balance throughput vs backlogged packet memory consumption.

These changes reduce peak RSS in UDP TX benchmarks that previously regressed in 8fc6dca. All other benchmarks remain largely unchanged. Netstack benchmarks are new, with back-tested results from 1e69418.

The following throughput and peak RSS benchmarks were performed with iperf3 between two Intel i5-12400 nodes running Ubuntu 24.04 (Linux 6.8).

The UDP benchmarks did not use UDP GSO on the sender, so they were roughly equivalent to single packet I/O through wireguard-go.

TCP/1 signifies one TCP stream; TCP/128 signifies 128 parallel TCP streams. -NS signifies netstack, and -RX/-TX signify the side netstack was running on, with the other being a natural TUN.

Change column is calculated against the oldest baseline (1e69418).

```csv
Throughput (Mb/s)
  Test            1e69418      8fc6dca  queue-size   Change
  TCP/1            10,371       11,354      11,407   +9.98%
  TCP/1-NS-TX       9,225       10,553      10,481  +13.61%
  TCP/1-NS-RX       8,573        9,097       9,002   +5.00%
  TCP/128           7,886        8,404       8,427   +6.85%
  TCP/128-NS-TX     4,613        6,408       5,448  +18.10%
  TCP/128-NS-RX     6,730        8,524       8,279  +23.02%
  UDP/1             2,111        2,853       2,751  +30.33%
  UDP/1-NS-TX       2,022        1,941       1,904   -5.85%
  UDP/1-NS-RX       2,087        2,444       2,261   +8.35%
  UDP/128           1,747        2,235       2,216  +26.87%
  UDP/128-NS-TX     1,325        1,615       1,424   +7.47%
  UDP/128-NS-RX     1,743        2,219       2,240  +28.50%

Peak memory (VmHWM, kB)
  Test           Side    1e69418      8fc6dca  queue-size   Change
  TCP/1          TX       98,240       52,596      52,508  -46.55%
                 RX      287,748       73,384      65,404  -77.27%
  TCP/1-NS-TX    TX      254,196       85,116      76,076  -70.07%
  TCP/1-NS-RX    RX      434,952       70,420      70,916  -83.70%
  TCP/128        TX      101,196       52,812      51,740  -48.87%
                 RX      290,420       63,620      62,716  -78.41%
  TCP/128-NS-TX  TX    1,499,200    1,199,304     821,740  -45.19%
  TCP/128-NS-RX  RX    3,945,960      475,276     153,516  -96.11%
  UDP/1          TX       58,864      160,840      58,060   -1.37%
                 RX      137,516       49,900      51,732  -62.38%
  UDP/1-NS-TX    TX      214,924      282,400      59,956  -72.10%
  UDP/1-NS-RX    RX      112,152       49,004      49,108  -56.21%
  UDP/128        TX       66,148      116,096      57,344  -13.31%
                 RX      154,384       56,556      57,572  -62.71%
  UDP/128-NS-TX  TX      187,096      225,080      88,628  -52.63%
  UDP/128-NS-RX  RX      156,108       74,556      75,952  -51.35%
```

Updates tailscale/corp#46716
Updates tailscale/corp#22467
Updates tailscale/corp#36989
Updates tailscale/corp#37878