### PR TITLE
ipn/ipnlocal: report state encryption from the store on macOS

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -9192,7 +9192,7 @@ var (
 )
 
 func (b *LocalBackend) stateEncrypted() opt.Bool {
-	switch runtime.GOOS {
+	switch envknob.GOOS() {
 	case "android", "ios":
 		return opt.NewBool(true)
 	case "darwin":
@@ -9202,13 +9202,11 @@ func (b *LocalBackend) stateEncrypted() opt.Bool {
 		case version.IsMacSysExt():
 			sp, _ := b.polc.GetBoolean(pkey.EncryptState, true)
 			return opt.NewBool(sp)
-		default:
-			// Probably self-compiled tailscaled, we don't use the Keychain
-			// there.
-			return opt.NewBool(false)
 		}
-	default:
-		_, ok := b.store.(ipn.EncryptedStateStore)
-		return opt.NewBool(ok)
+		// Not a Tailscale-shipped macOS app (self-compiled tailscaled, tsnet,
+		// or another embedder): we don't manage the Keychain for it, so defer
+		// to whatever its state store reports, as on other platforms.
 	}
+	_, ok := b.store.(ipn.EncryptedStateStore)
+	return opt.NewBool(ok)
 }

--- a/ipn/ipnlocal/local_test.go
+++ b/ipn/ipnlocal/local_test.go
@@ -36,6 +36,7 @@ import (
 	"tailscale.com/control/controlknobs"
 	"tailscale.com/drive"
 	"tailscale.com/drive/driveimpl"
+	"tailscale.com/envknob"
 	"tailscale.com/feature"
 	_ "tailscale.com/feature/condregister/portmapper"
 	"tailscale.com/health"
@@ -9910,6 +9911,70 @@ func TestApplyPrefsToHostinfoDedup(t *testing.T) {
 			}
 			if !slices.Equal(tt.wantTags, hi.RequestTags) {
 				t.Errorf("RequestTags mismatch, got %v; want %v", hi.RequestTags, tt.wantTags)
+			}
+		})
+	}
+}
+
+// encryptedTestStore is an [ipn.StateStore] that opts into the
+// [ipn.EncryptedStateStore] marker interface, as an out-of-tree store backed by
+// e.g. the Keychain would.
+type encryptedTestStore struct {
+	ipn.EncryptedStateStore
+	*mem.Store
+}
+
+func TestStateEncrypted(t *testing.T) {
+	tests := []struct {
+		name  string
+		goos  string
+		store ipn.StateStore
+		want  bool
+	}{
+		{
+			name:  "linux-plain-store",
+			goos:  "linux",
+			store: new(mem.Store),
+			want:  false,
+		},
+		{
+			name:  "linux-encrypted-store",
+			goos:  "linux",
+			store: &encryptedTestStore{Store: new(mem.Store)},
+			want:  true,
+		},
+		{
+			// Self-compiled tailscaled with a file store: unchanged.
+			name:  "darwin-plain-store",
+			goos:  "darwin",
+			store: new(mem.Store),
+			want:  false,
+		},
+		{
+			// An embedder (tsnet or a custom client) whose store encrypts at
+			// rest gets to say so, as on every other platform.
+			name:  "darwin-encrypted-store",
+			goos:  "darwin",
+			store: &encryptedTestStore{Store: new(mem.Store)},
+			want:  true,
+		},
+		{
+			name:  "android",
+			goos:  "android",
+			store: new(mem.Store),
+			want:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envknob.SetenvForTest(t, "TS_DEBUG_FAKE_GOOS", tt.goos)
+
+			sys := tsd.NewSystemWithBus(eventbustest.NewBus(t))
+			sys.Set(tt.store)
+			b := newTestLocalBackendWithSys(t, sys)
+
+			if got := b.stateEncrypted(); got != opt.NewBool(tt.want) {
+				t.Errorf("stateEncrypted() = %v; want %v", got, opt.NewBool(tt.want))
 			}
 		})
 	}


### PR DESCRIPTION
stateEncrypted hardcoded false on darwin for anything that isn't the Mac App Store app or the macsys system extension, on the assumption that such a build is a self-compiled tailscaled that doesn't use the Keychain. Embedders (tsnet, custom clients) land in that branch too, so a node whose state store encrypts at rest had no way to report StateEncrypted on macOS, unlike on every other platform.

Fall through to the same ipn.EncryptedStateStore check the other platforms use. A plain file-backed tailscaled still reports false, since a file store does not implement the marker interface, so the shipped macOS variants are unaffected.

Read the OS through envknob.GOOS() so the darwin path is testable off darwin, and add TestStateEncrypted.

Fixes #21041


Change-Id: I2e9115a0aa285c55ed54fb1ef25bc0079d3a5bf2