### PR TITLE
util/safediff: keep pending stats when a line does not fit

### DIFF
--- a/util/safediff/diff.go
+++ b/util/safediff/diff.go
@@ -131,7 +131,8 @@ func Lines(x, y string, maxSize int) (out string, truncated bool) {
 		// Append the stats (if non-zero) and the line text.
 		// The stats reports the number of preceding identical lines.
 		if !truncated {
-			bufLen := len(buf) // original length (in case we exceed maxSize)
+			bufLen := len(buf)     // original length (in case we exceed maxSize)
+			origStats := prevStats // original stats (in case we exceed maxSize)
 			if !prevStats.isZero() {
 				buf = prevStats.appendText(buf)
 				prevStats = stats{} // just printed, so clear the stats
@@ -141,7 +142,8 @@ func Lines(x, y string, maxSize int) (out string, truncated bool) {
 			if !truncated {
 				return
 			}
-			buf = buf[:bufLen] // restore original buffer contents
+			buf = buf[:bufLen]    // restore original buffer contents
+			prevStats = origStats // restore stats since they were not printed
 		}
 
 		// Output is truncated, so just update the statistics.

--- a/util/safediff/diff_test.go
+++ b/util/safediff/diff_test.go
@@ -4,6 +4,8 @@
 package safediff
 
 import (
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -89,7 +91,7 @@ func TestLines(t *testing.T) {
 		t.Errorf("Lines: output unexpectedly not truncated")
 	}
 
-	wantDiff = "… 17 identical, 3 removed, and 3 inserted lines\n"
+	wantDiff = "… 22 identical, 3 removed, and 3 inserted lines\n"
 	gotDiff, gotTrunc = Lines(x, y, 0)
 	if d := cmp.Diff(gotDiff, wantDiff); d != "" {
 		t.Errorf("Lines mismatch (-got +want):\n%s\ngot:\n%s\nwant:\n%s", d, gotDiff, wantDiff)
@@ -177,4 +179,79 @@ func TestLines(t *testing.T) {
 	} else if gotTrunc == true {
 		t.Errorf("Lines: output unexpectedly truncated")
 	}
+}
+
+// TestLinesAccounting verifies that every input line is accounted for in the
+// output, whether printed individually or tallied in a "…" summary, at every
+// maxSize. Truncation must only ever hide lines, never lose track of them.
+func TestLinesAccounting(t *testing.T) {
+	x := strings.Repeat("identical\n", 50) + "before\n" + strings.Repeat("identical\n", 50)
+	y := strings.Repeat("identical\n", 50) + "after\n" + strings.Repeat("identical\n", 50)
+
+	// Tally the expected counts straight from the edit-script.
+	var want stats
+	for _, e := range diffStrings(strings.Split(x, "\n"), strings.Split(y, "\n")) {
+		switch e {
+		case identical:
+			want.numIdentical++
+		case modified:
+			want.numRemoved++
+			want.numInserted++
+		case removed:
+			want.numRemoved++
+		case inserted:
+			want.numInserted++
+		}
+	}
+
+	for _, maxSize := range append([]int{-1}, rangeInts(0, 400)...) {
+		out, _ := Lines(x, y, maxSize)
+		if got := tallyDiff(t, out); got != want {
+			t.Errorf("Lines(maxSize=%d) accounts for %+v lines, want %+v; output:\n%s", maxSize, got, want, out)
+		}
+	}
+}
+
+func rangeInts(lo, hi int) []int {
+	out := make([]int, 0, hi-lo)
+	for i := lo; i < hi; i++ {
+		out = append(out, i)
+	}
+	return out
+}
+
+var summaryRx = regexp.MustCompile(`(\d+) (identical|removed|inserted)`)
+
+// tallyDiff counts how many lines of each kind a [Lines] output accounts for,
+// summing both individually printed lines and "…" summary statements.
+func tallyDiff(t *testing.T, out string) (s stats) {
+	t.Helper()
+	for line := range strings.Lines(out) {
+		switch {
+		case strings.HasPrefix(line, "  "):
+			s.numIdentical++
+		case strings.HasPrefix(line, "- "):
+			s.numRemoved++
+		case strings.HasPrefix(line, "+ "):
+			s.numInserted++
+		case strings.HasPrefix(line, "… "):
+			for _, m := range summaryRx.FindAllStringSubmatch(line, -1) {
+				n, err := strconv.Atoi(m[1])
+				if err != nil {
+					t.Fatalf("bad summary line %q: %v", line, err)
+				}
+				switch m[2] {
+				case "identical":
+					s.numIdentical += n
+				case "removed":
+					s.numRemoved += n
+				case "inserted":
+					s.numInserted += n
+				}
+			}
+		default:
+			t.Fatalf("unexpected output line %q", line)
+		}
+	}
+	return s
 }


### PR DESCRIPTION
`safediff.Lines` is documented to truncate its output to `maxSize`, rolling the lines it cannot print into a `… N identical lines` summary. When truncation kicks in, one entire pending summary group is dropped: those lines are neither printed nor counted, so the totals come out lower than the input.

`mayAppendLine` flushed `prevStats` into the buffer and zeroed it *before* it knew whether the line would fit. On overflow it rewound `buf`, discarding the summary text it had just written, but left `prevStats` zeroed, so those counts never reached the trailing summary either.

The fix saves `prevStats` alongside the buffer length and restores it when the line is rejected.

Totalling every identical line the output accounts for, whether printed individually or counted in a summary, using the 25 line fixture already in `TestLines` (22 identical lines):

| maxSize | before | after |
| --- | --- | --- |
| 0 | 17 | 22 |
| 50 | 17 | 22 |
| 100 | 22 | 22 |

Only the case where the first flush overflows is affected; once a group has been printed successfully there is nothing pending to lose, which is why `maxSize` 100 is already correct.

The loss scales with the input, since it is however many lines were in that one group. With 101 identical lines around a single changed line, `maxSize=0` reported 52 identical instead of 101. For the kind of policy file diff the package doc shows, with `… 440 identical lines` groups, a truncated diff could under-report hundreds of lines.

Two things kept this hidden: the only in-tree caller, `cmd/jsonimports`, passes `maxSize = -1` and so never truncates, and `TestLines` had the wrong number (`17`) baked in as its expected output. That expectation is corrected here.

`TestLinesAccounting` is added to pin the invariant: every input line must be accounted for, printed or summarized, at every `maxSize`. It fails against the unpatched code (reporting 52 of 101 identical lines) and passes with the fix.

Package tests, `cmd/jsonimports`, `go vet` and `staticcheck` all pass, and `FuzzDiff` ran 18.9M executions clean.

Fixes #21233
