### PR TITLE
ssh/tailssh: close the pty master when a session’s context is canceled

### DIFF
--- a/ssh/tailssh/pty_disconnect_test.go
+++ b/ssh/tailssh/pty_disconnect_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build linux || darwin
+
+package tailssh
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/netip"
+	"os/exec"
+	"syscall"
+	"testing"
+
+	"github.com/creack/pty"
+	"tailscale.com/types/logger"
+)
+
+// TestKillOnContextDoneClosesPTYMaster verifies the fix for #21150: when the
+// client connection drops, the session teardown must close the pty master
+// (the session's stdin writer) so the kernel delivers SIGHUP to the slave's
+// foreground process group - reaping login shells that outlived their
+// login/su helper. Reading the slave after the last master closes yields
+// EIO on Linux and EOF on darwin.
+func TestKillOnContextDoneClosesPTYMaster(t *testing.T) {
+	ptmx, tty, err := pty.Open()
+	if err != nil {
+		t.Skipf("pty.Open: %v", err)
+	}
+	defer tty.Close()
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cmd := exec.Command("sleep", "60")
+	if err := cmd.Start(); err != nil {
+		t.Skipf("starting sleep: %v", err)
+	}
+	defer cmd.Process.Kill()
+
+	ss := &sshSession{
+		ctx:         ctx,
+		cancelCtx:   cancel,
+		logf:        logger.Discard,
+		conn:        &conn{info: &sshConnInfo{src: netip.MustParseAddrPort("100.64.0.1:12345")}},
+		cmd:         cmd,
+		wrStdin:     ptmx,
+		exitHandled: make(chan struct{}),
+	}
+
+	cancel(errors.New("client disconnected"))
+	ss.killProcessOnContextDone()
+
+	// Idempotency: the stdin copier goroutine also closes on its way out;
+	// this must be safe (a double Close on an *os.File risks closing an
+	// unrelated reused fd).
+	ss.closeStdin()
+
+	// With the last master fd closed, a read on the slave must fail
+	// (EIO on Linux, EOF on darwin) instead of blocking forever.
+	buf := make([]byte, 8)
+	_, err = tty.Read(buf)
+	if err == nil {
+		t.Fatal("read from pty slave succeeded after master close; want EIO or EOF")
+	}
+	if !errors.Is(err, io.EOF) && !errors.Is(err, syscall.EIO) {
+		t.Fatalf("read from pty slave: got %v, want EIO or EOF", err)
+	}
+}

--- a/ssh/tailssh/tailssh.go
+++ b/ssh/tailssh/tailssh.go
@@ -764,6 +764,11 @@ type sshSession struct {
 	// either it exits itself or is terminated
 	exitOnce sync.Once
 
+	// stdinCloseOnce guards closeStdin, which may fire from both the stdin
+	// copier goroutine and killProcessOnContextDone. A double Close on an
+	// *os.File risks closing an unrelated reused fd.
+	stdinCloseOnce sync.Once
+
 	// exitHandled is closed when killProcessOnContextDone finishes writing any
 	// termination message to the client. run() waits on this before calling
 	// ss.Exit to ensure the message is flushed before the SSH channel is torn
@@ -913,6 +918,17 @@ func (ss *sshSession) killProcessOnContextDone() {
 		// implicitly via PTY-master close (session.c:2246), we send it
 		// explicitly because non-PTY sessions use pipes.
 		ss.cmd.Process.Signal(syscall.SIGHUP)
+
+		// SIGHUP above reaches only the direct child. For pty sessions the
+		// user's login shell lives in its own session under the login/su
+		// helper and survives it, keeping the pty slave open; the stdout
+		// copier then never sees EOF, teardown wedges, and the pty master
+		// is never closed - so the shell blocks forever on a pty read that
+		// can never return EOF (see #21150). Closing the pty master makes
+		// the kernel SIGHUP the slave's foreground process group, reaping
+		// the orphaned shell. For non-pty sessions the child instead
+		// observes stdin EOF, matching disconnect semantics.
+		ss.closeStdin()
 	})
 }
 
@@ -1144,7 +1160,7 @@ func (ss *sshSession) run() {
 	var wg sync.WaitGroup
 
 	go func() {
-		defer ss.wrStdin.Close()
+		defer ss.closeStdin()
 		if _, err := io.Copy(rec.writer("i", ss.wrStdin), ss); err != nil {
 			logf("stdin copy: %v", err)
 			ss.cancelCtx(err)
@@ -1726,6 +1742,18 @@ func (ue userVisibleError) SSHTerminationMessage() string { return ue.msg }
 type SSHTerminationError interface {
 	error
 	SSHTerminationMessage() string
+}
+
+// closeStdin closes the session's stdin writer exactly once. For pty
+// sessions, wrStdin is the pty master: closing it is what makes the kernel
+// deliver SIGHUP to the slave's foreground process group, the same
+// mechanism OpenSSH relies on implicitly (session.c).
+func (ss *sshSession) closeStdin() {
+	ss.stdinCloseOnce.Do(func() {
+		if ss.wrStdin != nil {
+			ss.wrStdin.Close()
+		}
+	})
 }
 
 func closeAll(cs ...io.Closer) {


### PR DESCRIPTION
Fixes #21150

## Problem

On Tailscale SSH client disconnect, `tailscaled` never closes the pty master it allocated for the session. The login shell gets no SIGHUP, stays blocked on a pty read that can never return EOF, and every session leaks one pty, one shell, and one logind session. The reporting host had 47 orphaned shells and ~2.09 GB held after 11 days.

## Root cause

`killProcessOnContextDone` only SIGHUPs the direct child - the `tailscaled be-child ssh` helper. The user's login shell lives in its own session under the `login(1)`/`su` helper's exec'd process and survives the helper's exit. It keeps the pty slave open, so the stdout copier (`io.Copy(ss, ss.rdStdout)`) never sees EOF, `run()` wedges permanently in `wg.Wait()`, the deferred `ss.Close()` never runs, and the stdin copier - whose deferred `wrStdin.Close()` is the only close of the pty master - stays blocked reading the still-open SSH channel. Master open, shell alive: each side waits on the other, until the daemon restarts.

## Fix

Close the pty master in `killProcessOnContextDone`, immediately after the SIGHUP to the direct child. Closing the last master fd makes the kernel deliver SIGHUP to the slave's foreground process group - the exact mechanism OpenSSH relies on implicitly (`session.c`) - so the orphaned shell is reaped, the slave is freed, the stdout copier EOFs, and teardown completes.

- New `sshSession.closeStdin()` guarded by a `sync.Once`; the stdin copier's defer routes through it too, so a double `Close` can never hand a reused fd to an unrelated file.
- For non-pty sessions, closing the stdin writer at teardown makes the child observe stdin EOF, which matches disconnect semantics.

## Verification

- New `TestKillOnContextDoneClosesPTYMaster`: allocates a real pty, cancels the session context, runs `killProcessOnContextDone`, and asserts the slave read fails (EIO/EOF) instead of blocking forever; also asserts repeated `closeStdin()` is safe.
- `go build`, `go vet`, and the full `ssh/tailssh` package suite pass locally (go1.27.1, linux/amd64), including the existing SSH harness tests.

> Built by breken, your AI support engineer - breken.ai - this one's on us.
