### PR TITLE
wgengine/{filter,magicsock}: avoid maps for capability checks

### DIFF
--- a/wgengine/filter/filter.go
+++ b/wgengine/filter/filter.go
@@ -18,6 +18,7 @@ import (
 	"tailscale.com/net/netaddr"
 	"tailscale.com/net/packet"
 	"tailscale.com/tailcfg"
+	"tailscale.com/tailcfg/peercap"
 	"tailscale.com/tstime/rate"
 	"tailscale.com/types/ipproto"
 	"tailscale.com/types/logger"
@@ -432,6 +433,30 @@ func (f *Filter) CapsWithValues(srcIP, dstIP netip.Addr) tailcfg.PeerCapMap {
 		}
 	}
 	return out
+}
+
+// HasCapability reports whether srcIP has the given capability when talking
+// to dstIP.
+func (f *Filter) HasCapability(srcIP, dstIP netip.Addr, cap peercap.Cap) bool {
+	var mm matches
+	switch {
+	case srcIP.Is4():
+		mm = f.cap4
+	case srcIP.Is6():
+		mm = f.cap6
+	}
+
+	for _, m := range mm {
+		if !m.SrcsContains(srcIP) {
+			continue
+		}
+		for _, cm := range m.Caps {
+			if cm.Cap == cap && cm.Dst.Contains(dstIP) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // ShieldsUp reports whether this is a "shields up" (block everything

--- a/wgengine/filter/filter_test.go
+++ b/wgengine/filter/filter_test.go
@@ -1066,6 +1066,157 @@ func TestPeerCaps(t *testing.T) {
 	}
 }
 
+func TestHasCapability(t *testing.T) {
+	mm, err := MatchesFromFilterRules([]tailcfg.FilterRule{
+		{
+			SrcIPs: []string{"*"},
+			CapGrant: []tailcfg.CapGrant{{
+				Dsts: []netip.Prefix{netip.MustParsePrefix("0.0.0.0/0")},
+				Caps: []peercap.Cap{"is_ipv4"},
+			}},
+		},
+		{
+			SrcIPs: []string{"*"},
+			CapGrant: []tailcfg.CapGrant{{
+				Dsts: []netip.Prefix{netip.MustParsePrefix("::/0")},
+				Caps: []peercap.Cap{"is_ipv6"},
+			}},
+		},
+		{
+			SrcIPs: []string{"100.199.0.0/16"},
+			CapGrant: []tailcfg.CapGrant{{
+				Dsts: []netip.Prefix{netip.MustParsePrefix("100.200.0.0/16")},
+				Caps: []peercap.Cap{"some_super_admin"},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	filt := New(mm, nil, nil, nil, nil, t.Logf)
+	tests := []struct {
+		name     string
+		src, dst string
+		cap      peercap.Cap
+		want     bool
+	}{
+		{
+			name: "v4",
+			src:  "1.2.3.4",
+			dst:  "2.4.5.5",
+			cap:  "is_ipv4",
+			want: true,
+		},
+		{
+			name: "v6",
+			src:  "1::1",
+			dst:  "2::2",
+			cap:  "is_ipv6",
+			want: true,
+		},
+		{
+			name: "admin",
+			src:  "100.199.1.2",
+			dst:  "100.200.3.4",
+			cap:  "some_super_admin",
+			want: true,
+		},
+		{
+			name: "wrong_capability",
+			src:  "1.2.3.4",
+			dst:  "2.4.5.5",
+			cap:  "is_ipv6",
+		},
+		{
+			name: "wrong_source",
+			src:  "100.198.1.2",
+			dst:  "100.200.3.4",
+			cap:  "some_super_admin",
+		},
+		{
+			name: "wrong_destination",
+			src:  "100.199.1.2",
+			dst:  "100.201.3.4",
+			cap:  "some_super_admin",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filt.HasCapability(netip.MustParseAddr(tt.src), netip.MustParseAddr(tt.dst), tt.cap)
+			if got != tt.want {
+				t.Errorf("got %v; want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func BenchmarkHasCapability(b *testing.B) {
+	const (
+		numRules    = 100
+		capsPerRule = 10
+		numCaps     = numRules * capsPerRule
+	)
+	src := netip.MustParseAddr("100.64.0.1")
+	dst := netip.MustParseAddr("100.64.0.2")
+	targetCap := peercap.RelayTarget
+
+	tests := []struct {
+		name        string
+		targetIndex int
+	}{
+		{"first", 0},
+		{"last", numCaps - 1},
+		{"missing", -1},
+	}
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			rules := make([]tailcfg.FilterRule, numRules)
+			for ruleIndex := range rules {
+				caps := make([]peercap.Cap, capsPerRule)
+				for capIndex := range caps {
+					index := ruleIndex*capsPerRule + capIndex
+					caps[capIndex] = peercap.Cap(fmt.Sprintf("https://tailscale.com/cap/benchmark-%d", index))
+					if index == tt.targetIndex {
+						caps[capIndex] = targetCap
+					}
+				}
+				rules[ruleIndex] = tailcfg.FilterRule{
+					SrcIPs: []string{"100.64.0.1"},
+					CapGrant: []tailcfg.CapGrant{{
+						Dsts: []netip.Prefix{netip.MustParsePrefix("100.64.0.2/32")},
+						Caps: caps,
+					}},
+				}
+			}
+			mm, err := MatchesFromFilterRules(rules)
+			if err != nil {
+				b.Fatal(err)
+			}
+			filt := New(mm, nil, nil, nil, nil, logger.Discard)
+			want := tt.targetIndex >= 0
+			if got := filt.CapsWithValues(src, dst).HasCapability(targetCap); got != want {
+				b.Fatalf("CapsWithValues().HasCapability() = %v; want %v", got, want)
+			}
+			if got := filt.HasCapability(src, dst, targetCap); got != want {
+				b.Fatalf("HasCapability() = %v; want %v", got, want)
+			}
+
+			b.Run("CapsWithValues", func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					filt.CapsWithValues(src, dst).HasCapability(targetCap)
+				}
+			})
+			b.Run("HasCapability", func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					filt.HasCapability(src, dst, targetCap)
+				}
+			})
+		})
+	}
+}
+
 var (
 	filterMatchFile = flag.String("filter-match-file", "", "JSON file of []filter.Match to benchmark")
 )

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -2951,7 +2951,7 @@ func nodeHasCap(filt *filter.Filter, src, dst tailcfg.NodeView, cap peercap.Cap)
 				// same address family they either have the capability or not.
 				// We do not check against additional host addresses of the same
 				// address family.
-				return filt.CapsWithValues(srcAddr, dstAddr).HasCapability(cap)
+				return filt.HasCapability(srcAddr, dstAddr, cap)
 			}
 		}
 	}


### PR DESCRIPTION
Add `Filter.HasCapability` to check for one capability without building a map containing every capability and its values.

Use the new method when selecting peer relay servers. This removes all allocations from the capability check and avoids collecting information that the caller immediately discards.

The worst-case complexity remains O(m * n), but the new method reduces the constant factor and avoids allocating a map just to obtain a boolean result.

Benchmark results on an Intel Core i5-1334U with Linux/amd64 and Go 1.27.1, using the median of five runs:

```
                           CapsWithValues    HasCapability
    first match                    210 us             18 ns
    last match                     262 us           3.51 us
    missing capability             224 us           3.52 us
```

`CapsWithValues` allocated 190984 B in 22 allocations per operation.
`HasCapability` performed no allocations.

Updates #16331 

Change-Id: I569e2ce86a0769cd9b4e5c952dd7f8409f785521
Signed-off-by: Antonio Lentini <antonio.lentini2004@pm.me>