### PR TITLE
wgengine/netstack: split outbound traffic into destination queues

### DIFF
--- a/wgengine/netstack/link_endpoint.go
+++ b/wgengine/netstack/link_endpoint.go
@@ -5,6 +5,7 @@ package netstack
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"gvisor.dev/gvisor/pkg/buffer"
@@ -98,31 +99,65 @@ const (
 	tcpGROSupported
 )
 
-// linkEndpoint implements stack.LinkEndpoint and stack.GSOEndpoint. Outbound
-// packets written by gVisor towards Tailscale are stored in a channel.
-// Inbound is fed to gVisor via injectInbound or gro. This is loosely
-// modeled after gvisor.dev/pkg/tcpip/link/channel.Endpoint.
+// outboundQueueRouter is a function that takes an input packet and returns an
+// associated [outboundQueue] decision.
+type outboundQueueRouter func(*stack.PacketBuffer) outboundQueue
+
+// outboundQueue describes outbound [queue]'s attached to [linkEndpoint].
+type outboundQueue int
+
+const (
+	// outboundDrop indicates that the packet should be discarded. It does not
+	// correspond to a real queue.
+	outboundDrop outboundQueue = iota
+	// outboundToWireGuard is the outboundQueue for packets that should be
+	// delivered to WireGuard for potential transmission to a remote peer.
+	outboundToWireGuard
+	// outboundToHost is the outboundQueue for packets that should be delivered
+	// to the local host networking stack.
+	outboundToHost
+	// outboundLoopback is the outboundQueue for packets that should be looped
+	// back into gVisor.
+	outboundLoopback
+	// outboundQueueLimit is the exclusive upper bound of outboundQueue values.
+	outboundQueueLimit
+)
+
+// linkEndpoint implements [stack.LinkEndpoint] and [stack.GSOEndpoint]. Outbound
+// packets written by gVisor towards Tailscale are stored in one of several
+// outbound [queue]'s. Inbound is fed to gVisor via [linkEndpoint.injectInbound]
+// or [linkEndpoint.gro]. linkEndpoint is loosely modeled after
+// [gvisor.dev/pkg/tcpip/link/channel.Endpoint].
 type linkEndpoint struct {
-	SupportedGSOKind stack.SupportedGSO
-	supportedGRO     supportedGRO
+	SupportedGSOKind    stack.SupportedGSO
+	supportedGRO        supportedGRO
+	outboundQueueRouter outboundQueueRouter
 
 	mu         sync.RWMutex // mu guards the following fields
 	dispatcher stack.NetworkDispatcher
 	linkAddr   tcpip.LinkAddress
 	mtu        uint32
 
-	q *queue // outbound
+	outboundQueues [outboundQueueLimit]*queue // outbound
 }
 
-func newLinkEndpoint(size int, mtu uint32, linkAddr tcpip.LinkAddress, supportedGRO supportedGRO) *linkEndpoint {
+// newLinkEndpoint constructs a [*linkEndpoint]. size is applied independently
+// to each outbound [queue], so total size = num outbound queues * size.
+func newLinkEndpoint(size int, mtu uint32, linkAddr tcpip.LinkAddress, supportedGRO supportedGRO, outboundQueueRouter outboundQueueRouter) *linkEndpoint {
 	le := &linkEndpoint{
-		supportedGRO: supportedGRO,
-		q: &queue{
+		supportedGRO:        supportedGRO,
+		outboundQueueRouter: outboundQueueRouter,
+		mtu:                 mtu,
+		linkAddr:            linkAddr,
+	}
+	for n := range le.outboundQueues {
+		if n == int(outboundDrop) {
+			continue
+		}
+		le.outboundQueues[n] = &queue{
 			c:        make(chan *stack.PacketBuffer, size),
 			closedCh: make(chan struct{}),
-		},
-		mtu:      mtu,
-		linkAddr: linkAddr,
+		}
 	}
 	return le
 }
@@ -152,36 +187,52 @@ func (ep *linkEndpoint) gro(p *packet.Parsed, g *gro.GRO) *gro.GRO {
 	return g
 }
 
-// Close closes l. Further packet injections will return an error, and all
+// Close closes ep. Further packet injections will return an error, and all
 // pending packets are discarded. Close may be called concurrently with
 // WritePackets.
 func (ep *linkEndpoint) Close() {
 	ep.mu.Lock()
 	ep.dispatcher = nil
 	ep.mu.Unlock()
-	ep.q.Close()
+	for _, q := range ep.outboundQueues {
+		if q != nil {
+			q.Close()
+		}
+	}
 	ep.Drain()
 }
 
-// Read does non-blocking read one packet from the outbound packet queue.
-func (ep *linkEndpoint) Read() *stack.PacketBuffer {
-	return ep.q.Read()
+// Read reads from the provided [outboundQueue] in non-blocking fashion.
+func (ep *linkEndpoint) Read(queue outboundQueue) *stack.PacketBuffer {
+	return ep.outboundQueues[queue].Read()
 }
 
-// ReadContext does blocking read for one packet from the outbound packet queue.
-// It can be cancelled by ctx, and in this case, it returns nil.
-func (ep *linkEndpoint) ReadContext(ctx context.Context) *stack.PacketBuffer {
-	return ep.q.ReadContext(ctx)
+// ReadContext reads from the provided [outboundQueue] in blocking fashion. It
+// can be canceled by ctx, in which case it will return nil.
+func (ep *linkEndpoint) ReadContext(ctx context.Context, queue outboundQueue) *stack.PacketBuffer {
+	return ep.outboundQueues[queue].ReadContext(ctx)
 }
 
-// Drain removes all outbound packets from the channel and counts them.
+// Drain drains all packets from outbound queues and returns the number drained.
 func (ep *linkEndpoint) Drain() int {
-	return ep.q.Drain()
+	var total int
+	for _, q := range ep.outboundQueues {
+		if q != nil {
+			total += q.Drain()
+		}
+	}
+	return total
 }
 
 // NumQueued returns the number of packets queued for outbound.
 func (ep *linkEndpoint) NumQueued() int {
-	return ep.q.Num()
+	var total int
+	for _, q := range ep.outboundQueues {
+		if q != nil {
+			total += q.Num()
+		}
+	}
+	return total
 }
 
 func (ep *linkEndpoint) injectInbound(p *packet.Parsed) {
@@ -304,7 +355,7 @@ func (ep *linkEndpoint) SetLinkAddress(addr tcpip.LinkAddress) {
 	ep.linkAddr = addr
 }
 
-// WritePackets stores outbound packets into the channel.
+// WritePackets routes outbound packets into the appropriate outbound [queue].
 // Multiple concurrent calls are permitted.
 func (ep *linkEndpoint) WritePackets(pkts stack.PacketBufferList) (int, tcpip.Error) {
 	n := 0
@@ -316,7 +367,15 @@ func (ep *linkEndpoint) WritePackets(pkts stack.PacketBufferList) (int, tcpip.Er
 	//  control MTU (and by effect TCP MSS in gVisor) we *shouldn't* expect to
 	//  ever overflow 128 slots (see wireguard-go/tun.ErrTooManySegments usage).
 	for _, pkt := range pkts.AsSlice() {
-		if err := ep.q.Write(pkt); err != nil {
+		q := ep.outboundQueueRouter(pkt)
+		if q == outboundDrop {
+			n++
+			continue
+		}
+		if q < 0 || q >= outboundQueueLimit {
+			panic(fmt.Sprintf("linkEndpoint.outboundQueueRouter returned %v which is outside outboundQueueLimit(%v)", q, outboundQueueLimit))
+		}
+		if err := ep.outboundQueues[q].Write(pkt); err != nil {
 			if _, ok := err.(*tcpip.ErrNoBufferSpace); !ok && n == 0 {
 				return 0, err
 			}

--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -217,7 +217,7 @@ type Impl struct {
 	dialer    *tsdial.Dialer
 	ctx       context.Context        // alive until Close
 	ctxCancel context.CancelFunc     // called on Close
-	injectWG  sync.WaitGroup         // wait for the inject goroutine
+	injectWG  sync.WaitGroup         // wait for the inject goroutines
 	lb        *ipnlocal.LocalBackend // or nil
 	dns       *dns.Manager
 
@@ -350,80 +350,10 @@ func Create(logf logger.Logf, tundev *tstun.Wrapper, e wgengine.Engine, mc *magi
 	if dialer == nil {
 		return nil, errors.New("nil Dialer")
 	}
-	ipstack := stack.New(stack.Options{
-		NetworkProtocols:   []stack.NetworkProtocolFactory{ipv4.NewProtocol, ipv6.NewProtocol},
-		TransportProtocols: []stack.TransportProtocolFactory{tcp.NewProtocol, udp.NewProtocol, icmp.NewProtocol4, icmp.NewProtocol6},
-	})
-	sackEnabledOpt := tcpip.TCPSACKEnabled(true) // TCP SACK is disabled by default
-	tcpipErr := ipstack.SetTransportProtocolOption(tcp.ProtocolNumber, &sackEnabledOpt)
-	if tcpipErr != nil {
-		return nil, fmt.Errorf("could not enable TCP SACK: %v", tcpipErr)
-	}
-	// See https://github.com/tailscale/tailscale/issues/9707
-	// gVisor's RACK performs poorly. ACKs do not appear to be handled in a
-	// timely manner, leading to spurious retransmissions and a reduced
-	// congestion window.
-	tcpRecoveryOpt := tcpip.TCPRecovery(0)
-	tcpipErr = ipstack.SetTransportProtocolOption(tcp.ProtocolNumber, &tcpRecoveryOpt)
-	if tcpipErr != nil {
-		return nil, fmt.Errorf("could not disable TCP RACK: %v", tcpipErr)
-	}
-	// gVisor defaults to reno at the time of writing. We explicitly set reno
-	// congestion control in order to prevent unexpected changes. Netstack
-	// has an int overflow in sender congestion window arithmetic that is more
-	// prone to trigger with cubic congestion control.
-	// See https://github.com/google/gvisor/issues/11632
-	renoOpt := tcpip.CongestionControlOption("reno")
-	tcpipErr = ipstack.SetTransportProtocolOption(tcp.ProtocolNumber, &renoOpt)
-	if tcpipErr != nil {
-		return nil, fmt.Errorf("could not set reno congestion control: %v", tcpipErr)
-	}
-	err := setTCPBufSizes(ipstack)
-	if err != nil {
-		return nil, err
-	}
-	supportedGSOKind := stack.GSONotSupported
-	supportedGROKind := groNotSupported
-	if runtime.GOOS == "linux" && buildfeatures.HasGRO {
-		// TODO(jwhited): add Windows support https://github.com/tailscale/corp/issues/21874
-		supportedGROKind = tcpGROSupported
-		supportedGSOKind = stack.HostGSOSupported
-	}
-	linkEP := newLinkEndpoint(512, uint32(tstun.DefaultTUNMTU()), "", supportedGROKind)
-	linkEP.SupportedGSOKind = supportedGSOKind
-	if tcpipProblem := ipstack.CreateNIC(nicID, linkEP); tcpipProblem != nil {
-		return nil, fmt.Errorf("could not create netstack NIC: %v", tcpipProblem)
-	}
-	// By default the netstack NIC will only accept packets for the IPs
-	// registered to it. Since in some cases we dynamically register IPs
-	// based on the packets that arrive, the NIC needs to accept all
-	// incoming packets. The NIC won't receive anything it isn't meant to
-	// since WireGuard will only send us packets that are meant for us.
-	ipstack.SetPromiscuousMode(nicID, true)
-	// Add IPv4 and IPv6 default routes, so all incoming packets from the Tailscale side
-	// are handled by the one fake NIC we use.
-	ipv4Subnet, err := tcpip.NewSubnet(tcpip.AddrFromSlice(make([]byte, 4)), tcpip.MaskFromBytes(make([]byte, 4)))
-	if err != nil {
-		return nil, fmt.Errorf("could not create IPv4 subnet: %v", err)
-	}
-	ipv6Subnet, err := tcpip.NewSubnet(tcpip.AddrFromSlice(make([]byte, 16)), tcpip.MaskFromBytes(make([]byte, 16)))
-	if err != nil {
-		return nil, fmt.Errorf("could not create IPv6 subnet: %v", err)
-	}
-	ipstack.SetRouteTable([]tcpip.Route{
-		{
-			Destination: ipv4Subnet,
-			NIC:         nicID,
-		},
-		{
-			Destination: ipv6Subnet,
-			NIC:         nicID,
-		},
-	})
+	// construct [Impl] before [linkEndpoint], as [linkEndpoint] construction
+	// requires [Impl.outboundQueueForPacket] and non-nil ip lookup funcs.
 	ns := &Impl{
 		logf:                  logf,
-		ipstack:               ipstack,
-		linkEP:                linkEP,
 		tundev:                tundev,
 		e:                     e,
 		pm:                    pm,
@@ -441,6 +371,76 @@ func Create(logf logger.Logf, tundev *tstun.Wrapper, e wgengine.Engine, mc *magi
 	ns.ctx, ns.ctxCancel = context.WithCancel(context.Background())
 	ns.atomicIsLocalIPFunc.Store(ipset.FalseContainsIPFunc())
 	ns.atomicIsVIPServiceIPFunc.Store(ipset.FalseContainsIPFunc())
+	ns.ipstack = stack.New(stack.Options{
+		NetworkProtocols:   []stack.NetworkProtocolFactory{ipv4.NewProtocol, ipv6.NewProtocol},
+		TransportProtocols: []stack.TransportProtocolFactory{tcp.NewProtocol, udp.NewProtocol, icmp.NewProtocol4, icmp.NewProtocol6},
+	})
+	sackEnabledOpt := tcpip.TCPSACKEnabled(true) // TCP SACK is disabled by default
+	tcpipErr := ns.ipstack.SetTransportProtocolOption(tcp.ProtocolNumber, &sackEnabledOpt)
+	if tcpipErr != nil {
+		return nil, fmt.Errorf("could not enable TCP SACK: %v", tcpipErr)
+	}
+	// See https://github.com/tailscale/tailscale/issues/9707
+	// gVisor's RACK performs poorly. ACKs do not appear to be handled in a
+	// timely manner, leading to spurious retransmissions and a reduced
+	// congestion window.
+	tcpRecoveryOpt := tcpip.TCPRecovery(0)
+	tcpipErr = ns.ipstack.SetTransportProtocolOption(tcp.ProtocolNumber, &tcpRecoveryOpt)
+	if tcpipErr != nil {
+		return nil, fmt.Errorf("could not disable TCP RACK: %v", tcpipErr)
+	}
+	// gVisor defaults to reno at the time of writing. We explicitly set reno
+	// congestion control in order to prevent unexpected changes. Netstack
+	// has an int overflow in sender congestion window arithmetic that is more
+	// prone to trigger with cubic congestion control.
+	// See https://github.com/google/gvisor/issues/11632
+	renoOpt := tcpip.CongestionControlOption("reno")
+	tcpipErr = ns.ipstack.SetTransportProtocolOption(tcp.ProtocolNumber, &renoOpt)
+	if tcpipErr != nil {
+		return nil, fmt.Errorf("could not set reno congestion control: %v", tcpipErr)
+	}
+	err := setTCPBufSizes(ns.ipstack)
+	if err != nil {
+		return nil, err
+	}
+	supportedGSOKind := stack.GSONotSupported
+	supportedGROKind := groNotSupported
+	if runtime.GOOS == "linux" && buildfeatures.HasGRO {
+		// TODO(jwhited): add Windows support https://github.com/tailscale/corp/issues/21874
+		supportedGROKind = tcpGROSupported
+		supportedGSOKind = stack.HostGSOSupported
+	}
+	ns.linkEP = newLinkEndpoint(512, uint32(tstun.DefaultTUNMTU()), "", supportedGROKind, ns.outboundQueueForPacket)
+	ns.linkEP.SupportedGSOKind = supportedGSOKind
+	if tcpipProblem := ns.ipstack.CreateNIC(nicID, ns.linkEP); tcpipProblem != nil {
+		return nil, fmt.Errorf("could not create netstack NIC: %v", tcpipProblem)
+	}
+	// By default the netstack NIC will only accept packets for the IPs
+	// registered to it. Since in some cases we dynamically register IPs
+	// based on the packets that arrive, the NIC needs to accept all
+	// incoming packets. The NIC won't receive anything it isn't meant to
+	// since WireGuard will only send us packets that are meant for us.
+	ns.ipstack.SetPromiscuousMode(nicID, true)
+	// Add IPv4 and IPv6 default routes, so all incoming packets from the Tailscale side
+	// are handled by the one fake NIC we use.
+	ipv4Subnet, err := tcpip.NewSubnet(tcpip.AddrFromSlice(make([]byte, 4)), tcpip.MaskFromBytes(make([]byte, 4)))
+	if err != nil {
+		return nil, fmt.Errorf("could not create IPv4 subnet: %v", err)
+	}
+	ipv6Subnet, err := tcpip.NewSubnet(tcpip.AddrFromSlice(make([]byte, 16)), tcpip.MaskFromBytes(make([]byte, 16)))
+	if err != nil {
+		return nil, fmt.Errorf("could not create IPv6 subnet: %v", err)
+	}
+	ns.ipstack.SetRouteTable([]tcpip.Route{
+		{
+			Destination: ipv4Subnet,
+			NIC:         nicID,
+		},
+		{
+			Destination: ipv6Subnet,
+			NIC:         nicID,
+		},
+	})
 	ns.tundev.PostFilterPacketInboundFromWireGuard = ns.injectInbound
 	ns.tundev.PreFilterPacketOutboundToWireGuardNetstackIntercept = ns.handleLocalPackets
 	stacksForMetrics.Store(ns, struct{}{})
@@ -449,6 +449,8 @@ func Create(logf logger.Logf, tundev *tstun.Wrapper, e wgengine.Engine, mc *magi
 
 func (ns *Impl) Close() error {
 	stacksForMetrics.Delete(ns)
+	// Cancel the injection goroutines before ipstack.Wait closes linkEP's
+	// outbound queues. A nil queue read is expected only after cancellation.
 	ns.ctxCancel()
 	ns.ipstack.Close()
 	ns.ipstack.Wait()
@@ -647,9 +649,9 @@ func (ns *Impl) Start(b LocalBackend) error {
 	udpFwd := udp.NewForwarder(ns.ipstack, ns.acceptUDPNoICMP)
 	ns.ipstack.SetTransportProtocolHandler(tcp.ProtocolNumber, ns.wrapTCPProtocolHandler(tcpFwd.HandlePacket))
 	ns.ipstack.SetTransportProtocolHandler(udp.ProtocolNumber, ns.wrapUDPProtocolHandler(udpFwd.HandlePacket))
-	ns.injectWG.Go(func() {
-		ns.inject()
-	})
+	ns.injectWG.Go(ns.injectToHost)
+	ns.injectWG.Go(ns.injectToWireGuard)
+	ns.injectWG.Go(ns.injectLoopback)
 	if ns.ready.Swap(true) {
 		panic("already started")
 	}
@@ -1021,6 +1023,48 @@ func (ns *Impl) DialContextUDPWithBind(ctx context.Context, localAddr netip.Addr
 	return gonet.DialUDP(ns.ipstack, localAddress, remoteAddress, ipType)
 }
 
+// outboundQueueForPacket is the [outboundQueueRouter] used by [linkEndpoint].
+func (ns *Impl) outboundQueueForPacket(pkt *stack.PacketBuffer) outboundQueue {
+	switch {
+	case ns.shouldSendToHost(pkt):
+		return outboundToHost
+	case ns.isSelfDst(pkt):
+		// Self-addressed packet: deliver back into gVisor directly
+		// via the link endpoint's dispatcher, but only if the packet is not
+		// earmarked for the host. Neither the inbound path (fakeTUN Write is a
+		// no-op) nor the outbound path (WireGuard has no peer for our own IP)
+		// can handle these.
+		return outboundLoopback
+	default:
+		return outboundToWireGuard
+	}
+}
+
+// injectToWireGuard reads packets from the [outboundToWireGuard] [linkEndpoint]
+// queue and injects them into tstun for eventual delivery to wireguard-go via
+// [tun.Device.Read].
+func (ns *Impl) injectToWireGuard() {
+	for {
+		// TODO(jwhited): read-ahead and deliver a vector of packets to tstun
+		// for improved performance.
+		pkt := ns.linkEP.ReadContext(ns.ctx, outboundToWireGuard)
+		if pkt == nil {
+			if ns.ctx.Err() != nil {
+				return
+			}
+			panic("linkEndpoint.ReadContext returned nil with active context")
+		}
+		if debugPackets {
+			ns.logf("[v2] injectToWireGuard: % x",
+				stack.PayloadSince(pkt.NetworkHeader()).AsSlice())
+		}
+		if err := ns.tundev.InjectOutboundPacketBuffer(pkt); err != nil {
+			ns.logf("netstack injectToWireGuard err: %v", err)
+			return
+		}
+	}
+}
+
 // getInjectInboundPacketSlab returns packet memory and related descriptors to
 // be used when calling [tstun.Wrapper.InjectInboundPacketBuffer]. The returned
 // elements are sized with consideration for MTU and GSO support on [Impl.linkEP],
@@ -1038,55 +1082,48 @@ func (ns *Impl) getInjectInboundPacketSlab() (slab []byte, packets []tun.ReadPac
 		make([][]byte, packetCount)
 }
 
-// The inject goroutine reads in packets that netstack generated, and delivers
-// them to the correct path.
-func (ns *Impl) inject() {
+// injectToHost reads packets from the [outboundToHost] [linkEndpoint] queue and
+// injects them into tstun for eventual delivery to the host networking stack
+// via [tun.Device.Write]. MagicDNS flows are one example of packets that are
+// routed over this path.
+func (ns *Impl) injectToHost() {
 	inboundSlab, packets, writeBufs := ns.getInjectInboundPacketSlab()
 	for {
-		pkt := ns.linkEP.ReadContext(ns.ctx)
+		pkt := ns.linkEP.ReadContext(ns.ctx, outboundToHost)
 		if pkt == nil {
 			if ns.ctx.Err() != nil {
-				// Return without logging.
 				return
 			}
-			ns.logf("[v2] ReadContext-for-write = ok=false")
-			continue
+			panic("linkEndpoint.ReadContext returned nil with active context")
 		}
-
 		if debugPackets {
-			ns.logf("[v2] packet Write out: % x", stack.PayloadSince(pkt.NetworkHeader()).AsSlice())
+			ns.logf("[v2] injectToHost: % x",
+				stack.PayloadSince(pkt.NetworkHeader()).AsSlice())
 		}
+		if err := ns.tundev.InjectInboundPacketBuffer(pkt, inboundSlab, packets, writeBufs); err != nil {
+			ns.logf("netstack injectToHost err: %v", err)
+			return
+		}
+	}
+}
 
-		// In the normal case, netstack synthesizes the bytes for
-		// traffic which should transit back into WG and go to peers.
-		// However, some uses of netstack (presently, magic DNS)
-		// send traffic destined for the local device, hence must
-		// be injected 'inbound'.
-		sendToHost := ns.shouldSendToHost(pkt)
-
-		// pkt has a non-zero refcount, so injection methods takes
-		// ownership of one count and will decrement on completion.
-		if sendToHost {
-			if err := ns.tundev.InjectInboundPacketBuffer(pkt, inboundSlab, packets, writeBufs); err != nil {
-				ns.logf("netstack inject inbound: %v", err)
+// injectLoopback reads packets from the [outboundLoopback] [linkEndpoint]
+// queue and writes them back towards gVisor. [tsnet.Server] flows towards self
+// Tailscale addresses are one example of packets that flow on this path.
+func (ns *Impl) injectLoopback() {
+	for {
+		pkt := ns.linkEP.ReadContext(ns.ctx, outboundLoopback)
+		if pkt == nil {
+			if ns.ctx.Err() != nil {
 				return
 			}
-		} else {
-			// Self-addressed packet: deliver back into gVisor directly
-			// via the link endpoint's dispatcher, but only if the packet is not
-			// earmarked for the host. Neither the inbound path (fakeTUN Write is a
-			// no-op) nor the outbound path (WireGuard has no peer for our own IP)
-			// can handle these.
-			if ns.isSelfDst(pkt) {
-				ns.linkEP.DeliverLoopback(pkt)
-				continue
-			}
-
-			if err := ns.tundev.InjectOutboundPacketBuffer(pkt); err != nil {
-				ns.logf("netstack inject outbound: %v", err)
-				return
-			}
+			panic("linkEndpoint.ReadContext returned nil with active context")
 		}
+		if debugPackets {
+			ns.logf("[v2] injectLoopback: % x",
+				stack.PayloadSince(pkt.NetworkHeader()).AsSlice())
+		}
+		ns.linkEP.DeliverLoopback(pkt)
 	}
 }
 
@@ -1162,8 +1199,8 @@ func (ns *Impl) shouldSendToHost(pkt *stack.PacketBuffer) bool {
 }
 
 // isSelfDst reports whether pkt's destination IP is a local Tailscale IP
-// assigned to this node. This is used by inject() to detect self-addressed
-// packets that need loopback delivery.
+// assigned to this node. This is used by outboundQueueForPacket() to detect
+// self-addressed packets that need loopback delivery.
 func (ns *Impl) isSelfDst(pkt *stack.PacketBuffer) bool {
 	hdr := pkt.Network()
 	switch v := hdr.(type) {

--- a/wgengine/netstack/netstack_test.go
+++ b/wgengine/netstack/netstack_test.go
@@ -1891,10 +1891,14 @@ func TestIsSelfDst(t *testing.T) {
 	}
 }
 
+func alwaysOutboundToWireGuard(*stack.PacketBuffer) outboundQueue {
+	return outboundToWireGuard
+}
+
 // TestDeliverLoopback verifies that DeliverLoopback correctly re-serializes an
 // outbound packet and delivers it back into gVisor's inbound path.
 func TestDeliverLoopback(t *testing.T) {
-	ep := newLinkEndpoint(64, 1280, "", groNotSupported)
+	ep := newLinkEndpoint(64, 1280, "", groNotSupported, alwaysOutboundToWireGuard)
 
 	// Track delivered packets via a mock dispatcher.
 	type delivered struct {
@@ -1961,7 +1965,7 @@ func TestDeliverLoopback(t *testing.T) {
 	})
 
 	t.Run("nil_dispatcher", func(t *testing.T) {
-		ep2 := newLinkEndpoint(64, 1280, "", groNotSupported)
+		ep2 := newLinkEndpoint(64, 1280, "", groNotSupported, alwaysOutboundToWireGuard)
 		// Don't attach a dispatcher.
 		selfAddr := netip.MustParseAddrPort("100.64.1.2:8081")
 		pkt := makeUDP4PacketBuffer(selfAddr, selfAddr)
@@ -2081,7 +2085,7 @@ func TestLinkEndpointInjectInboundIPv4Fragments(t *testing.T) {
 	})
 	defer s.Close()
 
-	ep := newLinkEndpoint(64, 1280, "", groNotSupported)
+	ep := newLinkEndpoint(64, 1280, "", groNotSupported, alwaysOutboundToWireGuard)
 	if err := s.CreateNIC(nicID, ep); err != nil {
 		t.Fatalf("CreateNIC: %v", err)
 	}
@@ -2128,10 +2132,10 @@ func TestLinkEndpointInjectInboundIPv4Fragments(t *testing.T) {
 	}
 }
 
-// TestInjectLoopback verifies that the inject goroutine delivers self-addressed
-// packets back into gVisor (via DeliverLoopback) instead of sending them to
-// WireGuard outbound. This is a regression test for a bug where self-dial
-// packets were sent to WireGuard and silently dropped.
+// TestInjectLoopback verifies that [linkEndpoint] routes self-addressed packets
+// to the loopback queue and that [Impl.injectLoopback] delivers them back into
+// gVisor. This is a regression test for a bug where self-dial packets were sent
+// to WireGuard and silently dropped.
 func TestInjectLoopback(t *testing.T) {
 	selfIP4 := netip.MustParseAddr("100.64.1.2")
 
@@ -2173,21 +2177,30 @@ func TestInjectLoopback(t *testing.T) {
 		ReserveHeaderBytes: header.IPv4MinimumSize + header.UDPMinimumSize,
 		Payload:            buffer.MakeWithData(payload),
 	})
+	defer pkt.DecRef()
 	copy(pkt.TransportHeader().Push(header.UDPMinimumSize),
 		raw[header.IPv4MinimumSize:header.IPv4MinimumSize+header.UDPMinimumSize])
 	pkt.TransportProtocolNumber = header.UDPProtocolNumber
 	copy(pkt.NetworkHeader().Push(header.IPv4MinimumSize), raw[:header.IPv4MinimumSize])
 	pkt.NetworkProtocolNumber = header.IPv4ProtocolNumber
 
-	if err := ns.linkEP.q.Write(pkt); err != nil {
-		t.Fatalf("queue.Write: %v", err)
+	var pkts stack.PacketBufferList
+	pkts.PushBack(pkt)
+	n, tcpipErr := ns.linkEP.WritePackets(pkts)
+	if tcpipErr != nil {
+		t.Fatalf("WritePackets: %v", tcpipErr)
+	}
+	if n != 1 {
+		t.Fatalf("WritePackets wrote %d packets, want 1", n)
 	}
 
-	// The inject goroutine should detect the self-addressed packet via
-	// isSelfDst and deliver it back into gVisor via DeliverLoopback.
+	// [linkEndpoint.WritePackets] should detect the self-addressed packet via
+	// [Impl.outboundQueueForPacket], place it on the [outboundLoopback] queue,
+	// which [Impl.injectLoopback] should deliver back into gVisor via
+	// [linkEndpoint.DeliverLoopback].
 	pc.SetReadDeadline(time.Now().Add(5 * time.Second))
 	buf := make([]byte, 256)
-	n, _, err := pc.ReadFrom(buf)
+	n, _, err = pc.ReadFrom(buf)
 	if err != nil {
 		t.Fatalf("ReadFrom: %v (self-addressed packet was not looped back)", err)
 	}


### PR DESCRIPTION
Route packets to dedicated WireGuard, host, and loopback queues when gVisor writes them. Drain each queue in a separate goroutine, preparing the outbound path for batching and multiqueue WireGuard delivery.

Updates tailscale/corp#37878