### PR TITLE
types/geo: drop the duplicate SphericalAngleTo fuzz target

### DIFF
--- a/types/geo/point_test.go
+++ b/types/geo/point_test.go
@@ -550,23 +550,6 @@ func TestPointSphericalAngleTo(t *testing.T) {
 	}
 }
 
-func FuzzPointSphericalAngleTo(f *testing.F) {
-	for _, tt := range corpusPointSphericalAngleTo {
-		xLat, xLng, _ := tt.x.LatLngFloat64()
-		yLat, yLng, _ := tt.y.LatLngFloat64()
-		f.Add(xLat, xLng, yLat, yLng)
-	}
-
-	f.Fuzz(func(t *testing.T, xLat float64, xLng float64, yLat float64, yLng float64) {
-		x := geo.MakePoint(geo.Degrees(xLat), geo.Degrees(xLng))
-		y := geo.MakePoint(geo.Degrees(yLat), geo.Degrees(yLng))
-		got, _ := x.SphericalAngleTo(y)
-		if math.IsNaN(float64(got)) {
-			t.Errorf("got NaN result with xLat=%.15f xLng=%.15f yLat=%.15f yLng=%.15f", xLat, xLng, yLat, yLng)
-		}
-	})
-}
-
 func approx[T ~float64](x, y T) bool {
 	return math.Abs(float64(x)-float64(y)) <= 1e-5
 }


### PR DESCRIPTION
#21069 moved each package's fuzz targets into a `fuzz_test.go` in the implementation package, since oss-fuzz cannot use targets that live in a `_test` package. For every other package it deleted the original, but in `types/geo` the copy in `point_test.go` (package `geo_test`) was left behind, so `FuzzPointSphericalAngleTo` now exists twice.

Go refuses to fuzz an ambiguous name, so the target cannot be fuzzed at all:

```
$ go test ./types/geo -fuzz '^FuzzPointSphericalAngleTo$'
testing: will not fuzz, -fuzz matches more than one fuzz test: [FuzzPointSphericalAngleTo FuzzPointSphericalAngleTo]
FAIL
```

`-fuzz` takes a regexp, so there is no spelling that selects just one of them. Both copies still run against their seed corpora during a normal `go test`, which is why this went unnoticed: the package's tests pass, but the fuzzing the move was made to enable has been off for this target since.

This deletes the `geo_test` copy, matching what the original move did everywhere else and leaving the in-package target that oss-fuzz needs. The two bodies are equivalent; the only difference was where the seed corpus came from, and the surviving target's inline corpus is already an exact transcription of all nine `corpusPointSphericalAngleTo` points. That variable is still used by the neighbouring `TestPointSphericalAngleTo`, so nothing is orphaned and no coverage is lost.

With the name unambiguous the target fuzzes again; I ran 27M executions with no NaN found. `go test ./types/geo/` and `go vet` pass.

I found this by running every `Fuzz*` target in the repo; the rest were clean.

Updates #21069
