### PR TITLE
util/ringlog: make Clear a no-op on a nil RingLog

### DIFF
--- a/util/ringlog/ringlog.go
+++ b/util/ringlog/ringlog.go
@@ -70,7 +70,12 @@ func (rb *RingLog[T]) Len() int {
 }
 
 // Clear will empty the ring log.
+//
+// It does nothing if rb is nil.
 func (rb *RingLog[T]) Clear() {
+	if rb == nil {
+		return
+	}
 	rb.mu.Lock()
 	defer rb.mu.Unlock()
 	rb.pos = 0

--- a/util/ringlog/ringlog_test.go
+++ b/util/ringlog/ringlog_test.go
@@ -53,3 +53,18 @@ func TestRingLog(t *testing.T) {
 		}
 	})
 }
+
+// TestNil verifies that every method tolerates a nil *RingLog, which is how
+// callers that opt out of logging represent a disabled log. For example,
+// magicsock leaves endpoint.debugUpdates nil on iOS and Android to save memory.
+func TestNil(t *testing.T) {
+	var rb *RingLog[int]
+	rb.Add(1)
+	if got := rb.Len(); got != 0 {
+		t.Errorf("Len() = %d, want 0", got)
+	}
+	if got := rb.GetAll(); got != nil {
+		t.Errorf("GetAll() = %v, want nil", got)
+	}
+	rb.Clear()
+}


### PR DESCRIPTION
`Add`, `GetAll` and `Len` all check for a nil receiver and document that they do nothing, because a nil `*RingLog` is how callers represent a disabled log. `magicsock` leaves `endpoint.debugUpdates` nil on iOS and Android to save memory, and then calls `Add` on it unconditionally from a dozen places.

`Clear` is the one method without that check, so it would panic on exactly those platforms.

Nothing calls `Clear` on a nil log today, so this is a latent footgun rather than an observed crash. But the asymmetry is easy to fall into given the other three methods, and the fix is three lines.

Adds the check and a `TestNil` covering all four methods; it panics against the unpatched `Clear` and passes with the fix.

Updates #cleanup
