### PR TITLE
control/controlclient: make mapSession not run in a separate goroutine

### DIFF
--- a/control/controlclient/direct.go
+++ b/control/controlclient/direct.go
@@ -115,9 +115,8 @@ type Direct struct {
 	netinfo                 *tailcfg.NetInfo
 	endpoints               []tailcfg.Endpoint
 	tkaHead                 string
-	lastPingURL             string      // last PingRequest.URL received, for dup suppression
-	connectionHandleForTest string      // sent in MapRequest.ConnectionHandleForTest
-	streamingMapSession     *mapSession // the one streaming mapSession instance
+	lastPingURL             string // last PingRequest.URL received, for dup suppression
+	connectionHandleForTest string // sent in MapRequest.ConnectionHandleForTest
 
 	controlClientID int64 // Random ID used to differentiate clients for consumers of messages.
 }
@@ -929,8 +928,8 @@ func (c *Direct) PollNetMap(ctx context.Context, nu NetmapUpdater) error {
 // update it observed. It is used by tests and [NetmapFromMapResponseForDebug].
 // It will report only the first netmap seen.
 type rememberLastNetmapUpdater struct {
-	last          *netmap.NetworkMap
-	done          chan any
+	last *netmap.NetworkMap
+	done chan any
 }
 
 func (nu *rememberLastNetmapUpdater) UpdateFullNetmap(nm *netmap.NetworkMap) {
@@ -1197,22 +1196,8 @@ func (c *Direct) sendMapRequest(ctx context.Context, isStreaming bool, nu Netmap
 		return nil
 	}
 
-	if isStreaming && c.streamingMapSession != nil {
-		panic("mapSession is already set")
-	}
-
 	sess := newMapSession(persist.PrivateNodeKey(), nu, c.controlKnobs)
-	if isStreaming {
-		c.streamingMapSession = sess
-		defer func() {
-			sess.Close()
-			c.mu.Lock()
-			c.streamingMapSession = nil
-			c.mu.Unlock()
-		}()
-	} else {
-		defer sess.Close()
-	}
+	defer sess.Close()
 	sess.cancel = cancel
 	sess.logf = c.logf
 	sess.vlogf = vlogf

--- a/control/controlclient/map.go
+++ b/control/controlclient/map.go
@@ -98,10 +98,6 @@ type mapSession struct {
 	lastPopBrowserURL      string
 	lastTKAInfo            *tailcfg.TKAInfo
 	lastNetmapSummary      string // from NetworkMap.VeryConcise
-	cqmu                   sync.Mutex
-	changeQueue            chan *tailcfg.MapResponse
-	changeQueueClosed      bool
-	processQueue           sync.WaitGroup
 
 	// mu protects the peers map.
 	peersMu sync.RWMutex
@@ -128,46 +124,9 @@ func newMapSession(privateNodeKey key.NodePrivate, nu NetmapUpdater, controlKnob
 		cancel:            func() {},
 		onDebug:           func(context.Context, *tailcfg.Debug) error { return nil },
 		onSelfNodeChanged: func(*netmap.NetworkMap) {},
-		changeQueue:       make(chan *tailcfg.MapResponse),
-		changeQueueClosed: false,
 	}
 	ms.sessionAliveCtx, ms.sessionAliveCtxClose = context.WithCancel(context.Background())
-	ms.processQueue.Add(1)
-	go ms.run()
 	return ms
-}
-
-// run starts the mapSession processing a queue of tailcfg.MapResponse one by
-// one until close() is called on the mapSession.
-// When the mapSession is closed, the remaining queue is locked and processed
-// before the mapSession is done processing.
-func (ms *mapSession) run() {
-	defer ms.processQueue.Done()
-
-	for {
-		select {
-		case change := <-ms.changeQueue:
-			ms.handleNonKeepAliveMapResponse(ms.sessionAliveCtx, change)
-		case <-ms.sessionAliveCtx.Done():
-			// Drain any remaining items in the queue before exiting.
-			// Lock the queue during this time to avoid updates through other channels
-			// to be overwritten. This is especially relevant for calls to
-			// updateDiscoForNode.
-			ms.cqmu.Lock()
-			ms.changeQueueClosed = true
-			ms.cqmu.Unlock()
-			for {
-				select {
-				case change := <-ms.changeQueue:
-					ms.handleNonKeepAliveMapResponse(ms.sessionAliveCtx, change)
-				default:
-					// Queue is empty, close it and exit
-					close(ms.changeQueue)
-					return
-				}
-			}
-		}
-	}
 }
 
 // occasionallyPrintSummary logs summary at most once very 5 minutes. The
@@ -190,7 +149,6 @@ func (ms *mapSession) clock() tstime.Clock {
 
 func (ms *mapSession) Close() {
 	ms.sessionAliveCtxClose()
-	ms.processQueue.Wait()
 }
 
 var ErrChangeQueueClosed = errors.New("change queue closed")
@@ -203,44 +161,15 @@ var ErrChangeQueueClosed = errors.New("change queue closed")
 //
 // Debug messages are handled first, followed by pushing the response onto a
 // queue for new updates handled sequentially.
+//
+// TODO(bradfitz): make this handle all fields later. For now (2023-08-20) this
+// is [re]factoring progress enough.
 func (ms *mapSession) HandleNonKeepAliveMapResponse(ctx context.Context, resp *tailcfg.MapResponse) error {
 	if debug := resp.Debug; debug != nil {
 		if err := ms.onDebug(ctx, debug); err != nil {
 			return err
 		}
 	}
-
-	ms.cqmu.Lock()
-
-	if ms.changeQueueClosed {
-		ms.cqmu.Unlock()
-		ms.processQueue.Wait()
-		return ErrChangeQueueClosed
-	}
-
-	defer ms.cqmu.Unlock()
-
-	return ms.addRespToQueue(resp)
-}
-
-func (ms *mapSession) addRespToQueue(resp *tailcfg.MapResponse) error {
-	select {
-	case ms.changeQueue <- resp:
-		return nil
-	case <-ms.sessionAliveCtx.Done():
-		return ErrChangeQueueClosed
-	}
-}
-
-// handleNonKeepAliveMapResponse handles a non-KeepAlive MapResponse (full or
-// incremental).
-//
-// All fields that are valid on a KeepAlive MapResponse have already been
-// handled.
-//
-// TODO(bradfitz): make this handle all fields later. For now (2023-08-20) this
-// is [re]factoring progress enough.
-func (ms *mapSession) handleNonKeepAliveMapResponse(ctx context.Context, resp *tailcfg.MapResponse) error {
 	if DevKnob.StripEndpoints() {
 		for _, p := range resp.Peers {
 			p.Endpoints = nil

--- a/control/controlclient/map_test.go
+++ b/control/controlclient/map_test.go
@@ -931,7 +931,7 @@ func TestExistingPeerReplacementHandledIncrementally(t *testing.T) {
 		AllowedIPs: []netip.Prefix{netip.MustParsePrefix("100.64.0.1/32")},
 		Hostinfo:   (&tailcfg.Hostinfo{}).View(),
 	}
-	if err := ms.handleNonKeepAliveMapResponse(ctx, &tailcfg.MapResponse{
+	if err := ms.HandleNonKeepAliveMapResponse(ctx, &tailcfg.MapResponse{
 		Node:  &tailcfg.Node{Name: "self.example.ts.net."},
 		Peers: []*tailcfg.Node{peer},
 	}); err != nil {
@@ -943,7 +943,7 @@ func TestExistingPeerReplacementHandledIncrementally(t *testing.T) {
 
 	replacement := peer.Clone()
 	replacement.AllowedIPs = append(replacement.AllowedIPs, netip.MustParsePrefix("100.64.0.2/32"))
-	if err := ms.handleNonKeepAliveMapResponse(ctx, &tailcfg.MapResponse{
+	if err := ms.HandleNonKeepAliveMapResponse(ctx, &tailcfg.MapResponse{
 		PeersChanged: []*tailcfg.Node{replacement},
 	}); err != nil {
 		t.Fatal(err)
@@ -995,7 +995,7 @@ func TestUpsertReplaysUserProfiles(t *testing.T) {
 		AllowedIPs: []netip.Prefix{netip.MustParsePrefix("100.64.0.1/32")},
 		Hostinfo:   (&tailcfg.Hostinfo{}).View(),
 	}
-	if err := ms.handleNonKeepAliveMapResponse(ctx, &tailcfg.MapResponse{
+	if err := ms.HandleNonKeepAliveMapResponse(ctx, &tailcfg.MapResponse{
 		Node:  &tailcfg.Node{Name: "self.example.ts.net."},
 		Peers: []*tailcfg.Node{peer},
 		UserProfiles: []tailcfg.UserProfile{
@@ -1014,7 +1014,7 @@ func TestUpsertReplaysUserProfiles(t *testing.T) {
 	// both profiles, before the delta lands.
 	replacement := peer.Clone()
 	replacement.AllowedIPs = append(replacement.AllowedIPs, netip.MustParsePrefix("100.64.0.2/32"))
-	if err := ms.handleNonKeepAliveMapResponse(ctx, &tailcfg.MapResponse{
+	if err := ms.HandleNonKeepAliveMapResponse(ctx, &tailcfg.MapResponse{
 		PeersChanged: []*tailcfg.Node{replacement},
 	}); err != nil {
 		t.Fatal(err)
@@ -1045,7 +1045,7 @@ func TestUpsertReplaysUserProfiles(t *testing.T) {
 	// A patch-only change (no upsert) must not replay any profiles.
 	patched := replacement.Clone()
 	patched.Endpoints = eps("10.0.0.1:1111")
-	if err := ms.handleNonKeepAliveMapResponse(ctx, &tailcfg.MapResponse{
+	if err := ms.HandleNonKeepAliveMapResponse(ctx, &tailcfg.MapResponse{
 		PeersChanged: []*tailcfg.Node{patched},
 	}); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Prior to 85bb5f8 mapSession was running directly as part of the
controlClient. That was changed previously to let discoKeys to flow into
the mapSession for TSMP learned keys, using the mapSession for filtering
of keys.

Since moving the TSMP key learning directly into the userspace engine,
and introducing the notion of two active disco keys for an enpoint, we
no longer need mapSession to run in a separate goroutine and have
separate paths of entry for data.

This commit effectively reverts the last changes that was previously
made in the controlClient to support TSMP.

Updates #20590

Signed-off-by: Claus Lensbøl <claus@tailscale.com>
