### PR TITLE
wgengine/router/osrouter: keep accepting IPv6 RAs when enabling forwarding

### DIFF
--- a/wgengine/router/osrouter/router_linux.go
+++ b/wgengine/router/osrouter/router_linux.go
@@ -1391,26 +1391,79 @@ func (r *linuxRouter) upInterface() error {
 	return netlink.LinkSetUp(link)
 }
 
+// sysctlWrite is a single sysctl to write, named by its slash-separated path
+// relative to /proc/sys.
+type sysctlWrite struct {
+	path string
+	val  string
+}
+
 func (r *linuxRouter) enableIPForwarding() {
-	sysctls := map[string]string{
-		"net.ipv4.ip_forward":          "1",
-		"net.ipv6.conf.all.forwarding": "1",
+	// accept_ra has to be raised before forwarding is turned on. With the
+	// default accept_ra=1 the kernel stops accepting (and stops soliciting)
+	// IPv6 Router Advertisements as soon as forwarding is enabled, so
+	// SLAAC-derived addresses stop being renewed and eventually disappear.
+	// accept_ra=2 keeps accepting RAs with forwarding enabled, and writing it
+	// first means we never pass through a state where RAs are dropped.
+	//
+	// accept_ra is not an "all"-aware sysctl: the kernel only consults the
+	// per-interface value, and net.ipv6.conf.default.accept_ra only seeds
+	// interfaces that appear later. So set the default for future interfaces,
+	// then every interface that already exists.
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		r.logf("warning: listing interfaces to set accept_ra: %v", err)
 	}
-	for k, v := range sysctls {
-		if err := writeSysctl(k, v); err != nil {
-			r.logf("warning: %v", k, v, err)
+	for _, s := range ipForwardingSysctls(ifaces) {
+		if err := writeSysctlPath(s.path, s.val); err != nil {
+			r.logf("warning: %v", err)
 			continue
 		}
-		r.logf("sysctl(%v=%v): ok", k, v)
+		r.logf("sysctl(%v=%v): ok", sysctlKeyForPath(s.path), s.val)
 	}
 }
 
+// ipForwardingSysctls returns the sysctls to write, in the order they must be
+// written, to enable IP forwarding on a host with the given interfaces.
+func ipForwardingSysctls(ifaces []net.Interface) []sysctlWrite {
+	sysctls := []sysctlWrite{
+		{"net/ipv6/conf/default/accept_ra", "2"},
+	}
+	for _, iface := range ifaces {
+		// Router Advertisements never arrive on loopback.
+		if iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		// Interface names can contain dots (VLANs such as eth0.100), so the
+		// /proc path is assembled directly instead of by translating dots in
+		// a sysctl key.
+		sysctls = append(sysctls, sysctlWrite{"net/ipv6/conf/" + iface.Name + "/accept_ra", "2"})
+	}
+	return append(sysctls,
+		sysctlWrite{"net/ipv4/ip_forward", "1"},
+		sysctlWrite{"net/ipv6/conf/all/forwarding", "1"},
+	)
+}
+
 func writeSysctl(key, val string) error {
-	fn := "/proc/sys/" + strings.Replace(key, ".", "/", -1)
+	return writeSysctlPath(strings.ReplaceAll(key, ".", "/"), val)
+}
+
+// writeSysctlPath writes val to /proc/sys/<path>. Unlike writeSysctl it takes
+// an already slash-separated path, for sysctls where a path element can itself
+// contain a dot, such as a VLAN interface name (eth0.100).
+func writeSysctlPath(path, val string) error {
+	fn := "/proc/sys/" + path
 	if err := os.WriteFile(fn, []byte(val), 0644); err != nil {
-		return fmt.Errorf("sysctl(%v=%v): %v", key, val, err)
+		return fmt.Errorf("sysctl(%v=%v): %v", sysctlKeyForPath(path), val, err)
 	}
 	return nil
+}
+
+// sysctlKeyForPath renders a slash-separated sysctl path in the conventional
+// dotted form, for logging.
+func sysctlKeyForPath(path string) string {
+	return strings.ReplaceAll(path, "/", ".")
 }
 
 // downInterface sets the tunnel interface administratively down.

--- a/wgengine/router/osrouter/router_linux_test.go
+++ b/wgengine/router/osrouter/router_linux_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"net"
 	"net/netip"
 	"os"
 	"reflect"
@@ -2110,5 +2111,50 @@ func TestCleanUpOnlyTouchesTunInterface(t *testing.T) {
 	}
 	if !slices.Contains(fake.ips, "100.64.0.5/32 dev eth0") {
 		t.Errorf("non-Tailscale CGNAT addr on eth0 was wrongly removed; ips=%q", fake.ips)
+	}
+}
+
+func TestIPForwardingSysctls(t *testing.T) {
+	ifaces := []net.Interface{
+		{Name: "lo", Flags: net.FlagLoopback | net.FlagUp},
+		{Name: "eth0", Flags: net.FlagUp},
+		{Name: "eth0.100", Flags: net.FlagUp}, // VLAN: the name contains a dot
+	}
+
+	got := ipForwardingSysctls(ifaces)
+	want := []sysctlWrite{
+		{"net/ipv6/conf/default/accept_ra", "2"},
+		{"net/ipv6/conf/eth0/accept_ra", "2"},
+		{"net/ipv6/conf/eth0.100/accept_ra", "2"},
+		{"net/ipv4/ip_forward", "1"},
+		{"net/ipv6/conf/all/forwarding", "1"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ipForwardingSysctls() = %v, want %v", got, want)
+	}
+
+	// Enabling forwarding while accept_ra is still at its default of 1 makes
+	// the kernel stop accepting Router Advertisements, so every accept_ra
+	// write has to happen before forwarding is turned on.
+	lastAcceptRA, firstForwarding := -1, len(got)
+	for i, s := range got {
+		switch {
+		case strings.HasSuffix(s.path, "/accept_ra"):
+			lastAcceptRA = i
+		case s.path == "net/ipv4/ip_forward", strings.HasSuffix(s.path, "/forwarding"):
+			firstForwarding = min(firstForwarding, i)
+		}
+	}
+	if lastAcceptRA > firstForwarding {
+		t.Errorf("accept_ra written after forwarding was enabled: %v", got)
+	}
+}
+
+func TestSysctlKeyForPath(t *testing.T) {
+	// A VLAN interface name contains a dot, which is why per-interface sysctls
+	// are addressed by path rather than by translating dots in a key.
+	const path = "net/ipv6/conf/eth0.100/accept_ra"
+	if got, want := sysctlKeyForPath(path), "net.ipv6.conf.eth0.100.accept_ra"; got != want {
+		t.Errorf("sysctlKeyForPath(%q) = %q, want %q", path, got, want)
 	}
 }


### PR DESCRIPTION
`enableIPForwarding` sets `net.ipv6.conf.all.forwarding=1` for gokrazy subnet routers but leaves `accept_ra` at its default of `1`, which the kernel reads as "accept RAs only if forwarding is disabled". Enabling forwarding therefore makes the node stop accepting — and, per `Documentation/networking/ip-sysctl.rst`, stop *soliciting* — Router Advertisements, so SLAAC-derived addresses stop being renewed and eventually disappear.

Diagnosed by @markdrayton in gokrazy/gokrazy#390.

## Changes

- **Write `accept_ra=2` before enabling forwarding.** The sysctls were held in a Go map, so the write order was random; they're an ordered slice now. This means the node never passes through a `forwarding=1` / `accept_ra=1` state in which RAs are dropped, so existing address lifetimes keep being renewed and no Router Solicitation is needed in the common case.
- **Write `net.ipv6.conf.default.accept_ra` and every existing interface.** `accept_ra` is not an "all"-aware sysctl: `ipv6_accept_ra()` consults only the per-interface value, and `conf.default` only seeds interfaces created later. This is unlike `forwarding`, which `all` does propagate — which is exactly why the original one-line `all.forwarding` write had no working counterpart. Loopback is skipped.
- **Address per-interface sysctls by path** rather than by translating dots in a key. `writeSysctl` maps `.` to `/`, so a VLAN interface such as `eth0.100` would otherwise write to `/proc/sys/net/ipv6/conf/eth0/100/accept_ra` — the same class of bug as #4300. `writeSysctl` is kept for dotted keys and now delegates to `writeSysctlPath`.
- **Fix the warning log**, which passed three arguments to a single `%v`:

  ```
  warning: net.ipv4.ip_forward
  %!(EXTRA string=1, *errors.errorString=permission denied)
  ```

  It hid the reason a sysctl write failed.

## Testing

The sysctl list construction is extracted into a pure `ipForwardingSysctls()` so it can be tested without writing to `/proc`. Tests cover the ordering invariant (every `accept_ra` write precedes the forwarding writes) and VLAN interface naming.

`go test ./wgengine/router/osrouter/` passes on Linux apart from three tests that require `/dev/net/tun`, which fail identically on an unmodified tree in the same environment.

I don't have a gokrazy subnet router on an IPv6 LAN, so this has not been verified end-to-end on hardware.

## Note

This also prevents the misconfiguration described in #6826 on the one platform where Tailscale itself enables forwarding, though it doesn't implement the detection/warning that issue asks for.

Fixes #21140
Updates gokrazy/gokrazy#390
