### PR TITLE
net/netmon: match interface IPs exactly

### DIFF
--- a/net/netmon/netmon_test.go
+++ b/net/netmon/netmon_test.go
@@ -219,6 +219,16 @@ func TestInterfaceIPDisappeared(t *testing.T) {
 	}
 }
 
+func TestHasIPDoesNotMatchSibling(t *testing.T) {
+	target := netip.MustParseAddr("2001:db8::1")
+	state := &State{InterfaceIPs: map[string][]netip.Prefix{
+		"eth0": {netip.PrefixFrom(netip.MustParseAddr("2001:db8::2"), 64)},
+	}}
+	if state.HasIP(target) {
+		t.Fatalf("HasIP(%v) matched a different address in the same subnet", target)
+	}
+}
+
 // tests (*ChangeDelta).RebindRequired
 func TestRebindRequired(t *testing.T) {
 	// s1 must not be nil by definition

--- a/net/netmon/state.go
+++ b/net/netmon/state.go
@@ -418,7 +418,7 @@ func (s *State) HasIP(ip netip.Addr) bool {
 	}
 	for _, pv := range s.InterfaceIPs {
 		for _, p := range pv {
-			if p.Contains(ip) {
+			if p.Addr() == ip {
 				return true
 			}
 		}


### PR DESCRIPTION
Fixes #21205

State.HasIP currently uses netip.Prefix.Contains, so a deleted address is still reported as present when another address remains in the same subnet. This prevents InterfaceIPDisappeared from closing connections bound to the deleted address.

Compare the prefix address directly instead. Add a regression test covering two distinct IPv6 addresses in the same /64.

Tests: go test ./net/netmon -run TestHasIPDoesNotMatchSibling; go test ./net/netmon; git diff --check

AI assistance was used to prepare this contribution; the change and tests were reviewed before submission.