### PR TITLE
go.mod: bump wireguard-go dep

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -173,4 +173,4 @@
     });
   };
 }
-# nix-direnv cache busting line: sha256-CWVrylj619J+DQOFe+nLjhcCJ0IVPpZhbKv3a9iQYsw=
+# nix-direnv cache busting line: sha256-ymYDwGo15grikyBCgjX1XwxjTjUocx61tr8TIk+E8uQ=

--- a/flakehashes.json
+++ b/flakehashes.json
@@ -4,7 +4,7 @@
     "sri": "sha256-+cTlDLusJthxTayVx6yGoqZHRN4ylvs/9Qpy4P2dlDI="
   },
   "vendor": {
-    "goModSum": "sha256-sO/NFZwTGIGvVe7jMKDEl/Kv1YRzt+veWrYltfgkuR4=",
-    "sri": "sha256-CWVrylj619J+DQOFe+nLjhcCJ0IVPpZhbKv3a9iQYsw="
+    "goModSum": "sha256-08yr9eaxTcEmphgR+dvn6qgVrvr6jOVYCdgezF01W7g=",
+    "sri": "sha256-ymYDwGo15grikyBCgjX1XwxjTjUocx61tr8TIk+E8uQ="
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -126,7 +126,7 @@ require (
 	github.com/tailscale/ts-gokrazy v0.0.0-20260630224145-b83088f2e52e
 	github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976
 	github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6
-	github.com/tailscale/wireguard-go v0.0.0-20260904160635-24b5b6917431
+	github.com/tailscale/wireguard-go v0.0.0-20260910010640-7658b3f64aff
 	github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e
 	github.com/tc-hib/winres v0.2.1
 	github.com/tcnksm/go-httpstat v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1217,8 +1217,8 @@ github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976 h1:U
 github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976/go.mod h1:agQPE6y6ldqCOui2gkIh7ZMztTkIQKH049tv8siLuNQ=
 github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6 h1:l10Gi6w9jxvinoiq15g8OToDdASBni4CyJOdHY1Hr8M=
 github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6/go.mod h1:ZXRML051h7o4OcI0d3AaILDIad/Xw0IkXaHM17dic1Y=
-github.com/tailscale/wireguard-go v0.0.0-20260904160635-24b5b6917431 h1:opfY1yfV/mJzmbxJZw/cXLkmNwp4qjRZ51tC6RG3VPI=
-github.com/tailscale/wireguard-go v0.0.0-20260904160635-24b5b6917431/go.mod h1:rUelGmuK4UnSJYM5gl5Mknp6YbwwcL8+VAPMhNYe+jg=
+github.com/tailscale/wireguard-go v0.0.0-20260910010640-7658b3f64aff h1:LVNwjT0hrk7StAgSlpVc44ckAFDqciJXLcZEQpPXhgk=
+github.com/tailscale/wireguard-go v0.0.0-20260910010640-7658b3f64aff/go.mod h1:rUelGmuK4UnSJYM5gl5Mknp6YbwwcL8+VAPMhNYe+jg=
 github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e h1:zOGKqN5D5hHhiYUp091JqK7DPCqSARyUfduhGUY8Bek=
 github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e/go.mod h1:orPd6JZXXRyuDusYilywte7k094d7dycXXU5YnWsrwg=
 github.com/tc-hib/winres v0.2.1 h1:YDE0FiP0VmtRaDn7+aaChp1KiF4owBiJa5l964l5ujA=

--- a/shell.nix
+++ b/shell.nix
@@ -16,4 +16,4 @@
 ) {
   src =  ./.;
 }).shellNix
-# nix-direnv cache busting line: sha256-CWVrylj619J+DQOFe+nLjhcCJ0IVPpZhbKv3a9iQYsw=
+# nix-direnv cache busting line: sha256-ymYDwGo15grikyBCgjX1XwxjTjUocx61tr8TIk+E8uQ=


### PR DESCRIPTION
tailscale/wireguard-go@7658b3f removes a packet copy and mutex in tun.Device.Read on Linux.

Updates tailscale/corp#37878