### PR TITLE
ipn/localapi: restrict debug-dial-types and debug-log access

### DIFF
--- a/ipn/localapi/debug.go
+++ b/ipn/localapi/debug.go
@@ -25,6 +25,7 @@ import (
 	"tailscale.com/feature"
 	"tailscale.com/feature/buildfeatures"
 	"tailscale.com/ipn"
+	"tailscale.com/net/tsaddr"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/logger"
 	"tailscale.com/util/eventbus"
@@ -95,6 +96,10 @@ func (h *Handler) serveComponentDebugLogging(w http.ResponseWriter, r *http.Requ
 }
 
 func (h *Handler) serveDebugDialTypes(w http.ResponseWriter, r *http.Request) {
+	if !buildfeatures.HasDebug {
+		http.Error(w, "debug not supported in this build", http.StatusNotImplemented)
+		return
+	}
 	if !h.PermitWrite {
 		http.Error(w, "debug-dial-types access denied", http.StatusForbidden)
 		return
@@ -108,10 +113,18 @@ func (h *Handler) serveDebugDialTypes(w http.ResponseWriter, r *http.Request) {
 	port := r.FormValue("port")
 	network := r.FormValue("network")
 
-	addr := ip + ":" + port
-	if _, err := netip.ParseAddrPort(addr); err != nil {
+	addr := net.JoinHostPort(ip, port)
+	ipp, err := netip.ParseAddrPort(addr)
+	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprintf(w, "invalid address %q: %v", addr, err)
+		return
+	}
+
+	// Probe tailnet-assigned IPs only: SystemDial and BareDial skip
+	// Tailscale entirely, so anything else is a root-dial reachability oracle.
+	if !tsaddr.IsTailscaleIP(ipp.Addr()) {
+		http.Error(w, "refusing to dial non-Tailscale address "+addr, http.StatusBadRequest)
 		return
 	}
 
@@ -522,7 +535,7 @@ func (h *Handler) serveDebugLog(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, feature.ErrUnavailable.Error(), http.StatusNotImplemented)
 		return
 	}
-	if !h.PermitRead {
+	if !h.PermitWrite {
 		http.Error(w, "debug-log access denied", http.StatusForbidden)
 		return
 	}

--- a/ipn/localapi/debug_test.go
+++ b/ipn/localapi/debug_test.go
@@ -8,11 +8,15 @@ package localapi
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"net/url"
+	"strings"
 	"testing"
 
 	"tailscale.com/ipn"
 	"tailscale.com/ipn/ipnauth"
+	"tailscale.com/net/netmon"
+	"tailscale.com/net/tsaddr"
 	"tailscale.com/tstest"
 )
 
@@ -71,5 +75,147 @@ func TestServeDevSetStateStore(t *testing.T) {
 				t.Errorf("res.StatusCode = %d, want %d", res.StatusCode, tt.wantStatus)
 			}
 		})
+	}
+}
+
+func TestServeDebugLogGate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc        string
+		permitRead  bool
+		permitWrite bool
+		wantStatus  int
+	}{
+		{
+			desc:       "read-only-denied",
+			permitRead: true,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			desc:        "write-allowed",
+			permitRead:  true,
+			permitWrite: true,
+			wantStatus:  http.StatusNoContent,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			h := handlerForTest(t, &Handler{
+				PermitRead:  tt.permitRead,
+				PermitWrite: tt.permitWrite,
+				b:           newTestLocalBackend(t),
+			})
+			req := httptest.NewRequest("POST", "http://local-tailscaled.sock/localapi/v0/debug-log",
+				strings.NewReader(`{"prefix":"test","lines":["line"]}`))
+			resp := httptest.NewRecorder()
+			h.serveDebugLog(resp, req)
+
+			if resp.Code != tt.wantStatus {
+				t.Errorf("resp.Code = %d, want %d; body: %s", resp.Code, tt.wantStatus, resp.Body.String())
+			}
+		})
+	}
+}
+
+func TestServeDebugDialTypesRestrictsAddress(t *testing.T) {
+	t.Parallel()
+
+	// Unassigned tailnet IPs: pass the address gate but never connect
+	const tsAddr = "100.64.0.1"
+	const tsAddrV6 = "fd7a:115c:a1e0::1"
+	const subnetRoute = "192.168.0.0/16"
+
+	tests := []struct {
+		desc       string
+		ip         string
+		wantStatus int
+	}{
+		{
+			desc:       "loopback-denied",
+			ip:         "127.0.0.1",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			desc:       "rfc1918-denied",
+			ip:         "192.168.1.1",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			desc:       "public-ip-denied",
+			ip:         "8.8.8.8",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			desc:       "tailscale-allowed",
+			ip:         tsAddr,
+			wantStatus: http.StatusOK,
+		},
+		{
+			desc:       "tailscale-v6-allowed",
+			ip:         tsAddrV6,
+			wantStatus: http.StatusOK,
+		},
+		{
+			// Even with 192.168.0.0/16 advertised as a subnet route,
+			// the address-class gate must still refuse RFC1918: SystemDial
+			// and BareDial don't consult the route table.
+			desc:       "advertised-subnet-still-denied",
+			ip:         "192.168.1.1",
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			routes := []netip.Prefix{tsaddr.CGNATRange()}
+			if tt.desc == "advertised-subnet-still-denied" {
+				routes = append(routes, netip.MustParsePrefix(subnetRoute))
+			}
+			b := newTestLocalBackend(t)
+			b.Dialer().SetNetMon(netmon.NewStatic())
+			b.Dialer().SetRoutes(routes, nil)
+
+			h := handlerForTest(t, &Handler{
+				PermitRead:  true,
+				PermitWrite: true,
+				b:           b,
+			})
+			// UDP dials complete without traffic, avoiding the TCP connect timeout
+			req := httptest.NewRequest("POST", "http://local-tailscaled.sock/localapi/v0/debug-dial-types?ip="+tt.ip+"&port=1&network=udp", nil)
+			resp := httptest.NewRecorder()
+			h.serveDebugDialTypes(resp, req)
+
+			if resp.Code != tt.wantStatus {
+				t.Errorf("resp.Code = %d, want %d; body: %s", resp.Code, tt.wantStatus, resp.Body.String())
+			}
+		})
+	}
+}
+
+func TestServeDebugDialTypesReportsDialers(t *testing.T) {
+	t.Parallel()
+
+	b := newTestLocalBackend(t)
+	b.Dialer().SetNetMon(netmon.NewStatic())
+	b.Dialer().SetRoutes([]netip.Prefix{tsaddr.CGNATRange()}, nil)
+
+	h := handlerForTest(t, &Handler{
+		PermitRead:  true,
+		PermitWrite: true,
+		b:           b,
+	})
+	req := httptest.NewRequest("POST", "http://local-tailscaled.sock/localapi/v0/debug-dial-types?ip=100.64.0.1&port=1&network=udp", nil)
+	resp := httptest.NewRecorder()
+	h.serveDebugDialTypes(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("resp.Code = %d, want %d; body: %s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	for _, name := range []string{"SystemDial", "UserDial", "PeerDial", "BareDial"} {
+		if !strings.Contains(resp.Body.String(), "["+name+"]") {
+			t.Errorf("output missing %q dialer line; body: %s", name, resp.Body.String())
+		}
 	}
 }

--- a/ipn/localapi/localapi_test.go
+++ b/ipn/localapi/localapi_test.go
@@ -35,6 +35,7 @@ import (
 	"tailscale.com/tailcfg/peercap"
 	"tailscale.com/tsd"
 	"tailscale.com/tstest"
+	"tailscale.com/tstime"
 	"tailscale.com/types/key"
 	"tailscale.com/types/logger"
 	"tailscale.com/types/logid"
@@ -52,6 +53,9 @@ func handlerForTest(t testing.TB, h *Handler) *Handler {
 	}
 	if h.logf == nil {
 		h.logf = logger.TestLogger(t)
+	}
+	if h.clock == nil {
+		h.clock = tstime.StdClock{}
 	}
 	return h
 }


### PR DESCRIPTION
The debug-dial-types endpoint dials any caller-supplied address from the root daemon, including via SystemDial and a bare net.Dialer that bypass Tailscale, regressing the tailscale/corp#39702 fix that serveDial's Dial-Self guard put in place.

Close (but less impactful) the debug-log endpoint was gated on PermitRead, which any local user connecting to the world-writable tailscaled socket passes. Although forged log entries are always possible, we should limit the ability for local users to influence that flow with respects to a given node.

This change restricts debug-dial-types to tailnet-assigned IPs via tsaddr.IsTailscaleIP, so no advertised subnet route can widen the probe back to private LAN ranges.

The log gap is fixed by requiring PermitWrite for debug-log, matching the trust level of every other mutating debug endpoint. Also add a buildfeatures.HasDebug guard to debug-dial-types for parity with serveDebug.

Fixes tailscale/corp#48141
Fixes tailscale/corp#48143