### PR TITLE
ipn/ipnlocal: add exceptions to 4via6 filter

### DIFF
--- a/ipn/ipnlocal/via.go
+++ b/ipn/ipnlocal/via.go
@@ -4,13 +4,105 @@
 package ipnlocal
 
 import (
+	"errors"
+	"fmt"
+	"log"
 	"net/netip"
+	"strings"
+	"sync"
 
+	"go4.org/netipx"
+	"tailscale.com/envknob"
 	"tailscale.com/net/tsaddr"
+	"tailscale.com/util/clientmetric"
 )
 
 // v4BroadcastAddr is 255.255.255.255, the limited broadcast address.
 var v4BroadcastAddr = netip.AddrFrom4([4]byte{255, 255, 255, 255})
+
+// viaAdditionsEnv is the name of an environment variable that can be set to
+// override the 4via6 host-scoped address restrictions. Only use this if you are
+// certain that there is not a better solution (e.g. perhaps tailscale serve,
+// possibly using a Service). Use of this feature will have security
+// implications: ensure that your ACLs/Grants are written appropriately.
+// The value of the environment variable is a comma separated list of IPv4
+// ranges (two IPv4 addresses separated by a hyphen), IPv4 prefixes (CIDR
+// notation), or IPv4 addresses. Spaces are permitted around the commas.
+const viaAdditionsEnv = "TS_4VIA6_ALLOW_LOCAL"
+
+var viaTargetAdditions = sync.OnceValue(func() *netipx.IPSet {
+	v, err := generateViaTargetAdditions(envknob.String(viaAdditionsEnv))
+	if err != nil {
+		log.Print(err)
+	}
+
+	if v != nil {
+		has4via6AdditionsMetric := clientmetric.NewGauge("4via6_allow_local")
+		has4via6AdditionsMetric.Set(1)
+	}
+
+	return v
+})
+
+func generateViaTargetAdditions(rawAdditions string) (*netipx.IPSet, error) {
+	rawAdditions = strings.TrimSpace(rawAdditions)
+	if rawAdditions == "" {
+		return nil, nil
+	}
+
+	var ips netipx.IPSetBuilder
+
+	rawAddrs := strings.Split(rawAdditions, ",")
+	errs := make([]error, 0, len(rawAddrs))
+	for _, rawAddr := range rawAddrs {
+		rawAddr = strings.TrimSpace(rawAddr)
+		if rawAddr == "" {
+			continue
+		}
+
+		// Try parsing as a range
+		if ipRange, err := netipx.ParseIPRange(rawAddr); err == nil {
+			if !ipRange.From().Is4() || !ipRange.To().Is4() {
+				errs = append(errs, fmt.Errorf("rejecting %v range %v: not IPv4", viaAdditionsEnv, ipRange))
+				continue
+			}
+
+			ips.AddRange(ipRange)
+			continue
+		}
+
+		// Try parsing as a prefix
+		if prefix, err := netip.ParsePrefix(rawAddr); err == nil {
+			if !prefix.Addr().Is4() {
+				errs = append(errs, fmt.Errorf("rejecting %v prefix %v: not IPv4", viaAdditionsEnv, prefix))
+				continue
+			}
+
+			ips.AddPrefix(prefix)
+			continue
+		}
+
+		// Try parsing as an individual IP
+		if addr, err := netip.ParseAddr(rawAddr); err == nil {
+			if !addr.Is4() {
+				errs = append(errs, fmt.Errorf("rejecting %v address %v: not IPv4", viaAdditionsEnv, addr))
+				continue
+			}
+
+			ips.Add(addr)
+			continue
+		}
+
+		errs = append(errs, fmt.Errorf("rejecting %v value %q: not a range, prefix, or address", viaAdditionsEnv, rawAddr))
+	}
+
+	ipSet, err := ips.IPSet()
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	return ipSet, errors.Join(errs...)
+}
 
 // viaTargetAllowed reports whether ip may be forwarded to after unmapping a
 // 4via6 destination. The packet filter only sees the outer via address, so
@@ -18,14 +110,24 @@ var v4BroadcastAddr = netip.AddrFrom4([4]byte{255, 255, 255, 255})
 func viaTargetAllowed(ip netip.Addr) bool {
 	if !ip.Is4() {
 		return false // UnmapVia only returns IPv4
-	} else if ip.IsLoopback() || ip.IsMulticast() || ip.IsUnspecified() || ip == v4BroadcastAddr {
+	}
+	if additions := viaTargetAdditions(); additions != nil {
+		// Permit unusual configurations to use host-scoped IP addresses as
+		// 4via6 destinations when provided in an envknob.
+		if additions.Contains(ip) {
+			return true
+		}
+	}
+	if ip.IsLoopback() || ip.IsMulticast() || ip.IsUnspecified() || ip == v4BroadcastAddr {
 		return false
-	} else if tsaddr.IsTailscaleIP(ip) {
+	}
+	if tsaddr.IsTailscaleIP(ip) {
 		// A CGNAT-range target may route to tailscale0 or to a site LAN
 		// depending on the tailnet and OS (see shouldUseOneCGNATRoute);
 		// it's hard to detect when forwarding would be OK, so deny always
 		return false
-	} else if ip.IsLinkLocalUnicast() {
+	}
+	if ip.IsLinkLocalUnicast() {
 		return false
 	}
 	return true

--- a/ipn/ipnlocal/via_test.go
+++ b/ipn/ipnlocal/via_test.go
@@ -5,10 +5,15 @@ package ipnlocal
 
 import (
 	"net/netip"
+	"slices"
 	"testing"
+
+	"go4.org/netipx"
 )
 
 func TestViaTargetAllowed(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		ip   string
 		want bool
@@ -62,5 +67,151 @@ func TestViaTargetAllowed(t *testing.T) {
 		if got := viaTargetAllowed(ip); got != tc.want {
 			t.Errorf("viaTargetAllowed(%v) = %v, want %v", ip, got, tc.want)
 		}
+	}
+}
+
+func TestGenerateViaTargetAdditions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		v        string
+		want     []netipx.IPRange
+		wantErrs []string
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name: "space",
+			v:    " ",
+		},
+		{
+			name:     "invalid-without-comma",
+			v:        "asdf",
+			wantErrs: []string{"rejecting " + viaAdditionsEnv + " value \"asdf\": not a range, prefix, or address"},
+		},
+		{
+			name: "empty-with-comma",
+			v:    " , ",
+		},
+		{
+			name: "invalid-with-comma",
+			v:    "asdf,fdsa",
+			wantErrs: []string{
+				"rejecting " + viaAdditionsEnv + " value \"asdf\": not a range, prefix, or address",
+				"rejecting " + viaAdditionsEnv + " value \"fdsa\": not a range, prefix, or address",
+			},
+		},
+		{
+			name: "single-range",
+			v:    "100.0.0.0-100.1.0.0",
+			want: []netipx.IPRange{netipx.MustParseIPRange("100.0.0.0-100.1.0.0")},
+		},
+		{
+			name: "single-prefix",
+			v:    "127.1.0.0/16",
+			want: []netipx.IPRange{netipx.MustParseIPRange("127.1.0.0-127.1.255.255")},
+		},
+		{
+			name: "single-addr",
+			v:    "255.255.255.255",
+			want: []netipx.IPRange{netipx.MustParseIPRange("255.255.255.255-255.255.255.255")},
+		},
+		{
+			name:     "single-ipv6-range",
+			v:        "fe80::-fe80::ffff",
+			wantErrs: []string{"rejecting " + viaAdditionsEnv + " range fe80::-fe80::ffff: not IPv4"},
+		},
+		{
+			name:     "single-ipv6-prefix",
+			v:        "fe80::/120",
+			wantErrs: []string{"rejecting " + viaAdditionsEnv + " prefix fe80::/120: not IPv4"},
+		},
+		{
+			name:     "single-ipv6-addr-bracket",
+			v:        "[fe80::]",
+			wantErrs: []string{"rejecting " + viaAdditionsEnv + " value \"[fe80::]\": not a range, prefix, or address"},
+		},
+		{
+			name:     "single-ipv6-addr-bare",
+			v:        "fe80::",
+			wantErrs: []string{"rejecting " + viaAdditionsEnv + " address fe80::: not IPv4"},
+		},
+		{
+			name:     "mixed-ipv4-ipv6",
+			v:        "127.1.0.0/16, fd7a:115c:a1e0:b1a:0:4:7f00:0/120",
+			wantErrs: []string{"rejecting " + viaAdditionsEnv + " prefix fd7a:115c:a1e0:b1a:0:4:7f00:0/120: not IPv4"},
+			want:     []netipx.IPRange{netipx.MustParseIPRange("127.1.0.0-127.1.255.255")},
+		},
+		{
+			name: "multiple",
+			v:    "192.0.0.5-192.0.0.10,127.1.0.0/16,8.8.8.8",
+			want: []netipx.IPRange{
+				netipx.MustParseIPRange("8.8.8.8-8.8.8.8"),
+				netipx.MustParseIPRange("127.1.0.0-127.1.255.255"),
+				netipx.MustParseIPRange("192.0.0.5-192.0.0.10"),
+			},
+		},
+		{
+			name: "invalid-in-middle",
+			v:    "192.0.0.5-192.0.0.10,asdf,127.1.0.0/16,8.8.8.8",
+			want: []netipx.IPRange{
+				netipx.MustParseIPRange("8.8.8.8-8.8.8.8"),
+				netipx.MustParseIPRange("127.1.0.0-127.1.255.255"),
+				netipx.MustParseIPRange("192.0.0.5-192.0.0.10"),
+			},
+			wantErrs: []string{"rejecting " + viaAdditionsEnv + " value \"asdf\": not a range, prefix, or address"},
+		},
+		{
+			name: "spaces-tabs-newline",
+			v:    "\n\n192.0.0.5-192.0.0.10\n ,\t127.1.0.0/16,      8.8.8.8\t\t",
+			want: []netipx.IPRange{
+				netipx.MustParseIPRange("8.8.8.8-8.8.8.8"),
+				netipx.MustParseIPRange("127.1.0.0-127.1.255.255"),
+				netipx.MustParseIPRange("192.0.0.5-192.0.0.10"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := generateViaTargetAdditions(tt.v)
+			if err == nil {
+				if len(tt.wantErrs) > 0 {
+					t.Error("returned no errors, want some errors")
+				}
+			} else {
+				var gotErrors []error
+				if unwrapper, ok := err.(interface{ Unwrap() []error }); ok {
+					gotErrors = unwrapper.Unwrap()
+				} else {
+					gotErrors = []error{err}
+				}
+
+				for i, e := range gotErrors {
+					if i >= len(tt.wantErrs) {
+						t.Errorf("error[%d] = %v, want no more errors", i, e)
+						continue
+					}
+					if e.Error() != tt.wantErrs[i] {
+						t.Errorf("error[%d] = %v, want %v", i, e, tt.wantErrs[i])
+					}
+				}
+				if len(gotErrors) < len(tt.wantErrs) {
+					t.Errorf("%d errors found, want %d", len(gotErrors), len(tt.wantErrs))
+				}
+			}
+
+			if got != nil {
+				gotRanges := got.Ranges()
+				if !slices.Equal(tt.want, gotRanges) {
+					t.Errorf("ipset.Ranges() = %v, want %v", gotRanges, tt.want)
+				}
+				return
+			}
+			if tt.want != nil {
+				t.Errorf("nil ipset, want ranges to be %v", tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Some customers rely on the ability for 4via6 subnet routers to expose loopback and/or link-local addresses. In situations where the administrator has deemed these to be safe, accept a list of allowed addresses in an environment variable named TS_4VIA6_ALLOW_LOCAL.

Change-Id: I7b3fe863696ee67aa352c4bd11edcbc8836920e3 Fixes #21019