### PR TITLE
ipn/ipnlocal: always arm the deadlock probe timer for a watched region

### DIFF
--- a/ipn/ipnlocal/local.go
+++ b/ipn/ipnlocal/local.go
@@ -283,7 +283,6 @@ type LocalBackend struct {
 	shouldInterceptTCPPortAtomic            syncs.AtomicValue[func(uint16) bool]         // TODO(nickkhyl): move to nodeBackend
 	shouldInterceptVIPServicesTCPPortAtomic syncs.AtomicValue[func(netip.AddrPort) bool] // TODO(nickkhyl): move to nodeBackend
 	numClientStatusCalls                    atomic.Uint32                                // TODO(nickkhyl): move to nodeBackend
-	lastDeadlockCheckUnix                   atomic.Int64
 	deadlockChecksInFlight                  atomic.Int64
 	deadlockTimerMu                         sync.Mutex
 	deadlockTimer                           *time.Timer

--- a/ipn/ipnlocal/watchdog.go
+++ b/ipn/ipnlocal/watchdog.go
@@ -7,8 +7,6 @@ import (
 	"log"
 	"runtime"
 	"time"
-
-	"tailscale.com/tstime"
 )
 
 // deadlockProbeDelay is how long a watched call must be in flight before we
@@ -37,19 +35,14 @@ func (b *LocalBackend) CheckDeadlocks() (done func()) {
 		return b.doneDeadlockCheck
 	}
 
-	// Fast path to avoid the deadlockTimerMu+Timer.Reset cost when
-	// CheckDeadlocks is called many times per second by non-overlapping
-	// callers: re-arm the probe timer at most once per wall-clock second.
-	// We use a unix-seconds timestamp (+1 so 0 can mean "never") and a CAS
-	// so that only one caller per second proceeds to touch the timer; the
-	// rest return early.
-	nowUnix := tstime.DefaultClock{Clock: b.Clock()}.Now().Unix() + 1
-	lastUnix := b.lastDeadlockCheckUnix.Load()
-	if lastUnix == nowUnix || !b.lastDeadlockCheckUnix.CompareAndSwap(lastUnix, nowUnix) {
-		return b.doneDeadlockCheck
-	}
-
-	// Slow path: (re)arm the probe timer. Lazily create it on first use.
+	// This is the 0->1 transition, so doneDeadlockCheck has stopped the probe
+	// timer and nothing else will re-arm it: the count only returns to zero
+	// once this region closes, and until then every other caller takes the
+	// early return above. Arming here is therefore mandatory. Skipping it,
+	// even to save a Timer.Reset, leaves this region unwatched for as long as
+	// it runs, which is exactly the case the watchdog exists to catch.
+	//
+	// (Re)arm the probe timer, lazily creating it on first use.
 	b.deadlockTimerMu.Lock()
 	defer b.deadlockTimerMu.Unlock()
 

--- a/ipn/ipnlocal/watchdog_test.go
+++ b/ipn/ipnlocal/watchdog_test.go
@@ -10,14 +10,22 @@ import (
 	"tailscale.com/tstest"
 )
 
-func TestCheckDeadlocksRateLimitAndTimerReuse(t *testing.T) {
+// probeArmed reports whether the delayed probe timer is currently armed.
+//
+// It works by stopping the timer, which reports true only if it stopped an
+// active timer, so it is destructive and each call must be treated as the
+// last word on that particular arming.
+func probeArmed(b *LocalBackend) bool {
+	b.deadlockTimerMu.Lock()
+	defer b.deadlockTimerMu.Unlock()
+	return b.deadlockProbeTimer != nil && b.deadlockProbeTimer.Stop()
+}
+
+func TestCheckDeadlocksTimerReuse(t *testing.T) {
 	clock := tstest.NewClock(tstest.ClockOpts{Start: time.Unix(123, 0)})
 	b := &LocalBackend{clock: clock}
 
 	done := b.CheckDeadlocks()
-	if b.lastDeadlockCheckUnix.Load() != 124 {
-		t.Fatalf("lastDeadlockCheckUnix = %v, want 124", b.lastDeadlockCheckUnix.Load())
-	}
 	timer := b.deadlockProbeTimer
 	if timer == nil {
 		t.Fatal("deadlockProbeTimer is nil")
@@ -33,21 +41,6 @@ func TestCheckDeadlocksRateLimitAndTimerReuse(t *testing.T) {
 		t.Fatalf("deadlockChecksInFlight after DoneDeadlockCheck = %v, want 0", b.deadlockChecksInFlight.Load())
 	}
 
-	doneCh := make(chan struct{})
-	go func() {
-		b.CheckDeadlocks()()
-		close(doneCh)
-	}()
-	select {
-	case <-doneCh:
-	case <-time.After(1 * time.Second):
-		t.Fatal("same-second CheckDeadlocks did not take the rate-limit fast path")
-	}
-	if b.deadlockProbeTimer != timer {
-		t.Fatal("same-second CheckDeadlocks allocated a new probe timer")
-	}
-
-	clock.Advance(time.Second)
 	done = b.CheckDeadlocks()
 	if b.deadlockProbeTimer != timer {
 		t.Fatal("CheckDeadlocks allocated a new probe timer instead of reusing the existing one")
@@ -61,4 +54,43 @@ func TestCheckDeadlocksRateLimitAndTimerReuse(t *testing.T) {
 		t.Fatal("runDeadlockProbe did not allocate the deadlock timer")
 	}
 	done()
+}
+
+// TestCheckDeadlocksArmsEveryRegion verifies that opening a watched region
+// always leaves a probe timer armed, including for regions that open in the
+// same wall-clock second as an earlier, already-closed one. Without that, a
+// region that goes on to deadlock is never probed: the in-flight count never
+// returns to zero, so every later caller takes the "already open" early return
+// and nothing re-arms the timer.
+func TestCheckDeadlocksArmsEveryRegion(t *testing.T) {
+	clock := tstest.NewClock(tstest.ClockOpts{Start: time.Unix(123, 0)})
+	b := &LocalBackend{clock: clock}
+
+	// A short region that opens and closes within one second.
+	b.CheckDeadlocks()()
+
+	// A second region in that same second, which then wedges and never
+	// closes. It must still be watched.
+	b.CheckDeadlocks()
+	if got := b.deadlockChecksInFlight.Load(); got != 1 {
+		t.Fatalf("deadlockChecksInFlight = %v, want 1", got)
+	}
+	if !probeArmed(b) {
+		t.Fatal("probe timer not armed for a region opened in the same second as an earlier one")
+	}
+
+	// A later caller arrives while the wedged region is still open. It takes
+	// the "already open" path, which relies on the timer above having been
+	// armed, so the watchdog must still be able to fire.
+	clock.Advance(2 * time.Second)
+	b.CheckDeadlocks()
+	if got := b.deadlockChecksInFlight.Load(); got != 2 {
+		t.Fatalf("deadlockChecksInFlight = %v, want 2", got)
+	}
+
+	// With work in flight, the probe must actually do its job.
+	b.runDeadlockProbe()
+	if b.deadlockTimer == nil {
+		t.Fatal("runDeadlockProbe did not allocate the deadlock timer while work was in flight")
+	}
 }


### PR DESCRIPTION
`CheckDeadlocks` returned early without arming the probe timer when another region had already armed it in the same wall-clock second:

```go
if b.deadlockChecksInFlight.Add(1) != 1 {
	return b.doneDeadlockCheck
}

nowUnix := tstime.DefaultClock{Clock: b.Clock()}.Now().Unix() + 1
lastUnix := b.lastDeadlockCheckUnix.Load()
if lastUnix == nowUnix || !b.lastDeadlockCheckUnix.CompareAndSwap(lastUnix, nowUnix) {
	return b.doneDeadlockCheck
}
```

That rate-limit check is only ever reached on the 0->1 in-flight transition, because every other value takes the "already open" early return above it. The 0->1 transition is exactly the one that must arm the timer, since `doneDeadlockCheck` stops it on the 1->0 transition. So the fast path skipped arming only when arming was mandatory, breaking the invariant stated in its own neighbouring comment: "If a watched region is already open, the probe timer is already armed."

It is also self-reinforcing. Once an unarmed region wedges, the in-flight count never returns to zero, so every later caller takes the "already open" path and nothing re-arms the timer.

Sampling the probe timer's armed state at each step:

| step | in-flight | probe timer armed |
| --- | --- | --- |
| region 1 opens (first call of the second) | 1 | yes |
| region 1 closes | 0 | no |
| region 2 opens (same second) | 1 | no |
| region 3 opens (2s later, region 2 still wedged) | 2 | no |

The fast path's comment describes its target case as "CheckDeadlocks is called many times per second by non-overlapping callers". Non-overlapping callers are precisely a stream of 0->1 transitions, so in the workload it was written for, all but the first region per second goes unwatched.

This drops the fast path so the 0->1 transition always arms, and removes the now-unused `lastDeadlockCheckUnix` field.

On the cost: this adds one uncontended mutex acquisition and a `Timer.Reset` per outermost watched region, which seems small next to the `LocalBackend` operations being bracketed (`Start`, `SetControlClientStatus`, `UpdateNetmapDelta`, `UpdatePacketFilter`). I could not find a way to keep the optimization while `doneDeadlockCheck` stops the timer, since a skipped arming then means no pending probe at all. Making the timer free-running instead would keep it, but at the price of probing every subsystem lock every `deadlockProbeDelay` under load, which seemed worse. Happy to go a different way if you'd prefer.

`TestCheckDeadlocksRateLimitAndTimerReuse` asserted the old behaviour, so it is replaced by `TestCheckDeadlocksTimerReuse` (timer reuse, unchanged in spirit) and `TestCheckDeadlocksArmsEveryRegion`, which pins the invariant. The latter fails against the unpatched code at the "same second" step and passes with the fix.

`go test ./ipn/ipnlocal/` and `go vet` pass.

Fixes #21235
