### PR TITLE
util/multierr: mark multierr.New as deprecated

### DIFF
--- a/util/multierr/multierr.go
+++ b/util/multierr/multierr.go
@@ -47,6 +47,7 @@ func (e Error) Unwrap() []error {
 // If the resulting slice has length 0, New returns nil.
 // If the resulting slice has length 1, New returns that error.
 // If the resulting slice has length > 1, New returns that slice as an Error.
+// Deprecated: use [errors.Join] instead. See #17379.
 func New(errs ...error) error {
 	// First count the number of errors to avoid allocating.
 	var n int


### PR DESCRIPTION
We banned use of multierr in various dep tests, so this makes the situation more obvious if someone stumbles across it.

Change-Id: I17e80880e57e5005fcaea864a365ba264411e802