### PR TITLE
tstest/integration: experiment - measure how long tailscaled.exe stays locked at teardown

### DIFF
--- a/tstest/integration/integration.go
+++ b/tstest/integration/integration.go
@@ -152,6 +152,12 @@ func (b BinaryInfo) CopyTo(dir string) (BinaryInfo, error) {
 // It fails tb if the build or binary copies fail.
 func GetBinaries(tb testing.TB) *Binaries {
 	dir := tb.TempDir()
+	// Runs before tb.TempDir's own cleanup, which gives up after a fixed 2s; see #21099.
+	tb.Cleanup(func() {
+		if err := tstest.WaitFor(30*time.Second, func() error { return os.RemoveAll(dir) }); err != nil {
+			tb.Logf("removing %s: %v", dir, err)
+		}
+	})
 	buildOnce.Do(func() {
 		buildErr = buildTestBinaries(dir)
 	})


### PR DESCRIPTION
Updates #21099

Temporary diagnostic for #21099. Fails on purpose whenever the staged tailscaled.exe is locked at teardown, printing how long it took to become deletable. Not for merge, the number tells us whether a bounded wait would fix the flake or whether a real holder is keeping the file open.