### PR TITLE
ipn/ipnlocal: only require peerapi masquerade Host match per address family

### DIFF
--- a/ipn/ipnlocal/peerapi.go
+++ b/ipn/ipnlocal/peerapi.go
@@ -266,10 +266,16 @@ func (h *peerAPIHandler) isAddressValid(addr netip.Addr) bool {
 	if !addr.IsValid() {
 		return false
 	}
-	v4MasqAddr, hasMasqV4 := h.peerNode.SelfNodeV4MasqAddrForThisPeer().GetOk()
-	v6MasqAddr, hasMasqV6 := h.peerNode.SelfNodeV6MasqAddrForThisPeer().GetOk()
-	if hasMasqV4 || hasMasqV6 {
-		return addr == v4MasqAddr || addr == v6MasqAddr
+	// A masquerade address for a family, if set, replaces this node's
+	// native address of that family from the peer's point of view.
+	// A masquerade address for one family says nothing about the other
+	// family, so the other family still falls through to the self
+	// address check below.
+	if v4MasqAddr, ok := h.peerNode.SelfNodeV4MasqAddrForThisPeer().GetOk(); ok && addr.Is4() {
+		return addr == v4MasqAddr
+	}
+	if v6MasqAddr, ok := h.peerNode.SelfNodeV6MasqAddrForThisPeer().GetOk(); ok && addr.Is6() {
+		return addr == v6MasqAddr
 	}
 	pfx := netip.PrefixFrom(addr, addr.BitLen())
 	return views.SliceContains(h.selfNode.Addresses(), pfx)

--- a/ipn/ipnlocal/peerapi_test.go
+++ b/ipn/ipnlocal/peerapi_test.go
@@ -188,6 +188,53 @@ func TestHandlePeerAPI(t *testing.T) {
 	}
 }
 
+func TestPeerAPIIsAddressValid(t *testing.T) {
+	selfNode := &tailcfg.Node{
+		Addresses: []netip.Prefix{
+			netip.MustParsePrefix("100.64.0.1/32"),
+			netip.MustParsePrefix("fd7a:115c:a1e0::1/128"),
+		},
+	}
+	tests := []struct {
+		name   string
+		masqV4 string // SelfNodeV4MasqAddrForThisPeer, if non-empty
+		masqV6 string // SelfNodeV6MasqAddrForThisPeer, if non-empty
+		addr   string
+		want   bool
+	}{
+		{"no_masq_native_v4", "", "", "100.64.0.1", true},
+		{"no_masq_native_v6", "", "", "fd7a:115c:a1e0::1", true},
+		{"no_masq_other_addr", "", "", "100.64.0.9", false},
+		{"masq_v4_masq_addr", "100.99.1.1", "", "100.99.1.1", true},
+		{"masq_v4_native_v4", "100.99.1.1", "", "100.64.0.1", false},
+		{"masq_v4_native_v6", "100.99.1.1", "", "fd7a:115c:a1e0::1", true},
+		{"masq_v6_masq_addr", "", "fd7a:115c:a1e0::99", "fd7a:115c:a1e0::99", true},
+		{"masq_v6_native_v6", "", "fd7a:115c:a1e0::99", "fd7a:115c:a1e0::1", false},
+		{"masq_v6_native_v4", "", "fd7a:115c:a1e0::99", "100.64.0.1", true},
+		{"masq_both_native_v4", "100.99.1.1", "fd7a:115c:a1e0::99", "100.64.0.1", false},
+		{"masq_both_masq_v4", "100.99.1.1", "fd7a:115c:a1e0::99", "100.99.1.1", true},
+		{"masq_both_masq_v6", "100.99.1.1", "fd7a:115c:a1e0::99", "fd7a:115c:a1e0::99", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			peerNode := &tailcfg.Node{}
+			if tt.masqV4 != "" {
+				peerNode.SelfNodeV4MasqAddrForThisPeer = new(netip.MustParseAddr(tt.masqV4))
+			}
+			if tt.masqV6 != "" {
+				peerNode.SelfNodeV6MasqAddrForThisPeer = new(netip.MustParseAddr(tt.masqV6))
+			}
+			h := &peerAPIHandler{
+				selfNode: selfNode.View(),
+				peerNode: peerNode.View(),
+			}
+			if got := h.isAddressValid(netip.MustParseAddr(tt.addr)); got != tt.want {
+				t.Errorf("isAddressValid(%v) = %v; want %v", tt.addr, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsPeerAPIDNSAllowed(t *testing.T) {
 	// This test can not be run in parallel because it modifies
 	// HookReplyToDNSQueries and exitNodeDNSFilterForTest.


### PR DESCRIPTION
isAddressValid rejected all non-masquerade destination addresses
whenever any masquerade address was set for the peer. With a v6-only
masquerade pair, the peer's client still dials the v4 (native, not
masqueraded) peerapi URL, so every fresh peerapi connection got a 403.

The bug was masked by HTTP keep-alive: peerNode is snapshotted per
connection, so connections established before the masquerade was
configured kept validating against the old node view. It surfaced when
a newer tailscale/go toolchain started closing idle netstack
connections, forcing fresh peerapi connections and failing the
TestNATPing v6=true NAT subtests with 403s.

A masquerade address for one family says nothing about the other
family, so require a masquerade address match only for the address
family it applies to, and fall through to the self-addresses check for
the other family.

Fixes #21194
