### PR TITLE
k8s-operator/api-proxy: fix outbound Host header for impersonated requests

### DIFF
--- a/k8s-operator/api-proxy/proxy.go
+++ b/k8s-operator/api-proxy/proxy.go
@@ -441,6 +441,13 @@ func (ap *APIServerProxy) recordRequestAsEvent(req *http.Request, who *apitype.W
 func (ap *APIServerProxy) addImpersonationHeadersAsRequired(r *http.Request) {
 	r.URL.Scheme = ap.upstreamURL.Scheme
 	r.URL.Host = ap.upstreamURL.Host
+	// r.Host determines the outbound Host header (and HTTP/2 :authority).
+	// Without this, it stays whatever Host the client used to reach this
+	// proxy, which mismatches the upstream apiserver and gets rejected
+	// with 421 Misdirected Request by strict HTTP/2 virtual-host matching
+	// (e.g. an Istio ingress gateway terminating TLS in front of the
+	// apiserver).
+	r.Host = ap.upstreamURL.Host
 	if !ap.authMode {
 		// If we are not providing authentication, then we are just
 		// proxying to the Kubernetes API, so we don't need to do

--- a/k8s-operator/api-proxy/proxy_test.go
+++ b/k8s-operator/api-proxy/proxy_test.go
@@ -8,6 +8,7 @@ package apiproxy
 import (
 	"net/http"
 	"net/netip"
+	"net/url"
 	"reflect"
 	"testing"
 
@@ -127,6 +128,36 @@ func TestImpersonationHeaders(t *testing.T) {
 		if d := cmp.Diff(tc.wantHeaders, r.Header); d != "" {
 			t.Errorf("unexpected header (-want +got):\n%s", d)
 		}
+	}
+}
+
+func TestAddImpersonationHeadersAsRequiredSetsHost(t *testing.T) {
+	zl, err := zap.NewDevelopment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	upstream := must.Get(url.Parse("https://198.51.100.1:443"))
+	ap := &APIServerProxy{
+		log:         zl.Sugar(),
+		authMode:    false,
+		upstreamURL: upstream,
+	}
+
+	// Client reaches the proxy over its own (tailnet) hostname, which is
+	// unrelated to the upstream apiserver.
+	r := must.Get(http.NewRequest("GET", "https://my-node.some-tailnet.ts.net/version", nil))
+
+	ap.addImpersonationHeadersAsRequired(r)
+
+	if r.URL.Host != upstream.Host {
+		t.Errorf("r.URL.Host = %q, want %q", r.URL.Host, upstream.Host)
+	}
+	// r.Host drives the outbound Host header / HTTP2 :authority. If it is
+	// left as the inbound tailnet hostname, strict HTTP/2 virtual-host
+	// matching downstream (e.g. an Istio ingress gateway in front of the
+	// apiserver) rejects the request with 421 Misdirected Request.
+	if r.Host != upstream.Host {
+		t.Errorf("r.Host = %q, want %q", r.Host, upstream.Host)
 	}
 }
 


### PR DESCRIPTION
When proxying requests to the Kubernetes API server, `addImpersonationHeadersAsRequired` rewrites `r.URL.Host` to point at the configured upstream apiserver, but never updates `r.Host`. Since the outgoing request's Host header / HTTP2 `:authority` is taken from `r.Host` when set, the proxied request keeps whatever Host the client originally used to reach the proxy (e.g. the tailnet/MagicDNS hostname) instead of the actual apiserver hostname.

This is harmless behind a plain TCP/SNI passthrough, but breaks when the apiserver sits behind an HTTP/2-aware reverse proxy that enforces strict virtual-host matching per RFC 7540 §8.1.2.3 (e.g. an Istio ingress gateway terminating TLS). In that case every proxied request is rejected with:

```
421 Misdirected Request
```

Fix: set `r.Host` to the upstream host alongside `r.URL.Host`, mirroring what `httputil.ProxyRequest.SetURL` does for the same reason (its doc comment: "SetURL rewrites the outbound Host header to match the target's host").

Added a regression test (`TestAddImpersonationHeadersAsRequiredSetsHost`) that fails without the fix.

Fixes https://github.com/tailscale/tailscale/issues/21201