### PR TITLE
ipn,tsnet: replace LocalBackend.NetMap with NetMapNoPeers/NetMapWithPeers

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -8081,7 +8081,7 @@ func (s netLogNodeSource) NodeByAddr(addr netip.Addr) (_ tailcfg.NodeView, _ tai
 // flow logging identity from the current netmap. ok is false if the
 // netmap does not enable network flow logging for this node.
 func (s netLogNodeSource) NetLogIDs() (nodeID, domainID logid.PrivateID, logExitFlows bool, ok bool) {
-	nm := s.b.NetMap()
+	nm := s.b.NetMapNoPeers()
 	if nm == nil || !nm.SelfNode.Valid() {
 		return
 	}

--- a/ipn/ipnlocal/serve_test.go
+++ b/ipn/ipnlocal/serve_test.go
@@ -840,7 +840,7 @@ func TestServeHTTPProxyHeaders(t *testing.T) {
 func TestServeHTTPProxyGrantHeader(t *testing.T) {
 	b := newTestBackend(t)
 
-	nm := b.NetMap()
+	nm := b.NetMapWithPeers()
 	matches, err := filter.MatchesFromFilterRules([]tailcfg.FilterRule{
 		{
 			SrcIPs: []string{"100.150.151.152"},

--- a/ipn/ipnlocal/state_test.go
+++ b/ipn/ipnlocal/state_test.go
@@ -634,7 +634,7 @@ func TestStateMachine(t *testing.T) {
 		// Verify login finished but need machine auth using backend state
 		c.Assert(isFullyAuthenticated(b), qt.IsTrue)
 		c.Assert(needsMachineAuth(b), qt.IsTrue)
-		nm := b.NetMap()
+		nm := b.NetMapNoPeers()
 		c.Assert(nm, qt.IsNotNil)
 		// For an empty netmap (after initial login), SelfNode may not be valid yet.
 		// In this case, we can't check MachineAuthorized, but needsMachineAuth already verified the state.
@@ -661,7 +661,7 @@ func TestStateMachine(t *testing.T) {
 		// nn[0] is a state notification after machine auth granted
 		c.Assert(len(nn), qt.Equals, 1)
 		// Verify machine authorized using backend state
-		nm := b.NetMap()
+		nm := b.NetMapNoPeers()
 		c.Assert(nm, qt.IsNotNil)
 		c.Assert(nm.SelfNode.Valid(), qt.IsTrue)
 		c.Assert(nm.SelfNode.MachineAuthorized(), qt.IsTrue)
@@ -2036,7 +2036,7 @@ func (e *mockEngine) Done() <-chan struct{} {
 
 // hasValidNetMap returns true if the backend has a valid network map with a valid self node.
 func hasValidNetMap(b *LocalBackend) bool {
-	nm := b.NetMap()
+	nm := b.NetMapNoPeers()
 	return nm != nil && nm.SelfNode.Valid()
 }
 
@@ -2055,8 +2055,8 @@ func needsLogin(b *LocalBackend) bool {
 // needsMachineAuth returns true if the user has logged in but the machine is not yet authorized.
 // This includes the case where we have a netmap but no valid SelfNode yet (empty netmap after initial login).
 func needsMachineAuth(b *LocalBackend) bool {
-	// Note: b.NetMap() and b.Prefs() handle their own locking
-	nm := b.NetMap()
+	// Note: b.NetMapNoPeers() and b.Prefs() handle their own locking
+	nm := b.NetMapNoPeers()
 	prefs := b.Prefs()
 	if prefs.LoggedOut() || nm == nil {
 		return false
@@ -2080,8 +2080,8 @@ func hasAuthURL(b *LocalBackend) bool {
 // canRouteTraffic returns true if the backend is capable of routing traffic.
 // This requires a valid netmap, machine authorization, and WantRunning preference.
 func canRouteTraffic(b *LocalBackend) bool {
-	// Note: b.NetMap() and b.Prefs() handle their own locking
-	nm := b.NetMap()
+	// Note: b.NetMapNoPeers() and b.Prefs() handle their own locking
+	nm := b.NetMapNoPeers()
 	prefs := b.Prefs()
 	return nm != nil &&
 		nm.SelfNode.Valid() &&

--- a/tsnet/tsnet_test.go
+++ b/tsnet/tsnet_test.go
@@ -1120,7 +1120,7 @@ func setUpServiceState(t *testing.T, name, ip string, host, client *Server,
 
 	// The Service host must have the 'service-host' capability, which
 	// is a mapping from the Service name to the Service VIP.
-	cm := host.lb.NetMap().SelfNode.CapMap()
+	cm := host.lb.NetMapNoPeers().SelfNode.CapMap()
 	svcIPMap := make(tailcfg.ServiceIPMappings)
 	if cm.Contains(nodecap.ServiceHost) {
 		parsed := must.Get(tailcfg.UnmarshalNodeCapViewJSON[tailcfg.ServiceIPMappings](cm, nodecap.ServiceHost))
@@ -1137,8 +1137,8 @@ func setUpServiceState(t *testing.T, name, ip string, host, client *Server,
 
 	// The Service host must be allowed to advertise the Service VIP.
 	subnetRoutes := []netip.Prefix{netip.MustParsePrefix(ip + `/32`)}
-	selfAddresses := host.lb.NetMap().SelfNode.Addresses()
-	for _, existingRoute := range host.lb.NetMap().SelfNode.AllowedIPs().All() {
+	selfAddresses := host.lb.NetMapNoPeers().SelfNode.Addresses()
+	for _, existingRoute := range host.lb.NetMapNoPeers().SelfNode.AllowedIPs().All() {
 		if views.SliceContains(selfAddresses, existingRoute) {
 			continue
 		}


### PR DESCRIPTION
This method has been deprecated for four months; replace all uses with the Peers or NoPeers equivalents.

Updates #12542