### PR TITLE
cmd/cigocacher: stop logging default cache dir

### DIFF
--- a/cmd/cigocacher/cigocacher.go
+++ b/cmd/cigocacher/cigocacher.go
@@ -121,7 +121,6 @@ func main() {
 			log.Fatal(err)
 		}
 		*dir = filepath.Join(d, "go-cacher")
-		log.Printf("Defaulting to cache dir %v ...", *dir)
 	}
 	if err := os.MkdirAll(*dir, 0750); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
We have visibility into what the gocacheprog is doing via its stats in the github jobs, and its session on the server side, so this is just a spammy log line that doesn't print anything very interesting. In particular, cigocacher is started once for each package when you pass a list of packages to testwrapper, so it prints many times for jobs where we filter to a certain set of packages.

Updates #cleanup