### PR TITLE
paths: return an absolute default socket path on Android

### DIFF
--- a/paths/paths.go
+++ b/paths/paths.go
@@ -31,6 +31,14 @@ func DefaultTailscaledSocket() string {
 	if runtime.GOOS == "plan9" {
 		return "/srv/tailscaled.sock"
 	}
+	if runtime.GOOS == "android" {
+		// Android (e.g. a userspace tailscaled under Termux) has no /var,
+		// and the cwd-relative fallback below only works when the daemon
+		// and the CLI happen to be started from the same directory
+		// (see #21161). Use the shared per-app temp directory so both
+		// agree on an absolute path.
+		return filepath.Join(os.TempDir(), "tailscaled.sock")
+	}
 	switch distro.Get() {
 	case distro.Synology:
 		if distro.DSMVersion() == 6 {


### PR DESCRIPTION
Fixes #21161

## Problem

On Android (e.g. a userspace `tailscaled` under Termux) `paths.DefaultTailscaledSocket()` has no Android case: the `os.Stat("/var/run")` check fails and the function returns the cwd-relative `tailscaled.sock`. The daemon creates its socket wherever it was started and the CLI looks for one wherever *it* was started - they only agree by coincidence, as reproduced in the issue.

## Fix

Return `os.TempDir()/tailscaled.sock` on Android. `os.TempDir()` resolves the shared per-app temp directory (`$TMPDIR` under Termux), following the same pattern as the existing QNAP `/tmp` default, so daemon and CLI agree on an absolute path regardless of working directory.

Note: I left the unrelated pid in the reported error message out of scope - that part comes from the CLI's generic connection failure path.

## Verification

- `go build` for linux/amd64 and `GOOS=android GOARCH=arm64 CGO_ENABLED=0 go build` both pass (verified against the same build flags as the reporter). `gofmt` clean.
