### PR TITLE
ipn/ipnlocal: prefer one CGNAT route on iOS

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -6221,13 +6221,15 @@ func shouldUseOneCGNATRoute(logf logger.Logf, mon *netmon.Monitor, controlKnobs 
 	// Prefer a single CGNAT route on platforms where updateing the VPN
 	// configuration is espensive. On macOS, changing the network extension
 	// configuration can disrupt existing connections notably Chrome; see
-	// https://github.com/tailscale/tailscale/issues/3102). On Android, updating
+	// https://github.com/tailscale/tailscale/issues/3102). The same route churn
+	// can disrupt iOS connections; see https://github.com/tailscale/tailscale/issues/21125.
+	// On Android, updating
 	// VpnService.Builder configuration requires establishing a new VPN interface,
 	// which tears down long lived TCP connections.
 	//
 	// Only use fine-grained routes if another interfaces is also using the CGNAT
 	// IP range.
-	if versionOS == "macOS" || versionOS == "android" {
+	if versionOS == "macOS" || versionOS == "android" || versionOS == "iOS" {
 		hasCGNATInterface, err := mon.HasCGNATInterface()
 		if err != nil {
 			logf("shouldUseOneCGNATRoute: Could not determine if any interfaces use CGNAT: %v", err)

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -9414,6 +9414,30 @@ func TestShouldUseOneCGNATRoute(t *testing.T) {
 			want:    false,
 		},
 		{
+			name:      "iOS/tailscale-cgnat",
+			versionOS: "iOS",
+			ifaces: []netmon.Interface{
+				makeInterface(1, "lo0", "127.0.0.1/8"),
+				makeInterface(2, "en0", "10.203.33.114/23"),
+				makeInterface(3, "utun0", "100.95.71.186/32"),
+			},
+			tsName:  "utun0",
+			tsIndex: 3,
+			want:    true,
+		},
+		{
+			name:      "iOS/multiple-cgnats",
+			versionOS: "iOS",
+			ifaces: []netmon.Interface{
+				makeInterface(1, "lo0", "127.0.0.1/8"),
+				makeInterface(2, "en0", "100.124.0.1/32"),
+				makeInterface(3, "utun0", "100.95.71.186/32"),
+			},
+			tsName:  "utun0",
+			tsIndex: 3,
+			want:    false,
+		},
+		{
 			name:      "plan9/tailscale-cgnat",
 			versionOS: "plan9",
 			ifaces: []netmon.Interface{


### PR DESCRIPTION
## Summary

Prefer a single `100.64.0.0/10` route on iOS when no non-Tailscale interface uses the CGNAT range.

This extends the existing automatic OneCGNAT platform selection from macOS and Android to iOS. Explicit `OneCGNAT` control-knob values still take precedence, and `netmon.Monitor.HasCGNATInterface` still falls back to fine-grained peer routes when another interface uses RFC 6598 space.

## Motivation

iOS currently receives a `/32` route for each Tailscale peer. On physical iPhone and iPad devices with many peer and Mullvad routes, route-sensitive TCP discovery became intermittently slow or unavailable, and failed attempts could leave tunnel connectivity stalled until the VPN was toggled.

Applying the existing `one-cgnat?v=true` node attribute to the same stock iOS clients coalesced the peer routes to `100.64.0.0/10` while preserving an unrelated `10.7.0.1/32` subnet route. Repeated reconnects then completed without the previous route-discovery stalls. A small amount of application-level retry remained because the reproducer has a separate 100 ms TCP probe deadline.

This follows the Android change in #19652 and uses the same existing safety behavior.

## Tests

- `./tool/go test ./ipn/ipnlocal -run '^TestShouldUseOneCGNATRoute$' -count=1`
- Added iOS cases with and without a non-Tailscale CGNAT interface.
- Verified `one-cgnat?v=true` on stock iOS/iPadOS clients with physical devices.

Fixes #21125
