### PR TITLE
control/controlclient: add support for retry-after in map sessions

### DIFF
--- a/control/controlclient/auto.go
+++ b/control/controlclient/auto.go
@@ -36,6 +36,10 @@ type LoginGoal struct {
 
 var _ Client = (*Auto)(nil)
 
+// maxRetryWindow defines the upper bound on how long control is allowed
+// to tell the client to wait before retrying a request.
+const maxRetryWindow = 5 * time.Minute
+
 // waitUnpause waits until either the client is unpaused or the Auto client is
 // shut down. It reports whether the client should keep running (i.e. it's not
 // closed).
@@ -90,7 +94,11 @@ func (c *Auto) updateRoutine() {
 			if ctx.Err() == nil {
 				c.direct.logf("lite map update error after %v: %v", d, err)
 			}
-			bo.BackOff(ctx, err)
+			if rle, rateLimited := errors.AsType[*rateLimitError](err); rateLimited {
+				c.waitRetryAfter(ctx, "updateRoutine", rle)
+			} else {
+				bo.BackOff(ctx, err)
+			}
 			continue
 		}
 		bo.Reset()
@@ -359,11 +367,7 @@ func (c *Auto) authRoutine() {
 			c.direct.health.SetAuthRoutineInError(err)
 			report(err, f)
 			if rle, ok := errors.AsType[*rateLimitError](err); ok {
-				c.logf("authRoutine: %s", rle)
-				select {
-				case <-ctx.Done():
-				case <-time.After(rle.retryAfter):
-				}
+				c.waitRetryAfter(ctx, "authRoutine", rle)
 			} else {
 				bo.BackOff(ctx, err)
 			}
@@ -624,10 +628,11 @@ func (c *Auto) mapRoutine() {
 		c.mu.Lock()
 		c.inMapPoll = false
 		paused := c.paused
+		rle, rateLimited := errors.AsType[*rateLimitError](err)
 
 		if paused {
 			mrs.bo.Reset()
-		} else {
+		} else if !rateLimited {
 			mrs.bo.BackOff(ctx, err)
 		}
 		c.mu.Unlock()
@@ -638,6 +643,28 @@ func (c *Auto) mapRoutine() {
 		} else {
 			report(err, "PollNetMap")
 		}
+
+		if rateLimited {
+			c.waitRetryAfter(ctx, "mapRoutine", rle)
+		}
+	}
+}
+
+// waitRetryAfter sleeps for the delay the server requested in rle, capped at
+// [maxRetryWindow] or until ctx is done, whichever comes first.
+func (c *Auto) waitRetryAfter(ctx context.Context, routine string, rle *rateLimitError) {
+	if rle.retryAfter > maxRetryWindow {
+		rle.retryAfter = maxRetryWindow
+	}
+
+	c.logf("%s: %s", routine, rle)
+
+	t, ch := c.clock.NewTimer(rle.retryAfter)
+	defer t.Stop()
+
+	select {
+	case <-ctx.Done():
+	case <-ch:
 	}
 }
 

--- a/control/controlclient/auto_test.go
+++ b/control/controlclient/auto_test.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"tailscale.com/tailcfg"
+	"tailscale.com/tstime"
 )
 
 type userProfileUpdateObserver struct{}
@@ -63,4 +65,56 @@ func TestMapRoutineStateUpdateUserProfilesConcurrentCancelMapCtx(t *testing.T) {
 	}
 	c.observerQueue.Shutdown()
 	c.mapCancel()
+}
+
+func TestWaitRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		retryAfter  time.Duration
+		cancelAfter time.Duration
+		want        time.Duration
+	}{
+		{
+			name:        "returns_on_context_cancellation",
+			retryAfter:  time.Minute,
+			cancelAfter: time.Second,
+			want:        time.Second,
+		},
+		{
+			name:       "returns_on_specified_retry_time",
+			retryAfter: time.Minute,
+			want:       time.Minute,
+		},
+		{
+			name:       "does_not_exceed_max_wait_time",
+			retryAfter: maxRetryWindow + 1,
+			want:       maxRetryWindow,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+
+				if tt.cancelAfter != 0 {
+					time.AfterFunc(tt.cancelAfter, cancel)
+				}
+
+				c := &Auto{
+					clock: tstime.StdClock{},
+					logf:  t.Logf,
+				}
+				start := time.Now()
+				c.waitRetryAfter(ctx, "test", &rateLimitError{retryAfter: tt.retryAfter})
+				if got := time.Since(start); got != tt.want {
+					t.Errorf("waitRetryAfter; got = %v, want %v", got, tt.want)
+				}
+			})
+		})
+	}
 }

--- a/control/controlclient/controlclient_test.go
+++ b/control/controlclient/controlclient_test.go
@@ -406,10 +406,10 @@ func testHTTPS(t *testing.T, withProxy bool) {
 	}
 }
 
-// TestRegisterRateLimited verifies that the client correctly handles 429
-// responses to registration requests by parsing the Retry-After header
-// and returning a rateLimitError.
-func TestRegisterRateLimited(t *testing.T) {
+// newDirectForTestControl serves control and returns a direct client wired to
+// reach it.
+func newDirectForTestControl(t testing.TB, tc *testcontrol.Server) *Direct {
+	t.Helper()
 	bakedroots.ResetForTest(t, tlstest.TestRootCA())
 
 	bus := eventbustest.NewBus(t)
@@ -418,17 +418,10 @@ func TestRegisterRateLimited(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer controlLn.Close()
+	t.Cleanup(func() { controlLn.Close() })
 
-	var registerAttempts atomic.Int64
-	tc := &testcontrol.Server{
-		Logf: tstest.WhileTestRunningLogger(t),
-		MaybeRateLimitRegister: func() (bool, string, string) {
-			if registerAttempts.Add(1) == 1 {
-				return true, "30", "try again later"
-			}
-			return false, "", ""
-		},
+	if tc.Logf == nil {
+		tc.Logf = tstest.WhileTestRunningLogger(t)
 	}
 	controlSrv := &http.Server{
 		Handler:  tc,
@@ -476,6 +469,7 @@ func TestRegisterRateLimited(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewDirect: %v", err)
 	}
+	t.Cleanup(func() { d.Close() })
 
 	d.dnsCache.LookupIPForTest = func(ctx context.Context, host string) ([]netip.Addr, error) {
 		if host == "controlplane.tstest" {
@@ -484,12 +478,28 @@ func TestRegisterRateLimited(t *testing.T) {
 		t.Errorf("unexpected DNS query for %q", host)
 		return nil, fmt.Errorf("unexpected DNS lookup for %q", host)
 	}
+	return d
+}
+
+// TestRegisterRateLimited verifies that the client correctly handles 429
+// responses to registration requests by parsing the Retry-After header
+// and returning a [rateLimitError].
+func TestRegisterRateLimited(t *testing.T) {
+	var registerAttempts atomic.Int64
+	d := newDirectForTestControl(t, &testcontrol.Server{
+		MaybeRejectRequest: testcontrol.RejectRequestForPath("/machine/register", func() (int, string, string) {
+			if registerAttempts.Add(1) == 1 {
+				return http.StatusTooManyRequests, "30", "try again later"
+			}
+			return 0, "", ""
+		}),
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	// First attempt should get a 429 and return a rateLimitError.
-	_, err = d.TryLogin(ctx, LoginEphemeral)
+	_, err := d.TryLogin(ctx, LoginEphemeral)
 	if err == nil {
 		t.Fatal("expected rate limit error on first attempt, got nil")
 	}
@@ -498,10 +508,10 @@ func TestRegisterRateLimited(t *testing.T) {
 		t.Fatalf("expected *rateLimitError, got %T: %v", err, err)
 	}
 	if rle.retryAfter != 30*time.Second {
-		t.Errorf("retryAfter = %v, want 30s", rle.retryAfter)
+		t.Errorf("retryAfter; got = %v, want 30s", rle.retryAfter)
 	}
 	if rle.msg != "try again later" {
-		t.Errorf("msg = %q, want %q", rle.msg, "try again later")
+		t.Errorf("msg; got = %q, want %q", rle.msg, "try again later")
 	}
 
 	// Second attempt should succeed (server no longer rate-limiting).
@@ -514,7 +524,74 @@ func TestRegisterRateLimited(t *testing.T) {
 	}
 
 	if got := registerAttempts.Load(); got != 2 {
-		t.Errorf("register attempts = %d, want 2", got)
+		t.Errorf("register attempts; got = %d, want 2", got)
+	}
+}
+
+// TestMapRequestRateLimited verifies that the client turns 429 and 503
+// responses to map requests into a [rateLimitError] carrying the server's
+// Retry-After value, and that other failures don't.
+func TestMapRequestRateLimited(t *testing.T) {
+	tests := []struct {
+		name           string
+		status         int
+		retryAfter     string
+		wantRateLimit  bool
+		wantRetryAfter time.Duration
+	}{
+		{name: "429-with-header", status: 429, retryAfter: "30", wantRateLimit: true, wantRetryAfter: 30 * time.Second},
+		{name: "503-with-header", status: 503, retryAfter: "45", wantRateLimit: true, wantRetryAfter: 45 * time.Second},
+		{name: "503-no-header", status: 503, wantRateLimit: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mapAttempts atomic.Int64
+			d := newDirectForTestControl(t, &testcontrol.Server{
+				MaybeRejectRequest: testcontrol.RejectRequestForPath("/machine/map", func() (int, string, string) {
+					if mapAttempts.Add(1) == 1 {
+						return tt.status, tt.retryAfter, "slow down"
+					}
+					return 0, "", ""
+				}),
+			})
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			if _, err := d.TryLogin(ctx, LoginEphemeral); err != nil {
+				t.Fatalf("TryLogin: %v", err)
+			}
+
+			// First attempt is rejected.
+			_, err := d.FetchNetMapForTest(ctx)
+			if err == nil {
+				t.Fatal("expected error on first map request, got nil")
+			}
+			rle, ok := errors.AsType[*rateLimitError](err)
+			if ok != tt.wantRateLimit {
+				t.Fatalf("got *rateLimitError = %v, want %v; err = %v", ok, tt.wantRateLimit, err)
+			}
+			if ok {
+				if rle.retryAfter != tt.wantRetryAfter {
+					t.Errorf("retryAfter = %v, want %v", rle.retryAfter, tt.wantRetryAfter)
+				}
+				if rle.msg != "slow down" {
+					t.Errorf("msg = %q, want %q", rle.msg, "slow down")
+				}
+			}
+
+			// Second attempt should succeed (server no longer rejecting).
+			nm, err := d.FetchNetMapForTest(ctx)
+			if err != nil {
+				t.Fatalf("FetchNetMapForTest after rejection: %v", err)
+			}
+			if nm == nil {
+				t.Fatal("got nil netmap")
+			}
+			if got := mapAttempts.Load(); got != 2 {
+				t.Errorf("map attempts = %d, want 2", got)
+			}
+		})
 	}
 }
 

--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -619,6 +619,18 @@ func parseRateLimitError(res *http.Response) *rateLimitError {
 	return ret
 }
 
+// isRateLimitedResponse reports whether a non-200 response should be
+// treated as a rate limit rather than a generic failure subject to backoff.
+func isRateLimitedResponse(res *http.Response) bool {
+	switch res.StatusCode {
+	case http.StatusTooManyRequests:
+		return true
+	case http.StatusServiceUnavailable:
+		return res.Header.Get("Retry-After") != ""
+	}
+	return false
+}
+
 func (c *Direct) doLogin(ctx context.Context, opt loginOpt) (mustRegen bool, newURL string, nks tkatype.MarshaledSignature, err error) {
 	if c.panicOnUse {
 		panic("tainted client")
@@ -814,7 +826,7 @@ func (c *Direct) doLogin(ctx context.Context, opt loginOpt) (mustRegen bool, new
 		return regen, opt.URL, nil, fmt.Errorf("register request: %w", err)
 	}
 	// Handle 429 Too Many Requests with a specific error type that includes the retry-after duration.
-	if res.StatusCode == 429 {
+	if isRateLimitedResponse(res) {
 		rle := parseRateLimitError(res)
 		msg := fmt.Sprintf("node registration rate limited; will retry after %v", rle.retryAfter)
 		return false, "", nil, vizerror.WrapWithMessage(rle, msg)
@@ -929,8 +941,8 @@ func (c *Direct) PollNetMap(ctx context.Context, nu NetmapUpdater) error {
 // update it observed. It is used by tests and [NetmapFromMapResponseForDebug].
 // It will report only the first netmap seen.
 type rememberLastNetmapUpdater struct {
-	last          *netmap.NetworkMap
-	done          chan any
+	last *netmap.NetworkMap
+	done chan any
 }
 
 func (nu *rememberLastNetmapUpdater) UpdateFullNetmap(nm *netmap.NetworkMap) {
@@ -1182,6 +1194,10 @@ func (c *Direct) sendMapRequest(ctx context.Context, isStreaming bool, nu Netmap
 	}
 	vlogf("netmap: Do = %v after %v", res.StatusCode, time.Since(t0).Round(time.Millisecond))
 	if res.StatusCode != 200 {
+		if isRateLimitedResponse(res) {
+			rle := parseRateLimitError(res)
+			return fmt.Errorf("initial fetch failed %d: %w", res.StatusCode, rle)
+		}
 		msg, _ := io.ReadAll(res.Body)
 		res.Body.Close()
 		return fmt.Errorf("initial fetch failed %d: %.200s",

--- a/control/controlclient/direct_test.go
+++ b/control/controlclient/direct_test.go
@@ -220,6 +220,35 @@ func TestParseRateLimitError(t *testing.T) {
 	}
 }
 
+func TestIsRateLimitedResponse(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		retryAfter string
+		want       bool
+	}{
+		{name: "429-no-header", statusCode: 429, want: true},
+		{name: "429-with-header", statusCode: 429, retryAfter: "30", want: true},
+		{name: "503-with-header", statusCode: 503, retryAfter: "30", want: true},
+		{name: "503-no-header", statusCode: 503, want: false},
+		{name: "500-with-header", statusCode: 500, retryAfter: "30", want: false},
+		{name: "200", statusCode: 200, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			if tt.retryAfter != "" {
+				rec.Header().Set("Retry-After", tt.retryAfter)
+			}
+			rec.WriteHeader(tt.statusCode)
+
+			if got := isRateLimitedResponse(rec.Result()); got != tt.want {
+				t.Errorf("shouldHonorRetryAfter; got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRateLimitErrorIsError(t *testing.T) {
 	err := &rateLimitError{msg: "test", retryAfter: 5 * time.Second}
 	var target *rateLimitError

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -195,7 +195,8 @@ type CapabilityVersion int
 //   - 144: 2026-07-31: Client sends [packet.TSMPDiscoKeyAdvertisement] around WireGuard handshakes
 //   - 145: 2026-08-04: Client understands [NodeAttrScopeQuad100OnMacOS]
 //   - 146: 2026-09-02: Client understands [NodeAttrConnReject]; can handle C2N /debug/rejects.
-const CurrentCapabilityVersion CapabilityVersion = 146
+//   - 147: 2026-09-09: Client handles 429/503 responses with retry-after headers to /machine/ endpoints
+const CurrentCapabilityVersion CapabilityVersion = 147
 
 // ID is an integer ID for a user, node, or login allocated by the
 // control plane.

--- a/tstest/integration/testcontrol/testcontrol.go
+++ b/tstest/integration/testcontrol/testcontrol.go
@@ -127,10 +127,10 @@ type Server struct {
 	ExplicitBaseURL string           // e.g. "http://127.0.0.1:1234" with no trailing URL
 	HTTPTestServer  *httptest.Server // if non-nil, used to get BaseURL
 
-	// MaybeRateLimitRegister, if non-nil, is called before processing
-	// register requests. If it returns true, a 429 response is sent
-	// with the given Retry-After header value and body string.
-	MaybeRateLimitRegister func() (reject bool, retryAfter string, msg string)
+	// MaybeRejectRequest, if non-nil, is called before processing
+	// machine requests. If it returns a non-zero status, the request is rejected
+	// with that status code, the given Retry-After header value, and body string.
+	MaybeRejectRequest func(*http.Request) (status int, retryAfter string, msg string)
 
 	// ModifyFirstMapResponse, if non-nil, is called exactly once per
 	// MapResponse stream to modify the first MapResponse sent in response to it.
@@ -538,6 +538,16 @@ func (s *Server) serveMachine(w http.ResponseWriter, r *http.Request) {
 	mkey, ok := ctx.Value(peerMachinePublicContextKey{}).(key.MachinePublic)
 	if !ok {
 		panic("no peer machine public key in context")
+	}
+
+	if fn := s.MaybeRejectRequest; fn != nil {
+		if status, retryAfter, msg := fn(r); status != 0 {
+			if retryAfter != "" {
+				w.Header().Set("Retry-After", retryAfter)
+			}
+			http.Error(w, msg, status)
+			return
+		}
 	}
 
 	switch r.URL.Path {
@@ -953,16 +963,6 @@ func (s *Server) CompleteDeviceApproval(controlUrl string, urlStr string, nodeKe
 }
 
 func (s *Server) serveRegister(w http.ResponseWriter, r *http.Request, mkey key.MachinePublic) {
-	if fn := s.MaybeRateLimitRegister; fn != nil {
-		if reject, retryAfter, msg := fn(); reject {
-			if retryAfter != "" {
-				w.Header().Set("Retry-After", retryAfter)
-			}
-			http.Error(w, msg, http.StatusTooManyRequests)
-			return
-		}
-	}
-
 	msg, err := io.ReadAll(io.LimitReader(r.Body, msgLimit))
 	r.Body.Close()
 	if err != nil {
@@ -1983,4 +1983,16 @@ func breakSameNodeMapResponseStreams(req *tailcfg.MapRequest) bool {
 		return false
 	}
 	return true
+}
+
+// RejectRequestForPath returns a request rejection for requests matching
+// the given path.
+func RejectRequestForPath(path string, fn func() (status int, retryAfter string, msg string)) func(*http.Request) (status int, retryAfter string, msg string) {
+	return func(r *http.Request) (status int, retryAfter string, msg string) {
+		if r.URL.Path != path {
+			return 0, "", ""
+		}
+
+		return fn()
+	}
 }


### PR DESCRIPTION
Previously retry-after support was added to register requests in #19403, in order to have more fine tuned client/control interactions in cases of rate limiting.

This change expands that support to map sessions as well.

Updates tailscale/corp#47299