### PR TITLE
prober: honor continuous probe lifetimes and retry delays

### DIFF
--- a/prober/prober.go
+++ b/prober/prober.go
@@ -319,7 +319,6 @@ func (p *Probe) loop() {
 			// TODO(percy):implement exponential backoff, possibly using util/backoff.
 			select {
 			case <-time.After(-1 * p.interval):
-				p.run()
 			case <-p.ctx.Done():
 				return
 			}
@@ -344,13 +343,17 @@ func (p *Probe) loop() {
 // run invokes the probe function and records the result. It returns the probe
 // result and an error if the probe failed.
 //
-// The probe function is invoked with a timeout slightly less than interval, so
-// that the probe either succeeds or fails before the next cycle is scheduled to
-// start.
+// For periodic probes, the execution timeout defaults to slightly less than
+// the interval so that the next cycle can start on schedule.
 func (p *Probe) run() (pi ProbeInfo, err error) {
-	// Probes are scheduled each p.interval, so we don't wait longer than that.
-	semaCtx, cancel := context.WithTimeout(p.ctx, p.interval)
-	defer cancel()
+	// Periodic probes don't wait for a slot longer than their interval.
+	// Continuous probes use their lifetime context.
+	semaCtx := p.ctx
+	if !p.IsContinuous() {
+		var cancel func()
+		semaCtx, cancel = context.WithTimeout(semaCtx, p.interval)
+		defer cancel()
+	}
 	if !p.runSema.AcquireContext(semaCtx) {
 		return pi, fmt.Errorf("probe %s: context cancelled", p.name)
 	}

--- a/prober/prober_test.go
+++ b/prober/prober_test.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -36,6 +37,98 @@ const (
 )
 
 var epoch = time.Unix(0, 0)
+
+func TestProberContinuousWaitForSlot(t *testing.T) {
+	for _, cancelWhileWaiting := range []bool{false, true} {
+		t.Run(fmt.Sprintf("cancel=%v", cancelWhileWaiting), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				called := false
+				probe := newProbe(&Prober{now: time.Now}, "continuous", -time.Second, nil,
+					FuncProbe(func(ctx context.Context) error {
+						called = true
+						return ctx.Err()
+					}))
+				defer probe.cancel()
+				probe.runSema.Acquire()
+				releaseSlot := sync.OnceFunc(probe.runSema.Release)
+				defer releaseSlot()
+
+				done := make(chan error, 1)
+				go func() {
+					_, err := probe.run()
+					done <- err
+				}()
+				synctest.Wait()
+				// The negative interval is a retry delay, not a deadline
+				// for waiting on the slot.
+				time.Sleep(2 * time.Second)
+				synctest.Wait()
+				select {
+				case err := <-done:
+					t.Fatalf("run returned while the concurrency slot was held: %v", err)
+				default:
+				}
+
+				if cancelWhileWaiting {
+					probe.cancel()
+				} else {
+					releaseSlot()
+				}
+				err := <-done
+				if cancelWhileWaiting {
+					if err == nil || called {
+						t.Fatalf("canceled run: err=%v, called=%v; want error without calling probe", err, called)
+					}
+				} else if err != nil || !called {
+					t.Fatalf("released run: err=%v, called=%v; want successful probe", err, called)
+				}
+			})
+		})
+	}
+}
+
+func TestProberContinuousRetry(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const retryInterval = time.Second
+		// Buffer a duplicate attempt so it can be detected once the loop blocks.
+		starts := make(chan time.Time, 2)
+		probe := newProbe(&Prober{now: time.Now}, "continuous", -retryInterval, nil,
+			FuncProbe(func(ctx context.Context) error {
+				select {
+				case starts <- time.Now():
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+				return errors.New("probe failed")
+			}))
+		defer func() {
+			probe.cancel()
+			<-probe.stopped
+		}()
+
+		start := time.Now()
+		go probe.loop()
+		for i := range 3 {
+			synctest.Wait()
+			if got := len(starts); got != 1 {
+				t.Fatalf("after %v: got %d new probe calls, want 1", time.Since(start), got)
+			}
+			if got := (<-starts).Sub(start); got != time.Duration(i)*retryInterval {
+				t.Fatalf("probe %d started after %v, want %v", i, got, time.Duration(i)*retryInterval)
+			}
+			if i < 2 {
+				time.Sleep(retryInterval)
+			}
+		}
+
+		beforeCancel := time.Now()
+		probe.cancel()
+		<-probe.stopped
+		if elapsed := time.Since(beforeCancel); elapsed != 0 {
+			t.Fatalf("canceling the retry wait advanced time by %v", elapsed)
+		}
+	})
+}
 
 func TestProberTiming(t *testing.T) {
 	clk := newFakeTime()


### PR DESCRIPTION
Fixes #21134.

Continuous probes use a negative interval to specify the delay before retrying. `Probe.run` also passed that interval to `context.WithTimeout` when acquiring its concurrency slot, yielding an already-expired context. Even with a free slot, acquisition could select cancellation and skip the callback.

Use the probe's lifetime context for continuous semaphore acquisition. Callback execution already uses that context; periodic acquisition and execution deadlines are unchanged.

The continuous loop also called `p.run()` both in the timer case and at the top of the loop. Remove the timer-case invocation so each returned attempt waits the configured delay before another attempt. This restores the scheduling used by DERP queue-delay monitoring, without changing client dataplane behavior.

### Regression coverage

The new `testing/synctest` tests use local callbacks and fake time to cover:

- Waiting for a concurrency slot beyond the absolute retry interval, then proceeding when released.
- Cancellation while waiting for a slot, without invoking the callback.
- One initial attempt followed by correctly spaced retries.
- Prompt shutdown while waiting to retry.

The slot-wait test fails on unmodified main. With only the semaphore fix applied, the retry test independently fails with `after 1s: got 2 new probe calls, want 1`, including under the race detector.

### Validation

Passed with the repository-pinned Go toolchain on macOS/arm64:

```sh
./tool/go test -p=2 ./prober -run '^TestProberContinuous' -count=100 -timeout=3m
./tool/go test -p=2 ./prober ./cmd/derpprobe -count=1 -timeout=5m
./tool/go test -p=2 -race ./prober -count=1 -timeout=5m
./tool/go test -p=2 -race ./prober -run '^TestProberContinuous' -count=100 -cpu=1,2,8 -timeout=3m
```

`cmd/derpprobe` has no package tests. Also passed:

- The repository's custom vet analyzer (`./cmd/vet`) against `./prober ./cmd/derpprobe`.
- A Linux/amd64 build of `./cmd/derpprobe` with `CGO_ENABLED=0`.
- `gofmt` and `git diff --check`.
