### PR TITLE
cmd/tailscale/cli: clarify online status for devices without traffic

### DIFF
--- a/cmd/tailscale/cli/status.go
+++ b/cmd/tailscale/cli/status.go
@@ -32,6 +32,11 @@ var statusCmd = &ffcli.Command{
 	ShortHelp:  "Show state of tailscaled and its connections",
 	LongHelp: strings.TrimSpace(`
 
+In the Status column, online means the device is connected to the control
+plane and has no recorded traffic. Active and idle describe traffic activity;
+offline means the device is not connected to the control plane. Being online
+does not guarantee that the device is reachable from this machine.
+
 JSON FORMAT
 
 Warning: this format has changed between releases and might change more
@@ -184,7 +189,7 @@ func runStatus(ctx context.Context, args []string) error {
 			} else if !ps.Online {
 				f("offline%s", lastSeenFmt(ps.LastSeen))
 			} else {
-				f("-")
+				f("online")
 			}
 		} else {
 			f("active; ")

--- a/cmd/tailscale/cli/status_test.go
+++ b/cmd/tailscale/cli/status_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"strings"
+	"testing"
+
+	"tailscale.com/client/local"
+	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/tstest"
+	"tailscale.com/types/key"
+)
+
+func TestStatusNoTraffic(t *testing.T) {
+	for _, online := range []bool{true, false} {
+		want := "offline"
+		if online {
+			want = "online"
+		}
+		t.Run(want, func(t *testing.T) {
+			st := &ipnstate.Status{
+				BackendState: "Running",
+				Self: &ipnstate.PeerStatus{
+					HostName:     "device",
+					OS:           "linux",
+					TailscaleIPs: []netip.Addr{netip.MustParseAddr("100.64.0.1")},
+					Online:       online,
+				},
+			}
+			peer := *st.Self
+			peer.HostName = "peer"
+			peer.TailscaleIPs = []netip.Addr{netip.MustParseAddr("100.64.0.2")}
+			st.Peer = map[key.NodePublic]*ipnstate.PeerStatus{key.NewNode().Public(): &peer}
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/localapi/v0/serve-config" {
+					io.WriteString(w, "null")
+					return
+				}
+				if r.URL.Path != "/localapi/v0/status" {
+					http.NotFound(w, r)
+					return
+				}
+				if err := json.NewEncoder(w).Encode(st); err != nil {
+					t.Error(err)
+				}
+			}))
+			defer srv.Close()
+			tstest.Replace(t, &localClient, local.Client{
+				Dial: func(ctx context.Context, network, addr string) (net.Conn, error) {
+					return (&net.Dialer{}).DialContext(ctx, "tcp", srv.Listener.Addr().String())
+				},
+			})
+			tstest.Replace(t, &statusArgs.self, true)
+			tstest.Replace(t, &statusArgs.peers, true)
+			var out bytes.Buffer
+			tstest.Replace[io.Writer](t, &Stdout, &out)
+			if err := runStatus(context.Background(), nil); err != nil {
+				t.Fatal(err)
+			}
+			lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+			if len(lines) != 2 {
+				t.Fatalf("status output = %q; want self and peer rows", out.String())
+			}
+			for _, line := range lines {
+				fields := strings.Fields(line)
+				if len(fields) != 5 || fields[4] != want {
+					t.Errorf("status row = %q; want five columns ending in %q", line, want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
When an online device has no recorded traffic, `tailscale status` displays `-`, making its online state unclear. Display `online` in the existing `Status` column and explain control-plane connectivity versus traffic activity in `status --help`.

```text
Before: 100.64.0.1  device  user@  linux  -
After:  100.64.0.1  device  user@  linux  online
```

The change applies to both self and peer rows. Existing active, idle, offline, exit-node details, and JSON output are unchanged. Scripts matching the literal `-` in human-readable output would need updating. Online describes the daemon's reported control-plane connection, not guaranteed reachability.

Validation:
- `go test ./cmd/tailscale/cli`
- `go vet ./cmd/tailscale/cli`
- Regression test fails with the original `-` output and passes with this change, covering self and peer rows online/offline without traffic.
- Ran the modified CLI against a local daemon: all four online devices displayed `online`.

Full repository tests and non-Linux platforms were not tested.

Updates #21212
