### PR TITLE
release/dist/unixpkgs: recommend libnss-resolve for MagicDNS

### DIFF
--- a/release/dist/unixpkgs/pkgs.go
+++ b/release/dist/unixpkgs/pkgs.go
@@ -273,6 +273,11 @@ func (t *debTarget) Build(b *dist.Build) ([]string, error) {
 				// installed anyway and it's useful for debugging. But
 				// we can live without it, so it's not Depends.
 				"iproute2",
+				// Lets glibc resolve MagicDNS names through
+				// systemd-resolved. Not installed by default on
+				// Ubuntu minimal images. Recommends rather than
+				// Depends, since not every install needs it.
+				"libnss-resolve",
 			},
 			Replaces:  []string{"tailscale-relay"},
 			Conflicts: []string{"tailscale-relay"},


### PR DESCRIPTION
This adds `libnss-resolve` to the deb package's `Recommends` list, following up on #14509.

In #14509 I reported this on Ubuntu Server 24.04.1 minimal: MagicDNS names did not resolve until I installed `libnss-resolve` by hand, and installing the package alone fixed it with no manual `/etc/nsswitch.conf` edit. Another user on the same issue confirmed that installing the package fixed their symptom too. On the minimal image I tested, the package was not present by default.

I have used `Recommends` rather than `Depends` so that an operator who does not want this integration can omit it, though it is worth being explicit that APT installs recommendations by default, so in practice most installs would pull it in. That is the tradeoff I would want reviewed, and it is why this is a proposal rather than an obvious change: on Ubuntu 24.04 `libnss-resolve` depends on the separate `systemd-resolved` package, so on a host not already running it this can install systemd-resolved and change how `/etc/resolv.conf` is managed system wide, well beyond the minimal install case that motivated it. On 22.04 the dependency is on `systemd` itself rather than a separate package. A maintainer may prefer to scope this more narrowly, or to address it in the resolver layer instead; I am happy to follow whichever direction you prefer.

On verification: the branch merges cleanly onto current `main` (`023255e8`), and `libnss-resolve` is still absent from the `Recommends` list. I have not re-run the original end to end installation test on a fresh minimal image, so this rests on the reports in #14509.

Updates #14509
