### PR TITLE
net/socks5: log through the server when Server.Logf is nil

### DIFF
--- a/net/socks5/socks5.go
+++ b/net/socks5/socks5.go
@@ -132,7 +132,7 @@ func (s *Server) Serve(ln net.Listener) error {
 		}
 		go func() {
 			defer c.Close()
-			conn := &Conn{logf: s.Logf, clientConn: c, srv: s}
+			conn := &Conn{clientConn: c, srv: s}
 			err := conn.Run()
 			if err != nil {
 				s.logf("client connection failed: %v", err)
@@ -147,7 +147,6 @@ type Conn struct {
 	// The struct is filled by each of the internal
 	// methods in turn as the transaction progresses.
 
-	logf       logger.Logf
 	srv        *Server
 	clientConn net.Conn
 	request    *request
@@ -158,6 +157,12 @@ type Conn struct {
 	udpClientAddr syncs.MutexValue[net.Addr]
 
 	udpTargetConns map[socksAddr]net.Conn
+}
+
+// logf logs to the server's logger, which falls back to the standard logger
+// when Server.Logf is nil.
+func (c *Conn) logf(format string, args ...any) {
+	c.srv.logf(format, args...)
 }
 
 // Run starts the new connection.

--- a/net/socks5/socks5_test.go
+++ b/net/socks5/socks5_test.go
@@ -8,9 +8,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"golang.org/x/net/proxy"
 )
@@ -168,6 +171,59 @@ func TestReadPassword(t *testing.T) {
 	}
 }
 
+// newUDPAssociateConn opens a SOCKS5 connection to the server on socks5Port
+// and completes a UDP ASSOCIATE handshake on it. It returns the TCP control
+// connection and the address of the server's UDP relay.
+func newUDPAssociateConn(t *testing.T, socks5Port int) (socks5Conn net.Conn, socks5UDPAddr socksAddr) {
+	t.Helper()
+
+	// net/proxy doesn't support UDP, so we need to manually send the SOCKS5 UDP request
+	conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", socks5Port))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Close the control connection even when the handshake below fails, since
+	// a t.Fatal here skips the caller's own close.
+	t.Cleanup(func() { conn.Close() })
+
+	_, err = conn.Write([]byte{socks5Version, 0x01, noAuthRequired}) // client hello with no auth
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf [3]byte
+	if _, err := io.ReadFull(conn, buf[:2]); err != nil { // server hello
+		t.Fatal(err)
+	}
+	if buf[0] != socks5Version || buf[1] != noAuthRequired {
+		t.Fatalf("got: %q want: 0x05 0x00", buf[:2])
+	}
+
+	targetAddr := socksAddr{addrType: ipv4, addr: "0.0.0.0", port: 0}
+	targetAddrPkt, err := targetAddr.marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = conn.Write(append([]byte{socks5Version, byte(udpAssociate), 0x00}, targetAddrPkt...)) // client request
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The bind address that follows the header is variable length, so parse it
+	// straight from the connection rather than from a fixed-size read.
+	if _, err := io.ReadFull(conn, buf[:3]); err != nil { // server response header
+		t.Fatal(err)
+	}
+	if !bytes.Equal(buf[:3], []byte{socks5Version, 0x00, 0x00}) {
+		t.Fatalf("got: %q want: 0x05 0x00 0x00", buf[:3])
+	}
+	udpProxySocksAddr, err := parseSocksAddr(conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return conn, udpProxySocksAddr
+}
+
 func TestUDP(t *testing.T) {
 	// backend UDP server which we'll use SOCKS5 to connect to
 	newUDPEchoServer := func() net.PacketConn {
@@ -198,52 +254,7 @@ func TestUDP(t *testing.T) {
 	socks5Port := socks5.Addr().(*net.TCPAddr).Port
 	go socks5Server(socks5)
 
-	// make a socks5 udpAssociate conn
-	newUdpAssociateConn := func() (socks5Conn net.Conn, socks5UDPAddr socksAddr) {
-		// net/proxy don't support UDP, so we need to manually send the SOCKS5 UDP request
-		conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", socks5Port))
-		if err != nil {
-			t.Fatal(err)
-		}
-		_, err = conn.Write([]byte{socks5Version, 0x01, noAuthRequired}) // client hello with no auth
-		if err != nil {
-			t.Fatal(err)
-		}
-		buf := make([]byte, 1024)
-		n, err := conn.Read(buf) // server hello
-		if err != nil {
-			t.Fatal(err)
-		}
-		if n != 2 || buf[0] != socks5Version || buf[1] != noAuthRequired {
-			t.Fatalf("got: %q want: 0x05 0x00", buf[:n])
-		}
-
-		targetAddr := socksAddr{addrType: ipv4, addr: "0.0.0.0", port: 0}
-		targetAddrPkt, err := targetAddr.marshal()
-		if err != nil {
-			t.Fatal(err)
-		}
-		_, err = conn.Write(append([]byte{socks5Version, byte(udpAssociate), 0x00}, targetAddrPkt...)) // client request
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		n, err = conn.Read(buf) // server response
-		if err != nil {
-			t.Fatal(err)
-		}
-		if n < 3 || !bytes.Equal(buf[:3], []byte{socks5Version, 0x00, 0x00}) {
-			t.Fatalf("got: %q want: 0x05 0x00 0x00", buf[:n])
-		}
-		udpProxySocksAddr, err := parseSocksAddr(bytes.NewReader(buf[3:n]))
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		return conn, udpProxySocksAddr
-	}
-
-	conn, udpProxySocksAddr := newUdpAssociateConn()
+	conn, udpProxySocksAddr := newUDPAssociateConn(t, socks5Port)
 	defer conn.Close()
 
 	sendUDPAndWaitResponse := func(socks5UDPConn net.Conn, addr socksAddr, body []byte) (responseBody []byte) {
@@ -337,40 +348,8 @@ func TestUDPConcurrent(t *testing.T) {
 		server.Serve(socks5ln)
 	}()
 
-	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", socks5Port))
-	if err != nil {
-		t.Fatal(err)
-	}
+	conn, udpProxySocksAddr := newUDPAssociateConn(t, socks5Port)
 	defer conn.Close()
-	if _, err := conn.Write([]byte{socks5Version, 0x01, noAuthRequired}); err != nil {
-		t.Fatal(err)
-	}
-	buf := make([]byte, 1024)
-	n, err := conn.Read(buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n != 2 || buf[0] != socks5Version || buf[1] != noAuthRequired {
-		t.Fatalf("got %q, want 0x05 0x00", buf[:n])
-	}
-	targetAddrPkt, err := socksAddr{addrType: ipv4, addr: "0.0.0.0", port: 0}.marshal()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := conn.Write(append([]byte{socks5Version, byte(udpAssociate), 0x00}, targetAddrPkt...)); err != nil {
-		t.Fatal(err)
-	}
-	n, err = conn.Read(buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n < 3 || !bytes.Equal(buf[:3], []byte{socks5Version, 0x00, 0x00}) {
-		t.Fatalf("got %q, want 0x05 0x00 0x00", buf[:n])
-	}
-	udpProxySocksAddr, err := parseSocksAddr(bytes.NewReader(buf[3:n]))
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	udpProxyAddr, err := net.ResolveUDPAddr("udp", udpProxySocksAddr.hostPort())
 	if err != nil {
@@ -422,5 +401,75 @@ func TestUDPConcurrent(t *testing.T) {
 	// the proxy relayed something.
 	if gotReply == 0 {
 		t.Error("got no responses back through the proxy")
+	}
+}
+
+// syncBuffer is a bytes.Buffer that is safe for concurrent use.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// TestUDPLogNilLogf checks that a UDP error path logs through the standard
+// logger when Server.Logf is nil. It used to panic instead, because Conn kept
+// its own copy of the nil Server.Logf and called it without a fallback.
+func TestUDPLogNilLogf(t *testing.T) {
+	var logs syncBuffer
+	oldOut := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(oldOut) })
+
+	socks5, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { socks5.Close() })
+	socks5Port := socks5.Addr().(*net.TCPAddr).Port
+	go func() {
+		var server Server // Logf stays nil, which is what this test exercises
+		err := server.Serve(socks5)
+		if err != nil && !errors.Is(err, net.ErrClosed) {
+			panic(err)
+		}
+	}()
+
+	conn, udpProxySocksAddr := newUDPAssociateConn(t, socks5Port)
+	defer conn.Close()
+
+	udpProxyAddr, err := net.ResolveUDPAddr("udp", udpProxySocksAddr.hostPort())
+	if err != nil {
+		t.Fatal(err)
+	}
+	socks5UDPConn, err := net.DialUDP("udp", nil, udpProxyAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer socks5UDPConn.Close()
+
+	// This datagram is too short to be a SOCKS5 UDP request, so the server
+	// fails to parse it and logs the failure.
+	if _, err := socks5UDPConn.Write([]byte{0x00}); err != nil {
+		t.Fatal(err)
+	}
+
+	const want = "handle udp request fail"
+	deadline := time.Now().Add(10 * time.Second)
+	for !strings.Contains(logs.String(), want) {
+		if time.Now().After(deadline) {
+			t.Fatalf("log output %q does not contain %q", logs.String(), want)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }


### PR DESCRIPTION
Serve copied the raw Server.Logf field into each Conn, so the UDP error paths called a nil func instead of falling back to log.Printf. Conn already holds the Server, so drop the duplicated field and log through the server's method.

Fixes #21047